### PR TITLE
Refactor WebGPU interface

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -465,25 +465,32 @@ interface WebGPUQueue {
     WebGPUFence insertFence();
 };
 
-// SwapChain / RenderingContext
-dictionary WebGPUSwapChainDescriptor {
-    WebGPUTextureUsageFlags usage;
-    WebGPUTextureFormatEnum format;
-    u32 width;
-    u32 height;
-};
-
 interface WebGPUSwapChain {
-    void configure(WebGPUSwapChainDescriptor descriptor);
     WebGPUTexture getNextTexture();
     void present();
 };
 
-interface WebGPURenderingContext : WebGPUSwapChain {
+// Parameter structure to initialize a swapchain,
+// to be provided to `HTMLCanvasElement.getContext()`.
+dictionary WebGPUSwapChainDescriptor {
+    WebGPUDevice device;
+    WebGPUTextureUsageFlags usage;
+    WebGPUTextureFormatEnum format;
+};
+
+// The context returned by `HTMLCanvasElement.getContext`.
+//
+// Note: the relationship to `WebGPUSwapChain` may be revised
+// and changed from "is a" into "has a" in the future.
+interface WebGPUSCanvasContext: WebGPUSwapChain {
 };
 
 // Device
 interface WebGPUDevice {
+    WebGPUExtensions getExtensions();
+    WebGPUFeatures getFeatures();
+    WebGPULimits getLimits();
+
     WebGPUBuffer createBuffer(WebGPUBufferDescriptor descriptor);
     WebGPUTexture createTexture(WebGPUTextureDescriptor descriptor);
     WebGPUSampler createSampler(WebGPUSamplerDescriptor descriptor);
@@ -527,9 +534,7 @@ dictionary WebGPUDeviceDescriptor {
 };
 
 interface WebGPU {
-    static WebGPUExtensions getExtensions();
-    static WebGPUFeatures getFeatures();
-    static WebGPULimits getLimits();
+    static WebGPU instance();
 
-    static WebGPUDevice createDevice(WebGPUDeviceDescriptor descriptor);
+    WebGPUDevice createDevice(WebGPUDeviceDescriptor descriptor);
 };

--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -465,11 +465,6 @@ interface WebGPUQueue {
     WebGPUFence insertFence();
 };
 
-interface WebGPUSwapChain {
-    WebGPUTexture getNextTexture();
-    void present();
-};
-
 // Parameter structure to initialize a swapchain,
 // to be provided to `HTMLCanvasElement.getContext()`.
 dictionary WebGPUSwapChainDescriptor {
@@ -478,11 +473,10 @@ dictionary WebGPUSwapChainDescriptor {
     WebGPUTextureFormatEnum format;
 };
 
-// The context returned by `HTMLCanvasElement.getContext`.
-//
-// Note: the relationship to `WebGPUSwapChain` may be revised
-// and changed from "is a" into "has a" in the future.
-interface WebGPUSCanvasContext: WebGPUSwapChain {
+// The swapchain that is returned by `HTMLCanvasElement.getContext`.
+interface WebGPUSwapChain {
+    WebGPUTexture getNextTexture();
+    void commit();
 };
 
 // Device


### PR DESCRIPTION
I don't see how `configure` is going to work. If we spawn a swapchain associated with a canvas, then:
  - the dimensions are taken from the canvas
  - other parameters (like usage and format) are provided as an extra

Was the original intent to have swapchain controlling the canvas it's displayed on?

As for `WebGPURenderingContext`, supposing it is analogous to something like `VkInstance`, we should detach it from the swap chain in order to support multiple swap chains controlled by the same context/instance.

We haven't talked enough about what the context is going to have (instance? device? physical device?), but we can surely re-add it with more details once we figure them out.