### PR TITLE
Changes to WebGPU device creation.

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -516,19 +516,15 @@ dictionary WebGPUExtensions {
     bool anisotropicFiltering;
 };
 
-dictionary WebGPUFeatures {
-    bool logicOp;
-};
-
 dictionary WebGPULimits {
     u32 maxBindGroups;
 };
 
 // Device
 interface WebGPUDevice {
-    attribute readonly WebGPUExtensions extensions;
-    attribute readonly WebGPUFeatures features;
-    attribute readonly WebGPULimits limits;
+    readonly attribute WebGPUExtensions extensions;
+    readonly attribute WebGPULimits limits;
+    readonly attribute WebGPUAdapter adapter;
 
     WebGPUBuffer createBuffer(WebGPUBufferDescriptor descriptor);
     WebGPUTexture createTexture(WebGPUTextureDescriptor descriptor);
@@ -557,19 +553,17 @@ interface WebGPUDevice {
 
 dictionary WebGPUDeviceDescriptor {
     WebGPUExtensions extensions;
-    WebGPUFeatures features;
     //WebGPULimits limits; Don't expose higher limits for now.
 
     // TODO are other things configurable like queues?
 };
 
 interface WebGPUAdapter {
-    attribute readonly DOMString name;
-    attribute readonly WebGPUExtensions extensions;
-    attribute readonly WebGPUFeatures features;
-    //attribute readonly WebGPULimits limits; Don't expose higher limits for now.
+    readonly attribute DOMString name;
+    readonly attribute WebGPUExtensions extensions;
+    //readonly attribute WebGPULimits limits; Don't expose higher limits for now.
 
-    static WebGPUDevice createDevice(WebGPUDeviceDescriptor descriptor);
+    WebGPUDevice createDevice(WebGPUDeviceDescriptor descriptor);
 };
 
 enum WebGPUPowerPreference { "default", "low-power", "high-performance" };

--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -579,5 +579,11 @@ dictionary WebGPUAdapterDescriptor {
 };
 
 interface WebGPU {
-    static WebGPUAdapter getAdapter(WebGPUAdapterDescriptor desc);
+    WebGPUAdapter getAdapter(WebGPUAdapterDescriptor desc);
 };
+
+// Add a "webgpu" member to Window that contains the global instance of a "WebGPU"
+interface mixin WebGPUProvider {
+    [Replaceable, SameObject] readonly attribute WebGPU webgpu;
+}
+Window includes WebGPUProvider;


### PR DESCRIPTION
PTAL, I'm starting to experiment with Blink code for WebGPU and noticed the sketch.idl didn't provide any way to get a `WebGPU` object. Added one in a similar fashion to `AnimationFrameProvider`.