### PR TITLE
BindGroupBinding: add array bindings, remove start/count

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -147,10 +147,10 @@ interface WebGPUBindingType {
 };
 
 dictionary WebGPUBindGroupBinding {
+    u32 binding;
     WebGPUShaderStageFlags visibility;
     WebGPUBindingType type;
-    u32 start;
-    u32 count;
+    u32 arraySize;
 };
 
 dictionary WebGPUBindGroupLayoutDescriptor {


### PR DESCRIPTION
Investigation into how this works on various backends TBD.

(binding/arraySize mirror Vulkan's binding/descriptorCount.)