### PR TITLE
Remove WebGPUBindGroupBinding.count

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -147,10 +147,9 @@ interface WebGPUBindingType {
 };
 
 dictionary WebGPUBindGroupBinding {
+    u32 binding;
     WebGPUShaderStageFlags visibility;
     WebGPUBindingType type;
-    u32 start;
-    u32 count;
 };
 
 dictionary WebGPUBindGroupLayoutDescriptor {


### PR DESCRIPTION
After considering (and closing) #61, I still think this change is good.

A `WebGPUBindGroupBinding` should refer to an individual binding, and not a range of bindings. I don't think the extra indirection is adding any value.

The net effect of this is that, for a shader like this (from NXT's `ComputeBoids.cpp`):

```glsl
layout(std140, set = 0, binding = 0) uniform SimParams { /*...*/ } params;
layout(std140, set = 0, binding = 1) buffer ParticlesA { /*...*/ } particlesA;
layout(std140, set = 0, binding = 2) buffer ParticlesB { /*...*/ } particlesB;
```

the bind group layout definition changes as follows:

```diff
 let bgl = device.createBindGroupLayout({
   bindingTypes: [
-    { visibility: WebGPUShaderStageBit.COMPUTE, type: WebGPUBindingType.UNIFORM_BUFFER, start: 0, count: 1 },
-    { visibility: WebGPUShaderStageBit.COMPUTE, type: WebGPUBindingType.STORAGE_BUFFER, start: 1, count: 2 },
+    { binding: 0, visibility: WebGPUShaderStageBit.COMPUTE, type: WebGPUBindingType.UNIFORM_BUFFER },
+    { binding: 1, visibility: WebGPUShaderStageBit.COMPUTE, type: WebGPUBindingType.STORAGE_BUFFER },
+    { binding: 2, visibility: WebGPUShaderStageBit.COMPUTE, type: WebGPUBindingType.STORAGE_BUFFER },
   ]
 });

 let bufParams = /*...*/;
 let bufsParticles = [ /*...*/, /*...*/ ];
+// createBindGroup doesn't change:
 let bg = device.createBindGroup({
   layout: bgl,
   bindings: [
     { resources: [ bufParams ], start: 0, count: 1 },
     { resources: bufsParticles, start: 1, count: 2 },
   ]
 ]);
```

(Separately, `arraySize` from #61 could still be relevant if we want to add array bindings later on.)