### PR TITLE
Promisify createDevice and getAdapter

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -572,7 +572,7 @@ dictionary WebGPUAdapterDescriptor {
 };
 
 interface WebGPU {
-    WebGPUAdapter getAdapter(WebGPUAdapterDescriptor desc);
+    Promise<WebGPUAdapter> requestAdapter(WebGPUAdapterDescriptor desc);
 };
 
 // Add a "webgpu" member to Window that contains the global instance of a "WebGPU"

--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -562,7 +562,7 @@ interface WebGPUAdapter {
     readonly attribute WebGPUExtensions extensions;
     //readonly attribute WebGPULimits limits; Don't expose higher limits for now.
 
-    WebGPUDevice createDevice(WebGPUDeviceDescriptor descriptor);
+    Promise<WebGPUDevice> requestDevice(WebGPUDeviceDescriptor descriptor);
 };
 
 enum WebGPUPowerPreference { "default", "low-power", "high-performance" };

--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -562,7 +562,7 @@ interface WebGPUAdapter {
     readonly attribute WebGPUExtensions extensions;
     //readonly attribute WebGPULimits limits; Don't expose higher limits for now.
 
-    Promise<WebGPUDevice> requestDevice(WebGPUDeviceDescriptor descriptor);
+    WebGPUDevice createDevice(WebGPUDeviceDescriptor descriptor);
 };
 
 enum WebGPUPowerPreference { "default", "low-power", "high-performance" };


### PR DESCRIPTION
As loading driver could take some time, it may be better to return a promise when creating a WebGOU device. What do you think?