### PR TITLE
Remove need for dynamic typing in WebGPUBinding

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -213,17 +213,16 @@ interface WebGPUPipelineLayout {
 };
 
 // BindGroup
-dictionary WebGPUBufferBinding {
+dictionary WebGPUBinding {
+    u32 binding;
+
+    WebGPUSampler sampler;
+
+    WebGPUTextureView textureView;
+
     WebGPUBuffer buffer;
     u32 offset;
     u32 size;
-};
-
-typedef (WebGPUSampler or WebGPUTextureView or WebGPUBufferBinding) WebGPUBindingResource;
-
-dictionary WebGPUBinding {
-    uint32_t binding;
-    WebGPUBindingResource resource;
 };
 
 dictionary WebGPUBindGroupDescriptor {


### PR DESCRIPTION
Sum types cannot be expressed easily in statically typed languages that don't have them. I tried removing the need for them in WebGPUBinding and to see what it looks like, and it seems ok. WDYT?