### PR TITLE
(Mostly) pass IDL validation again

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -272,18 +272,7 @@ dictionary WebGPUBlendStateDescriptor {
 interface WebGPUBlendState {
 };
 
-enum WebGPUCompareFunction {
-    "never",
-    "less",
-    "lessEqual",
-    "greater",
-    "greaterEqual",
-    "equal",
-    "notEqual",
-    "always",
-};
-
-WebGPUStencilOperation {
+enum WebGPUStencilOperation {
     "keep",
     "zero",
     "replace",
@@ -295,10 +284,10 @@ WebGPUStencilOperation {
 };
 
 dictionary WebGPUStencilStateFaceDescriptor {
-    WebGPUCompareFunctionEnum compare;
-    WebGPUStencilOperationEnum stencilFailOp;
-    WebGPUStencilOperationEnum depthFailOp;
-    WebGPUStencilOperationEnum passOp;
+    WebGPUCompareFunction compare;
+    WebGPUStencilOperation stencilFailOp;
+    WebGPUStencilOperation depthFailOp;
+    WebGPUStencilOperation passOp;
 };
 
 dictionary WebGPUDepthStencilStateDescriptor {


### PR DESCRIPTION
Using the webidl2.js validator, which you can use here:
http://kai.graphics/webidl2.js/checker/
(My fork so that the checker can be hosted on GitHub Pages.)
this passes, except for the Number.MAX_VALUE.