### PR TITLE
Add WebGPUTextureAspectFlags

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -501,12 +501,19 @@ dictionary WebGPUBufferCopyView {
     u32 imageHeight;
 };
 
+typedef u32 WebGPUTextureAspectFlags;
+interface WebGPUTextureAspect {
+    const u32 COLOR = 1;
+    const u32 DEPTH = 2;
+    const u32 STENCIL = 4;
+};
+
 dictionary WebGPUTextureCopyView {
     WebGPUTexture texture;
     u32 level;
     u32 slice;
     WebGPUOrigin3D origin;
-    WebGPUTextureAspect aspect;
+    WebGPUTextureAspectFlags aspect;
 };
 
 interface WebGPUCommandBuffer {


### PR DESCRIPTION
The changes in #69 reference `WebGPUTextureAspect` but it wasn't added in the PR.

Not sure if it has been discussed outside #69 yet, but I guess something like this definition would be reasonable.