### PR TITLE
Provide the attachments state when starting a render pass

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -514,6 +514,7 @@ dictionary WebGPURenderPassDepthStencilAttachmentDescriptor {
 };
 
 dictionary WebGPURenderPassDescriptor {
+    WebGPUAttachmentsState attachmentsState;
     sequence<WebGPURenderPassColorAttachmentDescriptor> colorAttachments;
     WebGPURenderPassDepthStencilAttachmentDescriptor depthStencilAttachment;
 };

--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -397,13 +397,13 @@ dictionary WebGPUShaderModuleDescriptor {
 interface WebGPUShaderModule {
 };
 
-// AttachmentState
-dictionary WebGPUAttachmentStateDescriptor {
+// Description of the framebuffer attachments
+dictionary WebGPUAttachmentsStateDescriptor {
     sequence<WebGPUTextureFormatEnum> formats;
     // TODO other stuff like sample count etc.
 };
 
-interface WebGPUAttachmentState {
+interface WebGPUAttachmentsState {
 };
 
 // Common stuff for ComputePipeline and RenderPipeline
@@ -444,10 +444,10 @@ enum WebGPUPrimitiveTopology {
 
 dictionary WebGPURenderPipelineDescriptor : WebGPUPipelineDescriptorBase {
     WebGPUPrimitiveTopologyEnum primitiveTopology;
-    sequence<WebGPUBlendState> blendState;
+    sequence<WebGPUBlendState> blendStates;
     WebGPUDepthStencilState depthStencilState;
     WebGPUInputState inputState;
-    WebGPUAttachmentState attachmentState;
+    WebGPUAttachmentsState attachmentsState;
     // TODO other properties
 };
 
@@ -628,7 +628,7 @@ interface WebGPUDevice {
     WebGPUDepthStencilState createDepthStencilState(WebGPUDepthStencilStateDescriptor descriptor);
     WebGPUInputState createInputState(WebGPUInputStateDescriptor descriptor);
     WebGPUShaderModule createShaderModule(WebGPUShaderModuleDescriptor descriptor);
-    WebGPUAttachmentState createAttachmentState(WebGPUAttachmentStateDescriptor descriptor);
+    WebGPUAttachmentsState createAttachmentsState(WebGPUAttachmentsStateDescriptor descriptor);
     WebGPUComputePipeline createComputePipeline(WebGPUComputePipelineDescriptor descriptor);
     WebGPURenderPipeline createRenderPipeline(WebGPURenderPipelineDescriptor descriptor);
 


### PR DESCRIPTION
This PR is based on #91 
Actual changes (one line!) are in the second commit.

Fixes  #103

I propose to include the attachment state into the render pass descriptor for the following reasons:
  - to establish a clear contract with the user that all the pipeline states used in this pass have to be created with this very state of attachments, and no something that is "compatible" with the provided targets
  - to make the implementation more straightforward: we need to know the `VkRenderPass` when starting one, and `WebGPUAttachmentsState` is what represents a render pass. We could *try* deriving it based on the formats of the render targets provided, but this seems rather backwards... say, what if the user created two different `WebGPUAttachmentsState` objects from the same inputs? Do we then require the implementation to de-duplicate those? TL:DR; I think it's possible to work around, but it doesn't worth it - the user should clearly be aware of the attachment state they plan to use at this point.