### PR TITLE
Fixed pipeline layout in compute/render passes

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -514,9 +514,14 @@ dictionary WebGPURenderPassDepthStencilAttachmentDescriptor {
 };
 
 dictionary WebGPURenderPassDescriptor {
+    WebGPUPipelineLayout pipelineLayout;
     WebGPUAttachmentsState attachmentsState;
     sequence<WebGPURenderPassColorAttachmentDescriptor> colorAttachments;
     WebGPURenderPassDepthStencilAttachmentDescriptor depthStencilAttachment;
+};
+
+dictionary WebGPUComputePassDescriptor {
+    WebGPUPipelineLayout pipelineLayout;
 };
 
 dictionary WebGPUBufferCopyView {
@@ -536,7 +541,7 @@ dictionary WebGPUTextureCopyView {
 
 interface WebGPUCommandBuffer {
     WebGPURenderPassEncoder beginRenderPass(WebGPURenderPassDescriptor descriptor);
-    WebGPUComputePassEncoder beginComputePass();
+    WebGPUComputePassEncoder beginComputePass(WebGPUComputePassDescriptor descriptor);
 
     // Commands allowed outside of "passes"
     void copyBufferToBuffer(

--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -514,6 +514,7 @@ dictionary WebGPURenderPassDepthStencilAttachmentDescriptor {
 };
 
 dictionary WebGPURenderPassDescriptor {
+    WebGPUAttachmentsState attachmentsState;
     sequence<WebGPURenderPassColorAttachmentDescriptor> colorAttachments;
     WebGPURenderPassDepthStencilAttachmentDescriptor depthStencilAttachment;
 };

--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -397,13 +397,13 @@ dictionary WebGPUShaderModuleDescriptor {
 interface WebGPUShaderModule {
 };
 
-// AttachmentState
-dictionary WebGPUAttachmentStateDescriptor {
+// Description of the framebuffer attachments
+dictionary WebGPUAttachmentsStateDescriptor {
     sequence<WebGPUTextureFormatEnum> formats;
     // TODO other stuff like sample count etc.
 };
 
-interface WebGPUAttachmentState {
+interface WebGPUAttachmentsState {
 };
 
 // Common stuff for ComputePipeline and RenderPipeline
@@ -444,10 +444,10 @@ enum WebGPUPrimitiveTopology {
 
 dictionary WebGPURenderPipelineDescriptor : WebGPUPipelineDescriptorBase {
     WebGPUPrimitiveTopologyEnum primitiveTopology;
-    sequence<WebGPUBlendState> blendState;
+    sequence<WebGPUBlendState> blendStates;
     WebGPUDepthStencilState depthStencilState;
     WebGPUInputState inputState;
-    WebGPUAttachmentState attachmentState;
+    WebGPUAttachmentsState attachmentsState;
     // TODO other properties
 };
 
@@ -628,7 +628,7 @@ interface WebGPUDevice {
     WebGPUDepthStencilState createDepthStencilState(WebGPUDepthStencilStateDescriptor descriptor);
     WebGPUInputState createInputState(WebGPUInputStateDescriptor descriptor);
     WebGPUShaderModule createShaderModule(WebGPUShaderModuleDescriptor descriptor);
-    WebGPUAttachmentState createAttachmentState(WebGPUAttachmentStateDescriptor descriptor);
+    WebGPUAttachmentsState createAttachmentsState(WebGPUAttachmentsStateDescriptor descriptor);
     WebGPUComputePipeline createComputePipeline(WebGPUComputePipelineDescriptor descriptor);
     WebGPURenderPipeline createRenderPipeline(WebGPURenderPipelineDescriptor descriptor);
 


### PR DESCRIPTION
This PR includes #92, which includes #91 (we need to go deeper!), so only the last commit needs to be taken into consideration. It's sort of a proposal/RFC, open for discussion.

Basically, since our render/compute passes encapsulate the resource binding scope, it seems natural to require all those resources to belong to the same pipeline layout. Changing the pipeline layout in practice in low-level APIs like D3D12/Vulkan requires re-binding of some of the resources, based on the layout compatibility rules, and is not generally something that is done often. Chances are that if you are going to use a completely different pipeline layout, you'd also render into different render targets, so this is going to be happening in a different pass.

An alternative would be to allow (automatic?) pipeline layout changes through a pass. That would require us to document precisely when the change is possible, how it is achieved, and likely also to provide the pipeline layout argument for binding the resource groups.