### PR TITLE
Add destroy() to WebGPU[Buffer|Texture]

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -75,6 +75,8 @@ dictionary WebGPUBufferDescriptor {
 interface WebGPUBuffer {
     readonly attribute ArrayBuffer? mapping;
     void unmap();
+
+    void destroy();
 };
 
 // Texture
@@ -144,6 +146,8 @@ interface WebGPUTextureView {
 interface WebGPUTexture {
     WebGPUTextureView createTextureView(WebGPUTextureViewDescriptor desc);
     WebGPUTextureView createDefaultTextureView();
+
+    void destroy();
 };
 
 // Samplers


### PR DESCRIPTION
These can be used to free the GPU memory associated with resources
without waiting for javascript garbage collection to occur.

PTAL @jdashg @litherum @RafaelCintron 