### PR TITLE
Pass attachments state by value

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -402,13 +402,20 @@ dictionary WebGPUShaderModuleDescriptor {
 interface WebGPUShaderModule {
 };
 
-// Description of the framebuffer attachments
-dictionary WebGPUAttachmentsStateDescriptor {
-    sequence<WebGPUTextureFormatEnum> formats;
-    // TODO other stuff like sample count etc.
+// Description of a single attachment
+dictionary WebGPUAttachment {
+    // Attachment data format
+    WebGPUTextureFormatEnum format;
+    // Number of MSAA samples
+    u32 samples;
 };
 
-interface WebGPUAttachmentsState {
+// Description of the framebuffer attachments
+dictionary WebGPUAttachmentsState {
+    // Array of color attachments
+    sequence<WebGPUAttachment> colorAttachments;
+    // Optional depth/stencil attachment
+    WebGPUAttachment? depthStencilAttachment;
 };
 
 // Common stuff for ComputePipeline and RenderPipeline
@@ -431,7 +438,7 @@ dictionary WebGPUPipelineDescriptorBase {
     sequence<WebGPUPipelineStageDescriptor> stages;
 };
 
-// ComputePipeline
+// WebGPUComputePipeline
 dictionary WebGPUComputePipelineDescriptor : WebGPUPipelineDescriptorBase {
 };
 
@@ -642,7 +649,6 @@ interface WebGPUDevice {
     WebGPUDepthStencilState createDepthStencilState(WebGPUDepthStencilStateDescriptor descriptor);
     WebGPUInputState createInputState(WebGPUInputStateDescriptor descriptor);
     WebGPUShaderModule createShaderModule(WebGPUShaderModuleDescriptor descriptor);
-    WebGPUAttachmentsState createAttachmentsState(WebGPUAttachmentsStateDescriptor descriptor);
     WebGPUComputePipeline createComputePipeline(WebGPUComputePipelineDescriptor descriptor);
     WebGPURenderPipeline createRenderPipeline(WebGPURenderPipelineDescriptor descriptor);
 


### PR DESCRIPTION
This is an alternative to #92. I like it less, but I need this problem to be solved so here is what the other position can look like. Please do form an opinion on which approach works better for us!

Fixes #103

The way this proposal works is: attachments state is not baked. We provide it as a dictionary when creating a render pipeline, and it has the necessary information to figure out what attachments need to be resolved by the end of an *implicit* pass. When beginning a render pass, we have the actual textures, so we can derive the same formats and sample counts, plus we provide the MSAA sample count of rasterization, which should allow us to reconstruct/derive the render pass object to use.

The reason I like this solution less is: there are more implicit bits, and more work for the backend. We need to document that the attachment formats and sample counts have to exactly match between render pipelines and render passes where they are used, and the backend needs to check for them. In #92, the idea was that the actual handle to *baked* `WebGPUAttachmentsState` has to match, which is easier to document, and the backend doesn't have to keep a global map between the attachment descriptions and actual native render passes.