### PR TITLE
s/window.webgpu/window.gpu

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -688,6 +688,6 @@ interface WebGPU {
 
 // Add a "webgpu" member to Window that contains the global instance of a "WebGPU"
 interface mixin WebGPUProvider {
-    [Replaceable, SameObject] readonly attribute WebGPU webgpu;
+    [Replaceable, SameObject] readonly attribute WebGPU gpu;
 };
 Window includes WebGPUProvider;


### PR DESCRIPTION
Web-prefixed APIs such as [WebUSB](https://wicg.github.io/webusb/#dom-navigator-usb), [Web Bluetooth](https://webbluetoothcg.github.io/web-bluetooth/#dom-navigator-bluetooth), [Web NFC](https://w3c.github.io/web-nfc/#dom-navigator-nfc) and [more](https://webaudio.github.io/web-midi-api/#dom-navigator-requestmidiaccess) do not expose the "web" part on the main entry point: `navigator.usb`, `navigator.bluetooth`, `navigator.nfc`.

I think it should be the same for this API: `window.gpu` instead of `window.webgpu`.