### PR TITLE
Add an optional WebGPUDevice property to WebGPUSwapChainDescriptor

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -607,6 +607,7 @@ interface WebGPUQueue {
 
 // SwapChain / RenderingContext
 dictionary WebGPUSwapChainDescriptor {
+    WebGPUDevice? device;
     WebGPUTextureUsageFlags usage;
     WebGPUTextureFormatEnum format;
     u32 width;


### PR DESCRIPTION
Add an optional WebGPUDevice property to the WebGPUSwapChainDescriptor used to configure the context. This device is needed for setting a valid pixelFormat before creating a pipeline. Optional because the device only needs to be configured once, if the developer only has access to one WebGPUDevice.