### PR TITLE
Add setStencilReference() to WebGPURenderPassEncoder

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -480,6 +480,7 @@ interface WebGPUProgrammablePassEncoder {
 
 interface WebGPURenderPassEncoder : WebGPUProgrammablePassEncoder {
     void setBlendColor(float r, float g, float b, float a);
+    void setStencilReference(u32 reference);
     void setIndexBuffer(WebGPUBuffer buffer, u32 offset);
     void setVertexBuffers(u32 startSlot, sequence<WebGPUBuffer> buffers, sequence<u32> offsets);
 


### PR DESCRIPTION
This function is used to set stencil reference value, which is a
must for stencil test.

