### PR TITLE
Add depthTestEnabled and stencilTestEnabled to DepthStencilDescriptor

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -336,9 +336,11 @@ dictionary WebGPUStencilStateFaceDescriptor {
 };
 
 dictionary WebGPUDepthStencilStateDescriptor {
+    bool depthTestEnabled;
     bool depthWriteEnabled;
     WebGPUCompareFunction depthCompare;
 
+    bool stencilTestEnabled;
     WebGPUStencilStateFaceDescriptor front;
     WebGPUStencilStateFaceDescriptor back;
 


### PR DESCRIPTION
Please refer to the investigation at https://github.com/gpuweb/gpuweb/issues/118 and the discussion at https://github.com/gpuweb/gpuweb/pull/114. 

Here comes the comparison about depthTestEnable/stencilTestEnable in Metal, D3D12 and Vulkan:
D3D12 and Vulkan can support depthTestEnabled and stencilTestEnabled directly in its depth/stencil state or descriptor. Both of them can only enable/disable depth or stencil test for both front and back faces. They can't enable depth or stencil test for one face and disable it for the other face.

Metal doesn't have a variable to explict disable/enable depth test or stencil test. But it can make depth test always pass via setting depthCompareFunction to its default value MTLCompareFunction.always. And it can disable stencil test via setting MTLStencilDescriptor to nil for front or back face separately. 

Based on the fact above (please correct me if I made mistakes), I prefer to add depthTestEnabled and stencilTestEnabled in WebGPUDepthStencilStateDescriptor:
If we add these two parameters, it can be supported directly in D3D12 and Vulkan. And it is doable in Metal too. And it's straightforward for web devs. 

If we don't have these two parameters. Then we need to say in WebGPU spec:
1) setting **WebGPUCompareFunction depthCompare** in WebGPUDepthStencilDescriptor to **always** to disable depth test. 
2) setting both **WebGPUStencilStateFaceDescriptor front** and **WebGPUStencilStateFaceDescriptor back** to null object (or **WebGPUCompareFunction compare** to **always** for both front and back faces) in order to disable stencil test for both faces. If you only set one face to null and don't set the other face, an error will be generated.    

No matter we add these two parameters or not, we basically do the same for underlying 3 graphics APIs under the hood in order to disable depth/stencil test or toggle between enabling/disabling. But it seems to me that adding these two parameters is much more straightforward for web devs. 

So I created this pr for discussion. PTAL. 
If you think we don't need them, I'm OK to close this pr.  And I totally agree with Kai that we should  either have both or have neither. 