### PR TITLE
Allow WebGPUShaderModuleDescriptor to accept a DOMString

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -395,8 +395,11 @@ interface WebGPUInputState {
 };
 
 // ShaderModule
+
+typedef (ArrayBuffer or DOMString) ArrayBufferOrDOMString;
+
 dictionary WebGPUShaderModuleDescriptor {
-    ArrayBuffer code;
+    required ArrayBufferOrDOMString code;
 };
 
 interface WebGPUShaderModule {

--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -396,6 +396,9 @@ interface WebGPUInputState {
 
 // ShaderModule
 
+// Note: While the choice of shader language is undecided,
+// WebGPUShaderModuleDescriptor will temporarily accept both
+// text and binary input.
 typedef (ArrayBuffer or DOMString) ArrayBufferOrDOMString;
 
 dictionary WebGPUShaderModuleDescriptor {


### PR DESCRIPTION
While we haven't decided whether to allow a binary or string-based language as shader code, have the initializer dictionary supply both.

Also, the field should be required, so that missing code can be rejected at the bindings level.