### PR TITLE
Add WebGPUDebugLabel mixin and label to relevant dictionaries

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -704,9 +704,9 @@ Window includes WebGPUProvider;
 // ****************************************************************************
 
 partial WebGPUProgrammablePassEncoder {
-    void pushDebugGroup(DOMString groupName);
-    void popDebugGroup(DOMString groupName);
-    void insertDebugMarker(DOMString markerName);
+    void pushDebugGroup(DOMString groupLabel);
+    void popDebugGroup(DOMString groupLabel);
+    void insertDebugMarker(DOMString markerLabel);
 };
 
 interface mixin WebGPUDebugLabel {

--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -703,6 +703,12 @@ Window includes WebGPUProvider;
 // DEBUGGING HELPERS
 // ****************************************************************************
 
+partial WebGPUProgrammablePassEncoder {
+    void pushDebugGroup(DOMString groupName);
+    void popDebugGroup(DOMString groupName);
+    void insertDebugMarker(DOMString markerName);
+};
+
 interface mixin WebGPUDebugLabel {
     attribute DOMString label;
 };

--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -678,7 +678,11 @@ interface WebGPUAdapter {
     WebGPUDevice createDevice(WebGPUDeviceDescriptor descriptor);
 };
 
-enum WebGPUPowerPreference { "default", "low-power", "high-performance" };
+enum WebGPUPowerPreference {
+    "default",
+    "low-power",
+    "high-performance"
+};
 
 dictionary WebGPUAdapterDescriptor {
     WebGPUPowerPreference powerPreference;
@@ -692,4 +696,52 @@ interface WebGPU {
 interface mixin WebGPUProvider {
     [Replaceable, SameObject] readonly attribute WebGPU gpu;
 };
+
 Window includes WebGPUProvider;
+
+// ****************************************************************************
+// DEBUGGING HELPERS
+// ****************************************************************************
+
+interface mixin WebGPUDebugLabel {
+    attribute DOMString label;
+};
+
+WebGPUBlendState includes WebGPUDebugLabel;
+WebGPUCommandBuffer includes WebGPUDebugLabel;
+WebGPUComputePipeline includes WebGPUDebugLabel;
+WebGPUDepthStencilState includes WebGPUDebugLabel;
+WebGPUFence includes WebGPUDebugLabel;
+WebGPUInputState includes WebGPUDebugLabel;
+WebGPUProgrammablePassEncoder includes WebGPUDebugLabel;
+WebGPUQueue includes WebGPUDebugLabel;
+WebGPURenderPipeline includes WebGPUDebugLabel;
+WebGPUShaderModule includes WebGPUDebugLabel;
+
+partial dictionary WebGPUBlendStateDescriptor {
+    DOMString label;
+};
+
+partial dictionary WebGPUCommandBufferDescriptor {
+    DOMString label;
+};
+
+partial dictionary WebGPUDepthStencilStateDescriptor {
+    DOMString label;
+};
+
+partial dictionary WebGPUFenceDescriptor {
+    DOMString label;
+};
+
+partial dictionary WebGPUInputStateDescriptor {
+    DOMString label;
+};
+
+partial dictionary WebGPUPipelineDescriptorBase {
+    DOMString label;
+};
+
+partial dictionary WebGPUShaderModuleDescriptor {
+    DOMString label;
+};


### PR DESCRIPTION
To make debugging in Metal easier, we've found it helpful to add a label or name to MTLCommandQueue, so that you can identify in tools what commands are being executed when. We think this would also be useful in WebGPU.

However (and this is totally my fault for not paying attention) it's not clear to me how you'd create multiple WebGPUQueues, since we only expose a getter. Maybe the label should be on the command buffers?