### PR TITLE
WebIDL gpu namespace should have Exposed extended attribute

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -687,6 +687,7 @@ dictionary WebGPUAdapterDescriptor {
     WebGPUPowerPreference powerPreference;
 };
 
+[Exposed=Window]
 namespace gpu {
     Promise<WebGPUAdapter> requestAdapter(WebGPUAdapterDescriptor desc);
 };


### PR DESCRIPTION
According to https://heycam.github.io/webidl/#idl-namespaces :

> "Namespaces must be annotated with the [Exposed] extended attribute."

Ultimately this will likely be exposed on Worker too.