### PR TITLE
Make requestAdapter powerPreference optional

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -678,17 +678,16 @@ interface WebGPUAdapter {
 };
 
 enum WebGPUPowerPreference {
-    "default",
     "low-power",
     "high-performance"
 };
 
-dictionary WebGPUAdapterDescriptor {
+dictionary WebGPURequestAdapterOptions {
     WebGPUPowerPreference powerPreference;
 };
 
 namespace gpu {
-    Promise<WebGPUAdapter> requestAdapter(WebGPUAdapterDescriptor desc);
+    Promise<WebGPUAdapter> requestAdapter(optional WebGPURequestAdapterOptions options);
 };
 
 // ****************************************************************************


### PR DESCRIPTION
For sake of simplicity and readability, I'd suggest making requestAdapter powerPreference optional.
It means web developers who simply want to have access to the default adapter would go with

```js
const adapter = await gpu.requestAdapter();
```

instead of 

```js
const adapter = await gpu.requestAdapter({ powerPreference: 'default' });
```