### PR TITLE
Rename Binding to BindGroupBinding.

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -249,14 +249,14 @@ dictionary WebGPUBufferBinding {
 
 typedef (WebGPUSampler or WebGPUTextureView or WebGPUBufferBinding) WebGPUBindingResource;
 
-dictionary WebGPUBinding {
+dictionary WebGPUBindGroupBinding {
     u32 binding;
     WebGPUBindingResource resource;
 };
 
 dictionary WebGPUBindGroupDescriptor {
     WebGPUBindGroupLayout layout;
-    sequence<WebGPUBinding> bindings;
+    sequence<WebGPUBindGroupBinding> bindings;
 };
 
 interface WebGPUBindGroup {


### PR DESCRIPTION
This makes it more clear that this dictionary is meant to be used inside
the BindGroupDescriptor and not BindGroupLayoutDescriptor.