### PR TITLE
WebIDL: add WebGPURasterizationStateDescriptor

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -266,6 +266,27 @@ interface WebGPUBindGroup {
 // PIPELINE CREATION (blend state, DS state, ..., pipelines)
 // ****************************************************************************
 
+// RasterizationState
+enum WebGPUFrontFace {
+    "ccw",
+    "cw"
+};
+
+enum WebGPUCullMode {
+    "none",
+    "front",
+    "back"
+};
+
+dictionary WebGPURasterizationStateDescriptor {
+    WebGPUFrontFace frontFace;
+    WebGPUCullMode cullMode;
+
+    i32 depthBias;
+    float depthBiasSlopeScale;
+    float depthBiasClamp;
+};
+
 // BlendState
 enum WebGPUBlendFactor {
     "zero",
@@ -447,6 +468,7 @@ dictionary WebGPURenderPipelineDescriptor : WebGPUPipelineDescriptorBase {
     WebGPUPipelineStageDescriptor fragmentStage;
 
     WebGPUPrimitiveTopologyEnum primitiveTopology;
+    WebGPURasterizationStateDescriptor rasterizationState;
     sequence<WebGPUBlendStateDescriptor> blendStates;
     WebGPUDepthStencilStateDescriptor depthStencilState;
     WebGPUInputStateDescriptor inputState;


### PR DESCRIPTION
Per the discussions at https://github.com/gpuweb/gpuweb/issues/137, I submitted this pull request to update the WebIDL. 

In addition, we can add some features related to rasterization state (like depth clip/clamp and triangle fill mode) as extensions if we are clear about how to add extensions in WebGPU IDL.

PTAL when you have time, @kvark , @RafaelCintron , @litherum , @kainino0x , @Kangz . Thank you. 