### PR TITLE
Remove texture aspect flags from copy view

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -543,7 +543,6 @@ dictionary WebGPUTextureCopyView {
     u32 level;
     u32 slice;
     WebGPUOrigin3D origin;
-    WebGPUTextureAspectFlags aspect;
 };
 
 interface WebGPUCommandBuffer {


### PR DESCRIPTION
As mentioned in https://github.com/gpuweb/gpuweb/issues/69#issuecomment-444178868 and https://github.com/gpuweb/gpuweb/pull/89#discussion_r218523586 we have some restrictions around texture copies, so it shouldn't be necessary to have separate bits for depth/stencil.