### PR TITLE
IndexFormat, VertexFormat and InputStepMode should be enums

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -380,10 +380,9 @@ enum WebGPUVertexFormat {
     // TODO other vertex formats
 };
 
-typedef u32 WebGPUInputStepModeEnum;
-interface WebGPUInputStepMode {
-    const u32 VERTEX = 0;
-    const u32 INSTANCE = 1;
+enum WebGPUInputStepMode {
+    "vertex",
+    "instance"
 };
 
 dictionary WebGPUVertexAttributeDescriptor {
@@ -396,7 +395,7 @@ dictionary WebGPUVertexAttributeDescriptor {
 dictionary WebGPUVertexInputDescriptor {
     u32 inputSlot;
     u32 stride;
-    WebGPUInputStepModeEnum stepMode;
+    WebGPUInputStepMode stepMode;
 };
 
 dictionary WebGPUInputStateDescriptor {

--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -372,12 +372,11 @@ enum WebGPUIndexFormat {
     "uint32"
 };
 
-typedef u32 WebGPUVertexFormatEnum;
-interface WebGPUVertexFormat {
-    const u32 FLOAT_R32_G32_B32_A32 = 0;
-    const u32 FLOAT_R32_G32_B32 = 1;
-    const u32 FLOAT_R32_G32 = 2;
-    const u32 FLOAT_R32 = 3;
+enum WebGPUVertexFormat {
+    "floatR32G32B32A32",
+    "floatR32G32B32",
+    "floatR32G32",
+    "floatR32"
     // TODO other vertex formats
 };
 
@@ -391,7 +390,7 @@ dictionary WebGPUVertexAttributeDescriptor {
     u32 shaderLocation;
     u32 inputSlot;
     u32 offset;
-    WebGPUVertexFormatEnum format;
+    WebGPUVertexFormat format;
 };
 
 dictionary WebGPUVertexInputDescriptor {

--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -366,10 +366,10 @@ dictionary WebGPUDepthStencilStateDescriptor {
 };
 
 // InputState
-typedef u32 WebGPUIndexFormatEnum;
-interface WebGPUIndexFormat {
-    const u32 UINT16 = 0;
-    const u32 UINT32 = 1;
+
+enum WebGPUIndexFormat {
+    "uint16",
+    "uint32"
 };
 
 typedef u32 WebGPUVertexFormatEnum;
@@ -401,7 +401,7 @@ dictionary WebGPUVertexInputDescriptor {
 };
 
 dictionary WebGPUInputStateDescriptor {
-    WebGPUIndexFormatEnum indexFormat;
+    WebGPUIndexFormat indexFormat;
 
     sequence<WebGPUVertexAttributeDescriptor> attributes;
     sequence<WebGPUVertexInputDescriptor> inputs;


### PR DESCRIPTION
Since all these values are exclusive, they should be enums in the IDL.

This way implementations can possibly validate in their bindings code.