### PR TITLE
Fix a typo for issue #160

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -458,7 +458,7 @@ enum WebGPUPrimitiveTopology {
     "pointList",
     "lineList",
     "lineStrip",
-    "trangleList",
+    "triangleList",
     "triangleStrip"
 };
 


### PR DESCRIPTION
In  `enum WebGPUPrimitiveTopology`, `triangleList` was misspelled as `trangleList`.