### PR TITLE
Remove groupLabel parameter from popDebugGroup

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -718,7 +718,7 @@ namespace gpu {
 
 partial interface WebGPUProgrammablePassEncoder {
     void pushDebugGroup(DOMString groupLabel);
-    void popDebugGroup(DOMString groupLabel);
+    void popDebugGroup();
     void insertDebugMarker(DOMString markerLabel);
 };
 


### PR DESCRIPTION
Remove groupLabel parameter from `popDebugGroup`.

`popDebugGroup` was initially merged to the IDL in https://github.com/gpuweb/gpuweb/commit/f6b5b250101bf13ac3ed82810be1df247fc7a3f1

None of the backends allow you to pass the `groupLabel` as a parameter. All backends will match `popDebugGroup` equivalent with the last called `pushDebugGroup` equivalent.

**DX12 PIX**
`void PIXEndEvent(ID3D12GraphicsCommandList* commandList);` [[MSDN]](https://blogs.msdn.microsoft.com/pix/winpixeventruntime/)
    
**Vulkan**
`void vkCmdDebugMarkerEndEXT(VkCommandBuffer commandBuffer);` [[Khronos]](https://www.khronos.org/registry/vulkan/specs/1.0-extensions/html/vkspec.html#vkCmdDebugMarkerEndEXT)

**Metal**
`func popDebugGroup()` [[Apple]](https://developer.apple.com/documentation/metal/mtlcommandbuffer/2869549-popdebuggroup)
