### PR TITLE
IDL: Remove dummy blit() command.

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -594,9 +594,6 @@ interface GPUCommandBuffer {
         GPUTextureCopyView source,
         GPUTextureCopyView destination,
         GPUExtent3D copySize);
-
-    // TODO figure which other commands are needed
-    void blit();
 };
 
 dictionary GPUCommandBufferDescriptor {


### PR DESCRIPTION
This is unlikely to be implemented because some native APIs don't have
blit operations. It was just an example and didn't have arguments
anyway.