### PR TITLE
Swapchain: rename getNextTexture to acquireNextTexture

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -640,7 +640,7 @@ dictionary WebGPUSwapChainDescriptor {
 
 interface WebGPUSwapChain {
     void configure(WebGPUSwapChainDescriptor descriptor);
-    WebGPUTexture getNextTexture();
+    WebGPUTexture acquireNextTexture();
     void present();
 };
 


### PR DESCRIPTION
"Get" made it seem like this call was idempotent when it actually gives
you a different texture everytime it is called (with present() in
between).