### PR TITLE
Rename VertexInputDescriptor to VertexBufferDescriptor

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -393,7 +393,7 @@ dictionary GPUVertexAttributeDescriptor {
     GPUVertexFormat format;
 };
 
-dictionary GPUVertexInputDescriptor {
+dictionary GPUVertexBufferDescriptor {
     u32 inputSlot;
     u32 stride;
     GPUInputStepMode stepMode;
@@ -403,7 +403,7 @@ dictionary GPUInputStateDescriptor {
     GPUIndexFormat indexFormat;
 
     sequence<GPUVertexAttributeDescriptor> attributes;
-    sequence<GPUVertexInputDescriptor> inputs;
+    sequence<GPUVertexBufferDescriptor> inputs;
 };
 
 // ShaderModule


### PR DESCRIPTION
This makes it more clear that each of these descriptors corresponds to
on of the entries in "setVertexBuffers".

The "inputSlot" member isn't renamed as it is being discussed in an
other issue.