### PR TITLE
Remove device and extent from SwapchainDescriptor.

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -630,11 +630,8 @@ interface GPUQueue {
 
 // SwapChain / RenderingContext
 dictionary GPUSwapChainDescriptor {
-    GPUDevice? device;
     GPUTextureUsageFlags usage;
     GPUTextureFormat format;
-    u32 width;
-    u32 height;
 };
 
 interface GPUSwapChain {


### PR DESCRIPTION
The extent would be instead set using the canvas width and height
attributes, and the device is only useful for the initial creation of
the swapchain that should have a different descriptor (possible
inheriting from the swapchain descriptor).