### PR TITLE
Make endPass() not use a fluent syntax.

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -485,7 +485,8 @@ interface GPURenderPipeline {
 
 /// Common interface for render and compute pass encoders.
 interface GPUProgrammablePassEncoder {
-    GPUCommandBuffer endPass();
+    void endPass();
+
     // Allowed in both compute and render passes
     //TODO: setPushConstants() ?
     void setBindGroup(u32 index, GPUBindGroup bindGroup, optional sequence<u32> dynamicOffsets);


### PR DESCRIPTION
This is assuming that the encoder interfaces will not use fluent syntax
either.