### PR TITLE
Remove PRESENT usage from the texture

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -102,7 +102,6 @@ interface WebGPUTextureUsage {
     const u32 SAMPLED = 4;
     const u32 STORAGE = 8;
     const u32 OUTPUT_ATTACHMENT = 16;
-    const u32 PRESENT = 32;
 };
 
 dictionary WebGPUTextureDescriptor {


### PR DESCRIPTION
Do we still need that usage exposed to the users? Since the swapchain images are not created by them, they'll never need to actually specify it in our API.