### PR TITLE
Promise versions of create*Pipeline

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -673,6 +673,9 @@ interface GPUDevice {
     GPUComputePipeline createComputePipeline(GPUComputePipelineDescriptor descriptor);
     GPURenderPipeline createRenderPipeline(GPURenderPipelineDescriptor descriptor);
 
+    Promise<GPUComputePipeline> createReadyComputePipeline(GPUComputePipelineDescriptor descriptor);
+    Promise<GPURenderPipeline> createReadyRenderPipeline(GPUPipelineDescriptor descriptor);
+
     GPUCommandBuffer createCommandBuffer(GPUCommandBufferDescriptor descriptor);
     GPUFence createFence(GPUFenceDescriptor descriptor);
 


### PR DESCRIPTION
* `Promise<GPUComputePipeline> createReadyComputePipeline(...);`
* `Promise<GPURenderPipeline> createReadyRenderPipeline(...);`

Fixes #128.