### PR TITLE
BindGroupLayoutBindings should be identified by its position in the sequence

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -252,7 +252,6 @@ dictionary GPUBufferBinding {
 typedef (GPUSampler or GPUTextureView or GPUBufferBinding) GPUBindingResource;
 
 dictionary GPUBindGroupBinding {
-    u32 binding;
     GPUBindingResource resource;
 };
 


### PR DESCRIPTION
This group has agreed that the officially-supported human-readable language for writing WebGPU shaders is WHLSL, and WHLSL strives to be source-compatible with HLSL.

In HLSL, it's pretty common to see things like:
```HLSL
SamplerState theSampler : register(s0);
ConstantBuffer<Foo> theBuffer : register(b0);
```
Note that these two resources share the same number, but differ by their type. Therefore, in order to bind resources to these bind points, a WebGPU program would create a `GPUBindGroupLayoutDescriptor` that looks like:

```JS
[{binding: 0, type: "sampler"}, {binding: 0, type: "uniform-buffer"}]
```

So far, we haven't specified the validation requirements for `GPUBindGroupLayout`s, but the above code requires that (binding, type) be unique, rather than just (binding).

This is fine, except when the author wants to go ahead and actually `GPUDevice.createBindGroup()`. If the `GPUBindGroupBinding` doesn't list the type, it doesn't know which `GPUBindGroupLayoutBinding` each item corresponds to. Therefore, this patch removes the `binding` member of the `GPUBindGroupBinding` dictionary. Instead, the `sequence<GPUBindGroupBinding> bindings` member of `GPUBindGroupDescriptor` must be parallel to the `sequence<GPUBindGroupLayoutBinding> bindings` member of `GPUBindGroupLayoutDescriptor`.

Another way we could do this is to instead add a `GPUBindingType type` member of `GPUBindGroupBinding`, but using parallel arrays is simpler and easier to understand.