### PR TITLE
Use modern texture types

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -215,7 +215,7 @@ enum GPUBindingType {
     "uniform-buffer",
     "dynamic-uniform-buffer",
     "sampler",
-    "sampled-texture",
+    "texture",
     "storage-buffer",
     "dynamic-storage-buffer"
     // TODO other binding types


### PR DESCRIPTION
This group has agreed that the officially-supported human-readable language for writing WebGPU shaders is WHLSL, and WHLSL strives to be source-compatible with HLSL.

According to the [Microsoft documentation](https://docs.microsoft.com/en-us/windows/desktop/direct3dhlsl/dx-graphics-hlsl-texture), modern HLSL uses distinct texture and sampler types, rather than sampled-texture types.