### PR TITLE
ErrorHandling.md: tryCreate*

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -660,6 +660,9 @@ interface GPUDevice {
     GPUTexture createTexture(GPUTextureDescriptor descriptor);
     GPUSampler createSampler(GPUSamplerDescriptor descriptor);
 
+    Promise<GPUBuffer?> tryCreateBuffer(GPUBufferDescriptor descriptor);
+    Promise<GPUTexture?> tryCreateTexture(GPUTextureDescriptor descriptor);
+
     GPUBindGroupLayout createBindGroupLayout(GPUBindGroupLayoutDescriptor descriptor);
     GPUPipelineLayout createPipelineLayout(GPUPipelineLayoutDescriptor descriptor);
     GPUBindGroup createBindGroup(GPUBindGroupDescriptor descriptor);
@@ -674,7 +677,6 @@ interface GPUDevice {
     GPUQueue getQueue();
 
     attribute GPULogCallback onLog;
-    GPUObjectStatusQuery getObjectStatus(GPUStatusableObject statusableObject);
 };
 
 dictionary GPUDeviceDescriptor {


### PR DESCRIPTION
Provides a simpler API for fallible allocation of `GPUBuffer`s and `GPUTexture`s.

EDIT: Note this removes the object status query too.