### PR TITLE
Remove blendEnabled for consistency with (lack of) depthTestEnabled

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -336,7 +336,6 @@ dictionary GPUBlendDescriptor {
 dictionary GPUColorStateDescriptor {
     GPUTextureFormat format;
 
-    boolean blendEnabled;
     GPUBlendDescriptor alphaBlend;
     GPUBlendDescriptor colorBlend;
     GPUColorWriteFlags writeMask;


### PR DESCRIPTION
This value can be inferred by WebGPU implementation and we can stir
developers towards enabling blending only when needed with good
defaults.