### PR TITLE
Remove GPUSamplerDescriptor.maxAnisotropy.

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -190,7 +190,6 @@ dictionary GPUSamplerDescriptor {
     GPUFilterMode mipmapFilter = "nearest";
     float lodMinClamp = 0;
     float lodMaxClamp = 0xffffffff; // TODO: What should this be? Was Number.MAX_VALUE.
-    u32 maxAnisotropy = 1;
     GPUCompareFunction compareFunction = "never";
     GPUBorderColor borderColor = "transparentBlack";
 };


### PR DESCRIPTION
We agreed that anisotropic filtering would be an extension so this
parameters shouldn't be defined in the descriptor for core WebGPU.