### PR TITLE
Separate the command buffer and command encoder concepts

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -562,6 +562,9 @@ dictionary GPUTextureCopyView {
 };
 
 interface GPUCommandBuffer {
+};
+
+interface GPUCommandEncoder {
     GPURenderPassEncoder beginRenderPass(GPURenderPassDescriptor descriptor);
     GPUComputePassEncoder beginComputePass();
 
@@ -587,9 +590,11 @@ interface GPUCommandBuffer {
         GPUTextureCopyView source,
         GPUTextureCopyView destination,
         GPUExtent3D copySize);
+
+    GPUCommandBuffer finish();
 };
 
-dictionary GPUCommandBufferDescriptor {
+dictionary GPUCommandEncoderDescriptor {
     //TODO: reusability flag?
 };
 
@@ -662,7 +667,7 @@ interface GPUDevice {
     Promise<GPUComputePipeline> createReadyComputePipeline(GPUComputePipelineDescriptor descriptor);
     Promise<GPURenderPipeline> createReadyRenderPipeline(GPUPipelineDescriptor descriptor);
 
-    GPUCommandBuffer createCommandBuffer(GPUCommandBufferDescriptor descriptor);
+    GPUCommandEncoder createCommandEncoder(GPUCommandEncoderDescriptor descriptor);
     GPUFence createFence(GPUFenceDescriptor descriptor);
 
     GPUQueue getQueue();
@@ -715,6 +720,7 @@ interface mixin GPUDebugLabel {
 };
 
 GPUCommandBuffer includes GPUDebugLabel;
+GPUCommandEncoder includes GPUDebugLabel;
 GPUComputePipeline includes GPUDebugLabel;
 GPUFence includes GPUDebugLabel;
 GPUProgrammablePassEncoder includes GPUDebugLabel;
@@ -722,7 +728,7 @@ GPUQueue includes GPUDebugLabel;
 GPURenderPipeline includes GPUDebugLabel;
 GPUShaderModule includes GPUDebugLabel;
 
-partial dictionary GPUCommandBufferDescriptor {
+partial dictionary GPUCommandEncoderDescriptor {
     DOMString label;
 };
 


### PR DESCRIPTION
The CommandEncoder represents a top-level encoder of commands with a
finish() method that "consumes" the encoder and turns it into a command
buffer that is ready to be executed.

Advantages compared to the previous version of the IDL are:
 - Better type-safety: it shows the difference between the encoding of
commands and a finalized bundle of commands more explictly.
 - Better type-safety (for threads): only GPUCommandBuffers would be
transferrable / shareable to a different threads. Encoders would stay
inside the worker in which they were created.
 - More explicit validation point: some validation such as checking all
passes are ended, can only be done once we know the buffer is finished
encoding.
 - Allow implementations to free temporary encoding datastructures
early, which will be more important with reusable command buffers.

Disadvantages:
 - Requires an extra finish() call and introduces a mostly empty type,
increasing the complexity of the API slightly. (note that beginner WebGPU
developers can just do `queue.submit([encoder.finish()])` which doesn't
look very complicated)