### PR TITLE
Split AttachmentState between Color and DepthStencil states

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -330,10 +330,12 @@ dictionary GPUBlendDescriptor {
     GPUBlendOperation operation;
 };
 
-dictionary GPUBlendStateDescriptor {
+dictionary GPUColorStateDescriptor {
+    GPUTextureFormat format;
+
     boolean blendEnabled;
-    GPUBlendDescriptor alpha;
-    GPUBlendDescriptor color;
+    GPUBlendDescriptor alphaBlend;
+    GPUBlendDescriptor colorBlend;
     GPUColorWriteFlags writeMask;
 };
 
@@ -356,6 +358,8 @@ dictionary GPUStencilStateFaceDescriptor {
 };
 
 dictionary GPUDepthStencilStateDescriptor {
+    GPUTextureFormat format;
+
     boolean depthWriteEnabled;
     GPUCompareFunction depthCompare;
 
@@ -420,20 +424,6 @@ dictionary GPUShaderModuleDescriptor {
 interface GPUShaderModule {
 };
 
-// Description of a single attachment
-dictionary GPUAttachmentDescriptor {
-    // Attachment data format
-    GPUTextureFormat format;
-};
-
-// Description of the framebuffer attachments
-dictionary GPUAttachmentsStateDescriptor {
-    // Array of color attachments
-    sequence<GPUAttachmentDescriptor> colorAttachments;
-    // Optional depth/stencil attachment
-    GPUAttachmentDescriptor? depthStencilAttachment;
-};
-
 dictionary GPUPipelineStageDescriptor {
     GPUShaderModule module;
     DOMString entryPoint;
@@ -467,10 +457,10 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
 
     GPUPrimitiveTopology primitiveTopology;
     GPURasterizationStateDescriptor rasterizationState;
-    sequence<GPUBlendStateDescriptor> blendStates;
-    GPUDepthStencilStateDescriptor depthStencilState;
+    sequence<GPUColorStateDescriptor> colorStates;
+    GPUDepthStencilStateDescriptor? depthStencilState;
     GPUInputStateDescriptor inputState;
-    GPUAttachmentsStateDescriptor attachmentsState;
+
     // Number of MSAA samples
     u32 sampleCount;
     // TODO other properties


### PR DESCRIPTION
The attachment state didn't contain much and the colorAttachments felt
redundant given the blendStates sequence had to have the same elements.

This renames GPUBlendStateDescriptor to GPUColorStateDescriptor and adds
the color attachment format to it. Likewise it adds the depth stencil
attachment format to the GPUDepthStencilStateDescriptor, and makes it
optional so that it can be null when there are no depth stencil
attahchments.