### PR TITLE
Remove GPUPipelineLayout and inline it in GPUPipelineDescriptorBase

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -237,14 +237,6 @@ dictionary GPUBindGroupLayoutDescriptor {
 interface GPUBindGroupLayout {
 };
 
-// PipelineLayout
-dictionary GPUPipelineLayoutDescriptor {
-    sequence<GPUBindGroupLayout> bindGroupLayouts;
-};
-
-interface GPUPipelineLayout {
-};
-
 // BindGroup
 dictionary GPUBufferBinding {
     GPUBuffer buffer;
@@ -444,7 +436,7 @@ dictionary GPUPipelineStageDescriptor {
 };
 
 dictionary GPUPipelineDescriptorBase {
-    GPUPipelineLayout layout;
+    sequence<GPUBindGroupLayout> bindGroupLayouts;
 };
 
 // GPUComputePipeline
@@ -662,7 +654,6 @@ interface GPUDevice {
     GPUSampler createSampler(GPUSamplerDescriptor descriptor);
 
     GPUBindGroupLayout createBindGroupLayout(GPUBindGroupLayoutDescriptor descriptor);
-    GPUPipelineLayout createPipelineLayout(GPUPipelineLayoutDescriptor descriptor);
     GPUBindGroup createBindGroup(GPUBindGroupDescriptor descriptor);
 
     GPUShaderModule createShaderModule(GPUShaderModuleDescriptor descriptor);


### PR DESCRIPTION
The pipeline layouts only contained the list of bind group layouts and
didn't add any value by being a separate object. Removing them reduces
the API complexity.