### PR TITLE
Modify swap chain IDL to reflect consensus in the F2F

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -625,7 +625,10 @@ interface GPUQueue {
     void signal(GPUFence fence, u64 signalValue);
 };
 
-// SwapChain / RenderingContext
+// SwapChain / CanvasContext
+interface GPUCanvasContext {
+};
+
 dictionary GPUSwapChainDescriptor {
     required GPUCanvasContext context;
     required GPUTextureFormat format;
@@ -634,9 +637,6 @@ dictionary GPUSwapChainDescriptor {
 
 interface GPUSwapChain {
     GPUTexture getTexture();
-};
-
-interface GPURenderingContext : GPUSwapChain {
 };
 
 // Web GPU "namespace" used for device creation

--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -627,14 +627,13 @@ interface GPUQueue {
 
 // SwapChain / RenderingContext
 dictionary GPUSwapChainDescriptor {
-    GPUTextureUsageFlags usage;
-    GPUTextureFormat format;
+    required GPUCanvasContext context;
+    required GPUTextureFormat format;
+    GPUTextureUsageFlags usage = GPUTextureUsage.OUTPUT_ATTACHMENT;
 };
 
 interface GPUSwapChain {
-    void configure(GPUSwapChainDescriptor descriptor);
-    GPUTexture getNextTexture();
-    void present();
+    GPUTexture getTexture();
 };
 
 interface GPURenderingContext : GPUSwapChain {
@@ -675,10 +674,16 @@ interface GPUDevice {
     GPUCommandBuffer createCommandBuffer(GPUCommandBufferDescriptor descriptor);
     GPUFence createFence(GPUFenceDescriptor descriptor);
 
+    // Calling createSwapChain a second time for the same GPUCanvasContext
+    // invalidates the previous one, and all of the textures it’s produced.
+    GPUSwapChain createSwapChain(GPUSwapChainDescriptor desc);
+
     GPUQueue getQueue();
 
     attribute GPULogCallback onLog;
     GPUObjectStatusQuery getObjectStatus(GPUStatusableObject statusableObject);
+
+    Promise<GPUTextureFormat> getSwapChainPreferredFormat(GPUCanvasContext context);
 };
 
 dictionary GPUDeviceDescriptor {

--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -636,7 +636,7 @@ dictionary GPUSwapChainDescriptor {
 };
 
 interface GPUSwapChain {
-    GPUTexture getTexture();
+    GPUTexture getCurrentTexture();
 };
 
 // Web GPU "namespace" used for device creation

--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -676,7 +676,7 @@ interface GPUDevice {
 
     // Calling createSwapChain a second time for the same GPUCanvasContext
     // invalidates the previous one, and all of the textures it’s produced.
-    GPUSwapChain createSwapChain(GPUSwapChainDescriptor desc);
+    GPUSwapChain createSwapChain(GPUSwapChainDescriptor descriptor);
 
     GPUQueue getQueue();
 


### PR DESCRIPTION
Added required 'context' and 'format' members to GPUSwapChainDescriptor dictionary
Added 'usage' member to GPUSwapChainDescriptor dictionary with a default value of OUTPUT_ATTACHMENT.
Renamed GPUSwapChain.getNextTexture to GPUSwapChain.getCurrentTexture
Removed GPUSwapChain.present. "Presenting" happens implicitly like WebGL does
Removed GPUSwapChain.configure. When canvas is resized, developer must make a new swapchain from the GPUDevice.
Added GPUDevice.getSwapChainPreferredFormat. Developers can query for the preferred format and potentially receive something besides r8g8b8a8-unorm.
Added GPUDevice.createSwapChain. Developers must make a swap chain for a canvas in order for its contents to appear on the page.
Added GPUCanvasContext
Removed GPURenderingContext

Fixes #182 