### PR TITLE
Make depthStencilAttachment field optional in GPURenderPassDescriptor

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -544,7 +544,7 @@ dictionary GPURenderPassDepthStencilAttachmentDescriptor {
 
 dictionary GPURenderPassDescriptor {
     sequence<GPURenderPassColorAttachmentDescriptor> colorAttachments;
-    GPURenderPassDepthStencilAttachmentDescriptor depthStencilAttachment;
+    GPURenderPassDepthStencilAttachmentDescriptor? depthStencilAttachment;
 };
 
 dictionary GPUBufferCopyView {


### PR DESCRIPTION
Since the depthStencilState on the GPURenderPipeline is optional, the depthStencilAttachment for the GPURenderPassEncoder should also be optional.