### PR TITLE
GPUTexture.createTextureView -> createView.

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -208,8 +208,8 @@ interface GPUTextureView {
 };
 
 interface GPUTexture {
-    GPUTextureView createTextureView(GPUTextureViewDescriptor desc);
-    GPUTextureView createDefaultTextureView();
+    GPUTextureView createView(GPUTextureViewDescriptor desc);
+    GPUTextureView createDefaultView();
 
     void destroy();
 };


### PR DESCRIPTION
The "texture" word seems redundant: calling `myTexture.createView` will
obviously return a texture view.