### PR TITLE
Provide getSubData() as a sibling to setSubData()

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -66,6 +66,7 @@ dictionary GPUBufferDescriptor {
 
 interface GPUBuffer {
     void setSubData(u32 offset, ArrayBuffer data);
+    Promise<ArrayBuffer> getSubData(u32 offset, u32 length);
 
     Promise<ArrayBuffer> mapReadAsync();
     Promise<ArrayBuffer> mapWriteAsync();


### PR DESCRIPTION
We have `setSubData()` so it makes sense to have `getSubData()` for symmetry. It doesn't make much sense to have one without the other.