### PR TITLE
window.gpu -> navigator.gpu

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -792,9 +792,19 @@ dictionary GPURequestAdapterOptions {
 };
 
 [Exposed=Window]
-namespace gpu {
+interface GPU {
     // May reject with DOMException  // TODO: DOMException("OperationError")?
     Promise<GPUAdapter> requestAdapter(optional GPURequestAdapterOptions options);
+};
+
+[Exposed=Window]
+partial interface Navigator {
+    [SameObject] readonly attribute GPU gpu;
+};
+
+[Exposed=DedicatedWorker]
+partial interface WorkerNavigator {
+    [SameObject] readonly attribute GPU gpu;
 };
 
 // ****************************************************************************


### PR DESCRIPTION
This is more of an idea than a proposal. When looking at some of the other APIs (WebUSB in particular) it seemed like this was a more natural API. @beaufortfrancois, since you proposed the thing we have currently, what do you think of this?