### PR TITLE
Move depth bias related fields into a separate struct

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -335,13 +335,16 @@ enum GPUCullMode {
     "back"
 };
 
+dictionary GPUDepthBiasDescriptor {
+    i32 offset;
+    float slopeScale;
+    float clamp;
+};
+
 dictionary GPURasterizationStateDescriptor {
     GPUFrontFace frontFace;
     GPUCullMode cullMode;
-
-    i32 depthBias;
-    float depthBiasSlopeScale;
-    float depthBiasClamp;
+    GPUDepthBiasDescriptor depthBias;
 };
 
 // BlendState


### PR DESCRIPTION
Encapsulating close semantics in a struct allows for less headache for the user: if they get depth bias parameters from one place (say, associated with the target surface) and cull mode and front face from the other, they no longer need to come up with their own struct and then copy all the relevant fields one by one.