### PR TITLE
Expose better limits on GPUAdapter

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -792,7 +792,7 @@ interface GPUDevice {
 
 dictionary GPUDeviceDescriptor {
     GPUExtensions extensions;
-    //GPULimits limits; Don't expose higher limits for now.
+    GPULimits limits;
 
     // TODO are other things configurable like queues?
 };


### PR DESCRIPTION
PTAL, eventually we'll need to expose limits so uncommenting this member of GPUDeviceDescriptor. It doesn't mean that prototype implementations of WebGPU need to expose higher than required limits.