### PR TITLE
Remove clamp-to-border-color option from GPUSampler

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -218,8 +218,7 @@ interface GPUTexture {
 enum GPUAddressMode {
     "clamp-to-edge",
     "repeat",
-    "mirror-repeat",
-    "clamp-to-border-color"
+    "mirror-repeat"
 };
 
 enum GPUFilterMode {
@@ -238,12 +237,6 @@ enum GPUCompareFunction {
     "always"
 };
 
-enum GPUBorderColor {
-    "transparent-black",
-    "opaque-black",
-    "opaque-white"
-};
-
 dictionary GPUSamplerDescriptor {
     GPUAddressMode addressModeU = "clampToEdge";
     GPUAddressMode addressModeV = "clampToEdge";
@@ -255,7 +248,6 @@ dictionary GPUSamplerDescriptor {
     float lodMaxClamp = 0xffffffff; // TODO: What should this be? Was Number.MAX_VALUE.
     u32 maxAnisotropy = 1;
     GPUCompareFunction compareFunction = "never";
-    GPUBorderColor borderColor = "transparentBlack";
 };
 
 interface GPUSampler {


### PR DESCRIPTION
MTLSamplerBorderColor is supported only on macOS 10.12 and above, meaning clamp-to-border-color is not implementable on iOS.

https://developer.apple.com/documentation/metal/mtlsamplerbordercolor?language=objc