### PR TITLE
Add GPUDevice.createReadyShaderModule()

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -779,6 +779,8 @@ interface GPUDevice {
     GPUBindGroup createBindGroup(GPUBindGroupDescriptor descriptor);
 
     GPUShaderModule createShaderModule(GPUShaderModuleDescriptor descriptor);
+    Promise<GPUShaderModule> createReadyShaderModule(GPUShaderModuleDescriptor descriptor);
+
     GPUComputePipeline createComputePipeline(GPUComputePipelineDescriptor descriptor);
     GPURenderPipeline createRenderPipeline(GPURenderPipelineDescriptor descriptor);
 


### PR DESCRIPTION
The balance of compilation between `GPUDevice.createShaderModule()` and `GPUDevice.create***Pipeline()` is undefined. On some implementations, the bulk of the compilation will happen in `GPUDevice.createShaderModule()`, and on other implementation, the bulk of the compilation will happen in `GPUDevice.create***Pipeline()`. Therefore, it seems there should be a `Ready` variant of `GPUDevice.createShaderModule()` for all the same reasons that there is a `Ready` variant of `GPUDevice.create***Pipeline()`.