### PR TITLE
Change rowPitch integer to u32

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -641,7 +641,7 @@ dictionary GPURenderPassDescriptor {
 dictionary GPUBufferCopyView {
     GPUBuffer buffer;
     u64 offset;
-    u64 rowPitch;
+    u32 rowPitch;
     u32 imageHeight;
 };
 


### PR DESCRIPTION
The `rowPitch` is the number of bytes in each "row" when a buffer is interpreted as a texture. It would make sense that the same numerical limits for texture sizes apply to this value as well. While conceptually it is okay for this to be `u64`, D3D12 and Vulkan only support a `u32` row pitch.
 - https://docs.microsoft.com/en-us/windows/desktop/api/d3d12/ns-d3d12-d3d12_subresource_footprint
 - https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/VkBufferImageCopy.html