### PR TITLE
Remove GPUUncapturedErrorEvent constructor and device.onuncapturederror

### DIFF
--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -837,6 +837,10 @@ interface GPUUncapturedErrorEvent : Event {
 
 // TODO: is it possible to expose the EventTarget only on the main thread?
 partial interface GPUDevice : EventTarget {
+    // GPUDevice has an event target on "uncapturederror" (but no
+    // onuncapturederror property). It can be listened with
+    //   device.addEventListener("uncapturederror", ev => {});
+    // (ev is a GPUUncapturedErrorEvent object.)
 };
 
 // ****************************************************************************

--- a/design/sketch.webidl
+++ b/design/sketch.webidl
@@ -829,21 +829,14 @@ partial interface GPUDevice {
 // ****************************************************************************
 
 [
-    Constructor(DOMString type, GPUUncapturedErrorEventInit gpuUncapturedErrorEventInitDict),
     Exposed=Window
 ]
 interface GPUUncapturedErrorEvent : Event {
     readonly attribute GPUError error;
 };
 
-dictionary GPUUncapturedErrorEventInit : EventInit {
-    required DOMString message;
-};
-
 // TODO: is it possible to expose the EventTarget only on the main thread?
 partial interface GPUDevice : EventTarget {
-    [Exposed=Window]
-    attribute EventHandler onuncapturederror;
 };
 
 // ****************************************************************************


### PR DESCRIPTION
- The GPUUncapturedErrorEvent constructor is only needed to synthesize
  events for dispatchEvent. dispatchEvent is not useful here because the
  browser does not do any handling of the event; it only calls the event
  handlers. (This also removes GPUUncapturedErrorEventInit.)

- device.onuncapturederror is unnecessary because addEventListener
  is more powerful. onuncapturederror seems like an anti-pattern. (If
  we figure out why these are normally included, we can add it back.)