### PR TITLE
Replace ArrayBuffers with garbage-friendly alternatives

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -338,10 +338,10 @@ Shader Module {#shader}
 // Note: While the choice of shader language is undecided,
 // GPUShaderModuleDescriptor will temporarily accept both
 // text and binary input.
-typedef (ArrayBuffer or DOMString) ArrayBufferOrDOMString;
+typedef (Uint32Array or DOMString) GPUShaderCode;
 
 dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
-    required ArrayBufferOrDOMString code;
+    required GPUShaderCode code;
 };
 
 interface GPUShaderModule : GPUObjectBase {


### PR DESCRIPTION
Taking ArrayBuffer as input is problematic: if an application wants to provide a sub-range of an existing ArrayBuffer, it must make a copy of all of the data into a new ArrayBuffer.

- ~~setSubData: Uses ~~ArrayBuffer~~ BufferSource + srcOffset + size to avoid the garbage overhead of creating an ArrayBufferView.~~
- GPUShaderModuleDescriptor: creating pipelines is already very expensive, so this just takes ~~an ArrayBufferView~~ ~~a BufferSource~~ a Uint32Array.