### PR TITLE
Use uppercase for FrontFace enums

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -346,8 +346,8 @@ Pipeline Creation {#pipeline-creation}
 <script type=idl>
 // RasterizationState
 enum GPUFrontFace {
-    "ccw",
-    "cw"
+    "CCW",
+    "CW"
 };
 
 enum GPUCullMode {


### PR DESCRIPTION
CCW and CW are acronyms for CounterClockWise and ClockWise. So it's
better to use uppercase for these two abbreviations.