### PR TITLE
Add some more defaults in AttachmentDescriptors

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1011,7 +1011,7 @@ dictionary GPURenderPassColorAttachmentDescriptor {
     GPUTextureView? resolveTarget = null;
 
     required GPULoadOp loadOp;
-    required GPUStoreOp storeOp;
+    required GPUStoreOp storeOp = "store";
     GPUColor clearColor;
 };
 </script>
@@ -1027,7 +1027,7 @@ dictionary GPURenderPassDepthStencilAttachmentDescriptor {
 
     required GPULoadOp depthLoadOp;
     required GPUStoreOp depthStoreOp;
-    required float clearDepth;
+    required float clearDepth = 1.0;
 
     required GPULoadOp stencilLoadOp;
     required GPUStoreOp stencilStoreOp;


### PR DESCRIPTION
The `storeOp` make sense to be `"store"` for two reasons:

1. Currently, that's the only option in the IDL
2. For the color buffer, even if we add a "lazy clear" option, an author just wanting to render something is usually going to want to see the results of that rendering. This isn't necessarily true for the depth buffer or the stencil buffer, so this patch doesn't modify the `depthStoreOp` or `stencilStoreOp`. When authors hook up multisampling, they can also explicitly disable storing, if they desire.

Similarly for `clearDepth`. The default is what most authors want, which is a normal-acting depth buffer. If developers want to do something more complicated, they can modify the `clearDepth` themselves.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/litherum/gpuweb/pull/268.html" title="Last updated on Jul 12, 2019, 9:42 PM UTC (d5c0c23)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/268/c6db522...litherum:d5c0c23.html" title="Last updated on Jul 12, 2019, 9:42 PM UTC (d5c0c23)">Diff</a>