### PR TITLE
Make GPUPipelineLayout optional in GPUPipelineDescriptorBase

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -537,7 +537,7 @@ dictionary GPUPipelineStageDescriptor {
 };
 
 dictionary GPUPipelineDescriptorBase {
-    required GPUPipelineLayout layout;
+    GPUPipelineLayout? layout = null;
 };
 </script>
 


### PR DESCRIPTION
As I understand it, a GPUPipelineLayout is only needed by a GPUPipelineDescriptor if there are resource bindings that pipeline shaders need to access. When there are no resource bindings, not specifying 'layout' should be equivalent to setting an empty GPUPipelineLayout.