### PR TITLE
Make indexFormat optional in inputStateDescriptor

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -518,7 +518,7 @@ dictionary GPUVertexBufferDescriptor {
 };
 
 dictionary GPUVertexInputDescriptor {
-    required GPUIndexFormat indexFormat;
+    GPUIndexFormat indexFormat = "uint32";
     required sequence<GPUVertexBufferDescriptor?> vertexBuffers;
 };
 </script>


### PR DESCRIPTION
I don't think indexFormat is useful if this pipeline isn't used for indexed drawing.

I'm not sure if it should be a validation error to call "drawIndexed" (+setIndexBuffer) without supplying the indexFormat, or if we should provide a default.

Thoughts?