### PR TITLE
Move primitiveTopology to GPURasterizationState

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -363,6 +363,8 @@ dictionary GPURasterizationStateDescriptor {
     i32 depthBias = 0;
     float depthBiasSlopeScale = 0;
     float depthBiasClamp = 0;
+
+    required GPUPrimitiveTopology primitiveTopology;
 };
 
 // BlendState
@@ -569,7 +571,6 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
     required GPUPipelineStageDescriptor vertexStage;
     GPUPipelineStageDescriptor? fragmentStage = null;
 
-    required GPUPrimitiveTopology primitiveTopology;
     required GPURasterizationStateDescriptor rasterizationState;
     required sequence<GPUColorStateDescriptor> colorStates;
     GPUDepthStencilStateDescriptor? depthStencilState = null;


### PR DESCRIPTION
This is so that the render pipeline descriptor only contains one sub-descriptor per stage and one sub descriptor per stage before or after.

Not too strongly attached to it though.