### PR TITLE
Make entryPoint default to "main"

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -527,7 +527,7 @@ Pipeline Descriptors {#pipeline-descriptors}
 <script type=idl>
 dictionary GPUPipelineStageDescriptor {
     required GPUShaderModule module;
-    required DOMString entryPoint;
+    DOMString entryPoint = "main";
     // TODO other stuff like specialization constants?
 };
 


### PR DESCRIPTION
I think it's fair to make "GPUPipelineStageDescriptor" entryPoint defaults to "main" as this is a common path. WDYT?