### PR TITLE
Add sample mask and alpha-to-coverage state to RenderPipelineDescriptor

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -572,6 +572,8 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
 
     // Number of MSAA samples
     u32 sampleCount = 1;
+    u32 sampleMask = 0xFFFFFFFF;
+    bool alphaToCoverageEnabled = false;
     // TODO other properties
 };
 


### PR DESCRIPTION
This patch adds sample mask and alpha-to-coverage state to the render
pipeline descriptor after the discussion in issue #267.