### PR TITLE
Redo swapchain with ImageBitmap

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -736,22 +736,34 @@ Canvas Rendering and Swap Chain {#swapchain}
 ============================================
 
 <script type=idl>
-interface GPUCanvasContext {
-    // Calling configureSwapChain a second time invalidates the previous one,
-    // and all of the textures it’s produced.
-    GPUSwapChain configureSwapChain(GPUSwapChainDescriptor descriptor);
-
-    Promise<GPUTextureFormat> getSwapChainPreferredFormat(GPUDevice device);
-}
-
 dictionary GPUSwapChainDescriptor {
-    required GPUDevice device;
+    required ImageBitmapRenderingContext context;
     required GPUTextureFormat format;
     GPUTextureUsageFlags usage = GPUTextureUsage.OUTPUT_ATTACHMENT;
 };
 
 interface GPUSwapChain {
-    GPUTexture getCurrentTexture();
+    // Returns a new GPUTexture representing the next image in the swapchain.
+    //
+    // Sets the "has active swapchain image" flag.
+    // Throws an exception if the active was already set.
+    GPUTexture getNextTexture();
+
+    // Transfers the swapchain texture to an ImageBitmap. The GPUTexture
+    // becomes invalid. Throws an exception if the texture is not from this
+    // swapchain, or if it is invalid.
+    ImageBitmap transferToImageBitmap(GPUTexture texture);
+
+    // To present the ImageBitmap, use transferFromImageBitmap on the
+    // ImageBitmapRenderingContext that this GPUSwapChain was created from.
+    //
+    // Doing so closes the ImageBitmap, and unsets the "has active swapchain
+    // image" flag on the GPUSwapChain.
+
+    // Example:
+    //     const texture = swapchain.getNextTexture();
+    //     renderInto(texture);
+    //     ibrc.transferFromImageBitmap(swapchain.transferToImageBitmap(texture));
 };
 </script>
 
@@ -790,6 +802,11 @@ interface GPUDevice {
     GPUCommandEncoder createCommandEncoder(GPUCommandEncoderDescriptor descriptor);
 
     GPUQueue getQueue();
+
+    // Calling configureSwapChain a second time invalidates/detaches the
+    // previous GPUSwapChain, and all of the swapchain images it has produced.
+    GPUSwapChain configureSwapChain(GPUSwapChainDescriptor descriptor);
+    Promise<GPUTextureFormat> getSwapChainPreferredFormat(ImageBitmapRenderingContext context);
 };
 
 dictionary GPUDeviceDescriptor {


### PR DESCRIPTION
For preliminary discussion, see https://github.com/kainino0x/gpuweb/pull/4.

There are two motivations behind this.
- Reintroduce explicit swap control by building out an explicit-swap path that (I think) already exists (transferToImageBitmap+transferFromImageBitmap).
- Reduce the amount of added API surface (by avoiding an extra rendering context type). (Only sort of achieves this goal.)

Additional considerations:
- Be compatible with other ImageBitmap APIs.
- Be compatible native swapchain semantics.