### PR TITLE
Add GPUTexelBufferView

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Locally generated artefacts
+/spec/index.html
+/spec/webgpu.idl

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -74,10 +74,22 @@ dictionary GPUBufferDescriptor : GPUObjectDescriptorBase {
     required GPUBufferUsageFlags usage;
 };
 
+dictionary GPUTexelBufferViewDescriptor : GPUObjectDescriptorBase {
+    required GPUTextureFormat format;
+    u64 offset = 0;
+    required u64 size;
+};
+
+interface GPUTexelBufferView : GPUObjectBase {
+};
+
 interface GPUBuffer : GPUObjectBase {
     Promise<ArrayBuffer> mapReadAsync();
     Promise<ArrayBuffer> mapWriteAsync();
     void unmap();
+
+    GPUTexelBufferView createTexelView(GPUTexelBufferViewDescriptor desc);
+    GPUTexelBufferView createDefaultTexelView();
 
     void destroy();
 };
@@ -282,9 +294,13 @@ enum GPUBindingType {
     "dynamic-uniform-buffer",
     "sampler",
     "sampled-texture",
+    "storage-texture",
     "storage-buffer",
-    "dynamic-storage-buffer"
-    // TODO other binding types
+    "dynamic-storage-buffer",
+    "sampled-texel-buffer",
+    "dynamic-sampled-texel-buffer",
+    "storage-texel-buffer",
+    "dynamic-storage-texel-buffer"
 };
 
 dictionary GPUBindGroupLayoutBinding {
@@ -313,7 +329,7 @@ dictionary GPUBufferBinding {
     required u64 size;
 };
 
-typedef (GPUSampler or GPUTextureView or GPUBufferBinding) GPUBindingResource;
+typedef (GPUSampler or GPUTextureView or GPUBufferBinding or GPUTexelBufferView) GPUBindingResource;
 
 dictionary GPUBindGroupBinding {
     required u32 binding;


### PR DESCRIPTION
Closes #162 

## 1. What is the API?

In D3D12 and Metal, texel buffer views are exposed the same way as texture views: via SRV/UAV and `MTLTexture` correspondingly. In Vulkan, there is a separate `VkBufferView` type describing this object.

I suggest us go with a separate object type as well (as opposed to piggy-backing on `GPUTextureView`) because the produced view is more restricted than a normal texture view. It can only be used for bind group creation, where we already have an implicit enumeration `GPUBindingResource`, so it's trivial to extend it.

## 2. Which texture formats can buffers be viewed as ?

One option would be to have some sort of query to ask the implementation if a specific texture format can be used for a texel view. I think having this query would harm portability and leave heavy fingerprints. Therefore, I suggest us just listing the formats in the spec document for MVP:

| format | sampled-texel | storage-texel |
| ------ | ------------- | ------------- |
| r8unorm | v |   |
| r8unorm-srgb |   |   |
| r8snorm | v |   |
| r8uint | v |   |
| r8sint | v |   |
| r16unorm |   |   |
| r16snorm |   |   |
| r16uint | v |   |
| r16sint | v |   |
| r16float | v |   |
| rg8unorm | v |   |
| rg8unorm-srgb |   |   |
| rg8snorm | v |   |
| rg8uint | v |   |
| rg8sint | v |   |
| b5g6r5unorm |   |   |
| r32uint | v | v |
| r32sint | v | v |
| r32float | v | v |
| rg16unorm |   |   |
| rg16snorm |   |   |
| rg16uint | v |   |
| rg16sint | v |   |
| rg16float | v |   |
| rgba8unorm | v | v |
| rgba8unorm-srgb |   |   |
| rgba8snorm | v | v |
| rgba8uint | v | v |
| rgba8sint | v | v |
| bgra8unorm | v | v |
| bgra8unorm-srgb |   |   |
| rgb10a2unorm | v |   |
| rg11b10float | v |   |
| rg32uint | v | v |
| rg32sint | v | v |
| rg32float | v | v |
| rgba16unorm |   |   |
| rgba16snorm |   |   |
| rgba16uint | v | v |
| rgba16sint | v | v |
| rgba16float | v | v |
| rgba32uint | v | v |
| rgba32sint | v | v |
| rgba32float | v | v |
| depth32float |  |  |
| depth32float-stencil8 |  |  |
