### PR TITLE
Change GPUColor/Origin3D/Extent3D to sequences

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -23,24 +23,9 @@ typedef long i32;
 typedef unsigned long u32;
 typedef unsigned long long u64;
 
-dictionary GPUColor {
-    required float r;
-    required float g;
-    required float b;
-    required float a;
-};
-
-dictionary GPUOrigin3D {
-    u32 x = 0;
-    u32 y = 0;
-    u32 z = 0;
-};
-
-dictionary GPUExtent3D {
-    required u32 width;
-    required u32 height;
-    required u32 depth;
-};
+typedef sequence<float> GPUColor;   // [float, float, float, float]
+typedef sequence<u32> GPUOrigin3D;  // [u32, u32, u32]
+typedef sequence<u32> GPUExtent3D;  // [u32, u32, u32]
 
 typedef sequence<any> GPUMappedBuffer;  // [GPUBuffer, ArrayBuffer]
 
@@ -649,7 +634,7 @@ dictionary GPURenderPassColorAttachmentDescriptor {
 
     required GPULoadOp loadOp;
     required GPUStoreOp storeOp;
-    GPUColor clearColor;  // defaults to {r: 0.0, g: 0.0, b: 0.0, a: 1.0}
+    GPUColor clearColor;  // defaults to [0.0, 0.0, 0.0, 1.0]
 };
 
 dictionary GPURenderPassDepthStencilAttachmentDescriptor {
@@ -686,7 +671,7 @@ dictionary GPUTextureCopyView {
     required GPUTexture texture;
     u32 mipLevel = 0;
     u32 arrayLayer = 0;
-    GPUOrigin3D origin;  // defaults to {x: 0, y: 0, z: 0}
+    GPUOrigin3D origin;  // defaults to [0, 0, 0]
 };
 
 interface GPUCommandBuffer : GPUObjectBase {


### PR DESCRIPTION
This makes WebGPU app code less verbose/hard to type. Without this, I think apps are likely to have their own boilerplate helpers: `makeGPUColor = (r, g, b, a) => ({r, g, b, a})`, etc.

Open for debate.