### PR TITLE
Set initial frontFace value to "ccw"

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -365,7 +365,7 @@ enum GPUCullMode {
 };
 
 dictionary GPURasterizationStateDescriptor {
-    required GPUFrontFace frontFace;
+    GPUFrontFace frontFace = "ccw";
     GPUCullMode cullMode = "none";
 
     i32 depthBias = 0;


### PR DESCRIPTION
Instead of having web developers to specify a rasterizationState `frontFace` value for every single`GPURenderPipelineDescriptor` ~~and `GPUComputePipelineDescriptor`~~,  how about having a default value as in OpenGL?

See https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glFrontFace.xhtml

