### PR TITLE
Add slot into VertexBuffer

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -525,6 +525,7 @@ dictionary GPUVertexAttributeDescriptor {
 };
 
 dictionary GPUVertexBufferDescriptor {
+    required u32 slot;
     required u64 stride;
     GPUInputStepMode stepMode = "vertex";
     required sequence<GPUVertexAttributeDescriptor> attributeSet;
@@ -532,7 +533,7 @@ dictionary GPUVertexBufferDescriptor {
 
 dictionary GPUVertexInputDescriptor {
     GPUIndexFormat indexFormat = "uint32";
-    required sequence<GPUVertexBufferDescriptor?> vertexBuffers;
+    required sequence<GPUVertexBufferDescriptor> vertexBuffers;
 };
 </script>
 


### PR DESCRIPTION
Right now, we don't have "slot" in vertexBuffer. I think it's not very good for webgpu developers. Because developers need to set "NULL" objects for the vertex buffers that are not existed in vertex input. For example, If the first buffer's slot is 3, and the second buffer's slot is 9. Developers might need to set vertex buffers via a sequence in vertexInput like this: {NULLObj, NULLObj, NullObj, VertexBuffer1, NULLObj, NullObj, NULLObj, NULLObj, NULLObj, VertexBuffer2}. Moreover, If the slot of anyone vertex buffer change, web developers need to reset the sequence and insert different numbers of NULLObj in the sequence. It is not good (this situation is really rare though). You see, it seems to be a little bit silly to count the NULLObj one by one and set the correct slot implicitly in this way.

And we do use buffer slot under the hood (for native graphics developers). 

So, I think it's better to add "slot" in VertexBuffer and set the slot explicitly. It is much clear. WDYT? 