### PR TITLE
Change GPUObjectBase to a mixin

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -49,7 +49,7 @@ dictionary GPUExtent3D {
 
 typedef sequence<any> GPUMappedBuffer;  // [GPUBuffer, ArrayBuffer]
 
-interface GPUObjectBase {
+interface mixin GPUObjectBase {
     attribute DOMString? label;
 };
 
@@ -81,7 +81,8 @@ dictionary GPUBufferDescriptor : GPUObjectDescriptorBase {
     required GPUBufferUsageFlags usage;
 };
 
-interface GPUBuffer : GPUObjectBase {
+GPUBuffer includes GPUObjectBase;
+interface GPUBuffer {
     Promise<ArrayBuffer> mapReadAsync();
     Promise<ArrayBuffer> mapWriteAsync();
     void unmap();
@@ -218,10 +219,12 @@ dictionary GPUTextureViewDescriptor : GPUObjectDescriptorBase {
     u32 arrayLayerCount = 1;
 };
 
-interface GPUTextureView : GPUObjectBase {
+GPUTextureView includes GPUObjectBase;
+interface GPUTextureView {
 };
 
-interface GPUTexture : GPUObjectBase {
+GPUTexture includes GPUObjectBase;
+interface GPUTexture {
     GPUTextureView createView(GPUTextureViewDescriptor desc);
     GPUTextureView createDefaultView();
 
@@ -267,7 +270,8 @@ dictionary GPUSamplerDescriptor : GPUObjectDescriptorBase {
     GPUCompareFunction compare = "never";
 };
 
-interface GPUSampler : GPUObjectBase {
+GPUSampler includes GPUObjectBase;
+interface GPUSampler {
 };
 </script>
 
@@ -304,14 +308,16 @@ dictionary GPUBindGroupLayoutDescriptor : GPUObjectDescriptorBase {
     required sequence<GPUBindGroupLayoutBinding> bindings;
 };
 
-interface GPUBindGroupLayout : GPUObjectBase {
+GPUBindGroupLayout includes GPUObjectBase;
+interface GPUBindGroupLayout {
 };
 
 dictionary GPUPipelineLayoutDescriptor : GPUObjectDescriptorBase {
     required sequence<GPUBindGroupLayout> bindGroupLayouts;
 };
 
-interface GPUPipelineLayout : GPUObjectBase {
+GPUPipelineLayout includes GPUObjectBase;
+interface GPUPipelineLayout {
 };
 
 dictionary GPUBufferBinding {
@@ -332,7 +338,8 @@ dictionary GPUBindGroupDescriptor : GPUObjectDescriptorBase {
     required sequence<GPUBindGroupBinding> bindings;
 };
 
-interface GPUBindGroup : GPUObjectBase {
+GPUBindGroup includes GPUObjectBase;
+interface GPUBindGroup {
 };
 </script>
 
@@ -349,7 +356,8 @@ dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
     required GPUShaderCode code;
 };
 
-interface GPUShaderModule : GPUObjectBase {
+GPUShaderModule includes GPUObjectBase;
+interface GPUShaderModule {
 };
 </script>
 
@@ -559,7 +567,8 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
     required GPUPipelineStageDescriptor computeStage;
 };
 
-interface GPUComputePipeline : GPUObjectBase {
+GPUComputePipeline includes GPUObjectBase;
+interface GPUComputePipeline {
 };
 </script>
 
@@ -592,7 +601,8 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
     // TODO other properties
 };
 
-interface GPURenderPipeline : GPUObjectBase {
+GPURenderPipeline includes GPUObjectBase;
+interface GPURenderPipeline {
 };
 </script>
 
@@ -600,7 +610,8 @@ Command Recording {#command-recording}
 ======================================
 
 <script type=idl>
-interface GPUProgrammablePassEncoder : GPUObjectBase {
+GPUProgrammablePassEncoder includes GPUObjectBase;
+interface GPUProgrammablePassEncoder {
     void endPass();
 
     // Allowed in both compute and render passes
@@ -701,10 +712,12 @@ dictionary ImageBitmapCopyView {
     GPUOrigin2D origin;
 };
 
-interface GPUCommandBuffer : GPUObjectBase {
+GPUCommandBuffer includes GPUObjectBase;
+interface GPUCommandBuffer {
 };
 
-interface GPUCommandEncoder : GPUObjectBase {
+GPUCommandEncoder includes GPUObjectBase;
+interface GPUCommandEncoder {
     GPURenderPassEncoder beginRenderPass(GPURenderPassDescriptor descriptor);
     GPUComputePassEncoder beginComputePass(GPUComputePassEncoder? descriptor);
 
@@ -758,7 +771,8 @@ dictionary GPUFenceDescriptor : GPUObjectDescriptorBase {
     u64 initialValue = 0;
 };
 
-interface GPUFence : GPUObjectBase {
+GPUFence includes GPUObjectBase;
+interface GPUFence {
     u64 getCompletedValue();
     Promise<void> onCompletion(u64 completionValue);
 };
@@ -768,7 +782,8 @@ Queues {#queues}
 ================
 
 <script type=idl>
-interface GPUQueue : GPUObjectBase {
+GPUQueue includes GPUObjectBase;
+interface GPUQueue {
     void submit(sequence<GPUCommandBuffer> buffers);
 
     GPUFence createFence(GPUFenceDescriptor descriptor);
@@ -794,7 +809,8 @@ dictionary GPUSwapChainDescriptor : GPUObjectDescriptorBase {
     GPUTextureUsageFlags usage = 0x10;  // GPUTextureUsage.OUTPUT_ATTACHMENT
 };
 
-interface GPUSwapChain : GPUObjectBase {
+GPUSwapChain includes GPUObjectBase;
+interface GPUSwapChain {
     GPUTexture getCurrentTexture();
 };
 </script>
@@ -812,7 +828,8 @@ dictionary GPULimits {
 };
 
 // Device
-interface GPUDevice : GPUObjectBase {
+GPUDevice includes GPUObjectBase;
+partial interface GPUDevice {
     readonly attribute GPUExtensions extensions;
     readonly attribute GPULimits limits;
     readonly attribute GPUAdapter adapter;
@@ -843,7 +860,8 @@ dictionary GPUDeviceDescriptor : GPUObjectDescriptorBase {
     // TODO are other things configurable like queues?
 };
 
-interface GPUAdapter : GPUObjectBase {
+GPUAdapter includes GPUObjectBase;
+interface GPUAdapter {
     readonly attribute DOMString name;
     readonly attribute GPUExtensions extensions;
     //readonly attribute GPULimits limits; Don't expose higher limits for now.
@@ -937,12 +955,8 @@ dictionary GPUUncapturedErrorEventInit : EventInit {
     required GPUError error;
 };
 
-// TODO: EventTarget is actually an interface, not a mixin, but it probably should be a mixin.
-[Exposed=Window]
-GPUDevice includes EventTarget;
-
-partial interface GPUDevice {
-    [Exposed=Window]
+// TODO: Expose EventTarget only to one thread?
+interface GPUDevice : EventTarget {
     attribute EventHandler onuncapturederror;
 };
 </script>


### PR DESCRIPTION
This makes GPUObjectBase no longer visible in the JS prototype chain.

Necessary for GPUDevice, which needs to subclass EventHandler.

That said, it's not necessary to do this across the board like this; we could do it specially for GPUDevice by just removing GPUObjectBase from its inheritance, and adding `attribute DOMString? label` to the device interface.

It depends on whether we want GPUObjectBase to be an interface visible to JS. It would allow hijacking of GPUObjectBase if you wanted to do something funky, like automagically label all objects, or something. With a mixin, that would have to be done on all of the interfaces individually.