### PR TITLE
Split GPUDevice into primary and ref, introducing mixin GPUDeviceBase

### DIFF
--- a/design/ErrorHandling.md
+++ b/design/ErrorHandling.md
@@ -267,9 +267,10 @@ If there are no error scopes on the stack, `popErrorScope()` rejects.
 
 If the device is lost, `popErrorScope()` always rejects.
 
-\* Error scope state is **per-device, per-execution-context**.
-That is, when a `GPUDevice` is posted to a Worker for the first time, the new `GPUDevice` copy's error scope stack is empty.
-(If a `GPUDevice` is copied *back* to an execution context it already existed on, it shares its error scope state with all other copies on that execution context.)
+\* Error scope state is **per-underlying-device, per-execution-context**.
+That is, when a device (`GPUDevice` or `GPUDeviceRef`) appears on a Worker for the first time (via `requestDevice` or `onmessage`), the new `GPUDeviceRef`'s error scope stack is empty.
+(If a single execution context ends up with multiple `GPUDevice`/`GPUDeviceRef` objects pointing at the same underlying WebGPU device, they all share the same error scope state.
+Uncaptured errors always bubble to the event handler on the primary `GPUDevice`; uncaptured errors cannot be caught from `GPUDeviceRef`s.
 
 ```webidl
 enum GPUErrorFilter {

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -934,6 +934,7 @@ interface GPUValidationError {
 typedef (GPUOutOfMemoryError or GPUValidationError) GPUError;
 
 partial interface mixin GPUDeviceBase {
+    // Error scopes are per-GPUDeviceBase object (not shared between refs).
     void pushErrorScope(GPUErrorFilter filter);
     Promise<GPUError?> popErrorScope();
 };
@@ -963,6 +964,7 @@ interface GPUDevice : EventTarget {
 };
 
 // This type is returned when a GPUDevice is cloned via postMessage.
+// It is clonable and transferrable.
 GPUDeviceRef includes GPUDeviceBase;
 interface GPUDeviceRef {
 };

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -803,11 +803,11 @@ interface GPUCanvasContext {
     // and all of the textures it’s produced.
     GPUSwapChain configureSwapChain(GPUSwapChainDescriptor descriptor);
 
-    Promise<GPUTextureFormat> getSwapChainPreferredFormat(GPUDevice device);
+    Promise<GPUTextureFormat> getSwapChainPreferredFormat(GPUDeviceBase device);
 };
 
 dictionary GPUSwapChainDescriptor : GPUObjectDescriptorBase {
-    required GPUDevice device;
+    required GPUDeviceBase device;
     required GPUTextureFormat format;
     GPUTextureUsageFlags usage = 0x10;  // GPUTextureUsage.OUTPUT_ATTACHMENT
 };
@@ -830,8 +830,7 @@ dictionary GPULimits {
 };
 
 // Device
-[Exposed=(Window, Worker)]
-interface GPUDevice : EventTarget {
+interface mixin GPUDeviceBase : GPUObjectBase {
     readonly attribute GPUExtensions extensions;
     readonly attribute GPULimits limits;
     readonly attribute GPUAdapter adapter;
@@ -854,8 +853,6 @@ interface GPUDevice : EventTarget {
 
     GPUQueue getQueue();
 };
-
-GPUDevice includes GPUObjectBase;
 
 dictionary GPUDeviceDescriptor : GPUObjectDescriptorBase {
     GPUExtensions extensions;
@@ -907,7 +904,7 @@ interface GPUDeviceLostInfo {
     readonly attribute DOMString message;
 };
 
-partial interface GPUDevice {
+partial interface mixin GPUDeviceBase {
     readonly attribute Promise<GPUDeviceLostInfo> lost;
 };
 </script>
@@ -936,7 +933,7 @@ interface GPUValidationError {
 
 typedef (GPUOutOfMemoryError or GPUValidationError) GPUError;
 
-partial interface GPUDevice {
+partial interface mixin GPUDeviceBase {
     void pushErrorScope(GPUErrorFilter filter);
     Promise<GPUError?> popErrorScope();
 };
@@ -958,8 +955,15 @@ dictionary GPUUncapturedErrorEventInit : EventInit {
     required GPUError error;
 };
 
-partial interface GPUDevice {
-    [Exposed=Window]
+// This type is returned by requestDevice. It cannot be transferred.
+// If cloned, a GPUDeviceRef is produced on the receiving end.
+GPUDevice includes GPUDeviceBase;
+interface GPUDevice : EventTarget {
     attribute EventHandler onuncapturederror;
+};
+
+// This type is returned when a GPUDevice is cloned via postMessage.
+GPUDeviceRef includes GPUDeviceBase;
+interface GPUDeviceRef {
 };
 </script>


### PR DESCRIPTION
This makes two types of GPUDeviceBase: GPUDevice and GPUDeviceRef.
Only GPUDevice is an EventHandler. GPUDeviceRef is a reference to a
GPUDeviceBase from another worker, and does not receive events.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/316.html" title="Last updated on Jun 27, 2019, 8:13 PM UTC (1226a3a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/316/37e0cfb...kainino0x:1226a3a.html" title="Last updated on Jun 27, 2019, 8:13 PM UTC (1226a3a)">Diff</a>