### PR TITLE
Consistently use FooFlags for typedef, FooFlag.Bar for bits.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -66,9 +66,9 @@ Buffers {#buffers}
 ==================
 
 <script type=idl>
-typedef u32 GPUBufferUsageFlags;
+typedef u32 GPUBufferUsageFlagsT;
 
-interface GPUBufferUsage {
+interface GPUBufferUsageFlags {
     const u32 NONE      = 0x0000;
     const u32 MAP_READ  = 0x0001;
     const u32 MAP_WRITE = 0x0002;
@@ -83,7 +83,7 @@ interface GPUBufferUsage {
 
 dictionary GPUBufferDescriptor : GPUObjectDescriptorBase {
     required u64 size;
-    required GPUBufferUsageFlags usage;
+    required GPUBufferUsageFlagsT usage;
 };
 
 interface GPUBuffer : GPUObjectBase {
@@ -180,9 +180,9 @@ enum GPUTextureFormat {
     "depth24plus-stencil8"
 };
 
-typedef u32 GPUTextureUsageFlags;
+typedef u32 GPUTextureUsageFlagsT;
 
-interface GPUTextureUsage {
+interface GPUTextureUsageFlags {
     const u32 NONE              = 0x00;
     const u32 COPY_SRC          = 0x01;
     const u32 COPY_DST          = 0x02;
@@ -198,7 +198,7 @@ dictionary GPUTextureDescriptor : GPUObjectDescriptorBase {
     u32 sampleCount = 1;
     GPUTextureDimension dimension = "2d";
     required GPUTextureFormat format;
-    required GPUTextureUsageFlags usage;
+    required GPUTextureUsageFlagsT usage;
 };
 
 // Texture view
@@ -284,9 +284,9 @@ Binding and Layout {#binding}
 =============================
 
 <script type=idl>
-typedef u32 GPUShaderStageFlags;
+typedef u32 GPUShaderStageFlagsT;
 
-interface GPUShaderStageBit {
+interface GPUShaderStageFlags {
     const u32 NONE     = 0x0;
     const u32 VERTEX   = 0x1;
     const u32 FRAGMENT = 0x2;
@@ -305,7 +305,7 @@ enum GPUBindingType {
 
 dictionary GPUBindGroupLayoutBinding {
     required u32 binding;
-    required GPUShaderStageFlags visibility;
+    required GPUShaderStageFlagsT visibility;
     required GPUBindingType type;
     // For texture bindings only, we need to know the dimensions and multi-sampling
     // properties at the layout creation time. This allows Metal-based implementations
@@ -423,8 +423,8 @@ enum GPUBlendOperation {
     "max"
 };
 
-typedef u32 GPUColorWriteFlags;
-interface GPUColorWriteBits {
+typedef u32 GPUColorWriteFlagsT;
+interface GPUColorWriteFlags {
     const u32 NONE  = 0x0;
     const u32 RED   = 0x1;
     const u32 GREEN = 0x2;
@@ -444,7 +444,7 @@ dictionary GPUColorStateDescriptor {
 
     required GPUBlendDescriptor alphaBlend;
     required GPUBlendDescriptor colorBlend;
-    GPUColorWriteFlags writeMask = 0xF;  // GPUColorWriteBits.ALL
+    GPUColorWriteFlagsT writeMask = 0xF;  // GPUColorWriteFlags.ALL
 };
 
 enum GPUStencilOperation {
@@ -649,7 +649,7 @@ interface GPURenderPassEncoder : GPUProgrammablePassEncoder {
 
     void draw(u32 vertexCount, u32 instanceCount, u32 firstVertex, u32 firstInstance);
     void drawIndexed(u32 indexCount, u32 instanceCount, u32 firstIndex, i32 baseVertex, u32 firstInstance);
-    
+
     // Base instance must be set to zero inside the indirect buffer
     void drawIndirect(GPUBuffer indirectBuffer, u64 indirectOffset);
     void drawIndexedIndirect(GPUBuffer indirectBuffer, u64 indirectOffset);
@@ -816,7 +816,7 @@ interface GPUCanvasContext {
 dictionary GPUSwapChainDescriptor : GPUObjectDescriptorBase {
     required GPUDevice device;
     required GPUTextureFormat format;
-    GPUTextureUsageFlags usage = 0x10;  // GPUTextureUsage.OUTPUT_ATTACHMENT
+    GPUTextureUsageFlagsT usage = 0x10;  // GPUTextureUsageFlags.OUTPUT_ATTACHMENT
 };
 
 interface GPUSwapChain : GPUObjectBase {


### PR DESCRIPTION
Alternative to #292.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jdashg/gpuweb/pull/318.html" title="Last updated on Jul 2, 2019, 7:54 PM UTC (cb44226)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/318/627d096...jdashg:cb44226.html" title="Last updated on Jul 2, 2019, 7:54 PM UTC (cb44226)">Diff</a>