### PR TITLE
For e.g. GPUOrigin2D, accept either dict or sequence.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -23,29 +23,33 @@ typedef long i32;
 typedef unsigned long u32;
 typedef unsigned long long u64;
 
-dictionary GPUColor {
+dictionary GPUColorDict {
     required float r;
     required float g;
     required float b;
     required float a;
 };
+typedef (sequence<float> or GPUColorDict) GPUColor;
 
-dictionary GPUOrigin2D {
+dictionary GPUOrigin2DDict {
     u32 x = 0;
     u32 y = 0;
 };
+typedef (sequence<u32> or GPUOrigin2DDict) GPUOrigin2D;
 
-dictionary GPUOrigin3D {
+dictionary GPUOrigin3DDict {
     u32 x = 0;
     u32 y = 0;
     u32 z = 0;
 };
+typedef (sequence<u32> or GPUOrigin3DDict) GPUOrigin3D;
 
-dictionary GPUExtent3D {
+dictionary GPUExtent3DDict {
     required u32 width;
     required u32 height;
     required u32 depth;
 };
+typedef (sequence<u32> or GPUExtent3DDict) GPUExtent3D;
 
 typedef sequence<any> GPUMappedBuffer;  // [GPUBuffer, ArrayBuffer]
 


### PR DESCRIPTION
Alternative to #299.