### PR TITLE
Make descriptor optional for createCommandEncoder

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -835,7 +835,7 @@ interface GPUDevice : GPUObjectBase {
     GPUComputePipeline createComputePipeline(GPUComputePipelineDescriptor descriptor);
     GPURenderPipeline createRenderPipeline(GPURenderPipelineDescriptor descriptor);
 
-    GPUCommandEncoder createCommandEncoder(GPUCommandEncoderDescriptor? descriptor);
+    GPUCommandEncoder createCommandEncoder(optional GPUCommandEncoderDescriptor descriptor);
 
     GPUQueue getQueue();
 };

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -835,7 +835,7 @@ interface GPUDevice : GPUObjectBase {
     GPUComputePipeline createComputePipeline(GPUComputePipelineDescriptor descriptor);
     GPURenderPipeline createRenderPipeline(GPURenderPipelineDescriptor descriptor);
 
-    GPUCommandEncoder createCommandEncoder(GPUCommandEncoderDescriptor descriptor);
+    GPUCommandEncoder createCommandEncoder(GPUCommandEncoderDescriptor? descriptor);
 
     GPUQueue getQueue();
 };


### PR DESCRIPTION
How about making `GPUCommandEncoderDescriptor ` optional in `createCommandEncoder` as the potential reusability flag would be `false` by default?

FYI @JusSn 