### PR TITLE
Make descriptor optional for adapter.requestDevice

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -853,7 +853,7 @@ interface GPUAdapter : GPUObjectBase {
     //readonly attribute GPULimits limits; Don't expose higher limits for now.
 
     // May reject with DOMException  // TODO: DOMException("OperationError")?
-    Promise<GPUDevice> requestDevice(GPUDeviceDescriptor descriptor);
+    Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor);
 };
 
 enum GPUPowerPreference {


### PR DESCRIPTION
Following https://github.com/gpuweb/gpuweb/pull/321#issuecomment-500875225, we should make sure all trailing dictionaries with default values are optional as bikeshed complains otherwise.

```js
    const adapter = await navigator.gpu.requestAdapter();
    const device = await adapter.requestDevice(/* optional */);
```