### PR TITLE
Make descriptor optional for commandBuffer.finish

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -746,7 +746,7 @@ interface GPUCommandEncoder : GPUObjectBase {
     void popDebugGroup();
     void insertDebugMarker(DOMString markerLabel);
 
-    GPUCommandBuffer finish(GPUCommandBufferDescriptor? descriptor);
+    GPUCommandBuffer finish(optional GPUCommandBufferDescriptor? descriptor);
 };
 
 dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -746,7 +746,7 @@ interface GPUCommandEncoder : GPUObjectBase {
     void popDebugGroup();
     void insertDebugMarker(DOMString markerLabel);
 
-    GPUCommandBuffer finish(optional GPUCommandBufferDescriptor? descriptor);
+    GPUCommandBuffer finish(optional GPUCommandBufferDescriptor descriptor);
 };
 
 dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {


### PR DESCRIPTION
Following https://github.com/gpuweb/gpuweb/pull/321#issuecomment-500875225, we should make sure all trailing dictionaries with default values are optional as bikeshed complains otherwise.

```js
    const adapter = await navigator.gpu.requestAdapter();
    const device = await adapter.requestDevice();
    const commandEncoder = device.createCommandEncoder();
    ...
    const commandBuffer = commandEncoder.finish(/* optional */);
    device.getQueue().submit([commandBuffer]);
```