### PR TITLE
Make descriptor optional for queue.createFence

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -775,7 +775,7 @@ Queues {#queues}
 interface GPUQueue : GPUObjectBase {
     void submit(sequence<GPUCommandBuffer> buffers);
 
-    GPUFence createFence(GPUFenceDescriptor descriptor);
+    GPUFence createFence(optional GPUFenceDescriptor descriptor);
     void signal(GPUFence fence, u64 signalValue);
 };
 </script>


### PR DESCRIPTION
Following https://github.com/gpuweb/gpuweb/pull/321#issuecomment-500875225, we should make sure all trailing dictionaries with default values are optional as bikeshed complains otherwise.

```js
    const adapter = await navigator.gpu.requestAdapter();
    const device = await adapter.requestDevice();
    const queue = device.getQueue();
    const fence = queue.createFence(/* optional */);
```