### PR TITLE
Make descriptor optional for device.createSampler

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -825,7 +825,7 @@ interface GPUDevice : GPUObjectBase {
     GPUMappedBuffer createBufferMapped(GPUBufferDescriptor descriptor);
     Promise<GPUMappedBuffer> createBufferMappedAsync(GPUBufferDescriptor descriptor);
     GPUTexture createTexture(GPUTextureDescriptor descriptor);
-    GPUSampler createSampler(GPUSamplerDescriptor descriptor);
+    GPUSampler createSampler(optional GPUSamplerDescriptor descriptor);
 
     GPUBindGroupLayout createBindGroupLayout(GPUBindGroupLayoutDescriptor descriptor);
     GPUPipelineLayout createPipelineLayout(GPUPipelineLayoutDescriptor descriptor);


### PR DESCRIPTION
Following https://github.com/gpuweb/gpuweb/pull/321#issuecomment-500875225, we should make sure all trailing dictionaries with default values are optional as bikeshed complains otherwise.

```js
    const adapter = await navigator.gpu.requestAdapter();
    const device = await adapter.requestDevice();
    const sampler = device.createSampler(/* optional */);
```