### PR TITLE
s/bool/boolean

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -592,7 +592,7 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
     // Number of MSAA samples
     u32 sampleCount = 1;
     u32 sampleMask = 0xFFFFFFFF;
-    bool alphaToCoverageEnabled = false;
+    boolean alphaToCoverageEnabled = false;
     // TODO other properties
 };
 


### PR DESCRIPTION
`bool` is not a valid value in WebIDL, `boolean` is. This PR fixes that.