### PR TITLE
Expose "GPUDevice : EventTarget" to worker

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -49,7 +49,7 @@ dictionary GPUExtent3D {
 
 typedef sequence<any> GPUMappedBuffer;  // [GPUBuffer, ArrayBuffer]
 
-interface GPUObjectBase {
+interface mixin GPUObjectBase {
     attribute DOMString? label;
 };
 
@@ -816,7 +816,8 @@ dictionary GPULimits {
 };
 
 // Device
-interface GPUDevice : GPUObjectBase {
+[Exposed=(Window, Worker)] 
+interface GPUDevice : EventTarget {
     readonly attribute GPUExtensions extensions;
     readonly attribute GPULimits limits;
     readonly attribute GPUAdapter adapter;
@@ -839,6 +840,8 @@ interface GPUDevice : GPUObjectBase {
 
     GPUQueue getQueue();
 };
+
+GPUDevice includes GPUObjectBase;
 
 dictionary GPUDeviceDescriptor : GPUObjectDescriptorBase {
     GPUExtensions extensions;
@@ -940,10 +943,6 @@ interface GPUUncapturedErrorEvent : Event {
 dictionary GPUUncapturedErrorEventInit : EventInit {
     required GPUError error;
 };
-
-// TODO: EventTarget is actually an interface, not a mixin, but it probably should be a mixin.
-[Exposed=Window]
-GPUDevice includes EventTarget;
 
 partial interface GPUDevice {
     [Exposed=Window]


### PR DESCRIPTION
When running bikeshed, I encounter some issues regarding GPUDevice including EventTarget. See below.

```bash
$ curl https://api.csswg.org/bikeshed/ -F file=@index.bs -F output=err
Error running preprocessor, returned code: 1.
FATAL ERROR: IDL SYNTAX ERROR LINE: 15 - skipped: "[Exposed=Window] GPUDevice includes EventTarget"
 ✘  Did not generate, due to fatal errors
```

This PR fixes this by exposing only EventTarget to worker, not `onuncapturederror`.
I'm not sure if that's OK with you folks and would love your input.