### PR TITLE
Fixed bufferSubData JS example

### DIFF
--- a/design/BufferOperations.md
+++ b/design/BufferOperations.md
@@ -188,7 +188,7 @@ function AutoRingBuffer(device, chunkSize) {
 
     function Chunk() {
         const size = chunkSize;
-        const (buf, initialMap) = this.device.createBufferMapped({
+        const [buf, initialMap] = this.device.createBufferMapped({
             size: size,
             usage: GPUBufferUsage.MAP_WRITE | GPUBufferUsage.TRANSFER_SRC,
         });

--- a/design/BufferOperations.md
+++ b/design/BufferOperations.md
@@ -152,26 +152,27 @@ stagingVertexBuffer.mapWriteAsync().then((stagingData) => {
 });
 ```
 
-### Updating data to an existing buffer (like `gl.bufferSubData`)
+### Updating data to an existing buffer (like WebGL's `bufferSubData`)
 
 ```js
 function bufferSubData(device, destBuffer, destOffset, srcArrayBuffer) {
-  const byteCount = srcArrayBuffer.byteLength;
-  const [srcBuffer, arrayBuffer] = device.createBufferMapped({
-    size: byteCount,
-    usage: GPUBufferUsage.TRANSFER_SRC
-  });
-  new Uint8Array(arrayBuffer).set(new Uint8Array(srcArrayBuffer)); // memcpy
-  srcBuffer.unmap();
+    const byteCount = srcArrayBuffer.byteLength;
+    const [srcBuffer, arrayBuffer] = device.createBufferMapped({
+        size: byteCount,
+        usage: GPUBufferUsage.TRANSFER_SRC
+    });
+    new Uint8Array(arrayBuffer).set(new Uint8Array(srcArrayBuffer)); // memcpy
+    srcBuffer.unmap();
 
-  const encoder = device.createCommandEncoder();
-  encoder.copyBufferToBuffer(srcBuffer, 0, destBuffer, destOffset, byteCount);
-  const commandBuffer = encoder.finish();
-  const queue = device.getQueue();
-  queue.submit([commandBuffer]);
+    const encoder = device.createCommandEncoder();
+    encoder.copyBufferToBuffer(srcBuffer, 0, destBuffer, destOffset, byteCount);
+    const commandBuffer = encoder.finish();
+    const queue = device.getQueue();
+    queue.submit([commandBuffer]);
 
-  srcBuffer.destroy();
+    srcBuffer.destroy();
 }
+
 ```
 
 As usual, batching per-frame uploads through fewer (or a single) buffer reduces
@@ -179,7 +180,8 @@ overhead.
 
 Applications are free to implement their own heuristics for batching or reusing
 upload buffers:
-```
+
+```js
 function AutoRingBuffer(device, chunkSize) {
     const queue = device.getQueue();
     let availChunks = [];

--- a/design/BufferOperations.md
+++ b/design/BufferOperations.md
@@ -152,25 +152,25 @@ stagingVertexBuffer.mapWriteAsync().then((stagingData) => {
 });
 ```
 
-### Updating data to an existing buffer (like webgl.bufferSubData)
+### Updating data to an existing buffer (like `gl.bufferSubData`)
 
-```
+```js
 function bufferSubData(device, destBuffer, destOffset, srcArrayBuffer) {
-    const byteCount = srcArrayBuffer.byteLength;
-    const (srcBuffer, mapping) = device.createBufferMapped({
-        size: byteCount,
-        usage: GPUBufferUsage.TRANSFER_SRC,
-    });
-    (new Uint8Array(mapping)).set(new Uint8Array(srcArrayBuffer)); // memcpy
-    srcBuffer.unmap();
+  const byteCount = srcArrayBuffer.byteLength;
+  const [srcBuffer, arrayBuffer] = device.createBufferMapped({
+    size: byteCount,
+    usage: GPUBufferUsage.TRANSFER_SRC
+  });
+  new Uint8Array(arrayBuffer).set(new Uint8Array(srcArrayBuffer)); // memcpy
+  srcBuffer.unmap();
 
-    const enc = device.createCommandEncoder({});
-    enc.copyBufferToBuffer(srcBuffer, 0, destBuffer, destOffset, byteCount);
-    const cb = enc.finish();
-    const q = device.getQueue();
-    q.submit([cb]);
+  const encoder = device.createCommandEncoder();
+  encoder.copyBufferToBuffer(srcBuffer, 0, destBuffer, destOffset, byteCount);
+  const commandBuffer = encoder.finish();
+  const queue = device.getQueue();
+  queue.submit([commandBuffer]);
 
-    srcBuffer.destroy();
+  srcBuffer.destroy();
 }
 ```
 


### PR DESCRIPTION
This PR is about fixing `const (srcBuffer, arrayBuffer) = device.createBufferMapped(...)` which was not valid. It should be `const [srcBuffer, arrayBuffer] = device.createBufferMapped(...)`.

It also uses 2 spaces indentation and fixes nits.