### PR TITLE
s/bool/boolean

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -308,7 +308,7 @@ dictionary GPUBindGroupLayoutBinding {
     // For uniform, storage and readonly storage buffer, means that the binding
     // has a dynamic offset. One offset must be passed to setBindGroup for each
     // dynamic binding in increasing order of `binding` number.
-    bool dynamic = false;
+    boolean dynamic = false;
 };
 
 dictionary GPUBindGroupLayoutDescriptor : GPUObjectDescriptorBase {


### PR DESCRIPTION
@Kangz `bool` is not valid in Web IDL. This PR fixes this. Hopefully https://github.com/gpuweb/gpuweb/pull/334 will catch this in the future. 