### PR TITLE
Make sampler filters required in createSampler

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -267,9 +267,9 @@ dictionary GPUSamplerDescriptor : GPUObjectDescriptorBase {
     GPUAddressMode addressModeU = "clamp-to-edge";
     GPUAddressMode addressModeV = "clamp-to-edge";
     GPUAddressMode addressModeW = "clamp-to-edge";
-    GPUFilterMode magFilter = "nearest";
-    GPUFilterMode minFilter = "nearest";
-    GPUFilterMode mipmapFilter = "nearest";
+    required GPUFilterMode magFilter;
+    required GPUFilterMode minFilter;
+    required GPUFilterMode mipmapFilter;
     float lodMinClamp = 0;
     float lodMaxClamp = 0xffffffff; // TODO: What should this be? Was Number.MAX_VALUE.
     GPUCompareFunction compare = "never";
@@ -833,7 +833,7 @@ interface GPUDevice : EventTarget {
     GPUMappedBuffer createBufferMapped(GPUBufferDescriptor descriptor);
     Promise<GPUMappedBuffer> createBufferMappedAsync(GPUBufferDescriptor descriptor);
     GPUTexture createTexture(GPUTextureDescriptor descriptor);
-    GPUSampler createSampler(optional GPUSamplerDescriptor descriptor);
+    GPUSampler createSampler(GPUSamplerDescriptor descriptor);
 
     GPUBindGroupLayout createBindGroupLayout(GPUBindGroupLayoutDescriptor descriptor);
     GPUPipelineLayout createPipelineLayout(GPUPipelineLayoutDescriptor descriptor);


### PR DESCRIPTION
This PR replaces "Make descriptor optional for device.createSampler" (#327) because of "Prepare master branch for automatic build and deploy" (#334) that have been pushed.

By making `magFilter`, `minFilter`, and `mipmapFilter` required, we can remove the `optional` descriptor in `createSampler`.