### PR TITLE
Update spec URL

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4,7 +4,7 @@ Shortname: webgpu
 Level: 1
 Status: w3c/ED
 Group: webgpu
-URL: https://github.com/gpuweb/gpuweb/spec/
+URL: https://gpuweb.github.io/gpuweb
 Editor: The GPU for the Web Community Group, W3C https://github.com/gpuweb/
 Abstract: WebGPU exposes an API for performing operations, such as rendering and computation, on a Graphics Processing Unit.
 </pre>


### PR DESCRIPTION
This PR updates spec URL to https://gpuweb.github.io/gpuweb instead of the invalid https://github.com/gpuweb/gpuweb/spec/