### PR TITLE
Provide texture dimension in GPUBindGroupLayoutBinding

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -309,7 +309,7 @@ dictionary GPUBindGroupLayoutBinding {
     // properties at the layout creation time. This allows Metal-based implementations
     // to back the respective bind groups with `MTLArgumentBuffer` objects that
     // are more efficient to bind at run-time.
-    GPUTextureViewDimension? textureDimension;
+    GPUTextureViewDimension textureDimension;
     bool multisample = false;
     // For uniform, storage and readonly storage buffer, means that the binding
     // has a dynamic offset. One offset must be passed to setBindGroup for each

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -305,9 +305,12 @@ dictionary GPUBindGroupLayoutBinding {
     required u32 binding;
     required GPUShaderStageFlags visibility;
     required GPUBindingType type;
-    // For texture bindings only, we need to know the dimensions at the
-    // bind group creation time and validate the created bind groups accordingly.
+    // For texture bindings only, we need to know the dimensions and multi-sampling
+    // properties at the layout creation time. This allows Metal-based implementations
+    // to back the respective bind groups with `MTLArgumentBuffer` objects that
+    // are more efficient to bind at run-time.
     GPUTextureViewDimension? textureDimension;
+    bool multisample = false;
     // For uniform, storage and readonly storage buffer, means that the binding
     // has a dynamic offset. One offset must be passed to setBindGroup for each
     // dynamic binding in increasing order of `binding` number.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -305,6 +305,9 @@ dictionary GPUBindGroupLayoutBinding {
     required u32 binding;
     required GPUShaderStageFlags visibility;
     required GPUBindingType type;
+    // For texture bindings only, we need to know the dimensions at the
+    // bind group creation time and validate the created bind groups accordingly.
+    GPUTextureViewDimension? textureDimension;
     // For uniform, storage and readonly storage buffer, means that the binding
     // has a dynamic offset. One offset must be passed to setBindGroup for each
     // dynamic binding in increasing order of `binding` number.


### PR DESCRIPTION
This is required to have the bind groups backed by Metal indirect argument buffers. We want `MTLArgumentEncoder` to be associated with `GPUBindGroupLayout`, and its construction requires [textureType](https://developer.apple.com/documentation/metal/mtlargumentdescriptor/2915741-texturetype) to be known.
cc @litherum @JusSn


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/339.html" title="Last updated on Jun 25, 2019, 3:09 PM UTC (bc9114d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/339/56a09c9...bc9114d.html" title="Last updated on Jun 25, 2019, 3:09 PM UTC (bc9114d)">Diff</a>