### PR TITLE
Use COPY instead of TRANSFER for GPUBufferUsage and GPUTextureUsage

### DIFF
--- a/design/BufferOperations.md
+++ b/design/BufferOperations.md
@@ -119,7 +119,7 @@ The mapping starts filled with zeros.
 ```js
 const readPixelsBuffer = device.createBuffer({
     size: 4,
-    usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.TRANSFER_DST,
+    usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST,
 });
 
 // Commands copying a pixel from a texture into readPixelsBuffer are submitted
@@ -140,7 +140,7 @@ const size = model.computeVertexBufferSize();
 
 const stagingVertexBuffer = device.createBuffer({
     size: size,
-    usage: GPUBufferUsage.MAP_WRITE | GPUBufferUsage.TRANSFER_SRC,
+    usage: GPUBufferUsage.MAP_WRITE | GPUBufferUsage.COPY_SRC,
 });
 
 stagingVertexBuffer.mapWriteAsync().then((stagingData) => {
@@ -159,7 +159,7 @@ function bufferSubData(device, destBuffer, destOffset, srcArrayBuffer) {
     const byteCount = srcArrayBuffer.byteLength;
     const [srcBuffer, arrayBuffer] = device.createBufferMapped({
         size: byteCount,
-        usage: GPUBufferUsage.TRANSFER_SRC
+        usage: GPUBufferUsage.COPY_SRC
     });
     new Uint8Array(arrayBuffer).set(new Uint8Array(srcArrayBuffer)); // memcpy
     srcBuffer.unmap();
@@ -190,7 +190,7 @@ function AutoRingBuffer(device, chunkSize) {
         const size = chunkSize;
         const [buf, initialMap] = this.device.createBufferMapped({
             size: size,
-            usage: GPUBufferUsage.MAP_WRITE | GPUBufferUsage.TRANSFER_SRC,
+            usage: GPUBufferUsage.MAP_WRITE | GPUBufferUsage.COPY_SRC,
         });
 
         let mapTyped;

--- a/design/UsageValidationRules.md
+++ b/design/UsageValidationRules.md
@@ -7,17 +7,17 @@ Buffers have the following usages (and commands inducing that usage):
  - `INDEX` for `buffer` in calls to `WebGPUCommandEncoder.setIndexBuffer`
  - `INDIRECT` for `indirectBuffer` in calls to `WebGPUCommandEncode.{draw|drawIndexed|dispatch}Indirect`
  - `UBO` and `STORAGE` for buffers referenced by bindgroups passed to `setBindGroup`, with the usage corresponding to the binding's type.
- - `TRANSFER_SRC` for buffers used as the copy source of various commands.
- - `TRANSFER_DST` for buffers used as the copy destination of various commands.
+ - `COPY_SRC` for buffers used as the copy source of various commands.
+ - `COPY_DST` for buffers used as the copy destination of various commands.
  - (Maybe `STORAGE_TEXEL` and `UNIFORM_TEXEL`?)
 
 Textures have the following usages:
  - `OUTPUT_ATTACHMENT` for the subresources referenced by `WebGPURenderPassDescriptor`
  - `SAMPLED` and `STORAGE` for subresources corresponding to the image views referenced by bindgroups passed to `setBindGroup`, with the usage corresponding to the binding's type.
- - `TRANSFER_SRC` for textures used as the copy source of various commands.
- - `TRANSFER_DST` for textures used as the copy destination of various commands.
+ - `COPY_SRC` for textures used as the copy source of various commands.
+ - `COPY_DST` for textures used as the copy destination of various commands.
 
-Read only usages are `VERTEX`, `INDEX`, `INDIRECT`, `UBO`, `TRANSFER_SRC` and `SAMPLED`.
+Read only usages are `VERTEX`, `INDEX`, `INDIRECT`, `UBO`, `COPY_SRC` and `SAMPLED`.
 
 ## Render passes
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -183,8 +183,8 @@ typedef u32 GPUTextureUsageFlags;
 
 interface GPUTextureUsage {
     const u32 NONE              = 0x00;
-    const u32 TRANSFER_SRC      = 0x01;
-    const u32 TRANSFER_DST      = 0x02;
+    const u32 COPY_SRC          = 0x01;
+    const u32 COPY_DST          = 0x02;
     const u32 SAMPLED           = 0x04;
     const u32 STORAGE           = 0x08;
     const u32 OUTPUT_ATTACHMENT = 0x10;

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -69,15 +69,15 @@ Buffers {#buffers}
 typedef u32 GPUBufferUsageFlags;
 
 interface GPUBufferUsage {
-    const u32 NONE         = 0x0000;
-    const u32 MAP_READ     = 0x0001;
-    const u32 MAP_WRITE    = 0x0002;
-    const u32 TRANSFER_SRC = 0x0004;
-    const u32 TRANSFER_DST = 0x0008;
-    const u32 INDEX        = 0x0010;
-    const u32 VERTEX       = 0x0020;
-    const u32 UNIFORM      = 0x0040;
-    const u32 STORAGE      = 0x0080;
+    const u32 NONE      = 0x0000;
+    const u32 MAP_READ  = 0x0001;
+    const u32 MAP_WRITE = 0x0002;
+    const u32 COPY_SRC  = 0x0004;
+    const u32 COPY_DST  = 0x0008;
+    const u32 INDEX     = 0x0010;
+    const u32 VERTEX    = 0x0020;
+    const u32 UNIFORM   = 0x0040;
+    const u32 STORAGE   = 0x0080;
 };
 
 dictionary GPUBufferDescriptor : GPUObjectDescriptorBase {


### PR DESCRIPTION
GPUBufferUsage `TRANSFER_SRC` and `TRANSFER_DST` and GPUTextureUsage `TRANSFER_SRC` and `TRANSFER_DST`  seem to be used only for `GPUCommandEncoder.copyX` operations such as `copyBufferToBuffer`, `copyBufferToTexture`, `copyTextureToBuffer`, and `copyTextureToTexture`.

How about making it renaming them to `COPY_SRC` and `COPY_DST` for  consistency?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/342.html" title="Last updated on Jun 26, 2019, 5:28 AM UTC (d406a75)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/342/37e0cfb...d406a75.html" title="Last updated on Jun 26, 2019, 5:28 AM UTC (d406a75)">Diff</a>