### PR TITLE
Set y & z optional in GPUComputePassEncoder.dispatch

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -646,7 +646,7 @@ interface GPURenderPassEncoder : GPUProgrammablePassEncoder {
 
 interface GPUComputePassEncoder : GPUProgrammablePassEncoder {
     void setPipeline(GPUComputePipeline pipeline);
-    void dispatch(u32 x, u32 y, u32 z);
+    void dispatch(u32 x, optional u32 y = 1, optional u32 z = 1);
 
     // TODO add missing commands
 };


### PR DESCRIPTION
This PR is about setting default values for `y` and `z` arguments in `GPUComputePassEncoder.dispatch` so that web developers who don't need 2D or 3D can simply omit the `y` and `z` values.

What do you think?

```js
const x = 42;
myComputePassEncoder.dispatch(x); // y and z are 1 by default
```
