### PR TITLE
Make GPUBufferBinding size optional

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -329,7 +329,8 @@ interface GPUPipelineLayout : GPUObjectBase {
 dictionary GPUBufferBinding {
     required GPUBuffer buffer;
     u64 offset = 0;
-    required u64 size;
+    // If size is undefined, use the whole size of the buffer.
+    u64 size;
 };
 
 typedef (GPUSampler or GPUTextureView or GPUBufferBinding) GPUBindingResource;


### PR DESCRIPTION
FIX #331


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/346.html" title="Last updated on Jun 25, 2019, 7:17 PM UTC (c63df3a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/346/64225b4...c63df3a.html" title="Last updated on Jun 25, 2019, 7:17 PM UTC (c63df3a)">Diff</a>