### PR TITLE
Do not require rasterizationState in GPURenderPipelineDescriptor

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -593,7 +593,7 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
     GPUPipelineStageDescriptor? fragmentStage = null;
 
     required GPUPrimitiveTopology primitiveTopology;
-    required GPURasterizationStateDescriptor rasterizationState;
+    GPURasterizationStateDescriptor rasterizationState;
     required sequence<GPUColorStateDescriptor> colorStates;
     GPUDepthStencilStateDescriptor? depthStencilState = null;
     required GPUVertexInputDescriptor vertexInput;


### PR DESCRIPTION
With the default `frontFace` value now set to "ccw" in #313, the `rasterizationState`from GPURenderPipelineDescriptor should not be required anymore.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/347.html" title="Last updated on Jun 26, 2019, 8:41 AM UTC (4ac2c73)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/347/37e0cfb...4ac2c73.html" title="Last updated on Jun 26, 2019, 8:41 AM UTC (4ac2c73)">Diff</a>