### PR TITLE
Fix Typo

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -960,6 +960,6 @@ dictionary GPUUncapturedErrorEventInit : EventInit {
 
 partial interface GPUDevice {
     [Exposed=Window]
-    attribute EventHandler onuncapturederror;
+    attribute EventHandler onUncapturedError;
 };
 </script>


### PR DESCRIPTION
Changes capitalization of `onuncapturederror` to `onUncapturedError` in order to make it more consistent with `GPUUncapturedErrorEvent`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mehmetoguzderin/gpuweb/pull/350.html" title="Last updated on Jun 29, 2019, 7:35 PM UTC (bb68ed1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/350/37e0cfb...mehmetoguzderin:bb68ed1.html" title="Last updated on Jun 29, 2019, 7:35 PM UTC (bb68ed1)">Diff</a>