### PR TITLE
Bind point renaming

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -500,11 +500,36 @@ typedef (Uint32Array or DOMString) GPUShaderCode;
 
 dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
     required GPUShaderCode code;
+    sequence<GPUOverriddenBindPoint>? overriddenBindPoints = null;
 };
 </script>
 
 Note: While the choice of shader language is undecided,
 `GPUShaderModuleDescriptor` will temporarily accept both text and binary input.
+
+#### Bind Point Renaming #### {#bind-point-renaming}
+
+<script type=idl>
+dictionary GPUShaderSemantic {
+    required DOMString type; // "u", "s", "t", "b"
+    required u32 binding;
+    u32 space = 0;
+};
+</script>
+
+<script type=idl>
+dictionary GPUBindPoint {
+    required u32 binding;
+    required u32 bindGroup;
+};
+</script>
+
+<script type=idl>
+dictionary GPUOverriddenBindPoint {
+    required GPUShaderSemantic shaderSemantic;
+    required GPUBindPoint overriddenBindPoint;
+};
+</script>
 
 
 Pipelines {#pipelines}


### PR DESCRIPTION
Due to the resolution that the WebGPU API's binding model should not be modified to match the shading language's binding model, and due to the fact that backwards compatibility with existing HLSL code is important, this patch adds an "adapter" to bridge between the two binding models. This adapter exists in the Javascript API, because we're trying to minimize the number of places that existing shaders have to be updated.

The proposal is fairly simple: provide a mapping of strings (of the form `register(u2, space1)`) to the two-level binding model used in the API. This mapping is provided in the `GPUShaderModule` so compilation can be done as early as possible and doesn't have to be deferred until pipeline creation time.

This new map is optional, so authors which already have a source file which adheres to WebGPU's binding model don't need to supply anything. If this field is not present, it behaves as if the map has 0 fields in it. For every field that is present, compilation is expected to behave as if the WHLSL semantic is replaced with the associated value. For every semantic in the source shader, if a mapping is not present for it, it behaves as if the binding comes from the digit after the type character (the `2` in `register(u2, space1)`) and the bindGroup comes from the `space` (the `1` in `register(u2, space1)`).

If honoring this mapping would cause duplicate binding points, the program is in error (we don't try again without the mapping; the mapping, when specified, is required to be applied). If two parameters in the source program (before the mapping) have duplicate semantics, the program is in error.

SPIR-V would just ignore this new field.

This renaming allows for mapping a parameter from one bind group to another. This is so that a WHLSL program with all its parameters in the same `space` can spread those parameters out across multiple bind groups.

Also considered: Instead of the keys being strings, they could be a dictionary containing 3 fields: binding, bind group, and type. However, this has less flexibility for further binding model advances in the future, doesn't map well to WebIDL, and is less obvious to a WHLSL author which variable maps to which entry in the map.

Usage:
```Javascript
const overriddenBindPoints = {"register(u2, space1)": {binding: 3, bindGroup: 4}};
const computeStage = device.createShaderModule(code, overriddenBindPoints);
const pipelineDescriptor = {computeStage, ...};
const computePipeline = device.createComputePipeline(pipelineDescriptor);
```


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/litherum/gpuweb/pull/351.html" title="Last updated on Jul 12, 2019, 9:46 PM UTC (abdaff2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/351/c6db522...litherum:abdaff2.html" title="Last updated on Jul 12, 2019, 9:46 PM UTC (abdaff2)">Diff</a>