### PR TITLE
s/float/double/ for GPUColor to support i32/u32.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -30,13 +30,15 @@ typedef unsigned long long u64;
 
 <script type=idl>
 dictionary GPUColorDict {
-    required float r;
-    required float g;
-    required float b;
-    required float a;
+    required double r;
+    required double g;
+    required double b;
+    required double a;
 };
-typedef (sequence<float> or GPUColorDict) GPUColor;
+typedef (sequence<double> or GPUColorDict) GPUColor;
 </script>
+
+Note: `double` is large enough to precisely hold `i32`/`u32`.
 
 <script type=idl>
 dictionary GPUOrigin2DDict {


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jdashg/gpuweb/pull/355.html" title="Last updated on Jul 12, 2019, 9:35 PM UTC (5a22e7f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/355/c6db522...jdashg:5a22e7f.html" title="Last updated on Jul 12, 2019, 9:35 PM UTC (5a22e7f)">Diff</a>