### PR TITLE
Immutable sampler support

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -407,6 +407,7 @@ dictionary GPUBindGroupLayoutBinding {
     required GPUBindingType type;
     GPUTextureViewDimension textureDimension;
     boolean multisample = false;
+    GPUSamplerDescriptor immutableSampler;
     boolean dynamic = false;
 };
 </script>
@@ -418,6 +419,12 @@ dictionary GPUBindGroupLayoutBinding {
     Note: This allows Metal-based implementations to back the respective bind
     groups with `MTLArgumentBuffer` objects that are more efficient to bind at
     run-time.
+
+  * {{GPUBindGroupLayoutBinding/immutableSampler}}:
+    For a binding with {{GPUBindGroupLayoutBinding/type}} of
+    {{GPUBindingType/sampler}}, if the sampler descriptor is provided here, it
+    becomes a part of the layout: an "immutable" sampler object, in a sense
+    that no bind group binding call can affect it.
 
   * {{GPUBindGroupLayoutBinding/dynamic}}:
     For uniform, storage and readonly storage buffer, means that the binding


### PR DESCRIPTION
An immutable sampler is one that is a part of the pipeline layout *definition*, not affected by any bind group binding. The benefits of specifying a sampler as immutable are:
  - on Vulkan, immutable samplers are part of the API, provided in [vkCreateDescriptorSetLayout](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateDescriptorSetLayout.html), so the mapping is trivial.
  - on D3D12, immutable samplers can be hard-coded into the root signature that corresponds to `GPUPipelineLayout`. They are represented by the [static sampler](https://docs.microsoft.com/en-us/windows/win32/api/d3d12/ns-d3d12-d3d12_static_sampler_desc) concept.
  - on Metal iOS before "MTLFeatureSet_iOS_GPUFamily3_v1" it's impossible to create a sampler with a comparison function, which is often used for shadow map sampling. If it's provided as a part of the pipeline layout, the implementation may hard-code the sampler *into* the generated MSL shader code, effectively supporting comparison. See https://github.com/KhronosGroup/MoltenVK/issues/556 for some real use-case discussion. A as consequence, we may want to document the restriction (for all platforms) that comparison operation is only available on immutable samplers.

If the `immutableSampler` field of `GPUBindGroupLayoutBinding` is not nil, and the binding type is "sampler", then this binding is not expected to be provided in `GPUBindGroupDescriptor` corresponding to the creation of a bind group with this layout.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/356.html" title="Last updated on Jul 12, 2019, 9:05 PM UTC (327f77a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/356/c6db522...kvark:327f77a.html" title="Last updated on Jul 12, 2019, 9:05 PM UTC (327f77a)">Diff</a>