### PR TITLE
Remove some texture formats that are not universal.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -241,7 +241,6 @@ should follow the convention here, with the texture name as a prefix. e.g.
 enum GPUTextureFormat {
     // 8-bit formats
     "r8unorm",
-    "r8unorm-srgb",
     "r8snorm",
     "r8uint",
     "r8sint",
@@ -253,12 +252,9 @@ enum GPUTextureFormat {
     "r16sint",
     "r16float",
     "rg8unorm",
-    "rg8unorm-srgb",
     "rg8snorm",
     "rg8uint",
     "rg8sint",
-    // Packed 16-bit formats
-    "b5g6r5unorm",
 
     // 32-bit formats
     "r32uint",


### PR DESCRIPTION
The r8unorm-srgb and rg8unorm-srgb are not guaranteed to be present in
Vulkan and in fact rg8unorm-srgb isn't available on a recent NVIDIA
Linux Vulkan driver.

The r5g6b5unorm format isn't supported on Metal on macOS.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/357.html" title="Last updated on Jul 12, 2019, 9:29 PM UTC (32db090)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/357/c6db522...Kangz:32db090.html" title="Last updated on Jul 12, 2019, 9:29 PM UTC (32db090)">Diff</a>