### PR TITLE
Rename GPUPipelineStageDescriptor to GPUProgrammableStageDescriptor

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -517,7 +517,7 @@ dictionary GPUPipelineDescriptorBase : GPUObjectDescriptorBase {
 </script>
 
 <script type=idl>
-dictionary GPUPipelineStageDescriptor {
+dictionary GPUProgrammableStageDescriptor {
     required GPUShaderModule module;
     required DOMString entryPoint;
     // TODO: other stuff like specialization constants?
@@ -535,7 +535,7 @@ interface GPUComputePipeline : GPUObjectBase {
 
 <script type=idl>
 dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
-    required GPUPipelineStageDescriptor computeStage;
+    required GPUProgrammableStageDescriptor computeStage;
 };
 </script>
 
@@ -550,8 +550,8 @@ interface GPURenderPipeline : GPUObjectBase {
 
 <script type=idl>
 dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
-    required GPUPipelineStageDescriptor vertexStage;
-    GPUPipelineStageDescriptor? fragmentStage = null;
+    required GPUProgrammableStageDescriptor vertexStage;
+    GPUProgrammableStageDescriptor? fragmentStage = null;
 
     required GPUPrimitiveTopology primitiveTopology;
     GPURasterizationStateDescriptor rasterizationState;


### PR DESCRIPTION
The important part is that these stages are programmable since they hold
a shader module. There are other pipeline stages like rasterization that
aren't programmable and use a different descriptor.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/359.html" title="Last updated on Jul 12, 2019, 9:39 PM UTC (41d3c3e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/359/c6db522...Kangz:41d3c3e.html" title="Last updated on Jul 12, 2019, 9:39 PM UTC (41d3c3e)">Diff</a>