### PR TITLE
Small rename of CopyB2B args from src/dst to source/destination.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -735,10 +735,10 @@ interface GPUCommandEncoder : GPUObjectBase {
 
     // Commands allowed outside of "passes"
     void copyBufferToBuffer(
-        GPUBuffer src,
-        u64 srcOffset,
-        GPUBuffer dst,
-        u64 dstOffset,
+        GPUBuffer source,
+        u64 sourceOffset,
+        GPUBuffer destination,
+        u64 destinationOffset,
         u64 size);
 
     void copyBufferToTexture(


### PR DESCRIPTION
This is more in line with the naming for the other types of copies.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/360.html" title="Last updated on Jul 7, 2019, 6:12 PM UTC (28b1627)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/360/627d096...Kangz:28b1627.html" title="Last updated on Jul 7, 2019, 6:12 PM UTC (28b1627)">Diff</a>