### PR TITLE
Fail build on all bikeshed errors

### DIFF
--- a/spec/Makefile
+++ b/spec/Makefile
@@ -1,7 +1,7 @@
 all: index.html webgpu.idl
 
 index.html: index.bs
-	bikeshed spec index.bs
+	bikeshed --die-on=everything spec index.bs
 
 webgpu.idl: index.bs extract-idl.py
 	python extract-idl.py index.bs > webgpu.idl


### PR DESCRIPTION
To make sure WebGPU spec is always compliant, we should make Travis CI builds fail on any errors. This should catch errors like `bool` recently pushed in https://github.com/gpuweb/gpuweb/pull/339