### PR TITLE
GPUBGLBinding: rename multisample to multisampled.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -406,7 +406,7 @@ dictionary GPUBindGroupLayoutBinding {
     required GPUShaderStageFlags visibility;
     required GPUBindingType type;
     GPUTextureViewDimension textureDimension;
-    boolean multisample = false;
+    boolean multisampled = false;
     boolean dynamic = false;
 };
 </script>


### PR DESCRIPTION
This is because reading binding.multisampled = false seems like better
grammar than binding.multisample.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/367.html" title="Last updated on Jul 15, 2019, 12:29 PM UTC (c24da29)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/367/3d9b473...Kangz:c24da29.html" title="Last updated on Jul 15, 2019, 12:29 PM UTC (c24da29)">Diff</a>