### PR TITLE
Remove TODO from GPUComputePassEncoder

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1036,8 +1036,6 @@ interface GPUComputePassEncoder : GPUProgrammablePassEncoder {
     void dispatchIndirect(GPUBuffer indirectBuffer, u64 indirectOffset);
 
     void endPass();
-
-    // TODO: add missing commands
 };
 </script>
 


### PR DESCRIPTION
Now that we've added dispatchIndirect, I'm not aware of anything else
that's concretely missing here.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/369.html" title="Last updated on Jul 15, 2019, 4:43 PM UTC (7e6e3ed)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/369/8252e82...kainino0x:7e6e3ed.html" title="Last updated on Jul 15, 2019, 4:43 PM UTC (7e6e3ed)">Diff</a>