### PR TITLE
Do not require alphaBlend and colorBlend in GPUColorStateDescriptor

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -720,8 +720,8 @@ enum GPUCullMode {
 dictionary GPUColorStateDescriptor {
     required GPUTextureFormat format;
 
-    required GPUBlendDescriptor alphaBlend;
-    required GPUBlendDescriptor colorBlend;
+    GPUBlendDescriptor alphaBlend;
+    GPUBlendDescriptor colorBlend;
     GPUColorWriteFlags writeMask = 0xF;  // GPUColorWrite.ALL
 };
 </script>


### PR DESCRIPTION
Since `GPUBlendDescriptor` has default values for all its keys, I think we should make `alphaBlend` and `colorBlend` not required in `GPUColorStateDescriptor`.

What do you think?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/370.html" title="Last updated on Jul 15, 2019, 3:31 PM UTC (34de6b7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/370/8252e82...34de6b7.html" title="Last updated on Jul 15, 2019, 3:31 PM UTC (34de6b7)">Diff</a>