### PR TITLE
Make GPUBuffer a valid GPUBindingResource

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -570,7 +570,7 @@ dictionary GPUBindGroupDescriptor : GPUObjectDescriptorBase {
 </script>
 
 <script type=idl>
-typedef (GPUSampler or GPUTextureView or GPUBufferBinding) GPUBindingResource;
+typedef (GPUSampler or GPUTextureView or GPUBufferBinding or GPUBuffer) GPUBindingResource;
 
 dictionary GPUBindGroupBinding {
     required u32 binding;


### PR DESCRIPTION
Let's make code easier to digest by simply passing a GPU Buffer as a resource in a bind group if `offset` and `size` from `GPUBufferBinding` do not matter. In other words, let's make `GPUBuffer` a valid `GPUBindingResource`.

**PROPOSED**

```js
const bindGroup = someGpuDevice.createBindGroup({
  layout: someBindGroupLayout,
  bindings: [
    {
      binding: 0,
      resource: someGpuBuffer
    }
  ]
})
```

**CURRENT**

```js
const bindGroup = someGpuDevice.createBindGroup({
  layout: someBindGroupLayout,
  bindings: [
    {
      binding: 0,
      resource: {
        buffer: someGpuBuffer
      }
    }
  ]
})
```


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/371.html" title="Last updated on Jul 15, 2019, 2:56 PM UTC (952583c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/371/8252e82...952583c.html" title="Last updated on Jul 15, 2019, 2:56 PM UTC (952583c)">Diff</a>