### PR TITLE
Make GPURenderPipelineDescriptor.fragmentStage required

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -655,7 +655,7 @@ interface GPURenderPipeline : GPUObjectBase {
 <script type=idl>
 dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
     required GPUProgrammableStageDescriptor vertexStage;
-    GPUProgrammableStageDescriptor? fragmentStage = null;
+    required GPUProgrammableStageDescriptor fragmentStage;
 
     required GPUPrimitiveTopology primitiveTopology;
     GPURasterizationStateDescriptor rasterizationState;


### PR DESCRIPTION
Not all target Vulkan devices support side-effects from the vertex
shader. This means that vertex-only in core WebGPU can't have any
observable results.

The group decided to have vertex-only pipeline because all target APIs
supported them but if they can't do anything, they probably shouldn't be
part of core WebGPU (and be in extension instead).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/372.html" title="Last updated on Jul 18, 2019, 1:44 PM UTC (90d3b4d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/372/e0516e6...Kangz:90d3b4d.html" title="Last updated on Jul 18, 2019, 1:44 PM UTC (90d3b4d)">Diff</a>