### PR TITLE
Add a default for GPURenderPassColorAttachmentDescriptor.storeOp

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1118,7 +1118,7 @@ dictionary GPURenderPassColorAttachmentDescriptor {
     GPUTextureView? resolveTarget = null;
 
     required (GPULoadOp or GPUColor) loadValue;
-    required GPUStoreOp storeOp;
+    GPUStoreOp storeOp = "store";
 };
 </script>
 


### PR DESCRIPTION
Originally authored by @litherum. Supersedes #268.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/376.html" title="Last updated on Jul 24, 2019, 2:55 AM UTC (eec68d4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/376/f49bb87...kainino0x:eec68d4.html" title="Last updated on Jul 24, 2019, 2:55 AM UTC (eec68d4)">Diff</a>