### PR TITLE
Do not require vertexInput in GPURenderPipelineDescriptor

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -666,7 +666,7 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
     GPURasterizationStateDescriptor rasterizationState;
     required sequence<GPUColorStateDescriptor> colorStates;
     GPUDepthStencilStateDescriptor? depthStencilState = null;
-    required GPUVertexInputDescriptor vertexInput;
+    GPUVertexInputDescriptor vertexInput;
 
     u32 sampleCount = 1;
     u32 sampleMask = 0xFFFFFFFF;


### PR DESCRIPTION
In the case of a vertex shader with no input,`vertexInput` doesn't make sense. It would be great if we wouldn't require it in GPURenderPipelineDescriptor.

I believe these "do not require X" PRs will improve the learning phase for developers interested in WebGPU:
- Step 1: Draw a triangle (introducing `vertextStage`)
- Step 2: Draw a colored triangle (introducing `fragmentStage`)
- Step 3: Draw a triangle without hardcoding vertices values (introducing `vertextInput`)