### PR TITLE
Remove `? =null` from nullable dictionaries

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -660,7 +660,7 @@ interface GPURenderPipeline : GPUObjectBase {
 <script type=idl>
 dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
     required GPUProgrammableStageDescriptor vertexStage;
-    GPUProgrammableStageDescriptor? fragmentStage = null;
+    GPUProgrammableStageDescriptor fragmentStage = null;
 
     required GPUPrimitiveTopology primitiveTopology;
     GPURasterizationStateDescriptor rasterizationState;

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -660,12 +660,12 @@ interface GPURenderPipeline : GPUObjectBase {
 <script type=idl>
 dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
     required GPUProgrammableStageDescriptor vertexStage;
-    GPUProgrammableStageDescriptor fragmentStage = null;
+    GPUProgrammableStageDescriptor fragmentStage;
 
     required GPUPrimitiveTopology primitiveTopology;
     GPURasterizationStateDescriptor rasterizationState;
     required sequence<GPUColorStateDescriptor> colorStates;
-    GPUDepthStencilStateDescriptor depthStencilState = null;
+    GPUDepthStencilStateDescriptor depthStencilState;
     required GPUVertexInputDescriptor vertexInput;
 
     u32 sampleCount = 1;
@@ -1106,7 +1106,7 @@ When a {{GPURenderPassEncoder}} is created, it has the following default state:
 <script type=idl>
 dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
     required sequence<GPURenderPassColorAttachmentDescriptor> colorAttachments;
-    GPURenderPassDepthStencilAttachmentDescriptor depthStencilAttachment = null;
+    GPURenderPassDepthStencilAttachmentDescriptor depthStencilAttachment;
 };
 </script>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -665,7 +665,7 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
     required GPUPrimitiveTopology primitiveTopology;
     GPURasterizationStateDescriptor rasterizationState;
     required sequence<GPUColorStateDescriptor> colorStates;
-    GPUDepthStencilStateDescriptor? depthStencilState = null;
+    GPUDepthStencilStateDescriptor depthStencilState = null;
     required GPUVertexInputDescriptor vertexInput;
 
     u32 sampleCount = 1;
@@ -1106,7 +1106,7 @@ When a {{GPURenderPassEncoder}} is created, it has the following default state:
 <script type=idl>
 dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
     required sequence<GPURenderPassColorAttachmentDescriptor> colorAttachments;
-    GPURenderPassDepthStencilAttachmentDescriptor? depthStencilAttachment = null;
+    GPURenderPassDepthStencilAttachmentDescriptor depthStencilAttachment = null;
 };
 </script>
 


### PR DESCRIPTION
As per the WebIDL spec, "if the type of the dictionary member, after resolving typedefs, is a nullable type, its inner type must not be a dictionary type".
Source: https://heycam.github.io/webidl/#idl-dictionaries

Therefore, this PR removes the `?` from nullable dictionaries in WebGPU.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/381.html" title="Last updated on Aug 2, 2019, 6:54 AM UTC (43d2c41)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/381/f49bb87...43d2c41.html" title="Last updated on Aug 2, 2019, 6:54 AM UTC (43d2c41)">Diff</a>