### PR TITLE
Remove the 16bit component snorm formats.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -359,8 +359,6 @@ enum GPUTextureFormat {
     "r8sint",
 
     // 16-bit formats
-    "r16unorm",
-    "r16snorm",
     "r16uint",
     "r16sint",
     "r16float",
@@ -373,8 +371,6 @@ enum GPUTextureFormat {
     "r32uint",
     "r32sint",
     "r32float",
-    "rg16unorm",
-    "rg16snorm",
     "rg16uint",
     "rg16sint",
     "rg16float",
@@ -393,8 +389,6 @@ enum GPUTextureFormat {
     "rg32uint",
     "rg32sint",
     "rg32float",
-    "rgba16unorm",
-    "rgba16snorm",
     "rgba16uint",
     "rgba16sint",
     "rgba16float",


### PR DESCRIPTION
They aren't guaranteed supported in Vulkan and in practice aren't
available even on recent Qualcomm HW.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/383.html" title="Last updated on Aug 19, 2019, 2:59 PM UTC (c94f73a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/383/5c886ab...Kangz:c94f73a.html" title="Last updated on Aug 19, 2019, 2:59 PM UTC (c94f73a)">Diff</a>