### PR TITLE
Add a component type for GPUBGLBinding compatiblity

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -414,6 +414,13 @@ enum GPUTextureFormat {
     found in native APIs, which has a precision of
     1 ULP = 1 / (2<sup>24</sup> &minus; 1).
 
+<script type=idl>
+enum GPUTextureComponentType {
+    "float",
+    "sint",
+    "uint"
+};
+</script>
 
 Samplers {#samplers}
 ====================
@@ -509,6 +516,7 @@ dictionary GPUBindGroupLayoutBinding {
     required GPUShaderStageFlags visibility;
     required GPUBindingType type;
     GPUTextureViewDimension textureDimension;
+    GPUTextureComponentType textureComponentType = "float";
     boolean multisampled = false;
     boolean dynamic = false;
 };


### PR DESCRIPTION
In shaders there are several texture types for each dimensionality
depending on their component type. It can be either float, uint or
sint, with maybe in the future depth/stencil if WebGPU allows reading
such textures.

The component type of a GPUTextureView's format must match the
component type of its binding in the shader module. This is for
several reasons:

 - Vulkan requires the following: "The Sampled Type of an
OpTypeImage declaration must match the numeric format of the
corresponding resource in type and signedness, as shown in the
SPIR-V Sampled Type column of the Interpretation of Numeric Format
table, or the values obtained by reading or sampling from this image
are undefined."

 - It is also required in OpenGL for the texture units to be complete,
a uint or sint texture unit used with a non-nearest sampler is
incomplete and returns black texels.

Similar constraints must exist in other APIs.

To encode this compatibility constraint, a new member is added to
GPUBindGroupLayoutBinding that is a new enum GPUTextureComponentType
that give the component type of the texture.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/384.html" title="Last updated on Aug 20, 2019, 7:15 AM UTC (6a7b7f6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/384/ce23c5b...Kangz:6a7b7f6.html" title="Last updated on Aug 20, 2019, 7:15 AM UTC (6a7b7f6)">Diff</a>