### PR TITLE
Add textureCompressionBC to GPUExtensions

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -182,6 +182,7 @@ dictionary GPUDeviceDescriptor : GPUObjectDescriptorBase {
 <script type=idl>
 dictionary GPUExtensions {
     boolean anisotropicFiltering = false;
+    boolean textureCompressionBC = false;
 };
 </script>
 


### PR DESCRIPTION
I believe BC compressed texture formats are a good candidate for GPUExtensions. The `textureCompressionBC` boolean specifies whether all of the BC compressed texture formats are supported or not.

WDYT?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/385.html" title="Last updated on Aug 2, 2019, 1:19 PM UTC (e6b492f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/385/5bb2d16...e6b492f.html" title="Last updated on Aug 2, 2019, 1:19 PM UTC (e6b492f)">Diff</a>