### PR TITLE
Add 'all' to GPUErrorFilter

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1266,7 +1266,8 @@ partial interface GPUDevice {
 enum GPUErrorFilter {
     "none",
     "out-of-memory",
-    "validation"
+    "validation",
+    "all"
 };
 </script>
 


### PR DESCRIPTION
It's pretty common for a programmer to want to capture all errors. Indeed, this is the behavior of glGetError().

Without this addition, an author wanting to do this would have to wrap their code in multiple error scopes,
one for each type of filter. This means that the WebGPU API can never add another type of error scope, because
existing code has to exhaustively list each one, and we can't expect every site to be updated when we add a new
type of error.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/litherum/gpuweb/pull/387.html" title="Last updated on Aug 6, 2019, 8:33 PM UTC (efa0229)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/387/5bb2d16...litherum:efa0229.html" title="Last updated on Aug 6, 2019, 8:33 PM UTC (efa0229)">Diff</a>