### PR TITLE
Add defaults to GPUTextureViewDescriptor, remove createDefaultView

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -251,8 +251,7 @@ Textures {#textures}
 
 <script type=idl>
 interface GPUTexture : GPUObjectBase {
-    GPUTextureView createView(GPUTextureViewDescriptor descriptor);
-    GPUTextureView createDefaultView();
+    GPUTextureView createView(optional GPUTextureViewDescriptor descriptor);
 
     void destroy();
 };
@@ -303,15 +302,21 @@ interface GPUTextureView : GPUObjectBase {
 
 <script type=idl>
 dictionary GPUTextureViewDescriptor : GPUObjectDescriptorBase {
-    required GPUTextureFormat format;
-    required GPUTextureViewDimension dimension;
-    required GPUTextureAspect aspect;
+    GPUTextureFormat format;
+    GPUTextureViewDimension dimension;
+    GPUTextureAspect aspect = "all";
     u32 baseMipLevel = 0;
     u32 mipLevelCount = 1;
     u32 baseArrayLayer = 0;
     u32 arrayLayerCount = 1;
 };
 </script>
+
+  * {{GPUTextureViewDescriptor/format}}:
+    If unspecified, defaults to the format of the texture.
+
+  * {{GPUTextureViewDescriptor/dimension}}:
+    If unspecified, defaults to the dimension of the texture.
 
 <script type=idl>
 enum GPUTextureViewDimension {


### PR DESCRIPTION
These defaults seem reasonable and unsurprising to me.

I feel like we must have discussed these already before, but it's really hard to find anything about it in our GitHub issues.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/389.html" title="Last updated on Aug 6, 2019, 8:56 PM UTC (4bf553b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/389/5bb2d16...kainino0x:4bf553b.html" title="Last updated on Aug 6, 2019, 8:56 PM UTC (4bf553b)">Diff</a>