### PR TITLE
Make GPUShaderModule serializable

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -598,6 +598,7 @@ Shader Modules {#shader-modules}
 ## GPUShaderModule ## {#shader-module}
 
 <script type=idl>
+[Serializable]
 interface GPUShaderModule : GPUObjectBase {
 };
 </script>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -603,6 +603,12 @@ interface GPUShaderModule : GPUObjectBase {
 };
 </script>
 
+{{GPUShaderModule}} is {{Serializable}}. It is a reference to an internal
+shader module object, and {{Serializable}} means that the reference can be
+*copied* between realms (threads/workers), allowing multiple realms to access
+it concurrently. Since {{GPUShaderModule}} immutable, there are no race
+conditions.
+
 ### Shader Module Creation ### {#shader-module-creation}
 
 <script type=idl>


### PR DESCRIPTION
Since GPUShaderModule is immutable, this makes it serializable so it can be initialized in the background and sent anywhere.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/399.html" title="Last updated on Aug 15, 2019, 6:40 PM UTC (1b5a9c2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/399/c4fc14d...kainino0x:1b5a9c2.html" title="Last updated on Aug 15, 2019, 6:40 PM UTC (1b5a9c2)">Diff</a>