### PR TITLE
Make layout objects serializable

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -482,6 +482,7 @@ Resource Binding {#binding}
 ## GPUPipelineLayout ## {#pipeline-layout}
 
 <script type=idl>
+[Serializable]
 interface GPUPipelineLayout : GPUObjectBase {
 };
 </script>
@@ -497,6 +498,7 @@ dictionary GPUPipelineLayoutDescriptor : GPUObjectDescriptorBase {
 ## GPUBindGroupLayout ## {#bind-group-layout}
 
 <script type=idl>
+[Serializable]
 interface GPUBindGroupLayout : GPUObjectBase {
 };
 </script>


### PR DESCRIPTION
Since these objects are immutable, this makes them serializable so they can be initialized in the background and sent anywhere.

This isn't actually necessary for background initialization of modules/pipelines, but should also be easy to add.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/400.html" title="Last updated on Aug 8, 2019, 7:13 PM UTC (55f91cc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/400/c4fc14d...kainino0x:55f91cc.html" title="Last updated on Aug 8, 2019, 7:13 PM UTC (55f91cc)">Diff</a>