### PR TITLE
Make pipeline objects serializable

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -636,6 +636,7 @@ dictionary GPUProgrammableStageDescriptor {
 ## GPUComputePipeline ## {#compute-pipeline}
 
 <script type=idl>
+[Serializable]
 interface GPUComputePipeline : GPUObjectBase {
 };
 </script>
@@ -651,6 +652,7 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
 ## GPURenderPipeline ## {#render-pipeline}
 
 <script type=idl>
+[Serializable]
 interface GPURenderPipeline : GPUObjectBase {
 };
 </script>


### PR DESCRIPTION
Since these objects are immutable, this makes them serializable so they can be initialized in the background and sent anywhere.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/401.html" title="Last updated on Aug 8, 2019, 7:13 PM UTC (832ec89)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/401/c4fc14d...kainino0x:832ec89.html" title="Last updated on Aug 8, 2019, 7:13 PM UTC (832ec89)">Diff</a>