### PR TITLE
Make GPUBuffer/Texture serializable

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -198,6 +198,7 @@ Buffers {#buffers}
 ## GPUBuffer ## {#buffer}
 
 <script type=idl>
+[Serializable]
 interface GPUBuffer : GPUObjectBase {
     Promise<ArrayBuffer> mapReadAsync();
     Promise<ArrayBuffer> mapWriteAsync();
@@ -250,6 +251,7 @@ Textures {#textures}
 ## GPUTexture ## {#texture}
 
 <script type=idl>
+[Serializable]
 interface GPUTexture : GPUObjectBase {
     GPUTextureView createView(GPUTextureViewDescriptor descriptor);
     GPUTextureView createDefaultView();

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -208,6 +208,12 @@ interface GPUBuffer : GPUObjectBase {
 };
 </script>
 
+{{GPUBuffer}} is {{Serializable}}. It is a reference to an internal buffer
+object, and {{Serializable}} means that the reference can be *copied* between
+realms (threads/workers), allowing multiple realms to access it concurrently.
+Since {{GPUBuffer}} has internal state (mapped, destroyed), that state is
+internally-synchronized - these state changes occur atomically across realms.
+
 ### Creation ### {#buffer-creation}
 
 <script type=idl>


### PR DESCRIPTION
Per https://github.com/gpuweb/gpuweb/issues/354#issuecomment-511616037, these are made serializable rather than transferable to avoid confusing tracking with other objects which reference buffers and textures.

State has to be internally synchronized between threads, but the state changes are only observable through WebGPU function calls (like submit/map/unmap/destroy).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/402.html" title="Last updated on Nov 4, 2019, 11:08 PM UTC (ea4c5d7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/402/2f9a39e...kainino0x:ea4c5d7.html" title="Last updated on Nov 4, 2019, 11:08 PM UTC (ea4c5d7)">Diff</a>