### PR TITLE
Set mipLevelCount and arrayLayerCount to 0 in TextureViewDescriptor by default

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -307,11 +307,17 @@ dictionary GPUTextureViewDescriptor : GPUObjectDescriptorBase {
     required GPUTextureViewDimension dimension;
     required GPUTextureAspect aspect;
     u32 baseMipLevel = 0;
-    u32 mipLevelCount = 1;
+    u32 mipLevelCount = 0;
     u32 baseArrayLayer = 0;
-    u32 arrayLayerCount = 1;
+    u32 arrayLayerCount = 0;
 };
 </script>
+
+  * {{GPUTextureViewDescriptor/mipLevelCount}}:
+    If mipLevelCount == 0, baseMipLevel must also be 0 and the texture view will cover all the mipmap levels of the original texture.
+
+  * {{GPUTextureViewDescriptor/arrayLayerCount}}:
+    If arrayLayerCount == 0, baseArrayLayer must also be 0 and the texture view will cover all the array layers of the original texture.
 
 <script type=idl>
 enum GPUTextureViewDimension {

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -314,10 +314,10 @@ dictionary GPUTextureViewDescriptor : GPUObjectDescriptorBase {
 </script>
 
   * {{GPUTextureViewDescriptor/mipLevelCount}}:
-    If mipLevelCount == 0, baseMipLevel must also be 0 and the texture view will cover all the mipmap levels of the original texture.
+    If mipLevelCount == 0, the texture view will cover all the mipmap levels starting from baseMipLevel.
 
   * {{GPUTextureViewDescriptor/arrayLayerCount}}:
-    If arrayLayerCount == 0, baseArrayLayer must also be 0 and the texture view will cover all the array layers of the original texture.
+    If arrayLayerCount == 0, the texture view will cover all the array layers starting from baseArrayLayer.
 
 <script type=idl>
 enum GPUTextureViewDimension {


### PR DESCRIPTION
The default value of mipLevelCount and arrayLayerCount should be 0 in
TextureViewDescriptor to specify the texture view will cover all the
mipmap levels and array layers of the original texture when base mipmap
level and base array layer is also 0.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Jiawei-Shao/gpuweb/pull/407.html" title="Last updated on Aug 22, 2019, 4:55 PM UTC (22d01ac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/407/3fb5374...Jiawei-Shao:22d01ac.html" title="Last updated on Aug 22, 2019, 4:55 PM UTC (22d01ac)">Diff</a>