### PR TITLE
Provide resolve information to RenderBundle creation

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1180,8 +1180,15 @@ interface GPURenderBundleEncoder : GPURenderEncoderBase {
 ### Encoding ### {#render-bundle-encoding}
 
 <script type=idl>
+dictionary GPURenderBundleColorAttachmentDescriptor {
+   required GPUTextureFormat format;
+   GPUTextureFormat resolveFormat;
+}
+</script>
+
+<script type=idl>
 dictionary GPURenderBundleEncoderDescriptor : GPUObjectDescriptorBase {
-    required sequence<GPUTextureFormat> colorFormats;
+    required sequence<GPURenderBundleColorAttachmentDescriptor> colorAttachments;
     GPUTextureFormat depthStencilFormat;
     u32 sampleCount = 1;
 };

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1183,7 +1183,7 @@ interface GPURenderBundleEncoder : GPURenderEncoderBase {
 dictionary GPURenderBundleColorAttachmentDescriptor {
    required GPUTextureFormat format;
    GPUTextureFormat resolveFormat;
-}
+};
 </script>
 
 <script type=idl>


### PR DESCRIPTION
Currently, `GPURenderBundleEncoderDescriptor` has the formats of the color and depth targets. In order to find the compatible Vulkan render (sub) pass, we also need to know, which targets are resolves, and what the destination formats are. Without this, we aren't able to specify the proper inheritance info for the backing Secondary Command Buffer.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/410.html" title="Last updated on Aug 15, 2019, 3:08 AM UTC (2b1af3e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/410/f0e7eba...2b1af3e.html" title="Last updated on Aug 15, 2019, 3:08 AM UTC (2b1af3e)">Diff</a>