### PR TITLE
Remove vertex input

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -227,7 +227,6 @@ interface GPUBufferUsage {
     const u32 COPY_SRC  = 0x0004;
     const u32 COPY_DST  = 0x0008;
     const u32 INDEX     = 0x0010;
-    const u32 VERTEX    = 0x0020;
     const u32 UNIFORM   = 0x0040;
     const u32 STORAGE   = 0x0080;
     const u32 INDIRECT  = 0x0100;
@@ -666,7 +665,7 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
     GPURasterizationStateDescriptor rasterizationState;
     required sequence<GPUColorStateDescriptor> colorStates;
     GPUDepthStencilStateDescriptor depthStencilState;
-    required GPUVertexInputDescriptor vertexInput;
+    GPUIndexFormat indexFormat = "uint32";
 
     u32 sampleCount = 1;
     u32 sampleMask = 0xFFFFFFFF;
@@ -827,89 +826,6 @@ enum GPUIndexFormat {
 };
 </script>
 
-#### Vertex formats #### {#vertex-formats}
-
-The name of the format specifies the data type of the component, the number of
-values, and whether the data is normalized.
-
-  * `uchar` = unsigned 8-bit value
-  * `char` = signed 8-bit value
-  * `ushort` = unsigned 16-bit value
-  * `short` = signed 16-bit value
-  * `half` = half-precision 16-bit floating point value
-  * `float` = 32-bit floating point value
-  * `uint` = unsigned 32-bit integer value
-  * `int` = signed 32-bit integer value
-
-If no number of values is given in the name, a single value is provided.
-If the format has the `-bgra` suffix, it means the values are arranged as
-blue, green, red and alpha values.
-
-<script type=idl>
-enum GPUVertexFormat {
-    "uchar2",
-    "uchar4",
-    "char2",
-    "char4",
-    "uchar2norm",
-    "uchar4norm",
-    "char2norm",
-    "char4norm",
-    "ushort2",
-    "ushort4",
-    "short2",
-    "short4",
-    "ushort2norm",
-    "ushort4norm",
-    "short2norm",
-    "short4norm",
-    "half2",
-    "half4",
-    "float",
-    "float2",
-    "float3",
-    "float4",
-    "uint",
-    "uint2",
-    "uint3",
-    "uint4",
-    "int",
-    "int2",
-    "int3",
-    "int4"
-};
-</script>
-
-<script type=idl>
-enum GPUInputStepMode {
-    "vertex",
-    "instance"
-};
-</script>
-
-<script type=idl>
-dictionary GPUVertexAttributeDescriptor {
-    u64 offset = 0;
-    required GPUVertexFormat format;
-    required u32 shaderLocation;
-};
-</script>
-
-<script type=idl>
-dictionary GPUVertexBufferDescriptor {
-    required u64 stride;
-    GPUInputStepMode stepMode = "vertex";
-    required sequence<GPUVertexAttributeDescriptor> attributeSet;
-};
-</script>
-
-<script type=idl>
-dictionary GPUVertexInputDescriptor {
-    GPUIndexFormat indexFormat = "uint32";
-    required sequence<GPUVertexBufferDescriptor?> vertexBuffers;
-};
-</script>
-
 
 Command Buffers {#command-buffers}
 ==================================
@@ -1059,10 +975,7 @@ Render Passes {#render-passes}
 <script type=idl>
 interface GPURenderEncoderBase : GPUProgrammablePassEncoder {
     void setPipeline(GPURenderPipeline pipeline);
-
     void setIndexBuffer(GPUBuffer buffer, u64 offset);
-    void setVertexBuffers(u32 startSlot,
-                          sequence<GPUBuffer> buffers, sequence<u64> offsets);
 
     void draw(u32 vertexCount, u32 instanceCount,
               u32 firstVertex, u32 firstInstance);


### PR DESCRIPTION
This is a pretty huge change, but I think we should seriously consider this option that Dzmitry brought up a while back. I'd like to at least hear what people think.

Removing vertex input doesn't mean we can never re-add it.

Applications would use vertex pulling instead. On the one hand, in many cases this significantly simplifies things by removing the complex structs describing vertex input (strides/offsets/stepMode in particular); users just bind a buffer and access it as an array of structs (doing `/ 255.0` or similar for normalization).

In other cases there is a tradeoff: Data in a struct can only be i32, u32, or f32, I think, except with extension support I'm not sure we can rely on. Anything else (i8, i16, f16, etc.) have to come in as texture storage bindings and be read with texelFetch (works for normalization too). (OTOH, it essentially deduplicates the vertex and texture format tables. 🙂) [EDIT] James points out that using texture storage also means you can't interleave attributes.

There are several motivations:
- Simplifies the API.
- Simplifies implementation on Metal and low quality robust buffer access implementations - don't have to implement shader transforms for converting vertex inputs to storage buffer bindings (into those arrays of structs, if that's even possible).
- Unifies out-of-bounds buffer access rules so more accesses happen explicitly inside shaders.

I'm pretty sure this is possible on Metal, Vulkan, D3D12, D3D11, and OpenGL ES 3.1. A hypothetical ES <=3.0 implementation might need to re-add the vertex input API (or on 3.0 they could probably use texture fetches for all vertex data).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/411.html" title="Last updated on Aug 16, 2019, 12:16 AM UTC (f254d9e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/411/f0e7eba...kainino0x:f254d9e.html" title="Last updated on Aug 16, 2019, 12:16 AM UTC (f254d9e)">Diff</a>