### PR TITLE
Change vertex stride/offset to unsigned long

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -889,7 +889,7 @@ enum GPUInputStepMode {
 
 <script type=idl>
 dictionary GPUVertexAttributeDescriptor {
-    u64 offset = 0;
+    u32 offset = 0;
     required GPUVertexFormat format;
     required u32 shaderLocation;
 };
@@ -897,7 +897,7 @@ dictionary GPUVertexAttributeDescriptor {
 
 <script type=idl>
 dictionary GPUVertexBufferDescriptor {
-    required u64 stride;
+    required u32 stride;
     GPUInputStepMode stepMode = "vertex";
     required sequence<GPUVertexAttributeDescriptor> attributeSet;
 };

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1173,7 +1173,6 @@ enum GPUInputStepMode {
 
 <script type=idl>
 dictionary GPUVertexAttributeDescriptor {
-
     unsigned long offset = 0;
     required GPUVertexFormat format;
     required unsigned long shaderLocation;


### PR DESCRIPTION
Vertex buffer stride can't be very large (Dawn currently has 2048). Offset is always less than that.
This seems like a safe assumption for a long time.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/412.html" title="Last updated on Sep 9, 2019, 7:13 PM UTC (38f2c60)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/412/5ec2ce1...kainino0x:38f2c60.html" title="Last updated on Sep 9, 2019, 7:13 PM UTC (38f2c60)">Diff</a>