### PR TITLE
add default value to setIndexBuffer.offset

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1060,7 +1060,7 @@ Render Passes {#render-passes}
 interface GPURenderEncoderBase : GPUProgrammablePassEncoder {
     void setPipeline(GPURenderPipeline pipeline);
 
-    void setIndexBuffer(GPUBuffer buffer, u64 offset);
+    void setIndexBuffer(GPUBuffer buffer, optional u64 offset = 0);
     void setVertexBuffers(u32 startSlot,
                           sequence<GPUBuffer> buffers, sequence<u64> offsets);
 


### PR DESCRIPTION
This is a little less trivial for setVertexBuffers. E.g. should we allow offsets to be smaller than buffers, and any past the end are treated as 0? Then the default could be []. Or should buffers.length === offsets.length, in which case it would probably make more sense to have two overloads, one with offsets and one without


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Aug 22, 2019, 4:43 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fkainino0x%2Fgpuweb%2F6d59ef0cfa420da4fe15ee45ec1e9f0f2507333b%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%23414.)._
</details>
