### PR TITLE
Make GPUBGLBinding.textureDimension default to 2d.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -515,7 +515,7 @@ dictionary GPUBindGroupLayoutBinding {
     required u32 binding;
     required GPUShaderStageFlags visibility;
     required GPUBindingType type;
-    GPUTextureViewDimension textureDimension;
+    GPUTextureViewDimension textureDimension = "2d";
     GPUTextureComponentType textureComponentType = "float";
     boolean multisampled = false;
     boolean dynamic = false;


### PR DESCRIPTION
This is the most common case and avoids having an optional dictionary
member with no default value (but that still requires a value for
texture bindings).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/417.html" title="Last updated on Aug 20, 2019, 7:23 AM UTC (5875aca)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/417/1858d1b...Kangz:5875aca.html" title="Last updated on Aug 20, 2019, 7:23 AM UTC (5875aca)">Diff</a>