### PR TITLE
Make it easier to upload data into buffers correctly

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -199,6 +199,8 @@ Buffers {#buffers}
 
 <script type=idl>
 interface GPUBuffer : GPUObjectBase {
+    void setSubData(u64 offset, ArrayBuffer data);
+
     Promise<ArrayBuffer> mapReadAsync();
     Promise<ArrayBuffer> mapWriteAsync();
     void unmap();


### PR DESCRIPTION
`setSubData()` was removed in de471bf370118f21340de4652c1fcd4c7e2b310f. We should consider adding it back for two reasons, neither of which were stated during the discussion when it was removed:

1. Babylon.js [uses](https://github.com/BabylonJS/Babylon.js/blob/WebGPU/src/Engines/webgpuEngine.ts#L570) it, and the Google WebGPU demos [use](https://github.com/austinEng/webgpu-samples/search?q=setSubData&unscoped_q=setSubData) it, so it must be useful. These demos represent a significant percentage (> 50%?) of the public WebGPU examples we know about.

2. Without it, we would have API that’s easier to use incorrectly than to use correctly.

It is common practice in WebGL and native 3D graphics APIs to upload data for the current frame which commands are being recording commands for. Indeed, in WebGPU, have an implicit present after `rAF()` returns, so being able to upload your uniforms (or whatever) to a buffer before rAF() returns is important.

Using `mapWriteAsync()` requires you to wait on a promise, so if you do the naive thing and just wait on the promise inside `rAF()`, you’ll miss your present. Instead, the easiest way without `setSubData()` to upload data for the current frame would be to `createBufferMapped()` in each `rAF()`, which is unfortunate because it would cause runaway video memory growth. For small apps, this growth probably wouldn’t manifest as a performance problem, but would manifest as a battery life problem. The correct way to do it with `mapWriteAsync()` is for the application to create a pool of previously-mapped buffers, and manage the pool’s lifetime, state tracking, growth, etc. I’d expect the big engines to get this right, but I would expect most WebGPU applications would just do the simple bad thing of calling `createBufferMapped()` in each `rAF()`, which is an anti-pattern. If we gave them `setSubData()`, it’s more likely that more apps would actually do the right thing.

(You may say: “Why don’t we just make createBufferMapped() smart enough to recycle buffers?” However, this requires there to be a garbage collection every few frames, which would cause more problems than it would solve. Garbage collections often don’t occur until the system is running low on memory, which is way too late to be able to recycle these buffers reasonably.)

I’m just worried about a potential proliferation of WebGPU websites that have pathological memory growth because it's easier to write than to do the correct thing. The problem is potentially large because roughly every WebGPU application is going to want to upload a new set of uniforms for each frame, so potentially every app is going to be tempted to do the wrong thing.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/litherum/gpuweb/pull/418.html" title="Last updated on Oct 7, 2019, 7:47 PM UTC (b9738ce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/418/f87e1e4...litherum:b9738ce.html" title="Last updated on Oct 7, 2019, 7:47 PM UTC (b9738ce)">Diff</a>