### PR TITLE
Fully specify the defaults of GPUTextureViewDescriptor

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -312,7 +312,9 @@ dictionary GPUTextureViewDescriptor : GPUObjectDescriptorBase {
 };
 </script>
 
-<!-- TODO: make this a standalone algorithm used in the createView algorithm -->
+<!-- TODO(kainino0x): Make this a standalone algorithm used in the createView algorithm. -->
+<!-- TODO(kainino0x): The references to GPUTextureDescriptor here should actually refer to
+internal slots of a [=texture=] internal object once we have one. -->
 
 <div algorithm="resolving GPUTextureViewDescriptor defaults">
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -313,16 +313,26 @@ dictionary GPUTextureViewDescriptor : GPUObjectDescriptorBase {
 </script>
 
   * {{GPUTextureViewDescriptor/format}}:
-    If unspecified, defaults to the format of the texture.
+    If unspecified, defaults to the texture's {{GPUTextureDescriptor/format}}.
 
   * {{GPUTextureViewDescriptor/dimension}}:
-    If unspecified, defaults to the dimension of the texture.
+    If unspecified:
+      - If the texture's {{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"1d"}},
+        defaults to {{GPUTextureViewDimension/"1d"}}.
+      - If the texture's {{GPUTextureDescriptor/dimension}} and {{GPUTextureDescriptor/arrayLayerCount}}
+        are {{GPUTextureDimension/"2d"}} and equal to 1, respectively,
+        defaults to {{GPUTextureViewDimension/"2d"}}.
+      - If the texture's {{GPUTextureDescriptor/dimension}} and {{GPUTextureDescriptor/arrayLayerCount}}
+        are {{GPUTextureDimension/"2d"}} and greater than 1, respectively,
+        defaults to {{GPUTextureViewDimension/"2d-array"}}.
+      - If the texture's {{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"3d"}},
+        defaults to {{GPUTextureViewDimension/"3d"}}.
 
   * {{GPUTextureViewDescriptor/mipLevelCount}}:
-    If mipLevelCount == 0, the texture view will cover all the mipmap levels starting from baseMipLevel.
+    If 0, the texture view will cover all the mipmap levels starting from {{GPUTextureViewDescriptor/baseMipLevel}}.
 
   * {{GPUTextureViewDescriptor/arrayLayerCount}}:
-    If arrayLayerCount == 0, the texture view will cover all the array layers starting from baseArrayLayer.
+    If 0, the texture view will cover all the array layers starting from {{GPUTextureViewDescriptor/baseArrayLayer}}.
 
 <script type=idl>
 enum GPUTextureViewDimension {

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -312,27 +312,32 @@ dictionary GPUTextureViewDescriptor : GPUObjectDescriptorBase {
 };
 </script>
 
+<!-- TODO: make this a standalone algorithm used in the createView algorithm -->
+
+<div algorithm="resolving GPUTextureViewDescriptor defaults">
+
   * {{GPUTextureViewDescriptor/format}}:
-    If unspecified, defaults to the texture's {{GPUTextureDescriptor/format}}.
+    If unspecified, defaults to |texture|.{{GPUTextureDescriptor/format}}.
 
   * {{GPUTextureViewDescriptor/dimension}}:
     If unspecified:
-      - If the texture's {{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"1d"}},
+      - If |texture|.{{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"1d"}},
         defaults to {{GPUTextureViewDimension/"1d"}}.
-      - If the texture's {{GPUTextureDescriptor/dimension}} and {{GPUTextureDescriptor/arrayLayerCount}}
-        are {{GPUTextureDimension/"2d"}} and equal to 1, respectively,
-        defaults to {{GPUTextureViewDimension/"2d"}}.
-      - If the texture's {{GPUTextureDescriptor/dimension}} and {{GPUTextureDescriptor/arrayLayerCount}}
-        are {{GPUTextureDimension/"2d"}} and greater than 1, respectively,
-        defaults to {{GPUTextureViewDimension/"2d-array"}}.
-      - If the texture's {{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"3d"}},
+      - If |texture|.{{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"2d"}}:
+          - If |texture|.{{GPUTextureDescriptor/arrayLayerCount}} is greater than 1
+            and {{GPUTextureViewDescriptor/arrayLayerCount}} is 0,
+            defaults to {{GPUTextureViewDimension/"2d-array"}}.
+          - Otherwise, defaults to {{GPUTextureViewDimension/"2d"}}.
+      - If |texture|.{{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"3d"}},
         defaults to {{GPUTextureViewDimension/"3d"}}.
 
   * {{GPUTextureViewDescriptor/mipLevelCount}}:
-    If 0, the texture view will cover all the mipmap levels starting from {{GPUTextureViewDescriptor/baseMipLevel}}.
+    If 0, defaults to |texture|.{{GPUTextureDescriptor/mipLevelCount}} &minus; {{GPUTextureViewDescriptor/baseMipLevel}}.
 
   * {{GPUTextureViewDescriptor/arrayLayerCount}}:
-    If 0, the texture view will cover all the array layers starting from {{GPUTextureViewDescriptor/baseArrayLayer}}.
+    If 0, defaults to |texture|.{{GPUTextureDescriptor/arrayLayerCount}} &minus; {{GPUTextureViewDescriptor/baseArrayLayer}}.
+
+</div>
 
 <script type=idl>
 enum GPUTextureViewDimension {


### PR DESCRIPTION
Alternatives:
1. ~~(This PR)~~ Default to `"2d-array"` iff the **texture**'s `arrayLayerCount` is >1.
2. Default to `"2d-array"` if the **view**'s `arrayLayerCount` is explicitly or implicitly set to >1.
3. Default to `"2d-array"` if the **view**'s `arrayLayerCount` is explicitly set to >1 (`"2d"` with `arrayLayerCount = 1` otherwise).
4. Never default to `"2d-array"`; change view's `arrayLayerCount` to always default to 1; error if arrayLayerCount is >1 but dimension is not explicitly set to `"2d-array"`.
5. Never default to `"2d-array"`; error if the **texture**'s `arrayLayerCount` is >1.
6. Never default to `"2d-array"`; error if the **view**'s `arrayLayerCount` is explicitly or implicitly >1.

[EDIT: typos and more complete list of alternatives]


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/424.html" title="Last updated on Aug 23, 2019, 10:21 PM UTC (b28ac7f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/424/767e515...kainino0x:b28ac7f.html" title="Last updated on Aug 23, 2019, 10:21 PM UTC (b28ac7f)">Diff</a>