### PR TITLE
Make device.popErrorScope() throw an exception if there are no scopes

### DIFF
--- a/design/ErrorHandling.md
+++ b/design/ErrorHandling.md
@@ -263,7 +263,7 @@ Any further errors it captures are **silently ignored**.
 
 If an error is not captured by an error scope, it is passed out to the enclosing error scope.
 
-If there are no error scopes on the stack, `popErrorScope()` rejects.
+If there are no error scopes on the stack, `popErrorScope()` throws OperationError.
 
 If the device is lost, `popErrorScope()` always rejects.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1583,6 +1583,8 @@ partial interface GPUDevice {
 };
 </script>
 
+{{GPUDevice/popErrorScope()}} throws {{OperationError}} if there are no error scopes on the stack.
+
 
 ## Telemetry ## {#telemetry}
 


### PR DESCRIPTION
According to [ErrorConventions](https://github.com/gpuweb/gpuweb/blob/master/design/ErrorConventions.md)
> Validation which depends on state which can be tracked on the client-side: Error may (but usually won't) be synchronous.

The number of error scopes on the stack is easily tracked client-side.
It is easy to verify if popErrorScope() is allowed so it should throw
a DOMException instead of rejecting the Promise.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/austinEng/gpuweb/pull/429.html" title="Last updated on Sep 6, 2019, 6:04 PM UTC (cd5c7f2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/429/5ec2ce1...austinEng:cd5c7f2.html" title="Last updated on Sep 6, 2019, 6:04 PM UTC (cd5c7f2)">Diff</a>