### PR TITLE
Clarify popErrorScope() rejects with OperationError if the device is lost

### DIFF
--- a/design/ErrorHandling.md
+++ b/design/ErrorHandling.md
@@ -265,7 +265,7 @@ If an error is not captured by an error scope, it is passed out to the enclosing
 
 If there are no error scopes on the stack, `popErrorScope()` throws OperationError.
 
-If the device is lost, `popErrorScope()` always rejects.
+If the device is lost, `popErrorScope()` always rejects with AbortError.
 
 \* Error scope state is **per-device, per-execution-context**.
 That is, when a `GPUDevice` is posted to a Worker for the first time, the new `GPUDevice` copy's error scope stack is empty.

--- a/design/ErrorHandling.md
+++ b/design/ErrorHandling.md
@@ -265,7 +265,7 @@ If an error is not captured by an error scope, it is passed out to the enclosing
 
 If there are no error scopes on the stack, `popErrorScope()` throws OperationError.
 
-If the device is lost, `popErrorScope()` always rejects with AbortError.
+If the device is lost, `popErrorScope()` always rejects with OperationError.
 
 \* Error scope state is **per-device, per-execution-context**.
 That is, when a `GPUDevice` is posted to a Worker for the first time, the new `GPUDevice` copy's error scope stack is empty.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1620,7 +1620,7 @@ partial interface GPUDevice {
 </script>
 
 {{GPUDevice/popErrorScope()}} throws {{OperationError}} if there are no error scopes on the stack.
-
+{{GPUDevice/popErrorScope()}} rejects with {{AbortError}} if the device is lost.
 
 ## Telemetry ## {#telemetry}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1620,7 +1620,7 @@ partial interface GPUDevice {
 </script>
 
 {{GPUDevice/popErrorScope()}} throws {{OperationError}} if there are no error scopes on the stack.
-{{GPUDevice/popErrorScope()}} rejects with {{AbortError}} if the device is lost.
+{{GPUDevice/popErrorScope()}} rejects with {{OperationError}} if the device is lost.
 
 ## Telemetry ## {#telemetry}
 


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/DOMException), AbortError means "The operation was aborted."

When the device is lost, any attempt to `popErrorScope` is aborted and cannot complete because the device is gone. This is the same DOMException that the: 
- Fetch API uses for aborted requests
- [Payments API](https://w3c.github.io/payment-request/#show-method) uses when the document isn't active anymore
- [Push API](https://www.w3.org/TR/push-api/#pushmanager-interface) uses to terminate a subscription


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/austinEng/gpuweb/pull/433.html" title="Last updated on Nov 4, 2019, 11:23 PM UTC (92832bb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/433/51d3fbc...austinEng:92832bb.html" title="Last updated on Nov 4, 2019, 11:23 PM UTC (92832bb)">Diff</a>