### PR TITLE
Add a subsection about coordinate systems

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -27,6 +27,18 @@ Introduction {#intro}
 
 This specification rocks.
 
+Convention {#convention}
+========================
+
+## Coordinate Systems ## {#coordinate-systems}
+WebGPU's coordinate systems match DirectX and Metal's coordinate systems in graphics pipeline.
+  - Y-axis is up in normalized device coordinate (NDC): point(-1.0, -1.0) in NDC is located at the bottom-left corner of NDC.
+    In addition, x and y in NDC should be between -1.0 and 1.0 inclusive, while z in NDC should be between 0.0 and 1.0 inclusive.
+    Vertices out of this range in NDC will not introduce any errors, but they will be clipped.
+  - Y-axis is down in framebuffer coordinate, viewport coordinate and fragment/pixel coordinate:
+    origin(0, 0) is located at the top-left corner in these coordinate systems.
+  - Window/present coordinate matches framebuffer coordinate.
+  - UV of origin(0, 0) in texture coordinate represents the first texel (the lowest byte) in texture memory.
 
 Type Definitions {#type-definitions}
 ============================


### PR DESCRIPTION
Since we got consensus on WebGPU's coordinate systems: #416 , shall we add a subsection into the specification about this? 

I added a section "Convention". I assume that we may have such kind of stuff which impacts a few sections/objects and not belong to any particular section. However, both the section name "Convention" and the statement about coordinate systems might be inappropriate, please give suggestions on better wording if needed.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Richard-Yunchao/gpuweb/pull/434.html" title="Last updated on Sep 12, 2019, 4:53 PM UTC (72f6e9c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/434/51d3fbc...Richard-Yunchao:72f6e9c.html" title="Last updated on Sep 12, 2019, 4:53 PM UTC (72f6e9c)">Diff</a>