### PR TITLE
Return TextureView by the SwapChain

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1559,13 +1559,12 @@ interface GPUCanvasContext {
 dictionary GPUSwapChainDescriptor : GPUObjectDescriptorBase {
     required GPUDevice device;
     required GPUTextureFormat format;
-    GPUTextureUsageFlags usage = 0x10;  // GPUTextureUsage.OUTPUT_ATTACHMENT
 };
 </script>
 
 <script type=idl>
 interface GPUSwapChain : GPUObjectBase {
-    GPUTexture getCurrentTexture();
+    GPUTextureView getCurrentTextureView();
 };
 </script>
 


### PR DESCRIPTION
This is a straw-man proposal as a follow-up to #437 investigation. It limits the usage of swapchain textures to only `OUTPUT_ATTACHMENT` and returns them by views instead of by textures. This allows us to expose the most efficient code path for a typical use that is also universally portable.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/438.html" title="Last updated on Sep 16, 2019, 4:00 PM UTC (f6a1319)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/438/51d3fbc...kvark:f6a1319.html" title="Last updated on Sep 16, 2019, 4:00 PM UTC (f6a1319)">Diff</a>