### PR TITLE
Add Uint32Array overload for setBindGroup

### DIFF
--- a/spec/Makefile
+++ b/spec/Makefile
@@ -1,7 +1,7 @@
 all: index.html webgpu.idl
 
 index.html: index.bs
-	bikeshed --die-on=everything spec index.bs
+	bikeshed --die-on=link-error spec index.bs
 
 webgpu.idl: index.bs extract-idl.py
 	python extract-idl.py index.bs > webgpu.idl

--- a/spec/Makefile
+++ b/spec/Makefile
@@ -1,7 +1,7 @@
 all: index.html webgpu.idl
 
 index.html: index.bs
-	bikeshed --die-on=link-error spec index.bs
+	bikeshed --die-on=everything spec index.bs
 
 webgpu.idl: index.bs extract-idl.py
 	python extract-idl.py index.bs > webgpu.idl

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1604,7 +1604,12 @@ dictionary GPUImageBitmapCopyView {
 <script type=idl>
 interface mixin GPUProgrammablePassEncoder {
     void setBindGroup(unsigned long index, GPUBindGroup bindGroup,
-                      optional sequence<GPUBufferSize> dynamicOffsets = []);
+                      optional sequence<unsigned long> dynamicOffsets = []);
+
+    void setBindGroup(unsigned long index, GPUBindGroup bindGroup,
+                      Uint32Array dynamicOffsetsData,
+                      unsigned long long dynamicOffsetsDataStart,
+                      unsigned long long dynamicOffsetsDataLength);
 
     void pushDebugGroup(DOMString groupLabel);
     void popDebugGroup();


### PR DESCRIPTION
From discussion in #421 

This is useful to reduce bindings overhead in type conversion from
passing a vanilla JavaScript array. Emscripten applications will use
this API to efficiently pass data in the heap to WebGPU.

The overload has optional arguments dynamicOffsetsReadOffset and
dynamicOffsetsReadLength which specify a subregion in the Uint32Array
to read from.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/austinEng/gpuweb/pull/440.html" title="Last updated on Nov 4, 2019, 11:26 PM UTC (9dca7d3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/440/2f9a39e...austinEng:9dca7d3.html" title="Last updated on Nov 4, 2019, 11:26 PM UTC (9dca7d3)">Diff</a>