### PR TITLE
Add default value for dynamicOffsets

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1424,7 +1424,7 @@ dictionary GPUImageBitmapCopyView {
 <script type=idl>
 interface GPUProgrammablePassEncoder : GPUObjectBase {
     void setBindGroup(unsigned long index, GPUBindGroup bindGroup,
-                      optional sequence<GPUBufferSize> dynamicOffsets);
+                      optional sequence<GPUBufferSize> dynamicOffsets = []);
 
     void pushDebugGroup(DOMString groupLabel);
     void popDebugGroup();


### PR DESCRIPTION
This PR simply adds a default value to the optional argument dynamicOffsets.
This is a widely used pattern for "optional sequence<...>" in Web APIs as you can see at https://cs.chromium.org/search/?q=%22optional+sequence%22+f:blink+f:idl$+-f:external&type=cs


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/443.html" title="Last updated on Sep 24, 2019, 7:59 AM UTC (ff64506)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/443/0a2bb28...ff64506.html" title="Last updated on Sep 24, 2019, 7:59 AM UTC (ff64506)">Diff</a>