### PR TITLE
The Type must not be the identifier of the same or another typedef

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -32,7 +32,6 @@ Type Definitions {#type-definitions}
 ============================
 
 <script type=idl>
-typedef unsigned long GPUFlags;
 typedef unsigned long long GPUBufferSize;
 </script>
 
@@ -490,16 +489,16 @@ dictionary GPUBufferDescriptor : GPUObjectDescriptorBase {
 <script type=idl>
 typedef unsigned long GPUBufferUsageFlags;
 interface GPUBufferUsage {
-    const GPUFlags NONE      = 0x0000;
-    const GPUFlags MAP_READ  = 0x0001;
-    const GPUFlags MAP_WRITE = 0x0002;
-    const GPUFlags COPY_SRC  = 0x0004;
-    const GPUFlags COPY_DST  = 0x0008;
-    const GPUFlags INDEX     = 0x0010;
-    const GPUFlags VERTEX    = 0x0020;
-    const GPUFlags UNIFORM   = 0x0040;
-    const GPUFlags STORAGE   = 0x0080;
-    const GPUFlags INDIRECT  = 0x0100;
+    const GPUBufferUsageFlags NONE      = 0x0000;
+    const GPUBufferUsageFlags MAP_READ  = 0x0001;
+    const GPUBufferUsageFlags MAP_WRITE = 0x0002;
+    const GPUBufferUsageFlags COPY_SRC  = 0x0004;
+    const GPUBufferUsageFlags COPY_DST  = 0x0008;
+    const GPUBufferUsageFlags INDEX     = 0x0010;
+    const GPUBufferUsageFlags VERTEX    = 0x0020;
+    const GPUBufferUsageFlags UNIFORM   = 0x0040;
+    const GPUBufferUsageFlags STORAGE   = 0x0080;
+    const GPUBufferUsageFlags INDIRECT  = 0x0100;
 };
 </script>
 
@@ -560,12 +559,12 @@ enum GPUTextureDimension {
 <script type=idl>
 typedef unsigned long GPUTextureUsageFlags;
 interface GPUTextureUsage {
-    const GPUFlags NONE              = 0x00;
-    const GPUFlags COPY_SRC          = 0x01;
-    const GPUFlags COPY_DST          = 0x02;
-    const GPUFlags SAMPLED           = 0x04;
-    const GPUFlags STORAGE           = 0x08;
-    const GPUFlags OUTPUT_ATTACHMENT = 0x10;
+    const GPUTextureUsageFlags NONE              = 0x00;
+    const GPUTextureUsageFlags COPY_SRC          = 0x01;
+    const GPUTextureUsageFlags COPY_DST          = 0x02;
+    const GPUTextureUsageFlags SAMPLED           = 0x04;
+    const GPUTextureUsageFlags STORAGE           = 0x08;
+    const GPUTextureUsageFlags OUTPUT_ATTACHMENT = 0x10;
 };
 </script>
 
@@ -830,10 +829,10 @@ dictionary GPUBindGroupLayoutBinding {
 <script type=idl>
 typedef unsigned long GPUShaderStageFlags;
 interface GPUShaderStage {
-    const GPUFlags NONE     = 0x0;
-    const GPUFlags VERTEX   = 0x1;
-    const GPUFlags FRAGMENT = 0x2;
-    const GPUFlags COMPUTE  = 0x4;
+    const GPUShaderStageFlags NONE     = 0x0;
+    const GPUShaderStageFlags VERTEX   = 0x1;
+    const GPUShaderStageFlags FRAGMENT = 0x2;
+    const GPUShaderStageFlags COMPUTE  = 0x4;
 };
 </script>
 
@@ -1135,12 +1134,12 @@ dictionary GPUColorStateDescriptor {
 <script type=idl>
 typedef unsigned long GPUColorWriteFlags;
 interface GPUColorWrite {
-    const GPUFlags NONE  = 0x0;
-    const GPUFlags RED   = 0x1;
-    const GPUFlags GREEN = 0x2;
-    const GPUFlags BLUE  = 0x4;
-    const GPUFlags ALPHA = 0x8;
-    const GPUFlags ALL   = 0xF;
+    const GPUColorWriteFlags NONE  = 0x0;
+    const GPUColorWriteFlags RED   = 0x1;
+    const GPUColorWriteFlags GREEN = 0x2;
+    const GPUColorWriteFlags BLUE  = 0x4;
+    const GPUColorWriteFlags ALPHA = 0x8;
+    const GPUColorWriteFlags ALL   = 0xF;
 };
 </script>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -488,7 +488,7 @@ dictionary GPUBufferDescriptor : GPUObjectDescriptorBase {
 ## Buffer Usage ## {#buffer-usage}
 
 <script type=idl>
-typedef GPUFlags GPUBufferUsageFlags;
+typedef unsigned long GPUBufferUsageFlags;
 interface GPUBufferUsage {
     const GPUFlags NONE      = 0x0000;
     const GPUFlags MAP_READ  = 0x0001;
@@ -558,7 +558,7 @@ enum GPUTextureDimension {
 </script>
 
 <script type=idl>
-typedef GPUFlags GPUTextureUsageFlags;
+typedef unsigned long GPUTextureUsageFlags;
 interface GPUTextureUsage {
     const GPUFlags NONE              = 0x00;
     const GPUFlags COPY_SRC          = 0x01;
@@ -828,7 +828,7 @@ dictionary GPUBindGroupLayoutBinding {
     associated shader stage.
 
 <script type=idl>
-typedef GPUFlags GPUShaderStageFlags;
+typedef unsigned long GPUShaderStageFlags;
 interface GPUShaderStage {
     const GPUFlags NONE     = 0x0;
     const GPUFlags VERTEX   = 0x1;
@@ -1133,7 +1133,7 @@ dictionary GPUColorStateDescriptor {
 </script>
 
 <script type=idl>
-typedef GPUFlags GPUColorWriteFlags;
+typedef unsigned long GPUColorWriteFlags;
 interface GPUColorWrite {
     const GPUFlags NONE  = 0x0;
     const GPUFlags RED   = 0x1;


### PR DESCRIPTION
According to https://heycam.github.io/webidl/#idl-typedefs, the Type must not be the identifier of the same or another typedef.

Bikeshed should have checked this. I've filed an issue at https://github.com/tabatkins/bikeshed/issues/1531


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/444.html" title="Last updated on Sep 26, 2019, 7:42 AM UTC (65903ca)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/444/76252bc...65903ca.html" title="Last updated on Sep 26, 2019, 7:42 AM UTC (65903ca)">Diff</a>