### PR TITLE
Fix XML warning

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -889,7 +889,7 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
 
 <div algorithm="GPUDevice.createBindGroupLayout(descriptor)">
 
-The <dfn-type="method" dfn-for="GPUDevice">createBindGroupLayout(|descriptor|)</dfn> method is used to create {{GPUBindGroupLayout}}s.
+The <dfn method for="GPUDevice">createBindGroupLayout(|descriptor|)</dfn> method is used to create {{GPUBindGroupLayout}}s.
 
 1. Ensure [=device validation=] is not violated.
 1. Let |layout| be a new valid {{GPUBindGroupLayout}} object.


### PR DESCRIPTION
```
/Users/kainino/sources/bikeshed/venv/lib/python2.7/site-packages/html5lib/_ihatexml.py:265: DataLossWarning: Coercing non-XML name
  warnings.warn("Coercing non-XML name", DataLossWarning)
```


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/448.html" title="Last updated on Sep 30, 2019, 2:16 AM UTC (de3bff9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/448/5b1122a...kainino0x:de3bff9.html" title="Last updated on Sep 30, 2019, 2:16 AM UTC (de3bff9)">Diff</a>