### PR TITLE
Use = {} syntax in more places, make stencil faces optional

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -147,7 +147,7 @@ partial interface WorkerNavigator {
 [Exposed=Window]
 interface GPU {
     // May reject with DOMException  // TODO: DOMException("OperationError")?
-    Promise<GPUAdapter> requestAdapter(optional GPURequestAdapterOptions options);
+    Promise<GPUAdapter> requestAdapter(optional GPURequestAdapterOptions options = {});
 };
 </script>
 
@@ -183,7 +183,7 @@ interface GPUAdapter {
     //readonly attribute GPULimits limits; Don't expose higher limits for now.
 
     // May reject with DOMException  // TODO: DOMException("OperationError")?
-    Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor);
+    Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor = {});
 };
 </script>
 
@@ -322,7 +322,7 @@ interface GPUDevice : EventTarget {
     GPUMappedBuffer createBufferMapped(GPUBufferDescriptor descriptor);
     Promise<GPUMappedBuffer> createBufferMappedAsync(GPUBufferDescriptor descriptor);
     GPUTexture createTexture(GPUTextureDescriptor descriptor);
-    GPUSampler createSampler(optional GPUSamplerDescriptor descriptor);
+    GPUSampler createSampler(optional GPUSamplerDescriptor descriptor = {});
 
     GPUBindGroupLayout createBindGroupLayout(GPUBindGroupLayoutDescriptor descriptor);
     GPUPipelineLayout createPipelineLayout(GPUPipelineLayoutDescriptor descriptor);
@@ -332,7 +332,7 @@ interface GPUDevice : EventTarget {
     GPUComputePipeline createComputePipeline(GPUComputePipelineDescriptor descriptor);
     GPURenderPipeline createRenderPipeline(GPURenderPipelineDescriptor descriptor);
 
-    GPUCommandEncoder createCommandEncoder(optional GPUCommandEncoderDescriptor descriptor);
+    GPUCommandEncoder createCommandEncoder(optional GPUCommandEncoderDescriptor descriptor = {});
     GPURenderBundleEncoder createRenderBundleEncoder(GPURenderBundleEncoderDescriptor descriptor);
 
     GPUQueue getQueue();
@@ -370,8 +370,8 @@ To get a {{GPUDevice}}, use {{GPUAdapter/requestDevice()}}.
 
 <script type=idl>
 dictionary GPUDeviceDescriptor : GPUObjectDescriptorBase {
-    GPUExtensions extensions;
-    GPULimits limits;
+    GPUExtensions extensions = {};
+    GPULimits limits = {};
 
     // TODO: are other things configurable like queues?
 };
@@ -541,7 +541,7 @@ Textures {#textures}
 
 <script type=idl>
 interface GPUTexture {
-    GPUTextureView createView(optional GPUTextureViewDescriptor descriptor);
+    GPUTextureView createView(optional GPUTextureViewDescriptor descriptor = {});
 
     void destroy();
 };
@@ -1087,7 +1087,7 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
     GPUProgrammableStageDescriptor fragmentStage;
 
     required GPUPrimitiveTopology primitiveTopology;
-    GPURasterizationStateDescriptor rasterizationState;
+    GPURasterizationStateDescriptor rasterizationState = {};
     required sequence<GPUColorStateDescriptor> colorStates;
     GPUDepthStencilStateDescriptor depthStencilState;
     GPUVertexInputDescriptor vertexInput = {};
@@ -1147,8 +1147,8 @@ enum GPUCullMode {
 dictionary GPUColorStateDescriptor {
     required GPUTextureFormat format;
 
-    GPUBlendDescriptor alphaBlend;
-    GPUBlendDescriptor colorBlend;
+    GPUBlendDescriptor alphaBlend = {};
+    GPUBlendDescriptor colorBlend = {};
     GPUColorWriteFlags writeMask = 0xF;  // GPUColorWrite.ALL
 };
 </script>
@@ -1225,8 +1225,8 @@ dictionary GPUDepthStencilStateDescriptor {
     boolean depthWriteEnabled = false;
     GPUCompareFunction depthCompare = "always";
 
-    required GPUStencilStateFaceDescriptor stencilFront;
-    required GPUStencilStateFaceDescriptor stencilBack;
+    GPUStencilStateFaceDescriptor stencilFront = {};
+    GPUStencilStateFaceDescriptor stencilBack = {};
 
     unsigned long stencilReadMask = 0xFFFFFFFF;
     unsigned long stencilWriteMask = 0xFFFFFFFF;
@@ -1362,7 +1362,7 @@ Command Encoding {#command-encoding}
 <script type=idl>
 interface GPUCommandEncoder {
     GPURenderPassEncoder beginRenderPass(GPURenderPassDescriptor descriptor);
-    GPUComputePassEncoder beginComputePass(optional GPUComputePassDescriptor descriptor);
+    GPUComputePassEncoder beginComputePass(optional GPUComputePassDescriptor descriptor = {});
 
     void copyBufferToBuffer(
         GPUBuffer source,
@@ -1395,7 +1395,7 @@ interface GPUCommandEncoder {
     void popDebugGroup();
     void insertDebugMarker(DOMString markerLabel);
 
-    GPUCommandBuffer finish(optional GPUCommandBufferDescriptor descriptor);
+    GPUCommandBuffer finish(optional GPUCommandBufferDescriptor descriptor = {});
 };
 GPUCommandEncoder includes GPUObjectBase;
 </script>
@@ -1427,7 +1427,7 @@ dictionary GPUTextureCopyView {
     required GPUTexture texture;
     unsigned long mipLevel = 0;
     unsigned long arrayLayer = 0;
-    GPUOrigin3D origin;
+    GPUOrigin3D origin = {};
 };
 </script>
 
@@ -1436,7 +1436,7 @@ dictionary GPUTextureCopyView {
 <script type=idl>
 dictionary GPUImageBitmapCopyView {
     required ImageBitmap imageBitmap;
-    GPUOrigin2D origin;
+    GPUOrigin2D origin = {};
 };
 </script>
 
@@ -1609,7 +1609,7 @@ dictionary GPURenderBundleDescriptor : GPUObjectDescriptorBase {
 
 <script type=idl>
 interface GPURenderBundleEncoder : GPURenderEncoderBase {
-    GPURenderBundle finish(optional GPURenderBundleDescriptor descriptor);
+    GPURenderBundle finish(optional GPURenderBundleDescriptor descriptor = {});
 };
 </script>
 
@@ -1631,7 +1631,7 @@ Queues {#queues}
 interface GPUQueue {
     void submit(sequence<GPUCommandBuffer> buffers);
 
-    GPUFence createFence(optional GPUFenceDescriptor descriptor);
+    GPUFence createFence(optional GPUFenceDescriptor descriptor = {});
     void signal(GPUFence fence, unsigned long long signalValue);
 };
 GPUQueue includes GPUObjectBase;


### PR DESCRIPTION
There's one functional change here, which is that `stencilFront` and `stencilBack` become optional (as they always should have been starting with #241).

Fixes #420 (I think)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/449.html" title="Last updated on Oct 3, 2019, 1:53 AM UTC (cbe0b69)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/449/c6f6c6c...kainino0x:cbe0b69.html" title="Last updated on Oct 3, 2019, 1:53 AM UTC (cbe0b69)">Diff</a>