### PR TITLE
Dictionaries must not be used as the type of an attribute

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -179,7 +179,7 @@ and exposes its capabilities (extensions and limits).
 <script type=idl>
 interface GPUAdapter {
     readonly attribute DOMString name;
-    readonly attribute GPUExtensions extensions;
+    readonly attribute object extensions;
     //readonly attribute GPULimits limits; Don't expose higher limits for now.
 
     // May reject with DOMException  // TODO: DOMException("OperationError")?
@@ -314,8 +314,8 @@ It is the top-level object through which [=WebGPU interfaces=] are created.
 <script type=idl>
 [Exposed=(Window, Worker), Serializable]
 interface GPUDevice : EventTarget {
-    readonly attribute GPUExtensions extensions;
-    readonly attribute GPULimits limits;
+    readonly attribute object extensions;
+    readonly attribute object limits;
     readonly attribute GPUAdapter adapter;
 
     GPUBuffer createBuffer(GPUBufferDescriptor descriptor);


### PR DESCRIPTION
According to https://heycam.github.io/webidl/#idl-dictionaries,
"Dictionaries must not be used as the type of an attribute or constant."


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/romandev/gpuweb/pull/451.html" title="Last updated on Oct 1, 2019, 3:13 PM UTC (9aea636)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/451/5b1122a...romandev:9aea636.html" title="Last updated on Oct 1, 2019, 3:13 PM UTC (9aea636)">Diff</a>