### PR TITLE
Use `includes` instead of inheritance

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -518,13 +518,14 @@ interface GPUBufferUsage {
 
 
 <script type=idl>
-interface GPUBuffer : GPUObjectBase {
+interface GPUBuffer {
     Promise<ArrayBuffer> mapReadAsync();
     Promise<ArrayBuffer> mapWriteAsync();
     void unmap();
 
     void destroy();
 };
+GPUBuffer includes GPUObjectBase;
 
 typedef sequence<any> GPUMappedBuffer;
 </script>
@@ -539,11 +540,12 @@ Textures {#textures}
 ## GPUTexture ## {#texture}
 
 <script type=idl>
-interface GPUTexture : GPUObjectBase {
+interface GPUTexture {
     GPUTextureView createView(optional GPUTextureViewDescriptor descriptor);
 
     void destroy();
 };
+GPUTexture includes GPUObjectBase;
 </script>
 
 ### Texture Creation ### {#texture-creation}
@@ -583,8 +585,9 @@ interface GPUTextureUsage {
 ## GPUTextureView ## {#texture-view}
 
 <script type=idl>
-interface GPUTextureView : GPUObjectBase {
+interface GPUTextureView {
 };
+GPUTextureView includes GPUObjectBase;
 </script>
 
 ### Texture View Creation ### {#texture-view-creation}
@@ -745,8 +748,9 @@ Samplers {#samplers}
 ## GPUSampler ## {#sampler}
 
 <script type=idl>
-interface GPUSampler : GPUObjectBase {
+interface GPUSampler {
 };
+GPUSampler includes GPUObjectBase;
 </script>
 
 ### Creation ### {#sampler-creation}
@@ -803,8 +807,9 @@ A {{GPUBindGroupLayout}} defines the interface between a set of resources bound 
 
 <script type=idl>
 [Serializable]
-interface GPUBindGroupLayout : GPUObjectBase {
+interface GPUBindGroupLayout {
 };
+GPUBindGroupLayout includes GPUObjectBase;
 </script>
 
 ### Creation ### {#bind-group-layout-creation}
@@ -950,8 +955,9 @@ If any of the following conditions are violated:
 ## GPUBindGroup ## {#bind-groups}
 
 <script type=idl>
-interface GPUBindGroup : GPUObjectBase {
+interface GPUBindGroup {
 };
+GPUBindGroup includes GPUObjectBase;
 </script>
 
 ### Bind Group Creation ### {#bind-group-creation}
@@ -985,8 +991,9 @@ dictionary GPUBufferBinding {
 ## GPUPipelineLayout ## {#pipeline-layout}
 
 <script type=idl>
-interface GPUPipelineLayout : GPUObjectBase {
+interface GPUPipelineLayout {
 };
+GPUPipelineLayout includes GPUObjectBase;
 </script>
 
 ### Creation ### {#pipeline-layout-creation}
@@ -1004,8 +1011,9 @@ Shader Modules {#shader-modules}
 
 <script type=idl>
 [Serializable]
-interface GPUShaderModule : GPUObjectBase {
+interface GPUShaderModule {
 };
+GPUShaderModule includes GPUObjectBase;
 </script>
 
 {{GPUShaderModule}} is {{Serializable}}. It is a reference to an internal
@@ -1049,8 +1057,9 @@ dictionary GPUProgrammableStageDescriptor {
 
 <script type=idl>
 [Serializable]
-interface GPUComputePipeline : GPUObjectBase {
+interface GPUComputePipeline {
 };
+GPUComputePipeline includes GPUObjectBase;
 </script>
 
 ### Creation ### {#compute-pipeline-creation}
@@ -1065,8 +1074,9 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
 
 <script type=idl>
 [Serializable]
-interface GPURenderPipeline : GPUObjectBase {
+interface GPURenderPipeline {
 };
+GPURenderPipeline includes GPUObjectBase;
 </script>
 
 ### Creation ### {#render-pipeline-creation}
@@ -1331,8 +1341,9 @@ Command Buffers {#command-buffers}
 ## GPUCommandBuffer ## {#command-buffer}
 
 <script type=idl>
-interface GPUCommandBuffer : GPUObjectBase {
+interface GPUCommandBuffer {
 };
+GPUCommandBuffer includes GPUObjectBase;
 </script>
 
 ### Creation ### {#command-buffer-creation}
@@ -1349,7 +1360,7 @@ Command Encoding {#command-encoding}
 ## GPUCommandEncoder ## {#command-encoder}
 
 <script type=idl>
-interface GPUCommandEncoder : GPUObjectBase {
+interface GPUCommandEncoder {
     GPURenderPassEncoder beginRenderPass(GPURenderPassDescriptor descriptor);
     GPUComputePassEncoder beginComputePass(optional GPUComputePassDescriptor descriptor);
 
@@ -1386,6 +1397,7 @@ interface GPUCommandEncoder : GPUObjectBase {
 
     GPUCommandBuffer finish(optional GPUCommandBufferDescriptor descriptor);
 };
+GPUCommandEncoder includes GPUObjectBase;
 </script>
 
   * {{GPUCommandEncoder/copyImageBitmapToTexture()}}:
@@ -1433,7 +1445,7 @@ dictionary GPUImageBitmapCopyView {
 ## Programmable Passes ## {#programmable-passes}
 
 <script type=idl>
-interface GPUProgrammablePassEncoder : GPUObjectBase {
+interface GPUProgrammablePassEncoder {
     void setBindGroup(unsigned long index, GPUBindGroup bindGroup,
                       optional sequence<GPUBufferSize> dynamicOffsets = []);
 
@@ -1441,6 +1453,7 @@ interface GPUProgrammablePassEncoder : GPUObjectBase {
     void popDebugGroup();
     void insertDebugMarker(DOMString markerLabel);
 };
+GPUProgrammablePassEncoder includes GPUObjectBase;
 </script>
 
 Debug groups in a {{GPUCommandEncoder}} or {{GPUProgrammablePassEncoder}}
@@ -1582,8 +1595,9 @@ Bundles {#bundles}
 ## GPURenderBundle ## {#render-bundle}
 
 <script type=idl>
-interface GPURenderBundle : GPUObjectBase {
+interface GPURenderBundle {
 };
+GPURenderBundle includes GPUObjectBase;
 </script>
 
 ### Creation ### {#render-bundle-creation}
@@ -1614,21 +1628,23 @@ Queues {#queues}
 ================
 
 <script type=idl>
-interface GPUQueue : GPUObjectBase {
+interface GPUQueue {
     void submit(sequence<GPUCommandBuffer> buffers);
 
     GPUFence createFence(optional GPUFenceDescriptor descriptor);
     void signal(GPUFence fence, unsigned long long signalValue);
 };
+GPUQueue includes GPUObjectBase;
 </script>
 
 ## GPUFence ## {#fence}
 
 <script type=idl>
-interface GPUFence : GPUObjectBase {
+interface GPUFence {
     unsigned long long getCompletedValue();
     Promise<void> onCompletion(unsigned long long completionValue);
 };
+GPUFence includes GPUObjectBase;
 </script>
 
 ### Creation ### {#fence-creation}
@@ -1666,9 +1682,10 @@ dictionary GPUSwapChainDescriptor : GPUObjectDescriptorBase {
 </script>
 
 <script type=idl>
-interface GPUSwapChain : GPUObjectBase {
+interface GPUSwapChain {
     GPUTexture getCurrentTexture();
 };
+GPUSwapChain includes GPUObjectBase;
 </script>
 
 


### PR DESCRIPTION
The `GPUObjectBase` is defined as `Interface mixin`. So, we should use
`includes` instead of inheritance.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/romandev/gpuweb/pull/452.html" title="Last updated on Oct 2, 2019, 8:14 AM UTC (03dcc4a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/452/0aaf9b2...romandev:03dcc4a.html" title="Last updated on Oct 2, 2019, 8:14 AM UTC (03dcc4a)">Diff</a>