### PR TITLE
Add definitions loosely explaining types of `object`s

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -113,7 +113,9 @@ interface mixin GPUObjectBase {
 <dl dfn-type=attribute dfn-for=GPUObjectBase>
     : <dfn>label</dfn>
     ::
+</dl>
 
+<dl dfn-type=attribute dfn-for=GPUObjectBase>
     : <dfn>\[[device]]</dfn>, of type [=device=], readonly
     ::
         An internal slot holding the [=device=] on which the object exists.
@@ -190,11 +192,6 @@ interface GPUAdapter {
 {{GPUAdapter}} has the following attributes:
 
 <dl dfn-type=attribute dfn-for=GPUAdapter>
-    : <dfn>\[[adapter]]</dfn>, of type [=adapter=], readonly
-    ::
-        An internal slot holding the [=adapter=] to which this {{GPUAdapter}}
-        refers.
-
     : <dfn>name</dfn>
     ::
         A human-readable name identifying the adapter.
@@ -211,6 +208,15 @@ interface GPUAdapter {
             not by the [=adapter=], it will be `false`.
           - If an extension is supported by the user agent and
             by the [=adapter=], it will be `true`.
+</dl>
+
+{{GPUAdapter}} also has the following internal slots:
+
+<dl dfn-type=attribute dfn-for=GPUAdapter>
+    : <dfn>\[[adapter]]</dfn>, of type [=adapter=], readonly
+    ::
+        An internal slot holding the [=adapter=] to which this {{GPUAdapter}}
+        refers.
 </dl>
 
 ### Getting an Adapter ### {#adapter-creation}
@@ -314,9 +320,9 @@ It is the top-level object through which [=WebGPU interfaces=] are created.
 <script type=idl>
 [Exposed=(Window, Worker), Serializable]
 interface GPUDevice : EventTarget {
+    readonly attribute GPUAdapter adapter;
     readonly attribute object extensions;
     readonly attribute object limits;
-    readonly attribute GPUAdapter adapter;
 
     GPUBuffer createBuffer(GPUBufferDescriptor descriptor);
     GPUMappedBuffer createBufferMapped(GPUBufferDescriptor descriptor);
@@ -339,6 +345,22 @@ interface GPUDevice : EventTarget {
 };
 GPUDevice includes GPUObjectBase;
 </script>
+
+{{GPUDevice}} has the following attributes:
+
+<dl dfn-type=attribute dfn-for=GPUDevice>
+    : <dfn>adapter</dfn>
+    ::
+        The {{GPUAdapter}} from which this device was created.
+
+    : <dfn>extensions</dfn>
+    ::
+        A {{GPUExtensions}} object exposing the extensions with which this device was created.
+
+    : <dfn>limits</dfn>
+    ::
+        A {{GPULimits}} object exposing the limits with which this device was created.
+</dl>
 
 {{GPUDevice}} also has the following internal slots:
 


### PR DESCRIPTION
and minor cleanups.

Follow-up to #451.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/453.html" title="Last updated on Oct 1, 2019, 5:16 PM UTC (2aded00)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/453/0aaf9b2...kainino0x:2aded00.html" title="Last updated on Oct 1, 2019, 5:16 PM UTC (2aded00)">Diff</a>