### PR TITLE
Add GPUShaderTransformFunction to GPUShaderModuleDescriptor

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1014,18 +1014,41 @@ shader module object, and {{Serializable}} means that the reference can be
 it concurrently. Since {{GPUShaderModule}} immutable, there are no race
 conditions.
 
-### Shader Module Creation ### {#shader-module-creation}
+### {{GPUShaderModuleDescriptor}} ### {#GPUShaderModuleDescriptor}
+
+This specifies the options to use in creating a {{GPUShaderModule}}.
 
 <script type=idl>
 typedef (Uint32Array or DOMString) GPUShaderCode;
+typedef any GPUShaderSource;
+callback GPUShaderTransformFunction = GPUShaderCode (GPUShaderSource source);
 
 dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
-    required GPUShaderCode code;
+    required GPUShaderSource source;
+    GPUShaderTransformFunction transform;
 };
 </script>
 
 Note: While the choice of shader language is undecided,
-`GPUShaderModuleDescriptor` will temporarily accept both text and binary input.
+{{GPUShaderCode}} will temporarily accept both text and binary input.
+
+### {{GPUDevice/createShaderModule(descriptor)|GPUDevice.createShaderModule(descriptor)}} ### {#GPUDevice-createShaderModule}
+
+<dl dfn-type="method" dfn-for="GPUDevice">
+	: <dfn>createShaderModule(descriptor)</dfn>
+	::
+		<div algorithm="GPUDevice.createShaderModule(descriptor)">
+            1. If {{GPUShaderModuleDescriptor/transform}} is unspecified, it defaults
+                to the identity function.
+
+            1. Let |code| be the result of invoking {{GPUShaderModuleDescriptor/transform}}
+                on {{GPUShaderModuleDescriptor/source}}.
+
+            1. If |code| is not of type {{GPUShaderCode}}, throw {{TypeError}}.
+
+            1. Return a new {{GPUShaderModule}} object created from |code|.
+        </div>
+</dl>
 
 
 Pipelines {#pipelines}


### PR DESCRIPTION
Given that both WSL and SPIR-V intend to be compilation targets, we should ensure that developers have a good way to work with shaders in other source languages.

This PR adds an optional `transform` function which, if present, is invoked on the code passed in the `GPUShaderModuleDescriptor`.

An application would write code like the following:
```javascript
const shaderModule = device.createShaderModule({
   source: myHighLevelLanguageString,
   transform: hll => someTransformToWSLOrSPIRV(hll),
});
```
or
```javascript
const shaderModule = device.createShaderModule({
   source: {
     code: myParameterizedHighLevelLanguageString,
     parameters: { numLights: 10, unrollLoops: true }
   },
   transform: obj => applySpecialization(obj),
});
```

An application may compile any language to WSL or SPIR-V without the addition of the `transform` member. However, explicitly providing it gives the browser a direct reference to the transform so it can be re-invoked to recompile shaders. The proposed API enables the creation of developer tools which provide live editing for GLSL, HLSL, MSL, ...**any source language** shaders (given a user-land transform is provided) regardless of the API shader ingestion language.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/austinEng/gpuweb/pull/454.html" title="Last updated on Oct 1, 2019, 10:39 PM UTC (837b67e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/454/0aaf9b2...austinEng:837b67e.html" title="Last updated on Oct 1, 2019, 10:39 PM UTC (837b67e)">Diff</a>