### PR TITLE
Make GPUProgrammablePassEncoder and GPURenderEncoderBase interface mixin

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1467,7 +1467,7 @@ dictionary GPUImageBitmapCopyView {
 ## Programmable Passes ## {#programmable-passes}
 
 <script type=idl>
-interface GPUProgrammablePassEncoder {
+interface mixin GPUProgrammablePassEncoder {
     void setBindGroup(unsigned long index, GPUBindGroup bindGroup,
                       optional sequence<GPUBufferSize> dynamicOffsets = []);
 
@@ -1487,13 +1487,14 @@ Compute Passes {#compute-passes}
 ## GPUComputePassEncoder ## {#compute-pass-encoder}
 
 <script type=idl>
-interface GPUComputePassEncoder : GPUProgrammablePassEncoder {
+interface GPUComputePassEncoder {
     void setPipeline(GPUComputePipeline pipeline);
     void dispatch(unsigned long x, optional unsigned long y = 1, optional unsigned long z = 1);
     void dispatchIndirect(GPUBuffer indirectBuffer, GPUBufferSize indirectOffset);
 
     void endPass();
 };
+GPUComputePassEncoder includes GPUProgrammablePassEncoder;
 </script>
 
 ### Creation ### {#compute-pass-encoder-creation}
@@ -1509,7 +1510,7 @@ Render Passes {#render-passes}
 ## GPURenderPassEncoder ## {#render-pass-encoder}
 
 <script type=idl>
-interface GPURenderEncoderBase : GPUProgrammablePassEncoder {
+interface mixin GPURenderEncoderBase {
     void setPipeline(GPURenderPipeline pipeline);
 
     void setIndexBuffer(GPUBuffer buffer, optional GPUBufferSize offset = 0);
@@ -1524,8 +1525,9 @@ interface GPURenderEncoderBase : GPUProgrammablePassEncoder {
     void drawIndirect(GPUBuffer indirectBuffer, GPUBufferSize indirectOffset);
     void drawIndexedIndirect(GPUBuffer indirectBuffer, GPUBufferSize indirectOffset);
 };
+GPURenderEncoderBase includes GPUProgrammablePassEncoder;
 
-interface GPURenderPassEncoder : GPURenderEncoderBase {
+interface GPURenderPassEncoder {
     void setViewport(float x, float y,
                      float width, float height,
                      float minDepth, float maxDepth);
@@ -1538,6 +1540,7 @@ interface GPURenderPassEncoder : GPURenderEncoderBase {
     void executeBundles(sequence<GPURenderBundle> bundles);
     void endPass();
 };
+GPURenderPassEncoder includes GPURenderEncoderBase;
 </script>
 
   * In indirect draw calls, the base instance field (inside the indirect
@@ -1630,9 +1633,10 @@ dictionary GPURenderBundleDescriptor : GPUObjectDescriptorBase {
 </script>
 
 <script type=idl>
-interface GPURenderBundleEncoder : GPURenderEncoderBase {
+interface GPURenderBundleEncoder {
     GPURenderBundle finish(optional GPURenderBundleDescriptor descriptor = {});
 };
+GPURenderBundleEncoder includes GPURenderEncoderBase;
 </script>
 
 ### Encoding ### {#render-bundle-encoding}


### PR DESCRIPTION
The GPUProgrammablePassEncoder and GPURenderEncoderBase are sharing
their common methods in each different interfaces by using inheritance.
However, it is better to use interface mixin because those interfaces
don't need to have their own prototype chain.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/romandev/gpuweb/pull/459.html" title="Last updated on Oct 7, 2019, 1:02 PM UTC (40e5ae4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/459/57d610b...romandev:40e5ae4.html" title="Last updated on Oct 7, 2019, 1:02 PM UTC (40e5ae4)">Diff</a>