### PR TITLE
Remove more sequences from the hot path

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1533,7 +1533,7 @@ interface GPURenderPassEncoder {
     void setBlendColor(GPUColor color);
     void setStencilReference(unsigned long reference);
 
-    void executeBundles(sequence<GPURenderBundle> bundles);
+    void executeBundle(GPURenderBundle bundle);
     void endPass();
 };
 GPURenderPassEncoder includes GPURenderEncoderBase;
@@ -1651,7 +1651,7 @@ Queues {#queues}
 
 <script type=idl>
 interface GPUQueue {
-    void submit(sequence<GPUCommandBuffer> buffers);
+    void submit(GPUCommandBuffer commandBuffer);
 
     GPUFence createFence(optional GPUFenceDescriptor descriptor = {});
     void signal(GPUFence fence, unsigned long long signalValue);


### PR DESCRIPTION
We decided to replace setVertexBuffers with setVertexBuffer.
Perhaps it's worth considering the same for other sequences.

(The outstanding one is setBindGroup, which is harder.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/467.html" title="Last updated on Oct 9, 2019, 2:54 AM UTC (bdf881e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/467/e0f468a...kainino0x:bdf881e.html" title="Last updated on Oct 9, 2019, 2:54 AM UTC (bdf881e)">Diff</a>