### PR TITLE
Change setVertexBuffers to setVertexBuffer

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1535,8 +1535,7 @@ interface mixin GPURenderEncoderBase {
     void setPipeline(GPURenderPipeline pipeline);
 
     void setIndexBuffer(GPUBuffer buffer, optional GPUBufferSize offset = 0);
-    void setVertexBuffers(unsigned long startSlot,
-                          sequence<GPUBuffer> buffers, sequence<GPUBufferSize> offsets);
+    void setVertexBuffer(unsigned long slot, GPUBuffer buffer, optional GPUBufferSize offset = 0);
 
     void draw(unsigned long vertexCount, unsigned long instanceCount,
               unsigned long firstVertex, unsigned long firstInstance);


### PR DESCRIPTION
We determined in #421 that setVertexBuffer is both more ergonomic and more
performant for JavaScript bindings.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/austinEng/gpuweb/pull/468.html" title="Last updated on Oct 9, 2019, 5:15 AM UTC (1512682)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/468/90fa9df...austinEng:1512682.html" title="Last updated on Oct 9, 2019, 5:15 AM UTC (1512682)">Diff</a>