### PR TITLE
Vertex input: description, mental model, naming

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1330,28 +1330,41 @@ enum GPUInputStepMode {
 </script>
 
 <script type=idl>
-dictionary GPUVertexAttributeDescriptor {
-    GPUBufferSize offset = 0;
-    required GPUVertexFormat format;
-    required unsigned long shaderLocation;
-};
-</script>
-
-<script type=idl>
-dictionary GPUVertexBufferDescriptor {
-    required GPUBufferSize stride;
-    GPUInputStepMode stepMode = "vertex";
-    required sequence<GPUVertexAttributeDescriptor> attributeSet;
-};
-</script>
-
-<script type=idl>
 dictionary GPUVertexInputDescriptor {
     GPUIndexFormat indexFormat = "uint32";
     sequence<GPUVertexBufferDescriptor?> vertexBuffers = [];
 };
 </script>
 
+A <dfn dfn>vertex buffer</dfn> is a view into buffer memory as an *array of structures*.
+{{GPUVertexBufferDescriptor/elementStride}} is the stride, in bytes, between *elements* of the array.
+Each element of a vertex buffer is a *structure* whose memory layout is defined by
+{{GPUVertexBufferDescriptor/structure}}, which describes the *members* of the structure.
+
+Each {{GPUVertexStructureMemberDescriptor}} describes its
+{{GPUVertexStructureMemberDescriptor/format}} and its
+{{GPUVertexStructureMemberDescriptor/offset}}, in bytes, within the structure.
+
+When used in a vertex shader, members are accessed by their *location*,
+which is specified by {{GPUVertexStructureMemberDescriptor/shaderLocation}}.
+All of the locations must be unique within the {{GPUVertexInputDescriptor}}.
+
+<script type=idl>
+dictionary GPUVertexBufferDescriptor {
+    required GPUBufferSize elementStride;
+    GPUInputStepMode stepMode = "vertex";
+    required sequence<GPUVertexStructureMemberDescriptor> structure;
+};
+</script>
+
+<script type=idl>
+dictionary GPUVertexStructureMemberDescriptor {
+    required GPUVertexFormat format;
+    required GPUBufferSize offset;
+
+    required unsigned long shaderLocation;
+};
+</script>
 
 Command Buffers {#command-buffers}
 ==================================

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1475,29 +1475,29 @@ dictionary GPUVertexInputDescriptor {
 };
 </script>
 
-A <dfn dfn>vertex buffer</dfn> is a view into buffer memory as an *array of structures*.
-{{GPUVertexBufferDescriptor/arrayStride}} is the stride, in bytes, between *elements* of the array.
-Each element of a vertex buffer is a *structure* whose memory layout is defined by
-{{GPUVertexBufferDescriptor/structMembers}}, which describes the *members* of the structure.
+A <dfn dfn>vertex buffer</dfn> is, conceptually, a view into buffer memory as an *array of structures*.
+{{GPUVertexBufferDescriptor/arrayStride}} is the stride, in bytes, between *elements* of that array.
+Each element of a vertex buffer is like a *structure* whose memory layout is defined by
+{{GPUVertexBufferDescriptor/attributes}}, which describes the *members* of the structure.
 
-Each {{GPUVertexStructureMemberDescriptor}} describes its
-{{GPUVertexStructureMemberDescriptor/format}} and its
-{{GPUVertexStructureMemberDescriptor/offset}}, in bytes, within the structure.
+Each {{GPUVertexAttributeDescriptor}} describes its
+{{GPUVertexAttributeDescriptor/format}} and its
+{{GPUVertexAttributeDescriptor/offset}}, in bytes, within the structure.
 
-When used in a vertex shader, members are accessed by their *location*,
-which is specified by {{GPUVertexStructureMemberDescriptor/shaderLocation}}.
+Each attribute appears as a separate input in a vertex shader, each bound by *location*,
+which is specified by {{GPUVertexAttributeDescriptor/shaderLocation}}.
 All of the locations must be unique within the {{GPUVertexInputDescriptor}}.
 
 <script type=idl>
 dictionary GPUVertexBufferDescriptor {
     required GPUBufferSize arrayStride;
     GPUInputStepMode stepMode = "vertex";
-    required sequence<GPUVertexStructureMemberDescriptor> structMembers;
+    required sequence<GPUVertexAttributeDescriptor> attributes;
 };
 </script>
 
 <script type=idl>
-dictionary GPUVertexStructureMemberDescriptor {
+dictionary GPUVertexAttributeDescriptor {
     required GPUVertexFormat format;
     required GPUBufferSize offset;
 
@@ -1945,3 +1945,5 @@ partial interface GPUDevice {
 Eventually all of these should disappear but they are useful to avoid warning while building the specification.
 
 [=buffer state/mapped=] [=buffer state/destroyed=]
+
+[=vertex buffer=]

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1248,7 +1248,7 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
     GPURasterizationStateDescriptor rasterizationState = {};
     required sequence<GPUColorStateDescriptor> colorStates;
     GPUDepthStencilStateDescriptor depthStencilState;
-    GPUVertexInputDescriptor vertexInput = {};
+    GPUVertexStateDescriptor vertexState = {};
 
     unsigned long sampleCount = 1;
     unsigned long sampleMask = 0xFFFFFFFF;
@@ -1399,7 +1399,7 @@ dictionary GPUStencilStateFaceDescriptor {
 };
 </script>
 
-### Vertex Input ### {#vertex-input}
+### Vertex State ### {#vertex-state}
 
 <script type=idl>
 enum GPUIndexFormat {
@@ -1469,16 +1469,16 @@ enum GPUInputStepMode {
 </script>
 
 <script type=idl>
-dictionary GPUVertexInputDescriptor {
+dictionary GPUVertexStateDescriptor {
     GPUIndexFormat indexFormat = "uint32";
-    sequence<GPUVertexBufferDescriptor?> vertexBuffers = [];
+    sequence<GPUVertexBufferLayoutDescriptor?> vertexBuffers = [];
 };
 </script>
 
 A <dfn dfn>vertex buffer</dfn> is, conceptually, a view into buffer memory as an *array of structures*.
-{{GPUVertexBufferDescriptor/arrayStride}} is the stride, in bytes, between *elements* of that array.
-Each element of a vertex buffer is like a *structure* whose memory layout is defined by
-{{GPUVertexBufferDescriptor/attributes}}, which describes the *members* of the structure.
+{{GPUVertexBufferLayoutDescriptor/arrayStride}} is the stride, in bytes, between *elements* of that array.
+Each element of a vertex buffer is like a *structure* with a memory layout defined by its
+{{GPUVertexBufferLayoutDescriptor/attributes}}, which describe the *members* of the structure.
 
 Each {{GPUVertexAttributeDescriptor}} describes its
 {{GPUVertexAttributeDescriptor/format}} and its
@@ -1486,10 +1486,10 @@ Each {{GPUVertexAttributeDescriptor}} describes its
 
 Each attribute appears as a separate input in a vertex shader, each bound by *location*,
 which is specified by {{GPUVertexAttributeDescriptor/shaderLocation}}.
-All of the locations must be unique within the {{GPUVertexInputDescriptor}}.
+All of the locations must be unique within the {{GPUVertexStateDescriptor}}.
 
 <script type=idl>
-dictionary GPUVertexBufferDescriptor {
+dictionary GPUVertexBufferLayoutDescriptor {
     required GPUBufferSize arrayStride;
     GPUInputStepMode stepMode = "vertex";
     required sequence<GPUVertexAttributeDescriptor> attributes;

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1337,9 +1337,9 @@ dictionary GPUVertexInputDescriptor {
 </script>
 
 A <dfn dfn>vertex buffer</dfn> is a view into buffer memory as an *array of structures*.
-{{GPUVertexBufferDescriptor/elementStride}} is the stride, in bytes, between *elements* of the array.
+{{GPUVertexBufferDescriptor/arrayStride}} is the stride, in bytes, between *elements* of the array.
 Each element of a vertex buffer is a *structure* whose memory layout is defined by
-{{GPUVertexBufferDescriptor/structure}}, which describes the *members* of the structure.
+{{GPUVertexBufferDescriptor/structMembers}}, which describes the *members* of the structure.
 
 Each {{GPUVertexStructureMemberDescriptor}} describes its
 {{GPUVertexStructureMemberDescriptor/format}} and its
@@ -1351,9 +1351,9 @@ All of the locations must be unique within the {{GPUVertexInputDescriptor}}.
 
 <script type=idl>
 dictionary GPUVertexBufferDescriptor {
-    required GPUBufferSize elementStride;
+    required GPUBufferSize arrayStride;
     GPUInputStepMode stepMode = "vertex";
-    required sequence<GPUVertexStructureMemberDescriptor> structure;
+    required sequence<GPUVertexStructureMemberDescriptor> structMembers;
 };
 </script>
 


### PR DESCRIPTION
I've been struggling with coming up with a mental model for vertex input
ever since we rephrased it in terms of the "push" model. Because we were
talking about vertex pulling recently, in which things can really be
phrased as arrays-of-structures, I realized that was the basis I needed
to make the mental model finally make sense.

The key naming change is that "vertex buffers" no longer contain
"attributes". Instead, they are arrays which contain "structures", and
each structure is defined by a sequence of "members". Those members
*secondarily* specify their shader input location.

I also wrote some text to describe this mental model.

There is also one functional change aside from naming: the attribute
byte offset is no longer optional. I think it's crucial to the mental
modeling that the offset be front-and-center in the vertex structure
definition.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/469.html" title="Last updated on Nov 4, 2019, 11:10 PM UTC (6b24523)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/469/2f9a39e...kainino0x:6b24523.html" title="Last updated on Nov 4, 2019, 11:10 PM UTC (6b24523)">Diff</a>