### PR TITLE
Fix incorrect use of `includes`

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1585,7 +1585,6 @@ interface mixin GPUProgrammablePassEncoder {
     void popDebugGroup();
     void insertDebugMarker(DOMString markerLabel);
 };
-GPUProgrammablePassEncoder includes GPUObjectBase;
 </script>
 
 Debug groups in a {{GPUCommandEncoder}} or {{GPUProgrammablePassEncoder}}
@@ -1604,6 +1603,7 @@ interface GPUComputePassEncoder {
 
     void endPass();
 };
+GPUComputePassEncoder includes GPUObjectBase;
 GPUComputePassEncoder includes GPUProgrammablePassEncoder;
 </script>
 
@@ -1634,7 +1634,6 @@ interface mixin GPURenderEncoderBase {
     void drawIndirect(GPUBuffer indirectBuffer, GPUBufferSize indirectOffset);
     void drawIndexedIndirect(GPUBuffer indirectBuffer, GPUBufferSize indirectOffset);
 };
-GPURenderEncoderBase includes GPUProgrammablePassEncoder;
 
 interface GPURenderPassEncoder {
     void setViewport(float x, float y,
@@ -1649,6 +1648,8 @@ interface GPURenderPassEncoder {
     void executeBundles(sequence<GPURenderBundle> bundles);
     void endPass();
 };
+GPURenderPassEncoder includes GPUObjectBase;
+GPURenderPassEncoder includes GPUProgrammablePassEncoder;
 GPURenderPassEncoder includes GPURenderEncoderBase;
 </script>
 
@@ -1745,6 +1746,8 @@ dictionary GPURenderBundleDescriptor : GPUObjectDescriptorBase {
 interface GPURenderBundleEncoder {
     GPURenderBundle finish(optional GPURenderBundleDescriptor descriptor = {});
 };
+GPURenderBundleEncoder includes GPUObjectBase;
+GPURenderBundleEncoder includes GPUProgrammablePassEncoder;
 GPURenderBundleEncoder includes GPURenderEncoderBase;
 </script>
 


### PR DESCRIPTION
According to the spec[1], the first identifier of `includes` statement
MUST reference a `interface`. It means that a `interface mixin` cannot
include the other `interface mixin`.

This is a fix-up PR for #459, and discovered from Chromium implementation[2].

[1] https://heycam.github.io/webidl/#includes-statement
[2] https://chromium-review.googlesource.com/c/chromium/src/+/1856618


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/romandev/gpuweb/pull/470.html" title="Last updated on Oct 12, 2019, 6:18 PM UTC (a394945)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/470/ed23b0e...romandev:a394945.html" title="Last updated on Oct 12, 2019, 6:18 PM UTC (a394945)">Diff</a>