### PR TITLE
Initial spec text for "navigator.gpu" + small fixes

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -526,11 +526,7 @@ dictionary GPUBindGroupLayoutBinding {
     required u32 binding;
     required GPUShaderStageFlags visibility;
     required GPUBindingType type;
-<<<<<<< HEAD
     GPUTextureViewDimension textureDimension = "2d";
-=======
-    GPUTextureViewDimension textureDimension;
->>>>>>> Add a component type for GPUBGLBinding compatiblity (#384)
     GPUTextureComponentType textureComponentType = "float";
     boolean multisampled = false;
     boolean dynamic = false;

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -250,7 +250,7 @@ Initialization {#initialization}
 ## Examples ## {#initialization-examples}
 
 <div class="example">
-The following code acquires the default {{GPUDevice}}.
+The following code acquires a {{GPUDevice}} in the default configuration, from the default adapter.
 
 <pre highlight="js">
 navigator.gpu.requestAdapter().then(adapter => {

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -247,6 +247,24 @@ dictionary GPUObjectDescriptorBase {
 Initialization {#initialization}
 ================================
 
+## Examples ## {#initialization-examples}
+
+<div class="example">
+The following code acquires the default {{GPUDevice}}.
+
+<pre highlight="js">
+navigator.gpu.requestAdapter().then(adapter => {
+    adapter.requestDevice().then(device => {
+        // Use 'device' as needed.
+    });
+}).catch(error => {
+    // WebGPU is unsupported, or no adapters or devices are available.
+});
+</pre>
+</div>
+
+## navigator.gpu ## {#navigator-gpu}
+
 <script type=idl>
 [Exposed=Window]
 partial interface Navigator {
@@ -259,6 +277,10 @@ partial interface WorkerNavigator {
 };
 </script>
 
+The {{Navigator/gpu}} attribute is used to access a {{GPU}} object from the main thread or a dedicated worker.
+
+## GPU ## {#gpu-interface}
+
 <script type=idl>
 [Exposed=Window]
 interface GPU {
@@ -266,6 +288,8 @@ interface GPU {
     Promise<GPUAdapter> requestAdapter(optional GPURequestAdapterOptions options = {});
 };
 </script>
+
+A {{GPU}} object is the entry point to the WebGPU API. It is used to create [=adapters=].
 
 ## Adapters ## {#adapters}
 
@@ -544,7 +568,7 @@ dictionary GPULimits {
     unsigned long maxDynamicStorageBuffersPerPipelineLayout = 4;
     unsigned long maxSampledTexturesPerShaderStage = 16;
     unsigned long maxSamplersPerShaderStage = 16;
-    unsigned long maxStorageBuffersPerPipelineLayout = 8;
+    unsigned long maxStorageBuffersPerShaderStage = 4;
     unsigned long maxStorageTexturesPerShaderStage = 4;
     unsigned long maxUniformBuffersPerShaderStage = 12;
 };
@@ -621,7 +645,7 @@ dictionary GPUBufferDescriptor : GPUObjectDescriptorBase {
 
                 1. Record a validation error in the current scope.
                 <!-- TODO(kangz): Once we have a description of the error monad, explain what the error buffer is. -->
-                1. Create an error buffer and return the result.
+                1. Create an invalid {{GPUBuffer}} and return the result.
 
             1. Let |b| be a new {{GPUBuffer}} object.
             1. Set the {{GPUBuffer/[[size]]}} slot of |b| to the value of the {{GPUBufferDescriptor/size}} attribute of |descriptor|.
@@ -1066,8 +1090,8 @@ If any of the following conditions are violated:
         fewer |bindingDescriptor|s of type {{GPUBindingType/uniform-buffer}} with {{GPUBindGroupLayoutBinding/hasDynamicOffset}} set to `true` in
         |descriptor| that are visible to any shader stage.
 
-<dfn>storage buffer validation</dfn>: There must be {{GPULimits/maxStorageBuffersPerPipelineLayout|GPULimits.maxStorageBuffersPerPipelineLayout}} or
-    fewer |bindingDescriptor|s of type {{GPUBindingType/storage-buffer}} in |descriptor| that are visible to any shader stage.
+<dfn>storage buffer validation</dfn>: There must be {{GPULimits/maxStorageBuffersPerShaderStage|GPULimits.maxStorageBuffersPerShaderStage}} or
+    fewer |bindingDescriptor|s of type {{GPUBindingType/storage-buffer}} visible on each shader stage in |descriptor|.
 
 <dfn>dynamic storage buffer validation</dfn>: There must be {{GPULimits/maxDynamicStorageBuffersPerPipelineLayout|GPULimits.maxDynamicStorageBuffersPerPipelineLayout}} or
         fewer |bindingDescriptor|s of type {{GPUBindingType/storage-buffer}} with {{GPUBindGroupLayoutBinding/hasDynamicOffset}} set to `true`

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -526,7 +526,11 @@ dictionary GPUBindGroupLayoutBinding {
     required u32 binding;
     required GPUShaderStageFlags visibility;
     required GPUBindingType type;
+<<<<<<< HEAD
     GPUTextureViewDimension textureDimension = "2d";
+=======
+    GPUTextureViewDimension textureDimension;
+>>>>>>> Add a component type for GPUBGLBinding compatiblity (#384)
     GPUTextureComponentType textureComponentType = "float";
     boolean multisampled = false;
     boolean dynamic = false;

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -289,7 +289,8 @@ interface GPU {
 };
 </script>
 
-A {{GPU}} object is the entry point to the WebGPU API. It is used to create [=adapters=].
+<dfn interface>GPU</dfn> defines the interface of `navigator.gpu`, the entry point to WebGPU.
+It exposes {{GPU/requestAdapter()}}, for acquiring [=adapters=].
 
 ## Adapters ## {#adapters}
 


### PR DESCRIPTION
Updates #471.

Unfortunately it's not much; thought this would be more but not sure what else needs to go here.

My intention with the examples is to add more if/when device creation gets more complicated. Does GPUAdapterOptions/"power-preference" need an example in its current state? There isn't a way to query what kind of GPU was provided, since it's just a hint.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JusSn/gpuweb/pull/479.html" title="Last updated on Oct 24, 2019, 12:07 AM UTC (cea74b3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/479/51bc2ff...JusSn:cea74b3.html" title="Last updated on Oct 24, 2019, 12:07 AM UTC (cea74b3)">Diff</a>