### PR TITLE
Add an explainer for GPULimits

### DIFF
--- a/design/Limits.md
+++ b/design/Limits.md
@@ -1,0 +1,29 @@
+# GPULimits Explainer
+
+This document lists the citations for the "limits" in the WebGPU API that decide the minimum capabilities of a compliant WebGPU implementation.
+
+## The GPULimits Dictionary (10/29/19)
+
+```javascript
+dictionary GPULimits {
+    unsigned long maxBindGroups = 4;
+    unsigned long maxDynamicUniformBuffersPerPipelineLayout = 8;
+    unsigned long maxDynamicStorageBuffersPerPipelineLayout = 4;
+    unsigned long maxSampledTexturesPerShaderStage = 16;
+    unsigned long maxSamplersPerShaderStage = 16;
+    unsigned long maxStorageBuffersPerShaderStage = 4;
+    unsigned long maxStorageTexturesPerShaderStage = 4;
+    unsigned long maxUniformBuffersPerShaderStage = 12;
+};
+```
+
+Limit | API Doc | gpuweb issue/PR
+--- | --- | ---
+`maxBindGroups = 4;` | [Vulkan](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#limits-minmax) `maxBoundDescriptorSets` |
+`maxDynamicUniformBuffersPerPipelineLayout = 8;` | [Vulkan](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#limits-minmax) `maxDescriptorSetUniformBuffersDynamic` | [#406](https://github.com/gpuweb/gpuweb/issues/406)
+`maxDynamicStorageBuffersPerPipelineLayout = 4;` | [Vulkan](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#limits-minmax) `maxDescriptorSetStorageBuffersDynamic` | [#406](https://github.com/gpuweb/gpuweb/issues/406)
+`maxSampledTexturesPerShaderStage = 16;` | [Vulkan](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#limits-minmax) `maxPerStageDescriptorSampledImages` | [#409](https://github.com/gpuweb/gpuweb/issues/409)
+`maxSamplersPerShaderStage = 16;` | [Vulkan](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#limits-minmax) `maxPerStageDescriptorSamplers` | [#409](https://github.com/gpuweb/gpuweb/issues/409)
+`maxStorageBuffersPerShaderStage = 4;` | [Vulkan](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#limits-minmax) `maxPerStageDescriptorStorageBuffers` | [#409](https://github.com/gpuweb/gpuweb/issues/409)
+`maxStorageTexturesPerShaderStage = 4;` | [Vulkan](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#limits-minmax) `maxPerStageDescriptorStorageImages` | [#409](https://github.com/gpuweb/gpuweb/issues/409)
+`maxUniformBuffersPerShaderStage = 12;` | [Vulkan](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#limits-minmax) `maxPerStageDescriptorUniformBuffers` | [#409](https://github.com/gpuweb/gpuweb/issues/409)

--- a/design/Limits.md
+++ b/design/Limits.md
@@ -2,7 +2,7 @@
 
 This document lists the citations for the "limits" in the WebGPU API that decide the minimum capabilities of a compliant WebGPU implementation.
 
-## The GPULimits Dictionary (10/29/19)
+## The GPULimits Dictionary (last updated 2019-10-29)
 
 ```javascript
 dictionary GPULimits {

--- a/design/Limits.md
+++ b/design/Limits.md
@@ -19,11 +19,11 @@ dictionary GPULimits {
 
 Limit | API Doc | gpuweb issue/PR
 --- | --- | ---
-`maxBindGroups = 4;` | [Vulkan](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#limits-minmax) `maxBoundDescriptorSets` |
-`maxDynamicUniformBuffersPerPipelineLayout = 8;` | [Vulkan](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#limits-minmax) `maxDescriptorSetUniformBuffersDynamic` | [#406](https://github.com/gpuweb/gpuweb/issues/406)
-`maxDynamicStorageBuffersPerPipelineLayout = 4;` | [Vulkan](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#limits-minmax) `maxDescriptorSetStorageBuffersDynamic` | [#406](https://github.com/gpuweb/gpuweb/issues/406)
-`maxSampledTexturesPerShaderStage = 16;` | [Vulkan](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#limits-minmax) `maxPerStageDescriptorSampledImages` | [#409](https://github.com/gpuweb/gpuweb/issues/409)
-`maxSamplersPerShaderStage = 16;` | [Vulkan](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#limits-minmax) `maxPerStageDescriptorSamplers` | [#409](https://github.com/gpuweb/gpuweb/issues/409)
-`maxStorageBuffersPerShaderStage = 4;` | [Vulkan](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#limits-minmax) `maxPerStageDescriptorStorageBuffers` | [#409](https://github.com/gpuweb/gpuweb/issues/409)
-`maxStorageTexturesPerShaderStage = 4;` | [Vulkan](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#limits-minmax) `maxPerStageDescriptorStorageImages` | [#409](https://github.com/gpuweb/gpuweb/issues/409)
-`maxUniformBuffersPerShaderStage = 12;` | [Vulkan](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#limits-minmax) `maxPerStageDescriptorUniformBuffers` | [#409](https://github.com/gpuweb/gpuweb/issues/409)
+`maxBindGroups = 4;` | [Vulkan](https://vulkan.lunarg.com/doc/view/latest/linux/chunked_spec/chap36.html#limits-required) `maxBoundDescriptorSets` |
+`maxDynamicUniformBuffersPerPipelineLayout = 8;` | [Vulkan](https://vulkan.lunarg.com/doc/view/latest/linux/chunked_spec/chap36.html#limits-required) `maxDescriptorSetUniformBuffersDynamic` | [#406](https://github.com/gpuweb/gpuweb/issues/406)
+`maxDynamicStorageBuffersPerPipelineLayout = 4;` | [Vulkan](https://vulkan.lunarg.com/doc/view/latest/linux/chunked_spec/chap36.html#limits-required) `maxDescriptorSetStorageBuffersDynamic` | [#406](https://github.com/gpuweb/gpuweb/issues/406)
+`maxSampledTexturesPerShaderStage = 16;` | [Vulkan](https://vulkan.lunarg.com/doc/view/latest/linux/chunked_spec/chap36.html#limits-required) `maxPerStageDescriptorSampledImages` | [#409](https://github.com/gpuweb/gpuweb/issues/409)
+`maxSamplersPerShaderStage = 16;` | [Vulkan](https://vulkan.lunarg.com/doc/view/latest/linux/chunked_spec/chap36.html#limits-required) `maxPerStageDescriptorSamplers` | [#409](https://github.com/gpuweb/gpuweb/issues/409)
+`maxStorageBuffersPerShaderStage = 4;` | [Vulkan](https://vulkan.lunarg.com/doc/view/latest/linux/chunked_spec/chap36.html#limits-required) `maxPerStageDescriptorStorageBuffers` | [#409](https://github.com/gpuweb/gpuweb/issues/409)
+`maxStorageTexturesPerShaderStage = 4;` | [Vulkan](https://vulkan.lunarg.com/doc/view/latest/linux/chunked_spec/chap36.html#limits-required) `maxPerStageDescriptorStorageImages` | [#409](https://github.com/gpuweb/gpuweb/issues/409)
+`maxUniformBuffersPerShaderStage = 12;` | [Vulkan](https://vulkan.lunarg.com/doc/view/latest/linux/chunked_spec/chap36.html#limits-required) `maxPerStageDescriptorUniformBuffers` | [#409](https://github.com/gpuweb/gpuweb/issues/409)

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -526,11 +526,7 @@ dictionary GPUBindGroupLayoutBinding {
     required u32 binding;
     required GPUShaderStageFlags visibility;
     required GPUBindingType type;
-<<<<<<< HEAD
     GPUTextureViewDimension textureDimension = "2d";
-=======
-    GPUTextureViewDimension textureDimension;
->>>>>>> Add a component type for GPUBGLBinding compatiblity (#384)
     GPUTextureComponentType textureComponentType = "float";
     boolean multisampled = false;
     boolean dynamic = false;

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -526,7 +526,11 @@ dictionary GPUBindGroupLayoutBinding {
     required u32 binding;
     required GPUShaderStageFlags visibility;
     required GPUBindingType type;
+<<<<<<< HEAD
     GPUTextureViewDimension textureDimension = "2d";
+=======
+    GPUTextureViewDimension textureDimension;
+>>>>>>> Add a component type for GPUBGLBinding compatiblity (#384)
     GPUTextureComponentType textureComponentType = "float";
     boolean multisampled = false;
     boolean dynamic = false;


### PR DESCRIPTION
This explainer will track the rationale behind each WebGPU limit. All queryable restrictions should have a corresponding reason in this doc.

Edit: [Rendered](https://github.com/JusSn/gpuweb/blob/limitsmd/design/Limits.md)