### PR TITLE
Update setBindGroup dynamic offsets to 32 bit

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1604,7 +1604,7 @@ dictionary GPUImageBitmapCopyView {
 <script type=idl>
 interface mixin GPUProgrammablePassEncoder {
     void setBindGroup(unsigned long index, GPUBindGroup bindGroup,
-                      optional sequence<GPUBufferSize> dynamicOffsets = []);
+                      optional sequence<unsigned long> dynamicOffsets = []);
 
     void pushDebugGroup(DOMString groupLabel);
     void popDebugGroup();


### PR DESCRIPTION
Vulkan only has 32 bit dynamic offsets. Resolution at the [New Orleans F2F, Day 2](https://docs.google.com/document/d/1HD-9cKjuQDqOoi5rQ8oLCfuw2AHJR-3BC8IeLziKnuY/edit#heading=h.90e362xvkw7e) was to change these to 32 bit as step 1, and then add an additional Uint32Array overload in #440 as step 2


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/austinEng/gpuweb/pull/485.html" title="Last updated on Nov 1, 2019, 12:49 AM UTC (f6f1ae8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/485/3661602...austinEng:f6f1ae8.html" title="Last updated on Nov 1, 2019, 12:49 AM UTC (f6f1ae8)">Diff</a>