### PR TITLE
Make copyImageBitmapToTexture a GPUQueue operation.

### DIFF
--- a/design/ImageBitmapToTexture.md
+++ b/design/ImageBitmapToTexture.md
@@ -6,7 +6,7 @@ dictionary GPUImageBitmapCopyView {
     GPUOrigin2D origin;
 };
 
-partial interface GPUCommandEncoder {
+partial interface GPUQueue {
     void copyImageBitmapToTexture(
         GPUImageBitmapCopyView source,
         GPUTextureCopyView destination,
@@ -15,14 +15,16 @@ partial interface GPUCommandEncoder {
 };
 ```
 
-`copyImageBitmapToTexture` encodes a copy from a source sub-rectangle of an `ImageBitmap` into a destination sub-resource of a `GPUTexture`.
-When the command buffer is submitted, the `ImageBitmap` must not be detached.
-If it is, a validation error is generated.
+`copyImageBitmapToTexture` submits a copy from a source sub-rectangle of an `ImageBitmap` into a destination sub-resource of a `GPUTexture`.
+The `ImageBitmap` must not be detached, if it is, a validation error is generated.
 
 ## Alternatives Considered
 
   * Creating a `GPUTexture` directly from an `ImageBitmap`, attempting to avoid copies, is impractical because it requires the GPUTexture's format to match the internal representation of the `ImageBitmap`, which is not exposed to the Web platform.
     Additionally, `ImageBitmap`s may be GPU- or CPU-backed, and wrapping a CPU-backed `ImageBitmap` is a significant meta-operation that requires an additional copy to be submitted.
+ * Having `copyImageBitmapToTexture` on `GPUCommandEncoder`: this makes implementations much more complicated because they can't know when the copy will be effectively submitted.
+    It also allows having multiple `copyImageBitmapToTexture` at different sports in the `GPUCommandEncoder` which would require splicing the encoder and keeping track of all the chunks.
+    Realistically copying imagebitmaps will be during loading to copy from <img> elements, or at most a couple times per frame for example to copy a camera frame, so an immediate copy is fine.
 
 ## Issues
 

--- a/design/ImageBitmapToTexture.md
+++ b/design/ImageBitmapToTexture.md
@@ -24,7 +24,7 @@ The `ImageBitmap` must not be detached, if it is, a validation error is generate
     Additionally, `ImageBitmap`s may be GPU- or CPU-backed, and wrapping a CPU-backed `ImageBitmap` is a significant meta-operation that requires an additional copy to be submitted.
  * Having `copyImageBitmapToTexture` on `GPUCommandEncoder`: this makes implementations much more complicated because they can't know when the copy will be effectively submitted.
     It also allows having multiple `copyImageBitmapToTexture` at different sports in the `GPUCommandEncoder` which would require splicing the encoder and keeping track of all the chunks.
-    Realistically copying imagebitmaps will be during loading to copy from <img> elements, or at most a couple times per frame for example to copy a camera frame, so an immediate copy is fine.
+    Realistically, copying `ImageBitmap`s will be during loading to copy from `<img>` elements, or at most a couple times per frame for example to copy a camera frame, so an immediate copy is fine.
 
 ## Issues
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1591,11 +1591,6 @@ interface GPUCommandEncoder {
         GPUTextureCopyView destination,
         GPUExtent3D copySize);
 
-    void copyImageBitmapToTexture(
-        GPUImageBitmapCopyView source,
-        GPUTextureCopyView destination,
-        GPUExtent3D copySize);
-
     void pushDebugGroup(DOMString groupLabel);
     void popDebugGroup();
     void insertDebugMarker(DOMString markerLabel);
@@ -1604,9 +1599,6 @@ interface GPUCommandEncoder {
 };
 GPUCommandEncoder includes GPUObjectBase;
 </script>
-
-  * {{GPUCommandEncoder/copyImageBitmapToTexture()}}:
-      * For now, `copySize.z` must be `1`.
 
 ### Creation ### {#command-encoder-creation}
 
@@ -1849,9 +1841,17 @@ interface GPUQueue {
 
     GPUFence createFence(optional GPUFenceDescriptor descriptor = {});
     void signal(GPUFence fence, unsigned long long signalValue);
+
+    void copyImageBitmapToTexture(
+        GPUImageBitmapCopyView source,
+        GPUTextureCopyView destination,
+        GPUExtent3D copySize);
 };
 GPUQueue includes GPUObjectBase;
 </script>
+
+ - {{GPUQueue/copyImageBitmapToTexture()}}:
+   - For now, `copySize.z` must be `1`.
 
 {{GPUQueue/submit(commandBuffers)}} does nothing and produces an error if any of the following is true:
 


### PR DESCRIPTION
CC @shaoboyan 

In the discussion around immediate data upload we've opened up the idea of having immediate operations on the GPUQueue. Using this for `copyImageBitmapToTexture` would significantly simplify it's implementation with no detriment to the usability of the API.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/488.html" title="Last updated on Nov 7, 2019, 11:20 PM UTC (6df6648)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/488/37812f5...Kangz:6df6648.html" title="Last updated on Nov 7, 2019, 11:20 PM UTC (6df6648)">Diff</a>