### PR TITLE
Expose limits on the adapter

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -328,7 +328,7 @@ and exposes its capabilities (extensions and limits).
 interface GPUAdapter {
     readonly attribute DOMString name;
     readonly attribute object extensions;
-    //readonly attribute GPULimits limits; Don't expose higher limits for now.
+    readonly attribute object limits;
 
     // May reject with DOMException  // TODO: DOMException("OperationError")?
     Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor = {});
@@ -354,6 +354,11 @@ interface GPUAdapter {
             not by the [=adapter=], it will be `false`.
           - If an extension is supported by the user agent and
             by the [=adapter=], it will be `true`.
+
+    : <dfn>limits</dfn>
+    ::
+        A {{GPULimits}} object which exposes the maximum limits supported
+        by the adapter.
 </dl>
 
 {{GPUAdapter}} also has the following internal slots:


### PR DESCRIPTION
There's no reason to leave this out anymore.
Implementations can implement it whenever they want.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/489.html" title="Last updated on Nov 6, 2019, 9:17 PM UTC (5b7c1fe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/489/37812f5...kainino0x:5b7c1fe.html" title="Last updated on Nov 6, 2019, 9:17 PM UTC (5b7c1fe)">Diff</a>