### PR TITLE
Change .getQueue() to .defaultQueue

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -470,7 +470,7 @@ interface GPUDevice : EventTarget {
     readonly attribute object extensions;
     readonly attribute object limits;
 
-    readonly attribute GPUQueue defaultQueue;
+    [SameObject] readonly attribute GPUQueue defaultQueue;
 
     GPUBuffer createBuffer(GPUBufferDescriptor descriptor);
     GPUMappedBuffer createBufferMapped(GPUBufferDescriptor descriptor);

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -470,6 +470,8 @@ interface GPUDevice : EventTarget {
     readonly attribute object extensions;
     readonly attribute object limits;
 
+    readonly attribute GPUQueue defaultQueue;
+
     GPUBuffer createBuffer(GPUBufferDescriptor descriptor);
     GPUMappedBuffer createBufferMapped(GPUBufferDescriptor descriptor);
     Promise<GPUMappedBuffer> createBufferMappedAsync(GPUBufferDescriptor descriptor);
@@ -486,8 +488,6 @@ interface GPUDevice : EventTarget {
 
     GPUCommandEncoder createCommandEncoder(optional GPUCommandEncoderDescriptor descriptor = {});
     GPURenderBundleEncoder createRenderBundleEncoder(GPURenderBundleEncoderDescriptor descriptor);
-
-    GPUQueue getQueue();
 };
 GPUDevice includes GPUObjectBase;
 </script>


### PR DESCRIPTION
It's expected that we'll add multi-queue support to WebGPU. To prepare
for this, rename getQueue to getDefaultQueue under the assumption
(/recommendation) that adding multi-queue should be a non-breaking
addition to the API. This change should make the current API safe for
the multi-queue future.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/490.html" title="Last updated on Nov 12, 2019, 3:19 PM UTC (8688ee4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/490/37812f5...kainino0x:8688ee4.html" title="Last updated on Nov 12, 2019, 3:19 PM UTC (8688ee4)">Diff</a>