### PR TITLE
Revert "Expose limits on the adapter"

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -328,7 +328,7 @@ and exposes its capabilities (extensions and limits).
 interface GPUAdapter {
     readonly attribute DOMString name;
     readonly attribute object extensions;
-    readonly attribute object limits;
+    //readonly attribute GPULimits limits; Don't expose higher limits for now.
 
     // May reject with DOMException  // TODO: DOMException("OperationError")?
     Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor = {});
@@ -354,11 +354,6 @@ interface GPUAdapter {
             not by the [=adapter=], it will be `false`.
           - If an extension is supported by the user agent and
             by the [=adapter=], it will be `true`.
-
-    : <dfn>limits</dfn>
-    ::
-        A {{GPULimits}} object which exposes the maximum limits supported
-        by the adapter.
 </dl>
 
 {{GPUAdapter}} also has the following internal slots:


### PR DESCRIPTION
Reverts gpuweb/gpuweb#489

Corentin says this is okay: https://lists.w3.org/Archives/Member/internal-gpu/2019Nov/0008.html


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/494.html" title="Last updated on Nov 11, 2019, 9:48 PM UTC (05fa293)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/494/e597343...05fa293.html" title="Last updated on Nov 11, 2019, 9:48 PM UTC (05fa293)">Diff</a>