### PR TITLE
Add [SameObject] to several more attributes.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -466,7 +466,7 @@ It is the top-level object through which [=WebGPU interfaces=] are created.
 <script type=idl>
 [Exposed=(Window, Worker), Serializable]
 interface GPUDevice : EventTarget {
-    readonly attribute GPUAdapter adapter;
+    [SameObject] readonly attribute GPUAdapter adapter;
     readonly attribute object extensions;
     readonly attribute object limits;
 
@@ -1920,7 +1920,7 @@ interface GPUDeviceLostInfo {
 };
 
 partial interface GPUDevice {
-    readonly attribute Promise<GPUDeviceLostInfo> lost;
+    [SameObject] readonly attribute Promise<GPUDeviceLostInfo> lost;
 };
 </script>
 
@@ -1969,7 +1969,7 @@ interface GPUUncapturedErrorEvent : Event {
         DOMString type,
         GPUUncapturedErrorEventInit gpuUncapturedErrorEventInitDict
     );
-    readonly attribute GPUError error;
+    [SameObject] readonly attribute GPUError error;
 };
 
 dictionary GPUUncapturedErrorEventInit : EventInit {


### PR DESCRIPTION
Adds `[SameObject]` to the following attributes:

- `GPUAdapter` `GPUDevice.adapter`
- `Promise<GPUDeviceLostInfo>` `GPUDevice.lost`
- `GPUError` `GPUUncapturedErrorEvent.error`

In addition to these which already had it:

- `GPUQueue` `GPUDevice.defaultQueue`
- `GPU` `Navigator.gpu`
- `GPU` `WorkerNavigator.gpu`

Perhaps more important is which objects are *not* marked as `[SameObject]`:

- `string` `GPUAdapter.name`
- `string` `GPUDeviceLostInfo.message`
- `string` `GPUValidationError.message`
- `object` `GPUAdapter.extensions`
- `object` `GPUAdapter.limits` (when it exists)
- `object` `GPUDevice.extensions`
- `object` `GPUDevice.limits`

which means any additional properties added to these objects may not be
preserved.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/496.html" title="Last updated on Nov 12, 2019, 3:31 PM UTC (3be7d9a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/496/6dfbcec...kainino0x:3be7d9a.html" title="Last updated on Nov 12, 2019, 3:31 PM UTC (3be7d9a)">Diff</a>