### PR TITLE
Add [EnforceRange] to all integers

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1708,9 +1708,9 @@ interface mixin GPURenderEncoderBase {
     void setVertexBuffer(GPUIndex32 slot, GPUBuffer buffer, optional GPUBufferSize offset = 0);
 
     void draw(GPUSize32 vertexCount, GPUSize32 instanceCount,
-              GPUIndex32 firstVertex, GPUIndex32 firstInstance);
+              GPUSize32 firstVertex, GPUSize32 firstInstance);
     void drawIndexed(GPUSize32 indexCount, GPUSize32 instanceCount,
-                     GPUIndex32 firstIndex, GPUSignedOffset32 baseVertex, GPUIndex32 firstInstance);
+                     GPUSize32 firstIndex, GPUSignedOffset32 baseVertex, GPUSize32 firstInstance);
 
     void drawIndirect(GPUBuffer indirectBuffer, GPUBufferSize indirectOffset);
     void drawIndexedIndirect(GPUBuffer indirectBuffer, GPUBufferSize indirectOffset);

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -158,7 +158,10 @@ Type Definitions {#type-definitions}
 ============================
 
 <script type=idl>
-typedef unsigned long long GPUBufferSize;
+typedef [EnforceRange] unsigned long long GPUBufferSize;
+typedef [EnforceRange] unsigned long long enforced_u64;
+typedef [EnforceRange] unsigned long enforced_u32;
+typedef [EnforceRange] long enforced_i32;
 </script>
 
 ## Colors and Vectors ## {#colors-and-vectors}
@@ -178,28 +181,28 @@ integers and single-precision floats.
 
 <script type=idl>
 dictionary GPUOrigin2DDict {
-    unsigned long x = 0;
-    unsigned long y = 0;
+    enforced_u32 x = 0;
+    enforced_u32 y = 0;
 };
-typedef (sequence<unsigned long> or GPUOrigin2DDict) GPUOrigin2D;
+typedef (sequence<enforced_u32> or GPUOrigin2DDict) GPUOrigin2D;
 </script>
 
 <script type=idl>
 dictionary GPUOrigin3DDict {
-    unsigned long x = 0;
-    unsigned long y = 0;
-    unsigned long z = 0;
+    enforced_u32 x = 0;
+    enforced_u32 y = 0;
+    enforced_u32 z = 0;
 };
-typedef (sequence<unsigned long> or GPUOrigin3DDict) GPUOrigin3D;
+typedef (sequence<enforced_u32> or GPUOrigin3DDict) GPUOrigin3D;
 </script>
 
 <script type=idl>
 dictionary GPUExtent3DDict {
-    required unsigned long width;
-    required unsigned long height;
-    required unsigned long depth;
+    required enforced_u32 width;
+    required enforced_u32 height;
+    required enforced_u32 depth;
 };
-typedef (sequence<unsigned long> or GPUExtent3DDict) GPUExtent3D;
+typedef (sequence<enforced_u32> or GPUExtent3DDict) GPUExtent3D;
 </script>
 
 <script type=idl>
@@ -571,14 +574,14 @@ dictionary GPUExtensions {
 
 <script type=idl>
 dictionary GPULimits {
-    unsigned long maxBindGroups = 4;
-    unsigned long maxDynamicUniformBuffersPerPipelineLayout = 8;
-    unsigned long maxDynamicStorageBuffersPerPipelineLayout = 4;
-    unsigned long maxSampledTexturesPerShaderStage = 16;
-    unsigned long maxSamplersPerShaderStage = 16;
-    unsigned long maxStorageBuffersPerShaderStage = 4;
-    unsigned long maxStorageTexturesPerShaderStage = 4;
-    unsigned long maxUniformBuffersPerShaderStage = 12;
+    enforced_u32 maxBindGroups = 4;
+    enforced_u32 maxDynamicUniformBuffersPerPipelineLayout = 8;
+    enforced_u32 maxDynamicStorageBuffersPerPipelineLayout = 4;
+    enforced_u32 maxSampledTexturesPerShaderStage = 16;
+    enforced_u32 maxSamplersPerShaderStage = 16;
+    enforced_u32 maxStorageBuffersPerShaderStage = 4;
+    enforced_u32 maxStorageTexturesPerShaderStage = 4;
+    enforced_u32 maxUniformBuffersPerShaderStage = 12;
 };
 </script>
 
@@ -712,7 +715,7 @@ Note: This allows the user agent to reclaim the GPU memory associated with the {
 ## Buffer Usage ## {#buffer-usage}
 
 <script type=idl>
-typedef unsigned long GPUBufferUsageFlags;
+typedef enforced_u32 GPUBufferUsageFlags;
 interface GPUBufferUsage {
     const GPUBufferUsageFlags MAP_READ  = 0x0001;
     const GPUBufferUsageFlags MAP_WRITE = 0x0002;
@@ -748,9 +751,9 @@ GPUTexture includes GPUObjectBase;
 <script type=idl>
 dictionary GPUTextureDescriptor : GPUObjectDescriptorBase {
     required GPUExtent3D size;
-    unsigned long arrayLayerCount = 1;
-    unsigned long mipLevelCount = 1;
-    unsigned long sampleCount = 1;
+    enforced_u32 arrayLayerCount = 1;
+    enforced_u32 mipLevelCount = 1;
+    enforced_u32 sampleCount = 1;
     GPUTextureDimension dimension = "2d";
     required GPUTextureFormat format;
     required GPUTextureUsageFlags usage;
@@ -766,7 +769,7 @@ enum GPUTextureDimension {
 </script>
 
 <script type=idl>
-typedef unsigned long GPUTextureUsageFlags;
+typedef enforced_u32 GPUTextureUsageFlags;
 interface GPUTextureUsage {
     const GPUTextureUsageFlags COPY_SRC          = 0x01;
     const GPUTextureUsageFlags COPY_DST          = 0x02;
@@ -791,10 +794,10 @@ dictionary GPUTextureViewDescriptor : GPUObjectDescriptorBase {
     GPUTextureFormat format;
     GPUTextureViewDimension dimension;
     GPUTextureAspect aspect = "all";
-    unsigned long baseMipLevel = 0;
-    unsigned long mipLevelCount = 0;
-    unsigned long baseArrayLayer = 0;
-    unsigned long arrayLayerCount = 0;
+    enforced_u32 baseMipLevel = 0;
+    enforced_u32 mipLevelCount = 0;
+    enforced_u32 baseArrayLayer = 0;
+    enforced_u32 arrayLayerCount = 0;
 };
 </script>
 
@@ -1020,7 +1023,7 @@ A {{GPUBindGroupLayoutBinding}} describes a single shader resource binding to be
 
 <script type=idl>
 dictionary GPUBindGroupLayoutBinding {
-    required unsigned long binding;
+    required enforced_u32 binding;
     required GPUShaderStageFlags visibility;
     required GPUBindingType type;
     GPUTextureViewDimension textureDimension = "2d";
@@ -1038,7 +1041,7 @@ dictionary GPUBindGroupLayoutBinding {
     associated shader stage.
 
 <script type=idl>
-typedef unsigned long GPUShaderStageFlags;
+typedef enforced_u32 GPUShaderStageFlags;
 interface GPUShaderStage {
     const GPUShaderStageFlags VERTEX   = 0x1;
     const GPUShaderStageFlags FRAGMENT = 0x2;
@@ -1166,7 +1169,7 @@ dictionary GPUBindGroupDescriptor : GPUObjectDescriptorBase {
 typedef (GPUSampler or GPUTextureView or GPUBufferBinding) GPUBindingResource;
 
 dictionary GPUBindGroupBinding {
-    required unsigned long binding;
+    required enforced_u32 binding;
     required GPUBindingResource resource;
 };
 </script>
@@ -1285,8 +1288,8 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
     GPUDepthStencilStateDescriptor depthStencilState;
     GPUVertexStateDescriptor vertexState = {};
 
-    unsigned long sampleCount = 1;
-    unsigned long sampleMask = 0xFFFFFFFF;
+    enforced_u32 sampleCount = 1;
+    enforced_u32 sampleMask = 0xFFFFFFFF;
     boolean alphaToCoverageEnabled = false;
     // TODO: other properties
 };
@@ -1313,7 +1316,7 @@ dictionary GPURasterizationStateDescriptor {
     GPUFrontFace frontFace = "ccw";
     GPUCullMode cullMode = "none";
 
-    long depthBias = 0;
+    enforced_i32 depthBias = 0;
     float depthBiasSlopeScale = 0;
     float depthBiasClamp = 0;
 };
@@ -1347,7 +1350,7 @@ dictionary GPUColorStateDescriptor {
 </script>
 
 <script type=idl>
-typedef unsigned long GPUColorWriteFlags;
+typedef enforced_u32 GPUColorWriteFlags;
 interface GPUColorWrite {
     const GPUColorWriteFlags RED   = 0x1;
     const GPUColorWriteFlags GREEN = 0x2;
@@ -1420,8 +1423,8 @@ dictionary GPUDepthStencilStateDescriptor {
     GPUStencilStateFaceDescriptor stencilFront = {};
     GPUStencilStateFaceDescriptor stencilBack = {};
 
-    unsigned long stencilReadMask = 0xFFFFFFFF;
-    unsigned long stencilWriteMask = 0xFFFFFFFF;
+    enforced_u32 stencilReadMask = 0xFFFFFFFF;
+    enforced_u32 stencilWriteMask = 0xFFFFFFFF;
 };
 </script>
 
@@ -1536,7 +1539,7 @@ dictionary GPUVertexAttributeDescriptor {
     required GPUVertexFormat format;
     required GPUBufferSize offset;
 
-    required unsigned long shaderLocation;
+    required enforced_u32 shaderLocation;
 };
 </script>
 
@@ -1614,16 +1617,16 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 dictionary GPUBufferCopyView {
     required GPUBuffer buffer;
     GPUBufferSize offset = 0;
-    required unsigned long rowPitch;
-    required unsigned long imageHeight;
+    required enforced_u32 rowPitch;
+    required enforced_u32 imageHeight;
 };
 </script>
 
 <script type=idl>
 dictionary GPUTextureCopyView {
     required GPUTexture texture;
-    unsigned long mipLevel = 0;
-    unsigned long arrayLayer = 0;
+    enforced_u32 mipLevel = 0;
+    enforced_u32 arrayLayer = 0;
     GPUOrigin3D origin = {};
 };
 </script>
@@ -1643,13 +1646,13 @@ dictionary GPUImageBitmapCopyView {
 
 <script type=idl>
 interface mixin GPUProgrammablePassEncoder {
-    void setBindGroup(unsigned long index, GPUBindGroup bindGroup,
-                      optional sequence<unsigned long> dynamicOffsets = []);
+    void setBindGroup(enforced_u32 index, GPUBindGroup bindGroup,
+                      optional sequence<enforced_u32> dynamicOffsets = []);
 
-    void setBindGroup(unsigned long index, GPUBindGroup bindGroup,
+    void setBindGroup(enforced_u32 index, GPUBindGroup bindGroup,
                       Uint32Array dynamicOffsetsData,
-                      unsigned long long dynamicOffsetsDataStart,
-                      unsigned long long dynamicOffsetsDataLength);
+                      enforced_u64 dynamicOffsetsDataStart,
+                      enforced_u64 dynamicOffsetsDataLength);
 
     void pushDebugGroup(DOMString groupLabel);
     void popDebugGroup();
@@ -1668,7 +1671,7 @@ Compute Passes {#compute-passes}
 <script type=idl>
 interface GPUComputePassEncoder {
     void setPipeline(GPUComputePipeline pipeline);
-    void dispatch(unsigned long x, optional unsigned long y = 1, optional unsigned long z = 1);
+    void dispatch(enforced_u32 x, optional enforced_u32 y = 1, optional enforced_u32 z = 1);
     void dispatchIndirect(GPUBuffer indirectBuffer, GPUBufferSize indirectOffset);
 
     void endPass();
@@ -1694,12 +1697,12 @@ interface mixin GPURenderEncoderBase {
     void setPipeline(GPURenderPipeline pipeline);
 
     void setIndexBuffer(GPUBuffer buffer, optional GPUBufferSize offset = 0);
-    void setVertexBuffer(unsigned long slot, GPUBuffer buffer, optional GPUBufferSize offset = 0);
+    void setVertexBuffer(enforced_u32 slot, GPUBuffer buffer, optional GPUBufferSize offset = 0);
 
-    void draw(unsigned long vertexCount, unsigned long instanceCount,
-              unsigned long firstVertex, unsigned long firstInstance);
-    void drawIndexed(unsigned long indexCount, unsigned long instanceCount,
-                     unsigned long firstIndex, long baseVertex, unsigned long firstInstance);
+    void draw(enforced_u32 vertexCount, enforced_u32 instanceCount,
+              enforced_u32 firstVertex, enforced_u32 firstInstance);
+    void drawIndexed(enforced_u32 indexCount, enforced_u32 instanceCount,
+                     enforced_u32 firstIndex, enforced_i32 baseVertex, enforced_u32 firstInstance);
 
     void drawIndirect(GPUBuffer indirectBuffer, GPUBufferSize indirectOffset);
     void drawIndexedIndirect(GPUBuffer indirectBuffer, GPUBufferSize indirectOffset);
@@ -1710,10 +1713,10 @@ interface GPURenderPassEncoder {
                      float width, float height,
                      float minDepth, float maxDepth);
 
-    void setScissorRect(unsigned long x, unsigned long y, unsigned long width, unsigned long height);
+    void setScissorRect(enforced_u32 x, enforced_u32 y, enforced_u32 width, enforced_u32 height);
 
     void setBlendColor(GPUColor color);
-    void setStencilReference(unsigned long reference);
+    void setStencilReference(enforced_u32 reference);
 
     void executeBundles(sequence<GPURenderBundle> bundles);
     void endPass();
@@ -1773,7 +1776,7 @@ dictionary GPURenderPassDepthStencilAttachmentDescriptor {
     required (GPULoadOp or float) depthLoadValue;
     required GPUStoreOp depthStoreOp;
 
-    required (GPULoadOp or unsigned long) stencilLoadValue;
+    required (GPULoadOp or enforced_u32) stencilLoadValue;
     required GPUStoreOp stencilStoreOp;
 };
 </script>
@@ -1827,7 +1830,7 @@ GPURenderBundleEncoder includes GPURenderEncoderBase;
 dictionary GPURenderBundleEncoderDescriptor : GPUObjectDescriptorBase {
     required sequence<GPUTextureFormat> colorFormats;
     GPUTextureFormat depthStencilFormat;
-    unsigned long sampleCount = 1;
+    enforced_u32 sampleCount = 1;
 };
 </script>
 
@@ -1840,7 +1843,7 @@ interface GPUQueue {
     void submit(sequence<GPUCommandBuffer> commandBuffers);
 
     GPUFence createFence(optional GPUFenceDescriptor descriptor = {});
-    void signal(GPUFence fence, unsigned long long signalValue);
+    void signal(GPUFence fence, enforced_u64 signalValue);
 
     void copyImageBitmapToTexture(
         GPUImageBitmapCopyView source,
@@ -1861,8 +1864,8 @@ GPUQueue includes GPUObjectBase;
 
 <script type=idl>
 interface GPUFence {
-    unsigned long long getCompletedValue();
-    Promise<void> onCompletion(unsigned long long completionValue);
+    enforced_u64 getCompletedValue();
+    Promise<void> onCompletion(enforced_u64 completionValue);
 };
 GPUFence includes GPUObjectBase;
 </script>
@@ -1871,7 +1874,7 @@ GPUFence includes GPUObjectBase;
 
 <script type=idl>
 dictionary GPUFenceDescriptor : GPUObjectDescriptorBase {
-    unsigned long long initialValue = 0;
+    enforced_u64 initialValue = 0;
 };
 </script>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -995,7 +995,7 @@ GPUBuffer includes GPUObjectBase;
 {{GPUBuffer}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUBuffer">
-    : <dfn>\[[size]]</dfn> of type {{GPUBufferSize}}.
+    : <dfn>\[[size]]</dfn> of type {{GPUSize64}}.
     ::
         The length of the {{GPUBuffer}} allocation in bytes.
 
@@ -1057,7 +1057,7 @@ This specifies the options to use in creating a {{GPUBuffer}}.
 
 <script type=idl>
 dictionary GPUBufferDescriptor : GPUObjectDescriptorBase {
-    required GPUBufferSize size;
+    required GPUSize64 size;
     required GPUBufferUsageFlags usage;
 };
 </script>
@@ -1726,8 +1726,8 @@ dictionary GPUBindGroupBinding {
 <script type=idl>
 dictionary GPUBufferBinding {
     required GPUBuffer buffer;
-    GPUBufferSize offset = 0;
-    GPUBufferSize size;
+    GPUSize64 offset = 0;
+    GPUSize64 size;
 };
 </script>
 
@@ -2169,7 +2169,7 @@ Every location must be unique within the {{GPUVertexStateDescriptor}}.
 
 <script type=idl>
 dictionary GPUVertexBufferLayoutDescriptor {
-    required GPUBufferSize arrayStride;
+    required GPUSize64 arrayStride;
     GPUInputStepMode stepMode = "vertex";
     required sequence<GPUVertexAttributeDescriptor> attributes;
 };
@@ -2178,7 +2178,7 @@ dictionary GPUVertexBufferLayoutDescriptor {
 <script type=idl>
 dictionary GPUVertexAttributeDescriptor {
     required GPUVertexFormat format;
-    required GPUBufferSize offset;
+    required GPUSize64 offset;
 
     required GPUIndex32 shaderLocation;
 };
@@ -2215,10 +2215,10 @@ interface GPUCommandEncoder {
 
     void copyBufferToBuffer(
         GPUBuffer source,
-        GPUBufferSize sourceOffset,
+        GPUSize64 sourceOffset,
         GPUBuffer destination,
-        GPUBufferSize destinationOffset,
-        GPUBufferSize size);
+        GPUSize64 destinationOffset,
+        GPUSize64 size);
 
     void copyBufferToTexture(
         GPUBufferCopyView source,
@@ -2257,9 +2257,9 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 <script type=idl>
 dictionary GPUBufferCopyView {
     required GPUBuffer buffer;
-    GPUBufferSize offset = 0;
-    required GPUIntegerCoordinate rowPitch;
-    required GPUIntegerCoordinate imageHeight;
+    GPUSize64 offset = 0;
+    required GPUSize32 rowPitch;
+    required GPUSize32 imageHeight;
 };
 </script>
 
@@ -2293,8 +2293,8 @@ interface mixin GPUProgrammablePassEncoder {
 
     void setBindGroup(GPUIndex32 index, GPUBindGroup bindGroup,
                       Uint32Array dynamicOffsetsData,
-                      GPUBufferSize dynamicOffsetsDataStart,
-                      GPUBufferSize dynamicOffsetsDataLength);
+                      GPUSize64 dynamicOffsetsDataStart,
+                      GPUSize64 dynamicOffsetsDataLength);
 
     void pushDebugGroup(DOMString groupLabel);
     void popDebugGroup();
@@ -2314,7 +2314,7 @@ Compute Passes {#compute-passes}
 interface GPUComputePassEncoder {
     void setPipeline(GPUComputePipeline pipeline);
     void dispatch(GPUSize32 x, optional GPUSize32 y = 1, optional GPUSize32 z = 1);
-    void dispatchIndirect(GPUBuffer indirectBuffer, GPUBufferSize indirectOffset);
+    void dispatchIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
 
     void endPass();
 };
@@ -2338,16 +2338,16 @@ Render Passes {#render-passes}
 interface mixin GPURenderEncoderBase {
     void setPipeline(GPURenderPipeline pipeline);
 
-    void setIndexBuffer(GPUBuffer buffer, optional GPUBufferSize offset = 0);
-    void setVertexBuffer(GPUIndex32 slot, GPUBuffer buffer, optional GPUBufferSize offset = 0);
+    void setIndexBuffer(GPUBuffer buffer, optional GPUSize64 offset = 0);
+    void setVertexBuffer(GPUIndex32 slot, GPUBuffer buffer, optional GPUSize64 offset = 0);
 
     void draw(GPUSize32 vertexCount, GPUSize32 instanceCount,
               GPUSize32 firstVertex, GPUSize32 firstInstance);
     void drawIndexed(GPUSize32 indexCount, GPUSize32 instanceCount,
                      GPUSize32 firstIndex, GPUSignedOffset32 baseVertex, GPUSize32 firstInstance);
 
-    void drawIndirect(GPUBuffer indirectBuffer, GPUBufferSize indirectOffset);
-    void drawIndexedIndirect(GPUBuffer indirectBuffer, GPUBufferSize indirectOffset);
+    void drawIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
+    void drawIndexedIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
 };
 
 interface GPURenderPassEncoder {
@@ -2634,7 +2634,7 @@ Type Definitions {#type-definitions}
 ====================================
 
 <script type=idl>
-typedef [EnforceRange] unsigned long long GPUBufferSize;
+typedef [EnforceRange] unsigned long long GPUSize64;
 typedef [EnforceRange] unsigned long GPUBufferDynamicOffset;
 typedef [EnforceRange] unsigned long long GPUFenceValue;
 typedef [EnforceRange] unsigned long GPUStencilValue;

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -159,9 +159,16 @@ Type Definitions {#type-definitions}
 
 <script type=idl>
 typedef [EnforceRange] unsigned long long GPUBufferSize;
-typedef [EnforceRange] unsigned long long enforced_u64;
-typedef [EnforceRange] unsigned long enforced_u32;
-typedef [EnforceRange] long enforced_i32;
+typedef [EnforceRange] unsigned long GPUBufferDynamicOffset;
+typedef [EnforceRange] unsigned long long GPUFenceValue;
+typedef [EnforceRange] unsigned long GPUStencilValue;
+typedef [EnforceRange] unsigned long GPUSampleMask;
+typedef [EnforceRange] long GPUDepthBias;
+
+typedef [EnforceRange] unsigned long GPUIntegerCoordinate;
+typedef [EnforceRange] unsigned long GPUIndex32;
+typedef [EnforceRange] unsigned long GPUSize32;
+typedef [EnforceRange] long GPUSignedOffset32;
 </script>
 
 ## Colors and Vectors ## {#colors-and-vectors}
@@ -181,28 +188,28 @@ integers and single-precision floats.
 
 <script type=idl>
 dictionary GPUOrigin2DDict {
-    enforced_u32 x = 0;
-    enforced_u32 y = 0;
+    GPUIntegerCoordinate x = 0;
+    GPUIntegerCoordinate y = 0;
 };
-typedef (sequence<enforced_u32> or GPUOrigin2DDict) GPUOrigin2D;
+typedef (sequence<GPUIntegerCoordinate> or GPUOrigin2DDict) GPUOrigin2D;
 </script>
 
 <script type=idl>
 dictionary GPUOrigin3DDict {
-    enforced_u32 x = 0;
-    enforced_u32 y = 0;
-    enforced_u32 z = 0;
+    GPUIntegerCoordinate x = 0;
+    GPUIntegerCoordinate y = 0;
+    GPUIntegerCoordinate z = 0;
 };
-typedef (sequence<enforced_u32> or GPUOrigin3DDict) GPUOrigin3D;
+typedef (sequence<GPUIntegerCoordinate> or GPUOrigin3DDict) GPUOrigin3D;
 </script>
 
 <script type=idl>
 dictionary GPUExtent3DDict {
-    required enforced_u32 width;
-    required enforced_u32 height;
-    required enforced_u32 depth;
+    required GPUIntegerCoordinate width;
+    required GPUIntegerCoordinate height;
+    required GPUIntegerCoordinate depth;
 };
-typedef (sequence<enforced_u32> or GPUExtent3DDict) GPUExtent3D;
+typedef (sequence<GPUIntegerCoordinate> or GPUExtent3DDict) GPUExtent3D;
 </script>
 
 <script type=idl>
@@ -574,14 +581,14 @@ dictionary GPUExtensions {
 
 <script type=idl>
 dictionary GPULimits {
-    enforced_u32 maxBindGroups = 4;
-    enforced_u32 maxDynamicUniformBuffersPerPipelineLayout = 8;
-    enforced_u32 maxDynamicStorageBuffersPerPipelineLayout = 4;
-    enforced_u32 maxSampledTexturesPerShaderStage = 16;
-    enforced_u32 maxSamplersPerShaderStage = 16;
-    enforced_u32 maxStorageBuffersPerShaderStage = 4;
-    enforced_u32 maxStorageTexturesPerShaderStage = 4;
-    enforced_u32 maxUniformBuffersPerShaderStage = 12;
+    GPUSize32 maxBindGroups = 4;
+    GPUSize32 maxDynamicUniformBuffersPerPipelineLayout = 8;
+    GPUSize32 maxDynamicStorageBuffersPerPipelineLayout = 4;
+    GPUSize32 maxSampledTexturesPerShaderStage = 16;
+    GPUSize32 maxSamplersPerShaderStage = 16;
+    GPUSize32 maxStorageBuffersPerShaderStage = 4;
+    GPUSize32 maxStorageTexturesPerShaderStage = 4;
+    GPUSize32 maxUniformBuffersPerShaderStage = 12;
 };
 </script>
 
@@ -715,7 +722,7 @@ Note: This allows the user agent to reclaim the GPU memory associated with the {
 ## Buffer Usage ## {#buffer-usage}
 
 <script type=idl>
-typedef enforced_u32 GPUBufferUsageFlags;
+typedef [EnforceRange] unsigned long GPUBufferUsageFlags;
 interface GPUBufferUsage {
     const GPUBufferUsageFlags MAP_READ  = 0x0001;
     const GPUBufferUsageFlags MAP_WRITE = 0x0002;
@@ -751,9 +758,9 @@ GPUTexture includes GPUObjectBase;
 <script type=idl>
 dictionary GPUTextureDescriptor : GPUObjectDescriptorBase {
     required GPUExtent3D size;
-    enforced_u32 arrayLayerCount = 1;
-    enforced_u32 mipLevelCount = 1;
-    enforced_u32 sampleCount = 1;
+    GPUIntegerCoordinate arrayLayerCount = 1;
+    GPUIntegerCoordinate mipLevelCount = 1;
+    GPUSize32 sampleCount = 1;
     GPUTextureDimension dimension = "2d";
     required GPUTextureFormat format;
     required GPUTextureUsageFlags usage;
@@ -769,7 +776,7 @@ enum GPUTextureDimension {
 </script>
 
 <script type=idl>
-typedef enforced_u32 GPUTextureUsageFlags;
+typedef [EnforceRange] unsigned long GPUTextureUsageFlags;
 interface GPUTextureUsage {
     const GPUTextureUsageFlags COPY_SRC          = 0x01;
     const GPUTextureUsageFlags COPY_DST          = 0x02;
@@ -794,10 +801,10 @@ dictionary GPUTextureViewDescriptor : GPUObjectDescriptorBase {
     GPUTextureFormat format;
     GPUTextureViewDimension dimension;
     GPUTextureAspect aspect = "all";
-    enforced_u32 baseMipLevel = 0;
-    enforced_u32 mipLevelCount = 0;
-    enforced_u32 baseArrayLayer = 0;
-    enforced_u32 arrayLayerCount = 0;
+    GPUIntegerCoordinate baseMipLevel = 0;
+    GPUIntegerCoordinate mipLevelCount = 0;
+    GPUIntegerCoordinate baseArrayLayer = 0;
+    GPUIntegerCoordinate arrayLayerCount = 0;
 };
 </script>
 
@@ -1023,7 +1030,7 @@ A {{GPUBindGroupLayoutBinding}} describes a single shader resource binding to be
 
 <script type=idl>
 dictionary GPUBindGroupLayoutBinding {
-    required enforced_u32 binding;
+    required GPUIndex32 binding;
     required GPUShaderStageFlags visibility;
     required GPUBindingType type;
     GPUTextureViewDimension textureDimension = "2d";
@@ -1041,7 +1048,7 @@ dictionary GPUBindGroupLayoutBinding {
     associated shader stage.
 
 <script type=idl>
-typedef enforced_u32 GPUShaderStageFlags;
+typedef [EnforceRange] unsigned long GPUShaderStageFlags;
 interface GPUShaderStage {
     const GPUShaderStageFlags VERTEX   = 0x1;
     const GPUShaderStageFlags FRAGMENT = 0x2;
@@ -1169,7 +1176,7 @@ dictionary GPUBindGroupDescriptor : GPUObjectDescriptorBase {
 typedef (GPUSampler or GPUTextureView or GPUBufferBinding) GPUBindingResource;
 
 dictionary GPUBindGroupBinding {
-    required enforced_u32 binding;
+    required GPUIndex32 binding;
     required GPUBindingResource resource;
 };
 </script>
@@ -1288,8 +1295,8 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
     GPUDepthStencilStateDescriptor depthStencilState;
     GPUVertexStateDescriptor vertexState = {};
 
-    enforced_u32 sampleCount = 1;
-    enforced_u32 sampleMask = 0xFFFFFFFF;
+    GPUSize32 sampleCount = 1;
+    GPUSampleMask sampleMask = 0xFFFFFFFF;
     boolean alphaToCoverageEnabled = false;
     // TODO: other properties
 };
@@ -1316,7 +1323,7 @@ dictionary GPURasterizationStateDescriptor {
     GPUFrontFace frontFace = "ccw";
     GPUCullMode cullMode = "none";
 
-    enforced_i32 depthBias = 0;
+    GPUDepthBias depthBias = 0;
     float depthBiasSlopeScale = 0;
     float depthBiasClamp = 0;
 };
@@ -1350,7 +1357,7 @@ dictionary GPUColorStateDescriptor {
 </script>
 
 <script type=idl>
-typedef enforced_u32 GPUColorWriteFlags;
+typedef [EnforceRange] unsigned long GPUColorWriteFlags;
 interface GPUColorWrite {
     const GPUColorWriteFlags RED   = 0x1;
     const GPUColorWriteFlags GREEN = 0x2;
@@ -1423,8 +1430,8 @@ dictionary GPUDepthStencilStateDescriptor {
     GPUStencilStateFaceDescriptor stencilFront = {};
     GPUStencilStateFaceDescriptor stencilBack = {};
 
-    enforced_u32 stencilReadMask = 0xFFFFFFFF;
-    enforced_u32 stencilWriteMask = 0xFFFFFFFF;
+    GPUStencilValue stencilReadMask = 0xFFFFFFFF;
+    GPUStencilValue stencilWriteMask = 0xFFFFFFFF;
 };
 </script>
 
@@ -1539,7 +1546,7 @@ dictionary GPUVertexAttributeDescriptor {
     required GPUVertexFormat format;
     required GPUBufferSize offset;
 
-    required enforced_u32 shaderLocation;
+    required GPUIndex32 shaderLocation;
 };
 </script>
 
@@ -1617,16 +1624,16 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 dictionary GPUBufferCopyView {
     required GPUBuffer buffer;
     GPUBufferSize offset = 0;
-    required enforced_u32 rowPitch;
-    required enforced_u32 imageHeight;
+    required GPUIntegerCoordinate rowPitch;
+    required GPUIntegerCoordinate imageHeight;
 };
 </script>
 
 <script type=idl>
 dictionary GPUTextureCopyView {
     required GPUTexture texture;
-    enforced_u32 mipLevel = 0;
-    enforced_u32 arrayLayer = 0;
+    GPUIntegerCoordinate mipLevel = 0;
+    GPUIntegerCoordinate arrayLayer = 0;
     GPUOrigin3D origin = {};
 };
 </script>
@@ -1645,14 +1652,15 @@ dictionary GPUImageBitmapCopyView {
 ## Programmable Passes ## {#programmable-passes}
 
 <script type=idl>
-interface mixin GPUProgrammablePassEncoder {
-    void setBindGroup(enforced_u32 index, GPUBindGroup bindGroup,
-                      optional sequence<enforced_u32> dynamicOffsets = []);
 
-    void setBindGroup(enforced_u32 index, GPUBindGroup bindGroup,
+interface mixin GPUProgrammablePassEncoder {
+    void setBindGroup(GPUIndex32 index, GPUBindGroup bindGroup,
+                      optional sequence<GPUBufferDynamicOffset> dynamicOffsets = []);
+
+    void setBindGroup(GPUIndex32 index, GPUBindGroup bindGroup,
                       Uint32Array dynamicOffsetsData,
-                      enforced_u64 dynamicOffsetsDataStart,
-                      enforced_u64 dynamicOffsetsDataLength);
+                      GPUBufferSize dynamicOffsetsDataStart,
+                      GPUBufferSize dynamicOffsetsDataLength);
 
     void pushDebugGroup(DOMString groupLabel);
     void popDebugGroup();
@@ -1671,7 +1679,7 @@ Compute Passes {#compute-passes}
 <script type=idl>
 interface GPUComputePassEncoder {
     void setPipeline(GPUComputePipeline pipeline);
-    void dispatch(enforced_u32 x, optional enforced_u32 y = 1, optional enforced_u32 z = 1);
+    void dispatch(GPUSize32 x, optional GPUSize32 y = 1, optional GPUSize32 z = 1);
     void dispatchIndirect(GPUBuffer indirectBuffer, GPUBufferSize indirectOffset);
 
     void endPass();
@@ -1697,12 +1705,12 @@ interface mixin GPURenderEncoderBase {
     void setPipeline(GPURenderPipeline pipeline);
 
     void setIndexBuffer(GPUBuffer buffer, optional GPUBufferSize offset = 0);
-    void setVertexBuffer(enforced_u32 slot, GPUBuffer buffer, optional GPUBufferSize offset = 0);
+    void setVertexBuffer(GPUIndex32 slot, GPUBuffer buffer, optional GPUBufferSize offset = 0);
 
-    void draw(enforced_u32 vertexCount, enforced_u32 instanceCount,
-              enforced_u32 firstVertex, enforced_u32 firstInstance);
-    void drawIndexed(enforced_u32 indexCount, enforced_u32 instanceCount,
-                     enforced_u32 firstIndex, enforced_i32 baseVertex, enforced_u32 firstInstance);
+    void draw(GPUSize32 vertexCount, GPUSize32 instanceCount,
+              GPUIndex32 firstVertex, GPUIndex32 firstInstance);
+    void drawIndexed(GPUSize32 indexCount, GPUSize32 instanceCount,
+                     GPUIndex32 firstIndex, GPUSignedOffset32 baseVertex, GPUIndex32 firstInstance);
 
     void drawIndirect(GPUBuffer indirectBuffer, GPUBufferSize indirectOffset);
     void drawIndexedIndirect(GPUBuffer indirectBuffer, GPUBufferSize indirectOffset);
@@ -1713,10 +1721,11 @@ interface GPURenderPassEncoder {
                      float width, float height,
                      float minDepth, float maxDepth);
 
-    void setScissorRect(enforced_u32 x, enforced_u32 y, enforced_u32 width, enforced_u32 height);
+    void setScissorRect(GPUIntegerCoordinate x, GPUIntegerCoordinate y,
+                        GPUIntegerCoordinate width, GPUIntegerCoordinate height);
 
     void setBlendColor(GPUColor color);
-    void setStencilReference(enforced_u32 reference);
+    void setStencilReference(GPUStencilValue reference);
 
     void executeBundles(sequence<GPURenderBundle> bundles);
     void endPass();
@@ -1776,7 +1785,7 @@ dictionary GPURenderPassDepthStencilAttachmentDescriptor {
     required (GPULoadOp or float) depthLoadValue;
     required GPUStoreOp depthStoreOp;
 
-    required (GPULoadOp or enforced_u32) stencilLoadValue;
+    required (GPULoadOp or GPUStencilValue) stencilLoadValue;
     required GPUStoreOp stencilStoreOp;
 };
 </script>
@@ -1830,7 +1839,7 @@ GPURenderBundleEncoder includes GPURenderEncoderBase;
 dictionary GPURenderBundleEncoderDescriptor : GPUObjectDescriptorBase {
     required sequence<GPUTextureFormat> colorFormats;
     GPUTextureFormat depthStencilFormat;
-    enforced_u32 sampleCount = 1;
+    GPUSize32 sampleCount = 1;
 };
 </script>
 
@@ -1843,7 +1852,7 @@ interface GPUQueue {
     void submit(sequence<GPUCommandBuffer> commandBuffers);
 
     GPUFence createFence(optional GPUFenceDescriptor descriptor = {});
-    void signal(GPUFence fence, enforced_u64 signalValue);
+    void signal(GPUFence fence, GPUFenceValue signalValue);
 
     void copyImageBitmapToTexture(
         GPUImageBitmapCopyView source,
@@ -1864,8 +1873,8 @@ GPUQueue includes GPUObjectBase;
 
 <script type=idl>
 interface GPUFence {
-    enforced_u64 getCompletedValue();
-    Promise<void> onCompletion(enforced_u64 completionValue);
+    GPUFenceValue getCompletedValue();
+    Promise<void> onCompletion(GPUFenceValue completionValue);
 };
 GPUFence includes GPUObjectBase;
 </script>
@@ -1874,7 +1883,7 @@ GPUFence includes GPUObjectBase;
 
 <script type=idl>
 dictionary GPUFenceDescriptor : GPUObjectDescriptorBase {
-    enforced_u64 initialValue = 0;
+    GPUFenceValue initialValue = 0;
 };
 </script>
 


### PR DESCRIPTION
[`[EnforceRange]`](https://heycam.github.io/webidl/#EnforceRange) is the most-strict and least-surprising mode of `number`-to-integer conversion in WebIDL. (The default is modular, the other option is `[Clamp]`.) `[EnforceRange]` rounds the (double-precision floating point) `number` to an integer, then throws if it's outside of the range of the integer type. It has the benefit that removing this attribute would be a non-breaking change (in that it would change from throwing to not-throwing).

I've been meaning to do this for a long time, but I didn't realize that it was an attribute on the type and not the fields/parameters themselves, or I might have done this before removing all the typedefs. 🙃

I'm not attached to using typedefs, it just makes it slightly more apparent if something diverges from this (IMO) (the word `long` will appear). This PR does not leave any unenforced integer types.

Austin did some quick measurements in Chrome's bindings, and this doesn't seem to impact performance in the non-failure case, for us.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/498.html" title="Last updated on Feb 11, 2020, 3:07 AM UTC (75f212b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/498/a8d1858...kainino0x:75f212b.html" title="Last updated on Feb 11, 2020, 3:07 AM UTC (75f212b)">Diff</a>