### PR TITLE
Remove [SameObject] from GPUDevice.lost

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1920,7 +1920,7 @@ interface GPUDeviceLostInfo {
 };
 
 partial interface GPUDevice {
-    [SameObject] readonly attribute Promise<GPUDeviceLostInfo> lost;
+    readonly attribute Promise<GPUDeviceLostInfo> lost;
 };
 </script>
 


### PR DESCRIPTION
According to the WebIDL spec[1], promise-type attribute doesn't allow
[SameObject] extended attribute.

[1] https://heycam.github.io/webidl/#idl-attributes


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/romandev/gpuweb/pull/505.html" title="Last updated on Nov 27, 2019, 2:38 AM UTC (7fa7f39)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/505/2e9fa05...romandev:7fa7f39.html" title="Last updated on Nov 27, 2019, 2:38 AM UTC (7fa7f39)">Diff</a>