### PR TITLE
Synchronous GPUBuffer.map().

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -202,13 +202,6 @@ dictionary GPUExtent3DDict {
 typedef (sequence<unsigned long> or GPUExtent3DDict) GPUExtent3D;
 </script>
 
-<script type=idl>
-typedef sequence<any> GPUMappedBuffer;
-</script>
-
-{{GPUMappedBuffer}} is always a sequence of 2 elements, of types {{GPUBuffer}}
-and {{ArrayBuffer}}, respectively.
-
 ## Internal Objects ## {#webgpu-internal-objects}
 
 An <dfn dfn>internal object</dfn> is a non-exposed conceptual WebGPU object.
@@ -473,8 +466,6 @@ interface GPUDevice : EventTarget {
     [SameObject] readonly attribute GPUQueue defaultQueue;
 
     GPUBuffer createBuffer(GPUBufferDescriptor descriptor);
-    GPUMappedBuffer createBufferMapped(GPUBufferDescriptor descriptor);
-    Promise<GPUMappedBuffer> createBufferMappedAsync(GPUBufferDescriptor descriptor);
     GPUTexture createTexture(GPUTextureDescriptor descriptor);
     GPUSampler createSampler(optional GPUSamplerDescriptor descriptor = {});
 
@@ -723,9 +714,9 @@ interface GPUBufferUsage {
 };
 </script>
 
-{{GPUBufferUsage/MAP_READ}} cannot be used with {{GPUBufferUsage/STORAGE}}.
-MAP_READ cannot ensure efficient mappability of buffers that may be written to as storage
-buffers.
+In order to guarantee immediate, efficient, and portable mapping, buffers
+marked for {{GPUBufferUsage/MAP_WRITE}} are only writable by the CPU,
+and cannot be also marked for {{GPUBufferUsage/COPY_DST}} or {{GPUBufferUsage/STORAGE}}.
 
 ## Buffer Mapping ## {#buffer-mapping}
 
@@ -737,16 +728,34 @@ interface GPUMap {
 };
 </script>
 
+{{GPUBuffer/map()}} returns null if the device is lost.
+
+Because MAP_WRITE is writable only by the CPU, the contents of the ArrayBuffer
+are unchanged between unmap and map. (Or, if the buffer has not been previously
+mapped, the initial buffer contents.
+
+If the contents of a mapping without {{GPUMap/WRITE}} are changed, on unmap(),
+the device is lost.
+Additionally, writing to a read-only ArrayBuffer returned from mapping without
+{{GPUMap/WRITE}} MAY throw an error.
+
+Only one mapping may be active per buffer at a time.
+
 With {{GPUQueue/createFence()}} and awaiting {{GPUFence/onCompletion()}}, it's possible
 to ensure that {{GPUBuffer/map()}} provides an efficient mapping to memory with a minimal
 number of copies.
 
 If applications do not ensure proper fencing, {{GPUBuffer/map()}} may provide a less
-efficient mapping. (likely requiring an extra allocation and copy) Implementations should
-provide warnings to surface when this overhead is incurred.
+efficient mapping. (such as requiring an extra allocation and copy) Implementations should
+provide warnings to inform when this overhead is incurred.
 
-{{GPUMap/READ}} and {{GPUMap/WRITE}} are not mutually exclusive, though such a combined
-mapping may incur more overhead than one or the other alone.
+{{GPUMap/READ}} will stall if its contents are stale. Because this condition is
+precisely identifiable, implementations SHOULD warn when {{GPUFence/onCompletion()}}
+has not guaranteed that {{GPUMap/READ}} is immediately satisfiable, even if it
+it happens to be ready.
+
+After {{GPUBuffer/unmap()}}, any new contents of the buffer will be visible to any
+subsequent {{GPUQueue.submit()}}.
 
 Textures {#textures}
 ====================

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -595,14 +595,11 @@ its mapping.
 {{GPUBuffer|GPUBuffers}} can be created via the following functions:
 
  - {{GPUDevice/createBuffer(descriptor)|GPUDevice.createBuffer(descriptor)}} that returns a new unmapped buffer.
- - {{GPUDevice/createBufferMapped(descriptor)|GPUDevice.createBufferMapped(descriptor)}} that returns a mapped buffer and its mapping.
- - {{GPUDevice/createBufferMappedAsync(descriptor)|GPUDevice.createBufferMappedAsync(descriptor)}} that returns a Promise of a mapped buffer and its mapping.
 
 <script type=idl>
 [Serializable]
 interface GPUBuffer {
-    Promise<ArrayBuffer> mapReadAsync();
-    Promise<ArrayBuffer> mapWriteAsync();
+    ArrayBuffer? map(GPUMapFlags flags, GPUBufferSize offset = 0, GPUBufferSize size = 0);
     void unmap();
 
     void destroy();
@@ -662,7 +659,7 @@ dictionary GPUBufferDescriptor : GPUObjectDescriptorBase {
         <div algorithm="validation GPUBufferDescriptor(device, descriptor)">
             1. If device is lost return false.
             1. If any of the bits of |descriptor|'s {{GPUBufferDescriptor/usage}} aren't present in this device's [[allowed buffer usages]] return false.
-            1. If both the {{GPUBufferUsage/MAP_READ}} and {{GPUBufferUsage/MAP_WRITE}} bits of |descriptor|'s {{GPUBufferDescriptor/usage}} attribute are set, return false.
+            1. If both the {{GPUBufferUsage/MAP_READ}} and {{GPUBufferUsage/STORAGE}} bits of |descriptor|'s {{GPUBufferDescriptor/usage}} attribute are set, return false.
             1. Return true.
         </div>
 </dl>
@@ -691,7 +688,7 @@ dictionary GPUBufferDescriptor : GPUObjectDescriptorBase {
 ## Buffer Destruction ## {#buffer-destruction}
 
 An application that no longer requires a {{GPUBuffer}} can choose to lose
-access to it before garbage collection by calling {{GPUBuffer/destroy()}}. 
+access to it before garbage collection by calling {{GPUBuffer/destroy()}}.
 
 Note: This allows the user agent to reclaim the GPU memory associated with the {{GPUBuffer}}
  once all previously submitted operations using it are complete.
@@ -726,7 +723,30 @@ interface GPUBufferUsage {
 };
 </script>
 
+{{GPUBufferUsage/MAP_READ}} cannot be used with {{GPUBufferUsage/STORAGE}}.
+MAP_READ cannot ensure efficient mappability of buffers that may be written to as storage
+buffers.
+
 ## Buffer Mapping ## {#buffer-mapping}
+
+<script type=idl>
+typedef unsigned long GPUMapFlags;
+interface GPUMap {
+    const GPUMapFlags READ  = 0x0001;
+    const GPUMapFlags WRITE = 0x0002;
+};
+</script>
+
+With {{GPUQueue/createFence()}} and awaiting {{GPUFence/onCompletion()}}, it's possible
+to ensure that {{GPUBuffer/map()}} provides an efficient mapping to memory with a minimal
+number of copies.
+
+If applications do not ensure proper fencing, {{GPUBuffer/map()}} may provide a less
+efficient mapping. (likely requiring an extra allocation and copy) Implementations should
+provide warnings to surface when this overhead is incurred.
+
+{{GPUMap/READ}} and {{GPUMap/WRITE}} are not mutually exclusive, though such a combined
+mapping may incur more overhead than one or the other alone.
 
 Textures {#textures}
 ====================


### PR DESCRIPTION
Replaces createBufferMapped, mapReadAsync, mapWriteAsync.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jdashg/gpuweb/pull/506.html" title="Last updated on Dec 5, 2019, 7:37 AM UTC (26567b3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/506/2e9fa05...jdashg:26567b3.html" title="Last updated on Dec 5, 2019, 7:37 AM UTC (26567b3)">Diff</a>