### PR TITLE
Add depth16unorm to WebGPU SPEC

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -913,6 +913,7 @@ enum GPUTextureFormat {
     "rgba32float",
 
     // Depth and stencil formats
+    "depth16unorm",
     "depth32float",
     "depth24plus",
     "depth24plus-stencil8"


### PR DESCRIPTION
This patch adds "depth16unorm" to WebGPU SPEC as it can be supported
on D3D12 (required in feature level 11_0), Metal (all Metal feature sets) and
Vulkan (required in Vulkan SPEC).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Jiawei-Shao/gpuweb/pull/508.html" title="Last updated on Apr 17, 2020, 7:39 PM UTC (377f5c9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/508/ce4132a...Jiawei-Shao:377f5c9.html" title="Last updated on Apr 17, 2020, 7:39 PM UTC (377f5c9)">Diff</a>