### PR TITLE
GPUQueue.writeBuffer/writeTexture

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2495,10 +2495,10 @@ interface GPUQueue {
 
     void writeBuffer(
         ArrayBuffer sourceData,
-        GPUBufferSize sourceOffset,
+        GPUSize64 sourceOffset,
         GPUBuffer destination,
-        GPUBufferSize destinationOffset,
-        GPUBufferSize size);
+        GPUSize64 destinationOffset,
+        GPUSize64 size);
 
     void writeTexture(
         ArrayBuffer sourceData,
@@ -2524,7 +2524,7 @@ GPUQueue includes GPUObjectBase;
         The operation does nothing and produces an error if any of the following is true:
 
          - `destination` buffer wasn't created with {{GPUBufferUsage/COPY_DST}} flag in {{GPUBufferDescriptor/usage}}.
-         - `destination` buffer must not be destroyed
+         - `destination` buffer is destroyed
          - `destinationOffset + size` exceeds the {{GPUBufferDescriptor/size}} of the `destination` buffer.
          - `destination` buffer isn't in the `"unmapped"` [=buffer state=].
          - `destinationOffset` is not a multiple of 4.
@@ -2540,7 +2540,7 @@ GPUQueue includes GPUObjectBase;
         The operation does nothing and produces an error if any of the following is true:
 
          - `destination.texture` texture wasn't created with {{GPUTextureUsage/COPY_DST}} flag in {{GPUTextureDescriptor/usage}}.
-         - `destination.texture` must not be destroyed
+         - `destination.texture` is destroyed
          - `destination.origin + size` exceeds the size of texture dimensions of the mipmap `destination.mipLevel`.
          - any of the `size` extents are zero
          - `sourceOffset + requiredSize` exceeds `sourceData.byteLength`, where `requiredSize` can be computed as

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2221,15 +2221,13 @@ interface GPUCommandEncoder {
         GPUSize64 size);
 
     void copyBufferToTexture(
-        GPUBuffer source,
-        GPUTextureDataLayout sourceLayout,
+        GPUBufferCopyView source,
         GPUTextureCopyView destination,
         GPUExtent3D copySize);
 
     void copyTextureToBuffer(
         GPUTextureCopyView source,
-        GPUBuffer destination,
-        GPUTextureDataLayout destinationLayout,
+        GPUBufferCopyView destination,
         GPUExtent3D copySize);
 
     void copyTextureToTexture(
@@ -2257,10 +2255,8 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 ## Copy Commands ## {#copy-commands}
 
 <script type=idl>
-dictionary GPUTextureDataLayout {
-    GPUSize64 offset = 0;
-    required GPUSize32 rowPitch;
-    required GPUSize32 imageHeight;
+dictionary GPUBufferCopyView: GPUTextureDataLayout {
+    required GPUBuffer buffer;
 };
 </script>
 
@@ -2481,6 +2477,14 @@ dictionary GPURenderBundleEncoderDescriptor : GPUObjectDescriptorBase {
 
 Queues {#queues}
 ================
+
+<script type=idl>
+dictionary GPUTextureDataLayout {
+    GPUSize64 offset = 0;
+    required GPUSize32 rowPitch;
+    required GPUSize32 imageHeight;
+};
+</script>
 
 <script type=idl>
 interface GPUQueue {

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2519,6 +2519,8 @@ GPUQueue includes GPUObjectBase;
     ::
         Takes the `sourceData` contents starting from the offset `sourceOffset` and
         schedules a write operation of these contents to the `destination` buffer in the queue.
+        Any subsequent modifications to sourceData do not affect what is written
+        at the time that the scheduled operation runs.
         The operation does nothing and produces an error if any of the following is true:
 
          - `destination` buffer wasn't created with {{GPUBufferUsage/COPY_DST}} flag in {{GPUBufferDescriptor/usage}}.
@@ -2531,8 +2533,10 @@ GPUQueue includes GPUObjectBase;
 
     : <dfn>writeTexture(sourceData, sourceLayout, destination, size)</dfn>
     ::
-        Takes the `source` contents and schedules a write operation of these contents to the
+        Takes the `sourceData` contents and schedules a write operation of these contents to the
         `destination` texture copy view in the queue.
+        Any subsequent modifications to sourceData do not affect what is written
+        at the time that the scheduled operation runs.
         The operation does nothing and produces an error if any of the following is true:
 
          - `destination.texture` texture wasn't created with {{GPUTextureUsage/COPY_DST}} flag in {{GPUTextureDescriptor/usage}}.
@@ -2540,7 +2544,7 @@ GPUQueue includes GPUObjectBase;
          - `destination.origin + size` exceeds the size of texture dimensions of the mipmap `destination.mipLevel`.
          - any of the `size` extents are zero
          - `sourceOffset + requiredSize` exceeds `sourceData.byteLength`, where `requiredSize` can be computed as
-            `(sourceLayout.imageHeight * sourceLayout.rowPitch * (size.depth - 1) + sourceLayout.rowPitch * (size.height - 1) + size.width) * bpp`.
+            `(sourceLayout.imageHeight * (size.depth - 1) + size.height - 1) * sourceLayout.rowPitch + size.width * bpp`.
 
     : <dfn>copyImageBitmapToTexture(source, destination, size)</dfn>
     ::

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2488,6 +2488,21 @@ interface GPUQueue {
     GPUFence createFence(optional GPUFenceDescriptor descriptor = {});
     void signal(GPUFence fence, GPUFenceValue signalValue);
 
+    void setBufferSubData(
+        GPUBuffer destination,
+        GPUBufferSize destinationOffset,
+        GPUBufferSize size,
+        ArrayBuffer sourceData,
+        GPUBufferSize sourceOffset);
+
+    void setTextureSubData(
+        GPUTextureCopyView destination,
+        unsigned long rowPitch,
+        unsigned long imageHeight,
+        GPUExtent3D size,
+        ArrayBuffer sourceData,
+        GPUBufferSize sourceOffset);
+
     void copyImageBitmapToTexture(
         GPUImageBitmapCopyView source,
         GPUTextureCopyView destination,
@@ -2496,7 +2511,28 @@ interface GPUQueue {
 GPUQueue includes GPUObjectBase;
 </script>
 
- - {{GPUQueue/copyImageBitmapToTexture()}}:
+{{GPUQueue/setBufferSubData()}} takes the `sourceData` contents starting from the offset `sourceOffset` and
+schedules a write operation of these contents to the `destination` buffer in the queue.
+The operation does nothing and produces an error if any of the following is true:
+
+ - `destination` texture wasn't created with `GPUTextureUsage.COPY_DST` flag in {{GPUTextureDescriptor/usage}}.
+ - `destinationOffset + size` exceeds the {{GPUBufferDescriptor/size}} of the `destination` buffer.
+ - `destination` buffer isn't in the `"unmapped"` [=buffer state=].
+ - `size` is not a multiple of 4.
+ - `size` is zero.
+ - `sourceOffset + size` exceeds `sourceData.length`.
+
+{{GPUQueue/setTextureSubData()}} takes the `source` contents and schedules a write operation
+of these contents to the `destination` texture copy view in the queue.
+The operation does nothing and produces an error if any of the following is true:
+
+ - `destination` buffer wasn't created with `GPUBufferUsage.COPY_DST` flag in {{GPUBufferDescriptor/usage}}.
+ - `destination.origin + size` exceeds the size of texture dimensions of the mipmap `destination.mipmapLevel`.
+ - any of the `size` extents are zero
+ - `sourceOffset + size` exceeds the size required for the copy, which can be computed as
+    `(imageHeight * rowPitch * (size.depth - 1) + rowPitch * (size.height - 1) + size.width) * bpp`.
+
+{{GPUQueue/copyImageBitmapToTexture()}}:
    - For now, `copySize.z` must be `1`.
 
 {{GPUQueue/submit(commandBuffers)}} does nothing and produces an error if any of the following is true:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2221,13 +2221,15 @@ interface GPUCommandEncoder {
         GPUSize64 size);
 
     void copyBufferToTexture(
-        GPUBufferCopyView source,
+        GPUBuffer source,
+        GPUTextureDataLayout sourceLayout,
         GPUTextureCopyView destination,
         GPUExtent3D copySize);
 
     void copyTextureToBuffer(
         GPUTextureCopyView source,
-        GPUBufferCopyView destination,
+        GPUBuffer destination,
+        GPUTextureDataLayout destinationLayout,
         GPUExtent3D copySize);
 
     void copyTextureToTexture(
@@ -2255,8 +2257,7 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 ## Copy Commands ## {#copy-commands}
 
 <script type=idl>
-dictionary GPUBufferCopyView {
-    required GPUBuffer buffer;
+dictionary GPUTextureDataLayout {
     GPUSize64 offset = 0;
     required GPUSize32 rowPitch;
     required GPUSize32 imageHeight;
@@ -2489,56 +2490,67 @@ interface GPUQueue {
     void signal(GPUFence fence, GPUFenceValue signalValue);
 
     void writeBuffer(
+        ArrayBuffer sourceData,
+        GPUBufferSize sourceOffset,
         GPUBuffer destination,
         GPUBufferSize destinationOffset,
-        GPUBufferSize size,
-        ArrayBuffer sourceData,
-        GPUBufferSize sourceOffset);
+        GPUBufferSize size);
 
     void writeTexture(
-        GPUTextureCopyView destination,
-        unsigned long rowPitch,
-        unsigned long imageHeight,
-        GPUExtent3D size,
         ArrayBuffer sourceData,
-        GPUBufferSize sourceOffset);
+        GPUTextureDataLayout sourceLayout,
+        GPUTextureCopyView destination,
+        GPUExtent3D size);
 
     void copyImageBitmapToTexture(
         GPUImageBitmapCopyView source,
         GPUTextureCopyView destination,
-        GPUExtent3D copySize);
+        GPUExtent3D size);
 };
 GPUQueue includes GPUObjectBase;
 </script>
 
-{{GPUQueue/writeBuffer()}} takes the `sourceData` contents starting from the offset `sourceOffset` and
-schedules a write operation of these contents to the `destination` buffer in the queue.
-The operation does nothing and produces an error if any of the following is true:
+<dl dfn-type="method" dfn-for="GPUQueue">
+    : <dfn>writeBuffer(sourceData, sourceOffset, destination, destinationOffset, size)</dfn>
+    ::
+        Takes the `sourceData` contents starting from the offset `sourceOffset` and
+        schedules a write operation of these contents to the `destination` buffer in the queue.
+        The operation does nothing and produces an error if any of the following is true:
 
- - `destination` buffer wasn't created with `GPUBufferUsage.COPY_DST` flag in {{GPUBufferDescriptor/usage}}.
- - `destinationOffset + size` exceeds the {{GPUBufferDescriptor/size}} of the `destination` buffer.
- - `destination` buffer isn't in the `"unmapped"` [=buffer state=].
- - `destinationOffset` is not a multiple of 4.
- - `size` is not a multiple of 4.
- - `size` is zero.
- - `sourceOffset + size` exceeds `sourceData.byteLength`.
+         - `destination` buffer wasn't created with {{GPUBufferUsage/COPY_DST}} flag in {{GPUBufferDescriptor/usage}}.
+         - `destination` buffer must not be destroyed
+         - `destinationOffset + size` exceeds the {{GPUBufferDescriptor/size}} of the `destination` buffer.
+         - `destination` buffer isn't in the `"unmapped"` [=buffer state=].
+         - `destinationOffset` is not a multiple of 4.
+         - `size` is not a positive multiple of 4.
+         - `sourceOffset + size` exceeds `sourceData.byteLength`.
 
-{{GPUQueue/writeTexture()}} takes the `source` contents and schedules a write operation
-of these contents to the `destination` texture copy view in the queue.
-The operation does nothing and produces an error if any of the following is true:
+    : <dfn>writeTexture(sourceData, sourceLayout, destination, size)</dfn>
+    ::
+        Takes the `source` contents and schedules a write operation of these contents to the
+        `destination` texture copy view in the queue.
+        The operation does nothing and produces an error if any of the following is true:
 
- - `destination.texture` texture wasn't created with `GPUTextureUsage.COPY_DST` flag in {{GPUTextureDescriptor/usage}}.
- - `destination.origin + size` exceeds the size of texture dimensions of the mipmap `destination.mipLevel`.
- - any of the `size` extents are zero
- - `sourceOffset + requiredSize` exceeds `sourceData.byteLength`, where `requiredSize` can be computed as
-    `(imageHeight * rowPitch * (size.depth - 1) + rowPitch * (size.height - 1) + size.width) * bpp`.
+         - `destination.texture` texture wasn't created with {{GPUTextureUsage/COPY_DST}} flag in {{GPUTextureDescriptor/usage}}.
+         - `destination.texture` must not be destroyed
+         - `destination.origin + size` exceeds the size of texture dimensions of the mipmap `destination.mipLevel`.
+         - any of the `size` extents are zero
+         - `sourceOffset + requiredSize` exceeds `sourceData.byteLength`, where `requiredSize` can be computed as
+            `(sourceLayout.imageHeight * sourceLayout.rowPitch * (size.depth - 1) + sourceLayout.rowPitch * (size.height - 1) + size.width) * bpp`.
 
-{{GPUQueue/copyImageBitmapToTexture()}}:
-   - For now, `copySize.z` must be `1`.
+    : <dfn>copyImageBitmapToTexture(source, destination, size)</dfn>
+    ::
+        Schedules a copy operation of the contents of an image bitmap into the destination texture.
 
-{{GPUQueue/submit(commandBuffers)}} does nothing and produces an error if any of the following is true:
+         - For now, `size.z` must be `1`.
 
- - Any {{GPUBuffer}} referenced in any element of `commandBuffers` isn't in the `"unmapped"` [=buffer state=].
+    : <dfn>submit(commandBuffers)</dfn>
+    ::
+        Schedules the execution of the command buffers by the GPU on this queue.
+        Does nothing and produces an error if any of the following is true:
+
+            - Any {{GPUBuffer}} referenced in any element of `commandBuffers` isn't in the `"unmapped"` [=buffer state=].
+</dl>
 
 ## GPUFence ## {#fence}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2488,14 +2488,14 @@ interface GPUQueue {
     GPUFence createFence(optional GPUFenceDescriptor descriptor = {});
     void signal(GPUFence fence, GPUFenceValue signalValue);
 
-    void setBufferSubData(
+    void writeBuffer(
         GPUBuffer destination,
         GPUBufferSize destinationOffset,
         GPUBufferSize size,
         ArrayBuffer sourceData,
         GPUBufferSize sourceOffset);
 
-    void setTextureSubData(
+    void writeTexture(
         GPUTextureCopyView destination,
         unsigned long rowPitch,
         unsigned long imageHeight,
@@ -2511,23 +2511,24 @@ interface GPUQueue {
 GPUQueue includes GPUObjectBase;
 </script>
 
-{{GPUQueue/setBufferSubData()}} takes the `sourceData` contents starting from the offset `sourceOffset` and
+{{GPUQueue/writeBuffer()}} takes the `sourceData` contents starting from the offset `sourceOffset` and
 schedules a write operation of these contents to the `destination` buffer in the queue.
 The operation does nothing and produces an error if any of the following is true:
 
  - `destination` texture wasn't created with `GPUTextureUsage.COPY_DST` flag in {{GPUTextureDescriptor/usage}}.
  - `destinationOffset + size` exceeds the {{GPUBufferDescriptor/size}} of the `destination` buffer.
  - `destination` buffer isn't in the `"unmapped"` [=buffer state=].
+ - `destinationOffset` is not a multiple of 4.
  - `size` is not a multiple of 4.
  - `size` is zero.
  - `sourceOffset + size` exceeds `sourceData.length`.
 
-{{GPUQueue/setTextureSubData()}} takes the `source` contents and schedules a write operation
+{{GPUQueue/writeTexture()}} takes the `source` contents and schedules a write operation
 of these contents to the `destination` texture copy view in the queue.
 The operation does nothing and produces an error if any of the following is true:
 
- - `destination` buffer wasn't created with `GPUBufferUsage.COPY_DST` flag in {{GPUBufferDescriptor/usage}}.
- - `destination.origin + size` exceeds the size of texture dimensions of the mipmap `destination.mipmapLevel`.
+ - `destination.texture` texture wasn't created with `GPUTextureUsage.COPY_DST` flag in {{GPUTextureDescriptor/usage}}.
+ - `destination.origin + size` exceeds the size of texture dimensions of the mipmap `destination.mipLevel`.
  - any of the `size` extents are zero
  - `sourceOffset + size` exceeds the size required for the copy, which can be computed as
     `(imageHeight * rowPitch * (size.depth - 1) + rowPitch * (size.height - 1) + size.width) * bpp`.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2515,13 +2515,13 @@ GPUQueue includes GPUObjectBase;
 schedules a write operation of these contents to the `destination` buffer in the queue.
 The operation does nothing and produces an error if any of the following is true:
 
- - `destination` texture wasn't created with `GPUTextureUsage.COPY_DST` flag in {{GPUTextureDescriptor/usage}}.
+ - `destination` buffer wasn't created with `GPUBufferUsage.COPY_DST` flag in {{GPUBufferDescriptor/usage}}.
  - `destinationOffset + size` exceeds the {{GPUBufferDescriptor/size}} of the `destination` buffer.
  - `destination` buffer isn't in the `"unmapped"` [=buffer state=].
  - `destinationOffset` is not a multiple of 4.
  - `size` is not a multiple of 4.
  - `size` is zero.
- - `sourceOffset + size` exceeds `sourceData.length`.
+ - `sourceOffset + size` exceeds `sourceData.byteLength`.
 
 {{GPUQueue/writeTexture()}} takes the `source` contents and schedules a write operation
 of these contents to the `destination` texture copy view in the queue.
@@ -2530,7 +2530,7 @@ The operation does nothing and produces an error if any of the following is true
  - `destination.texture` texture wasn't created with `GPUTextureUsage.COPY_DST` flag in {{GPUTextureDescriptor/usage}}.
  - `destination.origin + size` exceeds the size of texture dimensions of the mipmap `destination.mipLevel`.
  - any of the `size` extents are zero
- - `sourceOffset + size` exceeds the size required for the copy, which can be computed as
+ - `sourceOffset + requiredSize` exceeds `sourceData.byteLength`, where `requiredSize` can be computed as
     `(imageHeight * rowPitch * (size.depth - 1) + rowPitch * (size.height - 1) + size.width) * bpp`.
 
 {{GPUQueue/copyImageBitmapToTexture()}}:


### PR DESCRIPTION
This PR brings setSubData calls on the queue for buffers and textures.

This PR can be seen as either:
  - an evolution of #418 
  - a more concrete and drastically reduced version of  #491


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/509.html" title="Last updated on Apr 13, 2020, 8:06 PM UTC (d7cb553)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/509/0419bcd...kvark:d7cb553.html" title="Last updated on Apr 13, 2020, 8:06 PM UTC (d7cb553)">Diff</a>