### PR TITLE
unmap() rejects pending map*Async() Promises.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -691,7 +691,7 @@ dictionary GPUBufferDescriptor : GPUObjectDescriptorBase {
 ## Buffer Destruction ## {#buffer-destruction}
 
 An application that no longer requires a {{GPUBuffer}} can choose to lose
-access to it before garbage collection by calling {{GPUBuffer/destroy()}}. 
+access to it before garbage collection by calling {{GPUBuffer/destroy()}}.
 
 Note: This allows the user agent to reclaim the GPU memory associated with the {{GPUBuffer}}
  once all previously submitted operations using it are complete.
@@ -727,6 +727,12 @@ interface GPUBufferUsage {
 </script>
 
 ## Buffer Mapping ## {#buffer-mapping}
+
+If {{GPUBuffer/unmap()}} is called while the Promise from
+{{GPUBuffer/mapReadAsync()}} or {{GPUBuffer/mapReadAsync()}} is pending, the
+Promise is rejected, and {{GPUBuffer/[[state]]}} is set to [=buffer state/unmapped=].
+This restores the availability of a buffer for valid use by a
+{{GPUCommandBuffer}} passed to {{GPUQueue/submit()}}.
 
 Textures {#textures}
 ====================

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -729,7 +729,7 @@ interface GPUBufferUsage {
 ## Buffer Mapping ## {#buffer-mapping}
 
 If {{GPUBuffer/unmap()}} is called while the Promise from
-{{GPUBuffer/mapReadAsync()}} or {{GPUBuffer/mapReadAsync()}} is pending, the
+{{GPUBuffer/mapReadAsync()}} or {{GPUBuffer/mapWriteAsync()}} is pending, the
 Promise is rejected, and {{GPUBuffer/[[state]]}} is set to [=buffer state/unmapped=].
 This restores the availability of a buffer for valid use by a
 {{GPUCommandBuffer}} passed to {{GPUQueue/submit()}}.


### PR DESCRIPTION
Resolving this ambiguity this was allows for efficient mappings of whole buffer contents.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jdashg/gpuweb/pull/512.html" title="Last updated on Dec 6, 2019, 10:37 PM UTC (94c1f6c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/512/ce4132a...jdashg:94c1f6c.html" title="Last updated on Dec 6, 2019, 10:37 PM UTC (94c1f6c)">Diff</a>