### PR TITLE
Remove createBufferMappedAsync

### DIFF
--- a/design/BufferOperations.md
+++ b/design/BufferOperations.md
@@ -40,7 +40,7 @@ Buffers have an internal state machine that has three states:
 
 In the following a buffer's state is a shorthand for the buffer's state machine.
 Buffers created with `GPUDevice.createBuffer` start in the unmapped state.
-Buffers created with `GPUDevice.createBufferMapped` or `GPUDevice.createBufferMappedAsync` start in the mapped state.
+Buffers created with `GPUDevice.createBufferMapped` start in the mapped state.
 
 State transitions are the following:
 
@@ -100,12 +100,10 @@ A buffer can be created already mapped:
 ```webidl
 partial interface GPUDevice {
     (GPUBuffer, ArrayBuffer) createBufferMapped(GPUBufferDescriptor descriptor);
-    Promise<(GPUBuffer, ArrayBuffer)> createBufferMappedAsync(GPUBufferDescriptor descriptor);
 };
 ```
 
 `GPUDevice.createBufferMapped` returns a buffer in the mapped state along with an write mapping representing the whole range of the buffer.
-`GPUDevice.createBufferMappedAsync` returns the same values as a promise and provides more opportunities for optimization in implementations of the API.
 
 These entry points do not require the `MAP_WRITE` usage to be specified.
 The `MAP_WRITE` usage may be specified if the buffer needs to be re-mappable later on.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -595,7 +595,6 @@ its mapping.
 
  - {{GPUDevice/createBuffer(descriptor)|GPUDevice.createBuffer(descriptor)}} that returns a new unmapped buffer.
  - {{GPUDevice/createBufferMapped(descriptor)|GPUDevice.createBufferMapped(descriptor)}} that returns a mapped buffer and its mapping.
- - {{GPUDevice/createBufferMappedAsync(descriptor)|GPUDevice.createBufferMappedAsync(descriptor)}} that returns a Promise of a mapped buffer and its mapping.
 
 <script type=idl>
 [Serializable]

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -474,7 +474,6 @@ interface GPUDevice : EventTarget {
 
     GPUBuffer createBuffer(GPUBufferDescriptor descriptor);
     GPUMappedBuffer createBufferMapped(GPUBufferDescriptor descriptor);
-    Promise<GPUMappedBuffer> createBufferMappedAsync(GPUBufferDescriptor descriptor);
     GPUTexture createTexture(GPUTextureDescriptor descriptor);
     GPUSampler createSampler(optional GPUSamplerDescriptor descriptor = {});
 


### PR DESCRIPTION
createBufferMappedAsync was added as a specific optimization for
multiprocess browsers with cross-process mapping (i.e. mmapping the
gpu process's buffer mapping into content-process memory).

This optimization is platform-dependent and difficult to implement. It
provides benefits for mapWriteAsync even without
createBufferMappedAsync. In absence of the optimization, there's no
reason to use createBufferMappedAsync, so it's unlikely that users will
do so.

So, to minimize the amount of unneeded API surface at 1.0, I think we
should take this out, and add it back once we have some implementation
experience, and more established WebGPU apps where we can test the
performance of a path like this.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/516.html" title="Last updated on Dec 14, 2019, 1:47 AM UTC (94497fa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/516/f6b7414...kainino0x:94497fa.html" title="Last updated on Dec 14, 2019, 1:47 AM UTC (94497fa)">Diff</a>