### PR TITLE
Make imageHeight optional

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1615,7 +1615,7 @@ dictionary GPUBufferCopyView {
     required GPUBuffer buffer;
     GPUBufferSize offset = 0;
     required unsigned long rowPitch;
-    required unsigned long imageHeight;
+    unsigned long imageHeight = 0;
 };
 </script>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2270,10 +2270,7 @@ dictionary GPUBufferCopyView {
         For {{GPUTextureDimension/3d}} textures, `z` refers to the texture's depth.
         For {{GPUTextureDimension/2d}} textures, `z` refers to the texture's array layers.
 
-        `imageHeight` defaults to zero.
-
-        Note:
-        A `imageHeight` of zero is only valid for copies with a `copySize.depth` of 1.
+        An `imageHeight` of zero is only valid for copies with a `copySize.depth` of 1.
 </dl>
 
 <script type=idl>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1619,6 +1619,20 @@ dictionary GPUBufferCopyView {
 };
 </script>
 
+<dl dfn-type=dict-member dfn-for=GPUBufferCopyView>
+    : <dfn>imageHeight</dfn>
+    ::
+        The pitch (measured as a multiple of {{GPUBufferCopyView/rowPitch}} bytes)
+        between different `z` values of the target texture.
+        For {{GPUTextureDimension/3d}} textures, `z` refers to the texture's depth.
+        For {{GPUTextureDimension/2d}} textures, `z` refers to the texture's array layers.
+
+        `imageHeight` defaults to zero.
+
+        Note:
+        A `imageHeight` of zero is only valid for copies with a `copySize.depth` of 1.
+</dl>
+
 <script type=idl>
 dictionary GPUTextureCopyView {
     required GPUTexture texture;


### PR DESCRIPTION
It's [awkward](https://github.com/gpuweb/cts/pull/95/files#diff-d79e5d51a5b1c3e1d586625d3f7aff62R77) to have to specify an `imageHeight` when you're not doing an array/3d texture copy (i.e. almost always).
Make it default to 0 - and I'd have this be valid unless `copySize.depth > 1`.

... also, I still don't really like the name "imageHeight"...


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/517.html" title="Last updated on Mar 9, 2020, 10:17 PM UTC (1f0c902)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/517/da1d4f8...1f0c902.html" title="Last updated on Mar 9, 2020, 10:17 PM UTC (1f0c902)">Diff</a>