### PR TITLE
Change GPUExtensions into sequence<GPUExtensionName>

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -327,7 +327,7 @@ and exposes its capabilities (extensions and limits).
 <script type=idl>
 interface GPUAdapter {
     readonly attribute DOMString name;
-    readonly attribute object extensions;
+    readonly attribute sequence<GPUExtensionName> extensions;
     //readonly attribute GPULimits limits; Don't expose higher limits for now.
 
     // May reject with DOMException  // TODO: DOMException("OperationError")?
@@ -345,15 +345,7 @@ interface GPUAdapter {
 
     : <dfn>extensions</dfn>
     ::
-        A {{GPUExtensions}} object which enumerates the extensions supported
-        by the user agent, and whether each extension is supported by the
-        underlying implementation.
-          - If an extension is not supported by the user agent,
-            it will not be present in the object.
-          - If an extension is supported by the user agent, but
-            not by the [=adapter=], it will be `false`.
-          - If an extension is supported by the user agent and
-            by the [=adapter=], it will be `true`.
+        A sequence containing the {{GPUExtensionName}}s of the extensions supported by the adapter.
 </dl>
 
 {{GPUAdapter}} also has the following internal slots:
@@ -467,7 +459,7 @@ It is the top-level object through which [=WebGPU interfaces=] are created.
 [Exposed=(Window, Worker), Serializable]
 interface GPUDevice : EventTarget {
     [SameObject] readonly attribute GPUAdapter adapter;
-    readonly attribute object extensions;
+    readonly attribute sequence<GPUExtensionName> extensions;
     readonly attribute object limits;
 
     [SameObject] readonly attribute GPUQueue defaultQueue;
@@ -501,11 +493,13 @@ GPUDevice includes GPUObjectBase;
 
     : <dfn>extensions</dfn>
     ::
-        A {{GPUExtensions}} object exposing the extensions with which this device was created.
+        A sequence containing the {{GPUExtensionName}}s of the extensions
+        supported by the device (i.e. the ones with which it was created).
 
     : <dfn>limits</dfn>
     ::
-        A {{GPULimits}} object exposing the limits with which this device was created.
+        A {{GPULimits}} object exposing the limits
+        supported by the device (i.e. the ones with which it was created).
 </dl>
 
 {{GPUDevice}} also has the following internal slots:
@@ -538,7 +532,7 @@ To get a {{GPUDevice}}, use {{GPUAdapter/requestDevice()}}.
 
 <script type=idl>
 dictionary GPUDeviceDescriptor : GPUObjectDescriptorBase {
-    GPUExtensions extensions = {};
+    sequence<GPUExtensionName> extensions = [];
     GPULimits limits = {};
 
     // TODO: are other things configurable like queues?
@@ -560,12 +554,13 @@ dictionary GPUDeviceDescriptor : GPUObjectDescriptorBase {
         (i.e. the requested extensions or limits cannot be supported),
         {{GPUAdapter/requestDevice()}} rejects with a "{{NotSupportedError}}".
 
-    1. Otherwise, a {{GPUDevice}} is created with the {{GPUExtensions}} and {{GPULimits}} specified.
+    1. Otherwise, a {{GPUDevice}} is created with the specified
+        {{GPUDeviceDescriptor/extensions}} and {{GPUDeviceDescriptor/limits}}.
 </div>
 
 <script type=idl>
-dictionary GPUExtensions {
-    boolean anisotropicFiltering = false;
+enum GPUExtensionName {
+    "anisotropic-filtering"
 };
 </script>
 


### PR DESCRIPTION
- Makes it so unknown extensions in a GPUDeviceDescriptor aren't
  blindly accepted (and will even be autovalidated by bindings code)
- Gets rid of the "have to return `object`" problem
- Gets rid of the "false vs undefined vs not-present" problem


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/518.html" title="Last updated on Dec 14, 2019, 1:44 AM UTC (554893b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/518/f6b7414...kainino0x:554893b.html" title="Last updated on Dec 14, 2019, 1:44 AM UTC (554893b)">Diff</a>