### PR TITLE
[Sketch for discussion] Separate 3d-texture depth from 2d-array-texture layer

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -194,12 +194,12 @@ typedef (sequence<unsigned long> or GPUOrigin3DDict) GPUOrigin3D;
 </script>
 
 <script type=idl>
-dictionary GPUExtent3DDict {
+dictionary GPUTextureExtent {
     required unsigned long width;
     required unsigned long height;
-    required unsigned long depth;
+    unsigned long depth = 1;
+    unsigned long arrayLayerCount = 1;
 };
-typedef (sequence<unsigned long> or GPUExtent3DDict) GPUExtent3D;
 </script>
 
 <script type=idl>
@@ -747,8 +747,7 @@ GPUTexture includes GPUObjectBase;
 
 <script type=idl>
 dictionary GPUTextureDescriptor : GPUObjectDescriptorBase {
-    required GPUExtent3D size;
-    unsigned long arrayLayerCount = 1;
+    required GPUTextureExtent size;
     unsigned long mipLevelCount = 1;
     unsigned long sampleCount = 1;
     GPUTextureDimension dimension = "2d";
@@ -812,8 +811,8 @@ internal slots of a [=texture=] internal object once we have one. -->
       - If |texture|.{{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"1d"}},
         defaults to {{GPUTextureViewDimension/"1d"}}.
       - If |texture|.{{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"2d"}}:
-          - If |texture|.{{GPUTextureDescriptor/arrayLayerCount}} is greater than 1
-            and {{GPUTextureViewDescriptor/arrayLayerCount}} is 0,
+          - If |texture|.size.{{GPUTextureExtent/arrayLayerCount}} is greater than 1
+            and size.{{GPUTextureExtent/arrayLayerCount}} is 0,
             defaults to {{GPUTextureViewDimension/"2d-array"}}.
           - Otherwise, defaults to {{GPUTextureViewDimension/"2d"}}.
       - If |texture|.{{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"3d"}},
@@ -822,8 +821,8 @@ internal slots of a [=texture=] internal object once we have one. -->
   * {{GPUTextureViewDescriptor/mipLevelCount}}:
     If 0, defaults to |texture|.{{GPUTextureDescriptor/mipLevelCount}} &minus; {{GPUTextureViewDescriptor/baseMipLevel}}.
 
-  * {{GPUTextureViewDescriptor/arrayLayerCount}}:
-    If 0, defaults to |texture|.{{GPUTextureDescriptor/arrayLayerCount}} &minus; {{GPUTextureViewDescriptor/baseArrayLayer}}.
+  * size.{{GPUTextureExtent/arrayLayerCount}}:
+    If 0, defaults to |texture|.size.{{GPUTextureExtent/arrayLayerCount}} &minus; {{GPUTextureViewDescriptor/baseArrayLayer}}.
 
 </div>
 
@@ -1579,17 +1578,17 @@ interface GPUCommandEncoder {
     void copyBufferToTexture(
         GPUBufferCopyView source,
         GPUTextureCopyView destination,
-        GPUExtent3D copySize);
+        GPUTextureExtent copySize);
 
     void copyTextureToBuffer(
         GPUTextureCopyView source,
         GPUBufferCopyView destination,
-        GPUExtent3D copySize);
+        GPUTextureExtent copySize);
 
     void copyTextureToTexture(
         GPUTextureCopyView source,
         GPUTextureCopyView destination,
-        GPUExtent3D copySize);
+        GPUTextureExtent copySize);
 
     void pushDebugGroup(DOMString groupLabel);
     void popDebugGroup();
@@ -1845,13 +1844,14 @@ interface GPUQueue {
     void copyImageBitmapToTexture(
         GPUImageBitmapCopyView source,
         GPUTextureCopyView destination,
-        GPUExtent3D copySize);
+        GPUTextureExtent copySize);
 };
 GPUQueue includes GPUObjectBase;
 </script>
 
- - {{GPUQueue/copyImageBitmapToTexture()}}:
-   - For now, `copySize.z` must be `1`.
+  - {{GPUQueue/copyImageBitmapToTexture()}}:
+      - copySize.{{GPUTextureExtent/depth}} must be 1.
+      - copySize.{{GPUTextureExtent/arrayLayerCount}} must be 1.
 
 {{GPUQueue/submit(commandBuffers)}} does nothing and produces an error if any of the following is true:
 


### PR DESCRIPTION
Tries to disentangle these two concepts.

Also theoretically makes 3d array textures expressible.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/520.html" title="Last updated on Dec 17, 2019, 1:41 AM UTC (a2a2040)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/520/ce4132a...kainino0x:a2a2040.html" title="Last updated on Dec 17, 2019, 1:41 AM UTC (a2a2040)">Diff</a>