### PR TITLE
requestDevice returns null if adapter is lost

### DIFF
--- a/design/ErrorHandling.md
+++ b/design/ErrorHandling.md
@@ -39,7 +39,8 @@ partial interface GPUDevice {
 `GPUAdapter.requestDevice` requests a device from the adapter.
 It returns a Promise which resolves when a device is ready.
 The Promise may not resolve for a long time - it resolves when the browser is ready for the application to bring up (or restore) its content.
-If the adapter is unable to create a device (i.e. because the adapter was lost), the Promise rejects.
+If the adapter is lost and therefore unable to create a device, `requestDevice()` returns null.
+If the `options` are invalid (e.g. they exceed the limits of the adapter), `requestDevice()` rejects.
 
 The `GPUDevice` may be lost if something goes fatally wrong on the device (e.g. unexpected driver error, crash, or native device loss).
 The `GPUDevice` provides a promise, `device.lost`, which resolves when the device is lost.
@@ -49,6 +50,13 @@ Once `lost` resolves, the `GPUDevice` cannot be used anymore.
 The device and all objects created from the device have become invalid.
 All further operations on the device and its objects are errors.
 The `"validationerror"` event will no longer fire. (This makes all further operations no-ops.)
+
+An app should never give up on getting WebGPU access due to
+`requestDevice` returning null or `GPUDevice.lost` resolving.
+It should only give up based on a `requestAdapter` rejection.
+(It should also give up on a `requestDevice` rejection, as that indicates an app programming error.)
+If `requestDevice` rejects, either the app has requested capabilities the adapter doesn't have,
+or the adapter has been lost and the app should `requestAdapter` again.
 
 ### Example Code
 
@@ -66,47 +74,43 @@ class MyRenderer {
       this.initFallback();
     }
   }
-  async initWebGPU() {
-    await this.ensureDevice();
-    // ... Upload resources, etc.
-  }
   initFallback() { /* try WebGL, 2D Canvas, or other fallback */ }
-  async ensureDevice() {
+  async initWebGPU() {
     // Stop rendering. (If there was already a device, WebGPU calls made before
     // the app notices the device is lost are okay - they are no-ops.)
     this.device = null;
 
     // Keep current adapter (but make a new one if there isn't a current one.)
-    // If we can't get an adapter, ensureDevice rejects and the app falls back.
-    await ensureAdapter();
-
-    try {
-      await ensureDeviceOnCurrentAdapter();
-      // Got a device.
-      return;
-    } catch (e) {
-      console.error("device request failed", e);
-      // That failed; try a new adapter entirely.
+    await tryEnsureDeviceOnCurrentAdapter();
+    // If the device is null, the adapter was lost. Try a new adapter.
+    // Continue doing this until one is found or an error is thrown.
+    while (!this.device) {
       this.adapter = null;
-      // If we can't get a new adapter, it causes ensureDevice to reject and the app to fall back.
-      await ensureAdapter();
-      await ensureDeviceOnCurrentAdapter();
+      await tryEnsureDeviceOnCurrentAdapter();
     }
+
+    // ... Upload resources, etc.
   }
-  async ensureAdapter() {
+  async tryEnsureDeviceOnCurrentAdapter() {
+    // If no adapter, get one.
+    // If we can't, rejects and the app falls back.
     if (!this.adapter) {
       // If no adapter, get one.
       // (If requestAdapter rejects, no matching adapter is available. Exit to fallback.)
       this.adapter = await gpu.requestAdapter({ /* options */ });
     }
-  }
-  async ensureDeviceOnCurrentAdapter() {
+
+    // Try to get a device.
+    //   null => try new adapter
+    //   rejection => options were invalid (app programming error)
     this.device = await this.adapter.requestDevice({ /* options */ });
-    this.device.lost.then((info) => {
-      // Device was lost.
-      console.error("device lost", info);
-      // Try to get a device again.
-      this.ensureDevice();
+    if (!this.device) {
+      return;
+    }
+    // When the device is lost, just try to get a device again.
+    device.lost.then((info) => {
+      console.error("Device was lost.", info);
+      this.initWebGPU();
     });
   }
 }

--- a/design/ErrorHandling.md
+++ b/design/ErrorHandling.md
@@ -55,8 +55,6 @@ An app should never give up on getting WebGPU access due to
 `requestDevice` returning null or `GPUDevice.lost` resolving.
 It should only give up based on a `requestAdapter` rejection.
 (It should also give up on a `requestDevice` rejection, as that indicates an app programming error.)
-If `requestDevice` rejects, either the app has requested capabilities the adapter doesn't have,
-or the adapter has been lost and the app should `requestAdapter` again.
 
 ### Example Code
 


### PR DESCRIPTION
This means all rejections from requestAdapter/requestDevice are "give up on webgpu" scenarios, simplifying the logic.