### PR TITLE
gpu.onadapteradded

### DIFF
--- a/design/ErrorHandling.md
+++ b/design/ErrorHandling.md
@@ -17,7 +17,7 @@ There is one other use case that is closely related to error handling:
 
 Meanwhile, error handling should not make the API clunky to use,
 and it should not encourage flaky code - in particular, a single system event
-should never send multiple competing signals to the application (e.g. device.lost and
+should never send multiple competing signals to the application (e.g. requestAdapter resolve and
 onadapteradded), so the application never has to worry about deduplicating signals.
 
 ## *Debugging*: Dev Tools

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -290,14 +290,40 @@ The {{Navigator/gpu}} attribute is used to access a {{GPU}} object from the main
 
 <script type=idl>
 [Exposed=Window]
-interface GPU {
+interface GPU : EventTarget {
     // May reject with DOMException  // TODO: DOMException("OperationError")?
     Promise<GPUAdapter> requestAdapter(optional GPURequestAdapterOptions options = {});
+
+    attribute EventHandler onadapteradded;
 };
 </script>
 
 <dfn interface>GPU</dfn> defines the interface of `navigator.gpu`, the entry point to WebGPU.
 It exposes {{GPU/requestAdapter()}}, for acquiring [=adapters=].
+
+{{GPU}} has the following event types:
+
+<dl dfn-type=event dfn-for=GPU>
+    : <dfn>adapteradded</dfn>
+    ::
+        A new adapter is available and may be visible via a call to {{GPU/requestAdapter()}}.
+
+        Note:
+        Handling this event is optional.
+        Applications may use this event to, for example:
+        <br>
+        (1) If initialization previously failed ({{GPU/requestAdapter()}} rejected,
+            detect when it should re-attempt initialization.
+        <br>
+        (2) If already using WebGPU, switch to a higher-power adapter if one becomes available.
+
+        Note:
+        A single system event (e.g. battery status change, or GPU connect/disconnect)
+        should never trigger multiple competing signals,
+        so it is safe to handle each such signal individually.
+        (For example, a system event may trigger multiple {{GPUDevice/lost}} signals,
+        but not both {{GPU/adapteradded}} and {{GPUDevice/lost}}.)
+</dl>
 
 ## Adapters ## {#adapters}
 


### PR DESCRIPTION
> The `GPU.onadapteradded` event fires when a new adapter is available.
> Handling this is optional.
> If the application was previously unable to initialize WebGPU,
> this is its chance to do so.
> If it is already running, it may choose to look through the new
> adapters to see if it wants to switch to one of them.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/522.html" title="Last updated on Feb 5, 2020, 10:44 PM UTC (fec4764)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/522/a8d1858...kainino0x:fec4764.html" title="Last updated on Feb 5, 2020, 10:44 PM UTC (fec4764)">Diff</a>