### PR TITLE
Pluralize requestAdapters and adjacent changes

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -144,8 +144,8 @@ These measures are similar to those used in WebGL.
 
 ## Fingerprinting ## {#security-fingerprint}
 WebGPU defines the lowest allowed limits and capabilities of any {{GPUAdapter}}.
-and encourages applications to target these standard limits. The actual result from
-{{GPU/requestAdapter()}} may have higher limits, and could be subject to finger printing.
+and encourages applications to target these standard limits. The actual results from
+{{GPU/requestAdapters()}} may have higher limits, and could be subject to fingerprinting.
 
 
 Terminology &amp; Conventions {#terminology-and-conventions}
@@ -496,19 +496,19 @@ partial interface WorkerNavigator {
 <script type=idl>
 [Exposed=(Window, DedicatedWorker)]
 interface GPU {
-    Promise<GPUAdapter> requestAdapter(optional GPURequestAdapterOptions options = {});
+    Promise<sequence<GPUAdapter>> requestAdapters(optional GPURequestAdapterOptions options = {});
 };
 </script>
 
 {{GPU}} has the methods defined by the following sections.
 
-### <dfn method for=GPU>requestAdapter(options)</dfn> ### {#requestadapter}
+### <dfn method for=GPU>requestAdapters(options)</dfn> ### {#requestadapter}
 
-<div algorithm=requestAdapter>
+<div algorithm=requestAdapters>
     **Arguments:**
       - optional {{GPURequestAdapterOptions}} |options| = {}
 
-    **Returns:** |promise|, of type Promise<{{GPUAdapter}}>.
+    **Returns:** |promise|, of type Promise<sequence<{{GPUAdapter}}>>.
 
     Requests an [=adapter=] from the user agent.
     The user agent chooses whether to return an adapter, and, if so,
@@ -516,9 +516,13 @@ interface GPU {
 
     Returns [=a new promise=], |promise|.
 
-      - If the user agent chooses to return an adapter,
-        |promise| [=resolves=] with a new {{GPUAdapter}} encapsulating
-        a new [=adapter=].
+      - If the user agent chooses to return adapters, |promise| [=resolves=]
+        with a sequence of *at least one* {{GPUAdapter}} objects.
+        If a {{GPUAdapter}} represents an [=adapter=] which was previously
+        returned to this [=agent=], it will be returned as the same {{GPUAdapter}} object.
+        The order and contents of this sequence are influenced by the provided
+        {{GPURequestAdapterOptions}} {{GPU/requestAdapters()/options}}.
+
       - Otherwise, |promise| [=rejects=] with an {{OperationError}}.
 
     Issue: Figure out how to integrate the options.
@@ -546,14 +550,16 @@ enum GPUPowerPreference {
 <dl dfn-type=dict-member dfn-for=GPURequestAdapterOptions>
     : <dfn>powerPreference</dfn>
     ::
-        Optionally provides a hint indicating what class of [=adapter=] should be selected from
-        the system's available adapters.
+        Optionally provides a hint indicating what class of [=adapter=] should be preferred.
 
-        The value of this hint may influence which adapter is chosen, but it must not
-        influence whether an adapter is returned or not.
+        The adapters returned for the request will be ordered according to preference,
+        with preferred adapters appearing at the beginning of the list.
+
+        This hint may also influence which adapters are or are not returned for the request.
 
         Note:
-        The primary utility of this hint is to influence which GPU is used in a multi-GPU system.
+        The primary utility of this hint is to influence which GPU is listed
+        first in a multi-GPU system.
         For instance, some laptops have a low-power integrated GPU and a high-performance
         discrete GPU.
 
@@ -600,7 +606,7 @@ enum GPUPowerPreference {
 A {{GPUAdapter}} encapsulates an [=adapter=],
 and describes its capabilities (extensions and limits).
 
-To get a {{GPUAdapter}}, use {{GPU/requestAdapter()}}.
+To get a {{GPUAdapter}}, use `navigator.gpu.`{{GPU/requestAdapters()}}.
 
 <script type=idl>
 interface GPUAdapter {


### PR DESCRIPTION
We made requestAdapter singular due to fingerprinting concerns, IIRC.

- `requestAdapters` is not any more prone to fingerprinting. The UA can choose to put whichever adapters it wants in the list. Any adapters returned from it could have been found by searching the space of possible `requestAdapter` calls.
- Many applications would end up trying to get every adapter they can find (by searching the space ...) and then using their own logic to pick among them. This prevents apps from needing that pattern.
- `requestAdapters` still allows an easy default: e.g. ask for `"low-power"`, then get adapter `[0]`.
- `requestAdapter` is hostile to any situation where the UA **does** want to give a little more trust to the app, perhaps Electron, Node, or even installed PWAs.

~Finally, adds `hasMajorPerformanceCaveat` as one thing that pluralizing `requestAdapters` enables simply.~ (EDIT: will figure out later)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/524.html" title="Last updated on Jan 13, 2020, 10:53 PM UTC (2471512)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/524/c1e5ed4...kainino0x:2471512.html" title="Last updated on Jan 13, 2020, 10:53 PM UTC (2471512)">Diff</a>