### PR TITLE
Add initial spec for buffer mapping.

### DIFF
--- a/spec/Makefile
+++ b/spec/Makefile
@@ -1,7 +1,7 @@
 all: index.html webgpu.idl
 
 index.html: index.bs
-	bikeshed --die-on=everything spec index.bs
+	bikeshed  spec index.bs
 
 webgpu.idl: index.bs extract-idl.py
 	python extract-idl.py index.bs > webgpu.idl

--- a/spec/Makefile
+++ b/spec/Makefile
@@ -1,7 +1,7 @@
 all: index.html webgpu.idl
 
 index.html: index.bs
-	bikeshed  spec index.bs
+	bikeshed --die-on=everything spec index.bs
 
 webgpu.idl: index.bs extract-idl.py
 	python extract-idl.py index.bs > webgpu.idl

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -847,7 +847,7 @@ Note:
         {{GPUBuffer/[[mapping]]}}
      - [=buffer state/mapped for reading=] and [=buffer state/mapped for writing=]
         with an {{ArrayBuffer}} typed {{GPUBuffer/[[mapping]]}}.
-    - [=buffer state/mapping pending for reading=] and [=buffer state/mapping pending for writing=]
+     - [=buffer state/mapping pending for reading=] and [=buffer state/mapping pending for writing=]
         with an {{Promise}} typed {{GPUBuffer/[[mapping]]}}.
 </div>
 
@@ -992,7 +992,7 @@ Issue: Add client-side validation that a mapped buffer can only be unmapped and 
                 if {{[[state]]}} isn't [=buffer state/unmapped=]:
 
                 1. Record a validation error on the current scope.
-                1. Return a new promise that rejects.
+                1. Return [=a promise rejected with=] an {{AbortError}}.
 
                 Issue: Specify that the rejection happens on the device timeline.
 
@@ -1025,7 +1025,7 @@ Issue: Add client-side validation that a mapped buffer can only be unmapped and 
                 if {{[[state]]}} isn't [=buffer state/unmapped=]:
 
                 1. Record a validation error on the current scope.
-                1. Return a new promise that rejects.
+                1. Return [=a promise rejected with=] an {{AbortError}}.
 
                 Issue: Specify that the rejection happens on the device timeline.
 
@@ -1058,7 +1058,7 @@ Issue: Add client-side validation that a mapped buffer can only be unmapped and 
 
             1. If the {{[[mapping]]}} slot of |this| is a {{Promise}}:
 
-                1. Reject {{[[mapping]]}}.
+                1. [=Reject=] {{[[mapping]]}} with an {{AbortError}}.
                 1. Set the {{[[mapping]]}} slot of |this| to null.
 
             1. If the {{[[mapping]]}} slot of |this| is an {{ArrayBuffer}}:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -913,7 +913,7 @@ dictionary GPUBufferDescriptor : GPUObjectDescriptorBase {
                 1. Create an invalid {{GPUBuffer}} and return the result.
 
             1. Let |b| be a new {{GPUBuffer}} object.
-            1. Let |m| be an {{ArrayBuffer}} of size the {{GPUBuffer/[[size]]}} slot of |b| filled with zeroes.
+            1. Let |m| be a zero-filled {{ArrayBuffer}} of size the {{GPUBuffer/[[size]]}} slot of |b|.
             1. Set the {{GPUBuffer/[[size]]}} slot of |b| to the value of the {{GPUBufferDescriptor/size}} attribute of |descriptor|.
             1. Set the {{GPUBuffer/[[usage]]}} slot of |b| to the value of the {{GPUBufferDescriptor/usage}} attribute of |descriptor|.
             1. Set the {{GPUBuffer/[[state]]}} internal slot of |b| to [=buffer state/mapped for writing=].
@@ -989,7 +989,7 @@ it can be used by the GPU again.
 
             1. Let |p| be a new {{Promise}}.
             1. Set the {{[[mapping_promise]]}} slot of |this| to |p|.
-            1. Set the {{[[state]]}} slot of |this| to [=buffer state/mapped for reading=]
+            1. Set the {{[[state]]}} slot of |this| to [=buffer state/mapped for reading=].
             1. Enqueue an operation on the [=Queue timeline=] that will execute the following:
 
                 1. Let |m| be a new {{ArrayBuffer}} of size the {{[[size]]}} of |this|.
@@ -1014,7 +1014,7 @@ it can be used by the GPU again.
 
             1. Let |p| be a new {{Promise}}.
             1. Set the {{[[mapping_promise]]}} slot of |this| to |p|.
-            1. Set the {{[[state]]}} slot of |this| to [=buffer state/mapped for writing=]
+            1. Set the {{[[state]]}} slot of |this| to [=buffer state/mapped for writing=].
             1. Enqueue an operation on the [=Queue timeline=] that will execute the following:
 
                 1. Let |m| be a new {{ArrayBuffer}} of size the {{[[size]]}} of |this| that is filled with zeroes.
@@ -1034,7 +1034,7 @@ it can be used by the GPU again.
             1. If the {{[[state]]}} slot of |this| is not [=buffer state/mapped for reading=] or [=buffer state/mapped for writing=]:
 
                 1. Record a validation error on the current scope.
-                1. Return
+                1. Return.
 
             1. If the {{[[mapping_promise]]}} slot of |this| is not null:
 
@@ -1050,7 +1050,7 @@ it can be used by the GPU again.
                 1. Detach the {{ArrayBuffer}} in the {{[[mapping]]}} slot of |this|.
                 1. Set the {{[[mapping]]}} slot of |this| to null.
 
-            1. Set the {{[[state]]}} slot of |this| to [=buffer state/unmapped=]
+            1. Set the {{[[state]]}} slot of |this| to [=buffer state/unmapped=].
 
         </div>
 </dl>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -783,9 +783,10 @@ its mapping.
 {{GPUBuffer|GPUBuffers}} can be created via the following functions:
 
  - {{GPUDevice/createBuffer(descriptor)|GPUDevice.createBuffer(descriptor)}}
-     that returns a new unmapped buffer.
+     that returns a new buffer in the [=buffer state/unmapped=] state.
  - {{GPUDevice/createBufferMapped(descriptor)|GPUDevice.createBufferMapped(descriptor)}}
-     that returns a new mapped buffer and its mapping.
+     that returns a new buffer in the [=buffer state/mapped for writing=] state and its
+     mapping.
 
 <script type=idl>
 [Serializable]
@@ -814,17 +815,13 @@ GPUBuffer includes GPUObjectBase;
     ::
         The current state of the {{GPUBuffer}}.
 
-    : <dfn>\[[mapping]]</dfn> of type {{ArrayBuffer}}.
+    : <dfn>\[[mapping]]</dfn> of type {{ArrayBuffer}} or {{Promise}} or `null`.
     ::
         The mapping for this {{GPUBuffer}}.
-
-    : <dfn>\[[mapping_promise]]</dfn> of type {{Promise}}.
-    ::
-        A promise for the mapping.
 </dl>
 
-Each {{GPUBuffer}} has a current <dfn dfn>buffer state</dfn> which is one of
-the following:
+Each {{GPUBuffer}} has a current <dfn dfn>buffer state</dfn> on the [=Content timeline=]
+which is one of the following:
 
  - "<dfn dfn for="buffer state">mapped for reading</dfn>" where the {{GPUBuffer}} is
      available for CPU operations reading its content.
@@ -843,12 +840,16 @@ Note:
 {{GPUBuffer/[[size]]}} and {{GPUBuffer/[[usage]]}} are immutable once the
 {{GPUBuffer}} has been created.
 
-Note:
-{{GPUBuffer}}'s {{GPUBuffer/[[state]]}} is a state machine where the states are
-[=buffer state/unmapped=], [=buffer state/destroyed=], [=buffer state/mapped for reading=] /
-[=buffer state/mapped for writing=] along with a non-null {{GPUBuffer/[[mapping]]}}, or
-[=buffer state/mapping pending for reading=] / [=buffer state/mapping pending for writing=] along
-with a non-null {{GPUBuffer/[[mapping_promise]]}}.
+<div class=note>
+    {{GPUBuffer}} has a state machine where the states are:
+
+     - [=buffer state/unmapped=] and [=buffer state/destroyed=] with a `null`
+        {{GPUBuffer/[[mapping]]}}
+     - [=buffer state/mapped for reading=] and [=buffer state/mapped for writing=]
+        with an {{ArrayBuffer}} typed {{GPUBuffer/[[mapping]]}}.
+    - [=buffer state/mapping pending for reading=] and [=buffer state/mapping pending for writing=]
+        with an {{Promise}} typed {{GPUBuffer/[[mapping]]}}.
+</div>
 
 {{GPUBuffer}} is {{Serializable}}. It is a reference to an internal buffer
 object, and {{Serializable}} means that the reference can be *copied* between
@@ -899,7 +900,6 @@ dictionary GPUBufferDescriptor : GPUObjectDescriptorBase {
             1. Set the {{GPUBuffer/[[usage]]}} slot of |b| to the value of the {{GPUBufferDescriptor/usage}} attribute of |descriptor|.
             1. Set the {{GPUBuffer/[[state]]}} internal slot of |b| to [=buffer state/unmapped=].
             1. Set the {{GPUBuffer/[[mapping]]}} internal slot of |b| to `null`.
-            1. Set the {{GPUBuffer/[[mapping_promise]]}} internal slot of |b| to `null`.
             1. Set each byte of |b|'s allocation to zero.
             1. Return |b|.
         </div>
@@ -923,7 +923,6 @@ dictionary GPUBufferDescriptor : GPUObjectDescriptorBase {
             1. Set the {{GPUBuffer/[[usage]]}} slot of |b| to the value of the {{GPUBufferDescriptor/usage}} attribute of |descriptor|.
             1. Set the {{GPUBuffer/[[state]]}} internal slot of |b| to [=buffer state/mapped for writing=].
             1. Set the {{GPUBuffer/[[mapping]]}} internal slot of |b| to |m|.
-            1. Set the {{GPUBuffer/[[mapping_promise]]}} internal slot of |b| to `null`.
             1. Set each byte of |b|'s allocation to zero.
             1. Return a sequence containing |b| and |m| in that order.
         </div>
@@ -971,14 +970,14 @@ interface GPUBufferUsage {
 
 An application can request to map a {{GPUBuffer}} to get its mapping which is
 an {{ArrayBuffer}} representing the {{GPUBuffer}}'s allocation. Mappings are
-requested asynchronously so that the user agent can ensure the GPU is finished
+requested asynchronously so that the user agent can ensure the GPU finished
 using the {{GPUBuffer}} before the application gets its mapping. Mappings can
 be requested for reading with {{GPUBuffer/mapReadAsync}} or writing with
 {{GPUBuffer/mapWriteAsync}}. A mapped {{GPUBuffer}} cannot be used by the GPU
-and must be unmapped using {{GPUBuffer/unmap}} before it can be used by the GPU
-again.
+and must be unmapped using {{GPUBuffer/unmap}} before it can be used on the
+[=Queue timeline=].
 
-<!-- TODO(kangz) add client-side validation that a mapped buffer can only be destroyed on the worker on which it was mapped -->
+Issue: Add client-side validation that a mapped buffer can only be unmapped and destroyed on the worker on which it was mapped.
 
 ### {{GPUBuffer/mapReadAsync|GPUDevice.mapReadAsync}} ### {#GPUBuffer-mapReadAsync}
 
@@ -986,14 +985,19 @@ again.
     : <dfn>mapReadAsync()</dfn>
     ::
         <div algorithm="GPUBuffer.mapReadAsync()">
-            <!-- TODO(kangz) handle error buffers once we have a description of the error monad -->
-            1. If the {{[[usage]]}} slot of |this| doesn't contain the {{GPUBufferUsage/MAP_READ}} bit:
+
+            Issue: Handle error buffers once we have a description of the error monad.
+
+            1. If the {{[[usage]]}} slot of |this| doesn't contain the {{GPUBufferUsage/MAP_READ}} bit or
+                if {{[[state]]}} isn't [=buffer state/unmapped=]:
 
                 1. Record a validation error on the current scope.
-                1. Return a new promise that rejects. <!-- TODO(kangz) specify on that it happens on the device timeline-->
+                1. Return a new promise that rejects.
+
+                Issue: Specify that the rejection happens on the device timeline.
 
             1. Let |p| be a new {{Promise}}.
-            1. Set the {{[[mapping_promise]]}} slot of |this| to |p|.
+            1. Set the {{[[mapping]]}} slot of |this| to |p|.
             1. Set the {{[[state]]}} slot of |this| to [=buffer state/mapping pending for reading=].
             1. Enqueue an operation on the [=Queue timeline=] that will execute the following:
 
@@ -1014,14 +1018,19 @@ again.
     : <dfn>mapWriteAsync()</dfn>
     ::
         <div algorithm="GPUBuffer.mapWriteAsync()">
-            <!-- TODO(kangz) handle error buffers once we have a description of the error monad -->
-            1. If the {{[[usage]]}} slot of |this| doesn't contain the {{GPUBufferUsage/MAP_WRITE}} bit:
+
+            Issue: Handle error buffers once we have a description of the error monad.
+
+            1. If the {{[[usage]]}} slot of |this| doesn't contain the {{GPUBufferUsage/MAP_WRITE}} bit or
+                if {{[[state]]}} isn't [=buffer state/unmapped=]:
 
                 1. Record a validation error on the current scope.
-                1. Return a new promise that rejects. <!-- TODO(kangz) specify on that it happens on the device timeline-->
+                1. Return a new promise that rejects.
+
+                Issue: Specify that the rejection happens on the device timeline.
 
             1. Let |p| be a new {{Promise}}.
-            1. Set the {{[[mapping_promise]]}} slot of |this| to |p|.
+            1. Set the {{[[mapping]]}} slot of |this| to |p|.
             1. Set the {{[[state]]}} slot of |this| to [=buffer state/mapping pending for writing=].
             1. Enqueue an operation on the [=Queue timeline=] that will execute the following:
 
@@ -1047,18 +1056,18 @@ again.
                 1. Record a validation error on the current scope.
                 1. Return.
 
-            1. If the {{[[mapping_promise]]}} slot of |this| is not null:
+            1. If the {{[[mapping]]}} slot of |this| is a {{Promise}}:
 
-                1. Reject {{[[mapping_promise]]}}.
-                1. Set the {{[[mapping_promise]]}} slot of |this| to null.
+                1. Reject {{[[mapping]]}}.
+                1. Set the {{[[mapping]]}} slot of |this| to null.
 
-            1. If the {{[[mapping]]}} slot of |this| is not null:
+            1. If the {{[[mapping]]}} slot of |this| is an {{ArrayBuffer}}:
 
                 1. If the {{[[state]]}} slot of this is [=buffer state/mapped for writing=]:
 
                     1. Enqueue an operation on the [=Queue timeline=] that updates |this|'s allocation to the content of the {{ArrayBuffer}} in the {{[[mapping]]}} slot of |this|.
 
-                1. Detach the {{ArrayBuffer}} in the {{[[mapping]]}} slot of |this|.
+                1. Detach |this|.{{[[mapping]]}} from its content.
                 1. Set the {{[[mapping]]}} slot of |this| to null.
 
             1. Set the {{[[state]]}} slot of |this| to [=buffer state/unmapped=].

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -827,9 +827,13 @@ Each {{GPUBuffer}} has a current <dfn dfn>buffer state</dfn> which is one of
 the following:
 
  - "<dfn dfn for="buffer state">mapped for reading</dfn>" where the {{GPUBuffer}} is
-     available for CPU operations.
+     available for CPU operations reading its content.
  - "<dfn dfn for="buffer state">mapped for writing</dfn>" where the {{GPUBuffer}} is
-     available for CPU operations.
+     available for CPU operations writing its content.
+ - "<dfn dfn for="buffer state">mapping pending for reading</dfn>" where the {{GPUBuffer}} is
+     being made available for reading its content.
+ - "<dfn dfn for="buffer state">mapping pending for writing</dfn>" where the {{GPUBuffer}} is
+     being made available for writing its content.
  - "<dfn dfn for="buffer state">unmapped</dfn>" where the {{GPUBuffer}} is
      available for GPU operations.
  - "<dfn dfn for="buffer state">destroyed</dfn>" where the {{GPUBuffer}} is
@@ -840,10 +844,11 @@ Note:
 {{GPUBuffer}} has been created.
 
 Note:
-At most one of {{GPUBuffer/[[mapping]]}} and {{GPUBuffer/[[mapping_promise]]}}
-is non-null and at least one of them is non-null if and only if the
-{{GPUBuffer/[[state]]}} is [=buffer state/mapped for reading=] or
-[=buffer state/mapped for writing=].
+{{GPUBuffer}}'s {{GPUBuffer/[[state]]}} is a state machine where the states are
+[=buffer state/unmapped=], [=buffer state/destroyed=], [=buffer state/mapped for reading=] /
+[=buffer state/mapped for writing=] along with a non-null {{GPUBuffer/[[mapping]]}}, or
+[=buffer state/mapping pending for reading=] / [=buffer state/mapping pending for writing=] along
+with a non-null {{GPUBuffer/[[mapping_promise]]}}.
 
 {{GPUBuffer}} is {{Serializable}}. It is a reference to an internal buffer
 object, and {{Serializable}} means that the reference can be *copied* between
@@ -970,8 +975,8 @@ requested asynchronously so that the user agent can ensure the GPU is finished
 using the {{GPUBuffer}} before the application gets its mapping. Mappings can
 be requested for reading with {{GPUBuffer/mapReadAsync}} or writing with
 {{GPUBuffer/mapWriteAsync}}. A mapped {{GPUBuffer}} cannot be used by the GPU
-and must be unmapped using {{GPUBuffer/unmap}} or {{GPUBuffer/destroy}} before
-it can be used by the GPU again.
+and must be unmapped using {{GPUBuffer/unmap}} before it can be used by the GPU
+again.
 
 <!-- TODO(kangz) add client-side validation that a mapped buffer can only be destroyed on the worker on which it was mapped -->
 
@@ -989,12 +994,15 @@ it can be used by the GPU again.
 
             1. Let |p| be a new {{Promise}}.
             1. Set the {{[[mapping_promise]]}} slot of |this| to |p|.
-            1. Set the {{[[state]]}} slot of |this| to [=buffer state/mapped for reading=].
+            1. Set the {{[[state]]}} slot of |this| to [=buffer state/mapping pending for reading=].
             1. Enqueue an operation on the [=Queue timeline=] that will execute the following:
 
                 1. Let |m| be a new {{ArrayBuffer}} of size the {{[[size]]}} of |this|.
                 1. Set the content of |m| to the content of |this|'s allocation.
-                1. Resolve |p| with |m| if it is not already rejected.
+                1. Set the {{[[state]]}} slot of |this| to [=buffer state/mapped for reading=].
+                1. If |p| is pending:
+
+                    1. Resolve |p| with |m|.
 
             1. Return |p|.
         </div>
@@ -1014,11 +1022,14 @@ it can be used by the GPU again.
 
             1. Let |p| be a new {{Promise}}.
             1. Set the {{[[mapping_promise]]}} slot of |this| to |p|.
-            1. Set the {{[[state]]}} slot of |this| to [=buffer state/mapped for writing=].
+            1. Set the {{[[state]]}} slot of |this| to [=buffer state/mapping pending for writing=].
             1. Enqueue an operation on the [=Queue timeline=] that will execute the following:
 
                 1. Let |m| be a new {{ArrayBuffer}} of size the {{[[size]]}} of |this| that is filled with zeroes.
-                1. Resolve |p| with |m| if it is not already rejected.
+                1. Set the {{[[state]]}} slot of |this| to [=buffer state/mapped for writing=].
+                1. If |p| is pending:
+
+                    1. Resolve |p| with |m|.
 
             1. Return |p|.
         </div>
@@ -1031,14 +1042,14 @@ it can be used by the GPU again.
     ::
         <div algorithm="GPUBuffer.unmap()">
 
-            1. If the {{[[state]]}} slot of |this| is not [=buffer state/mapped for reading=] or [=buffer state/mapped for writing=]:
+            1. If the {{[[state]]}} slot of |this| is [=buffer state/unmapped=] or [=buffer state/destroyed=]:
 
                 1. Record a validation error on the current scope.
                 1. Return.
 
             1. If the {{[[mapping_promise]]}} slot of |this| is not null:
 
-                1. Reject the promise in {{[[mapping_promise]]}}.
+                1. Reject {{[[mapping_promise]]}}.
                 1. Set the {{[[mapping_promise]]}} slot of |this| to null.
 
             1. If the {{[[mapping]]}} slot of |this| is not null:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -782,8 +782,10 @@ its mapping.
 
 {{GPUBuffer|GPUBuffers}} can be created via the following functions:
 
- - {{GPUDevice/createBuffer(descriptor)|GPUDevice.createBuffer(descriptor)}} that returns a new unmapped buffer.
- - {{GPUDevice/createBufferMapped(descriptor)|GPUDevice.createBufferMapped(descriptor)}} that returns a mapped buffer and its mapping.
+ - {{GPUDevice/createBuffer(descriptor)|GPUDevice.createBuffer(descriptor)}}
+     that returns a new unmapped buffer.
+ - {{GPUDevice/createBufferMapped(descriptor)|GPUDevice.createBufferMapped(descriptor)}}
+     that returns a new mapped buffer and its mapping.
 
 <script type=idl>
 [Serializable]
@@ -811,16 +813,37 @@ GPUBuffer includes GPUObjectBase;
     : <dfn>\[[state]]</dfn> of type [=buffer state=].
     ::
         The current state of the {{GPUBuffer}}.
+
+    : <dfn>\[[mapping]]</dfn> of type {{ArrayBuffer}}.
+    ::
+        The mapping for this {{GPUBuffer}}.
+
+    : <dfn>\[[mapping_promise]]</dfn> of type {{Promise}}.
+    ::
+        A promise for the mapping.
 </dl>
 
-Each {{GPUBuffer}} has a current <dfn dfn>buffer state</dfn> which is one of the following:
+Each {{GPUBuffer}} has a current <dfn dfn>buffer state</dfn> which is one of
+the following:
 
- - "<dfn dfn for="buffer state">mapped</dfn>" where the {{GPUBuffer}} is available for CPU operations.
- - "<dfn dfn for="buffer state">unmapped</dfn>" where the {{GPUBuffer}} is available for GPU operations.
- - "<dfn dfn for="buffer state">destroyed</dfn>" where the {{GPUBuffer}} is no longer available for any operations except {{GPUBuffer/destroy}}.
+ - "<dfn dfn for="buffer state">mapped for reading</dfn>" where the {{GPUBuffer}} is
+     available for CPU operations.
+ - "<dfn dfn for="buffer state">mapped for writing</dfn>" where the {{GPUBuffer}} is
+     available for CPU operations.
+ - "<dfn dfn for="buffer state">unmapped</dfn>" where the {{GPUBuffer}} is
+     available for GPU operations.
+ - "<dfn dfn for="buffer state">destroyed</dfn>" where the {{GPUBuffer}} is
+     no longer available for any operations except {{GPUBuffer/destroy}}.
 
 Note:
-{{GPUBuffer/[[size]]}} and {{GPUBuffer/[[usage]]}} are immutable once the {{GPUBuffer}} has been created.
+{{GPUBuffer/[[size]]}} and {{GPUBuffer/[[usage]]}} are immutable once the
+{{GPUBuffer}} has been created.
+
+Note:
+At most one of {{GPUBuffer/[[mapping]]}} and {{GPUBuffer/[[mapping_promise]]}}
+is non-null and at least one of them is non-null if and only if the
+{{GPUBuffer/[[state]]}} is [=buffer state/mapped for reading=] or
+[=buffer state/mapped for writing=].
 
 {{GPUBuffer}} is {{Serializable}}. It is a reference to an internal buffer
 object, and {{Serializable}} means that the reference can be *copied* between
@@ -870,8 +893,34 @@ dictionary GPUBufferDescriptor : GPUObjectDescriptorBase {
             1. Set the {{GPUBuffer/[[size]]}} slot of |b| to the value of the {{GPUBufferDescriptor/size}} attribute of |descriptor|.
             1. Set the {{GPUBuffer/[[usage]]}} slot of |b| to the value of the {{GPUBufferDescriptor/usage}} attribute of |descriptor|.
             1. Set the {{GPUBuffer/[[state]]}} internal slot of |b| to [=buffer state/unmapped=].
+            1. Set the {{GPUBuffer/[[mapping]]}} internal slot of |b| to `null`.
+            1. Set the {{GPUBuffer/[[mapping_promise]]}} internal slot of |b| to `null`.
             1. Set each byte of |b|'s allocation to zero.
             1. Return |b|.
+        </div>
+</dl>
+
+### {{GPUDevice/createBufferMapped(descriptor)|GPUDevice.createBufferMapped(descriptor)}} ### {#GPUDevice-createBufferMapped}
+
+<dl dfn-type="method" dfn-for="GPUDevice">
+    : <dfn>createBufferMapped(descriptor)</dfn>
+    ::
+        <div algorithm="GPUDevice.createBufferMapped(descriptor)">
+            1. If the result of [$validating GPUBufferDescriptor$](this, descriptor) is false:
+
+                1. Record a validation error in the current scope.
+                <!-- TODO(kangz): Once we have a description of the error monad, explain what the error buffer is. -->
+                1. Create an invalid {{GPUBuffer}} and return the result.
+
+            1. Let |b| be a new {{GPUBuffer}} object.
+            1. Let |m| be an {{ArrayBuffer}} of size the {{GPUBuffer/[[size]]}} slot of |b| filled with zeroes.
+            1. Set the {{GPUBuffer/[[size]]}} slot of |b| to the value of the {{GPUBufferDescriptor/size}} attribute of |descriptor|.
+            1. Set the {{GPUBuffer/[[usage]]}} slot of |b| to the value of the {{GPUBufferDescriptor/usage}} attribute of |descriptor|.
+            1. Set the {{GPUBuffer/[[state]]}} internal slot of |b| to [=buffer state/mapped for writing=].
+            1. Set the {{GPUBuffer/[[mapping]]}} internal slot of |b| to |m|.
+            1. Set the {{GPUBuffer/[[mapping_promise]]}} internal slot of |b| to `null`.
+            1. Set each byte of |b|'s allocation to zero.
+            1. Return a sequence containing |b| and |m| in that order.
         </div>
 </dl>
 
@@ -881,14 +930,14 @@ An application that no longer requires a {{GPUBuffer}} can choose to lose
 access to it before garbage collection by calling {{GPUBuffer/destroy()}}.
 
 Note: This allows the user agent to reclaim the GPU memory associated with the {{GPUBuffer}}
- once all previously submitted operations using it are complete.
+once all previously submitted operations using it are complete.
 
 <dl dfn-type="method" dfn-for="GPUBuffer">
     : <dfn>destroy()</dfn>
     ::
         <div algorithm="GPUBuffer.destroy()">
             <!-- TODO(kangz) handle error buffers once we have a description of the error monad -->
-            1. If the {{[[state]]}} slot of |this| is [=buffer state/mapped=]
+            1. If the {{[[state]]}} slot of |this| is [=buffer state/mapped for reading=] or [=buffer state/mapped for writing=]:
 
                 1. Run the steps to unmap `"this"`
 
@@ -914,6 +963,97 @@ interface GPUBufferUsage {
 </script>
 
 ## Buffer Mapping ## {#buffer-mapping}
+
+An application can request to map a {{GPUBuffer}} to get its mapping which is
+an {{ArrayBuffer}} representing the {{GPUBuffer}}'s allocation. Mappings are
+requested asynchronously so that the user agent can ensure the GPU is finished
+using the {{GPUBuffer}} before the application gets its mapping. Mappings can
+be requested for reading with {{GPUBuffer/mapReadAsync}} or writing with
+{{GPUBuffer/mapWriteAsync}}. A mapped {{GPUBuffer}} cannot be used by the GPU
+and must be unmapped using {{GPUBuffer/unmap}} or {{GPUBuffer/destroy}} before
+it can be used by the GPU again.
+
+<!-- TODO(kangz) add client-side validation that a mapped buffer can only be destroyed on the worker on which it was mapped -->
+
+### {{GPUBuffer/mapReadAsync|GPUDevice.mapReadAsync}} ### {#GPUBuffer-mapReadAsync}
+
+<dl dfn-type="method" dfn-for="GPUBuffer">
+    : <dfn>mapReadAsync()</dfn>
+    ::
+        <div algorithm="GPUBuffer.mapReadAsync()">
+            <!-- TODO(kangz) handle error buffers once we have a description of the error monad -->
+            1. If the {{[[usage]]}} slot of |this| doesn't contain the {{GPUBufferUsage/MAP_READ}} bit:
+
+                1. Record a validation error on the current scope.
+                1. Return a new promise that rejects. <!-- TODO(kangz) specify on that it happens on the device timeline-->
+
+            1. Let |p| be a new {{Promise}}.
+            1. Set the {{[[mapping_promise]]}} slot of |this| to |p|.
+            1. Set the {{[[state]]}} slot of |this| to [=buffer state/mapped for reading=]
+            1. Enqueue an operation on the [=Queue timeline=] that will execute the following:
+
+                1. Let |m| be a new {{ArrayBuffer}} of size the {{[[size]]}} of |this|.
+                1. Set the content of |m| to the content of |this|'s allocation.
+                1. Resolve |p| with |m| if it is not already rejected.
+
+            1. Return |p|.
+        </div>
+</dl>
+
+### {{GPUBuffer/mapWriteAsync|GPUDevice.mapWriteAsync}} ### {#GPUBuffer-mapWriteAsync}
+
+<dl dfn-type="method" dfn-for="GPUBuffer">
+    : <dfn>mapWriteAsync()</dfn>
+    ::
+        <div algorithm="GPUBuffer.mapWriteAsync()">
+            <!-- TODO(kangz) handle error buffers once we have a description of the error monad -->
+            1. If the {{[[usage]]}} slot of |this| doesn't contain the {{GPUBufferUsage/MAP_WRITE}} bit:
+
+                1. Record a validation error on the current scope.
+                1. Return a new promise that rejects. <!-- TODO(kangz) specify on that it happens on the device timeline-->
+
+            1. Let |p| be a new {{Promise}}.
+            1. Set the {{[[mapping_promise]]}} slot of |this| to |p|.
+            1. Set the {{[[state]]}} slot of |this| to [=buffer state/mapped for writing=]
+            1. Enqueue an operation on the [=Queue timeline=] that will execute the following:
+
+                1. Let |m| be a new {{ArrayBuffer}} of size the {{[[size]]}} of |this| that is filled with zeroes.
+                1. Resolve |p| with |m| if it is not already rejected.
+
+            1. Return |p|.
+        </div>
+</dl>
+
+### {{GPUBuffer/unmap|GPUBuffer.unmap()}} ### {#GPUBuffer-unmap}
+
+<dl dfn-type="method" dfn-for="GPUBuffer">
+    : <dfn>unmap()</dfn>
+    ::
+        <div algorithm="GPUBuffer.unmap()">
+
+            1. If the {{[[state]]}} slot of |this| is not [=buffer state/mapped for reading=] or [=buffer state/mapped for writing=]:
+
+                1. Record a validation error on the current scope.
+                1. Return
+
+            1. If the {{[[mapping_promise]]}} slot of |this| is not null:
+
+                1. Reject the promise in {{[[mapping_promise]]}}.
+                1. Set the {{[[mapping_promise]]}} slot of |this| to null.
+
+            1. If the {{[[mapping]]}} slot of |this| is not null:
+
+                1. If the {{[[state]]}} slot of this is [=buffer state/mapped for writing=]:
+
+                    1. Enqueue an operation on the [=Queue timeline=] that updates |this|'s allocation to the content of the {{ArrayBuffer}} in the {{[[mapping]]}} slot of |this|.
+
+                1. Detach the {{ArrayBuffer}} in the {{[[mapping]]}} slot of |this|.
+                1. Set the {{[[mapping]]}} slot of |this| to null.
+
+            1. Set the {{[[state]]}} slot of |this| to [=buffer state/unmapped=]
+
+        </div>
+</dl>
 
 Textures {#textures}
 ====================


### PR DESCRIPTION
PTAL

I tried to make things very explicit, but we're lacking concepts for the "queue timeline progression", error scopes, "error monad" and others in the spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/525.html" title="Last updated on Jan 10, 2020, 10:57 AM UTC (8cd3d17)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/525/420d477...Kangz:8cd3d17.html" title="Last updated on Jan 10, 2020, 10:57 AM UTC (8cd3d17)">Diff</a>