### PR TITLE
Add a validation rule for buffer binding

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1238,6 +1238,8 @@ The <dfn method for="GPUDevice">createBindGroupLayout(|descriptor|)</dfn> method
 1. Let |layout| be a new valid {{GPUBindGroupLayout}} object.
 1. For each {{GPUBindGroupLayoutBinding}} |bindingDescriptor| in |descriptor|.{{GPUBindGroupLayoutDescriptor/bindings}}:
     1. Ensure |bindingDescriptor|.{{GPUBindGroupLayoutBinding/binding}} does not violate [=binding validation=].
+    1. If |bindingDescriptor|.{{GPUBindGroupLayoutBinding/visibility}} includes {{GPUShaderStage/VERTEX}}
+        , ensure [=vertex shader binding validation=] is not violated.
     1. If |bindingDescriptor|.{{GPUBindGroupLayoutBinding/type}} is {{GPUBindingType/uniform-buffer}}:
         1. Ensure [=uniform buffer validation=] is not violated.
         1. If |bindingDescriptor|.{{GPUBindGroupLayoutBinding/hasDynamicOffset}} is `true`, ensure [=dynamic uniform buffer validation=] is not violated.
@@ -1263,6 +1265,8 @@ If any of the following conditions are violated:
 <dfn>device validation</dfn>: The {{GPUDevice}} must not be lost.
 
 <dfn>binding validation</dfn>: Each |bindingDescriptor|.{{GPUBindGroupLayoutBinding/binding}} in |descriptor| must be unique.
+
+<dfn>vertex shader binding validation</dfn>: {{GPUBindingType/storage-buffer}} is not allowed.
 
 <dfn>uniform buffer validation</dfn>: There must be {{GPULimits/maxUniformBuffersPerShaderStage|GPULimits.maxUniformBuffersPerShaderStage}} or
     fewer |bindingDescriptor|s of type {{GPUBindingType/uniform-buffer}} visible on each shader stage in |descriptor|.


### PR DESCRIPTION
(Writable) storage buffer is not supported in vertex shader stage
on many devices/OSes [1]. So WebGPU should disallow storage-buffer
binding in vertex shader. This change added such a validation rule
in spec.

[1] https://vulkan.gpuinfo.org/listreports.php?feature=vertexPipelineStoresAndAtomics&option=not


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Richard-Yunchao/gpuweb/pull/526.html" title="Last updated on Dec 20, 2019, 8:53 PM UTC (d7d2515)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/526/402b691...Richard-Yunchao:d7d2515.html" title="Last updated on Dec 20, 2019, 8:53 PM UTC (d7d2515)">Diff</a>