### PR TITLE
Add read-only and write-only storage textures as new binding types

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1777,6 +1777,7 @@ The <dfn method for="GPUDevice">createBindGroup(|descriptor|)</dfn> method is us
         1. Ensure |bindingDescriptor|.{{GPUBindGroupBinding/resource}} is a
             valid {{GPUTextureView}} object.
         1. Ensure [=texture view binding validation=] is not violated.
+        1. Ensure |bindingDescriptor|.{{GPUBindGroupLayoutBinding/storageTextureFormat}} is a valid {{GPUTextureFormat}}.
     1. If |layoutBinding|.{{GPUBindGroupLayoutBinding/type}} is
         {{GPUBindingType/"uniform-buffer"}} or {{GPUBindingType/"storage-buffer"}}
         or {{GPUBindingType/"readonly-storage-buffer"}}.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -859,7 +859,8 @@ dictionary GPULimits {
         For each possible {{GPUShaderStage}} `stage`,
         the maximum number of {{GPUBindGroupLayoutDescriptor/bindings}} for which:
 
-          - {{GPUBindGroupLayoutBinding/type}} is {{GPUBindingType/"storage-texture"}}, and
+          - {{GPUBindGroupLayoutBinding/type}} is {{GPUBindingType/"readonly-storage-texture"}} or
+            {{GPUBindingType/"writeonly-storage-texture"}}, and
           - {{GPUBindGroupLayoutBinding/visibility}} includes `stage`,
 
         across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
@@ -1643,7 +1644,7 @@ The <dfn method for="GPUDevice">createBindGroupLayout(|descriptor|)</dfn> method
         1. If |bindingDescriptor|.{{GPUBindGroupLayoutBinding/hasDynamicOffset}} is `true`, ensure [=dynamic storage buffer validation=] is not violated.
     1. If |bindingDescriptor|.{{GPUBindGroupLayoutBinding/type}} is {{GPUBindingType/sampled-texture}}
         , ensure [=sampled texture validation=] is not violated.
-    1. If |bindingDescriptor|.{{GPUBindGroupLayoutBinding/type}} is {{GPUBindingType/storage-texture}}
+    1. If |bindingDescriptor|.{{GPUBindGroupLayoutBinding/type}} is {{GPUBindingType/readonly-storage-texture}} or {{GPUBindingType/writeonly-storage-texture}}
         , ensure [=storage texture validation=] is not violated.
     1. If |bindingDescriptor|.{{GPUBindGroupLayoutBinding/type}} is {{GPUBindingType/sampler}}
         , ensure [=sampler validation=] is not violated.
@@ -1682,7 +1683,7 @@ If any of the following conditions are violated:
     |bindingDescriptor|.{{GPUBindGroupLayoutBinding/hasDynamicOffset}} must be `false`.
 
 <dfn>storage texture validation</dfn>: There must be {{GPULimits/maxStorageTexturesPerShaderStage|GPULimits.maxStorageTexturesPerShaderStage}} or
-    fewer |bindingDescriptor|s of type {{GPUBindingType/storage-texture}} visible on each shader stage in |descriptor|.
+    fewer |bindingDescriptor|s of type {{GPUBindingType/readonly-storage-texture}} and {{GPUBindingType/writeonly-storage-texture}} visible on each shader stage in |descriptor|.
     |bindingDescriptor|.{{GPUBindGroupLayoutBinding/hasDynamicOffset}} must be `false`.
 
 <dfn>sampler validation</dfn>: There must be {{GPULimits/maxSamplersPerShaderStage|GPULimits.maxSamplersPerShaderStage}} or
@@ -1771,7 +1772,8 @@ The <dfn method for="GPUDevice">createBindGroup(|descriptor|)</dfn> method is us
         1. Ensure |bindingDescriptor|.{{GPUBindGroupBinding/resource}} is a
             valid {{GPUSampler}} object.
     1. If |layoutBinding|.{{GPUBindGroupLayoutBinding/type}} is
-        {{GPUBindingType/"sampled-texture"}} or {{GPUBindingType/"storage-texture"}}.
+        {{GPUBindingType/"sampled-texture"}} or {{GPUBindingType/"readonly-storage-texture"}} or
+        {{GPUBindingType/"writeonly-storage-texture"}}.
         1. Ensure |bindingDescriptor|.{{GPUBindGroupBinding/resource}} is a
             valid {{GPUTextureView}} object.
         1. Ensure [=texture view binding validation=] is not violated.
@@ -1809,8 +1811,8 @@ If any of the following conditions are violated:
         {{GPUBindingType/"sampled-texture"}}, |view|'s texture's {{GPUTextureDescriptor/usage}}
         must include {{GPUTextureUsage/SAMPLED}}.
     1. If |layoutBinding|.{{GPUBindGroupLayoutBinding/type}} is
-        {{GPUBindingType/"storage-texture"}}, |view|'s texture's {{GPUTextureDescriptor/usage}}
-        must include {{GPUTextureUsage/STORAGE}}.
+        {{GPUBindingType/"readonly-storage-texture"}} or {{GPUBindingType/"writeonly-storage-texture"}},
+        |view|'s texture's {{GPUTextureDescriptor/usage}} must include {{GPUTextureUsage/STORAGE}}.
 
 <dfn>buffer binding validation</dfn>: Let |bufferBinding| be
     |bindingDescriptor|.{{GPUBindGroupBinding/resource}}, a {{GPUBufferBinding}}.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1311,7 +1311,7 @@ interface GPUTextureUsage {
     const GPUTextureUsageFlags COPY_DST          = 0x02;
     const GPUTextureUsageFlags SAMPLED           = 0x04;
     const GPUTextureUsageFlags STORAGE           = 0x08;
-    const GPUTextureUsageFlags READONLY_STORAGE  = 0x10;
+    const GPUTextureUsageFlags STORAGE_READ      = 0x10;
     const GPUTextureUsageFlags OUTPUT_ATTACHMENT = 0x20;
 };
 </script>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1567,6 +1567,7 @@ dictionary GPUBindGroupLayoutBinding {
     GPUTextureComponentType textureComponentType = "float";
     boolean multisampled = false;
     boolean hasDynamicOffset = false;
+    GPUTextureFormat storageTextureFormat = {};
 };
 </script>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1564,10 +1564,10 @@ dictionary GPUBindGroupLayoutBinding {
     required GPUShaderStageFlags visibility;
     required GPUBindingType type;
     GPUTextureViewDimension textureDimension = "2d";
-    GPUTextureComponentType sampledTextureComponentType;
+    GPUTextureComponentType textureComponentType = "float";
     boolean multisampled = false;
     boolean hasDynamicOffset = false;
-    GPUTextureFormat storageTextureFormat;
+    GPUTextureFormat storageTextureFormat = {};
 };
 </script>
 
@@ -1577,11 +1577,6 @@ dictionary GPUBindGroupLayoutBinding {
   * {{GPUBindGroupLayoutBinding/visibility}}:
     A bitset of the members of {{GPUShaderStage}}. Each set bit indicates that a {{GPUBindGroupLayoutBinding}}'s resource will be accessible from the
     associated shader stage.
-
-  * {{GPUBindGroupLayoutBinding/sampledTextureComponentType}}:
-    The texture component type when {{GPUBindGroupLayoutBinding/type}} is {{GPUBindingType/sampled-texture}}. If {{GPUBindGroupLayoutBinding/type}} is
-    {{GPUBindingType/sampled-texture}} and {{GPUBindGroupLayoutBinding/sampledTextureComponentType}} is not set,
-    {{GPUBindGroupLayoutBinding/sampledTextureComponentType}} defaults to "float".
 
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUShaderStageFlags;
@@ -1807,15 +1802,15 @@ If any of the following conditions are violated:
     This |layoutBinding| must be compatible with this |view|. This requires:
     1. Its |layoutBinding|.{{GPUBindGroupLayoutBinding/textureDimension}} must equal |view|'s
         {{GPUTextureViewDescriptor/dimension}}.
+    1. Its |layoutBinding|.{{GPUBindGroupLayoutBinding/textureComponentType}} must be compatible
+        with |view|'s {{GPUTextureViewDescriptor/format}}.
     1. If |layoutBinding|.{{GPUBindGroupLayoutBinding/multisampled}} is `true`, |view|'s texture's
         {{GPUTextureDescriptor/sampleCount}} must be greater than 1.
         Otherwise, if |bindingDescriptor|.{{GPUBindGroupLayoutBinding/multisampled}} is `false`,
         |view|'s texture's {{GPUTextureDescriptor/sampleCount}} must be 1.
     1. If |layoutBinding|.{{GPUBindGroupLayoutBinding/type}} is
         {{GPUBindingType/"sampled-texture"}}, |view|'s texture's {{GPUTextureDescriptor/usage}}
-        must include {{GPUTextureUsage/SAMPLED}} and
-        |layoutBinding|.{{GPUBindGroupLayoutBinding/sampledTextureComponentType}} must be compatible
-        with |view|'s {{GPUTextureViewDescriptor/format}}.
+        must include {{GPUTextureUsage/SAMPLED}}.
     1. If |layoutBinding|.{{GPUBindGroupLayoutBinding/type}} is
         {{GPUBindingType/"readonly-storage-texture"}} or {{GPUBindingType/"writeonly-storage-texture"}},
         |view|'s texture's {{GPUTextureDescriptor/usage}} must include {{GPUTextureUsage/STORAGE}}.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1564,10 +1564,10 @@ dictionary GPUBindGroupLayoutBinding {
     required GPUShaderStageFlags visibility;
     required GPUBindingType type;
     GPUTextureViewDimension textureDimension = "2d";
-    GPUTextureComponentType textureComponentType = "float";
+    GPUTextureComponentType sampledTextureComponentType;
     boolean multisampled = false;
     boolean hasDynamicOffset = false;
-    GPUTextureFormat storageTextureFormat = {};
+    GPUTextureFormat storageTextureFormat;
 };
 </script>
 
@@ -1577,6 +1577,11 @@ dictionary GPUBindGroupLayoutBinding {
   * {{GPUBindGroupLayoutBinding/visibility}}:
     A bitset of the members of {{GPUShaderStage}}. Each set bit indicates that a {{GPUBindGroupLayoutBinding}}'s resource will be accessible from the
     associated shader stage.
+
+  * {{GPUBindGroupLayoutBinding/sampledTextureComponentType}}:
+    The texture component type when {{GPUBindGroupLayoutBinding/type}} is {{GPUBindingType/sampled-texture}}. If {{GPUBindGroupLayoutBinding/type}} is
+    {{GPUBindingType/sampled-texture}} and {{GPUBindGroupLayoutBinding/sampledTextureComponentType}} is not set,
+    {{GPUBindGroupLayoutBinding/sampledTextureComponentType}} defaults to "float".
 
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUShaderStageFlags;
@@ -1802,15 +1807,15 @@ If any of the following conditions are violated:
     This |layoutBinding| must be compatible with this |view|. This requires:
     1. Its |layoutBinding|.{{GPUBindGroupLayoutBinding/textureDimension}} must equal |view|'s
         {{GPUTextureViewDescriptor/dimension}}.
-    1. Its |layoutBinding|.{{GPUBindGroupLayoutBinding/textureComponentType}} must be compatible
-        with |view|'s {{GPUTextureViewDescriptor/format}}.
     1. If |layoutBinding|.{{GPUBindGroupLayoutBinding/multisampled}} is `true`, |view|'s texture's
         {{GPUTextureDescriptor/sampleCount}} must be greater than 1.
         Otherwise, if |bindingDescriptor|.{{GPUBindGroupLayoutBinding/multisampled}} is `false`,
         |view|'s texture's {{GPUTextureDescriptor/sampleCount}} must be 1.
     1. If |layoutBinding|.{{GPUBindGroupLayoutBinding/type}} is
         {{GPUBindingType/"sampled-texture"}}, |view|'s texture's {{GPUTextureDescriptor/usage}}
-        must include {{GPUTextureUsage/SAMPLED}}.
+        must include {{GPUTextureUsage/SAMPLED}} and
+        |layoutBinding|.{{GPUBindGroupLayoutBinding/sampledTextureComponentType}} must be compatible
+        with |view|'s {{GPUTextureViewDescriptor/format}}.
     1. If |layoutBinding|.{{GPUBindGroupLayoutBinding/type}} is
         {{GPUBindingType/"readonly-storage-texture"}} or {{GPUBindingType/"writeonly-storage-texture"}},
         |view|'s texture's {{GPUTextureDescriptor/usage}} must include {{GPUTextureUsage/STORAGE}}.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1311,7 +1311,8 @@ interface GPUTextureUsage {
     const GPUTextureUsageFlags COPY_DST          = 0x02;
     const GPUTextureUsageFlags SAMPLED           = 0x04;
     const GPUTextureUsageFlags STORAGE           = 0x08;
-    const GPUTextureUsageFlags OUTPUT_ATTACHMENT = 0x10;
+    const GPUTextureUsageFlags READONLY_STORAGE  = 0x10;
+    const GPUTextureUsageFlags OUTPUT_ATTACHMENT = 0x20;
 };
 </script>
 
@@ -1595,7 +1596,8 @@ enum GPUBindingType {
     "readonly-storage-buffer",
     "sampler",
     "sampled-texture",
-    "storage-texture"
+    "storage-texture",
+    "readonly-storage-texture"
     // TODO: other binding types
 };
 </script>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1311,8 +1311,7 @@ interface GPUTextureUsage {
     const GPUTextureUsageFlags COPY_DST          = 0x02;
     const GPUTextureUsageFlags SAMPLED           = 0x04;
     const GPUTextureUsageFlags STORAGE           = 0x08;
-    const GPUTextureUsageFlags STORAGE_READ      = 0x10;
-    const GPUTextureUsageFlags OUTPUT_ATTACHMENT = 0x20;
+    const GPUTextureUsageFlags OUTPUT_ATTACHMENT = 0x10;
 };
 </script>
 
@@ -1597,8 +1596,8 @@ enum GPUBindingType {
     "readonly-storage-buffer",
     "sampler",
     "sampled-texture",
-    "storage-texture",
-    "readonly-storage-texture"
+    "readonly-storage-texture",
+    "writeonly-storage-texture"
     // TODO: other binding types
 };
 </script>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1567,7 +1567,7 @@ dictionary GPUBindGroupLayoutBinding {
     GPUTextureComponentType textureComponentType = "float";
     boolean multisampled = false;
     boolean hasDynamicOffset = false;
-    GPUTextureFormat storageTextureFormat = {};
+    GPUTextureFormat storageTextureFormat;
 };
 </script>
 


### PR DESCRIPTION
This patch adds "readonly-storage-texture" and "writeonly-storage-texture" as new enums of
GPUBindingType.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Jiawei-Shao/gpuweb/pull/532.html" title="Last updated on Feb 25, 2020, 5:57 AM UTC (fb6f38c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/532/a9de584...Jiawei-Shao:fb6f38c.html" title="Last updated on Feb 25, 2020, 5:57 AM UTC (fb6f38c)">Diff</a>