### PR TITLE
BindGroupLayout's dynamic offset only applies on buffer.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1280,12 +1280,15 @@ If any of the following conditions are violated:
 
 <dfn>sampled texture validation</dfn>: There must be {{GPULimits/maxSampledTexturesPerShaderStage|GPULimits.maxSampledTexturesPerShaderStage}} or
     fewer |bindingDescriptor|s of type {{GPUBindingType/sampled-texture}} visible on each shader stage in |descriptor|.
+    |bindingDescriptor|.{{GPUBindGroupLayoutBinding/hasDynamicOffset}} must be `false`.
 
 <dfn>storage texture validation</dfn>: There must be {{GPULimits/maxStorageTexturesPerShaderStage|GPULimits.maxStorageTexturesPerShaderStage}} or
     fewer |bindingDescriptor|s of type {{GPUBindingType/storage-texture}} visible on each shader stage in |descriptor|.
+    |bindingDescriptor|.{{GPUBindGroupLayoutBinding/hasDynamicOffset}} must be `false`.
 
 <dfn>sampler validation</dfn>: There must be {{GPULimits/maxSamplersPerShaderStage|GPULimits.maxSamplersPerShaderStage}} or
     fewer |bindingDescriptor|s of type {{GPUBindingType/sampler}} visible on each shader stage in |descriptor|.
+    |bindingDescriptor|.{{GPUBindGroupLayoutBinding/hasDynamicOffset}} must be `false`.
 
 </dl>
 </div>


### PR DESCRIPTION
This change explicitly added this validation rule in spec. 

PTAL. Thanks!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Richard-Yunchao/gpuweb/pull/539.html" title="Last updated on Jan 10, 2020, 5:08 AM UTC (5f61465)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/539/402b691...Richard-Yunchao:5f61465.html" title="Last updated on Jan 10, 2020, 5:08 AM UTC (5f61465)">Diff</a>