### PR TITLE
Use FrozenArray<> instead of sequence<> for `extensions` attribute.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -605,7 +605,7 @@ To get a {{GPUAdapter}}, use {{GPU/requestAdapter()}}.
 <script type=idl>
 interface GPUAdapter {
     readonly attribute DOMString name;
-    readonly attribute sequence<GPUExtensionName> extensions;
+    readonly attribute FrozenArray<GPUExtensionName> extensions;
     //readonly attribute GPULimits limits; Don't expose higher limits for now.
 
     Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor = {});
@@ -702,7 +702,7 @@ To get a {{GPUDevice}}, use {{GPUAdapter/requestDevice()}}.
 [Exposed=(Window, DedicatedWorker), Serializable]
 interface GPUDevice : EventTarget {
     [SameObject] readonly attribute GPUAdapter adapter;
-    readonly attribute sequence<GPUExtensionName> extensions;
+    readonly attribute FrozenArray<GPUExtensionName> extensions;
     readonly attribute object limits;
 
     [SameObject] readonly attribute GPUQueue defaultQueue;


### PR DESCRIPTION
Sequences must not be used as the type of an attribute or constant[1].

[1] https://heycam.github.io/webidl/#idl-sequence


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/romandev/gpuweb/pull/545.html" title="Last updated on Jan 26, 2020, 3:46 PM UTC (c1e1f08)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/545/c1e5ed4...romandev:c1e1f08.html" title="Last updated on Jan 26, 2020, 3:46 PM UTC (c1e1f08)">Diff</a>