### PR TITLE
Switch dynamicOffsetsDataLength to 32 instead of 64

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2294,7 +2294,7 @@ interface mixin GPUProgrammablePassEncoder {
     void setBindGroup(GPUIndex32 index, GPUBindGroup bindGroup,
                       Uint32Array dynamicOffsetsData,
                       GPUSize64 dynamicOffsetsDataStart,
-                      GPUSize64 dynamicOffsetsDataLength);
+                      GPUSize32 dynamicOffsetsDataLength);
 
     void pushDebugGroup(DOMString groupLabel);
     void popDebugGroup();
@@ -2634,13 +2634,13 @@ Type Definitions {#type-definitions}
 ====================================
 
 <script type=idl>
-typedef [EnforceRange] unsigned long long GPUSize64;
 typedef [EnforceRange] unsigned long GPUBufferDynamicOffset;
 typedef [EnforceRange] unsigned long long GPUFenceValue;
 typedef [EnforceRange] unsigned long GPUStencilValue;
 typedef [EnforceRange] unsigned long GPUSampleMask;
 typedef [EnforceRange] long GPUDepthBias;
 
+typedef [EnforceRange] unsigned long long GPUSize64;
 typedef [EnforceRange] unsigned long GPUIntegerCoordinate;
 typedef [EnforceRange] unsigned long GPUIndex32;
 typedef [EnforceRange] unsigned long GPUSize32;


### PR DESCRIPTION
Because you can't have more dynamic offsets than the number of bindings
in a bindgroup, which is indexed by GPUIndex32.

Found while looking at #498.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/548.html" title="Last updated on Feb 11, 2020, 5:34 AM UTC (f2d86ed)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/548/56b4d3b...kainino0x:f2d86ed.html" title="Last updated on Feb 11, 2020, 5:34 AM UTC (f2d86ed)">Diff</a>