### PR TITLE
Minor typos and editing.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -136,7 +136,7 @@ and support blacklisting particular drivers from using some of the native API ba
 ## Timing attacks ## {#security-timing}
 WebGPU is designed for multi-threaded use via Web Workers. Some of the objects,
 like {{GPUBuffer}}, have shared state which can be simultaneously accessed.
-This allows race conditions to occur, similar to those of accessing an SharedArrayBuffer
+This allows race conditions to occur, similar to those of accessing a SharedArrayBuffer
 from multiple Web Workers, which makes the thread scheduling observable
 and allows the creation of high-precision timers.
 The theoretical attack vectors are a subset of those of SharedArrayBuffer.
@@ -167,7 +167,7 @@ For example, where `buffer` is a {{GPUBuffer}}, `buffer.[[device]].[[adapter]]` 
 
 ## Coordinate Systems ## {#coordinate-systems}
 
-WebGPU's coordinate systems match DirectX and Metal's coordinate systems in graphics pipeline.
+WebGPU's coordinate systems match DirectX and Metal's coordinate systems in a graphics pipeline.
   - Y-axis is up in normalized device coordinate (NDC): point(-1.0, -1.0) in NDC is located at the bottom-left corner of NDC.
     In addition, x and y in NDC should be between -1.0 and 1.0 inclusive, while z in NDC should be between 0.0 and 1.0 inclusive.
     Vertices out of this range in NDC will not introduce any errors, but they will be clipped.
@@ -276,7 +276,7 @@ has components working on different timelines in parallel:
 : <dfn dfn>Device timeline</dfn>
 :: Associated with the GPU device operations
     that are issued by the user agent.
-    It includes creation of adapters, devicies, and GPU resources
+    It includes creation of adapters, devices, and GPU resources
     and state objects, which are typically synchronous operations from the point
     of view of the user agent part that controls the GPU,
     but can live in a separate OS process.
@@ -406,7 +406,7 @@ this buffer can't be used in any other way within this pass.
 
 The [=subresources=] of textures included in the views provided to
 {{GPURenderPassColorAttachmentDescriptor/attachment|GPURenderPassColorAttachmentDescriptor.attachment}} and
-{{GPURenderPassColorAttachmentDescriptor/resolveTarget|GPURenderPassColorAttachmentDescriptor/resolveTarget}}
+{{GPURenderPassColorAttachmentDescriptor/resolveTarget|GPURenderPassColorAttachmentDescriptor.resolveTarget}}
 are considered to have {{GPUTextureUsage/OUTPUT_ATTACHMENT}}
 for the [=usage scope=] of this render pass.
 
@@ -950,14 +950,14 @@ GPUDevice includes GPUObjectBase;
 {{GPUDevice}} objects are [=serializable objects=].
 
 <div algorithm>
-    <dfn abstract-op>To serialize a GPUDevice object</dfn>,
+    <dfn abstract-op>The steps to serialize a GPUDevice object</dfn>,
     given |value|, |serialized|, and |forStorage|, are:
      1. If |forStorage| is true, throw a "{{DataCloneError}}".
      1. Set |serialized|.device to the value of |value|.{{GPUDevice/[[device]]}}.
 </div>
 
 <div algorithm>
-    <dfn abstract-op>To deserialize a GPUDevice object</dfn>,
+    <dfn abstract-op>The steps to deserialize a GPUDevice object</dfn>,
     given |serialized| and |value|, are:
      1. Set |value|.{{GPUDevice/[[device]]}} to |serialized|.device.
 </div>
@@ -1040,7 +1040,7 @@ Note:
      - [=buffer state/mapped for reading=] and [=buffer state/mapped for writing=]
         with an {{ArrayBuffer}} typed {{GPUBuffer/[[mapping]]}}.
      - [=buffer state/mapping pending for reading=] and [=buffer state/mapping pending for writing=]
-        with an {{Promise}} typed {{GPUBuffer/[[mapping]]}}.
+        with a {{Promise}} typed {{GPUBuffer/[[mapping]]}}.
 </div>
 
 {{GPUBuffer}} is {{Serializable}}. It is a reference to an internal buffer
@@ -1110,8 +1110,8 @@ dictionary GPUBufferDescriptor : GPUObjectDescriptorBase {
                 1. Create an invalid {{GPUBuffer}} and return the result.
 
             1. Let |b| be a new {{GPUBuffer}} object.
-            1. Let |m| be a zero-filled {{ArrayBuffer}} of size the {{GPUBuffer/[[size]]}} slot of |b|.
             1. Set the {{GPUBuffer/[[size]]}} slot of |b| to the value of the {{GPUBufferDescriptor/size}} attribute of |descriptor|.
+            1. Let |m| be a zero-filled {{ArrayBuffer}} of size the {{GPUBuffer/[[size]]}} slot of |b|.
             1. Set the {{GPUBuffer/[[usage]]}} slot of |b| to the value of the {{GPUBufferDescriptor/usage}} attribute of |descriptor|.
             1. Set the {{GPUBuffer/[[state]]}} internal slot of |b| to [=buffer state/mapped for writing=].
             1. Set the {{GPUBuffer/[[mapping]]}} internal slot of |b| to |m|.
@@ -1397,9 +1397,9 @@ and data type for the component.
   * `sint` = signed int
   * `float` = floating point
 
-If the format has the `-srgb` suffix, then sRGB gamma compression and
-decompression are applied during the reading and writing of color values in the
-pixel. Compressed texture formats are provided by extensions. Their naming
+If the format has the `-srgb` suffix, then sRGB conversions from gamma to linear
+and vice versa are applied during the reading and writing of color values in the
+shader. Compressed texture formats are provided by extensions. Their naming
 should follow the convention here, with the texture name as a prefix. e.g.
 `etc2-rgba8unorm`.
 
@@ -1856,7 +1856,7 @@ GPUShaderModule includes GPUObjectBase;
 {{GPUShaderModule}} is {{Serializable}}. It is a reference to an internal
 shader module object, and {{Serializable}} means that the reference can be
 *copied* between realms (threads/workers), allowing multiple realms to access
-it concurrently. Since {{GPUShaderModule}} immutable, there are no race
+it concurrently. Since {{GPUShaderModule}} is immutable, there are no race
 conditions.
 
 ### Shader Module Creation ### {#shader-module-creation}


### PR DESCRIPTION
- Some typos and missing words;
- sRGB is a color conversion, not compression; it occurs during sampling
  and writing, ie. in the shader, not the "pixel";
- Steps in 7.1.3. use b.size before assigning it;


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bpeersmoz/gpuweb/pull/553.html" title="Last updated on Feb 20, 2020, 10:22 PM UTC (753f959)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/553/a9de584...bpeersmoz:753f959.html" title="Last updated on Feb 20, 2020, 10:22 PM UTC (753f959)">Diff</a>