### PR TITLE
Add `size` to setIndexBuffer/setVertexBuffer.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2370,9 +2370,7 @@ GPURenderPassEncoder includes GPURenderEncoderBase;
 </script>
 
   * {{GPURenderEncoderBase/setIndexBuffer()}}/{{GPURenderEncoderBase/setVertexBuffer()}}:
-      * If `size` is zero, the size of the {{GPUBuffer}} is used. (Binding a subset instead of the
-        whole buffer allows for concurrent use of other parts of the buffer)
-
+      * If `size` is zero, the size of the {{GPUBuffer}} is used.
 
   * In indirect draw calls, the base instance field (inside the indirect
     buffer data) must be set to zero.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2338,8 +2338,8 @@ Render Passes {#render-passes}
 interface mixin GPURenderEncoderBase {
     void setPipeline(GPURenderPipeline pipeline);
 
-    void setIndexBuffer(GPUBuffer buffer, optional GPUSize64 offset = 0);
-    void setVertexBuffer(GPUIndex32 slot, GPUBuffer buffer, optional GPUSize64 offset = 0);
+    void setIndexBuffer(GPUBuffer buffer, optional GPUSize64 offset = 0, optional GPUSize64 size = 0);
+    void setVertexBuffer(GPUIndex32 slot, GPUBuffer buffer, optional GPUSize64 offset = 0, optional GPUSize64 size = 0);
 
     void draw(GPUSize32 vertexCount, GPUSize32 instanceCount,
               GPUSize32 firstVertex, GPUSize32 firstInstance);
@@ -2368,6 +2368,11 @@ GPURenderPassEncoder includes GPUObjectBase;
 GPURenderPassEncoder includes GPUProgrammablePassEncoder;
 GPURenderPassEncoder includes GPURenderEncoderBase;
 </script>
+
+  * {{GPURenderEncoderBase/setIndexBuffer()}}/{{GPURenderEncoderBase/setVertexBuffer()}}:
+      * If `size` is zero, the size of the {{GPUBuffer}} is used. (Binding a subset instead of the
+        whole buffer allows for concurrent use of other parts of the buffer)
+
 
   * In indirect draw calls, the base instance field (inside the indirect
     buffer data) must be set to zero.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2370,7 +2370,7 @@ GPURenderPassEncoder includes GPURenderEncoderBase;
 </script>
 
   * {{GPURenderEncoderBase/setIndexBuffer()}}/{{GPURenderEncoderBase/setVertexBuffer()}}:
-      * If `size` is zero, the size of the {{GPUBuffer}} is used.
+      * If `size` is zero, the remaining size (after `offset`) of the {{GPUBuffer}} is used.
 
   * In indirect draw calls, the base instance field (inside the indirect
     buffer data) must be set to zero.


### PR DESCRIPTION
> If `size` is zero, the size of the {{GPUBuffer}} is used. (Binding a subset instead of the
whole buffer allows for concurrent use of other parts of the buffer)

This potentially includes mapping subsets of otherwise in-use buffers.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jdashg/gpuweb/pull/554.html" title="Last updated on Mar 10, 2020, 6:04 PM UTC (dad528a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/554/0419bcd...jdashg:dad528a.html" title="Last updated on Mar 10, 2020, 6:04 PM UTC (dad528a)">Diff</a>