### PR TITLE
[wgsl] Rename IDENTIFIER to IDENT

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -746,7 +746,7 @@ type_alias
 
 <pre class='def'>
 type_decl
-  : IDENTIFIER
+  : IDENT
   | BOOL
   | FLOAT32
   | INT32
@@ -1129,7 +1129,7 @@ postfix_expression
   :
   | BRACE_LEFT logical_or_expression BRACE_RIGHT postfix_expression
   | PAREN_LEFT argument_expression_list* PAREN_RIGHT postfix_expression
-  | PERIOD IDENTIFIER postfix_expression
+  | PERIOD IDENT postfix_expression
  
 argument_expression_list
   : (logical_or_expression COMMA)* logical_or_expression


### PR DESCRIPTION
Looks like the use of `IDENTIFIER` was wrong as it's not defined?