### PR TITLE
[wgsl] Fixup struct syntax examples

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -129,8 +129,8 @@ Issue: (dneto): the last element of a struct defining the contents of a storage 
 <div class='example' heading="Structure">
   <xmp highlight='rust'>
     type foo = struct {
-      var a : i32;
-      var b : vec2<f32>;
+      a : i32;
+      b : vec2<f32>;
     }
   </xmp>
 </div>
@@ -870,8 +870,8 @@ Issue: (dneto): MatrixStride, RowMajor, ColMajor layout decorations are needed f
 <div class='example' heading='Structure'>
   <xmp>
     type my_struct = struct {
-      [[offset 0]] var a : f32;
-      [[offset 4]] var b : vec4<f32>;
+      [[offset 0]] a : f32;
+      [[offset 4]] b : vec4<f32>;
     };
 
                   OpName %my_struct "my_struct"

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -728,8 +728,8 @@ type_alias
     type Arr = array<i32, 5>;
 
     type ResType = struct {
-      sf0 : vec4<f32>,
-      sf1 : vec4<i32>
+      sf0 : vec4<f32>;
+      sf1 : vec4<i32>;
     };
 
     type RTArr = [[stride 16]] array<vec4<f32>>;
@@ -737,7 +737,7 @@ type_alias
     type S = [[block]] struct {
       [[offset 0]] a : f32;
       [[offset 4]] b : f32;
-      [[offset 16]] data : RTArr
+      [[offset 16]] data : RTArr;
     };
   </xmp>
 </div>


### PR DESCRIPTION
This CL fixes a few missing or incorrect semicolons in the struct
examples.