### PR TITLE
"gpu" is not a valid canvas context type; "gpupresent" is

### DIFF
--- a/samples/hello-cube.html
+++ b/samples/hello-cube.html
@@ -104,7 +104,7 @@ async function init() {
     const aspect = Math.abs(canvas.width / canvas.height);
     mat4.perspective(projectionMatrix, (2 * Math.PI) / 5, aspect, 1, 100.0);
 
-    const context = canvas.getContext('gpu');
+    const context = canvas.getContext('gpupresent');
 
     const swapChainDescriptor = { 
         device: device, 


### PR DESCRIPTION
Tested on Google Chrome 82.0.4073.0 (Official Build) canary (64-bit)