### PR TITLE
[wgsl] Match built-in decorator names

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -606,34 +606,34 @@ builtin_decoration
           OpDecorate %gl_Position BuiltIn Position
 
     [[builtin vertex_idx]]
-          OpDecorate %gl_Position BuiltIn VertexId
+          OpDecorate %gl_VertexId BuiltIn VertexId
 
     [[builtin instance_idx]]
-          OpDecorate %gl_Position BuiltIn InstanceIndex
+          OpDecorate %gl_InstanceId BuiltIn InstanceIndex
 
     [[builtin front_facing]]
-          OpDecorate %gl_Position BuiltIn FrontFacing
+          OpDecorate %gl_FrontFacing BuiltIn FrontFacing
 
     [[builtin frag_coord]]
-          OpDecorate %gl_Position BuiltIn FragCoord
+          OpDecorate %gl_FragCoord BuiltIn FragCoord
 
     [[builtin frag_depth]]
-          OpDecorate %gl_Position BuiltIn FragDepth
+          OpDecorate %gl_FragDepth BuiltIn FragDepth
 
     [[builtin num_workgroups]]
-          OpDecorate %gl_Position BuiltIn NumWorkgroups
+          OpDecorate %gl_NumWorkGroups BuiltIn NumWorkgroups
 
     [[builtin workgroup_size]]
-          OpDecorate %gl_Position BuiltIn WorkgroupSize
+          OpDecorate %gl_WorkGroupSize BuiltIn WorkgroupSize
 
     [[builtin local_invocation_id]]
-          OpDecorate %gl_Position BuiltIn LocalInvocationId
+          OpDecorate %gl_LocalInvocationID BuiltIn LocalInvocationId
 
     [[builtin local_invocation_idx]]
-          OpDecorate %gl_Position BuiltIn LocalInvocationIndex
+          OpDecorate %gl_LocalInvocationIndex BuiltIn LocalInvocationIndex
 
     [[builtin global_invocation_id]]
-          OpDecorate %gl_Position BuiltIn GlobalInvocationId
+          OpDecorate %gl_GlobalInvocationID BuiltIn GlobalInvocationId
   </xmp>
 </div>
 


### PR DESCRIPTION
Update the example of built-in decorators section to match decorators specified