### PR TITLE
Rename BGLBinding.textureDimension to viewDimension.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1563,7 +1563,7 @@ dictionary GPUBindGroupLayoutBinding {
     required GPUIndex32 binding;
     required GPUShaderStageFlags visibility;
     required GPUBindingType type;
-    GPUTextureViewDimension textureDimension = "2d";
+    GPUTextureViewDimension viewDimension = "2d";
     GPUTextureComponentType textureComponentType = "float";
     boolean multisampled = false;
     boolean hasDynamicOffset = false;
@@ -1603,7 +1603,7 @@ enum GPUBindingType {
 };
 </script>
 
-  * {{GPUBindGroupLayoutBinding/textureDimension}}, {{GPUBindGroupLayoutBinding/multisampled}}:
+  * {{GPUBindGroupLayoutBinding/viewDimension}}, {{GPUBindGroupLayoutBinding/multisampled}}:
     Describes the dimensionality of texture view bindings, and indicates if they are multisampled.
 
     Note: This allows Metal-based implementations to back the respective bind
@@ -1800,7 +1800,7 @@ If any of the following conditions are violated:
 <dfn>texture view binding validation</dfn>: Let |view| be
     |bindingDescriptor|.{{GPUBindGroupBinding/resource}}, a {{GPUTextureView}}.
     This |layoutBinding| must be compatible with this |view|. This requires:
-    1. Its |layoutBinding|.{{GPUBindGroupLayoutBinding/textureDimension}} must equal |view|'s
+    1. Its |layoutBinding|.{{GPUBindGroupLayoutBinding/viewDimension}} must equal |view|'s
         {{GPUTextureViewDescriptor/dimension}}.
     1. Its |layoutBinding|.{{GPUBindGroupLayoutBinding/textureComponentType}} must be compatible
         with |view|'s {{GPUTextureViewDescriptor/format}}.


### PR DESCRIPTION
Fixes #587

Alternatively we could rename it to `textureViewDimension` but that's a mouthful.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/589.html" title="Last updated on Mar 4, 2020, 10:22 AM UTC (ebb4b4b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/589/e3b427d...Kangz:ebb4b4b.html" title="Last updated on Mar 4, 2020, 10:22 AM UTC (ebb4b4b)">Diff</a>