### PR TITLE
Remove GPUShaderCode since WebGPU only accepts WGSL

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1867,16 +1867,10 @@ conditions.
 ### Shader Module Creation ### {#shader-module-creation}
 
 <script type=idl>
-typedef (Uint32Array or DOMString) GPUShaderCode;
-
 dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
-    required GPUShaderCode code;
+    required DOMString code;
 };
 </script>
-
-Note: While the choice of shader language is undecided,
-`GPUShaderModuleDescriptor` will temporarily accept both text and binary input.
-
 
 Pipelines {#pipelines}
 ======================


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/591.html" title="Last updated on Mar 4, 2020, 10:29 AM UTC (bdacfc8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/591/e3b427d...Kangz:bdacfc8.html" title="Last updated on Mar 4, 2020, 10:29 AM UTC (bdacfc8)">Diff</a>