### PR TITLE
Add "comparison-sampler" binding type

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -833,7 +833,7 @@ dictionary GPULimits {
         For each possible {{GPUShaderStage}} `stage`,
         the maximum number of {{GPUBindGroupLayoutDescriptor/bindings}} for which:
 
-          - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampler"}}, and
+          - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampler"}}  or {{GPUBindingType/"comparison-sampler"}}, and
           - {{GPUBindGroupLayoutEntry/visibility}} includes `stage`,
 
         across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
@@ -1487,6 +1487,15 @@ interface GPUSampler {
 GPUSampler includes GPUObjectBase;
 </script>
 
+
+{{GPUSampler}} has the following internal slots:
+
+<dl dfn-type=attribute dfn-for="GPUSampler">
+    : <dfn>\[[compareEnable]]</dfn> of type {{boolean}}.
+    ::
+        Whether the {{GPUSampler}} is used as a comparison sampler.
+</dl>
+
 ### Creation ### {#sampler-creation}
 
 <script type=idl>
@@ -1499,9 +1508,24 @@ dictionary GPUSamplerDescriptor : GPUObjectDescriptorBase {
     GPUFilterMode mipmapFilter = "nearest";
     float lodMinClamp = 0;
     float lodMaxClamp = 0xffffffff; // TODO: What should this be? Was Number.MAX_VALUE.
-    GPUCompareFunction compare = "never";
+    GPUCompareFunction compare;
 };
 </script>
+
+### {{GPUDevice/createSampler(descriptor)|GPUDevice.createSampler(descriptor)}} ### {#GPUDevice-createSampler}
+
+<dl dfn-type="method" dfn-for="GPUDevice">
+    : <dfn>createSampler(descriptor)</dfn>
+    ::
+        <div algorithm="GPUDevice.createSampler(descriptor)">
+            **Arguments:**
+                - optional {{GPUSamplerDescriptor}} |descriptor| = {}
+            1. Let |s| be a new {{GPUSampler}} object.
+            1. Set the {{GPUSampler/[[compareEnable]]}} slot of |s| to false if the {{GPUSamplerDescriptor/compare}} attribute
+                  of |descriptor| is null or undefined. Otherwise, set it to true.
+            1. Return |s|.
+        </div>
+</dl>
 
 <script type=idl>
 enum GPUAddressMode {
@@ -1596,6 +1620,7 @@ enum GPUBindingType {
     "storage-buffer",
     "readonly-storage-buffer",
     "sampler",
+    "comparison-sampler",
     "sampled-texture",
     "readonly-storage-texture",
     "writeonly-storage-texture"
@@ -1770,7 +1795,11 @@ The <dfn method for="GPUDevice">createBindGroup(|descriptor|)</dfn> method is us
     1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
         {{GPUBindingType/"sampler"}}:
         1. Ensure |bindingDescriptor|.{{GPUBindGroupEntry/resource}} is a
-            valid {{GPUSampler}} object.
+            valid {{GPUSampler}} object and {{GPUSampler/[[compareEnable]]}} is false.
+    1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
+        {{GPUBindingType/"comparison-sampler"}}:
+        1. Ensure |bindingDescriptor|.{{GPUBindGroupEntry/resource}} is a
+            valid {{GPUSampler}} object and {{GPUSampler/[[compareEnable]]}} is true.
     1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
         {{GPUBindingType/"sampled-texture"}} or {{GPUBindingType/"readonly-storage-texture"}} or
         {{GPUBindingType/"writeonly-storage-texture"}}.


### PR DESCRIPTION
Based on issue #552, comparison samplers may not be used without specifying
so on creation. This adds a new "comparison-sampler" binding type and makes the
sampler compare function nullable. Comparison samplers can only be used if a
compare function was specified on creation.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/austinEng/gpuweb/pull/595.html" title="Last updated on Mar 9, 2020, 10:34 PM UTC (ab75f18)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/595/da1d4f8...austinEng:ab75f18.html" title="Last updated on Mar 9, 2020, 10:34 PM UTC (ab75f18)">Diff</a>