### PR TITLE
Add validation rules for CopyBufferToBuffer

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2305,9 +2305,9 @@ dictionary GPUImageBitmapCopyView {
 
   Given a {{GPUCommandEncoder}} |encoder| and the arguments {{GPUBuffer}} |source|, {{GPUSize64}} |sourceOffset|, {{GPUBuffer}} |destination|, {{GPUSize64}} |destinationOffset|, {{GPUSize64}} |size|, the following validation rules apply:
 
-  - |encoder|.{{GPUCommandEncoder/copyBufferToBuffer()}} must be called before calling |encoder|.{{GPUCommandEncoder/finish()}}. // TODO: define the state machine for GPUCommandEncoder.
-  - |encoder|.{{GPUCommandEncoder/copyBufferToBuffer()}} must be called outside of any {{GPURenderPassEncoder}}s.
-  - |encoder|.{{GPUCommandEncoder/copyBufferToBuffer()}} must be called outside of any {{GPUComputePassEncoder}}s.
+  - |encoder| must be a [=valid=] {{GPUCommandEncoder}}.
+  - |encoder|.{{GPUCommandEncoder/copyBufferToBuffer()}} must not be called when a {{GPURenderPassEncoder}} is active on |encoder|.
+  - |encoder|.{{GPUCommandEncoder/copyBufferToBuffer()}} must not be called when a {{GPUComputePassEncoder}} is active on |encoder|.
   - |source| must be a [=valid=] {{GPUBuffer}}.
   - |destination| must be a [=valid=] {{GPUBuffer}}.
   - The {{GPUBuffer/[[usage]]}} of |source| must contain {{GPUBufferUsage/COPY_SRC}}.
@@ -2315,10 +2315,15 @@ dictionary GPUImageBitmapCopyView {
   - |size| must be a multiple of 4.
   - |sourceOffset| must be a multiple of 4.
   - |destinationOffset| must be a multiple of 4.
-  - (|sourceOffset| + |size|) must not overflow a {{GPUBuffer/[[size]]}}. // TODO: figure out how to handle overflows in the spec.
+  - (|sourceOffset| + |size|) must not overflow a {{GPUBuffer/[[size]]}}.
   - (|destinationOffset| + |size|) must not overflow a {{GPUBuffer/[[size]]}}.
   - The {{GPUBuffer/[[size]]}} of |source| must be greater than or equal to (|sourceOffset| + |size|).
   - The {{GPUBuffer/[[size]]}} of |destination| must be greater than or equal to (|destinationOffset| + |size|).
+  - If |source| and |destination| are the same buffer, the copy range from |sourceOffset| to (|sourceOffset| + |size|) must not overlap with the copy range from |destinationOffset| to (|destinationOffset| + |size|).
+
+Issue(gpuweb/gpuweb#21): Define the state machine for GPUCommandEncoder.
+
+Issue(gpuweb/gpuweb#69): figure out how to handle overflows in the spec.
 
 </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2315,8 +2315,8 @@ dictionary GPUImageBitmapCopyView {
   - |size| must be a multiple of 4.
   - |sourceOffset| must be a multiple of 4.
   - |destinationOffset| must be a multiple of 4.
-  - (|sourceOffset| + |size|) must not overflow a {{GPUBuffer/[[size]]}}.
-  - (|destinationOffset| + |size|) must not overflow a {{GPUBuffer/[[size]]}}.
+  - (|sourceOffset| + |size|) must not overflow a {{GPUSize64}}.
+  - (|destinationOffset| + |size|) must not overflow a {{GPUSize64}}.
   - The {{GPUBuffer/[[size]]}} of |source| must be greater than or equal to (|sourceOffset| + |size|).
   - The {{GPUBuffer/[[size]]}} of |destination| must be greater than or equal to (|destinationOffset| + |size|).
   - If |source| and |destination| are the same buffer, the copy range from |sourceOffset| to (|sourceOffset| + |size|) must not overlap with the copy range from |destinationOffset| to (|destinationOffset| + |size|).

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2282,6 +2282,29 @@ dictionary GPUImageBitmapCopyView {
 
   * {{GPUImageBitmapCopyView/origin}}: If unspecified, defaults to `[0, 0]`.
 
+### {{GPUCommandEncoder/copyBufferToBuffer()|GPUCommandEncoder.copyBufferToBuffer(GPUBuffer, GPUSize64, GPUBuffer, GPUSize64, GPUSize64)}} ### {#GPUCommandEncoder-copyBufferToBuffer}
+
+<div algorithm="GPUCommandEncoder.copyBufferToBuffer(GPUBuffer, GPUSize64, GPUBuffer, GPUSize64, GPUSize64)">
+
+The <dfn method for="GPUCommandEncoder">copyBufferToBuffer(|source|, |sourceOffset|, |destination|, |destinationOffset|, |size|)</dfn> method is used to perform {{GPUBuffer}} to {{GPUBuffer}} copies.
+
+1. Ensure {{GPUCommandEncoder/copyBufferToBuffer()}} is called before {{GPUCommandEncoder/finish()}}.
+1. Ensure {{GPUCommandEncoder/copyBufferToBuffer()}} is called outside of any {{GPURenderPassEncoder}}s.
+1. Ensure {{GPUCommandEncoder/copyBufferToBuffer()}} is called outside of any {{GPUComputePassEncoder}}s.
+1. Ensure |source| is a valid {{GPUBuffer}}.
+1. Ensure |destination| is a valid {{GPUBuffer}}.
+1. Ensure the {{GPUBuffer/[[usage]]}} of |source| contains {{GPUBufferUsage/COPY_SRC}}.
+1. Ensure the {{GPUBuffer/[[usage]]}} of |destination| contains {{GPUBufferUsage/COPY_DST}}.
+1. Ensure |size| is a multiple of 4.
+1. Ensure |sourceOffset| is a multiple of 4.
+1. Ensure |destinationOffset| is a multiple of 4.
+1. Ensure (|sourceOffset| + |size|) does not overflow.
+1. Ensure (|destinationOffset| + |size|) does not overflow.
+1. Ensure the {{GPUBuffer/[[size]]}} of |source| is greater than or equal to (|sourceOffset| + |size|).
+1. Ensure the {{GPUBuffer/[[size]]}} of |destination| is greater than or equal to (|destinationOffset| + |size|).
+
+</div>
+
 ## Programmable Passes ## {#programmable-passes}
 
 <script type=idl>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2282,26 +2282,43 @@ dictionary GPUImageBitmapCopyView {
 
   * {{GPUImageBitmapCopyView/origin}}: If unspecified, defaults to `[0, 0]`.
 
-### {{GPUCommandEncoder/copyBufferToBuffer()|GPUCommandEncoder.copyBufferToBuffer(GPUBuffer, GPUSize64, GPUBuffer, GPUSize64, GPUSize64)}} ### {#GPUCommandEncoder-copyBufferToBuffer}
+### <dfn method for=GPUCommandEncoder>copyBufferToBuffer(source, sourceOffset, destination, destinationOffset, size)</dfn> ### {#GPUCommandEncoder-copyBufferToBuffer}
 
-<div algorithm="GPUCommandEncoder.copyBufferToBuffer(GPUBuffer, GPUSize64, GPUBuffer, GPUSize64, GPUSize64)">
+<div algorithm="GPUCommandEncoder.copyBufferToBuffer">
 
-The <dfn method for="GPUCommandEncoder">copyBufferToBuffer(|source|, |sourceOffset|, |destination|, |destinationOffset|, |size|)</dfn> method is used to perform {{GPUBuffer}} to {{GPUBuffer}} copies.
+  **Arguments:**
+    - {{GPUBuffer}} |source|
+    - {{GPUSize64}} |sourceOffset|
+    - {{GPUBuffer}} |destination|
+    - {{GPUSize64}} |destinationOffset|
+    - {{GPUSize64}} |size|
 
-1. Ensure {{GPUCommandEncoder/copyBufferToBuffer()}} is called before {{GPUCommandEncoder/finish()}}.
-1. Ensure {{GPUCommandEncoder/copyBufferToBuffer()}} is called outside of any {{GPURenderPassEncoder}}s.
-1. Ensure {{GPUCommandEncoder/copyBufferToBuffer()}} is called outside of any {{GPUComputePassEncoder}}s.
-1. Ensure |source| is a valid {{GPUBuffer}}.
-1. Ensure |destination| is a valid {{GPUBuffer}}.
-1. Ensure the {{GPUBuffer/[[usage]]}} of |source| contains {{GPUBufferUsage/COPY_SRC}}.
-1. Ensure the {{GPUBuffer/[[usage]]}} of |destination| contains {{GPUBufferUsage/COPY_DST}}.
-1. Ensure |size| is a multiple of 4.
-1. Ensure |sourceOffset| is a multiple of 4.
-1. Ensure |destinationOffset| is a multiple of 4.
-1. Ensure (|sourceOffset| + |size|) does not overflow.
-1. Ensure (|destinationOffset| + |size|) does not overflow.
-1. Ensure the {{GPUBuffer/[[size]]}} of |source| is greater than or equal to (|sourceOffset| + |size|).
-1. Ensure the {{GPUBuffer/[[size]]}} of |destination| is greater than or equal to (|destinationOffset| + |size|).
+  **Returns:** void
+
+  Encode a command into the {{GPUCommandEncoder}} that copies |size| bytes of data from the |sourceOffset| of a {{GPUBuffer}} |source| to the |destinationOffset| of another {{GPUBuffer}} |destination|.
+
+</div>
+
+<div algorithm class=validusage>
+
+  <dfn abstract-op>copyBufferToBuffer Valid Usage</dfn>
+
+  Given a {{GPUCommandEncoder}} |encoder| and the arguments {{GPUBuffer}} |source|, {{GPUSize64}} |sourceOffset|, {{GPUBuffer}} |destination|, {{GPUSize64}} |destinationOffset|, {{GPUSize64}} |size|, the following validation rules apply:
+
+  - |encoder|.{{GPUCommandEncoder/copyBufferToBuffer()}} must be called before calling |encoder|.{{GPUCommandEncoder/finish()}}. // TODO: define the state machine for GPUCommandEncoder.
+  - |encoder|.{{GPUCommandEncoder/copyBufferToBuffer()}} must be called outside of any {{GPURenderPassEncoder}}s.
+  - |encoder|.{{GPUCommandEncoder/copyBufferToBuffer()}} must be called outside of any {{GPUComputePassEncoder}}s.
+  - |source| must be a [=valid=] {{GPUBuffer}}.
+  - |destination| must be a [=valid=] {{GPUBuffer}}.
+  - The {{GPUBuffer/[[usage]]}} of |source| must contain {{GPUBufferUsage/COPY_SRC}}.
+  - The {{GPUBuffer/[[usage]]}} of |destination| must contain {{GPUBufferUsage/COPY_DST}}.
+  - |size| must be a multiple of 4.
+  - |sourceOffset| must be a multiple of 4.
+  - |destinationOffset| must be a multiple of 4.
+  - (|sourceOffset| + |size|) must not overflow a {{GPUBuffer/[[size]]}}. // TODO: figure out how to handle overflows in the spec.
+  - (|destinationOffset| + |size|) must not overflow a {{GPUBuffer/[[size]]}}.
+  - The {{GPUBuffer/[[size]]}} of |source| must be greater than or equal to (|sourceOffset| + |size|).
+  - The {{GPUBuffer/[[size]]}} of |destination| must be greater than or equal to (|destinationOffset| + |size|).
 
 </div>
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: write EPROTO 139762724145024:error:1407742E:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert protocol version:../deps/openssl/openssl/ssl/s23_clnt.c:772:
 :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 12, 2020, 6:55 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fgpuweb%2Fgpuweb%2Fpull%2F597%2F7260799.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2FJiawei-Shao%2Fgpuweb%2Fpull%2F597.html)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%23597.)._
</details>
