### PR TITLE
Synchronization section: editing nits

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -416,12 +416,12 @@ Issue(gpuweb/gpuweb#514): Document read-only states for depth views.
 
 For each [=subresource=] of a [=physical resource=], the usage is tracked on the [=Queue timeline=].
 
-Issue: This section will need to be redacted to support multiple queues.
+Issue: This section will need to be revised to support multiple queues.
 
-The [=Queue timeline=] could be split into a sequence of [=usage scopes=]:
-within each scope the usage of the [=subresource=] stays unchanged,
-and the implementation transitions the [=subresource=] to the new usage
-at the [=usage scope=] boundaries.
+The [=Queue timeline=] is split into a sequence of [=usage scopes=].
+Within each scope, the usage of a given [=subresource=] is constant.
+The [=subresource=] transitions to the new usage
+at the boundaries between [=usage scope=].
 
 This specification defines the following [=usage scopes=]:
   1. an individual command on a {{GPUCommandEncoder}}, such as {{GPUCommandEncoder/copyBufferToTexture()|GPUCommandEncoder.copyBufferToTexture}}.
@@ -438,8 +438,8 @@ regarless of whether the indexed draw calls are used afterwards.
 The [=usage scopes=] are validated at {{GPUCommandEncoder/finish()|GPUCommandEncoder.finish}} time.
 The implementation performs the <dfn dfn>usage scope validation</dfn> by composing
 the union of all usage flags of each [=subresources=] used in the [=usage scope=].
-A {{GPUValidationError}} is generated in the current scope with appropriate error message
-if that contains a [=mutating usage=] combined with any other usage.
+A {{GPUValidationError}} is generated in the current scope with an appropriate error message
+if that union contains a [=mutating usage=] combined with any other usage.
 
 Core Internal Objects {#core-internal-objects}
 ==============================================
@@ -1800,9 +1800,11 @@ A {{GPUBindGroup}} object has the following internal slots:
     : <dfn>\[[bindings]]</dfn> of type sequence<{{GPUBindGroupEntry}}>.
     ::
         The set of {{GPUBindGroupEntry}}s this {{GPUBindGroup}} describes.
+
     : <dfn>\[[usedBuffers]]</dfn> of type maplike<{{GPUBuffer}}, {{GPUBufferUsage}}>.
     ::
         The set of buffers used by this bind group and the corresponding usage flags.
+
     : <dfn>\[[usedTextures]]</dfn> of type maplike<{{GPUTexture}} [=subresource=], {{GPUTextureUsage}}>.
     ::
         The set of texure subresources used by this bind group. Each subresource is
@@ -1851,8 +1853,8 @@ The <dfn method for="GPUDevice">createBindGroup(|descriptor|)</dfn> method is us
 1. Return a new {{GPUBindGroup}} object with:
     - {{GPUBindGroup/[[layout]]}} = |descriptor|.{{GPUBindGroupDescriptor/layout}}
     - {{GPUBindGroup/[[bindings]]}} = |descriptor|.{{GPUBindGroupDescriptor/bindings}}
-    - {{GPUBindGroup/[[usedBuffers]]}} = union of the buffer usages across the bindings
-    - {{GPUBindGroup/[[usedTextures]]}} = union of the texture subresources usages across the bindings
+    - {{GPUBindGroup/[[usedBuffers]]}} = union of the buffer usages across all bindings
+    - {{GPUBindGroup/[[usedTextures]]}} = union of the texture [=subresource=] usages across all bindings
 
 <b>Validation Conditions</b>
 
@@ -1876,12 +1878,12 @@ If any of the following conditions are violated:
         |view|'s texture's {{GPUTextureDescriptor/sampleCount}} must be 1.
     1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
         {{GPUBindingType/"sampled-texture"}}, |view|'s texture's {{GPUTextureDescriptor/usage}}
-        must include {{GPUTextureUsage/SAMPLED}}. Each texture's [=subresource=] seen by the |view|
+        must include {{GPUTextureUsage/SAMPLED}}. Each texture [=subresource=] seen by |view|
         is added to {{GPUBindGroup/[[usedTextures]]}} with {{GPUTextureUsage/SAMPLED}} flag.
     1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
         {{GPUBindingType/"readonly-storage-texture"}} or {{GPUBindingType/"writeonly-storage-texture"}},
         |view|'s texture's {{GPUTextureDescriptor/usage}} must include {{GPUTextureUsage/STORAGE}}.
-        Each texture's [=subresource=] seen by the |view|
+        Each texture [=subresource=] seen by |view|
         is added to {{GPUBindGroup/[[usedTextures]]}} with {{GPUTextureUsage/STORAGE}} flag.
 
 <dfn>buffer binding validation</dfn>: Let |bufferBinding| be
@@ -1889,12 +1891,12 @@ If any of the following conditions are violated:
     This |layoutBinding| must be compatible with this |bufferBinding|. This requires:
     1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"uniform-buffer"}},
         the |bufferBinding|.{{GPUBufferBinding/buffer}}'s {{GPUBufferDescriptor/usage}} must include
-        {{GPUBufferUsage/UNIFORM}}. The buffer is added to {{GPUBindGroup/[[usedBuffers]]}} map
+        {{GPUBufferUsage/UNIFORM}}. The buffer is added to the {{GPUBindGroup/[[usedBuffers]]}} map
         with {{GPUBufferUsage/UNIFORM}} flag.
     1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"storage-buffer"}}
         or {{GPUBindingType/"readonly-storage-buffer"}}, the
         |bufferBinding|.{{GPUBufferBinding/buffer}}'s {{GPUBufferDescriptor/usage}} must include
-        {{GPUBufferUsage/STORAGE}}. The buffer is added to {{GPUBindGroup/[[usedBuffers]]}} map
+        {{GPUBufferUsage/STORAGE}}. The buffer is added to the {{GPUBindGroup/[[usedBuffers]]}} map
         with {{GPUBufferUsage/STORAGE}} flag.
     1. The bound part designated by |bufferBinding|.{{GPUBufferBinding/offset}} and
         |bufferBinding|.{{GPUBufferBinding/size}} must reside inside the buffer.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -421,12 +421,12 @@ according to the type of the subresource.
 
 Issue: This section will need to be revised to support multiple queues.
 
-On the [=Queue timeline=], there is ordered sequence of [=usage scopes=].
+On the [=Queue timeline=], there is an ordered sequence of [=usage scopes=].
 Each item on the timeline is contained within exactly one scope.
 For the duration of each scope, the set of [=usage flags=] of any given
 [=subresource=] is constant.
-The [=subresource=] transitions to the new usage
-at the boundaries between [=usage scope=].
+A [=subresource=] may transition to new usages 
+at the boundaries between [=usage scope=]s.
 
 This specification defines the following [=usage scopes=]:
   1. an individual command on a {{GPUCommandEncoder}}, such as {{GPUCommandEncoder/copyBufferToTexture()|GPUCommandEncoder.copyBufferToTexture}}.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -422,7 +422,7 @@ according to the type of the subresource.
 Issue: This section will need to be revised to support multiple queues.
 
 On the [=Queue timeline=], there is ordered sequence of [=usage scopes=].
-Each item on the timeline is contained with in exactly one scope.
+Each item on the timeline is contained within exactly one scope.
 For the duration of each scope, the set of [=usage flags=] of any given
 [=subresource=] is constant.
 The [=subresource=] transitions to the new usage

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -414,12 +414,17 @@ Issue(gpuweb/gpuweb#514): Document read-only states for depth views.
 
 ## Synchronization ## {#programming-model-synchronization}
 
-For each [=subresource=] of a [=physical resource=], the usage is tracked on the [=Queue timeline=].
+For each [=subresource=] of a [=physical resource=], its set of
+[=usage flags=] is tracked on the [=Queue timeline=].
+<dfn dfn>Usage flags</dfn> are {{GPUBufferUsage}} or {{GPUTextureUsage}} flags,
+according to the type of the subresource.
 
 Issue: This section will need to be revised to support multiple queues.
 
-The [=Queue timeline=] is split into a sequence of [=usage scopes=].
-Within each scope, the usage of a given [=subresource=] is constant.
+On the [=Queue timeline=], there is ordered sequence of [=usage scopes=].
+Each item on the timeline is contained with in exactly one scope.
+For the duration of each scope, the set of [=usage flags=] of any given
+[=subresource=] is constant.
 The [=subresource=] transitions to the new usage
 at the boundaries between [=usage scope=].
 
@@ -437,7 +442,7 @@ regarless of whether the indexed draw calls are used afterwards.
 
 The [=usage scopes=] are validated at {{GPUCommandEncoder/finish()|GPUCommandEncoder.finish}} time.
 The implementation performs the <dfn dfn>usage scope validation</dfn> by composing
-the union of all usage flags of each [=subresources=] used in the [=usage scope=].
+the set of all [=usage flags=] of each [=subresource=] used in the [=usage scope=].
 A {{GPUValidationError}} is generated in the current scope with an appropriate error message
 if that union contains a [=mutating usage=] combined with any other usage.
 


### PR DESCRIPTION
@kvark just a few nits. please make sure it still matches your intent.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: write EPROTO 140222018242432:error:1407742E:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert protocol version:../deps/openssl/openssl/ssl/s23_clnt.c:772:
 :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 16, 2020, 10:33 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fgpuweb%2Fgpuweb%2Fpull%2F607%2F7531dda.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fkainino0x%2Fgpuweb%2Fpull%2F607.html)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%23607.)._
</details>
