### PR TITLE
Spec bytesPerRow and rowsPerImage

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -377,7 +377,7 @@ which can be split into two groups:
 
 Issue(gpuweb/gpuweb#296): Consider merging all read-only usages.
 
-Textures may consist of separate mipmap levels and array layers,
+Textures may consist of separate [=mipmap levels=] and [=array layers=],
 which can be used differently at any given time. For the matter of usage validation,
 we'll call them <dfn dfn>subresources</dfn>.
 
@@ -994,6 +994,8 @@ GPUDevice includes GPUObjectBase;
 
 # {{GPUBuffer}} # {#GPUBuffer}
 
+Issue: define <dfn dfn>buffer</dfn> (internal object)
+
 A {{GPUBuffer}} represents a block of memory that can be used in GPU operations.
 Data is stored in linear layout, meaning that each byte of the allocation can be
 addressed by its offset from the start of the {{GPUBuffer}}, subject to alignment
@@ -1299,7 +1301,11 @@ Issue: Add client-side validation that a mapped buffer can only be unmapped and 
 Textures {#textures}
 ====================
 
-## GPUTexture ## {#texture}
+Issue: define <dfn dfn>texture</dfn> (internal object)
+
+Issue: define <dfn dfn>mipmap level</dfn>, <dfn dfn>array layer</dfn>, <dfn dfn>slice</dfn> (concepts)
+
+## GPUTexture ## {#gpu-texture}
 
 <script type=idl>
 [Serializable]
@@ -1368,7 +1374,7 @@ dictionary GPUTextureViewDescriptor : GPUObjectDescriptorBase {
 
 <!-- TODO(kainino0x): Make this a standalone algorithm used in the createView algorithm. -->
 <!-- TODO(kainino0x): The references to GPUTextureDescriptor here should actually refer to
-internal slots of a [=texture=] internal object once we have one. -->
+internal slots of a texture internal object once we have one. -->
 
 <div algorithm="resolving GPUTextureViewDescriptor defaults">
 
@@ -2324,24 +2330,38 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 
 ## Copy Commands ## {#copy-commands}
 
+### <dfn dictionary>GPUBufferCopyView</dfn> ### {#gpu-buffer-copy-view}
+
 <script type=idl>
 dictionary GPUBufferCopyView {
     required GPUBuffer buffer;
     GPUSize64 offset = 0;
-    required GPUSize32 rowPitch;
-    GPUSize32 imageHeight = 0;
+    required GPUSize32 bytesPerRow;
+    GPUSize32 rowsPerImage = 0;
 };
 </script>
 
-<dl dfn-type=dict-member dfn-for=GPUBufferCopyView>
-    : <dfn>imageHeight</dfn>
-    ::
-        The pitch (measured as a multiple of {{GPUBufferCopyView/rowPitch}} bytes)
-        between different `z` values of the target texture.
-        For {{GPUTextureDimension/3d}} textures, `z` refers to the texture's depth.
-        For {{GPUTextureDimension/2d}} textures, `z` refers to the texture's array layers.
+A {{GPUBufferCopyView}} is a view of a [=buffer=] as an array of <dfn dfn>images</dfn>,
+used when copying data between a [=texture=] and a [=buffer=].
 
-        An `imageHeight` of zero is only valid for copies with a `copySize.depth` of 1.
+  - For {{GPUTextureDimension/2d}} textures, data is copied between one [=image=] and one [=array layer=].
+  - For {{GPUTextureDimension/3d}} textures, data is copied between one [=image=] and one depth [=slice=].
+
+<dl dfn-type=dict-member dfn-for=GPUBufferCopyView>
+    : <dfn>bytesPerRow</dfn>
+    ::
+        The stride, in bytes, between the beginning of each row of data and
+        the subsequent row.
+
+    : <dfn>rowsPerImage</dfn>
+    ::
+        {{GPUBufferCopyView/rowsPerImage}} &times; {{GPUBufferCopyView/bytesPerRow}}
+        is the stride, in bytes, between the beginning of each [=image=] of data
+        and the subsequent [=image=].
+
+        Note:
+        {{GPUBufferCopyView/rowsPerImage}} must be zero for copies with a `copySize.depth` of 1,
+        and must be greater than zero otherwise.
 </dl>
 
 <script type=idl>


### PR DESCRIPTION
These have been renamed from rowPitch and imageHeight.
Also touches some surrounding material/definitions.

Fixes #148 
Supersedes #519


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: write EPROTO 140049978214272:error:1407742E:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert protocol version:../deps/openssl/openssl/ssl/s23_clnt.c:772:
 :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 13, 2020, 7:48 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fgpuweb%2Fgpuweb%2Fpull%2F608%2F82346de.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fkainino0x%2Fgpuweb%2Fpull%2F608.html)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%23608.)._
</details>
