### PR TITLE
Rename bindings to entries for consistency

### DIFF
--- a/samples/hello-cube.html
+++ b/samples/hello-cube.html
@@ -9,8 +9,8 @@
 <canvas height=1000 width=1000></canvas>
 <script>
 /*******
-* This preview of Web GPU uses WHLSL as its shading language. 
-* The choice of shading language(s) that will be ingested by the API is still under deliberation. 
+* This preview of Web GPU uses WHLSL as its shading language.
+* The choice of shading language(s) that will be ingested by the API is still under deliberation.
 *******/
 const positionAttributeNum  = 0;
 const colorAttributeNum     = 1;
@@ -24,14 +24,14 @@ struct FragmentData {
 }
 
 vertex FragmentData vertex_main(
-    float4 position : attribute(${positionAttributeNum}), 
-    float4 color : attribute(${colorAttributeNum}), 
+    float4 position : attribute(${positionAttributeNum}),
+    float4 color : attribute(${colorAttributeNum}),
     constant float4x4[] modelViewProjectionMatrix : register(b${transformBindingNum}))
 {
     FragmentData out;
     out.position = mul(modelViewProjectionMatrix[0], position);
     out.color = color;
-    
+
     return out;
 }
 
@@ -106,8 +106,8 @@ async function init() {
 
     const context = canvas.getContext('gpu');
 
-    const swapChainDescriptor = { 
-        device: device, 
+    const swapChainDescriptor = {
+        device: device,
         format: "bgra8unorm"
     };
     swapChain = context.configureSwapChain(swapChainDescriptor);
@@ -142,13 +142,13 @@ async function init() {
     const vertexInputDescriptor = { vertexBuffers: [vertexBufferDescriptor] };
 
     // Bind group binding layout
-    const transformBufferBindGroupLayoutBinding = {
+    const transformBufferBindGroupLayoutEntry = {
         binding: transformBindingNum, // id[[(0)]]
         visibility: GPUShaderStageBit.VERTEX,
         type: "uniform-buffer"
     };
 
-    const bindGroupLayoutDescriptor = { bindings: [transformBufferBindGroupLayoutBinding] };
+    const bindGroupLayoutDescriptor = { entries: [transformBufferBindGroupLayoutEntry] };
     bindGroupLayout = device.createBindGroupLayout(bindGroupLayoutDescriptor);
 
     // Pipeline
@@ -230,7 +230,7 @@ async function init() {
         clearDepth: 1.0
     };
 
-    renderPassDescriptor = { 
+    renderPassDescriptor = {
         colorAttachments: [colorAttachment],
         depthStencilAttachment: depthAttachment
     };
@@ -262,13 +262,13 @@ function createBindGroupDescriptor(transformBuffer) {
         offset: 0,
         size: transformSize
     };
-    const transformBufferBindGroupBinding = {
+    const transformBufferBindGroupEntry = {
         binding: transformBindingNum,
         resource: transformBufferBinding
     };
     return {
         layout: bindGroupLayout,
-        bindings: [transformBufferBindGroupBinding]
+        entries: [transformBufferBindGroupEntry]
     };
 }
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -821,7 +821,7 @@ dictionary GPULimits {
 
     : <dfn>maxDynamicUniformBuffersPerPipelineLayout</dfn>
     ::
-        The maximum number of {{GPUBindGroupLayoutDescriptor/bindings}} for which:
+        The maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
 
           - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"uniform-buffer"}}, and
           - {{GPUBindGroupLayoutEntry/hasDynamicOffset}} is true,
@@ -833,7 +833,7 @@ dictionary GPULimits {
 
     : <dfn>maxDynamicStorageBuffersPerPipelineLayout</dfn>
     ::
-        The maximum number of {{GPUBindGroupLayoutDescriptor/bindings}} for which:
+        The maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
 
           - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"storage-buffer"}}, and
           - {{GPUBindGroupLayoutEntry/hasDynamicOffset}} is true,
@@ -846,7 +846,7 @@ dictionary GPULimits {
     : <dfn>maxSampledTexturesPerShaderStage</dfn>
     ::
         For each possible {{GPUShaderStage}} `stage`,
-        the maximum number of {{GPUBindGroupLayoutDescriptor/bindings}} for which:
+        the maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
 
           - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampled-texture"}}, and
           - {{GPUBindGroupLayoutEntry/visibility}} includes `stage`,
@@ -859,7 +859,7 @@ dictionary GPULimits {
     : <dfn>maxSamplersPerShaderStage</dfn>
     ::
         For each possible {{GPUShaderStage}} `stage`,
-        the maximum number of {{GPUBindGroupLayoutDescriptor/bindings}} for which:
+        the maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
 
           - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampler"}}  or {{GPUBindingType/"comparison-sampler"}}, and
           - {{GPUBindGroupLayoutEntry/visibility}} includes `stage`,
@@ -872,7 +872,7 @@ dictionary GPULimits {
     : <dfn>maxStorageBuffersPerShaderStage</dfn>
     ::
         For each possible {{GPUShaderStage}} `stage`,
-        the maximum number of {{GPUBindGroupLayoutDescriptor/bindings}} for which:
+        the maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
 
           - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"storage-buffer"}}, and
           - {{GPUBindGroupLayoutEntry/visibility}} includes `stage`,
@@ -885,7 +885,7 @@ dictionary GPULimits {
     : <dfn>maxStorageTexturesPerShaderStage</dfn>
     ::
         For each possible {{GPUShaderStage}} `stage`,
-        the maximum number of {{GPUBindGroupLayoutDescriptor/bindings}} for which:
+        the maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
 
           - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"readonly-storage-texture"}} or
             {{GPUBindingType/"writeonly-storage-texture"}}, and
@@ -899,7 +899,7 @@ dictionary GPULimits {
     : <dfn>maxUniformBuffersPerShaderStage</dfn>
     ::
         For each possible {{GPUShaderStage}} `stage`,
-        the maximum number of {{GPUBindGroupLayoutDescriptor/bindings}} for which:
+        the maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
 
           - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/uniform-buffer}}, and
           - {{GPUBindGroupLayoutEntry/visibility}} includes `stage`,
@@ -1604,7 +1604,7 @@ A {{GPUBindGroupLayout}} is created via {{GPUDevice/createBindGroupLayout()|GPUD
 
 <script type=idl>
 dictionary GPUBindGroupLayoutDescriptor : GPUObjectDescriptorBase {
-    required sequence<GPUBindGroupLayoutEntry> bindings;
+    required sequence<GPUBindGroupLayoutEntry> entries;
 };
 </script>
 
@@ -1672,7 +1672,7 @@ enum GPUBindingType {
 A {{GPUBindGroupLayout}} object has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUBindGroupLayout">
-    : <dfn>\[[bindings]]</dfn> of type sequence<{{GPUBindGroupLayoutEntry}}>.
+    : <dfn>\[[entries]]</dfn> of type sequence<{{GPUBindGroupLayoutEntry}}>.
     ::
         The set of {{GPUBindGroupLayoutEntry}}s this {{GPUBindGroupLayout}} describes.
 </dl>
@@ -1685,7 +1685,7 @@ The <dfn method for="GPUDevice">createBindGroupLayout(|descriptor|)</dfn> method
 
 1. Ensure [=device validation=] is not violated.
 1. Let |layout| be a new valid {{GPUBindGroupLayout}} object.
-1. For each {{GPUBindGroupLayoutEntry}} |bindingDescriptor| in |descriptor|.{{GPUBindGroupLayoutDescriptor/bindings}}:
+1. For each {{GPUBindGroupLayoutEntry}} |bindingDescriptor| in |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
     1. Ensure |bindingDescriptor|.{{GPUBindGroupLayoutEntry/binding}} does not violate [=binding validation=].
     1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/visibility}} includes {{GPUShaderStage/VERTEX}}
         , ensure [=vertex shader binding validation=] is not violated.
@@ -1701,7 +1701,7 @@ The <dfn method for="GPUDevice">createBindGroupLayout(|descriptor|)</dfn> method
         , ensure [=storage texture validation=] is not violated.
     1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/sampler}}
         , ensure [=sampler validation=] is not violated.
-    1. Insert |bindingDescriptor| into |layout|.{{GPUBindGroupLayout/[[bindings]]}}.
+    1. Insert |bindingDescriptor| into |layout|.{{GPUBindGroupLayout/[[entries]]}}.
 1. Return |layout|.
 
 <b>Validation Conditions</b>
@@ -1764,7 +1764,7 @@ A {{GPUBindGroup}} is created via {{GPUDevice/createBindGroup()|GPUDevice.create
 <script type=idl>
 dictionary GPUBindGroupDescriptor : GPUObjectDescriptorBase {
     required GPUBindGroupLayout layout;
-    required sequence<GPUBindGroupEntry> bindings;
+    required sequence<GPUBindGroupEntry> entries;
 };
 </script>
 
@@ -1797,7 +1797,7 @@ A {{GPUBindGroup}} object has the following internal slots:
     ::
         The {{GPUBindGroupLayout}} associated with this {{GPUBindGroup}}.
 
-    : <dfn>\[[bindings]]</dfn> of type sequence<{{GPUBindGroupEntry}}>.
+    : <dfn>\[[entries]]</dfn> of type sequence<{{GPUBindGroupEntry}}>.
     ::
         The set of {{GPUBindGroupEntry}}s this {{GPUBindGroup}} describes.
     : <dfn>\[[usedBuffers]]</dfn> of type maplike<{{GPUBuffer}}, {{GPUBufferUsage}}>.
@@ -1818,13 +1818,13 @@ The <dfn method for="GPUDevice">createBindGroup(|descriptor|)</dfn> method is us
 
 1. Ensure [=bind group device validation=] is not violated.
 1. Ensure |descriptor|.{{GPUBindGroupDescriptor/layout}} is a [=valid=] {{GPUBindGroupLayout}}.
-1. Ensure the number of {{GPUBindGroupLayoutDescriptor/bindings}} of
+1. Ensure the number of {{GPUBindGroupLayoutDescriptor/entries}} of
     |descriptor|.{{GPUBindGroupDescriptor/layout}} exactly equals to the number of
-    |descriptor|.{{GPUBindGroupDescriptor/bindings}}.
+    |descriptor|.{{GPUBindGroupDescriptor/entries}}.
 1. For each {{GPUBindGroupEntry}} |bindingDescriptor| in
-    |descriptor|.{{GPUBindGroupDescriptor/bindings}}:
+    |descriptor|.{{GPUBindGroupDescriptor/entries}}:
     1. Ensure there is exactly one {{GPUBindGroupLayoutEntry}} |layoutBinding| in
-        {{GPUBindGroupLayoutDescriptor/bindings}} of |descriptor|.{{GPUBindGroupDescriptor/layout}}
+        {{GPUBindGroupLayoutDescriptor/entries}} of |descriptor|.{{GPUBindGroupDescriptor/layout}}
         such that |layoutBinding|.{{GPUBindGroupLayoutEntry/binding}} equals to
         |bindingDescriptor|.{{GPUBindGroupEntry/binding}}.
     1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
@@ -1850,9 +1850,9 @@ The <dfn method for="GPUDevice">createBindGroup(|descriptor|)</dfn> method is us
         1. Ensure [=buffer binding validation=] is not violated.
 1. Return a new {{GPUBindGroup}} object with:
     - {{GPUBindGroup/[[layout]]}} = |descriptor|.{{GPUBindGroupDescriptor/layout}}
-    - {{GPUBindGroup/[[bindings]]}} = |descriptor|.{{GPUBindGroupDescriptor/bindings}}
-    - {{GPUBindGroup/[[usedBuffers]]}} = union of the buffer usages across the bindings
-    - {{GPUBindGroup/[[usedTextures]]}} = union of the texture subresources usages across the bindings
+    - {{GPUBindGroup/[[entries]]}} = |descriptor|.{{GPUBindGroupDescriptor/entries}}
+    - {{GPUBindGroup/[[usedBuffers]]}} = union of the buffer usages across the entries
+    - {{GPUBindGroup/[[usedTextures]]}} = union of the texture subresources usages across the entries
 
 <b>Validation Conditions</b>
 


### PR DESCRIPTION
This is a follow-up to #590 to make the naming of fields consistent.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: write EPROTO 140049978214272:error:1407742E:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert protocol version:../deps/openssl/openssl/ssl/s23_clnt.c:772:
 :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 13, 2020, 4:49 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fgpuweb%2Fgpuweb%2Fpull%2F611%2F3bf43c1.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fkvark%2Fgpuweb%2Fpull%2F611.html)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%23611.)._
</details>
