### PR TITLE
Merge arrayLayerCount into size.depth

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2625,7 +2625,7 @@ GPUQueue includes GPUObjectBase;
 </script>
 
  - {{GPUQueue/copyImageBitmapToTexture()}}:
-   - For now, `copySize.z` must be `1`.
+   - For now, {{GPUQueue/copyImageBitmapToTexture(source, destination, copySize)/copySize}}.[=Extent3D/depth=] must be `1`.
 
 {{GPUQueue/submit(commandBuffers)}} does nothing and produces an error if any of the following is true:
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1316,7 +1316,6 @@ GPUTexture includes GPUObjectBase;
 <script type=idl>
 dictionary GPUTextureDescriptor : GPUObjectDescriptorBase {
     required GPUExtent3D size;
-    GPUIntegerCoordinate arrayLayerCount = 1;
     GPUIntegerCoordinate mipLevelCount = 1;
     GPUSize32 sampleCount = 1;
     GPUTextureDimension dimension = "2d";
@@ -1380,7 +1379,7 @@ internal slots of a [=texture=] internal object once we have one. -->
       - If |texture|.{{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"1d"}},
         defaults to {{GPUTextureViewDimension/"1d"}}.
       - If |texture|.{{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"2d"}}:
-          - If |texture|.{{GPUTextureDescriptor/arrayLayerCount}} is greater than 1
+          - If |texture|.{{GPUTextureDescriptor/size}}.[=Extent3D/depth=] is greater than 1
             and {{GPUTextureViewDescriptor/arrayLayerCount}} is 0,
             defaults to {{GPUTextureViewDimension/"2d-array"}}.
           - Otherwise, defaults to {{GPUTextureViewDimension/"2d"}}.
@@ -1391,7 +1390,7 @@ internal slots of a [=texture=] internal object once we have one. -->
     If 0, defaults to |texture|.{{GPUTextureDescriptor/mipLevelCount}} &minus; {{GPUTextureViewDescriptor/baseMipLevel}}.
 
   * {{GPUTextureViewDescriptor/arrayLayerCount}}:
-    If 0, defaults to |texture|.{{GPUTextureDescriptor/arrayLayerCount}} &minus; {{GPUTextureViewDescriptor/baseArrayLayer}}.
+    If 0, defaults to |texture|.{{GPUTextureDescriptor/size}}.[=Extent3D/depth=] &minus; {{GPUTextureViewDescriptor/baseArrayLayer}}.
 
 </div>
 
@@ -2819,6 +2818,24 @@ dictionary GPUExtent3DDict {
 typedef (sequence<GPUIntegerCoordinate> or GPUExtent3DDict) GPUExtent3D;
 </script>
 
+An <dfn dfn>Extent3D</dfn> is a {{GPUExtent3D}}.
+[=Extent3D=] is a spec namespace for the following definitions:
+<!-- This is silly, but provides convenient syntax for the spec. -->
+
+<div algorithm="GPUExtent3D accessors" dfn-for=Extent3D>
+    For a given {{GPUExtent3D}} value |extent|, depending on its type, the syntax:
+
+      * |extent|.<dfn dfn>width</dfn> refers to
+        either {{GPUExtent3DDict}}.{{GPUExtent3DDict/width}}
+        or the first item of the sequence.
+      * |extent|.<dfn dfn>height</dfn> refers to
+        either {{GPUExtent3DDict}}.{{GPUExtent3DDict/height}}
+        or the second item of the sequence.
+      * |extent|.<dfn dfn>depth</dfn> refers to
+        either {{GPUExtent3DDict}}.{{GPUExtent3DDict/depth}}
+        or the third item of the sequence.
+</div>
+
 <script type=idl>
 typedef sequence<(GPUBuffer or ArrayBuffer)> GPUMappedBuffer;
 </script>
@@ -2826,8 +2843,10 @@ typedef sequence<(GPUBuffer or ArrayBuffer)> GPUMappedBuffer;
 {{GPUMappedBuffer}} is always a sequence of 2 elements, of types {{GPUBuffer}}
 and {{ArrayBuffer}}, respectively.
 
-# Temporary usages of non-exported dfns ## {#temp-dfn-usages}
+# Temporary usages of non-exported dfns # {#temp-dfn-usages}
 
 Eventually all of these should disappear but they are useful to avoid warning while building the specification.
 
 [=vertex buffer=]
+[=Extent3D/width=]
+[=Extent3D/height=]


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: write EPROTO 140049978214272:error:1407742E:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert protocol version:../deps/openssl/openssl/ssl/s23_clnt.c:772:
 :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 14, 2020, 3:05 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fgpuweb%2Fgpuweb%2Fpull%2F613%2F3bf43c1.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fgpuweb%2Fgpuweb%2Fpull%2F613.html)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%23613.)._
</details>
