### PR TITLE
[wgsl] Remove push constant from WGSL.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -414,7 +414,6 @@ Note: literals are parsed greedy. This means that for statements like `a -5`
   <tr><td>`POSITION`<td> position
   <tr><td>`PREMREGE`<td>premerge
   <tr><td>`PRIVATE`<td>private
-  <tr><td>`PUSH_CONSTANT`<td>push_constant
   <tr><td>`REGARDLESS`<td>regardless
   <tr><td>`RETURN`<td>return
   <tr><td>`SET`<td>set
@@ -816,7 +815,6 @@ storage_class
   | UNIFORM_CONSTANT
   | STORAGE_BUFFER
   | IMAGE
-  | PUSH_CONSTANT
   | PRIVATE
   | FUNCTION
 </pre>
@@ -832,7 +830,6 @@ storage_class
   <tr><td>uniform_constant<td>UniformConstant
   <tr><td>storage_buffer<td>StorageBuffer
   <tr><td>image<td>Image
-  <tr><td>push_constant<td>PushConstant
   <tr><td>private<td>Private
   <tr><td>function<td>Function
 </table>


### PR DESCRIPTION
It was decided that push constants will not be in WebGPU at this point.
Remove references from the WGSL spec.

Fixes #612