### PR TITLE
Reorder fields of GPUBindGroupLayoutEntry

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1622,9 +1622,9 @@ dictionary GPUBindGroupLayoutEntry {
     required GPUBindingType type;
     GPUTextureViewDimension viewDimension = "2d";
     GPUTextureComponentType textureComponentType = "float";
+    GPUTextureFormat storageTextureFormat;
     boolean multisampled = false;
     boolean hasDynamicOffset = false;
-    GPUTextureFormat storageTextureFormat;
 };
 </script>
 


### PR DESCRIPTION
Just a cosmetic change to group fields related to texture properties together.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: write EPROTO 140222018242432:error:1407742E:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert protocol version:../deps/openssl/openssl/ssl/s23_clnt.c:772:
 :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 16, 2020, 11:22 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fgpuweb%2Fgpuweb%2Fpull%2F618%2F7531dda.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fgpuweb%2Fgpuweb%2Fpull%2F618.html)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%23618.)._
</details>
