### PR TITLE
Add definitions about copy commands with textures

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -410,6 +410,15 @@ The [=subresources=] of textures included in the views provided to
 are considered to have {{GPUTextureUsage/OUTPUT_ATTACHMENT}}
 for the [=usage scope=] of this render pass.
 
+The <dfn dfn>physical size</dfn> of a {{GPUTexture}} [=subresource=] is the dimension of the {{GPUTexture}}
+[=subresource=] in pixels that includes the possible extra paddings to form complete [=texel blocks=] in the
+[=subresource=]. The extra paddings only exists in a compressed texture mipmap whose {{GPUTexture/[[textureSize]]}}
+at [=mipmap level=] 0 are multiple of [=texel block size=], but its subdivided levels are not. For example,
+considering a texture in BC format whose {{GPUTexture/[[textureSize]]}} is {60, 60, 1}, when sampling the texture
+at [=mipmap level=] 2, the sampling hardware uses {15, 15, 1} as the size of the [=subresource=], while its
+[=physical size=] is {16, 16, 1} as the block-compression algorithm can only operate on 4x4 [=texel blocks=]. There
+is no extra padding for the {{GPUTexture}} [=subresources=] with non-compressed texture formats.
+
 Issue(gpuweb/gpuweb#514): Document read-only states for depth views.
 
 ## Synchronization ## {#programming-model-synchronization}
@@ -1322,6 +1331,34 @@ interface GPUTexture {
 GPUTexture includes GPUObjectBase;
 </script>
 
+{{GPUTexture}} has the following internal slots:
+<dl dfn-type=attribute dfn-for="GPUTexture">
+    : <dfn>\[[textureSize]]</dfn> of type {{GPUExtent3D}}.
+    ::
+        The size of the {{GPUTexture}} in texels.
+
+    : <dfn>\[[mipLevelCount]]</dfn> of type {{GPUIntegerCoordinate}}.
+    ::
+        The total number of the mipmap levels of the {{GPUTexture}}.
+
+    : <dfn>\[[sampleCount]]</dfn> of type {{GPUSize32}}.
+    ::
+        The sample count of the {{GPUTexture}}.
+
+    : <dfn>\[[dimension]]</dfn> of type {{GPUTextureDimension}}.
+    ::
+        The dimension of the {{GPUTexture}}.
+
+    : <dfn>\[[format]]</dfn> of type {{GPUTextureFormat}}.
+    ::
+        The format of the {{GPUTexture}}.
+
+    : <dfn>\[[textureUsage]]</dfn> of type {{GPUTextureUsageFlags}}.
+    ::
+        The allowed usages for this {{GPUTexture}}.
+
+</dl>
+
 ### Texture Creation ### {#texture-creation}
 
 <script type=idl>
@@ -1441,6 +1478,16 @@ and vice versa are applied during the reading and writing of color values in the
 shader. Compressed texture formats are provided by extensions. Their naming
 should follow the convention here, with the texture name as a prefix. e.g.
 `etc2-rgba8unorm`.
+
+The <dfn dfn>texel block</dfn> is a single addressable element of an uncompressed texture, or a single
+compressed block of a compressed texture. The <dfn dfn>texel block size</dfn> of a {{GPUTextureFormat}} is
+the number of bytes to store one [=texel block=]. The [=texel block size=] of each {{GPUTextureFormat}} is a
+constant value except for {{GPUTextureFormat/"depth24plus"}} and {{GPUTextureFormat/"depth24plus-stencil8"}}.
+
+The <dfn dfn>texel block width</dfn> and <dfn dfn> texel block height </dfn> specifies the dimension of
+one [=texel block=]. [=texel block width=] is the number of pixels in each row of one [=texel block=],
+and [=texel block height=] is the number of texel rows in one [=texel block=]. The [=texel block width=]
+and [=texel block height=] of non-compressed texture formats are 1.
 
 <script type=idl>
 enum GPUTextureFormat {
@@ -2370,6 +2417,8 @@ used when copying data between a [=texture=] and a [=buffer=].
         and must be greater than zero otherwise.
 </dl>
 
+### <dfn dictionary>GPUTextureCopyView</dfn> ### {#gpu-texture-copy-view}
+
 <script type=idl>
 dictionary GPUTextureCopyView {
     required GPUTexture texture;
@@ -2379,7 +2428,15 @@ dictionary GPUTextureCopyView {
 };
 </script>
 
+A {{GPUTextureCopyView}} is a view of a sub-region of a [=texture=] [=subresource=] with the initial offset {{GPUOrigin3D} in
+texels, used when copying data between two [=texture=]s, from a [=buffer=] to a [=texture=] and from a [=texture=] to a [=buffer=].
+
+  - For {{GPUTextureDimension/2d}} textures, data is copied between one [=image=] and one [=array layer=].
+  - For {{GPUTextureDimension/3d}} textures, data is copied between one [=image=] and one depth [=slice=].
+
   * {{GPUTextureCopyView/origin}}: If unspecified, defaults to `[0, 0, 0]`.
+
+### <dfn dictionary>GPUImageBitmapCopyView</dfn> ### {#gpu-image-bitmap-copy-view}
 
 <script type=idl>
 dictionary GPUImageBitmapCopyView {

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -411,13 +411,19 @@ are considered to have {{GPUTextureUsage/OUTPUT_ATTACHMENT}}
 for the [=usage scope=] of this render pass.
 
 The <dfn dfn>physical size</dfn> of a {{GPUTexture}} [=subresource=] is the dimension of the {{GPUTexture}}
-[=subresource=] in pixels that includes the possible extra paddings to form complete [=texel blocks=] in the
-[=subresource=]. The extra paddings only exists in a compressed texture mipmap whose {{GPUTexture/[[textureSize]]}}
-at [=mipmap level=] 0 are multiple of [=texel block size=], but its subdivided levels are not. For example,
-considering a texture in BC format whose {{GPUTexture/[[textureSize]]}} is {60, 60, 1}, when sampling the texture
-at [=mipmap level=] 2, the sampling hardware uses {15, 15, 1} as the size of the [=subresource=], while its
-[=physical size=] is {16, 16, 1} as the block-compression algorithm can only operate on 4x4 [=texel blocks=]. There
-is no extra padding for the {{GPUTexture}} [=subresources=] with non-compressed texture formats.
+[=subresource=] in texels that includes the possible extra paddings to form complete [=texel blocks=] in the
+[=subresource=].
+
+  - For pixel-based {{GPUTextureFormat}}s, the [=physical size=] is always equal to the size of the [=subresource=]
+    used in the sampling hardwares.
+  - {{GPUTexture}}s in compressed {{GPUTextureFormat}}s always have a [=mipmap level=] 0 whose {{GPUTexture/[[textureSize]]}}
+    is a multiple of the [=texel block size=], but the lower mipmap levels might not be the multiple of the [=texel block size=]
+    and can have paddings.
+
+Example: considering a {{GPUTexture}} in BC format whose {{GPUTexture/[[textureSize]]}} is {60, 60, 1}, when sampling
+the {{GPUTexture}} at [=mipmap level=] 2, the sampling hardware uses {15, 15, 1} as the size of the [=subresource=],
+while its [=physical size=] is {16, 16, 1} as the block-compression algorithm can only operate on 4x4 [=texel blocks=].
+There is no extra padding for the {{GPUTexture}} [=subresources=] with non-compressed {{GPUTextureFormat}}s.
 
 Issue(gpuweb/gpuweb#514): Document read-only states for depth views.
 
@@ -1335,7 +1341,7 @@ GPUTexture includes GPUObjectBase;
 <dl dfn-type=attribute dfn-for="GPUTexture">
     : <dfn>\[[textureSize]]</dfn> of type {{GPUExtent3D}}.
     ::
-        The size of the {{GPUTexture}} in texels.
+        The size of the {{GPUTexture}} in texels in [=mipmap level=] 0.
 
     : <dfn>\[[mipLevelCount]]</dfn> of type {{GPUIntegerCoordinate}}.
     ::
@@ -1343,7 +1349,7 @@ GPUTexture includes GPUObjectBase;
 
     : <dfn>\[[sampleCount]]</dfn> of type {{GPUSize32}}.
     ::
-        The sample count of the {{GPUTexture}}.
+        The number of samples in each texel of the {{GPUTexture}}.
 
     : <dfn>\[[dimension]]</dfn> of type {{GPUTextureDimension}}.
     ::
@@ -1479,15 +1485,17 @@ shader. Compressed texture formats are provided by extensions. Their naming
 should follow the convention here, with the texture name as a prefix. e.g.
 `etc2-rgba8unorm`.
 
-The <dfn dfn>texel block</dfn> is a single addressable element of an uncompressed texture, or a single
-compressed block of a compressed texture. The <dfn dfn>texel block size</dfn> of a {{GPUTextureFormat}} is
-the number of bytes to store one [=texel block=]. The [=texel block size=] of each {{GPUTextureFormat}} is a
-constant value except for {{GPUTextureFormat/"depth24plus"}} and {{GPUTextureFormat/"depth24plus-stencil8"}}.
+For pixel-based {{GPUTextureFormat}}s, the <dfn dfn>texel block</dfn> is a single addressable element of the texture,
+and their <dfn dfn>texel block width</dfn> and <dfn dfn>texel block height</dfn> are always 1.
 
-The <dfn dfn>texel block width</dfn> and <dfn dfn> texel block height </dfn> specifies the dimension of
-one [=texel block=]. [=texel block width=] is the number of pixels in each row of one [=texel block=],
-and [=texel block height=] is the number of texel rows in one [=texel block=]. The [=texel block width=]
-and [=texel block height=] of non-compressed texture formats are 1.
+For block-based compressed {{GPUTextureFormat}}s, the [=texel block=] is a single compressed block of a compressed
+texture. The [=texel block width=] and [=texel block height=] specifies the dimension of one [=texel block=]. The
+[=texel block width=] is the number of texels in each row of one [=texel block=], and the [=texel block height=] is
+the number of texel rows in one [=texel block=]. 
+
+The <dfn dfn>texel block size</dfn> of a {{GPUTextureFormat}} is the number of bytes to store one [=texel block=].
+The [=texel block size=] of each {{GPUTextureFormat}} is constant except for {{GPUTextureFormat/"depth24plus"}} and
+{{GPUTextureFormat/"depth24plus-stencil8"}}.
 
 <script type=idl>
 enum GPUTextureFormat {
@@ -2428,11 +2436,11 @@ dictionary GPUTextureCopyView {
 };
 </script>
 
-A {{GPUTextureCopyView}} is a view of a sub-region of a [=texture=] [=subresource=] with the initial offset {{GPUOrigin3D} in
-texels, used when copying data between two [=texture=]s, from a [=buffer=] to a [=texture=] and from a [=texture=] to a [=buffer=].
+A {{GPUTextureCopyView}} is a view of a sub-region of a [=texture=] [=subresource=] with the initial offset {{GPUOrigin3D}} in
+texels, used when copying data from or to a {{GPUTexture}}.
 
-  - For {{GPUTextureDimension/2d}} textures, data is copied between one [=image=] and one [=array layer=].
-  - For {{GPUTextureDimension/3d}} textures, data is copied between one [=image=] and one depth [=slice=].
+  - For {{GPUTextureDimension/2d}} textures, data is copied from or to one [=mipmap level=] and one [=array layer=] of the [=texture=].
+  - For {{GPUTextureDimension/3d}} textures, data is copied from or to one [=mipmap level=] of the [=texture=].
 
   * {{GPUTextureCopyView/origin}}: If unspecified, defaults to `[0, 0, 0]`.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -416,15 +416,14 @@ The <dfn dfn>physical size</dfn> of a {{GPUTexture}} [=subresource=] is the dime
 
   - For pixel-based {{GPUTextureFormat}}s, the [=physical size=] is always equal to the size of the [=subresource=]
     used in the sampling hardwares.
-  - {{GPUTexture}}s in compressed {{GPUTextureFormat}}s always have a [=mipmap level=] 0 whose {{GPUTexture/[[textureSize]]}}
-    is a multiple of the [=texel block size=], but the lower mipmap levels might not be the multiple of the [=texel block size=]
-    and can have paddings.
+  - {{GPUTexture}}s in block-based compressed {{GPUTextureFormat}}s always have a [=mipmap level=] 0 whose {{GPUTexture/[[textureSize]]}}
+    is a multiple of the [=texel block size=], but the lower mipmap levels might not be the multiple of the [=texel block size=] and can
+    have paddings.
 
 <div class="example">
 Considering a {{GPUTexture}} in BC format whose {{GPUTexture/[[textureSize]]}} is {60, 60, 1}, when sampling
 the {{GPUTexture}} at [=mipmap level=] 2, the sampling hardware uses {15, 15, 1} as the size of the [=subresource=],
 while its [=physical size=] is {16, 16, 1} as the block-compression algorithm can only operate on 4x4 [=texel blocks=].
-There is no extra padding for the {{GPUTexture}} [=subresources=] with non-compressed {{GPUTextureFormat}}s.
 </div>
 
 Issue(gpuweb/gpuweb#514): Document read-only states for depth views.
@@ -1487,13 +1486,13 @@ shader. Compressed texture formats are provided by extensions. Their naming
 should follow the convention here, with the texture name as a prefix. e.g.
 `etc2-rgba8unorm`.
 
-For pixel-based {{GPUTextureFormat}}s, the <dfn dfn>texel block</dfn> is a single addressable element of the texture,
-and their <dfn dfn>texel block width</dfn> and <dfn dfn>texel block height</dfn> are always 1.
+The <dfn dfn>texel block</dfn> is a single addressable element of the textures in pixel-based {{GPUTextureFormat}}s,
+and a single compressed block of the textures in block-based compressed {{GPUTextureFormat}}s.
 
-For block-based compressed {{GPUTextureFormat}}s, the [=texel block=] is a single compressed block of a compressed
-texture. The [=texel block width=] and [=texel block height=] specifies the dimension of one [=texel block=]. The
-[=texel block width=] is the number of texels in each row of one [=texel block=], and the [=texel block height=] is
-the number of texel rows in one [=texel block=]. 
+The <dfn dfn>texel block width</dfn> and <dfn dfn>texel block height</dfn> specifies the dimension of one [=texel block=].
+  - For pixel-based {{GPUTextureFormat}}s, the [=texel block width=] and [=texel block height=] are always 1.
+  - For block-based compressed {{GPUTextureFormat}}s, the [=texel block width=] is the number of texels in each row of one [=texel block=],
+    and the [=texel block height=] is the number of texel rows in one [=texel block=].
 
 The <dfn dfn>texel block size</dfn> of a {{GPUTextureFormat}} is the number of bytes to store one [=texel block=].
 The [=texel block size=] of each {{GPUTextureFormat}} is constant except for {{GPUTextureFormat/"depth24plus"}} and
@@ -2442,9 +2441,10 @@ A {{GPUTextureCopyView}} is a view of a sub-region of a [=texture=] [=subresourc
 texels, used when copying data from or to a {{GPUTexture}}.
 
   - For {{GPUTextureDimension/2d}} textures, data is copied from or to one [=mipmap level=] and one [=array layer=] of the [=texture=].
-  - For {{GPUTextureDimension/3d}} textures, data is copied from or to one [=mipmap level=] of the [=texture=].
 
   * {{GPUTextureCopyView/origin}}: If unspecified, defaults to `[0, 0, 0]`.
+
+Issue(gpuweb/gpuweb#69): Define the copies with {{GPUTextureDimension/1d}} and {{GPUTextureDimension/3d}} textures.
 
 ### <dfn dictionary>GPUImageBitmapCopyView</dfn> ### {#gpu-image-bitmap-copy-view}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -420,10 +420,12 @@ The <dfn dfn>physical size</dfn> of a {{GPUTexture}} [=subresource=] is the dime
     is a multiple of the [=texel block size=], but the lower mipmap levels might not be the multiple of the [=texel block size=]
     and can have paddings.
 
-Example: considering a {{GPUTexture}} in BC format whose {{GPUTexture/[[textureSize]]}} is {60, 60, 1}, when sampling
+<div class="example">
+Considering a {{GPUTexture}} in BC format whose {{GPUTexture/[[textureSize]]}} is {60, 60, 1}, when sampling
 the {{GPUTexture}} at [=mipmap level=] 2, the sampling hardware uses {15, 15, 1} as the size of the [=subresource=],
 while its [=physical size=] is {16, 16, 1} as the block-compression algorithm can only operate on 4x4 [=texel blocks=].
 There is no extra padding for the {{GPUTexture}} [=subresources=] with non-compressed {{GPUTextureFormat}}s.
+</div>
 
 Issue(gpuweb/gpuweb#514): Document read-only states for depth views.
 


### PR DESCRIPTION
This patch adds several definitions that are required in the
validation rules of copy commands with textures.
- the internal slots of a GPUTexture
- texel block
- texel block size
- texel block width
- texel block height
- the physical size of a texture subresource
- GPUTextureCopyView

This patch also adds a sub-title for GPUImageBitmapCopyView to
keep it in the same style as GPUBufferCopyView.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 23, 2020, 9:25 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fgpuweb%2Fgpuweb%2Fpull%2F623%2F2ce1971.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2FJiawei-Shao%2Fgpuweb%2Fpull%2F623.html)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 sysreq@w3.org to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%23623.)._
</details>
