### PR TITLE
Add callback entrypoints for per-frame Promise entrypoints.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -425,7 +425,7 @@ On the [=Queue timeline=], there is an ordered sequence of [=usage scopes=].
 Each item on the timeline is contained within exactly one scope.
 For the duration of each scope, the set of [=usage flags=] of any given
 [=subresource=] is constant.
-A [=subresource=] may transition to new usages 
+A [=subresource=] may transition to new usages
 at the boundaries between [=usage scope=]s.
 
 This specification defines the following [=usage scopes=]:
@@ -1017,8 +1017,12 @@ its mapping.
      mapping.
 
 <script type=idl>
+callback BufferMapCallback = void (ArrayBuffer? mapping);
+
 [Serializable]
 interface GPUBuffer {
+    void requestMapRead(BufferMapCallback callback);  // Generates no new garbage.
+    void requestMapWrite(BufferMapCallback callback); // Generates no new garbage.
     Promise<ArrayBuffer> mapReadAsync();
     Promise<ArrayBuffer> mapWriteAsync();
     void unmap();
@@ -2663,9 +2667,12 @@ GPUQueue includes GPUObjectBase;
 ## GPUFence ## {#fence}
 
 <script type=idl>
+callback FenceCompletionCallback = void (bool complete);
+
 interface GPUFence {
     GPUFenceValue getCompletedValue();
-    Promise<void> onCompletion(GPUFenceValue completionValue);
+    void onCompletion(GPUFenceValue completionValue, FenceCompletionCallback callback);
+    Promise<void> onCompletionAsync(GPUFenceValue completionValue);
 };
 GPUFence includes GPUObjectBase;
 </script>
@@ -2752,9 +2759,12 @@ typedef (GPUOutOfMemoryError or GPUValidationError) GPUError;
 </script>
 
 <script type=idl>
+callback PopErrorScopeCallback = void (bool complete, GPUError? error);
+
 partial interface GPUDevice {
     void pushErrorScope(GPUErrorFilter filter);
-    Promise<GPUError?> popErrorScope();
+    void popErrorScope(PopErrorScopeCallback callback); // Generates no new garbage.
+    Promise<GPUError?> popErrorScopeAsync();
 };
 </script>
 


### PR DESCRIPTION
Callbacks generate no new garbage themselves.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 23, 2020, 9:27 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fgpuweb%2Fgpuweb%2Fpull%2F626%2F2e86cff.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fjdashg%2Fgpuweb%2Fpull%2F626.html)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 sysreq@w3.org to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%23626.)._
</details>
