### PR TITLE
[wgsl] Fix loop in the example

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1081,7 +1081,7 @@ ordering requirements for a loop in SPIR-V.
   <xmp>
     const a : i32 = 2;
     var i : i32 = 0; <1>
-    loop () {
+    loop {
       break if (i >= 4);
 
       a = a * 2;


### PR DESCRIPTION
The definition of loops doesn't have `paren_rhs_stmt`, so I assume the example shouldn't make use of it.