### PR TITLE
Minor toplevel copyediting

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -29,13 +29,14 @@ spec: webidl; urlPrefix: https://heycam.github.io/webidl/#
 
 <style>
 .validusage {
-    border-color: #88e !important;
+    padding: .5em;
+    border: thin solid #88e !important;
+    border-radius: .5em;
 }
 </style>
 
 
-Introduction {#intro}
-=====================
+# Introduction # {#intro}
 
 *This section is non-normative.*
 
@@ -64,10 +65,11 @@ a {{GPURenderPipeline}} or a {{GPUComputePipeline}} object. The state not includ
 in these [=pipeline=] objects is set during encoding with commands,
 such as {{GPUCommandEncoder/beginRenderPass()}} or {{GPURenderPassEncoder/setBlendColor()}}.
 
-Security considerations {#security}
-=====================
+
+# Security considerations # {#security}
 
 ## CPU-based undefined behavior ## {#security-cpu-ub}
+
 A WebGPU implementation translates the workloads issued by the user into API commands specific
 to the target platform. Native APIs specify the valid usage for the commands
 (for example, see [vkCreateDescriptorSetLayout](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateDescriptorSetLayout.html))
@@ -85,6 +87,7 @@ generating an error, and no other operation occurring.
 See [[#errors-and-debugging]] for more information about error handling.
 
 ## GPU-based undefined behavior ## {#security-gpu-ub}
+
 WebGPU [=shader=]s are executed by the compute units inside GPU hardware. In native APIs,
 some of the shader instructions may result in undefined behavior on the GPU.
 In order to address that, the shader instruction set and its defined behaviors are
@@ -92,6 +95,7 @@ strictly defined by WebGPU. When a shader is provided, the WebGPU implementation
 before doing any translation (to platform-specific shaders) or transformation passes.
 
 ## Out-of-bounds access in shaders ## {#security-shader}
+
 [=Shader=]s can access [=physical resource=]s either directly or via <dfn dfn>texture unit</dfn>s,
 which are fixed-function hardware blocks that handle texture coordinate conversions.
 Validation on the API side can only guarantee that all the inputs to the shader are provided and
@@ -117,6 +121,7 @@ the implementation is allowed to:
   3. partially discard the draw or dispatch call
 
 ## Invalid data ## {#security-invalid-data}
+
 When uploading [floating-point](https://en.wikipedia.org/wiki/IEEE_754) data from CPU to GPU,
 or generating it on the GPU, we may end up with a binary representation that doesn't correspond
 to a valid number, such as infinity or NaN (not-a-number). The GPU behavior in this case is
@@ -125,6 +130,7 @@ WebGPU guarantees that introducing invalid floating-point numbers would only aff
 of arithmetic computations and will not have other side effects.
 
 ## Driver bugs ## {#security-driver-bugs}
+
 GPU drivers are subject to bugs like any other software. If a bug occurs, an attacker
 could possibly exploit the incorrect behavior of the driver to get access to unprivileged data.
 In order to reduce the risk, the WebGPU working group will coordinate with GPU vendors
@@ -134,6 +140,7 @@ WebGPU implementations are expected to have workarounds for some of the discover
 and support blacklisting particular drivers from using some of the native API backends.
 
 ## Timing attacks ## {#security-timing}
+
 WebGPU is designed for multi-threaded use via Web Workers. Some of the objects,
 like {{GPUBuffer}}, have shared state which can be simultaneously accessed.
 This allows race conditions to occur, similar to those of accessing a SharedArrayBuffer
@@ -142,6 +149,7 @@ and allows the creation of high-precision timers.
 The theoretical attack vectors are a subset of those of SharedArrayBuffer.
 
 ## Denial of service ## {#security-dos}
+
 WebGPU applications have access to GPU memory and compute units. A WebGPU implementation may limit
 the available GPU memory to an application, in order to keep other applications responsive.
 For GPU processing time, a WebGPU implementation may set up "watchdog" timer that makes sure an
@@ -149,13 +157,13 @@ application doesn't cause GPU unresponsiveness for more than a few seconds.
 These measures are similar to those used in WebGL.
 
 ## Fingerprinting ## {#security-fingerprint}
+
 WebGPU defines the required limits and capabilities of any {{GPUAdapter}}.
 and encourages applications to target these standard limits. The actual result from
 {{GPU/requestAdapter()}} may have [=better=] limits, and could be subject to fingerprinting.
 
 
-Terminology &amp; Conventions {#terminology-and-conventions}
-============================================================
+# Terminology &amp; Conventions # {#terminology-and-conventions}
 
 ## Dot Syntax ## {#dot-syntax}
 
@@ -259,8 +267,7 @@ dictionary GPUObjectDescriptorBase {
 </dl>
 
 
-Programming Model {#programming-model}
-======================================
+# Programming Model # {#programming-model}
 
 ## Timelines ## {#programming-model-timelines}
 
@@ -462,8 +469,8 @@ the set of all [=usage flags=] of each [=subresource=] used in the [=usage scope
 A {{GPUValidationError}} is generated in the current scope with an appropriate error message
 if that union contains a [=mutating usage=] combined with any other usage.
 
-Core Internal Objects {#core-internal-objects}
-==============================================
+
+# Core Internal Objects # {#core-internal-objects}
 
 ## Adapters ## {#adapters}
 
@@ -547,8 +554,7 @@ A [=device=] has the following internal slots:
 [=Devices=] are exposed via {{GPUDevice}}.
 
 
-Initialization {#initialization}
-================================
+# Initialization # {#initialization}
 
 ## Examples ## {#initialization-examples}
 
@@ -591,7 +597,7 @@ interface GPU {
 
 ### <dfn method for=GPU>requestAdapter(options)</dfn> ### {#requestadapter}
 
-<div algorithm=requestAdapter>
+<div algorithm=GPU.requestAdapter>
     **Arguments:**
       - optional {{GPURequestAdapterOptions}} |options| = {}
 
@@ -728,9 +734,11 @@ interface GPUAdapter {
 
   - The methods defined by the following sub-sections.
 
-### <dfn method for=GPUAdapter>requestDevice(descriptor)</dfn> ### {#requestdevice}
+### <dfn method for=GPUAdapter>requestDevice(optional descriptor)</dfn> ### {#requestdevice}
 
-<div algorithm=requestDevice>
+<div algorithm=GPUAdapter.requestDevice>
+    <strong>|this|:</strong> of type {{GPUAdapter}}.
+
     **Arguments:**
         - optional {{GPUDeviceDescriptor}} |descriptor| = {}
 
@@ -742,28 +750,27 @@ interface GPUAdapter {
     On the [=Device timeline=], the following steps occur:
 
       - If the user agent can fulfill the request and
-        the [$requestDevice Valid Usage|valid usage$] rules are met:
+        the [$GPUAdapter.requestDevice/Valid Usage$] rules are met:
 
           - |promise| [=resolves=] to a new {{GPUDevice}} object encapsulating
             [=a new device=] with the capabilities described by |descriptor|.
 
       - Otherwise, |promise| [=rejects=] with an {{OperationError}}.
-</div>
 
-<div algorithm class=validusage>
-    <dfn abstract-op>requestDevice Valid Usage</dfn>
+    <div class=validusage dfn-for=GPUAdapter.requestDevice>
+        <dfn abstract-op>Valid Usage</dfn>
 
-    Given an [=adapter=] |adapter| and a {{GPUDeviceDescriptor}} |descriptor|,
-    the following validation rules apply:
+        Let |adapter| be |this|.{{GPUAdapter/[[adapter]]}}.
 
-      - The set of {{GPUExtensionName}} values in
-        |descriptor|.{{GPUDeviceDescriptor/extensions}}
-        must be a subset of those in |adapter|.{{adapter/[[extensions]]}}.
+        - The set of {{GPUExtensionName}} values in
+            |descriptor|.{{GPUDeviceDescriptor/extensions}}
+            must be a subset of those in |adapter|.{{adapter/[[extensions]]}}.
 
-      - For each type of limit in {{GPULimits}}, the value of that limit in
-        |descriptor|.{{GPUDeviceDescriptor/limits}}
-        must be no [=better=] than the value of that limit in
-        |adapter|.{{adapter/[[limits]]}}.
+        - For each type of limit in {{GPULimits}}, the value of that limit in
+            |descriptor|.{{GPUDeviceDescriptor/limits}}
+            must be no [=better=] than the value of that limit in
+            |adapter|.{{adapter/[[limits]]}}.
+    </div>
 </div>
 
 #### <dfn dictionary>GPUDeviceDescriptor</dfn> #### {#gpudevicedescriptor}
@@ -1013,7 +1020,9 @@ GPUDevice includes GPUObjectBase;
 </div>
 
 
-# {{GPUBuffer}} # {#GPUBuffer}
+# Buffers # {#buffers}
+
+## <dfn interface>GPUBuffer</dfn> ## {#buffer-interface}
 
 Issue: define <dfn dfn>buffer</dfn> (internal object)
 
@@ -1101,7 +1110,7 @@ realms (threads/workers), allowing multiple realms to access it concurrently.
 Since {{GPUBuffer}} has internal state (mapped, destroyed), that state is
 internally-synchronized - these state changes occur atomically across realms.
 
-## Buffer creation ## {#buffer-creation}
+## Buffer Creation ## {#buffer-creation}
 
 ### {{GPUBufferDescriptor}} ### {#GPUBufferDescriptor}
 
@@ -1180,18 +1189,16 @@ access to it before garbage collection by calling {{GPUBuffer/destroy()}}.
 Note: This allows the user agent to reclaim the GPU memory associated with the {{GPUBuffer}}
 once all previously submitted operations using it are complete.
 
-<dl dfn-type="method" dfn-for="GPUBuffer">
-    : <dfn>destroy()</dfn>
-    ::
-        <div algorithm="GPUBuffer.destroy()">
-            <!-- TODO(kangz) handle error buffers once we have a description of the error monad -->
-            1. If the {{[[state]]}} slot of |this| is [=buffer state/mapped for reading=] or [=buffer state/mapped for writing=]:
+### <dfn method for=GPUBuffer>destroy()</dfn> ### {#buffer-destroy}
 
-                1. Run the steps to unmap `"this"`
+<div algorithm="GPUBuffer.destroy">
+    <!-- TODO(kangz) handle error buffers once we have a description of the error monad -->
+    1. If the {{[[state]]}} slot of |this| is [=buffer state/mapped for reading=] or [=buffer state/mapped for writing=]:
 
-            1. Set the {{[[state]]}} slot of |this| to [=buffer state/destroyed=]
-        </div>
-</dl>
+        1. Run the steps to unmap `"this"`
+
+    1. Set the {{[[state]]}} slot of |this| to [=buffer state/destroyed=]
+</div>
 
 ## Buffer Usage ## {#buffer-usage}
 
@@ -1225,108 +1232,95 @@ Issue: Add client-side validation that a mapped buffer can only be unmapped and 
 
 ### {{GPUBuffer/mapReadAsync|GPUDevice.mapReadAsync}} ### {#GPUBuffer-mapReadAsync}
 
-<dl dfn-type="method" dfn-for="GPUBuffer">
-    : <dfn>mapReadAsync()</dfn>
-    ::
-        <div algorithm="GPUBuffer.mapReadAsync()">
+<div algorithm="GPUBuffer.mapReadAsync">
+    Issue: Handle error buffers once we have a description of the error monad.
 
-            Issue: Handle error buffers once we have a description of the error monad.
+    1. If the {{[[usage]]}} slot of |this| doesn't contain the {{GPUBufferUsage/MAP_READ}} bit or
+        if {{[[state]]}} isn't [=buffer state/unmapped=]:
 
-            1. If the {{[[usage]]}} slot of |this| doesn't contain the {{GPUBufferUsage/MAP_READ}} bit or
-                if {{[[state]]}} isn't [=buffer state/unmapped=]:
+        1. Record a validation error on the current scope.
+        1. Return [=a promise rejected with=] an {{AbortError}}.
 
-                1. Record a validation error on the current scope.
-                1. Return [=a promise rejected with=] an {{AbortError}}.
+        Issue: Specify that the rejection happens on the device timeline.
 
-                Issue: Specify that the rejection happens on the device timeline.
+    1. Let |p| be a new {{Promise}}.
+    1. Set the {{[[mapping]]}} slot of |this| to |p|.
+    1. Set the {{[[state]]}} slot of |this| to [=buffer state/mapping pending for reading=].
+    1. Enqueue an operation on the [=Queue timeline=] that will execute the following:
 
-            1. Let |p| be a new {{Promise}}.
-            1. Set the {{[[mapping]]}} slot of |this| to |p|.
-            1. Set the {{[[state]]}} slot of |this| to [=buffer state/mapping pending for reading=].
-            1. Enqueue an operation on the [=Queue timeline=] that will execute the following:
+        1. Let |m| be a new {{ArrayBuffer}} of size the {{[[size]]}} of |this|.
+        1. Set the content of |m| to the content of |this|'s allocation.
+        1. Set the {{[[state]]}} slot of |this| to [=buffer state/mapped for reading=].
+        1. If |p| is pending:
 
-                1. Let |m| be a new {{ArrayBuffer}} of size the {{[[size]]}} of |this|.
-                1. Set the content of |m| to the content of |this|'s allocation.
-                1. Set the {{[[state]]}} slot of |this| to [=buffer state/mapped for reading=].
-                1. If |p| is pending:
+            1. Resolve |p| with |m|.
 
-                    1. Resolve |p| with |m|.
-
-            1. Return |p|.
-        </div>
-</dl>
+    1. Return |p|.
+</div>
 
 ### {{GPUBuffer/mapWriteAsync|GPUDevice.mapWriteAsync}} ### {#GPUBuffer-mapWriteAsync}
 
-<dl dfn-type="method" dfn-for="GPUBuffer">
-    : <dfn>mapWriteAsync()</dfn>
-    ::
-        <div algorithm="GPUBuffer.mapWriteAsync()">
+<div algorithm="GPUBuffer.mapWriteAsync">
 
-            Issue: Handle error buffers once we have a description of the error monad.
+    Issue: Handle error buffers once we have a description of the error monad.
 
-            1. If the {{[[usage]]}} slot of |this| doesn't contain the {{GPUBufferUsage/MAP_WRITE}} bit or
-                if {{[[state]]}} isn't [=buffer state/unmapped=]:
+    1. If the {{[[usage]]}} slot of |this| doesn't contain the {{GPUBufferUsage/MAP_WRITE}} bit or
+        if {{[[state]]}} isn't [=buffer state/unmapped=]:
 
-                1. Record a validation error on the current scope.
-                1. Return [=a promise rejected with=] an {{AbortError}}.
+        1. Record a validation error on the current scope.
+        1. Return [=a promise rejected with=] an {{AbortError}}.
 
-                Issue: Specify that the rejection happens on the device timeline.
+        Issue: Specify that the rejection happens on the device timeline.
 
-            1. Let |p| be a new {{Promise}}.
-            1. Set the {{[[mapping]]}} slot of |this| to |p|.
-            1. Set the {{[[state]]}} slot of |this| to [=buffer state/mapping pending for writing=].
-            1. Enqueue an operation on the [=Queue timeline=] that will execute the following:
+    1. Let |p| be a new {{Promise}}.
+    1. Set the {{[[mapping]]}} slot of |this| to |p|.
+    1. Set the {{[[state]]}} slot of |this| to [=buffer state/mapping pending for writing=].
+    1. Enqueue an operation on the [=Queue timeline=] that will execute the following:
 
-                1. Let |m| be a new {{ArrayBuffer}} of size the {{[[size]]}} of |this| that is filled with zeroes.
-                1. Set the {{[[state]]}} slot of |this| to [=buffer state/mapped for writing=].
-                1. If |p| is pending:
+        1. Let |m| be a new {{ArrayBuffer}} of size the {{[[size]]}} of |this| that is filled with zeroes.
+        1. Set the {{[[state]]}} slot of |this| to [=buffer state/mapped for writing=].
+        1. If |p| is pending:
 
-                    1. Resolve |p| with |m|.
+            1. Resolve |p| with |m|.
 
-            1. Return |p|.
-        </div>
-</dl>
+    1. Return |p|.
+</div>
 
-### {{GPUBuffer/unmap|GPUBuffer.unmap()}} ### {#GPUBuffer-unmap}
+### <dfn method for=GPUBuffer>unmap()</dfn> ### {#buffer-unmap}
 
-<dl dfn-type="method" dfn-for="GPUBuffer">
-    : <dfn>unmap()</dfn>
-    ::
-        <div algorithm="GPUBuffer.unmap()">
+<div algorithm="GPUBuffer.unmap">
 
-            1. If the {{[[state]]}} slot of |this| is [=buffer state/unmapped=] or [=buffer state/destroyed=]:
+    1. If the {{[[state]]}} slot of |this| is [=buffer state/unmapped=] or [=buffer state/destroyed=]:
 
-                1. Record a validation error on the current scope.
-                1. Return.
+        1. Record a validation error on the current scope.
+        1. Return.
 
-            1. If the {{[[mapping]]}} slot of |this| is a {{Promise}}:
+    1. If the {{[[mapping]]}} slot of |this| is a {{Promise}}:
 
-                1. [=Reject=] {{[[mapping]]}} with an {{AbortError}}.
-                1. Set the {{[[mapping]]}} slot of |this| to null.
+        1. [=Reject=] {{[[mapping]]}} with an {{AbortError}}.
+        1. Set the {{[[mapping]]}} slot of |this| to null.
 
-            1. If the {{[[mapping]]}} slot of |this| is an {{ArrayBuffer}}:
+    1. If the {{[[mapping]]}} slot of |this| is an {{ArrayBuffer}}:
 
-                1. If the {{[[state]]}} slot of this is [=buffer state/mapped for writing=]:
+        1. If the {{[[state]]}} slot of this is [=buffer state/mapped for writing=]:
 
-                    1. Enqueue an operation on the [=Queue timeline=] that updates |this|'s allocation to the content of the {{ArrayBuffer}} in the {{[[mapping]]}} slot of |this|.
+            1. Enqueue an operation on the [=Queue timeline=] that updates |this|'s allocation to the content of the {{ArrayBuffer}} in the {{[[mapping]]}} slot of |this|.
 
-                1. Detach |this|.{{[[mapping]]}} from its content.
-                1. Set the {{[[mapping]]}} slot of |this| to null.
+        1. Detach |this|.{{[[mapping]]}} from its content.
+        1. Set the {{[[mapping]]}} slot of |this| to null.
 
-            1. Set the {{[[state]]}} slot of |this| to [=buffer state/unmapped=].
+    1. Set the {{[[state]]}} slot of |this| to [=buffer state/unmapped=].
 
-        </div>
-</dl>
+</div>
 
-Textures {#textures}
-====================
+
+# Textures and Texture Views # {#textures}
 
 Issue: define <dfn dfn>texture</dfn> (internal object)
 
 Issue: define <dfn dfn>mipmap level</dfn>, <dfn dfn>array layer</dfn>, <dfn dfn>slice</dfn> (concepts)
 
-## GPUTexture ## {#gpu-texture}
+## <dfn interface>GPUTexture</dfn> ## {#texture-interface}
 
 <script type=idl>
 [Serializable]
@@ -1398,7 +1392,7 @@ interface GPUTextureUsage {
 };
 </script>
 
-## GPUTextureView ## {#texture-view}
+## GPUTextureView ## {#gpu-textureview}
 
 <script type=idl>
 interface GPUTextureView {
@@ -1420,9 +1414,10 @@ dictionary GPUTextureViewDescriptor : GPUObjectDescriptorBase {
 };
 </script>
 
-<!-- TODO(kainino0x): Make this a standalone algorithm used in the createView algorithm. -->
-<!-- TODO(kainino0x): The references to GPUTextureDescriptor here should actually refer to
-internal slots of a texture internal object once we have one. -->
+Issue: Make this a standalone algorithm used in the createView algorithm.
+
+Issue: The references to GPUTextureDescriptor here should actually refer to
+internal slots of a [=texture=] internal object once we have one.
 
 <div algorithm="resolving GPUTextureViewDescriptor defaults">
 
@@ -1467,6 +1462,19 @@ enum GPUTextureAspect {
     "depth-only"
 };
 </script>
+
+### {{GPUTexture}}.<dfn method for=GPUTexture>createView(descriptor)</dfn> ### {#textureview-createview}
+
+<div algorithm=GPUTexture.createView>
+    <strong>|this|:</strong> of type {{GPUTexture}}.
+
+    **Arguments:**
+        - optional {{GPUTextureViewDescriptor}} |descriptor|
+
+    **Returns:** |view|, of type {{GPUTextureView}}.
+
+    Issue: write definition. |this| |descriptor| |view|
+</div>
 
 ## Texture Formats ## {#texture-formats}
 
@@ -1570,8 +1578,8 @@ enum GPUTextureComponentType {
 };
 </script>
 
-Samplers {#samplers}
-====================
+
+# Samplers # {#samplers}
 
 ## GPUSampler ## {#sampler}
 
@@ -1606,20 +1614,23 @@ dictionary GPUSamplerDescriptor : GPUObjectDescriptorBase {
 };
 </script>
 
-### {{GPUDevice/createSampler(descriptor)|GPUDevice.createSampler(descriptor)}} ### {#GPUDevice-createSampler}
+### {{GPUDevice}}.<dfn method for=GPUDevice>createSampler(descriptor)</dfn> ### {#sampler-createsampler}
 
-<dl dfn-type="method" dfn-for="GPUDevice">
-    : <dfn>createSampler(descriptor)</dfn>
-    ::
-        <div algorithm="GPUDevice.createSampler(descriptor)">
-            **Arguments:**
-                - optional {{GPUSamplerDescriptor}} |descriptor| = {}
-            1. Let |s| be a new {{GPUSampler}} object.
-            1. Set the {{GPUSampler/[[compareEnable]]}} slot of |s| to false if the {{GPUSamplerDescriptor/compare}} attribute
-                  of |descriptor| is null or undefined. Otherwise, set it to true.
-            1. Return |s|.
-        </div>
-</dl>
+<div algorithm=GPUDevice.createSampler>
+    **Arguments:**
+        - optional {{GPUSamplerDescriptor}} |descriptor| = {}
+
+    **Returns:** {{GPUSampler}}
+
+    1. Let |s| be a new {{GPUSampler}} object.
+    1. Set the {{GPUSampler/[[compareEnable]]}} slot of |s| to false if the {{GPUSamplerDescriptor/compare}} attribute
+            of |descriptor| is null or undefined. Otherwise, set it to true.
+    1. Return |s|.
+
+    <div class=validusage dfn-for=GPUDevice.createSampler>
+        <dfn abstract-op>Valid Usage</dfn>
+    </div>
+</div>
 
 <script type=idl>
 enum GPUAddressMode {
@@ -1650,8 +1661,7 @@ enum GPUCompareFunction {
 </script>
 
 
-Resource Binding {#binding}
-===========================
+# Resource Binding # {#bindings}
 
 ## GPUBindGroupLayout ## {#bind-group-layout}
 
@@ -1745,74 +1755,79 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
 
 ### {{GPUDevice/createBindGroupLayout()|GPUDevice.createBindGroupLayout(GPUBindGroupLayoutDescriptor)}} ### {#GPUDevice-createBindGroupLayout}
 
-<div algorithm="GPUDevice.createBindGroupLayout(descriptor)">
+<div algorithm="GPUDevice.createBindGroupLayout">
+    <strong>this:</strong> of type {{GPUDevice}}.
 
-The <dfn method for="GPUDevice">createBindGroupLayout(|descriptor|)</dfn> method is used to create {{GPUBindGroupLayout}}s.
+    **Arguments:**
+        - {{GPUBindGroupLayoutDescriptor}} |descriptor|
 
-1. Ensure [=device validation=] is not violated.
-1. Let |layout| be a new valid {{GPUBindGroupLayout}} object.
-1. For each {{GPUBindGroupLayoutEntry}} |bindingDescriptor| in |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
-    1. Ensure |bindingDescriptor|.{{GPUBindGroupLayoutEntry/binding}} does not violate [=binding validation=].
-    1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/visibility}} includes {{GPUShaderStage/VERTEX}}
-        , ensure [=vertex shader binding validation=] is not violated.
-    1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/uniform-buffer}}:
-        1. Ensure [=uniform buffer validation=] is not violated.
-        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `true`, ensure [=dynamic uniform buffer validation=] is not violated.
-    1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/storage-buffer}} or {{GPUBindingType/readonly-storage-buffer}}:
-        1. Ensure [=storage buffer validation=] is not violated.
-        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `true`, ensure [=dynamic storage buffer validation=] is not violated.
-    1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/sampled-texture}}
-        , ensure [=sampled texture validation=] is not violated.
-    1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/readonly-storage-texture}} or {{GPUBindingType/writeonly-storage-texture}}
-        , ensure [=storage texture validation=] is not violated.
-    1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/sampler}}
-        , ensure [=sampler validation=] is not violated.
-    1. Insert |bindingDescriptor| into |layout|.{{GPUBindGroupLayout/[[entries]]}}.
-1. Return |layout|.
+    **Returns:** {{GPUBindGroupLayout}}.
 
-<b>Validation Conditions</b>
+    The <dfn method for="GPUDevice">createBindGroupLayout(|descriptor|)</dfn> method is used to create {{GPUBindGroupLayout}}s.
 
-<dl dfn-for="createBindGroupLayout(descriptor)">
-If any of the following conditions are violated:
-    1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
-    1. Create a new [=invalid=] {{GPUBindGroupLayout}} and return the result.
+    1. Ensure [=device validation=] is not violated.
+    1. Let |layout| be a new valid {{GPUBindGroupLayout}} object.
+    1. For each {{GPUBindGroupLayoutEntry}} |bindingDescriptor| in |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
+        1. Ensure |bindingDescriptor|.{{GPUBindGroupLayoutEntry/binding}} does not violate [=binding validation=].
+        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/visibility}} includes {{GPUShaderStage/VERTEX}}
+            , ensure [=vertex shader binding validation=] is not violated.
+        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/uniform-buffer}}:
+            1. Ensure [=uniform buffer validation=] is not violated.
+            1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `true`, ensure [=dynamic uniform buffer validation=] is not violated.
+        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/storage-buffer}} or {{GPUBindingType/readonly-storage-buffer}}:
+            1. Ensure [=storage buffer validation=] is not violated.
+            1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `true`, ensure [=dynamic storage buffer validation=] is not violated.
+        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/sampled-texture}}
+            , ensure [=sampled texture validation=] is not violated.
+        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/readonly-storage-texture}} or {{GPUBindingType/writeonly-storage-texture}}
+            , ensure [=storage texture validation=] is not violated.
+        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/sampler}}
+            , ensure [=sampler validation=] is not violated.
+        1. Insert |bindingDescriptor| into |layout|.{{GPUBindGroupLayout/[[entries]]}}.
+    1. Return |layout|.
 
-<dfn>device validation</dfn>: The {{GPUDevice}} must not be lost.
+    <div class=validusage dfn-for=GPUDevice.createBindGroupLayout>
+        <dfn abstract-op>Valid Usage</dfn>
 
-<dfn>binding validation</dfn>: Each |bindingDescriptor|.{{GPUBindGroupLayoutEntry/binding}} in |descriptor| must be unique.
+        If any of the following conditions are violated:
+            1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
+            1. Create a new [=invalid=] {{GPUBindGroupLayout}} and return the result.
 
-<dfn>vertex shader binding validation</dfn>: {{GPUBindingType/storage-buffer}} is not allowed.
+        <dfn>device validation</dfn>: The {{GPUDevice}} must not be lost.
 
-<dfn>uniform buffer validation</dfn>: There must be {{GPULimits/maxUniformBuffersPerShaderStage|GPULimits.maxUniformBuffersPerShaderStage}} or
-    fewer |bindingDescriptor|s of type {{GPUBindingType/uniform-buffer}} visible on each shader stage in |descriptor|.
+        <dfn>binding validation</dfn>: Each |bindingDescriptor|.{{GPUBindGroupLayoutEntry/binding}} in |descriptor| must be unique.
 
-<dfn>dynamic uniform buffer validation</dfn>: There must be {{GPULimits/maxDynamicUniformBuffersPerPipelineLayout|GPULimits.maxDynamicUniformBuffersPerPipelineLayout}} or
-        fewer |bindingDescriptor|s of type {{GPUBindingType/uniform-buffer}} with {{GPUBindGroupLayoutEntry/hasDynamicOffset}} set to `true` in
-        |descriptor| that are visible to any shader stage.
+        <dfn>vertex shader binding validation</dfn>: {{GPUBindingType/storage-buffer}} is not allowed.
 
-<dfn>storage buffer validation</dfn>: There must be {{GPULimits/maxStorageBuffersPerShaderStage|GPULimits.maxStorageBuffersPerShaderStage}} or
-    fewer |bindingDescriptor|s of type {{GPUBindingType/storage-buffer}} visible on each shader stage in |descriptor|.
+        <dfn>uniform buffer validation</dfn>: There must be {{GPULimits/maxUniformBuffersPerShaderStage|GPULimits.maxUniformBuffersPerShaderStage}} or
+            fewer |bindingDescriptor|s of type {{GPUBindingType/uniform-buffer}} visible on each shader stage in |descriptor|.
 
-<dfn>dynamic storage buffer validation</dfn>: There must be {{GPULimits/maxDynamicStorageBuffersPerPipelineLayout|GPULimits.maxDynamicStorageBuffersPerPipelineLayout}} or
-        fewer |bindingDescriptor|s of type {{GPUBindingType/storage-buffer}} with {{GPUBindGroupLayoutEntry/hasDynamicOffset}} set to `true`
-        in |descriptor| that are visible to any shader stage.
+        <dfn>dynamic uniform buffer validation</dfn>: There must be {{GPULimits/maxDynamicUniformBuffersPerPipelineLayout|GPULimits.maxDynamicUniformBuffersPerPipelineLayout}} or
+                fewer |bindingDescriptor|s of type {{GPUBindingType/uniform-buffer}} with {{GPUBindGroupLayoutEntry/hasDynamicOffset}} set to `true` in
+                |descriptor| that are visible to any shader stage.
 
-<dfn>sampled texture validation</dfn>: There must be {{GPULimits/maxSampledTexturesPerShaderStage|GPULimits.maxSampledTexturesPerShaderStage}} or
-    fewer |bindingDescriptor|s of type {{GPUBindingType/sampled-texture}} visible on each shader stage in |descriptor|.
-    |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} must be `false`.
+        <dfn>storage buffer validation</dfn>: There must be {{GPULimits/maxStorageBuffersPerShaderStage|GPULimits.maxStorageBuffersPerShaderStage}} or
+            fewer |bindingDescriptor|s of type {{GPUBindingType/storage-buffer}} visible on each shader stage in |descriptor|.
 
-<dfn>storage texture validation</dfn>: There must be {{GPULimits/maxStorageTexturesPerShaderStage|GPULimits.maxStorageTexturesPerShaderStage}} or
-    fewer |bindingDescriptor|s of type {{GPUBindingType/readonly-storage-texture}} and {{GPUBindingType/writeonly-storage-texture}} visible on each shader stage in |descriptor|.
-    |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} must be `false`.
+        <dfn>dynamic storage buffer validation</dfn>: There must be {{GPULimits/maxDynamicStorageBuffersPerPipelineLayout|GPULimits.maxDynamicStorageBuffersPerPipelineLayout}} or
+                fewer |bindingDescriptor|s of type {{GPUBindingType/storage-buffer}} with {{GPUBindGroupLayoutEntry/hasDynamicOffset}} set to `true`
+                in |descriptor| that are visible to any shader stage.
 
-<dfn>sampler validation</dfn>: There must be {{GPULimits/maxSamplersPerShaderStage|GPULimits.maxSamplersPerShaderStage}} or
-    fewer |bindingDescriptor|s of type {{GPUBindingType/sampler}} visible on each shader stage in |descriptor|.
-    |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} must be `false`.
+        <dfn>sampled texture validation</dfn>: There must be {{GPULimits/maxSampledTexturesPerShaderStage|GPULimits.maxSampledTexturesPerShaderStage}} or
+            fewer |bindingDescriptor|s of type {{GPUBindingType/sampled-texture}} visible on each shader stage in |descriptor|.
+            |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} must be `false`.
 
-</dl>
+        <dfn>storage texture validation</dfn>: There must be {{GPULimits/maxStorageTexturesPerShaderStage|GPULimits.maxStorageTexturesPerShaderStage}} or
+            fewer |bindingDescriptor|s of type {{GPUBindingType/readonly-storage-texture}} and {{GPUBindingType/writeonly-storage-texture}} visible on each shader stage in |descriptor|.
+            |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} must be `false`.
+
+        <dfn>sampler validation</dfn>: There must be {{GPULimits/maxSamplersPerShaderStage|GPULimits.maxSamplersPerShaderStage}} or
+            fewer |bindingDescriptor|s of type {{GPUBindingType/sampler}} visible on each shader stage in |descriptor|.
+            |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} must be `false`.
+    </div>
 </div>
 
-## GPUBindGroup ## {#bind-groups}
+## GPUBindGroup ## {#gpu-bindgroup}
 
 A {{GPUBindGroup}} defines a set of resources to be bound together in a group
     and how the resources are used in shader stages.
@@ -1879,94 +1894,98 @@ A {{GPUBindGroup}} object has the following internal slots:
 
 ### {{GPUDevice/createBindGroup()|GPUDevice.createBindGroup(GPUBindGroupDescriptor)}} ### {#GPUDevice-createBindGroup}
 
-<div algorithm="GPUDevice.createBindGroup(descriptor)">
+<div algorithm="GPUDevice.createBindGroup">
+    **Arguments:**
+        - {{GPUBindGroupDescriptor}} |descriptor|
 
-The <dfn method for="GPUDevice">createBindGroup(|descriptor|)</dfn> method is used to create
-    {{GPUBindGroup}}s.
+    **Returns:** {{GPUBindGroup}}.
 
-1. Ensure [=bind group device validation=] is not violated.
-1. Ensure |descriptor|.{{GPUBindGroupDescriptor/layout}} is a [=valid=] {{GPUBindGroupLayout}}.
-1. Ensure the number of {{GPUBindGroupLayoutDescriptor/entries}} of
-    |descriptor|.{{GPUBindGroupDescriptor/layout}} exactly equals to the number of
-    |descriptor|.{{GPUBindGroupDescriptor/entries}}.
-1. For each {{GPUBindGroupEntry}} |bindingDescriptor| in
-    |descriptor|.{{GPUBindGroupDescriptor/entries}}:
-    1. Ensure there is exactly one {{GPUBindGroupLayoutEntry}} |layoutBinding| in
-        {{GPUBindGroupLayoutDescriptor/entries}} of |descriptor|.{{GPUBindGroupDescriptor/layout}}
-        such that |layoutBinding|.{{GPUBindGroupLayoutEntry/binding}} equals to
-        |bindingDescriptor|.{{GPUBindGroupEntry/binding}}.
-    1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
-        {{GPUBindingType/"sampler"}}:
-        1. Ensure |bindingDescriptor|.{{GPUBindGroupEntry/resource}} is a
-            valid {{GPUSampler}} object and {{GPUSampler/[[compareEnable]]}} is false.
-    1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
-        {{GPUBindingType/"comparison-sampler"}}:
-        1. Ensure |bindingDescriptor|.{{GPUBindGroupEntry/resource}} is a
-            valid {{GPUSampler}} object and {{GPUSampler/[[compareEnable]]}} is true.
-    1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
-        {{GPUBindingType/"sampled-texture"}} or {{GPUBindingType/"readonly-storage-texture"}} or
-        {{GPUBindingType/"writeonly-storage-texture"}}.
-        1. Ensure |bindingDescriptor|.{{GPUBindGroupEntry/resource}} is a
-            valid {{GPUTextureView}} object.
-        1. Ensure [=texture view binding validation=] is not violated.
-        1. Ensure |bindingDescriptor|.{{GPUBindGroupLayoutEntry/storageTextureFormat}} is a valid {{GPUTextureFormat}}.
-    1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
-        {{GPUBindingType/"uniform-buffer"}} or {{GPUBindingType/"storage-buffer"}}
-        or {{GPUBindingType/"readonly-storage-buffer"}}.
-        1. Ensure |bindingDescriptor|.{{GPUBindGroupEntry/resource}} is a
-            valid {{GPUBufferBinding}} object.
-        1. Ensure [=buffer binding validation=] is not violated.
-1. Return a new {{GPUBindGroup}} object with:
-    - {{GPUBindGroup/[[layout]]}} = |descriptor|.{{GPUBindGroupDescriptor/layout}}
-    - {{GPUBindGroup/[[entries]]}} = |descriptor|.{{GPUBindGroupDescriptor/entries}}
-    - {{GPUBindGroup/[[usedBuffers]]}} = union of the buffer usages across all entries
-    - {{GPUBindGroup/[[usedTextures]]}} = union of the texture [=subresource=] usages across all entries
+    The <dfn method for="GPUDevice">createBindGroup(|descriptor|)</dfn> method is used to create
+        {{GPUBindGroup}}s.
 
-<b>Validation Conditions</b>
+    If any of the conditions below are violated:
+        1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
+        1. Create a new [=invalid=] {{GPUBindGroup}} and return the result.
 
-<dl dfn-for="createBindGroup(descriptor)">
-If any of the following conditions are violated:
-    1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
-    1. Create a new [=invalid=] {{GPUBindGroup}} and return the result.
+    1. Ensure [=bind group device validation=] is not violated.
+    1. Ensure |descriptor|.{{GPUBindGroupDescriptor/layout}} is a [=valid=] {{GPUBindGroupLayout}}.
+    1. Ensure the number of {{GPUBindGroupLayoutDescriptor/entries}} of
+        |descriptor|.{{GPUBindGroupDescriptor/layout}} exactly equals to the number of
+        |descriptor|.{{GPUBindGroupDescriptor/entries}}.
+    1. For each {{GPUBindGroupEntry}} |bindingDescriptor| in
+        |descriptor|.{{GPUBindGroupDescriptor/entries}}:
+        1. Ensure there is exactly one {{GPUBindGroupLayoutEntry}} |layoutBinding| in
+            {{GPUBindGroupLayoutDescriptor/entries}} of |descriptor|.{{GPUBindGroupDescriptor/layout}}
+            such that |layoutBinding|.{{GPUBindGroupLayoutEntry/binding}} equals to
+            |bindingDescriptor|.{{GPUBindGroupEntry/binding}}.
+        1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
+            {{GPUBindingType/"sampler"}}:
+            1. Ensure |bindingDescriptor|.{{GPUBindGroupEntry/resource}} is a
+                valid {{GPUSampler}} object and {{GPUSampler/[[compareEnable]]}} is false.
+        1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
+            {{GPUBindingType/"comparison-sampler"}}:
+            1. Ensure |bindingDescriptor|.{{GPUBindGroupEntry/resource}} is a
+                valid {{GPUSampler}} object and {{GPUSampler/[[compareEnable]]}} is true.
+        1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
+            {{GPUBindingType/"sampled-texture"}} or {{GPUBindingType/"readonly-storage-texture"}} or
+            {{GPUBindingType/"writeonly-storage-texture"}}.
+            1. Ensure |bindingDescriptor|.{{GPUBindGroupEntry/resource}} is a
+                valid {{GPUTextureView}} object.
+            1. Ensure [=texture view binding validation=] is not violated.
+            1. Ensure |bindingDescriptor|.{{GPUBindGroupLayoutEntry/storageTextureFormat}} is a valid {{GPUTextureFormat}}.
+        1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
+            {{GPUBindingType/"uniform-buffer"}} or {{GPUBindingType/"storage-buffer"}}
+            or {{GPUBindingType/"readonly-storage-buffer"}}.
+            1. Ensure |bindingDescriptor|.{{GPUBindGroupEntry/resource}} is a
+                valid {{GPUBufferBinding}} object.
+            1. Ensure [=buffer binding validation=] is not violated.
+    1. Return a new {{GPUBindGroup}} object with:
+        - {{GPUBindGroup/[[layout]]}} = |descriptor|.{{GPUBindGroupDescriptor/layout}}
+        - {{GPUBindGroup/[[entries]]}} = |descriptor|.{{GPUBindGroupDescriptor/entries}}
+        - {{GPUBindGroup/[[usedBuffers]]}} = union of the buffer usages across all entries
+        - {{GPUBindGroup/[[usedTextures]]}} = union of the texture [=subresource=] usages across all entries
 
-<dfn>bind group device validation</dfn>: The {{GPUDevice}} must not be lost.
+    <div class=validusage dfn-for=GPUDevice.createBindGroup>
+        <dfn abstract-op>Valid Usage</dfn>
 
-<dfn>texture view binding validation</dfn>: Let |view| be
-    |bindingDescriptor|.{{GPUBindGroupEntry/resource}}, a {{GPUTextureView}}.
-    This |layoutBinding| must be compatible with this |view|. This requires:
-    1. Its |layoutBinding|.{{GPUBindGroupLayoutEntry/viewDimension}} must equal |view|'s
-        {{GPUTextureViewDescriptor/dimension}}.
-    1. Its |layoutBinding|.{{GPUBindGroupLayoutEntry/textureComponentType}} must be compatible
-        with |view|'s {{GPUTextureViewDescriptor/format}}.
-    1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/multisampled}} is `true`, |view|'s texture's
-        {{GPUTextureDescriptor/sampleCount}} must be greater than 1.
-        Otherwise, if |bindingDescriptor|.{{GPUBindGroupLayoutEntry/multisampled}} is `false`,
-        |view|'s texture's {{GPUTextureDescriptor/sampleCount}} must be 1.
-    1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
-        {{GPUBindingType/"sampled-texture"}}, |view|'s texture's {{GPUTextureDescriptor/usage}}
-        must include {{GPUTextureUsage/SAMPLED}}. Each texture [=subresource=] seen by |view|
-        is added to {{GPUBindGroup/[[usedTextures]]}} with {{GPUTextureUsage/SAMPLED}} flag.
-    1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
-        {{GPUBindingType/"readonly-storage-texture"}} or {{GPUBindingType/"writeonly-storage-texture"}},
-        |view|'s texture's {{GPUTextureDescriptor/usage}} must include {{GPUTextureUsage/STORAGE}}.
-        Each texture [=subresource=] seen by |view|
-        is added to {{GPUBindGroup/[[usedTextures]]}} with {{GPUTextureUsage/STORAGE}} flag.
+        <dfn>bind group device validation</dfn>: The {{GPUDevice}} must not be lost.
 
-<dfn>buffer binding validation</dfn>: Let |bufferBinding| be
-    |bindingDescriptor|.{{GPUBindGroupEntry/resource}}, a {{GPUBufferBinding}}.
-    This |layoutBinding| must be compatible with this |bufferBinding|. This requires:
-    1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"uniform-buffer"}},
-        the |bufferBinding|.{{GPUBufferBinding/buffer}}'s {{GPUBufferDescriptor/usage}} must include
-        {{GPUBufferUsage/UNIFORM}}. The buffer is added to the {{GPUBindGroup/[[usedBuffers]]}} map
-        with {{GPUBufferUsage/UNIFORM}} flag.
-    1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"storage-buffer"}}
-        or {{GPUBindingType/"readonly-storage-buffer"}}, the
-        |bufferBinding|.{{GPUBufferBinding/buffer}}'s {{GPUBufferDescriptor/usage}} must include
-        {{GPUBufferUsage/STORAGE}}. The buffer is added to the {{GPUBindGroup/[[usedBuffers]]}} map
-        with {{GPUBufferUsage/STORAGE}} flag.
-    1. The bound part designated by |bufferBinding|.{{GPUBufferBinding/offset}} and
-        |bufferBinding|.{{GPUBufferBinding/size}} must reside inside the buffer.
-</dl>
+        <dfn>texture view binding validation</dfn>: Let |view| be
+            |bindingDescriptor|.{{GPUBindGroupEntry/resource}}, a {{GPUTextureView}}.
+            This |layoutBinding| must be compatible with this |view|. This requires:
+            1. Its |layoutBinding|.{{GPUBindGroupLayoutEntry/viewDimension}} must equal |view|'s
+                {{GPUTextureViewDescriptor/dimension}}.
+            1. Its |layoutBinding|.{{GPUBindGroupLayoutEntry/textureComponentType}} must be compatible
+                with |view|'s {{GPUTextureViewDescriptor/format}}.
+            1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/multisampled}} is `true`, |view|'s texture's
+                {{GPUTextureDescriptor/sampleCount}} must be greater than 1.
+                Otherwise, if |bindingDescriptor|.{{GPUBindGroupLayoutEntry/multisampled}} is `false`,
+                |view|'s texture's {{GPUTextureDescriptor/sampleCount}} must be 1.
+            1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
+                {{GPUBindingType/"sampled-texture"}}, |view|'s texture's {{GPUTextureDescriptor/usage}}
+                must include {{GPUTextureUsage/SAMPLED}}. Each texture [=subresource=] seen by |view|
+                is added to {{GPUBindGroup/[[usedTextures]]}} with {{GPUTextureUsage/SAMPLED}} flag.
+            1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
+                {{GPUBindingType/"readonly-storage-texture"}} or {{GPUBindingType/"writeonly-storage-texture"}},
+                |view|'s texture's {{GPUTextureDescriptor/usage}} must include {{GPUTextureUsage/STORAGE}}.
+                Each texture [=subresource=] seen by |view|
+                is added to {{GPUBindGroup/[[usedTextures]]}} with {{GPUTextureUsage/STORAGE}} flag.
+
+        <dfn>buffer binding validation</dfn>: Let |bufferBinding| be
+            |bindingDescriptor|.{{GPUBindGroupEntry/resource}}, a {{GPUBufferBinding}}.
+            This |layoutBinding| must be compatible with this |bufferBinding|. This requires:
+            1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"uniform-buffer"}},
+                the |bufferBinding|.{{GPUBufferBinding/buffer}}'s {{GPUBufferDescriptor/usage}} must include
+                {{GPUBufferUsage/UNIFORM}}. The buffer is added to the {{GPUBindGroup/[[usedBuffers]]}} map
+                with {{GPUBufferUsage/UNIFORM}} flag.
+            1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"storage-buffer"}}
+                or {{GPUBindingType/"readonly-storage-buffer"}}, the
+                |bufferBinding|.{{GPUBufferBinding/buffer}}'s {{GPUBufferDescriptor/usage}} must include
+                {{GPUBufferUsage/STORAGE}}. The buffer is added to the {{GPUBindGroup/[[usedBuffers]]}} map
+                with {{GPUBufferUsage/STORAGE}} flag.
+            1. The bound part designated by |bufferBinding|.{{GPUBufferBinding/offset}} and
+                |bufferBinding|.{{GPUBufferBinding/size}} must reside inside the buffer.
+    </div>
 </div>
 
 ## GPUPipelineLayout ## {#pipeline-layout}
@@ -1985,8 +2004,8 @@ dictionary GPUPipelineLayoutDescriptor : GPUObjectDescriptorBase {
 };
 </script>
 
-Shader Modules {#shader-modules}
-================================
+
+# Shader Modules # {#shader-modules}
 
 ## GPUShaderModule ## {#shader-module}
 
@@ -2011,8 +2030,8 @@ dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
 };
 </script>
 
-Pipelines {#pipelines}
-======================
+
+# Pipelines # {#pipelines}
 
 <script type=idl>
 dictionary GPUPipelineDescriptorBase : GPUObjectDescriptorBase {
@@ -2225,7 +2244,7 @@ enum GPUIndexFormat {
 };
 </script>
 
-#### Vertex formats #### {#vertex-formats}
+#### Vertex Formats #### {#vertex-formats}
 
 The name of the format specifies the data type of the component, the number of
 values, and whether the data is normalized.
@@ -2322,8 +2341,8 @@ dictionary GPUVertexAttributeDescriptor {
 };
 </script>
 
-Command Buffers {#command-buffers}
-==================================
+
+# Command Buffers # {#command-buffers}
 
 ## GPUCommandBuffer ## {#command-buffer}
 
@@ -2341,8 +2360,7 @@ dictionary GPUCommandBufferDescriptor : GPUObjectDescriptorBase {
 </script>
 
 
-Command Encoding {#command-encoding}
-====================================
+# Command Encoding # {#command-encoding}
 
 ## GPUCommandEncoder ## {#command-encoder}
 
@@ -2472,34 +2490,31 @@ dictionary GPUImageBitmapCopyView {
 
   Encode a command into the {{GPUCommandEncoder}} that copies |size| bytes of data from the |sourceOffset| of a {{GPUBuffer}} |source| to the |destinationOffset| of another {{GPUBuffer}} |destination|.
 
-</div>
+  <div class=validusage dfn-for=GPUCommandEncoder.copyBufferToBuffer>
+        <dfn abstract-op>Valid Usage</dfn>
 
-<div algorithm class=validusage>
+        Given a {{GPUCommandEncoder}} |encoder| and the arguments {{GPUBuffer}} |source|, {{GPUSize64}} |sourceOffset|, {{GPUBuffer}} |destination|, {{GPUSize64}} |destinationOffset|, {{GPUSize64}} |size|, the following validation rules apply:
 
-  <dfn abstract-op>copyBufferToBuffer Valid Usage</dfn>
+          * |encoder| must be a [=valid=] {{GPUCommandEncoder}}.
+          * |encoder|.{{GPUCommandEncoder/copyBufferToBuffer()}} must not be called when a {{GPURenderPassEncoder}} is active on |encoder|.
+          * |encoder|.{{GPUCommandEncoder/copyBufferToBuffer()}} must not be called when a {{GPUComputePassEncoder}} is active on |encoder|.
+          * |source| must be a [=valid=] {{GPUBuffer}}.
+          * |destination| must be a [=valid=] {{GPUBuffer}}.
+          * The {{GPUBuffer/[[usage]]}} of |source| must contain {{GPUBufferUsage/COPY_SRC}}.
+          * The {{GPUBuffer/[[usage]]}} of |destination| must contain {{GPUBufferUsage/COPY_DST}}.
+          * |size| must be a multiple of 4.
+          * |sourceOffset| must be a multiple of 4.
+          * |destinationOffset| must be a multiple of 4.
+          * (|sourceOffset| + |size|) must not overflow a {{GPUSize64}}.
+          * (|destinationOffset| + |size|) must not overflow a {{GPUSize64}}.
+          * The {{GPUBuffer/[[size]]}} of |source| must be greater than or equal to (|sourceOffset| + |size|).
+          * The {{GPUBuffer/[[size]]}} of |destination| must be greater than or equal to (|destinationOffset| + |size|).
+          * If |source| and |destination| are the same buffer, the copy range from |sourceOffset| to (|sourceOffset| + |size|) must not overlap with the copy range from |destinationOffset| to (|destinationOffset| + |size|).
 
-  Given a {{GPUCommandEncoder}} |encoder| and the arguments {{GPUBuffer}} |source|, {{GPUSize64}} |sourceOffset|, {{GPUBuffer}} |destination|, {{GPUSize64}} |destinationOffset|, {{GPUSize64}} |size|, the following validation rules apply:
+        Issue(gpuweb/gpuweb#21): Define the state machine for GPUCommandEncoder.
 
-  - |encoder| must be a [=valid=] {{GPUCommandEncoder}}.
-  - |encoder|.{{GPUCommandEncoder/copyBufferToBuffer()}} must not be called when a {{GPURenderPassEncoder}} is active on |encoder|.
-  - |encoder|.{{GPUCommandEncoder/copyBufferToBuffer()}} must not be called when a {{GPUComputePassEncoder}} is active on |encoder|.
-  - |source| must be a [=valid=] {{GPUBuffer}}.
-  - |destination| must be a [=valid=] {{GPUBuffer}}.
-  - The {{GPUBuffer/[[usage]]}} of |source| must contain {{GPUBufferUsage/COPY_SRC}}.
-  - The {{GPUBuffer/[[usage]]}} of |destination| must contain {{GPUBufferUsage/COPY_DST}}.
-  - |size| must be a multiple of 4.
-  - |sourceOffset| must be a multiple of 4.
-  - |destinationOffset| must be a multiple of 4.
-  - (|sourceOffset| + |size|) must not overflow a {{GPUSize64}}.
-  - (|destinationOffset| + |size|) must not overflow a {{GPUSize64}}.
-  - The {{GPUBuffer/[[size]]}} of |source| must be greater than or equal to (|sourceOffset| + |size|).
-  - The {{GPUBuffer/[[size]]}} of |destination| must be greater than or equal to (|destinationOffset| + |size|).
-  - If |source| and |destination| are the same buffer, the copy range from |sourceOffset| to (|sourceOffset| + |size|) must not overlap with the copy range from |destinationOffset| to (|destinationOffset| + |size|).
-
-Issue(gpuweb/gpuweb#21): Define the state machine for GPUCommandEncoder.
-
-Issue(gpuweb/gpuweb#69): figure out how to handle overflows in the spec.
-
+        Issue(gpuweb/gpuweb#69): figure out how to handle overflows in the spec.
+    </div>
 </div>
 
 ## Programmable Passes ## {#programmable-passes}
@@ -2524,8 +2539,8 @@ interface mixin GPUProgrammablePassEncoder {
 Debug groups in a {{GPUCommandEncoder}} or {{GPUProgrammablePassEncoder}}
 must be well nested.
 
-Compute Passes {#compute-passes}
-================================
+
+# Compute Passes # {#compute-passes}
 
 ## GPUComputePassEncoder ## {#compute-pass-encoder}
 
@@ -2548,8 +2563,8 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
 };
 </script>
 
-Render Passes {#render-passes}
-==============================
+
+# Render Passes # {#render-passes}
 
 ## GPURenderPassEncoder ## {#render-pass-encoder}
 
@@ -2662,8 +2677,7 @@ enum GPUStoreOp {
 </script>
 
 
-Bundles {#bundles}
-==================
+# Bundles # {#bundles}
 
 ## GPURenderBundle ## {#render-bundle}
 
@@ -2700,8 +2714,7 @@ dictionary GPURenderBundleEncoderDescriptor : GPUObjectDescriptorBase {
 </script>
 
 
-Queues {#queues}
-================
+# Queues # {#queues}
 
 <script type=idl>
 interface GPUQueue {
@@ -2746,8 +2759,7 @@ dictionary GPUFenceDescriptor : GPUObjectDescriptorBase {
 </script>
 
 
-Canvas Rendering and Swap Chain {#swapchain}
-============================================
+# Canvas Rendering &amp; Swap Chains # {#canvas-rendering}
 
 <script type=idl>
 interface GPUCanvasContext {
@@ -2786,8 +2798,8 @@ if {{GPUTexture/destroy()}} were called on it (making it unusable elsewhere in W
 Before this drawing buffer is presented for compositing, the implementation shall ensure that all
 rendering operations have been flushed to the drawing buffer.
 
-Errors &amp; Debugging {#errors-and-debugging}
-==============================================
+
+# Errors &amp; Debugging # {#errors-and-debugging}
 
 ## Fatal Errors ## {#fatal-errors}
 
@@ -2861,8 +2873,8 @@ partial interface GPUDevice {
 };
 </script>
 
-Type Definitions {#type-definitions}
-====================================
+
+# Type Definitions # {#type-definitions}
 
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUBufferDynamicOffset;
@@ -2878,7 +2890,7 @@ typedef [EnforceRange] unsigned long GPUSize32;
 typedef [EnforceRange] long GPUSignedOffset32;
 </script>
 
-## Colors and Vectors ## {#colors-and-vectors}
+## Colors &amp; Vectors ## {#colors-and-vectors}
 
 <script type=idl>
 dictionary GPUColorDict {
@@ -2943,6 +2955,7 @@ typedef sequence<(GPUBuffer or ArrayBuffer)> GPUMappedBuffer;
 
 {{GPUMappedBuffer}} is always a sequence of 2 elements, of types {{GPUBuffer}}
 and {{ArrayBuffer}}, respectively.
+
 
 # Temporary usages of non-exported dfns # {#temp-dfn-usages}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2495,21 +2495,21 @@ dictionary GPUImageBitmapCopyView {
 
         Given a {{GPUCommandEncoder}} |encoder| and the arguments {{GPUBuffer}} |source|, {{GPUSize64}} |sourceOffset|, {{GPUBuffer}} |destination|, {{GPUSize64}} |destinationOffset|, {{GPUSize64}} |size|, the following validation rules apply:
 
-          * |encoder| must be a [=valid=] {{GPUCommandEncoder}}.
-          * |encoder|.{{GPUCommandEncoder/copyBufferToBuffer()}} must not be called when a {{GPURenderPassEncoder}} is active on |encoder|.
-          * |encoder|.{{GPUCommandEncoder/copyBufferToBuffer()}} must not be called when a {{GPUComputePassEncoder}} is active on |encoder|.
-          * |source| must be a [=valid=] {{GPUBuffer}}.
-          * |destination| must be a [=valid=] {{GPUBuffer}}.
-          * The {{GPUBuffer/[[usage]]}} of |source| must contain {{GPUBufferUsage/COPY_SRC}}.
-          * The {{GPUBuffer/[[usage]]}} of |destination| must contain {{GPUBufferUsage/COPY_DST}}.
-          * |size| must be a multiple of 4.
-          * |sourceOffset| must be a multiple of 4.
-          * |destinationOffset| must be a multiple of 4.
-          * (|sourceOffset| + |size|) must not overflow a {{GPUSize64}}.
-          * (|destinationOffset| + |size|) must not overflow a {{GPUSize64}}.
-          * The {{GPUBuffer/[[size]]}} of |source| must be greater than or equal to (|sourceOffset| + |size|).
-          * The {{GPUBuffer/[[size]]}} of |destination| must be greater than or equal to (|destinationOffset| + |size|).
-          * If |source| and |destination| are the same buffer, the copy range from |sourceOffset| to (|sourceOffset| + |size|) must not overlap with the copy range from |destinationOffset| to (|destinationOffset| + |size|).
+          - |encoder| must be a [=valid=] {{GPUCommandEncoder}}.
+          - |encoder|.{{GPUCommandEncoder/copyBufferToBuffer()}} must not be called when a {{GPURenderPassEncoder}} is active on |encoder|.
+          - |encoder|.{{GPUCommandEncoder/copyBufferToBuffer()}} must not be called when a {{GPUComputePassEncoder}} is active on |encoder|.
+          - |source| must be a [=valid=] {{GPUBuffer}}.
+          - |destination| must be a [=valid=] {{GPUBuffer}}.
+          - The {{GPUBuffer/[[usage]]}} of |source| must contain {{GPUBufferUsage/COPY_SRC}}.
+          - The {{GPUBuffer/[[usage]]}} of |destination| must contain {{GPUBufferUsage/COPY_DST}}.
+          - |size| must be a multiple of 4.
+          - |sourceOffset| must be a multiple of 4.
+          - |destinationOffset| must be a multiple of 4.
+          - (|sourceOffset| + |size|) must not overflow a {{GPUSize64}}.
+          - (|destinationOffset| + |size|) must not overflow a {{GPUSize64}}.
+          - The {{GPUBuffer/[[size]]}} of |source| must be greater than or equal to (|sourceOffset| + |size|).
+          - The {{GPUBuffer/[[size]]}} of |destination| must be greater than or equal to (|destinationOffset| + |size|).
+          - If |source| and |destination| are the same buffer, the copy range from |sourceOffset| to (|sourceOffset| + |size|) must not overlap with the copy range from |destinationOffset| to (|destinationOffset| + |size|).
 
         Issue(gpuweb/gpuweb#21): Define the state machine for GPUCommandEncoder.
 


### PR DESCRIPTION
- Normalize some whitespace.
- Normalize header formats.
- Move "Valid Usage" sections inside their respective algorithms so they use the same variables.
- Wrap some existing usage rules in "Valid Usage" sections.

A bit rough still; some of what I edited is still inconsistent (especially algorithms and valid usage blocks). But I need to teach myself to do these incrementally instead of making frustratingly huge changes across the entire spec that I can never finish. 🙂 

"Hide whitespace changes" mode recommended because I changed some indentation.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/637.html" title="Last updated on Mar 25, 2020, 11:08 PM UTC (10dcbc3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/637/c4b3bca...kainino0x:10dcbc3.html" title="Last updated on Mar 25, 2020, 11:08 PM UTC (10dcbc3)">Diff</a>