### PR TITLE
Conform for loop example to the statements syntax

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1072,7 +1072,7 @@ ordering requirements for a loop in SPIR-V.
   <xmp>
     int a = 2;
     for (int i = 0; i < 4; i++) {
-      a *= 2
+      a *= 2;
     }
   </xmp>
 </div>


### PR DESCRIPTION
As per the definition of statements, the statement given inside the loop needs to be terminated by a semicolon. This pull request aims to match example to the definition.