### PR TITLE
Remove `break if` in favor of `if () { break; }`.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1130,7 +1130,7 @@ allows them to naturally use values defined in the loop body.
     const a : i32 = 2;
     var i : i32 = 0;      // <1>
     loop {
-      break if (i >= 4);
+      if (i >= 4) { break; }
 
       a = a * 2;
 
@@ -1156,12 +1156,12 @@ allows them to naturally use values defined in the loop body.
     const a : i32 = 2;
     var i : i32 = 0;
     loop {
-      break if (i >= 4);
+      if (i >= 4) { break; }
 
       const step : i32 = 1;
 
       i = i + 1;
-      continue if (i % 2 == 0);
+      if (i % 2 == 0) { continue; }
 
       a = a * 2;
     }
@@ -1173,11 +1173,11 @@ allows them to naturally use values defined in the loop body.
     const a : i32 = 2;
     var i : i32 = 0;
     loop {
-      break if (i >= 4);
+      if (i >= 4) { break; }
 
       const step : i32 = 1;
 
-      continue if (i % 2 == 0);
+      if (i % 2 == 0) { continue; }
 
       a = a * 2;
 
@@ -1203,18 +1203,12 @@ where there is no `continuing` construct.
 
 <pre class='def'>
 break_stmt
-  : BREAK ({IF | UNLESS} paren_rhs_stmt)?
+  : BREAK
 </pre>
 
 Use a `break` statement to transfer control to the first statement
 after the body of the nearest-enclosing [[#loop-statement]]
 or [[#switch-statement]].
-
-The `break` statement has three forms:
-
-* `break` followed by an `if`-qualified condition: transfers control if the condition evaluates to `true`.
-* `break` followed by an `unless`-qualified condition: transfers control if the condition evaluates to `false`.
-* `break` without a qualifying clause: always transfers control.
 
 When a `break` statement is placed such that it would exit from a loop's [[#continuing-statement]],
 the break statement must appear last in that [[#continuing-statement]].
@@ -1223,19 +1217,13 @@ the break statement must appear last in that [[#continuing-statement]].
 
 <pre class='def'>
 continue_stmt
-  : CONTINUE ({IF | UNLESS} paren_rhs_stmt)?
+  : CONTINUE
 </pre>
 
 Use a `continue` statement to transfer control in the nearest-enclosing [[#loop-statement]]:
 
 *  forward to the [[#continuing-statement]] at the end of the body of that loop, if it exists.
 *  otherwise backward to the first statement in the loop body, starting the next iteration
-
-The `continue` statement has three forms:
-
-* `continue` followed by an `if`-qualified condition: transfers control when the condition evaluates to `true`.
-* `continue` followed by an `unless`-qualified condition: transfers control when the condition evaluates to `false`
-* `continue` without a qualifying clause: always transfers control.
 
 A `continue` statement must not be placed such that it would transfer
 control to an enclosing [[#continuing-statement]].
@@ -1248,8 +1236,8 @@ control past a declaration used in the targeted continuing construct.
   <xmp>
     var i : i32 = 0;
     loop {
-      break if (i >= 4);
-      continue if (i % 2 == 0); // <3>
+      if (i >= 4) { break; }
+      if (i % 2 == 0) { continue; } // <3>
 
       const step : i32 = 2;
 


### PR DESCRIPTION
This leaves `unless` unused, so it was also removed here.