### PR TITLE
Add pipeline shader module error enumeration.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1992,22 +1992,22 @@ Shader Modules {#shader-modules}
 
 <script type=idl>
 enum GPUCompilationMessageType {
-    'error',
-    'warning',
-    'info'
+    "error",
+    "warning",
+    "info"
 };
 
 [Serializable]
 interface GPUCompilationMessage {
-    DOMString message;
-    GPUCompilationMessageType type;
-    unsigned long long lineNum;
-    unsigned long long linePos;
+    readonly attribute DOMString message;
+    readonly attribute GPUCompilationMessageType type;
+    readonly attribute unsigned long long lineNum;
+    readonly attribute unsigned long long linePos;
 };
 
 [Serializable]
 interface GPUCompilationInfo {
-    sequence<GPUCompilationMessage> messages;
+    readonly attribute sequence<GPUCompilationMessage> messages;
 };
 
 [Serializable]

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2003,15 +2003,16 @@ interface GPUCompilationMessage {
     GPUCompilationMessageType type;
     unsigned long long lineNum;
     unsigned long long linePos;
+};
 
-    DOMString? mappedFileName;
-    unsigned long long mappedLineNum;
-    unsigned long long mappedLinePos;
+[Serializable]
+interface GPUCompilationInfo {
+    sequence<GPUCompilationMessage> messages;
 };
 
 [Serializable]
 interface GPUShaderModule {
-    [SameObject] Promise<sequence<GPUCompilationMessage>> compilationMessages();
+    [SameObject] Promise<GPUCompilationInfo> compilationInfo();
 };
 GPUShaderModule includes GPUObjectBase;
 </script>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2012,7 +2012,7 @@ interface GPUCompilationInfo {
 
 [Serializable]
 interface GPUShaderModule {
-    [SameObject] Promise<GPUCompilationInfo> compilationInfo();
+    Promise<GPUCompilationInfo> compilationInfo();
 };
 GPUShaderModule includes GPUObjectBase;
 </script>
@@ -2022,11 +2022,6 @@ shader module object, and {{Serializable}} means that the reference can be
 *copied* between realms (threads/workers), allowing multiple realms to access
 it concurrently. Since {{GPUShaderModule}} is immutable, there are no race
 conditions.
-
-If no source-map was provided for the |GPUShaderModule|:
-- {{GPUCompilationMessage/mappedFileName}} will be null
-- {{GPUCompilationMessage/mappedLineNum}} will be 0
-- {{GPUCompilationMessage/mappedLinePos}} will be 0
 
 ### Shader Module Creation ### {#shader-module-creation}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2028,13 +2028,48 @@ dictionary GPUProgrammableStageDescriptor {
 };
 </script>
 
+<script type=idl>
+enum GPUCompilationMessageType {
+    'error',
+    'warning',
+    'info'
+};
+enum GPUProgrammableStageType {
+    'vertex',
+    'fragment',
+    'compute'
+};
+
+[Serializable]
+interface GPUCompilationMessage {
+    GPUCompilationMessageType type;
+    GPUProgrammableStageType stage;
+    unsigned long long lineNum;
+    unsigned long long linePos;
+    DOMString? mappedFileName;
+    unsigned long long mappedLineNum;
+    unsigned long long mappedLinePos;
+};
+
+[Serializable]
+interface GPUPipelineBase {
+    [SameObject] Promise<sequence<GPUCompilationMessage>> compilationMessages();
+};
+GPUPipelineBase includes GPUObjectBase;
+</script>
+
+If no source-map was provided for the stage's module:
+- {{GPUCompilationMessage/mappedFileName}} will be null
+- {{GPUCompilationMessage/mappedLineNum}} will be 0
+- {{GPUCompilationMessage/mappedLinePos}} will be 0
+
 ## GPUComputePipeline ## {#compute-pipeline}
 
 <script type=idl>
 [Serializable]
 interface GPUComputePipeline {
 };
-GPUComputePipeline includes GPUObjectBase;
+GPUComputePipeline includes GPUPipelineBase;
 </script>
 
 ### Creation ### {#compute-pipeline-creation}
@@ -2051,7 +2086,7 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
 [Serializable]
 interface GPURenderPipeline {
 };
-GPURenderPipeline includes GPUObjectBase;
+GPURenderPipeline includes GPUPipelineBase;
 </script>
 
 ### Creation ### {#render-pipeline-creation}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1991,8 +1991,27 @@ Shader Modules {#shader-modules}
 ## GPUShaderModule ## {#shader-module}
 
 <script type=idl>
+enum GPUCompilationMessageType {
+    'error',
+    'warning',
+    'info'
+};
+
+[Serializable]
+interface GPUCompilationMessage {
+    DOMString message;
+    GPUCompilationMessageType type;
+    unsigned long long lineNum;
+    unsigned long long linePos;
+
+    DOMString? mappedFileName;
+    unsigned long long mappedLineNum;
+    unsigned long long mappedLinePos;
+};
+
 [Serializable]
 interface GPUShaderModule {
+    [SameObject] Promise<sequence<GPUCompilationMessage>> compilationMessages();
 };
 GPUShaderModule includes GPUObjectBase;
 </script>
@@ -2002,6 +2021,11 @@ shader module object, and {{Serializable}} means that the reference can be
 *copied* between realms (threads/workers), allowing multiple realms to access
 it concurrently. Since {{GPUShaderModule}} is immutable, there are no race
 conditions.
+
+If no source-map was provided for the |GPUShaderModule|:
+- {{GPUCompilationMessage/mappedFileName}} will be null
+- {{GPUCompilationMessage/mappedLineNum}} will be 0
+- {{GPUCompilationMessage/mappedLinePos}} will be 0
 
 ### Shader Module Creation ### {#shader-module-creation}
 
@@ -2028,48 +2052,13 @@ dictionary GPUProgrammableStageDescriptor {
 };
 </script>
 
-<script type=idl>
-enum GPUCompilationMessageType {
-    'error',
-    'warning',
-    'info'
-};
-enum GPUProgrammableStageType {
-    'vertex',
-    'fragment',
-    'compute'
-};
-
-[Serializable]
-interface GPUCompilationMessage {
-    GPUCompilationMessageType type;
-    GPUProgrammableStageType stage;
-    unsigned long long lineNum;
-    unsigned long long linePos;
-    DOMString? mappedFileName;
-    unsigned long long mappedLineNum;
-    unsigned long long mappedLinePos;
-};
-
-[Serializable]
-interface GPUPipelineBase {
-    [SameObject] Promise<sequence<GPUCompilationMessage>> compilationMessages();
-};
-GPUPipelineBase includes GPUObjectBase;
-</script>
-
-If no source-map was provided for the stage's module:
-- {{GPUCompilationMessage/mappedFileName}} will be null
-- {{GPUCompilationMessage/mappedLineNum}} will be 0
-- {{GPUCompilationMessage/mappedLinePos}} will be 0
-
 ## GPUComputePipeline ## {#compute-pipeline}
 
 <script type=idl>
 [Serializable]
 interface GPUComputePipeline {
 };
-GPUComputePipeline includes GPUPipelineBase;
+GPUComputePipeline includes GPUObjectBase;
 </script>
 
 ### Creation ### {#compute-pipeline-creation}
@@ -2086,7 +2075,7 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
 [Serializable]
 interface GPURenderPipeline {
 };
-GPURenderPipeline includes GPUPipelineBase;
+GPURenderPipeline includes GPUObjectBase;
 </script>
 
 ### Creation ### {#render-pipeline-creation}


### PR DESCRIPTION
Related to #645 shader-maps.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jdashg/gpuweb/pull/646.html" title="Last updated on May 18, 2020, 9:34 PM UTC (ad1ea78)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/646/5048a91...jdashg:ad1ea78.html" title="Last updated on May 18, 2020, 9:34 PM UTC (ad1ea78)">Diff</a>