### PR TITLE
GPUBuffer.mapRange() with subranges.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1033,16 +1033,33 @@ its mapping.
      mapping.
 
 <script type=idl>
+typedef [EnforceRange] unsigned long GPUBufferMapFlags;
+interface GPUBufferMap {
+    const GPUBufferMapFlags READ  = 0x0001;
+    const GPUBufferMapFlags WRITE = 0x0002;
+    const GPUBufferMapFlags READ_WRITE = 0x0003;
+
+    ArrayBuffer map;
+};
+
 [Serializable]
 interface GPUBuffer {
-    Promise<ArrayBuffer> mapReadAsync();
-    Promise<ArrayBuffer> mapWriteAsync();
-    void unmap();
+    Promise<GPUBufferMap> map(GPUBufferMapFlags flags, unsigned long long offset = 0, unsigned long long size = 0);
+    void unmap(GPUBufferMap toUnmap);
 
     void destroy();
 };
 GPUBuffer includes GPUObjectBase;
 </script>
+
+If size is zero, {{GPUBuffer/map}} treats it as an effective size of buffer-length-starting-at-offset.
+Effective size of a mapping must not be zero.
+{{GPUBuffer/map}} fails (and rejects) if the range overlaps with already-mapped ranges in GPUBuffer.
+{{GPUBuffer/map}}'s Promise resolves before {{GPUFence/onCompletion}}'s Promise for any
+{{GPUQueue/signal}} enqueued after the last {{GPUQueue/submit}} that uses the buffer.
+
+{{GPUBuffer/unmap}} detaches {{GPUBufferMap/map}}. (length is truncated to zero)
+
 
 {{GPUBuffer}} has the following internal slots:
 
@@ -1059,9 +1076,9 @@ GPUBuffer includes GPUObjectBase;
     ::
         The current state of the {{GPUBuffer}}.
 
-    : <dfn>\[[mapping]]</dfn> of type {{ArrayBuffer}} or {{Promise}} or `null`.
+    : <dfn>\[[mappedRanges]]</dfn> of type {{sequence<GPUBufferMap>}}.
     ::
-        The mapping for this {{GPUBuffer}}.
+        The mappings for this {{GPUBuffer}}.
 </dl>
 
 Each {{GPUBuffer}} has a current <dfn dfn>buffer state</dfn> on the [=Content timeline=]
@@ -2723,9 +2740,8 @@ GPUQueue includes GPUObjectBase;
 
 {{GPUQueue/submit(commandBuffers)}} does nothing and produces an error if any of the following is true:
 
- - Any {{GPUBuffer}} referenced in any element of `commandBuffers` isn't in the `"unmapped"` [=buffer state=].
+ - Any {{GPUBuffer}} range referenced in any element of `commandBuffers` isn't entirely in the `"unmapped"` [=buffer state=].
  - Any of the [=usage scopes=] contained in the command buffers fail the [=usage scope validation=].
-
 
 ## GPUFence ## {#fence}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1033,19 +1033,22 @@ its mapping.
      mapping.
 
 <script type=idl>
-typedef [EnforceRange] unsigned long GPUBufferMapFlags;
-interface GPUBufferMap {
-    const GPUBufferMapFlags READ  = 0x0001;
-    const GPUBufferMapFlags WRITE = 0x0002;
-    const GPUBufferMapFlags READ_WRITE = 0x0003;
+typedef [EnforceRange] unsigned long GPUMapUsageFlags;
+interface GPUMapUsage {
+    const GPUMapUsageFlags READ  = 0x0001;
+    const GPUMapUsageFlags WRITE = 0x0002;
+    const GPUMapUsageFlags READ_WRITE = 0x0003;
+};
 
-    ArrayBuffer map;
+interface GPUMappedSubrange {
+    ArrayBuffer mapped;
 };
 
 [Serializable]
 interface GPUBuffer {
-    Promise<GPUBufferMap> map(GPUBufferMapFlags flags, unsigned long long offset = 0, unsigned long long size = 0);
-    void unmap(GPUBufferMap toUnmap);
+    Promise<void> mapRangeAsync(GPUBufferMapFlags flags, unsigned long long offset = 0, unsigned long long size = 0);
+    GPUMappedSubrange? getMappedSubrange(unsigned long long offset = 0, unsigned long long size = 0);
+    void unmapRange(unsigned long long offset = 0, unsigned long long size = 0);
 
     void destroy();
 };
@@ -1057,8 +1060,19 @@ Effective size of a mapping must not be zero.
 {{GPUBuffer/map}} fails (and rejects) if the range overlaps with already-mapped ranges in GPUBuffer.
 {{GPUBuffer/map}}'s Promise resolves before {{GPUFence/onCompletion}}'s Promise for any
 {{GPUQueue/signal}} enqueued after the last {{GPUQueue/submit}} that uses the buffer.
+If |mapRangeAsync| requests a subrange that is not in the "unmapped" state, the promise rejects.
+(If two duplicate calls to |mapRangeAsync| are made back-to-back, the second will always reject)
+When the promise from |mapRangeAsync| resolves, its subrange is marked as "mapped".
 
-{{GPUBuffer/unmap}} detaches {{GPUBufferMap/map}}. (length is truncated to zero)
+If |getMappedRange| is called while the requested subrange is not in the "mapped" state,
+|getMappedRange| fails and returns null.
+If |getMappedRange| succeeds, the subrange is set to the "visible" state.
+
+It is an error if |unmapRange| specifies range that:
+* Is not "mapped" or "visible".
+* Includes a part of an active |GPUMappedSubrange| but not the whole subrange.
+Otherwise, |unmapRange| marks the range as "unmapped", and for each {{GPUMappedSubrange}} within
+that range, {{GPUMappedSubrange/mapped}} is detached (length is truncated to zero).
 
 
 {{GPUBuffer}} has the following internal slots:
@@ -1076,9 +1090,9 @@ Effective size of a mapping must not be zero.
     ::
         The current state of the {{GPUBuffer}}.
 
-    : <dfn>\[[mappedRanges]]</dfn> of type {{sequence<GPUBufferMap>}}.
+    : <dfn>\[[mappedSubranges]]</dfn> of type {{sequence<GPUMappedSubrange>}}.
     ::
-        The mappings for this {{GPUBuffer}}.
+        The visible mappings for this {{GPUBuffer}}.
 </dl>
 
 Each {{GPUBuffer}} has a current <dfn dfn>buffer state</dfn> on the [=Content timeline=]


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jdashg/gpuweb/pull/649.html" title="Last updated on Apr 2, 2020, 3:43 AM UTC (1eb6aa1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/649/5048a91...jdashg:1eb6aa1.html" title="Last updated on Apr 2, 2020, 3:43 AM UTC (1eb6aa1)">Diff</a>