### PR TITLE
Add GPUCommandEncoder.updateBuffer for embedding small buffer updates.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2391,7 +2391,7 @@ interface GPUCommandEncoder {
         GPUTextureCopyView destination,
         GPUExtent3D copySize);
 
-    void updateBuffer(
+    void inlineUpdateBuffer(
         ArrayBuffer source,
         GPUSize64 sourceOffset,
         GPUBuffer destination,
@@ -2524,9 +2524,19 @@ dictionary GPUImageBitmapCopyView {
     </div>
 </div>
 
-### <dfn method for=GPUCommandEncoder>updateBuffer(source, sourceOffset, destination, destinationOffset, size)</dfn> ### {#GPUCommandEncoder-updateBuffer}
+### <dfn method for=GPUCommandEncoder>inlineUpdateBuffer(source, sourceOffset, destination, destinationOffset, size)</dfn> ### {#GPUCommandEncoder-inlineUpdateBuffer}
 
-<div algorithm="GPUCommandEncoder.updateBuffer">
+It's often useful for applications to update buffer data prior to draw or compute operations.
+For example, updating model-view and projection matrices before or interleaved with rendering of a scene.
+When these uploads are small, it's viable to inline the update data into the command buffer.
+This does require more copies than other upload paths, but for small data sizes this overhead is negligible.
+Implementations are expected to warn against using this for medium-to-large buffer updates. (e.g. >64k)
+
+In Vulkan, this is similar to |vkCmdUpdateBuffer|.
+In D3D12, implementations can leverage |ID3D12GraphicsCommandList2::WriteBufferImmediate|.
+Metal might use |makeBuffer(bytesNoCopy:length:options:deallocator:)| around some section of shared command buffer serialization memory.
+
+<div algorithm="GPUCommandEncoder.inlineUpdateBuffer">
 
   **Arguments:**
     - {{ArrayBuffer}} |source|
@@ -2539,20 +2549,18 @@ dictionary GPUImageBitmapCopyView {
 
   Embed a copy of |source| from |sourceOffset| to |size| into the {{GPUCommandEncoder}}.
   Encode a command into the {{GPUCommandEncoder}} that copies |size| bytes of data from embedded copy to the |destinationOffset| of another {{GPUBuffer}} |destination|.
-  |size| must be less than or equal to 65536 bytes.
 
-  <div class=validusage dfn-for=GPUCommandEncoder.updateBuffer>
+  <div class=validusage dfn-for=GPUCommandEncoder.inlineUpdateBuffer>
         <dfn abstract-op>Valid Usage</dfn>
 
         Given a {{GPUCommandEncoder}} |encoder| and the arguments {{ArrayBuffer}} |source|, {{GPUSize64}} |sourceOffset|, {{GPUBuffer}} |destination|, {{GPUSize64}} |destinationOffset|, {{GPUSize64}} |size|, the following validation rules apply:
 
           - |encoder| must be a [=valid=] {{GPUCommandEncoder}}.
-          - |encoder|.{{GPUCommandEncoder/updateBuffer()}} must not be called when a {{GPURenderPassEncoder}} is active on |encoder|.
-          - |encoder|.{{GPUCommandEncoder/updateBuffer()}} must not be called when a {{GPUComputePassEncoder}} is active on |encoder|.
+          - |encoder|.{{GPUCommandEncoder/inlineUpdateBuffer()}} must not be called when a {{GPURenderPassEncoder}} is active on |encoder|.
+          - |encoder|.{{GPUCommandEncoder/inlineUpdateBuffer()}} must not be called when a {{GPUComputePassEncoder}} is active on |encoder|.
           - |destination| must be a [=valid=] {{GPUBuffer}}.
           - The {{GPUBuffer/[[usage]]}} of |destination| must contain {{GPUBufferUsage/COPY_DST}}.
           - |size| must be a multiple of 4.
-          - |size| must be less than or equal to 65536.
           - |sourceOffset| must be a multiple of 4.
           - |destinationOffset| must be a multiple of 4.
           - (|sourceOffset| + |size|) must not overflow a {{GPUSize64}}.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2391,6 +2391,13 @@ interface GPUCommandEncoder {
         GPUTextureCopyView destination,
         GPUExtent3D copySize);
 
+    void updateBuffer(
+        ArrayBuffer source,
+        GPUSize64 sourceOffset,
+        GPUBuffer destination,
+        GPUSize64 destinationOffset,
+        GPUSize64 size);
+
     void pushDebugGroup(DOMString groupLabel);
     void popDebugGroup();
     void insertDebugMarker(DOMString markerLabel);
@@ -2514,6 +2521,44 @@ dictionary GPUImageBitmapCopyView {
         Issue(gpuweb/gpuweb#21): Define the state machine for GPUCommandEncoder.
 
         Issue(gpuweb/gpuweb#69): figure out how to handle overflows in the spec.
+    </div>
+</div>
+
+### <dfn method for=GPUCommandEncoder>updateBuffer(source, sourceOffset, destination, destinationOffset, size)</dfn> ### {#GPUCommandEncoder-updateBuffer}
+
+<div algorithm="GPUCommandEncoder.updateBuffer">
+
+  **Arguments:**
+    - {{ArrayBuffer}} |source|
+    - {{GPUSize64}} |sourceOffset|
+    - {{GPUBuffer}} |destination|
+    - {{GPUSize64}} |destinationOffset|
+    - {{GPUSize64}} |size|
+
+  **Returns:** void
+
+  Embed a copy of |source| from |sourceOffset| to |size| into the {{GPUCommandEncoder}}.
+  Encode a command into the {{GPUCommandEncoder}} that copies |size| bytes of data from embedded copy to the |destinationOffset| of another {{GPUBuffer}} |destination|.
+  |size| must be less than or equal to 65536 bytes.
+
+  <div class=validusage dfn-for=GPUCommandEncoder.updateBuffer>
+        <dfn abstract-op>Valid Usage</dfn>
+
+        Given a {{GPUCommandEncoder}} |encoder| and the arguments {{ArrayBuffer}} |source|, {{GPUSize64}} |sourceOffset|, {{GPUBuffer}} |destination|, {{GPUSize64}} |destinationOffset|, {{GPUSize64}} |size|, the following validation rules apply:
+
+          - |encoder| must be a [=valid=] {{GPUCommandEncoder}}.
+          - |encoder|.{{GPUCommandEncoder/updateBuffer()}} must not be called when a {{GPURenderPassEncoder}} is active on |encoder|.
+          - |encoder|.{{GPUCommandEncoder/updateBuffer()}} must not be called when a {{GPUComputePassEncoder}} is active on |encoder|.
+          - |destination| must be a [=valid=] {{GPUBuffer}}.
+          - The {{GPUBuffer/[[usage]]}} of |destination| must contain {{GPUBufferUsage/COPY_DST}}.
+          - |size| must be a multiple of 4.
+          - |size| must be less than or equal to 65536.
+          - |sourceOffset| must be a multiple of 4.
+          - |destinationOffset| must be a multiple of 4.
+          - (|sourceOffset| + |size|) must not overflow a {{GPUSize64}}.
+          - (|destinationOffset| + |size|) must not overflow a {{GPUSize64}}.
+          - The {{ArrayBuffer/byteLength}} of |source| must be greater than or equal to (|sourceOffset| + |size|).
+          - The {{GPUBuffer/[[size]]}} of |destination| must be greater than or equal to (|destinationOffset| + |size|).
     </div>
 </div>
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jdashg/gpuweb/pull/650.html" title="Last updated on May 20, 2020, 11:42 PM UTC (30c71af)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/650/d00a99c...jdashg:30c71af.html" title="Last updated on May 20, 2020, 11:42 PM UTC (30c71af)">Diff</a>