### PR TITLE
[wgsl] Fixup VertexIdx SPIR-V example.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -606,7 +606,7 @@ builtin_decoration
           OpDecorate %gl_Position BuiltIn Position
 
     [[builtin vertex_idx]]
-          OpDecorate %gl_VertexId BuiltIn VertexId
+          OpDecorate %gl_VertexIdx BuiltIn VertexIndex
 
     [[builtin instance_idx]]
           OpDecorate %gl_InstanceId BuiltIn InstanceIndex


### PR DESCRIPTION
The VertexIdx was incorrectly set to convert to the VertexId instead of
the VertexIndex SPIR-V decoration.