### PR TITLE
Query API: Add Occlusion Query

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -802,7 +802,8 @@ allows additional usages of WebGPU that would have otherwise been invalid.
 
 <script type=idl>
 enum GPUExtensionName {
-    "texture-compression-bc"
+    "texture-compression-bc",
+    "precise-occlusion-query"
 };
 </script>
 
@@ -971,6 +972,8 @@ interface GPUDevice : EventTarget {
 
     GPUCommandEncoder createCommandEncoder(optional GPUCommandEncoderDescriptor descriptor = {});
     GPURenderBundleEncoder createRenderBundleEncoder(GPURenderBundleEncoderDescriptor descriptor);
+
+    GPUQuerySet createQuerySet(GPUQuerySetDescriptor descriptor);
 };
 GPUDevice includes GPUObjectBase;
 </script>
@@ -1205,15 +1208,16 @@ once all previously submitted operations using it are complete.
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUBufferUsageFlags;
 interface GPUBufferUsage {
-    const GPUBufferUsageFlags MAP_READ  = 0x0001;
-    const GPUBufferUsageFlags MAP_WRITE = 0x0002;
-    const GPUBufferUsageFlags COPY_SRC  = 0x0004;
-    const GPUBufferUsageFlags COPY_DST  = 0x0008;
-    const GPUBufferUsageFlags INDEX     = 0x0010;
-    const GPUBufferUsageFlags VERTEX    = 0x0020;
-    const GPUBufferUsageFlags UNIFORM   = 0x0040;
-    const GPUBufferUsageFlags STORAGE   = 0x0080;
-    const GPUBufferUsageFlags INDIRECT  = 0x0100;
+    const GPUBufferUsageFlags MAP_READ      = 0x0001;
+    const GPUBufferUsageFlags MAP_WRITE     = 0x0002;
+    const GPUBufferUsageFlags COPY_SRC      = 0x0004;
+    const GPUBufferUsageFlags COPY_DST      = 0x0008;
+    const GPUBufferUsageFlags INDEX         = 0x0010;
+    const GPUBufferUsageFlags VERTEX        = 0x0020;
+    const GPUBufferUsageFlags UNIFORM       = 0x0040;
+    const GPUBufferUsageFlags STORAGE       = 0x0080;
+    const GPUBufferUsageFlags INDIRECT      = 0x0100;
+    const GPUBufferUsageFlags QUERY_RESOLVE = 0x0200;
 };
 </script>
 
@@ -2395,6 +2399,13 @@ interface GPUCommandEncoder {
     void popDebugGroup();
     void insertDebugMarker(DOMString markerLabel);
 
+    void resolveQuerySet(
+        GPUQuerySet querySet,
+        GPUSize32 queryFirstIndex,
+        GPUSize32 queryCount,
+        GPUBuffer dstBuffer,
+        GPUSize64 dstOffset);
+
     GPUCommandBuffer finish(optional GPUCommandBufferDescriptor descriptor = {});
 };
 GPUCommandEncoder includes GPUObjectBase;
@@ -2595,6 +2606,9 @@ interface GPURenderPassEncoder {
     void setBlendColor(GPUColor color);
     void setStencilReference(GPUStencilValue reference);
 
+    void beginOcclusionQuery(GPUSize32 queryIndex, optional boolean preciseOcclusion = false);
+    void endOcclusionQuery(GPUSize32 queryIndex);
+
     void executeBundles(sequence<GPURenderBundle> bundles);
     void endPass();
 };
@@ -2632,6 +2646,7 @@ the pass's pipeline, bind groups, and vertex and index buffers are cleared. If z
 dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
     required sequence<GPURenderPassColorAttachmentDescriptor> colorAttachments;
     GPURenderPassDepthStencilAttachmentDescriptor depthStencilAttachment;
+    GPUQuerySet occlusionQuerySet;
 };
 </script>
 
@@ -2755,6 +2770,38 @@ GPUFence includes GPUObjectBase;
 <script type=idl>
 dictionary GPUFenceDescriptor : GPUObjectDescriptorBase {
     GPUFenceValue initialValue = 0;
+};
+</script>
+
+
+Queries {#queries}
+================
+
+## QuerySet ## {#queryset}
+
+<script type=idl>
+interface GPUQuerySet {
+    void destroy();
+};
+GPUQuerySet includes GPUObjectBase;
+</script>
+
+### Creation ### {#queryset-creation}
+
+<script type=idl>
+dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
+    required GPUQueryType type;
+    required GPUSize32 count;
+};
+</script>
+
+## QueryType ## {#querytype}
+
+<script type=idl>
+enum GPUQueryType {
+    "occlusion",
+    "pipeline-statistics",
+    "timestamp"
 };
 </script>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2605,7 +2605,7 @@ interface GPURenderPassEncoder {
     void setBlendColor(GPUColor color);
     void setStencilReference(GPUStencilValue reference);
 
-    void beginOcclusionQuery(GPUSize32 queryIndex, optional boolean preciseOcclusion = false);
+    void beginOcclusionQuery(GPUSize32 queryIndex);
     void endOcclusionQuery(GPUSize32 queryIndex);
 
     void executeBundles(sequence<GPURenderBundle> bundles);

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2799,9 +2799,7 @@ dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
 
 <script type=idl>
 enum GPUQueryType {
-    "occlusion",
-    "pipeline-statistics",
-    "timestamp"
+    "occlusion"
 };
 </script>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -802,8 +802,7 @@ allows additional usages of WebGPU that would have otherwise been invalid.
 
 <script type=idl>
 enum GPUExtensionName {
-    "texture-compression-bc",
-    "precise-occlusion-query"
+    "texture-compression-bc"
 };
 </script>
 


### PR DESCRIPTION
Add the definition of Occlusion Query and its requirements according to #614:
* Define QuerySet, QuerySetDescriptor and QueryType.
* Add query set in render pass descriptor for occlusion query.
* Add begin/endOcclusionQuery on render pass encoder.
* Resolve query result from query set on command encoder.
* Add a new buffer usage for resolving query result.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/haoxli/gpuweb/pull/656.html" title="Last updated on Mar 31, 2020, 4:57 AM UTC (b278bbf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/656/7e08b4b...haoxli:b278bbf.html" title="Last updated on Mar 31, 2020, 4:57 AM UTC (b278bbf)">Diff</a>