### PR TITLE
Add minimumBufferSize to BGL entry

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1951,7 +1951,7 @@ dictionary GPUBindGroupLayoutEntry {
     boolean hasDynamicOffset = false;
 
     // Used for uniform buffer and storage buffer bindings.
-    GPUSize64 minimumBufferBindingSize = 0;
+    GPUSize64 minBufferBindingSize = 0;
 
     // Used for sampled texture and storage texture bindings.
     GPUTextureViewDimension viewDimension;
@@ -2111,7 +2111,7 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
             {{GPUBindingType/"readonly-storage-buffer"}},
             ensure
             |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `false`,
-            and |bindingDescriptor|.{{GPUBindGroupLayoutEntry/minimumBufferBindingSize}} is zero.
+            and |bindingDescriptor|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} is zero.
         1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
             {{GPUBindingType/"sampled-texture"}},
             {{GPUBindingType/"readonly-storage-texture"}}, or
@@ -2369,9 +2369,11 @@ A {{GPUBindGroup}} object has the following internal slots:
                 |bufferBinding|.{{GPUBufferBinding/size}} must reside inside the buffer.
             1. The effective binding size, that is either explict in |bufferBinding|.{{GPUBufferBinding/size}}
                 or derived from |bufferBinding|.{{GPUBufferBinding/offset}} and the full size of the buffer,
-                is greater or equal to {{GPUBindGroupLayoutEntry/minimumBufferBindingSize|GPUBindGroupLayoutEntry.minimumBufferBindingSize}}.
+                is greater or equal to |layoutBinding|.{{GPUBindGroupLayoutEntry/minBufferBindingSize|GPUBindGroupLayoutEntry.minBufferBindingSize}}.
     </div>
 </div>
+
+Issue: define the "effective buffer binding size" separately.
 
 ## GPUPipelineLayout ## {#pipeline-layout}
 
@@ -2748,14 +2750,12 @@ A {{GPUProgrammableStageDescriptor}} describes the entry point in the user-provi
             the |binding| has to be a read-only storage buffer.
         1. If |entry|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampled-texture"}}, {{GPUBindingType/"readonly-storage-texture"}}, or {{GPUBindingType/"writeonly-storage-texture"}},
             the shader view dimension of the texture has to match |entry|.{{GPUBindGroupLayoutEntry/viewDimension}}.
-        1. If |entry|.{{GPUBindGroupLayoutEntry/minimumBufferBindingSize}} is not zero,
-            |entry|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"uniform-buffer"}}, {{GPUBindingType/"storage-buffer"}}, or
-            {{GPUBindingType/"readonly-storage-buffer"}}:
+        1. If |entry|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} is not zero:
               - if the corresponding structure defined in the shader has the last field being an unbound array type,
-                then the value of |entry|.{{GPUBindGroupLayoutEntry/minimumBufferBindingSize}} must be greater or equal to the
+                then the value of |entry|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} must be greater or equal to the
                 byte offset of that field plus the stride of the unbound array.
               - if the corresponding shader structure doesn't end with an unbound array type,
-                then the value of |entry|.{{GPUBindGroupLayoutEntry/minimumBufferBindingSize}} must be greater or equal to the
+                then the value of |entry|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} must be greater or equal to the
                 size of the structure.
 </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1965,6 +1965,8 @@ dictionary GPUBindGroupLayoutEntry {
 };
 </script>
 
+Issue(https://github.com/gpuweb/gpuweb/issues/851): consider making `textureComponentType` and `storageTextureFormat` truly optional.
+
 <dl dfn-type=dict-member dfn-for=GPUBindGroupLayoutEntry>
     : <dfn>binding</dfn>
     ::
@@ -2746,6 +2748,15 @@ A {{GPUProgrammableStageDescriptor}} describes the entry point in the user-provi
             the |binding| has to be a read-only storage buffer.
         1. If |entry|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampled-texture"}}, {{GPUBindingType/"readonly-storage-texture"}}, or {{GPUBindingType/"writeonly-storage-texture"}},
             the shader view dimension of the texture has to match |entry|.{{GPUBindGroupLayoutEntry/viewDimension}}.
+        1. If |entry|.{{GPUBindGroupLayoutEntry/minimumBufferBindingSize}} is not zero,
+            |entry|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"uniform-buffer"}}, {{GPUBindingType/"storage-buffer"}}, or
+            {{GPUBindingType/"readonly-storage-buffer"}}:
+              - if the corresponding structure defined in the shader has the last field being an unbound array type,
+                then the value of |entry|.{{GPUBindGroupLayoutEntry/minimumBufferBindingSize}} must be greater or equal to the
+                byte offset of that field plus the stride of the unbound array.
+              - if the corresponding shader structure doesn't end with an unbound array type,
+                then the value of |entry|.{{GPUBindGroupLayoutEntry/minimumBufferBindingSize}} must be greater or equal to the
+                size of the structure.
 </div>
 
 Issue: is there a match/switch statement in bikeshed?

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1950,6 +1950,9 @@ dictionary GPUBindGroupLayoutEntry {
     // Used for uniform buffer and storage buffer bindings.
     boolean hasDynamicOffset = false;
 
+    // Used for uniform buffer and storage buffer bindings.
+    GPUSize64 minimumBufferBindingSize = 0;
+
     // Used for sampled texture and storage texture bindings.
     GPUTextureViewDimension viewDimension;
 
@@ -2105,8 +2108,8 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
             {{GPUBindingType/"storage-buffer"}}, or
             {{GPUBindingType/"readonly-storage-buffer"}},
             ensure
-            |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}}
-            is `false`.
+            |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `false`,
+            and |bindingDescriptor|.{{GPUBindGroupLayoutEntry/minimumBufferBindingSize}} is zero.
         1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
             {{GPUBindingType/"sampled-texture"}},
             {{GPUBindingType/"readonly-storage-texture"}}, or
@@ -2188,24 +2191,7 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
 Two {{GPUBindGroupLayout}} objects |a| and |b| are considered <dfn dfn>group-equivalent</dfn>
 if and only if, for any binding number |binding|, one of the following is true:
     - it's missing from both |a|.{{GPUBindGroupLayout/[[entryMap]]}} and |b|.{{GPUBindGroupLayout/[[entryMap]]}}.
-    - |a|.{{GPUBindGroupLayout/[[entryMap]]}}[|binding|] is [=entry-equivalent=] to |b|.{{GPUBindGroupLayout/[[entryMap]]}}[|binding|]
-</div>
-
-<div algorithm>
-Two {{GPUBindGroupLayoutEntry}} entries |a| and |b| are considered <dfn dfn>entry-equivalent</dfn> if all of the conditions are true:
-
-    1. |a|.{{GPUBindGroupLayoutEntry/binding}} == |b|.{{GPUBindGroupLayoutEntry/binding}}
-    1. |a|.{{GPUBindGroupLayoutEntry/visibility}} == |b|.{{GPUBindGroupLayoutEntry/visibility}}
-    1. |a|.{{GPUBindGroupLayoutEntry/type}} == |b|.{{GPUBindGroupLayoutEntry/type}}
-    1. if |a|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"uniform-buffer"}}, {{GPUBindingType/"storage-buffer"}}, or {{GPUBindingType/"readonly-storage-buffer"}}, then:
-        - |a|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} == |b|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}}
-    1. if |a|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampled-texture"}}, then:
-        - |a|.{{GPUBindGroupLayoutEntry/viewDimension}} == |b|.{{GPUBindGroupLayoutEntry/viewDimension}}
-        - |a|.{{GPUBindGroupLayoutEntry/textureComponentType}} == |b|.{{GPUBindGroupLayoutEntry/textureComponentType}}
-        - |a|.{{GPUBindGroupLayoutEntry/multisampled}} == |b|.{{GPUBindGroupLayoutEntry/multisampled}}
-    1. if |a|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"readonly-storage-texture"}} or {{GPUBindingType/"writeonly-storage-texture"}}, then:
-        - |a|.{{GPUBindGroupLayoutEntry/viewDimension}} == |b|.{{GPUBindGroupLayoutEntry/viewDimension}}
-        - |a|.{{GPUBindGroupLayoutEntry/storageTextureFormat}} == |b|.{{GPUBindGroupLayoutEntry/storageTextureFormat}}
+    - |a|.{{GPUBindGroupLayout/[[entryMap]]}}[|binding|] == |b|.{{GPUBindGroupLayout/[[entryMap]]}}[|binding|]
 </div>
 
 If bind groups layouts are [=group-equivalent=] they can be interchangeably used in all contents.
@@ -2379,6 +2365,9 @@ A {{GPUBindGroup}} object has the following internal slots:
                 with {{GPUBufferUsage/STORAGE}} flag.
             1. The bound part designated by |bufferBinding|.{{GPUBufferBinding/offset}} and
                 |bufferBinding|.{{GPUBufferBinding/size}} must reside inside the buffer.
+            1. The effective binding size, that is either explict in |bufferBinding|.{{GPUBufferBinding/size}}
+                or derived from |bufferBinding|.{{GPUBufferBinding/offset}} and the full size of the buffer,
+                is greater or equal to {{GPUBindGroupLayoutEntry/minimumBufferBindingSize|GPUBindGroupLayoutEntry.minimumBufferBindingSize}}.
     </div>
 </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2751,11 +2751,11 @@ A {{GPUProgrammableStageDescriptor}} describes the entry point in the user-provi
         1. If |entry|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampled-texture"}}, {{GPUBindingType/"readonly-storage-texture"}}, or {{GPUBindingType/"writeonly-storage-texture"}},
             the shader view dimension of the texture has to match |entry|.{{GPUBindGroupLayoutEntry/viewDimension}}.
         1. If |entry|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} is not zero:
-              - if the corresponding structure defined in the shader has the last field being an unbound array type,
-                then the value of |entry|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} must be greater or equal to the
-                byte offset of that field plus the stride of the unbound array.
-              - if the corresponding shader structure doesn't end with an unbound array type,
-                then the value of |entry|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} must be greater or equal to the
+              - If the last field of the corresponding structure defined in the shader has an unbounded array type,
+                then the value of |entry|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} must be greater than or equal to the
+                byte offset of that field plus the stride of the unbounded array.
+              - If the corresponding shader structure doesn't end with an unbounded array type,
+                then the value of |entry|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} must be greater than or equal to the
                 size of the structure.
 </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2369,7 +2369,7 @@ A {{GPUBindGroup}} object has the following internal slots:
                 |bufferBinding|.{{GPUBufferBinding/size}} must reside inside the buffer.
             1. The effective binding size, that is either explict in |bufferBinding|.{{GPUBufferBinding/size}}
                 or derived from |bufferBinding|.{{GPUBufferBinding/offset}} and the full size of the buffer,
-                is greater or equal to |layoutBinding|.{{GPUBindGroupLayoutEntry/minBufferBindingSize|GPUBindGroupLayoutEntry.minBufferBindingSize}}.
+                is greater than or equal to |layoutBinding|.{{GPUBindGroupLayoutEntry/minBufferBindingSize|GPUBindGroupLayoutEntry.minBufferBindingSize}}.
     </div>
 </div>
 


### PR DESCRIPTION
This is a follow-up to https://github.com/gpuweb/gpuweb/issues/546#issuecomment-607207587 that is meant to start the discussion on how this issue can be addressed, and proposes a strawman solution :)

It's often the case where the buffers visible to a shader are structured, which means the shader sees it as:
```rust
type Particles = struct {
  [[offset 0]] particles : array<float, 10>;
  [[offset 40]] other_field: i32;
  [[offset 44]] unbound_array: array<i32, 0>;
};
```

This structure can be seen as 2 parts:
  1. the bounded portion: it has named fields, some could be fixed-size arrays.
  2. the unbound array of something, indexed dynamically.

This stawman proposal is to require the minimum size of (1) portion to be specified in BGL entry. Any buffer binding created for it has to specify the size that is ">=" that minimum size. When a pipeline is created, we can inspect the structured parts of the buffer bindings of the shader, and validate that the minimum buffer size covers the (1) portion.

What this allows us to do is basically avoiding the access address checks for named non-array fields of buffer bindings (as well as the fields of structures in a arrays). This means more efficient shader code being generated and ran on the GPU. Since uniform buffers are used a lot, having efficient loads from them is essential for performance (although, we don't have concrete benchmarks showing how much it would cost to do a check for every field access, yet).

What this limits the user to do is having a buffer that only partially covers a structured buffer binding. My feeling is that this is a fine compromise, and the users can always work around this by creating a slightly bigger buffer.

Some more details on how the buffer access rules would work in the shader:
  - when accessing arrays within a buffer, we check for index and consider the access to be OOB if the structure by that index doesn't fit into the binding (i.e. no partial structure access).
  - when accessing other fields (either top-level, or within an array by index that is in bounds), there need to be no checks done.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/678.html" title="Last updated on Jun 10, 2020, 4:17 PM UTC (83111fc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/678/4514260...kvark:83111fc.html" title="Last updated on Jun 10, 2020, 4:17 PM UTC (83111fc)">Diff</a>