### PR TITLE
Add #buffer-uploads about mapping in modern graphics APIs and `copyDataToBuffer` example.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1316,6 +1316,42 @@ Issue: Add client-side validation that a mapped buffer can only be unmapped and 
 
 </div>
 
+## Buffer Uploads ## {#buffer-uploads}
+
+*This section is non-normative.*
+
+Modern graphics APIs have largely eschewed immediate data uploads in favor of mapping
+host-visible buffers and enqueuing copies into other (especially device-local) buffers as needed.
+Beginners in particular will want an easy way to upload new data for buffers without managing mappings.
+We encourage use of helper functions (like below) until more sophisticated buffer and mapping management is required.
+While copyDataToBuffer isn't always the most efficient approach, it is robust and easy to use for basic content.
+
+<div class="example">
+function copyDataToBuffer(device, queue, srcData, srcOffset,
+                          dstBuffer, dstOffset, size)
+{
+   size = size || (srcData.byteLength - srcOffset);
+
+   const [uploadBuf, map] = device.createBufferMapped({
+      size: size,
+      usage: GPUBufferUsage.COPY_SRC,
+   });
+   map.set(srcData, srcOffset);
+   uploadBuf.unmap();
+
+   const cenc = device.createCommandEncoder();
+   cenc.copyBufferToBuffer(uploadBuf, 0, dstBuffer, dstOffset, size);
+   const cbuf = cenc.finish();
+
+   queue.submit([cbuf]);
+   uploadBuf.destroy();
+};
+</div>
+
+More sophisticated content may require batched or pipelined uploads, possibly with staging areas and
+other tuned heuristics.
+Instead of guessing the intent of the application, this API offers the primitive building blocks to
+construct efficient abstractions for any usecase.
 
 # Textures and Texture Views # {#textures}
 


### PR DESCRIPTION
I keep wanting to refer back to this recommendation for easy buffer uploads, so I think it makes sense to propose some non-normative spec text about it.

This applies to the state of the spec today, and may or may not change based on ongoing work on buffer upload entrypoints.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jdashg/gpuweb/pull/680.html" title="Last updated on Apr 1, 2020, 10:11 PM UTC (8301bb0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/680/0245441...jdashg:8301bb0.html" title="Last updated on Apr 1, 2020, 10:11 PM UTC (8301bb0)">Diff</a>