### PR TITLE
Remove premerge

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -424,7 +424,6 @@ Note: literals are parsed greedy. This means that for statements like `a -5`
   <tr><td>`NOP`<td>nop
   <tr><td>`OFFSET`<td>offset
   <tr><td>`OUT`<td>out
-  <tr><td>`PREMREGE`<td>premerge
   <tr><td>`PRIVATE`<td>private
   <tr><td>`RETURN`<td>return
   <tr><td>`SET`<td>set
@@ -466,7 +465,7 @@ The following is a list of keywords which are reserved for future expansion.
     <td>using
     <td>while
     <td>regardless
-    <td>
+    <td>premerge
     <td>
 </table>
 
@@ -1016,21 +1015,14 @@ variable_stmt
 ## If Statement ## {#if-statement}
 <pre class='def'>
 if_stmt
-  : IF paren_rhs_stmt body_stmt {(elseif_stmt else_stmt?) | (else_stmt premerge_stmt?)}
+  : IF paren_rhs_stmt body_stmt elseif_stmt? else_stmt?
 
 elseif_stmt
   :ELSE_IF paren_rhs_stmt body_stmt elseif_stmt?
 
 else_stmt
   : ELSE body_stmt
-
-premerge_stmt
-  : PREMERGE body_stmt
 </pre>
-
-The `premerge` option won't be typically used. It exists to cover the case where
-a block can exist in SPIR-V which comes before the merge block if a branch
-conditional but is run by both blocks in the branch conditional.
 
 ## Unless Statement ## {#unless-statement}
 


### PR DESCRIPTION
We've already forfeited perfect CFG round-trippability of SPIR-V because of the
lack of phi operations. So, now we're in a world of degrees, where we have to
decide whether a concept is important enough to be required to be exactly faithfully
preserved, or unimportant enough to allow the concept to be modified by the
round-trip.

The benefit of `premerge` is unclear, as it has yet to be demonstrated.
This concept doesn't exist in GLSL, HLSL, or MSL, so it is at least conceivable
that it is unnecessary.

On the other hand, it adds an unfamiliar keyword/block to the language,
which makes the language more difficult to read/write. Implementations will have to
implement it, test it thoroughly, figure out how to represent it in the platform
shading languages, and maintain it over time.

For `premerge` specifically, the current cost seems to outweigh the benefit, at least
until the benefit is demonstrated. This PR removes `premerge` until that happens.

closes https://github.com/gpuweb/gpuweb/issues/660