### PR TITLE
No explicit grammar for decorations

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -966,10 +966,13 @@ variable_decoration_list
   : ATTR_LEFT (variable_decoration COMMA)* variable_decoration ATTR_RIGHT
 
 variable_decoration
-  : LOCATION PAREN_LEFT INT_LITERAL PAREN_RIGHT
-  | BUILTIN PAREN_LEFT IDENT PAREN_RIGHT
-  | BINDING PAREN_LEFT INT_LITERAL PAREN_RIGHT
-  | SET PAREN_LEFT INT_LITERAL PAREN_RIGHT
+  : IDENT PAREN_LEFT literal_or_ident PAREN_RIGHT
+
+literal_or_ident
+  : FLOAT_LITERAL
+  | INT_LITERAL
+  | UINT_LITERAL
+  | IDENT
 </pre>
 
 <div class='example' heading="Variable Decorations">
@@ -983,7 +986,17 @@ variable_decoration
   </xmp>
 </div>
 
-See [[#builtin-variables]] for the decorations for specifying built-in variables.
+<table class='data'>
+  <thead>
+    <tr><td>Variable decoration keys<td>Valid values
+  </thead>
+  <tr><td>`binding`<td>u32 literal
+  <tr><td>`builtin`<td>a Builtin Decoration Identifier (listed below)
+  <tr><td>`location`<td>u32 literal
+  <tr><td>`set`<td>u32 literal
+</table>
+
+See [[#builtin-variables]] for the list of Builtin Decoration Identifiers.
 
 ## Module Constants ## {#module-constants}
 
@@ -2994,11 +3007,9 @@ Issue: (dneto) Default rounding mode is an implementation choice.  Is that what 
   <thead>
     <tr><td>Token<td>Definition
   </thead>
-  <tr><td>`BINDING`<td>binding
   <tr><td>`BITCAST`<td>bitcast
   <tr><td>`BLOCK`<td>block
   <tr><td>`BREAK`<td>break
-  <tr><td>`BUILTIN`<td>builtin
   <tr><td>`CASE`<td>case
   <tr><td>`COMPUTE`<td>compute
   <tr><td>`CONST`<td>const
@@ -3019,14 +3030,12 @@ Issue: (dneto) Default rounding mode is an implementation choice.  Is that what 
   <tr><td>`IMAGE`<td>image
   <tr><td>`IN`<td>in
   <tr><td>`INPUT`<td>input
-  <tr><td>`LOCATION`<td>location
   <tr><td>`LOOP`<td>loop
   <tr><td>`OFFSET`<td>offset
   <tr><td>`OUT`<td>out
   <tr><td>`OUTPUT`<td>output
   <tr><td>`PRIVATE`<td>private
   <tr><td>`RETURN`<td>return
-  <tr><td>`SET`<td>set
   <tr><td>`STAGE`<td>stage
   <tr><td>`STORAGE_BUFFER`<td>storage_buffer
   <tr><td>`STRIDE`<td>stride


### PR DESCRIPTION
Split into two parts, off of #655. This will need to be rebased after #655. 

Decorations can't be validated much at parse time, so they shouldn't be tightly specified in the grammar.

"[location 0, builtin 0]" =parsing=> "Error: Failed to parse token after `builtin`, expected IDENT."

"[location 0, builtin frag_coord]" =parsing=> OK =compilation=> "Error: `frag_coord` cannot be an output of a vertex entrypoint."

Since having it in the grammar doesn't really reduce the validation load on the compiler, we might as well not constrain it in the grammar. (even if this double-validation is cheap/free)