### PR TITLE
Remove regardless

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -434,7 +434,6 @@ Note: literals are parsed greedy. This means that for statements like `a -5`
   <tr><td>`POSITION`<td> position
   <tr><td>`PREMREGE`<td>premerge
   <tr><td>`PRIVATE`<td>private
-  <tr><td>`REGARDLESS`<td>regardless
   <tr><td>`RETURN`<td>return
   <tr><td>`SET`<td>set
   <tr><td>`STORAGE_BUFFER`<td>storage_buffer
@@ -476,7 +475,7 @@ The following is a list of keywords which are reserved for future expansion.
   <tr>
     <td>using
     <td>while
-    <td>
+    <td>regardless
     <td>
     <td>
 </table>
@@ -1000,7 +999,6 @@ statement
       OpReturnValue
   | if_stmt
   | unless_stmt
-  | regardless_stmt
   | switch_stmt
   | loop_stmt
   | variable_stmt SEMICOLON
@@ -1047,17 +1045,6 @@ conditional but is run by both blocks in the branch conditional.
 unless_stmt
   : UNLESS paren_rhs_stmt body_stmt
 </pre>
-
-## Regardless Statement ## {#regardless-statement}
-
-<pre class='def'>
-regardless_stmt
-  : REGARDLESS paren_rhs_stmt body_stmt
-</pre>
-
-The `regardless` statement will probably not be used in most cases but exists to
-handle a specific case in SPIR-V. If you have an `OpBranchConditional` where both
-targets are the same block.
 
 ## Switch Statement ## {#switch-statement}
 <pre class='def'>


### PR DESCRIPTION
We've already forfeited perfect CFG round-trippability of SPIR-V because of the
lack of phi operations. So, now we're in a world of degrees, where we have to
decide whether a concept is important enough to be required to be exactly faithfully
preserved, or unimportant enough to allow the concept to be modified by the
round-trip.

The benefit of `regardless` is unclear, as it has yet to be demonstrated.
This concept doesn't exist in GLSL, HLSL, or MSL, so it is at least conceivable
that it is unnecessary.

On the other hand, it adds an unfamiliar keyword/block to the language,
which makes the language more difficult to read/write. Implementations will have to
implement it, test it thoroughly, figure out how to represent it in the platform
shading languages, and maintain it over time.

For `regardless` specifically, the current cost seems to outweigh the benefit, at least
until the benefit is demonstrated. This PR removes `regardless` until that happens.

closes https://github.com/gpuweb/gpuweb/issues/580