### PR TITLE
Query API: Pipeline Statistics Query

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -802,7 +802,8 @@ allows additional usages of WebGPU that would have otherwise been invalid.
 
 <script type=idl>
 enum GPUExtensionName {
-    "texture-compression-bc"
+    "texture-compression-bc",
+    "pipeline-statistics-query"
 };
 </script>
 
@@ -2543,6 +2544,9 @@ interface mixin GPUProgrammablePassEncoder {
     void pushDebugGroup(DOMString groupLabel);
     void popDebugGroup();
     void insertDebugMarker(DOMString markerLabel);
+
+    void beginPipelineStatisticsQuery(GPUQuerySet querySet, GPUSize32 queryIndex);
+    void endPipelineStatisticsQuery(GPUQuerySet querySet, GPUSize32 queryIndex);
 };
 </script>
 
@@ -2800,7 +2804,8 @@ dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
 
 <script type=idl>
 enum GPUQueryType {
-    "occlusion"
+    "occlusion",
+    "pipeline-statistics"
 };
 </script>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2797,8 +2797,17 @@ GPUQuerySet includes GPUObjectBase;
 dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
     required GPUQueryType type;
     required GPUSize32 count;
+    GPUPipelineStatisticFlags pipelineStatistics;
 };
 </script>
+
+  * {{GPUQuerySetDescriptor/pipelineStatistics}}: a bitmask of {{GPUPipelineStatisticFlags}} specifying which pipeline statistics will be returned in the new query set.
+    |pipelineStatistics| is ignored if type is not {{GPUQueryType/pipeline-statistics}}.
+    <div class=validusage dfn-for=GPUQuerySetDescriptor.pipelineStatistics>
+      <dfn abstract-op>Valid Usage</dfn>
+        1. If {{GPUExtensionName/pipeline-statistics-query}} is not available, |type| must not be {{GPUQueryType/pipeline-statistics}}.
+        2. If |type| is {{GPUQueryType/pipeline-statistics}},  |pipelineStatistics| must be a valid combination of {{GPUPipelineStatisticFlags}} values.
+    </div>
 
 ## QueryType ## {#querytype}
 
@@ -2808,6 +2817,23 @@ enum GPUQueryType {
     "pipeline-statistics"
 };
 </script>
+
+## Pipeline Statistics Query ## {#pipeline-statistics}
+
+<script type=idl>
+typedef [EnforceRange] unsigned long GPUPipelineStatisticFlags;
+interface GPUPipelineStatisticBit {
+    const GPUPipelineStatisticFlags VERTEX_SHADER_INVOCATIONS   = 0x01;
+    const GPUPipelineStatisticFlags CLIPPER_INVOCATIONS         = 0x02;
+    const GPUPipelineStatisticFlags CLIPPER_PRIMITIVES_OUT      = 0x04;
+    const GPUPipelineStatisticFlags FRAGMENT_SHADER_INVOCATIONS = 0x08;
+    const GPUPipelineStatisticFlags COMPUTE_SHADER_INVOCATIONS  = 0x10;
+};
+</script>
+
+When resolving the results of a pipeline statistics query, the number of pipeline statistics written into GPU buffer depends on the number of enabled {{GPUPipelineStatisticBit}} in {{GPUQuerySetDescriptor/pipelineStatistics}}.
+
+Each result is written into unsigned 64-bit integer and in the order of the lowest-valued member of the {{GPUPipelineStatisticBit}} to the highest.
 
 
 # Canvas Rendering &amp; Swap Chains # {#canvas-rendering}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2810,7 +2810,7 @@ dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
       <dfn abstract-op>Valid Usage</dfn>
         1. |pipelineStatistics| is ignored if type is not {{GPUQueryType/pipeline-statistics}}.
         2. If {{GPUExtensionName/pipeline-statistics-query}} is not available, |type| must not be {{GPUQueryType/pipeline-statistics}}.
-        3. If |type| is {{GPUQueryType/pipeline-statistics}},  |pipelineStatistics| must be a set of {{GPUPipelineStatisticName}} values which cannot be duplicated.
+        3. If |type| is {{GPUQueryType/pipeline-statistics}},  |pipelineStatistics| must be a sequence of {{GPUPipelineStatisticName}} values which cannot be duplicated.
     </div>
 </dl>
 
@@ -2827,15 +2827,15 @@ enum GPUQueryType {
 
 <script type=idl>
 enum GPUPipelineStatisticName {
-    "vertex_shader_invocations",
-    "clipper_invocations",
-    "clipper_primitives_out",
-    "fragment_shader_invocations",
-    "compute_shader_invocations"
+    "vertex-shader-invocations",
+    "clipper-invocations",
+    "clipper-primitives-out",
+    "fragment-shader-invocations",
+    "compute-shader-invocations"
 };
 </script>
 
-When resolving the results of a pipeline statistics query, each result is written into unsigned 64-bit integer, and the number and order of pipeline statistics written into GPU buffer depends on the number and order of {{GPUPipelineStatisticName}} specified in {{GPUQuerySetDescriptor/pipelineStatistics}}.
+When resolving pipeline statistics query, each result is written into uint64, and the number and order of the results written to GPU buffer matches the number and order of {{GPUPipelineStatisticName}} specified in {{GPUQuerySetDescriptor/pipelineStatistics}}.
 
 
 # Canvas Rendering &amp; Swap Chains # {#canvas-rendering}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2797,17 +2797,22 @@ GPUQuerySet includes GPUObjectBase;
 dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
     required GPUQueryType type;
     required GPUSize32 count;
-    GPUPipelineStatisticFlags pipelineStatistics;
+    sequence<GPUPipelineStatisticName> pipelineStatistics = [];
 };
 </script>
 
-  * {{GPUQuerySetDescriptor/pipelineStatistics}}: a bitmask of {{GPUPipelineStatisticFlags}} specifying which pipeline statistics will be returned in the new query set.
-    |pipelineStatistics| is ignored if type is not {{GPUQueryType/pipeline-statistics}}.
+<dl dfn-type=dict-member dfn-for=GPUQuerySetDescriptor>
+    : <dfn>pipelineStatistics</dfn>
+    ::
+        The set of {{GPUPipelineStatisticName}} values in this sequence defines which pipeline statistics will be returned in the new query set.
+
     <div class=validusage dfn-for=GPUQuerySetDescriptor.pipelineStatistics>
       <dfn abstract-op>Valid Usage</dfn>
-        1. If {{GPUExtensionName/pipeline-statistics-query}} is not available, |type| must not be {{GPUQueryType/pipeline-statistics}}.
-        2. If |type| is {{GPUQueryType/pipeline-statistics}},  |pipelineStatistics| must be a valid combination of {{GPUPipelineStatisticFlags}} values.
+        1. |pipelineStatistics| is ignored if type is not {{GPUQueryType/pipeline-statistics}}.
+        2. If {{GPUExtensionName/pipeline-statistics-query}} is not available, |type| must not be {{GPUQueryType/pipeline-statistics}}.
+        3. If |type| is {{GPUQueryType/pipeline-statistics}},  |pipelineStatistics| must be a set of {{GPUPipelineStatisticName}} values which cannot be duplicated.
     </div>
+</dl>
 
 ## QueryType ## {#querytype}
 
@@ -2821,19 +2826,16 @@ enum GPUQueryType {
 ## Pipeline Statistics Query ## {#pipeline-statistics}
 
 <script type=idl>
-typedef [EnforceRange] unsigned long GPUPipelineStatisticFlags;
-interface GPUPipelineStatisticBit {
-    const GPUPipelineStatisticFlags VERTEX_SHADER_INVOCATIONS   = 0x01;
-    const GPUPipelineStatisticFlags CLIPPER_INVOCATIONS         = 0x02;
-    const GPUPipelineStatisticFlags CLIPPER_PRIMITIVES_OUT      = 0x04;
-    const GPUPipelineStatisticFlags FRAGMENT_SHADER_INVOCATIONS = 0x08;
-    const GPUPipelineStatisticFlags COMPUTE_SHADER_INVOCATIONS  = 0x10;
+enum GPUPipelineStatisticName {
+    "vertex_shader_invocations",
+    "clipper_invocations",
+    "clipper_primitives_out",
+    "fragment_shader_invocations",
+    "compute_shader_invocations"
 };
 </script>
 
-When resolving the results of a pipeline statistics query, the number of pipeline statistics written into GPU buffer depends on the number of enabled {{GPUPipelineStatisticBit}} in {{GPUQuerySetDescriptor/pipelineStatistics}}.
-
-Each result is written into unsigned 64-bit integer and in the order of the lowest-valued member of the {{GPUPipelineStatisticBit}} to the highest.
+When resolving the results of a pipeline statistics query, each result is written into unsigned 64-bit integer, and the number and order of pipeline statistics written into GPU buffer depends on the number and order of {{GPUPipelineStatisticName}} specified in {{GPUQuerySetDescriptor/pipelineStatistics}}.
 
 
 # Canvas Rendering &amp; Swap Chains # {#canvas-rendering}


### PR DESCRIPTION
Add extension and entrypoints for pipeline statistics query according to #614.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/haoxli/gpuweb/pull/691.html" title="Last updated on Apr 29, 2020, 10:50 AM UTC (ea1cb3b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/691/fd27b88...haoxli:ea1cb3b.html" title="Last updated on Apr 29, 2020, 10:50 AM UTC (ea1cb3b)">Diff</a>