### PR TITLE
Allow e.g. `if (cond) break/continue/return/kill;` without brackets.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -970,9 +970,24 @@ pipeline_stage
 ## Statements ## {#statements}
 
 <pre class='def'>
+branch_stmt
+  : RETURN logical_or_expression SEMICOLON
+      OpReturn
+      OpReturnValue
+  | break_stmt SEMICOLON
+  | continue_stmt SEMICOLON
+  | KILL SEMICOLON
+
 body_stmt:
   : BRACKET_LEFT statements BRACKET_RIGHT
+  | branch_stmt
+</pre>
 
+While `body_stmt` is generally `{ statements }`, it also allows omitting brackets around some control-flow statements.
+This can better preserve author intent for cases like `if (expr) break;`, where adding statements within the body block would have more semantic impact than expected.
+`if (condition) { break/continue/return; }` is a common pattern where where the body block is unnecessary, since when the first statement branches/jumps, further statements in that block are unreachable.
+
+<pre class='def'>
 paren_rhs_stmt
   : PAREN_LEFT logical_or_expression PAREN_RIGHT
 
@@ -981,18 +996,13 @@ statements
 
 statement
   : SEMICOLON
-  | RETURN logical_or_expression SEMICOLON
-      OpReturn
-      OpReturnValue
+  | NOP SEMICOLON
+  | keyword_stmt
   | if_stmt
   | unless_stmt
   | switch_stmt
   | loop_stmt
   | variable_stmt SEMICOLON
-  | break_stmt SEMICOLON
-  | continue_stmt SEMICOLON
-  | KILL SEMICOLON
-  | NOP SEMICOLON
   | assignment_stmt SEMICOLON
 
 break_stmt
@@ -1025,6 +1035,7 @@ premerge_stmt
 The `premerge` option won't be typically used. It exists to cover the case where
 a block can exist in SPIR-V which comes before the merge block if a branch
 conditional but is run by both blocks in the branch conditional.
+
 
 ## Unless Statement ## {#unless-statement}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -996,13 +996,13 @@ statements
 
 statement
   : SEMICOLON
-  | NOP SEMICOLON
-  | keyword_stmt
+  | branch_stmt
   | if_stmt
   | unless_stmt
   | switch_stmt
   | loop_stmt
   | variable_stmt SEMICOLON
+  | NOP SEMICOLON
   | assignment_stmt SEMICOLON
 
 break_stmt
@@ -1035,7 +1035,6 @@ premerge_stmt
 The `premerge` option won't be typically used. It exists to cover the case where
 a block can exist in SPIR-V which comes before the merge block if a branch
 conditional but is run by both blocks in the branch conditional.
-
 
 ## Unless Statement ## {#unless-statement}
 


### PR DESCRIPTION
This can improve readability and intent-communication of e.g. `if (cond) break;`.
This comes from my own c++ style, where brackets are generally required,
except for (keyword) branch/jump statements.
We can choose to have a language with opinionated style and embed this
reasonable requirement into the grammar.