### PR TITLE
Add validation rules on copyTextureToTexture

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2489,7 +2489,6 @@ offset {{GPUOrigin3D}} in texels, used when copying data from or to a {{GPUTextu
 
   The following validation rules apply:
   - |textureCopyView|.{{GPUTextureCopyView/texture}} must be a [=valid=] {{GPUTexture}}.
-  - The {{GPUTexture/[[sampleCount]]}} of |textureCopyView|.{{GPUTextureCopyView/texture}} must be 1.
   - |textureCopyView|.{{GPUTextureCopyView/mipLevel}} must be less than the {{GPUTexture/[[mipLevelCount]]}} of
     |textureCopyView|.{{GPUTextureCopyView/texture}}.
   - If the |textureCopyView|.{{GPUTextureCopyView/texture}} is {{GPUTextureDimension/1d}} or {{GPUTextureDimension/3d}}:
@@ -2562,6 +2561,8 @@ WebGPU provides {{GPUCommandEncoder/copyBufferToTexture()}} for buffer-to-textur
 The following validation rules apply to both {{GPUCommandEncoder/copyBufferToTexture()}}
 and {{GPUCommandEncoder/copyTextureToBuffer()}}.
 
+[=Valid Texture Copy Range=] also applies to {{GPUCommandEncoder/copyTextureToTexture()}}.
+
 <div algorithm class=validusage>
 
 <dfn dfn>Valid Buffer Copy Range</dfn>
@@ -2598,8 +2599,6 @@ Given a {{GPUBufferCopyView}} |bufferCopyView|, a {{GPUTextureFormat}} |format| 
   For the texel block alignments:
   - |bufferCopyView|.{{GPUBufferCopyView/rowsPerImage}} must be a multiple of |blockHeight|.
   - |bufferCopyView|.{{GPUBufferCopyView/offset}} must be a multiple of |blockSize|.
-  - |copySize|.[=Extent3D/width=] must be a multiple of |blockWidth|.
-  - |copySize|.[=Extent3D/height=] must be a multiple of |blockHeight|.
 
   For other members in |bufferCopyView|:
   - If |copySize|.[=Extent3D/height=] is greater than 1:
@@ -2613,8 +2612,11 @@ Given a {{GPUBufferCopyView}} |bufferCopyView|, a {{GPUTextureFormat}} |format| 
 
 <dfn dfn>Valid Texture Copy Range</dfn>
 
-Given a {{GPUTextureCopyView}} |textureCopyView| and a {{GPUExtent3D}} |copySize|, the following
-validation rules apply:
+Given a {{GPUTextureCopyView}} |textureCopyView| and a {{GPUExtent3D}} |copySize|, let
+  - |blockWidth| be the [=texel block width=] of |textureCopyView|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
+  - |blockHeight| be the [=texel block height=] of |textureCopyView|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
+
+The following validation rules apply:
 
   - If the {{GPUTexture/[[dimension]]}} of |textureCopyView|.{{GPUTextureCopyView/texture}} is
     {{GPUTextureDimension/1d}}:
@@ -2624,6 +2626,8 @@ validation rules apply:
     - (|textureCopyView|.{{GPUTextureCopyView/origin}}.{{GPUOrigin3DDict/x}} + |copySize|.[=Extent3D/width=]) must be less than or equal to the width of the [=physical size=] of |textureCopyView|.{{GPUTextureCopyView/texture}} [=subresource=] at [=mipmap level=] {{GPUTextureCopyView/mipLevel}}.
     - (|textureCopyView|.{{GPUTextureCopyView/origin}}.{{GPUOrigin3DDict/y}} + |copySize|.[=Extent3D/height=]) must be less than or equal to the height of the [=physical size=] of |textureCopyView|.{{GPUTextureCopyView/texture}} [=subresource=] at [=mipmap level=] {{GPUTextureCopyView/mipLevel}}
     - (|textureCopyView|.{{GPUTextureCopyView/arrayLayer}} + |copySize|.[=Extent3D/depth=]) must be less than or equal to the depth of the [=Extent3D/depth=] of the |textureCopyView|.{{GPUTextureCopyView/texture}}.
+  - |copySize|.[=Extent3D/width=] must be a multiple of |blockWidth|.
+  - |copySize|.[=Extent3D/height=] must be a multiple of |blockHeight|.
 
 </div>
 
@@ -2676,6 +2680,7 @@ Given a {{GPUCommandEncoder}} |encoder| and the arguments {{GPUBufferCopyView}} 
   - |destination| must be [=valid=].
   - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}} must contain
     {{GPUTextureUsage/COPY_DST}}.
+  - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} must be 1.
 
   For the copy ranges:
   - [=Valid Buffer Copy Range=] applies to |source|, |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}
@@ -2721,6 +2726,7 @@ Given a {{GPUCommandEncoder}} |encoder| and the arguments {{GPUTextureCopyView}}
   - |source| must be [=valid=].
   - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}} must contain
     {{GPUTextureUsage/COPY_SRC}}.
+  - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} must be 1.
 
   For |destination|:
   - |destination| must be [=valid=].
@@ -2732,6 +2738,85 @@ Given a {{GPUCommandEncoder}} |encoder| and the arguments {{GPUTextureCopyView}}
   - [=Valid Texture Copy Range=] applies to |source| and |copySize|.
 
 </div>
+
+### <dfn method for=GPUCommandEncoder>copyTextureToTexture(source, destination, copySize)</dfn> ### {#GPUCommandEncoder-copyTextureToTexture}
+
+<div algorithm="GPUCommandEncoder.copyTextureToTexture">
+
+  **Arguments:**
+    - {{GPUTextureCopyView}} |source|
+    - {{GPUTextureCopyView}} |destination|
+    - {{GPUExtent3D}} |copySize|
+
+  **Returns:** void
+
+  Encode a command into the {{GPUCommandEncoder}} that copies data from a sub-region of one
+  or multiple continuous {{GPUTexture}} [=subresources=] to another sub-region of one or
+  multiple continuous {{GPUTexture}} [=subresources=].
+
+  |source| and |copySize| define the region of the source texture [=subresources=].
+
+  |destination| and |copySize| define the region of the destination texture [=subresources=].
+
+</div>
+
+<div algorithm class=validusage>
+
+<dfn abstract-op>copyTextureToTexture Valid Usage</dfn>
+
+Given a {{GPUCommandEncoder}} |encoder| and the arguments {{GPUTextureCopyView}} |source|,
+{{GPUTextureCopyView}} |destination|, {{GPUExtent3D}} |copySize|, let
+
+  - |copy on the whole subresource| be the copy whose parameters |source|, |destination| and |copySize| meets the following conditions:
+    - The width of the [=physical size=] of |source|.{{GPUTextureCopyView/texture}} [=subresource=] at [=mipmap level=] {{GPUTextureCopyView/mipLevel}} must be equal to |copySize|.[=Extent3D/width=].
+    - The height of the [=physical size=] of |source|.{{GPUTextureCopyView/texture}} [=subresource=] at [=mipmap level=] {{GPUTextureCopyView/mipLevel}} must be equal to |copySize|.[=Extent3D/height=].
+    - The depth of the [=physical size=] of |source|.{{GPUTextureCopyView/texture}} [=subresource=] at [=mipmap level=] {{GPUTextureCopyView/mipLevel}} must be equal to |copySize|.[=Extent3D/depth=].
+    - The width of the [=physical size=] of |destination|.{{GPUTextureCopyView/texture}} [=subresource=] at [=mipmap level=] {{GPUTextureCopyView/mipLevel}} must be equal to |copySize|.[=Extent3D/width=].
+    - The height of the [=physical size=] of |destination|.{{GPUTextureCopyView/texture}} [=subresource=] at [=mipmap level=] {{GPUTextureCopyView/mipLevel}} must be equal to |copySize|.[=Extent3D/height=].
+    - The depth of the [=physical size=] of |destination|.{{GPUTextureCopyView/texture}} [=subresource=] at [=mipmap level=] {{GPUTextureCopyView/mipLevel}} must be equal to |copySize|.[=Extent3D/depth=].
+
+The following validation rules apply:
+
+  For |encoder|:
+  - |encoder|.{{GPUCommandEncoder/copyTextureToTexture()}} must not be called when a {{GPURenderPassEncoder}}
+    is active on |encoder|.
+  - |encoder|.{{GPUCommandEncoder/copyTextureToTexture()}} must not be called when a {{GPUComputePassEncoder}}
+    is active on |encoder|.
+
+  For |source|:
+  - |source| must be [=valid=].
+  - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}} must contain
+    {{GPUTextureUsage/COPY_SRC}}.
+
+  For |destination|:
+  - |destination| must be [=valid=].
+  - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}} must contain
+    {{GPUTextureUsage/COPY_DST}}.
+
+  For the texture {{GPUTexture/[[sampleCount]]}}:
+  - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} must be equal to |destination|.
+    {{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}}.
+  - If |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is greater than 1:
+    - The copy with |source|, |destination| and |copySize| must be a |copy on the whole subresource|.
+
+  For the texture {{GPUTexture/[[format]]}}:
+  - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} must be equal to |destination|.
+    {{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
+  - If |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format:
+    - The copy with |source|, |destination| and |copySize| must be a |copy on the whole subresource|.
+
+  For the copy ranges:
+  - [=Valid Texture Copy Range=] applies to |source| and |copySize|.
+  - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
+  - The texture [=subresource=] represented by |source|.{{GPUTextureCopyView/texture}},
+    |source|.{{GPUTextureCopyView/mipLevel}} and |source|.{{GPUTextureCopyView/arrayLayer}} must be different
+    from the texture [=subresource=] represented by |destination|.{{GPUTextureCopyView/texture}},
+    |destination|.{{GPUTextureCopyView/mipLevel}} and |destination|.{{GPUTextureCopyView/arrayLayer}}.
+
+</dfn>
+
+</div>
+
 
 ## Programmable Passes ## {#programmable-passes}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2561,13 +2561,25 @@ WebGPU provides {{GPUCommandEncoder/copyBufferToTexture()}} for buffer-to-textur
 The following definitions and validation rules apply to both {{GPUCommandEncoder/copyBufferToTexture()}}
 and {{GPUCommandEncoder/copyTextureToBuffer()}}.
 
-The definition [=textureCopyView subresource size=] and the validation rules in [=Valid Texture Copy Range=] also applies to
+[=textureCopyView subresource size=] and [=Valid Texture Copy Range=] also applies to
 {{GPUCommandEncoder/copyTextureToTexture()}}.
 
-The <dfn dfn>textureCopyView subresource size</dfn> of a {{GPUTextureCopyView}} |textureCopyView| is a {{GPUExtent3D}} whose:
- - [=Extent3D/width=] is the width of the [=physical size=] of |textureCopyView|.{{GPUTextureCopyView/texture}} [=subresource=] at [=mipmap level=] |textureCopyView|.{{GPUTextureCopyView/mipLevel}}.
- - [=Extent3D/height=] is the height of the [=physical size=] of |textureCopyView|.{{GPUTextureCopyView/texture}} [=subresource=] at [=mipmap level=] |textureCopyView|.{{GPUTextureCopyView/mipLevel}}.
- - [=Extent3D/depth=] is the depth of the [=physical size=] of |textureCopyView|.{{GPUTextureCopyView/texture}} [=subresource=].
+<div algorithm="textureCopyView subresource size">
+
+<dfn dfn>textureCopyView subresource size</dfn>
+
+  **Arguments:**
+    - {{GPUTextureCopyView}} |textureCopyView|
+
+  **Returns:**
+    - {{GPUExtent3D}}
+
+  The [=textureCopyView subresource size=] of |textureCopyView| is calculated in the following steps:
+  - Its [=Extent3D/width=] is the width of the [=physical size=] of |textureCopyView|.{{GPUTextureCopyView/texture}} [=subresource=] at [=mipmap level=] |textureCopyView|.{{GPUTextureCopyView/mipLevel}}.
+  - Its [=Extent3D/height=] is the height of the [=physical size=] of |textureCopyView|.{{GPUTextureCopyView/texture}} [=subresource=] at [=mipmap level=] |textureCopyView|.{{GPUTextureCopyView/mipLevel}}.
+  - Its [=Extent3D/depth=] is the depth of the [=physical size=] of |textureCopyView|.{{GPUTextureCopyView/texture}} [=subresource=].
+
+</div>
 
 <div algorithm class=validusage>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2558,10 +2558,16 @@ dictionary GPUImageBitmapCopyView {
 WebGPU provides {{GPUCommandEncoder/copyBufferToTexture()}} for buffer-to-texture copies and
 {{GPUCommandEncoder/copyTextureToBuffer()}} for texture-to-buffer copies.
 
-The following validation rules apply to both {{GPUCommandEncoder/copyBufferToTexture()}}
+The following definitions and validation rules apply to both {{GPUCommandEncoder/copyBufferToTexture()}}
 and {{GPUCommandEncoder/copyTextureToBuffer()}}.
 
-[=Valid Texture Copy Range=] also applies to {{GPUCommandEncoder/copyTextureToTexture()}}.
+The definition [=textureCopyView subresource size=] and the validation rules in [=Valid Texture Copy Range=] also applies to
+{{GPUCommandEncoder/copyTextureToTexture()}}.
+
+The <dfn dfn>textureCopyView subresource size</dfn> of a {{GPUTextureCopyView}} |textureCopyView| is a {{GPUExtent3D}} whose:
+ - [=Extent3D/width=] is the width of the [=physical size=] of |textureCopyView|.{{GPUTextureCopyView/texture}} [=subresource=] at [=mipmap level=] |textureCopyView|.{{GPUTextureCopyView/mipLevel}}.
+ - [=Extent3D/height=] is the height of the [=physical size=] of |textureCopyView|.{{GPUTextureCopyView/texture}} [=subresource=] at [=mipmap level=] |textureCopyView|.{{GPUTextureCopyView/mipLevel}}.
+ - [=Extent3D/depth=] is the depth of the [=physical size=] of |textureCopyView|.{{GPUTextureCopyView/texture}} [=subresource=].
 
 <div algorithm class=validusage>
 
@@ -2623,9 +2629,9 @@ The following validation rules apply:
     - Both |copySize|.[=Extent3D/height=] and [=Extent3D/depth=] must be 1.
   - If the {{GPUTexture/[[dimension]]}} of |textureCopyView|.{{GPUTextureCopyView/texture}} is
     {{GPUTextureDimension/2d}}:
-    - (|textureCopyView|.{{GPUTextureCopyView/origin}}.{{GPUOrigin3DDict/x}} + |copySize|.[=Extent3D/width=]) must be less than or equal to the width of the [=physical size=] of |textureCopyView|.{{GPUTextureCopyView/texture}} [=subresource=] at [=mipmap level=] {{GPUTextureCopyView/mipLevel}}.
-    - (|textureCopyView|.{{GPUTextureCopyView/origin}}.{{GPUOrigin3DDict/y}} + |copySize|.[=Extent3D/height=]) must be less than or equal to the height of the [=physical size=] of |textureCopyView|.{{GPUTextureCopyView/texture}} [=subresource=] at [=mipmap level=] {{GPUTextureCopyView/mipLevel}}
-    - (|textureCopyView|.{{GPUTextureCopyView/arrayLayer}} + |copySize|.[=Extent3D/depth=]) must be less than or equal to the depth of the [=Extent3D/depth=] of the |textureCopyView|.{{GPUTextureCopyView/texture}}.
+    - (|textureCopyView|.{{GPUTextureCopyView/origin}}.{{GPUOrigin3DDict/x}} + |copySize|.[=Extent3D/width=]) must be less than or equal to the [=Extent3D/width=] of the [=textureCopyView subresource size=] of |textureCopyView|.
+    - (|textureCopyView|.{{GPUTextureCopyView/origin}}.{{GPUOrigin3DDict/y}} + |copySize|.[=Extent3D/height=]) must be less than or equal to the [=Extent3D/height=] of the [=textureCopyView subresource size=] of |textureCopyView|.
+    - (|textureCopyView|.{{GPUTextureCopyView/arrayLayer}} + |copySize|.[=Extent3D/depth=]) must be less than or equal to the [=Extent3D/depth=] of the [=textureCopyView subresource size=] of |textureCopyView|.
   - |copySize|.[=Extent3D/width=] must be a multiple of |blockWidth|.
   - |copySize|.[=Extent3D/height=] must be a multiple of |blockHeight|.
 
@@ -2767,13 +2773,9 @@ Given a {{GPUCommandEncoder}} |encoder| and the arguments {{GPUTextureCopyView}}
 Given a {{GPUCommandEncoder}} |encoder| and the arguments {{GPUTextureCopyView}} |source|,
 {{GPUTextureCopyView}} |destination|, {{GPUExtent3D}} |copySize|, let
 
-  - |copy on the whole subresource| be the copy whose parameters |source|, |destination| and |copySize| meets the following conditions:
-    - The width of the [=physical size=] of |source|.{{GPUTextureCopyView/texture}} [=subresource=] at [=mipmap level=] {{GPUTextureCopyView/mipLevel}} must be equal to |copySize|.[=Extent3D/width=].
-    - The height of the [=physical size=] of |source|.{{GPUTextureCopyView/texture}} [=subresource=] at [=mipmap level=] {{GPUTextureCopyView/mipLevel}} must be equal to |copySize|.[=Extent3D/height=].
-    - The depth of the [=physical size=] of |source|.{{GPUTextureCopyView/texture}} [=subresource=] at [=mipmap level=] {{GPUTextureCopyView/mipLevel}} must be equal to |copySize|.[=Extent3D/depth=].
-    - The width of the [=physical size=] of |destination|.{{GPUTextureCopyView/texture}} [=subresource=] at [=mipmap level=] {{GPUTextureCopyView/mipLevel}} must be equal to |copySize|.[=Extent3D/width=].
-    - The height of the [=physical size=] of |destination|.{{GPUTextureCopyView/texture}} [=subresource=] at [=mipmap level=] {{GPUTextureCopyView/mipLevel}} must be equal to |copySize|.[=Extent3D/height=].
-    - The depth of the [=physical size=] of |destination|.{{GPUTextureCopyView/texture}} [=subresource=] at [=mipmap level=] {{GPUTextureCopyView/mipLevel}} must be equal to |copySize|.[=Extent3D/depth=].
+  - A |copy of the whole subresource| be the command |encoder|.{{GPUCommandEncoder/copyTextureToTexture()}} whose parameters |source|, |destination| and |copySize| meet the following conditions:
+    - The [=textureCopyView subresource size=] of |source| must be equal to |copySize|.
+    - The [=textureCopyView subresource size=] of |destination| must be equal to |copySize|.
 
 The following validation rules apply:
 
@@ -2797,21 +2799,19 @@ The following validation rules apply:
   - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} must be equal to |destination|.
     {{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}}.
   - If |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is greater than 1:
-    - The copy with |source|, |destination| and |copySize| must be a |copy on the whole subresource|.
+    - The copy with |source|, |destination| and |copySize| must be a |copy of the whole subresource|.
 
   For the texture {{GPUTexture/[[format]]}}:
   - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} must be equal to |destination|.
     {{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
   - If |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format:
-    - The copy with |source|, |destination| and |copySize| must be a |copy on the whole subresource|.
+    - The copy with |source|, |destination| and |copySize| must be a |copy of the whole subresource|.
 
   For the copy ranges:
   - [=Valid Texture Copy Range=] applies to |source| and |copySize|.
   - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
-  - The texture [=subresource=] represented by |source|.{{GPUTextureCopyView/texture}},
-    |source|.{{GPUTextureCopyView/mipLevel}} and |source|.{{GPUTextureCopyView/arrayLayer}} must be different
-    from the texture [=subresource=] represented by |destination|.{{GPUTextureCopyView/texture}},
-    |destination|.{{GPUTextureCopyView/mipLevel}} and |destination|.{{GPUTextureCopyView/arrayLayer}}.
+  - If |source|.{{GPUTextureCopyView/texture}} is the same as |destination|.{{GPUTextureCopyView/texture}}:
+    - Either |source|.{{GPUTextureCopyView/arrayLayer}} is not equal to |destination|.{{GPUTextureCopyView/arrayLayer}} or |source|.{{GPUTextureCopyView/mipLevel}} is not equal to |destination|.{{GPUTextureCopyView/mipLevel}}.
 
 </dfn>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2574,10 +2574,11 @@ and {{GPUCommandEncoder/copyTextureToBuffer()}}.
   **Returns:**
     - {{GPUExtent3D}}
 
-  The [=textureCopyView subresource size=] of |textureCopyView| is calculated in the following steps:
-  - Its [=Extent3D/width=] is the width of the [=physical size=] of |textureCopyView|.{{GPUTextureCopyView/texture}} [=subresource=] at [=mipmap level=] |textureCopyView|.{{GPUTextureCopyView/mipLevel}}.
-  - Its [=Extent3D/height=] is the height of the [=physical size=] of |textureCopyView|.{{GPUTextureCopyView/texture}} [=subresource=] at [=mipmap level=] |textureCopyView|.{{GPUTextureCopyView/mipLevel}}.
-  - Its [=Extent3D/depth=] is the depth of the [=physical size=] of |textureCopyView|.{{GPUTextureCopyView/texture}} [=subresource=].
+  The [=textureCopyView subresource size=] of |textureCopyView| is calculated as follows:
+
+  Its [=Extent3D/width=], [=Extent3D/height=] and [=Extent3D/depth=] are the width, height, and depth, respectively,
+  of the [=physical size=] of |textureCopyView|.{{GPUTextureCopyView/texture}} [=subresource=] at [=mipmap level=]
+  |textureCopyView|.{{GPUTextureCopyView/mipLevel}}.
 
 </div>
 
@@ -2641,9 +2642,7 @@ The following validation rules apply:
     - Both |copySize|.[=Extent3D/height=] and [=Extent3D/depth=] must be 1.
   - If the {{GPUTexture/[[dimension]]}} of |textureCopyView|.{{GPUTextureCopyView/texture}} is
     {{GPUTextureDimension/2d}}:
-    - (|textureCopyView|.{{GPUTextureCopyView/origin}}.{{GPUOrigin3DDict/x}} + |copySize|.[=Extent3D/width=]) must be less than or equal to the [=Extent3D/width=] of the [=textureCopyView subresource size=] of |textureCopyView|.
-    - (|textureCopyView|.{{GPUTextureCopyView/origin}}.{{GPUOrigin3DDict/y}} + |copySize|.[=Extent3D/height=]) must be less than or equal to the [=Extent3D/height=] of the [=textureCopyView subresource size=] of |textureCopyView|.
-    - (|textureCopyView|.{{GPUTextureCopyView/arrayLayer}} + |copySize|.[=Extent3D/depth=]) must be less than or equal to the [=Extent3D/depth=] of the [=textureCopyView subresource size=] of |textureCopyView|.
+    - (|textureCopyView|.{{GPUTextureCopyView/origin}}.{{GPUOrigin3DDict/x}} + |copySize|.[=Extent3D/width=]), (|textureCopyView|.{{GPUTextureCopyView/origin}}.{{GPUOrigin3DDict/y}} + |copySize|.[=Extent3D/height=]) and (|textureCopyView|.{{GPUTextureCopyView/arrayLayer}} + |copySize|.[=Extent3D/depth=]) must be less than or equal to the [=Extent3D/width=], [=Extent3D/height=], and [=Extent3D/depth=], respectively, of the [=textureCopyView subresource size=] of |textureCopyView|.
   - |copySize|.[=Extent3D/width=] must be a multiple of |blockWidth|.
   - |copySize|.[=Extent3D/height=] must be a multiple of |blockHeight|.
 
@@ -2769,7 +2768,7 @@ Given a {{GPUCommandEncoder}} |encoder| and the arguments {{GPUTextureCopyView}}
   **Returns:** void
 
   Encode a command into the {{GPUCommandEncoder}} that copies data from a sub-region of one
-  or multiple continuous {{GPUTexture}} [=subresources=] to another sub-region of one or
+  or multiple contiguous {{GPUTexture}} [=subresources=] to another sub-region of one or
   multiple continuous {{GPUTexture}} [=subresources=].
 
   |source| and |copySize| define the region of the source texture [=subresources=].
@@ -2823,7 +2822,7 @@ The following validation rules apply:
   - [=Valid Texture Copy Range=] applies to |source| and |copySize|.
   - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
   - If |source|.{{GPUTextureCopyView/texture}} is the same as |destination|.{{GPUTextureCopyView/texture}}:
-    - Either |source|.{{GPUTextureCopyView/arrayLayer}} is not equal to |destination|.{{GPUTextureCopyView/arrayLayer}} or |source|.{{GPUTextureCopyView/mipLevel}} is not equal to |destination|.{{GPUTextureCopyView/mipLevel}}.
+    - The [=subresource=] at [=mipmap level=] |source|.{{GPUTextureCopyView/mipLevel}} and [=array layer=] |source|.{{GPUTextureCopyView/arrayLayer}} must be different from the [=subresource=] at [=mipmap level=] |destination|.{{GPUTextureCopyView/mipLevel}} and [=array layer=] |destination|.{{GPUTextureCopyView/arrayLayer}}.
 
 </dfn>
 


### PR DESCRIPTION
This patch adds the validation rules on copyTextureToTexture:

- Updated "GPUTextureCopyView Valid Usage" and "Valid Texture Copy
  Range" to reuse them in the validations of copyTextureToTexture.
- The format of the source texture must be the same as the one of
  the destination texture as is required on Metal.
- We can only copy the whole subresource when the textures are in
  depth-stencil formats or the textures are multisampled as is
  required by D3D12.
- The source and destination subresources must be different as is
  required by D3D12.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Jiawei-Shao/gpuweb/pull/725.html" title="Last updated on Apr 29, 2020, 7:11 AM UTC (635e554)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/725/d05d63c...Jiawei-Shao:635e554.html" title="Last updated on Apr 29, 2020, 7:11 AM UTC (635e554)">Diff</a>