### PR TITLE
Merge GPUTextureCopyView.arrayLayer into .origin.z

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -388,7 +388,7 @@ Textures may consist of separate [=mipmap levels=] and [=array layers=],
 which can be used differently at any given time.
 Each such <dfn dfn>subresource</dfn> is uniquely identified by a
 [=texture=], [=mipmap level=], and
-(if it is not {{GPUTextureDimension/3d}}) [=array layer=].
+(for {{GPUTextureDimension/2d}} textures only) [=array layer=].
 
 The **main usage rule** is that any [=subresource=]
 at any given time can only be in either:
@@ -3217,12 +3217,9 @@ The following validation rules apply:
               - The [=subresource=] of |textureCopyView|.{{GPUTextureCopyView/texture}} at
                 [=mipmap level=] |textureCopyView|.{{GPUTextureCopyView/mipLevel}} and
                 [=array layer=] |arrayLayer|.
-      - If |textureCopyView|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[dimension]]}}
-        is {{GPUTextureDimension/"3d"}}:
+      - Otherwise:
           - The [=subresource=] of |textureCopyView|.{{GPUTextureCopyView/texture}} at
             [=mipmap level=] |textureCopyView|.{{GPUTextureCopyView/mipLevel}}.
-
-    Issue: Define for {{GPUTextureDimension/"1d"}}.
 </div>
 
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -385,8 +385,10 @@ which can be split into two groups:
 Issue(gpuweb/gpuweb#296): Consider merging all read-only usages.
 
 Textures may consist of separate [=mipmap levels=] and [=array layers=],
-which can be used differently at any given time. For the matter of usage validation,
-we'll call them <dfn dfn>subresources</dfn>.
+which can be used differently at any given time.
+Each such <dfn dfn>subresource</dfn> is uniquely identified by a
+[=texture=], [=mipmap level=], and
+(if it is not {{GPUTextureDimension/3d}}) [=array layer=].
 
 The **main usage rule** is that any [=subresource=]
 at any given time can only be in either:
@@ -2866,8 +2868,8 @@ offset {{GPUOrigin3D}} in texels, used when copying data from or to a {{GPUTextu
   - |textureCopyView|.{{GPUTextureCopyView/texture}} must be a [=valid=] {{GPUTexture}}.
   - |textureCopyView|.{{GPUTextureCopyView/mipLevel}} must be less than the {{GPUTexture/[[mipLevelCount]]}} of
     |textureCopyView|.{{GPUTextureCopyView/texture}}.
-  - |textureCopyView|.{{GPUTextureCopyView/origin}}.{{GPUOrigin3DDict/x}} must be a multiple of |blockWidth|.
-  - |textureCopyView|.{{GPUTextureCopyView/origin}}.{{GPUOrigin3DDict/y}} must be a multiple of |blockHeight|.
+  - |textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/x=] must be a multiple of |blockWidth|.
+  - |textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/y=] must be a multiple of |blockHeight|.
 
 </div>
 
@@ -3015,12 +3017,12 @@ The following validation rules apply:
     - Both |copySize|.[=Extent3D/height=] and [=Extent3D/depth=] must be 1.
   - If the {{GPUTexture/[[dimension]]}} of |textureCopyView|.{{GPUTextureCopyView/texture}} is
     {{GPUTextureDimension/2d}}:
-    - (|textureCopyView|.{{GPUTextureCopyView/origin}}.{{GPUOrigin3DDict/x}} + |copySize|.[=Extent3D/width=]),
-      (|textureCopyView|.{{GPUTextureCopyView/origin}}.{{GPUOrigin3DDict/y}} + |copySize|.[=Extent3D/height=]), and
-      (|textureCopyView|.{{GPUTextureCopyView/origin}}.{{GPUOrigin3DDict/z}} + |copySize|.[=Extent3D/depth=])
-      must be less than or equal to the
-      [=Extent3D/width=], [=Extent3D/height=], and [=Extent3D/depth=], respectively,
-      of the [=textureCopyView subresource size=] of |textureCopyView|.
+     -  (|textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/x=] + |copySize|.[=Extent3D/width=]),
+        (|textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/y=] + |copySize|.[=Extent3D/height=]), and
+        (|textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/z=] + |copySize|.[=Extent3D/depth=])
+        must be less than or equal to the
+        [=Extent3D/width=], [=Extent3D/height=], and [=Extent3D/depth=], respectively,
+        of the [=textureCopyView subresource size=] of |textureCopyView|.
   - |copySize|.[=Extent3D/width=] must be a multiple of |blockWidth|.
   - |copySize|.[=Extent3D/height=] must be a multiple of |blockHeight|.
 
@@ -3160,7 +3162,7 @@ Given a {{GPUCommandEncoder}} |encoder| and the arguments {{GPUTextureCopyView}}
 <dfn abstract-op>copyTextureToTexture Valid Usage</dfn>
 
 Given a {{GPUCommandEncoder}} |encoder| and the arguments {{GPUTextureCopyView}} |source|,
-{{GPUTextureCopyView}} |destination|, {{GPUExtent3D}} |copySize|, let
+{{GPUTextureCopyView}} |destination|, {{GPUExtent3D}} |copySize|, let:
 
   - A |copy of the whole subresource| be the command |encoder|.{{GPUCommandEncoder/copyTextureToTexture()}} whose parameters |source|, |destination| and |copySize| meet the following conditions:
     - The [=textureCopyView subresource size=] of |source| must be equal to |copySize|.
@@ -3199,11 +3201,28 @@ The following validation rules apply:
   For the copy ranges:
   - [=Valid Texture Copy Range=] applies to |source| and |copySize|.
   - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
-  - If |source|.{{GPUTextureCopyView/texture}} is the same as |destination|.{{GPUTextureCopyView/texture}}:
-    - The [=subresource=] at [=mipmap level=] |source|.{{GPUTextureCopyView/mipLevel}} and [=array layer=] |source|.{{GPUTextureCopyView/arrayLayer}} must be different from the [=subresource=] at [=mipmap level=] |destination|.{{GPUTextureCopyView/mipLevel}} and [=array layer=] |destination|.{{GPUTextureCopyView/arrayLayer}}.
+  - The [$set of subresources for texture copy$](|source|, |copySize|) and
+     the  [$set of subresources for texture copy$](|destination|, |copySize|) must be disjoint.
 
-</dfn>
+</div>
 
+<div algorithm>
+    The <dfn abstract-op>set of subresources for texture copy</dfn>(|textureCopyView|, |copySize|)
+    is the set containing:
+
+      - If |textureCopyView|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[dimension]]}}
+        is {{GPUTextureDimension/"2d"}}:
+          - For each |arrayLayer| of the |copySize|.[=Extent3D/depth=] [=array layers=]
+            starting at |textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/z=]:
+              - The [=subresource=] of |textureCopyView|.{{GPUTextureCopyView/texture}} at
+                [=mipmap level=] |textureCopyView|.{{GPUTextureCopyView/mipLevel}} and
+                [=array layer=] |arrayLayer|.
+      - If |textureCopyView|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[dimension]]}}
+        is {{GPUTextureDimension/"3d"}}:
+          - The [=subresource=] of |textureCopyView|.{{GPUTextureCopyView/texture}} at
+            [=mipmap level=] |textureCopyView|.{{GPUTextureCopyView/mipLevel}}.
+
+    Issue: Define for {{GPUTextureDimension/"1d"}}.
 </div>
 
 
@@ -3648,6 +3667,24 @@ dictionary GPUOrigin3DDict {
 typedef (sequence<GPUIntegerCoordinate> or GPUOrigin3DDict) GPUOrigin3D;
 </script>
 
+An <dfn dfn>Origin3D</dfn> is a {{GPUOrigin3D}}.
+[=Origin3D=] is a spec namespace for the following definitions:
+<!-- This is silly, but provides convenient syntax for the spec. -->
+
+<div algorithm="GPUOrigin3D accessors" dfn-for=Origin3D>
+    For a given {{GPUOrigin3D}} value |origin|, depending on its type, the syntax:
+
+      - |origin|.<dfn dfn>x</dfn> refers to
+        either {{GPUOrigin3DDict}}.{{GPUOrigin3DDict/x}}
+        or the first item of the sequence.
+      - |origin|.<dfn dfn>y</dfn> refers to
+        either {{GPUOrigin3DDict}}.{{GPUOrigin3DDict/y}}
+        or the second item of the sequence.
+      - |origin|.<dfn dfn>z</dfn> refers to
+        either {{GPUOrigin3DDict}}.{{GPUOrigin3DDict/z}}
+        or the third item of the sequence.
+</div>
+
 <script type=idl>
 dictionary GPUExtent3DDict {
     required GPUIntegerCoordinate width;
@@ -3664,13 +3701,13 @@ An <dfn dfn>Extent3D</dfn> is a {{GPUExtent3D}}.
 <div algorithm="GPUExtent3D accessors" dfn-for=Extent3D>
     For a given {{GPUExtent3D}} value |extent|, depending on its type, the syntax:
 
-      * |extent|.<dfn dfn>width</dfn> refers to
+      - |extent|.<dfn dfn>width</dfn> refers to
         either {{GPUExtent3DDict}}.{{GPUExtent3DDict/width}}
         or the first item of the sequence.
-      * |extent|.<dfn dfn>height</dfn> refers to
+      - |extent|.<dfn dfn>height</dfn> refers to
         either {{GPUExtent3DDict}}.{{GPUExtent3DDict/height}}
         or the second item of the sequence.
-      * |extent|.<dfn dfn>depth</dfn> refers to
+      - |extent|.<dfn dfn>depth</dfn> refers to
         either {{GPUExtent3DDict}}.{{GPUExtent3DDict/depth}}
         or the third item of the sequence.
 </div>
@@ -3688,5 +3725,3 @@ and {{ArrayBuffer}}, respectively.
 Eventually all of these should disappear but they are useful to avoid warning while building the specification.
 
 [=vertex buffer=]
-[=Extent3D/width=]
-[=Extent3D/height=]

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2469,7 +2469,6 @@ Given a {{GPUBufferCopyView}} |bufferCopyView|, the following validation rules a
 dictionary GPUTextureCopyView {
     required GPUTexture texture;
     GPUIntegerCoordinate mipLevel = 0;
-    GPUIntegerCoordinate arrayLayer = 0;
     GPUOrigin3D origin = {};
 };
 </script>
@@ -2492,8 +2491,6 @@ offset {{GPUOrigin3D}} in texels, used when copying data from or to a {{GPUTextu
   - The {{GPUTexture/[[sampleCount]]}} of |textureCopyView|.{{GPUTextureCopyView/texture}} must be 1.
   - |textureCopyView|.{{GPUTextureCopyView/mipLevel}} must be less than the {{GPUTexture/[[mipLevelCount]]}} of
     |textureCopyView|.{{GPUTextureCopyView/texture}}.
-  - If the |textureCopyView|.{{GPUTextureCopyView/texture}} is {{GPUTextureDimension/1d}} or {{GPUTextureDimension/3d}}:
-    - |textureCopyView|.{{GPUTextureCopyView/arrayLayer}} must be zero.
   - |textureCopyView|.{{GPUTextureCopyView/origin}}.{{GPUOrigin3DDict/x}} must be a multiple of |blockWidth|.
   - |textureCopyView|.{{GPUTextureCopyView/origin}}.{{GPUOrigin3DDict/y}} must be a multiple of |blockHeight|.
 
@@ -2623,7 +2620,7 @@ validation rules apply:
     {{GPUTextureDimension/2d}}:
     - (|textureCopyView|.{{GPUTextureCopyView/origin}}.{{GPUOrigin3DDict/x}} + |copySize|.[=Extent3D/width=]) must be less than or equal to the width of the [=physical size=] of |textureCopyView|.{{GPUTextureCopyView/texture}} [=subresource=] at [=mipmap level=] {{GPUTextureCopyView/mipLevel}}.
     - (|textureCopyView|.{{GPUTextureCopyView/origin}}.{{GPUOrigin3DDict/y}} + |copySize|.[=Extent3D/height=]) must be less than or equal to the height of the [=physical size=] of |textureCopyView|.{{GPUTextureCopyView/texture}} [=subresource=] at [=mipmap level=] {{GPUTextureCopyView/mipLevel}}
-    - (|textureCopyView|.{{GPUTextureCopyView/arrayLayer}} + |copySize|.[=Extent3D/depth=]) must be less than or equal to the depth of the [=Extent3D/depth=] of the |textureCopyView|.{{GPUTextureCopyView/texture}}.
+    - (|textureCopyView|.{{GPUTextureCopyView/origin}}.{{GPUOrigin3DDict/z}} + |copySize|.[=Extent3D/depth=]) must be less than or equal to the depth of the [=Extent3D/depth=] of the |textureCopyView|.{{GPUTextureCopyView/texture}}.
 
 </div>
 


### PR DESCRIPTION
Similar to what was done for GPUTextureDescriptor in #613, I just missed it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/730.html" title="Last updated on May 8, 2020, 5:53 PM UTC (615fa8f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/730/be26167...kainino0x:615fa8f.html" title="Last updated on May 8, 2020, 5:53 PM UTC (615fa8f)">Diff</a>