### PR TITLE
Read-only depth-stencil pass

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2877,9 +2877,11 @@ dictionary GPURenderPassDepthStencilAttachmentDescriptor {
 
     required (GPULoadOp or float) depthLoadValue;
     required GPUStoreOp depthStoreOp;
+    boolean depthReadOnly = false;
 
     required (GPULoadOp or GPUStencilValue) stencilLoadValue;
     required GPUStoreOp stencilStoreOp;
+    boolean stencilReadOnly = false;
 };
 </script>
 


### PR DESCRIPTION
Fixes #514 

This is a strawman proposal to solve the use case explained in https://github.com/gpuweb/gpuweb/issues/514#issuecomment-623047982

If the depth in a render pass is read-only, its usage allows it also be used as a shader-accessible texture in this pass.

Obviously the spec will need to explain how this works. Filed #745 for more general introduction of the "shadow" usage bits.

Edit - unresolved questions:
- [ ] whether the group agrees this is needed
- [x] mini-investigation on the platform support of this feature - https://github.com/gpuweb/gpuweb/issues/514#issuecomment-628925960
- [ ] whether we can have separate flags for depth and stencil, or just one for combined
- [ ] spec wording for the usage validation


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/746.html" title="Last updated on May 19, 2020, 1:27 PM UTC (83d11a9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/746/3c7143a...83d11a9.html" title="Last updated on May 19, 2020, 1:27 PM UTC (83d11a9)">Diff</a>