### PR TITLE
Specifies the state machine of GPUCommandEncoder

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1231,11 +1231,11 @@ once all previously submitted operations using it are complete.
 <div algorithm="GPUBuffer.destroy">
   <strong>|this|:</strong> of type {{GPUBuffer}}.
 
-  1. If the |this|.{{[[state]]}} is [=buffer state/mapped=] or [=buffer state/mapped at creation=]:
+  1. If the |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapped=] or [=buffer state/mapped at creation=]:
 
     1. Run the steps to unmap |this|
 
-  1. Set |this|.{{[[state]]}} to [=buffer state/destroyed=]
+  1. Set |this|.{{GPUBuffer/[[state]]}} to [=buffer state/destroyed=]
 
   Issue: Handle error buffers once we have a description of the error monad.
 </div>
@@ -1286,15 +1286,15 @@ Issue(gpuweb/gpuweb#605): Add client-side validation that a mapped buffer can
 
   1. Let |p| be a new {{Promise}}.
   1. Set |this|.{{[[mapping]]}} to |p|.
-  1. Set |this|.{{[[state]]}} to [=buffer state/mapping pending=].
+  1. Set |this|.{{GPUBuffer/[[state]]}} to [=buffer state/mapping pending=].
   1. Enqueue an operation on the default queue's [=Queue timeline=] that will execute the following:
 
-     1. If |this|.{{[[state]]}} is [=buffer state/mapping pending=]:
+     1. If |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapping pending=]:
 
         1. Let |m| be a new {{ArrayBuffer}} of size |size|.
         1. Set the content of |m| to the content of |this|'s allocation starting at offset |offset| and for |size| bytes.
         1. Set |this|.{{[[mapping]]}} to |m|.
-        1. Set |this|.{{[[state]]}} to [=buffer state/mapped=].
+        1. Set |this|.{{GPUBuffer/[[state]]}} to [=buffer state/mapped=].
         1. Set |this|.{{[[mapping_range]]}} to `[start, offset]`.
         1. Set |this|.{{[[mapped_ranges]]}} to `[]`.
         1. Resolve |p|.
@@ -1312,7 +1312,7 @@ Issue(gpuweb/gpuweb#605): Add client-side validation that a mapped buffer can
       1. |size| must be a multiple of 4.
       1. |offset| + |size| must be less or equal to |this|.{{[[size]]}}
       1. |this|.{{[[usage]]}} must contain {{GPUBufferUsage/MAP_READ}} or {{GPUBufferUsage/MAP_WRITE}}.
-      1. |this|.{{[[state]]}} must be [=buffer state/unmapped=]
+      1. |this|.{{GPUBuffer/[[state]]}} must be [=buffer state/unmapped=]
 
     </dfn>
   </div>
@@ -1343,7 +1343,7 @@ Issue(gpuweb/gpuweb#605): Add client-side validation that a mapped buffer can
       Given a {{GPUBuffer}} |this|, a {{GPUSize64}} |offset| and a {{GPUSize64}} |size|
       the following validation rules apply:
 
-      1. |this|.{{[[state]]}} must be [=buffer state/mapped=] or [=buffer state/mapped at creation=].
+      1. |this|.{{GPUBuffer/[[state]]}} must be [=buffer state/mapped=] or [=buffer state/mapped at creation=].
       1. |offset| must be a multiple of 8.
       1. |size| must be a multiple of 4.
       1. |offset| must be greater than or equal to |this|.{{[[mapping_range]]}}[0].
@@ -1367,17 +1367,17 @@ Issue(gpuweb/gpuweb#605): Add client-side validation that a mapped buffer can
     1. Record a validation error on the current scope.
     1. Return.
 
-  1. If |this|.{{[[state]]}} is [=buffer state/mapping pending=]:
+  1. If |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapping pending=]:
 
     1. [=Reject=] {{[[mapping]]}} with an {{OperationError}}.
     1. Set |this|.{{[[mapping]]}} to null.
 
-  1. If |this|.{{[[state]]}} is [=buffer state/mapped=] or [=buffer state/mapped at creation=]:
+  1. If |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapped=] or [=buffer state/mapped at creation=]:
 
     1. If one of the two following conditions holds:
 
-        1. |this|.{{[[state]]}} is [=buffer state/mapped at creation=]
-        1. |this|.{{[[state]]}} is [=buffer state/mapped=] and |this|.{{[[usage]]}} contains {{GPUBufferUsage/MAP_WRITE}}
+        1. |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapped at creation=]
+        1. |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapped=] and |this|.{{[[usage]]}} contains {{GPUBufferUsage/MAP_WRITE}}
 
     1. Then:
 
@@ -1389,7 +1389,7 @@ Issue(gpuweb/gpuweb#605): Add client-side validation that a mapped buffer can
     1. Set |this|.{{[[mapping_range]]}} to null.
     1. Set |this|.{{[[mapped_ranges]]}} to null.
 
-  1. Set |this|.{{[[state]]}} to [=buffer state/unmapped=].
+  1. Set |this|.{{GPUBuffer/[[state]]}} to [=buffer state/unmapped=].
 
   Note: When a {{GPUBufferUsage/MAP_READ}} buffer (not currently mapped at creation) is unmapped,
     any local modifications done by the application to the mapped ranges {{ArrayBuffer}} are
@@ -1400,8 +1400,8 @@ Issue(gpuweb/gpuweb#605): Add client-side validation that a mapped buffer can
 
       Given a {{GPUBuffer}} the following validation rules apply:
 
-      1. |this|.{{[[state]]}} must not be [=buffer state/unmapped=]
-      1. |this|.{{[[state]]}} must not be [=buffer state/destroyed=]
+      1. |this|.{{GPUBuffer/[[state]]}} must not be [=buffer state/unmapped=]
+      1. |this|.{{GPUBuffer/[[state]]}} must not be [=buffer state/destroyed=]
 
       Note: It is valid to unmap an error {{GPUBuffer}} that is [=buffer state/mapped at creation=] because
       the [=Content timeline=] might not know it is an error {{GPUBuffer}}.
@@ -3053,15 +3053,15 @@ which may be one of the following:
 <div class=note>
     {{GPUCommandEncoder}} has a state machine where the states are:
 
-     - {{encoder state/open}} when initially created until {{GPUComputePassEncoder/finish()}} is called and when the
+     - {{encoder state/open}} when initially created until {{GPUCommandEncoder/finish()}} is called and when the
         {{GPUCommandEncoder}} has no active {{GPURenderPassEncoder}} or {{GPUComputePassEncoder}}.
      - {{encoder state/encoding a render pass}} once {{GPUCommandEncoder/beginRenderPass()}} is called sucessfully
-        until {{GPURenderPassEncoder/finish()}} is called on the returned {{GPURenderPassEncoder}}, at which point the
-        [=encoder state=] reverts to {{encoder state/open}}.
+        until {{GPURenderPassEncoder/endPass()}} is called on the returned {{GPURenderPassEncoder}}, at which point the
+        state reverts to {{encoder state/open}}.
      - {{encoder state/encoding a compute pass}} once {{GPUCommandEncoder/beginComputePass()}} is called sucessfully
-        until {{GPUComputePassEncoder/finish()}} is called on the returned {{GPUComputePassEncoder}}, at which point the
-        [=encoder state=] reverts to {{encoder state/open}}.
-     - {{encoder state/closed}} once {{GPUComputePassEncoder/finish()}} is called or when the {{GPUCommandEncoder}} is
+        until {{GPUComputePassEncoder/endPass()}} is called on the returned {{GPUComputePassEncoder}}, at which point the
+        state reverts to {{encoder state/open}}.
+     - {{encoder state/closed}} once {{GPUCommandEncoder/finish()}} is called or when the {{GPUCommandEncoder}} is
         [=invalid=].
 </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3034,27 +3034,35 @@ GPUCommandEncoder includes GPUObjectBase;
 {{GPUCommandEncoder}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUCommandEncoder">
-    : <dfn>\[[state]]</dfn> of type [=encoder state=].
+    : <dfn>\[[state]]</dfn> of type {{encoder state}}.
     ::
-        The current state of the {{GPUCommandEncoder}}, initially set to [=encoder state/open=].
+        The current state of the {{GPUCommandEncoder}}, initially set to {{encoder state/open}}.
 </dl>
 
-Each {{GPUCommandEncoder}} has a current <dfn>encoder state</dfn> on the [=Content timeline=]
+Each {{GPUCommandEncoder}} has a current <dfn dfn-type="enum">encoder state</dfn> on the [=Content timeline=]
 which may be one of the following:
 
- - "<dfn for="encoder state">open</dfn>" where the {{GPUCommandEncoder}} is available to begin new operations.
- - "<dfn for="encoder state">recording a render pass</dfn>" where the {{GPUCommandEncoder}} has an active {{GPURenderPassEncoder}}.
- - "<dfn for="encoder state">recording a compute pass</dfn>" where the {{GPUCommandEncoder}} has an active {{GPUComputePassEncoder}}.
- - "<dfn for="encoder state">closed</dfn>" where the {{GPUCommandEncoder}} is
+ - "<dfn dfn-type="enum-value" for="encoder state">open</dfn>" where the {{GPUCommandEncoder}} is available to begin new operations.
+ - "<dfn dfn-type="enum-value" for="encoder state">encoding a render pass</dfn>" where the {{GPUCommandEncoder}} has an active
+    {{GPURenderPassEncoder}}.
+ - "<dfn dfn-type="enum-value" for="encoder state">encoding a compute pass</dfn>" where the {{GPUCommandEncoder}} has an active
+    {{GPUComputePassEncoder}}.
+ - "<dfn dfn-type="enum-value" for="encoder state">closed</dfn>" where the {{GPUCommandEncoder}} is
      no longer available for any operations.
 
 <div class=note>
     {{GPUCommandEncoder}} has a state machine where the states are:
 
-     - [=encoder state/open=] when initially created until {{GPUComputePassEncoder/finish()}} is called and when the {{GPUCommandEncoder}} has no active {{GPURenderPassEncoder}} or {{GPUComputePassEncoder}}.
-     - [=encoder state/recording a render pass=] once {{GPUCommandEncoder/beginRenderPass()}} is called sucessfully until {{GPURenderPassEncoder/finish()}} is called on the returned {{GPURenderPassEncoder}}, at which point the [=encoder state=] reverts to [=encoder state/open=].
-     - [=encoder state/recording a compute pass=] once {{GPUCommandEncoder/beginComputePass()}} is called sucessfully until {{GPUComputePassEncoder/finish()}} is called on the returned {{GPUComputePassEncoder}}, at which point the [=encoder state=] reverts to [=encoder state/open=].
-     - [=encoder state/closed=] once {{GPUComputePassEncoder/finish()}} is called or when the {{GPUCommandEncoder}} is [=invalid=].
+     - {{encoder state/open}} when initially created until {{GPUComputePassEncoder/finish()}} is called and when the
+        {{GPUCommandEncoder}} has no active {{GPURenderPassEncoder}} or {{GPUComputePassEncoder}}.
+     - {{encoder state/encoding a render pass}} once {{GPUCommandEncoder/beginRenderPass()}} is called sucessfully
+        until {{GPURenderPassEncoder/finish()}} is called on the returned {{GPURenderPassEncoder}}, at which point the
+        [=encoder state=] reverts to {{encoder state/open}}.
+     - {{encoder state/encoding a compute pass}} once {{GPUCommandEncoder/beginComputePass()}} is called sucessfully
+        until {{GPUComputePassEncoder/finish()}} is called on the returned {{GPUComputePassEncoder}}, at which point the
+        [=encoder state=] reverts to {{encoder state/open}}.
+     - {{encoder state/closed}} once {{GPUComputePassEncoder/finish()}} is called or when the {{GPUCommandEncoder}} is
+        [=invalid=].
 </div>
 
 ### Creation ### {#command-encoder-creation}
@@ -3178,7 +3186,7 @@ dictionary GPUImageBitmapCopyView {
 
         Given a {{GPUCommandEncoder}} |encoder| and the arguments {{GPUBuffer}} |source|, {{GPUSize64}} |sourceOffset|, {{GPUBuffer}} |destination|, {{GPUSize64}} |destinationOffset|, {{GPUSize64}} |size|, the following validation rules apply:
 
-          - |encoder|.{{GPUCommandEncoder/[[state]]}} must be [=encoder state/open=].
+          - |encoder|.{{GPUCommandEncoder/[[state]]}} must be {{encoder state/open}}.
           - |source| must be a [=valid=] {{GPUBuffer}}.
           - |destination| must be a [=valid=] {{GPUBuffer}}.
           - The {{GPUBuffer/[[usage]]}} of |source| must contain {{GPUBufferUsage/COPY_SRC}}.
@@ -3329,7 +3337,7 @@ Given a {{GPUCommandEncoder}} |encoder| and the arguments {{GPUBufferCopyView}} 
 {{GPUTextureCopyView}} |destination| and {{GPUExtent3D}} |copySize|, the following validation rules apply:
 
   For |encoder|:
-  - |encoder|.{{GPUCommandEncoder/[[state]]}} must be [=encoder state/open=].
+  - |encoder|.{{GPUCommandEncoder/[[state]]}} must be {{encoder state/open}}.
 
   For |source|:
   - |source| must be [=valid=].
@@ -3376,7 +3384,7 @@ Given a {{GPUCommandEncoder}} |encoder| and the arguments {{GPUTextureCopyView}}
 {{GPUBufferCopyView}} |destination|, {{GPUExtent3D}} |copySize|, the following validation rules apply:
 
   For |encoder|:
-  - |encoder|.{{GPUCommandEncoder/[[state]]}} must be [=encoder state/open=].
+  - |encoder|.{{GPUCommandEncoder/[[state]]}} must be {{encoder state/open}}.
 
   For |source|:
   - |source| must be [=valid=].
@@ -3430,7 +3438,7 @@ Given a {{GPUCommandEncoder}} |encoder| and the arguments {{GPUTextureCopyView}}
 The following validation rules apply:
 
   For |encoder|:
-  - |encoder|.{{GPUCommandEncoder/[[state]]}} must be [=encoder state/open=].
+  - |encoder|.{{GPUCommandEncoder/[[state]]}} must be {{encoder state/open}}.
 
   For |source|:
   - |source| must be [=valid=].

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3042,28 +3042,35 @@ GPUCommandEncoder includes GPUObjectBase;
 Each {{GPUCommandEncoder}} has a current <dfn dfn-type="enum">encoder state</dfn> on the [=Content timeline=]
 which may be one of the following:
 
- - "<dfn dfn-type="enum-value" for="encoder state">open</dfn>" where the {{GPUCommandEncoder}} is available to begin new operations.
- - "<dfn dfn-type="enum-value" for="encoder state">encoding a render pass</dfn>" where the {{GPUCommandEncoder}} has an active
-    {{GPURenderPassEncoder}}.
- - "<dfn dfn-type="enum-value" for="encoder state">encoding a compute pass</dfn>" where the {{GPUCommandEncoder}} has an active
-    {{GPUComputePassEncoder}}.
- - "<dfn dfn-type="enum-value" for="encoder state">closed</dfn>" where the {{GPUCommandEncoder}} is
-     no longer available for any operations.
+<dl dfn-type="enum-value" dfn-for="encoder state">
+    : "<dfn>open</dfn>"
+    ::
+        Indicates the {{GPUCommandEncoder}} is available to begin new operations. The {{GPUCommandEncoder/[[state]]}} is
+        {{encoder state/open}} any time the {{GPUCommandEncoder}} is [=valid=] and has no active
+        {{GPURenderPassEncoder}} or {{GPUComputePassEncoder}}.
 
-<div class=note>
-    {{GPUCommandEncoder}} has a state machine where the states are:
+    : "<dfn>encoding a render pass</dfn>"
+    ::
+        Indicates the {{GPUCommandEncoder}} has an active {{GPURenderPassEncoder}}. The
+        {{GPUCommandEncoder/[[state]]}} becomes {{encoder state/encoding a render pass}} once
+        {{GPUCommandEncoder/beginRenderPass()}} is called sucessfully until {{GPURenderPassEncoder/endPass()}} is called
+        on the returned {{GPURenderPassEncoder}}, at which point the {{GPUCommandEncoder/[[state]]}} reverts to
+        {{encoder state/open}}.
 
-     - {{encoder state/open}} when initially created until {{GPUCommandEncoder/finish()}} is called and when the
-        {{GPUCommandEncoder}} has no active {{GPURenderPassEncoder}} or {{GPUComputePassEncoder}}.
-     - {{encoder state/encoding a render pass}} once {{GPUCommandEncoder/beginRenderPass()}} is called sucessfully
-        until {{GPURenderPassEncoder/endPass()}} is called on the returned {{GPURenderPassEncoder}}, at which point the
-        state reverts to {{encoder state/open}}.
-     - {{encoder state/encoding a compute pass}} once {{GPUCommandEncoder/beginComputePass()}} is called sucessfully
-        until {{GPUComputePassEncoder/endPass()}} is called on the returned {{GPUComputePassEncoder}}, at which point the
-        state reverts to {{encoder state/open}}.
-     - {{encoder state/closed}} once {{GPUCommandEncoder/finish()}} is called or when the {{GPUCommandEncoder}} is
-        [=invalid=].
-</div>
+    : "<dfn>encoding a compute pass</dfn>"
+    ::
+        Indicates the {{GPUCommandEncoder}} has an active {{GPUComputePassEncoder}}.  The
+        {{GPUCommandEncoder/[[state]]}} becomes {{encoder state/encoding a compute pass}} once
+        {{GPUCommandEncoder/beginComputePass()}} is called sucessfully until {{GPUComputePassEncoder/endPass()}} is
+        called on the returned {{GPUComputePassEncoder}}, at which point the {{GPUCommandEncoder/[[state]]}} reverts to
+        {{encoder state/open}}.
+
+    : "<dfn>closed</dfn>"
+    ::
+        Indicates the {{GPUCommandEncoder}} is no longer available for any operations. The
+        {{GPUCommandEncoder/[[state]]}} becomes {{encoder state/closed}} once {{GPUCommandEncoder/finish()}} is called
+        or the {{GPUCommandEncoder}} otherwise becomes [=invalid=].
+</dl>
 
 ### Creation ### {#command-encoder-creation}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3054,16 +3054,16 @@ which may be one of the following:
         Indicates the {{GPUCommandEncoder}} has an active {{GPURenderPassEncoder}}. The
         {{GPUCommandEncoder/[[state]]}} becomes {{encoder state/encoding a render pass}} once
         {{GPUCommandEncoder/beginRenderPass()}} is called sucessfully until {{GPURenderPassEncoder/endPass()}} is called
-        on the returned {{GPURenderPassEncoder}}, at which point the {{GPUCommandEncoder/[[state]]}} reverts to
-        {{encoder state/open}}.
+        on the returned {{GPURenderPassEncoder}}, at which point the {{GPUCommandEncoder/[[state]]}}
+        (if the encoder is still valid) reverts to {{encoder state/open}}.
 
     : "<dfn>encoding a compute pass</dfn>"
     ::
         Indicates the {{GPUCommandEncoder}} has an active {{GPUComputePassEncoder}}.  The
         {{GPUCommandEncoder/[[state]]}} becomes {{encoder state/encoding a compute pass}} once
         {{GPUCommandEncoder/beginComputePass()}} is called sucessfully until {{GPUComputePassEncoder/endPass()}} is
-        called on the returned {{GPUComputePassEncoder}}, at which point the {{GPUCommandEncoder/[[state]]}} reverts to
-        {{encoder state/open}}.
+        called on the returned {{GPUComputePassEncoder}}, at which point the {{GPUCommandEncoder/[[state]]}}
+        (if the encoder is still valid) reverts to {{encoder state/open}}.
 
     : "<dfn>closed</dfn>"
     ::

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3178,7 +3178,7 @@ dictionary GPUImageBitmapCopyView {
 
         Given a {{GPUCommandEncoder}} |encoder| and the arguments {{GPUBuffer}} |source|, {{GPUSize64}} |sourceOffset|, {{GPUBuffer}} |destination|, {{GPUSize64}} |destinationOffset|, {{GPUSize64}} |size|, the following validation rules apply:
 
-          - {{GPUCommandEncoder/[[state]]}} of |encoder| must be [=encoder state/open=].
+          - |encoder|.{{GPUCommandEncoder/[[state]]}} must be [=encoder state/open=].
           - |source| must be a [=valid=] {{GPUBuffer}}.
           - |destination| must be a [=valid=] {{GPUBuffer}}.
           - The {{GPUBuffer/[[usage]]}} of |source| must contain {{GPUBufferUsage/COPY_SRC}}.
@@ -3329,7 +3329,7 @@ Given a {{GPUCommandEncoder}} |encoder| and the arguments {{GPUBufferCopyView}} 
 {{GPUTextureCopyView}} |destination| and {{GPUExtent3D}} |copySize|, the following validation rules apply:
 
   For |encoder|:
-  - {{GPUCommandEncoder/[[state]]}} of |encoder| must be [=encoder state/open=].
+  - |encoder|.{{GPUCommandEncoder/[[state]]}} must be [=encoder state/open=].
 
   For |source|:
   - |source| must be [=valid=].
@@ -3376,7 +3376,7 @@ Given a {{GPUCommandEncoder}} |encoder| and the arguments {{GPUTextureCopyView}}
 {{GPUBufferCopyView}} |destination|, {{GPUExtent3D}} |copySize|, the following validation rules apply:
 
   For |encoder|:
-  - {{GPUCommandEncoder/[[state]]}} of |encoder| must be [=encoder state/open=].
+  - |encoder|.{{GPUCommandEncoder/[[state]]}} must be [=encoder state/open=].
 
   For |source|:
   - |source| must be [=valid=].
@@ -3430,7 +3430,7 @@ Given a {{GPUCommandEncoder}} |encoder| and the arguments {{GPUTextureCopyView}}
 The following validation rules apply:
 
   For |encoder|:
-  - {{GPUCommandEncoder/[[state]]}} of |encoder| must be [=encoder state/open=].
+  - |encoder|.{{GPUCommandEncoder/[[state]]}} must be [=encoder state/open=].
 
   For |source|:
   - |source| must be [=valid=].

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3031,6 +3031,32 @@ interface GPUCommandEncoder {
 GPUCommandEncoder includes GPUObjectBase;
 </script>
 
+{{GPUCommandEncoder}} has the following internal slots:
+
+<dl dfn-type=attribute dfn-for="GPUCommandEncoder">
+    : <dfn>\[[state]]</dfn> of type [=encoder state=].
+    ::
+        The current state of the {{GPUCommandEncoder}}, initially set to [=encoder state/open=].
+</dl>
+
+Each {{GPUCommandEncoder}} has a current <dfn>encoder state</dfn> on the [=Content timeline=]
+which may be one of the following:
+
+ - "<dfn for="encoder state">open</dfn>" where the {{GPUCommandEncoder}} is available to begin new operations.
+ - "<dfn for="encoder state">recording a render pass</dfn>" where the {{GPUCommandEncoder}} has an active {{GPURenderPassEncoder}}.
+ - "<dfn for="encoder state">recording a compute pass</dfn>" where the {{GPUCommandEncoder}} has an active {{GPUComputePassEncoder}}.
+ - "<dfn for="encoder state">closed</dfn>" where the {{GPUCommandEncoder}} is
+     no longer available for any operations.
+
+<div class=note>
+    {{GPUCommandEncoder}} has a state machine where the states are:
+
+     - [=encoder state/open=] when initially created until {{GPUComputePassEncoder/finish()}} is called and when the {{GPUCommandEncoder}} has no active {{GPURenderPassEncoder}} or {{GPUComputePassEncoder}}.
+     - [=encoder state/recording a render pass=] once {{GPUCommandEncoder/beginRenderPass()}} is called sucessfully until {{GPURenderPassEncoder/finish()}} is called on the returned {{GPURenderPassEncoder}}, at which point the [=encoder state=] reverts to [=encoder state/open=].
+     - [=encoder state/recording a compute pass=] once {{GPUCommandEncoder/beginComputePass()}} is called sucessfully until {{GPUComputePassEncoder/finish()}} is called on the returned {{GPUComputePassEncoder}}, at which point the [=encoder state=] reverts to [=encoder state/open=].
+     - [=encoder state/closed=] once {{GPUComputePassEncoder/finish()}} is called or when the {{GPUCommandEncoder}} is [=invalid=].
+</div>
+
 ### Creation ### {#command-encoder-creation}
 
 <script type=idl>
@@ -3152,9 +3178,7 @@ dictionary GPUImageBitmapCopyView {
 
         Given a {{GPUCommandEncoder}} |encoder| and the arguments {{GPUBuffer}} |source|, {{GPUSize64}} |sourceOffset|, {{GPUBuffer}} |destination|, {{GPUSize64}} |destinationOffset|, {{GPUSize64}} |size|, the following validation rules apply:
 
-          - |encoder| must be a [=valid=] {{GPUCommandEncoder}}.
-          - |encoder|.{{GPUCommandEncoder/copyBufferToBuffer()}} must not be called when a {{GPURenderPassEncoder}} is active on |encoder|.
-          - |encoder|.{{GPUCommandEncoder/copyBufferToBuffer()}} must not be called when a {{GPUComputePassEncoder}} is active on |encoder|.
+          - {{GPUCommandEncoder/[[state]]}} of |encoder| must be [=encoder state/open=].
           - |source| must be a [=valid=] {{GPUBuffer}}.
           - |destination| must be a [=valid=] {{GPUBuffer}}.
           - The {{GPUBuffer/[[usage]]}} of |source| must contain {{GPUBufferUsage/COPY_SRC}}.
@@ -3305,10 +3329,7 @@ Given a {{GPUCommandEncoder}} |encoder| and the arguments {{GPUBufferCopyView}} 
 {{GPUTextureCopyView}} |destination| and {{GPUExtent3D}} |copySize|, the following validation rules apply:
 
   For |encoder|:
-  - |encoder|.{{GPUCommandEncoder/copyBufferToTexture()}} must not be called when a {{GPURenderPassEncoder}}
-    is active on |encoder|.
-  - |encoder|.{{GPUCommandEncoder/copyBufferToTexture()}} must not be called when a {{GPUComputePassEncoder}}
-    is active on |encoder|.
+  - {{GPUCommandEncoder/[[state]]}} of |encoder| must be [=encoder state/open=].
 
   For |source|:
   - |source| must be [=valid=].
@@ -3355,10 +3376,7 @@ Given a {{GPUCommandEncoder}} |encoder| and the arguments {{GPUTextureCopyView}}
 {{GPUBufferCopyView}} |destination|, {{GPUExtent3D}} |copySize|, the following validation rules apply:
 
   For |encoder|:
-  - |encoder|.{{GPUCommandEncoder/copyTextureToBuffer()}} must not be called when a {{GPURenderPassEncoder}}
-    is active on |encoder|.
-  - |encoder|.{{GPUCommandEncoder/copyTextureToBuffer()}} must not be called when a {{GPUComputePassEncoder}}
-    is active on |encoder|.
+  - {{GPUCommandEncoder/[[state]]}} of |encoder| must be [=encoder state/open=].
 
   For |source|:
   - |source| must be [=valid=].
@@ -3412,10 +3430,7 @@ Given a {{GPUCommandEncoder}} |encoder| and the arguments {{GPUTextureCopyView}}
 The following validation rules apply:
 
   For |encoder|:
-  - |encoder|.{{GPUCommandEncoder/copyTextureToTexture()}} must not be called when a {{GPURenderPassEncoder}}
-    is active on |encoder|.
-  - |encoder|.{{GPUCommandEncoder/copyTextureToTexture()}} must not be called when a {{GPUComputePassEncoder}}
-    is active on |encoder|.
+  - {{GPUCommandEncoder/[[state]]}} of |encoder| must be [=encoder state/open=].
 
   For |source|:
   - |source| must be [=valid=].


### PR DESCRIPTION
Fixes #653

First contribution to this spec, so please let me know if there's areas where I'm not conforming to convention or overlooking anything. I've still got a lot of the patterns from the WebXR spec burned into my brain, so apologies is any of that leaks through. 😄 

The description of the states is inferred from other areas of the spec text so if they don't match the expected states let me know. Also, I opted not to describe an "invalid" state since it seemed like it could easily be confused with the internal object `invalid` state, and it felt like a "closed" state the encompassed the encoder being both finished or invalid could be sufficient for validation purposes.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/toji/gpuweb/pull/752.html" title="Last updated on May 12, 2020, 7:01 PM UTC (eccd69c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/752/083b858...toji:eccd69c.html" title="Last updated on May 12, 2020, 7:01 PM UTC (eccd69c)">Diff</a>