### PR TITLE
[wgsl] Updating loop section to include for

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1243,7 +1243,9 @@ top of the [[#loop-statement]]. The `for` transforms into loop as:
     # TODO(dsinclair): Wrap in a block when/if we get lexical scoping
     var i : i32 = 0;
     loop {
-      break unless (i < 4);
+      if (!(i < 4)) {
+        break;
+      }
 
       if (a == 0) {
         continue;

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -496,6 +496,7 @@ Note: literals are parsed greedy. This means that for statements like `a -5`
   <tr><td>`FALLTHROUGH`<td>fallthrough
   <tr><td>`FALSE`<td>false
   <tr><td>`FN`<td>fn
+  <tr><td>`FOR`<td>for
   <tr><td>`FRAGMENT`<td>fragment
   <tr><td>`FUNCTION`<td>function
   <tr><td>`IF`<td>if
@@ -533,7 +534,6 @@ The following is a list of keywords which are reserved for future expansion.
     <td>f16
   <tr>
     <td>f64
-    <td>for
     <td>i8
     <td>i16
     <td>i64
@@ -1031,6 +1031,7 @@ statement
   | if_stmt
   | switch_stmt
   | loop_stmt
+  | for_stmt
   | variable_stmt SEMICOLON
   | break_stmt SEMICOLON
   | continue_stmt SEMICOLON
@@ -1134,6 +1135,7 @@ Optionally, the last statement in the loop body may be a
 
 Note: The loop statement is one of the biggest differences from other shader
 languages.
+
 This design directly expresses loop idioms commonly found in compiled code.
 In particular, placing the loop update statements at the end of the loop body
 allows them to naturally use values defined in the loop body.
@@ -1211,15 +1213,46 @@ allows them to naturally use values defined in the loop body.
 </div>
 * <2> The continue construct is placed at the end of the `loop`
 
-### Other Looping Constructs ### {#other-looping}
+### For statement ### {#for-statement}
 
-Note: This is *proposed* but not in the [SHORTNAME] spec yet
+<pre class='def'>
+for_stmt
+  : FOR PAREN_LEFT for_header PAREN_RIGHT BRACKET_LEFT statements BRACKET_RIGHT
+
+for_header
+  : variable_stmt? SEMICOLON logical_or_expression? SEMICOLON assignment_stmt?
+</pre>
 
 The `for(var i : i32 = 0; i < 4; i = i + 1) {}` statement is syntactic sugar on
-top of the [[#loop-statement]].
+top of the [[#loop-statement]]. The `for` transforms into loop as:
 
-The `while(i < 4) {}` is syntactic sugar on top of the [[#loop-statement]]
-where there is no `continuing` construct.
+<div class='example' heading="For to Loop transformation">
+  <xmp>
+    for(var i : i32 = 0; i < 4; i = i + 1) {
+      if (a == 0) {
+        continue;
+      }
+      a = a + 2;
+    }
+
+    Converts too:
+
+    # TODO(dsinclair): Wrap in a block when/if we get lexical scoping
+    var i : i32 = 0;
+    loop {
+      break if (!(i < 4));
+
+      if (a == 0) {
+        continue;
+      }
+      a = a + 2;
+
+      continuing {
+        i = i + 1;
+      }
+    }
+  </xmp>
+</div>
 
 ## Break statement ## {#break-statement}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1032,6 +1032,7 @@ statement
   | switch_stmt
   | loop_stmt
   | for_stmt
+  | func_call_stmt SEMICOLON
   | variable_stmt SEMICOLON
   | break_stmt SEMICOLON
   | continue_stmt SEMICOLON
@@ -1220,7 +1221,9 @@ for_stmt
   : FOR PAREN_LEFT for_header PAREN_RIGHT BRACKET_LEFT statements BRACKET_RIGHT
 
 for_header
-  : variable_stmt? SEMICOLON logical_or_expression? SEMICOLON assignment_stmt?
+  : (variable_stmt | assignment_stmt | func_call_stmt)? SEMICOLON
+     logical_or_expression? SEMICOLON
+     (assignment_stmt | func_call_stmt)?
 </pre>
 
 The `for(var i : i32 = 0; i < 4; i = i + 1) {}` statement is syntactic sugar on
@@ -1253,6 +1256,12 @@ top of the [[#loop-statement]]. The `for` transforms into loop as:
     }
   </xmp>
 </div>
+
+## Function call statemnet ## {#func-call-statement}
+<pre class='def'>
+func_call_stmt
+  : IDENT PAREN_LEFT argument_expression_list* PAREN_RIGHT
+</pre>
 
 ## Break statement ## {#break-statement}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1243,7 +1243,7 @@ top of the [[#loop-statement]]. The `for` transforms into loop as:
     # TODO(dsinclair): Wrap in a block when/if we get lexical scoping
     var i : i32 = 0;
     loop {
-      break if (!(i < 4));
+      break unless (i < 4);
 
       if (a == 0) {
         continue;


### PR DESCRIPTION
This CL adds the `for` keyword syntax into the language. The `for` is a
sugaring on top of the `loop/continue` statement.

Fixes #569


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 1, 2020, 8:20 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdj2%2Fgpuweb%2F9f1e539fb3f7ddc7c072cc3700533028378ea4d6%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%23757.)._
</details>
