### PR TITLE
Fix "VertexState" Typo

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2331,7 +2331,7 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
 };
 </script>
 
-  * {{GPURenderPipelineDescriptor/vertexState}} describes
+  * {{GPURenderPipelineDescriptor/vertexStage}} describes
     the vertex shader entry point of the [=pipeline=]
   * {{GPURenderPipelineDescriptor/fragmentStage}} describes
     the fragment shader entry point of the [=pipeline=]. If it's "null", the [[#no-color-output]] mode is enabled.


### PR DESCRIPTION
It should be `vertexStage `.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/06wj/gpuweb/pull/759.html" title="Last updated on May 7, 2020, 12:23 PM UTC (ef36b8d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/759/960a572...06wj:ef36b8d.html" title="Last updated on May 7, 2020, 12:23 PM UTC (ef36b8d)">Diff</a>