### PR TITLE
Query API: Timestamp Query

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4182,9 +4182,9 @@ enum GPUPipelineStatisticName {
 };
 </script>
 
-* When resolving pipeline statistics query, each result is written into {{GPUSize64}}, and the number and order of the results written to GPU buffer matches the number and order of {{GPUPipelineStatisticName}} specified in {{GPUQuerySetDescriptor/pipelineStatistics}}.
+When resolving pipeline statistics query, each result is written into {{GPUSize64}}, and the number and order of the results written to GPU buffer matches the number and order of {{GPUPipelineStatisticName}} specified in {{GPUQuerySetDescriptor/pipelineStatistics}}.
 
-* {{GPURenderPassEncoder/beginPipelineStatisticsQuery()}} and {{GPURenderPassEncoder/endPipelineStatisticsQuery()}} (on both {{GPUComputePassEncoder}} and {{GPURenderPassEncoder}}) cannot be nested. A pipeline statistics query must be ended before beginning another one.
+The {{GPURenderPassEncoder/beginPipelineStatisticsQuery()}} and {{GPURenderPassEncoder/endPipelineStatisticsQuery()}} (on both {{GPUComputePassEncoder}} and {{GPURenderPassEncoder}}) cannot be nested. A pipeline statistics query must be ended before beginning another one.
 
 Pipeline statistics query requires {{GPUExtensionName/pipeline-statistics-query}} is available on the device.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4196,6 +4196,8 @@ Timestamp query requires {{GPUExtensionName/timestamp-query}} is available on th
 
 Note: The timestamp values may be zero if the physical device reset timestamp counter, please ignore it and the following values.
 
+Issue: Write normative text about timestamp value resets.
+
 Issue: Because timestamp query provides high-resolution GPU timestamp, we need to decide what constraints, if any, are on its availability.
 
 # Canvas Rendering &amp; Swap Chains # {#canvas-rendering}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3064,6 +3064,8 @@ interface GPUCommandEncoder {
     void popDebugGroup();
     void insertDebugMarker(USVString markerLabel);
 
+    void writeTimestamp(GPUQuerySet querySet, GPUSize32 queryIndex);
+
     void resolveQuerySet(
         GPUQuerySet querySet,
         GPUSize32 firstQuery,

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -805,7 +805,8 @@ allows additional usages of WebGPU that would have otherwise been invalid.
 <script type=idl>
 enum GPUExtensionName {
     "texture-compression-bc",
-    "pipeline-statistics-query"
+    "pipeline-statistics-query",
+    "timestamp-query"
 };
 </script>
 
@@ -3693,6 +3694,10 @@ interface mixin GPUProgrammablePassEncoder {
     void pushDebugGroup(USVString groupLabel);
     void popDebugGroup();
     void insertDebugMarker(USVString markerLabel);
+
+    void beginPipelineStatisticsQuery(GPUQuerySet querySet, GPUSize32 queryIndex);
+    void endPipelineStatisticsQuery(GPUQuerySet querySet, GPUSize32 queryIndex);
+    void writeTimestamp(GPUQuerySet querySet, GPUSize32 queryIndex);
 };
 </script>
 
@@ -4158,7 +4163,8 @@ dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
 <script type=idl>
 enum GPUQueryType {
     "occlusion",
-    "pipeline-statistics"
+    "pipeline-statistics",
+    "timestamp"
 };
 </script>
 
@@ -4177,6 +4183,11 @@ enum GPUPipelineStatisticName {
 * When resolving pipeline statistics query, each result is written into uint64, and the number and order of the results written to GPU buffer matches the number and order of {{GPUPipelineStatisticName}} specified in {{GPUQuerySetDescriptor/pipelineStatistics}}.
 
 * {{GPURenderPassEncoder/beginPipelineStatisticsQuery()}} and {{GPURenderPassEncoder/endPipelineStatisticsQuery()}} (on both {{GPUComputePassEncoder}} and {{GPURenderPassEncoder}}) cannot be nested. A pipeline statistics query must be ended before beginning another one.
+
+## Timestamp Query ## {#timestamp}
+Timestamp query allows application to write timestamp values to a {{GPUQuerySet}} by calling {{GPUProgrammablePassEncoder/writeTimestamp()}} on render pass or compute pass, and then resolve timestamp values in **nanoseconds** (type of {{GPUSize64}}) to a {{GPUBuffer}} (using {{GPUCommandEncoder/resolveQuerySet()}}).
+
+Note: The timestamp values may be zero if the physical device reset timestamp counter, please ignore it and the following values.
 
 
 # Canvas Rendering &amp; Swap Chains # {#canvas-rendering}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4188,8 +4188,8 @@ The {{GPURenderPassEncoder/beginPipelineStatisticsQuery()}} and {{GPURenderPassE
 
 Pipeline statistics query requires {{GPUExtensionName/pipeline-statistics-query}} is available on the device.
 
-
 ## Timestamp Query ## {#timestamp}
+
 Timestamp query allows application to write timestamp values to a {{GPUQuerySet}} by calling {{GPURenderPassEncoder/writeTimestamp()}} on {{GPUComputePassEncoder}} or {{GPURenderPassEncoder}} or {{GPUCommandEncoder}}, and then resolve timestamp values in **nanoseconds** (type of {{GPUSize64}}) to a {{GPUBuffer}} (using {{GPUCommandEncoder/resolveQuerySet()}}).
 
 Timestamp query requires {{GPUExtensionName/timestamp-query}} is available on the device.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4182,12 +4182,17 @@ enum GPUPipelineStatisticName {
 };
 </script>
 
-* When resolving pipeline statistics query, each result is written into uint64, and the number and order of the results written to GPU buffer matches the number and order of {{GPUPipelineStatisticName}} specified in {{GPUQuerySetDescriptor/pipelineStatistics}}.
+* When resolving pipeline statistics query, each result is written into {{GPUSize64}}, and the number and order of the results written to GPU buffer matches the number and order of {{GPUPipelineStatisticName}} specified in {{GPUQuerySetDescriptor/pipelineStatistics}}.
 
 * {{GPURenderPassEncoder/beginPipelineStatisticsQuery()}} and {{GPURenderPassEncoder/endPipelineStatisticsQuery()}} (on both {{GPUComputePassEncoder}} and {{GPURenderPassEncoder}}) cannot be nested. A pipeline statistics query must be ended before beginning another one.
 
+Pipeline statistics query requires {{GPUExtensionName/pipeline-statistics-query}} is available on the device.
+
+
 ## Timestamp Query ## {#timestamp}
 Timestamp query allows application to write timestamp values to a {{GPUQuerySet}} by calling {{GPUProgrammablePassEncoder/writeTimestamp()}} on render pass or compute pass, and then resolve timestamp values in **nanoseconds** (type of {{GPUSize64}}) to a {{GPUBuffer}} (using {{GPUCommandEncoder/resolveQuerySet()}}).
+
+Timestamp query requires {{GPUExtensionName/timestamp-query}} is available on the device.
 
 Note: The timestamp values may be zero if the physical device reset timestamp counter, please ignore it and the following values.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3696,10 +3696,6 @@ interface mixin GPUProgrammablePassEncoder {
     void pushDebugGroup(USVString groupLabel);
     void popDebugGroup();
     void insertDebugMarker(USVString markerLabel);
-
-    void beginPipelineStatisticsQuery(GPUQuerySet querySet, GPUSize32 queryIndex);
-    void endPipelineStatisticsQuery(GPUQuerySet querySet, GPUSize32 queryIndex);
-    void writeTimestamp(GPUQuerySet querySet, GPUSize32 queryIndex);
 };
 </script>
 
@@ -3787,6 +3783,8 @@ interface GPUComputePassEncoder {
     void beginPipelineStatisticsQuery(GPUQuerySet querySet, GPUSize32 queryIndex);
     void endPipelineStatisticsQuery();
 
+    void writeTimestamp(GPUQuerySet querySet, GPUSize32 queryIndex);
+
     void endPass();
 };
 GPUComputePassEncoder includes GPUObjectBase;
@@ -3863,6 +3861,8 @@ interface GPURenderPassEncoder {
 
     void beginPipelineStatisticsQuery(GPUQuerySet querySet, GPUSize32 queryIndex);
     void endPipelineStatisticsQuery();
+
+    void writeTimestamp(GPUQuerySet querySet, GPUSize32 queryIndex);
 
     void executeBundles(sequence<GPURenderBundle> bundles);
     void endPass();
@@ -4190,7 +4190,7 @@ Pipeline statistics query requires {{GPUExtensionName/pipeline-statistics-query}
 
 
 ## Timestamp Query ## {#timestamp}
-Timestamp query allows application to write timestamp values to a {{GPUQuerySet}} by calling {{GPUProgrammablePassEncoder/writeTimestamp()}} on render pass or compute pass, and then resolve timestamp values in **nanoseconds** (type of {{GPUSize64}}) to a {{GPUBuffer}} (using {{GPUCommandEncoder/resolveQuerySet()}}).
+Timestamp query allows application to write timestamp values to a {{GPUQuerySet}} by calling {{GPURenderPassEncoder/writeTimestamp()}} on {{GPUComputePassEncoder}} or {{GPURenderPassEncoder}} or {{GPUCommandEncoder}}, and then resolve timestamp values in **nanoseconds** (type of {{GPUSize64}}) to a {{GPUBuffer}} (using {{GPUCommandEncoder/resolveQuerySet()}}).
 
 Timestamp query requires {{GPUExtensionName/timestamp-query}} is available on the device.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4196,6 +4196,7 @@ Timestamp query requires {{GPUExtensionName/timestamp-query}} is available on th
 
 Note: The timestamp values may be zero if the physical device reset timestamp counter, please ignore it and the following values.
 
+Issue: Because timestamp query provides high-resolution GPU timestamp, we need to decide what constraints, if any, are on its availability.
 
 # Canvas Rendering &amp; Swap Chains # {#canvas-rendering}
 


### PR DESCRIPTION
Add extension and entrypoints for timestamp query according to #614.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/haoxli/gpuweb/pull/771.html" title="Last updated on Jun 8, 2020, 8:04 PM UTC (53adb8e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/771/7ace193...haoxli:53adb8e.html" title="Last updated on Jun 8, 2020, 8:04 PM UTC (53adb8e)">Diff</a>