### PR TITLE
Documented debug marker methods

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3067,6 +3067,10 @@ GPUCommandEncoder includes GPUObjectBase;
     : <dfn>\[[state]]</dfn> of type {{encoder state}}.
     ::
         The current state of the {{GPUCommandEncoder}}, initially set to {{encoder state/open}}.
+
+    : <dfn>\[[debug_group_stack]]</dfn> of type `sequence<DOMString>`.
+    ::
+        A stack of active debug group labels.
 </dl>
 
 Each {{GPUCommandEncoder}} has a current <dfn dfn-type="enum">encoder state</dfn> on the [=Content timeline=]
@@ -3546,8 +3550,125 @@ The following validation rules apply:
             [=mipmap level=] |textureCopyView|.{{GPUTextureCopyView/mipLevel}}.
 </div>
 
+## Debug Markers ## {#command-encoder-debug-markers}
 
-## Programmable Passes ## {#programmable-passes}
+Command encoders provide methods to apply debug labels to groups of commands or insert a single
+label into the command sequence. Debug groups can be nested to create a hierarchy of labeled
+commands. These labels MAY be passed to the native API backends for tooling, MAY be used by the user
+agent's internal tooling, or MAY be a no-op when such tooling is not available or applicable.
+
+Debug groups in a {{GPUCommandEncoder}} or {{GPUProgrammablePassEncoder}}
+must be well nested.
+
+### <dfn method for=GPUCommandEncoder>pushDebugGroup(groupLabel)</dfn> ### {#GPUCommandEncoder-pushDebugGroup}
+
+<div algorithm="GPUCommandEncoder.pushDebugGroup">
+    <strong>|this|:</strong> of type {{GPUCommandEncoder}}.
+
+    **Arguments:**
+      - {{DOMString}} |groupLabel|
+
+    **Returns:** void
+
+    Marks the beginning of a labeled group of commands for the {{GPUCommandEncoder}}.
+
+    |groupLabel| defines the label for the command group.
+
+    On the [=Device timeline=], the following steps occur:
+
+        - If the user agent can fulfill the request and
+            the [$GPUCommandEncoder.pushDebugGroup/Valid Usage$] rules are met:
+
+            - push |groupLabel| onto then end of |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.
+
+    <div class=validusage dfn-for=GPUCommandEncoder.pushDebugGroup>
+        <dfn abstract-op>Valid Usage</dfn>
+
+        For |this|:
+        - |this|.{{GPUCommandEncoder/[[state]]}} must be {{encoder state/open}}.
+    </div>
+
+</div>
+
+### <dfn method for=GPUCommandEncoder>popDebugGroup()</dfn> ### {#GPUCommandEncoder-popDebugGroup}
+
+<div algorithm="GPUCommandEncoder.popDebugGroup">
+    <strong>|this|:</strong> of type {{GPUCommandEncoder}}.
+
+    **Returns:** void
+
+    Marks the end of a labeled group of commands for the {{GPUCommandEncoder}}.
+
+    On the [=Device timeline=], the following steps occur:
+
+        - If the user agent can fulfill the request and
+            the [$GPUCommandEncoder.popDebugGroup/Valid Usage$] rules are met:
+
+            - pop an entry off the end of |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.
+
+    <div class=validusage dfn-for=GPUCommandEncoder.popDebugGroup>
+        <dfn abstract-op>Valid Usage</dfn>
+
+        For |this|:
+        - |this|.{{GPUCommandEncoder/[[state]]}} must be {{encoder state/open}}.
+        - |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.length must be greater than 0.
+    </div>
+
+</div>
+
+### <dfn method for=GPUCommandEncoder>insertDebugMarker(markerLabel)</dfn> ### {#GPUCommandEncoder-insertDebugMarker}
+
+<div algorithm="GPUCommandEncoder.insertDebugMarker">
+    <strong>|this|:</strong> of type {{GPUCommandEncoder}}.
+
+    **Arguments:**
+        - {{DOMString}} |markerLabel|
+
+    **Returns:** void
+
+    Inserts a single debug marker label into the {{GPUCommandEncoder}}'s commands sequence .
+
+    |markerLabel| defines the label to insert.
+
+    <div class=validusage dfn-for=GPUCommandEncoder.insertDebugMarker>
+        <dfn abstract-op>Valid Usage</dfn>
+
+        For |this|:
+        - |this|.{{GPUCommandEncoder/[[state]]}} must be {{encoder state/open}}.
+    </div>
+
+</div>
+
+## Finalization ## {#command-encoder-finalization}
+
+Once the command encoder has finished submitting any commands a {{GPUCommandBuffer}} can be created
+by calling {{GPUCommandEncoder/finish()}}. Once {{GPUCommandEncoder/finish()}} has been called the
+command encoder can no longer be used.
+
+### <dfn method for=GPUCommandEncoder>finish(descriptor)</dfn> ### {#GPUCommandEncoder-finish}
+
+<div algorithm="GPUCommandEncoder.finish">
+    <strong>|this|:</strong> of type {{GPUCommandEncoder}}.
+
+    **Arguments:**
+        - optional {{GPUCommandBufferDescriptor}} descriptor = {}
+
+    **Returns:** {{GPUCommandBuffer}}
+
+    Completes recording of the commands sequence and returns a corresponding {{GPUCommandBuffer}}.
+
+    <div class=validusage dfn-for=GPUCommandEncoder.finish>
+        <dfn abstract-op>Valid Usage</dfn>
+
+        For |this|:
+        - |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.length must 0.
+
+        Issue: Add remaining validation.
+    </div>
+
+</div>
+
+# Programmable Passes # {#programmable-passes}
 
 <script type=idl>
 
@@ -3569,9 +3690,85 @@ interface mixin GPUProgrammablePassEncoder {
 };
 </script>
 
+{{GPUProgrammablePassEncoder}} has the following internal slots:
+
+<dl dfn-type=attribute dfn-for="GPUProgrammablePassEncoder">
+    : <dfn>\[[debug_group_stack]]</dfn> of type `sequence<DOMString>`.
+    ::
+        A stack of active debug group labels.
+</dl>
+
+## Debug Markers ## {#programmable-passes-debug-markers}
+
+Similar to Command encoders, programmable pass encoders provide methods to apply debug labels to
+groups of commands or insert a single label into the command sequence. Debug groups can be nested to
+create a hierarchy of labeled commands. These labels MAY be passed to the native API backends for
+tooling, MAY be used by the user agent's internal tooling, or MAY be a no-op when such tooling is
+not available or applicable.
+
 Debug groups in a {{GPUCommandEncoder}} or {{GPUProgrammablePassEncoder}}
 must be well nested.
 
+### <dfn method for=GPUProgrammablePassEncoder>pushDebugGroup(groupLabel)</dfn> ### {#GPUProgrammablePassEncoder-pushDebugGroup}
+
+<div algorithm="GPUProgrammablePassEncoder.pushDebugGroup">
+    <strong>|this|:</strong> of type {{GPUProgrammablePassEncoder}}.
+
+    **Arguments:**
+      - {{DOMString}} |groupLabel|
+
+    **Returns:** void
+
+    Marks the beginning of a labeled group of commands for the {{GPUProgrammablePassEncoder}}.
+
+    |groupLabel| defines the label for the command group.
+
+    On the [=Device timeline=], the following steps occur:
+
+        - If the user agent can fulfill the request:
+
+            - push |groupLabel| onto then end of |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.
+</div>
+
+### <dfn method for=GPUProgrammablePassEncoder>popDebugGroup()</dfn> ### {#GPUProgrammablePassEncoder-popDebugGroup}
+
+<div algorithm="GPUProgrammablePassEncoder.popDebugGroup">
+    <strong>|this|:</strong> of type {{GPUProgrammablePassEncoder}}.
+
+    **Returns:** void
+
+    Marks the end of a labeled group of commands for the {{GPUProgrammablePassEncoder}}.
+
+    On the [=Device timeline=], the following steps occur:
+
+        - If the user agent can fulfill the request and
+            the [$GPUProgrammablePassEncoder.popDebugGroup/Valid Usage$] rules are met:
+
+            - pop an entry off the end of |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.
+
+    <div class=validusage dfn-for=GPUProgrammablePassEncoder.popDebugGroup>
+        <dfn abstract-op>Valid Usage</dfn>
+
+        For |this|:
+        - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.length must be greater than 0.
+    </div>
+
+</div>
+
+### <dfn method for=GPUProgrammablePassEncoder>insertDebugMarker(markerLabel)</dfn> ### {#GPUProgrammablePassEncoder-insertDebugMarker}
+
+<div algorithm="GPUProgrammablePassEncoder.insertDebugMarker">
+
+    **Arguments:**
+        - {{DOMString}} |markerLabel|
+
+    **Returns:** void
+
+    Inserts a single debug marker label into the {{GPUProgrammablePassEncoder}}'s commands sequence .
+
+    |markerLabel| defines the label to insert.
+
+</div>
 
 # Compute Passes # {#compute-passes}
 
@@ -3596,6 +3793,31 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
 };
 </script>
 
+## Finalization ## {#compute-pass-encoder-finalization}
+
+Once the compute pass encoder has finished submitting any commands the pass is completed by calling
+{{GPUComputePassEncoder/endPass()}}. Once {{GPUComputePassEncoder/endPass()}} has been called the
+compute pass encoder can no longer be used.
+
+### <dfn method for=GPUComputePassEncoder>endPass()</dfn> ### {#GPUComputePassEncoder-endPass}
+
+<div algorithm="GPUComputePassEncoder.endPass">
+    <strong>this:</strong> of type {{GPUComputePassEncoder}}.
+
+    **Returns:** void
+
+    Completes recording of the compute pass commands sequence.
+
+    <div class=validusage dfn-for=GPUComputePassEncoder.endPass>
+        <dfn abstract-op>Valid Usage</dfn>
+
+        For |this|:
+        - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.length must 0.
+
+        Issue: Add remaining validation.
+    </div>
+
+</div>
 
 # Render Passes # {#render-passes}
 
@@ -3717,6 +3939,31 @@ enum GPUStoreOp {
 };
 </script>
 
+## Finalization ## {#render-pass-encoder-finalization}
+
+Once the render pass encoder has finished submitting any commands the pass is completed by calling
+{{GPURenderPassEncoder/endPass()}}. Once {{GPURenderPassEncoder/endPass()}} has been called the
+compute pass encoder can no longer be used.
+
+### <dfn method for=GPURenderPassEncoder>endPass()</dfn> ### {#GPURenderPassEncoder-endPass}
+
+<div algorithm="GPURenderPassEncoder.endPass">
+    <strong>this:</strong> of type {{GPURenderPassEncoder}}.
+
+    **Returns:** void
+
+    Completes recording of the compute pass commands sequence.
+
+    <div class=validusage dfn-for=GPURenderPassEncoder.endPass>
+        <dfn abstract-op>Valid Usage</dfn>
+
+        For |this|:
+        - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.length must 0.
+
+        Issue: Add remaining validation.
+    </div>
+
+</div>
 
 # Bundles # {#bundles}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3552,10 +3552,11 @@ The following validation rules apply:
 
 ## Debug Markers ## {#command-encoder-debug-markers}
 
-Command encoders provide methods to apply debug labels to groups of commands or insert a single
-label into the command sequence. Debug groups can be nested to create a hierarchy of labeled
-commands. These labels MAY be passed to the native API backends for tooling, MAY be used by the user
-agent's internal tooling, or MAY be a no-op when such tooling is not available or applicable.
+Both command encoders and programmable pass encoders provide methods to apply debug labels to groups
+of commands or insert a single label into the command sequence. Debug groups can be nested to create
+a hierarchy of labeled commands. These labels may be passed to the native API backends for tooling,
+may be used by the user agent's internal tooling, or may be a no-op when such tooling is not
+available or applicable.
 
 Debug groups in a {{GPUCommandEncoder}} or {{GPUProgrammablePassEncoder}}
 must be well nested.
@@ -3576,8 +3577,7 @@ must be well nested.
 
     On the [=Device timeline=], the following steps occur:
 
-        - If the user agent can fulfill the request and
-            the [$GPUCommandEncoder.pushDebugGroup/Valid Usage$] rules are met:
+        - If the [$GPUCommandEncoder.pushDebugGroup/Valid Usage$] rules are met:
 
             - push |groupLabel| onto then end of |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.
 
@@ -3601,8 +3601,7 @@ must be well nested.
 
     On the [=Device timeline=], the following steps occur:
 
-        - If the user agent can fulfill the request and
-            the [$GPUCommandEncoder.popDebugGroup/Valid Usage$] rules are met:
+        - If the [$GPUCommandEncoder.popDebugGroup/Valid Usage$] rules are met:
 
             - pop an entry off the end of |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.
 
@@ -3641,7 +3640,7 @@ must be well nested.
 
 ## Finalization ## {#command-encoder-finalization}
 
-Once the command encoder has finished submitting any commands a {{GPUCommandBuffer}} can be created
+A {{GPUCommandBuffer}} containing the commands recorded by the {{GPUCommandEncoder}} can be created
 by calling {{GPUCommandEncoder/finish()}}. Once {{GPUCommandEncoder/finish()}} has been called the
 command encoder can no longer be used.
 
@@ -3700,14 +3699,9 @@ interface mixin GPUProgrammablePassEncoder {
 
 ## Debug Markers ## {#programmable-passes-debug-markers}
 
-Similar to Command encoders, programmable pass encoders provide methods to apply debug labels to
-groups of commands or insert a single label into the command sequence. Debug groups can be nested to
-create a hierarchy of labeled commands. These labels MAY be passed to the native API backends for
-tooling, MAY be used by the user agent's internal tooling, or MAY be a no-op when such tooling is
-not available or applicable.
-
-Debug groups in a {{GPUCommandEncoder}} or {{GPUProgrammablePassEncoder}}
-must be well nested.
+Debug marker methods for programmable pass encoders provide the same functionality as
+[[#command-encoder-debug-markers|command encoder debug markers]] while recording a programmable
+pass.
 
 ### <dfn method for=GPUProgrammablePassEncoder>pushDebugGroup(groupLabel)</dfn> ### {#GPUProgrammablePassEncoder-pushDebugGroup}
 
@@ -3725,9 +3719,7 @@ must be well nested.
 
     On the [=Device timeline=], the following steps occur:
 
-        - If the user agent can fulfill the request:
-
-            - push |groupLabel| onto then end of |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.
+        - push |groupLabel| onto then end of |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.
 </div>
 
 ### <dfn method for=GPUProgrammablePassEncoder>popDebugGroup()</dfn> ### {#GPUProgrammablePassEncoder-popDebugGroup}
@@ -3741,8 +3733,7 @@ must be well nested.
 
     On the [=Device timeline=], the following steps occur:
 
-        - If the user agent can fulfill the request and
-            the [$GPUProgrammablePassEncoder.popDebugGroup/Valid Usage$] rules are met:
+        - If the [$GPUProgrammablePassEncoder.popDebugGroup/Valid Usage$] rules are met:
 
             - pop an entry off the end of |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.
 
@@ -3795,9 +3786,9 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
 
 ## Finalization ## {#compute-pass-encoder-finalization}
 
-Once the compute pass encoder has finished submitting any commands the pass is completed by calling
-{{GPUComputePassEncoder/endPass()}}. Once {{GPUComputePassEncoder/endPass()}} has been called the
-compute pass encoder can no longer be used.
+The compute pass encoder can be ended by calling {{GPUComputePassEncoder/endPass()}} once the user
+has finished recording commands for the pass. Once {{GPUComputePassEncoder/endPass()}} has been
+called the compute pass encoder can no longer be used.
 
 ### <dfn method for=GPUComputePassEncoder>endPass()</dfn> ### {#GPUComputePassEncoder-endPass}
 
@@ -3941,9 +3932,9 @@ enum GPUStoreOp {
 
 ## Finalization ## {#render-pass-encoder-finalization}
 
-Once the render pass encoder has finished submitting any commands the pass is completed by calling
-{{GPURenderPassEncoder/endPass()}}. Once {{GPURenderPassEncoder/endPass()}} has been called the
-compute pass encoder can no longer be used.
+The render pass encoder can be ended by calling {{GPURenderPassEncoder/endPass()}} once the user
+has finished recording commands for the pass. Once {{GPURenderPassEncoder/endPass()}} has been
+called the render pass encoder can no longer be used.
 
 ### <dfn method for=GPURenderPassEncoder>endPass()</dfn> ### {#GPURenderPassEncoder-endPass}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3068,7 +3068,7 @@ GPUCommandEncoder includes GPUObjectBase;
     ::
         The current state of the {{GPUCommandEncoder}}, initially set to {{encoder state/open}}.
 
-    : <dfn>\[[debug_group_stack]]</dfn> of type `sequence<DOMString>`.
+    : <dfn>\[[debug_group_stack]]</dfn> of type `sequence<USVString>`.
     ::
         A stack of active debug group labels.
 </dl>
@@ -3567,7 +3567,7 @@ must be well nested.
     <strong>|this|:</strong> of type {{GPUCommandEncoder}}.
 
     **Arguments:**
-      - {{DOMString}} |groupLabel|
+      - {{USVString}} |groupLabel|
 
     **Returns:** void
 
@@ -3584,7 +3584,6 @@ must be well nested.
     <div class=validusage dfn-for=GPUCommandEncoder.pushDebugGroup>
         <dfn abstract-op>Valid Usage</dfn>
 
-        For |this|:
         - |this|.{{GPUCommandEncoder/[[state]]}} must be {{encoder state/open}}.
     </div>
 
@@ -3608,7 +3607,6 @@ must be well nested.
     <div class=validusage dfn-for=GPUCommandEncoder.popDebugGroup>
         <dfn abstract-op>Valid Usage</dfn>
 
-        For |this|:
         - |this|.{{GPUCommandEncoder/[[state]]}} must be {{encoder state/open}}.
         - |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.length must be greater than 0.
     </div>
@@ -3621,7 +3619,7 @@ must be well nested.
     <strong>|this|:</strong> of type {{GPUCommandEncoder}}.
 
     **Arguments:**
-        - {{DOMString}} |markerLabel|
+        - {{USVString}} |markerLabel|
 
     **Returns:** void
 
@@ -3632,7 +3630,6 @@ must be well nested.
     <div class=validusage dfn-for=GPUCommandEncoder.insertDebugMarker>
         <dfn abstract-op>Valid Usage</dfn>
 
-        For |this|:
         - |this|.{{GPUCommandEncoder/[[state]]}} must be {{encoder state/open}}.
     </div>
 
@@ -3659,7 +3656,6 @@ command encoder can no longer be used.
     <div class=validusage dfn-for=GPUCommandEncoder.finish>
         <dfn abstract-op>Valid Usage</dfn>
 
-        For |this|:
         - |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.length must 0.
 
         Issue: Add remaining validation.
@@ -3692,7 +3688,7 @@ interface mixin GPUProgrammablePassEncoder {
 {{GPUProgrammablePassEncoder}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUProgrammablePassEncoder">
-    : <dfn>\[[debug_group_stack]]</dfn> of type `sequence<DOMString>`.
+    : <dfn>\[[debug_group_stack]]</dfn> of type `sequence<USVString>`.
     ::
         A stack of active debug group labels.
 </dl>
@@ -3709,7 +3705,7 @@ pass.
     <strong>|this|:</strong> of type {{GPUProgrammablePassEncoder}}.
 
     **Arguments:**
-      - {{DOMString}} |groupLabel|
+      - {{USVString}} |groupLabel|
 
     **Returns:** void
 
@@ -3740,7 +3736,6 @@ pass.
     <div class=validusage dfn-for=GPUProgrammablePassEncoder.popDebugGroup>
         <dfn abstract-op>Valid Usage</dfn>
 
-        For |this|:
         - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.length must be greater than 0.
     </div>
 
@@ -3751,7 +3746,7 @@ pass.
 <div algorithm="GPUProgrammablePassEncoder.insertDebugMarker">
 
     **Arguments:**
-        - {{DOMString}} |markerLabel|
+        - {{USVString}} |markerLabel|
 
     **Returns:** void
 
@@ -3793,7 +3788,7 @@ called the compute pass encoder can no longer be used.
 ### <dfn method for=GPUComputePassEncoder>endPass()</dfn> ### {#GPUComputePassEncoder-endPass}
 
 <div algorithm="GPUComputePassEncoder.endPass">
-    <strong>this:</strong> of type {{GPUComputePassEncoder}}.
+    <strong>|this|:</strong> of type {{GPUComputePassEncoder}}.
 
     **Returns:** void
 
@@ -3802,7 +3797,6 @@ called the compute pass encoder can no longer be used.
     <div class=validusage dfn-for=GPUComputePassEncoder.endPass>
         <dfn abstract-op>Valid Usage</dfn>
 
-        For |this|:
         - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.length must 0.
 
         Issue: Add remaining validation.
@@ -3939,7 +3933,7 @@ called the render pass encoder can no longer be used.
 ### <dfn method for=GPURenderPassEncoder>endPass()</dfn> ### {#GPURenderPassEncoder-endPass}
 
 <div algorithm="GPURenderPassEncoder.endPass">
-    <strong>this:</strong> of type {{GPURenderPassEncoder}}.
+    <strong>|this|:</strong> of type {{GPURenderPassEncoder}}.
 
     **Returns:** void
 
@@ -3948,7 +3942,6 @@ called the render pass encoder can no longer be used.
     <div class=validusage dfn-for=GPURenderPassEncoder.endPass>
         <dfn abstract-op>Valid Usage</dfn>
 
-        For |this|:
         - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.length must 0.
 
         Issue: Add remaining validation.


### PR DESCRIPTION
Added spec text/validation for both the command encoder and pass encoder's debug marker methods. (These are largely identical but have minor variations in the validation, primarily due to the pass encoder not needing to worry about open render/compute passes like the command encoder does.)

Some of the verbiage used here is just educated guesses based off of perusing the vulkan/D3D12 equivalent docs. Happy to change any of it around if there's better "WebGPU approved" terms for any particular concept.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/toji/gpuweb/pull/785.html" title="Last updated on May 21, 2020, 3:58 PM UTC (86c8ebf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/785/8e82f01...toji:86c8ebf.html" title="Last updated on May 21, 2020, 3:58 PM UTC (86c8ebf)">Diff</a>