### PR TITLE
Enable 'make online' to output bikeshed validation

### DIFF
--- a/spec/Makefile
+++ b/spec/Makefile
@@ -7,5 +7,6 @@ webgpu.idl: index.bs extract-idl.py
 	python extract-idl.py index.bs > webgpu.idl
 
 online:
+	curl https://api.csswg.org/bikeshed/ -F file=@index.bs -F output=err
 	curl https://api.csswg.org/bikeshed/ -F file=@index.bs -F force=1 > index.html
 	python extract-idl.py index.bs > webgpu.idl


### PR DESCRIPTION
I've found that the "make online" option for the spec is a convenient way to get up and running fast, but it currently doesn't provide any feedback if there's any errors or warnings in the spec text. Copied this pattern over from WebXR where it's been very helpful in the same situation.