### PR TITLE
Replace DOMString with USVString for wgsl and debug strings

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -222,7 +222,7 @@ Any interface which includes {{GPUObjectBase}} is a [=WebGPU interface=].
 
 <script type=idl>
 interface mixin GPUObjectBase {
-    attribute DOMString? label;
+    attribute USVString? label;
 };
 </script>
 
@@ -254,7 +254,7 @@ which is typically done via one of the `create*` methods of {{GPUDevice}}.
 
 <script type=idl>
 dictionary GPUObjectDescriptorBase {
-    DOMString label;
+    USVString label;
 };
 </script>
 
@@ -2250,7 +2250,7 @@ conditions.
 
 <script type=idl>
 dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
-    required DOMString code;
+    required USVString code;
     object sourceMap;
 };
 </script>
@@ -2436,7 +2436,7 @@ has a default layout created and used instead.
 <script type=idl>
 dictionary GPUProgrammableStageDescriptor {
     required GPUShaderModule module;
-    required DOMString entryPoint;
+    required USVString entryPoint;
 };
 </script>
 
@@ -3042,9 +3042,9 @@ interface GPUCommandEncoder {
         GPUTextureCopyView destination,
         GPUExtent3D copySize);
 
-    void pushDebugGroup(DOMString groupLabel);
+    void pushDebugGroup(USVString groupLabel);
     void popDebugGroup();
-    void insertDebugMarker(DOMString markerLabel);
+    void insertDebugMarker(USVString markerLabel);
 
     void resolveQuerySet(
         GPUQuerySet querySet,
@@ -3536,9 +3536,9 @@ interface mixin GPUProgrammablePassEncoder {
                       GPUSize64 dynamicOffsetsDataStart,
                       GPUSize32 dynamicOffsetsDataLength);
 
-    void pushDebugGroup(DOMString groupLabel);
+    void pushDebugGroup(USVString groupLabel);
     void popDebugGroup();
-    void insertDebugMarker(DOMString markerLabel);
+    void insertDebugMarker(USVString markerLabel);
 
     void beginPipelineStatisticsQuery(GPUQuerySet querySet, GPUSize32 queryIndex);
     void endPipelineStatisticsQuery(GPUQuerySet querySet, GPUSize32 queryIndex);


### PR DESCRIPTION
See issue for context.

Note: This is strictly breaking, but changing back from USVString to DOMString would be non-breaking.

Issue: #784


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/787.html" title="Last updated on May 18, 2020, 10:30 PM UTC (ec8742b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/787/6253635...kainino0x:ec8742b.html" title="Last updated on May 18, 2020, 10:30 PM UTC (ec8742b)">Diff</a>