### PR TITLE
Disallow source and destination to be the same buffer in B2B copy

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3229,7 +3229,7 @@ dictionary GPUImageBitmapCopyView {
           - (|destinationOffset| + |size|) must not overflow a {{GPUSize64}}.
           - The {{GPUBuffer/[[size]]}} of |source| must be greater than or equal to (|sourceOffset| + |size|).
           - The {{GPUBuffer/[[size]]}} of |destination| must be greater than or equal to (|destinationOffset| + |size|).
-          - If |source| and |destination| are the same buffer, the copy range from |sourceOffset| to (|sourceOffset| + |size|) must not overlap with the copy range from |destinationOffset| to (|destinationOffset| + |size|).
+          - |source| and |destination| cannot the same {{GPUBuffer}}.
 
         Issue(gpuweb/gpuweb#21): Define the state machine for GPUCommandEncoder.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3229,7 +3229,7 @@ dictionary GPUImageBitmapCopyView {
           - (|destinationOffset| + |size|) must not overflow a {{GPUSize64}}.
           - The {{GPUBuffer/[[size]]}} of |source| must be greater than or equal to (|sourceOffset| + |size|).
           - The {{GPUBuffer/[[size]]}} of |destination| must be greater than or equal to (|destinationOffset| + |size|).
-          - |source| and |destination| cannot the same {{GPUBuffer}}.
+          - |source| and |destination| cannot be the same {{GPUBuffer}}.
 
         Issue(gpuweb/gpuweb#21): Define the state machine for GPUCommandEncoder.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3229,7 +3229,7 @@ dictionary GPUImageBitmapCopyView {
           - (|destinationOffset| + |size|) must not overflow a {{GPUSize64}}.
           - The {{GPUBuffer/[[size]]}} of |source| must be greater than or equal to (|sourceOffset| + |size|).
           - The {{GPUBuffer/[[size]]}} of |destination| must be greater than or equal to (|destinationOffset| + |size|).
-          - |source| and |destination| cannot be the same {{GPUBuffer}}.
+          - |source| and |destination| must not be the same {{GPUBuffer}}.
 
         Issue(gpuweb/gpuweb#21): Define the state machine for GPUCommandEncoder.
 


### PR DESCRIPTION
For the decisions made in #783.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Jiawei-Shao/gpuweb/pull/788.html" title="Last updated on May 19, 2020, 4:22 AM UTC (8e4ded1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/788/6253635...Jiawei-Shao:8e4ded1.html" title="Last updated on May 19, 2020, 4:22 AM UTC (8e4ded1)">Diff</a>