### PR TITLE
Remove TODO for signed and unordered comparisons

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1288,28 +1288,6 @@ unary_expression
 singular_expression
   : primary_expression postfix_expression
 
-Issue: (dsinclair): Add following. Do we want to add the regular versions as well?
-# | unord_greater_than_equal(a, b)
-#      OpFUordGreaterThanEqual
-# | unord_greater_than(a, b)
-#       OpFUordGreaterThan
-# | unord_less_than_equal(a, b)
-#      OpFUordLessThanEqual
-# | unord_less_than(a, b)
-#      OpFUordLessThan
-# | unord_not_equal(a, b)
-#      OpFUordNotEqual
-# | unord_equal(a, b)
-#      OpFUordEqual
-# | signed_greater_than_equal(a, b)
-#      OpSGreaterThanEqual
-# | signed_greater_than(a, b)
-#      OpSGreaterThan
-# | signed_less_than_equal(a, b)
-#      OpSLessThanEqual
-# | signed_less_than(a, b)
-#      OpSLessThan
-
 multiplicative_expression
   : unary_expression
   | multiplicative_expression STAR unary_expression


### PR DESCRIPTION
We no longer need those builtins:

- PR https://github.com/gpuweb/gpuweb/pull/772 added type rules for
  signed integer comparisons
- Resolution of https://github.com/gpuweb/gpuweb/issues/706 is to not
  have unordered floating point comparisons as a direct language
  feature.