### PR TITLE
Small change to writeBuffer/Texture

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3773,8 +3773,8 @@ interface GPUQueue {
 
     void writeTexture(
       GPUTextureCopyView destination,
-      GPUTextureDataLayout dataLayout,
       ArrayBuffer data,
+      GPUTextureDataLayout dataLayout,
       GPUExtent3D size);
 
     void copyImageBitmapToTexture(
@@ -3811,7 +3811,7 @@ GPUQueue includes GPUObjectBase;
 </div>
 
 <div algorithm>
-    : <dfn>writeTexture(|destination|, |dataLayout|, |data|, |size|)</dfn>
+    : <dfn>writeTexture(|destination|, |data|, |dataLayout|, |size|)</dfn>
     ::
         Takes the |data| contents and schedules a write operation of these contents to the
         |destination| texture copy view in the queue.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3765,17 +3765,18 @@ interface GPUQueue {
     void signal(GPUFence fence, GPUFenceValue signalValue);
 
     void writeBuffer(
-        ArrayBuffer sourceData,
-        GPUSize64 sourceOffset,
-        GPUBuffer destination,
-        GPUSize64 destinationOffset,
-        GPUSize64 size);
+        GPUBuffer buffer,
+        GPUSize64 bufferOffset,
+        ArrayBuffer data,
+        optional GPUSize64 dataOffset = 0,
+        optional GPUSize64 size = 0);
 
     void writeTexture(
-      ArrayBuffer sourceData,
-      GPUTextureDataLayout sourceLayout,
       GPUTextureCopyView destination,
-      GPUExtent3D size);
+      GPUExtent3D size,
+      GPUTextureDataLayout dataLayout,
+      ArrayBuffer data,
+      optional GPUSize64 dataOffset = 0);
 
     void copyImageBitmapToTexture(
         GPUImageBitmapCopyView source,
@@ -3787,43 +3788,49 @@ GPUQueue includes GPUObjectBase;
 
 <dl dfn-type="method" dfn-for="GPUQueue">
 <div algorithm>
-    : <dfn>writeBuffer(|sourceData|, |sourceOffset|, |destination|, |destinationOffset|, |size|)</dfn>
+    : <dfn>writeBuffer(|buffer|, |bufferOffset|, |data|, |dataOffset|, |size|)</dfn>
     ::
-        Takes the |sourceData| contents of size |size|, starting from the byte offset |sourceOffset|,
-        and schedules a write operation of these contents to the |destination| buffer on the
-        [=Queue timeline=] starting at |destinationOffset|.
-        Any subsequent modifications to |sourceData| do not affect what is written
+        Takes the |data| contents of size |size|, starting from the byte offset |dataOffset|,
+        and schedules a write operation of these contents to the |buffer| buffer on the
+        [=Queue timeline=] starting at |bufferOffset|.
+        Any subsequent modifications to |data| do not affect what is written
         at the time that the scheduled operation runs.
 
+        If |size| is 0, it is set to |data|.byteLength - |dataOffset| if the result is non-negative,
+        or throws {{OperationError}} otherwise.
+
         The operation throws {{OperationError}} if any of the following is true:
-        - |destination| buffer isn't in the `"unmapped"` [=buffer state=].
-        - |destinationOffset| is not a multiple of 4.
+        - |buffer| buffer isn't in the `"unmapped"` [=buffer state=].
+        - |bufferOffset| is not a multiple of 4.
         - |size| is not a positive multiple of 4.
-        - |sourceOffset| + |size| exceeds |sourceData|.byteLength.
+        - |dataOffset| + |size| exceeds |data|.byteLength.
 
         The operation does nothing and produces an error if any of the following is true:
-        - |destination|.{{GPUBuffer/[[usage]]}} doesn't include {{GPUBufferUsage/COPY_DST}} flag.
-        - |destination| buffer is destroyed
-        - |destinationOffset| + |size| exceeds |destination|.{{GPUBuffer/[[size]]}}.
+        - |bufferOffset| + |size| exceeds |buffer|.{{GPUBuffer/[[size]]}}.
+        - |buffer|.{{GPUBuffer/[[usage]]}} doesn't include {{GPUBufferUsage/COPY_DST}} flag.
+        - |buffer| buffer is destroyed
 </div>
 
 <div algorithm>
-    : <dfn>writeTexture(|sourceData|, |sourceLayout|, |destination|, |size|)</dfn>
+    : <dfn>writeTexture(|destination|, |size|, |dataLayout|, |data|, |dataOffset|)</dfn>
     ::
-        Takes the |sourceData| contents and schedules a write operation of these contents to the
+        Takes the |data| contents and schedules a write operation of these contents to the
         |destination| texture copy view in the queue.
-        Any subsequent modifications to |sourceData| do not affect what is written
+        Any subsequent modifications to |data| do not affect what is written
         at the time that the scheduled operation runs.
+
+        The operation throws {{OperationError}} if |dataOffset| exceeds |data|.byteLength.
+
         The operation does nothing and produces an error if any of the following is true:
 
          - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}}
             doesn't include {{GPUTextureUsage/COPY_DST}} flag.
          - |destination|.{{GPUTextureCopyView/texture}} is destroyed
-         - [$validating linear texture data$](|sourceLayout|, |sourceData|.byteLength, |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}, |size|) fails.
+         - [$validating linear texture data$](|dataLayout|, |data|.byteLength - |dataOffset|, |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}, |size|) fails.
          - [=Valid Texture Copy Range=] fails to apply to |destination| and |size|.
 
          Note: unlike {{GPUCommandEncoder/copyBufferToTexture()|GPUCommandEncoder.copyBufferToTexture}},
-         there is no alignment requirement on |sourceLayout|.{{GPUTextureDataLayout/bytesPerRow}}.
+         there is no alignment requirement on |dataLayout|.{{GPUTextureDataLayout/bytesPerRow}}.
 </div>
 
     : <dfn>copyImageBitmapToTexture(source, destination, copySize)</dfn>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3773,9 +3773,9 @@ interface GPUQueue {
 
     void writeTexture(
       GPUTextureCopyView destination,
-      GPUExtent3D size,
       GPUTextureDataLayout dataLayout,
-      ArrayBuffer data);
+      ArrayBuffer data,
+      GPUExtent3D size);
 
     void copyImageBitmapToTexture(
         GPUImageBitmapCopyView source,
@@ -3811,7 +3811,7 @@ GPUQueue includes GPUObjectBase;
 </div>
 
 <div algorithm>
-    : <dfn>writeTexture(|destination|, |size|, |dataLayout|, |data|, |dataOffset|)</dfn>
+    : <dfn>writeTexture(|destination|, |dataLayout|, |data|, |size|)</dfn>
     ::
         Takes the |data| contents and schedules a write operation of these contents to the
         |destination| texture copy view in the queue.
@@ -3826,7 +3826,7 @@ GPUQueue includes GPUObjectBase;
          - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}}
             doesn't include {{GPUTextureUsage/COPY_DST}} flag.
          - |destination|.{{GPUTextureCopyView/texture}} is destroyed
-         - [$validating linear texture data$](|dataLayout|, |data|.byteLength - |dataOffset|, |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}, |size|) fails.
+         - [$validating linear texture data$](|dataLayout|, |data|.byteLength, |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}, |size|) fails.
          - [=Valid Texture Copy Range=] fails to apply to |destination| and |size|.
 
          Note: unlike {{GPUCommandEncoder/copyBufferToTexture()|GPUCommandEncoder.copyBufferToTexture}},

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3769,14 +3769,13 @@ interface GPUQueue {
         GPUSize64 bufferOffset,
         ArrayBuffer data,
         optional GPUSize64 dataOffset = 0,
-        optional GPUSize64 size = 0);
+        optional GPUSize64 size);
 
     void writeTexture(
       GPUTextureCopyView destination,
       GPUExtent3D size,
       GPUTextureDataLayout dataLayout,
-      ArrayBuffer data,
-      optional GPUSize64 dataOffset = 0);
+      ArrayBuffer data);
 
     void copyImageBitmapToTexture(
         GPUImageBitmapCopyView source,
@@ -3819,7 +3818,8 @@ GPUQueue includes GPUObjectBase;
         Any subsequent modifications to |data| do not affect what is written
         at the time that the scheduled operation runs.
 
-        The operation throws {{OperationError}} if |dataOffset| exceeds |data|.byteLength.
+        The operation throws {{OperationError}} if |dataLayout|.{{GPUTextureDataLayout/offset}}
+        exceeds |data|.byteLength.
 
         The operation does nothing and produces an error if any of the following is true:
 


### PR DESCRIPTION
This does the following changes to `writeBuffer/Texture`:
  - Reorder the arguments so that the destination comes first. Contrary
to copies that go from source to destination, this writes to an object
some data. So the object written to is more important.
  - Rename `source` to `data`.
  - Rename `destination` to `buffer` in writeBuffer.
  - `dataOffset` is made optional and defaulting to 0. It is also added
to `writeTexture` so that subparts of an `ArrayBuffer` can be selected
without having to create garbage. (and validation updated) (another
reason why the reordering was done)
  - Most of the validation for `writeBuffer` is moved so it can be done
in the GPU process side, instead of synchronously producing an
`OperationError`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/795.html" title="Last updated on May 21, 2020, 1:18 PM UTC (ee7ff1b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/795/cc74459...Kangz:ee7ff1b.html" title="Last updated on May 21, 2020, 1:18 PM UTC (ee7ff1b)">Diff</a>