### PR TITLE
Move pipeline statistics query to render encoder and compute encoder

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3563,9 +3563,6 @@ interface mixin GPUProgrammablePassEncoder {
     void pushDebugGroup(USVString groupLabel);
     void popDebugGroup();
     void insertDebugMarker(USVString markerLabel);
-
-    void beginPipelineStatisticsQuery(GPUQuerySet querySet, GPUSize32 queryIndex);
-    void endPipelineStatisticsQuery(GPUQuerySet querySet, GPUSize32 queryIndex);
 };
 </script>
 
@@ -3582,6 +3579,9 @@ interface GPUComputePassEncoder {
     void setPipeline(GPUComputePipeline pipeline);
     void dispatch(GPUSize32 x, optional GPUSize32 y = 1, optional GPUSize32 z = 1);
     void dispatchIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
+
+    void beginPipelineStatisticsQuery(GPUQuerySet querySet, GPUSize32 queryIndex);
+    void endPipelineStatisticsQuery();
 
     void endPass();
 };
@@ -3632,6 +3632,9 @@ interface GPURenderPassEncoder {
 
     void beginOcclusionQuery(GPUSize32 queryIndex);
     void endOcclusionQuery(GPUSize32 queryIndex);
+
+    void beginPipelineStatisticsQuery(GPUQuerySet querySet, GPUSize32 queryIndex);
+    void endPipelineStatisticsQuery();
 
     void executeBundles(sequence<GPURenderBundle> bundles);
     void endPass();
@@ -3919,7 +3922,9 @@ enum GPUPipelineStatisticName {
 };
 </script>
 
-When resolving pipeline statistics query, each result is written into uint64, and the number and order of the results written to GPU buffer matches the number and order of {{GPUPipelineStatisticName}} specified in {{GPUQuerySetDescriptor/pipelineStatistics}}.
+* When resolving pipeline statistics query, each result is written into uint64, and the number and order of the results written to GPU buffer matches the number and order of {{GPUPipelineStatisticName}} specified in {{GPUQuerySetDescriptor/pipelineStatistics}}.
+
+* {{GPURenderPassEncoder/beginPipelineStatisticsQuery()}} and {{GPURenderPassEncoder/endPipelineStatisticsQuery()}} (on both {{GPUComputePassEncoder}} and {{GPURenderPassEncoder}}) cannot be nested. A pipeline statistics query must be ended before beginning another one.
 
 
 # Canvas Rendering &amp; Swap Chains # {#canvas-rendering}


### PR DESCRIPTION
These query APIs do not support on render bundles, move them to `GPUComputePassEncoder` and `GPURenderPassEncoder`.
Issue: #794


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/haoxli/gpuweb/pull/797.html" title="Last updated on May 27, 2020, 3:24 AM UTC (64ff17e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/797/7861a34...haoxli:64ff17e.html" title="Last updated on May 27, 2020, 3:24 AM UTC (64ff17e)">Diff</a>