### PR TITLE
Disallow using image cube or cube map array texture views as storage textures

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1879,8 +1879,7 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
         1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/sampled-texture}}
             , ensure [=sampled texture validation=] is not violated.
         1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/readonly-storage-texture}} or {{GPUBindingType/writeonly-storage-texture}}
-            1. Ensure [=storage texture validation=] is not violated.
-            1. |bindingDescriptor|.{{GPUBindGroupLayoutEntry/viewDimension}} must not be {{GPUTextureViewDimension/cube}} or {{GPUTextureViewDimension/cube-array}}.
+            , ensure [=storage texture validation=] is not violated.
         1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/sampler}}
             , ensure [=sampler validation=] is not violated.
         1. Insert |bindingDescriptor| into |layout|.{{GPUBindGroupLayout/[[entryMap]]}}
@@ -1921,6 +1920,7 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
         <dfn>storage texture validation</dfn>: There must be {{GPULimits/maxStorageTexturesPerShaderStage|GPULimits.maxStorageTexturesPerShaderStage}} or
             fewer |bindingDescriptor|s of type {{GPUBindingType/readonly-storage-texture}} and {{GPUBindingType/writeonly-storage-texture}} visible on each shader stage in |descriptor|.
             |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} must be `false`.
+            |bindingDescriptor|.{{GPUBindGroupLayoutEntry/viewDimension}} must not be {{GPUTextureViewDimension/cube}} or {{GPUTextureViewDimension/cube-array}}.
 
         <dfn>sampler validation</dfn>: There must be {{GPULimits/maxSamplersPerShaderStage|GPULimits.maxSamplersPerShaderStage}} or
             fewer |bindingDescriptor|s of type {{GPUBindingType/sampler}} visible on each shader stage in |descriptor|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1879,7 +1879,8 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
         1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/sampled-texture}}
             , ensure [=sampled texture validation=] is not violated.
         1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/readonly-storage-texture}} or {{GPUBindingType/writeonly-storage-texture}}
-            , ensure [=storage texture validation=] is not violated.
+            1. Ensure [=storage texture validation=] is not violated.
+            1. |bindingDescriptor|.{{GPUBindGroupLayoutEntry/viewDimension}} must not be {{GPUTextureViewDimension/cube}} or {{GPUTextureViewDimension/cube-array}}.
         1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/sampler}}
             , ensure [=sampler validation=] is not violated.
         1. Insert |bindingDescriptor| into |layout|.{{GPUBindGroupLayout/[[entryMap]]}}


### PR DESCRIPTION
This patch adds validation to disallow using cube map and cube map array
texture views as storage textures as HLSL doesn't support RWTextureCube
or RWTextureCubeArray, and Load() function cannot be called on TextureCube
or TextureCubeArray.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Jiawei-Shao/gpuweb/pull/798.html" title="Last updated on May 21, 2020, 10:32 AM UTC (8b34f8b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/798/6253635...Jiawei-Shao:8b34f8b.html" title="Last updated on May 21, 2020, 10:32 AM UTC (8b34f8b)">Diff</a>