### PR TITLE
Add GPULimits.maxUniformBufferBindingSize.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2117,6 +2117,11 @@ A {{GPUBindGroup}} object has the following internal slots:
                 {{GPUBufferUsage/UNIFORM}} and |bufferBinding|.{{GPUBufferBinding/size}} must be less than or equal
                 {{GPULimits/maxUniformBufferBindingSize}}. The buffer is added to the {{GPUBindGroup/[[usedBuffers]]}}
                 map with {{GPUBufferUsage/UNIFORM}} flag.
+
+                Issue: This validation should take into account the default when  {{GPUBufferBinding/size}} is not set.
+                Also should {{GPUBufferBinding/size}} default to the `buffer.byteLength - offset` or
+                `min(buffer.byteLength - offset, limits.maxUniformBufferBindingSize)`?
+
             1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"storage-buffer"}}
                 or {{GPUBindingType/"readonly-storage-buffer"}}, the
                 |bufferBinding|.{{GPUBufferBinding/buffer}}'s {{GPUBufferDescriptor/usage}} must include

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -838,6 +838,7 @@ dictionary GPULimits {
     GPUSize32 maxStorageBuffersPerShaderStage = 4;
     GPUSize32 maxStorageTexturesPerShaderStage = 4;
     GPUSize32 maxUniformBuffersPerShaderStage = 12;
+    GPUSize32 maxUniformBufferBindingSize = 16384;
 };
 </script>
 
@@ -937,6 +938,12 @@ dictionary GPULimits {
 
         across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
         when creating a {{GPUPipelineLayout}}.
+
+        Higher is [=better=].
+
+    : <dfn>maxUniformBufferBindingSize</dfn>
+    ::
+        The maximum {{GPUBufferBinding}}.{{GPUBufferBinding/size}} for bindings of type {{GPUBindingType/uniform-buffer}}.
 
         Higher is [=better=].
 </dl>
@@ -2107,8 +2114,9 @@ A {{GPUBindGroup}} object has the following internal slots:
             This |layoutBinding| must be compatible with this |bufferBinding|. This requires:
             1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"uniform-buffer"}},
                 the |bufferBinding|.{{GPUBufferBinding/buffer}}'s {{GPUBufferDescriptor/usage}} must include
-                {{GPUBufferUsage/UNIFORM}}. The buffer is added to the {{GPUBindGroup/[[usedBuffers]]}} map
-                with {{GPUBufferUsage/UNIFORM}} flag.
+                {{GPUBufferUsage/UNIFORM}} and |bufferBinding|.{{GPUBufferBinding/size}} must be less than
+                {{GPULimits/maxUniformBufferBindingSize}}. The buffer is added to the {{GPUBindGroup/[[usedBuffers]]}}
+                map with {{GPUBufferUsage/UNIFORM}} flag.
             1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"storage-buffer"}}
                 or {{GPUBindingType/"readonly-storage-buffer"}}, the
                 |bufferBinding|.{{GPUBufferBinding/buffer}}'s {{GPUBufferDescriptor/usage}} must include

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2114,7 +2114,7 @@ A {{GPUBindGroup}} object has the following internal slots:
             This |layoutBinding| must be compatible with this |bufferBinding|. This requires:
             1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"uniform-buffer"}},
                 the |bufferBinding|.{{GPUBufferBinding/buffer}}'s {{GPUBufferDescriptor/usage}} must include
-                {{GPUBufferUsage/UNIFORM}} and |bufferBinding|.{{GPUBufferBinding/size}} must be less than
+                {{GPUBufferUsage/UNIFORM}} and |bufferBinding|.{{GPUBufferBinding/size}} must be less than or equal
                 {{GPULimits/maxUniformBufferBindingSize}}. The buffer is added to the {{GPUBindGroup/[[usedBuffers]]}}
                 map with {{GPUBufferUsage/UNIFORM}} flag.
             1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"storage-buffer"}}


### PR DESCRIPTION
Start with a minimum maximum of 2^14 as that's the limit in Vulkan
that's hit for various ARM devices and for Swiftshader. Limits for Metal
and D3D12 are unclear but should be more than this.

The limit could be increased if we decided that the ARM devices should
be falling back to a WebGPU-compatibility feature level instead.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/803.html" title="Last updated on May 27, 2020, 9:36 AM UTC (54c3577)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/803/c6d1fb9...Kangz:54c3577.html" title="Last updated on May 27, 2020, 9:36 AM UTC (54c3577)">Diff</a>