### PR TITLE
Remove NOP.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -421,7 +421,6 @@ Note: literals are parsed greedy. This means that for statements like `a -5`
   <tr><td>`KILL`<td>kill
   <tr><td>`LOCATION`<td>location
   <tr><td>`LOOP`<td>loop
-  <tr><td>`NOP`<td>nop
   <tr><td>`OFFSET`<td>offset
   <tr><td>`OUT`<td>out
   <tr><td>`PRIVATE`<td>private
@@ -1006,7 +1005,6 @@ statement
   | break_stmt SEMICOLON
   | continue_stmt SEMICOLON
   | KILL SEMICOLON
-  | NOP SEMICOLON
   | assignment_stmt SEMICOLON
 
 variable_stmt
@@ -1087,7 +1085,7 @@ The loop construct causes a block of statements, the *loop body*, to execute rep
 
 This repetition can be interrupted by a [[#break-statement]], `return`, or `kill`.
 
-Optionally, the last statement in the loop body may be a 
+Optionally, the last statement in the loop body may be a
 [[#continuing-statement]].
 
 Note: The loop statement is one of the biggest differences from other shader


### PR DESCRIPTION
The NOP command was put in to satisfy complete bijectivity to SPIR-V.
Since that is not a goal anymore, the nop is no longer necessary.
Removed.