### PR TITLE
GPUSamplerDescriptor and GPUSampler creation spec 

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1703,7 +1703,13 @@ enum GPUTextureComponentType {
 
 # Samplers # {#samplers}
 
-## GPUSampler ## {#sampler}
+## <dfn interface>GPUSampler</dfn> ## {#sampler-interface}
+
+A {{GPUSampler}} encodes transformations and filtering information that can
+be used in a shader to interpret texture resource data. 
+
+{{GPUSampler|GPUSamplers}} are created via {{GPUDevice/createSampler(descriptor)|GPUDevice.createSampler(optional descriptor)}}
+that returns a new sampler object.
 
 <script type=idl>
 interface GPUSampler {
@@ -1711,16 +1717,22 @@ interface GPUSampler {
 GPUSampler includes GPUObjectBase;
 </script>
 
-
 {{GPUSampler}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUSampler">
+    : <dfn>\[[descriptor]]</dfn>, of type {{GPUSamplerDescriptor}}, readonly
+    ::
+        The {{GPUSamplerDescriptor}} with which the {{GPUSampler}} was created.
     : <dfn>\[[compareEnable]]</dfn> of type {{boolean}}.
     ::
         Whether the {{GPUSampler}} is used as a comparison sampler.
 </dl>
 
-### Creation ### {#sampler-creation}
+## Sampler Creation ## {#sampler-creation}
+
+### {{GPUSamplerDescriptor}} ### {#GPUSamplerDescriptor}
+
+A {{GPUSamplerDescriptor}} specifies the options to use to create a {{GPUSampler}}.
 
 <script type=idl>
 dictionary GPUSamplerDescriptor : GPUObjectDescriptorBase {
@@ -1736,23 +1748,25 @@ dictionary GPUSamplerDescriptor : GPUObjectDescriptorBase {
 };
 </script>
 
-### {{GPUDevice}}.<dfn method for=GPUDevice>createSampler(descriptor)</dfn> ### {#sampler-createsampler}
+- {{GPUSamplerDescriptor/addressModeU}}, {{GPUSamplerDescriptor/addressModeV}}, 
+    and {{GPUSamplerDescriptor/addressModeW}} specify the address modes for the texture width,
+    height, and depth coordinates, respectively.
+- {{GPUSamplerDescriptor/magFilter}} specifies the sampling behavior when the sample footprint
+    is smaller than or equal to one texel.
+- {{GPUSamplerDescriptor/minFilter}} specifies the sampling behavior when the sample footprint 
+    is larger than one texel.
+- {{GPUSamplerDescriptor/mipmapFilter}} specifies behavior for sampling between two mipmap levels.
+- {{GPUSamplerDescriptor/lodMinClamp}} and {{GPUSamplerDescriptor/lodMaxClamp}} specify the minimum and
+    maximum levels of detail, respectively, used internally when sampling a texture.
+- If {{GPUSamplerDescriptor/compare}} is provided, the sampler will be a comparison sampler with the specified
+    {{GPUCompareFunction}}.
 
-<div algorithm=GPUDevice.createSampler>
-    **Arguments:**
-        - optional {{GPUSamplerDescriptor}} |descriptor| = {}
+Issue: explain how LOD is calculated and if there are differences here between platforms.
 
-    **Returns:** {{GPUSampler}}
+{{GPUAddressMode}} describes the behavior of the sampler if the sample footprint extends beyond
+the bounds of the sampled texture.
 
-    1. Let |s| be a new {{GPUSampler}} object.
-    1. Set the {{GPUSampler/[[compareEnable]]}} slot of |s| to false if the {{GPUSamplerDescriptor/compare}} attribute
-            of |descriptor| is null or undefined. Otherwise, set it to true.
-    1. Return |s|.
-
-    <div class=validusage dfn-for=GPUDevice.createSampler>
-        <dfn abstract-op>Valid Usage</dfn>
-    </div>
-</div>
+Issue: Describe a "sample footprint" in greater detail.
 
 <script type=idl>
 enum GPUAddressMode {
@@ -1762,12 +1776,46 @@ enum GPUAddressMode {
 };
 </script>
 
+<dl dfn-type="enum-value" dfn-for=GPUAddressMode>
+    : <dfn>"clamp-to-edge"</dfn>
+    ::
+        Texture coordinates are clamped between 0.0 and 1.0, inclusive.
+
+    : <dfn>"repeat"</dfn>
+    ::
+        Texture coordinates wrap to the other side of the texture.
+
+    : <dfn>"mirror-repeat"</dfn>
+    ::
+        Texture coordinates wrap to the other side of the texture, but the texture is flipped
+        when the integer part of the coordinate is odd. 
+</dl>
+
+{{GPUFilterMode}} describes the behavior of the sampler if the sample footprint does not exactly 
+match one texel.
+
 <script type=idl>
 enum GPUFilterMode {
     "nearest",
     "linear"
 };
 </script>
+
+<dl dfn-type="enum-value" dfn-for=GPUFilterMode>
+    : <dfn>"nearest"</dfn>
+    ::
+        Return the value of the texel nearest to the texture coordinates.
+
+    : <dfn>"linear"</dfn>
+    ::
+        Select two texels in each dimension and return a linear interpolation between their values. 
+</dl>
+
+{{GPUCompareFunction}} specifies the behavior of a comparison sampler. If a comparison sampler is
+used in a shader, an input value is compared to the sampled texture value, and the result of this 
+comparison test (0.0f for pass, or 1.0f for fail) is used in the filtering operation.
+
+Issue: describe how filtering interacts with comparison sampling.
 
 <script type=idl>
 enum GPUCompareFunction {
@@ -1782,6 +1830,77 @@ enum GPUCompareFunction {
 };
 </script>
 
+<dl dfn-type="enum-value" dfn-for=GPUCompareFunction>
+    : <dfn>"never"</dfn>
+    ::
+        Comparison tests never pass.
+
+    : <dfn>"less"</dfn>
+    ::
+        A provided value passes the comparison test if it is less than the sampled value.
+
+    : <dfn>"equal"</dfn>
+    ::
+        A provided value passes the comparison test if it is equal to the sampled value.
+
+    : <dfn>"less-equal"</dfn>
+    ::
+        A provided value passes the comparison test if it is less than or equal to the sampled value.
+
+    : <dfn>"greater"</dfn>
+    ::
+        A provided value passes the comparison test if it is greater than the sampled value.
+
+    : <dfn>"not-equal"</dfn>
+    ::
+        A provided value passes the comparison test if it is not equal to the sampled value.
+
+    : <dfn>"greater-equal"</dfn>
+    ::
+        A provided value passes the comparison test if it is greater than or equal to the sampled value.
+
+    : <dfn>"always"</dfn>
+    ::
+        Comparison tests always pass.
+</dl>
+
+<div algorithm>
+    <dfn abstract-op>validating GPUSamplerDescriptor</dfn>(device, descriptor)
+    **Arguments:**
+        - {{GPUDevice}} |device|
+        - {{GPUSamplerDescriptor}} |descriptor|
+    
+    **Returns:** boolean
+
+    Return true if and only if all of the following conditions apply:
+        - |device| is valid.
+        - |descriptor|.{{GPUSamplerDescriptor/lodMinClamp}} is greater than or equal to 0.
+        - |descriptor|.{{GPUSamplerDescriptor/lodMaxClamp}} is greater than or equal to
+            |descriptor|.{{GPUSamplerDescriptor/lodMinClamp}}.
+</div>
+
+### {{GPUDevice}}.<dfn method for=GPUDevice>createSampler(descriptor)</dfn> ### {#sampler-createsampler}
+
+<div algorithm=GPUDevice.createSampler>
+    **Arguments:**
+        - optional {{GPUSamplerDescriptor}} |descriptor| = {}
+
+    **Returns:** {{GPUSampler}}
+
+    1. Let |s| be a new {{GPUSampler}} object.
+    1. Set |s|.{{GPUSampler/[[descriptor]]}} to |descriptor|.
+    1. Set |s|.{{GPUSampler/[[compareEnable]]}} to false if the {{GPUSamplerDescriptor/compare}} attribute
+            of |s|.{{GPUSampler/[[descriptor]]}} is null or undefined. Otherwise, set it to true.
+    1. Return |s|.
+
+    <div class=validusage dfn-for=GPUDevice.createSampler>
+        <dfn abstract-op>Valid Usage</dfn>
+        - If |descriptor| is not null or undefined:
+            - If [$validating GPUSamplerDescriptor$](this, |descriptor|) returns false:
+                1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
+                1. Create a new [=invalid=] {{GPUSampler}} and return the result.
+    </div>
+</div>
 
 # Resource Binding # {#bindings}
 


### PR DESCRIPTION
I'm sure I'm missing a lot! We've talked about just saving the entire descriptor in the `GPU` object before, but I don't think I saw another instance where we were doing that.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JusSn/gpuweb/pull/805.html" title="Last updated on Jun 8, 2020, 7:49 PM UTC (807b509)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/805/6d6e392...JusSn:807b509.html" title="Last updated on Jun 8, 2020, 7:49 PM UTC (807b509)">Diff</a>