### PR TITLE
Put some writeBuffer validation on the device timeline

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4031,14 +4031,14 @@ GPUQueue includes GPUObjectBase;
 
         The operation throws {{OperationError}} if any of the following is true:
         - |buffer| buffer isn't in the `"unmapped"` [=buffer state=].
-        - |bufferOffset| is not a multiple of 4.
-        - |size| is not a positive multiple of 4.
         - |dataOffset| + |size| exceeds |data|.byteLength.
 
         The operation does nothing and produces an error if any of the following is true:
         - |bufferOffset| + |size| exceeds |buffer|.{{GPUBuffer/[[size]]}}.
         - |buffer|.{{GPUBuffer/[[usage]]}} doesn't include {{GPUBufferUsage/COPY_DST}} flag.
         - |buffer| buffer is destroyed
+        - |bufferOffset| is not a multiple of 4.
+        - |size| is not a positive multiple of 4.
 </div>
 
 <div algorithm>


### PR DESCRIPTION
FYI this is what was promised on the last PR. But specifically for writeBuffer I think all the content timeline validation makes sense because it allows knowing more about the copy that's going to be performed into shmem. So closing this immediately.