### PR TITLE
Add GPUTextureDescriptor.viewFormats

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1459,6 +1459,11 @@ GPUTexture includes GPUObjectBase;
     ::
         The allowed usages for this {{GPUTexture}}.
 
+    : <dfn>\[[viewFormats]]</dfn> of type `sequence<{{GPUTextureFormat}}>`.
+    ::
+        The usages that are allowed to be used as {{GPUTextureViewDescriptor}}.{{GPUTextureViewDescriptor/format}}
+        for views created from thie {{GPUTexture}}.
+
 </dl>
 
 ### Texture Creation ### {#texture-creation}
@@ -1471,6 +1476,7 @@ dictionary GPUTextureDescriptor : GPUObjectDescriptorBase {
     GPUTextureDimension dimension = "2d";
     required GPUTextureFormat format;
     required GPUTextureUsageFlags usage;
+    sequence<GPUTextureFormat> viewFormats;
 };
 </script>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1461,8 +1461,10 @@ GPUTexture includes GPUObjectBase;
 
     : <dfn>\[[viewFormats]]</dfn> of type `sequence<{{GPUTextureFormat}}>`.
     ::
-        The usages that are allowed to be used as {{GPUTextureViewDescriptor}}.{{GPUTextureViewDescriptor/format}}
-        for views created from thie {{GPUTexture}}.
+        The additional formats that are allowed to be used as {{GPUTextureViewDescriptor}}.{{GPUTextureViewDescriptor/format}}
+        for views created from this {{GPUTexture}}.
+
+        The base texture format {{GPUTextureFormatDescriptor/format}} is always allowed.
 
 </dl>
 


### PR DESCRIPTION
This is an addition that would allow using different view formats than the texture's main format.

On Metal it would translate to looking at whether the format can be reinterpreted without the `MTLTextureUsagePixelFormatView` usage flag. I believe it is possible for example between `rgba8-unorm`, `rgba8-unorm-srgb` and `rgba8-uint`. On the other hand, conversion between `rgba8-unorm` and `r32-uint` wouldn't be free like that.

On Vulkan it would translate to using `VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT` if any format is set. That flag is a bit pessimistic so when available we'd use [VK_KHR_image_format_list](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_KHR_image_format_list.html) instead.

On D3D12, well I'm not sure because I wasn't not able to find the relevant documentation again. But something similar would happen (like we'd use a typeless format only if we need to).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/811.html" title="Last updated on May 28, 2020, 8:37 AM UTC (b7e0143)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/811/bbda4fd...Kangz:b7e0143.html" title="Last updated on May 28, 2020, 8:37 AM UTC (b7e0143)">Diff</a>