### PR TITLE
Fix getMappedRange arguments

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1323,7 +1323,7 @@ Issue(gpuweb/gpuweb#605): Add client-side validation that a mapped buffer can
   </div>
 </div>
 
-### <dfn method for=GPUBuffer>getMappedRange(start, offset)</dfn> ### {#GPUBuffer-getMappedRange}
+### <dfn method for=GPUBuffer>getMappedRange(offset, size)</dfn> ### {#GPUBuffer-getMappedRange}
 
 <div algorithm="GPUBuffer.getMappedRange">
   <strong>|this|:</strong> of type {{GPUBuffer}}.


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/813.html" title="Last updated on May 27, 2020, 3:16 PM UTC (cfeda23)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/813/bbda4fd...cfeda23.html" title="Last updated on May 27, 2020, 3:16 PM UTC (cfeda23)">Diff</a>