### PR TITLE
[wgsl] Minor spec cleanups.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1027,7 +1027,7 @@ Otherwise the expression must be present, and is called the *return value*.
 In this case the call site of this function invocation evaluates to the return value.
 The type of the return value must match the return type of the function.
 
-## Variable Statement ## { #var-statement}
+## Variable Statement ## {#var-statement}
 <pre class='def'>
 variable_stmt
   : variable_decl

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -416,7 +416,7 @@ Note: literals are parsed greedy. This means that for statements like `a -5`
   <tr><td>`FUNCTION`<td>function
   <tr><td>`IF`<td>if
   <tr><td>`IMAGE`<td>image
-  <tr><td>`IMPORT_`<td>import
+  <tr><td>`IMPORT`<td>import
   <tr><td>`IN`<td>in
   <tr><td>`KILL`<td>kill
   <tr><td>`LOCATION`<td>location
@@ -748,7 +748,7 @@ type_decl
   | UINT32
   | VEC2 LESS_THAN type_decl GREATER_THAN
   | VEC3 LESS_THAN type_decl GREATER_THAN
-  | VEC3 LESS_THAN type_decl GREATER_THAN
+  | VEC4 LESS_THAN type_decl GREATER_THAN
   | PTR LESS_THAN storage_class, type_decl GREATER_THAN
   | ARRAY LESS_THAN type_decl COMMA INT_LITERAL GREATER_THAN
   | ARRAY LESS_THAN type_decl GREATER_THAN
@@ -1006,7 +1006,29 @@ statement
   | continue_stmt SEMICOLON
   | KILL SEMICOLON
   | assignment_stmt SEMICOLON
+</pre>
 
+## Return statement ## {#return-statement}
+
+<pre class='def'>
+return_stmt
+  : RETURN logical_or_expression?
+</pre>
+
+A `return` statement ends execution of the current function.
+If the function is an entry point, then the current shader invocation
+is terminated.
+Otherwise, evaluation continues with the next expression or statement after
+the evaluation of the call site of the current function invocation.
+
+If the return type of the function is the void type, then the return statement
+must not have an expression.
+Otherwise the expression must be present, and is called the *return value*.
+In this case the call site of this function invocation evaluates to the return value.
+The type of the return value must match the return type of the function.
+
+## Variable Statement ## { #var-statement}
+<pre class='def'>
 variable_stmt
   : variable_decl
   | variable_decl EQUAL logical_or_expression
@@ -1019,7 +1041,7 @@ if_stmt
   : IF paren_rhs_stmt body_stmt elseif_stmt? else_stmt?
 
 elseif_stmt
-  :ELSE_IF paren_rhs_stmt body_stmt elseif_stmt?
+  : ELSE_IF paren_rhs_stmt body_stmt elseif_stmt?
 
 else_stmt
   : ELSE body_stmt
@@ -1241,7 +1263,7 @@ control past a declaration used in the targeted continuing construct.
 
 ## Continuing statement ## {#continuing-statement}
 
-<pre>
+<pre class='def'>
 continuing_stmt:
   : CONTINUING body_stmt
 </pre>
@@ -1421,25 +1443,6 @@ const_expr
          %f = OpConstantComposite %v4float %f0 %f1 %f2 %f1
   </xmp>
 </div>
-
-## Return statement ## {#return-statement}
-
-<pre>
-return_stmt
-  : RETURN logical_or_expression?
-</pre>
-
-A `return` statement ends execution of the current function.
-If the function is an entry point, then the current shader invocation
-is terminated.
-Otherwise, evaluation continues with the next expression or statement after
-the evaluation of the call site of the current function invocation.
-
-If the return type of the function is the void type, then the return statement
-must not have an expression.
-Otherwise the expression must be present, and is called the *return value*.
-In this case the call site of this function invocation evaluates to the return value.
-The type of the return value must match the return type of the function.
 
 # Validation # {#validation}
 


### PR DESCRIPTION
This CL fixes up a couple incorrect formatting options in the spec and
moves the return statement up to a spot where it makes a bit more sense.