### PR TITLE
[wgsl] Fix definition of const_expr

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1392,7 +1392,7 @@ const_literal
   | FALSE
 
 const_expr
-  : type_decl PAREN_LEFT (const_expr COMMA)? const_expr PAREN_RIGHT
+  : type_decl PAREN_LEFT (const_expr COMMA)* const_expr PAREN_RIGHT
   | const_literal
 </pre>
 


### PR DESCRIPTION
This CL updates the const_expr to use the proper * instead of ?.

Fixes #800