### PR TITLE
Clarify t2t copy same texture

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3530,7 +3530,7 @@ The following validation rules apply:
   - [=Valid Texture Copy Range=] applies to |source| and |copySize|.
   - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
   - If |source|.{{GPUTextureCopyView/texture}} and |destination|.{{GPUTextureCopyView/texture}} are the same texture:
-    - If the {{GPUTexture/[[dimension]]}} of |source|.{{GPUTextureCopyView/texture}} and |destination|.{{GPUTextureCopyView/texture}} are both {{GPUTextureDimension/2d}}:
+    - If the {{GPUTexture/[[dimension]]}} of |source|.{{GPUTextureCopyView/texture}} is {{GPUTextureDimension/2d}}:
       -|source|.{{GPUTextureCopyView/origin}}.[=Origin3D/z=] must not be equal to |destination|.{{GPUTextureCopyView/origin}}.[=Origin3D/z=].
     - The region specified by |source|.{{GPUTextureCopyView/origin}} and |copySize|, and the region specified by |destination|.{{GPUTextureCopyView/origin}} and |copySize|, must not overlap.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3529,25 +3529,11 @@ The following validation rules apply:
   For the copy ranges:
   - [=Valid Texture Copy Range=] applies to |source| and |copySize|.
   - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
-  - The [$set of subresources for texture copy$](|source|, |copySize|) and
-     the  [$set of subresources for texture copy$](|destination|, |copySize|) must be disjoint.
+  - If |source|.{{GPUTextureCopyView/texture}} and |destination|.{{GPUTextureCopyView/texture}} are the same texture:
+    - If the {{GPUTexture/[[dimension]]}} of |source|.{{GPUTextureCopyView/texture}} and |destination|.{{GPUTextureCopyView/texture}} are both {{GPUTextureDimension/2d}}:
+      -|source|.{{GPUTextureCopyView/origin}}.[=Origin3D/z=] must not be equal to |destination|.{{GPUTextureCopyView/origin}}.[=Origin3D/z=].
+    - The region specified by |source|.{{GPUTextureCopyView/origin}} and |copySize|, and the region specified by |destination|.{{GPUTextureCopyView/origin}} and |copySize|, must not overlap.
 
-</div>
-
-<div algorithm>
-    The <dfn abstract-op>set of subresources for texture copy</dfn>(|textureCopyView|, |copySize|)
-    is the set containing:
-
-      - If |textureCopyView|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[dimension]]}}
-        is {{GPUTextureDimension/"2d"}}:
-          - For each |arrayLayer| of the |copySize|.[=Extent3D/depth=] [=array layers=]
-            starting at |textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/z=]:
-              - The [=subresource=] of |textureCopyView|.{{GPUTextureCopyView/texture}} at
-                [=mipmap level=] |textureCopyView|.{{GPUTextureCopyView/mipLevel}} and
-                [=array layer=] |arrayLayer|.
-      - Otherwise:
-          - The [=subresource=] of |textureCopyView|.{{GPUTextureCopyView/texture}} at
-            [=mipmap level=] |textureCopyView|.{{GPUTextureCopyView/mipLevel}}.
 </div>
 
 ## Debug Markers ## {#command-encoder-debug-markers}


### PR DESCRIPTION
This patch intends to clarify the validation rules on the texture-to
-texture copies when the source and destination textures are the
same one.
- when the source and destination textures are both 2D textures, we
  cannot allow the source base array layer being equal to the
  destination base array layer as D3D12 function CopyTextureRegion()
  requires the source and destination resources must be different
  subresources.
- the copy source and destination region must not overlap as is
  required in Vulkan SPEC.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 1, 2020, 8:50 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FJiawei-Shao%2Fgpuweb%2F10b3f6820d975a4db69cb84eb116b6611584fd00%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%23823.)._
</details>
