### PR TITLE
Remove workgroup_size from builtin list.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -618,9 +618,6 @@ variable_decoration
     [[builtin num_workgroups]]
           OpDecorate %gl_NumWorkGroups BuiltIn NumWorkgroups
 
-    [[builtin workgroup_size]]
-          OpDecorate %gl_WorkGroupSize BuiltIn WorkgroupSize
-
     [[builtin local_invocation_id]]
           OpDecorate %gl_LocalInvocationID BuiltIn LocalInvocationId
 
@@ -646,7 +643,6 @@ type, function decorations and storage class.
     <tr><td>frag_coord<td>vec4&ltf32&gt<td>Fragment Input
     <tr><td>frag_depth<td>f32<td>Fragment Output
     <tr><td>num_workgroups<td>vec3&ltu32&gt<td>Compute Input
-    <tr><td>workgroup_size<td>vec3&ltu32&gt<td>Compute Input
     <tr><td>local_invocation_id<td>vec3&ltu32&gt<td>Compute Input
     <tr><td>global_invocation_id<td>vec3&ltu32&gt<td>Compute Input
     <tr><td>local_invocation_idx<td>u32<td>Compute Input


### PR DESCRIPTION
The WorkgroupSize in Vulkan is special in that it must be set on a
specialization constant or a constant value. This CL removes it from the
list as it was not correctly specified with this restriction.

Issue #750