### PR TITLE
Documenting render pass creation and descriptors

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1508,6 +1508,20 @@ interface GPUTextureView {
 GPUTextureView includes GPUObjectBase;
 </script>
 
+{{GPUTextureView}} has the following internal slots:
+
+<dl dfn-type=attribute dfn-for="GPUTextureView">
+    : <dfn>\[[texture]]</dfn>
+    ::
+        The {{GPUTexture}} into which this is a view.
+
+    : <dfn>\[[descriptor]]</dfn>
+    ::
+        The {{GPUTextureViewDescriptor}} describing this texture view.
+
+        All optional fields of {{GPUTextureViewDescriptor}} are defined.
+</dl>
+
 ### Texture View Creation ### {#texture-view-creation}
 
 <script type=idl>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3148,6 +3148,19 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 
             - Set |this|.{{GPUCommandEncoder/[[state]]}} to {{encoder state/encoding a render pass}}.
 
+            - For each |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
+
+                - Each texture [=subresource=] seen by |colorAttachment|.{{GPURenderPassColorAttachmentDescriptor/attachment}}
+                    is considered to be used as {{GPUTextureUsage/OUTPUT_ATTACHMENT}} for the
+                    duration of the render pass.
+
+            - Let |depthStencilAttachment| be |descriptor|.{{GPURenderPassDescriptor/depthStencilAttachment}}.
+            - If |depthStencilAttachment| is not `null`:
+
+                - Each texture [=subresource=] seen by |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}
+                    is considered to be used as {{GPUTextureUsage/OUTPUT_ATTACHMENT}} for the
+                    duration of the render pass.
+
     <div class=validusage dfn-for=GPUCommandEncoder.beginRenderPass>
         <dfn abstract-op>Valid Usage</dfn>
 
@@ -3987,8 +4000,8 @@ dictionary GPURenderPassColorAttachmentDescriptor {
 <dl dfn-type=dict-member dfn-for=GPURenderPassColorAttachmentDescriptor>
     : <dfn>attachment</dfn>
     ::
-        A {{GPUTextureView}} describing the texture [=subresource=] the [=pipeline=] will output to
-        for this color attachment.
+        A {{GPUTextureView}} describing the texture [=subresource=] that will be output to for this
+        color attachment.
 
     : <dfn>resolveTarget</dfn>
     ::
@@ -3998,11 +4011,15 @@ dictionary GPURenderPassColorAttachmentDescriptor {
 
     : <dfn>loadValue</dfn>
     ::
-        Issue: Describe this dictionary member
+        If a {{GPULoadOp}}, indicates the load operation to perform on
+        {{GPURenderPassColorAttachmentDescriptor/attachment}} prior to executing the render pass.
+        If a {{GPUColor}}, indicates the value to clear {{GPURenderPassColorAttachmentDescriptor/attachment}}
+        to prior to executing the render pass.
 
     : <dfn>storeOp</dfn>
     ::
-        Issue: Describe this dictionary member
+        The store operation to perform on {{GPURenderPassColorAttachmentDescriptor/attachment}}
+        after executing the render pass.
 </dl>
 
 <div class=validusage dfn-for=GPURenderPassColorAttachmentDescriptor>
@@ -4012,7 +4029,9 @@ dictionary GPURenderPassColorAttachmentDescriptor {
     apply:
 
     1. |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}} must have a renderable color format.
-    1. |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}}.{{GPUTexture/[[textureUsage]]}} must contain {{GPUTextureUsage/OUTPUT_ATTACHMENT}}.
+    1. |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}}.{{GPUTexture/[[textureUsage]]}}
+        must contain {{GPUTextureUsage/OUTPUT_ATTACHMENT}}.
+    1. |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}} must be a view of a single [=subresource=].
     1. If |this|.{{GPURenderPassColorAttachmentDescriptor/resolveTarget}} is not `null`:
 
         1. |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}} must be multisampled.
@@ -4047,32 +4066,45 @@ dictionary GPURenderPassDepthStencilAttachmentDescriptor {
 <dl dfn-type=dict-member dfn-for=GPURenderPassDepthStencilAttachmentDescriptor>
     : <dfn>attachment</dfn>
     ::
-        A {{GPUTextureView}} describing the texture [=subresource=] the [=pipeline=] will output to
+        A {{GPUTextureView}} describing the texture [=subresource=] that will be output to
         and read from for this depth/stencil attachment.
 
     : <dfn>depthLoadValue</dfn>
     ::
-        Issue: Describe this dictionary member
+        If a {{GPULoadOp}}, indicates the load operation to perform on
+        {{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}'s depth component prior to
+        executing the render pass.
+        If a `float`, indicates the value to clear {{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}'s
+        depth component to prior to executing the render pass.
 
     : <dfn>depthStoreOp</dfn>
     ::
-        Issue: Describe this dictionary member
+        The store operation to perform on {{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}'s
+        depth component after executing the render pass.
 
     : <dfn>depthReadOnly</dfn>
     ::
-        Indicates that the depth component of the attachment is read only.
+        Indicates that the depth component of {{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}
+        is read only.
 
     : <dfn>stencilLoadValue</dfn>
     ::
-        Issue: Describe this dictionary member
+        If a {{GPULoadOp}}, indicates the load operation to perform on
+        {{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}'s stencil component prior to
+        executing the render pass.
+        If a {{GPUStencilValue}}, indicates the value to clear
+        {{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}'s stencil component to prior to
+        executing the render pass.
 
     : <dfn>stencilStoreOp</dfn>
     ::
-        Issue: Describe this dictionary member
+        The store operation to perform on {{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}'s
+        stencil component after executing the render pass.
 
     : <dfn>stencilReadOnly</dfn>
     ::
-        Indicates that the stencil component of the attachment is read only.
+        Indicates that the stencil component of {{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}
+        is read only.
 </dl>
 
 <div class=validusage dfn-for=GPURenderPassDepthStencilAttachmentDescriptor>
@@ -4081,11 +4113,18 @@ dictionary GPURenderPassDepthStencilAttachmentDescriptor {
     Given a {{GPURenderPassDepthStencilAttachmentDescriptor}} |this| the following validation
     rules apply:
 
-    1. |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}} must have a renderable depth-and/or-stencil format.
+    1. |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}} must have a renderable
+        depth-and/or-stencil format.
+    1. |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}} must be a view of a
+        single [=subresource=].
     1. |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/depthReadOnly}} is `true`,
-        |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/depthLoadValue}} must be {{GPULoadOp/"load"}}.
+        |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/depthLoadValue}} must be
+        {{GPULoadOp/"load"}} and |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/depthStoreOp}}
+        must be {{GPUStoreOp/"store"}}.
     1. |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/stencilReadOnly}} is `true`,
-        |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/stencilLoadValue}} must be {{GPULoadOp/"load"}}.
+        |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/stencilLoadValue}} must be
+        {{GPULoadOp/"load"}} and |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/stencilStoreOp}}
+        must be {{GPUStoreOp/"store"}}.
 
     Issue: Describe the remaining validation rules for this type.
 </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3128,6 +3128,38 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 };
 </script>
 
+## Pass Encoding ## {#command-encoder-pass-encoding}
+
+### <dfn method for=GPUCommandEncoder>beginRenderPass(descriptor)</dfn> ### {#GPUCommandEncoder-beginRenderPass}
+
+<div algorithm="GPUCommandEncoder.beginRenderPass">
+    <strong>|this|:</strong> of type {{GPUCommandEncoder}}.
+
+    **Arguments:**
+        - {{GPURenderPassDescriptor}} |descriptor|
+
+    **Returns:** GPURenderPassEncoder
+
+    Begins encoding a render pass described by |descriptor|.
+
+    On the [=Device timeline=], the following steps occur:
+
+        - If the [$GPUCommandEncoder.beginRenderPass/Valid Usage$] rules are met:
+
+            - Set |this|.{{GPUCommandEncoder/[[state]]}} to {{encoder state/encoding a render pass}}.
+
+    <div class=validusage dfn-for=GPUCommandEncoder.beginRenderPass>
+        <dfn abstract-op>Valid Usage</dfn>
+
+        Given the argument {{GPURenderPassDescriptor}} |descriptor|, the following validation rules apply:
+
+          1. |this|.{{GPUCommandEncoder/[[state]]}} must be {{encoder state/open}}.
+          1. |descriptor| must meet the
+            [$GPURenderPassDescriptor/Valid Usage|GPURenderPassDescriptor Valid Usage$] rules.
+
+    </div>
+</div>
+
 ## Copy Commands ## {#copy-commands}
 
 ### <dfn dictionary>GPUTextureDataLayout</dfn> ### {#gpu-texture-data-layout}
@@ -3898,6 +3930,38 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
 };
 </script>
 
+<dl dfn-type=dict-member dfn-for=GPURenderPassDescriptor>
+    : <dfn>colorAttachments</dfn>
+    ::
+        The set of {{GPURenderPassColorAttachmentDescriptor}} values in this sequence defines which
+        color attachments will be output to when executing this render pass.
+
+    : <dfn>depthStencilAttachment</dfn>
+    ::
+        The {{GPURenderPassDepthStencilAttachmentDescriptor}} value that defines the depth/stencil
+        attachment that will be output to and tested against when executing this render pass.
+
+    : <dfn>occlusionQuerySet</dfn>
+    ::
+        Issue: Describe this dictionary member
+</dl>
+
+<div class=validusage dfn-for=GPURenderPassDescriptor>
+    <dfn abstract-op>Valid Usage</dfn>
+
+    Given a {{GPURenderPassDescriptor}} |this| the following validation rules apply:
+
+    1. |this|.{{GPURenderPassDescriptor/colorAttachments}}.length must greater than `0` or
+        |this|.{{GPURenderPassDescriptor/depthStencilAttachment}} must not be `null`.
+    1. For each |colorAttachment| in |this|.{{GPURenderPassDescriptor/colorAttachments}}:
+
+        1. |colorAttachment| must meet the [$GPURenderPassColorAttachmentDescriptor/Valid Usage|GPURenderPassColorAttachmentDescriptor Valid Usage$] rules.
+
+    1. If |this|.{{GPURenderPassDescriptor/depthStencilAttachment}} is not `null`:
+
+        1. |this|.{{GPURenderPassDescriptor/depthStencilAttachment}} must meet the [$GPURenderPassDepthStencilAttachmentDescriptor/Valid Usage|GPURenderPassDepthStencilAttachmentDescriptor Valid Usage$] rules.
+</div>
+
 #### Color Attachments #### {#color-attachments}
 
 <script type=idl>
@@ -3909,6 +3973,45 @@ dictionary GPURenderPassColorAttachmentDescriptor {
     GPUStoreOp storeOp = "store";
 };
 </script>
+
+<dl dfn-type=dict-member dfn-for=GPURenderPassColorAttachmentDescriptor>
+    : <dfn>attachment</dfn>
+    ::
+        A {{GPUTextureView}} describing the texture [=subresource=] the [=pipeline=] will output to
+        for this color attachment.
+
+    : <dfn>resolveTarget</dfn>
+    ::
+        A {{GPUTextureView}} describing the texture [=subresource=] that will receive the resolved
+        output for this color attachment if {{GPURenderPassColorAttachmentDescriptor/attachment}} is
+        multisampled.
+
+    : <dfn>loadValue</dfn>
+    ::
+        Issue: Describe this dictionary member
+
+    : <dfn>storeOp</dfn>
+    ::
+        Issue: Describe this dictionary member
+</dl>
+
+<div class=validusage dfn-for=GPURenderPassColorAttachmentDescriptor>
+    <dfn abstract-op>Valid Usage</dfn>
+
+    Given a {{GPURenderPassColorAttachmentDescriptor}} |this| the following validation rules
+    apply:
+
+    1. |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}} must have a renderable color format.
+    1. If |this|.{{GPURenderPassColorAttachmentDescriptor/resolveTarget}} is not `null`:
+
+        1. |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}} must be multisampled.
+        1. |this|.{{GPURenderPassColorAttachmentDescriptor/resolveTarget}} must not be multisampled.
+        1. Issue: Describe the remainder of resolveTarget validation
+
+    1. Otherwise |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}} must not be multisampled.
+
+    Issue: Describe the remaining validation rules for this type.
+</div>
 
 #### Depth/Stencil Attachments #### {#depth-stencil-attachments}
 
@@ -3925,6 +4028,48 @@ dictionary GPURenderPassDepthStencilAttachmentDescriptor {
     boolean stencilReadOnly = false;
 };
 </script>
+
+<dl dfn-type=dict-member dfn-for=GPURenderPassDepthStencilAttachmentDescriptor>
+    : <dfn>attachment</dfn>
+    ::
+        A {{GPUTextureView}} describing the texture [=subresource=] the [=pipeline=] will output to
+        and read from for this depth/stencil attachment.
+
+    : <dfn>depthLoadValue</dfn>
+    ::
+        Issue: Describe this dictionary member
+
+    : <dfn>depthStoreOp</dfn>
+    ::
+        Issue: Describe this dictionary member
+
+    : <dfn>depthReadOnly</dfn>
+    ::
+        Indicates that the depth component of the attachment is read only.
+
+    : <dfn>stencilLoadValue</dfn>
+    ::
+        Issue: Describe this dictionary member
+
+    : <dfn>stencilStoreOp</dfn>
+    ::
+        Issue: Describe this dictionary member
+
+    : <dfn>stencilReadOnly</dfn>
+    ::
+        Indicates that the stencil component of the attachment is read only.
+</dl>
+
+<div class=validusage dfn-for=GPURenderPassDepthStencilAttachmentDescriptor>
+    <dfn abstract-op>Valid Usage</dfn>
+
+    Given a {{GPURenderPassDepthStencilAttachmentDescriptor}} |this| the following validation
+    rules apply:
+
+    1. |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}} must have a renderable depth or stencil format.
+
+    Issue: Describe the remaining validation rules for this type.
+</div>
 
 ### Load &amp; Store Operations ### {#load-and-store-ops}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4066,7 +4066,7 @@ dictionary GPURenderPassDepthStencilAttachmentDescriptor {
     Given a {{GPURenderPassDepthStencilAttachmentDescriptor}} |this| the following validation
     rules apply:
 
-    1. |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}} must have a renderable depth or stencil format.
+    1. |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}} must have a renderable depth-and/or-stencil format.
 
     Issue: Describe the remaining validation rules for this type.
 </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3138,7 +3138,7 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
     **Arguments:**
         - {{GPURenderPassDescriptor}} |descriptor|
 
-    **Returns:** GPURenderPassEncoder
+    **Returns:** {{GPURenderPassEncoder}}
 
     Begins encoding a render pass described by |descriptor|.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3951,6 +3951,8 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
 
     Given a {{GPURenderPassDescriptor}} |this| the following validation rules apply:
 
+    1. |this|.{{GPURenderPassDescriptor/colorAttachments}}.length must be less than or equal to the
+        [=maximum color attachments=].
     1. |this|.{{GPURenderPassDescriptor/colorAttachments}}.length must greater than `0` or
         |this|.{{GPURenderPassDescriptor/depthStencilAttachment}} must not be `null`.
     1. For each |colorAttachment| in |this|.{{GPURenderPassDescriptor/colorAttachments}}:
@@ -3960,6 +3962,14 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
     1. If |this|.{{GPURenderPassDescriptor/depthStencilAttachment}} is not `null`:
 
         1. |this|.{{GPURenderPassDescriptor/depthStencilAttachment}} must meet the [$GPURenderPassDepthStencilAttachmentDescriptor/Valid Usage|GPURenderPassDepthStencilAttachmentDescriptor Valid Usage$] rules.
+
+    1. Each {{GPURenderPassColorAttachmentDescriptor/attachment}} in |this|.{{GPURenderPassDescriptor/colorAttachments}}
+        and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}},
+        if present, must have all have the same {{GPUTexture/[[sampleCount]]}}.
+
+    Issue: Define <dfn>maximum color attachments</dfn>
+
+    Issue(gpuweb/gpuweb#503): support for no attachments
 </div>
 
 #### Color Attachments #### {#color-attachments}
@@ -4002,11 +4012,16 @@ dictionary GPURenderPassColorAttachmentDescriptor {
     apply:
 
     1. |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}} must have a renderable color format.
+    1. |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}}.{{GPUTexture/[[textureUsage]]}} must contain {{GPUTextureUsage/OUTPUT_ATTACHMENT}}.
     1. If |this|.{{GPURenderPassColorAttachmentDescriptor/resolveTarget}} is not `null`:
 
         1. |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}} must be multisampled.
         1. |this|.{{GPURenderPassColorAttachmentDescriptor/resolveTarget}} must not be multisampled.
-        1. Issue: Describe the remainder of resolveTarget validation
+        1. |this|.{{GPURenderPassColorAttachmentDescriptor/resolveTarget}}.{{GPUTexture/[[textureSize]]}}
+            must match |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}}.{{GPUTexture/[[textureSize]]}}.
+        1. |this|.{{GPURenderPassColorAttachmentDescriptor/resolveTarget}}.{{GPUTexture/[[format]]}}
+            must match |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}}.{{GPUTexture/[[format]]}}.
+        1. Issue: Describe any remaining resolveTarget validation
 
     1. Otherwise |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}} must not be multisampled.
 
@@ -4067,6 +4082,10 @@ dictionary GPURenderPassDepthStencilAttachmentDescriptor {
     rules apply:
 
     1. |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}} must have a renderable depth-and/or-stencil format.
+    1. |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/depthReadOnly}} is `true`,
+        |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/depthLoadValue}} must be {{GPULoadOp/"load"}}.
+    1. |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/stencilReadOnly}} is `true`,
+        |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/stencilLoadValue}} must be {{GPULoadOp/"load"}}.
 
     Issue: Describe the remaining validation rules for this type.
 </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4035,19 +4035,21 @@ dictionary GPURenderPassColorAttachmentDescriptor {
     apply:
 
     1. |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}} must have a renderable color format.
-    1. |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}}.{{GPUTexture/[[textureUsage]]}}
+    1. |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[textureUsage]]}}
         must contain {{GPUTextureUsage/OUTPUT_ATTACHMENT}}.
     1. |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}} must be a view of a single [=subresource=].
     1. If |this|.{{GPURenderPassColorAttachmentDescriptor/resolveTarget}} is not `null`:
 
         1. |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}} must be multisampled.
         1. |this|.{{GPURenderPassColorAttachmentDescriptor/resolveTarget}} must not be multisampled.
-        1. |this|.{{GPURenderPassColorAttachmentDescriptor/resolveTarget}}.{{GPUTexture/[[textureUsage]]}}
+        1. |this|.{{GPURenderPassColorAttachmentDescriptor/resolveTarget}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[textureUsage]]}}
             must contain {{GPUTextureUsage/OUTPUT_ATTACHMENT}}.
+        1. |this|.{{GPURenderPassColorAttachmentDescriptor/resolveTarget}} must be a view of a single [=subresource=].
+
         1. The dimensions of the [=subresource=]s seen by |this|.{{GPURenderPassColorAttachmentDescriptor/resolveTarget}}
             and |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}} must match.
-        1. |this|.{{GPURenderPassColorAttachmentDescriptor/resolveTarget}}.{{GPUTexture/[[format]]}}
-            must match |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}}.{{GPUTexture/[[format]]}}.
+        1. |this|.{{GPURenderPassColorAttachmentDescriptor/resolveTarget}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[format]]}}
+            must match |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[format]]}}.
         1. Issue: Describe any remaining resolveTarget validation
 
     Issue: Describe the remaining validation rules for this type.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3150,16 +3150,18 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 
             - For each |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
 
-                - Each texture [=subresource=] seen by |colorAttachment|.{{GPURenderPassColorAttachmentDescriptor/attachment}}
+                - The texture [=subresource=] seen by |colorAttachment|.{{GPURenderPassColorAttachmentDescriptor/attachment}}
                     is considered to be used as {{GPUTextureUsage/OUTPUT_ATTACHMENT}} for the
                     duration of the render pass.
 
             - Let |depthStencilAttachment| be |descriptor|.{{GPURenderPassDescriptor/depthStencilAttachment}}.
             - If |depthStencilAttachment| is not `null`:
 
-                - Each texture [=subresource=] seen by |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}
+                - The texture [=subresource=] seen by |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}
                     is considered to be used as {{GPUTextureUsage/OUTPUT_ATTACHMENT}} for the
                     duration of the render pass.
+
+    Issue: specify the behavior of read-only depth/stencil
 
     <div class=validusage dfn-for=GPUCommandEncoder.beginRenderPass>
         <dfn abstract-op>Valid Usage</dfn>
@@ -3980,6 +3982,10 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
         and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}},
         if present, must have all have the same {{GPUTexture/[[sampleCount]]}}.
 
+    1. The dimensions of the [=subresource=]s seen by each {{GPURenderPassColorAttachmentDescriptor/attachment}} in |this|.{{GPURenderPassDescriptor/colorAttachments}}
+        and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}},
+        if present, must match.
+
     Issue: Define <dfn>maximum color attachments</dfn>
 
     Issue(gpuweb/gpuweb#503): support for no attachments
@@ -4036,13 +4042,13 @@ dictionary GPURenderPassColorAttachmentDescriptor {
 
         1. |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}} must be multisampled.
         1. |this|.{{GPURenderPassColorAttachmentDescriptor/resolveTarget}} must not be multisampled.
-        1. |this|.{{GPURenderPassColorAttachmentDescriptor/resolveTarget}}.{{GPUTexture/[[textureSize]]}}
-            must match |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}}.{{GPUTexture/[[textureSize]]}}.
+        1. |this|.{{GPURenderPassColorAttachmentDescriptor/resolveTarget}}.{{GPUTexture/[[textureUsage]]}}
+            must contain {{GPUTextureUsage/OUTPUT_ATTACHMENT}}.
+        1. The dimensions of the [=subresource=]s seen by |this|.{{GPURenderPassColorAttachmentDescriptor/resolveTarget}}
+            and |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}} must match.
         1. |this|.{{GPURenderPassColorAttachmentDescriptor/resolveTarget}}.{{GPUTexture/[[format]]}}
             must match |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}}.{{GPUTexture/[[format]]}}.
         1. Issue: Describe any remaining resolveTarget validation
-
-    1. Otherwise |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}} must not be multisampled.
 
     Issue: Describe the remaining validation rules for this type.
 </div>
@@ -4117,6 +4123,8 @@ dictionary GPURenderPassDepthStencilAttachmentDescriptor {
         depth-and/or-stencil format.
     1. |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}} must be a view of a
         single [=subresource=].
+    1. |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}.{{GPUTexture/[[textureUsage]]}}
+        must contain {{GPUTextureUsage/OUTPUT_ATTACHMENT}}.
     1. |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/depthReadOnly}} is `true`,
         |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/depthLoadValue}} must be
         {{GPULoadOp/"load"}} and |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/depthStoreOp}}


### PR DESCRIPTION
This pull request is incomplete, but I wanted to verify that the pattern I'm using here is what the group would like to see. Started with simply documenting `beginRenderPass()` and fell down a rabbit hole real quick.

It looks like elsewhere in the spec validation of various descriptors is described in the algorithms that make use of them. It feels cleaner to me, however, to describe the criteria for a valid descriptor with the descriptor dictionary definition. Not only does this make it easier for those reading the spec later to reference, as all the rules for a type are in one place, but also allows for multiple algorithms to reference the same validation rules and makes validation of nested descriptors more palatable.

If this approach works for the group I'll be happy to flesh out this PR with a more complete set of validation rules and key descriptions.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/toji/gpuweb/pull/831.html" title="Last updated on Jun 5, 2020, 11:28 PM UTC (9e21ed0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/831/0268a8d...toji:9e21ed0.html" title="Last updated on Jun 5, 2020, 11:28 PM UTC (9e21ed0)">Diff</a>