### PR TITLE
Allow BufferSource in writeBuffer/writeTexture

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5068,7 +5068,7 @@ GPUQueue includes GPUObjectBase;
             **Returns:** `void`
 
             - Let |dataBytes| be [=get a copy of the buffer source|a copy of the bytes held by the buffer source=] |data|.
-            - Let |dataByteSize| be the number of bytes in |bytes|.
+            - Let |dataByteSize| be the number of bytes in |dataBytes|.
             - If any of the following conditions are unsatisfied,
                 throw {{OperationError}} and stop.
                 <div class=validusage>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5017,8 +5017,8 @@ GPUQueue includes GPUObjectBase;
 
             **Returns:** `void`
 
-            - If |data| is a TypedArray, let the element type be the type of the TypedArray.
-                Otherwise, let the element type be bytes.
+            - If |data| is an {{ArrayBuffer}} or {{DataView}}, let the element type be "byte".
+                Otherwise, |data| is a TypedArray; let the element type be the type of the TypedArray.
             - Let |dataSize| be the size of |data|, in elements.
             - If |size| is unspecified,
                 let |contentsSize| be |dataSize| &minus; |dataOffset|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4978,13 +4978,13 @@ interface GPUQueue {
     void writeBuffer(
         GPUBuffer buffer,
         GPUSize64 bufferOffset,
-        [AllowShared] ArrayBuffer data,
+        [AllowShared] BufferSource data,
         optional GPUSize64 dataOffset = 0,
         optional GPUSize64 size);
 
     void writeTexture(
       GPUTextureCopyView destination,
-      [AllowShared] ArrayBuffer data,
+      [AllowShared] BufferSource data,
       GPUTextureDataLayout dataLayout,
       GPUExtent3D size);
 
@@ -5010,15 +5010,18 @@ GPUQueue includes GPUObjectBase;
             <ul dfn-type=argument dfn-for="GPUQueue/writeBuffer(buffer, bufferOffset, data, dataOffset, size)">
                 - |buffer|: {{GPUBuffer}} <dfn>buffer</dfn>
                 - |bufferOffset|: {{GPUSize64}} <dfn>bufferOffset</dfn>
-                - |data|: <code>[{{AllowShared}}] {{ArrayBuffer}}</code> <dfn>data</dfn>
+                - |data|: <code>[{{AllowShared}}] {{BufferSource}}</code> <dfn>data</dfn>
                 - |dataOffset|: optional {{GPUSize64}} <dfn>dataOffset</dfn> = 0
                 - |size|: optional {{GPUSize64}} <dfn>size</dfn>
             </ul>
 
             **Returns:** `void`
 
+            - If |data| is a TypedArray, let the element type be the type of the TypedArray.
+                Otherwise, let the element type be bytes.
+            - Let |dataSize| be the size of |data|, in elements.
             - If |size| is unspecified,
-                let |contentsSize| be |data|.`byteLength` &minus; |dataOffset|.
+                let |contentsSize| be |dataSize| &minus; |dataOffset|.
                 Otherwise, let |contentsSize| be |size|.
             - If any of the following conditions are unsatisfied,
                 throw {{OperationError}} and stop.
@@ -5026,21 +5029,22 @@ GPUQueue includes GPUObjectBase;
                      here, because they depend on contentsSize above. -->
                 <div class=validusage>
                     - |contentsSize| &ge; 0.
-                    - |dataOffset| + |contentsSize| &le; |data|.`byteLength`.
-                    - |buffer|.{{GPUBuffer/[[state]]}} is [=buffer state/unmapped=].
-                    - |contentsSize| is a multiple of 4.
-                    - |bufferOffset| is a multiple of 4.
+                    - |dataOffset| + |contentsSize| &le; |dataSize|.
+                    - |contentsSize|, converted to bytes, is a multiple of 4 bytes.
                 </div>
-            - Let |contents| be the contents of the |contentsSize| bytes
-                in |data| starting from the byte offset |dataOffset|.
+            - Let |dataContents| be [=get a copy of the buffer source|a copy of the bytes held by the buffer source=].
+            - Let |contents| be the |contentsSize| elements of |dataContents| starting at
+                an offset of |dataOffset| elements.
             - Issue the following steps on the [=Queue timeline=] of |this|:
                 <div class=queue-timeline>
                     - If any of the following conditions are unsatisfied,
                         generate a validation error and stop.
                         <div class=validusage>
                             - |buffer| is [=valid=].
+                            - |buffer|.{{GPUBuffer/[[state]]}} is [=buffer state/unmapped=].
                             - |buffer|.{{GPUBuffer/[[usage]]}} includes {{GPUBufferUsage/COPY_DST}}.
-                            - |bufferOffset| + |contentsSize| &le; |buffer|.{{GPUBuffer/[[size]]}}.
+                            - |bufferOffset|, converted to bytes, is a multiple of 4 bytes.
+                            - |bufferOffset| + |contentsSize|, converted to bytes, &le; |buffer|.{{GPUBuffer/[[size]]}} bytes.
                         </div>
                     - Write |contents| into |buffer| starting at |bufferOffset|.
                 </div>
@@ -5056,20 +5060,25 @@ GPUQueue includes GPUObjectBase;
             **Arguments:**
             <ul dfn-type=argument dfn-for="GPUQueue/writeTexture(destination, data, dataLayout, size)">
                 - |destination|: {{GPUTextureCopyView}} <dfn>destination</dfn>
-                - |data|: <code>[{{AllowShared}}] {{ArrayBuffer}}</code> <dfn>data</dfn>
+                - |data|: <code>[{{AllowShared}}] {{BufferSource}}</code> <dfn>data</dfn>
                 - |dataLayout|: {{GPUTextureDataLayout}} <dfn>dataLayout</dfn>
                 - |size|: {{GPUExtent3D}} <dfn>size</dfn>
             </ul>
 
             **Returns:** `void`
 
+            - Let |dataBytes| be [=get a copy of the buffer source|a copy of the bytes held by the buffer source=] |data|.
+            - Let |dataByteSize| be the number of bytes in |bytes|.
             - If any of the following conditions are unsatisfied,
                 throw {{OperationError}} and stop.
                 <div class=validusage>
-                    - |dataLayout|.{{GPUTextureDataLayout/offset}} <= |data|.`byteLength`.
+                    - [$validating linear texture data$](|dataLayout|,
+                        |dataByteSize|,
+                        |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}},
+                        |size|) succeeds.
                 </div>
             - Let |contents| be the contents of the [=images=] seen by
-                viewing |data| with |dataLayout|.
+                viewing |dataBytes| with |dataLayout| and |size|.
 
                 Issue: Specify more formally.
             - Issue the following steps on the [=Queue timeline=] of |this|:
@@ -5081,10 +5090,6 @@ GPUQueue includes GPUObjectBase;
                             - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}}
                                 includes {{GPUTextureUsage/COPY_DST}}.
                             - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is 1.
-                            - [$validating linear texture data$](|dataLayout|,
-                                |data|.byteLength,
-                                |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}},
-                                |size|) succeeds.
                             - [=Valid Texture Copy Range=](|destination|, |size|)
                                 is satisfied.
 


### PR DESCRIPTION
and move some validation between sync and async (in particular buffer map-state validation is now async).

~Note that this makes the offsets/sizes always in bytes, which is unlike [WebGL](https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.3) which allows ArrayBufferView (not BufferSource) with offsets in elements (or bytes for the non-element-based DataView).~

Closes #820 
Closes #821


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/832.html" title="Last updated on Aug 3, 2020, 10:00 PM UTC (629c3d0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/832/82e29b6...kainino0x:629c3d0.html" title="Last updated on Aug 3, 2020, 10:00 PM UTC (629c3d0)">Diff</a>