### PR TITLE
[wgsl] Remove unless.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -502,7 +502,6 @@ Note: literals are parsed greedy. This means that for statements like `a -5`
   <tr><td>`TYPE`<td>type
   <tr><td>`UNIFORM`<td>uniform
   <tr><td>`UNIFORM_CONSTANT`<td>uniform_constant
-  <tr><td>`UNLESS`<td>unless
   <tr><td>`VAR`<td>var
   <tr><td>`VERTEX`<td>vertex
   <tr><td>`WORKGROUP`<td>workgroup
@@ -531,11 +530,11 @@ The following is a list of keywords which are reserved for future expansion.
     <td>u16
     <td>u64
   <tr>
+    <td>unless
     <td>using
     <td>while
     <td>regardless
     <td>premerge
-    <td>
 </table>
 
 ## Syntactic Tokens ## {#syntactic-tokens}
@@ -1016,7 +1015,6 @@ statement
   : SEMICOLON
   | return_stmt SEMICOLON
   | if_stmt
-  | unless_stmt
   | switch_stmt
   | loop_stmt
   | variable_stmt SEMICOLON
@@ -1063,13 +1061,6 @@ elseif_stmt
 
 else_stmt
   : ELSE body_stmt
-</pre>
-
-## Unless Statement ## {#unless-statement}
-
-<pre class='def'>
-unless_stmt
-  : UNLESS paren_rhs_stmt body_stmt
 </pre>
 
 ## Switch Statement ## {#switch-statement}


### PR DESCRIPTION
This CL removes the unless statement from the grammar. The unless
keyword has been reserved if we determine we want unless in the future.

Fixes #577