### PR TITLE
wgsl: Fix conditions on break from continuing

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1232,10 +1232,70 @@ When a `break` statement is placed such that it would exit from a loop's [[#cont
 then:
 
 * The `break` statement must appear as either:
-    * The only statement in the true-branch clause of an `if` that has no `else` clause and no `elseif` clauses, or
+    * The only statement in the true-branch clause of an `if` that has:
+        * no `else` clause or an empty `else` clause
+        * no `elseif` clauses
     * The only statement in the `else` clause of an `if` that has an empty true-branch clause and no `elseif` clauses.
 * That `if` statement must appear last in the `continuing` clause.
 
+<div class='example' heading="[SHORTNAME] Valid loop if-break from a continuing clause">
+  <xmp>
+    const a : i32 = 2;
+    var i : i32 = 0;
+    loop {
+      const step : i32 = 1;
+
+      if (i % 2 == 0) { continue; }
+
+      a = a * 2;
+
+      continuing {
+        i = i + step;
+        if (i >= 4) { break; }
+      }
+    }
+  </xmp>
+</div>
+
+<div class='example' heading="[SHORTNAME] Valid loop if-else-break from a continuing clause">
+  <xmp>
+    const a : i32 = 2;
+    var i : i32 = 0;
+    loop {
+      const step : i32 = 1;
+
+      if (i % 2 == 0) { continue; }
+
+      a = a * 2;
+
+      continuing {
+        i = i + step;
+        if (i < 4) {} else { break; }
+      }
+    }
+  </xmp>
+</div>
+
+<div class='example' heading="[SHORTNAME] Invalid breaks from a continuing clause">
+  <xmp>
+    const a : i32 = 2;
+    var i : i32 = 0;
+    loop {
+      const step : i32 = 1;
+
+      if (i % 2 == 0) { continue; }
+
+      a = a * 2;
+
+      continuing {
+        i = i + step;
+        break;                                    // Invalid: too early
+        if (i < 4) { i = i + 1 } else { break; }  // Invalid: if is too complex, and too early
+        if (i >= 4) { break; } else { i = i + 1 } // Invalid: if is too complex
+      }
+    }
+  </xmp>
+</div>
 
 ## Continue statement ## {#continue-statement}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1229,7 +1229,13 @@ after the body of the nearest-enclosing [[#loop-statement]]
 or [[#switch-statement]].
 
 When a `break` statement is placed such that it would exit from a loop's [[#continuing-statement]],
-the break statement must appear last in that [[#continuing-statement]].
+then:
+
+* The `break` statement must appear as either:
+    * The only statement in the true-branch clause of an `if` that has no `else` clause and no `elseif` clauses, or
+    * The only statement in the `else` clause of an `if` that has an empty true-branch clause and no `elseif` clauses.
+* That `if` statement must appear last in the `continuing` clause.
+
 
 ## Continue statement ## {#continue-statement}
 


### PR DESCRIPTION
A break from a continuing clause must be conditional, where that
condition does nothing else, and that conditional must come last
in the continuing clause.

- If it's unconditional then there is no actual backedge for the loop,
  and so it's not a loop in the first place.
- if it comes too early then it breaks the rule that the backedge
  must post-dominate the head of the continuing clause.
- Still allows conditional exit from the loop at the bottom of the loop.