### PR TITLE
Fix handling of storageTextureFormat in createBindGroup

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1508,6 +1508,20 @@ interface GPUTextureView {
 GPUTextureView includes GPUObjectBase;
 </script>
 
+{{GPUTextureView}} has the following internal slots:
+
+<dl dfn-type=attribute dfn-for="GPUTextureView">
+    : <dfn>\[[texture]]</dfn>
+    ::
+        The {{GPUTexture}} into which this is a view.
+
+    : <dfn>\[[descriptor]]</dfn>
+    ::
+        The {{GPUTextureViewDescriptor}} describing this texture view.
+
+        All optional fields of {{GPUTextureViewDescriptor}} are defined.
+</dl>
+
 ### Texture View Creation ### {#texture-view-creation}
 
 <script type=idl>
@@ -2053,30 +2067,34 @@ A {{GPUBindGroup}} object has the following internal slots:
         |descriptor|.{{GPUBindGroupDescriptor/entries}}.
     1. For each {{GPUBindGroupEntry}} |bindingDescriptor| in
         |descriptor|.{{GPUBindGroupDescriptor/entries}}:
+        1. Let |resource| be |bindingDescriptor|.{{GPUBindGroupEntry/resource}}.
         1. Ensure there is exactly one {{GPUBindGroupLayoutEntry}} |layoutBinding| in
             {{GPUBindGroupLayoutDescriptor/entries}} of |descriptor|.{{GPUBindGroupDescriptor/layout}}
             such that |layoutBinding|.{{GPUBindGroupLayoutEntry/binding}} equals to
             |bindingDescriptor|.{{GPUBindGroupEntry/binding}}.
         1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
             {{GPUBindingType/"sampler"}}:
-            1. Ensure |bindingDescriptor|.{{GPUBindGroupEntry/resource}} is a
+            1. Ensure |resource| is a
                 valid {{GPUSampler}} object and {{GPUSampler/[[compareEnable]]}} is false.
         1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
             {{GPUBindingType/"comparison-sampler"}}:
-            1. Ensure |bindingDescriptor|.{{GPUBindGroupEntry/resource}} is a
+            1. Ensure |resource| is a
                 valid {{GPUSampler}} object and {{GPUSampler/[[compareEnable]]}} is true.
         1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
             {{GPUBindingType/"sampled-texture"}} or {{GPUBindingType/"readonly-storage-texture"}} or
             {{GPUBindingType/"writeonly-storage-texture"}}.
-            1. Ensure |bindingDescriptor|.{{GPUBindGroupEntry/resource}} is a
-                valid {{GPUTextureView}} object.
+            1. Ensure |resource| is a valid {{GPUTextureView}} object.
             1. Ensure [=texture view binding validation=] is not violated.
-            1. Ensure |bindingDescriptor|.{{GPUBindGroupLayoutEntry/storageTextureFormat}} is a valid {{GPUTextureFormat}}.
+            1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
+                {{GPUBindingType/"readonly-storage-texture"}} or
+                {{GPUBindingType/"writeonly-storage-texture"}}.
+                1. Ensure
+                    |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}
+                    is equal to |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTextureFormat}}.
         1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
             {{GPUBindingType/"uniform-buffer"}} or {{GPUBindingType/"storage-buffer"}}
             or {{GPUBindingType/"readonly-storage-buffer"}}.
-            1. Ensure |bindingDescriptor|.{{GPUBindGroupEntry/resource}} is a
-                valid {{GPUBufferBinding}} object.
+            1. Ensure |resource| is a valid {{GPUBufferBinding}} object.
             1. Ensure [=buffer binding validation=] is not violated.
     1. Return a new {{GPUBindGroup}} object with:
         - {{GPUBindGroup/[[layout]]}} = |descriptor|.{{GPUBindGroupDescriptor/layout}}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2074,16 +2074,16 @@ A {{GPUBindGroup}} object has the following internal slots:
             |bindingDescriptor|.{{GPUBindGroupEntry/binding}}.
         1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
             {{GPUBindingType/"sampler"}}:
-            1. Ensure |resource| is a
-                valid {{GPUSampler}} object and {{GPUSampler/[[compareEnable]]}} is false.
+            1. Ensure |resource| is a [=valid=] {{GPUSampler}} object.
+            1. Ensure |resource|.{{GPUSampler/[[compareEnable]]}} is false.
         1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
             {{GPUBindingType/"comparison-sampler"}}:
-            1. Ensure |resource| is a
-                valid {{GPUSampler}} object and {{GPUSampler/[[compareEnable]]}} is true.
+            1. Ensure |resource| is a [=valid=] {{GPUSampler}} object.
+            1. Ensure |resource|.{{GPUSampler/[[compareEnable]]}} is true.
         1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
             {{GPUBindingType/"sampled-texture"}} or {{GPUBindingType/"readonly-storage-texture"}} or
             {{GPUBindingType/"writeonly-storage-texture"}}.
-            1. Ensure |resource| is a valid {{GPUTextureView}} object.
+            1. Ensure |resource| is a [=valid=] {{GPUTextureView}} object.
             1. Ensure [=texture view binding validation=] is not violated.
             1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
                 {{GPUBindingType/"readonly-storage-texture"}} or
@@ -2094,7 +2094,8 @@ A {{GPUBindGroup}} object has the following internal slots:
         1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
             {{GPUBindingType/"uniform-buffer"}} or {{GPUBindingType/"storage-buffer"}}
             or {{GPUBindingType/"readonly-storage-buffer"}}.
-            1. Ensure |resource| is a valid {{GPUBufferBinding}} object.
+            1. Ensure |resource| is a {{GPUBufferBinding}}.
+            1. Ensure |resource|.{{GPUBufferBinding/buffer}} is [=valid=].
             1. Ensure [=buffer binding validation=] is not violated.
     1. Return a new {{GPUBindGroup}} object with:
         - {{GPUBindGroup/[[layout]]}} = |descriptor|.{{GPUBindGroupDescriptor/layout}}


### PR DESCRIPTION
This previously referred to the non-existent
bindingDescriptor.storageTextureFormat.

Fixed to validate the layoutBinding.storageTextureFormat against the
resource.[[descriptor]].format.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 3, 2020, 10:29 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fgpuweb%2Fgpuweb%2Fc2be4cdade3f34c39a174e704cb2f12f344fbb78%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%23838.)._
</details>
