### PR TITLE
Disallow use of irrelevant GPUBindGroupLayoutEntry members

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1799,20 +1799,90 @@ dictionary GPUBindGroupLayoutEntry {
     required GPUIndex32 binding;
     required GPUShaderStageFlags visibility;
     required GPUBindingType type;
-    GPUTextureViewDimension viewDimension = "2d";
-    GPUTextureComponentType textureComponentType = "float";
-    GPUTextureFormat storageTextureFormat;
-    boolean multisampled = false;
+
+    // Used for uniform buffer and storage buffer bindings.
     boolean hasDynamicOffset = false;
+
+    // Used for sampled texture and storage texture bindings.
+    GPUTextureViewDimension viewDimension;
+
+    // Used for sampled texture bindings.
+    GPUTextureComponentType textureComponentType;
+    boolean multisampled = false;
+
+    // Used for storage texture bindings.
+    GPUTextureFormat storageTextureFormat;
 };
 </script>
 
-  * {{GPUBindGroupLayoutEntry/binding}}:
-    A unique identifier for a resource binding within a {{GPUBindGroupLayoutEntry}}, a corresponding {{GPUBindGroupEntry}}, and shader stages.
+<dl dfn-type=dict-member dfn-for=GPUBindGroupLayoutEntry>
+    : <dfn>binding</dfn>
+    ::
+        A unique identifier for a resource binding within a
+        {{GPUBindGroupLayoutEntry}}, a corresponding {{GPUBindGroupEntry}},
+        and shader stages.
 
-  * {{GPUBindGroupLayoutEntry/visibility}}:
-    A bitset of the members of {{GPUShaderStage}}. Each set bit indicates that a {{GPUBindGroupLayoutEntry}}'s resource will be accessible from the
-    associated shader stage.
+    : <dfn>visibility</dfn>
+    ::
+        A bitset of the members of {{GPUShaderStage}}.
+        Each set bit indicates that a {{GPUBindGroupLayoutEntry}}'s resource
+        will be accessible from the associated shader stage.
+
+    : <dfn>hasDynamicOffset</dfn>
+    ::
+        If the {{GPUBindGroupLayoutEntry/type}} is
+        {{GPUBindingType/"uniform-buffer"}},
+        {{GPUBindingType/"storage-buffer"}}, or
+        {{GPUBindingType/"readonly-storage-buffer"}},
+        this indicates whether a binding requires a dynamic offset.
+
+        Otherwise, it must be `false`.
+
+    : <dfn>viewDimension</dfn>
+    ::
+        If the {{GPUBindGroupLayoutEntry/type}} is
+        {{GPUBindingType/"sampled-texture"}},
+        {{GPUBindingType/"readonly-storage-texture"}}, or
+        {{GPUBindingType/"writeonly-storage-texture"}},
+        this defaults to {{GPUTextureViewDimension/"2d"}}
+        and is the required {{GPUTextureViewDescriptor/dimension}}
+        of a texture view bound to this binding.
+
+        Otherwise, it must be `undefined`.
+
+    : <dfn>textureComponentType</dfn>
+    ::
+        If the {{GPUBindGroupLayoutEntry/type}} is
+        {{GPUBindingType/"sampled-texture"}},
+        this defaults to {{GPUTextureComponentType/"float"}}
+        and is the required component type of the {{GPUTextureViewDescriptor/format}}
+        of a texture view bound to this binding.
+
+        Otherwise, it must be `undefined`.
+
+    : <dfn>multisampled</dfn>
+    ::
+        If the {{GPUBindGroupLayoutEntry/type}} is
+        {{GPUBindingType/"sampled-texture"}},
+        this indicates whether a binding must have a sample count greater than 1.
+
+        Otherwise, it must be `false`.
+
+    : <dfn>storageTextureFormat</dfn>
+    ::
+        If the {{GPUBindGroupLayoutEntry/type}} is
+        {{GPUBindingType/"readonly-storage-texture"}}
+        or {{GPUBindingType/"writeonly-storage-texture"}},
+        this is the required {{GPUTextureViewDescriptor/format}}
+        of a texture view bound to this binding.
+
+        Otherwise, it must be `undefined`.
+</dl>
+
+Note:
+{{GPUBindGroupLayoutEntry/viewDimension}} and {{GPUBindGroupLayoutEntry/multisampled}}
+enable Metal-based WebGPU implementations to back the respective bind groups
+with `MTLArgumentBuffer` objects that are more efficient to bind at run-time.
 
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUShaderStageFlags;
@@ -1836,22 +1906,8 @@ enum GPUBindingType {
     "sampled-texture",
     "readonly-storage-texture",
     "writeonly-storage-texture"
-    // TODO: other binding types
 };
 </script>
-
-  * {{GPUBindGroupLayoutEntry/viewDimension}}, {{GPUBindGroupLayoutEntry/multisampled}}:
-    Describes the dimensionality of texture view bindings, and indicates if they are multisampled.
-
-    Note: This allows Metal-based implementations to back the respective bind
-    groups with `MTLArgumentBuffer` objects that are more efficient to bind at
-    run-time.
-
-  * {{GPUBindGroupLayoutEntry/hasDynamicOffset}}:
-    For {{GPUBindingType/uniform-buffer}}, {{GPUBindingType/storage-buffer}}, and {{GPUBindingType/readonly-storage-buffer}} bindings,
-    indicates that the binding has a dynamic offset. One offset must be passed to
-    setBindGroup for each dynamic binding in increasing order of
-    {{GPUBindGroupLayoutEntry/binding}} number.
 
 A {{GPUBindGroupLayout}} object has the following internal slots:
 
@@ -1878,8 +1934,36 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
     1. Let |layout| be a new valid {{GPUBindGroupLayout}} object.
     1. For each {{GPUBindGroupLayoutEntry}} |bindingDescriptor| in |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
         1. Ensure |bindingDescriptor|.{{GPUBindGroupLayoutEntry/binding}} does not violate [=binding validation=].
-        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/visibility}} includes {{GPUShaderStage/VERTEX}}
-            , ensure [=vertex shader binding validation=] is not violated.
+        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/visibility}}
+            includes {{GPUShaderStage/VERTEX}},
+            ensure [=vertex shader binding validation=] is not violated.
+        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
+            {{GPUBindingType/"uniform-buffer"}},
+            {{GPUBindingType/"storage-buffer"}}, or
+            {{GPUBindingType/"readonly-storage-buffer"}},
+            ensure
+            |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}}
+            is `false`.
+        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
+            {{GPUBindingType/"sampled-texture"}},
+            {{GPUBindingType/"readonly-storage-texture"}}, or
+            {{GPUBindingType/"writeonly-storage-texture"}},
+            ensure
+            |bindingDescriptor|.{{GPUBindGroupLayoutEntry/viewDimension}}
+            is `undefined`.
+        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
+            {{GPUBindingType/"sampled-texture"}},
+            ensure
+            |bindingDescriptor|.{{GPUBindGroupLayoutEntry/textureComponentType}}
+            is `undefined` and
+            |bindingDescriptor|.{{GPUBindGroupLayoutEntry/multisampled}}
+            is `false`.
+        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
+            {{GPUBindingType/"readonly-storage-texture"}}
+            or {{GPUBindingType/"writeonly-storage-texture"}},
+            ensure
+            |bindingDescriptor|.{{GPUBindGroupLayoutEntry/storageTextureFormat}}
+            is `undefined`.
         1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/uniform-buffer}}:
             1. Ensure [=uniform buffer validation=] is not violated.
             1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `true`, ensure [=dynamic uniform buffer validation=] is not violated.
@@ -1925,16 +2009,13 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
 
         <dfn>sampled texture validation</dfn>: There must be {{GPULimits/maxSampledTexturesPerShaderStage|GPULimits.maxSampledTexturesPerShaderStage}} or
             fewer |bindingDescriptor|s of type {{GPUBindingType/sampled-texture}} visible on each shader stage in |descriptor|.
-            |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} must be `false`.
 
         <dfn>storage texture validation</dfn>: There must be {{GPULimits/maxStorageTexturesPerShaderStage|GPULimits.maxStorageTexturesPerShaderStage}} or
             fewer |bindingDescriptor|s of type {{GPUBindingType/readonly-storage-texture}} and {{GPUBindingType/writeonly-storage-texture}} visible on each shader stage in |descriptor|.
-            |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} must be `false`.
             |bindingDescriptor|.{{GPUBindGroupLayoutEntry/viewDimension}} must not be {{GPUTextureViewDimension/cube}} or {{GPUTextureViewDimension/cube-array}}.
 
         <dfn>sampler validation</dfn>: There must be {{GPULimits/maxSamplersPerShaderStage|GPULimits.maxSamplersPerShaderStage}} or
             fewer |bindingDescriptor|s of type {{GPUBindingType/sampler}} visible on each shader stage in |descriptor|.
-            |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} must be `false`.
     </div>
 </div>
 
@@ -3695,6 +3776,12 @@ interface mixin GPUProgrammablePassEncoder {
     void insertDebugMarker(USVString markerLabel);
 };
 </script>
+
+  - One offset must be passed to
+      {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)}} or
+      {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsetsData, dynamicOffsetsDataStart, dynamicOffsetsDataLength)}}
+      for each dynamic binding in a bind group, in increasing order of
+      {{GPUBindGroupLayoutEntry/binding}} number.
 
 {{GPUProgrammablePassEncoder}} has the following internal slots:
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1820,13 +1820,22 @@ dictionary GPUBindGroupLayoutEntry {
     ::
         A unique identifier for a resource binding within a
         {{GPUBindGroupLayoutEntry}}, a corresponding {{GPUBindGroupEntry}},
-        and shader stages.
+        and the {{GPUShaderModule}}s.
 
     : <dfn>visibility</dfn>
     ::
         A bitset of the members of {{GPUShaderStage}}.
         Each set bit indicates that a {{GPUBindGroupLayoutEntry}}'s resource
         will be accessible from the associated shader stage.
+
+    : <dfn>type</dfn>
+    ::
+        The type of the binding.
+        The value of this member influences the interpretation of other members.
+
+        Note:
+        This member is used to determine compatibility between a
+        {{GPUPipelineLayout}} and a {{GPUShaderModule}}.
 
     : <dfn>hasDynamicOffset</dfn>
     ::
@@ -1843,20 +1852,23 @@ dictionary GPUBindGroupLayoutEntry {
         If the {{GPUBindGroupLayoutEntry/type}} is
         {{GPUBindingType/"sampled-texture"}},
         {{GPUBindingType/"readonly-storage-texture"}}, or
-        {{GPUBindingType/"writeonly-storage-texture"}},
-        this defaults to {{GPUTextureViewDimension/"2d"}}
-        and is the required {{GPUTextureViewDescriptor/dimension}}
-        of a texture view bound to this binding.
+        {{GPUBindingType/"writeonly-storage-texture"}}:
+
+          - This is the required {{GPUTextureViewDescriptor/dimension}}
+            of a texture view bound to this binding.
+          - If `undefined`, it defaults to {{GPUTextureViewDimension/"2d"}}.
 
         Otherwise, it must be `undefined`.
 
     : <dfn>textureComponentType</dfn>
     ::
         If the {{GPUBindGroupLayoutEntry/type}} is
-        {{GPUBindingType/"sampled-texture"}},
-        this defaults to {{GPUTextureComponentType/"float"}}
-        and is the required component type of the {{GPUTextureViewDescriptor/format}}
-        of a texture view bound to this binding.
+        {{GPUBindingType/"sampled-texture"}}:
+
+          - This is the required component type of the
+            {{GPUTextureViewDescriptor/format}}
+            of a texture view bound to this binding.
+          - If `undefined`, it defaults to {{GPUTextureComponentType/"float"}}.
 
         Otherwise, it must be `undefined`.
 
@@ -1867,6 +1879,10 @@ dictionary GPUBindGroupLayoutEntry {
         this indicates whether a binding must have a sample count greater than 1.
 
         Otherwise, it must be `false`.
+
+        Note:
+        This member is used to determine compatibility between a
+        {{GPUPipelineLayout}} and a {{GPUShaderModule}}.
 
     : <dfn>storageTextureFormat</dfn>
     ::


### PR DESCRIPTION
Fixes #829


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/839.html" title="Last updated on Jun 5, 2020, 11:56 PM UTC (f07d281)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/839/c2be4cd...kainino0x:f07d281.html" title="Last updated on Jun 5, 2020, 11:56 PM UTC (f07d281)">Diff</a>