### PR TITLE
Remove argument in endOcclusionQuery

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3852,7 +3852,7 @@ interface GPURenderPassEncoder {
     void setStencilReference(GPUStencilValue reference);
 
     void beginOcclusionQuery(GPUSize32 queryIndex);
-    void endOcclusionQuery(GPUSize32 queryIndex);
+    void endOcclusionQuery();
 
     void beginPipelineStatisticsQuery(GPUQuerySet querySet, GPUSize32 queryIndex);
     void endPipelineStatisticsQuery();


### PR DESCRIPTION
We clarify begin/end operations are not allowed to be nested in #794 , so remove argument in endOcclusionQuery as same as endPipelineStatisticsQuery.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 4, 2020, 2:48 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fhaoxli%2Fgpuweb%2F510b0e7b9b58413891f1423bc5dfd8d7a888fd76%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%23840.)._
</details>
