### PR TITLE
Remove is_finite and is_normal intrinsics.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -958,10 +958,8 @@ param_list
 
   <tr><td>all(BoolVec) -&gt; bool<td>OpAll
   <tr><td>any(BoolVec) -&gt; bool<td>OpAny
-  <tr><td>is_finite(float) -&gt; bool<td>OpIsFinite
   <tr><td>is_inf(float) -&gt; bool<td>OpIsInf
   <tr><td>is_nan(float) -&gt; bool<td>OpIsNan
-  <tr><td>is_normal(float) -&gt; bool<td>OpIsNormal
   <tr><td>dot(vecN<f32>, vecN<f32>) -&gt; float<td>OpDot
   <tr><td>outer_product(vecN<f32>, vecM<f32>) -&gt; matNxM<f32><td>OpOuterProduct
 </table>


### PR DESCRIPTION
This CL removes the is_finite and is_normal intrinsics. In order to
convert them into the OpIsFinite and OpIsNormal in SPIR-V the Kernel
capability is required. The Kernel capability requires a Kernel
execution mode. We do not use the Kernel execution mode but the
GLCompute execution mode for compute shaders.

If these methods are desired, they'll need to be added to the standard
library.