### PR TITLE
Fix xml parsing warnings

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1856,7 +1856,7 @@ enum GPUBindingType {
 A {{GPUBindGroupLayout}} object has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUBindGroupLayout">
-    : <dfn>\[[entryMap]]</dfn> of type map<u32, {{GPUBindGroupLayoutEntry}}>.
+    : <dfn>\[[entryMap]]</dfn> of type `map<u32, {{GPUBindGroupLayoutEntry}}>`.
     ::
         The map of binding indices pointing to the {{GPUBindGroupLayoutEntry}}s,
         which this {{GPUBindGroupLayout}} describes.


### PR DESCRIPTION
Debugged this by making the warning messages include the code being parsed in `.../bikeshed/venv/lib/python2.7/site-packages/html5lib/_ihatexml.py`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/844.html" title="Last updated on Jun 5, 2020, 11:39 PM UTC (0fce421)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/844/e083754...kainino0x:0fce421.html" title="Last updated on Jun 5, 2020, 11:39 PM UTC (0fce421)">Diff</a>