### PR TITLE
Document compute pass creation

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3158,7 +3158,7 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 
     On the [=Device timeline=], the following steps occur:
 
-        - If the [$GPUCommandEncoder.beginRenderPass/Valid Usage$] rules are met:
+        - If the [$GPUCommandEncoder.beginRenderPass/beginRenderPass Valid Usage$] rules are met:
 
             - Set |this|.{{GPUCommandEncoder/[[state]]}} to {{encoder state/encoding a render pass}}.
 
@@ -3178,13 +3178,41 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
     Issue: specify the behavior of read-only depth/stencil
 
     <div class=validusage dfn-for=GPUCommandEncoder.beginRenderPass>
-        <dfn abstract-op>Valid Usage</dfn>
+        <dfn abstract-op>beginRenderPass Valid Usage</dfn>
 
         Given the argument {{GPURenderPassDescriptor}} |descriptor|, the following validation rules apply:
 
           1. |this|.{{GPUCommandEncoder/[[state]]}} must be {{encoder state/open}}.
           1. |descriptor| must meet the
-            [$GPURenderPassDescriptor/Valid Usage|GPURenderPassDescriptor Valid Usage$] rules.
+            [$GPURenderPassDescriptor/GPURenderPassDescriptor Valid Usage$] rules.
+
+    </div>
+</div>
+
+### <dfn method for=GPUCommandEncoder>beginComputePass(descriptor)</dfn> ### {#GPUCommandEncoder-beginComputePass}
+
+<div algorithm="GPUCommandEncoder.beginComputePass">
+    <strong>|this|:</strong> of type {{GPUCommandEncoder}}.
+
+    **Arguments:**
+        - {{GPUComputePassDescriptor}} |descriptor|
+
+    **Returns:** {{GPUComputePassEncoder}}
+
+    Begins encoding a compute pass described by |descriptor|.
+
+    On the [=Device timeline=], the following steps occur:
+
+        - If the [$GPUCommandEncoder.beginComputePass/beginComputePass Valid Usage$] rules are met:
+
+            - Set |this|.{{GPUCommandEncoder/[[state]]}} to {{encoder state/encoding a compute pass}}.
+
+    <div class=validusage dfn-for=GPUCommandEncoder.beginComputePass>
+        <dfn abstract-op>beginComputePass Valid Usage</dfn>
+
+        Given the argument {{GPUComputePassDescriptor}} |descriptor|, the following validation rules apply:
+
+          1. |this|.{{GPUCommandEncoder/[[state]]}} must be {{encoder state/open}}.
 
     </div>
 </div>
@@ -3976,7 +4004,7 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
 </dl>
 
 <div class=validusage dfn-for=GPURenderPassDescriptor>
-    <dfn abstract-op>Valid Usage</dfn>
+    <dfn abstract-op>GPURenderPassDescriptor Valid Usage</dfn>
 
     Given a {{GPURenderPassDescriptor}} |this| the following validation rules apply:
 
@@ -3986,11 +4014,11 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
         |this|.{{GPURenderPassDescriptor/depthStencilAttachment}} must not be `null`.
     1. For each |colorAttachment| in |this|.{{GPURenderPassDescriptor/colorAttachments}}:
 
-        1. |colorAttachment| must meet the [$GPURenderPassColorAttachmentDescriptor/Valid Usage|GPURenderPassColorAttachmentDescriptor Valid Usage$] rules.
+        1. |colorAttachment| must meet the [$GPURenderPassColorAttachmentDescriptor/GPURenderPassColorAttachmentDescriptor Valid Usage$] rules.
 
     1. If |this|.{{GPURenderPassDescriptor/depthStencilAttachment}} is not `null`:
 
-        1. |this|.{{GPURenderPassDescriptor/depthStencilAttachment}} must meet the [$GPURenderPassDepthStencilAttachmentDescriptor/Valid Usage|GPURenderPassDepthStencilAttachmentDescriptor Valid Usage$] rules.
+        1. |this|.{{GPURenderPassDescriptor/depthStencilAttachment}} must meet the [$GPURenderPassDepthStencilAttachmentDescriptor/GPURenderPassDepthStencilAttachmentDescriptor Valid Usage$] rules.
 
     1. Each {{GPURenderPassColorAttachmentDescriptor/attachment}} in |this|.{{GPURenderPassDescriptor/colorAttachments}}
         and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}},
@@ -4043,7 +4071,7 @@ dictionary GPURenderPassColorAttachmentDescriptor {
 </dl>
 
 <div class=validusage dfn-for=GPURenderPassColorAttachmentDescriptor>
-    <dfn abstract-op>Valid Usage</dfn>
+    <dfn abstract-op>GPURenderPassColorAttachmentDescriptor Valid Usage</dfn>
 
     Given a {{GPURenderPassColorAttachmentDescriptor}} |this| the following validation rules
     apply:
@@ -4130,7 +4158,7 @@ dictionary GPURenderPassDepthStencilAttachmentDescriptor {
 </dl>
 
 <div class=validusage dfn-for=GPURenderPassDepthStencilAttachmentDescriptor>
-    <dfn abstract-op>Valid Usage</dfn>
+    <dfn abstract-op>GPURenderPassDepthStencilAttachmentDescriptor Valid Usage</dfn>
 
     Given a {{GPURenderPassDepthStencilAttachmentDescriptor}} |this| the following validation
     rules apply:


### PR DESCRIPTION
Also, since this was far simpler than the render pass equivalent, took the oppornutity to address the [validation name conflicts](https://github.com/gpuweb/gpuweb/pull/831#discussion_r436199833) pointed out by @kainino0x


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/toji/gpuweb/pull/846.html" title="Last updated on Jun 6, 2020, 6:23 PM UTC (d7ec1ac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/846/d2929d9...toji:d7ec1ac.html" title="Last updated on Jun 6, 2020, 6:23 PM UTC (d7ec1ac)">Diff</a>