### PR TITLE
Add gpu texture format supported by copyImageBitmapToTexture destination

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4315,6 +4315,7 @@ GPUQueue includes GPUObjectBase;
         The operation throws {{OperationError}} if any of the following any of the following requirements are unmet:
 
         - {{GPUQueue/copyImageBitmapToTexture(source, destination, copySize)/copySize}}.[=Extent3D/depth=] must be `1`.
+        - {{GPUQueue/copyImageBitmapToTexture(source, destination, copySize)/destination}}.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} must be {{GPUTextureFormat/"rgba8unorm"}} or {{GPUTextureFormat/"rgba8unorm-srgb"}} or {{GPUTextureFormat/"bgra8unorm"}} or {{GPUTextureFormat/"bgra8unorm-srgb"}} or {{GPUTextureFormat/"rgb10a2unorm"}} or {{GPUTextureFormat/"rgba16float"}} or {{GPUTextureFormat/"rgba32float"}} or {{GPUTextureFormat/"rg8unorm"}} or {{GPUTextureFormat/"rg16float"}}.
 
     : <dfn>submit(commandBuffers)</dfn>
     ::


### PR DESCRIPTION
This patch added gpu texture format supported by copyImageBitmapToTexture.
If developer provided other format textures, copyImageBitmapToTexture doesn't
do color conversion for it and report type error.