### PR TITLE
Add gpu texture format supported by copyImageBitmapToTexture destination

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4315,6 +4315,7 @@ GPUQueue includes GPUObjectBase;
         The operation throws {{OperationError}} if any of the following any of the following requirements are unmet:
 
         - {{GPUQueue/copyImageBitmapToTexture(source, destination, copySize)/copySize}}.[=Extent3D/depth=] must be `1`.
+        - {{GPUQueue/copyImageBitmapToTexture(source, destination, copySize)/destination}}.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} must be {{GPUTextureFormat/"rgba8unorm"}} or {{GPUTextureFormat/"rgba8unorm-srgb"}} or {{GPUTextureFormat/"bgra8unorm"}} or {{GPUTextureFormat/"bgra8unorm-srgb"}} or {{GPUTextureFormat/"rgb10a2unorm"}} or {{GPUTextureFormat/"rgba16float"}} or {{GPUTextureFormat/"rgba32float"}} or {{GPUTextureFormat/"rg8unorm"}} or {{GPUTextureFormat/"rg16float"}}.
 
     : <dfn>submit(commandBuffers)</dfn>
     ::

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4315,7 +4315,16 @@ GPUQueue includes GPUObjectBase;
         The operation throws {{OperationError}} if any of the following any of the following requirements are unmet:
 
         - {{GPUQueue/copyImageBitmapToTexture(source, destination, copySize)/copySize}}.[=Extent3D/depth=] must be `1`.
-        - {{GPUQueue/copyImageBitmapToTexture(source, destination, copySize)/destination}}.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} must be {{GPUTextureFormat/"rgba8unorm"}} or {{GPUTextureFormat/"rgba8unorm-srgb"}} or {{GPUTextureFormat/"bgra8unorm"}} or {{GPUTextureFormat/"bgra8unorm-srgb"}} or {{GPUTextureFormat/"rgb10a2unorm"}} or {{GPUTextureFormat/"rgba16float"}} or {{GPUTextureFormat/"rgba32float"}} or {{GPUTextureFormat/"rg8unorm"}} or {{GPUTextureFormat/"rg16float"}}.
+        - {{GPUQueue/copyImageBitmapToTexture(source, destination, copySize)/destination}}.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} must be one of the following:
+             - {{GPUTextureFormat/"rgba8unorm"}} 
+             - {{GPUTextureFormat/"rgba8unorm-srgb"}}
+             - {{GPUTextureFormat/"bgra8unorm"}}
+             - {{GPUTextureFormat/"bgra8unorm-srgb"}}
+             - {{GPUTextureFormat/"rgb10a2unorm"}}
+             - {{GPUTextureFormat/"rgba16float"}}
+             - {{GPUTextureFormat/"rgba32float"}}
+             - {{GPUTextureFormat/"rg8unorm"}}
+             - {{GPUTextureFormat/"rg16float"}}
 
     : <dfn>submit(commandBuffers)</dfn>
     ::


### PR DESCRIPTION
This patch added gpu texture format supported by copyImageBitmapToTexture.
If developer provided other format textures, copyImageBitmapToTexture doesn't
do color conversion for it and report type error.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shaoboyan/gpuweb/pull/849.html" title="Last updated on Jun 8, 2020, 8:43 AM UTC (f0fb64f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/849/d2929d9...shaoboyan:f0fb64f.html" title="Last updated on Jun 8, 2020, 8:43 AM UTC (f0fb64f)">Diff</a>