### PR TITLE
Documented render pass rasterization state methods

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4491,8 +4491,8 @@ attachments used by this encoder.
     <strong>|this|:</strong> of type {{GPURenderPassEncoder}}.
 
     **Arguments:**
-        - `float` x - minimum X value of the viewport in pixels
-        - `float` y - minimum Y value of the viewport in pixels
+        - `float` |x| - minimum X value of the viewport in pixels
+        - `float` |y| - minimum Y value of the viewport in pixels
         - `float` |width| of the viewport in pixels
         - `float` |height| of the viewport in pixels
         - `float` |minDepth| - Minimum depth value of the viewport
@@ -4509,7 +4509,8 @@ attachments used by this encoder.
 
         - If the [$GPURenderPassEncoder.setViewport/setViewport Valid Usage$] rules are met:
 
-            - Set |this|.{{GPURenderPassEncoder/[[viewport]]}} to the extents passed to the method.
+            - Set |this|.{{GPURenderPassEncoder/[[viewport]]}} to the extents |x|, |y|, |width|,
+                |height|, |minDepth|, and |maxDepth|.
 
     <div class=validusage dfn-for=GPURenderPassEncoder.setViewport>
         <dfn abstract-op>setViewport Valid Usage</dfn>
@@ -4546,7 +4547,8 @@ attachments used by this encoder.
 
         - If the [$GPURenderPassEncoder.setScissorRect/setScissorRect Valid Usage$] rules are met:
 
-            - Set |this|.{{GPURenderPassEncoder/[[scissor_rectangle]]}} to the extents passed to the method.
+            - Set |this|.{{GPURenderPassEncoder/[[scissor_rectangle]]}} to the extents |x|, |y|,
+                |width|, and |height|.
 
     <div class=validusage dfn-for=GPURenderPassEncoder.setScissorRect>
         <dfn abstract-op>setScissorRect Valid Usage</dfn>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4234,17 +4234,22 @@ GPURenderPassEncoder includes GPURenderEncoderBase;
   * In indirect draw calls, the base instance field (inside the indirect
     buffer data) must be set to zero.
 
-  * {{GPURenderPassEncoder/setScissorRect()}}:
-      * An error is generated if `width` or `height` is not greater than 0.
+{{GPURenderPassEncoder}} has the following internal slots:
 
-When a {{GPURenderPassEncoder}} is created, it has the following default state:
-  * Viewport:
-      * `x, y` = `0.0, 0.0`
-      * `width, height` = the dimensions of the pass's render targets
-      * `minDepth, maxDepth` = `0.0, 1.0`
-  * Scissor rectangle:
-      * `x, y` = `0, 0`
-      * `width, height` = the dimensions of the pass's render targets
+<dl dfn-type=attribute dfn-for="GPURenderPassEncoder">
+    : <dfn>\[[viewport]]</dfn>
+    ::
+        The current viewport, initially set to the following extents:
+            - `x, y` = `0.0, 0.0`
+            - `width, height` = the dimensions of the pass's render attachments
+            - `minDepth, maxDepth` = `0.0, 1.0`
+
+    : <dfn>\[[scissor_rectangle]]</dfn>
+    ::
+        The current scissor rectangle, initially set to the following extents:
+            - `x, y` = `0.0, 0.0`
+            - `width, height` = the dimensions of the pass's render attachments
+</dl>
 
 When a {{GPURenderBundle}} is executed, it does not inherit the pass's pipeline,
 bind groups, or vertex or index buffers. After a {{GPURenderBundle}} has executed,
@@ -4478,7 +4483,7 @@ attachments used by this encoder.
 ### <dfn method for=GPURenderPassEncoder>setViewport(x, y, width, height, minDepth, maxDepth)</dfn> ### {#GPURenderPassEncoder-setViewport}
 
 <div algorithm="GPURenderPassEncoder.setViewport">
-    <strong>this:</strong> of type {{GPURenderPassEncoder}}.
+    <strong>|this|:</strong> of type {{GPURenderPassEncoder}}.
 
     **Arguments:**
         - `float` x - Left side of the viewport in pixels
@@ -4491,8 +4496,14 @@ attachments used by this encoder.
 
     **Returns:** void
 
-    Sets the viewport used during the rasterization stage to linearly map from normalized device
-    coordinates to viewport coordinates.
+    Sets the {{GPURenderPassEncoder/[[viewport]]}} used during the rasterization stage to linearly
+    map from normalized device coordinates to viewport coordinates.
+
+    On the [=Device timeline=], the following steps occur:
+
+        - If the [$GPURenderPassEncoder.setViewport/setViewport Valid Usage$] rules are met:
+
+            - Set |this|.{{GPURenderPassEncoder/[[viewport]]}} to the extents passed to the method.
 
     <div class=validusage dfn-for=GPURenderPassEncoder.setViewport>
         <dfn abstract-op>setViewport Valid Usage</dfn>
@@ -4504,12 +4515,14 @@ attachments used by this encoder.
 
     </div>
 
+    Issue: Allowed for GPUs to use fixed point or rounded viewport coordinates
+
 </div>
 
 ### <dfn method for=GPURenderPassEncoder>setScissorRect(x, y, width, height)</dfn> ### {#GPURenderPassEncoder-setScissorRect}
 
 <div algorithm="GPURenderPassEncoder.setScissorRect">
-    <strong>this:</strong> of type {{GPURenderPassEncoder}}.
+    <strong>|this|:</strong> of type {{GPURenderPassEncoder}}.
 
     **Arguments:**
         - {{GPUIntegerCoordinate}} x - Left side of the scissor rectangle in pixels
@@ -4519,8 +4532,15 @@ attachments used by this encoder.
 
     **Returns:** void
 
-    Sets the scissor rectangle used during the rasterization stage. After transformation into
-    viewport coordinates any fragments which fall outside the scissor rectangle will be discarded.
+    Sets the {{GPURenderPassEncoder/[[scissor_rectangle]]}} used during the rasterization stage.
+    After transformation into viewport coordinates any fragments which fall outside the scissor
+    rectangle will be discarded.
+
+    On the [=Device timeline=], the following steps occur:
+
+        - If the [$GPURenderPassEncoder.setScissorRect/setScissorRect Valid Usage$] rules are met:
+
+            - Set |this|.{{GPURenderPassEncoder/[[scissor_rectangle]]}} to the extents passed to the method.
 
     <div class=validusage dfn-for=GPURenderPassEncoder.setScissorRect>
         <dfn abstract-op>setScissorRect Valid Usage</dfn>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4241,20 +4241,16 @@ GPURenderPassEncoder includes GPURenderEncoderBase;
     ::
         Set to the following extents:
             - `width, height` = the dimensions of the pass's render attachments
-
-    : <dfn>\[[viewport]]</dfn>
-    ::
-        The current viewport, initially set to the following extents:
-            - `x, y` = `0.0, 0.0`
-            - `width, height` = the dimensions of the pass's render attachments
-            - `minDepth, maxDepth` = `0.0, 1.0`
-
-    : <dfn>\[[scissor_rectangle]]</dfn>
-    ::
-        The current scissor rectangle, initially set to the following extents:
-            - `x, y` = `0.0, 0.0`
-            - `width, height` = the dimensions of the pass's render attachments
 </dl>
+
+When a {{GPURenderPassEncoder}} is created, it has the following default state:
+  * Viewport:
+      * `x, y` = `0.0, 0.0`
+      * `width, height` = the dimensions of the pass's render targets
+      * `minDepth, maxDepth` = `0.0, 1.0`
+  * Scissor rectangle:
+      * `x, y` = `0, 0`
+      * `width, height` = the dimensions of the pass's render targets
 
 When a {{GPURenderBundle}} is executed, it does not inherit the pass's pipeline,
 bind groups, or vertex or index buffers. After a {{GPURenderBundle}} has executed,
@@ -4488,7 +4484,7 @@ attachments used by this encoder.
 ### <dfn method for=GPURenderPassEncoder>setViewport(x, y, width, height, minDepth, maxDepth)</dfn> ### {#GPURenderPassEncoder-setViewport}
 
 <div algorithm="GPURenderPassEncoder.setViewport">
-    <strong>|this|:</strong> of type {{GPURenderPassEncoder}}.
+    <strong>this:</strong> of type {{GPURenderPassEncoder}}.
 
     **Arguments:**
         - `float` |x| - minimum X value of the viewport in pixels
@@ -4502,15 +4498,14 @@ attachments used by this encoder.
 
     **Returns:** void
 
-    Sets the {{GPURenderPassEncoder/[[viewport]]}} used during the rasterization stage to linearly
-    map from normalized device coordinates to viewport coordinates.
+    Sets the viewport used during the rasterization stage to linearly map from normalized device
+    coordinates to viewport coordinates.
 
     On the [=Device timeline=], the following steps occur:
 
         - If the [$GPURenderPassEncoder.setViewport/setViewport Valid Usage$] rules are met:
 
-            - Set |this|.{{GPURenderPassEncoder/[[viewport]]}} to the extents |x|, |y|, |width|,
-                |height|, |minDepth|, and |maxDepth|.
+            - Set the viewport to the extents |x|, |y|, |width|, |height|, |minDepth|, and |maxDepth|.
 
     <div class=validusage dfn-for=GPURenderPassEncoder.setViewport>
         <dfn abstract-op>setViewport Valid Usage</dfn>
@@ -4539,7 +4534,7 @@ attachments used by this encoder.
 
     **Returns:** void
 
-    Sets the {{GPURenderPassEncoder/[[scissor_rectangle]]}} used during the rasterization stage.
+    Sets the scissor rectangle used during the rasterization stage.
     After transformation into viewport coordinates any fragments which fall outside the scissor
     rectangle will be discarded.
 
@@ -4547,8 +4542,7 @@ attachments used by this encoder.
 
         - If the [$GPURenderPassEncoder.setScissorRect/setScissorRect Valid Usage$] rules are met:
 
-            - Set |this|.{{GPURenderPassEncoder/[[scissor_rectangle]]}} to the extents |x|, |y|,
-                |width|, and |height|.
+            - Set the scissor rectangle to the extents |x|, |y|, |width|, and |height|.
 
     <div class=validusage dfn-for=GPURenderPassEncoder.setScissorRect>
         <dfn abstract-op>setScissorRect Valid Usage</dfn>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4455,7 +4455,7 @@ dictionary GPURenderPassDepthStencilAttachmentDescriptor {
     Issue: Describe the remaining validation rules for this type.
 </div>
 
-### Load &amp; Store Operations ### {#load-and-store-ops}
+#### Load &amp; Store Operations #### {#load-and-store-ops}
 
 <script type=idl>
 enum GPULoadOp {
@@ -4469,6 +4469,98 @@ enum GPUStoreOp {
     "clear"
 };
 </script>
+
+## Rasterization state ## {#render-pass-encoder-rasterization-state}
+
+The render pass encoder has several methods which affect how draw commands are rasterized to the
+attachments used by this encoder.
+
+### <dfn method for=GPURenderPassEncoder>setViewport(x, y, width, height, minDepth, maxDepth)</dfn> ### {#GPURenderPassEncoder-setViewport}
+
+<div algorithm="GPURenderPassEncoder.setViewport">
+    <strong>this:</strong> of type {{GPURenderPassEncoder}}.
+
+    **Arguments:**
+        - `float` x - Left side of the viewport in pixels
+        - `float` y - Top side of the viewport in pixels
+        - `float` |width| of the viewport in pixels
+        - `float` |height| of the viewport in pixels
+        - `float` |minDepth| - Minimum depth value of the viewport
+        - `float` |maxDepth| - Maximum depth value of the viewport. May be less than or equal to
+            |minDepth|.
+
+    **Returns:** void
+
+    Sets the viewport used during the rasterization stage to linearly map from normalized device
+    coordinates to viewport coordinates.
+
+    <div class=validusage dfn-for=GPURenderPassEncoder.setViewport>
+        <dfn abstract-op>setViewport Valid Usage</dfn>
+
+        1. |width| must be greater than `0`.
+        1. |height| must be greater than `0`.
+        1. |minDepth| must be greater than or equal to `0.0` and less than or equal to `1.0`.
+        1. |maxDepth| must be greater than or equal to `0.0` and less than or equal to `1.0`.
+
+    </div>
+
+</div>
+
+### <dfn method for=GPURenderPassEncoder>setScissorRect(x, y, width, height)</dfn> ### {#GPURenderPassEncoder-setScissorRect}
+
+<div algorithm="GPURenderPassEncoder.setScissorRect">
+    <strong>this:</strong> of type {{GPURenderPassEncoder}}.
+
+    **Arguments:**
+        - {{GPUIntegerCoordinate}} x - Left side of the scissor rectangle in pixels
+        - {{GPUIntegerCoordinate}} y - Top side of the scissor rectangle in pixels
+        - {{GPUIntegerCoordinate}} |width| of the scissor rectangle in pixels
+        - {{GPUIntegerCoordinate}} |height| of the scissor rectangle in pixels
+
+    **Returns:** void
+
+    Sets the scissor rectangle used during the rasterization stage. After transformation into
+    viewport coordinates any fragments which fall outside the scissor rectangle will be discarded.
+
+    <div class=validusage dfn-for=GPURenderPassEncoder.setScissorRect>
+        <dfn abstract-op>setScissorRect Valid Usage</dfn>
+
+        1. |width| must be greater than `0`.
+        1. |height| must be greater than `0`.
+
+    </div>
+
+</div>
+
+### <dfn method for=GPURenderPassEncoder>setBlendColor(color)</dfn> ### {#GPURenderPassEncoder-setBlendColor}
+
+<div algorithm="GPURenderPassEncoder.setBlendColor">
+    <strong>this:</strong> of type {{GPURenderPassEncoder}}.
+
+    **Arguments:**
+        - {{GPUColor}} color
+
+    **Returns:** void
+
+    Sets the constant blend color and alpha values used with {{GPUBlendFactor/"blend-color"}} and
+    {{GPUBlendFactor/"one-minus-blend-color"}} {{GPUBlendFactor}}s.
+
+</div>
+
+### <dfn method for=GPURenderPassEncoder>setStencilReference(reference)</dfn> ### {#GPURenderPassEncoder-setStencilReference}
+
+<div algorithm="GPURenderPassEncoder.setStencilReference">
+    <strong>this:</strong> of type {{GPURenderPassEncoder}}.
+
+    **Arguments:**
+        - {{GPUStencilValue}} reference
+
+    **Returns:** void
+
+    Sets the stencil reference value used during stencil tests with the the {{GPUStencilOperation/"replace"}}
+    {{GPUStencilOperation}}.
+
+</div>
 
 ## Finalization ## {#render-pass-encoder-finalization}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1747,7 +1747,7 @@ enum GPUTextureComponentType {
 ## <dfn interface>GPUSampler</dfn> ## {#sampler-interface}
 
 A {{GPUSampler}} encodes transformations and filtering information that can
-be used in a shader to interpret texture resource data. 
+be used in a shader to interpret texture resource data.
 
 {{GPUSampler|GPUSamplers}} are created via {{GPUDevice/createSampler(descriptor)|GPUDevice.createSampler(optional descriptor)}}
 that returns a new sampler object.
@@ -1789,12 +1789,12 @@ dictionary GPUSamplerDescriptor : GPUObjectDescriptorBase {
 };
 </script>
 
-- {{GPUSamplerDescriptor/addressModeU}}, {{GPUSamplerDescriptor/addressModeV}}, 
+- {{GPUSamplerDescriptor/addressModeU}}, {{GPUSamplerDescriptor/addressModeV}},
     and {{GPUSamplerDescriptor/addressModeW}} specify the address modes for the texture width,
     height, and depth coordinates, respectively.
 - {{GPUSamplerDescriptor/magFilter}} specifies the sampling behavior when the sample footprint
     is smaller than or equal to one texel.
-- {{GPUSamplerDescriptor/minFilter}} specifies the sampling behavior when the sample footprint 
+- {{GPUSamplerDescriptor/minFilter}} specifies the sampling behavior when the sample footprint
     is larger than one texel.
 - {{GPUSamplerDescriptor/mipmapFilter}} specifies behavior for sampling between two mipmap levels.
 - {{GPUSamplerDescriptor/lodMinClamp}} and {{GPUSamplerDescriptor/lodMaxClamp}} specify the minimum and
@@ -1829,10 +1829,10 @@ enum GPUAddressMode {
     : <dfn>"mirror-repeat"</dfn>
     ::
         Texture coordinates wrap to the other side of the texture, but the texture is flipped
-        when the integer part of the coordinate is odd. 
+        when the integer part of the coordinate is odd.
 </dl>
 
-{{GPUFilterMode}} describes the behavior of the sampler if the sample footprint does not exactly 
+{{GPUFilterMode}} describes the behavior of the sampler if the sample footprint does not exactly
 match one texel.
 
 <script type=idl>
@@ -1849,11 +1849,11 @@ enum GPUFilterMode {
 
     : <dfn>"linear"</dfn>
     ::
-        Select two texels in each dimension and return a linear interpolation between their values. 
+        Select two texels in each dimension and return a linear interpolation between their values.
 </dl>
 
 {{GPUCompareFunction}} specifies the behavior of a comparison sampler. If a comparison sampler is
-used in a shader, an input value is compared to the sampled texture value, and the result of this 
+used in a shader, an input value is compared to the sampled texture value, and the result of this
 comparison test (0.0f for pass, or 1.0f for fail) is used in the filtering operation.
 
 Issue: describe how filtering interacts with comparison sampling.
@@ -1910,7 +1910,7 @@ enum GPUCompareFunction {
     **Arguments:**
         - {{GPUDevice}} |device|
         - {{GPUSamplerDescriptor}} |descriptor|
-    
+
     **Returns:** boolean
 
     Return true if and only if all of the following conditions apply:
@@ -4237,6 +4237,11 @@ GPURenderPassEncoder includes GPURenderEncoderBase;
 {{GPURenderPassEncoder}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPURenderPassEncoder">
+    : <dfn>\[[attachment_size]]</dfn>
+    ::
+        Set to the following extents:
+            - `width, height` = the dimensions of the pass's render attachments
+
     : <dfn>\[[viewport]]</dfn>
     ::
         The current viewport, initially set to the following extents:
@@ -4486,13 +4491,14 @@ attachments used by this encoder.
     <strong>|this|:</strong> of type {{GPURenderPassEncoder}}.
 
     **Arguments:**
-        - `float` x - Left side of the viewport in pixels
-        - `float` y - Top side of the viewport in pixels
+        - `float` x - minimum X value of the viewport in pixels
+        - `float` y - minimum Y value of the viewport in pixels
         - `float` |width| of the viewport in pixels
         - `float` |height| of the viewport in pixels
         - `float` |minDepth| - Minimum depth value of the viewport
-        - `float` |maxDepth| - Maximum depth value of the viewport. May be less than or equal to
-            |minDepth|.
+        - `float` |maxDepth| - Maximum depth value of the viewport.
+
+    Issue: Are flipped depth ranges supported on all backends?
 
     **Returns:** void
 
@@ -4525,8 +4531,8 @@ attachments used by this encoder.
     <strong>|this|:</strong> of type {{GPURenderPassEncoder}}.
 
     **Arguments:**
-        - {{GPUIntegerCoordinate}} x - Left side of the scissor rectangle in pixels
-        - {{GPUIntegerCoordinate}} y - Top side of the scissor rectangle in pixels
+        - {{GPUIntegerCoordinate}} |x| - minimum X value of the scissor rectangle in pixels
+        - {{GPUIntegerCoordinate}} |y| - minimum Y value of the scissor rectangle in pixels
         - {{GPUIntegerCoordinate}} |width| of the scissor rectangle in pixels
         - {{GPUIntegerCoordinate}} |height| of the scissor rectangle in pixels
 
@@ -4545,8 +4551,12 @@ attachments used by this encoder.
     <div class=validusage dfn-for=GPURenderPassEncoder.setScissorRect>
         <dfn abstract-op>setScissorRect Valid Usage</dfn>
 
+        1. |x| must be greater than or equal to `0`.
+        1. |y| must be greater than or equal to `0`.
         1. |width| must be greater than `0`.
         1. |height| must be greater than `0`.
+        1. |x|+|width| must be less than or equal to |this|.{{GPURenderPassEncoder/[[attachment_size]]}}.width.
+        1. |y|+|height| must be less than or equal to |this|.{{GPURenderPassEncoder/[[attachment_size]]}}.height.
 
     </div>
 


### PR DESCRIPTION
Adds documentation for
 - setViewport
 - setScissor
 - setBlendColor
 - setStencilReference

Descriptions were based off of both the Vulkan and Metal docs. Please double check to make sure they're still applicable to WebGPU.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/toji/gpuweb/pull/850.html" title="Last updated on Jun 8, 2020, 11:52 PM UTC (3b913d7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/850/d2929d9...toji:3b913d7.html" title="Last updated on Jun 8, 2020, 11:52 PM UTC (3b913d7)">Diff</a>