### PR TITLE
[wgsl] Add spec text around vector accessors.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -375,17 +375,30 @@ Issue: (dneto) It feels like this needs some reorganization. Perhaps "Evaluation
 Accessing members of a vector can be done either using array subscripting (e.g. `a[2]`) or using convenience names for each element of the vector. The available convenience names are:
 
 <table class='data'>
-  <tr><td>rgba<td>where r is the first component and a is the last component
-  <tr><td>xyzw<td>where x is the first component and w is the last component
+  <tr><td>rgba<td>where r is the first component. Each letter is applied to the
+    components in order up to the size of the vector.
+  <tr><td>xyzw<td>where x is the first component. Each letter is applied to the
+    components in order up to the size of hte vector.
 </table>
 
-The convenience names are accessed using the `.` notation. (e.g. `a.bgra`).
+The convenience names are accessed using the `.` notation. (e.g. `color.bgra`).
 
 NOTE: the convenience letterings can not be mixed. (i.e. you can not use `rybw`).
 
 Using a convenience letter, or array subscript, which accesses an element past the end of the vector is an error.
 
-The ordering of the names does not matter, fewer component names can be provided then there are elements in the vector and the component names can be duplicated.
+The ordering of the names does not matter, fewer component names can be provided then there are elements in the vector and the component names can be duplicated. Providing more then 4 component names in a single swizzle is an error.
+
+The result type depends on the number of letters provided. Assuming a `vec4<f32>`
+<table>
+  <thead>
+    <tr><td>Accessor<td>Result type
+  </thead>
+  <tr><td>r<td>`f32`
+  <tr><td>rg<td>`vec2<f32>`
+  <tr><td>rgb<td>`vec3<f32>`
+  <tr><td>rgba<td>`vec4<f32>`
+</table>
 
 <div class='example'>
   <xmp highlight='rust'>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -376,9 +376,9 @@ Accessing members of a vector can be done either using array subscripting (e.g. 
 
 <table class='data'>
   <tr><td>rgba<td>where r is the first component. Each letter is applied to the
-    components in order up to the size of the vector.
+    components in order up to the size of the source vector.
   <tr><td>xyzw<td>where x is the first component. Each letter is applied to the
-    components in order up to the size of hte vector.
+    components in order up to the size of the source vector.
 </table>
 
 The convenience names are accessed using the `.` notation. (e.g. `color.bgra`).
@@ -387,7 +387,7 @@ NOTE: the convenience letterings can not be mixed. (i.e. you can not use `rybw`)
 
 Using a convenience letter, or array subscript, which accesses an element past the end of the vector is an error.
 
-The ordering of the names does not matter, fewer component names can be provided then there are elements in the vector and the component names can be duplicated. Providing more then 4 component names in a single swizzle is an error.
+The convenience letterings can be applied in any order, including duplicating letters as needed. You can provide 1 to 4 letters when extracing components from a vector. Providing more then 4 letters is an error.
 
 The result type depends on the number of letters provided. Assuming a `vec4<f32>`
 <table>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -372,14 +372,12 @@ Issue: (dneto) It feels like this needs some reorganization. Perhaps "Evaluation
 </div>
 
 ## Vector Accessors ## {#vector-accessor}
-Accessing members of a vector can be done either using array subscripting (e.g. `a[2]`) or using convenience names for each element of the vector. The available convenience names are:
+Accessing members of a vector can be done either using array subscripting (e.g. `a[2]`) or using a sequence of convenience names, each mapping to an element of the source vector.
 
-<table class='data'>
-  <tr><td>rgba<td>where r is the first component. Each letter is applied to the
-    components in order up to the size of the source vector.
-  <tr><td>xyzw<td>where x is the first component. Each letter is applied to the
-    components in order up to the size of the source vector.
-</table>
+<ul>
+  <li>The colour set of convenience names: `r`, `g`, `b`, `a` for vector elements 0, 1, 2, and 3 respectively.
+  <li>The dimensional set of convenience names: `x`, `y`, `z`, `w` for vector elements 0, 1, 2, and 3, respectively.
+</ul>
 
 The convenience names are accessed using the `.` notation. (e.g. `color.bgra`).
 
@@ -403,10 +401,10 @@ The result type depends on the number of letters provided. Assuming a `vec4<f32>
 <div class='example'>
   <xmp highlight='rust'>
     var a : vec3<f32> = vec3<f32>(1., 2., 3.);
-    var b : f32 = a.y;
-    var c : vec2<f32> = a.bb;
-    var d : vec3<f32> = a.zyw;
-    var e : f32 = a[1];
+    var b : f32 = a.y;          # b = 2.0
+    var c : vec2<f32> = a.bb;   # c = (3.0, 3.0)
+    var d : vec3<f32> = a.zyx;  # d = (3.0, 2.0, 1.0)
+    var e : f32 = a[1];         # e = 2.0
   </xmp>
 </div>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -371,6 +371,32 @@ Issue: (dneto) It feels like this needs some reorganization. Perhaps "Evaluation
   such that the redundant loads are eliminated.
 </div>
 
+## Vector Accessors ## {#vector-accessor}
+Accessing members of a vector can be done either using array subscripting (e.g. `a[2]`) or using convenience names for each element of the vector. The available convenience names are:
+
+<table class='data'>
+  <tr><td>rgba<td>where r is the first component and a is the last component
+  <tr><td>xyzw<td>where x is the first component and w is the last component
+</table>
+
+The convenience names are accessed using the `.` notation. (e.g. `a.bgra`).
+
+NOTE: the convenience letterings can not be mixed. (i.e. you can not use `rybw`).
+
+Using a convenience letter, or array subscript, which accesses an element past the end of the vector is an error.
+
+The ordering of the names does not matter, fewer component names can be provided then there are elements in the vector and the component names can be duplicated.
+
+<div class='example'>
+  <xmp highlight='rust'>
+    var a : vec3<f32> = vec3<f32>(1., 2., 3.);
+    var b : f32 = a.y;
+    var c : vec2<f32> = a.bb;
+    var d : vec3<f32> = a.zyw;
+    var e : f32 = a[1];
+  </xmp>
+</div>
+
 # Grammar # {#grammar}
 
 ## Scoping ## {#scoping}


### PR DESCRIPTION
This CL adds some initial spec text around the vector accessors and adds
in that `rgba` and `xyzw` are valid accessors for a vector.

Fixes #754