### PR TITLE
Introduce GPUTextureBinding.readOnlyDepthStencil

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2245,7 +2245,7 @@ dictionary GPUBindGroupDescriptor : GPUObjectDescriptorBase {
 A {{GPUBindGroupEntry}} describes a single resource to be bound in a {{GPUBindGroup}}.
 
 <script type=idl>
-typedef (GPUSampler or GPUTextureView or GPUBufferBinding) GPUBindingResource;
+typedef (GPUSampler or GPUTextureBinding or GPUBufferBinding) GPUBindingResource;
 
 dictionary GPUBindGroupEntry {
     required GPUIndex32 binding;
@@ -2263,6 +2263,16 @@ dictionary GPUBufferBinding {
 
   * {{GPUBufferBinding/size}}: If undefined, specifies the range starting at
       {{GPUBufferBinding/offset}} and ending at the end of the buffer.
+
+<script type=idl>
+dictionary GPUTextureBinding {
+    required GPUTextureView view;
+    boolean readOnlyDepthStencil = false;
+};
+</script>
+
+  * {{GPUTextureBinding/readOnlyDepthStencil}}: if true, the binding can only be used in
+      render passes with read-only depth and stencil.
 
 A {{GPUBindGroup}} object has the following internal slots:
 


### PR DESCRIPTION
This is a required follow-up to #746 (read-only depth/stencil, or RODS for short).

## Problem

We implemented RODS and found a missing piece in the design. In Vulkan, creating a `VkDescriptorSet` (which is used to back `GPUBindGroup`) with an `VkImage` requires specifying the image layout. Previously, our implementation was always setting it to `VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL` for sampled textures. If an image subresource is used as the depth-stencil attachment, however, it's layout must be one of the depth-stencil types (like `VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL`), or `VK_IMAGE_LAYOUT_GENERAL`. It's *not* allowed to be `VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL`. Therefore, naively binding the depth texture view in a RODS pass leads to Vulkan validation error, because the image is in `VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL` (for example), while the bound descriptor set expects it to be in `VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL`.

## Considered solutions

One obvious solution is to use `VK_IMAGE_LAYOUT_GENERAL` for all sampled texture bindings as well as RODS attachments. We don't want to do this, since `GENERAL` layout is not as efficient as more specific layouts. Doing this would negatively affect *all* texture bindings, not just the ones related to RODS.

Another choice is to say that we don't get RODS at all, and roll-back #746. This will be sad, because RODS is supported on all platforms that we are targeting, and it's useful.

Finally, there is a way I could think of, that doesn't affect non-RODS scenarios, but requires an extra API field. When creating a bind group entry, we can tell if it's going to be used for RODS passes only, or not, by having a boolean `readOnlyDepthStencil` flag. This would affect the "shadow" usage of the subresources bound in a pass. On the implementation side, we are going to be using `VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL` instead of `VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL` if this flag is set.

In order to add the flag, the PR introduces `GPUTextureBinding` struct in the same way we have `GPUBufferBinding`. I think it's good to have it regardless, in order to allow extensions to affect texture view bindings by extending it.

## Disclaimer

This PR doesn't fully specify the validation this flag. It's blocked on #745 , which is the key to figuring out how to properly separate the RODS usage from regular `GPUTextureUsage.SAMPLED`. Note: #745 needs to be done regardless of RODS, it's also required for `STORAGE` usage separation of read/write.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/859.html" title="Last updated on Jun 11, 2020, 2:43 PM UTC (21d4c4e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/859/0cc44c8...kvark:21d4c4e.html" title="Last updated on Jun 11, 2020, 2:43 PM UTC (21d4c4e)">Diff</a>