### PR TITLE
[WIP] Read-only GPUTextureView

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1553,6 +1553,7 @@ dictionary GPUTextureViewDescriptor : GPUObjectDescriptorBase {
     GPUTextureFormat format;
     GPUTextureViewDimension dimension;
     GPUTextureAspect aspect = "all";
+    boolean readOnly = false;
     GPUIntegerCoordinate baseMipLevel = 0;
     GPUIntegerCoordinate mipLevelCount = 0;
     GPUIntegerCoordinate baseArrayLayer = 0;
@@ -4309,6 +4310,8 @@ dictionary GPURenderPassColorAttachmentDescriptor {
     1. |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[textureUsage]]}}
         must contain {{GPUTextureUsage/OUTPUT_ATTACHMENT}}.
     1. |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}} must be a view of a single [=subresource=].
+    1. |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/readOnly}}
+        must be `false`.
     1. If |this|.{{GPURenderPassColorAttachmentDescriptor/resolveTarget}} is not `null`:
 
         1. |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}} must be multisampled.
@@ -4334,11 +4337,9 @@ dictionary GPURenderPassDepthStencilAttachmentDescriptor {
 
     required (GPULoadOp or float) depthLoadValue;
     required GPUStoreOp depthStoreOp;
-    boolean depthReadOnly = false;
 
     required (GPULoadOp or GPUStencilValue) stencilLoadValue;
     required GPUStoreOp stencilStoreOp;
-    boolean stencilReadOnly = false;
 };
 </script>
 
@@ -4361,11 +4362,6 @@ dictionary GPURenderPassDepthStencilAttachmentDescriptor {
         The store operation to perform on {{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}'s
         depth component after executing the render pass.
 
-    : <dfn>depthReadOnly</dfn>
-    ::
-        Indicates that the depth component of {{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}
-        is read only.
-
     : <dfn>stencilLoadValue</dfn>
     ::
         If a {{GPULoadOp}}, indicates the load operation to perform on
@@ -4380,10 +4376,6 @@ dictionary GPURenderPassDepthStencilAttachmentDescriptor {
         The store operation to perform on {{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}'s
         stencil component after executing the render pass.
 
-    : <dfn>stencilReadOnly</dfn>
-    ::
-        Indicates that the stencil component of {{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}
-        is read only.
 </dl>
 
 <div class=validusage dfn-for=GPURenderPassDepthStencilAttachmentDescriptor>
@@ -4398,14 +4390,11 @@ dictionary GPURenderPassDepthStencilAttachmentDescriptor {
         single [=subresource=].
     1. |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}.{{GPUTexture/[[textureUsage]]}}
         must contain {{GPUTextureUsage/OUTPUT_ATTACHMENT}}.
-    1. |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/depthReadOnly}} is `true`,
-        |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/depthLoadValue}} must be
-        {{GPULoadOp/"load"}} and |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/depthStoreOp}}
-        must be {{GPUStoreOp/"store"}}.
-    1. |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/stencilReadOnly}} is `true`,
-        |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/stencilLoadValue}} must be
-        {{GPULoadOp/"load"}} and |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/stencilStoreOp}}
-        must be {{GPUStoreOp/"store"}}.
+    1. if |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/readOnly}} is `true`:
+        - |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/depthLoadValue}} must be {{GPULoadOp/"load"}}.
+        - |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/depthStoreOp}} must be {{GPUStoreOp/"store"}}.
+        - |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/stencilLoadValue}} must be {{GPULoadOp/"load"}}.
+        - |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/stencilStoreOp}} must be {{GPUStoreOp/"store"}}.
 
     Issue: Describe the remaining validation rules for this type.
 </div>


### PR DESCRIPTION
Follow-up to #746 , see investigation in https://github.com/gpuweb/gpuweb/issues/514#issuecomment-628925960
Closes #859

This is an alternative fix/evolution of RODS (problem described in #859) that came to mind, and I like it much more. Creating a view could be done by limiting the available usages (through this view) to only read from the texture. This means we no longer need additional `GPURenderPassDescriptor` fields, and we don't need to change `GPUTextureBinding`.

Specifying the read-only property at the view creation matches D3D12 API, where the user specifies [D3D12_DSV_FLAGS](https://docs.microsoft.com/en-us/windows/win32/api/d3d12/ne-d3d12-d3d12_dsv_flags). It also allows the implementation to avoid creating UAVs for viewing textures that support `STORAGE` usage if the user doesn't need to write to the storage (i.e. if they use "readonly-storage-texture" binding).

The spec is bare-bones here. I'll be happy to write it down in more detail once/if we agree about the direction here.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/860.html" title="Last updated on Jul 2, 2020, 8:02 PM UTC (99b3f66)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/860/0cc44c8...kvark:99b3f66.html" title="Last updated on Jul 2, 2020, 8:02 PM UTC (99b3f66)">Diff</a>