### PR TITLE
Specify minBufferBindingSize behavior for default pipeline

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2696,13 +2696,17 @@ has a default layout created and used instead.
 
             1. If |groupDescs|[|group|] has an entry |previousEntry| with {{GPUBindGroupLayoutEntry/binding}} equal to |binding|:
 
-                1. If a member other than {{GPUBindGroupLayoutEntry/visibility}} or {{GPUBindGroupLayoutEntry/minBufferBindingSize}} is unequal between |previousEntry| and |entry|:
+                1. If |entry| has different {{GPUBindGroupLayoutEntry/visibility}} than |previousEntry|:
+
+                    1. Add the bits set in |entry|.{{GPUBindGroupLayoutEntry/visibility}} into |previousEntry|.{{GPUBindGroupLayoutEntry/visibility}}
+
+                1. If |entry| has greater {{GPUBindGroupLayoutEntry/minBufferBindingSize}} than |previousEntry|:
+
+                    1. Set |previousEntry|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} to |entry|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}}.
+
+                1. If any other property is unequal between |entry| and |previousEntry|:
 
                     1. Return null (which will cause the creation of the pipeline to fail).
-
-                1. Add the bits set in |entry|.{{GPUBindGroupLayoutEntry/visibility}} into |previousEntry|.{{GPUBindGroupLayoutEntry/visibility}}.
-
-                1. Set |previousEntry|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} to the maximum of |previousEntry|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} and |entry|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}}.
 
             1. Else
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2658,6 +2658,8 @@ has a default layout created and used instead.
 
                 1. Set |entry|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} to |resource|'s minimum buffer binding size.
 
+                    Issue: link to a definition for "minimum buffer binding size" in the "reflection information".
+
                 1. If |resource| is for a uniform buffer:
 
                     1. Set |entry|.{{GPUBindGroupLayoutEntry/type}} to {{GPUBindingType/uniform-buffer}}.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2656,6 +2656,8 @@ has a default layout created and used instead.
 
                 1. Set |entry|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} to false.
 
+                1. Set |entry|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} to |resource|'s minimum buffer binding size.
+
                 1. If |resource| is for a uniform buffer:
 
                     1. Set |entry|.{{GPUBindGroupLayoutEntry/type}} to {{GPUBindingType/uniform-buffer}}.
@@ -2692,13 +2694,13 @@ has a default layout created and used instead.
 
             1. If |groupDescs|[|group|] has an entry |previousEntry| with {{GPUBindGroupLayoutEntry/binding}} equal to |binding|:
 
-                1. If |previousEntry| is equal to |entry| up to {{GPUBindGroupLayoutEntry/visibility}}:
-
-                    1. Add the bits set in |entry|.{{GPUBindGroupLayoutEntry/visibility}} into |previousEntry|.{{GPUBindGroupLayoutEntry/visibility}}
-
-                1. Else
+                1. If a member other than {{GPUBindGroupLayoutEntry/visibility}} or {{GPUBindGroupLayoutEntry/minBufferBindingSize}} is unequal between |previousEntry| and |entry|:
 
                     1. Return null (which will cause the creation of the pipeline to fail).
+
+                1. Add the bits set in |entry|.{{GPUBindGroupLayoutEntry/visibility}} into |previousEntry|.{{GPUBindGroupLayoutEntry/visibility}}.
+
+                1. Set |previousEntry|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} to the maximum of |previousEntry|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} and |entry|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}}.
 
             1. Else
 


### PR DESCRIPTION
When creating a default pipeline, we can encounter different minBufferBindingSize from the shader reflection for the same binding. For example, a vertex shader that uses two floats from a buffer, and a fragment shader that only specifies one float from the same buffer.

This updates the algorithm in the default pipeline section to handle minBufferBindingSize by taking the maximum seen across all instances of the binding.