### PR TITLE
Interface/member definition style, CSS for timelines and <dl>s

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -821,7 +821,9 @@ interface GPUAdapter {
             **Called on:** {{GPUAdapter}} |this|.
 
             **Arguments:**
-                - optional {{GPUDeviceDescriptor}} |descriptor| = {}
+            <ul dfn-type=argument dfn-for="GPUAdapter/requestDevice(descriptor)">
+                - |descriptor|: optional {{GPUDeviceDescriptor}} <dfn>descriptor</dfn> = {}
+            </ul>
 
             **Returns:** |promise|, of type Promise<{{GPUDevice}}?>.
 
@@ -4647,11 +4649,13 @@ GPUQueue includes GPUObjectBase;
             **Called on:** {{GPUQueue}} |this|.
 
             **Arguments:**
-                - {{GPUBuffer}} |buffer|
-                - {{GPUSize64}} |bufferOffset|
-                - <code>[{{AllowShared}}] {{ArrayBuffer}}</code> |data|
-                - optional {{GPUSize64}} |dataOffset| = 0
-                - optional {{GPUSize64}} |size|
+            <ul dfn-type=argument dfn-for="GPUQueue/writeBuffer(buffer, bufferOffset, data, dataOffset, size)">
+                - |buffer|: {{GPUBuffer}} <dfn>buffer</dfn>
+                - |bufferOffset|: {{GPUSize64}} <dfn>bufferOffset</dfn>
+                - |data|: <code>[{{AllowShared}}] {{ArrayBuffer}}</code> <dfn>data</dfn>
+                - |dataOffset|: optional {{GPUSize64}} <dfn>dataOffset</dfn> = 0
+                - |size|: optional {{GPUSize64}} <dfn>size</dfn>
+            </ul>
 
             **Returns:** `void`
 
@@ -4692,10 +4696,12 @@ GPUQueue includes GPUObjectBase;
             **Called on:** {{GPUQueue}} |this|.
 
             **Arguments:**
-                - {{GPUTextureCopyView}} |destination|
-                - <code>[{{AllowShared}}] {{ArrayBuffer}}</code> |data|
-                - {{GPUTextureDataLayout}} |dataLayout|
-                - {{GPUExtent3D}} |size|
+            <ul dfn-type=argument dfn-for="GPUQueue/writeTexture(destination, data, dataLayout, size)">
+                - |destination|: {{GPUTextureCopyView}} <dfn>destination</dfn>
+                - |data|: <code>[{{AllowShared}}] {{ArrayBuffer}}</code> <dfn>data</dfn>
+                - |dataLayout|: {{GPUTextureDataLayout}} <dfn>dataLayout</dfn>
+                - |size|: {{GPUExtent3D}} <dfn>size</dfn>
+            </ul>
 
             **Returns:** `void`
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -28,10 +28,74 @@ spec: webidl; urlPrefix: https://heycam.github.io/webidl/#
 </pre>
 
 <style>
-.validusage {
+/* Make <dl> blocks more distinct from their surroundings. */
+dl {
+    border-left: thin solid #f3e48c;
+    padding-left: .5em;
+}
+
+/* <p> by default has these margins. Update ul/ol/dl to match,
+ * since they are also put in places where paragraphs go. */
+p, ul, ol, dl {
+    margin: 1em 0;
+}
+
+/* Box for Valid Usage requirements. */
+div.validusage {
     padding: .5em;
     border: thin solid #88e !important;
     border-radius: .5em;
+}
+
+/*
+ * Boxes for steps that occur on a particular timeline.
+ */
+div.content-timeline, div.device-timeline, div.queue-timeline {
+    padding: .5em;
+    border-radius: .5em;
+}
+.content-timeline {
+    background: rgba(0, 255, 0, 0.05);
+}
+.device-timeline {
+    background: rgba(255, 0, 0, 0.05);
+}
+.queue-timeline {
+    background: rgba(255, 0, 255, 0.05);
+}
+
+/*
+ * Stylistic labels, for clarity of presentation of these blocks.
+ *
+ * NOTE: This text is non-accessible and non-selectable; surrounding
+ * text must also explain the context.
+ */
+.validusage, .content-timeline, .device-timeline, .queue-timeline {
+    position: relative;
+}
+.validusage::before,
+.content-timeline::before,
+.device-timeline::before,
+.queue-timeline::before {
+    font-weight: bold;
+    font-style: italic;
+    font-size: 130%;
+    color: rgba(0, 0, 0, 0.15);
+    position: absolute;
+    right: .3em;
+    top: -.1em;
+}
+.validusage::before {
+    content: "Valid Usage";
+}
+.content-timeline::before {
+    content: "Content Timeline";
+}
+.device-timeline::before {
+    content: "Device Timeline";
+}
+.queue-timeline::before {
+    content: "Queue Timeline";
 }
 </style>
 
@@ -722,70 +786,72 @@ interface GPUAdapter {
 };
 </script>
 
-{{GPUAdapter}} has:
+{{GPUAdapter}} has the following attributes:
 
-  - These attributes:
-    <dl dfn-type=attribute dfn-for=GPUAdapter>
-        : <dfn>name</dfn>
-        ::
-            A human-readable name identifying the adapter.
-            The contents are implementation-defined.
+<dl dfn-type=attribute dfn-for=GPUAdapter>
+    : <dfn>name</dfn>
+    ::
+        A human-readable name identifying the adapter.
+        The contents are implementation-defined.
 
-        : <dfn>extensions</dfn>
-        ::
-            Accessor for `this`.{{GPUAdapter/[[adapter]]}}.{{adapter/[[extensions]]}}.
-    </dl>
+    : <dfn>extensions</dfn>
+    ::
+        Accessor for `this`.{{GPUAdapter/[[adapter]]}}.{{adapter/[[extensions]]}}.
+</dl>
 
-  - These internal slots:
-    <dl dfn-type=attribute dfn-for=GPUAdapter>
-        : <dfn>\[[adapter]]</dfn>, of type [=adapter=], readonly
-        ::
-            An internal slot holding the [=adapter=] to which this {{GPUAdapter}}
-            refers.
-    </dl>
+{{GPUAdapter}} has the following internal slots:
 
-  - The methods defined by the following sub-sections.
+<dl dfn-type=attribute dfn-for=GPUAdapter>
+    : <dfn>\[[adapter]]</dfn>, of type [=adapter=], readonly
+    ::
+        The [=adapter=] to which this {{GPUAdapter}} refers.
+</dl>
 
-### <dfn method for=GPUAdapter>requestDevice(optional descriptor)</dfn> ### {#requestdevice}
+{{GPUAdapter}} has the following methods:
 
-<div algorithm=GPUAdapter.requestDevice>
-    <strong>|this|:</strong> of type {{GPUAdapter}}.
+<dl dfn-type=method dfn-for=GPUAdapter>
+    : <dfn>requestDevice(descriptor)</dfn>
+    ::
+        Requests a [=device=] from the [=adapter=].
 
-    **Arguments:**
-        - optional {{GPUDeviceDescriptor}} |descriptor| = {}
+        <div algorithm=GPUAdapter.requestDevice>
+            **Called on:** {{GPUAdapter}} |this|.
 
-    **Returns:** |promise|, of type Promise<{{GPUDevice}}>.
+            **Arguments:**
+                - optional {{GPUDeviceDescriptor}} |descriptor| = {}
 
-    Requests a [=device=] from the [=adapter=].
+            **Returns:** |promise|, of type Promise<{{GPUDevice}}>.
 
-    Returns [=a new promise=], |promise|.
-    On the [=Device timeline=], the following steps occur:
+            - Let |promise| be [=a new promise=].
+            - Issue the following steps to the [=Device timeline=]:
+                <div class=device-timeline>
+                    - If any of the following conditions are unsatisfied,
+                        [=reject=] |promise| with an {{OperationError}} and stop.
 
-      - If the user agent can fulfill the request and
-        the [$GPUAdapter.requestDevice/Valid Usage$] rules are met:
+                        <div class=validusage>
+                            - The set of {{GPUExtensionName}} values in
+                                |descriptor|.{{GPUDeviceDescriptor/extensions}}
+                                is a subset of those in
+                                |adapter|.{{adapter/[[extensions]]}}.
 
-          - |promise| [=resolves=] to a new {{GPUDevice}} object encapsulating
-            [=a new device=] with the capabilities described by |descriptor|.
+                            - For each type of limit in {{GPULimits}},
+                                the value of that limit in
+                                |descriptor|.{{GPUDeviceDescriptor/limits}}
+                                is no [=better=] than the value of that limit in
+                                |adapter|.{{adapter/[[limits]]}}.
 
-      - Otherwise, |promise| [=rejects=] with an {{OperationError}}.
+                            where |adapter| is |this|.{{GPUAdapter/[[adapter]]}}.
+                        </div>
 
-    <div class=validusage dfn-for=GPUAdapter.requestDevice>
-        <dfn abstract-op>Valid Usage</dfn>
+                    - [=Resolve=] |promise| to a new {{GPUDevice}} object encapsulating
+                        [=a new device=] with the capabilities described by |descriptor|.
+                </div>
+            - Return |promise|.
 
-        Let |adapter| be |this|.{{GPUAdapter/[[adapter]]}}.
+        </div>
+</dl>
 
-        - The set of {{GPUExtensionName}} values in
-            |descriptor|.{{GPUDeviceDescriptor/extensions}}
-            must be a subset of those in |adapter|.{{adapter/[[extensions]]}}.
-
-        - For each type of limit in {{GPULimits}}, the value of that limit in
-            |descriptor|.{{GPUDeviceDescriptor/limits}}
-            must be no [=better=] than the value of that limit in
-            |adapter|.{{adapter/[[limits]]}}.
-    </div>
-</div>
-
-#### <dfn dictionary>GPUDeviceDescriptor</dfn> #### {#gpudevicedescriptor}
+### <dfn dictionary>GPUDeviceDescriptor</dfn> ### {#gpudevicedescriptor}
 
 {{GPUDeviceDescriptor}} describes a device request.
 
@@ -795,6 +861,8 @@ dictionary GPUDeviceDescriptor : GPUObjectDescriptorBase {
     GPULimits limits = {};
 };
 </script>
+
+{{GPUDeviceDescriptor}} has the following members:
 
 <dl dfn-type=dict-member dfn-for=GPUDeviceDescriptor>
     : <dfn>extensions</dfn>
@@ -1228,7 +1296,7 @@ interface GPUBufferUsage {
     or {{GPUBufferUsage/MAP_WRITE}} in {{GPUBufferDescriptor/usage}}. This can be used to set the buffer's
     initial data.
 
-  <div algorithm class=validusage>
+  <div class=validusage>
     <dfn abstract-op>createBuffer Valid Usage</dfn>
       Given a {{GPUDevice}} |this| and a {{GPUBufferDescriptor}} |descriptor|
       the following validation rules apply:
@@ -1706,7 +1774,7 @@ enum GPUTextureFormat {
     "depth24plus-stencil8",
 
     // BC compressed formats usable if "texture-compression-bc" is both
-    // supported by the device/user agent and enabled in createDevice.
+    // supported by the device/user agent and enabled in requestDevice.
     "bc1-rgba-unorm",
     "bc1-rgba-unorm-srgb",
     "bc2-rgba-unorm",
@@ -4562,53 +4630,103 @@ interface GPUQueue {
 GPUQueue includes GPUObjectBase;
 </script>
 
+{{GPUQueue}} has the following methods:
+
 <dl dfn-type="method" dfn-for="GPUQueue">
-<div algorithm>
-    : <dfn>writeBuffer(|buffer|, |bufferOffset|, |data|, |dataOffset|, |size|)</dfn>
+    : <dfn>writeBuffer(buffer, bufferOffset, data, dataOffset, size)</dfn>
     ::
-        Takes the |data| contents of size |size|, starting from the byte offset |dataOffset|,
-        and schedules a write operation of these contents to the |buffer| buffer on the
-        [=Queue timeline=] starting at |bufferOffset|.
-        Any subsequent modifications to |data| do not affect what is written
-        at the time that the scheduled operation runs.
+        Issues a write operation of the provided data into a {{GPUBuffer}}.
 
-        If |size| is unspecified, it is set to |data|.byteLength - |dataOffset| if the result is non-negative,
-        or throws {{OperationError}} otherwise.
+        <div algorithm=GPUQueue.writeBuffer>
+            **Called on:** {{GPUQueue}} |this|.
 
-        The operation throws {{OperationError}} if any of the following is true:
-        - |buffer| buffer isn't in the `"unmapped"` [=buffer state=].
-        - |bufferOffset| is not a multiple of 4.
-        - |size| is not a positive multiple of 4.
-        - |dataOffset| + |size| exceeds |data|.byteLength.
+            **Arguments:**
+                - {{GPUBuffer}} |buffer|
+                - {{GPUSize64}} |bufferOffset|
+                - <code>[{{AllowShared}}] {{ArrayBuffer}}</code> |data|
+                - optional {{GPUSize64}} |dataOffset| = 0
+                - optional {{GPUSize64}} |size|
 
-        The operation does nothing and produces an error if any of the following is true:
-        - |bufferOffset| + |size| exceeds |buffer|.{{GPUBuffer/[[size]]}}.
-        - |buffer|.{{GPUBuffer/[[usage]]}} doesn't include {{GPUBufferUsage/COPY_DST}} flag.
-        - |buffer| buffer is destroyed
-</div>
+            **Returns:** `void`
 
-<div algorithm>
-    : <dfn>writeTexture(|destination|, |data|, |dataLayout|, |size|)</dfn>
+            - If |size| is unspecified,
+                let |contentsSize| be |data|.`byteLength` &minus; |dataOffset|.
+                Otherwise, let |contentsSize| be |size|.
+            - If any of the following conditions are unsatisfied,
+                throw {{OperationError}} and stop.
+                <!-- Note: it's easiest to write the valid usage rules inline
+                     here, because they depend on contentsSize above. -->
+                <div class=validusage>
+                    - |contentsSize| &ge; 0.
+                    - |dataOffset| + |contentsSize| &le; |data|.`byteLength`.
+                    - |buffer|.{{GPUBuffer/[[state]]}} is [=buffer state/unmapped=].
+                    - |bufferOffset| is a multiple of 4.
+                    - |size| is a positive multiple of 4.
+                </div>
+            - Let |contents| be the contents of the |contentsSize| bytes
+                in |data| starting from the byte offset |dataOffset|.
+            - Issue the following steps on the [=Queue timeline=] of |this|:
+                <div class=queue-timeline>
+                    - If any of the following conditions are unsatisfied,
+                        generate a validation error and stop.
+                        <div class=validusage>
+                            - |buffer| is [=valid=].
+                            - |buffer|.{{GPUBuffer/[[usage]]}} includes {{GPUBufferUsage/COPY_DST}}.
+                            - |bufferOffset| + |size| &le; |buffer|.{{GPUBuffer/[[size]]}}.
+                        </div>
+                    - Write |contents| into |buffer| starting at |bufferOffset|.
+                </div>
+        </div>
+
+    : <dfn>writeTexture(destination, data, dataLayout, size)</dfn>
     ::
-        Takes the |data| contents and schedules a write operation of these contents to the
-        |destination| texture copy view in the queue.
-        Any subsequent modifications to |data| do not affect what is written
-        at the time that the scheduled operation runs.
+        Issues a write operation of the provided data into a {{GPUTexture}}.
 
-        The operation throws {{OperationError}} if |dataLayout|.{{GPUTextureDataLayout/offset}}
-        exceeds |data|.byteLength.
+        <div algorithm=GPUQueue.writeTexture>
+            **Called on:** {{GPUQueue}} |this|.
 
-        The operation does nothing and produces an error if any of the following is true:
+            **Arguments:**
+                - {{GPUTextureCopyView}} |destination|
+                - <code>[{{AllowShared}}] {{ArrayBuffer}}</code> |data|
+                - {{GPUTextureDataLayout}} |dataLayout|
+                - {{GPUExtent3D}} |size|
 
-         - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}}
-            doesn't include {{GPUTextureUsage/COPY_DST}} flag.
-         - |destination|.{{GPUTextureCopyView/texture}} is destroyed
-         - [$validating linear texture data$](|dataLayout|, |data|.byteLength, |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}, |size|) fails.
-         - [=Valid Texture Copy Range=] fails to apply to |destination| and |size|.
+            **Returns:** `void`
 
-         Note: unlike {{GPUCommandEncoder/copyBufferToTexture()|GPUCommandEncoder.copyBufferToTexture}},
-         there is no alignment requirement on |dataLayout|.{{GPUTextureDataLayout/bytesPerRow}}.
-</div>
+            - If any of the following conditions are unsatisfied,
+                throw {{OperationError}} and stop.
+                <div class=validusage>
+                    - |dataLayout|.{{GPUTextureDataLayout/offset}} <= |data|.`byteLength`.
+                </div>
+            - Let |contents| be the contents of the [=images=] seen by
+                viewing |data| with |dataLayout|.
+
+                Issue: Specify more formally.
+            - Issue the following steps on the [=Queue timeline=] of |this|:
+                <div class=queue-timeline>
+                    - If any of the following conditions are unsatisfied,
+                        generate a validation error and stop.
+                        <div class=validusage>
+                            - |destination|.{{GPUTextureCopyView/texture}} is [=valid=].
+                            - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}}
+                                includes {{GPUTextureUsage/COPY_DST}}.
+                            - [$validating linear texture data$](|dataLayout|,
+                                |data|.byteLength,
+                                |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}},
+                                |size|) succeeds.
+                            - [=Valid Texture Copy Range=](|destination|, |size|)
+                                is satisfied.
+
+                            Note: unlike
+                            {{GPUCommandEncoder}}.{{GPUCommandEncoder/copyBufferToTexture()}},
+                            there is no alignment requirement on
+                            |dataLayout|.{{GPUTextureDataLayout/bytesPerRow}}.
+                        </div>
+                    - Write |contents| into |destination|.
+
+                        Issue: Specify more formally.
+                </div>
+        </div>
 
     : <dfn>copyImageBitmapToTexture(source, destination, copySize)</dfn>
     ::
@@ -4674,12 +4792,13 @@ dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
     ::
         The set of {{GPUPipelineStatisticName}} values in this sequence defines which pipeline statistics will be returned in the new query set.
 
-    <div class=validusage dfn-for=GPUQuerySetDescriptor.pipelineStatistics>
-      <dfn abstract-op>Valid Usage</dfn>
-        1. |pipelineStatistics| is ignored if type is not {{GPUQueryType/pipeline-statistics}}.
-        2. If {{GPUExtensionName/pipeline-statistics-query}} is not available, |type| must not be {{GPUQueryType/pipeline-statistics}}.
-        3. If |type| is {{GPUQueryType/pipeline-statistics}},  |pipelineStatistics| must be a sequence of {{GPUPipelineStatisticName}} values which cannot be duplicated.
-    </div>
+        <div class=validusage dfn-for=GPUQuerySetDescriptor.pipelineStatistics>
+            <dfn abstract-op>Valid Usage</dfn>
+
+            1. |pipelineStatistics| is ignored if type is not {{GPUQueryType/pipeline-statistics}}.
+            2. If {{GPUExtensionName/pipeline-statistics-query}} is not available, |type| must not be {{GPUQueryType/pipeline-statistics}}.
+            3. If |type| is {{GPUQueryType/pipeline-statistics}},  |pipelineStatistics| must be a sequence of {{GPUPipelineStatisticName}} values which cannot be duplicated.
+        </div>
 </dl>
 
 ## QueryType ## {#querytype}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4670,8 +4670,8 @@ GPUQueue includes GPUObjectBase;
                     - |contentsSize| &ge; 0.
                     - |dataOffset| + |contentsSize| &le; |data|.`byteLength`.
                     - |buffer|.{{GPUBuffer/[[state]]}} is [=buffer state/unmapped=].
+                    - |contentsSize| is a multiple of 4.
                     - |bufferOffset| is a multiple of 4.
-                    - |size| is a positive multiple of 4.
                 </div>
             - Let |contents| be the contents of the |contentsSize| bytes
                 in |data| starting from the byte offset |dataOffset|.
@@ -4682,7 +4682,7 @@ GPUQueue includes GPUObjectBase;
                         <div class=validusage>
                             - |buffer| is [=valid=].
                             - |buffer|.{{GPUBuffer/[[usage]]}} includes {{GPUBufferUsage/COPY_DST}}.
-                            - |bufferOffset| + |size| &le; |buffer|.{{GPUBuffer/[[size]]}}.
+                            - |bufferOffset| + |contentsSize| &le; |buffer|.{{GPUBuffer/[[size]]}}.
                         </div>
                     - Write |contents| into |buffer| starting at |bufferOffset|.
                 </div>


### PR DESCRIPTION
Here's a more stylized/readable format for interface, member, and method definitions. It includes new styling and conventions for valid usage rules, steps on timelines, etc.

It's trialled on requestDevice, writeBuffer, and writeTexture as templates of its use that we can reproduce elsewhere.

---

Styling changes:

- Yellow line for dl blocks to set them off from surrounding text
- Backgrounds for timelines
- Gray background text to make it easy for timeline and valid usage blocks without reading the text before them

Convention changes:

- Deeper nesting of blocks; valid usage block inline (inside or outside of pipeline blocks)
- `**Called on:** {{GPUAdapter}} |this|` instead of `|this|, of type {{GPUAdapter}}`

---

([Rendered](https://kai.graphics/gpuweb/spec/))

![image](https://user-images.githubusercontent.com/606355/85320917-b0974400-b478-11ea-9477-342bf2d23885.png)

![image](https://user-images.githubusercontent.com/606355/85320805-85acf000-b478-11ea-89a4-2c6ac1a706e1.png)
