### PR TITLE
Allow requestAdapter and requestDevice to resolve to null

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -601,7 +601,7 @@ partial interface WorkerNavigator {
 <script type=idl>
 [Exposed=(Window, DedicatedWorker)]
 interface GPU {
-    Promise<GPUAdapter> requestAdapter(optional GPURequestAdapterOptions options = {});
+    Promise<GPUAdapter?> requestAdapter(optional GPURequestAdapterOptions options = {});
 };
 </script>
 
@@ -613,7 +613,7 @@ interface GPU {
     **Arguments:**
       - optional {{GPURequestAdapterOptions}} |options| = {}
 
-    **Returns:** |promise|, of type Promise<{{GPUAdapter}}>.
+    **Returns:** |promise|, of type Promise<{{GPUAdapter}}?>.
 
     Requests an [=adapter=] from the user agent.
     The user agent chooses whether to return an adapter, and, if so,
@@ -622,14 +622,17 @@ interface GPU {
     Returns [=a new promise=], |promise|.
     On the [=Device timeline=], the following steps occur:
 
-      - If the user agent chooses to return an adapter:
+    - If the user agent chooses to return an adapter:
 
-          - The user agent chooses an [=adapter=] |adapter| according to the rules in
+        - The user agent chooses an [=adapter=] |adapter| according to the rules in
             [[#adapter-selection]].
 
-          - |promise| [=resolves=] with a new {{GPUAdapter}} encapsulating |adapter|.
+        - |promise| [=resolves=] with a new {{GPUAdapter}} encapsulating |adapter|.
 
-      - Otherwise, |promise| [=rejects=] with an {{OperationError}}.
+    - Otherwise, |promise| [=resolves=] with `null`.
+
+    <!-- If we add ways to make invalid adapter requests (aside from those
+         that violate IDL rules), specify that they reject the promise. -->
 </div>
 
 #### Adapter Selection #### {#adapter-selection}
@@ -718,7 +721,7 @@ interface GPUAdapter {
     readonly attribute FrozenArray<GPUExtensionName> extensions;
     //readonly attribute GPULimits limits; Don't expose higher limits for now.
 
-    Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor = {});
+    Promise<GPUDevice?> requestDevice(optional GPUDeviceDescriptor descriptor = {});
 };
 </script>
 
@@ -754,20 +757,21 @@ interface GPUAdapter {
     **Arguments:**
         - optional {{GPUDeviceDescriptor}} |descriptor| = {}
 
-    **Returns:** |promise|, of type Promise<{{GPUDevice}}>.
+    **Returns:** |promise|, of type Promise<{{GPUDevice}}?>.
 
     Requests a [=device=] from the [=adapter=].
 
     Returns [=a new promise=], |promise|.
     On the [=Device timeline=], the following steps occur:
 
-      - If the user agent can fulfill the request and
-        the [$GPUAdapter.requestDevice/Valid Usage$] rules are met:
+    - If the [$GPUAdapter.requestDevice/Valid Usage$] rules are unsatisfied,
+        [=reject=] |promise| with an {{OperationError}} and stop.
 
-          - |promise| [=resolves=] to a new {{GPUDevice}} object encapsulating
-            [=a new device=] with the capabilities described by |descriptor|.
+    - If the user agent cannot fulfill the request,
+        [=resolve=] |promise| to `null` and stop.
 
-      - Otherwise, |promise| [=rejects=] with an {{OperationError}}.
+    - [=Resolve=] |promise| to a new {{GPUDevice}} object encapsulating
+        [=a new device=] with the capabilities described by |descriptor|.
 
     <div class=validusage dfn-for=GPUAdapter.requestDevice>
         <dfn abstract-op>Valid Usage</dfn>


### PR DESCRIPTION
In requestAdapter, like requestDevice, promise rejection should be
reserved for programmer errors. If there is no adapter available,
return null.

I meant to make this change a long time ago, but it got lost in a larger rework of the initialization APIs that I have not yet managed to complete.