### PR TITLE
Add time query on GPUCommandBuffer

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3292,7 +3292,7 @@ Issue(https://github.com/gpuweb/gpuweb/issues/693): add a limit to the number of
 
 <script type=idl>
 interface GPUCommandBuffer {
-    double getExecutionTime();
+    readonly attribute Promise<double> executionTime;
 };
 GPUCommandBuffer includes GPUObjectBase;
 </script>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3300,15 +3300,29 @@ GPUCommandBuffer includes GPUObjectBase;
 {{GPUCommandBuffer}} has the following attributes:
 
 <dl dfn-type=attribute dfn-for="GPUCommandBuffer">
-    : <dfn>\[[executionTime]]</dfn> of type Promise<{{double}}>, readonly
+    : <dfn>executionTime</dfn> of type Promise<{{double}}>, readonly
     ::
-        The total time, in seconds, that GPU execute this command buffer.
+        The total time, in seconds, that GPU took to execute this command buffer.
 
-        - If {{GPUCommandEncoderDescriptor/measureExecutionTime}} is set to true:
+        Note:
+        If {{GPUCommandEncoderDescriptor/measureExecutionTime}} is true,
+        resolves after the command buffer executes.
+        Otherwise, rejects with an {{OperationError}}.
 
-            - |promise| [=resolves=] with the execution time of command buffer. The |promise| of execution time is fecthed when GPUQueue.{{GPUQueue/submit()}}.
+        <div class=issue>
+            Specify the creation and resolution of the promise.
 
-        - Otherwise, |promise| [=rejects=] with an {{OperationError}}.
+            In {{GPUCommandEncoder/finish()}}, it should be specified that a
+            new promise is created and stored in this attribute.
+            The promise starts rejected if measureExecutionTime is false.
+            If the finish() fails, then resolve to 0.
+
+            In {{GPUQueue/submit()}}, it should be specified that (if
+            measureExecutionTime is set), work is issued to read back the
+            execution time, and, when that completes,
+            the promise is resolved with that value.
+            If the submit() fails, then resolve to 0.
+        </div>
 </dl>
 
 ### Creation ### {#command-buffer-creation}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3306,12 +3306,10 @@ GPUCommandBuffer includes GPUObjectBase;
 
         - If {{GPUCommandEncoderDescriptor/measureExecutionTime}} is set to true:
 
-            - |promise| [=resolves=] with the execution time of command buffer.
+            - |promise| [=resolves=] with the execution time of command buffer. The |promise| of execution time is fecthed when GPUQueue.{{GPUQueue/submit()}}.
 
         - Otherwise, |promise| [=rejects=] with an {{OperationError}}.
 </dl>
-
-Issue: define exactly when this promise is resolved and whether the value is fetched on submit or lazily.
 
 ### Creation ### {#command-buffer-creation}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3302,12 +3302,12 @@ GPUCommandBuffer includes GPUObjectBase;
 <dl dfn-type=attribute dfn-for="GPUCommandBuffer">
     : <dfn>executionTime</dfn> of type Promise<{{double}}>, readonly
     ::
-        The total time, in seconds, that GPU took to execute this command buffer.
+        The total time, in seconds, that the GPU took to execute this command buffer.
 
         Note:
         If {{GPUCommandEncoderDescriptor/measureExecutionTime}} is true,
-        resolves after the command buffer executes.
-        Otherwise, rejects with an {{OperationError}}.
+        this resolves after the command buffer executes.
+        Otherwise, this rejects with an {{OperationError}}.
 
         <div class=issue>
             Specify the creation and resolution of the promise.
@@ -3315,13 +3315,13 @@ GPUCommandBuffer includes GPUObjectBase;
             In {{GPUCommandEncoder/finish()}}, it should be specified that a
             new promise is created and stored in this attribute.
             The promise starts rejected if measureExecutionTime is false.
-            If the finish() fails, then resolve to 0.
+            If the finish() fails, then the promise resolves to 0.
 
             In {{GPUQueue/submit()}}, it should be specified that (if
             measureExecutionTime is set), work is issued to read back the
             execution time, and, when that completes,
             the promise is resolved with that value.
-            If the submit() fails, then resolve to 0.
+            If the submit() fails, then the promise resolves to 0.
         </div>
 </dl>
 
@@ -3440,7 +3440,7 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 <dl dfn-type=dict-member dfn-for=GPUCommandEncoderDescriptor>
     : <dfn>measureExecutionTime</dfn>
     ::
-        Enable the measurement of GPU execution time of the entire command buffer.
+        Enable measurement of the GPU execution time of the entire command buffer.
 </dl>
 
 ## Pass Encoding ## {#command-encoder-pass-encoding}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3301,7 +3301,7 @@ GPUCommandBuffer includes GPUObjectBase;
 
 <script type=idl>
 dictionary GPUCommandBufferDescriptor : GPUObjectDescriptorBase {
-    boolean executionTimeEnabled = false;
+    boolean measureExecutionTime = false;
 };
 </script>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3311,6 +3311,8 @@ GPUCommandBuffer includes GPUObjectBase;
         - Otherwise, |promise| [=rejects=] with an {{OperationError}}.
 </dl>
 
+Issue: define exactly when this promise is resolved and whether the value is fetched on submit or lazily.
+
 ### Creation ### {#command-buffer-creation}
 
 <script type=idl>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3292,6 +3292,7 @@ Issue(https://github.com/gpuweb/gpuweb/issues/693): add a limit to the number of
 
 <script type=idl>
 interface GPUCommandBuffer {
+    double getExecutionTime();
 };
 GPUCommandBuffer includes GPUObjectBase;
 </script>
@@ -3300,9 +3301,19 @@ GPUCommandBuffer includes GPUObjectBase;
 
 <script type=idl>
 dictionary GPUCommandBufferDescriptor : GPUObjectDescriptorBase {
+    boolean executionTimeEnabled = false;
 };
 </script>
 
+### <dfn method for=GPUCommandBuffer>getExecutionTime()</dfn> ### {#GPUCommandBuffer-getExecutionTime}
+
+<div algorithm=GPUCommandBuffer.getExecutionTime>
+
+    **Returns:** |executionTime|, of type {{double}}.
+
+    The |executionTime| is the total time, in seconds, that GPU execute this command buffer if the {{GPUCommandBufferDescriptor/executionTimeEnabled}} is set to ture, otherwise the |executionTime| is 0.0.
+
+</div>
 
 # Command Encoding # {#command-encoding}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3297,23 +3297,27 @@ interface GPUCommandBuffer {
 GPUCommandBuffer includes GPUObjectBase;
 </script>
 
+{{GPUCommandBuffer}} has the following attributes:
+
+<dl dfn-type=attribute dfn-for="GPUCommandBuffer">
+    : <dfn>\[[executionTime]]</dfn> of type Promise<{{double}}>, readonly
+    ::
+        The total time, in seconds, that GPU execute this command buffer.
+
+        - If {{GPUCommandEncoderDescriptor/measureExecutionTime}} is set to true:
+
+            - |promise| [=resolves=] with the execution time of command buffer.
+
+        - Otherwise, |promise| [=rejects=] with an {{OperationError}}.
+</dl>
+
 ### Creation ### {#command-buffer-creation}
 
 <script type=idl>
 dictionary GPUCommandBufferDescriptor : GPUObjectDescriptorBase {
-    boolean measureExecutionTime = false;
 };
 </script>
 
-### <dfn method for=GPUCommandBuffer>getExecutionTime()</dfn> ### {#GPUCommandBuffer-getExecutionTime}
-
-<div algorithm=GPUCommandBuffer.getExecutionTime>
-
-    **Returns:** |executionTime|, of type {{double}}.
-
-    The |executionTime| is the total time, in seconds, that GPU execute this command buffer if the {{GPUCommandBufferDescriptor/executionTimeEnabled}} is set to ture, otherwise the |executionTime| is 0.0.
-
-</div>
 
 # Command Encoding # {#command-encoding}
 
@@ -3413,9 +3417,17 @@ which may be one of the following:
 
 <script type=idl>
 dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
+    boolean measureExecutionTime = false;
+
     // TODO: reusability flag?
 };
 </script>
+
+<dl dfn-type=dict-member dfn-for=GPUCommandEncoderDescriptor>
+    : <dfn>measureExecutionTime</dfn>
+    ::
+        Enable the measurement of GPU execution time of the entire command buffer.
+</dl>
 
 ## Pass Encoding ## {#command-encoder-pass-encoding}
 


### PR DESCRIPTION
The getExecutionTime return the the total time, in seconds, that GPU execute this command buffer. (#614 )


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/haoxli/gpuweb/pull/870.html" title="Last updated on Jul 13, 2020, 8:54 PM UTC (d0c217d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/870/7419a3a...haoxli:d0c217d.html" title="Last updated on Jul 13, 2020, 8:54 PM UTC (d0c217d)">Diff</a>