### PR TITLE
Re-introduce createReady*Pipeline and remove GPUErrorFilter "none"

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2854,7 +2854,9 @@ Same as {{GPUDevice/createComputePipeline()}}, but returns its result as a
 promise which doesn't resolve until the pipeline is ready to be used without
 additional delay.
 
-Issue: Define fully.
+If pipeline creation fails, this resolves to an [=invalid=] {{GPUComputePipeline}} object.
+
+Issue: Define fully. (Probably by just calling directly into createComputePipeline.)
 
 Note: Use of this method is preferred whenever possible, as it prevents
 blocking [=queue timeline=] work on pipeline compilation.
@@ -3027,7 +3029,9 @@ Same as {{GPUDevice/createRenderPipeline()}}, but returns its result as a
 promise which doesn't resolve until the pipeline is ready to be used without
 additional delay.
 
-Issue: Define fully.
+If pipeline creation fails, this resolves to an [=invalid=] {{GPURenderPipeline}} object.
+
+Issue: Define fully. (Probably by just calling directly into createRenderPipeline.)
 
 Note: Use of this method is preferred whenever possible, as it prevents
 blocking [=queue timeline=] work on pipeline compilation.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -993,6 +993,8 @@ interface GPUDevice : EventTarget {
     GPUShaderModule createShaderModule(GPUShaderModuleDescriptor descriptor);
     GPUComputePipeline createComputePipeline(GPUComputePipelineDescriptor descriptor);
     GPURenderPipeline createRenderPipeline(GPURenderPipelineDescriptor descriptor);
+    Promise<GPUComputePipeline> createReadyComputePipeline(GPUComputePipelineDescriptor descriptor);
+    Promise<GPURenderPipeline> createReadyRenderPipeline(GPURenderPipelineDescriptor descriptor);
 
     GPUCommandEncoder createCommandEncoder(optional GPUCommandEncoderDescriptor descriptor = {});
     GPURenderBundleEncoder createRenderBundleEncoder(GPURenderBundleEncoderDescriptor descriptor);
@@ -2824,7 +2826,7 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
 };
 </script>
 
-### {{GPUDevice/createComputePipeline()|GPUDevice.createComputePipeline(GPUComputePipelineDescriptor)}} ### {#device-createComputePipeline}
+### {{GPUDevice/createComputePipeline()}} ### {#device-createComputePipeline}
 
 <div algorithm="GPUDevice.createComputePipeline">
     **Arguments:**
@@ -2838,11 +2840,24 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
         1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
         1. Create a new [=invalid=] {{GPUComputePipeline}} and return the result.
 
+    Then perform the following steps:
+
     1. Ensure the {{GPUDevice}} is not lost.
     1. Ensure the |descriptor|.{{GPUPipelineDescriptorBase/layout}} is a [=valid=] {{GPUPipelineLayout}}.
     1. Ensure the [$validating GPUProgrammableStageDescriptor$]({{GPUShaderStage/COMPUTE}},
         |descriptor|.{{GPUComputePipelineDescriptor/computeStage}}, |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
 </div>
+
+### {{GPUDevice/createReadyComputePipeline()}} ### {#device-createReadyComputePipeline}
+
+Same as {{GPUDevice/createComputePipeline()}}, but returns its result as a
+promise which doesn't resolve until the pipeline is ready to be used without
+additional delay.
+
+Issue: Define fully.
+
+Note: Use of this method is preferred whenever possible, as it prevents
+blocking [=queue timeline=] work on pipeline compilation.
 
 ## GPURenderPipeline ## {#render-pipeline}
 
@@ -2965,7 +2980,7 @@ is enabled, the [=shader-output mask=] becomes the [=alpha-to-coverage mask=]. O
 
 Issue: link to the semantics of SV_SampleIndex and SV_Coverage in WGSL spec.
 
-### {{GPUDevice/createRenderPipeline()|GPUDevice.createRenderPipeline(GPURenderPipelineDescriptor)}} ### {#device-createRenderPipeline}
+### {{GPUDevice/createRenderPipeline()}} ### {#device-createRenderPipeline}
 
 <div algorithm="GPUDevice.createRenderPipeline">
     **Arguments:**
@@ -2978,6 +2993,8 @@ Issue: link to the semantics of SV_SampleIndex and SV_Coverage in WGSL spec.
     If any of the conditions below are violated:
         1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
         1. Create a new [=invalid=] {{GPURenderPipeline}} and return the result.
+
+    Then perform the following steps:
 
     1. Ensure the {{GPUDevice}} is not lost.
     1. Ensure the |descriptor|.{{GPUPipelineDescriptorBase/layout}} is
@@ -3003,6 +3020,17 @@ Issue: need a proper limit for the maximum number of color targets.
 Issue: need a more detailed validation of the render states.
 
 Issue: need description of the render states.
+
+### {{GPUDevice/createReadyRenderPipeline()}} ### {#device-createReadyRenderPipeline}
+
+Same as {{GPUDevice/createRenderPipeline()}}, but returns its result as a
+promise which doesn't resolve until the pipeline is ready to be used without
+additional delay.
+
+Issue: Define fully.
+
+Note: Use of this method is preferred whenever possible, as it prevents
+blocking [=queue timeline=] work on pipeline compilation.
 
 ### Primitive Topology ### {#primitive-topology}
 
@@ -4785,7 +4813,6 @@ partial interface GPUDevice {
 
 <script type=idl>
 enum GPUErrorFilter {
-    "none",
     "out-of-memory",
     "validation"
 };


### PR DESCRIPTION
These methods are simple and extremely useful. They allow programs to
easily wait for these long running compilation operations to complete
before issuing work that blocks on them, making it easier to avoid
hitches in webpage (and whole-browser) rendering.

Previously I removed these in favor of wrapping them in error scopes
with GPUErrorFilter "none" (#238) as I felt that they overlapped in
functionality. However, the createPipeline methods are the most
significant source asynchronous resource creation blocking queue
timeline work.

TODO: (If there are others we think are important, we should either
unremove GPUErrorFilter "none" or give them Promise-based versions.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/871.html" title="Last updated on Jul 6, 2020, 10:41 PM UTC (6251b23)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/871/7c83251...kainino0x:6251b23.html" title="Last updated on Jul 6, 2020, 10:41 PM UTC (6251b23)">Diff</a>