### PR TITLE
Add aspect back to GPUTextureCopyView

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4486,7 +4486,7 @@ offset {{GPUOrigin3D}} in texels, used when copying data from or to a {{GPUTextu
   - |textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/y=] must be a multiple of |blockHeight|.
   - The [=textureCopyView subresource size=] of |textureCopyView| is equal to |copySize| if either of
       the following conditions is true:
-        - |textureCopyView|.{{GPUTextureCopyView/texture}}.{{GPUTextureFormat/[[format]]}} is a depth-stencil format.
+        - |textureCopyView|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format.
         - |textureCopyView|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is greater than 1.
 
 </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4706,10 +4706,9 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
                     {{GPUTextureUsage/COPY_DST}}.
                 - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is 1.
                 - If |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format:
-                    - |destination|.{{GPUTextureCopyView/aspect}} must refer to a single aspect of
+                    - |destination|.{{GPUTextureCopyView/aspect}} must refer to a single copyable aspect of
                         |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
-                    - |destination|.{{GPUTextureCopyView/aspect}} must not refer to the depth aspect of
-                        |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
+                        See [[#depth-formats|depth-formats]].
                 - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
                 - |source|.{{GPUTextureDataLayout/offset}} is a multiple of the [=texel block size=]
                     of |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
@@ -4745,8 +4744,9 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
                     {{GPUTextureUsage/COPY_SRC}}.
                 - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is 1.
                 - If |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format:
-                    - |source|.{{GPUTextureCopyView/aspect}} must refer to a single aspect of
+                    - |source|.{{GPUTextureCopyView/aspect}} must refer to a single copyable aspect of
                         |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
+                        See [[#depth-formats|depth-formats]].
                 - [$validating GPUBufferCopyView$](|destination|) returns `true`.
                 - |destination|.{{GPUBufferCopyView/buffer}}.{{GPUBuffer/[[usage]]}} contains
                     {{GPUBufferUsage/COPY_DST}}.
@@ -6469,12 +6469,15 @@ GPUQueue includes GPUObjectBase;
                     1. If any of the following conditions are unsatisfied,
                         generate a validation error and stop.
                         <div class=validusage>
-                            - [$validating GPUTextureCopyView$](|destination|) returns `true`.
+                            - [$validating GPUTextureCopyView$](|destination|, |size|) returns `true`.
                             - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}}
                                 includes {{GPUTextureUsage/COPY_DST}}.
                             - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is 1.
                             - [=Valid Texture Copy Range=](|destination|, |size|)
                                 is satisfied.
+                            - |destination|.{{GPUTextureCopyView/aspect}} refers to a single copyable aspect
+                                of |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
+                                See [[#depth-formats|depth-formats]].
 
                             Note: unlike
                             {{GPUCommandEncoder}}.{{GPUCommandEncoder/copyBufferToTexture()}},

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4456,6 +4456,7 @@ dictionary GPUTextureCopyView {
     required GPUTexture texture;
     GPUIntegerCoordinate mipLevel = 0;
     GPUOrigin3D origin = {};
+    GPUTextureAspect aspect = "all";
 };
 </script>
 
@@ -4482,6 +4483,10 @@ offset {{GPUOrigin3D}} in texels, used when copying data from or to a {{GPUTextu
     |textureCopyView|.{{GPUTextureCopyView/texture}}.
   - |textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/x=] must be a multiple of |blockWidth|.
   - |textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/y=] must be a multiple of |blockHeight|.
+  - If |textureCopyView|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}
+    has both depth and stencil aspects,
+    |textureCopyView|.{{GPUTextureCopyView/aspect}} must be
+    {{GPUTextureAspect/"depth-only"}} or {{GPUTextureAspect/"stencil-only"}}.
 
 </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4470,6 +4470,7 @@ offset {{GPUOrigin3D}} in texels, used when copying data from or to a {{GPUTextu
 
   **Arguments:**
     - {{GPUTextureCopyView}} |textureCopyView|
+    - {{GPUExtent3D}} |copySize|
 
   **Returns:** {{boolean}}
 
@@ -4483,10 +4484,10 @@ offset {{GPUOrigin3D}} in texels, used when copying data from or to a {{GPUTextu
     |textureCopyView|.{{GPUTextureCopyView/texture}}.
   - |textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/x=] must be a multiple of |blockWidth|.
   - |textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/y=] must be a multiple of |blockHeight|.
-  - If |textureCopyView|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}
-    has both depth and stencil aspects,
-    |textureCopyView|.{{GPUTextureCopyView/aspect}} must be
-    {{GPUTextureAspect/"depth-only"}} or {{GPUTextureAspect/"stencil-only"}}.
+  - The [=textureCopyView subresource size=] of |textureCopyView| is equal to |copySize| if either of
+      the following conditions is true:
+        - |textureCopyView|.{{GPUTextureCopyView/texture}}.{{GPUTextureFormat/[[format]]}} is a depth-stencil format.
+        - |textureCopyView|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is greater than 1.
 
 </div>
 
@@ -4700,10 +4701,15 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
                 - [$validating GPUBufferCopyView$](|source|) returns `true`.
                 - |source|.{{GPUBufferCopyView/buffer}}.{{GPUBuffer/[[usage]]}} contains
                     {{GPUBufferUsage/COPY_SRC}}.
-                - [$validating GPUTextureCopyView$](|destination|) returns `true`.
+                - [$validating GPUTextureCopyView$](|destination|, |copySize|) returns `true`.
                 - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}} contains
                     {{GPUTextureUsage/COPY_DST}}.
                 - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is 1.
+                - If |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format:
+                    - |destination|.{{GPUTextureCopyView/aspect}} must refer to a single aspect of
+                        |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
+                    - |destination|.{{GPUTextureCopyView/aspect}} must not refer to the depth aspect of
+                        |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
                 - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
                 - |source|.{{GPUTextureDataLayout/offset}} is a multiple of the [=texel block size=]
                     of |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
@@ -4734,10 +4740,13 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
             If any of the following conditions are unsatisfied, generate a validation error and stop.
             <div class=validusage>
                 - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
-                - [$validating GPUTextureCopyView$](|source|) returns `true`.
+                - [$validating GPUTextureCopyView$](|source|, |copySize|) returns `true`.
                 - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}} contains
                     {{GPUTextureUsage/COPY_SRC}}.
                 - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is 1.
+                - If |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format:
+                    - |source|.{{GPUTextureCopyView/aspect}} must refer to a single aspect of
+                        |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
                 - [$validating GPUBufferCopyView$](|destination|) returns `true`.
                 - |destination|.{{GPUBufferCopyView/buffer}}.{{GPUBuffer/[[usage]]}} contains
                     {{GPUBufferUsage/COPY_DST}}.
@@ -4769,27 +4778,23 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
 
             **Returns:** {{undefined}}
 
-            1. Let |copy of the whole subresource| be the command |this|.{{GPUCommandEncoder/copyTextureToTexture()}}
-                whose parameters |source|, |destination| and |copySize| meet the following conditions:
-                - The [=textureCopyView subresource size=] of |source| is equal to |copySize|.
-                - The [=textureCopyView subresource size=] of |destination| is equal to |copySize|.
             1. If any of the following conditions are unsatisfied, generate a validation error and stop.
                 <div class=validusage>
                     - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
-                    - [$validating GPUTextureCopyView$](|source|) returns `true`.
+                    - [$validating GPUTextureCopyView$](|source|, |copySize|) returns `true`.
                     - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}} contains
                         {{GPUTextureUsage/COPY_SRC}}.
-                    - [$validating GPUTextureCopyView$](|destination|) returns `true`.
+                    - [$validating GPUTextureCopyView$](|destination|, |copySize|) returns `true`.
                     - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}} contains
                         {{GPUTextureUsage/COPY_DST}}.
                     - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is equal to |destination|.
                         {{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}}.
-                    - If |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is greater than 1:
-                        - The copy with |source|, |destination| and |copySize| is a |copy of the whole subresource|.
                     - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} is equal to |destination|.
                         {{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
                     - If |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format:
-                        - The copy with |source|, |destination| and |copySize| is a |copy of the whole subresource|.
+                        - |source|.{{GPUTextureCopyView/aspect}} and |destination|.{{GPUTextureCopyView/aspect}}
+                            must both refer to all aspects of |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}
+                            and |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}, respectively.
                     - [=Valid Texture Copy Range=] applies to |source| and |copySize|.
                     - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
                     - The [$set of subresources for texture copy$](|source|, |copySize|) and


### PR DESCRIPTION
Per discussions on #652. It was removed in #143.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/873.html" title="Last updated on Oct 29, 2020, 2:47 PM UTC (2b25ea2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/873/51d54af...kainino0x:2b25ea2.html" title="Last updated on Oct 29, 2020, 2:47 PM UTC (2b25ea2)">Diff</a>