### PR TITLE
Make minBufferBindingSize optional

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1982,7 +1982,7 @@ dictionary GPUBindGroupLayoutEntry {
     boolean hasDynamicOffset = false;
 
     // Used for uniform buffer and storage buffer bindings.
-    GPUSize64 minBufferBindingSize = 0;
+    GPUSize64? minBufferBindingSize = null;
 
     // Used for sampled texture and storage texture bindings.
     GPUTextureViewDimension viewDimension;
@@ -2142,7 +2142,7 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
             {{GPUBindingType/"readonly-storage-buffer"}},
             ensure
             |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `false`,
-            and |bindingDescriptor|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} is zero.
+            and |bindingDescriptor|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} is null.
         1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
             {{GPUBindingType/"sampled-texture"}},
             {{GPUBindingType/"readonly-storage-texture"}}, or
@@ -2398,7 +2398,8 @@ A {{GPUBindGroup}} object has the following internal slots:
                 with {{GPUBufferUsage/STORAGE}} flag.
             1. The bound part designated by |bufferBinding|.{{GPUBufferBinding/offset}} and
                 |bufferBinding|.{{GPUBufferBinding/size}} must reside inside the buffer.
-            1. The effective binding size, that is either explict in |bufferBinding|.{{GPUBufferBinding/size}}
+            1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/minBufferBindingSize|GPUBindGroupLayoutEntry.minBufferBindingSize}} is not null,
+                The effective binding size, that is either explict in |bufferBinding|.{{GPUBufferBinding/size}}
                 or derived from |bufferBinding|.{{GPUBufferBinding/offset}} and the full size of the buffer,
                 is greater than or equal to |layoutBinding|.{{GPUBindGroupLayoutEntry/minBufferBindingSize|GPUBindGroupLayoutEntry.minBufferBindingSize}}.
     </div>
@@ -2781,7 +2782,7 @@ A {{GPUProgrammableStageDescriptor}} describes the entry point in the user-provi
             the |binding| has to be a read-only storage buffer.
         1. If |entry|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampled-texture"}}, {{GPUBindingType/"readonly-storage-texture"}}, or {{GPUBindingType/"writeonly-storage-texture"}},
             the shader view dimension of the texture has to match |entry|.{{GPUBindGroupLayoutEntry/viewDimension}}.
-        1. If |entry|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} is not zero:
+        1. If |entry|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} is not null:
               - If the last field of the corresponding structure defined in the shader has an unbounded array type,
                 then the value of |entry|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} must be greater than or equal to the
                 byte offset of that field plus the stride of the unbounded array.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1982,7 +1982,7 @@ dictionary GPUBindGroupLayoutEntry {
     boolean hasDynamicOffset = false;
 
     // Used for uniform buffer and storage buffer bindings.
-    GPUSize64? minBufferBindingSize = null;
+    GPUSize64 minBufferBindingSize;
 
     // Used for sampled texture and storage texture bindings.
     GPUTextureViewDimension viewDimension;

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2398,10 +2398,10 @@ A {{GPUBindGroup}} object has the following internal slots:
                 with {{GPUBufferUsage/STORAGE}} flag.
             1. The bound part designated by |bufferBinding|.{{GPUBufferBinding/offset}} and
                 |bufferBinding|.{{GPUBufferBinding/size}} must reside inside the buffer.
-            1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/minBufferBindingSize|GPUBindGroupLayoutEntry.minBufferBindingSize}} is not null,
-                The effective binding size, that is either explict in |bufferBinding|.{{GPUBufferBinding/size}}
-                or derived from |bufferBinding|.{{GPUBufferBinding/offset}} and the full size of the buffer,
-                is greater than or equal to |layoutBinding|.{{GPUBindGroupLayoutEntry/minBufferBindingSize|GPUBindGroupLayoutEntry.minBufferBindingSize}}.
+            1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/minBufferBindingSize|GPUBindGroupLayoutEntry.minBufferBindingSize}} is not undefined:
+                - The effective binding size, that is either explict in |bufferBinding|.{{GPUBufferBinding/size}}
+                    or derived from |bufferBinding|.{{GPUBufferBinding/offset}} and the full size of the buffer,
+                    is greater than or equal to |layoutBinding|.{{GPUBindGroupLayoutEntry/minBufferBindingSize|GPUBindGroupLayoutEntry.minBufferBindingSize}}.
     </div>
 </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2142,7 +2142,7 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
             {{GPUBindingType/"readonly-storage-buffer"}},
             ensure
             |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `false`,
-            and |bindingDescriptor|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} is null.
+            and |bindingDescriptor|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} is undefined.
         1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
             {{GPUBindingType/"sampled-texture"}},
             {{GPUBindingType/"readonly-storage-texture"}}, or

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2782,7 +2782,7 @@ A {{GPUProgrammableStageDescriptor}} describes the entry point in the user-provi
             the |binding| has to be a read-only storage buffer.
         1. If |entry|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampled-texture"}}, {{GPUBindingType/"readonly-storage-texture"}}, or {{GPUBindingType/"writeonly-storage-texture"}},
             the shader view dimension of the texture has to match |entry|.{{GPUBindGroupLayoutEntry/viewDimension}}.
-        1. If |entry|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} is not null:
+        1. If |entry|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} is not undefined:
               - If the last field of the corresponding structure defined in the shader has an unbounded array type,
                 then the value of |entry|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} must be greater than or equal to the
                 byte offset of that field plus the stride of the unbounded array.


### PR DESCRIPTION
When the author opt-in to using minBufferBindingSize, this enables two checks:
1. The appropriate buffer in any bind groups created with this bind group layout is larger than minBufferBindingSize
2. minBufferBindingSize is larger than is necessary given the shader

If the author opts in to these requirements, we can do bounds checking at bind group creation / shader compilation time. However, if the author does not opt in to these requirements, we must do bounds checking at draw call time.

Rather than using a sentinel 0 for the second check, we should have the author explicit enable them via out-of-band messaging. This doesn't matter for the first check (since any buffer length is greater-than-or-equal-to 0), but it does matter for the second check.

This patch doesn't change any defaults; it just makes makes the opt-in to earlier bounds checking more explicit.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/litherum/gpuweb/pull/874.html" title="Last updated on Jul 20, 2020, 9:49 PM UTC (0d2a054)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/874/ec5cda7...litherum:0d2a054.html" title="Last updated on Jul 20, 2020, 9:49 PM UTC (0d2a054)">Diff</a>