### PR TITLE
Allow types to be defined with zero init syntax.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1273,7 +1273,7 @@ The block of statements must not contain a return or kill statement.
 <pre class='def'>
 primary_expression
   : (IDENT NAMESPACE)* IDENT
-  | type_decl PAREN_LEFT argument_expression_list PAREN_RIGHT
+  | type_decl PAREN_LEFT argument_expression_list* PAREN_RIGHT
   | const_literal
   | paren_rhs_stmt
   | CAST LESS_THAN type_decl GREATER_THAN paren_rhs_stmt


### PR DESCRIPTION
This Cl updates the type initializer to allow the type to be declared
with a zero initializer.

Issue #685