### PR TITLE
Correct mapAsync mode agrument type

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1067,7 +1067,7 @@ that returns a new buffer in the [=buffer state/mapped=] or [=buffer state/unmap
 <script type=idl>
 [Serializable]
 interface GPUBuffer {
-    Promise<void> mapAsync(GPUMapMode mode, optional GPUSize64 offset = 0, optional GPUSize64 size = 0);
+    Promise<void> mapAsync(GPUMapModeFlags mode, optional GPUSize64 offset = 0, optional GPUSize64 size = 0);
     ArrayBuffer getMappedRange(optional GPUSize64 offset = 0, optional GPUSize64 size = 0);
     void unmap();
 
@@ -1109,9 +1109,9 @@ GPUBuffer includes GPUObjectBase;
         The {{ArrayBuffer}}s returned via {{getMappedRange}} to the application. They are tracked
         so they can be detached when {{unmap}} is called.
 
-    : <dfn>\[[map_mode]]</dfn> of type {{GPUMapMode}}.
+    : <dfn>\[[map_mode]]</dfn> of type {{GPUMapModeFlags}}.
     ::
-        The {{GPUMapMode}} of the last call to {{GPUBuffer/mapAsync()}} (if any).
+        The {{GPUMapModeFlags}} of the last call to {{GPUBuffer/mapAsync()}} (if any).
 </dl>
 
 Issue: {{GPUBuffer/[[usage]]}} is differently named from {{GPUTexture/[[textureUsage]]}}.
@@ -1287,7 +1287,7 @@ Issue(gpuweb/gpuweb#605): Add client-side validation that a mapped buffer can
   only be unmapped and destroyed on the worker on which it was mapped. Likewise
   {{GPUBuffer/getMappedRange}} can only be called on that worker.
 
-### <dfn method for=GPUBuffer>mapAsync(offset, size)</dfn> ### {#GPUBuffer-mapAsync}
+### <dfn method for=GPUBuffer>mapAsync(mode, offset, size)</dfn> ### {#GPUBuffer-mapAsync}
 
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUMapModeFlags;
@@ -1302,7 +1302,7 @@ interface GPUMapMode {
   <strong>|this|:</strong> of type {{GPUBuffer}}.
 
   **Arguments:**
-    - {{GPUMapMode}} |mode|
+    - {{GPUMapModeFlags}} |mode|
     - {{GPUSize64}} |offset|
     - {{GPUSize64}} |size|
 
@@ -1340,7 +1340,7 @@ interface GPUMapMode {
   <div algorithm class=validusage>
     <dfn abstract-op>mapAsync Valid Usage</dfn>
 
-      Given a {{GPUBuffer}} |this|, a {{GPUMapMode}} |mode|, a {{GPUSize64}} |offset|
+      Given a {{GPUBuffer}} |this|, a {{GPUMapModeFlags}} |mode|, a {{GPUSize64}} |offset|
       and a {{GPUSize64}} |size|, the following validation rules apply:
 
       1. |this| must be a [=valid=] {{GPUBuffer}}.
@@ -2284,11 +2284,11 @@ A {{GPUBindGroup}} object has the following internal slots:
     ::
         The set of {{GPUBindGroupEntry}}s this {{GPUBindGroup}} describes.
 
-    : <dfn>\[[usedBuffers]]</dfn> of type maplike<{{GPUBuffer}}, {{GPUBufferUsage}}>.
+    : <dfn>\[[usedBuffers]]</dfn> of type maplike<{{GPUBuffer}}, {{GPUBufferUsageFlags}}>.
     ::
         The set of buffers used by this bind group and the corresponding usage flags.
 
-    : <dfn>\[[usedTextures]]</dfn> of type maplike<{{GPUTexture}} [=subresource=], {{GPUTextureUsage}}>.
+    : <dfn>\[[usedTextures]]</dfn> of type maplike<{{GPUTexture}} [=subresource=], {{GPUTextureUsageFlags}}>.
     ::
         The set of texure subresources used by this bind group. Each subresource is
         stored with the union of usage flags that apply to it.


### PR DESCRIPTION
The `GPUBuffer.mapAsync()` method should accept `GPUMapModeFlags` as argument instead of `GPUMapMode` because method needs to accept `unsigned long` type instead of an interface equivalent.
This is similar to the usage of `GPUBufferUsageFlags` instead of `GPUBufferUsage` in `GPUBufferDescriptor` (same in the case of `GPUTexture`).

Also adds the missing `mode` argument in the `mapAsync()` algorithm title.