### PR TITLE
Describe module constants, including pipeline-overrideable

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -917,7 +917,7 @@ module header and each usage of a GLSL method will add the appropriate
 
 A *module constant* declares a name for a value, outside of all function declarations.
 The name is available for use after the end of the declaration,
-until the end of the WGSL program.
+until the end of the [SHORTNAME] program.
 
 When the declaration has no attributes, the value is the expression in the declaration.
 
@@ -939,8 +939,11 @@ the constant is *pipeline-overridable*. In this case:
     to a value of the constant's type.
     If the mapping does not have an entry for the pipeline constant ID, then the expression
     in the declaration is used as the value.
-  * Pipeline constant IDs must be unique within the WGSL program: Two module constants
+  * Pipeline constant IDs must be unique within the [SHORTNAME] program: Two module constants
     must not use the same pipeline constant ID.
+
+Issue(dneto): What happens is the application supplies a constant ID that is not in the program?
+Proposal: pipeline creation fails with an error.
 
 <div class='example' heading='Module constants, pipeline-overrideable'>
   <xmp>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -950,7 +950,7 @@ the constant is *pipeline-overridable*. In this case:
 </div>
 
 When a variable or feature is used within control flow that depends on the
-value of a constant, then that variable or feature is considerd to be used by the
+value of a constant, then that variable or feature is considered to be used by the
 program.
 This is true regardless of the value of the constant, whether that value
 is the one from the constant's declaration or from a pipeline override.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -717,6 +717,7 @@ Note: literals are parsed greedy. This means that for statements like `a -5`
   <tr><td>`CAST`<td>cast
   <tr><td>`COMPUTE`<td>compute
   <tr><td>`CONST`<td>const
+  <tr><td>`CONSTANT_ID`<td>constant_id
   <tr><td>`CONTINUE`<td>continue
   <tr><td>`CONTINUING`<td>continuing
   <tr><td>`DEFAULT`<td>default
@@ -911,6 +912,64 @@ module header and each usage of a GLSL method will add the appropriate
       %1 = OpExtInstImport "GLSL.std.450"
   </xmp>
 </div>
+
+## Module Constants ## {#module-constants}
+
+A *module constant* declares a name for a value, outside of all function declarations.
+The name is available for use after the end of the declaration,
+until the end of the WGSL program.
+
+When the declaration has no attributes, the value is the expression in the declaration.
+
+<div class='example' heading='Module constants'>
+  <xmp>
+    const golden : f32 = 1.61803398875;       # The golden ratio
+    const e2 : vec3<i32> = vec3<i32>(0,1,0);  # The second unit vector for three dimensions.
+  </xmp>
+</div>
+
+When the declaration uses the `constant_id` attribute,
+the constant is *pipeline-overridable*. In this case:
+
+  * The type must one of the [[#scalar-types]].
+  * The attribute's literal operand is known as the *pipeline constant ID*,
+    and must be a non-negative integer value representable in 32 bits.
+  * The application can specify its own value for the name at pipeline-creation time.
+    The pipeline creation API accepts a mapping from the pipeline constant ID
+    to a value of the constant's type.
+    If the mapping does not have an entry for the pipeline constant ID, then the expression
+    in the declaration is used as the value.
+  * Pipeline constant IDs must be unique within the WGSL program: Two module constants
+    must not use the same pipeline constant ID.
+
+<div class='example' heading='Module constants, pipeline-overrideable'>
+  <xmp>
+    [[constant_id 0]]    const has_point_light : bool = true;      # Algorithmic control
+    [[constant_id 1200]] const specular_param : f32 = 2.3;         # Numeric control
+  </xmp>
+</div>
+
+When a variable or feature is used within control flow that depends on the
+value of a constant, then that variable or feature is considerd to be used by the
+program.
+This is true regardless of the value of the constant, whether that value
+is the one from the constant's declaration or from a pipeline override.
+
+<pre class='def'>
+global_constant_decl
+  : global_const_decoration_list? CONST variable_ident_decl EQUAL const_expr
+
+global_const_decoration_list
+  : ATTR_LEFT global_const_decoration ATTR_RIGHT
+
+global_const_decoration
+  : CONSTANT_ID INT_LITERAL
+</pre>
+
+Issue(dneto): The WebGPU pipeline creation API must specify how API-supplied values are mapped to
+shader scalar values.  For booleans, I suggest using a 32-bit integer, where only 0 maps to `false`.
+If WGSL gains non-32-bit numeric scalars, I recommend overridable constants continue being 32-bit
+numeric types.
 
 ## Module Variables ## {#module-variables}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -919,7 +919,8 @@ A *module constant* declares a name for a value, outside of all function declara
 The name is available for use after the end of the declaration,
 until the end of the [SHORTNAME] program.
 
-When the declaration has no attributes, the value is the expression in the declaration.
+When the declaration has no attributes, an initializer expression must be present,
+and the name denotes the value of that expression.
 
 <div class='example' heading='Module constants'>
   <xmp>
@@ -932,15 +933,16 @@ When the declaration uses the `constant_id` attribute,
 the constant is *pipeline-overridable*. In this case:
 
   * The type must one of the [[#scalar-types]].
+  * The initializer expression is optional.
   * The attribute's literal operand is known as the *pipeline constant ID*,
     and must be a non-negative integer value representable in 32 bits.
+  * Pipeline constant IDs must be unique within the [SHORTNAME] program: Two module constants
+    must not use the same pipeline constant ID.
   * The application can specify its own value for the name at pipeline-creation time.
     The pipeline creation API accepts a mapping from the pipeline constant ID
     to a value of the constant's type.
-    If the mapping does not have an entry for the pipeline constant ID, then the expression
-    in the declaration is used as the value.
-  * Pipeline constant IDs must be unique within the [SHORTNAME] program: Two module constants
-    must not use the same pipeline constant ID.
+    If the mapping has an entry for the ID, the value in the mapping is used.
+    Otherwise, the initializer expression must be present, and its value is used.
 
 Issue(dneto): What happens is the application supplies a constant ID that is not in the program?
 Proposal: pipeline creation fails with an error.
@@ -949,6 +951,7 @@ Proposal: pipeline creation fails with an error.
   <xmp>
     [[constant_id 0]]    const has_point_light : bool = true;      # Algorithmic control
     [[constant_id 1200]] const specular_param : f32 = 2.3;         # Numeric control
+    [[constant_id 1300]] const gain : f32;                         # Must be overridden
   </xmp>
 </div>
 
@@ -960,18 +963,21 @@ is the one from the constant's declaration or from a pipeline override.
 
 <pre class='def'>
 global_constant_decl
-  : global_const_decoration_list? CONST variable_ident_decl EQUAL const_expr
+  : global_const_decoration_list? CONST variable_ident_decl global_const_initializer?
 
 global_const_decoration_list
   : ATTR_LEFT global_const_decoration ATTR_RIGHT
 
 global_const_decoration
   : CONSTANT_ID INT_LITERAL
+
+global_const_initializer
+  : EQUAL const_expr
 </pre>
 
 Issue(dneto): The WebGPU pipeline creation API must specify how API-supplied values are mapped to
 shader scalar values.  For booleans, I suggest using a 32-bit integer, where only 0 maps to `false`.
-If WGSL gains non-32-bit numeric scalars, I recommend overridable constants continue being 32-bit
+If [SHORTNAME] gains non-32-bit numeric scalars, I recommend overridable constants continue being 32-bit
 numeric types.
 
 ## Module Variables ## {#module-variables}


### PR DESCRIPTION
Fixes #572

Includes a strict "static use" rule. It allows for a very
simple implementation (no assumed smarts for dead code elimination),
and shifts the burden to the application to cleanup for interface matching.

This features corresponds roughly to:
- SPIR-V specialization constants, except you can't use them
  in all the same places. For example, in SPIR-V an array
  size may be a specialization constant scalar, but no in WGSL.
- MSL function constants, except:
  - MSL allows vector values
  - MSL has a facility for excluding an entry point interface
    parameter based on the value of a boolean function constant.