### PR TITLE
Attributes are optional on module-scope variables

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -636,8 +636,8 @@ module header and each usage of a GLSL method will add the appropriate
 
 <pre class='def'>
 global_variable_decl
-  : variable_decoration_list variable_decl
-  | variable_decoration_list variable_decl EQUAL const_expr
+  : variable_decoration_list? variable_decl
+  | variable_decoration_list? variable_decl EQUAL const_expr
 
 global_constant_decl
   : CONST variable_ident_decl EQUAL const_expr


### PR DESCRIPTION
Fixes #885

E.g. I can declare a module-scope private variable
without any attributes.