### PR TITLE
Fix mapping_range slot value in GPUBuffer

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1331,7 +1331,7 @@ interface GPUMapMode {
         1. Set the content of |m| to the content of |this|'s allocation starting at offset |offset| and for |size| bytes.
         1. Set |this|.{{[[mapping]]}} to |m|.
         1. Set |this|.{{GPUBuffer/[[state]]}} to [=buffer state/mapped=].
-        1. Set |this|.{{[[mapping_range]]}} to `[start, offset]`.
+        1. Set |this|.{{[[mapping_range]]}} to `[offset, offset + size]`.
         1. Set |this|.{{[[mapped_ranges]]}} to `[]`.
         1. Resolve |p|.
 
@@ -1387,7 +1387,7 @@ interface GPUMapMode {
       1. |offset| must be a multiple of 8.
       1. |size| must be a multiple of 4.
       1. |offset| must be greater than or equal to |this|.{{[[mapping_range]]}}[0].
-      1. |offset| + |size| must be less than or equal to |this|.{{[[mapping_range]]}}[0] + |this|.{{[[mapping_range]]}}[1].
+      1. |offset| + |size| must be less than or equal to |this|.{{[[mapping_range]]}}[1].
       1. [|offset|, |offset| + |size|) must not overlap another range in |this|.{{[[mapped_ranges]]}}.
 
       Note: It is valid to get mapped ranges of an error {{GPUBuffer}} that is [=buffer state/mapped at creation=] because
@@ -2173,7 +2173,7 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
             , ensure [=sampled texture validation=] is not violated.
         1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/readonly-storage-texture}} or {{GPUBindingType/writeonly-storage-texture}}
             , ensure [=storage texture validation=] is not violated.
-        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/sampler}}
+        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/sampler}} or {{GPUBindingType/comparison-sampler}}
             , ensure [=sampler validation=] is not violated.
         1. Insert |bindingDescriptor| into |layout|.{{GPUBindGroupLayout/[[entryMap]]}}
             with the key of |bindingDescriptor|/{{GPUBindGroupLayoutEntry/binding}}.


### PR DESCRIPTION
This also adds `comparison-sampler` for validation under createBindGroupLayout.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kunalmohan/gpuweb/pull/894.html" title="Last updated on Jun 28, 2020, 2:37 PM UTC (3b7faeb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/894/d111c53...kunalmohan:3b7faeb.html" title="Last updated on Jun 28, 2020, 2:37 PM UTC (3b7faeb)">Diff</a>