### PR TITLE
Remove references of MappedBuffer and createBufferMapped

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -982,7 +982,6 @@ interface GPUDevice : EventTarget {
     [SameObject] readonly attribute GPUQueue defaultQueue;
 
     GPUBuffer createBuffer(GPUBufferDescriptor descriptor);
-    GPUMappedBuffer createBufferMapped(GPUBufferDescriptor descriptor);
     GPUTexture createTexture(GPUTextureDescriptor descriptor);
     GPUSampler createSampler(optional GPUSamplerDescriptor descriptor = {});
 
@@ -4933,14 +4932,6 @@ An <dfn dfn>Extent3D</dfn> is a {{GPUExtent3D}}.
         either {{GPUExtent3DDict}}.{{GPUExtent3DDict/depth}}
         or the third item of the sequence.
 </div>
-
-<script type=idl>
-typedef sequence<(GPUBuffer or ArrayBuffer)> GPUMappedBuffer;
-</script>
-
-{{GPUMappedBuffer}} is always a sequence of 2 elements, of types {{GPUBuffer}}
-and {{ArrayBuffer}}, respectively.
-
 
 # Temporary usages of non-exported dfns # {#temp-dfn-usages}
 


### PR DESCRIPTION
As discussed in the Riot chat, these are deprecated, but there are some leftovers in the spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/almarklein/gpuweb/pull/896.html" title="Last updated on Jul 1, 2020, 8:12 AM UTC (967be87)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/896/be18ab8...almarklein:967be87.html" title="Last updated on Jul 1, 2020, 8:12 AM UTC (967be87)">Diff</a>