### PR TITLE
Require mapped buffer sizes aligned to 4

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1314,6 +1314,8 @@ interface GPUBufferUsage {
         the only other usage it may contain is {{GPUBufferUsage/COPY_DST}}.
       1. If |descriptor|.{{GPUBufferDescriptor/usage}} contains {{GPUBufferUsage/MAP_WRITE}} then
         the only other usage it may contain is {{GPUBufferUsage/COPY_SRC}}.
+      1. If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is true then
+        |descriptor|.{{GPUBufferDescriptor/size}} must be a multiple of 4.
 
       Issue(gpuweb/gpuweb#605): Explain what are a {{GPUDevice}}'s `[[allowed buffer usages]]`
     </dfn>


### PR DESCRIPTION
This change makes `mappedAtCreation` requirements consistent with `mapAsync`, which means `mappedAtCreation` can be explained in terms of mapping operations. It also makes the implementation life simpler, since under the hood we need to copy the contents of the buffer, and the copy has to be aligned to 4.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/899.html" title="Last updated on Jul 2, 2020, 9:19 PM UTC (bdc3caa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/899/c66dabc...kvark:bdc3caa.html" title="Last updated on Jul 2, 2020, 9:19 PM UTC (bdc3caa)">Diff</a>