### PR TITLE
Use FrozenArray for GPUCompilationInfo's attribute

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2591,7 +2591,7 @@ interface GPUCompilationMessage {
 
 [Serializable]
 interface GPUCompilationInfo {
-    readonly attribute sequence<GPUCompilationMessage> messages;
+    readonly attribute FrozenArray<GPUCompilationMessage> messages;
 };
 
 [Serializable]


### PR DESCRIPTION
https://heycam.github.io/webidl/#idl-sequence says:
> Sequences must not be used as the type of an attribute or constant.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/foolip/gpuweb/pull/902.html" title="Last updated on Jul 3, 2020, 8:51 PM UTC (4241e78)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/902/c66dabc...foolip:4241e78.html" title="Last updated on Jul 3, 2020, 8:51 PM UTC (4241e78)">Diff</a>