### PR TITLE
Change the semantic of default size in writeBuffer

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4659,7 +4659,7 @@ GPUQueue includes GPUObjectBase;
             **Returns:** `void`
 
             - If |size| is unspecified,
-                let |contentsSize| be |data|.`byteLength` &minus; |dataOffset|.
+                let |contentsSize| be |buffer|.{{GPUBuffer/[[size]]}} &minus; |bufferOffset|.
                 Otherwise, let |contentsSize| be |size|.
             - If any of the following conditions are unsatisfied,
                 throw {{OperationError}} and stop.


### PR DESCRIPTION
I believe defaulting to the buffer size is consistent with the rest of the API where the size is unspecified.
Also, it works better for a case where the user uses one `ArrayBuffer` to fill out many `GPUBuffer` objects.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/903.html" title="Last updated on Jul 4, 2020, 4:21 PM UTC (23a83fa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/903/c66dabc...23a83fa.html" title="Last updated on Jul 4, 2020, 4:21 PM UTC (23a83fa)">Diff</a>