### PR TITLE
Bug in validating linear texture data

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3775,10 +3775,10 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
     - |layout|.{{GPUTextureDataLayout/offset}} must be a multiple of |blockSize|.
 
     For other members in |layout|:
-    - If |copyExtent|.[=Extent3D/height=] is greater than 1:
-      - |layout|.{{GPUTextureDataLayout/bytesPerRow}} must be greater than or equal to the number of |bytesInACompleteRow|.
+    - If |copyExtent|.[=Extent3D/height=] is greater than 1 or |copyExtent|.[=Extent3D/depth=] is greater than 1:
+        - |layout|.{{GPUTextureDataLayout/bytesPerRow}} must be greater than or equal to the number of |bytesInACompleteRow|.
     - If |copyExtent|.[=Extent3D/depth=] is greater than 1:
-      - |layout|.{{GPUTextureDataLayout/rowsPerImage}} must be greater than or equal to |copyExtent|.[=Extent3D/height=].
+        - |layout|.{{GPUTextureDataLayout/rowsPerImage}} must be greater than or equal to |copyExtent|.[=Extent3D/height=].
 </div>
 
 <div algorithm class=validusage>


### PR DESCRIPTION
The spec assumes that if copyExtent.height = 1, then we don't need to care about aligning rows to bytesPerRow, but it is still possible in that case that copyExtent.depth > 1 and we should be doing that.

Here's an example of what I mean: if copyExtent = {256, 1, 256}, blockWidth = blockHeight = blockSize = 1, bytesPerRow = 0 (this is allowed since copyExtent.height = 1), rowsPerImage = 1, then requiredBytesInCopy = 256 by the algorithm in spec, even though we need 256 * 256 bytes.

Here's a possible fix to that. We could also remove the if condition completely and require bytesPerRow to be passed always (that's the way it's currently implemented in Dawn). Either way seems to be fine.

Also, the style change makes the if structure a bit more apparent.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ponitka/gpuweb/pull/904.html" title="Last updated on Jul 6, 2020, 1:20 PM UTC (bdf9edb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/904/2dade02...ponitka:bdf9edb.html" title="Last updated on Jul 6, 2020, 1:20 PM UTC (bdf9edb)">Diff</a>