### PR TITLE
[wgsl] Add text around entry point function.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -988,6 +988,8 @@ file.
 The input and output parameters to the entry point are determined by which
 global variables are used in the function and any called functions.
 
+The entry point function must be declared with no arguments and returning `void`.
+
 <pre class='def'>
 entry_point_decl:
    : ENTRY_POINT pipeline_stage EQUAL IDENT
@@ -1595,6 +1597,8 @@ the test name.
           module
 * v-0021: Can not re-assign a constant.
 * v-0022: Global variables must have a storage class
+* v-0023: Entry point functions accept no parameters
+* v-0024: Entry point functions return void
 
 # Type Checking # {#type-checking}
 


### PR DESCRIPTION
This CL adds restrictions on the WGSL entry point functions to accept no
parameters and to return void.

Fixes #778
Issue #889