### PR TITLE
Specify default offset and size for getMappedRange

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1537,44 +1537,54 @@ interface GPUMapMode {
 ### <dfn method for=GPUBuffer>getMappedRange(offset, size)</dfn> ### {#GPUBuffer-getMappedRange}
 
 <div algorithm="GPUBuffer.getMappedRange">
-  <strong>|this|:</strong> of type {{GPUBuffer}}.
+    <strong>|this|:</strong> of type {{GPUBuffer}}.
 
-  **Arguments:**
+    **Arguments:**
+
     - {{GPUSize64}} |offset|
     - {{GPUSize64}} |size|
 
-  **Returns:** {{ArrayBuffer}}
+    **Returns:** {{ArrayBuffer}}
 
-  1. If |size| is unspecified and |offset| is less than this.{{[[size]]}}, let |rangeSize| be this.{{[[size]]}} - |offset|. Otherwise, let |rangeSize| be |size|.
+    1. If |size| is unspecified:
 
-  1. If this call doesn't follow the [$getMappedRange Valid Usage$]:
+        - If |offset| &ge; this.{{[[size]]}}, throw an {{OperationError}} and stop.
+        - Let |rangeSize| be this.{{[[size]]}} - |offset|.
 
-    1. Throw an {{OperationError}}.
+        Otherwise, let |rangeSize| be |size|.
 
-  1. Let |m| be a new {{ArrayBuffer}} of size |rangeSize| pointing at the content of |this|.{{[[mapping]]}} at offset |offset| - |this|.{{[[mapping_range]]}}[0].
-  1. Append |m| to |this|.{{[[mapped_ranges]]}}.
-  1. Return |m|.
+    1. If this call doesn't follow the [$getMappedRange Valid Usage$]:
 
-  <div algorithm class=validusage>
-    <dfn abstract-op>getMappedRange Valid Usage</dfn>
+        1. Throw an {{OperationError}} and stop.
 
-      Given a {{GPUBuffer}} |this|, a {{GPUSize64}} |offset| and a {{GPUSize64}} |rangeSize|
-      the following validation rules apply:
+    1. Let |m| be a new {{ArrayBuffer}} of size |rangeSize| pointing at the content
+        of |this|.{{[[mapping]]}} at offset |offset| - |this|.{{[[mapping_range]]}}[0].
 
-      1. |this|.{{GPUBuffer/[[state]]}} must be [=buffer state/mapped=] or [=buffer state/mapped at creation=].
-      1. |offset| must be a multiple of 8.
-      1. |rangeSize| must be a multiple of 4.
-      1. |offset| must be greater than or equal to |this|.{{[[mapping_range]]}}[0].
-      1. |offset| + |rangeSize| must be less than or equal to |this|.{{[[mapping_range]]}}[1].
-      1. [|offset|, |offset| + |rangeSize|) must not overlap another range in |this|.{{[[mapped_ranges]]}}.
+    1. Append |m| to |this|.{{[[mapped_ranges]]}}.
 
-      Note: It is valid to get mapped ranges of an error {{GPUBuffer}} that is [=buffer state/mapped at creation=] because
-      the [=Content timeline=] might not know it is an error {{GPUBuffer}}.
+    1. Return |m|.
 
-      Issue: Consider aligning mapAsync offset to 8.
+    <div algorithm class=validusage>
+        <dfn abstract-op>getMappedRange Valid Usage</dfn>
 
-    </dfn>
-  </div>
+        Given a {{GPUBuffer}} |this|, a {{GPUSize64}} |offset| and a {{GPUSize64}} |rangeSize|
+        the following validation rules apply:
+
+        1. |this|.{{GPUBuffer/[[state]]}} must be [=buffer state/mapped=] or [=buffer state/mapped at creation=].
+        1. |offset| must be a multiple of 8.
+        1. |rangeSize| must be a positive multiple of 4.
+        1. |offset| must be greater than or equal to |this|.{{[[mapping_range]]}}[0].
+        1. |offset| + |rangeSize| must be less than or equal to |this|.{{[[mapping_range]]}}[1].
+        1. [|offset|, |offset| + |rangeSize|) must not overlap another range in |this|.{{[[mapped_ranges]]}}.
+
+        Note: It is always valid to get mapped ranges of an {{GPUBuffer}} that is
+        [=buffer state/mapped at creation=], even if it is [=invalid=], because
+        the [=Content timeline=] might not know it is invalid.
+
+        Issue: Consider aligning mapAsync offset to 8 to match this.
+
+        </dfn>
+    </div>
 </div>
 
 ### <dfn method for=GPUBuffer>unmap()</dfn> ### {#GPUBuffer-unmap}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1242,7 +1242,7 @@ that returns a new buffer in the [=buffer state/mapped=] or [=buffer state/unmap
 [Serializable]
 interface GPUBuffer {
     Promise<void> mapAsync(GPUMapModeFlags mode, optional GPUSize64 offset = 0, optional GPUSize64 size = 0);
-    ArrayBuffer getMappedRange(optional GPUSize64 offset = 0, optional GPUSize64 size = 0);
+    ArrayBuffer getMappedRange(optional GPUSize64 offset = 0, optional GPUSize64 size);
     void unmap();
 
     void destroy();
@@ -1545,29 +1545,33 @@ interface GPUMapMode {
 
   **Returns:** {{ArrayBuffer}}
 
+  1. If |size| is unspecified and |offset| is less than this.{{[[size]]}}, let |rangeSize| be this.{{[[size]]}} - |offset|. Otherwise, let |rangeSize| be |size|.
+
   1. If this call doesn't follow the [$getMappedRange Valid Usage$]:
 
     1. Throw an {{OperationError}}.
 
-  1. Let |m| be a new {{ArrayBuffer}} of size |size| pointing at the content of |this|.{{[[mapping]]}} at offset |offset| - |this|.{{[[mapping_range]]}}[0].
+  1. Let |m| be a new {{ArrayBuffer}} of size |rangeSize| pointing at the content of |this|.{{[[mapping]]}} at offset |offset| - |this|.{{[[mapping_range]]}}[0].
   1. Append |m| to |this|.{{[[mapped_ranges]]}}.
   1. Return |m|.
 
   <div algorithm class=validusage>
     <dfn abstract-op>getMappedRange Valid Usage</dfn>
 
-      Given a {{GPUBuffer}} |this|, a {{GPUSize64}} |offset| and a {{GPUSize64}} |size|
+      Given a {{GPUBuffer}} |this|, a {{GPUSize64}} |offset| and a {{GPUSize64}} |rangeSize|
       the following validation rules apply:
 
       1. |this|.{{GPUBuffer/[[state]]}} must be [=buffer state/mapped=] or [=buffer state/mapped at creation=].
       1. |offset| must be a multiple of 8.
-      1. |size| must be a multiple of 4.
+      1. |rangeSize| must be a multiple of 4.
       1. |offset| must be greater than or equal to |this|.{{[[mapping_range]]}}[0].
-      1. |offset| + |size| must be less than or equal to |this|.{{[[mapping_range]]}}[1].
-      1. [|offset|, |offset| + |size|) must not overlap another range in |this|.{{[[mapped_ranges]]}}.
+      1. |offset| + |rangeSize| must be less than or equal to |this|.{{[[mapping_range]]}}[1].
+      1. [|offset|, |offset| + |rangeSize|) must not overlap another range in |this|.{{[[mapped_ranges]]}}.
 
       Note: It is valid to get mapped ranges of an error {{GPUBuffer}} that is [=buffer state/mapped at creation=] because
       the [=Content timeline=] might not know it is an error {{GPUBuffer}}.
+
+      Issue: Consider aligning mapAsync offset to 8.
 
     </dfn>
   </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1577,13 +1577,11 @@ interface GPUMapMode {
         1. |offset| + |rangeSize| must be less than or equal to |this|.{{[[mapping_range]]}}[1].
         1. [|offset|, |offset| + |rangeSize|) must not overlap another range in |this|.{{[[mapped_ranges]]}}.
 
-        Note: It is always valid to get mapped ranges of an {{GPUBuffer}} that is
+        Note: It is always valid to get mapped ranges of a {{GPUBuffer}} that is
         [=buffer state/mapped at creation=], even if it is [=invalid=], because
         the [=Content timeline=] might not know it is invalid.
 
         Issue: Consider aligning mapAsync offset to 8 to match this.
-
-        </dfn>
     </div>
 </div>
 


### PR DESCRIPTION
Defaults are specified w.r.t buffer `mapping_range`.
While setting the default size, `offset` is checked with only lower bound inclusion to prevent zero-sized array buffers to be returned.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kunalmohan/gpuweb/pull/908.html" title="Last updated on Jul 22, 2020, 6:09 PM UTC (f3a9a2a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/908/895623e...kunalmohan:f3a9a2a.html" title="Last updated on Jul 22, 2020, 6:09 PM UTC (f3a9a2a)">Diff</a>