### PR TITLE
Short-circuiting &&, ||; non-short-circuit bool and and or

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1063,7 +1063,7 @@ body_stmt:
   : BRACE_LEFT statements BRACE_RIGHT
 
 paren_rhs_stmt
-  : PAREN_LEFT logical_or_expression PAREN_RIGHT
+  : PAREN_LEFT short_circuit_or_expression PAREN_RIGHT
 
 statements
   : statement*
@@ -1088,7 +1088,7 @@ statement
 
 <pre class='def'>
 return_stmt
-  : RETURN logical_or_expression?
+  : RETURN short_circuit_or_expression?
 </pre>
 
 A `return` statement ends execution of the current function.
@@ -1107,8 +1107,8 @@ The type of the return value must match the return type of the function.
 <pre class='def'>
 variable_stmt
   : variable_decl
-  | variable_decl EQUAL logical_or_expression
-  | CONST variable_ident_decl EQUAL logical_or_expression
+  | variable_decl EQUAL short_circuit_or_expression
+  | CONST variable_ident_decl EQUAL short_circuit_or_expression
 </pre>
 
 ## If Statement ## {#if-statement}
@@ -1266,7 +1266,7 @@ for_stmt
 
 for_header
   : (variable_stmt | assignment_stmt | func_call_stmt)? SEMICOLON
-     logical_or_expression? SEMICOLON
+     short_circuit_or_expression? SEMICOLON
      (assignment_stmt | func_call_stmt)?
 </pre>
 
@@ -1458,12 +1458,12 @@ primary_expression
 
 postfix_expression
   :
-  | BRACKET_LEFT logical_or_expression BRACKET_RIGHT postfix_expression
+  | BRACKET_LEFT short_circuit_or_expression BRACKET_RIGHT postfix_expression
   | PAREN_LEFT argument_expression_list* PAREN_RIGHT postfix_expression
   | PERIOD IDENT postfix_expression
 
 argument_expression_list
-  : (logical_or_expression COMMA)* logical_or_expression
+  : (short_circuit_or_expression COMMA)* short_circuit_or_expression
 
 unary_expression
   : singular_expression
@@ -1538,30 +1538,25 @@ equality_expression
 and_expression
   : equality_expression
   | and_expression AND equality_expression
-       OpBitwiseAnd
 
 exclusive_or_expression
   : and_expression
   | exclusive_or_expression XOR and_expression
-       OpBitwiseXor
 
 inclusive_or_expression
   : exclusive_or_expression
   | inclusive_or_expression OR exclusive_or_expression
-       OpBitwiseOr
 
-logical_and_expression
+short_circuit_and_expression
   : inclusive_or_expression
-  | logical_and_expression AND_AND inclusive_or_expression
-      OpLogicalAnd
+  | short_circuit_and_expression AND_AND inclusive_or_expression
 
-logical_or_expression
-  : logical_and_expression
-  | logical_or_expression OR_OR logical_and_expression
-      OpLogicalOr
+short_circuit_or_expression
+  : short_circuit_and_expression
+  | short_circuit_or_expression OR_OR short_circuit_and_expression
 
 assignment_stmt
-  : singular_expression EQUAL logical_or_expression
+  : singular_expression EQUAL short_circuit_or_expression
       If singular_expression is a variable, this maps to OpStore to the variable.
       Otherwise, singular expression is a pointer expression in an Assigning (L-value) context
       which maps to OpAccessChain followed by OpStore
@@ -2046,17 +2041,17 @@ Issue: (dneto): Bitwise-complement is under discussion.  https://github.com/gpuw
           *e2* : *T*<br>
           *T* is *Integral*
        <td class="nowrap">`e1 | e2` : *T*
-       <td>Bitwise-or (OpBitwiseOr)
+       <td>Bitwise-or
   <tr><td>*e1* : *T*<br>
           *e2* : *T*<br>
           *T* is *Integral*
        <td class="nowrap">`e1 & e2` : *T*
-       <td>Bitwise-and (OpBitwiseAnd)
+       <td>Bitwise-and
   <tr><td>*e1* : *T*<br>
           *e2* : *T*<br>
           *T* is *Integral*
        <td class="nowrap">`e1 ^ e2` : *T*
-       <td>Bitwise-exclusive-or (OpBitwiseXor)
+       <td>Bitwise-exclusive-or
 </table>
 
 <table class='data'>
@@ -2241,10 +2236,16 @@ Issue: (dneto): Bitwise-complement is under discussion.  https://github.com/gpuw
   <thead>
     <tr><td>Precondition<td>Conclusion<td>Notes
   </thead>
-  <tr><td>*e1* : bool<br>*e2* : bool<td>`e1 || e2` : bool<td>Logical or (OpLogicalOr)
-  <tr><td>*e1* : bool<br>*e2* : bool<td>`e1 && e2` : bool<td>Logical and (OpLogicalAnd)
-  <tr><td>*e1* : *T*<br>*e2* : *T*<br>*T* is *BoolVec*<td>`e1 || e2` : *T*<td>Component-wise logical or (OpLogicalOr)
-  <tr><td>*e1* : *T*<br>*e2* : *T*<br>*T* is *BoolVec*<td>`e1 && e2` : *T*<td>Component-wise logical and (OpLogicalAnd)
+  <tr><td>*e1* : bool<br>*e2* : bool<td>`e1 || e2` : bool<td>
+    Short-circuiting "or". Yields `true` if either `e1` or `e2` are true; evaluates `e2` only if `e1` is false.
+  <tr><td>*e1* : bool<br>*e2* : bool<td>`e1 && e2` : bool<td>
+    Short-circuiting "and". Yields `true` if both `e1` and `e2` are true; evaluates `e2` only if `e1` is true.
+  <tr><td>*e1* : bool<br>*e2* : bool<td>`e1 | e2` : bool<td>
+    Logical "or". Evaluates both `e1` and `e2`; yields `true` if either are `true`.
+  <tr><td>*e1* : bool<br>*e2* : bool<td>`e1 & e2` : bool<td>
+    Logical "and". Evaluates both `e1` and `e2`; yields `true` if both are `true`.
+  <tr><td>*e1* : *T*<br>*e2* : *T*<br>*T* is *BoolVec*<td>`e1 | e2` : *T*<td>Component-wise logical "or"
+  <tr><td>*e1* : *T*<br>*e2* : *T*<br>*T* is *BoolVec*<td>`e1 & e2` : *T*<td>Component-wise logical "and"
 </table>
 
 # Glossary # {#glossary}


### PR DESCRIPTION
- Defines short-circuiting behaviour for &&, ||, for scalars
- && and || on vectors is a type error
- Defines & and | as non-shor-circuiting, operating on scalar bool
  or vector bool
- Removes annotations of SPIR-V instructions for OpLogicalAnd,
OpLogicalOr and the bitwise logical operations.

Fixes #675