### PR TITLE
Tighten bit shifts

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2008,32 +2008,42 @@ Issue: (dneto): Bitwise-complement is under discussion.  https://github.com/gpuw
     <tr><td>Precondition<td>Conclusion<td>Notes
   </thead>
   <tr><td>*e1* : *T*<br>
-          *e2* : *T*<br>
+          *e2* : u32<br>
           *T* is *Int*
        <td class="nowrap">`e1 << e2` : *T*
-       <td>Shift *e1* left by *e2* bits (OpShiftLeftLogical)
-  <tr><td>*e1* : *T*<br>
-          *e2* : *T*<br>
-          *T* is *IntVec*
-       <td class="nowrap">`e1 << e2` : *T*
+       <td>Shift left:<br>
+           Shift *e1* left, inserting zero bits at the least significant positions,
+           and discarding the most significant bits.
+           The number of bits to shift is the value of *e2* modulo the bit width of *e1*.
+           (OpShiftLeftLogical)
+  <tr><td>*e1* : vec*N*&lt;*T*&gt;<br>
+          *e2* : vec*N*&lt;u32&gt;<br>
+          *T* is *Int*
+       <td class="nowrap">`e1 << e2` : vec*N*&lt;*T*&gt;
        <td>Component-wise shift left (OpShiftLeftLogical)
   <tr><td>*e1* : u32<br>
           *e2* : u32<br>
        <td class="nowrap">`e1 >> e2` : u32
-       <td>Logical shift *e1* right by *e2* bits, i.e. inserting zero at most significant bits (OpShiftRightLogical)
-  <tr><td>*e1* : *T*<br>
-          *e2* : *T*<br>
-          *T* is vec*N*&lt;u32&gt;
-       <td class="nowrap">`e1 >> e2` : *T*
+       <td>Logical shift right:<br>
+           Shift *e1* right, inserting zero bits at the most significant positions,
+           and discarding the least significant bits.
+           The number of bits to shift is the value of *e2* modulo the bit width of *e1*.
+           (OpShiftRightLogical)
+  <tr><td>*e1* : vec*N*&lt;u32&gt;<br>
+          *e2* : u32<br>
+       <td class="nowrap">`e1 >> e2` : vec*N*&lt;u32&gt;
        <td>Component-wise logical shift right (OpShiftRightLogical)
   <tr><td>*e1* : i32<br>
-          *e2* : i32<br>
+          *e2* : u32<br>
        <td class="nowrap">`e1 >> e2` : i32
-       <td>Arithmetic shift *e1* right by *e2* bits, i.e. replicating the sign bit of *e1* at most significant bits (OpShiftRightArithmetic)
-  <tr><td>*e1* : *T*<br>
-          *e2* : *T*<br>
-          *T* is vec*N*&lt;i32&gt;
-       <td class="nowrap">`e1 >> e2` : *T*
+       <td>Arithmetic shift right:<br>
+           Shift *e1* right, copying the sign bit of *e1* into the most significant positions,
+           and discarding the least significant bits.
+           The number of bits to shift is the value of *e2* modulo the bit width of *e1*.
+           (OpShiftRightLogical)
+  <tr><td>*e1* : vec*N*&lt;i32&gt;<br>
+          *e2* : vec*N*&lt;u32&gt;<br>
+       <td class="nowrap">`e1 >> e2` : vec*N*&lt;i32&gt;
        <td>Component-wise arithmetic shift right (OpShiftRightArithmetic)
 </table>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2014,13 +2014,15 @@ Issue: (dneto): Bitwise-complement is under discussion.  https://github.com/gpuw
        <td>Shift left:<br>
            Shift |e1| left, inserting zero bits at the least significant positions,
            and discarding the most significant bits.
-           The number of bits to shift is the value of |e2| modulo the bit width of |e1|.
+           The number of bits to shift is the value of |e2| modulo the bit width of |e1|.<br>
            (OpShiftLeftLogical)
   <tr algorithm="vector shift left"><td>|e1| : vec|N|&lt;|T|&gt;<br>
           |e2| : vec|N|&lt;u32&gt;<br>
           |T| is *Int*
        <td class="nowrap">|e1| `<<` |e2| : vec|N|&lt;|T|&gt;
-       <td>Component-wise shift left (OpShiftLeftLogical)
+       <td>Component-wise shift left:<br>
+           Component |i| of the result is `(`|e1|`[`|i|`] << `|e2|`[`|i|`])`<br>
+           (OpShiftLeftLogical)
   <tr algorithm="scalar logical shift right"><td>|e1| : u32<br>
           |e2| : u32<br>
        <td class="nowrap">|e1| `>>` |e2| `: u32`
@@ -2032,7 +2034,9 @@ Issue: (dneto): Bitwise-complement is under discussion.  https://github.com/gpuw
   <tr algorithm="vector logical shift right"><td>|e1| : vec|N|&lt;u32&gt;<br>
           |e2| : u32<br>
        <td class="nowrap">|e1| `>>` |e2| : vec|N|&lt;u32&gt;
-       <td>Component-wise logical shift right (OpShiftRightLogical)
+       <td>Component-wise logical shift right:<br>
+           Component |i| of the result is `(`|e1|`[`|i|`] >> `|e2|`[`|i|`])`
+           (OpShiftRightLogical)
   <tr algorithm="scalar arithmetic shift right"><td>|e1| : i32<br>
           |e2| : u32<br>
        <td class="nowrap">|e1| `>>` |e2| : i32
@@ -2040,11 +2044,13 @@ Issue: (dneto): Bitwise-complement is under discussion.  https://github.com/gpuw
            Shift |e1| right, copying the sign bit of |e1| into the most significant positions,
            and discarding the least significant bits.
            The number of bits to shift is the value of |e2| modulo the bit width of |e1|.
-           (OpShiftRightLogical)
+           (OpShiftRightArithmetic)
   <tr algorithm="vector arithmetic shift right"><td>|e1| : vec|N|&lt;i32&gt;<br>
           |e2| : vec|N|&lt;u32&gt;<br>
        <td class="nowrap">|e1| `>>` |e2| : vec|N|&lt;i32&gt;
-       <td>Component-wise arithmetic shift right (OpShiftRightArithmetic)
+       <td>Component-wise arithmetic shift right:<br>
+           Component |i| of the result is `(`|e1|`[`|i|`] >> `|e2|`[`|i|`])`
+           (OpShiftRightArithmetic)
 </table>
 
 <table class='data'>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2007,43 +2007,43 @@ Issue: (dneto): Bitwise-complement is under discussion.  https://github.com/gpuw
   <thead>
     <tr><td>Precondition<td>Conclusion<td>Notes
   </thead>
-  <tr><td>*e1* : *T*<br>
-          *e2* : u32<br>
-          *T* is *Int*
-       <td class="nowrap">`e1 << e2` : *T*
+  <tr algorithm="scalar shift left"><td>|e1| : |T|<br>
+          |e2| : u32<br>
+          |T| is *Int*
+       <td class="nowrap">|e1| `<<` |e2| : |T|
        <td>Shift left:<br>
-           Shift *e1* left, inserting zero bits at the least significant positions,
+           Shift |e1| left, inserting zero bits at the least significant positions,
            and discarding the most significant bits.
-           The number of bits to shift is the value of *e2* modulo the bit width of *e1*.
+           The number of bits to shift is the value of |e2| modulo the bit width of |e1|.
            (OpShiftLeftLogical)
-  <tr><td>*e1* : vec*N*&lt;*T*&gt;<br>
-          *e2* : vec*N*&lt;u32&gt;<br>
-          *T* is *Int*
-       <td class="nowrap">`e1 << e2` : vec*N*&lt;*T*&gt;
+  <tr algorithm="vector shift left"><td>|e1| : vec|N|&lt;|T|&gt;<br>
+          |e2| : vec|N|&lt;u32&gt;<br>
+          |T| is *Int*
+       <td class="nowrap">|e1| `<<` |e2| : vec|N|&lt;|T|&gt;
        <td>Component-wise shift left (OpShiftLeftLogical)
-  <tr><td>*e1* : u32<br>
-          *e2* : u32<br>
-       <td class="nowrap">`e1 >> e2` : u32
-       <td>Logical shift right:<br>
-           Shift *e1* right, inserting zero bits at the most significant positions,
+  <tr algorithm="scalar logical shift right"><td>|e1| : u32<br>
+          |e2| : u32<br>
+       <td class="nowrap">|e1| `>>` |e2| `: u32`
+       <td >Logical shift right:<br>
+           Shift |e1| right, inserting zero bits at the most significant positions,
            and discarding the least significant bits.
-           The number of bits to shift is the value of *e2* modulo the bit width of *e1*.
+           The number of bits to shift is the value of |e2| modulo the bit width of |e1|.
            (OpShiftRightLogical)
-  <tr><td>*e1* : vec*N*&lt;u32&gt;<br>
-          *e2* : u32<br>
-       <td class="nowrap">`e1 >> e2` : vec*N*&lt;u32&gt;
+  <tr algorithm="vector logical shift right"><td>|e1| : vec|N|&lt;u32&gt;<br>
+          |e2| : u32<br>
+       <td class="nowrap">|e1| `>>` |e2| : vec|N|&lt;u32&gt;
        <td>Component-wise logical shift right (OpShiftRightLogical)
-  <tr><td>*e1* : i32<br>
-          *e2* : u32<br>
-       <td class="nowrap">`e1 >> e2` : i32
+  <tr algorithm="scalar arithmetic shift right"><td>|e1| : i32<br>
+          |e2| : u32<br>
+       <td class="nowrap">|e1| `>>` |e2| : i32
        <td>Arithmetic shift right:<br>
-           Shift *e1* right, copying the sign bit of *e1* into the most significant positions,
+           Shift |e1| right, copying the sign bit of |e1| into the most significant positions,
            and discarding the least significant bits.
-           The number of bits to shift is the value of *e2* modulo the bit width of *e1*.
+           The number of bits to shift is the value of |e2| modulo the bit width of |e1|.
            (OpShiftRightLogical)
-  <tr><td>*e1* : vec*N*&lt;i32&gt;<br>
-          *e2* : vec*N*&lt;u32&gt;<br>
-       <td class="nowrap">`e1 >> e2` : vec*N*&lt;i32&gt;
+  <tr algorithm="vector arithmetic shift right"><td>|e1| : vec|N|&lt;i32&gt;<br>
+          |e2| : vec|N|&lt;u32&gt;<br>
+       <td class="nowrap">|e1| `>>` |e2| : vec|N|&lt;i32&gt;
        <td>Component-wise arithmetic shift right (OpShiftRightArithmetic)
 </table>
 


### PR DESCRIPTION
- RHS of shift must be unsigned type
- number of bits to shift is the RHS modulo the component width
  of the LHS

Fixes #827
Fixes #828