### PR TITLE
Changing writeTexture validation

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4721,7 +4721,7 @@ GPUQueue includes GPUObjectBase;
                             - [$validating GPUTextureCopyView$](|destination|) returns true.
                             - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}}
                                 includes {{GPUTextureUsage/COPY_DST}}.
-                            - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} must be 1.
+                            - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is 1.
                             - [$validating linear texture data$](|dataLayout|,
                                 |data|.byteLength,
                                 |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}},

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4718,9 +4718,10 @@ GPUQueue includes GPUObjectBase;
                     - If any of the following conditions are unsatisfied,
                         generate a validation error and stop.
                         <div class=validusage>
-                            - |destination|.{{GPUTextureCopyView/texture}} is [=valid=].
+                            - [$validating GPUTextureCopyView$](|destination|) returns true.
                             - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}}
                                 includes {{GPUTextureUsage/COPY_DST}}.
+                            - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} must be 1.
                             - [$validating linear texture data$](|dataLayout|,
                                 |data|.byteLength,
                                 |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}},


### PR DESCRIPTION
These are changes in validation of writeTexture to make it match validation of copyBufferToTexture.

We should validate the whole texture copy view instead of only the texture inside it and also check the sampleCount of the texture.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ponitka/gpuweb/pull/916.html" title="Last updated on Jul 9, 2020, 8:24 AM UTC (31da6d5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/916/2dade02...ponitka:31da6d5.html" title="Last updated on Jul 9, 2020, 8:24 AM UTC (31da6d5)">Diff</a>