### PR TITLE
[wgsl] Rename kill to discard.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -548,6 +548,7 @@ Note: literals are parsed greedy. This means that for statements like `a -5`
   <tr><td>`CONTINUE`<td>continue
   <tr><td>`CONTINUING`<td>continuing
   <tr><td>`DEFAULT`<td>default
+  <tr><td>`DISCARD`<td>discard
   <tr><td>`ELSE`<td>else
   <tr><td>`ELSE_IF`<td>elseif
   <tr><td>`ENTRY_POINT`<td>entry_point
@@ -561,7 +562,6 @@ Note: literals are parsed greedy. This means that for statements like `a -5`
   <tr><td>`IMAGE`<td>image
   <tr><td>`IMPORT`<td>import
   <tr><td>`IN`<td>in
-  <tr><td>`KILL`<td>kill
   <tr><td>`LOCATION`<td>location
   <tr><td>`LOOP`<td>loop
   <tr><td>`OFFSET`<td>offset
@@ -1100,7 +1100,7 @@ statement
   | variable_stmt SEMICOLON
   | break_stmt SEMICOLON
   | continue_stmt SEMICOLON
-  | KILL SEMICOLON
+  | DISCARD SEMICOLON
   | assignment_stmt SEMICOLON
   | body_stmt
 </pre>
@@ -1194,7 +1194,8 @@ loop_stmt
 
 The loop construct causes a block of statements, the *loop body*, to execute repeatedly.
 
-This repetition can be interrupted by a [[#break-statement]], `return`, or `kill`.
+This repetition can be interrupted by a [[#break-statement]], `return`, or
+`discard`.
 
 Optionally, the last statement in the loop body may be a
 [[#continuing-statement]].
@@ -1457,7 +1458,7 @@ continuing_stmt:
 A *continuing* construct is a block of statements to be executed at the end of a loop iteration.
 The construct is optional.
 
-The block of statements must not contain a return or kill statement.
+The block of statements must not contain a return or discard statement.
 
 ## Expression statement ## {#expression-statement}
 <pre class='def'>


### PR DESCRIPTION
This CL updates the name of the kill command to be discard.

Fixes #911