### PR TITLE
Add a validation rule for multisample texture view dimension for BindGroupLayout

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2361,7 +2361,8 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
             1. Ensure [=storage buffer validation=] is not violated.
             1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `true`, ensure [=dynamic storage buffer validation=] is not violated.
         1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/sampled-texture}}
-            , ensure [=sampled texture validation=] is not violated.
+            1. Ensure [=sampled texture validation=] is not violated.
+            1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/multisampled}} is `true`, ensure [=multisample texture view dimension validation=] is not violated.
         1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/readonly-storage-texture}} or {{GPUBindingType/writeonly-storage-texture}}
             , ensure [=storage texture validation=] is not violated.
         1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/sampler}} or {{GPUBindingType/comparison-sampler}}
@@ -2399,6 +2400,8 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
 
         <dfn>sampled texture validation</dfn>: There must be {{GPULimits/maxSampledTexturesPerShaderStage|GPULimits.maxSampledTexturesPerShaderStage}} or
             fewer |bindingDescriptor|s of type {{GPUBindingType/sampled-texture}} visible on each shader stage in |descriptor|.
+
+        <dfn>multisample texture view dimension validation</dfn>: |bindingDescriptor|.{{GPUBindGroupLayoutEntry/viewDimension}} must be {{GPUTextureViewDimension/2d}} or `undefined`.
 
         <dfn>storage texture validation</dfn>: There must be {{GPULimits/maxStorageTexturesPerShaderStage|GPULimits.maxStorageTexturesPerShaderStage}} or
             fewer |bindingDescriptor|s of type {{GPUBindingType/readonly-storage-texture}} and {{GPUBindingType/writeonly-storage-texture}} visible on each shader stage in |descriptor|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2401,7 +2401,7 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
         <dfn>sampled texture validation</dfn>: There must be {{GPULimits/maxSampledTexturesPerShaderStage|GPULimits.maxSampledTexturesPerShaderStage}} or
             fewer |bindingDescriptor|s of type {{GPUBindingType/sampled-texture}} visible on each shader stage in |descriptor|.
 
-        <dfn>multisample texture view dimension validation</dfn>: |bindingDescriptor|.{{GPUBindGroupLayoutEntry/viewDimension}} must be {{GPUTextureViewDimension/2d}} or `undefined`.
+        <dfn>multisample texture view dimension validation</dfn>: |bindingDescriptor|.{{GPUBindGroupLayoutEntry/viewDimension}} must be {{GPUTextureViewDimension/2d}}.
 
         <dfn>storage texture validation</dfn>: There must be {{GPULimits/maxStorageTexturesPerShaderStage|GPULimits.maxStorageTexturesPerShaderStage}} or
             fewer |bindingDescriptor|s of type {{GPUBindingType/readonly-storage-texture}} and {{GPUBindingType/writeonly-storage-texture}} visible on each shader stage in |descriptor|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2323,6 +2323,8 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
     1. Ensure [=bind group layout device validation=] is not violated.
     1. Let |layout| be a new valid {{GPUBindGroupLayout}} object.
     1. For each {{GPUBindGroupLayoutEntry}} |bindingDescriptor| in |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
+        1. Issue: Add a step to bake the default values (e.g.
+             {{GPUBindGroupLayoutEntry/viewDimension}} to "2d") into the |bindingDescriptor|.
         1. Ensure |bindingDescriptor|.{{GPUBindGroupLayoutEntry/binding}} does not violate [=binding validation=].
         1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/visibility}}
             includes {{GPUShaderStage/VERTEX}},


### PR DESCRIPTION
I am pretty sure we can't support multisample for 1D, cube, cube-array, 3d texture view (which is specified in `viewDimension` in BindGroupLayout. So I added a validation rule for that. However, I am not 100% sure whether we can support multisampling for 2D array texture view, but I also said it is NOT supported in this validation rule. Please correct me if I made a mistake. 

PTAL. Thank you.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Richard-Yunchao/gpuweb/pull/924.html" title="Last updated on Jul 15, 2020, 5:17 PM UTC (de43e30)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/924/4c29179...Richard-Yunchao:de43e30.html" title="Last updated on Jul 15, 2020, 5:17 PM UTC (de43e30)">Diff</a>