### PR TITLE
Add a validation rule for storageTextureFormat in BGL

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2377,8 +2377,9 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
         1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/sampled-texture}}
             1. Ensure [=sampled texture validation=] is not violated.
             1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/multisampled}} is `true`, ensure [=multisample texture view dimension validation=] is not violated.
-        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/readonly-storage-texture}} or {{GPUBindingType/writeonly-storage-texture}}
-            , ensure [=storage texture validation=] is not violated.
+        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/readonly-storage-texture}} or {{GPUBindingType/writeonly-storage-texture}}:
+            1. Ensure [=storage texture validation=] is not violated.
+            1. Ensure [=storage texture format validation=] is not violated.
         1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/sampler}} or {{GPUBindingType/comparison-sampler}}
             , ensure [=sampler validation=] is not violated.
         1. Insert |bindingDescriptor| into |layout|.{{GPUBindGroupLayout/[[entryMap]]}}
@@ -2420,6 +2421,8 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
         <dfn>storage texture validation</dfn>: There must be {{GPULimits/maxStorageTexturesPerShaderStage|GPULimits.maxStorageTexturesPerShaderStage}} or
             fewer |bindingDescriptor|s of type {{GPUBindingType/readonly-storage-texture}} and {{GPUBindingType/writeonly-storage-texture}} visible on each shader stage in |descriptor|.
             |bindingDescriptor|.{{GPUBindGroupLayoutEntry/viewDimension}} must not be {{GPUTextureViewDimension/cube}} or {{GPUTextureViewDimension/cube-array}}.
+
+        <dfn>storage texture format validation</dfn>: |bindingDescriptor|.{{GPUBindGroupLayoutEntry/storageTextureFormat}} must be a format which can support storage usage.
 
         <dfn>sampler validation</dfn>: There must be {{GPULimits/maxSamplersPerShaderStage|GPULimits.maxSamplersPerShaderStage}} or
             fewer |bindingDescriptor|s of type {{GPUBindingType/sampler}} visible on each shader stage in |descriptor|.


### PR DESCRIPTION
storageTextureFormat in BindGroupLayout must be a format which can
support storage usage. Any other format is invalid.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Richard-Yunchao/gpuweb/pull/925.html" title="Last updated on Jul 21, 2020, 2:48 PM UTC (f68cff3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/925/3748677...Richard-Yunchao:f68cff3.html" title="Last updated on Jul 21, 2020, 2:48 PM UTC (f68cff3)">Diff</a>