### PR TITLE
Add examples of timeline boxes next to timeline definitions

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -446,6 +446,10 @@ has components working on different timelines in parallel:
 :: Associated with the execution of the Web script.
     It includes calling all methods described by this specification.
 
+    <div class=content-timeline>
+        Steps executed on the content timeline look like this.
+    </div>
+
 : <dfn dfn>Device timeline</dfn>
 :: Associated with the GPU device operations
     that are issued by the user agent.
@@ -454,10 +458,18 @@ has components working on different timelines in parallel:
     of view of the user agent part that controls the GPU,
     but can live in a separate OS process.
 
+    <div class=device-timeline>
+        Steps executed on the device timeline look like this.
+    </div>
+
 : <dfn dfn>Queue timeline</dfn>
 :: Associated with the execution of operations
     on the compute units of the GPU. It includes actual draw, copy,
     and compute jobs that run on the GPU.
+
+    <div class=queue-timeline>
+        Steps executed on the queue timeline look like this.
+    </div>
 
 In this specification, asynchronous operations are used when the result value
 depends on work that happens on any timeline other than the [=Content timeline=].


### PR DESCRIPTION
Just as a key/reference, and as a test of the three timeline box types.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/927.html" title="Last updated on Jul 15, 2020, 8:39 PM UTC (1bb8cbc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/927/fe1fcba...kainino0x:1bb8cbc.html" title="Last updated on Jul 15, 2020, 8:39 PM UTC (1bb8cbc)">Diff</a>