### PR TITLE
Don't use EnforceRange types for flags consts on interfaces

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1355,16 +1355,16 @@ dictionary GPUBufferDescriptor : GPUObjectDescriptorBase {
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUBufferUsageFlags;
 interface GPUBufferUsage {
-    const unsigned long MAP_READ      = 0x0001;
-    const unsigned long MAP_WRITE     = 0x0002;
-    const unsigned long COPY_SRC      = 0x0004;
-    const unsigned long COPY_DST      = 0x0008;
-    const unsigned long INDEX         = 0x0010;
-    const unsigned long VERTEX        = 0x0020;
-    const unsigned long UNIFORM       = 0x0040;
-    const unsigned long STORAGE       = 0x0080;
-    const unsigned long INDIRECT      = 0x0100;
-    const unsigned long QUERY_RESOLVE = 0x0200;
+    const GPUFlagsConstant MAP_READ      = 0x0001;
+    const GPUFlagsConstant MAP_WRITE     = 0x0002;
+    const GPUFlagsConstant COPY_SRC      = 0x0004;
+    const GPUFlagsConstant COPY_DST      = 0x0008;
+    const GPUFlagsConstant INDEX         = 0x0010;
+    const GPUFlagsConstant VERTEX        = 0x0020;
+    const GPUFlagsConstant UNIFORM       = 0x0040;
+    const GPUFlagsConstant STORAGE       = 0x0080;
+    const GPUFlagsConstant INDIRECT      = 0x0100;
+    const GPUFlagsConstant QUERY_RESOLVE = 0x0200;
 };
 </script>
 
@@ -1468,8 +1468,8 @@ Issue(gpuweb/gpuweb#605): Add client-side validation that a mapped buffer can
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUMapModeFlags;
 interface GPUMapMode {
-    const unsigned long READ  = 0x0001;
-    const unsigned long WRITE = 0x0002;
+    const GPUFlagsConstant READ  = 0x0001;
+    const GPUFlagsConstant WRITE = 0x0002;
 };
 </script>
 
@@ -1696,11 +1696,11 @@ enum GPUTextureDimension {
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUTextureUsageFlags;
 interface GPUTextureUsage {
-    const unsigned long COPY_SRC          = 0x01;
-    const unsigned long COPY_DST          = 0x02;
-    const unsigned long SAMPLED           = 0x04;
-    const unsigned long STORAGE           = 0x08;
-    const unsigned long OUTPUT_ATTACHMENT = 0x10;
+    const GPUFlagsConstant COPY_SRC          = 0x01;
+    const GPUFlagsConstant COPY_DST          = 0x02;
+    const GPUFlagsConstant SAMPLED           = 0x04;
+    const GPUFlagsConstant STORAGE           = 0x08;
+    const GPUFlagsConstant OUTPUT_ATTACHMENT = 0x10;
 };
 </script>
 
@@ -2277,9 +2277,9 @@ with `MTLArgumentBuffer` objects that are more efficient to bind at run-time.
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUShaderStageFlags;
 interface GPUShaderStage {
-    const unsigned long VERTEX   = 0x1;
-    const unsigned long FRAGMENT = 0x2;
-    const unsigned long COMPUTE  = 0x4;
+    const GPUFlagsConstant VERTEX   = 0x1;
+    const GPUFlagsConstant FRAGMENT = 0x2;
+    const GPUFlagsConstant COMPUTE  = 0x4;
 };
 </script>
 
@@ -3295,11 +3295,11 @@ dictionary GPUColorStateDescriptor {
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUColorWriteFlags;
 interface GPUColorWrite {
-    const unsigned long RED   = 0x1;
-    const unsigned long GREEN = 0x2;
-    const unsigned long BLUE  = 0x4;
-    const unsigned long ALPHA = 0x8;
-    const unsigned long ALL   = 0xF;
+    const GPUFlagsConstant RED   = 0x1;
+    const GPUFlagsConstant GREEN = 0x2;
+    const GPUFlagsConstant BLUE  = 0x4;
+    const GPUFlagsConstant ALPHA = 0x8;
+    const GPUFlagsConstant ALL   = 0xF;
 };
 </script>
 
@@ -5311,6 +5311,8 @@ typedef [EnforceRange] unsigned long GPUIntegerCoordinate;
 typedef [EnforceRange] unsigned long GPUIndex32;
 typedef [EnforceRange] unsigned long GPUSize32;
 typedef [EnforceRange] long GPUSignedOffset32;
+
+typedef unsigned long GPUFlagsConstant;
 </script>
 
 ## Colors &amp; Vectors ## {#colors-and-vectors}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1355,16 +1355,16 @@ dictionary GPUBufferDescriptor : GPUObjectDescriptorBase {
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUBufferUsageFlags;
 interface GPUBufferUsage {
-    const GPUBufferUsageFlags MAP_READ      = 0x0001;
-    const GPUBufferUsageFlags MAP_WRITE     = 0x0002;
-    const GPUBufferUsageFlags COPY_SRC      = 0x0004;
-    const GPUBufferUsageFlags COPY_DST      = 0x0008;
-    const GPUBufferUsageFlags INDEX         = 0x0010;
-    const GPUBufferUsageFlags VERTEX        = 0x0020;
-    const GPUBufferUsageFlags UNIFORM       = 0x0040;
-    const GPUBufferUsageFlags STORAGE       = 0x0080;
-    const GPUBufferUsageFlags INDIRECT      = 0x0100;
-    const GPUBufferUsageFlags QUERY_RESOLVE = 0x0200;
+    const unsigned long MAP_READ      = 0x0001;
+    const unsigned long MAP_WRITE     = 0x0002;
+    const unsigned long COPY_SRC      = 0x0004;
+    const unsigned long COPY_DST      = 0x0008;
+    const unsigned long INDEX         = 0x0010;
+    const unsigned long VERTEX        = 0x0020;
+    const unsigned long UNIFORM       = 0x0040;
+    const unsigned long STORAGE       = 0x0080;
+    const unsigned long INDIRECT      = 0x0100;
+    const unsigned long QUERY_RESOLVE = 0x0200;
 };
 </script>
 
@@ -1468,8 +1468,8 @@ Issue(gpuweb/gpuweb#605): Add client-side validation that a mapped buffer can
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUMapModeFlags;
 interface GPUMapMode {
-    const GPUMapModeFlags READ  = 0x0001;
-    const GPUMapModeFlags WRITE = 0x0002;
+    const unsigned long READ  = 0x0001;
+    const unsigned long WRITE = 0x0002;
 };
 </script>
 
@@ -1696,11 +1696,11 @@ enum GPUTextureDimension {
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUTextureUsageFlags;
 interface GPUTextureUsage {
-    const GPUTextureUsageFlags COPY_SRC          = 0x01;
-    const GPUTextureUsageFlags COPY_DST          = 0x02;
-    const GPUTextureUsageFlags SAMPLED           = 0x04;
-    const GPUTextureUsageFlags STORAGE           = 0x08;
-    const GPUTextureUsageFlags OUTPUT_ATTACHMENT = 0x10;
+    const unsigned long COPY_SRC          = 0x01;
+    const unsigned long COPY_DST          = 0x02;
+    const unsigned long SAMPLED           = 0x04;
+    const unsigned long STORAGE           = 0x08;
+    const unsigned long OUTPUT_ATTACHMENT = 0x10;
 };
 </script>
 
@@ -2277,9 +2277,9 @@ with `MTLArgumentBuffer` objects that are more efficient to bind at run-time.
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUShaderStageFlags;
 interface GPUShaderStage {
-    const GPUShaderStageFlags VERTEX   = 0x1;
-    const GPUShaderStageFlags FRAGMENT = 0x2;
-    const GPUShaderStageFlags COMPUTE  = 0x4;
+    const unsigned long VERTEX   = 0x1;
+    const unsigned long FRAGMENT = 0x2;
+    const unsigned long COMPUTE  = 0x4;
 };
 </script>
 
@@ -3295,11 +3295,11 @@ dictionary GPUColorStateDescriptor {
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUColorWriteFlags;
 interface GPUColorWrite {
-    const GPUColorWriteFlags RED   = 0x1;
-    const GPUColorWriteFlags GREEN = 0x2;
-    const GPUColorWriteFlags BLUE  = 0x4;
-    const GPUColorWriteFlags ALPHA = 0x8;
-    const GPUColorWriteFlags ALL   = 0xF;
+    const unsigned long RED   = 0x1;
+    const unsigned long GREEN = 0x2;
+    const unsigned long BLUE  = 0x4;
+    const unsigned long ALPHA = 0x8;
+    const unsigned long ALL   = 0xF;
 };
 </script>
 


### PR DESCRIPTION
This is an "output" field, where (at least in principle), EnforceRange is not allowed.

While I don't think WebIDL ever officially added this requirement, it is almost certainly supposed to be there. And apparently Chromium's IDL generators enforce it.

Issue: #549


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/928.html" title="Last updated on Jul 20, 2020, 11:09 PM UTC (19437b2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/928/184f68b...kainino0x:19437b2.html" title="Last updated on Jul 20, 2020, 11:09 PM UTC (19437b2)">Diff</a>