### PR TITLE
Make getMappedRange() return the whole mapped range.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1507,7 +1507,7 @@ interface GPUMapMode {
         1. Set the content of |m| to the content of |this|'s allocation starting at offset |offset| and for |size| bytes.
         1. Set |this|.{{[[mapping]]}} to |m|.
         1. Set |this|.{{GPUBuffer/[[state]]}} to [=buffer state/mapped=].
-        1. Set |this|.{{[[mapping_range]]}} to `[offset, offset + size]`.
+        1. Set |this|.{{[[mapping_range]]}} to `[offset, size]`.
         1. Set |this|.{{[[mapped_ranges]]}} to `[]`.
         1. Resolve |p|.
 
@@ -1545,11 +1545,15 @@ interface GPUMapMode {
 
   **Returns:** {{ArrayBuffer}}
 
+  1. If |size| is 0 and |offset| is less than or equal to |this|.{{[[mapping_range]]}}[1]:
+
+    1. Set |size| to |this|.{{[[mapping_range]]}}[1] - |offset|.
+
   1. If this call doesn't follow the [$getMappedRange Valid Usage$]:
 
     1. Throw an {{OperationError}}.
 
-  1. Let |m| be a new {{ArrayBuffer}} of size |size| pointing at the content of |this|.{{[[mapping]]}} at offset |offset| - |this|.{{[[mapping_range]]}}[0].
+  1. Let |m| be a new {{ArrayBuffer}} of size |size| pointing at the content of |this|.{{[[mapping]]}} at offset |offset| + |this|.{{[[mapping_range]]}}[0].
   1. Append |m| to |this|.{{[[mapped_ranges]]}}.
   1. Return |m|.
 
@@ -1562,7 +1566,6 @@ interface GPUMapMode {
       1. |this|.{{GPUBuffer/[[state]]}} must be [=buffer state/mapped=] or [=buffer state/mapped at creation=].
       1. |offset| must be a multiple of 8.
       1. |size| must be a multiple of 4.
-      1. |offset| must be greater than or equal to |this|.{{[[mapping_range]]}}[0].
       1. |offset| + |size| must be less than or equal to |this|.{{[[mapping_range]]}}[1].
       1. [|offset|, |offset| + |size|) must not overlap another range in |this|.{{[[mapped_ranges]]}}.
 


### PR DESCRIPTION
Previously the following code would throw an `OperationError` because
the offset was less than the mapped range's offset:

```
// buffer is a 12 byte map readable buffer.
await buffer.mapAsync(GPUMapMode.Read, 4, 4);
const data = buffer.getMappedRange();
```

By changing the offset to be relative to the mapped range, and making
the default size to cover the rest of the range, the code above returns
an `ArrayBuffer` for bytes [4, 8) of the buffer.

+CC @kunalmohan 