### PR TITLE
Add array stride

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -124,19 +124,60 @@ A vector type is a <dfn dfn>numeric vector</dfn> type if its component type is a
 </div>
 
 ## Array Types ## {#array-types}
+
+An array is an indexable sequence of values of elements of some other type.
+The first element is always at index 0.
+
+An array type is either sized or unsized.
+
 <table class='data'>
   <thead>
     <tr><td>Type<td>Description
   </thead>
   <tr><td>array<*E*,*N*><td>An *N*-element array of elements of type *E*.<br>
   <tr><td>array<*E*><td>A runtime-sized array of elements of type *E*,
-                       also known as a runtime array.
+                       also known as an unsized array.
                        These may only appear in specific contexts.<br>
 </table>
 
-Issue: (dneto): Complete description of `Array<E,N>`
+A sized array type is parameterized by its element type and by the number of
+elements in the array, which must be a positive integer literal value.
+The last valid array index is one less than the number of elements in the array.
 
-Issue: (dneto): the last element of a struct defining the contents of a storage buffer.
+<div class='example' heading='Sized array'>
+  <xmp>
+    // Declare a variable that is an array of five elements,
+    // where each element is an i32 value.
+    // The first valid index is 0.  The last valid index is 4.
+    var params : array<i32,5>;
+
+    const first_param : i32 = param[0];  // Read the first element.
+    param[4] = 12;  // Write the last element.
+  </xmp>
+</div>
+
+An unsized array type is only parameterized by its element type.
+Unsized arrays may only be used in specific contexts.
+
+A host-shareable array must have a host-shareable element type, and must
+have explicitly declared layout, via the *stride* attribute.
+The *stride* of a host-shareable array is the number of bytes
+from the start of one element to the start of the next.  The stride
+must be at least as large as the layout size of the element, and
+must be a multiple of the element alignment requirement.
+Other factors may also constrain stride.
+
+<div class='example' heading='Sized and unsized arrays with strides'>
+  <xmp>
+    // Declare a type alias for an array of 12 elements, where each element is
+    // an u32 value.  There are sixteen bytes between successive elements.
+    type Params = [[stride 16]] array<u32,12>;
+
+    // Declare a type alias for an unsized array, where each element is
+    // an f32 value.  There are four bytes between successive elements.
+    type MeasurementsArray = [[stride 4]] array<f32>;
+  </xmp>
+</div>
 
 ## Structure Types ## {#struct-types}
 <table class='data'>
@@ -676,6 +717,7 @@ Note: literals are parsed greedy. This means that for statements like `a -5`
   <tr><td>`MAT4x3`<td>mat4x3  # column x row
   <tr><td>`MAT4x4`<td>mat4x4  # column x row
   <tr><td>`POINTER`<td>ptr
+  <tr><td>`STRIDE`<td>stride
   <tr><td>`SAMPLER`<td>sampler
   <tr><td>`SAMPLER_COMPARISON`<td>sampler_comparison
   <tr><td>`STRUCT`<td>struct
@@ -1195,6 +1237,7 @@ variable_storage_decoration:
 <pre class='def'>
 type_alias
   : TYPE IDENT EQUAL type_decl
+  | TYPE IDENT EQUAL decorated_array_decl
   | TYPE IDENT EQUAL struct_decl
 </pre>
 
@@ -1229,9 +1272,8 @@ type_decl
   | VEC2 LESS_THAN type_decl GREATER_THAN
   | VEC3 LESS_THAN type_decl GREATER_THAN
   | VEC4 LESS_THAN type_decl GREATER_THAN
+  | array_decl
   | PTR LESS_THAN storage_class, type_decl GREATER_THAN
-  | ARRAY LESS_THAN type_decl COMMA INT_LITERAL GREATER_THAN
-  | ARRAY LESS_THAN type_decl GREATER_THAN
   | MAT2x2 LESS_THAN type_decl GREATER_THAN
   | MAT2x3 LESS_THAN type_decl GREATER_THAN
   | MAT2x4 LESS_THAN type_decl GREATER_THAN
@@ -1308,6 +1350,20 @@ storage_class
   <tr><td>private<td>Private
   <tr><td>function<td>Function
 </table>
+
+## Arrays ## {#arrays}
+
+<pre class='def'>
+decorated_array_decl
+  : ATTR_LEFT array_decoration ATTR_RIGHT array_decl
+
+array_decl
+  | ARRAY LESS_THAN type_decl COMMA INT_LITERAL GREATER_THAN
+  | ARRAY LESS_THAN type_decl GREATER_THAN
+
+array_decoration
+  | STRIDE INT_LITERAL
+</pre>
 
 ## Structures ## {#structures}
 


### PR DESCRIPTION
Array stride is an attribute that can be declared on an alias
declaration of an array type.

Fixes #773