### PR TITLE
Limit for the sample count mask

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1129,6 +1129,7 @@ dictionary GPULimits {
     GPUSize32 maxUniformBuffersPerShaderStage = 12;
     GPUSize32 maxUniformBufferBindingSize = 16384;
     GPUSize64 sampleCountMask = 5;
+    GPUSize64 maxTexelBlockSize = 64;
 };
 </script>
 
@@ -1248,6 +1249,13 @@ dictionary GPULimits {
         The default limit supports MSAA levels of 4 and 1 (non-multisampled), resulting in the mask value of 5.
 
         One mask is [=better=] than the other if it fully includes it.
+    : <dfn>maxTexelBlockSize</dfn>
+    ::
+        Maximum size of a texel block that a texture can have.
+        In a multi-sampled texture, the texel block size is
+        the size of a format &times; the number of samples.
+
+        Higher is [=better=].
 </dl>
 
 ## <dfn interface>GPUDevice</dfn> ## {#gpu-device}
@@ -1853,6 +1861,7 @@ interface GPUTextureUsage {
             **Returns:** {{GPUTexture}}
 
             Issue: Describe {{GPUDevice/createTexture()}} algorithm steps.
+            Issue: Take the `sampleCountMask` and `maxTexelBlockSize` into account.
         </div>
 </dl>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1128,6 +1128,7 @@ dictionary GPULimits {
     GPUSize32 maxStorageTexturesPerShaderStage = 4;
     GPUSize32 maxUniformBuffersPerShaderStage = 12;
     GPUSize32 maxUniformBufferBindingSize = 16384;
+    GPUSize64 sampleCountMask = 5;
 };
 </script>
 
@@ -1235,6 +1236,18 @@ dictionary GPULimits {
         The maximum {{GPUBufferBinding}}.{{GPUBufferBinding/size}} for bindings of type {{GPUBindingType/uniform-buffer}}.
 
         Higher is [=better=].
+
+    : <dfn>sampleCountMask</dfn>
+    ::
+        The mask of supported values for {{GPUTextureDescriptor/sampleCount}},
+        {{GPURenderPipelineDescriptor/sampleCount}}, and {{GPURenderBundleEncoderDescriptor/sampleCount}}.
+
+        In each of these uses, the sample count is a power of two, and the relevant bit needs to be
+        included in this mask for valid usage.
+
+        The default limit supports MSAA levels of 4 and 1 (non-multisampled), resulting in the mask value of 5.
+
+        One mask is [=better=] than the other if it fully includes it.
 </dl>
 
 ## <dfn interface>GPUDevice</dfn> ## {#gpu-device}
@@ -3538,6 +3551,7 @@ Issue: link to the semantics of SV_SampleIndex and SV_Coverage in WGSL spec.
                                     |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
                             - |descriptor|.{{GPURenderPipelineDescriptor/colorStates}}.length is less than
                                 or equal to 4.
+                            - |descriptor|.{{GPURenderPipelineDescriptor/sampleCount}} is not included in {{GPULimits/sampleCountMask|GPULimits.sampleCountMask}}.
                             - [$validating GPUVertexStateDescriptor$](|descriptor|.{{GPURenderPipelineDescriptor/vertexState}},
                                 |descriptor|.{{GPURenderPipelineDescriptor/vertexStage}}) passes.
                             - If |descriptor|.{{GPURenderPipelineDescriptor/alphaToCoverageEnabled}} is `true`:


### PR DESCRIPTION
Related to the investigation in #108
We know that we can universally support MSAA x4, but we'd want to use higher levels if available, too.
This shouldn't be a portability concern, since most applications are written to support various sample counts, so they can trivially adjust to platforms that have different mask than the developers machine.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/932.html" title="Last updated on Sep 1, 2020, 4:01 AM UTC (f8726d9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/932/999510e...kvark:f8726d9.html" title="Last updated on Sep 1, 2020, 4:01 AM UTC (f8726d9)">Diff</a>