### PR TITLE
Move GPUStencilOperation to the correct section

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3353,19 +3353,6 @@ enum GPUBlendOperation {
 };
 </script>
 
-<script type=idl>
-enum GPUStencilOperation {
-    "keep",
-    "zero",
-    "replace",
-    "invert",
-    "increment-clamp",
-    "decrement-clamp",
-    "increment-wrap",
-    "decrement-wrap"
-};
-</script>
-
 ### Depth/Stencil State ### {#depth-stencil-state}
 
 <script type=idl>
@@ -3389,6 +3376,19 @@ dictionary GPUStencilStateFaceDescriptor {
     GPUStencilOperation failOp = "keep";
     GPUStencilOperation depthFailOp = "keep";
     GPUStencilOperation passOp = "keep";
+};
+</script>
+
+<script type=idl>
+enum GPUStencilOperation {
+    "keep",
+    "zero",
+    "replace",
+    "invert",
+    "increment-clamp",
+    "decrement-clamp",
+    "increment-wrap",
+    "decrement-wrap"
 };
 </script>
 


### PR DESCRIPTION
Moving GPUStencilOperation from 10.3.9.1. Blend State to 10.3.10. Depth/Stencil State


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ponitka/gpuweb/pull/934.html" title="Last updated on Jul 20, 2020, 1:37 PM UTC (e53834d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/934/07a594b...ponitka:e53834d.html" title="Last updated on Jul 20, 2020, 1:37 PM UTC (e53834d)">Diff</a>