### PR TITLE
Precisely define depth24plus as "either depth24unorm or depth32float"

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1916,14 +1916,17 @@ enum GPUTextureFormat {
 };
 </script>
 
-  * The `depth24plus` family of formats ({{GPUTextureFormat/depth24plus}} and
-    {{GPUTextureFormat/depth24plus-stencil8}})
-    must have a depth-component precision of
-    1 ULP &le; 1 / (2<sup>24</sup>).
+The depth aspect of the `depth24plus` family of formats
+({{GPUTextureFormat/depth24plus}} and {{GPUTextureFormat/depth24plus-stencil8}})
+may be implemented as either a 24-bit unsigned normalized value ("depth24unorm")
+or a 32-bit IEEE 754 floating point value ("depth32float").
 
-    Note: This is unlike the 24-bit unsigned normalized format family typically
-    found in native APIs, which has a precision of
-    1 ULP = 1 / (2<sup>24</sup> &minus; 1).
+Note:
+While the precision of depth32float is strictly higher than the precision of
+depth24unorm for all values in the representable range (0.0 to 1.0),
+note that the set of representable values is not exactly the same:
+for depth24unorm, 1 ULP has a constant value of 1 / (2<sup>24</sup> &minus; 1);
+for depth32float, 1 ULP has a variable value no greater than 1 / (2<sup>24</sup>).
 
 <script type=idl>
 enum GPUTextureComponentType {
@@ -5080,7 +5083,7 @@ GPUQueue includes GPUObjectBase;
 
         - {{GPUQueue/copyImageBitmapToTexture(source, destination, copySize)/copySize}}.[=Extent3D/depth=] must be `1`.
         - {{GPUQueue/copyImageBitmapToTexture(source, destination, copySize)/destination}}.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} must be one of the following:
-             - {{GPUTextureFormat/"rgba8unorm"}} 
+             - {{GPUTextureFormat/"rgba8unorm"}}
              - {{GPUTextureFormat/"rgba8unorm-srgb"}}
              - {{GPUTextureFormat/"bgra8unorm"}}
              - {{GPUTextureFormat/"bgra8unorm-srgb"}}


### PR DESCRIPTION
and fix an error in the precision calculations I added a long time ago.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/938.html" title="Last updated on Jul 20, 2020, 11:01 PM UTC (432db8b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/938/184f68b...kainino0x:432db8b.html" title="Last updated on Jul 20, 2020, 11:01 PM UTC (432db8b)">Diff</a>