### PR TITLE
Add indexFormat to setIndexBuffer

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4491,7 +4491,7 @@ called the compute pass encoder can no longer be used.
 interface mixin GPURenderEncoderBase {
     void setPipeline(GPURenderPipeline pipeline);
 
-    void setIndexBuffer(GPUBuffer buffer, optional GPUSize64 offset = 0, optional GPUSize64 size = 0);
+    void setIndexBuffer(GPUBuffer buffer, GPUIndexFormat indexFormat, optional GPUSize64 offset = 0, optional GPUSize64 size = 0);
     void setVertexBuffer(GPUIndex32 slot, GPUBuffer buffer, optional GPUSize64 offset = 0, optional GPUSize64 size = 0);
 
     void draw(GPUSize32 vertexCount, optional GPUSize32 instanceCount = 1,


### PR DESCRIPTION
Now that indexFormat isn't allowed except for strip topologies (#940), the indexFormat is required at setIndexBuffer (as agreed upon).

Issue: #767


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/943.html" title="Last updated on Jul 22, 2020, 6:02 PM UTC (214bad4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/943/88df2a2...kainino0x:214bad4.html" title="Last updated on Jul 22, 2020, 6:02 PM UTC (214bad4)">Diff</a>