### PR TITLE
Remove num_workgroups builtin variable

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1146,9 +1146,6 @@ variable_decoration
     [[builtin frag_depth]]
           OpDecorate %gl_FragDepth BuiltIn FragDepth
 
-    [[builtin num_workgroups]]
-          OpDecorate %gl_NumWorkGroups BuiltIn NumWorkgroups
-
     [[builtin local_invocation_id]]
           OpDecorate %gl_LocalInvocationID BuiltIn LocalInvocationId
 
@@ -1173,7 +1170,6 @@ type, function decorations and storage class.
     <tr><td>front_facing<td>bool<td>Fragment Input
     <tr><td>frag_coord<td>vec4&ltf32&gt<td>Fragment Input
     <tr><td>frag_depth<td>f32<td>Fragment Output
-    <tr><td>num_workgroups<td>vec3&ltu32&gt<td>Compute Input
     <tr><td>local_invocation_id<td>vec3&ltu32&gt<td>Compute Input
     <tr><td>global_invocation_id<td>vec3&ltu32&gt<td>Compute Input
     <tr><td>local_invocation_idx<td>u32<td>Compute Input


### PR DESCRIPTION
Fixes #920

There's no simple translation into HLSL, so the feature has
been removed from WebGPU MVP.