### PR TITLE
Use out-of-band messaging for the mipmap and array layer count

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1787,10 +1787,10 @@ internal slots of a [=texture=] internal object once we have one.
         defaults to {{GPUTextureViewDimension/"3d"}}.
 
   * {{GPUTextureViewDescriptor/mipLevelCount}}:
-    If undefined or "null", defaults to |texture|.{{GPUTextureDescriptor/mipLevelCount}} &minus; {{GPUTextureViewDescriptor/baseMipLevel}}.
+    If undefined, defaults to |texture|.{{GPUTextureDescriptor/mipLevelCount}} &minus; {{GPUTextureViewDescriptor/baseMipLevel}}.
 
   * {{GPUTextureViewDescriptor/arrayLayerCount}}:
-    If undefined or "null", defaults to |texture|.{{GPUTextureDescriptor/size}}.[=Extent3D/depth=] &minus; {{GPUTextureViewDescriptor/baseArrayLayer}}.
+    If undefined, defaults to |texture|.{{GPUTextureDescriptor/size}}.[=Extent3D/depth=] &minus; {{GPUTextureViewDescriptor/baseArrayLayer}}.
 
 </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1758,9 +1758,9 @@ dictionary GPUTextureViewDescriptor : GPUObjectDescriptorBase {
     GPUTextureViewDimension dimension;
     GPUTextureAspect aspect = "all";
     GPUIntegerCoordinate baseMipLevel = 0;
-    GPUIntegerCoordinate? mipLevelCount;
+    GPUIntegerCoordinate mipLevelCount;
     GPUIntegerCoordinate baseArrayLayer = 0;
-    GPUIntegerCoordinate? arrayLayerCount;
+    GPUIntegerCoordinate arrayLayerCount;
 };
 </script>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1758,9 +1758,9 @@ dictionary GPUTextureViewDescriptor : GPUObjectDescriptorBase {
     GPUTextureViewDimension dimension;
     GPUTextureAspect aspect = "all";
     GPUIntegerCoordinate baseMipLevel = 0;
-    GPUIntegerCoordinate mipLevelCount = 0;
+    GPUIntegerCoordinate? mipLevelCount;
     GPUIntegerCoordinate baseArrayLayer = 0;
-    GPUIntegerCoordinate arrayLayerCount = 0;
+    GPUIntegerCoordinate? arrayLayerCount;
 };
 </script>
 
@@ -1787,10 +1787,10 @@ internal slots of a [=texture=] internal object once we have one.
         defaults to {{GPUTextureViewDimension/"3d"}}.
 
   * {{GPUTextureViewDescriptor/mipLevelCount}}:
-    If 0, defaults to |texture|.{{GPUTextureDescriptor/mipLevelCount}} &minus; {{GPUTextureViewDescriptor/baseMipLevel}}.
+    If undefined or "null", defaults to |texture|.{{GPUTextureDescriptor/mipLevelCount}} &minus; {{GPUTextureViewDescriptor/baseMipLevel}}.
 
   * {{GPUTextureViewDescriptor/arrayLayerCount}}:
-    If 0, defaults to |texture|.{{GPUTextureDescriptor/size}}.[=Extent3D/depth=] &minus; {{GPUTextureViewDescriptor/baseArrayLayer}}.
+    If undefined or "null", defaults to |texture|.{{GPUTextureDescriptor/size}}.[=Extent3D/depth=] &minus; {{GPUTextureViewDescriptor/baseArrayLayer}}.
 
 </div>
 


### PR DESCRIPTION
This is in line with the changes we are doing for `minBufferBindingSize` and other sizes.

I don't like the "if xxx, defaults to yyy" scheme of things, since it's not clear how "defaults to" works in this case. This PR keeps this, but would be nice to refactor this later in follow-ups.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/945.html" title="Last updated on Jul 27, 2020, 9:11 PM UTC (0086450)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/945/bbaf154...0086450.html" title="Last updated on Jul 27, 2020, 9:11 PM UTC (0086450)">Diff</a>