### PR TITLE
Reorganize built-in functions into own section

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2704,17 +2704,19 @@ the contents of the existing table.
   <tr><td>any(BoolVec) -&gt; bool<td>OpAny
   <tr><td>select(*T*,*T*,bool) -&gt; *T*<td>
        For scalar or vector type *T*.
-       `select(a,b,c)` evaluates to *a* when *c* is true, and *b* otherwise.
+       `select(a,b,c)` evaluates to *a* when *c* is true, and *b* otherwise.<br>
+       OpSelect
   <tr><td>select(vec*N*&lt;*T*&gt;,vec*N*&lt;*T*&gt;,vec*N*&lt;bool&gt;) -&gt; vec*N*&lt;*T*&gt;<td>
        For scalar type *T*.
-       `select(a,b,c)` evaluates to a vector with component *i* being `select(a[i], b[i], c[i])`.
+       `select(a,b,c)` evaluates to a vector with component *i* being `select(a[i], b[i], c[i])`.<br>
+       OpSelect
 </table>
 
 ## Value-testing built-in functions ## {#value-testing-builtin-functions}
 
 <table class='data'>
   <thead>
-    <tr><td>Logical built-in functions<td>SPIR-V
+    <tr><td>Value-testing built-in functions<td>SPIR-V
   </thead>
   <tr><td>is_finite(float) -&gt; bool<td>OpIsFinite
   <tr><td>is_inf(float) -&gt; bool<td>OpIsInf
@@ -2726,10 +2728,10 @@ the contents of the existing table.
 
 <table class='data'>
   <thead>
-    <tr><td>Built-in<td>SPIR-V
+    <tr><td>Vector built-in functions<td>SPIR-V
   </thead>
-  <tr><td>dot(vecN<f32>, vecN<f32>) -&gt; float<td>OpDot
-  <tr><td>outer_product(vecN<f32>, vecM<f32>) -&gt; matNxM<f32><td>OpOuterProduct
+  <tr><td>dot(vecN&lt;f32&gt;, vecN&lt;f32&gt;) -&gt; float<td>OpDot
+  <tr><td>outer_product(vecN&lt;f32&gt;, vecM&lt;f32&gt;) -&gt; matNxM&lt;f32&gt;<td>OpOuterProduct
 </table>
 
 ## Derivative built-in functions ## {#derivative-builtin-functions}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1403,37 +1403,6 @@ param_list
   </xmp>
 </div>
 
-### Builtin Functions ### {#builtin-functions}
-
-<table class='data'>
-  <thead>
-    <tr><td>Builtins<td>SPIR-V
-  </thead>
-  <tr><td>dpdx(IDENT) -&gt; float<td>OpDPdx
-  <tr><td>dpdx_coarse(IDENT) -&gt; float<td>OpDPdxCoarse
-  <tr><td>dpdx_fine(IDENT) -&gt; float<td>OpDPdxFine
-  <tr><td>dpdy(IDENT) -&gt; float<td>OpDPdy
-  <tr><td>dpdy_coarse(IDENT) -&gt; float<td>OpDPdyCoarse
-  <tr><td>dpdy_fine(IDENT) -&gt; float<td>OpDPdyFine
-  <tr><td>fwidth(IDENT) -&gt; float<td>OpFwidth
-  <tr><td>fwidth_coarse(IDENT) -&gt; float<td>OpFwidthCoarse
-  <tr><td>fwidth_fine(IDENT) -&gt; float<td>OpFwidthFine
-
-  <tr><td>all(BoolVec) -&gt; bool<td>OpAll
-  <tr><td>any(BoolVec) -&gt; bool<td>OpAny
-  <tr><td>is_finite(float) -&gt; bool<td>OpIsFinite
-  <tr><td>is_inf(float) -&gt; bool<td>OpIsInf
-  <tr><td>is_nan(float) -&gt; bool<td>OpIsNan
-  <tr><td>is_normal(float) -&gt; bool<td>OpIsNormal
-  <tr><td>dot(vecN<f32>, vecN<f32>) -&gt; float<td>OpDot
-  <tr><td>outer_product(vecN<f32>, vecM<f32>) -&gt; matNxM<f32><td>OpOuterProduct
-  <tr><td>select(*T*,*T*,bool) -&gt; *T*<td>
-       For scalar or vector type *T*.
-       `select(a,b,c)` evaluates to *a* when *c* is true, and *b* otherwise.
-  <tr><td>select(vec*N*&lt;*T*&gt;,vec*N*&lt;*T*&gt;,vec*N*&lt;bool&gt;) -&gt; vec*N*&lt;*T*&gt;<td>
-       For scalar type *T*.
-       `select(a,b,c)` evaluates to a vector with component *i* being `select(a[i], b[i], c[i])`.
-</table>
 
 ## Entry Points ## {#entry-points}
 The `entry_point` declares an entry point into the module. The entry points may
@@ -2701,6 +2670,83 @@ Issue: (dneto): Bitwise-complement is under discussion.  https://github.com/gpuw
     Logical "and". Evaluates both `e1` and `e2`; yields `true` if both are `true`.
   <tr><td>*e1* : *T*<br>*e2* : *T*<br>*T* is *BoolVec*<td>`e1 | e2` : *T*<td>Component-wise logical "or"
   <tr><td>*e1* : *T*<br>*e2* : *T*<br>*T* is *BoolVec*<td>`e1 & e2` : *T*<td>Component-wise logical "and"
+</table>
+
+# Built-in functions # {#builtin-functions}
+
+Certain functions are always available in a [SHORTNAME] program,
+and are provided by the implementation.
+These are called *built-in functions*.
+
+Since a built-in function is always in scope, it is an error to attempt to redefine
+one or to use the name of a built-in function as an identifier for any other
+kind of declaration.
+
+Unlike ordinary functions defined in a [SHORTNAME] program,
+a built-in function may use the same function name with different
+sets of parameters.
+In other words, a built-in function may have more than one *overload*,
+but ordinary function definitions in [SHORTNAME] may not.
+
+When calling a built-in function, all arguments to the function are evaluated
+before function evaulation begins.
+
+TODO(dneto): Elaborate the descriptions of the built-in functions.  So far I've only reorganized
+the contents of the existing table.
+
+## Logical built-in functions ## {#logical-builtin-functions}
+
+<table class='data'>
+  <thead>
+    <tr><td>Logical built-in functions<td>SPIR-V
+  </thead>
+  <tr><td>all(BoolVec) -&gt; bool<td>OpAll
+  <tr><td>any(BoolVec) -&gt; bool<td>OpAny
+  <tr><td>select(*T*,*T*,bool) -&gt; *T*<td>
+       For scalar or vector type *T*.
+       `select(a,b,c)` evaluates to *a* when *c* is true, and *b* otherwise.
+  <tr><td>select(vec*N*&lt;*T*&gt;,vec*N*&lt;*T*&gt;,vec*N*&lt;bool&gt;) -&gt; vec*N*&lt;*T*&gt;<td>
+       For scalar type *T*.
+       `select(a,b,c)` evaluates to a vector with component *i* being `select(a[i], b[i], c[i])`.
+</table>
+
+## Value-testing built-in functions ## {#value-testing-builtin-functions}
+
+<table class='data'>
+  <thead>
+    <tr><td>Logical built-in functions<td>SPIR-V
+  </thead>
+  <tr><td>is_finite(float) -&gt; bool<td>OpIsFinite
+  <tr><td>is_inf(float) -&gt; bool<td>OpIsInf
+  <tr><td>is_nan(float) -&gt; bool<td>OpIsNan
+  <tr><td>is_normal(float) -&gt; bool<td>OpIsNormal
+</table>
+
+## Vector built-in functions ## {#vector-builtin-functions}
+
+<table class='data'>
+  <thead>
+    <tr><td>Built-in<td>SPIR-V
+  </thead>
+  <tr><td>dot(vecN<f32>, vecN<f32>) -&gt; float<td>OpDot
+  <tr><td>outer_product(vecN<f32>, vecM<f32>) -&gt; matNxM<f32><td>OpOuterProduct
+</table>
+
+## Derivative built-in functions ## {#derivative-builtin-functions}
+
+<table class='data'>
+  <thead>
+    <tr><td>Derivative built-in functions<td>SPIR-V
+  </thead>
+  <tr><td>dpdx(IDENT) -&gt; float<td>OpDPdx
+  <tr><td>dpdx_coarse(IDENT) -&gt; float<td>OpDPdxCoarse
+  <tr><td>dpdx_fine(IDENT) -&gt; float<td>OpDPdxFine
+  <tr><td>dpdy(IDENT) -&gt; float<td>OpDPdy
+  <tr><td>dpdy_coarse(IDENT) -&gt; float<td>OpDPdyCoarse
+  <tr><td>dpdy_fine(IDENT) -&gt; float<td>OpDPdyFine
+  <tr><td>fwidth(IDENT) -&gt; float<td>OpFwidth
+  <tr><td>fwidth_coarse(IDENT) -&gt; float<td>OpFwidthCoarse
+  <tr><td>fwidth_fine(IDENT) -&gt; float<td>OpFwidthFine
 </table>
 
 # Glossary # {#glossary}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -525,50 +525,6 @@ sampler_comparison
   OpTypeSampler
 </pre>
 
-## Texture Functions ## {#texture-functions}
-
-<pre class='def'>
-`vec4<type> texture_load(texture_ro, i32 coords, i32 level_of_detail)`
-`vec4<type> texture_load(texture_ro, vec2<i32> coords, i32 level_of_detail)`
-`vec4<type> texture_load(texture_ro, vec3<i32> coords, i32 level_of_detail)`
-  %32 = OpImageFetch %v4float %texture_ro %coords Lod %level_of_detail
-
-TODO(dsinclair): Texture load on a sampled texture
-
-TODO(dsinclair): Texture load on multi-sampled texture
-
-TODO(dsinclair): Add `texture_write` method for texture_wo with integral coords
-
-TODO(dsinclair): Allow a small constant offset on the coordinate? May not be portable.
-
-`vec4<type> texture_sample(texture_sampled, sampler, f32 coords)`
-`vec4<type> texture_sample(texture_sampled, sampler, vec2<f32> coords)`
-`vec4<type> texture_sample(texture_sampled, sampler, vec3<f32> coords)`
-`vec4<type> texture_sample(texture_sampled, sampler, vec4<f32> coords)`
-  %24 = OpImageSampleImplicitLod %v4float %sampled_image %coords
-
-`vec4<type> texture_sample_level(texture_sampled, sampler, f32 coords, f32 lod)`
-`vec4<type> texture_sample_level(texture_sampled, sampler, vec2<f32> coords, f32 lod)`
-`vec4<type> texture_sample_level(texture_sampled, sampler, vec3<f32> coords, f32 lod)`
-`vec4<type> texture_sample_level(texture_sampled, sampler, vec4<f32> coords, f32 lod)`
-  %25 = OpImageSampleExplicitLod %v4float %sampled_image %coords Lod %lod
-
-`vec4<type> texture_sample_bias(texture_sampled, sampler, f32 coords, f32 bias)`
-`vec4<type> texture_sample_bias(texture_sampled, sampler, vec2<f32> coords, f32 bias)`
-`vec4<type> texture_sample_bias(texture_sampled, sampler, vec3<f32> coords, f32 bias)`
-`vec4<type> texture_sample_bias(texture_sampled, sampler, vec4<f32> coords, f32 bias)`
-  %19 = OpImageSampleImplicitLod %v4float %sampled_image %coords Bias %bias
-
-`f32 texture_sample_compare(texture_depth, sampler_comparison, f32 coords, f32 depth_reference)`
-`f32 texture_sample_compare(texture_depth, sampler_comparison, vec2<f32> coords, f32 depth_reference)`
-`f32 texture_sample_compare(texture_depth, sampler_comparison, vec3<f32> coords, f32 depth_reference)`
-  %65 = OpImageSampleDrefImplicitLod %float %sampled_image %coord %depth_reference Lod %float_0
-
-TODO(dsinclair): Add Level-of-Detail via explicit gradient. "Grad" image operand in SPIR-V
-
-TODO(dsinclair): Need gather operations
-</pre>
-
 # Grammar # {#grammar}
 
 ## Scoping ## {#scoping}
@@ -2750,6 +2706,50 @@ the contents of the existing table.
   <tr><td>fwidth_coarse(IDENT) -&gt; float<td>OpFwidthCoarse
   <tr><td>fwidth_fine(IDENT) -&gt; float<td>OpFwidthFine
 </table>
+
+## Texture built-in functions ## {#texture-builtin-functions}
+
+<pre class='def'>
+`vec4<type> texture_load(texture_ro, i32 coords, i32 level_of_detail)`
+`vec4<type> texture_load(texture_ro, vec2<i32> coords, i32 level_of_detail)`
+`vec4<type> texture_load(texture_ro, vec3<i32> coords, i32 level_of_detail)`
+  %32 = OpImageFetch %v4float %texture_ro %coords Lod %level_of_detail
+
+TODO(dsinclair): Texture load on a sampled texture
+
+TODO(dsinclair): Texture load on multi-sampled texture
+
+TODO(dsinclair): Add `texture_write` method for texture_wo with integral coords
+
+TODO(dsinclair): Allow a small constant offset on the coordinate? May not be portable.
+
+`vec4<type> texture_sample(texture_sampled, sampler, f32 coords)`
+`vec4<type> texture_sample(texture_sampled, sampler, vec2<f32> coords)`
+`vec4<type> texture_sample(texture_sampled, sampler, vec3<f32> coords)`
+`vec4<type> texture_sample(texture_sampled, sampler, vec4<f32> coords)`
+  %24 = OpImageSampleImplicitLod %v4float %sampled_image %coords
+
+`vec4<type> texture_sample_level(texture_sampled, sampler, f32 coords, f32 lod)`
+`vec4<type> texture_sample_level(texture_sampled, sampler, vec2<f32> coords, f32 lod)`
+`vec4<type> texture_sample_level(texture_sampled, sampler, vec3<f32> coords, f32 lod)`
+`vec4<type> texture_sample_level(texture_sampled, sampler, vec4<f32> coords, f32 lod)`
+  %25 = OpImageSampleExplicitLod %v4float %sampled_image %coords Lod %lod
+
+`vec4<type> texture_sample_bias(texture_sampled, sampler, f32 coords, f32 bias)`
+`vec4<type> texture_sample_bias(texture_sampled, sampler, vec2<f32> coords, f32 bias)`
+`vec4<type> texture_sample_bias(texture_sampled, sampler, vec3<f32> coords, f32 bias)`
+`vec4<type> texture_sample_bias(texture_sampled, sampler, vec4<f32> coords, f32 bias)`
+  %19 = OpImageSampleImplicitLod %v4float %sampled_image %coords Bias %bias
+
+`f32 texture_sample_compare(texture_depth, sampler_comparison, f32 coords, f32 depth_reference)`
+`f32 texture_sample_compare(texture_depth, sampler_comparison, vec2<f32> coords, f32 depth_reference)`
+`f32 texture_sample_compare(texture_depth, sampler_comparison, vec3<f32> coords, f32 depth_reference)`
+  %65 = OpImageSampleDrefImplicitLod %float %sampled_image %coord %depth_reference Lod %float_0
+
+TODO(dsinclair): Add Level-of-Detail via explicit gradient. "Grad" image operand in SPIR-V
+
+TODO(dsinclair): Need gather operations
+</pre>
 
 # Glossary # {#glossary}
 


### PR DESCRIPTION
One step toward "Inventing a standard library" #667

- Move the list of built-in functions into its own section at the end
- Add an overview of built-in functions and how they are special.
- Grouped the existing built-ins by semantic category

TODO: Elaborate the semantics and type rules.