### PR TITLE
Add popcount and reverse_bits integer built-in functions

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2688,6 +2688,38 @@ the contents of the existing table.
   <tr><td>is_normal(float) -&gt; bool<td>OpIsNormal
 </table>
 
+## Integer built-in functions ## {#integer-builtin-functions}
+
+<table class='data'>
+  <thead>
+    <tr><td>Precondition<td>Built-in<td>Description
+  </thead>
+  <tr algorithm="scalar popcount"><td>|e| : |T|<br>
+          |T| is u32 or i32<br>
+      <td class="nowrap">`popcount(`|e|`)` : |T|
+      <td>The number of 1 bits in the representation of |e|.<br>
+          Also known as "population count".<br>
+          (SPIR-V OpBitCount)
+  <tr algorithm="vector popcount"><td>|e| : vec|N|<|T|><br>
+          |T| is u32 or i32.
+      <td class="nowrap">`popcount(`|e|`)` : vec|N|<|T|><br>
+      <td>Component-wise population count:
+          Component |i| of the result is `popcount(`|e|`[`|i|`])`<br>
+          (SPIR-V OpBitCount)
+  <tr algorithm="scalar bit reversal"><td>|e| : |T|<br>
+          |T| is u32 or i32<br>
+      <td class="nowrap">`reverse_bits(`|e|`)` : |T|
+      <td>Reverses the bits in |e|:  The bit at position |k| of the result equals the
+          bit at position 31-|k| of |e|.<br>
+          (SPIR-V OpBitReverse)
+  <tr algorithm="vector bit reversal"><td>|e| : vec|N|<|T|><br>
+          |T| is u32 or i32.
+      <td class="nowrap">`reverse_bits(`|e|`)` : vec|N|<|T|><br>
+      <td>Component-wise bit reversal:
+          Component |i| of the result is `reverse_bits(`|e|`[`|i|`])`<br>
+          (SPIR-V OpBitReverse)
+</table>
+
 ## Vector built-in functions ## {#vector-builtin-functions}
 
 <table class='data'>


### PR DESCRIPTION
This builds on #946 

popcount corresponds to:

- std::popcount in C++
- popcount in MSL
- OpBitCount in SPIR-V
- countbits in HLSL (which only has the unsigned variant)

reverse_bits corresponds to:
- reverse_bits in MSL
- OpBitReverse in SPIR-V
- reversebits in HLSL (which only has the unsigned variant)


Editorially, I structured the table more like what's in the "type checking" sections.  I shied away from using function prototype syntax (e.g.     popcount(i32)-> i32   ) because we haven't defined that as possible elsewher in the WGSL spec.  So I expressed the overloads as type checking rules, like we did for arithmetic operators.