### PR TITLE
Make BindGroupLayout parameters' default/undefined consistent

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2187,13 +2187,13 @@ dictionary GPUBindGroupLayoutEntry {
     boolean hasDynamicOffset = false;
 
     // Used for uniform buffer and storage buffer bindings.
-    GPUSize64 minBufferBindingSize;
+    GPUSize64 minBufferBindingSize = 0;
 
     // Used for sampled texture and storage texture bindings.
-    GPUTextureViewDimension viewDimension;
+    GPUTextureViewDimension viewDimension = "2d";
 
     // Used for sampled texture bindings.
-    GPUTextureComponentType textureComponentType;
+    GPUTextureComponentType textureComponentType = "float";
     boolean multisampled = false;
 
     // Used for storage texture bindings.
@@ -2230,20 +2230,24 @@ Issue(https://github.com/gpuweb/gpuweb/issues/851): consider making `textureComp
         If the {{GPUBindGroupLayoutEntry/type}} is
         {{GPUBindingType/"uniform-buffer"}},
         {{GPUBindingType/"storage-buffer"}}, or
-        {{GPUBindingType/"readonly-storage-buffer"}},
-        this indicates whether a binding requires a dynamic offset.
+        {{GPUBindingType/"readonly-storage-buffer"}}:
 
-        Otherwise, it must be `false`.
+          - This indicates whether a binding requires a dynamic offset.
+          - If `undefined`, it defaults to `false`.
+
+        Otherwise, it must be `undefined`.
 
     : <dfn>minBufferBindingSize</dfn>
     ::
         If the {{GPUBindGroupLayoutEntry/type}} is
         {{GPUBindingType/"uniform-buffer"}},
         {{GPUBindingType/"storage-buffer"}}, or
-        {{GPUBindingType/"readonly-storage-buffer"}},
-        this may be used to indicate the minimum buffer binding size.
+        {{GPUBindingType/"readonly-storage-buffer"}}:
 
-        Otherwise, it must be 0.
+          - This may be used to indicate the minimum buffer binding size.
+          - If `undefined`, it defaults to 0.
+
+        Otherwise, it must be `undefined`.
 
     : <dfn>viewDimension</dfn>
     ::
@@ -2273,10 +2277,12 @@ Issue(https://github.com/gpuweb/gpuweb/issues/851): consider making `textureComp
     : <dfn>multisampled</dfn>
     ::
         If the {{GPUBindGroupLayoutEntry/type}} is
-        {{GPUBindingType/"sampled-texture"}},
-        this indicates whether a binding must have a sample count greater than 1.
+        {{GPUBindingType/"sampled-texture"}}:
 
-        Otherwise, it must be `false`.
+          - This indicates whether a binding must have a sample count greater than 1.
+          - If `undefined`, it defaults to `false`.
+
+        Otherwise, it must be `undefined`.
 
         Note:
         This member is used to determine compatibility between a
@@ -2358,8 +2364,8 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
             {{GPUBindingType/"storage-buffer"}}, or
             {{GPUBindingType/"readonly-storage-buffer"}},
             ensure
-            |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `false`,
-            and |bindingDescriptor|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} is undefined.
+            |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}}
+            and |bindingDescriptor|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} are undefined.
         1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
             {{GPUBindingType/"sampled-texture"}},
             {{GPUBindingType/"readonly-storage-texture"}}, or
@@ -2371,9 +2377,9 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
             {{GPUBindingType/"sampled-texture"}},
             ensure
             |bindingDescriptor|.{{GPUBindGroupLayoutEntry/textureComponentType}}
-            is `undefined` and
+            and
             |bindingDescriptor|.{{GPUBindGroupLayoutEntry/multisampled}}
-            is `false`.
+            are undefined.
         1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
             {{GPUBindingType/"readonly-storage-texture"}}
             or {{GPUBindingType/"writeonly-storage-texture"}},

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2183,20 +2183,20 @@ dictionary GPUBindGroupLayoutEntry {
     required GPUShaderStageFlags visibility;
     required GPUBindingType type;
 
-    // Used for uniform buffer and storage buffer bindings.
-    boolean hasDynamicOffset = false;
+    // Used for uniform buffer and storage buffer bindings. Must be undefined if not relevant.
+    boolean hasDynamicOffset;
 
-    // Used for uniform buffer and storage buffer bindings.
-    GPUSize64 minBufferBindingSize = 0;
+    // Used for uniform buffer and storage buffer bindings. Must be undefined if not relevant.
+    GPUSize64 minBufferBindingSize;
 
-    // Used for sampled texture and storage texture bindings.
-    GPUTextureViewDimension viewDimension = "2d";
+    // Used for sampled texture and storage texture bindings. Must be undefined if not relevant.
+    GPUTextureViewDimension viewDimension;
 
-    // Used for sampled texture bindings.
-    GPUTextureComponentType textureComponentType = "float";
-    boolean multisampled = false;
+    // Used for sampled texture bindings. Must be undefined if not relevant.
+    GPUTextureComponentType textureComponentType;
+    boolean multisampled;
 
-    // Used for storage texture bindings.
+    // Used for storage texture bindings. Must be undefined if not relevant.
     GPUTextureFormat storageTextureFormat;
 };
 </script>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2183,20 +2183,20 @@ dictionary GPUBindGroupLayoutEntry {
     required GPUShaderStageFlags visibility;
     required GPUBindingType type;
 
-    // Used for uniform buffer and storage buffer bindings. Must be undefined if not relevant.
+    // Used for uniform buffer and storage buffer bindings. Must be undefined for other binding types.
     boolean hasDynamicOffset;
 
-    // Used for uniform buffer and storage buffer bindings. Must be undefined if not relevant.
+    // Used for uniform buffer and storage buffer bindings. Must be undefined for other binding types.
     GPUSize64 minBufferBindingSize;
 
-    // Used for sampled texture and storage texture bindings. Must be undefined if not relevant.
+    // Used for sampled texture and storage texture bindings. Must be undefined for other binding types.
     GPUTextureViewDimension viewDimension;
 
-    // Used for sampled texture bindings. Must be undefined if not relevant.
+    // Used for sampled texture bindings. Must be undefined for other binding types.
     GPUTextureComponentType textureComponentType;
     boolean multisampled;
 
-    // Used for storage texture bindings. Must be undefined if not relevant.
+    // Used for storage texture bindings. Must be undefined for other binding types.
     GPUTextureFormat storageTextureFormat;
 };
 </script>


### PR DESCRIPTION
If the binding type in BindGroupLayout is incorrect, it is better
to say that hasDynamicOffset, minBufferBindingSize and multisampled
should be undefined. The current statement that an explicit default
value is correct doesn't make sense because the binding type is
totally wrong.

And this statement is consistent with other parameters like
viewDimension, storageTextureFormat.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Richard-Yunchao/gpuweb/pull/949.html" title="Last updated on Jul 23, 2020, 10:27 PM UTC (014fa16)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/949/b21ab87...Richard-Yunchao:014fa16.html" title="Last updated on Jul 23, 2020, 10:27 PM UTC (014fa16)">Diff</a>