### PR TITLE
Remove default=0 for mapAsync size and allow size=0 in getMappedRange

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1253,7 +1253,7 @@ that returns a new buffer in the [=buffer state/mapped=] or [=buffer state/unmap
 <script type=idl>
 [Serializable]
 interface GPUBuffer {
-    Promise<void> mapAsync(GPUMapModeFlags mode, optional GPUSize64 offset = 0, optional GPUSize64 size = 0);
+    Promise<void> mapAsync(GPUMapModeFlags mode, optional GPUSize64 offset = 0, optional GPUSize64 size);
     ArrayBuffer getMappedRange(optional GPUSize64 offset = 0, optional GPUSize64 size);
     void unmap();
 
@@ -1433,7 +1433,7 @@ interface GPUBufferUsage {
         |descriptor|.{{GPUBufferDescriptor/size}} must be a multiple of 4.
 
       Issue(gpuweb/gpuweb#605): Explain what are a {{GPUDevice}}'s `[[allowed buffer usages]]`
-    </dfn>
+
   </div>
 </div>
 
@@ -1486,64 +1486,64 @@ interface GPUMapMode {
 </script>
 
 <div algorithm="GPUBuffer.mapAsync">
+    <strong>|this|:</strong> of type {{GPUBuffer}}.
 
-  <strong>|this|:</strong> of type {{GPUBuffer}}.
-
-  **Arguments:**
+    **Arguments:**
     - {{GPUMapModeFlags}} |mode|
     - {{GPUSize64}} |offset|
     - {{GPUSize64}} |size|
 
-  **Returns:** {{Promise}}
+    **Returns:** {{Promise}}
 
-  Issue(gpuweb/gpuweb#605): Handle error buffers once we have a description of the error monad.
+    Issue(gpuweb/gpuweb#605): Handle error buffers once we have a description of the error monad.
 
-  1. If |size| is 0 and |offset| is less than |this|.{{[[size]]}}:
+    1. If |size| is unspecified:
 
-    1. Set |size| to |this|.{{[[size]]}} - |offset|
+        - If |offset| &ge; |this|.{{GPUBuffer/[[size]]}}, reject with an {{OperationError}} and stop.
+        - Let |rangeSize| be |this|.{{GPUBuffer/[[size]]}} - |offset|.
 
-  1. If this call doesn't follow [$mapAsync Valid Usage$]:
+        Otherwise, let |rangeSize| be |size|.
 
-    1. Record a validation error on the current scope.
-    1. Return [=a promise rejected with=] an {{AbortError}} on the [=Device timeline=].
+    1. If this call doesn't follow [$mapAsync Valid Usage$]:
 
-  1. Let |p| be a new {{Promise}}.
-  1. Set |this|.{{[[mapping]]}} to |p|.
-  1. Set |this|.{{GPUBuffer/[[state]]}} to [=buffer state/mapping pending=].
-  1. Set |this|.{{GPUBuffer/[[map_mode]]}} to |mode|.
-  1. Enqueue an operation on the default queue's [=Queue timeline=] that will execute the following:
+      1. Record a validation error on the current scope.
+      1. Return [=a promise rejected with=] an {{AbortError}} on the [=Device timeline=].
 
-     1. If |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapping pending=]:
+    1. Let |p| be a new {{Promise}}.
+    1. Set |this|.{{GPUBuffer/[[mapping]]}} to |p|.
+    1. Set |this|.{{GPUBuffer/[[state]]}} to [=buffer state/mapping pending=].
+    1. Set |this|.{{GPUBuffer/[[map_mode]]}} to |mode|.
+    1. Enqueue an operation on the default queue's [=Queue timeline=] that will execute the following:
 
-        1. Let |m| be a new {{ArrayBuffer}} of size |size|.
-        1. Set the content of |m| to the content of |this|'s allocation starting at offset |offset| and for |size| bytes.
-        1. Set |this|.{{[[mapping]]}} to |m|.
-        1. Set |this|.{{GPUBuffer/[[state]]}} to [=buffer state/mapped=].
-        1. Set |this|.{{[[mapping_range]]}} to `[offset, offset + size]`.
-        1. Set |this|.{{[[mapped_ranges]]}} to `[]`.
-        1. Resolve |p|.
+        1. If |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapping pending=]:
 
-  1. Return |p|.
+            1. Let |m| be a new {{ArrayBuffer}} of size |rangeSize|.
+            1. Set the content of |m| to the content of |this|'s allocation starting at offset |offset| and for |rangeSize| bytes.
+            1. Set |this|.{{GPUBuffer/[[mapping]]}} to |m|.
+            1. Set |this|.{{GPUBuffer/[[state]]}} to [=buffer state/mapped=].
+            1. Set |this|.{{GPUBuffer/[[mapping_range]]}} to <code>[|offset|, |offset| + |rangeSize|]</code>.
+            1. Set |this|.{{GPUBuffer/[[mapped_ranges]]}} to `[]`.
+            1. Resolve |p|.
 
-  <div algorithm class=validusage>
-    <dfn abstract-op>mapAsync Valid Usage</dfn>
+    1. Return |p|.
 
-      Given a {{GPUBuffer}} |this|, a {{GPUMapModeFlags}} |mode|, a {{GPUSize64}} |offset|
-      and a {{GPUSize64}} |size|, the following validation rules apply:
+    <div algorithm class=validusage>
+        <dfn abstract-op>mapAsync Valid Usage</dfn>
 
-      1. |this| must be a [=valid=] {{GPUBuffer}}.
-      1. |offset| must be a multiple of 4.
-      1. |size| must be a multiple of 4.
-      1. |offset| + |size| must be less or equal to |this|.{{[[size]]}}
-      1. |this|.{{GPUBuffer/[[state]]}} must be [=buffer state/unmapped=]
-      1. |mode| must contain exactly one of {{GPUMapMode/READ}} or {{GPUMapMode/WRITE}}.
-      1. If |mode| contains {{GPUMapMode/READ}} then |this|.{{[[usage]]}} must contain {{GPUBufferUsage/MAP_READ}}.
-      1. If |mode| contains {{GPUMapMode/WRITE}} then |this|.{{[[usage]]}} must contain {{GPUBufferUsage/MAP_WRITE}}.
+        Given a {{GPUBuffer}} |this|, a {{GPUMapModeFlags}} |mode|, a {{GPUSize64}} |offset|
+        and a {{GPUSize64}} |rangeSize|, the following validation rules apply:
 
-      Issue: Do we validate that |mode| contains only valid flags?
+        1. |this| must be a [=valid=] {{GPUBuffer}}.
+        1. |offset| must be a multiple of 4.
+        1. |rangeSize| must be a multiple of 4.
+        1. |offset| + |rangeSize| must be less or equal to |this|.{{[[size]]}}
+        1. |this|.{{GPUBuffer/[[state]]}} must be [=buffer state/unmapped=]
+        1. |mode| must contain exactly one of {{GPUMapMode/READ}} or {{GPUMapMode/WRITE}}.
+        1. If |mode| contains {{GPUMapMode/READ}} then |this|.{{[[usage]]}} must contain {{GPUBufferUsage/MAP_READ}}.
+        1. If |mode| contains {{GPUMapMode/WRITE}} then |this|.{{[[usage]]}} must contain {{GPUBufferUsage/MAP_WRITE}}.
 
-    </dfn>
-  </div>
+        Issue: Do we validate that |mode| contains only valid flags?
+    </div>
 </div>
 
 ### <dfn method for=GPUBuffer>getMappedRange(offset, size)</dfn> ### {#GPUBuffer-getMappedRange}
@@ -1584,7 +1584,7 @@ interface GPUMapMode {
 
         1. |this|.{{GPUBuffer/[[state]]}} must be [=buffer state/mapped=] or [=buffer state/mapped at creation=].
         1. |offset| must be a multiple of 8.
-        1. |rangeSize| must be a positive multiple of 4.
+        1. |rangeSize| must be a multiple of 4.
         1. |offset| must be greater than or equal to |this|.{{[[mapping_range]]}}[0].
         1. |offset| + |rangeSize| must be less than or equal to |this|.{{[[mapping_range]]}}[1].
         1. [|offset|, |offset| + |rangeSize|) must not overlap another range in |this|.{{[[mapped_ranges]]}}.
@@ -1646,7 +1646,6 @@ interface GPUMapMode {
       Note: It is valid to unmap an error {{GPUBuffer}} that is [=buffer state/mapped at creation=] because
       the [=Content timeline=] might not know it is an error {{GPUBuffer}}.
 
-    </dfn>
   </div>
 </div>
 


### PR DESCRIPTION
And fix algorithm when size is unspecified.

And fix some indentation and stray close tags.

Fixes #941
Fixes #948


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/951.html" title="Last updated on Jul 23, 2020, 11:56 PM UTC (5d2e454)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/951/b21ab87...kainino0x:5d2e454.html" title="Last updated on Jul 23, 2020, 11:56 PM UTC (5d2e454)">Diff</a>