### PR TITLE
Allow struct_decl to have a name.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -150,7 +150,7 @@ Issue: (dneto): the last element of a struct defining the contents of a storage 
 
 <div class='example' heading="Structure">
   <xmp highlight='rust'>
-    type foo = struct {
+    struct Data {
       a : i32;
       b : vec2<f32>;
     }
@@ -200,7 +200,7 @@ The zero values are as follows:
 
 <div class='example' heading="Zero-valued structures">
   <xmp highlight='rust'>
-    type Student = struct {
+    struct Student {
       grade : i32;
       GPA : f32;
       attendance : array<bool,4>;
@@ -888,6 +888,7 @@ global_decl
   | global_constant_decl SEMICOLON
   | entry_point_decl SEMICOLON
   | type_alias SEMICOLON
+  | struct_decl SEMICOLON
   | function_decl
 </pre>
 
@@ -1191,25 +1192,13 @@ variable_storage_decoration:
 <pre class='def'>
 type_alias
   : TYPE IDENT EQUAL type_decl
-  | TYPE IDENT EQUAL struct_decl
 </pre>
 
 <div class='example' heading='Type Alias'>
   <xmp>
     type Arr = array<i32, 5>;
 
-    type ResType = struct {
-      sf0 : vec4<f32>;
-      sf1 : vec4<i32>;
-    };
-
     type RTArr = [[stride 16]] array<vec4<f32>>;
-
-    type S = [[block]] struct {
-      [[offset 0]] a : f32;
-      [[offset 4]] b : f32;
-      [[offset 16]] data : RTArr;
-    };
   </xmp>
 </div>
 
@@ -1255,9 +1244,6 @@ type_decl
 
     u32
        %4 = OpTypeInt 32 0
-
-    struct { i : i32; j : u32; x : f32; y : f32; }
-       %foo = OpTypeStruct %3 %4 %2 %2 ;  assuming above SPIR-V types
 
     vec2<f32>
         %7 = OpTypeVector %float 2
@@ -1309,7 +1295,7 @@ storage_class
 
 <pre class='def'>
 struct_decl
-  : struct_decoration_decl? STRUCT struct_body_decl
+  : struct_decoration_decl? STRUCT IDENT struct_body_decl
 
 struct_decoration_decl
   : ATTR_LEFT struct_decoration ATTR_RIGHT
@@ -1338,7 +1324,7 @@ Issue: (dneto): MatrixStride, RowMajor, ColMajor layout decorations are needed f
 
 <div class='example' heading='Structure'>
   <xmp>
-    type my_struct = struct {
+    struct my_struct {
       [[offset 0]] a : f32;
       [[offset 4]] b : vec4<f32>;
     };
@@ -1349,6 +1335,12 @@ Issue: (dneto): MatrixStride, RowMajor, ColMajor layout decorations are needed f
                   OpMemberName %my_struct 1 "b"
                   OpMemberDecorate %my_struct 1 Offset 4
      %my_struct = OpTypeStruct %float %v4float
+
+    [[block]] struct S {
+      [[offset 0]] a : f32;
+      [[offset 4]] b : f32;
+      [[offset 16]] data : RTArr;
+    };
   </xmp>
 </div>
 


### PR DESCRIPTION
This CL removes the requirement for a struct to be the RHS of a `type`
statement and, instead, allows an IDENT to be provided in the struct
declaration.

The struct is still required to be defined in the module scope.

The [[block]] attribute remains on the LHS of the struct_decl.

```
[[block]] struct A { [[offset 0]] b : f32; }
```

Fixes #735