### PR TITLE
writeonly-storage-texture shouldn't be allowed in vertex stage in BGL

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2409,7 +2409,7 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
 
         <dfn>binding validation</dfn>: Each |bindingDescriptor|.{{GPUBindGroupLayoutEntry/binding}} in |descriptor| must be unique.
 
-        <dfn>vertex shader binding validation</dfn>: {{GPUBindingType/storage-buffer}} is not allowed.
+        <dfn>vertex shader binding validation</dfn>: {{GPUBindingType/storage-buffer}} and {{GPUBindingType/writeonly-storage-texture}} are not allowed.
 
         <dfn>uniform buffer validation</dfn>: There must be {{GPULimits/maxUniformBuffersPerShaderStage|GPULimits.maxUniformBuffersPerShaderStage}} or
             fewer |bindingDescriptor|s of type {{GPUBindingType/uniform-buffer}} visible on each shader stage in |descriptor|.


### PR DESCRIPTION
I didn't work in storage-texture related validation, but I remember that writeonly-storage-texture is not allowed in vertex stage. And CTS (createBindGroupLayout) also validated this rule.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Richard-Yunchao/gpuweb/pull/953.html" title="Last updated on Jul 24, 2020, 3:27 PM UTC (19302d9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/953/b21ab87...Richard-Yunchao:19302d9.html" title="Last updated on Jul 24, 2020, 3:27 PM UTC (19302d9)">Diff</a>