### PR TITLE
Introduce Subgroup Operations Extension

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3036,9 +3036,9 @@ Stages of a compute [=pipeline=]:
 <script type=idl>
 [Serializable]
 interface GPUComputePipeline {
-    // Available if "subgroup-operations" is both
+    // Attribute exists if and only if "subgroup-operations" is both
     // supported by the device/user agent and enabled in requestDevice.
-    readonly attribute GPUSize32? subgroupSize;
+    readonly attribute GPUSize32 subgroupSize;
 };
 GPUComputePipeline includes GPUObjectBase;
 GPUComputePipeline includes GPUPipelineBase;

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3036,10 +3036,9 @@ Stages of a compute [=pipeline=]:
 <script type=idl>
 [Serializable]
 interface GPUComputePipeline {
-    // Attributes exist if "subgroup-operations" is both supported
+    // Attribute exists if "subgroup-operations" is both supported
     // by the device/user agent and is enabled in requestDevice.
-    readonly attribute GPUSize32 minSubgroupSize;
-    readonly attribute GPUSize32 maxSubgroupSize;
+    readonly attribute GPUSize32 subgroupSize;
 };
 GPUComputePipeline includes GPUObjectBase;
 GPUComputePipeline includes GPUPipelineBase;

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3036,8 +3036,8 @@ Stages of a compute [=pipeline=]:
 <script type=idl>
 [Serializable]
 interface GPUComputePipeline {
-    // Attribute exists if and only if "subgroup-operations" is both
-    // supported by the device/user agent and enabled in requestDevice.
+    // Attribute exists if "subgroup-operations" is both supported
+    // by the device/user agent and is enabled in requestDevice.
     readonly attribute GPUSize32 subgroupSize;
 };
 GPUComputePipeline includes GPUObjectBase;

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1126,7 +1126,6 @@ enum GPUExtensionName {
     "pipeline-statistics-query",
     "texture-compression-bc",
     "timestamp-query",
-    "depth-clamping",
     "subgroup-operations"
 };
 </script>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3036,9 +3036,6 @@ Stages of a compute [=pipeline=]:
 <script type=idl>
 [Serializable]
 interface GPUComputePipeline {
-    // Attribute exists if "subgroup-operations" is both supported
-    // by the device/user agent and is enabled in requestDevice.
-    readonly attribute GPUSize32 subgroupSize;
 };
 GPUComputePipeline includes GPUObjectBase;
 GPUComputePipeline includes GPUPipelineBase;

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3036,6 +3036,9 @@ Stages of a compute [=pipeline=]:
 <script type=idl>
 [Serializable]
 interface GPUComputePipeline {
+    // Available if "subgroup-operations" is both
+    // supported by the device/user agent and enabled in requestDevice.
+    readonly attribute GPUSize32? subgroupSize;
 };
 GPUComputePipeline includes GPUObjectBase;
 GPUComputePipeline includes GPUPipelineBase;

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3038,8 +3038,8 @@ Stages of a compute [=pipeline=]:
 interface GPUComputePipeline {
     // Attributes exists if "subgroup-operations" is both supported
     // by the device/user agent and is enabled in requestDevice.
-    readonly attribute GPUSize32 subgroupSizeMin;
-    readonly attribute GPUSize32 subgroupSizeMax;
+    readonly attribute GPUSize32 minSubgroupSize;
+    readonly attribute GPUSize32 maxSubgroupSize;
 };
 GPUComputePipeline includes GPUObjectBase;
 GPUComputePipeline includes GPUPipelineBase;

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1005,7 +1005,8 @@ enum GPUExtensionName {
     "texture-compression-bc",
     "pipeline-statistics-query",
     "timestamp-query",
-    "depth-clamping"
+    "depth-clamping",
+    "subgroup-operations"
 };
 </script>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3036,9 +3036,10 @@ Stages of a compute [=pipeline=]:
 <script type=idl>
 [Serializable]
 interface GPUComputePipeline {
-    // Attribute exists if "subgroup-operations" is both supported
+    // Attributes exists if "subgroup-operations" is both supported
     // by the device/user agent and is enabled in requestDevice.
-    readonly attribute GPUSize32 subgroupSize;
+    readonly attribute GPUSize32 subgroupSizeMin;
+    readonly attribute GPUSize32 subgroupSizeMax;
 };
 GPUComputePipeline includes GPUObjectBase;
 GPUComputePipeline includes GPUPipelineBase;

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3036,7 +3036,7 @@ Stages of a compute [=pipeline=]:
 <script type=idl>
 [Serializable]
 interface GPUComputePipeline {
-    // Attributes exists if "subgroup-operations" is both supported
+    // Attributes exist if "subgroup-operations" is both supported
     // by the device/user agent and is enabled in requestDevice.
     readonly attribute GPUSize32 minSubgroupSize;
     readonly attribute GPUSize32 maxSubgroupSize;

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3039,7 +3039,8 @@ TODO(dsinclair): Need gather operations
   <tr><td>subgroupAll(bool) -&gt; bool<td>OpGroupNonUniformAll
   <tr><td>subgroupAny(bool) -&gt; bool<td>OpGroupNonUniformAny
   <tr><td>subgroupBallot(bool) -&gt; vec4&lt;u32&gt;<td>OpGroupNonUniformBallot
-  <tr><td>subgroupBroadcastFirst(Scalar) -&gt; Scalar<td>OpGroupNonUniformBroadcastFirst
+  <tr><td>subgroupBroadcastFirst(Integral) -&gt; Integral<td>OpGroupNonUniformBroadcastFirst
+  <tr><td>subgroupBroadcastFirst(Floating) -&gt; Floating<td>OpGroupNonUniformBroadcastFirst
   <tr><td>subgroupAdd(Integral) -&gt; Integral<td>OpGroupNonUniformIAdd with Reduce
   <tr><td>subgroupAdd(Floating) -&gt; Floating<td>OpGroupNonUniformFAdd with Reduce
   <tr><td>subgroupMul(Integral) -&gt; Integral<td>OpGroupNonUniformIMul with Reduce

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2753,9 +2753,26 @@ TODO(dsinclair): Need gather operations
   <thead>
     <tr><td>Subgroup built-in functions<td>SPIR-V
   </thead>
+  <tr><td>subgroup_size() -&gt; u32<td>SubgroupSize
+  <tr><td>subgroup_local_index() -&gt; u32<td>SubgroupLocalInvocationId
+  <tr><td>subgroup_is_first() -&gt; bool<td>OpGroupNonUniformElect
+  <tr><td>subgroup_all(bool) -&gt; bool<td>OpGroupNonUniformAll
+  <tr><td>subgroup_any(bool) -&gt; bool<td>OpGroupNonUniformAny
+  <tr><td>subgroup_ballot(bool) -&gt; vec4&lt;u32&gt;<td>OpGroupNonUniformBallot
+  <tr><td>subgroup_broadcast(T,u32) -&gt; T<td>OpGroupNonUniformBroadcast
+  <tr><td>subgroup_broadcast_first(T) -&gt; T<td>OpGroupNonUniformBroadcastFirst
+  <tr><td>subgroup_add(T) -&gt; T<td>OpGroupNonUniformIAdd or OpGroupNonUniformFAdd with Reduce
+  <tr><td>subgroup_mul(T) -&gt; T<td>OpGroupNonUniformIMul or OpGroupNonUniformFMul with Reduce
+  <tr><td>subgroup_min(T) -&gt; T<td>OpGroupNonUniformUMin or OpGroupNonUniformSMin or OpGroupNonUniformFMin with Reduce
+  <tr><td>subgroup_max(T) -&gt; T<td>OpGroupNonUniformUMax or OpGroupNonUniformSMax or OpGroupNonUniformFMax with Reduce
+  <tr><td>subgroup_and(T) -&gt; T<td>OpGroupNonUniformBitwiseAnd
+  <tr><td>subgroup_or(T) -&gt; T<td>OpGroupNonUniformBitwiseOr
+  <tr><td>subgroup_xor(T) -&gt; T<td>OpGroupNonUniformBitwiseXor
+  <tr><td>subgroup_prefix_add(T) -&gt; T<td>OpGroupNonUniformIAdd or OpGroupNonUniformFAdd with ExclusiveScan
+  <tr><td>subgroup_prefix_mul(T) -&gt; T<td>OpGroupNonUniformIMul or OpGroupNonUniformFMul with ExclusiveScan
 </table>
 
-Note: Functions exist if "subgroup-operations" is both supported
+Note: Subgroup functions exist if "subgroup-operations" is both supported
       by the device/user agent and is enabled in requestDevice.
 
 # Glossary # {#glossary}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2759,17 +2759,17 @@ TODO(dsinclair): Need gather operations
   <tr><td>subgroup_all(bool) -&gt; bool<td>OpGroupNonUniformAll
   <tr><td>subgroup_any(bool) -&gt; bool<td>OpGroupNonUniformAny
   <tr><td>subgroup_ballot(bool) -&gt; vec4&lt;u32&gt;<td>OpGroupNonUniformBallot
-  <tr><td>subgroup_broadcast(T,u32) -&gt; T<td>OpGroupNonUniformBroadcast
-  <tr><td>subgroup_broadcast_first(T) -&gt; T<td>OpGroupNonUniformBroadcastFirst
-  <tr><td>subgroup_add(T) -&gt; T<td>OpGroupNonUniformIAdd or OpGroupNonUniformFAdd with Reduce
-  <tr><td>subgroup_mul(T) -&gt; T<td>OpGroupNonUniformIMul or OpGroupNonUniformFMul with Reduce
-  <tr><td>subgroup_min(T) -&gt; T<td>OpGroupNonUniformUMin or OpGroupNonUniformSMin or OpGroupNonUniformFMin with Reduce
-  <tr><td>subgroup_max(T) -&gt; T<td>OpGroupNonUniformUMax or OpGroupNonUniformSMax or OpGroupNonUniformFMax with Reduce
-  <tr><td>subgroup_and(T) -&gt; T<td>OpGroupNonUniformBitwiseAnd
-  <tr><td>subgroup_or(T) -&gt; T<td>OpGroupNonUniformBitwiseOr
-  <tr><td>subgroup_xor(T) -&gt; T<td>OpGroupNonUniformBitwiseXor
-  <tr><td>subgroup_prefix_add(T) -&gt; T<td>OpGroupNonUniformIAdd or OpGroupNonUniformFAdd with ExclusiveScan
-  <tr><td>subgroup_prefix_mul(T) -&gt; T<td>OpGroupNonUniformIMul or OpGroupNonUniformFMul with ExclusiveScan
+  <tr><td>subgroup_broadcast(*T*,u32) -&gt; *T*<td>OpGroupNonUniformBroadcast
+  <tr><td>subgroup_broadcast_first(*T*) -&gt; *T*<td>OpGroupNonUniformBroadcastFirst
+  <tr><td>subgroup_add(*T*) -&gt; *T*<td>OpGroupNonUniformIAdd or OpGroupNonUniformFAdd with Reduce
+  <tr><td>subgroup_mul(*T*) -&gt; *T*<td>OpGroupNonUniformIMul or OpGroupNonUniformFMul with Reduce
+  <tr><td>subgroup_min(*T*) -&gt; *T*<td>OpGroupNonUniformUMin or OpGroupNonUniformSMin or OpGroupNonUniformFMin with Reduce
+  <tr><td>subgroup_max(*T*) -&gt; *T*<td>OpGroupNonUniformUMax or OpGroupNonUniformSMax or OpGroupNonUniformFMax with Reduce
+  <tr><td>subgroup_and(*T*) -&gt; *T*<td>OpGroupNonUniformBitwiseAnd
+  <tr><td>subgroup_or(*T*) -&gt; *T*<td>OpGroupNonUniformBitwiseOr
+  <tr><td>subgroup_xor(*T*) -&gt; *T*<td>OpGroupNonUniformBitwiseXor
+  <tr><td>subgroup_prefix_add(*T*) -&gt; *T*<td>OpGroupNonUniformIAdd or OpGroupNonUniformFAdd with ExclusiveScan
+  <tr><td>subgroup_prefix_mul(*T*) -&gt; *T*<td>OpGroupNonUniformIMul or OpGroupNonUniformFMul with ExclusiveScan
 </table>
 
 Note: Subgroup functions exist if "subgroup-operations" is both supported

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2758,7 +2758,7 @@ TODO(dsinclair): Need gather operations
   <tr><td>subgroup_is_first() -&gt; bool<td>OpGroupNonUniformElect
   <tr><td>subgroup_all(bool) -&gt; bool<td>OpGroupNonUniformAll
   <tr><td>subgroup_any(bool) -&gt; bool<td>OpGroupNonUniformAny
-  <tr><td>subgroup_ballot(bool) -&gt; vec4&lt;u32&gt;<td>OpGroupNonUniformBallot
+  <tr><td>subgroup_ballot(bool) -&gt; vec2&lt;u32&gt;<td>OpGroupNonUniformBallot
   <tr><td>subgroup_broadcast(*T*,u32) -&gt; *T*<td>OpGroupNonUniformBroadcast
   <tr><td>subgroup_broadcast_first(*T*) -&gt; *T*<td>OpGroupNonUniformBroadcastFirst
   <tr><td>subgroup_add(*T*) -&gt; *T*<td>OpGroupNonUniformIAdd or OpGroupNonUniformFAdd with Reduce

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3213,12 +3213,9 @@ TODO(dsinclair): Need gather operations
   <thead>
     <tr><td>Subgroup built-in functions<td>SPIR-V
   </thead>
-  <tr><td>subgroupIsFirst() -&gt; bool<td>OpGroupNonUniformElect
   <tr><td>subgroupAll(bool) -&gt; bool<td>OpGroupNonUniformAll
   <tr><td>subgroupAny(bool) -&gt; bool<td>OpGroupNonUniformAny
   <tr><td>subgroupBallot(bool) -&gt; vec4&lt;u32&gt;<td>OpGroupNonUniformBallot
-  <tr><td>subgroupBroadcastFirst(Integral) -&gt; Integral<td>OpGroupNonUniformBroadcastFirst
-  <tr><td>subgroupBroadcastFirst(Floating) -&gt; Floating<td>OpGroupNonUniformBroadcastFirst
   <tr><td>subgroupAdd(Integral) -&gt; Integral<td>OpGroupNonUniformIAdd with Reduce
   <tr><td>subgroupAdd(Floating) -&gt; Floating<td>OpGroupNonUniformFAdd with Reduce
   <tr><td>subgroupMul(Integral) -&gt; Integral<td>OpGroupNonUniformIMul with Reduce

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1110,6 +1110,12 @@ variable_decoration
 
     [[builtin global_invocation_id]]
           OpDecorate %gl_GlobalInvocationID BuiltIn GlobalInvocationId
+
+    [[builtin subgroup_size]]
+          OpDecorate %gl_SubgroupSize BuiltIn SubgroupSize
+
+    [[builtin subgroup_invocation_idx]]
+          OpDecorate %gl_SubgroupInvocationID BuiltIn SubgroupLocalInvocationId
   </xmp>
 </div>
 
@@ -1129,6 +1135,14 @@ type, function decorations and storage class.
     <tr><td>local_invocation_id<td>vec3&ltu32&gt<td>Compute Input
     <tr><td>global_invocation_id<td>vec3&ltu32&gt<td>Compute Input
     <tr><td>local_invocation_idx<td>u32<td>Compute Input
+    <tr><td>subgroup_size<td>u32<td>Compute Input<br>
+                                    Exists if "subgroup-operations"<br>
+                                    is both supported by the device/user<br>
+                                    and is enabled in requestDevice
+    <tr><td>subgroup_invocation_idx<td>u32<td>Compute Input<br>
+                                              Exists if "subgroup-operations"<br>
+                                              is both supported by the device/user<br>
+                                              and is enabled in requestDevice
 </table>
 
 <pre class='def'>
@@ -2753,23 +2767,27 @@ TODO(dsinclair): Need gather operations
   <thead>
     <tr><td>Subgroup built-in functions<td>SPIR-V
   </thead>
-  <tr><td>subgroup_size() -&gt; u32<td>SubgroupSize
-  <tr><td>subgroup_local_index() -&gt; u32<td>SubgroupLocalInvocationId
   <tr><td>subgroup_is_first() -&gt; bool<td>OpGroupNonUniformElect
   <tr><td>subgroup_all(bool) -&gt; bool<td>OpGroupNonUniformAll
   <tr><td>subgroup_any(bool) -&gt; bool<td>OpGroupNonUniformAny
   <tr><td>subgroup_ballot(bool) -&gt; vec2&lt;u32&gt;<td>OpGroupNonUniformBallot
-  <tr><td>subgroup_broadcast(*T*,u32) -&gt; *T*<td>OpGroupNonUniformBroadcast
-  <tr><td>subgroup_broadcast_first(*T*) -&gt; *T*<td>OpGroupNonUniformBroadcastFirst
-  <tr><td>subgroup_add(*T*) -&gt; *T*<td>OpGroupNonUniformIAdd or OpGroupNonUniformFAdd with Reduce
-  <tr><td>subgroup_mul(*T*) -&gt; *T*<td>OpGroupNonUniformIMul or OpGroupNonUniformFMul with Reduce
-  <tr><td>subgroup_min(*T*) -&gt; *T*<td>OpGroupNonUniformUMin or OpGroupNonUniformSMin or OpGroupNonUniformFMin with Reduce
-  <tr><td>subgroup_max(*T*) -&gt; *T*<td>OpGroupNonUniformUMax or OpGroupNonUniformSMax or OpGroupNonUniformFMax with Reduce
-  <tr><td>subgroup_and(*T*) -&gt; *T*<td>OpGroupNonUniformBitwiseAnd
-  <tr><td>subgroup_or(*T*) -&gt; *T*<td>OpGroupNonUniformBitwiseOr
-  <tr><td>subgroup_xor(*T*) -&gt; *T*<td>OpGroupNonUniformBitwiseXor
-  <tr><td>subgroup_prefix_add(*T*) -&gt; *T*<td>OpGroupNonUniformIAdd or OpGroupNonUniformFAdd with ExclusiveScan
-  <tr><td>subgroup_prefix_mul(*T*) -&gt; *T*<td>OpGroupNonUniformIMul or OpGroupNonUniformFMul with ExclusiveScan
+  <tr><td>subgroup_broadcast(Scalar,u32) -&gt; Scalar<td>OpGroupNonUniformBroadcast
+  <tr><td>subgroup_broadcast_first(Scalar) -&gt; Scalar<td>OpGroupNonUniformBroadcastFirst
+  <tr><td>subgroup_add(Integral) -&gt; Integral<td>OpGroupNonUniformIAdd with Reduce
+  <tr><td>subgroup_add(Floating) -&gt; Floating<td>OpGroupNonUniformFAdd with Reduce
+  <tr><td>subgroup_mul(Integral) -&gt; Integral<td>OpGroupNonUniformIMul with Reduce
+  <tr><td>subgroup_mul(Floating) -&gt; Floating<td>OpGroupNonUniformFMul with Reduce
+  <tr><td>subgroup_min(Integral) -&gt; Integral<td>OpGroupNonUniformUMin or OpGroupNonUniformSMin with Reduce
+  <tr><td>subgroup_min(Floating) -&gt; Floating<td>OpGroupNonUniformFMin with Reduce
+  <tr><td>subgroup_max(Integral) -&gt; Integral<td>OpGroupNonUniformUMax or OpGroupNonUniformSMax with Reduce
+  <tr><td>subgroup_max(Floating) -&gt; Floating<td>OpGroupNonUniformFMax with Reduce
+  <tr><td>subgroup_and(Integral) -&gt; Integral<td>OpGroupNonUniformBitwiseAnd
+  <tr><td>subgroup_or(Integral) -&gt; Integral<td>OpGroupNonUniformBitwiseOr
+  <tr><td>subgroup_xor(Integral) -&gt; Integral<td>OpGroupNonUniformBitwiseXor
+  <tr><td>subgroup_prefix_add(Integral) -&gt; Integral<td>OpGroupNonUniformIAdd with ExclusiveScan
+  <tr><td>subgroup_prefix_add(Floating) -&gt; Floating<td>OpGroupNonUniformFAdd with ExclusiveScan
+  <tr><td>subgroup_prefix_mul(Integral) -&gt; Integral<td>OpGroupNonUniformIMul with ExclusiveScan
+  <tr><td>subgroup_prefix_mul(Floating) -&gt; Floating<td>OpGroupNonUniformFMul with ExclusiveScan
 </table>
 
 Note: Subgroup functions exist if "subgroup-operations" is both supported

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3208,7 +3208,6 @@ TODO(dsinclair): Need gather operations
 ## Atomic built-in functions ## {#atomic-builtin-functions}
 
 ## Subgroup built-in functions ## {#subgroup-builtin-functions}
-
 <table class='data'>
   <thead>
     <tr><td>Subgroup built-in functions<td>SPIR-V

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1137,12 +1137,10 @@ type, function decorations and storage class.
     <tr><td>local_invocation_idx<td>u32<td>Compute Input
     <tr><td>subgroup_size<td>u32<td>Compute Input<br>
                                     Exists if "subgroup-operations"<br>
-                                    is both supported by the device/user<br>
-                                    and is enabled in requestDevice
+                                              is enabled in requestDevice.
     <tr><td>subgroup_invocation_idx<td>u32<td>Compute Input<br>
                                               Exists if "subgroup-operations"<br>
-                                              is both supported by the device/user<br>
-                                              and is enabled in requestDevice
+                                              is enabled in requestDevice.
 </table>
 
 <pre class='def'>
@@ -2790,8 +2788,8 @@ TODO(dsinclair): Need gather operations
   <tr><td>subgroup_prefix_mul(Floating) -&gt; Floating<td>OpGroupNonUniformFMul with ExclusiveScan
 </table>
 
-Note: Subgroup functions exist if "subgroup-operations" is both supported
-      by the device/user agent and is enabled in requestDevice.
+Note: Subgroup functions exist if "subgroup-operations"<br>
+      is enabled in requestDevice.
 
 # Glossary # {#glossary}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2788,8 +2788,7 @@ TODO(dsinclair): Need gather operations
   <tr><td>subgroup_prefix_mul(Floating) -&gt; Floating<td>OpGroupNonUniformFMul with ExclusiveScan
 </table>
 
-Note: Subgroup functions exist if "subgroup-operations"<br>
-      is enabled in requestDevice.
+Note: Subgroup functions exist if "subgroup-operations" is enabled in requestDevice.
 
 # Glossary # {#glossary}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2852,6 +2852,12 @@ the test name.
 
     [[builtin global_invocation_id]]
           OpDecorate %gl_GlobalInvocationID BuiltIn GlobalInvocationId
+
+    [[builtin subgroup_size]]
+          OpDecorate %gl_SubgroupSize BuiltIn SubgroupSize
+
+    [[builtin subgroup_invocation_idx]]
+          OpDecorate %gl_SubgroupInvocationID BuiltIn SubgroupLocalInvocationId
   </xmp>
 </div>
 
@@ -2873,6 +2879,12 @@ TODO: list storage class and shader stage restrictions.
     <tr><td>local_invocation_id<td>vec3&ltu32&gt<td>Compute Input
     <tr><td>global_invocation_id<td>vec3&ltu32&gt<td>Compute Input
     <tr><td>local_invocation_idx<td>u32<td>Compute Input
+    <tr><td>subgroup_size<td>u32<td>Compute Input<br>
+                                    Exists if "subgroup-operations"<br>
+                                    is enabled in requestDevice.
+    <tr><td>subgroup_invocation_idx<td>u32<td>Compute Input<br>
+                                              Exists if "subgroup-operations"<br>
+                                              is enabled in requestDevice.
 </table>
 
 # Built-in functions # {#builtin-functions}
@@ -3016,6 +3028,36 @@ TODO(dsinclair): Need gather operations
 </pre>
 
 ## Atomic built-in functions ## {#atomic-builtin-functions}
+
+## Subgroup built-in functions ## {#subgroup-builtin-functions}
+
+<table class='data'>
+  <thead>
+    <tr><td>Subgroup built-in functions<td>SPIR-V
+  </thead>
+  <tr><td>subgroup_is_first() -&gt; bool<td>OpGroupNonUniformElect
+  <tr><td>subgroup_all(bool) -&gt; bool<td>OpGroupNonUniformAll
+  <tr><td>subgroup_any(bool) -&gt; bool<td>OpGroupNonUniformAny
+  <tr><td>subgroup_ballot(bool) -&gt; vec4&lt;u32&gt;<td>OpGroupNonUniformBallot
+  <tr><td>subgroup_broadcast_first(Scalar) -&gt; Scalar<td>OpGroupNonUniformBroadcastFirst
+  <tr><td>subgroup_add(Integral) -&gt; Integral<td>OpGroupNonUniformIAdd with Reduce
+  <tr><td>subgroup_add(Floating) -&gt; Floating<td>OpGroupNonUniformFAdd with Reduce
+  <tr><td>subgroup_mul(Integral) -&gt; Integral<td>OpGroupNonUniformIMul with Reduce
+  <tr><td>subgroup_mul(Floating) -&gt; Floating<td>OpGroupNonUniformFMul with Reduce
+  <tr><td>subgroup_min(Integral) -&gt; Integral<td>OpGroupNonUniformUMin or OpGroupNonUniformSMin with Reduce
+  <tr><td>subgroup_min(Floating) -&gt; Floating<td>OpGroupNonUniformFMin with Reduce
+  <tr><td>subgroup_max(Integral) -&gt; Integral<td>OpGroupNonUniformUMax or OpGroupNonUniformSMax with Reduce
+  <tr><td>subgroup_max(Floating) -&gt; Floating<td>OpGroupNonUniformFMax with Reduce
+  <tr><td>subgroup_and(Integral) -&gt; Integral<td>OpGroupNonUniformBitwiseAnd
+  <tr><td>subgroup_or(Integral) -&gt; Integral<td>OpGroupNonUniformBitwiseOr
+  <tr><td>subgroup_xor(Integral) -&gt; Integral<td>OpGroupNonUniformBitwiseXor
+  <tr><td>subgroup_prefix_add(Integral) -&gt; Integral<td>OpGroupNonUniformIAdd with ExclusiveScan
+  <tr><td>subgroup_prefix_add(Floating) -&gt; Floating<td>OpGroupNonUniformFAdd with ExclusiveScan
+  <tr><td>subgroup_prefix_mul(Integral) -&gt; Integral<td>OpGroupNonUniformIMul with ExclusiveScan
+  <tr><td>subgroup_prefix_mul(Floating) -&gt; Floating<td>OpGroupNonUniformFMul with ExclusiveScan
+</table>
+
+Note: Subgroup functions exist if "subgroup-operations" is enabled in requestDevice.
 
 # Glossary # {#glossary}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3035,26 +3035,26 @@ TODO(dsinclair): Need gather operations
   <thead>
     <tr><td>Subgroup built-in functions<td>SPIR-V
   </thead>
-  <tr><td>subgroup_is_first() -&gt; bool<td>OpGroupNonUniformElect
-  <tr><td>subgroup_all(bool) -&gt; bool<td>OpGroupNonUniformAll
-  <tr><td>subgroup_any(bool) -&gt; bool<td>OpGroupNonUniformAny
-  <tr><td>subgroup_ballot(bool) -&gt; vec4&lt;u32&gt;<td>OpGroupNonUniformBallot
-  <tr><td>subgroup_broadcast_first(Scalar) -&gt; Scalar<td>OpGroupNonUniformBroadcastFirst
-  <tr><td>subgroup_add(Integral) -&gt; Integral<td>OpGroupNonUniformIAdd with Reduce
-  <tr><td>subgroup_add(Floating) -&gt; Floating<td>OpGroupNonUniformFAdd with Reduce
-  <tr><td>subgroup_mul(Integral) -&gt; Integral<td>OpGroupNonUniformIMul with Reduce
-  <tr><td>subgroup_mul(Floating) -&gt; Floating<td>OpGroupNonUniformFMul with Reduce
-  <tr><td>subgroup_min(Integral) -&gt; Integral<td>OpGroupNonUniformUMin or OpGroupNonUniformSMin with Reduce
-  <tr><td>subgroup_min(Floating) -&gt; Floating<td>OpGroupNonUniformFMin with Reduce
-  <tr><td>subgroup_max(Integral) -&gt; Integral<td>OpGroupNonUniformUMax or OpGroupNonUniformSMax with Reduce
-  <tr><td>subgroup_max(Floating) -&gt; Floating<td>OpGroupNonUniformFMax with Reduce
-  <tr><td>subgroup_and(Integral) -&gt; Integral<td>OpGroupNonUniformBitwiseAnd
-  <tr><td>subgroup_or(Integral) -&gt; Integral<td>OpGroupNonUniformBitwiseOr
-  <tr><td>subgroup_xor(Integral) -&gt; Integral<td>OpGroupNonUniformBitwiseXor
-  <tr><td>subgroup_prefix_add(Integral) -&gt; Integral<td>OpGroupNonUniformIAdd with ExclusiveScan
-  <tr><td>subgroup_prefix_add(Floating) -&gt; Floating<td>OpGroupNonUniformFAdd with ExclusiveScan
-  <tr><td>subgroup_prefix_mul(Integral) -&gt; Integral<td>OpGroupNonUniformIMul with ExclusiveScan
-  <tr><td>subgroup_prefix_mul(Floating) -&gt; Floating<td>OpGroupNonUniformFMul with ExclusiveScan
+  <tr><td>subgroupIsFirst() -&gt; bool<td>OpGroupNonUniformElect
+  <tr><td>subgroupAll(bool) -&gt; bool<td>OpGroupNonUniformAll
+  <tr><td>subgroupAny(bool) -&gt; bool<td>OpGroupNonUniformAny
+  <tr><td>subgroupBallot(bool) -&gt; vec4&lt;u32&gt;<td>OpGroupNonUniformBallot
+  <tr><td>subgroupBroadcastFirst(Scalar) -&gt; Scalar<td>OpGroupNonUniformBroadcastFirst
+  <tr><td>subgroupAdd(Integral) -&gt; Integral<td>OpGroupNonUniformIAdd with Reduce
+  <tr><td>subgroupAdd(Floating) -&gt; Floating<td>OpGroupNonUniformFAdd with Reduce
+  <tr><td>subgroupMul(Integral) -&gt; Integral<td>OpGroupNonUniformIMul with Reduce
+  <tr><td>subgroupMul(Floating) -&gt; Floating<td>OpGroupNonUniformFMul with Reduce
+  <tr><td>subgroupMin(Integral) -&gt; Integral<td>OpGroupNonUniformUMin or OpGroupNonUniformSMin with Reduce
+  <tr><td>subgroupMin(Floating) -&gt; Floating<td>OpGroupNonUniformFMin with Reduce
+  <tr><td>subgroupMax(Integral) -&gt; Integral<td>OpGroupNonUniformUMax or OpGroupNonUniformSMax with Reduce
+  <tr><td>subgroupMax(Floating) -&gt; Floating<td>OpGroupNonUniformFMax with Reduce
+  <tr><td>subgroupAnd(Integral) -&gt; Integral<td>OpGroupNonUniformBitwiseAnd
+  <tr><td>subgroupOr(Integral) -&gt; Integral<td>OpGroupNonUniformBitwiseOr
+  <tr><td>subgroupXor(Integral) -&gt; Integral<td>OpGroupNonUniformBitwiseXor
+  <tr><td>subgroupPrefixAdd(Integral) -&gt; Integral<td>OpGroupNonUniformIAdd with ExclusiveScan
+  <tr><td>subgroupPrefixAdd(Floating) -&gt; Floating<td>OpGroupNonUniformFAdd with ExclusiveScan
+  <tr><td>subgroupPrefixMul(Integral) -&gt; Integral<td>OpGroupNonUniformIMul with ExclusiveScan
+  <tr><td>subgroupPrefixMul(Floating) -&gt; Floating<td>OpGroupNonUniformFMul with ExclusiveScan
 </table>
 
 Note: Subgroup functions exist if "subgroup-operations" is enabled in requestDevice.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2770,7 +2770,7 @@ TODO(dsinclair): Need gather operations
   <tr><td>subgroup_is_first() -&gt; bool<td>OpGroupNonUniformElect
   <tr><td>subgroup_all(bool) -&gt; bool<td>OpGroupNonUniformAll
   <tr><td>subgroup_any(bool) -&gt; bool<td>OpGroupNonUniformAny
-  <tr><td>subgroup_ballot(bool) -&gt; vec2&lt;u32&gt;<td>OpGroupNonUniformBallot
+  <tr><td>subgroup_ballot(bool) -&gt; vec4&lt;u32&gt;<td>OpGroupNonUniformBallot
   <tr><td>subgroup_broadcast(Scalar,u32) -&gt; Scalar<td>OpGroupNonUniformBroadcast
   <tr><td>subgroup_broadcast_first(Scalar) -&gt; Scalar<td>OpGroupNonUniformBroadcastFirst
   <tr><td>subgroup_add(Integral) -&gt; Integral<td>OpGroupNonUniformIAdd with Reduce

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2769,7 +2769,6 @@ TODO(dsinclair): Need gather operations
   <tr><td>subgroup_all(bool) -&gt; bool<td>OpGroupNonUniformAll
   <tr><td>subgroup_any(bool) -&gt; bool<td>OpGroupNonUniformAny
   <tr><td>subgroup_ballot(bool) -&gt; vec4&lt;u32&gt;<td>OpGroupNonUniformBallot
-  <tr><td>subgroup_broadcast(Scalar,u32) -&gt; Scalar<td>OpGroupNonUniformBroadcast
   <tr><td>subgroup_broadcast_first(Scalar) -&gt; Scalar<td>OpGroupNonUniformBroadcastFirst
   <tr><td>subgroup_add(Integral) -&gt; Integral<td>OpGroupNonUniformIAdd with Reduce
   <tr><td>subgroup_add(Floating) -&gt; Floating<td>OpGroupNonUniformFAdd with Reduce

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2747,6 +2747,17 @@ TODO(dsinclair): Add Level-of-Detail via explicit gradient. "Grad" image operand
 TODO(dsinclair): Need gather operations
 </pre>
 
+## Subgroup built-in functions ## {#subgroup-builtin-functions}
+
+<table class='data'>
+  <thead>
+    <tr><td>Subgroup built-in functions<td>SPIR-V
+  </thead>
+</table>
+
+Note: Functions usable if "subgroup-operations" is both supported
+      by the device/user agent and is enabled in requestDevice.
+
 # Glossary # {#glossary}
 
 <table class='data'>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2755,7 +2755,7 @@ TODO(dsinclair): Need gather operations
   </thead>
 </table>
 
-Note: Functions usable if "subgroup-operations" is both supported
+Note: Functions exist if "subgroup-operations" is both supported
       by the device/user agent and is enabled in requestDevice.
 
 # Glossary # {#glossary}


### PR DESCRIPTION
**Preview WebGPU Changes:** https://mehmetoguzderin.github.io/webgpu/webgpu.html
**Preview WGSL Changes:** https://mehmetoguzderin.github.io/webgpu/wgsl.html
**Preview Argdown:** https://kvark.github.io/webgpu-debate/SubgroupOps.component.html

This pull request works towards https://github.com/gpuweb/gpuweb/issues/667 for standard library. For that, the first form of subgroup operations extension to host and device specifications is introduced. Host exposure is directly deducible for all host APIs since it is compute-only, and the set of device instructions is the greatest common factor minus operations that take in a mask or invocation index.


# Motivation

Subgroup operations provide [speed-up](https://developer.nvidia.com/blog/cuda-pro-tip-optimized-filtering-warp-aggregated-atomics/) proportional to the subgroup size. They provide a great opportunity to optimize both global and local reduction operations, especially for algorithms that need to specialize general graphs. And their presence is getting more common than ever.


# Trade-offs

## Lack of Exposed Hardware Banding

Although it is possible to increase market penetration of subgroup operations extension significantly by banding it to permutation and reduction similar to Metal, such direction increases the API surface, possibly crusting for a very narrow use case. Moreover, [indicators](http://www.vulkan.gpuinfo.org/displayreport.php?id=9027) of next-generation mobile hardware show that they will almost ubiquitously support reduction operations.

## Exclusion of Quad Operations

This proposal excludes quad operations from the definition of subgroup operations. New hardware reports on [Adreno](http://www.vulkan.gpuinfo.org/displayreport.php?id=9027) and [PowerVR](http://vulkan.gpuinfo.org/displayreport.php?id=8768) show lack of quad support. Also, excluding quad operations makes it easier to avoid more ambiguous operations, delegating their presence to a proper quad operations extension.

## Exclusion of Indexed or Masked Operations

This proposal excludes indexed or masked operations to avoid undefined behavior on divergence, reconvergence, and possibly out of bounds indexing. The current set of exposed operations are implicitly active on all APIs.


# Presence of Extension for APIs

DirectX 12 | Metal | Vulkan
-|-|-
`D3D12_FEATURE_DATA_D3D12_OPTIONS1.WaveOps` | `MTLDevice.supportsFamily(MTLGPUFamilyMac2)` ([needs clarification](https://developer.apple.com/documentation/metal/porting_your_metal_code_to_apple_silicon): ` MTLDevice.supportsFamily(MTLGPUFamilyApple6)`) | `(VkPhysicalDeviceSubgroupProperties.supportedOperations & (VK_SUBGROUP_FEATURE_BASIC_BIT & VK_SUBGROUP_FEATURE_VOTE_BIT & VK_SUBGROUP_FEATURE_ARITHMETIC_BIT & VK_SUBGROUP_FEATURE_BALLOT_BIT)) & (VkPhysicalDeviceSubgroupProperties.supportedStages & VK_SHADER_STAGE_COMPUTE_BIT)`


# Related Issues

- https://github.com/gpuweb/gpuweb/issues/667
- https://github.com/gpuweb/gpuweb/issues/78
- https://github.com/gpuweb/WSL/issues/5


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mehmetoguzderin/gpuweb/pull/954.html" title="Last updated on Nov 5, 2020, 2:30 PM UTC (12b284e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/954/12458b4...mehmetoguzderin:12b284e.html" title="Last updated on Nov 5, 2020, 2:30 PM UTC (12b284e)">Diff</a>