### PR TITLE
Change rowsPerImage to count in blocks

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4044,6 +4044,9 @@ write into a [=texture=] from the {{GPUQueue}}.
   - For {{GPUTextureDimension/2d}} textures, data is copied between one or multiple contiguous [=images=] and [=array layers=].
   - For {{GPUTextureDimension/3d}} textures, data is copied between one or multiple contiguous [=images=] and depth [=slices=].
 
+Operations that copy between byte arrays and textures always work with rows of [=texel blocks=],
+which we'll call <dfn dfn>block row</dfn>s. It's not possible to update only a part of a [=texel block=].
+
 Issue: Define images more precisely. In particular, define them as being comprised of [=texel blocks=].
 
 Issue: Define the exact copy semantics, by reference to common algorithms shared by the copy methods.
@@ -4051,11 +4054,11 @@ Issue: Define the exact copy semantics, by reference to common algorithms shared
 <dl dfn-type=dict-member dfn-for=GPUTextureDataLayout>
     : <dfn>bytesPerRow</dfn>
     ::
-        The stride, in bytes, between the beginning of each row of [=texel blocks=] and the subsequent row.
+        The stride, in bytes, between the beginning of each [=block row=] and the subsequent [=block row=].
 
     : <dfn>rowsPerImage</dfn>
     ::
-        Number of block rows per single [=image=] of the [=texture=].
+        Number of [=block rows=] per single [=image=] of the [=texture=].
         {{GPUTextureDataLayout/rowsPerImage}} &times;
         {{GPUTextureDataLayout/bytesPerRow}} is the stride, in bytes, between the beginning of each [=image=] of data and the subsequent [=image=].
 </dl>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4055,9 +4055,9 @@ Issue: Define the exact copy semantics, by reference to common algorithms shared
 
     : <dfn>rowsPerImage</dfn>
     ::
-        {{GPUTextureDataLayout/rowsPerImage}} &divide; [=texel block height=] &times;
-        {{GPUTextureDataLayout/bytesPerRow}} is the stride, in bytes, between the beginning of each [=image=]
-        of data and the subsequent [=image=].
+        Number of block rows per single [=image=] of the [=texture=].
+        {{GPUTextureDataLayout/rowsPerImage}} &times;
+        {{GPUTextureDataLayout/bytesPerRow}} is the stride, in bytes, between the beginning of each [=image=] of data and the subsequent [=image=].
 </dl>
 
 ### <dfn dictionary>GPUBufferCopyView</dfn> ### {#gpu-buffer-copy-view}
@@ -4226,8 +4226,7 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
             if (copyExtent.width == 0 || copyExtent.height == 0 || copyExtent.depth == 0) {
                 requiredBytesInCopy = 0;
             } else {
-                GPUSize64 texelBlockRowsPerImage = layout.rowsPerImage / blockHeight;
-                GPUSize64 bytesPerImage = layout.bytesPerRow * texelBlockRowsPerImage;
+                GPUSize64 bytesPerImage = layout.bytesPerRow * layout.rowsPerImage;
                 GPUSize64 bytesInLastSlice =
                     layout.bytesPerRow * (copyExtent.height / blockHeight - 1) + (copyExtent.width / blockWidth * blockSize);
                 requiredBytesInCopy = bytesPerImage * (copyExtent.depth - 1) + bytesInLastSlice;
@@ -4238,19 +4237,18 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
 
     For the copy being in-bounds:
     - If |layout|.{{GPUTextureDataLayout/rowsPerImage}} is not 0, it must be greater than or equal to
-        |copyExtent|.[=Extent3D/height=].
+        |copyExtent|.[=Extent3D/height=] &divide; |blockHeight|.
     - (|layout|.{{GPUTextureDataLayout/offset}} + |requiredBytesInCopy|) must not overflow a {{GPUSize64}}.
     - (|layout|.{{GPUTextureDataLayout/offset}} + |requiredBytesInCopy|) must be smaller than or equal to |byteSize|.
 
     For the texel block alignments:
-    - |layout|.{{GPUTextureDataLayout/rowsPerImage}} must be a multiple of |blockHeight|.
     - |layout|.{{GPUTextureDataLayout/offset}} must be a multiple of |blockSize|.
 
     For other members in |layout|:
     - If |copyExtent|.[=Extent3D/height=] is greater than 1 or |copyExtent|.[=Extent3D/depth=] is greater than 1:
         - |layout|.{{GPUTextureDataLayout/bytesPerRow}} must be greater than or equal to the number of |bytesInACompleteRow|.
     - If |copyExtent|.[=Extent3D/depth=] is greater than 1:
-        - |layout|.{{GPUTextureDataLayout/rowsPerImage}} must be greater than or equal to |copyExtent|.[=Extent3D/height=].
+        - |layout|.{{GPUTextureDataLayout/rowsPerImage}} must not be 0.
 </div>
 
 <div algorithm class=validusage>


### PR DESCRIPTION
This PR tries to address a consistency problem noted by @cwfitzgerald: we have 2 fields with "row" in them: `bytesPerRow` and `rowsPerImage`. However, the former is actually per row of blocks, while the latter is currently about row of texels. This is confusing. We could change the naming to indicate the difference. This PR changes the semantics of `rowsPerImage` instead, such that anything with "row" in it talks about texel blocks only.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/958.html" title="Last updated on Aug 14, 2020, 4:01 PM UTC (ca240aa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/958/2688ff1...kvark:ca240aa.html" title="Last updated on Aug 14, 2020, 4:01 PM UTC (ca240aa)">Diff</a>