### PR TITLE
Updating the style of the methods I've documented

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3729,78 +3729,72 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 
 ## Pass Encoding ## {#command-encoder-pass-encoding}
 
-### <dfn method for=GPUCommandEncoder>beginRenderPass(descriptor)</dfn> ### {#GPUCommandEncoder-beginRenderPass}
+<dl dfn-type="method" dfn-for="GPUCommandEncoder">
+    : <dfn>beginRenderPass(descriptor)</dfn>
+    ::
 
-<div algorithm="GPUCommandEncoder.beginRenderPass">
-    <strong>|this|:</strong> of type {{GPUCommandEncoder}}.
+        Begins encoding a render pass described by |descriptor|.
 
-    **Arguments:**
-        - {{GPURenderPassDescriptor}} |descriptor|
+        <div algorithm=GPUCommandEncoder.beginRenderPass>
+            **Called on:** {{GPUCommandEncoder}} |this|.
 
-    **Returns:** {{GPURenderPassEncoder}}
+            **Arguments:**
+            <ul dfn-type=argument dfn-for="GPUCommandEncoder/beginRenderPass(descriptor)">
+                - |descriptor|: {{GPURenderPassDescriptor}} <dfn>descriptor</dfn>
+            </ul
 
-    Begins encoding a render pass described by |descriptor|.
+            **Returns:** {{GPURenderPassEncoder}}
 
-    On the [=Device timeline=], the following steps occur:
+            - Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
+                    - If any of the following conditions are unsatisfied, generate a validation
+                        error and stop.
+                        <div class=validusage>
+                            - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
+                            - |descriptor| meets the
+                                [$GPURenderPassDescriptor/GPURenderPassDescriptor Valid Usage$] rules.
+                        </div>
+                    - Set |this|.{{GPUCommandEncoder/[[state]]}} to {{encoder state/encoding a render pass}}.
+                    - For each |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
+                        - The texture [=subresource=] seen by |colorAttachment|.{{GPURenderPassColorAttachmentDescriptor/attachment}}
+                            is considered to be used as {{GPUTextureUsage/OUTPUT_ATTACHMENT}} for the
+                            duration of the render pass.
+                    - Let |depthStencilAttachment| be |descriptor|.{{GPURenderPassDescriptor/depthStencilAttachment}}.
+                    - If |depthStencilAttachment| is not `null`:
+                        - The texture [=subresource=] seen by |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}
+                            is considered to be used as {{GPUTextureUsage/OUTPUT_ATTACHMENT}} for the
+                            duration of the render pass.
+                </div>
 
-        - If the [$GPUCommandEncoder.beginRenderPass/beginRenderPass Valid Usage$] rules are met:
+            Issue: specify the behavior of read-only depth/stencil
+        </div>
 
-            - Set |this|.{{GPUCommandEncoder/[[state]]}} to {{encoder state/encoding a render pass}}.
+    : <dfn>beginComputePass(descriptor)</dfn>
+    ::
 
-            - For each |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
+        Begins encoding a compute pass described by |descriptor|.
 
-                - The texture [=subresource=] seen by |colorAttachment|.{{GPURenderPassColorAttachmentDescriptor/attachment}}
-                    is considered to be used as {{GPUTextureUsage/OUTPUT_ATTACHMENT}} for the
-                    duration of the render pass.
+        <div algorithm=GPUCommandEncoder.beginComputePass>
+            **Called on:** {{GPUCommandEncoder}} |this|.
 
-            - Let |depthStencilAttachment| be |descriptor|.{{GPURenderPassDescriptor/depthStencilAttachment}}.
-            - If |depthStencilAttachment| is not `null`:
+            **Arguments:**
+            <ul dfn-type=argument dfn-for="GPUCommandEncoder/beginComputePass(descriptor)">
+                - descriptor: {{GPUComputePassDescriptor}} <dfn>descriptor</dfn>
+            </ul
 
-                - The texture [=subresource=] seen by |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}
-                    is considered to be used as {{GPUTextureUsage/OUTPUT_ATTACHMENT}} for the
-                    duration of the render pass.
+            **Returns:** {{GPUComputePassEncoder}}
 
-    Issue: specify the behavior of read-only depth/stencil
-
-    <div class=validusage dfn-for=GPUCommandEncoder.beginRenderPass>
-        <dfn abstract-op>beginRenderPass Valid Usage</dfn>
-
-        Given the argument {{GPURenderPassDescriptor}} |descriptor|, the following validation rules apply:
-
-          1. |this|.{{GPUCommandEncoder/[[state]]}} must be {{encoder state/open}}.
-          1. |descriptor| must meet the
-            [$GPURenderPassDescriptor/GPURenderPassDescriptor Valid Usage$] rules.
-
-    </div>
-</div>
-
-### <dfn method for=GPUCommandEncoder>beginComputePass(descriptor)</dfn> ### {#GPUCommandEncoder-beginComputePass}
-
-<div algorithm="GPUCommandEncoder.beginComputePass">
-    <strong>|this|:</strong> of type {{GPUCommandEncoder}}.
-
-    **Arguments:**
-        - {{GPUComputePassDescriptor}} |descriptor|
-
-    **Returns:** {{GPUComputePassEncoder}}
-
-    Begins encoding a compute pass described by |descriptor|.
-
-    On the [=Device timeline=], the following steps occur:
-
-        - If the [$GPUCommandEncoder.beginComputePass/beginComputePass Valid Usage$] rules are met:
-
-            - Set |this|.{{GPUCommandEncoder/[[state]]}} to {{encoder state/encoding a compute pass}}.
-
-    <div class=validusage dfn-for=GPUCommandEncoder.beginComputePass>
-        <dfn abstract-op>beginComputePass Valid Usage</dfn>
-
-        Given the argument {{GPUComputePassDescriptor}} |descriptor|, the following validation rules apply:
-
-          1. |this|.{{GPUCommandEncoder/[[state]]}} must be {{encoder state/open}}.
-
-    </div>
-</div>
+            - Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
+                    - If any of the following conditions are unsatisfied, generate a validation
+                        error and stop.
+                        <div class=validusage>
+                            - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
+                        </div>
+                    - Set |this|.{{GPUCommandEncoder/[[state]]}} to {{encoder state/encoding a compute pass}}.
+                </div>
+        </div>
+</dl>
 
 ## Copy Commands ## {#copy-commands}
 
@@ -4481,24 +4475,31 @@ The compute pass encoder can be ended by calling {{GPUComputePassEncoder/endPass
 has finished recording commands for the pass. Once {{GPUComputePassEncoder/endPass()}} has been
 called the compute pass encoder can no longer be used.
 
-### <dfn method for=GPUComputePassEncoder>endPass()</dfn> ### {#GPUComputePassEncoder-endPass}
+<dl dfn-type="method" dfn-for="GPUComputePassEncoder">
+    : <dfn>endPass()</dfn>
+    ::
 
-<div algorithm="GPUComputePassEncoder.endPass">
-    <strong>|this|:</strong> of type {{GPUComputePassEncoder}}.
+        Completes recording of the compute pass commands sequence.
 
-    **Returns:** void
+        <div algorithm="GPUComputePassEncoder.endPass">
+            **Called on:** {{GPUComputePassEncoder}} |this|.
 
-    Completes recording of the compute pass commands sequence.
+            **Returns:** void
 
-    <div class=validusage dfn-for=GPUComputePassEncoder.endPass>
-        <dfn abstract-op>Valid Usage</dfn>
+            - Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
+                    - If any of the following conditions are unsatisfied,
+                        generate a validation error and stop.
+                        <div class=validusage>
+                            - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.length is 0.
+                        </div>
 
-        - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.length must 0.
+                    Issue: Add remaining validation.
+                </div>
 
-        Issue: Add remaining validation.
-    </div>
-
-</div>
+            Issue: Allowed for GPUs to use fixed point or rounded viewport coordinates
+        </div>
+</dl>
 
 # Render Passes # {#render-passes}
 
@@ -4799,115 +4800,115 @@ enum GPUStoreOp {
 
 ## Rasterization state ## {#render-pass-encoder-rasterization-state}
 
-The render pass encoder has several methods which affect how draw commands are rasterized to the
+The {{GPURenderPassEncoder}} has several methods which affect how draw commands are rasterized to
 attachments used by this encoder.
 
-### <dfn method for=GPURenderPassEncoder>setViewport(x, y, width, height, minDepth, maxDepth)</dfn> ### {#GPURenderPassEncoder-setViewport}
+<dl dfn-type="method" dfn-for="GPURenderPassEncoder">
+    : <dfn>setViewport(x, y, width, height, minDepth, maxDepth)</dfn>
+    ::
 
-<div algorithm="GPURenderPassEncoder.setViewport">
-    <strong>this:</strong> of type {{GPURenderPassEncoder}}.
+        Sets the viewport used during the rasterization stage to linearly map from normalized device
+        coordinates to viewport coordinates.
 
-    **Arguments:**
-        - `float` |x| - minimum X value of the viewport in pixels
-        - `float` |y| - minimum Y value of the viewport in pixels
-        - `float` |width| of the viewport in pixels
-        - `float` |height| of the viewport in pixels
-        - `float` |minDepth| - Minimum depth value of the viewport
-        - `float` |maxDepth| - Maximum depth value of the viewport.
+        <div algorithm="GPURenderPassEncoder.setViewport">
+            **Called on:** {{GPURenderPassEncoder}} |this|.
 
-    Issue: Are flipped depth ranges supported on all backends?
+            **Arguments:**
+            <ul dfn-type=argument dfn-for="GPURenderPassEncoder/setViewport(x, y, width, height, minDepth, maxDepth)">
+                - |x|: `float` <dfn>x</dfn> minimum X value of the viewport in pixels
+                - |y|: `float` <dfn>y</dfn> minimum Y value of the viewport in pixels
+                - |width|: `float` <dfn>width</dfn> of the viewport in pixels
+                - |height|: `float` <dfn>height</dfn> of the viewport in pixels
+                - |minDepth|: `float` <dfn>minDepth</dfn> Minimum depth value of the viewport
+                - |maxDepth|: `float` <dfn>maxDepth</dfn> Maximum depth value of the viewport.
+            </ul>
 
-    **Returns:** void
+            **Returns:** void
 
-    Sets the viewport used during the rasterization stage to linearly map from normalized device
-    coordinates to viewport coordinates.
+            - Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
+                    - If any of the following conditions are unsatisfied, generate a validation
+                        error and stop.
+                        <div class=validusage>
+                            - |width| is greater than `0`.
+                            - |height| is greater than `0`.
+                            - |minDepth| is greater than or equal to `0.0` and less than or equal to `1.0`.
+                            - |maxDepth| is greater than or equal to `0.0` and less than or equal to `1.0`.
+                        </div>
+                    - Set the viewport to the extents |x|, |y|, |width|, |height|, |minDepth|, and |maxDepth|.
+                </div>
 
-    On the [=Device timeline=], the following steps occur:
+            Issue: Allowed for GPUs to use fixed point or rounded viewport coordinates
+        </div>
 
-        - If the [$GPURenderPassEncoder.setViewport/setViewport Valid Usage$] rules are met:
+    : <dfn>setScissorRect(x, y, width, height)</dfn>
+    ::
 
-            - Set the viewport to the extents |x|, |y|, |width|, |height|, |minDepth|, and |maxDepth|.
+        Sets the scissor rectangle used during the rasterization stage.
+        After transformation into viewport coordinates any fragments which fall outside the scissor
+        rectangle will be discarded.
 
-    <div class=validusage dfn-for=GPURenderPassEncoder.setViewport>
-        <dfn abstract-op>setViewport Valid Usage</dfn>
+        <div algorithm="GPURenderPassEncoder.setScissorRect">
+            **Called on:** {{GPURenderPassEncoder}} |this|.
 
-        1. |width| must be greater than `0`.
-        1. |height| must be greater than `0`.
-        1. |minDepth| must be greater than or equal to `0.0` and less than or equal to `1.0`.
-        1. |maxDepth| must be greater than or equal to `0.0` and less than or equal to `1.0`.
+            **Arguments:**
+            <ul dfn-type=argument dfn-for="GPURenderPassEncoder/setScissorRect(x, y, width, height)">
+                - |x|: {{GPUIntegerCoordinate}} <dfn>x</dfn> minimum X value of the scissor rectangle in pixels
+                - |y|: {{GPUIntegerCoordinate}} <dfn>y</dfn> minimum Y value of the scissor rectangle in pixels
+                - |width|: {{GPUIntegerCoordinate}} <dfn>width</dfn> of the scissor rectangle in pixels
+                - |height|: {{GPUIntegerCoordinate}} <dfn>height</dfn> of the scissor rectangle in pixels
+            </ul>
 
-    </div>
+            **Returns:** void
 
-    Issue: Allowed for GPUs to use fixed point or rounded viewport coordinates
+            - Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
+                    - If any of the following conditions are unsatisfied, generate a validation
+                        error and stop.
+                        <div class=validusage>
+                            - |x| is greater than or equal to `0`.
+                            - |y| is greater than or equal to `0`.
+                            - |width| is greater than `0`.
+                            - |height| is greater than `0`.
+                            - |x|+|width| is less than or equal to
+                                |this|.{{GPURenderPassEncoder/[[attachment_size]]}}.width.
+                            - |y|+|height| is less than or equal to
+                                |this|.{{GPURenderPassEncoder/[[attachment_size]]}}.height.
+                        </div>
+                    - Set the scissor rectangle to the extents |x|, |y|, |width|, and |height|.
+                </div>
+        </div>
 
-</div>
+    : <dfn>setBlendColor(color)</dfn>
+    ::
 
-### <dfn method for=GPURenderPassEncoder>setScissorRect(x, y, width, height)</dfn> ### {#GPURenderPassEncoder-setScissorRect}
+        Sets the constant blend color and alpha values used with {{GPUBlendFactor/"blend-color"}}
+        and {{GPUBlendFactor/"one-minus-blend-color"}} {{GPUBlendFactor}}s.
 
-<div algorithm="GPURenderPassEncoder.setScissorRect">
-    <strong>|this|:</strong> of type {{GPURenderPassEncoder}}.
+        <div algorithm="GPURenderPassEncoder.setBlendColor">
+            **Called on:** {{GPURenderPassEncoder}} this.
 
-    **Arguments:**
-        - {{GPUIntegerCoordinate}} |x| - minimum X value of the scissor rectangle in pixels
-        - {{GPUIntegerCoordinate}} |y| - minimum Y value of the scissor rectangle in pixels
-        - {{GPUIntegerCoordinate}} |width| of the scissor rectangle in pixels
-        - {{GPUIntegerCoordinate}} |height| of the scissor rectangle in pixels
+            **Arguments:**
+            <ul dfn-type=argument dfn-for="GPURenderPassEncoder/setBlendColor(color)">
+                - color: {{GPUColor}} <dfn>color</dfn>
+            </ul>
+        </div>
 
-    **Returns:** void
+    : <dfn>setStencilReference(reference)</dfn>
+    ::
 
-    Sets the scissor rectangle used during the rasterization stage.
-    After transformation into viewport coordinates any fragments which fall outside the scissor
-    rectangle will be discarded.
+        Sets the stencil reference value used during stencil tests with the the
+        {{GPUStencilOperation/"replace"}} {{GPUStencilOperation}}.
 
-    On the [=Device timeline=], the following steps occur:
+        <div algorithm="GPURenderPassEncoder.setStencilReference">
+            **Called on:** {{GPURenderPassEncoder}} this.
 
-        - If the [$GPURenderPassEncoder.setScissorRect/setScissorRect Valid Usage$] rules are met:
-
-            - Set the scissor rectangle to the extents |x|, |y|, |width|, and |height|.
-
-    <div class=validusage dfn-for=GPURenderPassEncoder.setScissorRect>
-        <dfn abstract-op>setScissorRect Valid Usage</dfn>
-
-        1. |x| must be greater than or equal to `0`.
-        1. |y| must be greater than or equal to `0`.
-        1. |width| must be greater than `0`.
-        1. |height| must be greater than `0`.
-        1. |x|+|width| must be less than or equal to |this|.{{GPURenderPassEncoder/[[attachment_size]]}}.width.
-        1. |y|+|height| must be less than or equal to |this|.{{GPURenderPassEncoder/[[attachment_size]]}}.height.
-
-    </div>
-
-</div>
-
-### <dfn method for=GPURenderPassEncoder>setBlendColor(color)</dfn> ### {#GPURenderPassEncoder-setBlendColor}
-
-<div algorithm="GPURenderPassEncoder.setBlendColor">
-    <strong>this:</strong> of type {{GPURenderPassEncoder}}.
-
-    **Arguments:**
-        - {{GPUColor}} color
-
-    **Returns:** void
-
-    Sets the constant blend color and alpha values used with {{GPUBlendFactor/"blend-color"}} and
-    {{GPUBlendFactor/"one-minus-blend-color"}} {{GPUBlendFactor}}s.
-
-</div>
-
-### <dfn method for=GPURenderPassEncoder>setStencilReference(reference)</dfn> ### {#GPURenderPassEncoder-setStencilReference}
-
-<div algorithm="GPURenderPassEncoder.setStencilReference">
-    <strong>this:</strong> of type {{GPURenderPassEncoder}}.
-
-    **Arguments:**
-        - {{GPUStencilValue}} reference
-
-    **Returns:** void
-
-    Sets the stencil reference value used during stencil tests with the the {{GPUStencilOperation/"replace"}}
-    {{GPUStencilOperation}}.
-
-</div>
+            **Arguments:**
+            <ul dfn-type=argument dfn-for="GPURenderPassEncoder/setBlendColor(color)">
+                - reference: {{GPUStencilValue}} <dfn>reference</dfn>
+            </ul>
+        </div>
+</dl>
 
 ## Finalization ## {#render-pass-encoder-finalization}
 
@@ -4915,24 +4916,29 @@ The render pass encoder can be ended by calling {{GPURenderPassEncoder/endPass()
 has finished recording commands for the pass. Once {{GPURenderPassEncoder/endPass()}} has been
 called the render pass encoder can no longer be used.
 
-### <dfn method for=GPURenderPassEncoder>endPass()</dfn> ### {#GPURenderPassEncoder-endPass}
+<dl dfn-type="method" dfn-for="GPURenderPassEncoder">
+    : <dfn>endPass()</dfn>
+    ::
 
-<div algorithm="GPURenderPassEncoder.endPass">
-    <strong>|this|:</strong> of type {{GPURenderPassEncoder}}.
+        Completes recording of the compute pass commands sequence.
 
-    **Returns:** void
+        <div algorithm="GPURenderPassEncoder.endPass">
+            **Called on:** {{GPURenderPassEncoder}} |this|.
 
-    Completes recording of the compute pass commands sequence.
+            **Returns:** void
 
-    <div class=validusage dfn-for=GPURenderPassEncoder.endPass>
-        <dfn abstract-op>Valid Usage</dfn>
+            - Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
+                    - If any of the following conditions are unsatisfied, generate a validation
+                        error and stop.
+                        <div class=validusage>
+                            - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.length is 0.
+                        </div>
+                </div>
 
-        - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.length must 0.
-
-        Issue: Add remaining validation.
-    </div>
-
-</div>
+            Issue: Add remaining validation.
+        </div>
+</dl>
 
 # Bundles # {#bundles}
 
@@ -5112,7 +5118,7 @@ GPUQueue includes GPUObjectBase;
 
         - {{GPUQueue/copyImageBitmapToTexture(source, destination, copySize)/copySize}}.[=Extent3D/depth=] must be `1`.
         - {{GPUQueue/copyImageBitmapToTexture(source, destination, copySize)/destination}}.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} must be one of the following:
-             - {{GPUTextureFormat/"rgba8unorm"}} 
+             - {{GPUTextureFormat/"rgba8unorm"}}
              - {{GPUTextureFormat/"rgba8unorm-srgb"}}
              - {{GPUTextureFormat/"bgra8unorm"}}
              - {{GPUTextureFormat/"bgra8unorm-srgb"}}


### PR DESCRIPTION
Matching the style of Kai's most recent contributions, which I like quite a bit.

One this lands I'm happy to take a pass at the rest of the documented methods to try and normalize our method documentation across the spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/toji/gpuweb/pull/961.html" title="Last updated on Jul 29, 2020, 11:37 PM UTC (c559aff)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/961/c9ebf9a...toji:c559aff.html" title="Last updated on Jul 29, 2020, 11:37 PM UTC (c559aff)">Diff</a>