### PR TITLE
Converting argument lists to Bikeshed's argumentdef format

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -97,6 +97,35 @@ div.content-timeline, div.device-timeline, div.queue-timeline {
 .queue-timeline::before {
     content: "Queue Timeline";
 }
+
+/*
+ * Ensure that argumentdef blocks don't overflow algorithm section borders. This is made far harder
+ * than it needs to be because the top-level W3C stylesheet has several @media + min-width variants
+ * that mark themselves as !important and then proceed to do the wrong thing.
+ */
+@media screen and (min-width: 78em) {
+    body:not(.toc-inline) .algorithm .overlarge {
+        margin-right: auto !important;
+    }
+}
+@media screen and (min-width: 90em) {
+    body:not(.toc-inline) .algorithm .overlarge {
+        margin-right: auto !important;
+    }
+}
+.algorithm .overlarge {
+    margin-right: auto !important;
+}
+/*
+ * The default algorithm style has a caption that doesn't suit this spec's
+ * formatting particularly well. Hide it.
+ */
+.algorithm .argumentdef {
+    margin-top: 0;
+}
+.algorithm .argumentdef>caption {
+    display: none;
+}
 </style>
 
 
@@ -933,9 +962,9 @@ interface GPUAdapter {
             **Called on:** {{GPUAdapter}} |this|.
 
             **Arguments:**
-            <ul dfn-type=argument dfn-for="GPUAdapter/requestDevice(descriptor)">
-                - |descriptor|: optional {{GPUDeviceDescriptor}} <dfn>descriptor</dfn> = {}
-            </ul>
+            <pre class=argumentdef for="GPUAdapter/requestDevice(descriptor)">
+                |descriptor|:
+            </pre>
 
             **Returns:** |promise|, of type Promise<{{GPUDevice}}?>.
 
@@ -3739,9 +3768,9 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
             **Called on:** {{GPUCommandEncoder}} |this|.
 
             **Arguments:**
-            <ul dfn-type=argument dfn-for="GPUCommandEncoder/beginRenderPass(descriptor)">
-                - |descriptor|: {{GPURenderPassDescriptor}} <dfn>descriptor</dfn>
-            </ul
+            <pre class=argumentdef for="GPUCommandEncoder/beginRenderPass(descriptor)">
+                |descriptor|:
+            </pre>
 
             **Returns:** {{GPURenderPassEncoder}}
 
@@ -3778,9 +3807,9 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
             **Called on:** {{GPUCommandEncoder}} |this|.
 
             **Arguments:**
-            <ul dfn-type=argument dfn-for="GPUCommandEncoder/beginComputePass(descriptor)">
-                - descriptor: {{GPUComputePassDescriptor}} <dfn>descriptor</dfn>
-            </ul
+            <pre class=argumentdef for="GPUCommandEncoder/beginComputePass(descriptor)">
+                descriptor:
+            </pre>
 
             **Returns:** {{GPUComputePassEncoder}}
 
@@ -4814,14 +4843,14 @@ attachments used by this encoder.
             **Called on:** {{GPURenderPassEncoder}} |this|.
 
             **Arguments:**
-            <ul dfn-type=argument dfn-for="GPURenderPassEncoder/setViewport(x, y, width, height, minDepth, maxDepth)">
-                - |x|: `float` <dfn>x</dfn> minimum X value of the viewport in pixels
-                - |y|: `float` <dfn>y</dfn> minimum Y value of the viewport in pixels
-                - |width|: `float` <dfn>width</dfn> of the viewport in pixels
-                - |height|: `float` <dfn>height</dfn> of the viewport in pixels
-                - |minDepth|: `float` <dfn>minDepth</dfn> Minimum depth value of the viewport
-                - |maxDepth|: `float` <dfn>maxDepth</dfn> Maximum depth value of the viewport.
-            </ul>
+            <pre class=argumentdef for="GPURenderPassEncoder/setViewport(x, y, width, height, minDepth, maxDepth)">
+                |x|: Minimum X value of the viewport in pixels.
+                |y|: Minimum Y value of the viewport in pixels.
+                |width|: Width of the viewport in pixels.
+                |height|: Height of the viewport in pixels.
+                |minDepth|: Minimum depth value of the viewport.
+                |maxDepth|: Maximum depth value of the viewport.
+            </pre>
 
             **Returns:** void
 
@@ -4852,12 +4881,12 @@ attachments used by this encoder.
             **Called on:** {{GPURenderPassEncoder}} |this|.
 
             **Arguments:**
-            <ul dfn-type=argument dfn-for="GPURenderPassEncoder/setScissorRect(x, y, width, height)">
-                - |x|: {{GPUIntegerCoordinate}} <dfn>x</dfn> minimum X value of the scissor rectangle in pixels
-                - |y|: {{GPUIntegerCoordinate}} <dfn>y</dfn> minimum Y value of the scissor rectangle in pixels
-                - |width|: {{GPUIntegerCoordinate}} <dfn>width</dfn> of the scissor rectangle in pixels
-                - |height|: {{GPUIntegerCoordinate}} <dfn>height</dfn> of the scissor rectangle in pixels
-            </ul>
+            <pre class=argumentdef for="GPURenderPassEncoder/setScissorRect(x, y, width, height)">
+                |x|: Minimum X value of the scissor rectangle in pixels.
+                |y|: Minimum Y value of the scissor rectangle in pixels.
+                |width|: Width of the scissor rectangle in pixels.
+                |height|: Height of the scissor rectangle in pixels.
+            </pre>
 
             **Returns:** void
 
@@ -4889,9 +4918,9 @@ attachments used by this encoder.
             **Called on:** {{GPURenderPassEncoder}} this.
 
             **Arguments:**
-            <ul dfn-type=argument dfn-for="GPURenderPassEncoder/setBlendColor(color)">
-                - color: {{GPUColor}} <dfn>color</dfn>
-            </ul>
+            <pre class=argumentdef for="GPURenderPassEncoder/setBlendColor(color)">
+                color:
+            </pre>
         </div>
 
     : <dfn>setStencilReference(reference)</dfn>
@@ -4904,9 +4933,9 @@ attachments used by this encoder.
             **Called on:** {{GPURenderPassEncoder}} this.
 
             **Arguments:**
-            <ul dfn-type=argument dfn-for="GPURenderPassEncoder/setBlendColor(color)">
-                - reference: {{GPUStencilValue}} <dfn>reference</dfn>
-            </ul>
+            <pre class=argumentdef for="GPURenderPassEncoder/setStencilReference(reference)">
+                reference:
+            </pre>
         </div>
 </dl>
 
@@ -5018,13 +5047,13 @@ GPUQueue includes GPUObjectBase;
             **Called on:** {{GPUQueue}} |this|.
 
             **Arguments:**
-            <ul dfn-type=argument dfn-for="GPUQueue/writeBuffer(buffer, bufferOffset, data, dataOffset, size)">
-                - |buffer|: {{GPUBuffer}} <dfn>buffer</dfn>
-                - |bufferOffset|: {{GPUSize64}} <dfn>bufferOffset</dfn>
-                - |data|: <code>[{{AllowShared}}] {{ArrayBuffer}}</code> <dfn>data</dfn>
-                - |dataOffset|: optional {{GPUSize64}} <dfn>dataOffset</dfn> = 0
-                - |size|: optional {{GPUSize64}} <dfn>size</dfn>
-            </ul>
+            <pre class=argumentdef for="GPUQueue/writeBuffer(buffer, bufferOffset, data, dataOffset, size)">
+                |buffer|:
+                |bufferOffset|:
+                |data|:
+                |dataOffset|:
+                |size|:
+            </pre>
 
             **Returns:** `void`
 
@@ -5065,12 +5094,12 @@ GPUQueue includes GPUObjectBase;
             **Called on:** {{GPUQueue}} |this|.
 
             **Arguments:**
-            <ul dfn-type=argument dfn-for="GPUQueue/writeTexture(destination, data, dataLayout, size)">
-                - |destination|: {{GPUTextureCopyView}} <dfn>destination</dfn>
-                - |data|: <code>[{{AllowShared}}] {{ArrayBuffer}}</code> <dfn>data</dfn>
-                - |dataLayout|: {{GPUTextureDataLayout}} <dfn>dataLayout</dfn>
-                - |size|: {{GPUExtent3D}} <dfn>size</dfn>
-            </ul>
+            <pre class=argumentdef for="GPUQueue/writeTexture(destination, data, dataLayout, size)">
+                |destination|:
+                |data|:
+                |dataLayout|:
+                |size|:
+            </pre>
 
             **Returns:** `void`
 


### PR DESCRIPTION
Only tackling the "new style" definitions for the moment to make sure the precedent is set for any new additions. Definitely liking this formatting better, though!

The stylesheet additions at the top of this PR are a bit unfortunate, but I felt were necessary to ensure the use of this markup fit with the spec's existing style. For reference, this is how it would look _without_ the CSS changes:

<img width="758" alt="without-style-fixes" src="https://user-images.githubusercontent.com/805273/88968488-438b8100-d264-11ea-9827-8c7750149d49.png">

And this is how it looks with the CSS changes included:

<img width="760" alt="with-style-fixes" src="https://user-images.githubusercontent.com/805273/88968516-4c7c5280-d264-11ea-8667-30324efcecaf.png">


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/toji/gpuweb/pull/963.html" title="Last updated on Jul 30, 2020, 8:00 PM UTC (0fb0e91)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/963/08ac865...toji:0fb0e91.html" title="Last updated on Jul 30, 2020, 8:00 PM UTC (0fb0e91)">Diff</a>