### PR TITLE
Updating more methods to the new style.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -46,6 +46,15 @@ div.validusage {
     border: thin solid #88e !important;
     border-radius: .5em;
 }
+/*
+ * If the Valid Usage requirements are the first child of a *-timeline block give it a larger top
+ * margin to prevent the block labels from overlapping.
+ */
+.content-timeline>.validusage:first-child,
+.device-timeline>.validusage:first-child,
+.queue-timeline>.validusage:first-child {
+    margin-top: 1.5em;
+}
 
 /*
  * Boxes for steps that occur on a particular timeline.
@@ -810,37 +819,46 @@ interface GPU {
 };
 </script>
 
-{{GPU}} has the methods defined by the following sections.
+{{GPU}} has the following methods:
 
-### <dfn method for=GPU>requestAdapter(options)</dfn> ### {#requestadapter}
+<dl dfn-type="method" dfn-for="GPU">
+    : <dfn>requestAdapter(options)</dfn>
+    ::
 
-<div algorithm=GPU.requestAdapter>
-    **Arguments:**
-      - optional {{GPURequestAdapterOptions}} |options| = {}
+        Requests an [=adapter=] from the user agent.
+        The user agent chooses whether to return an adapter, and, if so,
+        chooses according to the provided options.
 
-    **Returns:** |promise|, of type Promise<{{GPUAdapter}}?>.
+        <div algorithm=GPU.requestAdapter>
+            **Called on:** {{GPU}} |this|.
 
-    Requests an [=adapter=] from the user agent.
-    The user agent chooses whether to return an adapter, and, if so,
-    chooses according to the provided |options|.
+            **Arguments:**
+            <pre class=argumentdef for="GPU/requestAdapter(options)">
+                options:
+            </pre>
 
-    Returns [=a new promise=], |promise|.
-    On the [=Device timeline=], the following steps occur:
+            **Returns:** |promise|, of type Promise<{{GPUAdapter}}?>.
 
-    - If the user agent chooses to return an adapter:
+            - Let |promise| be [=a new promise=].
+            - Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
+                    - If the user agent chooses to return an adapter:
 
-        - The user agent chooses an [=adapter=] |adapter| according to the rules in
-            [[#adapter-selection]].
+                        - The user agent chooses an [=adapter=] |adapter| according to the rules in
+                            [[#adapter-selection]].
 
-        - |promise| [=resolves=] with a new {{GPUAdapter}} encapsulating |adapter|.
+                        - |promise| [=resolves=] with a new {{GPUAdapter}} encapsulating |adapter|.
 
-    - Otherwise, |promise| [=resolves=] with `null`.
+                    - Otherwise, |promise| [=resolves=] with `null`.
+                </div>
+            - Return |promise|.
 
-    <!-- If we add ways to make invalid adapter requests (aside from those
-         that violate IDL rules), specify that they reject the promise. -->
-</div>
+            <!-- If we add ways to make invalid adapter requests (aside from those
+                 that violate IDL rules), specify that they reject the promise. -->
+        </div>
+</dl>
 
-#### Adapter Selection #### {#adapter-selection}
+### Adapter Selection ### {#adapter-selection}
 
 <dfn dictionary>GPURequestAdapterOptions</dfn>
 provides hints to the user agent indicating what
@@ -3913,11 +3931,10 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 
             - Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
-                    - If any of the following conditions are unsatisfied, generate a validation
-                        error and stop.
-                        <div class=validusage>
-                            - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
-                        </div>
+                    <div class=validusage>
+                        - If |this|.{{GPUCommandEncoder/[[state]]}} is not {{encoder state/open}},
+                            generate a validation error and stop.
+                    </div>
                     - Set |this|.{{GPUCommandEncoder/[[state]]}} to {{encoder state/encoding a compute pass}}.
                 </div>
         </div>
@@ -4370,79 +4387,78 @@ available or applicable.
 Debug groups in a {{GPUCommandEncoder}} or {{GPUProgrammablePassEncoder}}
 must be well nested.
 
-### <dfn method for=GPUCommandEncoder>pushDebugGroup(groupLabel)</dfn> ### {#GPUCommandEncoder-pushDebugGroup}
+<dl dfn-type="method" dfn-for="GPUCommandEncoder">
+    : <dfn>pushDebugGroup(groupLabel)</dfn>
+    ::
 
-<div algorithm="GPUCommandEncoder.pushDebugGroup">
-    <strong>|this|:</strong> of type {{GPUCommandEncoder}}.
+        Marks the beginning of a labeled group of commands for the {{GPUCommandEncoder}}.
 
-    **Arguments:**
-      - {{USVString}} |groupLabel|
+        <div algorithm=GPUCommandEncoder.pushDebugGroup>
+            **Called on:** {{GPUCommandEncoder}} |this|.
 
-    **Returns:** void
+            **Arguments:**
+            <pre class=argumentdef for="GPUCommandEncoder/pushDebugGroup(groupLabel)">
+                |groupLabel|: The label for the command group.
+            </pre>
 
-    Marks the beginning of a labeled group of commands for the {{GPUCommandEncoder}}.
+            **Returns:** void
 
-    |groupLabel| defines the label for the command group.
+            - Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
+                    <div class=validusage>
+                        - If |this|.{{GPUCommandEncoder/[[state]]}} is not {{encoder state/open}},
+                            generate a validation error and stop.
+                    </div>
+                    - Push |groupLabel| onto then end of |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.
+                </div>
+        </div>
 
-    On the [=Device timeline=], the following steps occur:
+    : <dfn>popDebugGroup()</dfn>
+    ::
 
-        - If the [$GPUCommandEncoder.pushDebugGroup/Valid Usage$] rules are met:
+        Marks the end of a labeled group of commands for the {{GPUCommandEncoder}}.
 
-            - push |groupLabel| onto then end of |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.
+        <div algorithm=GPUCommandEncoder.popDebugGroup>
+            **Called on:** {{GPUCommandEncoder}} |this|.
 
-    <div class=validusage dfn-for=GPUCommandEncoder.pushDebugGroup>
-        <dfn abstract-op>Valid Usage</dfn>
+            **Returns:** void
 
-        - |this|.{{GPUCommandEncoder/[[state]]}} must be {{encoder state/open}}.
-    </div>
+            - Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
+                    - If any of the following conditions are unsatisfied, generate a validation
+                        error and stop.
+                        <div class=validusage>
+                            - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
+                            - |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.length is greater than 0.
+                        </div>
+                    - Pop an entry off the end of |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.
+                </div>
+        </div>
 
-</div>
+    : <dfn>insertDebugMarker(markerLabel)</dfn>
+    ::
 
-### <dfn method for=GPUCommandEncoder>popDebugGroup()</dfn> ### {#GPUCommandEncoder-popDebugGroup}
+        Marks the end of a labeled group of commands for the {{GPUCommandEncoder}}.
 
-<div algorithm="GPUCommandEncoder.popDebugGroup">
-    <strong>|this|:</strong> of type {{GPUCommandEncoder}}.
+        <div algorithm=GPUCommandEncoder.insertDebugMarker>
+            **Called on:** {{GPUCommandEncoder}} |this|.
 
-    **Returns:** void
+            **Arguments:**
+            <pre class=argumentdef for="GPUCommandEncoder/insertDebugMarker(markerLabel)">
+                markerLabel: The label to insert.
+            </pre>
 
-    Marks the end of a labeled group of commands for the {{GPUCommandEncoder}}.
+            **Returns:** void
 
-    On the [=Device timeline=], the following steps occur:
-
-        - If the [$GPUCommandEncoder.popDebugGroup/Valid Usage$] rules are met:
-
-            - pop an entry off the end of |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.
-
-    <div class=validusage dfn-for=GPUCommandEncoder.popDebugGroup>
-        <dfn abstract-op>Valid Usage</dfn>
-
-        - |this|.{{GPUCommandEncoder/[[state]]}} must be {{encoder state/open}}.
-        - |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.length must be greater than 0.
-    </div>
-
-</div>
-
-### <dfn method for=GPUCommandEncoder>insertDebugMarker(markerLabel)</dfn> ### {#GPUCommandEncoder-insertDebugMarker}
-
-<div algorithm="GPUCommandEncoder.insertDebugMarker">
-    <strong>|this|:</strong> of type {{GPUCommandEncoder}}.
-
-    **Arguments:**
-        - {{USVString}} |markerLabel|
-
-    **Returns:** void
-
-    Inserts a single debug marker label into the {{GPUCommandEncoder}}'s commands sequence .
-
-    |markerLabel| defines the label to insert.
-
-    <div class=validusage dfn-for=GPUCommandEncoder.insertDebugMarker>
-        <dfn abstract-op>Valid Usage</dfn>
-
-        - |this|.{{GPUCommandEncoder/[[state]]}} must be {{encoder state/open}}.
-    </div>
-
-</div>
+            - Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
+                    <div class=validusage>
+                        - If |this|.{{GPUCommandEncoder/[[state]]}} is not {{encoder state/open}},
+                            generate a validation error and stop.
+                    </div>
+                </div>
+        </div>
+</dl>
 
 ## Queries ## {#command-encoder-queries}
 
@@ -4491,27 +4507,33 @@ A {{GPUCommandBuffer}} containing the commands recorded by the {{GPUCommandEncod
 by calling {{GPUCommandEncoder/finish()}}. Once {{GPUCommandEncoder/finish()}} has been called the
 command encoder can no longer be used.
 
-### <dfn method for=GPUCommandEncoder>finish(descriptor)</dfn> ### {#GPUCommandEncoder-finish}
+<dl dfn-type="method" dfn-for="GPUCommandEncoder">
+    : <dfn>finish(descriptor)</dfn>
+    ::
 
-<div algorithm="GPUCommandEncoder.finish">
-    <strong>|this|:</strong> of type {{GPUCommandEncoder}}.
+        Completes recording of the commands sequence and returns a corresponding {{GPUCommandBuffer}}.
 
-    **Arguments:**
-        - optional {{GPUCommandBufferDescriptor}} descriptor = {}
+        <div algorithm=GPUCommandEncoder.finish>
+            **Called on:** {{GPUCommandEncoder}} |this|.
 
-    **Returns:** {{GPUCommandBuffer}}
+            **Arguments:**
+            <pre class=argumentdef for="GPUCommandEncoder/finish(descriptor)">
+                descriptor:
+            </pre>
 
-    Completes recording of the commands sequence and returns a corresponding {{GPUCommandBuffer}}.
+            **Returns:** void
 
-    <div class=validusage dfn-for=GPUCommandEncoder.finish>
-        <dfn abstract-op>Valid Usage</dfn>
+            - Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
+                    <div class=validusage>
+                        - If |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.length is not 0,
+                            generate a validation error and stop.
+                    </div>
 
-        - |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.length must 0.
-
-        Issue: Add remaining validation.
-    </div>
-
-</div>
+                    Issue: Add remaining validation.
+                </div>
+        </div>
+</dl>
 
 # Programmable Passes # {#programmable-passes}
 
@@ -4600,62 +4622,64 @@ Debug marker methods for programmable pass encoders provide the same functionali
 [[#command-encoder-debug-markers|command encoder debug markers]] while recording a programmable
 pass.
 
-### <dfn method for=GPUProgrammablePassEncoder>pushDebugGroup(groupLabel)</dfn> ### {#GPUProgrammablePassEncoder-pushDebugGroup}
+<dl dfn-type="method" dfn-for="GPUProgrammablePassEncoder">
+    : <dfn>pushDebugGroup(groupLabel)</dfn>
+    ::
 
-<div algorithm="GPUProgrammablePassEncoder.pushDebugGroup">
-    <strong>|this|:</strong> of type {{GPUProgrammablePassEncoder}}.
+        Marks the beginning of a labeled group of commands for the {{GPUProgrammablePassEncoder}}.
 
-    **Arguments:**
-      - {{USVString}} |groupLabel|
+        <div algorithm=GPUProgrammablePassEncoder.pushDebugGroup>
+            **Called on:** {{GPUProgrammablePassEncoder}} |this|.
 
-    **Returns:** void
+            **Arguments:**
+            <pre class=argumentdef for="GPUProgrammablePassEncoder/pushDebugGroup(groupLabel)">
+                |groupLabel|: The label for the command group.
+            </pre>
 
-    Marks the beginning of a labeled group of commands for the {{GPUProgrammablePassEncoder}}.
+            **Returns:** void
 
-    |groupLabel| defines the label for the command group.
+            - Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
+                    - Push |groupLabel| onto then end of |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.
+                </div>
+        </div>
 
-    On the [=Device timeline=], the following steps occur:
+    : <dfn>popDebugGroup()</dfn>
+    ::
 
-        - push |groupLabel| onto then end of |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.
-</div>
+        Marks the end of a labeled group of commands for the {{GPUProgrammablePassEncoder}}.
 
-### <dfn method for=GPUProgrammablePassEncoder>popDebugGroup()</dfn> ### {#GPUProgrammablePassEncoder-popDebugGroup}
+        <div algorithm=GPUProgrammablePassEncoder.popDebugGroup>
+            **Called on:** {{GPUProgrammablePassEncoder}} |this|.
 
-<div algorithm="GPUProgrammablePassEncoder.popDebugGroup">
-    <strong>|this|:</strong> of type {{GPUProgrammablePassEncoder}}.
+            **Returns:** void
 
-    **Returns:** void
+            - Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
+                   <div class=validusage>
+                        - If |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.length is not greater than 0,
+                            generate a validation error and stop.
+                    </div>
+                    - Pop an entry off the end of |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.
+                </div>
+        </div>
 
-    Marks the end of a labeled group of commands for the {{GPUProgrammablePassEncoder}}.
+    : <dfn>insertDebugMarker(markerLabel)</dfn>
+    ::
 
-    On the [=Device timeline=], the following steps occur:
+        Inserts a single debug marker label into the {{GPUProgrammablePassEncoder}}'s commands sequence .
 
-        - If the [$GPUProgrammablePassEncoder.popDebugGroup/Valid Usage$] rules are met:
+        <div algorithm=GPUProgrammablePassEncoder.insertDebugMarker>
+            **Called on:** {{GPUProgrammablePassEncoder}} this.
 
-            - pop an entry off the end of |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.
+            **Arguments:**
+            <pre class=argumentdef for="GPUProgrammablePassEncoder/insertDebugMarker(markerLabel)">
+                markerLabel: The label to insert.
+            </pre>
 
-    <div class=validusage dfn-for=GPUProgrammablePassEncoder.popDebugGroup>
-        <dfn abstract-op>Valid Usage</dfn>
-
-        - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.length must be greater than 0.
-    </div>
-
-</div>
-
-### <dfn method for=GPUProgrammablePassEncoder>insertDebugMarker(markerLabel)</dfn> ### {#GPUProgrammablePassEncoder-insertDebugMarker}
-
-<div algorithm="GPUProgrammablePassEncoder.insertDebugMarker">
-
-    **Arguments:**
-        - {{USVString}} |markerLabel|
-
-    **Returns:** void
-
-    Inserts a single debug marker label into the {{GPUProgrammablePassEncoder}}'s commands sequence .
-
-    |markerLabel| defines the label to insert.
-
-</div>
+            **Returns:** void
+        </div>
+</dl>
 
 # Compute Passes # {#compute-passes}
 
@@ -4808,11 +4832,10 @@ called the compute pass encoder can no longer be used.
 
             - Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
-                    - If any of the following conditions are unsatisfied,
-                        generate a validation error and stop.
-                        <div class=validusage>
-                            - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.length is 0.
-                        </div>
+                    <div class=validusage>
+                        - If |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.length is not 0,
+                            generate a validation error and stop.
+                    </div>
 
                     Issue: Add remaining validation.
                 </div>
@@ -5476,14 +5499,13 @@ called the render pass encoder can no longer be used.
 
             - Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
-                    - If any of the following conditions are unsatisfied, generate a validation
-                        error and stop.
-                        <div class=validusage>
-                            - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.length is 0.
-                        </div>
-                </div>
+                    <div class=validusage>
+                        - If |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.length is not 0,
+                            generate a validation error and stop.
+                    </div>
 
-            Issue: Add remaining validation.
+                    Issue: Add remaining validation.
+                </div>
         </div>
 </dl>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3890,26 +3890,26 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 
             **Returns:** {{GPURenderPassEncoder}}
 
-            - Issue the following steps on the [=Device timeline=] of |this|:
-                <div class=device-timeline>
-                    - If any of the following conditions are unsatisfied, generate a validation
-                        error and stop.
-                        <div class=validusage>
-                            - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
-                            - |descriptor| meets the
-                                [$GPURenderPassDescriptor/GPURenderPassDescriptor Valid Usage$] rules.
-                        </div>
-                    - Set |this|.{{GPUCommandEncoder/[[state]]}} to {{encoder state/encoding a render pass}}.
-                    - For each |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
-                        - The texture [=subresource=] seen by |colorAttachment|.{{GPURenderPassColorAttachmentDescriptor/attachment}}
-                            is considered to be used as {{GPUTextureUsage/OUTPUT_ATTACHMENT}} for the
-                            duration of the render pass.
-                    - Let |depthStencilAttachment| be |descriptor|.{{GPURenderPassDescriptor/depthStencilAttachment}}.
-                    - If |depthStencilAttachment| is not `null`:
-                        - The texture [=subresource=] seen by |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}
-                            is considered to be used as {{GPUTextureUsage/OUTPUT_ATTACHMENT}} for the
-                            duration of the render pass.
-                </div>
+            Issue the following steps on the [=Device timeline=] of |this|:
+            <div class=device-timeline>
+                - If any of the following conditions are unsatisfied, generate a validation
+                    error and stop.
+                    <div class=validusage>
+                        - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
+                        - |descriptor| meets the
+                            [$GPURenderPassDescriptor/GPURenderPassDescriptor Valid Usage$] rules.
+                    </div>
+                - Set |this|.{{GPUCommandEncoder/[[state]]}} to {{encoder state/encoding a render pass}}.
+                - For each |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
+                    - The texture [=subresource=] seen by |colorAttachment|.{{GPURenderPassColorAttachmentDescriptor/attachment}}
+                        is considered to be used as {{GPUTextureUsage/OUTPUT_ATTACHMENT}} for the
+                        duration of the render pass.
+                - Let |depthStencilAttachment| be |descriptor|.{{GPURenderPassDescriptor/depthStencilAttachment}}.
+                - If |depthStencilAttachment| is not `null`:
+                    - The texture [=subresource=] seen by |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}
+                        is considered to be used as {{GPUTextureUsage/OUTPUT_ATTACHMENT}} for the
+                        duration of the render pass.
+            </div>
 
             Issue: specify the behavior of read-only depth/stencil
         </div>
@@ -3929,14 +3929,15 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 
             **Returns:** {{GPUComputePassEncoder}}
 
-            - Issue the following steps on the [=Device timeline=] of |this|:
-                <div class=device-timeline>
+            Issue the following steps on the [=Device timeline=] of |this|:
+            <div class=device-timeline>
+                - If any of the following conditions are unsatisfied, generate a validation
+                    error and stop.
                     <div class=validusage>
-                        - If |this|.{{GPUCommandEncoder/[[state]]}} is not {{encoder state/open}},
-                            generate a validation error and stop.
+                        - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
                     </div>
-                    - Set |this|.{{GPUCommandEncoder/[[state]]}} to {{encoder state/encoding a compute pass}}.
-                </div>
+                - Set |this|.{{GPUCommandEncoder/[[state]]}} to {{encoder state/encoding a compute pass}}.
+            </div>
         </div>
 </dl>
 
@@ -4403,14 +4404,15 @@ must be well nested.
 
             **Returns:** void
 
-            - Issue the following steps on the [=Device timeline=] of |this|:
-                <div class=device-timeline>
+            Issue the following steps on the [=Device timeline=] of |this|:
+            <div class=device-timeline>
+                - If any of the following conditions are unsatisfied, generate a validation
+                    error and stop.
                     <div class=validusage>
-                        - If |this|.{{GPUCommandEncoder/[[state]]}} is not {{encoder state/open}},
-                            generate a validation error and stop.
+                        - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
                     </div>
-                    - Push |groupLabel| onto then end of |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.
-                </div>
+                - Push |groupLabel| onto then end of |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.
+            </div>
         </div>
 
     : <dfn>popDebugGroup()</dfn>
@@ -4423,16 +4425,16 @@ must be well nested.
 
             **Returns:** void
 
-            - Issue the following steps on the [=Device timeline=] of |this|:
-                <div class=device-timeline>
-                    - If any of the following conditions are unsatisfied, generate a validation
-                        error and stop.
-                        <div class=validusage>
-                            - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
-                            - |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.length is greater than 0.
-                        </div>
-                    - Pop an entry off the end of |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.
-                </div>
+            Issue the following steps on the [=Device timeline=] of |this|:
+            <div class=device-timeline>
+                - If any of the following conditions are unsatisfied, generate a validation
+                    error and stop.
+                    <div class=validusage>
+                        - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
+                        - |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.length is greater than 0.
+                    </div>
+                - Pop an entry off the end of |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.
+            </div>
         </div>
 
     : <dfn>insertDebugMarker(markerLabel)</dfn>
@@ -4450,13 +4452,14 @@ must be well nested.
 
             **Returns:** void
 
-            - Issue the following steps on the [=Device timeline=] of |this|:
-                <div class=device-timeline>
+            Issue the following steps on the [=Device timeline=] of |this|:
+            <div class=device-timeline>
+                - If any of the following conditions are unsatisfied, generate a validation
+                    error and stop.
                     <div class=validusage>
-                        - If |this|.{{GPUCommandEncoder/[[state]]}} is not {{encoder state/open}},
-                            generate a validation error and stop.
+                        - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
                     </div>
-                </div>
+            </div>
         </div>
 </dl>
 
@@ -4523,15 +4526,16 @@ command encoder can no longer be used.
 
             **Returns:** void
 
-            - Issue the following steps on the [=Device timeline=] of |this|:
-                <div class=device-timeline>
+            Issue the following steps on the [=Device timeline=] of |this|:
+            <div class=device-timeline>
+                - If any of the following conditions are unsatisfied, generate a validation
+                    error and stop.
                     <div class=validusage>
-                        - If |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.length is not 0,
-                            generate a validation error and stop.
+                        - |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.length is 0.
                     </div>
 
-                    Issue: Add remaining validation.
-                </div>
+                Issue: Add remaining validation.
+            </div>
         </div>
 </dl>
 
@@ -4638,10 +4642,10 @@ pass.
 
             **Returns:** void
 
-            - Issue the following steps on the [=Device timeline=] of |this|:
-                <div class=device-timeline>
-                    - Push |groupLabel| onto then end of |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.
-                </div>
+            Issue the following steps on the [=Device timeline=] of |this|:
+            <div class=device-timeline>
+                - Push |groupLabel| onto then end of |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.
+            </div>
         </div>
 
     : <dfn>popDebugGroup()</dfn>
@@ -4654,14 +4658,15 @@ pass.
 
             **Returns:** void
 
-            - Issue the following steps on the [=Device timeline=] of |this|:
-                <div class=device-timeline>
-                   <div class=validusage>
-                        - If |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.length is not greater than 0,
-                            generate a validation error and stop.
+            Issue the following steps on the [=Device timeline=] of |this|:
+            <div class=device-timeline>
+                - If any of the following conditions are unsatisfied, generate a validation
+                    error and stop.
+                    <div class=validusage>
+                        - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.length is greater than 0s.
                     </div>
-                    - Pop an entry off the end of |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.
-                </div>
+                - Pop an entry off the end of |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.
+            </div>
         </div>
 
     : <dfn>insertDebugMarker(markerLabel)</dfn>
@@ -4830,15 +4835,16 @@ called the compute pass encoder can no longer be used.
 
             **Returns:** void
 
-            - Issue the following steps on the [=Device timeline=] of |this|:
-                <div class=device-timeline>
+            Issue the following steps on the [=Device timeline=] of |this|:
+            <div class=device-timeline>
+                - If any of the following conditions are unsatisfied, generate a validation
+                    error and stop.
                     <div class=validusage>
-                        - If |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.length is not 0,
-                            generate a validation error and stop.
+                        - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.length is 0.
                     </div>
 
-                    Issue: Add remaining validation.
-                </div>
+                Issue: Add remaining validation.
+            </div>
 
             Issue: Allowed for GPUs to use fixed point or rounded viewport coordinates
         </div>
@@ -5299,18 +5305,18 @@ attachments used by this encoder.
 
             **Returns:** void
 
-            - Issue the following steps on the [=Device timeline=] of |this|:
-                <div class=device-timeline>
-                    - If any of the following conditions are unsatisfied, generate a validation
-                        error and stop.
-                        <div class=validusage>
-                            - |width| is greater than `0`.
-                            - |height| is greater than `0`.
-                            - |minDepth| is greater than or equal to `0.0` and less than or equal to `1.0`.
-                            - |maxDepth| is greater than or equal to `0.0` and less than or equal to `1.0`.
-                        </div>
-                    - Set the viewport to the extents |x|, |y|, |width|, |height|, |minDepth|, and |maxDepth|.
-                </div>
+            Issue the following steps on the [=Device timeline=] of |this|:
+            <div class=device-timeline>
+                - If any of the following conditions are unsatisfied, generate a validation
+                    error and stop.
+                    <div class=validusage>
+                        - |width| is greater than `0`.
+                        - |height| is greater than `0`.
+                        - |minDepth| is greater than or equal to `0.0` and less than or equal to `1.0`.
+                        - |maxDepth| is greater than or equal to `0.0` and less than or equal to `1.0`.
+                    </div>
+                - Set the viewport to the extents |x|, |y|, |width|, |height|, |minDepth|, and |maxDepth|.
+            </div>
 
             Issue: Allowed for GPUs to use fixed point or rounded viewport coordinates
         </div>
@@ -5335,22 +5341,22 @@ attachments used by this encoder.
 
             **Returns:** void
 
-            - Issue the following steps on the [=Device timeline=] of |this|:
-                <div class=device-timeline>
-                    - If any of the following conditions are unsatisfied, generate a validation
-                        error and stop.
-                        <div class=validusage>
-                            - |x| is greater than or equal to `0`.
-                            - |y| is greater than or equal to `0`.
-                            - |width| is greater than `0`.
-                            - |height| is greater than `0`.
-                            - |x|+|width| is less than or equal to
-                                |this|.{{GPURenderPassEncoder/[[attachment_size]]}}.width.
-                            - |y|+|height| is less than or equal to
-                                |this|.{{GPURenderPassEncoder/[[attachment_size]]}}.height.
-                        </div>
-                    - Set the scissor rectangle to the extents |x|, |y|, |width|, and |height|.
-                </div>
+            Issue the following steps on the [=Device timeline=] of |this|:
+            <div class=device-timeline>
+                - If any of the following conditions are unsatisfied, generate a validation
+                    error and stop.
+                    <div class=validusage>
+                        - |x| is greater than or equal to `0`.
+                        - |y| is greater than or equal to `0`.
+                        - |width| is greater than `0`.
+                        - |height| is greater than `0`.
+                        - |x|+|width| is less than or equal to
+                            |this|.{{GPURenderPassEncoder/[[attachment_size]]}}.width.
+                        - |y|+|height| is less than or equal to
+                            |this|.{{GPURenderPassEncoder/[[attachment_size]]}}.height.
+                    </div>
+                - Set the scissor rectangle to the extents |x|, |y|, |width|, and |height|.
+            </div>
         </div>
 
     : <dfn>setBlendColor(color)</dfn>
@@ -5497,15 +5503,16 @@ called the render pass encoder can no longer be used.
 
             **Returns:** void
 
-            - Issue the following steps on the [=Device timeline=] of |this|:
-                <div class=device-timeline>
+            Issue the following steps on the [=Device timeline=] of |this|:
+            <div class=device-timeline>
+                - If any of the following conditions are unsatisfied, generate a validation
+                    error and stop.
                     <div class=validusage>
-                        - If |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.length is not 0,
-                            generate a validation error and stop.
+                        - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.length is 0.
                     </div>
 
-                    Issue: Add remaining validation.
-                </div>
+                Issue: Add remaining validation.
+            </div>
         </div>
 </dl>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -821,7 +821,7 @@ interface GPU {
 
 {{GPU}} has the following methods:
 
-<dl dfn-type="method" dfn-for="GPU">
+<dl dfn-type=method dfn-for=GPU>
     : <dfn>requestAdapter(options)</dfn>
     ::
 
@@ -837,7 +837,7 @@ interface GPU {
                 options:
             </pre>
 
-            **Returns:** |promise|, of type Promise<{{GPUAdapter}}?>.
+            **Returns:** `Promise<{{GPUAdapter}}?>`.
 
             - Let |promise| be [=a new promise=].
             - Issue the following steps on the [=Device timeline=] of |this|:
@@ -984,7 +984,7 @@ interface GPUAdapter {
                 |descriptor|:
             </pre>
 
-            **Returns:** |promise|, of type Promise<{{GPUDevice}}?>.
+            **Returns:** `Promise<{{GPUDevice}}?>`.
 
             - Let |promise| be [=a new promise=].
             - Issue the following steps to the [=Device timeline=]:
@@ -3874,7 +3874,7 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 
 ## Pass Encoding ## {#command-encoder-pass-encoding}
 
-<dl dfn-type="method" dfn-for="GPUCommandEncoder">
+<dl dfn-type=method dfn-for=GPUCommandEncoder>
     : <dfn>beginRenderPass(descriptor)</dfn>
     ::
 
@@ -4406,8 +4406,7 @@ must be well nested.
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
-                - If any of the following conditions are unsatisfied, generate a validation
-                    error and stop.
+                - If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
                     </div>
@@ -4427,8 +4426,7 @@ must be well nested.
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
-                - If any of the following conditions are unsatisfied, generate a validation
-                    error and stop.
+                - If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
                         - |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.length is greater than 0.
@@ -4454,8 +4452,7 @@ must be well nested.
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
-                - If any of the following conditions are unsatisfied, generate a validation
-                    error and stop.
+                - If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
                     </div>
@@ -4510,7 +4507,7 @@ A {{GPUCommandBuffer}} containing the commands recorded by the {{GPUCommandEncod
 by calling {{GPUCommandEncoder/finish()}}. Once {{GPUCommandEncoder/finish()}} has been called the
 command encoder can no longer be used.
 
-<dl dfn-type="method" dfn-for="GPUCommandEncoder">
+<dl dfn-type=method dfn-for=GPUCommandEncoder>
     : <dfn>finish(descriptor)</dfn>
     ::
 
@@ -4531,6 +4528,7 @@ command encoder can no longer be used.
                 - If any of the following conditions are unsatisfied, generate a validation
                     error and stop.
                     <div class=validusage>
+                        - |this| is [=valid=].
                         - |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.length is 0.
                     </div>
 
@@ -4626,7 +4624,7 @@ Debug marker methods for programmable pass encoders provide the same functionali
 [[#command-encoder-debug-markers|command encoder debug markers]] while recording a programmable
 pass.
 
-<dl dfn-type="method" dfn-for="GPUProgrammablePassEncoder">
+<dl dfn-type=method dfn-for=GPUProgrammablePassEncoder>
     : <dfn>pushDebugGroup(groupLabel)</dfn>
     ::
 
@@ -4663,7 +4661,7 @@ pass.
                 - If any of the following conditions are unsatisfied, generate a validation
                     error and stop.
                     <div class=validusage>
-                        - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.length is greater than 0s.
+                        - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.length is greater than 0.
                     </div>
                 - Pop an entry off the end of |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.
             </div>
@@ -4672,7 +4670,7 @@ pass.
     : <dfn>insertDebugMarker(markerLabel)</dfn>
     ::
 
-        Inserts a single debug marker label into the {{GPUProgrammablePassEncoder}}'s commands sequence .
+        Inserts a single debug marker label into the {{GPUProgrammablePassEncoder}}'s commands sequence.
 
         <div algorithm=GPUProgrammablePassEncoder.insertDebugMarker>
             **Called on:** {{GPUProgrammablePassEncoder}} this.


### PR DESCRIPTION
Also fixed a style bug with `.validusage` blocks overlapping the title of their parent if they're the first child of a `.*-timeline` block. This allowed me to condense several single-check validation steps into one line.

(My intent is to convert every method in the spec to the new, consistent style over the next few days. I'll be doing it in blocks to keep the patch size reasonable and reviewable.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/toji/gpuweb/pull/964.html" title="Last updated on Aug 4, 2020, 3:52 PM UTC (07e3e6d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/964/ecb1bf0...toji:07e3e6d.html" title="Last updated on Aug 4, 2020, 3:52 PM UTC (07e3e6d)">Diff</a>