### PR TITLE
Add a method defintion stub for every remaining method in the spec

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1756,6 +1756,47 @@ interface GPUTextureUsage {
 };
 </script>
 
+<dl dfn-type=method dfn-for=GPUDevice>
+    : <dfn>createTexture(descriptor)</dfn>
+    ::
+        Creates a new {{GPUTexture}}.
+
+        <div algorithm=GPUDevice.createTexture>
+            **Called on:** {{GPUDevice}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPUDevice/createTexture(descriptor)">
+                descriptor:
+            </pre>
+
+            **Returns:** {{GPUTexture}}
+
+            Issue: Describe {{GPUDevice/createTexture()}} algorithm steps.
+        </div>
+</dl>
+
+### Texture Destruction ### {#texture-destruction}
+
+An application that no longer requires a {{GPUTexture}} can choose to lose access to it before
+garbage collection by calling {{GPUTexture/destroy()}}.
+
+Note: This allows the user agent to reclaim the GPU memory associated with the {{GPUTexture}} once
+all previously submitted operations using it are complete.
+
+<dl dfn-type=method dfn-for=GPUTexture>
+    : <dfn>destroy()</dfn>
+    ::
+        Destroys a {{GPUTexture}}.
+
+        <div algorithm=GPUTexture.destroy>
+            **Called on:** {{GPUTexture}} this.
+
+            **Returns:** void
+
+            Issue: Describe {{GPUTexture/destroy()}} algorithm steps.
+        </div>
+</dl>
+
 ## GPUTextureView ## {#gpu-textureview}
 
 <script type=idl>
@@ -2808,6 +2849,41 @@ source-map-v3 format. (https://sourcemaps.info/spec.html)
 Source maps are optional, but serve as a standardized way to support dev-tool
 integration such as source-language debugging.
 
+<dl dfn-type=method dfn-for=GPUDevice>
+    : <dfn>createShaderModule(descriptor)</dfn>
+    ::
+        Creates a new {{GPUShaderModule}}.
+
+        <div algorithm=GPUDevice.createShaderModule>
+            **Called on:** {{GPUDevice}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPUDevice/createShaderModule(descriptor)">
+                descriptor:
+            </pre>
+
+            **Returns:** {{GPUShaderModule}}
+
+            Issue: Describe {{GPUDevice/createShaderModule()}} algorithm steps.
+        </div>
+</dl>
+
+### Shader Module Compilation Information ### {#shader-module-compilation-information}
+
+<dl dfn-type=method dfn-for=GPUShaderModule>
+    : <dfn>compilationInfo()</dfn>
+    ::
+        Returns any messages generated during the {{GPUShaderModule}}'s compilation.
+
+        <div algorithm=GPUShaderModule.compilationInfo>
+            **Called on:** {{GPUShaderModule}} this.
+
+            **Returns:** Promise<{{GPUCompilationInfo}}>
+
+            Issue: Describe {{GPUShaderModule/compilationInfo()}} algorithm steps.
+        </div>
+</dl>
+
 # Pipelines # {#pipelines}
 
 A <dfn dfn>pipeline</dfn>, be it {{GPUComputePipeline}} or {{GPURenderPipeline}},
@@ -3756,6 +3832,25 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
         Enable measurement of the GPU execution time of the entire command buffer.
 </dl>
 
+<dl dfn-type=method dfn-for=GPUDevice>
+    : <dfn>createCommandEncoder(descriptor)</dfn>
+    ::
+        Creates a new {{GPUCommandEncoder}}.
+
+        <div algorithm=GPUDevice.createCommandEncoder>
+            **Called on:** {{GPUDevice}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPUDevice/createCommandEncoder(descriptor)">
+                descriptor:
+            </pre>
+
+            **Returns:** {{GPUCommandEncoder}}
+
+            Issue: Describe {{GPUDevice/createCommandEncoder()}} algorithm steps.
+        </div>
+</dl>
+
 ## Pass Encoding ## {#command-encoder-pass-encoding}
 
 <dl dfn-type="method" dfn-for="GPUCommandEncoder">
@@ -4346,6 +4441,47 @@ must be well nested.
 
 </div>
 
+## Queries ## {#command-encoder-queries}
+
+<dl dfn-type=method dfn-for=GPUCommandEncoder>
+    : <dfn>writeTimestamp(querySet, queryIndex)</dfn>
+    ::
+
+        <div algorithm=GPUCommandEncoder.writeTimestamp>
+            **Called on:** {{GPUCommandEncoder}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPUCommandEncoder/writeTimestamp(querySet, queryIndex)">
+                querySet:
+                queryIndex:
+            </pre>
+
+            **Returns:** void
+
+            Issue: Describe {{GPUCommandEncoder/writeTimestamp()}} algorithm steps.
+        </div>
+
+    : <dfn>resolveQuerySet(querySet, firstQuery, queryCount, destination, destinationOffset)</dfn>
+    ::
+
+        <div algorithm=GPUCommandEncoder.resolveQuerySet>
+            **Called on:** {{GPUCommandEncoder}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPUCommandEncoder/resolveQuerySet(querySet, firstQuery, queryCount, destination, destinationOffset)">
+                querySet:
+                firstQuery:
+                queryCount:
+                destination:
+                destinationOffset:
+            </pre>
+
+            **Returns:** void
+
+            Issue: Describe {{GPUCommandEncoder/resolveQuerySet()}} algorithm steps.
+        </div>
+</dl>
+
 ## Finalization ## {#command-encoder-finalization}
 
 A {{GPUCommandBuffer}} containing the commands recorded by the {{GPUCommandEncoder}} can be created
@@ -4405,6 +4541,54 @@ interface mixin GPUProgrammablePassEncoder {
     : <dfn>\[[debug_group_stack]]</dfn> of type `sequence<USVString>`.
     ::
         A stack of active debug group labels.
+</dl>
+
+## Bind Groups ## {#programmable-passes-bind-groups}
+
+<dl dfn-type=method dfn-for=GPUProgrammablePassEncoder>
+    : <dfn>setBindGroup(index, bindGroup, dynamicOffsets)</dfn>
+    ::
+
+        <div algorithm=GPUProgrammablePassEncoder.setBindGroup>
+            **Called on:** {{GPUProgrammablePassEncoder}} this.
+
+            **Arguments:**
+            <!--The overload appears to be confusing bikeshed, and it ends up expecting this to
+                define the arguments for the 5-arg variant of the method, despite the "for"
+                explicitly pointing at the 3-arg variant.-->
+            <!--pre class=argumentdef for="GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)">
+                index:
+                bindGroup:
+                dynamicOffsets:
+            </pre-->
+
+            Issue: Resolve bikeshed conflict when using `argumentdef` with
+                {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)}}.
+
+            **Returns:** void
+
+            Issue: Describe {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)}} algorithm steps.
+        </div>
+
+    : <dfn>setBindGroup(index, bindGroup, dynamicOffsetsData, dynamicOffsetsDataStart, dynamicOffsetsDataLength)</dfn>
+    ::
+
+        <div algorithm=GPUProgrammablePassEncoder.setBindGroup2>
+            **Called on:** {{GPUProgrammablePassEncoder}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsetsData, dynamicOffsetsDataStart, dynamicOffsetsDataLength)">
+                index:
+                bindGroup:
+                dynamicOffsetsData:
+                dynamicOffsetsDataStart:
+                dynamicOffsetsDataLength:
+            </pre>
+
+            **Returns:** void
+
+            Issue: Describe {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsetsData, dynamicOffsetsDataStart, dynamicOffsetsDataLength)}} algorithm steps.
+        </div>
 </dl>
 
 ## Debug Markers ## {#programmable-passes-debug-markers}
@@ -4498,7 +4682,111 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
 };
 </script>
 
-## Finalization ## {#compute-pass-encoder-finalization}
+### Dispatch ### {#compute-pass-encoder-dispatch}
+
+<dl dfn-type=method dfn-for=GPUComputePassEncoder>
+    : <dfn>setPipeline(pipeline)</dfn>
+    ::
+
+        <div algorithm="GPUComputePassEncoder.setPipeline">
+            **Called on:** {{GPUComputePassEncoder}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPUComputePassEncoder/setPipeline(pipeline)">
+                pipeline:
+            </pre>
+
+            **Returns:** void
+
+            Issue: Describe {{GPUComputePassEncoder/setPipeline()}} algorithm steps.
+        </div>
+
+    : <dfn>dispatch(x, y, z)</dfn>
+    ::
+
+        <div algorithm="GPUComputePassEncoder.dispatch">
+            **Called on:** {{GPUComputePassEncoder}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPUComputePassEncoder/dispatch(x, y, z)">
+                x:
+                y:
+                z:
+            </pre>
+
+            **Returns:** void
+
+            Issue: Describe {{GPUComputePassEncoder/dispatch()}} algorithm steps.
+        </div>
+
+    : <dfn>dispatchIndirect(indirectBuffer, indirectOffset)</dfn>
+    ::
+
+        <div algorithm="GPUComputePassEncoder.dispatchIndirect">
+            **Called on:** {{GPUComputePassEncoder}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPUComputePassEncoder/dispatchIndirect(indirectBuffer, indirectOffset)">
+                indirectBuffer:
+                indirectOffset:
+            </pre>
+
+            **Returns:** void
+
+            Issue: Describe {{GPUComputePassEncoder/dispatchIndirect()}} algorithm steps.
+        </div>
+</dl>
+
+### Queries ### {#compute-pass-encoder-queries}
+
+<dl dfn-type=method dfn-for=GPUComputePassEncoder>
+    : <dfn>beginPipelineStatisticsQuery(querySet, queryIndex)</dfn>
+    ::
+
+        <div algorithm="GPUComputePassEncoder.beginPipelineStatisticsQuery">
+            **Called on:** {{GPUComputePassEncoder}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPUComputePassEncoder/beginPipelineStatisticsQuery(querySet, queryIndex)">
+                querySet:
+                queryIndex:
+            </pre>
+
+            **Returns:** void
+
+            Issue: Describe {{GPUComputePassEncoder/beginPipelineStatisticsQuery()}} algorithm steps.
+        </div>
+
+    : <dfn>endPipelineStatisticsQuery()</dfn>
+    ::
+
+        <div algorithm="GPUComputePassEncoder.endPipelineStatisticsQuery">
+            **Called on:** {{GPUComputePassEncoder}} this.
+
+            **Returns:** void
+
+            Issue: Describe {{GPUComputePassEncoder/endPipelineStatisticsQuery()}} algorithm steps.
+        </div>
+
+    : <dfn>writeTimestamp(querySet, queryIndex)</dfn>
+    ::
+
+        <div algorithm="GPUComputePassEncoder.writeTimestamp">
+            **Called on:** {{GPUComputePassEncoder}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPUComputePassEncoder/writeTimestamp(querySet, queryIndex)">
+                querySet:
+                queryIndex:
+            </pre>
+
+            **Returns:** void
+
+            Issue: Describe {{GPUComputePassEncoder/writeTimestamp()}} algorithm steps.
+        </div>
+</dl>
+
+### Finalization ### {#compute-pass-encoder-finalization}
 
 The compute pass encoder can be ended by calling {{GPUComputePassEncoder/endPass()}} once the user
 has finished recording commands for the pass. Once {{GPUComputePassEncoder/endPass()}} has been
@@ -4827,7 +5115,138 @@ enum GPUStoreOp {
 };
 </script>
 
-## Rasterization state ## {#render-pass-encoder-rasterization-state}
+### Drawing ### {#render-pass-encoder-drawing}
+
+<dl dfn-type=method dfn-for=GPURenderEncoderBase>
+    : <dfn>setPipeline(pipeline)</dfn>
+    ::
+
+        <div algorithm="GPURenderEncoderBase.setPipeline">
+            **Called on:** {{GPURenderEncoderBase}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPURenderEncoderBase/setPipeline(pipeline)">
+                pipeline:
+            </pre>
+
+            **Returns:** void
+
+            Issue: Describe {{GPURenderEncoderBase/setPipeline()}} algorithm steps.
+        </div>
+
+    : <dfn>setIndexBuffer(buffer, indexFormat, offset, size)</dfn>
+    ::
+
+        <div algorithm="GPURenderEncoderBase.setIndexBuffer">
+            **Called on:** {{GPURenderEncoderBase}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPURenderEncoderBase/setIndexBuffer(buffer, indexFormat, offset, size)">
+                buffer:
+                indexFormat:
+                offset:
+                size:
+            </pre>
+
+            **Returns:** void
+
+            Issue: Describe {{GPURenderEncoderBase/setIndexBuffer()}} algorithm steps.
+        </div>
+
+    : <dfn>setVertexBuffer(slot, buffer, offset, size)</dfn>
+    ::
+
+        <div algorithm="GPURenderEncoderBase.setVertexBuffer">
+            **Called on:** {{GPURenderEncoderBase}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPURenderEncoderBase/setVertexBuffer(slot, buffer, offset, size)">
+                slot:
+                buffer:
+                offset:
+                size:
+            </pre>
+
+            **Returns:** void
+
+            Issue: Describe {{GPURenderEncoderBase/setVertexBuffer()}} algorithm steps.
+        </div>
+
+    : <dfn>draw(vertexCount, instanceCount, firstVertex, firstInstance)</dfn>
+    ::
+
+        <div algorithm="GPURenderEncoderBase.draw">
+            **Called on:** {{GPURenderEncoderBase}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPURenderEncoderBase/draw(vertexCount, instanceCount, firstVertex, firstInstance)">
+                vertexCount:
+                instanceCount:
+                firstVertex:
+                firstInstance:
+            </pre>
+
+            **Returns:** void
+
+            Issue: Describe {{GPURenderEncoderBase/draw()}} algorithm steps.
+        </div>
+
+    : <dfn>drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance)</dfn>
+    ::
+
+        <div algorithm="GPURenderEncoderBase.drawIndexed">
+            **Called on:** {{GPURenderEncoderBase}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPURenderEncoderBase/drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance)">
+                indexCount:
+                instanceCount:
+                firstIndex:
+                baseVertex:
+                firstInstance:
+            </pre>
+
+            **Returns:** void
+
+            Issue: Describe {{GPURenderEncoderBase/drawIndexed()}} algorithm steps.
+        </div>
+
+    : <dfn>drawIndirect(indirectBuffer, indirectOffset)</dfn>
+    ::
+
+        <div algorithm="GPURenderEncoderBase.drawIndirect">
+            **Called on:** {{GPURenderEncoderBase}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPURenderEncoderBase/drawIndirect(indirectBuffer, indirectOffset)">
+                indirectBuffer:
+                indirectOffset:
+            </pre>
+
+            **Returns:** void
+
+            Issue: Describe {{GPURenderEncoderBase/drawIndirect()}} algorithm steps.
+        </div>
+
+    : <dfn>drawIndexedIndirect(indirectBuffer, indirectOffset)</dfn>
+    ::
+
+        <div algorithm="GPURenderEncoderBase.drawIndexedIndirect">
+            **Called on:** {{GPURenderEncoderBase}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPURenderEncoderBase/drawIndexedIndirect(indirectBuffer, indirectOffset)">
+                indirectBuffer:
+                indirectOffset:
+            </pre>
+
+            **Returns:** void
+
+            Issue: Describe {{GPURenderEncoderBase/drawIndexedIndirect()}} algorithm steps.
+        </div>
+</dl>
+
+### Rasterization state ### {#render-pass-encoder-rasterization-state}
 
 The {{GPURenderPassEncoder}} has several methods which affect how draw commands are rasterized to
 attachments used by this encoder.
@@ -4939,7 +5358,103 @@ attachments used by this encoder.
         </div>
 </dl>
 
-## Finalization ## {#render-pass-encoder-finalization}
+### Queries ### {#render-pass-encoder-queries}
+
+<dl dfn-type=method dfn-for=GPURenderPassEncoder>
+    : <dfn>beginOcclusionQuery(queryIndex)</dfn>
+    ::
+
+        <div algorithm="GPURenderPassEncoder.beginOcclusionQuery">
+            **Called on:** {{GPURenderPassEncoder}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPURenderPassEncoder/beginOcclusionQuery(queryIndex)">
+                queryIndex:
+            </pre>
+
+            **Returns:** void
+
+            Issue: Describe {{GPURenderPassEncoder/beginOcclusionQuery()}} algorithm steps.
+        </div>
+
+    : <dfn>endOcclusionQuery()</dfn>
+    ::
+
+        <div algorithm="GPURenderPassEncoder.endOcclusionQuery">
+            **Called on:** {{GPURenderPassEncoder}} this.
+
+            **Returns:** void
+
+            Issue: Describe {{GPURenderPassEncoder/endOcclusionQuery()}} algorithm steps.
+        </div>
+
+    : <dfn>beginPipelineStatisticsQuery(querySet, queryIndex)</dfn>
+    ::
+
+        <div algorithm="GPURenderPassEncoder.beginPipelineStatisticsQuery">
+            **Called on:** {{GPURenderPassEncoder}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPURenderPassEncoder/beginPipelineStatisticsQuery(querySet, queryIndex)">
+                querySet:
+                queryIndex:
+            </pre>
+
+            **Returns:** void
+
+            Issue: Describe {{GPURenderPassEncoder/beginPipelineStatisticsQuery()}} algorithm steps.
+        </div>
+
+    : <dfn>endPipelineStatisticsQuery()</dfn>
+    ::
+
+        <div algorithm="GPURenderPassEncoder.endPipelineStatisticsQuery">
+            **Called on:** {{GPURenderPassEncoder}} this.
+
+            **Returns:** void
+
+            Issue: Describe {{GPURenderPassEncoder/endPipelineStatisticsQuery()}} algorithm steps.
+        </div>
+
+    : <dfn>writeTimestamp(querySet, queryIndex)</dfn>
+    ::
+
+        <div algorithm="GPURenderPassEncoder.writeTimestamp">
+            **Called on:** {{GPURenderPassEncoder}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPURenderPassEncoder/writeTimestamp(querySet, queryIndex)">
+                querySet:
+                queryIndex:
+            </pre>
+
+            **Returns:** void
+
+            Issue: Describe {{GPURenderPassEncoder/writeTimestamp()}} algorithm steps.
+        </div>
+</dl>
+
+### Bundles ### {#render-pass-encoder-bundles}
+
+<dl dfn-type=method dfn-for=GPURenderPassEncoder>
+    : <dfn>executeBundles(bundles)</dfn>
+    ::
+
+        <div algorithm="GPURenderPassEncoder.executeBundles">
+            **Called on:** {{GPURenderPassEncoder}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPURenderPassEncoder/executeBundles(bundles)">
+                bundles:
+            </pre>
+
+            **Returns:** void
+
+            Issue: Describe {{GPURenderPassEncoder/executeBundles()}} algorithm steps.
+        </div>
+</dl>
+
+### Finalization ### {#render-pass-encoder-finalization}
 
 The render pass encoder can be ended by calling {{GPURenderPassEncoder/endPass()}} once the user
 has finished recording commands for the pass. Once {{GPURenderPassEncoder/endPass()}} has been
@@ -4995,6 +5510,25 @@ GPURenderBundleEncoder includes GPUProgrammablePassEncoder;
 GPURenderBundleEncoder includes GPURenderEncoderBase;
 </script>
 
+<dl dfn-type=method dfn-for=GPUDevice>
+    : <dfn>createRenderBundleEncoder(descriptor)</dfn>
+    ::
+        Creates a new {{GPURenderBundleEncoder}}.
+
+        <div algorithm=GPUDevice.createRenderBundleEncoder>
+            **Called on:** {{GPUDevice}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPUDevice/createRenderBundleEncoder(descriptor)">
+                descriptor:
+            </pre>
+
+            **Returns:** {{GPURenderBundleEncoder}}
+
+            Issue: Describe {{GPUDevice/createRenderBundleEncoder()}} algorithm steps.
+        </div>
+</dl>
+
 ### Encoding ### {#render-bundle-encoding}
 
 <script type=idl>
@@ -5005,6 +5539,25 @@ dictionary GPURenderBundleEncoderDescriptor : GPUObjectDescriptorBase {
 };
 </script>
 
+### Finalization ### {#render-bundle-finalization}
+
+<dl dfn-type=method dfn-for=GPURenderBundleEncoder>
+    : <dfn>finish(descriptor)</dfn>
+    ::
+
+        <div algorithm="GPURenderBundleEncoder.finish">
+            **Called on:** {{GPURenderBundleEncoder}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPURenderBundleEncoder/finish(descriptor)">
+                descriptor:
+            </pre>
+
+            **Returns:** {{GPURenderBundle}}
+
+            Issue: Describe {{GPURenderBundleEncoder/finish()}} algorithm steps.
+        </div>
+</dl>
 
 # Queues # {#queues}
 
@@ -5185,6 +5738,78 @@ dictionary GPUFenceDescriptor : GPUObjectDescriptorBase {
 };
 </script>
 
+<dl dfn-type=method dfn-for=GPUQueue>
+    : <dfn>createFence(descriptor)</dfn>
+    ::
+
+        <div algorithm="GPUQueue.createFence">
+            **Called on:** {{GPUQueue}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPUQueue/createFence(descriptor)">
+                descriptor:
+            </pre>
+
+            **Returns:** {{GPUFence}}
+
+            Issue: Describe {{GPUQueue/createFence()}} algorithm steps.
+        </div>
+</dl>
+
+### Completion ### {#fence-signaling}
+
+Completion of a fence is signaled from the {{GPUQueue}} that created it.
+
+<dl dfn-type=method dfn-for=GPUQueue>
+    : <dfn>signal(fence, signalValue)</dfn>
+    ::
+
+        <div algorithm="GPUQueue.signal">
+            **Called on:** {{GPUQueue}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPUQueue/signal(fence, signalValue)">
+                fence:
+                signalValue:
+            </pre>
+
+            **Returns:** void
+
+            Issue: Describe {{GPUQueue/signal()}} algorithm steps.
+        </div>
+</dl>
+
+The completion of the fence and the value it completes with can be observed from the {{GPUFence}}.
+
+<dl dfn-type=method dfn-for=GPUFence>
+    : <dfn>getCompletedValue()</dfn>
+    ::
+
+        <div algorithm="GPUFence.getCompletedValue">
+            **Called on:** {{GPUFence}} this.
+
+            **Returns:** {{GPUFenceValue}}
+
+            Issue: Describe {{GPUFence/getCompletedValue()}} algorithm steps.
+        </div>
+
+    : <dfn>onCompletion(completionValue)</dfn>
+    ::
+
+        <div algorithm="GPUFence.onCompletion">
+            **Called on:** {{GPUFence}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPUFence/onCompletion(completionValue)">
+                completionValue:
+            </pre>
+
+            **Returns:** {{Promise}}
+
+            Issue: Describe {{GPUFence/onCompletion()}} algorithm steps.
+        </div>
+</dl>
+
 
 Queries {#queries}
 ================
@@ -5219,6 +5844,40 @@ dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
             1. |pipelineStatistics| is ignored if type is not {{GPUQueryType/pipeline-statistics}}.
             2. If {{GPUExtensionName/pipeline-statistics-query}} is not available, |type| must not be {{GPUQueryType/pipeline-statistics}}.
             3. If |type| is {{GPUQueryType/pipeline-statistics}},  |pipelineStatistics| must be a sequence of {{GPUPipelineStatisticName}} values which cannot be duplicated.
+        </div>
+</dl>
+
+<dl dfn-type=method dfn-for=GPUDevice>
+    : <dfn>createQuerySet(descriptor)</dfn>
+    ::
+        Creates a new {{GPUQuerySet}}.
+
+        <div algorithm=GPUDevice.createQuerySet>
+            **Called on:** {{GPUDevice}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPUDevice/createQuerySet(descriptor)">
+                descriptor:
+            </pre>
+
+            **Returns:** {{GPUQuerySet}}
+
+            Issue: Describe {{GPUDevice/createQuerySet()}} algorithm steps.
+        </div>
+</dl>
+
+### Finalization ### {#queryset-finalization}
+
+<dl dfn-type=method dfn-for=GPUQuerySet>
+    : <dfn>destroy()</dfn>
+    ::
+
+        <div algorithm="GPUQuerySet.signal">
+            **Called on:** {{GPUQuerySet}} this.
+
+            **Returns:** void
+
+            Issue: Describe {{GPUQuerySet/destroy()}} algorithm steps.
         </div>
 </dl>
 
@@ -5272,11 +5931,43 @@ interface GPUCanvasContext {
 };
 </script>
 
-  * {{GPUCanvasContext/configureSwapChain()}}:
-    Configures the swap chain for this canvas, and returns a new
-    {{GPUSwapChain}} object representing it. Destroys any swapchain
-    previously returned by `configureSwapChain`, including all of the
-    textures it has produced.
+<dl dfn-type=method dfn-for=GPUCanvasContext>
+    : <dfn>configureSwapChain(descriptor)</dfn>
+    ::
+        Configures the swap chain for this canvas, and returns a new
+        {{GPUSwapChain}} object representing it. Destroys any swapchain
+        previously returned by `configureSwapChain`, including all of the
+        textures it has produced.
+
+        <div algorithm="GPUCanvasContext.configureSwapChain">
+            **Called on:** {{GPUCanvasContext}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPUCanvasContext/configureSwapChain(descriptor)">
+                descriptor:
+            </pre>
+
+            **Returns:** {{GPUSwapChain}}
+
+            Issue: Describe {{GPUCanvasContext/configureSwapChain()}} algorithm steps.
+        </div>
+
+    : <dfn>getSwapChainPreferredFormat(device)</dfn>
+    ::
+
+        <div algorithm="GPUCanvasContext.getSwapChainPreferredFormat">
+            **Called on:** {{GPUCanvasContext}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPUCanvasContext/getSwapChainPreferredFormat(device)">
+                device:
+            </pre>
+
+            **Returns:** Promise<{{GPUTextureFormat}}>
+
+            Issue: Describe {{GPUCanvasContext/getSwapChainPreferredFormat()}} algorithm steps.
+        </div>
+</dl>
 
 <script type=idl>
 dictionary GPUSwapChainDescriptor : GPUObjectDescriptorBase {
@@ -5301,6 +5992,18 @@ if {{GPUTexture/destroy()}} were called on it (making it unusable elsewhere in W
 Before this drawing buffer is presented for compositing, the implementation shall ensure that all
 rendering operations have been flushed to the drawing buffer.
 
+<dl dfn-type=method dfn-for=GPUSwapChain>
+    : <dfn>getCurrentTexture()</dfn>
+    ::
+
+        <div algorithm="GPUSwapChain.getCurrentTexture">
+            **Called on:** {{GPUSwapChain}} this.
+
+            **Returns:** {{GPUTexture}}
+
+            Issue: Describe {{GPUSwapChain/getCurrentTexture()}} algorithm steps.
+        </div>
+</dl>
 
 # Errors &amp; Debugging # {#errors-and-debugging}
 


### PR DESCRIPTION
This should give us a reasonably placed stub definition for every remaining undocumented method in the spec. Each stub currently lays out the methods `this`, it's arguments, and it's return type. No descriptive text is included unless some already existed and no algorithmic steps are defined. An issue has been placed in each stub to indicate that the algorithm needs to be completed as a way of tracking remaining work.

Felt like this would help alleviate some of the remaining mechanical gruntwork needed, keep the spec formatting consistent with Kai's new style, and let future patches focus on the more important bits.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/toji/gpuweb/pull/969.html" title="Last updated on Jul 31, 2020, 11:18 PM UTC (659dc8a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/969/df8051c...toji:659dc8a.html" title="Last updated on Jul 31, 2020, 11:18 PM UTC (659dc8a)">Diff</a>