### PR TITLE
Add depth texture component type

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2046,7 +2046,9 @@ for depth32float, 1 ULP has a variable value no greater than 1 / (2<sup>24</sup>
 enum GPUTextureComponentType {
     "float",
     "sint",
-    "uint"
+    "uint",
+    // Texture is used with comparison sampling only.
+    "depth-comparison"
 };
 </script>
 
@@ -2680,8 +2682,6 @@ A {{GPUBindGroup}} object has the following internal slots:
                                     - |resource| is [$valid to use with$] |this|.
                                     - |layoutBinding|.{{GPUBindGroupLayoutEntry/viewDimension}} is
                                         equal to |resource|'s {{GPUTextureViewDescriptor/dimension}}.
-                                    - |layoutBinding|.{{GPUBindGroupLayoutEntry/textureComponentType}}
-                                        is compatible with |resource|'s {{GPUTextureViewDescriptor/format}}.
 
                                     - If |layoutBinding|.{{GPUBindGroupLayoutEntry/multisampled}} is `true`:
                                         - |resource|'s texture's {{GPUTextureDescriptor/sampleCount}} is greater than 1.
@@ -2691,6 +2691,8 @@ A {{GPUBindGroup}} object has the following internal slots:
                                     - If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampled-texture"}}:
                                         - |resource|'s texture's {{GPUTextureDescriptor/usage}} includes
                                             {{GPUTextureUsage/SAMPLED}}.
+                                        - |layoutBinding|.{{GPUBindGroupLayoutEntry/textureComponentType}}
+                                            is compatible with |resource|'s {{GPUTextureViewDescriptor/format}}.
 
                                     - If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
                                         {{GPUBindingType/"readonly-storage-texture"}} or
@@ -2735,6 +2737,8 @@ A {{GPUBindGroup}} object has the following internal slots:
                                             size of the buffer, is greater than or equal to
                                             |layoutBinding|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}}.
                         </div>
+
+                        Issue: define the association between texture formats and component types
 
                         Then:
                             1. Generate a {{GPUValidationError}} in the current scope with appropriate


### PR DESCRIPTION
As a follow-up to #909, we have a situation that texture bindings that are used with comparison samplers *have to* be used only with comparison sampling, and they have separate types `texture_depth_*`. This PR is adding an API binding type specifically to reflect the relevant depth textures in the shader.

Having this binding type allows us to validate the binding at pipeline and bind group creation. If we don't add it, we can only validate at draw time. So this belongs to the group of properties outlined in #851.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/970.html" title="Last updated on Aug 17, 2020, 8:12 PM UTC (44107f3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/970/82d202e...44107f3.html" title="Last updated on Aug 17, 2020, 8:12 PM UTC (44107f3)">Diff</a>