### PR TITLE
Add stencil8

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2024,13 +2024,11 @@ enum GPUTextureFormat {
 };
 </script>
 
-Note:
 The depth aspect of the {{GPUTextureFormat/depth24plus-stencil8}}) format
 may be implemented as either a 24-bit unsigned normalized value ("depth24unorm")
 or a 32-bit IEEE 754 floating point value ("depth32float").
 
-Note:
-The {{GPUTextureFormat/depth24plus-stencil8}}) format may be implemented as
+The {{GPUTextureFormat/stencil8}}) format may be implemented as
 either a real "stencil8", or "depth24stencil8", where the depth aspect is
 hidden and inaccessible.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1950,8 +1950,7 @@ The <dfn dfn>texel block width</dfn> and <dfn dfn>texel block height</dfn> speci
     and the [=texel block height=] is the number of texel rows in one [=texel block=].
 
 The <dfn dfn>texel block size</dfn> of a {{GPUTextureFormat}} is the number of bytes to store one [=texel block=].
-The [=texel block size=] of each {{GPUTextureFormat}} is constant except for {{GPUTextureFormat/"depth24plus"}} and
-{{GPUTextureFormat/"depth24plus-stencil8"}}.
+The [=texel block size=] of each {{GPUTextureFormat}} is constant except for {{GPUTextureFormat/"stencil8"}} and {{GPUTextureFormat/"depth24plus-stencil8"}}.
 
 <script type=idl>
 enum GPUTextureFormat {
@@ -2002,9 +2001,9 @@ enum GPUTextureFormat {
     "rgba32float",
 
     // Depth and stencil formats
-    "depth32float",
-    "depth24plus",
+    "stencil8",
     "depth24plus-stencil8",
+    "depth32float",
 
     // BC compressed formats usable if "texture-compression-bc" is both
     // supported by the device/user agent and enabled in requestDevice.
@@ -2025,10 +2024,15 @@ enum GPUTextureFormat {
 };
 </script>
 
-The depth aspect of the `depth24plus` family of formats
-({{GPUTextureFormat/depth24plus}} and {{GPUTextureFormat/depth24plus-stencil8}})
+Note:
+The depth aspect of the {{GPUTextureFormat/depth24plus-stencil8}}) format
 may be implemented as either a 24-bit unsigned normalized value ("depth24unorm")
 or a 32-bit IEEE 754 floating point value ("depth32float").
+
+Note:
+The {{GPUTextureFormat/depth24plus-stencil8}}) format may be implemented as
+either a real "stencil8", or "depth24stencil8", where the depth aspect is
+hidden and inaccessible.
 
 Note:
 While the precision of depth32float is strictly higher than the precision of
@@ -4284,8 +4288,7 @@ Issue(gpuweb/gpuweb#69): Define the copies with {{GPUTextureDimension/1d}} and
 
 Issue(gpuweb/gpuweb#537): Additional restrictions on rowsPerImage if needed.
 
-Issue(gpuweb/gpuweb#652): Define the copies with {{GPUTextureFormat/"depth24plus"}} and
-{{GPUTextureFormat/"depth24plus-stencil8"}}.
+Issue(gpuweb/gpuweb#652): Define the copies with {{GPUTextureFormat/"depth24plus-stencil8"}} and {{GPUTextureFormat/"stencil8"}}.
 
 Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, similar to "validating linear texture data"
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1950,7 +1950,7 @@ The <dfn dfn>texel block width</dfn> and <dfn dfn>texel block height</dfn> speci
     and the [=texel block height=] is the number of texel rows in one [=texel block=].
 
 The <dfn dfn>texel block size</dfn> of a {{GPUTextureFormat}} is the number of bytes to store one [=texel block=].
-The [=texel block size=] of each {{GPUTextureFormat}} is constant except for {{GPUTextureFormat/"stencil8"}} and {{GPUTextureFormat/"depth24plus-stencil8"}}.
+The [=texel block size=] of each {{GPUTextureFormat}} is constant except for {{GPUTextureFormat/"stencil8"}}, {{GPUTextureFormat/"depth24plus"}}, and {{GPUTextureFormat/"depth24plus-stencil8"}}.
 
 <script type=idl>
 enum GPUTextureFormat {
@@ -2002,6 +2002,7 @@ enum GPUTextureFormat {
 
     // Depth and stencil formats
     "stencil8",
+    "depth24plus",
     "depth24plus-stencil8",
     "depth32float",
 
@@ -2024,8 +2025,8 @@ enum GPUTextureFormat {
 };
 </script>
 
-The depth aspect of the {{GPUTextureFormat/depth24plus-stencil8}}) format
-may be implemented as either a 24-bit unsigned normalized value ("depth24unorm")
+The depth aspect of the {{GPUTextureFormat/"depth24plus"}}) and {{GPUTextureFormat/"depth24plus-stencil8"}})
+formats may be implemented as either a 24-bit unsigned normalized value ("depth24unorm")
 or a 32-bit IEEE 754 floating point value ("depth32float").
 
 The {{GPUTextureFormat/stencil8}}) format may be implemented as
@@ -4286,7 +4287,8 @@ Issue(gpuweb/gpuweb#69): Define the copies with {{GPUTextureDimension/1d}} and
 
 Issue(gpuweb/gpuweb#537): Additional restrictions on rowsPerImage if needed.
 
-Issue(gpuweb/gpuweb#652): Define the copies with {{GPUTextureFormat/"depth24plus-stencil8"}} and {{GPUTextureFormat/"stencil8"}}.
+Issue(gpuweb/gpuweb#652): Define the copies with {{GPUTextureFormat/"depth24plus"}},
+{{GPUTextureFormat/"depth24plus-stencil8"}}, and {{GPUTextureFormat/"stencil8"}}.
 
 Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, similar to "validating linear texture data"
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2027,9 +2027,9 @@ enum GPUTextureFormat {
 
 The depth aspect of the {{GPUTextureFormat/"depth24plus"}}) and {{GPUTextureFormat/"depth24plus-stencil8"}})
 formats may be implemented as either a 24-bit unsigned normalized value ("depth24unorm")
+or a 32-bit IEEE 754 floating point value ("depth32float").
 
 Issue: add something on GPULimits that gives an estimate of the bytes per texel of "stencil8"
-or a 32-bit IEEE 754 floating point value ("depth32float").
 
 The {{GPUTextureFormat/stencil8}}) format may be implemented as
 either a real "stencil8", or "depth24stencil8", where the depth aspect is

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2027,6 +2027,8 @@ enum GPUTextureFormat {
 
 The depth aspect of the {{GPUTextureFormat/"depth24plus"}}) and {{GPUTextureFormat/"depth24plus-stencil8"}})
 formats may be implemented as either a 24-bit unsigned normalized value ("depth24unorm")
+
+Issue: add something on GPULimits that gives an estimate of the bytes per texel of "stencil8"
 or a 32-bit IEEE 754 floating point value ("depth32float").
 
 The {{GPUTextureFormat/stencil8}}) format may be implemented as


### PR DESCRIPTION
This PR updates our list of depth-stencil formats, and it's a bit controversial/strawmanny:

- `stencil8` was agreed upon in #306. I tried to think of a better name, but in the end decided that just "stencil8" is fine: unlike "depth24plus", for stencil there is no change in usage or outcome per platform. The only difference is the size, and we document that.

- `depth24plus` is a weird format. It has weaker guarantees that `depth32float`, and yet it doesn't offer anything on top: it's the same size, and it has equal or less precision. Any reason to keep it at all?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/971.html" title="Last updated on Aug 14, 2020, 5:43 PM UTC (526e3c1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/971/2688ff1...kvark:526e3c1.html" title="Last updated on Aug 14, 2020, 5:43 PM UTC (526e3c1)">Diff</a>