### PR TITLE
Add some restrictions about resource usage tracking/validation

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -639,10 +639,9 @@ We define <dfn dfn>subresource</dfn> to be either a whole buffer, or a [=texture
 Some [=internal usage=]s are compatible with others. A [=subresource=] can be in a state
 that combines multiple usages together. We consider a list |U| to be
 a <dfn dfn>compatible usage list</dfn> if (and only if) it satisfies any of the following rules:
-    - Each usage in |U| is [=internal usage/input=], [=internal usage/constant=], or [=internal usage/storage-read=].
+    - Each usage in |U| is [=internal usage/input=], [=internal usage/constant=], [=internal usage/storage-read=], or [=internal usage/attachment-read=].
     - Each usage in |U| is [=internal usage/storage=] or [=internal usage/storage-read=].
     - Each usage in |U| is [=internal usage/storage-write=].
-    - Each usage in |U| is [=internal usage/attachment-read=], [=internal usage/storage-read=], or [=internal usage/constant=].
     - |U| contains exactly one element: [=internal usage/attachment=].
 </div>
 
@@ -665,14 +664,18 @@ For example, binding the same buffer for [=internal usage/storage=] as well as f
 as well as the owning {{GPUCommandEncoder}} into the error state.
 This combination of usages does not make a [=compatible usage list=].
 
-Note:
-All invisible usages and replaced usages should be tracked, for example:
-  1) a resource binding attached to a shader stage with visiblity none,
-  2) a resource binding attached to compute shader stage in render pass, or vice versa,
-  3) resource usages bound in a group that is replaced by a different bind group within current [=usage scope=],
-  4) index or vertex buffer usage bound but replaced by a different
-  {{GPURenderEncoderBase/setIndexBuffer()|GPURenderEncoderBase.setIndexBuffer}} or
-  {{GPURenderEncoderBase/setVertexBuffer()|GPURenderEncoderBase.setVertexBuffer}} within current [=usage scope=].
+Note: race condition of multiple writable storage buffer/texture usages in a single [=usage scope=] is allowed.
+
+<div class=note>
+    This means usages are tracked at state-setting time, not draw/dispatch time,
+    and they ignore binding {{GPUBindGroupLayoutEntry/visibility}}.
+    This means the following example usages **are** tracked:
+
+    - Bind group entries with visibility 0, or visible only to the the compute stage used in a render pass or vice versa.
+    - Bind groups and vertex buffers not used by a pipeline.
+    - Index or vertex buffers not used by any draw call.
+    - Bind groups, index buffers, or vertex buffers which are `set`, then shadowed by another `set` call.
+</div>
 
 The [=subresources=] of textures included in the views provided to
 {{GPURenderPassColorAttachmentDescriptor/attachment|GPURenderPassColorAttachmentDescriptor.attachment}} and

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -596,24 +596,35 @@ Issue(gpuweb/gpuweb#296): Consider merging all read-only usages.
 Textures may consist of separate [=mipmap levels=] and [=array layers=],
 which can be used differently at any given time.
 Each such <dfn dfn>subresource</dfn> is uniquely identified by a
-[=texture=], [=mipmap level=], and
-(for {{GPUTextureDimension/2d}} textures only) [=array layer=].
+[=texture=], [=mipmap level=],
+(for {{GPUTextureDimension/2d}} textures only) [=array layer=],
+and [=aspect=].
 
-The **main usage rule** is that any [=subresource=]
-at any given time can only be in either:
+<dfn dfn>atom resource</dfn> means a whole buffer or a single subresource of a texture.
+
+The **main usage rule** is that any [=atom resource=]
+at any given time within [=usage scope=] can only be in either:
   - a combination of [=read-only usage=]s
   - a single [=mutating usage=]
+
+The only exception is that a combination of writeonly-storage-texture usages, or a combination
+of storage-buffer usages upon the same [#atom resource#] in render pass is allowed.
+
+Note that all invisible usages and overwritten usages should be counted, for example:
+  - a resource binding attached to a shader stage with visiblity none
+  - a resource binding attached to compute shader stage in render pass, or vice versa
+  - a collection of bindings are set by a bind group but being overwritten within current [=usage scope=]
 
 Enforcing this rule allows the API to limit when data races can occur
 when working with memory. That property makes applications written against
 WebGPU more likely to run without modification on different platforms.
 
-Generally, when an implementation processes an operation that uses a [=subresource=]
+Generally, when an implementation processes an operation that uses a [=atom resource=]
 in a different way than its current usage allows, it schedules a transition of the resource
 into the new state. In some cases, like within an open {{GPURenderPassEncoder}}, such a
 transition is impossible due to the hardware limitations.
 We define these places as <dfn dfn>usage scopes</dfn>:
-each [=subresource=] must not change usage within the [=usage scope=].
+each [=atom resource=] must not change usage within the [=usage scope=].
 
 For example, binding the same buffer for {{GPUBufferUsage/STORAGE|GPUBufferUsage.STORAGE}} as well as for
 {{GPUBufferUsage/VERTEX|GPUBufferUsage.VERTEX}} within the same {{GPURenderPassEncoder}} would put the encoder
@@ -648,18 +659,18 @@ Issue(gpuweb/gpuweb#514): Document read-only states for depth views.
 
 ### Synchronization ### {#programming-model-synchronization}
 
-For each [=subresource=] of a [=physical resource=], its set of
+For each [=atom resource=] of a [=physical resource=], its set of
 [=usage flags=] is tracked on the [=Queue timeline=].
 <dfn dfn>Usage flags</dfn> are {{GPUBufferUsage}} or {{GPUTextureUsage}} flags,
-according to the type of the subresource.
+according to the type of the [=atom resource=].
 
 Issue: This section will need to be revised to support multiple queues.
 
 On the [=Queue timeline=], there is an ordered sequence of [=usage scopes=].
 Each item on the timeline is contained within exactly one scope.
 For the duration of each scope, the set of [=usage flags=] of any given
-[=subresource=] is constant.
-A [=subresource=] may transition to new usages
+[=atom resource=] is constant.
+A [=atom resource=] may transition to new usages
 at the boundaries between [=usage scope=]s.
 
 This specification defines the following [=usage scopes=]:
@@ -676,7 +687,7 @@ regardless of whether the indexed draw calls are used afterwards.
 
 The [=usage scopes=] are validated at {{GPUCommandEncoder/finish()|GPUCommandEncoder.finish}} time.
 The implementation performs the <dfn dfn>usage scope validation</dfn> by composing
-the set of all [=usage flags=] of each [=subresource=] used in the [=usage scope=].
+the set of all [=usage flags=] of each [=atom resource=] used in the [=usage scope=].
 A {{GPUValidationError}} is generated in the current scope with an appropriate error message
 if that union contains a [=mutating usage=] combined with any other usage.
 
@@ -1682,7 +1693,7 @@ interface GPUMapMode {
 
 Issue: define <dfn dfn>texture</dfn> (internal object)
 
-Issue: define <dfn dfn>mipmap level</dfn>, <dfn dfn>array layer</dfn>, <dfn dfn>slice</dfn> (concepts)
+Issue: define <dfn dfn>mipmap level</dfn>, <dfn dfn>array layer</dfn>, <dfn dfn>aspect</dfn>, <dfn dfn>slice</dfn> (concepts)
 
 ## <dfn interface>GPUTexture</dfn> ## {#texture-interface}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -666,17 +666,6 @@ This combination of usages does not make a [=compatible usage list=].
 
 Note: race condition of multiple writable storage buffer/texture usages in a single [=usage scope=] is allowed.
 
-<div class=note>
-    This means usages are tracked at state-setting time, not draw/dispatch time,
-    and they ignore binding {{GPUBindGroupLayoutEntry/visibility}}.
-    This means the following example usages **are** tracked:
-
-    - Bind group entries with visibility 0, or visible only to the the compute stage used in a render pass or vice versa.
-    - Bind groups and vertex buffers not used by a pipeline.
-    - Index or vertex buffers not used by any draw call.
-    - Bind groups, index buffers, or vertex buffers which are `set`, then shadowed by another `set` call.
-</div>
-
 The [=subresources=] of textures included in the views provided to
 {{GPURenderPassColorAttachmentDescriptor/attachment|GPURenderPassColorAttachmentDescriptor.attachment}} and
 {{GPURenderPassColorAttachmentDescriptor/resolveTarget|GPURenderPassColorAttachmentDescriptor.resolveTarget}}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -610,11 +610,14 @@ at any given time within [=usage scope=] can only be in either:
 The only exception is that a combination of writeonly-storage-texture usages, or a combination
 of storage-buffer usages upon the same [#atom resource#] in render pass is allowed.
 
-Note that all invisible usages and overwritten usages should be counted, for example:
-  - a resource binding attached to a shader stage with visiblity none
-  - a resource binding attached to compute shader stage in render pass, or vice versa
-  - a collection of bindings are set by a bind group but being overwritten within current [=usage scope=]
-  - index or vertex buffer being overwritten within current [=usage scope=]
+Note:
+All invisible usages and replaced usages should be tracked, for example:
+  1) a resource binding attached to a shader stage with visiblity none,
+  2) a resource binding attached to compute shader stage in render pass, or vice versa,
+  3) resource usages bound in a group that is replaced by a different bind group within current [=usage scope=],
+  4) index or vertex buffer usage bound but replaced by a different
+  {{GPURenderEncoderBase/setIndexBuffer()|GPURenderEncoderBase.setIndexBuffer}} or
+  {{GPURenderEncoderBase/setVertexBuffer()|GPURenderEncoderBase.setVertexBuffer}} within current [=usage scope=].
 
 Enforcing this rule allows the API to limit when data races can occur
 when working with memory. That property makes applications written against

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -614,6 +614,7 @@ Note that all invisible usages and overwritten usages should be counted, for exa
   - a resource binding attached to a shader stage with visiblity none
   - a resource binding attached to compute shader stage in render pass, or vice versa
   - a collection of bindings are set by a bind group but being overwritten within current [=usage scope=]
+  - index or vertex buffer being overwritten within current [=usage scope=]
 
 Enforcing this rule allows the API to limit when data races can occur
 when working with memory. That property makes applications written against


### PR DESCRIPTION
The revisions include:
  - add aspect (in addition to array layer and mip level) for
    subresource
  - add definition of atom resource, and use atom resource to
    replace subresource
  - race condition of writable storage buffer/texture in render
    pass is allowed
  - resource usages validation is done within "usage scope"
  - invisible usages and overwritten usages should be tracked


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Richard-Yunchao/gpuweb/pull/972.html" title="Last updated on Aug 25, 2020, 6:26 PM UTC (78475c8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/972/f9b2c4d...Richard-Yunchao:78475c8.html" title="Last updated on Aug 25, 2020, 6:26 PM UTC (78475c8)">Diff</a>