### PR TITLE
Updated createBindGroupLayout to new method style

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2415,7 +2415,7 @@ enum GPUBindingType {
 };
 </script>
 
-A {{GPUBindGroupLayout}} object has the following internal slots:
+A {{GPUBindGroupLayout}} object has the following methods:
 
 <dl dfn-type=attribute dfn-for="GPUBindGroupLayout">
     : <dfn>\[[entryMap]]</dfn> of type `map<u32, {{GPUBindGroupLayoutEntry}}>`.
@@ -2428,110 +2428,105 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
     : <dfn>createBindGroupLayout(descriptor)</dfn>
     ::
 
-    Creates a {{GPUBindGroupLayout}}.
+        Creates a {{GPUBindGroupLayout}}.
 
-    <div algorithm=GPUDevice.createBindGroupLayout>
-        **Called on:** {{GPUDevice}} |this|.
+        <div algorithm=GPUDevice.createBindGroupLayout>
+            **Called on:** {{GPUDevice}} |this|.
 
-        **Arguments:**
-        <pre class=argumentdef for="GPUDevice/createBindGroupLayout(descriptor)">
-            |descriptor|:
-        </pre>
+            **Arguments:**
+            <pre class=argumentdef for="GPUDevice/createBindGroupLayout(descriptor)">
+                |descriptor|:
+            </pre>
 
-        **Returns:** {{GPUBindGroupLayout}}
+            **Returns:** {{GPUBindGroupLayout}}
 
-        1. If any of the following conditions are unsatisfied:
-            <div class=validusage>
-                - |this| is a [=valid=] {{GPUDevice}}.
-                - Each |bindingDescriptor|.{{GPUBindGroupLayoutEntry/binding}} in |descriptor| is unique.
-                - There is {{GPULimits/maxUniformBuffersPerShaderStage|GPULimits.maxUniformBuffersPerShaderStage}}
-                    or fewer |bindingDescriptor|s of type {{GPUBindingType/uniform-buffer}} visible
-                    on each shader stage in |descriptor|.
-                - There is {{GPULimits/maxDynamicUniformBuffersPerPipelineLayout|GPULimits.maxDynamicUniformBuffersPerPipelineLayout}}
-                    or fewer |bindingDescriptor|s of type {{GPUBindingType/uniform-buffer}} with
-                    {{GPUBindGroupLayoutEntry/hasDynamicOffset}} set to `true` visible on any shader
-                    stage in |descriptor|.
-                -  There is {{GPULimits/maxStorageBuffersPerShaderStage|GPULimits.maxStorageBuffersPerShaderStage}}
-                    or fewer |bindingDescriptor|s of type {{GPUBindingType/storage-buffer}} visible
-                    on each shader stage in |descriptor|.
-                - There is {{GPULimits/maxDynamicStorageBuffersPerPipelineLayout|GPULimits.maxDynamicStorageBuffersPerPipelineLayout}}
-                    or fewer |bindingDescriptor|s of type {{GPUBindingType/storage-buffer}} with
-                    {{GPUBindGroupLayoutEntry/hasDynamicOffset}} set to `true` visible on any shader
-                    stage in |descriptor|.
-                - There is {{GPULimits/maxSampledTexturesPerShaderStage|GPULimits.maxSampledTexturesPerShaderStage}}
-                    or fewer |bindingDescriptor|s of type {{GPUBindingType/sampled-texture}} visible
-                    on each shader stage in |descriptor|.
-                - There is {{GPULimits/maxStorageTexturesPerShaderStage|GPULimits.maxStorageTexturesPerShaderStage}}
-                    or fewer |bindingDescriptor|s of type {{GPUBindingType/readonly-storage-texture}}
-                    and {{GPUBindingType/writeonly-storage-texture}} visible on each shader stage in
-                    |descriptor|.
-                - There is {{GPULimits/maxSamplersPerShaderStage|GPULimits.maxSamplersPerShaderStage}}
-                    or fewer |bindingDescriptor|s of type {{GPUBindingType/sampler}} visible on each
-                    shader stage in |descriptor|.
-            </div>
+            1. Let |layout| be a new valid {{GPUBindGroupLayout}} object.
+            1. Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
+                    1. If any of the following conditions are unsatisfied:
+                        <div class=validusage>
+                            - |this| is a [=valid=] {{GPUDevice}}.
+                            - The {{GPUBindGroupLayoutEntry/binding}} of each entry in |descriptor| is unique.
+                            - For each shader stage, the number of entries in |descriptor| with
+                                {{GPUBindGroupLayoutEntry/type}} {{GPUBindingType/uniform-buffer}} &le;
+                                {{GPULimits/maxUniformBuffersPerShaderStage|GPULimits.maxUniformBuffersPerShaderStage}}.
+                            - For each shader stage, the number of entries in |descriptor| with
+                                {{GPUBindGroupLayoutEntry/type}} {{GPUBindingType/storage-buffer}} &le;
+                                {{GPULimits/maxStorageBuffersPerShaderStage|GPULimits.maxStorageBuffersPerShaderStage}}.
+                            - For each shader stage, the number of entries in |descriptor| with
+                                {{GPUBindGroupLayoutEntry/type}} {{GPUBindingType/sampled-texture}} &le;
+                                {{GPULimits/maxSampledTexturesPerShaderStage|GPULimits.maxSampledTexturesPerShaderStage}}.
+                            - For each shader stage, the number of entries in |descriptor| with
+                                {{GPUBindGroupLayoutEntry/type}} {{GPUBindingType/readonly-storage-texture}} or
+                                {{GPUBindingType/writeonly-storage-texture}} &le;
+                                {{GPULimits/maxStorageTexturesPerShaderStage|GPULimits.maxStorageTexturesPerShaderStage}}.
+                            - For each shader stage, the number of entries in |descriptor| with
+                                {{GPUBindGroupLayoutEntry/type}} {{GPUBindingType/sampler}} &le;
+                                {{GPULimits/maxSamplersPerShaderStage|GPULimits.maxSamplersPerShaderStage}}.
+                            - The number of entries in |descriptor| with {{GPUBindGroupLayoutEntry/type}}
+                                {{GPUBindingType/uniform-buffer}} and {{GPUBindGroupLayoutEntry/hasDynamicOffset}} `true` &le;
+                                {{GPULimits/maxDynamicUniformBuffersPerPipelineLayout|GPULimits.maxDynamicUniformBuffersPerPipelineLayout}}.
+                            - The number of entries in |descriptor| with {{GPUBindGroupLayoutEntry/type}}
+                                {{GPUBindingType/storage-buffer}} and {{GPUBindGroupLayoutEntry/hasDynamicOffset}} `true` &le;
+                                {{GPULimits/maxDynamicStorageBuffersPerPipelineLayout|GPULimits.maxDynamicStorageBuffersPerPipelineLayout}}.
+                        
+                            - For each {{GPUBindGroupLayoutEntry}} |bindingDescriptor| in |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
+                                - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/visibility}} includes
+                                    {{GPUShaderStage/VERTEX}}:
+                                    - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is not
+                                        {{GPUBindingType/storage-buffer}} or {{GPUBindingType/writeonly-storage-texture}}.
+                                
+                                - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
+                                    {{GPUBindingType/"uniform-buffer"}}, {{GPUBindingType/"storage-buffer"}}, or
+                                    {{GPUBindingType/"readonly-storage-buffer"}}:
+                                    - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `undefined`.
+                                    - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} is `undefined`.
 
-            Then:
-                1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
-                1. Create a new [=invalid=] {{GPUBindGroupLayout}} and return the result.
+                                - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
+                                    {{GPUBindingType/"sampled-texture"}}, {{GPUBindingType/"readonly-storage-texture"}},
+                                    or {{GPUBindingType/"writeonly-storage-texture"}}:
+                                        - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/viewDimension}} is `undefined`.
 
-        1. Let |layout| be a new valid {{GPUBindGroupLayout}} object.
-        1. For each {{GPUBindGroupLayoutEntry}} |bindingDescriptor| in |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
-            1. If any of the following conditions are unsatisfied:
-                <div class=validusage>
-                    - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/visibility}} includes
-                        {{GPUShaderStage/VERTEX}}:
-                        - {{GPUBindingType/storage-buffer}} and {{GPUBindingType/writeonly-storage-texture}}
-                            are not allowed.
+                                - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
+                                    {{GPUBindingType/"sampled-texture"}}:
+                                    - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/textureComponentType}} is `undefined.`
+                                    - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/multisampled}} is `undefined.`
 
-                    - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
-                        {{GPUBindingType/"uniform-buffer"}}, {{GPUBindingType/"storage-buffer"}}, or
-                        {{GPUBindingType/"readonly-storage-buffer"}}:
-                        - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `undefined`.
-                        - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} is `undefined`.
+                                - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
+                                    {{GPUBindingType/"readonly-storage-texture"}} or
+                                    {{GPUBindingType/"writeonly-storage-texture"}}:
+                                    - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/storageTextureFormat}} is `undefined`.
 
-                    - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
-                        {{GPUBindingType/"sampled-texture"}}, {{GPUBindingType/"readonly-storage-texture"}},
-                        or {{GPUBindingType/"writeonly-storage-texture"}}:
-                            - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/viewDimension}} is `undefined`.
+                                - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/sampled-texture}}
+                                    and |bindingDescriptor|.{{GPUBindGroupLayoutEntry/multisampled}} is `true`:
+                                    - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/viewDimension}} is
+                                        {{GPUTextureViewDimension/2d}}.
 
-                    - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
-                        {{GPUBindingType/"sampled-texture"}}:
-                        - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/textureComponentType}} is `undefined.`
-                        - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/multisampled}} is `undefined.`
+                                - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is
+                                    {{GPUBindingType/readonly-storage-texture}} or
+                                    {{GPUBindingType/writeonly-storage-texture}}:
+                                    - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/viewDimension}} is not
+                                        {{GPUTextureViewDimension/cube}} or {{GPUTextureViewDimension/cube-array}}.
+                                    - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/storageTextureFormat}} must
+                                        be a format which can support storage usage.
+                        </div>
 
-                    - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
-                        {{GPUBindingType/"readonly-storage-texture"}} or
-                        {{GPUBindingType/"writeonly-storage-texture"}}:
-                        - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/storageTextureFormat}} is `undefined`.
+                        Then:
+                            1. Generate a {{GPUValidationError}} in the current scope with appropriate
+                                error message.
+                            1. Make |layout| [=invalid=] and return |layout|.
 
-                    - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/sampled-texture}}
-                        and |bindingDescriptor|.{{GPUBindGroupLayoutEntry/multisampled}} is `true`:
-                        - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/viewDimension}} is
-                            {{GPUTextureViewDimension/2d}}.
+                    1. For each {{GPUBindGroupLayoutEntry}} |bindingDescriptor| in
+                        |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
+                        1. Insert |bindingDescriptor| into |layout|.{{GPUBindGroupLayout/[[entryMap]]}}
+                            with the key of |bindingDescriptor|.{{GPUBindGroupLayoutEntry/binding}}.
 
-                    - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is
-                        {{GPUBindingType/readonly-storage-texture}} or
-                        {{GPUBindingType/writeonly-storage-texture}}:
-                        - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/viewDimension}} is not
-                            {{GPUTextureViewDimension/cube}}
-                        - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/viewDimension}} is not
-                            {{GPUTextureViewDimension/cube}}{{GPUTextureViewDimension/cube-array}}.
-                        - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/storageTextureFormat}} must
-                            be a format which can support storage usage.
+                        Issue: Add a step to bake the default values (e.g.
+                            {{GPUBindGroupLayoutEntry/viewDimension}} to "2d") into the |bindingDescriptor|.
                 </div>
+            1. Return |layout|.
 
-                Then:
-                    1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
-                    1. Make |layout| [=invalid=] and return |layout|.
-
-            1. Insert |bindingDescriptor| into |layout|.{{GPUBindGroupLayout/[[entryMap]]}}
-                with the key of |bindingDescriptor|/{{GPUBindGroupLayoutEntry/binding}}.
-
-            Issue: Add a step to bake the default values (e.g.
-                {{GPUBindGroupLayoutEntry/viewDimension}} to "2d") into the |bindingDescriptor|.
-        1. Return |layout|.
-
-    </div>
+        </div>
 </dl>
 
 ### Compatibility ### {#bind-group-compatibility}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2424,114 +2424,115 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
         which this {{GPUBindGroupLayout}} describes.
 </dl>
 
-### {{GPUDevice/createBindGroupLayout()|GPUDevice.createBindGroupLayout(GPUBindGroupLayoutDescriptor)}} ### {#GPUDevice-createBindGroupLayout}
+<dl dfn-type=method dfn-for=GPUDevice>
+    : <dfn>createBindGroupLayout(descriptor)</dfn>
+    ::
 
-<div algorithm="GPUDevice.createBindGroupLayout">
-    <strong>this:</strong> of type {{GPUDevice}}.
+    Creates a {{GPUBindGroupLayout}}.
 
-    **Arguments:**
-        - {{GPUBindGroupLayoutDescriptor}} |descriptor|
+    <div algorithm=GPUDevice.createBindGroupLayout>
+        **Called on:** {{GPUDevice}} |this|.
 
-    **Returns:** {{GPUBindGroupLayout}}.
+        **Arguments:**
+        <pre class=argumentdef for="GPUDevice/createBindGroupLayout(descriptor)">
+            |descriptor|:
+        </pre>
 
-    The <dfn method for="GPUDevice">createBindGroupLayout(|descriptor|)</dfn> method is used to create {{GPUBindGroupLayout}}s.
+        **Returns:** {{GPUBindGroupLayout}}
 
-    1. Ensure [=bind group layout device validation=] is not violated.
-    1. Let |layout| be a new valid {{GPUBindGroupLayout}} object.
-    1. For each {{GPUBindGroupLayoutEntry}} |bindingDescriptor| in |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
-        1. Issue: Add a step to bake the default values (e.g.
-             {{GPUBindGroupLayoutEntry/viewDimension}} to "2d") into the |bindingDescriptor|.
-        1. Ensure |bindingDescriptor|.{{GPUBindGroupLayoutEntry/binding}} does not violate [=binding validation=].
-        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/visibility}}
-            includes {{GPUShaderStage/VERTEX}},
-            ensure [=vertex shader binding validation=] is not violated.
-        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
-            {{GPUBindingType/"uniform-buffer"}},
-            {{GPUBindingType/"storage-buffer"}}, or
-            {{GPUBindingType/"readonly-storage-buffer"}},
-            ensure
-            |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}}
-            and |bindingDescriptor|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} are undefined.
-        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
-            {{GPUBindingType/"sampled-texture"}},
-            {{GPUBindingType/"readonly-storage-texture"}}, or
-            {{GPUBindingType/"writeonly-storage-texture"}},
-            ensure
-            |bindingDescriptor|.{{GPUBindGroupLayoutEntry/viewDimension}}
-            is `undefined`.
-        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
-            {{GPUBindingType/"sampled-texture"}},
-            ensure
-            |bindingDescriptor|.{{GPUBindGroupLayoutEntry/textureComponentType}}
-            and
-            |bindingDescriptor|.{{GPUBindGroupLayoutEntry/multisampled}}
-            are undefined.
-        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
-            {{GPUBindingType/"readonly-storage-texture"}}
-            or {{GPUBindingType/"writeonly-storage-texture"}},
-            ensure
-            |bindingDescriptor|.{{GPUBindGroupLayoutEntry/storageTextureFormat}}
-            is `undefined`.
-        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/uniform-buffer}}:
-            1. Ensure [=uniform buffer validation=] is not violated.
-            1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `true`, ensure [=dynamic uniform buffer validation=] is not violated.
-        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/storage-buffer}} or {{GPUBindingType/readonly-storage-buffer}}:
-            1. Ensure [=storage buffer validation=] is not violated.
-            1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `true`, ensure [=dynamic storage buffer validation=] is not violated.
-        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/sampled-texture}}
-            1. Ensure [=sampled texture validation=] is not violated.
-            1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/multisampled}} is `true`, ensure [=multisample texture view dimension validation=] is not violated.
-        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/readonly-storage-texture}} or {{GPUBindingType/writeonly-storage-texture}}:
-            1. Ensure [=storage texture validation=] is not violated.
-            1. Ensure [=storage texture format validation=] is not violated.
-        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/sampler}} or {{GPUBindingType/comparison-sampler}}
-            , ensure [=sampler validation=] is not violated.
-        1. Insert |bindingDescriptor| into |layout|.{{GPUBindGroupLayout/[[entryMap]]}}
-            with the key of |bindingDescriptor|/{{GPUBindGroupLayoutEntry/binding}}.
-    1. Return |layout|.
+        1. If any of the following conditions are unsatisfied:
+            <div class=validusage>
+                - |this| is a [=valid=] {{GPUDevice}}.
+                - Each |bindingDescriptor|.{{GPUBindGroupLayoutEntry/binding}} in |descriptor| is unique.
+                - There is {{GPULimits/maxUniformBuffersPerShaderStage|GPULimits.maxUniformBuffersPerShaderStage}}
+                    or fewer |bindingDescriptor|s of type {{GPUBindingType/uniform-buffer}} visible
+                    on each shader stage in |descriptor|.
+                - There is {{GPULimits/maxDynamicUniformBuffersPerPipelineLayout|GPULimits.maxDynamicUniformBuffersPerPipelineLayout}}
+                    or fewer |bindingDescriptor|s of type {{GPUBindingType/uniform-buffer}} with
+                    {{GPUBindGroupLayoutEntry/hasDynamicOffset}} set to `true` visible on any shader
+                    stage in |descriptor|.
+                -  There is {{GPULimits/maxStorageBuffersPerShaderStage|GPULimits.maxStorageBuffersPerShaderStage}}
+                    or fewer |bindingDescriptor|s of type {{GPUBindingType/storage-buffer}} visible
+                    on each shader stage in |descriptor|.
+                - There is {{GPULimits/maxDynamicStorageBuffersPerPipelineLayout|GPULimits.maxDynamicStorageBuffersPerPipelineLayout}}
+                    or fewer |bindingDescriptor|s of type {{GPUBindingType/storage-buffer}} with
+                    {{GPUBindGroupLayoutEntry/hasDynamicOffset}} set to `true` visible on any shader
+                    stage in |descriptor|.
+                - There is {{GPULimits/maxSampledTexturesPerShaderStage|GPULimits.maxSampledTexturesPerShaderStage}}
+                    or fewer |bindingDescriptor|s of type {{GPUBindingType/sampled-texture}} visible
+                    on each shader stage in |descriptor|.
+                - There is {{GPULimits/maxStorageTexturesPerShaderStage|GPULimits.maxStorageTexturesPerShaderStage}}
+                    or fewer |bindingDescriptor|s of type {{GPUBindingType/readonly-storage-texture}}
+                    and {{GPUBindingType/writeonly-storage-texture}} visible on each shader stage in
+                    |descriptor|.
+                - There is {{GPULimits/maxSamplersPerShaderStage|GPULimits.maxSamplersPerShaderStage}}
+                    or fewer |bindingDescriptor|s of type {{GPUBindingType/sampler}} visible on each
+                    shader stage in |descriptor|.
+            </div>
 
-    <div class=validusage dfn-for=GPUDevice.createBindGroupLayout>
-        <dfn abstract-op>Valid Usage</dfn>
+            Then:
+                1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
+                1. Create a new [=invalid=] {{GPUBindGroupLayout}} and return the result.
 
-        If any of the following conditions are violated:
-            1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
-            1. Create a new [=invalid=] {{GPUBindGroupLayout}} and return the result.
+        1. Let |layout| be a new valid {{GPUBindGroupLayout}} object.
+        1. For each {{GPUBindGroupLayoutEntry}} |bindingDescriptor| in |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
+            1. If any of the following conditions are unsatisfied:
+                <div class=validusage>
+                    - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/visibility}} includes
+                        {{GPUShaderStage/VERTEX}}:
+                        - {{GPUBindingType/storage-buffer}} and {{GPUBindingType/writeonly-storage-texture}}
+                            are not allowed.
 
-        <dfn>bind group layout device validation</dfn>: The {{GPUDevice}} must not be lost.
+                    - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
+                        {{GPUBindingType/"uniform-buffer"}}, {{GPUBindingType/"storage-buffer"}}, or
+                        {{GPUBindingType/"readonly-storage-buffer"}}:
+                        - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `undefined`.
+                        - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} is `undefined`.
 
-        <dfn>binding validation</dfn>: Each |bindingDescriptor|.{{GPUBindGroupLayoutEntry/binding}} in |descriptor| must be unique.
+                    - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
+                        {{GPUBindingType/"sampled-texture"}}, {{GPUBindingType/"readonly-storage-texture"}},
+                        or {{GPUBindingType/"writeonly-storage-texture"}}:
+                            - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/viewDimension}} is `undefined`.
 
-        <dfn>vertex shader binding validation</dfn>: {{GPUBindingType/storage-buffer}} and {{GPUBindingType/writeonly-storage-texture}} are not allowed.
+                    - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
+                        {{GPUBindingType/"sampled-texture"}}:
+                        - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/textureComponentType}} is `undefined.`
+                        - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/multisampled}} is `undefined.`
 
-        <dfn>uniform buffer validation</dfn>: There must be {{GPULimits/maxUniformBuffersPerShaderStage|GPULimits.maxUniformBuffersPerShaderStage}} or
-            fewer |bindingDescriptor|s of type {{GPUBindingType/uniform-buffer}} visible on each shader stage in |descriptor|.
+                    - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
+                        {{GPUBindingType/"readonly-storage-texture"}} or
+                        {{GPUBindingType/"writeonly-storage-texture"}}:
+                        - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/storageTextureFormat}} is `undefined`.
 
-        <dfn>dynamic uniform buffer validation</dfn>: There must be {{GPULimits/maxDynamicUniformBuffersPerPipelineLayout|GPULimits.maxDynamicUniformBuffersPerPipelineLayout}} or
-                fewer |bindingDescriptor|s of type {{GPUBindingType/uniform-buffer}} with {{GPUBindGroupLayoutEntry/hasDynamicOffset}} set to `true` in
-                |descriptor| that are visible to any shader stage.
+                    - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/sampled-texture}}
+                        and |bindingDescriptor|.{{GPUBindGroupLayoutEntry/multisampled}} is `true`:
+                        - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/viewDimension}} is
+                            {{GPUTextureViewDimension/2d}}.
 
-        <dfn>storage buffer validation</dfn>: There must be {{GPULimits/maxStorageBuffersPerShaderStage|GPULimits.maxStorageBuffersPerShaderStage}} or
-            fewer |bindingDescriptor|s of type {{GPUBindingType/storage-buffer}} visible on each shader stage in |descriptor|.
+                    - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is
+                        {{GPUBindingType/readonly-storage-texture}} or
+                        {{GPUBindingType/writeonly-storage-texture}}:
+                        - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/viewDimension}} is not
+                            {{GPUTextureViewDimension/cube}}
+                        - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/viewDimension}} is not
+                            {{GPUTextureViewDimension/cube}}{{GPUTextureViewDimension/cube-array}}.
+                        - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/storageTextureFormat}} must
+                            be a format which can support storage usage.
+                </div>
 
-        <dfn>dynamic storage buffer validation</dfn>: There must be {{GPULimits/maxDynamicStorageBuffersPerPipelineLayout|GPULimits.maxDynamicStorageBuffersPerPipelineLayout}} or
-                fewer |bindingDescriptor|s of type {{GPUBindingType/storage-buffer}} with {{GPUBindGroupLayoutEntry/hasDynamicOffset}} set to `true`
-                in |descriptor| that are visible to any shader stage.
+                Then:
+                    1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
+                    1. Make |layout| [=invalid=] and return |layout|.
 
-        <dfn>sampled texture validation</dfn>: There must be {{GPULimits/maxSampledTexturesPerShaderStage|GPULimits.maxSampledTexturesPerShaderStage}} or
-            fewer |bindingDescriptor|s of type {{GPUBindingType/sampled-texture}} visible on each shader stage in |descriptor|.
+            1. Insert |bindingDescriptor| into |layout|.{{GPUBindGroupLayout/[[entryMap]]}}
+                with the key of |bindingDescriptor|/{{GPUBindGroupLayoutEntry/binding}}.
 
-        <dfn>multisample texture view dimension validation</dfn>: |bindingDescriptor|.{{GPUBindGroupLayoutEntry/viewDimension}} must be {{GPUTextureViewDimension/2d}}.
+            Issue: Add a step to bake the default values (e.g.
+                {{GPUBindGroupLayoutEntry/viewDimension}} to "2d") into the |bindingDescriptor|.
+        1. Return |layout|.
 
-        <dfn>storage texture validation</dfn>: There must be {{GPULimits/maxStorageTexturesPerShaderStage|GPULimits.maxStorageTexturesPerShaderStage}} or
-            fewer |bindingDescriptor|s of type {{GPUBindingType/readonly-storage-texture}} and {{GPUBindingType/writeonly-storage-texture}} visible on each shader stage in |descriptor|.
-            |bindingDescriptor|.{{GPUBindGroupLayoutEntry/viewDimension}} must not be {{GPUTextureViewDimension/cube}} or {{GPUTextureViewDimension/cube-array}}.
-
-        <dfn>storage texture format validation</dfn>: |bindingDescriptor|.{{GPUBindGroupLayoutEntry/storageTextureFormat}} must be a format which can support storage usage.
-
-        <dfn>sampler validation</dfn>: There must be {{GPULimits/maxSamplersPerShaderStage|GPULimits.maxSamplersPerShaderStage}} or
-            fewer |bindingDescriptor|s of type {{GPUBindingType/sampler}} visible on each shader stage in |descriptor|.
     </div>
-</div>
+</dl>
 
 ### Compatibility ### {#bind-group-compatibility}
 


### PR DESCRIPTION
This method was a beast to convert, so it gets it's own PR. Looks like `createBindGroup` will be the same way.

Given that we're trying to life validation into the method's algorithm itself, and this method was defined in such a way that the validation logic bounced back and forth between the algorithm and the externally defined validation, I ended up changing the flow significantly. Validation is now broken into two main blocks: Validation that applies to the entire descriptor and validation that applies to each individual entry.

Previously some of the validation nested in the per-entry loop actually validated that the entire descriptor did not exceed various limits. Given that those limits can safely apply even in none of the entries actually contain the resource type in question I lifted all instances of that type of validation to the descriptor-wide validation steps. This both is a more appropriate scope and doesn't imply that the same validation step needs to be run each time a new resources of that type is encountered.

Also, since the validation failure resolution is multi-step I used the same `- If: /*...*/ Then:` pattern established in #966. It works here, but given the size of the validation blocks it may be a bit awkward to read, especially on smaller screens.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/toji/gpuweb/pull/973.html" title="Last updated on Aug 5, 2020, 4:26 AM UTC (f82394e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/973/0094a8a...toji:f82394e.html" title="Last updated on Aug 5, 2020, 4:26 AM UTC (f82394e)">Diff</a>