### PR TITLE
Add rgb9e5Float texture format

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1975,6 +1975,7 @@ enum GPUTextureFormat {
     "bgra8unorm",
     "bgra8unorm-srgb",
     // Packed 32-bit formats
+    "rgb9e5float",
     "rgb10a2unorm",
     "rg11b10float",
 
@@ -2026,6 +2027,8 @@ depth24unorm for all values in the representable range (0.0 to 1.0),
 note that the set of representable values is not exactly the same:
 for depth24unorm, 1 ULP has a constant value of 1 / (2<sup>24</sup> &minus; 1);
 for depth32float, 1 ULP has a variable value no greater than 1 / (2<sup>24</sup>).
+
+Issue: rgb9e5float cannot be used as a color attachment.
 
 <script type=idl>
 enum GPUTextureComponentType {

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1997,9 +1997,9 @@ enum GPUTextureFormat {
     "bgra8unorm",
     "bgra8unorm-srgb",
     // Packed 32-bit formats
-    "rgb9e5float",
+    "rgb9e5ufloat",
     "rgb10a2unorm",
-    "rg11b10float",
+    "rg11b10ufloat",
 
     // 64-bit formats
     "rg32uint",
@@ -2056,7 +2056,7 @@ note that the set of representable values is not exactly the same:
 for depth24unorm, 1 ULP has a constant value of 1 / (2<sup>24</sup> &minus; 1);
 for depth32float, 1 ULP has a variable value no greater than 1 / (2<sup>24</sup>).
 
-Issue: rgb9e5float cannot be used as a color attachment.
+Issue: {{GPUTextureFormat/"rgb9e5ufloat"}} cannot be used as a color attachment.
 
 <script type=idl>
 enum GPUTextureComponentType {


### PR DESCRIPTION
Closes #957.

This adds the `rgb9e5Float` format and adds a note that it cannot be used as a color attachment.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cwfitzgerald/gpuweb/pull/975.html" title="Last updated on Aug 19, 2020, 7:05 PM UTC (09278b1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/975/8acdb53...cwfitzgerald:09278b1.html" title="Last updated on Aug 19, 2020, 7:05 PM UTC (09278b1)">Diff</a>