### PR TITLE
Updating multiple methods to the new style (Pt. 4)

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -839,19 +839,19 @@ interface GPU {
 
             **Returns:** `Promise<{{GPUAdapter}}?>`.
 
-            - Let |promise| be [=a new promise=].
-            - Issue the following steps on the [=Device timeline=] of |this|:
+            1. Let |promise| be [=a new promise=].
+            1. Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
-                    - If the user agent chooses to return an adapter:
+                    1. If the user agent chooses to return an adapter:
 
-                        - The user agent chooses an [=adapter=] |adapter| according to the rules in
+                        1. The user agent chooses an [=adapter=] |adapter| according to the rules in
                             [[#adapter-selection]].
 
-                        - |promise| [=resolves=] with a new {{GPUAdapter}} encapsulating |adapter|.
+                        1. |promise| [=resolves=] with a new {{GPUAdapter}} encapsulating |adapter|.
 
-                    - Otherwise, |promise| [=resolves=] with `null`.
+                    1. Otherwise, |promise| [=resolves=] with `null`.
                 </div>
-            - Return |promise|.
+            1. Return |promise|.
 
             <!-- If we add ways to make invalid adapter requests (aside from those
                  that violate IDL rules), specify that they reject the promise. -->
@@ -986,10 +986,10 @@ interface GPUAdapter {
 
             **Returns:** `Promise<{{GPUDevice}}?>`.
 
-            - Let |promise| be [=a new promise=].
-            - Issue the following steps to the [=Device timeline=]:
+            1. Let |promise| be [=a new promise=].
+            1. Issue the following steps to the [=Device timeline=]:
                 <div class=device-timeline>
-                    - If any of the following conditions are unsatisfied,
+                    1. If any of the following conditions are unsatisfied,
                         [=reject=] |promise| with an {{OperationError}} and stop.
 
                         <div class=validusage>
@@ -1007,13 +1007,13 @@ interface GPUAdapter {
                             where |adapter| is |this|.{{GPUAdapter/[[adapter]]}}.
                         </div>
 
-                    - If the user agent cannot fulfill the request,
+                    1. If the user agent cannot fulfill the request,
                         [=resolve=] |promise| to `null` and stop.
 
-                    - [=Resolve=] |promise| to a new {{GPUDevice}} object encapsulating
+                    1. [=Resolve=] |promise| to a new {{GPUDevice}} object encapsulating
                         [=a new device=] with the capabilities described by |descriptor|.
                 </div>
-            - Return |promise|.
+            1. Return |promise|.
 
         </div>
 </dl>
@@ -2779,37 +2779,41 @@ dictionary GPUPipelineLayoutDescriptor : GPUObjectDescriptorBase {
 };
 </script>
 
-### {{GPUDevice}}.<dfn method for=GPUDevice>createPipelineLayout(descriptor)</dfn> ### {#device-create-pipeline-layout}
+<dl dfn-type=method dfn-for=GPUDevice>
+    : <dfn>createPipelineLayout(descriptor)</dfn>
+    ::
 
-<div algorithm=GPUDevice.createPipelineLayout>
-    **Arguments:**
-        - {{GPUPipelineLayoutDescriptor}} |descriptor|
+        <div algorithm=GPUDevice.createPipelineLayout>
+            **Called on:** {{GPUDevice}} |this|.
 
-    **Returns:** {{GPUPipelineLayout}}.
+            **Arguments:**
+            <pre class=argumentdef for="GPUDevice/createPipelineLayout(descriptor)">
+                |descriptor|:
+            </pre>
 
-    1. Ensure [=pipeline layout device validation=] is not violated.
-    1. Ensure [=pipeline layout entries validation=] is not violated.
-    1. Let |pl| be a new {{GPUPipelineLayout}} object.
-    1. Set the |pl|.{{GPUPipelineLayout/[[bindGroupLayouts]]}} to |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}.
-    1. Return |pl|.
+            **Returns:** {{GPUBuffer}}
 
-    <div class=validusage dfn-for=GPUDevice.createPipelineLayout>
-        <dfn abstract-op>Valid Usage</dfn>
+            1. If any of the following conditions are unsatisfied:
+                <div class=validusage>
+                    - |this| is a [=valid=] {{GPUDevice}}.
+                    - There is {{GPULimits/maxBindGroups|GPULimits.maxBindGroups}} or fewer
+                        elements in |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}.
+                    - Every {{GPUBindGroupLayout}} in |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
+                        is [=valid=].
+                </div>
 
-        If any of the following conditions are violated:
-            1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
-            1. Create a new [=invalid=] {{GPUPipelineLayout}} and return the result.
+                Then:
+                    1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
+                    1. Create a new [=invalid=] {{GPUPipelineLayout}} and return the result.
 
-        <dfn>pipeline layout device validation</dfn>: The {{GPUDevice}} must not be lost.
+            1. Let |pl| be a new {{GPUPipelineLayout}} object.
+            1. Set the |pl|.{{GPUPipelineLayout/[[bindGroupLayouts]]}} to
+                |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}.
+            1. Return |pl|.
 
-        <dfn>pipeline layout entries validation</dfn>:
-        There must be {{GPULimits/maxBindGroups|GPULimits.maxBindGroups}} or fewer
-        elements in |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}.
-        All these {{GPUBindGroupLayout}} entries have to be valid.
-    </div>
-
-    Issue: there will be more limits applicable to the whole pipeline layout.
-</div>
+            Issue: there will be more limits applicable to the whole pipeline layout.
+        </div>
+</dl>
 
 Note: two {{GPUPipelineLayout}} objects are considered equivalent for any usage
 if their internal {{GPUPipelineLayout/[[bindGroupLayouts]]}} sequences contain
@@ -2940,33 +2944,37 @@ interface mixin GPUPipelineBase {
         The definition of the layout of resources which can be used with `this`.
 </dl>
 
-### <dfn method for=GPUPipelineBase>getBindGroupLayout(index)</dfn> ### {#pipelinebase-getBindGroupLayout}
+{{GPUPipelineBase}} has the following methods:
+<dl dfn-type=method dfn-for=GPUPipelineBase>
+    : <dfn>getBindGroupLayout(index)</dfn>
+    ::
 
-<div algorithm="GPUPipelineBase.getBindGroupLayout">
-    **Arguments:**
+        <div algorithm=GPUPipelineBase.getBindGroupLayout>
+            **Called on:** {{GPUPipelineBase}} |this|.
 
-        - {{unsigned long}} |index|
+            **Arguments:**
+            <pre class=argumentdef for="GPUPipelineBase/getBindGroupLayout(index)">
+                |index|:
+            </pre>
 
-    **Returns:** {{GPUBindGroupLayout}}
+            **Returns:** {{GPUBindGroupLayout}}
 
-    1. If |index| is greater or equal to {{GPULimits/maxBindGroups}}:
+            1. If |index| is greater or equal to {{GPULimits/maxBindGroups}}:
+                1. Throw a {{RangeError}}.
 
-        1. Throw a {{RangeError}}.
+            1. If |this| is not [=valid=]:
+                1. Return a new error {{GPUBindGroupLayout}}.
 
-    1. If |this| is not [=valid=]:
+            1. Return a new {{GPUBindGroupLayout}} object that references the same internal object as
+                |this|.{{GPUPipelineBase/[[layout]]}}.{{GPUPipelineLayout/[[bindGroupLayouts]]}}[|index|].
 
-        1. Return a new error {{GPUBindGroupLayout}}.
+            Issue: Specify this more properly once we have internal objects for {{GPUBindGroupLayout}}.
+                Alternatively only spec is as a new internal objects that's [=group-equivalent=]
 
-    1. Return a new {{GPUBindGroupLayout}} object that references the same internal object as
-        |this|.{{GPUPipelineBase/[[layout]]}}.{{GPUPipelineLayout/[[bindGroupLayouts]]}}[|index|].
-
-    Issue: Specify this more properly once we have internal objects for {{GPUBindGroupLayout}}.
-        Alternatively only spec is as a new internal objects that's [=group-equivalent=]
-
-    Note: Only returning new {{GPUBindGroupLayout}} objects ensures no synchronization is necessary
-        between the [=Content timeline=] and the [=Device timeline=].
-
-</div>
+            Note: Only returning new {{GPUBindGroupLayout}} objects ensures no synchronization is necessary
+                between the [=Content timeline=] and the [=Device timeline=].
+        </div>
+</dl>
 
 ### Default pipeline layout ### {#default-pipeline-layout}
 
@@ -3175,27 +3183,35 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
 };
 </script>
 
-### {{GPUDevice/createComputePipeline()}} ### {#device-createComputePipeline}
+<dl dfn-type=method dfn-for=GPUDevice>
+    : <dfn>createComputePipeline(descriptor)</dfn>
+    ::
+        Creates a {{GPUComputePipeline}}.
 
-<div algorithm="GPUDevice.createComputePipeline">
-    **Arguments:**
-        - {{GPUComputePipelineDescriptor}} |descriptor|
+        <div algorithm=GPUDevice.createComputePipeline>
+            **Called on:** {{GPUDevice}} |this|.
 
-    **Returns:** {{GPUComputePipeline}}.
+            **Arguments:**
+            <pre class=argumentdef for="GPUDevice/createComputePipeline(descriptor)">
+                |descriptor|:
+            </pre>
 
-    The <dfn method for="GPUDevice">createComputePipeline(|descriptor|)</dfn> method is used to create {{GPUComputePipeline}}s.
+            **Returns:** {{GPUComputePipeline}}
 
-    If any of the conditions below are violated:
-        1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
-        1. Create a new [=invalid=] {{GPUComputePipeline}} and return the result.
+            If any of the following conditions are unsatisfied:
+                <div class=validusage>
+                    - |this| is a [=valid=] {{GPUDevice}}.
+                    - |descriptor|.{{GPUPipelineDescriptorBase/layout}} is a [=valid=] {{GPUPipelineLayout}}.
+                    - [$validating GPUProgrammableStageDescriptor$]({{GPUShaderStage/COMPUTE}},
+                        |descriptor|.{{GPUComputePipelineDescriptor/computeStage}},
+                        |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
+                </div>
 
-    Then perform the following steps:
-
-    1. Ensure the {{GPUDevice}} is not lost.
-    1. Ensure the |descriptor|.{{GPUPipelineDescriptorBase/layout}} is a [=valid=] {{GPUPipelineLayout}}.
-    1. Ensure the [$validating GPUProgrammableStageDescriptor$]({{GPUShaderStage/COMPUTE}},
-        |descriptor|.{{GPUComputePipelineDescriptor/computeStage}}, |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
-</div>
+            Then:
+                1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
+                1. Create a new [=invalid=] {{GPUComputePipeline}} and return the result.
+        </div>
+</dl>
 
 ### {{GPUDevice/createReadyComputePipeline()}} ### {#device-createReadyComputePipeline}
 
@@ -3342,46 +3358,55 @@ is enabled, the [=shader-output mask=] becomes the [=alpha-to-coverage mask=]. O
 
 Issue: link to the semantics of SV_SampleIndex and SV_Coverage in WGSL spec.
 
-### {{GPUDevice/createRenderPipeline()}} ### {#device-createRenderPipeline}
+<dl dfn-type=method dfn-for=GPUDevice>
+    : <dfn>createRenderPipeline(descriptor)</dfn>
+    ::
 
-<div algorithm="GPUDevice.createRenderPipeline">
-    **Arguments:**
-        - {{GPURenderPipelineDescriptor}} |descriptor|
+        Creates a {{GPURenderPipeline}}.
 
-    **Returns:** {{GPURenderPipeline}}.
+        <div algorithm=GPUDevice.createRenderPipeline>
+            **Called on:** {{GPUDevice}} |this|.
 
-    The <dfn method for="GPUDevice">createRenderPipeline(|descriptor|)</dfn> method is used to create {{GPURenderPipeline}}s.
+            **Arguments:**
+            <pre class=argumentdef for="GPUDevice/createRenderPipeline(descriptor)">
+                |descriptor|:
+            </pre>
 
-    If any of the conditions below are violated:
-        1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
-        1. Create a new [=invalid=] {{GPURenderPipeline}} and return the result.
+            **Returns:** {{GPUBuffer}}
 
-    Then perform the following steps:
+            If any of the following conditions are unsatisfied:
+                <div class=validusage>
+                    - |this| is a [=valid=] {{GPUDevice}}.
+                    - |descriptor|.{{GPUPipelineDescriptorBase/layout}} is a [=valid=] {{GPUPipelineLayout}}.
+                    - [$validating GPUProgrammableStageDescriptor$]({{GPUShaderStage/VERTEX}},
+                        |descriptor|.{{GPURenderPipelineDescriptor/vertexStage}},
+                        |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
+                    - If |descriptor|.{{GPURenderPipelineDescriptor/fragmentStage}} is not `null`:
+                        - [$validating GPUProgrammableStageDescriptor$]({{GPUShaderStage/FRAGMENT}},
+                            |descriptor|.{{GPURenderPipelineDescriptor/fragmentStage}},
+                            |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
+                    - |descriptor|.{{GPURenderPipelineDescriptor/colorStates}}.length is less than
+                        or equal to 4.
+                    - [$validating GPUVertexStateDescriptor$](|descriptor|.{{GPURenderPipelineDescriptor/vertexState}},
+                        |descriptor|.{{GPURenderPipelineDescriptor/vertexStage}}) passes.
+                    - If |descriptor|.{{GPURenderPipelineDescriptor/alphaToCoverageEnabled}} is `true`:
+                        - |descriptor|.{{GPURenderPipelineDescriptor/sampleCount}} is greater than 1.
+                    - If the output SV_Coverage semantics is [=statically used=] by
+                        |descriptor|.{{GPURenderPipelineDescriptor/fragmentStage}}:
+                        - |descriptor|.{{GPURenderPipelineDescriptor/alphaToCoverageEnabled}} is `false`.
+                </div>
 
-    1. Ensure the {{GPUDevice}} is not lost.
-    1. Ensure the |descriptor|.{{GPUPipelineDescriptorBase/layout}} is
-        a [=valid=] {{GPUPipelineLayout}}.
-    1. Ensure the [$validating GPUProgrammableStageDescriptor$]({{GPUShaderStage/VERTEX}},
-        |descriptor|.{{GPURenderPipelineDescriptor/vertexStage}},
-        |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
-    1. If |descriptor|.{{GPURenderPipelineDescriptor/fragmentStage}} is not "null",
-        ensure the [$validating GPUProgrammableStageDescriptor$]({{GPUShaderStage/FRAGMENT}},
-        |descriptor|.{{GPURenderPipelineDescriptor/fragmentStage}},
-        |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
-    1. Ensure the |descriptor|.{{GPURenderPipelineDescriptor/colorStates}}.length is less than or equal to 4.
-    1. Ensure [$validating GPUVertexStateDescriptor$](|descriptor|.{{GPURenderPipelineDescriptor/vertexState}},
-        |descriptor|.{{GPURenderPipelineDescriptor/vertexStage}}) passes.
-    1. If |descriptor|.{{GPURenderPipelineDescriptor/alphaToCoverageEnabled}} is true,
-        ensure |descriptor|.{{GPURenderPipelineDescriptor/sampleCount}} is greater than 1.
-    2. If the output SV_Coverage semantics is [=statically used=] by |descriptor|.{{GPURenderPipelineDescriptor/fragmentStage}},
-        ensure |descriptor|.{{GPURenderPipelineDescriptor/alphaToCoverageEnabled}} is false.
-</div>
+            Then:
+                1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
+                1. Create a new [=invalid=] {{GPURenderPipeline}} and return the result.
 
-Issue: need a proper limit for the maximum number of color targets.
+            Issue: need a proper limit for the maximum number of color targets.
 
-Issue: need a more detailed validation of the render states.
+            Issue: need a more detailed validation of the render states.
 
-Issue: need description of the render states.
+            Issue: need description of the render states.
+        </div>
+</dl>
 
 ### {{GPUDevice/createReadyRenderPipeline()}} ### {#device-createReadyRenderPipeline}
 
@@ -3888,21 +3913,21 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
-                - If any of the following conditions are unsatisfied, generate a validation
+                1. If any of the following conditions are unsatisfied, generate a validation
                     error and stop.
                     <div class=validusage>
                         - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
                         - |descriptor| meets the
                             [$GPURenderPassDescriptor/GPURenderPassDescriptor Valid Usage$] rules.
                     </div>
-                - Set |this|.{{GPUCommandEncoder/[[state]]}} to {{encoder state/encoding a render pass}}.
-                - For each |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
-                    - The texture [=subresource=] seen by |colorAttachment|.{{GPURenderPassColorAttachmentDescriptor/attachment}}
+                1. Set |this|.{{GPUCommandEncoder/[[state]]}} to {{encoder state/encoding a render pass}}.
+                1. For each |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
+                    1. The texture [=subresource=] seen by |colorAttachment|.{{GPURenderPassColorAttachmentDescriptor/attachment}}
                         is considered to be used as {{GPUTextureUsage/OUTPUT_ATTACHMENT}} for the
                         duration of the render pass.
-                - Let |depthStencilAttachment| be |descriptor|.{{GPURenderPassDescriptor/depthStencilAttachment}}.
-                - If |depthStencilAttachment| is not `null`:
-                    - The texture [=subresource=] seen by |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}
+                1. Let |depthStencilAttachment| be |descriptor|.{{GPURenderPassDescriptor/depthStencilAttachment}}.
+                1. If |depthStencilAttachment| is not `null`:
+                    1. The texture [=subresource=] seen by |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}
                         is considered to be used as {{GPUTextureUsage/OUTPUT_ATTACHMENT}} for the
                         duration of the render pass.
             </div>
@@ -3927,12 +3952,12 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
-                - If any of the following conditions are unsatisfied, generate a validation
+                1. If any of the following conditions are unsatisfied, generate a validation
                     error and stop.
                     <div class=validusage>
                         - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
                     </div>
-                - Set |this|.{{GPUCommandEncoder/[[state]]}} to {{encoder state/encoding a compute pass}}.
+                1. Set |this|.{{GPUCommandEncoder/[[state]]}} to {{encoder state/encoding a compute pass}}.
             </div>
         </div>
 </dl>
@@ -4045,45 +4070,48 @@ dictionary GPUImageBitmapCopyView {
 
   * {{GPUImageBitmapCopyView/origin}}: If unspecified, defaults to `[0, 0]`.
 
-### <dfn method for=GPUCommandEncoder>copyBufferToBuffer(source, sourceOffset, destination, destinationOffset, size)</dfn> ### {#GPUCommandEncoder-copyBufferToBuffer}
+<dl dfn-type=method dfn-for=GPUCommandEncoder>
+    : <dfn>copyBufferToBuffer(source, sourceOffset, destination, destinationOffset, size)</dfn>
+    ::
+        Encode a command into the {{GPUCommandEncoder}} that copies data from a sub-region of a
+        {{GPUBuffer}} to a sub-region of another {{GPUBuffer}}.
 
-<div algorithm="GPUCommandEncoder.copyBufferToBuffer">
+        <div algorithm=GPUCommandEncoder.copyBufferToBuffer>
+            **Called on:** {{GPUCommandEncoder}} |this|.
 
-  **Arguments:**
-    - {{GPUBuffer}} |source|
-    - {{GPUSize64}} |sourceOffset|
-    - {{GPUBuffer}} |destination|
-    - {{GPUSize64}} |destinationOffset|
-    - {{GPUSize64}} |size|
+            **Arguments:**
+            <pre class=argumentdef for="GPUCommandEncoder/copyBufferToBuffer(source, sourceOffset, destination, destinationOffset, size)">
+                |source|: The {{GPUBuffer}} to copy from.
+                |sourceOffset|: Offset in bytes into |source| to begin copying from.
+                |destination|: The {{GPUBuffer}} to copy to.
+                |destinationOffset|: Offset in bytes into |destination| to place the copied data.
+                |size|: Bytes to copy.
+            </pre>
 
-  **Returns:** void
+            **Returns:** `void`
 
-  Encode a command into the {{GPUCommandEncoder}} that copies |size| bytes of data from the |sourceOffset| of a {{GPUBuffer}} |source| to the |destinationOffset| of another {{GPUBuffer}} |destination|.
+            If any of the following conditions are unsatisfied, generate a validation error and stop.
+            <div class=validusage>
+                - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
+                - |source| is a [=valid=] {{GPUBuffer}}.
+                - |destination| is a [=valid=] {{GPUBuffer}}.
+                - |source|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/COPY_SRC}}.
+                - |destination|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/COPY_DST}}.
+                - |size| is a multiple of 4.
+                - |sourceOffset| is a multiple of 4.
+                - |destinationOffset| is a multiple of 4.
+                - (|sourceOffset| + |size|) does not overflow a {{GPUSize64}}.
+                - (|destinationOffset| + |size|) does not overflow a {{GPUSize64}}.
+                - |source|.{{GPUBuffer/[[size]]}} is greater than or equal to (|sourceOffset| + |size|).
+                - |destination|.{{GPUBuffer/[[size]]}} is greater than or equal to (|destinationOffset| + |size|).
+                - |source| and |destination| are not the same {{GPUBuffer}}.
+            </div>
 
-  <div class=validusage dfn-for=GPUCommandEncoder.copyBufferToBuffer>
-        <dfn abstract-op>Valid Usage</dfn>
+            Issue(gpuweb/gpuweb#21): Define the state machine for GPUCommandEncoder.
 
-        Given a {{GPUCommandEncoder}} |encoder| and the arguments {{GPUBuffer}} |source|, {{GPUSize64}} |sourceOffset|, {{GPUBuffer}} |destination|, {{GPUSize64}} |destinationOffset|, {{GPUSize64}} |size|, the following validation rules apply:
-
-          - |encoder|.{{GPUCommandEncoder/[[state]]}} must be {{encoder state/open}}.
-          - |source| must be a [=valid=] {{GPUBuffer}}.
-          - |destination| must be a [=valid=] {{GPUBuffer}}.
-          - The {{GPUBuffer/[[usage]]}} of |source| must contain {{GPUBufferUsage/COPY_SRC}}.
-          - The {{GPUBuffer/[[usage]]}} of |destination| must contain {{GPUBufferUsage/COPY_DST}}.
-          - |size| must be a multiple of 4.
-          - |sourceOffset| must be a multiple of 4.
-          - |destinationOffset| must be a multiple of 4.
-          - (|sourceOffset| + |size|) must not overflow a {{GPUSize64}}.
-          - (|destinationOffset| + |size|) must not overflow a {{GPUSize64}}.
-          - The {{GPUBuffer/[[size]]}} of |source| must be greater than or equal to (|sourceOffset| + |size|).
-          - The {{GPUBuffer/[[size]]}} of |destination| must be greater than or equal to (|destinationOffset| + |size|).
-          - |source| and |destination| must not be the same {{GPUBuffer}}.
-
-        Issue(gpuweb/gpuweb#21): Define the state machine for GPUCommandEncoder.
-
-        Issue(gpuweb/gpuweb#69): figure out how to handle overflows in the spec.
-    </div>
-</div>
+            Issue(gpuweb/gpuweb#69): figure out how to handle overflows in the spec.
+        </div>
+</dl>
 
 ### Copy Between Buffer and Texture ### {#copy-between-buffer-texture}
 
@@ -4198,164 +4226,125 @@ Issue(gpuweb/gpuweb#652): Define the copies with {{GPUTextureFormat/"depth24plus
 
 Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, similar to "validating linear texture data"
 
-#### <dfn method for=GPUCommandEncoder>copyBufferToTexture(source, destination, copySize)</dfn> #### {#GPUCommandEncoder-copyBufferToTexture}
+<dl dfn-type=method dfn-for=GPUCommandEncoder>
+    : <dfn>copyBufferToTexture(source, destination, copySize)</dfn>
+    ::
+        Encode a command into the {{GPUCommandEncoder}} that copies data from a sub-region of a
+        {{GPUBuffer}} to a sub-region of one or multiple continuous {{GPUTexture}} [=subresources=].
 
-<div algorithm="GPUCommandEncoder.copyBufferToTexture">
+        <div algorithm=GPUCommandEncoder.copyBufferToTexture>
+            **Called on:** {{GPUCommandEncoder}} |this|.
 
-  **Arguments:**
-    - {{GPUBufferCopyView}} |source|
-    - {{GPUTextureCopyView}} |destination|
-    - {{GPUExtent3D}} |copySize|
+            **Arguments:**
+            <pre class=argumentdef for="GPUCommandEncoder/copyBufferToTexture(source, destination, copySize)">
+                |source|: Combined with |copySize|, defines the region of the source buffer.
+                |destination|: Combined with |copySize|, defines the region of the destination
+                    texture [=subresource=].
+                |copySize|:
+            </pre>
 
-  **Returns:** void
+            **Returns:** `void`
 
-  Encode a command into the {{GPUCommandEncoder}} that copies data from a sub-region of a
-  {{GPUBuffer}} to a sub-region of one or multiple continuous {{GPUTexture}} [=subresources=].
+            If any of the following conditions are unsatisfied, generate a validation error and stop.
+            <div class=validusage>
+                - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
+                - [$validating GPUBufferCopyView$](|source|) returns `true`.
+                - |source|.{{GPUBufferCopyView/buffer}}.{{GPUBuffer/[[usage]]}} contains
+                    {{GPUBufferUsage/COPY_SRC}}.
+                - [$validating GPUTextureCopyView$](|destination|) returns `true`.
+                - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}} contains
+                    {{GPUTextureUsage/COPY_DST}}.
+                - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is 1.
+                - [$validating linear texture data$](|source|,
+                    |source|.{{GPUBufferCopyView/buffer}}.{{GPUBuffer/[[size]]}},
+                    |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}},
+                    |copySize|) succeeds.
+                - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
+            </div>
+        </div>
 
-  |source| and |copySize| define the region of the source buffer.
+    : <dfn>copyTextureToBuffer(source, destination, copySize)</dfn>
+    ::
+        Encode a command into the {{GPUCommandEncoder}} that copies data from a sub-region of one or
+        multiple continuous {{GPUTexture}} [=subresources=]to a sub-region of a {{GPUBuffer}}.
 
-  |destination| and |copySize| define the region of the destination texture [=subresource=].
+        <div algorithm=GPUCommandEncoder.copyTextureToBuffer>
+            **Called on:** {{GPUCommandEncoder}} |this|.
 
-</div>
+            **Arguments:**
+            <pre class=argumentdef for="GPUCommandEncoder/copyTextureToBuffer(source, destination, copySize)">
+                |source|: Combined with |copySize|, defines the region of the source texture [=subresources=].
+                |destination|: Combined with |copySize|, defines the region of the destination buffer.
+                |copySize|:
+            </pre>
 
-<div algorithm class=validusage>
+            **Returns:** `void`
 
-<dfn abstract-op>copyBufferToTexture Valid Usage</dfn>
+            If any of the following conditions are unsatisfied, generate a validation error and stop.
+            <div class=validusage>
+                - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
+                - [$validating GPUTextureCopyView$](|source|) returns true.
+                - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}} contains
+                    {{GPUTextureUsage/COPY_SRC}}.
+                - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is 1.
+                - [$validating GPUBufferCopyView$](|destination|) returns true.
+                - |destination|.{{GPUBufferCopyView/buffer}}.{{GPUBuffer/[[usage]]}} contains
+                    {{GPUBufferUsage/COPY_DST}}.
+                - [$validating linear texture data$](|destination|,
+                    |destination|.{{GPUBufferCopyView/buffer}}.{{GPUBuffer/[[size]]}},
+                    |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}},
+                    |copySize|) succeeds.
+                - [=Valid Texture Copy Range=] applies to |source| and |copySize|.
+            </div>
+        </div>
 
-Given a {{GPUCommandEncoder}} |encoder| and the arguments {{GPUBufferCopyView}} |source|,
-{{GPUTextureCopyView}} |destination| and {{GPUExtent3D}} |copySize|, the following validation rules apply:
+    : <dfn>copyTextureToTexture(source, destination, copySize)</dfn>
+    ::
+        Encode a command into the {{GPUCommandEncoder}} that copies data from a sub-region of one
+        or multiple contiguous {{GPUTexture}} [=subresources=] to another sub-region of one or
+        multiple continuous {{GPUTexture}} [=subresources=].
 
-  For |encoder|:
-  - |encoder|.{{GPUCommandEncoder/[[state]]}} must be {{encoder state/open}}.
+        <div algorithm=GPUCommandEncoder.copyTextureToTexture>
+            **Called on:** {{GPUCommandEncoder}} |this|.
 
-  For |source|:
-  - [$validating GPUBufferCopyView$](|source|) returns true.
-  - |source|.{{GPUBufferCopyView/buffer}}.{{GPUBuffer/[[usage]]}} must contain {{GPUBufferUsage/COPY_SRC}}.
+            **Arguments:**
+            <pre class=argumentdef for="GPUCommandEncoder/copyTextureToTexture(source, destination, copySize)">
+                |source|: Combined with |copySize|, defines the region of the source texture [=subresources=].
+                |destination|: Combined with |copySize|, defines the region of the destination
+                    texture [=subresources=].
+                |copySize|:
+            </pre>
 
-  For |destination|:
-  - [$validating GPUTextureCopyView$](|destination|) returns true.
-  - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}} must contain
-    {{GPUTextureUsage/COPY_DST}}.
-  - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} must be 1.
+            **Returns:** `void`
 
-  For the copy ranges:
-  - [$validating linear texture data$](|source|, |source|.{{GPUBufferCopyView/buffer}}.{{GPUBuffer/[[size]]}}, |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}, |copySize|) succeeds.
-  - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
-
-</div>
-
-#### <dfn method for=GPUCommandEncoder>copyTextureToBuffer(source, destination, copySize)</dfn> #### {#GPUCommandEncoder-copyTextureToBuffer}
-
-<div algorithm="GPUCommandEncoder.copyTextureToBuffer">
-
-  **Arguments:**
-    - {{GPUTextureCopyView}} |source|
-    - {{GPUBufferCopyView}} |destination|
-    - {{GPUExtent3D}} |copySize|
-
-  **Returns:** void
-
-  Encode a command into the {{GPUCommandEncoder}} that copies data from a sub-region of one or multiple continuous
-  {{GPUTexture}} [=subresources=]to a sub-region of a {{GPUBuffer}}.
-
-  |source| and |copySize| define the region of the source texture [=subresource=].
-
-  |destination| and |copySize| define the region of the destination buffer.
-
-</div>
-
-<div algorithm class=validusage>
-
-<dfn abstract-op>copyTextureToBuffer Valid Usage</dfn>
-
-Given a {{GPUCommandEncoder}} |encoder| and the arguments {{GPUTextureCopyView}} |source|,
-{{GPUBufferCopyView}} |destination|, {{GPUExtent3D}} |copySize|, the following validation rules apply:
-
-  For |encoder|:
-  - |encoder|.{{GPUCommandEncoder/[[state]]}} must be {{encoder state/open}}.
-
-  For |source|:
-  - [$validating GPUTextureCopyView$](|source|) returns true.
-  - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}} must contain
-    {{GPUTextureUsage/COPY_SRC}}.
-  - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} must be 1.
-
-  For |destination|:
-  - [$validating GPUBufferCopyView$](|destination|) returns true.
-  - |destination|.{{GPUBufferCopyView/buffer}}.{{GPUBuffer/[[usage]]}} must contain {{GPUBufferUsage/COPY_DST}}.
-
-  For the copy ranges:
-  - [$validating linear texture data$](|destination|, |destination|.{{GPUBufferCopyView/buffer}}.{{GPUBuffer/[[size]]}}, |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}, |copySize|) succeeds.
-  - [=Valid Texture Copy Range=] applies to |source| and |copySize|.
-
-</div>
-
-### <dfn method for=GPUCommandEncoder>copyTextureToTexture(source, destination, copySize)</dfn> ### {#GPUCommandEncoder-copyTextureToTexture}
-
-<div algorithm="GPUCommandEncoder.copyTextureToTexture">
-
-  **Arguments:**
-    - {{GPUTextureCopyView}} |source|
-    - {{GPUTextureCopyView}} |destination|
-    - {{GPUExtent3D}} |copySize|
-
-  **Returns:** void
-
-  Encode a command into the {{GPUCommandEncoder}} that copies data from a sub-region of one
-  or multiple contiguous {{GPUTexture}} [=subresources=] to another sub-region of one or
-  multiple continuous {{GPUTexture}} [=subresources=].
-
-  |source| and |copySize| define the region of the source texture [=subresources=].
-
-  |destination| and |copySize| define the region of the destination texture [=subresources=].
-
-</div>
-
-<div algorithm class=validusage>
-
-<dfn abstract-op>copyTextureToTexture Valid Usage</dfn>
-
-Given a {{GPUCommandEncoder}} |encoder| and the arguments {{GPUTextureCopyView}} |source|,
-{{GPUTextureCopyView}} |destination|, {{GPUExtent3D}} |copySize|, let:
-
-  - A |copy of the whole subresource| be the command |encoder|.{{GPUCommandEncoder/copyTextureToTexture()}} whose parameters |source|, |destination| and |copySize| meet the following conditions:
-    - The [=textureCopyView subresource size=] of |source| must be equal to |copySize|.
-    - The [=textureCopyView subresource size=] of |destination| must be equal to |copySize|.
-
-The following validation rules apply:
-
-  For |encoder|:
-  - |encoder|.{{GPUCommandEncoder/[[state]]}} must be {{encoder state/open}}.
-
-  For |source|:
-  - [$validating GPUTextureCopyView$](|source|) returns true.
-  - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}} must contain
-    {{GPUTextureUsage/COPY_SRC}}.
-
-  For |destination|:
-  - [$validating GPUTextureCopyView$](|destination|) returns true.
-  - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}} must contain
-    {{GPUTextureUsage/COPY_DST}}.
-
-  For the texture {{GPUTexture/[[sampleCount]]}}:
-  - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} must be equal to |destination|.
-    {{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}}.
-  - If |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is greater than 1:
-    - The copy with |source|, |destination| and |copySize| must be a |copy of the whole subresource|.
-
-  For the texture {{GPUTexture/[[format]]}}:
-  - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} must be equal to |destination|.
-    {{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
-  - If |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format:
-    - The copy with |source|, |destination| and |copySize| must be a |copy of the whole subresource|.
-
-  For the copy ranges:
-  - [=Valid Texture Copy Range=] applies to |source| and |copySize|.
-  - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
-  - The [$set of subresources for texture copy$](|source|, |copySize|) and
-     the  [$set of subresources for texture copy$](|destination|, |copySize|) must be disjoint.
-
-</div>
+            1. Let |copy of the whole subresource| be the command |this|.{{GPUCommandEncoder/copyTextureToTexture()}}
+                whose parameters |source|, |destination| and |copySize| meet the following conditions:
+                - The [=textureCopyView subresource size=] of |source| is equal to |copySize|.
+                - The [=textureCopyView subresource size=] of |destination| is equal to |copySize|.
+            1. If any of the following conditions are unsatisfied, generate a validation error and stop.
+                <div class=validusage>
+                    - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
+                    - [$validating GPUTextureCopyView$](|source|) returns true.
+                    - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}} contains
+                        {{GPUTextureUsage/COPY_SRC}}.
+                    - [$validating GPUTextureCopyView$](|destination|) returns true.
+                    - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}} contains
+                        {{GPUTextureUsage/COPY_DST}}.
+                    - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is equal to |destination|.
+                        {{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}}.
+                    - If |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is greater than 1:
+                        - The copy with |source|, |destination| and |copySize| is a |copy of the whole subresource|.
+                    - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} is equal to |destination|.
+                        {{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
+                    - If |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format:
+                        - The copy with |source|, |destination| and |copySize| is a |copy of the whole subresource|.
+                    - [=Valid Texture Copy Range=] applies to |source| and |copySize|.
+                    - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
+                    - The [$set of subresources for texture copy$](|source|, |copySize|) and
+                        the [$set of subresources for texture copy$](|destination|, |copySize|) is disjoint.
+                </div>
+        </div>
+</dl>
 
 <div algorithm>
     The <dfn abstract-op>set of subresources for texture copy</dfn>(|textureCopyView|, |copySize|)
@@ -4384,7 +4373,7 @@ available or applicable.
 Debug groups in a {{GPUCommandEncoder}} or {{GPUProgrammablePassEncoder}}
 must be well nested.
 
-<dl dfn-type="method" dfn-for="GPUCommandEncoder">
+<dl dfn-type=method dfn-for=GPUCommandEncoder>
     : <dfn>pushDebugGroup(groupLabel)</dfn>
     ::
 
@@ -4521,7 +4510,7 @@ command encoder can no longer be used.
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
-                - If any of the following conditions are unsatisfied, generate a validation
+                1. If any of the following conditions are unsatisfied, generate a validation
                     error and stop.
                     <div class=validusage>
                         - |this| is [=valid=].
@@ -4638,7 +4627,7 @@ pass.
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
-                - Push |groupLabel| onto then end of |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.
+                1. Push |groupLabel| onto then end of |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.
             </div>
         </div>
 
@@ -4654,12 +4643,12 @@ pass.
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
-                - If any of the following conditions are unsatisfied, generate a validation
+                1. If any of the following conditions are unsatisfied, generate a validation
                     error and stop.
                     <div class=validusage>
                         - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.length is greater than 0.
                     </div>
-                - Pop an entry off the end of |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.
+                1. Pop an entry off the end of |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.
             </div>
         </div>
 
@@ -4831,7 +4820,7 @@ called the compute pass encoder can no longer be used.
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
-                - If any of the following conditions are unsatisfied, generate a validation
+                1. If any of the following conditions are unsatisfied, generate a validation
                     error and stop.
                     <div class=validusage>
                         - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.length is 0.
@@ -5301,7 +5290,7 @@ attachments used by this encoder.
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
-                - If any of the following conditions are unsatisfied, generate a validation
+                1. If any of the following conditions are unsatisfied, generate a validation
                     error and stop.
                     <div class=validusage>
                         - |width| is greater than `0`.
@@ -5309,7 +5298,7 @@ attachments used by this encoder.
                         - |minDepth| is greater than or equal to `0.0` and less than or equal to `1.0`.
                         - |maxDepth| is greater than or equal to `0.0` and less than or equal to `1.0`.
                     </div>
-                - Set the viewport to the extents |x|, |y|, |width|, |height|, |minDepth|, and |maxDepth|.
+                1. Set the viewport to the extents |x|, |y|, |width|, |height|, |minDepth|, and |maxDepth|.
             </div>
 
             Issue: Allowed for GPUs to use fixed point or rounded viewport coordinates
@@ -5337,7 +5326,7 @@ attachments used by this encoder.
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
-                - If any of the following conditions are unsatisfied, generate a validation
+                1. If any of the following conditions are unsatisfied, generate a validation
                     error and stop.
                     <div class=validusage>
                         - |x| is greater than or equal to `0`.
@@ -5349,7 +5338,7 @@ attachments used by this encoder.
                         - |y|+|height| is less than or equal to
                             |this|.{{GPURenderPassEncoder/[[attachment_size]]}}.height.
                     </div>
-                - Set the scissor rectangle to the extents |x|, |y|, |width|, and |height|.
+                1. Set the scissor rectangle to the extents |x|, |y|, |width|, and |height|.
             </div>
         </div>
 
@@ -5499,7 +5488,7 @@ called the render pass encoder can no longer be used.
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
-                - If any of the following conditions are unsatisfied, generate a validation
+                1. If any of the following conditions are unsatisfied, generate a validation
                     error and stop.
                     <div class=validusage>
                         - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.length is 0.
@@ -5636,13 +5625,13 @@ GPUQueue includes GPUObjectBase;
 
             **Returns:** `void`
 
-            - If |data| is an {{ArrayBuffer}} or {{DataView}}, let the element type be "byte".
+            1. If |data| is an {{ArrayBuffer}} or {{DataView}}, let the element type be "byte".
                 Otherwise, |data| is a TypedArray; let the element type be the type of the TypedArray.
-            - Let |dataSize| be the size of |data|, in elements.
-            - If |size| is unspecified,
+            1. Let |dataSize| be the size of |data|, in elements.
+            1. If |size| is unspecified,
                 let |contentsSize| be |dataSize| &minus; |dataOffset|.
                 Otherwise, let |contentsSize| be |size|.
-            - If any of the following conditions are unsatisfied,
+            1. If any of the following conditions are unsatisfied,
                 throw {{OperationError}} and stop.
                 <!-- Note: it's easiest to write the valid usage rules inline
                      here, because they depend on contentsSize above. -->
@@ -5651,12 +5640,12 @@ GPUQueue includes GPUObjectBase;
                     - |dataOffset| + |contentsSize| &le; |dataSize|.
                     - |contentsSize|, converted to bytes, is a multiple of 4 bytes.
                 </div>
-            - Let |dataContents| be [=get a copy of the buffer source|a copy of the bytes held by the buffer source=].
-            - Let |contents| be the |contentsSize| elements of |dataContents| starting at
+            1. Let |dataContents| be [=get a copy of the buffer source|a copy of the bytes held by the buffer source=].
+            1. Let |contents| be the |contentsSize| elements of |dataContents| starting at
                 an offset of |dataOffset| elements.
-            - Issue the following steps on the [=Queue timeline=] of |this|:
+            1. Issue the following steps on the [=Queue timeline=] of |this|:
                 <div class=queue-timeline>
-                    - If any of the following conditions are unsatisfied,
+                    1. If any of the following conditions are unsatisfied,
                         generate a validation error and stop.
                         <div class=validusage>
                             - |buffer| is [=valid=].
@@ -5665,7 +5654,7 @@ GPUQueue includes GPUObjectBase;
                             - |bufferOffset|, converted to bytes, is a multiple of 4 bytes.
                             - |bufferOffset| + |contentsSize|, converted to bytes, &le; |buffer|.{{GPUBuffer/[[size]]}} bytes.
                         </div>
-                    - Write |contents| into |buffer| starting at |bufferOffset|.
+                    1. Write |contents| into |buffer| starting at |bufferOffset|.
                 </div>
         </div>
 
@@ -5686,9 +5675,9 @@ GPUQueue includes GPUObjectBase;
 
             **Returns:** `void`
 
-            - Let |dataBytes| be [=get a copy of the buffer source|a copy of the bytes held by the buffer source=] |data|.
-            - Let |dataByteSize| be the number of bytes in |dataBytes|.
-            - If any of the following conditions are unsatisfied,
+            1. Let |dataBytes| be [=get a copy of the buffer source|a copy of the bytes held by the buffer source=] |data|.
+            1. Let |dataByteSize| be the number of bytes in |dataBytes|.
+            1. If any of the following conditions are unsatisfied,
                 throw {{OperationError}} and stop.
                 <div class=validusage>
                     - [$validating linear texture data$](|dataLayout|,
@@ -5696,13 +5685,13 @@ GPUQueue includes GPUObjectBase;
                         |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}},
                         |size|) succeeds.
                 </div>
-            - Let |contents| be the contents of the [=images=] seen by
+            1. Let |contents| be the contents of the [=images=] seen by
                 viewing |dataBytes| with |dataLayout| and |size|.
 
                 Issue: Specify more formally.
-            - Issue the following steps on the [=Queue timeline=] of |this|:
+            1. Issue the following steps on the [=Queue timeline=] of |this|:
                 <div class=queue-timeline>
-                    - If any of the following conditions are unsatisfied,
+                    1. If any of the following conditions are unsatisfied,
                         generate a validation error and stop.
                         <div class=validusage>
                             - [$validating GPUTextureCopyView$](|destination|) returns true.
@@ -5717,7 +5706,7 @@ GPUQueue includes GPUObjectBase;
                             there is no alignment requirement on
                             |dataLayout|.{{GPUTextureDataLayout/bytesPerRow}}.
                         </div>
-                    - Write |contents| into |destination|.
+                    1. Write |contents| into |destination|.
 
                         Issue: Specify more formally.
                 </div>
@@ -5727,28 +5716,55 @@ GPUQueue includes GPUObjectBase;
     ::
         Schedules a copy operation of the contents of an image bitmap into the destination texture.
 
-        The operation throws {{OperationError}} if any of the following any of the following requirements are unmet:
+        <div algorithm=GPUQueue.copyImageBitmapToTexture>
+            **Called on:** {{GPUQueue}} this.
 
-        - {{GPUQueue/copyImageBitmapToTexture(source, destination, copySize)/copySize}}.[=Extent3D/depth=] must be `1`.
-        - {{GPUQueue/copyImageBitmapToTexture(source, destination, copySize)/destination}}.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} must be one of the following:
-             - {{GPUTextureFormat/"rgba8unorm"}}
-             - {{GPUTextureFormat/"rgba8unorm-srgb"}}
-             - {{GPUTextureFormat/"bgra8unorm"}}
-             - {{GPUTextureFormat/"bgra8unorm-srgb"}}
-             - {{GPUTextureFormat/"rgb10a2unorm"}}
-             - {{GPUTextureFormat/"rgba16float"}}
-             - {{GPUTextureFormat/"rgba32float"}}
-             - {{GPUTextureFormat/"rg8unorm"}}
-             - {{GPUTextureFormat/"rg16float"}}
+            **Arguments:**
+            <pre class=argumentdef for="GPUQueue/copyImageBitmapToTexture(source, destination, copySize)">
+                source:
+                |destination|:
+                |copySize|:
+            </pre>
+
+            **Returns:** `void`
+
+            If any of the following conditions are unsatisfied, throw an {{OperationError}} and stop.
+            <div class=validusage>
+                - |copySize|.[=Extent3D/depth=] is `1`.
+                - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} is one of the following:
+                    - {{GPUTextureFormat/"rgba8unorm"}}
+                    - {{GPUTextureFormat/"rgba8unorm-srgb"}}
+                    - {{GPUTextureFormat/"bgra8unorm"}}
+                    - {{GPUTextureFormat/"bgra8unorm-srgb"}}
+                    - {{GPUTextureFormat/"rgb10a2unorm"}}
+                    - {{GPUTextureFormat/"rgba16float"}}
+                    - {{GPUTextureFormat/"rgba32float"}}
+                    - {{GPUTextureFormat/"rg8unorm"}}
+                    - {{GPUTextureFormat/"rg16float"}}
+            </div>
+        </div>
 
     : <dfn>submit(commandBuffers)</dfn>
     ::
         Schedules the execution of the command buffers by the GPU on this queue.
 
-        Does nothing and produces an error if any of the following is true:
+        <div algorithm=GPUQueue.submit>
+            **Called on:** {{GPUQueue}} this.
 
-        - Any {{GPUBuffer}} referenced in any element of {{GPUQueue/submit(commandBuffers)/commandBuffers}} isn't in the `"unmapped"` [=buffer state=].
-        - Any of the [=usage scopes=] contained in the command buffers fail the [=usage scope validation=].
+            **Arguments:**
+            <pre class=argumentdef for="GPUQueue/submit(commandBuffers)">
+                |commandBuffers|:
+            </pre>
+
+            **Returns:** `void`
+
+            If any of the following conditions are unsatisfied, generate a validation error and stop.
+            <div class=validusage>
+                - Every {{GPUBuffer}} referenced in any element of |commandBuffers| is in the
+                    `"unmapped"` [=buffer state=].
+                - Every [=usage scope=] contained in |commandBuffers| satisfies the [=usage scope validation=].
+            </div>
+        </div>
 </dl>
 
 ## GPUFence ## {#fence}


### PR DESCRIPTION
Intended for this to be smaller and it kind of got away from me.

In addition to moving several algorithms back to numbers lists as discussed in #966, this primarily updates the `createPipelineLayout()`. `getBindGroupLayout()`, `createComputePipeline()`, `createRenderPipeline()`, and `copy{texture/buffer}to{texture/buffer}()` methods to the new style. There were several different validations styles at work here and I've tried my best to normalize them, but they'll definitely need additional work going forward.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/toji/gpuweb/pull/976.html" title="Last updated on Aug 4, 2020, 11:01 PM UTC (597979e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/976/0094a8a...toji:597979e.html" title="Last updated on Aug 4, 2020, 11:01 PM UTC (597979e)">Diff</a>