### PR TITLE
Updated createBindGroup to new method style

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2605,118 +2605,141 @@ A {{GPUBindGroup}} object has the following internal slots:
         stored with the union of usage flags that apply to it.
 </dl>
 
-### {{GPUDevice/createBindGroup()|GPUDevice.createBindGroup(GPUBindGroupDescriptor)}} ### {#GPUDevice-createBindGroup}
+<dl dfn-type=method dfn-for=GPUDevice>
+    : <dfn>createBindGroup(descriptor)</dfn>
+    ::
 
-<div algorithm="GPUDevice.createBindGroup">
-    **Arguments:**
-        - {{GPUBindGroupDescriptor}} |descriptor|
+        Creates a {{GPUBindGroup}}.
 
-    **Returns:** {{GPUBindGroup}}.
+        <div algorithm=GPUDevice.createBindGroup>
+            **Called on:** {{GPUDevice}} |this|.
 
-    The <dfn method for="GPUDevice">createBindGroup(|descriptor|)</dfn> method is used to create
-        {{GPUBindGroup}}s.
+            **Arguments:**
+            <pre class=argumentdef for="GPUDevice/createBindGroup(descriptor)">
+                |descriptor|:
+            </pre>
 
-    If any of the conditions below are violated:
-        1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
-        1. Create a new [=invalid=] {{GPUBindGroup}} and return the result.
+            **Returns:** {{GPUBindGroup}}
 
-    1. Ensure [=bind group device validation=] is not violated.
-    1. Ensure |descriptor|.{{GPUBindGroupDescriptor/layout}} is a [=valid=] {{GPUBindGroupLayout}}.
-    1. Ensure the number of {{GPUBindGroupLayoutDescriptor/entries}} of
-        |descriptor|.{{GPUBindGroupDescriptor/layout}} exactly equals to the number of
-        |descriptor|.{{GPUBindGroupDescriptor/entries}}.
-    1. For each {{GPUBindGroupEntry}} |bindingDescriptor| in
-        |descriptor|.{{GPUBindGroupDescriptor/entries}}:
-        1. Let |resource| be |bindingDescriptor|.{{GPUBindGroupEntry/resource}}.
-        1. Ensure there is exactly one {{GPUBindGroupLayoutEntry}} |layoutBinding| in
-            {{GPUBindGroupLayoutDescriptor/entries}} of |descriptor|.{{GPUBindGroupDescriptor/layout}}
-            such that |layoutBinding|.{{GPUBindGroupLayoutEntry/binding}} equals to
-            |bindingDescriptor|.{{GPUBindGroupEntry/binding}}.
-        1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
-            {{GPUBindingType/"sampler"}}:
-            1. Ensure |resource| is a [=valid=] {{GPUSampler}} object.
-            1. Ensure |resource|.{{GPUSampler/[[compareEnable]]}} is false.
-        1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
-            {{GPUBindingType/"comparison-sampler"}}:
-            1. Ensure |resource| is a [=valid=] {{GPUSampler}} object.
-            1. Ensure |resource|.{{GPUSampler/[[compareEnable]]}} is true.
-        1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
-            {{GPUBindingType/"sampled-texture"}} or {{GPUBindingType/"readonly-storage-texture"}} or
-            {{GPUBindingType/"writeonly-storage-texture"}}.
-            1. Ensure |resource| is a [=valid=] {{GPUTextureView}} object.
-            1. Ensure [=texture view binding validation=] is not violated.
-            1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
-                {{GPUBindingType/"readonly-storage-texture"}} or
-                {{GPUBindingType/"writeonly-storage-texture"}}.
-                1. Ensure
-                    |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}
-                    is equal to |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTextureFormat}}.
-        1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
-            {{GPUBindingType/"uniform-buffer"}} or {{GPUBindingType/"storage-buffer"}}
-            or {{GPUBindingType/"readonly-storage-buffer"}}.
-            1. Ensure |resource| is a {{GPUBufferBinding}}.
-            1. Ensure |resource|.{{GPUBufferBinding/buffer}} is [=valid=].
-            1. Ensure [=buffer binding validation=] is not violated.
-    1. Return a new {{GPUBindGroup}} object with:
-        - {{GPUBindGroup/[[layout]]}} = |descriptor|.{{GPUBindGroupDescriptor/layout}}
-        - {{GPUBindGroup/[[entries]]}} = |descriptor|.{{GPUBindGroupDescriptor/entries}}
-        - {{GPUBindGroup/[[usedBuffers]]}} = union of the buffer usages across all entries
-        - {{GPUBindGroup/[[usedTextures]]}} = union of the texture [=subresource=] usages across all entries
+            1. Let |bindGroup| be a new valid {{GPUBindGroup}} object.
+            1. Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
+                    1. If any of the following conditions are unsatisfied:
+                        <div class=validusage>
+                            - |this| is a [=valid=] {{GPUDevice}}.
+                            - |descriptor|.{{GPUBindGroupDescriptor/layout}} is a [=valid=] {{GPUBindGroupLayout}}.
+                            - The number of {{GPUBindGroupLayoutDescriptor/entries}} of
+                                |descriptor|.{{GPUBindGroupDescriptor/layout}} is exactly equal to
+                                the number of |descriptor|.{{GPUBindGroupDescriptor/entries}}.
 
-    <div class=validusage dfn-for=GPUDevice.createBindGroup>
-        <dfn abstract-op>Valid Usage</dfn>
+                            For each {{GPUBindGroupEntry}} |bindingDescriptor| in
+                                |descriptor|.{{GPUBindGroupDescriptor/entries}}:
+                                - Let |resource| be |bindingDescriptor|.{{GPUBindGroupEntry/resource}}.
+                                - There is exactly one {{GPUBindGroupLayoutEntry}} |layoutBinding|
+                                    in |descriptor|.{{GPUBindGroupDescriptor/layout}}.{{GPUBindGroupLayoutDescriptor/entries}}
+                                    such that |layoutBinding|.{{GPUBindGroupLayoutEntry/binding}} equals to
+                                    |bindingDescriptor|.{{GPUBindGroupEntry/binding}}.
 
-        <dfn>bind group device validation</dfn>: The {{GPUDevice}} must not be lost.
+                                - If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampler"}}:
+                                    - |resource| is a [=valid=] {{GPUSampler}} object.
+                                    - |resource|.{{GPUSampler/[[compareEnable]]}} is `false`.
 
-        <dfn>texture view binding validation</dfn>: Let |view| be
-            |bindingDescriptor|.{{GPUBindGroupEntry/resource}}, a {{GPUTextureView}}.
-            This |layoutBinding| must be compatible with this |view|. This requires:
-            1. Its |layoutBinding|.{{GPUBindGroupLayoutEntry/viewDimension}} must equal |view|'s
-                {{GPUTextureViewDescriptor/dimension}}.
-            1. Its |layoutBinding|.{{GPUBindGroupLayoutEntry/textureComponentType}} must be compatible
-                with |view|'s {{GPUTextureViewDescriptor/format}}.
-            1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/multisampled}} is `true`, |view|'s texture's
-                {{GPUTextureDescriptor/sampleCount}} must be greater than 1.
-                Otherwise, if |bindingDescriptor|.{{GPUBindGroupLayoutEntry/multisampled}} is `false`,
-                |view|'s texture's {{GPUTextureDescriptor/sampleCount}} must be 1.
-            1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
-                {{GPUBindingType/"sampled-texture"}}, |view|'s texture's {{GPUTextureDescriptor/usage}}
-                must include {{GPUTextureUsage/SAMPLED}}. Each texture [=subresource=] seen by |view|
-                is added to {{GPUBindGroup/[[usedTextures]]}} with {{GPUTextureUsage/SAMPLED}} flag.
-            1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
-                {{GPUBindingType/"readonly-storage-texture"}} or {{GPUBindingType/"writeonly-storage-texture"}},
-                |view|'s texture's {{GPUTextureDescriptor/usage}} must include {{GPUTextureUsage/STORAGE}}.
-                Each texture [=subresource=] seen by |view|
-                is added to {{GPUBindGroup/[[usedTextures]]}} with {{GPUTextureUsage/STORAGE}} flag.
+                                - If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"comparison-sampler"}}:
+                                    - |resource| is a [=valid=] {{GPUSampler}} object.
+                                    - |resource|.{{GPUSampler/[[compareEnable]]}} is `true`.
 
-        <dfn>buffer binding validation</dfn>: Let |bufferBinding| be
-            |bindingDescriptor|.{{GPUBindGroupEntry/resource}}, a {{GPUBufferBinding}}.
-            This |layoutBinding| must be compatible with this |bufferBinding|. This requires:
-            1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"uniform-buffer"}},
-                the |bufferBinding|.{{GPUBufferBinding/buffer}}'s {{GPUBufferDescriptor/usage}} must include
-                {{GPUBufferUsage/UNIFORM}} and |bufferBinding|.{{GPUBufferBinding/size}} must be less than or equal
-                {{GPULimits/maxUniformBufferBindingSize}}. The buffer is added to the {{GPUBindGroup/[[usedBuffers]]}}
-                map with {{GPUBufferUsage/UNIFORM}} flag.
+                                -  If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
+                                    {{GPUBindingType/"sampled-texture"}} or
+                                    {{GPUBindingType/"readonly-storage-texture"}} or
+                                    {{GPUBindingType/"writeonly-storage-texture"}}:
+                                    - |resource| is a [=valid=] {{GPUTextureView}} object.
+                                    - |layoutBinding|.{{GPUBindGroupLayoutEntry/viewDimension}} is
+                                        equal to |resource|'s {{GPUTextureViewDescriptor/dimension}}.
+                                    - |layoutBinding|.{{GPUBindGroupLayoutEntry/textureComponentType}}
+                                        is compatible with |resource|'s {{GPUTextureViewDescriptor/format}}.
 
-                Issue: This validation should take into account the default when  {{GPUBufferBinding/size}} is not set.
-                Also should {{GPUBufferBinding/size}} default to the `buffer.byteLength - offset` or
-                `min(buffer.byteLength - offset, limits.maxUniformBufferBindingSize)`?
+                                    - If |layoutBinding|.{{GPUBindGroupLayoutEntry/multisampled}} is `true`:
+                                        - |resource|'s texture's {{GPUTextureDescriptor/sampleCount}} is greater than 1.
+                                    - If |layoutBinding|.{{GPUBindGroupLayoutEntry/multisampled}} is `false`:
+                                        - |resource|'s texture's {{GPUTextureDescriptor/sampleCount}} is 1.
 
-            1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"storage-buffer"}}
-                or {{GPUBindingType/"readonly-storage-buffer"}}, the
-                |bufferBinding|.{{GPUBufferBinding/buffer}}'s {{GPUBufferDescriptor/usage}} must include
-                {{GPUBufferUsage/STORAGE}}. The buffer is added to the {{GPUBindGroup/[[usedBuffers]]}} map
-                with {{GPUBufferUsage/STORAGE}} flag.
-            1. The bound part designated by |bufferBinding|.{{GPUBufferBinding/offset}} and
-                |bufferBinding|.{{GPUBufferBinding/size}} must reside inside the buffer.
-            1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/minBufferBindingSize|GPUBindGroupLayoutEntry.minBufferBindingSize}} is not undefined:
-                - The effective binding size, that is either explict in |bufferBinding|.{{GPUBufferBinding/size}}
-                    or derived from |bufferBinding|.{{GPUBufferBinding/offset}} and the full size of the buffer,
-                    is greater than or equal to |layoutBinding|.{{GPUBindGroupLayoutEntry/minBufferBindingSize|GPUBindGroupLayoutEntry.minBufferBindingSize}}.
-    </div>
-</div>
+                                    - If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampled-texture"}}:
+                                        - |resource|'s texture's {{GPUTextureDescriptor/usage}} includes
+                                            {{GPUTextureUsage/SAMPLED}}.
+                                        - Each texture [=subresource=] seen by |resource| is added
+                                            to {{GPUBindGroup/[[usedTextures]]}} with
+                                            {{GPUTextureUsage/SAMPLED}} flag.
 
-Issue: define the "effective buffer binding size" separately.
+                                    - If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
+                                        {{GPUBindingType/"readonly-storage-texture"}} or
+                                        {{GPUBindingType/"writeonly-storage-texture"}}:
+                                        - |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}
+                                            is equal to |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTextureFormat}}.
+                                        - |resource|'s texture's {{GPUTextureDescriptor/usage}} includes
+                                            {{GPUTextureUsage/STORAGE}}.
+                                        - Each texture [=subresource=] seen by |resource| is added
+                                            to {{GPUBindGroup/[[usedTextures]]}} with
+                                            {{GPUTextureUsage/STORAGE}} flag.
+
+                                - If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
+                                    {{GPUBindingType/"uniform-buffer"}} or
+                                    {{GPUBindingType/"storage-buffer"}} or
+                                    {{GPUBindingType/"readonly-storage-buffer"}}:
+                                    - |resource| is a {{GPUBufferBinding}}.
+                                    - |resource|.{{GPUBufferBinding/buffer}} is [=valid=].
+                                    - Let |bufferBinding| be |bindingDescriptor|.{{GPUBindGroupEntry/resource}},
+                                        a {{GPUBufferBinding}}.
+
+                                    - If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"uniform-buffer"}}:
+                                        - |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
+                                            includes {{GPUBufferUsage/UNIFORM}}.
+                                        - |bufferBinding|.{{GPUBufferBinding/size}} &le; {{GPULimits/maxUniformBufferBindingSize}}.
+                                        - The buffer is added to the {{GPUBindGroup/[[usedBuffers]]}}
+                                            map with {{GPUBufferUsage/UNIFORM}} flag.
+
+                                        Issue: This validation should take into account the default when  {{GPUBufferBinding/size}} is not set.
+                                        Also should {{GPUBufferBinding/size}} default to the `buffer.byteLength - offset` or
+                                        `min(buffer.byteLength - offset, limits.maxUniformBufferBindingSize)`?
+
+                                    - If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
+                                        {{GPUBindingType/"storage-buffer"}} or
+                                        {{GPUBindingType/"readonly-storage-buffer"}}:
+                                        - |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
+                                            includes {{GPUBufferUsage/STORAGE}}.
+                                        - The buffer is added to the {{GPUBindGroup/[[usedBuffers]]}}
+                                            map with {{GPUBufferUsage/STORAGE}} flag.
+
+                                    - The bound part designated by |bufferBinding|.{{GPUBufferBinding/offset}} and
+                                        |bufferBinding|.{{GPUBufferBinding/size}} resides inside the buffer.
+
+                                    - If |layoutBinding|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}}
+                                        is not `undefined`:
+                                        - The effective binding size, that is either explict in
+                                            |bufferBinding|.{{GPUBufferBinding/size}} or derived from
+                                            |bufferBinding|.{{GPUBufferBinding/offset}} and the full
+                                            size of the buffer, is greater than or equal to
+                                            |layoutBinding|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}}.
+                        </div>
+
+                        Then:
+                            1. Generate a {{GPUValidationError}} in the current scope with appropriate
+                                error message.
+                            1. Make |bindGroup| [=invalid=] and return |bindGroup|.
+
+                    1. Let |bindGroup|.{{GPUBindGroup/[[layout]]}} =
+                        |descriptor|.{{GPUBindGroupDescriptor/layout}}.
+                    1. Let |bindGroup|.{{GPUBindGroup/[[entries]]}} =
+                        |descriptor|.{{GPUBindGroupDescriptor/entries}}.
+                    1. Let |bindGroup|.{{GPUBindGroup/[[usedBuffers]]}} = union of the buffer usages
+                        across all entries.
+                    1. Let |bindGroup|.{{GPUBindGroup/[[usedTextures]]}} = union of the texture
+                        [=subresource=] usages across all entries.
+                </div>
+            1. Return |bindGroup|.
+
+            Issue: define the "effective buffer binding size" separately.
+        </div>
+</dl>
 
 ## GPUPipelineLayout ## {#pipeline-layout}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2666,9 +2666,6 @@ A {{GPUBindGroup}} object has the following internal slots:
                                     - If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampled-texture"}}:
                                         - |resource|'s texture's {{GPUTextureDescriptor/usage}} includes
                                             {{GPUTextureUsage/SAMPLED}}.
-                                        - Each texture [=subresource=] seen by |resource| is added
-                                            to {{GPUBindGroup/[[usedTextures]]}} with
-                                            {{GPUTextureUsage/SAMPLED}} flag.
 
                                     - If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
                                         {{GPUBindingType/"readonly-storage-texture"}} or
@@ -2677,9 +2674,6 @@ A {{GPUBindGroup}} object has the following internal slots:
                                             is equal to |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTextureFormat}}.
                                         - |resource|'s texture's {{GPUTextureDescriptor/usage}} includes
                                             {{GPUTextureUsage/STORAGE}}.
-                                        - Each texture [=subresource=] seen by |resource| is added
-                                            to {{GPUBindGroup/[[usedTextures]]}} with
-                                            {{GPUTextureUsage/STORAGE}} flag.
 
                                 - If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
                                     {{GPUBindingType/"uniform-buffer"}} or
@@ -2694,8 +2688,6 @@ A {{GPUBindGroup}} object has the following internal slots:
                                         - |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
                                             includes {{GPUBufferUsage/UNIFORM}}.
                                         - |bufferBinding|.{{GPUBufferBinding/size}} &le; {{GPULimits/maxUniformBufferBindingSize}}.
-                                        - The buffer is added to the {{GPUBindGroup/[[usedBuffers]]}}
-                                            map with {{GPUBufferUsage/UNIFORM}} flag.
 
                                         Issue: This validation should take into account the default when  {{GPUBufferBinding/size}} is not set.
                                         Also should {{GPUBufferBinding/size}} default to the `buffer.byteLength - offset` or
@@ -2706,8 +2698,6 @@ A {{GPUBindGroup}} object has the following internal slots:
                                         {{GPUBindingType/"readonly-storage-buffer"}}:
                                         - |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
                                             includes {{GPUBufferUsage/STORAGE}}.
-                                        - The buffer is added to the {{GPUBindGroup/[[usedBuffers]]}}
-                                            map with {{GPUBufferUsage/STORAGE}} flag.
 
                                     - The bound part designated by |bufferBinding|.{{GPUBufferBinding/offset}} and
                                         |bufferBinding|.{{GPUBufferBinding/size}} resides inside the buffer.
@@ -2734,6 +2724,32 @@ A {{GPUBindGroup}} object has the following internal slots:
                         across all entries.
                     1. Let |bindGroup|.{{GPUBindGroup/[[usedTextures]]}} = union of the texture
                         [=subresource=] usages across all entries.
+
+                    1. For each {{GPUBindGroupEntry}} |bindingDescriptor| in
+                        |descriptor|.{{GPUBindGroupDescriptor/entries}}:
+                        1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
+                            {{GPUBindingType/"sampled-texture"}}:
+                            1. Each texture [=subresource=] seen by |resource| is added
+                                to {{GPUBindGroup/[[usedTextures]]}} with
+                                {{GPUTextureUsage/SAMPLED}} flag.
+
+                        1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
+                            {{GPUBindingType/"readonly-storage-texture"}} or
+                            {{GPUBindingType/"writeonly-storage-texture"}}:
+                            1. Each texture [=subresource=] seen by |resource| is added to
+                                {{GPUBindGroup/[[usedTextures]]}} with {{GPUTextureUsage/STORAGE}}
+                                flag.
+
+                        1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
+                            {{GPUBindingType/"uniform-buffer"}}:
+                            1. The buffer is added to the {{GPUBindGroup/[[usedBuffers]]}}
+                                map with {{GPUBufferUsage/UNIFORM}} flag.
+
+                        1. If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
+                            {{GPUBindingType/"storage-buffer"}} or
+                            {{GPUBindingType/"readonly-storage-buffer"}}:
+                            1. The buffer is added to the {{GPUBindGroup/[[usedBuffers]]}}
+                                map with {{GPUBufferUsage/STORAGE}} flag.
                 </div>
             1. Return |bindGroup|.
 


### PR DESCRIPTION
Kind of a sequel to #973, we've got another really huge, single-method conversion.

One question I have is that there's a few lines in here along the lines of:

```
- Each texture [=subresource=] seen by |resource| is added to {{GPUBindGroup/[[usedTextures]]}} with {{GPUTextureUsage/SAMPLED}} flag.
```

Are these intended to be actions (Add these subresources to this map now) or tests (Fail if these subresources are not already in this map with that usage?)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/toji/gpuweb/pull/977.html" title="Last updated on Aug 6, 2020, 7:09 PM UTC (51fafad)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/977/26462a7...toji:51fafad.html" title="Last updated on Aug 6, 2020, 7:09 PM UTC (51fafad)">Diff</a>