### PR TITLE
Adding validation for GPURenderPassEncoderBase methods

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2469,13 +2469,13 @@ A {{GPUBindGroupLayout}} object has the following methods:
                             - The number of entries in |descriptor| with {{GPUBindGroupLayoutEntry/type}}
                                 {{GPUBindingType/storage-buffer}} and {{GPUBindGroupLayoutEntry/hasDynamicOffset}} `true` &le;
                                 {{GPULimits/maxDynamicStorageBuffersPerPipelineLayout|GPULimits.maxDynamicStorageBuffersPerPipelineLayout}}.
-                        
+
                             - For each {{GPUBindGroupLayoutEntry}} |bindingDescriptor| in |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
                                 - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/visibility}} includes
                                     {{GPUShaderStage/VERTEX}}:
                                     - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is not
                                         {{GPUBindingType/storage-buffer}} or {{GPUBindingType/writeonly-storage-texture}}.
-                                
+
                                 - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
                                     {{GPUBindingType/"uniform-buffer"}}, {{GPUBindingType/"storage-buffer"}}, or
                                     {{GPUBindingType/"readonly-storage-buffer"}}:
@@ -4917,11 +4917,24 @@ GPURenderPassEncoder includes GPUProgrammablePassEncoder;
 GPURenderPassEncoder includes GPURenderEncoderBase;
 </script>
 
-  * {{GPURenderEncoderBase/setIndexBuffer()}}/{{GPURenderEncoderBase/setVertexBuffer()}}:
-      * If `size` is zero, the remaining size (after `offset`) of the {{GPUBuffer}} is used.
-
   * In indirect draw calls, the base instance field (inside the indirect
     buffer data) must be set to zero.
+
+{{GPURenderEncoderBase}} has the following internal slots:
+
+<dl dfn-type=attribute dfn-for="GPURenderEncoderBase">
+    : <dfn>\[[pipeline]]</dfn>, of type {{GPURenderPipeline}}
+    ::
+        The current {{GPURenderPipeline}}, initially `null`.
+
+    : <dfn>\[[index_buffer]]</dfn>, of type {{GPUBuffer}}
+    ::
+        The current buffer to read index data from, initially `null`.
+
+    : <dfn>\[[vertex_buffers]]</dfn>, of type sequence<{{GPUBuffer}}>
+    ::
+        The current {{GPUBuffer}}s to read vertex data from, initially an empty [=/list=].
+</dl>
 
 {{GPURenderPassEncoder}} has the following internal slots:
 
@@ -5190,6 +5203,7 @@ enum GPUStoreOp {
                         - |pipeline| is [=valid=].
                         - |pipeline|.{{GPUObjectBase/[[device]]}} is |this|.
                     </div>
+                1. Set |this|.{{GPURenderEncoderBase/[[pipeline]]}} to be |pipeline|.
             </div>
         </div>
 
@@ -5223,6 +5237,7 @@ enum GPUStoreOp {
                     </div>
                 1. Add |buffer| to the [=usage scope=] as
                     {{GPUBufferUsage/INDEX|GPUBufferUsage.INDEX}}).
+                1. Set |this|.{{GPURenderEncoderBase/[[index_buffer]]}} to be |buffer|.
             </div>
         </div>
 
@@ -5259,6 +5274,7 @@ enum GPUStoreOp {
                     </div>
                 1. Add |buffer| to the [=usage scope=] as
                     {{GPUBufferUsage/VERTEX|GPUBufferUsage.VERTEX}}).
+                1. Set |this|.{{GPURenderEncoderBase/[[vertex_buffers]]}}[|slot|] to be |buffer|.
             </div>
         </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5264,16 +5264,17 @@ enum GPUStoreOp {
 
     : <dfn>draw(vertexCount, instanceCount, firstVertex, firstInstance)</dfn>
     ::
+        Draws primitives.
 
         <div algorithm="GPURenderEncoderBase.draw">
             **Called on:** {{GPURenderEncoderBase}} this.
 
             **Arguments:**
             <pre class=argumentdef for="GPURenderEncoderBase/draw(vertexCount, instanceCount, firstVertex, firstInstance)">
-                vertexCount:
-                instanceCount:
-                firstVertex:
-                firstInstance:
+                vertexCount: The number of vertices to draw.
+                instanceCount: The number of instances to draw.
+                firstVertex: Vertex to begin drawing from.
+                firstInstance: First instance to draw.
             </pre>
 
             **Returns:** void
@@ -5283,17 +5284,18 @@ enum GPUStoreOp {
 
     : <dfn>drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance)</dfn>
     ::
+        Draws indexed primitives.
 
         <div algorithm="GPURenderEncoderBase.drawIndexed">
             **Called on:** {{GPURenderEncoderBase}} this.
 
             **Arguments:**
             <pre class=argumentdef for="GPURenderEncoderBase/drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance)">
-                indexCount:
-                instanceCount:
-                firstIndex:
-                baseVertex:
-                firstInstance:
+                indexCount: The number of indices to draw.
+                instanceCount: The number of instances to draw.
+                firstIndex: Index to begin drawing from.
+                baseVertex: Vertex to which corresponds to index zero.
+                firstInstance: First instance to draw.
             </pre>
 
             **Returns:** void
@@ -5303,14 +5305,29 @@ enum GPUStoreOp {
 
     : <dfn>drawIndirect(indirectBuffer, indirectOffset)</dfn>
     ::
+        Draws primitives using parameters read from a {{GPUBuffer}}.
+
+        The <dfn dfn>indirect draw parameters</dfn> encoded in the buffer must be a tightly
+        packed block of **four 32-bit unsigned integer values (16 bytes total)**, given in the same
+        order as the arguments for {{GPURenderEncoderBase/draw()}}. Written as a C struct,
+        the data layout would be:
+
+        ```c
+        struct GPUDrawIndirectParameters {
+            uint32_t vertexCount;
+            uint32_t instanceCount;
+            uint32_t firstVertex;
+            uint32_t firstInstance;
+        };
+        ```
 
         <div algorithm="GPURenderEncoderBase.drawIndirect">
             **Called on:** {{GPURenderEncoderBase}} this.
 
             **Arguments:**
             <pre class=argumentdef for="GPURenderEncoderBase/drawIndirect(indirectBuffer, indirectOffset)">
-                |indirectBuffer|:
-                |indirectOffset|:
+                |indirectBuffer|: Buffer containing the [=indirect draw parameters=].
+                |indirectOffset|: Offset in bytes into |indirectBuffer| where the drawing data begins.
             </pre>
 
             **Returns:** void
@@ -5322,10 +5339,10 @@ enum GPUStoreOp {
                     <div class=validusage>
                         - |indirectBuffer| is [=valid=].
                         - |indirectBuffer|.{{GPUObjectBase/[[device]]}} is |this|.
-                        - |indirectOffset| + [=draw indirect size=] &le;
+                        - |indirectOffset| + sizeof([=indirect draw parameters=]) &le;
                             |indirectBuffer|.{{GPUBuffer/[[size]]}}.
 
-                        Issue: Define the <dfn dfn>draw indirect size</dfn> (`4 * sizeof(uint32_t)`).
+                        Issue: Does |indirectOffset| need a particular alignment?
                     </div>
                 1. Add |indirectBuffer| to the [=usage scope=] as
                     {{GPUBufferUsage/INDIRECT|GPUBufferUsage.INDIRECT}}).
@@ -5334,14 +5351,30 @@ enum GPUStoreOp {
 
     : <dfn>drawIndexedIndirect(indirectBuffer, indirectOffset)</dfn>
     ::
+        Draws indexed primitives using parameters read from a {{GPUBuffer}}.
+
+        The <dfn dfn>indirect drawIndexed parameters</dfn> encoded in the buffer must be a
+        tightly packed block of **five 32-bit unsigned integer values (20 bytes total)**, given in
+        the same order as the arguments for {{GPURenderEncoderBase/drawIndexed()}}. Written as a C
+        struct, the data layout would be:
+
+        ```c
+        struct GPUDrawIndexedIndirectParameters {
+            uint32_t indexCount;
+            uint32_t instanceCount;
+            uint32_t firstIndex;
+            uint32_t baseVertex;
+            uint32_t firstInstance;
+        };
+        ```
 
         <div algorithm="GPURenderEncoderBase.drawIndexedIndirect">
             **Called on:** {{GPURenderEncoderBase}} this.
 
             **Arguments:**
             <pre class=argumentdef for="GPURenderEncoderBase/drawIndexedIndirect(indirectBuffer, indirectOffset)">
-                |indirectBuffer|:
-                |indirectOffset|:
+                |indirectBuffer|: Buffer containing the [=indirect drawIndexed parameters=].
+                |indirectOffset|: Offset in bytes into |indirectBuffer| where the drawing data begins.
             </pre>
 
             **Returns:** void
@@ -5353,11 +5386,10 @@ enum GPUStoreOp {
                     <div class=validusage>
                         - |indirectBuffer| is [=valid=].
                         - |indirectBuffer|.{{GPUObjectBase/[[device]]}} is |this|.
-                        - |indirectOffset| + [=draw indexed indirect size=] &le;
+                        - |indirectOffset| + sizeof([=indirect drawIndexed parameters=]) &le;
                             |indirectBuffer|.{{GPUBuffer/[[size]]}}.
 
-                        Issue: Define the <dfn dfn>draw indexed indirect size</dfn>
-                            (`5 * sizeof(uint32_t)`).
+                        Issue: Does |indirectOffset| need a particular alignment?
                     </div>
                 1. Add |indirectBuffer| to the [=usage scope=] as
                     {{GPUBufferUsage/INDIRECT|GPUBufferUsage.INDIRECT}}).

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5170,56 +5170,96 @@ enum GPUStoreOp {
 <dl dfn-type=method dfn-for=GPURenderEncoderBase>
     : <dfn>setPipeline(pipeline)</dfn>
     ::
+        Sets the current {{GPURenderPipeline}}.
 
         <div algorithm="GPURenderEncoderBase.setPipeline">
             **Called on:** {{GPURenderEncoderBase}} this.
 
             **Arguments:**
             <pre class=argumentdef for="GPURenderEncoderBase/setPipeline(pipeline)">
-                pipeline:
+                |pipeline|: The render pipeline to use for subsequent drawing commands.
             </pre>
 
             **Returns:** void
 
-            Issue: Describe {{GPURenderEncoderBase/setPipeline()}} algorithm steps.
+            Issue the following steps on the [=Queue timeline=] of |this|:
+            <div class=queue-timeline>
+                1. If any of the following conditions are unsatisfied, generate a
+                    {{GPUValidationError}} error and stop.
+                    <div class=validusage>
+                        - |pipeline| is [=valid=].
+                        - |pipeline|.{{GPUObjectBase/[[device]]}} is |this|.
+                    </div>
+            </div>
         </div>
 
     : <dfn>setIndexBuffer(buffer, indexFormat, offset, size)</dfn>
     ::
+        Sets the current index buffer.
 
         <div algorithm="GPURenderEncoderBase.setIndexBuffer">
             **Called on:** {{GPURenderEncoderBase}} this.
 
             **Arguments:**
             <pre class=argumentdef for="GPURenderEncoderBase/setIndexBuffer(buffer, indexFormat, offset, size)">
-                buffer:
-                indexFormat:
-                offset:
-                size:
+                |buffer|: Buffer containing index data to use for subsequent drawing commands.
+                indexFormat: Format of the index data contained in |buffer|.
+                |offset|: Offset in bytes into |buffer| where the index data begins.
+                |size|: Size in bytes of the index data in |buffer|.
+                    If `0`, |buffer|.{{GPUBuffer/[[size]]}} - |offset| is used.
             </pre>
 
             **Returns:** void
 
-            Issue: Describe {{GPURenderEncoderBase/setIndexBuffer()}} algorithm steps.
+            Issue the following steps on the [=Queue timeline=] of |this|:
+            <div class=queue-timeline>
+                1. If any of the following conditions are unsatisfied, generate a
+                    {{GPUValidationError}} error and stop.
+                    <div class=validusage>
+                        - |buffer| is [=valid=].
+                        - |buffer|.{{GPUObjectBase/[[device]]}} is |this|.
+                        - |offset| &le; |buffer|.{{GPUBuffer/[[size]]}}.
+                        - |size| &le; |buffer|.{{GPUBuffer/[[size]]}} - |offset|.
+                    </div>
+                1. Add |buffer| to the [=usage scope=] as
+                    {{GPUBufferUsage/INDEX|GPUBufferUsage.INDEX}}).
+            </div>
         </div>
 
     : <dfn>setVertexBuffer(slot, buffer, offset, size)</dfn>
     ::
+        Sets the current vertex buffer for a given bind group slot.
 
         <div algorithm="GPURenderEncoderBase.setVertexBuffer">
             **Called on:** {{GPURenderEncoderBase}} this.
 
             **Arguments:**
             <pre class=argumentdef for="GPURenderEncoderBase/setVertexBuffer(slot, buffer, offset, size)">
-                slot:
-                buffer:
-                offset:
-                size:
+                |slot|: The bind group slot to set the vertex buffer for.
+                |buffer|: Buffer containing vertex data to use for subsequent drawing commands.
+                |offset|: Offset in bytes into |buffer| where the vertex data begins.
+                |size|: Size in bytes of the vertex data in |buffer|.
+                    If `0`, |buffer|.{{GPUBuffer/[[size]]}} - |offset| is used.
             </pre>
 
             **Returns:** void
 
-            Issue: Describe {{GPURenderEncoderBase/setVertexBuffer()}} algorithm steps.
+            Issue the following steps on the [=Queue timeline=] of |this|:
+            <div class=queue-timeline>
+                1. If any of the following conditions are unsatisfied, generate a
+                    {{GPUValidationError}} error and stop.
+                    <div class=validusage>
+                        - |buffer| is [=valid=].
+                        - |buffer|.{{GPUObjectBase/[[device]]}} is |this|.
+                        - |slot| &lt; [=maximum number of vertex buffers=].
+                        - |offset| &le; |buffer|.{{GPUBuffer/[[size]]}}.
+                        - |size| &le; |buffer|.{{GPUBuffer/[[size]]}} - |offset|.
+
+                        Issue: Define the <dfn dfn>maximum number of vertex buffers</dfn>.
+                    </div>
+                1. Add |buffer| to the [=usage scope=] as
+                    {{GPUBufferUsage/VERTEX|GPUBufferUsage.VERTEX}}).
+            </div>
         </div>
 
     : <dfn>draw(vertexCount, instanceCount, firstVertex, firstInstance)</dfn>
@@ -5269,13 +5309,27 @@ enum GPUStoreOp {
 
             **Arguments:**
             <pre class=argumentdef for="GPURenderEncoderBase/drawIndirect(indirectBuffer, indirectOffset)">
-                indirectBuffer:
-                indirectOffset:
+                |indirectBuffer|:
+                |indirectOffset|:
             </pre>
 
             **Returns:** void
 
-            Issue: Describe {{GPURenderEncoderBase/drawIndirect()}} algorithm steps.
+            Issue the following steps on the [=Queue timeline=] of |this|:
+            <div class=queue-timeline>
+                1. If any of the following conditions are unsatisfied, generate a
+                    {{GPUValidationError}} error and stop.
+                    <div class=validusage>
+                        - |indirectBuffer| is [=valid=].
+                        - |indirectBuffer|.{{GPUObjectBase/[[device]]}} is |this|.
+                        - |indirectOffset| + [=draw indirect size=] &le;
+                            |indirectBuffer|.{{GPUBuffer/[[size]]}}.
+
+                        Issue: Define the <dfn dfn>draw indirect size</dfn> (`4 * sizeof(uint32_t)`).
+                    </div>
+                1. Add |indirectBuffer| to the [=usage scope=] as
+                    {{GPUBufferUsage/INDIRECT|GPUBufferUsage.INDIRECT}}).
+            </div>
         </div>
 
     : <dfn>drawIndexedIndirect(indirectBuffer, indirectOffset)</dfn>
@@ -5286,13 +5340,28 @@ enum GPUStoreOp {
 
             **Arguments:**
             <pre class=argumentdef for="GPURenderEncoderBase/drawIndexedIndirect(indirectBuffer, indirectOffset)">
-                indirectBuffer:
-                indirectOffset:
+                |indirectBuffer|:
+                |indirectOffset|:
             </pre>
 
             **Returns:** void
 
-            Issue: Describe {{GPURenderEncoderBase/drawIndexedIndirect()}} algorithm steps.
+            Issue the following steps on the [=Queue timeline=] of |this|:
+            <div class=queue-timeline>
+                1. If any of the following conditions are unsatisfied, generate a
+                    {{GPUValidationError}} error and stop.
+                    <div class=validusage>
+                        - |indirectBuffer| is [=valid=].
+                        - |indirectBuffer|.{{GPUObjectBase/[[device]]}} is |this|.
+                        - |indirectOffset| + [=draw indexed indirect size=] &le;
+                            |indirectBuffer|.{{GPUBuffer/[[size]]}}.
+
+                        Issue: Define the <dfn dfn>draw indexed indirect size</dfn>
+                            (`5 * sizeof(uint32_t)`).
+                    </div>
+                1. Add |indirectBuffer| to the [=usage scope=] as
+                    {{GPUBufferUsage/INDIRECT|GPUBufferUsage.INDIRECT}}).
+            </div>
         </div>
 </dl>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5182,8 +5182,8 @@ enum GPUStoreOp {
 
             **Returns:** void
 
-            Issue the following steps on the [=Queue timeline=] of |this|:
-            <div class=queue-timeline>
+            Issue the following steps on the [=Device timeline=] of |this|:
+            <div class=device-timeline>
                 1. If any of the following conditions are unsatisfied, generate a
                     {{GPUValidationError}} error and stop.
                     <div class=validusage>
@@ -5211,8 +5211,8 @@ enum GPUStoreOp {
 
             **Returns:** void
 
-            Issue the following steps on the [=Queue timeline=] of |this|:
-            <div class=queue-timeline>
+            Issue the following steps on the [=Device timeline=] of |this|:
+            <div class=device-timeline>
                 1. If any of the following conditions are unsatisfied, generate a
                     {{GPUValidationError}} error and stop.
                     <div class=validusage>
@@ -5244,8 +5244,8 @@ enum GPUStoreOp {
 
             **Returns:** void
 
-            Issue the following steps on the [=Queue timeline=] of |this|:
-            <div class=queue-timeline>
+            Issue the following steps on the [=Device timeline=] of |this|:
+            <div class=device-timeline>
                 1. If any of the following conditions are unsatisfied, generate a
                     {{GPUValidationError}} error and stop.
                     <div class=validusage>
@@ -5273,7 +5273,7 @@ enum GPUStoreOp {
             <pre class=argumentdef for="GPURenderEncoderBase/draw(vertexCount, instanceCount, firstVertex, firstInstance)">
                 vertexCount: The number of vertices to draw.
                 instanceCount: The number of instances to draw.
-                firstVertex: Vertex to begin drawing from.
+                firstVertex: Offset in vertices into the vertex buffers to begin drawing from.
                 firstInstance: First instance to draw.
             </pre>
 
@@ -5293,8 +5293,8 @@ enum GPUStoreOp {
             <pre class=argumentdef for="GPURenderEncoderBase/drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance)">
                 indexCount: The number of indices to draw.
                 instanceCount: The number of instances to draw.
-                firstIndex: Index to begin drawing from.
-                baseVertex: Vertex to which corresponds to index zero.
+                firstIndex: Offset in indices into the index buffer begin drawing from.
+                baseVertex: Added to each index before indexing into the vertex buffers.
                 firstInstance: First instance to draw.
             </pre>
 
@@ -5309,16 +5309,14 @@ enum GPUStoreOp {
 
         The <dfn dfn>indirect draw parameters</dfn> encoded in the buffer must be a tightly
         packed block of **four 32-bit unsigned integer values (16 bytes total)**, given in the same
-        order as the arguments for {{GPURenderEncoderBase/draw()}}. Written as a C struct,
-        the data layout would be:
+        order as the arguments for {{GPURenderEncoderBase/draw()}}. For example:
 
-        ```c
-        struct GPUDrawIndirectParameters {
-            uint32_t vertexCount;
-            uint32_t instanceCount;
-            uint32_t firstVertex;
-            uint32_t firstInstance;
-        };
+        ```js
+        let drawIndirectParameters = new Uint32Array(4);
+        drawIndirectParameters[0] = vertexCount;
+        drawIndirectParameters[1] = instanceCount;
+        drawIndirectParameters[2] = firstVertex;
+        drawIndirectParameters[3] = firstInstance;
         ```
 
         <div algorithm="GPURenderEncoderBase.drawIndirect">
@@ -5332,8 +5330,8 @@ enum GPUStoreOp {
 
             **Returns:** void
 
-            Issue the following steps on the [=Queue timeline=] of |this|:
-            <div class=queue-timeline>
+            Issue the following steps on the [=Device timeline=] of |this|:
+            <div class=device-timeline>
                 1. If any of the following conditions are unsatisfied, generate a
                     {{GPUValidationError}} error and stop.
                     <div class=validusage>
@@ -5341,8 +5339,7 @@ enum GPUStoreOp {
                         - |indirectBuffer|.{{GPUObjectBase/[[device]]}} is |this|.
                         - |indirectOffset| + sizeof([=indirect draw parameters=]) &le;
                             |indirectBuffer|.{{GPUBuffer/[[size]]}}.
-
-                        Issue: Does |indirectOffset| need a particular alignment?
+                        - |indirectOffset| is a multiple of 4.
                     </div>
                 1. Add |indirectBuffer| to the [=usage scope=] as
                     {{GPUBufferUsage/INDIRECT|GPUBufferUsage.INDIRECT}}).
@@ -5355,17 +5352,15 @@ enum GPUStoreOp {
 
         The <dfn dfn>indirect drawIndexed parameters</dfn> encoded in the buffer must be a
         tightly packed block of **five 32-bit unsigned integer values (20 bytes total)**, given in
-        the same order as the arguments for {{GPURenderEncoderBase/drawIndexed()}}. Written as a C
-        struct, the data layout would be:
+        the same order as the arguments for {{GPURenderEncoderBase/drawIndexed()}}. For example:
 
-        ```c
-        struct GPUDrawIndexedIndirectParameters {
-            uint32_t indexCount;
-            uint32_t instanceCount;
-            uint32_t firstIndex;
-            uint32_t baseVertex;
-            uint32_t firstInstance;
-        };
+        ```js
+        let drawIndexedIndirectParameters = new Uint32Array(5);
+        drawIndexedIndirectParameters[0] = indexCount;
+        drawIndexedIndirectParameters[1] = instanceCount;
+        drawIndexedIndirectParameters[2] = firstIndex;
+        drawIndexedIndirectParameters[3] = baseVertex;
+        drawIndexedIndirectParameters[4] = firstInstance;
         ```
 
         <div algorithm="GPURenderEncoderBase.drawIndexedIndirect">
@@ -5379,8 +5374,8 @@ enum GPUStoreOp {
 
             **Returns:** void
 
-            Issue the following steps on the [=Queue timeline=] of |this|:
-            <div class=queue-timeline>
+            Issue the following steps on the [=Device timeline=] of |this|:
+            <div class=device-timeline>
                 1. If any of the following conditions are unsatisfied, generate a
                     {{GPUValidationError}} error and stop.
                     <div class=validusage>
@@ -5388,8 +5383,7 @@ enum GPUStoreOp {
                         - |indirectBuffer|.{{GPUObjectBase/[[device]]}} is |this|.
                         - |indirectOffset| + sizeof([=indirect drawIndexed parameters=]) &le;
                             |indirectBuffer|.{{GPUBuffer/[[size]]}}.
-
-                        Issue: Does |indirectOffset| need a particular alignment?
+                        - |indirectOffset| is a multiple of 4.
                     </div>
                 1. Add |indirectBuffer| to the [=usage scope=] as
                     {{GPUBufferUsage/INDIRECT|GPUBufferUsage.INDIRECT}}).

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4931,9 +4931,13 @@ GPURenderPassEncoder includes GPURenderEncoderBase;
     ::
         The current buffer to read index data from, initially `null`.
 
-    : <dfn>\[[vertex_buffers]]</dfn>, of type sequence<{{GPUBuffer}}>
+    : <dfn>\[[index_format]]</dfn>, of type {{GPUIndexFormat}}
     ::
-        The current {{GPUBuffer}}s to read vertex data from, initially an empty [=/list=].
+        The format of the index data in {{GPURenderEncoderBase/[[index_buffer]]}}.
+
+    : <dfn>\[[vertex_buffers]]</dfn>, of type map<slot, {{GPUBuffer}}>
+    ::
+        The current {{GPUBuffer}}s to read vertex data from for each slot, initially empty.
 </dl>
 
 {{GPURenderPassEncoder}} has the following internal slots:
@@ -5197,8 +5201,7 @@ enum GPUStoreOp {
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
-                1. If any of the following conditions are unsatisfied, generate a
-                    {{GPUValidationError}} error and stop.
+                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |pipeline| is [=valid=].
                         - |pipeline|.{{GPUObjectBase/[[device]]}} is |this|.
@@ -5217,7 +5220,7 @@ enum GPUStoreOp {
             **Arguments:**
             <pre class=argumentdef for="GPURenderEncoderBase/setIndexBuffer(buffer, indexFormat, offset, size)">
                 |buffer|: Buffer containing index data to use for subsequent drawing commands.
-                indexFormat: Format of the index data contained in |buffer|.
+                |indexFormat|: Format of the index data contained in |buffer|.
                 |offset|: Offset in bytes into |buffer| where the index data begins.
                 |size|: Size in bytes of the index data in |buffer|.
                     If `0`, |buffer|.{{GPUBuffer/[[size]]}} - |offset| is used.
@@ -5227,30 +5230,30 @@ enum GPUStoreOp {
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
-                1. If any of the following conditions are unsatisfied, generate a
-                    {{GPUValidationError}} error and stop.
+                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |buffer| is [=valid=].
                         - |buffer|.{{GPUObjectBase/[[device]]}} is |this|.
                         - |offset| &le; |buffer|.{{GPUBuffer/[[size]]}}.
-                        - |size| &le; |buffer|.{{GPUBuffer/[[size]]}} - |offset|.
+                        - |offset| + |size| &le; |buffer|.{{GPUBuffer/[[size]]}}.
                     </div>
                 1. Add |buffer| to the [=usage scope=] as
                     {{GPUBufferUsage/INDEX|GPUBufferUsage.INDEX}}).
                 1. Set |this|.{{GPURenderEncoderBase/[[index_buffer]]}} to be |buffer|.
+                1. Set |this|.{{GPURenderEncoderBase/[[index_format]]}} to be |indexFormat|.
             </div>
         </div>
 
     : <dfn>setVertexBuffer(slot, buffer, offset, size)</dfn>
     ::
-        Sets the current vertex buffer for a given bind group slot.
+        Sets the current vertex buffer for the given slot.
 
         <div algorithm="GPURenderEncoderBase.setVertexBuffer">
             **Called on:** {{GPURenderEncoderBase}} this.
 
             **Arguments:**
             <pre class=argumentdef for="GPURenderEncoderBase/setVertexBuffer(slot, buffer, offset, size)">
-                |slot|: The bind group slot to set the vertex buffer for.
+                |slot|: The vertex buffer slot to set the vertex buffer for.
                 |buffer|: Buffer containing vertex data to use for subsequent drawing commands.
                 |offset|: Offset in bytes into |buffer| where the vertex data begins.
                 |size|: Size in bytes of the vertex data in |buffer|.
@@ -5261,14 +5264,13 @@ enum GPUStoreOp {
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
-                1. If any of the following conditions are unsatisfied, generate a
-                    {{GPUValidationError}} error and stop.
+                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |buffer| is [=valid=].
                         - |buffer|.{{GPUObjectBase/[[device]]}} is |this|.
                         - |slot| &lt; [=maximum number of vertex buffers=].
                         - |offset| &le; |buffer|.{{GPUBuffer/[[size]]}}.
-                        - |size| &le; |buffer|.{{GPUBuffer/[[size]]}} - |offset|.
+                        - |offset| + |size| &le; |buffer|.{{GPUBuffer/[[size]]}}.
 
                         Issue: Define the <dfn dfn>maximum number of vertex buffers</dfn>.
                     </div>
@@ -5289,7 +5291,7 @@ enum GPUStoreOp {
             <pre class=argumentdef for="GPURenderEncoderBase/draw(vertexCount, instanceCount, firstVertex, firstInstance)">
                 vertexCount: The number of vertices to draw.
                 instanceCount: The number of instances to draw.
-                firstVertex: Offset in vertices into the vertex buffers to begin drawing from.
+                firstVertex: Offset into the vertex buffers, in vertices, to begin drawing from.
                 firstInstance: First instance to draw.
             </pre>
 
@@ -5309,8 +5311,8 @@ enum GPUStoreOp {
             <pre class=argumentdef for="GPURenderEncoderBase/drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance)">
                 indexCount: The number of indices to draw.
                 instanceCount: The number of instances to draw.
-                firstIndex: Offset in indices into the index buffer begin drawing from.
-                baseVertex: Added to each index before indexing into the vertex buffers.
+                firstIndex: Offset into the index buffer, in indices, begin drawing from.
+                baseVertex: Added to each index value before indexing into the vertex buffers.
                 firstInstance: First instance to draw.
             </pre>
 
@@ -5348,8 +5350,7 @@ enum GPUStoreOp {
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
-                1. If any of the following conditions are unsatisfied, generate a
-                    {{GPUValidationError}} error and stop.
+                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |indirectBuffer| is [=valid=].
                         - |indirectBuffer|.{{GPUObjectBase/[[device]]}} is |this|.
@@ -5392,8 +5393,7 @@ enum GPUStoreOp {
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
-                1. If any of the following conditions are unsatisfied, generate a
-                    {{GPUValidationError}} error and stop.
+                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |indirectBuffer| is [=valid=].
                         - |indirectBuffer|.{{GPUObjectBase/[[device]]}} is |this|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4935,9 +4935,13 @@ GPURenderPassEncoder includes GPURenderEncoderBase;
     ::
         The format of the index data in {{GPURenderEncoderBase/[[index_buffer]]}}.
 
-    : <dfn>\[[vertex_buffers]]</dfn>, of type map<slot, {{GPUBuffer}}>
+    : <dfn>\[[vertex_buffers]]</dfn>, of type map&lt;slot, {{GPUBuffer}}&gt;
     ::
         The current {{GPUBuffer}}s to read vertex data from for each slot, initially empty.
+
+    : <dfn>\[[bind_groups]]</dfn>, of type map&lt;index, {{GPUBindGroup}}&gt;
+    ::
+        The current {{GPUBindGroup}}s to to render with for each index, initially empty.
 </dl>
 
 {{GPURenderPassEncoder}} has the following internal slots:
@@ -5205,6 +5209,8 @@ enum GPUStoreOp {
                     <div class=validusage>
                         - |pipeline| is [=valid=].
                         - |pipeline|.{{GPUObjectBase/[[device]]}} is |this|.
+
+                        Issue: Validate that |pipeline| is compatible with the render pass descriptor.
                     </div>
                 1. Set |this|.{{GPURenderEncoderBase/[[pipeline]]}} to be |pipeline|.
             </div>
@@ -5234,11 +5240,10 @@ enum GPUStoreOp {
                     <div class=validusage>
                         - |buffer| is [=valid=].
                         - |buffer|.{{GPUObjectBase/[[device]]}} is |this|.
-                        - |offset| &le; |buffer|.{{GPUBuffer/[[size]]}}.
+                        - |buffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDEX}}.
                         - |offset| + |size| &le; |buffer|.{{GPUBuffer/[[size]]}}.
                     </div>
-                1. Add |buffer| to the [=usage scope=] as
-                    {{GPUBufferUsage/INDEX|GPUBufferUsage.INDEX}}).
+                1. Add |buffer| to the [=usage scope=] as {{GPUBufferUsage/INDEX}}.
                 1. Set |this|.{{GPURenderEncoderBase/[[index_buffer]]}} to be |buffer|.
                 1. Set |this|.{{GPURenderEncoderBase/[[index_format]]}} to be |indexFormat|.
             </div>
@@ -5268,14 +5273,13 @@ enum GPUStoreOp {
                     <div class=validusage>
                         - |buffer| is [=valid=].
                         - |buffer|.{{GPUObjectBase/[[device]]}} is |this|.
+                        - |buffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/VERTEX}}.
                         - |slot| &lt; [=maximum number of vertex buffers=].
-                        - |offset| &le; |buffer|.{{GPUBuffer/[[size]]}}.
                         - |offset| + |size| &le; |buffer|.{{GPUBuffer/[[size]]}}.
 
                         Issue: Define the <dfn dfn>maximum number of vertex buffers</dfn>.
                     </div>
-                1. Add |buffer| to the [=usage scope=] as
-                    {{GPUBufferUsage/VERTEX|GPUBufferUsage.VERTEX}}).
+                1. Add |buffer| to the [=usage scope=] as {{GPUBufferUsage/VERTEX}}.
                 1. Set |this|.{{GPURenderEncoderBase/[[vertex_buffers]]}}[|slot|] to be |buffer|.
             </div>
         </div>
@@ -5354,12 +5358,12 @@ enum GPUStoreOp {
                     <div class=validusage>
                         - |indirectBuffer| is [=valid=].
                         - |indirectBuffer|.{{GPUObjectBase/[[device]]}} is |this|.
+                        - |indirectBuffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDIRECT}}.
                         - |indirectOffset| + sizeof([=indirect draw parameters=]) &le;
                             |indirectBuffer|.{{GPUBuffer/[[size]]}}.
                         - |indirectOffset| is a multiple of 4.
                     </div>
-                1. Add |indirectBuffer| to the [=usage scope=] as
-                    {{GPUBufferUsage/INDIRECT|GPUBufferUsage.INDIRECT}}).
+                1. Add |indirectBuffer| to the [=usage scope=] as {{GPUBufferUsage/INDIRECT}}.
             </div>
         </div>
 
@@ -5397,12 +5401,12 @@ enum GPUStoreOp {
                     <div class=validusage>
                         - |indirectBuffer| is [=valid=].
                         - |indirectBuffer|.{{GPUObjectBase/[[device]]}} is |this|.
+                        - |indirectBuffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDIRECT}}.
                         - |indirectOffset| + sizeof([=indirect drawIndexed parameters=]) &le;
                             |indirectBuffer|.{{GPUBuffer/[[size]]}}.
                         - |indirectOffset| is a multiple of 4.
                     </div>
-                1. Add |indirectBuffer| to the [=usage scope=] as
-                    {{GPUBufferUsage/INDIRECT|GPUBufferUsage.INDIRECT}}).
+                1. Add |indirectBuffer| to the [=usage scope=] as {{GPUBufferUsage/INDIRECT}}.
             </div>
         </div>
 </dl>


### PR DESCRIPTION
Draft for the moment because I'm not done yet, but wanted to ask some questions while I finished up:

 - My intuition is that these steps should take place on the queue timeline, but I'm still kind of fuzzy on which things execute where so I could be wrong.
 - I'm leaning heavily on the Dawn source to determine what validation is needed, but there's odd omissions. For example, `draw()` and `drawIndexed()` have no validation that I can see, and `indexFormat` for `setIndexBuffer()` isn't actually being passed in to the dawn version of the command encoder? I'm assuming I'm just missing something?
 - Very much not sure about the "add |buffer| to [=usage scope=] as..." bits, would appreciate feedback on if that's formulated correctly.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/toji/gpuweb/pull/980.html" title="Last updated on Aug 11, 2020, 3:50 PM UTC (e61225f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/980/4d0f488...toji:e61225f.html" title="Last updated on Aug 11, 2020, 3:50 PM UTC (e61225f)">Diff</a>