### PR TITLE
Added validation for both setBindGroup() variants

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2418,10 +2418,14 @@ enum GPUBindingType {
 A {{GPUBindGroupLayout}} object has the following methods:
 
 <dl dfn-type=attribute dfn-for="GPUBindGroupLayout">
-    : <dfn>\[[entryMap]]</dfn> of type `map<u32, {{GPUBindGroupLayoutEntry}}>`.
+    : <dfn>\[[entryMap]]</dfn> of type map&lt;{{GPUSize32}}, {{GPUBindGroupLayoutEntry}}&gt.
     ::
         The map of binding indices pointing to the {{GPUBindGroupLayoutEntry}}s,
         which this {{GPUBindGroupLayout}} describes.
+
+    : <dfn>\[[dynamicOffsetCount]]</dfn> of type {{GPUSize32}}.
+    ::
+        The number of buffer bindings with dynamic offsets in this {{GPUBindGroupLayout}}.
 </dl>
 
 <dl dfn-type=method dfn-for=GPUDevice>
@@ -2516,6 +2520,8 @@ A {{GPUBindGroupLayout}} object has the following methods:
                                 error message.
                             1. Make |layout| [=invalid=] and return |layout|.
 
+                    1. Set |layout|.{{GPUBindGroupLayout/[[dynamicOffsetCount]]}} to the number of
+                        entries in |descriptor| where {{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `true`.
                     1. For each {{GPUBindGroupLayoutEntry}} |bindingDescriptor| in
                         |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
                         1. Insert |bindingDescriptor| into |layout|.{{GPUBindGroupLayout/[[entryMap]]}}
@@ -4588,6 +4594,10 @@ interface mixin GPUProgrammablePassEncoder {
     : <dfn>\[[debug_group_stack]]</dfn> of type `sequence<USVString>`.
     ::
         A stack of active debug group labels.
+
+    : <dfn>\[[bind_groups]]</dfn>, of type map&lt;index, {{GPUBindGroup}}&gt;
+    ::
+        The current {{GPUBindGroup}} for each index, initially empty.
 </dl>
 
 ## Bind Groups ## {#programmable-passes-bind-groups}
@@ -4600,21 +4610,34 @@ interface mixin GPUProgrammablePassEncoder {
             **Called on:** {{GPUProgrammablePassEncoder}} this.
 
             **Arguments:**
-            <!--The overload appears to be confusing bikeshed, and it ends up expecting this to
+            <pre class=argumentdef for="GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)">
+                |index|: The index to set the bind group at.
+                |bindGroup|: Bind group to use for subsequent render or compute commands.
+
+                <!--The overload appears to be confusing bikeshed, and it ends up expecting this to
                 define the arguments for the 5-arg variant of the method, despite the "for"
                 explicitly pointing at the 3-arg variant.-->
-            <!--pre class=argumentdef for="GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)">
-                index:
-                bindGroup:
-                dynamicOffsets:
-            </pre-->
+                <!--|dynamicOffsets|: Array containing buffer offsets in bytes for each entry in
+                    |bindGroup| with marked as {{GPUBindGroupLayoutEntry/hasDynamicOffset}}.-->
+            </pre>
 
             Issue: Resolve bikeshed conflict when using `argumentdef` with
                 {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)}}.
 
             **Returns:** void
 
-            Issue: Describe {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)}} algorithm steps.
+            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+            <div class=device-timeline>
+                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+                    <div class=validusage>
+                        - |bindGroup| is [=valid=].
+                        - |bindGroup|.{{GPUObjectBase/[[device]]}} is |this|.{{GPUObjectBase/[[device]]}}.
+                        - |index| &lt; {{GPULimits/maxBindGroups|GPULimits.maxBindGroups}}.
+                        - dynamicOffsets.length is
+                            |bindGroup|.{{GPUBindGroup/[[layout]]}}.{{GPUBindGroupLayout/[[dynamicOffsetCount]]}}.
+                    </div>
+                1. Set |this|.{{GPUProgrammablePassEncoder/[[bind_groups]]}}[|index|] to be |bindGroup|.
+            </div>
         </div>
 
     : <dfn>setBindGroup(index, bindGroup, dynamicOffsetsData, dynamicOffsetsDataStart, dynamicOffsetsDataLength)</dfn>
@@ -4625,16 +4648,30 @@ interface mixin GPUProgrammablePassEncoder {
 
             **Arguments:**
             <pre class=argumentdef for="GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsetsData, dynamicOffsetsDataStart, dynamicOffsetsDataLength)">
-                index:
-                bindGroup:
-                dynamicOffsetsData:
-                dynamicOffsetsDataStart:
-                dynamicOffsetsDataLength:
+                |index|: The index to set the bind group at.
+                |bindGroup|: Bind group to use for subsequent render or compute commands.
+                |dynamicOffsetsData|: Array containing buffer offsets in bytes for each entry in
+                    |bindGroup| with marked as {{GPUBindGroupLayoutEntry/hasDynamicOffset}}.
+                |dynamicOffsetsDataStart|: Offset in elements into |dynamicOffsetsData| where the
+                    buffer offset data begins.
+                |dynamicOffsetsDataLength|: Number of buffer offsets to read from |dynamicOffsetsData|.
             </pre>
 
             **Returns:** void
 
-            Issue: Describe {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsetsData, dynamicOffsetsDataStart, dynamicOffsetsDataLength)}} algorithm steps.
+            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+            <div class=device-timeline>
+                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+                    <div class=validusage>
+                        - |bindGroup| is [=valid=].
+                        - |bindGroup|.{{GPUObjectBase/[[device]]}} is |this|.{{GPUObjectBase/[[device]]}}.
+                        - |index| &lt; {{GPULimits/maxBindGroups|GPULimits.maxBindGroups}}.
+                        - |dynamicOffsetsDataLength| is
+                            |bindGroup|.{{GPUBindGroup/[[layout]]}}.{{GPUBindGroupLayout/[[dynamicOffsetCount]]}}.
+                        - |dynamicOffsetsDataStart| + |dynamicOffsetsDataLength| &le; |dynamicOffsetsData|.length.
+                    </div>
+                1. Set |this|.{{GPUProgrammablePassEncoder/[[bind_groups]]}}[|index|] to be |bindGroup|.
+            </div>
         </div>
 </dl>
 
@@ -4938,10 +4975,6 @@ GPURenderPassEncoder includes GPURenderEncoderBase;
     : <dfn>\[[vertex_buffers]]</dfn>, of type map&lt;slot, {{GPUBuffer}}&gt;
     ::
         The current {{GPUBuffer}}s to read vertex data from for each slot, initially empty.
-
-    : <dfn>\[[bind_groups]]</dfn>, of type map&lt;index, {{GPUBindGroup}}&gt;
-    ::
-        The current {{GPUBindGroup}}s to to render with for each index, initially empty.
 </dl>
 
 {{GPURenderPassEncoder}} has the following internal slots:
@@ -5203,12 +5236,12 @@ enum GPUStoreOp {
 
             **Returns:** void
 
-            Issue the following steps on the [=Device timeline=] of |this|:
+            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |pipeline| is [=valid=].
-                        - |pipeline|.{{GPUObjectBase/[[device]]}} is |this|.
+                        - |pipeline|.{{GPUObjectBase/[[device]]}} is |this|.{{GPUObjectBase/[[device]]}}.
 
                         Issue: Validate that |pipeline| is compatible with the render pass descriptor.
                     </div>
@@ -5234,12 +5267,12 @@ enum GPUStoreOp {
 
             **Returns:** void
 
-            Issue the following steps on the [=Device timeline=] of |this|:
+            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |buffer| is [=valid=].
-                        - |buffer|.{{GPUObjectBase/[[device]]}} is |this|.
+                        - |buffer|.{{GPUObjectBase/[[device]]}} is |this|.{{GPUObjectBase/[[device]]}}.
                         - |buffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDEX}}.
                         - |offset| + |size| &le; |buffer|.{{GPUBuffer/[[size]]}}.
                     </div>
@@ -5267,12 +5300,12 @@ enum GPUStoreOp {
 
             **Returns:** void
 
-            Issue the following steps on the [=Device timeline=] of |this|:
+            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |buffer| is [=valid=].
-                        - |buffer|.{{GPUObjectBase/[[device]]}} is |this|.
+                        - |buffer|.{{GPUObjectBase/[[device]]}} is |this|.{{GPUObjectBase/[[device]]}}.
                         - |buffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/VERTEX}}.
                         - |slot| &lt; [=maximum number of vertex buffers=].
                         - |offset| + |size| &le; |buffer|.{{GPUBuffer/[[size]]}}.
@@ -5352,12 +5385,12 @@ enum GPUStoreOp {
 
             **Returns:** void
 
-            Issue the following steps on the [=Device timeline=] of |this|:
+            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |indirectBuffer| is [=valid=].
-                        - |indirectBuffer|.{{GPUObjectBase/[[device]]}} is |this|.
+                        - |indirectBuffer|.{{GPUObjectBase/[[device]]}} is |this|.{{GPUObjectBase/[[device]]}}.
                         - |indirectBuffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDIRECT}}.
                         - |indirectOffset| + sizeof([=indirect draw parameters=]) &le;
                             |indirectBuffer|.{{GPUBuffer/[[size]]}}.
@@ -5395,12 +5428,12 @@ enum GPUStoreOp {
 
             **Returns:** void
 
-            Issue the following steps on the [=Device timeline=] of |this|:
+            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |indirectBuffer| is [=valid=].
-                        - |indirectBuffer|.{{GPUObjectBase/[[device]]}} is |this|.
+                        - |indirectBuffer|.{{GPUObjectBase/[[device]]}} is |this|.{{GPUObjectBase/[[device]]}}.
                         - |indirectBuffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDIRECT}}.
                         - |indirectOffset| + sizeof([=indirect drawIndexed parameters=]) &le;
                             |indirectBuffer|.{{GPUBuffer/[[size]]}}.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -459,6 +459,19 @@ It may become [=invalid=] during its lifetime, but it will never become valid ag
       - If the [=device=] that owns an object is lost, the object becomes invalid.
 </div>
 
+<div algorithm>
+    To determine if a given {{GPUObjectBase}} |object| is <dfn abstract-op>valid to use with</dfn>
+    a |targetObject|, run the following steps:
+
+        1. If any of the following conditions are unsatisfied return `false`:
+            <div class=validusage>
+                - |object| is [=valid=]
+                - If |targetObject| is a {{GPUDevice}} |object|.{{GPUObjectBase/[[device]]}} is |targetObject|.
+                - Otherwise |object|.{{GPUObjectBase/[[device]]}} is |targetObject|.{{GPUObjectBase/[[device]]}}.
+            </div>
+        1. Return `true`.
+</div>
+
 ## Coordinate Systems ## {#coordinate-systems}
 
 WebGPU's coordinate systems match DirectX and Metal's coordinate systems in a graphics pipeline.
@@ -2633,7 +2646,7 @@ A {{GPUBindGroup}} object has the following internal slots:
                     1. If any of the following conditions are unsatisfied:
                         <div class=validusage>
                             - |this| is a [=valid=] {{GPUDevice}}.
-                            - |descriptor|.{{GPUBindGroupDescriptor/layout}} is a [=valid=] {{GPUBindGroupLayout}}.
+                            - |descriptor|.{{GPUBindGroupDescriptor/layout}} is [$valid to use with$] |this|.
                             - The number of {{GPUBindGroupLayoutDescriptor/entries}} of
                                 |descriptor|.{{GPUBindGroupDescriptor/layout}} is exactly equal to
                                 the number of |descriptor|.{{GPUBindGroupDescriptor/entries}}.
@@ -2647,18 +2660,18 @@ A {{GPUBindGroup}} object has the following internal slots:
                                     |bindingDescriptor|.{{GPUBindGroupEntry/binding}}.
 
                                 - If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampler"}}:
-                                    - |resource| is a [=valid=] {{GPUSampler}} object.
+                                    - |resource| is [$valid to use with$] |this|.
                                     - |resource|.{{GPUSampler/[[compareEnable]]}} is `false`.
 
                                 - If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"comparison-sampler"}}:
-                                    - |resource| is a [=valid=] {{GPUSampler}} object.
+                                    - |resource| is [$valid to use with$] |this|.
                                     - |resource|.{{GPUSampler/[[compareEnable]]}} is `true`.
 
                                 -  If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
                                     {{GPUBindingType/"sampled-texture"}} or
                                     {{GPUBindingType/"readonly-storage-texture"}} or
                                     {{GPUBindingType/"writeonly-storage-texture"}}:
-                                    - |resource| is a [=valid=] {{GPUTextureView}} object.
+                                    - |resource| is [$valid to use with$] |this|.
                                     - |layoutBinding|.{{GPUBindGroupLayoutEntry/viewDimension}} is
                                         equal to |resource|'s {{GPUTextureViewDescriptor/dimension}}.
                                     - |layoutBinding|.{{GPUBindGroupLayoutEntry/textureComponentType}}
@@ -2686,7 +2699,7 @@ A {{GPUBindGroup}} object has the following internal slots:
                                     {{GPUBindingType/"storage-buffer"}} or
                                     {{GPUBindingType/"readonly-storage-buffer"}}:
                                     - |resource| is a {{GPUBufferBinding}}.
-                                    - |resource|.{{GPUBufferBinding/buffer}} is [=valid=].
+                                    - |resource|.{{GPUBufferBinding/buffer}} is [$valid to use with$] |this|.
                                     - Let |bufferBinding| be |bindingDescriptor|.{{GPUBindGroupEntry/resource}},
                                         a {{GPUBufferBinding}}.
 
@@ -2840,7 +2853,7 @@ dictionary GPUPipelineLayoutDescriptor : GPUObjectDescriptorBase {
                     - There is {{GPULimits/maxBindGroups|GPULimits.maxBindGroups}} or fewer
                         elements in |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}.
                     - Every {{GPUBindGroupLayout}} in |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
-                        is [=valid=].
+                        is [$valid to use with$] |this|.
                 </div>
 
                 Then:
@@ -3242,7 +3255,7 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
             If any of the following conditions are unsatisfied:
                 <div class=validusage>
                     - |this| is a [=valid=] {{GPUDevice}}.
-                    - |descriptor|.{{GPUPipelineDescriptorBase/layout}} is a [=valid=] {{GPUPipelineLayout}}.
+                    - |descriptor|.{{GPUPipelineDescriptorBase/layout}} is [$valid to use with$] |this|.
                     - [$validating GPUProgrammableStageDescriptor$]({{GPUShaderStage/COMPUTE}},
                         |descriptor|.{{GPUComputePipelineDescriptor/computeStage}},
                         |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
@@ -3418,7 +3431,7 @@ Issue: link to the semantics of SV_SampleIndex and SV_Coverage in WGSL spec.
             If any of the following conditions are unsatisfied:
                 <div class=validusage>
                     - |this| is a [=valid=] {{GPUDevice}}.
-                    - |descriptor|.{{GPUPipelineDescriptorBase/layout}} is a [=valid=] {{GPUPipelineLayout}}.
+                    - |descriptor|.{{GPUPipelineDescriptorBase/layout}} is [$valid to use with$] |this|.
                     - [$validating GPUProgrammableStageDescriptor$]({{GPUShaderStage/VERTEX}},
                         |descriptor|.{{GPURenderPipelineDescriptor/vertexStage}},
                         |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
@@ -4134,8 +4147,8 @@ dictionary GPUImageBitmapCopyView {
             If any of the following conditions are unsatisfied, generate a validation error and stop.
             <div class=validusage>
                 - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
-                - |source| is a [=valid=] {{GPUBuffer}}.
-                - |destination| is a [=valid=] {{GPUBuffer}}.
+                - |source| is [$valid to use with$] |this|.
+                - |destination| is [$valid to use with$] |this|.
                 - |source|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/COPY_SRC}}.
                 - |destination|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/COPY_DST}}.
                 - |size| is a multiple of 4.
@@ -4630,8 +4643,7 @@ interface mixin GPUProgrammablePassEncoder {
             <div class=device-timeline>
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
-                        - |bindGroup| is [=valid=].
-                        - |bindGroup|.{{GPUObjectBase/[[device]]}} is |this|.{{GPUObjectBase/[[device]]}}.
+                        - |bindGroup| is [$valid to use with$] |this|.
                         - |index| &lt; {{GPULimits/maxBindGroups|GPULimits.maxBindGroups}}.
                         - |dynamicOffsets|.length is
                             |bindGroup|.{{GPUBindGroup/[[layout]]}}.{{GPUBindGroupLayout/[[dynamicOffsetCount]]}}.
@@ -4672,8 +4684,7 @@ interface mixin GPUProgrammablePassEncoder {
             <div class=device-timeline>
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
-                        - |bindGroup| is [=valid=].
-                        - |bindGroup|.{{GPUObjectBase/[[device]]}} is |this|.{{GPUObjectBase/[[device]]}}.
+                        - |bindGroup| is [$valid to use with$] |this|.
                         - |index| &lt; {{GPULimits/maxBindGroups|GPULimits.maxBindGroups}}.
                         - |dynamicOffsetsDataLength| is
                             |bindGroup|.{{GPUBindGroup/[[layout]]}}.{{GPUBindGroupLayout/[[dynamicOffsetCount]]}}.
@@ -4702,7 +4713,7 @@ interface mixin GPUProgrammablePassEncoder {
     1. Let |layout| be |bindGroup|.{{GPUBindGroup/[[layout]]}}.
     1. For each {{GPUBindGroupEntry}} |entry| in |bindGroup|.{{GPUBindGroup/[[entries]]}}:
         1. Let |bindingDescriptor| be the {{GPUBindGroupLayoutEntry}} at
-            |layout|.{{[[entryMap]]}}[|entry|.{{GPUBindGroupEntry/binding}}]:
+            |layout|.{{GPUBindGroupLayout/[[entryMap]]}}[|entry|.{{GPUBindGroupEntry/binding}}]:
         1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `true`:
             1. Let |bufferBinding| be |entry|.{{GPUBindGroupEntry/resource}}.
             1. Let |minBufferBindingSize| be |bindingDescriptor|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}}.
@@ -5275,8 +5286,7 @@ enum GPUStoreOp {
             <div class=device-timeline>
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
-                        - |pipeline| is [=valid=].
-                        - |pipeline|.{{GPUObjectBase/[[device]]}} is |this|.{{GPUObjectBase/[[device]]}}.
+                        - |pipeline| is [$valid to use with$] |this|.
 
                         Issue: Validate that |pipeline| is compatible with the render pass descriptor.
                     </div>
@@ -5306,8 +5316,7 @@ enum GPUStoreOp {
             <div class=device-timeline>
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
-                        - |buffer| is [=valid=].
-                        - |buffer|.{{GPUObjectBase/[[device]]}} is |this|.{{GPUObjectBase/[[device]]}}.
+                        - |buffer| is [$valid to use with$] |this|.
                         - |buffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDEX}}.
                         - |offset| + |size| &le; |buffer|.{{GPUBuffer/[[size]]}}.
                     </div>
@@ -5339,8 +5348,7 @@ enum GPUStoreOp {
             <div class=device-timeline>
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
-                        - |buffer| is [=valid=].
-                        - |buffer|.{{GPUObjectBase/[[device]]}} is |this|.{{GPUObjectBase/[[device]]}}.
+                        - |buffer| is [$valid to use with$] |this|.
                         - |buffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/VERTEX}}.
                         - |slot| &lt; [=maximum number of vertex buffers=].
                         - |offset| + |size| &le; |buffer|.{{GPUBuffer/[[size]]}}.
@@ -5424,8 +5432,7 @@ enum GPUStoreOp {
             <div class=device-timeline>
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
-                        - |indirectBuffer| is [=valid=].
-                        - |indirectBuffer|.{{GPUObjectBase/[[device]]}} is |this|.{{GPUObjectBase/[[device]]}}.
+                        - |indirectBuffer| is [$valid to use with$] |this|.
                         - |indirectBuffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDIRECT}}.
                         - |indirectOffset| + sizeof([=indirect draw parameters=]) &le;
                             |indirectBuffer|.{{GPUBuffer/[[size]]}}.
@@ -5467,8 +5474,7 @@ enum GPUStoreOp {
             <div class=device-timeline>
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
-                        - |indirectBuffer| is [=valid=].
-                        - |indirectBuffer|.{{GPUObjectBase/[[device]]}} is |this|.{{GPUObjectBase/[[device]]}}.
+                        - |indirectBuffer| is [$valid to use with$] |this|.
                         - |indirectBuffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDIRECT}}.
                         - |indirectOffset| + sizeof([=indirect drawIndexed parameters=]) &le;
                             |indirectBuffer|.{{GPUBuffer/[[size]]}}.
@@ -5866,7 +5872,7 @@ GPUQueue includes GPUObjectBase;
                     1. If any of the following conditions are unsatisfied,
                         generate a validation error and stop.
                         <div class=validusage>
-                            - |buffer| is [=valid=].
+                            - |buffer| is [$valid to use with$] |this|.
                             - |buffer|.{{GPUBuffer/[[state]]}} is [=buffer state/unmapped=].
                             - |buffer|.{{GPUBuffer/[[usage]]}} includes {{GPUBufferUsage/COPY_DST}}.
                             - |bufferOffset|, converted to bytes, is a multiple of 4 bytes.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4636,21 +4636,14 @@ interface mixin GPUProgrammablePassEncoder {
                         - |dynamicOffsets|.length is
                             |bindGroup|.{{GPUBindGroup/[[layout]]}}.{{GPUBindGroupLayout/[[dynamicOffsetCount]]}}.
 
-                        - Let |dynamicOffsetIndex| be `0`.
-                        - For each {{GPUBindGroupLayoutEntry}} |bindingDescriptor| in
-                            |bindGroup|.{{GPUBindGroup/[[layout]]}}.{{[[entryMap]]}}:
+                        - [$Iterate over each dynamic binding offset$] in |bindGroup| and
+                            run the following steps for each |bufferBinding|, |minBufferBindingSize|,
+                            and |dynamicOffsetIndex|:
 
-                            - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `true`:
-
-                                - Let |bufferBinding| be the {{GPUBindGroupEntry/resource}} of the
-                                    {{GPUBindGroupEntry}} in |bindGroup|.{{GPUBindGroup/[[entries]]}}
-                                    that corresponds with |bindingDescriptor|.
-                                - Let |bufferDynamicOffset| be |dynamicOffsets|[|dynamicOffsetIndex|].
-                                - Set |dynamicOffsetIndex| to be |dynamicOffsetIndex| + `1`
-                                - |bufferBinding|.{{GPUBufferBinding/offset}} + |bufferDynamicOffset| +
-                                    |bindingDescriptor|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}}
-                                    &le; |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBuffer/[[size]]}}.
-                                - Let |dynamicOffsetIndex| be |dynamicOffsetIndex| + `1`
+                            - Let |bufferDynamicOffset| be |dynamicOffsets|[|dynamicOffsetIndex|].
+                            - |bufferBinding|.{{GPUBufferBinding/offset}} + |bufferDynamicOffset| +
+                                |minBufferBindingSize| &le;
+                                |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBuffer/[[size]]}}.
                     </div>
                 1. Set |this|.{{GPUProgrammablePassEncoder/[[bind_groups]]}}[|index|] to be |bindGroup|.
             </div>
@@ -4686,26 +4679,36 @@ interface mixin GPUProgrammablePassEncoder {
                             |bindGroup|.{{GPUBindGroup/[[layout]]}}.{{GPUBindGroupLayout/[[dynamicOffsetCount]]}}.
                         - |dynamicOffsetsDataStart| + |dynamicOffsetsDataLength| &le; |dynamicOffsetsData|.length.
 
-                        - Let |dynamicOffsetIndex| be |dynamicOffsetsDataStart|.
-                        - For each {{GPUBindGroupLayoutEntry}} |bindingDescriptor| in
-                            |bindGroup|.{{GPUBindGroup/[[layout]]}}.{{[[entryMap]]}}:
+                        - [$Iterate over each dynamic binding offset$] in |bindGroup| and
+                            run the following steps for each |bufferBinding|, |minBufferBindingSize|,
+                            and |dynamicOffsetIndex|:
 
-                            - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `true`:
-
-                                - Let |bufferBinding| be the {{GPUBindGroupEntry/resource}} of the
-                                    {{GPUBindGroupEntry}} in |bindGroup|.{{GPUBindGroup/[[entries]]}}
-                                    that corresponds with |bindingDescriptor|.
-                                - Let |bufferDynamicOffset| be |dynamicOffsetsData|[|dynamicOffsetIndex|].
-                                - Set |dynamicOffsetIndex| to be |dynamicOffsetIndex| + `1`
-                                - |bufferBinding|.{{GPUBufferBinding/offset}} + |bufferDynamicOffset| +
-                                    |bindingDescriptor|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}}
-                                    &le; |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBuffer/[[size]]}}.
-                                - Let |dynamicOffsetIndex| be |dynamicOffsetIndex| + `1`
+                            - Let |bufferDynamicOffset| be
+                                |dynamicOffsetsData|[|dynamicOffsetIndex| + |dynamicOffsetsDataStart|].
+                            - |bufferBinding|.{{GPUBufferBinding/offset}} + |bufferDynamicOffset| +
+                                |minBufferBindingSize| &le;
+                                |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBuffer/[[size]]}}.
                     </div>
                 1. Set |this|.{{GPUProgrammablePassEncoder/[[bind_groups]]}}[|index|] to be |bindGroup|.
             </div>
         </div>
 </dl>
+
+<div algorithm>
+    To <dfn abstract-op>Iterate over each dynamic binding offset</dfn> in a given {{GPUBindGroup}} |bindGroup|
+    with a given list of |steps| to be executed for each dynamic offset:
+
+    1. Let |dynamicOffsetIndex| be `0`.
+    1. Let |layout| be |bindGroup|.{{GPUBindGroup/[[layout]]}}.
+    1. For each {{GPUBindGroupEntry}} |entry| in |bindGroup|.{{GPUBindGroup/[[entries]]}}:
+        1. Let |bindingDescriptor| be the {{GPUBindGroupLayoutEntry}} at
+            |layout|.{{[[entryMap]]}}[|entry|.{{GPUBindGroupEntry/binding}}]:
+        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `true`:
+            1. Let |bufferBinding| be |entry|.{{GPUBindGroupEntry/resource}}.
+            1. Let |minBufferBindingSize| be |bindingDescriptor|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}}.
+            1. Call |steps| with |bufferBinding|, |minBufferBindingSize|, and |dynamicOffsetIndex|.
+            1. Let |dynamicOffsetIndex| be |dynamicOffsetIndex| + `1`
+</div>
 
 ## Debug Markers ## {#programmable-passes-debug-markers}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4621,8 +4621,8 @@ interface mixin GPUProgrammablePassEncoder {
                     |bindGroup| with marked as {{GPUBindGroupLayoutEntry/hasDynamicOffset}}.-->
             </pre>
 
-            Issue: Resolve bikeshed conflict when using `argumentdef` with
-                {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)}}.
+            Issue: Resolve bikeshed conflict when using `argumentdef` with overloaded functions that prevents us from
+                defining |dynamicOffsets|.
 
             **Returns:** void
 
@@ -4633,8 +4633,24 @@ interface mixin GPUProgrammablePassEncoder {
                         - |bindGroup| is [=valid=].
                         - |bindGroup|.{{GPUObjectBase/[[device]]}} is |this|.{{GPUObjectBase/[[device]]}}.
                         - |index| &lt; {{GPULimits/maxBindGroups|GPULimits.maxBindGroups}}.
-                        - dynamicOffsets.length is
+                        - |dynamicOffsets|.length is
                             |bindGroup|.{{GPUBindGroup/[[layout]]}}.{{GPUBindGroupLayout/[[dynamicOffsetCount]]}}.
+
+                        - Let |dynamicOffsetIndex| be `0`.
+                        - For each {{GPUBindGroupLayoutEntry}} |bindingDescriptor| in
+                            |bindGroup|.{{GPUBindGroup/[[layout]]}}.{{[[entryMap]]}}:
+
+                            - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `true`:
+
+                                - Let |bufferBinding| be the {{GPUBindGroupEntry/resource}} of the
+                                    {{GPUBindGroupEntry}} in |bindGroup|.{{GPUBindGroup/[[entries]]}}
+                                    that corresponds with |bindingDescriptor|.
+                                - Let |bufferDynamicOffset| be |dynamicOffsets|[|dynamicOffsetIndex|].
+                                - Set |dynamicOffsetIndex| to be |dynamicOffsetIndex| + `1`
+                                - |bufferBinding|.{{GPUBufferBinding/offset}} + |bufferDynamicOffset| +
+                                    |bindingDescriptor|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}}
+                                    &le; |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBuffer/[[size]]}}.
+                                - Let |dynamicOffsetIndex| be |dynamicOffsetIndex| + `1`
                     </div>
                 1. Set |this|.{{GPUProgrammablePassEncoder/[[bind_groups]]}}[|index|] to be |bindGroup|.
             </div>
@@ -4669,6 +4685,22 @@ interface mixin GPUProgrammablePassEncoder {
                         - |dynamicOffsetsDataLength| is
                             |bindGroup|.{{GPUBindGroup/[[layout]]}}.{{GPUBindGroupLayout/[[dynamicOffsetCount]]}}.
                         - |dynamicOffsetsDataStart| + |dynamicOffsetsDataLength| &le; |dynamicOffsetsData|.length.
+
+                        - Let |dynamicOffsetIndex| be |dynamicOffsetsDataStart|.
+                        - For each {{GPUBindGroupLayoutEntry}} |bindingDescriptor| in
+                            |bindGroup|.{{GPUBindGroup/[[layout]]}}.{{[[entryMap]]}}:
+
+                            - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `true`:
+
+                                - Let |bufferBinding| be the {{GPUBindGroupEntry/resource}} of the
+                                    {{GPUBindGroupEntry}} in |bindGroup|.{{GPUBindGroup/[[entries]]}}
+                                    that corresponds with |bindingDescriptor|.
+                                - Let |bufferDynamicOffset| be |dynamicOffsetsData|[|dynamicOffsetIndex|].
+                                - Set |dynamicOffsetIndex| to be |dynamicOffsetIndex| + `1`
+                                - |bufferBinding|.{{GPUBufferBinding/offset}} + |bufferDynamicOffset| +
+                                    |bindingDescriptor|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}}
+                                    &le; |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBuffer/[[size]]}}.
+                                - Let |dynamicOffsetIndex| be |dynamicOffsetIndex| + `1`
                     </div>
                 1. Set |this|.{{GPUProgrammablePassEncoder/[[bind_groups]]}}[|index|] to be |bindGroup|.
             </div>


### PR DESCRIPTION
Also fixes an error I made with a previous PR where I mistakenly compared GPUDevices against GPURenderPassEncoders instead of the GPUDevice the render pass encoder was created with.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/toji/gpuweb/pull/998.html" title="Last updated on Aug 13, 2020, 8:01 PM UTC (aeaf777)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/998/16aeeef...toji:aeaf777.html" title="Last updated on Aug 13, 2020, 8:01 PM UTC (aeaf777)">Diff</a>