### PR TITLE
Enable Bikeshed's "Assume Explicit For" option

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -16,6 +16,7 @@ Markup Shorthands: markdown yes
 Markup Shorthands: dfn yes
 Markup Shorthands: idl yes
 Markup Shorthands: css no
+Assume Explicit For: yes
 </pre>
 
 <pre class='anchors'>
@@ -453,7 +454,7 @@ It may become [=invalid=] during its lifetime, but it will never become valid ag
 
       - If there is an error in the creation of an object, it is immediately invalid.
         This can happen, for example, if the [=object descriptor=] doesn't describe a valid
-        object, or if there is not enough memory to allocate a [=resource=].
+        object, or if there is not enough memory to allocate a resource.
       - If an object is explicitly destroyed (e.g. {{GPUBuffer/destroy()|GPUBuffer.destroy()}}),
         it becomes invalid.
       - If the [=device=] that owns an object is lost, the object becomes invalid.
@@ -1328,9 +1329,9 @@ GPUBuffer includes GPUObjectBase;
     ::
         The mapping for this {{GPUBuffer}}. The {{ArrayBuffer}} isn't directly accessible
         and is instead accessed through views into it, called the mapped ranges, that are
-        stored in {{[[mapped_ranges]]}}
+        stored in {{GPUBuffer/[[mapped_ranges]]}}
 
-        Issue(gpuweb/gpuweb#605): Specify {{[[mapping]]}} in term of `DataBlock` similarly
+        Issue(gpuweb/gpuweb#605): Specify {{GPUBuffer/[[mapping]]}} in term of `DataBlock` similarly
         to `AllocateArrayBuffer`?
 
     : <dfn>\[[mapping_range]]</dfn> of type `sequence<Number>` or `null`.
@@ -1339,8 +1340,8 @@ GPUBuffer includes GPUObjectBase;
 
     : <dfn>\[[mapped_ranges]]</dfn> of type `sequence<ArrayBuffer>` or `null`.
     ::
-        The {{ArrayBuffer}}s returned via {{getMappedRange}} to the application. They are tracked
-        so they can be detached when {{unmap}} is called.
+        The {{ArrayBuffer}}s returned via {{GPUBuffer/getMappedRange}} to the application. They are tracked
+        so they can be detached when {{GPUBuffer/unmap}} is called.
 
     : <dfn>\[[map_mode]]</dfn> of type {{GPUMapModeFlags}}.
     ::
@@ -1376,9 +1377,9 @@ Note:
      - [=buffer state/unmapped=] and [=buffer state/destroyed=].
      - [=buffer state/mapped=] or [=buffer state/mapped at creation=] with an
         {{ArrayBuffer}} typed {{GPUBuffer/[[mapping]]}}, a sequence of two
-        numbers in {{[[mapping_range]]}} and a sequence of {{ArrayBuffer}}
-        in {{[[mapped_ranges]]}}
-     - [=buffer state/mapping pending=] with a {{Promise}} typed {{[[mapping]]}}.
+        numbers in {{GPUBuffer/[[mapping_range]]}} and a sequence of {{ArrayBuffer}}
+        in {{GPUBuffer/[[mapped_ranges]]}}
+     - [=buffer state/mapping pending=] with a {{Promise}} typed {{GPUBuffer/[[mapping]]}}.
 </div>
 
 {{GPUBuffer}} is {{Serializable}}. It is a reference to an internal buffer
@@ -1566,11 +1567,11 @@ interface GPUMapMode {
                     - |this| is a [=valid=] {{GPUBuffer}}.
                     - |offset| is a multiple of 4.
                     - |rangeSize| is a multiple of 4.
-                    - |offset| + |rangeSize| is less or equal to |this|.{{[[size]]}}
+                    - |offset| + |rangeSize| is less or equal to |this|.{{GPUBuffer/[[size]]}}
                     - |this|.{{GPUBuffer/[[state]]}} is [=buffer state/unmapped=]
                     - |mode| contains exactly one of {{GPUMapMode/READ}} or {{GPUMapMode/WRITE}}.
-                    - If |mode| contains {{GPUMapMode/READ}} then |this|.{{[[usage]]}} must contain {{GPUBufferUsage/MAP_READ}}.
-                    - If |mode| contains {{GPUMapMode/WRITE}} then |this|.{{[[usage]]}} must contain {{GPUBufferUsage/MAP_WRITE}}.
+                    - If |mode| contains {{GPUMapMode/READ}} then |this|.{{GPUBuffer/[[usage]]}} must contain {{GPUBufferUsage/MAP_READ}}.
+                    - If |mode| contains {{GPUMapMode/WRITE}} then |this|.{{GPUBuffer/[[usage]]}} must contain {{GPUBufferUsage/MAP_WRITE}}.
 
                     Issue: Do we validate that |mode| contains only valid flags?
                 </div>
@@ -1614,8 +1615,8 @@ interface GPUMapMode {
             **Returns:** {{ArrayBuffer}}
 
             1. If |size| is unspecified:
-                1. If |offset| &gt; this.{{[[size]]}}, throw an {{OperationError}} and stop.
-                1. Let |rangeSize| be this.{{[[size]]}} - |offset|.
+                1. If |offset| &gt; this.{{GPUBuffer/[[size]]}}, throw an {{OperationError}} and stop.
+                1. Let |rangeSize| be this.{{GPUBuffer/[[size]]}} - |offset|.
 
                 Else:
                 1. Let |rangeSize| be |size|.
@@ -1625,9 +1626,9 @@ interface GPUMapMode {
                     - |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapped=] or [=buffer state/mapped at creation=].
                     - |offset| is a multiple of 8.
                     - |rangeSize| is a multiple of 4.
-                    - |offset| is greater than or equal to |this|.{{[[mapping_range]]}}[0].
-                    - |offset| + |rangeSize| is less than or equal to |this|.{{[[mapping_range]]}}[1].
-                    - [|offset|, |offset| + |rangeSize|) does not overlap another range in |this|.{{[[mapped_ranges]]}}.
+                    - |offset| is greater than or equal to |this|.{{GPUBuffer/[[mapping_range]]}}[0].
+                    - |offset| + |rangeSize| is less than or equal to |this|.{{GPUBuffer/[[mapping_range]]}}[1].
+                    - [|offset|, |offset| + |rangeSize|) does not overlap another range in |this|.{{GPUBuffer/[[mapped_ranges]]}}.
 
                     Note: It is always valid to get mapped ranges of a {{GPUBuffer}} that is
                     [=buffer state/mapped at creation=], even if it is [=invalid=], because
@@ -1637,9 +1638,9 @@ interface GPUMapMode {
                 </div>
 
             1. Let |m| be a new {{ArrayBuffer}} of size |rangeSize| pointing at the content
-                of |this|.{{[[mapping]]}} at offset |offset| - |this|.{{[[mapping_range]]}}[0].
+                of |this|.{{GPUBuffer/[[mapping]]}} at offset |offset| - |this|.{{GPUBuffer/[[mapping_range]]}}[0].
 
-            1. Append |m| to |this|.{{[[mapped_ranges]]}}.
+            1. Append |m| to |this|.{{GPUBuffer/[[mapped_ranges]]}}.
 
             1. Return |m|.
         </div>
@@ -1665,24 +1666,24 @@ interface GPUMapMode {
 
             1. If |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapping pending=]:
 
-                1. [=Reject=] {{[[mapping]]}} with an {{OperationError}}.
-                1. Set |this|.{{[[mapping]]}} to null.
+                1. [=Reject=] {{GPUBuffer/[[mapping]]}} with an {{OperationError}}.
+                1. Set |this|.{{GPUBuffer/[[mapping]]}} to null.
 
             1. If |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapped=] or [=buffer state/mapped at creation=]:
 
                 1. If one of the two following conditions holds:
 
                     - |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapped at creation=]
-                    - |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapped=] and |this|.{{[[map_mode]]}} contains {{GPUMapMode/WRITE}}
+                    - |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapped=] and |this|.{{GPUBuffer/[[map_mode]]}} contains {{GPUMapMode/WRITE}}
 
                     Then:
-                    1. Enqueue an operation on the default queue's [=Queue timeline=] that updates the |this|.{{[[mapping_range]]}}
-                        of |this|'s allocation to the content of |this|.{{[[mapping]]}}.
+                    1. Enqueue an operation on the default queue's [=Queue timeline=] that updates the |this|.{{GPUBuffer/[[mapping_range]]}}
+                        of |this|'s allocation to the content of |this|.{{GPUBuffer/[[mapping]]}}.
 
-                1. Detach each {{ArrayBuffer}} in |this|.{{[[mapped_ranges]]}} from its content.
-                1. Set |this|.{{[[mapping]]}} to null.
-                1. Set |this|.{{[[mapping_range]]}} to null.
-                1. Set |this|.{{[[mapped_ranges]]}} to null.
+                1. Detach each {{ArrayBuffer}} in |this|.{{GPUBuffer/[[mapped_ranges]]}} from its content.
+                1. Set |this|.{{GPUBuffer/[[mapping]]}} to null.
+                1. Set |this|.{{GPUBuffer/[[mapping_range]]}} to null.
+                1. Set |this|.{{GPUBuffer/[[mapped_ranges]]}} to null.
 
             1. Set |this|.{{GPUBuffer/[[state]]}} to [=buffer state/unmapped=].
 
@@ -5018,7 +5019,7 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
         and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}},
         if present, must match.
 
-    Issue: Define <dfn>maximum color attachments</dfn>
+    Issue: Define <dfn for=>maximum color attachments</dfn>
 
     Issue(gpuweb/gpuweb#503): support for no attachments
 </div>
@@ -5277,7 +5278,7 @@ enum GPUStoreOp {
                         - |slot| &lt; [=maximum number of vertex buffers=].
                         - |offset| + |size| &le; |buffer|.{{GPUBuffer/[[size]]}}.
 
-                        Issue: Define the <dfn dfn>maximum number of vertex buffers</dfn>.
+                        Issue: Define the <dfn dfn for=>maximum number of vertex buffers</dfn>.
                     </div>
                 1. Add |buffer| to the [=usage scope=] as {{GPUBufferUsage/VERTEX}}.
                 1. Set |this|.{{GPURenderEncoderBase/[[vertex_buffers]]}}[|slot|] to be |buffer|.
@@ -5329,7 +5330,7 @@ enum GPUStoreOp {
     ::
         Draws primitives using parameters read from a {{GPUBuffer}}.
 
-        The <dfn dfn>indirect draw parameters</dfn> encoded in the buffer must be a tightly
+        The <dfn dfn for=>indirect draw parameters</dfn> encoded in the buffer must be a tightly
         packed block of **four 32-bit unsigned integer values (16 bytes total)**, given in the same
         order as the arguments for {{GPURenderEncoderBase/draw()}}. For example:
 
@@ -5371,7 +5372,7 @@ enum GPUStoreOp {
     ::
         Draws indexed primitives using parameters read from a {{GPUBuffer}}.
 
-        The <dfn dfn>indirect drawIndexed parameters</dfn> encoded in the buffer must be a
+        The <dfn dfn for=>indirect drawIndexed parameters</dfn> encoded in the buffer must be a
         tightly packed block of **five 32-bit unsigned integer values (20 bytes total)**, given in
         the same order as the arguments for {{GPURenderEncoderBase/drawIndexed()}}. For example:
 


### PR DESCRIPTION
and fix resulting errors.

This prevents scoped definitions (`<dfn for=...>`) from polluting the
global namespace.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/999.html" title="Last updated on Aug 13, 2020, 2:24 AM UTC (de18a29)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/999/16aeeef...kainino0x:de18a29.html" title="Last updated on Aug 13, 2020, 2:24 AM UTC (de18a29)">Diff</a>