### PR TITLE
New binding type for multisampled textures

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2323,7 +2323,6 @@ dictionary GPUBindGroupLayoutEntry {
 
     // Used for sampled texture bindings. Must be undefined for other binding types.
     GPUTextureComponentType textureComponentType;
-    boolean multisampled;
 
     // Used for storage texture bindings. Must be undefined for other binding types.
     GPUTextureFormat storageTextureFormat;
@@ -2403,20 +2402,6 @@ Issue(https://github.com/gpuweb/gpuweb/issues/851): consider making `textureComp
 
         Otherwise, it must be `undefined`.
 
-    : <dfn>multisampled</dfn>
-    ::
-        If the {{GPUBindGroupLayoutEntry/type}} is
-        {{GPUBindingType/"sampled-texture"}}:
-
-          - This indicates whether a binding must have a sample count greater than 1.
-          - If `undefined`, it defaults to `false`.
-
-        Otherwise, it must be `undefined`.
-
-        Note:
-        This member is used to determine compatibility between a
-        {{GPUPipelineLayout}} and a {{GPUShaderModule}}.
-
     : <dfn>storageTextureFormat</dfn>
     ::
         If the {{GPUBindGroupLayoutEntry/type}} is
@@ -2429,9 +2414,9 @@ Issue(https://github.com/gpuweb/gpuweb/issues/851): consider making `textureComp
 </dl>
 
 Note:
-{{GPUBindGroupLayoutEntry/viewDimension}} and {{GPUBindGroupLayoutEntry/multisampled}}
-enable Metal-based WebGPU implementations to back the respective bind groups
-with `MTLArgumentBuffer` objects that are more efficient to bind at run-time.
+{{GPUBindGroupLayoutEntry/viewDimension}} enables Metal-based WebGPU implementations
+to back the respective bind groups with `MTLArgumentBuffer` objects
+that are more efficient to bind at run-time.
 
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUShaderStageFlags;
@@ -2453,6 +2438,7 @@ enum GPUBindingType {
     "sampler",
     "comparison-sampler",
     "sampled-texture",
+    "multisampled-texture",
     "readonly-storage-texture",
     "writeonly-storage-texture"
 };
@@ -2534,17 +2520,15 @@ A {{GPUBindGroupLayout}} object has the following methods:
                                         - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/viewDimension}} is `undefined`.
 
                                 - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
-                                    {{GPUBindingType/"sampled-texture"}}:
+                                    {{GPUBindingType/"sampled-texture"}} or {{GPUBindingType/"multisampled-texture"}}:
                                     - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/textureComponentType}} is `undefined.`
-                                    - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/multisampled}} is `undefined.`
 
                                 - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
                                     {{GPUBindingType/"readonly-storage-texture"}} or
                                     {{GPUBindingType/"writeonly-storage-texture"}}:
                                     - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/storageTextureFormat}} is `undefined`.
 
-                                - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/sampled-texture}}
-                                    and |bindingDescriptor|.{{GPUBindGroupLayoutEntry/multisampled}} is `true`:
+                                - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/multisampled-texture}}:
                                     - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/viewDimension}} is
                                         {{GPUTextureViewDimension/2d}}.
 
@@ -2693,30 +2677,32 @@ A {{GPUBindGroup}} object has the following internal slots:
 
                                 -  If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
                                     {{GPUBindingType/"sampled-texture"}} or
+                                    {{GPUBindingType/"multisampled-texture"}}:
+                                    - |resource| is [$valid to use with$] |this|.
+                                    - |layoutBinding|.{{GPUBindGroupLayoutEntry/viewDimension}} is
+                                        equal to |resource|'s {{GPUTextureViewDescriptor/dimension}}.
+                                    - |layoutBinding|.{{GPUBindGroupLayoutEntry/textureComponentType}}
+                                        is compatible with |resource|'s {{GPUTextureViewDescriptor/format}}.
+                                    - |resource|'s texture's {{GPUTextureDescriptor/usage}} includes
+                                            {{GPUTextureUsage/SAMPLED}}.
+
+                                - If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampled-texture"}}:
+                                    - |resource|'s texture's {{GPUTextureDescriptor/sampleCount}} is 1.
+
+                                - If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"multisampled-texture"}}:
+                                    - |resource|'s texture's {{GPUTextureDescriptor/sampleCount}} is greater than 1.
+
+                                - If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
                                     {{GPUBindingType/"readonly-storage-texture"}} or
                                     {{GPUBindingType/"writeonly-storage-texture"}}:
                                     - |resource| is [$valid to use with$] |this|.
                                     - |layoutBinding|.{{GPUBindGroupLayoutEntry/viewDimension}} is
                                         equal to |resource|'s {{GPUTextureViewDescriptor/dimension}}.
-
-                                    - If |layoutBinding|.{{GPUBindGroupLayoutEntry/multisampled}} is `true`:
-                                        - |resource|'s texture's {{GPUTextureDescriptor/sampleCount}} is greater than 1.
-                                    - If |layoutBinding|.{{GPUBindGroupLayoutEntry/multisampled}} is `false`:
-                                        - |resource|'s texture's {{GPUTextureDescriptor/sampleCount}} is 1.
-
-                                    - If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampled-texture"}}:
-                                        - |resource|'s texture's {{GPUTextureDescriptor/usage}} includes
-                                            {{GPUTextureUsage/SAMPLED}}.
-                                        - |layoutBinding|.{{GPUBindGroupLayoutEntry/textureComponentType}}
-                                            is compatible with |resource|'s {{GPUTextureViewDescriptor/format}}.
-
-                                    - If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
-                                        {{GPUBindingType/"readonly-storage-texture"}} or
-                                        {{GPUBindingType/"writeonly-storage-texture"}}:
-                                        - |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}
-                                            is equal to |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTextureFormat}}.
-                                        - |resource|'s texture's {{GPUTextureDescriptor/usage}} includes
-                                            {{GPUTextureUsage/STORAGE}}.
+                                    - |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}
+                                        is equal to |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTextureFormat}}.
+                                    - |resource|'s texture's {{GPUTextureDescriptor/usage}} includes
+                                        {{GPUTextureUsage/STORAGE}}.
+                                    - |resource|'s texture's {{GPUTextureDescriptor/sampleCount}} is 1.
 
                                 - If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
                                     {{GPUBindingType/"uniform-buffer"}} or
@@ -3119,11 +3105,11 @@ has a default layout created and used instead.
 
                 1. Set |entry|.{{GPUBindGroupLayoutEntry/textureComponentType}} to |resource|'s component type.
                 1. Set |entry|.{{GPUBindGroupLayoutEntry/viewDimension}} to |resource|'s dimension.
-                1. If |resource| is multisampled:
+                1. If |resource| is for a multisampled texture:
 
-                    1. Set |entry|.{{GPUBindGroupLayoutEntry/multisampled}} to true.
+                    1. Set |entry|.{{GPUBindGroupLayoutEntry/type}} to {{GPUBindingType/multisampled-texture}}.
 
-                1. If |resource| is for a sampled texture:
+                1. If |resource| is for a single-sampled texture:
 
                     1. Set |entry|.{{GPUBindGroupLayoutEntry/type}} to {{GPUBindingType/sampled-texture}}.
 
@@ -3216,9 +3202,10 @@ A {{GPUProgrammableStageDescriptor}} describes the entry point in the user-provi
                   : {{GPUBindingType/"comparison-sampler"}}
                   :: the |binding| is a comparison sampler
                   : {{GPUBindingType/"sampled-texture"}}
-                  ::
-                    1. the |binding| is a sampled texture with the component type of |entry|.{{GPUBindGroupLayoutEntry/textureComponentType}}.
-                    2. it must be multisampled if and only if |entry|.{{GPUBindGroupLayoutEntry/multisampled}} is true.
+                  :: the |binding| is a sampled texture with the component type of |entry|.{{GPUBindGroupLayoutEntry/textureComponentType}}
+                      and it has to have a sample count of 1.
+                  : {{GPUBindingType/"multisampled-texture"}}
+                  :: the |binding| is a multisampled texture with the component type of |entry|.{{GPUBindGroupLayoutEntry/textureComponentType}}.
                   : {{GPUBindingType/"readonly-storage-texture"}}
                   :: the |binding| is a read-only storage texture with format of |entry|.{{GPUBindGroupLayoutEntry/storageTextureFormat}}
                   : {{GPUBindingType/"writeonly-storage-texture"}}


### PR DESCRIPTION
Fixes #990

Problem: on the shader side, MSAA-enabled textures are *not* sampled. We have the `texture_load` instruction to access them, and `texture_sample` is forbidden (in WGSL). Therefore, it's confusing to bind them as "sampled-texture" types. This PR adds a new binding type specifically for MSAA textures, and it removes the old boolean `multisampled` from BGL entry.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/1005.html" title="Last updated on Aug 24, 2020, 7:32 PM UTC (7aedd70)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1005/415fc87...kvark:7aedd70.html" title="Last updated on Aug 24, 2020, 7:32 PM UTC (7aedd70)">Diff</a>