### PR TITLE
Revise the "validating linear texture data" algorithm

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4215,48 +4215,58 @@ and {{GPUCommandEncoder/copyTextureToBuffer()}}.
 
 Issue: define this as an algorithm with (texture, mipmapLevel) parameters and use the call syntax instead of referring to the definition by label.
 
-<div algorithm class=validusage>
+<div algorithm>
     <dfn abstract-op>validating linear texture data</dfn>(layout, byteSize, format, copyExtent)
 
     **Arguments:**
-        - {{GPUTextureDataLayout}} |layout| of the linear texture data
-        - {{GPUSize64}} |byteSize| - total size of the linear data, in bytes
-        - {{GPUTextureFormat}} |format| of the texture
-        - {{GPUExtent3D}} |copyExtent| - extent of the texture to copy
+    : {{GPUTextureDataLayout}} |layout|
+    :: Layout of the linear texture data.
+    : {{GPUSize64}} |byteSize|
+    :: Total size of the linear data, in bytes.
+    : {{GPUTextureFormat}} |format|
+    :: Format of the texture.
+    : {{GPUExtent3D}} |copyExtent|
+    :: Extent of the texture to copy.
 
-    Let:
-        - |blockWidth| be the [=texel block width=] of |format|.
-        - |blockHeight| be the [=texel block height=] of |format|.
-        - |blockSize| be the [=texel block size=] of |format|.
-        - |bytesInACompleteRow| be |blockSize| &times; |copyExtent|.[=Extent3D/width=] &div; |blockWidth|.
-        - |requiredBytesInCopy| be calculated with the following algorithm assuming all the parameters are [=valid=]:
-            ```
-            if (copyExtent.width == 0 || copyExtent.height == 0 || copyExtent.depth == 0) {
-                requiredBytesInCopy = 0;
-            } else {
-                GPUSize64 bytesPerImage = layout.bytesPerRow * layout.rowsPerImage;
-                GPUSize64 bytesInLastSlice =
-                    layout.bytesPerRow * (copyExtent.height / blockHeight - 1) + (copyExtent.width / blockWidth * blockSize);
-                requiredBytesInCopy = bytesPerImage * (copyExtent.depth - 1) + bytesInLastSlice;
-            }
-            ```
+    1. Let |blockWidth|, |blockHeight|, and |blockSize| be the
+        [=texel block width=], [=texel block height|height=], and
+        [=texel block size|size=] of |format|.
 
-    The following validation rules apply:
+    1. It is assumed that |copyExtent|.[=Extent3D/width=] is a multiple of |blockWidth|
+        and |copyExtent|.[=Extent3D/height=] is a multiple of |blockHeight|. Let:
+            - |widthInBlocks| be |copyExtent|.[=Extent3D/width=] &divide; |blockWidth|.
+            - |heightInBlocks| be |copyExtent|.[=Extent3D/height=] &divide; |blockHeight|.
+            - |bytesInACompleteRow| be |blockSize| &times; |widthInBlocks|.
 
-    For the copy being in-bounds:
-    - If |layout|.{{GPUTextureDataLayout/rowsPerImage}} is not 0, it must be greater than or equal to
-        |copyExtent|.[=Extent3D/height=] &divide; |blockHeight|.
-    - (|layout|.{{GPUTextureDataLayout/offset}} + |requiredBytesInCopy|) must not overflow a {{GPUSize64}}.
-    - (|layout|.{{GPUTextureDataLayout/offset}} + |requiredBytesInCopy|) must be smaller than or equal to |byteSize|.
+    1. Fail if the following conditions are not satisfied:
+        <div class=validusage>
+            - If |heightInBlocks| &gt; 1 or |copyExtent|.[=Extent3D/depth=] &gt; 1:
+                - |layout|.{{GPUTextureDataLayout/bytesPerRow}} must be
+                    greater than or equal to the number of |bytesInACompleteRow|.
+            - If |copyExtent|.[=Extent3D/depth=] &gt; 1:
+                - |layout|.{{GPUTextureDataLayout/rowsPerImage}} must not be 0.
 
-    For the texel block alignments:
-    - |layout|.{{GPUTextureDataLayout/offset}} must be a multiple of |blockSize|.
+            These ensure the copy's subregions of the linear data do not overlap.
+        </div>
 
-    For other members in |layout|:
-    - If |copyExtent|.[=Extent3D/height=] is greater than 1 or |copyExtent|.[=Extent3D/depth=] is greater than 1:
-        - |layout|.{{GPUTextureDataLayout/bytesPerRow}} must be greater than or equal to the number of |bytesInACompleteRow|.
-    - If |copyExtent|.[=Extent3D/depth=] is greater than 1:
-        - |layout|.{{GPUTextureDataLayout/rowsPerImage}} must not be 0.
+    1. If |widthInBlocks|, |heightInBlocks|, or |copyExtent|.[=Extent3D/depth=] is 0:
+            - Let |requiredBytesInCopy| be 0.
+        Otherwise:
+            - Let |bytesPerImage| be |layout|.{{GPUTextureDataLayout/bytesPerRow}}
+                &times; |layout|.{{GPUTextureDataLayout/rowsPerImage}}.
+            - Let |bytesInLastSlice| be
+                |layout|.{{GPUTextureDataLayout/bytesPerRow}} &times; (|heightInBlocks| &minus; 1) +
+                |widthInBlocks| &times; |blockSize|.
+            - Let |requiredBytesInCopy| be
+                |bytesPerImage| &times; (|copyExtent|.[=Extent3D/depth=] &minus; 1) +
+                |bytesInLastSlice|.
+
+    1. Fail if the following conditions are not satisfied:
+        <div class=validusage>
+            - |layout|.{{GPUTextureDataLayout/offset}} + |requiredBytesInCopy|
+                must be smaller than or equal to |byteSize|.
+            - |layout|.{{GPUTextureDataLayout/offset}} must be a multiple of |blockSize|.
+        </div>
 </div>
 
 <div algorithm class=validusage>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4243,8 +4243,10 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
             - If |heightInBlocks| &gt; 1 or |copyExtent|.[=Extent3D/depth=] &gt; 1:
                 - |layout|.{{GPUTextureDataLayout/bytesPerRow}} must be
                     greater than or equal to the number of |bytesInACompleteRow|.
-            - If |copyExtent|.[=Extent3D/depth=] &gt; 1:
-                - |layout|.{{GPUTextureDataLayout/rowsPerImage}} must not be 0.
+            - If |copyExtent|.[=Extent3D/depth=] &gt; 1 or
+                |layout|.{{GPUTextureDataLayout/rowsPerImage}} &gt; 0:
+                - |layout|.{{GPUTextureDataLayout/rowsPerImage}} must be
+                    greater than or equal to |heightInBlocks|.
 
             These ensure the copy's subregions of the linear data do not overlap.
         </div>


### PR DESCRIPTION
- Reformats this algorithm to have explicit steps
- Removes the code block (to remove ambiguities about integer overflows, etc.)
- Removes a redundant rule about overflowing a GPUSize64
- Fixes #987: bytesPerRow only required if height \*in blocks\* > 1
- ~Fixes `#984`: rowsPerImage should not be validated unless used~


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1006.html" title="Last updated on Aug 19, 2020, 6:47 PM UTC (35f7faf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1006/8a008ad...kainino0x:35f7faf.html" title="Last updated on Aug 19, 2020, 6:47 PM UTC (35f7faf)">Diff</a>