### PR TITLE
Adding validation to GPUComputePassEncoder methods

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4613,12 +4613,6 @@ interface mixin GPUProgrammablePassEncoder {
 };
 </script>
 
-  - One offset must be passed to
-      {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)}} or
-      {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsetsData, dynamicOffsetsDataStart, dynamicOffsetsDataLength)}}
-      for each dynamic binding in a bind group, in increasing order of
-      {{GPUBindGroupLayoutEntry/binding}} number.
-
 {{GPUProgrammablePassEncoder}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUProgrammablePassEncoder">
@@ -4626,7 +4620,7 @@ interface mixin GPUProgrammablePassEncoder {
     ::
         A stack of active debug group labels.
 
-    : <dfn>\[[bind_groups]]</dfn>, of type map&lt;index, {{GPUBindGroup}}&gt;
+    : <dfn>\[[bind_groups]]</dfn>, of type map&lt;{{GPUIndex32}}, {{GPUBindGroup}}&gt;
     ::
         The current {{GPUBindGroup}} for each index, initially empty.
 </dl>
@@ -4826,6 +4820,14 @@ GPUComputePassEncoder includes GPUObjectBase;
 GPUComputePassEncoder includes GPUProgrammablePassEncoder;
 </script>
 
+{{GPUComputePassEncoder}} has the following internal slots:
+
+<dl dfn-type=attribute dfn-for="GPUComputePassEncoder">
+    : <dfn>\[[pipeline]]</dfn>, of type {{GPUComputePipeline}}
+    ::
+        The current {{GPUComputePipeline}}, initially `null`.
+</dl>
+
 ### Creation ### {#compute-pass-encoder-creation}
 
 <script type=idl>
@@ -4838,55 +4840,112 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
 <dl dfn-type=method dfn-for=GPUComputePassEncoder>
     : <dfn>setPipeline(pipeline)</dfn>
     ::
+        Sets the current {{GPUComputePipeline}}.
 
         <div algorithm="GPUComputePassEncoder.setPipeline">
             **Called on:** {{GPUComputePassEncoder}} this.
 
             **Arguments:**
             <pre class=argumentdef for="GPUComputePassEncoder/setPipeline(pipeline)">
-                pipeline:
+                |pipeline|: The compute pipeline to use for subsequent dispatch commands.
             </pre>
 
             **Returns:** {{undefined}}
 
-            Issue: Describe {{GPUComputePassEncoder/setPipeline()}} algorithm steps.
+            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+            <div class=device-timeline>
+                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+                    <div class=validusage>
+                        - |pipeline| is [$valid to use with$] |this|.
+                    </div>
+                1. Set |this|.{{GPUComputePassEncoder/[[pipeline]]}} to be |pipeline|.
+            </div>
         </div>
 
     : <dfn>dispatch(x, y, z)</dfn>
     ::
+        Dispatch work to be performed with the current {{GPUComputePipeline}}.
 
         <div algorithm="GPUComputePassEncoder.dispatch">
             **Called on:** {{GPUComputePassEncoder}} this.
 
             **Arguments:**
             <pre class=argumentdef for="GPUComputePassEncoder/dispatch(x, y, z)">
-                x:
-                y:
-                z:
+                x: Number of thread groups to dispatch in the X dimension.
+                y: Number of thread groups to dispatch in the Y dimension.
+                z: Number of thread groups to dispatch in the Z dimension.
             </pre>
 
             **Returns:** {{undefined}}
 
-            Issue: Describe {{GPUComputePassEncoder/dispatch()}} algorithm steps.
+            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+            <div class=device-timeline>
+                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+                    <div class=validusage>
+                        - It is [$valid to dispatch$] with |this|.
+                    </div>
+            </div>
         </div>
 
     : <dfn>dispatchIndirect(indirectBuffer, indirectOffset)</dfn>
     ::
+        Dispatch work to be performed with the current {{GPUComputePipeline}} using parameters read
+        from a {{GPUBuffer}}.
+
+        The <dfn dfn for=>indirect dispatch parameters</dfn> encoded in the buffer must be a tightly
+        packed block of **three 32-bit unsigned integer values (12 bytes total)**, given in the same
+        order as the arguments for {{GPUComputePassEncoder/dispatch()}}. For example:
+
+        ```js
+        let dispatchIndirectParameters = new Uint32Array(3);
+        dispatchIndirectParameters[0] = x;
+        dispatchIndirectParameters[1] = y;
+        dispatchIndirectParameters[2] = z;
+        ```
 
         <div algorithm="GPUComputePassEncoder.dispatchIndirect">
             **Called on:** {{GPUComputePassEncoder}} this.
 
             **Arguments:**
             <pre class=argumentdef for="GPUComputePassEncoder/dispatchIndirect(indirectBuffer, indirectOffset)">
-                indirectBuffer:
-                indirectOffset:
+                |indirectBuffer|: Buffer containing the [=indirect dispatch parameters=].
+                |indirectOffset|: Offset in bytes into |indirectBuffer| where the dispatch data begins.
             </pre>
 
             **Returns:** {{undefined}}
 
-            Issue: Describe {{GPUComputePassEncoder/dispatchIndirect()}} algorithm steps.
+            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+            <div class=device-timeline>
+                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+                    <div class=validusage>
+                        - It is [$valid to dispatch$] with |this|.
+                        - |indirectBuffer| is [$valid to use with$] |this|.
+                        - |indirectBuffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDIRECT}}.
+                        - |indirectOffset| + sizeof([=indirect dispatch parameters=]) &le;
+                            |indirectBuffer|.{{GPUBuffer/[[size]]}}.
+                        - |indirectOffset| is a multiple of 4.
+                    </div>
+                1. Add |indirectBuffer| to the [=usage scope=] as {{GPUBufferUsage/INDIRECT}}.
+            </div>
         </div>
 </dl>
+
+<div algorithm>
+    To determine if it's <dfn abstract-op>valid to dispatch</dfn> with {{GPUComputePassEncoder}} |encoder|
+    run the following steps:
+
+    1. If any of the following conditions are unsatisfied return `false`:
+        <div class=validusage>
+            - |encoder|.{{GPUComputePassEncoder/[[pipeline]]}} is not `null`.
+            - Let |pipelineLayout| be |encoder|.{{GPUComputePassEncoder/[[pipeline]]}}.{{GPUPipelineBase/[[layout]]}}.
+            - For each pair of ({{GPUIndex32}} |index|, {{GPUBindGroupLayout}} |bindGroupLayout|) in
+                |pipelineLayout|.{{GPUPipelineLayout/[[bindGroupLayouts]]}}.
+                - Let |bindGroup| be |encoder|.{{GPUProgrammablePassEncoder/[[bind_groups]]}}[|index|].
+                - |bindGroup| is not `null`.
+                - |bindGroup|.{{GPUBindGroup/[[layout]]}} is [=group-equivalent=] with |bindGroupLayout|.
+        </div>
+    1. Return `true`.
+</div>
 
 ### Queries ### {#compute-pass-encoder-queries}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4871,9 +4871,9 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
 
             **Arguments:**
             <pre class=argumentdef for="GPUComputePassEncoder/dispatch(x, y, z)">
-                x: Number of thread groups to dispatch in the X dimension.
-                y: Number of thread groups to dispatch in the Y dimension.
-                z: Number of thread groups to dispatch in the Z dimension.
+                x: X dimension of the grid of thread groups to dispatch.
+                y: Y dimension of the grid of thread groups to dispatch.
+                z: Z dimension of the grid of thread groups to dispatch.
             </pre>
 
             **Returns:** {{undefined}}
@@ -4934,15 +4934,15 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
     To determine if it's <dfn abstract-op>valid to dispatch</dfn> with {{GPUComputePassEncoder}} |encoder|
     run the following steps:
 
-    1. If any of the following conditions are unsatisfied return `false`:
+    1. If any of the following conditions are unsatisfied, return `false`:
         <div class=validusage>
-            - |encoder|.{{GPUComputePassEncoder/[[pipeline]]}} is not `null`.
+            - |encoder|.{{GPUComputePassEncoder/[[pipeline]]}} must not be `null`.
             - Let |pipelineLayout| be |encoder|.{{GPUComputePassEncoder/[[pipeline]]}}.{{GPUPipelineBase/[[layout]]}}.
             - For each pair of ({{GPUIndex32}} |index|, {{GPUBindGroupLayout}} |bindGroupLayout|) in
                 |pipelineLayout|.{{GPUPipelineLayout/[[bindGroupLayouts]]}}.
                 - Let |bindGroup| be |encoder|.{{GPUProgrammablePassEncoder/[[bind_groups]]}}[|index|].
-                - |bindGroup| is not `null`.
-                - |bindGroup|.{{GPUBindGroup/[[layout]]}} is [=group-equivalent=] with |bindGroupLayout|.
+                - |bindGroup| must not be `null`.
+                - |bindGroup|.{{GPUBindGroup/[[layout]]}} must be [=group-equivalent=] with |bindGroupLayout|.
         </div>
     1. Return `true`.
 </div>


### PR DESCRIPTION
Quick note: Build process is broken at this point and I don't know how to fix it, so I haven't been able to verify that this all links correctly.

Adds validation for about half the `GPUComputePassEncoder` methods, and specifically does some validation that the pipeline and bind group state is valid when calling either of the dispatch variants. If this passes muster I'll mirror the same logic back to the `GPURenderPassEncoderBase` methods.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/toji/gpuweb/pull/1007.html" title="Last updated on Aug 18, 2020, 7:51 PM UTC (97775b9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1007/a19c8e0...toji:97775b9.html" title="Last updated on Aug 18, 2020, 7:51 PM UTC (97775b9)">Diff</a>