### PR TITLE
Change void->undefined, normalize formatting of Returns: lines

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -851,7 +851,7 @@ interface GPU {
                 options:
             </pre>
 
-            **Returns:** `Promise<{{GPUAdapter}}?>`.
+            **Returns:** {{Promise}}&lt;{{GPUAdapter}}?&gt;
 
             1. Let |promise| be [=a new promise=].
             1. Issue the following steps on the [=Device timeline=] of |this|:
@@ -998,7 +998,7 @@ interface GPUAdapter {
                 |descriptor|:
             </pre>
 
-            **Returns:** `Promise<{{GPUDevice}}?>`.
+            **Returns:** {{Promise}}&lt;{{GPUDevice}}?&gt;
 
             1. Let |promise| be [=a new promise=].
             1. Issue the following steps to the [=Device timeline=]:
@@ -1314,11 +1314,11 @@ that returns a new buffer in the [=buffer state/mapped=] or [=buffer state/unmap
 <script type=idl>
 [Serializable]
 interface GPUBuffer {
-    Promise<void> mapAsync(GPUMapModeFlags mode, optional GPUSize64 offset = 0, optional GPUSize64 size);
+    Promise<undefined> mapAsync(GPUMapModeFlags mode, optional GPUSize64 offset = 0, optional GPUSize64 size);
     ArrayBuffer getMappedRange(optional GPUSize64 offset = 0, optional GPUSize64 size);
-    void unmap();
+    undefined unmap();
 
-    void destroy();
+    undefined destroy();
 };
 GPUBuffer includes GPUObjectBase;
 </script>
@@ -1516,7 +1516,7 @@ once all previously submitted operations using it are complete.
     <div algorithm=GPUBuffer.destroy>
         **Called on:** {{GPUBuffer}} |this|.
 
-        **Returns:** void
+        **Returns:** {{undefined}}
 
         1. If the |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapped=] or [=buffer state/mapped at creation=]:
             1. Run the steps to unmap |this|.
@@ -1565,7 +1565,7 @@ interface GPUMapMode {
                 |size|:
             </pre>
 
-            **Returns:** `Promise<void>`
+            **Returns:** {{Promise}}&lt;{{undefined}}&gt;
 
             Issue(gpuweb/gpuweb#605): Handle error buffers once we have a description of the error monad.
 
@@ -1664,7 +1664,7 @@ interface GPUMapMode {
         <div algorithm=GPUBuffer.unmap>
             **Called on:** {{GPUBuffer}} |this|.
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             1. If any of the following conditions are unsatisfied, generate a validation
                 error and stop.
@@ -1719,7 +1719,7 @@ Issue: define <dfn dfn>mipmap level</dfn>, <dfn dfn>array layer</dfn>, <dfn dfn>
 interface GPUTexture {
     GPUTextureView createView(optional GPUTextureViewDescriptor descriptor = {});
 
-    void destroy();
+    undefined destroy();
 };
 GPUTexture includes GPUObjectBase;
 </script>
@@ -1819,7 +1819,7 @@ all previously submitted operations using it are complete.
         <div algorithm=GPUTexture.destroy>
             **Called on:** {{GPUTexture}} this.
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue: Describe {{GPUTexture/destroy()}} algorithm steps.
         </div>
@@ -2227,7 +2227,7 @@ enum GPUCompareFunction {
         - {{GPUDevice}} |device|
         - {{GPUSamplerDescriptor}} |descriptor|
 
-    **Returns:** boolean
+    **Returns:** {{boolean}}
 
     Return true if and only if all of the following conditions apply:
         - |device| is valid.
@@ -2963,7 +2963,7 @@ integration such as source-language debugging.
         <div algorithm=GPUShaderModule.compilationInfo>
             **Called on:** {{GPUShaderModule}} this.
 
-            **Returns:** Promise<{{GPUCompilationInfo}}>
+            **Returns:** {{Promise}}&lt;{{GPUCompilationInfo}}&gt;
 
             Issue: Describe {{GPUShaderModule/compilationInfo()}} algorithm steps.
         </div>
@@ -3845,35 +3845,35 @@ interface GPUCommandEncoder {
     GPURenderPassEncoder beginRenderPass(GPURenderPassDescriptor descriptor);
     GPUComputePassEncoder beginComputePass(optional GPUComputePassDescriptor descriptor = {});
 
-    void copyBufferToBuffer(
+    undefined copyBufferToBuffer(
         GPUBuffer source,
         GPUSize64 sourceOffset,
         GPUBuffer destination,
         GPUSize64 destinationOffset,
         GPUSize64 size);
 
-    void copyBufferToTexture(
+    undefined copyBufferToTexture(
         GPUBufferCopyView source,
         GPUTextureCopyView destination,
         GPUExtent3D copySize);
 
-    void copyTextureToBuffer(
+    undefined copyTextureToBuffer(
         GPUTextureCopyView source,
         GPUBufferCopyView destination,
         GPUExtent3D copySize);
 
-    void copyTextureToTexture(
+    undefined copyTextureToTexture(
         GPUTextureCopyView source,
         GPUTextureCopyView destination,
         GPUExtent3D copySize);
 
-    void pushDebugGroup(USVString groupLabel);
-    void popDebugGroup();
-    void insertDebugMarker(USVString markerLabel);
+    undefined pushDebugGroup(USVString groupLabel);
+    undefined popDebugGroup();
+    undefined insertDebugMarker(USVString markerLabel);
 
-    void writeTimestamp(GPUQuerySet querySet, GPUSize32 queryIndex);
+    undefined writeTimestamp(GPUQuerySet querySet, GPUSize32 queryIndex);
 
-    void resolveQuerySet(
+    undefined resolveQuerySet(
         GPUQuerySet querySet,
         GPUSize32 firstQuery,
         GPUSize32 queryCount,
@@ -4088,7 +4088,7 @@ A {{GPUBufferCopyView}} contains the actual [=texture=] data placed in a [=buffe
   **Arguments:**
     - {{GPUBufferCopyView}} |bufferCopyView|
 
-  **Returns:** boolean
+  **Returns:** {{boolean}}
 
   Return true if and only if all of the following conditions apply:
     - |bufferCopyView|.{{GPUBufferCopyView/buffer}} must be a [=valid=] {{GPUBuffer}}.
@@ -4117,7 +4117,7 @@ offset {{GPUOrigin3D}} in texels, used when copying data from or to a {{GPUTextu
   **Arguments:**
     - {{GPUTextureCopyView}} |textureCopyView|
 
-  **Returns:** boolean
+  **Returns:** {{boolean}}
 
   Let:
   - |blockWidth| be the [=texel block width=] of |textureCopyView|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
@@ -4163,7 +4163,7 @@ dictionary GPUImageBitmapCopyView {
                 |size|: Bytes to copy.
             </pre>
 
-            **Returns:** `void`
+            **Returns:** {{undefined}}
 
             If any of the following conditions are unsatisfied, generate a validation error and stop.
             <div class=validusage>
@@ -4206,8 +4206,7 @@ and {{GPUCommandEncoder/copyTextureToBuffer()}}.
   **Arguments:**
     - {{GPUTextureCopyView}} |textureCopyView|
 
-  **Returns:**
-    - {{GPUExtent3D}}
+  **Returns:** {{GPUExtent3D}}
 
   The [=textureCopyView subresource size=] of |textureCopyView| is calculated as follows:
 
@@ -4316,7 +4315,7 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
                 |copySize|:
             </pre>
 
-            **Returns:** `void`
+            **Returns:** {{undefined}}
 
             If any of the following conditions are unsatisfied, generate a validation error and stop.
             <div class=validusage>
@@ -4351,7 +4350,7 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
                 |copySize|:
             </pre>
 
-            **Returns:** `void`
+            **Returns:** {{undefined}}
 
             If any of the following conditions are unsatisfied, generate a validation error and stop.
             <div class=validusage>
@@ -4388,7 +4387,7 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
                 |copySize|:
             </pre>
 
-            **Returns:** `void`
+            **Returns:** {{undefined}}
 
             1. Let |copy of the whole subresource| be the command |this|.{{GPUCommandEncoder/copyTextureToTexture()}}
                 whose parameters |source|, |destination| and |copySize| meet the following conditions:
@@ -4460,7 +4459,7 @@ must be well nested.
                 |groupLabel|: The label for the command group.
             </pre>
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
@@ -4480,7 +4479,7 @@ must be well nested.
         <div algorithm=GPUCommandEncoder.popDebugGroup>
             **Called on:** {{GPUCommandEncoder}} |this|.
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
@@ -4506,7 +4505,7 @@ must be well nested.
                 markerLabel: The label to insert.
             </pre>
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
@@ -4533,7 +4532,7 @@ must be well nested.
                 queryIndex:
             </pre>
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue: Describe {{GPUCommandEncoder/writeTimestamp()}} algorithm steps.
         </div>
@@ -4553,7 +4552,7 @@ must be well nested.
                 destinationOffset:
             </pre>
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue: Describe {{GPUCommandEncoder/resolveQuerySet()}} algorithm steps.
         </div>
@@ -4579,7 +4578,7 @@ command encoder can no longer be used.
                 descriptor:
             </pre>
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
@@ -4600,17 +4599,17 @@ command encoder can no longer be used.
 <script type=idl>
 
 interface mixin GPUProgrammablePassEncoder {
-    void setBindGroup(GPUIndex32 index, GPUBindGroup bindGroup,
+    undefined setBindGroup(GPUIndex32 index, GPUBindGroup bindGroup,
                       optional sequence<GPUBufferDynamicOffset> dynamicOffsets = []);
 
-    void setBindGroup(GPUIndex32 index, GPUBindGroup bindGroup,
+    undefined setBindGroup(GPUIndex32 index, GPUBindGroup bindGroup,
                       Uint32Array dynamicOffsetsData,
                       GPUSize64 dynamicOffsetsDataStart,
                       GPUSize32 dynamicOffsetsDataLength);
 
-    void pushDebugGroup(USVString groupLabel);
-    void popDebugGroup();
-    void insertDebugMarker(USVString markerLabel);
+    undefined pushDebugGroup(USVString groupLabel);
+    undefined popDebugGroup();
+    undefined insertDebugMarker(USVString markerLabel);
 };
 </script>
 
@@ -4656,7 +4655,7 @@ interface mixin GPUProgrammablePassEncoder {
             Issue: Resolve bikeshed conflict when using `argumentdef` with overloaded functions that prevents us from
                 defining |dynamicOffsets|.
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
@@ -4697,7 +4696,7 @@ interface mixin GPUProgrammablePassEncoder {
                 |dynamicOffsetsDataLength|: Number of buffer offsets to read from |dynamicOffsetsData|.
             </pre>
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
@@ -4760,7 +4759,7 @@ pass.
                 |groupLabel|: The label for the command group.
             </pre>
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
@@ -4776,7 +4775,7 @@ pass.
         <div algorithm=GPUProgrammablePassEncoder.popDebugGroup>
             **Called on:** {{GPUProgrammablePassEncoder}} |this|.
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
@@ -4802,7 +4801,7 @@ pass.
                 markerLabel: The label to insert.
             </pre>
 
-            **Returns:** void
+            **Returns:** {{undefined}}
         </div>
 </dl>
 
@@ -4812,16 +4811,16 @@ pass.
 
 <script type=idl>
 interface GPUComputePassEncoder {
-    void setPipeline(GPUComputePipeline pipeline);
-    void dispatch(GPUSize32 x, optional GPUSize32 y = 1, optional GPUSize32 z = 1);
-    void dispatchIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
+    undefined setPipeline(GPUComputePipeline pipeline);
+    undefined dispatch(GPUSize32 x, optional GPUSize32 y = 1, optional GPUSize32 z = 1);
+    undefined dispatchIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
 
-    void beginPipelineStatisticsQuery(GPUQuerySet querySet, GPUSize32 queryIndex);
-    void endPipelineStatisticsQuery();
+    undefined beginPipelineStatisticsQuery(GPUQuerySet querySet, GPUSize32 queryIndex);
+    undefined endPipelineStatisticsQuery();
 
-    void writeTimestamp(GPUQuerySet querySet, GPUSize32 queryIndex);
+    undefined writeTimestamp(GPUQuerySet querySet, GPUSize32 queryIndex);
 
-    void endPass();
+    undefined endPass();
 };
 GPUComputePassEncoder includes GPUObjectBase;
 GPUComputePassEncoder includes GPUProgrammablePassEncoder;
@@ -4848,7 +4847,7 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
                 pipeline:
             </pre>
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue: Describe {{GPUComputePassEncoder/setPipeline()}} algorithm steps.
         </div>
@@ -4866,7 +4865,7 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
                 z:
             </pre>
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue: Describe {{GPUComputePassEncoder/dispatch()}} algorithm steps.
         </div>
@@ -4883,7 +4882,7 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
                 indirectOffset:
             </pre>
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue: Describe {{GPUComputePassEncoder/dispatchIndirect()}} algorithm steps.
         </div>
@@ -4904,7 +4903,7 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
                 queryIndex:
             </pre>
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue: Describe {{GPUComputePassEncoder/beginPipelineStatisticsQuery()}} algorithm steps.
         </div>
@@ -4915,7 +4914,7 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
         <div algorithm="GPUComputePassEncoder.endPipelineStatisticsQuery">
             **Called on:** {{GPUComputePassEncoder}} this.
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue: Describe {{GPUComputePassEncoder/endPipelineStatisticsQuery()}} algorithm steps.
         </div>
@@ -4932,7 +4931,7 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
                 queryIndex:
             </pre>
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue: Describe {{GPUComputePassEncoder/writeTimestamp()}} algorithm steps.
         </div>
@@ -4953,7 +4952,7 @@ called the compute pass encoder can no longer be used.
         <div algorithm="GPUComputePassEncoder.endPass">
             **Called on:** {{GPUComputePassEncoder}} |this|.
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
@@ -4976,43 +4975,43 @@ called the compute pass encoder can no longer be used.
 
 <script type=idl>
 interface mixin GPURenderEncoderBase {
-    void setPipeline(GPURenderPipeline pipeline);
+    undefined setPipeline(GPURenderPipeline pipeline);
 
-    void setIndexBuffer(GPUBuffer buffer, GPUIndexFormat indexFormat, optional GPUSize64 offset = 0, optional GPUSize64 size = 0);
-    void setVertexBuffer(GPUIndex32 slot, GPUBuffer buffer, optional GPUSize64 offset = 0, optional GPUSize64 size = 0);
+    undefined setIndexBuffer(GPUBuffer buffer, GPUIndexFormat indexFormat, optional GPUSize64 offset = 0, optional GPUSize64 size = 0);
+    undefined setVertexBuffer(GPUIndex32 slot, GPUBuffer buffer, optional GPUSize64 offset = 0, optional GPUSize64 size = 0);
 
-    void draw(GPUSize32 vertexCount, optional GPUSize32 instanceCount = 1,
+    undefined draw(GPUSize32 vertexCount, optional GPUSize32 instanceCount = 1,
               optional GPUSize32 firstVertex = 0, optional GPUSize32 firstInstance = 0);
-    void drawIndexed(GPUSize32 indexCount, optional GPUSize32 instanceCount = 1,
+    undefined drawIndexed(GPUSize32 indexCount, optional GPUSize32 instanceCount = 1,
                      optional GPUSize32 firstIndex = 0,
                      optional GPUSignedOffset32 baseVertex = 0,
                      optional GPUSize32 firstInstance = 0);
 
-    void drawIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
-    void drawIndexedIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
+    undefined drawIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
+    undefined drawIndexedIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
 };
 
 interface GPURenderPassEncoder {
-    void setViewport(float x, float y,
+    undefined setViewport(float x, float y,
                      float width, float height,
                      float minDepth, float maxDepth);
 
-    void setScissorRect(GPUIntegerCoordinate x, GPUIntegerCoordinate y,
+    undefined setScissorRect(GPUIntegerCoordinate x, GPUIntegerCoordinate y,
                         GPUIntegerCoordinate width, GPUIntegerCoordinate height);
 
-    void setBlendColor(GPUColor color);
-    void setStencilReference(GPUStencilValue reference);
+    undefined setBlendColor(GPUColor color);
+    undefined setStencilReference(GPUStencilValue reference);
 
-    void beginOcclusionQuery(GPUSize32 queryIndex);
-    void endOcclusionQuery();
+    undefined beginOcclusionQuery(GPUSize32 queryIndex);
+    undefined endOcclusionQuery();
 
-    void beginPipelineStatisticsQuery(GPUQuerySet querySet, GPUSize32 queryIndex);
-    void endPipelineStatisticsQuery();
+    undefined beginPipelineStatisticsQuery(GPUQuerySet querySet, GPUSize32 queryIndex);
+    undefined endPipelineStatisticsQuery();
 
-    void writeTimestamp(GPUQuerySet querySet, GPUSize32 queryIndex);
+    undefined writeTimestamp(GPUQuerySet querySet, GPUSize32 queryIndex);
 
-    void executeBundles(sequence<GPURenderBundle> bundles);
-    void endPass();
+    undefined executeBundles(sequence<GPURenderBundle> bundles);
+    undefined endPass();
 };
 GPURenderPassEncoder includes GPUObjectBase;
 GPURenderPassEncoder includes GPUProgrammablePassEncoder;
@@ -5299,7 +5298,7 @@ enum GPUStoreOp {
                 |pipeline|: The render pipeline to use for subsequent drawing commands.
             </pre>
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
@@ -5329,7 +5328,7 @@ enum GPUStoreOp {
                     If `0`, |buffer|.{{GPUBuffer/[[size]]}} - |offset| is used.
             </pre>
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
@@ -5361,7 +5360,7 @@ enum GPUStoreOp {
                     If `0`, |buffer|.{{GPUBuffer/[[size]]}} - |offset| is used.
             </pre>
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
@@ -5394,7 +5393,7 @@ enum GPUStoreOp {
                 firstInstance: First instance to draw.
             </pre>
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue: Describe {{GPURenderEncoderBase/draw()}} algorithm steps.
         </div>
@@ -5415,7 +5414,7 @@ enum GPUStoreOp {
                 firstInstance: First instance to draw.
             </pre>
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue: Describe {{GPURenderEncoderBase/drawIndexed()}} algorithm steps.
         </div>
@@ -5445,7 +5444,7 @@ enum GPUStoreOp {
                 |indirectOffset|: Offset in bytes into |indirectBuffer| where the drawing data begins.
             </pre>
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
@@ -5487,7 +5486,7 @@ enum GPUStoreOp {
                 |indirectOffset|: Offset in bytes into |indirectBuffer| where the drawing data begins.
             </pre>
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
@@ -5529,7 +5528,7 @@ attachments used by this encoder.
                 |maxDepth|: Maximum depth value of the viewport.
             </pre>
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
@@ -5565,7 +5564,7 @@ attachments used by this encoder.
                 |height|: Height of the scissor rectangle in pixels.
             </pre>
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
@@ -5630,7 +5629,7 @@ attachments used by this encoder.
                 queryIndex:
             </pre>
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue: Describe {{GPURenderPassEncoder/beginOcclusionQuery()}} algorithm steps.
         </div>
@@ -5641,7 +5640,7 @@ attachments used by this encoder.
         <div algorithm="GPURenderPassEncoder.endOcclusionQuery">
             **Called on:** {{GPURenderPassEncoder}} this.
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue: Describe {{GPURenderPassEncoder/endOcclusionQuery()}} algorithm steps.
         </div>
@@ -5658,7 +5657,7 @@ attachments used by this encoder.
                 queryIndex:
             </pre>
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue: Describe {{GPURenderPassEncoder/beginPipelineStatisticsQuery()}} algorithm steps.
         </div>
@@ -5669,7 +5668,7 @@ attachments used by this encoder.
         <div algorithm="GPURenderPassEncoder.endPipelineStatisticsQuery">
             **Called on:** {{GPURenderPassEncoder}} this.
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue: Describe {{GPURenderPassEncoder/endPipelineStatisticsQuery()}} algorithm steps.
         </div>
@@ -5686,7 +5685,7 @@ attachments used by this encoder.
                 queryIndex:
             </pre>
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue: Describe {{GPURenderPassEncoder/writeTimestamp()}} algorithm steps.
         </div>
@@ -5706,7 +5705,7 @@ attachments used by this encoder.
                 bundles:
             </pre>
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue: Describe {{GPURenderPassEncoder/executeBundles()}} algorithm steps.
         </div>
@@ -5727,7 +5726,7 @@ called the render pass encoder can no longer be used.
         <div algorithm="GPURenderPassEncoder.endPass">
             **Called on:** {{GPURenderPassEncoder}} |this|.
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
@@ -5821,25 +5820,25 @@ dictionary GPURenderBundleEncoderDescriptor : GPUObjectDescriptorBase {
 
 <script type=idl>
 interface GPUQueue {
-    void submit(sequence<GPUCommandBuffer> commandBuffers);
+    undefined submit(sequence<GPUCommandBuffer> commandBuffers);
 
     GPUFence createFence(optional GPUFenceDescriptor descriptor = {});
-    void signal(GPUFence fence, GPUFenceValue signalValue);
+    undefined signal(GPUFence fence, GPUFenceValue signalValue);
 
-    void writeBuffer(
+    undefined writeBuffer(
         GPUBuffer buffer,
         GPUSize64 bufferOffset,
         [AllowShared] BufferSource data,
         optional GPUSize64 dataOffset = 0,
         optional GPUSize64 size);
 
-    void writeTexture(
+    undefined writeTexture(
       GPUTextureCopyView destination,
       [AllowShared] BufferSource data,
       GPUTextureDataLayout dataLayout,
       GPUExtent3D size);
 
-    void copyImageBitmapToTexture(
+    undefined copyImageBitmapToTexture(
         GPUImageBitmapCopyView source,
         GPUTextureCopyView destination,
         GPUExtent3D copySize);
@@ -5866,7 +5865,7 @@ GPUQueue includes GPUObjectBase;
                 |size|:
             </pre>
 
-            **Returns:** `void`
+            **Returns:** {{undefined}}
 
             1. If |data| is an {{ArrayBuffer}} or {{DataView}}, let the element type be "byte".
                 Otherwise, |data| is a TypedArray; let the element type be the type of the TypedArray.
@@ -5916,7 +5915,7 @@ GPUQueue includes GPUObjectBase;
                 |size|:
             </pre>
 
-            **Returns:** `void`
+            **Returns:** {{undefined}}
 
             1. Let |dataBytes| be [=get a copy of the buffer source|a copy of the bytes held by the buffer source=] |data|.
             1. Let |dataByteSize| be the number of bytes in |dataBytes|.
@@ -5969,7 +5968,7 @@ GPUQueue includes GPUObjectBase;
                 |copySize|:
             </pre>
 
-            **Returns:** `void`
+            **Returns:** {{undefined}}
 
             If any of the following conditions are unsatisfied, throw an {{OperationError}} and stop.
             <div class=validusage>
@@ -5999,7 +5998,7 @@ GPUQueue includes GPUObjectBase;
                 |commandBuffers|:
             </pre>
 
-            **Returns:** `void`
+            **Returns:** {{undefined}}
 
             If any of the following conditions are unsatisfied, generate a validation error and stop.
             <div class=validusage>
@@ -6015,7 +6014,7 @@ GPUQueue includes GPUObjectBase;
 <script type=idl>
 interface GPUFence {
     GPUFenceValue getCompletedValue();
-    Promise<void> onCompletion(GPUFenceValue completionValue);
+    Promise<undefined> onCompletion(GPUFenceValue completionValue);
 };
 GPUFence includes GPUObjectBase;
 </script>
@@ -6063,7 +6062,7 @@ Completion of a fence is signaled from the {{GPUQueue}} that created it.
                 signalValue:
             </pre>
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue: Describe {{GPUQueue/signal()}} algorithm steps.
         </div>
@@ -6094,7 +6093,7 @@ The completion of the fence and the value it completes with can be observed from
                 completionValue:
             </pre>
 
-            **Returns:** {{Promise}}
+            **Returns:** {{Promise}}&lt;{{undefined}}&gt;
 
             Issue: Describe {{GPUFence/onCompletion()}} algorithm steps.
         </div>
@@ -6108,7 +6107,7 @@ Queries {#queries}
 
 <script type=idl>
 interface GPUQuerySet {
-    void destroy();
+    undefined destroy();
 };
 GPUQuerySet includes GPUObjectBase;
 </script>
@@ -6165,7 +6164,7 @@ dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
         <div algorithm="GPUQuerySet.signal">
             **Called on:** {{GPUQuerySet}} this.
 
-            **Returns:** void
+            **Returns:** {{undefined}}
 
             Issue: Describe {{GPUQuerySet/destroy()}} algorithm steps.
         </div>
@@ -6253,7 +6252,7 @@ interface GPUCanvasContext {
                 device:
             </pre>
 
-            **Returns:** Promise<{{GPUTextureFormat}}>
+            **Returns:** {{Promise}}&lt;{{GPUTextureFormat}}&gt;
 
             Issue: Describe {{GPUCanvasContext/getSwapChainPreferredFormat()}} algorithm steps.
         </div>
@@ -6334,7 +6333,7 @@ typedef (GPUOutOfMemoryError or GPUValidationError) GPUError;
 
 <script type=idl>
 partial interface GPUDevice {
-    void pushErrorScope(GPUErrorFilter filter);
+    undefined pushErrorScope(GPUErrorFilter filter);
     Promise<GPUError?> popErrorScope();
 };
 </script>


### PR DESCRIPTION
First change was needed for a WebIDL spec change, just did second change while I was at it.

Fixes the build/CI.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1009.html" title="Last updated on Aug 18, 2020, 7:25 PM UTC (da52dcd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1009/af218ea...kainino0x:da52dcd.html" title="Last updated on Aug 18, 2020, 7:25 PM UTC (da52dcd)">Diff</a>