### PR TITLE
Additional validation for all draw methods

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3347,6 +3347,16 @@ GPURenderPipeline includes GPUObjectBase;
 GPURenderPipeline includes GPUPipelineBase;
 </script>
 
+{{GPURenderPipeline}} has the following internal slots:
+
+<dl dfn-type=attribute dfn-for=GPURenderPipeline>
+    : <dfn>\[[descriptor]]</dfn>, of type {{GPURenderPipelineDescriptor}}
+    ::
+        The {{GPURenderPipelineDescriptor}} describing this pipeline.
+
+        All optional fields of {{GPURenderPipelineDescriptor}} are defined.
+</dl>
+
 ### Creation ### {#render-pipeline-creation}
 
 <script type=idl>
@@ -3456,33 +3466,42 @@ Issue: link to the semantics of SV_SampleIndex and SV_Coverage in WGSL spec.
                 |descriptor|:
             </pre>
 
-            **Returns:** {{GPUBuffer}}
+            **Returns:** {{GPURenderPipeline}}
 
-            If any of the following conditions are unsatisfied:
-                <div class=validusage>
-                    - |this| is a [=valid=] {{GPUDevice}}.
-                    - |descriptor|.{{GPUPipelineDescriptorBase/layout}} is [$valid to use with$] |this|.
-                    - [$validating GPUProgrammableStageDescriptor$]({{GPUShaderStage/VERTEX}},
-                        |descriptor|.{{GPURenderPipelineDescriptor/vertexStage}},
-                        |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
-                    - If |descriptor|.{{GPURenderPipelineDescriptor/fragmentStage}} is not `null`:
-                        - [$validating GPUProgrammableStageDescriptor$]({{GPUShaderStage/FRAGMENT}},
-                            |descriptor|.{{GPURenderPipelineDescriptor/fragmentStage}},
-                            |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
-                    - |descriptor|.{{GPURenderPipelineDescriptor/colorStates}}.length is less than
-                        or equal to 4.
-                    - [$validating GPUVertexStateDescriptor$](|descriptor|.{{GPURenderPipelineDescriptor/vertexState}},
-                        |descriptor|.{{GPURenderPipelineDescriptor/vertexStage}}) passes.
-                    - If |descriptor|.{{GPURenderPipelineDescriptor/alphaToCoverageEnabled}} is `true`:
-                        - |descriptor|.{{GPURenderPipelineDescriptor/sampleCount}} is greater than 1.
-                    - If the output SV_Coverage semantics is [=statically used=] by
-                        |descriptor|.{{GPURenderPipelineDescriptor/fragmentStage}}:
-                        - |descriptor|.{{GPURenderPipelineDescriptor/alphaToCoverageEnabled}} is `false`.
+            1. Let |pipeline| be a new valid {{GPURenderPipeline}} object.
+            1. Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
+                    1. If any of the following conditions are unsatisfied:
+                        <div class=validusage>
+                            - |this| is a [=valid=] {{GPUDevice}}.
+                            - |descriptor|.{{GPUPipelineDescriptorBase/layout}} is [$valid to use with$] |this|.
+                            - [$validating GPUProgrammableStageDescriptor$]({{GPUShaderStage/VERTEX}},
+                                |descriptor|.{{GPURenderPipelineDescriptor/vertexStage}},
+                                |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
+                            - If |descriptor|.{{GPURenderPipelineDescriptor/fragmentStage}} is not `null`:
+                                - [$validating GPUProgrammableStageDescriptor$]({{GPUShaderStage/FRAGMENT}},
+                                    |descriptor|.{{GPURenderPipelineDescriptor/fragmentStage}},
+                                    |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
+                            - |descriptor|.{{GPURenderPipelineDescriptor/colorStates}}.length is less than
+                                or equal to 4.
+                            - [$validating GPUVertexStateDescriptor$](|descriptor|.{{GPURenderPipelineDescriptor/vertexState}},
+                                |descriptor|.{{GPURenderPipelineDescriptor/vertexStage}}) passes.
+                            - If |descriptor|.{{GPURenderPipelineDescriptor/alphaToCoverageEnabled}} is `true`:
+                                - |descriptor|.{{GPURenderPipelineDescriptor/sampleCount}} is greater than 1.
+                            - If the output SV_Coverage semantics is [=statically used=] by
+                                |descriptor|.{{GPURenderPipelineDescriptor/fragmentStage}}:
+                                - |descriptor|.{{GPURenderPipelineDescriptor/alphaToCoverageEnabled}} is `false`.
+                        </div>
+
+                        Then:
+                            1. Generate a {{GPUValidationError}} in the current scope with appropriate
+                                error message.
+                            1. Make |pipeline| [=invalid=].
+
+                    1. Set |pipeline|.{{GPURenderPipeline/[[descriptor]]}} to |descriptor|.
+
                 </div>
-
-            Then:
-                1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
-                1. Create a new [=invalid=] {{GPURenderPipeline}} and return the result.
+            1. Return |pipeline|.
 
             Issue: need a proper limit for the maximum number of color targets.
 
@@ -5479,7 +5498,13 @@ enum GPUStoreOp {
 
             **Returns:** {{undefined}}
 
-            Issue: Describe {{GPURenderEncoderBase/draw()}} algorithm steps.
+            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+            <div class=device-timeline>
+                If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+                <div class=validusage>
+                    - It is [$valid to draw$] with |this|.
+                </div>
+            </div>
         </div>
 
     : <dfn>drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance)</dfn>
@@ -5500,7 +5525,14 @@ enum GPUStoreOp {
 
             **Returns:** {{undefined}}
 
-            Issue: Describe {{GPURenderEncoderBase/drawIndexed()}} algorithm steps.
+            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+            <div class=device-timeline>
+                If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+                <div class=validusage>
+                    - It is [$valid to draw$] with |this|.
+                    - |this|.{{GPURenderEncoderBase/[[index_buffer]]}} is not `null`.
+                </div>
+            </div>
         </div>
 
     : <dfn>drawIndirect(indirectBuffer, indirectOffset)</dfn>
@@ -5534,6 +5566,7 @@ enum GPUStoreOp {
             <div class=device-timeline>
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
+                        - It is [$valid to draw$] with |this|.
                         - |indirectBuffer| is [$valid to use with$] |this|.
                         - |indirectBuffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDIRECT}}.
                         - |indirectOffset| + sizeof([=indirect draw parameters=]) &le;
@@ -5576,6 +5609,8 @@ enum GPUStoreOp {
             <div class=device-timeline>
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
+                        - It is [$valid to draw$] with |this|.
+                        - |this|.{{GPURenderEncoderBase/[[index_buffer]]}} is not `null`.
                         - |indirectBuffer| is [$valid to use with$] |this|.
                         - |indirectBuffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDIRECT}}.
                         - |indirectOffset| + sizeof([=indirect drawIndexed parameters=]) &le;
@@ -5586,6 +5621,28 @@ enum GPUStoreOp {
             </div>
         </div>
 </dl>
+
+<div algorithm>
+    To determine if it's <dfn abstract-op>valid to draw</dfn> with {{GPURenderEncoderBase}} |encoder|
+    run the following steps:
+
+    1. If any of the following conditions are unsatisfied, return `false`:
+        <div class=validusage>
+            - |encoder|.{{GPURenderEncoderBase/[[pipeline]]}} must not be `null`.
+            - Let |pipelineLayout| be |encoder|.{{GPURenderEncoderBase/[[pipeline]]}}.{{GPUPipelineBase/[[layout]]}}.
+            - For each pair of ({{GPUIndex32}} |index|, {{GPUBindGroupLayout}} |bindGroupLayout|) in
+                |pipelineLayout|.{{GPUPipelineLayout/[[bindGroupLayouts]]}}.
+                - Let |bindGroup| be |encoder|.{{GPUProgrammablePassEncoder/[[bind_groups]]}}[|index|].
+                - |bindGroup| must not be `null`.
+                - |bindGroup|.{{GPUBindGroup/[[layout]]}} must be [=group-equivalent=] with |bindGroupLayout|.
+
+            - Let |pipelineDescriptor| be |encoder|.{{GPURenderEncoderBase/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.
+            - For each {{GPUIndex32}} |slot| `0` to
+                |pipelineDescriptor|.{{GPURenderPipelineDescriptor/vertexState}}.{{GPUVertexStateDescriptor/vertexBuffers}}.length:
+                - |encoder|.{{GPURenderEncoderBase/[[vertex_buffers]]}}[|slot|] must not be `null`.
+        </div>
+    1. Return `true`.
+</div>
 
 ### Rasterization state ### {#render-pass-encoder-rasterization-state}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -636,7 +636,7 @@ We define <dfn dfn>subresource</dfn> to be either a whole buffer, or a [=texture
 
 <div algorithm="compatible usage list">
 Some [=internal usage=]s are compatible with others. A [=subresource=] can be in a state
-that combines multiple usages together. We consider a list |U| to be 
+that combines multiple usages together. We consider a list |U| to be
 a <dfn dfn>compatible usage list</dfn> if (and only if) it satisfies any of the following rules:
     - Each usage in |U| is [=internal usage/input=], [=internal usage/constant=], or [=internal usage/storage-read=].
     - Each usage in |U| is [=internal usage/storage=] or [=internal usage/storage-read=].
@@ -3358,7 +3358,7 @@ GPURenderPipeline includes GPUPipelineBase;
 
     : <dfn>\[[strip_index_format]]</dfn>, of type {{GPUIndexFormat}}?
     ::
-        The format index data this pipeline requires, initially `null`.
+        The format index data this pipeline requires, initially `undefined`.
 </dl>
 
 ### Creation ### {#render-pipeline-creation}
@@ -3495,6 +3495,11 @@ Issue: link to the semantics of SV_SampleIndex and SV_Coverage in WGSL spec.
                             - If the output SV_Coverage semantics is [=statically used=] by
                                 |descriptor|.{{GPURenderPipelineDescriptor/fragmentStage}}:
                                 - |descriptor|.{{GPURenderPipelineDescriptor/alphaToCoverageEnabled}} is `false`.
+                            - If |descriptor|.{{GPURenderPipelineDescriptor/primitiveTopology}} is
+                                {{GPUPrimitiveTopology/"line-strip"}} or
+                                {{GPUPrimitiveTopology/"triangle-strip"}}:
+                                - |descriptor|.{{GPURenderPipelineDescriptor/vertexState}}.{{GPUVertexStateDescriptor/indexFormat}}
+                                    is not `undefined`.
                         </div>
 
                         Then:
@@ -4785,6 +4790,30 @@ interface mixin GPUProgrammablePassEncoder {
             1. Let |dynamicOffsetIndex| be |dynamicOffsetIndex| + `1`
 </div>
 
+<div algorithm>
+    <dfn abstract-op>Validate encoder bind groups</dfn>(encoder, pipeline)
+
+    **Arguments:**
+    : {{GPUProgrammablePassEncoder}} |encoder|
+    :: Encoder who's bind groups are being validated.
+    : {{GPUPipelineBase}} |pipeline|
+    :: Pipline to validate |encoder|s bind groups are compatible with.
+
+    If any of the following conditions are unsatisfied, return `false`:
+        <div class=validusage>
+            - |pipeline| must not be `null`.
+            - For each pair of ({{GPUIndex32}} |index|, {{GPUBindGroupLayout}} |bindGroupLayout|) in
+                |pipeline|.{{GPUPipelineBase/[[layout]]}}.{{GPUPipelineLayout/[[bindGroupLayouts]]}}.
+                - Let |bindGroup| be |encoder|.{{GPUProgrammablePassEncoder/[[bind_groups]]}}[|index|].
+                - |bindGroup| must not be `null`.
+                - |bindGroup|.{{GPUBindGroup/[[layout]]}} must be [=group-equivalent=] with |bindGroupLayout|.
+
+            Issue: Check buffer bindings against `minBufferBindingSize` if present.
+        </div>
+
+    Otherwise return `true`.
+</div>
+
 ## Debug Markers ## {#programmable-passes-debug-markers}
 
 Debug marker methods for programmable pass encoders provide the same functionality as
@@ -4934,7 +4963,8 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
             <div class=device-timeline>
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
-                        - It is [$valid to dispatch$] with |this|.
+                        - [$Validate encoder bind groups$](|this|, |this|.{{GPUComputePassEncoder/[[pipeline]]}})
+                            is `true`.
                     </div>
             </div>
         </div>
@@ -4970,7 +5000,8 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
             <div class=device-timeline>
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
-                        - It is [$valid to dispatch$] with |this|.
+                        - [$Validate encoder bind groups$](|this|, |this|.{{GPUComputePassEncoder/[[pipeline]]}})
+                            is `true`.
                         - |indirectBuffer| is [$valid to use with$] |this|.
                         - |indirectBuffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDIRECT}}.
                         - |indirectOffset| + sizeof([=indirect dispatch parameters=]) &le;
@@ -4981,23 +5012,6 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
             </div>
         </div>
 </dl>
-
-<div algorithm>
-    To determine if it's <dfn abstract-op>valid to dispatch</dfn> with {{GPUComputePassEncoder}} |encoder|
-    run the following steps:
-
-    1. If any of the following conditions are unsatisfied, return `false`:
-        <div class=validusage>
-            - |encoder|.{{GPUComputePassEncoder/[[pipeline]]}} must not be `null`.
-            - Let |pipelineLayout| be |encoder|.{{GPUComputePassEncoder/[[pipeline]]}}.{{GPUPipelineBase/[[layout]]}}.
-            - For each pair of ({{GPUIndex32}} |index|, {{GPUBindGroupLayout}} |bindGroupLayout|) in
-                |pipelineLayout|.{{GPUPipelineLayout/[[bindGroupLayouts]]}}.
-                - Let |bindGroup| be |encoder|.{{GPUProgrammablePassEncoder/[[bind_groups]]}}[|index|].
-                - |bindGroup| must not be `null`.
-                - |bindGroup|.{{GPUBindGroup/[[layout]]}} must be [=group-equivalent=] with |bindGroupLayout|.
-        </div>
-    1. Return `true`.
-</div>
 
 ### Queries ### {#compute-pass-encoder-queries}
 
@@ -5632,37 +5646,35 @@ enum GPUStoreOp {
     To determine if it's <dfn abstract-op>valid to draw</dfn> with {{GPURenderEncoderBase}} |encoder|
     run the following steps:
 
-    1. If any of the following conditions are unsatisfied, return `false`:
+    If any of the following conditions are unsatisfied, return `false`:
         <div class=validusage>
-            - |encoder|.{{GPURenderEncoderBase/[[pipeline]]}} must not be `null`.
-            - Let |pipelineLayout| be |encoder|.{{GPURenderEncoderBase/[[pipeline]]}}.{{GPUPipelineBase/[[layout]]}}.
-            - For each pair of ({{GPUIndex32}} |index|, {{GPUBindGroupLayout}} |bindGroupLayout|) in
-                |pipelineLayout|.{{GPUPipelineLayout/[[bindGroupLayouts]]}}.
-                - Let |bindGroup| be |encoder|.{{GPUProgrammablePassEncoder/[[bind_groups]]}}[|index|].
-                - |bindGroup| must not be `null`.
-                - |bindGroup|.{{GPUBindGroup/[[layout]]}} must be [=group-equivalent=] with |bindGroupLayout|.
+            - [$Validate encoder bind groups$](|encoder|, |encoder|.{{GPURenderEncoderBase/[[pipeline]]}})
+                must be `true`.
 
             - Let |pipelineDescriptor| be |encoder|.{{GPURenderEncoderBase/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.
             - For each {{GPUIndex32}} |slot| `0` to
                 |pipelineDescriptor|.{{GPURenderPipelineDescriptor/vertexState}}.{{GPUVertexStateDescriptor/vertexBuffers}}.length:
                 - |encoder|.{{GPURenderEncoderBase/[[vertex_buffers]]}}[|slot|] must not be `null`.
         </div>
-    1. Return `true`.
+
+    Otherwise return `true`.
 </div>
 
 <div algorithm>
     To determine if it's <dfn abstract-op>valid to draw indexed</dfn> with {{GPURenderEncoderBase}} |encoder|
     run the following steps:
 
-    1. If any of the following conditions are unsatisfied, return `false`:
+    If any of the following conditions are unsatisfied, return `false`:
         <div class=validusage>
             - It must be [$valid to draw$] with |encoder|.
+
             - |encoder|.{{GPURenderEncoderBase/[[index_buffer]]}} must not be `null`.
             - Let |stripIndexFormat| be |encoder|.{{GPURenderEncoderBase/[[pipeline]]}}.{{GPURenderPipeline/[[strip_index_format]]}}.
             - If |stripIndexFormat| is not `null`:
                 - |encoder|.{{GPURenderEncoderBase/[[index_format]]}} must be |stripIndexFormat|.
         </div>
-    1. Return `true`.
+
+    Otherwise return `true`.
 </div>
 
 ### Rasterization state ### {#render-pass-encoder-rasterization-state}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3355,6 +3355,10 @@ GPURenderPipeline includes GPUPipelineBase;
         The {{GPURenderPipelineDescriptor}} describing this pipeline.
 
         All optional fields of {{GPURenderPipelineDescriptor}} are defined.
+
+    : <dfn>\[[strip_index_format]]</dfn>, of type {{GPUIndexFormat}}?
+    ::
+        The format index data this pipeline requires, initially `null`.
 </dl>
 
 ### Creation ### {#render-pipeline-creation}
@@ -3499,6 +3503,10 @@ Issue: link to the semantics of SV_SampleIndex and SV_Coverage in WGSL spec.
                             1. Make |pipeline| [=invalid=].
 
                     1. Set |pipeline|.{{GPURenderPipeline/[[descriptor]]}} to |descriptor|.
+                    1. If |descriptor|.{{GPURenderPipelineDescriptor/primitiveTopology}} is
+                        {{GPUPrimitiveTopology/"line-strip"}} or {{GPUPrimitiveTopology/"triangle-strip"}}:
+                        1. Set |pipeline|.{{GPURenderPipeline/[[strip_index_format]]}} to
+                            |descriptor|.{{GPURenderPipelineDescriptor/vertexState}}.{{GPUVertexStateDescriptor/indexFormat}}.
 
                 </div>
             1. Return |pipeline|.
@@ -5529,8 +5537,7 @@ enum GPUStoreOp {
             <div class=device-timeline>
                 If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                 <div class=validusage>
-                    - It is [$valid to draw$] with |this|.
-                    - |this|.{{GPURenderEncoderBase/[[index_buffer]]}} is not `null`.
+                    - It is [$valid to draw indexed$] with |this|.
                 </div>
             </div>
         </div>
@@ -5609,8 +5616,7 @@ enum GPUStoreOp {
             <div class=device-timeline>
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
-                        - It is [$valid to draw$] with |this|.
-                        - |this|.{{GPURenderEncoderBase/[[index_buffer]]}} is not `null`.
+                        - It is [$valid to draw indexed$] with |this|.
                         - |indirectBuffer| is [$valid to use with$] |this|.
                         - |indirectBuffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDIRECT}}.
                         - |indirectOffset| + sizeof([=indirect drawIndexed parameters=]) &le;
@@ -5640,6 +5646,21 @@ enum GPUStoreOp {
             - For each {{GPUIndex32}} |slot| `0` to
                 |pipelineDescriptor|.{{GPURenderPipelineDescriptor/vertexState}}.{{GPUVertexStateDescriptor/vertexBuffers}}.length:
                 - |encoder|.{{GPURenderEncoderBase/[[vertex_buffers]]}}[|slot|] must not be `null`.
+        </div>
+    1. Return `true`.
+</div>
+
+<div algorithm>
+    To determine if it's <dfn abstract-op>valid to draw indexed</dfn> with {{GPURenderEncoderBase}} |encoder|
+    run the following steps:
+
+    1. If any of the following conditions are unsatisfied, return `false`:
+        <div class=validusage>
+            - It must be [$valid to draw$] with |encoder|.
+            - |encoder|.{{GPURenderEncoderBase/[[index_buffer]]}} must not be `null`.
+            - Let |stripIndexFormat| be |encoder|.{{GPURenderEncoderBase/[[pipeline]]}}.{{GPURenderPipeline/[[strip_index_format]]}}.
+            - If |stripIndexFormat| is not `null`:
+                - |encoder|.{{GPURenderEncoderBase/[[index_format]]}} must be |stripIndexFormat|.
         </div>
     1. Return `true`.
 </div>


### PR DESCRIPTION
Based on conversations with @kainino0x it sounds like there's some reshaping in progress for the pipeline creation (ie: #767) which may necessitate changes and additions here, but this should be a good place to start.

Required me to reformat `createPipeline()` in order to make the descriptor accessible as an internal slot, which also led my to realized that algorithm had the wrong return type. Oops!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/toji/gpuweb/pull/1010.html" title="Last updated on Aug 19, 2020, 9:32 PM UTC (48ec2ec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1010/9b3a658...toji:48ec2ec.html" title="Last updated on Aug 19, 2020, 9:32 PM UTC (48ec2ec)">Diff</a>