### PR TITLE
Rename bc6h-rgb-sfloat to bc6h-rgb-float

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2019,7 +2019,7 @@ enum GPUTextureFormat {
     "bc5-rg-unorm",
     "bc5-rg-snorm",
     "bc6h-rgb-ufloat",
-    "bc6h-rgb-sfloat",
+    "bc6h-rgb-float",
     "bc7-rgba-unorm",
     "bc7-rgba-unorm-srgb"
 };


### PR DESCRIPTION
For consistency (we don't use "sfloat" anywhere else).

The naming originally came from what D3D calls "SF16" (1+5+10 bits)
and "UF16" (0+5+11 bits):
https://docs.microsoft.com/en-us/windows/win32/direct3d11/bc6h-format
(Though I don't exactly understand what it means for components of BC6H
to have "bits" in the first place, since they're actually represented
in a compressed form anyway.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1011.html" title="Last updated on Aug 18, 2020, 9:16 PM UTC (019c2ee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1011/a86ffdf...kainino0x:019c2ee.html" title="Last updated on Aug 18, 2020, 9:16 PM UTC (019c2ee)">Diff</a>