### PR TITLE
Tweak requiredBytesInCopy, make bytesPerRow/rowsPerImage optional

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -636,7 +636,7 @@ We define <dfn dfn>subresource</dfn> to be either a whole buffer, or a [=texture
 
 <div algorithm="compatible usage list">
 Some [=internal usage=]s are compatible with others. A [=subresource=] can be in a state
-that combines multiple usages together. We consider a list |U| to be 
+that combines multiple usages together. We consider a list |U| to be
 a <dfn dfn>compatible usage list</dfn> if (and only if) it satisfies any of the following rules:
     - Each usage in |U| is [=internal usage/input=], [=internal usage/constant=], or [=internal usage/storage-read=].
     - Each usage in |U| is [=internal usage/storage=] or [=internal usage/storage-read=].
@@ -4053,8 +4053,8 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 <script type=idl>
 dictionary GPUTextureDataLayout {
     GPUSize64 offset = 0;
-    required GPUSize32 bytesPerRow;
-    GPUSize32 rowsPerImage = 0;
+    GPUSize32 bytesPerRow;
+    GPUSize32 rowsPerImage;
 };
 </script>
 
@@ -4077,11 +4077,15 @@ Issue: Define the exact copy semantics, by reference to common algorithms shared
     ::
         The stride, in bytes, between the beginning of each [=block row=] and the subsequent [=block row=].
 
+        Required if there are multiple [=block rows=] (i.e. the height or depth is more than one block).
+
     : <dfn>rowsPerImage</dfn>
     ::
         Number of [=block rows=] per single [=image=] of the [=texture=].
         {{GPUTextureDataLayout/rowsPerImage}} &times;
         {{GPUTextureDataLayout/bytesPerRow}} is the stride, in bytes, between the beginning of each [=image=] of data and the subsequent [=image=].
+
+        Required if there are multiple [=images=] (i.e. the depth is more than one).
 </dl>
 
 ### <dfn dictionary>GPUBufferCopyView</dfn> ### {#gpu-buffer-copy-view}
@@ -4255,28 +4259,29 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
 
     1. Fail if the following conditions are not satisfied:
         <div class=validusage>
-            - If |heightInBlocks| &gt; 1 or |copyExtent|.[=Extent3D/depth=] &gt; 1:
-                - |layout|.{{GPUTextureDataLayout/bytesPerRow}} must be
-                    greater than or equal to the number of |bytesInACompleteRow|.
-            - If |copyExtent|.[=Extent3D/depth=] &gt; 1 or
-                |layout|.{{GPUTextureDataLayout/rowsPerImage}} &gt; 0:
-                - |layout|.{{GPUTextureDataLayout/rowsPerImage}} must be
-                    greater than or equal to |heightInBlocks|.
-
-            These ensure the copy's subregions of the linear data do not overlap.
+            - If specified, |layout|.{{GPUTextureDataLayout/bytesPerRow}}
+                must be greater than or equal to |bytesInACompleteRow|.
+            - If specified, |layout|.{{GPUTextureDataLayout/rowsPerImage}}
+                must be greater than or equal to |heightInBlocks|.
+            - If |heightInBlocks| &gt; 1,
+                |layout|.{{GPUTextureDataLayout/bytesPerRow}} must be specified.
+            - If |copyExtent|.[=Extent3D/depth=] &gt; 1,
+                |layout|.{{GPUTextureDataLayout/bytesPerRow}} and
+                |layout|.{{GPUTextureDataLayout/rowsPerImage}} must be specified.
         </div>
 
-    1. If |widthInBlocks|, |heightInBlocks|, or |copyExtent|.[=Extent3D/depth=] is 0:
-            - Let |requiredBytesInCopy| be 0.
-        Otherwise:
-            - Let |bytesPerImage| be |layout|.{{GPUTextureDataLayout/bytesPerRow}}
-                &times; |layout|.{{GPUTextureDataLayout/rowsPerImage}}.
-            - Let |bytesInLastSlice| be
-                |layout|.{{GPUTextureDataLayout/bytesPerRow}} &times; (|heightInBlocks| &minus; 1) +
-                |widthInBlocks| &times; |blockSize|.
-            - Let |requiredBytesInCopy| be
-                |bytesPerImage| &times; (|copyExtent|.[=Extent3D/depth=] &minus; 1) +
-                |bytesInLastSlice|.
+    1. Let |requiredBytesInCopy| be |widthInBlocks| &times; |blockSize|.
+
+    1. If |heightInBlocks| &gt; 1, add
+        |layout|.{{GPUTextureDataLayout/bytesPerRow}} &times;
+        (|heightInBlocks| &minus; 1)
+        to |requiredBytesInCopy|.
+
+    1. If |copyExtent|.[=Extent3D/depth=] &gt; 1, add
+        |layout|.{{GPUTextureDataLayout/bytesPerRow}} &times;
+        |layout|.{{GPUTextureDataLayout/rowsPerImage}} &times;
+        (|copyExtent|.[=Extent3D/depth=] &minus; 1)
+        to |requiredBytesInCopy|.
 
     1. Fail if the following conditions are not satisfied:
         <div class=validusage>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4259,15 +4259,15 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
 
     1. Fail if the following conditions are not satisfied:
         <div class=validusage>
-            - If specified, |layout|.{{GPUTextureDataLayout/bytesPerRow}}
-                must be greater than or equal to |bytesInACompleteRow|.
-            - If specified, |layout|.{{GPUTextureDataLayout/rowsPerImage}}
-                must be greater than or equal to |heightInBlocks|.
             - If |heightInBlocks| &gt; 1,
                 |layout|.{{GPUTextureDataLayout/bytesPerRow}} must be specified.
             - If |copyExtent|.[=Extent3D/depth=] &gt; 1,
                 |layout|.{{GPUTextureDataLayout/bytesPerRow}} and
                 |layout|.{{GPUTextureDataLayout/rowsPerImage}} must be specified.
+            - If specified, |layout|.{{GPUTextureDataLayout/bytesPerRow}}
+                must be greater than or equal to |bytesInACompleteRow|.
+            - If specified, |layout|.{{GPUTextureDataLayout/rowsPerImage}}
+                must be greater than or equal to |heightInBlocks|.
         </div>
 
     1. Let |requiredBytesInCopy| be |widthInBlocks| &times; |blockSize|.


### PR DESCRIPTION
bytesPerRow and rowsPerImage are optional, but required if used.
Both values always have to make sense if they're provided (regardless of
whether they have an effect).

This shuffles the contents of this algorithm around again, to:
- Build requiredBytesInCopy incrementally.
- Remove the special-case for `width==0 || height==0 || depth==0`.
  Notably this changes the validation so that, e.g., for a `0x2x0` copy,
  `bytesPerRow * (2 - 1)` bytes are still required.

First proposed here: https://github.com/gpuweb/gpuweb/pull/1006#discussion_r471863797

Fixes #984


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1014.html" title="Last updated on Aug 20, 2020, 4:34 PM UTC (ca13f7d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1014/8acdb53...kainino0x:ca13f7d.html" title="Last updated on Aug 20, 2020, 4:34 PM UTC (ca13f7d)">Diff</a>