### PR TITLE
Add w3c.json file for W3C tracking purpose

### DIFF
--- a/w3c.json
+++ b/w3c.json
@@ -1,0 +1,5 @@
+{
+  "group": [96877, 125519],
+  "contacts": ["tidoust", "Kangz", "grorg"],
+  "repo-type": ["cg-report", "rec-track"]
+}


### PR DESCRIPTION
The file provides metadata about the repository so that W3C tools can process it automatically. See documentation at:
https://w3c.github.io/w3c.json.html

Group IDs are those of the CG and of the WG.