### PR TITLE
[wgsl] Add 'E' to float literal definition.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -73,7 +73,7 @@ TODO: What indicates the end of a line?  (E.g. A line ends at the next linefeed 
   <thead>
     <tr><td>Token<td>Definition
   </thead>
-  <tr><td>`FLOAT_LITERAL`<td>`(-?[0-9]*.[0-9]+ | -?[0-9]+.[0-9]*)(e(+|-)?[0-9]+)?`
+  <tr><td>`FLOAT_LITERAL`<td>`(-?[0-9]*.[0-9]+ | -?[0-9]+.[0-9]*)((e|E)(+|-)?[0-9]+)?`
   <tr><td>`INT_LITERAL`<td>`-?0x[0-9a-fA-F]+ | 0 | -?[1-9][0-9]*`
   <tr><td>`UINT_LITERAL`<td>`0x[0-9a-fA-F]+u | 0u | [1-9][0-9]*u`
   <tr><td>`STRING_LITERAL`<td>`"[^"]*"`


### PR DESCRIPTION
Allows a capital 'E' in scientific notation in float literals.