### PR TITLE
Updated validation rules for pipeline index formats

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3502,11 +3502,16 @@ Issue: link to the semantics of SV_SampleIndex and SV_Coverage in WGSL spec.
                             - If the output SV_Coverage semantics is [=statically used=] by
                                 |descriptor|.{{GPURenderPipelineDescriptor/fragmentStage}}:
                                 - |descriptor|.{{GPURenderPipelineDescriptor/alphaToCoverageEnabled}} is `false`.
-                            - If |descriptor|.{{GPURenderPipelineDescriptor/primitiveTopology}} is
-                                {{GPUPrimitiveTopology/"line-strip"}} or
-                                {{GPUPrimitiveTopology/"triangle-strip"}}:
-                                - |descriptor|.{{GPURenderPipelineDescriptor/vertexState}}.{{GPUVertexStateDescriptor/indexFormat}}
-                                    is not `undefined`.
+                            - If |descriptor|.{{GPURenderPipelineDescriptor/primitiveTopology}} is:
+                                <dl class="switch">
+                                    : {{GPUPrimitiveTopology/"line-strip"}} or
+                                        {{GPUPrimitiveTopology/"triangle-strip"}}
+                                    :: |descriptor|.{{GPURenderPipelineDescriptor/vertexState}}.{{GPUVertexStateDescriptor/indexFormat}}
+                                        is not `undefined`
+                                    : Otherwise
+                                    :: |descriptor|.{{GPURenderPipelineDescriptor/vertexState}}.{{GPUVertexStateDescriptor/indexFormat}}
+                                        is `undefined`
+                                </dl>
                         </div>
 
                         Then:
@@ -3765,7 +3770,7 @@ enum GPUInputStepMode {
 
 <script type=idl>
 dictionary GPUVertexStateDescriptor {
-    GPUIndexFormat indexFormat = "uint32";
+    GPUIndexFormat indexFormat;
     sequence<GPUVertexBufferLayoutDescriptor?> vertexBuffers = [];
 };
 </script>
@@ -5665,7 +5670,7 @@ enum GPUStoreOp {
 
             - |encoder|.{{GPURenderEncoderBase/[[index_buffer]]}} must not be `null`.
             - Let |stripIndexFormat| be |encoder|.{{GPURenderEncoderBase/[[pipeline]]}}.{{GPURenderPipeline/[[strip_index_format]]}}.
-            - If |stripIndexFormat| is not `null`:
+            - If |stripIndexFormat| is not `undefined`:
                 - |encoder|.{{GPURenderEncoderBase/[[index_format]]}} must be |stripIndexFormat|.
         </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -30,7 +30,7 @@ spec: webidl; urlPrefix: https://heycam.github.io/webidl/#
 
 <style>
 /* Make <dl> blocks more distinct from their surroundings. */
-dl {
+dl:not(.switch) {
     border-left: thin solid #f3e48c;
     padding-left: .5em;
 }
@@ -3402,13 +3402,6 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
     the optional depth-stencil attachment that is written by the [=pipeline=].
 - {{GPURenderPipelineDescriptor/vertexState}} configures
     the vertex fetch stage of the [=pipeline=].
-    - If {{GPURenderPipelineDescriptor/primitiveTopology}} is
-        {{GPUPrimitiveTopology/"line-strip"}} or
-        {{GPUPrimitiveTopology/"triangle-strip"}},
-        {{GPURenderPipelineDescriptor/vertexState}}.{{GPUVertexStateDescriptor/indexFormat}}
-        must be specified.
-
-        Otherwise, it must be unspecified.
 - {{GPURenderPipelineDescriptor/sampleCount}} is
     the number of MSAA samples that each attachment has to have.
 - {{GPURenderPipelineDescriptor/sampleMask}} is


### PR DESCRIPTION
Fixes #767, I believe.

Fixes one minor `null`/`undefined` mismatch, allows the pipeline `indexFormat` to be `undefined`, and specifies that strip topologies must have a defined index format while non-strip topologies must have an `undefined` index format.

BTW: Giving the "switch" statement in bikeshed a try here, let me know what you think of the formatting! I feel like it helps readability in this case.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/toji/gpuweb/pull/1022.html" title="Last updated on Aug 26, 2020, 11:20 PM UTC (f1c5e0f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1022/415fc87...toji:f1c5e0f.html" title="Last updated on Aug 26, 2020, 11:20 PM UTC (f1c5e0f)">Diff</a>