### PR TITLE
Texture Format Capabilities

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6715,7 +6715,7 @@ The "Filter" column specifies whether textures of this format can be sampled in 
         <th>{{GPUTextureUsage/OUTPUT_ATTACHMENT}}
         <th>{{GPUTextureUsage/STORAGE}}
         <th>Filter
-    <tr><td colspan=5>8-bit formats
+    <tr><td>8-bit formats<td  colspan=4>
     <tr>
         <td>{{GPUTextureFormat/r8unorm}}
         <td>{{GPUTextureComponentType/float}}
@@ -6740,7 +6740,7 @@ The "Filter" column specifies whether textures of this format can be sampled in 
         <td>&checkmark;
         <td>
         <td>
-    <tr><td colspan=5>16-bit formats
+    <tr><td>16-bit formats<td  colspan=4>
     <tr>
         <td>{{GPUTextureFormat/r16uint}}
         <td>{{GPUTextureComponentType/uint}}
@@ -6783,7 +6783,7 @@ The "Filter" column specifies whether textures of this format can be sampled in 
         <td>&checkmark;
         <td>
         <td>
-    <tr><td colspan=5>32-bit formats
+    <tr><td>32-bit formats<td  colspan=4>
     <tr>
         <td>{{GPUTextureFormat/r32uint}}
         <td>{{GPUTextureComponentType/uint}}
@@ -6818,6 +6818,66 @@ The "Filter" column specifies whether textures of this format can be sampled in 
         <td>{{GPUTextureFormat/rg16float}}
         <td>{{GPUTextureComponentType/float}}
         <td>&checkmark;
+        <td>&checkmark;
+        <td>&checkmark;
+    <tr>
+        <td>{{GPUTextureFormat/rgba8unorm}}
+        <td>{{GPUTextureComponentType/float}}
+        <td>&checkmark;
+        <td>&checkmark;
+        <td>&checkmark;
+    <tr>
+        <td>{{GPUTextureFormat/rgba8unorm-srgb}}
+        <td>{{GPUTextureComponentType/float}}
+        <td>&checkmark;
+        <td>
+        <td>&checkmark;
+    <tr>
+        <td>{{GPUTextureFormat/rgba8snorm}}
+        <td>{{GPUTextureComponentType/float}}
+        <td>
+        <td>&checkmark;
+        <td>&checkmark;
+    <tr>
+        <td>{{GPUTextureFormat/rgba8uint}}
+        <td>{{GPUTextureComponentType/uint}}
+        <td>&checkmark;
+        <td>&checkmark;
+        <td>
+    <tr>
+        <td>{{GPUTextureFormat/rgba8sint}}
+        <td>{{GPUTextureComponentType/sint}}
+        <td>&checkmark;
+        <td>&checkmark;
+        <td>
+    <tr>
+        <td>{{GPUTextureFormat/bgra8unorm}}
+        <td>{{GPUTextureComponentType/float}}
+        <td>&checkmark;
+        <td>
+        <td>&checkmark;
+    <tr>
+        <td>{{GPUTextureFormat/bgra8unorm-srgb}}
+        <td>{{GPUTextureComponentType/float}}
+        <td>&checkmark;
+        <td>
+        <td>&checkmark;
+    <tr>
+        <td>{{GPUTextureFormat/rgb10a2unorm}}
+        <td>{{GPUTextureComponentType/float}}
+        <td>&checkmark;
+        <td>
+        <td>&checkmark;
+    <tr>
+        <td>{{GPUTextureFormat/rgb10a2unorm}}
+        <td>{{GPUTextureComponentType/float}}
+        <td>&checkmark;
+        <td>
+        <td>&checkmark;
+    <tr>
+        <td>{{GPUTextureFormat/rg11b10ufloat}}
+        <td>{{GPUTextureComponentType/float}}
+        <td>&checkmark;
         <td>
         <td>&checkmark;
     <!-- more to come -->
@@ -6825,7 +6885,7 @@ The "Filter" column specifies whether textures of this format can be sampled in 
 
 ### Depth formats ### {#depth-formats}
 
-All depth formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, and {{GPUTextureUsage/OUTPUT_ATTACHMENT}} usage. However, the source/destination is restricted based on the format.
+All depth formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/SAMPLED}}, and {{GPUTextureUsage/OUTPUT_ATTACHMENT}} usage. However, the source/destination is restricted based on the format.
 
 None of the depth formats can be filtered.
 
@@ -6833,46 +6893,52 @@ None of the depth formats can be filtered.
     <tr>
         <th>Format
         <th>Aspect
-        <th>Copy depth from Buffer
-        <th>Copy depth into Buffer
+        <th>Copy aspect from Buffer
+        <th>Copy aspect into Buffer
         <th>Copy Texture
-        <th>{{GPUTextureUsage/SAMPLED}}
     <tr>
         <td>{{GPUTextureFormat/stencil8}}
         <td>stencil
-        <td colspan=2>&cross;
+        <td colspan=2>&checkmark;
         <td>{{GPUTextureFormat/stencil8}}
-        <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/depth16unorm}}
         <td>depth
         <td colspan=2>&checkmark;
         <td>{{GPUTextureFormat/depth16unorm}}
-        <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/depth24plus}}
         <td>depth
         <td colspan=2>&cross;
         <td>{{GPUTextureFormat/depth24plus}}, {{GPUTextureFormat/depth24plus-stencil8}}
-        <td>&cross;
     <tr>
         <td rowspan=2>{{GPUTextureFormat/depth24plus-stencil8}}
         <td>depth
         <td colspan=2>&cross;
         <td>{{GPUTextureFormat/depth24plus}} or {{GPUTextureFormat/depth24plus-stencil8}}
-        <td>&cross;
     <tr>
         <td>stencil
         <td colspan=2>&checkmark;
         <td>{{GPUTextureFormat/stencil8}}, {{GPUTextureFormat/depth24plus-stencil8}}, {{GPUTextureFormat/r8uint}}
-        <td>&cross;
     <tr>
         <td>{{GPUTextureFormat/depth32float}}
         <td>depth
         <td>&cross;
         <td>&checkmark;
         <td>{{GPUTextureFormat/depth32float}}
-        <td>&checkmark;
+</table>
+
+### Packed formats ### {#packed-formats}
+
+All packed texture formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, and {{GPUTextureUsage/SAMPLED}} usages. All of these formats have {{GPUTextureComponentType/float}} type and can be filtered on sampling.
+
+<table class='data'>
+    <tr>
+        <th>Format
+        <th>Block Size
+    <tr>
+        <td>{{GPUTextureFormat/rgb9e5ufloat}}
+        <td>1 &times; 1
 </table>
 
 ## Temporary usages of non-exported dfns ## {#temp-dfn-usages}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1115,7 +1115,6 @@ enum GPUExtensionName {
     "depth-clamping",
     "depth24unorm-stencil8",
     "depth32float-stencil8",
-    <!--"extended-storage-formats",-->
     "pipeline-statistics-query",
     "texture-compression-bc",
     "timestamp-query",
@@ -6753,11 +6752,7 @@ All plain color formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/
 
 Only formats with {{GPUTextureComponentType}} {{GPUTextureComponentType/"float"}} can be blended.
 
-The {{GPUTextureUsage/STORAGE|GPUTextureUsage.STORAGE}} column specifies the support for {{GPUTextureUsage/STORAGE}} usage in the core API. If there is a &star; mark, the atomic operations on the storage are also supported for this format.
-
-<!--
-If {{GPUExtensionName/"extended-storage-formats"}} extension is enabled on the device, all of the formats in this table can be created with {{GPUTextureUsage/STORAGE}} flag.
--->
+The {{GPUTextureUsage/STORAGE|GPUTextureUsage.STORAGE}} column specifies the support for {{GPUTextureUsage/STORAGE}} usage in the core API, including both {{GPUBindingType/readonly-storage-texture}} and {{GPUBindingType/writeonly-storage-texture}}. If there is a &star; mark, the atomic operations on the storage are also supported for this format.
 
 The "Filter" column specifies whether textures of this format can be sampled in shaders with a sampler having {{GPUFilterMode/linear}} filtering.
 
@@ -6769,7 +6764,7 @@ The "Filter" column specifies whether textures of this format can be sampled in 
             <th>{{GPUTextureUsage/STORAGE}}
             <th>Filter
     </thead>
-    <tr><th class=stickyheader>8-bit formats<th><th><th>
+    <tr><th class=stickyheader>8-bit per component<th><th><th>
     <tr>
         <td data-componenttype=norm>{{GPUTextureFormat/r8unorm}}
         <td>&checkmark;
@@ -6790,22 +6785,6 @@ The "Filter" column specifies whether textures of this format can be sampled in 
         <td>&checkmark;
         <td>
         <td>
-    <tr><th class=stickyheader>16-bit formats<th><th><th>
-    <tr>
-        <td data-componenttype=int>{{GPUTextureFormat/r16uint}}
-        <td>&checkmark;
-        <td>
-        <td>
-    <tr>
-        <td data-componenttype=int>{{GPUTextureFormat/r16sint}}
-        <td>&checkmark;
-        <td>
-        <td>
-    <tr>
-        <td data-componenttype=float>{{GPUTextureFormat/r16float}}
-        <td>&checkmark;
-        <td>
-        <td>&checkmark;
     <tr>
         <td data-componenttype=norm>{{GPUTextureFormat/rg8unorm}}
         <td>&checkmark;
@@ -6826,22 +6805,68 @@ The "Filter" column specifies whether textures of this format can be sampled in 
         <td>&checkmark;
         <td>
         <td>
-    <tr><th class=stickyheader>32-bit formats<th><th><th>
     <tr>
-        <td data-componenttype=int>{{GPUTextureFormat/r32uint}}
+        <td data-componenttype=norm>{{GPUTextureFormat/rgba8unorm}}
         <td>&checkmark;
-        <td>&checkmark;&star;
+        <td>&checkmark;
+        <td>&checkmark;
+    <tr>
+        <td data-componenttype=norm>{{GPUTextureFormat/rgba8unorm-srgb}}
+        <td>&checkmark;
+        <td>
+        <td>&checkmark;
+    <tr>
+        <td data-componenttype=norm>{{GPUTextureFormat/rgba8snorm}}
+        <td>
+        <td>&checkmark;
+        <td>&checkmark;
+    <tr>
+        <td data-componenttype=int>{{GPUTextureFormat/rgba8uint}}
+        <td>&checkmark;
+        <td>&checkmark;
         <td>
     <tr>
-        <td data-componenttype=int>{{GPUTextureFormat/r32sint}}
+        <td data-componenttype=int>{{GPUTextureFormat/rgba8sint}}
         <td>&checkmark;
-        <td>&checkmark;&star;
+        <td>&checkmark;
         <td>
     <tr>
-        <td data-componenttype=float>{{GPUTextureFormat/r32float}}
+        <td data-componenttype=norm>{{GPUTextureFormat/bgra8unorm}}
         <td>&checkmark;
+        <td>
         <td>&checkmark;
-        <td><!-- Metal -->
+    <tr>
+        <td data-componenttype=norm>{{GPUTextureFormat/bgra8unorm-srgb}}
+        <td>&checkmark;
+        <td>
+        <td>&checkmark;
+    <tr><th class=stickyheader><th><th><th>
+    <tr>
+        <td data-componenttype=norm>{{GPUTextureFormat/rgb10a2unorm}}
+        <td>&checkmark;
+        <td>
+        <td>&checkmark;
+    <tr>
+        <td data-componenttype=float>{{GPUTextureFormat/rg11b10ufloat}}
+        <td><!-- Vulkan -->
+        <td>
+        <td>&checkmark;
+    <tr><th class=stickyheader>16-bit per component<th><th><th>
+    <tr>
+        <td data-componenttype=int>{{GPUTextureFormat/r16uint}}
+        <td>&checkmark;
+        <td>
+        <td>
+    <tr>
+        <td data-componenttype=int>{{GPUTextureFormat/r16sint}}
+        <td>&checkmark;
+        <td>
+        <td>
+    <tr>
+        <td data-componenttype=float>{{GPUTextureFormat/r16float}}
+        <td>&checkmark;
+        <td>
+        <td>&checkmark;
     <tr>
         <td data-componenttype=int>{{GPUTextureFormat/rg16uint}}
         <td>&checkmark;
@@ -6858,67 +6883,6 @@ The "Filter" column specifies whether textures of this format can be sampled in 
         <td><!-- Vulkan -->
         <td>&checkmark;
     <tr>
-        <td data-componenttype=norm>{{GPUTextureFormat/rgba8unorm}}
-        <td>&checkmark;
-        <td>&checkmark;
-        <td>&checkmark;
-    <tr>
-        <td data-componenttype=norm>{{GPUTextureFormat/rgba8unorm-srgb}}
-        <td>&checkmark;
-        <td>
-        <td>&checkmark;
-    <tr>
-        <td data-componenttype=norm>{{GPUTextureFormat/rgba8snorm}}
-        <td>
-        <td><!-- D3D12 -->
-        <td>&checkmark;
-    <tr>
-        <td data-componenttype=int>{{GPUTextureFormat/rgba8uint}}
-        <td>&checkmark;
-        <td>&checkmark;
-        <td>
-    <tr>
-        <td data-componenttype=int>{{GPUTextureFormat/rgba8sint}}
-        <td>&checkmark;
-        <td>&checkmark;
-        <td>
-    <tr>
-        <td data-componenttype=norm>{{GPUTextureFormat/bgra8unorm}}
-        <td>&checkmark;
-        <td><!-- D3D12 -->
-        <td>&checkmark;
-    <tr>
-        <td data-componenttype=norm>{{GPUTextureFormat/bgra8unorm-srgb}}
-        <td>&checkmark;
-        <td>
-        <td>&checkmark;
-    <tr>
-        <td data-componenttype=norm>{{GPUTextureFormat/rgb10a2unorm}}
-        <td>&checkmark;
-        <td>
-        <td>&checkmark;
-    <tr>
-        <td data-componenttype=float>{{GPUTextureFormat/rg11b10ufloat}}
-        <td><!-- Vulkan -->
-        <td>
-        <td>&checkmark;
-    <tr><th class=stickyheader>64-bit formats<th><th><th>
-    <tr>
-        <td data-componenttype=int>{{GPUTextureFormat/rg32uint}}
-        <td>&checkmark;
-        <td><!-- D3D12 -->
-        <td>
-    <tr>
-        <td data-componenttype=int>{{GPUTextureFormat/rg32sint}}
-        <td>&checkmark;
-        <td><!-- D3D12 -->
-        <td>
-    <tr>
-        <td data-componenttype=float>{{GPUTextureFormat/rg32float}}
-        <td>&checkmark;
-        <td><!-- D3D12 -->
-        <td>
-    <tr>
         <td data-componenttype=int>{{GPUTextureFormat/rgba16uint}}
         <td>&checkmark;
         <td>&checkmark;
@@ -6933,7 +6897,37 @@ The "Filter" column specifies whether textures of this format can be sampled in 
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
-    <tr><th class=stickyheader>128-bit formats<th><th><th>
+    <tr><th class=stickyheader>32-bit per component<th><th><th>
+    <tr>
+        <td data-componenttype=int>{{GPUTextureFormat/r32uint}}
+        <td>&checkmark;
+        <td>&checkmark;&star;
+        <td>
+    <tr>
+        <td data-componenttype=int>{{GPUTextureFormat/r32sint}}
+        <td>&checkmark;
+        <td>&checkmark;&star;
+        <td>
+    <tr>
+        <td data-componenttype=float>{{GPUTextureFormat/r32float}}
+        <td>&checkmark;
+        <td>&checkmark;
+        <td><!-- Metal -->
+    <tr>
+        <td data-componenttype=int>{{GPUTextureFormat/rg32uint}}
+        <td>&checkmark;
+        <td>&checkmark;
+        <td>
+    <tr>
+        <td data-componenttype=int>{{GPUTextureFormat/rg32sint}}
+        <td>&checkmark;
+        <td>&checkmark;
+        <td>
+    <tr>
+        <td data-componenttype=float>{{GPUTextureFormat/rg32float}}
+        <td>&checkmark;
+        <td>&checkmark;
+        <td>
     <tr>
         <td data-componenttype=int>{{GPUTextureFormat/rgba32uint}}
         <td>&checkmark;

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6976,7 +6976,7 @@ None of the depth formats can be filtered.
         <td>depth
         <td colspan=2>&cross;
     <tr>
-        <td rowspan=2>{{GPUTextureFormat/depth24plus-stencil8}}
+        <td rowspan=2 style='white-space:nowrap'>{{GPUTextureFormat/depth24plus-stencil8}}
         <td rowspan=2>4 &minus; 8
         <td>depth
         <td colspan=2>&cross;

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1115,7 +1115,7 @@ enum GPUExtensionName {
     "depth-clamping",
     "depth24unorm-stencil8",
     "depth32float-stencil8",
-    "extended-storage-formats",
+    <!--"extended-storage-formats",-->
     "pipeline-statistics-query",
     "texture-compression-bc",
     "timestamp-query",
@@ -6753,7 +6753,11 @@ All plain color formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/
 
 Only formats with {{GPUTextureComponentType}} {{GPUTextureComponentType/"float"}} can be blended.
 
-The {{GPUTextureUsage/STORAGE|GPUTextureUsage.STORAGE}} column specifies the support for {{GPUTextureUsage/STORAGE}} usage in the core API. If {{GPUExtensionName/"extended-storage-formats"}} extension is enabled on the device, all of the formats in this table can be created with {{GPUTextureUsage/STORAGE}} flag.
+The {{GPUTextureUsage/STORAGE|GPUTextureUsage.STORAGE}} column specifies the support for {{GPUTextureUsage/STORAGE}} usage in the core API. If there is a &star; mark, the atomic operations on the storage are also supported for this format.
+
+<!--
+If {{GPUExtensionName/"extended-storage-formats"}} extension is enabled on the device, all of the formats in this table can be created with {{GPUTextureUsage/STORAGE}} flag.
+-->
 
 The "Filter" column specifies whether textures of this format can be sampled in shaders with a sampler having {{GPUFilterMode/linear}} filtering.
 
@@ -6826,12 +6830,12 @@ The "Filter" column specifies whether textures of this format can be sampled in 
     <tr>
         <td data-componenttype=int>{{GPUTextureFormat/r32uint}}
         <td>&checkmark;
-        <td>&checkmark;
+        <td>&checkmark;&star;
         <td>
     <tr>
         <td data-componenttype=int>{{GPUTextureFormat/r32sint}}
         <td>&checkmark;
-        <td>&checkmark;
+        <td>&checkmark;&star;
         <td>
     <tr>
         <td data-componenttype=float>{{GPUTextureFormat/r32float}}
@@ -6851,7 +6855,7 @@ The "Filter" column specifies whether textures of this format can be sampled in 
     <tr>
         <td data-componenttype=float>{{GPUTextureFormat/rg16float}}
         <td>&checkmark;
-        <td>&checkmark;
+        <td><!-- Vulkan -->
         <td>&checkmark;
     <tr>
         <td data-componenttype=norm>{{GPUTextureFormat/rgba8unorm}}
@@ -6866,7 +6870,7 @@ The "Filter" column specifies whether textures of this format can be sampled in 
     <tr>
         <td data-componenttype=norm>{{GPUTextureFormat/rgba8snorm}}
         <td>
-        <td>&checkmark;
+        <td><!-- D3D12 -->
         <td>&checkmark;
     <tr>
         <td data-componenttype=int>{{GPUTextureFormat/rgba8uint}}
@@ -6902,17 +6906,17 @@ The "Filter" column specifies whether textures of this format can be sampled in 
     <tr>
         <td data-componenttype=int>{{GPUTextureFormat/rg32uint}}
         <td>&checkmark;
-        <td>&checkmark;
+        <td><!-- D3D12 -->
         <td>
     <tr>
         <td data-componenttype=int>{{GPUTextureFormat/rg32sint}}
         <td>&checkmark;
-        <td>&checkmark;
+        <td><!-- D3D12 -->
         <td>
     <tr>
         <td data-componenttype=float>{{GPUTextureFormat/rg32float}}
         <td>&checkmark;
-        <td>&checkmark;
+        <td><!-- D3D12 -->
         <td>
     <tr>
         <td data-componenttype=int>{{GPUTextureFormat/rgba16uint}}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -136,10 +136,6 @@ div.content-timeline, div.device-timeline, div.queue-timeline {
 .algorithm .argumentdef>caption {
     display: none;
 }
-
-table.formats, table.formats tr th, table.formats tr td {
-    border: 1px thin gray;
-}
 </style>
 
 
@@ -6695,41 +6691,87 @@ An <dfn dfn>Extent3D</dfn> is a {{GPUExtent3D}}.
         or the third item of the sequence.
 </div>
 
-# Appendix # {#appendix}
+# Appendices # {#appendices}
 
 ## Texture Format Capabilities ## {#texture-format-caps}
 
-<table class='formats'>
+<table class='data'>
     <tr>
         <th>Format
         <th>Block
         <th>Component
         <th>Supported Usage
         <th>Filter
+    <tr><td>R8<td><td><td><td>
     <tr>
-        <td>{{GPUTextureFormat/"r8unorm"}}
+        <td>{{GPUTextureFormat/r8unorm}}
         <td>
-        <td>{{GPUTextureComponentType/"float"}}
+        <td>{{GPUTextureComponentType/float}}
         <td>{{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/SAMPLED}}, {{GPUTextureUsage/OUTPUT_ATTACHMENT}}
-        <td><span>&#10003;</span>
+        <td>&checkmark;
     <tr>
-        <td>{{GPUTextureFormat/"r8snorm"}}
+        <td>{{GPUTextureFormat/r8snorm}}
         <td>
-        <td>{{GPUTextureComponentType/"float"}}
+        <td>{{GPUTextureComponentType/float}}
         <td>{{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/SAMPLED}}
-        <td><span>&#10003;</span>
+        <td>&checkmark;
     <tr>
-        <td>{{GPUTextureFormat/"r8uint"}}
+        <td>{{GPUTextureFormat/r8uint}}
         <td>
-        <td>{{GPUTextureComponentType/"uint"}}
+        <td>{{GPUTextureComponentType/uint}}
         <td>{{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/SAMPLED}}, {{GPUTextureUsage/OUTPUT_ATTACHMENT}}
         <td>
     <tr>
-        <td>{{GPUTextureFormat/"r8sint"}}
+        <td>{{GPUTextureFormat/r8sint}}
         <td>
-        <td>{{GPUTextureComponentType/"sint"}}
+        <td>{{GPUTextureComponentType/sint}}
         <td>{{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/SAMPLED}}, {{GPUTextureUsage/OUTPUT_ATTACHMENT}}
         <td>
+    <tr><td>R16<td><td><td><td>
+    <tr>
+        <td>{{GPUTextureFormat/r16uint}}
+        <td>
+        <td>{{GPUTextureComponentType/uint}}
+        <td>{{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/SAMPLED}}, {{GPUTextureUsage/OUTPUT_ATTACHMENT}}
+        <td>
+    <tr>
+        <td>{{GPUTextureFormat/r16sint}}
+        <td>
+        <td>{{GPUTextureComponentType/sint}}
+        <td>{{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/SAMPLED}}, {{GPUTextureUsage/OUTPUT_ATTACHMENT}}
+        <td>
+    <tr>
+        <td>{{GPUTextureFormat/r16float}}
+        <td>
+        <td>{{GPUTextureComponentType/float}}
+        <td>{{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/SAMPLED}}, {{GPUTextureUsage/OUTPUT_ATTACHMENT}}
+        <td>&checkmark;
+    <tr><td>RG8<td><td><td><td>
+    <tr>
+        <td>{{GPUTextureFormat/rg8unorm}}
+        <td>
+        <td>{{GPUTextureComponentType/float}}
+        <td>{{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/SAMPLED}}, {{GPUTextureUsage/OUTPUT_ATTACHMENT}}
+        <td>&checkmark;
+    <tr>
+        <td>{{GPUTextureFormat/rg8snorm}}
+        <td>
+        <td>{{GPUTextureComponentType/float}}
+        <td>{{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/SAMPLED}}
+        <td>&checkmark;
+    <tr>
+        <td>{{GPUTextureFormat/rg8uint}}
+        <td>
+        <td>{{GPUTextureComponentType/uint}}
+        <td>{{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/SAMPLED}}, {{GPUTextureUsage/OUTPUT_ATTACHMENT}}
+        <td>
+    <tr>
+        <td>{{GPUTextureFormat/rg8sint}}
+        <td>
+        <td>{{GPUTextureComponentType/sint}}
+        <td>{{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/SAMPLED}}, {{GPUTextureUsage/OUTPUT_ATTACHMENT}}
+        <td>
+    <!-- 32-bit formats -->
 </table>
 
 Issue: document that blending is only supported for {{GPUTextureComponentType/"float"}}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -141,17 +141,35 @@ div.content-timeline, div.device-timeline, div.queue-timeline {
 /*
  * Extra style for texture format tables.
  */
-table.data tr.separator {
-    background: rgba(64, 64, 64, 0.2);
-}
-table.data tr.int {
+[data-componenttype="int"] {
     background: rgba(0, 0, 255, 0.05);
 }
-table.data tr.norm {
+[data-componenttype="norm"] {
     background: rgba(0, 255, 0, 0.05);
 }
-table.data tr.float {
+[data-componenttype="float"] {
     background: rgba(255, 0, 0, 0.05);
+}
+
+/*
+ * Add vertical lines to demarcate multi-column cells.
+ */
+table.data td[colspan] {
+    border-left-style: dotted;
+    border-right-style: dotted;
+}
+
+/*
+ * Sticky table headers.
+ */
+.overlarge {
+    /* position: sticky doesn't work inside scrollable elements. */
+    overflow-x: unset;
+}
+thead.stickyheader th, th.stickyheader {
+    position: sticky;
+    top: 0;
+    background: #f8f8f8;
 }
 </style>
 
@@ -6713,237 +6731,217 @@ An <dfn dfn>Extent3D</dfn> is a {{GPUExtent3D}}.
 
 ## Texture Format Capabilities ## {#texture-format-caps}
 
-Issue: add multisampling to these tables
+The {{GPUTextureComponentType}} of a texture format is expressed by the
+component type in the format name:
+
+<table class=data>
+    <thead>
+        <tr><th>Format component name <th>{{GPUTextureComponentType}}
+    </thead>
+    <tr><td data-componenttype=float>float <td>{{GPUTextureComponentType/float}}
+    <tr><td data-componenttype=norm>unorm <td>{{GPUTextureComponentType/float}}
+    <tr><td data-componenttype=norm>snorm <td>{{GPUTextureComponentType/float}}
+    <tr><td data-componenttype=int>uint <td>{{GPUTextureComponentType/uint}}
+    <tr><td data-componenttype=int>sint <td>{{GPUTextureComponentType/sint}}
+</table>
+
+Issue: Add multisampling to the tables below.
 
 ### Plain color formats ### {#plain-color-formats}
 
 All plain color formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, and {{GPUTextureUsage/SAMPLED}} usage.
 
-Only formats with {{GPUTextureComponentType/float|GPUTextureComponentType."float"}} can be blended.
+Only formats with {{GPUTextureComponentType}} {{GPUTextureComponentType/"float"}} can be blended.
 
 The {{GPUTextureUsage/STORAGE|GPUTextureUsage.STORAGE}} column specifies the support for {{GPUTextureUsage/STORAGE}} usage in the core API. If {{GPUExtensionName/"extended-storage-formats"}} extension is enabled on the device, all of the formats in this table can be created with {{GPUTextureUsage/STORAGE}} flag.
 
 The "Filter" column specifies whether textures of this format can be sampled in shaders with a sampler having {{GPUFilterMode/linear}} filtering.
 
 <table class='data'>
+    <thead class=stickyheader>
+        <tr>
+            <th>Format
+            <th>{{GPUTextureUsage/OUTPUT_ATTACHMENT}}
+            <th>{{GPUTextureUsage/STORAGE}}
+            <th>Filter
+    </thead>
+    <tr><th class=stickyheader>8-bit formats<th><th><th>
     <tr>
-        <th>Format
-        <th>Component
-        <th>{{GPUTextureUsage/OUTPUT_ATTACHMENT}}
-        <th>{{GPUTextureUsage/STORAGE}}
-        <th>Filter
-    <tr class='separator'><td>8-bit formats<td  colspan=4>
-    <tr class='norm'>
-        <td>{{GPUTextureFormat/r8unorm}}
-        <td>{{GPUTextureComponentType/float}}
+        <td data-componenttype=norm>{{GPUTextureFormat/r8unorm}}
         <td>&checkmark;
         <td>
         <td>&checkmark;
-    <tr class='norm'>
-        <td>{{GPUTextureFormat/r8snorm}}
-        <td>{{GPUTextureComponentType/float}}
+    <tr>
+        <td data-componenttype=norm>{{GPUTextureFormat/r8snorm}}
         <td>
         <td>
         <td>&checkmark;
-    <tr class='int'>
-        <td>{{GPUTextureFormat/r8uint}}
-        <td>{{GPUTextureComponentType/uint}}
+    <tr>
+        <td data-componenttype=int>{{GPUTextureFormat/r8uint}}
         <td>&checkmark;
         <td>
         <td>
-    <tr class='int'>
-        <td>{{GPUTextureFormat/r8sint}}
-        <td>{{GPUTextureComponentType/sint}}
+    <tr>
+        <td data-componenttype=int>{{GPUTextureFormat/r8sint}}
         <td>&checkmark;
         <td>
         <td>
-    <tr class='separator'><td>16-bit formats<td  colspan=4>
-    <tr class='int'>
-        <td>{{GPUTextureFormat/r16uint}}
-        <td>{{GPUTextureComponentType/uint}}
+    <tr><th class=stickyheader>16-bit formats<th><th><th>
+    <tr>
+        <td data-componenttype=int>{{GPUTextureFormat/r16uint}}
         <td>&checkmark;
         <td>
         <td>
-    <tr class='int'>
-        <td>{{GPUTextureFormat/r16sint}}
-        <td>{{GPUTextureComponentType/sint}}
+    <tr>
+        <td data-componenttype=int>{{GPUTextureFormat/r16sint}}
         <td>&checkmark;
         <td>
         <td>
-    <tr class='float'>
-        <td>{{GPUTextureFormat/r16float}}
-        <td>{{GPUTextureComponentType/float}}
+    <tr>
+        <td data-componenttype=float>{{GPUTextureFormat/r16float}}
         <td>&checkmark;
         <td>
         <td>&checkmark;
-    <tr class='norm'>
-        <td>{{GPUTextureFormat/rg8unorm}}
-        <td>{{GPUTextureComponentType/float}}
+    <tr>
+        <td data-componenttype=norm>{{GPUTextureFormat/rg8unorm}}
         <td>&checkmark;
         <td>
         <td>&checkmark;
-    <tr class='norm'>
-        <td>{{GPUTextureFormat/rg8snorm}}
-        <td>{{GPUTextureComponentType/float}}
+    <tr>
+        <td data-componenttype=norm>{{GPUTextureFormat/rg8snorm}}
         <td>
         <td>
         <td>&checkmark;
-    <tr class='int'>
-        <td>{{GPUTextureFormat/rg8uint}}
-        <td>{{GPUTextureComponentType/uint}}
+    <tr>
+        <td data-componenttype=int>{{GPUTextureFormat/rg8uint}}
         <td>&checkmark;
         <td>
         <td>
-    <tr class='int'>
-        <td>{{GPUTextureFormat/rg8sint}}
-        <td>{{GPUTextureComponentType/sint}}
+    <tr>
+        <td data-componenttype=int>{{GPUTextureFormat/rg8sint}}
         <td>&checkmark;
         <td>
         <td>
-    <tr class='separator'><td>32-bit formats<td  colspan=4>
-    <tr class='int'>
-        <td>{{GPUTextureFormat/r32uint}}
-        <td>{{GPUTextureComponentType/uint}}
+    <tr><th class=stickyheader>32-bit formats<th><th><th>
+    <tr>
+        <td data-componenttype=int>{{GPUTextureFormat/r32uint}}
         <td>&checkmark;
         <td>&checkmark;
         <td>
-    <tr class='int'>
-        <td>{{GPUTextureFormat/r32sint}}
-        <td>{{GPUTextureComponentType/sint}}
+    <tr>
+        <td data-componenttype=int>{{GPUTextureFormat/r32sint}}
         <td>&checkmark;
         <td>&checkmark;
         <td>
-    <tr class='float'>
-        <td>{{GPUTextureFormat/r32float}}
-        <td>{{GPUTextureComponentType/float}}
+    <tr>
+        <td data-componenttype=float>{{GPUTextureFormat/r32float}}
         <td>&checkmark;
         <td>&checkmark;
         <td><!-- Metal -->
-    <tr class='int'>
-        <td>{{GPUTextureFormat/rg16uint}}
-        <td>{{GPUTextureComponentType/uint}}
+    <tr>
+        <td data-componenttype=int>{{GPUTextureFormat/rg16uint}}
         <td>&checkmark;
         <td>
         <td>
-    <tr class='int'>
-        <td>{{GPUTextureFormat/rg16sint}}
-        <td>{{GPUTextureComponentType/sint}}
+    <tr>
+        <td data-componenttype=int>{{GPUTextureFormat/rg16sint}}
         <td>&checkmark;
         <td>
         <td>
-    <tr class='float'>
-        <td>{{GPUTextureFormat/rg16float}}
-        <td>{{GPUTextureComponentType/float}}
+    <tr>
+        <td data-componenttype=float>{{GPUTextureFormat/rg16float}}
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
-    <tr class='norm'>
-        <td>{{GPUTextureFormat/rgba8unorm}}
-        <td>{{GPUTextureComponentType/float}}
+    <tr>
+        <td data-componenttype=norm>{{GPUTextureFormat/rgba8unorm}}
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
-    <tr class='norm'>
-        <td>{{GPUTextureFormat/rgba8unorm-srgb}}
-        <td>{{GPUTextureComponentType/float}}
+    <tr>
+        <td data-componenttype=norm>{{GPUTextureFormat/rgba8unorm-srgb}}
         <td>&checkmark;
         <td>
         <td>&checkmark;
-    <tr class='norm'>
-        <td>{{GPUTextureFormat/rgba8snorm}}
-        <td>{{GPUTextureComponentType/float}}
+    <tr>
+        <td data-componenttype=norm>{{GPUTextureFormat/rgba8snorm}}
         <td>
         <td>&checkmark;
         <td>&checkmark;
-    <tr class='int'>
-        <td>{{GPUTextureFormat/rgba8uint}}
-        <td>{{GPUTextureComponentType/uint}}
+    <tr>
+        <td data-componenttype=int>{{GPUTextureFormat/rgba8uint}}
         <td>&checkmark;
         <td>&checkmark;
         <td>
-    <tr class='int'>
-        <td>{{GPUTextureFormat/rgba8sint}}
-        <td>{{GPUTextureComponentType/sint}}
+    <tr>
+        <td data-componenttype=int>{{GPUTextureFormat/rgba8sint}}
         <td>&checkmark;
         <td>&checkmark;
         <td>
-    <tr class='norm'>
-        <td>{{GPUTextureFormat/bgra8unorm}}
-        <td>{{GPUTextureComponentType/float}}
+    <tr>
+        <td data-componenttype=norm>{{GPUTextureFormat/bgra8unorm}}
         <td>&checkmark;
         <td><!-- D3D12 -->
         <td>&checkmark;
-    <tr class='norm'>
-        <td>{{GPUTextureFormat/bgra8unorm-srgb}}
-        <td>{{GPUTextureComponentType/float}}
+    <tr>
+        <td data-componenttype=norm>{{GPUTextureFormat/bgra8unorm-srgb}}
         <td>&checkmark;
         <td>
         <td>&checkmark;
-    <tr class='norm'>
-        <td>{{GPUTextureFormat/rgb10a2unorm}}
-        <td>{{GPUTextureComponentType/float}}
+    <tr>
+        <td data-componenttype=norm>{{GPUTextureFormat/rgb10a2unorm}}
         <td>&checkmark;
         <td>
         <td>&checkmark;
-    <tr class='float'>
-        <td>{{GPUTextureFormat/rg11b10ufloat}}
-        <td>{{GPUTextureComponentType/float}}
+    <tr>
+        <td data-componenttype=float>{{GPUTextureFormat/rg11b10ufloat}}
         <td>&checkmark;
         <td>
         <td>&checkmark;
-    <tr class='separator'><td>64-bit formats<td  colspan=4>
-    <tr class='int'>
-        <td>{{GPUTextureFormat/rg32uint}}
-        <td>{{GPUTextureComponentType/uint}}
+    <tr><th class=stickyheader>64-bit formats<th><th><th>
+    <tr>
+        <td data-componenttype=int>{{GPUTextureFormat/rg32uint}}
         <td>&checkmark;
         <td>&checkmark;
         <td>
-    <tr class='int'>
-        <td>{{GPUTextureFormat/rg32sint}}
-        <td>{{GPUTextureComponentType/sint}}
+    <tr>
+        <td data-componenttype=int>{{GPUTextureFormat/rg32sint}}
         <td>&checkmark;
         <td>&checkmark;
         <td>
-    <tr class='float'>
-        <td>{{GPUTextureFormat/rg32float}}
-        <td>{{GPUTextureComponentType/float}}
+    <tr>
+        <td data-componenttype=float>{{GPUTextureFormat/rg32float}}
         <td>&checkmark;
         <td>&checkmark;
         <td>
-    <tr class='int'>
-        <td>{{GPUTextureFormat/rgba16uint}}
-        <td>{{GPUTextureComponentType/uint}}
+    <tr>
+        <td data-componenttype=int>{{GPUTextureFormat/rgba16uint}}
         <td>&checkmark;
         <td>&checkmark;
         <td>
-    <tr class='int'>
-        <td>{{GPUTextureFormat/rgba16sint}}
-        <td>{{GPUTextureComponentType/sint}}
+    <tr>
+        <td data-componenttype=int>{{GPUTextureFormat/rgba16sint}}
         <td>&checkmark;
         <td>&checkmark;
         <td>
-    <tr class='float'>
-        <td>{{GPUTextureFormat/rgba16float}}
-        <td>{{GPUTextureComponentType/float}}
+    <tr>
+        <td data-componenttype=float>{{GPUTextureFormat/rgba16float}}
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
-    <tr class='separator'><td>128-bit formats<td  colspan=4>
-    <tr class='int'>
-        <td>{{GPUTextureFormat/rgba32uint}}
-        <td>{{GPUTextureComponentType/uint}}
-        <td>&checkmark;
-        <td>&checkmark;
-        <td>
-    <tr class='int'>
-        <td>{{GPUTextureFormat/rgba32sint}}
-        <td>{{GPUTextureComponentType/sint}}
+    <tr><th class=stickyheader>128-bit formats<th><th><th>
+    <tr>
+        <td data-componenttype=int>{{GPUTextureFormat/rgba32uint}}
         <td>&checkmark;
         <td>&checkmark;
         <td>
-    <tr class='float'>
-        <td>{{GPUTextureFormat/rgba32float}}
-        <td>{{GPUTextureComponentType/float}}
+    <tr>
+        <td data-componenttype=int>{{GPUTextureFormat/rgba32sint}}
+        <td>&checkmark;
+        <td>&checkmark;
+        <td>
+    <tr>
+        <td data-componenttype=float>{{GPUTextureFormat/rgba32float}}
         <td>&checkmark;
         <td>&checkmark;
         <td>
@@ -6956,12 +6954,14 @@ All depth formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_D
 None of the depth formats can be filtered.
 
 <table class='data'>
-    <tr>
-        <th>Format
-        <th>Bytes per texel
-        <th>Aspect
-        <th>Copy aspect from Buffer
-        <th>Copy aspect into Buffer
+    <thead>
+        <tr>
+            <th>Format
+            <th>Bytes per texel
+            <th>Aspect
+            <th>Copy aspect from Buffer
+            <th>Copy aspect into Buffer
+    </thead>
     <tr>
         <td>{{GPUTextureFormat/stencil8}}
         <td>1 &minus; 5
@@ -6989,8 +6989,8 @@ None of the depth formats can be filtered.
         <td>{{GPUTextureFormat/depth32float}}
         <td>4
         <td>depth
-        <td>&cross;
-        <td>&checkmark;
+        <td colspan=1>&cross;
+        <td colspan=1>&checkmark;
 </table>
 
 Copies between depth textures can only happen within the following sets of formats:
@@ -7007,53 +7007,55 @@ Issue: clarify if `depth24plus-stencil8` is copyable into `depth24plus` in Metal
 All packed texture formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, and {{GPUTextureUsage/SAMPLED}} usages. All of these formats have {{GPUTextureComponentType/float}} type and can be filtered on sampling.
 
 <table class='data'>
+    <thead class=stickyheader>
+        <tr>
+            <th>Format
+            <th>Bytes per block
+            <th>Block Size
+            <th>Extension
+    </thead>
     <tr>
-        <th>Format
-        <th>Bytes per block
-        <th>Block Size
-        <th>Extension
-    <tr class='float'>
-        <td>{{GPUTextureFormat/rgb9e5ufloat}}
+        <td data-componenttype=float>{{GPUTextureFormat/rgb9e5ufloat}}
         <td>4
         <td>1 &times; 1
         <td>
-    <tr class='norm'>
-        <td>{{GPUTextureFormat/bc1-rgba-unorm}}
+    <tr>
+        <td data-componenttype=norm>{{GPUTextureFormat/bc1-rgba-unorm}}
         <td rowspan=2>8
         <td rowspan=14>4 &times; 4
         <td rowspan=14>{{GPUExtensionName/texture-compression-bc}}
-    <tr class='norm'>
-        <td>{{GPUTextureFormat/bc1-rgba-unorm-srgb}}
-    <tr class='norm'>
-        <td>{{GPUTextureFormat/bc2-rgba-unorm}}
+    <tr>
+        <td data-componenttype=norm>{{GPUTextureFormat/bc1-rgba-unorm-srgb}}
+    <tr>
+        <td data-componenttype=norm>{{GPUTextureFormat/bc2-rgba-unorm}}
         <td rowspan=2>16
-    <tr class='norm'>
-        <td>{{GPUTextureFormat/bc2-rgba-unorm-srgb}}
-    <tr class='norm'>
-        <td>{{GPUTextureFormat/bc3-rgba-unorm}}
+    <tr>
+        <td data-componenttype=norm>{{GPUTextureFormat/bc2-rgba-unorm-srgb}}
+    <tr>
+        <td data-componenttype=norm>{{GPUTextureFormat/bc3-rgba-unorm}}
         <td rowspan=2>16
-    <tr class='norm'>
-        <td>{{GPUTextureFormat/bc3-rgba-unorm-srgb}}
-    <tr class='norm'>
-        <td>{{GPUTextureFormat/bc4-r-unorm}}
+    <tr>
+        <td data-componenttype=norm>{{GPUTextureFormat/bc3-rgba-unorm-srgb}}
+    <tr>
+        <td data-componenttype=norm>{{GPUTextureFormat/bc4-r-unorm}}
         <td rowspan=2>8
-    <tr class='norm'>
-        <td>{{GPUTextureFormat/bc4-r-snorm}}
-    <tr class='norm'>
-        <td>{{GPUTextureFormat/bc5-rg-unorm}}
+    <tr>
+        <td data-componenttype=norm>{{GPUTextureFormat/bc4-r-snorm}}
+    <tr>
+        <td data-componenttype=norm>{{GPUTextureFormat/bc5-rg-unorm}}
         <td rowspan=2>16
-    <tr class='norm'>
-        <td>{{GPUTextureFormat/bc5-rg-snorm}}
-    <tr class='float'>
-        <td>{{GPUTextureFormat/bc6h-rgb-ufloat}}
+    <tr>
+        <td data-componenttype=norm>{{GPUTextureFormat/bc5-rg-snorm}}
+    <tr>
+        <td data-componenttype=float>{{GPUTextureFormat/bc6h-rgb-ufloat}}
         <td rowspan=2>16
-    <tr class='float'>
-        <td>{{GPUTextureFormat/bc6h-rgb-float}}
-    <tr class='norm'>
-        <td>{{GPUTextureFormat/bc7-rgba-unorm}}
+    <tr>
+        <td data-componenttype=float>{{GPUTextureFormat/bc6h-rgb-float}}
+    <tr>
+        <td data-componenttype=norm>{{GPUTextureFormat/bc7-rgba-unorm}}
         <td rowspan=2>16
-    <tr class='norm'>
-        <td>{{GPUTextureFormat/bc7-rgba-unorm-srgb}}
+    <tr>
+        <td data-componenttype=norm>{{GPUTextureFormat/bc7-rgba-unorm-srgb}}
 </table>
 
 ## Temporary usages of non-exported dfns ## {#temp-dfn-usages}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6840,7 +6840,7 @@ The "Filter" column specifies whether textures of this format can be sampled in 
         <td>&checkmark;
         <td>
         <td>&checkmark;
-    <tr><th class=stickyheader><th><th><th>
+    <tr><th class=stickyheader>packed 32-bit formats<th><th><th>
     <tr>
         <td data-componenttype=norm>{{GPUTextureFormat/rgb10a2unorm}}
         <td>&checkmark;

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -126,6 +126,7 @@ div.content-timeline, div.device-timeline, div.queue-timeline {
 .algorithm .overlarge {
     margin-right: auto !important;
 }
+
 /*
  * The default algorithm style has a caption that doesn't suit this spec's
  * formatting particularly well. Hide it.
@@ -135,6 +136,22 @@ div.content-timeline, div.device-timeline, div.queue-timeline {
 }
 .algorithm .argumentdef>caption {
     display: none;
+}
+
+/*
+ * Extra style for texture format tables.
+ */
+table.data tr.separator {
+    background: rgba(64, 64, 64, 0.2);
+}
+table.data tr.int {
+    background: rgba(0, 0, 255, 0.05);
+}
+table.data tr.norm {
+    background: rgba(0, 255, 0, 0.05);
+}
+table.data tr.float {
+    background: rgba(255, 0, 0, 0.05);
 }
 </style>
 
@@ -6715,222 +6732,216 @@ The "Filter" column specifies whether textures of this format can be sampled in 
         <th>{{GPUTextureUsage/OUTPUT_ATTACHMENT}}
         <th>{{GPUTextureUsage/STORAGE}}
         <th>Filter
-    <tr><td>8-bit formats<td  colspan=4>
-    <tr>
+    <tr class='separator'><td>8-bit formats<td  colspan=4>
+    <tr class='norm'>
         <td>{{GPUTextureFormat/r8unorm}}
         <td>{{GPUTextureComponentType/float}}
         <td>&checkmark;
         <td>
         <td>&checkmark;
-    <tr>
+    <tr class='norm'>
         <td>{{GPUTextureFormat/r8snorm}}
         <td>{{GPUTextureComponentType/float}}
         <td>
         <td>
         <td>&checkmark;
-    <tr>
+    <tr class='int'>
         <td>{{GPUTextureFormat/r8uint}}
         <td>{{GPUTextureComponentType/uint}}
         <td>&checkmark;
         <td>
         <td>
-    <tr>
+    <tr class='int'>
         <td>{{GPUTextureFormat/r8sint}}
         <td>{{GPUTextureComponentType/sint}}
         <td>&checkmark;
         <td>
         <td>
-    <tr><td>16-bit formats<td  colspan=4>
-    <tr>
+    <tr class='separator'><td>16-bit formats<td  colspan=4>
+    <tr class='int'>
         <td>{{GPUTextureFormat/r16uint}}
         <td>{{GPUTextureComponentType/uint}}
         <td>&checkmark;
         <td>
         <td>
-    <tr>
+    <tr class='int'>
         <td>{{GPUTextureFormat/r16sint}}
         <td>{{GPUTextureComponentType/sint}}
         <td>&checkmark;
         <td>
         <td>
-    <tr>
+    <tr class='float'>
         <td>{{GPUTextureFormat/r16float}}
         <td>{{GPUTextureComponentType/float}}
         <td>&checkmark;
         <td>
         <td>&checkmark;
-    <tr>
+    <tr class='norm'>
         <td>{{GPUTextureFormat/rg8unorm}}
         <td>{{GPUTextureComponentType/float}}
         <td>&checkmark;
         <td>
         <td>&checkmark;
-    <tr>
+    <tr class='norm'>
         <td>{{GPUTextureFormat/rg8snorm}}
         <td>{{GPUTextureComponentType/float}}
         <td>
         <td>
         <td>&checkmark;
-    <tr>
+    <tr class='int'>
         <td>{{GPUTextureFormat/rg8uint}}
         <td>{{GPUTextureComponentType/uint}}
         <td>&checkmark;
         <td>
         <td>
-    <tr>
+    <tr class='int'>
         <td>{{GPUTextureFormat/rg8sint}}
         <td>{{GPUTextureComponentType/sint}}
         <td>&checkmark;
         <td>
         <td>
-    <tr><td>32-bit formats<td  colspan=4>
-    <tr>
+    <tr class='separator'><td>32-bit formats<td  colspan=4>
+    <tr class='int'>
         <td>{{GPUTextureFormat/r32uint}}
         <td>{{GPUTextureComponentType/uint}}
         <td>&checkmark;
         <td>&checkmark;
         <td>
-    <tr>
+    <tr class='int'>
         <td>{{GPUTextureFormat/r32sint}}
         <td>{{GPUTextureComponentType/sint}}
         <td>&checkmark;
         <td>&checkmark;
         <td>
-    <tr>
+    <tr class='float'>
         <td>{{GPUTextureFormat/r32float}}
         <td>{{GPUTextureComponentType/float}}
         <td>&checkmark;
         <td>&checkmark;
         <td><!-- Metal -->
-    <tr>
+    <tr class='int'>
         <td>{{GPUTextureFormat/rg16uint}}
         <td>{{GPUTextureComponentType/uint}}
         <td>&checkmark;
         <td>
         <td>
-    <tr>
+    <tr class='int'>
         <td>{{GPUTextureFormat/rg16sint}}
         <td>{{GPUTextureComponentType/sint}}
         <td>&checkmark;
         <td>
         <td>
-    <tr>
+    <tr class='float'>
         <td>{{GPUTextureFormat/rg16float}}
         <td>{{GPUTextureComponentType/float}}
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
-    <tr>
+    <tr class='norm'>
         <td>{{GPUTextureFormat/rgba8unorm}}
         <td>{{GPUTextureComponentType/float}}
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
-    <tr>
+    <tr class='norm'>
         <td>{{GPUTextureFormat/rgba8unorm-srgb}}
         <td>{{GPUTextureComponentType/float}}
         <td>&checkmark;
         <td>
         <td>&checkmark;
-    <tr>
+    <tr class='norm'>
         <td>{{GPUTextureFormat/rgba8snorm}}
         <td>{{GPUTextureComponentType/float}}
         <td>
         <td>&checkmark;
         <td>&checkmark;
-    <tr>
+    <tr class='int'>
         <td>{{GPUTextureFormat/rgba8uint}}
         <td>{{GPUTextureComponentType/uint}}
         <td>&checkmark;
         <td>&checkmark;
         <td>
-    <tr>
+    <tr class='int'>
         <td>{{GPUTextureFormat/rgba8sint}}
         <td>{{GPUTextureComponentType/sint}}
         <td>&checkmark;
         <td>&checkmark;
         <td>
-    <tr>
+    <tr class='norm'>
         <td>{{GPUTextureFormat/bgra8unorm}}
         <td>{{GPUTextureComponentType/float}}
         <td>&checkmark;
         <td><!-- D3D12 -->
         <td>&checkmark;
-    <tr>
+    <tr class='norm'>
         <td>{{GPUTextureFormat/bgra8unorm-srgb}}
         <td>{{GPUTextureComponentType/float}}
         <td>&checkmark;
         <td>
         <td>&checkmark;
-    <tr>
+    <tr class='norm'>
         <td>{{GPUTextureFormat/rgb10a2unorm}}
         <td>{{GPUTextureComponentType/float}}
         <td>&checkmark;
         <td>
         <td>&checkmark;
-    <tr>
-        <td>{{GPUTextureFormat/rgb10a2unorm}}
-        <td>{{GPUTextureComponentType/float}}
-        <td>&checkmark;
-        <td>
-        <td>&checkmark;
-    <tr>
+    <tr class='float'>
         <td>{{GPUTextureFormat/rg11b10ufloat}}
         <td>{{GPUTextureComponentType/float}}
         <td>&checkmark;
         <td>
         <td>&checkmark;
-    <tr><td>64-bit formats<td  colspan=4>
-    <tr>
+    <tr class='separator'><td>64-bit formats<td  colspan=4>
+    <tr class='int'>
         <td>{{GPUTextureFormat/rg32uint}}
         <td>{{GPUTextureComponentType/uint}}
         <td>&checkmark;
         <td>&checkmark;
         <td>
-    <tr>
+    <tr class='int'>
         <td>{{GPUTextureFormat/rg32sint}}
         <td>{{GPUTextureComponentType/sint}}
         <td>&checkmark;
         <td>&checkmark;
         <td>
-    <tr>
+    <tr class='float'>
         <td>{{GPUTextureFormat/rg32float}}
         <td>{{GPUTextureComponentType/float}}
         <td>&checkmark;
         <td>&checkmark;
         <td>
-    <tr>
+    <tr class='int'>
         <td>{{GPUTextureFormat/rgba16uint}}
         <td>{{GPUTextureComponentType/uint}}
         <td>&checkmark;
         <td>&checkmark;
         <td>
-    <tr>
+    <tr class='int'>
         <td>{{GPUTextureFormat/rgba16sint}}
         <td>{{GPUTextureComponentType/sint}}
         <td>&checkmark;
         <td>&checkmark;
         <td>
-    <tr>
+    <tr class='float'>
         <td>{{GPUTextureFormat/rgba16float}}
         <td>{{GPUTextureComponentType/float}}
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
-    <tr><td>128-bit formats<td  colspan=4>
-    <tr>
+    <tr class='separator'><td>128-bit formats<td  colspan=4>
+    <tr class='int'>
         <td>{{GPUTextureFormat/rgba32uint}}
         <td>{{GPUTextureComponentType/uint}}
         <td>&checkmark;
         <td>&checkmark;
         <td>
-    <tr>
+    <tr class='int'>
         <td>{{GPUTextureFormat/rgba32sint}}
         <td>{{GPUTextureComponentType/sint}}
         <td>&checkmark;
         <td>&checkmark;
         <td>
-    <tr>
+    <tr class='float'>
         <td>{{GPUTextureFormat/rgba32float}}
         <td>{{GPUTextureComponentType/float}}
         <td>&checkmark;
@@ -6938,13 +6949,11 @@ The "Filter" column specifies whether textures of this format can be sampled in 
         <td>
 </table>
 
-### Depth formats ### {#depth-formats}
+### Depth/stencil formats ### {#depth-formats}
 
 All depth formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/SAMPLED}}, and {{GPUTextureUsage/OUTPUT_ATTACHMENT}} usage. However, the source/destination is restricted based on the format.
 
 None of the depth formats can be filtered.
-
-Issue: clarify if `depth24plus-stencil8` is copyable into `depth24plus` in Metal.
 
 <table class='data'>
     <tr>
@@ -6953,43 +6962,45 @@ Issue: clarify if `depth24plus-stencil8` is copyable into `depth24plus` in Metal
         <th>Aspect
         <th>Copy aspect from Buffer
         <th>Copy aspect into Buffer
-        <th>Copy Texture
     <tr>
         <td>{{GPUTextureFormat/stencil8}}
         <td>1 &minus; 5
         <td>stencil
         <td colspan=2>&checkmark;
-        <td>{{GPUTextureFormat/stencil8}}
     <tr>
         <td>{{GPUTextureFormat/depth16unorm}}
         <td>2
         <td>depth
         <td colspan=2>&checkmark;
-        <td>{{GPUTextureFormat/depth16unorm}}
     <tr>
         <td>{{GPUTextureFormat/depth24plus}}
         <td>4
         <td>depth
         <td colspan=2>&cross;
-        <td>{{GPUTextureFormat/depth24plus}}, {{GPUTextureFormat/depth24plus-stencil8}}
     <tr>
         <td rowspan=2>{{GPUTextureFormat/depth24plus-stencil8}}
         <td rowspan=2>4 &minus; 8
         <td>depth
         <td colspan=2>&cross;
-        <td>{{GPUTextureFormat/depth24plus}} or {{GPUTextureFormat/depth24plus-stencil8}}
     <tr>
         <td>stencil
         <td colspan=2>&checkmark;
-        <td>{{GPUTextureFormat/stencil8}}, {{GPUTextureFormat/depth24plus-stencil8}}, {{GPUTextureFormat/r8uint}}
     <tr>
         <td>{{GPUTextureFormat/depth32float}}
         <td>4
         <td>depth
         <td>&cross;
         <td>&checkmark;
-        <td>{{GPUTextureFormat/depth32float}}
 </table>
+
+Copies between depth textures can only happen within the following sets of formats:
+  - {{GPUTextureFormat/stencil8}}, {{GPUTextureFormat/depth24plus-stencil8}} (stencil component), {{GPUTextureFormat/r8uint}}
+  - {{GPUTextureFormat/depth16unorm}}, {{GPUTextureFormat/r16uint}}
+  - {{GPUTextureFormat/depth24plus}}, {{GPUTextureFormat/depth24plus-stencil8}} (depth aspect)
+
+The {{GPUTextureFormat/depth32float}} format can only the destination if copied from another texture of the same format. It can also be a source of copies into {{GPUTextureFormat/r32float}}.
+
+Issue: clarify if `depth24plus-stencil8` is copyable into `depth24plus` in Metal.
 
 ### Packed formats ### {#packed-formats}
 
@@ -7001,47 +7012,47 @@ All packed texture formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsa
         <th>Bytes per block
         <th>Block Size
         <th>Extension
-    <tr>
+    <tr class='float'>
         <td>{{GPUTextureFormat/rgb9e5ufloat}}
         <td>4
         <td>1 &times; 1
         <td>
-    <tr>
+    <tr class='norm'>
         <td>{{GPUTextureFormat/bc1-rgba-unorm}}
         <td rowspan=2>8
         <td rowspan=14>4 &times; 4
         <td rowspan=14>{{GPUExtensionName/texture-compression-bc}}
-    <tr>
+    <tr class='norm'>
         <td>{{GPUTextureFormat/bc1-rgba-unorm-srgb}}
-    <tr>
+    <tr class='norm'>
         <td>{{GPUTextureFormat/bc2-rgba-unorm}}
         <td rowspan=2>16
-    <tr>
+    <tr class='norm'>
         <td>{{GPUTextureFormat/bc2-rgba-unorm-srgb}}
-    <tr>
+    <tr class='norm'>
         <td>{{GPUTextureFormat/bc3-rgba-unorm}}
         <td rowspan=2>16
-    <tr>
+    <tr class='norm'>
         <td>{{GPUTextureFormat/bc3-rgba-unorm-srgb}}
-    <tr>
+    <tr class='norm'>
         <td>{{GPUTextureFormat/bc4-r-unorm}}
         <td rowspan=2>8
-    <tr>
+    <tr class='norm'>
         <td>{{GPUTextureFormat/bc4-r-snorm}}
-    <tr>
+    <tr class='norm'>
         <td>{{GPUTextureFormat/bc5-rg-unorm}}
         <td rowspan=2>16
-    <tr>
+    <tr class='norm'>
         <td>{{GPUTextureFormat/bc5-rg-snorm}}
-    <tr>
+    <tr class='float'>
         <td>{{GPUTextureFormat/bc6h-rgb-ufloat}}
         <td rowspan=2>16
-    <tr>
+    <tr class='float'>
         <td>{{GPUTextureFormat/bc6h-rgb-float}}
-    <tr>
+    <tr class='norm'>
         <td>{{GPUTextureFormat/bc7-rgba-unorm}}
         <td rowspan=2>16
-    <tr>
+    <tr class='norm'>
         <td>{{GPUTextureFormat/bc7-rgba-unorm-srgb}}
 </table>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6695,86 +6695,116 @@ An <dfn dfn>Extent3D</dfn> is a {{GPUExtent3D}}.
 
 ## Texture Format Capabilities ## {#texture-format-caps}
 
+Issue: add multisampling to these tables
+
+### Plain color formats ### {#plain-color-formats}
+
+All plain color formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, and {{GPUTextureUsage/SAMPLED}} usage.
+
+Only formats with {{GPUTextureComponentType/float|GPUTextureComponentType."float"}} can be blended or filtered when sampling.
+
 <table class='data'>
     <tr>
         <th>Format
-        <th>Block
         <th>Component
-        <th>Supported Usage
-        <th>Filter
+        <th>{{GPUTextureUsage/OUTPUT_ATTACHMENT}}
     <tr><td>R8<td><td><td><td>
     <tr>
         <td>{{GPUTextureFormat/r8unorm}}
-        <td>
         <td>{{GPUTextureComponentType/float}}
-        <td>{{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/SAMPLED}}, {{GPUTextureUsage/OUTPUT_ATTACHMENT}}
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/r8snorm}}
-        <td>
         <td>{{GPUTextureComponentType/float}}
-        <td>{{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/SAMPLED}}
-        <td>&checkmark;
+        <td>
     <tr>
         <td>{{GPUTextureFormat/r8uint}}
-        <td>
         <td>{{GPUTextureComponentType/uint}}
-        <td>{{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/SAMPLED}}, {{GPUTextureUsage/OUTPUT_ATTACHMENT}}
-        <td>
+        <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/r8sint}}
-        <td>
         <td>{{GPUTextureComponentType/sint}}
-        <td>{{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/SAMPLED}}, {{GPUTextureUsage/OUTPUT_ATTACHMENT}}
-        <td>
+        <td>&checkmark;
     <tr><td>R16<td><td><td><td>
     <tr>
         <td>{{GPUTextureFormat/r16uint}}
-        <td>
         <td>{{GPUTextureComponentType/uint}}
-        <td>{{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/SAMPLED}}, {{GPUTextureUsage/OUTPUT_ATTACHMENT}}
-        <td>
+        <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/r16sint}}
-        <td>
         <td>{{GPUTextureComponentType/sint}}
-        <td>{{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/SAMPLED}}, {{GPUTextureUsage/OUTPUT_ATTACHMENT}}
+        <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/r16float}}
-        <td>
         <td>{{GPUTextureComponentType/float}}
-        <td>{{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/SAMPLED}}, {{GPUTextureUsage/OUTPUT_ATTACHMENT}}
         <td>&checkmark;
     <tr><td>RG8<td><td><td><td>
     <tr>
         <td>{{GPUTextureFormat/rg8unorm}}
-        <td>
         <td>{{GPUTextureComponentType/float}}
-        <td>{{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/SAMPLED}}, {{GPUTextureUsage/OUTPUT_ATTACHMENT}}
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rg8snorm}}
-        <td>
         <td>{{GPUTextureComponentType/float}}
-        <td>{{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/SAMPLED}}
-        <td>&checkmark;
+        <td>
     <tr>
         <td>{{GPUTextureFormat/rg8uint}}
-        <td>
         <td>{{GPUTextureComponentType/uint}}
-        <td>{{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/SAMPLED}}, {{GPUTextureUsage/OUTPUT_ATTACHMENT}}
-        <td>
+        <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rg8sint}}
-        <td>
         <td>{{GPUTextureComponentType/sint}}
-        <td>{{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/SAMPLED}}, {{GPUTextureUsage/OUTPUT_ATTACHMENT}}
-        <td>
+        <td>&checkmark;
     <!-- 32-bit formats -->
 </table>
 
-Issue: document that blending is only supported for {{GPUTextureComponentType/"float"}}
+### Depth formats ### {#depth-formats}
+
+All depth formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, and {{GPUTextureUsage/OUTPUT_ATTACHMENT}} usage. However, the source/destination is restricted based on the format.
+
+The stencil component of any format that has it can always be copied to and from buffers.
+
+None of the depth formats can be filtered.
+
+<table class='data'>
+    <tr>
+        <th>Format
+        <th>Copy depth from Buffer
+        <th>Copy depth into Buffer
+        <th>Copy Texture
+        <th>{{GPUTextureUsage/SAMPLED}}
+    <tr>
+        <td>{{GPUTextureFormat/stencil8}}
+        <td>
+        <td>
+        <td>{{GPUTextureFormat/stencil8}}
+        <td>&checkmark;
+    <tr>
+        <td>{{GPUTextureFormat/depth16unorm}}
+        <td>&checkmark;
+        <td>&checkmark;
+        <td>{{GPUTextureFormat/depth16unorm}}
+        <td>&checkmark;
+    <tr>
+        <td>{{GPUTextureFormat/depth24plus}}
+        <td>
+        <td>
+        <td>{{GPUTextureFormat/depth24plus}}, {{GPUTextureFormat/depth24plus-stencil8}}
+        <td>
+    <tr>
+        <td>{{GPUTextureFormat/depth24plus-stencil8}}
+        <td>
+        <td>
+        <td>{{GPUTextureFormat/depth24plus}} or {{GPUTextureFormat/depth24plus-stencil8}}
+        <td>
+    <tr>
+        <td>{{GPUTextureFormat/depth32float}}
+        <td>
+        <td>&checkmark;
+        <td>{{GPUTextureFormat/depth32float}}
+        <td>&checkmark;
+</table>
 
 ## Temporary usages of non-exported dfns ## {#temp-dfn-usages}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1118,7 +1118,7 @@ enum GPUExtensionName {
     "extended-storage-formats",
     "pipeline-statistics-query",
     "texture-compression-bc",
-    "timestamp-query"
+    "timestamp-query",
 };
 </script>
 
@@ -6895,7 +6895,7 @@ The "Filter" column specifies whether textures of this format can be sampled in 
         <td>&checkmark;
     <tr>
         <td data-componenttype=float>{{GPUTextureFormat/rg11b10ufloat}}
-        <td>&checkmark;
+        <td><!-- Vulkan -->
         <td>
         <td>&checkmark;
     <tr><th class=stickyheader>64-bit formats<th><th><th>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1080,9 +1080,10 @@ enum GPUExtensionName {
     "depth-clamping",
     "depth24unorm-stencil8",
     "depth32float-stencil8",
+    "extended-storage-formats",
     "pipeline-statistics-query",
     "texture-compression-bc",
-    "timestamp-query",
+    "timestamp-query"
 };
 </script>
 
@@ -6701,106 +6702,174 @@ Issue: add multisampling to these tables
 
 All plain color formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, and {{GPUTextureUsage/SAMPLED}} usage.
 
-Only formats with {{GPUTextureComponentType/float|GPUTextureComponentType."float"}} can be blended or filtered when sampling.
+Only formats with {{GPUTextureComponentType/float|GPUTextureComponentType."float"}} can be blended.
+
+The {{GPUTextureUsage/STORAGE|GPUTextureUsage.STORAGE}} column specifies the support for {{GPUTextureUsage/STORAGE}} usage in the core API. If {{GPUExtensionName/"extended-storage-formats"}} extension is enabled on the device, all of the formats in this table can be created with {{GPUTextureUsage/STORAGE}} flag.
+
+The "Filter" column specifies whether textures of this format can be sampled in shaders with a sampler having {{GPUFilterMode/linear}} filtering.
 
 <table class='data'>
     <tr>
         <th>Format
         <th>Component
         <th>{{GPUTextureUsage/OUTPUT_ATTACHMENT}}
-    <tr><td>R8<td><td><td><td>
+        <th>{{GPUTextureUsage/STORAGE}}
+        <th>Filter
+    <tr><td colspan=5>8-bit formats
     <tr>
         <td>{{GPUTextureFormat/r8unorm}}
         <td>{{GPUTextureComponentType/float}}
+        <td>&checkmark;
+        <td>
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/r8snorm}}
         <td>{{GPUTextureComponentType/float}}
         <td>
+        <td>
+        <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/r8uint}}
         <td>{{GPUTextureComponentType/uint}}
         <td>&checkmark;
+        <td>
+        <td>
     <tr>
         <td>{{GPUTextureFormat/r8sint}}
         <td>{{GPUTextureComponentType/sint}}
         <td>&checkmark;
-    <tr><td>R16<td><td><td><td>
+        <td>
+        <td>
+    <tr><td colspan=5>16-bit formats
     <tr>
         <td>{{GPUTextureFormat/r16uint}}
         <td>{{GPUTextureComponentType/uint}}
         <td>&checkmark;
+        <td>
+        <td>
     <tr>
         <td>{{GPUTextureFormat/r16sint}}
         <td>{{GPUTextureComponentType/sint}}
         <td>&checkmark;
         <td>
+        <td>
     <tr>
         <td>{{GPUTextureFormat/r16float}}
         <td>{{GPUTextureComponentType/float}}
         <td>&checkmark;
-    <tr><td>RG8<td><td><td><td>
+        <td>
+        <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rg8unorm}}
         <td>{{GPUTextureComponentType/float}}
+        <td>&checkmark;
+        <td>
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rg8snorm}}
         <td>{{GPUTextureComponentType/float}}
         <td>
+        <td>
+        <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rg8uint}}
         <td>{{GPUTextureComponentType/uint}}
         <td>&checkmark;
+        <td>
+        <td>
     <tr>
         <td>{{GPUTextureFormat/rg8sint}}
         <td>{{GPUTextureComponentType/sint}}
         <td>&checkmark;
-    <!-- 32-bit formats -->
+        <td>
+        <td>
+    <tr><td colspan=5>32-bit formats
+    <tr>
+        <td>{{GPUTextureFormat/r32uint}}
+        <td>{{GPUTextureComponentType/uint}}
+        <td>&checkmark;
+        <td>&checkmark;
+        <td>
+    <tr>
+        <td>{{GPUTextureFormat/r32sint}}
+        <td>{{GPUTextureComponentType/sint}}
+        <td>&checkmark;
+        <td>&checkmark;
+        <td>
+    <tr>
+        <td>{{GPUTextureFormat/r32float}}
+        <td>{{GPUTextureComponentType/float}}
+        <td>&checkmark;
+        <td>&checkmark;
+        <td>
+    <tr>
+        <td>{{GPUTextureFormat/rg16uint}}
+        <td>{{GPUTextureComponentType/uint}}
+        <td>&checkmark;
+        <td>
+        <td>
+    <tr>
+        <td>{{GPUTextureFormat/rg16sint}}
+        <td>{{GPUTextureComponentType/sint}}
+        <td>&checkmark;
+        <td>
+        <td>
+    <tr>
+        <td>{{GPUTextureFormat/rg16float}}
+        <td>{{GPUTextureComponentType/float}}
+        <td>&checkmark;
+        <td>
+        <td>&checkmark;
+    <!-- more to come -->
 </table>
 
 ### Depth formats ### {#depth-formats}
 
 All depth formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, and {{GPUTextureUsage/OUTPUT_ATTACHMENT}} usage. However, the source/destination is restricted based on the format.
 
-The stencil component of any format that has it can always be copied to and from buffers.
-
 None of the depth formats can be filtered.
 
 <table class='data'>
     <tr>
         <th>Format
+        <th>Aspect
         <th>Copy depth from Buffer
         <th>Copy depth into Buffer
         <th>Copy Texture
         <th>{{GPUTextureUsage/SAMPLED}}
     <tr>
         <td>{{GPUTextureFormat/stencil8}}
-        <td>
-        <td>
+        <td>stencil
+        <td colspan=2>&cross;
         <td>{{GPUTextureFormat/stencil8}}
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/depth16unorm}}
-        <td>&checkmark;
-        <td>&checkmark;
+        <td>depth
+        <td colspan=2>&checkmark;
         <td>{{GPUTextureFormat/depth16unorm}}
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/depth24plus}}
-        <td>
-        <td>
+        <td>depth
+        <td colspan=2>&cross;
         <td>{{GPUTextureFormat/depth24plus}}, {{GPUTextureFormat/depth24plus-stencil8}}
-        <td>
+        <td>&cross;
     <tr>
-        <td>{{GPUTextureFormat/depth24plus-stencil8}}
-        <td>
-        <td>
+        <td rowspan=2>{{GPUTextureFormat/depth24plus-stencil8}}
+        <td>depth
+        <td colspan=2>&cross;
         <td>{{GPUTextureFormat/depth24plus}} or {{GPUTextureFormat/depth24plus-stencil8}}
-        <td>
+        <td>&cross;
+    <tr>
+        <td>stencil
+        <td colspan=2>&checkmark;
+        <td>{{GPUTextureFormat/stencil8}}, {{GPUTextureFormat/depth24plus-stencil8}}, {{GPUTextureFormat/r8uint}}
+        <td>&cross;
     <tr>
         <td>{{GPUTextureFormat/depth32float}}
-        <td>
+        <td>depth
+        <td>&cross;
         <td>&checkmark;
         <td>{{GPUTextureFormat/depth32float}}
         <td>&checkmark;

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -136,6 +136,10 @@ div.content-timeline, div.device-timeline, div.queue-timeline {
 .algorithm .argumentdef>caption {
     display: none;
 }
+
+table.formats, table.formats tr th, table.formats tr td {
+    border: 1px thin gray;
+}
 </style>
 
 
@@ -6691,7 +6695,46 @@ An <dfn dfn>Extent3D</dfn> is a {{GPUExtent3D}}.
         or the third item of the sequence.
 </div>
 
-# Temporary usages of non-exported dfns # {#temp-dfn-usages}
+# Appendix # {#appendix}
+
+## Texture Format Capabilities ## {#texture-format-caps}
+
+<table class='formats'>
+    <tr>
+        <th>Format
+        <th>Block
+        <th>Component
+        <th>Supported Usage
+        <th>Filter
+    <tr>
+        <td>{{GPUTextureFormat/"r8unorm"}}
+        <td>
+        <td>{{GPUTextureComponentType/"float"}}
+        <td>{{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/SAMPLED}}, {{GPUTextureUsage/OUTPUT_ATTACHMENT}}
+        <td><span>&#10003;</span>
+    <tr>
+        <td>{{GPUTextureFormat/"r8snorm"}}
+        <td>
+        <td>{{GPUTextureComponentType/"float"}}
+        <td>{{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/SAMPLED}}
+        <td><span>&#10003;</span>
+    <tr>
+        <td>{{GPUTextureFormat/"r8uint"}}
+        <td>
+        <td>{{GPUTextureComponentType/"uint"}}
+        <td>{{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/SAMPLED}}, {{GPUTextureUsage/OUTPUT_ATTACHMENT}}
+        <td>
+    <tr>
+        <td>{{GPUTextureFormat/"r8sint"}}
+        <td>
+        <td>{{GPUTextureComponentType/"sint"}}
+        <td>{{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/SAMPLED}}, {{GPUTextureUsage/OUTPUT_ATTACHMENT}}
+        <td>
+</table>
+
+Issue: document that blending is only supported for {{GPUTextureComponentType/"float"}}
+
+## Temporary usages of non-exported dfns ## {#temp-dfn-usages}
 
 Eventually all of these should disappear but they are useful to avoid warning while building the specification.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6801,7 +6801,7 @@ The "Filter" column specifies whether textures of this format can be sampled in 
         <td>{{GPUTextureComponentType/float}}
         <td>&checkmark;
         <td>&checkmark;
-        <td>
+        <td><!-- Metal -->
     <tr>
         <td>{{GPUTextureFormat/rg16uint}}
         <td>{{GPUTextureComponentType/uint}}
@@ -6854,7 +6854,7 @@ The "Filter" column specifies whether textures of this format can be sampled in 
         <td>{{GPUTextureFormat/bgra8unorm}}
         <td>{{GPUTextureComponentType/float}}
         <td>&checkmark;
-        <td>
+        <td><!-- D3D12 -->
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/bgra8unorm-srgb}}
@@ -6880,7 +6880,62 @@ The "Filter" column specifies whether textures of this format can be sampled in 
         <td>&checkmark;
         <td>
         <td>&checkmark;
-    <!-- more to come -->
+    <tr><td>64-bit formats<td  colspan=4>
+    <tr>
+        <td>{{GPUTextureFormat/rg32uint}}
+        <td>{{GPUTextureComponentType/uint}}
+        <td>&checkmark;
+        <td>&checkmark;
+        <td>
+    <tr>
+        <td>{{GPUTextureFormat/rg32sint}}
+        <td>{{GPUTextureComponentType/sint}}
+        <td>&checkmark;
+        <td>&checkmark;
+        <td>
+    <tr>
+        <td>{{GPUTextureFormat/rg32float}}
+        <td>{{GPUTextureComponentType/float}}
+        <td>&checkmark;
+        <td>&checkmark;
+        <td>
+    <tr>
+        <td>{{GPUTextureFormat/rgba16uint}}
+        <td>{{GPUTextureComponentType/uint}}
+        <td>&checkmark;
+        <td>&checkmark;
+        <td>
+    <tr>
+        <td>{{GPUTextureFormat/rgba16sint}}
+        <td>{{GPUTextureComponentType/sint}}
+        <td>&checkmark;
+        <td>&checkmark;
+        <td>
+    <tr>
+        <td>{{GPUTextureFormat/rgba16float}}
+        <td>{{GPUTextureComponentType/float}}
+        <td>&checkmark;
+        <td>&checkmark;
+        <td>&checkmark;
+    <tr><td>128-bit formats<td  colspan=4>
+    <tr>
+        <td>{{GPUTextureFormat/rgba32uint}}
+        <td>{{GPUTextureComponentType/uint}}
+        <td>&checkmark;
+        <td>&checkmark;
+        <td>
+    <tr>
+        <td>{{GPUTextureFormat/rgba32sint}}
+        <td>{{GPUTextureComponentType/sint}}
+        <td>&checkmark;
+        <td>&checkmark;
+        <td>
+    <tr>
+        <td>{{GPUTextureFormat/rgba32float}}
+        <td>{{GPUTextureComponentType/float}}
+        <td>&checkmark;
+        <td>&checkmark;
+        <td>
 </table>
 
 ### Depth formats ### {#depth-formats}
@@ -6889,30 +6944,37 @@ All depth formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_D
 
 None of the depth formats can be filtered.
 
+Issue: clarify if `depth24plus-stencil8` is copyable into `depth24plus` in Metal.
+
 <table class='data'>
     <tr>
         <th>Format
+        <th>Bytes per texel
         <th>Aspect
         <th>Copy aspect from Buffer
         <th>Copy aspect into Buffer
         <th>Copy Texture
     <tr>
         <td>{{GPUTextureFormat/stencil8}}
+        <td>1 &minus; 5
         <td>stencil
         <td colspan=2>&checkmark;
         <td>{{GPUTextureFormat/stencil8}}
     <tr>
         <td>{{GPUTextureFormat/depth16unorm}}
+        <td>2
         <td>depth
         <td colspan=2>&checkmark;
         <td>{{GPUTextureFormat/depth16unorm}}
     <tr>
         <td>{{GPUTextureFormat/depth24plus}}
+        <td>4
         <td>depth
         <td colspan=2>&cross;
         <td>{{GPUTextureFormat/depth24plus}}, {{GPUTextureFormat/depth24plus-stencil8}}
     <tr>
         <td rowspan=2>{{GPUTextureFormat/depth24plus-stencil8}}
+        <td rowspan=2>4 &minus; 8
         <td>depth
         <td colspan=2>&cross;
         <td>{{GPUTextureFormat/depth24plus}} or {{GPUTextureFormat/depth24plus-stencil8}}
@@ -6922,6 +6984,7 @@ None of the depth formats can be filtered.
         <td>{{GPUTextureFormat/stencil8}}, {{GPUTextureFormat/depth24plus-stencil8}}, {{GPUTextureFormat/r8uint}}
     <tr>
         <td>{{GPUTextureFormat/depth32float}}
+        <td>4
         <td>depth
         <td>&cross;
         <td>&checkmark;
@@ -6935,10 +6998,51 @@ All packed texture formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsa
 <table class='data'>
     <tr>
         <th>Format
+        <th>Bytes per block
         <th>Block Size
+        <th>Extension
     <tr>
         <td>{{GPUTextureFormat/rgb9e5ufloat}}
+        <td>4
         <td>1 &times; 1
+        <td>
+    <tr>
+        <td>{{GPUTextureFormat/bc1-rgba-unorm}}
+        <td rowspan=2>8
+        <td rowspan=14>4 &times; 4
+        <td rowspan=14>{{GPUExtensionName/texture-compression-bc}}
+    <tr>
+        <td>{{GPUTextureFormat/bc1-rgba-unorm-srgb}}
+    <tr>
+        <td>{{GPUTextureFormat/bc2-rgba-unorm}}
+        <td rowspan=2>16
+    <tr>
+        <td>{{GPUTextureFormat/bc2-rgba-unorm-srgb}}
+    <tr>
+        <td>{{GPUTextureFormat/bc3-rgba-unorm}}
+        <td rowspan=2>16
+    <tr>
+        <td>{{GPUTextureFormat/bc3-rgba-unorm-srgb}}
+    <tr>
+        <td>{{GPUTextureFormat/bc4-r-unorm}}
+        <td rowspan=2>8
+    <tr>
+        <td>{{GPUTextureFormat/bc4-r-snorm}}
+    <tr>
+        <td>{{GPUTextureFormat/bc5-rg-unorm}}
+        <td rowspan=2>16
+    <tr>
+        <td>{{GPUTextureFormat/bc5-rg-snorm}}
+    <tr>
+        <td>{{GPUTextureFormat/bc6h-rgb-ufloat}}
+        <td rowspan=2>16
+    <tr>
+        <td>{{GPUTextureFormat/bc6h-rgb-float}}
+    <tr>
+        <td>{{GPUTextureFormat/bc7-rgba-unorm}}
+        <td rowspan=2>16
+    <tr>
+        <td>{{GPUTextureFormat/bc7-rgba-unorm-srgb}}
 </table>
 
 ## Temporary usages of non-exported dfns ## {#temp-dfn-usages}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6840,17 +6840,6 @@ The "Filter" column specifies whether textures of this format can be sampled in 
         <td>&checkmark;
         <td>
         <td>&checkmark;
-    <tr><th class=stickyheader>packed 32-bit formats<th><th><th>
-    <tr>
-        <td data-componenttype=norm>{{GPUTextureFormat/rgb10a2unorm}}
-        <td>&checkmark;
-        <td>
-        <td>&checkmark;
-    <tr>
-        <td data-componenttype=float>{{GPUTextureFormat/rg11b10ufloat}}
-        <td><!-- Vulkan -->
-        <td>
-        <td>&checkmark;
     <tr><th class=stickyheader>16-bit per component<th><th><th>
     <tr>
         <td data-componenttype=int>{{GPUTextureFormat/r16uint}}
@@ -6943,6 +6932,18 @@ The "Filter" column specifies whether textures of this format can be sampled in 
         <td>&checkmark;
         <td>&checkmark;
         <td>
+    <tr><th class=stickyheader>mixed component width<th><th><th>
+    <tr>
+        <td data-componenttype=norm>{{GPUTextureFormat/rgb10a2unorm}}
+        <td>&checkmark;
+        <td>
+        <td>&checkmark;
+    <tr>
+        <td data-componenttype=float>{{GPUTextureFormat/rg11b10ufloat}}
+        <td><!-- Vulkan -->
+        <td>
+        <td>&checkmark;
+    
 </table>
 
 ### Depth/stencil formats ### {#depth-formats}


### PR DESCRIPTION
I'd like to find a form of this table that we are happy with, before diving in and filling the data on all formats.

Relevant API tables:
- https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#features-required-format-support
- https://docs.microsoft.com/en-us/windows/win32/direct3ddxgi/hardware-support-for-direct3d-12-1-formats
- https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf

Intermediate table used to reason about the exposed features - https://github.com/gpuweb/gpuweb/wiki/Texture-format-capabilities


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/1027.html" title="Last updated on Sep 3, 2020, 3:44 AM UTC (d5da9a3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1027/cfd0734...kvark:d5da9a3.html" title="Last updated on Sep 3, 2020, 3:44 AM UTC (d5da9a3)">Diff</a>