### PR TITLE
Add a few special examples for resource usages tracking

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -704,7 +704,7 @@ This specification defines the following [=usage scopes=]:
   3. the whole {{GPURenderPassEncoder}}.
 
 <div class=note>
-    Resources that are used in state setting calls are always added as used resources in the containing [=usage scope=] as used resources.
+    Resources that are used in state setting calls are always added as used resources in the containing [=usage scope=].
     This means the following example resource usages **are** included in usage scope validation:
 
     - Resources used in every {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|GPUProgrammablePassEncoder.setBindGroup}}
@@ -713,7 +713,7 @@ This specification defines the following [=usage scopes=]:
         regardless of whether draw call depends on this buffer, or this buffer is shadowed by another 'set' call.
     - Index buffer used in every {{GPURenderEncoderBase/setIndexBuffer()|GPURenderEncoderBase.setIndexBuffer}}
         regardless of whether draw call depends on this buffer, or this buffer is shadowed by another 'set' call.
-    - Textures used as color attachments, resolve attachments or depth/stencil attachment in {{GPURenderPassDescriptor}} by {{GPUCommandEncoder/beginRenderPass()|GPUCommandEncoder.beginRenderPass}}
+    - Textures used as color attachments, resolve attachments or depth/stencil attachment in {{GPURenderPassDescriptor}} by {{GPUCommandEncoder/beginRenderPass()|GPUCommandEncoder.beginRenderPass()}}
         regardless of whether the shader actually depends on these attachments.
     - Resources used in bind group entries with visibility 0, or visible only to the the compute stage but used in a render pass or vice versa.
 </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -703,12 +703,20 @@ This specification defines the following [=usage scopes=]:
   2. an individual command on a {{GPUComputePassEncoder}}, such as {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|GPUProgrammablePassEncoder.setBindGroup}}.
   3. the whole {{GPURenderPassEncoder}}.
 
-Note: calling {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|GPUProgrammablePassEncoder.setBindGroup}}
-adds the {{GPUBindGroup/[[usedResources]]}} to the [=usage scope=]
-regardless of whether the shader or {{GPUPipelineLayout}} actually depends on these bindings.
-Similarly {{GPURenderEncoderBase/setIndexBuffer()|GPURenderEncoderBase.setIndexBuffer}}
-add the index buffer to the usage scope (as [=internal usage/input=])
-regardless of whether the indexed draw calls are used afterwards.
+<div class=note>
+  Resource usages are tracked at state-setting time, and they ignore binding {{GPUBindGroupLayoutEntry/visibility}}.
+  This means the following example usages within [=usage scopes=] **are** tracked and validated:
+
+  - Bind groups, vertex buffers or index buffers not used by any pipelines or any draw calls. For example,
+  calling {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|GPUProgrammablePassEncoder.setBindGroup}}
+  adds the {{GPUBindGroup/[[usedResources]]}} to the [=usage scope=]
+  regardless of whether the shader or {{GPUPipelineLayout}} actually depends on these bindings.
+  Similarly {{GPURenderEncoderBase/setIndexBuffer()|GPURenderEncoderBase.setIndexBuffer}}.
+  add the index buffer to the usage scope (as [=internal usage/input=])
+  regardless of whether the indexed draw calls are used afterwards.
+  - Bind groups, index buffers, or vertex buffers which are `set`, then shadowed by another `set` call.
+  - Bind group entries with visibility 0, or visible only to the the compute stage used in a render pass or vice versa.
+</div>
 
 The [=usage scopes=] are validated at {{GPUCommandEncoder/finish()|GPUCommandEncoder.finish}} time.
 The implementation performs the <dfn dfn>usage scope validation</dfn> by composing

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -704,18 +704,18 @@ This specification defines the following [=usage scopes=]:
   3. the whole {{GPURenderPassEncoder}}.
 
 <div class=note>
-  Resources that are used in state setting calls are always added to current [=usage scope=] as used resources.
-  This means the following example usages should be validated in current [=usage scope=]:
+    Resources that are used in state setting calls are always added as used resources in the containing [=usage scope=] as used resources.
+    This means the following example resource usages **are** included in usage scope validation:
 
-  - Resources used in every {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|GPUProgrammablePassEncoder.setBindGroup}}
-    regardless of whether the shader or {{GPUPipelineLayout}} actually depends on these bindings, or the bind group is shadowed by another 'set' call.
-  - Vertex buffer used in every {{GPURenderEncoderBase/setVertexBuffer()|GPURenderEncoderBase.setVertexBuffer}}
-    regardless of whether draw call depends on this buffer, or this buffer is shadowed by another 'set' call.
-  - Index buffer used in every {{GPURenderEncoderBase/setIndexBuffer()|GPURenderEncoderBase.setIndexBuffer}}
-    regardless of whether draw call depends on this buffer, or this buffer is shadowed by another 'set' call.
-  - Textures used as color attachments, resolve attachments or depth/stencil attachment in {{GPURenderPassDescriptor}} by {{GPUCommandEncoder/beginRenderPass()}}
-    regardless of whether the shader actually depends on these attachments.
-  - Resources used in bind group entries with visibility 0, or visible only to the the compute stage but used in a render pass or vice versa.
+    - Resources used in every {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|GPUProgrammablePassEncoder.setBindGroup}}
+        regardless of whether the shader or {{GPUPipelineLayout}} actually depends on these bindings, or the bind group is shadowed by another 'set' call.
+    - Vertex buffer used in every {{GPURenderEncoderBase/setVertexBuffer()|GPURenderEncoderBase.setVertexBuffer}}
+        regardless of whether draw call depends on this buffer, or this buffer is shadowed by another 'set' call.
+    - Index buffer used in every {{GPURenderEncoderBase/setIndexBuffer()|GPURenderEncoderBase.setIndexBuffer}}
+        regardless of whether draw call depends on this buffer, or this buffer is shadowed by another 'set' call.
+    - Textures used as color attachments, resolve attachments or depth/stencil attachment in {{GPURenderPassDescriptor}} by {{GPUCommandEncoder/beginRenderPass()|GPUCommandEncoder.beginRenderPass}}
+        regardless of whether the shader actually depends on these attachments.
+    - Resources used in bind group entries with visibility 0, or visible only to the the compute stage but used in a render pass or vice versa.
 </div>
 
 The [=usage scopes=] are validated at {{GPUCommandEncoder/finish()|GPUCommandEncoder.finish}} time.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -704,18 +704,18 @@ This specification defines the following [=usage scopes=]:
   3. the whole {{GPURenderPassEncoder}}.
 
 <div class=note>
-  Resource usages are tracked at state-setting time, and they ignore binding {{GPUBindGroupLayoutEntry/visibility}}.
-  This means the following example usages within [=usage scopes=] **are** tracked and validated:
+  Resources that are used in state setting calls are always added to current [=usage scope=] as used resources.
+  This means the following example usages should be validated in current [=usage scope=]:
 
-  - Bind groups, vertex buffers or index buffers not used by any pipelines or any draw calls. For example,
-  calling {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|GPUProgrammablePassEncoder.setBindGroup}}
-  adds the {{GPUBindGroup/[[usedResources]]}} to the [=usage scope=]
-  regardless of whether the shader or {{GPUPipelineLayout}} actually depends on these bindings.
-  Similarly {{GPURenderEncoderBase/setIndexBuffer()|GPURenderEncoderBase.setIndexBuffer}}.
-  add the index buffer to the usage scope (as [=internal usage/input=])
-  regardless of whether the indexed draw calls are used afterwards.
-  - Bind groups, index buffers, or vertex buffers which are `set`, then shadowed by another `set` call.
-  - Bind group entries with visibility 0, or visible only to the the compute stage used in a render pass or vice versa.
+  - Resources used in every {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|GPUProgrammablePassEncoder.setBindGroup}}
+  regardless of whether the shader or {{GPUPipelineLayout}} actually depends on these bindings, or the bind group is shadowed by another 'set' call.
+  - Vertex buffer used in every {{GPURenderEncoderBase/setVertexBuffer()|GPURenderEncoderBase.setVertexBuffer}}
+  regardless of whether draw call depends on this buffer, or this buffer is shadowed by another 'set' call.
+  - Index buffer used in every {{GPURenderEncoderBase/setIndexBuffer()|GPURenderEncoderBase.setIndexBuffer}}
+  regardless of whether draw call depends on this buffer, or this buffer is shadowed by another 'set' call.
+  - Textures used as color attachments, resolve attachments or depth/stencil attachment in {{GPURenderPassDescriptor}} by {{GPUCommandEncoder/beginRenderPass()}}.
+  regardless of whether the shader actually depends on these attachments.
+  - Resources used in bind group entries with visibility 0, or visible only to the the compute stage but used in a render pass or vice versa.
 </div>
 
 The [=usage scopes=] are validated at {{GPUCommandEncoder/finish()|GPUCommandEncoder.finish}} time.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -708,13 +708,13 @@ This specification defines the following [=usage scopes=]:
   This means the following example usages should be validated in current [=usage scope=]:
 
   - Resources used in every {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|GPUProgrammablePassEncoder.setBindGroup}}
-  regardless of whether the shader or {{GPUPipelineLayout}} actually depends on these bindings, or the bind group is shadowed by another 'set' call.
+    regardless of whether the shader or {{GPUPipelineLayout}} actually depends on these bindings, or the bind group is shadowed by another 'set' call.
   - Vertex buffer used in every {{GPURenderEncoderBase/setVertexBuffer()|GPURenderEncoderBase.setVertexBuffer}}
-  regardless of whether draw call depends on this buffer, or this buffer is shadowed by another 'set' call.
+    regardless of whether draw call depends on this buffer, or this buffer is shadowed by another 'set' call.
   - Index buffer used in every {{GPURenderEncoderBase/setIndexBuffer()|GPURenderEncoderBase.setIndexBuffer}}
-  regardless of whether draw call depends on this buffer, or this buffer is shadowed by another 'set' call.
-  - Textures used as color attachments, resolve attachments or depth/stencil attachment in {{GPURenderPassDescriptor}} by {{GPUCommandEncoder/beginRenderPass()}}.
-  regardless of whether the shader actually depends on these attachments.
+    regardless of whether draw call depends on this buffer, or this buffer is shadowed by another 'set' call.
+  - Textures used as color attachments, resolve attachments or depth/stencil attachment in {{GPURenderPassDescriptor}} by {{GPUCommandEncoder/beginRenderPass()}}
+    regardless of whether the shader actually depends on these attachments.
   - Resources used in bind group entries with visibility 0, or visible only to the the compute stage but used in a render pass or vice versa.
 </div>
 


### PR DESCRIPTION
For example, this change clarifies that shadowed usages/bindings and
invisible bindings should be tracked and validation.

This pr (and latest patch at #972) addressed feedback from CG meeting and spec editors' meeting on Monday. PTAL. Thank you!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Richard-Yunchao/gpuweb/pull/1030.html" title="Last updated on Sep 1, 2020, 5:39 PM UTC (e9fcbc6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1030/f9b2c4d...Richard-Yunchao:e9fcbc6.html" title="Last updated on Sep 1, 2020, 5:39 PM UTC (e9fcbc6)">Diff</a>