### PR TITLE
Adding access qualifiers for storage textures

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -570,19 +570,19 @@ type.
 ### Read-only Storage Texture Types ### {#texture-ro}
 <pre class='def'>
 `texture_ro_1d<type, image_storage_type>`
-  %1 = OpTypeImage %type 1D 0 0 0 2 image_storage_type
+  %1 = OpTypeImage %type 1D 0 0 0 2 image_storage_type ReadOnly
 
 `texture_ro_1d_array<type, image_storage_type>`
-  %1 = OpTypeImage %type 1D 0 1 0 2 image_storage_type
+  %1 = OpTypeImage %type 1D 0 1 0 2 image_storage_type ReadOnly
 
 `texture_ro_2d<type, image_storage_type>`
-  %1 = OpTypeImage %type 2D 0 0 0 2 image_storage_type
+  %1 = OpTypeImage %type 2D 0 0 0 2 image_storage_type ReadOnly
 
 `texture_ro_2d_array<type, image_storage_type>`
-  %1 = OpTypeImage %type 2D 0 1 0 2 image_storage_type
+  %1 = OpTypeImage %type 2D 0 1 0 2 image_storage_type ReadOnly
 
 `texture_ro_3d<type, image_storage_type>`
-  %1 = OpTypeImage %type 3D 0 0 0 2 image_storage_type
+  %1 = OpTypeImage %type 3D 0 0 0 2 image_storage_type ReadOnly
 </pre>
 * type must be `f32`, `i32` or `u32`
 * The parameterized type for the images is the type after conversion from reading.
@@ -592,19 +592,19 @@ type.
 ### Write-only Storage Texture Types ### {#texture-wo}
 <pre class='def'>
 `texture_wo_1d<image_storage_type>`
-  %1 = OpTypeImage %void 1D 0 0 0 2 image_storage_type
+  %1 = OpTypeImage %void 1D 0 0 0 2 image_storage_type WriteOnly
 
 `texture_wo_1d_array<image_storage_type>`
-  %1 = OpTypeImage %void 1D 0 1 0 2 image_storage_type
+  %1 = OpTypeImage %void 1D 0 1 0 2 image_storage_type WriteOnly
 
 `texture_wo_2d<image_storage_type>`
-  %1 = OpTypeImage %void 2D 0 0 0 2 image_storage_type
+  %1 = OpTypeImage %void 2D 0 0 0 2 image_storage_type WriteOnly
 
 `texture_wo_2d_array<image_storage_type>`
-  %1 = OpTypeImage %void 2D 0 1 0 2 image_storage_type
+  %1 = OpTypeImage %void 2D 0 1 0 2 image_storage_type WriteOnly
 
 `texture_wo_3d<image_storage_type>`
-  %1 = OpTypeImage %void 3D 0 0 0 2 image_storage_type
+  %1 = OpTypeImage %void 3D 0 0 0 2 image_storage_type WriteOnly
 </pre>
 
 ### Depth Texture Types ### {#texture-depth}


### PR DESCRIPTION
This is an optional parameter but should be specified for storage textures.