### PR TITLE
Better define createReady*Pipeline, plus misc cleanups

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1251,7 +1251,7 @@ To get a {{GPUDevice}}, use {{GPUAdapter/requestDevice()}}.
 interface GPUDevice : EventTarget {
     [SameObject] readonly attribute GPUAdapter adapter;
     readonly attribute FrozenArray<GPUExtensionName> extensions;
-    readonly attribute object limits;
+    readonly attribute GPULimits limits;
 
     [SameObject] readonly attribute GPUQueue defaultQueue;
 
@@ -1277,34 +1277,38 @@ interface GPUDevice : EventTarget {
 GPUDevice includes GPUObjectBase;
 </script>
 
-{{GPUDevice}} has:
+{{GPUDevice}} has the following attributes:
 
-  - These attributes:
-    <dl dfn-type=attribute dfn-for=GPUDevice>
-        : <dfn>adapter</dfn>
-        ::
-            The {{GPUAdapter}} from which this device was created.
+<dl dfn-type=attribute dfn-for=GPUDevice>
+    : <dfn>adapter</dfn>
+    ::
+        The {{GPUAdapter}} from which this device was created.
 
-        : <dfn>extensions</dfn>
-        ::
-            A sequence containing the {{GPUExtensionName}}s of the extensions
-            supported by the device (i.e. the ones with which it was created).
+    : <dfn>extensions</dfn>
+    ::
+        A sequence containing the {{GPUExtensionName}}s of the extensions
+        supported by the device (i.e. the ones with which it was created).
 
-        : <dfn>limits</dfn>
-        ::
-            A {{GPULimits}} object exposing the limits
-            supported by the device (i.e. the ones with which it was created).
-    </dl>
+    : <dfn>limits</dfn>
+    ::
+        A {{GPULimits}} object exposing the limits
+        supported by the device (i.e. the ones with which it was created).
 
-  - These internal slots:
-    <dl dfn-type=attribute dfn-for=GPUDevice>
-        : <dfn>\[[device]]</dfn>, of type [=device=], readonly
-        ::
-            The [=device=] that this {{GPUDevice}} refers to.
-    </dl>
+    : <dfn>defaultQueue</dfn>
+    ::
+        The default {{GPUQueue}} for this device.
+</dl>
 
-  - The methods listed in its WebIDL definition above,
-    which are defined elsewhere in this document.
+{{GPUDevice}} has the following internal slots:
+
+<dl dfn-type=attribute dfn-for=GPUDevice>
+    : <dfn>\[[device]]</dfn>, of type [=device=], readonly
+    ::
+        The [=device=] that this {{GPUDevice}} refers to.
+</dl>
+
+{{GPUDevice}} has the methods listed in its WebIDL definition above, which are defined elsewhere in
+this document.
 
 {{GPUDevice}} objects are [=serializable objects=].
 
@@ -1760,6 +1764,7 @@ GPUTexture includes GPUObjectBase;
 </script>
 
 {{GPUTexture}} has the following internal slots:
+
 <dl dfn-type=attribute dfn-for="GPUTexture">
     : <dfn>\[[textureSize]]</dfn> of type {{GPUExtent3D}}.
     ::
@@ -1860,7 +1865,7 @@ all previously submitted operations using it are complete.
         </div>
 </dl>
 
-## GPUTextureView ## {#gpu-textureview}
+## <dfn interface>GPUTextureView</dfn> ## {#gpu-textureview}
 
 <script type=idl>
 interface GPUTextureView {
@@ -1945,18 +1950,24 @@ enum GPUTextureAspect {
 };
 </script>
 
-### {{GPUTexture}}.<dfn method for=GPUTexture>createView(descriptor)</dfn> ### {#textureview-createview}
+<dl dfn-type=method dfn-for=GPUTexture>
+    : <dfn>createView(descriptor)</dfn>
+    ::
+        Creates a {{GPUTextureView}}.
 
-<div algorithm=GPUTexture.createView>
-    <strong>|this|:</strong> of type {{GPUTexture}}.
+    <div algorithm=GPUTexture.createView>
+        **Called on:** {{GPUTexture}} |this|.
 
-    **Arguments:**
-        - optional {{GPUTextureViewDescriptor}} |descriptor|
+        **Arguments:**
+        <pre class=argumentdef for="GPUTexture/createView(descriptor)">
+            |descriptor|: Description of the {{GPUTextureView}} to create.
+        </pre>
 
-    **Returns:** |view|, of type {{GPUTextureView}}.
+        **Returns:** |view|, of type {{GPUTextureView}}.
 
-    Issue: write definition. |this| |descriptor| |view|
-</div>
+        Issue: write definition. |this| |descriptor| |view|
+    </div>
+</dl>
 
 ## Texture Formats ## {#texture-formats}
 
@@ -2281,32 +2292,40 @@ enum GPUCompareFunction {
             |descriptor|.{{GPUSamplerDescriptor/lodMinClamp}}.
 </div>
 
-### {{GPUDevice}}.<dfn method for=GPUDevice>createSampler(descriptor)</dfn> ### {#sampler-createsampler}
+<dl dfn-type=method dfn-for=GPUDevice>
+    : <dfn>createSampler(descriptor)</dfn>
+    ::
+        Creates a {{GPUBindGroupLayout}}.
 
-<div algorithm=GPUDevice.createSampler>
-    **Arguments:**
-        - optional {{GPUSamplerDescriptor}} |descriptor| = {}
+    <div algorithm=GPUDevice.createSampler>
+        **Called on:** {{GPUDevice}} this.
 
-    **Returns:** {{GPUSampler}}
+        **Arguments:**
+        <pre class=argumentdef for="GPUDevice/createSampler(descriptor)">
+            |descriptor|: Description of the {{GPUSampler}} to create.
+        </pre>
 
-    1. Let |s| be a new {{GPUSampler}} object.
-    1. Set |s|.{{GPUSampler/[[descriptor]]}} to |descriptor|.
-    1. Set |s|.{{GPUSampler/[[compareEnable]]}} to false if the {{GPUSamplerDescriptor/compare}} attribute
-            of |s|.{{GPUSampler/[[descriptor]]}} is null or undefined. Otherwise, set it to true.
-    1. Return |s|.
+        **Returns:** {{GPUSampler}}
 
-    <div class=validusage dfn-for=GPUDevice.createSampler>
-        <dfn abstract-op>Valid Usage</dfn>
-        - If |descriptor| is not null or undefined:
-            - If [$validating GPUSamplerDescriptor$](this, |descriptor|) returns false:
-                1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
-                1. Create a new [=invalid=] {{GPUSampler}} and return the result.
+        1. Let |s| be a new {{GPUSampler}} object.
+        1. Set |s|.{{GPUSampler/[[descriptor]]}} to |descriptor|.
+        1. Set |s|.{{GPUSampler/[[compareEnable]]}} to false if the {{GPUSamplerDescriptor/compare}} attribute
+                of |s|.{{GPUSampler/[[descriptor]]}} is null or undefined. Otherwise, set it to true.
+        1. Return |s|.
+
+        <div class=validusage dfn-for=GPUDevice.createSampler>
+            <dfn abstract-op>Valid Usage</dfn>
+            - If |descriptor| is not null or undefined:
+                - If [$validating GPUSamplerDescriptor$](this, |descriptor|) returns false:
+                    1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
+                    1. Create a new [=invalid=] {{GPUSampler}} and return the result.
+        </div>
     </div>
-</div>
+</dl>
 
 # Resource Binding # {#bindings}
 
-## GPUBindGroupLayout ## {#bind-group-layout}
+## <dfn interface>GPUBindGroupLayout</dfn> ## {#bind-group-layout}
 
 A {{GPUBindGroupLayout}} defines the interface between a set of resources bound in a {{GPUBindGroup}} and their accessibility in shader stages.
 
@@ -2467,7 +2486,7 @@ enum GPUBindingType {
 };
 </script>
 
-A {{GPUBindGroupLayout}} object has the following methods:
+A {{GPUBindGroupLayout}} object has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUBindGroupLayout">
     : <dfn>\[[entryMap]]</dfn> of type map&lt;{{GPUSize32}}, {{GPUBindGroupLayoutEntry}}&gt.
@@ -2595,7 +2614,7 @@ if and only if, for any binding number |binding|, one of the following is true:
 
 If bind groups layouts are [=group-equivalent=] they can be interchangeably used in all contents.
 
-## GPUBindGroup ## {#gpu-bind-group}
+## <dfn interface>GPUBindGroup</dfn> ## {#gpu-bind-group}
 
 A {{GPUBindGroup}} defines a set of resources to be bound together in a group
     and how the resources are used in shader stages.
@@ -2807,7 +2826,7 @@ A {{GPUBindGroup}} object has the following internal slots:
         </div>
 </dl>
 
-## GPUPipelineLayout ## {#pipeline-layout}
+## <dfn interface>GPUPipelineLayout</dfn> ## {#pipeline-layout}
 
 A {{GPUPipelineLayout}} defines the mapping between resources of all {{GPUBindGroup}} objects set up during command encoding in {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup}}, and the shaders of the pipeline set by {{GPURenderEncoderBase/setPipeline(pipeline)|GPURenderEncoderBase.setPipeline}} or {{GPUComputePassEncoder/setPipeline(pipeline)|GPUComputePassEncoder.setPipeline}}.
 
@@ -2907,7 +2926,7 @@ if their internal {{GPUPipelineLayout/[[bindGroupLayouts]]}} sequences contain
 
 # Shader Modules # {#shader-modules}
 
-## GPUShaderModule ## {#shader-module}
+## <dfn interface>GPUShaderModule</dfn> ## {#shader-module}
 
 <script type=idl>
 enum GPUCompilationMessageType {
@@ -3024,6 +3043,7 @@ interface mixin GPUPipelineBase {
 </script>
 
 {{GPUPipelineBase}} has the following internal slots:
+
 <dl dfn-type=attribute dfn-for="GPUPipelineBase">
     : <dfn>\[[layout]]</dfn> of type `GPUPipelineLayout`.
     ::
@@ -3031,6 +3051,7 @@ interface mixin GPUPipelineBase {
 </dl>
 
 {{GPUPipelineBase}} has the following methods:
+
 <dl dfn-type=method dfn-for=GPUPipelineBase>
     : <dfn>getBindGroupLayout(index)</dfn>
     ::
@@ -3177,7 +3198,7 @@ has a default layout created and used instead.
 
 </div>
 
-### GPUProgrammableStageDescriptor ### {#GPUProgrammableStageDescriptor}
+### <dfn dictionary>GPUProgrammableStageDescriptor</dfn> ### {#GPUProgrammableStageDescriptor}
 
 <script type=idl>
 dictionary GPUProgrammableStageDescriptor {
@@ -3257,7 +3278,7 @@ A resource binding is considered to be <dfn dfn>statically used</dfn> by a shade
 if and only if it's reachable by the control flow graph of the shader module,
 starting at the entry point.
 
-## GPUComputePipeline ## {#compute-pipeline}
+## <dfn interface>GPUComputePipeline</dfn> ## {#compute-pipeline}
 
 A {{GPUComputePipeline}} is a kind of [=pipeline=] that controls the compute shader stage,
 and can be used in {{GPUComputePassEncoder}}.
@@ -3313,22 +3334,41 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
                 1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
                 1. Create a new [=invalid=] {{GPUComputePipeline}} and return the result.
         </div>
+
+    : <dfn>createReadyComputePipeline(descriptor)</dfn>
+    ::
+        Creates a {{GPUComputePipeline}}. The returned {{Promise}} resolves when the created pipeline
+        is ready to be used without additional delay.
+
+        If pipeline creation fails, the returned {{Promise}} resolves to an [=invalid=]
+        {{GPUComputePipeline}} object.
+
+        Note: Use of this method is preferred whenever possible, as it prevents blocking the
+        [=queue timeline=] work on pipeline compilation.
+
+        <div algorithm=GPUDevice.createReadyComputePipeline>
+            **Called on:** {{GPUDevice}} |this|.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPUDevice/createReadyComputePipeline(descriptor)">
+                |descriptor|: Description of the {{GPUComputePipeline}} to create.
+            </pre>
+
+            **Returns:** {{Promise}}&lt;{{GPUComputePipeline}}&gt;
+
+            1. Let |promise| be [=a new promise=].
+            1. Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
+                    1. Let |pipeline| be a new {{GPUComputePipeline}} created as if
+                        |this|.{{GPUDevice/createComputePipeline()}} was called with |descriptor|;
+
+                    1. When |pipeline| is ready to be used, [=resolve=] |promise| with |pipeline|.
+                </div>
+            1. Return |promise|.
+        </div>
 </dl>
 
-### {{GPUDevice/createReadyComputePipeline()}} ### {#device-createReadyComputePipeline}
-
-Same as {{GPUDevice/createComputePipeline()}}, but returns its result as a
-promise which doesn't resolve until the pipeline is ready to be used without
-additional delay.
-
-If pipeline creation fails, this resolves to an [=invalid=] {{GPUComputePipeline}} object.
-
-Issue: Define fully. (Probably by just calling directly into createComputePipeline.)
-
-Note: Use of this method is preferred whenever possible, as it prevents
-blocking [=queue timeline=] work on pipeline compilation.
-
-## GPURenderPipeline ## {#render-pipeline}
+## <dfn interface>GPURenderPipeline</dfn> ## {#render-pipeline}
 
 A {{GPURenderPipeline}} is a kind of [=pipeline=] that controls the vertex
 and fragment shader stages, and can be used in {{GPURenderPassEncoder}}
@@ -3537,20 +3577,39 @@ Issue: link to the semantics of SV_SampleIndex and SV_Coverage in WGSL spec.
 
             Issue: need description of the render states.
         </div>
+
+    : <dfn>createReadyRenderPipeline(descriptor)</dfn>
+    ::
+        Creates a {{GPURenderPipeline}}. The returned {{Promise}} resolves when the created pipeline
+        is ready to be used without additional delay.
+
+        If pipeline creation fails, the returned {{Promise}} resolves to an [=invalid=]
+        {{GPURenderPipeline}} object.
+
+        Note: Use of this method is preferred whenever possible, as it prevents blocking the
+        [=queue timeline=] work on pipeline compilation.
+
+        <div algorithm=GPUDevice.createReadyRenderPipeline>
+            **Called on:** {{GPUDevice}} |this|.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPUDevice/createReadyRenderPipeline(descriptor)">
+                |descriptor|: Description of the {{GPURenderPipeline}} to create.
+            </pre>
+
+            **Returns:** {{Promise}}&lt;{{GPURenderPipeline}}&gt;
+
+            1. Let |promise| be [=a new promise=].
+            1. Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
+                    1. Let |pipeline| be a new {{GPURenderPipeline}} created as if
+                        |this|.{{GPUDevice/createRenderPipeline()}} was called with |descriptor|;
+
+                    1. When |pipeline| is ready to be used, [=resolve=] |promise| with |pipeline|.
+                </div>
+            1. Return |promise|.
+        </div>
 </dl>
-
-### {{GPUDevice/createReadyRenderPipeline()}} ### {#device-createReadyRenderPipeline}
-
-Same as {{GPUDevice/createRenderPipeline()}}, but returns its result as a
-promise which doesn't resolve until the pipeline is ready to be used without
-additional delay.
-
-If pipeline creation fails, this resolves to an [=invalid=] {{GPURenderPipeline}} object.
-
-Issue: Define fully. (Probably by just calling directly into createRenderPipeline.)
-
-Note: Use of this method is preferred whenever possible, as it prevents
-blocking [=queue timeline=] work on pipeline compilation.
 
 ### Primitive Topology ### {#primitive-topology}
 
@@ -3880,7 +3939,7 @@ Issue(https://github.com/gpuweb/gpuweb/issues/693): add a limit to the number of
 
 # Command Buffers # {#command-buffers}
 
-## GPUCommandBuffer ## {#command-buffer}
+## <dfn interface>GPUCommandBuffer</dfn> ## {#command-buffer}
 
 <script type=idl>
 interface GPUCommandBuffer {
@@ -3927,7 +3986,7 @@ dictionary GPUCommandBufferDescriptor : GPUObjectDescriptorBase {
 
 # Command Encoding # {#command-encoding}
 
-## GPUCommandEncoder ## {#command-encoder}
+## <dfn interface>GPUCommandEncoder</dfn> ## {#command-encoder}
 
 <script type=idl>
 interface GPUCommandEncoder {
@@ -4926,7 +4985,7 @@ pass.
 
 # Compute Passes # {#compute-passes}
 
-## GPUComputePassEncoder ## {#compute-pass-encoder}
+## <dfn interface>GPUComputePassEncoder</dfn> ## {#compute-pass-encoder}
 
 <script type=idl>
 interface GPUComputePassEncoder {
@@ -5139,7 +5198,7 @@ called the compute pass encoder can no longer be used.
 
 # Render Passes # {#render-passes}
 
-## GPURenderPassEncoder ## {#render-pass-encoder}
+## <dfn interface>GPURenderPassEncoder</dfn> ## {#render-pass-encoder}
 
 <script type=idl>
 interface mixin GPURenderEncoderBase {
@@ -5957,7 +6016,7 @@ called the render pass encoder can no longer be used.
 
 # Bundles # {#bundles}
 
-## GPURenderBundle ## {#render-bundle}
+## <dfn interface>GPURenderBundle</dfn> ## {#render-bundle}
 
 <script type=idl>
 interface GPURenderBundle {
@@ -6226,7 +6285,7 @@ GPUQueue includes GPUObjectBase;
         </div>
 </dl>
 
-## GPUFence ## {#fence}
+## <dfn interface>GPUFence</dfn> ## {#fence}
 
 <script type=idl>
 interface GPUFence {
@@ -6326,7 +6385,7 @@ The completion of the fence and the value it completes with can be observed from
 Queries {#queries}
 ================
 
-## QuerySet ## {#queryset}
+## <dfn interface>GPUQuerySet</dfn> ## {#queryset}
 
 <script type=idl>
 interface GPUQuerySet {

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1251,7 +1251,7 @@ To get a {{GPUDevice}}, use {{GPUAdapter/requestDevice()}}.
 interface GPUDevice : EventTarget {
     [SameObject] readonly attribute GPUAdapter adapter;
     readonly attribute FrozenArray<GPUExtensionName> extensions;
-    readonly attribute GPULimits limits;
+    readonly attribute object limits;
 
     [SameObject] readonly attribute GPUQueue defaultQueue;
 


### PR DESCRIPTION
Apologies that this change is a little unfocused. The biggest change is that the two `createReady*Pipeline()` variants have real definitions now, but there was a bunch of other little cleanups and normalizations that I had in progress that got picked up along the way. I can separate them out if you want.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/toji/gpuweb/pull/1036.html" title="Last updated on Sep 1, 2020, 2:57 AM UTC (b86b8c0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1036/cfd0734...toji:b86b8c0.html" title="Last updated on Sep 1, 2020, 2:57 AM UTC (b86b8c0)">Diff</a>