### PR TITLE
Rewrite for clarity: switch selector is scalar integer

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1998,8 +1998,9 @@ case_body
 </pre>
 
 A switch statement transfers control to one of a set of case clauses, or to the `default` clause,
-depending the evaluation of a selector expression of a scalar integer type.
+depending on the evaluation of a selector expression.
 
+The selector expression must be of a scalar integer type.
 If the selector value equals a value in a case selector list, then control is transferred to
 the body of that case clause.
 If the selector value does not equal any of the case selector values, then control is


### PR DESCRIPTION
Break up a compound sentence into two, for clarity.