### PR TITLE
Update validation rule v-0008 to match the current spec

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2816,7 +2816,7 @@ the test name.
 * v-0005: Functions must be declared before use.
 * v-0006: Variables must be defined before use.
 * v-0007: Structures must be defined before use.
-* v-0008: All members of a switch must end with a return, break or fallthrough.
+* v-0008: switch statements must have exactly one default clause.
 * v-0009: break is only permitted in loop and switch constructs.
 * v-0010: continue only permitted in loop
 * v-0011: Global variable names must be unique


### PR DESCRIPTION
As 'break' is made implicit, this rule doesn't make sense anymore.

