### PR TITLE
Write WGSL "Shader Stages" section

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2316,6 +2316,8 @@ The type of the return value must match the return type of the function.
 
 ### Discard TODO ### {#discard-statement}
 
+The `discard` statement must only be used in a [=fragment=] shader stage.
+
 ## Function Call Statement TODO ## {#function-call-statement}
 
 <pre class='def'>
@@ -2451,7 +2453,48 @@ TODO: *This is a stub*
 
 # Entry Points TODO # {#entry-points}
 
+## Shader Stages ## {#shader-stages-sec}
+
+In WebGPU, a <dfn noexport>pipeline</dfn> is a unit of work executed on the GPU.
+There are two kinds of pipelines: GPUComputePipeline, and GPURenderPipeline.
+
+A <dfn noexport>GPUComputePipeline</dfn> runs a
+<dfn noexport>compute shader stage</dfn> over a logical
+grid of points with a controllable amount of parallelism,
+while reading and possibly updating buffer and image resources.
+
+A <dfn noexport>GPURenderPipeline</dfn> is a multi-stage process with
+two programmable stages among other fixed-function stages:
+
+* A <dfn noexport>vertex shader stage</dfn> maps input attributes for a single vertex into
+    output attributes for the vertex.
+* Fixed-function stages map vertices into graphic primitives (such as triangles)
+    which are then rasterized to produce fragments.
+* A <dfn noexport>fragment shader stage</dfn> processes each fragment,
+    possibly producing a fragment output.
+* Fixed-function stages consume a fragment output, possibly updating external state
+    such as color attachments and depth and stencil buffers.
+
+The WebGPU specification describes pipelines in greater detail.
+
+[SHORTNAME] defines three <dfn noexport>shader stages</dfn>, corresponding to the
+programmable parts of pipelines:
+
+* <dfn noexport>compute</dfn>
+* <dfn noexport>vertex</dfn>
+* <dfn noexport>fragment</dfn>
+
+<pre class='def'>
+pipeline_stage
+  : COMPUTE
+  | VERTEX
+  | FRAGMENT
+</pre>
+
+Each shader stage has its own set of features and constraints, described elsewhere.
+
 ## Entry point declaration TODO ## {#entry-point-decl}
+
 The `entry_point` declares an entry point into the module. The entry points may
 be forward declarations but the functions referenced must be declared in the
 file.
@@ -2466,11 +2509,6 @@ entry_point_decl:
    : ENTRY_POINT pipeline_stage EQUAL IDENT
    | ENTRY_POINT pipeline_stage AS STRING_LITERAL EQUAL IDENT
    | ENTRY_POINT pipeline_stage AS IDENT EQUAL IDENT
-
-pipeline_stage
-  : VERTEX
-  | FRAGMENT
-  | COMPUTE
 </pre>
 
 <div class='example' heading='Entry Point'>
@@ -2485,9 +2523,6 @@ pipeline_stage
        OpEntryPoint GLCompute %comp_main "comp_main" %gl_FragColor
   </xmp>
 </div>
-
-## Shader Stages TODO ## {#shader-stages}
-
 ## Shader Interface TODO ## {#shader-interface}
 
 ### Built-in variables TODO ### {#builtin-var-interface}


### PR DESCRIPTION
Move it before "Entry points"

The new section briefly introduces pipelines, and defines the three
shader stages.