### PR TITLE
Entry point

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2558,14 +2558,22 @@ Each shader stage has its own set of features and constraints, described elsewhe
 
 ## Entry point declaration TODO ## {#entry-point-decl}
 
-The `entry_point` declares an entry point into the module. The entry points may
-be forward declarations but the functions referenced must be declared in the
-file.
+An `entry_point` statement declares that a [SHORTNAME] function
+can be invoked as a particular [=shader stage=],
+and its external name.
 
-The input and output parameters to the entry point are determined by which
-global variables are used in the function and any called functions.
+The function is named after the `EQUAL` token.
+The function must be defined in the [SHORTNAME] module, either before or after
+the `entry_point` statement.
 
-The entry point function must be declared with no arguments and returning `void`.
+The external name is used to map to the entry point within a [SHORTNAME] module when
+configuring a pipeline.  There are three cases for determining the external name:
+
+* When there is no `AS` clause, then the external name is the same as the function name.
+* When there is an `AS STRING_LITERAL EQUAL IDENT` sub-clause, then the external name is the
+    content of the string literal provided.
+* When there is an `AS IDENT EQUAL IDENT` sub-clause, then the external name is the
+    identifer to the left of the EQUAL token.
 
 <pre class='def'>
 entry_point_decl:
@@ -2573,6 +2581,9 @@ entry_point_decl:
    | ENTRY_POINT pipeline_stage AS STRING_LITERAL EQUAL IDENT
    | ENTRY_POINT pipeline_stage AS IDENT EQUAL IDENT
 </pre>
+
+An entry point function must be declared with no arguments,
+and its return type must be [=void=].
 
 <div class='example' heading='Entry Point'>
   <xmp>
@@ -2586,11 +2597,25 @@ entry_point_decl:
        OpEntryPoint GLCompute %comp_main "comp_main" %gl_FragColor
   </xmp>
 </div>
+
+The set of <dfn noexport>functions in a shader stage</dfn> is the union of:
+
+* The entry point function for the stage.
+* The targets of function calls from within the body of a function
+    in the shader stage, whether or not that call is executed.
+
+The union is applied recursively, and stabilizes to a finite set.
+
 ## Shader Interface TODO ## {#shader-interface}
 
 ### Built-in variables TODO ### {#builtin-var-interface}
 
 ### Pipeline Input and Output Interface TODO ### {#pipeline-inputs-outputs}
+
+TODO(dneto): The following sentence was moved from elsewhere. Expand this.
+
+The input and output parameters to the entry point are determined by which
+global variables are used in the function and any called functions.
 
 #### Built-in inputs and outputs TODO #### {#builtin-inputs-outputs}
 TODO: *Stub*. Forward reference to list of builtin variables.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2604,7 +2604,8 @@ The set of <dfn noexport>functions in a shader stage</dfn> is the union of:
 * The targets of function calls from within the body of a function
     in the shader stage, whether or not that call is executed.
 
-The union is applied recursively, and stabilizes to a finite set.
+The union is applied repeatedly until it stabilizes.
+It will stabilize in a finite number of steps.
 
 ## Shader Interface TODO ## {#shader-interface}
 


### PR DESCRIPTION
    Elaborate 'entry_point'
    
    - mention the shader stage from the previous section
    - describe how to get the external name
    
    - describe the set of functions "in" a shader stage, so that
      elsewhere we can constrain features (e.g. discared is only usable
      in a fragment shader)

This builds on #1040 
 