### PR TITLE
Entry point fix, describe workgroups

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2661,26 +2661,33 @@ It will stabilize in a finite number of steps.
 
 <pre class='def'>
 entry_point_decoration
-  : WORKGROUP_SIZE PAREN_LEFT INT_LITERAL COMMA
-                              INT_LITERAL COMMA
-                              INT_LITERAL PAREN_RIGHT
+  : WORKGROUP_SIZE INT_LITERAL (INT_LITERAL INT_LITERAL?)?
 </pre>
 
 : <dfn noexport>workgroup_size</dfn>
 :: The `workgroup_size` attribute specifies the x, y, and z dimensions of the [=workgroup=]
     for a [=compute=] shader.
-    This attribute must only be used with a [=compute shader stage=] entry point.
+    The size in the x dimension is provided by the first literal.
+    The size in the y dimension is provided by the second literal, when present, and otherwise
+    is assumed to be 1.
+    The size in the z dimension is provided by the third literal, when present, and otherwise
+    is assumed to be 1.
     Each dimension size must be at least 1 and at most an upper bound specified by the WebGPU API.
+    This attribute must only be used with a [=compute shader stage=] entry point.
 
 ISSUE: Can we query upper bounds on workgroup size dimensions?  Is it independent of the shader, or
   a property to be queried after creating the shader module?
 
 <div class='example' heading='workgroup_size Attribute'>
   <xmp>
-    [[ workgroup_size(8,1,1) ]]
-    compute fn sorter() -> void { }
+    [[ workgroup_size 8 1 1 ]]
+    fn sorter() -> void { }
        OpEntryPoint GLCompute %sorter "sorter"
        OpExecutionMode %sorter LocalSize 8 1 1
+
+    [[ workgroup_size 8 ]]
+    compute fn reverser() -> void { }
+       OpExecutionMode %reverser LocalSize 8 1 1
   </xmp>
 </div>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -33,11 +33,11 @@ thead {
 <div class='example'>
   <xmp highlight='rust'>
     [[location 0]] var<out> gl_FragColor : vec4<f32>;
+    [[stage fragment]]
     fn main() -> void {
         gl_FragColor = vec4<f32>(0.4, 0.4, 0.8, 1.0);
         return;
     }
-    entry_point fragment = main;
   </xmp>
 </div>
 
@@ -2510,7 +2510,10 @@ module.
 
 <pre class='def'>
 function_decl
-  : function_header body_statement
+  : function_decoration_decl? function_header body_statement
+
+function_decoration_decl
+  : ATTR_LEFT (function_decoration COMMA)* function_decoration ATTR_RIGHT
 
 function_type_decl
   : type_decl
@@ -2602,13 +2605,6 @@ programmable parts of pipelines:
 * <dfn noexport>vertex</dfn>
 * <dfn noexport>fragment</dfn>
 
-<pre class='def'>
-pipeline_stage
-  : COMPUTE
-  | VERTEX
-  | FRAGMENT
-</pre>
-
 Each shader stage has its own set of features and constraints, described elsewhere.
 
 ## Entry point declaration ## {#entry-point-decl}
@@ -2616,8 +2612,8 @@ Each shader stage has its own set of features and constraints, described elsewhe
 An <dfn noexport>entry point</dfn> is a function that is invoked to perform
 the work for a particular [=shader stage=].
 
-To declare an entry point, write the name of the shader stage before the
-function declaration.
+Specify a `stage` attribute on a function declaration to declare that function
+as an entry point.
 
 When configuring the stage in the pipeline, the entry point is specified by providing
 the [SHORTNAME] module and the entry point's function name.
@@ -2626,25 +2622,21 @@ An entry point function must have no parameters,
 and its return type must be [=void=].
 
 ISSUE: We've lost the ability to use shader names that are invalid identifiers.
-
-<pre class='def'>
-entry_point_decl:
-   : entry_point_decoration_decl? pipeline_stage function_decl
-
-entry_point_decoration_decl
-  : ATTR_LEFT entry_point_decoration ATTR_RIGHT
-</pre>
+Do Metal and D3D12 limit entry point names to valid identifiers in C?
 
 <div class='example' heading='Entry Point'>
   <xmp>
-    vertex fn vtx_main() -> void { gl_Position = vec4<f32>(); }
-       OpEntryPoint Vertex %vtx_main "vtx_main" %gl_Position
+    [[stage vertex]]
+    fn vtx_main() -> void { gl_Position = vec4<f32>(); }
+       # OpEntryPoint Vertex %vtx_main "vtx_main" %gl_Position
 
-    fragment fn frag_main -> void { gl_FragColor = vec4<f32>(); }
-       OpEntryPoint Fragment %frag_main "frag_main" %gl_FragColor
+    [[stage fragment]]
+    fn frag_main -> void { gl_FragColor = vec4<f32>(); }
+       # OpEntryPoint Fragment %frag_main "frag_main" %gl_FragColor
 
-    compute fn main() -> void { }
-       OpEntryPoint GLCompute %main "main"
+    [[stage compute]]
+    fn main() -> void { }
+       # OpEntryPoint GLCompute %main "main"
   </xmp>
 </div>
 
@@ -2657,15 +2649,23 @@ The set of <dfn noexport>functions in a shader stage</dfn> is the union of:
 The union is applied repeatedly until it stabilizes.
 It will stabilize in a finite number of steps.
 
-### Entry point attributes ### {#entry-point-attributes}
+### Function attributes for entry points ### {#entry-point-attributes}
 
 <pre class='def'>
-entry_point_decoration
-  : WORKGROUP_SIZE INT_LITERAL (INT_LITERAL INT_LITERAL?)?
+function_decoration
+  : STAGE pipeline_stage
+  | WORKGROUP_SIZE INT_LITERAL (INT_LITERAL INT_LITERAL?)?
+
+pipeline_stage
+  : COMPUTE
+  | VERTEX
+  | FRAGMENT
 </pre>
 
+: <dfn noexport>stage</dfn>
+:: The `stage` attribute declares that a function is an entry point for particular pipeline stage.
 : <dfn noexport>workgroup_size</dfn>
-:: The `workgroup_size` attribute specifies the x, y, and z dimensions of the [=workgroup=]
+:: The `workgroup_size` attribute specifies the x, y, and z dimensions of the [=workgroup grid=]
     for a [=compute=] shader.
     The size in the x dimension is provided by the first literal.
     The size in the y dimension is provided by the second literal, when present, and otherwise
@@ -2680,13 +2680,13 @@ ISSUE: Can we query upper bounds on workgroup size dimensions?  Is it independen
 
 <div class='example' heading='workgroup_size Attribute'>
   <xmp>
-    [[ workgroup_size 8 1 1 ]]
+    [[ stage compute, workgroup_size 8 1 1 ]]
     fn sorter() -> void { }
        OpEntryPoint GLCompute %sorter "sorter"
        OpExecutionMode %sorter LocalSize 8 1 1
 
-    [[ workgroup_size 8 ]]
-    compute fn reverser() -> void { }
+    [[ stage compute, workgroup_size 8 ]]
+    fn reverser() -> void { }
        OpExecutionMode %reverser LocalSize 8 1 1
   </xmp>
 </div>
@@ -2734,7 +2734,6 @@ global_decl
   | type_alias SEMICOLON
   | struct_decl SEMICOLON
   | function_decl
-  | entry_point_decl
 </pre>
 
 
@@ -2965,7 +2964,6 @@ Issue: (dneto) Default rounding mode is an implementation choice.  Is that what 
   <tr><td>`DISCARD`<td>discard
   <tr><td>`ELSE`<td>else
   <tr><td>`ELSE_IF`<td>elseif
-  <tr><td>`ENTRY_POINT`<td>entry_point
   <tr><td>`FALLTHROUGH`<td>fallthrough
   <tr><td>`FALSE`<td>false
   <tr><td>`FN`<td>fn
@@ -2976,13 +2974,16 @@ Issue: (dneto) Default rounding mode is an implementation choice.  Is that what 
   <tr><td>`IMAGE`<td>image
   <tr><td>`IMPORT`<td>import
   <tr><td>`IN`<td>in
+  <tr><td>`INPUT`<td>input
   <tr><td>`LOCATION`<td>location
   <tr><td>`LOOP`<td>loop
   <tr><td>`OFFSET`<td>offset
   <tr><td>`OUT`<td>out
+  <tr><td>`OUTPUT`<td>output
   <tr><td>`PRIVATE`<td>private
   <tr><td>`RETURN`<td>return
   <tr><td>`SET`<td>set
+  <tr><td>`STAGE`<td>stage
   <tr><td>`STORAGE_BUFFER`<td>storage_buffer
   <tr><td>`STRIDE`<td>stride
   <tr><td>`SWITCH`<td>switch
@@ -2993,8 +2994,6 @@ Issue: (dneto) Default rounding mode is an implementation choice.  Is that what 
   <tr><td>`VAR`<td>var
   <tr><td>`VERTEX`<td>vertex
   <tr><td>`WORKGROUP`<td>workgroup
-  <tr><td>`INPUT`<td>input
-  <tr><td>`OUTPUT`<td>output
   <tr><td>`WORKGROUP_SIZE`<td>workgroup_size
 </table>
 <table class='data'>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2783,12 +2783,10 @@ entry point, or (1,1,1) if the entry point has no such attribute.
 There is exactly one invocation in a workgroup for each point in the workgroup grid.
 
 A compute shader begins execution when a WebGPU implementation
-removes a `GPUComputePassEncoder`'s `dispatch` or `dispatchIndirect` command
-from a queue and begins the specified work on the GPU.
-The <dfn noexport>dispatch size</dfn>,
-provided directly as arguments to the `dispatch` command, or indirectly
-through memory by the `dispatchIndirect` command, is an integer triple
-*(group_count_x, group_count_y, group_count_z)*.
+removes a dispatch command from a queue and begins the specified work on the GPU.
+The dispatch command specifies a <dfn noexport>dispatch size</dfn>,
+which is an integer triple *(group_count_x, group_count_y, group_count_z)*
+indicating the number of workgroups to be executed, as described in the following.
 
 The <dfn noexport>compute shader grid</dfn> for a particular dispatch
 is the set of points with integer coordinates *(CSi,CSj,CSk)* with:

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -33,7 +33,7 @@ thead {
 <div class='example'>
   <xmp highlight='rust'>
     [[location 0]] var<out> gl_FragColor : vec4<f32>;
-    [[stage fragment]]
+    [[stage(fragment)]]
     fn main() -> void {
         gl_FragColor = vec4<f32>(0.4, 0.4, 0.8, 1.0);
         return;
@@ -2621,20 +2621,17 @@ the [SHORTNAME] module and the entry point's function name.
 An entry point function must have no parameters,
 and its return type must be [=void=].
 
-ISSUE: We've lost the ability to use shader names that are invalid identifiers.
-Do Metal and D3D12 limit entry point names to valid identifiers in C?
-
 <div class='example' heading='Entry Point'>
   <xmp>
-    [[stage vertex]]
+    [[stage(vertex)]]
     fn vtx_main() -> void { gl_Position = vec4<f32>(); }
        # OpEntryPoint Vertex %vtx_main "vtx_main" %gl_Position
 
-    [[stage fragment]]
+    [[stage(fragment)]]
     fn frag_main -> void { gl_FragColor = vec4<f32>(); }
        # OpEntryPoint Fragment %frag_main "frag_main" %gl_FragColor
 
-    [[stage compute]]
+    [[stage(compute)]]
     fn main() -> void { }
        # OpEntryPoint GLCompute %main "main"
   </xmp>
@@ -2653,8 +2650,11 @@ It will stabilize in a finite number of steps.
 
 <pre class='def'>
 function_decoration
-  : STAGE pipeline_stage
-  | WORKGROUP_SIZE INT_LITERAL (INT_LITERAL INT_LITERAL?)?
+  : STAGE PAREN_LEFT pipeline_stage PAREN_RIGHT
+  | WORKGROUP_SIZE
+      PAREN_LEFT
+        INT_LITERAL ( COMMA INT_LITERAL ( COMMA INT_LITERAL )? )?
+      PAREN_RIGHT
 
 pipeline_stage
   : COMPUTE
@@ -2680,14 +2680,20 @@ ISSUE: Can we query upper bounds on workgroup size dimensions?  Is it independen
 
 <div class='example' heading='workgroup_size Attribute'>
   <xmp>
-    [[ stage compute, workgroup_size 8 1 1 ]]
+    [[ stage(compute), workgroup_size(8,1,1) ]]
     fn sorter() -> void { }
-       OpEntryPoint GLCompute %sorter "sorter"
-       OpExecutionMode %sorter LocalSize 8 1 1
+       # OpEntryPoint GLCompute %sorter "sorter"
+       # OpExecutionMode %sorter LocalSize 8 1 1
 
-    [[ stage compute, workgroup_size 8 ]]
+    [[ stage(compute), workgroup_size(8) ]]
     fn reverser() -> void { }
-       OpExecutionMode %reverser LocalSize 8 1 1
+       # OpEntryPoint GLCompute %reverser "reverser"
+       # OpExecutionMode %reverser LocalSize 8 1 1
+
+    [[ stage(compute) ]]
+    fn do_nothing() -> void { }
+       # OpEntryPoint GLCompute %do_nothing "do_nothing"
+       # OpExecutionMode %do_nothing LocalSize 1 1 1
   </xmp>
 </div>
 
@@ -2807,7 +2813,7 @@ where *workgroup_size_x*,
 
 The work to be performed by a compute shader dispatch is to execute exactly one
 invocation of the entry point for each point in the compute shader grid.
-The invocations are organized workgroups, so that each invocation
+The invocations are organized into workgroups, so that each invocation
 *(CSi, CSj, CSk)* is identified with the workgroup grid point
 
    ( *CSi* mod workgroup_size_x ,

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2611,41 +2611,89 @@ pipeline_stage
 
 Each shader stage has its own set of features and constraints, described elsewhere.
 
-## Entry point declaration TODO ## {#entry-point-decl}
+## Entry point declaration ## {#entry-point-decl}
 
-The `entry_point` declares an entry point into the module. The entry points may
-be forward declarations but the functions referenced must be declared in the
-file.
+An <dfn noexport>entry point</dfn> is a function that is invoked to perform
+the work for a particular [=shader stage=].
 
-The input and output parameters to the entry point are determined by which
-global variables are used in the function and any called functions.
+To declare an entry point, write the name of the shader stage before the
+function declaration.
 
-The entry point function must be declared with no arguments and returning `void`.
+When configuring the stage in the pipeline, the entry point is specified by providing
+the [SHORTNAME] module and the entry point's function name.
+
+An entry point function must have no parameters,
+and its return type must be [=void=].
+
+ISSUE: We've lost the ability to use shader names that are invalid identifiers.
 
 <pre class='def'>
-entry_point_decl
-  : ENTRY_POINT pipeline_stage EQUAL IDENT
-  | ENTRY_POINT pipeline_stage AS STRING_LITERAL EQUAL IDENT
-  | ENTRY_POINT pipeline_stage AS IDENT EQUAL IDENT
+entry_point_decl:
+   : entry_point_decoration_decl? pipeline_stage function_decl
+
+entry_point_decoration_decl
+  : ATTR_LEFT entry_point_decoration ATTR_RIGHT
 </pre>
 
 <div class='example' heading='Entry Point'>
   <xmp>
-    entry_point vertex = main
-       OpEntryPoint Vertex %vtx_main "vtx_main" %gl_FragColor
+    vertex fn vtx_main() -> void { gl_Position = vec4<f32>(); }
+       OpEntryPoint Vertex %vtx_main "vtx_main" %gl_Position
 
-    entry_point fragment as “frag_main” = main
-       OpEntryPoint Fragment %main "frag_main" %gl_FragColor
+    fragment fn frag_main -> void { gl_FragColor = vec4<f32>(); }
+       OpEntryPoint Fragment %frag_main "frag_main" %gl_FragColor
 
-    entry_point compute = comp_main
-       OpEntryPoint GLCompute %comp_main "comp_main" %gl_FragColor
+    compute fn main() -> void { }
+       OpEntryPoint GLCompute %main "main"
   </xmp>
 </div>
+
+The set of <dfn noexport>functions in a shader stage</dfn> is the union of:
+
+* The entry point function for the stage.
+* The targets of function calls from within the body of a function
+    in the shader stage, whether or not that call is executed.
+
+The union is applied repeatedly until it stabilizes.
+It will stabilize in a finite number of steps.
+
+### Entry point attributes ### {#entry-point-attributes}
+
+<pre class='def'>
+entry_point_decoration
+  : WORKGROUP_SIZE PAREN_LEFT INT_LITERAL COMMA
+                              INT_LITERAL COMMA
+                              INT_LITERAL PAREN_RIGHT
+</pre>
+
+: <dfn noexport>workgroup_size</dfn>
+:: The `workgroup_size` attribute specifies the x, y, and z dimensions of the [=workgroup=]
+    for a [=compute=] shader.
+    This attribute must only be used with a [=compute shader stage=] entry point.
+    Each dimension size must be at least 1 and at most an upper bound specified by the WebGPU API.
+
+ISSUE: Can we query upper bounds on workgroup size dimensions?  Is it independent of the shader, or
+  a property to be queried after creating the shader module?
+
+<div class='example' heading='workgroup_size Attribute'>
+  <xmp>
+    [[ workgroup_size(8,1,1) ]]
+    compute fn sorter() -> void { }
+       OpEntryPoint GLCompute %sorter "sorter"
+       OpExecutionMode %sorter LocalSize 8 1 1
+  </xmp>
+</div>
+
 ## Shader Interface TODO ## {#shader-interface}
 
 ### Built-in variables TODO ### {#builtin-var-interface}
 
 ### Pipeline Input and Output Interface TODO ### {#pipeline-inputs-outputs}
+
+TODO(dneto): The following sentence was moved from elsewhere. Expand this.
+
+The input and output parameters to the entry point are determined by which
+global variables are used in the function and any called functions.
 
 #### Built-in inputs and outputs TODO #### {#builtin-inputs-outputs}
 TODO: *Stub*. Forward reference to list of builtin variables.
@@ -2676,10 +2724,10 @@ global_decl
   | import_decl SEMICOLON
   | global_variable_decl SEMICOLON
   | global_constant_decl SEMICOLON
-  | entry_point_decl SEMICOLON
   | type_alias SEMICOLON
   | struct_decl SEMICOLON
   | function_decl
+  | entry_point_decl
 </pre>
 
 
@@ -2714,6 +2762,76 @@ TODO: *Stub*: Expression evaluation
 ### Divergence and reconvergence TODO ### {#divergence-reconvergence}
 
 ### Uniformity restrictions TODO ### {#uniformity-restrictions}
+
+## Compute Shaders and Workgroups TODO ## {#compute-shader-workgroups}
+
+A <dfn noexport>workgroup</dfn> is a set of invocations which
+concurrently execute a [=compute shader stage=] [=entry point=],
+and share access to shader variables in the `workgroup` storage class.
+
+The <dfn noexport>workgroup grid</dfn> for a compute shader is the set of points
+with integer coordinates *(i,j,k)* with:
+
+*  0 &leq; i &lt; workgroup_size_x
+*  0 &leq; j &lt; workgroup_size_y
+*  0 &leq; k &lt; workgroup_size_z
+
+where *(workgroup_size_x, workgroup_size_y, workgroup_size_z)* is
+the value specified for the [=workgroup_size=] attribute of the
+entry point, or (1,1,1) if the entry point has no such attribute.
+
+There is exactly one invocation in a workgroup for each point in the workgroup grid.
+
+A compute shader begins execution when a WebGPU implementation
+removes a `GPUComputePassEncoder`'s `dispatch` or `dispatchIndirect` command
+from a queue and begins the specified work on the GPU.
+The <dfn noexport>dispatch size</dfn>,
+provided directly as arguments to the `dispatch` command, or indirectly
+through memory by the `dispatchIndirect` command, is an integer triple
+*(group_count_x, group_count_y, group_count_z)*.
+
+The <dfn noexport>compute shader grid</dfn> for a particular dispatch
+is the set of points with integer coordinates *(CSi,CSj,CSk)* with:
+
+*  0 &leq; CSi &le; workgroup_size_x &times; group_count_x
+*  0 &leq; CSj &le; workgroup_size_y &times; group_count_y
+*  0 &leq; CSk &le; workgroup_size_z &times; group_count_z
+
+where *workgroup_size_x*,
+*workgroup_size_y*, and
+*workgroup_size_z* are as above for the compute shader entry point.
+
+The work to be performed by a compute shader dispatch is to execute exactly one
+invocation of the entry point for each point in the compute shader grid.
+The invocations are organized workgroups, so that each invocation
+*(CSi, CSj, CSk)* is identified with the workgroup grid point
+
+   ( *CSi* mod workgroup_size_x ,
+     *CSj* mod workgroup_size_y ,
+     *CSk* mod workgroup_size_z )
+
+in workgroup instance
+
+   ( &lfloor; *CSi* &div; workgroup_size_x &rfloor;,
+     &lfloor; *CSj* &div; workgroup_size_y &rfloor;,
+     &lfloor; *CSk* &div; workgroup_size_z &rfloor;).
+
+WebGPU provides no guarantees about:
+
+* Whether invocations from different workgroups execute concurrently.
+    That is, you cannot assume more than one workgroup executes at a time.
+* Whether, once invocations from a workgroup begin executing, that other workgroups
+    are blocked from execution.
+    That is, you cannot assume that only one workgroup executes at a time.
+    While a workgroup is executing, the implementation may choose to
+    concurrently execute other workgroups as well, or other queued but unblocked work.
+* Whether invocations from one particular workgroup begin executing before
+    the invocations of another workgroup.
+    That is, you cannot assume that workgroups are launched in a particular order.
+
+Issue: [WebGPU issue 1045](https://github.com/gpuweb/gpuweb/issues/1045):
+Dispatch group counts must be positive.
+However, how do we handle an indirect dispatch that specifies a group count of zero.
 
 ## Collective operations TODO ## {#collective-operations}
 
@@ -2872,6 +2990,7 @@ Issue: (dneto) Default rounding mode is an implementation choice.  Is that what 
   <tr><td>`WORKGROUP`<td>workgroup
   <tr><td>`INPUT`<td>input
   <tr><td>`OUTPUT`<td>output
+  <tr><td>`WORKGROUP_SIZE`<td>workgroup_size
 </table>
 <table class='data'>
   <caption>Image format keywords</caption>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2775,7 +2775,7 @@ TODO: *Stub*: Expression evaluation
 
 ### Uniformity restrictions TODO ### {#uniformity-restrictions}
 
-## Compute Shaders and Workgroups TODO ## {#compute-shader-workgroups}
+## Compute Shaders and Workgroups ## {#compute-shader-workgroups}
 
 A <dfn noexport>workgroup</dfn> is a set of invocations which
 concurrently execute a [=compute shader stage=] [=entry point=],


### PR DESCRIPTION
Fixes #662 : Declare an entry point by decorating the function declaration

- Adds ability to add attributes to an entry point declaration
- Adds the workgroup_size attribute
- Describes compute shader dispatch, in a new "Compute shaders and
  workgroups" section