### PR TITLE
Rename 'as' to bitcast; remove 'cast'

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1430,76 +1430,76 @@ Details of conversion to and from floating point are explained in [[#floating-po
 
 ## Reinterpretation of Representation Expressions ## {#bitcast-expr}
 
-A `bitCast` expression is used to reinterpet the bit representation of a
+A `bitcast` expression is used to reinterpet the bit representation of a
 value in one type as a value in another type.
 
 <table class='data'>
-  <caption>Scalar bitCast type rules</caption>
+  <caption>Scalar bitcast type rules</caption>
   <thead>
     <tr><td>Precondition<td>Conclusion<td>Notes
   </thead>
   <tr algorithm="scalar identity reinterpretation">
       <td>|e| : |T|,<br>
           |T| is one of i32, u32, f32
-      <td>bitCast&lt;|T|&gt;(|e|) : |T|
+      <td>bitcast&lt;|T|&gt;(|e|) : |T|
       <td>Identity transform.<br>
           The result is |e|.
           (OpCopyObject)
   <tr algorithm="scalar reinterpretation as signed integer">
       <td>|e| : |T|,<br>
           |T| is one of u32, f32
-      <td>bitCast&lt;i32&gt;(|e|) : i32
+      <td>bitcast&lt;i32&gt;(|e|) : i32
       <td>Reinterpretation of bits as a signed integer.<br>
           The result is the reinterpretation of the 32 bits in the representation of |e| as a [=i32=] value.
           (OpBitcast)
   <tr algorithm="scalar reinterpretation as unsigned integer">
       <td>|e| : |T|,<br>
           |T| is one of i32, f32
-      <td>bitCast&lt;u32&gt;(|e|) : u32
+      <td>bitcast&lt;u32&gt;(|e|) : u32
       <td>Reinterpretation of bits as an unsigned integer.<br>
           The result is the reinterpretation of the 32 bits in the representation of |e| as a [=u32=] value.
           (OpBitcast)
   <tr algorithm="scalar reinterpretation as floating point">
       <td>|e| : |T|,<br>
           |T| is one of i32, u32
-      <td>bitCast&lt;f32&gt;(|e|) : f32
+      <td>bitcast&lt;f32&gt;(|e|) : f32
       <td>Reinterpretation of bits as a floating point value.<br>
           The result is the reinterpretation of the 32 bits in the representation of |e| as a [=f32=] value.
           (OpBitcast)
 </table>
 
 <table class='data'>
-  <caption>Vector bitCast type rules</caption>
+  <caption>Vector bitcast type rules</caption>
   <thead>
     <tr><td>Precondition<td>Conclusion<td>Notes
   </thead>
   <tr algorithm="vector identity reinterpretation">
       <td>|e| : vec&lt;|N|&gt;|T|&gt;,<br>
           |T| is one of i32, u32, f32
-      <td>bitCast&lt;vec|N|&lt;|T|&gt;&gt;(|e|) : |T|
+      <td>bitcast&lt;vec|N|&lt;|T|&gt;&gt;(|e|) : |T|
       <td>Identity transform.<br>
           The result is |e|.
           (OpCopyObject)
   <tr algorithm="vector reinterpretation as signed integer">
       <td>|e| : vec&lt;|N|&gt;|T|&gt;,<br>
           |T| is one of u32, f32
-      <td>bitCast&lt;vec|N|&lt;i32&gt;&gt;(|e|) : vec|N|&lt;i32&gt;
+      <td>bitcast&lt;vec|N|&lt;i32&gt;&gt;(|e|) : vec|N|&lt;i32&gt;
       <td>Component-wise reinterpretation of bits.<br>
-          Component |i| of the result is `bitCast&lt;i32&gt;(`|e|`[`|i|`])`<br>
+          Component |i| of the result is `bitcast&lt;i32&gt;(`|e|`[`|i|`])`<br>
           (OpBitcast)
   <tr algorithm="vector reinterpretation as unsigned integer">
       <td>|e| : vec&lt;|N|&gt;|T|&gt;,<br>
           |T| is one of i32, f32
-      <td>bitCast&lt;vec|N|&lt;u32&gt;&gt;(|e|) : vec|N|&lt;u32&gt;
+      <td>bitcast&lt;vec|N|&lt;u32&gt;&gt;(|e|) : vec|N|&lt;u32&gt;
       <td>Component-wise reinterpretation of bits.<br>
-          Component |i| of the result is `bitCast&lt;u32&gt;(`|e|`[`|i|`])`<br>
+          Component |i| of the result is `bitcast&lt;u32&gt;(`|e|`[`|i|`])`<br>
           (OpBitcast)
   <tr algorithm="vector reinterpretation as floating point">
       <td>|e| : vec&lt;|N|&gt;|T|&gt;,<br>
           |T| is one of i32, u32
-      <td>bitCast&lt;vec|N|&lt;f32&gt;&gt;(|e|) : vec|N|&lt;f32&gt;
+      <td>bitcast&lt;vec|N|&lt;f32&gt;&gt;(|e|) : vec|N|&lt;f32&gt;
       <td>Component-wise Reinterpretation of bits.<br>
-          Component |i| of the result is `bitCast&lt;f32&gt;(`|e|`[`|i|`])`<br>
+          Component |i| of the result is `bitcast&lt;f32&gt;(`|e|`[`|i|`])`<br>
           (OpBitcast)
 
 </table>
@@ -2829,7 +2829,7 @@ Issue: (dneto) Default rounding mode is an implementation choice.  Is that what 
   </thead>
   <tr><td>`AS`<td>as
   <tr><td>`BINDING`<td>binding
-  <tr><td>`BITCAST`<td>bitCast
+  <tr><td>`BITCAST`<td>bitcast
   <tr><td>`BLOCK`<td>block
   <tr><td>`BREAK`<td>break
   <tr><td>`BUILTIN`<td>builtin

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1428,6 +1428,81 @@ Details of conversion to and from floating point are explained in [[#floating-po
 
 </table>
 
+## Reinterpretation of Representation Expressions ## {#bitcast-expr}
+
+A `bitCast` expression is used to reinterpet the bit representation of a
+value in one type as a value in another type.
+
+<table class='data'>
+  <caption>Scalar bitCast type rules</caption>
+  <thead>
+    <tr><td>Precondition<td>Conclusion<td>Notes
+  </thead>
+  <tr algorithm="scalar identity reinterpretation">
+      <td>|e| : |T|,<br>
+          |T| is one of i32, u32, f32
+      <td>bitCast&lt;|T|&gt;(|e|) : |T|
+      <td>Identity transform.<br>
+          The result is |e|.
+          (OpCopyObject)
+  <tr algorithm="scalar reinterpretation as signed integer">
+      <td>|e| : |T|,<br>
+          |T| is one of u32, f32
+      <td>bitCast&lt;i32&gt;(|e|) : i32
+      <td>Reinterpretation of bits as a signed integer.<br>
+          The result is the reinterpretation of the 32 bits in the representation of |e| as a [=i32=] value.
+          (OpBitcast)
+  <tr algorithm="scalar reinterpretation as unsigned integer">
+      <td>|e| : |T|,<br>
+          |T| is one of i32, f32
+      <td>bitCast&lt;u32&gt;(|e|) : u32
+      <td>Reinterpretation of bits as an unsigned integer.<br>
+          The result is the reinterpretation of the 32 bits in the representation of |e| as a [=u32=] value.
+          (OpBitcast)
+  <tr algorithm="scalar reinterpretation as floating point">
+      <td>|e| : |T|,<br>
+          |T| is one of i32, u32
+      <td>bitCast&lt;f32&gt;(|e|) : f32
+      <td>Reinterpretation of bits as a floating point value.<br>
+          The result is the reinterpretation of the 32 bits in the representation of |e| as a [=f32=] value.
+          (OpBitcast)
+</table>
+
+<table class='data'>
+  <caption>Vector bitCast type rules</caption>
+  <thead>
+    <tr><td>Precondition<td>Conclusion<td>Notes
+  </thead>
+  <tr algorithm="vector identity reinterpretation">
+      <td>|e| : vec&lt;|N|&gt;|T|&gt;,<br>
+          |T| is one of i32, u32, f32
+      <td>bitCast&lt;vec|N|&lt;|T|&gt;&gt;(|e|) : |T|
+      <td>Identity transform.<br>
+          The result is |e|.
+          (OpCopyObject)
+  <tr algorithm="vector reinterpretation as signed integer">
+      <td>|e| : vec&lt;|N|&gt;|T|&gt;,<br>
+          |T| is one of u32, f32
+      <td>bitCast&lt;vec|N|&lt;i32&gt;&gt;(|e|) : vec|N|&lt;i32&gt;
+      <td>Component-wise reinterpretation of bits.<br>
+          Component |i| of the result is `bitCast&lt;i32&gt;(`|e|`[`|i|`])`<br>
+          (OpBitcast)
+  <tr algorithm="vector reinterpretation as unsigned integer">
+      <td>|e| : vec&lt;|N|&gt;|T|&gt;,<br>
+          |T| is one of i32, f32
+      <td>bitCast&lt;vec|N|&lt;u32&gt;&gt;(|e|) : vec|N|&lt;u32&gt;
+      <td>Component-wise reinterpretation of bits.<br>
+          Component |i| of the result is `bitCast&lt;u32&gt;(`|e|`[`|i|`])`<br>
+          (OpBitcast)
+  <tr algorithm="vector reinterpretation as floating point">
+      <td>|e| : vec&lt;|N|&gt;|T|&gt;,<br>
+          |T| is one of i32, u32
+      <td>bitCast&lt;vec|N|&lt;f32&gt;&gt;(|e|) : vec|N|&lt;f32&gt;
+      <td>Component-wise Reinterpretation of bits.<br>
+          Component |i| of the result is `bitCast&lt;f32&gt;(`|e|`[`|i|`])`<br>
+          (OpBitcast)
+
+</table>
 
 ## Composite Value Expressions TODO ## {#composite-value-expr}
 
@@ -1884,15 +1959,7 @@ primary_expression
   | type_decl argument_expression_list
   | const_literal
   | paren_rhs_statement
-  | CAST LESS_THAN type_decl GREATER_THAN paren_rhs_statement
-      OpConvertFToU
-      OpConvertFToS
-      OpConvertSToF
-      OpConvertUToF
-      OpUConvert
-      OpSConvert
-      OpFConvert
-  | AS LESS_THAN type_decl GREATER_THAN paren_rhs_statement
+  | BITCAST LESS_THAN type_decl GREATER_THAN paren_rhs_statement
       OpBitcast
 
 postfix_expression
@@ -2762,11 +2829,11 @@ Issue: (dneto) Default rounding mode is an implementation choice.  Is that what 
   </thead>
   <tr><td>`AS`<td>as
   <tr><td>`BINDING`<td>binding
+  <tr><td>`BITCAST`<td>bitCast
   <tr><td>`BLOCK`<td>block
   <tr><td>`BREAK`<td>break
   <tr><td>`BUILTIN`<td>builtin
   <tr><td>`CASE`<td>case
-  <tr><td>`CAST`<td>cast
   <tr><td>`COMPUTE`<td>compute
   <tr><td>`CONST`<td>const
   <tr><td>`CONSTANT_ID`<td>constant_id


### PR DESCRIPTION
- Add bitCast rules.  It works on numeric scalars and vectors.
- Remove 'cast', because it is redundant with the type-constructor forms.

Fixes #1035