### PR TITLE
Don't throw errors synchronously in popErrorScope

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6633,8 +6633,20 @@ partial interface GPUDevice {
 };
 </script>
 
-{{GPUDevice/popErrorScope()}} throws {{OperationError}} if there are no error scopes on the stack.
-{{GPUDevice/popErrorScope()}} rejects with {{OperationError}} if the device is lost.
+<dl dfn-type=method dfn-for=GPUDevice>
+    : <dfn>pushErrorScope(filter)</dfn>
+    ::
+        Issue: Define pushErrorScope.
+
+    : <dfn>popErrorScope()</dfn>
+    ::
+        Issue: Define popErrorScope.
+
+        Rejects with {{OperationError}} if:
+
+        - The device is lost.
+        - There are no error scopes on the stack.
+</dl>
 
 ## Telemetry ## {#telemetry}
 


### PR DESCRIPTION
Per https://www.w3.org/2001/tag/doc/promises-guide#always-return-promises
promise-returning methods should never throw errors synchronously, only
reject the returned promise.

I thought this was fixed a long time ago but I guess I forgot.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1050.html" title="Last updated on Sep 3, 2020, 1:32 AM UTC (61083a6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1050/4cb9430...kainino0x:61083a6.html" title="Last updated on Sep 3, 2020, 1:32 AM UTC (61083a6)">Diff</a>