### PR TITLE
Fixing textureSampleCompare documentation

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3187,7 +3187,7 @@ TODO(dsinclair): Allow a small constant offset on the coordinate? May not be por
 `f32 textureSampleCompare(texture_depth, sampler_comparison, f32 coords, f32 depth_reference)`
 `f32 textureSampleCompare(texture_depth, sampler_comparison, vec2<f32> coords, f32 depth_reference)`
 `f32 textureSampleCompare(texture_depth, sampler_comparison, vec3<f32> coords, f32 depth_reference)`
-  %65 = OpImageSampleDrefImplicitLod %float %sampled_image %coord %depth_reference Lod %float_0
+  %65 = OpImageSampleDrefExplicitLod %float %sampled_image %coord %depth_reference Lod %float_0
 
 TODO(dsinclair): Add Level-of-Detail via explicit gradient. "Grad" image operand in SPIR-V
 


### PR DESCRIPTION
To use the Lod operand we need the function to be ExplicitLod.