### PR TITLE
Various grammar related updates to WGSL

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -781,7 +781,7 @@ type_decl
   | VEC2 LESS_THAN type_decl GREATER_THAN
   | VEC3 LESS_THAN type_decl GREATER_THAN
   | VEC4 LESS_THAN type_decl GREATER_THAN
-  | PTR LESS_THAN storage_class, type_decl GREATER_THAN
+  | POINTER LESS_THAN storage_class COMMA type_decl GREATER_THAN
   | array_decoration_list? ARRAY LESS_THAN type_decl COMMA INT_LITERAL GREATER_THAN
   | array_decoration_list? ARRAY LESS_THAN type_decl GREATER_THAN
   | MAT2x2 LESS_THAN type_decl GREATER_THAN
@@ -876,7 +876,7 @@ variable_decl
 variable_ident_decl
   : IDENT COLON type_decl
 
-variable_storage_decoration:
+variable_storage_decoration
   : LESS_THAN storage_class GREATER_THAN
 </pre>
 
@@ -934,9 +934,6 @@ global_variable_decl
   : variable_decoration_list? variable_decl
   | variable_decoration_list? sampler_or_texture_decl
   | variable_decoration_list? variable_decl EQUAL const_expr
-
-global_constant_decl
-  : CONST variable_ident_decl EQUAL const_expr
 
 variable_decoration_list
   : ATTR_LEFT (variable_decoration COMMA)* variable_decoration ATTR_RIGHT
@@ -1892,7 +1889,7 @@ TODO: *Stub*: how to write each of the abstract pointer operations
 <pre class='def'>
 primary_expression
   : (IDENT NAMESPACE)* IDENT
-  | type_decl PAREN_LEFT argument_expression_list* PAREN_RIGHT
+  | type_decl argument_expression_list
   | const_literal
   | paren_rhs_statement
   | CAST LESS_THAN type_decl GREATER_THAN paren_rhs_statement
@@ -1909,11 +1906,11 @@ primary_expression
 postfix_expression
   :
   | BRACKET_LEFT short_circuit_or_expression BRACKET_RIGHT postfix_expression
-  | PAREN_LEFT argument_expression_list* PAREN_RIGHT postfix_expression
+  | argument_expression_list postfix_expression
   | PERIOD IDENT postfix_expression
 
 argument_expression_list
-  : (short_circuit_or_expression COMMA)* short_circuit_or_expression
+  : PAREN_LEFT ((short_circuit_or_expression COMMA)* short_circuit_or_expression)? PAREN_RIGHT
 
 unary_expression
   : singular_expression
@@ -2184,7 +2181,7 @@ allows them to naturally use values defined in the loop body.
 
 <pre class='def'>
 for_statement
-  : FOR PAREN_LEFT for_header PAREN_RIGHT BRACE_LEFT statements BRACE_RIGHT
+  : FOR PAREN_LEFT for_header PAREN_RIGHT body_statement
 
 for_header
   : (variable_statement | assignment_statement | func_call_statement)? SEMICOLON
@@ -2348,7 +2345,7 @@ control past a declaration used in the targeted continuing construct.
 ### Continuing Statement ### {#continuing-statement}
 
 <pre class='def'>
-continuing_statement:
+continuing_statement
   : CONTINUING body_statement
 </pre>
 
@@ -2385,13 +2382,13 @@ The `discard` statement must only be used in a [=fragment=] shader stage.
 
 <pre class='def'>
 func_call_statement
-  : IDENT PAREN_LEFT argument_expression_list* PAREN_RIGHT
+  : IDENT argument_expression_list
 </pre>
 
 ## Statements Grammar Summary ## {#statements-summary}
 
 <pre class='def'>
-body_statement:
+body_statement
   : BRACE_LEFT statements BRACE_RIGHT
 
 paren_rhs_statement
@@ -2568,10 +2565,10 @@ global variables are used in the function and any called functions.
 The entry point function must be declared with no arguments and returning `void`.
 
 <pre class='def'>
-entry_point_decl:
-   : ENTRY_POINT pipeline_stage EQUAL IDENT
-   | ENTRY_POINT pipeline_stage AS STRING_LITERAL EQUAL IDENT
-   | ENTRY_POINT pipeline_stage AS IDENT EQUAL IDENT
+entry_point_decl
+  : ENTRY_POINT pipeline_stage EQUAL IDENT
+  | ENTRY_POINT pipeline_stage AS STRING_LITERAL EQUAL IDENT
+  | ENTRY_POINT pipeline_stage AS IDENT EQUAL IDENT
 </pre>
 
 <div class='example' heading='Entry Point'>
@@ -2817,6 +2814,8 @@ Issue: (dneto) Default rounding mode is an implementation choice.  Is that what 
   <tr><td>`VAR`<td>var
   <tr><td>`VERTEX`<td>vertex
   <tr><td>`WORKGROUP`<td>workgroup
+  <tr><td>`INPUT`<td>input
+  <tr><td>`OUTPUT`<td>output
 </table>
 <table class='data'>
   <caption>Image format keywords</caption>


### PR DESCRIPTION
The only one that's non obvious is there was a duplicate definition of `global_constant_decl`.