### PR TITLE
Updating alphaToCoverage spec

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3519,7 +3519,8 @@ In alpha-to-coverage mode, an additional <dfn dfn>alpha-to-coverage mask</dfn>
 of MSAA samples is generated based on the |alpha| component of the
 fragment shader output value of the {{GPURenderPipelineDescriptor/colorStates}}[0].
 
-The algorithm of producing the extra mask is platform-dependent. It guarantees that:
+The algorithm of producing the extra mask is platform-dependent and can vary for different pixels. 
+It guarantees that:
   - if |alpha| is 0.0 or less, the result is 0x0
   - if |alpha| is 1.0 or greater, the result is 0xFFFFFFFF
   - if |alpha| is greater than some other |alpha1|,


### PR DESCRIPTION
This might have been implied but wasn't clearly said by the spec.

Vulkan spec (https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#fragops-covg): 'The algorithm may be different at different framebuffer coordinates.'.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ponitka/gpuweb/pull/1055.html" title="Last updated on Sep 7, 2020, 8:53 AM UTC (fb3fb6b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1055/3c633ea...ponitka:fb3fb6b.html" title="Last updated on Sep 7, 2020, 8:53 AM UTC (fb3fb6b)">Diff</a>