### PR TITLE
Sketching out tracking of command lists

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4027,7 +4027,7 @@ GPUCommandBuffer includes GPUObjectBase;
 {{GPUCommandBuffer}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUCommandBuffer">
-    : <dfn>\[[command_list]]</dfn> of type [=list=]<[=GPU command=]>.
+    : <dfn>\[[command_list]]</dfn> of type [=list=]&lt;[=GPU command=]&gt;.
     ::
         A [=list=] of [=GPU commands=] to be executed on the [=Queue timeline=] when this command
         buffer is submitted.
@@ -4093,7 +4093,7 @@ GPUCommandEncoder includes GPUObjectBase;
 {{GPUCommandEncoder}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUCommandEncoder">
-    : <dfn>\[[command_list]]</dfn> of type [=list=]<[=GPU command=]>.
+    : <dfn>\[[command_list]]</dfn> of type [=list=]&lt;[=GPU command=]&gt;.
     ::
         A [=list=] of [=GPU command=] to be executed on the [=Queue timeline=] when the
         {{GPUCommandBuffer}} this encoder produces is submitted.
@@ -4802,27 +4802,24 @@ command encoder can no longer be used.
 
             **Returns:** {{GPUCommandBuffer}}
 
-            Issue the following steps on the [=Content timeline=] of |this|:
-            <div class=content-timeline>
-                1. Let |commandBuffer| be a new {{GPUCommandBuffer}}.
+            1. Let |commandBuffer| be a new {{GPUCommandBuffer}}.
+            1. Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
+                    1. If any of the following conditions are unsatisfied, generate a validation
+                        error and stop.
+                        <div class=validusage>
+                            - |this| is [=valid=].
+                            - |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.length is 0.
+                            - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
+                            - Every [=usage scope=] contained in |this| satisfies the [=usage scope validation=].
+                        </div>
 
-                1. Issue the following steps on the [=Device timeline=] of |this|:
-                    <div class=device-timeline>
-                        1. If any of the following conditions are unsatisfied, generate a validation
-                            error and stop.
-                            <div class=validusage>
-                                - |this| is [=valid=].
-                                - |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.length is 0.
-                                - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
-                            </div>
+                    1. Set |this|.{{GPUCommandEncoder/[[state]]}} to {{encoder state/closed}}.
+                    1. Let |commandBuffer|.{{GPUCommandBuffer/[[command_list]]}} be a [=list/clone=]
+                        of |this|.{{GPUCommandEncoder/[[command_list]]}}.
+                </div>
 
-                        1. Set |this|.{{GPUCommandEncoder/[[state]]}} to {{encoder state/closed}}.
-                        1. Let |commandBuffer|.{{GPUCommandBuffer/[[command_list]]}} be a [=list/clone=]
-                            of |this|.{{GPUCommandEncoder/[[command_list]]}}.
-                    </div>
-
-                1. Return |commandBuffer|.
-            </div>
+            1. Return |commandBuffer|.
         </div>
 </dl>
 
@@ -4851,11 +4848,6 @@ interface mixin GPUProgrammablePassEncoder {
     : <dfn>\[[command_encoder]]</dfn> of type {{GPUCommandEncoder}}.
     ::
         The {{GPUCommandEncoder}} that created this programmable pass.
-
-    : <dfn>\[[command_list]]</dfn> of type [=list=]<[=GPU command=]>.
-    ::
-        A [=list=] of [=GPU commands=] to be executed on the [=Queue timeline=] when this
-        programmable pass is submitted as part of a {{GPUCommandBuffer}}.
 
     : <dfn>\[[debug_group_stack]]</dfn> of type `sequence<USVString>`.
     ::
@@ -5151,7 +5143,8 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
                             is `true`.
                     </div>
 
-                1. [=list/Append=] a [=GPU command=] to |this|.{{GPUProgrammablePassEncoder/[[command_list]]}}
+                1. [=list/Append=] a [=GPU command=] to
+                    |this|.{{GPUProgrammablePassEncoder/[[command_encoder]]}}.{{GPUCommandEncoder/[[command_list]]}}
                     that captures the {{GPUComputePassEncoder}} state of |this| as |passState| and,
                     when executed, issues the following steps on the appropriate [=Queue timeline=]:
                     <div class=queue-timeline>
@@ -5280,9 +5273,6 @@ called the compute pass encoder can no longer be used.
 
                         Issue: Add remaining validation.
                     </div>
-
-                1. [=list/Extend=] |this|.{{GPUProgrammablePassEncoder/[[command_encoder]]}}.{{GPUCommandEncoder/[[command_list]]}}
-                    with |this|.{{GPUProgrammablePassEncoder/[[command_list]]}}.
             </div>
         </div>
 </dl>
@@ -6101,9 +6091,6 @@ called the render pass encoder can no longer be used.
 
                         Issue: Add remaining validation.
                     </div>
-
-                1. [=list/Extend=] |this|.{{GPUProgrammablePassEncoder/[[command_encoder]]}}.{{GPUCommandEncoder/[[command_list]]}}
-                    with |this|.{{GPUProgrammablePassEncoder/[[command_list]]}}.
             </div>
         </div>
 </dl>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2712,7 +2712,7 @@ A {{GPUBindGroup}} object has the following internal slots:
     ::
         The set of {{GPUBindGroupEntry}}s this {{GPUBindGroup}} describes.
 
-    : <dfn>\[[usedResources]]</dfn> of type map<[=subresource=], list<[=internal usage=]>>.
+    : <dfn>\[[usedResources]]</dfn> of type map<[=subresource=], [=list=]<[=internal usage=]>>.
     ::
         The set of buffer and texture [=subresource=]s used by this bind group,
         associated with lists of the [=internal usage=] flags.
@@ -3983,6 +3983,12 @@ Issue(https://github.com/gpuweb/gpuweb/issues/693): add a limit to the number of
 
 # Command Buffers # {#command-buffers}
 
+Command buffers are pre-recorded lists of [=GPU commands=] that can be submitted to a {{GPUQueue}}
+for execution.
+
+A <dfn dfn>GPU command</dfn> is an algorithm that executes on the {{GPUDevice}} which captures the
+state it requires to run.
+
 ## <dfn interface>GPUCommandBuffer</dfn> ## {#command-buffer}
 
 <script type=idl>
@@ -4023,9 +4029,10 @@ GPUCommandBuffer includes GPUObjectBase;
 {{GPUCommandBuffer}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUCommandBuffer">
-    : <dfn>\[[command_list]]</dfn> of type `sequence<algorithm>`.
+    : <dfn>\[[command_list]]</dfn> of type [=list=]<[=GPU command=]>.
     ::
-        A list of commands to be executed on the [=Queue timeline=] when this command buffer is run.
+        A [=list=] of [=GPU commands=] to be executed on the [=Queue timeline=] when this command
+        buffer is submitted.
 </dl>
 
 ### Creation ### {#command-buffer-creation}
@@ -4088,10 +4095,10 @@ GPUCommandEncoder includes GPUObjectBase;
 {{GPUCommandEncoder}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUCommandEncoder">
-    : <dfn>\[[command_list]]</dfn> of type `sequence<algorithm>`.
+    : <dfn>\[[command_list]]</dfn> of type [=list=]<[=GPU command=]>.
     ::
-        A list of commands to be executed on the [=Queue timeline=] when the command buffer this
-        encoder produces is run.
+        A [=list=] of [=GPU command=] to be executed on the [=Queue timeline=] when the
+        {{GPUCommandBuffer}} this encoder produces is submitted.
 
     : <dfn>\[[state]]</dfn> of type {{encoder state}}.
     ::
@@ -4800,7 +4807,6 @@ command encoder can no longer be used.
             Issue the following steps on the [=Content timeline=] of |this|:
             <div class=content-timeline>
                 1. Let |commandBuffer| be a new {{GPUCommandBuffer}}.
-                1. Set |this|.{{GPUCommandEncoder/[[state]]}} to {{encoder state/closed}}.
                 1. Issue the following steps on the [=Device timeline=] of |this|:
                     <div class=device-timeline>
                         1. If any of the following conditions are unsatisfied, generate a validation
@@ -4808,12 +4814,12 @@ command encoder can no longer be used.
                             <div class=validusage>
                                 - |this| is [=valid=].
                                 - |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.length is 0.
-
-                                Issue: Add remaining validation.
+                                - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
                             </div>
 
-                        1. Let |commandBuffer|.{{GPUCommandBuffer/[[command_list]]}} be a copy of
-                            |this|.{{GPUCommandEncoder/[[command_list]]}}.
+                        1. Set |this|.{{GPUCommandEncoder/[[state]]}} to {{encoder state/closed}}.
+                        1. Let |commandBuffer|.{{GPUCommandBuffer/[[command_list]]}} be a [=list/clone=]
+                            of |this|.{{GPUCommandEncoder/[[command_list]]}}.
                     </div>
 
                 1. Return |commandBuffer|.
@@ -4847,10 +4853,10 @@ interface mixin GPUProgrammablePassEncoder {
     ::
         The {{GPUCommandEncoder}} that created this programmable pass.
 
-    : <dfn>\[[command_list]]</dfn> of type `sequence<algorithm>`.
+    : <dfn>\[[command_list]]</dfn> of type [=list=]<[=GPU command=]>.
     ::
-        A list of commands to be executed on the [=Queue timeline=] when this programmable pass is
-        run as part of a command buffer.
+        A [=list=] of [=GPU commands=] to be executed on the [=Queue timeline=] when this
+        programmable pass is submitted as part of a {{GPUCommandBuffer}}.
 
     : <dfn>\[[debug_group_stack]]</dfn> of type `sequence<USVString>`.
     ::
@@ -5146,12 +5152,13 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
                             is `true`.
                     </div>
 
-                1. Let |pipeline| be |this|.{{GPUComputePassEncoder/[[pipeline]]}}.
-                1. Let |bindGroups| be |this|.{{GPUProgrammablePassEncoder/[[bind_groups]]}}.
-                1. Push a command onto |this|.{{GPUProgrammablePassEncoder/[[command_list]]}} that, when executed,
-                    issues the following steps on the appropriate [=Queue timeline=]:
+                1. [=list/Append=] a [=GPU command=] to |this|.{{GPUProgrammablePassEncoder/[[command_list]]}}
+                    that captures the {{GPUComputePassEncoder}} state of |this| as |passState| and,
+                    when executed, issues the following steps on the appropriate [=Queue timeline=]:
                     <div class=queue-timeline>
-                        1. Dispatch a grid of thread groups with dimensions |x|, |y|, |z| with |pipeline| using |bindGroups|.
+                        1. Dispatch a grid of thread groups with dimensions [|x|, |y|, |z|] with
+                            |passState|.{{GPUComputePassEncoder/[[pipeline]]}} using
+                            |passState|.{{GPUProgrammablePassEncoder/[[bind_groups]]}}.
                     </div>
             </div>
         </div>
@@ -5275,8 +5282,8 @@ called the compute pass encoder can no longer be used.
                         Issue: Add remaining validation.
                     </div>
 
-                1. Push each command in |this|.{{GPUProgrammablePassEncoder/[[command_list]]}} onto the end of
-                    |this|.{{GPUProgrammablePassEncoder/[[command_encoder]]}}.{{GPUCommandEncoder/[[command_list]]}}.
+                1. [=list/Extend=] |this|.{{GPUProgrammablePassEncoder/[[command_encoder]]}}.{{GPUCommandEncoder/[[command_list]]}}
+                    with |this|.{{GPUProgrammablePassEncoder/[[command_list]]}}.
             </div>
         </div>
 </dl>
@@ -6096,8 +6103,8 @@ called the render pass encoder can no longer be used.
                         Issue: Add remaining validation.
                     </div>
 
-                1. Push each command in |this|.{{GPUProgrammablePassEncoder/[[command_list]]}} onto the end of
-                    |this|.{{GPUProgrammablePassEncoder/[[command_encoder]]}}.{{GPUCommandEncoder/[[command_list]]}}.
+                1. [=list/Extend=] |this|.{{GPUProgrammablePassEncoder/[[command_encoder]]}}.{{GPUCommandEncoder/[[command_list]]}}
+                    with |this|.{{GPUProgrammablePassEncoder/[[command_list]]}}.
             </div>
         </div>
 </dl>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3984,10 +3984,8 @@ Issue(https://github.com/gpuweb/gpuweb/issues/693): add a limit to the number of
 # Command Buffers # {#command-buffers}
 
 Command buffers are pre-recorded lists of [=GPU commands=] that can be submitted to a {{GPUQueue}}
-for execution.
-
-A <dfn dfn>GPU command</dfn> is an algorithm that executes on the {{GPUDevice}} which captures the
-state it requires to run.
+for execution. Each <dfn dfn>GPU command</dfn> represents a task to be performed on the GPU, such as
+setting state, drawing, copying resources, etc.
 
 ## <dfn interface>GPUCommandBuffer</dfn> ## {#command-buffer}
 
@@ -4807,6 +4805,7 @@ command encoder can no longer be used.
             Issue the following steps on the [=Content timeline=] of |this|:
             <div class=content-timeline>
                 1. Let |commandBuffer| be a new {{GPUCommandBuffer}}.
+
                 1. Issue the following steps on the [=Device timeline=] of |this|:
                     <div class=device-timeline>
                         1. If any of the following conditions are unsatisfied, generate a validation
@@ -6377,7 +6376,6 @@ GPUQueue includes GPUObjectBase;
                     <div class=validusage>
                         - Every {{GPUBuffer}} referenced in any element of |commandBuffers| is in the
                             `"unmapped"` [=buffer state=].
-                        - Every [=usage scope=] contained in |commandBuffers| satisfies the [=usage scope validation=].
                     </div>
 
                 1. Issue the following steps on the [=Queue timeline=] of |this|:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3519,7 +3519,7 @@ In alpha-to-coverage mode, an additional <dfn dfn>alpha-to-coverage mask</dfn>
 of MSAA samples is generated based on the |alpha| component of the
 fragment shader output value of the {{GPURenderPipelineDescriptor/colorStates}}[0].
 
-The algorithm of producing the extra mask is platform-dependent and can vary for different pixels. 
+The algorithm of producing the extra mask is platform-dependent and can vary for different pixels.
 It guarantees that:
   - if |alpha| is 0.0 or less, the result is 0x0
   - if |alpha| is 1.0 or greater, the result is 0xFFFFFFFF
@@ -4020,6 +4020,14 @@ GPUCommandBuffer includes GPUObjectBase;
         </div>
 </dl>
 
+{{GPUCommandBuffer}} has the following internal slots:
+
+<dl dfn-type=attribute dfn-for="GPUCommandBuffer">
+    : <dfn>\[[command_list]]</dfn> of type `sequence<algorithm>`.
+    ::
+        A list of commands to be executed on the [=Queue timeline=] when this command buffer is run.
+</dl>
+
 ### Creation ### {#command-buffer-creation}
 
 <script type=idl>
@@ -4080,6 +4088,11 @@ GPUCommandEncoder includes GPUObjectBase;
 {{GPUCommandEncoder}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUCommandEncoder">
+    : <dfn>\[[command_list]]</dfn> of type `sequence<algorithm>`.
+    ::
+        A list of commands to be executed on the [=Queue timeline=] when the command buffer this
+        encoder produces is run.
+
     : <dfn>\[[state]]</dfn> of type {{encoder state}}.
     ::
         The current state of the {{GPUCommandEncoder}}, initially set to {{encoder state/open}}.
@@ -4782,18 +4795,28 @@ command encoder can no longer be used.
                 descriptor:
             </pre>
 
-            **Returns:** {{undefined}}
+            **Returns:** {{GPUCommandBuffer}}
 
-            Issue the following steps on the [=Device timeline=] of |this|:
-            <div class=device-timeline>
-                1. If any of the following conditions are unsatisfied, generate a validation
-                    error and stop.
-                    <div class=validusage>
-                        - |this| is [=valid=].
-                        - |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.length is 0.
+            Issue the following steps on the [=Content timeline=] of |this|:
+            <div class=content-timeline>
+                1. Let |commandBuffer| be a new {{GPUCommandBuffer}}.
+                1. Set |this|.{{GPUCommandEncoder/[[state]]}} to {{encoder state/closed}}.
+                1. Issue the following steps on the [=Device timeline=] of |this|:
+                    <div class=device-timeline>
+                        1. If any of the following conditions are unsatisfied, generate a validation
+                            error and stop.
+                            <div class=validusage>
+                                - |this| is [=valid=].
+                                - |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.length is 0.
+
+                                Issue: Add remaining validation.
+                            </div>
+
+                        1. Let |commandBuffer|.{{GPUCommandBuffer/[[command_list]]}} be a copy of
+                            |this|.{{GPUCommandEncoder/[[command_list]]}}.
                     </div>
 
-                Issue: Add remaining validation.
+                1. Return |commandBuffer|.
             </div>
         </div>
 </dl>
@@ -4820,6 +4843,15 @@ interface mixin GPUProgrammablePassEncoder {
 {{GPUProgrammablePassEncoder}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUProgrammablePassEncoder">
+    : <dfn>\[[command_encoder]]</dfn> of type {{GPUCommandEncoder}}.
+    ::
+        The {{GPUCommandEncoder}} that created this programmable pass.
+
+    : <dfn>\[[command_list]]</dfn> of type `sequence<algorithm>`.
+    ::
+        A list of commands to be executed on the [=Queue timeline=] when this programmable pass is
+        run as part of a command buffer.
+
     : <dfn>\[[debug_group_stack]]</dfn> of type `sequence<USVString>`.
     ::
         A stack of active debug group labels.
@@ -5099,9 +5131,9 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
 
             **Arguments:**
             <pre class=argumentdef for="GPUComputePassEncoder/dispatch(x, y, z)">
-                x: X dimension of the grid of thread groups to dispatch.
-                y: Y dimension of the grid of thread groups to dispatch.
-                z: Z dimension of the grid of thread groups to dispatch.
+                |x|: X dimension of the grid of thread groups to dispatch.
+                |y|: Y dimension of the grid of thread groups to dispatch.
+                |z|: Z dimension of the grid of thread groups to dispatch.
             </pre>
 
             **Returns:** {{undefined}}
@@ -5112,6 +5144,14 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
                     <div class=validusage>
                         - [$Validate encoder bind groups$](|this|, |this|.{{GPUComputePassEncoder/[[pipeline]]}})
                             is `true`.
+                    </div>
+
+                1. Let |pipeline| be |this|.{{GPUComputePassEncoder/[[pipeline]]}}.
+                1. Let |bindGroups| be |this|.{{GPUProgrammablePassEncoder/[[bind_groups]]}}.
+                1. Push a command onto |this|.{{GPUProgrammablePassEncoder/[[command_list]]}} that, when executed,
+                    issues the following steps on the appropriate [=Queue timeline=]:
+                    <div class=queue-timeline>
+                        1. Dispatch a grid of thread groups with dimensions |x|, |y|, |z| with |pipeline| using |bindGroups|.
                     </div>
             </div>
         </div>
@@ -5231,12 +5271,13 @@ called the compute pass encoder can no longer be used.
                     error and stop.
                     <div class=validusage>
                         - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.length is 0.
+
+                        Issue: Add remaining validation.
                     </div>
 
-                Issue: Add remaining validation.
+                1. Push each command in |this|.{{GPUProgrammablePassEncoder/[[command_list]]}} onto the end of
+                    |this|.{{GPUProgrammablePassEncoder/[[command_encoder]]}}.{{GPUCommandEncoder/[[command_list]]}}.
             </div>
-
-            Issue: Allowed for GPUs to use fixed point or rounded viewport coordinates
         </div>
 </dl>
 
@@ -6051,9 +6092,12 @@ called the render pass encoder can no longer be used.
                     error and stop.
                     <div class=validusage>
                         - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.length is 0.
+
+                        Issue: Add remaining validation.
                     </div>
 
-                Issue: Add remaining validation.
+                1. Push each command in |this|.{{GPUProgrammablePassEncoder/[[command_list]]}} onto the end of
+                    |this|.{{GPUProgrammablePassEncoder/[[command_encoder]]}}.{{GPUCommandEncoder/[[command_list]]}}.
             </div>
         </div>
 </dl>
@@ -6320,11 +6364,20 @@ GPUQueue includes GPUObjectBase;
 
             **Returns:** {{undefined}}
 
-            If any of the following conditions are unsatisfied, generate a validation error and stop.
-            <div class=validusage>
-                - Every {{GPUBuffer}} referenced in any element of |commandBuffers| is in the
-                    `"unmapped"` [=buffer state=].
-                - Every [=usage scope=] contained in |commandBuffers| satisfies the [=usage scope validation=].
+            Issue the following steps on the [=Device timeline=] of |this|:
+            <div class=device-timeline>
+                1. If any of the following conditions are unsatisfied, generate a validation error and stop.
+                    <div class=validusage>
+                        - Every {{GPUBuffer}} referenced in any element of |commandBuffers| is in the
+                            `"unmapped"` [=buffer state=].
+                        - Every [=usage scope=] contained in |commandBuffers| satisfies the [=usage scope validation=].
+                    </div>
+
+                1. Issue the following steps on the [=Queue timeline=] of |this|:
+                    <div class=queue-timeline>
+                        1. For each |commandBuffer| in |commandBuffers|:
+                            1. Execute each command in |commandBuffer|.{{GPUCommandBuffer/[[command_list]]}}.
+                    </div>
             </div>
         </div>
 </dl>
@@ -7023,7 +7076,7 @@ The "Filter" column specifies whether textures of this format can be sampled in 
         <td><!-- Vulkan -->
         <td>
         <td>&checkmark;
-    
+
 </table>
 
 ### Depth/stencil formats ### {#depth-formats}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4217,6 +4217,7 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
             </div>
 
             Issue: specify the behavior of read-only depth/stencil
+            Issue: Enqueue attachment loads (with loadOp clear).
         </div>
 
     : <dfn>beginComputePass(descriptor)</dfn>
@@ -6091,6 +6092,8 @@ called the render pass encoder can no longer be used.
 
                         Issue: Add remaining validation.
                     </div>
+
+                Issue: Enqueue the attachment stores (with storeOp clear).
             </div>
         </div>
 </dl>


### PR DESCRIPTION
Related to recent comments on https://github.com/gpuweb/gpuweb/pull/1037#issuecomment-686056222

Wanted to take a stab at sketching out how we could track commands from encoder to buffer to submit. I suspect this will take a fair bit of iteration, so I've only tried to "encode" a single command for now, but the list of commands is tracked all the way up the stack.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/toji/gpuweb/pull/1057.html" title="Last updated on Sep 14, 2020, 10:05 PM UTC (38c7b73)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1057/ce9a320...toji:38c7b73.html" title="Last updated on Sep 14, 2020, 10:05 PM UTC (38c7b73)">Diff</a>