### PR TITLE
Adding texture_sampler_types to type_decl

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -632,11 +632,9 @@ sampler_comparison
 </pre>
 
 ### Texture Types Grammar ### {#texture-types-grammar}
+TODO: Add texture usage validation rules.
 
 <pre class='def'>
-sampler_or_texture_decl
-  : VAR variable_storage_decoration? IDENT COLON texture_sampler_types
-
 texture_sampler_types
   : sampler_type
   | depth_texture_type
@@ -793,6 +791,7 @@ type_decl
   | MAT4x2 LESS_THAN type_decl GREATER_THAN
   | MAT4x3 LESS_THAN type_decl GREATER_THAN
   | MAT4x4 LESS_THAN type_decl GREATER_THAN
+  | texture_sampler_types
 </pre>
 
 When the type declaration is an identifer, then the expression must be in scope of a


### PR DESCRIPTION
Removed the additional sampler_or_texture_decl grammar element since the declarations are now covered by the ones including type_decl.

This solves the problem that in global_variable_decl we had variable_decl and sampler_or_texture_decl which both started with the same expressions and also makes texture_sampler_types covered by type_alias grammar, but it will be necessary to add additional validation rules that textures and samplers cannot be used in other places, so it might not be worth it.