### PR TITLE
Fix grammar inconsistency in read-only storage textures

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -569,42 +569,39 @@ type.
 
 ### Read-only Storage Texture Types ### {#texture-ro}
 <pre class='def'>
-`texture_ro_1d<type, image_storage_type>`
-  %1 = OpTypeImage %type 1D 0 0 0 2 image_storage_type ReadOnly
+`texture_ro_1d<image_storage_type>`
+  ; The %type is determined by the image format
+  %1 = OpTypeImage %type 1D 0 0 0 2 image_storage_type
 
-`texture_ro_1d_array<type, image_storage_type>`
-  %1 = OpTypeImage %type 1D 0 1 0 2 image_storage_type ReadOnly
+`texture_ro_1d_array<image_storage_type>`
+  %1 = OpTypeImage %type 1D 0 1 0 2 image_storage_type
 
-`texture_ro_2d<type, image_storage_type>`
-  %1 = OpTypeImage %type 2D 0 0 0 2 image_storage_type ReadOnly
+`texture_ro_2d<image_storage_type>`
+  %1 = OpTypeImage %type 2D 0 0 0 2 image_storage_type
 
-`texture_ro_2d_array<type, image_storage_type>`
-  %1 = OpTypeImage %type 2D 0 1 0 2 image_storage_type ReadOnly
+`texture_ro_2d_array<image_storage_type>`
+  %1 = OpTypeImage %type 2D 0 1 0 2 image_storage_type
 
-`texture_ro_3d<type, image_storage_type>`
-  %1 = OpTypeImage %type 3D 0 0 0 2 image_storage_type ReadOnly
+`texture_ro_3d<image_storage_type>`
+  %1 = OpTypeImage %type 3D 0 0 0 2 image_storage_type
 </pre>
-* type must be `f32`, `i32` or `u32`
-* The parameterized type for the images is the type after conversion from reading.
-    E.g. you can have an image with texels with 8bit unorm components, but when you read
-    them you get a 32-bit float result (or vec-of-f32).
 
 ### Write-only Storage Texture Types ### {#texture-wo}
 <pre class='def'>
 `texture_wo_1d<image_storage_type>`
-  %1 = OpTypeImage %void 1D 0 0 0 2 image_storage_type WriteOnly
+  %1 = OpTypeImage %void 1D 0 0 0 2 image_storage_type
 
 `texture_wo_1d_array<image_storage_type>`
-  %1 = OpTypeImage %void 1D 0 1 0 2 image_storage_type WriteOnly
+  %1 = OpTypeImage %void 1D 0 1 0 2 image_storage_type
 
 `texture_wo_2d<image_storage_type>`
-  %1 = OpTypeImage %void 2D 0 0 0 2 image_storage_type WriteOnly
+  %1 = OpTypeImage %void 2D 0 0 0 2 image_storage_type
 
 `texture_wo_2d_array<image_storage_type>`
-  %1 = OpTypeImage %void 2D 0 1 0 2 image_storage_type WriteOnly
+  %1 = OpTypeImage %void 2D 0 1 0 2 image_storage_type
 
 `texture_wo_3d<image_storage_type>`
-  %1 = OpTypeImage %void 3D 0 0 0 2 image_storage_type WriteOnly
+  %1 = OpTypeImage %void 3D 0 0 0 2 image_storage_type
 </pre>
 
 ### Depth Texture Types ### {#texture-depth}
@@ -3152,6 +3149,12 @@ TODO: deduplicate these tables
 `vec4<type> textureLoad(texture_ro, vec2<i32> coords, i32 level_of_detail)`
 `vec4<type> textureLoad(texture_ro, vec3<i32> coords, i32 level_of_detail)`
   %32 = OpImageLoad %v4float %texture_ro %coords Lod %level_of_detail
+
+TODO(dneto): The component type of the result value is one of the numeric
+scalar types (i32, u32, or f32). The type is determined by the declared
+image format of the texture.
+E.g.  The image can be declared with texels with 8bit unorm components, but
+the result of texture load is a vec4<f32> value.
 
 `vec4<type> textureLoad(texture_sampled, i32 coords, i32 level_of_detail)`
 `vec4<type> textureLoad(texture_sampled, vec2<i32> coords, i32 level_of_detail)`


### PR DESCRIPTION
Fixes #1056

Also, remove ReadOnly and WriteOnly literals in the SPIR-V examples
for declaring image types. Those optional literal qualifiers are only
used for Kernel modules, not Shader modules.