### PR TITLE
createBindGroup: Require a superset of the layout's bindings

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2740,17 +2740,15 @@ A {{GPUBindGroup}} object has the following internal slots:
                         <div class=validusage>
                             - |this| is a [=valid=] {{GPUDevice}}.
                             - |descriptor|.{{GPUBindGroupDescriptor/layout}} is [$valid to use with$] |this|.
-                            - The number of {{GPUBindGroupLayoutDescriptor/entries}} of
-                                |descriptor|.{{GPUBindGroupDescriptor/layout}} is exactly equal to
-                                the number of |descriptor|.{{GPUBindGroupDescriptor/entries}}.
 
-                            For each {{GPUBindGroupEntry}} |bindingDescriptor| in
-                                |descriptor|.{{GPUBindGroupDescriptor/entries}}:
-                                - Let |resource| be |bindingDescriptor|.{{GPUBindGroupEntry/resource}}.
-                                - There is exactly one {{GPUBindGroupLayoutEntry}} |layoutBinding|
-                                    in |descriptor|.{{GPUBindGroupDescriptor/layout}}.{{GPUBindGroupLayoutDescriptor/entries}}
+                            For each {{GPUBindGroupLayoutEntry}} |layoutBinding| in
+                                |descriptor|.{{GPUBindGroupDescriptor/layout}}.{{GPUBindGroupLayoutDescriptor/entries}}:
+                                - There is exactly one {{GPUBindGroupEntry}} |bindingDescriptor|
+                                    in |descriptor|.{{GPUBindGroupDescriptor/entries}}
                                     such that |layoutBinding|.{{GPUBindGroupLayoutEntry/binding}} equals to
                                     |bindingDescriptor|.{{GPUBindGroupEntry/binding}}.
+
+                                - Let |resource| be |bindingDescriptor|.{{GPUBindGroupEntry/resource}}.
 
                                 - If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampler"}}:
                                     - |resource| is [$valid to use with$] |this|.


### PR DESCRIPTION
This make bindgroup creation require that a superset of the layout's
bindings are specified, instead of exactly the correct set. This will
make code using getBindGroupLayout less likely to break during
development when the pipeline stops statically referencing a binding.

It also matches the rest of the API where we require superset, instead
of exact matches in most cases.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/1061.html" title="Last updated on Mar 9, 2021, 3:36 PM UTC (f2c98bd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1061/12458b4...Kangz:f2c98bd.html" title="Last updated on Mar 9, 2021, 3:36 PM UTC (f2c98bd)">Diff</a>