### PR TITLE
Updated internal slots to uses lists, stacks, and ordered maps

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -788,7 +788,7 @@ configuration (e.g. if the GPU was reset or disconnected and reconnected).
 An [=adapter=] has the following internal slots:
 
 <dl dfn-type=attribute dfn-for=adapter>
-    : <dfn>\[[extensions]]</dfn>, of type sequence<{{GPUExtensionName}}>, readonly
+    : <dfn>\[[extensions]]</dfn>, of type [=list=]&lt;{{GPUExtensionName}}&gt;, readonly
     ::
         The extensions which can be used to create devices on this adapter.
 
@@ -821,7 +821,7 @@ A [=device=] has the following internal slots:
     ::
         The [=adapter=] from which this device was created.
 
-    : <dfn>\[[extensions]]</dfn>, of type sequence<{{GPUExtensionName}}>, readonly
+    : <dfn>\[[extensions]]</dfn>, of type [=list=]&lt;{{GPUExtensionName}}&gt;, readonly
     ::
         The extensions which can be used on this device.
         No additional extensions can be used, even if the underlying [=adapter=] can support them.
@@ -1188,7 +1188,7 @@ dictionary GPULimits {
         The maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
 
           - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"uniform-buffer"}}, and
-          - {{GPUBindGroupLayoutEntry/hasDynamicOffset}} is true,
+          - {{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `true`,
 
         across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
         when creating a {{GPUPipelineLayout}}.
@@ -1200,7 +1200,7 @@ dictionary GPULimits {
         The maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
 
           - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"storage-buffer"}}, and
-          - {{GPUBindGroupLayoutEntry/hasDynamicOffset}} is true,
+          - {{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `true`,
 
         across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
         when creating a {{GPUPipelineLayout}}.
@@ -1358,7 +1358,7 @@ this document.
 <div algorithm>
     <dfn abstract-op>The steps to serialize a GPUDevice object</dfn>,
     given |value|, |serialized|, and |forStorage|, are:
-     1. If |forStorage| is true, throw a "{{DataCloneError}}".
+     1. If |forStorage| is `true`, throw a "{{DataCloneError}}".
      1. Set |serialized|.device to the value of |value|.{{GPUDevice/[[device]]}}.
 </div>
 
@@ -1422,11 +1422,11 @@ GPUBuffer includes GPUObjectBase;
         Issue(gpuweb/gpuweb#605): Specify {{GPUBuffer/[[mapping]]}} in term of `DataBlock` similarly
         to `AllocateArrayBuffer`?
 
-    : <dfn>\[[mapping_range]]</dfn> of type `sequence<Number>` or `null`.
+    : <dfn>\[[mapping_range]]</dfn> of type [=list=]&lt;[=Number=]&gt; or `null`.
     ::
         The range of this {{GPUBuffer}} that is mapped.
 
-    : <dfn>\[[mapped_ranges]]</dfn> of type `sequence<ArrayBuffer>` or `null`.
+    : <dfn>\[[mapped_ranges]]</dfn> of type [=list=]&lt;{{ArrayBuffer}}&gt; or `null`.
     ::
         The {{ArrayBuffer}}s returned via {{GPUBuffer/getMappedRange}} to the application. They are tracked
         so they can be detached when {{GPUBuffer/unmap}} is called.
@@ -1460,7 +1460,7 @@ Note:
 <div class=note>
    Note: {{GPUBuffer}} has a state machine with the following states.
     ({{GPUBuffer/[[mapping]]}}, {{GPUBuffer/[[mapping_range]]}},
-    and {{GPUBuffer/[[mapped_ranges]]}} are null when not specified.)
+    and {{GPUBuffer/[[mapped_ranges]]}} are `null` when not specified.)
 
      - [=buffer state/unmapped=] and [=buffer state/destroyed=].
      - [=buffer state/mapped=] or [=buffer state/mapped at creation=] with an
@@ -1492,10 +1492,10 @@ dictionary GPUBufferDescriptor : GPUObjectDescriptorBase {
 
 <div algorithm>
     <dfn abstract-op>validating GPUBufferDescriptor</dfn>(device, descriptor)
-        1. If device is lost return false.
-        1. If any of the bits of |descriptor|'s {{GPUBufferDescriptor/usage}} aren't present in this device's [[allowed buffer usages]] return false.
-        1. If both the {{GPUBufferUsage/MAP_READ}} and {{GPUBufferUsage/MAP_WRITE}} bits of |descriptor|'s {{GPUBufferDescriptor/usage}} attribute are set, return false.
-        1. Return true.
+        1. If device is lost return `false`.
+        1. If any of the bits of |descriptor|'s {{GPUBufferDescriptor/usage}} aren't present in this device's [[allowed buffer usages]] return `false`.
+        1. If both the {{GPUBufferUsage/MAP_READ}} and {{GPUBufferUsage/MAP_WRITE}} bits of |descriptor|'s {{GPUBufferDescriptor/usage}} attribute are set, return `false`.
+        1. Return `true`.
 </div>
 
 ## Buffer Usage ## {#buffer-usage}
@@ -1569,7 +1569,7 @@ interface GPUBufferUsage {
             1. Set each byte of |b|'s allocation to zero.
             1. Return |b|.
 
-            Note: it is valid to set {{GPUBufferDescriptor/mappedAtCreation}} to true without {{GPUBufferUsage/MAP_READ}}
+            Note: it is valid to set {{GPUBufferDescriptor/mappedAtCreation}} to `true` without {{GPUBufferUsage/MAP_READ}}
             or {{GPUBufferUsage/MAP_WRITE}} in {{GPUBufferDescriptor/usage}}. This can be used to set the buffer's
             initial data.
 
@@ -1733,7 +1733,7 @@ interface GPUMapMode {
             1. Let |m| be a new {{ArrayBuffer}} of size |rangeSize| pointing at the content
                 of |this|.{{GPUBuffer/[[mapping]]}} at offset |offset| - |this|.{{GPUBuffer/[[mapping_range]]}}[0].
 
-            1. Append |m| to |this|.{{GPUBuffer/[[mapped_ranges]]}}.
+            1. [=list/Append=] |m| to |this|.{{GPUBuffer/[[mapped_ranges]]}}.
 
             1. Return |m|.
         </div>
@@ -1762,7 +1762,7 @@ interface GPUMapMode {
             1. If |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapping pending=]:
 
                 1. [=Reject=] {{GPUBuffer/[[mapping]]}} with an {{OperationError}}.
-                1. Set |this|.{{GPUBuffer/[[mapping]]}} to null.
+                1. Set |this|.{{GPUBuffer/[[mapping]]}} to `null`.
 
             1. If |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapped=] or [=buffer state/mapped at creation=]:
 
@@ -1776,9 +1776,9 @@ interface GPUMapMode {
                         of |this|'s allocation to the content of |this|.{{GPUBuffer/[[mapping]]}}.
 
                 1. Detach each {{ArrayBuffer}} in |this|.{{GPUBuffer/[[mapped_ranges]]}} from its content.
-                1. Set |this|.{{GPUBuffer/[[mapping]]}} to null.
-                1. Set |this|.{{GPUBuffer/[[mapping_range]]}} to null.
-                1. Set |this|.{{GPUBuffer/[[mapped_ranges]]}} to null.
+                1. Set |this|.{{GPUBuffer/[[mapping]]}} to `null`.
+                1. Set |this|.{{GPUBuffer/[[mapping_range]]}} to `null`.
+                1. Set |this|.{{GPUBuffer/[[mapped_ranges]]}} to `null`.
 
             1. Set |this|.{{GPUBuffer/[[state]]}} to [=buffer state/unmapped=].
 
@@ -2328,7 +2328,7 @@ enum GPUCompareFunction {
 
     **Returns:** {{boolean}}
 
-    Return true if and only if all of the following conditions apply:
+    Return `true` if and only if all of the following conditions are satisfied:
         - |device| is valid.
         - |descriptor|.{{GPUSamplerDescriptor/lodMinClamp}} is greater than or equal to 0.
         - |descriptor|.{{GPUSamplerDescriptor/lodMaxClamp}} is greater than or equal to
@@ -2352,14 +2352,14 @@ enum GPUCompareFunction {
 
         1. Let |s| be a new {{GPUSampler}} object.
         1. Set |s|.{{GPUSampler/[[descriptor]]}} to |descriptor|.
-        1. Set |s|.{{GPUSampler/[[compareEnable]]}} to false if the {{GPUSamplerDescriptor/compare}} attribute
-                of |s|.{{GPUSampler/[[descriptor]]}} is null or undefined. Otherwise, set it to true.
+        1. Set |s|.{{GPUSampler/[[compareEnable]]}} to `false` if the {{GPUSamplerDescriptor/compare}} attribute
+                of |s|.{{GPUSampler/[[descriptor]]}} is `null` or undefined. Otherwise, set it to `true`.
         1. Return |s|.
 
         <div class=validusage dfn-for=GPUDevice.createSampler>
             <dfn abstract-op>Valid Usage</dfn>
-            - If |descriptor| is not null or undefined:
-                - If [$validating GPUSamplerDescriptor$](this, |descriptor|) returns false:
+            - If |descriptor| is not `null` or undefined:
+                - If [$validating GPUSamplerDescriptor$](this, |descriptor|) returns `false`:
                     1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
                     1. Create a new [=invalid=] {{GPUSampler}} and return the result.
         </div>
@@ -2532,7 +2532,7 @@ enum GPUBindingType {
 A {{GPUBindGroupLayout}} object has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUBindGroupLayout">
-    : <dfn>\[[entryMap]]</dfn> of type map&lt;{{GPUSize32}}, {{GPUBindGroupLayoutEntry}}&gt.
+    : <dfn>\[[entryMap]]</dfn> of type [=ordered map=]&lt;{{GPUSize32}}, {{GPUBindGroupLayoutEntry}}&gt.
     ::
         The map of binding indices pointing to the {{GPUBindGroupLayoutEntry}}s,
         which this {{GPUBindGroupLayout}} describes.
@@ -2650,7 +2650,7 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
 
 <div algorithm>
 Two {{GPUBindGroupLayout}} objects |a| and |b| are considered <dfn dfn>group-equivalent</dfn>
-if and only if, for any binding number |binding|, one of the following is true:
+if and only if, for any binding number |binding|, one of the following conditions is satisfied:
     - it's missing from both |a|.{{GPUBindGroupLayout/[[entryMap]]}} and |b|.{{GPUBindGroupLayout/[[entryMap]]}}.
     - |a|.{{GPUBindGroupLayout/[[entryMap]]}}[|binding|] == |b|.{{GPUBindGroupLayout/[[entryMap]]}}[|binding|]
 </div>
@@ -2712,7 +2712,7 @@ A {{GPUBindGroup}} object has the following internal slots:
     ::
         The set of {{GPUBindGroupEntry}}s this {{GPUBindGroup}} describes.
 
-    : <dfn>\[[usedResources]]</dfn> of type map<[=subresource=], [=list=]<[=internal usage=]>>.
+    : <dfn>\[[usedResources]]</dfn> of type [=ordered map=]&lt;[=subresource=], [=list=]&lt;[=internal usage=]&gt;&gt;.
     ::
         The set of buffer and texture [=subresource=]s used by this bind group,
         associated with lists of the [=internal usage=] flags.
@@ -2890,7 +2890,7 @@ GPUPipelineLayout includes GPUObjectBase;
 {{GPUPipelineLayout}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUPipelineLayout">
-    : <dfn>\[[bindGroupLayouts]]</dfn> of type sequence<{{GPUBindGroupLayout}}>.
+    : <dfn>\[[bindGroupLayouts]]</dfn> of type [=list=]&lt;{{GPUBindGroupLayout}}&gt;.
     ::
         The {{GPUBindGroupLayout}} objects provided at creation in {{GPUPipelineLayoutDescriptor/bindGroupLayouts|GPUPipelineLayoutDescriptor.bindGroupLayouts}}.
 </dl>
@@ -3170,7 +3170,7 @@ has a default layout created and used instead.
 
             1. If |resource| is for a buffer binding:
 
-                1. Set |entry|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} to false.
+                1. Set |entry|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} to `false`.
 
                 1. Set |entry|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} to |resource|'s minimum buffer binding size.
 
@@ -3222,7 +3222,7 @@ has a default layout created and used instead.
 
                 1. If any other property is unequal between |entry| and |previousEntry|:
 
-                    1. Return null (which will cause the creation of the pipeline to fail).
+                    1. Return `null` (which will cause the creation of the pipeline to fail).
 
             1. Else
 
@@ -3261,12 +3261,12 @@ A {{GPUProgrammableStageDescriptor}} describes the entry point in the user-provi
             - {{GPUPipelineLayout}} |layout|
 
         1. If the |descriptor|.{{GPUProgrammableStageDescriptor/module}} is not
-            a [=valid=] {{GPUShaderModule}} return false.
+            a [=valid=] {{GPUShaderModule}} return `false`.
         1. If the |descriptor|.{{GPUProgrammableStageDescriptor/module}} doesn't contain
-            an entry point at |stage| named |descriptor|.{{GPUProgrammableStageDescriptor/entryPoint}} return false.
+            an entry point at |stage| named |descriptor|.{{GPUProgrammableStageDescriptor/entryPoint}} return `false`.
         1. For each |binding| that is [=statically used=] by the shader entry point,
-            if the result of [$validating shader binding$](|binding|, |layout|) is false, return false.
-        1. Return true.
+            if the result of [$validating shader binding$](|binding|, |layout|) is `false`, return `false`.
+        1. Return `true`.
 </div>
 
 <div algorithm>
@@ -3278,7 +3278,7 @@ A {{GPUProgrammableStageDescriptor}} describes the entry point in the user-provi
     Consider the shader |binding| annotation of |bindIndex| for the
     binding index and |bindGroup| for the bind group index.
 
-    Return true if all of the following conditions are satisfied:
+    Return `true` if all of the following conditions are satisfied:
 
         1. |layout|.{{GPUPipelineLayout/[[bindGroupLayouts]]}}[|bindGroup|] contains
             a {{GPUBindGroupLayoutEntry}} |entry| whose |entry|.{{GPUBindGroupLayoutEntry/binding}} == |bindIndex|.
@@ -3484,7 +3484,7 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
 - {{GPURenderPipelineDescriptor/vertexStage}} describes
     the vertex shader entry point of the [=pipeline=]
 - {{GPURenderPipelineDescriptor/fragmentStage}} describes
-    the fragment shader entry point of the [=pipeline=]. If it's "null", the [[#no-color-output]] mode is enabled.
+    the fragment shader entry point of the [=pipeline=]. If it's `null`, the [[#no-color-output]] mode is enabled.
 - {{GPURenderPipelineDescriptor/primitiveTopology}} configures
     the primitive assembly stage of the [=pipeline=].
 - {{GPURenderPipelineDescriptor/rasterizationState}} configures
@@ -3684,10 +3684,10 @@ dictionary GPURasterizationStateDescriptor {
 
 <div algorithm>
     <dfn abstract-op>validating GPURasterizationStateDescriptor</dfn>(|device|, |descriptor|)
-        1. If |device| is lost return false.
-        1. If |descriptor|.{{GPURasterizationStateDescriptor/clampDepth}} is true and |device|.{{device/[[extensions]]}}
-            doesn't contain {{GPUExtensionName/"depth-clamping"}}, return false.
-        1. Return true.
+        1. If |device| is lost return `false`.
+        1. If |descriptor|.{{GPURasterizationStateDescriptor/clampDepth}} is `true` and |device|.{{device/[[extensions]]}}
+            doesn't [=list/contain=] {{GPUExtensionName/"depth-clamping"}}, return `false`.
+        1. Return `true`.
 </div>
 
 <script type=idl>
@@ -3947,7 +3947,7 @@ dictionary GPUVertexAttributeDescriptor {
         - {{GPUVertexBufferLayoutDescriptor}} |descriptor|
         - {{GPUProgrammableStageDescriptor}} |vertexStage|
 
-    Return true, if and only if, all of the following conditions are true:
+    Return `true`, if and only if, all of the following conditions are satisfied:
 
         1. |descriptor|.{{GPUVertexBufferLayoutDescriptor/attributes}}.length is less than or equal to 16.
         1. |descriptor|.{{GPUVertexBufferLayoutDescriptor/arrayStride}} is less then or equal to 2048.
@@ -3969,7 +3969,7 @@ Issue(https://github.com/gpuweb/gpuweb/issues/693): add a limit to the number of
         - {{GPUVertexStateDescriptor}} |descriptor|
         - {{GPUProgrammableStageDescriptor}} |vertexStage|
 
-    Return true, if and only if, all of the following conditions are true:
+    Return `true`, if and only if, all of the following conditions are satisfied:
 
         1. |descriptor|.{{GPUVertexStateDescriptor/vertexBuffers}}.length is less than or equal to 8
         1. Each |vertexBuffer| layout descriptor in the list |descriptor|.{{GPUVertexStateDescriptor/vertexBuffers}}
@@ -4004,7 +4004,7 @@ GPUCommandBuffer includes GPUObjectBase;
         The total time, in seconds, that the GPU took to execute this command buffer.
 
         Note:
-        If {{GPUCommandEncoderDescriptor/measureExecutionTime}} is true,
+        If {{GPUCommandEncoderDescriptor/measureExecutionTime}} is `true`,
         this resolves after the command buffer executes.
         Otherwise, this rejects with an {{OperationError}}.
 
@@ -4013,12 +4013,12 @@ GPUCommandBuffer includes GPUObjectBase;
 
             In {{GPUCommandEncoder/finish()}}, it should be specified that a
             new promise is created and stored in this attribute.
-            The promise starts rejected if measureExecutionTime is false.
-            If the finish() fails, then the promise resolves to 0.
+            The promise starts rejected if {{GPUCommandEncoderDescriptor/measureExecutionTime}}
+            is `false`. If the finish() fails, then the promise resolves to 0.
 
             In {{GPUQueue/submit()}}, it should be specified that (if
-            measureExecutionTime is set), work is issued to read back the
-            execution time, and, when that completes,
+            {{GPUCommandEncoderDescriptor/measureExecutionTime}} is set), work
+            is issued to read back the execution time, and, when that completes,
             the promise is resolved with that value.
             If the submit() fails, then the promise resolves to 0.
         </div>
@@ -4102,7 +4102,7 @@ GPUCommandEncoder includes GPUObjectBase;
     ::
         The current state of the {{GPUCommandEncoder}}, initially set to {{encoder state/open}}.
 
-    : <dfn>\[[debug_group_stack]]</dfn> of type `sequence<USVString>`.
+    : <dfn>\[[debug_group_stack]]</dfn> of type [=stack=]&lt;{{USVString}}&gt;.
     ::
         A stack of active debug group labels.
 </dl>
@@ -4306,7 +4306,7 @@ A {{GPUBufferCopyView}} contains the actual [=texture=] data placed in a [=buffe
 
   **Returns:** {{boolean}}
 
-  Return true if and only if all of the following conditions apply:
+  Return `true` if and only if all of the following conditions are satisfied:
     - |bufferCopyView|.{{GPUBufferCopyView/buffer}} must be a [=valid=] {{GPUBuffer}}.
     - |bufferCopyView|.{{GPUTextureDataLayout/bytesPerRow}} must be a multiple of 256.
 
@@ -4339,7 +4339,7 @@ offset {{GPUOrigin3D}} in texels, used when copying data from or to a {{GPUTextu
   - |blockWidth| be the [=texel block width=] of |textureCopyView|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
   - |blockHeight| be the [=texel block height=] of |textureCopyView|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
 
-  Return true if and only if all of the following conditions apply:
+  Return `true` if and only if all of the following conditions apply:
   - |textureCopyView|.{{GPUTextureCopyView/texture}} must be a [=valid=] {{GPUTexture}}.
   - |textureCopyView|.{{GPUTextureCopyView/mipLevel}} must be less than the {{GPUTexture/[[mipLevelCount]]}} of
     |textureCopyView|.{{GPUTextureCopyView/texture}}.
@@ -4583,11 +4583,11 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
             If any of the following conditions are unsatisfied, generate a validation error and stop.
             <div class=validusage>
                 - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
-                - [$validating GPUTextureCopyView$](|source|) returns true.
+                - [$validating GPUTextureCopyView$](|source|) returns `true`.
                 - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}} contains
                     {{GPUTextureUsage/COPY_SRC}}.
                 - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is 1.
-                - [$validating GPUBufferCopyView$](|destination|) returns true.
+                - [$validating GPUBufferCopyView$](|destination|) returns `true`.
                 - |destination|.{{GPUBufferCopyView/buffer}}.{{GPUBuffer/[[usage]]}} contains
                     {{GPUBufferUsage/COPY_DST}}.
                 - [$validating linear texture data$](|destination|,
@@ -4623,10 +4623,10 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
             1. If any of the following conditions are unsatisfied, generate a validation error and stop.
                 <div class=validusage>
                     - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
-                    - [$validating GPUTextureCopyView$](|source|) returns true.
+                    - [$validating GPUTextureCopyView$](|source|) returns `true`.
                     - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}} contains
                         {{GPUTextureUsage/COPY_SRC}}.
-                    - [$validating GPUTextureCopyView$](|destination|) returns true.
+                    - [$validating GPUTextureCopyView$](|destination|) returns `true`.
                     - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}} contains
                         {{GPUTextureUsage/COPY_DST}}.
                     - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is equal to |destination|.
@@ -4693,7 +4693,7 @@ must be well nested.
                     <div class=validusage>
                         - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
                     </div>
-                - Push |groupLabel| onto then end of |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.
+                - [=stack/Push=] |groupLabel| onto |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.
             </div>
         </div>
 
@@ -4711,9 +4711,9 @@ must be well nested.
                 - If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
-                        - |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.length is greater than 0.
+                        - |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}'s [=stack/size=] is greater than 0.
                     </div>
-                - Pop an entry off the end of |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.
+                - [=stack/Pop=] an entry off |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.
             </div>
         </div>
 
@@ -4810,7 +4810,7 @@ command encoder can no longer be used.
                         error and stop.
                         <div class=validusage>
                             - |this| is [=valid=].
-                            - |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.length is 0.
+                            - |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}'s [=stack/size=] is 0.
                             - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
                             - Every [=usage scope=] contained in |this| satisfies the [=usage scope validation=].
                         </div>
@@ -4850,11 +4850,11 @@ interface mixin GPUProgrammablePassEncoder {
     ::
         The {{GPUCommandEncoder}} that created this programmable pass.
 
-    : <dfn>\[[debug_group_stack]]</dfn> of type `sequence<USVString>`.
+    : <dfn>\[[debug_group_stack]]</dfn> of type [=stack=]&lt;{{USVString}}&gt;.
     ::
         A stack of active debug group labels.
 
-    : <dfn>\[[bind_groups]]</dfn>, of type map&lt;{{GPUIndex32}}, {{GPUBindGroup}}&gt;
+    : <dfn>\[[bind_groups]]</dfn>, of type [=ordered map=]&lt;{{GPUIndex32}}, {{GPUBindGroup}}&gt;
     ::
         The current {{GPUBindGroup}} for each index, initially empty.
 </dl>
@@ -5017,7 +5017,7 @@ pass.
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
-                1. Push |groupLabel| onto then end of |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.
+                1. [=stack/Push=] |groupLabel| onto |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.
             </div>
         </div>
 
@@ -5035,9 +5035,9 @@ pass.
                 1. If any of the following conditions are unsatisfied, generate a validation
                     error and stop.
                     <div class=validusage>
-                        - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.length is greater than 0.
+                        - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}'s [=stack/size=] is greater than 0.
                     </div>
-                1. Pop an entry off the end of |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.
+                1. [=stack/Pop=] an entry off of |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.
             </div>
         </div>
 
@@ -5270,7 +5270,7 @@ called the compute pass encoder can no longer be used.
                 1. If any of the following conditions are unsatisfied, generate a validation
                     error and stop.
                     <div class=validusage>
-                        - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.length is 0.
+                        - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}'s [=stack/size=] is 0.
 
                         Issue: Add remaining validation.
                     </div>
@@ -5345,7 +5345,7 @@ GPURenderPassEncoder includes GPURenderEncoderBase;
     ::
         The format of the index data in {{GPURenderEncoderBase/[[index_buffer]]}}.
 
-    : <dfn>\[[vertex_buffers]]</dfn>, of type map&lt;slot, {{GPUBuffer}}&gt;
+    : <dfn>\[[vertex_buffers]]</dfn>, of type [=ordered map=]&lt;slot, {{GPUBuffer}}&gt;
     ::
         The current {{GPUBuffer}}s to read vertex data from for each slot, initially empty.
 </dl>
@@ -6088,7 +6088,7 @@ called the render pass encoder can no longer be used.
                 1. If any of the following conditions are unsatisfied, generate a validation
                     error and stop.
                     <div class=validusage>
-                        - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.length is 0.
+                        - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}'s [=stack/size=] is 0.
 
                         Issue: Add remaining validation.
                     </div>
@@ -6296,7 +6296,7 @@ GPUQueue includes GPUObjectBase;
                     1. If any of the following conditions are unsatisfied,
                         generate a validation error and stop.
                         <div class=validusage>
-                            - [$validating GPUTextureCopyView$](|destination|) returns true.
+                            - [$validating GPUTextureCopyView$](|destination|) returns `true`.
                             - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}}
                                 includes {{GPUTextureUsage/COPY_DST}}.
                             - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is 1.


### PR DESCRIPTION
Addresses change requested in comment https://github.com/gpuweb/gpuweb/pull/1057#discussion_r486633903

Uses the defined lists/stack/map types more consistently, including referencing their methods and members where appropriate.

I also took a pass at normalizing how `true`, `false`, and `null` are formatted throughout the doc, since the discrepancy really stood out to me while making the prior change. This included rephrasing a couple of algorithm steps that used language like "if any of the following are true" to "if any of the following conditions are satisfied" for the sake of consistency and avoiding confusion with the literal `true` value.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/toji/gpuweb/pull/1070.html" title="Last updated on Sep 15, 2020, 6:28 PM UTC (a1860e5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1070/667b56c...toji:a1860e5.html" title="Last updated on Sep 15, 2020, 6:28 PM UTC (a1860e5)">Diff</a>