### PR TITLE
Add filtered texture and sampler binding types

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2433,8 +2433,9 @@ enum GPUCompareFunction {
         1. Set |s|.{{GPUSampler/[[compareEnable]]}} to `false` if the {{GPUSamplerDescriptor/compare}} attribute
                 of |s|.{{GPUSampler/[[descriptor]]}} is `null` or undefined. Otherwise, set it to `true`.
         1. Set |s|.{{GPUSampler/[[filterEnable]]}} to `false` if all of {{GPUSamplerDescriptor/magFilter}},
-            {{GPUSamplerDescriptor/minFilter}}, and {{GPUSamplerDescriptor/mipmapFilter}}, are {{GPUFilterMode/"nearest"}},
-            of |s|.{{GPUSampler/[[descriptor]]}} is null or undefined. Otherwise, set it to `true`.
+            {{GPUSamplerDescriptor/minFilter}}, and {{GPUSamplerDescriptor/mipmapFilter}},
+            of |s|.{{GPUSampler/[[descriptor]]}} are {{GPUFilterMode/"nearest"}}, is null or undefined.
+            Otherwise, set it to `true`.
         1. Return |s|.
 
         <div class=validusage dfn-for=GPUDevice.createSampler>
@@ -3362,7 +3363,7 @@ has a default layout created and used instead.
 
     Issue: This fills the pipeline layout with empty bindgroups. Revisit once the behavior of empty bindgroups is specified.
 
-    Issue: When do we want to derive "filtered-texture" versus "sampled-texture", and "filtering-sampled" versus "sampler"?
+    Issue: When do we want to derive "filtered-texture" versus "sampled-texture", and "sampler" versus "nonfiltering-sampler"?
 
 </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -972,8 +972,9 @@ a better limit is not specified.
         For each possible {{GPUShaderStage}} `stage`,
         the maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
 
-          - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampled-texture"}} or
-            {{GPUBindingType/"multisampled-texture"}}, and
+          - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampled-texture"}},
+            {{GPUBindingType/"filtered-texture"}}, or {{GPUBindingType/"multisampled-texture"}},
+            and
           - {{GPUBindGroupLayoutEntry/visibility}} includes `stage`,
 
         across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
@@ -985,7 +986,9 @@ a better limit is not specified.
         For each possible {{GPUShaderStage}} `stage`,
         the maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
 
-          - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampler"}}  or {{GPUBindingType/"comparison-sampler"}}, and
+          - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampler"}},
+            {{GPUBindingType/"nonfiltering-sampler"}}, or {{GPUBindingType/"comparison-sampler"}},
+            and
           - {{GPUBindGroupLayoutEntry/visibility}} includes `stage`,
 
         across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
@@ -2249,6 +2252,9 @@ GPUSampler includes GPUObjectBase;
     : <dfn>\[[compareEnable]]</dfn> of type {{boolean}}.
     ::
         Whether the {{GPUSampler}} is used as a comparison sampler.
+    : <dfn>\[[filterEnable]]</dfn> of type {{boolean}}.
+    ::
+        Whether the {{GPUSampler}} has any {{GPUFilterMode/"linear"}} filtering.
 </dl>
 
 ## Sampler Creation ## {#sampler-creation}
@@ -2426,6 +2432,9 @@ enum GPUCompareFunction {
         1. Set |s|.{{GPUSampler/[[descriptor]]}} to |descriptor|.
         1. Set |s|.{{GPUSampler/[[compareEnable]]}} to `false` if the {{GPUSamplerDescriptor/compare}} attribute
                 of |s|.{{GPUSampler/[[descriptor]]}} is `null` or undefined. Otherwise, set it to `true`.
+        1. Set |s|.{{GPUSampler/[[filterEnable]]}} to `false` if all of {{GPUSamplerDescriptor/magFilter}},
+            {{GPUSamplerDescriptor/minFilter}}, and {{GPUSamplerDescriptor/mipmapFilter}}, are {{GPUFilterMode/"nearest"}},
+            of |s|.{{GPUSampler/[[descriptor]]}} is null or undefined. Otherwise, set it to `true`.
         1. Return |s|.
 
         <div class=validusage dfn-for=GPUDevice.createSampler>
@@ -2541,7 +2550,8 @@ Issue(https://github.com/gpuweb/gpuweb/issues/851): consider making `textureComp
     : <dfn>textureComponentType</dfn>
     ::
         If the {{GPUBindGroupLayoutEntry/type}} is
-        {{GPUBindingType/"sampled-texture"}}:
+        {{GPUBindingType/"sampled-texture"}}, {{GPUBindingType/"filtered-texture"}},
+        or {{GPUBindingType/"multisampled-texture"}}:
 
           - This is the required component type of the
             {{GPUTextureViewDescriptor/format}}
@@ -2585,8 +2595,10 @@ enum GPUBindingType {
     "storage-buffer",
     "readonly-storage-buffer",
     "sampler",
+    "nonfiltering-sampler",
     "comparison-sampler",
     "sampled-texture",
+    "filtered-texture",
     "multisampled-texture",
     "readonly-storage-texture",
     "writeonly-storage-texture"
@@ -2617,6 +2629,10 @@ by this table:
         <td>[=internal usage/storage-read=]
     <tr>
         <td>{{GPUBindingType/"sampler"}}
+        <td>{{GPUSampler}}
+        <td>[=internal usage/constant=]
+    <tr>
+        <td>{{GPUBindingType/"nonfiltering-sampler"}}
         <td>{{GPUSampler}}
         <td>[=internal usage/constant=]
     <tr>
@@ -2683,14 +2699,16 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                                 {{GPUBindGroupLayoutEntry/type}} {{GPUBindingType/"storage-buffer"}} &le;
                                 {{GPULimits/maxStorageBuffersPerShaderStage|GPULimits.maxStorageBuffersPerShaderStage}}.
                             - For each shader stage, the number of entries in |descriptor| with
-                                {{GPUBindGroupLayoutEntry/type}} {{GPUBindingType/"sampled-texture"}} &le;
+                                {{GPUBindGroupLayoutEntry/type}} {{GPUBindingType/"sampled-texture"}},
+                                {{GPUBindingType/"filtered-texture"}}, or {{GPUBindingType/"multisampled-texture"}} &le;
                                 {{GPULimits/maxSampledTexturesPerShaderStage|GPULimits.maxSampledTexturesPerShaderStage}}.
                             - For each shader stage, the number of entries in |descriptor| with
                                 {{GPUBindGroupLayoutEntry/type}} {{GPUBindingType/"readonly-storage-texture"}} or
                                 {{GPUBindingType/"writeonly-storage-texture"}} &le;
                                 {{GPULimits/maxStorageTexturesPerShaderStage|GPULimits.maxStorageTexturesPerShaderStage}}.
                             - For each shader stage, the number of entries in |descriptor| with
-                                {{GPUBindGroupLayoutEntry/type}} {{GPUBindingType/"sampler"}} &le;
+                                {{GPUBindGroupLayoutEntry/type}} {{GPUBindingType/"sampler"}},
+                                {{GPUBindingType/"nonfiltering-sampler"}}, or {{GPUBindingType/"comparison-sampler"}} &le;
                                 {{GPULimits/maxSamplersPerShaderStage|GPULimits.maxSamplersPerShaderStage}}.
                             - The number of entries in |descriptor| with {{GPUBindGroupLayoutEntry/type}}
                                 {{GPUBindingType/"uniform-buffer"}} and {{GPUBindGroupLayoutEntry/hasDynamicOffset}} `true` &le;
@@ -2712,12 +2730,14 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                                     - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} is `undefined`.
 
                                 - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
-                                    {{GPUBindingType/"sampled-texture"}}, {{GPUBindingType/"readonly-storage-texture"}},
+                                    {{GPUBindingType/"sampled-texture"}}, {{GPUBindingType/"filtered-texture"}},
+                                    {{GPUBindingType/"multisampled-texture"}}, {{GPUBindingType/"readonly-storage-texture"}},
                                     or {{GPUBindingType/"writeonly-storage-texture"}}:
                                         - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/viewDimension}} is `undefined`.
 
                                 - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
-                                    {{GPUBindingType/"sampled-texture"}} or {{GPUBindingType/"multisampled-texture"}}:
+                                    {{GPUBindingType/"sampled-texture"}}, {{GPUBindingType/"filtered-texture"}},
+                                    or {{GPUBindingType/"multisampled-texture"}}:
                                     - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/textureComponentType}} is `undefined.`
 
                                 - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
@@ -2876,6 +2896,11 @@ A {{GPUBindGroup}} object has the following internal slots:
                                                     : {{GPUBindingType/"sampler"}}
                                                     :: |resource|.{{GPUSampler/[[compareEnable]]}} is `false`.
 
+                                                    : {{GPUBindingType/"nonfiltering-sampler"}}
+                                                    ::
+                                                        - |resource|.{{GPUSampler/[[compareEnable]]}} is `false`.
+                                                        - |resource|.{{GPUSampler/[[filterEnable]]}} is `false`.
+
                                                     : {{GPUBindingType/"comparison-sampler"}}
                                                     :: |resource|.{{GPUSampler/[[compareEnable]]}} is `true`.
                                                 </dl>
@@ -2892,7 +2917,7 @@ A {{GPUBindGroup}} object has the following internal slots:
                                                 Otherwise |texture|'s {{GPUTextureDescriptor/sampleCount}} is `1`.
                                             - If |bindingType| is
                                                 <dl class="switch">
-                                                    : {{GPUBindingType/"sampled-texture"}} or
+                                                    : {{GPUBindingType/"sampled-texture"}}, {{GPUBindingType/"filtered-texture"}}, or
                                                         {{GPUBindingType/"multisampled-texture"}}
                                                     :: |layoutBinding|.{{GPUBindGroupLayoutEntry/textureComponentType}}
                                                         is compatible with |resource|'s {{GPUTextureViewDescriptor/format}}.
@@ -2940,6 +2965,8 @@ A {{GPUBindGroup}} object has the following internal slots:
                                     </dl>
 
                         </div>
+
+                        Issue: convert the binding type checks into a switch.
 
                         Issue: define the association between texture formats and component types
 
@@ -3335,6 +3362,8 @@ has a default layout created and used instead.
 
     Issue: This fills the pipeline layout with empty bindgroups. Revisit once the behavior of empty bindgroups is specified.
 
+    Issue: When do we want to derive "filtered-texture" versus "sampled-texture", and "filtering-sampled" versus "sampler"?
+
 </div>
 
 ### <dfn dictionary>GPUProgrammableStageDescriptor</dfn> ### {#GPUProgrammableStageDescriptor}
@@ -3381,12 +3410,20 @@ A {{GPUProgrammableStageDescriptor}} describes the entry point in the user-provi
         1. If |entry|.{{GPUBindGroupLayoutEntry/type}} is:
             <dl class=switch>
                   : {{GPUBindingType/"sampler"}}
-                  :: the |binding| is a non-comparison sampler
+                  :: the |binding| is a non-comparison sampler, and all the textures it samples
+                      are bound as {{GPUBindingType/"filtered-texture"}}.
+                  : {{GPUBindingType/"nonfiltering-sampler"}}
+                  :: the |binding| is a non-comparison sampler.
                   : {{GPUBindingType/"comparison-sampler"}}
                   :: the |binding| is a comparison sampler
                   : {{GPUBindingType/"sampled-texture"}}
-                  :: the |binding| is a sampled texture with the component type of |entry|.{{GPUBindGroupLayoutEntry/textureComponentType}}
+                  :: The |binding| is a sampled texture with the component type of |entry|.{{GPUBindGroupLayoutEntry/textureComponentType}},
                       and it has to have a sample count of 1.
+                  : {{GPUBindingType/"filtered-texture"}}
+                  ::
+                      The |binding| is a sampled texture with the component type of |entry|.{{GPUBindGroupLayoutEntry/textureComponentType}}.
+                      It has to have a sample count of 1.
+                      All samplers that it's sampled with are bound as {{GPUBindingType/"sampler"}}.
                   : {{GPUBindingType/"multisampled-texture"}}
                   :: the |binding| is a multisampled texture with the component type of |entry|.{{GPUBindGroupLayoutEntry/textureComponentType}}.
                   : {{GPUBindingType/"readonly-storage-texture"}}
@@ -3400,7 +3437,8 @@ A {{GPUProgrammableStageDescriptor}} describes the entry point in the user-provi
                   : {{GPUBindingType/"readonly-storage-buffer"}}
                   :: the |binding| is a read-only storage buffer
             </dl>
-        1. If |entry|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampled-texture"}}, {{GPUBindingType/"readonly-storage-texture"}}, or {{GPUBindingType/"writeonly-storage-texture"}},
+        1. If |entry|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampled-texture"}},
+            {{GPUBindingType/"readonly-storage-texture"}}, or {{GPUBindingType/"writeonly-storage-texture"}},
             the shader view dimension of the texture has to match |entry|.{{GPUBindGroupLayoutEntry/viewDimension}}.
         1. If |entry|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} is not undefined:
               - If the last field of the corresponding structure defined in the shader has an unbounded array type,


### PR DESCRIPTION
Fixes #1034
Given the discussion on the issue, we can't have even the `Float` component type linearly sampled if the format doesn't support this. The only way to catch that early is having these new binding types.
Names are up to bikeshedding!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/1076.html" title="Last updated on Oct 6, 2020, 1:39 PM UTC (c1377a9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1076/cc5dde3...kvark:c1377a9.html" title="Last updated on Oct 6, 2020, 1:39 PM UTC (c1377a9)">Diff</a>