### PR TITLE
[wgsl] Remove sampled ms types.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -542,12 +542,6 @@ type.
 `texture_sampled_3d<type>`
   %1 = OpTypeImage %type 3D 0 0 0 1 Unknown
 
-`texture_sampled_2d_ms<type>`
-  %1 = OpTypeImage %type 2D 0 0 1 1 Unknown
-
-`texture_sampled_2d_ms_array<type>`
-  %1 = OpTypeImage %type 2D 0 1 1 1 Unknown
-
 `texture_sampled_cube<type>`
   %1 = OpTypeImage %type Cube 0 0 0 1 Unknown
 
@@ -653,8 +647,6 @@ sampled_texture_type
   | TEXTURE_SAMPLED_1D_ARRAY
   | TEXTURE_SAMPLED_2D
   | TEXTURE_SAMPLED_2D_ARRAY
-  | TEXTURE_SAMPLED_2D_MS
-  | TEXTURE_SAMPLED_2D_MS_ARRAY
   | TEXTURE_SAMPLED_3D
   | TEXTURE_SAMPLED_CUBE
   | TEXTURE_SAMPLED_CUBE_ARRAY
@@ -2739,8 +2731,6 @@ Issue: (dneto) Default rounding mode is an implementation choice.  Is that what 
   <tr><td>`TEXTURE_SAMPLED_1D_ARRAY`<td>texture_sampled_1d_array
   <tr><td>`TEXTURE_SAMPLED_2D`<td>texture_sampled_2d
   <tr><td>`TEXTURE_SAMPLED_2D_ARRAY`<td>texture_sampled_2d_array
-  <tr><td>`TEXTURE_SAMPLED_2D_MS`<td>texture_sampled_2d_ms
-  <tr><td>`TEXTURE_SAMPLED_2D_MS_ARRAY`<td>texture_sampled_2d_ms_array
   <tr><td>`TEXTURE_SAMPLED_3D`<td>texture_sampled_3d
   <tr><td>`TEXTURE_SAMPLED_CUBE`<td>texture_sampled_cube
   <tr><td>`TEXTURE_SAMPLED_CUBE_ARRAY`<td>texture_sampled_cube_array


### PR DESCRIPTION
This CL removes the texture_sampled_2d_ms and
texture_sampled_2d_ms_array types in favour of the
texture_multisampled_2d type.

Fixes #1075