### PR TITLE
GPUColor: remove sequence overload from the union

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6780,13 +6780,12 @@ typedef unsigned long GPUFlagsConstant;
 ## Colors &amp; Vectors ## {#colors-and-vectors}
 
 <script type=idl>
-dictionary GPUColorDict {
+dictionary GPUColor {
     required double r;
     required double g;
     required double b;
     required double a;
 };
-typedef (sequence<double> or GPUColorDict) GPUColor;
 </script>
 
 Note: `double` is large enough to precisely hold 32-bit signed/unsigned


### PR DESCRIPTION
The overload adds complexity for not much benefit (`{r: 0, g: 0, b: 0, a: 0}` vs `[0, 0, 0, 0]`).
More importantly, in certain contexts, the ordering of `[0, 0, 0, 0]` is not obvious. For example, when used as the clear color of a BGRA texture: does it use the "canonical" RGBA ordering, or does it match the format? This removes the ambiguity.

We previously decided to add this overload for convenience, and it was done in #319. However I think I was the main voice pushing for it. I still like the convenience, but unfortunately I think the ambiguity is a bigger problem.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1079.html" title="Last updated on Sep 15, 2020, 8:11 PM UTC (81ce9de)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1079/6e46b3b...kainino0x:81ce9de.html" title="Last updated on Sep 15, 2020, 8:11 PM UTC (81ce9de)">Diff</a>