### PR TITLE
[wgsl] Change attributes to be c++ style.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -32,7 +32,7 @@ thead {
 
 <div class='example'>
   <xmp highlight='rust'>
-    [[location 0]] var<out> gl_FragColor : vec4<f32>;
+    [[location(0)]] var<out> gl_FragColor : vec4<f32>;
     fn main() -> void {
         gl_FragColor = vec4<f32>(0.4, 0.4, 0.8, 1.0);
         return;
@@ -334,7 +334,7 @@ struct_member_decoration_decl
   | ATTR_LEFT (struct_member_decoration COMMA)* struct_member_decoration ATTR_RIGHT
 
 struct_member_decoration
-  : OFFSET INT_LITERAL
+  : OFFSET PAREN_LEFT INT_LITERAL PAREN_RIGHT
 </pre>
 
 Note: Layout decorations are required if the struct is used in an SSBO, UBO or
@@ -345,8 +345,8 @@ Issue: (dneto): MatrixStride, RowMajor, ColMajor layout decorations are needed f
 <div class='example' heading='Structure'>
   <xmp>
     struct my_struct {
-      [[offset 0]] a : f32;
-      [[offset 4]] b : vec4<f32>;
+      [[offset(0)]] a : f32;
+      [[offset(4)]] b : vec4<f32>;
     };
 
                   OpName %my_struct "my_struct"
@@ -359,9 +359,9 @@ Issue: (dneto): MatrixStride, RowMajor, ColMajor layout decorations are needed f
     type RTArr = [[stride 16]] array<vec4<f32>>;
 
     [[block]] struct S {
-      [[offset 0]] a : f32;
-      [[offset 4]] b : f32;
-      [[offset 16]] data : RTArr;
+      [[offset(0)]] a : f32;
+      [[offset(4)]] b : f32;
+      [[offset(16)]] data : RTArr;
     };
   </xmp>
 </div>
@@ -755,7 +755,7 @@ type_alias
   <xmp>
     type Arr = array<i32, 5>;
 
-    type RTArr = [[stride 16]] array<vec4<f32>>;
+    type RTArr = [[stride(16)]] array<vec4<f32>>;
   </xmp>
 </div>
 
@@ -794,7 +794,7 @@ array_decoration_list
   : ATTR_LEFT (array_decoration COMMA)* array_decoration ATTR_RIGHT
 
 array_decoration
-  : STRIDE INT_LITERAL
+  : STRIDE PAREN_LEFT INT_LITERAL PAREN_RIGHT
 </pre>
 
 <div class='example' heading="Type Declarations">
@@ -821,7 +821,7 @@ array_decoration
        %uint_4 = OpConstant %uint 4
             %9 = OpTypeArray %float %uint_4
 
-    [[stride 32]] array<f32, 4>
+    [[stride(32)]] array<f32, 4>
                  OpDecorate %9 ArrayStride 32
        %uint_4 = OpConstant %uint 4
             %9 = OpTypeArray %float %uint_4
@@ -930,18 +930,18 @@ variable_decoration_list
   : ATTR_LEFT (variable_decoration COMMA)* variable_decoration ATTR_RIGHT
 
 variable_decoration
-  : LOCATION INT_LITERAL
-  | BUILTIN IDENT
-  | BINDING INT_LITERAL
-  | SET INT_LITERAL
+  : LOCATION PAREN_LEFT INT_LITERAL PAREN_RIGHT
+  | BUILTIN PAREN_LEFT IDENT PAREN_RIGHT
+  | BINDING PAREN_LEFT INT_LITERAL PAREN_RIGHT
+  | SET PAREN_LEFT INT_LITERAL PAREN_RIGHT
 </pre>
 
 <div class='example' heading="Variable Decorations">
   <xmp>
-    [[location 2]]
+    [[location(2)]]
        OpDecorate %gl_FragColor Location 2
 
-    [[binding 3, set 4]]
+    [[binding(3), set(4)]]
        OpDecorate %gl_FragColor Binding 3
        OpDecorate %gl_FragColor DescriptorSet 4
   </xmp>
@@ -985,9 +985,9 @@ Proposal: pipeline creation fails with an error.
 
 <div class='example' heading='Module constants, pipeline-overrideable'>
   <xmp>
-    [[constant_id 0]]    const has_point_light : bool = true;      # Algorithmic control
-    [[constant_id 1200]] const specular_param : f32 = 2.3;         # Numeric control
-    [[constant_id 1300]] const gain : f32;                         # Must be overridden
+    [[constant_id(0)]]    const has_point_light : bool = true;      # Algorithmic control
+    [[constant_id(1200)]] const specular_param : f32 = 2.3;         # Numeric control
+    [[constant_id(1300)]] const gain : f32;                         # Must be overridden
   </xmp>
 </div>
 
@@ -1005,7 +1005,7 @@ global_const_decoration_list
   : ATTR_LEFT global_const_decoration ATTR_RIGHT
 
 global_const_decoration
-  : CONSTANT_ID INT_LITERAL
+  : CONSTANT_ID PAREN_LEFT INT_LITERAL PAREN_RIGHT
 
 global_const_initializer
   : EQUAL const_expr
@@ -1308,8 +1308,8 @@ The zero values are as follows:
 
 <div class='example' heading="Zero-valued arrays">
   <xmp highlight='rust'>
-    array<bool,2>()               # The zero-valued array of two booleans.
-    array<bool,2>(false, false)   # The same value, written explicitly.
+    array<bool, 2>()               # The zero-valued array of two booleans.
+    array<bool, 2>(false, false)   # The same value, written explicitly.
   </xmp>
 </div>
 
@@ -3024,31 +3024,31 @@ the test name.
 
 <div class='example' heading="Valid Built-in Decoration Identifiers">
   <xmp>
-    [[builtin position]]
+    [[builtin(position)]]
           OpDecorate %gl_Position BuiltIn Position
 
-    [[builtin vertex_idx]]
+    [[builtin(vertex_idx)]]
           OpDecorate %gl_VertexIdx BuiltIn VertexIndex
 
-    [[builtin instance_idx]]
+    [[builtin(instance_idx)]]
           OpDecorate %gl_InstanceId BuiltIn InstanceIndex
 
-    [[builtin front_facing]]
+    [[builtin(front_facing)]]
           OpDecorate %gl_FrontFacing BuiltIn FrontFacing
 
-    [[builtin frag_coord]]
+    [[builtin(frag_coord)]]
           OpDecorate %gl_FragCoord BuiltIn FragCoord
 
-    [[builtin frag_depth]]
+    [[builtin(frag_depth)]]
           OpDecorate %gl_FragDepth BuiltIn FragDepth
 
-    [[builtin local_invocation_id]]
+    [[builtin(local_invocation_id)]]
           OpDecorate %gl_LocalInvocationID BuiltIn LocalInvocationId
 
-    [[builtin local_invocation_idx]]
+    [[builtin(local_invocation_idx)]]
           OpDecorate %gl_LocalInvocationIndex BuiltIn LocalInvocationIndex
 
-    [[builtin global_invocation_id]]
+    [[builtin(global_invocation_id)]]
           OpDecorate %gl_GlobalInvocationID BuiltIn GlobalInvocationId
   </xmp>
 </div>


### PR DESCRIPTION
This CL updates the existing attributes to use a c++ function syntax
instead of spaces.

Issue #1067