### PR TITLE
GPUOrigin/Extent: remove dictionary overload from the union

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1959,7 +1959,7 @@ internal slots of a [=texture=] internal object once we have one.
       - If |texture|.{{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"1d"}},
         defaults to {{GPUTextureViewDimension/"1d"}}.
       - If |texture|.{{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"2d"}}:
-          - If |texture|.{{GPUTextureDescriptor/size}}.[=Extent3D/depth=] is greater than 1
+          - If |texture|.{{GPUTextureDescriptor/size}}[2] is greater than 1
             and {{GPUTextureViewDescriptor/arrayLayerCount}} is 0,
             defaults to {{GPUTextureViewDimension/"2d-array"}}.
           - Otherwise, defaults to {{GPUTextureViewDimension/"2d"}}.
@@ -1970,7 +1970,7 @@ internal slots of a [=texture=] internal object once we have one.
     If undefined, defaults to |texture|.{{GPUTextureDescriptor/mipLevelCount}} &minus; {{GPUTextureViewDescriptor/baseMipLevel}}.
 
   * {{GPUTextureViewDescriptor/arrayLayerCount}}:
-    If undefined, defaults to |texture|.{{GPUTextureDescriptor/size}}.[=Extent3D/depth=] &minus; {{GPUTextureViewDescriptor/baseArrayLayer}}.
+    If undefined, defaults to |texture|.{{GPUTextureDescriptor/size}}[2] &minus; {{GPUTextureViewDescriptor/baseArrayLayer}}.
 
 </div>
 
@@ -4318,14 +4318,12 @@ A {{GPUBufferCopyView}} contains the actual [=texture=] data placed in a [=buffe
 dictionary GPUTextureCopyView {
     required GPUTexture texture;
     GPUIntegerCoordinate mipLevel = 0;
-    GPUOrigin3D origin = {};
+    GPUOrigin3D origin = [];
 };
 </script>
 
 A {{GPUTextureCopyView}} is a view of a sub-region of one or multiple contiguous [=texture subresources=] with the initial
 offset {{GPUOrigin3D}} in texels, used when copying data from or to a {{GPUTexture}}.
-
-  * {{GPUTextureCopyView/origin}}: If unspecified, defaults to `[0, 0, 0]`.
 
 <div algorithm class=validusage>
 <dfn abstract-op>validating GPUTextureCopyView</dfn>
@@ -4343,8 +4341,8 @@ offset {{GPUOrigin3D}} in texels, used when copying data from or to a {{GPUTextu
   - |textureCopyView|.{{GPUTextureCopyView/texture}} must be a [=valid=] {{GPUTexture}}.
   - |textureCopyView|.{{GPUTextureCopyView/mipLevel}} must be less than the {{GPUTexture/[[mipLevelCount]]}} of
     |textureCopyView|.{{GPUTextureCopyView/texture}}.
-  - |textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/x=] must be a multiple of |blockWidth|.
-  - |textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/y=] must be a multiple of |blockHeight|.
+  - |textureCopyView|.{{GPUTextureCopyView/origin}}[0] must be a multiple of |blockWidth|.
+  - |textureCopyView|.{{GPUTextureCopyView/origin}}[1] must be a multiple of |blockHeight|.
 
 </div>
 
@@ -4355,11 +4353,9 @@ Issue(gpuweb/gpuweb#69): Define the copies with {{GPUTextureDimension/1d}} and {
 <script type=idl>
 dictionary GPUImageBitmapCopyView {
     required ImageBitmap imageBitmap;
-    GPUOrigin2D origin = {};
+    GPUOrigin2D origin = [];
 };
 </script>
-
-  * {{GPUImageBitmapCopyView/origin}}: If unspecified, defaults to `[0, 0]`.
 
 <dl dfn-type=method dfn-for=GPUCommandEncoder>
     : <dfn>copyBufferToBuffer(source, sourceOffset, destination, destinationOffset, size)</dfn>
@@ -4416,20 +4412,16 @@ and {{GPUCommandEncoder/copyTextureToBuffer()}}.
 {{GPUCommandEncoder/copyTextureToTexture()}}.
 
 <div algorithm="textureCopyView subresource size">
+    <dfn dfn>textureCopyView subresource size</dfn>
 
-<dfn dfn>textureCopyView subresource size</dfn>
+    **Arguments:**
+        - {{GPUTextureCopyView}} |textureCopyView|
 
-  **Arguments:**
-    - {{GPUTextureCopyView}} |textureCopyView|
+    **Returns:** {{GPUExtent3D}}
 
-  **Returns:** {{GPUExtent3D}}
-
-  The [=textureCopyView subresource size=] of |textureCopyView| is calculated as follows:
-
-  Its [=Extent3D/width=], [=Extent3D/height=] and [=Extent3D/depth=] are the width, height, and depth, respectively,
-  of the [=physical size=] of |textureCopyView|.{{GPUTextureCopyView/texture}} [=subresource=] at [=mipmap level=]
-  |textureCopyView|.{{GPUTextureCopyView/mipLevel}}.
-
+    The [=textureCopyView subresource size=] of |textureCopyView| is the [=physical size=] of
+    the subresource of |textureCopyView|.{{GPUTextureCopyView/texture}}
+    at [=mipmap level=] |textureCopyView|.{{GPUTextureCopyView/mipLevel}}.
 </div>
 
 Issue: define this as an algorithm with (texture, mipmapLevel) parameters and use the call syntax instead of referring to the definition by label.
@@ -4451,17 +4443,17 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
         [=texel block width=], [=texel block height|height=], and
         [=texel block size|size=] of |format|.
 
-    1. It is assumed that |copyExtent|.[=Extent3D/width=] is a multiple of |blockWidth|
-        and |copyExtent|.[=Extent3D/height=] is a multiple of |blockHeight|. Let:
-            - |widthInBlocks| be |copyExtent|.[=Extent3D/width=] &divide; |blockWidth|.
-            - |heightInBlocks| be |copyExtent|.[=Extent3D/height=] &divide; |blockHeight|.
+    1. It is assumed that |copyExtent|[0] is a multiple of |blockWidth|
+        and |copyExtent|[1] is a multiple of |blockHeight|. Let:
+            - |widthInBlocks| be |copyExtent|[0] &divide; |blockWidth|.
+            - |heightInBlocks| be |copyExtent|[1] &divide; |blockHeight|.
             - |bytesInACompleteRow| be |blockSize| &times; |widthInBlocks|.
 
     1. Fail if the following conditions are not satisfied:
         <div class=validusage>
             - If |heightInBlocks| &gt; 1,
                 |layout|.{{GPUTextureDataLayout/bytesPerRow}} must be specified.
-            - If |copyExtent|.[=Extent3D/depth=] &gt; 1,
+            - If |copyExtent|[2] &gt; 1,
                 |layout|.{{GPUTextureDataLayout/bytesPerRow}} and
                 |layout|.{{GPUTextureDataLayout/rowsPerImage}} must be specified.
             - If specified, |layout|.{{GPUTextureDataLayout/bytesPerRow}}
@@ -4477,10 +4469,10 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
         (|heightInBlocks| &minus; 1)
         to |requiredBytesInCopy|.
 
-    1. If |copyExtent|.[=Extent3D/depth=] &gt; 1, add
+    1. If |copyExtent|[2] &gt; 1, add
         |layout|.{{GPUTextureDataLayout/bytesPerRow}} &times;
         |layout|.{{GPUTextureDataLayout/rowsPerImage}} &times;
-        (|copyExtent|.[=Extent3D/depth=] &minus; 1)
+        (|copyExtent|[2] &minus; 1)
         to |requiredBytesInCopy|.
 
     1. Fail if the following conditions are not satisfied:
@@ -4492,29 +4484,26 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
 </div>
 
 <div algorithm class=validusage>
+    <dfn dfn>Valid Texture Copy Range</dfn>
 
-<dfn dfn>Valid Texture Copy Range</dfn>
+    Given a {{GPUTextureCopyView}} |textureCopyView| and a {{GPUExtent3D}} |copySize|, let:
 
-Given a {{GPUTextureCopyView}} |textureCopyView| and a {{GPUExtent3D}} |copySize|, let
-  - |blockWidth| be the [=texel block width=] of |textureCopyView|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
-  - |blockHeight| be the [=texel block height=] of |textureCopyView|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
+    - |blockWidth| be the [=texel block width=] of |textureCopyView|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
+    - |blockHeight| be the [=texel block height=] of |textureCopyView|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
 
-The following validation rules apply:
+    The following validation rules apply:
 
-  - If the {{GPUTexture/[[dimension]]}} of |textureCopyView|.{{GPUTextureCopyView/texture}} is
-    {{GPUTextureDimension/1d}}:
-    - Both |copySize|.[=Extent3D/height=] and [=Extent3D/depth=] must be 1.
-  - If the {{GPUTexture/[[dimension]]}} of |textureCopyView|.{{GPUTextureCopyView/texture}} is
-    {{GPUTextureDimension/2d}}:
-     -  (|textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/x=] + |copySize|.[=Extent3D/width=]),
-        (|textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/y=] + |copySize|.[=Extent3D/height=]), and
-        (|textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/z=] + |copySize|.[=Extent3D/depth=])
-        must be less than or equal to the
-        [=Extent3D/width=], [=Extent3D/height=], and [=Extent3D/depth=], respectively,
-        of the [=textureCopyView subresource size=] of |textureCopyView|.
-  - |copySize|.[=Extent3D/width=] must be a multiple of |blockWidth|.
-  - |copySize|.[=Extent3D/height=] must be a multiple of |blockHeight|.
-
+    - If the {{GPUTexture/[[dimension]]}} of |textureCopyView|.{{GPUTextureCopyView/texture}} is
+        {{GPUTextureDimension/1d}}:
+        - Both |copySize|[1] and |copySize|[2] must be 1.
+    - If the {{GPUTexture/[[dimension]]}} of |textureCopyView|.{{GPUTextureCopyView/texture}} is
+        {{GPUTextureDimension/2d}}:
+        - Let |subresourceSize| be the [=textureCopyView subresource size=] of |textureCopyView|.
+        - |textureCopyView|.{{GPUTextureCopyView/origin}}[0] + |copySize|[0] must be &le; |subresourceSize|[0].
+        - |textureCopyView|.{{GPUTextureCopyView/origin}}[1] + |copySize|[1] must be &le; |subresourceSize|[1].
+        - |textureCopyView|.{{GPUTextureCopyView/origin}}[2] + |copySize|[2] must be &le; |subresourceSize|[2].
+    - |copySize|[0] must be a multiple of |blockWidth|.
+    - |copySize|[1] must be a multiple of |blockHeight|.
 </div>
 
 Issue(gpuweb/gpuweb#69): Define the copies with {{GPUTextureDimension/1d}} and
@@ -4651,8 +4640,8 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
 
       - If |textureCopyView|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[dimension]]}}
         is {{GPUTextureDimension/"2d"}}:
-          - For each |arrayLayer| of the |copySize|.[=Extent3D/depth=] [=array layers=]
-            starting at |textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/z=]:
+          - For each |arrayLayer| of the |copySize|[2] [=array layers=]
+            starting at layer |textureCopyView|.{{GPUTextureCopyView/origin}}[2]:
               - The [=subresource=] of |textureCopyView|.{{GPUTextureCopyView/texture}} at
                 [=mipmap level=] |textureCopyView|.{{GPUTextureCopyView/mipLevel}} and
                 [=array layer=] |arrayLayer|.
@@ -6332,7 +6321,7 @@ GPUQueue includes GPUObjectBase;
 
             If any of the following conditions are unsatisfied, throw an {{OperationError}} and stop.
             <div class=validusage>
-                - |copySize|.[=Extent3D/depth=] is `1`.
+                - |copySize|[2] is `1`.
                 - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} is one of the following:
                     - {{GPUTextureFormat/"rgba8unorm"}}
                     - {{GPUTextureFormat/"rgba8unorm-srgb"}}
@@ -6777,7 +6766,7 @@ typedef [EnforceRange] long GPUSignedOffset32;
 typedef unsigned long GPUFlagsConstant;
 </script>
 
-## Colors &amp; Vectors ## {#colors-and-vectors}
+## GPUColor ## {#gpucolor}
 
 <script type=idl>
 dictionary GPUColorDict {
@@ -6792,67 +6781,57 @@ typedef (sequence<double> or GPUColorDict) GPUColor;
 Note: `double` is large enough to precisely hold 32-bit signed/unsigned
 integers and single-precision floats.
 
-<script type=idl>
-dictionary GPUOrigin2DDict {
-    GPUIntegerCoordinate x = 0;
-    GPUIntegerCoordinate y = 0;
-};
-typedef (sequence<GPUIntegerCoordinate> or GPUOrigin2DDict) GPUOrigin2D;
-</script>
+<!--
+It's a bit of a hack to override the usual conversion to sequence.
+But if we did it explicitly (e.g. with a "typecheck" algorithm), it would infect
+every dictionary that contains one of these members, and every method that takes
+any of those dictionaries or this type.
+-->
 
-<script type=idl>
-dictionary GPUOrigin3DDict {
-    GPUIntegerCoordinate x = 0;
-    GPUIntegerCoordinate y = 0;
-    GPUIntegerCoordinate z = 0;
-};
-typedef (sequence<GPUIntegerCoordinate> or GPUOrigin3DDict) GPUOrigin3D;
-</script>
+## GPUOrigin2D ## {#gpuorigin2d}
 
-An <dfn dfn>Origin3D</dfn> is a {{GPUOrigin3D}}.
-[=Origin3D=] is a spec namespace for the following definitions:
-<!-- This is silly, but provides convenient syntax for the spec. -->
+A <dfn typedef>GPUOrigin2D</dfn> is a [=sequence=] of exactly 2 {{GPUIntegerCoordinate}} values.
 
-<div algorithm="GPUOrigin3D accessors" dfn-for=Origin3D>
-    For a given {{GPUOrigin3D}} value |origin|, depending on its type, the syntax:
+<div algorithm="converting an ECMAScript value to GPUOrigin2D">
+    An ECMAScript value |V| is [=converted to an IDL value|converted=] to a {{GPUOrigin2D}} as follows:
 
-      - |origin|.<dfn dfn>x</dfn> refers to
-        either {{GPUOrigin3DDict}}.{{GPUOrigin3DDict/x}}
-        or the first item of the sequence.
-      - |origin|.<dfn dfn>y</dfn> refers to
-        either {{GPUOrigin3DDict}}.{{GPUOrigin3DDict/y}}
-        or the second item of the sequence.
-      - |origin|.<dfn dfn>z</dfn> refers to
-        either {{GPUOrigin3DDict}}.{{GPUOrigin3DDict/z}}
-        or the third item of the sequence.
+    - Let |S| be the result of [=converted to an IDL value|converting=]
+        |V| to an IDL [=sequence type|sequence&lt;GPUIntegerCoordinate&gt;=].
+    - If |S|.[=list/size=] &gt; 2, throw a {{TypeError}}.
+    - [=list/Extend=] |S| to exactly 2 elements, filling any missing elements with `0`.
+    - Return |S|.
 </div>
 
-<script type=idl>
-dictionary GPUExtent3DDict {
-    required GPUIntegerCoordinate width;
-    required GPUIntegerCoordinate height;
-    required GPUIntegerCoordinate depth;
-};
-typedef (sequence<GPUIntegerCoordinate> or GPUExtent3DDict) GPUExtent3D;
-</script>
+## GPUOrigin3D ## {#gpuorigin3d}
 
-An <dfn dfn>Extent3D</dfn> is a {{GPUExtent3D}}.
-[=Extent3D=] is a spec namespace for the following definitions:
-<!-- This is silly, but provides convenient syntax for the spec. -->
+A <dfn typedef>GPUOrigin3D</dfn> is a [=sequence=] of exactly 3 {{GPUIntegerCoordinate}} values.
 
-<div algorithm="GPUExtent3D accessors" dfn-for=Extent3D>
-    For a given {{GPUExtent3D}} value |extent|, depending on its type, the syntax:
+<div algorithm="converting an ECMAScript value to GPUOrigin3D">
+    An ECMAScript value |V| is [=converted to an IDL value|converted=] to a {{GPUOrigin3D}} as follows:
 
-      - |extent|.<dfn dfn>width</dfn> refers to
-        either {{GPUExtent3DDict}}.{{GPUExtent3DDict/width}}
-        or the first item of the sequence.
-      - |extent|.<dfn dfn>height</dfn> refers to
-        either {{GPUExtent3DDict}}.{{GPUExtent3DDict/height}}
-        or the second item of the sequence.
-      - |extent|.<dfn dfn>depth</dfn> refers to
-        either {{GPUExtent3DDict}}.{{GPUExtent3DDict/depth}}
-        or the third item of the sequence.
+    - Let |S| be the result of [=converted to an IDL value|converting=]
+        |V| to an IDL [=sequence type|sequence&lt;GPUIntegerCoordinate&gt;=].
+    - If |S|.[=list/size=] &gt; 3, throw a {{TypeError}}.
+    - [=list/Extend=] |S| to exactly 3 elements, filling any missing elements with `0`.
+    - Return |S|.
+
+    Note: This modification occurs after conversion of an ECMAScript object to
+    WebIDL; it does not affect the incoming ECMAScript object.
 </div>
+
+## GPUExtent3D ## {#gpuextent3d}
+
+A <dfn typedef>GPUExtent3D</dfn> is a [=sequence=] of exactly 3 {{GPUIntegerCoordinate}} values.
+
+<div algorithm="converting an ECMAScript value to GPUExtent3D">
+    An ECMAScript value |V| is [=converted to an IDL value|converted=] to a {{GPUExtent3D}} as follows:
+
+    - Let |S| be the result of [=converted to an IDL value|converting=]
+        |V| to an IDL [=sequence type|sequence&lt;GPUIntegerCoordinate&gt;=].
+    - If |S|.[=list/size=] &ne; 3, throw a {{TypeError}}.
+    - Return |S|.
+</div>
+
 
 # Appendices # {#appendices}
 


### PR DESCRIPTION
This overload adds complexity without providing much benefit of clarity.
The semantics of the values in an array are clear according to context:

- 1d: [width]
- 1d-array: [width, arraysize]
- 2d: [width, height]
- 2d-array/cube/cube-array: [width, height, arraysize]
- 3d: [width, height, depth]

In order to implement this, this redefines GPUOrigin2D, GPUOrigin3D, and
GPUExtent3D from scratch, as if they were specified in the WebIDL spec.
These essentially implement a specific case of tuples with default
values, which could be expressed in pseudo-WebIDL as:

```
typedef [GPUIntegerCoordinate = 0, GPUIntegerCoordinate = 0] GPUOrigin2D;
typedef [GPUIntegerCoordinate = 0, GPUIntegerCoordinate = 0, GPUIntegerCoordinate = 0] GPUOrigin3D;
typedef [GPUIntegerCoordinate, GPUIntegerCoordinate, GPUIntegerCoordinate] GPUExtent3D;
```

I previously proposed this in #299. After discussion, we compromised on
this union, and it was implemented in #319. However there were a number
of voices who didn't like the added complexity (and perceived loss of
type expressivity), and since then I've come to agree that the unioned
version is not the best choice.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1081.html" title="Last updated on Sep 16, 2020, 12:47 AM UTC (ba0a1b9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1081/6e46b3b...kainino0x:ba0a1b9.html" title="Last updated on Sep 16, 2020, 12:47 AM UTC (ba0a1b9)">Diff</a>