### PR TITLE
[wgsl] Add GLSL.std.450 methods to spec.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -120,7 +120,7 @@ Note: literals are parsed greedy. This means that for statements like `a -5`
 
 TODO: This is a stub.
 
-(Forward Reference) A name can denote a value, a type, a function, a variable, an import.
+(Forward Reference) A name can denote a value, a type, a function, or a variable.
 
 ### Scoping ### {#scoping}
 
@@ -137,11 +137,6 @@ declared.
 A declaration must not introduce a name when that name is already in scope at the start
 of the declaration.
 That is, shadow names are not allowed in [SHORTNAME].
-
-### Identifier name spaces TODO ### {#namespace}
-
-TODO: *Stub* Identifiers vs. attributes vs imports vs. ?
-For example, an attribute may have the same name as an identifier.
 
 
 # Types # {#types}
@@ -1954,7 +1949,7 @@ TODO: *Stub*: how to write each of the abstract pointer operations
 
 <pre class='def'>
 primary_expression
-  : (IDENT NAMESPACE)* IDENT
+  : IDENT
   | type_decl argument_expression_list
   | const_literal
   | paren_rhs_statement
@@ -2472,31 +2467,6 @@ statement
 </pre>
 
 
-# Imports TODO # {#imports}
-
-TODO: *Stub* In the abstract, what is the purpose of an import, and what does it provide.
-
-There is one import provided which is `GLSL.std.450`. All other uses of `import`
-will be rejected by [SHORTNAME] as being unknown. All uses of the imported methods must
-be prefixed by the import name as provided after the `as` keyword.
-
-<pre class='def'>
-import_decl
-  : IMPORT STRING_LITERAL AS (IDENT NAMESPACE)* IDENT
-</pre>
-
-The methods defined in `GLSL.std.450` become available with the given prefix.
-The initial import will add an `OpExtInstImport` instruction to the SPIR-V
-module header and each usage of a GLSL method will add the appropriate
-`OpExtIns` invocation.
-
-<div class='example' heading='Import'>
-  <xmp>
-    import "GLSL.std.450" as std::glsl;
-      %1 = OpExtInstImport "GLSL.std.450"
-  </xmp>
-</div>
-
 # Functions TODO # {#functions}
 
 A function declaration may only occur at module scope.
@@ -2673,7 +2643,6 @@ translation_unit
 <pre class='def'>
 global_decl
   : SEMICOLON
-  | import_decl SEMICOLON
   | global_variable_decl SEMICOLON
   | global_constant_decl SEMICOLON
   | entry_point_decl SEMICOLON
@@ -2851,7 +2820,6 @@ Issue: (dneto) Default rounding mode is an implementation choice.  Is that what 
   <tr><td>`FUNCTION`<td>function
   <tr><td>`IF`<td>if
   <tr><td>`IMAGE`<td>image
-  <tr><td>`IMPORT`<td>import
   <tr><td>`IN`<td>in
   <tr><td>`LOCATION`<td>location
   <tr><td>`LOOP`<td>loop
@@ -2970,7 +2938,6 @@ The following is a list of keywords which are reserved for future expansion.
   <tr><td>`SHIFT_LEFT`<td>`<<`
   <tr><td>`MODULO`<td>`%`
   <tr><td>`MINUS`<td>`-`
-  <tr><td>`NAMESPACE`<td>`::`
   <tr><td>`PERIOD`<td>`.`
   <tr><td>`PLUS`<td>`+`
   <tr><td>`OR`<td>`|`
@@ -2991,7 +2958,6 @@ Each validation item will be given a unique ID and a test must be provided
 when the validation is added. The tests will reference the validation ID in
 the test name.
 
-* v-0001: Only allowed import is “GLSL.std.450”
 * v-0002: Functions must end with a return statement.
 * v-0003: At least one of vertex, fragment or compute shader must be present.
 * v-0004: Recursion is not allowed.
@@ -3142,36 +3108,451 @@ TODO: deduplicate these tables
   <tr><td>*e* : *T*, *T* is *FloatVec*<td>`isNormal(e)` : bool<*N*>, where *N = Arity(T)*<td>OpIsNormal, or emulate
 </table>
 
+## Float built-in functions ## {#float-builtin-functions}
+
+<table class='data'>
+  <thead>
+    <tr><td>Precondition<td>Built-in<td>Description
+  </thead>
+  <tr algorithm="scalar case, float abs">
+    <td>|T| is f32
+    <td class="nowrap">`abs(`|e|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450FAbs)
+  <tr algorithm="vector case, float abs">
+    <td>|T| is f32
+    <td class="nowrap">`abs(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
+    <td>(GLSLstd450FAbs)
+  <tr algorithm="scalar case, acos">
+    <td>|T| is f32
+    <td class="nowrap">`acos(`|e|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450Acos)
+  <tr algorithm="vector case, acos">
+    <td>|T| is f32
+    <td class="nowrap">`acos(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
+    <td>(GLSLstd450Acos)
+  <tr algorithm="scalar case, asin">
+    <td>|T| is f32
+    <td class="nowrap">`asin(`|e|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450Asin)
+  <tr algorithm="vector case, asin">
+    <td>|T| is f32
+    <td class="nowrap">`asin(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
+    <td>(GLSLstd450Asin)
+  <tr algorithm="scalar case, atan">
+    <td>|T| is f32
+    <td class="nowrap">`atan(`|e|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450Atan)
+  <tr algorithm="vector case, atan">
+    <td>|T| is f32
+    <td class="nowrap">`atan(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
+    <td>(GLSLstd450Atan)
+  <tr algorithm="scalar case, atan2">
+    <td>|T| is f32
+    <td class="nowrap">`atan2(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450Atan2)
+  <tr algorithm="vector case, atan2">
+    <td>|T| is f32
+    <td class="nowrap">`atan2(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
+    <td>(GLSLstd450Atan2)
+  <tr algorithm="scalar case, ceil">
+    <td>|T| is f32
+    <td class="nowrap">`ceil(`|e|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450Ceil)
+  <tr algorithm="vector case, ceil">
+    <td>|T| is f32
+    <td class="nowrap">`ceil(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
+    <td>(GLSLstd450Ceil)
+  <tr algorithm="scalar case, clamp">
+    <td>|T| is f32
+    <td class="nowrap">`clamp(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T|`) -> ` |T|
+    <td>(GLSLstd450FClamp)
+  <tr algorithm="vector case, clamp">
+    <td>|T| is f32
+    <td class="nowrap">`clamp(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`, `|e3|`:` vec|N|<|T|>`) -> ` vec|N|<|T|>
+    <td>(GLSLstd450FClamp)
+  <tr algorithm="scalar case, cos">
+    <td>|T| is f32
+    <td class="nowrap">`cos(`|e|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450Cos)
+  <tr algorithm="vector case, cos">
+    <td>|T| is f32
+    <td class="nowrap">`cos(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
+    <td>(GLSLstd450Cos)
+  <tr algorithm="scalar case, cosh">
+    <td>|T| is f32
+    <td class="nowrap">`cosh(`|e|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450Cosh)
+  <tr algorithm="vector case, cosh">
+    <td>|T| is f32
+    <td class="nowrap">`cosh(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
+    <td>(GLSLstd450Cosh)
+  <tr algorithm="vector case, cross">
+    <td>|T| is f32
+    <td class="nowrap">`cross(`|e1|`:` vec3<|T|> `, `|e2|`:` vec3<|T|>`) -> ` vec3<|T|>
+    <td>(GLSLstd450Cross)
+  <tr algorithm="scalar case, distance">
+    <td>|T| is f32
+    <td class="nowrap">`distance(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450Distance)
+  <tr algorithm="vector case, distance">
+    <td>|T| is f32
+    <td class="nowrap">`distance(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`) -> ` vec|N|<|T|>
+    <td>(GLSLstd450Distance)
+  <tr algorithm="scalar case, exp">
+    <td>|T| is f32
+    <td class="nowrap">`exp(`|e|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450Exp)
+  <tr algorithm="vector case, exp">
+    <td>|T| is f32
+    <td class="nowrap">`exp(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
+    <td>(GLSLstd450Exp)
+  <tr algorithm="scalar case, exp2">
+    <td>|T| is f32
+    <td class="nowrap">`exp2(`|e|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450Exp2)
+  <tr algorithm="vector case, exp2">
+    <td>|T| is f32
+    <td class="nowrap">`exp2(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
+    <td>(GLSLstd450Exp2)
+  <tr algorithm="scalar case, faceForward">
+    <td>|T| is f32
+    <td class="nowrap">`faceForward(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450FaceForward)
+  <tr algorithm="vector case, faceForward">
+    <td>|T| is f32
+    <td class="nowrap">`faceForward(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`, `|e3|`:` vec|N|<|T|>`) -> ` vec|N|<|T|>
+    <td>(GLSLstd450FaceForward)
+  <tr algorithm="scalar case, floor">
+    <td>|T| is f32
+    <td class="nowrap">`floor(`|e|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450Floor)
+  <tr algorithm="vector case, floor">
+    <td>|T| is f32
+    <td class="nowrap">`floor(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
+    <td>(GLSLstd450Floor)
+  <tr algorithm="scalar case, fma">
+    <td>|T| is f32
+    <td class="nowrap">`fma(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450Fma)
+  <tr algorithm="vector case, fma">
+    <td>|T| is f32
+    <td class="nowrap">`fma(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`, `|e3|`:` vec|N|<|T|>`) -> ` vec|N|<|T|>
+    <td>(GLSLstd450Fma)
+  <tr algorithm="scalar case, fract">
+    <td>|T| is f32
+    <td class="nowrap">`fract(`|e|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450Fract)
+  <tr algorithm="vector case, fract">
+    <td>|T| is f32
+    <td class="nowrap">`fract(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
+    <td>(GLSLstd450Fract)
+  <tr algorithm="scalar case, frexp">
+    <td>|T| is f32<br>
+        |I| is i32 or u32
+    <td class="nowrap">`frexp(`|e1|`:` |T| `, `|e2|`:` ptr<|I|> `) -> ` |T|
+    <td>(GLSLstd450Frexp)
+  <tr algorithm="vector case, frexp">
+    <td>|T| is f32<br>
+        |I| is i32 or u32
+    <td class="nowrap">`frexp(`|e1|`:` vec|N|<|T|> `, `|e2|`:` ptr&lt;vec|N|&lt;|I|&gt;&gt;`) -> ` vec|N|<|T|>
+    <td>(GLSLstd450Frexp)
+  <tr algorithm="scalar case, inverseSqrt">
+    <td>|T| is f32
+    <td class="nowrap">`inverseSqrt(`|e|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450InverseSqrt)
+  <tr algorithm="vector case, inverseSqrt">
+    <td>|T| is f32
+    <td class="nowrap">`inverseSqrt(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
+    <td>(GLSLstd450InverseSqrt)
+  <tr algorithm="scalar case, ldexp">
+    <td>|T| is f32<br>
+        |I| is i32 or u32
+    <td class="nowrap">`ldexp(`|e1|`:` |T| `, `|e2|`:` ptr<|I|> `) -> ` |T|
+    <td>(GLSLstd450Ldexp)
+  <tr algorithm="vector case, ldexp">
+    <td>|T| is f32<br>
+        |I| is i32 or u32
+    <td class="nowrap">`ldexp(`|e1|`:` vec|N|<|T|> `, `|e2|`:` ptr&lt;vec|N|&lt;|I|&gt;&gt;`) -> ` vec|N|<|T|>
+    <td>(GLSLstd450Ldexp)
+  <tr algorithm="scalar case, length">
+    <td>|T| is f32
+    <td class="nowrap">`length(`|e|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450Length)
+  <tr algorithm="vector case, length">
+    <td>|T| is f32
+    <td class="nowrap">`length(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
+    <td>(GLSLstd450Length)
+  <tr algorithm="scalar case, log">
+    <td>|T| is f32
+    <td class="nowrap">`log(`|e|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450Log)
+  <tr algorithm="vector case, log">
+    <td>|T| is f32
+    <td class="nowrap">`log(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
+    <td>(GLSLstd450Log)
+  <tr algorithm="scalar case, log2">
+    <td>|T| is f32
+    <td class="nowrap">`log2(`|e|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450Log2)
+  <tr algorithm="vector case, log2">
+    <td>|T| is f32
+    <td class="nowrap">`log2(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
+    <td>(GLSLstd450Log2)
+  <tr algorithm="scalar case, max">
+    <td>|T| is f32
+    <td class="nowrap">`max(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450FMax)
+  <tr algorithm="vector case, max">
+    <td>|T| is f32
+    <td class="nowrap">`max(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`) -> ` vec|N|<|T|>
+    <td>(GLSLstd450FMax)
+  <tr algorithm="scalar case, min">
+    <td>|T| is f32
+    <td class="nowrap">`min(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450FMin)
+  <tr algorithm="vector case, min">
+    <td>|T| is f32
+    <td class="nowrap">`min(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`) -> ` vec|N|<|T|>
+    <td>(GLSLstd450FMin)
+  <tr algorithm="scalar case, mix">
+    <td>|T| is f32
+    <td class="nowrap">`mix(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T|`) -> ` |T|
+    <td>(GLSLstd450FMix)
+  <tr algorithm="vector case, mix">
+    <td>|T| is f32
+    <td class="nowrap">`mix(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`, `|e3|`:` vec|N|<|T|>`) -> ` vec|N|<|T|>
+    <td>(GLSLstd450Modf)
+  <tr algorithm="scalar case, modf">
+    <td>|T| is f32<br>
+    <td class="nowrap">`modf(`|e1|`:` |T| `, `|e2|`:` ptr<|T|> `) -> ` |T|
+    <td>(GLSLstd450Modf)
+  <tr algorithm="vector case, modf">
+    <td>|T| is f32
+    <td class="nowrap">`modf(`|e1|`:` vec|N|<|T|> `, `|e2|`:` ptr&lt;vec|N|&lt;|T|&gt;&gt;`) -> ` vec|N|<|T|>
+    <td>(GLSLstd450Modf)
+  <tr algorithm="scalar case, nclamp">
+    <td>|T| is f32
+    <td class="nowrap">`nclamp(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T|`) -> ` |T|
+    <td>(GLSLstd450NClamp)
+  <tr algorithm="vector case, nclamp">
+    <td>|T| is f32
+    <td class="nowrap">`nclamp(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`, `|e3|`:` vec|N|<|T|>`) -> ` vec|N|<|T|>
+    <td>(GLSLstd450NClamp)
+  <tr algorithm="scalar case, nmax">
+    <td>|T| is f32
+    <td class="nowrap">`nmax(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450NMax)
+  <tr algorithm="vector case, nmax">
+    <td>|T| is f32
+    <td class="nowrap">`nmax(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`) -> ` vec|N|<|T|>
+    <td>(GLSLstd450NMax)
+  <tr algorithm="scalar case, nmin">
+    <td>|T| is f32
+    <td class="nowrap">`nmin(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450NMin)
+  <tr algorithm="vector case, nmin">
+    <td>|T| is f32
+    <td class="nowrap">`nmin(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`) -> ` vec|N|<|T|>
+    <td>(GLSLstd450NMin)
+  <tr algorithm="vector case, normalize">
+    <td>|T| is f32
+    <td class="nowrap">`normalize(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
+    <td>(GLSLstd450Normalize)
+  <tr algorithm="scalar case, pow">
+    <td>|T| is f32
+    <td class="nowrap">`pow(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450Pow)
+  <tr algorithm="vector case, pow">
+    <td>|T| is f32
+    <td class="nowrap">`pow(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
+    <td>(GLSLstd450Pow)
+  <tr algorithm="scalar case, reflect">
+    <td>|T| is f32
+    <td class="nowrap">`reflect(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450Reflect)
+  <tr algorithm="vector case, reflect">
+    <td>|T| is f32
+    <td class="nowrap">`reflect(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`) -> ` vec|N|<|T|>
+    <td>(GLSLstd450Reflect)
+  <tr algorithm="scalar case, round">
+    <td>|T| is f32
+    <td class="nowrap">`round(`|e|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450Round)
+  <tr algorithm="vector case, round">
+    <td>|T| is f32
+    <td class="nowrap">`round(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
+    <td>(GLSLstd450Round)
+  <tr algorithm="scalar case, float sign">
+    <td>|T| is f32
+    <td class="nowrap">`sign(`|e|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450FSign)
+  <tr algorithm="vector case, float sign">
+    <td>|T| is f32
+    <td class="nowrap">`sign(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
+    <td>(GLSLstd450FSign)
+  <tr algorithm="scalar case, sin">
+    <td>|T| is f32
+    <td class="nowrap">`sin(`|e|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450Sin)
+  <tr algorithm="vector case, sin">
+    <td>|T| is f32
+    <td class="nowrap">`sin(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
+    <td>(GLSLstd450Sin)
+  <tr algorithm="scalar case, sinh">
+    <td>|T| is f32
+    <td class="nowrap">`sinh(`|e|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450Sinh)
+  <tr algorithm="vector case, sinh">
+    <td>|T| is f32
+    <td class="nowrap">`sinh(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
+    <td>(GLSLstd450Sinh)
+  <tr algorithm="scalar case, smoothStep">
+    <td>|T| is f32
+    <td class="nowrap">`smoothStep(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450SmoothStep)
+  <tr algorithm="vector case, smoothStep">
+    <td>|T| is f32
+    <td class="nowrap">`smoothStep(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`, `|e3|`:` vec|N|<|T|>`) -> ` vec|N|<|T|>
+    <td>(GLSLstd450SmoothStep)
+  <tr algorithm="scalar case, sqrt">
+    <td>|T| is f32
+    <td class="nowrap">`sqrt(`|e|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450Sqrt)
+  <tr algorithm="vector case, sqrt">
+    <td>|T| is f32
+    <td class="nowrap">`sqrt(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
+    <td>(GLSLstd450Sqrt)
+  <tr algorithm="scalar case, step">
+    <td>|T| is f32
+    <td class="nowrap">`step(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450Step)
+  <tr algorithm="vector case, step">
+    <td>|T| is f32
+    <td class="nowrap">`step(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`) -> ` vec|N|<|T|>
+    <td>(GLSLstd450Step)
+  <tr algorithm="scalar case, tan">
+    <td>|T| is f32
+    <td class="nowrap">`tan(`|e|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450Tan)
+  <tr algorithm="vector case, tan">
+    <td>|T| is f32
+    <td class="nowrap">`tan(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
+    <td>(GLSLstd450Tan)
+  <tr algorithm="scalar case, tanh">
+    <td>|T| is f32
+    <td class="nowrap">`tanh(`|e|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450Tanh)
+  <tr algorithm="vector case, tanh">
+    <td>|T| is f32
+    <td class="nowrap">`tanh(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
+    <td>(GLSLstd450Tanh)
+  <tr algorithm="scalar case, trunc">
+    <td>|T| is f32
+    <td class="nowrap">`trunc(`|e|`:` |T| `) -> ` |T|
+    <td>(GLSLstd450Trunc)
+  <tr algorithm="vector case, trunc">
+    <td>|T| is f32
+    <td class="nowrap">`trunc(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
+    <td>(GLSLstd450Trunc)
+</table>
+
 ## Integer built-in functions ## {#integer-builtin-functions}
 
 <table class='data'>
   <thead>
     <tr><td>Precondition<td>Built-in<td>Description
   </thead>
-  <tr algorithm="scalar case, count 1 bits"><td>
-          |T| is u32 or i32<br>
-      <td class="nowrap">`countOneBits(`|e|`:` |T| `) ->` |T|
-      <td>The number of 1 bits in the representation of |e|.<br>
-          Also known as "population count".<br>
-          (SPIR-V OpBitCount)
-  <tr algorithm="vector case, count 1 bits"><td>
-          |T| is u32 or i32
-      <td class="nowrap">`countOneBits(`|e|`:` vec|N|<|T|>`) ->` vec|N|<|T|><br>
-      <td>Component-wise population count:
-          Component |i| of the result is `countOneBits(`|e|`[`|i|`])`<br>
-          (SPIR-V OpBitCount)
-  <tr algorithm="scalar bit reversal"><td>
-          |T| is u32 or i32<br>
-      <td class="nowrap">`reverseBits(`|e|`:` |T| `) ->`  |T|
-      <td>Reverses the bits in |e|:  The bit at position |k| of the result equals the
-          bit at position 31-|k| of |e|.<br>
-          (SPIR-V OpBitReverse)
-  <tr algorithm="vector bit reversal"><td>
-          |T| is u32 or i32
-      <td class="nowrap">`reverseBits(`|e|`:` vec|N|<|T|> `) ->` vec|N|<|T|><br>
-      <td>Component-wise bit reversal:
-          Component |i| of the result is `reverseBits(`|e|`[`|i|`])`<br>
-          (SPIR-V OpBitReverse)
+  <tr algorithm="scalar case, abs">
+    <td>|T| is u32 or i32
+    <td class="nowrap">`abs(`|e|`:` |T| `) ->` |T|
+    <td>(GLSLstd450SAbs)
+  <tr algorithm="vector case, abs">
+    <td>|T| is u32 or i32
+    <td class="nowrap">`abs(`|e|`:` vec|N|<|T|> `) ->` vec|N|<|T|>
+    <td>(GLSLstd450SAbs)
+  <tr algorithm="scalar case, unsigned clamp">
+    <td>|T| is u32
+    <td class="nowrap">`clamp(`|e1|`:` |T| `, `|e2|`:` |T|`, `|e3|`:` |T|`) ->` |T|
+    <td>(GLSLstd450UClamp)
+  <tr algorithm="vector case, unsigned clamp">
+    <td>|T| is i32
+    <td class="nowrap">`clamp(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`, `|e3|`:`vec|N|<|T|> `) ->` vec|N|<|T|>
+    <td>(GLSLstd450UClamp)
+  <tr algorithm="scalar case, signed clamp">
+    <td>|T| is i32
+    <td class="nowrap">`clamp(`|e1|`:` |T| `, `|e2|`:` |T|`, `|e3|`:` |T|`) ->` |T|
+    <td>(GLSLstd450SClamp)
+  <tr algorithm="vector case, signed clamp">
+    <td>|T| is i32
+    <td class="nowrap">`clamp(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`, `|e3|`:`vec|N|<|T|> `) ->` vec|N|<|T|>
+    <td>(GLSLstd450SClamp)
+  <tr algorithm="scalar case, count 1 bits">
+    <td>|T| is u32 or i32<br>
+    <td class="nowrap">`countOneBits(`|e|`:` |T| `) ->` |T|
+    <td>The number of 1 bits in the representation of |e|.<br>
+        Also known as "population count".<br>
+        (SPIR-V OpBitCount)
+  <tr algorithm="vector case, count 1 bits">
+    <td>|T| is u32 or i32
+    <td class="nowrap">`countOneBits(`|e|`:` vec|N|<|T|>`) ->` vec|N|<|T|><br>
+    <td>Component-wise population count:
+        Component |i| of the result is `countOneBits(`|e|`[`|i|`])`<br>
+        (SPIR-V OpBitCount)
+  <tr algorithm="scalar case, unsigned max">
+    <td>|T| is u32
+    <td class="nowrap">`max(`|e1|`:` |T| `, `|e2|`:` |T|`) ->` |T|
+    <td>(GLSLstd450UMax)
+  <tr algorithm="vector case, unsigned max">
+    <td>|T| is i32
+    <td class="nowrap">`max(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`) ->` vec|N|<|T|>
+    <td>(GLSLstd450UMax)
+  <tr algorithm="scalar case, signed max">
+    <td>|T| is i32
+    <td class="nowrap">`max(`|e1|`:` |T| `, `|e2|`:` |T|`) ->` |T|
+    <td>(GLSLstd450SMax)
+  <tr algorithm="vector case, signed max">
+    <td>|T| is i32
+    <td class="nowrap">`max(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`) ->` vec|N|<|T|>
+    <td>(GLSLstd450SMax)
+  <tr algorithm="scalar case, unsigned min">
+    <td>|T| is u32
+    <td class="nowrap">`min(`|e1|`:` |T| `, `|e2|`:` |T|`) ->` |T|
+    <td>(GLSLstd450UMin)
+  <tr algorithm="vector case, unsigned min">
+    <td>|T| is i32
+    <td class="nowrap">`min(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`) ->` vec|N|<|T|>
+    <td>(GLSLstd450UMin)
+  <tr algorithm="scalar case, signed min">
+    <td>|T| is i32
+    <td class="nowrap">`min(`|e1|`:` |T| `, `|e2|`:` |T|`) ->` |T|
+    <td>(GLSLstd450SMin)
+  <tr algorithm="vector case, signed min">
+    <td>|T| is i32
+    <td class="nowrap">`min(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`) ->` vec|N|<|T|>
+    <td>(GLSLstd450SMin)
+  <tr algorithm="scalar bit reversal">
+    <td>|T| is u32 or i32<br>
+    <td class="nowrap">`reverseBits(`|e|`:` |T| `) ->`  |T|
+    <td>Reverses the bits in |e|:  The bit at position |k| of the result equals the
+        bit at position 31-|k| of |e|.<br>
+        (SPIR-V OpBitReverse)
+  <tr algorithm="vector bit reversal">
+    <td>|T| is u32 or i32
+    <td class="nowrap">`reverseBits(`|e|`:` vec|N|<|T|> `) ->` vec|N|<|T|><br>
+    <td>Component-wise bit reversal:
+        Component |i| of the result is `reverseBits(`|e|`[`|i|`])`<br>
+        (SPIR-V OpBitReverse)
+</table>
+
+## Matrix built-in functions ## {#matrix-builtin-functions}
+<table class='data'>
+  <thead>
+    <tr><td>Precondition<td>Built-in<td>Description
+  </thead>
+  <tr algorithm="determinant">
+    <td>|T| is f32
+    <td class="nowrap">`determinant(`|e|`:` mat|N|x|N|<|T|> `) -> ` vec|N|<|T|>
+    <td>(GLSLstd450Determinant)
 </table>
 
 ## Vector built-in functions ## {#vector-builtin-functions}
@@ -3221,7 +3602,7 @@ TODO: deduplicate these tables
 `vec4<type> textureLoad(texture_multisampled_2d, vec2<i32> coords, i32 sample_index)`
   %32 = OpImageFetch %v4float %texture_multisampled %coords Sample %sample_index
 
-TODO(dsinclair): Add `texture_write` method for texture_wo with integral coords
+TODO(dsinclair): Add `textureWrite` method for texture_wo with integral coords
 
 TODO(dsinclair): Allow a small constant offset on the coordinate? May not be portable.
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5,6 +5,7 @@ Level: 1
 Status: w3c/ED
 Group: webgpu
 URL: https://gpuweb.github.io/gpuweb/wgsl.html
+Ignored Vars: e, e1, e2, e3
 
 !Participate: <a href="https://github.com/gpuweb/gpuweb/issues/new?labels=wgsl">File an issue</a> (<a href="https://github.com/gpuweb/gpuweb/issues?q=is%3Aissue+is%3Aopen+label%3Awgsl">open issues</a>)
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3166,11 +3166,11 @@ TODO: deduplicate these tables
   <tr algorithm="scalar case, clamp">
     <td>|T| is f32
     <td class="nowrap">`clamp(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T|`) -> ` |T|
-    <td>(GLSLstd450FClamp)
+    <td>(GLSLstd450NClamp)
   <tr algorithm="vector case, clamp">
     <td>|T| is f32
     <td class="nowrap">`clamp(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`, `|e3|`:` vec|N|<|T|>`) -> ` vec|N|<|T|>
-    <td>(GLSLstd450FClamp)
+    <td>(GLSLstd450NClamp)
   <tr algorithm="scalar case, cos">
     <td>|T| is f32
     <td class="nowrap">`cos(`|e|`:` |T| `) -> ` |T|
@@ -3302,19 +3302,19 @@ TODO: deduplicate these tables
   <tr algorithm="scalar case, max">
     <td>|T| is f32
     <td class="nowrap">`max(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
-    <td>(GLSLstd450FMax)
+    <td>(GLSLstd450NMax)
   <tr algorithm="vector case, max">
     <td>|T| is f32
     <td class="nowrap">`max(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`) -> ` vec|N|<|T|>
-    <td>(GLSLstd450FMax)
+    <td>(GLSLstd450NMax)
   <tr algorithm="scalar case, min">
     <td>|T| is f32
     <td class="nowrap">`min(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
-    <td>(GLSLstd450FMin)
+    <td>(GLSLstd450NMin)
   <tr algorithm="vector case, min">
     <td>|T| is f32
     <td class="nowrap">`min(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`) -> ` vec|N|<|T|>
-    <td>(GLSLstd450FMin)
+    <td>(GLSLstd450NMin)
   <tr algorithm="scalar case, mix">
     <td>|T| is f32
     <td class="nowrap">`mix(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T|`) -> ` |T|
@@ -3331,30 +3331,6 @@ TODO: deduplicate these tables
     <td>|T| is f32
     <td class="nowrap">`modf(`|e1|`:` vec|N|<|T|> `, `|e2|`:` ptr&lt;vec|N|&lt;|T|&gt;&gt;`) -> ` vec|N|<|T|>
     <td>(GLSLstd450Modf)
-  <tr algorithm="scalar case, nclamp">
-    <td>|T| is f32
-    <td class="nowrap">`nclamp(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T|`) -> ` |T|
-    <td>(GLSLstd450NClamp)
-  <tr algorithm="vector case, nclamp">
-    <td>|T| is f32
-    <td class="nowrap">`nclamp(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`, `|e3|`:` vec|N|<|T|>`) -> ` vec|N|<|T|>
-    <td>(GLSLstd450NClamp)
-  <tr algorithm="scalar case, nmax">
-    <td>|T| is f32
-    <td class="nowrap">`nmax(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
-    <td>(GLSLstd450NMax)
-  <tr algorithm="vector case, nmax">
-    <td>|T| is f32
-    <td class="nowrap">`nmax(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`) -> ` vec|N|<|T|>
-    <td>(GLSLstd450NMax)
-  <tr algorithm="scalar case, nmin">
-    <td>|T| is f32
-    <td class="nowrap">`nmin(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
-    <td>(GLSLstd450NMin)
-  <tr algorithm="vector case, nmin">
-    <td>|T| is f32
-    <td class="nowrap">`nmin(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`) -> ` vec|N|<|T|>
-    <td>(GLSLstd450NMin)
   <tr algorithm="vector case, normalize">
     <td>|T| is f32
     <td class="nowrap">`normalize(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>


### PR DESCRIPTION
This CL adds the definitions of the methods from GLSL.std.450 into the
spec. The `import` keyword is removed and the methods are placed in the
global namespace. This also means the NAMESPACE version of identifiers
is also removed.

Issue #1018