### PR TITLE
Convert attribute lists to allow multiple entries.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -315,7 +315,7 @@ Issue: (dneto): Runtime-sized array is only usable as the last element of a stru
 
 <pre class='def'>
 struct_decl
-  : struct_decoration_decl? STRUCT IDENT struct_body_decl
+  : struct_decoration_decl* STRUCT IDENT struct_body_decl
 
 struct_decoration_decl
   : ATTR_LEFT struct_decoration ATTR_RIGHT
@@ -327,7 +327,7 @@ struct_body_decl
   : BRACE_LEFT struct_member* BRACE_RIGHT
 
 struct_member
-  : struct_member_decoration_decl variable_ident_decl SEMICOLON
+  : struct_member_decoration_decl+ variable_ident_decl SEMICOLON
 
 struct_member_decoration_decl
   :
@@ -772,8 +772,8 @@ type_decl
   | VEC3 LESS_THAN type_decl GREATER_THAN
   | VEC4 LESS_THAN type_decl GREATER_THAN
   | POINTER LESS_THAN storage_class COMMA type_decl GREATER_THAN
-  | array_decoration_list? ARRAY LESS_THAN type_decl COMMA INT_LITERAL GREATER_THAN
-  | array_decoration_list? ARRAY LESS_THAN type_decl GREATER_THAN
+  | array_decoration_list* ARRAY LESS_THAN type_decl COMMA INT_LITERAL GREATER_THAN
+  | array_decoration_list* ARRAY LESS_THAN type_decl GREATER_THAN
   | MAT2x2 LESS_THAN type_decl GREATER_THAN
   | MAT2x3 LESS_THAN type_decl GREATER_THAN
   | MAT2x4 LESS_THAN type_decl GREATER_THAN
@@ -922,9 +922,9 @@ of the program.
 
 <pre class='def'>
 global_variable_decl
-  : variable_decoration_list? variable_decl
-  | variable_decoration_list? sampler_or_texture_decl
-  | variable_decoration_list? variable_decl EQUAL const_expr
+  : variable_decoration_list* variable_decl
+  | variable_decoration_list* sampler_or_texture_decl
+  | variable_decoration_list* variable_decl EQUAL const_expr
 
 variable_decoration_list
   : ATTR_LEFT (variable_decoration COMMA)* variable_decoration ATTR_RIGHT
@@ -999,7 +999,7 @@ is the one from the constant's declaration or from a pipeline override.
 
 <pre class='def'>
 global_constant_decl
-  : global_const_decoration_list? CONST variable_ident_decl global_const_initializer?
+  : global_const_decoration_list* CONST variable_ident_decl global_const_initializer?
 
 global_const_decoration_list
   : ATTR_LEFT global_const_decoration ATTR_RIGHT


### PR DESCRIPTION
Previously you could only have a single attribute group for anything
which required attributes. This Cl updates to allow the attributes to be
provided in separate groupings.

```
[[binding(1), set(0)]]
```
is equivalent to
```
[[binding(1)]]
[[set(0)]]
```

Fixes #1067