### PR TITLE
Add "multisampled-texture" to maxSampledTexturesPerShaderStage

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1212,7 +1212,8 @@ dictionary GPULimits {
         For each possible {{GPUShaderStage}} `stage`,
         the maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
 
-          - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampled-texture"}}, and
+          - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampled-texture"}} or
+            {{GPUBindingType/"multisampled-texture"}}, and
           - {{GPUBindGroupLayoutEntry/visibility}} includes `stage`,
 
         across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/1084.html" title="Last updated on Sep 17, 2020, 12:41 PM UTC (5ea8847)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1084/08ba1ed...Kangz:5ea8847.html" title="Last updated on Sep 17, 2020, 12:41 PM UTC (5ea8847)">Diff</a>