### PR TITLE
[wgsl] Make body statement optional in statement.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2468,7 +2468,7 @@ statement
   | continue_statement SEMICOLON
   | DISCARD SEMICOLON
   | assignment_statement SEMICOLON
-  | body_statement
+  | body_statement?
 </pre>
 
 


### PR DESCRIPTION
Currently the spec accidentally requires a body statement if none of the
other statement types match. This is incorrect and the body_statement
should be made optional.