### PR TITLE
Remove type generic from RO texture types

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -559,25 +559,22 @@ type.
 
 ### Read-only Storage Texture Types ### {#texture-ro}
 <pre class='def'>
-`texture_ro_1d<type, image_storage_type>`
-  %1 = OpTypeImage %type 1D 0 0 0 2 image_storage_type ReadOnly
+`texture_ro_1d<image_storage_type>`
+  %1 = OpTypeImage type(image_storage_type) 1D 0 0 0 2 image_storage_type ReadOnly
 
-`texture_ro_1d_array<type, image_storage_type>`
-  %1 = OpTypeImage %type 1D 0 1 0 2 image_storage_type ReadOnly
+`texture_ro_1d_array<image_storage_type>`
+  %1 = OpTypeImage type(image_storage_type) 1D 0 1 0 2 image_storage_type ReadOnly
 
-`texture_ro_2d<type, image_storage_type>`
-  %1 = OpTypeImage %type 2D 0 0 0 2 image_storage_type ReadOnly
+`texture_ro_2d<image_storage_type>`
+  %1 = OpTypeImage type(image_storage_type) 0 0 0 2 image_storage_type ReadOnly
 
-`texture_ro_2d_array<type, image_storage_type>`
-  %1 = OpTypeImage %type 2D 0 1 0 2 image_storage_type ReadOnly
+`texture_ro_2d_array<image_storage_type>`
+  %1 = OpTypeImage type(image_storage_type) 0 1 0 2 image_storage_type ReadOnly
 
-`texture_ro_3d<type, image_storage_type>`
-  %1 = OpTypeImage %type 3D 0 0 0 2 image_storage_type ReadOnly
+`texture_ro_3d<image_storage_type>`
+  %1 = OpTypeImage type(image_storage_type) 3D 0 0 0 2 image_storage_type ReadOnly
 </pre>
-* type must be `f32`, `i32` or `u32`
-* The parameterized type for the images is the type after conversion from reading.
-    E.g. you can have an image with texels with 8bit unorm components, but when you read
-    them you get a 32-bit float result (or vec-of-f32).
+* type(image_storage_type) is one of `f32`, `i32`, or `u32`, depending on the storage type.
 
 ### Write-only Storage Texture Types ### {#texture-wo}
 <pre class='def'>


### PR DESCRIPTION
I don't think it's needed, since the storage format type can be uniquely associated to the sampling type. E.g. `R32UINT` is `u32`, and `RGBA8UNORM` is `f32`.