### PR TITLE
[wgsl] Allow multiple function decorations.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2481,7 +2481,7 @@ module.
 
 <pre class='def'>
 function_decl
-  : function_decoration_decl? function_header body_statement
+  : function_decoration_decl* function_header body_statement
 
 function_decoration_decl
   : ATTR_LEFT (function_decoration COMMA)* function_decoration ATTR_RIGHT


### PR DESCRIPTION
This CL updates the function decoration syntax to allow multiple
decoration groups to be provided.