### PR TITLE
[wgsl] Elaborate storage classes section

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -402,13 +402,13 @@ The following types are <dfn dfn noexport>IO-shareable</dfn>:
 * [=numeric scalar=] types
 * [=numeric vector=] types
 * [[#matrix-types]]
-* [[#array-types]] if its element type is IO-shareable, and the array is not runtime-sized.
+* [[#array-types]] if its element type is IO-shareable, and the array is not runtime-sized
 * [[#struct-types]] if all its members are IO-shareable
 
 The following kinds of values must be of IO-shareable type:
 
-* Values read from or written to built-in variables
-* Values accepted as inputs from an upstream pipeline stage
+* Values read from or written to built-in variables.
+* Values accepted as inputs from an upstream pipeline stage.
 * Values written as output for downstream processing in the pipeline, or to an output attachment.
 
 ### Host-shareable Types ### {#host-shareable-types}
@@ -421,9 +421,21 @@ The following types are <dfn dfn noexport>host-shareable</dfn>:
 * [[#array-types]] if the array type has a stride attribute and its element type is host-shareable
 * [[#struct-types]] if all its members are host-shareable
 
-The contents of uniform buffers and storage buffers must be of host-shareable type.
+Host-shareable types are used to describe the contents of buffers which are shared between
+the host and the GPU, or copied between host and GPU without format translation.
+When used for this purpose, the type must be additionally decorated with layout attributes
+as described in [[#memory-layout]].
+In particular, any variable using the `uniform` or `storage_buffer` storage classes must have
+a host-shareable [=store type=].
 
-TODO: *This is a stub*: Collectively, the *stride* and *offset* attributes are called *layout attributes*.
+Note: Any IO-shareable type is also host-shareable.
+Additionally, a runtime-sized array is host-shareable but is not IO-shareable.
+
+Note: Both IO-shareable and host-shareable types have concrete sizes, but counted differently.
+IO-shareable types are sized by a location-count metric, see [[#input-output-locations]].
+Host-shareable types are sized by a byte-count metric, see [[#memory-layout]].
+
+TODO: Add requirement for *offset* attribute on struct members.
 
 ### Storage Classes TODO ### {#storage-class}
 
@@ -544,6 +556,10 @@ Variables in certain storage classes must have [=host-shareable=] [=store type=]
 
 The memory layout of a type is significant only when referring to a value in those storage classes.
 This affects evaluation of a variable in one of those storage classes, or a pointer into one of those storage classes.
+
+TODO: *This is a stub*: Collectively, the *stride* and *offset* attributes are called *layout attributes*.
+
+TODO: <dfn noexport>layout attribute</dfn>
 
 ## Pointer Types TODO ## {#pointer-types}
 <table class='data'>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -495,18 +495,18 @@ Each storage class has unique properties affecting mutability, visibility, and t
       <td>[=Module scope=]
       <td>[=Host-shareable=]
       <td>See [[#memory-layout]].
-  <tr><td>image
+  <tr><td>texture
       <td>Read-only for [=read-only texture=]<br>
           Write-only for [=write-only texture=]
       <td>Invocations in the same shader stage
       <td>[=Module scope=]
-      <td>Depends on image format
+      <td>Depends on texture format
       <td>
   <tr><td>uniform_constant
       <td>Read-only
       <td>Invocations in the same shader stage
       <td>[=Module scope=]
-      <td>Opaque representation of handle to a sampler or image
+      <td>Opaque representation of handle to a sampler or texture
       <td>
 </table>
 
@@ -517,6 +517,9 @@ The last member of the structure type defining the store type for a `storage_buf
 may be a runtime-sized array.
 A runtime-sized array must not be used as the store type or contained within
 a store type in any other cases.
+
+Issue: The note about read-only `storage_buffer` variables may change depending
+on the outcome of https://github.com/gpuweb/gpuweb/issues/935
 
 
 <pre class='def'>
@@ -542,7 +545,7 @@ storage_class
   <tr><td>workgroup<td>Workgroup
   <tr><td>uniform_constant<td>UniformConstant
   <tr><td>storage_buffer<td>StorageBuffer
-  <tr><td>image<td>Image
+  <tr><td>texture<td>Image
   <tr><td>private<td>Private
   <tr><td>function<td>Function
 </table>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -507,13 +507,6 @@ and how to use variables with it.
       <td>The [=store type=] of a variable in the `storage_buffer` storage class
           must be a `block`-decorated [=host-shareable=] structure type.
           See also [[#memory-layout]].
-  <tr><td>texture
-      <td>Read-only for [=read-only texture=]<br>
-          Write-only for [=write-only texture=]
-      <td>Invocations in the same shader stage
-      <td>[=Module scope=]
-      <td>Depends on texture format
-      <td>
   <tr><td>uniform_constant
       <td>Read-only
       <td>Invocations in the same shader stage
@@ -531,11 +524,10 @@ storage_class
   | OUTPUT
   | FUNCTION
   | PRIVATE
-  | UNIFORM
   | WORKGROUP
-  | UNIFORM_CONSTANT
+  | UNIFORM
   | STORAGE_BUFFER
-  | IMAGE
+  | UNIFORM_CONSTANT
 </pre>
 
 <table class='data'>
@@ -548,7 +540,6 @@ storage_class
   <tr><td>workgroup<td>Workgroup
   <tr><td>uniform_constant<td>UniformConstant
   <tr><td>storage_buffer<td>StorageBuffer
-  <tr><td>texture<td>Image
   <tr><td>private<td>Private
   <tr><td>function<td>Function
 </table>
@@ -3157,7 +3148,6 @@ Issue: (dneto) Default rounding mode is an implementation choice.  Is that what 
   <tr><td>`FRAGMENT`<td>fragment
   <tr><td>`FUNCTION`<td>function
   <tr><td>`IF`<td>if
-  <tr><td>`IMAGE`<td>image
   <tr><td>`IN`<td>in
   <tr><td>`INPUT`<td>input
   <tr><td>`LOOP`<td>loop

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2951,6 +2951,14 @@ TODO: *Stub*. Location-sizing of types, non-overlap among variables referenced w
 
 ### Resource interface TODO ### {#resource-interface}
 
+TODO: *Stub* The resource interface of a shader stage is the set of module-scope
+variables statically accessed by functions
+in the sahder and which declare textures, samplers,
+and buffers (the latter are variables in `buffer` or `uniform` storage class).
+This is where we state the requirement for: set and binding attributes.
+Possibly move the content of the "Notes" column for the `buffer`, `uniform`, and
+`handle` rows from [[#storage-class]] to this section.
+
 ## Pipeline compatibility TODO ## {#pipeline-compatibility}
 
 ### Input-output matching rules TODO ### {#input-output-matching}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -377,7 +377,7 @@ Note: Layout decorations are required if the struct is used in an SSBO or UBO. O
 
 TODO: This section is a stub.
 
-In [SHORTNAME], a value of [[#storable-types]] may be stored in memory, for later retrieval.
+In [SHORTNAME], a value of [=storable=] type may be stored in memory, for later retrieval.
 
 ### Memory Locations TODO ### {#memory-locations}
 
@@ -395,6 +395,22 @@ The following types are <dfn dfn noexport>storable</dfn>:
 * [[#array-types]] if its element type is storable.
 * [[#struct-types]] if all its members are storable.
 
+### IO-shareable Types ### {#io-shareable-types}
+
+The following types are <dfn dfn noexport>IO-shareable</dfn>:
+
+* [=numeric scalar=] types
+* [=numeric vector=] types
+* [[#matrix-types]]
+* [[#array-types]] if its element type is IO-shareable, and the array is not runtime-sized.
+* [[#struct-types]] if all its members are IO-shareable
+
+The following kinds of values must be of IO-shareable type:
+
+* Values read from or written to built-in variables
+* Values accepted as inputs from an upstream pipeline stage
+* Values written as output for downstream processing in the pipeline, or to an output attachment.
+
 ### Host-shareable Types ### {#host-shareable-types}
 
 The following types are <dfn dfn noexport>host-shareable</dfn>:
@@ -405,21 +421,103 @@ The following types are <dfn dfn noexport>host-shareable</dfn>:
 * [[#array-types]] if the array type has a stride attribute and its element type is host-shareable
 * [[#struct-types]] if all its members are host-shareable
 
+The contents of uniform buffers and storage buffers must be of host-shareable type.
+
 TODO: *This is a stub*: Collectively, the *stride* and *offset* attributes are called *layout attributes*.
 
 ### Storage Classes TODO ### {#storage-class}
+
+Memory locations are partitioned into <dfn noexport>storage classes</dfn>.
+Each storage class has unique properties affecting mutability, visibility, and the values they may contain.
+
+
+<table class='data'>
+  <thead>
+    <tr><td>Storage class
+        <td>Readable by shader?<br>Writable by shader?
+        <td>Sharing among invocations
+        <td>Scope
+        <td>Restrictions on stored values
+        <td>Notes
+  </thead>
+  <tr><td>input
+      <td>Read-only
+      <td>Same invocation only
+      <td>[=Module scope=]
+      <td>[=IO-shareable=]
+      <td>Contains values written by an upstream pipeline stage, or by the implementation.
+  <tr><td>output
+      <td>Read-write
+      <td>Same invocation only
+      <td>[=Module scope=]
+      <td>[=IO-shareable=]
+      <td>Shader writes values for downstream pipeline processing.
+  <tr><td>function
+      <td>Read-write
+      <td>Same invocation only
+      <td>[=Function scope=]
+      <td>[=Storable=]
+      <td>
+  <tr><td>private
+      <td>Read-write
+      <td>Same invocation only
+      <td>[=Module scope=]
+      <td>[=Storable=]
+      <td>
+  <tr><td>workgroup
+      <td>Read-write
+      <td>Invocations in the same [=workgroup=]
+      <td>[=Module scope=]
+      <td>[=Storable=]
+      <td>
+  <tr><td>uniform
+      <td>Read-only
+      <td>Invocations in the same [=shader stage=]
+      <td>[=Module scope=]
+      <td>[=Host-shareable=]
+      <td>See [[#memory-layout]]
+  <tr><td>storage_buffer
+      <td>Readable.<br>
+          Also writable if the variable is not read-only.
+      <td>Invocations in the same [=shader stage=]
+      <td>[=Module scope=]
+      <td>[=Host-shareable=]
+      <td>See [[#memory-layout]].
+  <tr><td>image
+      <td>Read-only for [=read-only texture=]<br>
+          Write-only for [=write-only texture=]
+      <td>Invocations in the same shader stage
+      <td>[=Module scope=]
+      <td>Depends on image format
+      <td>
+  <tr><td>uniform_constant
+      <td>Read-only
+      <td>Invocations in the same shader stage
+      <td>[=Module scope=]
+      <td>Opaque representation of handle to a sampler or image
+      <td>
+</table>
+
+The [=store type=] of a variable for the `storage_buffer` or `uniform` storage classes
+must be a `block`-decorated [=host-shareable=] structure type.
+
+The last member of the structure type defining the store type for a `storage_buffer` variable
+may be a runtime-sized array.
+A runtime-sized array must not be used as the store type or contained within
+a store type in any other cases.
+
 
 <pre class='def'>
 storage_class
   : INPUT
   | OUTPUT
+  | FUNCTION
+  | PRIVATE
   | UNIFORM
   | WORKGROUP
   | UNIFORM_CONSTANT
   | STORAGE_BUFFER
   | IMAGE
-  | PRIVATE
-  | FUNCTION
 </pre>
 
 <table class='data'>
@@ -442,7 +540,7 @@ storage_class
 
 TODO: *The following is a stub*
 
-Variables in certain storage classes must have host-shareable store type with fully elaborated memory layout.
+Variables in certain storage classes must have [=host-shareable=] [=store type=] with fully elaborated memory layout.
 
 The memory layout of a type is significant only when referring to a value in those storage classes.
 This affects evaluation of a variable in one of those storage classes, or a pointer into one of those storage classes.
@@ -453,7 +551,7 @@ This affects evaluation of a variable in one of those storage classes, or a poin
     <tr><td>Type<td>Description
   </thead>
   <tr><td>ptr<*SC*,*T*><td>Pointer (or reference) to storage in [[#storage-class]] *SC*
-                            which can hold a value of the [[#storable-types]] *T*.
+                            which can hold a value of the [=storable=]] *T*.
                             Here, *T* is the known as the *pointee* type.
 </table>
 
@@ -568,6 +666,11 @@ type.
 * type must be `f32`, `i32` or `u32`
 
 ### Read-only Storage Texture Types ### {#texture-ro}
+
+A <dfn noexport>read-only texture</dfn> is an image from which individual texels
+may be read, without the use of a sampler.
+See [[#texture-builtin-functions]].
+
 <pre class='def'>
 `texture_ro_1d<image_storage_type>`
   %1 = OpTypeImage type(image_storage_type) 1D 0 0 0 2 image_storage_type
@@ -604,6 +707,11 @@ For example:
 </div>
 
 ### Write-only Storage Texture Types ### {#texture-wo}
+
+A <dfn noexport>write-only texture</dfn> is an image to which individual texels
+may be written.
+See [[#texture-builtin-functions]].
+
 <pre class='def'>
 `texture_wo_1d<image_storage_type>`
   %1 = OpTypeImage %void 1D 0 0 0 2 image_storage_type
@@ -880,9 +988,9 @@ TODO: *Stub* (describe what a constant is): A constant is a name for a value, de
 A <dfn dfn noexport>variable</dfn> is a named reference to storage that can contain a value of a
 particular storable type.
 
-Two types are associated with a variable: its *store type* (the type of value
-that may be placed in the referenced storage) and its *reference type* (the type
-of the variable itself).  If a variable has store type *T* and storage class *S*,
+Two types are associated with a variable: its <dfn noexport>store type</dfn> (the type of value
+that may be placed in the referenced storage) and its <dfn noexport>reference type</dfn> (the type
+of the variable itself).  If a variable has store type *T* and [=storage class=] *S*,
 then its reference type is pointer-to-*T*-in-*S*.
 
 A <dfn dfn noexport>variable declaration</dfn>:
@@ -953,7 +1061,7 @@ When a variable is created, its storage contains an initial value as follows:
 
 ## Module Scope Variables ## {#module-scope-variables}
 
-A variable or constant declared outside a function is at *module scope*.
+A variable or constant declared outside a function is at <dfn noexport>module scope</dfn>.
 The name is available for use immediately after its declaration statement, until the end
 of the program.
 
@@ -1096,7 +1204,7 @@ numeric types.
 
 ## Function Scope Variables ## {#function-scope-variables}
 
-A variable or constant declared in a declaration statement in a function body is in *function scope*.
+A variable or constant declared in a declaration statement in a function body is in <dfn noexport>function scope</dfn>.
 The name is available for use immediately after its declaration statement,
 and until the end of the brace-delimited list of statements immediately enclosing the declaration.
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -689,7 +689,7 @@ type.
 
 ### Read-only Storage Texture Types ### {#texture-ro}
 
-A <dfn noexport>read-only texture</dfn> is an image from which individual texels
+A <dfn noexport>read-only texture</dfn> is a texture from which individual texels
 may be read, without the use of a sampler.
 See [[#texture-builtin-functions]].
 
@@ -730,7 +730,7 @@ For example:
 
 ### Write-only Storage Texture Types ### {#texture-wo}
 
-A <dfn noexport>write-only texture</dfn> is an image to which individual texels
+A <dfn noexport>write-only texture</dfn> is a texture to which individual texels
 may be written.
 See [[#texture-builtin-functions]].
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -289,7 +289,7 @@ A vector type is a <dfn dfn>numeric vector</dfn> type if its component type is a
 
 Restrictions on runtime-sized arrays:
 * The last member of the structure type defining the [=store type=]
-    for a `storage_buffer` variable may be a runtime-sized array.
+    for a `buffer` variable may be a runtime-sized array.
 * A runtime-sized array must not be used as the store type or contained within
     a store type in any other cases.
 
@@ -432,7 +432,7 @@ Host-shareable types are used to describe the contents of buffers which are shar
 the host and the GPU, or copied between host and GPU without format translation.
 When used for this purpose, the type must be additionally decorated with layout attributes
 as described in [[#memory-layout]].
-In particular, any variable using the `uniform` or `storage_buffer` [=storage classes=] must have
+In particular, any variable using the `uniform` or `buffer` [=storage classes=] must have
 a host-shareable [=store type=].
 
 Note: Any IO-shareable type is also host-shareable.
@@ -498,16 +498,16 @@ and how to use variables with it.
       <td>The [=store type=] of a variable in the `uniform` storage class
           must be a `block`-decorated [=host-shareable=] structure type.
           See also [[#memory-layout]].
-  <tr><td>storage_buffer
+  <tr><td>buffer
       <td>Readable.<br>
           Also writable if the variable is not read-only.
       <td>Invocations in the same [=shader stage=]
       <td>[=Module scope=]
       <td>[=Host-shareable=]
-      <td>The [=store type=] of a variable in the `storage_buffer` storage class
+      <td>The [=store type=] of a variable in the `buffer` storage class
           must be a `block`-decorated [=host-shareable=] structure type.
           See also [[#memory-layout]].
-  <tr><td>uniform_constant
+  <tr><td>handle
       <td>Read-only
       <td>Invocations in the same shader stage
       <td>[=Module scope=]
@@ -515,7 +515,7 @@ and how to use variables with it.
       <td>
 </table>
 
-Issue: The note about read-only `storage_buffer` variables may change depending
+Issue: The note about read-only `buffer` variables may change depending
 on the outcome of https://github.com/gpuweb/gpuweb/issues/935
 
 <pre class='def'>
@@ -526,8 +526,7 @@ storage_class
   | PRIVATE
   | WORKGROUP
   | UNIFORM
-  | STORAGE_BUFFER
-  | UNIFORM_CONSTANT
+  | BUFFER
 </pre>
 
 <table class='data'>
@@ -538,8 +537,8 @@ storage_class
   <tr><td>out<td>Output
   <tr><td>uniform<td>Uniform
   <tr><td>workgroup<td>Workgroup
-  <tr><td>uniform_constant<td>UniformConstant
-  <tr><td>storage_buffer<td>StorageBuffer
+  <tr><td>handle<td>UniformConstant
+  <tr><td>buffer<td>StorageBuffer
   <tr><td>private<td>Private
   <tr><td>function<td>Function
 </table>
@@ -574,7 +573,7 @@ Note: Pointers are not storable.
 
 <div class='example' heading='Pointer'>
   <xmp highlight='rust'>
-    ptr<storage_buffer, i32>
+    ptr<buffer, i32>
     ptr<private, array<i32, 12>>
   </xmp>
 </div>
@@ -1010,7 +1009,7 @@ A <dfn dfn noexport>variable declaration</dfn>:
 
 * Determines the variable’s name, storage class, and store type (and hence its reference type)
 * Ensures the execution environment allocates storage for a value of the store type, for the lifetime of the variable.
-* Optionally have an *initializer* expression, if the variable is in the `Private`, `Function`, or `Output` [[#storage-class]].
+* Optionally have an *initializer* expression, if the variable is in the `private`, `function`, or `out` [[#storage-class]].
     If present, the initializer's type must match the store type of the variable.
 
 <pre class='def'>
@@ -1033,7 +1032,7 @@ Two variables with overlapping lifetimes must not have overlapping storage.
 
 When a variable is created, its storage contains an initial value as follows:
 
-* For variables in the `Private`, `Function`, or `Output` storage classes:
+* For variables in the `private`, `function`, or `out` storage classes:
     * The zero value for the store type, if the variable declaration has no initializer.
     * Otherwise, it is the result of evaluating the initializer expression at that point in the program execution.
 * For variables in other storage classes, the execution environment provides the initial value.
@@ -3131,6 +3130,8 @@ Issue: (dneto) Default rounding mode is an implementation choice.  Is that what 
   <tr><td>`BITCAST`<td>bitcast
   <tr><td>`BLOCK`<td>block
   <tr><td>`BREAK`<td>break
+  <tr><td>`BUFFER`<td>buffer
+  <tr><td>`BUILTIN`<td>builtin
   <tr><td>`CASE`<td>case
   <tr><td>`COMPUTE`<td>compute
   <tr><td>`CONST`<td>const
@@ -3147,6 +3148,7 @@ Issue: (dneto) Default rounding mode is an implementation choice.  Is that what 
   <tr><td>`FOR`<td>for
   <tr><td>`FRAGMENT`<td>fragment
   <tr><td>`FUNCTION`<td>function
+  <tr><td>`HANDLE`<td>handle
   <tr><td>`IF`<td>if
   <tr><td>`IN`<td>in
   <tr><td>`LOCATION`<td>location
@@ -3156,13 +3158,11 @@ Issue: (dneto) Default rounding mode is an implementation choice.  Is that what 
   <tr><td>`PRIVATE`<td>private
   <tr><td>`RETURN`<td>return
   <tr><td>`STAGE`<td>stage
-  <tr><td>`STORAGE_BUFFER`<td>storage_buffer
   <tr><td>`STRIDE`<td>stride
   <tr><td>`SWITCH`<td>switch
   <tr><td>`TRUE`<td>true
   <tr><td>`TYPE`<td>type
   <tr><td>`UNIFORM`<td>uniform
-  <tr><td>`UNIFORM_CONSTANT`<td>uniform_constant
   <tr><td>`VAR`<td>var
   <tr><td>`VERTEX`<td>vertex
   <tr><td>`WORKGROUP`<td>workgroup

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -498,6 +498,7 @@ and how to use variables with it.
       <td>The [=store type=] of a variable in the `uniform` storage class
           must be a `block`-decorated [=host-shareable=] structure type.
           See also [[#memory-layout]].
+          <br>Used with `uniform-buffer` WebGPU GPUBindingType.
   <tr><td>buffer
       <td>Readable.<br>
           Also writable if the variable is not read-only.
@@ -507,12 +508,13 @@ and how to use variables with it.
       <td>The [=store type=] of a variable in the `buffer` storage class
           must be a `block`-decorated [=host-shareable=] structure type.
           See also [[#memory-layout]].
+          <br>Used with `storage-buffer` or `readonly-storage-buffer` WebGPU GPUBindingType.
   <tr><td>handle
       <td>Read-only
       <td>Invocations in the same shader stage
       <td>[=Module scope=]
       <td>Opaque representation of handle to a sampler or texture
-      <td>
+      <td>Used with one of the sampler or texture WebGPU GPUBindingType values.
 </table>
 
 Issue: The note about read-only `buffer` variables may change depending

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -540,7 +540,7 @@ storage_class
 
 <table class='data'>
   <thead>
-    <tr><td>Name<td>SPIR-V Storage Class
+    <tr><td>WGSL storage class<td>SPIR-V storage class
   </thead>
   <tr><td>input<td>Input
   <tr><td>output<td>Output

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -437,18 +437,19 @@ Host-shareable types are sized by a byte-count metric, see [[#memory-layout]].
 
 TODO: Add requirement for *offset* attribute on struct members.
 
-### Storage Classes TODO ### {#storage-class}
+### Storage Classes ### {#storage-class}
 
 Memory locations are partitioned into <dfn noexport>storage classes</dfn>.
-Each storage class has unique properties affecting mutability, visibility, and the values they may contain.
-
+Each storage class has unique properties determining
+mutability, visibility, the values they may contain,
+and how to use variables with it.
 
 <table class='data'>
   <thead>
     <tr><td>Storage class
         <td>Readable by shader?<br>Writable by shader?
         <td>Sharing among invocations
-        <td>Scope
+        <td>Variable scope
         <td>Restrictions on stored values
         <td>Notes
   </thead>
@@ -510,7 +511,7 @@ Each storage class has unique properties affecting mutability, visibility, and t
       <td>
 </table>
 
-The [=store type=] of a variable for the `storage_buffer` or `uniform` storage classes
+The [=store type=] of a variable in the `storage_buffer` or `uniform` storage classes
 must be a `block`-decorated [=host-shareable=] structure type.
 
 The last member of the structure type defining the store type for a `storage_buffer` variable
@@ -520,7 +521,6 @@ a store type in any other cases.
 
 Issue: The note about read-only `storage_buffer` variables may change depending
 on the outcome of https://github.com/gpuweb/gpuweb/issues/935
-
 
 <pre class='def'>
 storage_class

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -460,13 +460,13 @@ and how to use variables with it.
         <td>Restrictions on stored values
         <td>Notes
   </thead>
-  <tr><td>input
+  <tr><td>in
       <td>Read-only
       <td>Same invocation only
       <td>[=Module scope=]
       <td>[=IO-shareable=]
       <td>Input from an upstream pipeline stage, or from the implementation.
-  <tr><td>output
+  <tr><td>out
       <td>Read-write
       <td>Same invocation only
       <td>[=Module scope=]
@@ -520,8 +520,8 @@ on the outcome of https://github.com/gpuweb/gpuweb/issues/935
 
 <pre class='def'>
 storage_class
-  : INPUT
-  | OUTPUT
+  : IN
+  | OUT
   | FUNCTION
   | PRIVATE
   | WORKGROUP
@@ -534,8 +534,8 @@ storage_class
   <thead>
     <tr><td>WGSL storage class<td>SPIR-V storage class
   </thead>
-  <tr><td>input<td>Input
-  <tr><td>output<td>Output
+  <tr><td>in<td>Input
+  <tr><td>out<td>Output
   <tr><td>uniform<td>Uniform
   <tr><td>workgroup<td>Workgroup
   <tr><td>uniform_constant<td>UniformConstant
@@ -3149,11 +3149,10 @@ Issue: (dneto) Default rounding mode is an implementation choice.  Is that what 
   <tr><td>`FUNCTION`<td>function
   <tr><td>`IF`<td>if
   <tr><td>`IN`<td>in
-  <tr><td>`INPUT`<td>input
+  <tr><td>`LOCATION`<td>location
   <tr><td>`LOOP`<td>loop
   <tr><td>`OFFSET`<td>offset
   <tr><td>`OUT`<td>out
-  <tr><td>`OUTPUT`<td>output
   <tr><td>`PRIVATE`<td>private
   <tr><td>`RETURN`<td>return
   <tr><td>`STAGE`<td>stage

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -289,7 +289,7 @@ A vector type is a <dfn dfn>numeric vector</dfn> type if its component type is a
 
 Restrictions on runtime-sized arrays:
 * The last member of the structure type defining the [=store type=]
-    for variable in the `buffer` [=storage class=] may be a runtime-sized array.
+    for variable in the `storage` [=storage class=] may be a runtime-sized array.
 * A runtime-sized array must not be used as the store type or contained within
     a store type in any other cases.
 * The type of an expression must not be a runtime-sized array type.
@@ -430,7 +430,7 @@ Host-shareable types are used to describe the contents of buffers which are shar
 the host and the GPU, or copied between host and GPU without format translation.
 When used for this purpose, the type must be additionally decorated with layout attributes
 as described in [[#memory-layout]].
-In particular, any variable using the `uniform` or `buffer` [=storage classes=] must have
+In particular, any variable using the `uniform` or `storage` [=storage classes=] must have
 a host-shareable [=store type=].
 
 Note: An [=IO-shareable=] type would also be host-shareable if it and its subtypes have
@@ -496,13 +496,13 @@ and how to use variables with it.
           must be a `block`-decorated [=host-shareable=] structure type.
           See also [[#memory-layout]].
           <br>Used with `uniform-buffer` WebGPU GPUBindingType.
-  <tr><td>buffer
+  <tr><td>storage
       <td>Readable.<br>
           Also writable if the variable is not read-only.
       <td>Invocations in the same [=shader stage=]
       <td>[=Module scope=]
       <td>[=Host-shareable=]
-      <td>The [=store type=] of a variable in the `buffer` storage class
+      <td>The [=store type=] of a variable in the `storage` storage class
           must be a `block`-decorated [=host-shareable=] structure type.
           See also [[#memory-layout]].
           <br>Used with `storage-buffer` or `readonly-storage-buffer` WebGPU GPUBindingType.
@@ -515,7 +515,7 @@ and how to use variables with it.
           The token `handle` is reserved: it is never used in a [SHORTNAME] program.
 </table>
 
-Issue: The note about read-only `buffer` variables may change depending
+Issue: The note about read-only `storage` variables may change depending
 on the outcome of https://github.com/gpuweb/gpuweb/issues/935
 
 <pre class='def'>
@@ -538,7 +538,7 @@ storage_class
   <tr><td>uniform<td>Uniform
   <tr><td>workgroup<td>Workgroup
   <tr><td>handle<td>UniformConstant
-  <tr><td>buffer<td>StorageBuffer
+  <tr><td>storage<td>StorageBuffer
   <tr><td>private<td>Private
   <tr><td>function<td>Function
 </table>
@@ -573,7 +573,7 @@ Note: Pointers are not storable.
 
 <div class='example' heading='Pointer'>
   <xmp highlight='rust'>
-    ptr<buffer, i32>
+    ptr<storage, i32>
     ptr<private, array<i32, 12>>
   </xmp>
 </div>
@@ -1091,7 +1091,7 @@ of the program.
 Variables at module scope are restricted as follows:
 
 * The variable must not be in the `function` [=storage classes|storage class=].
-* A variable in the `in`, `out`, `private`, `workgroup`, `uniform`, or `buffer` storage classes:
+* A variable in the `in`, `out`, `private`, `workgroup`, `uniform`, or `storage` storage classes:
     * Must be declared with an explicit storage class decoration.
     * Must use a [=store type=] as described in [[#storage-class]].
 * If the [=store type=] is a texture type or a sampler type, then the storage class is always `handle`.
@@ -1108,13 +1108,13 @@ Variables at module scope are restricted as follows:
       [[offset(0)]] specular: f32;
       [[offset(4)]]
     };
-    var<uniform> param: Params;         # A storage buffer
+    var<uniform> param: Params;          # A uniform buffer
 
     [[block]] struct PositionsBuffer {
       [[offset(0)]] pos: [[stride(8)]] array<vec2<f32>>;
     };
     # TODO(dneto): add set and binding
-    var<buffer> pbuf: PositionsBuffer;  # A uniform buffer
+    var<storage> pbuf: PositionsBuffer;  # A storage buffer
 
     var filter_params: sampler;   # Textures and samplers are always in "handle" storage.
   </xmp>
@@ -2954,9 +2954,9 @@ TODO: *Stub*. Location-sizing of types, non-overlap among variables referenced w
 TODO: *Stub* The resource interface of a shader stage is the set of module-scope
 variables statically accessed by functions
 in the sahder and which declare textures, samplers,
-and buffers (the latter are variables in `buffer` or `uniform` storage class).
+and buffers (the latter are variables in `storage` or `uniform` storage class).
 This is where we state the requirement for: set and binding attributes.
-Possibly move the content of the "Notes" column for the `buffer`, `uniform`, and
+Possibly move the content of the "Notes" column for the `storage`, `uniform`, and
 `handle` rows from [[#storage-class]] to this section.
 
 ## Pipeline compatibility TODO ## {#pipeline-compatibility}
@@ -3197,7 +3197,6 @@ Issue: (dneto) Default rounding mode is an implementation choice.  Is that what 
   <tr><td>`BITCAST`<td>bitcast
   <tr><td>`BLOCK`<td>block
   <tr><td>`BREAK`<td>break
-  <tr><td>`BUFFER`<td>buffer
   <tr><td>`BUILTIN`<td>builtin
   <tr><td>`CASE`<td>case
   <tr><td>`COMPUTE`<td>compute
@@ -3225,6 +3224,7 @@ Issue: (dneto) Default rounding mode is an implementation choice.  Is that what 
   <tr><td>`RETURN`<td>return
   <tr><td>`STAGE`<td>stage
   <tr><td>`STRIDE`<td>stride
+  <tr><td>`STORAGE`<td>storage
   <tr><td>`SWITCH`<td>switch
   <tr><td>`TRUE`<td>true
   <tr><td>`TYPE`<td>type

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -511,7 +511,8 @@ and how to use variables with it.
       <td>Invocations in the same shader stage
       <td>[=Module scope=]
       <td>Opaque representation of handle to a sampler or texture
-      <td>Used with one of the sampler or texture WebGPU GPUBindingType values.
+      <td>Used with one of the sampler or texture WebGPU GPUBindingType values.<br>
+          The token `handle` is reserved: it is never used in a [SHORTNAME] program.
 </table>
 
 Issue: The note about read-only `buffer` variables may change depending
@@ -995,6 +996,12 @@ array_decoration
 # Variable and const # {#variables}
 
 TODO: *Stub* (describe what a constant is): A constant is a name for a value, declared via a `const` declaration. What types are permitted?  Storable, plus pointer to store type.
+
+TODO(dneto): A const may not be of type pointer-to-handle. A function parameter may not have type pointer-to-handle.
+Otherwise we'd have a need to make a pointer-to-handle type expression. But we've reserved the `handle` keyword.
+When translating from SPIR-V, you must trace through
+the OpCopyObject (or no-index OpAccessChain) instructions that might be between
+the pointer-to-array and the pointer-to-struct.
 
 A <dfn dfn noexport>variable</dfn> is a named reference to storage that can contain a value of a
 particular storable type.
@@ -3192,7 +3199,6 @@ Issue: (dneto) Default rounding mode is an implementation choice.  Is that what 
   <tr><td>`FOR`<td>for
   <tr><td>`FRAGMENT`<td>fragment
   <tr><td>`FUNCTION`<td>function
-  <tr><td>`HANDLE`<td>handle
   <tr><td>`IF`<td>if
   <tr><td>`IN`<td>in
   <tr><td>`LOCATION`<td>location
@@ -3281,6 +3287,7 @@ The following is a list of keywords which are reserved for future expansion.
     <td>while
     <td>regardless
     <td>premerge
+    <td>handle
 </table>
 
 ## Syntactic Tokens ## {#syntactic-tokens}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -995,7 +995,8 @@ array_decoration
 
 # Variable and const # {#variables}
 
-TODO: *Stub* (describe what a constant is): A constant is a name for a value, declared via a `const` declaration. What types are permitted?  Storable, plus pointer to store type.
+TODO: *Stub* (describe what a constant is): A constant is a name for a value, declared via a `const` declaration.
+What types are permitted?  Storable, plus pointer to store type.
 
 TODO(dneto): A const may not be of type pointer-to-handle. A function parameter may not have type pointer-to-handle.
 Otherwise we'd have a need to make a pointer-to-handle type expression. But we've reserved the `handle` keyword.
@@ -1274,6 +1275,7 @@ The variable's [=store type=] must be [=storable=].
 
 A variable or constant declared in the first clause of a `for` statement is available for use in the second
 and third clauses and in the body of the `for` statement.
+
 
 ## Never-alias assumption TODO ## {#never-alias-assumption}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1095,22 +1095,28 @@ Variables at module scope are restricted as follows:
     * Must be declared with an explicit storage class decoration.
     * Must use a [=store type=] as described in [[#storage-class]].
 * If the [=store type=] is a texture type or a sampler type, then the storage class is always `handle`.
-    The variable declaration must not use the storage class decoration.
+    The variable declaration must not have a storage class decoration.
 
 <div class='example' heading="Module scope variable declarations">
   <xmp>
     var<in> twist: f32;
     var<out> spin: f32;
-    var<private> decibels : f32;
-    var<workgroup> worklist : array<i32,10>;
+    var<private> decibels: f32;
+    var<workgroup> worklist: array<i32,10>;
 
-    [[block]] struct Params { specular : f32; flat : f32; count : i32; };
-    var<uniform> param : Params;
+    [[block]] struct Params {
+      [[offset(0)]] specular: f32;
+      [[offset(4)]]
+    };
+    var<uniform> param: Params;         # A storage buffer
 
-    [[block]] struct PositionsBuffer { pos array<vec2<f32>>; };
-    var<buffer> pbuf : PositionsBuffer;
+    [[block]] struct PositionsBuffer {
+      [[offset(0)]] pos: [[stride(8)]] array<vec2<f32>>;
+    };
+    # TODO(dneto): add set and binding
+    var<buffer> pbuf: PositionsBuffer;  # A uniform buffer
 
-    var filter : sampler;       # Textures and samplers are always in "handle" storage.
+    var filter_params: sampler;   # Textures and samplers are always in "handle" storage.
   </xmp>
 </div>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -282,14 +282,21 @@ A vector type is a <dfn dfn>numeric vector</dfn> type if its component type is a
     <tr><td>Type<td>Description
   </thead>
   <tr><td>array<*E*,*N*><td>An *N*-element array of elements of type *E*.<br>
-  <tr><td>array<*E*><td>A runtime-sized array of elements of type *E*,
+  <tr><td>array<*E*><td>A <dfn noexport>runtime-sized</dfn> array of elements of type *E*,
                        also known as a runtime array.
                        These may only appear in specific contexts.<br>
 </table>
 
-Issue: (dneto): Complete description of `Array<E,N>`
+Restrictions on runtime-sized arrays:
+* The last member of the structure type defining the [=store type=]
+    for a `storage_buffer` variable may be a runtime-sized array.
+* A runtime-sized array must not be used as the store type or contained within
+    a store type in any other cases.
 
-Issue: (dneto): Runtime-sized array is only usable as the last element of a struct defining the contents of a storage buffer.
+TODO: Ban the ability to make runtime-arrays by loading them whole or the struct containing them,
+or creating them out of parts, via type constructor, via zero initializer.
+
+Issue: (dneto): Complete description of `Array<E,N>`
 
 ### Structure Types ### {#struct-types}
 <table class='data'>
@@ -402,7 +409,7 @@ The following types are <dfn dfn noexport>IO-shareable</dfn>:
 * [=numeric scalar=] types
 * [=numeric vector=] types
 * [[#matrix-types]]
-* [[#array-types]] if its element type is IO-shareable, and the array is not runtime-sized
+* [[#array-types]] if its element type is IO-shareable, and the array is not [=runtime-sized=]
 * [[#struct-types]] if all its members are IO-shareable
 
 The following kinds of values must be of IO-shareable type:
@@ -425,11 +432,11 @@ Host-shareable types are used to describe the contents of buffers which are shar
 the host and the GPU, or copied between host and GPU without format translation.
 When used for this purpose, the type must be additionally decorated with layout attributes
 as described in [[#memory-layout]].
-In particular, any variable using the `uniform` or `storage_buffer` storage classes must have
+In particular, any variable using the `uniform` or `storage_buffer` [=storage classes=] must have
 a host-shareable [=store type=].
 
 Note: Any IO-shareable type is also host-shareable.
-Additionally, a runtime-sized array is host-shareable but is not IO-shareable.
+Additionally, a [=runtime-sized=] array is host-shareable but is not IO-shareable.
 
 Note: Both IO-shareable and host-shareable types have concrete sizes, but counted differently.
 IO-shareable types are sized by a location-count metric, see [[#input-output-locations]].
@@ -441,7 +448,7 @@ TODO: Add requirement for *offset* attribute on struct members.
 
 Memory locations are partitioned into <dfn noexport>storage classes</dfn>.
 Each storage class has unique properties determining
-mutability, visibility, the values they may contain,
+mutability, visibility, the values it may contain,
 and how to use variables with it.
 
 <table class='data'>
@@ -458,13 +465,13 @@ and how to use variables with it.
       <td>Same invocation only
       <td>[=Module scope=]
       <td>[=IO-shareable=]
-      <td>Contains values written by an upstream pipeline stage, or by the implementation.
+      <td>Input from an upstream pipeline stage, or from the implementation.
   <tr><td>output
       <td>Read-write
       <td>Same invocation only
       <td>[=Module scope=]
       <td>[=IO-shareable=]
-      <td>Shader writes values for downstream pipeline processing.
+      <td>Output to a downstream pipeline stage.
   <tr><td>function
       <td>Read-write
       <td>Same invocation only
@@ -488,14 +495,18 @@ and how to use variables with it.
       <td>Invocations in the same [=shader stage=]
       <td>[=Module scope=]
       <td>[=Host-shareable=]
-      <td>See [[#memory-layout]]
+      <td>The [=store type=] of a variable in the `uniform` storage class
+          must be a `block`-decorated [=host-shareable=] structure type.
+          See also [[#memory-layout]].
   <tr><td>storage_buffer
       <td>Readable.<br>
           Also writable if the variable is not read-only.
       <td>Invocations in the same [=shader stage=]
       <td>[=Module scope=]
       <td>[=Host-shareable=]
-      <td>See [[#memory-layout]].
+      <td>The [=store type=] of a variable in the `storage_buffer` storage class
+          must be a `block`-decorated [=host-shareable=] structure type.
+          See also [[#memory-layout]].
   <tr><td>texture
       <td>Read-only for [=read-only texture=]<br>
           Write-only for [=write-only texture=]
@@ -510,14 +521,6 @@ and how to use variables with it.
       <td>Opaque representation of handle to a sampler or texture
       <td>
 </table>
-
-The [=store type=] of a variable in the `storage_buffer` or `uniform` storage classes
-must be a `block`-decorated [=host-shareable=] structure type.
-
-The last member of the structure type defining the store type for a `storage_buffer` variable
-may be a runtime-sized array.
-A runtime-sized array must not be used as the store type or contained within
-a store type in any other cases.
 
 Issue: The note about read-only `storage_buffer` variables may change depending
 on the outcome of https://github.com/gpuweb/gpuweb/issues/935
@@ -555,10 +558,10 @@ storage_class
 
 TODO: *The following is a stub*
 
-Variables in certain storage classes must have [=host-shareable=] [=store type=] with fully elaborated memory layout.
+Variables in certain storage classes must have a [=host-shareable=] [=store type=] with fully elaborated memory layout.
 
 The memory layout of a type is significant only when referring to a value in those storage classes.
-This affects evaluation of a variable in one of those storage classes, or a pointer into one of those storage classes.
+This affects evaluation of a variable in one of those storage classes, or of a pointer into one of those storage classes.
 
 TODO: *This is a stub*: Collectively, the *stride* and *offset* attributes are called *layout attributes*.
 
@@ -1387,7 +1390,7 @@ TODO: Should this only work for storable sized arrays?  https://github.com/gpuwe
 
 Each storable type *T* has a unique *zero value*, written in WGSL as the type followed by an empty pair of parentheses: *T* `()`.
 
-Issue: We should exclude being able to write the zero value for an runtime-sized array. https://github.com/gpuweb/gpuweb/issues/981
+Issue: We should exclude being able to write the zero value for an [=runtime-sized=] array. https://github.com/gpuweb/gpuweb/issues/981
 
 The zero values are as follows:
 
@@ -2959,7 +2962,7 @@ TODO: *Stub*: Expression evaluation
 
 A <dfn noexport>workgroup</dfn> is a set of invocations which
 concurrently execute a [=compute shader stage=] [=entry point=],
-and share access to shader variables in the `workgroup` storage class.
+and share access to shader variables in the `workgroup` [=storage class=].
 
 The <dfn noexport>workgroup grid</dfn> for a compute shader is the set of points
 with integer coordinates *(i,j,k)* with:

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -573,7 +573,7 @@ TODO: <dfn noexport>layout attribute</dfn>
     <tr><td>Type<td>Description
   </thead>
   <tr><td>ptr<*SC*,*T*><td>Pointer (or reference) to storage in [[#storage-class]] *SC*
-                            which can hold a value of the [=storable=]] *T*.
+                            which can hold a value of the [=storable=] *T*.
                             Here, *T* is the known as the *pointee* type.
 </table>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -289,12 +289,10 @@ A vector type is a <dfn dfn>numeric vector</dfn> type if its component type is a
 
 Restrictions on runtime-sized arrays:
 * The last member of the structure type defining the [=store type=]
-    for a `buffer` variable may be a runtime-sized array.
+    for variable in the `buffer` [=storage class=] may be a runtime-sized array.
 * A runtime-sized array must not be used as the store type or contained within
     a store type in any other cases.
-
-TODO: Ban the ability to make runtime-arrays by loading them whole or the struct containing them,
-or creating them out of parts, via type constructor, via zero initializer.
+* The type of an expression must not be a runtime-sized array type.
 
 Issue: (dneto): Complete description of `Array<E,N>`
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -423,8 +423,8 @@ The following types are <dfn dfn noexport>host-shareable</dfn>:
 * [=numeric scalar=] types
 * [=numeric vector=] types
 * [[#matrix-types]]
-* [[#array-types]] if the array type has a stride attribute and its element type is host-shareable
-* [[#struct-types]] if all its members are host-shareable
+* [[#array-types]] if the array type has a [=stride=] attribute and its element type is host-shareable
+* [[#struct-types]] if each of its members both has an [=offset=] attribute and is host-shareable
 
 Host-shareable types are used to describe the contents of buffers which are shared between
 the host and the GPU, or copied between host and GPU without format translation.
@@ -433,14 +433,13 @@ as described in [[#memory-layout]].
 In particular, any variable using the `uniform` or `buffer` [=storage classes=] must have
 a host-shareable [=store type=].
 
-Note: Any IO-shareable type is also host-shareable.
+Note: An [=IO-shareable=] type would also be host-shareable if it and its subtypes have
+the approporate [=stride=] and [=offset=] attributes.
 Additionally, a [=runtime-sized=] array is host-shareable but is not IO-shareable.
 
 Note: Both IO-shareable and host-shareable types have concrete sizes, but counted differently.
 IO-shareable types are sized by a location-count metric, see [[#input-output-locations]].
 Host-shareable types are sized by a byte-count metric, see [[#memory-layout]].
-
-TODO: Add requirement for *offset* attribute on struct members.
 
 ### Storage Classes ### {#storage-class}
 
@@ -553,7 +552,7 @@ Variables in certain storage classes must have a [=host-shareable=] [=store type
 The memory layout of a type is significant only when referring to a value in those storage classes.
 This affects evaluation of a variable in one of those storage classes, or of a pointer into one of those storage classes.
 
-TODO: *This is a stub*: Collectively, the *stride* and *offset* attributes are called *layout attributes*.
+TODO: *This is a stub*: Collectively, the <dfn noexport>stride</dfn> and <dfn noexport>offset</dfn> attributes are called *layout attributes*.
 
 TODO: <dfn noexport>layout attribute</dfn>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -640,7 +640,7 @@ Any other context.  Evaluates to *P.Read()*, yielding a value of *P*’s pointee
 type.
 </table>
 
-## Texture Types TODO ## {#texture-types}
+## Texture and Sampler Types TODO ## {#texture-types}
 
 ### Sampled Texture Types ### {#sampled-texture-type}
 
@@ -997,7 +997,7 @@ array_decoration
 
 # Variable and const # {#variables}
 
-TODO: *Stub* (describe what a constant is): A constant is a name for a value, declared via a `const` declaration.
+TODO: *Stub* (describe what a constant is): A constant is a name for a value, declared via a `const` declaration. What types are permitted?  Storable, plus pointer to store type.
 
 A <dfn dfn noexport>variable</dfn> is a named reference to storage that can contain a value of a
 particular storable type.
@@ -1009,10 +1009,14 @@ then its reference type is pointer-to-*T*-in-*S*.
 
 A <dfn dfn noexport>variable declaration</dfn>:
 
-* Determines the variable’s name, storage class, and store type (and hence its reference type)
+* Determines the variable’s name, storage class, and store type (and hence its reference type).
 * Ensures the execution environment allocates storage for a value of the store type, for the lifetime of the variable.
 * Optionally have an *initializer* expression, if the variable is in the `private`, `function`, or `out` [[#storage-class]].
     If present, the initializer's type must match the store type of the variable.
+
+See [[#module-scope-variables]] and [[#function-scope-variables]] for rules about where
+a variable in a particular storage class can be declared,
+and when the storage class decoration is required, optional, or forbidden.
 
 <pre class='def'>
 variable_statement
@@ -1030,7 +1034,7 @@ variable_storage_decoration
   : LESS_THAN storage_class GREATER_THAN
 </pre>
 
-Two variables with overlapping lifetimes must not have overlapping storage.
+Two variables with overlapping lifetimes will not have overlapping storage.
 
 When a variable is created, its storage contains an initial value as follows:
 
@@ -1079,6 +1083,32 @@ A variable or constant declared outside a function is at <dfn noexport>module sc
 The name is available for use immediately after its declaration statement, until the end
 of the program.
 
+Variables at module scope are restricted as follows:
+
+* The variable must not be in the `function` [=storage classes|storage class=].
+* A variable in the `in`, `out`, `private`, `workgroup`, `uniform`, or `buffer` storage classes:
+    * Must be declared with an explicit storage class decoration.
+    * Must use a [=store type=] as described in [[#storage-class]].
+* If the [=store type=] is a texture type or a sampler type, then the storage class is always `handle`.
+    The variable declaration must not use the storage class decoration.
+
+<div class='example' heading="Module scope variable declarations">
+  <xmp>
+    var<in> twist: f32;
+    var<out> spin: f32;
+    var<private> decibels : f32;
+    var<workgroup> worklist : array<i32,10>;
+
+    [[block]] struct Params { specular : f32; flat : f32; count : i32; };
+    var<uniform> param : Params;
+
+    [[block]] struct PositionsBuffer { pos array<vec2<f32>>; };
+    var<buffer> pbuf : PositionsBuffer;
+
+    var filter : sampler;       # Textures and samplers are always in "handle" storage.
+  </xmp>
+</div>
+
 <pre class='def'>
 global_variable_decl
   : variable_decoration_list* variable_decl
@@ -1119,6 +1149,7 @@ literal_or_ident
 </table>
 
 See [[#builtin-variables]] for the list of Builtin Decoration Identifiers.
+
 
 ## Module Constants ## {#module-constants}
 
@@ -1216,15 +1247,29 @@ shader scalar values.  For booleans, I suggest using a 32-bit integer, where onl
 If [SHORTNAME] gains non-32-bit numeric scalars, I recommend overridable constants continue being 32-bit
 numeric types.
 
-## Function Scope Variables ## {#function-scope-variables}
+## Function Scope Variables and Constants ## {#function-scope-variables}
 
 A variable or constant declared in a declaration statement in a function body is in <dfn noexport>function scope</dfn>.
 The name is available for use immediately after its declaration statement,
 and until the end of the brace-delimited list of statements immediately enclosing the declaration.
 
+A variable declared in function scope is always in the `function` [=storage class=].
+The variable storage decoration is optional.
+The variable's [=store type=] must be [=storable=].
+
+<div class='example' heading="Function scope variables and constants">
+  <xmp highlight='rust'>
+    fn f() -> void {
+       var<function> count : u32;  # A variable in function storage class.
+       var delta : i32;            # Another variable in the function storage class.
+       var sum : f32 = 0.0;        # A function storage class variable with initializer.
+       const unit : i32 = 1;       # A constant.
+    }
+  </xmp>
+</div>
+
 A variable or constant declared in the first clause of a `for` statement is available for use in the second
 and third clauses and in the body of the `for` statement.
-
 
 ## Never-alias assumption TODO ## {#never-alias-assumption}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -526,7 +526,7 @@ storage_class
   | PRIVATE
   | WORKGROUP
   | UNIFORM
-  | BUFFER
+  | STORAGE
 </pre>
 
 <table class='data'>


### PR DESCRIPTION
Also:
- Define IO-shareable
- Define read-only texture
- Define write-only texture
- Add more cross-links.
- Restrict where runtime-sized arrays may be used
- Store type of uniform and storage_buffer variables must be
block-decorated

Fixes #1004