### PR TITLE
[wgsl] Fixup stdlib method return values.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3323,7 +3323,7 @@ TODO: deduplicate these tables
     <td>(GLSLstd450Distance)
   <tr algorithm="vector case, distance">
     <td>|T| is f32
-    <td class="nowrap">`distance(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`) -> ` vec|N|<|T|>
+    <td class="nowrap">`distance(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`) -> ` |T|
     <td>(GLSLstd450Distance)
   <tr algorithm="scalar case, exp">
     <td>|T| is f32
@@ -3407,7 +3407,7 @@ TODO: deduplicate these tables
     <td>(GLSLstd450Length)
   <tr algorithm="vector case, length">
     <td>|T| is f32
-    <td class="nowrap">`length(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
+    <td class="nowrap">`length(`|e|`:` vec|N|<|T|> `) -> ` |T|
     <td>(GLSLstd450Length)
   <tr algorithm="scalar case, log">
     <td>|T| is f32
@@ -3654,7 +3654,7 @@ TODO: deduplicate these tables
   </thead>
   <tr algorithm="determinant">
     <td>|T| is f32
-    <td class="nowrap">`determinant(`|e|`:` mat|N|x|N|<|T|> `) -> ` vec|N|<|T|>
+    <td class="nowrap">`determinant(`|e|`:` mat|N|x|N|<|T|> `) -> ` |T|
     <td>(GLSLstd450Determinant)
 </table>
 


### PR DESCRIPTION
For the `determinant`, `length` and `distance` methods the return value
should always be a scalar.