### PR TITLE
Consistently use "invocation" and "workgroup" for compute

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -242,11 +242,11 @@ before doing any translation (to platform-specific shaders) or transformation pa
 Generally, allocating new memory may expose the leftover data of other applications running on the system.
 In order to address that, WebGPU conceptually initializes all the resources to zero, although in practice
 an implementation may skip this step if it sees the developer initializing the contents manually.
-This includes variables and shared threadgroup memory inside shaders.
+This includes variables and shared workgroup memory inside shaders.
 
-The precise mechanism of clearing the threadgroup memory can differ between platforms.
+The precise mechanism of clearing the workgroup memory can differ between platforms.
 If the native API does not provide facilities to clear it, the WebGPU implementation transforms the compute
-shader to first do a clear across all threads, synchronize them, and continue executing developer's code.
+shader to first do a clear across all invocations, synchronize them, and continue executing developer's code.
 
 ## Out-of-bounds access in shaders ## {#security-shader}
 
@@ -570,7 +570,7 @@ They are represented by callbacks and promises in JavaScript.
   2. User issues {{GPUQueue/submit(commandBuffers)|GPUQueue.submit()}} that hands over
     the {{GPUCommandBuffer}} to the user agent, which processes it
     on the [=Device timeline=] by calling the OS driver to do a low-level submission.
-  3. The submit gets dispatched by the GPU thread scheduler onto the
+  3. The submit gets dispatched by the GPU invocation scheduler onto the
     actual compute units for execution, which happens on the [=Queue timeline=].
 
 </div>
@@ -5142,9 +5142,9 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
 
             **Arguments:**
             <pre class=argumentdef for="GPUComputePassEncoder/dispatch(x, y, z)">
-                |x|: X dimension of the grid of thread groups to dispatch.
-                |y|: Y dimension of the grid of thread groups to dispatch.
-                |z|: Z dimension of the grid of thread groups to dispatch.
+                |x|: X dimension of the grid of workgroups to dispatch.
+                |y|: Y dimension of the grid of workgroups to dispatch.
+                |z|: Z dimension of the grid of workgroups to dispatch.
             </pre>
 
             **Returns:** {{undefined}}
@@ -5162,7 +5162,7 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
                     that captures the {{GPUComputePassEncoder}} state of |this| as |passState| and,
                     when executed, issues the following steps on the appropriate [=Queue timeline=]:
                     <div class=queue-timeline>
-                        1. Dispatch a grid of thread groups with dimensions [|x|, |y|, |z|] with
+                        1. Dispatch a grid of workgroups with dimensions [|x|, |y|, |z|] with
                             |passState|.{{GPUComputePassEncoder/[[pipeline]]}} using
                             |passState|.{{GPUProgrammablePassEncoder/[[bind_groups]]}}.
                     </div>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2724,7 +2724,7 @@ TODO: *Stub*
   * Initializers evaluated in textual order
 * No two variables have overlapping storage (might already be covered earlier?)
 
-### Program order (within a thread) TODO ### {#program-order}
+### Program order (within an invocation) TODO ### {#program-order}
 
 #### Function-scope variable lifetime and initialization TODO #### {#function-scope-variable-lifetime}
 


### PR DESCRIPTION
Instead of "thread" and "thread( )group".

Fixes #1031.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1095.html" title="Last updated on Sep 22, 2020, 6:42 PM UTC (eb3e7a1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1095/2530c80...kainino0x:eb3e7a1.html" title="Last updated on Sep 22, 2020, 6:42 PM UTC (eb3e7a1)">Diff</a>