### PR TITLE
[wgsl] Remove as keyword.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2921,7 +2921,6 @@ Issue: (dneto) Default rounding mode is an implementation choice.  Is that what 
   <thead>
     <tr><td>Token<td>Definition
   </thead>
-  <tr><td>`AS`<td>as
   <tr><td>`BINDING`<td>binding
   <tr><td>`BITCAST`<td>bitcast
   <tr><td>`BLOCK`<td>block


### PR DESCRIPTION
With the removal of the `as` keyword, `import as` and `entry_point as`
we no longer use as in the grammar. This CL removes it from the list of
keywords used in WGSL.