### PR TITLE
Make GPUAdapter.features a setlike interface

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -851,6 +851,19 @@ A [=device=] has the following internal slots:
 
 ### Extensions ### {#extensions}
 
+<dfn dfn>extension</dfn>
+
+#### <dfn interface>GPUAdapterExtensions</dfn> #### {#gpu-adapterextensions}
+
+{{GPUAdapterExtensions}} is a [=setlike=] interface. Its [=set entries=] are
+the {{GPUExtensionName}} values of the [=extensions=] supported by an adapter.
+
+<script type=idl>
+interface GPUAdapterExtensions {
+    readonly setlike<GPUExtensionName>;
+};
+</script>
+
 
 # Initialization # {#initialization}
 
@@ -1012,7 +1025,7 @@ To get a {{GPUAdapter}}, use {{GPU/requestAdapter()}}.
 <script type=idl>
 interface GPUAdapter {
     readonly attribute DOMString name;
-    readonly attribute FrozenArray<GPUExtensionName> extensions;
+    [SameObject] readonly attribute GPUAdapterExtensions extensions;
     //readonly attribute GPULimits limits; Don't expose higher limits for now.
 
     Promise<GPUDevice?> requestDevice(optional GPUDeviceDescriptor descriptor = {});


### PR DESCRIPTION
This makes it possible for apps to check for individual extension
support (`.has()`), which would let the UA track privacy budgeting with
better granularity.

@litherum mentioned this topic today in the WGSL meeting, which got me thinking about it. Does this address the concern with this mechanism? (Unrelated to the WGSL topic.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1098.html" title="Last updated on Oct 8, 2020, 9:34 PM UTC (e468685)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1098/1cb6b9d...kainino0x:e468685.html" title="Last updated on Oct 8, 2020, 9:34 PM UTC (e468685)">Diff</a>