### PR TITLE
Updated validation of createBindGroup/binding types

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2618,33 +2618,33 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                             - |this| is a [=valid=] {{GPUDevice}}.
                             - The {{GPUBindGroupLayoutEntry/binding}} of each entry in |descriptor| is unique.
                             - For each shader stage, the number of entries in |descriptor| with
-                                {{GPUBindGroupLayoutEntry/type}} {{GPUBindingType/uniform-buffer}} &le;
+                                {{GPUBindGroupLayoutEntry/type}} {{GPUBindingType/"uniform-buffer"}} &le;
                                 {{GPULimits/maxUniformBuffersPerShaderStage|GPULimits.maxUniformBuffersPerShaderStage}}.
                             - For each shader stage, the number of entries in |descriptor| with
-                                {{GPUBindGroupLayoutEntry/type}} {{GPUBindingType/storage-buffer}} &le;
+                                {{GPUBindGroupLayoutEntry/type}} {{GPUBindingType/"storage-buffer"}} &le;
                                 {{GPULimits/maxStorageBuffersPerShaderStage|GPULimits.maxStorageBuffersPerShaderStage}}.
                             - For each shader stage, the number of entries in |descriptor| with
-                                {{GPUBindGroupLayoutEntry/type}} {{GPUBindingType/sampled-texture}} &le;
+                                {{GPUBindGroupLayoutEntry/type}} {{GPUBindingType/"sampled-texture"}} &le;
                                 {{GPULimits/maxSampledTexturesPerShaderStage|GPULimits.maxSampledTexturesPerShaderStage}}.
                             - For each shader stage, the number of entries in |descriptor| with
-                                {{GPUBindGroupLayoutEntry/type}} {{GPUBindingType/readonly-storage-texture}} or
-                                {{GPUBindingType/writeonly-storage-texture}} &le;
+                                {{GPUBindGroupLayoutEntry/type}} {{GPUBindingType/"readonly-storage-texture"}} or
+                                {{GPUBindingType/"writeonly-storage-texture"}} &le;
                                 {{GPULimits/maxStorageTexturesPerShaderStage|GPULimits.maxStorageTexturesPerShaderStage}}.
                             - For each shader stage, the number of entries in |descriptor| with
-                                {{GPUBindGroupLayoutEntry/type}} {{GPUBindingType/sampler}} &le;
+                                {{GPUBindGroupLayoutEntry/type}} {{GPUBindingType/"sampler"}} &le;
                                 {{GPULimits/maxSamplersPerShaderStage|GPULimits.maxSamplersPerShaderStage}}.
                             - The number of entries in |descriptor| with {{GPUBindGroupLayoutEntry/type}}
-                                {{GPUBindingType/uniform-buffer}} and {{GPUBindGroupLayoutEntry/hasDynamicOffset}} `true` &le;
+                                {{GPUBindingType/"uniform-buffer"}} and {{GPUBindGroupLayoutEntry/hasDynamicOffset}} `true` &le;
                                 {{GPULimits/maxDynamicUniformBuffersPerPipelineLayout|GPULimits.maxDynamicUniformBuffersPerPipelineLayout}}.
                             - The number of entries in |descriptor| with {{GPUBindGroupLayoutEntry/type}}
-                                {{GPUBindingType/storage-buffer}} and {{GPUBindGroupLayoutEntry/hasDynamicOffset}} `true` &le;
+                                {{GPUBindingType/"storage-buffer"}} and {{GPUBindGroupLayoutEntry/hasDynamicOffset}} `true` &le;
                                 {{GPULimits/maxDynamicStorageBuffersPerPipelineLayout|GPULimits.maxDynamicStorageBuffersPerPipelineLayout}}.
 
                             - For each {{GPUBindGroupLayoutEntry}} |bindingDescriptor| in |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
                                 - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/visibility}} includes
                                     {{GPUShaderStage/VERTEX}}:
                                     - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is not
-                                        {{GPUBindingType/storage-buffer}} or {{GPUBindingType/writeonly-storage-texture}}.
+                                        {{GPUBindingType/"storage-buffer"}} or {{GPUBindingType/"writeonly-storage-texture"}}.
 
                                 - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
                                     {{GPUBindingType/"uniform-buffer"}}, {{GPUBindingType/"storage-buffer"}}, or
@@ -2666,13 +2666,13 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                                     {{GPUBindingType/"writeonly-storage-texture"}}:
                                     - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/storageTextureFormat}} is `undefined`.
 
-                                - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/multisampled-texture}}:
+                                - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"multisampled-texture"}}:
                                     - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/viewDimension}} is
                                         {{GPUTextureViewDimension/2d}}.
 
                                 - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is
-                                    {{GPUBindingType/readonly-storage-texture}} or
-                                    {{GPUBindingType/writeonly-storage-texture}}:
+                                    {{GPUBindingType/"readonly-storage-texture"}} or
+                                    {{GPUBindingType/"writeonly-storage-texture"}}:
                                     - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/viewDimension}} is not
                                         {{GPUTextureViewDimension/cube}} or {{GPUTextureViewDimension/cube-array}}.
                                     - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/storageTextureFormat}} must
@@ -2806,74 +2806,81 @@ A {{GPUBindGroup}} object has the following internal slots:
                                     such that |layoutBinding|.{{GPUBindGroupLayoutEntry/binding}} equals to
                                     |bindingDescriptor|.{{GPUBindGroupEntry/binding}}.
 
-                                - If the [=binding resource type=] for |bindingType| is {{GPUSampler}}:
-                                    - |resource| is a {{GPUSampler}}.
-                                    - |resource| is [$valid to use with$] |this|.
-                                    - If |bindingType| is
-                                        <dl class="switch">
-                                            : {{GPUBindingType/"sampler"}}
-                                            :: |resource|.{{GPUSampler/[[compareEnable]]}} is `false`.
+                                - If the [=binding resource type=] for |bindingType| is
+                                    <dl class="switch">
+                                        : {{GPUSampler}}
+                                        ::
+                                            - |resource| is a {{GPUSampler}}.
+                                            - |resource| is [$valid to use with$] |this|.
+                                            - If |bindingType| is
+                                                <dl class="switch">
+                                                    : {{GPUBindingType/"sampler"}}
+                                                    :: |resource|.{{GPUSampler/[[compareEnable]]}} is `false`.
 
-                                            : {{GPUBindingType/"comparison-sampler"}}
-                                            :: |resource|.{{GPUSampler/[[compareEnable]]}} is `true`.
-                                        </dl>
+                                                    : {{GPUBindingType/"comparison-sampler"}}
+                                                    :: |resource|.{{GPUSampler/[[compareEnable]]}} is `true`.
+                                                </dl>
 
-                                -  If the [=binding resource type=] for |bindingType| is {{GPUTextureView}}:
-                                    - |resource| is a {{GPUTextureView}}.
-                                    - |resource| is [$valid to use with$] |this|.
-                                    - Let |texture| be |resource|'s texture.
-                                    - |layoutBinding|.{{GPUBindGroupLayoutEntry/viewDimension}} is
-                                        equal to |resource|'s '{{GPUTextureViewDescriptor/dimension}}.
-                                    - If |bindingType| is {{GPUBindingType/"multisampled-texture"}}
-                                        |texture|'s {{GPUTextureDescriptor/sampleCount}} &gt; `1`,
-                                        Otherwise |texture|'s {{GPUTextureDescriptor/sampleCount}} is `1`.
-                                    - If |bindingType| is
-                                        <dl class="switch">
-                                            : {{GPUBindingType/"sampled-texture"}} or
-                                                {{GPUBindingType/"multisampled-texture"}}
-                                            :: |layoutBinding|.{{GPUBindGroupLayoutEntry/textureComponentType}}
-                                                is compatible with |resource|'s {{GPUTextureViewDescriptor/format}}.
-                                            :: |texture|'s {{GPUTextureDescriptor/usage}} includes
-                                                {{GPUTextureUsage/SAMPLED}}.
+                                        : {{GPUTextureView}}
+                                        ::
+                                            - |resource| is a {{GPUTextureView}}.
+                                            - |resource| is [$valid to use with$] |this|.
+                                            - Let |texture| be |resource|'s texture.
+                                            - |layoutBinding|.{{GPUBindGroupLayoutEntry/viewDimension}} is
+                                                equal to |resource|'s '{{GPUTextureViewDescriptor/dimension}}.
+                                            - If |bindingType| is {{GPUBindingType/"multisampled-texture"}}
+                                                |texture|'s {{GPUTextureDescriptor/sampleCount}} &gt; `1`,
+                                                Otherwise |texture|'s {{GPUTextureDescriptor/sampleCount}} is `1`.
+                                            - If |bindingType| is
+                                                <dl class="switch">
+                                                    : {{GPUBindingType/"sampled-texture"}} or
+                                                        {{GPUBindingType/"multisampled-texture"}}
+                                                    :: |layoutBinding|.{{GPUBindGroupLayoutEntry/textureComponentType}}
+                                                        is compatible with |resource|'s {{GPUTextureViewDescriptor/format}}.
+                                                    :: |texture|'s {{GPUTextureDescriptor/usage}} includes
+                                                        {{GPUTextureUsage/SAMPLED}}.
 
-                                            : {{GPUBindingType/"readonly-storage-texture"}} or
-                                                {{GPUBindingType/"writeonly-storage-texture"}}
-                                            :: |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}
-                                                is equal to |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTextureFormat}}.
-                                            :: |texture|'s {{GPUTextureDescriptor/usage}} includes
-                                                {{GPUTextureUsage/STORAGE}}.
-                                        </dl>
+                                                    : {{GPUBindingType/"readonly-storage-texture"}} or
+                                                        {{GPUBindingType/"writeonly-storage-texture"}}
+                                                    :: |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}
+                                                        is equal to |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTextureFormat}}.
+                                                    :: |texture|'s {{GPUTextureDescriptor/usage}} includes
+                                                        {{GPUTextureUsage/STORAGE}}.
+                                                </dl>
 
-                                -  If the [=binding resource type=] for |bindingType| is {{GPUBufferBinding}}:
-                                    - |resource| is a {{GPUBufferBinding}}.
-                                    - |resource|.{{GPUBufferBinding/buffer}} is [$valid to use with$] |this|.
-                                    - Let |bufferBinding| be |bindingDescriptor|.{{GPUBindGroupEntry/resource}},
-                                        a {{GPUBufferBinding}}.
-                                    - The bound part designated by |bufferBinding|.{{GPUBufferBinding/offset}} and
-                                        |bufferBinding|.{{GPUBufferBinding/size}} resides inside the buffer.
-                                    - If |layoutBinding|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}}
-                                        is not `undefined`:
-                                        - The effective binding size, that is either explict in
-                                            |bufferBinding|.{{GPUBufferBinding/size}} or derived from
-                                            |bufferBinding|.{{GPUBufferBinding/offset}} and the full
-                                            size of the buffer, is greater than or equal to
-                                            |layoutBinding|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}}.
+                                        :  {{GPUBufferBinding}}
+                                        ::
+                                            - |resource| is a {{GPUBufferBinding}}.
+                                            - |resource|.{{GPUBufferBinding/buffer}} is [$valid to use with$] |this|.
+                                            - Let |bufferBinding| be |bindingDescriptor|.{{GPUBindGroupEntry/resource}},
+                                                a {{GPUBufferBinding}}.
+                                            - The bound part designated by |bufferBinding|.{{GPUBufferBinding/offset}} and
+                                                |bufferBinding|.{{GPUBufferBinding/size}} resides inside the buffer.
+                                            - If |layoutBinding|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}}
+                                                is not `undefined`:
+                                                - The effective binding size, that is either explict in
+                                                    |bufferBinding|.{{GPUBufferBinding/size}} or derived from
+                                                    |bufferBinding|.{{GPUBufferBinding/offset}} and the full
+                                                    size of the buffer, is greater than or equal to
+                                                    |layoutBinding|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}}.
 
-                                    - If |bindingType| is
-                                        <dl class="switch">
-                                            : {{GPUBindingType/"uniform-buffer"}}
-                                            :: |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
-                                                includes {{GPUBufferUsage/UNIFORM}}.
-                                            :: |bufferBinding|.{{GPUBufferBinding/size}} &le; {{GPULimits/maxUniformBufferBindingSize}}.
-                                            :: Issue: This validation should take into account the default when  {{GPUBufferBinding/size}} is not set.
-                                                Also should {{GPUBufferBinding/size}} default to the `buffer.byteLength - offset` or
-                                                `min(buffer.byteLength - offset, limits.maxUniformBufferBindingSize)`?
+                                            - If |bindingType| is
+                                                <dl class="switch">
+                                                    : {{GPUBindingType/"uniform-buffer"}}
+                                                    :: |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
+                                                        includes {{GPUBufferUsage/UNIFORM}}.
+                                                    :: |bufferBinding|.{{GPUBufferBinding/size}} &le; {{GPULimits/maxUniformBufferBindingSize}}.
+                                                    :: Issue: This validation should take into account the default when  {{GPUBufferBinding/size}} is not set.
+                                                        Also should {{GPUBufferBinding/size}} default to the `buffer.byteLength - offset` or
+                                                        `min(buffer.byteLength - offset, limits.maxUniformBufferBindingSize)`?
 
-                                            : {{GPUBindingType/"storage-buffer"}} or
-                                                {{GPUBindingType/"readonly-storage-buffer"}}
-                                            :: |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
-                                                includes {{GPUBufferUsage/STORAGE}}.
-                                        </dl>
+                                                    : {{GPUBindingType/"storage-buffer"}} or
+                                                        {{GPUBindingType/"readonly-storage-buffer"}}
+                                                    :: |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
+                                                        includes {{GPUBufferUsage/STORAGE}}.
+                                                </dl>
+
+                                    </dl>
 
                         </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -19,6 +19,11 @@ Markup Shorthands: css no
 Assume Explicit For: yes
 </pre>
 
+<pre class="link-defaults">
+spec:html;
+    type:interface; text:Navigator
+</pre>
+
 <pre class='anchors'>
 spec: ECMA-262; urlPrefix: https://tc39.github.io/ecma262/
     type: dfn
@@ -2526,60 +2531,48 @@ Each {{GPUBindingType}} has an associated {{GPUBindingResource}} type and [=inte
 by this table:
 
 <table class="data">
-  <thead>
+    <thead>
+        <tr>
+            <th>{{GPUBindingType}}
+            <th><dfn dfn>Binding resource type</dfn>
+            <th><dfn dfn>Binding usage</dfn>
+    </thead>
     <tr>
-      <th>{{GPUBindingType}}</th>
-      <th><dfn dfn>Binding resource type</dfn></th>
-      <th><dfn dfn>Binding usage</dfn></th>
-    </tr>
-  </thead>
-  <tbody>
+        <td>{{GPUBindingType/"uniform-buffer"}}
+        <td>{{GPUBufferBinding}}
+        <td>[=internal usage/constant=]
     <tr>
-      <td>{{GPUBindingType/"uniform-buffer"}}</td>
-      <td>{{GPUBufferBinding}}</td>
-      <td>[=internal usage/constant=]</td>
-    </tr>
+        <td>{{GPUBindingType/"storage-buffer"}}
+        <td>{{GPUBufferBinding}}
+        <td>[=internal usage/storage=]
     <tr>
-      <td>{{GPUBindingType/"storage-buffer"}}</td>
-      <td>{{GPUBufferBinding}}</td>
-      <td>[=internal usage/storage=]</td>
-    </tr>
+        <td>{{GPUBindingType/"readonly-storage-buffer"}}
+        <td>{{GPUBufferBinding}}
+        <td>[=internal usage/storage-read=]
     <tr>
-      <td>{{GPUBindingType/"readonly-storage-buffer"}}</td>
-      <td>{{GPUBufferBinding}}</td>
-      <td>[=internal usage/storage-read=]</td>
-    </tr>
+        <td>{{GPUBindingType/"sampler"}}
+        <td>{{GPUSampler}}
+        <td>[=internal usage/constant=]
     <tr>
-      <td>{{GPUBindingType/"sampler"}}</td>
-      <td>{{GPUSampler}}</td>
-      <td></td>
-    </tr>
+        <td>{{GPUBindingType/"comparison-sampler"}}
+        <td>{{GPUSampler}}
+        <td>[=internal usage/constant=]
     <tr>
-      <td>{{GPUBindingType/"comparison-sampler"}}</td>
-      <td>{{GPUSampler}}</td>
-      <td></td>
-    </tr>
+        <td>{{GPUBindingType/"sampled-texture"}}
+        <td>{{GPUTextureView}}
+        <td>[=internal usage/constant=]
     <tr>
-      <td>{{GPUBindingType/"sampled-texture"}}</td>
-      <td>{{GPUTextureView}}</td>
-      <td>[=internal usage/constant=]</td>
-    </tr>
+        <td>{{GPUBindingType/"multisampled-texture"}}
+        <td>{{GPUTextureView}}
+        <td>[=internal usage/constant=]
     <tr>
-      <td>{{GPUBindingType/"multisampled-texture"}}</td>
-      <td>{{GPUTextureView}}</td>
-      <td>[=internal usage/constant=]</td>
-    </tr>
+        <td>{{GPUBindingType/"readonly-storage-texture"}}
+        <td>{{GPUTextureView}}
+        <td>[=internal usage/storage-read=]
     <tr>
-      <td>{{GPUBindingType/"readonly-storage-texture"}}</td>
-      <td>{{GPUTextureView}}</td>
-      <td>[=internal usage/storage-read=]</td>
-    </tr>
-    <tr>
-      <td>{{GPUBindingType/"writeonly-storage-texture"}}</td>
-      <td>{{GPUTextureView}}</td>
-      <td>[=internal usage/storage-write=]</td>
-    </tr>
-  </tbody>
+        <td>{{GPUBindingType/"writeonly-storage-texture"}}
+        <td>{{GPUTextureView}}
+        <td>[=internal usage/storage-write=]
 </table>
 
 A {{GPUBindGroupLayout}} object has the following internal slots:
@@ -2825,9 +2818,9 @@ A {{GPUBindGroup}} object has the following internal slots:
                                         ::
                                             - |resource| is a {{GPUTextureView}}.
                                             - |resource| is [$valid to use with$] |this|.
-                                            - Let |texture| be |resource|'s texture.
+                                            - Let |texture| be |resource|.{{GPUTextureView/[[texture]]}}.
                                             - |layoutBinding|.{{GPUBindGroupLayoutEntry/viewDimension}} is
-                                                equal to |resource|'s '{{GPUTextureViewDescriptor/dimension}}.
+                                                equal to |resource|'s {{GPUTextureViewDescriptor/dimension}}.
                                             - If |bindingType| is {{GPUBindingType/"multisampled-texture"}}
                                                 |texture|'s {{GPUTextureDescriptor/sampleCount}} &gt; `1`,
                                                 Otherwise |texture|'s {{GPUTextureDescriptor/sampleCount}} is `1`.
@@ -2852,31 +2845,29 @@ A {{GPUBindGroup}} object has the following internal slots:
                                         ::
                                             - |resource| is a {{GPUBufferBinding}}.
                                             - |resource|.{{GPUBufferBinding/buffer}} is [$valid to use with$] |this|.
-                                            - Let |bufferBinding| be |bindingDescriptor|.{{GPUBindGroupEntry/resource}},
-                                                a {{GPUBufferBinding}}.
-                                            - The bound part designated by |bufferBinding|.{{GPUBufferBinding/offset}} and
-                                                |bufferBinding|.{{GPUBufferBinding/size}} resides inside the buffer.
+                                            - The bound part designated by |resource|.{{GPUBufferBinding/offset}} and
+                                                |resource|.{{GPUBufferBinding/size}} resides inside the buffer.
                                             - If |layoutBinding|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}}
                                                 is not `undefined`:
                                                 - The effective binding size, that is either explict in
-                                                    |bufferBinding|.{{GPUBufferBinding/size}} or derived from
-                                                    |bufferBinding|.{{GPUBufferBinding/offset}} and the full
+                                                    |resource|.{{GPUBufferBinding/size}} or derived from
+                                                    |resource|.{{GPUBufferBinding/offset}} and the full
                                                     size of the buffer, is greater than or equal to
                                                     |layoutBinding|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}}.
 
                                             - If |bindingType| is
                                                 <dl class="switch">
                                                     : {{GPUBindingType/"uniform-buffer"}}
-                                                    :: |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
+                                                    :: |resource|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
                                                         includes {{GPUBufferUsage/UNIFORM}}.
-                                                    :: |bufferBinding|.{{GPUBufferBinding/size}} &le; {{GPULimits/maxUniformBufferBindingSize}}.
+                                                    :: |resource|.{{GPUBufferBinding/size}} &le; {{GPULimits/maxUniformBufferBindingSize}}.
                                                     :: Issue: This validation should take into account the default when  {{GPUBufferBinding/size}} is not set.
                                                         Also should {{GPUBufferBinding/size}} default to the `buffer.byteLength - offset` or
                                                         `min(buffer.byteLength - offset, limits.maxUniformBufferBindingSize)`?
 
                                                     : {{GPUBindingType/"storage-buffer"}} or
                                                         {{GPUBindingType/"readonly-storage-buffer"}}
-                                                    :: |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
+                                                    :: |resource|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
                                                         includes {{GPUBufferUsage/STORAGE}}.
                                                 </dl>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1266,7 +1266,7 @@ dictionary GPULimits {
         For each possible {{GPUShaderStage}} `stage`,
         the maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
 
-          - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/uniform-buffer}}, and
+          - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"uniform-buffer"}}, and
           - {{GPUBindGroupLayoutEntry/visibility}} includes `stage`,
 
         across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
@@ -1276,7 +1276,7 @@ dictionary GPULimits {
 
     : <dfn>maxUniformBufferBindingSize</dfn>
     ::
-        The maximum {{GPUBufferBinding}}.{{GPUBufferBinding/size}} for bindings of type {{GPUBindingType/uniform-buffer}}.
+        The maximum {{GPUBufferBinding}}.{{GPUBufferBinding/size}} for bindings of type {{GPUBindingType/"uniform-buffer"}}.
 
         Higher is [=better=].
 </dl>
@@ -2441,10 +2441,7 @@ Issue(https://github.com/gpuweb/gpuweb/issues/851): consider making `textureComp
 
     : <dfn>hasDynamicOffset</dfn>
     ::
-        If the {{GPUBindGroupLayoutEntry/type}} is
-        {{GPUBindingType/"uniform-buffer"}},
-        {{GPUBindingType/"storage-buffer"}}, or
-        {{GPUBindingType/"readonly-storage-buffer"}}:
+        If the [=binding resource type=] for {{GPUBindGroupLayoutEntry/type}} is {{GPUBufferBinding}}:
 
           - This indicates whether a binding requires a dynamic offset.
           - If `undefined`, it defaults to `false`.
@@ -2453,10 +2450,7 @@ Issue(https://github.com/gpuweb/gpuweb/issues/851): consider making `textureComp
 
     : <dfn>minBufferBindingSize</dfn>
     ::
-        If the {{GPUBindGroupLayoutEntry/type}} is
-        {{GPUBindingType/"uniform-buffer"}},
-        {{GPUBindingType/"storage-buffer"}}, or
-        {{GPUBindingType/"readonly-storage-buffer"}}:
+        If the [=binding resource type=] for {{GPUBindGroupLayoutEntry/type}} is {{GPUBufferBinding}}:
 
           - This may be used to indicate the minimum buffer binding size.
           - If `undefined`, it defaults to 0.
@@ -2465,10 +2459,7 @@ Issue(https://github.com/gpuweb/gpuweb/issues/851): consider making `textureComp
 
     : <dfn>viewDimension</dfn>
     ::
-        If the {{GPUBindGroupLayoutEntry/type}} is
-        {{GPUBindingType/"sampled-texture"}},
-        {{GPUBindingType/"readonly-storage-texture"}}, or
-        {{GPUBindingType/"writeonly-storage-texture"}}:
+        If the [=binding resource type=] for {{GPUBindGroupLayoutEntry/type}} is {{GPUTextureView}}:
 
           - This is the required {{GPUTextureViewDescriptor/dimension}}
             of a texture view bound to this binding.
@@ -2492,9 +2483,10 @@ Issue(https://github.com/gpuweb/gpuweb/issues/851): consider making `textureComp
     ::
         If the {{GPUBindGroupLayoutEntry/type}} is
         {{GPUBindingType/"readonly-storage-texture"}}
-        or {{GPUBindingType/"writeonly-storage-texture"}},
-        this is the required {{GPUTextureViewDescriptor/format}}
-        of a texture view bound to this binding.
+        or {{GPUBindingType/"writeonly-storage-texture"}}:
+
+          - This is the required {{GPUTextureViewDescriptor/format}}
+            of a texture view bound to this binding.
 
         Otherwise, it must be `undefined`.
 </dl>
@@ -2529,6 +2521,66 @@ enum GPUBindingType {
     "writeonly-storage-texture"
 };
 </script>
+
+Each {{GPUBindingType}} has an associated {{GPUBindingResource}} type and [=internal usage=], given
+by this table:
+
+<table class="data">
+  <thead>
+    <tr>
+      <th>{{GPUBindingType}}</th>
+      <th><dfn dfn>Binding resource type</dfn></th>
+      <th><dfn dfn>Binding usage</dfn></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>{{GPUBindingType/"uniform-buffer"}}</td>
+      <td>{{GPUBufferBinding}}</td>
+      <td>[=internal usage/constant=]</td>
+    </tr>
+    <tr>
+      <td>{{GPUBindingType/"storage-buffer"}}</td>
+      <td>{{GPUBufferBinding}}</td>
+      <td>[=internal usage/storage=]</td>
+    </tr>
+    <tr>
+      <td>{{GPUBindingType/"readonly-storage-buffer"}}</td>
+      <td>{{GPUBufferBinding}}</td>
+      <td>[=internal usage/storage-read=]</td>
+    </tr>
+    <tr>
+      <td>{{GPUBindingType/"sampler"}}</td>
+      <td>{{GPUSampler}}</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>{{GPUBindingType/"comparison-sampler"}}</td>
+      <td>{{GPUSampler}}</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>{{GPUBindingType/"sampled-texture"}}</td>
+      <td>{{GPUTextureView}}</td>
+      <td>[=internal usage/constant=]</td>
+    </tr>
+    <tr>
+      <td>{{GPUBindingType/"multisampled-texture"}}</td>
+      <td>{{GPUTextureView}}</td>
+      <td>[=internal usage/constant=]</td>
+    </tr>
+    <tr>
+      <td>{{GPUBindingType/"readonly-storage-texture"}}</td>
+      <td>{{GPUTextureView}}</td>
+      <td>[=internal usage/storage-read=]</td>
+    </tr>
+    <tr>
+      <td>{{GPUBindingType/"writeonly-storage-texture"}}</td>
+      <td>{{GPUTextureView}}</td>
+      <td>[=internal usage/storage-write=]</td>
+    </tr>
+  </tbody>
+</table>
 
 A {{GPUBindGroupLayout}} object has the following internal slots:
 
@@ -2748,75 +2800,57 @@ A {{GPUBindGroup}} object has the following internal slots:
                             For each {{GPUBindGroupEntry}} |bindingDescriptor| in
                                 |descriptor|.{{GPUBindGroupDescriptor/entries}}:
                                 - Let |resource| be |bindingDescriptor|.{{GPUBindGroupEntry/resource}}.
+                                - Let |bindingType| be |layoutBinding|.{{GPUBindGroupLayoutEntry/type}}.
                                 - There is exactly one {{GPUBindGroupLayoutEntry}} |layoutBinding|
                                     in |descriptor|.{{GPUBindGroupDescriptor/layout}}.{{GPUBindGroupLayoutDescriptor/entries}}
                                     such that |layoutBinding|.{{GPUBindGroupLayoutEntry/binding}} equals to
                                     |bindingDescriptor|.{{GPUBindGroupEntry/binding}}.
 
-                                - If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampler"}}:
+                                - If the [=binding resource type=] for |bindingType| is {{GPUSampler}}:
+                                    - |resource| is a {{GPUSampler}}.
                                     - |resource| is [$valid to use with$] |this|.
-                                    - |resource|.{{GPUSampler/[[compareEnable]]}} is `false`.
+                                    - If |bindingType| is
+                                        <dl class="switch">
+                                            : {{GPUBindingType/"sampler"}}
+                                            :: |resource|.{{GPUSampler/[[compareEnable]]}} is `false`.
 
-                                - If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"comparison-sampler"}}:
-                                    - |resource| is [$valid to use with$] |this|.
-                                    - |resource|.{{GPUSampler/[[compareEnable]]}} is `true`.
+                                            : {{GPUBindingType/"comparison-sampler"}}
+                                            :: |resource|.{{GPUSampler/[[compareEnable]]}} is `true`.
+                                        </dl>
 
-                                -  If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
-                                    {{GPUBindingType/"sampled-texture"}} or
-                                    {{GPUBindingType/"multisampled-texture"}}:
+                                -  If the [=binding resource type=] for |bindingType| is {{GPUTextureView}}:
+                                    - |resource| is a {{GPUTextureView}}.
                                     - |resource| is [$valid to use with$] |this|.
+                                    - Let |texture| be |resource|'s texture.
                                     - |layoutBinding|.{{GPUBindGroupLayoutEntry/viewDimension}} is
-                                        equal to |resource|'s {{GPUTextureViewDescriptor/dimension}}.
-                                    - |layoutBinding|.{{GPUBindGroupLayoutEntry/textureComponentType}}
-                                        is compatible with |resource|'s {{GPUTextureViewDescriptor/format}}.
-                                    - |resource|'s texture's {{GPUTextureDescriptor/usage}} includes
-                                            {{GPUTextureUsage/SAMPLED}}.
+                                        equal to |resource|'s '{{GPUTextureViewDescriptor/dimension}}.
+                                    - If |bindingType| is {{GPUBindingType/"multisampled-texture"}}
+                                        |texture|'s {{GPUTextureDescriptor/sampleCount}} &gt; `1`,
+                                        Otherwise |texture|'s {{GPUTextureDescriptor/sampleCount}} is `1`.
+                                    - If |bindingType| is
+                                        <dl class="switch">
+                                            : {{GPUBindingType/"sampled-texture"}} or
+                                                {{GPUBindingType/"multisampled-texture"}}
+                                            :: |layoutBinding|.{{GPUBindGroupLayoutEntry/textureComponentType}}
+                                                is compatible with |resource|'s {{GPUTextureViewDescriptor/format}}.
+                                            :: |texture|'s {{GPUTextureDescriptor/usage}} includes
+                                                {{GPUTextureUsage/SAMPLED}}.
 
-                                - If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampled-texture"}}:
-                                    - |resource|'s texture's {{GPUTextureDescriptor/sampleCount}} is 1.
+                                            : {{GPUBindingType/"readonly-storage-texture"}} or
+                                                {{GPUBindingType/"writeonly-storage-texture"}}
+                                            :: |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}
+                                                is equal to |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTextureFormat}}.
+                                            :: |texture|'s {{GPUTextureDescriptor/usage}} includes
+                                                {{GPUTextureUsage/STORAGE}}.
+                                        </dl>
 
-                                - If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"multisampled-texture"}}:
-                                    - |resource|'s texture's {{GPUTextureDescriptor/sampleCount}} is greater than 1.
-
-                                - If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
-                                    {{GPUBindingType/"readonly-storage-texture"}} or
-                                    {{GPUBindingType/"writeonly-storage-texture"}}:
-                                    - |resource| is [$valid to use with$] |this|.
-                                    - |layoutBinding|.{{GPUBindGroupLayoutEntry/viewDimension}} is
-                                        equal to |resource|'s {{GPUTextureViewDescriptor/dimension}}.
-                                    - |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}
-                                        is equal to |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTextureFormat}}.
-                                    - |resource|'s texture's {{GPUTextureDescriptor/usage}} includes
-                                        {{GPUTextureUsage/STORAGE}}.
-                                    - |resource|'s texture's {{GPUTextureDescriptor/sampleCount}} is 1.
-
-                                - If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
-                                    {{GPUBindingType/"uniform-buffer"}} or
-                                    {{GPUBindingType/"storage-buffer"}} or
-                                    {{GPUBindingType/"readonly-storage-buffer"}}:
+                                -  If the [=binding resource type=] for |bindingType| is {{GPUBufferBinding}}:
                                     - |resource| is a {{GPUBufferBinding}}.
                                     - |resource|.{{GPUBufferBinding/buffer}} is [$valid to use with$] |this|.
                                     - Let |bufferBinding| be |bindingDescriptor|.{{GPUBindGroupEntry/resource}},
                                         a {{GPUBufferBinding}}.
-
-                                    - If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"uniform-buffer"}}:
-                                        - |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
-                                            includes {{GPUBufferUsage/UNIFORM}}.
-                                        - |bufferBinding|.{{GPUBufferBinding/size}} &le; {{GPULimits/maxUniformBufferBindingSize}}.
-
-                                        Issue: This validation should take into account the default when  {{GPUBufferBinding/size}} is not set.
-                                        Also should {{GPUBufferBinding/size}} default to the `buffer.byteLength - offset` or
-                                        `min(buffer.byteLength - offset, limits.maxUniformBufferBindingSize)`?
-
-                                    - If |layoutBinding|.{{GPUBindGroupLayoutEntry/type}} is
-                                        {{GPUBindingType/"storage-buffer"}} or
-                                        {{GPUBindingType/"readonly-storage-buffer"}}:
-                                        - |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
-                                            includes {{GPUBufferUsage/STORAGE}}.
-
                                     - The bound part designated by |bufferBinding|.{{GPUBufferBinding/offset}} and
                                         |bufferBinding|.{{GPUBufferBinding/size}} resides inside the buffer.
-
                                     - If |layoutBinding|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}}
                                         is not `undefined`:
                                         - The effective binding size, that is either explict in
@@ -2824,6 +2858,23 @@ A {{GPUBindGroup}} object has the following internal slots:
                                             |bufferBinding|.{{GPUBufferBinding/offset}} and the full
                                             size of the buffer, is greater than or equal to
                                             |layoutBinding|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}}.
+
+                                    - If |bindingType| is
+                                        <dl class="switch">
+                                            : {{GPUBindingType/"uniform-buffer"}}
+                                            :: |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
+                                                includes {{GPUBufferUsage/UNIFORM}}.
+                                            :: |bufferBinding|.{{GPUBufferBinding/size}} &le; {{GPULimits/maxUniformBufferBindingSize}}.
+                                            :: Issue: This validation should take into account the default when  {{GPUBufferBinding/size}} is not set.
+                                                Also should {{GPUBufferBinding/size}} default to the `buffer.byteLength - offset` or
+                                                `min(buffer.byteLength - offset, limits.maxUniformBufferBindingSize)`?
+
+                                            : {{GPUBindingType/"storage-buffer"}} or
+                                                {{GPUBindingType/"readonly-storage-buffer"}}
+                                            :: |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
+                                                includes {{GPUBufferUsage/STORAGE}}.
+                                        </dl>
+
                         </div>
 
                         Issue: define the association between texture formats and component types
@@ -2841,32 +2892,12 @@ A {{GPUBindGroup}} object has the following internal slots:
 
                     1. For each {{GPUBindGroupEntry}} |bindingDescriptor| in
                         |descriptor|.{{GPUBindGroupDescriptor/entries}}:
-                        1. Let |internalUsage| be the result of [$GPUDevice/derive binding usage$](|layoutBinding|.{{GPUBindGroupLayoutEntry/type}})
+                        1. Let |internalUsage| be the [=binding usage=] for |layoutBinding|.{{GPUBindGroupLayoutEntry/type}}.
                         1. Each [=subresource=] seen by |resource| is added to {{GPUBindGroup/[[usedResources]]}} as |internalUsage|.
                 </div>
             1. Return |bindGroup|.
 
             Issue: define the "effective buffer binding size" separately.
-        </div>
-
-        <div algorithm>
-            <dfn abstract-op>derive binding usage</dfn>(|type|)
-
-            **Arguments:**
-                - {{GPUBindingType}} |type|
-
-            **Returns:** [=internal usage=]
-
-            1. If |type| is
-                {{GPUBindingType/"uniform-buffer"}} or {{GPUBindingType/"sampled-texture"}}:
-                1. return [=internal usage/constant=]
-            1. If |type| is
-                {{GPUBindingType/"readonly-storage-buffer"}} or {{GPUBindingType/"readonly-storage-texture"}}:
-                1. return [=internal usage/storage-read=]
-            1. If |type| is {{GPUBindingType/"storage-buffer"}}:
-                1. return [=internal usage/storage=]
-            1. If |type| is {{GPUBindingType/"writeonly-storage-texture"}}:
-                1. return [=internal usage/storage-write=]
         </div>
 </dl>
 
@@ -3163,11 +3194,11 @@ has a default layout created and used instead.
             1. If |resource| is for a sampler binding:
 
                     1. Set |entry|.{{GPUBindGroupLayoutEntry/type}} to
-                        {{GPUBindingType/sampler}}.
+                        {{GPUBindingType/"sampler"}}.
 
             1. If |resource| is for a comparison sampler binding:
 
-                1. Set |entry|.{{GPUBindGroupLayoutEntry/type}} to {{GPUBindingType/comparison-sampler}}.
+                1. Set |entry|.{{GPUBindGroupLayoutEntry/type}} to {{GPUBindingType/"comparison-sampler"}}.
 
             1. If |resource| is for a buffer binding:
 
@@ -3179,15 +3210,15 @@ has a default layout created and used instead.
 
                 1. If |resource| is for a uniform buffer:
 
-                    1. Set |entry|.{{GPUBindGroupLayoutEntry/type}} to {{GPUBindingType/uniform-buffer}}.
+                    1. Set |entry|.{{GPUBindGroupLayoutEntry/type}} to {{GPUBindingType/"uniform-buffer"}}.
 
                 1. If |resource| is for a read-only storage buffer:
 
-                    1. Set |entry|.{{GPUBindGroupLayoutEntry/type}} to {{GPUBindingType/readonly-storage-buffer}}.
+                    1. Set |entry|.{{GPUBindGroupLayoutEntry/type}} to {{GPUBindingType/"readonly-storage-buffer"}}.
 
                 1. If |resource| is for a storage buffer:
 
-                    1. Set |entry|.{{GPUBindGroupLayoutEntry/type}} to {{GPUBindingType/storage-buffer}}.
+                    1. Set |entry|.{{GPUBindGroupLayoutEntry/type}} to {{GPUBindingType/"storage-buffer"}}.
 
             1. If |resource| is for a texture binding:
 
@@ -3195,20 +3226,20 @@ has a default layout created and used instead.
                 1. Set |entry|.{{GPUBindGroupLayoutEntry/viewDimension}} to |resource|'s dimension.
                 1. If |resource| is for a multisampled texture:
 
-                    1. Set |entry|.{{GPUBindGroupLayoutEntry/type}} to {{GPUBindingType/multisampled-texture}}.
+                    1. Set |entry|.{{GPUBindGroupLayoutEntry/type}} to {{GPUBindingType/"multisampled-texture"}}.
 
                 1. If |resource| is for a single-sampled texture:
 
-                    1. Set |entry|.{{GPUBindGroupLayoutEntry/type}} to {{GPUBindingType/sampled-texture}}.
+                    1. Set |entry|.{{GPUBindGroupLayoutEntry/type}} to {{GPUBindingType/"sampled-texture"}}.
 
                 1. If |resource| is for a read-only storage texture:
 
-                    1. Set |entry|.{{GPUBindGroupLayoutEntry/type}} to {{GPUBindingType/readonly-storage-texture}}.
+                    1. Set |entry|.{{GPUBindGroupLayoutEntry/type}} to {{GPUBindingType/"readonly-storage-texture"}}.
                     1. Set |entry|.{{GPUBindGroupLayoutEntry/storageTextureFormat}} to |resource|'s format.
 
                 1. If |resource| is for a write-only storage texture:
 
-                    1. Set |entry|.{{GPUBindGroupLayoutEntry/type}} to {{GPUBindingType/writeonly-storage-texture}}.
+                    1. Set |entry|.{{GPUBindGroupLayoutEntry/type}} to {{GPUBindingType/"writeonly-storage-texture"}}.
                     1. Set |entry|.{{GPUBindGroupLayoutEntry/storageTextureFormat}} to |resource|'s format.
 
             1. If |groupDescs|[|group|] has an entry |previousEntry| with {{GPUBindGroupLayoutEntry/binding}} equal to |binding|:
@@ -6893,7 +6924,7 @@ All plain color formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/
 
 Only formats with {{GPUTextureComponentType}} {{GPUTextureComponentType/"float"}} can be blended.
 
-The {{GPUTextureUsage/STORAGE|GPUTextureUsage.STORAGE}} column specifies the support for {{GPUTextureUsage/STORAGE}} usage in the core API, including both {{GPUBindingType/readonly-storage-texture}} and {{GPUBindingType/writeonly-storage-texture}}. If there is a &star; mark, the atomic operations on the storage are also supported for this format.
+The {{GPUTextureUsage/STORAGE|GPUTextureUsage.STORAGE}} column specifies the support for {{GPUTextureUsage/STORAGE}} usage in the core API, including both {{GPUBindingType/"readonly-storage-texture"}} and {{GPUBindingType/"writeonly-storage-texture"}}. If there is a &star; mark, the atomic operations on the storage are also supported for this format.
 
 The "Filter" column specifies whether textures of this format can be sampled in shaders with a sampler having {{GPUFilterMode/linear}} filtering.
 


### PR DESCRIPTION
Fixes #1060, but goes a fair bit beyond that as well.

The validation for `createBindGroup` (and related bindings stuff) was brain-meltingly hard to parse, especially in bikeshed form, so I took a crack at improving it while fixing the resource type validation. Put the binding/resource/usage types in a table for easier reference and to provide a nicer shorthand throughout the doc for referring to logical binding type groups. Made use of switch statements to better nest some of the deeper logical branches, and made `GPUBindingType` references use quotes consistently.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/toji/gpuweb/pull/1099.html" title="Last updated on Sep 26, 2020, 5:14 AM UTC (4f05def)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1099/9a76713...toji:4f05def.html" title="Last updated on Sep 26, 2020, 5:14 AM UTC (4f05def)">Diff</a>