### PR TITLE
Fixup SPIR-V translation of the ! operator.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1969,7 +1969,7 @@ unary_expression
       OpSNegate
       OpFNegate
   | BANG unary_expression
-      OpNot
+      OpLogicalNot
 
 singular_expression
   : primary_expression postfix_expression


### PR DESCRIPTION
The ! should convert to an OpLogicalNot as it operates on boolean values
instead of OpNot.