### PR TITLE
More wording about privacy attacks

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -210,6 +210,10 @@ such as {{GPUCommandEncoder/beginRenderPass()}} or {{GPURenderPassEncoder/setBle
 
 ## Security ## {#security}
 
+The security requirements for WebGPU are the same as ever for the web, and are likewise non-negotiable.
+The general approach is strictly validating all the commands before they reach GPU,
+ensuring that a page can only work with its own data.
+
 ### CPU-based undefined behavior ### {#security-cpu-ub}
 
 A WebGPU implementation translates the workloads issued by the user into API commands specific
@@ -302,12 +306,21 @@ and disable WebGPU on drivers with known bugs that can't be worked around.
 
 ### Timing attacks ### {#security-timing}
 
-WebGPU is designed for multi-threaded use via Web Workers. Some of the objects,
-like {{GPUBuffer}}, have shared state which can be simultaneously accessed.
-This allows race conditions to occur, similar to those of accessing a SharedArrayBuffer
-from multiple Web Workers, which makes the thread scheduling observable
-and allows the creation of high-precision timers.
-The theoretical attack vectors are a subset of those of SharedArrayBuffer.
+WebGPU is designed for multi-threaded use via Web Workers. As such, the is designed not to open
+the users to modern high-precision timing attacks. Some of the objects, like `GPUBuffer`,
+have shared state which can be simultaneously accessed. This allows race conditions to occur,
+similar to those of accessing a `SharedArrayBuffer` from multiple Web Workers,
+which makes the thread scheduling observable.
+
+The set of mitigations to address this attack vector, employed by user agents,
+can be a subset of [mitigations](https://hacks.mozilla.org/2020/07/safely-reviving-shared-memory/)
+against the malicious `SharedArrayBuffer` use. In particular,
+the user agent may limit sharing a `GPUBuffer` to Web Workers belonging to the same
+[browser context group](https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-group).
+It may also serialize Web Workers that share a `GPUBuffer` to prevent any concurrency.
+
+In the end, the attack surface for the shared state in WebGPU will be
+a small subset of  the `SharedArrayBuffer` attacks.
 
 WebGPU also specifies the {{GPUExtensionName/"timestamp-query"}} extension, which
 provides high precision timing of GPU operations. The extension is optional, and a WebGPU
@@ -365,6 +378,12 @@ of CPU execution of Javascript.
 
 ## Privacy ## {#security-privacy}
 
+Table-stakes for WebGPU are matching the privacy guarantees of WebGL, but we are looking
+for opportunities where we can futher raise the bar on privacy.
+While these new APIs are powerful and valuable, our users' privacy is essential.
+We're working with our fellow standards body participants to ensure that
+WebGPU is not a vector for tracking users.
+
 ### Machine-specific limits ### {#security-machine-limits}
 
 WebGPU can expose a lot of detail on the underlying GPU architecture and the device geometry.
@@ -372,25 +391,28 @@ This includes available physical adapters, many limits on the GPU and CPU resour
 that could be used (such as the maximum texture size), and any optional hardware-specific
 features or extensions that are available.
 
-WebGPU is designed to have a strong baseline for the limits. This makes it viable (unlike WebGL)
-to *only* expose the baseline limits, trivially reducing the fingerprinting surface.
-The implementations may decide to only expose the baseline even if the hardware is more capable,
-or to support a limited number of higher-capable feature sets.
+This specification is designed with respect to a [privacy budget](https://www.johndcook.com/blog/2019/10/14/privacy-budget/).
+It allows an user agent to decide how much information about the target system is exposed to
+the developer, thus mitigating the privacy exposure risks.
+
+User agents can group different platforms into coarse groups, reducing the exposed difference
+in limits between them. The baseline (guaranteed) limits are also deliberately high enough
+to allow most application to work without requesting higher limits.
+All the usage of the API is validated according to the requested limits,
+so the actual hardware capabilities are not exposed to the users by accident.
 
 ### Machine-specific artifacts ### {#security-machine-artifacts}
 
-WebGPU doesn't specify some of the hardware behavior down to the expected bit values,
-providing some leeway for the platforms to differentiate. This applies to rasterization coverage
+There are some machine-specific rasterization/precision artifacts and performance differences
+that can be observed roughly in the same way as in WebGL. This applies to rasterization coverage
 and patterns, interpolation precision of the varyings between shader stages, compute unit scheduling,
 and more aspects of execution.
 
-The specification doesn't have mitigations to hide these differences in place.
-However our testing has shown that these fingerprintable artifacts
-are generally consistent for each hardware vendor's GPUs.
-For example, while it's possible to identify rasterization differences between Intel and AMD hardware,
-it becomes much harder to differentiate between generations of AMD GPUs.
+Generally, rasterization and precision fingerprints are identical across most or all
+of the devices of each vendor. Performance differences are relatively intractable,
+but also relatively low-signal (as with JS execution performance).
 
-Privacy-critical applications and users should utilize software implementations to eliminate such artifacts.
+Privacy-critical applications and user agents should utilize software implementations to eliminate such artifacts.
 
 ### Machine-specific performance ### {#security-machine-performance}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -315,13 +315,12 @@ like {{GPUBuffer}} or {{GPUQueue}}, have shared state which can be simultaneousl
 This allows race conditions to occur, similar to those of accessing a `SharedArrayBuffer`
 from multiple Web Workers, which makes the thread scheduling observable.
 
-The set of mitigations to address this attack vector, employed by user agents,
-can be a subset of [mitigations](https://hacks.mozilla.org/2020/07/safely-reviving-shared-memory/)
-against the malicious `SharedArrayBuffer` use. In particular,
-the user agent may limit sharing any object handles (such as {{GPUBuffer}}) to [=agents=] belonging
-to the same [=browsing context group=], and only if the
-[cross-origin isolated](https://web.dev/coop-coep/) policies are in place. 
-It may also serialize Web Workers that share any handles to prevent any concurrency entirely.
+WebGPU addresses this by only only exposing the shared-mutable-state operations to
+[=agents=] belonging to the same [=browsing context group=], and only if
+the [cross-origin isolated](https://web.dev/coop-coep/) policies are in place.
+This restriction matches the [mitigations](https://hacks.mozilla.org/2020/07/safely-reviving-shared-memory/)
+against the malicious `SharedArrayBuffer` use. Similarly, the user agent may also
+serialize the [=agents=] sharing any handles to prevent any concurrency entirely.
 
 In the end, the attack surface for races on shared state in WebGPU will be
 a small subset of the `SharedArrayBuffer` attacks.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -26,6 +26,9 @@ spec: ECMA-262; urlPrefix: https://tc39.github.io/ecma262/
 spec: webidl; urlPrefix: https://heycam.github.io/webidl/#
     type: dfn
         text: resolve; url: resolve
+spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/browsers.html#
+    type: dfn
+        text: browsing context group; url: browsing-context-group
 </pre>
 
 <style>
@@ -307,20 +310,21 @@ and disable WebGPU on drivers with known bugs that can't be worked around.
 ### Timing attacks ### {#security-timing}
 
 WebGPU is designed for multi-threaded use via Web Workers. As such, it is designed not to open
-the users to modern high-precision timing attacks. Some of the objects, like `GPUBuffer`,
-have shared state which can be simultaneously accessed. This allows race conditions to occur,
-similar to those of accessing a `SharedArrayBuffer` from multiple Web Workers,
-which makes the thread scheduling observable.
+the users to modern high-precision timing attacks. Some of the objects,
+like {{GPUBuffer}} or {{GPUQueue}}, have shared state which can be simultaneously accessed.
+This allows race conditions to occur, similar to those of accessing a `SharedArrayBuffer`
+from multiple Web Workers, which makes the thread scheduling observable.
 
 The set of mitigations to address this attack vector, employed by user agents,
 can be a subset of [mitigations](https://hacks.mozilla.org/2020/07/safely-reviving-shared-memory/)
 against the malicious `SharedArrayBuffer` use. In particular,
-the user agent may limit sharing a `GPUBuffer` to Web Workers belonging to the same
-[browser context group](https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-group).
-It may also serialize Web Workers that share a `GPUBuffer` to prevent any concurrency.
+the user agent may limit sharing any object handles (such as {{GPUBuffer}}) to [=agents=] belonging
+to the same [=browsing context group=], and only if the
+[cross-origin isolated](https://web.dev/coop-coep/) policies are in place. 
+It may also serialize Web Workers that share any handles to prevent any concurrency entirely.
 
-In the end, the attack surface for the shared state in WebGPU will be
-a small subset of  the `SharedArrayBuffer` attacks.
+In the end, the attack surface for races on shared state in WebGPU will be
+a small subset of the `SharedArrayBuffer` attacks.
 
 WebGPU also specifies the {{GPUExtensionName/"timestamp-query"}} extension, which
 provides high precision timing of GPU operations. The extension is optional, and a WebGPU
@@ -378,12 +382,6 @@ of CPU execution of Javascript.
 
 ## Privacy ## {#security-privacy}
 
-Table-stakes for WebGPU are matching the privacy guarantees of WebGL, but we are looking
-for opportunities where we can futher raise the bar on privacy.
-While these new APIs are powerful and valuable, our users' privacy is essential.
-We're working with our fellow standards body participants to ensure that
-WebGPU is not a vector for tracking users.
-
 ### Machine-specific limits ### {#security-machine-limits}
 
 WebGPU can expose a lot of detail on the underlying GPU architecture and the device geometry.
@@ -391,7 +389,7 @@ This includes available physical adapters, many limits on the GPU and CPU resour
 that could be used (such as the maximum texture size), and any optional hardware-specific
 features or extensions that are available.
 
-This specification is designed with respect to a [privacy budget](https://www.johndcook.com/blog/2019/10/14/privacy-budget/).
+This specification is designed with respect to a [privacy budget](https://github.com/bslassey/privacy-budget).
 It allows an user agent to decide how much information about the target system is exposed to
 the developer, thus mitigating the privacy exposure risks.
 
@@ -422,6 +420,9 @@ can show if the user's machine is fast at specific workloads.
 This is a fairly common vector (present in both WebGL and Javascript),
 but it's also low-signal and relatively intractable to truly normalize.
 
+WebGPU compute pipelines expose access to GPU unobstructed by the fixed-function hardware.
+This poses an additional risk for unique device fingerprinting. User agents can take steps
+to dissociate logical GPU invocations with actual compute units to reduce this risk.
 
 # Fundamentals # {#fundamentals}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -315,12 +315,7 @@ like {{GPUBuffer}} or {{GPUQueue}}, have shared state which can be simultaneousl
 This allows race conditions to occur, similar to those of accessing a `SharedArrayBuffer`
 from multiple Web Workers, which makes the thread scheduling observable.
 
-WebGPU addresses this by only only exposing the shared-mutable-state operations to
-[=agents=] belonging to the same [=browsing context group=], and only if
-the [cross-origin isolated](https://web.dev/coop-coep/) policies are in place.
-This restriction matches the [mitigations](https://hacks.mozilla.org/2020/07/safely-reviving-shared-memory/)
-against the malicious `SharedArrayBuffer` use. Similarly, the user agent may also
-serialize the [=agents=] sharing any handles to prevent any concurrency entirely.
+Issue: clarify the mitigations here
 
 In the end, the attack surface for races on shared state in WebGPU will be
 a small subset of the `SharedArrayBuffer` attacks.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -306,7 +306,7 @@ and disable WebGPU on drivers with known bugs that can't be worked around.
 
 ### Timing attacks ### {#security-timing}
 
-WebGPU is designed for multi-threaded use via Web Workers. As such, the is designed not to open
+WebGPU is designed for multi-threaded use via Web Workers. As such, it is designed not to open
 the users to modern high-precision timing attacks. Some of the objects, like `GPUBuffer`,
 have shared state which can be simultaneously accessed. This allows race conditions to occur,
 similar to those of accessing a `SharedArrayBuffer` from multiple Web Workers,


### PR DESCRIPTION
I was pointed, internally, that the spec notion of timing attacks and limits does not fully address the concerns. Here is an attempt to cover these bases, done with help from @jdashg . Please check carefully, and treat the content as a draft!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Sep 28, 2020, 2:27 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fkvark%2Fgpuweb%2F48fb37630690ac04b991af0419f871ba5c80eea8%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)

```
<html><body><p><strong>WARNING: </strong>mysqli_connect(): (HY000/2002): Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (111)</p></body></html>
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%231102.)._
</details>
