### PR TITLE
[wgsl] Fix bitcast note.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1477,21 +1477,21 @@ value in one type as a value in another type.
           |T| is one of u32, f32
       <td>bitcast&lt;vec|N|&lt;i32&gt;&gt;(|e|) : vec|N|&lt;i32&gt;
       <td>Component-wise reinterpretation of bits.<br>
-          Component |i| of the result is `bitcast&lt;i32&gt;(`|e|`[`|i|`])`<br>
+          Component |i| of the result is `bitcast<i32>(`|e|`[`|i|`])`<br>
           (OpBitcast)
   <tr algorithm="vector reinterpretation as unsigned integer">
       <td>|e| : vec&lt;|N|&gt;|T|&gt;,<br>
           |T| is one of i32, f32
       <td>bitcast&lt;vec|N|&lt;u32&gt;&gt;(|e|) : vec|N|&lt;u32&gt;
       <td>Component-wise reinterpretation of bits.<br>
-          Component |i| of the result is `bitcast&lt;u32&gt;(`|e|`[`|i|`])`<br>
+          Component |i| of the result is `bitcast<u32>(`|e|`[`|i|`])`<br>
           (OpBitcast)
   <tr algorithm="vector reinterpretation as floating point">
       <td>|e| : vec&lt;|N|&gt;|T|&gt;,<br>
           |T| is one of i32, u32
       <td>bitcast&lt;vec|N|&lt;f32&gt;&gt;(|e|) : vec|N|&lt;f32&gt;
       <td>Component-wise Reinterpretation of bits.<br>
-          Component |i| of the result is `bitcast&lt;f32&gt;(`|e|`[`|i|`])`<br>
+          Component |i| of the result is `bitcast<f32>(`|e|`[`|i|`])`<br>
           (OpBitcast)
 
 </table>


### PR DESCRIPTION
The Bitcast note was emitting the lt; gt; instead of < and > since
they are inside a code block.