### PR TITLE
Fix mapping to SPIR-V for texture buffers

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -577,6 +577,21 @@ type.
 * type(image_storage_type) is one of `f32`, `i32`, or `u32`, depending on the storage type.
 
 When mapping to SPIR-V, a read-only storage texture variable must also have a `NonWritable` decoration.
+For example:
+
+<div class='example' heading='Mapping a texture_ro_1d variable to SPIR-V'>
+  <xmp>
+      var<uniform_constant> tbuf : texture_ro_1d<rgba8unorm>;
+
+      # Maps to the following SPIR-V:
+      #  OpDecorate %tbuf NonWritable
+      #  ...
+      #  %float = OpTypeFloat 32
+      #  %image_type = OpTypeImage %float 1D 0 0 0 2 Rgba8
+      #  %image_ptr_type = OpTypePointer UniformConstant %image_type
+      #  %tbuf = OpVariable %image_ptr_type UniformConstant
+  </xmp>
+</div>
 
 ### Write-only Storage Texture Types ### {#texture-wo}
 <pre class='def'>
@@ -596,7 +611,22 @@ When mapping to SPIR-V, a read-only storage texture variable must also have a `N
   %1 = OpTypeImage %void 3D 0 0 0 2 image_storage_type
 </pre>
 
-When mapping to SPIR-V, a write-only storage texture variable must also have a `NonWritable` decoration.
+When mapping to SPIR-V, a write-only storage texture variable must also have a `NonReadable` decoration.
+For example:
+
+<div class='example' heading='Mapping a texture_wo_1d variable to SPIR-V'>
+  <xmp>
+      var<uniform_constant> tbuf : texture_wo_1d<rgba8unorm>;
+
+      # Maps to the following SPIR-V:
+      #  OpDecorate %tbuf NonReadable
+      #  ...
+      #  %float = OpTypeFloat 32
+      #  %image_type = OpTypeImage %float 1D 0 0 0 2 Rgba8
+      #  %image_ptr_type = OpTypePointer UniformConstant %image_type
+      #  %tbuf = OpVariable %image_ptr_type UniformConstant
+  </xmp>
+</div>
 
 ### Depth Texture Types ### {#texture-depth}
 <pre class='def'>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -560,39 +560,43 @@ type.
 ### Read-only Storage Texture Types ### {#texture-ro}
 <pre class='def'>
 `texture_ro_1d<image_storage_type>`
-  %1 = OpTypeImage type(image_storage_type) 1D 0 0 0 2 image_storage_type ReadOnly
+  %1 = OpTypeImage type(image_storage_type) 1D 0 0 0 2 image_storage_type
 
 `texture_ro_1d_array<image_storage_type>`
-  %1 = OpTypeImage type(image_storage_type) 1D 0 1 0 2 image_storage_type ReadOnly
+  %1 = OpTypeImage type(image_storage_type) 1D 0 1 0 2 image_storage_type
 
 `texture_ro_2d<image_storage_type>`
-  %1 = OpTypeImage type(image_storage_type) 0 0 0 2 image_storage_type ReadOnly
+  %1 = OpTypeImage type(image_storage_type) 0 0 0 2 image_storage_type
 
 `texture_ro_2d_array<image_storage_type>`
-  %1 = OpTypeImage type(image_storage_type) 0 1 0 2 image_storage_type ReadOnly
+  %1 = OpTypeImage type(image_storage_type) 0 1 0 2 image_storage_type
 
 `texture_ro_3d<image_storage_type>`
-  %1 = OpTypeImage type(image_storage_type) 3D 0 0 0 2 image_storage_type ReadOnly
+  %1 = OpTypeImage type(image_storage_type) 3D 0 0 0 2 image_storage_type
 </pre>
 * type(image_storage_type) is one of `f32`, `i32`, or `u32`, depending on the storage type.
+
+When mapping to SPIR-V, a read-only storage texture variable must also have a `NonWritable` decoration.
 
 ### Write-only Storage Texture Types ### {#texture-wo}
 <pre class='def'>
 `texture_wo_1d<image_storage_type>`
-  %1 = OpTypeImage %void 1D 0 0 0 2 image_storage_type WriteOnly
+  %1 = OpTypeImage %void 1D 0 0 0 2 image_storage_type
 
 `texture_wo_1d_array<image_storage_type>`
-  %1 = OpTypeImage %void 1D 0 1 0 2 image_storage_type WriteOnly
+  %1 = OpTypeImage %void 1D 0 1 0 2 image_storage_type
 
 `texture_wo_2d<image_storage_type>`
-  %1 = OpTypeImage %void 2D 0 0 0 2 image_storage_type WriteOnly
+  %1 = OpTypeImage %void 2D 0 0 0 2 image_storage_type
 
 `texture_wo_2d_array<image_storage_type>`
-  %1 = OpTypeImage %void 2D 0 1 0 2 image_storage_type WriteOnly
+  %1 = OpTypeImage %void 2D 0 1 0 2 image_storage_type
 
 `texture_wo_3d<image_storage_type>`
-  %1 = OpTypeImage %void 3D 0 0 0 2 image_storage_type WriteOnly
+  %1 = OpTypeImage %void 3D 0 0 0 2 image_storage_type
 </pre>
+
+When mapping to SPIR-V, a write-only storage texture variable must also have a `NonWritable` decoration.
 
 ### Depth Texture Types ### {#texture-depth}
 <pre class='def'>


### PR DESCRIPTION
For Shader SPIR-V, the variable must be decorated. The read/write
property is not part of the image type itself (like it is for Kernel
SPIR-V).