### PR TITLE
Introduce operator precedence table

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3844,7 +3844,7 @@ Issue: (mehmetoguzderin) Refine precedence rules ....
       <b>3</b>
     <td> <b><code>*</code></b>
     <td> Multiplication
-    <td colspan='1' rowspan='0' style='text-align: left'>
+    <td colspan='1' rowspan='18' style='text-align: left'>
       Left-to-right
   <tr>
     <td> <b><code>/</code></b>
@@ -3877,7 +3877,7 @@ Issue: (mehmetoguzderin) Refine precedence rules ....
     <td> <b><code>&lt;=</code></b>
     <td> Less than or equal
   <tr>
-    <td> <b><code>&gt;=</code></b>
+    <td> <b><code>&gt;</code></b>
     <td> Greater than
   <tr>
     <td> <b><code>&gt;=</code></b>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3805,11 +3805,6 @@ shorten vector declarations based on the type or number of elements provided.
 If you want `vec4<f32>` you must provide 4 float values in the constructor.
 
 ## Precedence ## {#precedence}
-
-Issue: (dsinclair) Write out precedence rules. Matches c and glsl rules ....
-
-Issue: (mehmetoguzderin) Refine precedence rules ....
-
 <table class='data'>
   <thead>
     <tr>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3820,22 +3820,16 @@ Issue: (mehmetoguzderin) Refine precedence rules ....
   </thead>
   <tr>
     <td rowspan='1' style='text-align: left'><b>1 (highest)</b>
-    <td> <b><code>(</code></b><i>,</i> <b><code>)</code></b>
+    <td> <b><code>(</code></b> <b><code>)</code></b>
     <td> Grouping
     <td rowspan='1'> Left-to-right
   <tr>
-    <td colspan='1' rowspan='4' style='text-align: left'>
+    <td colspan='1' rowspan='2' style='text-align: left'>
       <b>2</b>
     <td> <b><code>!</code></b>
     <td> Logical not
-    <td colspan='1' rowspan='4' style='text-align: left'>
+    <td colspan='1' rowspan='2' style='text-align: left'>
       Right-to-left
-  <tr>
-    <td> <b><code>~</code></b>
-    <td> Bitwise not
-  <tr>
-    <td> <b><code>+</code></b>
-    <td> Unary plus
   <tr>
     <td> <b><code>-</code></b>
     <td> Unary negation

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3808,6 +3808,7 @@ If you want `vec4<f32>` you must provide 4 float values in the constructor.
 
 Issue: (dsinclair) Write out precedence rules. Matches c and glsl rules ....
 
+
 ## Preamble ## {#preamble}
 [SHORTNAME] is focused on WebGPU shaders. As such, the following is defined for all
 shaders which are generated, when translated to SPIR-V.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -17,7 +17,7 @@ Markup Shorthands: idl no
 </pre>
 
 <style>
-tr:nth-child(2n) {
+tr:nth-child(2n):not(table.precedence tr) {
   background-color: #f0f0f0;
 }
 thead {
@@ -26,6 +26,13 @@ thead {
 }
 .nowrap {
   white-space:nowrap;
+}
+table.precedence th,
+table.precedence th[colspan],
+table.precedence td,
+table.precedence td[colspan] {
+  text-align: left;
+  border-right: 0;
 }
 </style>
 
@@ -3805,35 +3812,33 @@ shorten vector declarations based on the type or number of elements provided.
 If you want `vec4<f32>` you must provide 4 float values in the constructor.
 
 ## Precedence ## {#precedence}
-<table class='data'>
+<table class='precedence data'>
   <thead>
     <tr>
-      <td>Precedence
-      <td>Operators
-      <td>Description
-      <td>Associativity
+      <th>Precedence
+      <th>Operators
+      <th>Description
+      <th>Associativity
   </thead>
   <tr>
-    <td rowspan='1' style='text-align: left'><b>1 (highest)</b>
+    <th rowspan='1'>1 (highest)
     <td> `(` `)`
     <td> Grouping
     <td rowspan='1'> Left-to-right
   <tr>
-    <td colspan='1' rowspan='2' style='text-align: left'>
-      <b>2</b>
+    <th colspan='1' rowspan='2'>2
     <td> `!`
     <td> Logical not
-    <td colspan='1' rowspan='2' style='text-align: left'>
+    <td colspan='1' rowspan='2'>
       Right-to-left
   <tr>
     <td> `-`
     <td> Unary negation
   <tr>
-    <td colspan='1' rowspan='3' style='text-align: left'>
-      <b>3</b>
+    <th colspan='1' rowspan='3'>3
     <td> `*`
     <td> Multiplication
-    <td colspan='1' rowspan='18' style='text-align: left'>
+    <td colspan='1' rowspan='18'>
       Left-to-right
   <tr>
     <td> `/`
@@ -3842,24 +3847,21 @@ If you want `vec4<f32>` you must provide 4 float values in the constructor.
     <td> `%`
     <td> Remainder
   <tr>
-    <td colspan='1' rowspan='2' style='text-align: left'>
-      <b>4</b>
+    <th colspan='1' rowspan='2'>4
     <td> `+`
     <td> Addition
   <tr>
     <td> `-`
     <td> Subtraction
   <tr>
-    <td colspan='1' rowspan='2' style='text-align: left'>
-      <b>5</b>
+    <th colspan='1' rowspan='2'>5
     <td> `<<`
     <td> Bitwise left shift
   <tr>
     <td> `>>`
     <td> Bitwise right shift
   <tr>
-    <td colspan='1' rowspan='4' style='text-align: left'>
-      <b>6</b>
+    <th colspan='1' rowspan='4'>6
     <td> `<`
     <td> Less than
   <tr>
@@ -3872,36 +3874,30 @@ If you want `vec4<f32>` you must provide 4 float values in the constructor.
     <td> `>=`
     <td> Greater than or equal
   <tr>
-    <td colspan='1' rowspan='2' style='text-align: left'>
-      <b>7</b>
+    <th colspan='1' rowspan='2'>7
     <td> `==`
     <td> Equality
   <tr>
     <td> `!=`
     <td> Inequality
   <tr>
-    <td colspan='1' rowspan='1' style='text-align: left'>
-      <b>8</b>
+    <th colspan='1' rowspan='1'>8
     <td> `&`
     <td> Bitwise and
   <tr>
-    <td colspan='1' rowspan='1' style='text-align: left'>
-      <b>9</b>
+    <th colspan='1' rowspan='1'>9
     <td> `^`
     <td> Bitwise xor
   <tr>
-    <td colspan='1' rowspan='1' style='text-align: left'>
-      <b>10</b>
+    <th colspan='1' rowspan='1'>10
     <td> `|`
     <td> Bitwise or
   <tr>
-    <td colspan='1' rowspan='1' style='text-align: left'>
-      <b>11</b>
+    <th colspan='1' rowspan='1'>11
     <td> `&&`
     <td> Logical and
   <tr>
-    <td colspan='1' rowspan='1' style='text-align: left'>
-      <b>12 (lowest)</b>
+    <th colspan='1' rowspan='1'>12 (lowest)
     <td> `||`
     <td> Logical or
 </table>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -27,11 +27,23 @@ thead {
 .nowrap {
   white-space:nowrap;
 }
-table.precedence th,
-table.precedence th[rowspan],
-table.precedence td,
-table.precedence td[rowspan] {
+table.precedence tbody tr th[rowspan] {
+  border-right: 1px solid black;
+}
+table.precedence tbody tr td[rowspan] {
+  border-left: 1px solid black;
+}
+table.precedence tbody tr th,
+table.precedence tbody tr th[rowspan],
+table.precedence tbody tr td,
+table.precedence tbody tr td[rowspan] {
   text-align: left;
+}
+table.precedence tbody tr th[rowspan],
+table.precedence tbody tr th + td,
+table.precedence tbody tr th + td + td,
+table.precedence tbody tr td[rowspan] {
+  border-top: 1px solid black;
 }
 </style>
 
@@ -3811,7 +3823,7 @@ shorten vector declarations based on the type or number of elements provided.
 If you want `vec4<f32>` you must provide 4 float values in the constructor.
 
 ## Precedence ## {#precedence}
-<table class='precedence data'>
+<table class='data precedence'>
   <thead>
     <tr>
       <th>Precedence

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3807,6 +3807,7 @@ If you want `vec4<f32>` you must provide 4 float values in the constructor.
 ## Precedence ## {#precedence}
 
 Issue: (dsinclair) Write out precedence rules. Matches c and glsl rules ....
+
 Issue: (mehmetoguzderin) Refine precedence rules ....
 
 <table class='data'>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3807,7 +3807,114 @@ If you want `vec4<f32>` you must provide 4 float values in the constructor.
 ## Precedence ## {#precedence}
 
 Issue: (dsinclair) Write out precedence rules. Matches c and glsl rules ....
+Issue: (mehmetoguzderin) Refine precedence rules ....
 
+<table class='data'>
+  <thead>
+    <tr>
+      <td>Precedence
+      <td>Operators
+      <td>Description
+      <td>Associativity
+  </thead>
+  <tr>
+    <td rowspan='1' style='text-align: left'><b>1 (highest)</b>
+    <td> <b><code>(</code></b><i>,</i> <b><code>)</code></b>
+    <td> Grouping
+    <td rowspan='1'> Left-to-right
+  <tr>
+    <td colspan='1' rowspan='4' style='text-align: left'>
+      <b>2</b>
+    <td> <b><code>!</code></b>
+    <td> Logical not
+    <td colspan='1' rowspan='4' style='text-align: left'>
+      Right-to-left
+  <tr>
+    <td> <b><code>~</code></b>
+    <td> Bitwise not
+  <tr>
+    <td> <b><code>+</code></b>
+    <td> Unary plus
+  <tr>
+    <td> <b><code>-</code></b>
+    <td> Unary negation
+  <tr>
+    <td colspan='1' rowspan='3' style='text-align: left'>
+      <b>3</b>
+    <td> <b><code>*</code></b>
+    <td> Multiplication
+    <td colspan='1' rowspan='0' style='text-align: left'>
+      Left-to-right
+  <tr>
+    <td> <b><code>/</code></b>
+    <td> Division
+  <tr>
+    <td> <b><code>%</code></b>
+    <td> Remainder
+  <tr>
+    <td colspan='1' rowspan='2' style='text-align: left'>
+      <b>4</b>
+    <td> <b><code>+</code></b>
+    <td> Addition
+  <tr>
+    <td> <b><code>-</code></b>
+    <td> Subtraction
+  <tr>
+    <td colspan='1' rowspan='2' style='text-align: left'>
+      <b>5</b>
+    <td> <b><code>&lt;&lt;</code></b>
+    <td> Bitwise left shift
+  <tr>
+    <td> <b><code>&gt;&gt;</code></b>
+    <td> Bitwise right shift
+  <tr>
+    <td colspan='1' rowspan='4' style='text-align: left'>
+      <b>6</b>
+    <td> <b><code>&lt;</code></b>
+    <td> Less than
+  <tr>
+    <td> <b><code>&lt;=</code></b>
+    <td> Less than or equal
+  <tr>
+    <td> <b><code>&gt;=</code></b>
+    <td> Greater than
+  <tr>
+    <td> <b><code>&gt;=</code></b>
+    <td> Greater than or equal
+  <tr>
+    <td colspan='1' rowspan='2' style='text-align: left'>
+      <b>7</b>
+    <td> <b><code>==</code></b>
+    <td> Equality
+  <tr>
+    <td> <b><code>!=</code></b>
+    <td> Inequality
+  <tr>
+    <td colspan='1' rowspan='1' style='text-align: left'>
+      <b>8</b>
+    <td> <b><code>&</code></b>
+    <td> Bitwise and
+  <tr>
+    <td colspan='1' rowspan='1' style='text-align: left'>
+      <b>9</b>
+    <td> <b><code>^</code></b>
+    <td> Bitwise xor
+  <tr>
+    <td colspan='1' rowspan='1' style='text-align: left'>
+      <b>10</b>
+    <td> <b><code>|</code></b>
+    <td> Bitwise or
+  <tr>
+    <td colspan='1' rowspan='1' style='text-align: left'>
+      <b>11</b>
+    <td> <b><code>&&</code></b>
+    <td> Logical and
+  <tr>
+    <td colspan='1' rowspan='1' style='text-align: left'>
+      <b>12 (lowest)</b>
+    <td> <b><code>||</code></b>
+    <td> Logical or
+</table>
 
 ## Preamble ## {#preamble}
 [SHORTNAME] is focused on WebGPU shaders. As such, the following is defined for all

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3820,94 +3820,94 @@ Issue: (mehmetoguzderin) Refine precedence rules ....
   </thead>
   <tr>
     <td rowspan='1' style='text-align: left'><b>1 (highest)</b>
-    <td> <b><code>(</code></b> <b><code>)</code></b>
+    <td> `(` `)`
     <td> Grouping
     <td rowspan='1'> Left-to-right
   <tr>
     <td colspan='1' rowspan='2' style='text-align: left'>
       <b>2</b>
-    <td> <b><code>!</code></b>
+    <td> `!`
     <td> Logical not
     <td colspan='1' rowspan='2' style='text-align: left'>
       Right-to-left
   <tr>
-    <td> <b><code>-</code></b>
+    <td> `-`
     <td> Unary negation
   <tr>
     <td colspan='1' rowspan='3' style='text-align: left'>
       <b>3</b>
-    <td> <b><code>*</code></b>
+    <td> `*`
     <td> Multiplication
     <td colspan='1' rowspan='18' style='text-align: left'>
       Left-to-right
   <tr>
-    <td> <b><code>/</code></b>
+    <td> `/`
     <td> Division
   <tr>
-    <td> <b><code>%</code></b>
+    <td> `%`
     <td> Remainder
   <tr>
     <td colspan='1' rowspan='2' style='text-align: left'>
       <b>4</b>
-    <td> <b><code>+</code></b>
+    <td> `+`
     <td> Addition
   <tr>
-    <td> <b><code>-</code></b>
+    <td> `-`
     <td> Subtraction
   <tr>
     <td colspan='1' rowspan='2' style='text-align: left'>
       <b>5</b>
-    <td> <b><code>&lt;&lt;</code></b>
+    <td> `<<`
     <td> Bitwise left shift
   <tr>
-    <td> <b><code>&gt;&gt;</code></b>
+    <td> `>>`
     <td> Bitwise right shift
   <tr>
     <td colspan='1' rowspan='4' style='text-align: left'>
       <b>6</b>
-    <td> <b><code>&lt;</code></b>
+    <td> `<`
     <td> Less than
   <tr>
-    <td> <b><code>&lt;=</code></b>
+    <td> `<=`
     <td> Less than or equal
   <tr>
-    <td> <b><code>&gt;</code></b>
+    <td> `>`
     <td> Greater than
   <tr>
-    <td> <b><code>&gt;=</code></b>
+    <td> `>=`
     <td> Greater than or equal
   <tr>
     <td colspan='1' rowspan='2' style='text-align: left'>
       <b>7</b>
-    <td> <b><code>==</code></b>
+    <td> `==`
     <td> Equality
   <tr>
-    <td> <b><code>!=</code></b>
+    <td> `!=`
     <td> Inequality
   <tr>
     <td colspan='1' rowspan='1' style='text-align: left'>
       <b>8</b>
-    <td> <b><code>&</code></b>
+    <td> `&`
     <td> Bitwise and
   <tr>
     <td colspan='1' rowspan='1' style='text-align: left'>
       <b>9</b>
-    <td> <b><code>^</code></b>
+    <td> `^`
     <td> Bitwise xor
   <tr>
     <td colspan='1' rowspan='1' style='text-align: left'>
       <b>10</b>
-    <td> <b><code>|</code></b>
+    <td> `|`
     <td> Bitwise or
   <tr>
     <td colspan='1' rowspan='1' style='text-align: left'>
       <b>11</b>
-    <td> <b><code>&&</code></b>
+    <td> `&&`
     <td> Logical and
   <tr>
     <td colspan='1' rowspan='1' style='text-align: left'>
       <b>12 (lowest)</b>
-    <td> <b><code>||</code></b>
+    <td> `||`
     <td> Logical or
 </table>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3841,7 +3841,7 @@ If you want `vec4<f32>` you must provide 4 float values in the constructor.
     <td> `!`
     <td> Logical not
     <td colspan='1' rowspan='3'>
-      Nonassociative
+      Right-to-left
   <tr>
     <td> `~`
     <td> Bitwise not
@@ -3852,7 +3852,7 @@ If you want `vec4<f32>` you must provide 4 float values in the constructor.
     <th colspan='1' rowspan='3'>3
     <td> `*`
     <td> Multiplication
-    <td colspan='1' rowspan='10'>
+    <td colspan='1' rowspan='18'>
       Left-to-right
   <tr>
     <td> `/`
@@ -3875,23 +3875,9 @@ If you want `vec4<f32>` you must provide 4 float values in the constructor.
     <td> `>>`
     <td> Bitwise right shift
   <tr>
-    <th colspan='1' rowspan='1'>6
-    <td> `&`
-    <td> Bitwise and
-  <tr>
-    <th colspan='1' rowspan='1'>7
-    <td> `^`
-    <td> Bitwise xor
-  <tr>
-    <th colspan='1' rowspan='1'>8
-    <td> `|`
-    <td> Bitwise or
-  <tr>
-    <th colspan='1' rowspan='4'>9
+    <th colspan='1' rowspan='4'>6
     <td> `<`
     <td> Less than
-    <td colspan='1' rowspan='6'>
-      Require parentheses
   <tr>
     <td> `<=`
     <td> Less than or equal
@@ -3902,18 +3888,28 @@ If you want `vec4<f32>` you must provide 4 float values in the constructor.
     <td> `>=`
     <td> Greater than or equal
   <tr>
-    <th colspan='1' rowspan='2'>10
+    <th colspan='1' rowspan='2'>7
     <td> `==`
     <td> Equality
   <tr>
     <td> `!=`
     <td> Inequality
   <tr>
+    <th colspan='1' rowspan='1'>8
+    <td> `&`
+    <td> Bitwise and
+  <tr>
+    <th colspan='1' rowspan='1'>9
+    <td> `^`
+    <td> Bitwise xor
+  <tr>
+    <th colspan='1' rowspan='1'>10
+    <td> `|`
+    <td> Bitwise or
+  <tr>
     <th colspan='1' rowspan='1'>11
     <td> `&&`
     <td> Logical and
-    <td colspan='1' rowspan='2'>
-      Left-to-right
   <tr>
     <th colspan='1' rowspan='1'>12 (lowest)
     <td> `||`

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -17,7 +17,7 @@ Markup Shorthands: idl no
 </pre>
 
 <style>
-tr:nth-child(2n):not(table.precedence tr) {
+tr:nth-child(2n) td:not([rowspan]) {
   background-color: #f0f0f0;
 }
 thead {
@@ -28,11 +28,10 @@ thead {
   white-space:nowrap;
 }
 table.precedence th,
-table.precedence th[colspan],
+table.precedence th[rowspan],
 table.precedence td,
-table.precedence td[colspan] {
+table.precedence td[rowspan] {
   text-align: left;
-  border-right: 0;
 }
 </style>
 


### PR DESCRIPTION
This PR introduces the operator precedence table for the WGSL specification.

**[Preview here.](https://mehmetoguzderin.github.io/webgpu/webgpu-20200925-precedence.html#precedence)** Or here:

![mehmetoguzderin github io_webgpu_webgpu-20200925-precedence html(iPad Pro)](https://user-images.githubusercontent.com/5333693/95903123-67a82a00-0d9e-11eb-885a-651c2462f413.png)