### PR TITLE
describe texel formats (for storage texture types)

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -713,6 +713,8 @@ A <dfn noexport>texture</dfn> is a collection of texels supporting special opera
 In [SHORTNAME], those operations are invoked via texture builtin functions.
 See [[#texture-builtin-functions]] for a complete list.
 
+A [SHORTNAME] texture corresponds to a [[WebGPU#gputexture|WebGPU GPUTexture]].
+
 A texture is either arrayed, or non-arrayed:
 
 * A <dfn noexport>non-arrayed texture</dfn> is a grid of texels. Each texel has a unique grid coordinate.
@@ -767,6 +769,9 @@ A <dfn noexport>texel format</dfn> is characterized by:
     normally corresponding to the concepts of red, green, blue, and alpha channels.
 : <dfn noexport>channel format</dfn>
 :: The number of bits in the channel, and how those bits are interpreted.
+
+Each texel format in [SHORTNAME] corresponds to a [[WebGPU#enumdef-gputextureformat|WebGPU GPUTextureFormat]]
+with the same name.
 
 Only certain texel formats are used in [SHORTNAME] source code.
 The channel formats used to define those texel formats are listed in the

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -806,9 +806,12 @@ This is also known as the <dfn noexport>channel transfer function</dfn>, or CTF.
   <tr><td>32float<td>32<td>IEEE 754 32-bit floating point value |v|<td>f32<td>|v|
 </table>
 
-The types in [[#texture-ro]] and [[#texture-wo]] are parameterized by the texel formats listed in the
-<dfn dfn lt="storage-texel-formats">Texel Formats for Storage Textures</dfn> table.
-The last column uses the format-specific [=channel transfer function=] from the [=channel formats=] table.
+The texel formats listed in the
+<dfn dfn lt="storage-texel-formats">Texel Formats for Storage Textures</dfn> table
+correspond to the [[WebGPU#plain-color-formats|WebGPU plain color formats]]
+which support the [[WebGPU#dom-gputextureusage-storage|WebGPU STORAGE]] usage.
+These texel formats are used to parameterize the storage texture types defined
+in [[#texture-ro]] and [[#texture-wo]].
 
 When the texel format does not have all four channels, then:
 
@@ -817,6 +820,9 @@ When the texel format does not have all four channels, then:
     * If the texel format has no blue channel, then the third component of the shader value is 0.
     * If the texel format has no alpha channel, then the fourth component of the shader value is 1.
 * When writing the texel, shader value components for missing channels are ignored.
+
+The last column in the table below uses the format-specific
+[=channel transfer function=] from the [=channel formats=] table.
 
 <table class='data'>
   <caption>Texel Formats for Storage Textures</caption>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5,7 +5,7 @@ Level: 1
 Status: w3c/ED
 Group: webgpu
 URL: https://gpuweb.github.io/gpuweb/wgsl.html
-Ignored Vars: i, e, e1, e2, e3, N, Stride, Offset, Align, Extent, S, T, T1
+Ignored Vars: i, e, e1, e2, e3, N, v, Stride, Offset, Align, Extent, S, T, T1
 
 !Participate: <a href="https://github.com/gpuweb/gpuweb/issues/new?labels=wgsl">File an issue</a> (<a href="https://github.com/gpuweb/gpuweb/issues?q=is%3Aissue+is%3Aopen+label%3Awgsl">open issues</a>)
 
@@ -704,7 +704,162 @@ Any other context.  Evaluates to *P.Read()*, yielding a value of *P*’s pointee
 type.
 </table>
 
-## Texture and Sampler Types TODO ## {#texture-types}
+## Texture and Sampler Types ## {#texture-types}
+
+A <dfn noexport>texel</dfn> is a scalar or vector used as the smallest independently accessible element of a [=texture=].
+The word *texel* is short for *texture element*.
+
+A <dfn noexport>texture</dfn> is a collection of texels supporting special operations useful for rendering.
+In [SHORTNAME], those operations are invoked via texture builtin functions.
+See [[#texture-builtin-functions]] for a complete list.
+
+A texture is either arrayed, or non-arrayed:
+
+* A <dfn noexport>non-arrayed texture</dfn> is a grid of texels. Each texel has a unique grid coordinate.
+* An <dfn noexport>arrayed texture</dfn> is a homegeneous array of grids of texels.
+    In an arrayed texture, each texel is identified with its unique combination of array index and grid coordinate.
+
+A texture has the following features:
+
+: texel format
+:: the data in each texel. See [[#texel-formats]]
+:  dimensionality
+:: the number of dimensions in the grid coordinates, and how the coordinates are interpreted.
+    The number of dimensions is 1, 2, or 3.
+    In some cases the third coordinate is decomposed so as to specify a cube face and a layer index.
+: size
+:: the extent of grid coordinates along each dimension
+: arrayed
+:: whether the texture is arrayed
+: <dfn noexport>array size</dfn>
+:: the number of homogeneous grids, if the texture is arrayed
+
+TODO(dneto): Also capture the concept of mip levels.
+
+A texture's representation is typically optimized for rendering operations.
+To achieve this, many details are hidden from the programmer, including data layouts, data types, and
+internal operations that cannot be expressed directly in the shader language.
+
+As a consequence, a shader does not have direct access to the texel storage within a texture variable.
+Instead, use texture builtin functions as follows:
+
+* Within the shader:
+    * Declare a module-scope variable in the `uniform_constant` storage class,
+        where the [=store type=] is one of the texture types described in later sections.
+    * Inside a function, call one of the texture builtin functions, and provide
+        the texture variable as the first parameter.
+* When constructing the WebGPU pipeline, the texture variable's store type and binding
+    must be compatible with the corresponding bind group layout entry.
+
+In this way, the set of supported operations for a texture type
+is determined by the availability of texture builtin functions accepting that texture type
+as the first parameter.
+
+### Texel formats ### {#texel-formats}
+
+In [SHORTNAME], certain texture types are parameterized by texel format.
+
+A <dfn noexport>texel format</dfn> is characterized by:
+
+: <dfn noexport>channels</dfn>
+:: Each channel contains a scalar.
+    A texel format has up to four channels: `r`, `g`, `b`, and `a`,
+    normally corresponding to the concepts of red, green, blue, and alpha channels.
+: <dfn noexport>channel format</dfn>
+:: The number of bits in the channel, and how those bits are interpreted.
+
+Only certain texel formats are used in [SHORTNAME] source code.
+The channel formats used to define those texel formats are listed in the
+<dfn dfn>Channel Formats</dfn> table.
+The last column specfies the conversion from the stored channel bits to the value used in the shader.
+This is also known as the <dfn noexport>channel transfer function</dfn>, or CTF.
+
+<table class='data'>
+  <caption>Channel Formats</caption>
+  <thead>
+    <tr><th>Channel format
+        <th>Number of stored bits
+        <th>Interpetation of stored bits
+        <th>Shader type<td width="25%">Shader value
+(Channel Transfer Function)
+  </thead>
+  <tr><td>8unorm<td>8<td>unsigned integer |v| &isinv; {0,...,255}<td>f32<td> |v| &div; 255
+  <tr><td>8snorm<td>8<td>signed integer |v| &isinv; {-128,...,127}<td>f32<td> max(-1, |v| &div; 127)
+  <tr><td>8uint<td>8<td>unsigned integer |v| &isinv; {0,...,255}<td>u32<td> |v| &div; 255
+  <tr><td>8sint<td>8<td>signed integer |v| &isinv; {-128,...,127}<td>i32<td> max(-1, |v| &div; 127)
+  <tr><td>16uint<td>16<td>unsigned integer |v| &isinv; {0,...,65535}<td>u32<td> |v|
+  <tr><td>16sint<td>16<td>signed integer |v| &isinv; {-32768,...,32767}<td>i32<td> |v|
+  <tr><td>16float<td>16<td>IEEE 754 16-bit floating point value |v|, with 1 sign bit, 5 exponent bits, 10 mantissa bits<td>f32<td>|v|
+  <tr><td>32uint<td>32<td>32-bit unsigned integer value |v|<td>u32<td>|v|
+  <tr><td>32sint<td>32<td>32-bit signed integer value |v|<td>i32<td>|v|
+  <tr><td>32float<td>32<td>IEEE 754 32-bit floating point value |v|<td>f32<td>|v|
+</table>
+
+The types in [[#texture-ro]] and [[#texture-wo]] are parameterized by the texel formats listed in the
+<dfn dfn lt="storage-texel-formats">Texel Formats for Storage Textures</dfn> table.
+The last column uses the format-specific [=channel transfer function=] from the [=channel formats=] table.
+
+When the texel format does not have all four channels, then:
+
+* When reading the texel:
+    * If the texel format has no green channel, then the second component of the shader value is 0.
+    * If the texel format has no blue channel, then the third component of the shader value is 0.
+    * If the texel format has no alpha channel, then the fourth component of the shader value is 1.
+* When writing the texel, shader value components for missing channels are ignored.
+
+<table class='data'>
+  <caption>Texel Formats for Storage Textures</caption>
+  <thead>
+    <tr><th>Texel format
+        <th>Channel format
+        <th>Channels in memory order
+        <th width="50%">Corresponding shader value
+  </thead>
+  <tr><td>rgba8unorm<td>8unorm<td>r, g, b, a<td>vec4&lt;f32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
+  <tr><td>rgba8snorm<td>8snorm<td>r, g, b, a<td>vec4&lt;f32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
+  <tr><td>rgba8uint<td>8uint<td>r, g, b, a<td>vec4&lt;u32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
+  <tr><td>rgba8sint<td>8sint<td>r, g, b, a<td>vec4&lt;i32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
+  <tr><td>rgba16uint<td>16uint<td>r, g, b, a<td>vec4&lt;u32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
+  <tr><td>rgba16sint<td>16sint<td>r, g, b, a<td>vec4&lt;i32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
+  <tr><td>rgba16float<td>16float<td>r, g, b, a<td>vec4&lt;f32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
+  <tr><td>r32uint<td>32uint<td>r<td>vec4&lt;u32&gt;(CTF(r), 0u, 0u, 1u)
+  <tr><td>r32sint<td>32sint<td>r<td>vec4&lt;i32&gt;(CTF(r), 0, 0, 1)
+  <tr><td>r32float<td>32float<td>r<td>vec4&lt;f32&gt;(CTF(r), 0.0, 0.0, 1.0)
+  <tr><td>rg32uint<td>32uint<td>r, g<td>vec4&lt;u32&gt;(CTF(r), CTF(g), 0.0, 1.0)
+  <tr><td>rg32sint<td>32sint<td>r, g<td>vec4&lt;i32&gt;(CTF(r), CTF(g), 0.0, 1.0)
+  <tr><td>rg32float<td>32float<td>r, g<td>vec4&lt;f32&gt;(CTF(r), CTF(g), 0.0, 1.0)
+  <tr><td>rgba32uint<td>32uint<td>r, g, b, a<td>vec4&lt;u32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
+  <tr><td>rgba32sint<td>32sint<td>r, g, b, a<td>vec4&lt;i32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
+  <tr><td>rgba32float<td>32float<td>r, g, b, a<td>vec4&lt;f32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
+</table>
+
+The following table lists the correspondence between WGSL texel formats and
+[SPIR-V image formats](https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#_a_id_image_format_a_image_format).
+
+<table class='data'>
+  <caption>Mapping texel formats to SPIR-V</caption>
+  <thead>
+    <tr><th>Texel format
+        <th>SPIR-V Image Format
+        <th>SPIR-V Enabling Capability
+  </thead>
+  <tr><td>rgba8unorm<td>Rgba8<td>Shader
+  <tr><td>rgba8snorm<td>Rgba8Snorm<td>Shader
+  <tr><td>rgba8uint<td>Rgba8ui<td>Shader
+  <tr><td>rgba8sint<td>Rgba8i<td>Shader
+  <tr><td>rgba16uint<td>Rgba16ui<td>Shader
+  <tr><td>rgba16sint<td>Rgba16i<td>Shader
+  <tr><td>rgba16float<td>Rgba16f<td>Shader
+  <tr><td>r32uint<td>R32ui<td>Shader
+  <tr><td>r32sint<td>R32i<td>Shader
+  <tr><td>r32float<td>R32f<td>Shader
+  <tr><td>rg32uint<td>Rg32ui<td>StorageImageExtendedFormats
+  <tr><td>rg32sint<td>Rg32i<td>StorageImageExtendedFormats
+  <tr><td>rg32float<td>Rg32f<td>StorageImageExtendedFormats
+  <tr><td>rgba32uint<td>Rgba32ui<td>Shader
+  <tr><td>rgba32sint<td>Rgba32i<td>Shader
+  <tr><td>rgba32float<td>Rgba32f<td>Shader
+</table>
 
 ### Sampled Texture Types ### {#sampled-texture-type}
 
@@ -745,9 +900,14 @@ type.
 
 ### Read-only Storage Texture Types ### {#texture-ro}
 
-A <dfn noexport>read-only storage texture</dfn> is a texture from which individual texels
-may be read, without the use of a sampler.
+A <dfn noexport>read-only storage texture</dfn> supports reading a single texel without the use of a sampler,
+with automatic conversion of the stored texel value to a usable shader value.
 See [[#texture-builtin-functions]].
+
+A read-only storage texture type must be parameterized one of [=storage-texel-format|texel formats for storage textures=].
+The texel format determines the conversion function as specified in [[#texel-formats]].
+
+TODO(dneto): Move description of the conversion to the builtin function that actually does the reading.
 
 <pre class='def'>
 `texture_storage_ro_1d<image_storage_type>`
@@ -765,7 +925,12 @@ See [[#texture-builtin-functions]].
 `texture_storage_ro_3d<image_storage_type>`
   %1 = OpTypeImage type(image_storage_type) 3D 0 0 0 2 image_storage_type
 </pre>
-* type(image_storage_type) is one of `f32`, `i32`, or `u32`, depending on the storage type.
+
+In the SPIR-V mapping:
+* the *Image Format* parameter of the image type declaration is
+    as specified by the SPIR-V texel format correspondence table in [[#texel-formats]].
+* the *Sampled Type* parameter of the image type declaration is
+    the SPIR-V scalar type corresponding to the channel format for the texel format.
 
 When mapping to SPIR-V, a read-only storage texture variable must also have a `NonWritable` decoration.
 For example:
@@ -786,9 +951,16 @@ For example:
 
 ### Write-only Storage Texture Types ### {#texture-wo}
 
-A <dfn noexport>write-only storage texture</dfn> is a texture to which individual texels
-may be written.
+A <dfn noexport>write-only storage texture</dfn> supports writing a single texel, with automatic conversion
+of the shader value to a stored texel value.
 See [[#texture-builtin-functions]].
+
+A write-only storage texture type must be parameterized one of [=storage-texel-format|texel formats for storage textures=].
+The texel format determines the conversion function as specified in [[#texel-formats]].
+The *inverse* of the conversion function is used to convert the shader value to
+the stored texel.
+
+TODO(dneto): Move description of the conversion to the builtin function that actually does the writing.
 
 <pre class='def'>
 `texture_storage_wo_1d<image_storage_type>`
@@ -806,6 +978,12 @@ See [[#texture-builtin-functions]].
 `texture_storage_wo_3d<image_storage_type>`
   %1 = OpTypeImage %void 3D 0 0 0 2 image_storage_type
 </pre>
+
+In the SPIR-V mapping:
+* the *Image Format* parameter of the image type declaration is
+    as specified by the SPIR-V texel format correspondence table in [[#texel-formats]].
+* the *Sampled Type* parameter of the image type declaration is
+    the SPIR-V void type
 
 When mapping to SPIR-V, a write-only storage texture variable must also have a `NonReadable` decoration.
 For example:
@@ -857,7 +1035,7 @@ texture_sampler_types
   | depth_texture_type
   | sampled_texture_type LESS_THAN type_decl GREATER_THAN
   | multisampled_texture_type LESS_THAN type_decl GREATER_THAN
-  | storage_texture_type LESS_THAN image_storage_type GREATER_THAN
+  | storage_texture_type LESS_THAN texel_format GREATER_THAN
 
 sampler_type
   : SAMPLER
@@ -893,7 +1071,7 @@ depth_texture_type
   | TEXTURE_DEPTH_CUBE
   | TEXTURE_DEPTH_CUBE_ARRAY
 
-image_storage_type
+texel_format
   : R8UNORM
      R8  -- Capability: StorageImageExtendedFormats
   | R8SNORM
@@ -3548,7 +3726,7 @@ I've written what an NVIDIA GPU does.  See https://github.com/google/amber/pull/
   <tr><td>`RGBA8SNORM`<td>rgba8snorm
   <tr><td>`RGBA8UINT`<td>rgba8uint
   <tr><td>`RGBA8SINT`<td>rgba8sint
-  <tr><td>`BGRA8UNORM`<td>bgraunorm
+  <tr><td>`BGRA8UNORM`<td>bgra8unorm
   <tr><td>`BGRA8UNORM-SRGB`<td>bgra8unorm_srgb
   <tr><td>`RGB10A2UNORM`<td>rgb10a2unorm
   <tr><td>`RG11B10FLOAT`<td>rg11b10float
@@ -3562,6 +3740,9 @@ I've written what an NVIDIA GPU does.  See https://github.com/google/amber/pull/
   <tr><td>`RGBA32SINT`<td>rgba32sint
   <tr><td>`RGBA32FLOAT`<td>rgba32float
 </table>
+
+TODO(dneto): Eliminate the image formats that are not used in storage images.
+For example SRGB formats (bgra8unorm_srgb), mixed channel widths (rg11b10float), out-of-order channels (bgra8unorm)
 
 ## Reserved Keywords ## {#reserved-keywords}
 The following is a list of keywords which are reserved for future expansion.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -921,26 +921,26 @@ The texel format determines the conversion function as specified in [[#texel-for
 TODO(dneto): Move description of the conversion to the builtin function that actually does the reading.
 
 <pre class='def'>
-`texture_storage_ro_1d<image_storage_type>`
-  %1 = OpTypeImage type(image_storage_type) 1D 0 0 0 2 image_storage_type
+`texture_storage_ro_1d<texel_format>`
+  # %1 = OpTypeImage sampled_type 1D 0 0 0 2 image_format
 
-`texture_storage_ro_1d_array<image_storage_type>`
-  %1 = OpTypeImage type(image_storage_type) 1D 0 1 0 2 image_storage_type
+`texture_storage_ro_1d_array<texel_format>`
+  # %1 = OpTypeImage sampled_type 1D 0 1 0 2 image_format
 
-`texture_storage_ro_2d<image_storage_type>`
-  %1 = OpTypeImage type(image_storage_type) 0 0 0 2 image_storage_type
+`texture_storage_ro_2d<texel_format>`
+  # %1 = OpTypeImage sampled_type 0 0 0 2 image_format
 
-`texture_storage_ro_2d_array<image_storage_type>`
-  %1 = OpTypeImage type(image_storage_type) 0 1 0 2 image_storage_type
+`texture_storage_ro_2d_array<texel_format>`
+  # %1 = OpTypeImage sampled_type 0 1 0 2 image_format
 
-`texture_storage_ro_3d<image_storage_type>`
-  %1 = OpTypeImage type(image_storage_type) 3D 0 0 0 2 image_storage_type
+`texture_storage_ro_3d<texel_format>`
+  # %1 = OpTypeImage sampled_type 3D 0 0 0 2 texel_format
 </pre>
 
 In the SPIR-V mapping:
-* the *Image Format* parameter of the image type declaration is
+* The *Image Format* parameter of the image type declaration is
     as specified by the SPIR-V texel format correspondence table in [[#texel-formats]].
-* the *Sampled Type* parameter of the image type declaration is
+* The *Sampled Type* parameter of the image type declaration is
     the SPIR-V scalar type corresponding to the channel format for the texel format.
 
 When mapping to SPIR-V, a read-only storage texture variable must also have a `NonWritable` decoration.
@@ -974,26 +974,26 @@ the stored texel.
 TODO(dneto): Move description of the conversion to the builtin function that actually does the writing.
 
 <pre class='def'>
-`texture_storage_wo_1d<image_storage_type>`
-  %1 = OpTypeImage %void 1D 0 0 0 2 image_storage_type
+`texture_storage_wo_1d<texel_format>`
+  # %1 = OpTypeImage %void 1D 0 0 0 2 image_format
 
-`texture_storage_wo_1d_array<image_storage_type>`
-  %1 = OpTypeImage %void 1D 0 1 0 2 image_storage_type
+`texture_storage_wo_1d_array<texel_format>`
+  # %1 = OpTypeImage %void 1D 0 1 0 2 image_format
 
-`texture_storage_wo_2d<image_storage_type>`
-  %1 = OpTypeImage %void 2D 0 0 0 2 image_storage_type
+`texture_storage_wo_2d<texel_format>`
+  # %1 = OpTypeImage %void 2D 0 0 0 2 image_format
 
-`texture_storage_wo_2d_array<image_storage_type>`
-  %1 = OpTypeImage %void 2D 0 1 0 2 image_storage_type
+`texture_storage_wo_2d_array<texel_format>`
+  # %1 = OpTypeImage %void 2D 0 1 0 2 image_format
 
-`texture_storage_wo_3d<image_storage_type>`
-  %1 = OpTypeImage %void 3D 0 0 0 2 image_storage_type
+`texture_storage_wo_3d<texel_format>`
+  # %1 = OpTypeImage %void 3D 0 0 0 2 image_format
 </pre>
 
 In the SPIR-V mapping:
-* the *Image Format* parameter of the image type declaration is
+* The *Image Format* parameter of the image type declaration is
     as specified by the SPIR-V texel format correspondence table in [[#texel-formats]].
-* the *Sampled Type* parameter of the image type declaration is
+* The *Sampled Type* parameter of the image type declaration is
     the SPIR-V void type
 
 When mapping to SPIR-V, a write-only storage texture variable must also have a `NonReadable` decoration.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -934,10 +934,10 @@ TODO(dneto): Move description of the conversion to the builtin function that act
   # %1 = OpTypeImage sampled_type 1D 0 1 0 2 image_format
 
 `texture_storage_ro_2d<texel_format>`
-  # %1 = OpTypeImage sampled_type 0 0 0 2 image_format
+  # %1 = OpTypeImage sampled_type 2D 0 0 0 2 image_format
 
 `texture_storage_ro_2d_array<texel_format>`
-  # %1 = OpTypeImage sampled_type 0 1 0 2 image_format
+  # %1 = OpTypeImage sampled_type 2D 0 1 0 2 image_format
 
 `texture_storage_ro_3d<texel_format>`
   # %1 = OpTypeImage sampled_type 3D 0 0 0 2 texel_format

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -752,7 +752,7 @@ As a consequence, a shader does not have direct access to the texel storage with
 Instead, use texture builtin functions as follows:
 
 * Within the shader:
-    * Declare a module-scope variable in the `uniform_constant` storage class,
+    * Declare a module-scope variable in the `handle` [=storage class=],
         where the [=store type=] is one of the texture types described in later sections.
     * Inside a function, call one of the texture builtin functions, and provide
         the texture variable as the first parameter.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -724,19 +724,25 @@ A texture is either arrayed, or non-arrayed:
 A texture has the following features:
 
 : texel format
-:: the data in each texel. See [[#texel-formats]]
+:: The data in each texel. See [[#texel-formats]]
 :  dimensionality
-:: the number of dimensions in the grid coordinates, and how the coordinates are interpreted.
+:: The number of dimensions in the grid coordinates, and how the coordinates are interpreted.
     The number of dimensions is 1, 2, or 3.
     In some cases the third coordinate is decomposed so as to specify a cube face and a layer index.
 : size
-:: the extent of grid coordinates along each dimension
+:: The extent of grid coordinates along each dimension
+: mipmap levels
+:: The mipmap level count is at least 1 for sampled textures, and equal to 1 for storage textures.<br>
+    Mip level 0 contains a full size version of the texture.
+    Each successive mip level contains a filtered version of the previous mip level
+    at half the size (within rounding) of the previous mip level.<br>
+    When sampling a texture, an explicit or implicitly-computed level-of-detail is used
+    to select the mip levels from which to read texel data.  These are then combined via
+    filtering to produce the sampled value.
 : arrayed
 :: whether the texture is arrayed
 : <dfn noexport>array size</dfn>
 :: the number of homogeneous grids, if the texture is arrayed
-
-TODO(dneto): Also capture the concept of mip levels.
 
 A texture's representation is typically optimized for rendering operations.
 To achieve this, many details are hidden from the programmer, including data layouts, data types, and


### PR DESCRIPTION
I'd like to describe textures in more detail so we can more precisely describe the return type on texture builtin functions, and the sampled component type on sampled texture types.
I'd like to point back to a table in the "Texel formats" section introduced in this PR.