### PR TITLE
Explicitly list allowed component types per format.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6959,186 +6959,222 @@ The "Filter" column specifies whether textures of this format can be sampled in 
     <thead class=stickyheader>
         <tr>
             <th>Format
+            <th>{{GPUTextureComponentType|Component Types}}
             <th>{{GPUTextureUsage/OUTPUT_ATTACHMENT}}
             <th>{{GPUTextureUsage/STORAGE}}
             <th>Filter
     </thead>
-    <tr><th class=stickyheader>8-bit per component<th><th><th>
+    <tr><th class=stickyheader>8-bit per component<th><th><th><th>
     <tr>
         <td data-componenttype=norm>{{GPUTextureFormat/r8unorm}}
+        <td>{{GPUTextureComponentType/"float"}}
         <td>&checkmark;
         <td>
         <td>&checkmark;
     <tr>
         <td data-componenttype=norm>{{GPUTextureFormat/r8snorm}}
+        <td>{{GPUTextureComponentType/"float"}}
         <td>
         <td>
         <td>&checkmark;
     <tr>
         <td data-componenttype=int>{{GPUTextureFormat/r8uint}}
+        <td>{{GPUTextureComponentType/"uint"}}
         <td>&checkmark;
         <td>
         <td>
     <tr>
         <td data-componenttype=int>{{GPUTextureFormat/r8sint}}
+        <td>{{GPUTextureComponentType/"sint"}}
         <td>&checkmark;
         <td>
         <td>
     <tr>
         <td data-componenttype=norm>{{GPUTextureFormat/rg8unorm}}
+        <td>{{GPUTextureComponentType/"float"}}
         <td>&checkmark;
         <td>
         <td>&checkmark;
     <tr>
         <td data-componenttype=norm>{{GPUTextureFormat/rg8snorm}}
+        <td>{{GPUTextureComponentType/"float"}}
         <td>
         <td>
         <td>&checkmark;
     <tr>
         <td data-componenttype=int>{{GPUTextureFormat/rg8uint}}
+        <td>{{GPUTextureComponentType/"uint"}}
         <td>&checkmark;
         <td>
         <td>
     <tr>
         <td data-componenttype=int>{{GPUTextureFormat/rg8sint}}
+        <td>{{GPUTextureComponentType/"sint"}}
         <td>&checkmark;
         <td>
         <td>
     <tr>
         <td data-componenttype=norm>{{GPUTextureFormat/rgba8unorm}}
+        <td>{{GPUTextureComponentType/"float"}}
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
     <tr>
         <td data-componenttype=norm>{{GPUTextureFormat/rgba8unorm-srgb}}
+        <td>{{GPUTextureComponentType/"float"}}
         <td>&checkmark;
         <td>
         <td>&checkmark;
     <tr>
         <td data-componenttype=norm>{{GPUTextureFormat/rgba8snorm}}
+        <td>{{GPUTextureComponentType/"float"}}
         <td>
         <td>&checkmark;
         <td>&checkmark;
     <tr>
         <td data-componenttype=int>{{GPUTextureFormat/rgba8uint}}
+        <td>{{GPUTextureComponentType/"uint"}}
         <td>&checkmark;
         <td>&checkmark;
         <td>
     <tr>
         <td data-componenttype=int>{{GPUTextureFormat/rgba8sint}}
+        <td>{{GPUTextureComponentType/"sint"}}
         <td>&checkmark;
         <td>&checkmark;
         <td>
     <tr>
         <td data-componenttype=norm>{{GPUTextureFormat/bgra8unorm}}
+        <td>{{GPUTextureComponentType/"float"}}
         <td>&checkmark;
         <td>
         <td>&checkmark;
     <tr>
         <td data-componenttype=norm>{{GPUTextureFormat/bgra8unorm-srgb}}
+        <td>{{GPUTextureComponentType/"float"}}
         <td>&checkmark;
         <td>
         <td>&checkmark;
-    <tr><th class=stickyheader>16-bit per component<th><th><th>
+    <tr><th class=stickyheader>16-bit per component<th><th><th><th>
     <tr>
         <td data-componenttype=int>{{GPUTextureFormat/r16uint}}
+        <td>{{GPUTextureComponentType/"uint"}}
         <td>&checkmark;
         <td>
         <td>
     <tr>
         <td data-componenttype=int>{{GPUTextureFormat/r16sint}}
+        <td>{{GPUTextureComponentType/"sint"}}
         <td>&checkmark;
         <td>
         <td>
     <tr>
         <td data-componenttype=float>{{GPUTextureFormat/r16float}}
+        <td>{{GPUTextureComponentType/"float"}}
         <td>&checkmark;
         <td>
         <td>&checkmark;
     <tr>
         <td data-componenttype=int>{{GPUTextureFormat/rg16uint}}
+        <td>{{GPUTextureComponentType/"uint"}}
         <td>&checkmark;
         <td>
         <td>
     <tr>
         <td data-componenttype=int>{{GPUTextureFormat/rg16sint}}
+        <td>{{GPUTextureComponentType/"sint"}}
         <td>&checkmark;
         <td>
         <td>
     <tr>
         <td data-componenttype=float>{{GPUTextureFormat/rg16float}}
+        <td>{{GPUTextureComponentType/"float"}}
         <td>&checkmark;
         <td><!-- Vulkan -->
         <td>&checkmark;
     <tr>
         <td data-componenttype=int>{{GPUTextureFormat/rgba16uint}}
+        <td>{{GPUTextureComponentType/"uint"}}
         <td>&checkmark;
         <td>&checkmark;
         <td>
     <tr>
         <td data-componenttype=int>{{GPUTextureFormat/rgba16sint}}
+        <td>{{GPUTextureComponentType/"sint"}}
         <td>&checkmark;
         <td>&checkmark;
         <td>
     <tr>
         <td data-componenttype=float>{{GPUTextureFormat/rgba16float}}
+        <td>{{GPUTextureComponentType/"float"}}
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
-    <tr><th class=stickyheader>32-bit per component<th><th><th>
+    <tr><th class=stickyheader>32-bit per component<th><th><th><th>
     <tr>
         <td data-componenttype=int>{{GPUTextureFormat/r32uint}}
+        <td>{{GPUTextureComponentType/"uint"}}
         <td>&checkmark;
         <td>&checkmark;&star;
         <td>
     <tr>
         <td data-componenttype=int>{{GPUTextureFormat/r32sint}}
+        <td>{{GPUTextureComponentType/"sint"}}
         <td>&checkmark;
         <td>&checkmark;&star;
         <td>
     <tr>
         <td data-componenttype=float>{{GPUTextureFormat/r32float}}
+        <td>{{GPUTextureComponentType/"float"}}
         <td>&checkmark;
         <td>&checkmark;
         <td><!-- Metal -->
     <tr>
         <td data-componenttype=int>{{GPUTextureFormat/rg32uint}}
+        <td>{{GPUTextureComponentType/"uint"}}
         <td>&checkmark;
         <td>&checkmark;
         <td>
     <tr>
         <td data-componenttype=int>{{GPUTextureFormat/rg32sint}}
+        <td>{{GPUTextureComponentType/"sint"}}
         <td>&checkmark;
         <td>&checkmark;
         <td>
     <tr>
         <td data-componenttype=float>{{GPUTextureFormat/rg32float}}
+        <td>{{GPUTextureComponentType/"float"}}
         <td>&checkmark;
         <td>&checkmark;
         <td>
     <tr>
         <td data-componenttype=int>{{GPUTextureFormat/rgba32uint}}
+        <td>{{GPUTextureComponentType/"uint"}}
         <td>&checkmark;
         <td>&checkmark;
         <td>
     <tr>
         <td data-componenttype=int>{{GPUTextureFormat/rgba32sint}}
+        <td>{{GPUTextureComponentType/"sint"}}
         <td>&checkmark;
         <td>&checkmark;
         <td>
     <tr>
         <td data-componenttype=float>{{GPUTextureFormat/rgba32float}}
+        <td>{{GPUTextureComponentType/"float"}}
         <td>&checkmark;
         <td>&checkmark;
         <td>
-    <tr><th class=stickyheader>mixed component width<th><th><th>
+    <tr><th class=stickyheader>mixed component width<th><th><th><th>
     <tr>
         <td data-componenttype=norm>{{GPUTextureFormat/rgb10a2unorm}}
+        <td>{{GPUTextureComponentType/"float"}}
         <td>&checkmark;
         <td>
         <td>&checkmark;
     <tr>
         <td data-componenttype=float>{{GPUTextureFormat/rg11b10ufloat}}
+        <td>{{GPUTextureComponentType/"float"}}
         <td><!-- Vulkan -->
         <td>
         <td>&checkmark;
@@ -7157,6 +7193,7 @@ None of the depth formats can be filtered.
             <th>Format
             <th>Bytes per texel
             <th>Aspect
+            <th>{{GPUTextureComponentType|Component Types}}
             <th>Copy aspect from Buffer
             <th>Copy aspect into Buffer
     </thead>
@@ -7164,29 +7201,35 @@ None of the depth formats can be filtered.
         <td>{{GPUTextureFormat/stencil8}}
         <td>1 &minus; 5
         <td>stencil
+        <td>{{GPUTextureComponentType/"uint"}}
         <td colspan=2>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/depth16unorm}}
         <td>2
         <td>depth
+        <td>{{GPUTextureComponentType/"float"}}, {{GPUTextureComponentType/"depth-comparison"}}
         <td colspan=2>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/depth24plus}}
         <td>4
         <td>depth
+        <td>{{GPUTextureComponentType/"float"}}, {{GPUTextureComponentType/"depth-comparison"}}
         <td colspan=2>&cross;
     <tr>
         <td rowspan=2 style='white-space:nowrap'>{{GPUTextureFormat/depth24plus-stencil8}}
         <td rowspan=2>4 &minus; 8
         <td>depth
+        <td>{{GPUTextureComponentType/"float"}}, {{GPUTextureComponentType/"depth-comparison"}}
         <td colspan=2>&cross;
     <tr>
         <td>stencil
+        <td>{{GPUTextureComponentType/"uint"}}
         <td colspan=2>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/depth32float}}
         <td>4
         <td>depth
+        <td>{{GPUTextureComponentType/"float"}}, {{GPUTextureComponentType/"depth-comparison"}}
         <td colspan=1>&cross;
         <td colspan=1>&checkmark;
 </table>
@@ -7209,17 +7252,20 @@ All packed texture formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsa
         <tr>
             <th>Format
             <th>Bytes per block
+            <th>{{GPUTextureComponentType|Component Types}}
             <th>Block Size
             <th>Extension
     </thead>
     <tr>
         <td data-componenttype=float>{{GPUTextureFormat/rgb9e5ufloat}}
         <td>4
+        <td>{{GPUTextureComponentType/"float"}}
         <td>1 &times; 1
         <td>
     <tr>
         <td data-componenttype=norm>{{GPUTextureFormat/bc1-rgba-unorm}}
         <td rowspan=2>8
+        <td rowspan=14>{{GPUTextureComponentType/"float"}}
         <td rowspan=14>4 &times; 4
         <td rowspan=14>{{GPUExtensionName/texture-compression-bc}}
     <tr>


### PR DESCRIPTION
PTAL! The first commit is put on its own in #1117 and I'll rebase before this one is merged.

This is required because the depth format can be used as either "float"
or "depth-comparison"

Also removes the color encoding for the component type as it isn't very
accessible.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/1118.html" title="Last updated on Oct 1, 2020, 11:16 AM UTC (57afc6a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1118/edb6eef...Kangz:57afc6a.html" title="Last updated on Oct 1, 2020, 11:16 AM UTC (57afc6a)">Diff</a>