### PR TITLE
Update some notes and comments.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -333,13 +333,11 @@ struct_member_decoration
   : OFFSET PAREN_LEFT INT_LITERAL PAREN_RIGHT
 </pre>
 
-Note: Layout decorations are required if the struct is used in an SSBO, UBO or
-           Push Constant.  Otherwise, the layout will be ignored.
-
-Issue: (dneto): MatrixStride, RowMajor, ColMajor layout decorations are needed for matrices.
+Note: Layout decorations are required if the struct is used in an SSBO or UBO. Otherwise, the layout will be ignored.
 
 <div class='example' heading='Structure'>
   <xmp>
+    # Offset decorations
     struct my_struct {
       [[offset(0)]] a : f32;
       [[offset(4)]] b : vec4<f32>;
@@ -352,13 +350,24 @@ Issue: (dneto): MatrixStride, RowMajor, ColMajor layout decorations are needed f
                   OpMemberDecorate %my_struct 1 Offset 4
      %my_struct = OpTypeStruct %float %v4float
 
+    # Runtime Array
     type RTArr = [[stride 16]] array<vec4<f32>>;
-
     [[block]] struct S {
       [[offset(0)]] a : f32;
       [[offset(4)]] b : f32;
       [[offset(16)]] data : RTArr;
     };
+
+                  OpName %my_struct "my_struct"
+                  OpMemberName %my_struct 0 "a"
+                  OpMemberDecorate %my_struct 0 Offset 0
+                  OpMemberName %my_struct 1 "b"
+                  OpMemberDecorate %my_struct 1 Offset 4
+                  OpMemberName %my_struct 2 "data"
+                  OpMemberDecorate %my_struct 2 Offset 16
+                  OpDecorate %rt_arr ArrayStride 16
+        %rt_arr = OpTypeRuntimeArray %v4float
+     %my_struct = OpTypeStruct %float %v4float %rt_arr
   </xmp>
 </div>
 


### PR DESCRIPTION
This CL removes a reference to the removed push constants, removes the
note to add ColMajor, RowMajor to matrices as they are always column
major and updates some SPIR-V examples for runtime arrays.