### PR TITLE
Add read_only decoration to variables.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -961,6 +961,7 @@ variable_decoration
   | BUILTIN PAREN_LEFT IDENT PAREN_RIGHT
   | BINDING PAREN_LEFT INT_LITERAL PAREN_RIGHT
   | SET PAREN_LEFT INT_LITERAL PAREN_RIGHT
+  | READ_ONLY
 </pre>
 
 <div class='example' heading="Variable Decorations">
@@ -971,10 +972,15 @@ variable_decoration
     [[binding(3), set(4)]]
        OpDecorate %gl_FragColor Binding 3
        OpDecorate %gl_FragColor DescriptorSet 4
+
+    [[read_only]]
+       OpDecorate %foo NonWritable
   </xmp>
 </div>
 
 See [[#builtin-variables]] for the decorations for specifying built-in variables.
+
+The `read_only` decoration can only be applied to variables with the `storage_buffer` [[#storage-class]].
 
 ## Module Constants ## {#module-constants}
 
@@ -2986,6 +2992,7 @@ Issue: (dneto) Default rounding mode is an implementation choice.  Is that what 
   <tr><td>`OUT`<td>out
   <tr><td>`OUTPUT`<td>output
   <tr><td>`PRIVATE`<td>private
+  <tr><td>`READ_ONLY`<td>read_only
   <tr><td>`RETURN`<td>return
   <tr><td>`SET`<td>set
   <tr><td>`STAGE`<td>stage


### PR DESCRIPTION
This CL adds the `read_only` decoration to variables. This may only be
used on `storage_buffer` storage class variables.

Issue #935