### PR TITLE
Add arrayLength builtin method.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3266,6 +3266,7 @@ TODO: deduplicate these tables
   <tr><td>*e* : *T*, *T* is *FloatVec*<td>`isFinite(e)` : bool<*N*>, where *N = Arity(T)*<td>OpIsFinite, or emulate
   <tr><td>*e* : f32<td>`isNormal(e)` : bool<td>OpIsNormal
   <tr><td>*e* : *T*, *T* is *FloatVec*<td>`isNormal(e)` : bool<*N*>, where *N = Arity(T)*<td>OpIsNormal, or emulate
+  <tr><td>*e* : array<*E*><td>`arrayLength(e)` : u32<td>OpArrayLength
 </table>
 
 ## Float built-in functions ## {#float-builtin-functions}


### PR DESCRIPTION
This CL adds `arrayLength` for determining the length of a runtime
array.

Issue #989