### PR TITLE
Improve some more colors on dark mode

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -74,12 +74,15 @@ div.content-timeline, div.device-timeline, div.queue-timeline {
 }
 .content-timeline {
     background: rgba(0, 255, 0, 0.05);
+    background: var(--tint-green);
 }
 .device-timeline {
     background: rgba(255, 0, 0, 0.05);
+    background: var(--tint-red);
 }
 .queue-timeline {
     background: rgba(255, 0, 255, 0.05);
+    background: var(--tint-purple);
 }
 
 /*
@@ -99,7 +102,7 @@ div.content-timeline, div.device-timeline, div.queue-timeline {
     font-style: italic;
     font-size: 130%;
     color: rgba(0, 0, 0, 0.15);
-    color: var(--timeline-text);
+    color: var(--watermark-text);
     position: absolute;
     right: .3em;
     top: -.1em;
@@ -152,12 +155,15 @@ div.content-timeline, div.device-timeline, div.queue-timeline {
  */
 [data-componenttype="int"] {
     background: rgba(0, 0, 255, 0.05);
+    background: var(--tint-blue);
 }
 [data-componenttype="norm"] {
     background: rgba(0, 255, 0, 0.05);
+    background: var(--tint-green);
 }
 [data-componenttype="float"] {
     background: rgba(255, 0, 0, 0.05);
+    background: var(--tint-red);
 }
 
 /*
@@ -181,13 +187,26 @@ thead.stickyheader th, th.stickyheader {
     background: #f8f8f8;
     background: var(--stickyheader-background);
 }
+
 /*
  * Darkmode colors
  */
+:root {
+    --watermark-text: rgba(0, 0, 0, 15%);
+    --stickyheader-background: #f8f8f8;
+    --tint-red: rgba(255, 0, 0, 6%);
+    --tint-green: rgba(0, 255, 0, 10%);
+    --tint-blue: rgba(0, 0, 255, 5%);
+    --tint-purple: rgba(255, 0, 255, 5%);
+}
 @media (prefers-color-scheme:dark) {
     :root {
-        --timeline-text: rgba(255, 255, 255, 15);
+        --watermark-text: rgba(255, 255, 255, 25%);
         --stickyheader-background: #181818;
+        --tint-red: rgba(255, 0, 0, 20%);
+        --tint-green: rgba(0, 255, 0, 18%);
+        --tint-blue: rgba(0, 130, 255, 24%);
+        --tint-purple: rgba(255, 0, 255, 22%);
     }
 }
 


### PR DESCRIPTION
And:
- tweak tint colors for better perceptual intensity consistency
- fix syntax for alpha in rgba on watermarks

Followup to #1117


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1122.html" title="Last updated on Sep 30, 2020, 8:05 PM UTC (9de0994)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1122/edb6eef...kainino0x:9de0994.html" title="Last updated on Sep 30, 2020, 8:05 PM UTC (9de0994)">Diff</a>