### PR TITLE
Reformat GPULimits table

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -168,6 +168,16 @@ table.data td[colspan] {
     border-right-style: dotted;
 }
 
+table.data.no-colspan-center td[colspan],
+table.data.no-colspan-center th[colspan] {
+    text-align: unset;
+}
+
+table.data tr.row-continuation td,
+table.data tr.row-continuation th {
+    border-top: none;
+}
+
 /*
  * Sticky table headers.
  */
@@ -828,9 +838,9 @@ An [=adapter=] has the following internal slots:
 
     : <dfn>\[[limits]]</dfn>, of type {{GPULimits}}, readonly
     ::
-        The [=better|best=] limits which can be used to create devices on this adapter.
+        The [=limit/better|best=] limits which can be used to create devices on this adapter.
 
-        Each adapter limit must be the same or [=better=] than its default value in {{GPULimits}}.
+        Each adapter limit must be the same or [=limit/better=] than its default value in {{GPULimits}}.
 </dl>
 
 [=Adapters=] are exposed via {{GPUAdapter}}.
@@ -863,7 +873,7 @@ A [=device=] has the following internal slots:
     : <dfn>\[[limits]]</dfn>, of type {{GPULimits}}, readonly
     ::
         The limits which can be used on this device.
-        No [=better=] limits can be used, even if the underlying [=adapter=] can support them.
+        No [=limit/better=] limits can be used, even if the underlying [=adapter=] can support them.
 </dl>
 
 <div algorithm>
@@ -882,6 +892,148 @@ A [=device=] has the following internal slots:
 ## Optional Capabilities ## {#optional-capabilities}
 
 ### Limits ### {#limits}
+
+Each <dfn dfn>limit</dfn> is a numeric limit on the usage of WebGPU on a device.
+Each [=adapter=] has a set of supported limits, and
+[=devices=] are created with specific limits in place.
+The device limits are enforced regardless of the adapter's limits.
+
+One limit value may be <dfn dfn for=limit>better</dfn> than another.
+A [=limit/better=] limit value always relaxes validation, enabling strictly
+more programs to be valid. For each limit, "better" is defined.
+
+Note:
+Setting "better" limits may not necessarily be desirable, as they may have a performance impact.
+Because of this, and to improve portability across devices and implementations,
+applications should generally request the "worst" limits that work for their content
+(ideally, the default values).
+
+Each limit also has a <dfn dfn for=limit>baseline</dfn> value.
+Every [=adapter=] is guaranteed to support the baseline value or [=limit/better=].
+The baseline value is also the default value for the limit in {{GPULimits}} if
+a better limit is not specified.
+
+<table class="data no-colspan-center" dfn-type=dict-member dfn-for=GPULimits>
+    <thead>
+        <tr><th>{{GPULimits}} member <th>Type <th>[=limit/Better=] <th>[=limit/Baseline=]
+    </thead>
+
+    <tr><td><dfn>maxBindGroups</dfn>
+        <td>{{GPUSize32}} <td>Higher <td>4
+    <tr class=row-continuation><td colspan=4>
+        The maximum number of {{GPUBindGroupLayout|GPUBindGroupLayouts}}
+        allowed in {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
+        when creating a {{GPUPipelineLayout}}.
+
+    <tr><td><dfn>maxDynamicUniformBuffersPerPipelineLayout</dfn>
+        <td>{{GPUSize32}} <td>Higher <td>8
+    <tr class=row-continuation><td colspan=4>
+        The maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
+
+          - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"uniform-buffer"}}, and
+          - {{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `true`,
+
+        across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
+        when creating a {{GPUPipelineLayout}}.
+
+    <tr><td><dfn>maxDynamicStorageBuffersPerPipelineLayout</dfn>
+        <td>{{GPUSize32}} <td>Higher <td>4
+    <tr class=row-continuation><td colspan=4>
+        The maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
+
+          - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"storage-buffer"}}, and
+          - {{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `true`,
+
+        across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
+        when creating a {{GPUPipelineLayout}}.
+
+    <tr><td><dfn>maxSampledTexturesPerShaderStage</dfn>
+        <td>{{GPUSize32}} <td>Higher <td>16
+    <tr class=row-continuation><td colspan=4>
+        For each possible {{GPUShaderStage}} `stage`,
+        the maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
+
+          - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampled-texture"}} or
+            {{GPUBindingType/"multisampled-texture"}}, and
+          - {{GPUBindGroupLayoutEntry/visibility}} includes `stage`,
+
+        across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
+        when creating a {{GPUPipelineLayout}}.
+
+    <tr><td><dfn>maxSamplersPerShaderStage</dfn>
+        <td>{{GPUSize32}} <td>Higher <td>16
+    <tr class=row-continuation><td colspan=4>
+        For each possible {{GPUShaderStage}} `stage`,
+        the maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
+
+          - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampler"}}  or {{GPUBindingType/"comparison-sampler"}}, and
+          - {{GPUBindGroupLayoutEntry/visibility}} includes `stage`,
+
+        across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
+        when creating a {{GPUPipelineLayout}}.
+
+    <tr><td><dfn>maxStorageBuffersPerShaderStage</dfn>
+        <td>{{GPUSize32}} <td>Higher <td>4
+    <tr class=row-continuation><td colspan=4>
+        For each possible {{GPUShaderStage}} `stage`,
+        the maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
+
+          - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"storage-buffer"}}, and
+          - {{GPUBindGroupLayoutEntry/visibility}} includes `stage`,
+
+        across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
+        when creating a {{GPUPipelineLayout}}.
+
+    <tr><td><dfn>maxStorageTexturesPerShaderStage</dfn>
+        <td>{{GPUSize32}} <td>Higher <td>4
+    <tr class=row-continuation><td colspan=4>
+        For each possible {{GPUShaderStage}} `stage`,
+        the maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
+
+          - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"readonly-storage-texture"}} or
+            {{GPUBindingType/"writeonly-storage-texture"}}, and
+          - {{GPUBindGroupLayoutEntry/visibility}} includes `stage`,
+
+        across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
+        when creating a {{GPUPipelineLayout}}.
+
+    <tr><td><dfn>maxUniformBuffersPerShaderStage</dfn>
+        <td>{{GPUSize32}} <td>Higher <td>12
+    <tr class=row-continuation><td colspan=4>
+        For each possible {{GPUShaderStage}} `stage`,
+        the maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
+
+          - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/uniform-buffer}}, and
+          - {{GPUBindGroupLayoutEntry/visibility}} includes `stage`,
+
+        across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
+        when creating a {{GPUPipelineLayout}}.
+
+    <tr><td><dfn>maxUniformBufferBindingSize</dfn>
+        <td>{{GPUSize32}} <td>Higher <td>16384
+    <tr class=row-continuation><td colspan=4>
+        The maximum {{GPUBufferBinding}}.{{GPUBufferBinding/size}} for bindings
+        of type {{GPUBindingType/uniform-buffer}}.
+</table>
+
+#### <dfn dictionary>GPULimits</dfn> #### {#gpulimits}
+
+{{GPULimits}} describes the [=limits=] with which a device should be created.
+See {{GPUDeviceDescriptor/limits|GPUDeviceDescriptor.limits}}.
+
+<script type=idl>
+dictionary GPULimits {
+    GPUSize32 maxBindGroups = 4;
+    GPUSize32 maxDynamicUniformBuffersPerPipelineLayout = 8;
+    GPUSize32 maxDynamicStorageBuffersPerPipelineLayout = 4;
+    GPUSize32 maxSampledTexturesPerShaderStage = 16;
+    GPUSize32 maxSamplersPerShaderStage = 16;
+    GPUSize32 maxStorageBuffersPerShaderStage = 4;
+    GPUSize32 maxStorageTexturesPerShaderStage = 4;
+    GPUSize32 maxUniformBuffersPerShaderStage = 12;
+    GPUSize32 maxUniformBufferBindingSize = 16384;
+};
+</script>
 
 ### Extensions ### {#extensions}
 
@@ -1106,7 +1258,7 @@ interface GPUAdapter {
                             - For each type of limit in {{GPULimits}},
                                 the value of that limit in
                                 |descriptor|.{{GPUDeviceDescriptor/limits}}
-                                is no [=better=] than the value of that limit in
+                                is no [=limit/better=] than the value of that limit in
                                 |adapter|.{{adapter/[[limits]]}}.
 
                             where |adapter| is |this|.{{GPUAdapter/[[adapter]]}}.
@@ -1179,140 +1331,6 @@ enum GPUExtensionName {
     : <dfn>"depth32float-stencil8"</dfn>
     ::
         Allows for explicit creation of textures of format {{GPUTextureFormat/"depth32float-stencil8"}}.
-</dl>
-
-#### <dfn dictionary>GPULimits</dfn> #### {#gpulimits}
-
-{{GPULimits}} describes various limits in the usage of WebGPU on a device.
-
-One limit value may be <dfn dfn>better</dfn> than another.
-For each limit, "better" is defined.
-
-Note:
-Setting "better" limits may not necessarily be desirable.
-While they enable strictly more programs to be valid, they may have a performance impact.
-Because of this, and to improve portability across devices and implementations,
-applications should generally request the "worst" limits that work for their content.
-
-<script type=idl>
-dictionary GPULimits {
-    GPUSize32 maxBindGroups = 4;
-    GPUSize32 maxDynamicUniformBuffersPerPipelineLayout = 8;
-    GPUSize32 maxDynamicStorageBuffersPerPipelineLayout = 4;
-    GPUSize32 maxSampledTexturesPerShaderStage = 16;
-    GPUSize32 maxSamplersPerShaderStage = 16;
-    GPUSize32 maxStorageBuffersPerShaderStage = 4;
-    GPUSize32 maxStorageTexturesPerShaderStage = 4;
-    GPUSize32 maxUniformBuffersPerShaderStage = 12;
-    GPUSize32 maxUniformBufferBindingSize = 16384;
-};
-</script>
-
-<dl dfn-type=dict-member dfn-for=GPULimits>
-    : <dfn>maxBindGroups</dfn>
-    ::
-        The maximum number of {{GPUBindGroupLayout|GPUBindGroupLayouts}}
-        allowed in {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
-        when creating a {{GPUPipelineLayout}}.
-
-        Higher is [=better=].
-
-    : <dfn>maxDynamicUniformBuffersPerPipelineLayout</dfn>
-    ::
-        The maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
-
-          - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"uniform-buffer"}}, and
-          - {{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `true`,
-
-        across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
-        when creating a {{GPUPipelineLayout}}.
-
-        Higher is [=better=].
-
-    : <dfn>maxDynamicStorageBuffersPerPipelineLayout</dfn>
-    ::
-        The maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
-
-          - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"storage-buffer"}}, and
-          - {{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `true`,
-
-        across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
-        when creating a {{GPUPipelineLayout}}.
-
-        Higher is [=better=].
-
-    : <dfn>maxSampledTexturesPerShaderStage</dfn>
-    ::
-        For each possible {{GPUShaderStage}} `stage`,
-        the maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
-
-          - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampled-texture"}} or
-            {{GPUBindingType/"multisampled-texture"}}, and
-          - {{GPUBindGroupLayoutEntry/visibility}} includes `stage`,
-
-        across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
-        when creating a {{GPUPipelineLayout}}.
-
-        Higher is [=better=].
-
-    : <dfn>maxSamplersPerShaderStage</dfn>
-    ::
-        For each possible {{GPUShaderStage}} `stage`,
-        the maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
-
-          - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampler"}}  or {{GPUBindingType/"comparison-sampler"}}, and
-          - {{GPUBindGroupLayoutEntry/visibility}} includes `stage`,
-
-        across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
-        when creating a {{GPUPipelineLayout}}.
-
-        Higher is [=better=].
-
-    : <dfn>maxStorageBuffersPerShaderStage</dfn>
-    ::
-        For each possible {{GPUShaderStage}} `stage`,
-        the maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
-
-          - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"storage-buffer"}}, and
-          - {{GPUBindGroupLayoutEntry/visibility}} includes `stage`,
-
-        across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
-        when creating a {{GPUPipelineLayout}}.
-
-        Higher is [=better=].
-
-    : <dfn>maxStorageTexturesPerShaderStage</dfn>
-    ::
-        For each possible {{GPUShaderStage}} `stage`,
-        the maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
-
-          - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"readonly-storage-texture"}} or
-            {{GPUBindingType/"writeonly-storage-texture"}}, and
-          - {{GPUBindGroupLayoutEntry/visibility}} includes `stage`,
-
-        across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
-        when creating a {{GPUPipelineLayout}}.
-
-        Higher is [=better=].
-
-    : <dfn>maxUniformBuffersPerShaderStage</dfn>
-    ::
-        For each possible {{GPUShaderStage}} `stage`,
-        the maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
-
-          - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"uniform-buffer"}}, and
-          - {{GPUBindGroupLayoutEntry/visibility}} includes `stage`,
-
-        across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
-        when creating a {{GPUPipelineLayout}}.
-
-        Higher is [=better=].
-
-    : <dfn>maxUniformBufferBindingSize</dfn>
-    ::
-        The maximum {{GPUBufferBinding}}.{{GPUBufferBinding/size}} for bindings of type {{GPUBindingType/"uniform-buffer"}}.
-
-        Higher is [=better=].
 </dl>
 
 ## <dfn interface>GPUDevice</dfn> ## {#gpu-device}


### PR DESCRIPTION
Extracted from #1100 (and without the introduction of GPULimitName).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1124.html" title="Last updated on Oct 1, 2020, 2:27 AM UTC (d30f7cd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1124/edb6eef...kainino0x:d30f7cd.html" title="Last updated on Oct 1, 2020, 2:27 AM UTC (d30f7cd)">Diff</a>