### PR TITLE
Remove old texture rule.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -950,7 +950,6 @@ of the program.
 <pre class='def'>
 global_variable_decl
   : variable_decoration_list* variable_decl
-  | variable_decoration_list* sampler_or_texture_decl
   | variable_decoration_list* variable_decl EQUAL const_expr
 
 variable_decoration_list


### PR DESCRIPTION
This CL removes the global variable entry for textures which was missed
in #1058.