### PR TITLE
Some mapAsync tweaks found while writing validation tests.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1721,15 +1721,14 @@ interface GPUMapMode {
             Issue(gpuweb/gpuweb#605): Handle error buffers once we have a description of the error monad.
 
             1. If |size| is unspecified:
-                1. If |offset| &gt; |this|.{{GPUBuffer/[[size]]}}, reject with an {{OperationError}} and stop.
-                1. Let |rangeSize| be |this|.{{GPUBuffer/[[size]]}} - |offset|.
+                1. Let |rangeSize| be max(0, |this|.{{GPUBuffer/[[size]]}} - |offset|).
 
                 Otherwise, let |rangeSize| be |size|.
 
             1. If any of the following conditions are unsatisfied:
                 <div class=validusage>
                     - |this| is a [=valid=] {{GPUBuffer}}.
-                    - |offset| is a multiple of 4.
+                    - |offset| is a multiple of 8.
                     - |rangeSize| is a multiple of 4.
                     - |offset| + |rangeSize| is less or equal to |this|.{{GPUBuffer/[[size]]}}
                     - |this|.{{GPUBuffer/[[state]]}} is [=buffer state/unmapped=]
@@ -1742,7 +1741,7 @@ interface GPUMapMode {
 
                 Then:
                 1. Record a validation error on the current scope.
-                1. Return [=a promise rejected with=] an {{AbortError}} on the [=Device timeline=].
+                1. Return [=a promise rejected with=] an {{OperationError}} on the [=Device timeline=].
 
             1. Let |p| be a new {{Promise}}.
             1. Set |this|.{{GPUBuffer/[[mapping]]}} to |p|.
@@ -1833,7 +1832,7 @@ interface GPUMapMode {
 
             1. If |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapping pending=]:
 
-                1. [=Reject=] {{GPUBuffer/[[mapping]]}} with an {{OperationError}}.
+                1. [=Reject=] {{GPUBuffer/[[mapping]]}} with an {{AbortError}}.
                 1. Set |this|.{{GPUBuffer/[[mapping]]}} to `null`.
 
             1. If |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapped=] or [=buffer state/mapped at creation=]:


### PR DESCRIPTION
- mapAsync's offset should be aligned to 8 so that when doing
getMappedRange with an alignment of 8, the sum of the two offsets is
still aligned to 8 (for the Float64 typed array).
 - mapAsync validation errors are OperationErrors, but cancelling a
mapping should reject with AbortError (the two were inverted).
 - defaulting of the mapAsync size argument introduced a synchronous
promise rejection with no validation error produced. Make it take the
regular error path instead.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/1127.html" title="Last updated on Oct 2, 2020, 12:51 PM UTC (d56de8b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1127/74cd7c8...Kangz:d56de8b.html" title="Last updated on Oct 2, 2020, 12:51 PM UTC (d56de8b)">Diff</a>