### PR TITLE
Limit serialization to agents covered by COOP+COEP

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -361,7 +361,12 @@ like {{GPUBuffer}} or {{GPUQueue}}, have shared state which can be simultaneousl
 This allows race conditions to occur, similar to those of accessing a `SharedArrayBuffer`
 from multiple Web Workers, which makes the thread scheduling observable.
 
-Issue: clarify the mitigations here
+WebGPU addresses this by limiting the ability to deserialize (or share) objects only to
+the [=agents=] inside the [=browsing context group=], and only if
+the [cross-origin isolated](https://web.dev/coop-coep/) policies are in place.
+This restriction matches the [mitigations](https://hacks.mozilla.org/2020/07/safely-reviving-shared-memory/)
+against the malicious `SharedArrayBuffer` use. Similarly, the user agent may also
+serialize the [=agents=] sharing any handles to prevent any concurrency entirely.
 
 In the end, the attack surface for races on shared state in WebGPU will be
 a small subset of the `SharedArrayBuffer` attacks.
@@ -1437,6 +1442,8 @@ this document.
 <div algorithm>
     <dfn abstract-op>The steps to deserialize a GPUDevice object</dfn>,
     given |serialized| and |value|, are:
+     1. If the [=agent=] is outside of the [=browsing context group=], throw a "{{DataCloneError}}".
+     1. If the [COOP and COEP](https://web.dev/coop-coep/) aren't set, throw a "{{DataCloneError}}".
      1. Set |value|.{{GPUDevice/[[device]]}} to |serialized|.device.
 </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1452,6 +1452,9 @@ this document.
      1. Set |value|.{{GPUDevice/[[device]]}} to |serialized|.device.
 </div>
 
+Issue: `GPUDevice` doesn't really need the cross-origin policy restriction.
+It should be usable from multiple agents regardless. Once we describe the serialization
+of buffers, textures, and queues - the COOP+COEP logic should be moved in there.
 
 # Buffers # {#buffers}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -25,15 +25,20 @@ spec:html;
 </pre>
 
 <pre class='anchors'>
-spec: ECMA-262; urlPrefix: https://tc39.github.io/ecma262/
+spec: ECMA-262; urlPrefix: https://tc39.github.io/ecma262/#
     type: dfn
         text: agent; url: agent
+        text: surrounding agent; url: surrounding-agent
+        text: agent cluster; url: sec-agent-clusters
 spec: webidl; urlPrefix: https://heycam.github.io/webidl/#
     type: dfn
         text: resolve; url: resolve
 spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/browsers.html#
     type: dfn
         text: browsing context group; url: browsing-context-group
+spec: web-apis; urlPrefix: https://html.spec.whatwg.org/multipage/webappapis.html#
+    type: dfn
+        text: cross-origin isolated; url: cross-origin-isolated
 </pre>
 
 <style>
@@ -1435,6 +1440,8 @@ this document.
 <div algorithm>
     <dfn abstract-op>The steps to serialize a GPUDevice object</dfn>,
     given |value|, |serialized|, and |forStorage|, are:
+     1. Let |agentCluster| be the [=surrounding agent=]'s [=agent cluster=].
+     1. If |agentCluster|'s [=cross-origin isolated=] is false, throw a "{{DataCloneError}}".
      1. If |forStorage| is `true`, throw a "{{DataCloneError}}".
      1. Set |serialized|.device to the value of |value|.{{GPUDevice/[[device]]}}.
 </div>
@@ -1442,8 +1449,6 @@ this document.
 <div algorithm>
     <dfn abstract-op>The steps to deserialize a GPUDevice object</dfn>,
     given |serialized| and |value|, are:
-     1. If the [=agent=] is outside of the [=browsing context group=], throw a "{{DataCloneError}}".
-     1. If the [COOP and COEP](https://web.dev/coop-coep/) aren't set, throw a "{{DataCloneError}}".
      1. Set |value|.{{GPUDevice/[[device]]}} to |serialized|.device.
 </div>
 


### PR DESCRIPTION
Follow-up to #1102 with regards to cross-origin policies.
Looks like only `GPUDevice` serialization is specified so far, so I've put some wording in there that prevents sharing it. This may be a bit heavy-handed, but it's needed for demonstration. Once we have that described in queues and buffers, we can remove the wording from the `GPUDevice` specifically.

Edit: this is now shaped similarly to SAB:
https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/1128.html" title="Last updated on Oct 6, 2020, 1:23 PM UTC (7de9857)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1128/74cd7c8...kvark:7de9857.html" title="Last updated on Oct 6, 2020, 1:23 PM UTC (7de9857)">Diff</a>