### PR TITLE
Allow non-aligned offsets in writeTexture

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4581,9 +4581,7 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
 
     1. Fail if the following conditions are not satisfied:
         <div class=validusage>
-            - |layout|.{{GPUTextureDataLayout/offset}} + |requiredBytesInCopy|
-                must be smaller than or equal to |byteSize|.
-            - |layout|.{{GPUTextureDataLayout/offset}} must be a multiple of |blockSize|.
+            - |layout|.{{GPUTextureDataLayout/offset}} + |requiredBytesInCopy| &le; |byteSize|.
         </div>
 </div>
 
@@ -4651,11 +4649,13 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
                 - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}} contains
                     {{GPUTextureUsage/COPY_DST}}.
                 - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is 1.
+                - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
+                - |source|.{{GPUTextureDataLayout/offset}} is a multiple of the [=texel block size=]
+                    of |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
                 - [$validating linear texture data$](|source|,
                     |source|.{{GPUBufferCopyView/buffer}}.{{GPUBuffer/[[size]]}},
                     |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}},
                     |copySize|) succeeds.
-                - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
             </div>
         </div>
 
@@ -4686,11 +4686,13 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
                 - [$validating GPUBufferCopyView$](|destination|) returns `true`.
                 - |destination|.{{GPUBufferCopyView/buffer}}.{{GPUBuffer/[[usage]]}} contains
                     {{GPUBufferUsage/COPY_DST}}.
+                - [=Valid Texture Copy Range=] applies to |source| and |copySize|.
+                - |destination|.{{GPUTextureDataLayout/offset}} is a multiple of the [=texel block size=]
+                    of |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
                 - [$validating linear texture data$](|destination|,
                     |destination|.{{GPUBufferCopyView/buffer}}.{{GPUBuffer/[[size]]}},
                     |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}},
                     |copySize|) succeeds.
-                - [=Valid Texture Copy Range=] applies to |source| and |copySize|.
             </div>
         </div>
 


### PR DESCRIPTION
And fix the order of "ValidTextureCopyRange" (which checks width/height
block alignment) and "validating linear texture data" (which assumes
width/height block alignment).

Fixes #985


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1129.html" title="Last updated on Oct 1, 2020, 11:12 PM UTC (c55e6cd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1129/74cd7c8...kainino0x:c55e6cd.html" title="Last updated on Oct 1, 2020, 11:12 PM UTC (c55e6cd)">Diff</a>