### PR TITLE
Fix the computation of requiredBytesInCopy

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4566,18 +4566,27 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
                 must be greater than or equal to |heightInBlocks|.
         </div>
 
-    1. Let |requiredBytesInCopy| be |widthInBlocks| &times; |blockSize|.
-
-    1. If |heightInBlocks| &gt; 1, add
-        |layout|.{{GPUTextureDataLayout/bytesPerRow}} &times;
-        (|heightInBlocks| &minus; 1)
-        to |requiredBytesInCopy|.
+    1. Let |requiredBytesInCopy| be 0.
 
     1. If |copyExtent|.[=Extent3D/depth=] &gt; 1, add
         |layout|.{{GPUTextureDataLayout/bytesPerRow}} &times;
         |layout|.{{GPUTextureDataLayout/rowsPerImage}} &times;
         (|copyExtent|.[=Extent3D/depth=] &minus; 1)
         to |requiredBytesInCopy|.
+        (This covers all except the last image.)
+
+    1. If |copyExtent|.[=Extent3D/depth=] &gt; 0:
+
+        1. If |heightInBlocks| &gt; 1, add
+            |layout|.{{GPUTextureDataLayout/bytesPerRow}} &times;
+            (|heightInBlocks| &minus; 1)
+            to |requiredBytesInCopy|.
+            (This covers all of the last image except the last row.)
+
+        1. If |heightInBlocks| &gt; 0, add
+            |widthInBlocks| &times; |blockSize|
+            to |requiredBytesInCopy|.
+            (This covers the last row.)
 
     1. Fail if the following conditions are not satisfied:
         <div class=validusage>


### PR DESCRIPTION
I previously updated this in #1014. This PR fixes some cases where
requiredBytesInCopy was too large:

- 2x0x0: previously 2 * block size, now 0.
- 2x2x0: previously 4 * block size, now 0.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1130.html" title="Last updated on Oct 3, 2020, 2:38 AM UTC (4763eaf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1130/1901758...kainino0x:4763eaf.html" title="Last updated on Oct 3, 2020, 2:38 AM UTC (4763eaf)">Diff</a>