### PR TITLE
Add switch statement validation rules

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1015,7 +1015,7 @@ the constant is *pipeline-overridable*. In this case:
     If the mapping has an entry for the ID, the value in the mapping is used.
     Otherwise, the initializer expression must be present, and its value is used.
 
-Issue(dneto): What happens is the application supplies a constant ID that is not in the program?
+Issue(dneto): What happens if the application supplies a constant ID that is not in the program?
 Proposal: pipeline creation fails with an error.
 
 <div class='example' heading='Module constants, pipeline-overrideable'>
@@ -3134,24 +3134,27 @@ the test name.
 * v-0007: Structures must be defined before use.
 * v-0008: switch statements must have exactly one default clause.
 * v-0009: break is only permitted in loop and switch constructs.
-* v-0010: continue only permitted in loop
-* v-0011: Global variable names must be unique
-* v-0012: Structure names must be unique
+* v-0010: continue is only permitted in loop.
+* v-0011: Global variable names must be unique.
+* v-0012: Structure names must be unique.
 * v-0013: Variables declared in a function must be unique between that function
           and any global variables.
-* v-0014: Variables declared in a function must have unique names
-* v-0015: Runtime arrays may only appear as the last member of a struct
-* v-0016: Function names must be unique
-* v-0017: Builtin decorations must have the correct types
+* v-0014: Variables declared in a function must have unique names.
+* v-0015: Runtime arrays may only appear as the last member of a struct.
+* v-0016: Function names must be unique.
+* v-0017: Builtin decorations must have the correct types.
 * v-0018: Builtin decorations must be used with the correct shader type and
-          storage class
-* v-0019: Functions used in entry points must exist
+          storage class.
 * v-0020: The pair of `<entry point name, pipeline stage>` must be unique in the
-          module
-* v-0021: Can not re-assign a constant.
-* v-0022: Global variables must have a storage class
-* v-0023: Entry point functions accept no parameters
-* v-0024: Entry point functions return void
+          module.
+* v-0021: Cannot re-assign a constant.
+* v-0022: Global variables must have a storage class.
+* v-0023: Entry point functions accept no parameters.
+* v-0024: Entry point functions return void.
+* v-0025: Switch statement selector expression must be of a scalar integer type.
+* v-0026: The case selector values must have the same type as the selector expression.
+* v-0027: A literal value must not appear more than once in the case selectors for a switch statement.
+* v-0028: A fallthrough statement must not appear as the last statement in last clause of a switch.
 
 
 # Built-in variables TODO # {#builtin-variables}


### PR DESCRIPTION
This CL:
 Adds four new rules for validating switch statements.
Removes an outdated validation rule (v-0019) regarding entry points.
Fixes a minor typo.
