### PR TITLE
Make blending state explicit

### DIFF
--- a/samples/hello-cube.html
+++ b/samples/hello-cube.html
@@ -169,15 +169,17 @@ async function init() {
     };
     const colorState = {
         format: "bgra8unorm",
-        alphaBlend: {
-            srcFactor: "src-alpha",
-            dstFactor: "one-minus-src-alpha",
-            operation: "add"
-        },
-        colorBlend: {
-            srcFactor: "src-alpha",
-            dstFactor: "one-minus-src-alpha",
-            operation: "add"
+        blend: {
+            alpha: {
+                srcFactor: "src-alpha",
+                dstFactor: "one-minus-src-alpha",
+                operation: "add"
+            },
+            color: {
+                srcFactor: "src-alpha",
+                dstFactor: "one-minus-src-alpha",
+                operation: "add"
+            },
         },
         writeMask: GPUColorWriteBits.ALL
     };

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3822,9 +3822,15 @@ enum GPUCullMode {
 dictionary GPUColorStateDescriptor {
     required GPUTextureFormat format;
 
-    GPUBlendDescriptor alphaBlend = {};
-    GPUBlendDescriptor colorBlend = {};
+    GPUBlendDescriptor blend;
     GPUColorWriteFlags writeMask = 0xF;  // GPUColorWrite.ALL
+};
+</script>
+
+<script type=idl>
+dictionary GPUBlendDescriptor {
+    required GPUBlendComponent color;
+    required GPUBlendComponent alpha;
 };
 </script>
 
@@ -3842,7 +3848,7 @@ interface GPUColorWrite {
 #### Blend State #### {#blend-state}
 
 <script type=idl>
-dictionary GPUBlendDescriptor {
+dictionary GPUBlendComponent {
     GPUBlendFactor srcFactor = "one";
     GPUBlendFactor dstFactor = "zero";
     GPUBlendOperation operation = "add";
@@ -3886,9 +3892,9 @@ enum GPUBlendOperation {
 
         1. |descriptor|.{{GPUColorStateDescriptor/format}} is listed in {#plain-color-formats}
             with {{GPUTextureUsage/RENDER_ATTACHMENT}} capability.
-        1. |descriptor|.{{GPUColorStateDescriptor/alphaBlend}} and |descriptor|.{{GPUColorStateDescriptor/colorBlend}}
-            are either both defaults, or |descriptor|.{{GPUColorStateDescriptor/format}} has
-            {{GPUTextureComponentType/"float"}} component type.
+        1. |descriptor|.{{GPUColorStateDescriptor/blend}} is either `undefined`,
+            or the |descriptor|.{{GPUColorStateDescriptor/format}} is filterable
+            according to the {#plain-color-formats} table.
         1. |descriptor|.{{GPUColorStateDescriptor/writeMask}} is less than 16.
 </div>
 


### PR DESCRIPTION
Writing https://github.com/gpuweb/gpuweb/pull/1132/commits/251649e2a0a6f005e9de9669ba273a197aa7e8fd I realized how awkward our "default" values for blending are:
> |descriptor|.{{GPUColorStateDescriptor/alphaBlend}} and |descriptor|.{{GPUColorStateDescriptor/colorBlend}}
            are either both defaults, or |descriptor|.{{GPUColorStateDescriptor/format}} has
            {{GPUTextureComponentType/"float"}} component type.

I believe the spec would be better if instead of comparing to some "default" this was an explicit "provided" versus "undefined".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/1134.html" title="Last updated on Nov 20, 2020, 9:28 PM UTC (8b39d90)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1134/a019bbc...8b39d90.html" title="Last updated on Nov 20, 2020, 9:28 PM UTC (8b39d90)">Diff</a>