### PR TITLE
Reorder expression sections

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2034,6 +2034,9 @@ postfix_expression
 argument_expression_list
   : PAREN_LEFT ((short_circuit_or_expression COMMA)* short_circuit_or_expression)? PAREN_RIGHT
 
+singular_expression
+  : primary_expression postfix_expression
+
 unary_expression
   : singular_expression
   | MINUS unary_expression
@@ -2043,9 +2046,6 @@ unary_expression
       OpLogicalNot
   | TILDE unary_expression
       OpNot
-
-singular_expression
-  : primary_expression postfix_expression
 
 multiplicative_expression
   : unary_expression

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2082,6 +2082,18 @@ shift_expression
   | shift_expression SHIFT_RIGHT additive_expression
         OpShiftRightLogical or OpShiftRightArithmetic
 
+and_expression
+  : equality_expression
+  | and_expression AND equality_expression
+
+exclusive_or_expression
+  : and_expression
+  | exclusive_or_expression XOR and_expression
+
+inclusive_or_expression
+  : exclusive_or_expression
+  | inclusive_or_expression OR exclusive_or_expression
+
 relational_expression
   : shift_expression
   | relational_expression LESS_THAN shift_expression
@@ -2105,18 +2117,6 @@ equality_expression
   | relational_expression NOT_EQUAL relational_expression
         OpINotEqual
         OpFOrdNotEqual
-
-and_expression
-  : equality_expression
-  | and_expression AND equality_expression
-
-exclusive_or_expression
-  : and_expression
-  | exclusive_or_expression XOR and_expression
-
-inclusive_or_expression
-  : exclusive_or_expression
-  | inclusive_or_expression OR exclusive_or_expression
 
 short_circuit_and_expression
   : inclusive_or_expression

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2084,7 +2084,7 @@ shift_expression
 
 and_expression
   : shift_expression
-  | and_expression AND equality_expression
+  | and_expression AND shift_expression
 
 exclusive_or_expression
   : and_expression
@@ -2096,31 +2096,31 @@ inclusive_or_expression
 
 relational_expression
   : inclusive_or_expression
-  | relational_expression LESS_THAN shift_expression
+  | relational_expression LESS_THAN inclusive_or_expression
         OpULessThan
         OpFOrdLessThan
-  | relational_expression GREATER_THAN shift_expression
+  | relational_expression GREATER_THAN inclusive_or_expression
         OpUGreaterThan
         OpFOrdGreaterThan
-  | relational_expression LESS_THAN_EQUAL shift_expression
+  | relational_expression LESS_THAN_EQUAL inclusive_or_expression
         OpULessThanEqual
         OpFOrdLessThanEqual
-  | relational_expression GREATER_THAN_EQUAL shift_expression
+  | relational_expression GREATER_THAN_EQUAL inclusive_or_expression
         OpUGreaterThanEqual
         OpFOrdGreaterThanEqual
 
 equality_expression
   : relational_expression
-  | relational_expression EQUAL_EQUAL relational_expression
+  | equality_expression EQUAL_EQUAL relational_expression
         OpIEqual
         OpFOrdEqual
-  | relational_expression NOT_EQUAL relational_expression
+  | equality_expression NOT_EQUAL relational_expression
         OpINotEqual
         OpFOrdNotEqual
 
 short_circuit_and_expression
   : equality_expression
-  | short_circuit_and_expression AND_AND inclusive_or_expression
+  | short_circuit_and_expression AND_AND equality_expression
 
 short_circuit_or_expression
   : short_circuit_and_expression

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1700,6 +1700,109 @@ TODO: Type rules for vector access
       <td>Matrix times matrix (OpMatrixTimesMatrix)
 </table>
 
+## Bit Expressions TODO ## {#bit-expr}
+
+<table class='data'>
+  <caption>Unary bitwise operations</caption>
+  <thead>
+    <tr><td>Precondition<td>Conclusion<td>Notes
+  </thead>
+  <tr algorithm="scalar unsigned complement">
+       <td>|e| : u32<br>
+       <td class="nowrap">`~`|e| : u32
+       <td>Bitwise complement on unsigned integers. Result is the mathematical value (2<sup>32</sup> - 1  - |e|).
+          <br>OpNot
+  <tr algorithm="vector unsigned complement">
+      <td>|e| : vec|N|&lt;u32&gt;
+      <td>`~`|e| : vec|N|&lt;u32&gt;
+      <td>Component-wise unsigned complement. Component |i| of the result is `~(`|e|`[`|i|`])`.
+          <br>OpNot
+  <tr algorithm="scalar signed complement">
+       <td>|e| : i32<br>
+       <td class="nowrap">`~`|e| : i32
+       <td>Bitwise complement on signed integers. Result is i32(~u32(|e|)).
+          <br>OpNot
+  <tr algorithm="vector signed complement">
+      <td>|e| : vec|N|&lt;i32&gt;
+      <td>`~`|e| : vec|N|&lt;i32&gt;
+      <td>Component-wise signed complement. Component |i| of the result is `~(`|e|`[`|i|`])`.
+          <br>OpNot
+</table>
+
+<table class='data'>
+  <caption>Binary bitwise operations</caption>
+  <thead>
+    <tr><td>Precondition<td>Conclusion<td>Notes
+  </thead>
+  <tr><td>*e1* : *T*<br>
+          *e2* : *T*<br>
+          *T* is *Integral*
+       <td class="nowrap">`e1 | e2` : *T*
+       <td>Bitwise-or
+  <tr><td>*e1* : *T*<br>
+          *e2* : *T*<br>
+          *T* is *Integral*
+       <td class="nowrap">`e1 & e2` : *T*
+       <td>Bitwise-and
+  <tr><td>*e1* : *T*<br>
+          *e2* : *T*<br>
+          *T* is *Integral*
+       <td class="nowrap">`e1 ^ e2` : *T*
+       <td>Bitwise-exclusive-or
+</table>
+
+
+<table class='data'>
+  <caption>Bit shift expressions</caption>
+  <thead>
+    <tr><td>Precondition<td>Conclusion<td>Notes
+  </thead>
+  <tr algorithm="scalar shift left"><td>|e1| : |T|<br>
+          |e2| : u32<br>
+          |T| is *Int*
+       <td class="nowrap">|e1| `<<` |e2| : |T|
+       <td>Shift left:<br>
+           Shift |e1| left, inserting zero bits at the least significant positions,
+           and discarding the most significant bits.
+           The number of bits to shift is the value of |e2| modulo the bit width of |e1|.<br>
+           (OpShiftLeftLogical)
+  <tr algorithm="vector shift left"><td>|e1| : vec|N|&lt;|T|&gt;<br>
+          |e2| : vec|N|&lt;u32&gt;<br>
+          |T| is *Int*
+       <td class="nowrap">|e1| `<<` |e2| : vec|N|&lt;|T|&gt;
+       <td>Component-wise shift left:<br>
+           Component |i| of the result is `(`|e1|`[`|i|`] << `|e2|`[`|i|`])`<br>
+           (OpShiftLeftLogical)
+  <tr algorithm="scalar logical shift right"><td>|e1| : u32<br>
+          |e2| : u32<br>
+       <td class="nowrap">|e1| `>>` |e2| `: u32`
+       <td >Logical shift right:<br>
+           Shift |e1| right, inserting zero bits at the most significant positions,
+           and discarding the least significant bits.
+           The number of bits to shift is the value of |e2| modulo the bit width of |e1|.
+           (OpShiftRightLogical)
+  <tr algorithm="vector logical shift right"><td>|e1| : vec|N|&lt;u32&gt;<br>
+          |e2| : u32<br>
+       <td class="nowrap">|e1| `>>` |e2| : vec|N|&lt;u32&gt;
+       <td>Component-wise logical shift right:<br>
+           Component |i| of the result is `(`|e1|`[`|i|`] >> `|e2|`[`|i|`])`
+           (OpShiftRightLogical)
+  <tr algorithm="scalar arithmetic shift right"><td>|e1| : i32<br>
+          |e2| : u32<br>
+       <td class="nowrap">|e1| `>>` |e2| : i32
+       <td>Arithmetic shift right:<br>
+           Shift |e1| right, copying the sign bit of |e1| into the most significant positions,
+           and discarding the least significant bits.
+           The number of bits to shift is the value of |e2| modulo the bit width of |e1|.
+           (OpShiftRightArithmetic)
+  <tr algorithm="vector arithmetic shift right"><td>|e1| : vec|N|&lt;i32&gt;<br>
+          |e2| : vec|N|&lt;u32&gt;<br>
+       <td class="nowrap">|e1| `>>` |e2| : vec|N|&lt;i32&gt;
+       <td>Component-wise arithmetic shift right:<br>
+           Component |i| of the result is `(`|e1|`[`|i|`] >> `|e2|`[`|i|`])`
+           (OpShiftRightArithmetic)
+</table>
+
 ## Comparison Expressions TODO ## {#comparison-expr}
 
 <table class='data'>
@@ -1899,109 +2002,6 @@ TODO: Type rules for vector access
           *T* is vec*N*&lt;f32&gt;
        <td class="nowrap">`e1 > e2` : vec*N*&lt;bool&gt;
        <td>Component-wise greater than or equal (OpFOrdGreaterThan)
-</table>
-
-## Bit Expressions TODO ## {#bit-expr}
-
-<table class='data'>
-  <caption>Unary bitwise operations</caption>
-  <thead>
-    <tr><td>Precondition<td>Conclusion<td>Notes
-  </thead>
-  <tr algorithm="scalar unsigned complement">
-       <td>|e| : u32<br>
-       <td class="nowrap">`~`|e| : u32
-       <td>Bitwise complement on unsigned integers. Result is the mathematical value (2<sup>32</sup> - 1  - |e|).
-          <br>OpNot
-  <tr algorithm="vector unsigned complement">
-      <td>|e| : vec|N|&lt;u32&gt;
-      <td>`~`|e| : vec|N|&lt;u32&gt;
-      <td>Component-wise unsigned complement. Component |i| of the result is `~(`|e|`[`|i|`])`.
-          <br>OpNot
-  <tr algorithm="scalar signed complement">
-       <td>|e| : i32<br>
-       <td class="nowrap">`~`|e| : i32
-       <td>Bitwise complement on signed integers. Result is i32(~u32(|e|)).
-          <br>OpNot
-  <tr algorithm="vector signed complement">
-      <td>|e| : vec|N|&lt;i32&gt;
-      <td>`~`|e| : vec|N|&lt;i32&gt;
-      <td>Component-wise signed complement. Component |i| of the result is `~(`|e|`[`|i|`])`.
-          <br>OpNot
-</table>
-
-<table class='data'>
-  <caption>Binary bitwise operations</caption>
-  <thead>
-    <tr><td>Precondition<td>Conclusion<td>Notes
-  </thead>
-  <tr><td>*e1* : *T*<br>
-          *e2* : *T*<br>
-          *T* is *Integral*
-       <td class="nowrap">`e1 | e2` : *T*
-       <td>Bitwise-or
-  <tr><td>*e1* : *T*<br>
-          *e2* : *T*<br>
-          *T* is *Integral*
-       <td class="nowrap">`e1 & e2` : *T*
-       <td>Bitwise-and
-  <tr><td>*e1* : *T*<br>
-          *e2* : *T*<br>
-          *T* is *Integral*
-       <td class="nowrap">`e1 ^ e2` : *T*
-       <td>Bitwise-exclusive-or
-</table>
-
-
-<table class='data'>
-  <caption>Bit shift expressions</caption>
-  <thead>
-    <tr><td>Precondition<td>Conclusion<td>Notes
-  </thead>
-  <tr algorithm="scalar shift left"><td>|e1| : |T|<br>
-          |e2| : u32<br>
-          |T| is *Int*
-       <td class="nowrap">|e1| `<<` |e2| : |T|
-       <td>Shift left:<br>
-           Shift |e1| left, inserting zero bits at the least significant positions,
-           and discarding the most significant bits.
-           The number of bits to shift is the value of |e2| modulo the bit width of |e1|.<br>
-           (OpShiftLeftLogical)
-  <tr algorithm="vector shift left"><td>|e1| : vec|N|&lt;|T|&gt;<br>
-          |e2| : vec|N|&lt;u32&gt;<br>
-          |T| is *Int*
-       <td class="nowrap">|e1| `<<` |e2| : vec|N|&lt;|T|&gt;
-       <td>Component-wise shift left:<br>
-           Component |i| of the result is `(`|e1|`[`|i|`] << `|e2|`[`|i|`])`<br>
-           (OpShiftLeftLogical)
-  <tr algorithm="scalar logical shift right"><td>|e1| : u32<br>
-          |e2| : u32<br>
-       <td class="nowrap">|e1| `>>` |e2| `: u32`
-       <td >Logical shift right:<br>
-           Shift |e1| right, inserting zero bits at the most significant positions,
-           and discarding the least significant bits.
-           The number of bits to shift is the value of |e2| modulo the bit width of |e1|.
-           (OpShiftRightLogical)
-  <tr algorithm="vector logical shift right"><td>|e1| : vec|N|&lt;u32&gt;<br>
-          |e2| : u32<br>
-       <td class="nowrap">|e1| `>>` |e2| : vec|N|&lt;u32&gt;
-       <td>Component-wise logical shift right:<br>
-           Component |i| of the result is `(`|e1|`[`|i|`] >> `|e2|`[`|i|`])`
-           (OpShiftRightLogical)
-  <tr algorithm="scalar arithmetic shift right"><td>|e1| : i32<br>
-          |e2| : u32<br>
-       <td class="nowrap">|e1| `>>` |e2| : i32
-       <td>Arithmetic shift right:<br>
-           Shift |e1| right, copying the sign bit of |e1| into the most significant positions,
-           and discarding the least significant bits.
-           The number of bits to shift is the value of |e2| modulo the bit width of |e1|.
-           (OpShiftRightArithmetic)
-  <tr algorithm="vector arithmetic shift right"><td>|e1| : vec|N|&lt;i32&gt;<br>
-          |e2| : vec|N|&lt;u32&gt;<br>
-       <td class="nowrap">|e1| `>>` |e2| : vec|N|&lt;i32&gt;
-       <td>Component-wise arithmetic shift right:<br>
-           Component |i| of the result is `(`|e1|`[`|i|`] >> `|e2|`[`|i|`])`
-           (OpShiftRightArithmetic)
 </table>
 
 ## Function Call Expression TODO ## {#function-call-expr}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1617,7 +1617,7 @@ TODO: Type rules for vector access
 </table>
 
 
-## Arithmetic Expressions TODO ## {#arithemtic-expr}
+## Arithmetic Expressions TODO ## {#arithmetic-expr}
 
 <table class='data'>
   <caption>Unary arithmetic expressions</caption>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2083,7 +2083,7 @@ shift_expression
         OpShiftRightLogical or OpShiftRightArithmetic
 
 and_expression
-  : equality_expression
+  : shift_expression
   | and_expression AND equality_expression
 
 exclusive_or_expression
@@ -2095,7 +2095,7 @@ inclusive_or_expression
   | inclusive_or_expression OR exclusive_or_expression
 
 relational_expression
-  : shift_expression
+  : inclusive_or_expression
   | relational_expression LESS_THAN shift_expression
         OpULessThan
         OpFOrdLessThan
@@ -2119,7 +2119,7 @@ equality_expression
         OpFOrdNotEqual
 
 short_circuit_and_expression
-  : inclusive_or_expression
+  : equality_expression
   | short_circuit_and_expression AND_AND inclusive_or_expression
 
 short_circuit_or_expression

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2111,10 +2111,10 @@ relational_expression
 
 equality_expression
   : relational_expression
-  | equality_expression EQUAL_EQUAL relational_expression
+  | relational_expression EQUAL_EQUAL relational_expression
         OpIEqual
         OpFOrdEqual
-  | equality_expression NOT_EQUAL relational_expression
+  | relational_expression NOT_EQUAL relational_expression
         OpINotEqual
         OpFOrdNotEqual
 


### PR DESCRIPTION
This PR reorganizes comparison expressions to sit below bit ones. Also, it fixes a typo in the linking of arithmetic expressions.