### PR TITLE
Tighten setScissorRest / setViewport validation.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6022,8 +6022,14 @@ attachments used by this encoder.
                 1. If any of the following conditions are unsatisfied, generate a validation
                     error and stop.
                     <div class=validusage>
-                        - |width| is greater than `0`.
-                        - |height| is greater than `0`.
+                        - |x| is greater than or equal to `0`.
+                        - |y| is greater than or equal to `0`.
+                        - |width| is greater than or equal to `0`.
+                        - |height| is greater than or equal to `0`.
+                        - |x| + |width| is less than or equal to
+                            |this|.{{GPURenderPassEncoder/[[attachment_size]]}}.width.
+                        - |y| + |height| is less than or equal to
+                            |this|.{{GPURenderPassEncoder/[[attachment_size]]}}.height.
                         - |minDepth| is greater than or equal to `0.0` and less than or equal to `1.0`.
                         - |maxDepth| is greater than or equal to `0.0` and less than or equal to `1.0`.
                     </div>
@@ -6059,8 +6065,8 @@ attachments used by this encoder.
                     <div class=validusage>
                         - |x| is greater than or equal to `0`.
                         - |y| is greater than or equal to `0`.
-                        - |width| is greater than `0`.
-                        - |height| is greater than `0`.
+                        - |width| is greater than or equal to `0`.
+                        - |height| is greater than or equal to `0`.
                         - |x|+|width| is less than or equal to
                             |this|.{{GPURenderPassEncoder/[[attachment_size]]}}.width.
                         - |y|+|height| is less than or equal to

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6039,7 +6039,7 @@ attachments used by this encoder.
             Issue: Allowed for GPUs to use fixed point or rounded viewport coordinates
         </div>
 
-    : <dfn>setScissorRect(x, y, width, height)</dfn>
+    : <dfn>(x, y, width, height)</dfn>
     ::
         Sets the scissor rectangle used during the rasterization stage.
         After transformation into viewport coordinates any fragments which fall outside the scissor
@@ -6063,10 +6063,6 @@ attachments used by this encoder.
                 1. If any of the following conditions are unsatisfied, generate a validation
                     error and stop.
                     <div class=validusage>
-                        - |x| is greater than or equal to `0`.
-                        - |y| is greater than or equal to `0`.
-                        - |width| is greater than or equal to `0`.
-                        - |height| is greater than or equal to `0`.
                         - |x|+|width| is less than or equal to
                             |this|.{{GPURenderPassEncoder/[[attachment_size]]}}.width.
                         - |y|+|height| is less than or equal to

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6032,6 +6032,7 @@ attachments used by this encoder.
                             |this|.{{GPURenderPassEncoder/[[attachment_size]]}}.height.
                         - |minDepth| is greater than or equal to `0.0` and less than or equal to `1.0`.
                         - |maxDepth| is greater than or equal to `0.0` and less than or equal to `1.0`.
+                        - |minDepth| is greater than |maxDepth|.
                     </div>
                 1. Set the viewport to the extents |x|, |y|, |width|, |height|, |minDepth|, and |maxDepth|.
             </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6039,7 +6039,7 @@ attachments used by this encoder.
             Issue: Allowed for GPUs to use fixed point or rounded viewport coordinates
         </div>
 
-    : <dfn>(x, y, width, height)</dfn>
+    : <dfn>setScissorRect(x, y, width, height)</dfn>
     ::
         Sets the scissor rectangle used during the rasterization stage.
         After transformation into viewport coordinates any fragments which fall outside the scissor


### PR DESCRIPTION
Based on the investigation in #373 empty viewports are allowed in all
target APIs, which means that empty scissors can be emulated on APIs
that don't allow them.

Also record in the spec that we agreed that the viewport should be
contained in the attachment rect.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/1138.html" title="Last updated on Oct 11, 2020, 5:38 PM UTC (cc8e8df)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1138/3ab5af5...Kangz:cc8e8df.html" title="Last updated on Oct 11, 2020, 5:38 PM UTC (cc8e8df)">Diff</a>