### PR TITLE
Fix some basic typos

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -890,7 +890,7 @@ A <dfn dfn noexport>variable declaration</dfn>:
 * Determines the variable’s name, storage class, and store type (and hence its reference type)
 * Ensures the execution environment allocates storage for a value of the store type, for the lifetime of the variable.
 * Optionally have an *initializer* expression, if the variable is in the `Private`, `Function`, or `Output` [[#storage-class]].
-    If present, the intiailizer's type must match the store type of the variable.
+    If present, the initializer's type must match the store type of the variable.
 
 <pre class='def'>
 variable_statement
@@ -1097,7 +1097,7 @@ numeric types.
 ## Function Scope Variables ## {#function-scope-variables}
 
 A variable or constant declared in a declaration statement in a function body is in *function scope*.
-The name is available for use immedately after its declaration statement,
+The name is available for use immediately after its declaration statement,
 and until the end of the brace-delimited list of statements immediately enclosing the declaration.
 
 A variable or constant declared in the first clause of a `for` statement is available for use in the second
@@ -1569,7 +1569,7 @@ NOTE: the convenience letterings can not be mixed. (i.e. you can not use `rybw`)
 
 Using a convenience letter, or array subscript, which accesses an element past the end of the vector is an error.
 
-The convenience letterings can be applied in any order, including duplicating letters as needed. You can provide 1 to 4 letters when extracing components from a vector. Providing more then 4 letters is an error.
+The convenience letterings can be applied in any order, including duplicating letters as needed. You can provide 1 to 4 letters when extracting components from a vector. Providing more then 4 letters is an error.
 
 The result type depends on the number of letters provided. Assuming a `vec4<f32>`
 <table>
@@ -2805,7 +2805,7 @@ global_decl
 TODO: *Stub*
 
 * Setting values of builtin variables
-* External-interface varibales have initialized backing storage
+* External-interface variables have initialized backing storage
 * Internal module-scope variables have backing storage
   * Initializers evaluated in textual order
 * No two variables have overlapping storage (might already be covered earlier?)
@@ -2900,7 +2900,7 @@ However, how do we handle an indirect dispatch that specifies a group count of z
 
 ### Barrier TODO ### {#barrier}
 
-### Image Operations Requireing Uniformity TODO ### {#image-operations-requiring-uniformity}
+### Image Operations Requiring Uniformity TODO ### {#image-operations-requiring-uniformity}
 
 ### Derivatives TODO ### {#derivatives}
 


### PR DESCRIPTION
This PR fixes some basic typos inside the WGSL specification.