### PR TITLE
Update the limits section, remember the agent cluster

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -33,9 +33,6 @@ spec: ECMA-262; urlPrefix: https://tc39.github.io/ecma262/#
 spec: webidl; urlPrefix: https://heycam.github.io/webidl/#
     type: dfn
         text: resolve; url: resolve
-spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/browsers.html#
-    type: dfn
-        text: browsing context group; url: browsing-context-group
 spec: web-apis; urlPrefix: https://html.spec.whatwg.org/multipage/webappapis.html#
     type: dfn
         text: cross-origin isolated; url: cross-origin-isolated
@@ -351,7 +348,7 @@ This allows race conditions to occur, similar to those of accessing a `SharedArr
 from multiple Web Workers, which makes the thread scheduling observable.
 
 WebGPU addresses this by limiting the ability to deserialize (or share) objects only to
-the [=agents=] inside the [=browsing context group=], and only if
+the [=agents=] inside the [=agent cluster=], and only if
 the [cross-origin isolated](https://web.dev/coop-coep/) policies are in place.
 This restriction matches the [mitigations](https://hacks.mozilla.org/2020/07/safely-reviving-shared-memory/)
 against the malicious `SharedArrayBuffer` use. Similarly, the user agent may also
@@ -423,12 +420,12 @@ This includes available physical adapters, many limits on the GPU and CPU resour
 that could be used (such as the maximum texture size), and any optional hardware-specific
 capabilities that are available.
 
-This specification is designed with respect to a [privacy budget](https://github.com/bslassey/privacy-budget).
-It allows an user agent to decide how much information about the target system is exposed to
-the developer, thus mitigating the privacy exposure risks.
+User agents are not obligated to expose the real hardware limits, they are in full contol of
+how much the machine specifics are exposed. One strategy to reduce fingeprinting is binning
+all the target platforms into a few number of bins. In general, the privacy threat of exposing
+the hardware limits matches the one of WebGL.
 
-User agents can group different platforms into coarse groups, reducing the exposed difference
-in limits between them. The baseline (guaranteed) limits are also deliberately high enough
+The baseline (guaranteed) limits are also deliberately high enough
 to allow most application to work without requesting higher limits.
 All the usage of the API is validated according to the requested limits,
 so the actual hardware capabilities are not exposed to the users by accident.
@@ -1441,6 +1438,8 @@ GPUDevice includes GPUObjectBase;
         The [=device=] that this {{GPUDevice}} refers to.
 </dl>
 
+Issue: inherit from `GPUObjectBase`?
+
 {{GPUDevice}} has the methods listed in its WebIDL definition above, which are defined elsewhere in
 this document.
 
@@ -1449,8 +1448,8 @@ this document.
 <div algorithm>
     <dfn abstract-op>The steps to serialize a GPUDevice object</dfn>,
     given |value|, |serialized|, and |forStorage|, are:
-     1. Let |agentCluster| be the [=surrounding agent=]'s [=agent cluster=].
-     1. If |agentCluster|'s [=cross-origin isolated=] is false, throw a "{{DataCloneError}}".
+     1. Set |serialized|.agentCluster to be the [=surrounding agent=]'s [=agent cluster=].
+     1. If |serialized|.agentCluster's [=cross-origin isolated=] is false, throw a "{{DataCloneError}}".
      1. If |forStorage| is `true`, throw a "{{DataCloneError}}".
      1. Set |serialized|.device to the value of |value|.{{GPUDevice/[[device]]}}.
 </div>
@@ -1458,6 +1457,7 @@ this document.
 <div algorithm>
     <dfn abstract-op>The steps to deserialize a GPUDevice object</dfn>,
     given |serialized| and |value|, are:
+     1. If |serialized|.agentCluster is not the [=surrounding agent=]'s [=agent cluster=], throw a "{{DataCloneError}}".
      1. Set |value|.{{GPUDevice/[[device]]}} to |serialized|.device.
 </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -422,7 +422,7 @@ capabilities that are available.
 
 User agents are not obligated to expose the real hardware limits, they are in full contol of
 how much the machine specifics are exposed. One strategy to reduce fingeprinting is binning
-all the target platforms into a few number of bins. In general, the privacy threat of exposing
+all the target platforms into a few number of bins. In general, the privacy impact of exposing
 the hardware limits matches the one of WebGL.
 
 The baseline (guaranteed) limits are also deliberately high enough
@@ -1437,8 +1437,6 @@ GPUDevice includes GPUObjectBase;
     ::
         The [=device=] that this {{GPUDevice}} refers to.
 </dl>
-
-Issue: inherit from `GPUObjectBase`?
 
 {{GPUDevice}} has the methods listed in its WebIDL definition above, which are defined elsewhere in
 this document.


### PR DESCRIPTION
This is a follow-up to #1128. We were missing the logic of remembering the current agent cluster and comparing it upon deserialization.
In the machine-specific limits section, I also removed the notion of the privacy budget. It's apparently controversial and not established. Mozilla's tentative position is that it's not useful, and WebGPU should not be based on it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/1147.html" title="Last updated on Oct 22, 2020, 2:06 PM UTC (8f9f227)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1147/eb96ea6...kvark:8f9f227.html" title="Last updated on Oct 22, 2020, 2:06 PM UTC (8f9f227)">Diff</a>