### PR TITLE
Make the size defaulting of getMappedRange match mapAsync.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1803,11 +1803,9 @@ interface GPUMapMode {
             **Returns:** {{ArrayBuffer}}
 
             1. If |size| is unspecified:
-                1. If |offset| &gt; this.{{GPUBuffer/[[size]]}}, throw an {{OperationError}} and stop.
-                1. Let |rangeSize| be this.{{GPUBuffer/[[size]]}} - |offset|.
+                1. Let |rangeSize| be max(0, |this|.{{GPUBuffer/[[size]]}} - |offset|).
 
-                Else:
-                1. Let |rangeSize| be |size|.
+                Otherwise, let |rangeSize| be |size|.
 
             1. If any of the following conditions are unsatisfied, throw an {{OperationError}} and stop.
                 <div class=validusage>


### PR DESCRIPTION
The behavior is the same on all inputs, but the text is a bit simpler
and the exact same as for mapAsync.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/1149.html" title="Last updated on Oct 15, 2020, 8:53 AM UTC (244b266)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1149/f339dfb...Kangz:244b266.html" title="Last updated on Oct 15, 2020, 8:53 AM UTC (244b266)">Diff</a>