### PR TITLE
Disallow depth-comparison for multisampled-texture

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2751,6 +2751,8 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                                 - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"multisampled-texture"}}:
                                     - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/viewDimension}} is
                                         {{GPUTextureViewDimension/2d}}.
+                                    - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/textureComponentType}} is not
+                                        {{GPUTextureComponentType/depth-comparison}}.
 
                                 - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is
                                     {{GPUBindingType/"readonly-storage-texture"}} or


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/1151.html" title="Last updated on Oct 15, 2020, 3:35 PM UTC (caa6a38)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1151/f339dfb...Kangz:caa6a38.html" title="Last updated on Oct 15, 2020, 3:35 PM UTC (caa6a38)">Diff</a>