### PR TITLE
Add defaulting to 1 for GPUExtent3D members.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6963,6 +6963,21 @@ dictionary GPUOrigin2DDict {
 typedef (sequence<GPUIntegerCoordinate> or GPUOrigin2DDict) GPUOrigin2D;
 </script>
 
+An <dfn dfn>Origin2D</dfn> is a {{GPUOrigin2D}}.
+[=Origin2D=] is a spec namespace for the following definitions:
+<!-- This is silly, but provides convenient syntax for the spec. -->
+
+<div algorithm="GPUOrigin2D accessors" dfn-for=Origin2D>
+    For a given {{GPUOrigin2D}} value |origin|, depending on its type, the syntax:
+
+      - |origin|.<dfn dfn>x</dfn> refers to
+        either {{GPUOrigin2DDict}}.{{GPUOrigin2DDict/x}}
+        or the first item of the sequence or 0 if it isn't present.
+      - |origin|.<dfn dfn>y</dfn> refers to
+        either {{GPUOrigin2DDict}}.{{GPUOrigin2DDict/y}}
+        or the second item of the sequence or 0 if it isn't present.
+</div>
+
 <script type=idl>
 dictionary GPUOrigin3DDict {
     GPUIntegerCoordinate x = 0;
@@ -6981,20 +6996,20 @@ An <dfn dfn>Origin3D</dfn> is a {{GPUOrigin3D}}.
 
       - |origin|.<dfn dfn>x</dfn> refers to
         either {{GPUOrigin3DDict}}.{{GPUOrigin3DDict/x}}
-        or the first item of the sequence.
+        or the first item of the sequence or 0 if it isn't present.
       - |origin|.<dfn dfn>y</dfn> refers to
         either {{GPUOrigin3DDict}}.{{GPUOrigin3DDict/y}}
-        or the second item of the sequence.
+        or the second item of the sequence or 0 if it isn't present.
       - |origin|.<dfn dfn>z</dfn> refers to
         either {{GPUOrigin3DDict}}.{{GPUOrigin3DDict/z}}
-        or the third item of the sequence.
+        or the third item of the sequence or 0 if it isn't presnet.
 </div>
 
 <script type=idl>
 dictionary GPUExtent3DDict {
-    required GPUIntegerCoordinate width;
-    required GPUIntegerCoordinate height;
-    required GPUIntegerCoordinate depth;
+    GPUIntegerCoordinate width = 1;
+    GPUIntegerCoordinate height = 1;
+    GPUIntegerCoordinate depth = 1;
 };
 typedef (sequence<GPUIntegerCoordinate> or GPUExtent3DDict) GPUExtent3D;
 </script>
@@ -7008,13 +7023,13 @@ An <dfn dfn>Extent3D</dfn> is a {{GPUExtent3D}}.
 
       - |extent|.<dfn dfn>width</dfn> refers to
         either {{GPUExtent3DDict}}.{{GPUExtent3DDict/width}}
-        or the first item of the sequence.
+        or the first item of the sequence or 1 if it isn't present.
       - |extent|.<dfn dfn>height</dfn> refers to
         either {{GPUExtent3DDict}}.{{GPUExtent3DDict/height}}
-        or the second item of the sequence.
+        or the second item of the sequence or 1 if it isn't present.
       - |extent|.<dfn dfn>depth</dfn> refers to
         either {{GPUExtent3DDict}}.{{GPUExtent3DDict/depth}}
-        or the third item of the sequence.
+        or the third item of the sequence or 1 if it isn't present.
 </div>
 
 # Appendices # {#appendices}


### PR DESCRIPTION
Also allow passing sequences that are too small to GPUOrigin2/3D or
GPUExtent3D. (they are as if filled with the default value)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/1152.html" title="Last updated on Oct 15, 2020, 4:16 PM UTC (f2ac587)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1152/f339dfb...Kangz:f2ac587.html" title="Last updated on Oct 15, 2020, 4:16 PM UTC (f2ac587)">Diff</a>