### PR TITLE
Add validation rule for QuerySet and Timestamp Query

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4912,7 +4912,7 @@ must be well nested.
                 - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
                 - |querySet| is [$valid to use with$] |this|.
                 - |querySet|.{{GPUQuerySet/[[type]]}} is {{GPUQueryType/timestamp}}.
-                - |queryIndex| &lt |querySet|.{{GPUQuerySet/[[count]]}}.
+                - |queryIndex| &lt; |querySet|.{{GPUQuerySet/[[count]]}}.
             </div>
 
             Issue: Describe {{GPUCommandEncoder/writeTimestamp()}} algorithm steps.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4911,8 +4911,8 @@ must be well nested.
             <div class=validusage>
                 - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
                 - |querySet| is [$valid to use with$] |this|.
-                - |querySet|.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/timestamp}}.
-                - |queryIndex| &lt; |querySet|.{{GPUQuerySetDescriptor/count}}.
+                - |querySet|.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/timestamp}}.
+                - |queryIndex| &lt; |querySet|.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}}.
             </div>
 
             Issue: Describe {{GPUCommandEncoder/writeTimestamp()}} algorithm steps.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4894,17 +4894,27 @@ must be well nested.
 <dl dfn-type=method dfn-for=GPUCommandEncoder>
     : <dfn>writeTimestamp(querySet, queryIndex)</dfn>
     ::
+        Writes a timestamp value into |querySet| when all previous commands have completed executing.
 
         <div algorithm=GPUCommandEncoder.writeTimestamp>
             **Called on:** {{GPUCommandEncoder}} this.
 
             **Arguments:**
             <pre class=argumentdef for="GPUCommandEncoder/writeTimestamp(querySet, queryIndex)">
-                querySet:
-                queryIndex:
+                querySet: The query set that will store the timestamp values.
+                queryIndex: The index of the query in the query set.
             </pre>
 
             **Returns:** {{undefined}}
+
+            If any of the following conditions are unsatisfied, generate a validation error and stop.
+            <div class=validusage>
+                - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
+                - |querySet| is [$valid to use with$] |this|.
+                - |querySet|.{{GPUQuerySet/[[type]]}} is {{GPUQueryType/timestamp}}.
+                - |queryIndex| is less than |querySet|.{{GPUQuerySet/[[count]]}}.
+                - |queryIndex| cannot be rewritten on |this|.
+            </div>
 
             Issue: Describe {{GPUCommandEncoder/writeTimestamp()}} algorithm steps.
         </div>
@@ -5393,17 +5403,26 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
 
     : <dfn>writeTimestamp(querySet, queryIndex)</dfn>
     ::
+        Writes a timestamp value into |querySet| when all previous commands have completed executing.
 
         <div algorithm="GPUComputePassEncoder.writeTimestamp">
             **Called on:** {{GPUComputePassEncoder}} this.
 
             **Arguments:**
             <pre class=argumentdef for="GPUComputePassEncoder/writeTimestamp(querySet, queryIndex)">
-                querySet:
-                queryIndex:
+                querySet: The query set that will store the timestamp values.
+                queryIndex: The index of the query in the query set.
             </pre>
 
             **Returns:** {{undefined}}
+
+            If any of the following conditions are unsatisfied, generate a validation error and stop.
+            <div class=validusage>
+                - |querySet| is [$valid to use with$] |this|.
+                - |querySet|.{{GPUQuerySet/[[type]]}} is {{GPUQueryType/timestamp}}.
+                - |queryIndex| is less than |querySet|.{{GPUQuerySet/[[count]]}}.
+                - |queryIndex| cannot be rewritten on |this|.
+            </div>
 
             Issue: Describe {{GPUComputePassEncoder/writeTimestamp()}} algorithm steps.
         </div>
@@ -6187,17 +6206,26 @@ attachments used by this encoder.
 
     : <dfn>writeTimestamp(querySet, queryIndex)</dfn>
     ::
+        Writes a timestamp value into |querySet| when all previous commands have completed executing.
 
         <div algorithm="GPURenderPassEncoder.writeTimestamp">
             **Called on:** {{GPURenderPassEncoder}} this.
 
             **Arguments:**
             <pre class=argumentdef for="GPURenderPassEncoder/writeTimestamp(querySet, queryIndex)">
-                querySet:
-                queryIndex:
+                querySet: The query set that will store the timestamp values.
+                queryIndex: The index of the query in the query set.
             </pre>
 
             **Returns:** {{undefined}}
+
+            If any of the following conditions are unsatisfied, generate a validation error and stop.
+            <div class=validusage>
+                - |querySet| is [$valid to use with$] |this|.
+                - |querySet|.{{GPUQuerySet/[[type]]}} is {{GPUQueryType/timestamp}}.
+                - |queryIndex| is less than |querySet|.{{GPUQuerySet/[[count]]}}.
+                - |queryIndex| cannot be rewritten on |this|.
+            </div>
 
             Issue: Describe {{GPURenderPassEncoder/writeTimestamp()}} algorithm steps.
         </div>
@@ -6649,7 +6677,25 @@ interface GPUQuerySet {
 GPUQuerySet includes GPUObjectBase;
 </script>
 
+{{GPUQuerySet}} has the following internal slots:
+
+<dl dfn-type=attribute dfn-for="GPUQuerySet">
+    : <dfn>\[[type]]</dfn> of type {{GPUQueryType}}.
+    ::
+        The type of queries managed by this {{GPUQuerySet}}.
+
+    : <dfn>\[[count]]</dfn> of type {{GPUSize32}}.
+    ::
+        The number of queries managed by this {{GPUQuerySet}}.
+
+    : <dfn>\[[pipelineStatistics]]</dfn> of type sequence<{{GPUPipelineStatisticName}}>.
+    ::
+        The set of {{GPUPipelineStatisticName}} values to determine which pipeline statistics will be returned in this {{GPUQuerySet}}.
+</dl>
+
 ### Creation ### {#queryset-creation}
+
+A {{GPUQuerySetDescriptor}} specifies the options to use in creating a {{GPUQuerySet}}.
 
 <script type=idl>
 dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
@@ -6659,19 +6705,17 @@ dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
 };
 </script>
 
-<dl dfn-type=dict-member dfn-for=GPUQuerySetDescriptor>
-    : <dfn>pipelineStatistics</dfn>
-    ::
-        The set of {{GPUPipelineStatisticName}} values in this sequence defines which pipeline statistics will be returned in the new query set.
+<div class=validusage dfn-for=GPUQuerySetDescriptor>
+    <dfn abstract-op>GPUQuerySetDescriptor Valid Usage</dfn>
 
-        <div class=validusage dfn-for=GPUQuerySetDescriptor.pipelineStatistics>
-            <dfn abstract-op>Valid Usage</dfn>
+    Given a {{GPUQuerySetDescriptor}} |this| the following validation rules apply:
 
-            1. |pipelineStatistics| is ignored if type is not {{GPUQueryType/pipeline-statistics}}.
-            2. If {{GPUFeatureName/pipeline-statistics-query}} is not available, |type| must not be {{GPUQueryType/pipeline-statistics}}.
-            3. If |type| is {{GPUQueryType/pipeline-statistics}},  |pipelineStatistics| must be a sequence of {{GPUPipelineStatisticName}} values which cannot be duplicated.
-        </div>
-</dl>
+    1. |this|.{{GPUQuerySetDescriptor/type}} must be a [=valid=] {{GPUQueryType}}.
+    1. |this|.{{GPUQuerySetDescriptor/type}} must not be {{GPUQueryType/pipeline-statistics}} if {{GPUFeatureName/pipeline-statistics-query}} is not available.
+    1. |this|.{{GPUQuerySetDescriptor/type}} must not be {{GPUQueryType/timestamp}} if {{GPUFeatureName/timestamp-query}} is not available.
+    1. The maximum limitation of |this|.{{GPUQuerySetDescriptor/count}} is 8192.
+    1. |this|.{{GPUQuerySetDescriptor/pipelineStatistics}} must be ignored if |this|.{{GPUQuerySetDescriptor/type}} is not {{GPUQueryType/pipeline-statistics}}, otherwise it must be a sequence of {{GPUPipelineStatisticName}} values which cannot be duplicated.
+</div>
 
 <dl dfn-type=method dfn-for=GPUDevice>
     : <dfn>createQuerySet(descriptor)</dfn>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4242,6 +4242,11 @@ GPUCommandEncoder includes GPUObjectBase;
     : <dfn>\[[debug_group_stack]]</dfn> of type [=stack=]&lt;{{USVString}}&gt;.
     ::
         A stack of active debug group labels.
+
+    : <dfn>\[[queries_state_map]]</dfn>, of type [=ordered map=]&lt;{{GPUQuerySet}}, sequence&lt;{{boolean}}&gt;&gt;
+    ::
+        The queries state for each {{GPUQuerySet}} indicating which queries are used on the {{GPUCommandEncoder}},
+        initially empty.
 </dl>
 
 Each {{GPUCommandEncoder}} has a current <dfn dfn-type="enum">encoder state</dfn> on the [=Content timeline=]
@@ -4894,7 +4899,9 @@ must be well nested.
 <dl dfn-type=method dfn-for=GPUCommandEncoder>
     : <dfn>writeTimestamp(querySet, queryIndex)</dfn>
     ::
-        Writes a timestamp value into |querySet| when all previous commands have completed executing.
+        Writes a timestamp value into |querySet| when all previous commands have completed executing,
+        and sets the query state to `true` at |queryIndex| in the sequence of
+        {{GPUCommandEncoder}}.{{GPUCommandEncoder/[[queries_state_map]]}}.
 
         <div algorithm=GPUCommandEncoder.writeTimestamp>
             **Called on:** {{GPUCommandEncoder}} this.
@@ -4913,7 +4920,8 @@ must be well nested.
                 - |querySet| is [$valid to use with$] |this|.
                 - |querySet|.{{GPUQuerySet/[[type]]}} is {{GPUQueryType/timestamp}}.
                 - |queryIndex| &lt |querySet|.{{GPUQuerySet/[[count]]}}.
-                - |queryIndex| cannot be overwritten on the same |this|.
+                - The query state at |queryIndex| in the sequence of
+                  |this|.{{GPUCommandEncoder/[[queries_state_map]]}} must be `false`.
             </div>
 
             Issue: Describe {{GPUCommandEncoder/writeTimestamp()}} algorithm steps.
@@ -5403,7 +5411,9 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
 
     : <dfn>writeTimestamp(querySet, queryIndex)</dfn>
     ::
-        Writes a timestamp value into |querySet| when all previous commands have completed executing.
+        Writes a timestamp value into |querySet| when all previous commands have completed executing,
+        and sets the query state to `true` at |queryIndex| in the sequence of
+        {{GPUCommandEncoder}}.{{GPUCommandEncoder/[[queries_state_map]]}}.
 
         <div algorithm="GPUComputePassEncoder.writeTimestamp">
             **Called on:** {{GPUComputePassEncoder}} this.
@@ -5421,7 +5431,8 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
                 - |querySet| is [$valid to use with$] |this|.
                 - |querySet|.{{GPUQuerySet/[[type]]}} is {{GPUQueryType/timestamp}}.
                 - |queryIndex| &lt; |querySet|.{{GPUQuerySet/[[count]]}}.
-                - |queryIndex| cannot be overwritten on the same |this|.
+                - The query state at |queryIndex| in the sequence of
+                  {{GPUCommandEncoder}}.{{GPUCommandEncoder/[[queries_state_map]]}} must be `false`.
             </div>
 
             Issue: Describe {{GPUComputePassEncoder/writeTimestamp()}} algorithm steps.
@@ -6206,7 +6217,9 @@ attachments used by this encoder.
 
     : <dfn>writeTimestamp(querySet, queryIndex)</dfn>
     ::
-        Writes a timestamp value into |querySet| when all previous commands have completed executing.
+        Writes a timestamp value into |querySet| when all previous commands have completed executing,
+        and sets the query state to `true` at |queryIndex| in the sequence of
+        {{GPUCommandEncoder}}.{{GPUCommandEncoder/[[queries_state_map]]}}.
 
         <div algorithm="GPURenderPassEncoder.writeTimestamp">
             **Called on:** {{GPURenderPassEncoder}} this.
@@ -6224,7 +6237,8 @@ attachments used by this encoder.
                 - |querySet| is [$valid to use with$] |this|.
                 - |querySet|.{{GPUQuerySet/[[type]]}} is {{GPUQueryType/timestamp}}.
                 - |queryIndex| &lt; |querySet|.{{GPUQuerySet/[[count]]}}.
-                - |queryIndex| cannot be overwritten on the same |this|.
+                - The query state at |queryIndex| in the sequence of
+                  {{GPUCommandEncoder}}.{{GPUCommandEncoder/[[queries_state_map]]}} must be `false`.
             </div>
 
             Issue: Describe {{GPURenderPassEncoder/writeTimestamp()}} algorithm steps.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6222,7 +6222,7 @@ attachments used by this encoder.
                 - |querySet| is [$valid to use with$] |this|.
                 - |querySet|.{{GPUQuerySet/[[type]]}} is {{GPUQueryType/timestamp}}.
                 - |queryIndex| &lt; |querySet|.{{GPUQuerySet/[[count]]}}.
-                - The query at same |queryIndex| cannot be written twice in the same |this|.
+                - The query in |querySet| at index |queryIndex| has not been written earlier in this render pass.
             </div>
 
             Issue: Describe {{GPURenderPassEncoder/writeTimestamp()}} algorithm steps.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6706,7 +6706,7 @@ dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
 <div class=validusage dfn-for=GPUQuerySetDescriptor>
     <dfn abstract-op>GPUQuerySetDescriptor Valid Usage</dfn>
 
-    Given a {{GPUQuerySetDescriptor}} |this| the following validation rules apply:
+    Given a {{GPUQuerySetDescriptor}} |this|, the following validation rules apply:
 
     - |this|.{{GPUQuerySetDescriptor/type}} must not be {{GPUQueryType/pipeline-statistics}} if {{GPUFeatureName/pipeline-statistics-query}} is not available.
     - |this|.{{GPUQuerySetDescriptor/type}} must not be {{GPUQueryType/timestamp}} if {{GPUFeatureName/timestamp-query}} is not available.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5418,8 +5418,8 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
             If any of the following conditions are unsatisfied, generate a validation error and stop.
             <div class=validusage>
                 - |querySet| is [$valid to use with$] |this|.
-                - |querySet|.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/timestamp}}.
-                - |queryIndex| &lt; |querySet|.{{GPUQuerySetDescriptor/count}}.
+                - |querySet|.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/timestamp}}.
+                - |queryIndex| &lt; |querySet|.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}}.
             </div>
 
             Issue: Describe {{GPUComputePassEncoder/writeTimestamp()}} algorithm steps.
@@ -6220,8 +6220,8 @@ attachments used by this encoder.
             If any of the following conditions are unsatisfied, generate a validation error and stop.
             <div class=validusage>
                 - |querySet| is [$valid to use with$] |this|.
-                - |querySet|.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/timestamp}}.
-                - |queryIndex| &lt; |querySet|.{{GPUQuerySetDescriptor/count}}.
+                - |querySet|.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/timestamp}}.
+                - |queryIndex| &lt; |querySet|.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}}.
                 - The query in |querySet| at index |queryIndex| has not been written earlier in this render pass.
             </div>
 
@@ -6697,23 +6697,19 @@ dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
 };
 </script>
 
-- {{GPUQuerySetDescriptor/type}} specifies the type of queries managed by {{GPUQuerySet}}.
-- {{GPUQuerySetDescriptor/count}} specifies the number of queries managed by {{GPUQuerySet}}.
-- {{GPUQuerySetDescriptor/pipelineStatistics}} is a set of {{GPUPipelineStatisticName}} values to
-    determine which pipeline statistics will be returned in {{GPUQuerySet}}.
+<dl dfn-type=dict-member dfn-for=GPUQuerySetDescriptor>
+    : <dfn>type</dfn>
+    ::
+        The type of queries managed by {{GPUQuerySet}}.
 
-<div class=validusage dfn-for=GPUQuerySetDescriptor>
-    <dfn abstract-op>GPUQuerySetDescriptor Valid Usage</dfn>
+    : <dfn>count</dfn>
+    ::
+        The number of queries managed by {{GPUQuerySet}}.
 
-    Given a {{GPUQuerySetDescriptor}} |this|, the following validation rules apply:
-
-    - |this|.{{GPUQuerySetDescriptor/type}} must not be {{GPUQueryType/pipeline-statistics}} if {{GPUFeatureName/pipeline-statistics-query}}
-        is not available.
-    - |this|.{{GPUQuerySetDescriptor/type}} must not be {{GPUQueryType/timestamp}} if {{GPUFeatureName/timestamp-query}} is not available.
-    - |this|.{{GPUQuerySetDescriptor/count}} &le; 8192.
-    - |this|.{{GPUQuerySetDescriptor/pipelineStatistics}} must be undefined if |this|.{{GPUQuerySetDescriptor/type}} is not
-        {{GPUQueryType/pipeline-statistics}}, otherwise it must be a sequence of {{GPUPipelineStatisticName}} values which cannot be duplicated.
-</div>
+    : <dfn>pipelineStatistics</dfn>
+    ::
+        The set of {{GPUPipelineStatisticName}} values in this sequence defines which pipeline statistics will be returned in the new query set.
+</dl>
 
 <dl dfn-type=method dfn-for=GPUDevice>
     : <dfn>createQuerySet(descriptor)</dfn>
@@ -6729,6 +6725,19 @@ dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
             </pre>
 
             **Returns:** {{GPUQuerySet}}
+
+            If any of the following conditions are unsatisfied, return an error query set and stop.
+            <div class=validusage>
+                - |this| is a [=valid=] {{GPUDevice}}.
+                - |descriptor|.{{GPUQuerySetDescriptor/type}} must not be {{GPUQueryType/pipeline-statistics}} if
+                    {{GPUFeatureName/pipeline-statistics-query}} is not available.
+                - |descriptor|.{{GPUQuerySetDescriptor/type}} must not be {{GPUQueryType/timestamp}} if
+                    {{GPUFeatureName/timestamp-query}} is not available.
+                - |descriptor|.{{GPUQuerySetDescriptor/count}} &le; 8192.
+                - |descriptor|.{{GPUQuerySetDescriptor/pipelineStatistics}} must be undefined if |this|.{{GPUQuerySetDescriptor/type}}
+                    is not {{GPUQueryType/pipeline-statistics}}, otherwise it must be a sequence of {{GPUPipelineStatisticName}} values
+                    which cannot be duplicated.
+            </div>
 
             Issue: Describe {{GPUDevice/createQuerySet()}} algorithm steps.
         </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4912,8 +4912,8 @@ must be well nested.
                 - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
                 - |querySet| is [$valid to use with$] |this|.
                 - |querySet|.{{GPUQuerySet/[[type]]}} is {{GPUQueryType/timestamp}}.
-                - |queryIndex| is less than |querySet|.{{GPUQuerySet/[[count]]}}.
-                - |queryIndex| cannot be overwritten on |this|.
+                - |queryIndex| &lt |querySet|.{{GPUQuerySet/[[count]]}}.
+                - |queryIndex| cannot be overwritten on the same |this|.
             </div>
 
             Issue: Describe {{GPUCommandEncoder/writeTimestamp()}} algorithm steps.
@@ -5420,8 +5420,8 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
             <div class=validusage>
                 - |querySet| is [$valid to use with$] |this|.
                 - |querySet|.{{GPUQuerySet/[[type]]}} is {{GPUQueryType/timestamp}}.
-                - |queryIndex| is less than |querySet|.{{GPUQuerySet/[[count]]}}.
-                - |queryIndex| cannot be overwritten on |this|.
+                - |queryIndex| &lt; |querySet|.{{GPUQuerySet/[[count]]}}.
+                - |queryIndex| cannot be overwritten on the same |this|.
             </div>
 
             Issue: Describe {{GPUComputePassEncoder/writeTimestamp()}} algorithm steps.
@@ -6223,8 +6223,8 @@ attachments used by this encoder.
             <div class=validusage>
                 - |querySet| is [$valid to use with$] |this|.
                 - |querySet|.{{GPUQuerySet/[[type]]}} is {{GPUQueryType/timestamp}}.
-                - |queryIndex| is less than |querySet|.{{GPUQuerySet/[[count]]}}.
-                - |queryIndex| cannot be overwritten on |this|.
+                - |queryIndex| &lt; |querySet|.{{GPUQuerySet/[[count]]}}.
+                - |queryIndex| cannot be overwritten on the same |this|.
             </div>
 
             Issue: Describe {{GPURenderPassEncoder/writeTimestamp()}} algorithm steps.
@@ -6710,11 +6710,10 @@ dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
 
     Given a {{GPUQuerySetDescriptor}} |this| the following validation rules apply:
 
-    1. |this|.{{GPUQuerySetDescriptor/type}} must be a [=valid=] {{GPUQueryType}}.
-    1. |this|.{{GPUQuerySetDescriptor/type}} must not be {{GPUQueryType/pipeline-statistics}} if {{GPUFeatureName/pipeline-statistics-query}} is not available.
-    1. |this|.{{GPUQuerySetDescriptor/type}} must not be {{GPUQueryType/timestamp}} if {{GPUFeatureName/timestamp-query}} is not available.
-    1. The maximum limitation of |this|.{{GPUQuerySetDescriptor/count}} is 8192.
-    1. |this|.{{GPUQuerySetDescriptor/pipelineStatistics}} must be ignored if |this|.{{GPUQuerySetDescriptor/type}} is not {{GPUQueryType/pipeline-statistics}}, otherwise it must be a sequence of {{GPUPipelineStatisticName}} values which cannot be duplicated.
+    - |this|.{{GPUQuerySetDescriptor/type}} must not be {{GPUQueryType/pipeline-statistics}} if {{GPUFeatureName/pipeline-statistics-query}} is not available.
+    - |this|.{{GPUQuerySetDescriptor/type}} must not be {{GPUQueryType/timestamp}} if {{GPUFeatureName/timestamp-query}} is not available.
+    - |this|.{{GPUQuerySetDescriptor/count}} &le; 8192.
+    - |this|.{{GPUQuerySetDescriptor/pipelineStatistics}} must be undefined if |this|.{{GPUQuerySetDescriptor/type}} is not {{GPUQueryType/pipeline-statistics}}, otherwise it must be a sequence of {{GPUPipelineStatisticName}} values which cannot be duplicated.
 </div>
 
 <dl dfn-type=method dfn-for=GPUDevice>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4911,8 +4911,8 @@ must be well nested.
             <div class=validusage>
                 - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
                 - |querySet| is [$valid to use with$] |this|.
-                - |querySet|.{{GPUQuerySet/[[type]]}} is {{GPUQueryType/timestamp}}.
-                - |queryIndex| &lt; |querySet|.{{GPUQuerySet/[[count]]}}.
+                - |querySet|.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/timestamp}}.
+                - |queryIndex| &lt; |querySet|.{{GPUQuerySetDescriptor/count}}.
             </div>
 
             Issue: Describe {{GPUCommandEncoder/writeTimestamp()}} algorithm steps.
@@ -5418,8 +5418,8 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
             If any of the following conditions are unsatisfied, generate a validation error and stop.
             <div class=validusage>
                 - |querySet| is [$valid to use with$] |this|.
-                - |querySet|.{{GPUQuerySet/[[type]]}} is {{GPUQueryType/timestamp}}.
-                - |queryIndex| &lt; |querySet|.{{GPUQuerySet/[[count]]}}.
+                - |querySet|.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/timestamp}}.
+                - |queryIndex| &lt; |querySet|.{{GPUQuerySetDescriptor/count}}.
             </div>
 
             Issue: Describe {{GPUComputePassEncoder/writeTimestamp()}} algorithm steps.
@@ -6220,8 +6220,8 @@ attachments used by this encoder.
             If any of the following conditions are unsatisfied, generate a validation error and stop.
             <div class=validusage>
                 - |querySet| is [$valid to use with$] |this|.
-                - |querySet|.{{GPUQuerySet/[[type]]}} is {{GPUQueryType/timestamp}}.
-                - |queryIndex| &lt; |querySet|.{{GPUQuerySet/[[count]]}}.
+                - |querySet|.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/timestamp}}.
+                - |queryIndex| &lt; |querySet|.{{GPUQuerySetDescriptor/count}}.
                 - The query in |querySet| at index |queryIndex| has not been written earlier in this render pass.
             </div>
 
@@ -6678,17 +6678,11 @@ GPUQuerySet includes GPUObjectBase;
 {{GPUQuerySet}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUQuerySet">
-    : <dfn>\[[type]]</dfn> of type {{GPUQueryType}}.
+    : <dfn>\[[descriptor]]</dfn>, of type {{GPUQuerySetDescriptor}}
     ::
-        The type of queries managed by this {{GPUQuerySet}}.
+        The {{GPUQuerySetDescriptor}} describing this query set.
 
-    : <dfn>\[[count]]</dfn> of type {{GPUSize32}}.
-    ::
-        The number of queries managed by this {{GPUQuerySet}}.
-
-    : <dfn>\[[pipelineStatistics]]</dfn> of type sequence<{{GPUPipelineStatisticName}}>.
-    ::
-        The set of {{GPUPipelineStatisticName}} values to determine which pipeline statistics will be returned in this {{GPUQuerySet}}.
+        All optional fields of {{GPUTextureViewDescriptor}} are defined.
 </dl>
 
 ### Creation ### {#queryset-creation}
@@ -6702,6 +6696,10 @@ dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
     sequence<GPUPipelineStatisticName> pipelineStatistics = [];
 };
 </script>
+
+- {{GPUQuerySetDescriptor/type}} specifies the type of queries managed by {{GPUQuerySet}}.
+- {{GPUQuerySetDescriptor/count}} specifies the number of queries managed by {{GPUQuerySet}}.
+- {{GPUQuerySetDescriptor/pipelineStatistics}} is a set of {{GPUPipelineStatisticName}} values to determine which pipeline statistics will be returned in {{GPUQuerySet}}.
 
 <div class=validusage dfn-for=GPUQuerySetDescriptor>
     <dfn abstract-op>GPUQuerySetDescriptor Valid Usage</dfn>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6699,17 +6699,20 @@ dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
 
 - {{GPUQuerySetDescriptor/type}} specifies the type of queries managed by {{GPUQuerySet}}.
 - {{GPUQuerySetDescriptor/count}} specifies the number of queries managed by {{GPUQuerySet}}.
-- {{GPUQuerySetDescriptor/pipelineStatistics}} is a set of {{GPUPipelineStatisticName}} values to determine which pipeline statistics will be returned in {{GPUQuerySet}}.
+- {{GPUQuerySetDescriptor/pipelineStatistics}} is a set of {{GPUPipelineStatisticName}} values to
+    determine which pipeline statistics will be returned in {{GPUQuerySet}}.
 
 <div class=validusage dfn-for=GPUQuerySetDescriptor>
     <dfn abstract-op>GPUQuerySetDescriptor Valid Usage</dfn>
 
     Given a {{GPUQuerySetDescriptor}} |this|, the following validation rules apply:
 
-    - |this|.{{GPUQuerySetDescriptor/type}} must not be {{GPUQueryType/pipeline-statistics}} if {{GPUFeatureName/pipeline-statistics-query}} is not available.
+    - |this|.{{GPUQuerySetDescriptor/type}} must not be {{GPUQueryType/pipeline-statistics}} if {{GPUFeatureName/pipeline-statistics-query}}
+        is not available.
     - |this|.{{GPUQuerySetDescriptor/type}} must not be {{GPUQueryType/timestamp}} if {{GPUFeatureName/timestamp-query}} is not available.
     - |this|.{{GPUQuerySetDescriptor/count}} &le; 8192.
-    - |this|.{{GPUQuerySetDescriptor/pipelineStatistics}} must be undefined if |this|.{{GPUQuerySetDescriptor/type}} is not {{GPUQueryType/pipeline-statistics}}, otherwise it must be a sequence of {{GPUPipelineStatisticName}} values which cannot be duplicated.
+    - |this|.{{GPUQuerySetDescriptor/pipelineStatistics}} must be undefined if |this|.{{GPUQuerySetDescriptor/type}} is not
+        {{GPUQueryType/pipeline-statistics}}, otherwise it must be a sequence of {{GPUPipelineStatisticName}} values which cannot be duplicated.
 </div>
 
 <dl dfn-type=method dfn-for=GPUDevice>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4897,12 +4897,12 @@ must be well nested.
         Writes a timestamp value into |querySet| when all previous commands have completed executing.
 
         <div algorithm=GPUCommandEncoder.writeTimestamp>
-            **Called on:** {{GPUCommandEncoder}} this.
+            **Called on:** {{GPUCommandEncoder}} |this|.
 
             **Arguments:**
             <pre class=argumentdef for="GPUCommandEncoder/writeTimestamp(querySet, queryIndex)">
-                querySet: The query set that will store the timestamp values.
-                queryIndex: The index of the query in the query set.
+                |querySet|: The query set that will store the timestamp values.
+                |queryIndex|: The index of the query in the query set.
             </pre>
 
             **Returns:** {{undefined}}
@@ -5405,12 +5405,12 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
         Writes a timestamp value into |querySet| when all previous commands have completed executing.
 
         <div algorithm="GPUComputePassEncoder.writeTimestamp">
-            **Called on:** {{GPUComputePassEncoder}} this.
+            **Called on:** {{GPUComputePassEncoder}} |this|.
 
             **Arguments:**
             <pre class=argumentdef for="GPUComputePassEncoder/writeTimestamp(querySet, queryIndex)">
-                querySet: The query set that will store the timestamp values.
-                queryIndex: The index of the query in the query set.
+                |querySet|: The query set that will store the timestamp values.
+                |queryIndex|: The index of the query in the query set.
             </pre>
 
             **Returns:** {{undefined}}
@@ -6207,7 +6207,7 @@ attachments used by this encoder.
         Writes a timestamp value into |querySet| when all previous commands have completed executing.
 
         <div algorithm="GPURenderPassEncoder.writeTimestamp">
-            **Called on:** {{GPURenderPassEncoder}} this.
+            **Called on:** {{GPURenderPassEncoder}} |this|.
 
             **Arguments:**
             <pre class=argumentdef for="GPURenderPassEncoder/writeTimestamp(querySet, queryIndex)">

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4913,7 +4913,7 @@ must be well nested.
                 - |querySet| is [$valid to use with$] |this|.
                 - |querySet|.{{GPUQuerySet/[[type]]}} is {{GPUQueryType/timestamp}}.
                 - |queryIndex| is less than |querySet|.{{GPUQuerySet/[[count]]}}.
-                - |queryIndex| cannot be rewritten on |this|.
+                - |queryIndex| cannot be overwritten on |this|.
             </div>
 
             Issue: Describe {{GPUCommandEncoder/writeTimestamp()}} algorithm steps.
@@ -5421,7 +5421,7 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
                 - |querySet| is [$valid to use with$] |this|.
                 - |querySet|.{{GPUQuerySet/[[type]]}} is {{GPUQueryType/timestamp}}.
                 - |queryIndex| is less than |querySet|.{{GPUQuerySet/[[count]]}}.
-                - |queryIndex| cannot be rewritten on |this|.
+                - |queryIndex| cannot be overwritten on |this|.
             </div>
 
             Issue: Describe {{GPUComputePassEncoder/writeTimestamp()}} algorithm steps.
@@ -6224,7 +6224,7 @@ attachments used by this encoder.
                 - |querySet| is [$valid to use with$] |this|.
                 - |querySet|.{{GPUQuerySet/[[type]]}} is {{GPUQueryType/timestamp}}.
                 - |queryIndex| is less than |querySet|.{{GPUQuerySet/[[count]]}}.
-                - |queryIndex| cannot be rewritten on |this|.
+                - |queryIndex| cannot be overwritten on |this|.
             </div>
 
             Issue: Describe {{GPURenderPassEncoder/writeTimestamp()}} algorithm steps.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4242,11 +4242,6 @@ GPUCommandEncoder includes GPUObjectBase;
     : <dfn>\[[debug_group_stack]]</dfn> of type [=stack=]&lt;{{USVString}}&gt;.
     ::
         A stack of active debug group labels.
-
-    : <dfn>\[[queries_state_map]]</dfn>, of type [=ordered map=]&lt;{{GPUQuerySet}}, sequence&lt;{{boolean}}&gt;&gt;
-    ::
-        The queries state for each {{GPUQuerySet}} indicating which queries are used on the {{GPUCommandEncoder}},
-        initially empty.
 </dl>
 
 Each {{GPUCommandEncoder}} has a current <dfn dfn-type="enum">encoder state</dfn> on the [=Content timeline=]
@@ -4899,9 +4894,7 @@ must be well nested.
 <dl dfn-type=method dfn-for=GPUCommandEncoder>
     : <dfn>writeTimestamp(querySet, queryIndex)</dfn>
     ::
-        Writes a timestamp value into |querySet| when all previous commands have completed executing,
-        and sets the query state to `true` at |queryIndex| in the sequence of
-        {{GPUCommandEncoder}}.{{GPUCommandEncoder/[[queries_state_map]]}}.
+        Writes a timestamp value into |querySet| when all previous commands have completed executing.
 
         <div algorithm=GPUCommandEncoder.writeTimestamp>
             **Called on:** {{GPUCommandEncoder}} this.
@@ -4920,8 +4913,6 @@ must be well nested.
                 - |querySet| is [$valid to use with$] |this|.
                 - |querySet|.{{GPUQuerySet/[[type]]}} is {{GPUQueryType/timestamp}}.
                 - |queryIndex| &lt |querySet|.{{GPUQuerySet/[[count]]}}.
-                - The query state at |queryIndex| in the sequence of
-                  |this|.{{GPUCommandEncoder/[[queries_state_map]]}} must be `false`.
             </div>
 
             Issue: Describe {{GPUCommandEncoder/writeTimestamp()}} algorithm steps.
@@ -5411,9 +5402,7 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
 
     : <dfn>writeTimestamp(querySet, queryIndex)</dfn>
     ::
-        Writes a timestamp value into |querySet| when all previous commands have completed executing,
-        and sets the query state to `true` at |queryIndex| in the sequence of
-        {{GPUCommandEncoder}}.{{GPUCommandEncoder/[[queries_state_map]]}}.
+        Writes a timestamp value into |querySet| when all previous commands have completed executing.
 
         <div algorithm="GPUComputePassEncoder.writeTimestamp">
             **Called on:** {{GPUComputePassEncoder}} this.
@@ -5431,8 +5420,6 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
                 - |querySet| is [$valid to use with$] |this|.
                 - |querySet|.{{GPUQuerySet/[[type]]}} is {{GPUQueryType/timestamp}}.
                 - |queryIndex| &lt; |querySet|.{{GPUQuerySet/[[count]]}}.
-                - The query state at |queryIndex| in the sequence of
-                  {{GPUCommandEncoder}}.{{GPUCommandEncoder/[[queries_state_map]]}} must be `false`.
             </div>
 
             Issue: Describe {{GPUComputePassEncoder/writeTimestamp()}} algorithm steps.
@@ -6217,9 +6204,7 @@ attachments used by this encoder.
 
     : <dfn>writeTimestamp(querySet, queryIndex)</dfn>
     ::
-        Writes a timestamp value into |querySet| when all previous commands have completed executing,
-        and sets the query state to `true` at |queryIndex| in the sequence of
-        {{GPUCommandEncoder}}.{{GPUCommandEncoder/[[queries_state_map]]}}.
+        Writes a timestamp value into |querySet| when all previous commands have completed executing.
 
         <div algorithm="GPURenderPassEncoder.writeTimestamp">
             **Called on:** {{GPURenderPassEncoder}} this.
@@ -6237,8 +6222,7 @@ attachments used by this encoder.
                 - |querySet| is [$valid to use with$] |this|.
                 - |querySet|.{{GPUQuerySet/[[type]]}} is {{GPUQueryType/timestamp}}.
                 - |queryIndex| &lt; |querySet|.{{GPUQuerySet/[[count]]}}.
-                - The query state at |queryIndex| in the sequence of
-                  {{GPUCommandEncoder}}.{{GPUCommandEncoder/[[queries_state_map]]}} must be `false`.
+                - The query at same |queryIndex| cannot be written twice in the same |this|.
             </div>
 
             Issue: Describe {{GPURenderPassEncoder/writeTimestamp()}} algorithm steps.


### PR DESCRIPTION
Improve the description and validation rule for:
- GPUQuerySet and GPUQuerySetDescriptor.
- writeTimestamp on GPUCommandEncoder, GPUComputePassEncoder, GPURenderPassEncoder.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/haoxli/gpuweb/pull/1161.html" title="Last updated on Nov 16, 2020, 5:02 AM UTC (a076f9d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1161/51d54af...haoxli:a076f9d.html" title="Last updated on Nov 16, 2020, 5:02 AM UTC (a076f9d)">Diff</a>