### PR TITLE
Add maxStorageBufferBindingSize limit

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1045,7 +1045,7 @@ a better limit is not specified.
         of type {{GPUBindingType/uniform-buffer}}.
 
     <tr><td><dfn>maxStorageBufferBindingSize</dfn>
-        <td>{{GPUSize32}} <td>Higher <td> 128 Mb
+        <td>{{GPUSize32}} <td>Higher <td> 134217728 (128 MiB)
     <tr class=row-continuation><td colspan=4>
         The maximum {{GPUBufferBinding}}.{{GPUBufferBinding/size}} for bindings
         of types {{GPUBindingType/storage-buffer}} and {{GPUBindingType/readonly-storage-buffer}}.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1043,6 +1043,12 @@ a better limit is not specified.
     <tr class=row-continuation><td colspan=4>
         The maximum {{GPUBufferBinding}}.{{GPUBufferBinding/size}} for bindings
         of type {{GPUBindingType/uniform-buffer}}.
+
+    <tr><td><dfn>maxStorageBufferBindingSize</dfn>
+        <td>{{GPUSize32}} <td>Higher <td> 128 Mb
+    <tr class=row-continuation><td colspan=4>
+        The maximum {{GPUBufferBinding}}.{{GPUBufferBinding/size}} for bindings
+        of types {{GPUBindingType/storage-buffer}} and {{GPUBindingType/readonly-storage-buffer}}.
 </table>
 
 #### <dfn dictionary>GPULimits</dfn> #### {#gpulimits}
@@ -1061,6 +1067,7 @@ dictionary GPULimits {
     GPUSize32 maxStorageTexturesPerShaderStage = 4;
     GPUSize32 maxUniformBuffersPerShaderStage = 12;
     GPUSize32 maxUniformBufferBindingSize = 16384;
+    GPUSize32 maxStorageBufferBindingSize = 134217728;
 };
 </script>
 
@@ -2958,6 +2965,7 @@ A {{GPUBindGroup}} object has the following internal slots:
                                                         {{GPUBindingType/"readonly-storage-buffer"}}
                                                     :: |resource|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
                                                         includes {{GPUBufferUsage/STORAGE}}.
+                                                    :: |resource|.{{GPUBufferBinding/size}} &le; {{GPULimits/maxStorageBufferBindingSize}}.
                                                 </dl>
 
                                     </dl>


### PR DESCRIPTION
See Vulkan stats in https://vulkan.gpuinfo.org/displaydevicelimit.php?name=maxStorageBufferRange&platform=windows
Also related to https://github.com/gpuweb/gpuweb/issues/1135#issuecomment-713711714


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/1163.html" title="Last updated on Oct 21, 2020, 7:03 PM UTC (4008356)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1163/51d54af...kvark:4008356.html" title="Last updated on Oct 21, 2020, 7:03 PM UTC (4008356)">Diff</a>