### PR TITLE
Fix CI breakage with 'conventions'

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -457,7 +457,7 @@ to dissociate logical GPU invocations with actual compute units to reduce this r
 
 # Fundamentals # {#fundamentals}
 
-## Conventions ## {#conventions}
+## Conventions ## {#api-conventions}
 
 ### Dot Syntax ### {#dot-syntax}
 
@@ -7483,6 +7483,8 @@ All packed texture formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsa
 </table>
 
 ## Temporary usages of non-exported dfns ## {#temp-dfn-usages}
+
+[=Origin2D/x=] [=Origin2D/y=]
 
 Eventually all of these should disappear but they are useful to avoid warning while building the specification.
 


### PR DESCRIPTION
Filed https://github.com/tabatkins/bikeshed/issues/1805 for the issue we had


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/1167.html" title="Last updated on Oct 22, 2020, 3:41 PM UTC (a1cf3e9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1167/cafeb4f...kvark:a1cf3e9.html" title="Last updated on Oct 22, 2020, 3:41 PM UTC (a1cf3e9)">Diff</a>