### PR TITLE
Multi-queue synchronization

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6347,7 +6347,7 @@ interface GPUQueue {
     GPUSignalValue signal();
     readonly attribute GPUSignalValue lastSignaledValue;
 
-    undefined wait(GPUQueue queue, optional GPUSignalValue value);
+    undefined waitFor(GPUQueue queue, optional GPUSignalValue value);
 
     undefined submit(
         sequence<GPUCommandBuffer> commandBuffers,
@@ -6382,7 +6382,9 @@ GPUQueue includes GPUObjectBase;
 <dl dfn-type=attribute dfn-for=GPUQueue>
     : <dfn>lastSignaledValue</dfn> of type {{GPUSignalValue}}, readonly
     ::
-        The last value returned by {{GPUQueue/signal()}}.
+        Returns the integer value that is higher or equal to all the values
+        previously returned by either {{GPUQueue/lastSignaledValue}} or
+        {{GPUQueue/signal()}} on this queue.
 </dl>
 
 <dl dfn-type=method dfn-for=GPUQueue>
@@ -6562,10 +6564,13 @@ GPUQueue includes GPUObjectBase;
             </div>
         </div>
 
-    : <dfn>wait(queue, value)</dfn>
+    : <dfn>waitFor(queue, value)</dfn>
     ::
         Waits for the |queue| reaching |value| on the [=Queue timeline=]. If |value| is undefined,
         the |queue|.{{GPUQueue/lastSignaledValue}} is used instead.
+
+        The |value| has to be less or equal to the |queue|.{{GPUQueue/lastSignaledValue}},
+        or a validation error is produced.
 
         All the resource transitions from |queue| targeting |this| will be considered done on the [=Queue timeline=]
         after this call, and relevant resources can be used on |this|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6571,8 +6571,8 @@ GPUQueue includes GPUObjectBase;
 
     : <dfn>signal()</dfn>
     ::
-        Returns the largest signaled value for the queue that has propagated to
-        the [=content timeline=].
+        Returns a signal value corresponding to the work submitted to the queue up to this moment on the [=content timeline=].
+        This value has to be higher or equal to return value of the previous call to {{GPUQueue/signal()}} on this queue.
 
     : <dfn>onCompletion(signalValue)</dfn>
     ::

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6347,13 +6347,14 @@ interface GPUQueue {
     GPUSignalValue signal();
     readonly attribute GPUSignalValue lastSignaledValue;
 
-    Promise<undefined> onCompletion(optional GPUSignalValue value);
-
     undefined wait(GPUQueue queue, optional GPUSignalValue value);
 
     undefined submit(
         sequence<GPUCommandBuffer> commandBuffers,
         optional sequence<GPUResourceTransfer> transfers = []);
+
+    GPUFence createFence(optional GPUFenceDescriptor descriptor = {});
+    undefined signal(GPUFence fence, GPUFenceValue signalValue);
 
     undefined writeBuffer(
         GPUBuffer buffer,
@@ -6573,13 +6574,103 @@ GPUQueue includes GPUObjectBase;
     ::
         Returns a signal value corresponding to the work submitted to the queue up to this moment on the [=content timeline=].
         This value has to be higher or equal to return value of the previous call to {{GPUQueue/signal()}} on this queue.
-
-    : <dfn>onCompletion(signalValue)</dfn>
-    ::
-        Returns a {{Promise}} that resolves once the queue reaches `signalValue`
-        (or |this|.{{GPUQueue/lastSignaledValue}}) if undefined) on the [=content timeline=].
-
 </dl>
+
+## <dfn interface>GPUFence</dfn> ## {#fence}
+
+<script type=idl>
+interface GPUFence {
+    GPUFenceValue getCompletedValue();
+    Promise<undefined> onCompletion(GPUFenceValue completionValue);
+};
+GPUFence includes GPUObjectBase;
+</script>
+
+### Creation ### {#fence-creation}
+
+<script type=idl>
+dictionary GPUFenceDescriptor : GPUObjectDescriptorBase {
+    GPUFenceValue initialValue = 0;
+};
+</script>
+
+<dl dfn-type=method dfn-for=GPUQueue>
+    : <dfn>createFence(descriptor)</dfn>
+    ::
+        Creates a {{GPUFence}}.
+
+        <div algorithm="GPUQueue.createFence">
+            **Called on:** {{GPUQueue}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPUQueue/createFence(descriptor)">
+                descriptor: Description of the {{GPUFence}} to create.
+            </pre>
+
+            **Returns:** {{GPUFence}}
+
+            Issue: Describe {{GPUQueue/createFence()}} algorithm steps.
+        </div>
+</dl>
+
+### Completion ### {#fence-signaling}
+
+Completion of a fence is signaled from the {{GPUQueue}} that created it.
+
+<dl dfn-type=method dfn-for=GPUQueue>
+    : <dfn>signal(fence, signalValue)</dfn>
+    ::
+        Signals the given fence, increasing it's completed value to `signalValue`.
+
+        <div algorithm="GPUQueue.signal">
+            **Called on:** {{GPUQueue}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPUQueue/signal(fence, signalValue)">
+                |fence|: The fence to signal.
+                signalValue: The value to increase |fence|'s completion value to.
+            </pre>
+
+            **Returns:** {{undefined}}
+
+            Issue: Describe {{GPUQueue/signal()}} algorithm steps.
+        </div>
+</dl>
+
+The completion of the fence and the value it completes with can be observed from the {{GPUFence}}.
+
+<dl dfn-type=method dfn-for=GPUFence>
+    : <dfn>getCompletedValue()</dfn>
+    ::
+        Returns the largest signalled value completion value for the fence that has propagated to
+        the [=content timeline=].
+
+        <div algorithm="GPUFence.getCompletedValue">
+            **Called on:** {{GPUFence}} this.
+
+            **Returns:** {{GPUFenceValue}}
+
+            Issue: Describe {{GPUFence/getCompletedValue()}} algorithm steps.
+        </div>
+
+    : <dfn>onCompletion(completionValue)</dfn>
+    ::
+        Returns a {{Promise}} that resolves once the fence's completion value &ge; `completionValue`.
+        <div algorithm="GPUFence.onCompletion">
+            **Called on:** {{GPUFence}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPUFence/onCompletion(completionValue)">
+                completionValue: The completion value that the fence must meet or exceed before
+                    resolving the returned {{Promise}}
+            </pre>
+
+            **Returns:** {{Promise}}&lt;{{undefined}}&gt;
+
+            Issue: Describe {{GPUFence/onCompletion()}} algorithm steps.
+        </div>
+</dl>
+
 
 Queries {#queries}
 ================
@@ -6870,6 +6961,7 @@ partial interface GPUDevice {
 
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUBufferDynamicOffset;
+typedef [EnforceRange] unsigned long long GPUFenceValue;
 typedef [EnforceRange] unsigned long GPUStencilValue;
 typedef [EnforceRange] unsigned long GPUSampleMask;
 typedef [EnforceRange] long GPUDepthBias;

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6347,13 +6347,13 @@ interface GPUQueue {
     GPUSignalValue signal();
     readonly attribute GPUSignalValue lastSignaledValue;
 
+    Promise<undefined> onCompletion(optional GPUSignalValue value);
+
     undefined wait(GPUQueue queue, optional GPUSignalValue value);
 
     undefined submit(
         sequence<GPUCommandBuffer> commandBuffers,
         optional sequence<GPUResourceTransfer> transfers = []);
-
-    Promise<undefined> onCompletion(optional GPUSignalValue value);
 
     undefined writeBuffer(
         GPUBuffer buffer,
@@ -6381,8 +6381,7 @@ GPUQueue includes GPUObjectBase;
 <dl dfn-type=attribute dfn-for=GPUQueue>
     : <dfn>lastSignaledValue</dfn> of type {{GPUSignalValue}}, readonly
     ::
-        The smallest signal value representing the progress of all the work that has been submitted
-        to the queue by this moment on the [=content timeline=].
+        The last value returned by {{GPUQueue/signal()}}.
 </dl>
 
 <dl dfn-type=method dfn-for=GPUQueue>
@@ -6572,7 +6571,7 @@ GPUQueue includes GPUObjectBase;
 
     : <dfn>signal()</dfn>
     ::
-        Returns the largest signalled value for the queue that has propagated to
+        Returns the largest signaled value for the queue that has propagated to
         the [=content timeline=].
 
     : <dfn>onCompletion(signalValue)</dfn>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2018,6 +2018,8 @@ dictionary GPUTextureViewDescriptor : GPUObjectDescriptorBase {
 };
 </script>
 
+Issue: derive from `GPUTextureSubresourceRange`
+
 Issue: Make this a standalone algorithm used in the createView algorithm.
 
 Issue: The references to GPUTextureDescriptor here should actually refer to
@@ -6321,11 +6323,37 @@ dictionary GPURenderBundleEncoderDescriptor : GPUObjectDescriptorBase {
 # Queues # {#queues}
 
 <script type=idl>
-interface GPUQueue {
-    undefined submit(sequence<GPUCommandBuffer> commandBuffers);
+typedef [EnforceRange] unsigned long long GPUSignalValue;
 
-    GPUFence createFence(optional GPUFenceDescriptor descriptor = {});
-    undefined signal(GPUFence fence, GPUFenceValue signalValue);
+dictionary GPUTextureSubresourceRange {
+    GPUTextureAspect aspect = "all";
+    GPUIntegerCoordinate baseMipLevel = 0;
+    GPUIntegerCoordinate mipLevelCount;
+    GPUIntegerCoordinate baseArrayLayer = 0;
+    GPUIntegerCoordinate arrayLayerCount;
+};
+
+dictionary GPUTextureSubresources: GPUTextureSubresourceRange {
+    required GPUTexture texture;
+};
+
+dictionary GPUResourceTransfer {
+    required GPUQueue receivingQueue;
+    required sequence<GPUBuffer> buffers;
+    required sequence<GPUTextureSubresources> textureSubresources;
+};
+
+interface GPUQueue {
+    GPUSignalValue signal();
+    readonly attribute GPUSignalValue lastSignaledValue;
+
+    undefined wait(GPUQueue queue, optional GPUSignalValue value);
+
+    undefined submit(
+        sequence<GPUCommandBuffer> commandBuffers,
+        optional sequence<GPUResourceTransfer> transfers = []);
+
+    Promise<undefined> onCompletion(optional GPUSignalValue value);
 
     undefined writeBuffer(
         GPUBuffer buffer,
@@ -6349,6 +6377,13 @@ GPUQueue includes GPUObjectBase;
 </script>
 
 {{GPUQueue}} has the following methods:
+
+<dl dfn-type=attribute dfn-for=GPUQueue>
+    : <dfn>lastSignaledValue</dfn> of type {{GPUSignalValue}}, readonly
+    ::
+        The smallest signal value representing the progress of all the work that has been submitted
+        to the queue by this moment on the [=content timeline=].
+</dl>
 
 <dl dfn-type=method dfn-for=GPUQueue>
     : <dfn>writeBuffer(buffer, bufferOffset, data, dataOffset, size)</dfn>
@@ -6498,8 +6533,10 @@ GPUQueue includes GPUObjectBase;
             **Called on:** {{GPUQueue}} this.
 
             **Arguments:**
-            <pre class=argumentdef for="GPUQueue/submit(commandBuffers)">
-                |commandBuffers|:
+            <pre class=argumentdef for="GPUQueue/submit(commandBuffers, transfers)">
+                |commandBuffers|: list of {{GPUCommandBuffer}} to execute.
+                |transfers|: list of {{GPUResourceTransfer}} that represent transferring
+                    resource ownership from this {{GPUQueue}} to the others.
             </pre>
 
             **Returns:** {{undefined}}
@@ -6516,107 +6553,34 @@ GPUQueue includes GPUObjectBase;
                     <div class=queue-timeline>
                         1. For each |commandBuffer| in |commandBuffers|:
                             1. Execute each command in |commandBuffer|.{{GPUCommandBuffer/[[command_list]]}}.
+                        1. For each |transfer| in |transfers|:
+                            1. Transfer the |transfer|.{{GPUResourceTransfer/buffers}} to
+                                |transfer|.{{GPUResourceTransfer/receivingQueue}}.
+                            1. Transfer the |transfer|.{{GPUResourceTransfer/textureSubresources}} to
+                                |transfer|.{{GPUResourceTransfer/receivingQueue}}.
                     </div>
             </div>
         </div>
-</dl>
 
-## <dfn interface>GPUFence</dfn> ## {#fence}
-
-<script type=idl>
-interface GPUFence {
-    GPUFenceValue getCompletedValue();
-    Promise<undefined> onCompletion(GPUFenceValue completionValue);
-};
-GPUFence includes GPUObjectBase;
-</script>
-
-### Creation ### {#fence-creation}
-
-<script type=idl>
-dictionary GPUFenceDescriptor : GPUObjectDescriptorBase {
-    GPUFenceValue initialValue = 0;
-};
-</script>
-
-<dl dfn-type=method dfn-for=GPUQueue>
-    : <dfn>createFence(descriptor)</dfn>
+    : <dfn>wait(queue, value)</dfn>
     ::
-        Creates a {{GPUFence}}.
+        Waits for the |queue| reaching |value| on the [=Queue timeline=]. If |value| is undefined,
+        the |queue|.{{GPUQueue/lastSignaledValue}} is used instead.
 
-        <div algorithm="GPUQueue.createFence">
-            **Called on:** {{GPUQueue}} this.
+        All the resource transitions from |queue| targeting |this| will be considered done on the [=Queue timeline=]
+        after this call, and relevant resources can be used on |this|.
 
-            **Arguments:**
-            <pre class=argumentdef for="GPUQueue/createFence(descriptor)">
-                descriptor: Description of the {{GPUFence}} to create.
-            </pre>
-
-            **Returns:** {{GPUFence}}
-
-            Issue: Describe {{GPUQueue/createFence()}} algorithm steps.
-        </div>
-</dl>
-
-### Completion ### {#fence-signaling}
-
-Completion of a fence is signaled from the {{GPUQueue}} that created it.
-
-<dl dfn-type=method dfn-for=GPUQueue>
-    : <dfn>signal(fence, signalValue)</dfn>
+    : <dfn>signal()</dfn>
     ::
-        Signals the given fence, increasing it's completed value to `signalValue`.
-
-        <div algorithm="GPUQueue.signal">
-            **Called on:** {{GPUQueue}} this.
-
-            **Arguments:**
-            <pre class=argumentdef for="GPUQueue/signal(fence, signalValue)">
-                |fence|: The fence to signal.
-                signalValue: The value to increase |fence|'s completion value to.
-            </pre>
-
-            **Returns:** {{undefined}}
-
-            Issue: Describe {{GPUQueue/signal()}} algorithm steps.
-        </div>
-</dl>
-
-The completion of the fence and the value it completes with can be observed from the {{GPUFence}}.
-
-<dl dfn-type=method dfn-for=GPUFence>
-    : <dfn>getCompletedValue()</dfn>
-    ::
-        Returns the largest signalled value completion value for the fence that has propagated to
+        Returns the largest signalled value for the queue that has propagated to
         the [=content timeline=].
 
-        <div algorithm="GPUFence.getCompletedValue">
-            **Called on:** {{GPUFence}} this.
-
-            **Returns:** {{GPUFenceValue}}
-
-            Issue: Describe {{GPUFence/getCompletedValue()}} algorithm steps.
-        </div>
-
-    : <dfn>onCompletion(completionValue)</dfn>
+    : <dfn>onCompletion(signalValue)</dfn>
     ::
-        Returns a {{Promise}} that resolves once the fence's completion value &ge; `completionValue`.
+        Returns a {{Promise}} that resolves once the queue reaches `signalValue`
+        (or |this|.{{GPUQueue/lastSignaledValue}}) if undefined) on the [=content timeline=].
 
-        <div algorithm="GPUFence.onCompletion">
-            **Called on:** {{GPUFence}} this.
-
-            **Arguments:**
-            <pre class=argumentdef for="GPUFence/onCompletion(completionValue)">
-                completionValue: The completion value that the fence must meet or exceed before
-                    resolving the returned {{Promise}}
-            </pre>
-
-            **Returns:** {{Promise}}&lt;{{undefined}}&gt;
-
-            Issue: Describe {{GPUFence/onCompletion()}} algorithm steps.
-        </div>
 </dl>
-
 
 Queries {#queries}
 ================
@@ -6907,7 +6871,6 @@ partial interface GPUDevice {
 
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUBufferDynamicOffset;
-typedef [EnforceRange] unsigned long long GPUFenceValue;
 typedef [EnforceRange] unsigned long GPUStencilValue;
 typedef [EnforceRange] unsigned long GPUSampleMask;
 typedef [EnforceRange] long GPUDepthBias;


### PR DESCRIPTION
Closes #1066
Closes #1073 
This PR describes a merged proposal between ^ by the collective authorship of @Kangz , @austinEng, @kainino0x, and myself. It's incomplete (more spec text and validation is needed), but it clearly shows the direction.

~~The proposal removes `GPUFence` objects and instead assigns a monotonically increasing number to each queue directly, which simplifies the explicit synchronization and removes one level of indirection. We believe that the explicit is still desired here because it has little impact on API usability, since using multiple queues is optional.~~

Getting the signal value and waiting on it are separate operations on `GPUQueue`, as opposed to be associated with subimssions specifically, because they also need to take into account `writeBuffer` and `writeTexture`.

The transfer of ownership is still a part of the submission (like with `GPUTextureHandover` in #1066), but it's provided on the queue (like in #1073). This allows the Vulkan backend to avoid an extra dummy submission, all while still specifying the resource ownership fully in the `GPUQueue` API.

Texture ownership is done at the subresource level, which matches WebGPU synchronization today, as well as native APIs we target. This allows, for example, a streaming queue to upload individual mipmap levels and pass their ownership to the main queue.

Note that the PR doesn't include simultaneous access (`VK_SHARING_MODE_CONCURRENT`) between queues yet. I believe, enabling it for buffers would only require minor changes to the spec, and possibly an extra flag in `GPUBufferDescriptor`. We will follow-up with this.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/1169.html" title="Last updated on Nov 13, 2020, 9:06 PM UTC (43ecfb9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1169/5b02f86...kvark:43ecfb9.html" title="Last updated on Nov 13, 2020, 9:06 PM UTC (43ecfb9)">Diff</a>