### PR TITLE
Simplify requiredBytesInCopy algorithm slightly

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4598,25 +4598,18 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
 
     1. Let |requiredBytesInCopy| be 0.
 
-    1. If |copyExtent|.[=Extent3D/depth=] &gt; 1, add
-        |layout|.{{GPUTextureDataLayout/bytesPerRow}} &times;
-        |layout|.{{GPUTextureDataLayout/rowsPerImage}} &times;
-        (|copyExtent|.[=Extent3D/depth=] &minus; 1)
-        to |requiredBytesInCopy|.
-        (This covers all except the last image.)
-
     1. If |copyExtent|.[=Extent3D/depth=] &gt; 0:
-
-        1. If |heightInBlocks| &gt; 1, add
-            |layout|.{{GPUTextureDataLayout/bytesPerRow}} &times;
-            (|heightInBlocks| &minus; 1)
+        1. Add |layout|.{{GPUTextureDataLayout/bytesPerRow}} &times;
+            |layout|.{{GPUTextureDataLayout/rowsPerImage}} &times;
+            (|copyExtent|.[=Extent3D/depth=] &minus; 1)
             to |requiredBytesInCopy|.
-            (This covers all of the last image except the last row.)
+            (This covers all except the last image.)
 
-        1. If |heightInBlocks| &gt; 0, add
-            |widthInBlocks| &times; |blockSize|
-            to |requiredBytesInCopy|.
-            (This covers the last row.)
+        1. If |heightInBlocks| &gt; 0:
+            1. Add |layout|.{{GPUTextureDataLayout/bytesPerRow}} &times;
+                (|heightInBlocks| &minus; 1) + |bytesInACompleteRow|
+                to |requiredBytesInCopy|.
+                (This covers the last image.)
 
     1. Fail if the following conditions are not satisfied:
         <div class=validusage>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4581,7 +4581,9 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
         and |copyExtent|.[=Extent3D/height=] is a multiple of |blockHeight|. Let:
             - |widthInBlocks| be |copyExtent|.[=Extent3D/width=] &divide; |blockWidth|.
             - |heightInBlocks| be |copyExtent|.[=Extent3D/height=] &divide; |blockHeight|.
-            - |bytesInACompleteRow| be |blockSize| &times; |widthInBlocks|.
+            - |bytesInLastRow| be |blockSize| &times; |widthInBlocks|.
+            - |bytesPerImage| be |layout|.{{GPUTextureDataLayout/bytesPerRow}} &times;
+                |layout|.{{GPUTextureDataLayout/rowsPerImage}}.
 
     1. Fail if the following conditions are not satisfied:
         <div class=validusage>
@@ -4591,7 +4593,7 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
                 |layout|.{{GPUTextureDataLayout/bytesPerRow}} and
                 |layout|.{{GPUTextureDataLayout/rowsPerImage}} must be specified.
             - If specified, |layout|.{{GPUTextureDataLayout/bytesPerRow}}
-                must be greater than or equal to |bytesInACompleteRow|.
+                must be greater than or equal to |bytesInLastRow|.
             - If specified, |layout|.{{GPUTextureDataLayout/rowsPerImage}}
                 must be greater than or equal to |heightInBlocks|.
         </div>
@@ -4599,17 +4601,15 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
     1. Let |requiredBytesInCopy| be 0.
 
     1. If |copyExtent|.[=Extent3D/depth=] &gt; 0:
-        1. Add |layout|.{{GPUTextureDataLayout/bytesPerRow}} &times;
-            |layout|.{{GPUTextureDataLayout/rowsPerImage}} &times;
-            (|copyExtent|.[=Extent3D/depth=] &minus; 1)
-            to |requiredBytesInCopy|.
-            (This covers all except the last image.)
+        1. Let |bytesBeforeLastImage| be
+            |bytesPerImage| &times; (|copyExtent|.[=Extent3D/depth=] &minus; 1)
+        1. Add |bytesBeforeLastImage| to |requiredBytesInCopy|.
 
         1. If |heightInBlocks| &gt; 0:
-            1. Add |layout|.{{GPUTextureDataLayout/bytesPerRow}} &times;
-                (|heightInBlocks| &minus; 1) + |bytesInACompleteRow|
-                to |requiredBytesInCopy|.
-                (This covers the last image.)
+            1. Let |bytesInLastImage| be
+                |layout|.{{GPUTextureDataLayout/bytesPerRow}} &times;
+                (|heightInBlocks| &minus; 1) + |bytesInLastRow|.
+            1. Add |bytesInLastImage| to |requiredBytesInCopy|.
 
     1. Fail if the following conditions are not satisfied:
         <div class=validusage>


### PR DESCRIPTION
Should be equivalent, but simplifies by allowing "x - 1" even if x = 1.
Thanks to Corentin for identifying this when I was trying to implement
this computation in C++.

Sorry for the churn here. I seem to have forgotten math.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1172.html" title="Last updated on Oct 23, 2020, 7:57 PM UTC (72bfe4c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1172/13d58e9...kainino0x:72bfe4c.html" title="Last updated on Oct 23, 2020, 7:57 PM UTC (72bfe4c)">Diff</a>