### PR TITLE
Adjust custom style to support dark styles

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -18,10 +18,10 @@ Markup Shorthands: idl no
 
 <style>
 tr:nth-child(2n) {
-  background-color: #f0f0f0;
+  background-color: #b0b0b050;
 }
 thead {
-  background-color: #f0f0f0;
+  background-color: #b0b0b050;
   font-weight: bold;
 }
 .nowrap {


### PR DESCRIPTION
Table headers and `2n` rows are unreadable when viewing the wgsl spec on macOS in dark mode.

Instead of using an opaque almost-white color, use a darker, mostly-transparent color that works well for dark and light styles.