### PR TITLE
WGSL: Begin drafting textureSample[Compare]() builtins

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4005,8 +4005,8 @@ Where:
   </xmp>
 </div>
 
-Following the `<coordinates>` parameter, a number of additional named arguments may
-be passed for the sample operation:
+Following the `<coordinates>` parameter, a number of additional named arguments
+may be passed for the sample operation:
 
 #### Sample with texel offset #### {#texture-sample-with-offset}
 
@@ -4014,13 +4014,15 @@ be passed for the sample operation:
 <result> textureSample(<texture>, <sampler>, <coordinates>, offset: <offset> [, <named-arguments>])
 ```
 
-Applies the integer texel offset `<offset>` to the unnormalized texture coordinate before sampling.
+Applies the integer texel offset `<offset>` to the unnormalized texture
+coordinate before sampling. This offset is applied before applying any texture
+wrapping modes.
 
-TODO(ben-clayton): Check if the addressing modes of the sampler (e.g. wrapping) are applied before this offset or after.
+`<offset>` values may range from `[-8 .. 7]`. Values outside of this range will
+be clamped to the nearest limit.
 
-`<offset>` values may range from `[-8 .. 7]`. Values outside of this range will be clamped to the nearest limit.
-
-The type of `<offset>` is dependent on the type of `<texture>` and is either an `i32`, `vec2<i32>` or `vec3<i32>`:
+The type of `<offset>` is dependent on the type of `<texture>` and is either an
+`i32`, `vec2<i32>` or `vec3<i32>`:
 
 <table class='data'>
   <thead>
@@ -4182,22 +4184,23 @@ The comparision operator is defined by the `<sampler_comparison>`.
 
 #### Sample & Compare with texel offset #### {#texture-sample-compare-with-offset}
 
-Following the `depth_reference` parameter, an optional named parameter for specifying an integer texel offset may be specified:
+Following the `depth_reference` parameter, an optional named parameter for
+specifying an integer texel offset may be passed for the sample and compare
+operation:
 
 ```
 <result> textureSampleCompare(<depth_texture>, <sampler_comparison>, <coordinates>, f32 depth_reference, offset: <offset>)
 ```
 
+The integer texel offset is applied to the unnormalized texture coordinate
+before sampling. This offset is applied before applying any texture wrapping
+modes.
+
 `<offset>` is of type `vec2<i32>` and values may range from `[-8 .. 7]`. Values
 outside of this range will be clamped to the nearest limit.
 
-The offset is applied to the unnormalized texture coordinate before sampling.
-
 Offsets can only be specified when `<depth_texture>` is of type
 `texture_depth_2d` or `texture_depth_2d_array`.
-
-TODO(ben-clayton): Check if the addressing modes of the sampler (e.g. wrapping)
-are applied before this offset or after.
 
 <div class='example' heading="Sample and compare with offset">
   <xmp>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3961,42 +3961,48 @@ TODO: deduplicate these tables
 
 ### Sample ### {#texture-sample-functions}
 
-Sampling from a texture is done via the `textureSample` function:
-
 ```
 <result> textureSample(<texture>, <sampler>, <coordinates> [, <named-arguments>])
 ```
 
-Where:
+Samples a texture.
 
-* `<result>` is the texture's parameterized type when using [sampled](#sampled-texture-type) texture types.<br>
-* `<result>` is `f32` when using [depth](#texture-depth) texture types.
-* `<texture>` is one of the [sampled](#sampled-texture-type), or [depth](#texture-depth) texture types.
-* `<sampler>` is a [sampler type](#sampler-type).
-* `<coordinates>` are the texture coordinates used for sampling.
-    The type for the texture coordinates depends on the `<texture>` type and is
-    either a `f32`, `vec2<f32>`, `vec3<f32>` or `vec4<f32>`:
+**Parameters:**
 
-    <table class='data'>
-      <thead>
-        <tr><td>`<texture>` type<td>`<coordinates>` type
-      </thead>
-      <tr><td> `texture_sampled_1d<type>`         <td> `f32`
-      <tr><td> `texture_sampled_1d_array<type>`   <td> `vec2<f32>`
-      <tr><td> `texture_sampled_2d<type>`         <td> `vec2<f32>`
-      <tr><td> `texture_sampled_2d_array<type>`   <td> `vec3<f32>`
-      <tr><td> `texture_sampled_3d<type>`         <td> `vec3<f32>`
-      <tr><td> `texture_sampled_cube<type>`       <td> `vec3<f32>`
-      <tr><td> `texture_sampled_cube_array<type>` <td> `vec4<f32>`
-      <tr><td> `texture_depth_2d`                 <td> `vec2<f32>`
-      <tr><td> `texture_depth_2d_array`           <td> `vec3<f32>`
-      <tr><td> `texture_depth_cube`               <td> `vec3<f32>`
-      <tr><td> `texture_depth_cube_array`         <td> `vec4<f32>`
-    </table>
+`<texture>` is one of the [sampled](#sampled-texture-type), or [depth](#texture-depth) texture types.
 
-    Array textures (with `_array` suffix) use the last component of `<coordinates>`
-    to specify array index. This value is rounded to the nearest integer and is
-    clamped to the array range before sampling.
+`<sampler>` is a [sampler type](#sampler-type).
+
+`<coordinates>` are the texture coordinates used for sampling.
+The type for the texture coordinates depends on the `<texture>` type and is
+either a `f32`, `vec2<f32>`, `vec3<f32>` or `vec4<f32>`:
+
+<table class='data'>
+  <thead>
+    <tr><td>`<texture>` type<td>`<coordinates>` type
+  </thead>
+  <tr><td> `texture_sampled_1d<type>`         <td> `f32`
+  <tr><td> `texture_sampled_1d_array<type>`   <td> `vec2<f32>`
+  <tr><td> `texture_sampled_2d<type>`         <td> `vec2<f32>`
+  <tr><td> `texture_sampled_2d_array<type>`   <td> `vec3<f32>`
+  <tr><td> `texture_sampled_3d<type>`         <td> `vec3<f32>`
+  <tr><td> `texture_sampled_cube<type>`       <td> `vec3<f32>`
+  <tr><td> `texture_sampled_cube_array<type>` <td> `vec4<f32>`
+  <tr><td> `texture_depth_2d`                 <td> `vec2<f32>`
+  <tr><td> `texture_depth_2d_array`           <td> `vec3<f32>`
+  <tr><td> `texture_depth_cube`               <td> `vec3<f32>`
+  <tr><td> `texture_depth_cube_array`         <td> `vec4<f32>`
+</table>
+
+Array textures (with `_array` suffix) use the last component of `<coordinates>`
+to specify array index. This value is rounded to the nearest integer and is
+clamped to the array range before sampling.
+
+**Return value:**
+
+`<result>` is the texture's parameterized type when using
+[sampled](#sampled-texture-type) texture types.<br>
+`<result>` is `f32` when using [depth](#texture-depth) texture types.
 
 
 <div class='example' heading="Sample">
@@ -4015,10 +4021,10 @@ may be passed for the sample operation:
 ```
 
 Applies the integer texel offset `<offset>` to the unnormalized texture
-coordinate before sampling. This offset is applied before applying any texture
-wrapping modes.
+coordinate before sampling the texture. This offset is applied before applying
+any texture wrapping modes.
 
-`<offset>` values may range from `[-8 .. 7]`. Values outside of this range will
+`<offset>` values may range from `[-8..7]`. Values outside of this range will
 be clamped to the nearest limit.
 
 The type of `<offset>` is dependent on the type of `<texture>` and is either an
@@ -4148,38 +4154,40 @@ Consult the following tables for compatibility:
 
 ### Sample & Compare ### {#texture-sample-compare-functions}
 
-Sampling from a depth texture with a depth-comparison uses the `textureSampleCompare` function:
-
 ```
 f32 textureSampleCompare(<depth_texture>, <sampler_comparison>, <coordinates>, f32 depth_reference [, offset: <offset>])
 ```
 
-Where:
+Samples from a depth texture and compares the sampled depth values against a
+reference value.
 
-* `<depth_texture>` is a [depth](#texture-depth) texture type.
+**Parameters:**
 
-* `<sampler_comparison>` is a [sampler comparision](#sampler-type) type.
+`<depth_texture>` is a [depth](#texture-depth) texture type.
 
-* `<coordinates>` are the texture coordinates used for sampling.
-    The type for the texture coordinates depends on the `<texture>` type:
+`<sampler_comparison>` is a [sampler comparision](#sampler-type) type.
 
-    <table class='data'>
-      <thead>
-        <tr><td>`<texture>` type<td>`<coordinates>` type
-      </thead>
-      <tr><td> `texture_depth_2d`         <td> `vec2<f32>`
-      <tr><td> `texture_depth_2d_array`   <td> `vec3<f32>`
-      <tr><td> `texture_depth_cube`       <td> `vec3<f32>`
-      <tr><td> `texture_depth_cube_array` <td> `vec4<f32>`
-    </table>
+`<coordinates>` are the texture coordinates used for sampling.
+The type for the texture coordinates depends on the `<texture>` type:
 
-    Array textures (with `_array` suffix) use the last component of `<coordinates>`
-    to specify array index. This value is rounded to the nearest integer and is
-    clamped to the array range before sampling.
+<table class='data'>
+  <thead>
+    <tr><td>`<texture>` type<td>`<coordinates>` type
+  </thead>
+  <tr><td> `texture_depth_2d`         <td> `vec2<f32>`
+  <tr><td> `texture_depth_2d_array`   <td> `vec3<f32>`
+  <tr><td> `texture_depth_cube`       <td> `vec3<f32>`
+  <tr><td> `texture_depth_cube_array` <td> `vec4<f32>`
+</table>
 
+Array textures (with `_array` suffix) use the last component of `<coordinates>`
+to specify array index. This value is rounded to the nearest integer and is
+clamped to the array range before sampling.
 
-Samples the depth value at `<coordinates>`, and compares the sampled value against `depth_reference`
-and returns an `f32` in the range `[0.0 .. 1.0]`.
+**Return value:**
+
+A `f32` in the range `[0.0..1.0]`, representing the number of depth values
+that were greater or less than the reference value.
 The comparision operator is defined by the `<sampler_comparison>`.
 
 #### Sample & Compare with texel offset #### {#texture-sample-compare-with-offset}
@@ -4196,11 +4204,15 @@ The integer texel offset is applied to the unnormalized texture coordinate
 before sampling. This offset is applied before applying any texture wrapping
 modes.
 
-`<offset>` is of type `vec2<i32>` and values may range from `[-8 .. 7]`. Values
+`<offset>` is of type `vec2<i32>` and values may range from `[-8..7]`. Values
 outside of this range will be clamped to the nearest limit.
 
-Offsets can only be specified when `<depth_texture>` is of type
-`texture_depth_2d` or `texture_depth_2d_array`.
+The offsets parameter for `textureSampleCompare` is only supported for the
+following `<depth_texture>` types:
+<table class='data'>
+  <tr><td> `texture_depth_2d`
+  <tr><td> `texture_depth_2d_array`
+</table>
 
 <div class='example' heading="Sample and compare with offset">
   <xmp>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3961,7 +3961,7 @@ TODO: deduplicate these tables
 
 ### Sample ### {#texture-sample-functions}
 
-Sampling from a texture uses the `textureSample` function:
+Sampling from a texture is done via the `textureSample` function:
 
 ```
 <result> textureSample(<texture>, <sampler>, <coordinates> [, <named-arguments>])
@@ -3969,15 +3969,10 @@ Sampling from a texture uses the `textureSample` function:
 
 Where:
 
-* `<result>` is the texture's parameterized type when using [sampled](#sampled-texture-type)
-    or [read-only](#texture-ro) texture formats.<br>
+* `<result>` is the texture's parameterized type when using [sampled](#sampled-texture-type) texture types.<br>
 * `<result>` is `f32` when using [depth](#texture-depth) texture types.
-
-* `<texture>` is one of the [sampled](#sampled-texture-type),
-    [read-only](#texture-ro) or [depth](#texture-depth) texture types.
-
+* `<texture>` is one of the [sampled](#sampled-texture-type), or [depth](#texture-depth) texture types.
 * `<sampler>` is a [sampler type](#sampler-type).
-
 * `<coordinates>` are the texture coordinates used for sampling.
     The type for the texture coordinates depends on the `<texture>` type and is
     either a `f32`, `vec2<f32>`, `vec3<f32>` or `vec4<f32>`:
@@ -3993,11 +3988,6 @@ Where:
       <tr><td> `texture_sampled_3d<type>`         <td> `vec3<f32>`
       <tr><td> `texture_sampled_cube<type>`       <td> `vec3<f32>`
       <tr><td> `texture_sampled_cube_array<type>` <td> `vec4<f32>`
-      <tr><td> `texture_ro_1d<type>`              <td> `f32`
-      <tr><td> `texture_ro_1d_array<type>`        <td> `vec2<f32>`
-      <tr><td> `texture_ro_2d<type>`              <td> `vec2<f32>`
-      <tr><td> `texture_ro_2d_array<type>`        <td> `vec3<f32>`
-      <tr><td> `texture_ro_3d<type>`              <td> `vec3<f32>`
       <tr><td> `texture_depth_2d`                 <td> `vec2<f32>`
       <tr><td> `texture_depth_2d_array`           <td> `vec3<f32>`
       <tr><td> `texture_depth_cube`               <td> `vec3<f32>`
@@ -4005,7 +3995,8 @@ Where:
     </table>
 
     Array textures (with `_array` suffix) use the last component of `<coordinates>`
-    to specify array index.
+    to specify array index. This value is rounded to the nearest integer and is
+    clamped to the array range before sampling.
 
 
 <div class='example' heading="Sample">
@@ -4023,10 +4014,13 @@ be passed for the sample operation:
 <result> textureSample(<texture>, <sampler>, <coordinates>, offset: <offset> [, <named-arguments>])
 ```
 
-Applies the integer texel offset `<offset>` to the texture coordinate before sampling.
+Applies the integer texel offset `<offset>` to the unnormalized texture coordinate before sampling.
 
-The type of `<offset>` is dependent on the type of `<texture>` and is either an
-`i32`, `vec2<i32>` or `vec3<i32>`:
+TODO(ben-clayton): Check if the addressing modes of the sampler (e.g. wrapping) are applied before this offset or after.
+
+`<offset>` values may range from `[-8 .. 7]`. Values outside of this range will be clamped to the nearest limit.
+
+The type of `<offset>` is dependent on the type of `<texture>` and is either an `i32`, `vec2<i32>` or `vec3<i32>`:
 
 <table class='data'>
   <thead>
@@ -4037,13 +4031,6 @@ The type of `<offset>` is dependent on the type of `<texture>` and is either an
   <tr><td> `texture_sampled_2d<type>`         <td> `vec2<i32>`
   <tr><td> `texture_sampled_2d_array<type>`   <td> `vec2<i32>`
   <tr><td> `texture_sampled_3d<type>`         <td> `vec3<i32>`
-  <tr><td> `texture_sampled_cube<type>`       <td> `vec3<i32>`
-  <tr><td> `texture_sampled_cube_array<type>` <td> `vec3<i32>`
-  <tr><td> `texture_ro_1d<type>`              <td> `i32`
-  <tr><td> `texture_ro_1d_array<type>`        <td> `i32`
-  <tr><td> `texture_ro_2d<type>`              <td> `vec2<i32>`
-  <tr><td> `texture_ro_2d_array<type>`        <td> `vec2<i32>`
-  <tr><td> `texture_ro_3d<type>`              <td> `vec3<i32>`
   <tr><td> `texture_depth_2d`                 <td> `vec2<i32>`
   <tr><td> `texture_depth_2d_array`           <td> `vec2<i32>`
   <tr><td> `texture_depth_cube`               <td> `vec3<i32>`
@@ -4110,9 +4097,6 @@ The type `T` is dependent on the type of `<texture>`, and is either a
   <tr><td> `texture_sampled_3d<type>`         <td> `vec3<f32>`
   <tr><td> `texture_sampled_cube<type>`       <td> `vec3<f32>`
   <tr><td> `texture_sampled_cube_array<type>` <td> `vec3<f32>`
-  <tr><td> `texture_ro_2d<type>`              <td> `vec2<f32>`
-  <tr><td> `texture_ro_2d_array<type>`        <td> `vec2<f32>`
-  <tr><td> `texture_ro_3d<type>`              <td> `vec3<f32>`
   <tr><td> `texture_depth_2d`                 <td> `vec2<f32>`
   <tr><td> `texture_depth_2d_array`           <td> `vec2<f32>`
   <tr><td> `texture_depth_cube`               <td> `vec3<f32>`
@@ -4143,11 +4127,6 @@ Consult the following tables for compatibility:
   <tr><td> `texture_sampled_3d<type>`         <td>&#10003;<td>&#10003;<td>&#10003;<td>&#10003;
   <tr><td> `texture_sampled_cube<type>`       <td>        <td>&#10003;<td>&#10003;<td>&#10003;
   <tr><td> `texture_sampled_cube_array<type>` <td>        <td>&#10003;<td>&#10003;<td>&#10003;
-  <tr><td> `texture_ro_1d<type>`              <td>&#10003;<td>        <td>        <td>
-  <tr><td> `texture_ro_1d_array<type>`        <td>&#10003;<td>        <td>        <td>
-  <tr><td> `texture_ro_2d<type>`              <td>&#10003;<td>&#10003;<td>&#10003;<td>&#10003;
-  <tr><td> `texture_ro_2d_array<type>`        <td>&#10003;<td>&#10003;<td>&#10003;<td>&#10003;
-  <tr><td> `texture_ro_3d<type>`              <td>&#10003;<td>&#10003;<td>&#10003;<td>&#10003;
   <tr><td> `texture_depth_2d`                 <td>&#10003;<td>&#10003;<td>&#10003;<td>&#10003;
   <tr><td> `texture_depth_2d_array`           <td>&#10003;<td>&#10003;<td>&#10003;<td>&#10003;
   <tr><td> `texture_depth_cube`               <td>        <td>&#10003;<td>&#10003;<td>&#10003;
@@ -4193,11 +4172,12 @@ Where:
     </table>
 
     Array textures (with `_array` suffix) use the last component of `<coordinates>`
-    to specify array index.
+    to specify array index. This value is rounded to the nearest integer and is
+    clamped to the array range before sampling.
 
 
 Samples the depth value at `<coordinates>`, and compares the sampled value against `depth_reference`
-and returns an `f32` in the range `[0.0 - 1.0]`.
+and returns an `f32` in the range `[0.0 .. 1.0]`.
 The comparision operator is defined by the `<sampler_comparison>`.
 
 #### Sample & Compare with texel offset #### {#texture-sample-compare-with-offset}
@@ -4208,10 +4188,13 @@ Following the `depth_reference` parameter, an optional named parameter for speci
 <result> textureSampleCompare(<depth_texture>, <sampler_comparison>, <coordinates>, f32 depth_reference, offset: <offset>)
 ```
 
-If specified, the integer texel offset `<offset>` is applied to the texture coordinate before sampling.
+If specified, the integer texel offset `<offset>` is applied to the unnormalized texture coordinate before sampling.
 
-The type of `<offset>` is dependent on the type of `<texture>` and is either
-a `vec2<i32>` or `vec3<i32>`:
+TODO(ben-clayton): Check if the addressing modes of the sampler (e.g. wrapping) are applied before this offset or after.
+
+`<offset>` values may range from `[-8 .. 7]`. Values outside of this range will be clamped to the nearest limit.
+
+The type of `<offset>` is dependent on the type of `<texture>` and is either a `vec2<i32>` or `vec3<i32>`:
 
 <table class='data'>
   <thead>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3959,6 +3959,278 @@ TODO: deduplicate these tables
 
 ## Texture built-in functions ## {#texture-builtin-functions}
 
+### Sample ### {#texture-sample-functions}
+
+Sampling from a texture uses the `textureSample` function:
+
+```
+<result> textureSample(<texture>, <sampler>, <coordinates> [, <named-arguments>])
+```
+
+Where:
+
+* `<result>` is the texture's parameterized type when using [sampled](#sampled-texture-type)
+    or [read-only](#texture-ro) texture formats.<br>
+* `<result>` is `f32` when using [depth](#texture-depth) texture types.
+
+* `<texture>` is one of the [sampled](#sampled-texture-type),
+    [read-only](#texture-ro) or [depth](#texture-depth) texture types.
+
+* `<sampler>` is a [sampler type](#sampler-type).
+
+* `<coordinates>` are the texture coordinates used for sampling.
+    The type for the texture coordinates depends on the `<texture>` type and is
+    either a `f32`, `vec2<f32>`, `vec3<f32>` or `vec4<f32>`:
+
+    <table class='data'>
+      <thead>
+        <tr><td>`<texture>` type<td>`<coordinates>` type
+      </thead>
+      <tr><td> `texture_sampled_1d<type>`         <td> `f32`
+      <tr><td> `texture_sampled_1d_array<type>`   <td> `vec2<f32>`
+      <tr><td> `texture_sampled_2d<type>`         <td> `vec2<f32>`
+      <tr><td> `texture_sampled_2d_array<type>`   <td> `vec3<f32>`
+      <tr><td> `texture_sampled_3d<type>`         <td> `vec3<f32>`
+      <tr><td> `texture_sampled_cube<type>`       <td> `vec3<f32>`
+      <tr><td> `texture_sampled_cube_array<type>` <td> `vec4<f32>`
+      <tr><td> `texture_ro_1d<type>`              <td> `f32`
+      <tr><td> `texture_ro_1d_array<type>`        <td> `vec2<f32>`
+      <tr><td> `texture_ro_2d<type>`              <td> `vec2<f32>`
+      <tr><td> `texture_ro_2d_array<type>`        <td> `vec3<f32>`
+      <tr><td> `texture_ro_3d<type>`              <td> `vec3<f32>`
+      <tr><td> `texture_depth_2d`                 <td> `vec2<f32>`
+      <tr><td> `texture_depth_2d_array`           <td> `vec3<f32>`
+      <tr><td> `texture_depth_cube`               <td> `vec3<f32>`
+      <tr><td> `texture_depth_cube_array`         <td> `vec4<f32>`
+    </table>
+
+    Array textures (with `_array` suffix) use the last component of `<coordinates>`
+    to specify array index.
+
+
+<div class='example' heading="Sample">
+  <xmp>
+    color = textureSample(tex2D, s, coords);
+  </xmp>
+</div>
+
+Following the `<coordinates>` parameter, a number of additional named arguments may
+be passed for the sample operation:
+
+#### Sample with texel offset #### {#texture-sample-with-offset}
+
+```
+<result> textureSample(<texture>, <sampler>, <coordinates>, offset: <offset> [, <named-arguments>])
+```
+
+Applies the integer texel offset `<offset>` to the texture coordinate before sampling.
+
+The type of `<offset>` is dependent on the type of `<texture>` and is either an
+`i32`, `vec2<i32>` or `vec3<i32>`:
+
+<table class='data'>
+  <thead>
+    <tr><td>`<texture>` type<td>`<coordinates>` type
+  </thead>
+  <tr><td> `texture_sampled_1d<type>`         <td> `i32`
+  <tr><td> `texture_sampled_1d_array<type>`   <td> `i32`
+  <tr><td> `texture_sampled_2d<type>`         <td> `vec2<i32>`
+  <tr><td> `texture_sampled_2d_array<type>`   <td> `vec2<i32>`
+  <tr><td> `texture_sampled_3d<type>`         <td> `vec3<i32>`
+  <tr><td> `texture_sampled_cube<type>`       <td> `vec3<i32>`
+  <tr><td> `texture_sampled_cube_array<type>` <td> `vec3<i32>`
+  <tr><td> `texture_ro_1d<type>`              <td> `i32`
+  <tr><td> `texture_ro_1d_array<type>`        <td> `i32`
+  <tr><td> `texture_ro_2d<type>`              <td> `vec2<i32>`
+  <tr><td> `texture_ro_2d_array<type>`        <td> `vec2<i32>`
+  <tr><td> `texture_ro_3d<type>`              <td> `vec3<i32>`
+  <tr><td> `texture_depth_2d`                 <td> `vec2<i32>`
+  <tr><td> `texture_depth_2d_array`           <td> `vec2<i32>`
+  <tr><td> `texture_depth_cube`               <td> `vec3<i32>`
+  <tr><td> `texture_depth_cube_array`         <td> `vec3<i32>`
+</table>
+
+<div class='example' heading="Sample with offset">
+  <xmp>
+    color = textureSample(tex2D, s, coords, offset: vec2<i32>(1, 2));
+  </xmp>
+</div>
+
+#### Sample with mip bias #### {#texture-sample-with-bias}
+
+```
+<result> textureSample(<texture>, <sampler>, <coordinates>, bias: <f32> [, <named-arguments>])
+```
+
+Applies a bias to the mip level before sampling.
+
+The bias value must be between `-16.0` and `15.99`.
+
+<div class='example' heading="Sample with bias">
+  <xmp>
+    color = textureSample(tex2D, s, coords, bias: 1.0);
+  </xmp>
+</div>
+
+#### Sample with explicit LOD #### {#texture-sample-with-lod}
+
+```
+<result> textureSample(<texture>, <sampler>, <coordinates>, lod: <f32> [, <named-arguments>])
+```
+
+Specifies the explicit mip level to sample.
+Fractional values may interpolate between two levels.
+
+<div class='example' heading="Sample with explicit LOD">
+  <xmp>
+    color = textureSample(tex2D, s, coords, lod: 1.0);
+  </xmp>
+</div>
+
+#### Sample with explicit gradients #### {#texture-sample-with-grad}
+
+```
+<result> textureSample(<texture>, <sampler>, <coordinates>, grad: <gradients> [, <named-arguments>])
+```
+
+Uses the gradient specified by the gradient vectors in the two-dimensional array
+`<gradients>` to compute the sampling locations.
+
+`<gradients>` is of type `array<T, 2>`, where the first element holds the `ddx`
+derivative and the second holds the `ddy` derivitive.
+The type `T` is dependent on the type of `<texture>`, and is either a
+`vec2<f32>` or `vec3<f32>`:
+
+<table class='data'>
+  <thead>
+    <tr><td>`<texture>` type<td>`T` type
+  </thead>
+  <tr><td> `texture_sampled_2d<type>`         <td> `vec2<f32>`
+  <tr><td> `texture_sampled_2d_array<type>`   <td> `vec2<f32>`
+  <tr><td> `texture_sampled_3d<type>`         <td> `vec3<f32>`
+  <tr><td> `texture_sampled_cube<type>`       <td> `vec3<f32>`
+  <tr><td> `texture_sampled_cube_array<type>` <td> `vec3<f32>`
+  <tr><td> `texture_ro_2d<type>`              <td> `vec2<f32>`
+  <tr><td> `texture_ro_2d_array<type>`        <td> `vec2<f32>`
+  <tr><td> `texture_ro_3d<type>`              <td> `vec3<f32>`
+  <tr><td> `texture_depth_2d`                 <td> `vec2<f32>`
+  <tr><td> `texture_depth_2d_array`           <td> `vec2<f32>`
+  <tr><td> `texture_depth_cube`               <td> `vec3<f32>`
+  <tr><td> `texture_depth_cube_array`         <td> `vec3<f32>`
+</table>
+
+<div class='example' heading="Sample with explicit gradients">
+  <xmp>
+    var gradients : array<vec2<f32>, 2> = array<vec2<f32>, 2>(calcDDX(), calcDDY());
+    color = textureSample(tex2D, s, coords, grad: gradients);
+  </xmp>
+</div>
+
+#### Named Argument Compatibility #### {#texture-sample-named-arg-compatibility}
+
+Not all additional named arguments are compatible with every texture type, nor with each other.
+Consult the following tables for compatibility:
+
+<table class='data'>
+  <caption>Compatibility with texture type</caption>
+  <thead>
+    <tr><td>`<texture>` type                  <td>`offset`<td>`bias`  <td>`lod`   <td>`grad`
+  </thead>
+  <tr><td> `texture_sampled_1d<type>`         <td>&#10003;<td>        <td>        <td>
+  <tr><td> `texture_sampled_1d_array<type>`   <td>&#10003;<td>        <td>        <td>
+  <tr><td> `texture_sampled_2d<type>`         <td>&#10003;<td>&#10003;<td>&#10003;<td>&#10003;
+  <tr><td> `texture_sampled_2d_array<type>`   <td>&#10003;<td>&#10003;<td>&#10003;<td>&#10003;
+  <tr><td> `texture_sampled_3d<type>`         <td>&#10003;<td>&#10003;<td>&#10003;<td>&#10003;
+  <tr><td> `texture_sampled_cube<type>`       <td>        <td>&#10003;<td>&#10003;<td>&#10003;
+  <tr><td> `texture_sampled_cube_array<type>` <td>        <td>&#10003;<td>&#10003;<td>&#10003;
+  <tr><td> `texture_ro_1d<type>`              <td>&#10003;<td>        <td>        <td>
+  <tr><td> `texture_ro_1d_array<type>`        <td>&#10003;<td>        <td>        <td>
+  <tr><td> `texture_ro_2d<type>`              <td>&#10003;<td>&#10003;<td>&#10003;<td>&#10003;
+  <tr><td> `texture_ro_2d_array<type>`        <td>&#10003;<td>&#10003;<td>&#10003;<td>&#10003;
+  <tr><td> `texture_ro_3d<type>`              <td>&#10003;<td>&#10003;<td>&#10003;<td>&#10003;
+  <tr><td> `texture_depth_2d`                 <td>&#10003;<td>&#10003;<td>&#10003;<td>&#10003;
+  <tr><td> `texture_depth_2d_array`           <td>&#10003;<td>&#10003;<td>&#10003;<td>&#10003;
+  <tr><td> `texture_depth_cube`               <td>        <td>&#10003;<td>&#10003;<td>&#10003;
+  <tr><td> `texture_depth_cube_array`         <td>        <td>&#10003;<td>&#10003;<td>&#10003;
+</table>
+
+<table class='data'>
+  <caption>Compatibility with other named arguments</caption>
+  <thead>
+    <tr><td><td>`offset`<td>`bias` <td>`lod`  <td>`grad`
+  </thead>
+  <tr><td> `offset` <td>        <td>&#10003;<td>&#10003;<td>&#10003;
+  <tr><td> `bias`   <td>&#10003;<td>        <td>        <td>
+  <tr><td> `lod`    <td>&#10003;<td>        <td>        <td>
+  <tr><td> `grad`   <td>&#10003;<td>        <td>        <td>
+</table>
+
+### Sample & Compare ### {#texture-sample-compare-functions}
+
+Sampling from a depth texture with a depth-comparison uses the `textureSampleCompare` function:
+
+```
+f32 textureSampleCompare(<depth_texture>, <sampler_comparison>, <coordinates>, f32 depth_reference [, offset: <offset>])
+```
+
+Where:
+
+* `<depth_texture>` is a [depth](#texture-depth) texture type.
+
+* `<sampler_comparison>` is a [sampler comparision](#sampler-type) type.
+
+* `<coordinates>` are the texture coordinates used for sampling.
+    The type for the texture coordinates depends on the `<texture>` type:
+
+    <table class='data'>
+      <thead>
+        <tr><td>`<texture>` type<td>`<coordinates>` type
+      </thead>
+      <tr><td> `texture_depth_2d`         <td> `vec2<f32>`
+      <tr><td> `texture_depth_2d_array`   <td> `vec3<f32>`
+      <tr><td> `texture_depth_cube`       <td> `vec3<f32>`
+      <tr><td> `texture_depth_cube_array` <td> `vec4<f32>`
+    </table>
+
+    Array textures (with `_array` suffix) use the last component of `<coordinates>`
+    to specify array index.
+
+
+Samples the depth value at `<coordinates>`, and compares the sampled value against `depth_reference`
+and returns an `f32` in the range `[0.0 - 1.0]`.
+The comparision operator is defined by the `<sampler_comparison>`.
+
+#### Sample & Compare with texel offset #### {#texture-sample-compare-with-offset}
+
+Following the `depth_reference` parameter, an optional named parameter for specifying an integer texel offset may be specified:
+
+```
+<result> textureSampleCompare(<depth_texture>, <sampler_comparison>, <coordinates>, f32 depth_reference, offset: <offset>)
+```
+
+If specified, the integer texel offset `<offset>` is applied to the texture coordinate before sampling.
+
+The type of `<offset>` is dependent on the type of `<texture>` and is either
+a `vec2<i32>` or `vec3<i32>`:
+
+<table class='data'>
+  <thead>
+    <tr><td>`<texture>` type<td>`<coordinates>` type
+  </thead>
+  <tr><td> `texture_depth_2d`                 <td> `vec2<i32>`
+  <tr><td> `texture_depth_2d_array`           <td> `vec2<i32>`
+  <tr><td> `texture_depth_cube`               <td> `vec3<i32>`
+  <tr><td> `texture_depth_cube_array`         <td> `vec3<i32>`
+</table>
+
+<div class='example' heading="Sample and compare with offset">
+  <xmp>
+    color = textureSampleCompare(depth2D, s, coords, depthRef, offset: vec2<i32>(1, 2));
+  </xmp>
+</div>
+
+**TODO:**
+
 <pre class='def'>
 `vec4<type> textureLoad(texture_ro_1d      , i32       coords)`
 `vec4<type> textureLoad(texture_ro_2d      , vec2<i32> coords)`
@@ -3980,39 +4252,6 @@ TODO: deduplicate these tables
 TODO(dsinclair): Add `textureWrite` method for texture_wo with integral coords
 
 TODO(dsinclair): Allow a small constant offset on the coordinate? May not be portable.
-
-`vec4<type> textureSample(texture_sampled_1d        , sampler, f32       coords)`
-`vec4<type> textureSample(texture_sampled_2d        , sampler, vec2<f32> coords)`
-`vec4<type> textureSample(texture_sampled_1d_array  , sampler, vec2<f32> coords)`
-`vec4<type> textureSample(texture_sampled_3d        , sampler, vec3<f32> coords)`
-`vec4<type> textureSample(texture_sampled_2d_array  , sampler, vec3<f32> coords)`
-`vec4<type> textureSample(texture_sampled_cube      , sampler, vec3<f32> coords)`
-`vec4<type> textureSample(texture_sampled_cube_array, sampler, vec4<f32> coords)`
-  %24 = OpImageSampleImplicitLod %v4float %sampled_image %coords
-
-`vec4<type> textureSampleLevel(texture_sampled_1d        , sampler, f32       coords, f32 lod)`
-`vec4<type> textureSampleLevel(texture_sampled_2d        , sampler, vec2<f32> coords, f32 lod)`
-`vec4<type> textureSampleLevel(texture_sampled_1d_array  , sampler, vec2<f32> coords, f32 lod)`
-`vec4<type> textureSampleLevel(texture_sampled_3d        , sampler, vec3<f32> coords, f32 lod)`
-`vec4<type> textureSampleLevel(texture_sampled_2d_array  , sampler, vec3<f32> coords, f32 lod)`
-`vec4<type> textureSampleLevel(texture_sampled_cube      , sampler, vec3<f32> coords, f32 lod)`
-`vec4<type> textureSampleLevel(texture_sampled_cube_array, sampler, vec4<f32> coords, f32 lod)`
-  %25 = OpImageSampleExplicitLod %v4float %sampled_image %coords Lod %lod
-
-`vec4<type> textureSampleBias(texture_sampled_1d        , sampler, f32       coords, f32 bias)`
-`vec4<type> textureSampleBias(texture_sampled_2d        , sampler, vec2<f32> coords, f32 bias)`
-`vec4<type> textureSampleBias(texture_sampled_1d_array  , sampler, vec2<f32> coords, f32 bias)`
-`vec4<type> textureSampleBias(texture_sampled_3d        , sampler, vec3<f32> coords, f32 bias)`
-`vec4<type> textureSampleBias(texture_sampled_2d_array  , sampler, vec3<f32> coords, f32 bias)`
-`vec4<type> textureSampleBias(texture_sampled_cube      , sampler, vec3<f32> coords, f32 bias)`
-`vec4<type> textureSampleBias(texture_sampled_cube_array, sampler, vec4<f32> coords, f32 bias)`
-  %19 = OpImageSampleImplicitLod %v4float %sampled_image %coords Bias %bias
-
-`f32 textureSampleCompare(texture_depth_2d        , sampler_comparison, vec2<f32> coords, f32 depth_reference)`
-`f32 textureSampleCompare(texture_depth_2d_array  , sampler_comparison, vec3<f32> coords, f32 depth_reference)`
-`f32 textureSampleCompare(texture_depth_cube      , sampler_comparison, vec3<f32> coords, f32 depth_reference)`
-`f32 textureSampleCompare(texture_depth_cube_array, sampler_comparison, vec4<f32> coords, f32 depth_reference)`
-  %65 = OpImageSampleDrefExplicitLod %float %sampled_image %coord %depth_reference Lod %float_0
 
 TODO(dsinclair): Add Level-of-Detail via explicit gradient. "Grad" image operand in SPIR-V
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4118,30 +4118,30 @@ Consult the following tables for compatibility:
 <table class='data'>
   <caption>Compatibility with texture type</caption>
   <thead>
-    <tr><td>`<texture>` type                  <td>`offset`<td>`bias`  <td>`lod`   <td>`grad`
+    <tr><td>`<texture>` type                  <td>`offset`   <td>`bias`     <td>`lod`      <td>`grad`
   </thead>
-  <tr><td> `texture_sampled_1d<type>`         <td>&#10003;<td>        <td>        <td>
-  <tr><td> `texture_sampled_1d_array<type>`   <td>&#10003;<td>        <td>        <td>
-  <tr><td> `texture_sampled_2d<type>`         <td>&#10003;<td>&#10003;<td>&#10003;<td>&#10003;
-  <tr><td> `texture_sampled_2d_array<type>`   <td>&#10003;<td>&#10003;<td>&#10003;<td>&#10003;
-  <tr><td> `texture_sampled_3d<type>`         <td>&#10003;<td>&#10003;<td>&#10003;<td>&#10003;
-  <tr><td> `texture_sampled_cube<type>`       <td>        <td>&#10003;<td>&#10003;<td>&#10003;
-  <tr><td> `texture_sampled_cube_array<type>` <td>        <td>&#10003;<td>&#10003;<td>&#10003;
-  <tr><td> `texture_depth_2d`                 <td>&#10003;<td>&#10003;<td>&#10003;<td>&#10003;
-  <tr><td> `texture_depth_2d_array`           <td>&#10003;<td>&#10003;<td>&#10003;<td>&#10003;
-  <tr><td> `texture_depth_cube`               <td>        <td>&#10003;<td>&#10003;<td>&#10003;
-  <tr><td> `texture_depth_cube_array`         <td>        <td>&#10003;<td>&#10003;<td>&#10003;
+  <tr><td> `texture_sampled_1d<type>`         <td>&checkmark;<td>           <td>           <td>
+  <tr><td> `texture_sampled_1d_array<type>`   <td>&checkmark;<td>           <td>           <td>
+  <tr><td> `texture_sampled_2d<type>`         <td>&checkmark;<td>&checkmark;<td>&checkmark;<td>&checkmark;
+  <tr><td> `texture_sampled_2d_array<type>`   <td>&checkmark;<td>&checkmark;<td>&checkmark;<td>&checkmark;
+  <tr><td> `texture_sampled_3d<type>`         <td>&checkmark;<td>&checkmark;<td>&checkmark;<td>&checkmark;
+  <tr><td> `texture_sampled_cube<type>`       <td>           <td>&checkmark;<td>&checkmark;<td>&checkmark;
+  <tr><td> `texture_sampled_cube_array<type>` <td>           <td>&checkmark;<td>&checkmark;<td>&checkmark;
+  <tr><td> `texture_depth_2d`                 <td>&checkmark;<td>&checkmark;<td>&checkmark;<td>&checkmark;
+  <tr><td> `texture_depth_2d_array`           <td>&checkmark;<td>&checkmark;<td>&checkmark;<td>&checkmark;
+  <tr><td> `texture_depth_cube`               <td>           <td>&checkmark;<td>&checkmark;<td>&checkmark;
+  <tr><td> `texture_depth_cube_array`         <td>           <td>&checkmark;<td>&checkmark;<td>&checkmark;
 </table>
 
 <table class='data'>
   <caption>Compatibility with other named arguments</caption>
   <thead>
-    <tr><td><td>`offset`<td>`bias` <td>`lod`  <td>`grad`
+    <tr><td>        <td>`offset`   <td>`bias`     <td>`lod`      <td>`grad`
   </thead>
-  <tr><td> `offset` <td>        <td>&#10003;<td>&#10003;<td>&#10003;
-  <tr><td> `bias`   <td>&#10003;<td>        <td>        <td>
-  <tr><td> `lod`    <td>&#10003;<td>        <td>        <td>
-  <tr><td> `grad`   <td>&#10003;<td>        <td>        <td>
+  <tr><td> `offset` <td>           <td>&checkmark;<td>&checkmark;<td>&checkmark;
+  <tr><td> `bias`   <td>&checkmark;<td>           <td>           <td>
+  <tr><td> `lod`    <td>&checkmark;<td>           <td>           <td>
+  <tr><td> `grad`   <td>&checkmark;<td>           <td>           <td>
 </table>
 
 ### Sample & Compare ### {#texture-sample-compare-functions}
@@ -4188,23 +4188,16 @@ Following the `depth_reference` parameter, an optional named parameter for speci
 <result> textureSampleCompare(<depth_texture>, <sampler_comparison>, <coordinates>, f32 depth_reference, offset: <offset>)
 ```
 
-If specified, the integer texel offset `<offset>` is applied to the unnormalized texture coordinate before sampling.
+`<offset>` is of type `vec2<i32>` and values may range from `[-8 .. 7]`. Values
+outside of this range will be clamped to the nearest limit.
 
-TODO(ben-clayton): Check if the addressing modes of the sampler (e.g. wrapping) are applied before this offset or after.
+The offset is applied to the unnormalized texture coordinate before sampling.
 
-`<offset>` values may range from `[-8 .. 7]`. Values outside of this range will be clamped to the nearest limit.
+Offsets can only be specified when `<depth_texture>` is of type
+`texture_depth_2d` or `texture_depth_2d_array`.
 
-The type of `<offset>` is dependent on the type of `<texture>` and is either a `vec2<i32>` or `vec3<i32>`:
-
-<table class='data'>
-  <thead>
-    <tr><td>`<texture>` type<td>`<coordinates>` type
-  </thead>
-  <tr><td> `texture_depth_2d`                 <td> `vec2<i32>`
-  <tr><td> `texture_depth_2d_array`           <td> `vec2<i32>`
-  <tr><td> `texture_depth_cube`               <td> `vec3<i32>`
-  <tr><td> `texture_depth_cube_array`         <td> `vec3<i32>`
-</table>
+TODO(ben-clayton): Check if the addressing modes of the sampler (e.g. wrapping)
+are applied before this offset or after.
 
 <div class='example' heading="Sample and compare with offset">
   <xmp>


### PR DESCRIPTION
Instead of having a different `textureSample()` function for each offset, bias, lod and grad variant, this PR proposes using optional named arguments on the `textureSample()` and `textureSampleCompare()` functions.

This PR attempts to cover the union of the supported features of: SPIR-V 1.0, HLSL 5.1, MSL 1.0.

An HTML rendered version can be found at: https://ben-clayton.github.io/gpuweb/wgsl#texture-sample-functions

Issue: #573 