### PR TITLE
[wgsl] Remove the preamble section

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Build Bikeshed
         if: ${{ github.event.workflow_run.event == 'pull_request' && env.PR }}
         run: |
-          pip3 install bikeshed
+          pip3 install bikeshed==2.0.0
           export PATH="$(python3 -m site --user-base)/bin:${PATH}"
           bikeshed update
           mkdir out
@@ -92,6 +92,7 @@ jobs:
             Previews, as seen at the time of posting this comment:
             [**WebGPU**](${{ steps.deployment.outputs.details_url }}/index.html) | [**IDL**](${{ steps.deployment.outputs.details_url }}/webgpu.idl)
             [**WGSL**](${{ steps.deployment.outputs.details_url }}/wgsl.html)
+            <sub>${{ github.event.workflow_run.head_sha }}</sub>
             <!--
             pr;head;sha
             ${{ env.PR }};${{ github.event.workflow_run.head_repository.full_name }};${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,98 @@
+name: Preview PR
+
+on:
+  workflow_run:
+    workflows: ["Build and publish"]
+    types: 
+      - completed
+
+jobs:
+# This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-20.04
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      
+      # Extracts PR from Head SHA
+      - name: Find PR
+        if: ${{ github.event.workflow_run.event == 'pull_request' }}
+        run: |
+          PR=$(curl https://api.github.com/search/issues?q=${{ github.event.workflow_run.head_sha }} |
+          grep -Po "(?<=${{ github.event.workflow_run.repository.full_name }}\/pulls\/)\d*" | head -1)
+          echo "PR=$PR" >> $GITHUB_ENV
+      
+      # Replaces base specs with head specs
+      - name: Pull PR
+        if: ${{ github.event.workflow_run.event == 'pull_request' && env.PR }}
+        run: |
+          rm spec/index.bs
+          rm wgsl/index.bs
+          wget -O spec/index.bs https://raw.githubusercontent.com/${{ github.event.workflow_run.head_repository.full_name }}/${{ github.event.workflow_run.head_sha }}/spec/index.bs
+          wget -O wgsl/index.bs https://raw.githubusercontent.com/${{ github.event.workflow_run.head_repository.full_name }}/${{ github.event.workflow_run.head_sha }}/wgsl/index.bs
+      
+      # Adds Firebase config files to directory
+      - name: Init Firebase
+        if: ${{ github.event.workflow_run.event == 'pull_request' && env.PR }}
+        run: |
+          cat << EOF >> .firebaserc
+          {
+            "projects": {
+              "default": "gpuweb-prs"
+            }
+          }
+          EOF
+          cat << EOF >> firebase.json
+          {
+            "hosting": {
+              "public": "out",
+              "ignore": [
+                "firebase.json",
+                "**/.*",
+                "**/node_modules/**"
+              ]
+            }
+          }
+          EOF
+
+      # Builds Bikeshed specs
+      - name: Build Bikeshed
+        if: ${{ github.event.workflow_run.event == 'pull_request' && env.PR }}
+        run: |
+          pip3 install bikeshed
+          export PATH="$(python3 -m site --user-base)/bin:${PATH}"
+          bikeshed update --skip-manifest
+          mkdir out
+          make -C spec
+          make -C wgsl
+          cp spec/index.html out/index.html
+          cp spec/webgpu.idl out/webgpu.idl
+          cp wgsl/index.html out/wgsl.html
+      
+      # Deploys PR to Firebase
+      - name: Deploy PR
+        id: deployment
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        if: ${{ github.event.workflow_run.event == 'pull_request' && env.PR }}
+        with:
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          expires: 30d
+          channelId: prs-${{ env.PR }}-${{ github.event.workflow_run.head_sha }}
+        
+      # Comments on PR
+      - name: Comment PR
+        uses: peter-evans/create-or-update-comment@v1
+        if: ${{ github.event.workflow_run.event == 'pull_request' && env.PR }}
+        with:
+          issue-number: ${{ env.PR }}
+          body: |
+            Previews, as seen at the time of posting this comment:
+            [**WebGPU**](${{ steps.deployment.outputs.details_url }}/index.html) | [**IDL**](${{ steps.deployment.outputs.details_url }}/webgpu.idl)
+            [**WGSL**](${{ steps.deployment.outputs.details_url }}/wgsl.html)
+            <!--
+            pr;head;sha
+            ${{ env.PR }};${{ github.event.workflow_run.head_repository.full_name }};${{ github.event.workflow_run.head_sha }}
+            -->

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           pip3 install bikeshed
           export PATH="$(python3 -m site --user-base)/bin:${PATH}"
-          bikeshed update --skip-manifest
+          bikeshed update
           mkdir out
           make -C spec
           make -C wgsl

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,10 +11,9 @@ jobs:
 
       - name: Build with bikeshed
         run: |
-          git clone --depth 1 https://github.com/tabatkins/bikeshed.git
-          pip3 install --user --editable ./bikeshed
+          pip3 install bikeshed
           export PATH="$(python3 -m site --user-base)/bin:${PATH}"
-          bikeshed update
+          bikeshed update --skip-manifest
           mkdir out
           ./compile.sh
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,9 +11,9 @@ jobs:
 
       - name: Build with bikeshed
         run: |
-          pip3 install bikeshed
+          pip3 install bikeshed==2.0.0
           export PATH="$(python3 -m site --user-base)/bin:${PATH}"
-          bikeshed update --skip-manifest
+          bikeshed update
           mkdir out
           ./compile.sh
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4445,6 +4445,7 @@ dictionary GPUTextureCopyView {
     required GPUTexture texture;
     GPUIntegerCoordinate mipLevel = 0;
     GPUOrigin3D origin = {};
+    GPUTextureAspect aspect = "all";
 };
 </script>
 
@@ -4458,6 +4459,7 @@ offset {{GPUOrigin3D}} in texels, used when copying data from or to a {{GPUTextu
 
   **Arguments:**
     - {{GPUTextureCopyView}} |textureCopyView|
+    - {{GPUExtent3D}} |copySize|
 
   **Returns:** {{boolean}}
 
@@ -4471,6 +4473,10 @@ offset {{GPUOrigin3D}} in texels, used when copying data from or to a {{GPUTextu
     |textureCopyView|.{{GPUTextureCopyView/texture}}.
   - |textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/x=] must be a multiple of |blockWidth|.
   - |textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/y=] must be a multiple of |blockHeight|.
+  - The [=textureCopyView subresource size=] of |textureCopyView| is equal to |copySize| if either of
+      the following conditions is true:
+        - |textureCopyView|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format.
+        - |textureCopyView|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is greater than 1.
 
 </div>
 
@@ -4677,10 +4683,14 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
                 - [$validating GPUBufferCopyView$](|source|) returns `true`.
                 - |source|.{{GPUBufferCopyView/buffer}}.{{GPUBuffer/[[usage]]}} contains
                     {{GPUBufferUsage/COPY_SRC}}.
-                - [$validating GPUTextureCopyView$](|destination|) returns `true`.
+                - [$validating GPUTextureCopyView$](|destination|, |copySize|) returns `true`.
                 - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}} contains
                     {{GPUTextureUsage/COPY_DST}}.
                 - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is 1.
+                - If |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format:
+                    - |destination|.{{GPUTextureCopyView/aspect}} must refer to a single copyable aspect of
+                        |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
+                        See [[#depth-formats|depth-formats]].
                 - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
                 - |source|.{{GPUTextureDataLayout/offset}} is a multiple of the [=texel block size=]
                     of |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
@@ -4711,10 +4721,14 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
             If any of the following conditions are unsatisfied, generate a validation error and stop.
             <div class=validusage>
                 - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
-                - [$validating GPUTextureCopyView$](|source|) returns `true`.
+                - [$validating GPUTextureCopyView$](|source|, |copySize|) returns `true`.
                 - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}} contains
                     {{GPUTextureUsage/COPY_SRC}}.
                 - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is 1.
+                - If |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format:
+                    - |source|.{{GPUTextureCopyView/aspect}} must refer to a single copyable aspect of
+                        |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
+                        See [[#depth-formats|depth-formats]].
                 - [$validating GPUBufferCopyView$](|destination|) returns `true`.
                 - |destination|.{{GPUBufferCopyView/buffer}}.{{GPUBuffer/[[usage]]}} contains
                     {{GPUBufferUsage/COPY_DST}}.
@@ -4746,27 +4760,23 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
 
             **Returns:** {{undefined}}
 
-            1. Let |copy of the whole subresource| be the command |this|.{{GPUCommandEncoder/copyTextureToTexture()}}
-                whose parameters |source|, |destination| and |copySize| meet the following conditions:
-                - The [=textureCopyView subresource size=] of |source| is equal to |copySize|.
-                - The [=textureCopyView subresource size=] of |destination| is equal to |copySize|.
             1. If any of the following conditions are unsatisfied, generate a validation error and stop.
                 <div class=validusage>
                     - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
-                    - [$validating GPUTextureCopyView$](|source|) returns `true`.
+                    - [$validating GPUTextureCopyView$](|source|, |copySize|) returns `true`.
                     - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}} contains
                         {{GPUTextureUsage/COPY_SRC}}.
-                    - [$validating GPUTextureCopyView$](|destination|) returns `true`.
+                    - [$validating GPUTextureCopyView$](|destination|, |copySize|) returns `true`.
                     - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}} contains
                         {{GPUTextureUsage/COPY_DST}}.
                     - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is equal to |destination|.
                         {{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}}.
-                    - If |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is greater than 1:
-                        - The copy with |source|, |destination| and |copySize| is a |copy of the whole subresource|.
                     - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} is equal to |destination|.
                         {{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
                     - If |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format:
-                        - The copy with |source|, |destination| and |copySize| is a |copy of the whole subresource|.
+                        - |source|.{{GPUTextureCopyView/aspect}} and |destination|.{{GPUTextureCopyView/aspect}}
+                            must both refer to all aspects of |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}
+                            and |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}, respectively.
                     - [=Valid Texture Copy Range=] applies to |source| and |copySize|.
                     - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
                     - The [$set of subresources for texture copy$](|source|, |copySize|) and
@@ -6441,12 +6451,15 @@ GPUQueue includes GPUObjectBase;
                     1. If any of the following conditions are unsatisfied,
                         generate a validation error and stop.
                         <div class=validusage>
-                            - [$validating GPUTextureCopyView$](|destination|) returns `true`.
+                            - [$validating GPUTextureCopyView$](|destination|, |size|) returns `true`.
                             - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}}
                                 includes {{GPUTextureUsage/COPY_DST}}.
                             - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is 1.
                             - [=Valid Texture Copy Range=](|destination|, |size|)
                                 is satisfied.
+                            - |destination|.{{GPUTextureCopyView/aspect}} refers to a single copyable aspect
+                                of |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
+                                See [[#depth-formats|depth-formats]].
 
                             Note: unlike
                             {{GPUCommandEncoder}}.{{GPUCommandEncoder/copyBufferToTexture()}},

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -690,7 +690,7 @@ the user behind an `ArrayBuffer`, thus avoiding any data copies.
 
 ### Resource Usages ### {#programming-model-resource-usages}
 
-A [=physical resource=] can be used on GPU in one of the following <dfn dfn>internal usage</dfn>s:
+A [=physical resource=] can be used on GPU with an <dfn dfn>internal usage</dfn>:
 <dl dfn-type=dfn dfn-for="internal usage">
     : <dfn>input</dfn>
     :: Buffer with input data for draw or dispatch calls. Preserves the contents.
@@ -725,7 +725,7 @@ and [=aspect=].
 We define <dfn dfn>subresource</dfn> to be either a whole buffer, or a [=texture subresource=].
 
 <div algorithm="compatible usage list">
-Some [=internal usage=]s are compatible with others. A [=subresource=] can be in a state
+Some [=internal usages=] are compatible with others. A [=subresource=] can be in a state
 that combines multiple usages together. We consider a list |U| to be
 a <dfn dfn>compatible usage list</dfn> if (and only if) it satisfies any of the following rules:
     - Each usage in |U| is [=internal usage/input=], [=internal usage/constant=], [=internal usage/storage-read=], or [=internal usage/attachment-read=].
@@ -764,9 +764,9 @@ The <dfn dfn>physical size</dfn> of a [=texture subresource=] is the dimension o
 [=texture subresource=] in texels that includes the possible extra paddings
 to form complete [=texel blocks=] in the [=subresource=].
 
-  - For pixel-based {{GPUTextureFormat}}s, the [=physical size=] is always equal to the size of the [=texture subresource=]
+  - For pixel-based {{GPUTextureFormat|GPUTextureFormats}}, the [=physical size=] is always equal to the size of the [=texture subresource=]
     used in the sampling hardwares.
-  - {{GPUTexture}}s in block-based compressed {{GPUTextureFormat}}s always have a [=mipmap level=] 0 whose {{GPUTexture/[[textureSize]]}}
+  - [=Textures=] in block-based compressed {{GPUTextureFormat|GPUTextureFormats}} always have a [=mipmap level=] 0 whose {{GPUTexture/[[textureSize]]}}
     is a multiple of the [=texel block size=], but the lower mipmap levels might not be the multiple of the [=texel block size=] and can
     have paddings.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6049,7 +6049,7 @@ attachments used by this encoder.
                             |this|.{{GPURenderPassEncoder/[[attachment_size]]}}.height.
                         - |minDepth| is greater than or equal to `0.0` and less than or equal to `1.0`.
                         - |maxDepth| is greater than or equal to `0.0` and less than or equal to `1.0`.
-                        - |minDepth| is greater than |maxDepth|.
+                        - |maxDepth| is greater than |minDepth|.
                     </div>
                 1. Set the viewport to the extents |x|, |y|, |width|, |height|, |minDepth|, and |maxDepth|.
             </div>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -676,25 +676,25 @@ type.
 ### Sampled Texture Types ### {#sampled-texture-type}
 
 <pre class='def'>
-`texture_sampled_1d<type>`
+`texture_1d<type>`
   %1 = OpTypeImage %type 1D 0 0 0 1 Unknown
 
-`texture_sampled_1d_array<type>`
+`texture_1d_array<type>`
   %1 = OpTypeImage %type 1D 0 1 0 1 Unknown
 
-`texture_sampled_2d<type>`
+`texture_2d<type>`
   %1 = OpTypeImage %type 2D 0 0 0 1 Unknown
 
-`texture_sampled_2d_array<type>`
+`texture_2d_array<type>`
   %1 = OpTypeImage %type 2D 0 1 0 1 Unknown
 
-`texture_sampled_3d<type>`
+`texture_3d<type>`
   %1 = OpTypeImage %type 3D 0 0 0 1 Unknown
 
-`texture_sampled_cube<type>`
+`texture_cube<type>`
   %1 = OpTypeImage %type Cube 0 0 0 1 Unknown
 
-`texture_sampled_cube_array<type>`
+`texture_cube_array<type>`
   %1 = OpTypeImage %type Cube 0 1 0 1 Unknown
 </pre>
 * type must be `f32`, `i32` or `u32`
@@ -717,19 +717,19 @@ may be read, without the use of a sampler.
 See [[#texture-builtin-functions]].
 
 <pre class='def'>
-`texture_ro_1d<image_storage_type>`
+`texture_storage_ro_1d<image_storage_type>`
   %1 = OpTypeImage type(image_storage_type) 1D 0 0 0 2 image_storage_type
 
-`texture_ro_1d_array<image_storage_type>`
+`texture_storage_ro_1d_array<image_storage_type>`
   %1 = OpTypeImage type(image_storage_type) 1D 0 1 0 2 image_storage_type
 
-`texture_ro_2d<image_storage_type>`
+`texture_storage_ro_2d<image_storage_type>`
   %1 = OpTypeImage type(image_storage_type) 0 0 0 2 image_storage_type
 
-`texture_ro_2d_array<image_storage_type>`
+`texture_storage_ro_2d_array<image_storage_type>`
   %1 = OpTypeImage type(image_storage_type) 0 1 0 2 image_storage_type
 
-`texture_ro_3d<image_storage_type>`
+`texture_storage_ro_3d<image_storage_type>`
   %1 = OpTypeImage type(image_storage_type) 3D 0 0 0 2 image_storage_type
 </pre>
 * type(image_storage_type) is one of `f32`, `i32`, or `u32`, depending on the storage type.
@@ -737,9 +737,9 @@ See [[#texture-builtin-functions]].
 When mapping to SPIR-V, a read-only storage texture variable must also have a `NonWritable` decoration.
 For example:
 
-<div class='example' heading='Mapping a texture_ro_1d variable to SPIR-V'>
+<div class='example' heading='Mapping a texture_storage_ro_1d variable to SPIR-V'>
   <xmp>
-      var<uniform_constant> tbuf : texture_ro_1d<rgba8unorm>;
+      var tbuf : texture_storage_ro_1d<rgba8unorm>;
 
       # Maps to the following SPIR-V:
       #  OpDecorate %tbuf NonWritable
@@ -758,28 +758,28 @@ may be written.
 See [[#texture-builtin-functions]].
 
 <pre class='def'>
-`texture_wo_1d<image_storage_type>`
+`texture_storage_wo_1d<image_storage_type>`
   %1 = OpTypeImage %void 1D 0 0 0 2 image_storage_type
 
-`texture_wo_1d_array<image_storage_type>`
+`texture_storage_wo_1d_array<image_storage_type>`
   %1 = OpTypeImage %void 1D 0 1 0 2 image_storage_type
 
-`texture_wo_2d<image_storage_type>`
+`texture_storage_wo_2d<image_storage_type>`
   %1 = OpTypeImage %void 2D 0 0 0 2 image_storage_type
 
-`texture_wo_2d_array<image_storage_type>`
+`texture_storage_wo_2d_array<image_storage_type>`
   %1 = OpTypeImage %void 2D 0 1 0 2 image_storage_type
 
-`texture_wo_3d<image_storage_type>`
+`texture_storage_wo_3d<image_storage_type>`
   %1 = OpTypeImage %void 3D 0 0 0 2 image_storage_type
 </pre>
 
 When mapping to SPIR-V, a write-only storage texture variable must also have a `NonReadable` decoration.
 For example:
 
-<div class='example' heading='Mapping a texture_wo_1d variable to SPIR-V'>
+<div class='example' heading='Mapping a texture_storage_wo_1d variable to SPIR-V'>
   <xmp>
-      var<uniform_constant> tbuf : texture_wo_1d<rgba8unorm>;
+      var tbuf : texture_storage_wo_1d<rgba8unorm>;
 
       # Maps to the following SPIR-V:
       #  OpDecorate %tbuf NonReadable
@@ -831,28 +831,28 @@ sampler_type
   | SAMPLER_COMPARISON
 
 sampled_texture_type
-  : TEXTURE_SAMPLED_1D
-  | TEXTURE_SAMPLED_1D_ARRAY
-  | TEXTURE_SAMPLED_2D
-  | TEXTURE_SAMPLED_2D_ARRAY
-  | TEXTURE_SAMPLED_3D
-  | TEXTURE_SAMPLED_CUBE
-  | TEXTURE_SAMPLED_CUBE_ARRAY
+  : TEXTURE_1D
+  | TEXTURE_1D_ARRAY
+  | TEXTURE_2D
+  | TEXTURE_2D_ARRAY
+  | TEXTURE_3D
+  | TEXTURE_CUBE
+  | TEXTURE_CUBE_ARRAY
 
 multisampled_texture_type
   : TEXTURE_MULTISAMPLED_2D
 
 storage_texture_type
-  : TEXTURE_RO_1D
-  | TEXTURE_RO_1D_ARRAY
-  | TEXTURE_RO_2D
-  | TEXTURE_RO_2D_ARRAY
-  | TEXTURE_RO_3D
-  | TEXTURE_WO_1D
-  | TEXTURE_WO_1D_ARRAY
-  | TEXTURE_WO_2D
-  | TEXTURE_WO_2D_ARRAY
-  | TEXTURE_WO_3D
+  : TEXTURE_STORAGE_RO_1D
+  | TEXTURE_STORAGE_RO_1D_ARRAY
+  | TEXTURE_STORAGE_RO_2D
+  | TEXTURE_STORAGE_RO_2D_ARRAY
+  | TEXTURE_STORAGE_RO_3D
+  | TEXTURE_STORAGE_WO_1D
+  | TEXTURE_STORAGE_WO_1D_ARRAY
+  | TEXTURE_STORAGE_WO_2D
+  | TEXTURE_STORAGE_WO_2D_ARRAY
+  | TEXTURE_STORAGE_WO_3D
 
 depth_texture_type
   : TEXTURE_DEPTH_2D
@@ -3295,24 +3295,24 @@ Issue: (dneto) Default rounding mode is an implementation choice.  Is that what 
   <tr><td>`SAMPLER`<td>sampler
   <tr><td>`SAMPLER_COMPARISON`<td>sampler_comparison
   <tr><td>`STRUCT`<td>struct
-  <tr><td>`TEXTURE_SAMPLED_1D`<td>texture_sampled_1d
-  <tr><td>`TEXTURE_SAMPLED_1D_ARRAY`<td>texture_sampled_1d_array
-  <tr><td>`TEXTURE_SAMPLED_2D`<td>texture_sampled_2d
-  <tr><td>`TEXTURE_SAMPLED_2D_ARRAY`<td>texture_sampled_2d_array
-  <tr><td>`TEXTURE_SAMPLED_3D`<td>texture_sampled_3d
-  <tr><td>`TEXTURE_SAMPLED_CUBE`<td>texture_sampled_cube
-  <tr><td>`TEXTURE_SAMPLED_CUBE_ARRAY`<td>texture_sampled_cube_array
+  <tr><td>`TEXTURE_1D`<td>texture_1d
+  <tr><td>`TEXTURE_1D_ARRAY`<td>texture_1d_array
+  <tr><td>`TEXTURE_2D`<td>texture_2d
+  <tr><td>`TEXTURE_2D_ARRAY`<td>texture_2d_array
+  <tr><td>`TEXTURE_3D`<td>texture_3d
+  <tr><td>`TEXTURE_CUBE`<td>texture_cube
+  <tr><td>`TEXTURE_CUBE_ARRAY`<td>texture_cube_array
   <tr><td>`TEXTURE_MULTISAMPLED_2D`<td>texture_multisampled_2d
-  <tr><td>`TEXTURE_RO_1D`<td>texture_ro_1d
-  <tr><td>`TEXTURE_RO_1D_ARRAY`<td>texture_ro_1d_array
-  <tr><td>`TEXTURE_RO_2D`<td>texture_ro_2d
-  <tr><td>`TEXTURE_RO_2D_ARRAY`<td>texture_ro_2d_array
-  <tr><td>`TEXTURE_RO_3D`<td>texture_ro_3d
-  <tr><td>`TEXTURE_WO_1D`<td>texture_wo_1d
-  <tr><td>`TEXTURE_WO_1D_ARRAY`<td>texture_wo_1d_array
-  <tr><td>`TEXTURE_WO_2D`<td>texture_wo_2d
-  <tr><td>`TEXTURE_WO_2D_ARRAY`<td>texture_wo_2d_array
-  <tr><td>`TEXTURE_WO_3D`<td>texture_wo_3d
+  <tr><td>`TEXTURE_STORAGE_RO_1D`<td>texture_storage_ro_1d
+  <tr><td>`TEXTURE_STORAGE_RO_1D_ARRAY`<td>texture_storage_ro_1d_array
+  <tr><td>`TEXTURE_STORAGE_RO_2D`<td>texture_storage_ro_2d
+  <tr><td>`TEXTURE_STORAGE_RO_2D_ARRAY`<td>texture_storage_ro_2d_array
+  <tr><td>`TEXTURE_STORAGE_RO_3D`<td>texture_storage_ro_3d
+  <tr><td>`TEXTURE_STORAGE_WO_1D`<td>texture_storage_wo_1d
+  <tr><td>`TEXTURE_STORAGE_WO_1D_ARRAY`<td>texture_storage_wo_1d_array
+  <tr><td>`TEXTURE_STORAGE_WO_2D`<td>texture_storage_wo_2d
+  <tr><td>`TEXTURE_STORAGE_WO_2D_ARRAY`<td>texture_storage_wo_2d_array
+  <tr><td>`TEXTURE_STORAGE_WO_3D`<td>texture_storage_wo_3d
   <tr><td>`TEXTURE_DEPTH_2D`<td>texture_depth_2d
   <tr><td>`TEXTURE_DEPTH_2D_ARRAY`<td>texture_depth_2d_array
   <tr><td>`TEXTURE_DEPTH_CUBE`<td>texture_depth_cube
@@ -4181,52 +4181,52 @@ TODO: deduplicate these tables
 ## Texture built-in functions ## {#texture-builtin-functions}
 
 <pre class='def'>
-`vec4<type> textureLoad(texture_ro_1d      , i32       coords)`
-`vec4<type> textureLoad(texture_ro_2d      , vec2<i32> coords)`
-`vec4<type> textureLoad(texture_ro_1d_array, vec2<i32> coords)`
-`vec4<type> textureLoad(texture_ro_3d      , vec3<i32> coords)`
-`vec4<type> textureLoad(texture_ro_2d_array, vec3<i32> coords)`
-  %32 = OpImageRead %v4float %texture_ro %coords
+`vec4<type> textureLoad(texture_storage_ro_1d      , i32       coords)`
+`vec4<type> textureLoad(texture_storage_ro_2d      , vec2<i32> coords)`
+`vec4<type> textureLoad(texture_storage_ro_1d_array, vec2<i32> coords)`
+`vec4<type> textureLoad(texture_storage_ro_3d      , vec3<i32> coords)`
+`vec4<type> textureLoad(texture_storage_ro_2d_array, vec3<i32> coords)`
+  %32 = OpImageRead %v4float %texture_storage_ro %coords
 
-`vec4<type> textureLoad(texture_sampled_1d      , i32       coords, i32 level_of_detail)`
-`vec4<type> textureLoad(texture_sampled_2d      , vec2<i32> coords, i32 level_of_detail)`
-`vec4<type> textureLoad(texture_sampled_1d_array, vec2<i32> coords, i32 level_of_detail)`
-`vec4<type> textureLoad(texture_sampled_3d      , vec3<i32> coords, i32 level_of_detail)`
-`vec4<type> textureLoad(texture_sampled_2d_array, vec3<i32> coords, i32 level_of_detail)`
-  %32 = OpImageFetch %v4float %texture_sampled %coords Lod %level_of_detail
+`vec4<type> textureLoad(texture_1d      , i32       coords, i32 level_of_detail)`
+`vec4<type> textureLoad(texture_2d      , vec2<i32> coords, i32 level_of_detail)`
+`vec4<type> textureLoad(texture_1d_array, vec2<i32> coords, i32 level_of_detail)`
+`vec4<type> textureLoad(texture_3d      , vec3<i32> coords, i32 level_of_detail)`
+`vec4<type> textureLoad(texture_2d_array, vec3<i32> coords, i32 level_of_detail)`
+  %32 = OpImageFetch %v4float %texture %coords Lod %level_of_detail
 
 `vec4<type> textureLoad(texture_multisampled_2d, vec2<i32> coords, i32 sample_index)`
   %32 = OpImageFetch %v4float %texture_multisampled %coords Sample %sample_index
 
-TODO(dsinclair): Add `textureWrite` method for texture_wo with integral coords
+TODO(dsinclair): Add `textureWrite` method for texture_storage_wo with integral coords
 
 TODO(dsinclair): Allow a small constant offset on the coordinate? May not be portable.
 
-`vec4<type> textureSample(texture_sampled_1d        , sampler, f32       coords)`
-`vec4<type> textureSample(texture_sampled_2d        , sampler, vec2<f32> coords)`
-`vec4<type> textureSample(texture_sampled_1d_array  , sampler, vec2<f32> coords)`
-`vec4<type> textureSample(texture_sampled_3d        , sampler, vec3<f32> coords)`
-`vec4<type> textureSample(texture_sampled_2d_array  , sampler, vec3<f32> coords)`
-`vec4<type> textureSample(texture_sampled_cube      , sampler, vec3<f32> coords)`
-`vec4<type> textureSample(texture_sampled_cube_array, sampler, vec4<f32> coords)`
+`vec4<type> textureSample(texture_1d        , sampler, f32       coords)`
+`vec4<type> textureSample(texture_2d        , sampler, vec2<f32> coords)`
+`vec4<type> textureSample(texture_1d_array  , sampler, vec2<f32> coords)`
+`vec4<type> textureSample(texture_3d        , sampler, vec3<f32> coords)`
+`vec4<type> textureSample(texture_2d_array  , sampler, vec3<f32> coords)`
+`vec4<type> textureSample(texture_cube      , sampler, vec3<f32> coords)`
+`vec4<type> textureSample(texture_cube_array, sampler, vec4<f32> coords)`
   %24 = OpImageSampleImplicitLod %v4float %sampled_image %coords
 
-`vec4<type> textureSampleLevel(texture_sampled_1d        , sampler, f32       coords, f32 lod)`
-`vec4<type> textureSampleLevel(texture_sampled_2d        , sampler, vec2<f32> coords, f32 lod)`
-`vec4<type> textureSampleLevel(texture_sampled_1d_array  , sampler, vec2<f32> coords, f32 lod)`
-`vec4<type> textureSampleLevel(texture_sampled_3d        , sampler, vec3<f32> coords, f32 lod)`
-`vec4<type> textureSampleLevel(texture_sampled_2d_array  , sampler, vec3<f32> coords, f32 lod)`
-`vec4<type> textureSampleLevel(texture_sampled_cube      , sampler, vec3<f32> coords, f32 lod)`
-`vec4<type> textureSampleLevel(texture_sampled_cube_array, sampler, vec4<f32> coords, f32 lod)`
+`vec4<type> textureSampleLevel(texture_1d        , sampler, f32       coords, f32 lod)`
+`vec4<type> textureSampleLevel(texture_2d        , sampler, vec2<f32> coords, f32 lod)`
+`vec4<type> textureSampleLevel(texture_1d_array  , sampler, vec2<f32> coords, f32 lod)`
+`vec4<type> textureSampleLevel(texture_3d        , sampler, vec3<f32> coords, f32 lod)`
+`vec4<type> textureSampleLevel(texture_2d_array  , sampler, vec3<f32> coords, f32 lod)`
+`vec4<type> textureSampleLevel(texture_cube      , sampler, vec3<f32> coords, f32 lod)`
+`vec4<type> textureSampleLevel(texture_cube_array, sampler, vec4<f32> coords, f32 lod)`
   %25 = OpImageSampleExplicitLod %v4float %sampled_image %coords Lod %lod
 
-`vec4<type> textureSampleBias(texture_sampled_1d        , sampler, f32       coords, f32 bias)`
-`vec4<type> textureSampleBias(texture_sampled_2d        , sampler, vec2<f32> coords, f32 bias)`
-`vec4<type> textureSampleBias(texture_sampled_1d_array  , sampler, vec2<f32> coords, f32 bias)`
-`vec4<type> textureSampleBias(texture_sampled_3d        , sampler, vec3<f32> coords, f32 bias)`
-`vec4<type> textureSampleBias(texture_sampled_2d_array  , sampler, vec3<f32> coords, f32 bias)`
-`vec4<type> textureSampleBias(texture_sampled_cube      , sampler, vec3<f32> coords, f32 bias)`
-`vec4<type> textureSampleBias(texture_sampled_cube_array, sampler, vec4<f32> coords, f32 bias)`
+`vec4<type> textureSampleBias(texture_1d        , sampler, f32       coords, f32 bias)`
+`vec4<type> textureSampleBias(texture_2d        , sampler, vec2<f32> coords, f32 bias)`
+`vec4<type> textureSampleBias(texture_1d_array  , sampler, vec2<f32> coords, f32 bias)`
+`vec4<type> textureSampleBias(texture_3d        , sampler, vec3<f32> coords, f32 bias)`
+`vec4<type> textureSampleBias(texture_2d_array  , sampler, vec3<f32> coords, f32 bias)`
+`vec4<type> textureSampleBias(texture_cube      , sampler, vec3<f32> coords, f32 bias)`
+`vec4<type> textureSampleBias(texture_cube_array, sampler, vec4<f32> coords, f32 bias)`
   %19 = OpImageSampleImplicitLod %v4float %sampled_image %coords Bias %bias
 
 `f32 textureSampleCompare(texture_depth_2d        , sampler_comparison, vec2<f32> coords, f32 depth_reference)`

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -72,7 +72,7 @@ TODO: What indicates the end of a line?  (E.g. A line ends at the next linefeed 
 
 <table class='data'>
   <thead>
-    <tr><td>Token<td>Definition
+    <tr><th>Token<th>Definition
   </thead>
   <tr><td>`FLOAT_LITERAL`<td>`(-?[0-9]*.[0-9]+ | -?[0-9]+.[0-9]*)((e|E)(+|-)?[0-9]+)?`
   <tr><td>`INT_LITERAL`<td>`-?0x[0-9a-fA-F]+ | 0 | -?[1-9][0-9]*`
@@ -105,7 +105,7 @@ See [[#keyword-summary]] for a list of keywords.
 
 <table class='data'>
   <thead>
-    <tr><td>Token<td>Definition
+    <tr><th>Token<th>Definition
   </thead>
   <tr><td>`IDENT`<td>`[a-zA-Z][0-9a-zA-Z_]*`
 </table>
@@ -244,7 +244,7 @@ The <dfn dfn noexport>numeric scalar</dfn> types are [=i32=], [=u32=], and [=f32
 ### Vector Types ### {#vector-types}
 <table class='data'>
   <thead>
-    <tr><td>Type<td>Description
+    <tr><th>Type<th>Description
   </thead>
   <tr><td>vec*N*<*T*><td>Vector of *N* elements of type *T*.
                           *N* must be in {2, 3, 4} and *T*
@@ -263,7 +263,7 @@ A vector type is a <dfn dfn>numeric vector</dfn> type if its component type is a
 ### Matrix Types ### {#matrix-types}
 <table class='data'>
   <thead>
-    <tr><td>Type<td>Description
+    <tr><th>Type<th>Description
   </thead>
   <tr><td>mat*N*x*M*<*T*><td>Matrix of *N* columns and *M* rows, where
                                 *N* and *M* are both in {2, 3, 4}.
@@ -279,7 +279,7 @@ A vector type is a <dfn dfn>numeric vector</dfn> type if its component type is a
 ### Array Types ### {#array-types}
 <table class='data'>
   <thead>
-    <tr><td>Type<td>Description
+    <tr><th>Type<th>Description
   </thead>
   <tr><td>array<*E*,*N*><td>An *N*-element array of elements of type *E*.<br>
   <tr><td>array<*E*><td>A <dfn noexport>runtime-sized</dfn> array of elements of type *E*,
@@ -299,7 +299,7 @@ Issue: (dneto): Complete description of `Array<E,N>`
 ### Structure Types ### {#struct-types}
 <table class='data'>
   <thead>
-    <tr><td>Type<td>Description
+    <tr><th>Type<th>Description
   </thead>
   <tr><td>struct<*T1*,...,*Tn*><td>An ordered tuple of *N* members of types
                                     *T1* through *Tn*, with *N* being an
@@ -450,12 +450,12 @@ and how to use variables with it.
 
 <table class='data'>
   <thead>
-    <tr><td>Storage class
-        <td>Readable by shader?<br>Writable by shader?
-        <td>Sharing among invocations
-        <td>Variable scope
-        <td>Restrictions on stored values
-        <td>Notes
+    <tr><th>Storage class
+        <th>Readable by shader?<br>Writable by shader?
+        <th>Sharing among invocations
+        <th>Variable scope
+        <th>Restrictions on stored values
+        <th>Notes
   </thead>
   <tr><td>in
       <td>Read-only
@@ -531,7 +531,7 @@ storage_class
 
 <table class='data'>
   <thead>
-    <tr><td>WGSL storage class<td>SPIR-V storage class
+    <tr><th>WGSL storage class<th>SPIR-V storage class
   </thead>
   <tr><td>in<td>Input
   <tr><td>out<td>Output
@@ -560,7 +560,7 @@ TODO: <dfn noexport>layout attribute</dfn>
 ## Pointer Types TODO ## {#pointer-types}
 <table class='data'>
   <thead>
-    <tr><td>Type<td>Description
+    <tr><th>Type<th>Description
   </thead>
   <tr><td>ptr<*SC*,*T*><td>Pointer (or reference) to storage in [[#storage-class]] *SC*
                             which can hold a value of the [=storable=] *T*.
@@ -1151,7 +1151,7 @@ literal_or_ident
 
 <table class='data'>
   <thead>
-    <tr><td>Variable decoration keys<td>Valid values
+    <tr><th>Variable decoration keys<th>Valid values
   </thead>
   <tr><td>`binding`<td>u32 literal
   <tr><td>`builtin`<td>a Builtin Decoration Identifier (listed below)
@@ -1292,7 +1292,7 @@ and third clauses and in the body of the `for` statement.
 <table class='data'>
   <caption>Scalar literal type rules</caption>
   <thead>
-    <tr><td>Precondition<td>Conclusion<td>Notes
+    <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr><td><td>`true` : bool<td>OpConstantTrue %bool
   <tr><td><td>`false` : bool<td>OpConstantFalse %bool
@@ -1306,7 +1306,7 @@ and third clauses and in the body of the `for` statement.
 <table class='data'>
   <caption>Scalar constructor type rules</caption>
   <thead>
-    <tr><td>Precondition<td>Conclusion<td>Notes
+    <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr><td>*e* : bool<td>`bool(e)` : bool<td>Pass-through (OpCopyObject)
   <tr><td>*e* : i32<td>`i32(e)` : i32<td>Pass-through (OpCopyObject)
@@ -1317,7 +1317,7 @@ and third clauses and in the body of the `for` statement.
 <table class='data'>
   <caption>Vector constructor type rules, where *T* is a scalar type</caption>
   <thead>
-    <tr><td>Precondition<td>Conclusion<td>Notes
+    <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr>
     <td>*e1* : *T*<br>
@@ -1367,7 +1367,7 @@ and third clauses and in the body of the `for` statement.
 <table class='data'>
   <caption>Matrix constructor type rules</caption>
   <thead>
-    <tr><td>Precondition<td>Conclusion<td>Notes
+    <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr>
     <td>*e1* : vec2<f32><br>
@@ -1404,7 +1404,7 @@ and third clauses and in the body of the `for` statement.
 <table class='data'>
   <caption>Array constructor type rules</caption>
   <thead>
-    <tr><td>Precondition<td>Conclusion<td>Notes
+    <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr>
     <td>*e1* : *T*<br>
@@ -1418,7 +1418,7 @@ TODO: Should this only work for storable sized arrays?  https://github.com/gpuwe
 <table class='data'>
   <caption>Structure constructor type rules</caption>
   <thead>
-    <tr><td>Precondition<td>Conclusion<td>Notes
+    <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr>
     <td>*e1* : *T1*<br>
@@ -1455,7 +1455,7 @@ The zero values are as follows:
 <table class='data'>
   <caption>Scalar zero value type rules</caption>
   <thead>
-    <tr><td>Precondition<td>Conclusion<td>Notes
+    <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr><td><td>`bool()` : bool<td>false<br>Zero value (OpConstantNull for bool)
   <tr><td><td>`i32()` : i32<td>0<br>Zero value (OpConstantNull for i32)
@@ -1466,7 +1466,7 @@ The zero values are as follows:
 <table class='data'>
   <caption>Vector zero type rules, where *T* is a scalar type</caption>
   <thead>
-    <tr><td>Precondition<td>Conclusion<td>Notes
+    <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr>
     <td>
@@ -1499,7 +1499,7 @@ The zero values are as follows:
 <table class='data'>
   <caption>Matrix zero type rules</caption>
   <thead>
-    <tr><td>Precondition<td>Conclusion<td>Notes
+    <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr>
     <td>
@@ -1526,7 +1526,7 @@ The zero values are as follows:
 <table class='data'>
   <caption>Array zero type rules</caption>
   <thead>
-    <tr><td>Precondition<td>Conclusion<td>Notes
+    <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr>
     <td>*T* is storable
@@ -1544,7 +1544,7 @@ The zero values are as follows:
 <table class='data'>
   <caption>Structure zero type rules</caption>
   <thead>
-    <tr><td>Precondition<td>Conclusion<td>Notes
+    <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr>
     <td>`S` is a storable structure type.<br>
@@ -1581,7 +1581,7 @@ The zero values are as follows:
 <table class='data'>
   <caption>Scalar conversion type rules</caption>
   <thead>
-    <tr><td>Precondition<td>Conclusion<td>Notes
+    <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr algorithm="scalar reinterpretation from unsigned to signed">
       <td>|e| : u32<td>`i32(`|e|`)` : i32
@@ -1609,7 +1609,7 @@ Details of conversion to and from floating point are explained in [[#floating-po
 <table class='data'>
   <caption>Vector conversion type rules</caption>
   <thead>
-    <tr><td>Precondition<td>Conclusion<td>Notes
+    <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr algorithm="vector reinterpretation from unsigned to signed">
      <td>|e| : vec|N|&lt;u32&gt;
@@ -1663,7 +1663,7 @@ value in one type as a value in another type.
 <table class='data'>
   <caption>Scalar bitcast type rules</caption>
   <thead>
-    <tr><td>Precondition<td>Conclusion<td>Notes
+    <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr algorithm="scalar identity reinterpretation">
       <td>|e| : |T|,<br>
@@ -1698,7 +1698,7 @@ value in one type as a value in another type.
 <table class='data'>
   <caption>Vector bitcast type rules</caption>
   <thead>
-    <tr><td>Precondition<td>Conclusion<td>Notes
+    <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr algorithm="vector identity reinterpretation">
       <td>|e| : vec&lt;|N|&gt;|T|&gt;,<br>
@@ -1753,7 +1753,7 @@ The convenience letterings can be applied in any order, including duplicating le
 The result type depends on the number of letters provided. Assuming a `vec4<f32>`
 <table>
   <thead>
-    <tr><td>Accessor<td>Result type
+    <tr><th>Accessor<th>Result type
   </thead>
   <tr><td>r<td>`f32`
   <tr><td>rg<td>`vec2<f32>`
@@ -1783,7 +1783,7 @@ TODO: Type rules for vector access
 <table class='data'>
   <caption>Unary logical operations</caption>
   <thead>
-    <tr><td>Precondition<td>Conclusion<td>Notes
+    <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr algorithm="scalar boolean negation"><td>|e| : bool<td>`!`|e| : *bool*
       <td>Logical negation. Yields true when |e| is false, and false when |e| is true.<br>(OpLogicalNot)
@@ -1794,7 +1794,7 @@ TODO: Type rules for vector access
 <table class='data'>
   <caption>Binary logical expressions</caption>
   <thead>
-    <tr><td>Precondition<td>Conclusion<td>Notes
+    <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr><td>*e1* : bool<br>*e2* : bool<td>`e1 || e2` : bool<td>
     Short-circuiting "or". Yields `true` if either `e1` or `e2` are true; evaluates `e2` only if `e1` is false.
@@ -1814,7 +1814,7 @@ TODO: Type rules for vector access
 <table class='data'>
   <caption>Unary arithmetic expressions</caption>
   <thead>
-    <tr><td>Precondition<td>Conclusion<td>Notes
+    <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr><td>*e* : *T*, *T* is *SignedIntegral*<td>`-e` : *T*<td>Signed integer negation. OpSNegate
   <tr><td>*e* : *T*, *T* is *Floating*<td>`-e` : *T*<td>Floating point negation. OpFNegate
@@ -1823,7 +1823,7 @@ TODO: Type rules for vector access
 <table class='data'>
   <caption>Binary arithmetic expressions over scalars</caption>
   <thead>
-    <tr><td>Precondition<td>Conclusion<td>Notes
+    <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr><td>*e1* : u32<br> *e2* : u32<td class="nowrap">`e1 + e2` : u32<td>Integer addition, modulo 2<sup>32</sup> (OpIAdd)
   <tr><td>*e1* : i32<br> *e2* : i32<td>`e1 + e2` : i32<td>Integer addition, modulo 2<sup>32</sup> (OpIAdd)
@@ -1845,7 +1845,7 @@ TODO: Type rules for vector access
 <table class='data'>
   <caption>Binary arithmetic expressions over vectors</caption>
   <thead>
-    <tr><td>Precondition<td>Conclusion<td>Notes
+    <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr><td>*e1* : *T*<br> *e2* : *T*<br> *T* is *IntVec*<td class="nowrap">`e1 + e2` : *T*<td>Component-wise integer addition (OpIAdd)
   <tr><td>*e1* : *T*<br> *e2* : *T*<br> *T* is *FloatVec*<td class="nowrap">`e1 + e2` : *T*<td>Component-wise floating point addition (OpIAdd)
@@ -1864,7 +1864,7 @@ TODO: Type rules for vector access
 <table class='data'>
   <caption>Binary arithmetic expressions with mixed scalar, vector, and matrix operands</caption>
   <thead>
-    <tr><td>Precondition<td>Conclusion<td>Notes
+    <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr><td>*e1* : f32<br>
           *e2* : *T*<br>
@@ -1897,7 +1897,7 @@ TODO: Type rules for vector access
 <table class='data'>
   <caption>Comparisons over scalars</caption>
   <thead>
-    <tr><td>Precondition<td>Conclusion<td>Notes
+    <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr><td>*e1* : bool<br>
           *e2* : bool<br>
@@ -1984,7 +1984,7 @@ TODO: Type rules for vector access
 <table class='data'>
   <caption>Comparisons over vectors</caption>
   <thead>
-    <tr><td>Precondition<td>Conclusion<td>Notes
+    <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr><td>*e1* : *T*<br>
           *e2* : *T*<br>
@@ -2098,7 +2098,7 @@ TODO: Type rules for vector access
 <table class='data'>
   <caption>Unary bitwise operations</caption>
   <thead>
-    <tr><td>Precondition<td>Conclusion<td>Notes
+    <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr algorithm="scalar unsigned complement">
        <td>|e| : u32<br>
@@ -2125,7 +2125,7 @@ TODO: Type rules for vector access
 <table class='data'>
   <caption>Binary bitwise operations</caption>
   <thead>
-    <tr><td>Precondition<td>Conclusion<td>Notes
+    <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr><td>*e1* : *T*<br>
           *e2* : *T*<br>
@@ -2148,7 +2148,7 @@ TODO: Type rules for vector access
 <table class='data'>
   <caption>Bit shift expressions</caption>
   <thead>
-    <tr><td>Precondition<td>Conclusion<td>Notes
+    <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr algorithm="scalar shift left"><td>|e1| : |T|<br>
           |e2| : u32<br>
@@ -3142,7 +3142,7 @@ Issue: (dneto) Default rounding mode is an implementation choice.  Is that what 
 <table class='data'>
   <caption>Type-defining keywords</caption>
   <thead>
-    <tr><td>Token<td>Definition
+    <tr><th>Token<th>Definition
   </thead>
   <tr><td>`ARRAY`<td>array
   <tr><td>`BOOL`<td>bool
@@ -3424,7 +3424,7 @@ TODO: list storage class and shader stage restrictions.
 
 <table class='data' caption='Copy of WebGPU SPIR-V Environment Spec: Built-In Variables'>
   <thead>
-    <tr><td>Name<td>Type<td>Restrictions
+    <tr><th>Name<th>Type<th>Restrictions
   </thead>
     <tr><td>position<td>vec4&ltf32&gt<td>Vertex Output
     <tr><td>vertex_idx<td>i32<td>Vertex Input
@@ -3463,7 +3463,7 @@ the contents of the existing table.
 
 <table class='data'>
   <thead>
-    <tr><td>Logical built-in functions<td>SPIR-V
+    <tr><th>Logical built-in functions<td>SPIR-V
   </thead>
   <tr><td>all(BoolVec) -&gt; bool<td>OpAll
   <tr><td>any(BoolVec) -&gt; bool<td>OpAny
@@ -3481,7 +3481,7 @@ the contents of the existing table.
 
 <table class='data'>
   <thead>
-    <tr><td>Value-testing built-in functions<td>SPIR-V
+    <tr><th>Value-testing built-in functions<th>SPIR-V
   </thead>
   <tr><td>isFinite(float) -&gt; bool<td>OpIsFinite
   <tr><td>isInf(float) -&gt; bool<td>OpIsInf
@@ -3494,7 +3494,7 @@ TODO: deduplicate these tables
 <table class='data'>
   <caption>Unary operators</caption>
   <thead>
-    <tr><td>Precondition<td>Conclusion<td>Notes
+    <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr><td>*e* : f32<td>`isNan(e)` : bool<td>OpIsNan
   <tr><td>*e* : *T*, *T* is *FloatVec*<td>`isNan(e)` : bool<*N*>, where *N = Arity(T)*<td>OpIsNan
@@ -3511,7 +3511,7 @@ TODO: deduplicate these tables
 
 <table class='data'>
   <thead>
-    <tr><td>Precondition<td>Built-in<td>Description
+    <tr><th>Precondition<th>Built-in<th>Description
   </thead>
   <tr algorithm="scalar case, float abs">
     <td>|T| is f32
@@ -3835,7 +3835,7 @@ TODO: deduplicate these tables
 
 <table class='data'>
   <thead>
-    <tr><td>Precondition<td>Built-in<td>Description
+    <tr><th>Precondition<th>Built-in<th>Description
   </thead>
   <tr algorithm="scalar case, abs">
     <td>|T| is u32 or i32
@@ -3922,7 +3922,7 @@ TODO: deduplicate these tables
 ## Matrix built-in functions ## {#matrix-builtin-functions}
 <table class='data'>
   <thead>
-    <tr><td>Precondition<td>Built-in<td>Description
+    <tr><th>Precondition<th>Built-in<th>Description
   </thead>
   <tr algorithm="determinant">
     <td>|T| is f32
@@ -3934,7 +3934,7 @@ TODO: deduplicate these tables
 
 <table class='data'>
   <thead>
-    <tr><td>Vector built-in functions<td>SPIR-V
+    <tr><th>Vector built-in functions<th>SPIR-V
   </thead>
   <tr><td>dot(vecN&lt;f32&gt;, vecN&lt;f32&gt;) -&gt; float<td>OpDot
   <tr><td>outerProduct(vecN&lt;f32&gt;, vecM&lt;f32&gt;) -&gt; matNxM&lt;f32&gt;<td>OpOuterProduct
@@ -3944,7 +3944,7 @@ TODO: deduplicate these tables
 
 <table class='data'>
   <thead>
-    <tr><td>Derivative built-in functions<td>SPIR-V
+    <tr><th>Derivative built-in functions<th>SPIR-V
   </thead>
   <tr><td>dpdx(IDENT) -&gt; float<td>OpDPdx
   <tr><td>dpdxCoarse(IDENT) -&gt; float<td>OpDPdxCoarse
@@ -4027,7 +4027,7 @@ TODO: Remove terms unused in the rest of the specification.
 
 <table class='data'>
   <thead>
-    <tr><td>Term<td>Definition
+    <tr><th>Term<th>Definition
   </thead>
   <tr><td>Dominates
       <td>Basic block `A` *dominates* basic block `B` if:

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4306,18 +4306,11 @@ Issue: (dsinclair) Write out precedence rules. Matches c and glsl rules ....
 [SHORTNAME] is focused on WebGPU shaders. As such, the following is defined for all
 shaders which are generated, when translated to SPIR-V.
 
-TODO(dneto): Forcing the Vulkan memory model is obsolete and should be removed.
-
 <div class='example' heading='Preamble'>
   <xmp>
 ....
 OpCapability Shader
-OpCapability VulkanMemoryModel
-OpMemoryModel Logical VulkanKHR
+OpMemoryModel Logical GLSL450
 ....
   </xmp>
 </div>
-
-While we recognize that most Vulkan devices will not support VulkanMemoryModel
-we expect the SPIR-V generated to be converted by SPIRV-Tools after the fact
-to make the shader compatible.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -32,20 +32,33 @@ thead {
 
 <pre class=biblio>
 {
-	"WebGPU": {
-		"authors": [
-			"Dzmitry Malyshau",
-			"Justin Fan",
-			"Kai Ninomiya"
-		],
-		"href": "https://gpuweb.github.io/gpuweb/",
-		"title": "WebGPU",
-		"status": "Editor's Draft",
-		"publisher": "W3C",
-		"deliveredBy": [
-			"https://github.com/gpuweb/gpuweb"
-		]
-	}
+  "WebGPU": {
+    "authors": [
+      "Dzmitry Malyshau",
+      "Justin Fan",
+      "Kai Ninomiya"
+    ],
+    "href": "https://gpuweb.github.io/gpuweb/",
+    "title": "WebGPU",
+    "status": "Editor's Draft",
+    "publisher": "W3C",
+    "deliveredBy": [
+      "https://github.com/gpuweb/gpuweb"
+    ]
+  },
+  "VulkanMemoryModel": {
+    "authors": [
+      "Jeff Bolz",
+      "Alan Baker",
+      "Tobias Hector",
+      "David Neto",
+      "Robert Simpson",
+      "Brian Sumner"
+    ],
+    "href": "https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#memory-model",
+    "title": "Vulkan Memory Model",
+    "publisher": "Khronos Group"
+  }
 }
 </pre>
 
@@ -406,6 +419,9 @@ Note: Layout decorations are required if the struct is used in an SSBO or UBO. O
 TODO: This section is a stub.
 
 In [SHORTNAME], a value of [=storable=] type may be stored in memory, for later retrieval.
+
+In general [SHORTNAME] follows the [[!VulkanMemoryModel|Vulkan Memory Model]] with the following exceptions
+ * No Acquire/Release semantics
 
 ### Memory Locations TODO ### {#memory-locations}
 
@@ -4301,16 +4317,3 @@ If you want `vec4<f32>` you must provide 4 float values in the constructor.
 ## Precedence ## {#precedence}
 
 Issue: (dsinclair) Write out precedence rules. Matches c and glsl rules ....
-
-## Preamble ## {#preamble}
-[SHORTNAME] is focused on WebGPU shaders. As such, the following is defined for all
-shaders which are generated, when translated to SPIR-V.
-
-<div class='example' heading='Preamble'>
-  <xmp>
-....
-OpCapability Shader
-OpMemoryModel Logical GLSL450
-....
-  </xmp>
-</div>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -37,7 +37,6 @@ thead {
     [[stage(fragment)]]
     fn main() -> void {
         gl_FragColor = vec4<f32>(0.4, 0.4, 0.8, 1.0);
-        return;
     }
   </xmp>
 </div>
@@ -2683,8 +2682,8 @@ is terminated.
 Otherwise, evaluation continues with the next expression or statement after
 the evaluation of the call site of the current function invocation.
 
-If the return type of the function is the void type, then the return statement
-must not have an expression.
+If the return type of the function is the void type, then the return statement is
+optional. If the return statement is provided for a void function it must not have an expression.
 Otherwise the expression must be present, and is called the *return value*.
 In this case the call site of this function invocation evaluates to the return value.
 The type of the return value must match the return type of the function.
@@ -2735,8 +2734,8 @@ statement
 A function declaration may only occur at module scope.
 The function name is available for use after its declaration, until the end of the program.
 
-Functions must end with a `return` statement. The return may be given with a
-value to be returned.
+If the return type of the function is not the void type, then the last statement
+in the function body must be a return statement.
 
 Function names must be unique over all functions and all variables in the
 module.
@@ -3353,7 +3352,7 @@ Each validation item will be given a unique ID and a test must be provided
 when the validation is added. The tests will reference the validation ID in
 the test name.
 
-* v-0002: Functions must end with a return statement.
+* v-0002: Non-void functions must end with a return statement.
 * v-0003: At least one of vertex, fragment or compute shader must be present.
 * v-0004: Recursion is not allowed.
 * v-0005: Functions must be declared before use.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3249,7 +3249,7 @@ When converting a value to a floating point type:
 * If the original value is exactly representable in the destination type, then the result is that value.
     * If the original value is zero and of integral type, then the resulting value has a zero sign bit.
 * Otherwise, the original value is not exactly representable.
-    * If the original value is different from but lies between two adjact values representable in the destination type,
+    * If the original value is different from but lies between two adjacent values representable in the destination type,
          then the result is one of those two values.
          [SHORTNAME] does not specify whether the larger or smaller representable
          value is chosen, and different instances of such a conversion may choose differently.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -420,7 +420,9 @@ TODO: This section is a stub.
 
 In [SHORTNAME], a value of [=storable=] type may be stored in memory, for later retrieval.
 
-In general [SHORTNAME] follows the [[!VulkanMemoryModel|Vulkan Memory Model]] with the following exceptions
+In general [SHORTNAME] follows the [[!VulkanMemoryModel|Vulkan Memory Model]]
+with the following exceptions
+
  * No Acquire/Release semantics
 
 ### Memory Locations TODO ### {#memory-locations}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -13,6 +13,7 @@ Editor: dan sinclair, Google http://www.google.com, dsinclair@google.com
 Editor: Myles C. Maxfield, Apple Inc., mmaxfield@apple.com, w3cid 77180
 Abstract: Shading language for WebGPU.
 Markup Shorthands: markdown yes
+Markup Shorthands: biblio yes
 Markup Shorthands: idl no
 </pre>
 
@@ -29,7 +30,30 @@ thead {
 }
 </style>
 
+<pre class=biblio>
+{
+	"WebGPU": {
+		"authors": [
+			"Dzmitry Malyshau",
+			"Justin Fan",
+			"Kai Ninomiya"
+		],
+		"href": "https://gpuweb.github.io/gpuweb/",
+		"title": "WebGPU",
+		"status": "Editor's Draft",
+		"publisher": "W3C",
+		"deliveredBy": [
+			"https://github.com/gpuweb/gpuweb"
+		]
+	}
+}
+</pre>
+
 # Introduction # {#intro}
+
+WebGPU Shader Language ([SHORTNAME]) is the shader language for [[!WebGPU]].
+That is, an application using the WebGPU API uses [SHORTNAME] to express the programs, known as shaders,
+that run on the GPU.
 
 <div class='example'>
   <xmp highlight='rust'>
@@ -288,7 +312,7 @@ A vector type is a <dfn dfn>numeric vector</dfn> type if its component type is a
 
 Restrictions on runtime-sized arrays:
 * The last member of the structure type defining the [=store type=]
-    for variable in the `storage` [=storage class=] may be a runtime-sized array.
+    for a variable in the `storage` [=storage class=] may be a runtime-sized array.
 * A runtime-sized array must not be used as the store type or contained within
     a store type in any other cases.
 * The type of an expression must not be a runtime-sized array type.
@@ -423,12 +447,12 @@ The following types are <dfn dfn noexport>host-shareable</dfn>:
 * [=numeric vector=] types
 * [[#matrix-types]]
 * [[#array-types]] if the array type has a [=stride=] attribute and its element type is host-shareable
-* [[#struct-types]] if each of its members both has an [=offset=] attribute and is host-shareable
+* [[#struct-types]] if each member is host-shareable and has an [=offset=] attribute
 
 Host-shareable types are used to describe the contents of buffers which are shared between
 the host and the GPU, or copied between host and GPU without format translation.
 When used for this purpose, the type must be additionally decorated with layout attributes
-as described in [[#memory-layout]].
+as described in [[#memory-layouts]].
 In particular, any variable using the `uniform` or `storage` [=storage classes=] must have
 a host-shareable [=store type=].
 
@@ -438,7 +462,7 @@ Additionally, a [=runtime-sized=] array is host-shareable but is not IO-shareabl
 
 Note: Both IO-shareable and host-shareable types have concrete sizes, but counted differently.
 IO-shareable types are sized by a location-count metric, see [[#input-output-locations]].
-Host-shareable types are sized by a byte-count metric, see [[#memory-layout]].
+Host-shareable types are sized by a byte-count metric, see [[#memory-layouts]].
 
 ### Storage Classes ### {#storage-class}
 
@@ -493,7 +517,7 @@ and how to use variables with it.
       <td>[=Host-shareable=]
       <td>The [=store type=] of a variable in the `uniform` storage class
           must be a `block`-decorated [=host-shareable=] structure type.
-          See also [[#memory-layout]].
+          See also [[#memory-layouts]].
           <br>Used with `uniform-buffer` WebGPU GPUBindingType.
   <tr><td>storage
       <td>Readable.<br>
@@ -503,7 +527,7 @@ and how to use variables with it.
       <td>[=Host-shareable=]
       <td>The [=store type=] of a variable in the `storage` storage class
           must be a `block`-decorated [=host-shareable=] structure type.
-          See also [[#memory-layout]].
+          See also [[#memory-layouts]].
           <br>Used with `storage-buffer` or `readonly-storage-buffer` WebGPU GPUBindingType.
   <tr><td>handle
       <td>Read-only
@@ -543,12 +567,22 @@ storage_class
 </table>
 
 
-### Memory Layout Rules TODO ### {#memory-layout}
+### Memory Layout Rules TODO ### {#memory-layouts}
 
 TODO: *The following is a stub*
 
-Variables in certain storage classes must have a [=host-shareable=] [=store type=] with fully elaborated memory layout.
+A <dfn noexport>buffer variable</dfn> is a variable used to share
+bulk data organized as a sequence of bytes in memory.
+Buffers are shared between the CPU and the GPU, or between different shader stages
+in a pipeline, or between different pipelines.
 
+Because the data are shared without reformatting or translation,
+buffer producers and consumers must agree on the <dfn noexport>memory layout</dfn>,
+which is the description of how the buffer's bytes are organized into typed WGSL values.
+
+The [=store type=] of a buffer variable must be [=host-shareable=], with fully elaborated memory layout, as described below.
+
+Each buffer variable must be declared in either the `uniform` or `storage` storage classes.
 The memory layout of a type is significant only when referring to a value in those storage classes.
 This affects evaluation of a variable in one of those storage classes, or of a pointer into one of those storage classes.
 
@@ -1015,7 +1049,7 @@ A <dfn dfn noexport>variable declaration</dfn>:
 
 * Determines the variable’s name, storage class, and store type (and hence its reference type).
 * Ensures the execution environment allocates storage for a value of the store type, for the lifetime of the variable.
-* Optionally have an *initializer* expression, if the variable is in the `private`, `function`, or `out` [[#storage-class]].
+* Optionally have an *initializer* expression, if the variable is in the `private`, `function`, or `out` [=storage classes|storage class=].
     If present, the initializer's type must match the store type of the variable.
 
 See [[#module-scope-variables]] and [[#function-scope-variables]] for rules about where
@@ -1093,8 +1127,8 @@ Variables at module scope are restricted as follows:
 * A variable in the `in`, `out`, `private`, `workgroup`, `uniform`, or `storage` storage classes:
     * Must be declared with an explicit storage class decoration.
     * Must use a [=store type=] as described in [[#storage-class]].
-* If the [=store type=] is a texture type or a sampler type, then the storage class is always `handle`.
-    The variable declaration must not have a storage class decoration.
+* If the [=store type=] is a texture type or a sampler type, then the variable declaration must not
+    have a storage class decoration.  The storage class will always be `handle`.
 
 <div class='example' heading="Module scope variable declarations">
   <xmp>
@@ -1105,7 +1139,7 @@ Variables at module scope are restricted as follows:
 
     [[block]] struct Params {
       [[offset(0)]] specular: f32;
-      [[offset(4)]]
+      [[offset(4)]] count: i32;
     };
     var<uniform> param: Params;          # A uniform buffer
 
@@ -1159,7 +1193,6 @@ literal_or_ident
 </table>
 
 See [[#builtin-variables]] for the list of Builtin Decoration Identifiers.
-
 
 ## Module Constants ## {#module-constants}
 
@@ -1273,7 +1306,7 @@ The variable's [=store type=] must be [=storable=].
        var<function> count : u32;  # A variable in function storage class.
        var delta : i32;            # Another variable in the function storage class.
        var sum : f32 = 0.0;        # A function storage class variable with initializer.
-       const unit : i32 = 1;       # A constant.
+       const unit : i32 = 1;       # A constant. Const declarations don't use a storage class.
     }
   </xmp>
 </div>
@@ -2929,21 +2962,100 @@ ISSUE: Can we query upper bounds on workgroup size dimensions?  Is it independen
   </xmp>
 </div>
 
-## Shader Interface TODO ## {#shader-interface}
+## Shader Interface ## {#shader-interface}
 
-### Built-in variables TODO ### {#builtin-var-interface}
+The shader interface is the set of objects
+through which the shader accesses data external to the shader stage,
+either for reading or writing.
+The interface includes:
 
-### Pipeline Input and Output Interface TODO ### {#pipeline-inputs-outputs}
+* Pipeline inputs and outputs
+* Buffer resources
+* Texture resources
 
-TODO(dneto): The following sentence was moved from elsewhere. Expand this.
+These objects are represented by module-scope variables in certain storage classes.
 
-The input and output parameters to the entry point are determined by which
-global variables are used in the function and any called functions.
+We say a variable is <dfn noexport>statically accessed</dfn> by a function if any subexpression
+in the body of the function uses the variable's identifier,
+and that subexpression is [=in scope=] of the variable's declaration.
+Note that being statically accessed is independent of whether an execution of the shader
+will actually evaluate the subexpression, or even execute the enclosing statement.
 
-#### Built-in inputs and outputs TODO #### {#builtin-inputs-outputs}
-TODO: *Stub*. Forward reference to list of builtin variables.
+More precisely, the <dfn noexport>interface of a shader stage</dfn>
+is the set of module-scope variables
+[=statically accessed=] by [=functions in a shader stage|functions in the shader stage=],
+and which are in [=storage classes=] `in`, `out`, `uniform`, `storage`, or `handle`.
 
-#### User Data TODO #### {#user-data}
+### Pipeline Input and Output Interface ### {#pipeline-inputs-outputs}
+
+A <dfn noexport>pipeline input</dfn> is data provided to the shader stage from upstream in the pipeline.
+A pipeline input is denoted by a module-scope variable in the `in` [=storage class=].
+The store type must be [=IO-shareable=].
+
+A <dfn noexport>pipeline output</dfn> is data the shader provides for further processing downstream in the pipeline.
+A pipeline output is denoted by a module-scope variable in the `out` [=storage class=].
+The store type must be [=IO-shareable=].
+
+Each pipeline input or output is one of:
+
+* A built-in variable. See [[#builtin-inputs-outputs]].
+* A user data attribute. See [[#user-data-attributes]].
+
+#### Built-in inputs and outputs #### {#builtin-inputs-outputs}
+
+A <dfn noexport>built-in input variable</dfn> provides access to system-generated control information.
+The set of built-in inputs are listed in [[#builtin-variables]].
+
+To declare a variable for accessing a particular input built-in *X*:
+
+* Declare a module-scope variable in the `in` [=storage class=],
+    where the [=store type=] is the listed store type for *X*.
+* Apply a `builtin(`*X*`)` attribute to the variable.
+* The variable must not have an initializer. The system provides the value.
+
+A <dfn noexport>built-in output variable</dfn> is used by the shader to convey
+control information to later processing steps in the pipeline.
+The set of built-in outputs are listed in [[#builtin-variables]].
+
+To declare a variable for accessing a particular output built-in *Y*:
+
+* Declare a module-scope variable in the `out` [=storage class=],
+    where the [=store type=] is the listed store type for *Y*.
+* Apply a `builtin(`*Y*`)` attribute to the variable.
+* The variable may have an initializer, or not, as described in [[#variables]].
+
+<div class='example' heading="Declaring built-in variables">
+  <xmp>
+    # vertex shader output builtin
+    [[builtin(position)]] var<out> my_position : vec4<f32>;
+
+    # fragment shader input builtin
+    [[builtin(frag_coord)]] var<in> coord : vec4<f32>;
+
+    # compute shader builtin
+    [[builtin(global_invocation_id)]] var<in> global_id : vec3<u32>;
+  </xmp>
+</div>
+
+The `builtin` attribute must not be applied to a variable in a storage class other than `in` or `out`.
+
+An input built-in must only be applied to a variable in the `in` storage class.
+
+An output built-in must only be applied to a variable in the `out` storage class.
+
+A variable must not have more than one `builtin` attribute.
+
+Each built-in variable has an associated shader stage, as described in [[#builtin-variables]].
+If a built-in variable has stage *S* and is [=statically accessed=] by a function *F*,
+then *F* must be a [=functions in a shader stage|function in a shader=]
+for stage *S*.
+
+
+Issue:
+    1. The statement makes it clear that in/out storage classes for builtins are redundant.
+    2. On the other hand, in Vulkan, builtin variables occoupy I/O location slots (counting toward limits),
+
+#### User Data Attribute TODO #### {#user-data-attributes}
 
 #### Input-output Locations TODO #### {#input-output-locations}
 TODO: *Stub*. Location-sizing of types, non-overlap among variables referenced within an entry point static call tree.
@@ -2952,13 +3064,17 @@ TODO: *Stub*. Location-sizing of types, non-overlap among variables referenced w
 
 TODO: *Stub* The resource interface of a shader stage is the set of module-scope
 variables statically accessed by functions
-in the sahder and which declare textures, samplers,
+in the shader and which declare textures, samplers,
 and buffers (the latter are variables in `storage` or `uniform` storage class).
 This is where we state the requirement for: set and binding attributes.
 Possibly move the content of the "Notes" column for the `storage`, `uniform`, and
 `handle` rows from [[#storage-class]] to this section.
 
 ## Pipeline compatibility TODO ## {#pipeline-compatibility}
+
+TODO: match flat attribute
+
+TODO: user data inputs of fragment stage must be subset of user data outputs of vertex stage
 
 ### Input-output matching rules TODO ### {#input-output-matching}
 
@@ -3033,6 +3149,21 @@ entry point, or (1,1,1) if the entry point has no such attribute.
 
 There is exactly one invocation in a workgroup for each point in the workgroup grid.
 
+An invocation's <dfn noexport>local invocation ID</dfn> is the coordinate
+triple for the invocation's corresponding workgroup grid point.
+
+When an invocation has [=local invocation ID=] (i,j,k), then its
+<dfn noexport>local invocation index</dfn> is
+
+  i +
+  (j * workgroup_size_x) +
+  (k * workgroup_size_x * workgroup_size_y)
+
+<p algorithm="local index range">Note that if a workgroup has |W| invocations,
+then each invocation |I| the workgroup has a unique local invocation index |L|(|I|)
+such that 0 &le; |L|(|I|) &lt; |W|,
+and that entire range is covered.</p>
+
 A compute shader begins execution when a WebGPU implementation
 removes a dispatch command from a queue and begins the specified work on the GPU.
 The dispatch command specifies a <dfn noexport>dispatch size</dfn>,
@@ -3052,6 +3183,10 @@ where *workgroup_size_x*,
 
 The work to be performed by a compute shader dispatch is to execute exactly one
 invocation of the entry point for each point in the compute shader grid.
+
+An invocation's <dfn noexport>global invocation ID</dfn> is the coordinate
+triple for the invocation's corresponding compute shader grid point.
+
 The invocations are organized into workgroups, so that each invocation
 *(CSi, CSj, CSk)* is identified with the workgroup grid point
 
@@ -3383,58 +3518,145 @@ the test name.
 * v-0028: A fallthrough statement must not appear as the last statement in last clause of a switch.
 
 
-# Built-in variables TODO # {#builtin-variables}
+# Built-in variables # {#builtin-variables}
 
-<div class='example' heading="Valid Built-in Decoration Identifiers">
+See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
+
+<table class='data'>
+  <thead>
+    <tr><th>Built-in<th>Stage<th>Input or Output<th>Store type<th>Description
+  </thead>
+
+  <tr><td>`vertex_idx`
+      <td>vertex
+      <td>in
+      <td>u32
+      <td width="50%">Index of the current vertex within the current API-level draw command,
+         independent of draw instancing.
+
+         For a non-indexed draw, the first vertex has an index equal to the `firstIndex` argument
+         of the draw, whether provided directly or indirectly.
+         The index is incremented by one for each additional vertex in the draw instance.
+
+         For an indexed draw, the index is equal to the index buffer entry for
+         vertex, plus the `baseVertex` argument of the draw, whether provided directly or indirectly.
+
+  <tr><td>`instance_idx`
+      <td>vertex
+      <td>in
+      <td>u32
+      <td width="50%">Instance index of the current vertex within the current API-level draw command.
+
+         The first instance has an index equal to the `firstInstance` argument of the draw,
+         whether provided directly or indirectly.
+         The index is incremented by one for each additional instance in the draw.
+
+  <tr><td>`position`
+      <td>vertex
+      <td>out
+      <td>vec4&lt;f32&gt;
+      <td width="50%">Output position of the current vertex, using homogeneous coordinates.
+      After homogeneous normalization (where each of the *x*, *y*, and *z* components
+      are divided by the *w* component), the position is in the WebGPU normalized device
+      coordinate space.
+      See [[WebGPU#coordinate-systems|WebGPU &sect; Coordinate Systems]].
+
+  <tr><td>`frag_coord`
+      <td>fragment
+      <td>in
+      <td>vec4&lt;f32&gt;
+      <td width="50%">Framebuffer position of the current fragment, using normalized homogeneous
+      coordinates.
+      (The *x*, *y*, and *z* components have already been scaled such that *w* is now 1.)
+      See [[WebGPU#coordinate-systems|WebGPU &sect; Coordinate Systems]].
+
+  <tr><td>`front_facing`
+      <td>fragment
+      <td>in
+      <td>u32
+      <td width="50%">Non-zero when the current fragment is on a front-facing primitive.
+         Zero otherwise.
+         See [[WebGPU#dom-gpurasterizationstatedescriptor-frontface|WebGPU &sect; Rasterization State]].
+
+  <tr><td>`frag_depth`
+      <td>fragment
+      <td>out
+      <td>f32
+      <td width="50%">Updated depth of the fragment, in the viewport depth range.
+      See [[WebGPU#coordinate-systems|WebGPU &sect; Coordinate Systems]].
+
+  <tr><td>`local_invocation_id`
+      <td>compute
+      <td>in
+      <td>vec3&lt;u32&gt;
+      <td width="50%">The current invocation's [=local invocation ID=],
+            i.e. its position in the [=workgroup grid=].
+
+  <tr><td>`local_invocation_index`
+      <td>compute
+      <td>in
+      <td>u32
+      <td width="50%">The current invocation's [=local invocation index=], a linearized index of
+          the invocation's position within the [=workgroup grid=].
+
+  <tr><td>`global_invocation_id`
+      <td>compute
+      <td>in
+      <td>vec3&lt;u32&gt;
+      <td width="50%">The current invocation's [=global invocation ID=],
+            i.e. its position in the [=compute shader grid=].
+
+</table>
+
+<div class='example' heading="Declaring built-in variable: position">
   <xmp>
-    [[builtin(position)]]
-          OpDecorate %gl_Position BuiltIn Position
+    [[builtin(position)]] var<out> my_position : vec4<f32>;
 
-    [[builtin(vertex_idx)]]
-          OpDecorate %gl_VertexIdx BuiltIn VertexIndex
+    #   OpDecorate %my_pos BuiltIn Position
+    #   %float = OpTypeFloat 32
+    #   %v4float = OpTypeVector %float 4
+    #   %ptr = OpTypePointer Output %v4float
+    #   %my_pos = OpVariable %ptr Output
 
-    [[builtin(instance_idx)]]
-          OpDecorate %gl_InstanceId BuiltIn InstanceIndex
-
-    [[builtin(front_facing)]]
-          OpDecorate %gl_FrontFacing BuiltIn FrontFacing
-
-    [[builtin(frag_coord)]]
-          OpDecorate %gl_FragCoord BuiltIn FragCoord
-
-    [[builtin(frag_depth)]]
-          OpDecorate %gl_FragDepth BuiltIn FragDepth
-
-    [[builtin(local_invocation_id)]]
-          OpDecorate %gl_LocalInvocationID BuiltIn LocalInvocationId
-
-    [[builtin(local_invocation_idx)]]
-          OpDecorate %gl_LocalInvocationIndex BuiltIn LocalInvocationIndex
-
-    [[builtin(global_invocation_id)]]
-          OpDecorate %gl_GlobalInvocationID BuiltIn GlobalInvocationId
   </xmp>
 </div>
 
-The usages of the variable builtin decorations is further restricted in the
-type, function decorations and storage class.
+<div class='example' heading="Example built-in variable: vertex_idx">
+  <xmp>
+    [[builtin(vertex_idx)]] var<in> my_idx : u32;
 
-TODO: list storage class and shader stage restrictions.
+    #   OpDecorate %my_idx BuiltIn VertexIndex
+    #   %uint = OpTypeInt 32 0
+    #   %ptr = OpTypePointer Input %uint
+    #   %my_idx = OpVariable %ptr Input
 
-<table class='data' caption='Copy of WebGPU SPIR-V Environment Spec: Built-In Variables'>
-  <thead>
-    <tr><th>Name<th>Type<th>Restrictions
-  </thead>
-    <tr><td>position<td>vec4&ltf32&gt<td>Vertex Output
-    <tr><td>vertex_idx<td>i32<td>Vertex Input
-    <tr><td>instance_idx<td>i32<td>Vertex Input
-    <tr><td>front_facing<td>bool<td>Fragment Input
-    <tr><td>frag_coord<td>vec4&ltf32&gt<td>Fragment Input
-    <tr><td>frag_depth<td>f32<td>Fragment Output
-    <tr><td>local_invocation_id<td>vec3&ltu32&gt<td>Compute Input
-    <tr><td>global_invocation_id<td>vec3&ltu32&gt<td>Compute Input
-    <tr><td>local_invocation_idx<td>u32<td>Compute Input
-</table>
+  </xmp>
+</div>
+
+<div class='example' heading="Declaring other built-in variables">
+  <xmp>
+    [[builtin(instance_idx)]] var<in> my_inst_idx : u32;
+    #    OpDecorate %gl_InstanceId BuiltIn InstanceIndex
+
+    [[builtin(front_facing)]] var<in> is_front : u32;
+    #     OpDecorate %gl_FrontFacing BuiltIn FrontFacing
+
+    [[builtin(frag_coord)]] var<in> coord : vec4<f32>;
+    #     OpDecorate %gl_FragCoord BuiltIn FragCoord
+
+    [[builtin(frag_depth)]] var<out> depth : f32;
+    #     OpDecorate %gl_FragDepth BuiltIn FragDepth
+
+    [[builtin(local_invocation_id)]] var<in> local_id : vec3<u32>;
+    #     OpDecorate %gl_LocalInvocationID BuiltIn LocalInvocationId
+
+    [[builtin(local_invocation_idx)]] var<in> local_idx : u32;
+    #     OpDecorate %gl_LocalInvocationIndex BuiltIn LocalInvocationIndex
+
+    [[builtin(global_invocation_id)]] var<in> global_id : vec3<u32>;
+    #      OpDecorate %gl_GlobalInvocationID BuiltIn GlobalInvocationId
+  </xmp>
+</div>
 
 # Built-in functions # {#builtin-functions}
 


### PR DESCRIPTION
This CL removes the preamble section from the spec, the generated SPIR-V in this
case is an implementation detail. The Vulkan Memory Model is explicitly called out
as what we are following.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dj2/gpuweb/pull/1177.html" title="Last updated on Nov 10, 2020, 2:30 PM UTC (de16efa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1177/7a3f41b...dj2:de16efa.html" title="Last updated on Nov 10, 2020, 2:30 PM UTC (de16efa)">Diff</a>