### PR TITLE
[wgsl] Relax void return requirement.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -37,7 +37,6 @@ thead {
     [[stage(fragment)]]
     fn main() -> void {
         gl_FragColor = vec4<f32>(0.4, 0.4, 0.8, 1.0);
-        return;
     }
   </xmp>
 </div>
@@ -2683,8 +2682,8 @@ is terminated.
 Otherwise, evaluation continues with the next expression or statement after
 the evaluation of the call site of the current function invocation.
 
-If the return type of the function is the void type, then the return statement
-must not have an expression.
+If the return type of the function is the void type, then the return statement is
+optional. If the return statement is provided for a void function it must not have an expression.
 Otherwise the expression must be present, and is called the *return value*.
 In this case the call site of this function invocation evaluates to the return value.
 The type of the return value must match the return type of the function.
@@ -2735,7 +2734,8 @@ statement
 A function declaration may only occur at module scope.
 The function name is available for use after its declaration, until the end of the program.
 
-Functions must end with a `return` statement. The return may be given with a
+Functions returning a value must end with a `return` statement. Functions returning
+`void` may end in a `return` statement. The return may be given with a
 value to be returned.
 
 Function names must be unique over all functions and all variables in the
@@ -3353,7 +3353,7 @@ Each validation item will be given a unique ID and a test must be provided
 when the validation is added. The tests will reference the validation ID in
 the test name.
 
-* v-0002: Functions must end with a return statement.
+* v-0002: Non-void functions must end with a return statement.
 * v-0003: At least one of vertex, fragment or compute shader must be present.
 * v-0004: Recursion is not allowed.
 * v-0005: Functions must be declared before use.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2734,9 +2734,8 @@ statement
 A function declaration may only occur at module scope.
 The function name is available for use after its declaration, until the end of the program.
 
-Functions returning a value must end with a `return` statement. Functions returning
-`void` may end in a `return` statement. The return may be given with a
-value to be returned.
+If the return type of the function is not the void type, then the last statement
+in the function body must be a return statement.
 
 Function names must be unique over all functions and all variables in the
 module.


### PR DESCRIPTION
This CL relaxes the requirement that void functions have a final return
statement. This CL changes so that the return is optional if the
function returns void and is required for non-void functions.

Fixes #1156