### PR TITLE
[wgsl] Flip the default texture name.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -643,25 +643,25 @@ type.
 ### Sampled Texture Types ### {#sampled-texture-type}
 
 <pre class='def'>
-`texture_sampled_1d<type>`
+`texture_1d<type>`
   %1 = OpTypeImage %type 1D 0 0 0 1 Unknown
 
-`texture_sampled_1d_array<type>`
+`texture_1d_array<type>`
   %1 = OpTypeImage %type 1D 0 1 0 1 Unknown
 
-`texture_sampled_2d<type>`
+`texture_2d<type>`
   %1 = OpTypeImage %type 2D 0 0 0 1 Unknown
 
-`texture_sampled_2d_array<type>`
+`texture_2d_array<type>`
   %1 = OpTypeImage %type 2D 0 1 0 1 Unknown
 
-`texture_sampled_3d<type>`
+`texture_3d<type>`
   %1 = OpTypeImage %type 3D 0 0 0 1 Unknown
 
-`texture_sampled_cube<type>`
+`texture_cube<type>`
   %1 = OpTypeImage %type Cube 0 0 0 1 Unknown
 
-`texture_sampled_cube_array<type>`
+`texture_cube_array<type>`
   %1 = OpTypeImage %type Cube 0 1 0 1 Unknown
 </pre>
 * type must be `f32`, `i32` or `u32`
@@ -684,19 +684,19 @@ may be read, without the use of a sampler.
 See [[#texture-builtin-functions]].
 
 <pre class='def'>
-`texture_ro_1d<image_storage_type>`
+`texture_storage_ro_1d<image_storage_type>`
   %1 = OpTypeImage type(image_storage_type) 1D 0 0 0 2 image_storage_type
 
-`texture_ro_1d_array<image_storage_type>`
+`texture_storage_ro_1d_array<image_storage_type>`
   %1 = OpTypeImage type(image_storage_type) 1D 0 1 0 2 image_storage_type
 
-`texture_ro_2d<image_storage_type>`
+`texture_storage_ro_2d<image_storage_type>`
   %1 = OpTypeImage type(image_storage_type) 0 0 0 2 image_storage_type
 
-`texture_ro_2d_array<image_storage_type>`
+`texture_storage_ro_2d_array<image_storage_type>`
   %1 = OpTypeImage type(image_storage_type) 0 1 0 2 image_storage_type
 
-`texture_ro_3d<image_storage_type>`
+`texture_storage_ro_3d<image_storage_type>`
   %1 = OpTypeImage type(image_storage_type) 3D 0 0 0 2 image_storage_type
 </pre>
 * type(image_storage_type) is one of `f32`, `i32`, or `u32`, depending on the storage type.
@@ -704,9 +704,9 @@ See [[#texture-builtin-functions]].
 When mapping to SPIR-V, a read-only storage texture variable must also have a `NonWritable` decoration.
 For example:
 
-<div class='example' heading='Mapping a texture_ro_1d variable to SPIR-V'>
+<div class='example' heading='Mapping a texture_storage_ro_1d variable to SPIR-V'>
   <xmp>
-      var<uniform_constant> tbuf : texture_ro_1d<rgba8unorm>;
+      var<uniform_constant> tbuf : texture_storage_ro_1d<rgba8unorm>;
 
       # Maps to the following SPIR-V:
       #  OpDecorate %tbuf NonWritable
@@ -725,28 +725,28 @@ may be written.
 See [[#texture-builtin-functions]].
 
 <pre class='def'>
-`texture_wo_1d<image_storage_type>`
+`texture_storage_wo_1d<image_storage_type>`
   %1 = OpTypeImage %void 1D 0 0 0 2 image_storage_type
 
-`texture_wo_1d_array<image_storage_type>`
+`texture_storage_wo_1d_array<image_storage_type>`
   %1 = OpTypeImage %void 1D 0 1 0 2 image_storage_type
 
-`texture_wo_2d<image_storage_type>`
+`texture_storage_wo_2d<image_storage_type>`
   %1 = OpTypeImage %void 2D 0 0 0 2 image_storage_type
 
-`texture_wo_2d_array<image_storage_type>`
+`texture_storage_wo_2d_array<image_storage_type>`
   %1 = OpTypeImage %void 2D 0 1 0 2 image_storage_type
 
-`texture_wo_3d<image_storage_type>`
+`texture_storage_wo_3d<image_storage_type>`
   %1 = OpTypeImage %void 3D 0 0 0 2 image_storage_type
 </pre>
 
 When mapping to SPIR-V, a write-only storage texture variable must also have a `NonReadable` decoration.
 For example:
 
-<div class='example' heading='Mapping a texture_wo_1d variable to SPIR-V'>
+<div class='example' heading='Mapping a texture_storage_wo_1d variable to SPIR-V'>
   <xmp>
-      var<uniform_constant> tbuf : texture_wo_1d<rgba8unorm>;
+      var<uniform_constant> tbuf : texture_storage_wo_1d<rgba8unorm>;
 
       # Maps to the following SPIR-V:
       #  OpDecorate %tbuf NonReadable
@@ -798,28 +798,28 @@ sampler_type
   | SAMPLER_COMPARISON
 
 sampled_texture_type
-  : TEXTURE_SAMPLED_1D
-  | TEXTURE_SAMPLED_1D_ARRAY
-  | TEXTURE_SAMPLED_2D
-  | TEXTURE_SAMPLED_2D_ARRAY
-  | TEXTURE_SAMPLED_3D
-  | TEXTURE_SAMPLED_CUBE
-  | TEXTURE_SAMPLED_CUBE_ARRAY
+  : TEXTURE_1D
+  | TEXTURE_1D_ARRAY
+  | TEXTURE_2D
+  | TEXTURE_2D_ARRAY
+  | TEXTURE_3D
+  | TEXTURE_CUBE
+  | TEXTURE_CUBE_ARRAY
 
 multisampled_texture_type
   : TEXTURE_MULTISAMPLED_2D
 
 storage_texture_type
-  : TEXTURE_RO_1D
-  | TEXTURE_RO_1D_ARRAY
-  | TEXTURE_RO_2D
-  | TEXTURE_RO_2D_ARRAY
-  | TEXTURE_RO_3D
-  | TEXTURE_WO_1D
-  | TEXTURE_WO_1D_ARRAY
-  | TEXTURE_WO_2D
-  | TEXTURE_WO_2D_ARRAY
-  | TEXTURE_WO_3D
+  : TEXTURE_STORAGE_RO_1D
+  | TEXTURE_STORAGE_RO_1D_ARRAY
+  | TEXTURE_STORAGE_RO_2D
+  | TEXTURE_STORAGE_RO_2D_ARRAY
+  | TEXTURE_STORAGE_RO_3D
+  | TEXTURE_STORAGE_WO_1D
+  | TEXTURE_STORAGE_WO_1D_ARRAY
+  | TEXTURE_STORAGE_WO_2D
+  | TEXTURE_STORAGE_WO_2D_ARRAY
+  | TEXTURE_STORAGE_WO_3D
 
 depth_texture_type
   : TEXTURE_DEPTH_2D
@@ -3161,24 +3161,24 @@ Issue: (dneto) Default rounding mode is an implementation choice.  Is that what 
   <tr><td>`SAMPLER`<td>sampler
   <tr><td>`SAMPLER_COMPARISON`<td>sampler_comparison
   <tr><td>`STRUCT`<td>struct
-  <tr><td>`TEXTURE_SAMPLED_1D`<td>texture_sampled_1d
-  <tr><td>`TEXTURE_SAMPLED_1D_ARRAY`<td>texture_sampled_1d_array
-  <tr><td>`TEXTURE_SAMPLED_2D`<td>texture_sampled_2d
-  <tr><td>`TEXTURE_SAMPLED_2D_ARRAY`<td>texture_sampled_2d_array
-  <tr><td>`TEXTURE_SAMPLED_3D`<td>texture_sampled_3d
-  <tr><td>`TEXTURE_SAMPLED_CUBE`<td>texture_sampled_cube
-  <tr><td>`TEXTURE_SAMPLED_CUBE_ARRAY`<td>texture_sampled_cube_array
+  <tr><td>`TEXTURE_1D`<td>texture_1d
+  <tr><td>`TEXTURE_1D_ARRAY`<td>texture_1d_array
+  <tr><td>`TEXTURE_2D`<td>texture_2d
+  <tr><td>`TEXTURE_2D_ARRAY`<td>texture_2d_array
+  <tr><td>`TEXTURE_3D`<td>texture_3d
+  <tr><td>`TEXTURE_CUBE`<td>texture_cube
+  <tr><td>`TEXTURE_CUBE_ARRAY`<td>texture_cube_array
   <tr><td>`TEXTURE_MULTISAMPLED_2D`<td>texture_multisampled_2d
-  <tr><td>`TEXTURE_RO_1D`<td>texture_ro_1d
-  <tr><td>`TEXTURE_RO_1D_ARRAY`<td>texture_ro_1d_array
-  <tr><td>`TEXTURE_RO_2D`<td>texture_ro_2d
-  <tr><td>`TEXTURE_RO_2D_ARRAY`<td>texture_ro_2d_array
-  <tr><td>`TEXTURE_RO_3D`<td>texture_ro_3d
-  <tr><td>`TEXTURE_WO_1D`<td>texture_wo_1d
-  <tr><td>`TEXTURE_WO_1D_ARRAY`<td>texture_wo_1d_array
-  <tr><td>`TEXTURE_WO_2D`<td>texture_wo_2d
-  <tr><td>`TEXTURE_WO_2D_ARRAY`<td>texture_wo_2d_array
-  <tr><td>`TEXTURE_WO_3D`<td>texture_wo_3d
+  <tr><td>`TEXTURE_STORAGE_RO_1D`<td>texture_storage_ro_1d
+  <tr><td>`TEXTURE_STORAGE_RO_1D_ARRAY`<td>texture_storage_ro_1d_array
+  <tr><td>`TEXTURE_STORAGE_RO_2D`<td>texture_storage_ro_2d
+  <tr><td>`TEXTURE_STORAGE_RO_2D_ARRAY`<td>texture_storage_ro_2d_array
+  <tr><td>`TEXTURE_STORAGE_RO_3D`<td>texture_storage_ro_3d
+  <tr><td>`TEXTURE_STORAGE_WO_1D`<td>texture_storage_wo_1d
+  <tr><td>`TEXTURE_STORAGE_WO_1D_ARRAY`<td>texture_storage_wo_1d_array
+  <tr><td>`TEXTURE_STORAGE_WO_2D`<td>texture_storage_wo_2d
+  <tr><td>`TEXTURE_STORAGE_WO_2D_ARRAY`<td>texture_storage_wo_2d_array
+  <tr><td>`TEXTURE_STORAGE_WO_3D`<td>texture_storage_wo_3d
   <tr><td>`TEXTURE_DEPTH_2D`<td>texture_depth_2d
   <tr><td>`TEXTURE_DEPTH_2D_ARRAY`<td>texture_depth_2d_array
   <tr><td>`TEXTURE_DEPTH_CUBE`<td>texture_depth_cube
@@ -3960,52 +3960,52 @@ TODO: deduplicate these tables
 ## Texture built-in functions ## {#texture-builtin-functions}
 
 <pre class='def'>
-`vec4<type> textureLoad(texture_ro_1d      , i32       coords)`
-`vec4<type> textureLoad(texture_ro_2d      , vec2<i32> coords)`
-`vec4<type> textureLoad(texture_ro_1d_array, vec2<i32> coords)`
-`vec4<type> textureLoad(texture_ro_3d      , vec3<i32> coords)`
-`vec4<type> textureLoad(texture_ro_2d_array, vec3<i32> coords)`
-  %32 = OpImageRead %v4float %texture_ro %coords
+`vec4<type> textureLoad(texture_storage_ro_1d      , i32       coords)`
+`vec4<type> textureLoad(texture_storage_ro_2d      , vec2<i32> coords)`
+`vec4<type> textureLoad(texture_storage_ro_1d_array, vec2<i32> coords)`
+`vec4<type> textureLoad(texture_storage_ro_3d      , vec3<i32> coords)`
+`vec4<type> textureLoad(texture_storage_ro_2d_array, vec3<i32> coords)`
+  %32 = OpImageRead %v4float %texture_storage_ro %coords
 
-`vec4<type> textureLoad(texture_sampled_1d      , i32       coords, i32 level_of_detail)`
-`vec4<type> textureLoad(texture_sampled_2d      , vec2<i32> coords, i32 level_of_detail)`
-`vec4<type> textureLoad(texture_sampled_1d_array, vec2<i32> coords, i32 level_of_detail)`
-`vec4<type> textureLoad(texture_sampled_3d      , vec3<i32> coords, i32 level_of_detail)`
-`vec4<type> textureLoad(texture_sampled_2d_array, vec3<i32> coords, i32 level_of_detail)`
-  %32 = OpImageFetch %v4float %texture_sampled %coords Lod %level_of_detail
+`vec4<type> textureLoad(texture_1d      , i32       coords, i32 level_of_detail)`
+`vec4<type> textureLoad(texture_2d      , vec2<i32> coords, i32 level_of_detail)`
+`vec4<type> textureLoad(texture_1d_array, vec2<i32> coords, i32 level_of_detail)`
+`vec4<type> textureLoad(texture_3d      , vec3<i32> coords, i32 level_of_detail)`
+`vec4<type> textureLoad(texture_2d_array, vec3<i32> coords, i32 level_of_detail)`
+  %32 = OpImageFetch %v4float %texture %coords Lod %level_of_detail
 
 `vec4<type> textureLoad(texture_multisampled_2d, vec2<i32> coords, i32 sample_index)`
   %32 = OpImageFetch %v4float %texture_multisampled %coords Sample %sample_index
 
-TODO(dsinclair): Add `textureWrite` method for texture_wo with integral coords
+TODO(dsinclair): Add `textureWrite` method for texture_storage_wo with integral coords
 
 TODO(dsinclair): Allow a small constant offset on the coordinate? May not be portable.
 
-`vec4<type> textureSample(texture_sampled_1d        , sampler, f32       coords)`
-`vec4<type> textureSample(texture_sampled_2d        , sampler, vec2<f32> coords)`
-`vec4<type> textureSample(texture_sampled_1d_array  , sampler, vec2<f32> coords)`
-`vec4<type> textureSample(texture_sampled_3d        , sampler, vec3<f32> coords)`
-`vec4<type> textureSample(texture_sampled_2d_array  , sampler, vec3<f32> coords)`
-`vec4<type> textureSample(texture_sampled_cube      , sampler, vec3<f32> coords)`
-`vec4<type> textureSample(texture_sampled_cube_array, sampler, vec4<f32> coords)`
+`vec4<type> textureSample(texture_1d        , sampler, f32       coords)`
+`vec4<type> textureSample(texture_2d        , sampler, vec2<f32> coords)`
+`vec4<type> textureSample(texture_1d_array  , sampler, vec2<f32> coords)`
+`vec4<type> textureSample(texture_3d        , sampler, vec3<f32> coords)`
+`vec4<type> textureSample(texture_2d_array  , sampler, vec3<f32> coords)`
+`vec4<type> textureSample(texture_cube      , sampler, vec3<f32> coords)`
+`vec4<type> textureSample(texture_cube_array, sampler, vec4<f32> coords)`
   %24 = OpImageSampleImplicitLod %v4float %sampled_image %coords
 
-`vec4<type> textureSampleLevel(texture_sampled_1d        , sampler, f32       coords, f32 lod)`
-`vec4<type> textureSampleLevel(texture_sampled_2d        , sampler, vec2<f32> coords, f32 lod)`
-`vec4<type> textureSampleLevel(texture_sampled_1d_array  , sampler, vec2<f32> coords, f32 lod)`
-`vec4<type> textureSampleLevel(texture_sampled_3d        , sampler, vec3<f32> coords, f32 lod)`
-`vec4<type> textureSampleLevel(texture_sampled_2d_array  , sampler, vec3<f32> coords, f32 lod)`
-`vec4<type> textureSampleLevel(texture_sampled_cube      , sampler, vec3<f32> coords, f32 lod)`
-`vec4<type> textureSampleLevel(texture_sampled_cube_array, sampler, vec4<f32> coords, f32 lod)`
+`vec4<type> textureSampleLevel(texture_1d        , sampler, f32       coords, f32 lod)`
+`vec4<type> textureSampleLevel(texture_2d        , sampler, vec2<f32> coords, f32 lod)`
+`vec4<type> textureSampleLevel(texture_1d_array  , sampler, vec2<f32> coords, f32 lod)`
+`vec4<type> textureSampleLevel(texture_3d        , sampler, vec3<f32> coords, f32 lod)`
+`vec4<type> textureSampleLevel(texture_2d_array  , sampler, vec3<f32> coords, f32 lod)`
+`vec4<type> textureSampleLevel(texture_cube      , sampler, vec3<f32> coords, f32 lod)`
+`vec4<type> textureSampleLevel(texture_cube_array, sampler, vec4<f32> coords, f32 lod)`
   %25 = OpImageSampleExplicitLod %v4float %sampled_image %coords Lod %lod
 
-`vec4<type> textureSampleBias(texture_sampled_1d        , sampler, f32       coords, f32 bias)`
-`vec4<type> textureSampleBias(texture_sampled_2d        , sampler, vec2<f32> coords, f32 bias)`
-`vec4<type> textureSampleBias(texture_sampled_1d_array  , sampler, vec2<f32> coords, f32 bias)`
-`vec4<type> textureSampleBias(texture_sampled_3d        , sampler, vec3<f32> coords, f32 bias)`
-`vec4<type> textureSampleBias(texture_sampled_2d_array  , sampler, vec3<f32> coords, f32 bias)`
-`vec4<type> textureSampleBias(texture_sampled_cube      , sampler, vec3<f32> coords, f32 bias)`
-`vec4<type> textureSampleBias(texture_sampled_cube_array, sampler, vec4<f32> coords, f32 bias)`
+`vec4<type> textureSampleBias(texture_1d        , sampler, f32       coords, f32 bias)`
+`vec4<type> textureSampleBias(texture_2d        , sampler, vec2<f32> coords, f32 bias)`
+`vec4<type> textureSampleBias(texture_1d_array  , sampler, vec2<f32> coords, f32 bias)`
+`vec4<type> textureSampleBias(texture_3d        , sampler, vec3<f32> coords, f32 bias)`
+`vec4<type> textureSampleBias(texture_2d_array  , sampler, vec3<f32> coords, f32 bias)`
+`vec4<type> textureSampleBias(texture_cube      , sampler, vec3<f32> coords, f32 bias)`
+`vec4<type> textureSampleBias(texture_cube_array, sampler, vec4<f32> coords, f32 bias)`
   %19 = OpImageSampleImplicitLod %v4float %sampled_image %coords Bias %bias
 
 `f32 textureSampleCompare(texture_depth_2d        , sampler_comparison, vec2<f32> coords, f32 depth_reference)`

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -706,7 +706,7 @@ For example:
 
 <div class='example' heading='Mapping a texture_storage_ro_1d variable to SPIR-V'>
   <xmp>
-      var<uniform_constant> tbuf : texture_storage_ro_1d<rgba8unorm>;
+      var tbuf : texture_storage_ro_1d<rgba8unorm>;
 
       # Maps to the following SPIR-V:
       #  OpDecorate %tbuf NonWritable
@@ -746,7 +746,7 @@ For example:
 
 <div class='example' heading='Mapping a texture_storage_wo_1d variable to SPIR-V'>
   <xmp>
-      var<uniform_constant> tbuf : texture_storage_wo_1d<rgba8unorm>;
+      var tbuf : texture_storage_wo_1d<rgba8unorm>;
 
       # Maps to the following SPIR-V:
       #  OpDecorate %tbuf NonReadable


### PR DESCRIPTION
This CL swaps the short texture name to be sampled textures and
explicitly names the storage textures.

So, `texture_sampled_1d` -> `texture_1d` and `texture_ro_1d` ->
`texture_storage_ro_1d`.

Issue #1159