### PR TITLE
[wgsl] Update storage textures to use access qualifiers

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1275,31 +1275,37 @@ The following table lists the correspondence between WGSL texel formats and
 </pre>
 * type must be `f32`, `i32` or `u32`
 
-### Read-only Storage Texture Types ### {#texture-ro}
+### Storage Texture Types ### {#texture-storage}
 
 A <dfn noexport>read-only storage texture</dfn> supports reading a single texel without the use of a sampler,
-with automatic conversion of the stored texel value to a usable shader value.
+with automatic conversion of the stored texel value to a usable shader value. A <dfn noexport>write-only storage
+texture</dfn> supports writing a single texel, with automatic conversion
+of the shader value to a stored texel value.
 See [[#texture-builtin-functions]].
 
-A read-only storage texture type must be parameterized one of [=storage-texel-format|texel formats for storage textures=].
+A storage texture type must be parameterized by one of the
+[=storage-texel-format|texel formats for storage textures=].
 The texel format determines the conversion function as specified in [[#texel-formats]].
+
+For a write-only storage texture the *inverse* of the conversion function is used to convert the shader value to
+the stored texel.
 
 TODO(dneto): Move description of the conversion to the builtin function that actually does the reading.
 
 <pre class='def'>
-`texture_storage_ro_1d<texel_format>`
+`texture_storage_1d<texel_format>`
   // %1 = OpTypeImage sampled_type 1D 0 0 0 2 image_format
 
-`texture_storage_ro_1d_array<texel_format>`
+`texture_storage_1d_array<texel_format>`
   // %1 = OpTypeImage sampled_type 1D 0 1 0 2 image_format
 
-`texture_storage_ro_2d<texel_format>`
+`texture_storage_2d<texel_format>`
   // %1 = OpTypeImage sampled_type 2D 0 0 0 2 image_format
 
-`texture_storage_ro_2d_array<texel_format>`
+`texture_storage_2d_array<texel_format>`
   // %1 = OpTypeImage sampled_type 2D 0 1 0 2 image_format
 
-`texture_storage_ro_3d<texel_format>`
+`texture_storage_3d<texel_format>`
   // %1 = OpTypeImage sampled_type 3D 0 0 0 2 texel_format
 </pre>
 
@@ -1309,12 +1315,14 @@ In the SPIR-V mapping:
 * The *Sampled Type* parameter of the image type declaration is
     the SPIR-V scalar type corresponding to the channel format for the texel format.
 
-When mapping to SPIR-V, a read-only storage texture variable must also have a `NonWritable` decoration.
+When mapping to SPIR-V, a read-only storage texture variable must have a `NonWritable` decoration and
+a write-only storage texture variable must have a `NonReadable` decoration.
+
 For example:
 
-<div class='example wgsl global-scope' heading='Mapping a texture_storage_ro_1d variable to SPIR-V'>
+<div class='example wgsl global-scope' heading='Mapping a readable texture_storage_1d variable to SPIR-V'>
   <xmp>
-      var tbuf : texture_storage_ro_1d<rgba8unorm>;
+      var tbuf : [[access(read)]] texture_storage_1d<rgba8unorm>;
 
       // Maps to the following SPIR-V:
       //  OpDecorate %tbuf NonWritable
@@ -1326,48 +1334,9 @@ For example:
   </xmp>
 </div>
 
-### Write-only Storage Texture Types ### {#texture-wo}
-
-A <dfn noexport>write-only storage texture</dfn> supports writing a single texel, with automatic conversion
-of the shader value to a stored texel value.
-See [[#texture-builtin-functions]].
-
-A write-only storage texture type must be parameterized one of [=storage-texel-format|texel formats for storage textures=].
-The texel format determines the conversion function as specified in [[#texel-formats]].
-The *inverse* of the conversion function is used to convert the shader value to
-the stored texel.
-
-TODO(dneto): Move description of the conversion to the builtin function that actually does the writing.
-
-<pre class='def'>
-`texture_storage_wo_1d<texel_format>`
-  // %1 = OpTypeImage %void 1D 0 0 0 2 image_format
-
-`texture_storage_wo_1d_array<texel_format>`
-  // %1 = OpTypeImage %void 1D 0 1 0 2 image_format
-
-`texture_storage_wo_2d<texel_format>`
-  // %1 = OpTypeImage %void 2D 0 0 0 2 image_format
-
-`texture_storage_wo_2d_array<texel_format>`
-  // %1 = OpTypeImage %void 2D 0 1 0 2 image_format
-
-`texture_storage_wo_3d<texel_format>`
-  // %1 = OpTypeImage %void 3D 0 0 0 2 image_format
-</pre>
-
-In the SPIR-V mapping:
-* The *Image Format* parameter of the image type declaration is
-    as specified by the SPIR-V texel format correspondence table in [[#texel-formats]].
-* The *Sampled Type* parameter of the image type declaration is
-    the SPIR-V void type
-
-When mapping to SPIR-V, a write-only storage texture variable must also have a `NonReadable` decoration.
-For example:
-
-<div class='example wgsl global-scope' heading='Mapping a texture_storage_wo_1d variable to SPIR-V'>
+<div class='example wgsl global-scope' heading='Mapping a writable texture_storage_1d variable to SPIR-V'>
   <xmp>
-      var tbuf : texture_storage_wo_1d<rgba8unorm>;
+      var tbuf : [[access(write)]] texture_storage_1d<rgba8unorm>;
 
       // Maps to the following SPIR-V:
       //  OpDecorate %tbuf NonReadable
@@ -1431,16 +1400,11 @@ multisampled_texture_type
   : TEXTURE_MULTISAMPLED_2D
 
 storage_texture_type
-  : TEXTURE_STORAGE_RO_1D
-  | TEXTURE_STORAGE_RO_1D_ARRAY
-  | TEXTURE_STORAGE_RO_2D
-  | TEXTURE_STORAGE_RO_2D_ARRAY
-  | TEXTURE_STORAGE_RO_3D
-  | TEXTURE_STORAGE_WO_1D
-  | TEXTURE_STORAGE_WO_1D_ARRAY
-  | TEXTURE_STORAGE_WO_2D
-  | TEXTURE_STORAGE_WO_2D_ARRAY
-  | TEXTURE_STORAGE_WO_3D
+  : TEXTURE_STORAGE_1D
+  | TEXTURE_STORAGE_1D_ARRAY
+  | TEXTURE_STORAGE_2D
+  | TEXTURE_STORAGE_2D_ARRAY
+  | TEXTURE_STORAGE_3D
 
 depth_texture_type
   : TEXTURE_DEPTH_2D
@@ -1675,7 +1639,7 @@ variable_storage_decoration
   <thead>
     <tr><th>Variable declaration decoration keys<th>Valid values<th>Note
   </thead>
-  <tr><td>`access`<td>`read` or `read_write`<td>
+  <tr><td>`access`<td>`read`, `write` or `read_write`<td>
 </table>
 
 The access decoration must only appear on a type used as the store type for a
@@ -4052,16 +4016,11 @@ I've written what an NVIDIA GPU does.  See https://github.com/google/amber/pull/
   <tr><td>`TEXTURE_CUBE`<td>texture_cube
   <tr><td>`TEXTURE_CUBE_ARRAY`<td>texture_cube_array
   <tr><td>`TEXTURE_MULTISAMPLED_2D`<td>texture_multisampled_2d
-  <tr><td>`TEXTURE_STORAGE_RO_1D`<td>texture_storage_ro_1d
-  <tr><td>`TEXTURE_STORAGE_RO_1D_ARRAY`<td>texture_storage_ro_1d_array
-  <tr><td>`TEXTURE_STORAGE_RO_2D`<td>texture_storage_ro_2d
-  <tr><td>`TEXTURE_STORAGE_RO_2D_ARRAY`<td>texture_storage_ro_2d_array
-  <tr><td>`TEXTURE_STORAGE_RO_3D`<td>texture_storage_ro_3d
-  <tr><td>`TEXTURE_STORAGE_WO_1D`<td>texture_storage_wo_1d
-  <tr><td>`TEXTURE_STORAGE_WO_1D_ARRAY`<td>texture_storage_wo_1d_array
-  <tr><td>`TEXTURE_STORAGE_WO_2D`<td>texture_storage_wo_2d
-  <tr><td>`TEXTURE_STORAGE_WO_2D_ARRAY`<td>texture_storage_wo_2d_array
-  <tr><td>`TEXTURE_STORAGE_WO_3D`<td>texture_storage_wo_3d
+  <tr><td>`TEXTURE_STORAGE_1D`<td>texture_storage_1d
+  <tr><td>`TEXTURE_STORAGE_1D_ARRAY`<td>texture_storage_1d_array
+  <tr><td>`TEXTURE_STORAGE_2D`<td>texture_storage_2d
+  <tr><td>`TEXTURE_STORAGE_2D_ARRAY`<td>texture_storage_2d_array
+  <tr><td>`TEXTURE_STORAGE_3D`<td>texture_storage_3d
   <tr><td>`TEXTURE_DEPTH_2D`<td>texture_depth_2d
   <tr><td>`TEXTURE_DEPTH_2D_ARRAY`<td>texture_depth_2d_array
   <tr><td>`TEXTURE_DEPTH_CUBE`<td>texture_depth_cube
@@ -5167,11 +5126,11 @@ textureLoad(t : texture_depth_2d, coords : vec2<i32>) -> f32
 textureLoad(t : texture_depth_2d, coords : vec2<i32>, level : i32) -> f32
 textureLoad(t : texture_depth_2d_array, coords : vec2<i32>, array_index : i32) -> f32
 textureLoad(t : texture_depth_2d_array, coords : vec2<i32>, array_index : i32, level : i32) -> f32
-textureLoad(t : texture_storage_ro_1d<F>, coords : i32) -> vec4<T>
-textureLoad(t : texture_storage_ro_1d_array<F>, coords : i32, array_index : i32) -> vec4<T>
-textureLoad(t : texture_storage_ro_2d<F>, coords : vec2<i32>) -> vec4<T>
-textureLoad(t : texture_storage_ro_2d_array<F>, coords : vec2<i32>, array_index : i32) -> vec4<T>
-textureLoad(t : texture_storage_ro_3d<F>, coords : vec3<i32>) -> vec4<T>
+textureLoad(t : access(read) texture_storage_1d<F>, coords : i32) -> vec4<T>
+textureLoad(t : access(read) texture_storage_1d_array<F>, coords : i32, array_index : i32) -> vec4<T>
+textureLoad(t : access(read) texture_storage_2d<F>, coords : vec2<i32>) -> vec4<T>
+textureLoad(t : access(read) texture_storage_2d_array<F>, coords : vec2<i32>, array_index : i32) -> vec4<T>
+textureLoad(t : access(read) texture_storage_3d<F>, coords : vec3<i32>) -> vec4<T>
 ```
 
 For [read-only storage textures](#texture-ro) the returned channel format `T`
@@ -5207,11 +5166,11 @@ If any of the parameters are out of bounds, then zero in all components.
 Writes a single texel to a texture.
 
 ```rust
-textureStore(t : texture_storage_wo_1d<F>, coords : i32, value : vec4<T>) -> void
-textureStore(t : texture_storage_wo_1d_array<F>, coords : i32, array_index : i32, value : vec4<T>) -> void
-textureStore(t : texture_storage_wo_2d<F>, coords : vec2<i32>, value : vec4<T>) -> void
-textureStore(t : texture_storage_wo_2d_array<F>, coords : vec2<i32>, array_index : i32, value : vec4<T>) -> void
-textureStore(t : texture_storage_wo_3d<F>, coords : vec3<i32>, value : vec4<T>) -> void
+textureStore(t : access(write) texture_storage_1d<F>, coords : i32, value : vec4<T>) -> void
+textureStore(t : access(write) texture_storage_1d_array<F>, coords : i32, array_index : i32, value : vec4<T>) -> void
+textureStore(t : access(write) texture_storage_2d<F>, coords : vec2<i32>, value : vec4<T>) -> void
+textureStore(t : access(write) texture_storage_2d_array<F>, coords : vec2<i32>, array_index : i32, value : vec4<T>) -> void
+textureStore(t : access(write) texture_storage_3d<F>, coords : vec3<i32>, value : vec4<T>) -> void
 ```
 
 The channel format `T` depends on the storage texel format `F`.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5126,11 +5126,11 @@ textureLoad(t : texture_depth_2d, coords : vec2<i32>) -> f32
 textureLoad(t : texture_depth_2d, coords : vec2<i32>, level : i32) -> f32
 textureLoad(t : texture_depth_2d_array, coords : vec2<i32>, array_index : i32) -> f32
 textureLoad(t : texture_depth_2d_array, coords : vec2<i32>, array_index : i32, level : i32) -> f32
-textureLoad(t : access(read) texture_storage_1d<F>, coords : i32) -> vec4<T>
-textureLoad(t : access(read) texture_storage_1d_array<F>, coords : i32, array_index : i32) -> vec4<T>
-textureLoad(t : access(read) texture_storage_2d<F>, coords : vec2<i32>) -> vec4<T>
-textureLoad(t : access(read) texture_storage_2d_array<F>, coords : vec2<i32>, array_index : i32) -> vec4<T>
-textureLoad(t : access(read) texture_storage_3d<F>, coords : vec3<i32>) -> vec4<T>
+textureLoad(t : [[access(read)]] texture_storage_1d<F>, coords : i32) -> vec4<T>
+textureLoad(t : [[access(read)]] texture_storage_1d_array<F>, coords : i32, array_index : i32) -> vec4<T>
+textureLoad(t : [[access(read)]] texture_storage_2d<F>, coords : vec2<i32>) -> vec4<T>
+textureLoad(t : [[access(read)]] texture_storage_2d_array<F>, coords : vec2<i32>, array_index : i32) -> vec4<T>
+textureLoad(t : [[access(read)]] texture_storage_3d<F>, coords : vec3<i32>) -> vec4<T>
 ```
 
 For [read-only storage textures](#texture-storage) the returned channel format `T`
@@ -5166,11 +5166,11 @@ If any of the parameters are out of bounds, then zero in all components.
 Writes a single texel to a texture.
 
 ```rust
-textureStore(t : access(write) texture_storage_1d<F>, coords : i32, value : vec4<T>) -> void
-textureStore(t : access(write) texture_storage_1d_array<F>, coords : i32, array_index : i32, value : vec4<T>) -> void
-textureStore(t : access(write) texture_storage_2d<F>, coords : vec2<i32>, value : vec4<T>) -> void
-textureStore(t : access(write) texture_storage_2d_array<F>, coords : vec2<i32>, array_index : i32, value : vec4<T>) -> void
-textureStore(t : access(write) texture_storage_3d<F>, coords : vec3<i32>, value : vec4<T>) -> void
+textureStore(t : [[access(write)]] texture_storage_1d<F>, coords : i32, value : vec4<T>) -> void
+textureStore(t : [[access(write)]] texture_storage_1d_array<F>, coords : i32, array_index : i32, value : vec4<T>) -> void
+textureStore(t : [[access(write)]] texture_storage_2d<F>, coords : vec2<i32>, value : vec4<T>) -> void
+textureStore(t : [[access(write)]] texture_storage_2d_array<F>, coords : vec2<i32>, array_index : i32, value : vec4<T>) -> void
+textureStore(t : [[access(write)]] texture_storage_3d<F>, coords : vec3<i32>, value : vec4<T>) -> void
 ```
 
 The channel format `T` depends on the storage texel format `F`.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1171,7 +1171,7 @@ The texel formats listed in the
 correspond to the [[WebGPU#plain-color-formats|WebGPU plain color formats]]
 which support the [[WebGPU#dom-gputextureusage-storage|WebGPU STORAGE]] usage.
 These texel formats are used to parameterize the storage texture types defined
-in [[#texture-ro]] and [[#texture-wo]].
+in [[#texture-storage]].
 
 When the texel format does not have all four channels, then:
 
@@ -5133,7 +5133,7 @@ textureLoad(t : access(read) texture_storage_2d_array<F>, coords : vec2<i32>, ar
 textureLoad(t : access(read) texture_storage_3d<F>, coords : vec3<i32>) -> vec4<T>
 ```
 
-For [read-only storage textures](#texture-ro) the returned channel format `T`
+For [read-only storage textures](#texture-storage) the returned channel format `T`
 depends on the texel format `F`.
 [See the texel format table](#storage-texel-formats) for the mapping of texel
 format to channel format.
@@ -5144,7 +5144,7 @@ format to channel format.
   <tr><td>`t`<td>
   The [sampled](#sampled-texture-type),
   [multisampled](#multisampled-texture-type), [depth](#texture-depth) or
-  [read-only storage](#texture-ro) texture.
+  [read-only storage](#texture-storage) texture.
   <tr><td>`coords`<td>
   The 0-based texel coordinate.
   <tr><td>`array_index`<td>
@@ -5181,7 +5181,7 @@ format to channel format.
 
 <table class='data'>
   <tr><td>`t`<td>
-  The [write-only storage texture](#texture-wo).
+  The [write-only storage texture](#texture-storage).
   <tr><td>`coords`<td>
   The 0-based texel coordinate.<br>
   <tr><td>`array_index`<td>


### PR DESCRIPTION
This CL updates the storage textures to use an access qualifier instead of the typename
to specify read/write.

For example, `texture_storage_ro_1d<type>` -> `[[access(read)]] texture_storage_1d<type>`.

Issue #1159