### PR TITLE
[wgsl] Add access qualifier to buffer types

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1109,21 +1109,19 @@ variable_decl
   : VAR variable_storage_decoration? variable_ident_decl
 
 variable_ident_decl
-  : IDENT COLON variable_type_decoration_list* type_decl
+  : IDENT COLON variable_decoration_list* type_decl
 
 variable_storage_decoration
   : LESS_THAN storage_class GREATER_THAN
 
-variable_type_decoration_list
-  : ATTR_LEFT (variable_type_decoration COMMA)* variable_type_decoration ATTR_RIGHT
-
-variable_type_decoration
-  : ACCESS PAREN_LEFT access_type PAREN_RIGHT
-
-access_type
-  : READ
-  | READ_WRITE
 </pre>
+
+<table class='data'>
+  <thead>
+    <tr><th>Variable declaration decoration keys<th>Valid values<th>Note
+  </thead>
+  <tr><td>`access`<td>`read` or `read_write`<td>
+</table>
 
 The access decoration must only appear on a type used as the store type for a
 variable in the `storage` [=storage class=]. The access decoration must not appear

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -986,7 +986,7 @@ type_alias
 
 <pre class='def'>
 type_decl
-  : IDENT
+  : ident_type_decoration_list* IDENT
   | BOOL
   | FLOAT32
   | INT32
@@ -1018,7 +1018,21 @@ array_decoration_list
 
 array_decoration
   : STRIDE PAREN_LEFT INT_LITERAL PAREN_RIGHT
+
+ident_type_decoration_list
+  : ATTR_LEFT (ident_type_decoration COMMA)* ident_type_decoration ATTR_RIGHT
+
+ident_type_decoration
+  : ACCESS PAREN_LEFT access_type PAREN_RIGHT
+
+access_type
+  : READ
+  | READ_WRITE
 </pre>
+
+The `access` decoration may only be applied to identifiers which are a
+[=host-shareable=] struct type. The access modifier only has effect when the
+struct is the type of a `storage` [=storage class=] variable.
 
 <div class='example' heading="Type Declarations">
   <xmp>
@@ -1058,6 +1072,13 @@ array_decoration
   </xmp>
 </div>
 
+<div class='example' heading='Access qualifier'>
+  <xmp>
+    var<storage> buf1 : [[access(read)]] Buffer;       # can read, cannot write.
+    var<storage> buf2 : [[access(read_write)]] Buffer; # can both read and write
+    var<uniform> b3 : Buffer;  # UBO. Hence: read-only. More restrictive layout rules. Does not need a qualifier.
+  </xmp>
+</div>
 
 # Variable and const # {#variables}
 
@@ -3457,6 +3478,7 @@ I've written what an NVIDIA GPU does.  See https://github.com/google/amber/pull/
   <thead>
     <tr><td>Token<td>Definition
   </thead>
+  <tr><td>`ACCESS`<td>access
   <tr><td>`BITCAST`<td>bitcast
   <tr><td>`BLOCK`<td>block
   <tr><td>`BREAK`<td>break
@@ -3484,6 +3506,8 @@ I've written what an NVIDIA GPU does.  See https://github.com/google/amber/pull/
   <tr><td>`OFFSET`<td>offset
   <tr><td>`OUT`<td>out
   <tr><td>`PRIVATE`<td>private
+  <tr><td>`READ`<td>read
+  <tr><td>`READ_WRITE`<td>read_write
   <tr><td>`RETURN`<td>return
   <tr><td>`STAGE`<td>stage
   <tr><td>`STRIDE`<td>stride

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1128,7 +1128,8 @@ access_type
 The access decoration must only appear on a type used as the store type for a
 variable in the `storage` [=storage class=]. The access decoration must not appear
 on a type of const declaration nor as the store type for variable with a
-[=storage class=] other than `storage`.
+[=storage class=] other than `storage`. The access decoration is required for
+variables in the `storage` [=storage class=].
 
 Two variables with overlapping lifetimes will not have overlapping storage.
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1030,11 +1030,10 @@ access_type
   | READ_WRITE
 </pre>
 
-The `access` decoration may only be applied to identifiers which are a
-[=host-shareable=] struct type.
-
- * For storage buffers, exactly one of `access(read)`, `access(read_write)` is required.
- * For uniform buffers, no modifier is allowed.
+The access decoration must only appear on a type used as the store type for a
+variable in the `storage` [=storage class=]. The access decoration must not appear
+on a type of const declaration nor as the store type for variable with a
+[=storage class=] other than `storage`.
 
 <div class='example' heading="Type Declarations">
   <xmp>
@@ -1079,6 +1078,16 @@ The `access` decoration may only be applied to identifiers which are a
     # Storage buffers
     var<storage> buf1 : [[access(read)]] Buffer;       # Can read, cannot write.
     var<storage> buf2 : [[access(read_write)]] Buffer; # Can both read and write
+
+    # Access qualifier attached through a type alias.
+    type ROBuffer1 = [[access(read)]] Buffer;
+    var<storage> roBuf1 : ROBuffer1;  # Can read, cannot write
+
+    # Access qualifier directly attached to the struct definition.
+    [[access(read)]] struct ROBuffer2 {
+      var a : f32;
+    };
+    var<storage> roBuf2 : ROBuffer2;  # Can read, cannot write
 
     # Uniform buffer. Always read-only, and has more restrictive layout rules.
     var<uniform> params : ParamsTable;

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1031,8 +1031,10 @@ access_type
 </pre>
 
 The `access` decoration may only be applied to identifiers which are a
-[=host-shareable=] struct type. The access modifier only has effect when the
-struct is the type of a `storage` [=storage class=] variable.
+[=host-shareable=] struct type.
+
+ * For storage buffers, exactly one of `access(read)`, `access(read_write)` is required.
+ * For uniform buffers, no modifier is allowed.
 
 <div class='example' heading="Type Declarations">
   <xmp>
@@ -1074,9 +1076,12 @@ struct is the type of a `storage` [=storage class=] variable.
 
 <div class='example' heading='Access qualifier'>
   <xmp>
-    var<storage> buf1 : [[access(read)]] Buffer;       # can read, cannot write.
-    var<storage> buf2 : [[access(read_write)]] Buffer; # can both read and write
-    var<uniform> b3 : Buffer;  # UBO. Hence: read-only. More restrictive layout rules. Does not need a qualifier.
+    # Storage buffers
+    var<storage> buf1 : [[access(read)]] Buffer;       # Can read, cannot write.
+    var<storage> buf2 : [[access(read_write)]] Buffer; # Can both read and write
+
+    # Uniform buffer. Always read-only, and has more restrictive layout rules.
+    var<uniform> params : ParamsTable;
   </xmp>
 </div>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1083,12 +1083,6 @@ on a type of const declaration nor as the store type for variable with a
     type ROBuffer1 = [[access(read)]] Buffer;
     var<storage> roBuf1 : ROBuffer1;  # Can read, cannot write
 
-    # Access qualifier directly attached to the struct definition.
-    [[access(read)]] struct ROBuffer2 {
-      var a : f32;
-    };
-    var<storage> roBuf2 : ROBuffer2;  # Can read, cannot write
-
     # Uniform buffer. Always read-only, and has more restrictive layout rules.
     var<uniform> params : ParamsTable;
   </xmp>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3481,7 +3481,6 @@ I've written what an NVIDIA GPU does.  See https://github.com/google/amber/pull/
   <thead>
     <tr><td>Token<td>Definition
   </thead>
-  <tr><td>`ACCESS`<td>access
   <tr><td>`BITCAST`<td>bitcast
   <tr><td>`BLOCK`<td>block
   <tr><td>`BREAK`<td>break
@@ -3509,8 +3508,6 @@ I've written what an NVIDIA GPU does.  See https://github.com/google/amber/pull/
   <tr><td>`OFFSET`<td>offset
   <tr><td>`OUT`<td>out
   <tr><td>`PRIVATE`<td>private
-  <tr><td>`READ`<td>read
-  <tr><td>`READ_WRITE`<td>read_write
   <tr><td>`RETURN`<td>return
   <tr><td>`STAGE`<td>stage
   <tr><td>`STRIDE`<td>stride

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -986,7 +986,7 @@ type_alias
 
 <pre class='def'>
 type_decl
-  : ident_type_decoration_list* IDENT
+  : IDENT
   | BOOL
   | FLOAT32
   | INT32
@@ -1018,22 +1018,7 @@ array_decoration_list
 
 array_decoration
   : STRIDE PAREN_LEFT INT_LITERAL PAREN_RIGHT
-
-ident_type_decoration_list
-  : ATTR_LEFT (ident_type_decoration COMMA)* ident_type_decoration ATTR_RIGHT
-
-ident_type_decoration
-  : ACCESS PAREN_LEFT access_type PAREN_RIGHT
-
-access_type
-  : READ
-  | READ_WRITE
 </pre>
-
-The access decoration must only appear on a type used as the store type for a
-variable in the `storage` [=storage class=]. The access decoration must not appear
-on a type of const declaration nor as the store type for variable with a
-[=storage class=] other than `storage`.
 
 <div class='example' heading="Type Declarations">
   <xmp>
@@ -1078,10 +1063,6 @@ on a type of const declaration nor as the store type for variable with a
     # Storage buffers
     var<storage> buf1 : [[access(read)]] Buffer;       # Can read, cannot write.
     var<storage> buf2 : [[access(read_write)]] Buffer; # Can both read and write
-
-    # Access qualifier attached through a type alias.
-    type ROBuffer1 = [[access(read)]] Buffer;
-    var<storage> roBuf1 : ROBuffer1;  # Can read, cannot write
 
     # Uniform buffer. Always read-only, and has more restrictive layout rules.
     var<uniform> params : ParamsTable;
@@ -1128,11 +1109,26 @@ variable_decl
   : VAR variable_storage_decoration? variable_ident_decl
 
 variable_ident_decl
-  : IDENT COLON type_decl
+  : IDENT COLON variable_type_decoration_list* type_decl
 
 variable_storage_decoration
   : LESS_THAN storage_class GREATER_THAN
+
+variable_type_decoration_list
+  : ATTR_LEFT (variable_type_decoration COMMA)* variable_type_decoration ATTR_RIGHT
+
+variable_type_decoration
+  : ACCESS PAREN_LEFT access_type PAREN_RIGHT
+
+access_type
+  : READ
+  | READ_WRITE
 </pre>
+
+The access decoration must only appear on a type used as the store type for a
+variable in the `storage` [=storage class=]. The access decoration must not appear
+on a type of const declaration nor as the store type for variable with a
+[=storage class=] other than `storage`.
 
 Two variables with overlapping lifetimes will not have overlapping storage.
 


### PR DESCRIPTION
This CL adds the ability to provide an `access(read|read_write)` to a
buffer type. This is only available for storage variables.

Issue #1159