### PR TITLE
Upload CI build output as artifact

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,12 @@ jobs:
           mkdir out
           ./compile.sh
 
+      - name: Archive build ouput as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: rendered
+          path: out/
+
       - name: Deploy to GitHub Pages (only on main branch)
         if: ${{ success() && github.ref == 'refs/heads/main' }}
         uses: JamesIves/github-pages-deploy-action@releases/v3


### PR DESCRIPTION
Stores build output as GitHub artifact, that can be downloaded as .zip.

Then we 'just' need GitHub to implement UI for browing artifacts 😄 