### PR TITLE
Documented guaranteed swap chain formats and validation

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6816,20 +6816,20 @@ Issue: Because timestamp query provides high-resolution GPU timestamp, we need t
 interface GPUCanvasContext {
     GPUSwapChain configureSwapChain(GPUSwapChainDescriptor descriptor);
 
-    Promise<GPUTextureFormat> getSwapChainPreferredFormat(GPUDevice device);
+    GPUTextureFormat getSwapChainPreferredFormat(GPUAdapter adapter);
 };
 </script>
 
 {{GPUCanvasContext}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for=GPUCanvasContext>
-    : <dfn>\[[supported_formats]]</dfn>, of type [=ordered map=]&lt;{{GPUDevice}}, [=set=]&lt;{{GPUTextureFormat}}&gt;&gt;
+    : <dfn>\[[supported_formats]]</dfn>, of type [=ordered map=]&lt;{{GPUAdapter}}, [=set=]&lt;{{GPUTextureFormat}}&gt;&gt;
     ::
-        The {{GPUTextureFormat}}s that are valid to configure a {{GPUSwapChain}} with for a given {{GPUDevice}}.
+        The {{GPUTextureFormat}}s that are valid to configure a {{GPUSwapChain}} with for a given {{GPUAdapter}}.
 
-    : <dfn>\[[preferred_format]]</dfn>, of type [=ordered map=]&lt;{{GPUDevice}}, {{GPUTextureFormat}}&gt;
+    : <dfn>\[[preferred_format]]</dfn>, of type [=ordered map=]&lt;{{GPUAdapter}}, {{GPUTextureFormat}}&gt;
     ::
-        An optimal {{GPUTextureFormat}} to use when creating a {{GPUSwapChain}} for a given {{GPUDevice}}.
+        An optimal {{GPUTextureFormat}} to use when creating a {{GPUSwapChain}} for a given {{GPUAdapter}}.
 </dl>
 
 {{GPUCanvasContext}} has the following methods:
@@ -6852,15 +6852,18 @@ interface GPUCanvasContext {
 
             **Returns:** {{GPUSwapChain}}
 
-            1. If any of the following conditions are unsatisfied, generate a validation error and stop.
-                <div class=validusage>
-                    - |descriptor|.{{GPUSwapChainDescriptor/device}} is a [=valid=] {{GPUDevice}}.
-                    - Let |supportedFormats| be the [$supported swap chain formats$] for |this| and
-                        |descriptor|.{{GPUSwapChainDescriptor/device}}.
-                    - |supportedFormats| [=set/contains=] |descriptor|.{{GPUSwapChainDescriptor/format}}.
-                </div>
+            1. Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
+                    1. If any of the following conditions are unsatisfied, generate a validation error and stop.
+                        <div class=validusage>
+                            - |descriptor|.{{GPUSwapChainDescriptor/device}} is a [=valid=] {{GPUDevice}}.
+                            - Let |supportedFormats| be the [$supported swap chain formats$] for |this| and
+                                |descriptor|.{{GPUSwapChainDescriptor/device}}.{{GPUDevice/adapter}}.
+                            - |supportedFormats| [=set/contains=] |descriptor|.{{GPUSwapChainDescriptor/format}}.
+                        </div>
 
-            Issue: Describe remaining {{GPUCanvasContext/configureSwapChain()}} algorithm steps.
+                    Issue: Describe remaining {{GPUCanvasContext/configureSwapChain()}} algorithm steps.
+                </div>
         </div>
 
     : <dfn>getSwapChainPreferredFormat(device)</dfn>
@@ -6872,28 +6875,16 @@ interface GPUCanvasContext {
             **Called on:** {{GPUCanvasContext}} |this|.
 
             **Arguments:**
-            <pre class=argumentdef for="GPUCanvasContext/getSwapChainPreferredFormat(device)">
-                |device|: Device the swap chain format should be queried for.
+            <pre class=argumentdef for="GPUCanvasContext/getSwapChainPreferredFormat(adapter)">
+                |adapter|: Adapter the swap chain format should be queried for.
             </pre>
 
-            **Returns:** {{Promise}}&lt;{{GPUTextureFormat}}&gt;
+            **Returns:** {{GPUTextureFormat}}
 
-            1. Let |promise| be [=a new promise=].
-            1. Issue the following steps on the [=Device timeline=] of |this|:
-                <div class=device-timeline>
-                    1. If any of the following conditions are unsatisfied, [=reject=] |promise| with
-                        an {{OperationError}} and stop.
-
-                        <div class=validusage>
-                            - |device| is a [=valid=] {{GPUDevice}}.
-                        </div>
-
-                    1. Let |preferredFormat| be the [$preferred swap chain format$] for |this| and |device|.
-                    1. Let |supportedFormats| be the [$supported swap chain formats$] for |this| and |device|.
-                    1. [=set/Append=] |preferredFormat| to |supportedFormats|.
-                    1. [=Resolve=] |promise| with |preferredFormat|.
-                </div>
-            1. Return |promise|.
+            <div class=content-timeline>
+                1. Let |preferredFormat| be the [$preferred swap chain format$] for |this| and |adapter|.
+                1. Return |preferredFormat|.
+            </div>
         </div>
 </dl>
 
@@ -6904,25 +6895,27 @@ of the given {{GPUSwapChainDescriptor}}.{{GPUSwapChainDescriptor/device}}, initi
 
 <div algorithm>
     To get the <dfn abstract-op>supported swap chain formats</dfn> for a given {{GPUCanvasContext}}
-    |context| and a given {{GPUDevice}} |device| run the following steps:
+    |context| and a given {{GPUAdapter}} |adapter| run the following steps:
 
     1. Let |supportedFormats| be |context|.{{GPUCanvasContext/[[supported_formats]]}}
-    1. If |supportedFormats|[|device|] does not exis:
-        1. Set |supportedFormats|[|device|] to be a [=set/clone=] of [=guaranteed swap chain formats=].
-    1. Return |supportedFormats|[|device|].
+    1. If |supportedFormats|[|adapter|] does not exis:
+        1. Set |supportedFormats|[|adapter|] to be a [=set/clone=] of [=guaranteed swap chain formats=].
+        1. Let |preferredFormat| be the [$preferred swap chain format$] for |context| and |adapter|.
+        1. [=set/Append=] |preferredFormat| to |supportedFormats|[|adapter|].
+    1. Return |supportedFormats|[|adapter|].
 </div>
 
 <div algorithm>
     To get the <dfn abstract-op>preferred swap chain format</dfn> for a given {{GPUCanvasContext}}
-    |context| and a given {{GPUDevice}} |device| run the following steps::
+    |context| and a given {{GPUAdapter}} |adapter| run the following steps::
 
     1. Let |preferredFormat| be |context|.{{GPUCanvasContext/[[preferred_format]]}}
-    1. If |preferredFormat|[|device|] does not exist:
-        1. Set |preferredFormat|[|device|] to be an renderable {{GPUTextureFormat}} known to be
-            optimal for use with |context| and |device|. The user agent may use any criteria to
+    1. If |preferredFormat|[|adapter|] does not exist:
+        1. Set |preferredFormat|[|adapter|] to be an renderable {{GPUTextureFormat}} known to be
+            optimal for use with |context| and |adapter|. The user agent may use any criteria to
             select the format. If no optimal format is known, the user agent should select one of
             the [=guaranteed swap chain formats=].
-    1. Return |preferredFormat|[|device|].
+    1. Return |preferredFormat|[|adapter|].
 </div>
 
 <script type=idl>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1265,11 +1265,6 @@ interface GPUAdapter {
     : <dfn>\[[adapter]]</dfn>, of type [=adapter=], readonly
     ::
         The [=adapter=] to which this {{GPUAdapter}} refers.
-
-    : <dfn>\[[preferred_format]]</dfn>, of type {{GPUTextureFormat}}, readonly
-    ::
-        An optimal {{GPUTextureFormat}} to use when creating a {{GPUSwapChain}} for a this [=adapter=].
-        Must be one of the [=supported swap chain formats=].
 </dl>
 
 {{GPUAdapter}} has the following methods:
@@ -6825,14 +6820,6 @@ interface GPUCanvasContext {
 };
 </script>
 
-{{GPUCanvasContext}} has the following internal slots:
-
-<dl dfn-type=attribute dfn-for=GPUCanvasContext>
-    : <dfn>\[[preferred_format]]</dfn>, of type [=ordered map=]&lt;{{GPUAdapter}}, {{GPUTextureFormat}}&gt;
-    ::
-        An optimal {{GPUTextureFormat}} to use when creating a {{GPUSwapChain}} for a given {{GPUAdapter}}.
-</dl>
-
 {{GPUCanvasContext}} has the following methods:
 
 <dl dfn-type=method dfn-for=GPUCanvasContext>
@@ -6881,7 +6868,8 @@ interface GPUCanvasContext {
             **Returns:** {{GPUTextureFormat}}
 
             <div class=content-timeline>
-                1. Return |adapter|.{{GPUAdapter/[[preferred_format]]}}
+                1. Return an optimal {{GPUTextureFormat}} to use when creating a {{GPUSwapChain}}
+                    with the given |adapter|. Must be one of the [=supported swap chain formats=].
             </div>
         </div>
 </dl>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1265,6 +1265,11 @@ interface GPUAdapter {
     : <dfn>\[[adapter]]</dfn>, of type [=adapter=], readonly
     ::
         The [=adapter=] to which this {{GPUAdapter}} refers.
+
+    : <dfn>\[[preferred_format]]</dfn>, of type {{GPUTextureFormat}}, readonly
+    ::
+        An optimal {{GPUTextureFormat}} to use when creating a {{GPUSwapChain}} for a this [=adapter=].
+        Must be one of the [=supported swap chain formats=].
 </dl>
 
 {{GPUAdapter}} has the following methods:
@@ -6853,21 +6858,20 @@ interface GPUCanvasContext {
                     1. If any of the following conditions are unsatisfied, generate a validation error and stop.
                         <div class=validusage>
                             - |descriptor|.{{GPUSwapChainDescriptor/device}} is a [=valid=] {{GPUDevice}}.
-                            - Let |supportedFormats| be the [=supported swap chain formats=].
-                            - |supportedFormats| [=set/contains=] |descriptor|.{{GPUSwapChainDescriptor/format}}.
+                            - [=Supported swap chain formats=] [=set/contains=] |descriptor|.{{GPUSwapChainDescriptor/format}}.
                         </div>
 
                     Issue: Describe remaining {{GPUCanvasContext/configureSwapChain()}} algorithm steps.
                 </div>
         </div>
 
-    : <dfn>getSwapChainPreferredFormat(device)</dfn>
+    : <dfn>getSwapChainPreferredFormat(adapter)</dfn>
     ::
         Returns an optimal {{GPUTextureFormat}} to use for swap chains with this context and the
         given device.
 
         <div algorithm="GPUCanvasContext.getSwapChainPreferredFormat">
-            **Called on:** {{GPUCanvasContext}} |this|.
+            **Called on:** {{GPUCanvasContext}} this.
 
             **Arguments:**
             <pre class=argumentdef for="GPUCanvasContext/getSwapChainPreferredFormat(adapter)">
@@ -6877,8 +6881,7 @@ interface GPUCanvasContext {
             **Returns:** {{GPUTextureFormat}}
 
             <div class=content-timeline>
-                1. Let |preferredFormat| be the [$preferred swap chain format$] for |this| and |adapter|.
-                1. Return |preferredFormat|.
+                1. Return |adapter|.{{GPUAdapter/[[preferred_format]]}}
             </div>
         </div>
 </dl>
@@ -6888,18 +6891,6 @@ supported when specified as a {{GPUSwapChainDescriptor}}.{{GPUSwapChainDescripto
 of the given {{GPUSwapChainDescriptor}}.{{GPUSwapChainDescriptor/device}}, initially set to:
 &laquo;{{GPUTextureFormat/"bgra8unorm"}}, {{GPUTextureFormat/"bgra8unorm-srgb"}},
 {{GPUTextureFormat/"rgba8unorm"}}, {{GPUTextureFormat/"rgba8unorm-srgb"}}&raquo;.
-
-<div algorithm>
-    To get the <dfn abstract-op>preferred swap chain format</dfn> for a given {{GPUCanvasContext}}
-    |context| and a given {{GPUAdapter}} |adapter| run the following steps::
-
-    1. Let |preferredFormat| be |context|.{{GPUCanvasContext/[[preferred_format]]}}
-    1. If |preferredFormat|[|adapter|] does not exist:
-        1. Set |preferredFormat|[|adapter|] to be one of the [=supported swap chain formats=] known
-            to be optimal for use with |context| and |adapter|. The user agent may use any criteria
-            to select the format.
-    1. Return |preferredFormat|[|adapter|].
-</div>
 
 <script type=idl>
 dictionary GPUSwapChainDescriptor : GPUObjectDescriptorBase {

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1424,6 +1424,18 @@ GPUDevice includes GPUObjectBase;
     : <dfn>\[[device]]</dfn>, of type [=device=], readonly
     ::
         The [=device=] that this {{GPUDevice}} refers to.
+
+    : <dfn>\[[swap_chain_formats]]</dfn>, of type [=list=]&lt;{{GPUTextureFormat}}&gt;, readonly
+    ::
+        The {{GPUTextureFormat}}s that are valid to configure a {{GPUSwapChain}} with for this device.
+        The list must [=list/contain=] {{GPUTextureFormat/"bgra8unorm"}}, {{GPUTextureFormat/"bgra8unorm-srgb"}}
+        and {{GPUTextureFormat/"rgba16float"}}. Other renderable formats may be added according to
+        the capabilities of the user agent and [=device=].
+
+    : <dfn>\[[preferred_swap_chain_format]]</dfn>, of type {{GPUTextureFormat}}, readonly
+    ::
+        The optimal {{GPUTextureFormat}} to use for {{GPUSwapChain}}s with for this device.
+        If no optimal format is known this value should be {{GPUTextureFormat/"bgra8unorm"}}.
 </dl>
 
 {{GPUDevice}} has the methods listed in its WebIDL definition above, which are defined elsewhere in
@@ -6833,12 +6845,19 @@ interface GPUCanvasContext {
 
             **Arguments:**
             <pre class=argumentdef for="GPUCanvasContext/configureSwapChain(descriptor)">
-                descriptor: Description of the {{GPUSwapChain}} to configure.
+                |descriptor|: Description of the {{GPUSwapChain}} to configure.
             </pre>
 
             **Returns:** {{GPUSwapChain}}
 
-            Issue: Describe {{GPUCanvasContext/configureSwapChain()}} algorithm steps.
+            1. If any of the following conditions are unsatisfied, generate a validation error and stop.
+                <div class=validusage>
+                    - |descriptor|.{{GPUSwapChainDescriptor/device}} is a [=valid=] {{GPUDevice}}.
+                    - |descriptor|.{{GPUSwapChainDescriptor/device}}.{{GPUDevice/[[swap_chain_formats]]}}
+                        [=list/contains=] |descriptor|.{{GPUSwapChainDescriptor/format}}.
+                </div>
+
+            Issue: Describe remaining {{GPUCanvasContext/configureSwapChain()}} algorithm steps.
         </div>
 
     : <dfn>getSwapChainPreferredFormat(device)</dfn>
@@ -6851,12 +6870,17 @@ interface GPUCanvasContext {
 
             **Arguments:**
             <pre class=argumentdef for="GPUCanvasContext/getSwapChainPreferredFormat(device)">
-                device: Device the swap chain format should be queried for.
+                |device|: Device the swap chain format should be queried for.
             </pre>
 
             **Returns:** {{Promise}}&lt;{{GPUTextureFormat}}&gt;
 
-            Issue: Describe {{GPUCanvasContext/getSwapChainPreferredFormat()}} algorithm steps.
+            1. If any of the following conditions are unsatisfied, generate a validation error and stop.
+                <div class=validusage>
+                    - |device| is a [=valid=] {{GPUDevice}}.
+                </div>
+
+            1. Return |device|.{{GPUDevice/[[preferred_swap_chain_format]]}}.
         </div>
 </dl>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1424,18 +1424,6 @@ GPUDevice includes GPUObjectBase;
     : <dfn>\[[device]]</dfn>, of type [=device=], readonly
     ::
         The [=device=] that this {{GPUDevice}} refers to.
-
-    : <dfn>\[[swap_chain_formats]]</dfn>, of type [=list=]&lt;{{GPUTextureFormat}}&gt;, readonly
-    ::
-        The {{GPUTextureFormat}}s that are valid to configure a {{GPUSwapChain}} with for this device.
-        The list must [=list/contain=] {{GPUTextureFormat/"bgra8unorm"}}, {{GPUTextureFormat/"bgra8unorm-srgb"}}
-        and {{GPUTextureFormat/"rgba16float"}}. Other renderable formats may be added according to
-        the capabilities of the user agent and [=device=].
-
-    : <dfn>\[[preferred_swap_chain_format]]</dfn>, of type {{GPUTextureFormat}}, readonly
-    ::
-        The optimal {{GPUTextureFormat}} to use for {{GPUSwapChain}}s with for this device.
-        If no optimal format is known this value should be {{GPUTextureFormat/"bgra8unorm"}}.
 </dl>
 
 {{GPUDevice}} has the methods listed in its WebIDL definition above, which are defined elsewhere in
@@ -6832,6 +6820,20 @@ interface GPUCanvasContext {
 };
 </script>
 
+{{GPUCanvasContext}} has the following internal slots:
+
+<dl dfn-type=attribute dfn-for=GPUCanvasContext>
+    : <dfn>\[[supported_formats]]</dfn>, of type [=ordered map=]&lt;{{GPUDevice}}, [=set=]&lt;{{GPUTextureFormat}}&gt;&gt;
+    ::
+        The {{GPUTextureFormat}}s that are valid to configure a {{GPUSwapChain}} with for a given {{GPUDevice}}.
+
+    : <dfn>\[[preferred_format]]</dfn>, of type [=ordered map=]&lt;{{GPUDevice}}, {{GPUTextureFormat}}&gt;
+    ::
+        An optimal {{GPUTextureFormat}} to use when creating a {{GPUSwapChain}} for a given {{GPUDevice}}.
+</dl>
+
+{{GPUCanvasContext}} has the following methods:
+
 <dl dfn-type=method dfn-for=GPUCanvasContext>
     : <dfn>configureSwapChain(descriptor)</dfn>
     ::
@@ -6841,7 +6843,7 @@ interface GPUCanvasContext {
         textures it has produced.
 
         <div algorithm="GPUCanvasContext.configureSwapChain">
-            **Called on:** {{GPUCanvasContext}} this.
+            **Called on:** {{GPUCanvasContext}} |this|.
 
             **Arguments:**
             <pre class=argumentdef for="GPUCanvasContext/configureSwapChain(descriptor)">
@@ -6853,8 +6855,9 @@ interface GPUCanvasContext {
             1. If any of the following conditions are unsatisfied, generate a validation error and stop.
                 <div class=validusage>
                     - |descriptor|.{{GPUSwapChainDescriptor/device}} is a [=valid=] {{GPUDevice}}.
-                    - |descriptor|.{{GPUSwapChainDescriptor/device}}.{{GPUDevice/[[swap_chain_formats]]}}
-                        [=list/contains=] |descriptor|.{{GPUSwapChainDescriptor/format}}.
+                    - Let |supportedFormats| be the [$supported swap chain formats$] for |this| and
+                        |descriptor|.{{GPUSwapChainDescriptor/device}}.
+                    - |supportedFormats| [=set/contains=] |descriptor|.{{GPUSwapChainDescriptor/format}}.
                 </div>
 
             Issue: Describe remaining {{GPUCanvasContext/configureSwapChain()}} algorithm steps.
@@ -6866,7 +6869,7 @@ interface GPUCanvasContext {
         given device.
 
         <div algorithm="GPUCanvasContext.getSwapChainPreferredFormat">
-            **Called on:** {{GPUCanvasContext}} this.
+            **Called on:** {{GPUCanvasContext}} |this|.
 
             **Arguments:**
             <pre class=argumentdef for="GPUCanvasContext/getSwapChainPreferredFormat(device)">
@@ -6875,14 +6878,52 @@ interface GPUCanvasContext {
 
             **Returns:** {{Promise}}&lt;{{GPUTextureFormat}}&gt;
 
-            1. If any of the following conditions are unsatisfied, generate a validation error and stop.
-                <div class=validusage>
-                    - |device| is a [=valid=] {{GPUDevice}}.
-                </div>
+            1. Let |promise| be [=a new promise=].
+            1. Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
+                    1. If any of the following conditions are unsatisfied, [=reject=] |promise| with
+                        an {{OperationError}} and stop.
 
-            1. Return |device|.{{GPUDevice/[[preferred_swap_chain_format]]}}.
+                        <div class=validusage>
+                            - |device| is a [=valid=] {{GPUDevice}}.
+                        </div>
+
+                    1. Let |preferredFormat| be the [$preferred swap chain format$] for |this| and |device|.
+                    1. Let |supportedFormats| be the [$supported swap chain formats$] for |this| and |device|.
+                    1. [=set/Append=] |preferredFormat| to |supportedFormats|.
+                    1. [=Resolve=] |promise| with |preferredFormat|.
+                </div>
+            1. Return |promise|.
         </div>
 </dl>
+
+The <dfn dfn>guaranteed swap chain formats</dfn> are a [=set=] of {{GPUTextureFormat}}s that must be
+supported when specified as a {{GPUSwapChainDescriptor}}.{{GPUSwapChainDescriptor/format}} regardless
+of the given {{GPUSwapChainDescriptor}}.{{GPUSwapChainDescriptor/device}}, initially set to:
+«{{GPUTextureFormat/"bgra8unorm"}}, {{GPUTextureFormat/"bgra8unorm-srgb"}}, {{GPUTextureFormat/"rgba16float"}}».
+
+<div algorithm>
+    To get the <dfn abstract-op>supported swap chain formats</dfn> for a given {{GPUCanvasContext}}
+    |context| and a given {{GPUDevice}} |device| run the following steps:
+
+    1. Let |supportedFormats| be |context|.{{GPUCanvasContext/[[supported_formats]]}}
+    1. If |supportedFormats|[|device|] does not exis:
+        1. Set |supportedFormats|[|device|] to be a [=set/clone=] of [=guaranteed swap chain formats=].
+    1. Return |supportedFormats|[|device|].
+</div>
+
+<div algorithm>
+    To get the <dfn abstract-op>preferred swap chain format</dfn> for a given {{GPUCanvasContext}}
+    |context| and a given {{GPUDevice}} |device| run the following steps::
+
+    1. Let |preferredFormat| be |context|.{{GPUCanvasContext/[[preferred_format]]}}
+    1. If |preferredFormat|[|device|] does not exist:
+        1. Set |preferredFormat|[|device|] to be an renderable {{GPUTextureFormat}} known to be
+            optimal for use with |context| and |device|. The user agent may use any criteria to
+            select the format. If no optimal format is known, the user agent should select one of
+            the [=guaranteed swap chain formats=].
+    1. Return |preferredFormat|[|device|].
+</div>
 
 <script type=idl>
 dictionary GPUSwapChainDescriptor : GPUObjectDescriptorBase {

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6823,10 +6823,6 @@ interface GPUCanvasContext {
 {{GPUCanvasContext}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for=GPUCanvasContext>
-    : <dfn>\[[supported_formats]]</dfn>, of type [=ordered map=]&lt;{{GPUAdapter}}, [=set=]&lt;{{GPUTextureFormat}}&gt;&gt;
-    ::
-        The {{GPUTextureFormat}}s that are valid to configure a {{GPUSwapChain}} with for a given {{GPUAdapter}}.
-
     : <dfn>\[[preferred_format]]</dfn>, of type [=ordered map=]&lt;{{GPUAdapter}}, {{GPUTextureFormat}}&gt;
     ::
         An optimal {{GPUTextureFormat}} to use when creating a {{GPUSwapChain}} for a given {{GPUAdapter}}.
@@ -6857,8 +6853,7 @@ interface GPUCanvasContext {
                     1. If any of the following conditions are unsatisfied, generate a validation error and stop.
                         <div class=validusage>
                             - |descriptor|.{{GPUSwapChainDescriptor/device}} is a [=valid=] {{GPUDevice}}.
-                            - Let |supportedFormats| be the [$supported swap chain formats$] for |this| and
-                                |descriptor|.{{GPUSwapChainDescriptor/device}}.{{GPUDevice/adapter}}.
+                            - Let |supportedFormats| be the [=supported swap chain formats=].
                             - |supportedFormats| [=set/contains=] |descriptor|.{{GPUSwapChainDescriptor/format}}.
                         </div>
 
@@ -6888,22 +6883,11 @@ interface GPUCanvasContext {
         </div>
 </dl>
 
-The <dfn dfn>guaranteed swap chain formats</dfn> are a [=set=] of {{GPUTextureFormat}}s that must be
+The <dfn dfn>supported swap chain formats</dfn> are a [=set=] of {{GPUTextureFormat}}s that must be
 supported when specified as a {{GPUSwapChainDescriptor}}.{{GPUSwapChainDescriptor/format}} regardless
 of the given {{GPUSwapChainDescriptor}}.{{GPUSwapChainDescriptor/device}}, initially set to:
-«{{GPUTextureFormat/"bgra8unorm"}}, {{GPUTextureFormat/"bgra8unorm-srgb"}}, {{GPUTextureFormat/"rgba16float"}}».
-
-<div algorithm>
-    To get the <dfn abstract-op>supported swap chain formats</dfn> for a given {{GPUCanvasContext}}
-    |context| and a given {{GPUAdapter}} |adapter| run the following steps:
-
-    1. Let |supportedFormats| be |context|.{{GPUCanvasContext/[[supported_formats]]}}
-    1. If |supportedFormats|[|adapter|] does not exis:
-        1. Set |supportedFormats|[|adapter|] to be a [=set/clone=] of [=guaranteed swap chain formats=].
-        1. Let |preferredFormat| be the [$preferred swap chain format$] for |context| and |adapter|.
-        1. [=set/Append=] |preferredFormat| to |supportedFormats|[|adapter|].
-    1. Return |supportedFormats|[|adapter|].
-</div>
+&laquo;{{GPUTextureFormat/"bgra8unorm"}}, {{GPUTextureFormat/"bgra8unorm-srgb"}},
+{{GPUTextureFormat/"rgba8unorm"}}, {{GPUTextureFormat/"rgba8unorm-srgb"}}&raquo;.
 
 <div algorithm>
     To get the <dfn abstract-op>preferred swap chain format</dfn> for a given {{GPUCanvasContext}}
@@ -6911,10 +6895,9 @@ of the given {{GPUSwapChainDescriptor}}.{{GPUSwapChainDescriptor/device}}, initi
 
     1. Let |preferredFormat| be |context|.{{GPUCanvasContext/[[preferred_format]]}}
     1. If |preferredFormat|[|adapter|] does not exist:
-        1. Set |preferredFormat|[|adapter|] to be an renderable {{GPUTextureFormat}} known to be
-            optimal for use with |context| and |adapter|. The user agent may use any criteria to
-            select the format. If no optimal format is known, the user agent should select one of
-            the [=guaranteed swap chain formats=].
+        1. Set |preferredFormat|[|adapter|] to be one of the [=supported swap chain formats=] known
+            to be optimal for use with |context| and |adapter|. The user agent may use any criteria
+            to select the format.
     1. Return |preferredFormat|[|adapter|].
 </div>
 


### PR DESCRIPTION
Adds some text indicating which formats swapchains must support, and uses it in some validation for the swap chain configuration.

I suspect this will need some iteration to get to a happy place, and once the editors are good with the layout we'll probably want to get confirmation from the WG that the documented formats are indeed what everyone agrees on.  I have some questions/concerns to start:

 - It feels a bit odd to me to document this kind of requirement in the description of an internal slot, but I'm not sure where else would be appropriate? We could add yet another column to the [Plain color formats table](https://gpuweb.github.io/gpuweb/#plain-color-formats) but I'm wary of making that too much larger, especially if the column only applies to 2-3 formats.
 - What role does the `GPUCanvasContext` play in controlling the supported formats? I have all that info stored on the device now, but you wouldn't need to get the preferred format from the context if it didn't have some effect on the outcome. SHould both the device and the context have a list of supported formats and the validation happens against the ANDed union of the two? Similarly should each have a list of supported formats in order of preference and the preferred format returns the first entry that appears in both lists? If so, what is the context's list generated from?
- My assumption is that we're avoiding returning an explicit list of supported formats via the IDL in order to avoid fingerprinting concerns, correct?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/toji/gpuweb/pull/1185.html" title="Last updated on Nov 30, 2020, 11:27 PM UTC (0ef0862)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1185/4d2d3dc...toji:0ef0862.html" title="Last updated on Nov 30, 2020, 11:27 PM UTC (0ef0862)">Diff</a>