### PR TITLE
Partially revert "Simplify requiredBytesInCopy algorithm slightly"

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4581,7 +4581,7 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
         and |copyExtent|.[=Extent3D/height=] is a multiple of |blockHeight|. Let:
             - |widthInBlocks| be |copyExtent|.[=Extent3D/width=] &divide; |blockWidth|.
             - |heightInBlocks| be |copyExtent|.[=Extent3D/height=] &divide; |blockHeight|.
-            - |bytesInACompleteRow| be |blockSize| &times; |widthInBlocks|.
+            - |bytesInLastRow| be |blockSize| &times; |widthInBlocks|.
 
     1. Fail if the following conditions are not satisfied:
         <div class=validusage>
@@ -4591,19 +4591,20 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
                 |layout|.{{GPUTextureDataLayout/bytesPerRow}} and
                 |layout|.{{GPUTextureDataLayout/rowsPerImage}} must be specified.
             - If specified, |layout|.{{GPUTextureDataLayout/bytesPerRow}}
-                must be greater than or equal to |bytesInACompleteRow|.
+                must be greater than or equal to |bytesInLastRow|.
             - If specified, |layout|.{{GPUTextureDataLayout/rowsPerImage}}
                 must be greater than or equal to |heightInBlocks|.
         </div>
 
     1. Let |requiredBytesInCopy| be 0.
 
-    1. If |copyExtent|.[=Extent3D/depth=] &gt; 1, add
-        |layout|.{{GPUTextureDataLayout/bytesPerRow}} &times;
-        |layout|.{{GPUTextureDataLayout/rowsPerImage}} &times;
-        (|copyExtent|.[=Extent3D/depth=] &minus; 1)
-        to |requiredBytesInCopy|.
-        (This covers all except the last image.)
+    1. If |copyExtent|.[=Extent3D/depth=] &gt; 1:
+        1. Let |bytesPerImage| be
+            |layout|.{{GPUTextureDataLayout/bytesPerRow}} &times;
+            |layout|.{{GPUTextureDataLayout/rowsPerImage}}.
+        1. Let |bytesBeforeLastImage| be
+            |bytesPerImage| &times; (|copyExtent|.[=Extent3D/depth=] &minus; 1).
+        1. Add |bytesBeforeLastImage| to |requiredBytesInCopy|.
 
     1. If |copyExtent|.[=Extent3D/depth=] &gt; 0:
 
@@ -4611,12 +4612,9 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
             |layout|.{{GPUTextureDataLayout/bytesPerRow}} &times;
             (|heightInBlocks| &minus; 1)
             to |requiredBytesInCopy|.
-            (This covers all of the last image except the last row.)
 
         1. If |heightInBlocks| &gt; 0, add
-            |widthInBlocks| &times; |blockSize|
-            to |requiredBytesInCopy|.
-            (This covers the last row.)
+            |bytesInLastRow| to |requiredBytesInCopy|.
 
     1. Fail if the following conditions are not satisfied:
         <div class=validusage>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4581,9 +4581,7 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
         and |copyExtent|.[=Extent3D/height=] is a multiple of |blockHeight|. Let:
             - |widthInBlocks| be |copyExtent|.[=Extent3D/width=] &divide; |blockWidth|.
             - |heightInBlocks| be |copyExtent|.[=Extent3D/height=] &divide; |blockHeight|.
-            - |bytesInLastRow| be |blockSize| &times; |widthInBlocks|.
-            - |bytesPerImage| be |layout|.{{GPUTextureDataLayout/bytesPerRow}} &times;
-                |layout|.{{GPUTextureDataLayout/rowsPerImage}}.
+            - |bytesInACompleteRow| be |blockSize| &times; |widthInBlocks|.
 
     1. Fail if the following conditions are not satisfied:
         <div class=validusage>
@@ -4593,23 +4591,32 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
                 |layout|.{{GPUTextureDataLayout/bytesPerRow}} and
                 |layout|.{{GPUTextureDataLayout/rowsPerImage}} must be specified.
             - If specified, |layout|.{{GPUTextureDataLayout/bytesPerRow}}
-                must be greater than or equal to |bytesInLastRow|.
+                must be greater than or equal to |bytesInACompleteRow|.
             - If specified, |layout|.{{GPUTextureDataLayout/rowsPerImage}}
                 must be greater than or equal to |heightInBlocks|.
         </div>
 
     1. Let |requiredBytesInCopy| be 0.
 
-    1. If |copyExtent|.[=Extent3D/depth=] &gt; 0:
-        1. Let |bytesBeforeLastImage| be
-            |bytesPerImage| &times; (|copyExtent|.[=Extent3D/depth=] &minus; 1)
-        1. Add |bytesBeforeLastImage| to |requiredBytesInCopy|.
+    1. If |copyExtent|.[=Extent3D/depth=] &gt; 1, add
+        |layout|.{{GPUTextureDataLayout/bytesPerRow}} &times;
+        |layout|.{{GPUTextureDataLayout/rowsPerImage}} &times;
+        (|copyExtent|.[=Extent3D/depth=] &minus; 1)
+        to |requiredBytesInCopy|.
+        (This covers all except the last image.)
 
-        1. If |heightInBlocks| &gt; 0:
-            1. Let |bytesInLastImage| be
-                |layout|.{{GPUTextureDataLayout/bytesPerRow}} &times;
-                (|heightInBlocks| &minus; 1) + |bytesInLastRow|.
-            1. Add |bytesInLastImage| to |requiredBytesInCopy|.
+    1. If |copyExtent|.[=Extent3D/depth=] &gt; 0:
+
+        1. If |heightInBlocks| &gt; 1, add
+            |layout|.{{GPUTextureDataLayout/bytesPerRow}} &times;
+            (|heightInBlocks| &minus; 1)
+            to |requiredBytesInCopy|.
+            (This covers all of the last image except the last row.)
+
+        1. If |heightInBlocks| &gt; 0, add
+            |widthInBlocks| &times; |blockSize|
+            to |requiredBytesInCopy|.
+            (This covers the last row.)
 
     1. Fail if the following conditions are not satisfied:
         <div class=validusage>


### PR DESCRIPTION
~Reverts~ "Partially reverts" gpuweb/gpuweb#1172

The checks above this don't guarantee bytesPerRow or rowsPerImage aren't undefined when they're used. (That explains how I ended up writing this algorithm in such a complicated way.)

This PR fixes that while keeping the extra variable names for additional clarity.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#abstract-opdef-validating-linear-texture-data
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/1188.html#abstract-opdef-validating-linear-texture-data" title="Last updated on Dec 17, 2020, 2:30 AM UTC (76000f9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1188/22967dd...76000f9.html" title="Last updated on Dec 17, 2020, 2:30 AM UTC (76000f9)">Diff</a>