### PR TITLE
Allow any value for bytesPerRow/rowsPerImage if they're unused

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4593,15 +4593,12 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
 
     1. Fail if the following conditions are not satisfied:
         <div class=validusage>
-            - If |heightInBlocks| &gt; 1,
-                |layout|.{{GPUTextureDataLayout/bytesPerRow}} must be specified.
+            - If |heightInBlocks| &gt; 1 or |copyExtent|.[=Extent3D/depth=] &gt; 1,
+                |layout|.{{GPUTextureDataLayout/bytesPerRow}} must be specified
+                and greater than or equal to |bytesInLastRow|.
             - If |copyExtent|.[=Extent3D/depth=] &gt; 1,
-                |layout|.{{GPUTextureDataLayout/bytesPerRow}} and
-                |layout|.{{GPUTextureDataLayout/rowsPerImage}} must be specified.
-            - If specified, |layout|.{{GPUTextureDataLayout/bytesPerRow}}
-                must be greater than or equal to |bytesInLastRow|.
-            - If specified, |layout|.{{GPUTextureDataLayout/rowsPerImage}}
-                must be greater than or equal to |heightInBlocks|.
+                |layout|.{{GPUTextureDataLayout/rowsPerImage}} must be specified
+                and greater than or equal to |heightInBlocks|.
         </div>
 
     1. Let |requiredBytesInCopy| be 0.


### PR DESCRIPTION
Semantically we really just want to allow bytesPerRow or rowsPerImage to
be omitted if it's unused. This strictly-loosens the validation so that
if unused, any number value is also allowed (instead of requiring that
it make sense for "the copy IF the {height,depth} were bigger than it
really is."

This should make the validation a little less annoying for users. E.g.
if they have corner cases in their stride computations for
{height,depth}==1, they won't break the copy for no good reason.

This is also motivated by simplifying the C API for webgpu.h users
(most importantly WASM applications running webgpu.h-on-WebGPU).
This lets them always specify `0`, so the C API doesn't have to be able
to express `undefined` as a separate value.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1194.html" title="Last updated on Oct 30, 2020, 6:21 PM UTC (ae3be8d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1194/e3dde36...kainino0x:ae3be8d.html" title="Last updated on Oct 30, 2020, 6:21 PM UTC (ae3be8d)">Diff</a>