### PR TITLE
Fix min/maxDepth error condition in GPURenderPassEncoder.setViewport

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6049,7 +6049,7 @@ attachments used by this encoder.
                             |this|.{{GPURenderPassEncoder/[[attachment_size]]}}.height.
                         - |minDepth| is greater than or equal to `0.0` and less than or equal to `1.0`.
                         - |maxDepth| is greater than or equal to `0.0` and less than or equal to `1.0`.
-                        - |minDepth| is greater than |maxDepth|.
+                        - |maxDepth| is greater than |minDepth|.
                     </div>
                 1. Set the viewport to the extents |x|, |y|, |width|, |height|, |minDepth|, and |maxDepth|.
             </div>


### PR DESCRIPTION
All the conditions listed in this section must be true to pass validation, but min/maxDepth comparison is obviously reversed.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yzsolt/gpuweb/pull/1199.html" title="Last updated on Nov 3, 2020, 11:47 AM UTC (21ca43c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1199/e3dde36...yzsolt:21ca43c.html" title="Last updated on Nov 3, 2020, 11:47 AM UTC (21ca43c)">Diff</a>