### PR TITLE
[wgsl] Begin drafting textureSample builtins (v2)

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4184,25 +4184,25 @@ TODO: deduplicate these tables
 
 Samples a texture.
 
+<!-- TODO(ben-clayton): Remove alignment padding after review -->
+
 ```rust
-textureSample(texture : texture_sampled_1d<type>,         sampler : sampler, coords : f32                                             ) -> <type>
-textureSample(texture : texture_sampled_1d<type>,         sampler : sampler, coords : f32,                          offset : i32      ) -> <type>
-textureSample(texture : texture_sampled_1d_array<type>,   sampler : sampler, coords : f32,       array_index : u32                    ) -> <type>
-textureSample(texture : texture_sampled_1d_array<type>,   sampler : sampler, coords : f32,       array_index : u32, offset : i32      ) -> <type>
-textureSample(texture : texture_sampled_2d<type>,         sampler : sampler, coords : vec2<f32>,                                      ) -> <type>
-textureSample(texture : texture_sampled_2d<type>,         sampler : sampler, coords : vec2<f32>,                    offset : vec2<i32>) -> <type>
-textureSample(texture : texture_sampled_2d_array<type>,   sampler : sampler, coords : vec2<f32>, array_index : u32                    ) -> <type>
-textureSample(texture : texture_sampled_2d_array<type>,   sampler : sampler, coords : vec2<f32>, array_index : u32, offset : vec2<i32>) -> <type>
-textureSample(texture : texture_sampled_3d<type>,         sampler : sampler, coords : vec3<f32>                                       ) -> <type>
-textureSample(texture : texture_sampled_3d<type>,         sampler : sampler, coords : vec3<f32>,                    offset : vec3<i32>) -> <type>
-textureSample(texture : texture_sampled_cube<type>,       sampler : sampler, coords : vec3<f32>                                       ) -> <type>
-textureSample(texture : texture_sampled_cube_array<type>, sampler : sampler, coords : vec3<f32>, array_index : u32                    ) -> <type>
-textureSample(texture : texture_depth_2d,                 sampler : sampler, coords : vec2<f32>                                       ) -> f32
-textureSample(texture : texture_depth_2d,                 sampler : sampler, coords : vec2<f32>,                    offset : vec2<i32>) -> f32
-textureSample(texture : texture_depth_2d_array,           sampler : sampler, coords : vec2<f32>, array_index : u32                    ) -> f32
-textureSample(texture : texture_depth_2d_array,           sampler : sampler, coords : vec2<f32>, array_index : u32, offset : vec2<i32>) -> f32
-textureSample(texture : texture_depth_cube,               sampler : sampler, coords : vec3<f32>                                       ) -> f32
-textureSample(texture : texture_depth_cube_array,         sampler : sampler, coords : vec3<f32>, array_index : u32                    ) -> f32
+textureSample(texture : texture_1d<f32>,          sampler : sampler, coords : f32                                             ) -> vec4<f32>
+textureSample(texture : texture_1d_array<f32>,    sampler : sampler, coords : f32,       array_index : u32                    ) -> vec4<f32>
+textureSample(texture : texture_2d<f32>,          sampler : sampler, coords : vec2<f32>,                                      ) -> vec4<f32>
+textureSample(texture : texture_2d<f32>,          sampler : sampler, coords : vec2<f32>,                    offset : vec2<i32>) -> vec4<f32>
+textureSample(texture : texture_2d_array<f32>,    sampler : sampler, coords : vec2<f32>, array_index : u32                    ) -> vec4<f32>
+textureSample(texture : texture_2d_array<f32>,    sampler : sampler, coords : vec2<f32>, array_index : u32, offset : vec2<i32>) -> vec4<f32>
+textureSample(texture : texture_3d<f32>,          sampler : sampler, coords : vec3<f32>                                       ) -> vec4<f32>
+textureSample(texture : texture_3d<f32>,          sampler : sampler, coords : vec3<f32>,                    offset : vec3<i32>) -> vec4<f32>
+textureSample(texture : texture_cube<f32>,        sampler : sampler, coords : vec3<f32>                                       ) -> vec4<f32>
+textureSample(texture : texture_cube_array<f32>,  sampler : sampler, coords : vec3<f32>, array_index : u32                    ) -> vec4<f32>
+textureSample(texture : texture_depth_2d,         sampler : sampler, coords : vec2<f32>                                       ) -> f32
+textureSample(texture : texture_depth_2d,         sampler : sampler, coords : vec2<f32>,                    offset : vec2<i32>) -> f32
+textureSample(texture : texture_depth_2d_array,   sampler : sampler, coords : vec2<f32>, array_index : u32                    ) -> f32
+textureSample(texture : texture_depth_2d_array,   sampler : sampler, coords : vec2<f32>, array_index : u32, offset : vec2<i32>) -> f32
+textureSample(texture : texture_depth_cube,       sampler : sampler, coords : vec3<f32>                                       ) -> f32
+textureSample(texture : texture_depth_cube_array, sampler : sampler, coords : vec3<f32>, array_index : u32                    ) -> f32
 ```
 
 **Parameters:**
@@ -4234,28 +4234,21 @@ The sampled value.
 Samples a texture with a bias to the mip level.
 
 ```rust
-textureSampleBias(texture : texture_sampled_2d<type>,         sampler : sampler, coords : vec2<f32>,                    bias : f32                    ) -> <type>
-textureSampleBias(texture : texture_sampled_2d<type>,         sampler : sampler, coords : vec2<f32>,                    bias : f32, offset : vec2<i32>) -> <type>
-textureSampleBias(texture : texture_sampled_2d_array<type>,   sampler : sampler, coords : vec2<f32>, array_index : u32, bias : f32                    ) -> <type>
-textureSampleBias(texture : texture_sampled_2d_array<type>,   sampler : sampler, coords : vec2<f32>, array_index : u32, bias : f32, offset : vec2<i32>) -> <type>
-textureSampleBias(texture : texture_sampled_3d<type>,         sampler : sampler, coords : vec3<f32>,                    bias : f32                    ) -> <type>
-textureSampleBias(texture : texture_sampled_3d<type>,         sampler : sampler, coords : vec3<f32>,                    bias : f32, offset : vec3<i32>) -> <type>
-textureSampleBias(texture : texture_sampled_cube<type>,       sampler : sampler, coords : vec3<f32>,                    bias : f32                    ) -> <type>
-textureSampleBias(texture : texture_sampled_cube_array<type>, sampler : sampler, coords : vec3<f32>, array_index : u32, bias : f32                    ) -> <type>
-textureSampleBias(texture : texture_depth_2d,                 sampler : sampler, coords : vec2<f32>,                    bias : f32                    ) -> f32
-textureSampleBias(texture : texture_depth_2d,                 sampler : sampler, coords : vec2<f32>,                    bias : f32, offset : vec2<i32>) -> f32
-textureSampleBias(texture : texture_depth_2d_array,           sampler : sampler, coords : vec2<f32>, array_index : u32, bias : f32                    ) -> f32
-textureSampleBias(texture : texture_depth_2d_array,           sampler : sampler, coords : vec2<f32>, array_index : u32, bias : f32, offset : vec2<i32>) -> f32
-textureSampleBias(texture : texture_depth_cube,               sampler : sampler, coords : vec3<f32>,                    bias : f32                    ) -> f32
-textureSampleBias(texture : texture_depth_cube_array,         sampler : sampler, coords : vec3<f32>, array_index : u32, bias : f32                    ) -> f32
+textureSampleBias(texture : texture_2d<f32>,                  sampler : sampler, coords : vec2<f32>,                    bias : f32                    ) -> vec4<f32>
+textureSampleBias(texture : texture_2d<f32>,                  sampler : sampler, coords : vec2<f32>,                    bias : f32, offset : vec2<i32>) -> vec4<f32>
+textureSampleBias(texture : texture_2d_array<f32>,            sampler : sampler, coords : vec2<f32>, array_index : u32, bias : f32                    ) -> vec4<f32>
+textureSampleBias(texture : texture_2d_array<f32>,            sampler : sampler, coords : vec2<f32>, array_index : u32, bias : f32, offset : vec2<i32>) -> vec4<f32>
+textureSampleBias(texture : texture_3d<f32>,                  sampler : sampler, coords : vec3<f32>,                    bias : f32                    ) -> vec4<f32>
+textureSampleBias(texture : texture_3d<f32>,                  sampler : sampler, coords : vec3<f32>,                    bias : f32, offset : vec3<i32>) -> vec4<f32>
+textureSampleBias(texture : texture_cube<f32>,                sampler : sampler, coords : vec3<f32>,                    bias : f32                    ) -> vec4<f32>
+textureSampleBias(texture : texture_cube_array<f32>,          sampler : sampler, coords : vec3<f32>, array_index : u32, bias : f32                    ) -> vec4<f32>
 ```
 
 **Parameters:**
 
 <table class='data'>
   <tr><td>`texture`<td>
-  The [sampled](#sampled-texture-type) or [depth](#texture-depth) texture to
-  sample.
+  The [texture](#sampled-texture-type) to sample.
   <tr><td>`sampler`<td>
   The [sampler type](#sampler-type).
   <tr><td>`coords`<td>
@@ -4282,14 +4275,14 @@ The sampled value.
 Samples a texture using an explicit mip level.
 
 ```rust
-textureSampleLevel(texture : texture_sampled_2d<type>,         sampler : sampler, coords : vec2<f32>,                    level : f32                    ) -> <type>
-textureSampleLevel(texture : texture_sampled_2d<type>,         sampler : sampler, coords : vec2<f32>,                    level : f32, offset : vec2<i32>) -> <type>
-textureSampleLevel(texture : texture_sampled_2d_array<type>,   sampler : sampler, coords : vec2<f32>, array_index : u32, level : f32                    ) -> <type>
-textureSampleLevel(texture : texture_sampled_2d_array<type>,   sampler : sampler, coords : vec2<f32>, array_index : u32, level : f32, offset : vec2<i32>) -> <type>
-textureSampleLevel(texture : texture_sampled_3d<type>,         sampler : sampler, coords : vec3<f32>,                    level : f32                    ) -> <type>
-textureSampleLevel(texture : texture_sampled_3d<type>,         sampler : sampler, coords : vec3<f32>,                    level : f32, offset : vec3<i32>) -> <type>
-textureSampleLevel(texture : texture_sampled_cube<type>,       sampler : sampler, coords : vec3<f32>,                    level : f32                    ) -> <type>
-textureSampleLevel(texture : texture_sampled_cube_array<type>, sampler : sampler, coords : vec3<f32>, array_index : u32, level : f32                    ) -> <type>
+textureSampleLevel(texture : texture_2d<f32>,                  sampler : sampler, coords : vec2<f32>,                    level : f32                    ) -> vec4<f32>
+textureSampleLevel(texture : texture_2d<f32>,                  sampler : sampler, coords : vec2<f32>,                    level : f32, offset : vec2<i32>) -> vec4<f32>
+textureSampleLevel(texture : texture_2d_array<f32>,            sampler : sampler, coords : vec2<f32>, array_index : u32, level : f32                    ) -> vec4<f32>
+textureSampleLevel(texture : texture_2d_array<f32>,            sampler : sampler, coords : vec2<f32>, array_index : u32, level : f32, offset : vec2<i32>) -> vec4<f32>
+textureSampleLevel(texture : texture_3d<f32>,                  sampler : sampler, coords : vec3<f32>,                    level : f32                    ) -> vec4<f32>
+textureSampleLevel(texture : texture_3d<f32>,                  sampler : sampler, coords : vec3<f32>,                    level : f32, offset : vec3<i32>) -> vec4<f32>
+textureSampleLevel(texture : texture_cube<f32>,                sampler : sampler, coords : vec3<f32>,                    level : f32                    ) -> vec4<f32>
+textureSampleLevel(texture : texture_cube_array<f32>,          sampler : sampler, coords : vec3<f32>, array_index : u32, level : f32                    ) -> vec4<f32>
 textureSampleLevel(texture : texture_depth_2d,                 sampler : sampler, coords : vec2<f32>,                    level : f32                    ) -> f32
 textureSampleLevel(texture : texture_depth_2d,                 sampler : sampler, coords : vec2<f32>,                    level : f32, offset : vec2<i32>) -> f32
 textureSampleLevel(texture : texture_depth_2d_array,           sampler : sampler, coords : vec2<f32>, array_index : u32, level : f32                    ) -> f32
@@ -4312,7 +4305,8 @@ textureSampleLevel(texture : texture_depth_cube_array,         sampler : sampler
   The 0-based texture array index to sample.
   <tr><td>`level`<td>
   The mip level to sample from, with 0 representing the largest level.
-  Fractional values may interpolate between two levels.
+  Fractional values may interpolate between two levels if the format is
+  filterable according to the [Texture Format Capabilities](#texture-format-caps).
   <tr><td>`offset`<td>
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
@@ -4330,28 +4324,21 @@ The sampled value.
 Samples a texture using explicit gradients.
 
 ```rust
-textureSampleGrad(texture : texture_sampled_2d<type>,         sampler : sampler, coords : vec2<f32>,                    ddx : vec2<f32>, ddy : vec2<f32>                    ) -> <type>
-textureSampleGrad(texture : texture_sampled_2d<type>,         sampler : sampler, coords : vec2<f32>,                    ddx : vec2<f32>, ddy : vec2<f32>, offset : vec2<i32>) -> <type>
-textureSampleGrad(texture : texture_sampled_2d_array<type>,   sampler : sampler, coords : vec2<f32>, array_index : u32, ddx : vec2<f32>, ddy : vec2<f32>                    ) -> <type>
-textureSampleGrad(texture : texture_sampled_2d_array<type>,   sampler : sampler, coords : vec2<f32>, array_index : u32, ddx : vec2<f32>, ddy : vec2<f32>, offset : vec2<i32>) -> <type>
-textureSampleGrad(texture : texture_sampled_3d<type>,         sampler : sampler, coords : vec3<f32>,                    ddx : vec3<f32>, ddy : vec3<f32>                    ) -> <type>
-textureSampleGrad(texture : texture_sampled_3d<type>,         sampler : sampler, coords : vec3<f32>,                    ddx : vec3<f32>, ddy : vec3<f32>, offset : vec3<i32>) -> <type>
-textureSampleGrad(texture : texture_sampled_cube<type>,       sampler : sampler, coords : vec3<f32>,                    ddx : vec3<f32>, ddy : vec3<f32>                    ) -> <type>
-textureSampleGrad(texture : texture_sampled_cube_array<type>, sampler : sampler, coords : vec3<f32>, array_index : u32, ddx : vec3<f32>, ddy : vec3<f32>                    ) -> <type>
-textureSampleGrad(texture : texture_depth_2d,                 sampler : sampler, coords : vec2<f32>,                    ddx : vec2<f32>, ddy : vec2<f32>                    ) -> f32
-textureSampleGrad(texture : texture_depth_2d,                 sampler : sampler, coords : vec2<f32>,                    ddx : vec2<f32>, ddy : vec2<f32>, offset : vec2<i32>) -> f32
-textureSampleGrad(texture : texture_depth_2d_array,           sampler : sampler, coords : vec2<f32>, array_index : u32, ddx : vec2<f32>, ddy : vec2<f32>                    ) -> f32
-textureSampleGrad(texture : texture_depth_2d_array,           sampler : sampler, coords : vec2<f32>, array_index : u32, ddx : vec2<f32>, ddy : vec2<f32>, offset : vec2<i32>) -> f32
-textureSampleGrad(texture : texture_depth_cube,               sampler : sampler, coords : vec3<f32>,                    ddx : vec3<f32>, ddy : vec3<f32>                    ) -> f32
-textureSampleGrad(texture : texture_depth_cube_array,         sampler : sampler, coords : vec3<f32>, array_index : u32, ddx : vec3<f32>, ddy : vec3<f32>                    ) -> f32
+textureSampleGrad(texture : texture_2d<f32>,                  sampler : sampler, coords : vec2<f32>,                    ddx : vec2<f32>, ddy : vec2<f32>                    ) -> vec4<f32>
+textureSampleGrad(texture : texture_2d<f32>,                  sampler : sampler, coords : vec2<f32>,                    ddx : vec2<f32>, ddy : vec2<f32>, offset : vec2<i32>) -> vec4<f32>
+textureSampleGrad(texture : texture_2d_array<f32>,            sampler : sampler, coords : vec2<f32>, array_index : u32, ddx : vec2<f32>, ddy : vec2<f32>                    ) -> vec4<f32>
+textureSampleGrad(texture : texture_2d_array<f32>,            sampler : sampler, coords : vec2<f32>, array_index : u32, ddx : vec2<f32>, ddy : vec2<f32>, offset : vec2<i32>) -> vec4<f32>
+textureSampleGrad(texture : texture_3d<f32>,                  sampler : sampler, coords : vec3<f32>,                    ddx : vec3<f32>, ddy : vec3<f32>                    ) -> vec4<f32>
+textureSampleGrad(texture : texture_3d<f32>,                  sampler : sampler, coords : vec3<f32>,                    ddx : vec3<f32>, ddy : vec3<f32>, offset : vec3<i32>) -> vec4<f32>
+textureSampleGrad(texture : texture_cube<f32>,                sampler : sampler, coords : vec3<f32>,                    ddx : vec3<f32>, ddy : vec3<f32>                    ) -> vec4<f32>
+textureSampleGrad(texture : texture_cube_array<f32>,          sampler : sampler, coords : vec3<f32>, array_index : u32, ddx : vec3<f32>, ddy : vec3<f32>                    ) -> vec4<f32>
 ```
 
 **Parameters:**
 
 <table class='data'>
   <tr><td>`texture`<td>
-  The [sampled](#sampled-texture-type) or [depth](#texture-depth) texture to
-  sample.
+  The [texture](#sampled-texture-type) to sample.
   <tr><td>`sampler`<td>
   The [sampler type](#sampler-type).
   <tr><td>`coords`<td>
@@ -4409,10 +4396,15 @@ textureSampleCompare(texture : texture_depth_cube_array, sampler : sampler_compa
 
 **Returns:**
 
-A `f32` in the range `[0.0..1.0]`, representing the number of depth values
-that were greater or less than the reference value.
-The comparision operator is defined by the `<sampler_comparison>`.
+A value in the range `[0.0..1.0]`.
 
+Each sampled texel is compared against the reference value using the comparision
+operator defined by the `sampler_comparison`, resulting in either a `0` or `1`
+value for each texel.
+
+If the `sampler_comparison` uses bilinear filtering then the returned value is
+the filtered average of these values, otherwise the comparision result of a
+single texel is returned.
 
 **TODO:**
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4306,7 +4306,7 @@ textureSampleLevel(texture : texture_depth_cube_array,         sampler : sampler
   <tr><td>`level`<td>
   The mip level to sample from, with 0 representing the largest level.
   Fractional values may interpolate between two levels if the format is
-  filterable according to the [Texture Format Capabilities](#texture-format-caps).
+  filterable according to the [Texture Format Capabilities](https://gpuweb.github.io/gpuweb/#texture-format-caps).
   <tr><td>`offset`<td>
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4184,34 +4184,32 @@ TODO: deduplicate these tables
 
 Samples a texture.
 
-<!-- TODO(ben-clayton): Remove alignment padding after review -->
-
 ```rust
-textureSample(texture : texture_1d<f32>,          sampler : sampler, coords : f32                                             ) -> vec4<f32>
-textureSample(texture : texture_1d_array<f32>,    sampler : sampler, coords : f32,       array_index : u32                    ) -> vec4<f32>
-textureSample(texture : texture_2d<f32>,          sampler : sampler, coords : vec2<f32>,                                      ) -> vec4<f32>
-textureSample(texture : texture_2d<f32>,          sampler : sampler, coords : vec2<f32>,                    offset : vec2<i32>) -> vec4<f32>
-textureSample(texture : texture_2d_array<f32>,    sampler : sampler, coords : vec2<f32>, array_index : u32                    ) -> vec4<f32>
-textureSample(texture : texture_2d_array<f32>,    sampler : sampler, coords : vec2<f32>, array_index : u32, offset : vec2<i32>) -> vec4<f32>
-textureSample(texture : texture_3d<f32>,          sampler : sampler, coords : vec3<f32>                                       ) -> vec4<f32>
-textureSample(texture : texture_3d<f32>,          sampler : sampler, coords : vec3<f32>,                    offset : vec3<i32>) -> vec4<f32>
-textureSample(texture : texture_cube<f32>,        sampler : sampler, coords : vec3<f32>                                       ) -> vec4<f32>
-textureSample(texture : texture_cube_array<f32>,  sampler : sampler, coords : vec3<f32>, array_index : u32                    ) -> vec4<f32>
-textureSample(texture : texture_depth_2d,         sampler : sampler, coords : vec2<f32>                                       ) -> f32
-textureSample(texture : texture_depth_2d,         sampler : sampler, coords : vec2<f32>,                    offset : vec2<i32>) -> f32
-textureSample(texture : texture_depth_2d_array,   sampler : sampler, coords : vec2<f32>, array_index : u32                    ) -> f32
-textureSample(texture : texture_depth_2d_array,   sampler : sampler, coords : vec2<f32>, array_index : u32, offset : vec2<i32>) -> f32
-textureSample(texture : texture_depth_cube,       sampler : sampler, coords : vec3<f32>                                       ) -> f32
-textureSample(texture : texture_depth_cube_array, sampler : sampler, coords : vec3<f32>, array_index : u32                    ) -> f32
+textureSample(t : texture_1d<f32>, s : sampler, coords : f32) -> vec4<f32>
+textureSample(t : texture_1d_array<f32>, s : sampler, coords : f32, array_index : u32) -> vec4<f32>
+textureSample(t : texture_2d<f32>, s : sampler, coords : vec2<f32>,) -> vec4<f32>
+textureSample(t : texture_2d<f32>, s : sampler, coords : vec2<f32>, offset : vec2<i32>) -> vec4<f32>
+textureSample(t : texture_2d_array<f32>, s : sampler, coords : vec2<f32>, array_index : u32) -> vec4<f32>
+textureSample(t : texture_2d_array<f32>, s : sampler, coords : vec2<f32>, array_index : u32, offset : vec2<i32>) -> vec4<f32>
+textureSample(t : texture_3d<f32>, s : sampler, coords : vec3<f32>) -> vec4<f32>
+textureSample(t : texture_3d<f32>, s : sampler, coords : vec3<f32>, offset : vec3<i32>) -> vec4<f32>
+textureSample(t : texture_cube<f32>, s : sampler, coords : vec3<f32>) -> vec4<f32>
+textureSample(t : texture_cube_array<f32>, s : sampler, coords : vec3<f32>, array_index : u32) -> vec4<f32>
+textureSample(t : texture_depth_2d, s : sampler, coords : vec2<f32>) -> f32
+textureSample(t : texture_depth_2d, s : sampler, coords : vec2<f32>, offset : vec2<i32>) -> f32
+textureSample(t : texture_depth_2d_array, s : sampler, coords : vec2<f32>, array_index : u32) -> f32
+textureSample(t : texture_depth_2d_array, s : sampler, coords : vec2<f32>, array_index : u32, offset : vec2<i32>) -> f32
+textureSample(t : texture_depth_cube, s : sampler, coords : vec3<f32>) -> f32
+textureSample(t : texture_depth_cube_array, s : sampler, coords : vec3<f32>, array_index : u32) -> f32
 ```
 
 **Parameters:**
 
 <table class='data'>
-  <tr><td>`texture`<td>
+  <tr><td>`t`<td>
   The [sampled](#sampled-texture-type) or [depth](#texture-depth) texture to
   sample.
-  <tr><td>`sampler`<td>
+  <tr><td>`s`<td>
   The [sampler type](#sampler-type).
   <tr><td>`coords`<td>
   The texture coordinates used for sampling.
@@ -4234,22 +4232,22 @@ The sampled value.
 Samples a texture with a bias to the mip level.
 
 ```rust
-textureSampleBias(texture : texture_2d<f32>,                  sampler : sampler, coords : vec2<f32>,                    bias : f32                    ) -> vec4<f32>
-textureSampleBias(texture : texture_2d<f32>,                  sampler : sampler, coords : vec2<f32>,                    bias : f32, offset : vec2<i32>) -> vec4<f32>
-textureSampleBias(texture : texture_2d_array<f32>,            sampler : sampler, coords : vec2<f32>, array_index : u32, bias : f32                    ) -> vec4<f32>
-textureSampleBias(texture : texture_2d_array<f32>,            sampler : sampler, coords : vec2<f32>, array_index : u32, bias : f32, offset : vec2<i32>) -> vec4<f32>
-textureSampleBias(texture : texture_3d<f32>,                  sampler : sampler, coords : vec3<f32>,                    bias : f32                    ) -> vec4<f32>
-textureSampleBias(texture : texture_3d<f32>,                  sampler : sampler, coords : vec3<f32>,                    bias : f32, offset : vec3<i32>) -> vec4<f32>
-textureSampleBias(texture : texture_cube<f32>,                sampler : sampler, coords : vec3<f32>,                    bias : f32                    ) -> vec4<f32>
-textureSampleBias(texture : texture_cube_array<f32>,          sampler : sampler, coords : vec3<f32>, array_index : u32, bias : f32                    ) -> vec4<f32>
+textureSampleBias(t : texture_2d<f32>, s : sampler, coords : vec2<f32>, bias : f32) -> vec4<f32>
+textureSampleBias(t : texture_2d<f32>, s : sampler, coords : vec2<f32>, bias : f32, offset : vec2<i32>) -> vec4<f32>
+textureSampleBias(t : texture_2d_array<f32>, s : sampler, coords : vec2<f32>, array_index : u32, bias : f32) -> vec4<f32>
+textureSampleBias(t : texture_2d_array<f32>, s : sampler, coords : vec2<f32>, array_index : u32, bias : f32, offset : vec2<i32>) -> vec4<f32>
+textureSampleBias(t : texture_3d<f32>, s : sampler, coords : vec3<f32>, bias : f32) -> vec4<f32>
+textureSampleBias(t : texture_3d<f32>, s : sampler, coords : vec3<f32>, bias : f32, offset : vec3<i32>) -> vec4<f32>
+textureSampleBias(t : texture_cube<f32>, s : sampler, coords : vec3<f32>, bias : f32) -> vec4<f32>
+textureSampleBias(t : texture_cube_array<f32>, s : sampler, coords : vec3<f32>, array_index : u32, bias : f32) -> vec4<f32>
 ```
 
 **Parameters:**
 
 <table class='data'>
-  <tr><td>`texture`<td>
+  <tr><td>`t`<td>
   The [texture](#sampled-texture-type) to sample.
-  <tr><td>`sampler`<td>
+  <tr><td>`s`<td>
   The [sampler type](#sampler-type).
   <tr><td>`coords`<td>
   The texture coordinates used for sampling.
@@ -4275,29 +4273,29 @@ The sampled value.
 Samples a texture using an explicit mip level.
 
 ```rust
-textureSampleLevel(texture : texture_2d<f32>,                  sampler : sampler, coords : vec2<f32>,                    level : f32                    ) -> vec4<f32>
-textureSampleLevel(texture : texture_2d<f32>,                  sampler : sampler, coords : vec2<f32>,                    level : f32, offset : vec2<i32>) -> vec4<f32>
-textureSampleLevel(texture : texture_2d_array<f32>,            sampler : sampler, coords : vec2<f32>, array_index : u32, level : f32                    ) -> vec4<f32>
-textureSampleLevel(texture : texture_2d_array<f32>,            sampler : sampler, coords : vec2<f32>, array_index : u32, level : f32, offset : vec2<i32>) -> vec4<f32>
-textureSampleLevel(texture : texture_3d<f32>,                  sampler : sampler, coords : vec3<f32>,                    level : f32                    ) -> vec4<f32>
-textureSampleLevel(texture : texture_3d<f32>,                  sampler : sampler, coords : vec3<f32>,                    level : f32, offset : vec3<i32>) -> vec4<f32>
-textureSampleLevel(texture : texture_cube<f32>,                sampler : sampler, coords : vec3<f32>,                    level : f32                    ) -> vec4<f32>
-textureSampleLevel(texture : texture_cube_array<f32>,          sampler : sampler, coords : vec3<f32>, array_index : u32, level : f32                    ) -> vec4<f32>
-textureSampleLevel(texture : texture_depth_2d,                 sampler : sampler, coords : vec2<f32>,                    level : u32                    ) -> f32
-textureSampleLevel(texture : texture_depth_2d,                 sampler : sampler, coords : vec2<f32>,                    level : u32, offset : vec2<i32>) -> f32
-textureSampleLevel(texture : texture_depth_2d_array,           sampler : sampler, coords : vec2<f32>, array_index : u32, level : u32                    ) -> f32
-textureSampleLevel(texture : texture_depth_2d_array,           sampler : sampler, coords : vec2<f32>, array_index : u32, level : u32, offset : vec2<i32>) -> f32
-textureSampleLevel(texture : texture_depth_cube,               sampler : sampler, coords : vec3<f32>,                    level : u32                    ) -> f32
-textureSampleLevel(texture : texture_depth_cube_array,         sampler : sampler, coords : vec3<f32>, array_index : u32, level : u32                    ) -> f32
+textureSampleLevel(t : texture_2d<f32>, s : sampler, coords : vec2<f32>, level : f32) -> vec4<f32>
+textureSampleLevel(t : texture_2d<f32>, s : sampler, coords : vec2<f32>, level : f32, offset : vec2<i32>) -> vec4<f32>
+textureSampleLevel(t : texture_2d_array<f32>, s : sampler, coords : vec2<f32>, array_index : u32, level : f32) -> vec4<f32>
+textureSampleLevel(t : texture_2d_array<f32>, s : sampler, coords : vec2<f32>, array_index : u32, level : f32, offset : vec2<i32>) -> vec4<f32>
+textureSampleLevel(t : texture_3d<f32>, s : sampler, coords : vec3<f32>, level : f32) -> vec4<f32>
+textureSampleLevel(t : texture_3d<f32>, s : sampler, coords : vec3<f32>, level : f32, offset : vec3<i32>) -> vec4<f32>
+textureSampleLevel(t : texture_cube<f32>, s : sampler, coords : vec3<f32>, level : f32) -> vec4<f32>
+textureSampleLevel(t : texture_cube_array<f32>, s : sampler, coords : vec3<f32>, array_index : u32, level : f32) -> vec4<f32>
+textureSampleLevel(t : texture_depth_2d, s : sampler, coords : vec2<f32>, level : u32) -> f32
+textureSampleLevel(t : texture_depth_2d, s : sampler, coords : vec2<f32>, level : u32, offset : vec2<i32>) -> f32
+textureSampleLevel(t : texture_depth_2d_array, s : sampler, coords : vec2<f32>, array_index : u32, level : u32) -> f32
+textureSampleLevel(t : texture_depth_2d_array, s : sampler, coords : vec2<f32>, array_index : u32, level : u32, offset : vec2<i32>) -> f32
+textureSampleLevel(t : texture_depth_cube, s : sampler, coords : vec3<f32>, level : u32) -> f32
+textureSampleLevel(t : texture_depth_cube_array, s : sampler, coords : vec3<f32>, array_index : u32, level : u32) -> f32
 ```
 
 **Parameters:**
 
 <table class='data'>
-  <tr><td>`texture`<td>
+  <tr><td>`t`<td>
   The [sampled](#sampled-texture-type) or [depth](#texture-depth) texture to
   sample.
-  <tr><td>`sampler`<td>
+  <tr><td>`s`<td>
   The [sampler type](#sampler-type).
   <tr><td>`coords`<td>
   The texture coordinates used for sampling.
@@ -4325,22 +4323,22 @@ The sampled value.
 Samples a texture using explicit gradients.
 
 ```rust
-textureSampleGrad(texture : texture_2d<f32>,                  sampler : sampler, coords : vec2<f32>,                    ddx : vec2<f32>, ddy : vec2<f32>                    ) -> vec4<f32>
-textureSampleGrad(texture : texture_2d<f32>,                  sampler : sampler, coords : vec2<f32>,                    ddx : vec2<f32>, ddy : vec2<f32>, offset : vec2<i32>) -> vec4<f32>
-textureSampleGrad(texture : texture_2d_array<f32>,            sampler : sampler, coords : vec2<f32>, array_index : u32, ddx : vec2<f32>, ddy : vec2<f32>                    ) -> vec4<f32>
-textureSampleGrad(texture : texture_2d_array<f32>,            sampler : sampler, coords : vec2<f32>, array_index : u32, ddx : vec2<f32>, ddy : vec2<f32>, offset : vec2<i32>) -> vec4<f32>
-textureSampleGrad(texture : texture_3d<f32>,                  sampler : sampler, coords : vec3<f32>,                    ddx : vec3<f32>, ddy : vec3<f32>                    ) -> vec4<f32>
-textureSampleGrad(texture : texture_3d<f32>,                  sampler : sampler, coords : vec3<f32>,                    ddx : vec3<f32>, ddy : vec3<f32>, offset : vec3<i32>) -> vec4<f32>
-textureSampleGrad(texture : texture_cube<f32>,                sampler : sampler, coords : vec3<f32>,                    ddx : vec3<f32>, ddy : vec3<f32>                    ) -> vec4<f32>
-textureSampleGrad(texture : texture_cube_array<f32>,          sampler : sampler, coords : vec3<f32>, array_index : u32, ddx : vec3<f32>, ddy : vec3<f32>                    ) -> vec4<f32>
+textureSampleGrad(t : texture_2d<f32>, s : sampler, coords : vec2<f32>, ddx : vec2<f32>, ddy : vec2<f32>) -> vec4<f32>
+textureSampleGrad(t : texture_2d<f32>, s : sampler, coords : vec2<f32>, ddx : vec2<f32>, ddy : vec2<f32>, offset : vec2<i32>) -> vec4<f32>
+textureSampleGrad(t : texture_2d_array<f32>, s : sampler, coords : vec2<f32>, array_index : u32, ddx : vec2<f32>, ddy : vec2<f32>) -> vec4<f32>
+textureSampleGrad(t : texture_2d_array<f32>, s : sampler, coords : vec2<f32>, array_index : u32, ddx : vec2<f32>, ddy : vec2<f32>, offset : vec2<i32>) -> vec4<f32>
+textureSampleGrad(t : texture_3d<f32>, s : sampler, coords : vec3<f32>, ddx : vec3<f32>, ddy : vec3<f32>) -> vec4<f32>
+textureSampleGrad(t : texture_3d<f32>, s : sampler, coords : vec3<f32>, ddx : vec3<f32>, ddy : vec3<f32>, offset : vec3<i32>) -> vec4<f32>
+textureSampleGrad(t : texture_cube<f32>, s : sampler, coords : vec3<f32>, ddx : vec3<f32>, ddy : vec3<f32>) -> vec4<f32>
+textureSampleGrad(t : texture_cube_array<f32>, s : sampler, coords : vec3<f32>, array_index : u32, ddx : vec3<f32>, ddy : vec3<f32>) -> vec4<f32>
 ```
 
 **Parameters:**
 
 <table class='data'>
-  <tr><td>`texture`<td>
+  <tr><td>`t`<td>
   The [texture](#sampled-texture-type) to sample.
-  <tr><td>`sampler`<td>
+  <tr><td>`s`<td>
   The [sampler type](#sampler-type).
   <tr><td>`coords`<td>
   The texture coordinates used for sampling.
@@ -4367,20 +4365,20 @@ The sampled value.
 Samples a depth texture and compares the sampled depth values against a reference value.
 
 ```rust
-textureSampleCompare(texture : texture_depth_2d,         sampler : sampler_comparison, coords : vec2<f32>,                    depth_ref : f32                    ) -> f32
-textureSampleCompare(texture : texture_depth_2d,         sampler : sampler_comparison, coords : vec2<f32>,                    depth_ref : f32, offset : vec2<i32>) -> f32
-textureSampleCompare(texture : texture_depth_2d_array,   sampler : sampler_comparison, coords : vec2<f32>, array_index : u32, depth_ref : f32                    ) -> f32
-textureSampleCompare(texture : texture_depth_2d_array,   sampler : sampler_comparison, coords : vec2<f32>, array_index : u32, depth_ref : f32, offset : vec2<i32>) -> f32
-textureSampleCompare(texture : texture_depth_cube,       sampler : sampler_comparison, coords : vec3<f32>,                    depth_ref : f32                    ) -> f32
-textureSampleCompare(texture : texture_depth_cube_array, sampler : sampler_comparison, coords : vec3<f32>, array_index : u32, depth_ref : f32                    ) -> f32
+textureSampleCompare(t : texture_depth_2d, s : sampler_comparison, coords : vec2<f32>, depth_ref : f32) -> f32
+textureSampleCompare(t : texture_depth_2d, s : sampler_comparison, coords : vec2<f32>, depth_ref : f32, offset : vec2<i32>) -> f32
+textureSampleCompare(t : texture_depth_2d_array, s : sampler_comparison, coords : vec2<f32>, array_index : u32, depth_ref : f32) -> f32
+textureSampleCompare(t : texture_depth_2d_array, s : sampler_comparison, coords : vec2<f32>, array_index : u32, depth_ref : f32, offset : vec2<i32>) -> f32
+textureSampleCompare(t : texture_depth_cube, s : sampler_comparison, coords : vec3<f32>, depth_ref : f32) -> f32
+textureSampleCompare(t : texture_depth_cube_array, s : sampler_comparison, coords : vec3<f32>, array_index : u32, depth_ref : f32) -> f32
 ```
 
 **Parameters:**
 
 <table class='data'>
-  <tr><td>`texture`<td>
+  <tr><td>`t`<td>
   The [depth](#texture-depth) texture to sample.
-  <tr><td>`sampler`<td>
+  <tr><td>`s`<td>
   The [sampler comparision](#sampler-type) type.
   <tr><td>`coords`<td>
   The texture coordinates used for sampling.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4283,12 +4283,12 @@ textureSampleLevel(texture : texture_3d<f32>,                  sampler : sampler
 textureSampleLevel(texture : texture_3d<f32>,                  sampler : sampler, coords : vec3<f32>,                    level : f32, offset : vec3<i32>) -> vec4<f32>
 textureSampleLevel(texture : texture_cube<f32>,                sampler : sampler, coords : vec3<f32>,                    level : f32                    ) -> vec4<f32>
 textureSampleLevel(texture : texture_cube_array<f32>,          sampler : sampler, coords : vec3<f32>, array_index : u32, level : f32                    ) -> vec4<f32>
-textureSampleLevel(texture : texture_depth_2d,                 sampler : sampler, coords : vec2<f32>,                    level : f32                    ) -> f32
-textureSampleLevel(texture : texture_depth_2d,                 sampler : sampler, coords : vec2<f32>,                    level : f32, offset : vec2<i32>) -> f32
-textureSampleLevel(texture : texture_depth_2d_array,           sampler : sampler, coords : vec2<f32>, array_index : u32, level : f32                    ) -> f32
-textureSampleLevel(texture : texture_depth_2d_array,           sampler : sampler, coords : vec2<f32>, array_index : u32, level : f32, offset : vec2<i32>) -> f32
-textureSampleLevel(texture : texture_depth_cube,               sampler : sampler, coords : vec3<f32>,                    level : f32                    ) -> f32
-textureSampleLevel(texture : texture_depth_cube_array,         sampler : sampler, coords : vec3<f32>, array_index : u32, level : f32                    ) -> f32
+textureSampleLevel(texture : texture_depth_2d,                 sampler : sampler, coords : vec2<f32>,                    level : u32                    ) -> f32
+textureSampleLevel(texture : texture_depth_2d,                 sampler : sampler, coords : vec2<f32>,                    level : u32, offset : vec2<i32>) -> f32
+textureSampleLevel(texture : texture_depth_2d_array,           sampler : sampler, coords : vec2<f32>, array_index : u32, level : u32                    ) -> f32
+textureSampleLevel(texture : texture_depth_2d_array,           sampler : sampler, coords : vec2<f32>, array_index : u32, level : u32, offset : vec2<i32>) -> f32
+textureSampleLevel(texture : texture_depth_cube,               sampler : sampler, coords : vec3<f32>,                    level : u32                    ) -> f32
+textureSampleLevel(texture : texture_depth_cube_array,         sampler : sampler, coords : vec3<f32>, array_index : u32, level : u32                    ) -> f32
 ```
 
 **Parameters:**
@@ -4305,8 +4305,9 @@ textureSampleLevel(texture : texture_depth_cube_array,         sampler : sampler
   The 0-based texture array index to sample.
   <tr><td>`level`<td>
   The mip level to sample from, with 0 representing the largest level.
-  Fractional values may interpolate between two levels if the format is
-  filterable according to the [Texture Format Capabilities](https://gpuweb.github.io/gpuweb/#texture-format-caps).
+  For the functions where `level` is a `f32`, fractional values may interpolate
+  between two levels if the format is filterable according to the
+  [Texture Format Capabilities](https://gpuweb.github.io/gpuweb/#texture-format-caps).
   <tr><td>`offset`<td>
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4180,6 +4180,242 @@ TODO: deduplicate these tables
 
 ## Texture built-in functions ## {#texture-builtin-functions}
 
+### `textureSample` ### {#texturesample}
+
+Samples a texture.
+
+```rust
+textureSample(texture : texture_sampled_1d<type>,         sampler : sampler, coords : f32                                             ) -> <type>
+textureSample(texture : texture_sampled_1d<type>,         sampler : sampler, coords : f32,                          offset : i32      ) -> <type>
+textureSample(texture : texture_sampled_1d_array<type>,   sampler : sampler, coords : f32,       array_index : u32                    ) -> <type>
+textureSample(texture : texture_sampled_1d_array<type>,   sampler : sampler, coords : f32,       array_index : u32, offset : i32      ) -> <type>
+textureSample(texture : texture_sampled_2d<type>,         sampler : sampler, coords : vec2<f32>,                                      ) -> <type>
+textureSample(texture : texture_sampled_2d<type>,         sampler : sampler, coords : vec2<f32>,                    offset : vec2<i32>) -> <type>
+textureSample(texture : texture_sampled_2d_array<type>,   sampler : sampler, coords : vec2<f32>, array_index : u32                    ) -> <type>
+textureSample(texture : texture_sampled_2d_array<type>,   sampler : sampler, coords : vec2<f32>, array_index : u32, offset : vec2<i32>) -> <type>
+textureSample(texture : texture_sampled_3d<type>,         sampler : sampler, coords : vec3<f32>                                       ) -> <type>
+textureSample(texture : texture_sampled_3d<type>,         sampler : sampler, coords : vec3<f32>,                    offset : vec3<i32>) -> <type>
+textureSample(texture : texture_sampled_cube<type>,       sampler : sampler, coords : vec3<f32>                                       ) -> <type>
+textureSample(texture : texture_sampled_cube_array<type>, sampler : sampler, coords : vec3<f32>, array_index : u32                    ) -> <type>
+textureSample(texture : texture_depth_2d,                 sampler : sampler, coords : vec2<f32>                                       ) -> f32
+textureSample(texture : texture_depth_2d,                 sampler : sampler, coords : vec2<f32>,                    offset : vec2<i32>) -> f32
+textureSample(texture : texture_depth_2d_array,           sampler : sampler, coords : vec2<f32>, array_index : u32                    ) -> f32
+textureSample(texture : texture_depth_2d_array,           sampler : sampler, coords : vec2<f32>, array_index : u32, offset : vec2<i32>) -> f32
+textureSample(texture : texture_depth_cube,               sampler : sampler, coords : vec3<f32>                                       ) -> f32
+textureSample(texture : texture_depth_cube_array,         sampler : sampler, coords : vec3<f32>, array_index : u32                    ) -> f32
+```
+
+**Parameters:**
+
+<table class='data'>
+  <tr><td>`texture`<td>
+  The [sampled](#sampled-texture-type) or [depth](#texture-depth) texture to
+  sample.
+  <tr><td>`sampler`<td>
+  The [sampler type](#sampler-type).
+  <tr><td>`coords`<td>
+  The texture coordinates used for sampling.
+  <tr><td>`array_index`<td>
+  The 0-based texture array index to sample.
+  <tr><td>`offset`<td>
+  The optional texel offset applied to the unnormalized texture coordinate
+  before sampling the texture. This offset is applied before applying any
+  texture wrapping modes. `offset` values may range from `[-8..7]` in all
+  dimensions. Values outside of this range will be clamped to the nearest limit.
+</table>
+
+**Returns:**
+
+The sampled value.
+
+
+### `textureSampleBias` ### {#texturesamplebias}
+
+Samples a texture with a bias to the mip level.
+
+```rust
+textureSampleBias(texture : texture_sampled_2d<type>,         sampler : sampler, coords : vec2<f32>,                    bias : f32                    ) -> <type>
+textureSampleBias(texture : texture_sampled_2d<type>,         sampler : sampler, coords : vec2<f32>,                    bias : f32, offset : vec2<i32>) -> <type>
+textureSampleBias(texture : texture_sampled_2d_array<type>,   sampler : sampler, coords : vec2<f32>, array_index : u32, bias : f32                    ) -> <type>
+textureSampleBias(texture : texture_sampled_2d_array<type>,   sampler : sampler, coords : vec2<f32>, array_index : u32, bias : f32, offset : vec2<i32>) -> <type>
+textureSampleBias(texture : texture_sampled_3d<type>,         sampler : sampler, coords : vec3<f32>,                    bias : f32                    ) -> <type>
+textureSampleBias(texture : texture_sampled_3d<type>,         sampler : sampler, coords : vec3<f32>,                    bias : f32, offset : vec3<i32>) -> <type>
+textureSampleBias(texture : texture_sampled_cube<type>,       sampler : sampler, coords : vec3<f32>,                    bias : f32                    ) -> <type>
+textureSampleBias(texture : texture_sampled_cube_array<type>, sampler : sampler, coords : vec3<f32>, array_index : u32, bias : f32                    ) -> <type>
+textureSampleBias(texture : texture_depth_2d,                 sampler : sampler, coords : vec2<f32>,                    bias : f32                    ) -> f32
+textureSampleBias(texture : texture_depth_2d,                 sampler : sampler, coords : vec2<f32>,                    bias : f32, offset : vec2<i32>) -> f32
+textureSampleBias(texture : texture_depth_2d_array,           sampler : sampler, coords : vec2<f32>, array_index : u32, bias : f32                    ) -> f32
+textureSampleBias(texture : texture_depth_2d_array,           sampler : sampler, coords : vec2<f32>, array_index : u32, bias : f32, offset : vec2<i32>) -> f32
+textureSampleBias(texture : texture_depth_cube,               sampler : sampler, coords : vec3<f32>,                    bias : f32                    ) -> f32
+textureSampleBias(texture : texture_depth_cube_array,         sampler : sampler, coords : vec3<f32>, array_index : u32, bias : f32                    ) -> f32
+```
+
+**Parameters:**
+
+<table class='data'>
+  <tr><td>`texture`<td>
+  The [sampled](#sampled-texture-type) or [depth](#texture-depth) texture to
+  sample.
+  <tr><td>`sampler`<td>
+  The [sampler type](#sampler-type).
+  <tr><td>`coords`<td>
+  The texture coordinates used for sampling.
+  <tr><td>`array_index`<td>
+  The 0-based texture array index to sample.
+  <tr><td>`bias`<td>
+  The bias to apply to the mip level before sampling.
+  `bias` must be between `-16.0` and `15.99`.
+  <tr><td>`offset`<td>
+  The optional texel offset applied to the unnormalized texture coordinate
+  before sampling the texture. This offset is applied before applying any
+  texture wrapping modes. `offset` values may range from `[-8..7]` in all
+  dimensions. Values outside of this range will be clamped to the nearest limit.
+</table>
+
+**Returns:**
+
+The sampled value.
+
+
+### `textureSampleLevel` ### {#texturesamplelevel}
+
+Samples a texture using an explicit mip level.
+
+```rust
+textureSampleLevel(texture : texture_sampled_2d<type>,         sampler : sampler, coords : vec2<f32>,                    level : f32                    ) -> <type>
+textureSampleLevel(texture : texture_sampled_2d<type>,         sampler : sampler, coords : vec2<f32>,                    level : f32, offset : vec2<i32>) -> <type>
+textureSampleLevel(texture : texture_sampled_2d_array<type>,   sampler : sampler, coords : vec2<f32>, array_index : u32, level : f32                    ) -> <type>
+textureSampleLevel(texture : texture_sampled_2d_array<type>,   sampler : sampler, coords : vec2<f32>, array_index : u32, level : f32, offset : vec2<i32>) -> <type>
+textureSampleLevel(texture : texture_sampled_3d<type>,         sampler : sampler, coords : vec3<f32>,                    level : f32                    ) -> <type>
+textureSampleLevel(texture : texture_sampled_3d<type>,         sampler : sampler, coords : vec3<f32>,                    level : f32, offset : vec3<i32>) -> <type>
+textureSampleLevel(texture : texture_sampled_cube<type>,       sampler : sampler, coords : vec3<f32>,                    level : f32                    ) -> <type>
+textureSampleLevel(texture : texture_sampled_cube_array<type>, sampler : sampler, coords : vec3<f32>, array_index : u32, level : f32                    ) -> <type>
+textureSampleLevel(texture : texture_depth_2d,                 sampler : sampler, coords : vec2<f32>,                    level : f32                    ) -> f32
+textureSampleLevel(texture : texture_depth_2d,                 sampler : sampler, coords : vec2<f32>,                    level : f32, offset : vec2<i32>) -> f32
+textureSampleLevel(texture : texture_depth_2d_array,           sampler : sampler, coords : vec2<f32>, array_index : u32, level : f32                    ) -> f32
+textureSampleLevel(texture : texture_depth_2d_array,           sampler : sampler, coords : vec2<f32>, array_index : u32, level : f32, offset : vec2<i32>) -> f32
+textureSampleLevel(texture : texture_depth_cube,               sampler : sampler, coords : vec3<f32>,                    level : f32                    ) -> f32
+textureSampleLevel(texture : texture_depth_cube_array,         sampler : sampler, coords : vec3<f32>, array_index : u32, level : f32                    ) -> f32
+```
+
+**Parameters:**
+
+<table class='data'>
+  <tr><td>`texture`<td>
+  The [sampled](#sampled-texture-type) or [depth](#texture-depth) texture to
+  sample.
+  <tr><td>`sampler`<td>
+  The [sampler type](#sampler-type).
+  <tr><td>`coords`<td>
+  The texture coordinates used for sampling.
+  <tr><td>`array_index`<td>
+  The 0-based texture array index to sample.
+  <tr><td>`level`<td>
+  The mip level to sample from, with 0 representing the largest level.
+  Fractional values may interpolate between two levels.
+  <tr><td>`offset`<td>
+  The optional texel offset applied to the unnormalized texture coordinate
+  before sampling the texture. This offset is applied before applying any
+  texture wrapping modes. `offset` values may range from `[-8..7]` in all
+  dimensions. Values outside of this range will be clamped to the nearest limit.
+</table>
+
+**Returns:**
+
+The sampled value.
+
+
+### `textureSampleGrad` ### {#texturesamplegrad}
+
+Samples a texture using explicit gradients.
+
+```rust
+textureSampleGrad(texture : texture_sampled_2d<type>,         sampler : sampler, coords : vec2<f32>,                    ddx : vec2<f32>, ddy : vec2<f32>                    ) -> <type>
+textureSampleGrad(texture : texture_sampled_2d<type>,         sampler : sampler, coords : vec2<f32>,                    ddx : vec2<f32>, ddy : vec2<f32>, offset : vec2<i32>) -> <type>
+textureSampleGrad(texture : texture_sampled_2d_array<type>,   sampler : sampler, coords : vec2<f32>, array_index : u32, ddx : vec2<f32>, ddy : vec2<f32>                    ) -> <type>
+textureSampleGrad(texture : texture_sampled_2d_array<type>,   sampler : sampler, coords : vec2<f32>, array_index : u32, ddx : vec2<f32>, ddy : vec2<f32>, offset : vec2<i32>) -> <type>
+textureSampleGrad(texture : texture_sampled_3d<type>,         sampler : sampler, coords : vec3<f32>,                    ddx : vec3<f32>, ddy : vec3<f32>                    ) -> <type>
+textureSampleGrad(texture : texture_sampled_3d<type>,         sampler : sampler, coords : vec3<f32>,                    ddx : vec3<f32>, ddy : vec3<f32>, offset : vec3<i32>) -> <type>
+textureSampleGrad(texture : texture_sampled_cube<type>,       sampler : sampler, coords : vec3<f32>,                    ddx : vec3<f32>, ddy : vec3<f32>                    ) -> <type>
+textureSampleGrad(texture : texture_sampled_cube_array<type>, sampler : sampler, coords : vec3<f32>, array_index : u32, ddx : vec3<f32>, ddy : vec3<f32>                    ) -> <type>
+textureSampleGrad(texture : texture_depth_2d,                 sampler : sampler, coords : vec2<f32>,                    ddx : vec2<f32>, ddy : vec2<f32>                    ) -> f32
+textureSampleGrad(texture : texture_depth_2d,                 sampler : sampler, coords : vec2<f32>,                    ddx : vec2<f32>, ddy : vec2<f32>, offset : vec2<i32>) -> f32
+textureSampleGrad(texture : texture_depth_2d_array,           sampler : sampler, coords : vec2<f32>, array_index : u32, ddx : vec2<f32>, ddy : vec2<f32>                    ) -> f32
+textureSampleGrad(texture : texture_depth_2d_array,           sampler : sampler, coords : vec2<f32>, array_index : u32, ddx : vec2<f32>, ddy : vec2<f32>, offset : vec2<i32>) -> f32
+textureSampleGrad(texture : texture_depth_cube,               sampler : sampler, coords : vec3<f32>,                    ddx : vec3<f32>, ddy : vec3<f32>                    ) -> f32
+textureSampleGrad(texture : texture_depth_cube_array,         sampler : sampler, coords : vec3<f32>, array_index : u32, ddx : vec3<f32>, ddy : vec3<f32>                    ) -> f32
+```
+
+**Parameters:**
+
+<table class='data'>
+  <tr><td>`texture`<td>
+  The [sampled](#sampled-texture-type) or [depth](#texture-depth) texture to
+  sample.
+  <tr><td>`sampler`<td>
+  The [sampler type](#sampler-type).
+  <tr><td>`coords`<td>
+  The texture coordinates used for sampling.
+  <tr><td>`array_index`<td>
+  The 0-based texture array index to sample.
+  <tr><td>`ddx`<td>
+  The x direction derivative vector used to compute the sampling locations.
+  <tr><td>`ddy`<td>
+  The y direction derivative vector used to compute the sampling locations.
+  <tr><td>`offset`<td>
+  The optional texel offset applied to the unnormalized texture coordinate
+  before sampling the texture. This offset is applied before applying any
+  texture wrapping modes. `offset` values may range from `[-8..7]` in all
+  dimensions. Values outside of this range will be clamped to the nearest limit.
+</table>
+
+**Returns:**
+
+The sampled value.
+
+
+### `textureSampleCompare` ### {#texturesamplecompare}
+
+Samples a depth texture and compares the sampled depth values against a reference value.
+
+```rust
+textureSampleCompare(texture : texture_depth_2d,         sampler : sampler_comparison, coords : vec2<f32>,                    depth_ref : f32                    ) -> f32
+textureSampleCompare(texture : texture_depth_2d,         sampler : sampler_comparison, coords : vec2<f32>,                    depth_ref : f32, offset : vec2<i32>) -> f32
+textureSampleCompare(texture : texture_depth_2d_array,   sampler : sampler_comparison, coords : vec2<f32>, array_index : u32, depth_ref : f32                    ) -> f32
+textureSampleCompare(texture : texture_depth_2d_array,   sampler : sampler_comparison, coords : vec2<f32>, array_index : u32, depth_ref : f32, offset : vec2<i32>) -> f32
+textureSampleCompare(texture : texture_depth_cube,       sampler : sampler_comparison, coords : vec3<f32>,                    depth_ref : f32                    ) -> f32
+textureSampleCompare(texture : texture_depth_cube_array, sampler : sampler_comparison, coords : vec3<f32>, array_index : u32, depth_ref : f32                    ) -> f32
+```
+
+**Parameters:**
+
+<table class='data'>
+  <tr><td>`texture`<td>
+  The [depth](#texture-depth) texture to sample.
+  <tr><td>`sampler`<td>
+  The [sampler comparision](#sampler-type) type.
+  <tr><td>`coords`<td>
+  The texture coordinates used for sampling.
+  <tr><td>`array_index`<td>
+  The 0-based texture array index to sample.
+  <tr><td>`depth_ref`<td>
+  The reference value to compare the sampled depth value against.
+  <tr><td>`offset`<td>
+  The optional texel offset applied to the unnormalized texture coordinate
+  before sampling the texture. This offset is applied before applying any
+  texture wrapping modes. `offset` values may range from `[-8..7]` in all
+  dimensions. Values outside of this range will be clamped to the nearest limit.
+</table>
+
+**Returns:**
+
+A `f32` in the range `[0.0..1.0]`, representing the number of depth values
+that were greater or less than the reference value.
+The comparision operator is defined by the `<sampler_comparison>`.
+
+
+**TODO:**
+
 <pre class='def'>
 `vec4<type> textureLoad(texture_storage_ro_1d      , i32       coords)`
 `vec4<type> textureLoad(texture_storage_ro_2d      , vec2<i32> coords)`
@@ -4200,42 +4436,7 @@ TODO: deduplicate these tables
 
 TODO(dsinclair): Add `textureWrite` method for texture_storage_wo with integral coords
 
-TODO(dsinclair): Allow a small constant offset on the coordinate? May not be portable.
 
-`vec4<type> textureSample(texture_1d        , sampler, f32       coords)`
-`vec4<type> textureSample(texture_2d        , sampler, vec2<f32> coords)`
-`vec4<type> textureSample(texture_1d_array  , sampler, vec2<f32> coords)`
-`vec4<type> textureSample(texture_3d        , sampler, vec3<f32> coords)`
-`vec4<type> textureSample(texture_2d_array  , sampler, vec3<f32> coords)`
-`vec4<type> textureSample(texture_cube      , sampler, vec3<f32> coords)`
-`vec4<type> textureSample(texture_cube_array, sampler, vec4<f32> coords)`
-  %24 = OpImageSampleImplicitLod %v4float %sampled_image %coords
-
-`vec4<type> textureSampleLevel(texture_1d        , sampler, f32       coords, f32 lod)`
-`vec4<type> textureSampleLevel(texture_2d        , sampler, vec2<f32> coords, f32 lod)`
-`vec4<type> textureSampleLevel(texture_1d_array  , sampler, vec2<f32> coords, f32 lod)`
-`vec4<type> textureSampleLevel(texture_3d        , sampler, vec3<f32> coords, f32 lod)`
-`vec4<type> textureSampleLevel(texture_2d_array  , sampler, vec3<f32> coords, f32 lod)`
-`vec4<type> textureSampleLevel(texture_cube      , sampler, vec3<f32> coords, f32 lod)`
-`vec4<type> textureSampleLevel(texture_cube_array, sampler, vec4<f32> coords, f32 lod)`
-  %25 = OpImageSampleExplicitLod %v4float %sampled_image %coords Lod %lod
-
-`vec4<type> textureSampleBias(texture_1d        , sampler, f32       coords, f32 bias)`
-`vec4<type> textureSampleBias(texture_2d        , sampler, vec2<f32> coords, f32 bias)`
-`vec4<type> textureSampleBias(texture_1d_array  , sampler, vec2<f32> coords, f32 bias)`
-`vec4<type> textureSampleBias(texture_3d        , sampler, vec3<f32> coords, f32 bias)`
-`vec4<type> textureSampleBias(texture_2d_array  , sampler, vec3<f32> coords, f32 bias)`
-`vec4<type> textureSampleBias(texture_cube      , sampler, vec3<f32> coords, f32 bias)`
-`vec4<type> textureSampleBias(texture_cube_array, sampler, vec4<f32> coords, f32 bias)`
-  %19 = OpImageSampleImplicitLod %v4float %sampled_image %coords Bias %bias
-
-`f32 textureSampleCompare(texture_depth_2d        , sampler_comparison, vec2<f32> coords, f32 depth_reference)`
-`f32 textureSampleCompare(texture_depth_2d_array  , sampler_comparison, vec3<f32> coords, f32 depth_reference)`
-`f32 textureSampleCompare(texture_depth_cube      , sampler_comparison, vec3<f32> coords, f32 depth_reference)`
-`f32 textureSampleCompare(texture_depth_cube_array, sampler_comparison, vec4<f32> coords, f32 depth_reference)`
-  %65 = OpImageSampleDrefExplicitLod %float %sampled_image %coord %depth_reference Lod %float_0
-
-TODO(dsinclair): Add Level-of-Detail via explicit gradient. "Grad" image operand in SPIR-V
 
 TODO(dsinclair): Need gather operations
 </pre>


### PR DESCRIPTION
The function variant attempt to cover the union of the supported features of: SPIR-V 1.0, HLSL 5.1, MSL 1.0.

An HTML rendered version can be found at: https://ben-clayton.github.io/gpuweb/wgsl#texture-sample-functions (force-refresh of cache may be necessary)

Issue: #573