### PR TITLE
Don't skip manifest for now in Actions

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           pip3 install bikeshed
           export PATH="$(python3 -m site --user-base)/bin:${PATH}"
-          bikeshed update --skip-manifest
+          bikeshed update
           mkdir out
           make -C spec
           make -C wgsl


### PR DESCRIPTION
Although we can find a way to speedup with skipping manifest, more than 10 minutes is **too much** for now.