### PR TITLE
Append commit SHA to previews

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -62,8 +62,9 @@ jobs:
       - name: Build Bikeshed
         if: ${{ github.event.workflow_run.event == 'pull_request' && env.PR }}
         run: |
-          pip3 install bikeshed
+          pip3 install bikeshed==2.0.0
           export PATH="$(python3 -m site --user-base)/bin:${PATH}"
+          bikeshed update
           mkdir out
           make -C spec
           make -C wgsl

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -64,7 +64,6 @@ jobs:
         run: |
           pip3 install bikeshed
           export PATH="$(python3 -m site --user-base)/bin:${PATH}"
-          bikeshed update --skip-manifest
           mkdir out
           make -C spec
           make -C wgsl

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Build Bikeshed
         if: ${{ github.event.workflow_run.event == 'pull_request' && env.PR }}
         run: |
-          pip3 install bikeshed==2.0.0
+          pip3 install bikeshed
           export PATH="$(python3 -m site --user-base)/bin:${PATH}"
           bikeshed update
           mkdir out

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           pip3 install bikeshed
           export PATH="$(python3 -m site --user-base)/bin:${PATH}"
-          bikeshed update
+          bikeshed update --skip-manifest
           mkdir out
           make -C spec
           make -C wgsl
@@ -92,6 +92,7 @@ jobs:
             Previews, as seen at the time of posting this comment:
             [**WebGPU**](${{ steps.deployment.outputs.details_url }}/index.html) | [**IDL**](${{ steps.deployment.outputs.details_url }}/webgpu.idl)
             [**WGSL**](${{ steps.deployment.outputs.details_url }}/wgsl.html)
+            <sub>${{ github.event.workflow_run.head_sha }}</sub>
             <!--
             pr;head;sha
             ${{ env.PR }};${{ github.event.workflow_run.head_repository.full_name }};${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Build Bikeshed
         if: ${{ github.event.workflow_run.event == 'pull_request' && env.PR }}
         run: |
-          pip3 install bikeshed
+          pip3 install bikeshed==2.0.0
           export PATH="$(python3 -m site --user-base)/bin:${PATH}"
           bikeshed update
           mkdir out

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
 
       - name: Build with bikeshed
         run: |
-          pip3 install bikeshed
+          pip3 install bikeshed==2.0.0
           export PATH="$(python3 -m site --user-base)/bin:${PATH}"
           bikeshed update
           mkdir out

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
 
       - name: Build with bikeshed
         run: |
-          pip3 install bikeshed==2.0.0
+          pip3 install bikeshed
           export PATH="$(python3 -m site --user-base)/bin:${PATH}"
           bikeshed update
           mkdir out

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,9 +11,9 @@ jobs:
 
       - name: Build with bikeshed
         run: |
-          pip3 install bikeshed
+          pip3 install bikeshed==2.0.0
           export PATH="$(python3 -m site --user-base)/bin:${PATH}"
-          bikeshed update --skip-manifest
+          bikeshed update
           mkdir out
           ./compile.sh
 


### PR DESCRIPTION
Mentioned in https://github.com/gpuweb/gpuweb/pull/1205#issuecomment-722433681 and makes sense.

This also pins `bikeshed==2.0.0` to avoid update problem.