### PR TITLE
Clarify resource usages.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -694,25 +694,25 @@ A [=physical resource=] can be used on GPU in one of the following <dfn dfn>inte
 <dl dfn-type=dfn dfn-for="internal usage">
     : <dfn>input</dfn>
     :: Buffer with input data for draw or dispatch calls. Preserves the contents.
-        Allowed by {{GPUBufferUsage/INDEX}}, {{GPUBufferUsage/VERTEX}}, or {{GPUBufferUsage/INDIRECT}}.
+        Allowed by buffer {{GPUBufferUsage/INDEX}}, buffer {{GPUBufferUsage/VERTEX}}, or buffer {{GPUBufferUsage/INDIRECT}}.
     : <dfn>constant</dfn>
     ::  Resource bindings that are constant from the shader point of view. Preserves the contents.
-        Allowed by {{GPUBufferUsage/UNIFORM}} or {{GPUTextureUsage/SAMPLED}}.
+        Allowed by buffer {{GPUBufferUsage/UNIFORM}} or texture {{GPUTextureUsage/SAMPLED}}.
     : <dfn>storage</dfn>
     ::  Read-write storage resource binding.
-        Allowed by {{GPUBufferUsage/STORAGE}}.
+        Allowed by buffer {{GPUBufferUsage/STORAGE}}.
     : <dfn>storage-read</dfn>
     ::  Read-only storage resource bindings. Preserves the contents.
-        Allowed by {{GPUBufferUsage/STORAGE}} or {{GPUTextureUsage/STORAGE}}.
+        Allowed by buffer {{GPUBufferUsage/STORAGE}} or texture {{GPUTextureUsage/STORAGE}}.
     : <dfn>storage-write</dfn>
     ::  Write-only storage resource bindings.
-        Allowed by {{GPUTextureUsage/STORAGE}}.
+        Allowed by texture {{GPUTextureUsage/STORAGE}}.
     : <dfn>attachment</dfn>
     :: Texture used as an output attachment in a render pass.
-        Allowed by {{GPUTextureUsage/RENDER_ATTACHMENT}}.
+        Allowed by texture {{GPUTextureUsage/RENDER_ATTACHMENT}}.
     : <dfn>attachment-read</dfn>
     ::  Texture used as a read-only attachment in a render pass. Preserves the contents.
-        Allowed by {{GPUTextureUsage/RENDER_ATTACHMENT}}.
+        Allowed by texture {{GPUTextureUsage/RENDER_ATTACHMENT}}.
 </dl>
 
 Textures may consist of separate [=mipmap levels=] and [=array layers=],


### PR DESCRIPTION
This Cl updates the resource usage section to add the kind of usage
before the usage itself. This makes it clearer for instances where the
spec says `STORAGE or STORAGE` that this means `buffer STORAGE or
texture STORAGE`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dj2/gpuweb/pull/1212.html" title="Last updated on Nov 7, 2020, 2:48 PM UTC (56c0619)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1212/0480646...dj2:56c0619.html" title="Last updated on Nov 7, 2020, 2:48 PM UTC (56c0619)">Diff</a>