### PR TITLE
Make internal usage links encompass entire word.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -725,7 +725,7 @@ and [=aspect=].
 We define <dfn dfn>subresource</dfn> to be either a whole buffer, or a [=texture subresource=].
 
 <div algorithm="compatible usage list">
-Some [=internal usage|internal usages=] are compatible with others. A [=subresource=] can be in a state
+Some [=internal usages=] are compatible with others. A [=subresource=] can be in a state
 that combines multiple usages together. We consider a list |U| to be
 a <dfn dfn>compatible usage list</dfn> if (and only if) it satisfies any of the following rules:
     - Each usage in |U| is [=internal usage/input=], [=internal usage/constant=], [=internal usage/storage-read=], or [=internal usage/attachment-read=].
@@ -764,9 +764,9 @@ The <dfn dfn>physical size</dfn> of a [=texture subresource=] is the dimension o
 [=texture subresource=] in texels that includes the possible extra paddings
 to form complete [=texel blocks=] in the [=subresource=].
 
-  - For pixel-based {{GPUTextureFormat}}s, the [=physical size=] is always equal to the size of the [=texture subresource=]
+  - For pixel-based {{GPUTextureFormat|GPUTextureFormats}}, the [=physical size=] is always equal to the size of the [=texture subresource=]
     used in the sampling hardwares.
-  - {{GPUTexture}}s in block-based compressed {{GPUTextureFormat}}s always have a [=mipmap level=] 0 whose {{GPUTexture/[[textureSize]]}}
+  - {{GPUTexture|GPUTextures}} in block-based compressed {{GPUTextureFormat|GPUTextureFormats}} always have a [=mipmap level=] 0 whose {{GPUTexture/[[textureSize]]}}
     is a multiple of the [=texel block size=], but the lower mipmap levels might not be the multiple of the [=texel block size=] and can
     have paddings.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -690,7 +690,7 @@ the user behind an `ArrayBuffer`, thus avoiding any data copies.
 
 ### Resource Usages ### {#programming-model-resource-usages}
 
-A [=physical resource=] can be used on GPU in one of the following <dfn dfn>internal usage</dfn>s:
+A [=physical resource=] can be used on GPU with a <dfn dfn>internal usage</dfn>:
 <dl dfn-type=dfn dfn-for="internal usage">
     : <dfn>input</dfn>
     :: Buffer with input data for draw or dispatch calls. Preserves the contents.
@@ -725,7 +725,7 @@ and [=aspect=].
 We define <dfn dfn>subresource</dfn> to be either a whole buffer, or a [=texture subresource=].
 
 <div algorithm="compatible usage list">
-Some [=internal usage=]s are compatible with others. A [=subresource=] can be in a state
+Some [=internal usage|internal usages=] are compatible with others. A [=subresource=] can be in a state
 that combines multiple usages together. We consider a list |U| to be
 a <dfn dfn>compatible usage list</dfn> if (and only if) it satisfies any of the following rules:
     - Each usage in |U| is [=internal usage/input=], [=internal usage/constant=], [=internal usage/storage-read=], or [=internal usage/attachment-read=].

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -690,7 +690,7 @@ the user behind an `ArrayBuffer`, thus avoiding any data copies.
 
 ### Resource Usages ### {#programming-model-resource-usages}
 
-A [=physical resource=] can be used on GPU with a <dfn dfn>internal usage</dfn>:
+A [=physical resource=] can be used on GPU with an <dfn dfn>internal usage</dfn>:
 <dl dfn-type=dfn dfn-for="internal usage">
     : <dfn>input</dfn>
     :: Buffer with input data for draw or dispatch calls. Preserves the contents.
@@ -766,7 +766,7 @@ to form complete [=texel blocks=] in the [=subresource=].
 
   - For pixel-based {{GPUTextureFormat|GPUTextureFormats}}, the [=physical size=] is always equal to the size of the [=texture subresource=]
     used in the sampling hardwares.
-  - {{GPUTexture|GPUTextures}} in block-based compressed {{GPUTextureFormat|GPUTextureFormats}} always have a [=mipmap level=] 0 whose {{GPUTexture/[[textureSize]]}}
+  - [=Textures=] in block-based compressed {{GPUTextureFormat|GPUTextureFormats}} always have a [=mipmap level=] 0 whose {{GPUTexture/[[textureSize]]}}
     is a multiple of the [=texel block size=], but the lower mipmap levels might not be the multiple of the [=texel block size=] and can
     have paddings.
 


### PR DESCRIPTION
This Cl changes a bit of working and one of the internal usage links so
we don't have a dangling 's' with different formatting.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dj2/gpuweb/pull/1213.html" title="Last updated on Nov 10, 2020, 1:15 AM UTC (1734156)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1213/0480646...dj2:1734156.html" title="Last updated on Nov 10, 2020, 1:15 AM UTC (1734156)">Diff</a>