### PR TITLE
[wgsl] Remove the preamble section

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4306,18 +4306,11 @@ Issue: (dsinclair) Write out precedence rules. Matches c and glsl rules ....
 [SHORTNAME] is focused on WebGPU shaders. As such, the following is defined for all
 shaders which are generated, when translated to SPIR-V.
 
-TODO(dneto): Forcing the Vulkan memory model is obsolete and should be removed.
-
 <div class='example' heading='Preamble'>
   <xmp>
 ....
 OpCapability Shader
-OpCapability VulkanMemoryModel
-OpMemoryModel Logical VulkanKHR
+OpMemoryModel Logical GLSL450
 ....
   </xmp>
 </div>
-
-While we recognize that most Vulkan devices will not support VulkanMemoryModel
-we expect the SPIR-V generated to be converted by SPIRV-Tools after the fact
-to make the shader compatible.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -32,20 +32,33 @@ thead {
 
 <pre class=biblio>
 {
-	"WebGPU": {
-		"authors": [
-			"Dzmitry Malyshau",
-			"Justin Fan",
-			"Kai Ninomiya"
-		],
-		"href": "https://gpuweb.github.io/gpuweb/",
-		"title": "WebGPU",
-		"status": "Editor's Draft",
-		"publisher": "W3C",
-		"deliveredBy": [
-			"https://github.com/gpuweb/gpuweb"
-		]
-	}
+  "WebGPU": {
+    "authors": [
+      "Dzmitry Malyshau",
+      "Justin Fan",
+      "Kai Ninomiya"
+    ],
+    "href": "https://gpuweb.github.io/gpuweb/",
+    "title": "WebGPU",
+    "status": "Editor's Draft",
+    "publisher": "W3C",
+    "deliveredBy": [
+      "https://github.com/gpuweb/gpuweb"
+    ]
+  },
+  "VulkanMemoryModel": {
+    "authors": [
+      "Jeff Bolz",
+      "Alan Baker",
+      "Tobias Hector",
+      "David Neto",
+      "Robert Simpson",
+      "Brian Sumner"
+    ],
+    "href": "https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#memory-model",
+    "title": "Vulkan Memory Model",
+    "publisher": "Khronos Group"
+  }
 }
 </pre>
 
@@ -406,6 +419,9 @@ Note: Layout decorations are required if the struct is used in an SSBO or UBO. O
 TODO: This section is a stub.
 
 In [SHORTNAME], a value of [=storable=] type may be stored in memory, for later retrieval.
+
+In general [SHORTNAME] follows the [[!VulkanMemoryModel|Vulkan Memory Model]] with the following exceptions
+ * No Acquire/Release semantics
 
 ### Memory Locations TODO ### {#memory-locations}
 
@@ -4301,16 +4317,3 @@ If you want `vec4<f32>` you must provide 4 float values in the constructor.
 ## Precedence ## {#precedence}
 
 Issue: (dsinclair) Write out precedence rules. Matches c and glsl rules ....
-
-## Preamble ## {#preamble}
-[SHORTNAME] is focused on WebGPU shaders. As such, the following is defined for all
-shaders which are generated, when translated to SPIR-V.
-
-<div class='example' heading='Preamble'>
-  <xmp>
-....
-OpCapability Shader
-OpMemoryModel Logical GLSL450
-....
-  </xmp>
-</div>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -420,7 +420,9 @@ TODO: This section is a stub.
 
 In [SHORTNAME], a value of [=storable=] type may be stored in memory, for later retrieval.
 
-In general [SHORTNAME] follows the [[!VulkanMemoryModel|Vulkan Memory Model]] with the following exceptions
+In general [SHORTNAME] follows the [[!VulkanMemoryModel|Vulkan Memory Model]]
+with the following exceptions
+
  * No Acquire/Release semantics
 
 ### Memory Locations TODO ### {#memory-locations}


### PR DESCRIPTION
This CL removes the preamble section from the spec, the generated SPIR-V in this
case is an implementation detail. The Vulkan Memory Model is explicitly called out
as what we are following.

This is a recreation of https://github.com/gpuweb/gpuweb/pull/1177