### PR TITLE
Remove GPUFence

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -402,7 +402,7 @@ are used by other applications, and how much they allocate from them.
 
 If one site uses WebGPU at the same time as another, it may observe the increase
 in time it takes to process some work. For example, if a site constantly submits
-compute workloads and tracks fences for their completion,
+compute workloads and tracks completion of work on the queue,
 it may observe that something else also started using the GPU.
 
 A GPU has many parts that can be tested independently, such as the arithmetic units,
@@ -6335,8 +6335,7 @@ dictionary GPURenderBundleEncoderDescriptor : GPUObjectDescriptorBase {
 interface GPUQueue {
     undefined submit(sequence<GPUCommandBuffer> commandBuffers);
 
-    GPUFence createFence(optional GPUFenceDescriptor descriptor = {});
-    undefined signal(GPUFence fence, GPUFenceValue signalValue);
+    Promise<undefined> onCompletion();
 
     undefined writeBuffer(
         GPUBuffer buffer,
@@ -6533,104 +6532,24 @@ GPUQueue includes GPUObjectBase;
                     </div>
             </div>
         </div>
-</dl>
 
-## <dfn interface>GPUFence</dfn> ## {#fence}
-
-<script type=idl>
-interface GPUFence {
-    GPUFenceValue getCompletedValue();
-    Promise<undefined> onCompletion(GPUFenceValue completionValue);
-};
-GPUFence includes GPUObjectBase;
-</script>
-
-### Creation ### {#fence-creation}
-
-<script type=idl>
-dictionary GPUFenceDescriptor : GPUObjectDescriptorBase {
-    GPUFenceValue initialValue = 0;
-};
-</script>
-
-<dl dfn-type=method dfn-for=GPUQueue>
-    : <dfn>createFence(descriptor)</dfn>
+    : <dfn>onCompletion()</dfn>
     ::
-        Creates a {{GPUFence}}.
+        Returns a {{Promise}} that resolves once this queue finishes processing all the work submitted
+        up to this moment..
 
-        <div algorithm="GPUQueue.createFence">
+        <div algorithm="GPUQueue.onCompletion">
             **Called on:** {{GPUQueue}} this.
 
             **Arguments:**
-            <pre class=argumentdef for="GPUQueue/createFence(descriptor)">
-                descriptor: Description of the {{GPUFence}} to create.
-            </pre>
-
-            **Returns:** {{GPUFence}}
-
-            Issue: Describe {{GPUQueue/createFence()}} algorithm steps.
-        </div>
-</dl>
-
-### Completion ### {#fence-signaling}
-
-Completion of a fence is signaled from the {{GPUQueue}} that created it.
-
-<dl dfn-type=method dfn-for=GPUQueue>
-    : <dfn>signal(fence, signalValue)</dfn>
-    ::
-        Signals the given fence, increasing it's completed value to `signalValue`.
-
-        <div algorithm="GPUQueue.signal">
-            **Called on:** {{GPUQueue}} this.
-
-            **Arguments:**
-            <pre class=argumentdef for="GPUQueue/signal(fence, signalValue)">
-                |fence|: The fence to signal.
-                signalValue: The value to increase |fence|'s completion value to.
-            </pre>
-
-            **Returns:** {{undefined}}
-
-            Issue: Describe {{GPUQueue/signal()}} algorithm steps.
-        </div>
-</dl>
-
-The completion of the fence and the value it completes with can be observed from the {{GPUFence}}.
-
-<dl dfn-type=method dfn-for=GPUFence>
-    : <dfn>getCompletedValue()</dfn>
-    ::
-        Returns the largest signalled value completion value for the fence that has propagated to
-        the [=content timeline=].
-
-        <div algorithm="GPUFence.getCompletedValue">
-            **Called on:** {{GPUFence}} this.
-
-            **Returns:** {{GPUFenceValue}}
-
-            Issue: Describe {{GPUFence/getCompletedValue()}} algorithm steps.
-        </div>
-
-    : <dfn>onCompletion(completionValue)</dfn>
-    ::
-        Returns a {{Promise}} that resolves once the fence's completion value &ge; `completionValue`.
-
-        <div algorithm="GPUFence.onCompletion">
-            **Called on:** {{GPUFence}} this.
-
-            **Arguments:**
-            <pre class=argumentdef for="GPUFence/onCompletion(completionValue)">
-                completionValue: The completion value that the fence must meet or exceed before
-                    resolving the returned {{Promise}}
+            <pre class=argumentdef for="GPUQueue/onCompletion()">
             </pre>
 
             **Returns:** {{Promise}}&lt;{{undefined}}&gt;
 
-            Issue: Describe {{GPUFence/onCompletion()}} algorithm steps.
+            Issue: Describe {{GPUQueue/onCompletion()}} algorithm steps.
         </div>
 </dl>
-
 
 Queries {#queries}
 ================
@@ -6921,7 +6840,6 @@ partial interface GPUDevice {
 
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUBufferDynamicOffset;
-typedef [EnforceRange] unsigned long long GPUFenceValue;
 typedef [EnforceRange] unsigned long GPUStencilValue;
 typedef [EnforceRange] unsigned long GPUSampleMask;
 typedef [EnforceRange] long GPUDepthBias;

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6335,7 +6335,7 @@ dictionary GPURenderBundleEncoderDescriptor : GPUObjectDescriptorBase {
 interface GPUQueue {
     undefined submit(sequence<GPUCommandBuffer> commandBuffers);
 
-    Promise<undefined> onCompletion();
+    Promise<undefined> onSubmittedWorkDone();
 
     undefined writeBuffer(
         GPUBuffer buffer,
@@ -6533,21 +6533,21 @@ GPUQueue includes GPUObjectBase;
             </div>
         </div>
 
-    : <dfn>onCompletion()</dfn>
+    : <dfn>onSubmittedWorkDone()</dfn>
     ::
         Returns a {{Promise}} that resolves once this queue finishes processing all the work submitted
         up to this moment.
 
-        <div algorithm="GPUQueue.onCompletion">
+        <div algorithm="GPUQueue.onSubmittedWorkDone">
             **Called on:** {{GPUQueue}} this.
 
             **Arguments:**
-            <pre class=argumentdef for="GPUQueue/onCompletion()">
+            <pre class=argumentdef for="GPUQueue/onSubmittedWorkDone()">
             </pre>
 
             **Returns:** {{Promise}}&lt;{{undefined}}&gt;
 
-            Issue: Describe {{GPUQueue/onCompletion()}} algorithm steps.
+            Issue: Describe {{GPUQueue/onSubmittedWorkDone()}} algorithm steps.
         </div>
 </dl>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6536,7 +6536,7 @@ GPUQueue includes GPUObjectBase;
     : <dfn>onCompletion()</dfn>
     ::
         Returns a {{Promise}} that resolves once this queue finishes processing all the work submitted
-        up to this moment..
+        up to this moment.
 
         <div algorithm="GPUQueue.onCompletion">
             **Called on:** {{GPUQueue}} this.


### PR DESCRIPTION
This is a follow-up to #1169 which just removes the fences from the API, as requested - being a per-requisite for multi-queue landing.

Note: strictly speaking, GPUFence was introduced without much argument very early in the API. The main goal was - to match the native APIs (which have slightly different semantics there, btw), and to anticipate helping with future changes in WebGPU, such as buffer mapping and multi-queue synchronization. Well, now we have a clear idea of the API changes, since we are in the future, and it turns out we don't really need fences. So if we want them to stay, we need to argue *for* them being (re-) introduced. As it stands now, a single `Queue.onCompletion()` replaces fences just fine, and this is what this PR does.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/1217.html" title="Last updated on Nov 23, 2020, 10:45 PM UTC (5319cf7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1217/0855ad9...kvark:5319cf7.html" title="Last updated on Nov 23, 2020, 10:45 PM UTC (5319cf7)">Diff</a>