### PR TITLE
[wgsl] rename set to group

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1202,7 +1202,7 @@ TODO: Uniform buffer layout and storage buffer layout are defined in the next me
 As described in [[#resource-interface]],
 uniform buffers, storage buffers, textures, and samplers form the
 [=resource interface of a shader=].
-Such variables are declared with [=set=] and [=binding=] decorations.
+Such variables are declared with [=group=] and [=binding=] decorations.
 
 <div class='example' heading="Module scope variable declarations">
   <xmp>
@@ -1220,10 +1220,10 @@ Such variables are declared with [=set=] and [=binding=] decorations.
     [[block]] struct PositionsBuffer {
       [[offset(0)]] pos: [[stride(8)]] array<vec2<f32>>;
     };
-    [[set(0), binding(0)]]
+    [[group(0), binding(0)]]
     var<storage> pbuf: PositionsBuffer;  # A storage buffer
 
-    [[set(0), binding(1)]]
+    [[group(0), binding(1)]]
     var filter_params: sampler;   # Textures and samplers are always in "handle" storage.
   </xmp>
 </div>
@@ -1251,9 +1251,9 @@ literal_or_ident
     [[location(2)]]
        OpDecorate %gl_FragColor Location 2
 
-    [[binding(3), set(4)]]
-       OpDecorate %gl_FragColor Binding 3
+    [[group(4), binding(3)]]
        OpDecorate %gl_FragColor DescriptorSet 4
+       OpDecorate %gl_FragColor Binding 3
   </xmp>
 </div>
 
@@ -1263,8 +1263,8 @@ literal_or_ident
   </thead>
   <tr><td>`binding`<td>non-negative i32 literal<td>See [[#resource-interface]]
   <tr><td>`builtin`<td>a builtin variable identifier<td>See [[#builtin-variables]]
+  <tr><td>`group`<td>non-negative i32 literal<td>See [[#resource-interface]]
   <tr><td>`location`<td>non-negative i32 literal<td>See TBD
-  <tr><td>`set`<td>non-negative i32 literal<td>See [[#resource-interface]]
 </table>
 
 ## Module Constants ## {#module-constants}
@@ -3151,7 +3151,7 @@ The <dfn noexport>resource interface of a shader</dfn> is the set of module-scop
 resource variables [=statically accessed=] by
 [=functions in a shader stage|functions in the shader stage=].
 
-Each resource variable must be declared with both <dfn noexport>`set`</dfn>
+Each resource variable must be declared with both <dfn noexport>`group`</dfn>
 and <dfn noexport>`binding`</dfn> attributes.
 Together with the shader's stage, these identify the binding address
 of the resource on the shader's pipeline.
@@ -3159,7 +3159,7 @@ See [[WebGPU#pipeline-layout|WebGPU &sect; GPUPipelineLayout]].
 
 Bindings must not alias within a shader stage:
 two different variables in the resource interface of a given
-shader must not have the same set and binding values, when considered as a pair of values.
+shader must not have the same group and binding values, when considered as a pair of values.
 
 <table class='data'>
   <caption>Resource variable attributes</caption>
@@ -3167,7 +3167,7 @@ shader must not have the same set and binding values, when considered as a pair 
     <tr><th>Decoraton<th>Operand<th>Description
   </thead>
 
-  <tr><td>`set`
+  <tr><td>`group`
       <td>non-negative i32 literal
       <td>Bind group index
   <tr><td>`binding`


### PR DESCRIPTION
Highly related to #1214 (cc @dneto0 )
"resource binding group" is the term we use in host WebGPU API. There is no reason why WGSL should diverge from that.