### PR TITLE
Refactor GPUBindGroupLayout to isolate binding type definitions

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2566,19 +2566,19 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
     <tr>
         <td rowspan=3>{{GPUBindGroupLayoutEntry/texture}}
         <td rowspan=3>{{GPUTextureView}}
-        <td>{{GPUTextureType/"float"}}
+        <td>{{GPUTextureSampleType/"float"}}
         <td>[=internal usage/constant=]
     <tr>
-        <td>{{GPUTextureType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>[=internal usage/constant=]
     <tr>
-        <td>{{GPUTextureType/"depth-float"}}
+        <td>{{GPUTextureSampleType/"depth"}}
         <td>[=internal usage/constant=]
     <tr>
-        <td>{{GPUTextureType/"sint"}}
+        <td>{{GPUTextureSampleType/"sint"}}
         <td>[=internal usage/constant=]
     <tr>
-        <td>{{GPUTextureType/"uint"}}
+        <td>{{GPUTextureSampleType/"uint"}}
         <td>[=internal usage/constant=]
 
     <tr>
@@ -2655,16 +2655,16 @@ dictionary GPUSamplerBindingLayout {
 </dl>
 
 <script type=idl>
-enum GPUTextureType {
+enum GPUTextureSampleType {
   "float",
   "unfilterable-float",
-  "depth-float",
+  "depth",
   "sint",
   "uint",
 };
 
 dictionary GPUTextureBindingLayout {
-    GPUTextureType type = "float";
+    GPUTextureSampleType type = "float";
     GPUTextureViewDimension viewDimension = "2d";
     boolean multisampled = false;
 };
@@ -2808,7 +2808,7 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                                     - |textureLayout|.{{GPUTextureBindingLayout/viewDimension}} is
                                         {{GPUTextureViewDimension/"2d"}}.
                                     - |textureLayout|.{{GPUTextureBindingLayout/type}} is not
-                                        {{GPUTextureType/"depth-float"}}.
+                                        {{GPUTextureSampleType/"depth"}} or {{GPUTextureSampleType/"float"}}.
 
                                 - If |storageTextureLayout| is not `undefined`:
                                     - |storageTextureLayout|.{{GPUStorageTextureBindingLayout/viewDimension}} is not
@@ -7231,225 +7231,190 @@ The "Filter" column specifies whether textures of this format can be sampled in 
     <thead class=stickyheader>
         <tr>
             <th>Format
-            <th>{{GPUTextureComponentType|Component Type}}
+            <th>{{GPUTextureSampleType}}
             <th>{{GPUTextureUsage/RENDER_ATTACHMENT}}
             <th>{{GPUTextureUsage/STORAGE}}
-            <th>Filter
     </thead>
     <tr><th class=stickyheader>8-bit per component<th><th><th><th>
     <tr>
         <td>{{GPUTextureFormat/r8unorm}}
-        <td>{{GPUTextureComponentType/"float"}}
+        <td>{{GPUTextureSampleType/"float"}}
         <td>&checkmark;
         <td>
-        <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/r8snorm}}
-        <td>{{GPUTextureComponentType/"float"}}
+        <td>{{GPUTextureSampleType/"float"}}
         <td>
         <td>
-        <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/r8uint}}
-        <td>{{GPUTextureComponentType/"uint"}}
+        <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
-        <td>
         <td>
     <tr>
         <td>{{GPUTextureFormat/r8sint}}
-        <td>{{GPUTextureComponentType/"sint"}}
+        <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
-        <td>
         <td>
     <tr>
         <td>{{GPUTextureFormat/rg8unorm}}
-        <td>{{GPUTextureComponentType/"float"}}
+        <td>{{GPUTextureSampleType/"float"}}
         <td>&checkmark;
         <td>
-        <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rg8snorm}}
-        <td>{{GPUTextureComponentType/"float"}}
+        <td>{{GPUTextureSampleType/"float"}}
         <td>
         <td>
-        <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rg8uint}}
-        <td>{{GPUTextureComponentType/"uint"}}
+        <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
-        <td>
         <td>
     <tr>
         <td>{{GPUTextureFormat/rg8sint}}
-        <td>{{GPUTextureComponentType/"sint"}}
+        <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
-        <td>
         <td>
     <tr>
         <td>{{GPUTextureFormat/rgba8unorm}}
-        <td>{{GPUTextureComponentType/"float"}}
-        <td>&checkmark;
+        <td>{{GPUTextureSampleType/"float"}}
         <td>&checkmark;
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rgba8unorm-srgb}}
-        <td>{{GPUTextureComponentType/"float"}}
+        <td>{{GPUTextureSampleType/"float"}}
         <td>&checkmark;
         <td>
-        <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rgba8snorm}}
-        <td>{{GPUTextureComponentType/"float"}}
+        <td>{{GPUTextureSampleType/"float"}}
         <td>
-        <td>&checkmark;
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rgba8uint}}
-        <td>{{GPUTextureComponentType/"uint"}}
+        <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
         <td>&checkmark;
-        <td>
     <tr>
         <td>{{GPUTextureFormat/rgba8sint}}
-        <td>{{GPUTextureComponentType/"sint"}}
+        <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
         <td>&checkmark;
-        <td>
     <tr>
         <td>{{GPUTextureFormat/bgra8unorm}}
-        <td>{{GPUTextureComponentType/"float"}}
+        <td>{{GPUTextureSampleType/"float"}}
         <td>&checkmark;
         <td>
-        <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/bgra8unorm-srgb}}
-        <td>{{GPUTextureComponentType/"float"}}
+        <td>{{GPUTextureSampleType/"float"}}
         <td>&checkmark;
         <td>
-        <td>&checkmark;
     <tr><th class=stickyheader>16-bit per component<th><th><th><th>
     <tr>
         <td>{{GPUTextureFormat/r16uint}}
-        <td>{{GPUTextureComponentType/"uint"}}
+        <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
-        <td>
         <td>
     <tr>
         <td>{{GPUTextureFormat/r16sint}}
-        <td>{{GPUTextureComponentType/"sint"}}
+        <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
-        <td>
         <td>
     <tr>
         <td>{{GPUTextureFormat/r16float}}
-        <td>{{GPUTextureComponentType/"float"}}
+        <td>{{GPUTextureSampleType/"float"}}
         <td>&checkmark;
         <td>
-        <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rg16uint}}
-        <td>{{GPUTextureComponentType/"uint"}}
+        <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
-        <td>
         <td>
     <tr>
         <td>{{GPUTextureFormat/rg16sint}}
-        <td>{{GPUTextureComponentType/"sint"}}
+        <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
-        <td>
         <td>
     <tr>
         <td>{{GPUTextureFormat/rg16float}}
-        <td>{{GPUTextureComponentType/"float"}}
+        <td>{{GPUTextureSampleType/"float"}}
         <td>&checkmark;
         <td><!-- Vulkan -->
-        <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rgba16uint}}
-        <td>{{GPUTextureComponentType/"uint"}}
+        <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
         <td>&checkmark;
-        <td>
     <tr>
         <td>{{GPUTextureFormat/rgba16sint}}
-        <td>{{GPUTextureComponentType/"sint"}}
+        <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
         <td>&checkmark;
-        <td>
     <tr>
         <td>{{GPUTextureFormat/rgba16float}}
-        <td>{{GPUTextureComponentType/"float"}}
-        <td>&checkmark;
+        <td>{{GPUTextureSampleType/"float"}}
         <td>&checkmark;
         <td>&checkmark;
     <tr><th class=stickyheader>32-bit per component<th><th><th><th>
     <tr>
         <td>{{GPUTextureFormat/r32uint}}
-        <td>{{GPUTextureComponentType/"uint"}}
+        <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
         <td>&checkmark;
-        <td>
     <tr>
         <td>{{GPUTextureFormat/r32sint}}
-        <td>{{GPUTextureComponentType/"sint"}}
+        <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
         <td>&checkmark;
-        <td>
     <tr>
         <td>{{GPUTextureFormat/r32float}}
-        <td>{{GPUTextureComponentType/"float"}}
+        <td>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>&checkmark;
         <td><!-- Metal -->
     <tr>
         <td>{{GPUTextureFormat/rg32uint}}
-        <td>{{GPUTextureComponentType/"uint"}}
+        <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
         <td>&checkmark;
-        <td>
     <tr>
         <td>{{GPUTextureFormat/rg32sint}}
-        <td>{{GPUTextureComponentType/"sint"}}
+        <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
         <td>&checkmark;
-        <td>
     <tr>
         <td>{{GPUTextureFormat/rg32float}}
-        <td>{{GPUTextureComponentType/"float"}}
+        <td>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>&checkmark;
-        <td>
     <tr>
         <td>{{GPUTextureFormat/rgba32uint}}
-        <td>{{GPUTextureComponentType/"uint"}}
+        <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
         <td>&checkmark;
-        <td>
     <tr>
         <td>{{GPUTextureFormat/rgba32sint}}
-        <td>{{GPUTextureComponentType/"sint"}}
+        <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
         <td>&checkmark;
-        <td>
     <tr>
         <td>{{GPUTextureFormat/rgba32float}}
-        <td>{{GPUTextureComponentType/"float"}}
+        <td>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>&checkmark;
-        <td>
     <tr><th class=stickyheader>mixed component width<th><th><th><th>
     <tr>
         <td>{{GPUTextureFormat/rgb10a2unorm}}
-        <td>{{GPUTextureComponentType/"float"}}
+        <td>{{GPUTextureSampleType/"float"}}
         <td>&checkmark;
         <td>
-        <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rg11b10ufloat}}
-        <td>{{GPUTextureComponentType/"float"}}
+        <td>{{GPUTextureSampleType/"float"}}
         <td><!-- Vulkan -->
         <td>
-        <td>&checkmark;
 
 </table>
 
@@ -7465,7 +7430,7 @@ None of the depth formats can be filtered.
             <th>Format
             <th>Bytes per texel
             <th>Aspect
-            <th>{{GPUTextureComponentType|Component Types}}
+            <th>{{GPUTextureSampleType}}
             <th>Copy aspect from Buffer
             <th>Copy aspect into Buffer
     </thead>
@@ -7473,25 +7438,25 @@ None of the depth formats can be filtered.
         <td>{{GPUTextureFormat/stencil8}}
         <td>1 &minus; 5
         <td>stencil
-        <td>{{GPUTextureComponentType/"uint"}}
+        <td>{{GPUTextureSampleType/"uint"}}
         <td colspan=2>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/depth16unorm}}
         <td>2
         <td>depth
-        <td>{{GPUTextureComponentType/"float"}}, {{GPUTextureComponentType/"depth"}}
+        <td>{{GPUTextureSampleType/"depth"}}
         <td colspan=2>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/depth24plus}}
         <td>4
         <td>depth
-        <td>{{GPUTextureComponentType/"float"}}, {{GPUTextureComponentType/"depth"}}
+        <td>{{GPUTextureSampleType/"depth"}}
         <td colspan=2>&cross;
     <tr>
         <td rowspan=2 style='white-space:nowrap'>{{GPUTextureFormat/depth24plus-stencil8}}
         <td rowspan=2>4 &minus; 8
         <td>depth
-        <td>{{GPUTextureComponentType/"float"}}, {{GPUTextureComponentType/"depth"}}
+        <td>{{GPUTextureSampleType/"depth"}}
         <td colspan=2>&cross;
     <tr>
         <td>stencil
@@ -7501,7 +7466,7 @@ None of the depth formats can be filtered.
         <td>{{GPUTextureFormat/depth32float}}
         <td>4
         <td>depth
-        <td>{{GPUTextureComponentType/"float"}}, {{GPUTextureComponentType/"depth"}}
+        <td>{{GPUTextureSampleType/"depth"}}
         <td colspan=1>&cross;
         <td colspan=1>&checkmark;
 </table>
@@ -7524,20 +7489,20 @@ All packed texture formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsa
         <tr>
             <th>Format
             <th>Bytes per block
-            <th>{{GPUTextureComponentType|Component Types}}
+            <th>{{GPUTextureSampleType}}
             <th>Block Size
             <th>[=Feature=]
     </thead>
     <tr>
         <td>{{GPUTextureFormat/rgb9e5ufloat}}
         <td>4
-        <td>{{GPUTextureComponentType/"float"}}
+        <td>{{GPUTextureSampleType/"float"}}
         <td>1 &times; 1
         <td>
     <tr>
         <td>{{GPUTextureFormat/bc1-rgba-unorm}}
         <td rowspan=2>8
-        <td rowspan=14>{{GPUTextureComponentType/"float"}}
+        <td rowspan=14>{{GPUTextureSampleType/"float"}}
         <td rowspan=14>4 &times; 4
         <td rowspan=14>{{GPUFeatureName/texture-compression-bc}}
     <tr>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2797,7 +2797,7 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                                     - |textureLayout|.{{GPUTextureBindingLayout/viewDimension}} is
                                         {{GPUTextureViewDimension/"2d"}}.
                                     - |textureLayout|.{{GPUTextureBindingLayout/type}} is not
-                                        {{GPUTextureSampleType/"depth"}} or {{GPUTextureSampleType/"float"}}.
+                                        {{GPUTextureSampleType/"float"}}.
 
                                 - If |storageTextureLayout| is not `undefined`:
                                     - |storageTextureLayout|.{{GPUStorageTextureBindingLayout/viewDimension}} is not
@@ -7359,10 +7359,9 @@ The "Filter" column specifies whether textures of this format can be sampled in 
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/r32float}}
-        <td>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"unfilterable-float"}}<!-- Metal -->
         <td>&checkmark;
         <td>&checkmark;
-        <td><!-- Metal -->
     <tr>
         <td>{{GPUTextureFormat/rg32uint}}
         <td>{{GPUTextureSampleType/"uint"}}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -305,7 +305,7 @@ that guarantees that the access is limited to buffer bounds.
 
 Alternatively, an implementation may transform the shader code by inserting manual bounds checks.
 When this path is taken, the out-of-bound checks only apply to array indexing. They aren't needed
-for plain field access of shader structures due to the {{GPUBufferLayoutEntry/minBufferBindingSize}}
+for plain field access of shader structures due to the {{GPUBufferBindingLayout/minBufferBindingSize}}
 validation on the host side.
 
 If the shader attempts to load data outside of [=physical resource=] bounds,
@@ -958,7 +958,7 @@ a better limit is not specified.
         The maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
 
           - [%Layout entry binding type%] is {{GPUBufferType/"uniform"}}, and
-          - {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/hasDynamicOffset}} is `true`,
+          - {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}} is `true`,
 
         across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
         when creating a {{GPUPipelineLayout}}.
@@ -969,7 +969,7 @@ a better limit is not specified.
         The maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
 
           - [%Layout entry binding type%] is {{GPUBufferType/"storage"}}, and
-          - {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/hasDynamicOffset}} is `true`,
+          - {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}} is `true`,
 
         across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
         when creating a {{GPUPipelineLayout}}.
@@ -2226,7 +2226,7 @@ enum GPUTextureComponentType {
     "sint",
     "uint",
     // Texture is used with comparison sampling only.
-    "depth-stencil"
+    "depth"
 };
 </script>
 
@@ -2482,10 +2482,10 @@ dictionary GPUBindGroupLayoutEntry {
     required GPUIndex32 binding;
     required GPUShaderStageFlags visibility;
 
-    GPUBufferLayoutEntry buffer;
-    GPUSamplerLayoutEntry sampler;
-    GPUTextureLayoutEntry texture;
-    GPUStorageTextureLayoutEntry storageTexture;
+    GPUBufferBindingLayout buffer;
+    GPUSamplerBindingLayout sampler;
+    GPUTextureBindingLayout texture;
+    GPUStorageTextureBindingLayout storageTexture;
 };
 </script>
 
@@ -2578,10 +2578,10 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
     <tr>
         <td rowspan=2>{{GPUBindGroupLayoutEntry/storageTexture}}
         <td rowspan=2>{{GPUTextureView}}
-        <td>{{GPUStorageTextureType/"readonly"}}
+        <td>{{GPUStorageTextureAccess/"readonly"}}
         <td>[=internal usage/storage-read=]
     <tr>
-        <td>{{GPUStorageTextureType/"writeonly"}}
+        <td>{{GPUStorageTextureAccess/"writeonly"}}
         <td>[=internal usage/storage-write=]
 </table>
 
@@ -2589,13 +2589,13 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
     To get the <dfn abstract-op>layout entry binding type</dfn> in a given {{GPUBindGroupLayoutEntry}} |entry|:
 
     1. If |entry|.{{GPUBindGroupLayoutEntry/buffer}} is not `undefined`:
-        1. Return |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/type}}.
+        1. Return |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/type}}.
     1. If |entry|.{{GPUBindGroupLayoutEntry/sampler}} is not `undefined`:
-        1. Return |entry|.{{GPUBindGroupLayoutEntry/sampler}}.{{GPUSamplerLayoutEntry/type}}.
+        1. Return |entry|.{{GPUBindGroupLayoutEntry/sampler}}.{{GPUSamplerBindingLayout/type}}.
     1. If |entry|.{{GPUBindGroupLayoutEntry/texture}} is not `undefined`:
-        1. Return |entry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureLayoutEntry/type}}.
+        1. Return |entry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/type}}.
     1. If |entry|.{{GPUBindGroupLayoutEntry/storageTexture}} is not `undefined`:
-        1. Return |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureLayoutEntry/type}}.
+        1. Return |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/type}}.
 </div>
 
 <script type=idl>
@@ -2605,16 +2605,16 @@ enum GPUBufferType {
     "readonly-storage",
 };
 
-dictionary GPUBufferLayoutEntry {
+dictionary GPUBufferBindingLayout {
     GPUBufferType type = "uniform";
     boolean hasDynamicOffset = false;
     GPUSize64 minBufferBindingSize = 0;
 };
 </script>
 
-{{GPUBufferLayoutEntry}} dictionaries have the following members:
+{{GPUBufferBindingLayout}} dictionaries have the following members:
 
-<dl dfn-type=dict-member dfn-for=GPUBufferLayoutEntry>
+<dl dfn-type=dict-member dfn-for=GPUBufferBindingLayout>
     : <dfn>type</dfn>
     ::
         Indicates the type required for buffers bound to this bindings.
@@ -2635,14 +2635,14 @@ enum GPUSamplerType {
     "comparison",
 };
 
-dictionary GPUSamplerLayoutEntry {
+dictionary GPUSamplerBindingLayout {
     GPUSamplerType type = "filtering";
 };
 </script>
 
-{{GPUSamplerLayoutEntry}} dictionaries have the following members:
+{{GPUSamplerBindingLayout}} dictionaries have the following members:
 
-<dl dfn-type=dict-member dfn-for=GPUSamplerLayoutEntry>
+<dl dfn-type=dict-member dfn-for=GPUSamplerBindingLayout>
     : <dfn>type</dfn>
     ::
         Indicates the required type of a sampler bound to this bindings.
@@ -2655,19 +2655,19 @@ enum GPUTextureType {
     "multisample",
 };
 
-dictionary GPUTextureLayoutEntry {
+dictionary GPUTextureBindingLayout {
     GPUTextureType type = "filterable";
     GPUTextureComponentType componentType = "float";
     GPUTextureViewDimension viewDimension = "2d";
 };
 </script>
 
-Issue(https://github.com/gpuweb/gpuweb/issues/851): consider making {{GPUTextureLayoutEntry/componentType}}
+Issue(https://github.com/gpuweb/gpuweb/issues/851): consider making {{GPUTextureBindingLayout/componentType}}
 truly optional.
 
-{{GPUTextureLayoutEntry}} dictionaries have the following members:
+{{GPUTextureBindingLayout}} dictionaries have the following members:
 
-<dl dfn-type=dict-member dfn-for=GPUTextureLayoutEntry>
+<dl dfn-type=dict-member dfn-for=GPUTextureBindingLayout>
     : <dfn>type</dfn>
     ::
         Indicates the type required for texture views bound to this binding.
@@ -2688,24 +2688,24 @@ truly optional.
 </dl>
 
 <script type=idl>
-enum GPUStorageTextureType {
+enum GPUStorageTextureAccess {
     "readonly",
     "writeonly",
 };
 
-dictionary GPUStorageTextureLayoutEntry {
-    required GPUStorageTextureType type;
+dictionary GPUStorageTextureBindingLayout {
+    required GPUStorageTextureAccess type;
     required GPUTextureFormat format;
     GPUTextureViewDimension viewDimension = "2d";
 };
 </script>
 
-Issue(https://github.com/gpuweb/gpuweb/issues/851): consider making {{GPUStorageTextureLayoutEntry/format}}
+Issue(https://github.com/gpuweb/gpuweb/issues/851): consider making {{GPUStorageTextureBindingLayout/format}}
 truly optional.
 
-{{GPUStorageTextureLayoutEntry}} dictionaries have the following members:
+{{GPUStorageTextureBindingLayout}} dictionaries have the following members:
 
-<dl dfn-type=dict-member dfn-for=GPUStorageTextureLayoutEntry>
+<dl dfn-type=dict-member dfn-for=GPUStorageTextureBindingLayout>
     : <dfn>type</dfn>
     ::
         Indicates whether texture views bound to this binding will be bound for read-only or
@@ -2776,10 +2776,10 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                                 {{GPUBindGroupLayoutEntry/sampler}} &le;
                                 {{GPULimits/maxSamplersPerShaderStage|GPULimits.maxSamplersPerShaderStage}}.
                             - The number of entries in |descriptor| with a [$layout entry binding type$] of
-                                {{GPUBufferType/"uniform"}} and {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/hasDynamicOffset}} `true` &le;
+                                {{GPUBufferType/"uniform"}} and {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}} `true` &le;
                                 {{GPULimits/maxDynamicUniformBuffersPerPipelineLayout|GPULimits.maxDynamicUniformBuffersPerPipelineLayout}}.
                             - The number of entries in |descriptor| with a [$layout entry binding type$] of
-                                {{GPUBufferType/"storage"}} and {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/hasDynamicOffset}} `true` &le;
+                                {{GPUBufferType/"storage"}} and {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}} `true` &le;
                                 {{GPULimits/maxDynamicStorageBuffersPerPipelineLayout|GPULimits.maxDynamicStorageBuffersPerPipelineLayout}}.
 
                             - For each {{GPUBindGroupLayoutEntry}} |bindingDescriptor| in |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
@@ -2794,18 +2794,18 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                                 - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/visibility}} includes
                                     {{GPUShaderStage/VERTEX}}:
                                     - The [$layout entry binding type$] of |bindingDescriptor| is not
-                                        {{GPUBufferType/"readonly-storage"}} or {{GPUStorageTextureType/"writeonly"}}.
+                                        {{GPUBufferType/"readonly-storage"}} or {{GPUStorageTextureAccess/"writeonly"}}.
 
                                 - If the [$layout entry binding type$] of |bindingDescriptor| is {{GPUTextureType/"multisample"}}:
-                                    - |textureLayout|.{{GPUTextureLayoutEntry/viewDimension}} is
+                                    - |textureLayout|.{{GPUTextureBindingLayout/viewDimension}} is
                                         {{GPUTextureViewDimension/"2d"}}.
-                                    - |textureLayout|.{{GPUTextureLayoutEntry/componentType}} is not
-                                        {{GPUTextureComponentType/"depth-stencil"}}.
+                                    - |textureLayout|.{{GPUTextureBindingLayout/componentType}} is not
+                                        {{GPUTextureComponentType/"depth"}}.
 
                                 - If |storageTextureLayout| is not `undefined`:
-                                    - |storageTextureLayout|.{{GPUStorageTextureLayoutEntry/viewDimension}} is not
+                                    - |storageTextureLayout|.{{GPUStorageTextureBindingLayout/viewDimension}} is not
                                         {{GPUTextureViewDimension/"cube"}} or {{GPUTextureViewDimension/"cube-array"}}.
-                                    - |storageTextureLayout|.{{GPUStorageTextureLayoutEntry/format}} must be a format
+                                    - |storageTextureLayout|.{{GPUStorageTextureBindingLayout/format}} must be a format
                                         which can support storage usage.
                         </div>
 
@@ -2816,7 +2816,7 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
 
                     1. Set |layout|.{{GPUBindGroupLayout/[[dynamicOffsetCount]]}} to the number of
                         entries in |descriptor| where {{GPUBindGroupLayoutEntry/buffer}} is not `undefined` and
-                        {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/hasDynamicOffset}} is `true`.
+                        {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}} is `true`.
                     1. For each {{GPUBindGroupLayoutEntry}} |bindingDescriptor| in
                         |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
                         1. Insert |bindingDescriptor| into |layout|.{{GPUBindGroupLayout/[[entryMap]]}}
@@ -2953,12 +2953,12 @@ A {{GPUBindGroup}} object has the following internal slots:
                                             - |resource| is a {{GPUTextureView}}.
                                             - |resource| is [$valid to use with$] |this|.
                                             - Let |texture| be |resource|.{{GPUTextureView/[[texture]]}}.
-                                            - |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureLayoutEntry/viewDimension}}
+                                            - |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/viewDimension}}
                                                 is equal to |resource|'s {{GPUTextureViewDescriptor/dimension}}.
-                                            - |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureLayoutEntry/componentType}}
+                                            - |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/componentType}}
                                                 is compatible with |resource|'s {{GPUTextureViewDescriptor/format}}.
                                             - |texture|'s {{GPUTextureDescriptor/usage}} includes {{GPUTextureUsage/SAMPLED}}.
-                                            - If |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureLayoutEntry/type}}
+                                            - If |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/type}}
                                                 is {{GPUTextureType/"multisample"}}, |texture|'s {{GPUTextureDescriptor/sampleCount}}
                                                 &gt; `1`, Otherwise |texture|'s {{GPUTextureDescriptor/sampleCount}} is `1`.
 
@@ -2967,9 +2967,9 @@ A {{GPUBindGroup}} object has the following internal slots:
                                             - |resource| is a {{GPUTextureView}}.
                                             - |resource| is [$valid to use with$] |this|.
                                             - Let |texture| be |resource|.{{GPUTextureView/[[texture]]}}.
-                                            - |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureLayoutEntry/viewDimension}}
+                                            - |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/viewDimension}}
                                                 is equal to |resource|'s {{GPUTextureViewDescriptor/dimension}}.
-                                            - |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureLayoutEntry/format}}
+                                            - |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/format}}
                                                 is equal to |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
                                             - |texture|'s {{GPUTextureDescriptor/usage}} includes {{GPUTextureUsage/STORAGE}}.
 
@@ -2979,15 +2979,15 @@ A {{GPUBindGroup}} object has the following internal slots:
                                             - |resource|.{{GPUBufferBinding/buffer}} is [$valid to use with$] |this|.
                                             - The bound part designated by |resource|.{{GPUBufferBinding/offset}} and
                                                 |resource|.{{GPUBufferBinding/size}} resides inside the buffer.
-                                            - If |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/minBufferBindingSize}}
+                                            - If |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBufferBindingSize}}
                                                 is not `undefined`:
                                                 - The effective binding size, that is either explict in
                                                     |resource|.{{GPUBufferBinding/size}} or derived from
                                                     |resource|.{{GPUBufferBinding/offset}} and the full
                                                     size of the buffer, is greater than or equal to
-                                                    |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/minBufferBindingSize}}.
+                                                    |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBufferBindingSize}}.
 
-                                            - If |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/type}} is
+                                            - If |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/type}} is
                                                 <dl class="switch">
                                                     : {{GPUBufferType/"uniform"}}
                                                     :: |resource|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
@@ -3324,58 +3324,58 @@ has a default layout created and used instead.
             1. Set |entry|.{{GPUBindGroupLayoutEntry/visibility}} to |shaderStage|.
             1. If |resource| is for a sampler binding:
 
-                1. Let |samplerLayout| be a new {{GPUSamplerLayoutEntry}}.
+                1. Let |samplerLayout| be a new {{GPUSamplerBindingLayout}}.
                 1. Set |entry|.{{GPUBindGroupLayoutEntry/sampler}} to |samplerLayout|.
 
             1. If |resource| is for a comparison sampler binding:
 
-                1. Let |samplerLayout| be a new {{GPUSamplerLayoutEntry}}.
-                1. Set |samplerLayout|.{{GPUSamplerLayoutEntry/type}} to {{GPUSamplerType/"comparison"}}.
+                1. Let |samplerLayout| be a new {{GPUSamplerBindingLayout}}.
+                1. Set |samplerLayout|.{{GPUSamplerBindingLayout/type}} to {{GPUSamplerType/"comparison"}}.
                 1. Set |entry|.{{GPUBindGroupLayoutEntry/sampler}} to |samplerLayout|.
 
             1. If |resource| is for a buffer binding:
 
-                1. Let |bufferLayout| be a new {{GPUBufferLayoutEntry}}.
+                1. Let |bufferLayout| be a new {{GPUBufferBindingLayout}}.
 
-                1. Set |bufferLayout|.{{GPUBufferLayoutEntry/minBufferBindingSize}} to |resource|'s minimum buffer binding size.
+                1. Set |bufferLayout|.{{GPUBufferBindingLayout/minBufferBindingSize}} to |resource|'s minimum buffer binding size.
 
                     Issue: link to a definition for "minimum buffer binding size" in the "reflection information".
 
                 1. If |resource| is for a read-only storage buffer:
 
-                    1. Set |bufferLayout|.{{GPUBufferLayoutEntry/type}} to {{GPUBufferType/"readonly-storage"}}.
+                    1. Set |bufferLayout|.{{GPUBufferBindingLayout/type}} to {{GPUBufferType/"readonly-storage"}}.
 
                 1. If |resource| is for a storage buffer:
 
-                    1. Set |bufferLayout|.{{GPUBufferLayoutEntry/type}} to {{GPUBufferType/"storage"}}.
+                    1. Set |bufferLayout|.{{GPUBufferBindingLayout/type}} to {{GPUBufferType/"storage"}}.
 
                 1. Set |entry|.{{GPUBindGroupLayoutEntry/buffer}} to |bufferLayout|.
 
             1. If |resource| is for a sampled texture binding:
 
-                1. Let |textureLayout| be a new {{GPUTextureLayoutEntry}}.
+                1. Let |textureLayout| be a new {{GPUTextureBindingLayout}}.
 
-                1. Set |textureLayout|.{{GPUTextureLayoutEntry/componentType}} to |resource|'s component type.
-                1. Set |textureLayout|.{{GPUTextureLayoutEntry/viewDimension}} to |resource|'s dimension.
+                1. Set |textureLayout|.{{GPUTextureBindingLayout/componentType}} to |resource|'s component type.
+                1. Set |textureLayout|.{{GPUTextureBindingLayout/viewDimension}} to |resource|'s dimension.
                 1. If |resource| is for a multisampled texture:
 
-                    1. Set |textureLayout|.{{GPUTextureLayoutEntry/type}} to {{GPUTextureType/"multisample"}}.
+                    1. Set |textureLayout|.{{GPUTextureBindingLayout/type}} to {{GPUTextureType/"multisample"}}.
 
                 1. Set |entry|.{{GPUBindGroupLayoutEntry/texture}} to |textureLayout|.
 
             1. If |resource| is for a storage texture binding:
 
-                1. Let |storageTextureLayout| be a new {{GPUStorageTextureLayoutEntry}}.
-                1. Set |storageTextureLayout|.{{GPUStorageTextureLayoutEntry/format}} to |resource|'s format.
-                1. Set |storageTextureLayout|.{{GPUStorageTextureLayoutEntry/viewDimension}} to |resource|'s dimension.
+                1. Let |storageTextureLayout| be a new {{GPUStorageTextureBindingLayout}}.
+                1. Set |storageTextureLayout|.{{GPUStorageTextureBindingLayout/format}} to |resource|'s format.
+                1. Set |storageTextureLayout|.{{GPUStorageTextureBindingLayout/viewDimension}} to |resource|'s dimension.
 
                 1. If |resource| is for a read-only storage texture:
 
-                    1. Set |storageTextureLayout|.{{GPUStorageTextureLayoutEntry/type}} to {{GPUStorageTextureType/"readonly"}}.
+                    1. Set |storageTextureLayout|.{{GPUStorageTextureBindingLayout/type}} to {{GPUStorageTextureAccess/"readonly"}}.
 
                 1. If |resource| is for a write-only storage texture:
 
-                    1. Set |storageTextureLayout|.{{GPUStorageTextureLayoutEntry/type}} to {{GPUStorageTextureType/"writeonly"}}.
+                    1. Set |storageTextureLayout|.{{GPUStorageTextureBindingLayout/type}} to {{GPUStorageTextureAccess/"writeonly"}}.
 
                 1. Set |entry|.{{GPUBindGroupLayoutEntry/storageTexture}} to |storageTextureLayout|.
 
@@ -3386,11 +3386,11 @@ has a default layout created and used instead.
                     1. Add the bits set in |entry|.{{GPUBindGroupLayoutEntry/visibility}} into |previousEntry|.{{GPUBindGroupLayoutEntry/visibility}}
 
                 1. If |resource| is for a buffer binding and |entry| has greater
-                    {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/minBufferBindingSize}}
+                    {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBufferBindingSize}}
                     than |previousEntry|:
 
-                    1. Set |previousEntry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/minBufferBindingSize}}
-                        to |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/minBufferBindingSize}}.
+                    1. Set |previousEntry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBufferBindingSize}}
+                        to |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBufferBindingSize}}.
 
                 1. If any other property is unequal between |entry| and |previousEntry|:
 
@@ -3457,7 +3457,7 @@ A {{GPUProgrammableStageDescriptor}} describes the entry point in the user-provi
         1. If the defined [=binding member=] for |entry| is:
             <dl class=switch>
                 : {{GPUBindGroupLayoutEntry/buffer}}
-                :: If |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/type}} is:
+                :: If |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/type}} is:
                     <dl class=switch>
                         : {{GPUBufferType/"uniform"}}
                         :: The |binding| is a uniform buffer.
@@ -3466,16 +3466,16 @@ A {{GPUProgrammableStageDescriptor}} describes the entry point in the user-provi
                         : {{GPUBufferType/"readonly-storage"}}
                         :: The |binding| is a read-only storage buffer.
                     </dl>
-                :: If |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/minBufferBindingSize}} is not `0`:
+                :: If |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBufferBindingSize}} is not `0`:
                     - If the last field of the corresponding structure defined in the shader has an unbounded array type,
-                        then the value of |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/minBufferBindingSize}}
+                        then the value of |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBufferBindingSize}}
                         must be greater than or equal to the byte offset of that field plus the stride of the unbounded array.
                     - If the corresponding shader structure doesn't end with an unbounded array type,
-                        then the value of |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/minBufferBindingSize}}
+                        then the value of |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBufferBindingSize}}
                         must be greater than or equal to the size of the structure.
 
                 : {{GPUBindGroupLayoutEntry/sampler}}
-                :: If |entry|.{{GPUBindGroupLayoutEntry/sampler}}.{{GPUSamplerLayoutEntry/type}} is:
+                :: If |entry|.{{GPUBindGroupLayoutEntry/sampler}}.{{GPUSamplerBindingLayout/type}} is:
                     <dl class=switch>
                         : {{GPUSamplerType/"filtering"}}
                         :: the |binding| is a non-comparison sampler
@@ -3486,7 +3486,7 @@ A {{GPUProgrammableStageDescriptor}} describes the entry point in the user-provi
                     </dl>
 
                 : {{GPUBindGroupLayoutEntry/texture}}
-                :: If |entry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureLayoutEntry/type}} is:
+                :: If |entry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/type}} is:
                     <dl class=switch>
                         : {{GPUTextureType/"filterable"}}
                         :: The |binding| is a sampled texture with a sample count of 1.
@@ -3496,22 +3496,22 @@ A {{GPUProgrammableStageDescriptor}} describes the entry point in the user-provi
                         :: the |binding| is a multisampled texture.
                     </dl>
                 :: The component type of the texture matches
-                    |entry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureLayoutEntry/componentType}}.
+                    |entry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/componentType}}.
                 :: The shader view dimension of the texture matches
-                    |entry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureLayoutEntry/viewDimension}}.
+                    |entry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/viewDimension}}.
 
                 : {{GPUBindGroupLayoutEntry/storageTexture}}
-                :: If |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureLayoutEntry/type}} is:
+                :: If |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/type}} is:
                     <dl class=switch>
-                        : {{GPUStorageTextureType/"readonly"}}
+                        : {{GPUStorageTextureAccess/"readonly"}}
                         :: The |binding| is a read-only storage texture.
-                        : {{GPUStorageTextureType/"writeonly"}}
+                        : {{GPUStorageTextureAccess/"writeonly"}}
                         :: The |binding| is a writable storage texture.
                     </dl>
                 :: The format of the storage texture matches
-                    |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureLayoutEntry/format}}.
+                    |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/format}}.
                 :: The shader view dimension of the storage texture matches
-                    |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureLayoutEntry/viewDimension}}.
+                    |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/viewDimension}}.
 
             </dl>
 </div>
@@ -3530,7 +3530,7 @@ and can be used in {{GPUComputePassEncoder}}.
 Compute inputs and outputs are all contained in the bindings,
 according to the given {{GPUPipelineLayout}}.
 The outputs correspond to {{GPUBindGroupLayoutEntry/buffer}} bindings with a type of {{GPUBufferType/"storage"}}
-and {{GPUBindGroupLayoutEntry/storageTexture}} bindings with a type of {{GPUStorageTextureType/"writeonly"}}.
+and {{GPUBindGroupLayoutEntry/storageTexture}} bindings with a type of {{GPUStorageTextureAccess/"writeonly"}}.
 
 Stages of a compute [=pipeline=]:
   1. Compute shader
@@ -3626,8 +3626,8 @@ Render [=pipeline=] inputs are:
   - optionally, the depth-stencil attachment, described by {{GPUDepthStencilStateDescriptor}}
 
 Render [=pipeline=] outputs are:
-  - {{GPUBindGroupLayoutEntry/buffer}} bindings with a {{GPUBufferLayoutEntry/type}} of {{GPUBufferType/"storage"}}
-  - {{GPUBindGroupLayoutEntry/storageTexture}} bindings with a {{GPUStorageTextureLayoutEntry/type}} of {{GPUStorageTextureType/"writeonly"}}
+  - {{GPUBindGroupLayoutEntry/buffer}} bindings with a {{GPUBufferBindingLayout/type}} of {{GPUBufferType/"storage"}}
+  - {{GPUBindGroupLayoutEntry/storageTexture}} bindings with a {{GPUStorageTextureBindingLayout/type}} of {{GPUStorageTextureAccess/"writeonly"}}
   - the color attachments, described by {{GPUColorStateDescriptor}}
   - optionally, depth-stencil attachment, described by {{GPUDepthStencilStateDescriptor}}
 
@@ -5140,7 +5140,7 @@ interface mixin GPUProgrammablePassEncoder {
                 define the arguments for the 5-arg variant of the method, despite the "for"
                 explicitly pointing at the 3-arg variant.-->
                 <!--|dynamicOffsets|: Array containing buffer offsets in bytes for each entry in
-                    |bindGroup| marked as {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/hasDynamicOffset}}.-->
+                    |bindGroup| marked as {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}}.-->
             </pre>
 
             Issue: Resolve bikeshed conflict when using `argumentdef` with overloaded functions that prevents us from
@@ -5183,7 +5183,7 @@ interface mixin GPUProgrammablePassEncoder {
                 |index|: The index to set the bind group at.
                 |bindGroup|: Bind group to use for subsequent render or compute commands.
                 |dynamicOffsetsData|: Array containing buffer offsets in bytes for each entry in
-                    |bindGroup| marked as {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/hasDynamicOffset}}.
+                    |bindGroup| marked as {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}}.
                 |dynamicOffsetsDataStart|: Offset in elements into |dynamicOffsetsData| where the
                     buffer offset data begins.
                 |dynamicOffsetsDataLength|: Number of buffer offsets to read from |dynamicOffsetsData|.
@@ -5226,9 +5226,9 @@ interface mixin GPUProgrammablePassEncoder {
         1. Let |bindingDescriptor| be the {{GPUBindGroupLayoutEntry}} at
             |layout|.{{GPUBindGroupLayout/[[entryMap]]}}[|entry|.{{GPUBindGroupEntry/binding}}]:
         1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/buffer}} is not `undefined` and
-            |bindingDescriptor|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/hasDynamicOffset}} is `true`:
+            |bindingDescriptor|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}} is `true`:
             1. Let |bufferBinding| be |entry|.{{GPUBindGroupEntry/resource}}.
-            1. Let |minBufferBindingSize| be |bindingDescriptor|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/minBufferBindingSize}}.
+            1. Let |minBufferBindingSize| be |bindingDescriptor|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBufferBindingSize}}.
             1. Call |steps| with |bufferBinding|, |minBufferBindingSize|, and |dynamicOffsetIndex|.
             1. Let |dynamicOffsetIndex| be |dynamicOffsetIndex| + `1`
 </div>
@@ -7217,7 +7217,7 @@ All plain color formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/
 Only formats with {{GPUTextureComponentType}} {{GPUTextureComponentType/"float"}} can be blended.
 
 The {{GPUTextureUsage/STORAGE|GPUTextureUsage.STORAGE}} column specifies the support for {{GPUTextureUsage/STORAGE}}
-usage in the core API, including both {{GPUStorageTextureType/"readonly"}} and {{GPUStorageTextureType/"writeonly"}}.
+usage in the core API, including both {{GPUStorageTextureAccess/"readonly"}} and {{GPUStorageTextureAccess/"writeonly"}}.
 
 The "Filter" column specifies whether textures of this format can be sampled in shaders with a sampler having {{GPUFilterMode/linear}} filtering.
 
@@ -7473,19 +7473,19 @@ None of the depth formats can be filtered.
         <td>{{GPUTextureFormat/depth16unorm}}
         <td>2
         <td>depth
-        <td>{{GPUTextureComponentType/"float"}}, {{GPUTextureComponentType/"depth-stencil"}}
+        <td>{{GPUTextureComponentType/"float"}}, {{GPUTextureComponentType/"depth"}}
         <td colspan=2>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/depth24plus}}
         <td>4
         <td>depth
-        <td>{{GPUTextureComponentType/"float"}}, {{GPUTextureComponentType/"depth-stencil"}}
+        <td>{{GPUTextureComponentType/"float"}}, {{GPUTextureComponentType/"depth"}}
         <td colspan=2>&cross;
     <tr>
         <td rowspan=2 style='white-space:nowrap'>{{GPUTextureFormat/depth24plus-stencil8}}
         <td rowspan=2>4 &minus; 8
         <td>depth
-        <td>{{GPUTextureComponentType/"float"}}, {{GPUTextureComponentType/"depth-stencil"}}
+        <td>{{GPUTextureComponentType/"float"}}, {{GPUTextureComponentType/"depth"}}
         <td colspan=2>&cross;
     <tr>
         <td>stencil
@@ -7495,7 +7495,7 @@ None of the depth formats can be filtered.
         <td>{{GPUTextureFormat/depth32float}}
         <td>4
         <td>depth
-        <td>{{GPUTextureComponentType/"float"}}, {{GPUTextureComponentType/"depth-stencil"}}
+        <td>{{GPUTextureComponentType/"float"}}, {{GPUTextureComponentType/"depth"}}
         <td colspan=1>&cross;
         <td colspan=1>&checkmark;
 </table>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7214,8 +7214,6 @@ Only formats with {{GPUTextureSampleType}} {{GPUTextureSampleType/"float"}} can 
 The {{GPUTextureUsage/STORAGE|GPUTextureUsage.STORAGE}} column specifies the support for {{GPUTextureUsage/STORAGE}}
 usage in the core API, including both {{GPUStorageTextureAccess/"readonly"}} and {{GPUStorageTextureAccess/"writeonly"}}.
 
-The "Filter" column specifies whether textures of this format can be sampled in shaders with a sampler having {{GPUFilterMode/linear}} filtering.
-
 <table class='data'>
     <thead class=stickyheader>
         <tr>
@@ -7227,12 +7225,12 @@ The "Filter" column specifies whether textures of this format can be sampled in 
     <tr><th class=stickyheader>8-bit per component<th><th><th><th>
     <tr>
         <td>{{GPUTextureFormat/r8unorm}}
-        <td>{{GPUTextureSampleType/"float"}}
+        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/r8snorm}}
-        <td>{{GPUTextureSampleType/"float"}}
+        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>
         <td>
     <tr>
@@ -7247,12 +7245,12 @@ The "Filter" column specifies whether textures of this format can be sampled in 
         <td>
     <tr>
         <td>{{GPUTextureFormat/rg8unorm}}
-        <td>{{GPUTextureSampleType/"float"}}
+        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/rg8snorm}}
-        <td>{{GPUTextureSampleType/"float"}}
+        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>
         <td>
     <tr>
@@ -7267,17 +7265,17 @@ The "Filter" column specifies whether textures of this format can be sampled in 
         <td>
     <tr>
         <td>{{GPUTextureFormat/rgba8unorm}}
-        <td>{{GPUTextureSampleType/"float"}}
+        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rgba8unorm-srgb}}
-        <td>{{GPUTextureSampleType/"float"}}
+        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/rgba8snorm}}
-        <td>{{GPUTextureSampleType/"float"}}
+        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>
         <td>&checkmark;
     <tr>
@@ -7292,12 +7290,12 @@ The "Filter" column specifies whether textures of this format can be sampled in 
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/bgra8unorm}}
-        <td>{{GPUTextureSampleType/"float"}}
+        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/bgra8unorm-srgb}}
-        <td>{{GPUTextureSampleType/"float"}}
+        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>
     <tr><th class=stickyheader>16-bit per component<th><th><th><th>
@@ -7313,7 +7311,7 @@ The "Filter" column specifies whether textures of this format can be sampled in 
         <td>
     <tr>
         <td>{{GPUTextureFormat/r16float}}
-        <td>{{GPUTextureSampleType/"float"}}
+        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>
     <tr>
@@ -7328,7 +7326,7 @@ The "Filter" column specifies whether textures of this format can be sampled in 
         <td>
     <tr>
         <td>{{GPUTextureFormat/rg16float}}
-        <td>{{GPUTextureSampleType/"float"}}
+        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td><!-- Vulkan -->
     <tr>
@@ -7343,7 +7341,7 @@ The "Filter" column specifies whether textures of this format can be sampled in 
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rgba16float}}
-        <td>{{GPUTextureSampleType/"float"}}
+        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>&checkmark;
     <tr><th class=stickyheader>32-bit per component<th><th><th><th>
@@ -7395,12 +7393,12 @@ The "Filter" column specifies whether textures of this format can be sampled in 
     <tr><th class=stickyheader>mixed component width<th><th><th><th>
     <tr>
         <td>{{GPUTextureFormat/rgb10a2unorm}}
-        <td>{{GPUTextureSampleType/"float"}}
+        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/rg11b10ufloat}}
-        <td>{{GPUTextureSampleType/"float"}}
+        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td><!-- Vulkan -->
         <td>
 
@@ -7484,13 +7482,13 @@ All packed texture formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsa
     <tr>
         <td>{{GPUTextureFormat/rgb9e5ufloat}}
         <td>4
-        <td>{{GPUTextureSampleType/"float"}}
+        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>1 &times; 1
         <td>
     <tr>
         <td>{{GPUTextureFormat/bc1-rgba-unorm}}
         <td rowspan=2>8
-        <td rowspan=14>{{GPUTextureSampleType/"float"}}
+        <td rowspan=14>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td rowspan=14>4 &times; 4
         <td rowspan=14>{{GPUFeatureName/texture-compression-bc}}
     <tr>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2220,17 +2220,6 @@ for depth32float, 1 ULP has a variable value no greater than 1 / (2<sup>24</sup>
 
 Issue: {{GPUTextureFormat/"rgb9e5ufloat"}} cannot be used as a color attachment.
 
-<script type=idl>
-enum GPUTextureComponentType {
-    "float",
-    "sint",
-    "uint",
-    // Texture is used with comparison sampling only.
-    "depth"
-};
-</script>
-
-
 # Samplers # {#samplers}
 
 ## <dfn interface>GPUSampler</dfn> ## {#sampler-interface}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -290,7 +290,7 @@ shader to first do a clear across all invocations, synchronize them, and continu
 ## Out-of-bounds access in shaders ## {#security-shader}
 
 [=Shader=]s can access [=physical resource=]s either directly
-(for example, as a {{GPUBindingType/"uniform-buffer"}}), or via <dfn dfn>texture unit</dfn>s,
+(for example, as a {{GPUBufferKind/"uniform"}} {{GPUBufferBinding}}), or via <dfn dfn>texture unit</dfn>s,
 which are fixed-function hardware blocks that handle texture coordinate conversions.
 Validation on the API side can only guarantee that all the inputs to the shader are provided and
 they have the correct usage and types.
@@ -2473,29 +2473,34 @@ dictionary GPUBindGroupLayoutDescriptor : GPUObjectDescriptorBase {
 A {{GPUBindGroupLayoutEntry}} describes a single shader resource binding to be included in a {{GPUBindGroupLayout}}.
 
 <script type=idl>
+typedef [EnforceRange] unsigned long GPUShaderStageFlags;
+interface GPUShaderStage {
+    const GPUFlagsConstant VERTEX   = 0x1;
+    const GPUFlagsConstant FRAGMENT = 0x2;
+    const GPUFlagsConstant COMPUTE  = 0x4;
+};
+
 dictionary GPUBindGroupLayoutEntry {
     required GPUIndex32 binding;
     required GPUShaderStageFlags visibility;
-    required GPUBindingType type;
 
-    // Used for uniform buffer and storage buffer bindings. Must be undefined for other binding types.
-    boolean hasDynamicOffset;
+    // Used for uniform buffer and storage buffer bindings. Must be null for other binding types.
+    GPUBufferLayoutEntry? buffer;
 
-    // Used for uniform buffer and storage buffer bindings. Must be undefined for other binding types.
-    GPUSize64 minBufferBindingSize;
+    // Used for sampler bindings. Must be null for other binding types.
+    GPUSamplerLayoutEntry? sampler;
 
-    // Used for sampled texture and storage texture bindings. Must be undefined for other binding types.
-    GPUTextureViewDimension viewDimension;
+    // Used for sampled texture bindings. Must be null for other binding types.
+    GPUTextureLayoutEntry? texture;
 
-    // Used for sampled texture bindings. Must be undefined for other binding types.
-    GPUTextureComponentType textureComponentType;
-
-    // Used for storage texture bindings. Must be undefined for other binding types.
-    GPUTextureFormat storageTextureFormat;
+    // Used for storage texture bindings. Must be null for other binding types.
+    GPUStorageTextureLayoutEntry? storageTexture;
 };
 </script>
 
 Issue(https://github.com/gpuweb/gpuweb/issues/851): consider making `textureComponentType` and `storageTextureFormat` truly optional.
+
+{{GPUBindGroupLayoutEntry}} dictionaries have the following members:
 
 <dl dfn-type=dict-member dfn-for=GPUBindGroupLayoutEntry>
     : <dfn>binding</dfn>
@@ -2510,145 +2515,214 @@ Issue(https://github.com/gpuweb/gpuweb/issues/851): consider making `textureComp
         Each set bit indicates that a {{GPUBindGroupLayoutEntry}}'s resource
         will be accessible from the associated shader stage.
 
-    : <dfn>type</dfn>
+    : <dfn>buffer</dfn>
     ::
-        The type of the binding.
-        The value of this member influences the interpretation of other members.
+        When not `null` indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
+        is {{GPUBufferBinding}}.
 
-        Note:
-        This member is used to determine compatibility between a
-        {{GPUPipelineLayout}} and a {{GPUShaderModule}}.
-
-    : <dfn>hasDynamicOffset</dfn>
+    : <dfn>sampler</dfn>
     ::
-        If the [=binding resource type=] for {{GPUBindGroupLayoutEntry/type}} is {{GPUBufferBinding}}:
+        When not `null` indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
+        is {{GPUSampler}}.
 
-          - This indicates whether a binding requires a dynamic offset.
-          - If `undefined`, it defaults to `false`.
-
-        Otherwise, it must be `undefined`.
-
-    : <dfn>minBufferBindingSize</dfn>
+    : <dfn>texture</dfn>
     ::
-        If the [=binding resource type=] for {{GPUBindGroupLayoutEntry/type}} is {{GPUBufferBinding}}:
+        When not `null` indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
+        is {{GPUTextureView}}.
 
-          - This may be used to indicate the minimum buffer binding size.
-          - If `undefined`, it defaults to 0.
-
-        Otherwise, it must be `undefined`.
-
-    : <dfn>viewDimension</dfn>
+    : <dfn>storageTexture</dfn>
     ::
-        If the [=binding resource type=] for {{GPUBindGroupLayoutEntry/type}} is {{GPUTextureView}}:
-
-          - This is the required {{GPUTextureViewDescriptor/dimension}}
-            of a texture view bound to this binding.
-          - If `undefined`, it defaults to {{GPUTextureViewDimension/"2d"}}.
-
-        Otherwise, it must be `undefined`.
-
-    : <dfn>textureComponentType</dfn>
-    ::
-        If the {{GPUBindGroupLayoutEntry/type}} is
-        {{GPUBindingType/"sampled-texture"}}:
-
-          - This is the required component type of the
-            {{GPUTextureViewDescriptor/format}}
-            of a texture view bound to this binding.
-          - If `undefined`, it defaults to {{GPUTextureComponentType/"float"}}.
-
-        Otherwise, it must be `undefined`.
-
-    : <dfn>storageTextureFormat</dfn>
-    ::
-        If the {{GPUBindGroupLayoutEntry/type}} is
-        {{GPUBindingType/"readonly-storage-texture"}}
-        or {{GPUBindingType/"writeonly-storage-texture"}}:
-
-          - This is the required {{GPUTextureViewDescriptor/format}}
-            of a texture view bound to this binding.
-
-        Otherwise, it must be `undefined`.
+        When not `null` indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
+        is {{GPUTextureView}}.
 </dl>
 
-Note:
-{{GPUBindGroupLayoutEntry/viewDimension}} enables Metal-based WebGPU implementations
-to back the respective bind groups with `MTLArgumentBuffer` objects
-that are more efficient to bind at run-time.
+The [=binding type=] of a {{GPUBindGroupLayoutEntry}} is determined by which member of the {{GPUBindGroupLayoutEntry}}
+is defined: {{GPUBindGroupLayoutEntry/buffer}}, {{GPUBindGroupLayoutEntry/sampler}},
+{{GPUBindGroupLayoutEntry/texture}}, or {{GPUBindGroupLayoutEntry/storageTexture}}. Only one may be
+defined for any given {{GPUBindGroupLayoutEntry}}. Each member has an associated {{GPUBindingResource}}
+type and each [=binding kind=] has an associated [=internal usage=], given by this table:
 
-<script type=idl>
-typedef [EnforceRange] unsigned long GPUShaderStageFlags;
-interface GPUShaderStage {
-    const GPUFlagsConstant VERTEX   = 0x1;
-    const GPUFlagsConstant FRAGMENT = 0x2;
-    const GPUFlagsConstant COMPUTE  = 0x4;
-};
-</script>
-
-  * {{GPUBindGroupLayoutEntry/type}}:
-    A member of {{GPUBindingType}} that indicates the intended usage of a resource binding in its visible {{GPUShaderStage}}s.
-
-<script type=idl>
-enum GPUBindingType {
-    "uniform-buffer",
-    "storage-buffer",
-    "readonly-storage-buffer",
-    "sampler",
-    "comparison-sampler",
-    "sampled-texture",
-    "multisampled-texture",
-    "readonly-storage-texture",
-    "writeonly-storage-texture"
-};
-</script>
-
-Each {{GPUBindingType}} has an associated {{GPUBindingResource}} type and [=internal usage=], given
-by this table:
-
-<table class="data">
+<table class="data" style="white-space: nowrap">
     <thead>
         <tr>
-            <th>{{GPUBindingType}}
-            <th><dfn dfn>Binding resource type</dfn>
+            <th><dfn dfn>Binding type</dfn>
+            <th><dfn dfn lt="Binding Resource Type">Resource type</dfn>
+            <th><dfn dfn>Binding kind</dfn>
             <th><dfn dfn>Binding usage</dfn>
     </thead>
     <tr>
-        <td>{{GPUBindingType/"uniform-buffer"}}
-        <td>{{GPUBufferBinding}}
+        <td rowspan=3>{{GPUBindGroupLayoutEntry/buffer}}
+        <td rowspan=3>{{GPUBufferBinding}}
+        <td>{{GPUBufferKind/"uniform"}}
         <td>[=internal usage/constant=]
     <tr>
-        <td>{{GPUBindingType/"storage-buffer"}}
-        <td>{{GPUBufferBinding}}
+        <td>{{GPUBufferKind/"storage"}}
         <td>[=internal usage/storage=]
     <tr>
-        <td>{{GPUBindingType/"readonly-storage-buffer"}}
-        <td>{{GPUBufferBinding}}
+        <td>{{GPUBufferKind/"readonly-storage"}}
+        <td>[=internal usage/storage-read=]
+
+    <tr>
+        <td rowspan=3>{{GPUBindGroupLayoutEntry/sampler}}
+        <td rowspan=3>{{GPUSampler}}
+        <td>{{GPUSamplerKind/"filter-sampling"}}
+        <td>[=internal usage/constant=]
+    <tr>
+        <td>{{GPUSamplerKind/"point-sampling"}}
+        <td>[=internal usage/constant=]
+    <tr>
+        <td>{{GPUSamplerKind/"comparison"}}
+        <td>[=internal usage/constant=]
+
+    <tr>
+        <td rowspan=3>{{GPUBindGroupLayoutEntry/texture}}
+        <td rowspan=3>{{GPUTextureView}}
+        <td>{{GPUTextureKind/"filter-sampled"}}
+        <td>[=internal usage/constant=]
+    <tr>
+        <td>{{GPUTextureKind/"point-sampled"}}
+        <td>[=internal usage/constant=]
+    <tr>
+        <td>{{GPUTextureKind/"multisample"}}
+        <td>[=internal usage/constant=]
+
+    <tr>
+        <td rowspan=2>{{GPUBindGroupLayoutEntry/storageTexture}}
+        <td rowspan=2>{{GPUTextureView}}
+        <td>{{GPUStorageTextureKind/"readonly"}}
         <td>[=internal usage/storage-read=]
     <tr>
-        <td>{{GPUBindingType/"sampler"}}
-        <td>{{GPUSampler}}
-        <td>[=internal usage/constant=]
-    <tr>
-        <td>{{GPUBindingType/"comparison-sampler"}}
-        <td>{{GPUSampler}}
-        <td>[=internal usage/constant=]
-    <tr>
-        <td>{{GPUBindingType/"sampled-texture"}}
-        <td>{{GPUTextureView}}
-        <td>[=internal usage/constant=]
-    <tr>
-        <td>{{GPUBindingType/"multisampled-texture"}}
-        <td>{{GPUTextureView}}
-        <td>[=internal usage/constant=]
-    <tr>
-        <td>{{GPUBindingType/"readonly-storage-texture"}}
-        <td>{{GPUTextureView}}
-        <td>[=internal usage/storage-read=]
-    <tr>
-        <td>{{GPUBindingType/"writeonly-storage-texture"}}
-        <td>{{GPUTextureView}}
+        <td>{{GPUStorageTextureKind/"writeonly"}}
         <td>[=internal usage/storage-write=]
 </table>
+
+<script type=idl>
+enum GPUBufferKind {
+    "uniform",
+    "storage",
+    "readonly-storage",
+};
+
+dictionary GPUBufferLayoutEntry {
+    GPUBufferKind kind = "uniform";
+    boolean hasDynamicOffset = false;
+    GPUSize64 minBufferBindingSize = 0;
+};
+</script>
+
+{{GPUBufferLayoutEntry}} dictionaries have the following members:
+
+<dl dfn-type=dict-member dfn-for=GPUBufferLayoutEntry>
+    : <dfn>kind</dfn>
+    ::
+        Indicates the type required for buffers bound to this bindings.
+
+    : <dfn>hasDynamicOffset</dfn>
+    ::
+        Indicates whether this binding requires a dynamic offset.
+
+    : <dfn>minBufferBindingSize</dfn>
+    ::
+        May be used to indicate the minimum buffer binding size.
+</dl>
+
+<script type=idl>
+enum GPUSamplerKind {
+    "filter-sampling",
+    "point-sampling",
+    "comparison",
+};
+
+dictionary GPUSamplerLayoutEntry {
+    GPUSamplerKind kind = "filter-sampling";
+};
+</script>
+
+{{GPUSamplerLayoutEntry}} dictionaries have the following members:
+
+<dl dfn-type=dict-member dfn-for=GPUSamplerLayoutEntry>
+    : <dfn>kind</dfn>
+    ::
+        Indicates the required kind of a sampler bound to this bindings.
+</dl>
+
+<script type=idl>
+enum GPUTextureKind {
+    "filter-sampled",
+    "point-sampled",
+    "multisample",
+};
+
+enum GPUSamplingResultType {
+    "float",
+    "sint",
+    "uint",
+    "depth-comparison"
+};
+
+dictionary GPUTextureLayoutEntry {
+    GPUSampledTextureKind kind = "filter-sampled";
+    GPUSamplingResultType samplingResultType = "float";
+    GPUTextureViewDimension viewDimension = "2d";
+};
+</script>
+
+{{GPUTextureLayoutEntry}} dictionaries have the following members:
+
+<dl dfn-type=dict-member dfn-for=GPUTextureLayoutEntry>
+    : <dfn>kind</dfn>
+    ::
+        Indicates the type required for texture views bound to this binding.
+
+    : <dfn>samplingResultType</dfn>
+    ::
+        Indicates the required component type of the {{GPUTextureViewDescriptor/format}} for texture
+        views bound to this binding.
+
+    : <dfn>viewDimension</dfn>
+    ::
+        Indicates the required {{GPUTextureViewDescriptor/dimension}} for texture views bound to
+        this binding.
+
+        Note:
+            This enables Metal-based WebGPU implementations to back the respective bind groups with
+            `MTLArgumentBuffer` objects that are more efficient to bind at run-time.
+</dl>
+
+<script type=idl>
+enum GPUStorageTextureKind {
+    "readonly",
+    "writeonly",
+};
+
+dictionary GPUStorageTextureLayoutEntry {
+    GPUStorageTextureAccess kind;
+    GPUTextureFormat format;
+    GPUTextureViewDimension viewDimension = "2d";
+};
+</script>
+
+{{GPUStorageTextureLayoutEntry}} dictionaries have the following members:
+
+<dl dfn-type=dict-member dfn-for=GPUStorageTextureLayoutEntry>
+    : <dfn>kind</dfn>
+    ::
+        Indicates whether texture views bound to this binding will be bound for read-only or
+        write-only access.
+
+    : <dfn>format</dfn>
+    ::
+        The required {{GPUTextureViewDescriptor/format}} of texture views bound to this binding.
+
+    : <dfn>viewDimension</dfn>
+    ::
+        Indicates the required {{GPUTextureViewDescriptor/dimension}} for texture views bound to
+        this binding.
+
+        Note:
+            This enables Metal-based WebGPU implementations to back the respective bind groups with
+            `MTLArgumentBuffer` objects that are more efficient to bind at run-time.
+</dl>
 
 A {{GPUBindGroupLayout}} object has the following internal slots:
 
@@ -2709,44 +2783,34 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                                 {{GPULimits/maxDynamicStorageBuffersPerPipelineLayout|GPULimits.maxDynamicStorageBuffersPerPipelineLayout}}.
 
                             - For each {{GPUBindGroupLayoutEntry}} |bindingDescriptor| in |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
+                                - Let |bufferLayout| be |bindingDescriptor|.{{GPUBindGroupLayoutEntry/buffer}}
+                                - Let |samplerLayout| be |bindingDescriptor|.{{GPUBindGroupLayoutEntry/sampler}}
+                                - Let |textureLayout| be |bindingDescriptor|.{{GPUBindGroupLayoutEntry/texture}}
+                                - Let |storageTextureLayout| be |bindingDescriptor|.{{GPUBindGroupLayoutEntry/storageTexture}}
+
+                                - Exactly one of |bufferLayout|, |samplerLayout|, |textureLayout|,
+                                    or |storageTextureLayout| are not `null`.
+
                                 - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/visibility}} includes
                                     {{GPUShaderStage/VERTEX}}:
-                                    - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is not
-                                        {{GPUBindingType/"storage-buffer"}} or {{GPUBindingType/"writeonly-storage-texture"}}.
+                                    - |bufferLayout| is `null` or |bufferLayout|.{{GPUBufferLayoutEntry/kind}} is not
+                                        {{GPUBufferKind/"readonly-storage"}}.
+                                    - |storageTextureLayout| is `null` or
+                                        |storageTextureLayout|.{{GPUStorageTextureLayoutEntry/kind}} is not
+                                        {{GPUStorageTextureKind/"write-only"}}.
 
-                                - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
-                                    {{GPUBindingType/"uniform-buffer"}}, {{GPUBindingType/"storage-buffer"}}, or
-                                    {{GPUBindingType/"readonly-storage-buffer"}}:
-                                    - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `undefined`.
-                                    - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} is `undefined`.
+                                - If |textureLayout| is not `null` and |textureLayout|.{{GPUTextureLayoutEntry/kind}}
+                                    is {{GPUTextureKind/"multisample"}}:
+                                    - |textureLayout|.{{GPUTextureLayoutEntry/viewDimension}} is
+                                        {{GPUTextureViewDimension/"2d"}}.
+                                    - |textureLayout|.{{GPUTextureLayoutEntry/samplingResultType}} is not
+                                        {{GPUSamplingResultType/"depth-comparison"}}.
 
-                                - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
-                                    {{GPUBindingType/"sampled-texture"}}, {{GPUBindingType/"readonly-storage-texture"}},
-                                    or {{GPUBindingType/"writeonly-storage-texture"}}:
-                                        - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/viewDimension}} is `undefined`.
-
-                                - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
-                                    {{GPUBindingType/"sampled-texture"}} or {{GPUBindingType/"multisampled-texture"}}:
-                                    - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/textureComponentType}} is `undefined.`
-
-                                - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is **not**
-                                    {{GPUBindingType/"readonly-storage-texture"}} or
-                                    {{GPUBindingType/"writeonly-storage-texture"}}:
-                                    - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/storageTextureFormat}} is `undefined`.
-
-                                - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"multisampled-texture"}}:
-                                    - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/viewDimension}} is
-                                        {{GPUTextureViewDimension/2d}}.
-                                    - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/textureComponentType}} is not
-                                        {{GPUTextureComponentType/depth-comparison}}.
-
-                                - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/type}} is
-                                    {{GPUBindingType/"readonly-storage-texture"}} or
-                                    {{GPUBindingType/"writeonly-storage-texture"}}:
-                                    - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/viewDimension}} is not
-                                        {{GPUTextureViewDimension/cube}} or {{GPUTextureViewDimension/cube-array}}.
-                                    - |bindingDescriptor|.{{GPUBindGroupLayoutEntry/storageTextureFormat}} must
-                                        be a format which can support storage usage.
+                                - If |storageTextureLayout| is not `null`:
+                                    - |storageTextureLayout|.{{GPUStorageTextureLayoutEntry/viewDimension}} is not
+                                        {{GPUTextureViewDimension/"cube"}} or {{GPUTextureViewDimension/"cube-array"}}.
+                                    - |storageTextureLayout|.{{GPUStorageTextureLayoutEntry/format}} must be a format
+                                        which can support storage usage.
                         </div>
 
                         Then:
@@ -2870,71 +2934,68 @@ A {{GPUBindGroup}} object has the following internal slots:
                             For each {{GPUBindGroupEntry}} |bindingDescriptor| in
                                 |descriptor|.{{GPUBindGroupDescriptor/entries}}:
                                 - Let |resource| be |bindingDescriptor|.{{GPUBindGroupEntry/resource}}.
-                                - Let |bindingType| be |layoutBinding|.{{GPUBindGroupLayoutEntry/type}}.
                                 - There is exactly one {{GPUBindGroupLayoutEntry}} |layoutBinding|
                                     in |descriptor|.{{GPUBindGroupDescriptor/layout}}.{{GPUBindGroupLayoutDescriptor/entries}}
                                     such that |layoutBinding|.{{GPUBindGroupLayoutEntry/binding}} equals to
                                     |bindingDescriptor|.{{GPUBindGroupEntry/binding}}.
 
-                                - If the [=binding resource type=] for |bindingType| is
+                                - If the [=binding type=] for |layoutBinding| is
                                     <dl class="switch">
-                                        : {{GPUSampler}}
+                                        : {{GPUBindGroupLayoutEntry/sampler}}
                                         ::
                                             - |resource| is a {{GPUSampler}}.
                                             - |resource| is [$valid to use with$] |this|.
-                                            - If |bindingType| is
+                                            - If |layoutBinding|.{{GPUBindGroupLayoutEntry/sampler}}.{{GPUSamplerLayoutEntry/kind}} is
                                                 <dl class="switch">
-                                                    : {{GPUBindingType/"sampler"}}
+                                                    : {{GPUBindingType/"filter-sampling"}} or {{GPUBindingType/"point-sampling"}}
                                                     :: |resource|.{{GPUSampler/[[compareEnable]]}} is `false`.
 
-                                                    : {{GPUBindingType/"comparison-sampler"}}
+                                                    : {{GPUBindingType/"comparison"}}
                                                     :: |resource|.{{GPUSampler/[[compareEnable]]}} is `true`.
                                                 </dl>
 
-                                        : {{GPUTextureView}}
+                                        : {{GPUBindGroupLayoutEntry/texture}}
                                         ::
                                             - |resource| is a {{GPUTextureView}}.
                                             - |resource| is [$valid to use with$] |this|.
                                             - Let |texture| be |resource|.{{GPUTextureView/[[texture]]}}.
-                                            - |layoutBinding|.{{GPUBindGroupLayoutEntry/viewDimension}} is
-                                                equal to |resource|'s {{GPUTextureViewDescriptor/dimension}}.
-                                            - If |bindingType| is {{GPUBindingType/"multisampled-texture"}}
-                                                |texture|'s {{GPUTextureDescriptor/sampleCount}} &gt; `1`,
-                                                Otherwise |texture|'s {{GPUTextureDescriptor/sampleCount}} is `1`.
-                                            - If |bindingType| is
-                                                <dl class="switch">
-                                                    : {{GPUBindingType/"sampled-texture"}} or
-                                                        {{GPUBindingType/"multisampled-texture"}}
-                                                    :: |layoutBinding|.{{GPUBindGroupLayoutEntry/textureComponentType}}
-                                                        is compatible with |resource|'s {{GPUTextureViewDescriptor/format}}.
-                                                    :: |texture|'s {{GPUTextureDescriptor/usage}} includes
-                                                        {{GPUTextureUsage/SAMPLED}}.
+                                            - |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureLayoutEntry/viewDimension}}
+                                                is equal to |resource|'s {{GPUTextureViewDescriptor/dimension}}.
+                                            - |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureLayoutEntry/samplingResultType}}
+                                                is compatible with |resource|'s {{GPUTextureViewDescriptor/format}}.
+                                            - |texture|'s {{GPUTextureDescriptor/usage}} includes {{GPUTextureUsage/SAMPLED}}.
+                                            - If |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureLayoutEntry/kind}}
+                                                is {{GPUTextureKind/"multisample"}}, |texture|'s {{GPUTextureDescriptor/sampleCount}}
+                                                &gt; `1`, Otherwise |texture|'s {{GPUTextureDescriptor/sampleCount}} is `1`.
 
-                                                    : {{GPUBindingType/"readonly-storage-texture"}} or
-                                                        {{GPUBindingType/"writeonly-storage-texture"}}
-                                                    :: |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}
-                                                        is equal to |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTextureFormat}}.
-                                                    :: |texture|'s {{GPUTextureDescriptor/usage}} includes
-                                                        {{GPUTextureUsage/STORAGE}}.
-                                                </dl>
+                                        : {{GPUBindGroupLayoutEntry/storageTexture}}
+                                        ::
+                                            - |resource| is a {{GPUTextureView}}.
+                                            - |resource| is [$valid to use with$] |this|.
+                                            - Let |texture| be |resource|.{{GPUTextureView/[[texture]]}}.
+                                            - |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureLayoutEntry/viewDimension}}
+                                                is equal to |resource|'s {{GPUTextureViewDescriptor/dimension}}.
+                                            - |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureLayoutEntry/format}}
+                                                is equal to |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
+                                            - |texture|'s {{GPUTextureDescriptor/usage}} includes {{GPUTextureUsage/STORAGE}}.
 
-                                        :  {{GPUBufferBinding}}
+                                        :  {{GPUBindGroupLayoutEntry/buffer}}
                                         ::
                                             - |resource| is a {{GPUBufferBinding}}.
                                             - |resource|.{{GPUBufferBinding/buffer}} is [$valid to use with$] |this|.
                                             - The bound part designated by |resource|.{{GPUBufferBinding/offset}} and
                                                 |resource|.{{GPUBufferBinding/size}} resides inside the buffer.
-                                            - If |layoutBinding|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}}
+                                            - If |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/minBufferBindingSize}}
                                                 is not `undefined`:
                                                 - The effective binding size, that is either explict in
                                                     |resource|.{{GPUBufferBinding/size}} or derived from
                                                     |resource|.{{GPUBufferBinding/offset}} and the full
                                                     size of the buffer, is greater than or equal to
-                                                    |layoutBinding|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}}.
+                                                    |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/minBufferBindingSize}}.
 
-                                            - If |bindingType| is
+                                            - If |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/kind}} is
                                                 <dl class="switch">
-                                                    : {{GPUBindingType/"uniform-buffer"}}
+                                                    : {{GPUBufferKind/"uniform"}}
                                                     :: |resource|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
                                                         includes {{GPUBufferUsage/UNIFORM}}.
                                                     :: |resource|.{{GPUBufferBinding/size}} &le; {{GPULimits/maxUniformBufferBindingSize}}.
@@ -2942,8 +3003,8 @@ A {{GPUBindGroup}} object has the following internal slots:
                                                         Also should {{GPUBufferBinding/size}} default to the `buffer.byteLength - offset` or
                                                         `min(buffer.byteLength - offset, limits.maxUniformBufferBindingSize)`?
 
-                                                    : {{GPUBindingType/"storage-buffer"}} or
-                                                        {{GPUBindingType/"readonly-storage-buffer"}}
+                                                    : {{GPUBufferKind/"storage"}} or
+                                                        {{GPUBufferKind/"readonly-storage"}}
                                                     :: |resource|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
                                                         includes {{GPUBufferUsage/STORAGE}}.
                                                     :: |resource|.{{GPUBufferBinding/size}} &le; {{GPULimits/maxStorageBufferBindingSize}}.
@@ -2968,7 +3029,7 @@ A {{GPUBindGroup}} object has the following internal slots:
 
                     1. For each {{GPUBindGroupEntry}} |bindingDescriptor| in
                         |descriptor|.{{GPUBindGroupDescriptor/entries}}:
-                        1. Let |internalUsage| be the [=binding usage=] for |layoutBinding|.{{GPUBindGroupLayoutEntry/type}}.
+                        1. Let |internalUsage| be the [=binding usage=] for |layoutBinding|.
                         1. Each [=subresource=] seen by |resource| is added to {{GPUBindGroup/[[usedResources]]}} as |internalUsage|.
                 </div>
             1. Return |bindGroup|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -290,7 +290,7 @@ shader to first do a clear across all invocations, synchronize them, and continu
 ## Out-of-bounds access in shaders ## {#security-shader}
 
 [=Shader=]s can access [=physical resource=]s either directly
-(for example, as a {{GPUBufferKind/"uniform"}} {{GPUBufferBinding}}), or via <dfn dfn>texture unit</dfn>s,
+(for example, as a {{GPUBufferType/"uniform"}} {{GPUBufferBinding}}), or via <dfn dfn>texture unit</dfn>s,
 which are fixed-function hardware blocks that handle texture coordinate conversions.
 Validation on the API side can only guarantee that all the inputs to the shader are provided and
 they have the correct usage and types.
@@ -305,7 +305,7 @@ that guarantees that the access is limited to buffer bounds.
 
 Alternatively, an implementation may transform the shader code by inserting manual bounds checks.
 When this path is taken, the out-of-bound checks only apply to array indexing. They aren't needed
-for plain field access of shader structures due to the {{GPUBindGroupLayoutEntry/minBufferBindingSize}}
+for plain field access of shader structures due to the {{GPUBufferLayoutEntry/minBufferBindingSize}}
 validation on the host side.
 
 If the shader attempts to load data outside of [=physical resource=] bounds,
@@ -957,8 +957,8 @@ a better limit is not specified.
     <tr class=row-continuation><td colspan=4>
         The maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
 
-          - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"uniform-buffer"}}, and
-          - {{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `true`,
+          - [%Layout entry binding type%] is {{GPUBufferType/"uniform"}}, and
+          - {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/hasDynamicOffset}} is `true`,
 
         across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
         when creating a {{GPUPipelineLayout}}.
@@ -968,8 +968,8 @@ a better limit is not specified.
     <tr class=row-continuation><td colspan=4>
         The maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
 
-          - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"storage-buffer"}}, and
-          - {{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `true`,
+          - [%Layout entry binding type%] is {{GPUBufferType/"storage"}}, and
+          - {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/hasDynamicOffset}} is `true`,
 
         across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
         when creating a {{GPUPipelineLayout}}.
@@ -980,8 +980,7 @@ a better limit is not specified.
         For each possible {{GPUShaderStage}} `stage`,
         the maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
 
-          - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampled-texture"}} or
-            {{GPUBindingType/"multisampled-texture"}}, and
+          - {{GPUBindGroupLayoutEntry/texture}} is not `undefined`, and
           - {{GPUBindGroupLayoutEntry/visibility}} includes `stage`,
 
         across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
@@ -993,7 +992,7 @@ a better limit is not specified.
         For each possible {{GPUShaderStage}} `stage`,
         the maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
 
-          - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampler"}}  or {{GPUBindingType/"comparison-sampler"}}, and
+          - [=Binding member=] is {{GPUBindGroupLayoutEntry/sampler}}, and
           - {{GPUBindGroupLayoutEntry/visibility}} includes `stage`,
 
         across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
@@ -1005,7 +1004,7 @@ a better limit is not specified.
         For each possible {{GPUShaderStage}} `stage`,
         the maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
 
-          - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"storage-buffer"}}, and
+          - [%Layout entry binding type%] is {{GPUBufferType/"storage"}}, and
           - {{GPUBindGroupLayoutEntry/visibility}} includes `stage`,
 
         across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
@@ -1017,8 +1016,7 @@ a better limit is not specified.
         For each possible {{GPUShaderStage}} `stage`,
         the maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
 
-          - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"readonly-storage-texture"}} or
-            {{GPUBindingType/"writeonly-storage-texture"}}, and
+          - [=Binding member=] is {{GPUBindGroupLayoutEntry/storageTexture}}, and
           - {{GPUBindGroupLayoutEntry/visibility}} includes `stage`,
 
         across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
@@ -1030,7 +1028,7 @@ a better limit is not specified.
         For each possible {{GPUShaderStage}} `stage`,
         the maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
 
-          - {{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/uniform-buffer}}, and
+          - [%Layout entry binding type%] is {{GPUBufferType/"uniform"}}, and
           - {{GPUBindGroupLayoutEntry/visibility}} includes `stage`,
 
         across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
@@ -1039,14 +1037,14 @@ a better limit is not specified.
     <tr><td><dfn>maxUniformBufferBindingSize</dfn>
         <td>{{GPUSize32}} <td>Higher <td>16384
     <tr class=row-continuation><td colspan=4>
-        The maximum {{GPUBufferBinding}}.{{GPUBufferBinding/size}} for bindings
-        of type {{GPUBindingType/uniform-buffer}}.
+        The maximum {{GPUBufferBinding}}.{{GPUBufferBinding/size}} for bindings for which the
+        [%Layout entry binding type%] is {{GPUBufferType/"uniform"}}.
 
     <tr><td><dfn>maxStorageBufferBindingSize</dfn>
         <td>{{GPUSize32}} <td>Higher <td> 134217728 (128 MiB)
     <tr class=row-continuation><td colspan=4>
-        The maximum {{GPUBufferBinding}}.{{GPUBufferBinding/size}} for bindings
-        of types {{GPUBindingType/storage-buffer}} and {{GPUBindingType/readonly-storage-buffer}}.
+        The maximum {{GPUBufferBinding}}.{{GPUBufferBinding/size}} for bindings for which the
+        [%Layout entry binding type%] is {{GPUBufferType/"storage"}} or {{GPUBufferType/"readonly-storage"}}.
 </table>
 
 #### <dfn dictionary>GPULimits</dfn> #### {#gpulimits}
@@ -2228,7 +2226,7 @@ enum GPUTextureComponentType {
     "sint",
     "uint",
     // Texture is used with comparison sampling only.
-    "depth-comparison"
+    "depth-stencil"
 };
 </script>
 
@@ -2484,21 +2482,12 @@ dictionary GPUBindGroupLayoutEntry {
     required GPUIndex32 binding;
     required GPUShaderStageFlags visibility;
 
-    // Used for uniform buffer and storage buffer bindings. Must be null for other binding types.
-    GPUBufferLayoutEntry? buffer;
-
-    // Used for sampler bindings. Must be null for other binding types.
-    GPUSamplerLayoutEntry? sampler;
-
-    // Used for sampled texture bindings. Must be null for other binding types.
-    GPUTextureLayoutEntry? texture;
-
-    // Used for storage texture bindings. Must be null for other binding types.
-    GPUStorageTextureLayoutEntry? storageTexture;
+    GPUBufferLayoutEntry buffer;
+    GPUSamplerLayoutEntry sampler;
+    GPUTextureLayoutEntry texture;
+    GPUStorageTextureLayoutEntry storageTexture;
 };
 </script>
-
-Issue(https://github.com/gpuweb/gpuweb/issues/851): consider making `textureComponentType` and `storageTextureFormat` truly optional.
 
 {{GPUBindGroupLayoutEntry}} dictionaries have the following members:
 
@@ -2517,94 +2506,107 @@ Issue(https://github.com/gpuweb/gpuweb/issues/851): consider making `textureComp
 
     : <dfn>buffer</dfn>
     ::
-        When not `null` indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
+        When not `undefined` indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
         is {{GPUBufferBinding}}.
 
     : <dfn>sampler</dfn>
     ::
-        When not `null` indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
+        When not `undefined` indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
         is {{GPUSampler}}.
 
     : <dfn>texture</dfn>
     ::
-        When not `null` indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
+        When not `undefined` indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
         is {{GPUTextureView}}.
 
     : <dfn>storageTexture</dfn>
     ::
-        When not `null` indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
+        When not `undefined` indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
         is {{GPUTextureView}}.
 </dl>
 
-The [=binding type=] of a {{GPUBindGroupLayoutEntry}} is determined by which member of the {{GPUBindGroupLayoutEntry}}
+The [=binding member=] of a {{GPUBindGroupLayoutEntry}} is determined by which member of the {{GPUBindGroupLayoutEntry}}
 is defined: {{GPUBindGroupLayoutEntry/buffer}}, {{GPUBindGroupLayoutEntry/sampler}},
 {{GPUBindGroupLayoutEntry/texture}}, or {{GPUBindGroupLayoutEntry/storageTexture}}. Only one may be
 defined for any given {{GPUBindGroupLayoutEntry}}. Each member has an associated {{GPUBindingResource}}
-type and each [=binding kind=] has an associated [=internal usage=], given by this table:
+type and each [=binding type=] has an associated [=internal usage=], given by this table:
 
 <table class="data" style="white-space: nowrap">
     <thead>
         <tr>
-            <th><dfn dfn>Binding type</dfn>
+            <th><dfn dfn>Binding member</dfn>
             <th><dfn dfn lt="Binding Resource Type">Resource type</dfn>
-            <th><dfn dfn>Binding kind</dfn>
+            <th><dfn dfn>Binding type</dfn><br>
             <th><dfn dfn>Binding usage</dfn>
     </thead>
     <tr>
         <td rowspan=3>{{GPUBindGroupLayoutEntry/buffer}}
         <td rowspan=3>{{GPUBufferBinding}}
-        <td>{{GPUBufferKind/"uniform"}}
+        <td>{{GPUBufferType/"uniform"}}
         <td>[=internal usage/constant=]
     <tr>
-        <td>{{GPUBufferKind/"storage"}}
+        <td>{{GPUBufferType/"storage"}}
         <td>[=internal usage/storage=]
     <tr>
-        <td>{{GPUBufferKind/"readonly-storage"}}
+        <td>{{GPUBufferType/"readonly-storage"}}
         <td>[=internal usage/storage-read=]
 
     <tr>
         <td rowspan=3>{{GPUBindGroupLayoutEntry/sampler}}
         <td rowspan=3>{{GPUSampler}}
-        <td>{{GPUSamplerKind/"filter-sampling"}}
+        <td>{{GPUSamplerType/"filtering"}}
         <td>[=internal usage/constant=]
     <tr>
-        <td>{{GPUSamplerKind/"point-sampling"}}
+        <td>{{GPUSamplerType/"non-filtering"}}
         <td>[=internal usage/constant=]
     <tr>
-        <td>{{GPUSamplerKind/"comparison"}}
+        <td>{{GPUSamplerType/"comparison"}}
         <td>[=internal usage/constant=]
 
     <tr>
         <td rowspan=3>{{GPUBindGroupLayoutEntry/texture}}
         <td rowspan=3>{{GPUTextureView}}
-        <td>{{GPUTextureKind/"filter-sampled"}}
+        <td>{{GPUTextureType/"filterable"}}
         <td>[=internal usage/constant=]
     <tr>
-        <td>{{GPUTextureKind/"point-sampled"}}
+        <td>{{GPUTextureType/"unfilterable"}}
         <td>[=internal usage/constant=]
     <tr>
-        <td>{{GPUTextureKind/"multisample"}}
+        <td>{{GPUTextureType/"multisample"}}
         <td>[=internal usage/constant=]
 
     <tr>
         <td rowspan=2>{{GPUBindGroupLayoutEntry/storageTexture}}
         <td rowspan=2>{{GPUTextureView}}
-        <td>{{GPUStorageTextureKind/"readonly"}}
+        <td>{{GPUStorageTextureType/"readonly"}}
         <td>[=internal usage/storage-read=]
     <tr>
-        <td>{{GPUStorageTextureKind/"writeonly"}}
+        <td>{{GPUStorageTextureType/"writeonly"}}
         <td>[=internal usage/storage-write=]
 </table>
 
+<div algorithm>
+    To get the <dfn abstract-op>layout entry binding type</dfn> in a given {{GPUBindGroupLayoutEntry}} |entry|:
+
+    1. If |entry|.{{GPUBindGroupLayoutEntry/buffer}} is not `undefined`:
+        1. Return |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/type}}.
+    1. If |entry|.{{GPUBindGroupLayoutEntry/sampler}} is not `undefined`:
+        1. Return |entry|.{{GPUBindGroupLayoutEntry/sampler}}.{{GPUSamplerLayoutEntry/type}}.
+    1. If |entry|.{{GPUBindGroupLayoutEntry/texture}} is not `undefined`:
+        1. Return |entry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureLayoutEntry/type}}.
+    1. If |entry|.{{GPUBindGroupLayoutEntry/storageTexture}} is not `undefined`:
+        1. Return |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureLayoutEntry/type}}.
+</div>
+
 <script type=idl>
-enum GPUBufferKind {
+enum GPUBufferType {
     "uniform",
     "storage",
     "readonly-storage",
 };
 
 dictionary GPUBufferLayoutEntry {
-    GPUBufferKind kind = "uniform";
+    GPUBufferType type = "uniform";
     boolean hasDynamicOffset = false;
     GPUSize64 minBufferBindingSize = 0;
 };
@@ -2613,7 +2615,7 @@ dictionary GPUBufferLayoutEntry {
 {{GPUBufferLayoutEntry}} dictionaries have the following members:
 
 <dl dfn-type=dict-member dfn-for=GPUBufferLayoutEntry>
-    : <dfn>kind</dfn>
+    : <dfn>type</dfn>
     ::
         Indicates the type required for buffers bound to this bindings.
 
@@ -2627,54 +2629,50 @@ dictionary GPUBufferLayoutEntry {
 </dl>
 
 <script type=idl>
-enum GPUSamplerKind {
-    "filter-sampling",
-    "point-sampling",
+enum GPUSamplerType {
+    "filtering",
+    "non-filtering",
     "comparison",
 };
 
 dictionary GPUSamplerLayoutEntry {
-    GPUSamplerKind kind = "filter-sampling";
+    GPUSamplerType type = "filtering";
 };
 </script>
 
 {{GPUSamplerLayoutEntry}} dictionaries have the following members:
 
 <dl dfn-type=dict-member dfn-for=GPUSamplerLayoutEntry>
-    : <dfn>kind</dfn>
+    : <dfn>type</dfn>
     ::
-        Indicates the required kind of a sampler bound to this bindings.
+        Indicates the required type of a sampler bound to this bindings.
 </dl>
 
 <script type=idl>
-enum GPUTextureKind {
-    "filter-sampled",
-    "point-sampled",
+enum GPUTextureType {
+    "filterable",
+    "unfilterable",
     "multisample",
 };
 
-enum GPUSamplingResultType {
-    "float",
-    "sint",
-    "uint",
-    "depth-comparison"
-};
-
 dictionary GPUTextureLayoutEntry {
-    GPUSampledTextureKind kind = "filter-sampled";
-    GPUSamplingResultType samplingResultType = "float";
+    GPUTextureType type = "filterable";
+    GPUTextureComponentType componentType = "float";
     GPUTextureViewDimension viewDimension = "2d";
 };
 </script>
 
+Issue(https://github.com/gpuweb/gpuweb/issues/851): consider making {{GPUTextureLayoutEntry/componentType}}
+truly optional.
+
 {{GPUTextureLayoutEntry}} dictionaries have the following members:
 
 <dl dfn-type=dict-member dfn-for=GPUTextureLayoutEntry>
-    : <dfn>kind</dfn>
+    : <dfn>type</dfn>
     ::
         Indicates the type required for texture views bound to this binding.
 
-    : <dfn>samplingResultType</dfn>
+    : <dfn>componentType</dfn>
     ::
         Indicates the required component type of the {{GPUTextureViewDescriptor/format}} for texture
         views bound to this binding.
@@ -2690,22 +2688,25 @@ dictionary GPUTextureLayoutEntry {
 </dl>
 
 <script type=idl>
-enum GPUStorageTextureKind {
+enum GPUStorageTextureType {
     "readonly",
     "writeonly",
 };
 
 dictionary GPUStorageTextureLayoutEntry {
-    GPUStorageTextureAccess kind;
-    GPUTextureFormat format;
+    required GPUStorageTextureType type;
+    required GPUTextureFormat format;
     GPUTextureViewDimension viewDimension = "2d";
 };
 </script>
 
+Issue(https://github.com/gpuweb/gpuweb/issues/851): consider making {{GPUStorageTextureLayoutEntry/format}}
+truly optional.
+
 {{GPUStorageTextureLayoutEntry}} dictionaries have the following members:
 
 <dl dfn-type=dict-member dfn-for=GPUStorageTextureLayoutEntry>
-    : <dfn>kind</dfn>
+    : <dfn>type</dfn>
     ::
         Indicates whether texture views bound to this binding will be bound for read-only or
         write-only access.
@@ -2759,27 +2760,26 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                         <div class=validusage>
                             - |this| is a [=valid=] {{GPUDevice}}.
                             - The {{GPUBindGroupLayoutEntry/binding}} of each entry in |descriptor| is unique.
-                            - For each shader stage, the number of entries in |descriptor| with
-                                {{GPUBindGroupLayoutEntry/type}} {{GPUBindingType/"uniform-buffer"}} &le;
+                            - For each shader stage, the number of entries in |descriptor| with a [$layout entry binding type$] of
+                                {{GPUBufferType/"uniform"}} &le;
                                 {{GPULimits/maxUniformBuffersPerShaderStage|GPULimits.maxUniformBuffersPerShaderStage}}.
-                            - For each shader stage, the number of entries in |descriptor| with
-                                {{GPUBindGroupLayoutEntry/type}} {{GPUBindingType/"storage-buffer"}} &le;
+                            - For each shader stage, the number of entries in |descriptor| with a [$layout entry binding type$] of
+                                {{GPUBufferType/"storage"}} &le;
                                 {{GPULimits/maxStorageBuffersPerShaderStage|GPULimits.maxStorageBuffersPerShaderStage}}.
-                            - For each shader stage, the number of entries in |descriptor| with
-                                {{GPUBindGroupLayoutEntry/type}} {{GPUBindingType/"sampled-texture"}} &le;
+                            - For each shader stage, the number of entries in |descriptor| with a [$layout entry binding type$] of
+                                {{GPUTextureType/"filterable"}} &le;
                                 {{GPULimits/maxSampledTexturesPerShaderStage|GPULimits.maxSampledTexturesPerShaderStage}}.
-                            - For each shader stage, the number of entries in |descriptor| with
-                                {{GPUBindGroupLayoutEntry/type}} {{GPUBindingType/"readonly-storage-texture"}} or
-                                {{GPUBindingType/"writeonly-storage-texture"}} &le;
+                            - For each shader stage, the number of entries in |descriptor| with a [=binding member=] of
+                                {{GPUBindGroupLayoutEntry/storageTexture}} &le;
                                 {{GPULimits/maxStorageTexturesPerShaderStage|GPULimits.maxStorageTexturesPerShaderStage}}.
-                            - For each shader stage, the number of entries in |descriptor| with
-                                {{GPUBindGroupLayoutEntry/type}} {{GPUBindingType/"sampler"}} &le;
+                            - For each shader stage, the number of entries in |descriptor| with a [=binding member=] of
+                                {{GPUBindGroupLayoutEntry/sampler}} &le;
                                 {{GPULimits/maxSamplersPerShaderStage|GPULimits.maxSamplersPerShaderStage}}.
-                            - The number of entries in |descriptor| with {{GPUBindGroupLayoutEntry/type}}
-                                {{GPUBindingType/"uniform-buffer"}} and {{GPUBindGroupLayoutEntry/hasDynamicOffset}} `true` &le;
+                            - The number of entries in |descriptor| with a [$layout entry binding type$] of
+                                {{GPUBufferType/"uniform"}} and {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/hasDynamicOffset}} `true` &le;
                                 {{GPULimits/maxDynamicUniformBuffersPerPipelineLayout|GPULimits.maxDynamicUniformBuffersPerPipelineLayout}}.
-                            - The number of entries in |descriptor| with {{GPUBindGroupLayoutEntry/type}}
-                                {{GPUBindingType/"storage-buffer"}} and {{GPUBindGroupLayoutEntry/hasDynamicOffset}} `true` &le;
+                            - The number of entries in |descriptor| with a [$layout entry binding type$] of
+                                {{GPUBufferType/"storage"}} and {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/hasDynamicOffset}} `true` &le;
                                 {{GPULimits/maxDynamicStorageBuffersPerPipelineLayout|GPULimits.maxDynamicStorageBuffersPerPipelineLayout}}.
 
                             - For each {{GPUBindGroupLayoutEntry}} |bindingDescriptor| in |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
@@ -2789,24 +2789,20 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                                 - Let |storageTextureLayout| be |bindingDescriptor|.{{GPUBindGroupLayoutEntry/storageTexture}}
 
                                 - Exactly one of |bufferLayout|, |samplerLayout|, |textureLayout|,
-                                    or |storageTextureLayout| are not `null`.
+                                    or |storageTextureLayout| are not `undefined`.
 
                                 - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/visibility}} includes
                                     {{GPUShaderStage/VERTEX}}:
-                                    - |bufferLayout| is `null` or |bufferLayout|.{{GPUBufferLayoutEntry/kind}} is not
-                                        {{GPUBufferKind/"readonly-storage"}}.
-                                    - |storageTextureLayout| is `null` or
-                                        |storageTextureLayout|.{{GPUStorageTextureLayoutEntry/kind}} is not
-                                        {{GPUStorageTextureKind/"write-only"}}.
+                                    - The [$layout entry binding type$] of |bindingDescriptor| is not
+                                        {{GPUBufferType/"readonly-storage"}} or {{GPUStorageTextureType/"writeonly"}}.
 
-                                - If |textureLayout| is not `null` and |textureLayout|.{{GPUTextureLayoutEntry/kind}}
-                                    is {{GPUTextureKind/"multisample"}}:
+                                - If the [$layout entry binding type$] of |bindingDescriptor| is {{GPUTextureType/"multisample"}}:
                                     - |textureLayout|.{{GPUTextureLayoutEntry/viewDimension}} is
                                         {{GPUTextureViewDimension/"2d"}}.
-                                    - |textureLayout|.{{GPUTextureLayoutEntry/samplingResultType}} is not
-                                        {{GPUSamplingResultType/"depth-comparison"}}.
+                                    - |textureLayout|.{{GPUTextureLayoutEntry/componentType}} is not
+                                        {{GPUTextureComponentType/"depth-stencil"}}.
 
-                                - If |storageTextureLayout| is not `null`:
+                                - If |storageTextureLayout| is not `undefined`:
                                     - |storageTextureLayout|.{{GPUStorageTextureLayoutEntry/viewDimension}} is not
                                         {{GPUTextureViewDimension/"cube"}} or {{GPUTextureViewDimension/"cube-array"}}.
                                     - |storageTextureLayout|.{{GPUStorageTextureLayoutEntry/format}} must be a format
@@ -2819,14 +2815,12 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                             1. Make |layout| [=invalid=] and return |layout|.
 
                     1. Set |layout|.{{GPUBindGroupLayout/[[dynamicOffsetCount]]}} to the number of
-                        entries in |descriptor| where {{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `true`.
+                        entries in |descriptor| where {{GPUBindGroupLayoutEntry/buffer}} is not `undefined` and
+                        {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/hasDynamicOffset}} is `true`.
                     1. For each {{GPUBindGroupLayoutEntry}} |bindingDescriptor| in
                         |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
                         1. Insert |bindingDescriptor| into |layout|.{{GPUBindGroupLayout/[[entryMap]]}}
                             with the key of |bindingDescriptor|.{{GPUBindGroupLayoutEntry/binding}}.
-
-                        Issue: Add a step to bake the default values (e.g.
-                            {{GPUBindGroupLayoutEntry/viewDimension}} to "2d") into the |bindingDescriptor|.
                 </div>
             1. Return |layout|.
 
@@ -2939,18 +2933,18 @@ A {{GPUBindGroup}} object has the following internal slots:
                                     such that |layoutBinding|.{{GPUBindGroupLayoutEntry/binding}} equals to
                                     |bindingDescriptor|.{{GPUBindGroupEntry/binding}}.
 
-                                - If the [=binding type=] for |layoutBinding| is
+                                - If the defined [=binding member=] for |layoutBinding| is
                                     <dl class="switch">
                                         : {{GPUBindGroupLayoutEntry/sampler}}
                                         ::
                                             - |resource| is a {{GPUSampler}}.
                                             - |resource| is [$valid to use with$] |this|.
-                                            - If |layoutBinding|.{{GPUBindGroupLayoutEntry/sampler}}.{{GPUSamplerLayoutEntry/kind}} is
+                                            - If the [$layout entry binding type$] of |layoutBinding| is
                                                 <dl class="switch">
-                                                    : {{GPUBindingType/"filter-sampling"}} or {{GPUBindingType/"point-sampling"}}
+                                                    : {{GPUSamplerType/"filtering"}} or {{GPUSamplerType/"non-filtering"}}
                                                     :: |resource|.{{GPUSampler/[[compareEnable]]}} is `false`.
 
-                                                    : {{GPUBindingType/"comparison"}}
+                                                    : {{GPUSamplerType/"comparison"}}
                                                     :: |resource|.{{GPUSampler/[[compareEnable]]}} is `true`.
                                                 </dl>
 
@@ -2961,11 +2955,11 @@ A {{GPUBindGroup}} object has the following internal slots:
                                             - Let |texture| be |resource|.{{GPUTextureView/[[texture]]}}.
                                             - |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureLayoutEntry/viewDimension}}
                                                 is equal to |resource|'s {{GPUTextureViewDescriptor/dimension}}.
-                                            - |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureLayoutEntry/samplingResultType}}
+                                            - |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureLayoutEntry/componentType}}
                                                 is compatible with |resource|'s {{GPUTextureViewDescriptor/format}}.
                                             - |texture|'s {{GPUTextureDescriptor/usage}} includes {{GPUTextureUsage/SAMPLED}}.
-                                            - If |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureLayoutEntry/kind}}
-                                                is {{GPUTextureKind/"multisample"}}, |texture|'s {{GPUTextureDescriptor/sampleCount}}
+                                            - If |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureLayoutEntry/type}}
+                                                is {{GPUTextureType/"multisample"}}, |texture|'s {{GPUTextureDescriptor/sampleCount}}
                                                 &gt; `1`, Otherwise |texture|'s {{GPUTextureDescriptor/sampleCount}} is `1`.
 
                                         : {{GPUBindGroupLayoutEntry/storageTexture}}
@@ -2993,9 +2987,9 @@ A {{GPUBindGroup}} object has the following internal slots:
                                                     size of the buffer, is greater than or equal to
                                                     |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/minBufferBindingSize}}.
 
-                                            - If |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/kind}} is
+                                            - If |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/type}} is
                                                 <dl class="switch">
-                                                    : {{GPUBufferKind/"uniform"}}
+                                                    : {{GPUBufferType/"uniform"}}
                                                     :: |resource|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
                                                         includes {{GPUBufferUsage/UNIFORM}}.
                                                     :: |resource|.{{GPUBufferBinding/size}} &le; {{GPULimits/maxUniformBufferBindingSize}}.
@@ -3003,8 +2997,8 @@ A {{GPUBindGroup}} object has the following internal slots:
                                                         Also should {{GPUBufferBinding/size}} default to the `buffer.byteLength - offset` or
                                                         `min(buffer.byteLength - offset, limits.maxUniformBufferBindingSize)`?
 
-                                                    : {{GPUBufferKind/"storage"}} or
-                                                        {{GPUBufferKind/"readonly-storage"}}
+                                                    : {{GPUBufferType/"storage"}} or
+                                                        {{GPUBufferType/"readonly-storage"}}
                                                     :: |resource|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
                                                         includes {{GPUBufferUsage/STORAGE}}.
                                                     :: |resource|.{{GPUBufferBinding/size}} &le; {{GPULimits/maxStorageBufferBindingSize}}.
@@ -3330,54 +3324,60 @@ has a default layout created and used instead.
             1. Set |entry|.{{GPUBindGroupLayoutEntry/visibility}} to |shaderStage|.
             1. If |resource| is for a sampler binding:
 
-                    1. Set |entry|.{{GPUBindGroupLayoutEntry/type}} to
-                        {{GPUBindingType/"sampler"}}.
+                1. Let |samplerLayout| be a new {{GPUSamplerLayoutEntry}}.
+                1. Set |entry|.{{GPUBindGroupLayoutEntry/sampler}} to |samplerLayout|.
 
             1. If |resource| is for a comparison sampler binding:
 
-                1. Set |entry|.{{GPUBindGroupLayoutEntry/type}} to {{GPUBindingType/"comparison-sampler"}}.
+                1. Let |samplerLayout| be a new {{GPUSamplerLayoutEntry}}.
+                1. Set |samplerLayout|.{{GPUSamplerLayoutEntry/type}} to {{GPUSamplerType/"comparison"}}.
+                1. Set |entry|.{{GPUBindGroupLayoutEntry/sampler}} to |samplerLayout|.
 
             1. If |resource| is for a buffer binding:
 
-                1. Set |entry|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} to `false`.
+                1. Let |bufferLayout| be a new {{GPUBufferLayoutEntry}}.
 
-                1. Set |entry|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} to |resource|'s minimum buffer binding size.
+                1. Set |bufferLayout|.{{GPUBufferLayoutEntry/minBufferBindingSize}} to |resource|'s minimum buffer binding size.
 
                     Issue: link to a definition for "minimum buffer binding size" in the "reflection information".
 
-                1. If |resource| is for a uniform buffer:
-
-                    1. Set |entry|.{{GPUBindGroupLayoutEntry/type}} to {{GPUBindingType/"uniform-buffer"}}.
-
                 1. If |resource| is for a read-only storage buffer:
 
-                    1. Set |entry|.{{GPUBindGroupLayoutEntry/type}} to {{GPUBindingType/"readonly-storage-buffer"}}.
+                    1. Set |bufferLayout|.{{GPUBufferLayoutEntry/type}} to {{GPUBufferType/"readonly-storage"}}.
 
                 1. If |resource| is for a storage buffer:
 
-                    1. Set |entry|.{{GPUBindGroupLayoutEntry/type}} to {{GPUBindingType/"storage-buffer"}}.
+                    1. Set |bufferLayout|.{{GPUBufferLayoutEntry/type}} to {{GPUBufferType/"storage"}}.
 
-            1. If |resource| is for a texture binding:
+                1. Set |entry|.{{GPUBindGroupLayoutEntry/buffer}} to |bufferLayout|.
 
-                1. Set |entry|.{{GPUBindGroupLayoutEntry/textureComponentType}} to |resource|'s component type.
-                1. Set |entry|.{{GPUBindGroupLayoutEntry/viewDimension}} to |resource|'s dimension.
+            1. If |resource| is for a sampled texture binding:
+
+                1. Let |textureLayout| be a new {{GPUTextureLayoutEntry}}.
+
+                1. Set |textureLayout|.{{GPUTextureLayoutEntry/componentType}} to |resource|'s component type.
+                1. Set |textureLayout|.{{GPUTextureLayoutEntry/viewDimension}} to |resource|'s dimension.
                 1. If |resource| is for a multisampled texture:
 
-                    1. Set |entry|.{{GPUBindGroupLayoutEntry/type}} to {{GPUBindingType/"multisampled-texture"}}.
+                    1. Set |textureLayout|.{{GPUTextureLayoutEntry/type}} to {{GPUTextureType/"multisample"}}.
 
-                1. If |resource| is for a single-sampled texture:
+                1. Set |entry|.{{GPUBindGroupLayoutEntry/texture}} to |textureLayout|.
 
-                    1. Set |entry|.{{GPUBindGroupLayoutEntry/type}} to {{GPUBindingType/"sampled-texture"}}.
+            1. If |resource| is for a storage texture binding:
+
+                1. Let |storageTextureLayout| be a new {{GPUStorageTextureLayoutEntry}}.
+                1. Set |storageTextureLayout|.{{GPUStorageTextureLayoutEntry/format}} to |resource|'s format.
+                1. Set |storageTextureLayout|.{{GPUStorageTextureLayoutEntry/viewDimension}} to |resource|'s dimension.
 
                 1. If |resource| is for a read-only storage texture:
 
-                    1. Set |entry|.{{GPUBindGroupLayoutEntry/type}} to {{GPUBindingType/"readonly-storage-texture"}}.
-                    1. Set |entry|.{{GPUBindGroupLayoutEntry/storageTextureFormat}} to |resource|'s format.
+                    1. Set |storageTextureLayout|.{{GPUStorageTextureLayoutEntry/type}} to {{GPUStorageTextureType/"readonly"}}.
 
                 1. If |resource| is for a write-only storage texture:
 
-                    1. Set |entry|.{{GPUBindGroupLayoutEntry/type}} to {{GPUBindingType/"writeonly-storage-texture"}}.
-                    1. Set |entry|.{{GPUBindGroupLayoutEntry/storageTextureFormat}} to |resource|'s format.
+                    1. Set |storageTextureLayout|.{{GPUStorageTextureLayoutEntry/type}} to {{GPUStorageTextureType/"writeonly"}}.
+
+                1. Set |entry|.{{GPUBindGroupLayoutEntry/storageTexture}} to |storageTextureLayout|.
 
             1. If |groupDescs|[|group|] has an entry |previousEntry| with {{GPUBindGroupLayoutEntry/binding}} equal to |binding|:
 
@@ -3385,9 +3385,12 @@ has a default layout created and used instead.
 
                     1. Add the bits set in |entry|.{{GPUBindGroupLayoutEntry/visibility}} into |previousEntry|.{{GPUBindGroupLayoutEntry/visibility}}
 
-                1. If |entry| has greater {{GPUBindGroupLayoutEntry/minBufferBindingSize}} than |previousEntry|:
+                1. If |resource| is for a buffer binding and |entry| has greater
+                    {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/minBufferBindingSize}}
+                    than |previousEntry|:
 
-                    1. Set |previousEntry|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} to |entry|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}}.
+                    1. Set |previousEntry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/minBufferBindingSize}}
+                        to |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/minBufferBindingSize}}.
 
                 1. If any other property is unequal between |entry| and |previousEntry|:
 
@@ -3451,37 +3454,66 @@ A {{GPUProgrammableStageDescriptor}} describes the entry point in the user-provi
 
         1. |layout|.{{GPUPipelineLayout/[[bindGroupLayouts]]}}[|bindGroup|] contains
             a {{GPUBindGroupLayoutEntry}} |entry| whose |entry|.{{GPUBindGroupLayoutEntry/binding}} == |bindIndex|.
-        1. If |entry|.{{GPUBindGroupLayoutEntry/type}} is:
+        1. If the defined [=binding member=] for |entry| is:
             <dl class=switch>
-                  : {{GPUBindingType/"sampler"}}
-                  :: the |binding| is a non-comparison sampler
-                  : {{GPUBindingType/"comparison-sampler"}}
-                  :: the |binding| is a comparison sampler
-                  : {{GPUBindingType/"sampled-texture"}}
-                  :: the |binding| is a sampled texture with the component type of |entry|.{{GPUBindGroupLayoutEntry/textureComponentType}}
-                      and it has to have a sample count of 1.
-                  : {{GPUBindingType/"multisampled-texture"}}
-                  :: the |binding| is a multisampled texture with the component type of |entry|.{{GPUBindGroupLayoutEntry/textureComponentType}}.
-                  : {{GPUBindingType/"readonly-storage-texture"}}
-                  :: the |binding| is a read-only storage texture with format of |entry|.{{GPUBindGroupLayoutEntry/storageTextureFormat}}
-                  : {{GPUBindingType/"writeonly-storage-texture"}}
-                  :: the |binding| is a writable storage texture with format of |entry|.{{GPUBindGroupLayoutEntry/storageTextureFormat}}
-                  : {{GPUBindingType/"uniform-buffer"}}
-                  :: the |binding| is a uniform buffer
-                  : {{GPUBindingType/"storage-buffer"}}
-                  :: the |binding| is a storage buffer
-                  : {{GPUBindingType/"readonly-storage-buffer"}}
-                  :: the |binding| is a read-only storage buffer
+                : {{GPUBindGroupLayoutEntry/buffer}}
+                :: If |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/type}} is:
+                    <dl class=switch>
+                        : {{GPUBufferType/"uniform"}}
+                        :: The |binding| is a uniform buffer.
+                        : {{GPUBufferType/"storage"}}
+                        :: The |binding| is a storage buffer.
+                        : {{GPUBufferType/"readonly-storage"}}
+                        :: The |binding| is a read-only storage buffer.
+                    </dl>
+                :: If |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/minBufferBindingSize}} is not `0`:
+                    - If the last field of the corresponding structure defined in the shader has an unbounded array type,
+                        then the value of |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/minBufferBindingSize}}
+                        must be greater than or equal to the byte offset of that field plus the stride of the unbounded array.
+                    - If the corresponding shader structure doesn't end with an unbounded array type,
+                        then the value of |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/minBufferBindingSize}}
+                        must be greater than or equal to the size of the structure.
+
+                : {{GPUBindGroupLayoutEntry/sampler}}
+                :: If |entry|.{{GPUBindGroupLayoutEntry/sampler}}.{{GPUSamplerLayoutEntry/type}} is:
+                    <dl class=switch>
+                        : {{GPUSamplerType/"filtering"}}
+                        :: the |binding| is a non-comparison sampler
+                        : {{GPUSamplerType/"non-filtering"}}
+                        :: the |binding| is a non-comparison sampler
+                        : {{GPUSamplerType/"comparison"}}
+                        :: the |binding| is a comparison sampler
+                    </dl>
+
+                : {{GPUBindGroupLayoutEntry/texture}}
+                :: If |entry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureLayoutEntry/type}} is:
+                    <dl class=switch>
+                        : {{GPUTextureType/"filterable"}}
+                        :: The |binding| is a sampled texture with a sample count of 1.
+                        : {{GPUTextureType/"unfilterable"}}
+                        :: The |binding| is a sampled texture with a sample count of 1.
+                        : {{GPUTextureType/"multisample"}}
+                        :: the |binding| is a multisampled texture.
+                    </dl>
+                :: The component type of the texture matches
+                    |entry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureLayoutEntry/componentType}}.
+                :: The shader view dimension of the texture matches
+                    |entry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureLayoutEntry/viewDimension}}.
+
+                : {{GPUBindGroupLayoutEntry/storageTexture}}
+                :: If |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureLayoutEntry/type}} is:
+                    <dl class=switch>
+                        : {{GPUStorageTextureType/"readonly"}}
+                        :: The |binding| is a read-only storage texture.
+                        : {{GPUStorageTextureType/"writeonly"}}
+                        :: The |binding| is a writable storage texture.
+                    </dl>
+                :: The format of the storage texture matches
+                    |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureLayoutEntry/format}}.
+                :: The shader view dimension of the storage texture matches
+                    |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureLayoutEntry/viewDimension}}.
+
             </dl>
-        1. If |entry|.{{GPUBindGroupLayoutEntry/type}} is {{GPUBindingType/"sampled-texture"}}, {{GPUBindingType/"readonly-storage-texture"}}, or {{GPUBindingType/"writeonly-storage-texture"}},
-            the shader view dimension of the texture has to match |entry|.{{GPUBindGroupLayoutEntry/viewDimension}}.
-        1. If |entry|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} is not undefined:
-              - If the last field of the corresponding structure defined in the shader has an unbounded array type,
-                then the value of |entry|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} must be greater than or equal to the
-                byte offset of that field plus the stride of the unbounded array.
-              - If the corresponding shader structure doesn't end with an unbounded array type,
-                then the value of |entry|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}} must be greater than or equal to the
-                size of the structure.
 </div>
 
 Issue: is there a match/switch statement in bikeshed?
@@ -3497,7 +3529,8 @@ and can be used in {{GPUComputePassEncoder}}.
 
 Compute inputs and outputs are all contained in the bindings,
 according to the given {{GPUPipelineLayout}}.
-The outputs correspond to {{GPUBindingType/"storage-buffer"}} and {{GPUBindingType/"writeonly-storage-texture"}} binding types.
+The outputs correspond to {{GPUBindGroupLayoutEntry/buffer}} bindings with a type of {{GPUBufferType/"storage"}}
+and {{GPUBindGroupLayoutEntry/storageTexture}} bindings with a type of {{GPUStorageTextureType/"writeonly"}}.
 
 Stages of a compute [=pipeline=]:
   1. Compute shader
@@ -3593,7 +3626,8 @@ Render [=pipeline=] inputs are:
   - optionally, the depth-stencil attachment, described by {{GPUDepthStencilStateDescriptor}}
 
 Render [=pipeline=] outputs are:
-  - bindings of types {{GPUBindingType/"storage-buffer"}} and {{GPUBindingType/"writeonly-storage-texture"}}
+  - {{GPUBindGroupLayoutEntry/buffer}} bindings with a {{GPUBufferLayoutEntry/type}} of {{GPUBufferType/"storage"}}
+  - {{GPUBindGroupLayoutEntry/storageTexture}} bindings with a {{GPUStorageTextureLayoutEntry/type}} of {{GPUStorageTextureType/"writeonly"}}
   - the color attachments, described by {{GPUColorStateDescriptor}}
   - optionally, depth-stencil attachment, described by {{GPUDepthStencilStateDescriptor}}
 
@@ -5106,7 +5140,7 @@ interface mixin GPUProgrammablePassEncoder {
                 define the arguments for the 5-arg variant of the method, despite the "for"
                 explicitly pointing at the 3-arg variant.-->
                 <!--|dynamicOffsets|: Array containing buffer offsets in bytes for each entry in
-                    |bindGroup| with marked as {{GPUBindGroupLayoutEntry/hasDynamicOffset}}.-->
+                    |bindGroup| marked as {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/hasDynamicOffset}}.-->
             </pre>
 
             Issue: Resolve bikeshed conflict when using `argumentdef` with overloaded functions that prevents us from
@@ -5149,7 +5183,7 @@ interface mixin GPUProgrammablePassEncoder {
                 |index|: The index to set the bind group at.
                 |bindGroup|: Bind group to use for subsequent render or compute commands.
                 |dynamicOffsetsData|: Array containing buffer offsets in bytes for each entry in
-                    |bindGroup| with marked as {{GPUBindGroupLayoutEntry/hasDynamicOffset}}.
+                    |bindGroup| marked as {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/hasDynamicOffset}}.
                 |dynamicOffsetsDataStart|: Offset in elements into |dynamicOffsetsData| where the
                     buffer offset data begins.
                 |dynamicOffsetsDataLength|: Number of buffer offsets to read from |dynamicOffsetsData|.
@@ -5191,9 +5225,10 @@ interface mixin GPUProgrammablePassEncoder {
     1. For each {{GPUBindGroupEntry}} |entry| in |bindGroup|.{{GPUBindGroup/[[entries]]}}:
         1. Let |bindingDescriptor| be the {{GPUBindGroupLayoutEntry}} at
             |layout|.{{GPUBindGroupLayout/[[entryMap]]}}[|entry|.{{GPUBindGroupEntry/binding}}]:
-        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/hasDynamicOffset}} is `true`:
+        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/buffer}} is not `undefined` and
+            |bindingDescriptor|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/hasDynamicOffset}} is `true`:
             1. Let |bufferBinding| be |entry|.{{GPUBindGroupEntry/resource}}.
-            1. Let |minBufferBindingSize| be |bindingDescriptor|.{{GPUBindGroupLayoutEntry/minBufferBindingSize}}.
+            1. Let |minBufferBindingSize| be |bindingDescriptor|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferLayoutEntry/minBufferBindingSize}}.
             1. Call |steps| with |bufferBinding|, |minBufferBindingSize|, and |dynamicOffsetIndex|.
             1. Let |dynamicOffsetIndex| be |dynamicOffsetIndex| + `1`
 </div>
@@ -7181,7 +7216,8 @@ All plain color formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/
 
 Only formats with {{GPUTextureComponentType}} {{GPUTextureComponentType/"float"}} can be blended.
 
-The {{GPUTextureUsage/STORAGE|GPUTextureUsage.STORAGE}} column specifies the support for {{GPUTextureUsage/STORAGE}} usage in the core API, including both {{GPUBindingType/"readonly-storage-texture"}} and {{GPUBindingType/"writeonly-storage-texture"}}.
+The {{GPUTextureUsage/STORAGE|GPUTextureUsage.STORAGE}} column specifies the support for {{GPUTextureUsage/STORAGE}}
+usage in the core API, including both {{GPUStorageTextureType/"readonly"}} and {{GPUStorageTextureType/"writeonly"}}.
 
 The "Filter" column specifies whether textures of this format can be sampled in shaders with a sampler having {{GPUFilterMode/linear}} filtering.
 
@@ -7437,19 +7473,19 @@ None of the depth formats can be filtered.
         <td>{{GPUTextureFormat/depth16unorm}}
         <td>2
         <td>depth
-        <td>{{GPUTextureComponentType/"float"}}, {{GPUTextureComponentType/"depth-comparison"}}
+        <td>{{GPUTextureComponentType/"float"}}, {{GPUTextureComponentType/"depth-stencil"}}
         <td colspan=2>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/depth24plus}}
         <td>4
         <td>depth
-        <td>{{GPUTextureComponentType/"float"}}, {{GPUTextureComponentType/"depth-comparison"}}
+        <td>{{GPUTextureComponentType/"float"}}, {{GPUTextureComponentType/"depth-stencil"}}
         <td colspan=2>&cross;
     <tr>
         <td rowspan=2 style='white-space:nowrap'>{{GPUTextureFormat/depth24plus-stencil8}}
         <td rowspan=2>4 &minus; 8
         <td>depth
-        <td>{{GPUTextureComponentType/"float"}}, {{GPUTextureComponentType/"depth-comparison"}}
+        <td>{{GPUTextureComponentType/"float"}}, {{GPUTextureComponentType/"depth-stencil"}}
         <td colspan=2>&cross;
     <tr>
         <td>stencil
@@ -7459,7 +7495,7 @@ None of the depth formats can be filtered.
         <td>{{GPUTextureFormat/depth32float}}
         <td>4
         <td>depth
-        <td>{{GPUTextureComponentType/"float"}}, {{GPUTextureComponentType/"depth-comparison"}}
+        <td>{{GPUTextureComponentType/"float"}}, {{GPUTextureComponentType/"depth-stencil"}}
         <td colspan=1>&cross;
         <td colspan=1>&checkmark;
 </table>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2566,13 +2566,19 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
     <tr>
         <td rowspan=3>{{GPUBindGroupLayoutEntry/texture}}
         <td rowspan=3>{{GPUTextureView}}
-        <td>{{GPUTextureType/"filterable"}}
+        <td>{{GPUTextureType/"float"}}
         <td>[=internal usage/constant=]
     <tr>
-        <td>{{GPUTextureType/"unfilterable"}}
+        <td>{{GPUTextureType/"unfilterable-float"}}
         <td>[=internal usage/constant=]
     <tr>
-        <td>{{GPUTextureType/"multisample"}}
+        <td>{{GPUTextureType/"depth-float"}}
+        <td>[=internal usage/constant=]
+    <tr>
+        <td>{{GPUTextureType/"sint"}}
+        <td>[=internal usage/constant=]
+    <tr>
+        <td>{{GPUTextureType/"uint"}}
         <td>[=internal usage/constant=]
 
     <tr>
@@ -2650,19 +2656,21 @@ dictionary GPUSamplerBindingLayout {
 
 <script type=idl>
 enum GPUTextureType {
-    "filterable",
-    "unfilterable",
-    "multisample",
+  "float",
+  "unfilterable-float",
+  "depth-float",
+  "sint",
+  "uint",
 };
 
 dictionary GPUTextureBindingLayout {
-    GPUTextureType type = "filterable";
-    GPUTextureComponentType componentType = "float";
+    GPUTextureType type = "float";
     GPUTextureViewDimension viewDimension = "2d";
+    boolean multisampled = false;
 };
 </script>
 
-Issue(https://github.com/gpuweb/gpuweb/issues/851): consider making {{GPUTextureBindingLayout/componentType}}
+Issue(https://github.com/gpuweb/gpuweb/issues/851): consider making {{GPUTextureBindingLayout/type}}
 truly optional.
 
 {{GPUTextureBindingLayout}} dictionaries have the following members:
@@ -2672,11 +2680,6 @@ truly optional.
     ::
         Indicates the type required for texture views bound to this binding.
 
-    : <dfn>componentType</dfn>
-    ::
-        Indicates the required component type of the {{GPUTextureViewDescriptor/format}} for texture
-        views bound to this binding.
-
     : <dfn>viewDimension</dfn>
     ::
         Indicates the required {{GPUTextureViewDescriptor/dimension}} for texture views bound to
@@ -2685,6 +2688,10 @@ truly optional.
         Note:
             This enables Metal-based WebGPU implementations to back the respective bind groups with
             `MTLArgumentBuffer` objects that are more efficient to bind at run-time.
+
+    : <dfn>multisampled</dfn>
+    ::
+        Inicates whether or not texture views bound to this binding must be multisampled.
 </dl>
 
 <script type=idl>
@@ -2766,8 +2773,8 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                             - For each shader stage, the number of entries in |descriptor| with a [$layout entry binding type$] of
                                 {{GPUBufferType/"storage"}} &le;
                                 {{GPULimits/maxStorageBuffersPerShaderStage|GPULimits.maxStorageBuffersPerShaderStage}}.
-                            - For each shader stage, the number of entries in |descriptor| with a [$layout entry binding type$] of
-                                {{GPUTextureType/"filterable"}} &le;
+                            - For each shader stage, the number of entries in |descriptor| with a [=binding member=] of
+                                {{GPUBindGroupLayoutEntry/texture}} &le;
                                 {{GPULimits/maxSampledTexturesPerShaderStage|GPULimits.maxSampledTexturesPerShaderStage}}.
                             - For each shader stage, the number of entries in |descriptor| with a [=binding member=] of
                                 {{GPUBindGroupLayoutEntry/storageTexture}} &le;
@@ -2796,11 +2803,12 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                                     - The [$layout entry binding type$] of |bindingDescriptor| is not
                                         {{GPUBufferType/"readonly-storage"}} or {{GPUStorageTextureAccess/"writeonly"}}.
 
-                                - If the [$layout entry binding type$] of |bindingDescriptor| is {{GPUTextureType/"multisample"}}:
+                                - If the |textureLayout| is not `undefined` and
+                                    |textureLayout|.{{GPUTextureBindingLayout/multisampled}} is `true`:
                                     - |textureLayout|.{{GPUTextureBindingLayout/viewDimension}} is
                                         {{GPUTextureViewDimension/"2d"}}.
-                                    - |textureLayout|.{{GPUTextureBindingLayout/componentType}} is not
-                                        {{GPUTextureComponentType/"depth"}}.
+                                    - |textureLayout|.{{GPUTextureBindingLayout/type}} is not
+                                        {{GPUTextureType/"depth-float"}}.
 
                                 - If |storageTextureLayout| is not `undefined`:
                                     - |storageTextureLayout|.{{GPUStorageTextureBindingLayout/viewDimension}} is not
@@ -2955,11 +2963,11 @@ A {{GPUBindGroup}} object has the following internal slots:
                                             - Let |texture| be |resource|.{{GPUTextureView/[[texture]]}}.
                                             - |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/viewDimension}}
                                                 is equal to |resource|'s {{GPUTextureViewDescriptor/dimension}}.
-                                            - |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/componentType}}
+                                            - |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/type}}
                                                 is compatible with |resource|'s {{GPUTextureViewDescriptor/format}}.
                                             - |texture|'s {{GPUTextureDescriptor/usage}} includes {{GPUTextureUsage/SAMPLED}}.
-                                            - If |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/type}}
-                                                is {{GPUTextureType/"multisample"}}, |texture|'s {{GPUTextureDescriptor/sampleCount}}
+                                            - If |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/multisampled}}
+                                                is `true`, |texture|'s {{GPUTextureDescriptor/sampleCount}}
                                                 &gt; `1`, Otherwise |texture|'s {{GPUTextureDescriptor/sampleCount}} is `1`.
 
                                         : {{GPUBindGroupLayoutEntry/storageTexture}}
@@ -3355,11 +3363,11 @@ has a default layout created and used instead.
 
                 1. Let |textureLayout| be a new {{GPUTextureBindingLayout}}.
 
-                1. Set |textureLayout|.{{GPUTextureBindingLayout/componentType}} to |resource|'s component type.
+                1. Set |textureLayout|.{{GPUTextureBindingLayout/type}} to |resource|'s component type.
                 1. Set |textureLayout|.{{GPUTextureBindingLayout/viewDimension}} to |resource|'s dimension.
                 1. If |resource| is for a multisampled texture:
 
-                    1. Set |textureLayout|.{{GPUTextureBindingLayout/type}} to {{GPUTextureType/"multisample"}}.
+                    1. Set |textureLayout|.{{GPUTextureBindingLayout/multisampled}} to `true`.
 
                 1. Set |entry|.{{GPUBindGroupLayoutEntry/texture}} to |textureLayout|.
 
@@ -3486,17 +3494,15 @@ A {{GPUProgrammableStageDescriptor}} describes the entry point in the user-provi
                     </dl>
 
                 : {{GPUBindGroupLayoutEntry/texture}}
-                :: If |entry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/type}} is:
+                :: If |entry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/multisampled}} is:
                     <dl class=switch>
-                        : {{GPUTextureType/"filterable"}}
+                        : `true`
                         :: The |binding| is a sampled texture with a sample count of 1.
-                        : {{GPUTextureType/"unfilterable"}}
-                        :: The |binding| is a sampled texture with a sample count of 1.
-                        : {{GPUTextureType/"multisample"}}
+                        : `false`
                         :: the |binding| is a multisampled texture.
                     </dl>
                 :: The component type of the texture matches
-                    |entry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/componentType}}.
+                    |entry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/type}}.
                 :: The shader view dimension of the texture matches
                     |entry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/viewDimension}}.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7209,7 +7209,7 @@ Issue: Add multisampling to the tables below.
 
 All plain color formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, and {{GPUTextureUsage/SAMPLED}} usage.
 
-Only formats with {{GPUTextureComponentType}} {{GPUTextureComponentType/"float"}} can be blended.
+Only formats with {{GPUTextureSampleType}} {{GPUTextureSampleType/"float"}} can be blended.
 
 The {{GPUTextureUsage/STORAGE|GPUTextureUsage.STORAGE}} column specifies the support for {{GPUTextureUsage/STORAGE}}
 usage in the core API, including both {{GPUStorageTextureAccess/"readonly"}} and {{GPUStorageTextureAccess/"writeonly"}}.
@@ -7448,7 +7448,7 @@ None of the depth formats can be filtered.
         <td colspan=2>&cross;
     <tr>
         <td>stencil
-        <td>{{GPUTextureComponentType/"uint"}}
+        <td>{{GPUTextureSampleType/"uint"}}
         <td colspan=2>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/depth32float}}
@@ -7470,7 +7470,7 @@ Issue: clarify if `depth24plus-stencil8` is copyable into `depth24plus` in Metal
 
 ### Packed formats ### {#packed-formats}
 
-All packed texture formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, and {{GPUTextureUsage/SAMPLED}} usages. All of these formats have {{GPUTextureComponentType/float}} type and can be filtered on sampling.
+All packed texture formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, and {{GPUTextureUsage/SAMPLED}} usages. All of these formats have {{GPUTextureSampleType/"float"}} type and can be filtered on sampling.
 
 <table class='data'>
     <thead class=stickyheader>


### PR DESCRIPTION
Fixes #1164 

This is currently a WIP because this change touches a very large number of references in the spec and I haven't yet updated them all. Wanted to get this pushed to the server for the weekend, though, and figured you might be interested in taking a peek. Of special interest is the updated binding type table and the bind group validation logic.

One thing to note early on: The usage of the term "kind" has felt rather awkward as I've been writing out some of the spec prose here. I don't have a suggested alternative, just point out that I've found it hard to write about naturally.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/toji/gpuweb/pull/1223.html" title="Last updated on Nov 24, 2020, 10:15 PM UTC (4cbd93e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1223/78e7c93...toji:4cbd93e.html" title="Last updated on Nov 24, 2020, 10:15 PM UTC (4cbd93e)">Diff</a>