### PR TITLE
wgsl: Cross-reference individual storage classes

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -325,7 +325,7 @@ A vector type is a <dfn dfn>numeric vector</dfn> type if its component type is a
 
 Restrictions on runtime-sized arrays:
 * The last member of the structure type defining the [=store type=]
-    for a variable in the `storage` [=storage class=] may be a runtime-sized array.
+    for a variable in the [=storage classes/storage=] storage class may be a runtime-sized array.
 * A runtime-sized array must not be used as the store type or contained within
     a store type in any other cases.
 * The type of an expression must not be a runtime-sized array type.
@@ -492,7 +492,7 @@ Host-shareable types are used to describe the contents of buffers which are shar
 the host and the GPU, or copied between host and GPU without format translation.
 When used for this purpose, the type must be additionally decorated with layout attributes
 as described in [[#memory-layouts]].
-In particular, any variable using the `uniform` or `storage` [=storage classes=] must have
+In particular, any variable using the [=storage classes/uniform=] or [=storage classes/storage=] storage classes must have
 a host-shareable [=store type=].
 
 Note: An [=IO-shareable=] type would also be host-shareable if it and its subtypes have
@@ -511,6 +511,7 @@ mutability, visibility, the values it may contain,
 and how to use variables with it.
 
 <table class='data'>
+  <caption>Storage Classes</caption>
   <thead>
     <tr><th>Storage class
         <th>Readable by shader?<br>Writable by shader?
@@ -519,50 +520,50 @@ and how to use variables with it.
         <th>Restrictions on stored values
         <th>Notes
   </thead>
-  <tr><td>in
+  <tr><td><dfn noexport dfn-for="storage classes">in</dfn>
       <td>Read-only
       <td>Same invocation only
       <td>[=Module scope=]
       <td>[=IO-shareable=]
       <td>Input from an upstream pipeline stage, or from the implementation.
-  <tr><td>out
+  <tr><td><dfn noexport dfn-for="storage classes">out</dfn>
       <td>Read-write
       <td>Same invocation only
       <td>[=Module scope=]
       <td>[=IO-shareable=]
       <td>Output to a downstream pipeline stage.
-  <tr><td>function
+  <tr><td><dfn noexport dfn-for="storage classes">function</dfn>
       <td>Read-write
       <td>Same invocation only
       <td>[=Function scope=]
       <td>[=Storable=]
       <td>
-  <tr><td>private
+  <tr><td><dfn noexport dfn-for="storage classes">private</dfn>
       <td>Read-write
       <td>Same invocation only
       <td>[=Module scope=]
       <td>[=Storable=]
       <td>
-  <tr><td>workgroup
+  <tr><td><dfn noexport dfn-for="storage classes">workgroup</dfn>
       <td>Read-write
-      <td>Invocations in the same [=workgroup=]
+      <td>Invocations in the same [=compute shader stage|compute shader=] [=compute shader stage/workgroup=]
       <td>[=Module scope=]
       <td>[=Storable=]
       <td>
-  <tr><td>uniform
+  <tr><td><dfn noexport dfn-for="storage classes">uniform</dfn>
       <td>Read-only
       <td>Invocations in the same [=shader stage=]
       <td>[=Module scope=]
       <td>[=Host-shareable=]
       <td>For [=uniform buffer=] variables
-  <tr><td>storage
+  <tr><td><dfn noexport dfn-for="storage classes">storage</dfn>
       <td>Readable.<br>
           Also writable if the variable is not read-only.
       <td>Invocations in the same [=shader stage=]
       <td>[=Module scope=]
       <td>[=Host-shareable=]
       <td>For [=storage buffer=] variables
-  <tr><td>handle
+  <tr><td><dfn noexport dfn-for="storage classes">handle</dfn>
       <td>Read-only
       <td>Invocations in the same shader stage
       <td>[=Module scope=]
@@ -571,7 +572,7 @@ and how to use variables with it.
           The token `handle` is reserved: it is never used in a [SHORTNAME] program.
 </table>
 
-Issue: The note about read-only `storage` variables may change depending
+Issue: The note about read-only [=storage classes/storage=] variables may change depending
 on the outcome of https://github.com/gpuweb/gpuweb/issues/935
 
 <pre class='def'>
@@ -615,7 +616,7 @@ which is the description of how the buffer's bytes are organized into typed WGSL
 
 The [=store type=] of a buffer variable must be [=host-shareable=], with fully elaborated memory layout, as described below.
 
-Each buffer variable must be declared in either the `uniform` or `storage` storage classes.
+Each buffer variable must be declared in either the [=storage classes/uniform=] or [=storage classes/storage=] storage classes.
 The memory layout of a type is significant only when referring to a value in those storage classes.
 This affects evaluation of a variable in one of those storage classes, or of a pointer into one of those storage classes.
 
@@ -628,7 +629,7 @@ TODO: <dfn noexport>layout attribute</dfn>
   <thead>
     <tr><th>Type<th>Description
   </thead>
-  <tr><td>ptr<*SC*,*T*><td>Pointer (or reference) to storage in [[#storage-class]] *SC*
+  <tr><td>ptr<*SC*,*T*><td>Pointer (or reference) to storage in [=storage class=] *SC*
                             which can hold a value of the [=storable=] *T*.
                             Here, *T* is the known as the *pointee* type.
 </table>
@@ -658,7 +659,7 @@ A pointer value *P* supports the following operations:
                    less than the number of components in *P*’s pointee type.
                    The subaccess evaluation yields a pointer to the storage for
                    the K’th component within P’s referenced storage,
-                   using zero-based indexing. If P's storage class is SC, and
+                   using zero-based indexing. If P's [=storage class=] is SC, and
                    the K'th member of P's pointee type is of type T, then
                    the result type is `ptr<SC,T>`.
 </table>
@@ -752,7 +753,7 @@ As a consequence, a shader does not have direct access to the texel storage with
 Instead, use texture builtin functions as follows:
 
 * Within the shader:
-    * Declare a module-scope variable in the `handle` [=storage class=],
+    * Declare a module-scope variable in the [=storage classes/handle=] storage class,
         where the [=store type=] is one of the texture types described in later sections.
     * Inside a function, call one of the texture builtin functions, and provide
         the texture variable as the first parameter.
@@ -1270,7 +1271,7 @@ TODO: *Stub* (describe what a constant is): A constant is a name for a value, de
 What types are permitted?  Storable, plus pointer to store type.
 
 TODO(dneto): A const may not be of type pointer-to-handle. A function parameter may not have type pointer-to-handle.
-Otherwise we'd have a need to make a pointer-to-handle type expression. But we've reserved the `handle` keyword.
+Otherwise we'd have a need to make a pointer-to-handle type expression. But we've reserved the [=storage classes/handle=] keyword.
 When translating from SPIR-V, you must trace through
 the OpCopyObject (or no-index OpAccessChain) instructions that might be between
 the pointer-to-array and the pointer-to-struct.
@@ -1287,7 +1288,7 @@ A <dfn dfn noexport>variable declaration</dfn>:
 
 * Determines the variable’s name, storage class, and store type (and hence its reference type).
 * Ensures the execution environment allocates storage for a value of the store type, for the lifetime of the variable.
-* Optionally have an *initializer* expression, if the variable is in the `private`, `function`, or `out` [=storage classes|storage class=].
+* Optionally have an *initializer* expression, if the variable is in the [=storage classes/private=], [=storage classes/function=], or [=storage classes/out=] storage classes.
     If present, the initializer's type must match the store type of the variable.
 
 See [[#module-scope-variables]] and [[#function-scope-variables]] for rules about where
@@ -1319,16 +1320,17 @@ variable_storage_decoration
 </table>
 
 The access decoration must only appear on a type used as the store type for a
-variable in the `storage` [=storage class=]. The access decoration must not appear
+variable in the [=storage classes/storage=] storage class.
+The access decoration must not appear
 on a type of const declaration nor as the store type for variable with a
-[=storage class=] other than `storage`. The access decoration is required for
-variables in the `storage` [=storage class=].
+storage class other than [=storage classes/storage=]. The access decoration is required for
+variables in the [=storage classes/storage=] storage class.
 
 Two variables with overlapping lifetimes will not have overlapping storage.
 
 When a variable is created, its storage contains an initial value as follows:
 
-* For variables in the `private`, `function`, or `out` storage classes:
+* For variables in the [=storage classes/private=], [=storage classes/function=], or [=storage classes/out=] storage classes:
     * The zero value for the store type, if the variable declaration has no initializer.
     * Otherwise, it is the result of evaluating the initializer expression at that point in the program execution.
 * For variables in other storage classes, the execution environment provides the initial value.
@@ -1375,20 +1377,20 @@ of the program.
 
 Variables at module scope are restricted as follows:
 
-* The variable must not be in the `function` [=storage classes|storage class=].
-* A variable in the `in`, `out`, `private`, `workgroup`, `uniform`, or `storage` storage classes:
+* The variable must not be in the [=storage classes/function=] storage class.
+* A variable in the [=storage classes/in=], [=storage classes/out=], [=storage classes/private=], `workgroup`, [=storage classes/uniform=], or [=storage classes/storage=] storage classes:
     * Must be declared with an explicit storage class decoration.
     * Must use a [=store type=] as described in [[#storage-class]].
 * If the [=store type=] is a texture type or a sampler type, then the variable declaration must not
-    have a storage class decoration.  The storage class will always be `handle`.
+    have a storage class decoration.  The storage class will always be [=storage classes/handle=].
 
-Variables in the `in` and `out` storage classes are pipeline inputs and outputs. See [[#pipeline-inputs-outputs]].
+Variables in the [=storage classes/in=] and [=storage classes/out=] storage classes are pipeline inputs and outputs. See [[#pipeline-inputs-outputs]].
 
-A variable in the `uniform` storage class is a <dfn noexport>uniform buffer</dfn> variable.
+A variable in the [=storage classes/uniform=] storage class is a <dfn noexport>uniform buffer</dfn> variable.
 Its [=store type=] must be a [=host-shareable=] structure type with [=block=] attribute,
 satisfying the *uniform buffer layout* rules.
 
-A variable in the `storage` storage class is a <dfn noexport>storage buffer</dfn> variable.
+A variable in the [=storage classes/storage=] storage class is a <dfn noexport>storage buffer</dfn> variable.
 Its [=store type=] must be a [=host-shareable=] structure type with [=block=] attribute,
 satisfying the *storage buffer layout* rules.
 
@@ -1564,7 +1566,7 @@ A variable or constant declared in a declaration statement in a function body is
 The name is available for use immediately after its declaration statement,
 and until the end of the brace-delimited list of statements immediately enclosing the declaration.
 
-A variable declared in function scope is always in the `function` [=storage class=].
+A variable declared in function scope is always in the [=storage classes/function=] storage class.
 The variable storage decoration is optional.
 The variable's [=store type=] must be [=storable=].
 
@@ -3241,7 +3243,7 @@ The interface includes:
 * Buffer resources
 * Texture resources
 
-These objects are represented by module-scope variables in certain storage classes.
+These objects are represented by module-scope variables in certain [=storage classes=].
 
 We say a variable is <dfn noexport>statically accessed</dfn> by a function if any subexpression
 in the body of the function uses the variable's identifier,
@@ -3252,16 +3254,16 @@ will actually evaluate the subexpression, or even execute the enclosing statemen
 More precisely, the <dfn noexport>interface of a shader stage</dfn>
 is the set of module-scope variables
 [=statically accessed=] by [=functions in a shader stage|functions in the shader stage=],
-and which are in [=storage classes=] `in`, `out`, `uniform`, `storage`, or `handle`.
+and which are in storage classes [=storage classes/in=], [=storage classes/out=], [=storage classes/uniform=], [=storage classes/storage=], or [=storage classes/handle=].
 
 ### Pipeline Input and Output Interface ### {#pipeline-inputs-outputs}
 
 A <dfn noexport>pipeline input</dfn> is data provided to the shader stage from upstream in the pipeline.
-A pipeline input is denoted by a module-scope variable in the `in` [=storage class=].
+A pipeline input is denoted by a module-scope variable in the [=storage classes/in=] storage class.
 The store type must be [=IO-shareable=].
 
 A <dfn noexport>pipeline output</dfn> is data the shader provides for further processing downstream in the pipeline.
-A pipeline output is denoted by a module-scope variable in the `out` [=storage class=].
+A pipeline output is denoted by a module-scope variable in the [=storage classes/out=] storage class.
 The store type must be [=IO-shareable=].
 
 Each pipeline input or output is one of:
@@ -3276,7 +3278,7 @@ The set of built-in inputs are listed in [[#builtin-variables]].
 
 To declare a variable for accessing a particular input built-in *X*:
 
-* Declare a module-scope variable in the `in` [=storage class=],
+* Declare a module-scope variable in the [=storage classes/in=] storage class,
     where the [=store type=] is the listed store type for *X*.
 * Apply a `builtin(`*X*`)` attribute to the variable.
 * The variable must not have an initializer. The system provides the value.
@@ -3287,7 +3289,7 @@ The set of built-in outputs are listed in [[#builtin-variables]].
 
 To declare a variable for accessing a particular output built-in *Y*:
 
-* Declare a module-scope variable in the `out` [=storage class=],
+* Declare a module-scope variable in the [=storage classes/out=] storage class,
     where the [=store type=] is the listed store type for *Y*.
 * Apply a `builtin(`*Y*`)` attribute to the variable.
 * The variable may have an initializer, or not, as described in [[#variables]].
@@ -3305,11 +3307,11 @@ To declare a variable for accessing a particular output built-in *Y*:
   </xmp>
 </div>
 
-The `builtin` attribute must not be applied to a variable in a storage class other than `in` or `out`.
+The `builtin` attribute must not be applied to a variable in a storage class other than [=storage classes/in=] or [=storage classes/out=].
 
-An input built-in must only be applied to a variable in the `in` storage class.
+An input built-in must only be applied to a variable in the [=storage classes/in=] storage class.
 
-An output built-in must only be applied to a variable in the `out` storage class.
+An output built-in must only be applied to a variable in the [=storage classes/out=] storage class.
 
 A variable must not have more than one `builtin` attribute.
 
@@ -3472,9 +3474,9 @@ TODO: *Stub*: Expression evaluation
 
 ## Compute Shaders and Workgroups ## {#compute-shader-workgroups}
 
-A <dfn noexport>workgroup</dfn> is a set of invocations which
+A <dfn noexport for="compute shader stage">workgroup</dfn> is a set of invocations which
 concurrently execute a [=compute shader stage=] [=entry point=],
-and share access to shader variables in the `workgroup` [=storage class=].
+and share access to shader variables in the [=storage classes/workgroup=] storage class.
 
 The <dfn noexport>workgroup grid</dfn> for a compute shader is the set of points
 with integer coordinates *(i,j,k)* with:


### PR DESCRIPTION
Editorially, replace things like this:

         ... the `storage` [=storage class=]...

with

         ... the [=storage classes/storage=] storage class...

It's better to link to only the specific storage class; the second
link to the general concept would be distracting if we left it in.

Fixes #1232