### PR TITLE
[wgsl] Unify decoration declarations.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1435,6 +1435,7 @@ decoration_list
 
 decoration
   : IDENT PAREN_LEFT literal_or_ident PAREN_RIGHT
+  | IDENT
 
 literal_or_ident
   : FLOAT_LITERAL

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -373,27 +373,30 @@ A structure type with the [=block=] attribute must not be:
 
 <pre class='def'>
 struct_decl
-  : struct_decoration_decl* STRUCT IDENT struct_body_decl
+  : decoration_list* STRUCT IDENT struct_body_decl
+</pre>
 
-struct_decoration_decl
-  : ATTR_LEFT struct_decoration ATTR_RIGHT
+<table class='data'>
+  <thead>
+    <tr><th>Struct decoration keys<th>Valid values<th>Note
+  </thead>
+  <tr><td>`block`<td><td>The block decoration takes no parameters
+</table>
 
-struct_decoration
-  : BLOCK
-
+<pre class='def'>
 struct_body_decl
   : BRACE_LEFT struct_member* BRACE_RIGHT
 
 struct_member
-  : struct_member_decoration_decl+ variable_ident_decl SEMICOLON
-
-struct_member_decoration_decl
-  :
-  | ATTR_LEFT (struct_member_decoration COMMA)* struct_member_decoration ATTR_RIGHT
-
-struct_member_decoration
-  : OFFSET PAREN_LEFT INT_LITERAL PAREN_RIGHT
+  : decoration_list* variable_ident_decl SEMICOLON
 </pre>
+
+<table class='data'>
+  <thead>
+    <tr><th>Struct member decoration keys<th>Valid values<th>Note
+  </thead>
+  <tr><td>`offset`<td>non-negative i32 literal<td>
+</table>
 
 Note: Layout attributes are required if the structure type is used
 to define a [=uniform buffer=] or a [=storage buffer=]. See [[#memory-layouts]].
@@ -1190,8 +1193,8 @@ type_decl
   | VEC3 LESS_THAN type_decl GREATER_THAN
   | VEC4 LESS_THAN type_decl GREATER_THAN
   | POINTER LESS_THAN storage_class COMMA type_decl GREATER_THAN
-  | array_decoration_list* ARRAY LESS_THAN type_decl COMMA INT_LITERAL GREATER_THAN
-  | array_decoration_list* ARRAY LESS_THAN type_decl GREATER_THAN
+  | decoration_list* ARRAY LESS_THAN type_decl COMMA INT_LITERAL GREATER_THAN
+  | decoration_list* ARRAY LESS_THAN type_decl GREATER_THAN
   | MAT2x2 LESS_THAN type_decl GREATER_THAN
   | MAT2x3 LESS_THAN type_decl GREATER_THAN
   | MAT2x4 LESS_THAN type_decl GREATER_THAN
@@ -1207,13 +1210,12 @@ type_decl
 When the type declaration is an identifer, then the expression must be in scope of a
 declaration of the identifier as a type alias or structure type.
 
-<pre class='def'>
-array_decoration_list
-  : ATTR_LEFT (array_decoration COMMA)* array_decoration ATTR_RIGHT
-
-array_decoration
-  : STRIDE PAREN_LEFT INT_LITERAL PAREN_RIGHT
-</pre>
+<table class='data'>
+  <thead>
+    <tr><th>Array decoration keys<th>Valid values<th>Note
+  </thead>
+  <tr><td>`stride`<td>greater than zero i32 literal<td>
+</table>
 
 <div class='example' heading="Type Declarations">
   <xmp>
@@ -1304,7 +1306,7 @@ variable_decl
   : VAR variable_storage_decoration? variable_ident_decl
 
 variable_ident_decl
-  : IDENT COLON variable_decoration_list* type_decl
+  : IDENT COLON decoration_list* type_decl
 
 variable_storage_decoration
   : LESS_THAN storage_class GREATER_THAN
@@ -1425,13 +1427,13 @@ Such variables are declared with [=group=] and [=binding=] decorations.
 
 <pre class='def'>
 global_variable_decl
-  : variable_decoration_list* variable_decl
-  | variable_decoration_list* variable_decl EQUAL const_expr
+  : decoration_list* variable_decl
+  | decoration_list* variable_decl EQUAL const_expr
 
-variable_decoration_list
-  : ATTR_LEFT (variable_decoration COMMA)* variable_decoration ATTR_RIGHT
+decoration_list
+  : ATTR_LEFT (decoration COMMA)* decoration ATTR_RIGHT
 
-variable_decoration
+decoration
   : IDENT PAREN_LEFT literal_or_ident PAREN_RIGHT
 
 literal_or_ident
@@ -1454,7 +1456,7 @@ literal_or_ident
 
 <table class='data'>
   <thead>
-    <tr><th>Variable decoration keys<th>Valid values<th>Note
+    <tr><th>Global variable decoration keys<th>Valid values<th>Note
   </thead>
   <tr><td>`binding`<td>non-negative i32 literal<td>See [[#resource-interface]]
   <tr><td>`builtin`<td>a builtin variable identifier<td>See [[#builtin-variables]]
@@ -1512,13 +1514,7 @@ is the one from the constant's declaration or from a pipeline override.
 
 <pre class='def'>
 global_constant_decl
-  : global_const_decoration_list* CONST variable_ident_decl global_const_initializer?
-
-global_const_decoration_list
-  : ATTR_LEFT global_const_decoration ATTR_RIGHT
-
-global_const_decoration
-  : CONSTANT_ID PAREN_LEFT INT_LITERAL PAREN_RIGHT
+  : decoration_list* CONST variable_ident_decl global_const_initializer?
 
 global_const_initializer
   : EQUAL const_expr
@@ -1527,6 +1523,14 @@ const_expr
   : type_decl PAREN_LEFT (const_expr COMMA)* const_expr PAREN_RIGHT
   | const_literal
 </pre>
+
+<table class='data'>
+  <thead>
+    <tr><th>Global const decoration keys<th>Valid values<th>Note
+  </thead>
+  <tr><td>`constant_id`<td>non-negative i32 literal<td>
+</table>
+
 
 <div class='example' heading='Constants'>
   <xmp>
@@ -3043,10 +3047,7 @@ module.
 
 <pre class='def'>
 function_decl
-  : function_decoration_decl* function_header body_statement
-
-function_decoration_decl
-  : ATTR_LEFT (function_decoration COMMA)* function_decoration ATTR_RIGHT
+  : decoration_list* function_header body_statement
 
 function_type_decl
   : type_decl
@@ -3059,6 +3060,16 @@ param_list
   :
   | (variable_ident_decl COMMA)* variable_ident_decl
 </pre>
+
+<table class='data'>
+  <thead>
+    <tr><th>Function decoration keys<th>Valid values<th>Note
+  </thead>
+  <tr><td>`stage`<td>`compute` or `vertex` or `fragment`<td>
+  <tr><td>`workgroup_size`<td>non-negative i32 literals<td>The workgroup_size accepts
+    a comma separated list of up to 3 values. The values provide the x, y and z
+    dimensions.
+</table>
 
 <div class='example' heading='Function'>
   <xmp>
@@ -3180,20 +3191,6 @@ The union is applied repeatedly until it stabilizes.
 It will stabilize in a finite number of steps.
 
 ### Function attributes for entry points ### {#entry-point-attributes}
-
-<pre class='def'>
-function_decoration
-  : STAGE PAREN_LEFT pipeline_stage PAREN_RIGHT
-  | WORKGROUP_SIZE
-      PAREN_LEFT
-        INT_LITERAL ( COMMA INT_LITERAL ( COMMA INT_LITERAL )? )?
-      PAREN_RIGHT
-
-pipeline_stage
-  : COMPUTE
-  | VERTEX
-  | FRAGMENT
-</pre>
 
 : <dfn noexport>stage</dfn>
 :: The `stage` attribute declares that a function is an entry point for particular pipeline stage.
@@ -3679,11 +3676,8 @@ I've written what an NVIDIA GPU does.  See https://github.com/google/amber/pull/
   <tr><td>`BITCAST`<td>bitcast
   <tr><td>`BLOCK`<td>block
   <tr><td>`BREAK`<td>break
-  <tr><td>`BUILTIN`<td>builtin
   <tr><td>`CASE`<td>case
-  <tr><td>`COMPUTE`<td>compute
   <tr><td>`CONST`<td>const
-  <tr><td>`CONSTANT_ID`<td>constant_id
   <tr><td>`CONTINUE`<td>continue
   <tr><td>`CONTINUING`<td>continuing
   <tr><td>`DEFAULT`<td>default
@@ -3694,27 +3688,20 @@ I've written what an NVIDIA GPU does.  See https://github.com/google/amber/pull/
   <tr><td>`FALSE`<td>false
   <tr><td>`FN`<td>fn
   <tr><td>`FOR`<td>for
-  <tr><td>`FRAGMENT`<td>fragment
   <tr><td>`FUNCTION`<td>function
   <tr><td>`IF`<td>if
   <tr><td>`IN`<td>in
-  <tr><td>`LOCATION`<td>location
   <tr><td>`LOOP`<td>loop
-  <tr><td>`OFFSET`<td>offset
   <tr><td>`OUT`<td>out
   <tr><td>`PRIVATE`<td>private
   <tr><td>`RETURN`<td>return
-  <tr><td>`STAGE`<td>stage
-  <tr><td>`STRIDE`<td>stride
   <tr><td>`STORAGE`<td>storage
   <tr><td>`SWITCH`<td>switch
   <tr><td>`TRUE`<td>true
   <tr><td>`TYPE`<td>type
   <tr><td>`UNIFORM`<td>uniform
   <tr><td>`VAR`<td>var
-  <tr><td>`VERTEX`<td>vertex
   <tr><td>`WORKGROUP`<td>workgroup
-  <tr><td>`WORKGROUP_SIZE`<td>workgroup_size
 </table>
 <table class='data'>
   <caption>Image format keywords</caption>


### PR DESCRIPTION
This Cl removes all of the individual decoration grammar elements in
favour of a single `decoration_list`. All of the tokens related to
decorations have been removed and the relevant tables inserted into the
spec in their place.