### PR TITLE
wsgl: Add rule that offsets must be compile time constant

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4569,8 +4569,12 @@ textureSample(t : texture_depth_cube_array, s : sampler, coords : vec3<f32>, arr
   <tr><td>`offset`<td>
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
-  texture wrapping modes. `offset` values may range from `[-8..7]` in all
-  dimensions. Values outside of this range will be clamped to the nearest limit.
+  texture wrapping modes. <br>
+  `offset` must be compile time constant, and may only be provided as a
+  [literal](#literals), [constant expression](#module-constants) or from a
+  [const](#variables) variable. <br>
+  `offset` values must range from `[-8..7]` in all dimensions. Values outside of
+  this range will be treated as a compile time error.
 </table>
 
 **Returns:**
@@ -4610,8 +4614,13 @@ textureSampleBias(t : texture_cube_array<f32>, s : sampler, coords : vec3<f32>, 
   <tr><td>`offset`<td>
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
-  texture wrapping modes. `offset` values may range from `[-8..7]` in all
-  dimensions. Values outside of this range will be clamped to the nearest limit.
+  texture wrapping modes. <br>
+  `offset` must be compile time constant, and may only be provided as a
+  [literal](#literals), [`const_expr`](https://gpuweb.github.io/gpuweb/wgsl.html#module-constants) or from a
+  [`const`](https://gpuweb.thub.io/gpuweb/wgsl.html#variables)
+  variable.
+  `offset` values must range from `[-8..7]` in all dimensions. Values outside of
+  this range will be treated as a compile time error.
 </table>
 
 **Returns:**
@@ -4660,8 +4669,13 @@ textureSampleLevel(t : texture_depth_cube_array, s : sampler, coords : vec3<f32>
   <tr><td>`offset`<td>
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
-  texture wrapping modes. `offset` values may range from `[-8..7]` in all
-  dimensions. Values outside of this range will be clamped to the nearest limit.
+  texture wrapping modes. <br>
+  `offset` must be compile time constant, and may only be provided as a
+  [literal](#literals), [`const_expr`](https://gpuweb.github.io/gpuweb/wgsl.html#module-constants) or from a
+  [`const`](https://gpuweb.thub.io/gpuweb/wgsl.html#variables)
+  variable.
+  `offset` values must range from `[-8..7]` in all dimensions. Values outside of
+  this range will be treated as a compile time error.
 </table>
 
 **Returns:**
@@ -4702,8 +4716,13 @@ textureSampleGrad(t : texture_cube_array<f32>, s : sampler, coords : vec3<f32>, 
   <tr><td>`offset`<td>
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
-  texture wrapping modes. `offset` values may range from `[-8..7]` in all
-  dimensions. Values outside of this range will be clamped to the nearest limit.
+  texture wrapping modes. <br>
+  `offset` must be compile time constant, and may only be provided as a
+  [literal](#literals), [`const_expr`](https://gpuweb.github.io/gpuweb/wgsl.html#module-constants) or from a
+  [`const`](https://gpuweb.thub.io/gpuweb/wgsl.html#variables)
+  variable.
+  `offset` values must range from `[-8..7]` in all dimensions. Values outside of
+  this range will be treated as a compile time error.
 </table>
 
 **Returns:**
@@ -4740,8 +4759,13 @@ textureSampleCompare(t : texture_depth_cube_array, s : sampler_comparison, coord
   <tr><td>`offset`<td>
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
-  texture wrapping modes. `offset` values may range from `[-8..7]` in all
-  dimensions. Values outside of this range will be clamped to the nearest limit.
+  texture wrapping modes. <br>
+  `offset` must be compile time constant, and may only be provided as a
+  [literal](#literals), [`const_expr`](https://gpuweb.github.io/gpuweb/wgsl.html#module-constants) or from a
+  [`const`](https://gpuweb.thub.io/gpuweb/wgsl.html#variables)
+  variable.
+  `offset` values must range from `[-8..7]` in all dimensions. Values outside of
+  this range will be treated as a compile time error.
 </table>
 
 **Returns:**

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4569,12 +4569,12 @@ textureSample(t : texture_depth_cube_array, s : sampler, coords : vec3<f32>, arr
   <tr><td>`offset`<td>
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
-  texture wrapping modes. <br>
+  texture wrapping modes.<br>
   `offset` must be compile time constant, and may only be provided as a
-  [literal](#literals), [constant expression](#module-constants) or from a
-  [const](#variables) variable. <br>
-  `offset` values must range from `[-8..7]` in all dimensions. Values outside of
-  this range will be treated as a compile time error.
+  [module constant](#module-constants), [literal](#literals) or
+  `const_expr` expression (e.g. `vec2<i32>(1, 2)`).<br>
+  Each `offset` component must be at least `-8` and at most `7`. Values outside
+  of this range will be treated as a compile time error.
 </table>
 
 **Returns:**
@@ -4614,13 +4614,12 @@ textureSampleBias(t : texture_cube_array<f32>, s : sampler, coords : vec3<f32>, 
   <tr><td>`offset`<td>
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
-  texture wrapping modes. <br>
+  texture wrapping modes.<br>
   `offset` must be compile time constant, and may only be provided as a
-  [literal](#literals), [`const_expr`](https://gpuweb.github.io/gpuweb/wgsl.html#module-constants) or from a
-  [`const`](https://gpuweb.thub.io/gpuweb/wgsl.html#variables)
-  variable.
-  `offset` values must range from `[-8..7]` in all dimensions. Values outside of
-  this range will be treated as a compile time error.
+  [module constant](#module-constants), [literal](#literals) or
+  `const_expr` expression (e.g. `vec2<i32>(1, 2)`).<br>
+  Each `offset` component must be at least `-8` and at most `7`. Values outside
+  of this range will be treated as a compile time error.
 </table>
 
 **Returns:**
@@ -4669,13 +4668,12 @@ textureSampleLevel(t : texture_depth_cube_array, s : sampler, coords : vec3<f32>
   <tr><td>`offset`<td>
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
-  texture wrapping modes. <br>
+  texture wrapping modes.<br>
   `offset` must be compile time constant, and may only be provided as a
-  [literal](#literals), [`const_expr`](https://gpuweb.github.io/gpuweb/wgsl.html#module-constants) or from a
-  [`const`](https://gpuweb.thub.io/gpuweb/wgsl.html#variables)
-  variable.
-  `offset` values must range from `[-8..7]` in all dimensions. Values outside of
-  this range will be treated as a compile time error.
+  [module constant](#module-constants), [literal](#literals) or
+  `const_expr` expression (e.g. `vec2<i32>(1, 2)`).<br>
+  Each `offset` component must be at least `-8` and at most `7`. Values outside
+  of this range will be treated as a compile time error.
 </table>
 
 **Returns:**
@@ -4716,13 +4714,12 @@ textureSampleGrad(t : texture_cube_array<f32>, s : sampler, coords : vec3<f32>, 
   <tr><td>`offset`<td>
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
-  texture wrapping modes. <br>
+  texture wrapping modes.<br>
   `offset` must be compile time constant, and may only be provided as a
-  [literal](#literals), [`const_expr`](https://gpuweb.github.io/gpuweb/wgsl.html#module-constants) or from a
-  [`const`](https://gpuweb.thub.io/gpuweb/wgsl.html#variables)
-  variable.
-  `offset` values must range from `[-8..7]` in all dimensions. Values outside of
-  this range will be treated as a compile time error.
+  [module constant](#module-constants), [literal](#literals) or
+  `const_expr` expression (e.g. `vec2<i32>(1, 2)`).<br>
+  Each `offset` component must be at least `-8` and at most `7`. Values outside
+  of this range will be treated as a compile time error.
 </table>
 
 **Returns:**
@@ -4759,13 +4756,12 @@ textureSampleCompare(t : texture_depth_cube_array, s : sampler_comparison, coord
   <tr><td>`offset`<td>
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
-  texture wrapping modes. <br>
+  texture wrapping modes.<br>
   `offset` must be compile time constant, and may only be provided as a
-  [literal](#literals), [`const_expr`](https://gpuweb.github.io/gpuweb/wgsl.html#module-constants) or from a
-  [`const`](https://gpuweb.thub.io/gpuweb/wgsl.html#variables)
-  variable.
-  `offset` values must range from `[-8..7]` in all dimensions. Values outside of
-  this range will be treated as a compile time error.
+  [module constant](#module-constants), [literal](#literals) or
+  `const_expr` expression (e.g. `vec2<i32>(1, 2)`).<br>
+  Each `offset` component must be at least `-8` and at most `7`. Values outside
+  of this range will be treated as a compile time error.
 </table>
 
 **Returns:**

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4571,8 +4571,7 @@ textureSample(t : texture_depth_cube_array, s : sampler, coords : vec3<f32>, arr
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
   `offset` must be compile time constant, and may only be provided as a
-  [module constant](#module-constants), [literal](#literals) or
-  `const_expr` expression (e.g. `vec2<i32>(1, 2)`).<br>
+  [literal](#literals) or `const_expr` expression (e.g. `vec2<i32>(1, 2)`).<br>
   Each `offset` component must be at least `-8` and at most `7`. Values outside
   of this range will be treated as a compile time error.
 </table>
@@ -4616,8 +4615,7 @@ textureSampleBias(t : texture_cube_array<f32>, s : sampler, coords : vec3<f32>, 
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
   `offset` must be compile time constant, and may only be provided as a
-  [module constant](#module-constants), [literal](#literals) or
-  `const_expr` expression (e.g. `vec2<i32>(1, 2)`).<br>
+  [literal](#literals) or `const_expr` expression (e.g. `vec2<i32>(1, 2)`).<br>
   Each `offset` component must be at least `-8` and at most `7`. Values outside
   of this range will be treated as a compile time error.
 </table>
@@ -4670,8 +4668,7 @@ textureSampleLevel(t : texture_depth_cube_array, s : sampler, coords : vec3<f32>
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
   `offset` must be compile time constant, and may only be provided as a
-  [module constant](#module-constants), [literal](#literals) or
-  `const_expr` expression (e.g. `vec2<i32>(1, 2)`).<br>
+  [literal](#literals) or `const_expr` expression (e.g. `vec2<i32>(1, 2)`).<br>
   Each `offset` component must be at least `-8` and at most `7`. Values outside
   of this range will be treated as a compile time error.
 </table>
@@ -4716,8 +4713,7 @@ textureSampleGrad(t : texture_cube_array<f32>, s : sampler, coords : vec3<f32>, 
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
   `offset` must be compile time constant, and may only be provided as a
-  [module constant](#module-constants), [literal](#literals) or
-  `const_expr` expression (e.g. `vec2<i32>(1, 2)`).<br>
+  [literal](#literals) or `const_expr` expression (e.g. `vec2<i32>(1, 2)`).<br>
   Each `offset` component must be at least `-8` and at most `7`. Values outside
   of this range will be treated as a compile time error.
 </table>
@@ -4758,8 +4754,7 @@ textureSampleCompare(t : texture_depth_cube_array, s : sampler_comparison, coord
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
   `offset` must be compile time constant, and may only be provided as a
-  [module constant](#module-constants), [literal](#literals) or
-  `const_expr` expression (e.g. `vec2<i32>(1, 2)`).<br>
+  [literal](#literals) or `const_expr` expression (e.g. `vec2<i32>(1, 2)`).<br>
   Each `offset` component must be at least `-8` and at most `7`. Values outside
   of this range will be treated as a compile time error.
 </table>


### PR DESCRIPTION
Issue: #1235 