### PR TITLE
Specify [=debug label=].

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -497,12 +497,7 @@ interface mixin GPUObjectBase {
 <dl dfn-type=attribute dfn-for=GPUObjectBase>
     : <dfn>label</dfn>
     ::
-        A label which can be used by development tools (such as error/warning messages,
-        browser developer tools, or platform debugging utilities) to identify the underlying
-        [=internal object=] to the developer.
-        It has no specified format, and therefore cannot be reliably machine-parsed.
-
-        In any given situation, the user agent may or may not choose to use this label.
+        A [=debug label=] identifing the underlying [=internal object=].
 </dl>
 
 {{GPUObjectBase}} has the following internal slots:
@@ -512,6 +507,29 @@ interface mixin GPUObjectBase {
     ::
         An internal slot holding the [=device=] which owns the [=internal object=].
 </dl>
+
+{{GPUObjectDescriptorBase}} has the following members:
+
+<dl dfn-type=dict-member dfn-for=GPUObjectDescriptorBase>
+    : <dfn>label</dfn>
+    ::
+        The initial value of {{GPUObjectBase/label|GPUObjectBase.label}}.
+</dl>
+
+
+: <dfn dfn>Debug label</dfn>
+:: A string provided for use by development tools (such as error/warning messages,
+    browser developer tools, or platform debugging utilities) to identify the underlying
+    [=internal object=], debug group, or debug marker to the developer.
+    It has no specified format, and implementations MUST NOT use label contents in heuristics.
+
+    Implementations SHOULD preserve labels, including length, punctuation,
+    and non-ASCII codepoints when forwarding to underlying APIs,
+    though this preservation might not always be possible, and is not guaranteed.
+    Implementations MAY truncate, lossily change charset, or completely ignore labels.
+    For example, an implementation may have no direct mapping from WebGPU concept to platform API concept,
+    or such a mapping may be too onerous.
+
 
 ### Object Descriptors ### {#object-descriptors}
 
@@ -523,14 +541,6 @@ dictionary GPUObjectDescriptorBase {
     USVString label;
 };
 </script>
-
-{{GPUObjectDescriptorBase}} has the following members:
-
-<dl dfn-type=dict-member dfn-for=GPUObjectDescriptorBase>
-    : <dfn>label</dfn>
-    ::
-        The initial value of {{GPUObjectBase/label|GPUObjectBase.label}}.
-</dl>
 
 ## Invalid Internal Objects &amp; Contagious Invalidity ## {#invalidity}
 
@@ -5162,7 +5172,7 @@ pass.
 
             **Arguments:**
             <pre class=argumentdef for="GPUProgrammablePassEncoder/pushDebugGroup(groupLabel)">
-                |groupLabel|: The label for the command group.
+                |groupLabel|: The [=debug label=] for the command group.
             </pre>
 
             **Returns:** {{undefined}}
@@ -5202,7 +5212,7 @@ pass.
 
             **Arguments:**
             <pre class=argumentdef for="GPUProgrammablePassEncoder/insertDebugMarker(markerLabel)">
-                markerLabel: The label to insert.
+                markerLabel: The [=debug label=] to insert.
             </pre>
 
             **Returns:** {{undefined}}


### PR DESCRIPTION
* We SHOULD preserve length/charset
* We MUST NOT use labels in (WebGPU-implementation) heuristics
* Note that there may be not clear mapping for a label.