### PR TITLE
Make the [[front_facing]] builtin a boolean.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4289,8 +4289,8 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
       <td>fragment
       <td>in
       <td>bool
-      <td width="50%">Non-zero when the current fragment is on a front-facing primitive.
-         Zero otherwise.
+      <td width="50%">True when the current fragment is on a front-facing primitive.
+         False otherwise.
          See [[WebGPU#dom-gpurasterizationstatedescriptor-frontface|WebGPU &sect; Rasterization State]].
 
   <tr><td>`frag_depth`

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4288,7 +4288,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
   <tr><td>`front_facing`
       <td>fragment
       <td>in
-      <td>u32
+      <td>bool
       <td width="50%">Non-zero when the current fragment is on a front-facing primitive.
          Zero otherwise.
          See [[WebGPU#dom-gpurasterizationstatedescriptor-frontface|WebGPU &sect; Rasterization State]].


### PR DESCRIPTION
In HLSL SV_IsFrontFace is a boolean.
In MSL [front_facing] is a boolean.
In SPIRV for Vulkan variables decorated with FrontFacing must be
declared as a boolean value.