### PR TITLE
Bools are IO-shareable, but only for builtins

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -490,7 +490,7 @@ The following types are <dfn dfn noexport>storable</dfn>:
 
 The following types are <dfn dfn noexport>IO-shareable</dfn>:
 
-* [=numeric scalar=] types
+* [=scalar=] types
 * [=numeric vector=] types
 * [[#matrix-types]]
 * [[#array-types]] if its element type is IO-shareable, and the array is not [=runtime-sized=]
@@ -501,6 +501,10 @@ The following kinds of values must be of IO-shareable type:
 * Values read from or written to built-in variables.
 * Values accepted as inputs from an upstream pipeline stage.
 * Values written as output for downstream processing in the pipeline, or to an output attachment.
+
+Note: Only built-in pipeline inputs may have a boolean type.
+A user data attribute input or output must not be of [=bool=] type or contain a [=bool=] type.
+See [[#pipeline-inputs-outputs]].
 
 ### Host-shareable Types ### {#host-shareable-types}
 
@@ -537,8 +541,9 @@ The following types are <dfn dfn noexport>host-shareable</dfn>:
          of this member.
 </table>
 
-Note: An [=IO-shareable=] type would also be host-shareable if it and its subtypes have
-the approporate [=stride=] and [=offset=] attributes.
+Note: An [=IO-shareable=] type *T* would also be host-shareable if *T* and its subtypes have
+appropriate [=stride=] and [=offset=] attributes, and if *T* is not [=bool=] and did
+not contain a [=bool=].
 Additionally, a [=runtime-sized=] array is host-shareable but is not IO-shareable.
 
 Note: Both IO-shareable and host-shareable types have concrete sizes, but counted differently.
@@ -3678,6 +3683,8 @@ Issue:
     2. On the other hand, in Vulkan, builtin variables occoupy I/O location slots (counting toward limits),
 
 #### User Data Attribute TODO #### {#user-data-attributes}
+
+TODO: User data attributes must not be of [=bool=] type or contain a [=bool=] type.
 
 #### Input-output Locations TODO #### {#input-output-locations}
 TODO: *Stub*. Location-sizing of types, non-overlap among variables referenced within an entry point static call tree.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -503,7 +503,7 @@ The following kinds of values must be of IO-shareable type:
 * Values written as output for downstream processing in the pipeline, or to an output attachment.
 
 Note: Only built-in pipeline inputs may have a boolean type.
-A user data attribute input or output must not be of [=bool=] type or contain a [=bool=] type.
+A user input or output data attribute must not be of [=bool=] type or contain a [=bool=] type.
 See [[#pipeline-inputs-outputs]].
 
 ### Host-shareable Types ### {#host-shareable-types}
@@ -542,7 +542,7 @@ The following types are <dfn dfn noexport>host-shareable</dfn>:
 </table>
 
 Note: An [=IO-shareable=] type *T* would also be host-shareable if *T* and its subtypes have
-appropriate [=stride=] and [=offset=] attributes, and if *T* is not [=bool=] and did
+appropriate [=stride=] and [=offset=] attributes, and if *T* is not [=bool=] and does
 not contain a [=bool=].
 Additionally, a [=runtime-sized=] array is host-shareable but is not IO-shareable.
 


### PR DESCRIPTION
Fixes #1244