### PR TITLE
[wgsl] add validation rule: "v-0029: return must come last in its block"

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4243,6 +4243,7 @@ the test name.
 * v-0026: The case selector values must have the same type as the selector expression.
 * v-0027: A literal value must not appear more than once in the case selectors for a switch statement.
 * v-0028: A fallthrough statement must not appear as the last statement in last clause of a switch.
+* v-0029: Return must come last in its block.
 
 
 # Built-in variables # {#builtin-variables}


### PR DESCRIPTION
As we decided in the issue https://github.com/gpuweb/gpuweb/issues/996, it is invalid to have dead code after a return statement.