### PR TITLE
[wgsl] Add runtime-sized array validation rules

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4226,6 +4226,11 @@ the test name.
 * v-0027: A literal value must not appear more than once in the case selectors for a switch statement.
 * v-0028: A fallthrough statement must not appear as the last statement in last clause of a switch.
 * v-0029: Return must come last in its block.
+* v-0030: If a runtime-sized array appears inside the store type for a variable, then that variable
+          store type must be for a storage buffer variable.
+* v-0031: A runtime-sized array must not be the store type of a variable.
+* v-0032: A runtime-sized array must have a stride attribute.
+
 
 # Built-in variables # {#builtin-variables}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4211,7 +4211,8 @@ the test name.
 * v-0008: switch statements must have exactly one default clause.
 * v-0009: Break is only permitted in loop and switch constructs.
 * v-0010: continue is only permitted in loop.
-* v-0015: Runtime arrays may only appear as the last member of a struct.
+* v-0015: The last member of the structure type defining the "store type" for variable in the
+          storage storage class may be a runtime-sized array.
 * v-0017: Builtin decorations must have the correct types.
 * v-0018: Builtin decorations must be used with the correct shader type and
           storage class.
@@ -4226,9 +4227,9 @@ the test name.
 * v-0027: A literal value must not appear more than once in the case selectors for a switch statement.
 * v-0028: A fallthrough statement must not appear as the last statement in last clause of a switch.
 * v-0029: Return must come last in its block.
-* v-0030: If a runtime-sized array appears inside the store type for a variable, then that variable
-          store type must be for a storage buffer variable.
-* v-0031: A runtime-sized array must not be the store type of a variable.
+* v-0030: A runtime-sized array must not be used as the store type or contained within a store type
+          except as allowed by v-0015.
+* v-0031: The type of an expression must not be a runtime-sized array type.
 * v-0032: A runtime-sized array must have a stride attribute.
 
 


### PR DESCRIPTION
Here are my proposed validation rules for runtime-sized arrays:
v-0015: The last member of the structure type defining the "store type" for variable in the storage storage class may be a runtime-sized array.
v-0030: A runtime-sized array must not be used as the store type or contained within a store type except as allowed by v-0015
v-0031: The type of an expression must not be a runtime-sized array type.
v-0032: A runtime-sized array must have a stride attribute.