### PR TITLE
WGSL: idx -> index

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4254,7 +4254,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
     <tr><th>Built-in<th>Stage<th>Input or Output<th>Store type<th>Description
   </thead>
 
-  <tr><td>`vertex_idx`
+  <tr><td>`vertex_index`
       <td>vertex
       <td>in
       <td>u32
@@ -4268,7 +4268,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
          For an indexed draw, the index is equal to the index buffer entry for
          vertex, plus the `baseVertex` argument of the draw, whether provided directly or indirectly.
 
-  <tr><td>`instance_idx`
+  <tr><td>`instance_index`
       <td>vertex
       <td>in
       <td>u32
@@ -4348,21 +4348,21 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
   </xmp>
 </div>
 
-<div class='example' heading="Example built-in variable: vertex_idx">
+<div class='example' heading="Example built-in variable: vertex_index">
   <xmp>
-    [[builtin(vertex_idx)]] var<in> my_idx : u32;
+    [[builtin(vertex_index)]] var<in> my_index : u32;
 
-    #   OpDecorate %my_idx BuiltIn VertexIndex
+    #   OpDecorate %my_index BuiltIn VertexIndex
     #   %uint = OpTypeInt 32 0
     #   %ptr = OpTypePointer Input %uint
-    #   %my_idx = OpVariable %ptr Input
+    #   %my_index = OpVariable %ptr Input
 
   </xmp>
 </div>
 
 <div class='example' heading="Declaring other built-in variables">
   <xmp>
-    [[builtin(instance_idx)]] var<in> my_inst_idx : u32;
+    [[builtin(instance_index)]] var<in> my_inst_index : u32;
     #    OpDecorate %gl_InstanceId BuiltIn InstanceIndex
 
     [[builtin(front_facing)]] var<in> is_front : u32;
@@ -4377,7 +4377,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
     [[builtin(local_invocation_id)]] var<in> local_id : vec3<u32>;
     #     OpDecorate %gl_LocalInvocationID BuiltIn LocalInvocationId
 
-    [[builtin(local_invocation_idx)]] var<in> local_idx : u32;
+    [[builtin(local_invocation_index)]] var<in> local_index : u32;
     #     OpDecorate %gl_LocalInvocationIndex BuiltIn LocalInvocationIndex
 
     [[builtin(global_invocation_id)]] var<in> global_id : vec3<u32>;


### PR DESCRIPTION
Fixes #1253
This is more consistent with the naming in platform APIs and the saving
of 2 characters to type doesn't seem worth the weirdness.