### PR TITLE
Rename minBufferBindingSize

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -305,7 +305,7 @@ that guarantees that the access is limited to buffer bounds.
 
 Alternatively, an implementation may transform the shader code by inserting manual bounds checks.
 When this path is taken, the out-of-bound checks only apply to array indexing. They aren't needed
-for plain field access of shader structures due to the {{GPUBufferBindingLayout/minBufferBindingSize}}
+for plain field access of shader structures due to the {{GPUBufferBindingLayout/minBindingSize}}
 validation on the host side.
 
 If the shader attempts to load data outside of [=physical resource=] bounds,
@@ -2603,7 +2603,7 @@ enum GPUBufferType {
 dictionary GPUBufferBindingLayout {
     GPUBufferType type = "uniform";
     boolean hasDynamicOffset = false;
-    GPUSize64 minBufferBindingSize = 0;
+    GPUSize64 minBindingSize = 0;
 };
 </script>
 
@@ -2618,7 +2618,7 @@ dictionary GPUBufferBindingLayout {
     ::
         Indicates whether this binding requires a dynamic offset.
 
-    : <dfn>minBufferBindingSize</dfn>
+    : <dfn>minBindingSize</dfn>
     ::
         May be used to indicate the minimum buffer binding size.
 </dl>
@@ -2976,13 +2976,13 @@ A {{GPUBindGroup}} object has the following internal slots:
                                             - |resource|.{{GPUBufferBinding/buffer}} is [$valid to use with$] |this|.
                                             - The bound part designated by |resource|.{{GPUBufferBinding/offset}} and
                                                 |resource|.{{GPUBufferBinding/size}} resides inside the buffer.
-                                            - If |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBufferBindingSize}}
+                                            - If |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}}
                                                 is not `undefined`:
                                                 - The effective binding size, that is either explict in
                                                     |resource|.{{GPUBufferBinding/size}} or derived from
                                                     |resource|.{{GPUBufferBinding/offset}} and the full
                                                     size of the buffer, is greater than or equal to
-                                                    |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBufferBindingSize}}.
+                                                    |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}}.
 
                                             - If |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/type}} is
                                                 <dl class="switch">
@@ -3334,7 +3334,7 @@ has a default layout created and used instead.
 
                 1. Let |bufferLayout| be a new {{GPUBufferBindingLayout}}.
 
-                1. Set |bufferLayout|.{{GPUBufferBindingLayout/minBufferBindingSize}} to |resource|'s minimum buffer binding size.
+                1. Set |bufferLayout|.{{GPUBufferBindingLayout/minBindingSize}} to |resource|'s minimum buffer binding size.
 
                     Issue: link to a definition for "minimum buffer binding size" in the "reflection information".
 
@@ -3383,11 +3383,11 @@ has a default layout created and used instead.
                     1. Add the bits set in |entry|.{{GPUBindGroupLayoutEntry/visibility}} into |previousEntry|.{{GPUBindGroupLayoutEntry/visibility}}
 
                 1. If |resource| is for a buffer binding and |entry| has greater
-                    {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBufferBindingSize}}
+                    {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}}
                     than |previousEntry|:
 
-                    1. Set |previousEntry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBufferBindingSize}}
-                        to |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBufferBindingSize}}.
+                    1. Set |previousEntry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}}
+                        to |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}}.
 
                 1. If any other property is unequal between |entry| and |previousEntry|:
 
@@ -3463,12 +3463,12 @@ A {{GPUProgrammableStageDescriptor}} describes the entry point in the user-provi
                         : {{GPUBufferType/"readonly-storage"}}
                         :: The |binding| is a read-only storage buffer.
                     </dl>
-                :: If |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBufferBindingSize}} is not `0`:
+                :: If |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}} is not `0`:
                     - If the last field of the corresponding structure defined in the shader has an unbounded array type,
-                        then the value of |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBufferBindingSize}}
+                        then the value of |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}}
                         must be greater than or equal to the byte offset of that field plus the stride of the unbounded array.
                     - If the corresponding shader structure doesn't end with an unbounded array type,
-                        then the value of |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBufferBindingSize}}
+                        then the value of |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}}
                         must be greater than or equal to the size of the structure.
 
                 : {{GPUBindGroupLayoutEntry/sampler}}
@@ -5153,12 +5153,12 @@ interface mixin GPUProgrammablePassEncoder {
                             |bindGroup|.{{GPUBindGroup/[[layout]]}}.{{GPUBindGroupLayout/[[dynamicOffsetCount]]}}.
 
                         - [$Iterate over each dynamic binding offset$] in |bindGroup| and
-                            run the following steps for each |bufferBinding|, |minBufferBindingSize|,
+                            run the following steps for each |bufferBinding|, |minBindingSize|,
                             and |dynamicOffsetIndex|:
 
                             - Let |bufferDynamicOffset| be |dynamicOffsets|[|dynamicOffsetIndex|].
                             - |bufferBinding|.{{GPUBufferBinding/offset}} + |bufferDynamicOffset| +
-                                |minBufferBindingSize| &le;
+                                |minBindingSize| &le;
                                 |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBuffer/[[size]]}}.
                     </div>
                 1. Set |this|.{{GPUProgrammablePassEncoder/[[bind_groups]]}}[|index|] to be |bindGroup|.
@@ -5197,13 +5197,13 @@ interface mixin GPUProgrammablePassEncoder {
                         - |dynamicOffsetsDataStart| + |dynamicOffsetsDataLength| &le; |dynamicOffsetsData|.length.
 
                         - [$Iterate over each dynamic binding offset$] in |bindGroup| and
-                            run the following steps for each |bufferBinding|, |minBufferBindingSize|,
+                            run the following steps for each |bufferBinding|, |minBindingSize|,
                             and |dynamicOffsetIndex|:
 
                             - Let |bufferDynamicOffset| be
                                 |dynamicOffsetsData|[|dynamicOffsetIndex| + |dynamicOffsetsDataStart|].
                             - |bufferBinding|.{{GPUBufferBinding/offset}} + |bufferDynamicOffset| +
-                                |minBufferBindingSize| &le;
+                                |minBindingSize| &le;
                                 |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBuffer/[[size]]}}.
                     </div>
                 1. Set |this|.{{GPUProgrammablePassEncoder/[[bind_groups]]}}[|index|] to be |bindGroup|.
@@ -5223,8 +5223,8 @@ interface mixin GPUProgrammablePassEncoder {
         1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/buffer}} is not `undefined` and
             |bindingDescriptor|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}} is `true`:
             1. Let |bufferBinding| be |entry|.{{GPUBindGroupEntry/resource}}.
-            1. Let |minBufferBindingSize| be |bindingDescriptor|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBufferBindingSize}}.
-            1. Call |steps| with |bufferBinding|, |minBufferBindingSize|, and |dynamicOffsetIndex|.
+            1. Let |minBindingSize| be |bindingDescriptor|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}}.
+            1. Call |steps| with |bufferBinding|, |minBindingSize|, and |dynamicOffsetIndex|.
             1. Let |dynamicOffsetIndex| be |dynamicOffsetIndex| + `1`
 </div>
 
@@ -5246,7 +5246,7 @@ interface mixin GPUProgrammablePassEncoder {
                 - |bindGroup| must not be `null`.
                 - |bindGroup|.{{GPUBindGroup/[[layout]]}} must be [=group-equivalent=] with |bindGroupLayout|.
 
-            Issue: Check buffer bindings against `minBufferBindingSize` if present.
+            Issue: Check buffer bindings against `minBindingSize` if present.
         </div>
 
     Otherwise return `true`.


### PR DESCRIPTION
Since it's now a part of `GPUBufferBindingLayout`, the fact that it only applies to buffers is implied.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/1255.html" title="Last updated on Nov 25, 2020, 4:31 AM UTC (c743a01)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1255/f8f9ed9...kvark:c743a01.html" title="Last updated on Nov 25, 2020, 4:31 AM UTC (c743a01)">Diff</a>