### PR TITLE
Rename binding types

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -290,7 +290,7 @@ shader to first do a clear across all invocations, synchronize them, and continu
 ## Out-of-bounds access in shaders ## {#security-shader}
 
 [=Shader=]s can access [=physical resource=]s either directly
-(for example, as a {{GPUBufferType/"uniform"}} {{GPUBufferBinding}}), or via <dfn dfn>texture unit</dfn>s,
+(for example, as a {{GPUBufferBindingType/"uniform"}} {{GPUBufferBinding}}), or via <dfn dfn>texture unit</dfn>s,
 which are fixed-function hardware blocks that handle texture coordinate conversions.
 Validation on the API side can only guarantee that all the inputs to the shader are provided and
 they have the correct usage and types.
@@ -957,7 +957,7 @@ a better limit is not specified.
     <tr class=row-continuation><td colspan=4>
         The maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
 
-          - [%Layout entry binding type%] is {{GPUBufferType/"uniform"}}, and
+          - [%Layout entry binding type%] is {{GPUBufferBindingType/"uniform"}}, and
           - {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}} is `true`,
 
         across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
@@ -968,7 +968,7 @@ a better limit is not specified.
     <tr class=row-continuation><td colspan=4>
         The maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
 
-          - [%Layout entry binding type%] is {{GPUBufferType/"storage"}}, and
+          - [%Layout entry binding type%] is {{GPUBufferBindingType/"storage"}}, and
           - {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}} is `true`,
 
         across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
@@ -1004,7 +1004,7 @@ a better limit is not specified.
         For each possible {{GPUShaderStage}} `stage`,
         the maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
 
-          - [%Layout entry binding type%] is {{GPUBufferType/"storage"}}, and
+          - [%Layout entry binding type%] is {{GPUBufferBindingType/"storage"}}, and
           - {{GPUBindGroupLayoutEntry/visibility}} includes `stage`,
 
         across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
@@ -1028,7 +1028,7 @@ a better limit is not specified.
         For each possible {{GPUShaderStage}} `stage`,
         the maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
 
-          - [%Layout entry binding type%] is {{GPUBufferType/"uniform"}}, and
+          - [%Layout entry binding type%] is {{GPUBufferBindingType/"uniform"}}, and
           - {{GPUBindGroupLayoutEntry/visibility}} includes `stage`,
 
         across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
@@ -1038,13 +1038,13 @@ a better limit is not specified.
         <td>{{GPUSize32}} <td>Higher <td>16384
     <tr class=row-continuation><td colspan=4>
         The maximum {{GPUBufferBinding}}.{{GPUBufferBinding/size}} for bindings for which the
-        [%Layout entry binding type%] is {{GPUBufferType/"uniform"}}.
+        [%Layout entry binding type%] is {{GPUBufferBindingType/"uniform"}}.
 
     <tr><td><dfn>maxStorageBufferBindingSize</dfn>
         <td>{{GPUSize32}} <td>Higher <td> 134217728 (128 MiB)
     <tr class=row-continuation><td colspan=4>
         The maximum {{GPUBufferBinding}}.{{GPUBufferBinding/size}} for bindings for which the
-        [%Layout entry binding type%] is {{GPUBufferType/"storage"}} or {{GPUBufferType/"readonly-storage"}}.
+        [%Layout entry binding type%] is {{GPUBufferBindingType/"storage"}} or {{GPUBufferBindingType/"readonly-storage"}}.
 </table>
 
 #### <dfn dictionary>GPULimits</dfn> #### {#gpulimits}
@@ -2531,43 +2531,43 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
     <tr>
         <td rowspan=3>{{GPUBindGroupLayoutEntry/buffer}}
         <td rowspan=3>{{GPUBufferBinding}}
-        <td>{{GPUBufferType/"uniform"}}
+        <td>{{GPUBufferBindingType/"uniform"}}
         <td>[=internal usage/constant=]
     <tr>
-        <td>{{GPUBufferType/"storage"}}
+        <td>{{GPUBufferBindingType/"storage"}}
         <td>[=internal usage/storage=]
     <tr>
-        <td>{{GPUBufferType/"readonly-storage"}}
+        <td>{{GPUBufferBindingType/"readonly-storage"}}
         <td>[=internal usage/storage-read=]
 
     <tr>
         <td rowspan=3>{{GPUBindGroupLayoutEntry/sampler}}
         <td rowspan=3>{{GPUSampler}}
-        <td>{{GPUSamplerType/"filtering"}}
+        <td>{{GPUSamplerBindingType/"filtering"}}
         <td>[=internal usage/constant=]
     <tr>
-        <td>{{GPUSamplerType/"non-filtering"}}
+        <td>{{GPUSamplerBindingType/"non-filtering"}}
         <td>[=internal usage/constant=]
     <tr>
-        <td>{{GPUSamplerType/"comparison"}}
+        <td>{{GPUSamplerBindingType/"comparison"}}
         <td>[=internal usage/constant=]
 
     <tr>
         <td rowspan=3>{{GPUBindGroupLayoutEntry/texture}}
         <td rowspan=3>{{GPUTextureView}}
-        <td>{{GPUTextureSampleType/"float"}}
+        <td>{{GPUTextureBindingType/"float"}}
         <td>[=internal usage/constant=]
     <tr>
-        <td>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureBindingType/"unfilterable-float"}}
         <td>[=internal usage/constant=]
     <tr>
-        <td>{{GPUTextureSampleType/"depth"}}
+        <td>{{GPUTextureBindingType/"depth"}}
         <td>[=internal usage/constant=]
     <tr>
-        <td>{{GPUTextureSampleType/"sint"}}
+        <td>{{GPUTextureBindingType/"sint"}}
         <td>[=internal usage/constant=]
     <tr>
-        <td>{{GPUTextureSampleType/"uint"}}
+        <td>{{GPUTextureBindingType/"uint"}}
         <td>[=internal usage/constant=]
 
     <tr>
@@ -2590,18 +2590,18 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
     1. If |entry|.{{GPUBindGroupLayoutEntry/texture}} is not `undefined`:
         1. Return |entry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/type}}.
     1. If |entry|.{{GPUBindGroupLayoutEntry/storageTexture}} is not `undefined`:
-        1. Return |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/type}}.
+        1. Return |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/access}}.
 </div>
 
 <script type=idl>
-enum GPUBufferType {
+enum GPUBufferBindingType {
     "uniform",
     "storage",
     "readonly-storage",
 };
 
 dictionary GPUBufferBindingLayout {
-    GPUBufferType type = "uniform";
+    GPUBufferBindingType type = "uniform";
     boolean hasDynamicOffset = false;
     GPUSize64 minBufferBindingSize = 0;
 };
@@ -2624,14 +2624,14 @@ dictionary GPUBufferBindingLayout {
 </dl>
 
 <script type=idl>
-enum GPUSamplerType {
+enum GPUSamplerBindingType {
     "filtering",
     "non-filtering",
     "comparison",
 };
 
 dictionary GPUSamplerBindingLayout {
-    GPUSamplerType type = "filtering";
+    GPUSamplerBindingType type = "filtering";
 };
 </script>
 
@@ -2644,7 +2644,7 @@ dictionary GPUSamplerBindingLayout {
 </dl>
 
 <script type=idl>
-enum GPUTextureSampleType {
+enum GPUTextureBindingType {
   "float",
   "unfilterable-float",
   "depth",
@@ -2653,7 +2653,7 @@ enum GPUTextureSampleType {
 };
 
 dictionary GPUTextureBindingLayout {
-    GPUTextureSampleType type = "float";
+    GPUTextureBindingType type = "float";
     GPUTextureViewDimension viewDimension = "2d";
     boolean multisampled = false;
 };
@@ -2690,7 +2690,7 @@ enum GPUStorageTextureAccess {
 };
 
 dictionary GPUStorageTextureBindingLayout {
-    required GPUStorageTextureAccess type;
+    required GPUStorageTextureAccess access;
     required GPUTextureFormat format;
     GPUTextureViewDimension viewDimension = "2d";
 };
@@ -2702,7 +2702,7 @@ truly optional.
 {{GPUStorageTextureBindingLayout}} dictionaries have the following members:
 
 <dl dfn-type=dict-member dfn-for=GPUStorageTextureBindingLayout>
-    : <dfn>type</dfn>
+    : <dfn>access</dfn>
     ::
         Indicates whether texture views bound to this binding will be bound for read-only or
         write-only access.
@@ -2757,10 +2757,10 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                             - |this| is a [=valid=] {{GPUDevice}}.
                             - The {{GPUBindGroupLayoutEntry/binding}} of each entry in |descriptor| is unique.
                             - For each shader stage, the number of entries in |descriptor| with a [$layout entry binding type$] of
-                                {{GPUBufferType/"uniform"}} &le;
+                                {{GPUBufferBindingType/"uniform"}} &le;
                                 {{GPULimits/maxUniformBuffersPerShaderStage|GPULimits.maxUniformBuffersPerShaderStage}}.
                             - For each shader stage, the number of entries in |descriptor| with a [$layout entry binding type$] of
-                                {{GPUBufferType/"storage"}} &le;
+                                {{GPUBufferBindingType/"storage"}} &le;
                                 {{GPULimits/maxStorageBuffersPerShaderStage|GPULimits.maxStorageBuffersPerShaderStage}}.
                             - For each shader stage, the number of entries in |descriptor| with a [=binding member=] of
                                 {{GPUBindGroupLayoutEntry/texture}} &le;
@@ -2772,10 +2772,10 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                                 {{GPUBindGroupLayoutEntry/sampler}} &le;
                                 {{GPULimits/maxSamplersPerShaderStage|GPULimits.maxSamplersPerShaderStage}}.
                             - The number of entries in |descriptor| with a [$layout entry binding type$] of
-                                {{GPUBufferType/"uniform"}} and {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}} `true` &le;
+                                {{GPUBufferBindingType/"uniform"}} and {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}} `true` &le;
                                 {{GPULimits/maxDynamicUniformBuffersPerPipelineLayout|GPULimits.maxDynamicUniformBuffersPerPipelineLayout}}.
                             - The number of entries in |descriptor| with a [$layout entry binding type$] of
-                                {{GPUBufferType/"storage"}} and {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}} `true` &le;
+                                {{GPUBufferBindingType/"storage"}} and {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}} `true` &le;
                                 {{GPULimits/maxDynamicStorageBuffersPerPipelineLayout|GPULimits.maxDynamicStorageBuffersPerPipelineLayout}}.
 
                             - For each {{GPUBindGroupLayoutEntry}} |bindingDescriptor| in |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
@@ -2790,14 +2790,14 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                                 - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/visibility}} includes
                                     {{GPUShaderStage/VERTEX}}:
                                     - The [$layout entry binding type$] of |bindingDescriptor| is not
-                                        {{GPUBufferType/"readonly-storage"}} or {{GPUStorageTextureAccess/"writeonly"}}.
+                                        {{GPUBufferBindingType/"readonly-storage"}} or {{GPUStorageTextureAccess/"writeonly"}}.
 
                                 - If the |textureLayout| is not `undefined` and
                                     |textureLayout|.{{GPUTextureBindingLayout/multisampled}} is `true`:
                                     - |textureLayout|.{{GPUTextureBindingLayout/viewDimension}} is
                                         {{GPUTextureViewDimension/"2d"}}.
                                     - |textureLayout|.{{GPUTextureBindingLayout/type}} is not
-                                        {{GPUTextureSampleType/"float"}}.
+                                        {{GPUTextureBindingType/"float"}}.
 
                                 - If |storageTextureLayout| is not `undefined`:
                                     - |storageTextureLayout|.{{GPUStorageTextureBindingLayout/viewDimension}} is not
@@ -2938,10 +2938,10 @@ A {{GPUBindGroup}} object has the following internal slots:
                                             - |resource| is [$valid to use with$] |this|.
                                             - If the [$layout entry binding type$] of |layoutBinding| is
                                                 <dl class="switch">
-                                                    : {{GPUSamplerType/"filtering"}} or {{GPUSamplerType/"non-filtering"}}
+                                                    : {{GPUSamplerBindingType/"filtering"}} or {{GPUSamplerBindingType/"non-filtering"}}
                                                     :: |resource|.{{GPUSampler/[[compareEnable]]}} is `false`.
 
-                                                    : {{GPUSamplerType/"comparison"}}
+                                                    : {{GPUSamplerBindingType/"comparison"}}
                                                     :: |resource|.{{GPUSampler/[[compareEnable]]}} is `true`.
                                                 </dl>
 
@@ -2986,7 +2986,7 @@ A {{GPUBindGroup}} object has the following internal slots:
 
                                             - If |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/type}} is
                                                 <dl class="switch">
-                                                    : {{GPUBufferType/"uniform"}}
+                                                    : {{GPUBufferBindingType/"uniform"}}
                                                     :: |resource|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
                                                         includes {{GPUBufferUsage/UNIFORM}}.
                                                     :: |resource|.{{GPUBufferBinding/size}} &le; {{GPULimits/maxUniformBufferBindingSize}}.
@@ -2994,8 +2994,8 @@ A {{GPUBindGroup}} object has the following internal slots:
                                                         Also should {{GPUBufferBinding/size}} default to the `buffer.byteLength - offset` or
                                                         `min(buffer.byteLength - offset, limits.maxUniformBufferBindingSize)`?
 
-                                                    : {{GPUBufferType/"storage"}} or
-                                                        {{GPUBufferType/"readonly-storage"}}
+                                                    : {{GPUBufferBindingType/"storage"}} or
+                                                        {{GPUBufferBindingType/"readonly-storage"}}
                                                     :: |resource|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
                                                         includes {{GPUBufferUsage/STORAGE}}.
                                                     :: |resource|.{{GPUBufferBinding/size}} &le; {{GPULimits/maxStorageBufferBindingSize}}.
@@ -3327,7 +3327,7 @@ has a default layout created and used instead.
             1. If |resource| is for a comparison sampler binding:
 
                 1. Let |samplerLayout| be a new {{GPUSamplerBindingLayout}}.
-                1. Set |samplerLayout|.{{GPUSamplerBindingLayout/type}} to {{GPUSamplerType/"comparison"}}.
+                1. Set |samplerLayout|.{{GPUSamplerBindingLayout/type}} to {{GPUSamplerBindingType/"comparison"}}.
                 1. Set |entry|.{{GPUBindGroupLayoutEntry/sampler}} to |samplerLayout|.
 
             1. If |resource| is for a buffer binding:
@@ -3340,11 +3340,11 @@ has a default layout created and used instead.
 
                 1. If |resource| is for a read-only storage buffer:
 
-                    1. Set |bufferLayout|.{{GPUBufferBindingLayout/type}} to {{GPUBufferType/"readonly-storage"}}.
+                    1. Set |bufferLayout|.{{GPUBufferBindingLayout/type}} to {{GPUBufferBindingType/"readonly-storage"}}.
 
                 1. If |resource| is for a storage buffer:
 
-                    1. Set |bufferLayout|.{{GPUBufferBindingLayout/type}} to {{GPUBufferType/"storage"}}.
+                    1. Set |bufferLayout|.{{GPUBufferBindingLayout/type}} to {{GPUBufferBindingType/"storage"}}.
 
                 1. Set |entry|.{{GPUBindGroupLayoutEntry/buffer}} to |bufferLayout|.
 
@@ -3368,11 +3368,11 @@ has a default layout created and used instead.
 
                 1. If |resource| is for a read-only storage texture:
 
-                    1. Set |storageTextureLayout|.{{GPUStorageTextureBindingLayout/type}} to {{GPUStorageTextureAccess/"readonly"}}.
+                    1. Set |storageTextureLayout|.{{GPUStorageTextureBindingLayout/access}} to {{GPUStorageTextureAccess/"readonly"}}.
 
                 1. If |resource| is for a write-only storage texture:
 
-                    1. Set |storageTextureLayout|.{{GPUStorageTextureBindingLayout/type}} to {{GPUStorageTextureAccess/"writeonly"}}.
+                    1. Set |storageTextureLayout|.{{GPUStorageTextureBindingLayout/access}} to {{GPUStorageTextureAccess/"writeonly"}}.
 
                 1. Set |entry|.{{GPUBindGroupLayoutEntry/storageTexture}} to |storageTextureLayout|.
 
@@ -3456,11 +3456,11 @@ A {{GPUProgrammableStageDescriptor}} describes the entry point in the user-provi
                 : {{GPUBindGroupLayoutEntry/buffer}}
                 :: If |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/type}} is:
                     <dl class=switch>
-                        : {{GPUBufferType/"uniform"}}
+                        : {{GPUBufferBindingType/"uniform"}}
                         :: The |binding| is a uniform buffer.
-                        : {{GPUBufferType/"storage"}}
+                        : {{GPUBufferBindingType/"storage"}}
                         :: The |binding| is a storage buffer.
-                        : {{GPUBufferType/"readonly-storage"}}
+                        : {{GPUBufferBindingType/"readonly-storage"}}
                         :: The |binding| is a read-only storage buffer.
                     </dl>
                 :: If |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBufferBindingSize}} is not `0`:
@@ -3474,11 +3474,11 @@ A {{GPUProgrammableStageDescriptor}} describes the entry point in the user-provi
                 : {{GPUBindGroupLayoutEntry/sampler}}
                 :: If |entry|.{{GPUBindGroupLayoutEntry/sampler}}.{{GPUSamplerBindingLayout/type}} is:
                     <dl class=switch>
-                        : {{GPUSamplerType/"filtering"}}
+                        : {{GPUSamplerBindingType/"filtering"}}
                         :: the |binding| is a non-comparison sampler
-                        : {{GPUSamplerType/"non-filtering"}}
+                        : {{GPUSamplerBindingType/"non-filtering"}}
                         :: the |binding| is a non-comparison sampler
-                        : {{GPUSamplerType/"comparison"}}
+                        : {{GPUSamplerBindingType/"comparison"}}
                         :: the |binding| is a comparison sampler
                     </dl>
 
@@ -3496,7 +3496,7 @@ A {{GPUProgrammableStageDescriptor}} describes the entry point in the user-provi
                     |entry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/viewDimension}}.
 
                 : {{GPUBindGroupLayoutEntry/storageTexture}}
-                :: If |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/type}} is:
+                :: If |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/access}} is:
                     <dl class=switch>
                         : {{GPUStorageTextureAccess/"readonly"}}
                         :: The |binding| is a read-only storage texture.
@@ -3524,7 +3524,7 @@ and can be used in {{GPUComputePassEncoder}}.
 
 Compute inputs and outputs are all contained in the bindings,
 according to the given {{GPUPipelineLayout}}.
-The outputs correspond to {{GPUBindGroupLayoutEntry/buffer}} bindings with a type of {{GPUBufferType/"storage"}}
+The outputs correspond to {{GPUBindGroupLayoutEntry/buffer}} bindings with a type of {{GPUBufferBindingType/"storage"}}
 and {{GPUBindGroupLayoutEntry/storageTexture}} bindings with a type of {{GPUStorageTextureAccess/"writeonly"}}.
 
 Stages of a compute [=pipeline=]:
@@ -3621,8 +3621,8 @@ Render [=pipeline=] inputs are:
   - optionally, the depth-stencil attachment, described by {{GPUDepthStencilStateDescriptor}}
 
 Render [=pipeline=] outputs are:
-  - {{GPUBindGroupLayoutEntry/buffer}} bindings with a {{GPUBufferBindingLayout/type}} of {{GPUBufferType/"storage"}}
-  - {{GPUBindGroupLayoutEntry/storageTexture}} bindings with a {{GPUStorageTextureBindingLayout/type}} of {{GPUStorageTextureAccess/"writeonly"}}
+  - {{GPUBindGroupLayoutEntry/buffer}} bindings with a {{GPUBufferBindingLayout/type}} of {{GPUBufferBindingType/"storage"}}
+  - {{GPUBindGroupLayoutEntry/storageTexture}} bindings with a {{GPUStorageTextureBindingLayout/access}} of {{GPUStorageTextureAccess/"writeonly"}}
   - the color attachments, described by {{GPUColorStateDescriptor}}
   - optionally, depth-stencil attachment, described by {{GPUDepthStencilStateDescriptor}}
 
@@ -7209,7 +7209,7 @@ Issue: Add multisampling to the tables below.
 
 All plain color formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, and {{GPUTextureUsage/SAMPLED}} usage.
 
-Only formats with {{GPUTextureSampleType}} {{GPUTextureSampleType/"float"}} can be blended.
+Only formats with {{GPUTextureBindingType}} {{GPUTextureBindingType/"float"}} can be blended.
 
 The {{GPUTextureUsage/STORAGE|GPUTextureUsage.STORAGE}} column specifies the support for {{GPUTextureUsage/STORAGE}}
 usage in the core API, including both {{GPUStorageTextureAccess/"readonly"}} and {{GPUStorageTextureAccess/"writeonly"}}.
@@ -7218,187 +7218,187 @@ usage in the core API, including both {{GPUStorageTextureAccess/"readonly"}} and
     <thead class=stickyheader>
         <tr>
             <th>Format
-            <th>{{GPUTextureSampleType}}
+            <th>{{GPUTextureBindingType}}
             <th>{{GPUTextureUsage/RENDER_ATTACHMENT}}
             <th>{{GPUTextureUsage/STORAGE}}
     </thead>
     <tr><th class=stickyheader>8-bit per component<th><th><th><th>
     <tr>
         <td>{{GPUTextureFormat/r8unorm}}
-        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureBindingType/"float"}},<br/>{{GPUTextureBindingType/"unfilterable-float"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/r8snorm}}
-        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureBindingType/"float"}},<br/>{{GPUTextureBindingType/"unfilterable-float"}}
         <td>
         <td>
     <tr>
         <td>{{GPUTextureFormat/r8uint}}
-        <td>{{GPUTextureSampleType/"uint"}}
+        <td>{{GPUTextureBindingType/"uint"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/r8sint}}
-        <td>{{GPUTextureSampleType/"sint"}}
+        <td>{{GPUTextureBindingType/"sint"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/rg8unorm}}
-        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureBindingType/"float"}},<br/>{{GPUTextureBindingType/"unfilterable-float"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/rg8snorm}}
-        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureBindingType/"float"}},<br/>{{GPUTextureBindingType/"unfilterable-float"}}
         <td>
         <td>
     <tr>
         <td>{{GPUTextureFormat/rg8uint}}
-        <td>{{GPUTextureSampleType/"uint"}}
+        <td>{{GPUTextureBindingType/"uint"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/rg8sint}}
-        <td>{{GPUTextureSampleType/"sint"}}
+        <td>{{GPUTextureBindingType/"sint"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/rgba8unorm}}
-        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureBindingType/"float"}},<br/>{{GPUTextureBindingType/"unfilterable-float"}}
         <td>&checkmark;
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rgba8unorm-srgb}}
-        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureBindingType/"float"}},<br/>{{GPUTextureBindingType/"unfilterable-float"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/rgba8snorm}}
-        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureBindingType/"float"}},<br/>{{GPUTextureBindingType/"unfilterable-float"}}
         <td>
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rgba8uint}}
-        <td>{{GPUTextureSampleType/"uint"}}
+        <td>{{GPUTextureBindingType/"uint"}}
         <td>&checkmark;
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rgba8sint}}
-        <td>{{GPUTextureSampleType/"sint"}}
+        <td>{{GPUTextureBindingType/"sint"}}
         <td>&checkmark;
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/bgra8unorm}}
-        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureBindingType/"float"}},<br/>{{GPUTextureBindingType/"unfilterable-float"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/bgra8unorm-srgb}}
-        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureBindingType/"float"}},<br/>{{GPUTextureBindingType/"unfilterable-float"}}
         <td>&checkmark;
         <td>
     <tr><th class=stickyheader>16-bit per component<th><th><th><th>
     <tr>
         <td>{{GPUTextureFormat/r16uint}}
-        <td>{{GPUTextureSampleType/"uint"}}
+        <td>{{GPUTextureBindingType/"uint"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/r16sint}}
-        <td>{{GPUTextureSampleType/"sint"}}
+        <td>{{GPUTextureBindingType/"sint"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/r16float}}
-        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureBindingType/"float"}},<br/>{{GPUTextureBindingType/"unfilterable-float"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/rg16uint}}
-        <td>{{GPUTextureSampleType/"uint"}}
+        <td>{{GPUTextureBindingType/"uint"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/rg16sint}}
-        <td>{{GPUTextureSampleType/"sint"}}
+        <td>{{GPUTextureBindingType/"sint"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/rg16float}}
-        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureBindingType/"float"}},<br/>{{GPUTextureBindingType/"unfilterable-float"}}
         <td>&checkmark;
         <td><!-- Vulkan -->
     <tr>
         <td>{{GPUTextureFormat/rgba16uint}}
-        <td>{{GPUTextureSampleType/"uint"}}
+        <td>{{GPUTextureBindingType/"uint"}}
         <td>&checkmark;
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rgba16sint}}
-        <td>{{GPUTextureSampleType/"sint"}}
+        <td>{{GPUTextureBindingType/"sint"}}
         <td>&checkmark;
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rgba16float}}
-        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureBindingType/"float"}},<br/>{{GPUTextureBindingType/"unfilterable-float"}}
         <td>&checkmark;
         <td>&checkmark;
     <tr><th class=stickyheader>32-bit per component<th><th><th><th>
     <tr>
         <td>{{GPUTextureFormat/r32uint}}
-        <td>{{GPUTextureSampleType/"uint"}}
+        <td>{{GPUTextureBindingType/"uint"}}
         <td>&checkmark;
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/r32sint}}
-        <td>{{GPUTextureSampleType/"sint"}}
+        <td>{{GPUTextureBindingType/"sint"}}
         <td>&checkmark;
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/r32float}}
-        <td>{{GPUTextureSampleType/"unfilterable-float"}}<!-- Metal -->
+        <td>{{GPUTextureBindingType/"unfilterable-float"}}<!-- Metal -->
         <td>&checkmark;
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rg32uint}}
-        <td>{{GPUTextureSampleType/"uint"}}
+        <td>{{GPUTextureBindingType/"uint"}}
         <td>&checkmark;
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rg32sint}}
-        <td>{{GPUTextureSampleType/"sint"}}
+        <td>{{GPUTextureBindingType/"sint"}}
         <td>&checkmark;
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rg32float}}
-        <td>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureBindingType/"unfilterable-float"}}
         <td>&checkmark;
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rgba32uint}}
-        <td>{{GPUTextureSampleType/"uint"}}
+        <td>{{GPUTextureBindingType/"uint"}}
         <td>&checkmark;
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rgba32sint}}
-        <td>{{GPUTextureSampleType/"sint"}}
+        <td>{{GPUTextureBindingType/"sint"}}
         <td>&checkmark;
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rgba32float}}
-        <td>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureBindingType/"unfilterable-float"}}
         <td>&checkmark;
         <td>&checkmark;
     <tr><th class=stickyheader>mixed component width<th><th><th><th>
     <tr>
         <td>{{GPUTextureFormat/rgb10a2unorm}}
-        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureBindingType/"float"}},<br/>{{GPUTextureBindingType/"unfilterable-float"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/rg11b10ufloat}}
-        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureBindingType/"float"}},<br/>{{GPUTextureBindingType/"unfilterable-float"}}
         <td><!-- Vulkan -->
         <td>
 
@@ -7416,7 +7416,7 @@ None of the depth formats can be filtered.
             <th>Format
             <th>Bytes per texel
             <th>Aspect
-            <th>{{GPUTextureSampleType}}
+            <th>{{GPUTextureBindingType}}
             <th>Copy aspect from Buffer
             <th>Copy aspect into Buffer
     </thead>
@@ -7424,35 +7424,35 @@ None of the depth formats can be filtered.
         <td>{{GPUTextureFormat/stencil8}}
         <td>1 &minus; 5
         <td>stencil
-        <td>{{GPUTextureSampleType/"uint"}}
+        <td>{{GPUTextureBindingType/"uint"}}
         <td colspan=2>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/depth16unorm}}
         <td>2
         <td>depth
-        <td>{{GPUTextureSampleType/"depth"}}
+        <td>{{GPUTextureBindingType/"depth"}}
         <td colspan=2>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/depth24plus}}
         <td>4
         <td>depth
-        <td>{{GPUTextureSampleType/"depth"}}
+        <td>{{GPUTextureBindingType/"depth"}}
         <td colspan=2>&cross;
     <tr>
         <td rowspan=2 style='white-space:nowrap'>{{GPUTextureFormat/depth24plus-stencil8}}
         <td rowspan=2>4 &minus; 8
         <td>depth
-        <td>{{GPUTextureSampleType/"depth"}}
+        <td>{{GPUTextureBindingType/"depth"}}
         <td colspan=2>&cross;
     <tr>
         <td>stencil
-        <td>{{GPUTextureSampleType/"uint"}}
+        <td>{{GPUTextureBindingType/"uint"}}
         <td colspan=2>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/depth32float}}
         <td>4
         <td>depth
-        <td>{{GPUTextureSampleType/"depth"}}
+        <td>{{GPUTextureBindingType/"depth"}}
         <td colspan=1>&cross;
         <td colspan=1>&checkmark;
 </table>
@@ -7468,27 +7468,27 @@ Issue: clarify if `depth24plus-stencil8` is copyable into `depth24plus` in Metal
 
 ### Packed formats ### {#packed-formats}
 
-All packed texture formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, and {{GPUTextureUsage/SAMPLED}} usages. All of these formats have {{GPUTextureSampleType/"float"}} type and can be filtered on sampling.
+All packed texture formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, and {{GPUTextureUsage/SAMPLED}} usages. All of these formats have {{GPUTextureBindingType/"float"}} type and can be filtered on sampling.
 
 <table class='data'>
     <thead class=stickyheader>
         <tr>
             <th>Format
             <th>Bytes per block
-            <th>{{GPUTextureSampleType}}
+            <th>{{GPUTextureBindingType}}
             <th>Block Size
             <th>[=Feature=]
     </thead>
     <tr>
         <td>{{GPUTextureFormat/rgb9e5ufloat}}
         <td>4
-        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureBindingType/"float"}},<br/>{{GPUTextureBindingType/"unfilterable-float"}}
         <td>1 &times; 1
         <td>
     <tr>
         <td>{{GPUTextureFormat/bc1-rgba-unorm}}
         <td rowspan=2>8
-        <td rowspan=14>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td rowspan=14>{{GPUTextureBindingType/"float"}},<br/>{{GPUTextureBindingType/"unfilterable-float"}}
         <td rowspan=14>4 &times; 4
         <td rowspan=14>{{GPUFeatureName/texture-compression-bc}}
     <tr>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2555,19 +2555,19 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
     <tr>
         <td rowspan=3>{{GPUBindGroupLayoutEntry/texture}}
         <td rowspan=3>{{GPUTextureView}}
-        <td>{{GPUTextureBindingType/"float"}}
+        <td>{{GPUTextureSampleType/"float"}}
         <td>[=internal usage/constant=]
     <tr>
-        <td>{{GPUTextureBindingType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>[=internal usage/constant=]
     <tr>
-        <td>{{GPUTextureBindingType/"depth"}}
+        <td>{{GPUTextureSampleType/"depth"}}
         <td>[=internal usage/constant=]
     <tr>
-        <td>{{GPUTextureBindingType/"sint"}}
+        <td>{{GPUTextureSampleType/"sint"}}
         <td>[=internal usage/constant=]
     <tr>
-        <td>{{GPUTextureBindingType/"uint"}}
+        <td>{{GPUTextureSampleType/"uint"}}
         <td>[=internal usage/constant=]
 
     <tr>
@@ -2588,7 +2588,7 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
     1. If |entry|.{{GPUBindGroupLayoutEntry/sampler}} is not `undefined`:
         1. Return |entry|.{{GPUBindGroupLayoutEntry/sampler}}.{{GPUSamplerBindingLayout/type}}.
     1. If |entry|.{{GPUBindGroupLayoutEntry/texture}} is not `undefined`:
-        1. Return |entry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/type}}.
+        1. Return |entry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/sampleType}}.
     1. If |entry|.{{GPUBindGroupLayoutEntry/storageTexture}} is not `undefined`:
         1. Return |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/access}}.
 </div>
@@ -2644,7 +2644,7 @@ dictionary GPUSamplerBindingLayout {
 </dl>
 
 <script type=idl>
-enum GPUTextureBindingType {
+enum GPUTextureSampleType {
   "float",
   "unfilterable-float",
   "depth",
@@ -2653,19 +2653,19 @@ enum GPUTextureBindingType {
 };
 
 dictionary GPUTextureBindingLayout {
-    GPUTextureBindingType type = "float";
+    GPUTextureSampleType sampleType = "float";
     GPUTextureViewDimension viewDimension = "2d";
     boolean multisampled = false;
 };
 </script>
 
-Issue(https://github.com/gpuweb/gpuweb/issues/851): consider making {{GPUTextureBindingLayout/type}}
+Issue(https://github.com/gpuweb/gpuweb/issues/851): consider making {{GPUTextureBindingLayout/sampleType}}
 truly optional.
 
 {{GPUTextureBindingLayout}} dictionaries have the following members:
 
 <dl dfn-type=dict-member dfn-for=GPUTextureBindingLayout>
-    : <dfn>type</dfn>
+    : <dfn>sampleType</dfn>
     ::
         Indicates the type required for texture views bound to this binding.
 
@@ -2796,8 +2796,8 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                                     |textureLayout|.{{GPUTextureBindingLayout/multisampled}} is `true`:
                                     - |textureLayout|.{{GPUTextureBindingLayout/viewDimension}} is
                                         {{GPUTextureViewDimension/"2d"}}.
-                                    - |textureLayout|.{{GPUTextureBindingLayout/type}} is not
-                                        {{GPUTextureBindingType/"float"}}.
+                                    - |textureLayout|.{{GPUTextureBindingLayout/sampleType}} is not
+                                        {{GPUTextureSampleType/"float"}}.
 
                                 - If |storageTextureLayout| is not `undefined`:
                                     - |storageTextureLayout|.{{GPUStorageTextureBindingLayout/viewDimension}} is not
@@ -2952,7 +2952,7 @@ A {{GPUBindGroup}} object has the following internal slots:
                                             - Let |texture| be |resource|.{{GPUTextureView/[[texture]]}}.
                                             - |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/viewDimension}}
                                                 is equal to |resource|'s {{GPUTextureViewDescriptor/dimension}}.
-                                            - |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/type}}
+                                            - |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/sampleType}}
                                                 is compatible with |resource|'s {{GPUTextureViewDescriptor/format}}.
                                             - |texture|'s {{GPUTextureDescriptor/usage}} includes {{GPUTextureUsage/SAMPLED}}.
                                             - If |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/multisampled}}
@@ -3352,7 +3352,7 @@ has a default layout created and used instead.
 
                 1. Let |textureLayout| be a new {{GPUTextureBindingLayout}}.
 
-                1. Set |textureLayout|.{{GPUTextureBindingLayout/type}} to |resource|'s component type.
+                1. Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to |resource|'s component type.
                 1. Set |textureLayout|.{{GPUTextureBindingLayout/viewDimension}} to |resource|'s dimension.
                 1. If |resource| is for a multisampled texture:
 
@@ -3491,7 +3491,7 @@ A {{GPUProgrammableStageDescriptor}} describes the entry point in the user-provi
                         :: the |binding| is a multisampled texture.
                     </dl>
                 :: The component type of the texture matches
-                    |entry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/type}}.
+                    |entry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/sampleType}}.
                 :: The shader view dimension of the texture matches
                     |entry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/viewDimension}}.
 
@@ -7209,7 +7209,7 @@ Issue: Add multisampling to the tables below.
 
 All plain color formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, and {{GPUTextureUsage/SAMPLED}} usage.
 
-Only formats with {{GPUTextureBindingType}} {{GPUTextureBindingType/"float"}} can be blended.
+Only formats with {{GPUTextureSampleType}} {{GPUTextureSampleType/"float"}} can be blended.
 
 The {{GPUTextureUsage/STORAGE|GPUTextureUsage.STORAGE}} column specifies the support for {{GPUTextureUsage/STORAGE}}
 usage in the core API, including both {{GPUStorageTextureAccess/"readonly"}} and {{GPUStorageTextureAccess/"writeonly"}}.
@@ -7218,187 +7218,187 @@ usage in the core API, including both {{GPUStorageTextureAccess/"readonly"}} and
     <thead class=stickyheader>
         <tr>
             <th>Format
-            <th>{{GPUTextureBindingType}}
+            <th>{{GPUTextureSampleType}}
             <th>{{GPUTextureUsage/RENDER_ATTACHMENT}}
             <th>{{GPUTextureUsage/STORAGE}}
     </thead>
     <tr><th class=stickyheader>8-bit per component<th><th><th><th>
     <tr>
         <td>{{GPUTextureFormat/r8unorm}}
-        <td>{{GPUTextureBindingType/"float"}},<br/>{{GPUTextureBindingType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/r8snorm}}
-        <td>{{GPUTextureBindingType/"float"}},<br/>{{GPUTextureBindingType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>
         <td>
     <tr>
         <td>{{GPUTextureFormat/r8uint}}
-        <td>{{GPUTextureBindingType/"uint"}}
+        <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/r8sint}}
-        <td>{{GPUTextureBindingType/"sint"}}
+        <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/rg8unorm}}
-        <td>{{GPUTextureBindingType/"float"}},<br/>{{GPUTextureBindingType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/rg8snorm}}
-        <td>{{GPUTextureBindingType/"float"}},<br/>{{GPUTextureBindingType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>
         <td>
     <tr>
         <td>{{GPUTextureFormat/rg8uint}}
-        <td>{{GPUTextureBindingType/"uint"}}
+        <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/rg8sint}}
-        <td>{{GPUTextureBindingType/"sint"}}
+        <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/rgba8unorm}}
-        <td>{{GPUTextureBindingType/"float"}},<br/>{{GPUTextureBindingType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rgba8unorm-srgb}}
-        <td>{{GPUTextureBindingType/"float"}},<br/>{{GPUTextureBindingType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/rgba8snorm}}
-        <td>{{GPUTextureBindingType/"float"}},<br/>{{GPUTextureBindingType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rgba8uint}}
-        <td>{{GPUTextureBindingType/"uint"}}
+        <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rgba8sint}}
-        <td>{{GPUTextureBindingType/"sint"}}
+        <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/bgra8unorm}}
-        <td>{{GPUTextureBindingType/"float"}},<br/>{{GPUTextureBindingType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/bgra8unorm-srgb}}
-        <td>{{GPUTextureBindingType/"float"}},<br/>{{GPUTextureBindingType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>
     <tr><th class=stickyheader>16-bit per component<th><th><th><th>
     <tr>
         <td>{{GPUTextureFormat/r16uint}}
-        <td>{{GPUTextureBindingType/"uint"}}
+        <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/r16sint}}
-        <td>{{GPUTextureBindingType/"sint"}}
+        <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/r16float}}
-        <td>{{GPUTextureBindingType/"float"}},<br/>{{GPUTextureBindingType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/rg16uint}}
-        <td>{{GPUTextureBindingType/"uint"}}
+        <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/rg16sint}}
-        <td>{{GPUTextureBindingType/"sint"}}
+        <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/rg16float}}
-        <td>{{GPUTextureBindingType/"float"}},<br/>{{GPUTextureBindingType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td><!-- Vulkan -->
     <tr>
         <td>{{GPUTextureFormat/rgba16uint}}
-        <td>{{GPUTextureBindingType/"uint"}}
+        <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rgba16sint}}
-        <td>{{GPUTextureBindingType/"sint"}}
+        <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rgba16float}}
-        <td>{{GPUTextureBindingType/"float"}},<br/>{{GPUTextureBindingType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>&checkmark;
     <tr><th class=stickyheader>32-bit per component<th><th><th><th>
     <tr>
         <td>{{GPUTextureFormat/r32uint}}
-        <td>{{GPUTextureBindingType/"uint"}}
+        <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/r32sint}}
-        <td>{{GPUTextureBindingType/"sint"}}
+        <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/r32float}}
-        <td>{{GPUTextureBindingType/"unfilterable-float"}}<!-- Metal -->
+        <td>{{GPUTextureSampleType/"unfilterable-float"}}<!-- Metal -->
         <td>&checkmark;
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rg32uint}}
-        <td>{{GPUTextureBindingType/"uint"}}
+        <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rg32sint}}
-        <td>{{GPUTextureBindingType/"sint"}}
+        <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rg32float}}
-        <td>{{GPUTextureBindingType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rgba32uint}}
-        <td>{{GPUTextureBindingType/"uint"}}
+        <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rgba32sint}}
-        <td>{{GPUTextureBindingType/"sint"}}
+        <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rgba32float}}
-        <td>{{GPUTextureBindingType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>&checkmark;
     <tr><th class=stickyheader>mixed component width<th><th><th><th>
     <tr>
         <td>{{GPUTextureFormat/rgb10a2unorm}}
-        <td>{{GPUTextureBindingType/"float"}},<br/>{{GPUTextureBindingType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/rg11b10ufloat}}
-        <td>{{GPUTextureBindingType/"float"}},<br/>{{GPUTextureBindingType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td><!-- Vulkan -->
         <td>
 
@@ -7416,7 +7416,7 @@ None of the depth formats can be filtered.
             <th>Format
             <th>Bytes per texel
             <th>Aspect
-            <th>{{GPUTextureBindingType}}
+            <th>{{GPUTextureSampleType}}
             <th>Copy aspect from Buffer
             <th>Copy aspect into Buffer
     </thead>
@@ -7424,35 +7424,35 @@ None of the depth formats can be filtered.
         <td>{{GPUTextureFormat/stencil8}}
         <td>1 &minus; 5
         <td>stencil
-        <td>{{GPUTextureBindingType/"uint"}}
+        <td>{{GPUTextureSampleType/"uint"}}
         <td colspan=2>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/depth16unorm}}
         <td>2
         <td>depth
-        <td>{{GPUTextureBindingType/"depth"}}
+        <td>{{GPUTextureSampleType/"depth"}}
         <td colspan=2>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/depth24plus}}
         <td>4
         <td>depth
-        <td>{{GPUTextureBindingType/"depth"}}
+        <td>{{GPUTextureSampleType/"depth"}}
         <td colspan=2>&cross;
     <tr>
         <td rowspan=2 style='white-space:nowrap'>{{GPUTextureFormat/depth24plus-stencil8}}
         <td rowspan=2>4 &minus; 8
         <td>depth
-        <td>{{GPUTextureBindingType/"depth"}}
+        <td>{{GPUTextureSampleType/"depth"}}
         <td colspan=2>&cross;
     <tr>
         <td>stencil
-        <td>{{GPUTextureBindingType/"uint"}}
+        <td>{{GPUTextureSampleType/"uint"}}
         <td colspan=2>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/depth32float}}
         <td>4
         <td>depth
-        <td>{{GPUTextureBindingType/"depth"}}
+        <td>{{GPUTextureSampleType/"depth"}}
         <td colspan=1>&cross;
         <td colspan=1>&checkmark;
 </table>
@@ -7468,27 +7468,27 @@ Issue: clarify if `depth24plus-stencil8` is copyable into `depth24plus` in Metal
 
 ### Packed formats ### {#packed-formats}
 
-All packed texture formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, and {{GPUTextureUsage/SAMPLED}} usages. All of these formats have {{GPUTextureBindingType/"float"}} type and can be filtered on sampling.
+All packed texture formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, and {{GPUTextureUsage/SAMPLED}} usages. All of these formats have {{GPUTextureSampleType/"float"}} type and can be filtered on sampling.
 
 <table class='data'>
     <thead class=stickyheader>
         <tr>
             <th>Format
             <th>Bytes per block
-            <th>{{GPUTextureBindingType}}
+            <th>{{GPUTextureSampleType}}
             <th>Block Size
             <th>[=Feature=]
     </thead>
     <tr>
         <td>{{GPUTextureFormat/rgb9e5ufloat}}
         <td>4
-        <td>{{GPUTextureBindingType/"float"}},<br/>{{GPUTextureBindingType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>1 &times; 1
         <td>
     <tr>
         <td>{{GPUTextureFormat/bc1-rgba-unorm}}
         <td rowspan=2>8
-        <td rowspan=14>{{GPUTextureBindingType/"float"}},<br/>{{GPUTextureBindingType/"unfilterable-float"}}
+        <td rowspan=14>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td rowspan=14>4 &times; 4
         <td rowspan=14>{{GPUFeatureName/texture-compression-bc}}
     <tr>


### PR DESCRIPTION
Follow-up to #1223

I think `GPUBufferType` is confusing since it sounds like something that users would specify at buffer creation, and it doesn't have things like "it's a vertex buffer". This PR renames it to `GPUBufferBindingType` and does the same for samplers and textures for consistency.
The storage texture bindings don't really have a type, they have access flags instead. So the field is renamed to `access`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/1256.html" title="Last updated on Nov 25, 2020, 2:43 PM UTC (d86fc76)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1256/f8f9ed9...kvark:d86fc76.html" title="Last updated on Nov 25, 2020, 2:43 PM UTC (d86fc76)">Diff</a>