### PR TITLE
Fix some formatting issues from recent GPUBindGroupLayout changes

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -957,7 +957,7 @@ a better limit is not specified.
     <tr class=row-continuation><td colspan=4>
         The maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
 
-          - [%Layout entry binding type%] is {{GPUBufferBindingType/"uniform"}}, and
+          - [$layout entry binding type$] is {{GPUBufferBindingType/"uniform"}}, and
           - {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}} is `true`,
 
         across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
@@ -968,7 +968,7 @@ a better limit is not specified.
     <tr class=row-continuation><td colspan=4>
         The maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
 
-          - [%Layout entry binding type%] is {{GPUBufferBindingType/"storage"}}, and
+          - [$layout entry binding type$] is {{GPUBufferBindingType/"storage"}}, and
           - {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}} is `true`,
 
         across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
@@ -1004,7 +1004,7 @@ a better limit is not specified.
         For each possible {{GPUShaderStage}} `stage`,
         the maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
 
-          - [%Layout entry binding type%] is {{GPUBufferBindingType/"storage"}}, and
+          - [$layout entry binding type$] is {{GPUBufferBindingType/"storage"}}, and
           - {{GPUBindGroupLayoutEntry/visibility}} includes `stage`,
 
         across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
@@ -1028,7 +1028,7 @@ a better limit is not specified.
         For each possible {{GPUShaderStage}} `stage`,
         the maximum number of {{GPUBindGroupLayoutDescriptor/entries}} for which:
 
-          - [%Layout entry binding type%] is {{GPUBufferBindingType/"uniform"}}, and
+          - [$layout entry binding type$] is {{GPUBufferBindingType/"uniform"}}, and
           - {{GPUBindGroupLayoutEntry/visibility}} includes `stage`,
 
         across all {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
@@ -1038,13 +1038,13 @@ a better limit is not specified.
         <td>{{GPUSize32}} <td>Higher <td>16384
     <tr class=row-continuation><td colspan=4>
         The maximum {{GPUBufferBinding}}.{{GPUBufferBinding/size}} for bindings for which the
-        [%Layout entry binding type%] is {{GPUBufferBindingType/"uniform"}}.
+        [$layout entry binding type$] is {{GPUBufferBindingType/"uniform"}}.
 
     <tr><td><dfn>maxStorageBufferBindingSize</dfn>
         <td>{{GPUSize32}} <td>Higher <td> 134217728 (128 MiB)
     <tr class=row-continuation><td colspan=4>
         The maximum {{GPUBufferBinding}}.{{GPUBufferBinding/size}} for bindings for which the
-        [%Layout entry binding type%] is {{GPUBufferBindingType/"storage"}} or {{GPUBufferBindingType/"readonly-storage"}}.
+        [$layout entry binding type$] is {{GPUBufferBindingType/"storage"}} or {{GPUBufferBindingType/"readonly-storage"}}.
 </table>
 
 #### <dfn dictionary>GPULimits</dfn> #### {#gpulimits}
@@ -2553,8 +2553,8 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
         <td>[=internal usage/constant=]
 
     <tr>
-        <td rowspan=3>{{GPUBindGroupLayoutEntry/texture}}
-        <td rowspan=3>{{GPUTextureView}}
+        <td rowspan=5>{{GPUBindGroupLayoutEntry/texture}}
+        <td rowspan=5>{{GPUTextureView}}
         <td>{{GPUTextureSampleType/"float"}}
         <td>[=internal usage/constant=]
     <tr>


### PR DESCRIPTION
Just a couple of quick fixes for issues noticed during the editors call.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/toji/gpuweb/pull/1265.html" title="Last updated on Nov 30, 2020, 11:01 PM UTC (c0304f8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1265/4d2d3dc...toji:c0304f8.html" title="Last updated on Nov 30, 2020, 11:01 PM UTC (c0304f8)">Diff</a>