### PR TITLE
Add GPUAdapter.limits

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1067,13 +1067,13 @@ dictionary GPULimits {
 };
 </script>
 
-#### <dfn interface>GPUSupportedLimits</dfn> ### {#gpu-adapterlimits}
+#### <dfn interface>GPUAdapterLimits</dfn> ### {#gpu-adapterlimits}
 
-{{GPUSupportedLimits}} exposes the [=limits=] supported by an adapter.
+{{GPUAdapterLimits}} exposes the [=limits=] supported by an adapter.
 See {{GPUAdapter/limits|GPUAdapter.limits}}.
 
 <script type=idl>
-interface GPUSupportedLimits {
+interface GPUAdapterLimits {
     readonly attribute GPUSize32 maxBindGroups;
     readonly attribute GPUSize32 maxDynamicUniformBuffersPerPipelineLayout;
     readonly attribute GPUSize32 maxDynamicStorageBuffersPerPipelineLayout;
@@ -1260,7 +1260,7 @@ To get a {{GPUAdapter}}, use {{GPU/requestAdapter()}}.
 interface GPUAdapter {
     readonly attribute DOMString name;
     [SameObject] readonly attribute GPUAdapterFeatures features;
-    [SameObject] readonly attribute GPUSupportedLimits limits;
+    [SameObject] readonly attribute GPUAdapterLimits limits;
 
     Promise<GPUDevice?> requestDevice(optional GPUDeviceDescriptor descriptor = {});
 };
@@ -1405,7 +1405,7 @@ To get a {{GPUDevice}}, use {{GPUAdapter/requestDevice()}}.
 interface GPUDevice : EventTarget {
     [SameObject] readonly attribute GPUAdapter adapter;
     readonly attribute FrozenArray<GPUFeatureName> features;
-    [SameObject] readonly attribute GPUSupportedLimits limits;
+    readonly attribute object limits;
 
     [SameObject] readonly attribute GPUQueue defaultQueue;
 
@@ -1444,12 +1444,15 @@ GPUDevice includes GPUObjectBase;
         supported by the device (i.e. the ones with which it was created).
 
         Issue: Should this be {{GPUAdapterFeatures}} (which would be renamed to
-        GPUSupportedFeatures), for consistency?
+        GPUSupportedFeatures)?
 
     : <dfn>limits</dfn>
     ::
         Exposes the limits supported by the device
         (which are exactly the ones with which it was created).
+
+        Issue: Should this be {{GPUAdapterLimits}} (which would be renamed to
+        GPUSupportedLimits)?
 
     : <dfn>defaultQueue</dfn>
     ::

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1333,6 +1333,10 @@ interface GPUAdapter {
                             where |adapter| is |this|.{{GPUAdapter/[[adapter]]}}.
                         </div>
 
+                        Issue: This slightly distinguishes features unsupported by the adapter from
+                        features unrecognized by the UA. Should this be TypeError to match
+                        [WebIDL's enum conversion](https://heycam.github.io/webidl/#es-enumeration)?
+
                     1. If the user agent cannot fulfill the request,
                         [=resolve=] |promise| to `null` and stop.
 
@@ -1362,10 +1366,6 @@ dictionary GPUDeviceDescriptor : GPUObjectDescriptorBase {
     ::
         The set of {{GPUFeatureName}} values in this sequence defines the exact set of
         [=features=] that must be enabled on the device.
-
-        Issue: This needs to be a sequence of strings, so unknown feature names
-        don't cause IDL exceptions (so they have the same runtime behavior as known
-        but unsupported feature names).
 
     : <dfn>limits</dfn>
     ::

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1067,13 +1067,13 @@ dictionary GPULimits {
 };
 </script>
 
-#### <dfn interface>GPUAdapterLimits</dfn> ### {#gpu-adapterlimits}
+#### <dfn interface>GPUSupportedLimits</dfn> ### {#gpu-adapterlimits}
 
-{{GPUAdapterLimits}} exposes the [=limits=] supported by an adapter.
+{{GPUSupportedLimits}} exposes the [=limits=] supported by an adapter.
 See {{GPUAdapter/limits|GPUAdapter.limits}}.
 
 <script type=idl>
-interface GPUAdapterLimits {
+interface GPUSupportedLimits {
     readonly attribute GPUSize32 maxBindGroups;
     readonly attribute GPUSize32 maxDynamicUniformBuffersPerPipelineLayout;
     readonly attribute GPUSize32 maxDynamicStorageBuffersPerPipelineLayout;
@@ -1260,7 +1260,7 @@ To get a {{GPUAdapter}}, use {{GPU/requestAdapter()}}.
 interface GPUAdapter {
     readonly attribute DOMString name;
     [SameObject] readonly attribute GPUAdapterFeatures features;
-    [SameObject] readonly attribute GPUAdapterLimits limits;
+    [SameObject] readonly attribute GPUSupportedLimits limits;
 
     Promise<GPUDevice?> requestDevice(optional GPUDeviceDescriptor descriptor = {});
 };
@@ -1405,7 +1405,7 @@ To get a {{GPUDevice}}, use {{GPUAdapter/requestDevice()}}.
 interface GPUDevice : EventTarget {
     [SameObject] readonly attribute GPUAdapter adapter;
     readonly attribute FrozenArray<GPUFeatureName> features;
-    readonly attribute object limits;
+    [SameObject] readonly attribute GPUSupportedLimits limits;
 
     [SameObject] readonly attribute GPUQueue defaultQueue;
 
@@ -1443,10 +1443,13 @@ GPUDevice includes GPUObjectBase;
         A sequence containing the {{GPUFeatureName}} values of the features
         supported by the device (i.e. the ones with which it was created).
 
+        Issue: Should this be {{GPUAdapterFeatures}} (which would be renamed to
+        GPUSupportedFeatures), for consistency?
+
     : <dfn>limits</dfn>
     ::
-        A {{GPULimits}} object exposing the limits
-        supported by the device (i.e. the ones with which it was created).
+        Exposes the limits supported by the device
+        (which are exactly the ones with which it was created).
 
     : <dfn>defaultQueue</dfn>
     ::

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1067,6 +1067,26 @@ dictionary GPULimits {
 };
 </script>
 
+#### <dfn interface>GPUAdapterLimits</dfn> ### {#gpu-adapterlimits}
+
+{{GPUAdapterLimits}} exposes the [=limits=] supported by an adapter.
+See {{GPUAdapter/limits|GPUAdapter.limits}}.
+
+<script type=idl>
+interface GPUAdapterLimits {
+    readonly attribute GPUSize32 maxBindGroups;
+    readonly attribute GPUSize32 maxDynamicUniformBuffersPerPipelineLayout;
+    readonly attribute GPUSize32 maxDynamicStorageBuffersPerPipelineLayout;
+    readonly attribute GPUSize32 maxSampledTexturesPerShaderStage;
+    readonly attribute GPUSize32 maxSamplersPerShaderStage;
+    readonly attribute GPUSize32 maxStorageBuffersPerShaderStage;
+    readonly attribute GPUSize32 maxStorageTexturesPerShaderStage;
+    readonly attribute GPUSize32 maxUniformBuffersPerShaderStage;
+    readonly attribute GPUSize32 maxUniformBufferBindingSize;
+    readonly attribute GPUSize32 maxStorageBufferBindingSize;
+};
+</script>
+
 #### <dfn interface>GPUAdapterFeatures</dfn> #### {#gpu-adapterfeatures}
 
 {{GPUAdapterFeatures}} is a [=setlike=] interface. Its [=set entries=] are
@@ -1240,7 +1260,7 @@ To get a {{GPUAdapter}}, use {{GPU/requestAdapter()}}.
 interface GPUAdapter {
     readonly attribute DOMString name;
     [SameObject] readonly attribute GPUAdapterFeatures features;
-    //readonly attribute GPULimits limits; Don't expose higher limits for now.
+    [SameObject] readonly attribute GPUAdapterLimits limits;
 
     Promise<GPUDevice?> requestDevice(optional GPUDeviceDescriptor descriptor = {});
 };
@@ -1257,6 +1277,14 @@ interface GPUAdapter {
     : <dfn>features</dfn>
     ::
         Accessor for `this`.{{GPUAdapter/[[adapter]]}}.{{adapter/[[features]]}}.
+
+        Issue: Type no longer matches.
+
+    : <dfn>limits</dfn>
+    ::
+        Accessor for `this`.{{GPUAdapter/[[adapter]]}}.{{adapter/[[limits]]}}.
+
+        Issue: Type doesn't match.
 </dl>
 
 {{GPUAdapter}} has the following internal slots:
@@ -1335,9 +1363,16 @@ dictionary GPUDeviceDescriptor : GPUObjectDescriptorBase {
         The set of {{GPUFeatureName}} values in this sequence defines the exact set of
         [=features=] that must be enabled on the device.
 
+        Issue: This needs to be a sequence of strings, so unknown feature names
+        don't cause IDL exceptions (so they have the same runtime behavior as known
+        but unsupported feature names).
+
     : <dfn>limits</dfn>
     ::
         Defines the exact [=limits=] that must be enabled on the device.
+
+        Issue: This needs to be a `record<DOMString, any>`, so the UA can detect
+        requests for unrecognized limit names.
 </dl>
 
 #### <dfn enum>GPUFeatureName</dfn> #### {#gpufeaturename}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1052,6 +1052,9 @@ a better limit is not specified.
 {{GPULimits}} describes the [=limits=] with which a device should be created.
 See {{GPUDeviceDescriptor/limits|GPUDeviceDescriptor.limits}}.
 
+It also exposes the [=limits=] supported by an adapter.
+See {{GPUAdapter/limits|GPUAdapter.limits}}.
+
 <script type=idl>
 dictionary GPULimits {
     GPUSize32 maxBindGroups = 4;
@@ -1064,26 +1067,6 @@ dictionary GPULimits {
     GPUSize32 maxUniformBuffersPerShaderStage = 12;
     GPUSize32 maxUniformBufferBindingSize = 16384;
     GPUSize32 maxStorageBufferBindingSize = 134217728;
-};
-</script>
-
-#### <dfn interface>GPUAdapterLimits</dfn> ### {#gpu-adapterlimits}
-
-{{GPUAdapterLimits}} exposes the [=limits=] supported by an adapter.
-See {{GPUAdapter/limits|GPUAdapter.limits}}.
-
-<script type=idl>
-interface GPUAdapterLimits {
-    readonly attribute GPUSize32 maxBindGroups;
-    readonly attribute GPUSize32 maxDynamicUniformBuffersPerPipelineLayout;
-    readonly attribute GPUSize32 maxDynamicStorageBuffersPerPipelineLayout;
-    readonly attribute GPUSize32 maxSampledTexturesPerShaderStage;
-    readonly attribute GPUSize32 maxSamplersPerShaderStage;
-    readonly attribute GPUSize32 maxStorageBuffersPerShaderStage;
-    readonly attribute GPUSize32 maxStorageTexturesPerShaderStage;
-    readonly attribute GPUSize32 maxUniformBuffersPerShaderStage;
-    readonly attribute GPUSize32 maxUniformBufferBindingSize;
-    readonly attribute GPUSize32 maxStorageBufferBindingSize;
 };
 </script>
 
@@ -1260,7 +1243,7 @@ To get a {{GPUAdapter}}, use {{GPU/requestAdapter()}}.
 interface GPUAdapter {
     readonly attribute DOMString name;
     [SameObject] readonly attribute GPUAdapterFeatures features;
-    [SameObject] readonly attribute GPUAdapterLimits limits;
+    readonly attribute GPULimits limits;
 
     Promise<GPUDevice?> requestDevice(optional GPUDeviceDescriptor descriptor = {});
 };
@@ -1276,15 +1259,13 @@ interface GPUAdapter {
 
     : <dfn>features</dfn>
     ::
-        Accessor for `this`.{{GPUAdapter/[[adapter]]}}.{{adapter/[[features]]}}.
-
-        Issue: Type no longer matches.
+        The set of values in `this`.{{GPUAdapter/[[adapter]]}}.{{adapter/[[features]]}}.
 
     : <dfn>limits</dfn>
     ::
-        Accessor for `this`.{{GPUAdapter/[[adapter]]}}.{{adapter/[[limits]]}}.
+        The limits in `this`.{{GPUAdapter/[[adapter]]}}.{{adapter/[[limits]]}}.
 
-        Issue: Type doesn't match.
+        TODO: Should this be an `interface GPUAdapterLimits` or `GPUSupportedLimits`?
 </dl>
 
 {{GPUAdapter}} has the following internal slots:
@@ -1451,8 +1432,7 @@ GPUDevice includes GPUObjectBase;
         Exposes the limits supported by the device
         (which are exactly the ones with which it was created).
 
-        Issue: Should this be {{GPUAdapterLimits}} (which would be renamed to
-        GPUSupportedLimits)?
+        Issue: Should this be an `interface GPUSupportedLimits`?
 
     : <dfn>defaultQueue</dfn>
     ::


### PR DESCRIPTION
I think it's been determined that this API shouldn't consider privacy budgeting in it's design.

- UAs can still lazily-decide on GPULimits values.
- UAs can still do bucketing ahead of time, or even based on queries to GPULimits members.
- Apps can attempt requestDevice without checking limits, if they just want to know if their requested limits are supported.

Exact IDL interface is TBD, but editorial.

Needs more text to be filled out later. Also adds some other TODOs.

See also #489, #495; #1098, #1100.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1273.html" title="Last updated on Dec 15, 2020, 11:06 PM UTC (4410c80)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1273/df95e0f...kainino0x:4410c80.html" title="Last updated on Dec 15, 2020, 11:06 PM UTC (4410c80)">Diff</a>