### PR TITLE
Add GPULimits for vertex inputs

### DIFF
--- a/design/Limits.md
+++ b/design/Limits.md
@@ -14,16 +14,22 @@ dictionary GPULimits {
     unsigned long maxStorageBuffersPerShaderStage = 4;
     unsigned long maxStorageTexturesPerShaderStage = 4;
     unsigned long maxUniformBuffersPerShaderStage = 12;
+    unsigned long maxVertexBuffers = 8;
+    unsigned long maxVertexAttributes = 16;
+    unsigned long maxVertexArrayStride = 2048;
 };
 ```
 
 Limit | API Doc | gpuweb issue/PR
 --- | --- | ---
-`maxBindGroups = 4;` | [Vulkan](https://vulkan.lunarg.com/doc/view/latest/linux/chunked_spec/chap36.html#limits-required) `maxBoundDescriptorSets` |
-`maxDynamicUniformBuffersPerPipelineLayout = 8;` | [Vulkan](https://vulkan.lunarg.com/doc/view/latest/linux/chunked_spec/chap36.html#limits-required) `maxDescriptorSetUniformBuffersDynamic` | [#406](https://github.com/gpuweb/gpuweb/issues/406)
-`maxDynamicStorageBuffersPerPipelineLayout = 4;` | [Vulkan](https://vulkan.lunarg.com/doc/view/latest/linux/chunked_spec/chap36.html#limits-required) `maxDescriptorSetStorageBuffersDynamic` | [#406](https://github.com/gpuweb/gpuweb/issues/406)
-`maxSampledTexturesPerShaderStage = 16;` | [Vulkan](https://vulkan.lunarg.com/doc/view/latest/linux/chunked_spec/chap36.html#limits-required) `maxPerStageDescriptorSampledImages` | [#409](https://github.com/gpuweb/gpuweb/issues/409)
-`maxSamplersPerShaderStage = 16;` | [Vulkan](https://vulkan.lunarg.com/doc/view/latest/linux/chunked_spec/chap36.html#limits-required) `maxPerStageDescriptorSamplers` | [#409](https://github.com/gpuweb/gpuweb/issues/409)
-`maxStorageBuffersPerShaderStage = 4;` | [Vulkan](https://vulkan.lunarg.com/doc/view/latest/linux/chunked_spec/chap36.html#limits-required) `maxPerStageDescriptorStorageBuffers` | [#409](https://github.com/gpuweb/gpuweb/issues/409)
-`maxStorageTexturesPerShaderStage = 4;` | [Vulkan](https://vulkan.lunarg.com/doc/view/latest/linux/chunked_spec/chap36.html#limits-required) `maxPerStageDescriptorStorageImages` | [#409](https://github.com/gpuweb/gpuweb/issues/409)
-`maxUniformBuffersPerShaderStage = 12;` | [Vulkan](https://vulkan.lunarg.com/doc/view/latest/linux/chunked_spec/chap36.html#limits-required) `maxPerStageDescriptorUniformBuffers` | [#409](https://github.com/gpuweb/gpuweb/issues/409)
+`maxBindGroups = 4;` | [Vulkan](https://vulkan.lunarg.com/doc/view/latest/linux/chunked_spec/chap40.html#limits-minmax) `maxBoundDescriptorSets` |
+`maxDynamicUniformBuffersPerPipelineLayout = 8;` | [Vulkan](https://vulkan.lunarg.com/doc/view/latest/linux/chunked_spec/chap40.html#limits-minmax) `maxDescriptorSetUniformBuffersDynamic` | [#406](https://github.com/gpuweb/gpuweb/issues/406)
+`maxDynamicStorageBuffersPerPipelineLayout = 4;` | [Vulkan](https://vulkan.lunarg.com/doc/view/latest/linux/chunked_spec/chap40.html#limits-minmax) `maxDescriptorSetStorageBuffersDynamic` | [#406](https://github.com/gpuweb/gpuweb/issues/406)
+`maxSampledTexturesPerShaderStage = 16;` | [Vulkan](https://vulkan.lunarg.com/doc/view/latest/linux/chunked_spec/chap40.html#limits-minmax) `maxPerStageDescriptorSampledImages` | [#409](https://github.com/gpuweb/gpuweb/issues/409)
+`maxSamplersPerShaderStage = 16;` | [Vulkan](https://vulkan.lunarg.com/doc/view/latest/linux/chunked_spec/chap40.html#limits-minmax) `maxPerStageDescriptorSamplers` | [#409](https://github.com/gpuweb/gpuweb/issues/409)
+`maxStorageBuffersPerShaderStage = 4;` | [Vulkan](https://vulkan.lunarg.com/doc/view/latest/linux/chunked_spec/chap40.html#limits-minmax) `maxPerStageDescriptorStorageBuffers` | [#409](https://github.com/gpuweb/gpuweb/issues/409)
+`maxStorageTexturesPerShaderStage = 4;` | [Vulkan](https://vulkan.lunarg.com/doc/view/latest/linux/chunked_spec/chap40.html#limits-minmax) `maxPerStageDescriptorStorageImages` | [#409](https://github.com/gpuweb/gpuweb/issues/409)
+`maxUniformBuffersPerShaderStage = 12;` | [Vulkan](https://vulkan.lunarg.com/doc/view/latest/linux/chunked_spec/chap40.html#limits-minmax) `maxPerStageDescriptorUniformBuffers` | [#409](https://github.com/gpuweb/gpuweb/issues/409)
+`maxVertexBuffers = 8;` | [Vulkan](https://vulkan.lunarg.com/doc/view/latest/linux/chunked_spec/chap40.html#limits-minmax) `maxVertexInputBindings` | [#693](https://github.com/gpuweb/gpuweb/issues/693)
+`maxVertexAttributes = 16;` | [Vulkan](https://vulkan.lunarg.com/doc/view/latest/linux/chunked_spec/chap40.html#limits-minmax) `maxVertexInputAttributes` | [#693](https://github.com/gpuweb/gpuweb/issues/693)
+`maxVertexArrayStride = 2048;` | [Vulkan](https://vulkan.lunarg.com/doc/view/latest/linux/chunked_spec/chap40.html#limits-minmax) `maxVertexInputBindingStride` | [#693](https://github.com/gpuweb/gpuweb/issues/693)

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1049,17 +1049,21 @@ a better limit is not specified.
     <tr><td><dfn>maxVertexBuffers</dfn>
         <td>{{GPUSize32}} <td>Higher <td>8
     <tr class=row-continuation><td colspan=4>
-        The maximum number of {{GPUVertexStateDescriptor/vertexBuffers}} when creating a {{GPURenderPipeline}}.
+        The maximum number of {{GPUVertexStateDescriptor/vertexBuffers}}
+        when creating a {{GPURenderPipeline}}.
 
     <tr><td><dfn>maxVertexAttributes</dfn>
         <td>{{GPUSize32}} <td>Higher <td>16
     <tr class=row-continuation><td colspan=4>
-        The maximum number of {{GPUVertexBufferLayoutDescriptor/attributes}} when creating a {{GPURenderPipeline}}.
+        The maximum number of {{GPUVertexBufferLayoutDescriptor/attributes}}
+        in total across {{GPUVertexStateDescriptor/vertexBuffers}}
+        when creating a {{GPURenderPipeline}}.
 
     <tr><td><dfn>maxVertexArrayStride</dfn>
         <td>{{GPUSize32}} <td>Higher <td>2048
     <tr class=row-continuation><td colspan=4>
-        The maximum allowed {{GPUVertexBufferLayoutDescriptor/arrayStride}} when creating a {{GPURenderPipeline}}.
+        The maximum allowed {{GPUVertexBufferLayoutDescriptor/arrayStride}}
+        when creating a {{GPURenderPipeline}}.
 </table>
 
 #### <dfn dictionary>GPULimits</dfn> #### {#gpulimits}
@@ -4189,8 +4193,8 @@ dictionary GPUVertexAttributeDescriptor {
 
     Return `true`, if and only if, all of the following conditions are satisfied:
 
-        1. |descriptor|.{{GPUVertexBufferLayoutDescriptor/attributes}}.length is less than or equal to {{GPULimits/maxVertexAttributes}}.
-        1. |descriptor|.{{GPUVertexBufferLayoutDescriptor/arrayStride}} is less then or equal to {{GPULimits/maxVertexArrayStride}}.
+        1. |descriptor|.{{GPUVertexBufferLayoutDescriptor/arrayStride}} is less than or equal to
+            {{GPULimits/maxVertexArrayStride|GPULimits.maxVertexArrayStride}}.
         1. Any attribute |at| in the list |descriptor|.{{GPUVertexBufferLayoutDescriptor/attributes}} has
             |at|.{{GPUVertexAttributeDescriptor/offset}} + sizeOf(|at|.{{GPUVertexAttributeDescriptor/format}}) less or equal to
             |descriptor|.{{GPUVertexBufferLayoutDescriptor/arrayStride}}.
@@ -4209,9 +4213,13 @@ dictionary GPUVertexAttributeDescriptor {
 
     Return `true`, if and only if, all of the following conditions are satisfied:
 
-        1. |descriptor|.{{GPUVertexStateDescriptor/vertexBuffers}}.length is less than or equal to {{GPULimits/maxVertexBuffers}}
+        1. |descriptor|.{{GPUVertexStateDescriptor/vertexBuffers}}.length is less than or equal to
+            {{GPULimits/maxVertexBuffers|GPULimits.maxVertexBuffers}}
         1. Each |vertexBuffer| layout descriptor in the list |descriptor|.{{GPUVertexStateDescriptor/vertexBuffers}}
             passes [$validating GPUVertexBufferLayoutDescriptor$](|vertexBuffer|, |vertexStage|)
+        1. For every |vertexBuffer| in |descriptor|.{{GPUVertexStateDescriptor/vertexBuffers}},
+            the sum of every |vertexBuffer|.{{GPUVertexBufferLayoutDescriptor/attributes}}.length combined
+            is less than or equal to {{GPULimits/maxVertexAttributes|GPULimits.maxVertexAttributes}}.
         1. Each |at| in the union of all {{GPUVertexAttributeDescriptor}}
             across |descriptor|.{{GPUVertexStateDescriptor/vertexBuffers}} has a distinct
             |at|.{{GPUVertexAttributeDescriptor/shaderLocation}} value.
@@ -5952,7 +5960,7 @@ enum GPUStoreOp {
                     <div class=validusage>
                         - |buffer| is [$valid to use with$] |this|.
                         - |buffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/VERTEX}}.
-                        - |slot| &lt; {{GPULimits/maxVertexBuffers}}.
+                        - |slot| &lt; {{GPULimits/maxVertexBuffers|GPULimits.maxVertexBuffers}}.
                         - |offset| + |size| &le; |buffer|.{{GPUBuffer/[[size]]}}.
                     </div>
                 1. Add |buffer| to the [=usage scope=] as [=internal usage/input=].

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1045,6 +1045,21 @@ a better limit is not specified.
     <tr class=row-continuation><td colspan=4>
         The maximum {{GPUBufferBinding}}.{{GPUBufferBinding/size}} for bindings for which the
         [$layout entry binding type$] is {{GPUBufferBindingType/"storage"}} or {{GPUBufferBindingType/"readonly-storage"}}.
+
+    <tr><td><dfn>maxVertexBuffers</dfn>
+        <td>{{GPUSize32}} <td>Higher <td>8
+    <tr class=row-continuation><td colspan=4>
+        The maximum number of {{GPUVertexStateDescriptor/vertexBuffers}} when creating a {{GPURenderPipeline}}.
+
+    <tr><td><dfn>maxVertexAttributes</dfn>
+        <td>{{GPUSize32}} <td>Higher <td>16
+    <tr class=row-continuation><td colspan=4>
+        The maximum number of {{GPUVertexBufferLayoutDescriptor/attributes}} when creating a {{GPURenderPipeline}}.
+
+    <tr><td><dfn>maxVertexArrayStride</dfn>
+        <td>{{GPUSize32}} <td>Higher <td>2048
+    <tr class=row-continuation><td colspan=4>
+        The maximum allowed {{GPUVertexBufferLayoutDescriptor/arrayStride}} when creating a {{GPURenderPipeline}}.
 </table>
 
 #### <dfn dictionary>GPULimits</dfn> #### {#gpulimits}
@@ -1064,6 +1079,9 @@ dictionary GPULimits {
     GPUSize32 maxUniformBuffersPerShaderStage = 12;
     GPUSize32 maxUniformBufferBindingSize = 16384;
     GPUSize32 maxStorageBufferBindingSize = 134217728;
+    GPUSize32 maxVertexBuffers = 8;
+    GPUSize32 maxVertexAttributes = 16;
+    GPUSize32 maxVertexArrayStride = 2048;
 };
 </script>
 
@@ -4171,10 +4189,10 @@ dictionary GPUVertexAttributeDescriptor {
 
     Return `true`, if and only if, all of the following conditions are satisfied:
 
-        1. |descriptor|.{{GPUVertexBufferLayoutDescriptor/attributes}}.length is less than or equal to 16.
-        1. |descriptor|.{{GPUVertexBufferLayoutDescriptor/arrayStride}} is less then or equal to 2048.
+        1. |descriptor|.{{GPUVertexBufferLayoutDescriptor/attributes}}.length is less than or equal to {{GPULimits/maxVertexAttributes}}.
+        1. |descriptor|.{{GPUVertexBufferLayoutDescriptor/arrayStride}} is less then or equal to {{GPULimits/maxVertexArrayStride}}.
         1. Any attribute |at| in the list |descriptor|.{{GPUVertexBufferLayoutDescriptor/attributes}} has
-            |at|.{{GPUVertexAttributeDescriptor/offset} + sizeOf(|at|.{{GPUVertexAttributeDescriptor/format}} less or equal to
+            |at|.{{GPUVertexAttributeDescriptor/offset}} + sizeOf(|at|.{{GPUVertexAttributeDescriptor/format}}) less or equal to
             |descriptor|.{{GPUVertexBufferLayoutDescriptor/arrayStride}}.
         1. For every vertex attribute in the shader reflection of |vertexStage|.{{GPUProgrammableStageDescriptor/module}}
             that is know to be [=statically used=] by |vertexStage|.{{GPUProgrammableStageDescriptor/entryPoint}},
@@ -4182,8 +4200,6 @@ dictionary GPUVertexAttributeDescriptor {
             1. The shader format is |at|.{{GPUVertexAttributeDescriptor/format}}.
             2. The shader location is |at|.{{GPUVertexAttributeDescriptor/shaderLocation}}.
 </div>
-
-Issue(https://github.com/gpuweb/gpuweb/issues/693): add a limit to the number of vertex attributes
 
 <div algorithm>
     <dfn abstract-op>validating GPUVertexStateDescriptor</dfn>(descriptor, vertexStage)
@@ -4193,15 +4209,13 @@ Issue(https://github.com/gpuweb/gpuweb/issues/693): add a limit to the number of
 
     Return `true`, if and only if, all of the following conditions are satisfied:
 
-        1. |descriptor|.{{GPUVertexStateDescriptor/vertexBuffers}}.length is less than or equal to 8
+        1. |descriptor|.{{GPUVertexStateDescriptor/vertexBuffers}}.length is less than or equal to {{GPULimits/maxVertexBuffers}}
         1. Each |vertexBuffer| layout descriptor in the list |descriptor|.{{GPUVertexStateDescriptor/vertexBuffers}}
             passes [$validating GPUVertexBufferLayoutDescriptor$](|vertexBuffer|, |vertexStage|)
         1. Each |at| in the union of all {{GPUVertexAttributeDescriptor}}
             across |descriptor|.{{GPUVertexStateDescriptor/vertexBuffers}} has a distinct
             |at|.{{GPUVertexAttributeDescriptor/shaderLocation}} value.
 </div>
-
-Issue(https://github.com/gpuweb/gpuweb/issues/693): add a limit to the number of vertex buffers
 
 # Command Buffers # {#command-buffers}
 
@@ -5938,10 +5952,8 @@ enum GPUStoreOp {
                     <div class=validusage>
                         - |buffer| is [$valid to use with$] |this|.
                         - |buffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/VERTEX}}.
-                        - |slot| &lt; [=maximum number of vertex buffers=].
+                        - |slot| &lt; {{GPULimits/maxVertexBuffers}}.
                         - |offset| + |size| &le; |buffer|.{{GPUBuffer/[[size]]}}.
-
-                        Issue: Define the <dfn dfn for=>maximum number of vertex buffers</dfn>.
                     </div>
                 1. Add |buffer| to the [=usage scope=] as [=internal usage/input=].
                 1. Set |this|.{{GPURenderEncoderBase/[[vertex_buffers]]}}[|slot|] to be |buffer|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4217,8 +4217,8 @@ dictionary GPUVertexAttributeDescriptor {
             {{GPULimits/maxVertexBuffers|GPULimits.maxVertexBuffers}}
         1. Each |vertexBuffer| layout descriptor in the list |descriptor|.{{GPUVertexStateDescriptor/vertexBuffers}}
             passes [$validating GPUVertexBufferLayoutDescriptor$](|vertexBuffer|, |vertexStage|)
-        1. For every |vertexBuffer| in |descriptor|.{{GPUVertexStateDescriptor/vertexBuffers}},
-            the sum of every |vertexBuffer|.{{GPUVertexBufferLayoutDescriptor/attributes}}.length combined
+        1. The sum of |vertexBuffer|.{{GPUVertexBufferLayoutDescriptor/attributes}}.length,
+            over every |vertexBuffer| in |descriptor|.{{GPUVertexStateDescriptor/vertexBuffers}},
             is less than or equal to {{GPULimits/maxVertexAttributes|GPULimits.maxVertexAttributes}}.
         1. Each |at| in the union of all {{GPUVertexAttributeDescriptor}}
             across |descriptor|.{{GPUVertexStateDescriptor/vertexBuffers}} has a distinct


### PR DESCRIPTION
Fixes #693.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jespertheend/gpuweb/pull/1274.html" title="Last updated on Dec 5, 2020, 12:43 AM UTC (1fa2bba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1274/df95e0f...jespertheend:1fa2bba.html" title="Last updated on Dec 5, 2020, 12:43 AM UTC (1fa2bba)">Diff</a>