### PR TITLE
Associate command encoding with a queue

### DIFF
--- a/samples/hello-cube.html
+++ b/samples/hello-cube.html
@@ -278,7 +278,7 @@ function drawCommands(mappedGroup) {
     updateTransformArray(new Float32Array(mappedGroup.arrayBuffer));
     mappedGroup.buffer.unmap();
 
-    const commandEncoder = device.defaultQueue.createCommandEncoder();
+    const commandEncoder = device.createCommandEncoder();
     renderPassDescriptor.colorAttachments[0].attachment = swapChain.getCurrentTexture().createDefaultView();
     const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
 

--- a/samples/hello-cube.html
+++ b/samples/hello-cube.html
@@ -278,7 +278,7 @@ function drawCommands(mappedGroup) {
     updateTransformArray(new Float32Array(mappedGroup.arrayBuffer));
     mappedGroup.buffer.unmap();
 
-    const commandEncoder = device.createCommandEncoder();
+    const commandEncoder = device.defaultQueue.createCommandEncoder();
     renderPassDescriptor.colorAttachments[0].attachment = swapChain.getCurrentTexture().createDefaultView();
     const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4400,21 +4400,21 @@ which may be one of the following:
 
 <script type=idl>
 dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
-    boolean measureExecutionTime = false;
     GPUQueue queue;
-
+    boolean measureExecutionTime = false;
     // TODO: reusability flag?
 };
 </script>
 
 <dl dfn-type=dict-member dfn-for=GPUCommandEncoderDescriptor>
-    : <dfn>measureExecutionTime</dfn>
-    ::
-        Enable measurement of the GPU execution time of the entire command buffer.
-
     : <dfn>queue</dfn>
     ::
         The target queue which will be executing the commands.
+        If unspecified, the default queue is used.
+
+    : <dfn>measureExecutionTime</dfn>
+    ::
+        Enable measurement of the GPU execution time of the entire command buffer.
 </dl>
 
 <dl dfn-type=method dfn-for=GPUDevice>
@@ -6502,10 +6502,10 @@ GPURenderBundleEncoder includes GPURenderEncoderBase;
 
 <script type=idl>
 dictionary GPURenderBundleEncoderDescriptor : GPUObjectDescriptorBase {
+    GPUQueue queue;
     required sequence<GPUTextureFormat> colorFormats;
     GPUTextureFormat depthStencilFormat;
     GPUSize32 sampleCount = 1;
-    GPUQueue queue;
 };
 </script>
 
@@ -6558,14 +6558,6 @@ interface GPUQueue {
 };
 GPUQueue includes GPUObjectBase;
 </script>
-
-{{GPUQueue}} has the following internal slots:
-
-<dl dfn-type=attribute dfn-for="GPUQueue">
-    : <dfn>\[[device]]</dfn>, of type {{GPUDevice}}
-    ::
-        The parent device of this queue.
-</dl>
 
 {{GPUQueue}} has the following methods:
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1410,9 +1410,6 @@ interface GPUDevice : EventTarget {
     Promise<GPUComputePipeline> createReadyComputePipeline(GPUComputePipelineDescriptor descriptor);
     Promise<GPURenderPipeline> createReadyRenderPipeline(GPURenderPipelineDescriptor descriptor);
 
-    GPUCommandEncoder createCommandEncoder(optional GPUCommandEncoderDescriptor descriptor = {});
-    GPURenderBundleEncoder createRenderBundleEncoder(GPURenderBundleEncoderDescriptor descriptor);
-
     GPUQuerySet createQuerySet(GPUQuerySetDescriptor descriptor);
 };
 GPUDevice includes GPUObjectBase;
@@ -2024,11 +2021,15 @@ GPUTextureView includes GPUObjectBase;
     ::
         The {{GPUTexture}} into which this is a view.
 
-    : <dfn>\[[descriptor]]</dfn>
+    : <dfn>\[[descriptor]]</dfn>, of type {{GPUTextureViewDescriptor}}, read-only
     ::
-        The {{GPUTextureViewDescriptor}} describing this texture view.
+        The descriptor used to create this texture view.
 
         All optional fields of {{GPUTextureViewDescriptor}} are defined.
+
+    : <dfn>\[[extent]]</dfn>, of type {{GPUExtent3DDict}}, read-only
+    ::
+        The extent of this texture view.
 </dl>
 
 ### Texture View Creation ### {#texture-view-creation}
@@ -4271,6 +4272,10 @@ GPUCommandBuffer includes GPUObjectBase;
 {{GPUCommandBuffer}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUCommandBuffer">
+    : <dfn>\[[queue]]</dfn> of type {{GPUQueue}}.
+    ::
+        The parent queue, which will be executing the commands.
+
     : <dfn>\[[command_list]]</dfn> of type [=list=]&lt;[=GPU command=]&gt;.
     ::
         A [=list=] of [=GPU commands=] to be executed on the [=Queue timeline=] when this command
@@ -4337,6 +4342,10 @@ GPUCommandEncoder includes GPUObjectBase;
 {{GPUCommandEncoder}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUCommandEncoder">
+    : <dfn>\[[queue]]</dfn> of type {{GPUQueue}}.
+    ::
+        The parent queue, which will be executing the commands.
+
     : <dfn>\[[command_list]]</dfn> of type [=list=]&lt;[=GPU command=]&gt;.
     ::
         A [=list=] of [=GPU command=] to be executed on the [=Queue timeline=] when the
@@ -4400,22 +4409,30 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
         Enable measurement of the GPU execution time of the entire command buffer.
 </dl>
 
-<dl dfn-type=method dfn-for=GPUDevice>
+<dl dfn-type=method dfn-for=GPUQueue>
     : <dfn>createCommandEncoder(descriptor)</dfn>
     ::
         Creates a {{GPUCommandEncoder}}.
 
-        <div algorithm=GPUDevice.createCommandEncoder>
-            **Called on:** {{GPUDevice}} this.
+        <div algorithm=GPUQueue.createCommandEncoder>
+            **Called on:** {{GPUQueue}} this.
 
             **Arguments:**
-            <pre class=argumentdef for="GPUDevice/createCommandEncoder(descriptor)">
+            <pre class=argumentdef for="GPUQueue/createCommandEncoder(descriptor)">
                 descriptor: Description of the {{GPUCommandEncoder}} to create.
             </pre>
 
             **Returns:** {{GPUCommandEncoder}}
 
-            Issue: Describe {{GPUDevice/createCommandEncoder()}} algorithm steps.
+            Issue the following steps on the [=Device timeline=] of |this|.{{GPUQueue/[[device]]}}:
+            <div class=device-timeline>
+                1. Let |e| be a new {{GPUCommandEncoder}} object.
+                1. Set |e|.{{GPUCommandEncoder/[[command_list]]}} to an empty list.
+                1. Set |e|.{{GPUCommandEncoder/[[state]]}} to {{encoder state/open}}.
+                1. Set |e|.{{GPUCommandEncoder/[[debug_group_stack]]}} to an empty list.
+                1. Set |e|.{{GPUCommandEncoder/[[queue]]}} to |this|.
+                1. Return |e|.
+            </div>
         </div>
 </dl>
 
@@ -4458,6 +4475,12 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                             are considered to be used as [=internal usage/attachment-read=] for the duration of the render pass.
                     1. Else, the [=texture subresource=] seen by |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}
                         is considered to be used as [=internal usage/attachment=] for the duration of the render pass.
+                1. Let |p| be a new {{GPURenderPassEncoder}} object.
+                1. Set |p|.{{GPURenderPassEncoder/[[attachment_size]]}} to {{GPUTextureView/[[extent]]}}
+                    of any non-`null` attachment.
+                1. Set |p|.{{GPURenderPassEncoder/[[queue]]}} to |this|.{{GPUCommandEncoder/[[queue]]}}.
+                1. Return |p|.
+
             </div>
 
             Issue: specify the behavior of read-only depth/stencil
@@ -5095,6 +5118,7 @@ command encoder can no longer be used.
                         </div>
 
                     1. Set |this|.{{GPUCommandEncoder/[[state]]}} to {{encoder state/closed}}.
+                    1. Let |commandBuffer|.{{GPUCommandBuffer/[[queue]]}} be |this|.{{GPUCommandEncoder/[[queue]]}}.
                     1. Let |commandBuffer|.{{GPUCommandBuffer/[[command_list]]}} be a [=list/clone=]
                         of |this|.{{GPUCommandEncoder/[[command_list]]}}.
                 </div>
@@ -5641,6 +5665,10 @@ GPURenderPassEncoder includes GPURenderEncoderBase;
 {{GPURenderPassEncoder}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPURenderPassEncoder">
+    : <dfn>\[[queue]]</dfn> of type {{GPUQueue}}.
+    ::
+        The queue owning {{GPUCommandEncoder}}, which contains the pass.
+
     : <dfn>\[[attachment_size]]</dfn>
     ::
         Set to the following extents:
@@ -5700,12 +5728,10 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
         1. |this|.{{GPURenderPassDescriptor/depthStencilAttachment}} must meet the [$GPURenderPassDepthStencilAttachmentDescriptor/GPURenderPassDepthStencilAttachmentDescriptor Valid Usage$] rules.
 
     1. Each {{GPURenderPassColorAttachmentDescriptor/attachment}} in |this|.{{GPURenderPassDescriptor/colorAttachments}}
-        and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}},
-        if present, must have all have the same {{GPUTexture/[[sampleCount]]}}.
-
-    1. The dimensions of the [=subresource=]s seen by each {{GPURenderPassColorAttachmentDescriptor/attachment}} in |this|.{{GPURenderPassDescriptor/colorAttachments}}
-        and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}},
-        if present, must match.
+        and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}
+         if present:
+         - must have all the same {{GPUTextureView/[[texture]]}}.{{GPUTexture/[[sampleCount]]}}.
+         - must have all the same {{GPUTextureView/[[extent]]}}.
 
     Issue: Define <dfn for=>maximum color attachments</dfn>
 
@@ -6352,14 +6378,20 @@ attachments used by this encoder.
         {{GPURenderBundle}}s are executed, the command buffer state is unchanged.
 
         <div algorithm="GPURenderPassEncoder.executeBundles">
-            **Called on:** {{GPURenderPassEncoder}} this.
+            **Called on:** {{GPURenderPassEncoder}} |this|.
 
             **Arguments:**
             <pre class=argumentdef for="GPURenderPassEncoder/executeBundles(bundles)">
-                bundles: List of render bundles to execute.
+                |bundles|: List of render bundles to execute.
             </pre>
 
             **Returns:** {{undefined}}
+
+            If any of the following conditions are unsatisfied, generate a validation error and stop.
+            <div class=validusage>
+                - For each |bundle| in |bundles|,
+                    |bundle|.{{GPURenderBundle/[[queue]]}} is |this|.{{GPURenderPassEncoder/[[queue]]}}.
+            </div>
 
             Issue: Describe {{GPURenderPassEncoder/executeBundles()}} algorithm steps.
         </div>
@@ -6406,6 +6438,14 @@ interface GPURenderBundle {
 GPURenderBundle includes GPUObjectBase;
 </script>
 
+{{GPURenderBundle}} has the following internal slots:
+
+<dl dfn-type=attribute dfn-for="GPURenderBundle">
+    : <dfn>\[[queue]]</dfn> of type {{GPUQueue}}.
+    ::
+        The parent queue, which will be executing the commands.
+</dl>
+
 ### Creation ### {#render-bundle-creation}
 
 <script type=idl>
@@ -6422,23 +6462,31 @@ GPURenderBundleEncoder includes GPUProgrammablePassEncoder;
 GPURenderBundleEncoder includes GPURenderEncoderBase;
 </script>
 
-<dl dfn-type=method dfn-for=GPUDevice>
+<dl dfn-type=method dfn-for=GPUQueue>
     : <dfn>createRenderBundleEncoder(descriptor)</dfn>
     ::
         Creates a {{GPURenderBundleEncoder}}.
 
         <div algorithm=GPUDevice.createRenderBundleEncoder>
-            **Called on:** {{GPUDevice}} this.
+            **Called on:** {{GPUQueue}} this.
 
             **Arguments:**
-            <pre class=argumentdef for="GPUDevice/createRenderBundleEncoder(descriptor)">
+            <pre class=argumentdef for="GPUQueue/createRenderBundleEncoder(descriptor)">
                 descriptor: Description of the {{GPURenderBundleEncoder}} to create.
             </pre>
 
             **Returns:** {{GPURenderBundleEncoder}}
 
-            Issue: Describe {{GPUDevice/createRenderBundleEncoder()}} algorithm steps.
+            Issue: Describe {{GPUQueue/createRenderBundleEncoder()}} algorithm steps.
         </div>
+</dl>
+
+{{GPURenderBundleEncoder}} has the following internal slots:
+
+<dl dfn-type=attribute dfn-for="GPURenderBundleEncoder">
+    : <dfn>\[[queue]]</dfn> of type {{GPUQueue}}.
+    ::
+        The parent queue, which will be executing the commands.
 </dl>
 
 ### Encoding ### {#render-bundle-encoding}
@@ -6480,6 +6528,9 @@ interface GPUQueue {
 
     Promise<undefined> onSubmittedWorkDone();
 
+    GPUCommandEncoder createCommandEncoder(optional GPUCommandEncoderDescriptor descriptor = {});
+    GPURenderBundleEncoder createRenderBundleEncoder(GPURenderBundleEncoderDescriptor descriptor);
+
     undefined writeBuffer(
         GPUBuffer buffer,
         GPUSize64 bufferOffset,
@@ -6500,6 +6551,14 @@ interface GPUQueue {
 };
 GPUQueue includes GPUObjectBase;
 </script>
+
+{{GPUQueue}} has the following internal slots:
+
+<dl dfn-type=attribute dfn-for="GPUQueue">
+    : <dfn>\[[device]]</dfn>, of type {{GPUDevice}}
+    ::
+        The parent device of this queue.
+</dl>
 
 {{GPUQueue}} has the following methods:
 
@@ -6666,6 +6725,8 @@ GPUQueue includes GPUObjectBase;
                     <div class=validusage>
                         - Every {{GPUBuffer}} referenced in any element of |commandBuffers| is in the
                             `"unmapped"` [=buffer state=].
+                        - For every {{GPUCommandBuffer}} |commandBuffer| in |commandBuffers|,
+                            |commandBuffer|.{{GPUCommandBuffer/[[queue]]}} is |this|.
                     </div>
 
                 1. Issue the following steps on the [=Queue timeline=] of |this|:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1396,6 +1396,9 @@ interface GPUDevice : EventTarget {
 
     [SameObject] readonly attribute GPUQueue defaultQueue;
 
+    GPUCommandEncoder createCommandEncoder(optional GPUCommandEncoderDescriptor descriptor = {});
+    GPURenderBundleEncoder createRenderBundleEncoder(GPURenderBundleEncoderDescriptor descriptor);
+
     GPUBuffer createBuffer(GPUBufferDescriptor descriptor);
     GPUTexture createTexture(GPUTextureDescriptor descriptor);
     GPUSampler createSampler(optional GPUSamplerDescriptor descriptor = {});
@@ -4398,6 +4401,7 @@ which may be one of the following:
 <script type=idl>
 dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
     boolean measureExecutionTime = false;
+    GPUQueue queue;
 
     // TODO: reusability flag?
 };
@@ -4407,30 +4411,35 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
     : <dfn>measureExecutionTime</dfn>
     ::
         Enable measurement of the GPU execution time of the entire command buffer.
+
+    : <dfn>queue</dfn>
+    ::
+        The target queue which will be executing the commands.
 </dl>
 
-<dl dfn-type=method dfn-for=GPUQueue>
+<dl dfn-type=method dfn-for=GPUDevice>
     : <dfn>createCommandEncoder(descriptor)</dfn>
     ::
         Creates a {{GPUCommandEncoder}}.
 
-        <div algorithm=GPUQueue.createCommandEncoder>
-            **Called on:** {{GPUQueue}} this.
+        <div algorithm=GPUDevice.createCommandEncoder>
+            **Called on:** {{GPUDevice}} this.
 
             **Arguments:**
-            <pre class=argumentdef for="GPUQueue/createCommandEncoder(descriptor)">
-                descriptor: Description of the {{GPUCommandEncoder}} to create.
+            <pre class=argumentdef for="GPUDevice/createCommandEncoder(descriptor)">
+                |descriptor|: Description of the {{GPUCommandEncoder}} to create.
             </pre>
 
             **Returns:** {{GPUCommandEncoder}}
 
-            Issue the following steps on the [=Device timeline=] of |this|.{{GPUQueue/[[device]]}}:
+            Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
                 1. Let |e| be a new {{GPUCommandEncoder}} object.
                 1. Set |e|.{{GPUCommandEncoder/[[command_list]]}} to an empty list.
                 1. Set |e|.{{GPUCommandEncoder/[[state]]}} to {{encoder state/open}}.
                 1. Set |e|.{{GPUCommandEncoder/[[debug_group_stack]]}} to an empty list.
-                1. Set |e|.{{GPUCommandEncoder/[[queue]]}} to |this|.
+                1. Set |e|.{{GPUCommandEncoder/[[queue]]}} to |descriptor|.{{GPUCommandEncoderDescriptor/queue}},
+                    if it's not `null`, or otherwise to |this|.{{GPUDevice/defaultQueue}}.
                 1. Return |e|.
             </div>
         </div>
@@ -6462,7 +6471,7 @@ GPURenderBundleEncoder includes GPUProgrammablePassEncoder;
 GPURenderBundleEncoder includes GPURenderEncoderBase;
 </script>
 
-<dl dfn-type=method dfn-for=GPUQueue>
+<dl dfn-type=method dfn-for=GPUDevice>
     : <dfn>createRenderBundleEncoder(descriptor)</dfn>
     ::
         Creates a {{GPURenderBundleEncoder}}.
@@ -6471,13 +6480,13 @@ GPURenderBundleEncoder includes GPURenderEncoderBase;
             **Called on:** {{GPUQueue}} this.
 
             **Arguments:**
-            <pre class=argumentdef for="GPUQueue/createRenderBundleEncoder(descriptor)">
+            <pre class=argumentdef for="GPUDevice/createRenderBundleEncoder(descriptor)">
                 descriptor: Description of the {{GPURenderBundleEncoder}} to create.
             </pre>
 
             **Returns:** {{GPURenderBundleEncoder}}
 
-            Issue: Describe {{GPUQueue/createRenderBundleEncoder()}} algorithm steps.
+            Issue: Describe {{GPUDevice/createRenderBundleEncoder()}} algorithm steps.
         </div>
 </dl>
 
@@ -6496,6 +6505,7 @@ dictionary GPURenderBundleEncoderDescriptor : GPUObjectDescriptorBase {
     required sequence<GPUTextureFormat> colorFormats;
     GPUTextureFormat depthStencilFormat;
     GPUSize32 sampleCount = 1;
+    GPUQueue queue;
 };
 </script>
 
@@ -6527,9 +6537,6 @@ interface GPUQueue {
     undefined submit(sequence<GPUCommandBuffer> commandBuffers);
 
     Promise<undefined> onSubmittedWorkDone();
-
-    GPUCommandEncoder createCommandEncoder(optional GPUCommandEncoderDescriptor descriptor = {});
-    GPURenderBundleEncoder createRenderBundleEncoder(GPURenderBundleEncoderDescriptor descriptor);
 
     undefined writeBuffer(
         GPUBuffer buffer,


### PR DESCRIPTION
This is one of the API changes that we probably need in order to be ready for multi-queue support down the road (#1169 and friends).

Investigation bits:
  - In Vulkan, a command buffer is produced by the device from the `VkCommandPool`, creating which requires a queue family index to be specified: https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkCommandPoolCreateInfo.html . If we aren't exposing the queue families (and I don't think it's been really considered so far), then we have to associate a command encoder/buffer with a queue.
  - In Metal, a command buffer is produced from `MTLQueue`: https://developer.apple.com/documentation/metal/mtlcommandqueue/1508686-makecommandbuffer
  - In D3D12, a command buffer is produced with a specified `D3D12_COMMAND_LIST_TYPE`. There isn't either a queue, or a queue family required, as far as I see. However, it also allows creation of any number of queues of a type. Therefore, I see each queue type as a distant analogy to Vulkan's queue family.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/1278.html" title="Last updated on Dec 9, 2020, 3:12 PM UTC (60f6093)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1278/b5c36e3...kvark:60f6093.html" title="Last updated on Dec 9, 2020, 3:12 PM UTC (60f6093)">Diff</a>