### PR TITLE
Add [Clamp] to maxAnisotropy

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2286,7 +2286,7 @@ dictionary GPUSamplerDescriptor : GPUObjectDescriptorBase {
     float lodMinClamp = 0;
     float lodMaxClamp = 0xffffffff; // TODO: What should this be? Was Number.MAX_VALUE.
     GPUCompareFunction compare;
-    unsigned short maxAnisotropy = 1;
+    [Clamp] unsigned short maxAnisotropy = 1;
 };
 </script>
 
@@ -2303,6 +2303,7 @@ dictionary GPUSamplerDescriptor : GPUObjectDescriptorBase {
 - If {{GPUSamplerDescriptor/compare}} is provided, the sampler will be a comparison sampler with the specified
     {{GPUCompareFunction}}.
 - {{GPUSamplerDescriptor/maxAnisotropy}} specifies the maximum anisotropy value clamp used by the sampler.
+    - It must be &ge; 1.
 
     Note: most implementations support {{GPUSamplerDescriptor/maxAnisotropy}} values in range between 1 and 16, inclusive.
 


### PR DESCRIPTION
The default behavior (`value % 65536`) doesn't make any sense here.
We could use [EnforceRange], but [Clamp] makes sense:

- Any value of maxAnisotropy > 65535 behaves identically to 65535
  (that is, it's as if there's no maximum).
- Any value of maxAnisotropy < 0 behaves identically to 0
  (it's a validation error).

Fixes #1269.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1280.html" title="Last updated on Dec 7, 2020, 11:06 PM UTC (6088af8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1280/b5c36e3...kainino0x:6088af8.html" title="Last updated on Dec 7, 2020, 11:06 PM UTC (6088af8)">Diff</a>