### PR TITLE
abs only works on signed integer scalar or vector

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4773,14 +4773,25 @@ TODO: deduplicate these tables
   <thead>
     <tr><th>Precondition<th>Built-in<th>Description
   </thead>
-  <tr algorithm="scalar case, abs">
-    <td>|T| is u32 or i32
-    <td class="nowrap">`abs(`|e|`:` |T| `) ->` |T|
-    <td>(GLSLstd450SAbs)
-  <tr algorithm="vector case, abs">
-    <td>|T| is u32 or i32
-    <td class="nowrap">`abs(`|e|`:` vec|N|<|T|> `) ->` vec|N|<|T|>
-    <td>(GLSLstd450SAbs)
+  <tr algorithm="scalar case, signed abs">
+    <td>
+    <td class="nowrap">`abs`(|e|: i32 ) -> i32
+    <td>The absolute value of |e|.<br>
+        (GLSLstd450SAbs)
+  <tr algorithm="vector case, signed abs">
+    <td>
+    <td class="nowrap">`abs`(|e| : vec|N|&lt;i32&gt; ) -> vec|N|&lt;i32&gt;
+    <td>Component-wise absolute value:
+        Component |i| of the result is `abs(`|e|`[`|i|`])`<br>
+        (GLSLstd450SAbs)
+  <tr algorithm="scalar case, unsigned abs">
+    <td>
+    <td class="nowrap">`abs`(|e| : u32 ) -> u32
+    <td>Result is |e|.  This is provided for symmetry with `abs` for signed integers.
+  <tr algorithm="vector case, unsgined abs">
+    <td>
+    <td class="nowrap">`abs(`|e|`:` vec|N|&lt;u32&gt; `) ->` vec|N|&lt;u32&gt;
+    <td>Result is |e|.  This is provided for symmetry with `abs` for signed integer vectors.
   <tr algorithm="scalar case, unsigned clamp">
     <td>|T| is u32
     <td class="nowrap">`clamp(`|e1|`:` |T| `, `|e2|`:` |T|`, `|e3|`:` |T|`) ->` |T|


### PR DESCRIPTION
It doesn't make sense for it to apply to unsigned integer scalar or
vector.  It's a no-op in that case.