### PR TITLE
Add minmax-sampling feature

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2266,13 +2266,17 @@ GPUSampler includes GPUObjectBase;
     ::
         The {{GPUSamplerDescriptor}} with which the {{GPUSampler}} was created.
 
+    : <dfn>\[[isFiltering]]</dfn> of type {{boolean}}.
+    ::
+        Whether the {{GPUSampler}} weights multiple samples of a texture.
+
     : <dfn>\[[isComparison]]</dfn> of type {{boolean}}.
     ::
         Whether the {{GPUSampler}} is used as a comparison sampler.
 
-    : <dfn>\[[isFiltering]]</dfn> of type {{boolean}}.
+    : <dfn>\[[isMinMax]]</dfn> of type {{boolean}}.
     ::
-        Whether the {{GPUSampler}} weights multiple samples of a texture.
+        Whether the {{GPUSampler}} computes the minimum/maximum of samples of a texture.
 </dl>
 
 ## Sampler Creation ## {#sampler-creation}
@@ -2482,11 +2486,15 @@ enum GPUCompareFunction {
 
         1. Let |s| be a new {{GPUSampler}} object.
         1. Set |s|.{{GPUSampler/[[descriptor]]}} to |descriptor|.
-        1. Set |s|.{{GPUSampler/[[isComparison]]}} to `false` if the {{GPUSamplerDescriptor/compare}} attribute
-                of |s|.{{GPUSampler/[[descriptor]]}} is `null` or undefined. Otherwise, set it to `true`.
         1. Set |s|.{{GPUSampler/[[isFiltering]]}} to `false` if none of {{GPUSamplerDescriptor/minFilter}},
             {{GPUSamplerDescriptor/magFilter}}, or {{GPUSamplerDescriptor/mipmapFilter}} has the value of
             {{GPUFilterMode/"linear"}}. Otherwise, set it to `true`.
+        1. Set |s|.{{GPUSampler/[[isComparison]]}} to `false` if
+            |s|.{{GPUSampler/[[descriptor]]}}.{{GPUSamplerDescriptor/compare}} is `null` or undefined.
+            Otherwise, set it to `true`.
+        1. Set |s|.{{GPUSampler/[[isMinMax]]}} to `false` if
+            |s|.{{GPUSampler/[[descriptor]]}}.{{GPUSamplerDescriptor/reduction}} is {{GPUReductionMode/"weighted-average"}}.
+            Otherwise, set it to `true`.
         1. Return |s|.
 
         <div class=validusage dfn-for=GPUDevice.createSampler>
@@ -3008,15 +3016,25 @@ A {{GPUBindGroup}} object has the following internal slots:
                                             - If the [$layout entry binding type$] of |layoutBinding| is
                                                 <dl class="switch">
                                                     : {{GPUSamplerBindingType/"filtering"}}
-                                                    :: |resource|.{{GPUSampler/[[isComparison]]}} is `false`.
+                                                    ::
+                                                        |resource|.{{GPUSampler/[[isComparison]]}} is `false`.
+                                                        |resource|.{{GPUSampler/[[isMinMax]]}} is `false`.
 
                                                     : {{GPUSamplerBindingType/"non-filtering"}}
                                                     ::
                                                         |resource|.{{GPUSampler/[[isFiltering]]}} is `false`.
                                                         |resource|.{{GPUSampler/[[isComparison]]}} is `false`.
+                                                        |resource|.{{GPUSampler/[[isMinMax]]}} is `false`.
 
                                                     : {{GPUSamplerBindingType/"comparison"}}
-                                                    :: |resource|.{{GPUSampler/[[isComparison]]}} is `true`.
+                                                    ::
+                                                        |resource|.{{GPUSampler/[[isComparison]]}} is `true`.
+                                                        |resource|.{{GPUSampler/[[isMinMax]]}} is `false`.
+
+                                                    : {{GPUSamplerBindingType/"minmax"}}
+                                                    ::
+                                                        |resource|.{{GPUSampler/[[isComparison]]}} is `false`.
+                                                        |resource|.{{GPUSampler/[[isMinMax]]}} is `true`.
                                                 </dl>
 
                                         : {{GPUBindGroupLayoutEntry/texture}}
@@ -3555,7 +3573,7 @@ A {{GPUProgrammableStageDescriptor}} describes the entry point in the user-provi
                         : {{GPUSamplerBindingType/"comparison"}}
                         :: the |binding| is a comparison sampler
                         : {{GPUSamplerBindingType/"minmax"}}
-                        :: the |binding| is a min/max sampler
+                        :: the |binding| is a non-comparison sampler
                     </dl>
 
                 : {{GPUBindGroupLayoutEntry/texture}}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2289,6 +2289,7 @@ dictionary GPUSamplerDescriptor : GPUObjectDescriptorBase {
     GPUFilterMode magFilter = "nearest";
     GPUFilterMode minFilter = "nearest";
     GPUFilterMode mipmapFilter = "nearest";
+    GPUReductionMode reduction = "weighted-average";
     float lodMinClamp = 0;
     float lodMaxClamp = 0xffffffff; // TODO: What should this be? Was Number.MAX_VALUE.
     GPUCompareFunction compare;
@@ -2351,8 +2352,6 @@ match one texel.
 enum GPUFilterMode {
     "nearest",
     "linear",
-    "minimum",
-    "maximum",
 };
 </script>
 
@@ -2363,16 +2362,32 @@ enum GPUFilterMode {
 
     : <dfn>"linear"</dfn>
     ::
-        Select two texels in each dimension and return a linear interpolation between their values.
+        Select two texels in each dimension for the reduction operation.
+</dl>
+
+{{GPUReductionMode}} describes the operation a sampler does on multiple texels before it produces the result.
+
+<script type=idl>
+enum GPUReductionMode {
+    "weighted-average",
+    "minimum",
+    "maximum",
+};
+</script>
+
+<dl dfn-type="enum-value" dfn-for=GPUFilterMode>
+    : <dfn>"weighted-average"</dfn>
+    ::
+        Compute the weighted average of the texel values based on the position of a sample.
 
     : <dfn>"minimum"</dfn>
     ::
-        Select two texels in each dimension and return the minimum values between them, component-wise.
+        Compute the minimum between the texel values, component-wise.
         Requires {{GPUFeatureName/"minmax-sampling"}} feature to be enabled.
 
     : <dfn>"maximum"</dfn>
     ::
-        Select two texels in each dimension and return the maximum values between them, component-wise.
+        Compute the maximum between the texel values, component-wise.
         Requires {{GPUFeatureName/"minmax-sampling"}} feature to be enabled.
 </dl>
 
@@ -2444,8 +2459,8 @@ enum GPUCompareFunction {
             |descriptor|.{{GPUSamplerDescriptor/lodMinClamp}}.
         - |descriptor|.{{GPUSamplerDescriptor/magFilter}} and |descriptor.{{GPUSamplerDescriptor/mipmapFilter}}
             are either {{GPUFilterMode/"nearest"}} or {{GPUFilterMode/"linear"}}, independently.
-        - if |descriptor|.{{GPUSamplerDescriptor/minFilter}} is {{GPUFilterMode/"minimum"}} or
-            {{GPUFilterMode/"maximum"}}, then all of the following conditions are satisfied:
+        - if |descriptor|.{{GPUSamplerDescriptor/reduction}} is not {{GPUReductionMode/"weighted-average"}},
+            then all of the following conditions are satisfied:
             - |device|.{{device/[[features]]}} [=list/contains=] {{GPUFeatureName/"minmax-sampling"}}.
             - |descriptor|.{{GPUSamplerDescriptor/compare}} is `null`.
 </div>
@@ -2591,8 +2606,8 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
         <td>[=internal usage/storage-read=]
 
     <tr>
-        <td rowspan=3>{{GPUBindGroupLayoutEntry/sampler}}
-        <td rowspan=3>{{GPUSampler}}
+        <td rowspan=4>{{GPUBindGroupLayoutEntry/sampler}}
+        <td rowspan=4>{{GPUSampler}}
         <td>{{GPUSamplerBindingType/"filtering"}}
         <td>[=internal usage/constant=]
     <tr>
@@ -2600,6 +2615,9 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
         <td>[=internal usage/constant=]
     <tr>
         <td>{{GPUSamplerBindingType/"comparison"}}
+        <td>[=internal usage/constant=]
+    <tr>
+        <td>{{GPUSamplerBindingType/"minmax"}}
         <td>[=internal usage/constant=]
 
     <tr>
@@ -2678,6 +2696,7 @@ enum GPUSamplerBindingType {
     "filtering",
     "non-filtering",
     "comparison",
+    "minmax",
 };
 
 dictionary GPUSamplerBindingLayout {
@@ -3535,6 +3554,8 @@ A {{GPUProgrammableStageDescriptor}} describes the entry point in the user-provi
                         :: the |binding| is a non-comparison sampler
                         : {{GPUSamplerBindingType/"comparison"}}
                         :: the |binding| is a comparison sampler
+                        : {{GPUSamplerBindingType/"minmax"}}
+                        :: the |binding| is a min/max sampler
                     </dl>
 
                 : {{GPUBindGroupLayoutEntry/texture}}
@@ -7282,10 +7303,10 @@ The following enums are supported if and only if the {{GPUFeatureName/"minmax-sa
 [=feature=] is enabled:
 
 <dl>
-    : {{GPUFilterMode}}
+    : {{GPUReductionMode}}
     ::
-        * {{GPUFilterMode/"minimum"}}
-        * {{GPUFilterMode/"maximum"}}
+        * {{GPUReductionMode/"minimum"}}
+        * {{GPUReductionMode/"maximum"}}
 </dl>
 
 # Appendices # {#appendices}
@@ -7304,7 +7325,7 @@ The {{GPUTextureUsage/STORAGE|GPUTextureUsage.STORAGE}} column specifies the sup
 usage in the core API, including both {{GPUStorageTextureAccess/"readonly"}} and {{GPUStorageTextureAccess/"writeonly"}}.
 
 The "Min/Max sampling" column specifies the support for sampling a {{GPUTextureView}} of the format with a {{GPUSampler}}
-that uses {{GPUFilterMode/"minimum"}} or {{GPUFilterMode/"maximum"}}.
+bound as {{GPUSamplerBindingType/"minmax"}.
 
 <table class='data'>
     <thead class=stickyheader>
@@ -7479,7 +7500,7 @@ that uses {{GPUFilterMode/"minimum"}} or {{GPUFilterMode/"maximum"}}.
         <td>{{GPUTextureSampleType/"unfilterable-float"}}<!-- Metal -->
         <td>&checkmark;
         <td>&checkmark;
-        <td>&checkmark;
+        <td>&checkmark; <!-- this is tricky in Vulkan -->
     <tr>
         <td>{{GPUTextureFormat/rg32uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -7538,8 +7559,8 @@ All depth formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_D
 
 None of the depth formats can be filtered.
 
-The {{GPUTextureAspect/"depth-only"} aspect of all of the depth formats can be sampled
-with {{GPUFilterMode/"minimum"}} or {{GPUFilterMode/"maximum"}} modes.
+The {{GPUTextureAspect/"depth-only"}} aspect of all of the depth formats can be sampled
+with samplers bound as {{GPUSamplerBindingType/"minmax"}}.
 
 <table class='data'>
     <thead>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2351,7 +2351,7 @@ match one texel.
 enum GPUFilterMode {
     "nearest",
     "linear",
-    "minimim",
+    "minimum",
     "maximum",
 };
 </script>
@@ -2367,12 +2367,12 @@ enum GPUFilterMode {
 
     : <dfn>"minimum"</dfn>
     ::
-        Select two texels in each dimension and return the minimum value between them.
+        Select two texels in each dimension and return the minimum values between them, component-wise.
         Requires {{GPUFeatureName/"minmax-sampling"}} feature to be enabled.
 
     : <dfn>"maximum"</dfn>
     ::
-        Select two texels in each dimension and return the maximum value between them.
+        Select two texels in each dimension and return the maximum values between them, component-wise.
         Requires {{GPUFeatureName/"minmax-sampling"}} feature to be enabled.
 </dl>
 
@@ -2445,8 +2445,9 @@ enum GPUCompareFunction {
         - |descriptor|.{{GPUSamplerDescriptor/magFilter}} and |descriptor.{{GPUSamplerDescriptor/mipmapFilter}}
             are either {{GPUFilterMode/"nearest"}} or {{GPUFilterMode/"linear"}}, independently.
         - if |descriptor|.{{GPUSamplerDescriptor/minFilter}} is {{GPUFilterMode/"minimum"}} or
-            {{GPUFilterMode/"maximum"}}, then the |device|.{{device/[[features]]}}
-            [=list/contain=] {{GPUFeatureName/"minmax-sampling"}}.
+            {{GPUFilterMode/"maximum"}}, then all of the following conditions are satisfied:
+            - |device|.{{device/[[features]]}} [=list/contains=] {{GPUFeatureName/"minmax-sampling"}}.
+            - |descriptor|.{{GPUSamplerDescriptor/compare}} is `null`.
 </div>
 
 <dl dfn-type=method dfn-for=GPUDevice>
@@ -7302,6 +7303,9 @@ Only formats with {{GPUTextureSampleType}} {{GPUTextureSampleType/"float"}} can 
 The {{GPUTextureUsage/STORAGE|GPUTextureUsage.STORAGE}} column specifies the support for {{GPUTextureUsage/STORAGE}}
 usage in the core API, including both {{GPUStorageTextureAccess/"readonly"}} and {{GPUStorageTextureAccess/"writeonly"}}.
 
+The "Min/Max sampling" column specifies the support for sampling a {{GPUTextureView}} of the format with a {{GPUSampler}}
+that uses {{GPUFilterMode/"minimum"}} or {{GPUFilterMode/"maximum"}}.
+
 <table class='data'>
     <thead class=stickyheader>
         <tr>
@@ -7309,6 +7313,7 @@ usage in the core API, including both {{GPUStorageTextureAccess/"readonly"}} and
             <th>{{GPUTextureSampleType}}
             <th>{{GPUTextureUsage/RENDER_ATTACHMENT}}
             <th>{{GPUTextureUsage/STORAGE}}
+            <th>Min/Max sampling
     </thead>
     <tr><th class=stickyheader>8-bit per component<th><th><th><th>
     <tr>
@@ -7316,29 +7321,35 @@ usage in the core API, including both {{GPUStorageTextureAccess/"readonly"}} and
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>
+        <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/r8snorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>
         <td>
+        <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/r8uint}}
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
+        <td>
         <td>
     <tr>
         <td>{{GPUTextureFormat/r8sint}}
         <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
         <td>
+        <td>
     <tr>
         <td>{{GPUTextureFormat/rg8unorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>
+        <td>
     <tr>
         <td>{{GPUTextureFormat/rg8snorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>
         <td>
         <td>
     <tr>
@@ -7346,45 +7357,54 @@ usage in the core API, including both {{GPUStorageTextureAccess/"readonly"}} and
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
         <td>
+        <td>
     <tr>
         <td>{{GPUTextureFormat/rg8sint}}
         <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
+        <td>
         <td>
     <tr>
         <td>{{GPUTextureFormat/rgba8unorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>&checkmark;
+        <td>
     <tr>
         <td>{{GPUTextureFormat/rgba8unorm-srgb}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
+        <td>
         <td>
     <tr>
         <td>{{GPUTextureFormat/rgba8snorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>
         <td>&checkmark;
+        <td>
     <tr>
         <td>{{GPUTextureFormat/rgba8uint}}
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
         <td>&checkmark;
+        <td>
     <tr>
         <td>{{GPUTextureFormat/rgba8sint}}
         <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
         <td>&checkmark;
+        <td>
     <tr>
         <td>{{GPUTextureFormat/bgra8unorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>
+        <td>
     <tr>
         <td>{{GPUTextureFormat/bgra8unorm-srgb}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
+        <td>
         <td>
     <tr><th class=stickyheader>16-bit per component<th><th><th><th>
     <tr>
@@ -7392,60 +7412,72 @@ usage in the core API, including both {{GPUStorageTextureAccess/"readonly"}} and
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
         <td>
+        <td>
     <tr>
         <td>{{GPUTextureFormat/r16sint}}
         <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
+        <td>
         <td>
     <tr>
         <td>{{GPUTextureFormat/r16float}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>
+        <td>
     <tr>
         <td>{{GPUTextureFormat/rg16uint}}
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
+        <td>
         <td>
     <tr>
         <td>{{GPUTextureFormat/rg16sint}}
         <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
         <td>
+        <td>
     <tr>
         <td>{{GPUTextureFormat/rg16float}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td><!-- Vulkan -->
+        <td>
     <tr>
         <td>{{GPUTextureFormat/rgba16uint}}
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
         <td>&checkmark;
+        <td>
     <tr>
         <td>{{GPUTextureFormat/rgba16sint}}
         <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
         <td>&checkmark;
+        <td>
     <tr>
         <td>{{GPUTextureFormat/rgba16float}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>&checkmark;
+        <td>
     <tr><th class=stickyheader>32-bit per component<th><th><th><th>
     <tr>
         <td>{{GPUTextureFormat/r32uint}}
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
         <td>&checkmark;
+        <td>
     <tr>
         <td>{{GPUTextureFormat/r32sint}}
         <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
         <td>&checkmark;
+        <td>
     <tr>
         <td>{{GPUTextureFormat/r32float}}
         <td>{{GPUTextureSampleType/"unfilterable-float"}}<!-- Metal -->
+        <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
     <tr>
@@ -7453,41 +7485,49 @@ usage in the core API, including both {{GPUStorageTextureAccess/"readonly"}} and
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
         <td>&checkmark;
+        <td>
     <tr>
         <td>{{GPUTextureFormat/rg32sint}}
         <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
         <td>&checkmark;
+        <td>
     <tr>
         <td>{{GPUTextureFormat/rg32float}}
         <td>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>&checkmark;
+        <td>
     <tr>
         <td>{{GPUTextureFormat/rgba32uint}}
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
         <td>&checkmark;
+        <td>
     <tr>
         <td>{{GPUTextureFormat/rgba32sint}}
         <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
         <td>&checkmark;
+        <td>
     <tr>
         <td>{{GPUTextureFormat/rgba32float}}
         <td>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>&checkmark;
+        <td>
     <tr><th class=stickyheader>mixed component width<th><th><th><th>
     <tr>
         <td>{{GPUTextureFormat/rgb10a2unorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>
+        <td>
     <tr>
         <td>{{GPUTextureFormat/rg11b10ufloat}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td><!-- Vulkan -->
+        <td>
         <td>
 
 </table>
@@ -7497,6 +7537,9 @@ usage in the core API, including both {{GPUStorageTextureAccess/"readonly"}} and
 All depth formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/SAMPLED}}, and {{GPUTextureUsage/RENDER_ATTACHMENT}} usage. However, the source/destination is restricted based on the format.
 
 None of the depth formats can be filtered.
+
+The {{GPUTextureAspect/"depth-only"} aspect of all of the depth formats can be sampled
+with {{GPUFilterMode/"minimum"}} or {{GPUFilterMode/"maximum"}} modes.
 
 <table class='data'>
     <thead>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1375,6 +1375,7 @@ enum GPUFeatureName {
     "pipeline-statistics-query",
     "texture-compression-bc",
     "timestamp-query",
+    "minmax-sampling",
 };
 </script>
 
@@ -2349,7 +2350,9 @@ match one texel.
 <script type=idl>
 enum GPUFilterMode {
     "nearest",
-    "linear"
+    "linear",
+    "minimim",
+    "maximum",
 };
 </script>
 
@@ -2361,6 +2364,16 @@ enum GPUFilterMode {
     : <dfn>"linear"</dfn>
     ::
         Select two texels in each dimension and return a linear interpolation between their values.
+
+    : <dfn>"minimum"</dfn>
+    ::
+        Select two texels in each dimension and return the minimum value between them.
+        Requires {{GPUFeatureName/"minmax-sampling"}} feature to be enabled.
+
+    : <dfn>"maximum"</dfn>
+    ::
+        Select two texels in each dimension and return the maximum value between them.
+        Requires {{GPUFeatureName/"minmax-sampling"}} feature to be enabled.
 </dl>
 
 {{GPUCompareFunction}} specifies the behavior of a comparison sampler. If a comparison sampler is
@@ -2429,6 +2442,11 @@ enum GPUCompareFunction {
         - |descriptor|.{{GPUSamplerDescriptor/lodMinClamp}} is greater than or equal to 0.
         - |descriptor|.{{GPUSamplerDescriptor/lodMaxClamp}} is greater than or equal to
             |descriptor|.{{GPUSamplerDescriptor/lodMinClamp}}.
+        - |descriptor|.{{GPUSamplerDescriptor/magFilter}} and |descriptor.{{GPUSamplerDescriptor/mipmapFilter}}
+            are either {{GPUFilterMode/"nearest"}} or {{GPUFilterMode/"linear"}}, independently.
+        - if |descriptor|.{{GPUSamplerDescriptor/minFilter}} is {{GPUFilterMode/"minimum"}} or
+            {{GPUFilterMode/"maximum"}}, then the |device|.{{device/[[features]]}}
+            [=list/contain=] {{GPUFeatureName/"minmax-sampling"}}.
 </div>
 
 <dl dfn-type=method dfn-for=GPUDevice>
@@ -7251,6 +7269,22 @@ The following enums are supported if and only if the {{GPUFeatureName/"timestamp
     : {{GPUQueryType}}
     ::
         * {{GPUQueryType/"timestamp"}}
+</dl>
+
+## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>minmax-sampling</dfn> ## {#minmax-sampling}
+
+Allows for sampling modes that take the minimum or maximum of texture values.
+
+**Feature Enums**
+
+The following enums are supported if and only if the {{GPUFeatureName/"minmax-sampling"}}
+[=feature=] is enabled:
+
+<dl>
+    : {{GPUFilterMode}}
+    ::
+        * {{GPUFilterMode/"minimum"}}
+        * {{GPUFilterMode/"maximum"}}
 </dl>
 
 # Appendices # {#appendices}


### PR DESCRIPTION
Closes #1267

This is useful for building hierarchical depth bounds, as one example.

Hardware support:
- Vulkan: `VK_EXT_sampler_filter_minmax` is present on around [50% desktops](http://vulkan.gpuinfo.org/listextensions.php?platform=windows) and 25% Android devices. There is a set of formats supporting min/max sampling, enabled by [filterMinmaxSingleComponentFormats](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPhysicalDeviceSamplerFilterMinmaxProperties.html) property. It's hard to grasp the support surface for the others.
- D3D12: apparently gated by [TILED_RESOURCES_TIER_2](https://docs.microsoft.com/en-us/windows/win32/api/d3d12/ne-d3d12-d3d12_tiled_resources_tier), but I don't know how to find the stats on how widely it's supported, and whether or not all the formats support it (@RafaelCintron ?)
- D3D11: [MinMaxFiltering](https://docs.microsoft.com/en-us/windows/win32/api/d3d11/ns-d3d11-d3d11_feature_data_d3d11_options1) flag, nice documentation in https://docs.microsoft.com/en-us/windows/win32/direct3d11/tiled-resources-texture-sampling-features 
- Metal: not seeing anything for this

Note: min/max sampling shouldn't be considered "filtering" for the purpose of validation.

TODO:
- [x] figure out which formats support this, potentially add a column to our format table.
- [x] determine if it's a filter mode, or something entirely different. Can a sampler be linearly magnifying but minmaxing the minification? In D3D12 it can, it seems, but maybe we don't need that.
- [x] determine if a separate sampler binding type is needed


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/1283.html" title="Last updated on Dec 8, 2020, 11:00 PM UTC (eb1c48d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1283/34a7dad...kvark:eb1c48d.html" title="Last updated on Dec 8, 2020, 11:00 PM UTC (eb1c48d)">Diff</a>