### PR TITLE
Fix textureStore() value parameter syntax

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5180,11 +5180,11 @@ If any of the parameters are out of bounds, then zero in all components.
 Writes a single texel to a texture.
 
 ```rust
-textureStore(t : texture_storage_wo_1d<F>, coords : i32, vec4<T> value) -> void
-textureStore(t : texture_storage_wo_1d_array<F>, coords : i32, array_index : i32, vec4<T> value) -> void
-textureStore(t : texture_storage_wo_2d<F>, coords : vec2<i32>, vec4<T> value) -> void
-textureStore(t : texture_storage_wo_2d_array<F>, coords : vec2<i32>, array_index : i32, vec4<T> value) -> void
-textureStore(t : texture_storage_wo_3d<F>, coords : vec3<i32>, vec4<T> value) -> void
+textureStore(t : texture_storage_wo_1d<F>, coords : i32, value : vec4<T>) -> void
+textureStore(t : texture_storage_wo_1d_array<F>, coords : i32, array_index : i32, value : vec4<T>) -> void
+textureStore(t : texture_storage_wo_2d<F>, coords : vec2<i32>, value : vec4<T>) -> void
+textureStore(t : texture_storage_wo_2d_array<F>, coords : vec2<i32>, array_index : i32, value : vec4<T>) -> void
+textureStore(t : texture_storage_wo_3d<F>, coords : vec3<i32>, value : vec4<T>) -> void
 ```
 
 The channel format `T` depends on the storage texel format `F`.


### PR DESCRIPTION
It was written in a C-style, not wgsl style.