### PR TITLE
Add a hyphen to read-only and write-only

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1044,7 +1044,7 @@ a better limit is not specified.
         <td>{{GPUSize32}} <td>Higher <td> 134217728 (128 MiB)
     <tr class=row-continuation><td colspan=4>
         The maximum {{GPUBufferBinding}}.{{GPUBufferBinding/size}} for bindings for which the
-        [$layout entry binding type$] is {{GPUBufferBindingType/"storage"}} or {{GPUBufferBindingType/"readonly-storage"}}.
+        [$layout entry binding type$] is {{GPUBufferBindingType/"storage"}} or {{GPUBufferBindingType/"read-only-storage"}}.
 
     <tr><td><dfn>maxVertexBuffers</dfn>
         <td>{{GPUSize32}} <td>Higher <td>8
@@ -2568,7 +2568,7 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
         <td>{{GPUBufferBindingType/"storage"}}
         <td>[=internal usage/storage=]
     <tr>
-        <td>{{GPUBufferBindingType/"readonly-storage"}}
+        <td>{{GPUBufferBindingType/"read-only-storage"}}
         <td>[=internal usage/storage-read=]
 
     <tr>
@@ -2604,10 +2604,10 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
     <tr>
         <td rowspan=2>{{GPUBindGroupLayoutEntry/storageTexture}}
         <td rowspan=2>{{GPUTextureView}}
-        <td>{{GPUStorageTextureAccess/"readonly"}}
+        <td>{{GPUStorageTextureAccess/"read-only"}}
         <td>[=internal usage/storage-read=]
     <tr>
-        <td>{{GPUStorageTextureAccess/"writeonly"}}
+        <td>{{GPUStorageTextureAccess/"write-only"}}
         <td>[=internal usage/storage-write=]
 </table>
 
@@ -2628,7 +2628,7 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
 enum GPUBufferBindingType {
     "uniform",
     "storage",
-    "readonly-storage",
+    "read-only-storage",
 };
 
 dictionary GPUBufferBindingLayout {
@@ -2716,8 +2716,8 @@ truly optional.
 
 <script type=idl>
 enum GPUStorageTextureAccess {
-    "readonly",
-    "writeonly",
+    "read-only",
+    "write-only",
 };
 
 dictionary GPUStorageTextureBindingLayout {
@@ -2821,7 +2821,7 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                                 - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/visibility}} includes
                                     {{GPUShaderStage/VERTEX}}:
                                     - The [$layout entry binding type$] of |bindingDescriptor| is not
-                                        {{GPUBufferBindingType/"readonly-storage"}} or {{GPUStorageTextureAccess/"writeonly"}}.
+                                        {{GPUBufferBindingType/"read-only-storage"}} or {{GPUStorageTextureAccess/"write-only"}}.
 
                                 - If the |textureLayout| is not `undefined` and
                                     |textureLayout|.{{GPUTextureBindingLayout/multisampled}} is `true`:
@@ -3031,7 +3031,7 @@ A {{GPUBindGroup}} object has the following internal slots:
                                                         `min(buffer.byteLength - offset, limits.maxUniformBufferBindingSize)`?
 
                                                     : {{GPUBufferBindingType/"storage"}} or
-                                                        {{GPUBufferBindingType/"readonly-storage"}}
+                                                        {{GPUBufferBindingType/"read-only-storage"}}
                                                     :: |resource|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
                                                         includes {{GPUBufferUsage/STORAGE}}.
                                                     :: |resource|.{{GPUBufferBinding/size}} &le; {{GPULimits/maxStorageBufferBindingSize}}.
@@ -3376,7 +3376,7 @@ has a default layout created and used instead.
 
                 1. If |resource| is for a read-only storage buffer:
 
-                    1. Set |bufferLayout|.{{GPUBufferBindingLayout/type}} to {{GPUBufferBindingType/"readonly-storage"}}.
+                    1. Set |bufferLayout|.{{GPUBufferBindingLayout/type}} to {{GPUBufferBindingType/"read-only-storage"}}.
 
                 1. If |resource| is for a storage buffer:
 
@@ -3404,11 +3404,11 @@ has a default layout created and used instead.
 
                 1. If |resource| is for a read-only storage texture:
 
-                    1. Set |storageTextureLayout|.{{GPUStorageTextureBindingLayout/access}} to {{GPUStorageTextureAccess/"readonly"}}.
+                    1. Set |storageTextureLayout|.{{GPUStorageTextureBindingLayout/access}} to {{GPUStorageTextureAccess/"read-only"}}.
 
                 1. If |resource| is for a write-only storage texture:
 
-                    1. Set |storageTextureLayout|.{{GPUStorageTextureBindingLayout/access}} to {{GPUStorageTextureAccess/"writeonly"}}.
+                    1. Set |storageTextureLayout|.{{GPUStorageTextureBindingLayout/access}} to {{GPUStorageTextureAccess/"write-only"}}.
 
                 1. Set |entry|.{{GPUBindGroupLayoutEntry/storageTexture}} to |storageTextureLayout|.
 
@@ -3496,7 +3496,7 @@ A {{GPUProgrammableStageDescriptor}} describes the entry point in the user-provi
                         :: The |binding| is a uniform buffer.
                         : {{GPUBufferBindingType/"storage"}}
                         :: The |binding| is a storage buffer.
-                        : {{GPUBufferBindingType/"readonly-storage"}}
+                        : {{GPUBufferBindingType/"read-only-storage"}}
                         :: The |binding| is a read-only storage buffer.
                     </dl>
                 :: If |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}} is not `0`:
@@ -3534,9 +3534,9 @@ A {{GPUProgrammableStageDescriptor}} describes the entry point in the user-provi
                 : {{GPUBindGroupLayoutEntry/storageTexture}}
                 :: If |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/access}} is:
                     <dl class=switch>
-                        : {{GPUStorageTextureAccess/"readonly"}}
+                        : {{GPUStorageTextureAccess/"read-only"}}
                         :: The |binding| is a read-only storage texture.
-                        : {{GPUStorageTextureAccess/"writeonly"}}
+                        : {{GPUStorageTextureAccess/"write-only"}}
                         :: The |binding| is a writable storage texture.
                     </dl>
                 :: The format of the storage texture matches
@@ -3561,7 +3561,7 @@ and can be used in {{GPUComputePassEncoder}}.
 Compute inputs and outputs are all contained in the bindings,
 according to the given {{GPUPipelineLayout}}.
 The outputs correspond to {{GPUBindGroupLayoutEntry/buffer}} bindings with a type of {{GPUBufferBindingType/"storage"}}
-and {{GPUBindGroupLayoutEntry/storageTexture}} bindings with a type of {{GPUStorageTextureAccess/"writeonly"}}.
+and {{GPUBindGroupLayoutEntry/storageTexture}} bindings with a type of {{GPUStorageTextureAccess/"write-only"}}.
 
 Stages of a compute [=pipeline=]:
   1. Compute shader
@@ -3658,7 +3658,7 @@ Render [=pipeline=] inputs are:
 
 Render [=pipeline=] outputs are:
   - {{GPUBindGroupLayoutEntry/buffer}} bindings with a {{GPUBufferBindingLayout/type}} of {{GPUBufferBindingType/"storage"}}
-  - {{GPUBindGroupLayoutEntry/storageTexture}} bindings with a {{GPUStorageTextureBindingLayout/access}} of {{GPUStorageTextureAccess/"writeonly"}}
+  - {{GPUBindGroupLayoutEntry/storageTexture}} bindings with a {{GPUStorageTextureBindingLayout/access}} of {{GPUStorageTextureAccess/"write-only"}}
   - the color attachments, described by {{GPUColorStateDescriptor}}
   - optionally, depth-stencil attachment, described by {{GPUDepthStencilStateDescriptor}}
 
@@ -7266,7 +7266,7 @@ All plain color formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/
 Only formats with {{GPUTextureSampleType}} {{GPUTextureSampleType/"float"}} can be blended.
 
 The {{GPUTextureUsage/STORAGE|GPUTextureUsage.STORAGE}} column specifies the support for {{GPUTextureUsage/STORAGE}}
-usage in the core API, including both {{GPUStorageTextureAccess/"readonly"}} and {{GPUStorageTextureAccess/"writeonly"}}.
+usage in the core API, including both {{GPUStorageTextureAccess/"read-only"}} and {{GPUStorageTextureAccess/"write-only"}}.
 
 <table class='data'>
     <thead class=stickyheader>


### PR DESCRIPTION
Seems more correct, and translates into bindings in other languages better (e.g. ReadOnlyStorage instead of ReadonlyStorage).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1292.html" title="Last updated on Dec 10, 2020, 1:51 AM UTC (6038df6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1292/b91e780...kainino0x:6038df6.html" title="Last updated on Dec 10, 2020, 1:51 AM UTC (6038df6)">Diff</a>