### PR TITLE
Add workgroup size and ID builtins

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3908,7 +3908,7 @@ The invocations are organized into workgroups, so that each invocation
      *CSj* mod workgroup_size_y ,
      *CSk* mod workgroup_size_z )
 
-in workgroup instance
+in <dfn noexport>workgroup ID</dfn>
 
    ( &lfloor; *CSi* &div; workgroup_size_x &rfloor;,
      &lfloor; *CSj* &div; workgroup_size_y &rfloor;,
@@ -4319,7 +4319,20 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
       <td>in
       <td>vec3&lt;u32&gt;
       <td width="50%">The current invocation's [=global invocation ID=],
-            i.e. its position in the [=compute shader grid=].
+          i.e. its position in the [=compute shader grid=].
+
+  <tr><td>`workgroup_id`
+      <td>compute
+      <td>in
+      <td>vec3&lt;u32&gt;
+      <td width="50%">The current invocation's [=workgroup ID=],
+          i.e. the position of the workgroup in the the [=workgroup grid=].
+
+  <tr><td>`workgroup_size`
+      <td>compute
+      <td>in
+      <td>vec3&lt;u32&gt;
+      <td width="50%">The [=workgroup size=] of the current entry point.
 
 </table>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4332,7 +4332,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
       <td>compute
       <td>in
       <td>vec3&lt;u32&gt;
-      <td width="50%">The [=workgroup size=] of the current entry point.
+      <td width="50%">The [=workgroup_size=] of the current entry point.
 
 </table>
 


### PR DESCRIPTION
Fixes #750

| builtin                      | SPIR-V                   | HLSL                       | Metal            | GLSL            |
| ------------------- | ------------------ | ------------------- | ------------ | ------------ |
| `workgroup_id` | `WorkgroupId` | `SV_GroupID` | `threadgroup_position_in_grid` | `gl_WorkGroupID` |
| `workgroup_size` | `WorkgroupSize` | ??? | `dispatch_threads_per_threadgroup` | `gl_WorkGroupSize` |

The lack of `workgroup_size` in HLSL is a bit of a concern, but since we have to basically insert the same value in the `numgroups` declaration anyway:
```c++
[numthreads(4,5,6)
void Foo () {.. }
```
... we should be able to do the same for `workgroup_size` builtin