### PR TITLE
Make the default value of addressMode{U,V,W} align with WebGL

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2282,9 +2282,9 @@ A {{GPUSamplerDescriptor}} specifies the options to use to create a {{GPUSampler
 
 <script type=idl>
 dictionary GPUSamplerDescriptor : GPUObjectDescriptorBase {
-    GPUAddressMode addressModeU = "clamp-to-edge";
-    GPUAddressMode addressModeV = "clamp-to-edge";
-    GPUAddressMode addressModeW = "clamp-to-edge";
+    GPUAddressMode addressModeU = "repeat";
+    GPUAddressMode addressModeV = "repeat";
+    GPUAddressMode addressModeW = "repeat";
     GPUFilterMode magFilter = "nearest";
     GPUFilterMode minFilter = "nearest";
     GPUFilterMode mipmapFilter = "nearest";


### PR DESCRIPTION
This patch sets the default value of GPUSamplerDescriptor.addressMode
to "repeat" which is the same as the one in WebGL and OpenGL ES 2.0
SPEC.

Fixes #1296


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Jiawei-Shao/gpuweb/pull/1297.html" title="Last updated on Dec 10, 2020, 3:56 PM UTC (e359efd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1297/b91e780...Jiawei-Shao:e359efd.html" title="Last updated on Dec 10, 2020, 3:56 PM UTC (e359efd)">Diff</a>