### PR TITLE
Simplify the WGSL grammar for function calls

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2871,21 +2871,20 @@ TODO: *Stub*: how to write each of the abstract pointer operations
 
 <pre class='def'>
 primary_expression
-  : IDENT
+  : IDENT argument_expression_list?
   | type_decl argument_expression_list
   | const_literal
   | paren_rhs_statement
   | BITCAST LESS_THAN type_decl GREATER_THAN paren_rhs_statement
       OpBitcast
 
+argument_expression_list
+  : PAREN_LEFT ((short_circuit_or_expression COMMA)* short_circuit_or_expression)? PAREN_RIGHT
+
 postfix_expression
   :
   | BRACKET_LEFT short_circuit_or_expression BRACKET_RIGHT postfix_expression
-  | argument_expression_list postfix_expression
   | PERIOD IDENT postfix_expression
-
-argument_expression_list
-  : PAREN_LEFT ((short_circuit_or_expression COMMA)* short_circuit_or_expression)? PAREN_RIGHT
 
 unary_expression
   : singular_expression


### PR DESCRIPTION
The previous grammar allowed many weird things that we don't need, such as `1(a, b)(d)`.