### PR TITLE
Corrected flipped logic for multisampled texture binding

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3522,9 +3522,9 @@ A {{GPUProgrammableStageDescriptor}} describes the entry point in the user-provi
                 :: If |entry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/multisampled}} is:
                     <dl class=switch>
                         : `true`
-                        :: The |binding| is a sampled texture with a sample count of 1.
-                        : `false`
                         :: the |binding| is a multisampled texture.
+                        : `false`
+                        :: The |binding| is a sampled texture with a sample count of 1.
                     </dl>
                 :: The component type of the texture matches
                     |entry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/sampleType}}.


### PR DESCRIPTION
Fixes #1291


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/toji/gpuweb/pull/1300.html" title="Last updated on Dec 10, 2020, 10:55 PM UTC (445f619)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1300/72a339a...toji:445f619.html" title="Last updated on Dec 10, 2020, 10:55 PM UTC (445f619)">Diff</a>