### PR TITLE
Make all textureLoad functions on sampled textures require the level

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4994,19 +4994,14 @@ The dimensions of the texture in texels.<br>
 Reads a single texel from a texture without sampling or filtering.
 
 ```rust
-textureLoad(t : texture_1d<T>, coords : i32) -> vec4<T>
-textureLoad(t : texture_1d_array<T>, coords : i32, array_index : i32) -> vec4<T>
-textureLoad(t : texture_2d<T>, coords : vec2<i32>) -> vec4<T>
+textureLoad(t : texture_1d<T>, coords : i32, level : i32) -> vec4<T>
+textureLoad(t : texture_1d_array<T>, coords : i32, array_index : i32, level : i32) -> vec4<T>
 textureLoad(t : texture_2d<T>, coords : vec2<i32>, level : i32) -> vec4<T>
-textureLoad(t : texture_2d_array<T>, coords : vec2<i32>, array_index : i32) -> vec4<T>
 textureLoad(t : texture_2d_array<T>, coords : vec2<i32>, array_index : i32, level : i32) -> vec4<T>
-textureLoad(t : texture_3d<T>, coords : vec3<i32>) -> vec4<T>
 textureLoad(t : texture_3d<T>, coords : vec3<i32>, level : i32) -> vec4<T>
 textureLoad(t : texture_multisampled_2d<T>, coords : vec2<i32>, sample_index : i32)-> vec4<T>
 textureLoad(t : texture_multisampled_2d_array<T>, coords : vec2<i32>, array_index : i32, sample_index : i32)-> vec4<T>
-textureLoad(t : texture_depth_2d, coords : vec2<i32>) -> f32
 textureLoad(t : texture_depth_2d, coords : vec2<i32>, level : i32) -> f32
-textureLoad(t : texture_depth_2d_array, coords : vec2<i32>, array_index : i32) -> f32
 textureLoad(t : texture_depth_2d_array, coords : vec2<i32>, array_index : i32, level : i32) -> f32
 textureLoad(t : [[access(read)]] texture_storage_1d<F>, coords : i32) -> vec4<T>
 textureLoad(t : [[access(read)]] texture_storage_1d_array<F>, coords : i32, array_index : i32) -> vec4<T>
@@ -5159,8 +5154,11 @@ textureSample(t : texture_depth_cube_array, s : sampler, coords : vec3<f32>, arr
   <tr><td>`offset`<td>
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
-  texture wrapping modes. `offset` values may range from `[-8..7]` in all
-  dimensions. Values outside of this range will be clamped to the nearest limit.
+  texture wrapping modes.<br>
+  `offset` must be compile time constant, and may only be provided as a
+  [literal](#literals) or `const_expr` expression (e.g. `vec2<i32>(1, 2)`).<br>
+  Each `offset` component must be at least `-8` and at most `7`. Values outside
+  of this range will be treated as a compile time error.
 </table>
 
 **Returns:**
@@ -5200,8 +5198,11 @@ textureSampleBias(t : texture_cube_array<f32>, s : sampler, coords : vec3<f32>, 
   <tr><td>`offset`<td>
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
-  texture wrapping modes. `offset` values may range from `[-8..7]` in all
-  dimensions. Values outside of this range will be clamped to the nearest limit.
+  texture wrapping modes.<br>
+  `offset` must be compile time constant, and may only be provided as a
+  [literal](#literals) or `const_expr` expression (e.g. `vec2<i32>(1, 2)`).<br>
+  Each `offset` component must be at least `-8` and at most `7`. Values outside
+  of this range will be treated as a compile time error.
 </table>
 
 **Returns:**
@@ -5238,8 +5239,11 @@ textureSampleCompare(t : texture_depth_cube_array, s : sampler_comparison, coord
   <tr><td>`offset`<td>
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
-  texture wrapping modes. `offset` values may range from `[-8..7]` in all
-  dimensions. Values outside of this range will be clamped to the nearest limit.
+  texture wrapping modes.<br>
+  `offset` must be compile time constant, and may only be provided as a
+  [literal](#literals) or `const_expr` expression (e.g. `vec2<i32>(1, 2)`).<br>
+  Each `offset` component must be at least `-8` and at most `7`. Values outside
+  of this range will be treated as a compile time error.
 </table>
 
 **Returns:**
@@ -5288,8 +5292,11 @@ textureSampleGrad(t : texture_cube_array<f32>, s : sampler, coords : vec3<f32>, 
   <tr><td>`offset`<td>
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
-  texture wrapping modes. `offset` values may range from `[-8..7]` in all
-  dimensions. Values outside of this range will be clamped to the nearest limit.
+  texture wrapping modes.<br>
+  `offset` must be compile time constant, and may only be provided as a
+  [literal](#literals) or `const_expr` expression (e.g. `vec2<i32>(1, 2)`).<br>
+  Each `offset` component must be at least `-8` and at most `7`. Values outside
+  of this range will be treated as a compile time error.
 </table>
 
 **Returns:**
@@ -5338,8 +5345,11 @@ textureSampleLevel(t : texture_depth_cube_array, s : sampler, coords : vec3<f32>
   <tr><td>`offset`<td>
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
-  texture wrapping modes. `offset` values may range from `[-8..7]` in all
-  dimensions. Values outside of this range will be clamped to the nearest limit.
+  texture wrapping modes.<br>
+  `offset` must be compile time constant, and may only be provided as a
+  [literal](#literals) or `const_expr` expression (e.g. `vec2<i32>(1, 2)`).<br>
+  Each `offset` component must be at least `-8` and at most `7`. Values outside
+  of this range will be treated as a compile time error.
 </table>
 
 **Returns:**


### PR DESCRIPTION
The semantics of `textureLoad` functions without the `level` is confusing. There is never an implicit level to load:
  - in HLSL, "the last component specifies the mipmap level"
  - in MSL, there is always `lod` parameter in `.read()`, it's just defaulted to 0
  - in SPIRV, it reads like it's optional, but I wasn't able to find the description of what happens if it's not specified
  - in GLSL, `texelFetch` always has a LOD parameter

This PR reduces the number of `textureLoad` overloads, so I think it makes the spec better.