### PR TITLE
Add GPURequestAdapterOptions.majorPerformanceCaveat

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1186,11 +1186,15 @@ configuration is suitable for the application.
 
 <script type=idl>
 dictionary GPURequestAdapterOptions {
+    GPUMajorPerformanceCaveatOption majorPerformanceCaveat = "last-resort";
     GPUPowerPreference powerPreference;
 };
-</script>
 
-<script type=idl>
+enum GPUMajorPerformanceCaveatOption {
+    "never",
+    "last-resort",
+};
+
 enum GPUPowerPreference {
     "low-power",
     "high-performance"
@@ -1200,6 +1204,34 @@ enum GPUPowerPreference {
 {{GPURequestAdapterOptions}} has the following members:
 
 <dl dfn-type=dict-member dfn-for=GPURequestAdapterOptions>
+    : <dfn>majorPerformanceCaveat</dfn>
+    ::
+        Expresses a restriction on whether adapters with major performance caveats should be
+        returned by an adapter request. The behavior is implementation-defined: implementations
+        may choose whether to categorize any given adapter as having a major performance caveat
+        or not.
+
+        Note: The most common case of a major performance caveat is a CPU-based software
+        implementation. However, other adapters could also be categorized as having a major
+        performance caveat; for example, an adapter might require costly emulation of a major
+        feature due to a driver bug.
+
+        It must be one of the following <dfn enum for=>GPUMajorPerformanceCaveatOption</dfn> values:
+
+        <dl dfn-type=enum-value dfn-for=GPUMajorPerformanceCaveatOption>
+            : <dfn>"never"</dfn>
+            ::
+                Adapters with major performance caveats should never be allowed.
+
+            : <dfn>"last-resort"</dfn>
+            ::
+                Adapters with major performance caveats should only be allowed
+                if no other adapters are available.
+        </dl>
+
+        Issue: Add "always" as a third option, if requestAdapters is pluralized, which lists such
+        adapters last in the list.
+
     : <dfn>powerPreference</dfn>
     ::
         Optionally provides a hint indicating what class of [=adapter=] should be selected from
@@ -1217,10 +1249,10 @@ enum GPUPowerPreference {
         Depending on the exact hardware configuration, such as battery status and attached displays
         or removable GPUs, the user agent may select different [=adapters=] given the same power
         preference.
-        Typically, given the same hardware configuration and state and
-        `powerPreference`, the user agent is likely to select the same adapter.
+        Typically, given the same hardware configuration/state and
+        `powerPreference` value, the user agent is likely to select the same adapter.
 
-        It must be one of the following values:
+        It must be one of the following <dfn enum for=>GPUPowerPreference</dfn> values:
 
         <dl dfn-type=enum-value dfn-for=GPUPowerPreference>
             : `undefined` (or not present)


### PR DESCRIPTION
Naming open to bikeshedding. Note WebGL uses `boolean failIfMajorPerformanceCaveat = false;`


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1302.html" title="Last updated on Apr 13, 2021, 4:20 PM UTC (0f5df16)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1302/8d46d0a...kainino0x:0f5df16.html" title="Last updated on Apr 13, 2021, 4:20 PM UTC (0f5df16)">Diff</a>