### PR TITLE
Refactor GPURenderPipelineDescriptor API

### DIFF
--- a/samples/hello-cube.html
+++ b/samples/hello-cube.html
@@ -183,13 +183,17 @@ async function init() {
         },
         writeMask: GPUColorWriteBits.ALL
     };
+    const outputMergerStateDescriptor = {
+        colorStates: [colorState]
+    };
     const pipelineDescriptor = {
         layout: pipelineLayout,
 
         vertexStage: vertexStageDescriptor,
         fragmentStage: fragmentStageDescriptor,
 
-        colorStates: [colorState],
+
+        outputMerger: outputMergerStateDescriptor,
         depthStencilState: depthStateDescriptor,
         vertexInput: vertexInputDescriptor
     };

--- a/samples/hello-cube.html
+++ b/samples/hello-cube.html
@@ -185,7 +185,7 @@ async function init() {
         writeMask: GPUColorWriteBits.ALL
     };
     const colorWriteState = {
-        output: [colorState]
+        outputs: [colorState]
     };
     const pipelineDescriptor = {
         layout: pipelineLayout,

--- a/samples/hello-cube.html
+++ b/samples/hello-cube.html
@@ -189,7 +189,6 @@ async function init() {
         vertexStage: vertexStageDescriptor,
         fragmentStage: fragmentStageDescriptor,
 
-        primitiveTopology: "triangle-list",
         colorStates: [colorState],
         depthStencilState: depthStateDescriptor,
         vertexInput: vertexInputDescriptor

--- a/samples/hello-cube.html
+++ b/samples/hello-cube.html
@@ -184,8 +184,8 @@ async function init() {
         },
         writeMask: GPUColorWriteBits.ALL
     };
-    const outputMergerState = {
-        colors: [colorState]
+    const colorWriteState = {
+        output: [colorState]
     };
     const pipelineDescriptor = {
         layout: pipelineLayout,
@@ -193,10 +193,9 @@ async function init() {
         vertexStage: vertexStage,
         fragmentStage: fragmentStage,
 
-
-        outputMerger: outputMergerState,
-        depthStencilState: depthState,
         vertexInput: vertexInputState
+        depthStencilState: depthState,
+        colorWrite: colorWriteState,
     };
     pipeline = device.createRenderPipeline(pipelineDescriptor);
 

--- a/samples/hello-cube.html
+++ b/samples/hello-cube.html
@@ -123,24 +123,6 @@ async function init() {
     verticesWriteArray.set(verticesArray);
     verticesBuffer.unmap();
 
-    // Vertex Input
-    const positionAttributeDescriptor = {
-        shaderLocation: positionAttributeNum,  // [[attribute(0)]]
-        offset: 0,
-        format: "float4"
-    };
-    const colorAttributeDescriptor = {
-        shaderLocation: colorAttributeNum,
-        offset: colorOffset,
-        format: "float4"
-    }
-    const vertexBufferDescriptor = {
-        attributeSet: [positionAttributeDescriptor, colorAttributeDescriptor],
-        stride: vertexSize,
-        stepMode: "vertex"
-    };
-    const vertexInputDescriptor = { vertexBuffers: [vertexBufferDescriptor] };
-
     // Bind group binding layout
     const transformBufferBindGroupLayoutEntry = {
         binding: transformBindingNum, // id[[(0)]]
@@ -151,19 +133,38 @@ async function init() {
     const bindGroupLayoutDescriptor = { entries: [transformBufferBindGroupLayoutEntry] };
     bindGroupLayout = device.createBindGroupLayout(bindGroupLayoutDescriptor);
 
+    const pipelineLayoutDescriptor = { bindGroupLayouts: [bindGroupLayout] };
+    const pipelineLayout = device.createPipelineLayout(pipelineLayoutDescriptor);
+
+    // Vertex Input
+    const positionAttribute = {
+        shaderLocation: positionAttributeNum,  // [[attribute(0)]]
+        offset: 0,
+        format: "float4"
+    };
+    const colorAttribute = {
+        shaderLocation: colorAttributeNum,
+        offset: colorOffset,
+        format: "float4"
+    }
+    const vertexBufferLayout = {
+        attributeSet: [positionAttributeDescriptor, colorAttribute],
+        stride: vertexSize,
+        stepMode: "vertex"
+    };
+    const vertexInputState = { vertexBuffers: [vertexBufferLayout] };
+
     // Pipeline
-    const depthStateDescriptor = {
+    const depthState = {
         depthWriteEnabled: true,
         depthCompare: "less"
     };
 
-    const pipelineLayoutDescriptor = { bindGroupLayouts: [bindGroupLayout] };
-    const pipelineLayout = device.createPipelineLayout(pipelineLayoutDescriptor);
-    const vertexStageDescriptor = {
+    const vertexStage = {
         module: shaderModule,
         entryPoint: "vertex_main"
     };
-    const fragmentStageDescriptor = {
+    const fragmentStage = {
         module: shaderModule,
         entryPoint: "fragment_main"
     };
@@ -183,19 +184,19 @@ async function init() {
         },
         writeMask: GPUColorWriteBits.ALL
     };
-    const outputMergerStateDescriptor = {
-        colorStates: [colorState]
+    const outputMergerState = {
+        colors: [colorState]
     };
     const pipelineDescriptor = {
         layout: pipelineLayout,
 
-        vertexStage: vertexStageDescriptor,
-        fragmentStage: fragmentStageDescriptor,
+        vertexStage: vertexStage,
+        fragmentStage: fragmentStage,
 
 
-        outputMerger: outputMergerStateDescriptor,
-        depthStencilState: depthStateDescriptor,
-        vertexInput: vertexInputDescriptor
+        outputMerger: outputMergerState,
+        depthStencilState: depthState,
+        vertexInput: vertexInputState
     };
     pipeline = device.createRenderPipeline(pipelineDescriptor);
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -185,7 +185,7 @@ thead.stickyheader th, th.stickyheader {
 }
 
 /*
- * Darkmode colors
+ * Darkmode outputs
  */
 :root {
     --watermark-text: rgba(0, 0, 0, 15%);
@@ -3275,7 +3275,7 @@ integration such as source-language debugging.
 A <dfn dfn>pipeline</dfn>, be it {{GPUComputePipeline}} or {{GPURenderPipeline}},
 represents the complete function done by a combination of the GPU hardware, the driver,
 and the user agent, that process the input data in the shape of bindings and vertex buffers,
-and produces some output, like the colors in the output render targets.
+and produces some output, like the outputs in the output render targets.
 
 Structurally, the [=pipeline=] consists of a sequence of programmable stages (shaders)
 and fixed-function states, such as the blending modes.
@@ -3732,7 +3732,7 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
     GPURasterizerState rasterizer = {};
     GPUProgrammableStage fragmentStage;
     GPUDepthStencilState depthStencil;
-    required GPUOutputMergerState outputMerger;
+    required GPUColorWriteState colorWrite;
 };
 </script>
 
@@ -3754,7 +3754,7 @@ Refactor the shape of the render pipeline descriptor to clearly enumerate the
 ### No Color Output ### {#no-color-output}
 
 In no-color-output mode, [=pipeline=] does not produce any color attachment outputs,
-and the {{GPUOutputMergerState/colors}} is expected to be empty.
+and the {{GPUColorWriteState/outputs}} is expected to be empty.
 
 The [=pipeline=] still performs rasterization and produces depth values
 based on the vertex position output. The depth testing and stencil operations can still be used.
@@ -3850,14 +3850,14 @@ based on the vertex position output. The depth testing and stencil operations ca
             - [$validating GPURasterizerState$](|descriptor|.{{GPURenderPipelineDescriptor/rasterizer}},
                 |features|) succeeds.
             - If |descriptor|.{{GPURenderPipelineDescriptor/rasterizer}}.{{GPURasterizerState/sampleCount}} is 1:
-                - |descriptor|.{{GPURenderPipelineDescriptor/outputMerger}}.{{GPUOutputMergerState/alphaToCoverageEnabled}} is `false`,
+                - |descriptor|.{{GPURenderPipelineDescriptor/colorWrite}}.{{GPUColorWriteState/alphaToCoverageEnabled}} is `false`,
             - If |descriptor|.{{GPURenderPipelineDescriptor/fragmentStage}} is not `null`:
                 - [$validating GPUProgrammableStage$]({{GPUShaderStage/FRAGMENT}},
                     |descriptor|.{{GPURenderPipelineDescriptor/fragmentStage}},
                     |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
             - if |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}} is not `null`:
                 - [$validating GPUDepthStencilState$](|descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}) succeeds.
-            - [$validating GPUOutputMergerState$](|descriptor|.{{GPURenderPipelineDescriptor/outputMerger}},
+            - [$validating GPUColorWriteState$](|descriptor|.{{GPURenderPipelineDescriptor/colorWrite}},
                 |descriptor|.{{GPURenderPipelineDescriptor/fragmentStage}}) succeeds.
 </div>
 
@@ -4011,7 +4011,7 @@ based on the shape of the rasterized polygon. The samples incuded in the shape g
 bits 1 in the mask.
 
 The <dfn dfn>shader-output mask</dfn> takes the output value of SV_Coverage semantics in the fragment shader.
-If the semantics is not [=statically used=] by the shader, and {{GPUOutputMergerState/alphaToCoverageEnabled}}
+If the semantics is not [=statically used=] by the shader, and {{GPUColorWriteState/alphaToCoverageEnabled}}
 is enabled, the [=shader-output mask=] becomes the [=alpha-to-coverage mask=]. Otherwise, it defaults to 0xFFFFFFFF.
 
 Issue: link to the semantics of SV_SampleIndex and SV_Coverage in WGSL spec.
@@ -4019,44 +4019,44 @@ Issue: link to the semantics of SV_SampleIndex and SV_Coverage in WGSL spec.
 ### Output Merger State ### {#output-merger}
 
 <script type=idl>
-dictionary GPUOutputMergerState {
-    required sequence<GPUColorOutputState> colors;
+dictionary GPUColorWriteState {
+    required sequence<GPUColorOutputState> outputs;
     boolean alphaToCoverageEnabled = false;
 };
 </script>
 
-- {{GPUOutputMergerState/colors}} describes
+- {{GPUColorWriteState/outputs}} describes
     the color outputs that are written by the [=pipeline=].
-- {{GPUOutputMergerState/alphaToCoverageEnabled}} enables the [[#alpha-to-coverage]] mode.
+- {{GPUColorWriteState/alphaToCoverageEnabled}} enables the [[#alpha-to-coverage]] mode.
 
 <div algorithm>
-    <dfn abstract-op>validating GPUOutputMergerState</dfn>(descriptor, fragmentStage)
+    <dfn abstract-op>validating GPUColorWriteState</dfn>(descriptor, fragmentStage)
     **Arguments:**
         - {{GPUColorOutputState}} |descriptor|
         - {{GPUProgrammableStage}} |fragmentStage|
 
     Return `true`, if and only if, all of the following conditions are satisfied:
 
-        - For each |colorState| at |index| in |descriptor|.{{GPUOutputMergerState/colors}}:
+        - For each |colorState| at |index| in |descriptor|.{{GPUColorWriteState/outputs}}:
             - [$validating GPUColorOutputState$](|colorState|) succeeds.
             - |fragmentStage| contains an output variable [=statically used=]:
                 - with `location` annotation equal to |index|
-                - with a type that is compatible with |colorState|.{{GPUColorOutputState/format}}.
+                - with a type that is compatible with |colorState|.{{GPUColorOutputState/format}}
                     with {{GPUTextureUsage/RENDER_ATTACHMENT}} capability.
         - If the output `SV_Coverage` semantics is [=statically used=] by |fragmentStage|:
-            - |descriptor|.{{GPUOutputMergerState/alphaToCoverageEnabled}} is `false`.
+            - |descriptor|.{{GPUColorWriteState/alphaToCoverageEnabled}} is `false`.
         - If |fragmentStage| is `null`:
-            - |descriptor|.{{GPUOutputMergerState/colors}} is empty.
-        - |descriptor|.{{GPUOutputMergerState/colors}}.length is less than
+            - |descriptor|.{{GPUColorWriteState/outputs}} is empty.
+        - |descriptor|.{{GPUColorWriteState/outputs}}.length is less than
             or equal to 4.
 </div>
 
 #### Alpha to Coverage #### {#alpha-to-coverage}
 
-In alpha-to-coverage mode, which is enabled by {{GPUOutputMergerState/alphaToCoverageEnabled}},
+In alpha-to-coverage mode, which is enabled by {{GPUColorWriteState/alphaToCoverageEnabled}},
 an additional <dfn dfn>alpha-to-coverage mask</dfn>
 of MSAA samples is generated based on the |alpha| component of the
-fragment shader output value of the {{GPUOutputMergerState/colors}}[0].
+fragment shader output value of the {{GPUColorWriteState/outputs}}[0].
 
 The algorithm of producing the extra mask is platform-dependent and can vary for different pixels.
 It guarantees that:
@@ -7158,7 +7158,7 @@ typedef [EnforceRange] long GPUSignedOffset32;
 typedef unsigned long GPUFlagsConstant;
 </script>
 
-## Colors &amp; Vectors ## {#colors-and-vectors}
+## Colors &amp; Vectors ## {#outputs-and-vectors}
 
 <script type=idl>
 dictionary GPUColorDict {

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1049,14 +1049,14 @@ a better limit is not specified.
     <tr><td><dfn>maxVertexBuffers</dfn>
         <td>{{GPUSize32}} <td>Higher <td>8
     <tr class=row-continuation><td colspan=4>
-        The maximum number of {{GPUVertexStateDescriptor/vertexBuffers}}
+        The maximum number of {{GPUVertexInputState/vertexBuffers}}
         when creating a {{GPURenderPipeline}}.
 
     <tr><td><dfn>maxVertexAttributes</dfn>
         <td>{{GPUSize32}} <td>Higher <td>16
     <tr class=row-continuation><td colspan=4>
         The maximum number of {{GPUVertexBufferLayoutDescriptor/attributes}}
-        in total across {{GPUVertexStateDescriptor/vertexBuffers}}
+        in total across {{GPUVertexInputState/vertexBuffers}}
         when creating a {{GPURenderPipeline}}.
 
     <tr><td><dfn>maxVertexBufferArrayStride</dfn>
@@ -3359,7 +3359,7 @@ has a default layout created and used instead.
 
         1. Set |groupDesc|.{{GPUBindGroupLayoutDescriptor/entries}} to an empty sequence.
 
-    1. For each {{GPUProgrammableStageDescriptor}} |stageDesc| in the descriptor used to create the pipeline:
+    1. For each {{GPUProgrammableStage}} |stageDesc| in the descriptor used to create the pipeline:
 
         1. Let |stageInfo| be the "reflection information" for |stageDesc|.
 
@@ -3367,8 +3367,8 @@ has a default layout created and used instead.
                 spec and get information what the interface is for a {{GPUShaderModule}} for a specific
                 entrypoint.
 
-        1. Let |shaderStage| be the {{GPUShaderStageFlags}} for |stageDesc|.{{GPUProgrammableStageDescriptor/entryPoint}}
-            in |stageDesc|.{{GPUProgrammableStageDescriptor/module}}.
+        1. Let |shaderStage| be the {{GPUShaderStageFlags}} for |stageDesc|.{{GPUProgrammableStage/entryPoint}}
+            in |stageDesc|.{{GPUProgrammableStage/module}}.
         1. For each resource |resource| in |stageInfo|'s resource interface:
 
             1. Let |group| be |resource|'s "group" decoration.
@@ -3467,30 +3467,30 @@ has a default layout created and used instead.
 
 </div>
 
-### <dfn dictionary>GPUProgrammableStageDescriptor</dfn> ### {#GPUProgrammableStageDescriptor}
+### <dfn dictionary>GPUProgrammableStage</dfn> ### {#GPUProgrammableStage}
 
 <script type=idl>
-dictionary GPUProgrammableStageDescriptor {
+dictionary GPUProgrammableStage {
     required GPUShaderModule module;
     required USVString entryPoint;
 };
 </script>
 
-A {{GPUProgrammableStageDescriptor}} describes the entry point in the user-provided
+A {{GPUProgrammableStage}} describes the entry point in the user-provided
 {{GPUShaderModule}} that controls one of the programmable stages of a [=pipeline=].
 
 <div algorithm>
-    <dfn abstract-op>validating GPUProgrammableStageDescriptor</dfn>(stage, descriptor, layout)
+    <dfn abstract-op>validating GPUProgrammableStage</dfn>(stage, descriptor, layout)
         **Arguments:**
             - {{GPUShaderStage}} |stage|
-            - {{GPUProgrammableStageDescriptor}} |descriptor|
+            - {{GPUProgrammableStage}} |descriptor|
             - {{GPUPipelineLayout}} |layout|
 
         Return `true` if all of the following conditions are satisfied:
 
-            - The |descriptor|.{{GPUProgrammableStageDescriptor/module}} is [=valid=] {{GPUShaderModule}}.
-            - The |descriptor|.{{GPUProgrammableStageDescriptor/module}} contains
-                an entry point at |stage| named |descriptor|.{{GPUProgrammableStageDescriptor/entryPoint}}.
+            - The |descriptor|.{{GPUProgrammableStage/module}} is [=valid=] {{GPUShaderModule}}.
+            - The |descriptor|.{{GPUProgrammableStage/module}} contains
+                an entry point at |stage| named |descriptor|.{{GPUProgrammableStage/entryPoint}}.
             - For each |binding| that is [=statically used=] by the shader entry point,
                 the [$validating shader binding$](|binding|, |layout|) returns `true`.
             - For each texture sampling shader call that is [=statically used=] by the entry point:
@@ -3604,7 +3604,7 @@ GPUComputePipeline includes GPUPipelineBase;
 
 <script type=idl>
 dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
-    required GPUProgrammableStageDescriptor computeStage;
+    required GPUProgrammableStage computeStage;
 };
 </script>
 
@@ -3627,7 +3627,7 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
                 <div class=validusage>
                     - |this| is a [=valid=] {{GPUDevice}}.
                     - |descriptor|.{{GPUPipelineDescriptorBase/layout}} is [$valid to use with$] |this|.
-                    - [$validating GPUProgrammableStageDescriptor$]({{GPUShaderStage/COMPUTE}},
+                    - [$validating GPUProgrammableStage$]({{GPUShaderStage/COMPUTE}},
                         |descriptor|.{{GPUComputePipelineDescriptor/computeStage}},
                         |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
                 </div>
@@ -3678,24 +3678,24 @@ as well as {{GPURenderBundleEncoder}}.
 
 Render [=pipeline=] inputs are:
   - bindings, according to the given {{GPUPipelineLayout}}
-  - vertex and index buffers, described by {{GPUVertexStateDescriptor}}
+  - vertex and index buffers, described by {{GPUVertexInputState}}
   - the color attachments, described by {{GPUColorStateDescriptor}}
-  - optionally, the depth-stencil attachment, described by {{GPUDepthStencilStateDescriptor}}
+  - optionally, the depth-stencil attachment, described by {{GPUDepthStencilState}}
 
 Render [=pipeline=] outputs are:
   - {{GPUBindGroupLayoutEntry/buffer}} bindings with a {{GPUBufferBindingLayout/type}} of {{GPUBufferBindingType/"storage"}}
   - {{GPUBindGroupLayoutEntry/storageTexture}} bindings with a {{GPUStorageTextureBindingLayout/access}} of {{GPUStorageTextureAccess/"write-only"}}
   - the color attachments, described by {{GPUColorStateDescriptor}}
-  - optionally, depth-stencil attachment, described by {{GPUDepthStencilStateDescriptor}}
+  - optionally, depth-stencil attachment, described by {{GPUDepthStencilState}}
 
 Stages of a render [=pipeline=]:
-  1. Vertex fetch, controlled by {{GPUVertexStateDescriptor}}
+  1. Vertex fetch, controlled by {{GPUVertexInputState}}
   2. Vertex shader
   3. Primitive assembly - [[#primitive-assembly]]
-  4. Rasterization, controlled by {{GPURasterizerStateDescriptor}}
+  4. Rasterization, controlled by {{GPURasterizerState}}
   5. Fragment shader
-  6. Stencil test and operation, controlled by {{GPUDepthStencilStateDescriptor}}
-  7. Depth test and write, controlled by {{GPUDepthStencilStateDescriptor}}
+  6. Stencil test and operation, controlled by {{GPUDepthStencilState}}
+  7. Depth test and write, controlled by {{GPUDepthStencilState}}
   8. Output merging - [[#output-merger]]
 
 Issue: we need a deeper description of these stages
@@ -3726,13 +3726,13 @@ GPURenderPipeline includes GPUPipelineBase;
 
 <script type=idl>
 dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
-    GPUVertexStateDescriptor vertexState = {};
-    required GPUProgrammableStageDescriptor vertexStage;
-    GPUPrimitiveAssemblyStateDescriptor primitiveAssemblyState = {};
-    GPURasterizerStateDescriptor rasterizerState = {};
-    GPUProgrammableStageDescriptor fragmentStage;
-    GPUDepthStencilStateDescriptor depthStencilState;
-    required GPUOutputMergerStateDescriptor outputMergerState;
+    GPUVertexInputState vertexInput = {};
+    required GPUProgrammableStage vertexStage;
+    GPUPrimitiveAssemblerState primitiveAssembler = {};
+    GPURasterizerState rasterizer = {};
+    GPUProgrammableStage fragmentStage;
+    GPUDepthStencilState depthStencil;
+    required GPUOutputMergerState outputMerger;
 };
 </script>
 
@@ -3740,11 +3740,11 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
     the vertex shader entry point of the [=pipeline=]
 - {{GPURenderPipelineDescriptor/fragmentStage}} describes
     the fragment shader entry point of the [=pipeline=]. If it's `null`, the [[#no-color-output]] mode is enabled.
-- {{GPURenderPipelineDescriptor/rasterizerState}} configures
+- {{GPURenderPipelineDescriptor/rasterizer}} configures
     the rasterization stage of the [=pipeline=].
-- {{GPURenderPipelineDescriptor/depthStencilState}} describes
+- {{GPURenderPipelineDescriptor/depthStencil}} describes
     the optional depth-stencil attachment that is written by the [=pipeline=].
-- {{GPURenderPipelineDescriptor/vertexState}} configures
+- {{GPURenderPipelineDescriptor/vertexInput}} configures
     the vertex fetch stage of the [=pipeline=].
 
 Issue(https://github.com/gpuweb/gpuweb/issues/936):
@@ -3754,7 +3754,7 @@ Refactor the shape of the render pipeline descriptor to clearly enumerate the
 ### No Color Output ### {#no-color-output}
 
 In no-color-output mode, [=pipeline=] does not produce any color attachment outputs,
-and the {{GPUOutputMergerStateDescriptor/colorStates}} is expected to be empty.
+and the {{GPUOutputMergerState/colorStates}} is expected to be empty.
 
 The [=pipeline=] still performs rasterization and produces depth values
 based on the vertex position output. The depth testing and stencil operations can still be used.
@@ -3791,7 +3791,7 @@ based on the vertex position output. The depth testing and stencil operations ca
 
                     1. Set |pipeline|.{{GPURenderPipeline/[[descriptor]]}} to |descriptor|.
                     1. Set |pipeline|.{{GPURenderPipeline/[[strip_index_format]]}} to
-                        |descriptor|.{{GPURenderPipelineDescriptor/primitiveAssemblyState}}.{{GPUPrimitiveAssemblyStateDescriptor/stripIndexFormat}}.
+                        |descriptor|.{{GPURenderPipelineDescriptor/primitiveAssembler}}.{{GPUPrimitiveAssemblerState/stripIndexFormat}}.
 
                 </div>
             1. Return |pipeline|.
@@ -3840,24 +3840,24 @@ based on the vertex position output. The depth testing and stencil operations ca
 
         Return `true` if all of the following conditions are satisfied:
 
-            - [$validating GPUVertexStateDescriptor$](|descriptor|.{{GPURenderPipelineDescriptor/vertexState}},
+            - [$validating GPUVertexInputState$](|descriptor|.{{GPURenderPipelineDescriptor/vertexInput}},
                 |descriptor|.{{GPURenderPipelineDescriptor/vertexStage}}) succeeds.
-            - [$validating GPUProgrammableStageDescriptor$]({{GPUShaderStage/VERTEX}},
+            - [$validating GPUProgrammableStage$]({{GPUShaderStage/VERTEX}},
                 |descriptor|.{{GPURenderPipelineDescriptor/vertexStage}},
                 |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
-            - [$validating GPUPrimitiveAssemblyStateDescriptor$](|descriptor|.{{GPURenderPipelineDescriptor/primitiveAssemblyState}},
+            - [$validating GPUPrimitiveAssemblerState$](|descriptor|.{{GPURenderPipelineDescriptor/primitiveAssembler}},
                 |features|) succeeds.
-            - [$validating GPURasterizerStateDescriptor$](|descriptor|.{{GPURenderPipelineDescriptor/rasterizerState}},
+            - [$validating GPURasterizerState$](|descriptor|.{{GPURenderPipelineDescriptor/rasterizer}},
                 |features|) succeeds.
-            - If |descriptor|.{{GPURenderPipelineDescriptor/rasterizerState}}.{{GPURasterizerStateDescriptor/sampleCount}} is 1:
-                - |descriptor|.{{GPURenderPipelineDescriptor/outputMergerState}}.{{GPUOutputMergerStateDescriptor/alphaToCoverageEnabled}} is `false`,
+            - If |descriptor|.{{GPURenderPipelineDescriptor/rasterizer}}.{{GPURasterizerState/sampleCount}} is 1:
+                - |descriptor|.{{GPURenderPipelineDescriptor/outputMerger}}.{{GPUOutputMergerState/alphaToCoverageEnabled}} is `false`,
             - If |descriptor|.{{GPURenderPipelineDescriptor/fragmentStage}} is not `null`:
-                - [$validating GPUProgrammableStageDescriptor$]({{GPUShaderStage/FRAGMENT}},
+                - [$validating GPUProgrammableStage$]({{GPUShaderStage/FRAGMENT}},
                     |descriptor|.{{GPURenderPipelineDescriptor/fragmentStage}},
                     |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
-            - if |descriptor|.{{GPURenderPipelineDescriptor/depthStencilState}} is not `null`:
-                - [$validating GPUDepthStencilStateDescriptor$](|descriptor|.{{GPURenderPipelineDescriptor/depthStencilState}}) succeeds.
-            - [$validating GPUOutputMergerStateDescriptor$](|descriptor|.{{GPURenderPipelineDescriptor/outputMergerState}},
+            - if |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}} is not `null`:
+                - [$validating GPUDepthStencilState$](|descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}) succeeds.
+            - [$validating GPUOutputMergerState$](|descriptor|.{{GPURenderPipelineDescriptor/outputMerger}},
                 |descriptor|.{{GPURenderPipelineDescriptor/fragmentStage}}) succeeds.
 </div>
 
@@ -3872,15 +3872,15 @@ Issue: need a proper limit for the maximum number of color targets.
 ### Primitive Assembly ### {#primitive-assembly}
 
 <script type=idl>
-dictionary GPUPrimitiveAssemblyStateDescriptor {
+dictionary GPUPrimitiveAssemblerState {
     GPUPrimitiveTopology topology = "triangle-list";
     GPUIndexFormat stripIndexFormat;
 };
 </script>
 
-- {{GPUPrimitiveAssemblyStateDescriptor/topology}} defines what kind of
+- {{GPUPrimitiveAssemblerState/topology}} defines what kind of
     primitives are constructed by the [=pipeline=].
-- {{GPUPrimitiveAssemblyStateDescriptor/stripIndexFormat}} defines the supported
+- {{GPUPrimitiveAssemblerState/stripIndexFormat}} defines the supported
     index format for strip topologies.
 
 <script type=idl>
@@ -3894,15 +3894,15 @@ enum GPUPrimitiveTopology {
 </script>
 
 <div algorithm>
-    <dfn abstract-op>validating GPUPrimitiveAssemblyStateDescriptor</dfn>(|descriptor|)
+    <dfn abstract-op>validating GPUPrimitiveAssemblerState</dfn>(|descriptor|)
         Return `true` if all of the following conditions are met:
-            - If |descriptor|.{{GPUPrimitiveAssemblyStateDescriptor/topology}} is:
+            - If |descriptor|.{{GPUPrimitiveAssemblerState/topology}} is:
                 <dl class="switch">
                     : {{GPUPrimitiveTopology/"line-strip"}} or
                         {{GPUPrimitiveTopology/"triangle-strip"}}
-                    :: |descriptor|.{{GPUPrimitiveAssemblyStateDescriptor/stripIndexFormat}} is not `undefined`
+                    :: |descriptor|.{{GPUPrimitiveAssemblerState/stripIndexFormat}} is not `undefined`
                     : Otherwise
-                    :: |descriptor|.{{GPUPrimitiveAssemblyStateDescriptor/stripIndexFormat}} is `undefined`
+                    :: |descriptor|.{{GPUPrimitiveAssemblerState/stripIndexFormat}} is `undefined`
                 </dl>
 </div>
 
@@ -3922,8 +3922,8 @@ strip primitive topologies ({{GPUPrimitiveTopology/"line-strip"}} or
 should be started rather than continuing to construct the triangle strip with the prior indexed
 vertices.
 
-{{GPUPrimitiveAssemblyStateDescriptor}}s that specify a strip primitive topology must not have the
-{{GPUPrimitiveAssemblyStateDescriptor/stripIndexFormat}} set to `undefined`
+{{GPUPrimitiveAssemblerState}}s that specify a strip primitive topology must not have the
+{{GPUPrimitiveAssemblerState/stripIndexFormat}} set to `undefined`
 so that the [=primitive restart value=] that will be used is known at pipline creation time.
 
 <table class="data">
@@ -3949,7 +3949,7 @@ so that the [=primitive restart value=] that will be used is known at pipline cr
 ### Rasterization State ### {#rasterization-state}
 
 <script type=idl>
-dictionary GPURasterizerStateDescriptor {
+dictionary GPURasterizerState {
     GPUFrontFace frontFace = "ccw";
     GPUCullMode cullMode = "none";
     // Enable depth clamping (requires "depth-clamping" feature)
@@ -3964,15 +3964,15 @@ dictionary GPURasterizerStateDescriptor {
 };
 </script>
 
-- {{GPURasterizerStateDescriptor/sampleCount}} is
+- {{GPURasterizerState/sampleCount}} is
     the number of MSAA samples that each attachment has to have.
-- {{GPURasterizerStateDescriptor/sampleMask}} is
+- {{GPURasterizerState/sampleMask}} is
     a binary mask of MSAA samples, according to [[#sample-masking]].
 
 <div algorithm>
-    <dfn abstract-op>validating GPURasterizerStateDescriptor</dfn>(|device|, |descriptor|)
+    <dfn abstract-op>validating GPURasterizerState</dfn>(|device|, |descriptor|)
         Return `true` if all of the following conditions are met:
-            - |descriptor|.{{GPURasterizerStateDescriptor/clampDepth}} is `false`,
+            - |descriptor|.{{GPURasterizerState/clampDepth}} is `false`,
                 or |device|.{{device/[[features]]}} [=list/contain=] {{GPUFeatureName/"depth-clamping"}}.
 </div>
 
@@ -3994,9 +3994,9 @@ enum GPUCullMode {
 #### Sample Masking #### {#sample-masking}
 
 The <dfn dfn>final sample mask</dfn> for a pixel is computed as:
-[=rasterization mask=] & {{GPURasterizerStateDescriptor/sampleMask}} & [=shader-output mask=].
+[=rasterization mask=] & {{GPURasterizerState/sampleMask}} & [=shader-output mask=].
 
-Only the lower {{GPURasterizerStateDescriptor/sampleCount}} bits of the mask are considered.
+Only the lower {{GPURasterizerState/sampleCount}} bits of the mask are considered.
 
 If the least-significant bit at position |N| of the [=final sample mask=] has value of "0",
 the sample color outputs (corresponding to sample |N|) to all attachments of the fragment shader are discarded.
@@ -4011,7 +4011,7 @@ based on the shape of the rasterized polygon. The samples incuded in the shape g
 bits 1 in the mask.
 
 The <dfn dfn>shader-output mask</dfn> takes the output value of SV_Coverage semantics in the fragment shader.
-If the semantics is not [=statically used=] by the shader, and {{GPUOutputMergerStateDescriptor/alphaToCoverageEnabled}}
+If the semantics is not [=statically used=] by the shader, and {{GPUOutputMergerState/alphaToCoverageEnabled}}
 is enabled, the [=shader-output mask=] becomes the [=alpha-to-coverage mask=]. Otherwise, it defaults to 0xFFFFFFFF.
 
 Issue: link to the semantics of SV_SampleIndex and SV_Coverage in WGSL spec.
@@ -4019,44 +4019,44 @@ Issue: link to the semantics of SV_SampleIndex and SV_Coverage in WGSL spec.
 ### Output Merger State ### {#output-merger}
 
 <script type=idl>
-dictionary GPUOutputMergerStateDescriptor {
+dictionary GPUOutputMergerState {
     required sequence<GPUColorStateDescriptor> colorStates;
     boolean alphaToCoverageEnabled = false;
 };
 </script>
 
-- {{GPUOutputMergerStateDescriptor/colorStates}} describes
+- {{GPUOutputMergerState/colorStates}} describes
     the color attachments that are written by the [=pipeline=].
-- {{GPUOutputMergerStateDescriptor/alphaToCoverageEnabled}} enables the [[#alpha-to-coverage]] mode.
+- {{GPUOutputMergerState/alphaToCoverageEnabled}} enables the [[#alpha-to-coverage]] mode.
 
 <div algorithm>
-    <dfn abstract-op>validating GPUOutputMergerStateDescriptor</dfn>(descriptor, fragmentStage)
+    <dfn abstract-op>validating GPUOutputMergerState</dfn>(descriptor, fragmentStage)
     **Arguments:**
         - {{GPUColorStateDescriptor}} |descriptor|
-        - {{GPUProgrammableStageDescriptor}} |fragmentStage|
+        - {{GPUProgrammableStage}} |fragmentStage|
 
     Return `true`, if and only if, all of the following conditions are satisfied:
 
-        - For each |colorState| at |index| in |descriptor|.{{GPUOutputMergerStateDescriptor/colorStates}}:
+        - For each |colorState| at |index| in |descriptor|.{{GPUOutputMergerState/colorStates}}:
             - [$validating GPUColorStateDescriptor$](|colorState|) succeeds.
             - |fragmentStage| contains an output variable [=statically used=]:
                 - with `location` annotation equal to |index|
                 - with a type that is compatible with |colorState|.{{GPUColorStateDescriptor/format}}.
                     with {{GPUTextureUsage/RENDER_ATTACHMENT}} capability.
         - If the output `SV_Coverage` semantics is [=statically used=] by |fragmentStage|:
-            - |descriptor|.{{GPUOutputMergerStateDescriptor/alphaToCoverageEnabled}} is `false`.
+            - |descriptor|.{{GPUOutputMergerState/alphaToCoverageEnabled}} is `false`.
         - If |fragmentStage| is `null`:
-            - |descriptor|.{{GPUOutputMergerStateDescriptor/colorStates}} is empty.
-        - |descriptor|.{{GPUOutputMergerStateDescriptor/colorStates}}.length is less than
+            - |descriptor|.{{GPUOutputMergerState/colorStates}} is empty.
+        - |descriptor|.{{GPUOutputMergerState/colorStates}}.length is less than
             or equal to 4.
 </div>
 
 #### Alpha to Coverage #### {#alpha-to-coverage}
 
-In alpha-to-coverage mode, which is enabled by {{GPUOutputMergerStateDescriptor/alphaToCoverageEnabled}},
+In alpha-to-coverage mode, which is enabled by {{GPUOutputMergerState/alphaToCoverageEnabled}},
 an additional <dfn dfn>alpha-to-coverage mask</dfn>
 of MSAA samples is generated based on the |alpha| component of the
-fragment shader output value of the {{GPUOutputMergerStateDescriptor/colorStates}}[0].
+fragment shader output value of the {{GPUOutputMergerState/colorStates}}[0].
 
 The algorithm of producing the extra mask is platform-dependent and can vary for different pixels.
 It guarantees that:
@@ -4150,7 +4150,7 @@ enum GPUBlendOperation {
 ### Depth/Stencil State ### {#depth-stencil-state}
 
 <script type=idl>
-dictionary GPUDepthStencilStateDescriptor {
+dictionary GPUDepthStencilState {
     required GPUTextureFormat format;
 
     boolean depthWriteEnabled = false;
@@ -4187,19 +4187,19 @@ enum GPUStencilOperation {
 </script>
 
 <div algorithm>
-    <dfn abstract-op>validating GPUDepthStencilStateDescriptor</dfn>(descriptor)
+    <dfn abstract-op>validating GPUDepthStencilState</dfn>(descriptor)
     **Arguments:**
-        - {{GPUDepthStencilStateDescriptor}} |descriptor|
+        - {{GPUDepthStencilState}} |descriptor|
 
     Return `true`, if and only if, all of the following conditions are satisfied:
 
-        - |descriptor|.{{GPUDepthStencilStateDescriptor/format}} is listed in {#depth-formats}.
-        - if |descriptor|.{{GPUDepthStencilStateDescriptor/depthWriteEnabled}} is `true` or
-            |descriptor|.{{GPUDepthStencilStateDescriptor/depthCompare}} is not {{GPUCompareFunction/"always"}}:
-            - |descriptor|.{{GPUDepthStencilStateDescriptor/format}} must have a depth component.
-        - if |descriptor|.{{GPUDepthStencilStateDescriptor/stencilFront}} or
-            |descriptor|.{{GPUDepthStencilStateDescriptor/stencilBack}} are not default values:
-            - |descriptor|.{{GPUDepthStencilStateDescriptor/format}} must have a stencil component.
+        - |descriptor|.{{GPUDepthStencilState/format}} is listed in {#depth-formats}.
+        - if |descriptor|.{{GPUDepthStencilState/depthWriteEnabled}} is `true` or
+            |descriptor|.{{GPUDepthStencilState/depthCompare}} is not {{GPUCompareFunction/"always"}}:
+            - |descriptor|.{{GPUDepthStencilState/format}} must have a depth component.
+        - if |descriptor|.{{GPUDepthStencilState/stencilFront}} or
+            |descriptor|.{{GPUDepthStencilState/stencilBack}} are not default values:
+            - |descriptor|.{{GPUDepthStencilState/format}} must have a stencil component.
 
     Issue: how can this algorithm support depth/stencil formats that are added in extensions?
 </div>
@@ -4267,7 +4267,7 @@ enum GPUInputStepMode {
 </script>
 
 <script type=idl>
-dictionary GPUVertexStateDescriptor {
+dictionary GPUVertexInputState {
     sequence<GPUVertexBufferLayoutDescriptor?> vertexBuffers = [];
 };
 </script>
@@ -4283,7 +4283,7 @@ Each {{GPUVertexAttributeDescriptor}} describes its
 
 Each attribute appears as a separate input in a vertex shader, each bound by a numeric *location*,
 which is specified by {{GPUVertexAttributeDescriptor/shaderLocation}}.
-Every location must be unique within the {{GPUVertexStateDescriptor}}.
+Every location must be unique within the {{GPUVertexInputState}}.
 
 <script type=idl>
 dictionary GPUVertexBufferLayoutDescriptor {
@@ -4306,7 +4306,7 @@ dictionary GPUVertexAttributeDescriptor {
     <dfn abstract-op>validating GPUVertexBufferLayoutDescriptor</dfn>(descriptor, vertexStage)
     **Arguments:**
         - {{GPUVertexBufferLayoutDescriptor}} |descriptor|
-        - {{GPUProgrammableStageDescriptor}} |vertexStage|
+        - {{GPUProgrammableStage}} |vertexStage|
 
     Return `true`, if and only if, all of the following conditions are satisfied:
 
@@ -4315,30 +4315,30 @@ dictionary GPUVertexAttributeDescriptor {
         1. Any attribute |at| in the list |descriptor|.{{GPUVertexBufferLayoutDescriptor/attributes}} has
             |at|.{{GPUVertexAttributeDescriptor/offset}} + sizeOf(|at|.{{GPUVertexAttributeDescriptor/format}}) less or equal to
             |descriptor|.{{GPUVertexBufferLayoutDescriptor/arrayStride}}.
-        1. For every vertex attribute in the shader reflection of |vertexStage|.{{GPUProgrammableStageDescriptor/module}}
-            that is know to be [=statically used=] by |vertexStage|.{{GPUProgrammableStageDescriptor/entryPoint}},
+        1. For every vertex attribute in the shader reflection of |vertexStage|.{{GPUProgrammableStage/module}}
+            that is know to be [=statically used=] by |vertexStage|.{{GPUProgrammableStage/entryPoint}},
             there is a corresponding |at| element of |descriptor|.{{GPUVertexBufferLayoutDescriptor/attributes}} that:
             1. The shader format is |at|.{{GPUVertexAttributeDescriptor/format}}.
             2. The shader location is |at|.{{GPUVertexAttributeDescriptor/shaderLocation}}.
 </div>
 
 <div algorithm>
-    <dfn abstract-op>validating GPUVertexStateDescriptor</dfn>(descriptor, vertexStage)
+    <dfn abstract-op>validating GPUVertexInputState</dfn>(descriptor, vertexStage)
     **Arguments:**
-        - {{GPUVertexStateDescriptor}} |descriptor|
-        - {{GPUProgrammableStageDescriptor}} |vertexStage|
+        - {{GPUVertexInputState}} |descriptor|
+        - {{GPUProgrammableStage}} |vertexStage|
 
     Return `true`, if and only if, all of the following conditions are satisfied:
 
-        1. |descriptor|.{{GPUVertexStateDescriptor/vertexBuffers}}.length is less than or equal to
+        1. |descriptor|.{{GPUVertexInputState/vertexBuffers}}.length is less than or equal to
             {{GPULimits/maxVertexBuffers|GPULimits.maxVertexBuffers}}
-        1. Each |vertexBuffer| layout descriptor in the list |descriptor|.{{GPUVertexStateDescriptor/vertexBuffers}}
+        1. Each |vertexBuffer| layout descriptor in the list |descriptor|.{{GPUVertexInputState/vertexBuffers}}
             passes [$validating GPUVertexBufferLayoutDescriptor$](|vertexBuffer|, |vertexStage|)
         1. The sum of |vertexBuffer|.{{GPUVertexBufferLayoutDescriptor/attributes}}.length,
-            over every |vertexBuffer| in |descriptor|.{{GPUVertexStateDescriptor/vertexBuffers}},
+            over every |vertexBuffer| in |descriptor|.{{GPUVertexInputState/vertexBuffers}},
             is less than or equal to {{GPULimits/maxVertexAttributes|GPULimits.maxVertexAttributes}}.
         1. Each |at| in the union of all {{GPUVertexAttributeDescriptor}}
-            across |descriptor|.{{GPUVertexStateDescriptor/vertexBuffers}} has a distinct
+            across |descriptor|.{{GPUVertexInputState/vertexBuffers}} has a distinct
             |at|.{{GPUVertexAttributeDescriptor/shaderLocation}} value.
 </div>
 
@@ -6235,7 +6235,7 @@ enum GPUStoreOp {
 
             - Let |pipelineDescriptor| be |encoder|.{{GPURenderEncoderBase/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.
             - For each {{GPUIndex32}} |slot| `0` to
-                |pipelineDescriptor|.{{GPURenderPipelineDescriptor/vertexState}}.{{GPUVertexStateDescriptor/vertexBuffers}}.length:
+                |pipelineDescriptor|.{{GPURenderPipelineDescriptor/vertexInput}}.{{GPUVertexInputState/vertexBuffers}}.length:
                 - |encoder|.{{GPURenderEncoderBase/[[vertex_buffers]]}}[|slot|] must not be `null`.
         </div>
 
@@ -7262,9 +7262,9 @@ The following dictionary values are supported if and only if the {{GPUFeatureNam
 [=feature=] is enabled, otherwise they must be set to their default values:
 
 <dl>
-    : {{GPURasterizerStateDescriptor}}
+    : {{GPURasterizerState}}
     ::
-        * {{GPURasterizerStateDescriptor/clampDepth}}
+        * {{GPURasterizerState/clampDepth}}
 </dl>
 
 ## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>depth24unorm-stencil8</dfn> ## {#depth24unorm-stencil8}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3691,7 +3691,7 @@ Render [=pipeline=] outputs are:
 Stages of a render [=pipeline=]:
   1. Vertex fetch, controlled by {{GPUVertexStateDescriptor}}
   2. Vertex shader
-  3. Primitive assembly, controlled by {{GPUPrimitiveTopology}}
+  3. Primitive assembly - [[#primitive-assembly]]
   4. Rasterization, controlled by {{GPURasterizationStateDescriptor}}
   5. Fragment shader
   6. Stencil test and operation, controlled by {{GPUDepthStencilStateDescriptor}}
@@ -3726,18 +3726,13 @@ GPURenderPipeline includes GPUPipelineBase;
 
 <script type=idl>
 dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
-    required GPUProgrammableStageDescriptor vertexStage;
-    GPUProgrammableStageDescriptor fragmentStage;
-
-    required GPUPrimitiveTopology primitiveTopology;
-    GPURasterizationStateDescriptor rasterizationState = {};
-    required sequence<GPUColorStateDescriptor> colorStates;
-    GPUDepthStencilStateDescriptor depthStencilState;
     GPUVertexStateDescriptor vertexState = {};
-
-    GPUSize32 sampleCount = 1;
-    GPUSampleMask sampleMask = 0xFFFFFFFF;
-    boolean alphaToCoverageEnabled = false;
+    required GPUProgrammableStageDescriptor vertexStage;
+    GPUPrimitiveAssemblyStateDescriptor primitiveAssemblyState = {};
+    GPURasterizationStateDescriptor rasterizationState = {};
+    GPUProgrammableStageDescriptor fragmentStage;
+    GPUDepthStencilStateDescriptor depthStencilState;
+    required sequence<GPUColorStateDescriptor> colorStates;
 };
 </script>
 
@@ -3745,8 +3740,6 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
     the vertex shader entry point of the [=pipeline=]
 - {{GPURenderPipelineDescriptor/fragmentStage}} describes
     the fragment shader entry point of the [=pipeline=]. If it's `null`, the [[#no-color-output]] mode is enabled.
-- {{GPURenderPipelineDescriptor/primitiveTopology}} configures
-    the primitive assembly stage of the [=pipeline=].
 - {{GPURenderPipelineDescriptor/rasterizationState}} configures
     the rasterization stage of the [=pipeline=].
 - {{GPURenderPipelineDescriptor/colorStates}} describes
@@ -3755,11 +3748,6 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
     the optional depth-stencil attachment that is written by the [=pipeline=].
 - {{GPURenderPipelineDescriptor/vertexState}} configures
     the vertex fetch stage of the [=pipeline=].
-- {{GPURenderPipelineDescriptor/sampleCount}} is
-    the number of MSAA samples that each attachment has to have.
-- {{GPURenderPipelineDescriptor/sampleMask}} is
-    a binary mask of MSAA samples, according to [[#sample-masking]].
-- {{GPURenderPipelineDescriptor/alphaToCoverageEnabled}} enables the [[#alpha-to-coverage]] mode.
 
 Issue(https://github.com/gpuweb/gpuweb/issues/936):
 Refactor the shape of the render pipeline descriptor to clearly enumerate the
@@ -3772,44 +3760,6 @@ and the {{GPURenderPipelineDescriptor/colorStates}} is expected to be empty.
 
 The [=pipeline=] still performs rasterization and produces depth values
 based on the vertex position output. The depth testing and stencil operations can still be used.
-
-### Alpha to Coverage ### {#alpha-to-coverage}
-
-In alpha-to-coverage mode, an additional <dfn dfn>alpha-to-coverage mask</dfn>
-of MSAA samples is generated based on the |alpha| component of the
-fragment shader output value of the {{GPURenderPipelineDescriptor/colorStates}}[0].
-
-The algorithm of producing the extra mask is platform-dependent and can vary for different pixels.
-It guarantees that:
-  - if |alpha| is 0.0 or less, the result is 0x0
-  - if |alpha| is 1.0 or greater, the result is 0xFFFFFFFF
-  - if |alpha| is greater than some other |alpha1|,
-    then the produced sample mask has at least as many bits set to 1 as the mask for |alpha1|
-
-### Sample Masking ### {#sample-masking}
-
-The <dfn dfn>final sample mask</dfn> for a pixel is computed as:
-[=rasterization mask=] & {{GPURenderPipelineDescriptor/sampleMask}} & [=shader-output mask=].
-
-Only the lower {{GPURenderPipelineDescriptor/sampleCount}} bits of the mask are considered.
-
-If the least-significant bit at position |N| of the [=final sample mask=] has value of "0",
-the sample color outputs (corresponding to sample |N|) to all attachments of the fragment shader are discarded.
-Also, no depth test or stencil operations are executed on the relevant samples of the depth-stencil attachment.
-
-Note: the color output for sample |N| is produced by the fragment shader execution
-with SV_SampleIndex == |N| for the current pixel.
-If the fragment shader doesn't use this semantics, it's only executed once per pixel.
-
-The <dfn dfn>rasterization mask</dfn> is produced by the rasterization stage,
-based on the shape of the rasterized polygon. The samples incuded in the shape get the relevant
-bits 1 in the mask.
-
-The <dfn dfn>shader-output mask</dfn> takes the output value of SV_Coverage semantics in the fragment shader.
-If the semantics is not [=statically used=] by the shader, and {{GPURenderPipelineDescriptor/alphaToCoverageEnabled}}
-is enabled, the [=shader-output mask=] becomes the [=alpha-to-coverage mask=]. Otherwise, it defaults to 0xFFFFFFFF.
-
-Issue: link to the semantics of SV_SampleIndex and SV_Coverage in WGSL spec.
 
 <dl dfn-type=method dfn-for=GPUDevice>
     : <dfn>createRenderPipeline(descriptor)</dfn>
@@ -3842,10 +3792,8 @@ Issue: link to the semantics of SV_SampleIndex and SV_Coverage in WGSL spec.
                             1. Make |pipeline| [=invalid=].
 
                     1. Set |pipeline|.{{GPURenderPipeline/[[descriptor]]}} to |descriptor|.
-                    1. If |descriptor|.{{GPURenderPipelineDescriptor/primitiveTopology}} is
-                        {{GPUPrimitiveTopology/"line-strip"}} or {{GPUPrimitiveTopology/"triangle-strip"}}:
-                        1. Set |pipeline|.{{GPURenderPipeline/[[strip_index_format]]}} to
-                            |descriptor|.{{GPURenderPipelineDescriptor/vertexState}}.{{GPUVertexStateDescriptor/indexFormat}}.
+                    1. Set |pipeline|.{{GPURenderPipeline/[[strip_index_format]]}} to
+                        |descriptor|.{{GPURenderPipelineDescriptor/primitiveAssemblyState}}.{{GPUPrimitiveAssemblyStateDescriptor/stripIndexFormat}}.
 
                 </div>
             1. Return |pipeline|.
@@ -3940,7 +3888,19 @@ Issue: define what "compatible" means for render target formats.
 
 Issue: need a proper limit for the maximum number of color targets.
 
-### Primitive Topology ### {#primitive-topology}
+### Primitive Assembly ### {#primitive-assembly}
+
+<script type=idl>
+dictionary GPUPrimitiveAssemblyStateDescriptor {
+    GPUPrimitiveTopology topology = "triangle-list";
+    GPUIndexFormat stripIndexFormat;
+};
+</script>
+
+- {{GPUPrimitiveAssemblyStateDescriptor/topology}} defines what kind of
+    primitives are constructed by the [=pipeline=].
+- {{GPUPrimitiveAssemblyStateDescriptor/stripIndexFormat}} defines the supported
+    index format for strip topologies.
 
 <script type=idl>
 enum GPUPrimitiveTopology {
@@ -3948,8 +3908,61 @@ enum GPUPrimitiveTopology {
     "line-list",
     "line-strip",
     "triangle-list",
-    "triangle-strip"
+    "triangle-strip",
 };
+</script>
+
+<div algorithm>
+    <dfn abstract-op>validating GPUPrimitiveAssemblyStateDescriptor</dfn>(|descriptor|)
+        Return `true` if all of the following conditions are met:
+            - If |descriptor|.{{GPUPrimitiveAssemblyStateDescriptor/topology}} is:
+                <dl class="switch">
+                    : {{GPUPrimitiveTopology/"line-strip"}} or
+                        {{GPUPrimitiveTopology/"triangle-strip"}}
+                    :: |descriptor|.{{GPUPrimitiveAssemblyStateDescriptor/stripIndexFormat}} is not `undefined`
+                    : Otherwise
+                    :: |descriptor|.{{GPUPrimitiveAssemblyStateDescriptor/stripIndexFormat}} is `undefined`
+                </dl>
+</div>
+
+### Index Format ### {#index-format}
+
+<script type=idl>
+enum GPUIndexFormat {
+    "uint16",
+    "uint32"
+};
+</script>
+
+The index format determines both the data type of index values in a buffer and, when used with
+strip primitive topologies ({{GPUPrimitiveTopology/"line-strip"}} or
+{{GPUPrimitiveTopology/"triangle-strip"}}) also specifies the primitive restart value. The
+<dfn dfn>primitive restart value</dfn> indicates which index value indicates that a new primitive
+should be started rather than continuing to construct the triangle strip with the prior indexed
+vertices.
+
+{{GPUPrimitiveAssemblyStateDescriptor}}s that specify a strip primitive topology must not have the
+{{GPUPrimitiveAssemblyStateDescriptor/stripIndexFormat}} set to `undefined`
+so that the [=primitive restart value=] that will be used is known at pipline creation time.
+
+<table class="data">
+  <thead>
+    <tr>
+      <th>Index format</th>
+      <th>Primitive restart value</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>{{GPUIndexFormat/"uint16"}}</td>
+      <td>0xFFFF</td>
+    </tr>
+    <tr>
+      <td>{{GPUIndexFormat/"uint32"}}</td>
+      <td>0xFFFFFFFF</td>
+    </tr>
+  </tbody>
+</table>
 </script>
 
 ### Rasterization State ### {#rasterization-state}
@@ -3964,14 +3977,26 @@ dictionary GPURasterizationStateDescriptor {
     GPUDepthBias depthBias = 0;
     float depthBiasSlopeScale = 0;
     float depthBiasClamp = 0;
+
+    GPUSize32 sampleCount = 1;
+    GPUSampleMask sampleMask = 0xFFFFFFFF;
+    boolean alphaToCoverageEnabled = false;
 };
 </script>
 
+- {{GPURasterizationStateDescriptor/sampleCount}} is
+    the number of MSAA samples that each attachment has to have.
+- {{GPURasterizationStateDescriptor/sampleMask}} is
+    a binary mask of MSAA samples, according to [[#sample-masking]].
+- {{GPURasterizationStateDescriptor/alphaToCoverageEnabled}} enables the [[#alpha-to-coverage]] mode.
+
 <div algorithm>
-    <dfn abstract-op>validating GPURasterizationStateDescriptor</dfn>(|descriptor|, |features|)
-        1. If |descriptor|.{{GPURasterizationStateDescriptor/clampDepth}} is `true` and |features|
-            doesn't [=list/contain=] {{GPUFeatureName/"depth-clamping"}}, return `false`.
-        1. Return `true`.
+    <dfn abstract-op>validating GPURasterizationStateDescriptor</dfn>(|device|, |descriptor|)
+        Return `true` if all of the following conditions are met:
+            - |descriptor|.{{GPURasterizationStateDescriptor/clampDepth}} is `false`,
+                or |device|.{{device/[[features]]}} [=list/contain=] {{GPUFeatureName/"depth-clamping"}}.
+            - |descriptor|.{{GPURasterizationStateDescriptor/alphaToCoverageEnabled}} is `false`,
+                or |descriptor|.{{GPURasterizationStateDescriptor/sampleCount}} is greater than 1.
 </div>
 
 <script type=idl>
@@ -3988,6 +4013,45 @@ enum GPUCullMode {
     "back"
 };
 </script>
+
+#### Alpha to Coverage #### {#alpha-to-coverage}
+
+In alpha-to-coverage mode, which is enabled by {{GPURasterizationStateDescriptor/alphaToCoverageEnabled}},
+an additional <dfn dfn>alpha-to-coverage mask</dfn>
+of MSAA samples is generated based on the |alpha| component of the
+fragment shader output value of the {{GPURenderPipelineDescriptor/colorStates}}[0].
+
+The algorithm of producing the extra mask is platform-dependent and can vary for different pixels.
+It guarantees that:
+  - if |alpha| is 0.0 or less, the result is 0x0
+  - if |alpha| is 1.0 or greater, the result is 0xFFFFFFFF
+  - if |alpha| is greater than some other |alpha1|,
+    then the produced sample mask has at least as many bits set to 1 as the mask for |alpha1|
+
+#### Sample Masking #### {#sample-masking}
+
+The <dfn dfn>final sample mask</dfn> for a pixel is computed as:
+[=rasterization mask=] & {{GPURasterizationStateDescriptor/sampleMask}} & [=shader-output mask=].
+
+Only the lower {{GPURasterizationStateDescriptor/sampleCount}} bits of the mask are considered.
+
+If the least-significant bit at position |N| of the [=final sample mask=] has value of "0",
+the sample color outputs (corresponding to sample |N|) to all attachments of the fragment shader are discarded.
+Also, no depth test or stencil operations are executed on the relevant samples of the depth-stencil attachment.
+
+Note: the color output for sample |N| is produced by the fragment shader execution
+with SV_SampleIndex == |N| for the current pixel.
+If the fragment shader doesn't use this semantics, it's only executed once per pixel.
+
+The <dfn dfn>rasterization mask</dfn> is produced by the rasterization stage,
+based on the shape of the rasterized polygon. The samples incuded in the shape get the relevant
+bits 1 in the mask.
+
+The <dfn dfn>shader-output mask</dfn> takes the output value of SV_Coverage semantics in the fragment shader.
+If the semantics is not [=statically used=] by the shader, and {{GPURasterizationStateDescriptor/alphaToCoverageEnabled}}
+is enabled, the [=shader-output mask=] becomes the [=alpha-to-coverage mask=]. Otherwise, it defaults to 0xFFFFFFFF.
+
+Issue: link to the semantics of SV_SampleIndex and SV_Coverage in WGSL spec.
 
 ### Color State ### {#color-state}
 
@@ -4133,43 +4197,6 @@ enum GPUStencilOperation {
 
 ### Vertex State ### {#vertex-state}
 
-<script type=idl>
-enum GPUIndexFormat {
-    "uint16",
-    "uint32"
-};
-</script>
-
-The index format determines both the data type of index values in a buffer and, when used with
-strip primitive topologies ({{GPUPrimitiveTopology/"line-strip"}} or
-{{GPUPrimitiveTopology/"triangle-strip"}}) also specifies the primitive restart value. The
-<dfn dfn>primitive restart value</dfn> indicates which index value indicates that a new primitive
-should be started rather than continuing to construct the triangle strip with the prior indexed
-vertices.
-
-{{GPURenderPipelineDescriptor}}s that specify a strip primitive topology must not have the
-{{GPUVertexStateDescriptor/indexFormat}} set to `undefined` so that the [=primitive restart value=]
-that will be used is known at pipline creation time.
-
-<table class="data">
-  <thead>
-    <tr>
-      <th>Index format</th>
-      <th>Primitive restart value</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>{{GPUIndexFormat/"uint16"}}</td>
-      <td>0xFFFF</td>
-    </tr>
-    <tr>
-      <td>{{GPUIndexFormat/"uint32"}}</td>
-      <td>0xFFFFFFFF</td>
-    </tr>
-  </tbody>
-</table>
-
 #### Vertex Formats #### {#vertex-formats}
 
 The name of the format specifies the data type of the component, the number of
@@ -4232,7 +4259,6 @@ enum GPUInputStepMode {
 
 <script type=idl>
 dictionary GPUVertexStateDescriptor {
-    GPUIndexFormat indexFormat;
     sequence<GPUVertexBufferLayoutDescriptor?> vertexBuffers = [];
 };
 </script>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3692,11 +3692,11 @@ Stages of a render [=pipeline=]:
   1. Vertex fetch, controlled by {{GPUVertexStateDescriptor}}
   2. Vertex shader
   3. Primitive assembly - [[#primitive-assembly]]
-  4. Rasterization, controlled by {{GPURasterizationStateDescriptor}}
+  4. Rasterization, controlled by {{GPURasterizerStateDescriptor}}
   5. Fragment shader
   6. Stencil test and operation, controlled by {{GPUDepthStencilStateDescriptor}}
   7. Depth test and write, controlled by {{GPUDepthStencilStateDescriptor}}
-  8. Output merging, controlled by {{GPUColorStateDescriptor}}
+  8. Output merging - [[#output-merger]]
 
 Issue: we need a deeper description of these stages
 
@@ -3729,10 +3729,10 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
     GPUVertexStateDescriptor vertexState = {};
     required GPUProgrammableStageDescriptor vertexStage;
     GPUPrimitiveAssemblyStateDescriptor primitiveAssemblyState = {};
-    GPURasterizationStateDescriptor rasterizationState = {};
+    GPURasterizerStateDescriptor rasterizerState = {};
     GPUProgrammableStageDescriptor fragmentStage;
     GPUDepthStencilStateDescriptor depthStencilState;
-    required sequence<GPUColorStateDescriptor> colorStates;
+    required GPUOutputMergerStateDescriptor outputMergerState;
 };
 </script>
 
@@ -3740,10 +3740,8 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
     the vertex shader entry point of the [=pipeline=]
 - {{GPURenderPipelineDescriptor/fragmentStage}} describes
     the fragment shader entry point of the [=pipeline=]. If it's `null`, the [[#no-color-output]] mode is enabled.
-- {{GPURenderPipelineDescriptor/rasterizationState}} configures
+- {{GPURenderPipelineDescriptor/rasterizerState}} configures
     the rasterization stage of the [=pipeline=].
-- {{GPURenderPipelineDescriptor/colorStates}} describes
-    the color attachments that are written by the [=pipeline=].
 - {{GPURenderPipelineDescriptor/depthStencilState}} describes
     the optional depth-stencil attachment that is written by the [=pipeline=].
 - {{GPURenderPipelineDescriptor/vertexState}} configures
@@ -3756,7 +3754,7 @@ Refactor the shape of the render pipeline descriptor to clearly enumerate the
 ### No Color Output ### {#no-color-output}
 
 In no-color-output mode, [=pipeline=] does not produce any color attachment outputs,
-and the {{GPURenderPipelineDescriptor/colorStates}} is expected to be empty.
+and the {{GPUOutputMergerStateDescriptor/colorStates}} is expected to be empty.
 
 The [=pipeline=] still performs rasterization and produces depth values
 based on the vertex position output. The depth testing and stencil operations can still be used.
@@ -3842,42 +3840,25 @@ based on the vertex position output. The depth testing and stencil operations ca
 
         Return `true` if all of the following conditions are satisfied:
 
+            - [$validating GPUVertexStateDescriptor$](|descriptor|.{{GPURenderPipelineDescriptor/vertexState}},
+                |descriptor|.{{GPURenderPipelineDescriptor/vertexStage}}) succeeds.
             - [$validating GPUProgrammableStageDescriptor$]({{GPUShaderStage/VERTEX}},
                 |descriptor|.{{GPURenderPipelineDescriptor/vertexStage}},
                 |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
+            - [$validating GPUPrimitiveAssemblyStateDescriptor$](|descriptor|.{{GPURenderPipelineDescriptor/primitiveAssemblyState}},
+                |features|) succeeds.
+            - [$validating GPURasterizerStateDescriptor$](|descriptor|.{{GPURenderPipelineDescriptor/rasterizerState}},
+                |features|) succeeds.
+            - If |descriptor|.{{GPURenderPipelineDescriptor/rasterizerState}}.{{GPURasterizerStateDescriptor/sampleCount}} is 1:
+                - |descriptor|.{{GPURenderPipelineDescriptor/outputMergerState}}.{{GPUOutputMergerStateDescriptor/alphaToCoverageEnabled}} is `false`,
             - If |descriptor|.{{GPURenderPipelineDescriptor/fragmentStage}} is not `null`:
                 - [$validating GPUProgrammableStageDescriptor$]({{GPUShaderStage/FRAGMENT}},
                     |descriptor|.{{GPURenderPipelineDescriptor/fragmentStage}},
                     |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
-            - If |descriptor|.{{GPURenderPipelineDescriptor/fragmentStage}} is `null`:
-                - |descriptor|.{{GPURenderPipelineDescriptor/colorStates}} is empty.
-            - |descriptor|.{{GPURenderPipelineDescriptor/colorStates}}.length is less than
-                or equal to 4.
-            - For each |colorState| layout descriptor in the list
-                |descriptor|.{{GPURenderPipelineDescriptor/colorStates}}:
-                - [$validating GPUColorStateDescriptor$](|colorState|,
-                    |descriptor|.{{GPURenderPipelineDescriptor/fragmentStage}}) succeeds.
-            - [$validating GPURasterizationStateDescriptor$](|descriptor|.{{GPURenderPipelineDescriptor/rasterizationState}},
-                |features|) succeeds.
             - if |descriptor|.{{GPURenderPipelineDescriptor/depthStencilState}} is not `null`:
                 - [$validating GPUDepthStencilStateDescriptor$](|descriptor|.{{GPURenderPipelineDescriptor/depthStencilState}}) succeeds.
-            - [$validating GPUVertexStateDescriptor$](|descriptor|.{{GPURenderPipelineDescriptor/vertexState}},
-                |descriptor|.{{GPURenderPipelineDescriptor/vertexStage}}) succeeds.
-            - If |descriptor|.{{GPURenderPipelineDescriptor/alphaToCoverageEnabled}} is `true`:
-                - |descriptor|.{{GPURenderPipelineDescriptor/sampleCount}} is greater than 1.
-            - If the output SV_Coverage semantics is [=statically used=] by
-                |descriptor|.{{GPURenderPipelineDescriptor/fragmentStage}}:
-                - |descriptor|.{{GPURenderPipelineDescriptor/alphaToCoverageEnabled}} is `false`.
-            - If |descriptor|.{{GPURenderPipelineDescriptor/primitiveTopology}} is:
-                <dl class="switch">
-                    : {{GPUPrimitiveTopology/"line-strip"}} or
-                        {{GPUPrimitiveTopology/"triangle-strip"}}
-                    :: |descriptor|.{{GPURenderPipelineDescriptor/vertexState}}.{{GPUVertexStateDescriptor/indexFormat}}
-                        is not `undefined`
-                    : Otherwise
-                    :: |descriptor|.{{GPURenderPipelineDescriptor/vertexState}}.{{GPUVertexStateDescriptor/indexFormat}}
-                        is `undefined`
-                </dl>
+            - [$validating GPUOutputMergerStateDescriptor$](|descriptor|.{{GPURenderPipelineDescriptor/outputMergerState}},
+                |descriptor|.{{GPURenderPipelineDescriptor/fragmentStage}}) succeeds.
 </div>
 
 Issue: validate interface matching rules between VS and FS.
@@ -3968,7 +3949,7 @@ so that the [=primitive restart value=] that will be used is known at pipline cr
 ### Rasterization State ### {#rasterization-state}
 
 <script type=idl>
-dictionary GPURasterizationStateDescriptor {
+dictionary GPURasterizerStateDescriptor {
     GPUFrontFace frontFace = "ccw";
     GPUCullMode cullMode = "none";
     // Enable depth clamping (requires "depth-clamping" feature)
@@ -3980,23 +3961,19 @@ dictionary GPURasterizationStateDescriptor {
 
     GPUSize32 sampleCount = 1;
     GPUSampleMask sampleMask = 0xFFFFFFFF;
-    boolean alphaToCoverageEnabled = false;
 };
 </script>
 
-- {{GPURasterizationStateDescriptor/sampleCount}} is
+- {{GPURasterizerStateDescriptor/sampleCount}} is
     the number of MSAA samples that each attachment has to have.
-- {{GPURasterizationStateDescriptor/sampleMask}} is
+- {{GPURasterizerStateDescriptor/sampleMask}} is
     a binary mask of MSAA samples, according to [[#sample-masking]].
-- {{GPURasterizationStateDescriptor/alphaToCoverageEnabled}} enables the [[#alpha-to-coverage]] mode.
 
 <div algorithm>
-    <dfn abstract-op>validating GPURasterizationStateDescriptor</dfn>(|device|, |descriptor|)
+    <dfn abstract-op>validating GPURasterizerStateDescriptor</dfn>(|device|, |descriptor|)
         Return `true` if all of the following conditions are met:
-            - |descriptor|.{{GPURasterizationStateDescriptor/clampDepth}} is `false`,
+            - |descriptor|.{{GPURasterizerStateDescriptor/clampDepth}} is `false`,
                 or |device|.{{device/[[features]]}} [=list/contain=] {{GPUFeatureName/"depth-clamping"}}.
-            - |descriptor|.{{GPURasterizationStateDescriptor/alphaToCoverageEnabled}} is `false`,
-                or |descriptor|.{{GPURasterizationStateDescriptor/sampleCount}} is greater than 1.
 </div>
 
 <script type=idl>
@@ -4014,26 +3991,12 @@ enum GPUCullMode {
 };
 </script>
 
-#### Alpha to Coverage #### {#alpha-to-coverage}
-
-In alpha-to-coverage mode, which is enabled by {{GPURasterizationStateDescriptor/alphaToCoverageEnabled}},
-an additional <dfn dfn>alpha-to-coverage mask</dfn>
-of MSAA samples is generated based on the |alpha| component of the
-fragment shader output value of the {{GPURenderPipelineDescriptor/colorStates}}[0].
-
-The algorithm of producing the extra mask is platform-dependent and can vary for different pixels.
-It guarantees that:
-  - if |alpha| is 0.0 or less, the result is 0x0
-  - if |alpha| is 1.0 or greater, the result is 0xFFFFFFFF
-  - if |alpha| is greater than some other |alpha1|,
-    then the produced sample mask has at least as many bits set to 1 as the mask for |alpha1|
-
 #### Sample Masking #### {#sample-masking}
 
 The <dfn dfn>final sample mask</dfn> for a pixel is computed as:
-[=rasterization mask=] & {{GPURasterizationStateDescriptor/sampleMask}} & [=shader-output mask=].
+[=rasterization mask=] & {{GPURasterizerStateDescriptor/sampleMask}} & [=shader-output mask=].
 
-Only the lower {{GPURasterizationStateDescriptor/sampleCount}} bits of the mask are considered.
+Only the lower {{GPURasterizerStateDescriptor/sampleCount}} bits of the mask are considered.
 
 If the least-significant bit at position |N| of the [=final sample mask=] has value of "0",
 the sample color outputs (corresponding to sample |N|) to all attachments of the fragment shader are discarded.
@@ -4048,12 +4011,61 @@ based on the shape of the rasterized polygon. The samples incuded in the shape g
 bits 1 in the mask.
 
 The <dfn dfn>shader-output mask</dfn> takes the output value of SV_Coverage semantics in the fragment shader.
-If the semantics is not [=statically used=] by the shader, and {{GPURasterizationStateDescriptor/alphaToCoverageEnabled}}
+If the semantics is not [=statically used=] by the shader, and {{GPUOutputMergerStateDescriptor/alphaToCoverageEnabled}}
 is enabled, the [=shader-output mask=] becomes the [=alpha-to-coverage mask=]. Otherwise, it defaults to 0xFFFFFFFF.
 
 Issue: link to the semantics of SV_SampleIndex and SV_Coverage in WGSL spec.
 
-### Color State ### {#color-state}
+### Output Merger State ### {#output-merger}
+
+<script type=idl>
+dictionary GPUOutputMergerStateDescriptor {
+    required sequence<GPUColorStateDescriptor> colorStates;
+    boolean alphaToCoverageEnabled = false;
+};
+</script>
+
+- {{GPUOutputMergerStateDescriptor/colorStates}} describes
+    the color attachments that are written by the [=pipeline=].
+- {{GPUOutputMergerStateDescriptor/alphaToCoverageEnabled}} enables the [[#alpha-to-coverage]] mode.
+
+<div algorithm>
+    <dfn abstract-op>validating GPUOutputMergerStateDescriptor</dfn>(descriptor, fragmentStage)
+    **Arguments:**
+        - {{GPUColorStateDescriptor}} |descriptor|
+        - {{GPUProgrammableStageDescriptor}} |fragmentStage|
+
+    Return `true`, if and only if, all of the following conditions are satisfied:
+
+        - For each |colorState| at |index| in |descriptor|.{{GPUOutputMergerStateDescriptor/colorStates}}:
+            - [$validating GPUColorStateDescriptor$](|colorState|) succeeds.
+            - |fragmentStage| contains an output variable [=statically used=]:
+                - with `location` annotation equal to |index|
+                - with a type that is compatible with |colorState|.{{GPUColorStateDescriptor/format}}.
+                    with {{GPUTextureUsage/RENDER_ATTACHMENT}} capability.
+        - If the output `SV_Coverage` semantics is [=statically used=] by |fragmentStage|:
+            - |descriptor|.{{GPUOutputMergerStateDescriptor/alphaToCoverageEnabled}} is `false`.
+        - If |fragmentStage| is `null`:
+            - |descriptor|.{{GPUOutputMergerStateDescriptor/colorStates}} is empty.
+        - |descriptor|.{{GPUOutputMergerStateDescriptor/colorStates}}.length is less than
+            or equal to 4.
+</div>
+
+#### Alpha to Coverage #### {#alpha-to-coverage}
+
+In alpha-to-coverage mode, which is enabled by {{GPUOutputMergerStateDescriptor/alphaToCoverageEnabled}},
+an additional <dfn dfn>alpha-to-coverage mask</dfn>
+of MSAA samples is generated based on the |alpha| component of the
+fragment shader output value of the {{GPUOutputMergerStateDescriptor/colorStates}}[0].
+
+The algorithm of producing the extra mask is platform-dependent and can vary for different pixels.
+It guarantees that:
+  - if |alpha| is 0.0 or less, the result is 0x0
+  - if |alpha| is 1.0 or greater, the result is 0xFFFFFFFF
+  - if |alpha| is greater than some other |alpha1|,
+    then the produced sample mask has at least as many bits set to 1 as the mask for |alpha1|
+
+#### Color State #### {#color-state}
 
 <script type=idl>
 dictionary GPUColorStateDescriptor {
@@ -4121,10 +4133,9 @@ enum GPUBlendOperation {
 </script>
 
 <div algorithm>
-    <dfn abstract-op>validating GPUColorStateDescriptor</dfn>(descriptor, fragmentStage)
+    <dfn abstract-op>validating GPUColorStateDescriptor</dfn>(descriptor)
     **Arguments:**
         - {{GPUColorStateDescriptor}} |descriptor|
-        - {{GPUProgrammableStageDescriptor}} |fragmentStage|
 
     Return `true`, if and only if, all of the following conditions are satisfied:
 
@@ -4134,8 +4145,6 @@ enum GPUBlendOperation {
             or the |descriptor|.{{GPUColorStateDescriptor/format}} is filterable
             according to the {#plain-color-formats} table.
         - |descriptor|.{{GPUColorStateDescriptor/writeMask}} is less than 16.
-        - |fragmentStage| contains an output variable with a type that is compatible with
-            |descriptor|.{{GPUColorStateDescriptor/format}}.
 </div>
 
 ### Depth/Stencil State ### {#depth-stencil-state}
@@ -7253,9 +7262,9 @@ The following dictionary values are supported if and only if the {{GPUFeatureNam
 [=feature=] is enabled, otherwise they must be set to their default values:
 
 <dl>
-    : {{GPURasterizationStateDescriptor}}
+    : {{GPURasterizerStateDescriptor}}
     ::
-        * {{GPURasterizationStateDescriptor/clampDepth}}
+        * {{GPURasterizerStateDescriptor/clampDepth}}
 </dl>
 
 ## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>depth24unorm-stencil8</dfn> ## {#depth24unorm-stencil8}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -185,7 +185,7 @@ thead.stickyheader th, th.stickyheader {
 }
 
 /*
- * Darkmode outputs
+ * Darkmode colors
  */
 :root {
     --watermark-text: rgba(0, 0, 0, 15%);
@@ -3275,7 +3275,7 @@ integration such as source-language debugging.
 A <dfn dfn>pipeline</dfn>, be it {{GPUComputePipeline}} or {{GPURenderPipeline}},
 represents the complete function done by a combination of the GPU hardware, the driver,
 and the user agent, that process the input data in the shape of bindings and vertex buffers,
-and produces some output, like the outputs in the output render targets.
+and produces some output, like the colors in the output render targets.
 
 Structurally, the [=pipeline=] consists of a sequence of programmable stages (shaders)
 and fixed-function states, such as the blending modes.
@@ -3692,11 +3692,11 @@ Stages of a render [=pipeline=]:
   1. Vertex fetch, controlled by {{GPUVertexInputState}}
   2. Vertex shader
   3. Primitive assembly - [[#primitive-assembly]]
-  4. Rasterization, controlled by {{GPURasterizerState}}
+  4. Rasterization - [[#rasterization]]
   5. Fragment shader
   6. Stencil test and operation, controlled by {{GPUDepthStencilState}}
   7. Depth test and write, controlled by {{GPUDepthStencilState}}
-  8. Output merging - [[#output-merger]]
+  8. Color write - [[#color-write]]
 
 Issue: we need a deeper description of these stages
 
@@ -3728,8 +3728,8 @@ GPURenderPipeline includes GPUPipelineBase;
 dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
     GPUVertexInputState vertexInput = {};
     required GPUProgrammableStage vertexStage;
-    GPUPrimitiveAssemblerState primitiveAssembler = {};
-    GPURasterizerState rasterizer = {};
+    GPUPrimitiveAssemblyState primitiveAssembly = {};
+    GPURasterizationState rasterization = {};
     GPUProgrammableStage fragmentStage;
     GPUDepthStencilState depthStencil;
     required GPUColorWriteState colorWrite;
@@ -3740,7 +3740,7 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
     the vertex shader entry point of the [=pipeline=]
 - {{GPURenderPipelineDescriptor/fragmentStage}} describes
     the fragment shader entry point of the [=pipeline=]. If it's `null`, the [[#no-color-output]] mode is enabled.
-- {{GPURenderPipelineDescriptor/rasterizer}} configures
+- {{GPURenderPipelineDescriptor/rasterization}} configures
     the rasterization stage of the [=pipeline=].
 - {{GPURenderPipelineDescriptor/depthStencil}} describes
     the optional depth-stencil attachment that is written by the [=pipeline=].
@@ -3750,14 +3750,6 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
 Issue(https://github.com/gpuweb/gpuweb/issues/936):
 Refactor the shape of the render pipeline descriptor to clearly enumerate the
 (ordered) list of pipeline stages. And start formalizing the spec text.
-
-### No Color Output ### {#no-color-output}
-
-In no-color-output mode, [=pipeline=] does not produce any color attachment outputs,
-and the {{GPUColorWriteState/outputs}} is expected to be empty.
-
-The [=pipeline=] still performs rasterization and produces depth values
-based on the vertex position output. The depth testing and stencil operations can still be used.
 
 <dl dfn-type=method dfn-for=GPUDevice>
     : <dfn>createRenderPipeline(descriptor)</dfn>
@@ -3791,7 +3783,7 @@ based on the vertex position output. The depth testing and stencil operations ca
 
                     1. Set |pipeline|.{{GPURenderPipeline/[[descriptor]]}} to |descriptor|.
                     1. Set |pipeline|.{{GPURenderPipeline/[[strip_index_format]]}} to
-                        |descriptor|.{{GPURenderPipelineDescriptor/primitiveAssembler}}.{{GPUPrimitiveAssemblerState/stripIndexFormat}}.
+                        |descriptor|.{{GPURenderPipelineDescriptor/primitiveAssembly}}.{{GPUPrimitiveAssemblyState/stripIndexFormat}}.
 
                 </div>
             1. Return |pipeline|.
@@ -3845,11 +3837,11 @@ based on the vertex position output. The depth testing and stencil operations ca
             - [$validating GPUProgrammableStage$]({{GPUShaderStage/VERTEX}},
                 |descriptor|.{{GPURenderPipelineDescriptor/vertexStage}},
                 |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
-            - [$validating GPUPrimitiveAssemblerState$](|descriptor|.{{GPURenderPipelineDescriptor/primitiveAssembler}},
+            - [$validating GPUPrimitiveAssemblyState$](|descriptor|.{{GPURenderPipelineDescriptor/primitiveAssembly}},
                 |features|) succeeds.
-            - [$validating GPURasterizerState$](|descriptor|.{{GPURenderPipelineDescriptor/rasterizer}},
+            - [$validating GPURasterizationState$](|descriptor|.{{GPURenderPipelineDescriptor/rasterization}},
                 |features|) succeeds.
-            - If |descriptor|.{{GPURenderPipelineDescriptor/rasterizer}}.{{GPURasterizerState/sampleCount}} is 1:
+            - If |descriptor|.{{GPURenderPipelineDescriptor/rasterization}}.{{GPURasterizationState/sampleCount}} is 1:
                 - |descriptor|.{{GPURenderPipelineDescriptor/colorWrite}}.{{GPUColorWriteState/alphaToCoverageEnabled}} is `false`,
             - If |descriptor|.{{GPURenderPipelineDescriptor/fragmentStage}} is not `null`:
                 - [$validating GPUProgrammableStage$]({{GPUShaderStage/FRAGMENT}},
@@ -3869,18 +3861,18 @@ Issue: define what "compatible" means for render target formats.
 
 Issue: need a proper limit for the maximum number of color targets.
 
-### Primitive Assembly ### {#primitive-assembly}
+### Primitive Assembly State ### {#primitive-assembly}
 
 <script type=idl>
-dictionary GPUPrimitiveAssemblerState {
+dictionary GPUPrimitiveAssemblyState {
     GPUPrimitiveTopology topology = "triangle-list";
     GPUIndexFormat stripIndexFormat;
 };
 </script>
 
-- {{GPUPrimitiveAssemblerState/topology}} defines what kind of
+- {{GPUPrimitiveAssemblyState/topology}} defines what kind of
     primitives are constructed by the [=pipeline=].
-- {{GPUPrimitiveAssemblerState/stripIndexFormat}} defines the supported
+- {{GPUPrimitiveAssemblyState/stripIndexFormat}} defines the supported
     index format for strip topologies.
 
 <script type=idl>
@@ -3894,15 +3886,15 @@ enum GPUPrimitiveTopology {
 </script>
 
 <div algorithm>
-    <dfn abstract-op>validating GPUPrimitiveAssemblerState</dfn>(|descriptor|)
+    <dfn abstract-op>validating GPUPrimitiveAssemblyState</dfn>(|descriptor|)
         Return `true` if all of the following conditions are met:
-            - If |descriptor|.{{GPUPrimitiveAssemblerState/topology}} is:
+            - If |descriptor|.{{GPUPrimitiveAssemblyState/topology}} is:
                 <dl class="switch">
                     : {{GPUPrimitiveTopology/"line-strip"}} or
                         {{GPUPrimitiveTopology/"triangle-strip"}}
-                    :: |descriptor|.{{GPUPrimitiveAssemblerState/stripIndexFormat}} is not `undefined`
+                    :: |descriptor|.{{GPUPrimitiveAssemblyState/stripIndexFormat}} is not `undefined`
                     : Otherwise
-                    :: |descriptor|.{{GPUPrimitiveAssemblerState/stripIndexFormat}} is `undefined`
+                    :: |descriptor|.{{GPUPrimitiveAssemblyState/stripIndexFormat}} is `undefined`
                 </dl>
 </div>
 
@@ -3922,8 +3914,8 @@ strip primitive topologies ({{GPUPrimitiveTopology/"line-strip"}} or
 should be started rather than continuing to construct the triangle strip with the prior indexed
 vertices.
 
-{{GPUPrimitiveAssemblerState}}s that specify a strip primitive topology must not have the
-{{GPUPrimitiveAssemblerState/stripIndexFormat}} set to `undefined`
+{{GPUPrimitiveAssemblyState}}s that specify a strip primitive topology must not have the
+{{GPUPrimitiveAssemblyState/stripIndexFormat}} set to `undefined`
 so that the [=primitive restart value=] that will be used is known at pipline creation time.
 
 <table class="data">
@@ -3946,10 +3938,10 @@ so that the [=primitive restart value=] that will be used is known at pipline cr
 </table>
 </script>
 
-### Rasterization State ### {#rasterization-state}
+### Rasterizer State ### {#rasterization}
 
 <script type=idl>
-dictionary GPURasterizerState {
+dictionary GPURasterizationState {
     GPUFrontFace frontFace = "ccw";
     GPUCullMode cullMode = "none";
     // Enable depth clamping (requires "depth-clamping" feature)
@@ -3964,15 +3956,15 @@ dictionary GPURasterizerState {
 };
 </script>
 
-- {{GPURasterizerState/sampleCount}} is
+- {{GPURasterizationState/sampleCount}} is
     the number of MSAA samples that each attachment has to have.
-- {{GPURasterizerState/sampleMask}} is
+- {{GPURasterizationState/sampleMask}} is
     a binary mask of MSAA samples, according to [[#sample-masking]].
 
 <div algorithm>
-    <dfn abstract-op>validating GPURasterizerState</dfn>(|device|, |descriptor|)
+    <dfn abstract-op>validating GPURasterizationState</dfn>(|device|, |descriptor|)
         Return `true` if all of the following conditions are met:
-            - |descriptor|.{{GPURasterizerState/clampDepth}} is `false`,
+            - |descriptor|.{{GPURasterizationState/clampDepth}} is `false`,
                 or |device|.{{device/[[features]]}} [=list/contain=] {{GPUFeatureName/"depth-clamping"}}.
 </div>
 
@@ -3994,9 +3986,9 @@ enum GPUCullMode {
 #### Sample Masking #### {#sample-masking}
 
 The <dfn dfn>final sample mask</dfn> for a pixel is computed as:
-[=rasterization mask=] & {{GPURasterizerState/sampleMask}} & [=shader-output mask=].
+[=rasterization mask=] & {{GPURasterizationState/sampleMask}} & [=shader-output mask=].
 
-Only the lower {{GPURasterizerState/sampleCount}} bits of the mask are considered.
+Only the lower {{GPURasterizationState/sampleCount}} bits of the mask are considered.
 
 If the least-significant bit at position |N| of the [=final sample mask=] has value of "0",
 the sample color outputs (corresponding to sample |N|) to all attachments of the fragment shader are discarded.
@@ -4016,7 +4008,7 @@ is enabled, the [=shader-output mask=] becomes the [=alpha-to-coverage mask=]. O
 
 Issue: link to the semantics of SV_SampleIndex and SV_Coverage in WGSL spec.
 
-### Output Merger State ### {#output-merger}
+### Color Write State ### {#color-write}
 
 <script type=idl>
 dictionary GPUColorWriteState {
@@ -4051,6 +4043,14 @@ dictionary GPUColorWriteState {
             or equal to 4.
 </div>
 
+#### No Color Output #### {#no-color-output}
+
+In no-color-output mode, [=pipeline=] does not produce any color attachment outputs,
+and the {{GPUColorWriteState/outputs}} is expected to be empty.
+
+The [=pipeline=] still performs rasterization and produces depth values
+based on the vertex position output. The depth testing and stencil operations can still be used.
+
 #### Alpha to Coverage #### {#alpha-to-coverage}
 
 In alpha-to-coverage mode, which is enabled by {{GPUColorWriteState/alphaToCoverageEnabled}},
@@ -4065,7 +4065,7 @@ It guarantees that:
   - if |alpha| is greater than some other |alpha1|,
     then the produced sample mask has at least as many bits set to 1 as the mask for |alpha1|
 
-#### Color State #### {#color-state}
+#### Color Output State #### {#color-output-state}
 
 <script type=idl>
 dictionary GPUColorOutputState {
@@ -7262,9 +7262,9 @@ The following dictionary values are supported if and only if the {{GPUFeatureNam
 [=feature=] is enabled, otherwise they must be set to their default values:
 
 <dl>
-    : {{GPURasterizerState}}
+    : {{GPURasterizationState}}
     ::
-        * {{GPURasterizerState/clampDepth}}
+        * {{GPURasterizationState/clampDepth}}
 </dl>
 
 ## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>depth24unorm-stencil8</dfn> ## {#depth24unorm-stencil8}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1055,14 +1055,14 @@ a better limit is not specified.
     <tr><td><dfn>maxVertexAttributes</dfn>
         <td>{{GPUSize32}} <td>Higher <td>16
     <tr class=row-continuation><td colspan=4>
-        The maximum number of {{GPUVertexBufferLayoutDescriptor/attributes}}
+        The maximum number of {{GPUVertexBufferLayout/attributes}}
         in total across {{GPUVertexInputState/vertexBuffers}}
         when creating a {{GPURenderPipeline}}.
 
     <tr><td><dfn>maxVertexBufferArrayStride</dfn>
         <td>{{GPUSize32}} <td>Higher <td>2048
     <tr class=row-continuation><td colspan=4>
-        The maximum allowed {{GPUVertexBufferLayoutDescriptor/arrayStride}}
+        The maximum allowed {{GPUVertexBufferLayout/arrayStride}}
         when creating a {{GPURenderPipeline}}.
 </table>
 
@@ -3679,13 +3679,13 @@ as well as {{GPURenderBundleEncoder}}.
 Render [=pipeline=] inputs are:
   - bindings, according to the given {{GPUPipelineLayout}}
   - vertex and index buffers, described by {{GPUVertexInputState}}
-  - the color attachments, described by {{GPUColorStateDescriptor}}
+  - the color attachments, described by {{GPUColorOutputState}}
   - optionally, the depth-stencil attachment, described by {{GPUDepthStencilState}}
 
 Render [=pipeline=] outputs are:
   - {{GPUBindGroupLayoutEntry/buffer}} bindings with a {{GPUBufferBindingLayout/type}} of {{GPUBufferBindingType/"storage"}}
   - {{GPUBindGroupLayoutEntry/storageTexture}} bindings with a {{GPUStorageTextureBindingLayout/access}} of {{GPUStorageTextureAccess/"write-only"}}
-  - the color attachments, described by {{GPUColorStateDescriptor}}
+  - the color attachments, described by {{GPUColorOutputState}}
   - optionally, depth-stencil attachment, described by {{GPUDepthStencilState}}
 
 Stages of a render [=pipeline=]:
@@ -3754,7 +3754,7 @@ Refactor the shape of the render pipeline descriptor to clearly enumerate the
 ### No Color Output ### {#no-color-output}
 
 In no-color-output mode, [=pipeline=] does not produce any color attachment outputs,
-and the {{GPUOutputMergerState/colorStates}} is expected to be empty.
+and the {{GPUOutputMergerState/colors}} is expected to be empty.
 
 The [=pipeline=] still performs rasterization and produces depth values
 based on the vertex position output. The depth testing and stencil operations can still be used.
@@ -4020,34 +4020,34 @@ Issue: link to the semantics of SV_SampleIndex and SV_Coverage in WGSL spec.
 
 <script type=idl>
 dictionary GPUOutputMergerState {
-    required sequence<GPUColorStateDescriptor> colorStates;
+    required sequence<GPUColorOutputState> colors;
     boolean alphaToCoverageEnabled = false;
 };
 </script>
 
-- {{GPUOutputMergerState/colorStates}} describes
-    the color attachments that are written by the [=pipeline=].
+- {{GPUOutputMergerState/colors}} describes
+    the color outputs that are written by the [=pipeline=].
 - {{GPUOutputMergerState/alphaToCoverageEnabled}} enables the [[#alpha-to-coverage]] mode.
 
 <div algorithm>
     <dfn abstract-op>validating GPUOutputMergerState</dfn>(descriptor, fragmentStage)
     **Arguments:**
-        - {{GPUColorStateDescriptor}} |descriptor|
+        - {{GPUColorOutputState}} |descriptor|
         - {{GPUProgrammableStage}} |fragmentStage|
 
     Return `true`, if and only if, all of the following conditions are satisfied:
 
-        - For each |colorState| at |index| in |descriptor|.{{GPUOutputMergerState/colorStates}}:
-            - [$validating GPUColorStateDescriptor$](|colorState|) succeeds.
+        - For each |colorState| at |index| in |descriptor|.{{GPUOutputMergerState/colors}}:
+            - [$validating GPUColorOutputState$](|colorState|) succeeds.
             - |fragmentStage| contains an output variable [=statically used=]:
                 - with `location` annotation equal to |index|
-                - with a type that is compatible with |colorState|.{{GPUColorStateDescriptor/format}}.
+                - with a type that is compatible with |colorState|.{{GPUColorOutputState/format}}.
                     with {{GPUTextureUsage/RENDER_ATTACHMENT}} capability.
         - If the output `SV_Coverage` semantics is [=statically used=] by |fragmentStage|:
             - |descriptor|.{{GPUOutputMergerState/alphaToCoverageEnabled}} is `false`.
         - If |fragmentStage| is `null`:
-            - |descriptor|.{{GPUOutputMergerState/colorStates}} is empty.
-        - |descriptor|.{{GPUOutputMergerState/colorStates}}.length is less than
+            - |descriptor|.{{GPUOutputMergerState/colors}} is empty.
+        - |descriptor|.{{GPUOutputMergerState/colors}}.length is less than
             or equal to 4.
 </div>
 
@@ -4056,7 +4056,7 @@ dictionary GPUOutputMergerState {
 In alpha-to-coverage mode, which is enabled by {{GPUOutputMergerState/alphaToCoverageEnabled}},
 an additional <dfn dfn>alpha-to-coverage mask</dfn>
 of MSAA samples is generated based on the |alpha| component of the
-fragment shader output value of the {{GPUOutputMergerState/colorStates}}[0].
+fragment shader output value of the {{GPUOutputMergerState/colors}}[0].
 
 The algorithm of producing the extra mask is platform-dependent and can vary for different pixels.
 It guarantees that:
@@ -4068,7 +4068,7 @@ It guarantees that:
 #### Color State #### {#color-state}
 
 <script type=idl>
-dictionary GPUColorStateDescriptor {
+dictionary GPUColorOutputState {
     required GPUTextureFormat format;
 
     GPUBlendDescriptor blend;
@@ -4133,18 +4133,18 @@ enum GPUBlendOperation {
 </script>
 
 <div algorithm>
-    <dfn abstract-op>validating GPUColorStateDescriptor</dfn>(descriptor)
+    <dfn abstract-op>validating GPUColorOutputState</dfn>(descriptor)
     **Arguments:**
-        - {{GPUColorStateDescriptor}} |descriptor|
+        - {{GPUColorOutputState}} |descriptor|
 
     Return `true`, if and only if, all of the following conditions are satisfied:
 
-        - |descriptor|.{{GPUColorStateDescriptor/format}} is listed in {#plain-color-formats}
+        - |descriptor|.{{GPUColorOutputState/format}} is listed in {#plain-color-formats}
             with {{GPUTextureUsage/RENDER_ATTACHMENT}} capability.
-        - |descriptor|.{{GPUColorStateDescriptor/blend}} is either `undefined`,
-            or the |descriptor|.{{GPUColorStateDescriptor/format}} is filterable
+        - |descriptor|.{{GPUColorOutputState/blend}} is either `undefined`,
+            or the |descriptor|.{{GPUColorOutputState/format}} is filterable
             according to the {#plain-color-formats} table.
-        - |descriptor|.{{GPUColorStateDescriptor/writeMask}} is less than 16.
+        - |descriptor|.{{GPUColorOutputState/writeMask}} is less than 16.
 </div>
 
 ### Depth/Stencil State ### {#depth-stencil-state}
@@ -4268,33 +4268,33 @@ enum GPUInputStepMode {
 
 <script type=idl>
 dictionary GPUVertexInputState {
-    sequence<GPUVertexBufferLayoutDescriptor?> vertexBuffers = [];
+    sequence<GPUVertexBufferLayout?> vertexBuffers = [];
 };
 </script>
 
 A <dfn dfn>vertex buffer</dfn> is, conceptually, a view into buffer memory as an *array of structures*.
-{{GPUVertexBufferLayoutDescriptor/arrayStride}} is the stride, in bytes, between *elements* of that array.
+{{GPUVertexBufferLayout/arrayStride}} is the stride, in bytes, between *elements* of that array.
 Each element of a vertex buffer is like a *structure* with a memory layout defined by its
-{{GPUVertexBufferLayoutDescriptor/attributes}}, which describe the *members* of the structure.
+{{GPUVertexBufferLayout/attributes}}, which describe the *members* of the structure.
 
-Each {{GPUVertexAttributeDescriptor}} describes its
-{{GPUVertexAttributeDescriptor/format}} and its
-{{GPUVertexAttributeDescriptor/offset}}, in bytes, within the structure.
+Each {{GPUVertexAttribute}} describes its
+{{GPUVertexAttribute/format}} and its
+{{GPUVertexAttribute/offset}}, in bytes, within the structure.
 
 Each attribute appears as a separate input in a vertex shader, each bound by a numeric *location*,
-which is specified by {{GPUVertexAttributeDescriptor/shaderLocation}}.
+which is specified by {{GPUVertexAttribute/shaderLocation}}.
 Every location must be unique within the {{GPUVertexInputState}}.
 
 <script type=idl>
-dictionary GPUVertexBufferLayoutDescriptor {
+dictionary GPUVertexBufferLayout {
     required GPUSize64 arrayStride;
     GPUInputStepMode stepMode = "vertex";
-    required sequence<GPUVertexAttributeDescriptor> attributes;
+    required sequence<GPUVertexAttribute> attributes;
 };
 </script>
 
 <script type=idl>
-dictionary GPUVertexAttributeDescriptor {
+dictionary GPUVertexAttribute {
     required GPUVertexFormat format;
     required GPUSize64 offset;
 
@@ -4303,23 +4303,23 @@ dictionary GPUVertexAttributeDescriptor {
 </script>
 
 <div algorithm>
-    <dfn abstract-op>validating GPUVertexBufferLayoutDescriptor</dfn>(descriptor, vertexStage)
+    <dfn abstract-op>validating GPUVertexBufferLayout</dfn>(descriptor, vertexStage)
     **Arguments:**
-        - {{GPUVertexBufferLayoutDescriptor}} |descriptor|
+        - {{GPUVertexBufferLayout}} |descriptor|
         - {{GPUProgrammableStage}} |vertexStage|
 
     Return `true`, if and only if, all of the following conditions are satisfied:
 
-        1. |descriptor|.{{GPUVertexBufferLayoutDescriptor/arrayStride}} is less than or equal to
+        1. |descriptor|.{{GPUVertexBufferLayout/arrayStride}} is less than or equal to
             {{GPULimits/maxVertexBufferArrayStride|GPULimits.maxVertexBufferArrayStride}}.
-        1. Any attribute |at| in the list |descriptor|.{{GPUVertexBufferLayoutDescriptor/attributes}} has
-            |at|.{{GPUVertexAttributeDescriptor/offset}} + sizeOf(|at|.{{GPUVertexAttributeDescriptor/format}}) less or equal to
-            |descriptor|.{{GPUVertexBufferLayoutDescriptor/arrayStride}}.
+        1. Any attribute |at| in the list |descriptor|.{{GPUVertexBufferLayout/attributes}} has
+            |at|.{{GPUVertexAttribute/offset}} + sizeOf(|at|.{{GPUVertexAttribute/format}}) less or equal to
+            |descriptor|.{{GPUVertexBufferLayout/arrayStride}}.
         1. For every vertex attribute in the shader reflection of |vertexStage|.{{GPUProgrammableStage/module}}
             that is know to be [=statically used=] by |vertexStage|.{{GPUProgrammableStage/entryPoint}},
-            there is a corresponding |at| element of |descriptor|.{{GPUVertexBufferLayoutDescriptor/attributes}} that:
-            1. The shader format is |at|.{{GPUVertexAttributeDescriptor/format}}.
-            2. The shader location is |at|.{{GPUVertexAttributeDescriptor/shaderLocation}}.
+            there is a corresponding |at| element of |descriptor|.{{GPUVertexBufferLayout/attributes}} that:
+            1. The shader format is |at|.{{GPUVertexAttribute/format}}.
+            2. The shader location is |at|.{{GPUVertexAttribute/shaderLocation}}.
 </div>
 
 <div algorithm>
@@ -4333,13 +4333,13 @@ dictionary GPUVertexAttributeDescriptor {
         1. |descriptor|.{{GPUVertexInputState/vertexBuffers}}.length is less than or equal to
             {{GPULimits/maxVertexBuffers|GPULimits.maxVertexBuffers}}
         1. Each |vertexBuffer| layout descriptor in the list |descriptor|.{{GPUVertexInputState/vertexBuffers}}
-            passes [$validating GPUVertexBufferLayoutDescriptor$](|vertexBuffer|, |vertexStage|)
-        1. The sum of |vertexBuffer|.{{GPUVertexBufferLayoutDescriptor/attributes}}.length,
+            passes [$validating GPUVertexBufferLayout$](|vertexBuffer|, |vertexStage|)
+        1. The sum of |vertexBuffer|.{{GPUVertexBufferLayout/attributes}}.length,
             over every |vertexBuffer| in |descriptor|.{{GPUVertexInputState/vertexBuffers}},
             is less than or equal to {{GPULimits/maxVertexAttributes|GPULimits.maxVertexAttributes}}.
-        1. Each |at| in the union of all {{GPUVertexAttributeDescriptor}}
+        1. Each |at| in the union of all {{GPUVertexAttribute}}
             across |descriptor|.{{GPUVertexInputState/vertexBuffers}} has a distinct
-            |at|.{{GPUVertexAttributeDescriptor/shaderLocation}} value.
+            |at|.{{GPUVertexAttribute/shaderLocation}} value.
 </div>
 
 # Command Buffers # {#command-buffers}


### PR DESCRIPTION
Moved out of #1293 and reworked according to the latest input from the editors.
Closes #936

TL;DR:
- adds `GPUPrimitiveAssemblyStateDescriptor`, which contains the primitive topology with the strip index format.
- moves the sample count, mask, ~~and alpha-to-coverage~~ into the rasterization state
- reorders the fields of `GPURenderPipelineDescriptor` according to the order in the pipeline
- refactors the validation (but no new statements there)

Note: we probably want to move the alpha-to-coverage after the fragment shader


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/1307.html" title="Last updated on Dec 17, 2020, 7:26 PM UTC (2369972)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1307/22967dd...kvark:2369972.html" title="Last updated on Dec 17, 2020, 7:26 PM UTC (2369972)">Diff</a>