### PR TITLE
Remove GPUDevice.{adapter,features,limits}

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -886,6 +886,9 @@ A [=device=] has the following internal slots:
         No [=limit/better=] limits can be used, even if the underlying [=adapter=] can support them.
 </dl>
 
+Issue: [=device=] is already an internal concept. Having slots be marked as internal is redundant
+and adds extra `[[`/`]]` in spec text. Consider removing the brackets.
+
 <div algorithm>
     When <dfn dfn>a new device</dfn> |device| is created from [=adapter=] |adapter|
     with {{GPUDeviceDescriptor}} |descriptor|:
@@ -1390,10 +1393,6 @@ To get a {{GPUDevice}}, use {{GPUAdapter/requestDevice()}}.
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), Serializable]
 interface GPUDevice : EventTarget {
-    [SameObject] readonly attribute GPUAdapter adapter;
-    readonly attribute FrozenArray<GPUFeatureName> features;
-    readonly attribute object limits;
-
     [SameObject] readonly attribute GPUQueue defaultQueue;
 
     GPUBuffer createBuffer(GPUBufferDescriptor descriptor);
@@ -1421,20 +1420,6 @@ GPUDevice includes GPUObjectBase;
 {{GPUDevice}} has the following attributes:
 
 <dl dfn-type=attribute dfn-for=GPUDevice>
-    : <dfn>adapter</dfn>
-    ::
-        The {{GPUAdapter}} from which this device was created.
-
-    : <dfn>features</dfn>
-    ::
-        A sequence containing the {{GPUFeatureName}} values of the features
-        supported by the device (i.e. the ones with which it was created).
-
-    : <dfn>limits</dfn>
-    ::
-        A {{GPULimits}} object exposing the limits
-        supported by the device (i.e. the ones with which it was created).
-
     : <dfn>defaultQueue</dfn>
     ::
         The default {{GPUQueue}} for this device.


### PR DESCRIPTION
We don't normally include reflection info (e.g. texture dimensions) on objects. Removing them on GPUDevice as well is consistent and makes specification and implementation simpler.

For internal usage, `GPUDevice.[[device]].`{`[[adapter]]`,`[[features]]`,`[[limits]]`} still exist.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1309.html" title="Last updated on Dec 16, 2020, 11:00 PM UTC (4ade04a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1309/073ed82...kainino0x:4ade04a.html" title="Last updated on Dec 16, 2020, 11:00 PM UTC (4ade04a)">Diff</a>