### PR TITLE
Rename GPUDeviceDescriptor features/limits to nonGuaranteed*

### DIFF
--- a/design/ErrorConventions.md
+++ b/design/ErrorConventions.md
@@ -31,33 +31,33 @@ passed into `o.f`.
     E.g.:
     * If a parameter is passed in which doesn't match the type declared by the WebIDL.
 
-* If the method `o.f` is part of a disabled extension: Error **must** be synchronous.
-    * If the extension is *known but disabled*, `o.f` can be called, but
+* If the method `o.f` is part of a disabled feature: Error **must** be synchronous.
+    * If the feature is *known but disabled*, `o.f` can be called, but
       throws an exception (in the implementation).
-    * If the extension is *unknown*, `o.f` is `undefined`;
+    * If the feature is *unknown*, `o.f` is `undefined`;
       calling `undefined` throws an exception.
 
 * If the method `o.f` is available, but would return an instance of an
-  interface defined in a disabled extension: Error **must** be synchronous.
+  interface defined in a disabled feature: Error **must** be synchronous.
     * (We probably won't have this case anyway.)
 
 * If `o` **is** an interface (not an instance) that is defined in a disabled
-  extension: Error **must** be synchronous. However, note that the behavior
+  feature: Error **must** be synchronous. However, note that the behavior
   cannot match exactly:
-    * If the extension is *known but disabled*, `o.f` can be called, but
+    * If the feature is *known but disabled*, `o.f` can be called, but
       throws an exception (in the implementation).
-    * If the extension is *unknown*, `o` is not defined, so accessing `o`
+    * If the feature is *unknown*, `o` is not defined, so accessing `o`
       throws an exception (and accessing `window.o` gives `undefined`).
 
 * If any object in `A` contains any key that is not core or part of an enabled
-  extension: Error **must** be synchronous.
+  feature: Error **must** be synchronous.
     * This is explicitly made more strict than the usual WebIDL dictionary
       binding rules.
 
-* If any object in `A` is missing a required key (given current extensions): Error **must** be synchronous.
+* If any object in `A` is missing a required key (given current features): Error **must** be synchronous.
 
 * Validation which depends only on individual primitives (e.g. `Number`s) in
-  `A`, `device.limits`, and `device.extensions`:
+  `A`, `device.limits`, and `device.features`:
   Error **should (but may not)** be synchronous.
   E.g.:
     * A `Number` exceeds the associated entry in `limits`.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -890,11 +890,13 @@ A [=device=] has the following internal slots:
     When <dfn dfn>a new device</dfn> |device| is created from [=adapter=] |adapter|
     with {{GPUDeviceDescriptor}} |descriptor|:
 
-      - Set |device|.{{device/[[adapter]]}} to |adapter|.
+    1. Set |device|.{{device/[[adapter]]}} to |adapter|.
 
-      - Set |device|.{{device/[[features]]}} to |descriptor|.{{GPUDeviceDescriptor/features}}.
+    1. Set |device|.{{device/[[features]]}} to
+        |descriptor|.{{GPUDeviceDescriptor/optionalHardwareCapabilities}}.{{GPUOptionalHardwareCapabilities/features}}.
 
-      - Set |device|.{{device/[[limits]]}} to |descriptor|.{{GPUDeviceDescriptor/limits}}.
+    1. Set |device|.{{device/[[limits]]}} to
+        |descriptor|.{{GPUDeviceDescriptor/optionalHardwareCapabilities}}.{{GPUOptionalHardwareCapabilities/limits}}.
 </div>
 
 [=Devices=] are exposed via {{GPUDevice}}.
@@ -1069,7 +1071,7 @@ a better limit is not specified.
 #### <dfn dictionary>GPULimits</dfn> #### {#gpulimits}
 
 {{GPULimits}} describes the [=limits=] with which a device should be created.
-See {{GPUDeviceDescriptor/limits|GPUDeviceDescriptor.limits}}.
+See {{GPUOptionalHardwareCapabilities/limits|GPUOptionalHardwareCapabilities.limits}}.
 
 It also exposes the [=limits=] supported by an adapter.
 See {{GPUAdapter/limits|GPUAdapter.limits}}.
@@ -1323,13 +1325,13 @@ interface GPUAdapter {
 
                         <div class=validusage>
                             - The set of {{GPUFeatureName}} values in
-                                |descriptor|.{{GPUDeviceDescriptor/features}}
+                                |descriptor|.{{GPUDeviceDescriptor/optionalHardwareCapabilities}}.{{GPUOptionalHardwareCapabilities/features}}
                                 is a subset of those in
                                 |adapter|.{{adapter/[[features]]}}.
 
                             - For each type of limit in {{GPULimits}},
                                 the value of that limit in
-                                |descriptor|.{{GPUDeviceDescriptor/limits}}
+                                |descriptor|.{{GPUDeviceDescriptor/optionalHardwareCapabilities}}.{{GPUOptionalHardwareCapabilities/limits}}
                                 is no [=limit/better=] than the value of that limit in
                                 |adapter|.{{adapter/[[limits]]}}.
 
@@ -1357,14 +1359,28 @@ interface GPUAdapter {
 
 <script type=idl>
 dictionary GPUDeviceDescriptor : GPUObjectDescriptorBase {
-    sequence<GPUFeatureName> features = [];
-    GPULimits limits = {};
+    GPUOptionalHardwareCapabilities optionalHardwareCapabilities = {};
 };
 </script>
 
 {{GPUDeviceDescriptor}} has the following members:
 
 <dl dfn-type=dict-member dfn-for=GPUDeviceDescriptor>
+    : <dfn>optionalHardwareCapabilities</dfn>
+    ::
+        Requests optional hardware capabilities that are not available on all systems.
+</dl>
+
+{{GPUOptionalHardwareCapabilities}} has the following members:
+
+<script type=idl>
+dictionary GPUOptionalHardwareCapabilities {
+    sequence<GPUFeatureName> features = [];
+    GPULimits limits = {};
+};
+</script>
+
+<dl dfn-type=dict-member dfn-for=GPUOptionalHardwareCapabilities>
     : <dfn>features</dfn>
     ::
         The set of {{GPUFeatureName}} values in this sequence defines the exact set of

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -893,10 +893,10 @@ A [=device=] has the following internal slots:
     1. Set |device|.{{device/[[adapter]]}} to |adapter|.
 
     1. Set |device|.{{device/[[features]]}} to
-        |descriptor|.{{GPUDeviceDescriptor/optionalHardwareCapabilities}}.{{GPUOptionalHardwareCapabilities/features}}.
+        |descriptor|.{{GPUDeviceDescriptor/nonGuaranteedFeatures}}.
 
     1. Set |device|.{{device/[[limits]]}} to
-        |descriptor|.{{GPUDeviceDescriptor/optionalHardwareCapabilities}}.{{GPUOptionalHardwareCapabilities/limits}}.
+        |descriptor|.{{GPUDeviceDescriptor/nonGuaranteedLimits}}.
 </div>
 
 [=Devices=] are exposed via {{GPUDevice}}.
@@ -1071,7 +1071,7 @@ a better limit is not specified.
 #### <dfn dictionary>GPULimits</dfn> #### {#gpulimits}
 
 {{GPULimits}} describes the [=limits=] with which a device should be created.
-See {{GPUOptionalHardwareCapabilities/limits|GPUOptionalHardwareCapabilities.limits}}.
+See {{GPUDeviceDescriptor/nonGuaranteedLimits|GPUDeviceDescriptor.nonGuaranteedLimits}}.
 
 It also exposes the [=limits=] supported by an adapter.
 See {{GPUAdapter/limits|GPUAdapter.limits}}.
@@ -1325,13 +1325,13 @@ interface GPUAdapter {
 
                         <div class=validusage>
                             - The set of {{GPUFeatureName}} values in
-                                |descriptor|.{{GPUDeviceDescriptor/optionalHardwareCapabilities}}.{{GPUOptionalHardwareCapabilities/features}}
+                                |descriptor|.{{GPUDeviceDescriptor/nonGuaranteedFeatures}}
                                 is a subset of those in
                                 |adapter|.{{adapter/[[features]]}}.
 
                             - For each type of limit in {{GPULimits}},
                                 the value of that limit in
-                                |descriptor|.{{GPUDeviceDescriptor/optionalHardwareCapabilities}}.{{GPUOptionalHardwareCapabilities/limits}}
+                                |descriptor|.{{GPUDeviceDescriptor/nonGuaranteedLimits}}
                                 is no [=limit/better=] than the value of that limit in
                                 |adapter|.{{adapter/[[limits]]}}.
 
@@ -1359,34 +1359,20 @@ interface GPUAdapter {
 
 <script type=idl>
 dictionary GPUDeviceDescriptor : GPUObjectDescriptorBase {
-    GPUOptionalHardwareCapabilities optionalHardwareCapabilities = {};
+    sequence<GPUFeatureName> nonGuaranteedFeatures = [];
+    GPULimits nonGuaranteedLimits = {};
 };
 </script>
 
 {{GPUDeviceDescriptor}} has the following members:
 
 <dl dfn-type=dict-member dfn-for=GPUDeviceDescriptor>
-    : <dfn>optionalHardwareCapabilities</dfn>
-    ::
-        Requests optional hardware capabilities that are not available on all systems.
-</dl>
-
-{{GPUOptionalHardwareCapabilities}} has the following members:
-
-<script type=idl>
-dictionary GPUOptionalHardwareCapabilities {
-    sequence<GPUFeatureName> features = [];
-    GPULimits limits = {};
-};
-</script>
-
-<dl dfn-type=dict-member dfn-for=GPUOptionalHardwareCapabilities>
-    : <dfn>features</dfn>
+    : <dfn>nonGuaranteedFeatures</dfn>
     ::
         The set of {{GPUFeatureName}} values in this sequence defines the exact set of
         [=features=] that must be enabled on the device.
 
-    : <dfn>limits</dfn>
+    : <dfn>nonGuaranteedLimits</dfn>
     ::
         Defines the exact [=limits=] that must be enabled on the device.
 


### PR DESCRIPTION
Proposed variation on the agreed-upon `.allowNonDefaultCapabilities`.
Makes it completely clear that if you use this, you are excluding some
user devices.

Alternatives: `extendedHardwareCapabilities`, `optionalSystemCapabilities`, ..?

Fixes #684


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1313.html" title="Last updated on Jan 11, 2021, 9:59 PM UTC (eb16253)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1313/c6dc6d6...kainino0x:eb16253.html" title="Last updated on Jan 11, 2021, 9:59 PM UTC (eb16253)">Diff</a>