### PR TITLE
Pluralize GPU.requestAdapters

### DIFF
--- a/design/ErrorHandling.md
+++ b/design/ErrorHandling.md
@@ -76,8 +76,8 @@ An app should never give up on getting WebGPU access due to
 Instead of giving up, the app should try again starting with `requestAdapters()`.
 
 It *should* give up based on a `requestAdapters` returning `[]` or rejecting.
-(It should also give up on a `requestDevice` rejection, as that indicates the
-request was invalid, e.g. not compatible with the adapter - an app programming error,
+It *should* also give up on a `requestDevice` rejection, as that indicates the
+request was invalid (e.g., not compatible with the adapter - an app programming error,
 if they intended to check the adapter capabilities first.)
 
 ### Example Code

--- a/design/ErrorHandling.md
+++ b/design/ErrorHandling.md
@@ -77,7 +77,7 @@ Instead of giving up, the app should try again starting with `requestAdapters()`
 
 It *should* give up based on a `requestAdapters` returning `[]` or rejecting.
 It *should* also give up on a `requestDevice` rejection, as that indicates the
-request was invalid (e.g., not compatible with the adapter - an app programming error,
+request was invalid, e.g. not compatible with the adapter (an app programming error,
 if they intended to check the adapter capabilities first.)
 
 ### Example Code

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1139,40 +1139,38 @@ partial interface WorkerNavigator {
 <script type=idl>
 [Exposed=(Window, DedicatedWorker)]
 interface GPU {
-    Promise<GPUAdapter?> requestAdapter(optional GPURequestAdapterOptions options = {});
+    Promise<FrozenArray<GPUAdapter>> requestAdapters(optional GPURequestAdapterOptions options = {});
 };
 </script>
 
 {{GPU}} has the following methods:
 
 <dl dfn-type=method dfn-for=GPU>
-    : <dfn>requestAdapter(options)</dfn>
+    : <dfn>requestAdapters(options)</dfn>
     ::
-        Requests an [=adapter=] from the user agent.
-        The user agent chooses whether to return an adapter, and, if so,
-        chooses according to the provided options.
+        Requests a list of [=adapters=] from the user agent.
+        The user agent chooses what adapters to return, if any, and chooses
+        and orders the results according to the provided options.
 
-        <div algorithm=GPU.requestAdapter>
+        <div algorithm=GPU.requestAdapters>
             **Called on:** {{GPU}} |this|.
 
             **Arguments:**
-            <pre class=argumentdef for="GPU/requestAdapter(options)">
-                |options|: Criteria used to select the adapter.
+            <pre class=argumentdef for="GPU/requestAdapters(options)">
+                |options|: Criteria used to select adapters.
             </pre>
 
-            **Returns:** {{Promise}}&lt;{{GPUAdapter}}?&gt;
+            **Returns:** {{Promise}}&lt;{{FrozenArray}}&lt;{{GPUAdapter}}&gt;&gt;
 
             1. Let |promise| be [=a new promise=].
             1. Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
-                    1. If the user agent chooses to return an adapter:
+                    1. Let |adapters| be the list of adapters the user agent chooses to return,
+                        if any, according to the criteria in |options|, as described in
+                        [[#adapter-selection]].
 
-                        1. The user agent chooses an [=adapter=] |adapter| according to the rules in
-                            [[#adapter-selection]] and the criteria in |options|.
-
-                        1. |promise| [=resolves=] with a new {{GPUAdapter}} encapsulating |adapter|.
-
-                    1. Otherwise, |promise| [=resolves=] with `null`.
+                    1. [=Resolve=] |promise| with a list of new {{GPUAdapter}} objects encapsulating
+                        the adapters in |adapters|.
                 </div>
             1. Return |promise|.
 
@@ -1205,14 +1203,14 @@ enum GPUPowerPreference {
 <dl dfn-type=dict-member dfn-for=GPURequestAdapterOptions>
     : <dfn>powerPreference</dfn>
     ::
-        Optionally provides a hint indicating what class of [=adapter=] should be selected from
+        Optionally provides a hint indicating what class of [=adapter=] should be preferred from
         the system's available adapters.
 
-        The value of this hint may influence which adapter is chosen, but it must not
-        influence whether an adapter is returned or not.
+        The value of this hint may influence the order of adapters chosen, but it must not
+        influence whether any given adapter is returned or not.
 
         Note:
-        The primary utility of this hint is to influence which GPU is used in a multi-GPU system.
+        The primary utility of this hint is to influence which GPU is preferred in a multi-GPU system.
         For instance, some laptops have a low-power integrated GPU and a high-performance
         discrete GPU.
 
@@ -1259,7 +1257,7 @@ enum GPUPowerPreference {
 A {{GPUAdapter}} encapsulates an [=adapter=],
 and describes its capabilities ([=features=] and [=limits=]).
 
-To get a {{GPUAdapter}}, use {{GPU/requestAdapter()}}.
+To get a {{GPUAdapter}}, use {{GPU/requestAdapters()}}.
 
 <script type=idl>
 interface GPUAdapter {


### PR DESCRIPTION
Proposes (again) returning multiple adapters in response to an adapter request.

See #524 for previous discussion and rationale. (But note this PR differs in some small ways.)

> * `requestAdapters` is not any more prone to fingerprinting. The UA can choose to put whichever adapters it wants in the list. Any adapters returned from it could have been found by searching the space of possible `requestAdapter` calls.
> * Many applications would end up trying to get every adapter they can find (by searching the space ...) and then using their own logic to pick among them. This prevents apps from needing that pattern.
> * `requestAdapters` still allows an easy default: e.g. ask for `"low-power"`, then get adapter `[0]`.
> * `requestAdapter` is hostile to any situation where the UA **does** want to give a little more trust to the app, perhaps Electron, Node, or even **installed PWAs**.

It is now our opinion that this *is* the right solution. Like #1273, it's a highly flexible API that allows UAs to do device bucketing ahead of time, or even lazily during accesses to the returned array. Most apps will use item `[0]`, and such behavior can be observed by the UA if needed.

This design should avoid any pitfalls that would cause an otherwise well-written app (which chooses adapters properly on various hardware configurations, which is not hard) to fail on a UA which chooses to limit the set of returned adapters in any way; such a response would look equivalent to some other reasonable hardware configuration (e.g. a 2-gpu system looking like a 1-gpu system).

New in this PR, it requires specific predictable behavior, so that developers don't have to worry about some UAs e.g. requiring multiple calls to requestAdapters where others would not. (powerPreference **must** not affect the set of adapters returned, only the order.) I have further changes to propose after this that will require more predictable behavior for when *device* creation should fail, as well.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1314.html" title="Last updated on Dec 17, 2020, 2:32 AM UTC (5d9dc30)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1314/22967dd...kainino0x:5d9dc30.html" title="Last updated on Dec 17, 2020, 2:32 AM UTC (5d9dc30)">Diff</a>