### PR TITLE
Add GPUDevice.destroy()

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1416,7 +1416,7 @@ interface GPUDevice : EventTarget {
 
     [SameObject] readonly attribute GPUQueue defaultQueue;
 
-    void destroy();
+    undefined destroy();
 
     GPUBuffer createBuffer(GPUBufferDescriptor descriptor);
     GPUTexture createTexture(GPUTextureDescriptor descriptor);
@@ -1487,6 +1487,9 @@ Those not defined here are defined elsewhere in this document.
             **Called on:** {{GPUDevice}} |this|.
 
             1. Make |this|.{{GPUDevice/[[device]]}} [=invalid=].
+
+            Note: This does **not** resolve |this|.{{GPUDevice/lost}}.
+            It remains pending until the end of its lifetime.
         </div>
 
         Note:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1487,10 +1487,12 @@ Those not defined here are defined elsewhere in this document.
             **Called on:** {{GPUDevice}} |this|.
 
             1. Make |this|.{{GPUDevice/[[device]]}} [=invalid=].
+            1. Resolve {{GPUDevice/lost}}, on every {{GPUDevice}} associated with
+                |this|.{{GPUDevice/[[device]]}}, with a {{GPUDeviceLostInfo}} with
+                {{GPUDeviceLostInfo/reason}} {{GPUDeviceLostReason/"destroyed"}}
+                and an implementation-defined {{GPUDeviceLostInfo/message}}.
 
-            Note: |this|.{{GPUDevice/lost}} is a signal that device-loss recovery logic should run,
-            so it is *not* resolved when the device is explicitly destroyed.
-            It remains pending until the end of its lifetime.
+            Issue: Probably centralize this better with other device loss triggering.
         </div>
 
         Note:
@@ -7052,7 +7054,12 @@ rendering operations have been flushed to the drawing buffer.
 ## Fatal Errors ## {#fatal-errors}
 
 <script type=idl>
+enum GPUDeviceLostReason {
+    "destroyed",
+};
+
 interface GPUDeviceLostInfo {
+    readonly attribute (GPUDeviceLostReason or undefined) reason;
     readonly attribute DOMString message;
 };
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1492,7 +1492,7 @@ Those not defined here are defined elsewhere in this document.
                 {{GPUDeviceLostInfo/reason}} {{GPUDeviceLostReason/"destroyed"}}
                 and an implementation-defined {{GPUDeviceLostInfo/message}}.
 
-            Issue: Probably centralize this better with other device loss triggering.
+            Issue: Probably centralize this better with other device loss triggering, once added.
         </div>
 
         Note:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -538,6 +538,10 @@ If an object is successfully created, it is <dfn dfn>valid</dfn> at that moment.
 An [=internal object=] may be <dfn dfn>invalid</dfn>.
 It may become [=invalid=] during its lifetime, but it will never become valid again.
 
+Issue: Consider separating "invalid" from "destroyed".
+This would let validity be immutable, and only operations involving devices,
+buffers, and textures would check those objects' `[[destroyed]]` state explicitly.
+
 <div class=note>
     [=Invalid=] objects result from a number of situations, including:
 
@@ -1412,6 +1416,8 @@ interface GPUDevice : EventTarget {
 
     [SameObject] readonly attribute GPUQueue defaultQueue;
 
+    void destroy();
+
     GPUBuffer createBuffer(GPUBufferDescriptor descriptor);
     GPUTexture createTexture(GPUTextureDescriptor descriptor);
     GPUSampler createSampler(optional GPUSamplerDescriptor descriptor = {});
@@ -1469,8 +1475,25 @@ GPUDevice includes GPUObjectBase;
         The [=device=] that this {{GPUDevice}} refers to.
 </dl>
 
-{{GPUDevice}} has the methods listed in its WebIDL definition above, which are defined elsewhere in
-this document.
+{{GPUDevice}} has the methods listed in its WebIDL definition above.
+Those not defined here are defined elsewhere in this document.
+
+<dl dfn-type=method dfn-for=GPUDevice>
+    : <dfn>destroy()</dfn>
+    ::
+        Destroys the [=device=].
+
+        <div algorithm=GPUDevice.destroy()>
+            **Called on:** {{GPUDevice}} |this|.
+
+            1. Make |this|.{{GPUDevice/[[device]]}} [=invalid=].
+        </div>
+
+        Note:
+        This prevents any further operations on the device.
+        Implementations can free resource allocations immediately.
+        Outstanding asynchronous operations will fail, so implementations can abort them early.
+</dl>
 
 {{GPUDevice}} objects are [=serializable objects=].
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -539,8 +539,8 @@ An [=internal object=] may be <dfn dfn>invalid</dfn>.
 It may become [=invalid=] during its lifetime, but it will never become valid again.
 
 Issue: Consider separating "invalid" from "destroyed".
-This would let validity be immutable, and only operations involving devices,
-buffers, and textures would check those objects' `[[destroyed]]` state explicitly.
+This would let validity be immutable, and only operations involving devices, buffers, and textures
+(e.g. submit, map) would check those objects' `[[destroyed]]` state (explicitly).
 
 <div class=note>
     [=Invalid=] objects result from a number of situations, including:
@@ -1488,7 +1488,8 @@ Those not defined here are defined elsewhere in this document.
 
             1. Make |this|.{{GPUDevice/[[device]]}} [=invalid=].
 
-            Note: This does **not** resolve |this|.{{GPUDevice/lost}}.
+            Note: |this|.{{GPUDevice/lost}} is a signal that device-loss recovery logic should run,
+            so it is *not* resolved when the device is explicitly destroyed.
             It remains pending until the end of its lifetime.
         </div>
 


### PR DESCRIPTION
Like other `.destroy()` methods, immediately destroys the device and makes it invalid for future use (i.e. lost, though it doesn't fire the `.lost` promise).

This allows for eager cleanup of an entire device and its resources.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1316.html" title="Last updated on Jan 12, 2021, 3:07 AM UTC (9507e8e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1316/22967dd...kainino0x:9507e8e.html" title="Last updated on Jan 12, 2021, 3:07 AM UTC (9507e8e)">Diff</a>