### PR TITLE
textureSampleCompare always uses mip level 0

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5077,6 +5077,7 @@ The sampled value.
 ### `textureSampleCompare` ### {#texturesamplecompare}
 
 Samples a depth texture and compares the sampled depth values against a reference value.
+The depth texture is sampled at mip level 0.
 
 ```rust
 textureSampleCompare(t : texture_depth_2d, s : sampler_comparison, coords : vec2<f32>, depth_ref : f32) -> f32


### PR DESCRIPTION
Fixes: #1319