### PR TITLE
Update sampler anisotropic related validations in spec

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2362,7 +2362,6 @@ dictionary GPUSamplerDescriptor : GPUObjectDescriptorBase {
 - If {{GPUSamplerDescriptor/compare}} is provided, the sampler will be a comparison sampler with the specified
     {{GPUCompareFunction}}.
 - {{GPUSamplerDescriptor/maxAnisotropy}} specifies the maximum anisotropy value clamp used by the sampler.
-    - It must be &ge; 1. Otherwise (&equals; 0) generate a {{GPUValidationError}}.
 
     Note: most implementations support {{GPUSamplerDescriptor/maxAnisotropy}} values in range between 1 and 16, inclusive.
 
@@ -2483,6 +2482,7 @@ enum GPUCompareFunction {
         - |descriptor|.{{GPUSamplerDescriptor/lodMinClamp}} is greater than or equal to 0.
         - |descriptor|.{{GPUSamplerDescriptor/lodMaxClamp}} is greater than or equal to
             |descriptor|.{{GPUSamplerDescriptor/lodMinClamp}}.
+        - |descriptor|.{{GPUSamplerDescriptor/maxAnisotropy}} must be &ge; 1.
         - When |descriptor|.{{GPUSamplerDescriptor/maxAnisotropy}} is greater than 1,
             |descriptor|.{{GPUSamplerDescriptor/magFilter}}, |descriptor|.{{GPUSamplerDescriptor/minFilter}},
             and |descriptor|.{{GPUSamplerDescriptor/mipmapFilter}} must be equal to {{GPUFilterMode/"linear"}}.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2362,7 +2362,7 @@ dictionary GPUSamplerDescriptor : GPUObjectDescriptorBase {
 - If {{GPUSamplerDescriptor/compare}} is provided, the sampler will be a comparison sampler with the specified
     {{GPUCompareFunction}}.
 - {{GPUSamplerDescriptor/maxAnisotropy}} specifies the maximum anisotropy value clamp used by the sampler.
-    - It must be &ge; 1.
+    - It must be &ge; 1. Otherwise (&equals; 0) generate a {{GPUValidationError}}.
 
     Note: most implementations support {{GPUSamplerDescriptor/maxAnisotropy}} values in range between 1 and 16, inclusive.
 
@@ -2483,6 +2483,9 @@ enum GPUCompareFunction {
         - |descriptor|.{{GPUSamplerDescriptor/lodMinClamp}} is greater than or equal to 0.
         - |descriptor|.{{GPUSamplerDescriptor/lodMaxClamp}} is greater than or equal to
             |descriptor|.{{GPUSamplerDescriptor/lodMinClamp}}.
+        - When |descriptor|.{{GPUSamplerDescriptor/maxAnisotropy}} is greater than 1,
+            |descriptor|.{{GPUSamplerDescriptor/magFilter}}, |descriptor|.{{GPUSamplerDescriptor/minFilter}},
+            and |descriptor|.{{GPUSamplerDescriptor/mipmapFilter}} must be equal to {{GPUFilterMode/"linear"}}.
 </div>
 
 <dl dfn-type=method dfn-for=GPUDevice>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2482,7 +2482,7 @@ enum GPUCompareFunction {
         - |descriptor|.{{GPUSamplerDescriptor/lodMinClamp}} is greater than or equal to 0.
         - |descriptor|.{{GPUSamplerDescriptor/lodMaxClamp}} is greater than or equal to
             |descriptor|.{{GPUSamplerDescriptor/lodMinClamp}}.
-        - |descriptor|.{{GPUSamplerDescriptor/maxAnisotropy}} must be &ge; 1.
+        - |descriptor|.{{GPUSamplerDescriptor/maxAnisotropy}} is greater than or equal to 1.
         - When |descriptor|.{{GPUSamplerDescriptor/maxAnisotropy}} is greater than 1,
             |descriptor|.{{GPUSamplerDescriptor/magFilter}}, |descriptor|.{{GPUSamplerDescriptor/minFilter}},
             and |descriptor|.{{GPUSamplerDescriptor/mipmapFilter}} must be equal to {{GPUFilterMode/"linear"}}.


### PR DESCRIPTION
The behavior that requires minFilter, magFilter, and mipmapFilter to be 0 when maxAnisotropy > 1 comes from D3D12 implying
https://docs.microsoft.com/en-us/windows/win32/api/d3d12/ne-d3d12-d3d12_filter


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shrekshao/gpuweb/pull/1323.html" title="Last updated on Dec 24, 2020, 3:46 AM UTC (97caaed)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1323/32cd114...shrekshao:97caaed.html" title="Last updated on Dec 24, 2020, 3:46 AM UTC (97caaed)">Diff</a>