### PR TITLE
Add texture dimension limits

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -980,6 +980,34 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
         <tr><th>Limit name <th>Type <th>[=limit/Better=] <th>[=limit/Default=]
     </thead>
 
+    <tr><td><dfn>maxTextureDimension1D</dfn>
+        <td>{{GPUSize32}} <td>Higher <td>4096
+    <tr class=row-continuation><td colspan=4>
+        The maximum allowed {{GPUTextureDescriptor/size}}.{{GPUExtent3DDict/width}}
+        for which the {{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"1d"}}
+        when creating a {{GPUTexture}}.
+
+    <tr><td><dfn>maxTextureDimension2D</dfn>
+        <td>{{GPUSize32}} <td>Higher <td>4096
+    <tr class=row-continuation><td colspan=4>
+        The maximum allowed {{GPUTextureDescriptor/size}}.{{GPUExtent3DDict/width}} and {{GPUTextureDescriptor/size}}.{{GPUExtent3DDict/height}}
+        for which the {{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"2d"}}
+        when creating a {{GPUTexture}}.
+
+    <tr><td><dfn>maxTextureDimension3D</dfn>
+        <td>{{GPUSize32}} <td>Higher <td>256
+    <tr class=row-continuation><td colspan=4>
+        The maximum allowed {{GPUTextureDescriptor/size}}.{{GPUExtent3DDict/width}}, {{GPUTextureDescriptor/size}}.{{GPUExtent3DDict/height}} and {{GPUTextureDescriptor/size}}.{{GPUExtent3DDict/depth}}
+        for which the {{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"3d"}}
+        when creating a {{GPUTexture}}.
+
+    <tr><td><dfn>maxTextureArrayLayer</dfn>
+        <td>{{GPUSize32}} <td>Higher <td>256
+    <tr class=row-continuation><td colspan=4>
+        The maximum allowed {{GPUTextureDescriptor/size}}.{{GPUExtent3DDict/depth}}
+        for which the {{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"1d"}} or {{GPUTextureDimension/"2d"}}
+        when creating a {{GPUTexture}}.
+
     <tr><td><dfn>maxBindGroups</dfn>
         <td>{{GPUSize32}} <td>Higher <td>4
     <tr class=row-continuation><td colspan=4>
@@ -1108,6 +1136,10 @@ See {{GPUAdapter/limits|GPUAdapter.limits}}.
 
 <script type=idl>
 interface GPUAdapterLimits {
+    readonly attribute GPUSize32 maxTextureDimension1D;
+    readonly attribute GPUSize32 maxTextureDimension2D;
+    readonly attribute GPUSize32 maxTextureDimension3D;
+    readonly attribute GPUSize32 maxTextureArrayLayer;
     readonly attribute GPUSize32 maxBindGroups;
     readonly attribute GPUSize32 maxDynamicUniformBuffersPerPipelineLayout;
     readonly attribute GPUSize32 maxDynamicStorageBuffersPerPipelineLayout;

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -983,25 +983,25 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
     <tr><td><dfn>maxTextureDimension1D</dfn>
         <td>{{GPUSize32}} <td>Higher <td>8192
     <tr class=row-continuation><td colspan=4>
-        The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=]
+        The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=Extent3D/width=]
         of a [=texture=] created with {{GPUTextureDescriptor/dimension}} {{GPUTextureDimension/"1d"}}.
 
     <tr><td><dfn>maxTextureDimension2D</dfn>
         <td>{{GPUSize32}} <td>Higher <td>8192
     <tr class=row-continuation><td colspan=4>
-        The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=] and {{GPUTextureDescriptor/size}}.[=GPUExtent3DDict/height=]
+        The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=Extent3D/width=] and {{GPUTextureDescriptor/size}}.[=Extent3D/height=]
         of a [=texture=] created with {{GPUTextureDescriptor/dimension}} {{GPUTextureDimension/"2d"}}.
 
     <tr><td><dfn>maxTextureDimension3D</dfn>
         <td>{{GPUSize32}} <td>Higher <td>2048
     <tr class=row-continuation><td colspan=4>
-        The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=], {{GPUTextureDescriptor/size}}.[=GPUExtent3D/height=] and {{GPUTextureDescriptor/size}}.[=GPUExtent3D/depth=]
+        The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=Extent3D/width=], {{GPUTextureDescriptor/size}}.[=Extent3D/height=] and {{GPUTextureDescriptor/size}}.[=Extent3D/depth=]
         of a [=texture=] created with {{GPUTextureDescriptor/dimension}} {{GPUTextureDimension/"3d"}}.
 
     <tr><td><dfn>maxTextureArrayLayers</dfn>
         <td>{{GPUSize32}} <td>Higher <td>2048
     <tr class=row-continuation><td colspan=4>
-        The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=GPUExtent3DDict/depth=]
+        The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=Extent3D/depth=]
         of a [=texture=] created with {{GPUTextureDescriptor/dimension}} {{GPUTextureDimension/"1d"}} or {{GPUTextureDimension/"2d"}}.
 
     <tr><td><dfn>maxBindGroups</dfn>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -983,30 +983,26 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
     <tr><td><dfn>maxTextureDimension1D</dfn>
         <td>{{GPUSize32}} <td>Higher <td>8192
     <tr class=row-continuation><td colspan=4>
-        The maximum allowed {{GPUTextureDescriptor/size}}.{{GPUExtent3DDict/width}}
-        for which {{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"1d"}}
-        when creating a {{GPUTexture}}.
+        The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=]
+        of a [=texture=] created with {{GPUTextureDescriptor/dimension}} {{GPUTextureDimension/"1d"}}.
 
     <tr><td><dfn>maxTextureDimension2D</dfn>
         <td>{{GPUSize32}} <td>Higher <td>8192
     <tr class=row-continuation><td colspan=4>
-        The maximum allowed {{GPUTextureDescriptor/size}}.{{GPUExtent3DDict/width}} and {{GPUTextureDescriptor/size}}.{{GPUExtent3DDict/height}}
-        for which {{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"2d"}}
-        when creating a {{GPUTexture}}.
+        The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=] and {{GPUTextureDescriptor/size}}.[=GPUExtent3DDict/height=]
+        of a [=texture=] created with {{GPUTextureDescriptor/dimension}} {{GPUTextureDimension/"2d"}}.
 
     <tr><td><dfn>maxTextureDimension3D</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>1024
+        <td>{{GPUSize32}} <td>Higher <td>2048
     <tr class=row-continuation><td colspan=4>
-        The maximum allowed {{GPUTextureDescriptor/size}}.{{GPUExtent3DDict/width}}, {{GPUTextureDescriptor/size}}.{{GPUExtent3DDict/height}} and {{GPUTextureDescriptor/size}}.{{GPUExtent3DDict/depth}}
-        for which {{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"3d"}}
-        when creating a {{GPUTexture}}.
+        The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=GPUExtent3D/width=], {{GPUTextureDescriptor/size}}.[=GPUExtent3D/height=] and {{GPUTextureDescriptor/size}}.[=GPUExtent3D/depth=]
+        of a [=texture=] created with {{GPUTextureDescriptor/dimension}} {{GPUTextureDimension/"3d"}}.
 
     <tr><td><dfn>maxTextureArrayLayers</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>256
+        <td>{{GPUSize32}} <td>Higher <td>2048
     <tr class=row-continuation><td colspan=4>
-        The maximum allowed {{GPUTextureDescriptor/size}}.{{GPUExtent3DDict/depth}}
-        for which {{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"1d"}} or {{GPUTextureDimension/"2d"}}
-        when creating a {{GPUTexture}}.
+        The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=GPUExtent3DDict/depth=]
+        of a [=texture=] created with {{GPUTextureDescriptor/dimension}} {{GPUTextureDimension/"1d"}} or {{GPUTextureDimension/"2d"}}.
 
     <tr><td><dfn>maxBindGroups</dfn>
         <td>{{GPUSize32}} <td>Higher <td>4

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -981,31 +981,31 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
     </thead>
 
     <tr><td><dfn>maxTextureDimension1D</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>4096
+        <td>{{GPUSize32}} <td>Higher <td>8192
     <tr class=row-continuation><td colspan=4>
         The maximum allowed {{GPUTextureDescriptor/size}}.{{GPUExtent3DDict/width}}
-        for which the {{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"1d"}}
+        for which {{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"1d"}}
         when creating a {{GPUTexture}}.
 
     <tr><td><dfn>maxTextureDimension2D</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>4096
+        <td>{{GPUSize32}} <td>Higher <td>8192
     <tr class=row-continuation><td colspan=4>
         The maximum allowed {{GPUTextureDescriptor/size}}.{{GPUExtent3DDict/width}} and {{GPUTextureDescriptor/size}}.{{GPUExtent3DDict/height}}
-        for which the {{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"2d"}}
+        for which {{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"2d"}}
         when creating a {{GPUTexture}}.
 
     <tr><td><dfn>maxTextureDimension3D</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>256
+        <td>{{GPUSize32}} <td>Higher <td>1024
     <tr class=row-continuation><td colspan=4>
         The maximum allowed {{GPUTextureDescriptor/size}}.{{GPUExtent3DDict/width}}, {{GPUTextureDescriptor/size}}.{{GPUExtent3DDict/height}} and {{GPUTextureDescriptor/size}}.{{GPUExtent3DDict/depth}}
-        for which the {{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"3d"}}
+        for which {{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"3d"}}
         when creating a {{GPUTexture}}.
 
-    <tr><td><dfn>maxTextureArrayLayer</dfn>
+    <tr><td><dfn>maxTextureArrayLayers</dfn>
         <td>{{GPUSize32}} <td>Higher <td>256
     <tr class=row-continuation><td colspan=4>
         The maximum allowed {{GPUTextureDescriptor/size}}.{{GPUExtent3DDict/depth}}
-        for which the {{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"1d"}} or {{GPUTextureDimension/"2d"}}
+        for which {{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"1d"}} or {{GPUTextureDimension/"2d"}}
         when creating a {{GPUTexture}}.
 
     <tr><td><dfn>maxBindGroups</dfn>
@@ -1139,7 +1139,7 @@ interface GPUAdapterLimits {
     readonly attribute GPUSize32 maxTextureDimension1D;
     readonly attribute GPUSize32 maxTextureDimension2D;
     readonly attribute GPUSize32 maxTextureDimension3D;
-    readonly attribute GPUSize32 maxTextureArrayLayer;
+    readonly attribute GPUSize32 maxTextureArrayLayers;
     readonly attribute GPUSize32 maxBindGroups;
     readonly attribute GPUSize32 maxDynamicUniformBuffersPerPipelineLayout;
     readonly attribute GPUSize32 maxDynamicStorageBuffersPerPipelineLayout;


### PR DESCRIPTION
Texture size (width, height, depth) has limits according to its
type (1D, 2D, 3D, or 1D/2D Array, etc.). This change adds texture
dimension limits on GPUAdapterLimits.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Richard-Yunchao/gpuweb/pull/1328.html" title="Last updated on Jan 8, 2021, 11:38 PM UTC (e9a330c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1328/02d8383...Richard-Yunchao:e9a330c.html" title="Last updated on Jan 8, 2021, 11:38 PM UTC (e9a330c)">Diff</a>