### PR TITLE
wgsl: Markup examples with language and scope

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -76,7 +76,7 @@ WebGPU Shader Language ([SHORTNAME]) is the shader language for [[!WebGPU]].
 That is, an application using the WebGPU API uses [SHORTNAME] to express the programs, known as shaders,
 that run on the GPU.
 
-<div class='example'>
+<div class='example wgsl global-scope'>
   <xmp highlight='rust'>
     [[location(0)]] var<out> gl_FragColor : vec4<f32>;
     [[stage(fragment)]]
@@ -312,7 +312,7 @@ The <dfn dfn noexport>numeric scalar</dfn> types are [=i32=], [=u32=], and [=f32
 
 A vector type is a <dfn dfn>numeric vector</dfn> type if its component type is a [=numeric scalar=].
 
-<div class='example' heading='Vector'>
+<div class='example wgsl' heading='Vector'>
   <xmp highlight='rust'>
     vec2<f32>  // is a vector of two f32s.
   </xmp>
@@ -328,7 +328,7 @@ A vector type is a <dfn dfn>numeric vector</dfn> type if its component type is a
                                 *T* must be *f32*.
 </table>
 
-<div class='example' heading='Matrix'>
+<div class='example wgsl' heading='Matrix'>
   <xmp highlight='rust'>
     mat2x3<f32>  // is a 2 column, 3 row matrix of 32-bit floats.
   </xmp>
@@ -364,7 +364,7 @@ Issue: (dneto): Complete description of `Array<E,N>`
                                     integer greater than 0.
 </table>
 
-<div class='example' heading="Structure">
+<div class='example wgsl global-scope' heading="Structure">
   <xmp highlight='rust'>
     struct Data {
       a : i32;
@@ -422,21 +422,29 @@ struct_member
 Note: Layout attributes are required if the structure type is used
 to define a [=uniform buffer=] or a [=storage buffer=]. See [[#memory-layouts]].
 
-<div class='example' heading='Structure'>
+<div class='example wgsl global-scope' heading='Structure WGSL'>
   <xmp>
     // Offset decorations
     struct my_struct {
       [[offset(0)]] a : f32;
       [[offset(4)]] b : vec4<f32>;
     };
+  </xmp>
+</div>
 
+<div class='example spirv' heading='Structure SPIR-V'>
+  <xmp>
                   OpName %my_struct "my_struct"
                   OpMemberName %my_struct 0 "a"
                   OpMemberDecorate %my_struct 0 Offset 0
                   OpMemberName %my_struct 1 "b"
                   OpMemberDecorate %my_struct 1 Offset 4
      %my_struct = OpTypeStruct %float %v4float
+  </xmp>
+</div>
 
+<div class='example wgsl global-scope' heading='Structure WGSL'>
+  <xmp>
     // Runtime Array
     type RTArr = [[stride 16]] array<vec4<f32>>;
     [[block]] struct S {
@@ -444,7 +452,11 @@ to define a [=uniform buffer=] or a [=storage buffer=]. See [[#memory-layouts]].
       [[offset(4)]] b : f32;
       [[offset(16)]] data : RTArr;
     };
+  </xmp>
+</div>
 
+<div class='example spirv' heading='Structure SPIR-V'>
+  <xmp>
                   OpName %my_struct "my_struct"
                   OpMemberName %my_struct 0 "a"
                   OpMemberDecorate %my_struct 0 Offset 0
@@ -985,7 +997,7 @@ Note: We've described a SPIR-V logical pointer type.
 
 Note: Pointers are not storable.
 
-<div class='example' heading='Pointer'>
+<div class='example wgsl' heading='Pointer'>
   <xmp highlight='rust'>
     ptr<storage, i32>
     ptr<private, array<i32, 12>>
@@ -1300,7 +1312,7 @@ In the SPIR-V mapping:
 When mapping to SPIR-V, a read-only storage texture variable must also have a `NonWritable` decoration.
 For example:
 
-<div class='example' heading='Mapping a texture_storage_ro_1d variable to SPIR-V'>
+<div class='example wgsl global-scope' heading='Mapping a texture_storage_ro_1d variable to SPIR-V'>
   <xmp>
       var tbuf : texture_storage_ro_1d<rgba8unorm>;
 
@@ -1353,7 +1365,7 @@ In the SPIR-V mapping:
 When mapping to SPIR-V, a write-only storage texture variable must also have a `NonReadable` decoration.
 For example:
 
-<div class='example' heading='Mapping a texture_storage_wo_1d variable to SPIR-V'>
+<div class='example wgsl global-scope' heading='Mapping a texture_storage_wo_1d variable to SPIR-V'>
   <xmp>
       var tbuf : texture_storage_wo_1d<rgba8unorm>;
 
@@ -1517,7 +1529,7 @@ type_alias
   : TYPE IDENT EQUAL type_decl
 </pre>
 
-<div class='example' heading='Type Alias'>
+<div class='example wgsl global-scope' heading='Type Alias'>
   <xmp>
     type Arr = array<i32, 5>;
 
@@ -1600,7 +1612,7 @@ declaration of the identifier as a type alias or structure type.
   </xmp>
 </div>
 
-<div class='example' heading='Access qualifier'>
+<div class='example wgsl global-scope' heading='Access qualifier'>
   <xmp>
     // Storage buffers
     var<storage> buf1 : [[access(read)]] Buffer;       // Can read, cannot write.
@@ -1681,8 +1693,8 @@ When a variable is created, its storage contains an initial value as follows:
     * Otherwise, it is the result of evaluating the initializer expression at that point in the program execution.
 * For variables in other storage classes, the execution environment provides the initial value.
 
-<div class='example' header='Variable initial values'>
-  Consider the following snippet of WGSL:
+Consider the following snippet of WGSL:
+<div class='example wsgl function-scope' header='Variable initial values'>
   <xmp highlight='rust'>
     var i: i32;         // Initial value is 0.  Not recommended style.
     loop {
@@ -1691,18 +1703,20 @@ When a variable is created, its storage contains an initial value as follows:
       break if (i == 5);
     }
   </xmp>
-  The loop body will execute five times.
-  Variable `i` will take on values 0, 1, 2, 3, 4, 5, and variable `twice` will take on values 0, 2, 4, 6, 8.
 </div>
+The loop body will execute five times.
+Variable `i` will take on values 0, 1, 2, 3, 4, 5, and variable `twice` will take on values 0, 2, 4, 6, 8.
 
-<div class='example'>
-  Consider the following snippet of WGSL:
+Consider the following snippet of WGSL:
+<div class='example wsgl function-scope'>
   <xmp highlight='rust'>
     var x : f32 = 1.0;
     const y = x * x + x + 1;
   </xmp>
-  Because `x` is a variable, all accesses to it turn into load and store operations.
-  If this snippet was compiled to SPIR-V, it would be represented as
+</div>
+Because `x` is a variable, all accesses to it turn into load and store operations.
+If this snippet was compiled to SPIR-V, it would be represented as
+<div class='example spirv'>
   <xmp highlight='asm'>
     %temp_1 = OpLoad %float %x
     %temp_2 = OpLoad %float %x
@@ -1711,9 +1725,9 @@ When a variable is created, its storage contains an initial value as follows:
     %temp_5 = OpFAdd %float %temp_3 %temp_4
     %y      = OpFAdd %float %temp_5 %one
   </xmp>
-  However, it is expected that either the browser or the driver optimizes this intermediate representation
-  such that the redundant loads are eliminated.
 </div>
+However, it is expected that either the browser or the driver optimizes this intermediate representation
+such that the redundant loads are eliminated.
 
 ## Module Scope Variables ## {#module-scope-variables}
 
@@ -1745,7 +1759,7 @@ uniform buffers, storage buffers, textures, and samplers form the
 [=resource interface of a shader=].
 Such variables are declared with [=group=] and [=binding=] decorations.
 
-<div class='example' heading="Module scope variable declarations">
+<div class='example wgsl global-scope' heading="Module scope variable declarations">
   <xmp>
     var<in> twist: f32;
     var<out> spin: f32;
@@ -1818,7 +1832,7 @@ until the end of the [SHORTNAME] program.
 When the declaration has no attributes, an initializer expression must be present,
 and the name denotes the value of that expression.
 
-<div class='example' heading='Module constants'>
+<div class='example wgsl global-scope' heading='Module constants'>
   <xmp>
     const golden : f32 = 1.61803398875;       // The golden ratio
     const e2 : vec3<i32> = vec3<i32>(0,1,0);  // The second unit vector for three dimensions.
@@ -1843,7 +1857,7 @@ the constant is *pipeline-overridable*. In this case:
 Issue(dneto): What happens if the application supplies a constant ID that is not in the program?
 Proposal: pipeline creation fails with an error.
 
-<div class='example' heading='Module constants, pipeline-overrideable'>
+<div class='example wgsl global-scope' heading='Module constants, pipeline-overrideable'>
   <xmp>
     [[constant_id(0)]]    const has_point_light : bool = true;      // Algorithmic control
     [[constant_id(1200)]] const specular_param : f32 = 2.3;         // Numeric control
@@ -1917,7 +1931,7 @@ A variable declared in function scope is always in the [=storage classes/functio
 The variable storage decoration is optional.
 The variable's [=store type=] must be [=storable=].
 
-<div class='example' heading="Function scope variables and constants">
+<div class='example wgsl global-scope' heading="Function scope variables and constants">
   <xmp highlight='rust'>
     fn f() -> void {
        var<function> count : u32;  // A variable in function storage class.
@@ -2217,7 +2231,7 @@ The zero values are as follows:
   <tr>
 </table>
 
-<div class='example' heading="Zero-valued structures">
+<div class='example wgsl global-scope' heading="Zero-valued structures">
   <xmp highlight='rust'>
     struct Student {
       grade : i32;
@@ -2422,7 +2436,7 @@ The result type depends on the number of letters provided. Assuming a `vec4<f32>
   <tr><td>rgba<td>`vec4<f32>`
 </table>
 
-<div class='example'>
+<div class='example wgsl function-scope'>
   <xmp highlight='rust'>
     var a : vec3<f32> = vec3<f32>(1., 2., 3.);
     var b : f32 = a.y;          // b = 2.0
@@ -3080,7 +3094,7 @@ This design directly expresses loop idioms commonly found in compiled code.
 In particular, placing the loop update statements at the end of the loop body
 allows them to naturally use values defined in the loop body.
 
-<div class='example' heading='GLSL Loop'>
+<div class='example glsl' heading='GLSL Loop'>
   <xmp>
     int a = 2;
     for (int i = 0; i < 4; i++) {
@@ -3089,7 +3103,7 @@ allows them to naturally use values defined in the loop body.
   </xmp>
 </div>
 
-<div class='example' heading="[SHORTNAME] Loop">
+<div class='example wgsl function-scope' heading="[SHORTNAME] Loop">
   <xmp>
     const a : i32 = 2;
     var i : i32 = 0;      // <1>
@@ -3104,7 +3118,7 @@ allows them to naturally use values defined in the loop body.
 </div>
 * <1> The initialization is listed before the loop.
 
-<div class='example' heading='GLSL Loop with continue'>
+<div class='example glsl' heading='GLSL Loop with continue'>
   <xmp>
     int a = 2;
     const int step = 1;
@@ -3115,7 +3129,7 @@ allows them to naturally use values defined in the loop body.
   </xmp>
 </div>
 
-<div class='example' heading="[SHORTNAME] Loop with continue">
+<div class='example wgsl' heading="[SHORTNAME] Loop with continue">
   <xmp>
     const a : i32 = 2;
     var i : i32 = 0;
@@ -3132,7 +3146,7 @@ allows them to naturally use values defined in the loop body.
   </xmp>
 </div>
 
-<div class='example' heading="[SHORTNAME] Loop with continue and continuing">
+<div class='example wgsl' heading="[SHORTNAME] Loop with continue and continuing">
   <xmp>
     const a : i32 = 2;
     var i : i32 = 0;
@@ -3170,7 +3184,7 @@ The `for(initializer; condition; continuing) { body }` statement is syntactic su
 * If `condition` is non-empty, it is checked at the beginning of the loop body and if unsatisfied then a [[#break-statement]] is executed.
 * If `continuing` is non-empty, it becomes a [[#continuing-statement]] at the end of the loop body.
 
-<div class='example' heading="For to Loop transformation">
+<div class='example glsl' heading="For to Loop transformation">
   <xmp>
     for(var i : i32 = 0; i < 4; i = i + 1) {
       if (a == 0) {
@@ -3178,9 +3192,13 @@ The `for(initializer; condition; continuing) { body }` statement is syntactic su
       }
       a = a + 2;
     }
+  </xmp>
+</div>
 
-    Converts to:
+Converts to:
 
+<div class='example wgsl function-scope' heading="For to Loop transformation">
+  <xmp>
     { // Introduce new scope for loop variable i
       var i : i32 = 0;
       loop {
@@ -3223,7 +3241,7 @@ then:
     * The only statement in the `else` clause of an `if` that has an empty true-branch clause and no `elseif` clauses.
 * That `if` statement must appear last in the `continuing` clause.
 
-<div class='example' heading="[SHORTNAME] Valid loop if-break from a continuing clause">
+<div class='example wgsl function-scope' heading="[SHORTNAME] Valid loop if-break from a continuing clause">
   <xmp>
     const a : i32 = 2;
     var i : i32 = 0;
@@ -3242,7 +3260,7 @@ then:
   </xmp>
 </div>
 
-<div class='example' heading="[SHORTNAME] Valid loop if-else-break from a continuing clause">
+<div class='example wgsl function-scope' heading="[SHORTNAME] Valid loop if-else-break from a continuing clause">
   <xmp>
     const a : i32 = 2;
     var i : i32 = 0;
@@ -3261,7 +3279,7 @@ then:
   </xmp>
 </div>
 
-<div class='example' heading="[SHORTNAME] Invalid breaks from a continuing clause">
+<div class='example wgsl function-scope' heading="[SHORTNAME] Invalid breaks from a continuing clause">
   <xmp>
     const a : i32 = 2;
     var i : i32 = 0;
@@ -3301,7 +3319,7 @@ control to an enclosing [[#continuing-statement]].
 A `continue` statement must not be placed such that it would transfer
 control past a declaration used in the targeted continuing construct.
 
-<div class='example' heading="Invalid continue bypasses declaration">
+<div class='example wgsl function-scope' heading="Invalid continue bypasses declaration">
   <xmp>
     var i : i32 = 0;
     loop {
@@ -3521,7 +3539,7 @@ the [SHORTNAME] module and the entry point's function name.
 An entry point function must have no parameters,
 and its return type must be [=void=].
 
-<div class='example' heading='Entry Point'>
+<div class='example wgsl global-scope' heading='Entry Point'>
   <xmp>
     [[stage(vertex)]]
     fn vtx_main() -> void { gl_Position = vec4<f32>(); }
@@ -3564,7 +3582,7 @@ It will stabilize in a finite number of steps.
 ISSUE: Can we query upper bounds on workgroup size dimensions?  Is it independent of the shader, or
   a property to be queried after creating the shader module?
 
-<div class='example' heading='workgroup_size Attribute'>
+<div class='example wgsl global-scope' heading='workgroup_size Attribute'>
   <xmp>
     [[ stage(compute), workgroup_size(8,1,1) ]]
     fn sorter() -> void { }
@@ -3645,7 +3663,7 @@ To declare a variable for accessing a particular output built-in *Y*:
 * Apply a `builtin(`*Y*`)` attribute to the variable.
 * The variable may have an initializer, or not, as described in [[#variables]].
 
-<div class='example' heading="Declaring built-in variables">
+<div class='example wgsl global-scope' heading="Declaring built-in variables">
   <xmp>
     // vertex shader output builtin
     [[builtin(position)]] var<out> my_position : vec4<f32>;
@@ -4322,7 +4340,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
 
 </table>
 
-<div class='example' heading="Declaring built-in variable: position">
+<div class='example wgsl global-scope' heading="Declaring built-in variable: position">
   <xmp>
     [[builtin(position)]] var<out> my_position : vec4<f32>;
 
@@ -4335,7 +4353,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
   </xmp>
 </div>
 
-<div class='example' heading="Example built-in variable: vertex_index">
+<div class='example wgsl global-scope' heading="Example built-in variable: vertex_index">
   <xmp>
     [[builtin(vertex_index)]] var<in> my_index : u32;
 
@@ -4347,7 +4365,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
   </xmp>
 </div>
 
-<div class='example' heading="Declaring other built-in variables">
+<div class='example wgsl global-scope' heading="Declaring other built-in variables">
   <xmp>
     [[builtin(instance_index)]] var<in> my_inst_index : u32;
     //    OpDecorate %gl_InstanceId BuiltIn InstanceIndex
@@ -5367,7 +5385,7 @@ The following types are *composite types*:
 There are no implicit type promotions in [SHORTNAME]. If you want to convert between
 types you must use the cast syntax to do it.
 
-<div class='example'>
+<div class='example wgsl function-scope'>
   <xmp highlight='rust'>
     var e : f32 = 3;    // error: literal is the wrong type
 


### PR DESCRIPTION
For divs of class `example`, also add whether the language is `wgsl`, `spirv` or `glsl`. This class isn't used to adjust rendering style, but is parsed by tooling to ensure the WGSL examples actually compile.

Compilable WGSL examples also have the class `function-scope` or `global-scope`, which is used to tell the tool how the code should be interpreted.

Some examples that mixed languages have been broken up into multiple divs.