### PR TITLE
Fix mistakes in examples

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -369,7 +369,7 @@ Issue: (dneto): Complete description of `Array<E,N>`
     struct Data {
       a : i32;
       b : vec2<f32>;
-    }
+    };
   </xmp>
 </div>
 
@@ -446,7 +446,7 @@ to define a [=uniform buffer=] or a [=storage buffer=]. See [[#memory-layouts]].
 <div class='example wgsl global-scope' heading='Structure WGSL'>
   <xmp>
     // Runtime Array
-    type RTArr = [[stride 16]] array<vec4<f32>>;
+    type RTArr = [[stride(16)]] array<vec4<f32>>;
     [[block]] struct S {
       [[offset(0)]] a : f32;
       [[offset(4)]] b : f32;
@@ -1619,6 +1619,7 @@ declaration of the identifier as a type alias or structure type.
     var<storage> buf2 : [[access(read_write)]] Buffer; // Can both read and write
 
     // Uniform buffer. Always read-only, and has more restrictive layout rules.
+    struct ParamsTable {};
     var<uniform> params : ParamsTable;
   </xmp>
 </div>
@@ -2239,14 +2240,18 @@ The zero values are as follows:
       attendance : array<bool,4>;
     };
 
-    // The zero value for Student
-    Student()
+    fn func() -> void {
+      var s : Student;
 
-    // The same value, written explicitly.
-    Student(0, 0.0, array<bool,4>(false,false,false,false))
+      // The zero value for Student
+      s = Student();
 
-    // The same value, written with zero-valued members.
-    Student(i32(), f32(), array<bool,4>())
+      // The same value, written explicitly.
+      s = Student(0, 0.0, array<bool,4>(false, false, false, false));
+
+      // The same value, written with zero-valued members.
+      s = Student(i32(), f32(), array<bool,4>());
+    }
   </xmp>
 </div>
 
@@ -3131,7 +3136,7 @@ allows them to naturally use values defined in the loop body.
 
 <div class='example wgsl' heading="[SHORTNAME] Loop with continue">
   <xmp>
-    const a : i32 = 2;
+    var a : i32 = 2;
     var i : i32 = 0;
     loop {
       if (i >= 4) { break; }
@@ -3148,7 +3153,7 @@ allows them to naturally use values defined in the loop body.
 
 <div class='example wgsl' heading="[SHORTNAME] Loop with continue and continuing">
   <xmp>
-    const a : i32 = 2;
+    var a : i32 = 2;
     var i : i32 = 0;
     loop {
       if (i >= 4) { break; }
@@ -3201,6 +3206,7 @@ Converts to:
   <xmp>
     { // Introduce new scope for loop variable i
       var i : i32 = 0;
+      var a : i32 = 0;
       loop {
         if (!(i < 4)) {
           break;
@@ -3243,7 +3249,7 @@ then:
 
 <div class='example wgsl function-scope' heading="[SHORTNAME] Valid loop if-break from a continuing clause">
   <xmp>
-    const a : i32 = 2;
+    var a : i32 = 2;
     var i : i32 = 0;
     loop {
       const step : i32 = 1;
@@ -3262,7 +3268,7 @@ then:
 
 <div class='example wgsl function-scope' heading="[SHORTNAME] Valid loop if-else-break from a continuing clause">
   <xmp>
-    const a : i32 = 2;
+    var a : i32 = 2;
     var i : i32 = 0;
     loop {
       const step : i32 = 1;
@@ -3279,10 +3285,11 @@ then:
   </xmp>
 </div>
 
-<div class='example wgsl function-scope' heading="[SHORTNAME] Invalid breaks from a continuing clause">
+<div class='example wgsl function-scope expect-error' heading="[SHORTNAME] Invalid breaks from a continuing clause">
   <xmp>
-    const a : i32 = 2;
+    var a : i32 = 2;
     var i : i32 = 0;
+
     loop {
       const step : i32 = 1;
 
@@ -3319,7 +3326,7 @@ control to an enclosing [[#continuing-statement]].
 A `continue` statement must not be placed such that it would transfer
 control past a declaration used in the targeted continuing construct.
 
-<div class='example wgsl function-scope' heading="Invalid continue bypasses declaration">
+<div class='example wgsl function-scope expect-error' heading="Invalid continue bypasses declaration">
   <xmp>
     var i : i32 = 0;
     loop {
@@ -3541,12 +3548,15 @@ and its return type must be [=void=].
 
 <div class='example wgsl global-scope' heading='Entry Point'>
   <xmp>
+    [[builtin(position)]]   var<out> gl_Position  : vec4<f32>;
+    [[builtin(frag_coord)]] var<out> gl_FragColor : vec4<f32>;
+
     [[stage(vertex)]]
     fn vtx_main() -> void { gl_Position = vec4<f32>(); }
        // OpEntryPoint Vertex %vtx_main "vtx_main" %gl_Position
 
     [[stage(fragment)]]
-    fn frag_main -> void { gl_FragColor = vec4<f32>(); }
+    fn frag_main() -> void { gl_FragColor = vec4<f32>(); }
        // OpEntryPoint Fragment %frag_main "frag_main" %gl_FragColor
 
     [[stage(compute)]]


### PR DESCRIPTION
And annotate examples that are expected to not compile with `expect-error`