### PR TITLE
Only allow 2d textures for copyImageBitmapToTexture for now

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2007,7 +2007,7 @@ dictionary GPUTextureDescriptor : GPUObjectDescriptorBase {
 enum GPUTextureDimension {
     "1d",
     "2d",
-    "3d"
+    "3d",
 };
 </script>
 
@@ -6763,6 +6763,7 @@ GPUQueue includes GPUObjectBase;
             If any of the following conditions are unsatisfied, throw an {{OperationError}} and stop.
             <div class=validusage>
                 - |copySize|.[=Extent3D/depth=] is `1`.
+                - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[dimension]]}} is {{GPUTextureDimension/"2d"}}.
                 - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} is one of the following:
                     - {{GPUTextureFormat/"rgba8unorm"}}
                     - {{GPUTextureFormat/"rgba8unorm-srgb"}}


### PR DESCRIPTION
It's more minimal and solves the majority of usecases. We can generalize it anytime.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1335.html" title="Last updated on Jan 7, 2021, 5:18 AM UTC (2f20e09)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1335/32862dc...kainino0x:2f20e09.html" title="Last updated on Jan 7, 2021, 5:18 AM UTC (2f20e09)">Diff</a>