### PR TITLE
Change the name of CreateReady*Pipeline to Create*PipelineAsync

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1456,8 +1456,8 @@ interface GPUDevice : EventTarget {
     GPUShaderModule createShaderModule(GPUShaderModuleDescriptor descriptor);
     GPUComputePipeline createComputePipeline(GPUComputePipelineDescriptor descriptor);
     GPURenderPipeline createRenderPipeline(GPURenderPipelineDescriptor descriptor);
-    Promise<GPUComputePipeline> createReadyComputePipeline(GPUComputePipelineDescriptor descriptor);
-    Promise<GPURenderPipeline> createReadyRenderPipeline(GPURenderPipelineDescriptor descriptor);
+    Promise<GPUComputePipeline> createComputePipelineAsync(GPUComputePipelineDescriptor descriptor);
+    Promise<GPURenderPipeline> createRenderPipelineAsync(GPURenderPipelineDescriptor descriptor);
 
     GPUCommandEncoder createCommandEncoder(optional GPUCommandEncoderDescriptor descriptor = {});
     GPURenderBundleEncoder createRenderBundleEncoder(GPURenderBundleEncoderDescriptor descriptor);
@@ -3677,7 +3677,7 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
                 1. Create a new [=invalid=] {{GPUComputePipeline}} and return the result.
         </div>
 
-    : <dfn>createReadyComputePipeline(descriptor)</dfn>
+    : <dfn>createComputePipelineAsync(descriptor)</dfn>
     ::
         Creates a {{GPUComputePipeline}}. The returned {{Promise}} resolves when the created pipeline
         is ready to be used without additional delay.
@@ -3688,11 +3688,11 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
         Note: Use of this method is preferred whenever possible, as it prevents blocking the
         [=queue timeline=] work on pipeline compilation.
 
-        <div algorithm=GPUDevice.createReadyComputePipeline>
+        <div algorithm=GPUDevice.createComputePipelineAsync>
             **Called on:** {{GPUDevice}} |this|.
 
             **Arguments:**
-            <pre class=argumentdef for="GPUDevice/createReadyComputePipeline(descriptor)">
+            <pre class=argumentdef for="GPUDevice/createComputePipelineAsync(descriptor)">
                 |descriptor|: Description of the {{GPUComputePipeline}} to create.
             </pre>
 
@@ -3893,7 +3893,7 @@ Issue: link to the semantics of SV_SampleIndex and SV_Coverage in WGSL spec.
             Issue: need description of the render states.
         </div>
 
-    : <dfn>createReadyRenderPipeline(descriptor)</dfn>
+    : <dfn>createRenderPipelineAsync(descriptor)</dfn>
     ::
         Creates a {{GPURenderPipeline}}. The returned {{Promise}} resolves when the created pipeline
         is ready to be used without additional delay.
@@ -3904,11 +3904,11 @@ Issue: link to the semantics of SV_SampleIndex and SV_Coverage in WGSL spec.
         Note: Use of this method is preferred whenever possible, as it prevents blocking the
         [=queue timeline=] work on pipeline compilation.
 
-        <div algorithm=GPUDevice.createReadyRenderPipeline>
+        <div algorithm=GPUDevice.createRenderPipelineAsync>
             **Called on:** {{GPUDevice}} |this|.
 
             **Arguments:**
-            <pre class=argumentdef for="GPUDevice/createReadyRenderPipeline(descriptor)">
+            <pre class=argumentdef for="GPUDevice/createRenderPipelineAsync(descriptor)">
                 |descriptor|: Description of the {{GPURenderPipeline}} to create.
             </pre>
 


### PR DESCRIPTION
This patch changes the name of CreateReady*Pipeline()
(CreateReadyRenderPipeline() and CreateReadyComputePipeline()) to
Create*PipelineAsync() to make them more understandable that they
are just the async version of Create*Pipeline() and align with
buffer.mapAsync().


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Jiawei-Shao/gpuweb/pull/1336.html" title="Last updated on Jan 7, 2021, 6:35 AM UTC (6325a48)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1336/32862dc...Jiawei-Shao:6325a48.html" title="Last updated on Jan 7, 2021, 6:35 AM UTC (6325a48)">Diff</a>