### PR TITLE
[wgsl] Add textureDimensions()

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5196,6 +5196,61 @@ If any of the parameters are out of bounds, then the call to `textureStore()`
 does nothing.
 
 
+### `textureDimensions` ### {#texturedimensions}
+
+Returns the dimensions of a texture, or texture's mip level in texels.
+
+```rust
+textureDimensions(t : texture_1d<T>) -> i32
+textureDimensions(t : texture_1d_array<T>) -> i32
+textureDimensions(t : texture_2d<T>) -> vec2<i32>
+textureDimensions(t : texture_2d<T>, level : i32) -> vec2<i32>
+textureDimensions(t : texture_2d_array<T>) -> vec2<i32>
+textureDimensions(t : texture_2d_array<T>, level : i32) -> vec2<i32>
+textureDimensions(t : texture_3d<T>) -> vec3<i32>
+textureDimensions(t : texture_3d<T>, level : i32) -> vec3<i32>
+textureDimensions(t : texture_cube<T>) -> vec3<i32>
+textureDimensions(t : texture_cube<T>, level : i32) -> vec3<i32>
+textureDimensions(t : texture_cube_array<T>) -> vec3<i32>
+textureDimensions(t : texture_cube_array<T>, level : i32) -> vec3<i32>
+textureDimensions(t : texture_multisampled_2d<T>)-> vec2<i32>
+textureDimensions(t : texture_multisampled_2d_array<T>)-> vec2<i32>
+textureDimensions(t : texture_depth_2d) -> vec2<i32>
+textureDimensions(t : texture_depth_2d, level : i32) -> vec2<i32>
+textureDimensions(t : texture_depth_2d_array) -> vec2<i32>
+textureDimensions(t : texture_depth_2d_array, level : i32) -> vec2<i32>
+textureDimensions(t : texture_depth_cube) -> vec3<i32>
+textureDimensions(t : texture_depth_cube, level : i32) -> vec3<i32>
+textureDimensions(t : texture_depth_cube_array) -> vec3<i32>
+textureDimensions(t : texture_depth_cube_array, level : i32) -> vec3<i32>
+textureDimensions(t : texture_storage_ro_1d<F>) -> i32
+textureDimensions(t : texture_storage_ro_1d_array<F>) -> i32
+textureDimensions(t : texture_storage_ro_2d<F>) -> vec2<i32>
+textureDimensions(t : texture_storage_ro_2d_array<F>) -> vec2<i32>
+textureDimensions(t : texture_storage_ro_3d<F>) -> vec3<i32>
+textureDimensions(t : texture_storage_wo_1d<F>) -> i32
+textureDimensions(t : texture_storage_wo_1d_array<F>) -> i32
+textureDimensions(t : texture_storage_wo_2d<F>) -> vec2<i32>
+textureDimensions(t : texture_storage_wo_2d_array<F>) -> vec2<i32>
+textureDimensions(t : texture_storage_wo_3d<F>) -> vec3<i32>
+```
+
+**Parameters:**
+
+<table class='data'>
+  <tr><td>`t`<td>
+  The [sampled](#sampled-texture-type),
+  [multisampled](#multisampled-texture-type), [depth](#texture-depth),
+  [read-only storage](#texture-ro) or [write-only storage](#texture-wo) texture.
+  <tr><td>`level`<td>
+  The mip level, with level 0 containing a full size version of the texture.<br>
+  If omitted, the dimensions of level 0 are returned.
+</table>
+
+**Returns:**
+
+The dimensions of the texture in texels.<br>
+
 
 **TODO:**
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5223,16 +5223,11 @@ textureDimensions(t : texture_depth_cube) -> vec3<i32>
 textureDimensions(t : texture_depth_cube, level : i32) -> vec3<i32>
 textureDimensions(t : texture_depth_cube_array) -> vec3<i32>
 textureDimensions(t : texture_depth_cube_array, level : i32) -> vec3<i32>
-textureDimensions(t : texture_storage_ro_1d<F>) -> i32
-textureDimensions(t : texture_storage_ro_1d_array<F>) -> i32
-textureDimensions(t : texture_storage_ro_2d<F>) -> vec2<i32>
-textureDimensions(t : texture_storage_ro_2d_array<F>) -> vec2<i32>
-textureDimensions(t : texture_storage_ro_3d<F>) -> vec3<i32>
-textureDimensions(t : texture_storage_wo_1d<F>) -> i32
-textureDimensions(t : texture_storage_wo_1d_array<F>) -> i32
-textureDimensions(t : texture_storage_wo_2d<F>) -> vec2<i32>
-textureDimensions(t : texture_storage_wo_2d_array<F>) -> vec2<i32>
-textureDimensions(t : texture_storage_wo_3d<F>) -> vec3<i32>
+textureDimensions(t : texture_storage_1d<F>) -> i32
+textureDimensions(t : texture_storage_1d_array<F>) -> i32
+textureDimensions(t : texture_storage_2d<F>) -> vec2<i32>
+textureDimensions(t : texture_storage_2d_array<F>) -> vec2<i32>
+textureDimensions(t : texture_storage_3d<F>) -> vec3<i32>
 ```
 
 **Parameters:**
@@ -5240,8 +5235,8 @@ textureDimensions(t : texture_storage_wo_3d<F>) -> vec3<i32>
 <table class='data'>
   <tr><td>`t`<td>
   The [sampled](#sampled-texture-type),
-  [multisampled](#multisampled-texture-type), [depth](#texture-depth),
-  [read-only storage](#texture-ro) or [write-only storage](#texture-wo) texture.
+  [multisampled](#multisampled-texture-type), [depth](#texture-depth), or
+  [storage](#texture-storage) texture.
   <tr><td>`level`<td>
   The mip level, with level 0 containing a full size version of the texture.<br>
   If omitted, the dimensions of level 0 are returned.


### PR DESCRIPTION
I've opted for 'Dimensions' over 'Size' as proposed in #1107. While more verbose, I think Dimensions is a better description as "size" may be mistaken for memory-size (especially with compute shaders, storage textures and overloads that return a single scalar).

I propose adding additional, separate functions for retrieving number-of-arrays, number-of-levels, number-of-samples, etc.

Bug: #1107