### PR TITLE
Change `offset` to `span`.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -530,7 +530,7 @@ The following types are <dfn dfn noexport>host-shareable</dfn>:
 * [=numeric vector=] types
 * [[#matrix-types]]
 * [[#array-types]] if the array type has a [=stride=] attribute and its element type is host-shareable
-* [[#struct-types]] if each member is host-shareable and, if the size of the member isn't the same as the size of the type, has a [=span=] attribute
+* [[#struct-types]] if each member is host-shareable and, if the number of bytes in memory of the member isn't the same as the number of bytes of the type, has a [=span=] attribute
 
 <table class='data'>
   <caption>Layout attributes, for host-shareable types</caption>
@@ -944,8 +944,8 @@ when:
 * If |S| is a structure type struct&lt;|T|<sub>1</sub>,...,|T|<sub>|n|</sub>&gt;, then it satisfies
     standard buffer layout rules for |C| when all the following are satisifed:
     * Each member type |T|<sub>|i|</sub> satisfies standard buffer layout rules for |C|
-    * Members do not overlap, and are laid out in declaration order:
-    * If the structure is aligned, then members will also be aligned:
+    * Members do not overlap, and are laid out in declaration order
+    * If the structure is aligned, then members will also be aligned
 * If |S| is an array type `array`&lt;|E|,|N|&gt; or `array`&lt;|E|&gt;, then it satisfies
     standard buffer layout rules for |C| when all the following are satisifed:
     * Element type |E| satisfies standard buffer layout rules for |C|

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -416,18 +416,19 @@ struct_member
   <thead>
     <tr><th>Struct member decoration keys<th>Valid values<th>Note
   </thead>
-  <tr><td>`offset`<td>non-negative i32 literal<td>
+  <tr><td>`span`<td>non-negative i32 literal<td>
 </table>
 
-Note: Layout attributes are required if the structure type is used
-to define a [=uniform buffer=] or a [=storage buffer=]. See [[#memory-layouts]].
+Note: The span layout attributes are required if the structure type is used
+to define a [=uniform buffer=] or a [=storage buffer=] and the memory size of the
+member is not the same as the size of the member type. See [[#memory-layouts]].
 
 <div class='example wgsl global-scope' heading='Structure WGSL'>
   <xmp>
-    // Offset decorations
+    // Span decorations
     struct my_struct {
-      [[offset(0)]] a : f32;
-      [[offset(4)]] b : vec4<f32>;
+      a : f32;
+      [[span(16)]] b : vec3<f32>;
     };
   </xmp>
 </div>
@@ -448,9 +449,9 @@ to define a [=uniform buffer=] or a [=storage buffer=]. See [[#memory-layouts]].
     // Runtime Array
     type RTArr = [[stride(16)]] array<vec4<f32>>;
     [[block]] struct S {
-      [[offset(0)]] a : f32;
-      [[offset(4)]] b : f32;
-      [[offset(16)]] data : RTArr;
+      a : f32;
+      b : f32;
+      data : RTArr;
     };
   </xmp>
 </div>
@@ -529,7 +530,7 @@ The following types are <dfn dfn noexport>host-shareable</dfn>:
 * [=numeric vector=] types
 * [[#matrix-types]]
 * [[#array-types]] if the array type has a [=stride=] attribute and its element type is host-shareable
-* [[#struct-types]] if each member is host-shareable and has an [=offset=] attribute
+* [[#struct-types]] if each member is host-shareable and, if the size of the member isn't the same as the size of the type, has a [=span=] attribute
 
 <table class='data'>
   <caption>Layout attributes, for host-shareable types</caption>
@@ -542,15 +543,16 @@ The following types are <dfn dfn noexport>host-shareable</dfn>:
       <td>Applied to an array type.<br>
          The number of bytes from the start of one element of the array to the
          start of the next element.
-  <tr><td><dfn noexport>`offset`</dfn>
+  <tr><td><dfn noexport>`span`</dfn>
       <td>non-negative i32 literal
       <td>Applied to a member of a structure type.<br>
-         The number of bytes between the start of the structure and the location
-         of this member.
+         In the case where the memory size of a member does not match the size of the member type, a
+         `span` is required. The `span` must be the byte size of memory taken up by the current member and no larger.
+         e.g. `vec3<f32>` would be labeled `[[span(16)]]`
 </table>
 
 Note: An [=IO-shareable=] type would also be host-shareable if it and its subtypes have
-the approporate [=stride=] and [=offset=] attributes.
+the appropriate [=stride=] and [=span=] attributes.
 Additionally, a [=runtime-sized=] array is host-shareable but is not IO-shareable.
 
 Note: Both IO-shareable and host-shareable types have concrete sizes, but counted differently.
@@ -680,16 +682,16 @@ The terms defined in this section express counts of 8-bit bytes.
 We will use the following notation:
 
 * |Stride|(|A|) is the value of the [=stride=] attribute of array type |A|.
-* |Offset|(|S|,|i|) is the value of the [=offset=] attribute of the |i|'th member of structure type |S|.
+* |Span|(|S|,|i|) is the value of the [=span=] attribute of the |i|'th member of structure type |S|.
 
 The remainder of this section is structured as follows:
 * Section [[#memory-layout-intent]] describes the intent of the layout rules.  It is not normative.
 * Section [[#internal-value-layout]] says how the internals of a value are placed in byte memory
-    locations starting from a given byte offset in a buffer.  For composite types the layout
+    locations starting from the start of a buffer.  For composite types the layout
     depends on the properties of the type itself, the storage class, and the user-specified
-    [=stride=] and [=offset=] attributes.
-* Section [[#layout-constraints]] describes the contraints on array strides and structure member
-    offsets, ultimately yielding definitions for
+    [=stride=] and [=span=] attributes.
+* Section [[#layout-constraints]] describes the constraints on array strides and structure member
+    spans, ultimately yielding definitions for
     [=uniform buffer layout=] and [=storage buffer layout=].
 
 #### Memory Layout Intent #### {#memory-layout-intent}
@@ -721,8 +723,8 @@ or to a storage buffer variable.
 See [[#resource-layout-compatibility]].
 
 Compared to OpenGL:
-* For any type, OpenGL `std140` layout is the same as using the tightest offset and stride assignments in [SHORTNAME] [=uniform buffer layout=].
-* For any type, OpenGL `std430` layout is the same as using the tightest offset and stride assignments in [SHORTNAME] [=storage buffer layout=].
+* For any type, OpenGL `std140` layout is the same as using the tightest span and stride assignments in [SHORTNAME] [=uniform buffer layout=].
+* For any type, OpenGL `std430` layout is the same as using the tightest span and stride assignments in [SHORTNAME] [=storage buffer layout=].
 * OpenGL supports row-major matrices, but [SHORTNAME] does not.
 
 Compared to [[Vulkan1.2ext|Vulkan &sect; 15.6.4 Offset and Stride Assignment]]:
@@ -742,7 +744,7 @@ Compared to [[Vulkan1.2ext|Vulkan &sect; 15.6.4 Offset and Stride Assignment]]:
 This section describes how the internals of a value are placed in the byte locations
 of a buffer, given an assumed placement of the overall value.
 These layouts depend on the value's type, the storage class of the buffer,
-the [=stride=] attribute on array types, and the [=offset=] attribute on structure type
+the [=stride=] attribute on array types, and the [=span=] attribute on structure type
 members.
 
 Note: Matrix values are laid out more compactly in the [=storage classes/storage=] storage class
@@ -798,12 +800,13 @@ then:
 
 When a value of structure type |S| is placed at byte offset |k| of a host-shared memory buffer,
 then:
-   * The |i|'th member of the structure value is placed at byte offset |k| + |Offset|(|S|,|i|)
+   * The |i|'th member of the structure value is placed at byte offset |k|
+   * The next byte offset is |k| + |Span|(|S|,|i|)
 
 #### Layout Constraints and Standard Buffer Layout #### {#layout-constraints}
 
 This section defines a standard buffer layout, parameterized on storage class,
-and the associated constraints on array strides and structure member offsets.
+and the associated constraints on array strides and structure member spans.
 It also provides a way to compute the number of bytes occupied by a buffer variable
 and by its internal components.
 
@@ -918,10 +921,10 @@ where |N|<sub>runtime</sub> is the runtime-determined number of elements of <var
   <tr algorithm="extent of a structure">
       <td>struct&lt;|T|<sub>1</sub>,...,|T|<sub>|n|</sub>&gt;
       <td>[=roundUp=](|Align|(|S|,`storage`),|L|),<br>
-      where |L|&nbsp;=&nbsp;|Offset|(|S|,|n|)&nbsp;+&nbsp;|Extent|(|V|<sub>|n|</sub>,`storage`)),<br>
+      where |L|&nbsp;=&nbsp;Sum(0, n, |Span|(|S|,|i|)),`storage`)),<br>
       and |V|<sub>|n|</sub> is the last member of |V|
       <td>[=roundUp=](|Align|(|S|,`uniform`),|L|),<br>
-      where |L|&nbsp;=&nbsp;|Offset|(|S|,|n|)&nbsp;+&nbsp;|Extent|(|V|<sub>|n|</sub>,`uniform`)),<br>
+      where |L|&nbsp;=&nbsp;Sum(0, n, |Span|(|S|,|n|)),`uniform`)),<br>
       and |V|<sub>|n|</sub> is the last member of |V|
 </table>
 
@@ -942,16 +945,7 @@ when:
     standard buffer layout rules for |C| when all the following are satisifed:
     * Each member type |T|<sub>|i|</sub> satisfies standard buffer layout rules for |C|
     * Members do not overlap, and are laid out in declaration order:
-        <p algorithm="member offsets increase and prevent overlap">
-            |Offset|(|S|,|i|) + <var ignore>Extent</var>(|T|<sub>|i|</sub>,<var ignore>C</var>)
-            &le; |Offset|(|S|,|i|+1), for 1 &le; |i| &lt; <var ignore>n</var>
-        </p>
     * If the structure is aligned, then members will also be aligned:
-        <p algorithm="member alignment">
-            |Offset|(|S|,|i|)
-            = |k| &times; <var ignore>Align</var>(|T|<sub>|i|</sub>,<var ignore>C</var>),
-            for some non-negative integer |k|
-        </p>
 * If |S| is an array type `array`&lt;|E|,|N|&gt; or `array`&lt;|E|&gt;, then it satisfies
     standard buffer layout rules for |C| when all the following are satisifed:
     * Element type |E| satisfies standard buffer layout rules for |C|
@@ -1768,13 +1762,13 @@ Such variables are declared with [=group=] and [=binding=] decorations.
     var<workgroup> worklist: array<i32,10>;
 
     [[block]] struct Params {
-      [[offset(0)]] specular: f32;
-      [[offset(4)]] count: i32;
+      specular: f32;
+      count: i32;
     };
     var<uniform> param: Params;          // A uniform buffer
 
     [[block]] struct PositionsBuffer {
-      [[offset(0)]] pos: [[stride(8)]] array<vec2<f32>>;
+      pos: [[stride(8)]] array<vec2<f32>>;
     };
     [[group(0), binding(0)]]
     var<storage> pbuf: PositionsBuffer;  // A storage buffer


### PR DESCRIPTION
This CL removes the offset decoration from struct members and adds a
`span` decoration instead. The span reduces the amount of action at a
distance required when adding data members as each line is self
contained. This also reduces the amount of typing required as the span
is only required when the memory size does not patch the type size for a
member.

Fixes #1303