### PR TITLE
Remove the requirement to have entry points

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5025,7 +5025,6 @@ the test name.
 
 * v-0001: A declaration must not introduce a name when that name is already in scope at the start
           of the declaration.
-* v-0003: At least one of vertex, fragment or compute shader must be present.
 * v-0004: Recursion is not allowed.
 * v-0007: Structures must be defined before use.
 * v-0008: switch statements must have exactly one default clause.


### PR DESCRIPTION
See #1333 for some context. I don't think either tools or users gain anything from this validation rule. It doesn't need to be there.