### PR TITLE
mat2x2 is laid out tightly

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -707,7 +707,9 @@ In particular:
 * An array's element alignment is a multiple of the element type's alignment.
     * In a uniform buffer, the array element alignment is also a multiple of 16.
 * An array's alignment is the same as its element alignment.
-* A matrix with |N| columns is aligned as if it were an array of |N| column vectors.
+* A matrix with |N| columns is aligned as |N| column vectors without additional padding.
+    * If the columns are 3-element vector, then each vector has its own
+        internal padding to the size of a 4-element vector, as noted above.
 * A structure inherits the worst-case alignment of any of its members.
     * In a uniform buffer, the structure alignment is also a multiple of 16.
 * The members of a structure are laid out in order: earlier members are appear earlier in
@@ -721,7 +723,11 @@ or to a storage buffer variable.
 See [[#resource-layout-compatibility]].
 
 Compared to OpenGL:
-* For any type, OpenGL `std140` layout is the same as using the tightest offset and stride assignments in [SHORTNAME] [=uniform buffer layout=].
+* For any type except column major `mat2x2` and types that contain column major `mat2x2`,
+    OpenGL `std140` layout is the same as using the tightest offset and stride assignments in [SHORTNAME] [=uniform buffer layout=].
+* OpenGL `std140` layout of `mat2x2` has extra padding between column vectors that is not present in a `mat2x2` type in [SHORTNAME].
+    * The OpenGL `std140` layout of the `mat2x2` type has the second column vector starting 16 bytes after the first column vector.  
+        But in [SHORTNAME] the second column vector of `mat2x2<f32>` starts 8 bytes after the first column vector.
 * For any type, OpenGL `std430` layout is the same as using the tightest offset and stride assignments in [SHORTNAME] [=storage buffer layout=].
 * OpenGL supports row-major matrices, but [SHORTNAME] does not.
 
@@ -781,16 +787,11 @@ byte offset |k| of a host-shared buffer, then:
    * If |N| &ge; 3, then |V|.z is placed at byte offset |k|+8
    * If |N| &ge; 4, then |V|.w is placed at byte offset |k|+12
 
-When a matrix value |M| is placed at byte offset |k| of a host-shared memory buffer in
-the [=storage classes/storage=] [=storage class=], then:
+When a matrix value |M| is placed at byte offset |k| of a host-shared memory buffer, then:
    * If |M| has 2 rows, then:
       * Column vector |i| of |M| is placed at byte offset |k| + 8 &times; |i|
    * If |M| has 3 or 4 rows, then:
       * Column vector |i| of |M| is placed at byte offset |k| + 16 &times; |i|
-
-When a matrix value |M| is placed at byte offset |k| of a host-shared memory buffer in
-the [=storage classes/uniform=] storage class, then:
-   * Column vector |i| of |M| is placed at byte offset |k| + 16 &times; |i|
 
 When a value of array type |A| is placed at byte offset |k| of a host-shared memory buffer,
 then:
@@ -842,15 +843,18 @@ It is defined recursively in the following table:
   <tr algorithm="alignment of a matrix with 2 rows">
       <td>mat|N|x2&lt;f32&gt;
       <td>8
-      <td>16
+      <td>8
+          <!-- Vulkan base alignment: 2 times scalar aligment -->
   <tr algorithm="alignment of a matrix with 3 rows">
       <td>mat|N|x3&lt;f32&gt;
       <td>16
       <td>16
+          <!-- Vulkan base alignment: 4 times scalar aligment -->
   <tr algorithm="alignment of a matrix with 4 rows">
       <td>mat|N|x4&lt;f32&gt;
       <td>16
       <td>16
+          <!-- Vulkan base alignment: 4 times scalar aligment -->
   <tr algorithm="alignment of an array">
       <td>array<|T|,|N|>
       <td>|Align|(|T|,`storage`)
@@ -862,7 +866,7 @@ It is defined recursively in the following table:
   <tr algorithm="alignment of a structure">
       <td>struct&lt;|T1|,...,|Tn|&gt;
       <td>max(|Align|(|T1|,`storage`),..., |Align|(|Tn|,`storage`))
-      <td>roundUp(16, |A|),<br> where |A| = max(|Align|(|T1|,`uniform`),..., |Align|(|Tn|,`uniform`)))
+      <td>[=roundUp=](16, |A|),<br> where |A| = max(|Align|(|T1|,`uniform`),..., |Align|(|Tn|,`uniform`)))
 </table>
 
 The <dfn>allocation extent</dfn> of a value |V|
@@ -897,7 +901,7 @@ It is defined recursively in the following table:
   <tr algorithm="extent of a matrix with 2 rows">
       <td>mat|N|x2&lt;f32&gt;
       <td>|N| &times; 8
-      <td>|N| &times; 16
+      <td>|N| &times; 8
   <tr algorithm="extent of a matrix with 3 rows">
       <td>mat|N|x3&lt;f32&gt;
       <td>|N| &times; 16
@@ -963,9 +967,9 @@ when:
         <p algorithm="stride respects array element alignment">
         |Stride|(|S|) = |k| &times; |Align|(|E|,<var ignore>C</var>), for some positive integer |k|
         </p>
-    * For the [=storage classes/storage=] storage class, array elements are aligned to 16 byte boundaries:
+    * For the [=storage classes/uniform=] storage class, array elements are aligned to 16 byte boundaries:
         <p algorithm="16-byte array element alignment">
-            If <var ignore>C</var> is [=storage classes/storage=], then
+            If <var ignore>C</var> is [=storage classes/uniform=], then
             |Stride|(|S|)
             = |k| &times; 16 for some non-negative integer |k|
         </p>
@@ -978,7 +982,7 @@ element of a structure that is the store type for a buffer variable in the [=sto
 storage class.
 
 Host-shareable type |S| satisfies <dfn noexport>uniform buffer layout</dfn> when |S| satisfies
-[=standard buffer layout rules=] for storage class [=storage classes/storage=].
+[=standard buffer layout rules=] for storage class [=storage classes/uniform=].
 
 Host-shareable type |S| satisfies <dfn noexport>storage buffer layout</dfn> when |S| satisfies
 [=standard buffer layout rules=] for storage class [=storage classes/storage=].


### PR DESCRIPTION
Also fix typos in defining uniform storage buffer layout rules.
They take effect for *uniform* storage class, not *storage* storage
class.

See #1258