### PR TITLE
[wgsl] Further update access qualifiers for storage textures

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1277,9 +1277,12 @@ The following table lists the correspondence between WGSL texel formats and
 
 ### Storage Texture Types ### {#texture-storage}
 
-A <dfn noexport>read-only storage texture</dfn> supports reading a single texel without the use of a sampler,
-with automatic conversion of the stored texel value to a usable shader value. A <dfn noexport>write-only storage
-texture</dfn> supports writing a single texel, with automatic conversion
+A <dfn noexport>readable storage texture</dfn> has a `read` or `read_write`
+access qualifier, and supports reading a single texel without the use of a
+sampler, with automatic conversion of the stored texel value to a usable shader
+value.
+A <dfn noexport>writable storage texture</dfn> has a `write` or `read_write`
+access qualifier, and supports writing a single texel, with automatic conversion
 of the shader value to a stored texel value.
 See [[#texture-builtin-functions]].
 
@@ -1287,7 +1290,7 @@ A storage texture type must be parameterized by one of the
 [=storage-texel-format|texel formats for storage textures=].
 The texel format determines the conversion function as specified in [[#texel-formats]].
 
-For a write-only storage texture the *inverse* of the conversion function is used to convert the shader value to
+For a writable storage texture the *inverse* of the conversion function is used to convert the shader value to
 the stored texel.
 
 TODO(dneto): Move description of the conversion to the builtin function that actually does the reading.
@@ -1314,9 +1317,10 @@ In the SPIR-V mapping:
     as specified by the SPIR-V texel format correspondence table in [[#texel-formats]].
 * The *Sampled Type* parameter of the image type declaration is
     the SPIR-V scalar type corresponding to the channel format for the texel format.
-
-When mapping to SPIR-V, a read-only storage texture variable must have a `NonWritable` decoration and
-a write-only storage texture variable must have a `NonReadable` decoration.
+* A storage texture variable without a `write` or `read_write` access qualifier
+    must have a `NonWritable` decoration.
+* A storage texture variable without a `read` or `read_write` access qualifier
+    must have a `NonReadable` decoration.
 
 For example:
 
@@ -3743,9 +3747,9 @@ where compatibility is defined by the following table.
   <tr><td>sampled texture
       <td>[[WebGPU#dom-gpubindingtype-sampled-texture|sampled-texture]] or
           [[WebGPU#dom-gpubindingtype-multisampled-texture|multisampled-texture]]
-  <tr><td>[=read-only storage texture=]
+  <tr><td>[=non-writable storage texture=]
       <td>[[WebGPU#dom-gpubindingtype-readonly-storage-texture|readonly-storage-texture]]
-  <tr><td>[=write-only storage texture=]
+  <tr><td>[=non-readable storage texture=]
       <td>[[WebGPU#dom-gpubindingtype-writeonly-storage-texture|writeonly-storage-texture]]
 </table>
 
@@ -5126,14 +5130,14 @@ textureLoad(t : texture_depth_2d, coords : vec2<i32>) -> f32
 textureLoad(t : texture_depth_2d, coords : vec2<i32>, level : i32) -> f32
 textureLoad(t : texture_depth_2d_array, coords : vec2<i32>, array_index : i32) -> f32
 textureLoad(t : texture_depth_2d_array, coords : vec2<i32>, array_index : i32, level : i32) -> f32
-textureLoad(t : [[access(read)]] texture_storage_1d<F>, coords : i32) -> vec4<T>
-textureLoad(t : [[access(read)]] texture_storage_1d_array<F>, coords : i32, array_index : i32) -> vec4<T>
-textureLoad(t : [[access(read)]] texture_storage_2d<F>, coords : vec2<i32>) -> vec4<T>
-textureLoad(t : [[access(read)]] texture_storage_2d_array<F>, coords : vec2<i32>, array_index : i32) -> vec4<T>
-textureLoad(t : [[access(read)]] texture_storage_3d<F>, coords : vec3<i32>) -> vec4<T>
+textureLoad(t : texture_storage_1d<F>, coords : i32) -> vec4<T>
+textureLoad(t : texture_storage_1d_array<F>, coords : i32, array_index : i32) -> vec4<T>
+textureLoad(t : texture_storage_2d<F>, coords : vec2<i32>) -> vec4<T>
+textureLoad(t : texture_storage_2d_array<F>, coords : vec2<i32>, array_index : i32) -> vec4<T>
+textureLoad(t : texture_storage_3d<F>, coords : vec3<i32>) -> vec4<T>
 ```
 
-For [read-only storage textures](#texture-storage) the returned channel format `T`
+For [readable storage textures](#texture-storage) the returned channel format `T`
 depends on the texel format `F`.
 [See the texel format table](#storage-texel-formats) for the mapping of texel
 format to channel format.
@@ -5144,7 +5148,7 @@ format to channel format.
   <tr><td>`t`<td>
   The [sampled](#sampled-texture-type),
   [multisampled](#multisampled-texture-type), [depth](#texture-depth) or
-  [read-only storage](#texture-storage) texture.
+  [readable storage](#texture-storage) texture.
   <tr><td>`coords`<td>
   The 0-based texel coordinate.
   <tr><td>`array_index`<td>
@@ -5166,11 +5170,11 @@ If any of the parameters are out of bounds, then zero in all components.
 Writes a single texel to a texture.
 
 ```rust
-textureStore(t : [[access(write)]] texture_storage_1d<F>, coords : i32, value : vec4<T>) -> void
-textureStore(t : [[access(write)]] texture_storage_1d_array<F>, coords : i32, array_index : i32, value : vec4<T>) -> void
-textureStore(t : [[access(write)]] texture_storage_2d<F>, coords : vec2<i32>, value : vec4<T>) -> void
-textureStore(t : [[access(write)]] texture_storage_2d_array<F>, coords : vec2<i32>, array_index : i32, value : vec4<T>) -> void
-textureStore(t : [[access(write)]] texture_storage_3d<F>, coords : vec3<i32>, value : vec4<T>) -> void
+textureStore(t : texture_storage_1d<F>, coords : i32, value : vec4<T>) -> void
+textureStore(t : texture_storage_1d_array<F>, coords : i32, array_index : i32, value : vec4<T>) -> void
+textureStore(t : texture_storage_2d<F>, coords : vec2<i32>, value : vec4<T>) -> void
+textureStore(t : texture_storage_2d_array<F>, coords : vec2<i32>, array_index : i32, value : vec4<T>) -> void
+textureStore(t : texture_storage_3d<F>, coords : vec3<i32>, value : vec4<T>) -> void
 ```
 
 The channel format `T` depends on the storage texel format `F`.
@@ -5181,7 +5185,7 @@ format to channel format.
 
 <table class='data'>
   <tr><td>`t`<td>
-  The [write-only storage texture](#texture-storage).
+  The [writable storage texture](#texture-storage).
   <tr><td>`coords`<td>
   The 0-based texel coordinate.<br>
   <tr><td>`array_index`<td>


### PR DESCRIPTION
Additional tweaks after #1182.

Update the terms `read-only` and `write-only` in terms of the new access qualifiers.

Drop `[[access(read)]]` and `[[access(write)]]` annotations from the texture intrinsic overloads. These aren't legal signatures, and also incorrectly suggest that `[[access(read_write)]]` is not permitted.

Issue: #1159