### PR TITLE
Rename sample_mask to sample_mask_out

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4330,7 +4330,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
          by the primitive being rendered.
          <br>See [[WebGPU#sample-masking|WebGPU &sect; Sample Masking]].
 
-  <tr><td>`sample_mask`
+  <tr><td>`sample_mask_out`
       <td>fragment
       <td>out
       <td>u32
@@ -4340,7 +4340,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
          Zero bits in the written value will cause corresponding samples in
          the color attachments to be discarded.
          <br>The value in the variable is significant only if the
-         `sample_mask` variable is [=statically accessed=]
+         `sample_mask_out` variable is [=statically accessed=]
          by the fragment shader. If the variable is not statically accessed,
          then other factors determine sample coverage.
          <br>See [[WebGPU#sample-masking|WebGPU &sect; Sample Masking]].
@@ -4401,7 +4401,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
     //      OpDecorate %gl_SampleMaskIn BuiltIn SampleMask ; an input variable
     //      OpDecorate %gl_SampleMaskIn Flat
 
-    [[builtin(sample_mask)]] var<out> mask_out : u32;
+    [[builtin(sample_mask_out)]] var<out> mask_out : u32;
     //      OpDecorate %gl_SampleMask BuiltIn SampleMask ; an output variable
   </xmp>
 </div>


### PR DESCRIPTION
That reflects the title of the previous PR #1318, and the discussion
in the meeting of 2021-01-12

So now there would be:
  sample_mask_in
  sample_mask_out