### PR TITLE
[wgsl] Sort texture built-ins alphabetically

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -726,7 +726,7 @@ Compared to OpenGL:
 * For any type except column major `mat2x2` and types that contain column major `mat2x2`,
     OpenGL `std140` layout is the same as using the tightest offset and stride assignments in [SHORTNAME] [=uniform buffer layout=].
 * OpenGL `std140` layout of `mat2x2` has extra padding between column vectors that is not present in a `mat2x2` type in [SHORTNAME].
-    * The OpenGL `std140` layout of the `mat2x2` type has the second column vector starting 16 bytes after the first column vector.  
+    * The OpenGL `std140` layout of the `mat2x2` type has the second column vector starting 16 bytes after the first column vector.
         But in [SHORTNAME] the second column vector of `mat2x2<f32>` starts 8 bytes after the first column vector.
 * For any type, OpenGL `std430` layout is the same as using the tightest offset and stride assignments in [SHORTNAME] [=storage buffer layout=].
 * OpenGL supports row-major matrices, but [SHORTNAME] does not.
@@ -4927,6 +4927,111 @@ TODO: deduplicate these tables
 
 ## Texture built-in functions ## {#texture-builtin-functions}
 
+### `textureDimensions` ### {#texturedimensions}
+
+Returns the dimensions of a texture, or texture's mip level in texels.
+
+```rust
+textureDimensions(t : texture_1d<T>) -> i32
+textureDimensions(t : texture_1d_array<T>) -> i32
+textureDimensions(t : texture_2d<T>) -> vec2<i32>
+textureDimensions(t : texture_2d<T>, level : i32) -> vec2<i32>
+textureDimensions(t : texture_2d_array<T>) -> vec2<i32>
+textureDimensions(t : texture_2d_array<T>, level : i32) -> vec2<i32>
+textureDimensions(t : texture_3d<T>) -> vec3<i32>
+textureDimensions(t : texture_3d<T>, level : i32) -> vec3<i32>
+textureDimensions(t : texture_cube<T>) -> vec3<i32>
+textureDimensions(t : texture_cube<T>, level : i32) -> vec3<i32>
+textureDimensions(t : texture_cube_array<T>) -> vec3<i32>
+textureDimensions(t : texture_cube_array<T>, level : i32) -> vec3<i32>
+textureDimensions(t : texture_multisampled_2d<T>)-> vec2<i32>
+textureDimensions(t : texture_multisampled_2d_array<T>)-> vec2<i32>
+textureDimensions(t : texture_depth_2d) -> vec2<i32>
+textureDimensions(t : texture_depth_2d, level : i32) -> vec2<i32>
+textureDimensions(t : texture_depth_2d_array) -> vec2<i32>
+textureDimensions(t : texture_depth_2d_array, level : i32) -> vec2<i32>
+textureDimensions(t : texture_depth_cube) -> vec3<i32>
+textureDimensions(t : texture_depth_cube, level : i32) -> vec3<i32>
+textureDimensions(t : texture_depth_cube_array) -> vec3<i32>
+textureDimensions(t : texture_depth_cube_array, level : i32) -> vec3<i32>
+textureDimensions(t : texture_storage_1d<F>) -> i32
+textureDimensions(t : texture_storage_1d_array<F>) -> i32
+textureDimensions(t : texture_storage_2d<F>) -> vec2<i32>
+textureDimensions(t : texture_storage_2d_array<F>) -> vec2<i32>
+textureDimensions(t : texture_storage_3d<F>) -> vec3<i32>
+```
+
+**Parameters:**
+
+<table class='data'>
+  <tr><td>`t`<td>
+  The [sampled](#sampled-texture-type),
+  [multisampled](#multisampled-texture-type), [depth](#texture-depth), or
+  [storage](#texture-storage) texture.
+  <tr><td>`level`<td>
+  The mip level, with level 0 containing a full size version of the texture.<br>
+  If omitted, the dimensions of level 0 are returned.
+</table>
+
+**Returns:**
+
+The dimensions of the texture in texels.<br>
+
+
+### `textureLoad` ### {#textureload}
+
+Reads a single texel from a texture without sampling or filtering.
+
+```rust
+textureLoad(t : texture_1d<T>, coords : i32) -> vec4<T>
+textureLoad(t : texture_1d_array<T>, coords : i32, array_index : i32) -> vec4<T>
+textureLoad(t : texture_2d<T>, coords : vec2<i32>) -> vec4<T>
+textureLoad(t : texture_2d<T>, coords : vec2<i32>, level : i32) -> vec4<T>
+textureLoad(t : texture_2d_array<T>, coords : vec2<i32>, array_index : i32) -> vec4<T>
+textureLoad(t : texture_2d_array<T>, coords : vec2<i32>, array_index : i32, level : i32) -> vec4<T>
+textureLoad(t : texture_3d<T>, coords : vec3<i32>) -> vec4<T>
+textureLoad(t : texture_3d<T>, coords : vec3<i32>, level : i32) -> vec4<T>
+textureLoad(t : texture_multisampled_2d<T>, coords : vec2<i32>, sample_index : i32)-> vec4<T>
+textureLoad(t : texture_multisampled_2d_array<T>, coords : vec2<i32>, array_index : i32, sample_index : i32)-> vec4<T>
+textureLoad(t : texture_depth_2d, coords : vec2<i32>) -> f32
+textureLoad(t : texture_depth_2d, coords : vec2<i32>, level : i32) -> f32
+textureLoad(t : texture_depth_2d_array, coords : vec2<i32>, array_index : i32) -> f32
+textureLoad(t : texture_depth_2d_array, coords : vec2<i32>, array_index : i32, level : i32) -> f32
+textureLoad(t : [[access(read)]] texture_storage_1d<F>, coords : i32) -> vec4<T>
+textureLoad(t : [[access(read)]] texture_storage_1d_array<F>, coords : i32, array_index : i32) -> vec4<T>
+textureLoad(t : [[access(read)]] texture_storage_2d<F>, coords : vec2<i32>) -> vec4<T>
+textureLoad(t : [[access(read)]] texture_storage_2d_array<F>, coords : vec2<i32>, array_index : i32) -> vec4<T>
+textureLoad(t : [[access(read)]] texture_storage_3d<F>, coords : vec3<i32>) -> vec4<T>
+```
+
+For [read-only storage textures](#texture-storage) the returned channel format `T`
+depends on the texel format `F`.
+[See the texel format table](#storage-texel-formats) for the mapping of texel
+format to channel format.
+
+**Parameters:**
+
+<table class='data'>
+  <tr><td>`t`<td>
+  The [sampled](#sampled-texture-type),
+  [multisampled](#multisampled-texture-type), [depth](#texture-depth) or
+  [read-only storage](#texture-storage) texture.
+  <tr><td>`coords`<td>
+  The 0-based texel coordinate.
+  <tr><td>`array_index`<td>
+  The 0-based texture array index.
+  <tr><td>`level`<td>
+  The mip level, with level 0 containing a full size version of the texture.
+  <tr><td>`sample_index`<td>
+  The 0-based sample index of the multisampled texture.
+</table>
+
+**Returns:**
+
+If all the parameters are within bounds, the unfiltered texel data.<br>
+If any of the parameters are out of bounds, then zero in all components.
+
+
 ### `textureSample` ### {#texturesample}
 
 Samples a texture.
@@ -5015,6 +5120,94 @@ textureSampleBias(t : texture_cube_array<f32>, s : sampler, coords : vec3<f32>, 
 The sampled value.
 
 
+### `textureSampleCompare` ### {#texturesamplecompare}
+
+Samples a depth texture and compares the sampled depth values against a reference value.
+
+```rust
+textureSampleCompare(t : texture_depth_2d, s : sampler_comparison, coords : vec2<f32>, depth_ref : f32) -> f32
+textureSampleCompare(t : texture_depth_2d, s : sampler_comparison, coords : vec2<f32>, depth_ref : f32, offset : vec2<i32>) -> f32
+textureSampleCompare(t : texture_depth_2d_array, s : sampler_comparison, coords : vec2<f32>, array_index : i32, depth_ref : f32) -> f32
+textureSampleCompare(t : texture_depth_2d_array, s : sampler_comparison, coords : vec2<f32>, array_index : i32, depth_ref : f32, offset : vec2<i32>) -> f32
+textureSampleCompare(t : texture_depth_cube, s : sampler_comparison, coords : vec3<f32>, depth_ref : f32) -> f32
+textureSampleCompare(t : texture_depth_cube_array, s : sampler_comparison, coords : vec3<f32>, array_index : i32, depth_ref : f32) -> f32
+```
+
+**Parameters:**
+
+<table class='data'>
+  <tr><td>`t`<td>
+  The [depth](#texture-depth) texture to sample.
+  <tr><td>`s`<td>
+  The [sampler comparision](#sampler-type) type.
+  <tr><td>`coords`<td>
+  The texture coordinates used for sampling.
+  <tr><td>`array_index`<td>
+  The 0-based texture array index to sample.
+  <tr><td>`depth_ref`<td>
+  The reference value to compare the sampled depth value against.
+  <tr><td>`offset`<td>
+  The optional texel offset applied to the unnormalized texture coordinate
+  before sampling the texture. This offset is applied before applying any
+  texture wrapping modes. `offset` values may range from `[-8..7]` in all
+  dimensions. Values outside of this range will be clamped to the nearest limit.
+</table>
+
+**Returns:**
+
+A value in the range `[0.0..1.0]`.
+
+Each sampled texel is compared against the reference value using the comparision
+operator defined by the `sampler_comparison`, resulting in either a `0` or `1`
+value for each texel.
+
+If the `sampler_comparison` uses bilinear filtering then the returned value is
+the filtered average of these values, otherwise the comparision result of a
+single texel is returned.
+
+
+### `textureSampleGrad` ### {#texturesamplegrad}
+
+Samples a texture using explicit gradients.
+
+```rust
+textureSampleGrad(t : texture_2d<f32>, s : sampler, coords : vec2<f32>, ddx : vec2<f32>, ddy : vec2<f32>) -> vec4<f32>
+textureSampleGrad(t : texture_2d<f32>, s : sampler, coords : vec2<f32>, ddx : vec2<f32>, ddy : vec2<f32>, offset : vec2<i32>) -> vec4<f32>
+textureSampleGrad(t : texture_2d_array<f32>, s : sampler, coords : vec2<f32>, array_index : i32, ddx : vec2<f32>, ddy : vec2<f32>) -> vec4<f32>
+textureSampleGrad(t : texture_2d_array<f32>, s : sampler, coords : vec2<f32>, array_index : i32, ddx : vec2<f32>, ddy : vec2<f32>, offset : vec2<i32>) -> vec4<f32>
+textureSampleGrad(t : texture_3d<f32>, s : sampler, coords : vec3<f32>, ddx : vec3<f32>, ddy : vec3<f32>) -> vec4<f32>
+textureSampleGrad(t : texture_3d<f32>, s : sampler, coords : vec3<f32>, ddx : vec3<f32>, ddy : vec3<f32>, offset : vec3<i32>) -> vec4<f32>
+textureSampleGrad(t : texture_cube<f32>, s : sampler, coords : vec3<f32>, ddx : vec3<f32>, ddy : vec3<f32>) -> vec4<f32>
+textureSampleGrad(t : texture_cube_array<f32>, s : sampler, coords : vec3<f32>, array_index : i32, ddx : vec3<f32>, ddy : vec3<f32>) -> vec4<f32>
+```
+
+**Parameters:**
+
+<table class='data'>
+  <tr><td>`t`<td>
+  The [texture](#sampled-texture-type) to sample.
+  <tr><td>`s`<td>
+  The [sampler type](#sampler-type).
+  <tr><td>`coords`<td>
+  The texture coordinates used for sampling.
+  <tr><td>`array_index`<td>
+  The 0-based texture array index to sample.
+  <tr><td>`ddx`<td>
+  The x direction derivative vector used to compute the sampling locations.
+  <tr><td>`ddy`<td>
+  The y direction derivative vector used to compute the sampling locations.
+  <tr><td>`offset`<td>
+  The optional texel offset applied to the unnormalized texture coordinate
+  before sampling the texture. This offset is applied before applying any
+  texture wrapping modes. `offset` values may range from `[-8..7]` in all
+  dimensions. Values outside of this range will be clamped to the nearest limit.
+</table>
+
+**Returns:**
+
+The sampled value.
+
+
 ### `textureSampleLevel` ### {#texturesamplelevel}
 
 Samples a texture using an explicit mip level.
@@ -5065,148 +5258,6 @@ textureSampleLevel(t : texture_depth_cube_array, s : sampler, coords : vec3<f32>
 The sampled value.
 
 
-### `textureSampleGrad` ### {#texturesamplegrad}
-
-Samples a texture using explicit gradients.
-
-```rust
-textureSampleGrad(t : texture_2d<f32>, s : sampler, coords : vec2<f32>, ddx : vec2<f32>, ddy : vec2<f32>) -> vec4<f32>
-textureSampleGrad(t : texture_2d<f32>, s : sampler, coords : vec2<f32>, ddx : vec2<f32>, ddy : vec2<f32>, offset : vec2<i32>) -> vec4<f32>
-textureSampleGrad(t : texture_2d_array<f32>, s : sampler, coords : vec2<f32>, array_index : i32, ddx : vec2<f32>, ddy : vec2<f32>) -> vec4<f32>
-textureSampleGrad(t : texture_2d_array<f32>, s : sampler, coords : vec2<f32>, array_index : i32, ddx : vec2<f32>, ddy : vec2<f32>, offset : vec2<i32>) -> vec4<f32>
-textureSampleGrad(t : texture_3d<f32>, s : sampler, coords : vec3<f32>, ddx : vec3<f32>, ddy : vec3<f32>) -> vec4<f32>
-textureSampleGrad(t : texture_3d<f32>, s : sampler, coords : vec3<f32>, ddx : vec3<f32>, ddy : vec3<f32>, offset : vec3<i32>) -> vec4<f32>
-textureSampleGrad(t : texture_cube<f32>, s : sampler, coords : vec3<f32>, ddx : vec3<f32>, ddy : vec3<f32>) -> vec4<f32>
-textureSampleGrad(t : texture_cube_array<f32>, s : sampler, coords : vec3<f32>, array_index : i32, ddx : vec3<f32>, ddy : vec3<f32>) -> vec4<f32>
-```
-
-**Parameters:**
-
-<table class='data'>
-  <tr><td>`t`<td>
-  The [texture](#sampled-texture-type) to sample.
-  <tr><td>`s`<td>
-  The [sampler type](#sampler-type).
-  <tr><td>`coords`<td>
-  The texture coordinates used for sampling.
-  <tr><td>`array_index`<td>
-  The 0-based texture array index to sample.
-  <tr><td>`ddx`<td>
-  The x direction derivative vector used to compute the sampling locations.
-  <tr><td>`ddy`<td>
-  The y direction derivative vector used to compute the sampling locations.
-  <tr><td>`offset`<td>
-  The optional texel offset applied to the unnormalized texture coordinate
-  before sampling the texture. This offset is applied before applying any
-  texture wrapping modes. `offset` values may range from `[-8..7]` in all
-  dimensions. Values outside of this range will be clamped to the nearest limit.
-</table>
-
-**Returns:**
-
-The sampled value.
-
-
-### `textureSampleCompare` ### {#texturesamplecompare}
-
-Samples a depth texture and compares the sampled depth values against a reference value.
-
-```rust
-textureSampleCompare(t : texture_depth_2d, s : sampler_comparison, coords : vec2<f32>, depth_ref : f32) -> f32
-textureSampleCompare(t : texture_depth_2d, s : sampler_comparison, coords : vec2<f32>, depth_ref : f32, offset : vec2<i32>) -> f32
-textureSampleCompare(t : texture_depth_2d_array, s : sampler_comparison, coords : vec2<f32>, array_index : i32, depth_ref : f32) -> f32
-textureSampleCompare(t : texture_depth_2d_array, s : sampler_comparison, coords : vec2<f32>, array_index : i32, depth_ref : f32, offset : vec2<i32>) -> f32
-textureSampleCompare(t : texture_depth_cube, s : sampler_comparison, coords : vec3<f32>, depth_ref : f32) -> f32
-textureSampleCompare(t : texture_depth_cube_array, s : sampler_comparison, coords : vec3<f32>, array_index : i32, depth_ref : f32) -> f32
-```
-
-**Parameters:**
-
-<table class='data'>
-  <tr><td>`t`<td>
-  The [depth](#texture-depth) texture to sample.
-  <tr><td>`s`<td>
-  The [sampler comparision](#sampler-type) type.
-  <tr><td>`coords`<td>
-  The texture coordinates used for sampling.
-  <tr><td>`array_index`<td>
-  The 0-based texture array index to sample.
-  <tr><td>`depth_ref`<td>
-  The reference value to compare the sampled depth value against.
-  <tr><td>`offset`<td>
-  The optional texel offset applied to the unnormalized texture coordinate
-  before sampling the texture. This offset is applied before applying any
-  texture wrapping modes. `offset` values may range from `[-8..7]` in all
-  dimensions. Values outside of this range will be clamped to the nearest limit.
-</table>
-
-**Returns:**
-
-A value in the range `[0.0..1.0]`.
-
-Each sampled texel is compared against the reference value using the comparision
-operator defined by the `sampler_comparison`, resulting in either a `0` or `1`
-value for each texel.
-
-If the `sampler_comparison` uses bilinear filtering then the returned value is
-the filtered average of these values, otherwise the comparision result of a
-single texel is returned.
-
-
-### `textureLoad` ### {#textureload}
-
-Reads a single texel from a texture without sampling or filtering.
-
-```rust
-textureLoad(t : texture_1d<T>, coords : i32) -> vec4<T>
-textureLoad(t : texture_1d_array<T>, coords : i32, array_index : i32) -> vec4<T>
-textureLoad(t : texture_2d<T>, coords : vec2<i32>) -> vec4<T>
-textureLoad(t : texture_2d<T>, coords : vec2<i32>, level : i32) -> vec4<T>
-textureLoad(t : texture_2d_array<T>, coords : vec2<i32>, array_index : i32) -> vec4<T>
-textureLoad(t : texture_2d_array<T>, coords : vec2<i32>, array_index : i32, level : i32) -> vec4<T>
-textureLoad(t : texture_3d<T>, coords : vec3<i32>) -> vec4<T>
-textureLoad(t : texture_3d<T>, coords : vec3<i32>, level : i32) -> vec4<T>
-textureLoad(t : texture_multisampled_2d<T>, coords : vec2<i32>, sample_index : i32)-> vec4<T>
-textureLoad(t : texture_multisampled_2d_array<T>, coords : vec2<i32>, array_index : i32, sample_index : i32)-> vec4<T>
-textureLoad(t : texture_depth_2d, coords : vec2<i32>) -> f32
-textureLoad(t : texture_depth_2d, coords : vec2<i32>, level : i32) -> f32
-textureLoad(t : texture_depth_2d_array, coords : vec2<i32>, array_index : i32) -> f32
-textureLoad(t : texture_depth_2d_array, coords : vec2<i32>, array_index : i32, level : i32) -> f32
-textureLoad(t : [[access(read)]] texture_storage_1d<F>, coords : i32) -> vec4<T>
-textureLoad(t : [[access(read)]] texture_storage_1d_array<F>, coords : i32, array_index : i32) -> vec4<T>
-textureLoad(t : [[access(read)]] texture_storage_2d<F>, coords : vec2<i32>) -> vec4<T>
-textureLoad(t : [[access(read)]] texture_storage_2d_array<F>, coords : vec2<i32>, array_index : i32) -> vec4<T>
-textureLoad(t : [[access(read)]] texture_storage_3d<F>, coords : vec3<i32>) -> vec4<T>
-```
-
-For [read-only storage textures](#texture-storage) the returned channel format `T`
-depends on the texel format `F`.
-[See the texel format table](#storage-texel-formats) for the mapping of texel
-format to channel format.
-
-**Parameters:**
-
-<table class='data'>
-  <tr><td>`t`<td>
-  The [sampled](#sampled-texture-type),
-  [multisampled](#multisampled-texture-type), [depth](#texture-depth) or
-  [read-only storage](#texture-storage) texture.
-  <tr><td>`coords`<td>
-  The 0-based texel coordinate.
-  <tr><td>`array_index`<td>
-  The 0-based texture array index.
-  <tr><td>`level`<td>
-  The mip level, with level 0 containing a full size version of the texture.
-  <tr><td>`sample_index`<td>
-  The 0-based sample index of the multisampled texture.
-</table>
-
-**Returns:**
-
-If all the parameters are within bounds, the unfiltered texel data.<br>
-If any of the parameters are out of bounds, then zero in all components.
-
-
 ### `textureStore` ### {#texturestore}
 
 Writes a single texel to a texture.
@@ -5240,57 +5291,6 @@ format to channel format.
 
 If any of the parameters are out of bounds, then the call to `textureStore()`
 does nothing.
-
-
-### `textureDimensions` ### {#texturedimensions}
-
-Returns the dimensions of a texture, or texture's mip level in texels.
-
-```rust
-textureDimensions(t : texture_1d<T>) -> i32
-textureDimensions(t : texture_1d_array<T>) -> i32
-textureDimensions(t : texture_2d<T>) -> vec2<i32>
-textureDimensions(t : texture_2d<T>, level : i32) -> vec2<i32>
-textureDimensions(t : texture_2d_array<T>) -> vec2<i32>
-textureDimensions(t : texture_2d_array<T>, level : i32) -> vec2<i32>
-textureDimensions(t : texture_3d<T>) -> vec3<i32>
-textureDimensions(t : texture_3d<T>, level : i32) -> vec3<i32>
-textureDimensions(t : texture_cube<T>) -> vec3<i32>
-textureDimensions(t : texture_cube<T>, level : i32) -> vec3<i32>
-textureDimensions(t : texture_cube_array<T>) -> vec3<i32>
-textureDimensions(t : texture_cube_array<T>, level : i32) -> vec3<i32>
-textureDimensions(t : texture_multisampled_2d<T>)-> vec2<i32>
-textureDimensions(t : texture_multisampled_2d_array<T>)-> vec2<i32>
-textureDimensions(t : texture_depth_2d) -> vec2<i32>
-textureDimensions(t : texture_depth_2d, level : i32) -> vec2<i32>
-textureDimensions(t : texture_depth_2d_array) -> vec2<i32>
-textureDimensions(t : texture_depth_2d_array, level : i32) -> vec2<i32>
-textureDimensions(t : texture_depth_cube) -> vec3<i32>
-textureDimensions(t : texture_depth_cube, level : i32) -> vec3<i32>
-textureDimensions(t : texture_depth_cube_array) -> vec3<i32>
-textureDimensions(t : texture_depth_cube_array, level : i32) -> vec3<i32>
-textureDimensions(t : texture_storage_1d<F>) -> i32
-textureDimensions(t : texture_storage_1d_array<F>) -> i32
-textureDimensions(t : texture_storage_2d<F>) -> vec2<i32>
-textureDimensions(t : texture_storage_2d_array<F>) -> vec2<i32>
-textureDimensions(t : texture_storage_3d<F>) -> vec3<i32>
-```
-
-**Parameters:**
-
-<table class='data'>
-  <tr><td>`t`<td>
-  The [sampled](#sampled-texture-type),
-  [multisampled](#multisampled-texture-type), [depth](#texture-depth), or
-  [storage](#texture-storage) texture.
-  <tr><td>`level`<td>
-  The mip level, with level 0 containing a full size version of the texture.<br>
-  If omitted, the dimensions of level 0 are returned.
-</table>
-
-**Returns:**
-
-The dimensions of the texture in texels.<br>
 
 
 **TODO:**


### PR DESCRIPTION
They were randomly ordered before. As we add more functions this becomes increasingly noticable.