### PR TITLE
Clarify some text related to GPUVertexState.indexFormat

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3790,7 +3790,8 @@ GPURenderPipeline includes GPUPipelineBase;
 
     : <dfn>\[[strip_index_format]]</dfn>, of type {{GPUIndexFormat}}?
     ::
-        The format index data this pipeline requires, initially `undefined`.
+        The format index data this pipeline requires if using a strip primitive topology,
+        initially `undefined`.
 </dl>
 
 ### Creation ### {#render-pipeline-creation}
@@ -4218,9 +4219,11 @@ strip primitive topologies ({{GPUPrimitiveTopology/"line-strip"}} or
 should be started rather than continuing to construct the triangle strip with the prior indexed
 vertices.
 
-{{GPURenderPipelineDescriptor}}s that specify a strip primitive topology must not have the
-{{GPUVertexStateDescriptor/indexFormat}} set to `undefined` so that the [=primitive restart value=]
-that will be used is known at pipline creation time.
+{{GPURenderPipelineDescriptor}}s that specify a strip primitive topology must specify a
+{{GPUVertexStateDescriptor/indexFormat}} so that the [=primitive restart value=] that will be used
+is known at pipeline creation time. {{GPURenderPipelineDescriptor}}s that specify a list primitive
+topology must set {{GPUVertexStateDescriptor/indexFormat}} to `undefined`, and will use the index
+format passed to {{GPURenderEncoderBase/setIndexBuffer()}} when rendering.
 
 <table class="data">
   <thead>


### PR DESCRIPTION
This came out of a conversation with a developer on Twitter that highlighted to me that the spec language around this field was difficult to interpret. Tried making the intent and requirements more explicit in the spec prose.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/1350.html" title="Last updated on Jan 14, 2021, 7:14 PM UTC (5b87889)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1350/db1ed25...5b87889.html" title="Last updated on Jan 14, 2021, 7:14 PM UTC (5b87889)">Diff</a>