### PR TITLE
Tighten vertex state validation.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4350,10 +4350,10 @@ dictionary GPUVertexAttributeDescriptor {
 
     Return `true`, if and only if, all of the following conditions are satisfied:
 
-        1. |descriptor|.{{GPUVertexBufferLayoutDescriptor/arrayStride}} is less than or equal to
+        - |descriptor|.{{GPUVertexBufferLayoutDescriptor/arrayStride}} is less than or equal to
             |device|.{{GPUDevice/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBufferArrayStride}}.
-        1. |descriptor|.{{GPUVertexBufferLayoutDescriptor/arrayStride}} is a multiple of 4.
-        1. For each attribute |attrib| in the list |descriptor|.{{GPUVertexBufferLayoutDescriptor/attributes}}:
+        - |descriptor|.{{GPUVertexBufferLayoutDescriptor/arrayStride}} is a multiple of 4.
+        - For each attribute |attrib| in the list |descriptor|.{{GPUVertexBufferLayoutDescriptor/attributes}}:
             1. If |descriptor|.{{GPUVertexBufferLayoutDescriptor/arrayStride}} zero:
                 1. |attrib|.{{GPUVertexAttributeDescriptor/offset}} + sizeOf(|attrib|.{{GPUVertexAttributeDescriptor/format}}) less or equal to
                     |device|.{{GPUDevice/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBufferArrayStride}}.
@@ -4362,11 +4362,11 @@ dictionary GPUVertexAttributeDescriptor {
                     |descriptor|.{{GPUVertexBufferLayoutDescriptor/arrayStride}}.
             1. |attrib|.{{GPUVertexAttributeDescriptor/offset}} is a multiple of the size of one component of
                 |attrib|.{{GPUVertexAttributeDescriptor/format}}.
-        1. For every vertex attribute in the shader reflection of |vertexStage|.{{GPUProgrammableStageDescriptor/module}}
+        - For every vertex attribute in the shader reflection of |vertexStage|.{{GPUProgrammableStageDescriptor/module}}
             that is know to be [=statically used=] by |vertexStage|.{{GPUProgrammableStageDescriptor/entryPoint}},
             there is a corresponding |attrib| element of |descriptor|.{{GPUVertexBufferLayoutDescriptor/attributes}} for which:
-            1. The shader format is |attrib|.{{GPUVertexAttributeDescriptor/format}}.
-            2. The shader location is |attrib|.{{GPUVertexAttributeDescriptor/shaderLocation}}.
+            - The shader format is |attrib|.{{GPUVertexAttributeDescriptor/format}}, and
+            - The shader location is |attrib|.{{GPUVertexAttributeDescriptor/shaderLocation}}.
 </div>
 
 <div algorithm>
@@ -4378,15 +4378,15 @@ dictionary GPUVertexAttributeDescriptor {
 
     Return `true`, if and only if, all of the following conditions are satisfied:
 
-        1. |descriptor|.{{GPUVertexStateDescriptor/vertexBuffers}}.length is less than or equal to
+        - |descriptor|.{{GPUVertexStateDescriptor/vertexBuffers}}.length is less than or equal to
             |device|.{{GPUDevice/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBuffers}}.
-        1. Each |vertexBuffer| layout descriptor in the list |descriptor|.{{GPUVertexStateDescriptor/vertexBuffers}}
+        - Each |vertexBuffer| layout descriptor in the list |descriptor|.{{GPUVertexStateDescriptor/vertexBuffers}}
             passes [$validating GPUVertexBufferLayoutDescriptor$](|device|, |vertexBuffer|, |vertexStage|)
-        1. The sum of |vertexBuffer|.{{GPUVertexBufferLayoutDescriptor/attributes}}.length,
+        - The sum of |vertexBuffer|.{{GPUVertexBufferLayoutDescriptor/attributes}}.length,
             over every |vertexBuffer| in |descriptor|.{{GPUVertexStateDescriptor/vertexBuffers}},
             is less than or equal to
             |device|.{{GPUDevice/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexAttributes}}.
-        1. Each |attrib| in the union of all {{GPUVertexAttributeDescriptor}}
+        - Each |attrib| in the union of all {{GPUVertexAttributeDescriptor}}
             across |descriptor|.{{GPUVertexStateDescriptor/vertexBuffers}} has a distinct
             |attrib|.{{GPUVertexAttributeDescriptor/shaderLocation}} value.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4365,7 +4365,8 @@ dictionary GPUVertexAttributeDescriptor {
                 |attrib|.{{GPUVertexAttributeDescriptor/format}}.
         - For every vertex attribute in the shader reflection of |vertexStage|.{{GPUProgrammableStageDescriptor/module}}
             that is know to be [=statically used=] by |vertexStage|.{{GPUProgrammableStageDescriptor/entryPoint}},
-            there is a corresponding |attrib| element of |descriptor|.{{GPUVertexBufferLayoutDescriptor/attributes}} for which:
+            there is a corresponding |attrib| element of |descriptor|.{{GPUVertexBufferLayoutDescriptor/attributes}} for which
+            all of the following are true:
             - The shader format is |attrib|.{{GPUVertexAttributeDescriptor/format}}.
             - The shader location is |attrib|.{{GPUVertexAttributeDescriptor/shaderLocation}}.
 </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4350,22 +4350,23 @@ dictionary GPUVertexAttributeDescriptor {
 
     Return `true`, if and only if, all of the following conditions are satisfied:
 
-        - |descriptor|.{{GPUVertexBufferLayoutDescriptor/arrayStride}} is less than or equal to
+        - |descriptor|.{{GPUVertexBufferLayoutDescriptor/arrayStride}} &le;
             |device|.{{GPUDevice/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBufferArrayStride}}.
         - |descriptor|.{{GPUVertexBufferLayoutDescriptor/arrayStride}} is a multiple of 4.
         - For each attribute |attrib| in the list |descriptor|.{{GPUVertexBufferLayoutDescriptor/attributes}}:
-            1. If |descriptor|.{{GPUVertexBufferLayoutDescriptor/arrayStride}} zero:
-                1. |attrib|.{{GPUVertexAttributeDescriptor/offset}} + sizeOf(|attrib|.{{GPUVertexAttributeDescriptor/format}}) less or equal to
+            - If |descriptor|.{{GPUVertexBufferLayoutDescriptor/arrayStride}} is zero:
+                - |attrib|.{{GPUVertexAttributeDescriptor/offset}} + sizeof(|attrib|.{{GPUVertexAttributeDescriptor/format}}) &le;
                     |device|.{{GPUDevice/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBufferArrayStride}}.
-            1. Else
-                1. |attrib|.{{GPUVertexAttributeDescriptor/offset}} + sizeOf(|attrib|.{{GPUVertexAttributeDescriptor/format}}) less or equal to
+
+                Otherwise:
+                - |attrib|.{{GPUVertexAttributeDescriptor/offset}} + sizeof(|attrib|.{{GPUVertexAttributeDescriptor/format}}) &le;
                     |descriptor|.{{GPUVertexBufferLayoutDescriptor/arrayStride}}.
-            1. |attrib|.{{GPUVertexAttributeDescriptor/offset}} is a multiple of the size of one component of
+            - |attrib|.{{GPUVertexAttributeDescriptor/offset}} is a multiple of the size of one component of
                 |attrib|.{{GPUVertexAttributeDescriptor/format}}.
         - For every vertex attribute in the shader reflection of |vertexStage|.{{GPUProgrammableStageDescriptor/module}}
             that is know to be [=statically used=] by |vertexStage|.{{GPUProgrammableStageDescriptor/entryPoint}},
             there is a corresponding |attrib| element of |descriptor|.{{GPUVertexBufferLayoutDescriptor/attributes}} for which:
-            - The shader format is |attrib|.{{GPUVertexAttributeDescriptor/format}}, and
+            - The shader format is |attrib|.{{GPUVertexAttributeDescriptor/format}}.
             - The shader location is |attrib|.{{GPUVertexAttributeDescriptor/shaderLocation}}.
 </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4352,14 +4352,21 @@ dictionary GPUVertexAttributeDescriptor {
 
         1. |descriptor|.{{GPUVertexBufferLayoutDescriptor/arrayStride}} is less than or equal to
             |device|.{{GPUDevice/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBufferArrayStride}}.
-        1. Any attribute |at| in the list |descriptor|.{{GPUVertexBufferLayoutDescriptor/attributes}} has
-            |at|.{{GPUVertexAttributeDescriptor/offset}} + sizeOf(|at|.{{GPUVertexAttributeDescriptor/format}}) less or equal to
-            |descriptor|.{{GPUVertexBufferLayoutDescriptor/arrayStride}}.
+        1. |descriptor|.{{GPUVertexBufferLayoutDescriptor/arrayStride}} is a multiple of 4.
+        1. For each attribute |attrib| in the list |descriptor|.{{GPUVertexBufferLayoutDescriptor/attributes}}:
+            1. If |descriptor|.{{GPUVertexBufferLayoutDescriptor/arrayStride}} zero:
+                1. |attrib|.{{GPUVertexAttributeDescriptor/offset}} + sizeOf(|attrib|.{{GPUVertexAttributeDescriptor/format}}) less or equal to
+                    |device|.{{GPUDevice/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBufferArrayStride}}.
+            1. Else
+                1. |attrib|.{{GPUVertexAttributeDescriptor/offset}} + sizeOf(|attrib|.{{GPUVertexAttributeDescriptor/format}}) less or equal to
+                    |descriptor|.{{GPUVertexBufferLayoutDescriptor/arrayStride}}.
+            1. |attrib|.{{GPUVertexAttributeDescriptor/offset}} is a multiple of the size of one component of
+                |attrib|.{{GPUVertexAttributeDescriptor/format}}.
         1. For every vertex attribute in the shader reflection of |vertexStage|.{{GPUProgrammableStageDescriptor/module}}
             that is know to be [=statically used=] by |vertexStage|.{{GPUProgrammableStageDescriptor/entryPoint}},
-            there is a corresponding |at| element of |descriptor|.{{GPUVertexBufferLayoutDescriptor/attributes}} that:
-            1. The shader format is |at|.{{GPUVertexAttributeDescriptor/format}}.
-            2. The shader location is |at|.{{GPUVertexAttributeDescriptor/shaderLocation}}.
+            there is a corresponding |attrib| element of |descriptor|.{{GPUVertexBufferLayoutDescriptor/attributes}} for which:
+            1. The shader format is |attrib|.{{GPUVertexAttributeDescriptor/format}}.
+            2. The shader location is |attrib|.{{GPUVertexAttributeDescriptor/shaderLocation}}.
 </div>
 
 <div algorithm>
@@ -4379,9 +4386,12 @@ dictionary GPUVertexAttributeDescriptor {
             over every |vertexBuffer| in |descriptor|.{{GPUVertexStateDescriptor/vertexBuffers}},
             is less than or equal to
             |device|.{{GPUDevice/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexAttributes}}.
-        1. Each |at| in the union of all {{GPUVertexAttributeDescriptor}}
+        1. Each |attrib| in the union of all {{GPUVertexAttributeDescriptor}}
             across |descriptor|.{{GPUVertexStateDescriptor/vertexBuffers}} has a distinct
-            |at|.{{GPUVertexAttributeDescriptor/shaderLocation}} value.
+            |attrib|.{{GPUVertexAttributeDescriptor/shaderLocation}} value.
+
+        Issue: are the {{GPUVertexAttributeDescriptor/shaderLocation}} arbitrary or should they be less than
+        {{supported limits/maxVertexAttributes}}?
 </div>
 
 # Command Buffers # {#command-buffers}


### PR DESCRIPTION
- Allow having a stride of 0 and constrain attributes to not have and
end offset that goes past limits/maxVertexBufferArrayStride in that
case.
 - Metal requires that the arrayStride be a multiple of 4.
 - Metal requires that the offset of attributes be a multiple of the
size of one of the format's component.
 - Use |attrib| instead of |at| to make the validation less confusing.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/1351.html" title="Last updated on Jan 20, 2021, 11:57 PM UTC (6d1bab6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1351/c8000bb...Kangz:6d1bab6.html" title="Last updated on Jan 20, 2021, 11:57 PM UTC (6d1bab6)">Diff</a>