### PR TITLE
Refactor the GPURenderPipelineDescriptor according to aspects

### DIFF
--- a/samples/hello-cube.html
+++ b/samples/hello-cube.html
@@ -220,7 +220,7 @@ async function init() {
 
     // GPURenderPassDepthStencilAttachmentDescriptor
     const depthAttachment = {
-        attachment: depthTexture.createDefaultView(),
+        view: depthTexture.createDefaultView(),
         depthLoadOp: "clear",
         depthStoreOp: "store",
         clearDepth: 1.0
@@ -273,7 +273,7 @@ function drawCommands(mappedGroup) {
     mappedGroup.buffer.unmap();
 
     const commandEncoder = device.createCommandEncoder();
-    renderPassDescriptor.colorAttachments[0].attachment = swapChain.getCurrentTexture().createDefaultView();
+    renderPassDescriptor.colorAttachments[0].view = swapChain.getCurrentTexture().createDefaultView();
     const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
 
     // Encode drawing commands

--- a/samples/hello-cube.html
+++ b/samples/hello-cube.html
@@ -124,22 +124,21 @@ async function init() {
     verticesBuffer.unmap();
 
     // Vertex Input
-    const positionAttributeDescriptor = {
+    const positionAttributeState = {
         shaderLocation: positionAttributeNum,  // [[attribute(0)]]
         offset: 0,
         format: "float4"
     };
-    const colorAttributeDescriptor = {
+    const colorAttributeState = {
         shaderLocation: colorAttributeNum,
         offset: colorOffset,
         format: "float4"
     }
-    const vertexBufferDescriptor = {
-        attributeSet: [positionAttributeDescriptor, colorAttributeDescriptor],
+    const vertexBufferState = {
+        attributeSet: [positionAttributeState, colorAttributeState],
         stride: vertexSize,
         stepMode: "vertex"
     };
-    const vertexInputDescriptor = { vertexBuffers: [vertexBufferDescriptor] };
 
     // Bind group binding layout
     const transformBufferBindGroupLayoutEntry = {
@@ -159,15 +158,7 @@ async function init() {
 
     const pipelineLayoutDescriptor = { bindGroupLayouts: [bindGroupLayout] };
     const pipelineLayout = device.createPipelineLayout(pipelineLayoutDescriptor);
-    const vertexStageDescriptor = {
-        module: shaderModule,
-        entryPoint: "vertex_main"
-    };
-    const fragmentStageDescriptor = {
-        module: shaderModule,
-        entryPoint: "fragment_main"
-    };
-    const colorState = {
+    const colorTargetState = {
         format: "bgra8unorm",
         blend: {
             alpha: {
@@ -185,14 +176,17 @@ async function init() {
     };
     const pipelineDescriptor = {
         layout: pipelineLayout,
-
-        vertexStage: vertexStageDescriptor,
-        fragmentStage: fragmentStageDescriptor,
-
-        primitiveTopology: "triangle-list",
-        colorStates: [colorState],
-        depthStencilState: depthStateDescriptor,
-        vertexInput: vertexInputDescriptor
+        vertex: {
+            inputBuffers: [vertexBufferState],
+            module: shaderModule,
+            entryPoint: "vertex_main"
+        },
+        fragment: {
+            module: shaderModule,
+            entryPoint: "fragment_main"
+            outputTargets: [colorTargetState],
+        },
+        depthStencil: depthStateDescriptor,
     };
     pipeline = device.createRenderPipeline(pipelineDescriptor);
 

--- a/samples/hello-cube.html
+++ b/samples/hello-cube.html
@@ -177,14 +177,14 @@ async function init() {
     const pipelineDescriptor = {
         layout: pipelineLayout,
         vertex: {
-            inputBuffers: [vertexBufferState],
+            buffers: [vertexBufferState],
             module: shaderModule,
             entryPoint: "vertex_main"
         },
         fragment: {
             module: shaderModule,
             entryPoint: "fragment_main"
-            outputTargets: [colorTargetState],
+            targets: [colorTargetState],
         },
         depthStencil: depthStateDescriptor,
     };

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1112,14 +1112,14 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
     <tr><td><dfn>maxVertexBuffers</dfn>
         <td>{{GPUSize32}} <td>Higher <td>8
     <tr class=row-continuation><td colspan=4>
-        The maximum number of {{GPUVertexState/inputBuffers}}
+        The maximum number of {{GPUVertexState/buffers}}
         when creating a {{GPURenderPipeline}}.
 
     <tr><td><dfn>maxVertexAttributes</dfn>
         <td>{{GPUSize32}} <td>Higher <td>16
     <tr class=row-continuation><td colspan=4>
         The maximum number of {{GPUVertexBufferLayout/attributes}}
-        in total across {{GPUVertexState/inputBuffers}}
+        in total across {{GPUVertexState/buffers}}
         when creating a {{GPURenderPipeline}}.
 
     <tr><td><dfn>maxVertexBufferArrayStride</dfn>
@@ -3789,14 +3789,14 @@ Render [=pipeline=] outputs are:
   - optionally, depth-stencil attachment, described by {{GPUDepthStencilState}}
 
 Stages of a render [=pipeline=]:
-  1. Vertex fetch, controlled by {{GPUVertexState/inputBuffers|GPUVertexState.inputBuffers}}
+  1. Vertex fetch, controlled by {{GPUVertexState/buffers|GPUVertexState.buffers}}
   2. Vertex shader, controlled by {{GPUVertexState}}
   3. Primitive assembly, controlled by {{GPUPrimitiveState}}
   4. Rasterization, controlled by {{GPUPrimitiveState}}, {{GPUDepthStencilState}}, and {{GPUMultisampleState}}
   5. Fragment shader, controlled by {{GPUFragmentState}}
   6. Stencil test and operation, controlled by {{GPUDepthStencilState}}
   7. Depth test and write, controlled by {{GPUDepthStencilState}}
-  8. Output merging, controlled by {{GPUFragmentState/outputTargets|GPUFragmentState.outputs}}
+  8. Output merging, controlled by {{GPUFragmentState/targets|GPUFragmentState.targets}}
 
 Issue: we need a deeper description of these stages
 
@@ -3858,7 +3858,7 @@ based on the vertex position output. The depth testing and stencil operations ca
 
 In alpha-to-coverage mode, an additional <dfn dfn>alpha-to-coverage mask</dfn>
 of MSAA samples is generated based on the |alpha| component of the
-fragment shader output value of the {{GPURenderPipelineDescriptor/fragment}}.{{GPUFragmentState/outputTargets}}[0].
+fragment shader output value of the {{GPURenderPipelineDescriptor/fragment}}.{{GPUFragmentState/targets}}[0].
 
 The algorithm of producing the extra mask is platform-dependent and can vary for different pixels.
 It guarantees that:
@@ -4076,7 +4076,7 @@ dictionary GPUMultisampleState {
 
 <script type=idl>
 dictionary GPUFragmentState: GPUProgrammableStage {
-    required sequence<GPUColorTargetState> outputTargets;
+    required sequence<GPUColorTargetState> targets;
 };
 </script>
 
@@ -4084,8 +4084,8 @@ dictionary GPUFragmentState: GPUProgrammableStage {
     <dfn abstract-op>validating GPUFragmentState</dfn>(|descriptor|)
         Return `true` if all of the following conditions are satisfied:
 
-            - |descriptor|.{{GPUFragmentState/outputTargets}}.length is less than or equal to 4.
-            - For each |colorState| layout descriptor in the list |descriptor|.{{GPUFragmentState/outputTargets}}:
+            - |descriptor|.{{GPUFragmentState/targets}}.length is less than or equal to 4.
+            - For each |colorState| layout descriptor in the list |descriptor|.{{GPUFragmentState/targets}}:
                 - |colorState|.{{GPUColorTargetState/format}} is listed in {#plain-color-formats}
                     with {{GPUTextureUsage/RENDER_ATTACHMENT}} capability.
                 - |colorState|.{{GPUColorTargetState/blend}} is either `undefined`,
@@ -4336,7 +4336,7 @@ enum GPUInputStepMode {
 
 <script type=idl>
 dictionary GPUVertexState: GPUProgrammableStage {
-    sequence<GPUVertexBufferLayout?> inputBuffers = [];
+    sequence<GPUVertexBufferLayout?> buffers = [];
 };
 </script>
 
@@ -4408,16 +4408,16 @@ dictionary GPUVertexAttribute {
 
     Return `true`, if and only if, all of the following conditions are satisfied:
 
-        - |descriptor|.{{GPUVertexState/inputBuffers}}.length is less than or equal to
+        - |descriptor|.{{GPUVertexState/buffers}}.length is less than or equal to
             |device|.{{GPUDevice/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBuffers}}.
-        - Each |vertexBuffer| layout descriptor in the list |descriptor|.{{GPUVertexState/inputBuffers}}
+        - Each |vertexBuffer| layout descriptor in the list |descriptor|.{{GPUVertexState/buffers}}
             passes [$validating GPUVertexBufferLayout$](|device|, |vertexBuffer|, |descriptor|)
         - The sum of |vertexBuffer|.{{GPUVertexBufferLayout/attributes}}.length,
-            over every |vertexBuffer| in |descriptor|.{{GPUVertexState/inputBuffers}},
+            over every |vertexBuffer| in |descriptor|.{{GPUVertexState/buffers}},
             is less than or equal to
             |device|.{{GPUDevice/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexAttributes}}.
         - Each |attrib| in the union of all {{GPUVertexAttribute}}
-            across |descriptor|.{{GPUVertexState/inputBuffers}} has a distinct
+            across |descriptor|.{{GPUVertexState/buffers}} has a distinct
             |attrib|.{{GPUVertexAttribute/shaderLocation}} value.
 
         Issue: are the {{GPUVertexAttribute/shaderLocation}} arbitrary or should they be less than
@@ -6322,7 +6322,7 @@ enum GPUStoreOp {
 
             - Let |pipelineDescriptor| be |encoder|.{{GPURenderEncoderBase/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.
             - For each {{GPUIndex32}} |slot| `0` to
-                |pipelineDescriptor|.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/inputBuffers}}.length:
+                |pipelineDescriptor|.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}.length:
                 - |encoder|.{{GPURenderEncoderBase/[[vertex_buffers]]}}[|slot|] must not be `null`.
         </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1112,20 +1112,20 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
     <tr><td><dfn>maxVertexBuffers</dfn>
         <td>{{GPUSize32}} <td>Higher <td>8
     <tr class=row-continuation><td colspan=4>
-        The maximum number of {{GPUVertexStateDescriptor/vertexBuffers}}
+        The maximum number of {{GPUVertexState/inputBuffers}}
         when creating a {{GPURenderPipeline}}.
 
     <tr><td><dfn>maxVertexAttributes</dfn>
         <td>{{GPUSize32}} <td>Higher <td>16
     <tr class=row-continuation><td colspan=4>
-        The maximum number of {{GPUVertexBufferLayoutDescriptor/attributes}}
-        in total across {{GPUVertexStateDescriptor/vertexBuffers}}
+        The maximum number of {{GPUVertexBufferState/attributes}}
+        in total across {{GPUVertexState/inputBuffers}}
         when creating a {{GPURenderPipeline}}.
 
     <tr><td><dfn>maxVertexBufferArrayStride</dfn>
         <td>{{GPUSize32}} <td>Higher <td>2048
     <tr class=row-continuation><td colspan=4>
-        The maximum allowed {{GPUVertexBufferLayoutDescriptor/arrayStride}}
+        The maximum allowed {{GPUVertexBufferState/arrayStride}}
         when creating a {{GPURenderPipeline}}.
 </table>
 
@@ -3459,7 +3459,7 @@ has a default layout created and used instead.
 
         1. Set |groupDesc|.{{GPUBindGroupLayoutDescriptor/entries}} to an empty sequence.
 
-    1. For each {{GPUProgrammableStageDescriptor}} |stageDesc| in the descriptor used to create the pipeline:
+    1. For each {{GPUProgrammableStage}} |stageDesc| in the descriptor used to create the pipeline:
 
         1. Let |stageInfo| be the "reflection information" for |stageDesc|.
 
@@ -3467,8 +3467,8 @@ has a default layout created and used instead.
                 spec and get information what the interface is for a {{GPUShaderModule}} for a specific
                 entrypoint.
 
-        1. Let |shaderStage| be the {{GPUShaderStageFlags}} for |stageDesc|.{{GPUProgrammableStageDescriptor/entryPoint}}
-            in |stageDesc|.{{GPUProgrammableStageDescriptor/module}}.
+        1. Let |shaderStage| be the {{GPUShaderStageFlags}} for |stageDesc|.{{GPUProgrammableStage/entryPoint}}
+            in |stageDesc|.{{GPUProgrammableStage/module}}.
         1. For each resource |resource| in |stageInfo|'s resource interface:
 
             1. Let |group| be |resource|'s "group" decoration.
@@ -3567,30 +3567,30 @@ has a default layout created and used instead.
 
 </div>
 
-### <dfn dictionary>GPUProgrammableStageDescriptor</dfn> ### {#GPUProgrammableStageDescriptor}
+### <dfn dictionary>GPUProgrammableStage</dfn> ### {#GPUProgrammableStage}
 
 <script type=idl>
-dictionary GPUProgrammableStageDescriptor {
+dictionary GPUProgrammableStage {
     required GPUShaderModule module;
     required USVString entryPoint;
 };
 </script>
 
-A {{GPUProgrammableStageDescriptor}} describes the entry point in the user-provided
+A {{GPUProgrammableStage}} describes the entry point in the user-provided
 {{GPUShaderModule}} that controls one of the programmable stages of a [=pipeline=].
 
 <div algorithm>
-    <dfn abstract-op>validating GPUProgrammableStageDescriptor</dfn>(stage, descriptor, layout)
+    <dfn abstract-op>validating GPUProgrammableStage</dfn>(stage, descriptor, layout)
         **Arguments:**
             - {{GPUShaderStage}} |stage|
-            - {{GPUProgrammableStageDescriptor}} |descriptor|
+            - {{GPUProgrammableStage}} |descriptor|
             - {{GPUPipelineLayout}} |layout|
 
         Return `true` if all of the following conditions are satisfied:
 
-            - The |descriptor|.{{GPUProgrammableStageDescriptor/module}} is [=valid=] {{GPUShaderModule}}.
-            - The |descriptor|.{{GPUProgrammableStageDescriptor/module}} contains
-                an entry point at |stage| named |descriptor|.{{GPUProgrammableStageDescriptor/entryPoint}}.
+            - The |descriptor|.{{GPUProgrammableStage/module}} is [=valid=] {{GPUShaderModule}}.
+            - The |descriptor|.{{GPUProgrammableStage/module}} contains
+                an entry point at |stage| named |descriptor|.{{GPUProgrammableStage/entryPoint}}.
             - For each |binding| that is [=statically used=] by the shader entry point,
                 the [$validating shader binding$](|binding|, |layout|) returns `true`.
             - For each texture sampling shader call that is [=statically used=] by the entry point:
@@ -3704,7 +3704,7 @@ GPUComputePipeline includes GPUPipelineBase;
 
 <script type=idl>
 dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
-    required GPUProgrammableStageDescriptor computeStage;
+    required GPUProgrammableStage compute;
 };
 </script>
 
@@ -3727,8 +3727,8 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
                 <div class=validusage>
                     - |this| is a [=valid=] {{GPUDevice}}.
                     - |descriptor|.{{GPUPipelineDescriptorBase/layout}} is [$valid to use with$] |this|.
-                    - [$validating GPUProgrammableStageDescriptor$]({{GPUShaderStage/COMPUTE}},
-                        |descriptor|.{{GPUComputePipelineDescriptor/computeStage}},
+                    - [$validating GPUProgrammableStage$]({{GPUShaderStage/COMPUTE}},
+                        |descriptor|.{{GPUComputePipelineDescriptor/compute}},
                         |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
                 </div>
 
@@ -3778,25 +3778,25 @@ as well as {{GPURenderBundleEncoder}}.
 
 Render [=pipeline=] inputs are:
   - bindings, according to the given {{GPUPipelineLayout}}
-  - vertex and index buffers, described by {{GPUVertexStateDescriptor}}
-  - the color attachments, described by {{GPUColorStateDescriptor}}
-  - optionally, the depth-stencil attachment, described by {{GPUDepthStencilStateDescriptor}}
+  - vertex and index buffers, described by {{GPUVertexState}}
+  - the color attachments, described by {{GPUColorTargetState}}
+  - optionally, the depth-stencil attachment, described by {{GPUDepthStencilState}}
 
 Render [=pipeline=] outputs are:
   - {{GPUBindGroupLayoutEntry/buffer}} bindings with a {{GPUBufferBindingLayout/type}} of {{GPUBufferBindingType/"storage"}}
   - {{GPUBindGroupLayoutEntry/storageTexture}} bindings with a {{GPUStorageTextureBindingLayout/access}} of {{GPUStorageTextureAccess/"write-only"}}
-  - the color attachments, described by {{GPUColorStateDescriptor}}
-  - optionally, depth-stencil attachment, described by {{GPUDepthStencilStateDescriptor}}
+  - the color attachments, described by {{GPUColorTargetState}}
+  - optionally, depth-stencil attachment, described by {{GPUDepthStencilState}}
 
 Stages of a render [=pipeline=]:
-  1. Vertex fetch, controlled by {{GPUVertexStateDescriptor}}
-  2. Vertex shader
-  3. Primitive assembly, controlled by {{GPUPrimitiveTopology}}
-  4. Rasterization, controlled by {{GPURasterizationStateDescriptor}}
-  5. Fragment shader
-  6. Stencil test and operation, controlled by {{GPUDepthStencilStateDescriptor}}
-  7. Depth test and write, controlled by {{GPUDepthStencilStateDescriptor}}
-  8. Output merging, controlled by {{GPUColorStateDescriptor}}
+  1. Vertex fetch, controlled by {{GPUVertexState/inputBuffers|GPUVertexState.inputBuffers}}
+  2. Vertex shader, controlled by {{GPUVertexState}}
+  3. Primitive assembly, controlled by {{GPUPrimitiveState}}
+  4. Rasterization, controlled by {{GPUPrimitiveState}}, {{GPUDepthStencilState}}, and {{GPUMultisampleState}}
+  5. Fragment shader, controlled by {{GPUFragmentState}}
+  6. Stencil test and operation, controlled by {{GPUDepthStencilState}}
+  7. Depth test and write, controlled by {{GPUDepthStencilState}}
+  8. Output merging, controlled by {{GPUFragmentState/outputTargets|GPUFragmentState.outputs}}
 
 Issue: we need a deeper description of these stages
 
@@ -3827,49 +3827,29 @@ GPURenderPipeline includes GPUPipelineBase;
 
 <script type=idl>
 dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
-    required GPUProgrammableStageDescriptor vertexStage;
-    GPUProgrammableStageDescriptor fragmentStage;
-
-    required GPUPrimitiveTopology primitiveTopology;
-    GPURasterizationStateDescriptor rasterizationState = {};
-    required sequence<GPUColorStateDescriptor> colorStates;
-    GPUDepthStencilStateDescriptor depthStencilState;
-    GPUVertexStateDescriptor vertexState = {};
-
-    GPUSize32 sampleCount = 1;
-    GPUSampleMask sampleMask = 0xFFFFFFFF;
-    boolean alphaToCoverageEnabled = false;
+    required GPUVertexState vertex;
+    GPUPrimitiveState primitive = {};
+    GPUDepthStencilState depthStencil;
+    GPUMultisampleState multisample = {};
+    GPUFragmentState fragment;
 };
 </script>
 
-- {{GPURenderPipelineDescriptor/vertexStage}} describes
-    the vertex shader entry point of the [=pipeline=]
-- {{GPURenderPipelineDescriptor/fragmentStage}} describes
-    the fragment shader entry point of the [=pipeline=]. If it's `null`, the [[#no-color-output]] mode is enabled.
-- {{GPURenderPipelineDescriptor/primitiveTopology}} configures
-    the primitive assembly stage of the [=pipeline=].
-- {{GPURenderPipelineDescriptor/rasterizationState}} configures
-    the rasterization stage of the [=pipeline=].
-- {{GPURenderPipelineDescriptor/colorStates}} describes
-    the color attachments that are written by the [=pipeline=].
-- {{GPURenderPipelineDescriptor/depthStencilState}} describes
-    the optional depth-stencil attachment that is written by the [=pipeline=].
-- {{GPURenderPipelineDescriptor/vertexState}} configures
-    the vertex fetch stage of the [=pipeline=].
-- {{GPURenderPipelineDescriptor/sampleCount}} is
-    the number of MSAA samples that each attachment has to have.
-- {{GPURenderPipelineDescriptor/sampleMask}} is
-    a binary mask of MSAA samples, according to [[#sample-masking]].
-- {{GPURenderPipelineDescriptor/alphaToCoverageEnabled}} enables the [[#alpha-to-coverage]] mode.
-
-Issue(https://github.com/gpuweb/gpuweb/issues/936):
-Refactor the shape of the render pipeline descriptor to clearly enumerate the
-(ordered) list of pipeline stages. And start formalizing the spec text.
+- {{GPURenderPipelineDescriptor/vertex}} describes
+    the vertex shader entry point of the [=pipeline=] and its input buffer layouts.
+- {{GPURenderPipelineDescriptor/primitive}} describes the
+    the primitive-related properties of the [=pipeline=].
+- {{GPURenderPipelineDescriptor/depthStencil}} describes
+    the optional depth-stencil properties, including the testing, operations, and bias.
+- {{GPURenderPipelineDescriptor/multisample}} describes
+    the multi-sampling properties of the [=pipeline=].
+- {{GPURenderPipelineDescriptor/fragment}} describes
+    the fragment shader entry point of the [=pipeline=] and its output colors.
+    If it's `null`, the [[#no-color-output]] mode is enabled.
 
 ### No Color Output ### {#no-color-output}
 
-In no-color-output mode, [=pipeline=] does not produce any color attachment outputs,
-and the {{GPURenderPipelineDescriptor/colorStates}} is expected to be empty.
+In no-color-output mode, [=pipeline=] does not produce any color attachment outputs.
 
 The [=pipeline=] still performs rasterization and produces depth values
 based on the vertex position output. The depth testing and stencil operations can still be used.
@@ -3878,7 +3858,7 @@ based on the vertex position output. The depth testing and stencil operations ca
 
 In alpha-to-coverage mode, an additional <dfn dfn>alpha-to-coverage mask</dfn>
 of MSAA samples is generated based on the |alpha| component of the
-fragment shader output value of the {{GPURenderPipelineDescriptor/colorStates}}[0].
+fragment shader output value of the {{GPURenderPipelineDescriptor/fragment}}.{{GPUFragmentState/outputTargets}}[0].
 
 The algorithm of producing the extra mask is platform-dependent and can vary for different pixels.
 It guarantees that:
@@ -3890,9 +3870,9 @@ It guarantees that:
 ### Sample Masking ### {#sample-masking}
 
 The <dfn dfn>final sample mask</dfn> for a pixel is computed as:
-[=rasterization mask=] & {{GPURenderPipelineDescriptor/sampleMask}} & [=shader-output mask=].
+[=rasterization mask=] & {{GPUMultisampleState/mask}} & [=shader-output mask=].
 
-Only the lower {{GPURenderPipelineDescriptor/sampleCount}} bits of the mask are considered.
+Only the lower {{GPUMultisampleState/count}} bits of the mask are considered.
 
 If the least-significant bit at position |N| of the [=final sample mask=] has value of "0",
 the sample color outputs (corresponding to sample |N|) to all attachments of the fragment shader are discarded.
@@ -3907,7 +3887,7 @@ based on the shape of the rasterized polygon. The samples incuded in the shape g
 bits 1 in the mask.
 
 The <dfn dfn>shader-output mask</dfn> takes the output value of SV_Coverage semantics in the fragment shader.
-If the semantics is not [=statically used=] by the shader, and {{GPURenderPipelineDescriptor/alphaToCoverageEnabled}}
+If the semantics is not [=statically used=] by the shader, and {{GPUMultisampleState/alphaToCoverageEnabled}}
 is enabled, the [=shader-output mask=] becomes the [=alpha-to-coverage mask=]. Otherwise, it defaults to 0xFFFFFFFF.
 
 Issue: link to the semantics of SV_SampleIndex and SV_Coverage in WGSL spec.
@@ -3934,7 +3914,7 @@ Issue: link to the semantics of SV_SampleIndex and SV_Coverage in WGSL spec.
                         <div class=validusage>
                             - |this| is a [=valid=] {{GPUDevice}}.
                             - |descriptor|.{{GPUPipelineDescriptorBase/layout}} is [$valid to use with$] |this|.
-                            - [$validating GPURenderPipelineDescriptor$](|descriptor|, |this|.{{device/[[features]]}}) succeeds.
+                            - [$validating GPURenderPipelineDescriptor$](|descriptor|, |this|) succeeds.
                         </div>
 
                         Then:
@@ -3943,10 +3923,8 @@ Issue: link to the semantics of SV_SampleIndex and SV_Coverage in WGSL spec.
                             1. Make |pipeline| [=invalid=].
 
                     1. Set |pipeline|.{{GPURenderPipeline/[[descriptor]]}} to |descriptor|.
-                    1. If |descriptor|.{{GPURenderPipelineDescriptor/primitiveTopology}} is
-                        {{GPUPrimitiveTopology/"line-strip"}} or {{GPUPrimitiveTopology/"triangle-strip"}}:
-                        1. Set |pipeline|.{{GPURenderPipeline/[[strip_index_format]]}} to
-                            |descriptor|.{{GPURenderPipelineDescriptor/vertexState}}.{{GPUVertexStateDescriptor/indexFormat}}.
+                    1. Set |pipeline|.{{GPURenderPipeline/[[strip_index_format]]}} to
+                        |descriptor|.{{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/stripIndexFormat}}.
 
                 </div>
             1. Return |pipeline|.
@@ -3988,49 +3966,30 @@ Issue: link to the semantics of SV_SampleIndex and SV_Coverage in WGSL spec.
 </dl>
 
 <div algorithm>
-    <dfn abstract-op>validating GPURenderPipelineDescriptor</dfn>(descriptor, features)
+    <dfn abstract-op>validating GPURenderPipelineDescriptor</dfn>(descriptor, device)
         **Arguments:**
             - {{GPURenderPipelineDescriptor}} |descriptor|
-            - [=list=]&lt;{{GPUFeatureName}}&gt; |features|
+            - {{GPUDevice}} |device|
 
         Return `true` if all of the following conditions are satisfied:
 
-            - [$validating GPUProgrammableStageDescriptor$]({{GPUShaderStage/VERTEX}},
-                |descriptor|.{{GPURenderPipelineDescriptor/vertexStage}},
+            - [$validating GPUProgrammableStage$]({{GPUShaderStage/VERTEX}},
+                |descriptor|.{{GPURenderPipelineDescriptor/vertex}},
                 |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
-            - If |descriptor|.{{GPURenderPipelineDescriptor/fragmentStage}} is not `null`:
-                - [$validating GPUProgrammableStageDescriptor$]({{GPUShaderStage/FRAGMENT}},
-                    |descriptor|.{{GPURenderPipelineDescriptor/fragmentStage}},
+            - [$validating GPUVertexState$](|device|, |descriptor|.{{GPURenderPipelineDescriptor/vertex}},
+                |descriptor|.{{GPURenderPipelineDescriptor/vertex}}) succeeds.
+            - If |descriptor|.{{GPURenderPipelineDescriptor/fragment}} is not `null`:
+                - [$validating GPUProgrammableStage$]({{GPUShaderStage/FRAGMENT}},
+                    |descriptor|.{{GPURenderPipelineDescriptor/fragment}},
                     |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
-            - If |descriptor|.{{GPURenderPipelineDescriptor/fragmentStage}} is `null`:
-                - |descriptor|.{{GPURenderPipelineDescriptor/colorStates}} is empty.
-            - |descriptor|.{{GPURenderPipelineDescriptor/colorStates}}.length is less than
-                or equal to 4.
-            - For each |colorState| layout descriptor in the list
-                |descriptor|.{{GPURenderPipelineDescriptor/colorStates}}:
-                - [$validating GPUColorStateDescriptor$](|colorState|,
-                    |descriptor|.{{GPURenderPipelineDescriptor/fragmentStage}}) succeeds.
-            - [$validating GPURasterizationStateDescriptor$](|descriptor|.{{GPURenderPipelineDescriptor/rasterizationState}},
-                |features|) succeeds.
-            - if |descriptor|.{{GPURenderPipelineDescriptor/depthStencilState}} is not `null`:
-                - [$validating GPUDepthStencilStateDescriptor$](|descriptor|.{{GPURenderPipelineDescriptor/depthStencilState}}) succeeds.
-            - [$validating GPUVertexStateDescriptor$](|descriptor|.{{GPURenderPipelineDescriptor/vertexState}},
-                |descriptor|.{{GPURenderPipelineDescriptor/vertexStage}}) succeeds.
-            - If |descriptor|.{{GPURenderPipelineDescriptor/alphaToCoverageEnabled}} is `true`:
-                - |descriptor|.{{GPURenderPipelineDescriptor/sampleCount}} is greater than 1.
-            - If the output SV_Coverage semantics is [=statically used=] by
-                |descriptor|.{{GPURenderPipelineDescriptor/fragmentStage}}:
-                - |descriptor|.{{GPURenderPipelineDescriptor/alphaToCoverageEnabled}} is `false`.
-            - If |descriptor|.{{GPURenderPipelineDescriptor/primitiveTopology}} is:
-                <dl class="switch">
-                    : {{GPUPrimitiveTopology/"line-strip"}} or
-                        {{GPUPrimitiveTopology/"triangle-strip"}}
-                    :: |descriptor|.{{GPURenderPipelineDescriptor/vertexState}}.{{GPUVertexStateDescriptor/indexFormat}}
-                        is not `undefined`
-                    : Otherwise
-                    :: |descriptor|.{{GPURenderPipelineDescriptor/vertexState}}.{{GPUVertexStateDescriptor/indexFormat}}
-                        is `undefined`
-                </dl>
+                - [$validating GPUFragmentState$](|descriptor|.{{GPURenderPipelineDescriptor/fragment}}) succeeds.
+                - If the output SV_Coverage semantics is [=statically used=] by
+                    |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
+                    - |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/alphaToCoverageEnabled}} is `false`.
+            - [$validating GPUPrimitiveState$](|descriptor|.{{GPURenderPipelineDescriptor/primitive}}) succeeds.
+            - if |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}} is not `null`:
+                - [$validating GPUDepthStencilState$](|descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}, |device|.{{device/[[features]]}}) succeeds.
+            - [$validating GPUMultisampleState$](|descriptor|.{{GPURenderPipelineDescriptor/multisample}}) succeeds.
 </div>
 
 Issue: validate interface matching rules between VS and FS.
@@ -4041,7 +4000,7 @@ Issue: define what "compatible" means for render target formats.
 
 Issue: need a proper limit for the maximum number of color targets.
 
-### Primitive Topology ### {#primitive-topology}
+### Primitive State ### {#primitive-state}
 
 <script type=idl>
 enum GPUPrimitiveTopology {
@@ -4053,26 +4012,29 @@ enum GPUPrimitiveTopology {
 };
 </script>
 
-### Rasterization State ### {#rasterization-state}
-
 <script type=idl>
-dictionary GPURasterizationStateDescriptor {
+dictionary GPUPrimitiveState {
+    GPUPrimitiveTopology topology = "triangle-list";
+    GPUIndexFormat stripIndexFormat;
     GPUFrontFace frontFace = "ccw";
     GPUCullMode cullMode = "none";
-    // Enable depth clamping (requires "depth-clamping" feature)
-    boolean clampDepth = false;
-
-    GPUDepthBias depthBias = 0;
-    float depthBiasSlopeScale = 0;
-    float depthBiasClamp = 0;
 };
 </script>
 
 <div algorithm>
-    <dfn abstract-op>validating GPURasterizationStateDescriptor</dfn>(|descriptor|, |features|)
-        1. If |descriptor|.{{GPURasterizationStateDescriptor/clampDepth}} is `true` and |features|
-            doesn't [=list/contain=] {{GPUFeatureName/"depth-clamping"}}, return `false`.
-        1. Return `true`.
+    <dfn abstract-op>validating GPUPrimitiveState</dfn>(|descriptor|)
+        **Arguments:**
+            - {{GPUPrimitiveState}} |descriptor|
+
+        Return `true` if all of the following conditions are satisfied:
+            - If |descriptor|.{{GPUPrimitiveState/topology}} is:
+                <dl class="switch">
+                    : {{GPUPrimitiveTopology/"line-strip"}} or
+                        {{GPUPrimitiveTopology/"triangle-strip"}}
+                    :: |descriptor|.{{GPUPrimitiveState/stripIndexFormat}} is not `undefined`
+                    : Otherwise
+                    :: |descriptor|.{{GPUPrimitiveState/stripIndexFormat}} is `undefined`
+                </dl>
 </div>
 
 <script type=idl>
@@ -4090,10 +4052,57 @@ enum GPUCullMode {
 };
 </script>
 
-### Color State ### {#color-state}
+### Multisample State ### {#multisample-state}
 
 <script type=idl>
-dictionary GPUColorStateDescriptor {
+dictionary GPUMultisampleState {
+    GPUSize32 count = 1;
+    GPUSampleMask mask = 0xFFFFFFFF;
+    boolean alphaToCoverageEnabled = false;
+};
+</script>
+
+<div algorithm>
+    <dfn abstract-op>validating GPUMultisampleState</dfn>(|descriptor|)
+        **Arguments:**
+            - {{GPUMultisampleState}} |descriptor|
+
+        Return `true` if all of the following conditions are satisfied:
+            - If |descriptor|.{{GPUMultisampleState/alphaToCoverageEnabled}} is `true`:
+                - |descriptor|.{{GPUMultisampleState/count}} is greater than 1.
+</div>
+
+### Fragment State ### {#fragment-state}
+
+<script type=idl>
+dictionary GPUFragmentState: GPUProgrammableStage {
+    required sequence<GPUColorTargetState> outputTargets;
+};
+</script>
+
+<div algorithm>
+    <dfn abstract-op>validating GPUFragmentState</dfn>(|descriptor|)
+        Return `true` if all of the following conditions are satisfied:
+
+            - |descriptor|.{{GPUFragmentState/outputTargets}}.length is less than or equal to 4.
+            - For each |colorState| layout descriptor in the list |descriptor|.{{GPUFragmentState/outputTargets}}:
+                - |colorState|.{{GPUColorTargetState/format}} is listed in {#plain-color-formats}
+                    with {{GPUTextureUsage/RENDER_ATTACHMENT}} capability.
+                - |colorState|.{{GPUColorTargetState/blend}} is either `undefined`,
+                    or the |colorState|.{{GPUColorTargetState/format}} is filterable
+                    according to the {#plain-color-formats} table.
+                - |colorState|.{{GPUColorTargetState/writeMask}} is less than 16.
+                - |descriptor|.{{GPUProgrammableStage/module}} contains an output variable
+                    that is [=statically used=] by |descriptor|.{{GPUProgrammableStage/entryPoint}},
+                    and has a type that is compatible with |colorState|.{{GPUColorTargetState/format}}.
+</div>
+
+Issue: define the area of reach for "statically used" things of `GPUProgrammableStage`
+
+### Color Target State ### {#color-target-state}
+
+<script type=idl>
+dictionary GPUColorTargetState {
     required GPUTextureFormat format;
 
     GPUBlendDescriptor blend;
@@ -4157,28 +4166,10 @@ enum GPUBlendOperation {
 };
 </script>
 
-<div algorithm>
-    <dfn abstract-op>validating GPUColorStateDescriptor</dfn>(descriptor, fragmentStage)
-    **Arguments:**
-        - {{GPUColorStateDescriptor}} |descriptor|
-        - {{GPUProgrammableStageDescriptor}} |fragmentStage|
-
-    Return `true`, if and only if, all of the following conditions are satisfied:
-
-        - |descriptor|.{{GPUColorStateDescriptor/format}} is listed in {#plain-color-formats}
-            with {{GPUTextureUsage/RENDER_ATTACHMENT}} capability.
-        - |descriptor|.{{GPUColorStateDescriptor/blend}} is either `undefined`,
-            or the |descriptor|.{{GPUColorStateDescriptor/format}} is filterable
-            according to the {#plain-color-formats} table.
-        - |descriptor|.{{GPUColorStateDescriptor/writeMask}} is less than 16.
-        - |fragmentStage| contains an output variable with a type that is compatible with
-            |descriptor|.{{GPUColorStateDescriptor/format}}.
-</div>
-
 ### Depth/Stencil State ### {#depth-stencil-state}
 
 <script type=idl>
-dictionary GPUDepthStencilStateDescriptor {
+dictionary GPUDepthStencilState {
     required GPUTextureFormat format;
 
     boolean depthWriteEnabled = false;
@@ -4189,6 +4180,13 @@ dictionary GPUDepthStencilStateDescriptor {
 
     GPUStencilValue stencilReadMask = 0xFFFFFFFF;
     GPUStencilValue stencilWriteMask = 0xFFFFFFFF;
+
+    GPUDepthBias depthBias = 0;
+    float depthBiasSlopeScale = 0;
+    float depthBiasClamp = 0;
+
+    // Enable depth clamping (requires "depth-clamping" feature)
+    boolean clampDepth = false;
 };
 </script>
 
@@ -4215,19 +4213,22 @@ enum GPUStencilOperation {
 </script>
 
 <div algorithm>
-    <dfn abstract-op>validating GPUDepthStencilStateDescriptor</dfn>(descriptor)
+    <dfn abstract-op>validating GPUDepthStencilState</dfn>(descriptor, features)
     **Arguments:**
-        - {{GPUDepthStencilStateDescriptor}} |descriptor|
+        - {{GPUDepthStencilState}} |descriptor|
+        - [=list=]&lt;{{GPUFeatureName}}&gt; |features|
 
     Return `true`, if and only if, all of the following conditions are satisfied:
 
-        - |descriptor|.{{GPUDepthStencilStateDescriptor/format}} is listed in {#depth-formats}.
-        - if |descriptor|.{{GPUDepthStencilStateDescriptor/depthWriteEnabled}} is `true` or
-            |descriptor|.{{GPUDepthStencilStateDescriptor/depthCompare}} is not {{GPUCompareFunction/"always"}}:
-            - |descriptor|.{{GPUDepthStencilStateDescriptor/format}} must have a depth component.
-        - if |descriptor|.{{GPUDepthStencilStateDescriptor/stencilFront}} or
-            |descriptor|.{{GPUDepthStencilStateDescriptor/stencilBack}} are not default values:
-            - |descriptor|.{{GPUDepthStencilStateDescriptor/format}} must have a stencil component.
+        - |descriptor|.{{GPUDepthStencilState/format}} is listed in {#depth-formats}.
+        - if |descriptor|.{{GPUDepthStencilState/depthWriteEnabled}} is `true` or
+            |descriptor|.{{GPUDepthStencilState/depthCompare}} is not {{GPUCompareFunction/"always"}}:
+            - |descriptor|.{{GPUDepthStencilState/format}} must have a depth component.
+        - if |descriptor|.{{GPUDepthStencilState/stencilFront}} or
+            |descriptor|.{{GPUDepthStencilState/stencilBack}} are not default values:
+            - |descriptor|.{{GPUDepthStencilState/format}} must have a stencil component.
+        - If |descriptor|.{{GPUDepthStencilState/clampDepth}} is `true`:
+            - |features| must [=list/contain=] {{GPUFeatureName/"depth-clamping"}}.
 
     Issue: how can this algorithm support depth/stencil formats that are added in extensions?
 </div>
@@ -4248,10 +4249,10 @@ strip primitive topologies ({{GPUPrimitiveTopology/"line-strip"}} or
 should be started rather than continuing to construct the triangle strip with the prior indexed
 vertices.
 
-{{GPURenderPipelineDescriptor}}s that specify a strip primitive topology must specify a
-{{GPUVertexStateDescriptor/indexFormat}} so that the [=primitive restart value=] that will be used
-is known at pipeline creation time. {{GPURenderPipelineDescriptor}}s that specify a list primitive
-topology must set {{GPUVertexStateDescriptor/indexFormat}} to `undefined`, and will use the index
+{{GPUPrimitiveState}}s that specify a strip primitive topology must specify a
+{{GPUPrimitiveState/stripIndexFormat}} so that the [=primitive restart value=] that will be used
+is known at pipeline creation time. {{GPUPrimitiveState}}s that specify a list primitive
+topology must set {{GPUPrimitiveState/stripIndexFormat}} to `undefined`, and will use the index
 format passed to {{GPURenderEncoderBase/setIndexBuffer()}} when rendering.
 
 <table class="data">
@@ -4334,35 +4335,34 @@ enum GPUInputStepMode {
 </script>
 
 <script type=idl>
-dictionary GPUVertexStateDescriptor {
-    GPUIndexFormat indexFormat;
-    sequence<GPUVertexBufferLayoutDescriptor?> vertexBuffers = [];
+dictionary GPUVertexState: GPUProgrammableStage {
+    sequence<GPUVertexBufferState?> inputBuffers = [];
 };
 </script>
 
 A <dfn dfn>vertex buffer</dfn> is, conceptually, a view into buffer memory as an *array of structures*.
-{{GPUVertexBufferLayoutDescriptor/arrayStride}} is the stride, in bytes, between *elements* of that array.
+{{GPUVertexBufferState/arrayStride}} is the stride, in bytes, between *elements* of that array.
 Each element of a vertex buffer is like a *structure* with a memory layout defined by its
-{{GPUVertexBufferLayoutDescriptor/attributes}}, which describe the *members* of the structure.
+{{GPUVertexBufferState/attributes}}, which describe the *members* of the structure.
 
-Each {{GPUVertexAttributeDescriptor}} describes its
-{{GPUVertexAttributeDescriptor/format}} and its
-{{GPUVertexAttributeDescriptor/offset}}, in bytes, within the structure.
+Each {{GPUVertexAttributeState}} describes its
+{{GPUVertexAttributeState/format}} and its
+{{GPUVertexAttributeState/offset}}, in bytes, within the structure.
 
 Each attribute appears as a separate input in a vertex shader, each bound by a numeric *location*,
-which is specified by {{GPUVertexAttributeDescriptor/shaderLocation}}.
-Every location must be unique within the {{GPUVertexStateDescriptor}}.
+which is specified by {{GPUVertexAttributeState/shaderLocation}}.
+Every location must be unique within the {{GPUVertexState}}.
 
 <script type=idl>
-dictionary GPUVertexBufferLayoutDescriptor {
+dictionary GPUVertexBufferState {
     required GPUSize64 arrayStride;
     GPUInputStepMode stepMode = "vertex";
-    required sequence<GPUVertexAttributeDescriptor> attributes;
+    required sequence<GPUVertexAttributeState> attributes;
 };
 </script>
 
 <script type=idl>
-dictionary GPUVertexAttributeDescriptor {
+dictionary GPUVertexAttributeState {
     required GPUVertexFormat format;
     required GPUSize64 offset;
 
@@ -4371,57 +4371,56 @@ dictionary GPUVertexAttributeDescriptor {
 </script>
 
 <div algorithm>
-    <dfn abstract-op>validating GPUVertexBufferLayoutDescriptor</dfn>(device, descriptor, vertexStage)
+    <dfn abstract-op>validating GPUVertexBufferState</dfn>(device, descriptor, vertexStage)
     **Arguments:**
         - {{GPUDevice}} |device|
-        - {{GPUVertexBufferLayoutDescriptor}} |descriptor|
-        - {{GPUProgrammableStageDescriptor}} |vertexStage|
+        - {{GPUVertexBufferState}} |descriptor|
+        - {{GPUProgrammableStage}} |vertexStage|
 
     Return `true`, if and only if, all of the following conditions are satisfied:
 
-        - |descriptor|.{{GPUVertexBufferLayoutDescriptor/arrayStride}} &le;
+        - |descriptor|.{{GPUVertexBufferState/arrayStride}} &le;
             |device|.{{GPUDevice/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBufferArrayStride}}.
-        - |descriptor|.{{GPUVertexBufferLayoutDescriptor/arrayStride}} is a multiple of 4.
-        - For each attribute |attrib| in the list |descriptor|.{{GPUVertexBufferLayoutDescriptor/attributes}}:
-            - If |descriptor|.{{GPUVertexBufferLayoutDescriptor/arrayStride}} is zero:
-                - |attrib|.{{GPUVertexAttributeDescriptor/offset}} + sizeof(|attrib|.{{GPUVertexAttributeDescriptor/format}}) &le;
+        - |descriptor|.{{GPUVertexBufferState/arrayStride}} is a multiple of 4.
+        - For each attribute |attrib| in the list |descriptor|.{{GPUVertexBufferState/attributes}}:
+            - If |descriptor|.{{GPUVertexBufferState/arrayStride}} is zero:
+                - |attrib|.{{GPUVertexAttributeState/offset}} + sizeof(|attrib|.{{GPUVertexAttributeState/format}}) &le;
                     |device|.{{GPUDevice/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBufferArrayStride}}.
 
                 Otherwise:
-                - |attrib|.{{GPUVertexAttributeDescriptor/offset}} + sizeof(|attrib|.{{GPUVertexAttributeDescriptor/format}}) &le;
-                    |descriptor|.{{GPUVertexBufferLayoutDescriptor/arrayStride}}.
-            - |attrib|.{{GPUVertexAttributeDescriptor/offset}} is a multiple of the size of one component of
-                |attrib|.{{GPUVertexAttributeDescriptor/format}}.
-        - For every vertex attribute in the shader reflection of |vertexStage|.{{GPUProgrammableStageDescriptor/module}}
-            that is know to be [=statically used=] by |vertexStage|.{{GPUProgrammableStageDescriptor/entryPoint}},
-            there is a corresponding |attrib| element of |descriptor|.{{GPUVertexBufferLayoutDescriptor/attributes}} for which
+                - |attrib|.{{GPUVertexAttributeState/offset}} + sizeof(|attrib|.{{GPUVertexAttributeState/format}}) &le;
+                    |descriptor|.{{GPUVertexBufferState/arrayStride}}.
+            - |attrib|.{{GPUVertexAttributeState/offset}} is a multiple of the size of one component of
+                |attrib|.{{GPUVertexAttributeState/format}}.
+        - For every vertex attribute in the shader reflection of |vertexStage|.{{GPUProgrammableStage/module}}
+            that is know to be [=statically used=] by |vertexStage|.{{GPUProgrammableStage/entryPoint}},
+            there is a corresponding |attrib| element of |descriptor|.{{GPUVertexBufferState/attributes}} for which
             all of the following are true:
-            - The shader format is |attrib|.{{GPUVertexAttributeDescriptor/format}}.
-            - The shader location is |attrib|.{{GPUVertexAttributeDescriptor/shaderLocation}}.
+            - The shader format is |attrib|.{{GPUVertexAttributeState/format}}.
+            - The shader location is |attrib|.{{GPUVertexAttributeState/shaderLocation}}.
 </div>
 
 <div algorithm>
-    <dfn abstract-op>validating GPUVertexStateDescriptor</dfn>(device, descriptor, vertexStage)
+    <dfn abstract-op>validating GPUVertexState</dfn>(device, descriptor)
     **Arguments:**
         - {{GPUDevice}} |device|
-        - {{GPUVertexStateDescriptor}} |descriptor|
-        - {{GPUProgrammableStageDescriptor}} |vertexStage|
+        - {{GPUVertexState}} |descriptor|
 
     Return `true`, if and only if, all of the following conditions are satisfied:
 
-        - |descriptor|.{{GPUVertexStateDescriptor/vertexBuffers}}.length is less than or equal to
+        - |descriptor|.{{GPUVertexState/inputBuffers}}.length is less than or equal to
             |device|.{{GPUDevice/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBuffers}}.
-        - Each |vertexBuffer| layout descriptor in the list |descriptor|.{{GPUVertexStateDescriptor/vertexBuffers}}
-            passes [$validating GPUVertexBufferLayoutDescriptor$](|device|, |vertexBuffer|, |vertexStage|)
-        - The sum of |vertexBuffer|.{{GPUVertexBufferLayoutDescriptor/attributes}}.length,
-            over every |vertexBuffer| in |descriptor|.{{GPUVertexStateDescriptor/vertexBuffers}},
+        - Each |vertexBuffer| layout descriptor in the list |descriptor|.{{GPUVertexState/inputBuffers}}
+            passes [$validating GPUVertexBufferState$](|device|, |vertexBuffer|, |descriptor|)
+        - The sum of |vertexBuffer|.{{GPUVertexBufferState/attributes}}.length,
+            over every |vertexBuffer| in |descriptor|.{{GPUVertexState/inputBuffers}},
             is less than or equal to
             |device|.{{GPUDevice/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexAttributes}}.
-        - Each |attrib| in the union of all {{GPUVertexAttributeDescriptor}}
-            across |descriptor|.{{GPUVertexStateDescriptor/vertexBuffers}} has a distinct
-            |attrib|.{{GPUVertexAttributeDescriptor/shaderLocation}} value.
+        - Each |attrib| in the union of all {{GPUVertexAttributeState}}
+            across |descriptor|.{{GPUVertexState/inputBuffers}} has a distinct
+            |attrib|.{{GPUVertexAttributeState/shaderLocation}} value.
 
-        Issue: are the {{GPUVertexAttributeDescriptor/shaderLocation}} arbitrary or should they be less than
+        Issue: are the {{GPUVertexAttributeState/shaderLocation}} arbitrary or should they be less than
         {{supported limits/maxVertexAttributes}}?
 </div>
 
@@ -6323,7 +6322,7 @@ enum GPUStoreOp {
 
             - Let |pipelineDescriptor| be |encoder|.{{GPURenderEncoderBase/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.
             - For each {{GPUIndex32}} |slot| `0` to
-                |pipelineDescriptor|.{{GPURenderPipelineDescriptor/vertexState}}.{{GPUVertexStateDescriptor/vertexBuffers}}.length:
+                |pipelineDescriptor|.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/inputBuffers}}.length:
                 - |encoder|.{{GPURenderEncoderBase/[[vertex_buffers]]}}[|slot|] must not be `null`.
         </div>
 
@@ -7356,9 +7355,9 @@ The following dictionary values are supported if and only if the {{GPUFeatureNam
 [=feature=] is enabled, otherwise they must be set to their default values:
 
 <dl>
-    : {{GPURasterizationStateDescriptor}}
+    : {{GPUDepthStencilState}}
     ::
-        * {{GPURasterizationStateDescriptor/clampDepth}}
+        * {{GPUDepthStencilState/clampDepth}}
 </dl>
 
 ## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>depth24unorm-stencil8</dfn> ## {#depth24unorm-stencil8}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -760,8 +760,8 @@ This combination of usages does not make a [=compatible usage list=].
 Note: race condition of multiple writable storage buffer/texture usages in a single [=usage scope=] is allowed.
 
 The [=subresources=] of textures included in the views provided to
-{{GPURenderPassColorAttachmentDescriptor/attachment|GPURenderPassColorAttachmentDescriptor.attachment}} and
-{{GPURenderPassColorAttachmentDescriptor/resolveTarget|GPURenderPassColorAttachmentDescriptor.resolveTarget}}
+{{GPURenderPassColorAttachment/view|GPURenderPassColorAttachment.view}} and
+{{GPURenderPassColorAttachment/resolveTarget|GPURenderPassColorAttachment.resolveTarget}}
 are considered to be used as [=internal usage/attachment=] for the [=usage scope=] of this render pass.
 
 The <dfn dfn>physical size</dfn> of a [=texture subresource=] is the dimension of the
@@ -4105,13 +4105,13 @@ Issue: define the area of reach for "statically used" things of `GPUProgrammable
 dictionary GPUColorTargetState {
     required GPUTextureFormat format;
 
-    GPUBlendDescriptor blend;
+    GPUBlendState blend;
     GPUColorWriteFlags writeMask = 0xF;  // GPUColorWrite.ALL
 };
 </script>
 
 <script type=idl>
-dictionary GPUBlendDescriptor {
+dictionary GPUBlendState {
     required GPUBlendComponent color;
     required GPUBlendComponent alpha;
 };
@@ -4175,8 +4175,8 @@ dictionary GPUDepthStencilState {
     boolean depthWriteEnabled = false;
     GPUCompareFunction depthCompare = "always";
 
-    GPUStencilStateFaceDescriptor stencilFront = {};
-    GPUStencilStateFaceDescriptor stencilBack = {};
+    GPUStencilFaceState stencilFront = {};
+    GPUStencilFaceState stencilBack = {};
 
     GPUStencilValue stencilReadMask = 0xFFFFFFFF;
     GPUStencilValue stencilWriteMask = 0xFFFFFFFF;
@@ -4191,7 +4191,7 @@ dictionary GPUDepthStencilState {
 </script>
 
 <script type=idl>
-dictionary GPUStencilStateFaceDescriptor {
+dictionary GPUStencilFaceState {
     GPUCompareFunction compare = "always";
     GPUStencilOperation failOp = "keep";
     GPUStencilOperation depthFailOp = "keep";
@@ -4646,16 +4646,16 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                     </div>
                 1. Set |this|.{{GPUCommandEncoder/[[state]]}} to {{encoder state/encoding a render pass}}.
                 1. For each |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
-                    1. The [=texture subresource=] seen by |colorAttachment|.{{GPURenderPassColorAttachmentDescriptor/attachment}}
+                    1. The [=texture subresource=] seen by |colorAttachment|.{{GPURenderPassColorAttachment/view}}
                         is considered to be used as [=internal usage/attachment=] for the
                         duration of the render pass.
                 1. Let |depthStencilAttachment| be |descriptor|.{{GPURenderPassDescriptor/depthStencilAttachment}}.
                 1. If |depthStencilAttachment| is not `null`:
-                    1. if |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachmentDescriptor/depthReadOnly}} and
-                        {{GPURenderPassDepthStencilAttachmentDescriptor/stencilReadOnly}} are set
-                        1. The [=texture subresources=] seen by |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}
+                    1. if |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} and
+                        {{GPURenderPassDepthStencilAttachment/stencilReadOnly}} are set
+                        1. The [=texture subresources=] seen by |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/view}}
                             are considered to be used as [=internal usage/attachment-read=] for the duration of the render pass.
-                    1. Else, the [=texture subresource=] seen by |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}
+                    1. Else, the [=texture subresource=] seen by |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/view}}
                         is considered to be used as [=internal usage/attachment=] for the duration of the render pass.
             </div>
 
@@ -5864,8 +5864,8 @@ When a {{GPURenderPassEncoder}} is created, it has the following default state:
 
 <script type=idl>
 dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
-    required sequence<GPURenderPassColorAttachmentDescriptor> colorAttachments;
-    GPURenderPassDepthStencilAttachmentDescriptor depthStencilAttachment;
+    required sequence<GPURenderPassColorAttachment> colorAttachments;
+    GPURenderPassDepthStencilAttachment depthStencilAttachment;
     GPUQuerySet occlusionQuerySet;
 };
 </script>
@@ -5873,12 +5873,12 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
 <dl dfn-type=dict-member dfn-for=GPURenderPassDescriptor>
     : <dfn>colorAttachments</dfn>
     ::
-        The set of {{GPURenderPassColorAttachmentDescriptor}} values in this sequence defines which
+        The set of {{GPURenderPassColorAttachment}} values in this sequence defines which
         color attachments will be output to when executing this render pass.
 
     : <dfn>depthStencilAttachment</dfn>
     ::
-        The {{GPURenderPassDepthStencilAttachmentDescriptor}} value that defines the depth/stencil
+        The {{GPURenderPassDepthStencilAttachment}} value that defines the depth/stencil
         attachment that will be output to and tested against when executing this render pass.
 
     : <dfn>occlusionQuerySet</dfn>
@@ -5897,18 +5897,18 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
         |this|.{{GPURenderPassDescriptor/depthStencilAttachment}} must not be `null`.
     1. For each |colorAttachment| in |this|.{{GPURenderPassDescriptor/colorAttachments}}:
 
-        1. |colorAttachment| must meet the [$GPURenderPassColorAttachmentDescriptor/GPURenderPassColorAttachmentDescriptor Valid Usage$] rules.
+        1. |colorAttachment| must meet the [$GPURenderPassColorAttachment/GPURenderPassColorAttachment Valid Usage$] rules.
 
     1. If |this|.{{GPURenderPassDescriptor/depthStencilAttachment}} is not `null`:
 
-        1. |this|.{{GPURenderPassDescriptor/depthStencilAttachment}} must meet the [$GPURenderPassDepthStencilAttachmentDescriptor/GPURenderPassDepthStencilAttachmentDescriptor Valid Usage$] rules.
+        1. |this|.{{GPURenderPassDescriptor/depthStencilAttachment}} must meet the [$GPURenderPassDepthStencilAttachment/GPURenderPassDepthStencilAttachment Valid Usage$] rules.
 
-    1. Each {{GPURenderPassColorAttachmentDescriptor/attachment}} in |this|.{{GPURenderPassDescriptor/colorAttachments}}
-        and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}},
+    1. Each {{GPURenderPassColorAttachment/view}} in |this|.{{GPURenderPassDescriptor/colorAttachments}}
+        and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachment/view}},
         if present, must have all have the same {{GPUTexture/[[sampleCount]]}}.
 
-    1. The dimensions of the [=subresource=]s seen by each {{GPURenderPassColorAttachmentDescriptor/attachment}} in |this|.{{GPURenderPassDescriptor/colorAttachments}}
-        and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}},
+    1. The dimensions of the [=subresource=]s seen by each {{GPURenderPassColorAttachment/view}} in |this|.{{GPURenderPassDescriptor/colorAttachments}}
+        and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachment/view}},
         if present, must match.
 
     Issue: Define <dfn for=>maximum color attachments</dfn>
@@ -5919,8 +5919,8 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
 #### Color Attachments #### {#color-attachments}
 
 <script type=idl>
-dictionary GPURenderPassColorAttachmentDescriptor {
-    required GPUTextureView attachment;
+dictionary GPURenderPassColorAttachment {
+    required GPUTextureView view;
     GPUTextureView resolveTarget;
 
     required (GPULoadOp or GPUColor) loadValue;
@@ -5928,8 +5928,8 @@ dictionary GPURenderPassColorAttachmentDescriptor {
 };
 </script>
 
-<dl dfn-type=dict-member dfn-for=GPURenderPassColorAttachmentDescriptor>
-    : <dfn>attachment</dfn>
+<dl dfn-type=dict-member dfn-for=GPURenderPassColorAttachment>
+    : <dfn>view</dfn>
     ::
         A {{GPUTextureView}} describing the texture [=subresource=] that will be output to for this
         color attachment.
@@ -5937,44 +5937,44 @@ dictionary GPURenderPassColorAttachmentDescriptor {
     : <dfn>resolveTarget</dfn>
     ::
         A {{GPUTextureView}} describing the texture [=subresource=] that will receive the resolved
-        output for this color attachment if {{GPURenderPassColorAttachmentDescriptor/attachment}} is
+        output for this color attachment if {{GPURenderPassColorAttachment/view}} is
         multisampled.
 
     : <dfn>loadValue</dfn>
     ::
         If a {{GPULoadOp}}, indicates the load operation to perform on
-        {{GPURenderPassColorAttachmentDescriptor/attachment}} prior to executing the render pass.
-        If a {{GPUColor}}, indicates the value to clear {{GPURenderPassColorAttachmentDescriptor/attachment}}
+        {{GPURenderPassColorAttachment/view}} prior to executing the render pass.
+        If a {{GPUColor}}, indicates the value to clear {{GPURenderPassColorAttachment/view}}
         to prior to executing the render pass.
 
     : <dfn>storeOp</dfn>
     ::
-        The store operation to perform on {{GPURenderPassColorAttachmentDescriptor/attachment}}
+        The store operation to perform on {{GPURenderPassColorAttachment/view}}
         after executing the render pass.
 </dl>
 
-<div class=validusage dfn-for=GPURenderPassColorAttachmentDescriptor>
-    <dfn abstract-op>GPURenderPassColorAttachmentDescriptor Valid Usage</dfn>
+<div class=validusage dfn-for=GPURenderPassColorAttachment>
+    <dfn abstract-op>GPURenderPassColorAttachment Valid Usage</dfn>
 
-    Given a {{GPURenderPassColorAttachmentDescriptor}} |this| the following validation rules
+    Given a {{GPURenderPassColorAttachment}} |this| the following validation rules
     apply:
 
-    1. |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}} must have a renderable color format.
-    1. |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[textureUsage]]}}
+    1. |this|.{{GPURenderPassColorAttachment/view}} must have a renderable color format.
+    1. |this|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[textureUsage]]}}
         must contain {{GPUTextureUsage/RENDER_ATTACHMENT}}.
-    1. |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}} must be a view of a single [=subresource=].
-    1. If |this|.{{GPURenderPassColorAttachmentDescriptor/resolveTarget}} is not `null`:
+    1. |this|.{{GPURenderPassColorAttachment/view}} must be a view of a single [=subresource=].
+    1. If |this|.{{GPURenderPassColorAttachment/resolveTarget}} is not `null`:
 
-        1. |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}} must be multisampled.
-        1. |this|.{{GPURenderPassColorAttachmentDescriptor/resolveTarget}} must not be multisampled.
-        1. |this|.{{GPURenderPassColorAttachmentDescriptor/resolveTarget}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[textureUsage]]}}
+        1. |this|.{{GPURenderPassColorAttachment/view}} must be multisampled.
+        1. |this|.{{GPURenderPassColorAttachment/resolveTarget}} must not be multisampled.
+        1. |this|.{{GPURenderPassColorAttachment/resolveTarget}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[textureUsage]]}}
             must contain {{GPUTextureUsage/RENDER_ATTACHMENT}}.
-        1. |this|.{{GPURenderPassColorAttachmentDescriptor/resolveTarget}} must be a view of a single [=subresource=].
+        1. |this|.{{GPURenderPassColorAttachment/resolveTarget}} must be a view of a single [=subresource=].
 
-        1. The dimensions of the [=subresource=]s seen by |this|.{{GPURenderPassColorAttachmentDescriptor/resolveTarget}}
-            and |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}} must match.
-        1. |this|.{{GPURenderPassColorAttachmentDescriptor/resolveTarget}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[format]]}}
-            must match |this|.{{GPURenderPassColorAttachmentDescriptor/attachment}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[format]]}}.
+        1. The dimensions of the [=subresource=]s seen by |this|.{{GPURenderPassColorAttachment/resolveTarget}}
+            and |this|.{{GPURenderPassColorAttachment/view}} must match.
+        1. |this|.{{GPURenderPassColorAttachment/resolveTarget}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[format]]}}
+            must match |this|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[format]]}}.
         1. Issue: Describe any remaining resolveTarget validation
 
     Issue: Describe the remaining validation rules for this type.
@@ -5983,8 +5983,8 @@ dictionary GPURenderPassColorAttachmentDescriptor {
 #### Depth/Stencil Attachments #### {#depth-stencil-attachments}
 
 <script type=idl>
-dictionary GPURenderPassDepthStencilAttachmentDescriptor {
-    required GPUTextureView attachment;
+dictionary GPURenderPassDepthStencilAttachment {
+    required GPUTextureView view;
 
     required (GPULoadOp or float) depthLoadValue;
     required GPUStoreOp depthStoreOp;
@@ -5996,8 +5996,8 @@ dictionary GPURenderPassDepthStencilAttachmentDescriptor {
 };
 </script>
 
-<dl dfn-type=dict-member dfn-for=GPURenderPassDepthStencilAttachmentDescriptor>
-    : <dfn>attachment</dfn>
+<dl dfn-type=dict-member dfn-for=GPURenderPassDepthStencilAttachment>
+    : <dfn>view</dfn>
     ::
         A {{GPUTextureView}} describing the texture [=subresource=] that will be output to
         and read from for this depth/stencil attachment.
@@ -6005,60 +6005,60 @@ dictionary GPURenderPassDepthStencilAttachmentDescriptor {
     : <dfn>depthLoadValue</dfn>
     ::
         If a {{GPULoadOp}}, indicates the load operation to perform on
-        {{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}'s depth component prior to
+        {{GPURenderPassDepthStencilAttachment/view}}'s depth component prior to
         executing the render pass.
-        If a `float`, indicates the value to clear {{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}'s
+        If a `float`, indicates the value to clear {{GPURenderPassDepthStencilAttachment/view}}'s
         depth component to prior to executing the render pass.
 
     : <dfn>depthStoreOp</dfn>
     ::
-        The store operation to perform on {{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}'s
+        The store operation to perform on {{GPURenderPassDepthStencilAttachment/view}}'s
         depth component after executing the render pass.
 
     : <dfn>depthReadOnly</dfn>
     ::
-        Indicates that the depth component of {{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}
+        Indicates that the depth component of {{GPURenderPassDepthStencilAttachment/view}}
         is read only.
 
     : <dfn>stencilLoadValue</dfn>
     ::
         If a {{GPULoadOp}}, indicates the load operation to perform on
-        {{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}'s stencil component prior to
+        {{GPURenderPassDepthStencilAttachment/view}}'s stencil component prior to
         executing the render pass.
         If a {{GPUStencilValue}}, indicates the value to clear
-        {{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}'s stencil component to prior to
+        {{GPURenderPassDepthStencilAttachment/view}}'s stencil component to prior to
         executing the render pass.
 
     : <dfn>stencilStoreOp</dfn>
     ::
-        The store operation to perform on {{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}'s
+        The store operation to perform on {{GPURenderPassDepthStencilAttachment/view}}'s
         stencil component after executing the render pass.
 
     : <dfn>stencilReadOnly</dfn>
     ::
-        Indicates that the stencil component of {{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}
+        Indicates that the stencil component of {{GPURenderPassDepthStencilAttachment/view}}
         is read only.
 </dl>
 
-<div class=validusage dfn-for=GPURenderPassDepthStencilAttachmentDescriptor>
-    <dfn abstract-op>GPURenderPassDepthStencilAttachmentDescriptor Valid Usage</dfn>
+<div class=validusage dfn-for=GPURenderPassDepthStencilAttachment>
+    <dfn abstract-op>GPURenderPassDepthStencilAttachment Valid Usage</dfn>
 
-    Given a {{GPURenderPassDepthStencilAttachmentDescriptor}} |this| the following validation
+    Given a {{GPURenderPassDepthStencilAttachment}} |this| the following validation
     rules apply:
 
-    1. |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}} must have a renderable
+    1. |this|.{{GPURenderPassDepthStencilAttachment/view}} must have a renderable
         depth-and/or-stencil format.
-    1. |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}} must be a view of a
+    1. |this|.{{GPURenderPassDepthStencilAttachment/view}} must be a view of a
         single [=texture subresource=].
-    1. |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/attachment}}.{{GPUTexture/[[textureUsage]]}}
+    1. |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTexture/[[textureUsage]]}}
         must contain {{GPUTextureUsage/RENDER_ATTACHMENT}}.
-    1. |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/depthReadOnly}} is `true`,
-        |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/depthLoadValue}} must be
-        {{GPULoadOp/"load"}} and |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/depthStoreOp}}
+    1. |this|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} is `true`,
+        |this|.{{GPURenderPassDepthStencilAttachment/depthLoadValue}} must be
+        {{GPULoadOp/"load"}} and |this|.{{GPURenderPassDepthStencilAttachment/depthStoreOp}}
         must be {{GPUStoreOp/"store"}}.
-    1. |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/stencilReadOnly}} is `true`,
-        |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/stencilLoadValue}} must be
-        {{GPULoadOp/"load"}} and |this|.{{GPURenderPassDepthStencilAttachmentDescriptor/stencilStoreOp}}
+    1. |this|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}} is `true`,
+        |this|.{{GPURenderPassDepthStencilAttachment/stencilLoadValue}} must be
+        {{GPULoadOp/"load"}} and |this|.{{GPURenderPassDepthStencilAttachment/stencilStoreOp}}
         must be {{GPUStoreOp/"store"}}.
 
     Issue: Describe the remaining validation rules for this type.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1118,14 +1118,14 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
     <tr><td><dfn>maxVertexAttributes</dfn>
         <td>{{GPUSize32}} <td>Higher <td>16
     <tr class=row-continuation><td colspan=4>
-        The maximum number of {{GPUVertexBufferState/attributes}}
+        The maximum number of {{GPUVertexBufferLayout/attributes}}
         in total across {{GPUVertexState/inputBuffers}}
         when creating a {{GPURenderPipeline}}.
 
     <tr><td><dfn>maxVertexBufferArrayStride</dfn>
         <td>{{GPUSize32}} <td>Higher <td>2048
     <tr class=row-continuation><td colspan=4>
-        The maximum allowed {{GPUVertexBufferState/arrayStride}}
+        The maximum allowed {{GPUVertexBufferLayout/arrayStride}}
         when creating a {{GPURenderPipeline}}.
 </table>
 
@@ -4336,33 +4336,33 @@ enum GPUInputStepMode {
 
 <script type=idl>
 dictionary GPUVertexState: GPUProgrammableStage {
-    sequence<GPUVertexBufferState?> inputBuffers = [];
+    sequence<GPUVertexBufferLayout?> inputBuffers = [];
 };
 </script>
 
 A <dfn dfn>vertex buffer</dfn> is, conceptually, a view into buffer memory as an *array of structures*.
-{{GPUVertexBufferState/arrayStride}} is the stride, in bytes, between *elements* of that array.
+{{GPUVertexBufferLayout/arrayStride}} is the stride, in bytes, between *elements* of that array.
 Each element of a vertex buffer is like a *structure* with a memory layout defined by its
-{{GPUVertexBufferState/attributes}}, which describe the *members* of the structure.
+{{GPUVertexBufferLayout/attributes}}, which describe the *members* of the structure.
 
-Each {{GPUVertexAttributeState}} describes its
-{{GPUVertexAttributeState/format}} and its
-{{GPUVertexAttributeState/offset}}, in bytes, within the structure.
+Each {{GPUVertexAttribute}} describes its
+{{GPUVertexAttribute/format}} and its
+{{GPUVertexAttribute/offset}}, in bytes, within the structure.
 
 Each attribute appears as a separate input in a vertex shader, each bound by a numeric *location*,
-which is specified by {{GPUVertexAttributeState/shaderLocation}}.
+which is specified by {{GPUVertexAttribute/shaderLocation}}.
 Every location must be unique within the {{GPUVertexState}}.
 
 <script type=idl>
-dictionary GPUVertexBufferState {
+dictionary GPUVertexBufferLayout {
     required GPUSize64 arrayStride;
     GPUInputStepMode stepMode = "vertex";
-    required sequence<GPUVertexAttributeState> attributes;
+    required sequence<GPUVertexAttribute> attributes;
 };
 </script>
 
 <script type=idl>
-dictionary GPUVertexAttributeState {
+dictionary GPUVertexAttribute {
     required GPUVertexFormat format;
     required GPUSize64 offset;
 
@@ -4371,33 +4371,33 @@ dictionary GPUVertexAttributeState {
 </script>
 
 <div algorithm>
-    <dfn abstract-op>validating GPUVertexBufferState</dfn>(device, descriptor, vertexStage)
+    <dfn abstract-op>validating GPUVertexBufferLayout</dfn>(device, descriptor, vertexStage)
     **Arguments:**
         - {{GPUDevice}} |device|
-        - {{GPUVertexBufferState}} |descriptor|
+        - {{GPUVertexBufferLayout}} |descriptor|
         - {{GPUProgrammableStage}} |vertexStage|
 
     Return `true`, if and only if, all of the following conditions are satisfied:
 
-        - |descriptor|.{{GPUVertexBufferState/arrayStride}} &le;
+        - |descriptor|.{{GPUVertexBufferLayout/arrayStride}} &le;
             |device|.{{GPUDevice/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBufferArrayStride}}.
-        - |descriptor|.{{GPUVertexBufferState/arrayStride}} is a multiple of 4.
-        - For each attribute |attrib| in the list |descriptor|.{{GPUVertexBufferState/attributes}}:
-            - If |descriptor|.{{GPUVertexBufferState/arrayStride}} is zero:
-                - |attrib|.{{GPUVertexAttributeState/offset}} + sizeof(|attrib|.{{GPUVertexAttributeState/format}}) &le;
+        - |descriptor|.{{GPUVertexBufferLayout/arrayStride}} is a multiple of 4.
+        - For each attribute |attrib| in the list |descriptor|.{{GPUVertexBufferLayout/attributes}}:
+            - If |descriptor|.{{GPUVertexBufferLayout/arrayStride}} is zero:
+                - |attrib|.{{GPUVertexAttribute/offset}} + sizeof(|attrib|.{{GPUVertexAttribute/format}}) &le;
                     |device|.{{GPUDevice/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBufferArrayStride}}.
 
                 Otherwise:
-                - |attrib|.{{GPUVertexAttributeState/offset}} + sizeof(|attrib|.{{GPUVertexAttributeState/format}}) &le;
-                    |descriptor|.{{GPUVertexBufferState/arrayStride}}.
-            - |attrib|.{{GPUVertexAttributeState/offset}} is a multiple of the size of one component of
-                |attrib|.{{GPUVertexAttributeState/format}}.
+                - |attrib|.{{GPUVertexAttribute/offset}} + sizeof(|attrib|.{{GPUVertexAttribute/format}}) &le;
+                    |descriptor|.{{GPUVertexBufferLayout/arrayStride}}.
+            - |attrib|.{{GPUVertexAttribute/offset}} is a multiple of the size of one component of
+                |attrib|.{{GPUVertexAttribute/format}}.
         - For every vertex attribute in the shader reflection of |vertexStage|.{{GPUProgrammableStage/module}}
             that is know to be [=statically used=] by |vertexStage|.{{GPUProgrammableStage/entryPoint}},
-            there is a corresponding |attrib| element of |descriptor|.{{GPUVertexBufferState/attributes}} for which
+            there is a corresponding |attrib| element of |descriptor|.{{GPUVertexBufferLayout/attributes}} for which
             all of the following are true:
-            - The shader format is |attrib|.{{GPUVertexAttributeState/format}}.
-            - The shader location is |attrib|.{{GPUVertexAttributeState/shaderLocation}}.
+            - The shader format is |attrib|.{{GPUVertexAttribute/format}}.
+            - The shader location is |attrib|.{{GPUVertexAttribute/shaderLocation}}.
 </div>
 
 <div algorithm>
@@ -4411,16 +4411,16 @@ dictionary GPUVertexAttributeState {
         - |descriptor|.{{GPUVertexState/inputBuffers}}.length is less than or equal to
             |device|.{{GPUDevice/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBuffers}}.
         - Each |vertexBuffer| layout descriptor in the list |descriptor|.{{GPUVertexState/inputBuffers}}
-            passes [$validating GPUVertexBufferState$](|device|, |vertexBuffer|, |descriptor|)
-        - The sum of |vertexBuffer|.{{GPUVertexBufferState/attributes}}.length,
+            passes [$validating GPUVertexBufferLayout$](|device|, |vertexBuffer|, |descriptor|)
+        - The sum of |vertexBuffer|.{{GPUVertexBufferLayout/attributes}}.length,
             over every |vertexBuffer| in |descriptor|.{{GPUVertexState/inputBuffers}},
             is less than or equal to
             |device|.{{GPUDevice/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexAttributes}}.
-        - Each |attrib| in the union of all {{GPUVertexAttributeState}}
+        - Each |attrib| in the union of all {{GPUVertexAttribute}}
             across |descriptor|.{{GPUVertexState/inputBuffers}} has a distinct
-            |attrib|.{{GPUVertexAttributeState/shaderLocation}} value.
+            |attrib|.{{GPUVertexAttribute/shaderLocation}} value.
 
-        Issue: are the {{GPUVertexAttributeState/shaderLocation}} arbitrary or should they be less than
+        Issue: are the {{GPUVertexAttribute/shaderLocation}} arbitrary or should they be less than
         {{supported limits/maxVertexAttributes}}?
 </div>
 


### PR DESCRIPTION
Groups the properties of a pipeline according to the aspects. Related things are kept together, even if they can affect multiple stages of a pipeline.

Closes #1307
Closes #936

I also want to re-order the sections of the pipeline, but this can be done as a follow-up in order to make this PR easier.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/1352.html" title="Last updated on Jan 21, 2021, 11:38 PM UTC (5a0b8d9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1352/a0d10e9...kvark:5a0b8d9.html" title="Last updated on Jan 21, 2021, 11:38 PM UTC (5a0b8d9)">Diff</a>