### PR TITLE
Replace [[block]] attribute by [[layout(...)]]

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -376,17 +376,21 @@ Issue: (dneto): Complete description of `Array<E,N>`
 <table class='data'>
   <caption>Structure attributes</caption>
   <thead>
-    <tr><th>Attribute<th>Description
+    <tr><th>Attribute<th>Valid values<th>Description
   </thead>
 
-  <tr><td><dfn noexport>`block`</dfn>
+  <tr><td><dfn noexport>`layout`</dfn>
+      <td>`general` or `stoage`
       <td>Applies to a structure type.<br>
          Indicates this structure type represents the contents of a
          buffer resource occupying a single binding slot in the
          [=resource interface of a shader|shader's resource interface=].
-         The `block` attribute must be applied to a structure type used
+         The `layout` attribute must be applied to a structure type used
          as the [=store type=] of a [=uniform buffer=] or [=storage buffer=] variable.
 </table>
+
+Issue: describe the exact rules for `general` and `storage` layouts.
+Issue: describe the requirement that `layout(storage)` can only be used for storage buffers.
 
 A structure type with the [=block=] attribute must not be:
 * the element type of an array type.
@@ -447,7 +451,7 @@ to define a [=uniform buffer=] or a [=storage buffer=]. See [[#memory-layouts]].
   <xmp>
     // Runtime Array
     type RTArr = [[stride(16)]] array<vec4<f32>>;
-    [[block]] struct S {
+    [[layout(storage)]] struct S {
       [[offset(0)]] a : f32;
       [[offset(4)]] b : f32;
       [[offset(16)]] data : RTArr;
@@ -1735,13 +1739,13 @@ Such variables are declared with [=group=] and [=binding=] decorations.
     var<private> decibels: f32;
     var<workgroup> worklist: array<i32,10>;
 
-    [[block]] struct Params {
+    [[layout(general)]] struct Params {
       [[offset(0)]] specular: f32;
       [[offset(4)]] count: i32;
     };
     var<uniform> param: Params;          // A uniform buffer
 
-    [[block]] struct PositionsBuffer {
+    [[layout(storage)]] struct PositionsBuffer {
       [[offset(0)]] pos: [[stride(8)]] array<vec2<f32>>;
     };
     [[group(0), binding(0)]]
@@ -4041,7 +4045,6 @@ I've written what an NVIDIA GPU does.  See https://github.com/google/amber/pull/
     <tr><td>Token<td>Definition
   </thead>
   <tr><td>`BITCAST`<td>bitcast
-  <tr><td>`BLOCK`<td>block
   <tr><td>`BREAK`<td>break
   <tr><td>`CASE`<td>case
   <tr><td>`CONST`<td>const


### PR DESCRIPTION
Fixes #621
Related to #1339

### Motivation

For the purposes of WebGPU V1 we are considering 2 layouts: one suitable for all the buffers, and one for storage buffers only (better packed). We have the developers computing the layouts in their heads and putting up the numbers into WGSL today as `[[offset(xx)]]` attributes on structure fields. The offset of a field depends on:
  - the offset of the previous field
  - the size of the previous field
  - and the alignment of the current field, which is based on what kind of buffers this structure is going to be used in (uniform/storage)

This is problematic for the following reasons. First, it's just tedious and mechanical. Computing the offsets should be a job for the machine, not a human. It's not a problem for SPIR-V since it's not written by humans, but it *is* a problem for us. Refactoring becomes painful: changing the type affects all following fields, reordering is hard, etc.

Secondly, it's not obvious, by looking at a structure, where it can be used. We have the `[[block]]` saying it is used in storage or uniform buffers, but we can't say whether it's valid to be used in a uniform structure.

I believe there is a solution that addresses both of these concerns, by renaming the `[[block]]` and adding an explicit layout to it. We can call them by proper names, i.e. std140 becomes the "general" layout, since it can be used for any host-shareable structures, and std430 becomes the "storage" layout.

The `[[offset]]` attribute can be removed if this PR lands.

Edit: here is a code example
```rust
[[layout(general)]]
struct Foo {
  x: u32,
  y: vec4<f32>,
};

[[group(0), binding(1)]]
var<uniform> fooBuf: Foo;

[[layout(storage)]]
struct Bar {
  foo: Foo,
  z: vec2<i32>,
};

[[group(0), binding(2)]]
var<storage> barBuf: Bar;
```

### Issues

(1) It becomes more difficult to match the CPU code layout with GPU code layout.
I believe this can be addressed with simple tooling. The famous shader playground could just annotate the fields online, for example. Moreover, the CPU side structures, at least in C++ and Rust, don't have explicit offsets either. So some manual computation or tooling is needed for this side anyway, before anything can be compared.

(2) The list of layouts can grow, with things like "relaxed" and "scalar" on the radar.
My understanding is that exposing those layout explicitly will make it more clear to the users. If they aren't spelled out, we'd still need the actual specification in WGSL about how the offsets or spans are restricted, based on the layout. So we are going to need to define it, and it becomes a question of whether the layout is explicit or implicit.

(3) No ability to force the large gaps between members
Users can do it manually with padding, and the use case is fairly small, so I don't think we should cater to this.