### PR TITLE
Fixup SPIR-V for float division.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2502,7 +2502,7 @@ TODO: Type rules for vector access
   <tr><td>*e1* : f32<br> *e2* : f32<td>`e1 * e2` : f32<td>Floating point multiplication (OpFMul)
   <tr><td>*e1* : u32<br> *e2* : u32<td>`e1 / e2` : u32<td>Unsigned integer division (OpUDiv)
   <tr><td>*e1* : i32<br> *e2* : i32<td>`e1 / e2` : i32<td>Signed integer division (OpSDiv)
-  <tr><td>*e1* : f32<br> *e2* : f32<td>`e1 / e2` : f32<td>Floating point division (OpFAdd)
+  <tr><td>*e1* : f32<br> *e2* : f32<td>`e1 / e2` : f32<td>Floating point division (OpFDiv)
   <tr><td>*e1* : u32<br> *e2* : u32<td>`e1 % e2` : u32<td>Unsigned integer modulus (OpUMod)
   <tr><td>*e1* : i32<br> *e2* : i32<td>`e1 % e2` : i32<td>Signed integer remainder, where sign of non-zero result matches sign of *e2* (OpSMod)
   <tr><td>*e1* : f32<br> *e2* : f32<td>`e1 % e2` : f32<td>Floating point modulus, where sign of non-zero result matches sign of *e2* (OpFMod)


### PR DESCRIPTION
This CL fixes the SPIR-V translation of float division.

Fixes #1365