### PR TITLE
Clarify: Structure members have names

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -361,13 +361,17 @@ Issue: (dneto): Complete description of `Array<E,N>`
   <thead>
     <tr><th>Type<th>Description
   </thead>
-  <tr><td>struct<*T1*,...,*Tn*><td>An ordered tuple of *N* members of types
-                                    *T1* through *Tn*, with *N* being an
-                                    integer greater than 0.
+  <tr algorithm="structure type">
+      <td>struct&lt;|T|<sub>1</sub>,...,|T|<sub>N</sub>&gt;
+      <td>An ordered tuple of *N* members of types
+          |T|<sub>n</sub> through |T|<sub>N</sub>, with |N| being an integer greater than 0.
+          A structure type declaration specifies an identifier name for each member.
+          Two members of the same structure type must not have the same name.
 </table>
 
 <div class='example wgsl global-scope' heading="Structure">
   <xmp highlight='rust'>
+    // A structure with two members.
     struct Data {
       a : i32;
       b : vec2<f32>;
@@ -682,7 +686,7 @@ The terms defined in this section express counts of 8-bit bytes.
 We will use the following notation:
 
 * |Stride|(|A|) is the value of the [=stride=] attribute of array type |A|.
-* |Offset|(|S|,|i|) is the value of the [=offset=] attribute of the |i|'th member of structure type |S|.
+* |Offset|(|S|,|i|) is the value of the [=offset=] attribute of the |i|'<sup>th</sup> member of structure type |S|.
 
 The remainder of this section is structured as follows:
 * Section [[#memory-layout-intent]] describes the intent of the layout rules.  It is not normative.
@@ -801,7 +805,7 @@ then:
 
 When a value of structure type |S| is placed at byte offset |k| of a host-shared memory buffer,
 then:
-   * The |i|'th member of the structure value is placed at byte offset |k| + |Offset|(|S|,|i|)
+   * The |i|'<sup>th</sup> member of the structure value is placed at byte offset |k| + |Offset|(|S|,|i|)
 
 #### Layout Constraints and Standard Buffer Layout #### {#layout-constraints}
 


### PR DESCRIPTION
Also, member identifier names must be unique within a structure.

Also, fix superscripting in some places.