### PR TITLE
Add type rules for composite value decomposition

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2441,13 +2441,187 @@ The result type depends on the number of letters provided. Assuming a `vec4<f32>
   </xmp>
 </div>
 
-TODO: Type rules for vector access
+#### Vector single component selection #### {#vector-single-component}
+
+<table class='data'>
+  <caption>Vector decomposition: single component selection</caption>
+  <thead>
+    <tr><th>Precondition<th>Conclusion<th>Description
+  </thead>
+  <tr algorithm="first vector component selection"><td>|e| : vec|N|&lt;|T|&gt;<br>
+       <td class="nowrap">
+           |e|`.x` : |T|<br>
+           |e|`.r` : |T|
+       <td>Select the first component of |e|<br>
+           (OpCompositeExtract with selection index 0)
+  <tr algorithm="second vector component selection"><td>|e| : vec|N|&lt;|T|&gt;<br>
+       <td class="nowrap">
+           |e|`.y` : |T|<br>
+           |e|`.g` : |T|
+       <td>Select the second component of |e|<br>
+           (OpCompositeExtract with selection index 1)
+  <tr algorithm="third vector component selection"><td>|e| : vec|N|&lt;|T|&gt;<br>
+          |N| is 3 or 4
+       <td class="nowrap">
+           |e|`.z` : |T|<br>
+           |e|`.b` : |T|
+       <td>Select the third component of |e|<br>
+           (OpCompositeExtract with selection index 2)
+  <tr algorithm="fourth vector component selection"><td>|e| : vec4&lt;|T|&gt;
+       <td class="nowrap">
+           |e|`.w` : |T|<br>
+           |e|`.a` : |T|
+       <td>Select the fourth component of |e|<br>
+           (OpCompositeExtract with selection index 3)
+  <tr algorithm="vector indexed component selection"><td>|e| : vec|N|&lt;|T|&gt;<br>
+          |i| : *Int*
+       <td class="nowrap">
+           |e|[|i|] : |T|
+       <td>Select the |i|'<sup>th</sup> component of vector<br>
+           If |i| is outside the range [0,|N|-1], then an index in the range [0, |N|-1] is used instead.
+           (OpVectorExtractDynamic)
+</table>
+
+Issue: Which index is used when it's out of bounds?
+
+#### Vector multiple component selection #### {#vector-multi-component}
+
+<table class='data'>
+  <caption>Vector decomposition: multiple component selection
+  <thead>
+    <tr><th>Precondition<th>Conclusion<th>Description
+  </thead>
+  <tr algorithm="two component vector selection using .x .y">
+       <td class="nowrap">
+          |e| : vec|N|&lt;|T|&gt;<br>
+          |I| is the letter `x`, `y`, `z`, or `w`<br>
+          |J| is the letter `x`, `y`, `z`, or `w`<br>
+       <td class="nowrap">
+           |e|`.`|I||J| : vec2&lt;|T|&gt;<br>
+       <td>Computes the two-element vector with first component |e|.|I|, and second component |e|.|J|.<br>
+           Letter `z` is valid only when |N| is 3 or 4.<br>
+           Letter `w` is valid only when |N| is 4.<br>
+           (OpVectorShuffle)
+  <tr algorithm="two component vector selection using .r .g">
+       <td class="nowrap">
+          |e| : vec|N|&lt;|T|&gt;<br>
+          |I| is the letter `r`, `g`, `b`, or `a`<br>
+          |J| is the letter `r`, `g`, `b`, or `a`<br>
+       <td class="nowrap">
+           |e|`.`|I||J| : vec2&lt;|T|&gt;<br>
+       <td>Computes the two-element vector with first component |e|.|I|, and second component |e|.|J|.<br>
+           Letter `b` is valid only when |N| is 3 or 4.<br>
+           Letter `a` is valid only when |N| is 4.<br>
+           (OpVectorShuffle)
+  <tr algorithm="three component vector selection using .x .y">
+       <td class="nowrap">
+          |e| : vec|N|&lt;|T|&gt;<br>
+          |I| is the letter `x`, `y`, `z`, or `w`<br>
+          |J| is the letter `x`, `y`, `z`, or `w`<br>
+          |K| is the letter `x`, `y`, `z`, or `w`<br>
+       <td class="nowrap">
+           |e|`.`|I||J||K| : vec3&lt;|T|&gt;<br>
+       <td>Computes the three-element vector with first component |e|.|I|, second component |e|.|J|, and third component |e|.|K|.<br>
+           Letter `z` is valid only when |N| is 3 or 4.<br>
+           Letter `w` is valid only when |N| is 4.<br>
+           (OpVectorShuffle)
+  <tr algorithm="three component vector selection using .r .g">
+       <td class="nowrap">
+          |e| : vec|N|&lt;|T|&gt;<br>
+          |I| is the letter `r`, `g`, `b`, or `a`<br>
+          |J| is the letter `r`, `g`, `b`, or `a`<br>
+          |K| is the letter `r`, `g`, `b`, or `a`<br>
+       <td class="nowrap">
+           |e|`.`|I||J||K| : vec3&lt;|T|&gt;<br>
+       <td>Computes the three-element vector with first component |e|.|I|, second component |e|.|J|, and third component |e|.|K|.<br>
+           Letter `b` is only valid when |N| is 3 or 4.<br>
+           Letter `a` is only valid when |N| is 4.<br>
+           (OpVectorShuffle)
+  <tr algorithm="four component vector selection using .x .y">
+       <td class="nowrap">
+          |e| : vec|N|&lt;|T|&gt;<br>
+          |I| is the letter `x`, `y`, `z`, or `w`<br>
+          |J| is the letter `x`, `y`, `z`, or `w`<br>
+          |K| is the letter `x`, `y`, `z`, or `w`<br>
+          |L| is the letter `x`, `y`, `z`, or `w`<br>
+       <td class="nowrap">
+           |e|`.`|I||J||K||L| : vec4&lt;|T|&gt;<br>
+       <td>Computes the four-element vector with first component |e|.|I|, second component |e|.|J|, third component |e|.|K|, and fourth component |e|.|L|.<br>
+           Letter `z` is valid only when |N| is 3 or 4.<br>
+           Letter `w` is valid only when |N| is 4.<br>
+           (OpVectorShuffle)
+  <tr algorithm="four component vector selection using .r .g">
+       <td class="nowrap">
+          |e| : vec|N|&lt;|T|&gt;<br>
+          |I| is the letter `r`, `g`, `b`, or `a`<br>
+          |J| is the letter `r`, `g`, `b`, or `a`<br>
+          |K| is the letter `r`, `g`, `b`, or `a`<br>
+          |L| is the letter `r`, `g`, `b`, or `a`<br>
+       <td class="nowrap">
+           |e|`.`|I||J||K||L| : vec4&lt;|T|&gt;<br>
+       <td>Computes the four-element vector with first component |e|.|I|, second component |e|.|J|, third component |e|.|K|, and fourth component |e|.|L|.<br>
+           Letter `b` is only valid when |N| is 3 or 4.<br>
+           Letter `a` is only valid when |N| is 4.<br>
+           (OpVectorShuffle)
+</table>
 
 ### Matrix Access Expression TODO ### {#matrix-access-expr}
 
+<table class='data'>
+  <caption>Column vector extraction</caption>
+  <thead>
+    <tr><th>Precondition<th>Conclusion<th>Description
+  </thead>
+  <tr algorithm="matrix indexed column vector selection">
+       <td class="nowrap">
+          |e| : mat|N|x|M|&lt;|T|&gt;<br>
+          |i| : *Int*
+       <td class="nowrap">
+           |e|[|i|] : vec|M|&lt;|T|&gt;
+       <td>The result is the |i|'<sup>th</sup> column vector of |e|.<br>
+           If |i| is outside the range [0,|N|-1], then an index in the range [0, |N|-1] is used instead.<br>
+           (OpCompositeExtract)
+</table>
+
+Issue: Which index is used when it's out of bounds?
+
 ### Array Access Expression TODO ### {#array-access-expr}
 
+<table class='data'>
+  <caption>Array element extraction</caption>
+  <thead>
+    <tr><th>Precondition<th>Conclusion<th>Description
+  </thead>
+  <tr algorithm="sized array indexed element selection">
+       <td class="nowrap">
+          |e| : array&lt;|T|,|N|&gt;<br>
+          |i| : *Int*
+       <td class="nowrap">
+           |e|[|i|] : |T|
+       <td>The result is the value of the |i|'<sup>th</sup> element of the array value |e|.<br>
+           If |i| is outside the range [0,|N|-1], then an index in the range [0, |N|-1] is used instead.<br>
+           (OpCompositeExtract)
+</table>
+
+Issue: Which index is used when it's out of bounds?
+
 ### Structure Access Expression TODO ### {#struct-access-expr}
+
+<table class='data'>
+  <caption>Structure member extraction</caption>
+  <thead>
+    <tr><th>Precondition<th>Conclusion<th>Description
+  </thead>
+  <tr algorithm="structure member extraction">
+       <td class="nowrap">
+          |S| is a structure type<br>
+          |M| is the identifier name of a member of |S|, having type |T|<br>
+          |e| : |S|<br>
+       <td class="nowrap">
+           |e|.|M| : |T|
+       <td>The result is the value of the member with name |M| from the structure value |e|.<br>
+           (OpCompositeExtract, using the member index)
+</table>
 
 ## Logical Expressions TODO ## {#logical-expr}
 <table class='data'>


### PR DESCRIPTION
This pulls out the composite (non-pointer) decomposition type rules from #1368. 
This should be more straightforward.

I added an "issue" line about what index to use when the index is out of bounds.
That's debatable. 