### PR TITLE
Reset state even on empty executeBundles.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6552,8 +6552,9 @@ attachments used by this encoder.
 
         When a {{GPURenderBundle}} is executed, it does not inherit the render pass's pipeline, bind
         groups, or vertex and index buffers. After a {{GPURenderBundle}} has executed, the render
-        pass's pipeline, bind groups, and vertex and index buffers are cleared. If zero
-        {{GPURenderBundle}}s are executed, the command buffer state is unchanged.
+        pass's pipeline, bind groups, and vertex and index buffers are cleared.
+
+        Note: state is cleared even if zero {{GPURenderBundle|GPURenderBundles}} are executed.
 
         <div algorithm="GPURenderPassEncoder.executeBundles">
             **Called on:** {{GPURenderPassEncoder}} this.


### PR DESCRIPTION
This makes the behavior more consistent, otherwise applications with
variable numbers of bundles could get surprising behavior with state
leaking when there are zero bundles.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/1373.html" title="Last updated on Jan 26, 2021, 2:45 PM UTC (0fbdc87)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1373/81023e2...Kangz:0fbdc87.html" title="Last updated on Jan 26, 2021, 2:45 PM UTC (0fbdc87)">Diff</a>