### PR TITLE
Change [Buffer/Texture/ImageBitmap]CopyView to CopyLocation

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4501,18 +4501,18 @@ interface GPUCommandEncoder {
         GPUSize64 size);
 
     undefined copyBufferToTexture(
-        GPUBufferCopyView source,
-        GPUTextureCopyView destination,
+        GPUBufferCopyLocation source,
+        GPUTextureCopyLocation destination,
         GPUExtent3D copySize);
 
     undefined copyTextureToBuffer(
-        GPUTextureCopyView source,
-        GPUBufferCopyView destination,
+        GPUTextureCopyLocation source,
+        GPUBufferCopyLocation destination,
         GPUExtent3D copySize);
 
     undefined copyTextureToTexture(
-        GPUTextureCopyView source,
-        GPUTextureCopyView destination,
+        GPUTextureCopyLocation source,
+        GPUTextureCopyLocation destination,
         GPUExtent3D copySize);
 
     undefined pushDebugGroup(USVString groupLabel);
@@ -4731,34 +4731,34 @@ Issue: Define the exact copy semantics, by reference to common algorithms shared
         Required if there are multiple [=images=] (i.e. the depth is more than one).
 </dl>
 
-### <dfn dictionary>GPUBufferCopyView</dfn> ### {#gpu-buffer-copy-view}
+### <dfn dictionary>GPUBufferCopyLocation</dfn> ### {#gpu-buffer-copy-location}
 
 <script type=idl>
-dictionary GPUBufferCopyView : GPUTextureDataLayout {
+dictionary GPUBufferCopyLocation : GPUTextureDataLayout {
     required GPUBuffer buffer;
 };
 </script>
 
-A {{GPUBufferCopyView}} contains the actual [=texture=] data placed in a [=buffer=] according to {{GPUTextureDataLayout}}.
+A {{GPUBufferCopyLocation}} contains the actual [=texture=] data placed in a [=buffer=] according to {{GPUTextureDataLayout}}.
 
 <div algorithm class=validusage>
-<dfn abstract-op>validating GPUBufferCopyView</dfn>
+<dfn abstract-op>validating GPUBufferCopyLocation</dfn>
 
   **Arguments:**
-    - {{GPUBufferCopyView}} |bufferCopyView|
+    - {{GPUBufferCopyLocation}} |bufferCopyLocation|
 
   **Returns:** {{boolean}}
 
   Return `true` if and only if all of the following conditions are satisfied:
-    - |bufferCopyView|.{{GPUBufferCopyView/buffer}} must be a [=valid=] {{GPUBuffer}}.
-    - |bufferCopyView|.{{GPUTextureDataLayout/bytesPerRow}} must be a multiple of 256.
+    - |bufferCopyLocation|.{{GPUBufferCopyLocation/buffer}} must be a [=valid=] {{GPUBuffer}}.
+    - |bufferCopyLocation|.{{GPUTextureDataLayout/bytesPerRow}} must be a multiple of 256.
 
 </div>
 
-### <dfn dictionary>GPUTextureCopyView</dfn> ### {#gpu-texture-copy-view}
+### <dfn dictionary>GPUTextureCopyLocation</dfn> ### {#gpu-texture-copy-location}
 
 <script type=idl>
-dictionary GPUTextureCopyView {
+dictionary GPUTextureCopyLocation {
     required GPUTexture texture;
     GPUIntegerCoordinate mipLevel = 0;
     GPUOrigin3D origin = {};
@@ -4766,49 +4766,49 @@ dictionary GPUTextureCopyView {
 };
 </script>
 
-A {{GPUTextureCopyView}} is a view of a sub-region of one or multiple contiguous [=texture subresources=] with the initial
+A {{GPUTextureCopyLocation}} is a view of a sub-region of one or multiple contiguous [=texture subresources=] with the initial
 offset {{GPUOrigin3D}} in texels, used when copying data from or to a {{GPUTexture}}.
 
-  * {{GPUTextureCopyView/origin}}: If unspecified, defaults to `[0, 0, 0]`.
+  * {{GPUTextureCopyLocation/origin}}: If unspecified, defaults to `[0, 0, 0]`.
 
 <div algorithm class=validusage>
-<dfn abstract-op>validating GPUTextureCopyView</dfn>
+<dfn abstract-op>validating GPUTextureCopyLocation</dfn>
 
   **Arguments:**
-    - {{GPUTextureCopyView}} |textureCopyView|
+    - {{GPUTextureCopyLocation}} |textureCopyLocation|
     - {{GPUExtent3D}} |copySize|
 
   **Returns:** {{boolean}}
 
   Let:
-  - |blockWidth| be the [=texel block width=] of |textureCopyView|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
-  - |blockHeight| be the [=texel block height=] of |textureCopyView|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
+  - |blockWidth| be the [=texel block width=] of |textureCopyLocation|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}}.
+  - |blockHeight| be the [=texel block height=] of |textureCopyLocation|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}}.
 
   Return `true` if and only if all of the following conditions apply:
-  - |textureCopyView|.{{GPUTextureCopyView/texture}} must be a [=valid=] {{GPUTexture}}.
-  - |textureCopyView|.{{GPUTextureCopyView/mipLevel}} must be less than the {{GPUTexture/[[mipLevelCount]]}} of
-    |textureCopyView|.{{GPUTextureCopyView/texture}}.
-  - |textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/x=] must be a multiple of |blockWidth|.
-  - |textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/y=] must be a multiple of |blockHeight|.
-  - The [=textureCopyView subresource size=] of |textureCopyView| is equal to |copySize| if either of
+  - |textureCopyLocation|.{{GPUTextureCopyLocation/texture}} must be a [=valid=] {{GPUTexture}}.
+  - |textureCopyLocation|.{{GPUTextureCopyLocation/mipLevel}} must be less than the {{GPUTexture/[[mipLevelCount]]}} of
+    |textureCopyLocation|.{{GPUTextureCopyLocation/texture}}.
+  - |textureCopyLocation|.{{GPUTextureCopyLocation/origin}}.[=Origin3D/x=] must be a multiple of |blockWidth|.
+  - |textureCopyLocation|.{{GPUTextureCopyLocation/origin}}.[=Origin3D/y=] must be a multiple of |blockHeight|.
+  - The [=textureCopyLocation subresource size=] of |textureCopyLocation| is equal to |copySize| if either of
       the following conditions is true:
-        - |textureCopyView|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format.
-        - |textureCopyView|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is greater than 1.
+        - |textureCopyLocation|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format.
+        - |textureCopyLocation|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[sampleCount]]}} is greater than 1.
 
 </div>
 
 Issue(gpuweb/gpuweb#69): Define the copies with {{GPUTextureDimension/1d}} and {{GPUTextureDimension/3d}} textures.
 
-### <dfn dictionary>GPUImageBitmapCopyView</dfn> ### {#gpu-image-bitmap-copy-view}
+### <dfn dictionary>GPUImageBitmapCopyLocation</dfn> ### {#gpu-image-bitmap-copy-location}
 
 <script type=idl>
-dictionary GPUImageBitmapCopyView {
+dictionary GPUImageBitmapCopyLocation {
     required ImageBitmap imageBitmap;
     GPUOrigin2D origin = {};
 };
 </script>
 
-  * {{GPUImageBitmapCopyView/origin}}: If unspecified, defaults to `[0, 0]`.
+  * {{GPUImageBitmapCopyLocation/origin}}: If unspecified, defaults to `[0, 0]`.
 
 <dl dfn-type=method dfn-for=GPUCommandEncoder>
     : <dfn>copyBufferToBuffer(source, sourceOffset, destination, destinationOffset, size)</dfn>
@@ -4861,23 +4861,23 @@ WebGPU provides {{GPUCommandEncoder/copyBufferToTexture()}} for buffer-to-textur
 The following definitions and validation rules apply to both {{GPUCommandEncoder/copyBufferToTexture()}}
 and {{GPUCommandEncoder/copyTextureToBuffer()}}.
 
-[=textureCopyView subresource size=] and [=Valid Texture Copy Range=] also applies to
+[=textureCopyLocation subresource size=] and [=Valid Texture Copy Range=] also applies to
 {{GPUCommandEncoder/copyTextureToTexture()}}.
 
-<div algorithm="textureCopyView subresource size">
+<div algorithm="textureCopyLocation subresource size">
 
-<dfn dfn>textureCopyView subresource size</dfn>
+<dfn dfn>textureCopyLocation subresource size</dfn>
 
   **Arguments:**
-    - {{GPUTextureCopyView}} |textureCopyView|
+    - {{GPUTextureCopyLocation}} |textureCopyLocation|
 
   **Returns:** {{GPUExtent3D}}
 
-  The [=textureCopyView subresource size=] of |textureCopyView| is calculated as follows:
+  The [=textureCopyLocation subresource size=] of |textureCopyLocation| is calculated as follows:
 
   Its [=Extent3D/width=], [=Extent3D/height=] and [=Extent3D/depth=] are the width, height, and depth, respectively,
-  of the [=physical size=] of |textureCopyView|.{{GPUTextureCopyView/texture}} [=subresource=] at [=mipmap level=]
-  |textureCopyView|.{{GPUTextureCopyView/mipLevel}}.
+  of the [=physical size=] of |textureCopyLocation|.{{GPUTextureCopyLocation/texture}} [=subresource=] at [=mipmap level=]
+  |textureCopyLocation|.{{GPUTextureCopyLocation/mipLevel}}.
 
 </div>
 
@@ -4949,23 +4949,23 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
 
 <dfn dfn>Valid Texture Copy Range</dfn>
 
-Given a {{GPUTextureCopyView}} |textureCopyView| and a {{GPUExtent3D}} |copySize|, let
-  - |blockWidth| be the [=texel block width=] of |textureCopyView|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
-  - |blockHeight| be the [=texel block height=] of |textureCopyView|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
+Given a {{GPUTextureCopyLocation}} |textureCopyLocation| and a {{GPUExtent3D}} |copySize|, let
+  - |blockWidth| be the [=texel block width=] of |textureCopyLocation|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}}.
+  - |blockHeight| be the [=texel block height=] of |textureCopyLocation|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}}.
 
 The following validation rules apply:
 
-  - If the {{GPUTexture/[[dimension]]}} of |textureCopyView|.{{GPUTextureCopyView/texture}} is
+  - If the {{GPUTexture/[[dimension]]}} of |textureCopyLocation|.{{GPUTextureCopyLocation/texture}} is
     {{GPUTextureDimension/1d}}:
     - Both |copySize|.[=Extent3D/height=] and [=Extent3D/depth=] must be 1.
-  - If the {{GPUTexture/[[dimension]]}} of |textureCopyView|.{{GPUTextureCopyView/texture}} is
+  - If the {{GPUTexture/[[dimension]]}} of |textureCopyLocation|.{{GPUTextureCopyLocation/texture}} is
     {{GPUTextureDimension/2d}}:
-     -  (|textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/x=] + |copySize|.[=Extent3D/width=]),
-        (|textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/y=] + |copySize|.[=Extent3D/height=]), and
-        (|textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/z=] + |copySize|.[=Extent3D/depth=])
+     -  (|textureCopyLocation|.{{GPUTextureCopyLocation/origin}}.[=Origin3D/x=] + |copySize|.[=Extent3D/width=]),
+        (|textureCopyLocation|.{{GPUTextureCopyLocation/origin}}.[=Origin3D/y=] + |copySize|.[=Extent3D/height=]), and
+        (|textureCopyLocation|.{{GPUTextureCopyLocation/origin}}.[=Origin3D/z=] + |copySize|.[=Extent3D/depth=])
         must be less than or equal to the
         [=Extent3D/width=], [=Extent3D/height=], and [=Extent3D/depth=], respectively,
-        of the [=textureCopyView subresource size=] of |textureCopyView|.
+        of the [=textureCopyLocation subresource size=] of |textureCopyLocation|.
   - |copySize|.[=Extent3D/width=] must be a multiple of |blockWidth|.
   - |copySize|.[=Extent3D/height=] must be a multiple of |blockHeight|.
 
@@ -5002,23 +5002,23 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
             If any of the following conditions are unsatisfied, generate a validation error and stop.
             <div class=validusage>
                 - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
-                - [$validating GPUBufferCopyView$](|source|) returns `true`.
-                - |source|.{{GPUBufferCopyView/buffer}}.{{GPUBuffer/[[usage]]}} contains
+                - [$validating GPUBufferCopyLocation$](|source|) returns `true`.
+                - |source|.{{GPUBufferCopyLocation/buffer}}.{{GPUBuffer/[[usage]]}} contains
                     {{GPUBufferUsage/COPY_SRC}}.
-                - [$validating GPUTextureCopyView$](|destination|, |copySize|) returns `true`.
-                - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}} contains
+                - [$validating GPUTextureCopyLocation$](|destination|, |copySize|) returns `true`.
+                - |destination|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[textureUsage]]}} contains
                     {{GPUTextureUsage/COPY_DST}}.
-                - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is 1.
-                - If |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format:
-                    - |destination|.{{GPUTextureCopyView/aspect}} must refer to a single copyable aspect of
-                        |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
+                - |destination|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[sampleCount]]}} is 1.
+                - If |destination|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format:
+                    - |destination|.{{GPUTextureCopyLocation/aspect}} must refer to a single copyable aspect of
+                        |destination|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}}.
                         See [[#depth-formats|depth-formats]].
                 - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
                 - |source|.{{GPUTextureDataLayout/offset}} is a multiple of the [=texel block size=]
-                    of |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
+                    of |destination|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}}.
                 - [$validating linear texture data$](|source|,
-                    |source|.{{GPUBufferCopyView/buffer}}.{{GPUBuffer/[[size]]}},
-                    |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}},
+                    |source|.{{GPUBufferCopyLocation/buffer}}.{{GPUBuffer/[[size]]}},
+                    |destination|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}},
                     |copySize|) succeeds.
             </div>
         </div>
@@ -5043,23 +5043,23 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
             If any of the following conditions are unsatisfied, generate a validation error and stop.
             <div class=validusage>
                 - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
-                - [$validating GPUTextureCopyView$](|source|, |copySize|) returns `true`.
-                - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}} contains
+                - [$validating GPUTextureCopyLocation$](|source|, |copySize|) returns `true`.
+                - |source|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[textureUsage]]}} contains
                     {{GPUTextureUsage/COPY_SRC}}.
-                - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is 1.
-                - If |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format:
-                    - |source|.{{GPUTextureCopyView/aspect}} must refer to a single copyable aspect of
-                        |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
+                - |source|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[sampleCount]]}} is 1.
+                - If |source|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format:
+                    - |source|.{{GPUTextureCopyLocation/aspect}} must refer to a single copyable aspect of
+                        |source|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}}.
                         See [[#depth-formats|depth-formats]].
-                - [$validating GPUBufferCopyView$](|destination|) returns `true`.
-                - |destination|.{{GPUBufferCopyView/buffer}}.{{GPUBuffer/[[usage]]}} contains
+                - [$validating GPUBufferCopyLocation$](|destination|) returns `true`.
+                - |destination|.{{GPUBufferCopyLocation/buffer}}.{{GPUBuffer/[[usage]]}} contains
                     {{GPUBufferUsage/COPY_DST}}.
                 - [=Valid Texture Copy Range=] applies to |source| and |copySize|.
                 - |destination|.{{GPUTextureDataLayout/offset}} is a multiple of the [=texel block size=]
-                    of |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
+                    of |destination|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}}.
                 - [$validating linear texture data$](|destination|,
-                    |destination|.{{GPUBufferCopyView/buffer}}.{{GPUBuffer/[[size]]}},
-                    |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}},
+                    |destination|.{{GPUBufferCopyLocation/buffer}}.{{GPUBuffer/[[size]]}},
+                    |source|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}},
                     |copySize|) succeeds.
             </div>
         </div>
@@ -5085,20 +5085,20 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
             1. If any of the following conditions are unsatisfied, generate a validation error and stop.
                 <div class=validusage>
                     - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
-                    - [$validating GPUTextureCopyView$](|source|, |copySize|) returns `true`.
-                    - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}} contains
+                    - [$validating GPUTextureCopyLocation$](|source|, |copySize|) returns `true`.
+                    - |source|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[textureUsage]]}} contains
                         {{GPUTextureUsage/COPY_SRC}}.
-                    - [$validating GPUTextureCopyView$](|destination|, |copySize|) returns `true`.
-                    - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}} contains
+                    - [$validating GPUTextureCopyLocation$](|destination|, |copySize|) returns `true`.
+                    - |destination|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[textureUsage]]}} contains
                         {{GPUTextureUsage/COPY_DST}}.
-                    - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is equal to |destination|.
-                        {{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}}.
-                    - |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} is equal to |destination|.
-                        {{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
-                    - If |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format:
-                        - |source|.{{GPUTextureCopyView/aspect}} and |destination|.{{GPUTextureCopyView/aspect}}
-                            must both refer to all aspects of |source|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}
-                            and |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}, respectively.
+                    - |source|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[sampleCount]]}} is equal to |destination|.
+                        {{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[sampleCount]]}}.
+                    - |source|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}} is equal to |destination|.
+                        {{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}}.
+                    - If |source|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format:
+                        - |source|.{{GPUTextureCopyLocation/aspect}} and |destination|.{{GPUTextureCopyLocation/aspect}}
+                            must both refer to all aspects of |source|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}}
+                            and |destination|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}}, respectively.
                     - [=Valid Texture Copy Range=] applies to |source| and |copySize|.
                     - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
                     - The [$set of subresources for texture copy$](|source|, |copySize|) and
@@ -5108,19 +5108,19 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
 </dl>
 
 <div algorithm>
-    The <dfn abstract-op>set of subresources for texture copy</dfn>(|textureCopyView|, |copySize|)
+    The <dfn abstract-op>set of subresources for texture copy</dfn>(|textureCopyLocation|, |copySize|)
     is the set containing:
 
-      - If |textureCopyView|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[dimension]]}}
+      - If |textureCopyLocation|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[dimension]]}}
         is {{GPUTextureDimension/"2d"}}:
           - For each |arrayLayer| of the |copySize|.[=Extent3D/depth=] [=array layers=]
-            starting at |textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/z=]:
-              - The [=subresource=] of |textureCopyView|.{{GPUTextureCopyView/texture}} at
-                [=mipmap level=] |textureCopyView|.{{GPUTextureCopyView/mipLevel}} and
+            starting at |textureCopyLocation|.{{GPUTextureCopyLocation/origin}}.[=Origin3D/z=]:
+              - The [=subresource=] of |textureCopyLocation|.{{GPUTextureCopyLocation/texture}} at
+                [=mipmap level=] |textureCopyLocation|.{{GPUTextureCopyLocation/mipLevel}} and
                 [=array layer=] |arrayLayer|.
       - Otherwise:
-          - The [=subresource=] of |textureCopyView|.{{GPUTextureCopyView/texture}} at
-            [=mipmap level=] |textureCopyView|.{{GPUTextureCopyView/mipLevel}}.
+          - The [=subresource=] of |textureCopyLocation|.{{GPUTextureCopyLocation/texture}} at
+            [=mipmap level=] |textureCopyLocation|.{{GPUTextureCopyLocation/mipLevel}}.
 </div>
 
 ## Debug Markers ## {#command-encoder-debug-markers}
@@ -6692,14 +6692,14 @@ interface GPUQueue {
         optional GPUSize64 size);
 
     undefined writeTexture(
-      GPUTextureCopyView destination,
+      GPUTextureCopyLocation destination,
       [AllowShared] BufferSource data,
       GPUTextureDataLayout dataLayout,
       GPUExtent3D size);
 
     undefined copyImageBitmapToTexture(
-        GPUImageBitmapCopyView source,
-        GPUTextureCopyView destination,
+        GPUImageBitmapCopyLocation source,
+        GPUTextureCopyLocation destination,
         GPUExtent3D copySize);
 };
 GPUQueue includes GPUObjectBase;
@@ -6785,7 +6785,7 @@ GPUQueue includes GPUObjectBase;
                 <div class=validusage>
                     - [$validating linear texture data$](|dataLayout|,
                         |dataByteSize|,
-                        |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}},
+                        |destination|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}},
                         |size|) succeeds.
                 </div>
             1. Let |contents| be the contents of the [=images=] seen by
@@ -6797,14 +6797,14 @@ GPUQueue includes GPUObjectBase;
                     1. If any of the following conditions are unsatisfied,
                         generate a validation error and stop.
                         <div class=validusage>
-                            - [$validating GPUTextureCopyView$](|destination|, |size|) returns `true`.
-                            - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[textureUsage]]}}
+                            - [$validating GPUTextureCopyLocation$](|destination|, |size|) returns `true`.
+                            - |destination|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[textureUsage]]}}
                                 includes {{GPUTextureUsage/COPY_DST}}.
-                            - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[sampleCount]]}} is 1.
+                            - |destination|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[sampleCount]]}} is 1.
                             - [=Valid Texture Copy Range=](|destination|, |size|)
                                 is satisfied.
-                            - |destination|.{{GPUTextureCopyView/aspect}} refers to a single copyable aspect
-                                of |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}}.
+                            - |destination|.{{GPUTextureCopyLocation/aspect}} refers to a single copyable aspect
+                                of |destination|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}}.
                                 See [[#depth-formats|depth-formats]].
 
                             Note: unlike
@@ -6837,8 +6837,8 @@ GPUQueue includes GPUObjectBase;
             If any of the following conditions are unsatisfied, throw an {{OperationError}} and stop.
             <div class=validusage>
                 - |copySize|.[=Extent3D/depth=] is `1`.
-                - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[dimension]]}} is {{GPUTextureDimension/"2d"}}.
-                - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} is one of the following:
+                - |destination|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[dimension]]}} is {{GPUTextureDimension/"2d"}}.
+                - |destination|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}} is one of the following:
                     - {{GPUTextureFormat/"rgba8unorm"}}
                     - {{GPUTextureFormat/"rgba8unorm-srgb"}}
                     - {{GPUTextureFormat/"bgra8unorm"}}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4501,18 +4501,18 @@ interface GPUCommandEncoder {
         GPUSize64 size);
 
     undefined copyBufferToTexture(
-        GPUBufferCopyLocation source,
-        GPUTextureCopyLocation destination,
+        GPUImageCopyBuffer source,
+        GPUImageCopyTexture destination,
         GPUExtent3D copySize);
 
     undefined copyTextureToBuffer(
-        GPUTextureCopyLocation source,
-        GPUBufferCopyLocation destination,
+        GPUImageCopyTexture source,
+        GPUImageCopyBuffer destination,
         GPUExtent3D copySize);
 
     undefined copyTextureToTexture(
-        GPUTextureCopyLocation source,
-        GPUTextureCopyLocation destination,
+        GPUImageCopyTexture source,
+        GPUImageCopyTexture destination,
         GPUExtent3D copySize);
 
     undefined pushDebugGroup(USVString groupLabel);
@@ -4691,17 +4691,17 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 
 ## Copy Commands ## {#copy-commands}
 
-### <dfn dictionary>GPUTextureDataLayout</dfn> ### {#gpu-texture-data-layout}
+### <dfn dictionary>GPUImageDataLayout</dfn> ### {#gpu-image-data-layout}
 
 <script type=idl>
-dictionary GPUTextureDataLayout {
+dictionary GPUImageDataLayout {
     GPUSize64 offset = 0;
     GPUSize32 bytesPerRow;
     GPUSize32 rowsPerImage;
 };
 </script>
 
-A {{GPUTextureDataLayout}} is a layout of <dfn dfn>images</dfn> within some linear memory.
+A {{GPUImageDataLayout}} is a layout of <dfn dfn>images</dfn> within some linear memory.
 It's used when copying data between a [=texture=] and a [=buffer=], or when scheduling a
 write into a [=texture=] from the {{GPUQueue}}.
 
@@ -4715,7 +4715,7 @@ Issue: Define images more precisely. In particular, define them as being compris
 
 Issue: Define the exact copy semantics, by reference to common algorithms shared by the copy methods.
 
-<dl dfn-type=dict-member dfn-for=GPUTextureDataLayout>
+<dl dfn-type=dict-member dfn-for=GPUImageDataLayout>
     : <dfn>bytesPerRow</dfn>
     ::
         The stride, in bytes, between the beginning of each [=block row=] and the subsequent [=block row=].
@@ -4725,40 +4725,40 @@ Issue: Define the exact copy semantics, by reference to common algorithms shared
     : <dfn>rowsPerImage</dfn>
     ::
         Number of [=block rows=] per single [=image=] of the [=texture=].
-        {{GPUTextureDataLayout/rowsPerImage}} &times;
-        {{GPUTextureDataLayout/bytesPerRow}} is the stride, in bytes, between the beginning of each [=image=] of data and the subsequent [=image=].
+        {{GPUImageDataLayout/rowsPerImage}} &times;
+        {{GPUImageDataLayout/bytesPerRow}} is the stride, in bytes, between the beginning of each [=image=] of data and the subsequent [=image=].
 
         Required if there are multiple [=images=] (i.e. the depth is more than one).
 </dl>
 
-### <dfn dictionary>GPUBufferCopyLocation</dfn> ### {#gpu-buffer-copy-location}
+### <dfn dictionary>GPUImageCopyBuffer</dfn> ### {#gpu-image-copy-buffer}
 
 <script type=idl>
-dictionary GPUBufferCopyLocation : GPUTextureDataLayout {
+dictionary GPUImageCopyBuffer : GPUImageDataLayout {
     required GPUBuffer buffer;
 };
 </script>
 
-A {{GPUBufferCopyLocation}} contains the actual [=texture=] data placed in a [=buffer=] according to {{GPUTextureDataLayout}}.
+A {{GPUImageCopyBuffer}} contains the actual [=texture=] data placed in a [=buffer=] according to {{GPUImageDataLayout}}.
 
 <div algorithm class=validusage>
-<dfn abstract-op>validating GPUBufferCopyLocation</dfn>
+<dfn abstract-op>validating GPUImageCopyBuffer</dfn>
 
   **Arguments:**
-    - {{GPUBufferCopyLocation}} |bufferCopyLocation|
+    - {{GPUImageCopyBuffer}} |imageCopyBuffer|
 
   **Returns:** {{boolean}}
 
   Return `true` if and only if all of the following conditions are satisfied:
-    - |bufferCopyLocation|.{{GPUBufferCopyLocation/buffer}} must be a [=valid=] {{GPUBuffer}}.
-    - |bufferCopyLocation|.{{GPUTextureDataLayout/bytesPerRow}} must be a multiple of 256.
+    - |imageCopyBuffer|.{{GPUImageCopyBuffer/buffer}} must be a [=valid=] {{GPUBuffer}}.
+    - |imageCopyBuffer|.{{GPUImageDataLayout/bytesPerRow}} must be a multiple of 256.
 
 </div>
 
-### <dfn dictionary>GPUTextureCopyLocation</dfn> ### {#gpu-texture-copy-location}
+### <dfn dictionary>GPUImageCopyTexture</dfn> ### {#gpu-image-copy-texture}
 
 <script type=idl>
-dictionary GPUTextureCopyLocation {
+dictionary GPUImageCopyTexture {
     required GPUTexture texture;
     GPUIntegerCoordinate mipLevel = 0;
     GPUOrigin3D origin = {};
@@ -4766,49 +4766,49 @@ dictionary GPUTextureCopyLocation {
 };
 </script>
 
-A {{GPUTextureCopyLocation}} is a view of a sub-region of one or multiple contiguous [=texture subresources=] with the initial
+A {{GPUImageCopyTexture}} is a view of a sub-region of one or multiple contiguous [=texture subresources=] with the initial
 offset {{GPUOrigin3D}} in texels, used when copying data from or to a {{GPUTexture}}.
 
-  * {{GPUTextureCopyLocation/origin}}: If unspecified, defaults to `[0, 0, 0]`.
+  * {{GPUImageCopyTexture/origin}}: If unspecified, defaults to `[0, 0, 0]`.
 
 <div algorithm class=validusage>
-<dfn abstract-op>validating GPUTextureCopyLocation</dfn>
+<dfn abstract-op>validating GPUImageCopyTexture</dfn>
 
   **Arguments:**
-    - {{GPUTextureCopyLocation}} |textureCopyLocation|
+    - {{GPUImageCopyTexture}} |imageCopyTexture|
     - {{GPUExtent3D}} |copySize|
 
   **Returns:** {{boolean}}
 
   Let:
-  - |blockWidth| be the [=texel block width=] of |textureCopyLocation|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}}.
-  - |blockHeight| be the [=texel block height=] of |textureCopyLocation|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}}.
+  - |blockWidth| be the [=texel block width=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}.
+  - |blockHeight| be the [=texel block height=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}.
 
   Return `true` if and only if all of the following conditions apply:
-  - |textureCopyLocation|.{{GPUTextureCopyLocation/texture}} must be a [=valid=] {{GPUTexture}}.
-  - |textureCopyLocation|.{{GPUTextureCopyLocation/mipLevel}} must be less than the {{GPUTexture/[[mipLevelCount]]}} of
-    |textureCopyLocation|.{{GPUTextureCopyLocation/texture}}.
-  - |textureCopyLocation|.{{GPUTextureCopyLocation/origin}}.[=Origin3D/x=] must be a multiple of |blockWidth|.
-  - |textureCopyLocation|.{{GPUTextureCopyLocation/origin}}.[=Origin3D/y=] must be a multiple of |blockHeight|.
-  - The [=textureCopyLocation subresource size=] of |textureCopyLocation| is equal to |copySize| if either of
+  - |imageCopyTexture|.{{GPUImageCopyTexture/texture}} must be a [=valid=] {{GPUTexture}}.
+  - |imageCopyTexture|.{{GPUImageCopyTexture/mipLevel}} must be less than the {{GPUTexture/[[mipLevelCount]]}} of
+    |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.
+  - |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/x=] must be a multiple of |blockWidth|.
+  - |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/y=] must be a multiple of |blockHeight|.
+  - The [=imageCopyTexture subresource size=] of |imageCopyTexture| is equal to |copySize| if either of
       the following conditions is true:
-        - |textureCopyLocation|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format.
-        - |textureCopyLocation|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[sampleCount]]}} is greater than 1.
+        - |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format.
+        - |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[sampleCount]]}} is greater than 1.
 
 </div>
 
 Issue(gpuweb/gpuweb#69): Define the copies with {{GPUTextureDimension/1d}} and {{GPUTextureDimension/3d}} textures.
 
-### <dfn dictionary>GPUImageBitmapCopyLocation</dfn> ### {#gpu-image-bitmap-copy-location}
+### <dfn dictionary>GPUImageCopyImageBitmap</dfn> ### {#gpu-image-copy-image-bitmap-copy}
 
 <script type=idl>
-dictionary GPUImageBitmapCopyLocation {
+dictionary GPUImageCopyImageBitmap {
     required ImageBitmap imageBitmap;
     GPUOrigin2D origin = {};
 };
 </script>
 
-  * {{GPUImageBitmapCopyLocation/origin}}: If unspecified, defaults to `[0, 0]`.
+  * {{GPUImageCopyImageBitmap/origin}}: If unspecified, defaults to `[0, 0]`.
 
 <dl dfn-type=method dfn-for=GPUCommandEncoder>
     : <dfn>copyBufferToBuffer(source, sourceOffset, destination, destinationOffset, size)</dfn>
@@ -4861,23 +4861,23 @@ WebGPU provides {{GPUCommandEncoder/copyBufferToTexture()}} for buffer-to-textur
 The following definitions and validation rules apply to both {{GPUCommandEncoder/copyBufferToTexture()}}
 and {{GPUCommandEncoder/copyTextureToBuffer()}}.
 
-[=textureCopyLocation subresource size=] and [=Valid Texture Copy Range=] also applies to
+[=imageCopyTexture subresource size=] and [=Valid Texture Copy Range=] also applies to
 {{GPUCommandEncoder/copyTextureToTexture()}}.
 
-<div algorithm="textureCopyLocation subresource size">
+<div algorithm="imageCopyTexture subresource size">
 
-<dfn dfn>textureCopyLocation subresource size</dfn>
+<dfn dfn>imageCopyTexture subresource size</dfn>
 
   **Arguments:**
-    - {{GPUTextureCopyLocation}} |textureCopyLocation|
+    - {{GPUImageCopyTexture}} |imageCopyTexture|
 
   **Returns:** {{GPUExtent3D}}
 
-  The [=textureCopyLocation subresource size=] of |textureCopyLocation| is calculated as follows:
+  The [=imageCopyTexture subresource size=] of |imageCopyTexture| is calculated as follows:
 
   Its [=Extent3D/width=], [=Extent3D/height=] and [=Extent3D/depth=] are the width, height, and depth, respectively,
-  of the [=physical size=] of |textureCopyLocation|.{{GPUTextureCopyLocation/texture}} [=subresource=] at [=mipmap level=]
-  |textureCopyLocation|.{{GPUTextureCopyLocation/mipLevel}}.
+  of the [=physical size=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}} [=subresource=] at [=mipmap level=]
+  |imageCopyTexture|.{{GPUImageCopyTexture/mipLevel}}.
 
 </div>
 
@@ -4887,7 +4887,7 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
     <dfn abstract-op>validating linear texture data</dfn>(layout, byteSize, format, copyExtent)
 
     **Arguments:**
-    : {{GPUTextureDataLayout}} |layout|
+    : {{GPUImageDataLayout}} |layout|
     :: Layout of the linear texture data.
     : {{GPUSize64}} |byteSize|
     :: Total size of the linear data, in bytes.
@@ -4909,13 +4909,13 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
     1. Fail if the following conditions are not satisfied:
         <div class=validusage>
             - If |heightInBlocks| &gt; 1,
-                |layout|.{{GPUTextureDataLayout/bytesPerRow}} must be specified.
+                |layout|.{{GPUImageDataLayout/bytesPerRow}} must be specified.
             - If |copyExtent|.[=Extent3D/depth=] &gt; 1,
-                |layout|.{{GPUTextureDataLayout/bytesPerRow}} and
-                |layout|.{{GPUTextureDataLayout/rowsPerImage}} must be specified.
-            - If specified, |layout|.{{GPUTextureDataLayout/bytesPerRow}}
+                |layout|.{{GPUImageDataLayout/bytesPerRow}} and
+                |layout|.{{GPUImageDataLayout/rowsPerImage}} must be specified.
+            - If specified, |layout|.{{GPUImageDataLayout/bytesPerRow}}
                 must be greater than or equal to |bytesInLastRow|.
-            - If specified, |layout|.{{GPUTextureDataLayout/rowsPerImage}}
+            - If specified, |layout|.{{GPUImageDataLayout/rowsPerImage}}
                 must be greater than or equal to |heightInBlocks|.
         </div>
 
@@ -4923,8 +4923,8 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
 
     1. If |copyExtent|.[=Extent3D/depth=] &gt; 1:
         1. Let |bytesPerImage| be
-            |layout|.{{GPUTextureDataLayout/bytesPerRow}} &times;
-            |layout|.{{GPUTextureDataLayout/rowsPerImage}}.
+            |layout|.{{GPUImageDataLayout/bytesPerRow}} &times;
+            |layout|.{{GPUImageDataLayout/rowsPerImage}}.
         1. Let |bytesBeforeLastImage| be
             |bytesPerImage| &times; (|copyExtent|.[=Extent3D/depth=] &minus; 1).
         1. Add |bytesBeforeLastImage| to |requiredBytesInCopy|.
@@ -4932,7 +4932,7 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
     1. If |copyExtent|.[=Extent3D/depth=] &gt; 0:
 
         1. If |heightInBlocks| &gt; 1, add
-            |layout|.{{GPUTextureDataLayout/bytesPerRow}} &times;
+            |layout|.{{GPUImageDataLayout/bytesPerRow}} &times;
             (|heightInBlocks| &minus; 1)
             to |requiredBytesInCopy|.
 
@@ -4941,7 +4941,7 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
 
     1. Fail if the following conditions are not satisfied:
         <div class=validusage>
-            - |layout|.{{GPUTextureDataLayout/offset}} + |requiredBytesInCopy| &le; |byteSize|.
+            - |layout|.{{GPUImageDataLayout/offset}} + |requiredBytesInCopy| &le; |byteSize|.
         </div>
 </div>
 
@@ -4949,23 +4949,23 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
 
 <dfn dfn>Valid Texture Copy Range</dfn>
 
-Given a {{GPUTextureCopyLocation}} |textureCopyLocation| and a {{GPUExtent3D}} |copySize|, let
-  - |blockWidth| be the [=texel block width=] of |textureCopyLocation|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}}.
-  - |blockHeight| be the [=texel block height=] of |textureCopyLocation|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}}.
+Given a {{GPUImageCopyTexture}} |imageCopyTexture| and a {{GPUExtent3D}} |copySize|, let
+  - |blockWidth| be the [=texel block width=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}.
+  - |blockHeight| be the [=texel block height=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}.
 
 The following validation rules apply:
 
-  - If the {{GPUTexture/[[dimension]]}} of |textureCopyLocation|.{{GPUTextureCopyLocation/texture}} is
+  - If the {{GPUTexture/[[dimension]]}} of |imageCopyTexture|.{{GPUImageCopyTexture/texture}} is
     {{GPUTextureDimension/1d}}:
     - Both |copySize|.[=Extent3D/height=] and [=Extent3D/depth=] must be 1.
-  - If the {{GPUTexture/[[dimension]]}} of |textureCopyLocation|.{{GPUTextureCopyLocation/texture}} is
+  - If the {{GPUTexture/[[dimension]]}} of |imageCopyTexture|.{{GPUImageCopyTexture/texture}} is
     {{GPUTextureDimension/2d}}:
-     -  (|textureCopyLocation|.{{GPUTextureCopyLocation/origin}}.[=Origin3D/x=] + |copySize|.[=Extent3D/width=]),
-        (|textureCopyLocation|.{{GPUTextureCopyLocation/origin}}.[=Origin3D/y=] + |copySize|.[=Extent3D/height=]), and
-        (|textureCopyLocation|.{{GPUTextureCopyLocation/origin}}.[=Origin3D/z=] + |copySize|.[=Extent3D/depth=])
+     -  (|imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/x=] + |copySize|.[=Extent3D/width=]),
+        (|imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/y=] + |copySize|.[=Extent3D/height=]), and
+        (|imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/z=] + |copySize|.[=Extent3D/depth=])
         must be less than or equal to the
         [=Extent3D/width=], [=Extent3D/height=], and [=Extent3D/depth=], respectively,
-        of the [=textureCopyLocation subresource size=] of |textureCopyLocation|.
+        of the [=imageCopyTexture subresource size=] of |imageCopyTexture|.
   - |copySize|.[=Extent3D/width=] must be a multiple of |blockWidth|.
   - |copySize|.[=Extent3D/height=] must be a multiple of |blockHeight|.
 
@@ -5002,23 +5002,23 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
             If any of the following conditions are unsatisfied, generate a validation error and stop.
             <div class=validusage>
                 - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
-                - [$validating GPUBufferCopyLocation$](|source|) returns `true`.
-                - |source|.{{GPUBufferCopyLocation/buffer}}.{{GPUBuffer/[[usage]]}} contains
+                - [$validating GPUImageCopyBuffer$](|source|) returns `true`.
+                - |source|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[usage]]}} contains
                     {{GPUBufferUsage/COPY_SRC}}.
-                - [$validating GPUTextureCopyLocation$](|destination|, |copySize|) returns `true`.
-                - |destination|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[textureUsage]]}} contains
+                - [$validating GPUImageCopyTexture$](|destination|, |copySize|) returns `true`.
+                - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[textureUsage]]}} contains
                     {{GPUTextureUsage/COPY_DST}}.
-                - |destination|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[sampleCount]]}} is 1.
-                - If |destination|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format:
-                    - |destination|.{{GPUTextureCopyLocation/aspect}} must refer to a single copyable aspect of
-                        |destination|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}}.
+                - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[sampleCount]]}} is 1.
+                - If |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format:
+                    - |destination|.{{GPUImageCopyTexture/aspect}} must refer to a single copyable aspect of
+                        |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}.
                         See [[#depth-formats|depth-formats]].
                 - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
-                - |source|.{{GPUTextureDataLayout/offset}} is a multiple of the [=texel block size=]
-                    of |destination|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}}.
+                - |source|.{{GPUImageDataLayout/offset}} is a multiple of the [=texel block size=]
+                    of |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}.
                 - [$validating linear texture data$](|source|,
-                    |source|.{{GPUBufferCopyLocation/buffer}}.{{GPUBuffer/[[size]]}},
-                    |destination|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}},
+                    |source|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[size]]}},
+                    |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}},
                     |copySize|) succeeds.
             </div>
         </div>
@@ -5043,23 +5043,23 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
             If any of the following conditions are unsatisfied, generate a validation error and stop.
             <div class=validusage>
                 - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
-                - [$validating GPUTextureCopyLocation$](|source|, |copySize|) returns `true`.
-                - |source|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[textureUsage]]}} contains
+                - [$validating GPUImageCopyTexture$](|source|, |copySize|) returns `true`.
+                - |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[textureUsage]]}} contains
                     {{GPUTextureUsage/COPY_SRC}}.
-                - |source|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[sampleCount]]}} is 1.
-                - If |source|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format:
-                    - |source|.{{GPUTextureCopyLocation/aspect}} must refer to a single copyable aspect of
-                        |source|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}}.
+                - |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[sampleCount]]}} is 1.
+                - If |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format:
+                    - |source|.{{GPUImageCopyTexture/aspect}} must refer to a single copyable aspect of
+                        |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}.
                         See [[#depth-formats|depth-formats]].
-                - [$validating GPUBufferCopyLocation$](|destination|) returns `true`.
-                - |destination|.{{GPUBufferCopyLocation/buffer}}.{{GPUBuffer/[[usage]]}} contains
+                - [$validating GPUImageCopyBuffer$](|destination|) returns `true`.
+                - |destination|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[usage]]}} contains
                     {{GPUBufferUsage/COPY_DST}}.
                 - [=Valid Texture Copy Range=] applies to |source| and |copySize|.
-                - |destination|.{{GPUTextureDataLayout/offset}} is a multiple of the [=texel block size=]
-                    of |destination|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}}.
+                - |destination|.{{GPUImageDataLayout/offset}} is a multiple of the [=texel block size=]
+                    of |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}.
                 - [$validating linear texture data$](|destination|,
-                    |destination|.{{GPUBufferCopyLocation/buffer}}.{{GPUBuffer/[[size]]}},
-                    |source|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}},
+                    |destination|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[size]]}},
+                    |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}},
                     |copySize|) succeeds.
             </div>
         </div>
@@ -5085,20 +5085,20 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
             1. If any of the following conditions are unsatisfied, generate a validation error and stop.
                 <div class=validusage>
                     - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
-                    - [$validating GPUTextureCopyLocation$](|source|, |copySize|) returns `true`.
-                    - |source|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[textureUsage]]}} contains
+                    - [$validating GPUImageCopyTexture$](|source|, |copySize|) returns `true`.
+                    - |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[textureUsage]]}} contains
                         {{GPUTextureUsage/COPY_SRC}}.
-                    - [$validating GPUTextureCopyLocation$](|destination|, |copySize|) returns `true`.
-                    - |destination|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[textureUsage]]}} contains
+                    - [$validating GPUImageCopyTexture$](|destination|, |copySize|) returns `true`.
+                    - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[textureUsage]]}} contains
                         {{GPUTextureUsage/COPY_DST}}.
-                    - |source|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[sampleCount]]}} is equal to |destination|.
-                        {{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[sampleCount]]}}.
-                    - |source|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}} is equal to |destination|.
-                        {{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}}.
-                    - If |source|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format:
-                        - |source|.{{GPUTextureCopyLocation/aspect}} and |destination|.{{GPUTextureCopyLocation/aspect}}
-                            must both refer to all aspects of |source|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}}
-                            and |destination|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}}, respectively.
+                    - |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[sampleCount]]}} is equal to |destination|.
+                        {{GPUImageCopyTexture/texture}}.{{GPUTexture/[[sampleCount]]}}.
+                    - |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}} is equal to |destination|.
+                        {{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}.
+                    - If |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format:
+                        - |source|.{{GPUImageCopyTexture/aspect}} and |destination|.{{GPUImageCopyTexture/aspect}}
+                            must both refer to all aspects of |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}
+                            and |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}, respectively.
                     - [=Valid Texture Copy Range=] applies to |source| and |copySize|.
                     - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
                     - The [$set of subresources for texture copy$](|source|, |copySize|) and
@@ -5108,19 +5108,19 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
 </dl>
 
 <div algorithm>
-    The <dfn abstract-op>set of subresources for texture copy</dfn>(|textureCopyLocation|, |copySize|)
+    The <dfn abstract-op>set of subresources for texture copy</dfn>(|imageCopyTexture|, |copySize|)
     is the set containing:
 
-      - If |textureCopyLocation|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[dimension]]}}
+      - If |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[dimension]]}}
         is {{GPUTextureDimension/"2d"}}:
           - For each |arrayLayer| of the |copySize|.[=Extent3D/depth=] [=array layers=]
-            starting at |textureCopyLocation|.{{GPUTextureCopyLocation/origin}}.[=Origin3D/z=]:
-              - The [=subresource=] of |textureCopyLocation|.{{GPUTextureCopyLocation/texture}} at
-                [=mipmap level=] |textureCopyLocation|.{{GPUTextureCopyLocation/mipLevel}} and
+            starting at |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/z=]:
+              - The [=subresource=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}} at
+                [=mipmap level=] |imageCopyTexture|.{{GPUImageCopyTexture/mipLevel}} and
                 [=array layer=] |arrayLayer|.
       - Otherwise:
-          - The [=subresource=] of |textureCopyLocation|.{{GPUTextureCopyLocation/texture}} at
-            [=mipmap level=] |textureCopyLocation|.{{GPUTextureCopyLocation/mipLevel}}.
+          - The [=subresource=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}} at
+            [=mipmap level=] |imageCopyTexture|.{{GPUImageCopyTexture/mipLevel}}.
 </div>
 
 ## Debug Markers ## {#command-encoder-debug-markers}
@@ -6692,14 +6692,14 @@ interface GPUQueue {
         optional GPUSize64 size);
 
     undefined writeTexture(
-      GPUTextureCopyLocation destination,
+      GPUImageCopyTexture destination,
       [AllowShared] BufferSource data,
-      GPUTextureDataLayout dataLayout,
+      GPUImageDataLayout dataLayout,
       GPUExtent3D size);
 
     undefined copyImageBitmapToTexture(
-        GPUImageBitmapCopyLocation source,
-        GPUTextureCopyLocation destination,
+        GPUImageCopyImageBitmap source,
+        GPUImageCopyTexture destination,
         GPUExtent3D copySize);
 };
 GPUQueue includes GPUObjectBase;
@@ -6785,7 +6785,7 @@ GPUQueue includes GPUObjectBase;
                 <div class=validusage>
                     - [$validating linear texture data$](|dataLayout|,
                         |dataByteSize|,
-                        |destination|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}},
+                        |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}},
                         |size|) succeeds.
                 </div>
             1. Let |contents| be the contents of the [=images=] seen by
@@ -6797,20 +6797,20 @@ GPUQueue includes GPUObjectBase;
                     1. If any of the following conditions are unsatisfied,
                         generate a validation error and stop.
                         <div class=validusage>
-                            - [$validating GPUTextureCopyLocation$](|destination|, |size|) returns `true`.
-                            - |destination|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[textureUsage]]}}
+                            - [$validating GPUImageCopyTexture$](|destination|, |size|) returns `true`.
+                            - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[textureUsage]]}}
                                 includes {{GPUTextureUsage/COPY_DST}}.
-                            - |destination|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[sampleCount]]}} is 1.
+                            - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[sampleCount]]}} is 1.
                             - [=Valid Texture Copy Range=](|destination|, |size|)
                                 is satisfied.
-                            - |destination|.{{GPUTextureCopyLocation/aspect}} refers to a single copyable aspect
-                                of |destination|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}}.
+                            - |destination|.{{GPUImageCopyTexture/aspect}} refers to a single copyable aspect
+                                of |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}.
                                 See [[#depth-formats|depth-formats]].
 
                             Note: unlike
                             {{GPUCommandEncoder}}.{{GPUCommandEncoder/copyBufferToTexture()}},
                             there is no alignment requirement on
-                            |dataLayout|.{{GPUTextureDataLayout/bytesPerRow}}.
+                            |dataLayout|.{{GPUImageDataLayout/bytesPerRow}}.
                         </div>
                     1. Write |contents| into |destination|.
 
@@ -6837,8 +6837,8 @@ GPUQueue includes GPUObjectBase;
             If any of the following conditions are unsatisfied, throw an {{OperationError}} and stop.
             <div class=validusage>
                 - |copySize|.[=Extent3D/depth=] is `1`.
-                - |destination|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[dimension]]}} is {{GPUTextureDimension/"2d"}}.
-                - |destination|.{{GPUTextureCopyLocation/texture}}.{{GPUTexture/[[format]]}} is one of the following:
+                - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[dimension]]}} is {{GPUTextureDimension/"2d"}}.
+                - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}} is one of the following:
                     - {{GPUTextureFormat/"rgba8unorm"}}
                     - {{GPUTextureFormat/"rgba8unorm-srgb"}}
                     - {{GPUTextureFormat/"bgra8unorm"}}


### PR DESCRIPTION
After receiving feedback that the naming of `GPUTextureView` objects and `GPUTextureCopyView` dictionaries caused some confusion and conflation between the two concepts, renaming the dictionaries to ensure that they are clearly seen as different concepts.

The original suggestion on the editors call was `*CopyRegion` but on looking through Vulkan/D3D12 it appears that the term "region" in those APIs refers to both an origin and extent (as I would have expected.) Since these dictionaries only define the origins/layout of the data in question "region" didn't feel appropriate, so I went with the term "location" instead (taking inspiration from the [D3D_TEXTURE_COPY_LOCATION structure](https://docs.microsoft.com/en-us/windows/win32/api/d3d12/ns-d3d12-d3d12_texture_copy_location)) Given that these structures primarily point at origins/layers that felt accurate, and the only place it's really questionable is regarding the buffer `bytesPerRow` and `rowsPerImage`, which are more about the data layout than the origin. I'm more than happy to change that if there's any concerns though.

It's important to note that because these are dictionaries API users will _never type these names_, and as such renaming should be seen as purely an improvement in API clarity and self documentation.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/toji/gpuweb/pull/1375.html" title="Last updated on Feb 1, 2021, 11:05 PM UTC (de8c34a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1375/81023e2...toji:de8c34a.html" title="Last updated on Feb 1, 2021, 11:05 PM UTC (de8c34a)">Diff</a>