### PR TITLE
[wgsl] Fix type constructor matching in primary_expression

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2880,8 +2880,8 @@ TODO: *Stub*: how to write each of the abstract pointer operations
 
 <pre class='def'>
 primary_expression
-  : IDENT argument_expression_list?
-  | type_decl argument_expression_list
+  : type_decl argument_expression_list
+  | IDENT argument_expression_list?
   | const_literal
   | paren_rhs_statement
   | BITCAST LESS_THAN type_decl GREATER_THAN paren_rhs_statement


### PR DESCRIPTION
This makes sure that a struct constructor is matched properly.