### PR TITLE
Fix example shader in 8.2 Entry Point Declaration

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3544,15 +3544,16 @@ and its return type must be [=void=].
 <div class='example wgsl global-scope' heading='Entry Point'>
   <xmp>
     [[builtin(position)]]   var<out> gl_Position  : vec4<f32>;
-    [[builtin(frag_coord)]] var<out> gl_FragColor : vec4<f32>;
+    [[builtin(frag_coord)]] var<in> coord_in : vec4<f32>;
+    [[location(0)]] var<out> color : vec4<f32>;
 
     [[stage(vertex)]]
     fn vtx_main() -> void { gl_Position = vec4<f32>(); }
        // OpEntryPoint Vertex %vtx_main "vtx_main" %gl_Position
 
     [[stage(fragment)]]
-    fn frag_main() -> void { gl_FragColor = vec4<f32>(); }
-       // OpEntryPoint Fragment %frag_main "frag_main" %gl_FragColor
+    fn frag_main() -> void { color = vec4<f32>(coord_in.x, coord_in.y, 0.0, 1.0); }
+       // OpEntryPoint Fragment %frag_main "frag_main" %color %coord_in
 
     [[stage(compute)]]
     fn main() -> void { }


### PR DESCRIPTION
- frag_coord is a fragment input variable.
- Colour output is to a user variable at output location 0, in this example.