### PR TITLE
Remove obsolete note about matrix layout

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -762,9 +762,6 @@ These layouts depend on the value's type, the storage class of the buffer,
 the [=stride=] attribute on array types, and the [=offset=] attribute on structure type
 members.
 
-Note: Matrix values are laid out more compactly in the [=storage classes/storage=] storage class
-than in the [=storage classes/uniform=] storage class.
-
 A type can be used for values in both [=storage classes/uniform=] and [=storage classes/storage=] storage classes.
 This is valid as long as the layout constraints are satisifed for both storage classes.
 The data will appear identically in both storage classes, except for the case of matrices noted above.


### PR DESCRIPTION
This should have been removed as part of #1341 when we changed
matrix layout to be consistent across uniform and storage storage
classes.