### PR TITLE
Add GPULoadOp "zero"

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3915,7 +3915,7 @@ configuring each of the [=render stages=].
         1. Assemble primitives.
             For each instance, the primitives get assembled from the vertices that have been
             processed by the shaders, based on the |vertexList|.
-          
+
             1. First, if |descriptor|.{{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/stripIndexFormat}} is not `null`
                 (which means the primitive topology is a strip), and the |drawCall| is indexed,
                 the |vertexList| is split into sub-lists
@@ -6095,10 +6095,16 @@ dictionary GPURenderPassColorAttachment {
 
     : <dfn>loadValue</dfn>
     ::
-        If a {{GPULoadOp}}, indicates the load operation to perform on
-        {{GPURenderPassColorAttachment/view}} prior to executing the render pass.
-        If a {{GPUColor}}, indicates the value to clear {{GPURenderPassColorAttachment/view}}
-        to prior to executing the render pass.
+        If {{GPULoadOp/"load"}}, indicates that {{GPURenderPassColorAttachment/view}}'s
+        contents should be preserved prior to executing the render pass, and
+        loaded from memory into the render pass.
+
+        Otherwise, indicates that {{GPURenderPassColorAttachment/view}}'s
+        contents should be discarded prior to executing the render pass, and
+        another value should be loaded into the render pass instead:
+
+        - If {{GPULoadOp/"zero"}}, zero (`{ r: 0, g: 0, b: 0, a: 0 }`).
+        - If a {{GPUColor}} value, that value.
 
     : <dfn>storeOp</dfn>
     ::
@@ -6157,11 +6163,16 @@ dictionary GPURenderPassDepthStencilAttachment {
 
     : <dfn>depthLoadValue</dfn>
     ::
-        If a {{GPULoadOp}}, indicates the load operation to perform on
-        {{GPURenderPassDepthStencilAttachment/view}}'s depth component prior to
-        executing the render pass.
-        If a `float`, indicates the value to clear {{GPURenderPassDepthStencilAttachment/view}}'s
-        depth component to prior to executing the render pass.
+        If {{GPULoadOp/"load"}}, indicates that {{GPURenderPassDepthStencilAttachment/view}}'s
+        depth aspect contents should be preserved prior to executing the render pass,
+        and loaded from memory into the render pass.
+
+        Otherwise, indicates that {{GPURenderPassDepthStencilAttachment/view}}'s
+        depth aspect contents should be discarded prior to executing the render pass, and
+        another value should be loaded into the render pass instead:
+
+        - If {{GPULoadOp/"zero"}}, zero.
+        - If a `float` value, that value.
 
     : <dfn>depthStoreOp</dfn>
     ::
@@ -6175,12 +6186,16 @@ dictionary GPURenderPassDepthStencilAttachment {
 
     : <dfn>stencilLoadValue</dfn>
     ::
-        If a {{GPULoadOp}}, indicates the load operation to perform on
-        {{GPURenderPassDepthStencilAttachment/view}}'s stencil component prior to
-        executing the render pass.
-        If a {{GPUStencilValue}}, indicates the value to clear
-        {{GPURenderPassDepthStencilAttachment/view}}'s stencil component to prior to
-        executing the render pass.
+        If {{GPULoadOp/"load"}}, indicates that {{GPURenderPassDepthStencilAttachment/view}}'s
+        stencil aspect contents should be preserved prior to executing the render pass,
+        and loaded from memory into the render pass.
+
+        Otherwise, indicates that {{GPURenderPassDepthStencilAttachment/view}}'s
+        stencil aspect contents should be discarded prior to executing the render pass, and
+        another value should be loaded into the render pass instead:
+
+        - If {{GPULoadOp/"zero"}}, zero.
+        - If a {{GPUStencilValue}} value, that value.
 
     : <dfn>stencilStoreOp</dfn>
     ::
@@ -6221,14 +6236,15 @@ dictionary GPURenderPassDepthStencilAttachment {
 
 <script type=idl>
 enum GPULoadOp {
-    "load"
+    "load",
+    "zero",
 };
 </script>
 
 <script type=idl>
 enum GPUStoreOp {
     "store",
-    "clear"
+    "clear",
 };
 </script>
 


### PR DESCRIPTION
Fixes #1377.

Note the inconsistency with GPUStoreOp. I think this is OK, but maybe it's not ideal.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1389.html" title="Last updated on Jan 29, 2021, 11:00 PM UTC (66d94cc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1389/3cbd94a...kainino0x:66d94cc.html" title="Last updated on Jan 29, 2021, 11:00 PM UTC (66d94cc)">Diff</a>