### PR TITLE
Rename GPUExtent3DDict.depth to .depthOrArrayLayers

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -999,13 +999,13 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
     <tr><td><dfn>maxTextureDimension3D</dfn>
         <td>{{GPUSize32}} <td>Higher <td>2048
     <tr class=row-continuation><td colspan=4>
-        The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=Extent3D/width=], {{GPUTextureDescriptor/size}}.[=Extent3D/height=] and {{GPUTextureDescriptor/size}}.[=Extent3D/depthOrLayers=]
+        The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=Extent3D/width=], {{GPUTextureDescriptor/size}}.[=Extent3D/height=] and {{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=]
         of a [=texture=] created with {{GPUTextureDescriptor/dimension}} {{GPUTextureDimension/"3d"}}.
 
     <tr><td><dfn>maxTextureArrayLayers</dfn>
         <td>{{GPUSize32}} <td>Higher <td>2048
     <tr class=row-continuation><td colspan=4>
-        The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=Extent3D/depthOrLayers=]
+        The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=]
         of a [=texture=] created with {{GPUTextureDescriptor/dimension}} {{GPUTextureDimension/"1d"}} or {{GPUTextureDimension/"2d"}}.
 
     <tr><td><dfn>maxBindGroups</dfn>
@@ -2171,7 +2171,7 @@ internal slots of a [=texture=] internal object once we have one.
       - If |texture|.{{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"1d"}},
         defaults to {{GPUTextureViewDimension/"1d"}}.
       - If |texture|.{{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"2d"}}:
-          - If |texture|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrLayers=] is greater than 1
+          - If |texture|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] is greater than 1
             and {{GPUTextureViewDescriptor/arrayLayerCount}} is 0,
             defaults to {{GPUTextureViewDimension/"2d-array"}}.
           - Otherwise, defaults to {{GPUTextureViewDimension/"2d"}}.
@@ -2182,7 +2182,7 @@ internal slots of a [=texture=] internal object once we have one.
     If undefined, defaults to |texture|.{{GPUTextureDescriptor/mipLevelCount}} &minus; {{GPUTextureViewDescriptor/baseMipLevel}}.
 
   * {{GPUTextureViewDescriptor/arrayLayerCount}}:
-    If undefined, defaults to |texture|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrLayers=] &minus; {{GPUTextureViewDescriptor/baseArrayLayer}}.
+    If undefined, defaults to |texture|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] &minus; {{GPUTextureViewDescriptor/baseArrayLayer}}.
 
 </div>
 
@@ -5028,7 +5028,7 @@ and {{GPUCommandEncoder/copyTextureToBuffer()}}.
 
   The [=textureCopyView subresource size=] of |textureCopyView| is calculated as follows:
 
-  Its [=Extent3D/width=], [=Extent3D/height=] and [=Extent3D/depthOrLayers=] are the width, height, and depth, respectively,
+  Its [=Extent3D/width=], [=Extent3D/height=] and [=Extent3D/depthOrArrayLayers=] are the width, height, and depth, respectively,
   of the [=physical size=] of |textureCopyView|.{{GPUTextureCopyView/texture}} [=subresource=] at [=mipmap level=]
   |textureCopyView|.{{GPUTextureCopyView/mipLevel}}.
 
@@ -5063,7 +5063,7 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
         <div class=validusage>
             - If |heightInBlocks| &gt; 1,
                 |layout|.{{GPUTextureDataLayout/bytesPerRow}} must be specified.
-            - If |copyExtent|.[=Extent3D/depthOrLayers=] &gt; 1,
+            - If |copyExtent|.[=Extent3D/depthOrArrayLayers=] &gt; 1,
                 |layout|.{{GPUTextureDataLayout/bytesPerRow}} and
                 |layout|.{{GPUTextureDataLayout/rowsPerImage}} must be specified.
             - If specified, |layout|.{{GPUTextureDataLayout/bytesPerRow}}
@@ -5074,15 +5074,15 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
 
     1. Let |requiredBytesInCopy| be 0.
 
-    1. If |copyExtent|.[=Extent3D/depthOrLayers=] &gt; 1:
+    1. If |copyExtent|.[=Extent3D/depthOrArrayLayers=] &gt; 1:
         1. Let |bytesPerImage| be
             |layout|.{{GPUTextureDataLayout/bytesPerRow}} &times;
             |layout|.{{GPUTextureDataLayout/rowsPerImage}}.
         1. Let |bytesBeforeLastImage| be
-            |bytesPerImage| &times; (|copyExtent|.[=Extent3D/depthOrLayers=] &minus; 1).
+            |bytesPerImage| &times; (|copyExtent|.[=Extent3D/depthOrArrayLayers=] &minus; 1).
         1. Add |bytesBeforeLastImage| to |requiredBytesInCopy|.
 
-    1. If |copyExtent|.[=Extent3D/depthOrLayers=] &gt; 0:
+    1. If |copyExtent|.[=Extent3D/depthOrArrayLayers=] &gt; 0:
 
         1. If |heightInBlocks| &gt; 1, add
             |layout|.{{GPUTextureDataLayout/bytesPerRow}} &times;
@@ -5110,14 +5110,14 @@ The following validation rules apply:
 
   - If the {{GPUTexture/[[dimension]]}} of |textureCopyView|.{{GPUTextureCopyView/texture}} is
     {{GPUTextureDimension/1d}}:
-    - Both |copySize|.[=Extent3D/height=] and [=Extent3D/depthOrLayers=] must be 1.
+    - Both |copySize|.[=Extent3D/height=] and [=Extent3D/depthOrArrayLayers=] must be 1.
   - If the {{GPUTexture/[[dimension]]}} of |textureCopyView|.{{GPUTextureCopyView/texture}} is
     {{GPUTextureDimension/2d}}:
      -  (|textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/x=] + |copySize|.[=Extent3D/width=]),
         (|textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/y=] + |copySize|.[=Extent3D/height=]), and
-        (|textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/z=] + |copySize|.[=Extent3D/depthOrLayers=])
+        (|textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/z=] + |copySize|.[=Extent3D/depthOrArrayLayers=])
         must be less than or equal to the
-        [=Extent3D/width=], [=Extent3D/height=], and [=Extent3D/depthOrLayers=], respectively,
+        [=Extent3D/width=], [=Extent3D/height=], and [=Extent3D/depthOrArrayLayers=], respectively,
         of the [=textureCopyView subresource size=] of |textureCopyView|.
   - |copySize|.[=Extent3D/width=] must be a multiple of |blockWidth|.
   - |copySize|.[=Extent3D/height=] must be a multiple of |blockHeight|.
@@ -5266,7 +5266,7 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
 
       - If |textureCopyView|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[dimension]]}}
         is {{GPUTextureDimension/"2d"}}:
-          - For each |arrayLayer| of the |copySize|.[=Extent3D/depthOrLayers=] [=array layers=]
+          - For each |arrayLayer| of the |copySize|.[=Extent3D/depthOrArrayLayers=] [=array layers=]
             starting at |textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/z=]:
               - The [=subresource=] of |textureCopyView|.{{GPUTextureCopyView/texture}} at
                 [=mipmap level=] |textureCopyView|.{{GPUTextureCopyView/mipLevel}} and
@@ -6990,7 +6990,7 @@ GPUQueue includes GPUObjectBase;
 
             If any of the following conditions are unsatisfied, throw an {{OperationError}} and stop.
             <div class=validusage>
-                - |copySize|.[=Extent3D/depthOrLayers=] is `1`.
+                - |copySize|.[=Extent3D/depthOrArrayLayers=] is `1`.
                 - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[dimension]]}} is {{GPUTextureDimension/"2d"}}.
                 - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} is one of the following:
                     - {{GPUTextureFormat/"rgba8unorm"}}
@@ -7474,16 +7474,10 @@ An <dfn dfn>Origin3D</dfn> is a {{GPUOrigin3D}}.
 dictionary GPUExtent3DDict {
     GPUIntegerCoordinate width = 1;
     GPUIntegerCoordinate height = 1;
-    GPUIntegerCoordinate depthOrLayers = 1;
-    undefined depth;
+    GPUIntegerCoordinate depthOrArrayLayers = 1;
 };
 typedef (sequence<GPUIntegerCoordinate> or GPUExtent3DDict) GPUExtent3D;
 </script>
-
-Note: The presence of {{GPUExtent3DDict/width}} and {{GPUExtent3DDict/height}}
-implies the presence of a "depth" member. However, due to the rules of WebIDL,
-if an unrecognized member is provided, it is ignored completely.
-`undefined depth;` ensures users don't accidentally use the wrong name.
 
 An <dfn dfn>Extent3D</dfn> is a {{GPUExtent3D}}.
 [=Extent3D=] is a spec namespace for the following definitions:
@@ -7498,8 +7492,8 @@ An <dfn dfn>Extent3D</dfn> is a {{GPUExtent3D}}.
       - |extent|.<dfn dfn>height</dfn> refers to
         either {{GPUExtent3DDict}}.{{GPUExtent3DDict/height}}
         or the second item of the sequence (1 if not present).
-      - |extent|.<dfn dfn>depthOrLayers</dfn> refers to
-        either {{GPUExtent3DDict}}.{{GPUExtent3DDict/depthOrLayers}}
+      - |extent|.<dfn dfn>depthOrArrayLayers</dfn> refers to
+        either {{GPUExtent3DDict}}.{{GPUExtent3DDict/depthOrArrayLayers}}
         or the third item of the sequence (1 if not present).
 </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7563,13 +7563,13 @@ An <dfn dfn>Extent3D</dfn> is a {{GPUExtent3D}}.
 
       - |extent|.<dfn dfn>width</dfn> refers to
         either {{GPUExtent3DDict}}.{{GPUExtent3DDict/width}}
-        or the first item of the sequence or 1 if it isn't present.
+        or the first item of the sequence (1 if not present).
       - |extent|.<dfn dfn>height</dfn> refers to
         either {{GPUExtent3DDict}}.{{GPUExtent3DDict/height}}
-        or the second item of the sequence or 1 if it isn't present.
+        or the second item of the sequence (1 if not present).
       - |extent|.<dfn dfn>depthOrArrayLayers</dfn> refers to
         either {{GPUExtent3DDict}}.{{GPUExtent3DDict/depthOrArrayLayers}}
-        or the third item of the sequence or 1 if it isn't present.
+        or the third item of the sequence (1 if not present).
 </div>
 
 # Feature Index # {#feature-index}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -999,13 +999,13 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
     <tr><td><dfn>maxTextureDimension3D</dfn>
         <td>{{GPUSize32}} <td>Higher <td>2048
     <tr class=row-continuation><td colspan=4>
-        The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=Extent3D/width=], {{GPUTextureDescriptor/size}}.[=Extent3D/height=] and {{GPUTextureDescriptor/size}}.[=Extent3D/depth=]
+        The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=Extent3D/width=], {{GPUTextureDescriptor/size}}.[=Extent3D/height=] and {{GPUTextureDescriptor/size}}.[=Extent3D/depthOrLayers=]
         of a [=texture=] created with {{GPUTextureDescriptor/dimension}} {{GPUTextureDimension/"3d"}}.
 
     <tr><td><dfn>maxTextureArrayLayers</dfn>
         <td>{{GPUSize32}} <td>Higher <td>2048
     <tr class=row-continuation><td colspan=4>
-        The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=Extent3D/depth=]
+        The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=Extent3D/depthOrLayers=]
         of a [=texture=] created with {{GPUTextureDescriptor/dimension}} {{GPUTextureDimension/"1d"}} or {{GPUTextureDimension/"2d"}}.
 
     <tr><td><dfn>maxBindGroups</dfn>
@@ -2171,7 +2171,7 @@ internal slots of a [=texture=] internal object once we have one.
       - If |texture|.{{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"1d"}},
         defaults to {{GPUTextureViewDimension/"1d"}}.
       - If |texture|.{{GPUTextureDescriptor/dimension}} is {{GPUTextureDimension/"2d"}}:
-          - If |texture|.{{GPUTextureDescriptor/size}}.[=Extent3D/depth=] is greater than 1
+          - If |texture|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrLayers=] is greater than 1
             and {{GPUTextureViewDescriptor/arrayLayerCount}} is 0,
             defaults to {{GPUTextureViewDimension/"2d-array"}}.
           - Otherwise, defaults to {{GPUTextureViewDimension/"2d"}}.
@@ -2182,7 +2182,7 @@ internal slots of a [=texture=] internal object once we have one.
     If undefined, defaults to |texture|.{{GPUTextureDescriptor/mipLevelCount}} &minus; {{GPUTextureViewDescriptor/baseMipLevel}}.
 
   * {{GPUTextureViewDescriptor/arrayLayerCount}}:
-    If undefined, defaults to |texture|.{{GPUTextureDescriptor/size}}.[=Extent3D/depth=] &minus; {{GPUTextureViewDescriptor/baseArrayLayer}}.
+    If undefined, defaults to |texture|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrLayers=] &minus; {{GPUTextureViewDescriptor/baseArrayLayer}}.
 
 </div>
 
@@ -3915,7 +3915,7 @@ configuring each of the [=render stages=].
         1. Assemble primitives.
             For each instance, the primitives get assembled from the vertices that have been
             processed by the shaders, based on the |vertexList|.
-          
+
             1. First, if |descriptor|.{{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/stripIndexFormat}} is not `null`
                 (which means the primitive topology is a strip), and the |drawCall| is indexed,
                 the |vertexList| is split into sub-lists
@@ -5028,7 +5028,7 @@ and {{GPUCommandEncoder/copyTextureToBuffer()}}.
 
   The [=textureCopyView subresource size=] of |textureCopyView| is calculated as follows:
 
-  Its [=Extent3D/width=], [=Extent3D/height=] and [=Extent3D/depth=] are the width, height, and depth, respectively,
+  Its [=Extent3D/width=], [=Extent3D/height=] and [=Extent3D/depthOrLayers=] are the width, height, and depth, respectively,
   of the [=physical size=] of |textureCopyView|.{{GPUTextureCopyView/texture}} [=subresource=] at [=mipmap level=]
   |textureCopyView|.{{GPUTextureCopyView/mipLevel}}.
 
@@ -5063,7 +5063,7 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
         <div class=validusage>
             - If |heightInBlocks| &gt; 1,
                 |layout|.{{GPUTextureDataLayout/bytesPerRow}} must be specified.
-            - If |copyExtent|.[=Extent3D/depth=] &gt; 1,
+            - If |copyExtent|.[=Extent3D/depthOrLayers=] &gt; 1,
                 |layout|.{{GPUTextureDataLayout/bytesPerRow}} and
                 |layout|.{{GPUTextureDataLayout/rowsPerImage}} must be specified.
             - If specified, |layout|.{{GPUTextureDataLayout/bytesPerRow}}
@@ -5074,15 +5074,15 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
 
     1. Let |requiredBytesInCopy| be 0.
 
-    1. If |copyExtent|.[=Extent3D/depth=] &gt; 1:
+    1. If |copyExtent|.[=Extent3D/depthOrLayers=] &gt; 1:
         1. Let |bytesPerImage| be
             |layout|.{{GPUTextureDataLayout/bytesPerRow}} &times;
             |layout|.{{GPUTextureDataLayout/rowsPerImage}}.
         1. Let |bytesBeforeLastImage| be
-            |bytesPerImage| &times; (|copyExtent|.[=Extent3D/depth=] &minus; 1).
+            |bytesPerImage| &times; (|copyExtent|.[=Extent3D/depthOrLayers=] &minus; 1).
         1. Add |bytesBeforeLastImage| to |requiredBytesInCopy|.
 
-    1. If |copyExtent|.[=Extent3D/depth=] &gt; 0:
+    1. If |copyExtent|.[=Extent3D/depthOrLayers=] &gt; 0:
 
         1. If |heightInBlocks| &gt; 1, add
             |layout|.{{GPUTextureDataLayout/bytesPerRow}} &times;
@@ -5110,14 +5110,14 @@ The following validation rules apply:
 
   - If the {{GPUTexture/[[dimension]]}} of |textureCopyView|.{{GPUTextureCopyView/texture}} is
     {{GPUTextureDimension/1d}}:
-    - Both |copySize|.[=Extent3D/height=] and [=Extent3D/depth=] must be 1.
+    - Both |copySize|.[=Extent3D/height=] and [=Extent3D/depthOrLayers=] must be 1.
   - If the {{GPUTexture/[[dimension]]}} of |textureCopyView|.{{GPUTextureCopyView/texture}} is
     {{GPUTextureDimension/2d}}:
      -  (|textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/x=] + |copySize|.[=Extent3D/width=]),
         (|textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/y=] + |copySize|.[=Extent3D/height=]), and
-        (|textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/z=] + |copySize|.[=Extent3D/depth=])
+        (|textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/z=] + |copySize|.[=Extent3D/depthOrLayers=])
         must be less than or equal to the
-        [=Extent3D/width=], [=Extent3D/height=], and [=Extent3D/depth=], respectively,
+        [=Extent3D/width=], [=Extent3D/height=], and [=Extent3D/depthOrLayers=], respectively,
         of the [=textureCopyView subresource size=] of |textureCopyView|.
   - |copySize|.[=Extent3D/width=] must be a multiple of |blockWidth|.
   - |copySize|.[=Extent3D/height=] must be a multiple of |blockHeight|.
@@ -5266,7 +5266,7 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
 
       - If |textureCopyView|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[dimension]]}}
         is {{GPUTextureDimension/"2d"}}:
-          - For each |arrayLayer| of the |copySize|.[=Extent3D/depth=] [=array layers=]
+          - For each |arrayLayer| of the |copySize|.[=Extent3D/depthOrLayers=] [=array layers=]
             starting at |textureCopyView|.{{GPUTextureCopyView/origin}}.[=Origin3D/z=]:
               - The [=subresource=] of |textureCopyView|.{{GPUTextureCopyView/texture}} at
                 [=mipmap level=] |textureCopyView|.{{GPUTextureCopyView/mipLevel}} and
@@ -6990,7 +6990,7 @@ GPUQueue includes GPUObjectBase;
 
             If any of the following conditions are unsatisfied, throw an {{OperationError}} and stop.
             <div class=validusage>
-                - |copySize|.[=Extent3D/depth=] is `1`.
+                - |copySize|.[=Extent3D/depthOrLayers=] is `1`.
                 - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[dimension]]}} is {{GPUTextureDimension/"2d"}}.
                 - |destination|.{{GPUTextureCopyView/texture}}.{{GPUTexture/[[format]]}} is one of the following:
                     - {{GPUTextureFormat/"rgba8unorm"}}
@@ -7474,10 +7474,16 @@ An <dfn dfn>Origin3D</dfn> is a {{GPUOrigin3D}}.
 dictionary GPUExtent3DDict {
     GPUIntegerCoordinate width = 1;
     GPUIntegerCoordinate height = 1;
-    GPUIntegerCoordinate depth = 1;
+    GPUIntegerCoordinate depthOrLayers = 1;
+    undefined depth;
 };
 typedef (sequence<GPUIntegerCoordinate> or GPUExtent3DDict) GPUExtent3D;
 </script>
+
+Note: The presence of {{GPUExtent3DDict/width}} and {{GPUExtent3DDict/height}}
+implies the presence of a "depth" member. However, due to the rules of WebIDL,
+if an unrecognized member is provided, it is ignored completely.
+`undefined depth;` ensures users don't accidentally use the wrong name.
 
 An <dfn dfn>Extent3D</dfn> is a {{GPUExtent3D}}.
 [=Extent3D=] is a spec namespace for the following definitions:
@@ -7488,13 +7494,13 @@ An <dfn dfn>Extent3D</dfn> is a {{GPUExtent3D}}.
 
       - |extent|.<dfn dfn>width</dfn> refers to
         either {{GPUExtent3DDict}}.{{GPUExtent3DDict/width}}
-        or the first item of the sequence or 1 if it isn't present.
+        or the first item of the sequence (1 if not present).
       - |extent|.<dfn dfn>height</dfn> refers to
         either {{GPUExtent3DDict}}.{{GPUExtent3DDict/height}}
-        or the second item of the sequence or 1 if it isn't present.
-      - |extent|.<dfn dfn>depth</dfn> refers to
-        either {{GPUExtent3DDict}}.{{GPUExtent3DDict/depth}}
-        or the third item of the sequence or 1 if it isn't present.
+        or the second item of the sequence (1 if not present).
+      - |extent|.<dfn dfn>depthOrLayers</dfn> refers to
+        either {{GPUExtent3DDict}}.{{GPUExtent3DDict/depthOrLayers}}
+        or the third item of the sequence (1 if not present).
 </div>
 
 # Feature Index # {#feature-index}


### PR DESCRIPTION
Proposal.

Updates Extent3D as well, as it would be confusing if they didn't match.

Keeps a placeholder "depth" member with type undefined, to prevent accidental use of a silently-ignored dictionary entry.
Yes, this is weird, but WebIDL appears to allow it. If a browser implementation of WebIDL doesn't support it - Chromium's doesn't, unsurprisingly - it can be emulated by using another type (`int` or `any`, say) and then manually throwing a TypeError if the member is present.

See previous discussions:
https://github.com/gpuweb/gpuweb/issues/1372#issuecomment-768866675
https://github.com/gpuweb/gpuweb/pull/1081#issuecomment-696470308


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1390.html" title="Last updated on Feb 4, 2021, 5:59 AM UTC (09ced26)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1390/d305f2c...kainino0x:09ced26.html" title="Last updated on Feb 4, 2021, 5:59 AM UTC (09ced26)">Diff</a>