### PR TITLE
Fix "storage" restriction for VERTEX visible bindings

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2936,7 +2936,7 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                                 - If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/visibility}} includes
                                     {{GPUShaderStage/VERTEX}}:
                                     - The [$layout entry binding type$] of |bindingDescriptor| is not
-                                        {{GPUBufferBindingType/"read-only-storage"}} or {{GPUStorageTextureAccess/"write-only"}}.
+                                        {{GPUBufferBindingType/"storage"}} or {{GPUStorageTextureAccess/"write-only"}}.
 
                                 - If the |textureLayout| is not `undefined` and
                                     |textureLayout|.{{GPUTextureBindingLayout/multisampled}} is `true`:
@@ -3915,7 +3915,7 @@ configuring each of the [=render stages=].
         1. Assemble primitives.
             For each instance, the primitives get assembled from the vertices that have been
             processed by the shaders, based on the |vertexList|.
-          
+
             1. First, if |descriptor|.{{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/stripIndexFormat}} is not `null`
                 (which means the primitive topology is a strip), and the |drawCall| is indexed,
                 the |vertexList| is split into sub-lists


### PR DESCRIPTION
Fixes #1338


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/1399.html" title="Last updated on Feb 1, 2021, 10:01 PM UTC (5307a5b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1399/f39076a...5307a5b.html" title="Last updated on Feb 1, 2021, 10:01 PM UTC (5307a5b)">Diff</a>