### PR TITLE
Better describe how swap chains update the canvas

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7406,8 +7406,9 @@ GPUSwapChain includes GPUObjectBase;
 
         1. Let |texture| be |swapChain|.{{GPUSwapChain/[[currentTexture]]}}.
         1. If |texture| is `null`, stop.
-        1. Let |swapChain|.{{GPUSwapChain/[[currentTexture]]}} be `null`.
-        1. Ensure that all submissions have been flushed to |texture|.
+        1. Set |swapChain|.{{GPUSwapChain/[[currentTexture]]}} to `null`.
+        1. Ensure that all submitted work items (e.g. queue submissions) has
+            completed writing to |texture|.
         1. Update |swapChain|.{{GPUSwapChain/[[context]]}}.{{GPUCanvasContext/[[canvas]]}} with the
             contents of |texture|.
         1. Call {{GPUTexture/destroy()}} on |texture|.
@@ -7423,15 +7424,14 @@ GPUSwapChain includes GPUObjectBase;
         1. Let |canvas| be |swapChain|.{{GPUSwapChain/[[context]]}}.{{GPUCanvasContext/[[canvas]]}}.
         1. Let |device| be |swapChain|.{{GPUSwapChain/[[descriptor]]}}.{{GPUSwapChainDescriptor/device}}.
         1. Let |descriptor| be a new {{GPUTextureDescriptor}}.
-        1. Set |descriptor|.{{GPUTextureDescriptor/size}}.{{GPUExtent3DDict/width}} to |canvas|.width.
-        1. Set |descriptor|.{{GPUTextureDescriptor/size}}.{{GPUExtent3DDict/height}} to |canvas|.height.
+        1. Set |descriptor|.{{GPUTextureDescriptor/size}} to [|canvas|.width, |canvas|.height, 1].
         1. Set |descriptor|.{{GPUTextureDescriptor/format}} to
             |swapChain|.{{GPUSwapChain/[[descriptor]]}}.{{GPUSwapChainDescriptor/format}}.
         1. Set |descriptor|.{{GPUTextureDescriptor/usage}} to
             |swapChain|.{{GPUSwapChain/[[descriptor]]}}.{{GPUSwapChainDescriptor/usage}}.
         1. Let |texture| be a new {{GPUTexture}} created as if |device|.{{GPUDevice/createTexture()}}
             were called with |descriptor|.
-            <div class='note'>Note: If a previously presented texture from |swapChain| matches the required criteria,
+            <div class='note'>If a previously presented texture from |swapChain| matches the required criteria,
             its GPU memory may be re-used.</div>
         1. Ensure |texture| is cleared to `(0, 0, 0, 0)`.
         1. Return |texture|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7274,6 +7274,14 @@ interface GPUCanvasContext {
 };
 </script>
 
+{{GPUCanvasContext}} has the following internal slots:
+
+<dl dfn-type=attribute dfn-for="GPUCanvasContext">
+    : <dfn>\[[canvas]]</dfn> of type {{HTMLCanvasElement}}.
+    ::
+        The canvas this context was created from.
+</dl>
+
 {{GPUCanvasContext}} has the following methods:
 
 <dl dfn-type=method dfn-for=GPUCanvasContext>
@@ -7352,15 +7360,15 @@ GPUSwapChain includes GPUObjectBase;
 {{GPUSwapChain}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUSwapChain">
-    : <dfn>\[[format]]</dfn> of type {{GPUTextureFormat}}.
+    : <dfn>\[[context]]</dfn> of type {{GPUCanvasContext}}.
     ::
-        The format of the textures returned by this swap chain.
+        The context this swap chain was configured for.
 
-    : <dfn>\[[textureUsage]]</dfn> of type {{GPUTextureUsage}}.
+    : <dfn>\[[descriptor]]</dfn> of type {{GPUSwapChainDescriptor}}.
     ::
-        The usage of the textures returned by this swap chain.
+        The descriptor this swap chain was created with.
 
-    : <dfn>\[[dirty]]</dfn> of type {{boolean}}, initially `false`.
+    : <dfn>\[[dirty]]</dfn> of type {{boolean}}, initially `true`.
     ::
         Indicates if {{GPUSwapChain/[[currentTexture]]}} should be composited to the document
         during the next update.
@@ -7369,6 +7377,7 @@ GPUSwapChain includes GPUObjectBase;
     ::
         The current texture that will be returned by the swap chain when calling
         {{GPUSwapChain/getCurrentTexture()}}, and the next one to be composited to the document.
+        Initially set to the result of [$allocating a new swap chain texture$] for this swap chain.
 </dl>
 
 {{GPUSwapChain}} has the following methods:
@@ -7387,32 +7396,51 @@ GPUSwapChain includes GPUObjectBase;
             1. Set |this|.{{GPUSwapChain/[[dirty]]}} to `true`.
             1. Return |this|.{{GPUSwapChain/[[currentTexture]]}}.
         </div>
+
+        Note: Developers can expect that the same {{GPUTexture}} object will be returned by every
+        call to {{GPUSwapChain/getCurrentTexture()}} made within the same frame (i.e. between
+        invocations of [=Update the rendering=]).
 </dl>
 
 <div algorithm>
     During the "update the rendering [of the] `Document`" step of the "[=Update the rendering=]"
-    HTML processing model, the associated {{HTMLCanvasElement}} |canvas| for each {{GPUSwapChain}}
-    |swapChain| should <dfn abstract-op>present the swap chain content to the canvas</dfn> by running
-    the following steps:
+    HTML processing model, each {{GPUSwapChain}} |swapChain| must <dfn abstract-op>present the
+    swap chain content to the canvas</dfn> by running the following steps:
 
         1. If |swapChain|.{{GPUSwapChain/[[dirty]]}} is `false`, stop.
+        1. Let |canvas| be |swapChain|.{{GPUSwapChain/[[context]]}}.{{GPUCanvasContext/[[canvas]]}}.
         1. Let |displayTexture| be |swapChain|.{{GPUSwapChain/[[currentTexture]]}}.
-        1. Let |swapChain|.{{GPUSwapChain/[[currentTexture]]}} be a new {{GPUTexture}} with a
-            {{GPUTexture/[[textureSize]]}} of |canvas|.width and |canvas|.height, {{GPUTexture/[[format]]}}
-            of |swapChain|.{{GPUSwapChain/[[format]]}}, and {{GPUTexture/[[textureUsage]]}} of
-            |swapChain|.{{GPUSwapChain/[[textureUsage]]}}. If a previously presented texture from
-            |swapChain| matches the required criteria it's GPU memory may be re-used.
-        1. Ensure that all rendering operations have been flushed to |displayTexture|.
+        1. Let |swapChain|.{{GPUSwapChain/[[currentTexture]]}} be the result of [$allocating a new
+            swap chain texture$] for |swapChain|.
+        1. Ensure that all submissions have been flushed to |displayTexture|.
         1. Update |canvas| with the contents of |displayTexture|.
-        1. |displayTexture| must act as if {{GPUTexture/destroy()}} were called on it without
-            releasing the associated GPU memory.
+        1. Call {{GPUTexture/destroy()}} on |displayTexture|.
         1. Set |swapChain|.{{GPUSwapChain/[[dirty]]}} to be `false`.
+
+    Issue: The texture's should mark it's `[[destroyed]]` field as true rather than calling the
+    {{GPUTexture/destroy()}} method if we separate object invalid and destroyed states.
 </div>
 
-Note: Developers can expect that the same {{GPUTexture}} object will be returned by every call to
-{{GPUSwapChain/getCurrentTexture()}} made within the same callback, and additionally that the
-same {{GPUTexture}} object will be returned in each `requestAnimationFrame()` callback run as part
-of the same frame.
+<div algorithm>
+    To <dfn abstract-op lt='allocating a new swap chain texture'>Allocate a new swap chain texture</dfn>
+    for {{GPUSwapChain}} |swapChain| run the following steps:
+
+        1. Let |canvas| be |swapChain|.{{GPUSwapChain/[[context]]}}.{{GPUCanvasContext/[[canvas]]}}.
+        1. Let |device| be |swapChain|.{{GPUSwapChain/[[descriptor]]}}.{{GPUSwapChainDescriptor/device}}.
+        1. Let |descriptor| be a new {{GPUTextureDescriptor}}.
+        1. Set |descriptor|.{{GPUTextureDescriptor/size}}.{{GPUExtent3DDict/width}} to |canvas|.width.
+        1. Set |descriptor|.{{GPUTextureDescriptor/size}}.{{GPUExtent3DDict/height}} to |canvas|.height.
+        1. Set |descriptor|.{{GPUTextureDescriptor/format}} to
+            |swapChain|.{{GPUSwapChain/[[descriptor]]}}.{{GPUSwapChainDescriptor/format}}.
+        1. Set |descriptor|.{{GPUTextureDescriptor/usage}} to
+            |swapChain|.{{GPUSwapChain/[[descriptor]]}}.{{GPUSwapChainDescriptor/usage}}.
+        1. Let |texture| be a new {{GPUTexture}} created as if |device|.{{GPUDevice/createTexture()}}
+            were called with |descriptor|.
+            <div class='note'>Note: If a previously presented texture from |swapChain| matches the required criteria,
+            its GPU memory may be re-used.</div>
+        1. Ensure |texture| is cleared to `(0, 0, 0, 0)`.
+        1. Return |texture|.
+</div>
 
 # Errors &amp; Debugging # {#errors-and-debugging}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7349,13 +7349,29 @@ interface GPUSwapChain {
 GPUSwapChain includes GPUObjectBase;
 </script>
 
-In the "update the rendering [of the] `Document`" step of the "Update the rendering" HTML processing
-model, the contents of the {{GPUTexture}} most recently returned by
-{{GPUSwapChain/getCurrentTexture()}} are used to update the rendering for the `canvas`, and it is as
-if {{GPUTexture/destroy()}} were called on it (making it unusable elsewhere in WebGPU).
+{{GPUSwapChain}} has the following internal slots:
 
-Before this drawing buffer is presented for compositing, the implementation shall ensure that all
-rendering operations have been flushed to the drawing buffer.
+<dl dfn-type=attribute dfn-for="GPUSwapChain">
+    : <dfn>\[[format]]</dfn> of type {{GPUTextureFormat}}.
+    ::
+        The format of the textures returned by this swap chain.
+
+    : <dfn>\[[textureUsage]]</dfn> of type {{GPUTextureUsage}}.
+    ::
+        The usage of the textures returned by this swap chain.
+
+    : <dfn>\[[dirty]]</dfn> of type {{boolean}}, initially `false`.
+    ::
+        Indicates if {{GPUSwapChain/[[currentTexture]]}} should be composited to the document
+        during the next update.
+
+    : <dfn>\[[currentTexture]]</dfn> of type {{GPUTexture}}.
+    ::
+        The current texture that will be returned by the swap chain when calling
+        {{GPUSwapChain/getCurrentTexture()}}, and the next one to be composited to the document.
+</dl>
+
+{{GPUSwapChain}} has the following methods:
 
 <dl dfn-type=method dfn-for=GPUSwapChain>
     : <dfn>getCurrentTexture()</dfn>
@@ -7364,13 +7380,39 @@ rendering operations have been flushed to the drawing buffer.
         that created this swap chain next.
 
         <div algorithm="GPUSwapChain.getCurrentTexture">
-            **Called on:** {{GPUSwapChain}} this.
+            **Called on:** {{GPUSwapChain}} |this|.
 
             **Returns:** {{GPUTexture}}
 
-            Issue: Describe {{GPUSwapChain/getCurrentTexture()}} algorithm steps.
+            1. Set |this|.{{GPUSwapChain/[[dirty]]}} to `true`.
+            1. Return |this|.{{GPUSwapChain/[[currentTexture]]}}.
         </div>
 </dl>
+
+<div algorithm>
+    During the "update the rendering [of the] `Document`" step of the "[=Update the rendering=]"
+    HTML processing model, the associated {{HTMLCanvasElement}} |canvas| for each {{GPUSwapChain}}
+    |swapChain| should <dfn abstract-op>present the swap chain content to the canvas</dfn> by running
+    the following steps:
+
+        1. If |swapChain|.{{GPUSwapChain/[[dirty]]}} is `false`, stop.
+        1. Let |displayTexture| be |swapChain|.{{GPUSwapChain/[[currentTexture]]}}.
+        1. Let |swapChain|.{{GPUSwapChain/[[currentTexture]]}} be a new {{GPUTexture}} with a
+            {{GPUTexture/[[textureSize]]}} of |canvas|.width and |canvas|.height, {{GPUTexture/[[format]]}}
+            of |swapChain|.{{GPUSwapChain/[[format]]}}, and {{GPUTexture/[[textureUsage]]}} of
+            |swapChain|.{{GPUSwapChain/[[textureUsage]]}}. If a previously presented texture from
+            |swapChain| matches the required criteria it's GPU memory may be re-used.
+        1. Ensure that all rendering operations have been flushed to |displayTexture|.
+        1. Update |canvas| with the contents of |displayTexture|.
+        1. |displayTexture| must act as if {{GPUTexture/destroy()}} were called on it without
+            releasing the associated GPU memory.
+        1. Set |swapChain|.{{GPUSwapChain/[[dirty]]}} to be `false`.
+</div>
+
+Note: Developers can expect that the same {{GPUTexture}} object will be returned by every call to
+{{GPUSwapChain/getCurrentTexture()}} made within the same callback, and additionally that the
+same {{GPUTexture}} object will be returned in each `requestAnimationFrame()` callback run as part
+of the same frame.
 
 # Errors &amp; Debugging # {#errors-and-debugging}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7368,11 +7368,6 @@ GPUSwapChain includes GPUObjectBase;
     ::
         The descriptor this swap chain was created with.
 
-    : <dfn>\[[dirty]]</dfn> of type {{boolean}}, initially `true`.
-    ::
-        Indicates if {{GPUSwapChain/[[currentTexture]]}} should be composited to the document
-        during the next update.
-
     : <dfn>\[[currentTexture]]</dfn> of type {{GPUTexture}}.
     ::
         The current texture that will be returned by the swap chain when calling
@@ -7393,7 +7388,9 @@ GPUSwapChain includes GPUObjectBase;
 
             **Returns:** {{GPUTexture}}
 
-            1. Set |this|.{{GPUSwapChain/[[dirty]]}} to `true`.
+            1. If |this|.{{GPUSwapChain/[[currentTexture]]}} is `null`:
+                1. Let |this|.{{GPUSwapChain/[[currentTexture]]}} be the result of [$allocating a
+                    new swap chain texture$] for |this|.
             1. Return |this|.{{GPUSwapChain/[[currentTexture]]}}.
         </div>
 
@@ -7407,17 +7404,15 @@ GPUSwapChain includes GPUObjectBase;
     HTML processing model, each {{GPUSwapChain}} |swapChain| must <dfn abstract-op>present the
     swap chain content to the canvas</dfn> by running the following steps:
 
-        1. If |swapChain|.{{GPUSwapChain/[[dirty]]}} is `false`, stop.
-        1. Let |canvas| be |swapChain|.{{GPUSwapChain/[[context]]}}.{{GPUCanvasContext/[[canvas]]}}.
-        1. Let |displayTexture| be |swapChain|.{{GPUSwapChain/[[currentTexture]]}}.
-        1. Let |swapChain|.{{GPUSwapChain/[[currentTexture]]}} be the result of [$allocating a new
-            swap chain texture$] for |swapChain|.
-        1. Ensure that all submissions have been flushed to |displayTexture|.
-        1. Update |canvas| with the contents of |displayTexture|.
-        1. Call {{GPUTexture/destroy()}} on |displayTexture|.
-        1. Set |swapChain|.{{GPUSwapChain/[[dirty]]}} to be `false`.
+        1. Let |texture| be |swapChain|.{{GPUSwapChain/[[currentTexture]]}}.
+        1. If |texture| is `null`, stop.
+        1. Let |swapChain|.{{GPUSwapChain/[[currentTexture]]}} be `null`.
+        1. Ensure that all submissions have been flushed to |texture|.
+        1. Update |swapChain|.{{GPUSwapChain/[[context]]}}.{{GPUCanvasContext/[[canvas]]}} with the
+            contents of |texture|.
+        1. Call {{GPUTexture/destroy()}} on |texture|.
 
-    Issue: The texture's should mark it's `[[destroyed]]` field as true rather than calling the
+    Issue: The texture should mark its `[[destroyed]]` field as true rather than calling the
     {{GPUTexture/destroy()}} method if we separate object invalid and destroyed states.
 </div>
 


### PR DESCRIPTION
Fixes #1388

This change attempts to better describe how and when the swap chain presents it's contents to the canvas and when the texture returned by `getCurrentTexture()` is updated.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/toji/gpuweb/pull/1408.html" title="Last updated on Feb 6, 2021, 1:55 AM UTC (5c8602c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1408/d305f2c...toji:5c8602c.html" title="Last updated on Feb 6, 2021, 1:55 AM UTC (5c8602c)">Diff</a>