### PR TITLE
Restrict GPUVertexAttribute.shaderLocation < maxAttribs

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4620,6 +4620,8 @@ dictionary GPUVertexAttribute {
                     |descriptor|.{{GPUVertexBufferLayout/arrayStride}}.
             - |attrib|.{{GPUVertexAttribute/offset}} is a multiple of the size of one component of
                 |attrib|.{{GPUVertexAttribute/format}}.
+            - |attrib|.{{GPUVertexAttribute/shaderLocation}} is less than
+                |device|.{{GPUDevice/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexAttributes}}.
         - For every vertex attribute in the shader reflection of |vertexStage|.{{GPUProgrammableStage/module}}
             that is know to be [=statically used=] by |vertexStage|.{{GPUProgrammableStage/entryPoint}},
             there is a corresponding |attrib| element of |descriptor|.{{GPUVertexBufferLayout/attributes}} for which
@@ -4647,9 +4649,6 @@ dictionary GPUVertexAttribute {
         - Each |attrib| in the union of all {{GPUVertexAttribute}}
             across |descriptor|.{{GPUVertexState/buffers}} has a distinct
             |attrib|.{{GPUVertexAttribute/shaderLocation}} value.
-
-        Issue: are the {{GPUVertexAttribute/shaderLocation}} arbitrary or should they be less than
-        {{supported limits/maxVertexAttributes}}?
 </div>
 
 # Command Buffers # {#command-buffers}


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/1423.html" title="Last updated on Feb 9, 2021, 5:02 PM UTC (229bd95)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1423/f8fe453...Kangz:229bd95.html" title="Last updated on Feb 9, 2021, 5:02 PM UTC (229bd95)">Diff</a>