### PR TITLE
Rename frag_coord bultin to position

### DIFF
--- a/samples/hello-cube.html
+++ b/samples/hello-cube.html
@@ -40,8 +40,8 @@ fn main(
 }
 
 [[stage(fragment)]]
-fn main([[location(${colorLocation})]] color: vec4<f32>) -> [[location(0)]] vec4<f32> {
-    return color;
+fn main(data: FragmentData) -> [[location(0)]] vec4<f32> {
+    return data.color;
 }
 `;
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3747,7 +3747,7 @@ The return type of an entry point has to be of an [=Entry point IO type=], or [=
        // %return_value = OpVariable %ptr Output
 
     [[stage(fragment)]]
-    fn frag_main([[builtin(frag_coord)]] coord_in: vec4<f32>) -> [[location(0)]] vec4<f32> {
+    fn frag_main([[builtin(position)]] coord_in: vec4<f32>) -> [[location(0)]] vec4<f32> {
       return vec4<f32>(coord_in.x, coord_in.y, 0.0, 1.0);
     }
        // OpEntryPoint Fragment %frag_main "frag_main" %return_value %coord_in
@@ -4484,7 +4484,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
       coordinate space.
       See [[WebGPU#coordinate-systems|WebGPU &sect; Coordinate Systems]].
 
-  <tr><td>`frag_coord`
+  <tr><td>`position`
       <td>fragment
       <td>in
       <td>vec4&lt;f32&gt;
@@ -4610,7 +4610,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
     fn fs_main(
       [[builtin(front_facing)]] is_front : u32,
       //     OpDecorate %is_front BuiltIn FrontFacing
-      [[builtin(frag_coord)]] coord : vec4<f32>,
+      [[builtin(position)]] coord : vec4<f32>,
       //     OpDecorate %coord BuiltIn FragCoord
       [[builtin(sample_index)]] my_sample_index : u32,
       //      OpDecorate %my_sample_index BuiltIn SampleId


### PR DESCRIPTION
As a follow-up to #1426, I think having the position builtin available to both vertex output and fragment input has a good property of allowing users to share the structure between the stages. This matches HLSL's `SV_Position`.