### PR TITLE
Remove in/out storage classes

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -585,18 +585,6 @@ and how to use variables with it.
         <th>Restrictions on stored values
         <th>Notes
   </thead>
-  <tr><td><dfn noexport dfn-for="storage classes">in</dfn>
-      <td>Read-only
-      <td>Same invocation only
-      <td>[=Module scope=]
-      <td>[=IO-shareable=]
-      <td>Input from an upstream pipeline stage, or from the implementation.
-  <tr><td><dfn noexport dfn-for="storage classes">out</dfn>
-      <td>Read-write
-      <td>Same invocation only
-      <td>[=Module scope=]
-      <td>[=IO-shareable=]
-      <td>Output to a downstream pipeline stage.
   <tr><td><dfn noexport dfn-for="storage classes">function</dfn>
       <td>Read-write
       <td>Same invocation only
@@ -640,8 +628,6 @@ and how to use variables with it.
 Issue: The note about read-only [=storage classes/storage=] variables may change depending
 on the outcome of https://github.com/gpuweb/gpuweb/issues/935
 
-Issue: can we remove the "in" and "out" classes entirely?
-
 <pre class='def'>
 storage_class
   : IN
@@ -657,8 +643,6 @@ storage_class
   <thead>
     <tr><th>WGSL storage class<th>SPIR-V storage class
   </thead>
-  <tr><td>in<td>Input
-  <tr><td>out<td>Output
   <tr><td>uniform<td>Uniform
   <tr><td>workgroup<td>Workgroup
   <tr><td>handle<td>UniformConstant
@@ -1716,8 +1700,7 @@ of the program.
 
 Variables at [=module scope=] are restricted as follows:
 
-* The variable must not be in the [=storage classes/function=], [=storage classes/in=],
-    or [=storage classes/out=] storage classes.
+* The variable must not be in the [=storage classes/function=] storage class.
 * A variable in the [=storage classes/private=], [=storage classes/workgroup=], [=storage classes/uniform=], or [=storage classes/storage=] storage classes:
     * Must be declared with an explicit storage class decoration.
     * Must use a [=store type=] as described in [[#storage-class]].
@@ -3730,7 +3713,6 @@ When configuring the stage in the pipeline, the entry point is specified by prov
 the [SHORTNAME] module and the entry point's function name.
 
 The parameters of an entry point have to be within [=Entry point IO type=]s.
-They have [=storage classes/in=] storage class.
 The return type of an entry point has to be of an [=Entry point IO type=], or [=void=].
 
 <div class='example wgsl global-scope' heading='Entry Point'>
@@ -3829,7 +3811,7 @@ Note that being statically accessed is independent of whether an execution of th
 will actually evaluate the subexpression, or even execute the enclosing statement.
 
 More precisely, the <dfn noexport>interface of a shader stage</dfn> consists of:
-  - all parameters of the entry point (as [=storage classes/in=])
+  - all parameters of the entry point
   - the result value of the entry point
   - all [=module scope=] variables that are [=statically accessed=] by [=functions in a shader stage|functions in the shader stage=],
     and which are in storage classes [=storage classes/uniform=], [=storage classes/storage=], or [=storage classes/handle=].
@@ -3884,9 +3866,7 @@ If a built-in variable has stage *S* and is [=statically accessed=] by a functio
 then *F* must be a [=functions in a shader stage|function in a shader=]
 for stage *S*.
 
-Issue:
-    1. The statement makes it clear that in/out storage classes for builtins are redundant.
-    2. On the other hand, in Vulkan, builtin variables occoupy I/O location slots (counting toward limits),
+Issue: in Vulkan, builtin variables occoupy I/O location slots counting toward limits.
 
 #### User Data Attribute TODO #### {#user-data-attributes}
 
@@ -4275,9 +4255,7 @@ I've written what an NVIDIA GPU does.  See https://github.com/google/amber/pull/
   <tr><td>`FOR`<td>for
   <tr><td>`FUNCTION`<td>function
   <tr><td>`IF`<td>if
-  <tr><td>`IN`<td>in
   <tr><td>`LOOP`<td>loop
-  <tr><td>`OUT`<td>out
   <tr><td>`PRIVATE`<td>private
   <tr><td>`RETURN`<td>return
   <tr><td>`STORAGE`<td>storage


### PR DESCRIPTION
As a follow-up to #1426, we can remove the in/out storage classes because they have no extra properties or observable effects on the user.
Related to #1105