### PR TITLE
Make dictionary arguments optional with default value

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4738,17 +4738,17 @@ interface GPUCommandEncoder {
     undefined copyBufferToTexture(
         GPUImageCopyBuffer source,
         GPUImageCopyTexture destination,
-        GPUExtent3D copySize);
+        optional GPUExtent3D copySize = {});
 
     undefined copyTextureToBuffer(
         GPUImageCopyTexture source,
         GPUImageCopyBuffer destination,
-        GPUExtent3D copySize);
+        optional GPUExtent3D copySize = {});
 
     undefined copyTextureToTexture(
         GPUImageCopyTexture source,
         GPUImageCopyTexture destination,
-        GPUExtent3D copySize);
+        optional GPUExtent3D copySize = {});
 
     undefined pushDebugGroup(USVString groupLabel);
     undefined popDebugGroup();
@@ -6930,13 +6930,13 @@ interface GPUQueue {
     undefined writeTexture(
       GPUImageCopyTexture destination,
       [AllowShared] BufferSource data,
-      GPUImageDataLayout dataLayout,
-      GPUExtent3D size);
+      optional GPUImageDataLayout dataLayout = {},
+      optional GPUExtent3D size = {});
 
     undefined copyImageBitmapToTexture(
         GPUImageCopyImageBitmap source,
         GPUImageCopyTexture destination,
-        GPUExtent3D copySize);
+        optional GPUExtent3D copySize = {});
 };
 GPUQueue includes GPUObjectBase;
 </script>


### PR DESCRIPTION
This is required by https://heycam.github.io/webidl/#idl-operations:

> If the type of an argument is a dictionary type or a union type that
> has a dictionary type as one of its flattened member types, and that
> dictionary type and its ancestors have no required members, and the
> argument is either the final argument or is followed only by optional
> arguments, then the argument must be specified as optional and have a
> default value provided.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/foolip/gpuweb/pull/1440.html" title="Last updated on Feb 17, 2021, 12:34 PM UTC (2e28467)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1440/469c82c...foolip:2e28467.html" title="Last updated on Feb 17, 2021, 12:34 PM UTC (2e28467)">Diff</a>