### PR TITLE
Make GPUExtent3DDict's width member required

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7619,7 +7619,7 @@ An <dfn dfn>Origin3D</dfn> is a {{GPUOrigin3D}}.
 
 <script type=idl>
 dictionary GPUExtent3DDict {
-    GPUIntegerCoordinate width = 1;
+    required GPUIntegerCoordinate width;
     GPUIntegerCoordinate height = 1;
     GPUIntegerCoordinate depthOrArrayLayers = 1;
 };


### PR DESCRIPTION
An alternative to, and closes https://github.com/gpuweb/gpuweb/pull/1440.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/foolip/gpuweb/pull/1441.html" title="Last updated on Feb 17, 2021, 3:33 PM UTC (fc572cd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1441/c7cabdb...foolip:fc572cd.html" title="Last updated on Feb 17, 2021, 3:33 PM UTC (fc572cd)">Diff</a>