### PR TITLE
Workgroup size dimensions can be pipeline-overrideable constants

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1874,7 +1874,7 @@ and the name denotes the value of that expression.
 </div>
 
 When the declaration uses the `constant_id` attribute,
-the constant is *pipeline-overridable*. In this case:
+the constant is <dfn noexport>pipeline-overridable</dfn>. In this case:
 
   * The type must one of the [=scalar=] types.
   * The initializer expression is optional.
@@ -3693,10 +3693,12 @@ param_list
   <thead>
     <tr><th>Function decoration keys<th>Valid values<th>Note
   </thead>
-  <tr><td>`stage`<td>`compute` or `vertex` or `fragment`<td>
-  <tr><td>`workgroup_size`<td>non-negative i32 literals<td>The workgroup_size accepts
-    a comma separated list of up to 3 values. The values provide the x, y and z
-    dimensions.
+  <tr><td>`stage`<td>`compute` or `vertex` or `fragment`<td>See [[#entry-point-attributes]].
+  <tr><td>`workgroup_size`
+      <td>One, two, or three parameters.
+          Each parameter is either an i32 literal or the name of a [=pipeline-overridable=] constant of i32 type.
+      <td>Specifies the x, y and z dimensions of the [=workgroup grid=] for the compute shader.
+      <br>See [[#entry-point-attributes]].
 </table>
 
 <div class='example' heading='Function'>
@@ -3836,14 +3838,15 @@ It will stabilize in a finite number of steps.
 ### Function attributes for entry points ### {#entry-point-attributes}
 
 : <dfn noexport>stage</dfn>
-:: The `stage` attribute declares that a function is an entry point for particular pipeline stage.
+:: The `stage` attribute declares that a function is an entry point for a particular pipeline stage.
+    The parameter must be one of `vertex`, `fragment`, or `compute`.
 : <dfn noexport>workgroup_size</dfn>
 :: The `workgroup_size` attribute specifies the x, y, and z dimensions of the [=workgroup grid=]
     for a [=compute=] shader.
-    The size in the x dimension is provided by the first literal.
-    The size in the y dimension is provided by the second literal, when present, and otherwise
+    The size in the x dimension is provided by the first value.
+    The size in the y dimension is provided by the second value, when present, and otherwise
     is assumed to be 1.
-    The size in the z dimension is provided by the third literal, when present, and otherwise
+    The size in the z dimension is provided by the third value, when present, and otherwise
     is assumed to be 1.
     Each dimension size must be at least 1 and at most an upper bound specified by the WebGPU API.
     This attribute must only be used with a [=compute shader stage=] entry point.


### PR DESCRIPTION
Fixes #1442