### PR TITLE
Add workgroupBarrier to WGSL

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5814,7 +5814,7 @@ visible to all other threads in the workgroup before any affected memory or
 atomic operation program ordered after the workgroupBarrier is executed by a
 member of the workgroup.
 
-A memory, atomic or workgroupBarrier operation is an afftected operation if it
+A memory, atomic or workgroupBarrier operation is an affected operation if it
 operates on any of the storage classes listed in `storage_class_list`. That is,
 a workgroupBarrier is affected if the intersection of the storage class
 lists is non-empty, and memory and atomic operations operations are affected if

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3630,8 +3630,6 @@ func_call_statement
   : IDENT argument_expression_list
 </pre>
 
-The second form of the grammar `must` only be used with [[#sync-builtin-functions]].
-
 ## Statements Grammar Summary ## {#statements-summary}
 
 <pre class='def'>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3628,7 +3628,6 @@ The `discard` statement must only be used in a [=fragment=] shader stage.
 <pre class='def'>
 func_call_statement
   : IDENT argument_expression_list
-  | IDENT LESS_THAN storage_class_list GREATER_THAN argument_expression_list
 </pre>
 
 The second form of the grammar `must` only be used with [[#sync-builtin-functions]].
@@ -5800,47 +5799,51 @@ reduce a shader's memory bandwidth demand.
 
 ## Synchronization built-in functions ## {#sync-builtin-functions}
 
-[SHORTNAME] provides a single synchronization function:
+[SHORTNAME] provides the following synchronization functions:
 
 ```rust
-workgroupBarrier<storage_class_list>() -> void
+fn storageBarrier() -> void
+fn workgroupBarrier() -> void
 ```
 
-Execute a control barrier with Acquire/Release memory ordering. That is, all
-affected memory, atomic and barrier operations are ordered in
-[[#program-order]] relative to the barrier. Additionally, the affected memory
-and atomic operations program ordered before the workgroupBarrier must be
-visible to all other threads in the workgroup before any affected memory or
-atomic operation program ordered after the workgroupBarrier is executed by a
+All synchronization functions execute a control barrier with Acquire/Release
+memory ordering. That is, all synchronization functions, and affected memory
+and atomic operations are ordered in [[#program-order]] relative to the
+synchronization function.  Additionally, the affected memory and atomic
+operations program-ordered before the synchronization function must be visible
+to all other threads in the workgroup before any affected memory or atomic
+operation program-ordered after the synchronization function is executed by a
 member of the workgroup.
 
-A memory, atomic or workgroupBarrier operation is an affected operation if it
-operates on any of the storage classes listed in `storage_class_list`. That is,
-a workgroupBarrier is affected if the intersection of the storage class
-lists is non-empty, and memory and atomic operations operations are affected if
-they operate on a pointer in a storage class listed in the workgroupBarrier's
-`storage_class_list`.
+storageControlBarrier affects memory and atomic operations in the [=storage
+classes/storage=] storage class.
+
+workgroupControlBarrier affects memory and atomic operations in the [=storage
+classes/workgroup=] storage class.
 
 TODO: Add links to the eventual memory model.
 
 <div class='example spirv barrier mapping' heading="Mapping workgroupBarrier to SPIR-V">
   <xmp>
-    workgroupBarrier<storage>();
+    storageControlBarrier();
     // Maps to:
     // Execution Scope is Workgroup = %uint_2
     // Memory Scope is Device = %uint_1
     // Memory Semantics are AcquireRelease | UniformMemory (0x8 | 0x40) = %uint_72
     // OpControlBarrier %uint_2 %uint_1 %uint_72
 
-    workgroupBarrier<workgroup>();
+    workgroupControlBarrier();
     // Maps to:
     // Execution and Memory Scope are Workgroup = %uint_2
     // Memory semantics are AcquireRelease | WorkgroupMemory (0x8 | 0x100) = %uint_264
     // OpControlBarrier %uint_2 %uint_2 %uint_264
 
-    workgroupBarrier<storage,workgroup>();
-    workgroupBarrier<workgroup,storage>();
-    // Both map to:
+    workgroupBarrier();
+    storageBarrier();
+    // Or, equivalently:
+    storageBarrier();
+    workgroupBarrier();
+    // Could be mapped to a single OpControlBarrier:
     // Execution scope is Workgroup = %uint_2
     // Memory Scope is Device = %uint_1
     // Memory semantics are AcquireRelease | UniformMemory | WorkgroupMemory
@@ -5848,16 +5851,6 @@ TODO: Add links to the eventual memory model.
     // OpControlBarrier %uint_2 %uint_1 %uint_328
   </xmp>
 </div>
-
-### Storage Class List Grammar ### {#storage-class-list-grammar}
-
-<pre class='def'>
-storage_class_list
-  : storage_class
-  | storage_class_list COMMA storage_class
-</pre>
-
-Storage classes `must` be either [=storage classes/storage=] or [=storage classes/workgroup=].
 
 # Glossary # {#glossary}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5808,7 +5808,7 @@ workgroupBarrier<storage_class_list>() -> void
 
 Execute a control barrier with Acquire/Release memory ordering. That is, all
 affected memory, atomic and barrier operations are ordered in
-[[=program-order]] relative to the barrier. Additionally, the affected memory
+[[#program-order]] relative to the barrier. Additionally, the affected memory
 and atomic operations program ordered before the workgroupBarrier must be
 visible to all other threads in the workgroup before any affected memory or
 atomic operation program ordered after the workgroupBarrier is executed by a

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -541,10 +541,7 @@ TODO: This section is a stub.
 
 In [SHORTNAME], a value of [=storable=] type may be stored in memory, for later retrieval.
 
-In general [SHORTNAME] follows the [[!VulkanMemoryModel|Vulkan Memory Model]]
-with the following exceptions
-
- * No Acquire/Release semantics
+In general [SHORTNAME] follows the [[!VulkanMemoryModel|Vulkan Memory Model]].
 
 ### Memory Locations TODO ### {#memory-locations}
 
@@ -3631,7 +3628,10 @@ The `discard` statement must only be used in a [=fragment=] shader stage.
 <pre class='def'>
 func_call_statement
   : IDENT argument_expression_list
+  | IDENT LESS_THAN storage_class_list GREATER_THAN argument_expression_list
 </pre>
+
+The second form of the grammar `must` only be used with [[#sync-builtin-functions]].
 
 ## Statements Grammar Summary ## {#statements-summary}
 
@@ -5797,6 +5797,67 @@ reduce a shader's memory bandwidth demand.
         as an IEEE 754 binary16 value.
         See [[#floating-point-conversion]] for edge case behaviour.
 </table>
+
+## Synchronization built-in functions ## {#sync-builtin-functions}
+
+[SHORTNAME] provides a single synchronization function:
+
+```rust
+workgroupBarrier<storage_class_list>() -> void
+```
+
+Execute a control barrier with Acquire/Release memory ordering. That is, all
+affected memory, atomic and barrier operations are ordered in
+[[=program-order]] relative to the barrier. Additionally, the affected memory
+and atomic operations program ordered before the workgroupBarrier must be
+visible to all other threads in the workgroup before any affected memory or
+atomic operation program ordered after the workgroupBarrier is executed by a
+member of the workgroup.
+
+A memory, atomic or workgroupBarrier operation is an afftected operation if it
+operates on any of the storage classes listed in `storage_class_list`. That is,
+a workgroupBarrier is affected if the intersection of the storage class
+lists is non-empty, and memory and atomic operations operations are affected if
+they operate on a pointer in a storage class listed in the workgroupBarrier's
+`storage_class_list`.
+
+TODO: Add links to the eventual memory model.
+
+<div class='example spirv barrier mapping' heading="Mapping workgroupBarrier to SPIR-V">
+  <xmp>
+    workgroupBarrier<storage>();
+    // Maps to:
+    // Execution Scope is Workgroup = %uint_2
+    // Memory Scope is Device = %uint_1
+    // Memory Semantics are AcquireRelease | UniformMemory (0x8 | 0x40) = %uint_72
+    // OpControlBarrier %uint_2 %uint_1 %uint_72
+
+    workgroupBarrier<workgroup>();
+    // Maps to:
+    // Execution and Memory Scope are Workgroup = %uint_2
+    // Memory semantics are AcquireRelease | WorkgroupMemory (0x8 | 0x100) = %uint_264
+    // OpControlBarrier %uint_2 %uint_2 %uint_264
+
+    workgroupBarrier<storage,workgroup>();
+    workgroupBarrier<workgroup,storage>();
+    // Both map to:
+    // Execution scope is Workgroup = %uint_2
+    // Memory Scope is Device = %uint_1
+    // Memory semantics are AcquireRelease | UniformMemory | WorkgroupMemory
+    //   (0x8 | 0x40 | 0x100) = %uint_328
+    // OpControlBarrier %uint_2 %uint_1 %uint_328
+  </xmp>
+</div>
+
+### Storage Class List Grammar ### {#storage-class-list-grammar}
+
+<pre class='def'>
+storage_class_list
+  : storage_class
+  | storage_class_list COMMA storage_class
+</pre>
+
+Storage classes `must` be either [=storage classes/storage=] or [=storage classes/workgroup=].
 
 # Glossary # {#glossary}
 


### PR DESCRIPTION
Fixes #1374

* Adds workgroupBarrier as a control barrier templated on affected
  storage classes
* Modifies func_call_statement grammar to allow limited templates