### PR TITLE
Rewrite explanation of number tokens

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -128,7 +128,7 @@ TODO: What indicates the end of a line?  (E.g. A line ends at the next linefeed 
 
 ## Literals ## {#literals}
 
-Literal tokens are defined interms of certain character classes:
+Literal tokens are defined in terms of certain character classes:
 
 : <dfn noexport>nonzero-digit</dfn>
 :: `1` `2` `3` `4` `5` `6` `7` `8` `9`
@@ -163,7 +163,7 @@ In the following tables:
   <tr><td>`HEX_FLOAT_WITH_PERIOD`
       <td>`HEX_PREFIX`<br>
           `( (`[=hex-digits=]`? PERIOD` [=hex-digits=]`) | (`[=hex-digits=] `PERIOD) )`<br>
-          `BINARY_EXPONENT_PART ?`
+          `BINARY_EXPONENT_PART`
   <tr><td>`HEX_FLOAT_WITHOUT_PERIOD`
       <td>`HEX_PREFIX` [=hex-digits=] `BINARY_EXPONENT_PART`
   <tr><td>`HEX_FLOAT_LITERAL`
@@ -2781,7 +2781,7 @@ Issue: Which index is used when it's out of bounds?
   </thead>
   <tr><td>*e* : *T*, *T* is *SignedIntegral*<td>`-e` : *T*
       <td>Signed integer negation.
-      <br>OpSNegate. If *e* is a `const_literal`, then the negation can be foled into the OpConstant.
+      <br>OpSNegate. If *e* is a `const_literal`, then the negation can be folded into the OpConstant.
   <tr><td>*e* : *T*, *T* is *Floating*<td>`-e` : *T*
       <td>Floating point negation.
       <br>OpFNegate. If *e* is a `const_literal`, then the negation can be folded into the OpConstant.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -126,38 +126,72 @@ TODO: What indicates the end of a line?  (E.g. A line ends at the next linefeed 
 
 ## Tokens TODO ## {#tokens}
 
-## Literals TODO ## {#literals}
+## Literals ## {#literals}
+
+Literal tokens are defined interms of certain character classes:
+
+: <dfn noexport>nonzero-digit</dfn>
+:: `1` `2` `3` `4` `5` `6` `7` `8` `9`
+: <dfn noexport>digit</dfn>
+:: `0` `1` `2` `3` `4` `5` `6` `7` `8` `9`
+: <dfn noexport>digits</dfn>
+:: one or more [=digit=] characters in a row
+: <dfn noexport>hex-digit</dfn>
+:: `0` `1` `2` `3` `4` `5` `6` `7` `8` `9` `a` `b` `c` `d` `e` `f` `A` `B` `C` `D` `E` `F`
+: <dfn noexport>hex-digits</dfn>
+:: one or more [=hex-digit=] characters in a row
+
+In the following tables:
+
+* A grouping of items is indicated by parentheses: `(` and `)`.  The grouping forms a higher level item.
+* Alternatives are separated by the `|` character. One of the alternative items must be matched.
+* An optional item is followed by `?`.
+
+<table class='data'>
+  <thead>
+    <tr><th>Token part<th>Definition
+  </thead>
+  <tr><td>`EXPONENT_PART`<td>`(e|E) (+|-)?` [=digits=]
+  <tr><td>`DECIMAL_FLOAT_WITH_PERIOD`
+      <td> `( (`[=digits=]`? PERIOD` [=digits=]`) | (`[=digits=] `PERIOD) ) EXPONENT_PART ?`
+  <tr><td>`DECIMAL_FLOAT_WITHOUT_PERIOD`
+      <td>[=digits=] `EXPONENT_PART`
+  <tr><td>`DECIMAL_FLOAT_LITERAL`
+      <td> `DECIMAL_FLOAT_WITH_PERIOD | DECIMAL_FLOAT_WITHOUT_PERIOD`
+  <tr><td>`HEX_PREFIX`<td>`0(x|X)`
+  <tr><td>`BINARY_EXPONENT_PART`<td>`(p|P) (+|-)?` [=digits=]
+  <tr><td>`HEX_FLOAT_WITH_PERIOD`
+      <td>`HEX_PREFIX`<br>
+          `( (`[=hex-digits=]`? PERIOD` [=hex-digits=]`) | (`[=hex-digits=] `PERIOD) )`<br>
+          `BINARY_EXPONENT_PART ?`
+  <tr><td>`HEX_FLOAT_WITHOUT_PERIOD`
+      <td>`HEX_PREFIX` [=hex-digits=] `BINARY_EXPONENT_PART`
+  <tr><td>`HEX_FLOAT_LITERAL`
+      <td>`HEX_FLOAT_WITH_PERIOD | HEX_FLOAT_WITHOUT_PERIOD`
+</table>
 
 <table class='data'>
   <thead>
     <tr><th>Token<th>Definition
   </thead>
-  <tr><td>`DECIMAL_FLOAT_LITERAL`<td>`(-?[0-9]*.[0-9]+ | -?[0-9]+.[0-9]*)((e|E)(+|-)?[0-9]+)?`
-  <tr><td>`HEX_FLOAT_LITERAL`<td>`-?0x([0-9a-fA-F]*.?[0-9a-fA-F]+ | [0-9a-fA-F]+.[0-9a-fA-F]*)(p|P)(+|-)?[0-9]+`
-  <tr><td>`INT_LITERAL`<td>`-?0x[0-9a-fA-F]+ | 0 | -?[1-9][0-9]*`
-  <tr><td>`UINT_LITERAL`<td>`0x[0-9a-fA-F]+u | 0u | [1-9][0-9]*u`
+  <tr><td>`FLOAT_LITERAL`<td>`DECIMAL_FLOAT_LITERAL | HEX_FLOAT_LITERAL`
+  <tr><td>`INT_LITERAL`
+      <td>`0 |` [=nonzero-digit=] [=digits=]`? | HEX_PREFIX` [=hex-digits=]
+  <tr><td>`UINT_LITERAL`
+      <td>`0u |` [=nonzero-digit=] [=digits=]`? u | HEX_PREFIX` [=hex-digits=] `u`
 </table>
-
-Note: literals are parsed greedily. This means that for statements like `a -5`
-      this will *not* parse as `a` `minus` `5` but instead as `a` `-5` which
-      may be unexpected. A space must be inserted after the `-` if the first
-      expression is desired.
 
 <pre class='def'>
 const_literal
-  : INT_LITERAL
+  : MINUS? negatable_literal
   | UINT_LITERAL
-  | FLOAT_LITERAL
   | TRUE
   | FALSE
-</pre>
 
-<pre class='def'>
-FLOAT_LITERAL
-  : DECIMAL_FLOAT_LITERAL
-  | HEX_FLOAT_LITERAL
+negatable_literal
+  : INT_LITERAL
+  : FLOAT_LITERAL
 </pre>
-
 
 ## Keywords TODO ## {#keywords}
 
@@ -173,11 +207,6 @@ See [[#keyword-summary]] for a list of keywords.
   </thead>
   <tr><td>`IDENT`<td>`[a-zA-Z][0-9a-zA-Z_]*`
 </table>
-
-Note: literals are parsed greedy. This means that for statements like `a -5`
-      this will *not* parse as `a` `minus` `5` but instead as `a` `-5` which
-      may be unexpected. A space must be inserted after the `-` if the first
-      expression is desired.
 
 ## Attributes TODO ## {#attributes}
 
@@ -1837,9 +1866,7 @@ decoration
   | IDENT
 
 literal_or_ident
-  : FLOAT_LITERAL
-  | INT_LITERAL
-  | UINT_LITERAL
+  : const_literal
   | IDENT
 </pre>
 
@@ -2004,6 +2031,8 @@ and third clauses and in the body of the `for` statement.
   <tr><td><td>*UINT_LITERAL* : u32<td>OpConstant %uint *literal*
   <tr><td><td>*FLOAT_LITERAL* : f32<td>OpConstant %float *literal*
 </table>
+
+TODO: Explain how a literal token is converted to a value of matching type.
 
 ## Type Constructor Expressions TODO ## {#type-constructor-expr}
 
@@ -2750,8 +2779,12 @@ Issue: Which index is used when it's out of bounds?
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
-  <tr><td>*e* : *T*, *T* is *SignedIntegral*<td>`-e` : *T*<td>Signed integer negation. OpSNegate
-  <tr><td>*e* : *T*, *T* is *Floating*<td>`-e` : *T*<td>Floating point negation. OpFNegate
+  <tr><td>*e* : *T*, *T* is *SignedIntegral*<td>`-e` : *T*
+      <td>Signed integer negation.
+      <br>OpSNegate. If *e* is a `const_literal`, then the negation can be foled into the OpConstant.
+  <tr><td>*e* : *T*, *T* is *Floating*<td>`-e` : *T*
+      <td>Floating point negation.
+      <br>OpFNegate. If *e* is a `const_literal`, then the negation can be folded into the OpConstant.
 </table>
 
 <table class='data'>


### PR DESCRIPTION
- Removes the leading '-' from numeric literals.
  Should allow 'a-5' without needing an extra space.
- Allows scientific notation floats without a period
- Expresses numeric literals in terms of named parts, which is more readable
- Simplifies the with-a-period fraction cases, following C99 example.
- Allows 0x and 0X as the hex prefix
- Adds TODO to explain how a numeric literal is converted into a value
- For SPIR-V mapping, explains that the negation of a signed int literal or
  float literal can be folded into the underlying OpConstant.

Fixes #755, #1453