### PR TITLE
Introduce Subgroup Operations Extension

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1456,6 +1456,7 @@ enum GPUFeatureName {
     "pipeline-statistics-query",
     "texture-compression-bc",
     "timestamp-query",
+    "subgroup-operations"
 };
 </script>
 
@@ -7705,6 +7706,10 @@ The following enums are supported if and only if the {{GPUFeatureName/"pipeline-
     ::
         * {{GPUQueryType/"pipeline-statistics"}}
 </dl>
+
+## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>subgroup-operations</dfn> ## {#subgroup-operations}
+
+Issue: Define functionality when the {{GPUFeatureName/"subgroup-operations"}} [=feature=] is enabled.
 
 
 ## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>texture-compression-bc</dfn> ## {#texture-compression-bc}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4600,6 +4600,19 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
       <td>vec3&lt;u32&gt;
       <td width="50%">The [=workgroup_size=] of the current entry point.
 
+  <tr><td>`subgroup_size`
+      <td>compute
+      <td>in
+      <td>u32
+      <td width="50%">The subgroup size of the current entry point.
+
+  <tr><td>`subgroup_invocation_index`
+      <td>compute
+      <td>in
+      <td>u32
+      <td width="50%">The current invocation's subgroup invocation index.
+          Must be in range [0, `subgroup_size`-1].
+
   <tr><td>`sample_index`
       <td>fragment
       <td>in
@@ -5786,6 +5799,37 @@ reduce a shader's memory bandwidth demand.
         as an IEEE 754 binary16 value.
         See [[#floating-point-conversion]] for edge case behaviour.
 </table>
+
+## Subgroup built-in functions ## {#subgroup-builtin-functions}
+
+<table class='data'>
+  <thead>
+    <tr><td>Subgroup built-in functions<td>SPIR-V
+  </thead>
+  <tr><td>subgroupIsFirst() -&gt; bool<td>OpGroupNonUniformElect
+  <tr><td>subgroupAll(bool) -&gt; bool<td>OpGroupNonUniformAll
+  <tr><td>subgroupAny(bool) -&gt; bool<td>OpGroupNonUniformAny
+  <tr><td>subgroupBallot(bool) -&gt; vec4&lt;u32&gt;<td>OpGroupNonUniformBallot
+  <tr><td>subgroupBroadcastFirst(Integral) -&gt; Integral<td>OpGroupNonUniformBroadcastFirst		
+  <tr><td>subgroupBroadcastFirst(Floating) -&gt; Floating<td>OpGroupNonUniformBroadcastFirst
+  <tr><td>subgroupAdd(Integral) -&gt; Integral<td>OpGroupNonUniformIAdd with Reduce
+  <tr><td>subgroupAdd(Floating) -&gt; Floating<td>OpGroupNonUniformFAdd with Reduce
+  <tr><td>subgroupMul(Integral) -&gt; Integral<td>OpGroupNonUniformIMul with Reduce
+  <tr><td>subgroupMul(Floating) -&gt; Floating<td>OpGroupNonUniformFMul with Reduce
+  <tr><td>subgroupMin(Integral) -&gt; Integral<td>OpGroupNonUniformUMin or OpGroupNonUniformSMin with Reduce
+  <tr><td>subgroupMin(Floating) -&gt; Floating<td>OpGroupNonUniformFMin with Reduce
+  <tr><td>subgroupMax(Integral) -&gt; Integral<td>OpGroupNonUniformUMax or OpGroupNonUniformSMax with Reduce
+  <tr><td>subgroupMax(Floating) -&gt; Floating<td>OpGroupNonUniformFMax with Reduce
+  <tr><td>subgroupAnd(Integral) -&gt; Integral<td>OpGroupNonUniformBitwiseAnd
+  <tr><td>subgroupOr(Integral) -&gt; Integral<td>OpGroupNonUniformBitwiseOr
+  <tr><td>subgroupXor(Integral) -&gt; Integral<td>OpGroupNonUniformBitwiseXor
+  <tr><td>subgroupPrefixAdd(Integral) -&gt; Integral<td>OpGroupNonUniformIAdd with ExclusiveScan
+  <tr><td>subgroupPrefixAdd(Floating) -&gt; Floating<td>OpGroupNonUniformFAdd with ExclusiveScan
+  <tr><td>subgroupPrefixMul(Integral) -&gt; Integral<td>OpGroupNonUniformIMul with ExclusiveScan
+  <tr><td>subgroupPrefixMul(Floating) -&gt; Floating<td>OpGroupNonUniformFMul with ExclusiveScan
+</table>
+
+Note: Subgroup built-in functions exist if "subgroup-operations" is enabled in requestDevice.
 
 # Glossary # {#glossary}
 


### PR DESCRIPTION
**Preview WebGPU Changes:** https://mehmetoguzderin.github.io/webgpu/webgpu.html
**Preview WGSL Changes:** https://mehmetoguzderin.github.io/webgpu/wgsl.html
**Preview Argdown:** https://kvark.github.io/webgpu-debate/SubgroupOps.component.html

This pull request works towards https://github.com/gpuweb/gpuweb/issues/667 for standard library. For that, the first form of subgroup operations extension to host and device specifications is introduced. Host exposure is directly deducible for all host APIs since it is compute-only, and the set of device instructions is the greatest common factor minus operations that take in a mask or invocation index.


# Motivation

Subgroup operations provide [speed-up](https://developer.nvidia.com/blog/cuda-pro-tip-optimized-filtering-warp-aggregated-atomics/) proportional to the subgroup size. They provide a great opportunity to optimize both global and local reduction operations, especially for algorithms that need to specialize general graphs. And their presence is getting more common than ever.


# Trade-offs

## Lack of Exposed Hardware Banding

Although it is possible to increase market penetration of subgroup operations extension significantly by banding it to permutation and reduction similar to Metal, such direction increases the API surface, possibly crusting for a very narrow use case. Moreover, [indicators](http://www.vulkan.gpuinfo.org/displayreport.php?id=9027) of next-generation mobile hardware show that they will almost ubiquitously support reduction operations.

## Exclusion of Quad Operations

This proposal excludes quad operations from the definition of subgroup operations. New hardware reports on [Adreno](http://www.vulkan.gpuinfo.org/displayreport.php?id=9027) and [PowerVR](http://vulkan.gpuinfo.org/displayreport.php?id=8768) show lack of quad support. Also, excluding quad operations makes it easier to avoid more ambiguous operations, delegating their presence to a proper quad operations extension.

## Exclusion of Indexed or Masked Operations

This proposal excludes indexed or masked operations to avoid undefined behavior on divergence, reconvergence, and possibly out of bounds indexing. The current set of exposed operations are implicitly active on all APIs.


# Presence of Extension for APIs

DirectX 12 | Metal | Vulkan
-|-|-
`D3D12_FEATURE_DATA_D3D12_OPTIONS1.WaveOps` | `MTLDevice.supportsFamily(MTLGPUFamilyMac2)` ([needs clarification](https://developer.apple.com/documentation/metal/porting_your_metal_code_to_apple_silicon): ` MTLDevice.supportsFamily(MTLGPUFamilyApple6)`) | `(VkPhysicalDeviceSubgroupProperties.supportedOperations & (VK_SUBGROUP_FEATURE_BASIC_BIT & VK_SUBGROUP_FEATURE_VOTE_BIT & VK_SUBGROUP_FEATURE_ARITHMETIC_BIT & VK_SUBGROUP_FEATURE_BALLOT_BIT)) & (VkPhysicalDeviceSubgroupProperties.supportedStages & VK_SHADER_STAGE_COMPUTE_BIT)`


# Related Issues

- https://github.com/gpuweb/gpuweb/issues/667
- https://github.com/gpuweb/gpuweb/issues/78
- https://github.com/gpuweb/WSL/issues/5
- https://github.com/gpuweb/gpuweb/pull/954
