### PR TITLE
Remove the void type

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -490,13 +490,6 @@ For convenience, the type tables use the following shorthands:
 
 TODO(dneto): Do we still need all these shorthands?
 
-## Void Type ## {#void-type}
-
-The <dfn noexport>void</dfn> type contains no values.
-
-It is used where a type is required by the language but where no values are produced or consumed.
-For example, it is used for the return type of a function which does not produce a value.
-
 ## Value Types ## {#value-types}
 
 ### Boolean Type ### {#bool-type}
@@ -2177,7 +2170,7 @@ The variable's [=store type=] must be [=storable=].
 
 <div class='example wgsl global-scope' heading="Function scope variables and constants">
   <xmp highlight='rust'>
-    fn f() -> void {
+    fn f() {
        var<function> count : u32;  // A variable in function storage class.
        var delta : i32;            // Another variable in the function storage class.
        var sum : f32 = 0.0;        // A function storage class variable with initializer.
@@ -2487,7 +2480,7 @@ The zero values are as follows:
       attendance : array<bool,4>;
     };
 
-    fn func() -> void {
+    fn func() {
       var s : Student;
 
       // The zero value for Student
@@ -3347,7 +3340,7 @@ Issue: Which index is used when it's out of bounds?
 
 ## Function Call Expression TODO ## {#function-call-expr}
 
-TODO: *Stub*. Call to function returning non-void, is an expression.
+TODO: *Stub*. Call to function that has a [=return type=] is an expression.
 
 ## Variable or const reference TODO ## {#var-const-ref-expr}
 
@@ -3872,8 +3865,9 @@ is terminated.
 Otherwise, evaluation continues with the next expression or statement after
 the evaluation of the call site of the current function invocation.
 
-If the [=return type=] of the function is the [=void=] type, then the return statement is
-optional. If the return statement is provided for a void function it must not have an expression.
+If the function doesn't have a [=return type=], then the return statement is
+optional. If the return statement is provided for such a function, it must not
+supply a value.
 Otherwise the expression must be present, and is called the *return value*.
 In this case the call site of this function invocation evaluates to the return value.
 The type of the return value must match the return type of the function.
@@ -4009,11 +4003,8 @@ See [[#function-calls]].
 The scope of the identifier is the whole function body.
 Two formal parameters for a given function must not have the same name.
 
-If the function declaration does not specify a return type, then the function return type is [=void=].
-
-If the return type is not [=void=],
-then the last statement in the function body must be a [=return=] statement.
-
+If the return type of the function is specified, then the last statement
+in the function body must be a return statement.
 
 <pre class='def'>
 function_decl
@@ -4024,11 +4015,7 @@ function_header
 
 function_return_type_decl_optional
   :
-  | ARROW function_return_type_decl
-
-function_return_type_decl
-  : attribute_list* type_decl
-  | VOID
+  | ARROW attribute_list* type_decl
 
 param_list
   :
@@ -4140,7 +4127,9 @@ When configuring the stage in the pipeline, the entry point is specified by prov
 the [SHORTNAME] module and the entry point's function name.
 
 The parameters of an entry point have to be within [=Entry point IO type=]s.
-The return type of an entry point has to be of an [=Entry point IO type=], or [=void=].
+The return type of an entry point has to be of an [=Entry point IO type=], if specified.
+
+Note: compute entry points never have a return type.
 
 <div class='example wgsl global-scope' heading='Entry Point'>
   <xmp>
@@ -4167,7 +4156,7 @@ The return type of an entry point has to be of an [=Entry point IO type=], or [=
        // %return_value = OpVariable %ptr Output
 
     [[stage(compute)]]
-    fn comp_main() -> void { }
+    fn comp_main() { }
        // OpEntryPoint GLCompute %comp_main "comp_main"
   </xmp>
 </div>
@@ -4193,17 +4182,17 @@ ISSUE: Can we query upper bounds on workgroup size dimensions?  Is it independen
 <div class='example wgsl global-scope' heading='workgroup_size Attribute'>
   <xmp>
     [[ stage(compute), workgroup_size(8,1,1) ]]
-    fn sorter() -> void { }
+    fn sorter() { }
        // OpEntryPoint GLCompute %sorter "sorter"
        // OpExecutionMode %sorter LocalSize 8 1 1
 
     [[ stage(compute), workgroup_size(8) ]]
-    fn reverser() -> void { }
+    fn reverser() { }
        // OpEntryPoint GLCompute %reverser "reverser"
        // OpExecutionMode %reverser LocalSize 8 1 1
 
     [[ stage(compute) ]]
-    fn do_nothing() -> void { }
+    fn do_nothing() { }
        // OpEntryPoint GLCompute %do_nothing "do_nothing"
        // OpExecutionMode %do_nothing LocalSize 1 1 1
   </xmp>
@@ -4270,7 +4259,7 @@ The set of built-in outputs are listed in [[#builtin-variables]].
 To declare a variable for accessing a particular output built-in *Y* from an entry point:
 
 * Add a variable to the result of the entry point, where [=store type=] is the listed store type for *Y*:
-  * If the result type was [=void=], change it to the variable type.
+  * If there is no result type for the entry point, change it to the variable type.
   * Otherwise, make the result type to be a structure, where one of the fields is the new variable.
 * Apply a `builtin(`*Y*`)` attribute to the result variable.
 
@@ -4709,7 +4698,6 @@ I've written what an NVIDIA GPU does.  See https://github.com/google/amber/pull/
   <tr><td>`VEC2`<td>vec2
   <tr><td>`VEC3`<td>vec3
   <tr><td>`VEC4`<td>vec4
-  <tr><td>`VOID`<td>void
 </table>
 <table class='data'>
   <caption>Other keywords</caption>
@@ -5081,7 +5069,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
       //     OpDecorate %local_index BuiltIn LocalInvocationIndex
       [[builtin(global_invocation_id)]] global_id : vec3<u32>,
       //      OpDecorate %global_id BuiltIn GlobalInvocationId
-   ) -> void;
+   );
   </xmp>
 </div>
 
@@ -6049,10 +6037,10 @@ The sampled value.
 Writes a single texel to a texture.
 
 ```rust
-textureStore(t : [[access(write)]] texture_storage_1d<F>, coords : i32, value : vec4<T>) -> void
-textureStore(t : [[access(write)]] texture_storage_2d<F>, coords : vec2<i32>, value : vec4<T>) -> void
-textureStore(t : [[access(write)]] texture_storage_2d_array<F>, coords : vec2<i32>, array_index : i32, value : vec4<T>) -> void
-textureStore(t : [[access(write)]] texture_storage_3d<F>, coords : vec3<i32>, value : vec4<T>) -> void
+textureStore(t : [[access(write)]] texture_storage_1d<F>, coords : i32, value : vec4<T>)
+textureStore(t : [[access(write)]] texture_storage_2d<F>, coords : vec2<i32>, value : vec4<T>)
+textureStore(t : [[access(write)]] texture_storage_2d_array<F>, coords : vec2<i32>, array_index : i32, value : vec4<T>)
+textureStore(t : [[access(write)]] texture_storage_3d<F>, coords : vec3<i32>, value : vec4<T>)
 ```
 
 The channel format `T` depends on the storage texel format `F`.
@@ -6198,8 +6186,8 @@ reduce a shader's memory bandwidth demand.
 [SHORTNAME] provides the following synchronization functions:
 
 ```rust
-fn storageBarrier() -> void
-fn workgroupBarrier() -> void
+fn storageBarrier()
+fn workgroupBarrier()
 ```
 
 All synchronization functions execute a control barrier with Acquire/Release


### PR DESCRIPTION
Closes #1219
Closes #743

Basically, there is no utility right now for this type. It's obvious from looking at a function signature if a return statement is required, without the type.
If we ever feel that the type is needed, we can bring it back.