### PR TITLE
Make requestDevice not return null

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1331,7 +1331,7 @@ interface GPUAdapter {
     [SameObject] readonly attribute GPUAdapterFeatures features;
     [SameObject] readonly attribute GPUAdapterLimits limits;
 
-    Promise<GPUDevice?> requestDevice(optional GPUDeviceDescriptor descriptor = {});
+    Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor = {});
 };
 </script>
 
@@ -1402,10 +1402,18 @@ interface GPUAdapter {
                                 |adapter|.{{adapter/[[limits]]}}.
                         </div>
 
-                    1. If the user agent cannot fulfill the request,
-                        [=resolve=] |promise| to `null` and stop.
+                    1. If the user agent cannot fulfill the request:
 
-                    1. [=Resolve=] |promise| to a new {{GPUDevice}} object encapsulating
+                        1. Let |device| be a new {{GPUDevice}} object which has
+                            {{GPUDevice/lost|GPUDevice.lost}} resolved with a {{GPUDeviceLostInfo}}
+                            with {{GPUDeviceLostInfo/reason}} `undefined` and an
+                            implementation-defined {{GPUDeviceLostInfo/message}}.
+
+                            Issue: Probably centralize this better with other device loss triggering, once added.
+
+                        1. [=Resolve=] |promise| with |device| and stop.
+
+                    1. [=Resolve=] |promise| with a new {{GPUDevice}} object encapsulating
                         [=a new device=] with the capabilities described by |descriptor|.
                 </div>
             1. Return |promise|.


### PR DESCRIPTION
`requestDevice` returning null simply means "the UA couldn't do it for
some reason". There's no reason this should be distinguishable from device
loss, as it's essentially the same as the device being lost "at the last
moment" just before it's returned.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1465.html" title="Last updated on Feb 24, 2021, 7:16 AM UTC (a652153)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1465/0dc0dc1...kainino0x:a652153.html" title="Last updated on Feb 24, 2021, 7:16 AM UTC (a652153)">Diff</a>