### PR TITLE
Add an array access expression for runtime arrays

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2683,7 +2683,15 @@ Issue: Which index is used when it's out of bounds?
        <td>The result is the value of the |i|'<sup>th</sup> element of the array value |e|.<br>
            The first element is at index |i|=0.<br>
            If |i| is outside the range [0,|N|-1], then an index in the range [0, |N|-1] is used instead.<br>
-           (OpCompositeExtract)
+  <tr algorithm="runtime-sized array indexed element selection">
+       <td class="nowrap">
+          |e| : array&lt;|T|&gt;<br>
+          |i| : *Int*
+       <td class="nowrap">
+           |e|[|i|] : |T|
+       <td>The result is the value of the |i|'<sup>th</sup> element of the array value |e|.<br>
+           The first element is at index |i|=0.<br>
+           If |i| is outside the range [0,arrayLength(|e|)-1], then an index in the range [0, arrayLength(|e|)-1] is used instead.<br>
 </table>
 
 Issue: Which index is used when it's out of bounds?


### PR DESCRIPTION
* Missing expression for runtime-sized arrays
  * Limited to range [0, arrayLength(e) - 1]
* Removed suggestion that OpCompositeExtract is the SPIR-V translation
  as that is not always the case