### PR TITLE
Support basic inter-scope shadowing.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -199,9 +199,10 @@ Issue: (dneto) also lifetime.
 There are multiple levels of scoping depending on how and where things are
 declared.
 
-A declaration must not introduce a name when that name is already in scope at the start
+A declaration must not introduce a name when that name is already in the current scope at the start
 of the declaration.
-That is, shadow names are not allowed in [SHORTNAME].
+That is, shadow names are not allowed within the same scope, but shadowing of indentifiers in a
+more-outer scope is allowed.
 
 
 # Types # {#types}


### PR DESCRIPTION
Continue to forbid intra-scope shadowing.

```
var foo;
if (...) {
  var bar;
  var foo; // Allowed
  var bar; // Forbidden
}
```