### PR TITLE
Remove GPUDevice.adapter

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1479,7 +1479,6 @@ To get a {{GPUDevice}}, use {{GPUAdapter/requestDevice()}}.
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), Serializable]
 interface GPUDevice : EventTarget {
-    [SameObject] readonly attribute GPUAdapter adapter;
     readonly attribute FrozenArray<GPUFeatureName> features;
     readonly attribute object limits;
 
@@ -1512,10 +1511,6 @@ GPUDevice includes GPUObjectBase;
 {{GPUDevice}} has the following attributes:
 
 <dl dfn-type=attribute dfn-for=GPUDevice>
-    : <dfn>adapter</dfn>
-    ::
-        The {{GPUAdapter}} from which this device was created.
-
     : <dfn>features</dfn>
     ::
         A sequence containing the {{GPUFeatureName}} values of the features


### PR DESCRIPTION
Subset of #1309

GPUDevice.features and .limits are quite useful (e.g. for middleware). However we don't have "parent" pointers on other objects now, and they're not as obviously useful. We can definitely consider adding it back later but we should consider other "parent" pointers at the same time.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1478.html" title="Last updated on Mar 1, 2021, 10:47 PM UTC (9a7eaf0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1478/03e8058...kainino0x:9a7eaf0.html" title="Last updated on Mar 1, 2021, 10:47 PM UTC (9a7eaf0)">Diff</a>