### PR TITLE
Remove [EnforceRange] in GPUAdapterLimits

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1136,23 +1136,23 @@ See {{GPUAdapter/limits|GPUAdapter.limits}}.
 
 <script type=idl>
 interface GPUAdapterLimits {
-    readonly attribute GPUSize32 maxTextureDimension1D;
-    readonly attribute GPUSize32 maxTextureDimension2D;
-    readonly attribute GPUSize32 maxTextureDimension3D;
-    readonly attribute GPUSize32 maxTextureArrayLayers;
-    readonly attribute GPUSize32 maxBindGroups;
-    readonly attribute GPUSize32 maxDynamicUniformBuffersPerPipelineLayout;
-    readonly attribute GPUSize32 maxDynamicStorageBuffersPerPipelineLayout;
-    readonly attribute GPUSize32 maxSampledTexturesPerShaderStage;
-    readonly attribute GPUSize32 maxSamplersPerShaderStage;
-    readonly attribute GPUSize32 maxStorageBuffersPerShaderStage;
-    readonly attribute GPUSize32 maxStorageTexturesPerShaderStage;
-    readonly attribute GPUSize32 maxUniformBuffersPerShaderStage;
-    readonly attribute GPUSize32 maxUniformBufferBindingSize;
-    readonly attribute GPUSize32 maxStorageBufferBindingSize;
-    readonly attribute GPUSize32 maxVertexBuffers;
-    readonly attribute GPUSize32 maxVertexAttributes;
-    readonly attribute GPUSize32 maxVertexBufferArrayStride;
+    readonly attribute unsigned long maxTextureDimension1D;
+    readonly attribute unsigned long maxTextureDimension2D;
+    readonly attribute unsigned long maxTextureDimension3D;
+    readonly attribute unsigned long maxTextureArrayLayers;
+    readonly attribute unsigned long maxBindGroups;
+    readonly attribute unsigned long maxDynamicUniformBuffersPerPipelineLayout;
+    readonly attribute unsigned long maxDynamicStorageBuffersPerPipelineLayout;
+    readonly attribute unsigned long maxSampledTexturesPerShaderStage;
+    readonly attribute unsigned long maxSamplersPerShaderStage;
+    readonly attribute unsigned long maxStorageBuffersPerShaderStage;
+    readonly attribute unsigned long maxStorageTexturesPerShaderStage;
+    readonly attribute unsigned long maxUniformBuffersPerShaderStage;
+    readonly attribute unsigned long maxUniformBufferBindingSize;
+    readonly attribute unsigned long maxStorageBufferBindingSize;
+    readonly attribute unsigned long maxVertexBuffers;
+    readonly attribute unsigned long maxVertexAttributes;
+    readonly attribute unsigned long maxVertexBufferArrayStride;
 };
 </script>
 


### PR DESCRIPTION
Fixes #1484


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1485.html" title="Last updated on Mar 3, 2021, 7:07 PM UTC (851b811)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1485/03e8058...kainino0x:851b811.html" title="Last updated on Mar 3, 2021, 7:07 PM UTC (851b811)">Diff</a>