### PR TITLE
Make read_write access the default for storage buffers

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1717,8 +1717,9 @@ The access decoration must only appear on a type used as the store type for a
 variable in the [=storage classes/storage=] storage class.
 The access decoration must not appear
 on a type of const declaration nor as the store type for variable with a
-storage class other than [=storage classes/storage=]. The access decoration is required for
-variables in the [=storage classes/storage=] storage class.
+storage class other than [=storage classes/storage=]. If the access decoration
+is not present on the store type of a [=storage classes/storage=] storage class
+variable, it defaults to `read_write`.
 
 Two variables with overlapping lifetimes will not have overlapping storage.
 


### PR DESCRIPTION
* Remove the requirement to specify an access decoration for storage
  buffers
  * Make the default access read_write
* The makes the most common case simpler to use