### PR TITLE
[wgsl] Update grammar rules for entry point IO

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3682,7 +3682,7 @@ function_decl
   : decoration_list* function_header body_statement
 
 function_type_decl
-  : type_decl
+  : decoration_list* type_decl
   | VOID
 
 function_header
@@ -3690,7 +3690,10 @@ function_header
 
 param_list
   :
-  | (variable_ident_decl COMMA)* variable_ident_decl
+  | (param COMMA)* param
+
+param
+  : decoration_list* variable_ident_decl
 </pre>
 
 <table class='data'>
@@ -3703,6 +3706,22 @@ param_list
           Each parameter is either an i32 literal or the name of a [=pipeline-overridable=] constant of i32 type.
       <td>Specifies the x, y and z dimensions of the [=workgroup grid=] for the compute shader.
       <br>See [[#entry-point-attributes]].
+</table>
+
+<table class='data'>
+  <thead>
+    <tr><th>Function type decoration keys<th>Valid values<th>Note
+  </thead>
+  <tr><td>`builtin`<td>a builtin variable identifier<td>See [[#builtin-variables]]
+  <tr><td>`location`<td>non-negative i32 literal<td>See TBD
+</table>
+
+<table class='data'>
+  <thead>
+    <tr><th>Function parameter decoration keys<th>Valid values<th>Note
+  </thead>
+  <tr><td>`builtin`<td>a builtin variable identifier<td>See [[#builtin-variables]]
+  <tr><td>`location`<td>non-negative i32 literal<td>See TBD
 </table>
 
 <div class='example' heading='Function'>
@@ -4494,8 +4513,6 @@ the test name.
           module.
 * v-0021: Cannot re-assign a constant.
 * v-0022: Global variables must have a storage class.
-* v-0023: Entry point functions accept no parameters.
-* v-0024: Entry point functions return void.
 * v-0025: Switch statement selector expression must be of a scalar integer type.
 * v-0026: The case selector values must have the same type as the selector expression.
 * v-0027: A literal value must not appear more than once in the case selectors for a switch statement.


### PR DESCRIPTION
This is required for the grammar to support the changes made in #1426.

Also removes two obsolete validation rules.

Might be desirable to interleave those decoration keys tables with the grammar as done in other parts of the spec? LMK.