### PR TITLE
Revert "Add an array access expression for runtime arrays"

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2687,15 +2687,7 @@ Issue: Which index is used when it's out of bounds?
        <td>The result is the value of the |i|'<sup>th</sup> element of the array value |e|.<br>
            The first element is at index |i|=0.<br>
            If |i| is outside the range [0,|N|-1], then an index in the range [0, |N|-1] is used instead.<br>
-  <tr algorithm="runtime-sized array indexed element selection">
-       <td class="nowrap">
-          |e| : array&lt;|T|&gt;<br>
-          |i| : *Int*
-       <td class="nowrap">
-           |e|[|i|] : |T|
-       <td>The result is the value of the |i|'<sup>th</sup> element of the array value |e|.<br>
-           The first element is at index |i|=0.<br>
-           If |i| is outside the range [0,arrayLength(|e|)-1], then an index in the range [0, arrayLength(|e|)-1] is used instead.<br>
+           (OpCompositeExtract)
 </table>
 
 Issue: Which index is used when it's out of bounds?


### PR DESCRIPTION
Reverts gpuweb/gpuweb#1468

Reverting because we have the rule:

> The type of an expression must not be a runtime-sized array type.

You should not have been able to "load" the whole runtime array in the first place.