### PR TITLE
Rename sample_mask_out to sample_mask

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3956,9 +3956,8 @@ or the local variables in the function scope.
 A variable must not have more than one `builtin` attribute.
 
 Each built-in variable has an associated shader stage, as described in [[#builtin-variables]].
-If a built-in variable has stage *S* and is [=statically accessed=] by a function *F*,
-then *F* must be a [=functions in a shader stage|function in a shader=]
-for stage *S*.
+If a built-in variable has stage *S* and is used by a function *F*, as either an argument or the
+result type, then *F* must be a [=functions in a shader stage|function in a shader=] for stage *S*.
 
 Issue:
     1. The statement makes it clear that in/out storage classes for builtins are redundant.
@@ -4626,7 +4625,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
          is the number of MSAA samples specified for the GPU render pipeline.
          <br>See [[WebGPU#gpurenderpipe|WebGPU &sect; GPURenderPipeline]].
 
-  <tr><td>`sample_mask_in`
+  <tr><td>`sample_mask`
       <td>fragment
       <td>in
       <td>u32
@@ -4635,7 +4634,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
          by the primitive being rendered.
          <br>See [[WebGPU#sample-masking|WebGPU &sect; Sample Masking]].
 
-  <tr><td>`sample_mask_out`
+  <tr><td>`sample_mask`
       <td>fragment
       <td>out
       <td>u32
@@ -4644,10 +4643,6 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
          [[WebGPU#shader-output-mask|shader-output mask]].
          Zero bits in the written value will cause corresponding samples in
          the color attachments to be discarded.
-         <br>The value in the variable is significant only if the
-         `sample_mask_out` variable is [=statically accessed=]
-         by the fragment shader. If the variable is not statically accessed,
-         then other factors determine sample coverage.
          <br>See [[WebGPU#sample-masking|WebGPU &sect; Sample Masking]].
 </table>
 
@@ -4676,7 +4671,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
     struct FragmentOutput {
       [[builtin(frag_depth)]] depth: f32;
       //     OpDecorate %depth BuiltIn FragDepth
-      [[builtin(sample_mask_out)]] mask_out : u32;
+      [[builtin(sample_mask)]] mask_out : u32;
       //      OpDecorate %mask_out BuiltIn SampleMask ; an output variable
     };
 


### PR DESCRIPTION
Another follow-up to #1426, in addition to #143.
Having the names distinct is no longer needed.
Related to #1318 and #1346