### PR TITLE
Allow trailing commas in the argument lists, calls, and cases

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4966,7 +4966,7 @@ function_return_type_decl_optional
 
 param_list
   :
-  | (param COMMA)* param
+  | (param COMMA)* param COMMA?
 
 param
   : attribute_list* variable_ident_decl

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4261,7 +4261,7 @@ primary_expression
       OpBitcast
 
 argument_expression_list
-  : PAREN_LEFT ((short_circuit_or_expression COMMA)* short_circuit_or_expression)? PAREN_RIGHT
+  : PAREN_LEFT ((short_circuit_or_expression COMMA)* short_circuit_or_expression COMMA?)? PAREN_RIGHT
 
 postfix_expression
   :
@@ -4471,7 +4471,7 @@ switch_body
   | DEFAULT COLON BRACE_LEFT case_body BRACE_RIGHT
 
 case_selectors
-  : const_literal (COMMA const_literal)*
+  : const_literal (COMMA const_literal)* COMMA?
 
 case_body
   :


### PR DESCRIPTION
The spec has an example show why this is good:
```rust
    [[stage(vertex)]]
    fn vs_main(
      [[builtin(vertex_index)]] my_index: u32,
      [[builtin(instance_index)]] my_inst_index : u32, // <- trailing comma
    ) -> VertexOutput;
```