### PR TITLE
Add validation rules for Occlusion Query

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6733,7 +6733,7 @@ attachments used by this encoder.
             <div class=device-timeline>
                 1. If any of the following conditions are unsatisfied, generate a validation error and stop.
                     <div class=validusage>
-                        - |this|.{{GPURenderPassEncoder/[[occlusion_query_set]]}} is not null.
+                        - |this|.{{GPURenderPassEncoder/[[occlusion_query_set]]}} is not `null`.
                         - |queryIndex| &lt; |this|.{{GPURenderPassEncoder/[[occlusion_query_set]]}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}}.
                         - The query at same |queryIndex| must not have been previously written to in this pass.
                         - |this|.{{GPURenderPassEncoder/[[occlusion_query_active]]}} is `false`.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4900,7 +4900,6 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                             are considered to be used as [=internal usage/attachment-read=] for the duration of the render pass.
                     1. Else, the [=texture subresource=] seen by |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/view}}
                         is considered to be used as [=internal usage/attachment=] for the duration of the render pass.
-                1. Let |occlusionQuerySet| be |descriptor|.{{GPURenderPassDescriptor/occlusionQuerySet}}.
             </div>
 
             Issue: specify the behavior of read-only depth/stencil

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6730,7 +6730,7 @@ attachments used by this encoder.
                 1. If any of the following conditions are unsatisfied, generate a validation error and stop.
                     <div class=validusage>
                         - |this|.{{GPURenderPassEncoder/[[occlusion_query_set]]}} is [$valid to use with$] |this|.{{GPUObjectBase/[[device]]}}.
-                        - The query at same |queryIndex| can not be written twice in the same |this|.
+                        - The query at same |queryIndex| must not have been previously written to in this pass.
                         - The query can not be begun if the last occlsuion query is not ended.
                     </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7279,10 +7279,10 @@ enum GPUQueryType {
 
 ## Occlusion Query ## {#occlusion}
 
-Occlusion query is only available on render pass, to query the number of samples that pass all the
+Occlusion query is only available on render passes, to query the number of samples that pass all the
 per-fragment tests for a set of drawing commands, including scissor, sample mask, alpha to
 coverage, stencil, and depth tests. Any non-zero result value for the query indicates that at least
-one sample passes the tests, 0 indicates that no sample passes the tests.
+one sample passed the tests, 0 indicates that no samples passed the tests.
 
 When beginning a render pass, {{GPURenderPassDescriptor}}.{{GPURenderPassDescriptor/occlusionQuerySet}} must be set to be able to use occlusion queries during the pass. An occlusion query is begun
 and ended by calling {{GPURenderPassEncoder/beginOcclusionQuery()}} and

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6093,9 +6093,13 @@ GPURenderPassEncoder includes GPURenderEncoderBase;
         Set to the following extents:
             - `width, height` = the dimensions of the pass's render attachments
 
-    : <dfn>\[[occlusion_query_set]]</dfn>
+    : <dfn>\[[occlusion_query_set]]</dfn>, of type {{GPUQuerySet}}.
     ::
-        The current {{GPUQuerySet}} to write occlusion query data, initially `null`.
+        The current {{GPUQuerySet}} to write occlusion query data for the pass, initially `null`.
+
+    : <dfn>\[[occlusion_query_active]]</dfn>, of type {{boolean}}.
+    ::
+        Whether the pass's {{GPURenderPassEncoder/[[occlusion_query_set]]}} is being written.
 </dl>
 
 When a {{GPURenderPassEncoder}} is created, it has the following default state:
@@ -6130,7 +6134,7 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
 
     : <dfn>occlusionQuerySet</dfn>
     ::
-        The {{GPUQuerySet}} value defines where the occlusion query results will be output when beginning occlusion query.
+        The {{GPUQuerySet}} value defines where the occlusion query results will be stored for this pass.
 </dl>
 
 <div class=validusage dfn-for=GPURenderPassDescriptor>
@@ -6729,12 +6733,13 @@ attachments used by this encoder.
             <div class=device-timeline>
                 1. If any of the following conditions are unsatisfied, generate a validation error and stop.
                     <div class=validusage>
-                        - |this|.{{GPURenderPassEncoder/[[occlusion_query_set]]}} is [$valid to use with$] |this|.{{GPUObjectBase/[[device]]}}.
+                        - |this|.{{GPURenderPassEncoder/[[occlusion_query_set]]}} is not null.
+                        - |queryIndex| &lt; |this|.{{GPURenderPassEncoder/[[occlusion_query_set]]}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}}.
                         - The query at same |queryIndex| must not have been previously written to in this pass.
-                        - The query can not be begun if the last occlsuion query is not ended.
+                        - |this|.{{GPURenderPassEncoder/[[occlusion_query_active]]}} is false.
                     </div>
 
-                Issue: Describe {{GPURenderPassEncoder/beginOcclusionQuery()}} algorithm steps.
+                1. Set |this|.{{GPURenderPassEncoder/[[occlusion_query_active]]}} to true.
             </div>
         </div>
 
@@ -6750,11 +6755,10 @@ attachments used by this encoder.
             <div class=device-timeline>
                 1. If any of the following conditions are unsatisfied,  generate a validation error and stop.
                     <div class=validusage>
-                        - |this|.{{GPURenderPassEncoder/[[occlusion_query_set]]}} is [$valid to use with$] |this|.{{GPUObjectBase/[[device]]}}.
-                        - The query can not be ended if it is not begun.
+                        - |this|.{{GPURenderPassEncoder/[[occlusion_query_active]]}} is true.
                     </div>
 
-                Issue: Describe {{GPURenderPassEncoder/endOcclusionQuery()}} algorithm steps.
+                1. Set |this|.{{GPURenderPassEncoder/[[occlusion_query_active]]}} to false.
             </div>
         </div>
 
@@ -7284,7 +7288,8 @@ per-fragment tests for a set of drawing commands, including scissor, sample mask
 coverage, stencil, and depth tests. Any non-zero result value for the query indicates that at least
 one sample passed the tests, 0 indicates that no samples passed the tests.
 
-When beginning a render pass, {{GPURenderPassDescriptor}}.{{GPURenderPassDescriptor/occlusionQuerySet}} must be set to be able to use occlusion queries during the pass. An occlusion query is begun
+When beginning a render pass, {{GPURenderPassDescriptor}}.{{GPURenderPassDescriptor/occlusionQuerySet}}
+must be set to be able to use occlusion queries during the pass. An occlusion query is begun
 and ended by calling {{GPURenderPassEncoder/beginOcclusionQuery()}} and
 {{GPURenderPassEncoder/endOcclusionQuery()}} in pairs that cannot be nested.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6736,10 +6736,10 @@ attachments used by this encoder.
                         - |this|.{{GPURenderPassEncoder/[[occlusion_query_set]]}} is not null.
                         - |queryIndex| &lt; |this|.{{GPURenderPassEncoder/[[occlusion_query_set]]}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}}.
                         - The query at same |queryIndex| must not have been previously written to in this pass.
-                        - |this|.{{GPURenderPassEncoder/[[occlusion_query_active]]}} is false.
+                        - |this|.{{GPURenderPassEncoder/[[occlusion_query_active]]}} is `false`.
                     </div>
 
-                1. Set |this|.{{GPURenderPassEncoder/[[occlusion_query_active]]}} to true.
+                1. Set |this|.{{GPURenderPassEncoder/[[occlusion_query_active]]}} to `true`.
             </div>
         </div>
 
@@ -6755,10 +6755,10 @@ attachments used by this encoder.
             <div class=device-timeline>
                 1. If any of the following conditions are unsatisfied, generate a validation error and stop.
                     <div class=validusage>
-                        - |this|.{{GPURenderPassEncoder/[[occlusion_query_active]]}} is true.
+                        - |this|.{{GPURenderPassEncoder/[[occlusion_query_active]]}} is `true`.
                     </div>
 
-                1. Set |this|.{{GPURenderPassEncoder/[[occlusion_query_active]]}} to false.
+                1. Set |this|.{{GPURenderPassEncoder/[[occlusion_query_active]]}} to `false`.
             </div>
         </div>
 
@@ -6867,6 +6867,7 @@ called the render pass encoder can no longer be used.
                     error and stop.
                     <div class=validusage>
                         - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}'s [=stack/size=] is 0.
+                        - |this|.{{GPURenderPassEncoder/[[occlusion_query_active]]}} is `false`.
 
                         Issue: Add remaining validation.
                     </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6092,6 +6092,10 @@ GPURenderPassEncoder includes GPURenderEncoderBase;
     ::
         Set to the following extents:
             - `width, height` = the dimensions of the pass's render attachments
+
+    : <dfn>\[[occlusion_query_set]]</dfn>
+    ::
+        The current {{GPUQuerySet}} to write occlusion query data, initially `null`.
 </dl>
 
 When a {{GPURenderPassEncoder}} is created, it has the following default state:
@@ -6126,7 +6130,7 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
 
     : <dfn>occlusionQuerySet</dfn>
     ::
-        Issue: Describe this dictionary member
+        The {{GPUQuerySet}} value defines where the occlusion query results will be output when beginning occlusion query.
 </dl>
 
 <div class=validusage dfn-for=GPURenderPassDescriptor>
@@ -6153,6 +6157,11 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
     1. The dimensions of the [=subresource=]s seen by each {{GPURenderPassColorAttachment/view}} in |this|.{{GPURenderPassDescriptor/colorAttachments}}
         and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachment/view}},
         if present, must match.
+
+    1. If |this|.{{GPURenderPassDescriptor/occlusionQuerySet}} is not `null`:
+
+        1. |this|.{{GPURenderPassDescriptor/occlusionQuerySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/type}}
+            must be {{GPUQueryType/occlusion}}.
 
     Issue: Define <dfn for=>maximum color attachments</dfn>
 
@@ -6707,16 +6716,26 @@ attachments used by this encoder.
     ::
 
         <div algorithm="GPURenderPassEncoder.beginOcclusionQuery">
-            **Called on:** {{GPURenderPassEncoder}} this.
+            **Called on:** {{GPURenderPassEncoder}} |this|.
 
             **Arguments:**
             <pre class=argumentdef for="GPURenderPassEncoder/beginOcclusionQuery(queryIndex)">
-                queryIndex:
+                |queryIndex|: The index of the query in the query set.
             </pre>
 
             **Returns:** {{undefined}}
 
-            Issue: Describe {{GPURenderPassEncoder/beginOcclusionQuery()}} algorithm steps.
+            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+            <div class=device-timeline>
+                1. If any of the following conditions are unsatisfied, generate a validation error and stop.
+                    <div class=validusage>
+                        - |this|.{{GPURenderPassEncoder/[[occlusion_query_set]]}} is [$valid to use with$] |this|.{{GPUObjectBase/[[device]]}}.
+                        - The query at same |queryIndex| can not be written twice in the same |this|.
+                        - The query can not be begun if the last occlsuion query is not ended.
+                    </div>
+
+                Issue: Describe {{GPURenderPassEncoder/beginOcclusionQuery()}} algorithm steps.
+            </div>
         </div>
 
     : <dfn>endOcclusionQuery()</dfn>
@@ -6727,7 +6746,16 @@ attachments used by this encoder.
 
             **Returns:** {{undefined}}
 
-            Issue: Describe {{GPURenderPassEncoder/endOcclusionQuery()}} algorithm steps.
+            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+            <div class=device-timeline>
+                1. If any of the following conditions are unsatisfied,  generate a validation error and stop.
+                    <div class=validusage>
+                        - |this|.{{GPURenderPassEncoder/[[occlusion_query_set]]}} is [$valid to use with$] |this|.{{GPUObjectBase/[[device]]}}.
+                        - The query can not be ended if it is not begun.
+                    </div>
+
+                Issue: Describe {{GPURenderPassEncoder/endOcclusionQuery()}} algorithm steps.
+            </div>
         </div>
 
     : <dfn>beginPipelineStatisticsQuery(querySet, queryIndex)</dfn>
@@ -7248,6 +7276,18 @@ enum GPUQueryType {
     "timestamp"
 };
 </script>
+
+## Occlusion Query ## {#occlusion}
+
+Occlusion query is only available on render pass, to query the number of samples that pass all the
+per-fragment tests for a set of drawing commands, including scissor, sample mask, alpha to
+coverage, stencil, and depth tests. Any non-zero result value for the query indicates that at least
+one sample passes the tests, 0 indicates that no sample passes the tests.
+
+When beginning a render pass, {{GPURenderPassDescriptor/occlusionQuerySet}} in {{GPURenderPassDescriptor}}
+need to be set if we plan to call occlsuion query on the render pass. An occlusion query is begun
+and ended by calling {{GPURenderPassEncoder/beginOcclusionQuery()}} and
+{{GPURenderPassEncoder/endOcclusionQuery()}} in pairs.
 
 ## Pipeline Statistics Query ## {#pipeline-statistics}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7284,10 +7284,9 @@ per-fragment tests for a set of drawing commands, including scissor, sample mask
 coverage, stencil, and depth tests. Any non-zero result value for the query indicates that at least
 one sample passes the tests, 0 indicates that no sample passes the tests.
 
-When beginning a render pass, {{GPURenderPassDescriptor/occlusionQuerySet}} in {{GPURenderPassDescriptor}}
-need to be set if we plan to call occlsuion query on the render pass. An occlusion query is begun
+When beginning a render pass, {{GPURenderPassDescriptor}}.{{GPURenderPassDescriptor/occlusionQuerySet}} must be set to be able to use occlusion queries during the pass. An occlusion query is begun
 and ended by calling {{GPURenderPassEncoder/beginOcclusionQuery()}} and
-{{GPURenderPassEncoder/endOcclusionQuery()}} in pairs.
+{{GPURenderPassEncoder/endOcclusionQuery()}} in pairs that cannot be nested.
 
 ## Pipeline Statistics Query ## {#pipeline-statistics}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6753,7 +6753,7 @@ attachments used by this encoder.
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. If any of the following conditions are unsatisfied,  generate a validation error and stop.
+                1. If any of the following conditions are unsatisfied, generate a validation error and stop.
                     <div class=validusage>
                         - |this|.{{GPURenderPassEncoder/[[occlusion_query_active]]}} is true.
                     </div>
@@ -7283,10 +7283,11 @@ enum GPUQueryType {
 
 ## Occlusion Query ## {#occlusion}
 
-Occlusion query is only available on render passes, to query the number of samples that pass all the
-per-fragment tests for a set of drawing commands, including scissor, sample mask, alpha to
+Occlusion query is only available on render passes, to query the number of fragment samples that pass
+all the per-fragment tests for a set of drawing commands, including scissor, sample mask, alpha to
 coverage, stencil, and depth tests. Any non-zero result value for the query indicates that at least
-one sample passed the tests, 0 indicates that no samples passed the tests.
+one sample passed the tests and reached the output merging stage of the render pipeline, 0 indicates
+that no samples passed the tests.
 
 When beginning a render pass, {{GPURenderPassDescriptor}}.{{GPURenderPassDescriptor/occlusionQuerySet}}
 must be set to be able to use occlusion queries during the pass. An occlusion query is begun

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4900,6 +4900,7 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                             are considered to be used as [=internal usage/attachment-read=] for the duration of the render pass.
                     1. Else, the [=texture subresource=] seen by |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/view}}
                         is considered to be used as [=internal usage/attachment=] for the duration of the render pass.
+                1. Let |occlusionQuerySet| be |descriptor|.{{GPURenderPassDescriptor/occlusionQuerySet}}.
             </div>
 
             Issue: specify the behavior of read-only depth/stencil
@@ -6095,7 +6096,8 @@ GPURenderPassEncoder includes GPURenderEncoderBase;
 
     : <dfn>\[[occlusion_query_set]]</dfn>, of type {{GPUQuerySet}}.
     ::
-        The current {{GPUQuerySet}} to write occlusion query data for the pass, initially `null`.
+        The {{GPUQuerySet}} to store occlusion query results for the pass, which is initialized with
+        {{GPURenderPassDescriptor}}.{{GPURenderPassDescriptor/occlusionQuerySet}} at pass creation time.
 
     : <dfn>\[[occlusion_query_active]]</dfn>, of type {{boolean}}.
     ::


### PR DESCRIPTION
- Add description for occlusionQuerySet and Occlusion Query
- Add valid usage in occlusionQuery, beginOcclusionQuery() and endOcclusionQuery()


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/haoxli/gpuweb/pull/1494.html" title="Last updated on Mar 9, 2021, 10:46 AM UTC (0c05305)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1494/ea8e06a...haoxli:0c05305.html" title="Last updated on Mar 9, 2021, 10:46 AM UTC (0c05305)">Diff</a>