### PR TITLE
Added `HTMLCanvasElement.getContext` definition

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7283,15 +7283,15 @@ Issue: Because timestamp query provides high-resolution GPU timestamp, we need t
 
 ## HTMLCanvasElement.getContext ## {#canvas-getcontext}
 
-A {{GPUCanvasContext}} object can be obtained via the `getContext` method of a {{HTMLCanvasElement}} instance by
+A {{GPUCanvasContext}} object can be obtained via the `getContext` method of an {{HTMLCanvasElement}} instance by
 passing the string literal `'gpupresent'` as its `contextType` argument.
 
 <div class="example">
     Get a {{GPUCanvasContext}} from an offscreen {{HTMLCanvasElement}}:
-    ```ts
-    const canvas: HTMLCanvasElement = document.createElement('canvas');
-    const context: GPUCanvasContext =  canvas.getContext('gpupresent');
-    const swapChain: GPUSwapChain = context.configureSwapChain(/* ... */);
+    ```js
+    const canvas = document.createElement('canvas');
+    const context =  canvas.getContext('gpupresent');
+    const swapChain = context.configureSwapChain(/* ... */);
     // ...
     ```
 </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7281,7 +7281,7 @@ Issue: Because timestamp query provides high-resolution GPU timestamp, we need t
 
 # Canvas Rendering &amp; Swap Chains # {#canvas-rendering}
 
-## HTMLCanvasElement.getContext ## {#htmlcanvaselement-getcontext}
+## HTMLCanvasElement.getContext ## {#canvas-getcontext}
 
 A {{GPUCanvasContext}} object can be obtained via the `getContext` method of a {{HTMLCanvasElement}} instance:
 
@@ -7297,7 +7297,7 @@ partial interface HTMLCanvasElement {
 };
 </script>
 
-## GPUCanvasContext ## {#gpucanvascontext}
+## GPUCanvasContext ## {#canvas-context}
 
 <script type=idl>
 interface GPUCanvasContext {
@@ -7369,7 +7369,7 @@ interface GPUCanvasContext {
         </div>
 </dl>
 
-## GPUSwapChainDescriptor ## {#gpuswapchaindescriptor}
+## GPUSwapChainDescriptor ## {#swapchain-descriptor}
 
 The <dfn dfn>supported swap chain formats</dfn> are a [=set=] of {{GPUTextureFormat}}s that must be
 supported when specified as a {{GPUSwapChainDescriptor}}.{{GPUSwapChainDescriptor/format}} regardless
@@ -7385,7 +7385,7 @@ dictionary GPUSwapChainDescriptor : GPUObjectDescriptorBase {
 };
 </script>
 
-## GPUSwapChain ## {#gpuswapchain}
+## GPUSwapChain ## {#swapchain}
 
 <script type=idl>
 interface GPUSwapChain {

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7281,6 +7281,24 @@ Issue: Because timestamp query provides high-resolution GPU timestamp, we need t
 
 # Canvas Rendering &amp; Swap Chains # {#canvas-rendering}
 
+## HTMLCanvasElement.getContext ## {#htmlcanvaselement-getcontext}
+
+A {{GPUCanvasContext}} object can be obtained via the `getContext` method of a {{HTMLCanvasElement}} instance:
+
+Issue: WebIDL does not define syntax to use string literals as argument types, use an enum as a workaround.
+<script type=idl>
+enum GPUCanvasContextID {
+    "gpupresent"
+};
+
+[Exposed=Window]
+partial interface HTMLCanvasElement {
+    GPUCanvasContext getContext(GPUCanvasContextID contextId);
+};
+</script>
+
+## GPUCanvasContext ## {#gpucanvascontext}
+
 <script type=idl>
 interface GPUCanvasContext {
     GPUSwapChain configureSwapChain(GPUSwapChainDescriptor descriptor);
@@ -7351,6 +7369,8 @@ interface GPUCanvasContext {
         </div>
 </dl>
 
+## GPUSwapChainDescriptor ## {#gpuswapchaindescriptor}
+
 The <dfn dfn>supported swap chain formats</dfn> are a [=set=] of {{GPUTextureFormat}}s that must be
 supported when specified as a {{GPUSwapChainDescriptor}}.{{GPUSwapChainDescriptor/format}} regardless
 of the given {{GPUSwapChainDescriptor}}.{{GPUSwapChainDescriptor/device}}, initially set to:
@@ -7364,6 +7384,8 @@ dictionary GPUSwapChainDescriptor : GPUObjectDescriptorBase {
     GPUTextureUsageFlags usage = 0x10;  // GPUTextureUsage.RENDER_ATTACHMENT
 };
 </script>
+
+## GPUSwapChain ## {#gpuswapchain}
 
 <script type=idl>
 interface GPUSwapChain {

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -36,6 +36,9 @@ spec: webidl; urlPrefix: https://heycam.github.io/webidl/#
 spec: web-apis; urlPrefix: https://html.spec.whatwg.org/multipage/webappapis.html#
     type: dfn
         text: cross-origin isolated; url: cross-origin-isolated
+spec: canvas; urlPrefix:https://html.spec.whatwg.org/multipage/canvas.html#
+    type: dfn
+        text: getContext; url: dom-canvas-getcontext
 </pre>
 
 <style>
@@ -7283,7 +7286,7 @@ Issue: Because timestamp query provides high-resolution GPU timestamp, we need t
 
 ## HTMLCanvasElement.getContext ## {#canvas-getcontext}
 
-A {{GPUCanvasContext}} object can be obtained via the `getContext` method of an {{HTMLCanvasElement}} instance by
+A {{GPUCanvasContext}} object can be obtained via the [=getContext=] method of an {{HTMLCanvasElement}} instance by
 passing the string literal `'gpupresent'` as its `contextType` argument.
 
 <div class="example">

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -39,6 +39,7 @@ spec: web-apis; urlPrefix: https://html.spec.whatwg.org/multipage/webappapis.htm
 spec: canvas; urlPrefix:https://html.spec.whatwg.org/multipage/canvas.html#
     type: dfn
         text: getContext; url: dom-canvas-getcontext
+        text: HTMLCanvasElement.getContext; url: dom-canvas-getcontext
 </pre>
 
 <style>
@@ -7284,7 +7285,7 @@ Issue: Because timestamp query provides high-resolution GPU timestamp, we need t
 
 # Canvas Rendering &amp; Swap Chains # {#canvas-rendering}
 
-## HTMLCanvasElement.getContext ## {#canvas-getcontext}
+## [=HTMLCanvasElement.getContext=] ## {#canvas-getcontext}
 
 A {{GPUCanvasContext}} object can be obtained via the [=getContext=] method of an {{HTMLCanvasElement}} instance by
 passing the string literal `'gpupresent'` as its `contextType` argument.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -36,10 +36,6 @@ spec: webidl; urlPrefix: https://heycam.github.io/webidl/#
 spec: web-apis; urlPrefix: https://html.spec.whatwg.org/multipage/webappapis.html#
     type: dfn
         text: cross-origin isolated; url: cross-origin-isolated
-spec: canvas; urlPrefix:https://html.spec.whatwg.org/multipage/canvas.html#
-    type: dfn
-        text: getContext; url: dom-canvas-getcontext
-        text: HTMLCanvasElement.getContext; url: dom-canvas-getcontext
 </pre>
 
 <style>
@@ -7285,9 +7281,10 @@ Issue: Because timestamp query provides high-resolution GPU timestamp, we need t
 
 # Canvas Rendering &amp; Swap Chains # {#canvas-rendering}
 
-## [=HTMLCanvasElement.getContext=] ## {#canvas-getcontext}
+## {{HTMLCanvasElement/getContext()|HTMLCanvasElement.getContext()}} ## {#canvas-getcontext}
 
-A {{GPUCanvasContext}} object can be obtained via the [=getContext=] method of an {{HTMLCanvasElement}} instance by
+A {{GPUCanvasContext}} object can be obtained via the {{HTMLCanvasElement/getContext()}}
+method of an {{HTMLCanvasElement}} instance by
 passing the string literal `'gpupresent'` as its `contextType` argument.
 
 <div class="example">

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7291,12 +7291,12 @@ passing the string literal `'gpupresent'` as its `contextType` argument.
 
 <div class="example">
     Get a {{GPUCanvasContext}} from an offscreen {{HTMLCanvasElement}}:
-    ```js
-    const canvas = document.createElement('canvas');
-    const context =  canvas.getContext('gpupresent');
-    const swapChain = context.configureSwapChain(/* ... */);
-    // ...
-    ```
+    <pre highlight="js">
+        const canvas = document.createElement('canvas');
+        const context =  canvas.getContext('gpupresent');
+        const swapChain = context.configureSwapChain(/* ... */);
+        // ...
+    </pre>
 </div>
 
 ## GPUCanvasContext ## {#canvas-context}


### PR DESCRIPTION
+ added sub-sections to the `Canvas Rendering & Swap Chains` section

This should allow [this PR](https://github.com/gpuweb/types/pull/58) to generate a complete TypeScript  definitions file.
It will hopefully reignite the discussion in #131 so it can be closed.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/darionco/gpuweb/pull/1496.html" title="Last updated on Mar 11, 2021, 8:25 PM UTC (a1c602a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1496/b40a0d7...darionco:a1c602a.html" title="Last updated on Mar 11, 2021, 8:25 PM UTC (a1c602a)">Diff</a>