### PR TITLE
Allow sample functions in integer images

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1368,7 +1368,7 @@ TODO(dneto): Move description of the conversion to the builtin function that act
   // %1 = OpTypeImage sampled_type 2D 0 1 0 2 image_format
 
 `texture_storage_3d<texel_format>`
-  // %1 = OpTypeImage sampled_type 3D 0 0 0 2 texel_format
+  // %1 = OpTypeImage sampled_type 3D 0 0 0 2 image_format
 </pre>
 
 In the SPIR-V mapping:
@@ -5419,15 +5419,15 @@ If the number of samples per texel in the multisampled texture.
 Samples a texture.
 
 ```rust
-textureSample(t : texture_1d<f32>, s : sampler, coords : f32) -> vec4<f32>
-textureSample(t : texture_2d<f32>, s : sampler, coords : vec2<f32>) -> vec4<f32>
-textureSample(t : texture_2d<f32>, s : sampler, coords : vec2<f32>, offset : vec2<i32>) -> vec4<f32>
-textureSample(t : texture_2d_array<f32>, s : sampler, coords : vec2<f32>, array_index : i32) -> vec4<f32>
-textureSample(t : texture_2d_array<f32>, s : sampler, coords : vec2<f32>, array_index : i32, offset : vec2<i32>) -> vec4<f32>
-textureSample(t : texture_3d<f32>, s : sampler, coords : vec3<f32>) -> vec4<f32>
-textureSample(t : texture_3d<f32>, s : sampler, coords : vec3<f32>, offset : vec3<i32>) -> vec4<f32>
-textureSample(t : texture_cube<f32>, s : sampler, coords : vec3<f32>) -> vec4<f32>
-textureSample(t : texture_cube_array<f32>, s : sampler, coords : vec3<f32>, array_index : i32) -> vec4<f32>
+textureSample(t : texture_1d<T>, s : sampler, coords : f32) -> vec4<T>
+textureSample(t : texture_2d<T>, s : sampler, coords : vec2<f32>) -> vec4<T>
+textureSample(t : texture_2d<T>, s : sampler, coords : vec2<f32>, offset : vec2<i32>) -> vec4<T>
+textureSample(t : texture_2d_array<T>, s : sampler, coords : vec2<f32>, array_index : i32) -> vec4<T>
+textureSample(t : texture_2d_array<T>, s : sampler, coords : vec2<f32>, array_index : i32, offset : vec2<i32>) -> vec4<T>
+textureSample(t : texture_3d<T>, s : sampler, coords : vec3<f32>) -> vec4<T>
+textureSample(t : texture_3d<T>, s : sampler, coords : vec3<f32>, offset : vec3<i32>) -> vec4<T>
+textureSample(t : texture_cube<T>, s : sampler, coords : vec3<f32>) -> vec4<T>
+textureSample(t : texture_cube_array<T>, s : sampler, coords : vec3<f32>, array_index : i32) -> vec4<T>
 textureSample(t : texture_depth_2d, s : sampler, coords : vec2<f32>) -> f32
 textureSample(t : texture_depth_2d, s : sampler, coords : vec2<f32>, offset : vec2<i32>) -> f32
 textureSample(t : texture_depth_2d_array, s : sampler, coords : vec2<f32>, array_index : i32) -> f32
@@ -5468,14 +5468,14 @@ The sampled value.
 Samples a texture with a bias to the mip level.
 
 ```rust
-textureSampleBias(t : texture_2d<f32>, s : sampler, coords : vec2<f32>, bias : f32) -> vec4<f32>
-textureSampleBias(t : texture_2d<f32>, s : sampler, coords : vec2<f32>, bias : f32, offset : vec2<i32>) -> vec4<f32>
-textureSampleBias(t : texture_2d_array<f32>, s : sampler, coords : vec2<f32>, array_index : i32, bias : f32) -> vec4<f32>
-textureSampleBias(t : texture_2d_array<f32>, s : sampler, coords : vec2<f32>, array_index : i32, bias : f32, offset : vec2<i32>) -> vec4<f32>
-textureSampleBias(t : texture_3d<f32>, s : sampler, coords : vec3<f32>, bias : f32) -> vec4<f32>
-textureSampleBias(t : texture_3d<f32>, s : sampler, coords : vec3<f32>, bias : f32, offset : vec3<i32>) -> vec4<f32>
-textureSampleBias(t : texture_cube<f32>, s : sampler, coords : vec3<f32>, bias : f32) -> vec4<f32>
-textureSampleBias(t : texture_cube_array<f32>, s : sampler, coords : vec3<f32>, array_index : i32, bias : f32) -> vec4<f32>
+textureSampleBias(t : texture_2d<T>, s : sampler, coords : vec2<f32>, bias : f32) -> vec4<T>
+textureSampleBias(t : texture_2d<T>, s : sampler, coords : vec2<f32>, bias : f32, offset : vec2<i32>) -> vec4<T>
+textureSampleBias(t : texture_2d_array<T>, s : sampler, coords : vec2<f32>, array_index : i32, bias : f32) -> vec4<T>
+textureSampleBias(t : texture_2d_array<T>, s : sampler, coords : vec2<f32>, array_index : i32, bias : f32, offset : vec2<i32>) -> vec4<T>
+textureSampleBias(t : texture_3d<T>, s : sampler, coords : vec3<f32>, bias : f32) -> vec4<T>
+textureSampleBias(t : texture_3d<T>, s : sampler, coords : vec3<f32>, bias : f32, offset : vec3<i32>) -> vec4<T>
+textureSampleBias(t : texture_cube<T>, s : sampler, coords : vec3<f32>, bias : f32) -> vec4<T>
+textureSampleBias(t : texture_cube_array<T>, s : sampler, coords : vec3<f32>, array_index : i32, bias : f32) -> vec4<T>
 ```
 
 **Parameters:**
@@ -5561,14 +5561,14 @@ single texel is returned.
 Samples a texture using explicit gradients.
 
 ```rust
-textureSampleGrad(t : texture_2d<f32>, s : sampler, coords : vec2<f32>, ddx : vec2<f32>, ddy : vec2<f32>) -> vec4<f32>
-textureSampleGrad(t : texture_2d<f32>, s : sampler, coords : vec2<f32>, ddx : vec2<f32>, ddy : vec2<f32>, offset : vec2<i32>) -> vec4<f32>
-textureSampleGrad(t : texture_2d_array<f32>, s : sampler, coords : vec2<f32>, array_index : i32, ddx : vec2<f32>, ddy : vec2<f32>) -> vec4<f32>
-textureSampleGrad(t : texture_2d_array<f32>, s : sampler, coords : vec2<f32>, array_index : i32, ddx : vec2<f32>, ddy : vec2<f32>, offset : vec2<i32>) -> vec4<f32>
-textureSampleGrad(t : texture_3d<f32>, s : sampler, coords : vec3<f32>, ddx : vec3<f32>, ddy : vec3<f32>) -> vec4<f32>
-textureSampleGrad(t : texture_3d<f32>, s : sampler, coords : vec3<f32>, ddx : vec3<f32>, ddy : vec3<f32>, offset : vec3<i32>) -> vec4<f32>
-textureSampleGrad(t : texture_cube<f32>, s : sampler, coords : vec3<f32>, ddx : vec3<f32>, ddy : vec3<f32>) -> vec4<f32>
-textureSampleGrad(t : texture_cube_array<f32>, s : sampler, coords : vec3<f32>, array_index : i32, ddx : vec3<f32>, ddy : vec3<f32>) -> vec4<f32>
+textureSampleGrad(t : texture_2d<T>, s : sampler, coords : vec2<f32>, ddx : vec2<f32>, ddy : vec2<f32>) -> vec4<T>
+textureSampleGrad(t : texture_2d<T>, s : sampler, coords : vec2<f32>, ddx : vec2<f32>, ddy : vec2<f32>, offset : vec2<i32>) -> vec4<T>
+textureSampleGrad(t : texture_2d_array<T>, s : sampler, coords : vec2<f32>, array_index : i32, ddx : vec2<f32>, ddy : vec2<f32>) -> vec4<T>
+textureSampleGrad(t : texture_2d_array<T>, s : sampler, coords : vec2<f32>, array_index : i32, ddx : vec2<f32>, ddy : vec2<f32>, offset : vec2<i32>) -> vec4<T>
+textureSampleGrad(t : texture_3d<T>, s : sampler, coords : vec3<f32>, ddx : vec3<f32>, ddy : vec3<f32>) -> vec4<T>
+textureSampleGrad(t : texture_3d<T>, s : sampler, coords : vec3<f32>, ddx : vec3<f32>, ddy : vec3<f32>, offset : vec3<i32>) -> vec4<T>
+textureSampleGrad(t : texture_cube<T>, s : sampler, coords : vec3<f32>, ddx : vec3<f32>, ddy : vec3<f32>) -> vec4<T>
+textureSampleGrad(t : texture_cube_array<T>, s : sampler, coords : vec3<f32>, array_index : i32, ddx : vec3<f32>, ddy : vec3<f32>) -> vec4<T>
 ```
 
 **Parameters:**
@@ -5606,14 +5606,14 @@ The sampled value.
 Samples a texture using an explicit mip level.
 
 ```rust
-textureSampleLevel(t : texture_2d<f32>, s : sampler, coords : vec2<f32>, level : f32) -> vec4<f32>
-textureSampleLevel(t : texture_2d<f32>, s : sampler, coords : vec2<f32>, level : f32, offset : vec2<i32>) -> vec4<f32>
-textureSampleLevel(t : texture_2d_array<f32>, s : sampler, coords : vec2<f32>, array_index : i32, level : f32) -> vec4<f32>
-textureSampleLevel(t : texture_2d_array<f32>, s : sampler, coords : vec2<f32>, array_index : i32, level : f32, offset : vec2<i32>) -> vec4<f32>
-textureSampleLevel(t : texture_3d<f32>, s : sampler, coords : vec3<f32>, level : f32) -> vec4<f32>
-textureSampleLevel(t : texture_3d<f32>, s : sampler, coords : vec3<f32>, level : f32, offset : vec3<i32>) -> vec4<f32>
-textureSampleLevel(t : texture_cube<f32>, s : sampler, coords : vec3<f32>, level : f32) -> vec4<f32>
-textureSampleLevel(t : texture_cube_array<f32>, s : sampler, coords : vec3<f32>, array_index : i32, level : f32) -> vec4<f32>
+textureSampleLevel(t : texture_2d<T>, s : sampler, coords : vec2<f32>, level : f32) -> vec4<T>
+textureSampleLevel(t : texture_2d<T>, s : sampler, coords : vec2<f32>, level : f32, offset : vec2<i32>) -> vec4<T>
+textureSampleLevel(t : texture_2d_array<T>, s : sampler, coords : vec2<f32>, array_index : i32, level : f32) -> vec4<T>
+textureSampleLevel(t : texture_2d_array<T>, s : sampler, coords : vec2<f32>, array_index : i32, level : f32, offset : vec2<i32>) -> vec4<T>
+textureSampleLevel(t : texture_3d<T>, s : sampler, coords : vec3<f32>, level : f32) -> vec4<T>
+textureSampleLevel(t : texture_3d<T>, s : sampler, coords : vec3<f32>, level : f32, offset : vec3<i32>) -> vec4<T>
+textureSampleLevel(t : texture_cube<T>, s : sampler, coords : vec3<f32>, level : f32) -> vec4<T>
+textureSampleLevel(t : texture_cube_array<T>, s : sampler, coords : vec3<f32>, array_index : i32, level : f32) -> vec4<T>
 textureSampleLevel(t : texture_depth_2d, s : sampler, coords : vec2<f32>, level : i32) -> f32
 textureSampleLevel(t : texture_depth_2d, s : sampler, coords : vec2<f32>, level : i32, offset : vec2<i32>) -> f32
 textureSampleLevel(t : texture_depth_2d_array, s : sampler, coords : vec2<f32>, array_index : i32, level : i32) -> f32


### PR DESCRIPTION
* Previously only f32 textures were allowed to be used with sample
  built-ins
* fixed a typo in image mapping

I think it was just an oversight that the sampled type was required to be f32.