### PR TITLE
Add stage restriction to some texture built-ins

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5427,6 +5427,7 @@ If the number of samples per texel in the multisampled texture.
 ### `textureSample` ### {#texturesample}
 
 Samples a texture.
+Must only be used in a [=fragment=] shader stage.
 
 ```rust
 textureSample(t : texture_1d<f32>, s : sampler, coords : f32) -> vec4<f32>
@@ -5476,6 +5477,7 @@ The sampled value.
 ### `textureSampleBias` ### {#texturesamplebias}
 
 Samples a texture with a bias to the mip level.
+Must only be used in a [=fragment=] shader stage.
 
 ```rust
 textureSampleBias(t : texture_2d<f32>, s : sampler, coords : vec2<f32>, bias : f32) -> vec4<f32>


### PR DESCRIPTION
* textureSample and textureSampleBias both map to
  OpImageSampleImplicitLod which can only be used in fragment shaders so
  add that restriction to WGSL