### PR TITLE
Fix e2 type for component-wise logical shift right

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3170,7 +3170,7 @@ Issue: Which index is used when it's out of bounds?
            The number of bits to shift is the value of |e2| modulo the bit width of |e1|.
            (OpShiftRightLogical)
   <tr algorithm="vector logical shift right"><td>|e1| : vec|N|&lt;u32&gt;<br>
-          |e2| : u32<br>
+          |e2| : vec|N|&lt;u32&gt;<br>
        <td class="nowrap">|e1| `>>` |e2| : vec|N|&lt;u32&gt;
        <td>Component-wise logical shift right:<br>
            Component |i| of the result is `(`|e1|`[`|i|`] >> `|e2|`[`|i|`])`


### PR DESCRIPTION
e2 type should be vecN<u32>, not u32.