### PR TITLE
[wgsl] Allow `builtin` and `location` as struct member decorations

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -483,6 +483,8 @@ struct_member
     <tr><th>Struct member decoration keys<th>Valid values<th>Note
   </thead>
   <tr><td>`offset`<td>non-negative i32 literal<td>
+  <tr><td>`builtin`<td>a builtin variable identifier<td>See [[#builtin-variables]]
+  <tr><td>`location`<td>non-negative i32 literal<td>See TBD
 </table>
 
 Note: Layout attributes are required if the structure type is used
@@ -1912,9 +1914,7 @@ literal_or_ident
     <tr><th>Global variable decoration keys<th>Valid values<th>Note
   </thead>
   <tr><td>`binding`<td>non-negative i32 literal<td>See [[#resource-interface]]
-  <tr><td>`builtin`<td>a builtin variable identifier<td>See [[#builtin-variables]]
   <tr><td>`group`<td>non-negative i32 literal<td>See [[#resource-interface]]
-  <tr><td>`location`<td>non-negative i32 literal<td>See TBD
 </table>
 
 ## Module Constants ## {#module-constants}


### PR DESCRIPTION
Remove them from the list of valid global variable decorations.