### PR TITLE
[EDIT] navigator.gpu

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1178,22 +1178,15 @@ Possibly also include a simple example with no handling.
 
 ## navigator.gpu ## {#navigator-gpu}
 
-A {{GPU}} object is available via `navigator.gpu` on the {{Window}}:
+A {{GPU}} object is available in the {{Window}} and {{DedicatedWorkerGlobalScope}} contexts through the {{Navigator}}
+and {{WorkerNavigator}} interfaces respectively and is exposed via `navigator.gpu`:
 
 <script type=idl>
-[Exposed=Window]
-partial interface Navigator {
+interface mixin NavigatorGPU {
     [SameObject] readonly attribute GPU gpu;
 };
-</script>
-
-... as well as on dedicated workers:
-
-<script type=idl>
-[Exposed=DedicatedWorker]
-partial interface WorkerNavigator {
-    [SameObject] readonly attribute GPU gpu;
-};
+Navigator includes NavigatorGPU;
+WorkerNavigator includes NavigatorGPU;
 </script>
 
 ## GPU ## {#gpu-interface}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1241,11 +1241,9 @@ interface GPU {
 <div class="example">
     Request a {{GPUAdapter}}:
     <pre highlight="js">
-        // using async/await
         const adapter = await navigator.gpu.requestAdapter(/* ... */);
-
-        // using promises
-        navigator.gpu.requestAdapter(/* ... */).then(adapter => { /* ... */);
+        const features = adapter.features;
+        // ...
     </pre>
 </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1238,6 +1238,17 @@ interface GPU {
         </div>
 </dl>
 
+<div class="example">
+    Request a {{GPUAdapter}}:
+    <pre highlight="js">
+        // using async/await
+        const adapter = await navigator.gpu.requestAdapter(/* ... */);
+
+        // using promises
+        navigator.gpu.requestAdapter(/* ... */).then(adapter => { /* ... */);
+    </pre>
+</div>
+
 ### Adapter Selection ### {#adapter-selection}
 
 <dfn dictionary>GPURequestAdapterOptions</dfn>


### PR DESCRIPTION
The [system state](https://html.spec.whatwg.org/multipage/system-state.html) spec defines the properties of the [`Navigator`](https://html.spec.whatwg.org/multipage/system-state.html#navigator) interface as mixins:

> These interface mixins are defined separately so that WorkerNavigator can re-use parts of the Navigator interface.

this change makes sure the WebGPU spec doesn't conflict with the previous statement.

I've also added a small example on how to request an adapter from the `GPU` object exposed through `navigator.gpu`, although I am not sure if it is needed. Thoughts?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/darionco/gpuweb/pull/1513.html" title="Last updated on Mar 15, 2021, 4:45 PM UTC (593463c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1513/b1db1f7...darionco:593463c.html" title="Last updated on Mar 15, 2021, 4:45 PM UTC (593463c)">Diff</a>