### PR TITLE
[EDIT] Use `<pre>` instead of markdown for code blocks

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5887,12 +5887,12 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
         packed block of **three 32-bit unsigned integer values (12 bytes total)**, given in the same
         order as the arguments for {{GPUComputePassEncoder/dispatch()}}. For example:
 
-        ```js
-        let dispatchIndirectParameters = new Uint32Array(3);
-        dispatchIndirectParameters[0] = x;
-        dispatchIndirectParameters[1] = y;
-        dispatchIndirectParameters[2] = z;
-        ```
+        <pre highlight="js">
+            let dispatchIndirectParameters = new Uint32Array(3);
+            dispatchIndirectParameters[0] = x;
+            dispatchIndirectParameters[1] = y;
+            dispatchIndirectParameters[2] = z;
+        </pre>
 
         <div algorithm="GPUComputePassEncoder.dispatchIndirect">
             **Called on:** {{GPUComputePassEncoder}} this.
@@ -6504,13 +6504,13 @@ enum GPUStoreOp {
         packed block of **four 32-bit unsigned integer values (16 bytes total)**, given in the same
         order as the arguments for {{GPURenderEncoderBase/draw()}}. For example:
 
-        ```js
-        let drawIndirectParameters = new Uint32Array(4);
-        drawIndirectParameters[0] = vertexCount;
-        drawIndirectParameters[1] = instanceCount;
-        drawIndirectParameters[2] = firstVertex;
-        drawIndirectParameters[3] = firstInstance;
-        ```
+        <pre highlight="js">
+            let drawIndirectParameters = new Uint32Array(4);
+            drawIndirectParameters[0] = vertexCount;
+            drawIndirectParameters[1] = instanceCount;
+            drawIndirectParameters[2] = firstVertex;
+            drawIndirectParameters[3] = firstInstance;
+        </pre>
 
         <div algorithm="GPURenderEncoderBase.drawIndirect">
             **Called on:** {{GPURenderEncoderBase}} this.
@@ -6546,14 +6546,14 @@ enum GPUStoreOp {
         tightly packed block of **five 32-bit unsigned integer values (20 bytes total)**, given in
         the same order as the arguments for {{GPURenderEncoderBase/drawIndexed()}}. For example:
 
-        ```js
-        let drawIndexedIndirectParameters = new Uint32Array(5);
-        drawIndexedIndirectParameters[0] = indexCount;
-        drawIndexedIndirectParameters[1] = instanceCount;
-        drawIndexedIndirectParameters[2] = firstIndex;
-        drawIndexedIndirectParameters[3] = baseVertex;
-        drawIndexedIndirectParameters[4] = firstInstance;
-        ```
+        <pre highlight="js">
+            let drawIndexedIndirectParameters = new Uint32Array(5);
+            drawIndexedIndirectParameters[0] = indexCount;
+            drawIndexedIndirectParameters[1] = instanceCount;
+            drawIndexedIndirectParameters[2] = firstIndex;
+            drawIndexedIndirectParameters[3] = baseVertex;
+            drawIndexedIndirectParameters[4] = firstInstance;
+        </pre>
 
         <div algorithm="GPURenderEncoderBase.drawIndexedIndirect">
             **Called on:** {{GPURenderEncoderBase}} this.


### PR DESCRIPTION
Housekeeping change. Using `<pre>` tags allows for better whitespace management of code blocks, both in the bikeshed file and the rendered HTML as described in the [bikeshed spec](https://tabatkins.github.io/bikeshed/#pre-whitespace-stripping).

bikeshed BEFORE:
![Screenshot from 2021-03-12 11-10-19](https://user-images.githubusercontent.com/2651846/110966868-be049f00-8323-11eb-9fdc-9a89b16be7f1.png)

bikeshed AFTER:
![Screenshot from 2021-03-12 11-10-41](https://user-images.githubusercontent.com/2651846/110966902-c78e0700-8323-11eb-90af-10b0bcb523ce.png)

HTML BEFORE:
![Screenshot from 2021-03-12 11-11-02](https://user-images.githubusercontent.com/2651846/110966922-cd83e800-8323-11eb-8d14-9e04230609c4.png)

HTML AFTER:
![Screenshot from 2021-03-12 11-11-15](https://user-images.githubusercontent.com/2651846/110966943-d4125f80-8323-11eb-9e8a-af40ada69039.png)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/darionco/gpuweb/pull/1514.html" title="Last updated on Mar 12, 2021, 4:14 PM UTC (9fe6a46)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1514/b1db1f7...darionco:9fe6a46.html" title="Last updated on Mar 12, 2021, 4:14 PM UTC (9fe6a46)">Diff</a>