### PR TITLE
Refactor attributes

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -176,7 +176,136 @@ Note: literals are parsed greedy. This means that for statements like `a -5`
 
 An identifier must not have the same spelling as a keyword or as a reserved keyword.
 
-## Attributes TODO ## {#attributes}
+## Attributes ## {#attributes}
+
+Attributes provide a unified syntax for modifications of objects and types.
+They are used for a variety of purposes such as specifying the interface with the API.
+Generally speaking, from the language's point-of-view, attributes can be
+ignored for the purposes of type and semantic checking.
+
+<pre class='def'>
+attribute_list
+  : ATTR_LEFT (attribute COMMA)* attribute ATTR_RIGHT
+
+attribute
+  : IDENT PAREN_LEFT literal_or_ident PAREN_RIGHT
+  | IDENT
+
+literal_or_ident
+  : FLOAT_LITERAL
+  | INT_LITERAL
+  | UINT_LITERAL
+  | IDENT
+</pre>
+
+<table class='data'>
+  <caption>Attributes defined in [SHORTNAME]</caption>
+  <thead>
+    <tr><th>Attribute<th>Valid Values<th>Description
+  </thead>
+
+   <tr><td><dfn noexport>`access`</dfn>
+    <td>`read`, `write`, or `read_write`
+    <td>Must only be applied to a type used as a store type for a variable in
+    the [=storage classes/storage=] storage class.
+
+    Specifies the access qualification of a variable.
+
+  <tr><td><dfn noexport>`align`</dfn>
+    <td>positive i32 literal
+    <td>Must only be applied to a member of a [=structure=] type.
+
+    Must be a power of 2.
+
+    See memory layout [alignment and size](#alignment-and-size).
+
+  <tr><td><dfn noexport>`binding`
+    <td>non-negative i32 literal
+    <td>Must only be applied to a variable in the [=storage classes/storage=] or
+    [=storage classes/uniform=] storage classes, or a variable of [texture or
+    sampler](#texture-types) type.
+
+    Specifies the binding number of the resource.
+    See [[#resource-interface]].
+
+  <tr><td><dfn noexport>`block`</dfn>
+    <td>*None*
+    <td>Must only be applied to a [=structure=] type.
+
+    Indicates this structure type represents the contents of a buffer
+    resource occupying a single binding slot in the [=resource interface of a
+    shader|shader's resource interface=].
+
+    The `block` attribute must be applied to a structure type used as the
+    [=store type=] of a [=uniform buffer=] or [=storage buffer=] variable.
+
+    A structure type with the block attribute must not be:
+    * the element type of an [=array=] type
+    * the member type in another structure
+
+  <tr><td><dfn noexport>`builtin`
+    <td>a builtin variable identifier
+    <td>Must only be applied to an entry point function parameter, entry point
+    return type, or member of a [=structure=].
+
+    Declares a builtin variable.
+    See [[#builtin-variables]].
+
+  <tr><td><dfn noexport>`constant_id`
+    <td>non-negative i32 literal
+    <td>Must only be applied to module scope constant declaration of [=scalar=] type.
+
+    Specifies a [=pipeline-overridable=] constant.
+
+  <tr><td><dfn noexport>`group`
+    <td>non-negative i32 literal
+    <td>Must only be applied to a variable in the [=storage classes/storage=] or
+    [=storage classes/uniform=] storage classes, or a variable of [texture or
+    sampler](#texture-types) type.
+
+    Specifies the binding group of the resource.
+    See [[#resource-interface]].
+
+  <tr><td><dfn noexport>`location`
+    <td>non-negative i32 literal
+    <td>Must only be applied to an entry point function parameter, entry point
+    return type, or member of a [=structure=] type.
+
+    Specifies a part of the user-defined IO of an entry point. See TBD.
+
+  <tr><td><dfn noexport>`size`</dfn>
+    <td>positive i32 literal
+    <td>Must only be applied to a member of a [=structure=] type.
+
+    The number of bytes reserved in the struct for this member.
+
+  <tr><td><dfn noexport>`stage`</dfn>
+    <td>`compute`, `vertex`, or `fragment`
+    <td>Must only be applied to a function declaration.
+
+    Declares an entry point by specifying its pipeline stage.
+
+  <tr><td><dfn noexport>`stride`</dfn>
+    <td>positive i32 literal
+    <td>Must only be applied to an [=array=] type.
+
+    The number of bytes from the start of one element of the array to the
+    start of the next element.
+
+  <tr><td><dfn noexport>`workgroup_size`</dfn>
+    <td>One, two or three parameters. Each parameter is either a positive i32
+    literal or the name of a [=pipeline-overridable=] constant of i32 type.
+    <td>Must only be applied to a [=compute shader stage=] function declaration.
+
+    Specifies the x, y, and z dimensions of the [=workgroup grid=] for the compute shader.
+
+    The first parameter specifies the x dimension.
+    The second parameter, if provided, specifies the y dimension, otherwise is assumed to be 1.
+    The third parameter, if provided, specifies the z dimension, otherwise is assumed to be 1.
+    Each dimension must be at least 1 and at most an upper bound specified by the WebGPU API.
+
+</table>
+
 
 ## Declaration and scope ## {#declaration-and-scope}
 
@@ -410,6 +539,9 @@ An array element type must be one of:
 * an array type
 * a [=structure=] type
 
+[SHORTNAME] defines the following attributes that can be applied to array types:
+* [=stride=]
+
 Restrictions on runtime-sized arrays:
 * The last member of the structure type defining the [=store type=]
     for a variable in the [=storage classes/storage=] storage class may be a runtime-sized array.
@@ -458,53 +590,28 @@ Similarly, the same limitations apply to textures and samplers.
   </xmp>
 </div>
 
-<table class='data'>
-  <caption>Structure attributes</caption>
-  <thead>
-    <tr><th>Attribute<th>Description
-  </thead>
-
-  <tr><td><dfn noexport>`block`</dfn>
-      <td>Applies to a structure type.<br>
-         Indicates this structure type represents the contents of a
-         buffer resource occupying a single binding slot in the
-         [=resource interface of a shader|shader's resource interface=].
-         The `block` attribute must be applied to a structure type used
-         as the [=store type=] of a [=uniform buffer=] or [=storage buffer=] variable.
-</table>
-
-A structure type with the [=block=] attribute must not be:
-* the element type of an array type.
-* the member type in another structure.
-
 <pre class='def'>
 struct_decl
-  : decoration_list* STRUCT IDENT struct_body_decl
+  : attribute_list* STRUCT IDENT struct_body_decl
 </pre>
-
-<table class='data'>
-  <thead>
-    <tr><th>Struct decoration keys<th>Valid values<th>Note
-  </thead>
-  <tr><td>`block`<td><td>The block decoration takes no parameters
-</table>
 
 <pre class='def'>
 struct_body_decl
   : BRACE_LEFT struct_member* BRACE_RIGHT
 
 struct_member
-  : decoration_list* variable_ident_decl SEMICOLON
+  : attribute_list* variable_ident_decl SEMICOLON
 </pre>
 
-<table class='data'>
-  <thead>
-    <tr><th>Struct member decoration keys<th>Valid values<th>Note
-  </thead>
-  <tr><td>`offset`<td>non-negative i32 literal<td>
-  <tr><td>`builtin`<td>a builtin variable identifier<td>See [[#builtin-variables]]
-  <tr><td>`location`<td>non-negative i32 literal<td>See TBD
-</table>
+[SHORTNAME] defines the following attributes that can be applied to structure types:
+ * [=block=]
+
+[SHORTNAME] defines the following attributes that can be applied to structure members:
+ * [=builtin=]
+ * [=location=]
+ * [=stride=]
+ * [=align=]
+ * [=size=]
 
 Note: Layout attributes are required if the structure type is used
 to define a [=uniform buffer=] or a [=storage buffer=]. See [[#memory-layouts]].
@@ -627,26 +734,10 @@ The following types are <dfn dfn noexport>host-shareable</dfn>:
 * [[#array-types]] if the array type has a [=stride=] attribute and its element type is host-shareable
 * [[#struct-types]] if each member is host-shareable
 
-<table class='data'>
-  <caption>Layout attributes, for host-shareable types</caption>
-  <thead>
-    <tr><th>Decoraton<th>Operand<th>Description
-  </thead>
-  <tr><td><dfn noexport>`stride`</dfn>
-      <td>positive i32 literal
-      <td>Applied to an array type.<br>
-         The number of bytes from the start of one element of the array to the
-         start of the next element.
-  <tr><td><dfn noexport>`size`</dfn>
-      <td>positive i32 literal
-      <td>Applied to a member of a structure type.<br>
-         The number of bytes reserved in the struct for this member.
-  <tr><td><dfn noexport>`align`</dfn>
-      <td>positive i32 literal
-      <td>Applied to a member of a structure type.<br>
-         Must be a power of 2.<br>
-         See memory layout [alignment and size](#alignment-and-size).
-</table>
+[SHORTNAME] defines the following attributes that affect memory layouts:
+ * [=stride=]
+ * [=align=]
+ * [=size=]
 
 Note: An [=IO-shareable=] type *T* would also be host-shareable if *T* and its subtypes have
 appropriate [=stride=] attributes, and if *T* is not [=bool=] and does not contain a [=bool=].
@@ -1671,8 +1762,8 @@ type_decl
   | VEC3 LESS_THAN type_decl GREATER_THAN
   | VEC4 LESS_THAN type_decl GREATER_THAN
   | POINTER LESS_THAN storage_class COMMA type_decl GREATER_THAN
-  | decoration_list* ARRAY LESS_THAN type_decl COMMA INT_LITERAL GREATER_THAN
-  | decoration_list* ARRAY LESS_THAN type_decl GREATER_THAN
+  | attribute_list* ARRAY LESS_THAN type_decl COMMA INT_LITERAL GREATER_THAN
+  | attribute_list* ARRAY LESS_THAN type_decl GREATER_THAN
   | MAT2x2 LESS_THAN type_decl GREATER_THAN
   | MAT2x3 LESS_THAN type_decl GREATER_THAN
   | MAT2x4 LESS_THAN type_decl GREATER_THAN
@@ -1687,13 +1778,6 @@ type_decl
 
 When the type declaration is an identifer, then the expression must be in scope of a
 declaration of the identifier as a type alias or structure type.
-
-<table class='data'>
-  <thead>
-    <tr><th>Array decoration keys<th>Valid values<th>Note
-  </thead>
-  <tr><td>`stride`<td>greater than zero i32 literal<td>
-</table>
 
 <div class='example' heading="Type Declarations">
   <xmp>
@@ -1785,26 +1869,15 @@ variable_decl
   : VAR variable_storage_decoration? variable_ident_decl
 
 variable_ident_decl
-  : IDENT COLON decoration_list* type_decl
+  : IDENT COLON attribute_list* type_decl
 
 variable_storage_decoration
   : LESS_THAN storage_class GREATER_THAN
 
 </pre>
 
-<table class='data'>
-  <thead>
-    <tr><th>Variable declaration decoration keys<th>Valid values<th>Note
-  </thead>
-  <tr><td>`access`<td>`read`, `write` or `read_write`<td>
-</table>
-
-The access decoration must only appear on a type used as the store type for a
-variable in the [=storage classes/storage=] storage class.
-The access decoration must not appear
-on a type of const declaration nor as the store type for variable with a
-storage class other than [=storage classes/storage=]. The access decoration is required for
-variables in the [=storage classes/storage=] storage class.
+Variables in the [=storage classes/storage=] storage class must have an
+[=access=] attribute applied to the store type.
 
 Two variables with overlapping lifetimes will not have overlapping storage.
 
@@ -1903,21 +1976,8 @@ Such variables are declared with [=group=] and [=binding=] decorations.
 
 <pre class='def'>
 global_variable_decl
-  : decoration_list* variable_decl
-  | decoration_list* variable_decl EQUAL const_expr
-
-decoration_list
-  : ATTR_LEFT (decoration COMMA)* decoration ATTR_RIGHT
-
-decoration
-  : IDENT PAREN_LEFT literal_or_ident PAREN_RIGHT
-  | IDENT
-
-literal_or_ident
-  : FLOAT_LITERAL
-  | INT_LITERAL
-  | UINT_LITERAL
-  | IDENT
+  : attribute_list* variable_decl
+  | attribute_list* variable_decl EQUAL const_expr
 </pre>
 
 <div class='example' heading="Variable Decorations">
@@ -1931,13 +1991,9 @@ literal_or_ident
   </xmp>
 </div>
 
-<table class='data'>
-  <thead>
-    <tr><th>Global variable decoration keys<th>Valid values<th>Note
-  </thead>
-  <tr><td>`binding`<td>non-negative i32 literal<td>See [[#resource-interface]]
-  <tr><td>`group`<td>non-negative i32 literal<td>See [[#resource-interface]]
-</table>
+[SHORTNAME] defines the following attributes that can be applied to global variables:
+ * [=binding=]
+ * [=group=]
 
 ## Module Constants ## {#module-constants}
 
@@ -1955,7 +2011,7 @@ and the name denotes the value of that expression.
   </xmp>
 </div>
 
-When the declaration uses the `constant_id` attribute,
+When the declaration uses the [=constant_id=] attribute,
 the constant is <dfn noexport>pipeline-overridable</dfn>. In this case:
 
   * The type must one of the [=scalar=] types.
@@ -1989,7 +2045,7 @@ is the one from the constant's declaration or from a pipeline override.
 
 <pre class='def'>
 global_constant_decl
-  : decoration_list* CONST variable_ident_decl global_const_initializer?
+  : attribute_list* CONST variable_ident_decl global_const_initializer?
 
 global_const_initializer
   : EQUAL const_expr
@@ -1998,14 +2054,6 @@ const_expr
   : type_decl PAREN_LEFT (const_expr COMMA)* const_expr PAREN_RIGHT
   | const_literal
 </pre>
-
-<table class='data'>
-  <thead>
-    <tr><th>Global const decoration keys<th>Valid values<th>Note
-  </thead>
-  <tr><td>`constant_id`<td>non-negative i32 literal<td>
-</table>
-
 
 <div class='example' heading='Constants'>
   <xmp>
@@ -3775,10 +3823,10 @@ module.
 
 <pre class='def'>
 function_decl
-  : decoration_list* function_header body_statement
+  : attribute_list* function_header body_statement
 
 function_type_decl
-  : decoration_list* type_decl
+  : attribute_list* type_decl
   | VOID
 
 function_header
@@ -3789,36 +3837,17 @@ param_list
   | (param COMMA)* param
 
 param
-  : decoration_list* variable_ident_decl
+  : attribute_list* variable_ident_decl
 </pre>
 
-<table class='data'>
-  <thead>
-    <tr><th>Function decoration keys<th>Valid values<th>Note
-  </thead>
-  <tr><td>`stage`<td>`compute` or `vertex` or `fragment`<td>See [[#entry-point-attributes]].
-  <tr><td>`workgroup_size`
-      <td>One, two, or three parameters.
-          Each parameter is either an i32 literal or the name of a [=pipeline-overridable=] constant of i32 type.
-      <td>Specifies the x, y and z dimensions of the [=workgroup grid=] for the compute shader.
-      <br>See [[#entry-point-attributes]].
-</table>
+[SHORTNAME] defines the following attributes that can be applied to function declarations:
+ * [=stage=]
+ * [=workgroup_size=]
 
-<table class='data'>
-  <thead>
-    <tr><th>Function type decoration keys<th>Valid values<th>Note
-  </thead>
-  <tr><td>`builtin`<td>a builtin variable identifier<td>See [[#builtin-variables]]
-  <tr><td>`location`<td>non-negative i32 literal<td>See TBD
-</table>
-
-<table class='data'>
-  <thead>
-    <tr><th>Function parameter decoration keys<th>Valid values<th>Note
-  </thead>
-  <tr><td>`builtin`<td>a builtin variable identifier<td>See [[#builtin-variables]]
-  <tr><td>`location`<td>non-negative i32 literal<td>See TBD
-</table>
+[SHORTNAME] defines the following attributes that can be applied to function
+parameters and return types:
+ * [=builtin=]
+ * [=location=]
 
 <div class='example' heading='Function'>
   <xmp>
@@ -3955,19 +3984,9 @@ It will stabilize in a finite number of steps.
 
 ### Function attributes for entry points ### {#entry-point-attributes}
 
-: <dfn noexport>stage</dfn>
-:: The `stage` attribute declares that a function is an entry point for a particular pipeline stage.
-    The parameter must be one of `vertex`, `fragment`, or `compute`.
-: <dfn noexport>workgroup_size</dfn>
-:: The `workgroup_size` attribute specifies the x, y, and z dimensions of the [=workgroup grid=]
-    for a [=compute=] shader.
-    The size in the x dimension is provided by the first value.
-    The size in the y dimension is provided by the second value, when present, and otherwise
-    is assumed to be 1.
-    The size in the z dimension is provided by the third value, when present, and otherwise
-    is assumed to be 1.
-    Each dimension size must be at least 1 and at most an upper bound specified by the WebGPU API.
-    This attribute must only be used with a [=compute shader stage=] entry point.
+[SHORTNAME] defines the following attributes that can be applied to entry point declarations:
+ * [=stage=]
+ * [=workgroup_size=]
 
 ISSUE: Can we query upper bounds on workgroup size dimensions?  Is it independent of the shader, or
   a property to be queried after creating the shader module?
@@ -4093,8 +4112,8 @@ The <dfn noexport>resource interface of a shader</dfn> is the set of module-scop
 resource variables [=statically accessed=] by
 [=functions in a shader stage|functions in the shader stage=].
 
-Each resource variable must be declared with both <dfn noexport>`group`</dfn>
-and <dfn noexport>`binding`</dfn> attributes.
+Each resource variable must be declared with both [=group=] and [=binding=]
+attributes.
 Together with the shader's stage, these identify the binding address
 of the resource on the shader's pipeline.
 See [[WebGPU#pipeline-layout|WebGPU &sect; GPUPipelineLayout]].
@@ -4102,20 +4121,6 @@ See [[WebGPU#pipeline-layout|WebGPU &sect; GPUPipelineLayout]].
 Bindings must not alias within a shader stage:
 two different variables in the resource interface of a given
 shader must not have the same group and binding values, when considered as a pair of values.
-
-<table class='data'>
-  <caption>Resource variable attributes</caption>
-  <thead>
-    <tr><th>Decoraton<th>Operand<th>Description
-  </thead>
-
-  <tr><td>`group`
-      <td>non-negative i32 literal
-      <td>Bind group index
-  <tr><td>`binding`
-      <td>non-negative i32 literal
-      <td>Binding number index
-</table>
 
 ### Resource layout compatibility ### {#resource-layout-compatibility}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -178,8 +178,9 @@ An identifier must not have the same spelling as a keyword or as a reserved keyw
 
 ## Attributes ## {#attributes}
 
-Attributes provide a unified syntax for modifications of objects and types.
-They are used for a variety of purposes such as specifying the interface with the API.
+An <dfn noexport>attribute</dfn> modifies an object or type.
+[SHORTNAME] provides a unified syntax for applying attributes.
+Attributes are used for a variety of purposes such as specifying the interface with the API.
 Generally speaking, from the language's point-of-view, attributes can be
 ignored for the purposes of type and semantic checking.
 
@@ -204,14 +205,15 @@ literal_or_ident
     <tr><th>Attribute<th>Valid Values<th>Description
   </thead>
 
-   <tr><td><dfn noexport>`access`</dfn>
+   <tr><td><dfn noexport dfn-for="attribute">`access`</dfn>
     <td>`read`, `write`, or `read_write`
     <td>Must only be applied to a type used as a store type for a variable in
-    the [=storage classes/storage=] storage class.
+    the [=storage classes/storage=] storage class or a variable of [storage
+    texture](#texture-storage) type.
 
-    Specifies the access qualification of a variable.
+    Specifies the access qualification of a storage [=resource=] variable.
 
-  <tr><td><dfn noexport>`align`</dfn>
+  <tr><td><dfn noexport dfn-for="attribute">`align`</dfn>
     <td>positive i32 literal
     <td>Must only be applied to a member of a [=structure=] type.
 
@@ -219,16 +221,14 @@ literal_or_ident
 
     See memory layout [alignment and size](#alignment-and-size).
 
-  <tr><td><dfn noexport>`binding`
+  <tr><td><dfn noexport dfn-for="attribute">`binding`
     <td>non-negative i32 literal
-    <td>Must only be applied to a variable in the [=storage classes/storage=] or
-    [=storage classes/uniform=] storage classes, or a variable of [texture or
-    sampler](#texture-types) type.
+    <td>Must only be applied to a [=resource=] variable.
 
-    Specifies the binding number of the resource.
+    Specifies the binding number of the resource in a bind [=attribute/group=].
     See [[#resource-interface]].
 
-  <tr><td><dfn noexport>`block`</dfn>
+  <tr><td><dfn noexport dfn-for="attribute">`block`</dfn>
     <td>*None*
     <td>Must only be applied to a [=structure=] type.
 
@@ -243,7 +243,7 @@ literal_or_ident
     * the element type of an [=array=] type
     * the member type in another structure
 
-  <tr><td><dfn noexport>`builtin`
+  <tr><td><dfn noexport dfn-for="attribute">`builtin`
     <td>a builtin variable identifier
     <td>Must only be applied to an entry point function parameter, entry point
     return type, or member of a [=structure=].
@@ -251,48 +251,46 @@ literal_or_ident
     Declares a builtin variable.
     See [[#builtin-variables]].
 
-  <tr><td><dfn noexport>`constant_id`
+  <tr><td><dfn noexport dfn-for="attribute">`constant_id`
     <td>non-negative i32 literal
     <td>Must only be applied to module scope constant declaration of [=scalar=] type.
 
     Specifies a [=pipeline-overridable=] constant.
 
-  <tr><td><dfn noexport>`group`
+  <tr><td><dfn noexport dfn-for="attribute">`group`
     <td>non-negative i32 literal
-    <td>Must only be applied to a variable in the [=storage classes/storage=] or
-    [=storage classes/uniform=] storage classes, or a variable of [texture or
-    sampler](#texture-types) type.
+    <td>Must only be applied to a [=resource=] variable.
 
     Specifies the binding group of the resource.
     See [[#resource-interface]].
 
-  <tr><td><dfn noexport>`location`
+  <tr><td><dfn noexport dfn-for="attribute">`location`
     <td>non-negative i32 literal
     <td>Must only be applied to an entry point function parameter, entry point
     return type, or member of a [=structure=] type.
 
     Specifies a part of the user-defined IO of an entry point. See TBD.
 
-  <tr><td><dfn noexport>`size`</dfn>
+  <tr><td><dfn noexport dfn-for="attribute">`size`</dfn>
     <td>positive i32 literal
     <td>Must only be applied to a member of a [=structure=] type.
 
     The number of bytes reserved in the struct for this member.
 
-  <tr><td><dfn noexport>`stage`</dfn>
+  <tr><td><dfn noexport dfn-for="attribute">`stage`</dfn>
     <td>`compute`, `vertex`, or `fragment`
     <td>Must only be applied to a function declaration.
 
     Declares an entry point by specifying its pipeline stage.
 
-  <tr><td><dfn noexport>`stride`</dfn>
+  <tr><td><dfn noexport dfn-for="attribute">`stride`</dfn>
     <td>positive i32 literal
     <td>Must only be applied to an [=array=] type.
 
     The number of bytes from the start of one element of the array to the
     start of the next element.
 
-  <tr><td><dfn noexport>`workgroup_size`</dfn>
+  <tr><td><dfn noexport dfn-for="attribute">`workgroup_size`</dfn>
     <td>One, two or three parameters. Each parameter is either a positive i32
     literal or the name of a [=pipeline-overridable=] constant of i32 type.
     <td>Must only be applied to a [=compute shader stage=] function declaration.
@@ -540,7 +538,7 @@ An array element type must be one of:
 * a [=structure=] type
 
 [SHORTNAME] defines the following attributes that can be applied to array types:
-* [=stride=]
+* [=attribute/stride=]
 
 Restrictions on runtime-sized arrays:
 * The last member of the structure type defining the [=store type=]
@@ -604,14 +602,14 @@ struct_member
 </pre>
 
 [SHORTNAME] defines the following attributes that can be applied to structure types:
- * [=block=]
+ * [=attribute/block=]
 
 [SHORTNAME] defines the following attributes that can be applied to structure members:
- * [=builtin=]
- * [=location=]
- * [=stride=]
- * [=align=]
- * [=size=]
+ * [=attribute/builtin=]
+ * [=attribute/location=]
+ * [=attribute/stride=]
+ * [=attribute/align=]
+ * [=attribute/size=]
 
 Note: Layout attributes are required if the structure type is used
 to define a [=uniform buffer=] or a [=storage buffer=]. See [[#memory-layouts]].
@@ -735,9 +733,9 @@ The following types are <dfn dfn noexport>host-shareable</dfn>:
 * [[#struct-types]] if each member is host-shareable
 
 [SHORTNAME] defines the following attributes that affect memory layouts:
- * [=stride=]
- * [=align=]
- * [=size=]
+ * [=attribute/stride=]
+ * [=attribute/align=]
+ * [=attribute/size=]
 
 Note: An [=IO-shareable=] type *T* would also be host-shareable if *T* and its subtypes have
 appropriate [=stride=] attributes, and if *T* is not [=bool=] and does not contain a [=bool=].
@@ -866,7 +864,7 @@ We will use the following notation:
 
 Each [=host-shareable=] data type has a default alignment and size value.
 The alignment and size values for a given structure member can differ from the
-defaults if the [=align=] and / or [=size=] decorations are used.
+defaults if the [=attribute/align=] and / or [=attribute/size=] decorations are used.
 
 Alignment guarantees that a value's address in memory will be a multiple of the
 specified value. This can enable more efficient hardware instructions to be used
@@ -965,8 +963,9 @@ Each structure member has a default size and alignment value. These values are
 used to calculate each member's byte offset from the start of the structure.
 
 Structure members will use their type's size and alignment, unless the
-structure member is explicitly annotated with [=size=] and / or [=align=].
-decorations, in which case those member decorations take precedence.
+structure member is explicitly annotated with [=attribute/size=] and / or
+[=attribute/align=].  decorations, in which case those member decorations take
+precedence.
 
 The first structure member always has a zero byte offset from the start of the
 structure.
@@ -978,8 +977,8 @@ Subsequent members have the following byte offset from the start of the structur
 </p>
 
 Structure members must not overlap. If a structure member is decorated with the
-[=size=] attribute, the value must be at least as large as the default size of
-the member's type.
+[=attribute/size=] attribute, the value must be at least as large as the
+default size of the member's type.
 
 The alignment of a structure is equal to the largest alignment of all of its
 members:
@@ -1114,8 +1113,9 @@ the following structure:
 
 This section describes how the internals of a value are placed in the byte locations
 of a buffer, given an assumed placement of the overall value.
-These layouts depend on the value's type, the [=stride=] attribute on array
-types, and the [=align=] and [=size=] attributes on structure type members.
+These layouts depend on the value's type, the [=attribute/stride=] attribute on
+array types, and the [=attribute/align=] and [=attribute/size=] attributes on
+structure type members.
 
 The data will appear identically regardless of storage class.
 
@@ -1762,8 +1762,7 @@ type_decl
   | VEC3 LESS_THAN type_decl GREATER_THAN
   | VEC4 LESS_THAN type_decl GREATER_THAN
   | POINTER LESS_THAN storage_class COMMA type_decl GREATER_THAN
-  | attribute_list* ARRAY LESS_THAN type_decl COMMA INT_LITERAL GREATER_THAN
-  | attribute_list* ARRAY LESS_THAN type_decl GREATER_THAN
+  | attribute_list* ARRAY LESS_THAN type_decl (COMMA INT_LITERAL)? GREATER_THAN
   | MAT2x2 LESS_THAN type_decl GREATER_THAN
   | MAT2x3 LESS_THAN type_decl GREATER_THAN
   | MAT2x4 LESS_THAN type_decl GREATER_THAN
@@ -1876,8 +1875,9 @@ variable_storage_decoration
 
 </pre>
 
-Variables in the [=storage classes/storage=] storage class must have an
-[=access=] attribute applied to the store type.
+Variables in the [=storage classes/storage=] storage class and variables with a
+(storage texture)[#storage-textures] type must have an [=access=] attribute
+applied to the store type.
 
 Two variables with overlapping lifetimes will not have overlapping storage.
 
@@ -1940,17 +1940,17 @@ Variables at [=module scope=] are restricted as follows:
     have a storage class decoration.  The storage class will always be [=storage classes/handle=].
 
 A variable in the [=storage classes/uniform=] storage class is a <dfn noexport>uniform buffer</dfn> variable.
-Its [=store type=] must be a [=host-shareable=] structure type with [=block=] attribute,
+Its [=store type=] must be a [=host-shareable=] structure type with [=attribute/block=] attribute,
 satisfying the (storage class constraints)[#storage-class-constraints].
 
 A variable in the [=storage classes/storage=] storage class is a <dfn noexport>storage buffer</dfn> variable.
-Its [=store type=] must be a [=host-shareable=] structure type with [=block=] attribute,
+Its [=store type=] must be a [=host-shareable=] structure type with [=attribute/block=] attribute,
 satisfying the (storage class constraints)[#storage-class-constraints].
 
 As described in [[#resource-interface]],
 uniform buffers, storage buffers, textures, and samplers form the
 [=resource interface of a shader=].
-Such variables are declared with [=group=] and [=binding=] decorations.
+Such variables are declared with [=attribute/group=] and [=attribute/binding=] decorations.
 
 <div class='example wgsl global-scope' heading="Module scope variable declarations">
   <xmp>
@@ -1976,8 +1976,7 @@ Such variables are declared with [=group=] and [=binding=] decorations.
 
 <pre class='def'>
 global_variable_decl
-  : attribute_list* variable_decl
-  | attribute_list* variable_decl EQUAL const_expr
+  : attribute_list* variable_decl (EQUAL const_expr)?
 </pre>
 
 <div class='example' heading="Variable Decorations">
@@ -1992,8 +1991,8 @@ global_variable_decl
 </div>
 
 [SHORTNAME] defines the following attributes that can be applied to global variables:
- * [=binding=]
- * [=group=]
+ * [=attribute/binding=]
+ * [=attribute/group=]
 
 ## Module Constants ## {#module-constants}
 
@@ -3841,13 +3840,13 @@ param
 </pre>
 
 [SHORTNAME] defines the following attributes that can be applied to function declarations:
- * [=stage=]
- * [=workgroup_size=]
+ * [=attribute/stage=]
+ * [=attribute/workgroup_size=]
 
 [SHORTNAME] defines the following attributes that can be applied to function
 parameters and return types:
- * [=builtin=]
- * [=location=]
+ * [=attribute/builtin=]
+ * [=attribute/location=]
 
 <div class='example' heading='Function'>
   <xmp>
@@ -3985,8 +3984,8 @@ It will stabilize in a finite number of steps.
 ### Function attributes for entry points ### {#entry-point-attributes}
 
 [SHORTNAME] defines the following attributes that can be applied to entry point declarations:
- * [=stage=]
- * [=workgroup_size=]
+ * [=attribute/stage=]
+ * [=attribute/workgroup_size=]
 
 ISSUE: Can we query upper bounds on workgroup size dimensions?  Is it independent of the shader, or
   a property to be queried after creating the shader module?


### PR DESCRIPTION
* Fill out the attribute section
 * move all attribute definitions into this section in a single table
 * make this table define the attributes
 * move the attribute grammar into this section
* Remove attribute definitions from other sections
  * most often replace with a list of applicable linked attributes
* rename decoration and decoration_list to attribute and attribute_list

I think it is easier to discuss with the actual diff than opening an issue about it, but I find it easier to centralize all the attribute definitions into a single table that describes their meaning and how they can be used. Avoids potential confusion from having the same attribute described in multiple locations in the spec.

It will conflict with several open PRs as it stands, but I think all that can be worked out easily enough.