### PR TITLE
Fix array [[stride]] rule

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -991,8 +991,9 @@ In all cases, the array stride must be a multiple of the element alignment.
   </xmp>
 </div>
 
-Array elements must not overlap. Arrays decorated with the [=stride=] attribute
-must have a stride that is a multiple of the element type's size.
+Arrays decorated with the [=stride=] attribute must have a stride that is at
+least the size of the element type, and be a multiple of the element type's
+alignment value.
 
 The array size is equal to the element stride multiplied by the number of
 elements:


### PR DESCRIPTION
> Arrays decorated with the stride attribute must have a stride that is a multiple of the element type's size.

This isn't right, as an array of `vec3<i32>` would have 2/3 elements misaligned.