### PR TITLE
Clarify the check on buffer offset in buffer-texture copy with depth stencil formats

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5254,8 +5254,11 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
                         |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}.
                         See [[#depth-formats|depth-formats]].
                 - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
-                - |source|.{{GPUImageDataLayout/offset}} is a multiple of the [=texel block size=]
-                    of |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}.
+                - If |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}} is not a depth/stencil format:
+                    - |source|.{{GPUImageDataLayout/offset}} is a multiple of the [=texel block size=] of
+                      |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}.
+                - If |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}} is a depth/stencil format:
+                    - |source|.{{GPUImageDataLayout/offset}} is a multiple of 4.
                 - [$validating linear texture data$](|source|,
                     |source|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[size]]}},
                     |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}},
@@ -5295,8 +5298,11 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
                 - |destination|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[usage]]}} contains
                     {{GPUBufferUsage/COPY_DST}}.
                 - [=Valid Texture Copy Range=] applies to |source| and |copySize|.
-                - |destination|.{{GPUImageDataLayout/offset}} is a multiple of the [=texel block size=]
-                    of |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}.
+                - If |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}} is not a depth/stencil format:
+                    - |destination|.{{GPUImageDataLayout/offset}} is a multiple of the [=texel block size=] of
+                      |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}.
+                - If |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}} is a depth/stencil format:
+                    - |destination|.{{GPUImageDataLayout/offset}} is a multiple of 4.
                 - [$validating linear texture data$](|destination|,
                     |destination|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[size]]}},
                     |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}},

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5256,7 +5256,7 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
                 - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
                 - If |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}} is not a depth/stencil format:
                     - |source|.{{GPUImageDataLayout/offset}} is a multiple of the [=texel block size=] of
-                      |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}.
+                        |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}.
                 - If |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}} is a depth/stencil format:
                     - |source|.{{GPUImageDataLayout/offset}} is a multiple of 4.
                 - [$validating linear texture data$](|source|,
@@ -5300,7 +5300,7 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
                 - [=Valid Texture Copy Range=] applies to |source| and |copySize|.
                 - If |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}} is not a depth/stencil format:
                     - |destination|.{{GPUImageDataLayout/offset}} is a multiple of the [=texel block size=] of
-                      |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}.
+                        |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}.
                 - If |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}} is a depth/stencil format:
                     - |destination|.{{GPUImageDataLayout/offset}} is a multiple of 4.
                 - [$validating linear texture data$](|destination|,


### PR DESCRIPTION
This patch intends to clarify the validation rules on the
buffer offset in copyBufferToTexture() and copyTextureToBuffer() with
depth stencil formats. (The buffer offset must be a multiple of 4 when
the texture has a depth/stencil format).

According to Vulkan SPEC (1.2.172, chapter 19.4):
- VUID-vkCmdCopyBufferToImage-srcImage-04053
  If dstImage has a depth/stencil format, the bufferOffset member of any
  element of pRegions must be a multiple of 4
- VUID-vkCmdCopyImageToBuffer-srcImage-04053
  If srcImage has a depth/stencil format, the bufferOffset member of any
  element of pRegions must be a multiple of 4


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Jiawei-Shao/gpuweb/pull/1528.html" title="Last updated on Mar 17, 2021, 7:06 AM UTC (d7ff5cc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1528/afaa92f...Jiawei-Shao:d7ff5cc.html" title="Last updated on Mar 17, 2021, 7:06 AM UTC (d7ff5cc)">Diff</a>