### PR TITLE
Infer constant types in WGSL

### DIFF
--- a/samples/hello-cube.html
+++ b/samples/hello-cube.html
@@ -35,7 +35,6 @@ fn main(
     FragmentData out;
     out.position = mul(uniforms.modelViewProjectionMatrix[0], position);
     out.color = color;
-
     return out;
 }
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1879,7 +1879,8 @@ variable_storage_decoration
 
 </pre>
 
-The `const` identifiers are immutable. When a `const` identifier is declared without the corresponding type,
+The `const` identifiers denote values that are immutable.
+When a `const` identifier is declared without the corresponding type,
 e.g. `const foo = 4`, the type is automatically inferred from the expression to the right of `=`.
 If the type is provided, e.g `const foo: i32 = 4`, it has to match exactly to the type of the initializer expression.
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1866,7 +1866,7 @@ and when the storage class decoration is required, optional, or forbidden.
 variable_statement
   : variable_decl
   | variable_decl EQUAL short_circuit_or_expression
-  | CONST variable_ident_decl EQUAL short_circuit_or_expression
+  | CONST (IDENT | variable_ident_decl) EQUAL short_circuit_or_expression
 
 variable_decl
   : VAR variable_storage_decoration? variable_ident_decl
@@ -1878,6 +1878,10 @@ variable_storage_decoration
   : LESS_THAN storage_class GREATER_THAN
 
 </pre>
+
+The `const` identifiers are immutable. When a `const` identifier is declared without the corresponding type,
+e.g. `const foo = 4`, the type is automatically inferred from the expression to the right of `=`.
+If the type is provided, e.g `const foo: i32 = 4`, it has to match exactly to the type of the initializer expression.
 
 Variables in the [=storage classes/storage=] storage class and variables with a
 [storage texture](#texture-storage) type must have an [=access=] attribute


### PR DESCRIPTION
Helps #736 and #560 to the point of being able to postpone the rest till after MVP.

When porting shaders to WGSL, writing down the type for every constant appears to be the most painful thing. Consider [this shader](https://github.com/gfx-rs/wgpu-rs/blob/master/examples/water/water_shader.vert) for example, here is a slice of it:
```glsl
    vec4 a0 = b0.xzyw + s0.xzyw*sh.xxyy;
    vec4 a1 = b1.xzyw + s1.xzyw*sh.zzww;
    vec3 p0 = vec3(a0.xy, h.x);
    vec3 p1 = vec3(a0.zw, h.y);
    vec3 p2 = vec3(a1.xy, h.z);
    vec3 p3 = vec3(a1.zw, h.w);
```
Writing all of these with types is just painful:
```rust
    const a0: vec4<f32> = b0.xzyw + s0.xzyw*sh.xxyy;
    const a1: vec4<f32> = b1.xzyw + s1.xzyw*sh.zzww;
    const p0: vec3<f32> = vec3<f32>(a0.xy, h.x);
    const p1: vec3<f32> = vec3<f32>(a0.zw, h.y);
    const p2: vec3<f32> = vec3<f32>(a1.xy, h.z);
    const p3: vec3<f32> = vec3<f32>(a1.zw, h.w);
```

I generally want the language to be minimal and oppose the minor ergonomic changes if they increase complexity. This problem though is a major blocker for WGSL adoption in my eyes. Types are verbose and rich in special symbols (`:`, `<`, `>`), and most importantly - they are redundant in all cases where we can infer them. I believe our API is currently structured in a way that makes the right-hand-size expression always have a defined type, so inferring the `const` declarations is trivial.

**Justification** to limiting this change to `const` only:
  - `const` should be preferred over `var`. Making the former easy to write digs a good pit of success for WGSL.
  - just limiting the PR to the minimal scope where I believe it solves the problem.

Edit: this is what it will look like:
```rust
    const a0 = b0.xzyw + s0.xzyw*sh.xxyy;
    const a1 = b1.xzyw + s1.xzyw*sh.zzww;
    const p0 = vec3<f32>(a0.xy, h.x);
    const p1 = vec3<f32>(a0.zw, h.y);
    const p2 = vec3<f32>(a1.xy, h.z);
    const p3 = vec3<f32>(a1.zw, h.w);
```