### PR TITLE
Add GPUQuerySet state

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7303,7 +7303,7 @@ garbage collection by calling {{GPUQuerySet/destroy()}}.
     ::
         Destroys the {{GPUQuerySet}}.
 
-        <div algorithm="GPUQuerySet.signal">
+        <div algorithm="GPUQuerySet.destroy">
             **Called on:** {{GPUQuerySet}} |this|.
 
             **Returns:** {{undefined}}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7165,11 +7165,11 @@ GPUQueue includes GPUObjectBase;
                     <div class=validusage>
                         - Every {{GPUBuffer}} referenced in any element of |commandBuffers| is in the
                             `"unmapped"` [=buffer state=].
-                        - Every {{GPUQuerySet}} referenced in any element of |commandBuffers| is in the
-                            `"available"` [=query set state=]. Unlike the other types of query set,
-                            {{GPURenderPassDescriptor}}.{{GPURenderPassDescriptor/occlusionQuerySet}}
-                            is not referenced at {{GPURenderPassEncoder}} creation, but when
-                            {{GPURenderPassEncoder/beginOcclusionQuery()}} is called.
+                        - Every {{GPUQuerySet}} referenced in a command in any element of |commandBuffers| is
+                            in the [=query set state/available=] state. For occlusion queries,
+                            {{GPURenderPassDescriptor/occlusionQuerySet}} in {{GPUCommandEncoder/beginRenderPass()}}
+                            does not constitute a reference, while {{GPURenderPassEncoder/beginOcclusionQuery()}}
+                            does.
                     </div>
 
                 1. Issue the following steps on the [=Queue timeline=] of |this|:
@@ -7304,14 +7304,11 @@ garbage collection by calling {{GPUQuerySet/destroy()}}.
         Destroys the {{GPUQuerySet}}.
 
         <div algorithm="GPUQuerySet.signal">
-            **Called on:** {{GPUQuerySet}} this.
+            **Called on:** {{GPUQuerySet}} |this|.
 
             **Returns:** {{undefined}}
 
-            If any of the following conditions are unsatisfied, generate a validation error and stop.
-
             1. Set |this|.{{GPUQuerySet/[[state]]}} to [=query set state/destroyed=].
-
         </div>
 </dl>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7166,7 +7166,7 @@ GPUQueue includes GPUObjectBase;
                         - Every {{GPUBuffer}} referenced in any element of |commandBuffers| is in the
                             `"unmapped"` [=buffer state=].
                         - Every {{GPUQuerySet}} referenced in any element of |commandBuffers| is in the
-                            `"available"` [=query set state=]. Different with other types of query set,
+                            `"available"` [=query set state=]. Unlike the other types of query set,
                             {{GPURenderPassDescriptor}}.{{GPURenderPassDescriptor/occlusionQuerySet}}
                             is not referenced at {{GPURenderPassEncoder}} creation, but when
                             {{GPURenderPassEncoder/beginOcclusionQuery()}} is called.
@@ -7224,7 +7224,7 @@ GPUQuerySet includes GPUObjectBase;
         The current state of the {{GPUQuerySet}}.
 </dl>
 
-Each {{GPUQuerySet}} has a current <dfn dfn>query set state</dfn> on the [=Content timeline=]
+Each {{GPUQuerySet}} has a current <dfn dfn>query set state</dfn> on the [=Device timeline=]
 which is one of the following:
 
  - "<dfn dfn for="query set state">available</dfn>" where the {{GPUQuerySet}} is
@@ -7287,12 +7287,7 @@ dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
             </div>
 
             1. Let |q| be a new {{GPUQuerySet}} object.
-            1. Set |q|.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/type}} to |descriptor|.{{GPUQuerySetDescriptor/type}}.
-            1. Set |q|.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}} to |descriptor|.{{GPUQuerySetDescriptor/count}}.
-            1. If |descriptor|.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/pipeline-statistics}}:
-
-                1. Set |q|.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/pipelineStatistics}} to |descriptor|.{{GPUQuerySetDescriptor/pipelineStatistics}}.
-
+            1. Set |q|.{{GPUQuerySet/[[descriptor]]}} to |descriptor|.
             1. Set |q|.{{GPUQuerySet/[[state]]}} to [=query set state/available=].
             1. Return |q|.
         </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7165,6 +7165,11 @@ GPUQueue includes GPUObjectBase;
                     <div class=validusage>
                         - Every {{GPUBuffer}} referenced in any element of |commandBuffers| is in the
                             `"unmapped"` [=buffer state=].
+                        - Every {{GPUQuerySet}} referenced in any element of |commandBuffers| is in the
+                            `"available"` [=query set state=]. Different with other types of query set,
+                            {{GPURenderPassDescriptor}}.{{GPURenderPassDescriptor/occlusionQuerySet}}
+                            is not referenced at {{GPURenderPassEncoder}} creation, but when
+                            {{GPURenderPassEncoder/beginOcclusionQuery()}} is called.
                     </div>
 
                 1. Issue the following steps on the [=Queue timeline=] of |this|:
@@ -7213,9 +7218,21 @@ GPUQuerySet includes GPUObjectBase;
         The {{GPUQuerySetDescriptor}} describing this query set.
 
         All optional fields of {{GPUTextureViewDescriptor}} are defined.
+
+    : <dfn>\[[state]]</dfn> of type [=query set state=].
+    ::
+        The current state of the {{GPUQuerySet}}.
 </dl>
 
-### Creation ### {#queryset-creation}
+Each {{GPUQuerySet}} has a current <dfn dfn>query set state</dfn> on the [=Content timeline=]
+which is one of the following:
+
+ - "<dfn dfn for="query set state">available</dfn>" where the {{GPUQuerySet}} is
+     available for GPU operations on its content.
+ - "<dfn dfn for="query set state">destroyed</dfn>" where the {{GPUQuerySet}} is
+     no longer available for any operations except {{GPUQuerySet/destroy}}.
+
+### QuerySet Creation ### {#queryset-creation}
 
 A {{GPUQuerySetDescriptor}} specifies the options to use in creating a {{GPUQuerySet}}.
 
@@ -7269,11 +7286,22 @@ dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
                     which cannot be duplicated.
             </div>
 
-            Issue: Describe {{GPUDevice/createQuerySet()}} algorithm steps.
+            1. Let |q| be a new {{GPUQuerySet}} object.
+            1. Set |q|.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/type}} to |descriptor|.{{GPUQuerySetDescriptor/type}}.
+            1. Set |q|.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}} to |descriptor|.{{GPUQuerySetDescriptor/count}}.
+            1. If |descriptor|.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/pipeline-statistics}}:
+
+                1. Set |q|.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/pipelineStatistics}} to |descriptor|.{{GPUQuerySetDescriptor/pipelineStatistics}}.
+
+            1. Set |q|.{{GPUQuerySet/[[state]]}} to [=query set state/available=].
+            1. Return |q|.
         </div>
 </dl>
 
-### Finalization ### {#queryset-finalization}
+### QuerySet Destruction ### {#queryset-destruction}
+
+An application that no longer requires a {{GPUQuerySet}} can choose to lose access to it before
+garbage collection by calling {{GPUQuerySet/destroy()}}.
 
 <dl dfn-type=method dfn-for=GPUQuerySet>
     : <dfn>destroy()</dfn>
@@ -7285,7 +7313,13 @@ dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
 
             **Returns:** {{undefined}}
 
-            Issue: Describe {{GPUQuerySet/destroy()}} algorithm steps.
+            If any of the following conditions are unsatisfied, generate a validation error and stop.
+            <div class=validusage>
+                - |this| is [$valid to use with$] |this|.{{GPUObjectBase/[[device]]}}
+            </div>
+
+            1. Set |this|.{{GPUQuerySet/[[state]]}} to [=query set state/destroyed=].
+
         </div>
 </dl>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7309,9 +7309,6 @@ garbage collection by calling {{GPUQuerySet/destroy()}}.
             **Returns:** {{undefined}}
 
             If any of the following conditions are unsatisfied, generate a validation error and stop.
-            <div class=validusage>
-                - |this| is [$valid to use with$] |this|.{{GPUObjectBase/[[device]]}}
-            </div>
 
             1. Set |this|.{{GPUQuerySet/[[state]]}} to [=query set state/destroyed=].
 


### PR DESCRIPTION
- This is an internal attribute to indicate whether query set is available or destoryed.
- This state is used in query set creation and destory, and queue submit with queries commands.
- Add algorithm steps for query set creation and destory.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 9, 2021, 6:42 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fgpuweb%2Fgpuweb%2Fpull%2F1531%2Fd34f1cf.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fhaoxli%2Fgpuweb%2Fpull%2F1531.html)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 sysreq@w3.org to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%231531.)._
</details>
