### PR TITLE
[wgsl] Remove rule on arrays needing stride decorations to be host-sharable

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -627,7 +627,7 @@ The following types are <dfn dfn noexport>host-shareable</dfn>:
 * [=numeric scalar=] types
 * [=numeric vector=] types
 * [[#matrix-types]]
-* [[#array-types]] if the array type has a [=stride=] attribute and its element type is host-shareable
+* [[#array-types]] if the array element type is host-shareable
 * [[#struct-types]] if each member is host-shareable
 
 <table class='data'>


### PR DESCRIPTION

There's now a well defined default stride.