### PR TITLE
Disallow specifying the same attribute multiple times

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -184,6 +184,8 @@ Attributes are used for a variety of purposes such as specifying the interface w
 Generally speaking, from the language's point-of-view, attributes can be
 ignored for the purposes of type and semantic checking.
 
+An attribute must not be specified more than once per object or type.
+
 <pre class='def'>
 attribute_list
   : ATTR_LEFT (attribute COMMA)* attribute ATTR_RIGHT


### PR DESCRIPTION
Fixes #1488

* Invalid to specify an attribute multiple times per object or type.