### PR TITLE
Assignable expression

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3408,11 +3408,14 @@ compound_statement
 ## Assignment TODO ## {#assignment}
 
 <pre class='def'>
-assignment_statement
-  : singular_expression EQUAL short_circuit_or_expression
-      If singular_expression is a variable, this maps to OpStore to the variable.
+assignable_expression
+  : IDENT (postfix_expression)*
+    If assignable_expression is a variable, this maps to OpStore to the variable.
       Otherwise, singular expression is a pointer expression in an Assigning (L-value) context
       which maps to OpAccessChain followed by OpStore
+
+assignment_statement
+  : assignable_expression EQUAL short_circuit_or_expression
 </pre>
 
 ### Writing to a variable TODO ### {#writing-to-var}


### PR DESCRIPTION
This is a follow-up to #1456, on the topic of the type system reach with regards to references. This mini-proposal is developed in collaboration with ~~the white wolf~~ @jimblandy.

Basically, we all want WGSL to be able to statically check that the left side of the assignment statement is assignable. The disagreement is about what part of a static check is responsible for this. We can consider at least 3 different places for this:
  1. grammar
  2. type system
  3. post-type checks (like Rust's borrow checker, or other validation rules in WGSL)

This PR shows how we can get the static check with (1) + (3): grammar would ensure specific form of the left-hand expression, and the validation rules would check for mutability (i.e. is the `IDENT` really a `const` or a uniform buffer?). The proposal excludes pointers (since the pointers spec still needs to land either way, it's incomplete right now). I think it looks very simple and approachable.

The benefit of going this route is that the type system would not need to have any implicit coersions (from references to values on the right hand side).