### PR TITLE
Fix some examples in the spec

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -617,15 +617,14 @@ struct_member
  * [=attribute/align=]
  * [=attribute/size=]
 
-Note: Layout attributes are required if the structure type is used
+Note: Layout attributes may be required if the structure type is used
 to define a [=uniform buffer=] or a [=storage buffer=]. See [[#memory-layouts]].
 
 <div class='example wgsl global-scope' heading='Structure WGSL'>
   <xmp>
-    // Offset decorations
     struct my_struct {
-      [[offset(0)]] a : f32;
-      [[offset(4)]] b : vec4<f32>;
+      a : f32;
+      b : vec4<f32>;
     };
   </xmp>
 </div>
@@ -646,9 +645,9 @@ to define a [=uniform buffer=] or a [=storage buffer=]. See [[#memory-layouts]].
     // Runtime Array
     type RTArr = [[stride(16)]] array<vec4<f32>>;
     [[block]] struct S {
-      [[offset(0)]] a : f32;
-      [[offset(4)]] b : f32;
-      [[offset(16)]] data : RTArr;
+      a : f32;
+      b : f32;
+      data : RTArr;
     };
   </xmp>
 </div>
@@ -1022,7 +1021,7 @@ rounded to the next multiple of the structure's alignment:
     };
 
     [[group(0), binding(0)]]
-    var<storage> storage_buffer : B;
+    var<storage> storage_buffer : [[access(read_write)]] B;
   </xmp>
 </div>
 
@@ -1823,11 +1822,14 @@ declaration of the identifier as a type alias or structure type.
 <div class='example wgsl global-scope' heading='Access qualifier'>
   <xmp>
     // Storage buffers
+    [[group(0), binding(0)]]
     var<storage> buf1 : [[access(read)]] Buffer;       // Can read, cannot write.
+    [[group(0), binding(1)]
     var<storage> buf2 : [[access(read_write)]] Buffer; // Can both read and write
 
     // Uniform buffer. Always read-only, and has more restrictive layout rules.
     struct ParamsTable {};
+    [[group(0), binding(2)]]
     var<uniform> params : ParamsTable;
   </xmp>
 </div>
@@ -1962,16 +1964,17 @@ Such variables are declared with [=attribute/group=] and [=attribute/binding=] d
     var<workgroup> worklist: array<i32,10>;
 
     [[block]] struct Params {
-      [[offset(0)]] specular: f32;
-      [[offset(4)]] count: i32;
+      specular: f32;
+      count: i32;
     };
+    [[group(0)]], binding(2)]]
     var<uniform> param: Params;          // A uniform buffer
 
     [[block]] struct PositionsBuffer {
-      [[offset(0)]] pos: [[stride(8)]] array<vec2<f32>>;
+      pos: array<vec2<f32>>;
     };
     [[group(0), binding(0)]]
-    var<storage> pbuf: PositionsBuffer;  // A storage buffer
+    var<storage> pbuf: [[access(read_write)]] PositionsBuffer;  // A storage buffer
 
     [[group(0), binding(1)]]
     var filter_params: sampler;   // Textures and samplers are always in "handle" storage.


### PR DESCRIPTION
* Add access attribute to storage variables
* Add group and binding attributes to resource variables
* Remove offset from structure members
* Update a note to account for default struct layouts