### PR TITLE
Clarify discard statement

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3802,19 +3802,53 @@ In this case the call site of this function invocation evaluates to the return v
 The type of the return value must match the return type of the function.
 
 
-### Discard ### {#discard-statement}
+### Discard Statement ### {#discard-statement}
 
-The `discard` statement causes the current invocation to terminate and no
-entry point return value to be generated for the invocation. Only statements
-executed prior to the `discard` statement will have observable side effects. A
-`discard` statement may be executed by any function and the effect is the same,
-termination of the invocation occurs immediately upon executing the statement.
+The `discard` statement must only be used in a [=fragment=] shader stage.
+Executing a `discard` statement will:
+
+* immediately terminate the current invocation, and
+* prevent evaluation and generation of a return value for the [=entry point=], and
+* prevent the current fragment from being processed downstream in the [=GPURenderPipeline=].
+
+Only statements
+executed prior to the `discard` statement will have observable effects.
+
+Note: A `discard` statement may be executed by any
+[=functions in a shader stage|function in a fragment stage=] and the effect is the same:
+immediate termination of the invocation.
+
 After a `discard` statement is executed, control flow is non-uniform for the
 duration of the entry point.
 
-The `discard` statement must only be used in a [=fragment=] shader stage.
-
 Issue: [[#uniform-control-flow]] needs to state whether all invocations being discarded maintains uniform control flow.
+
+<div class='example' heading='Using the discard statement to throw away a fragment'>
+  <xmp>
+  var<private> will_emit_color: bool = false;
+
+  fn discard_if_shallow(pos: vec4<f32>) {
+    if (pos.z < 0.001) {
+      // If this is executed, then the will_emit_color flag will
+      // never be set to true.
+      discard;
+    }
+    will_emit_color = true;
+  }
+
+  [[stage(fragment)]]
+  fn main([[builtin(position)]] coord_in: vec4<f32>)
+    -> [[location(0)]] vec4<f32>
+  {
+    discard_if_shallow(coord_in);
+
+    // Set the flag and emit red, but only if the helper function
+    // did not execute the discard statement.
+    will_emit_color = true;
+    return vec4<f32>(1.0, 0.0, 0.0, 1.0);
+  }
+  </xmp>
+</div>
 
 ## Function Call Statement TODO ## {#function-call-statement}
 


### PR DESCRIPTION
- Emphasize that the fragment is removed from downstream processing
  in the graphics pipeline.
- add an example showing immediate termination, all the way up the
  conceptual call stack.