### PR TITLE
Fix grammar to make function return type optional

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4016,12 +4016,16 @@ then the last statement in the function body must be a [=return=] statement.
 function_decl
   : attribute_list* function_header compound_statement
 
-function_type_decl
+function_header
+  : FN IDENT PAREN_LEFT param_list PAREN_RIGHT function_return_type_decl_optional
+
+function_return_type_decl_optional
+  :
+  | ARROW function_return_type_decl
+
+function_return_type_decl
   : attribute_list* type_decl
   | VOID
-
-function_header
-  : FN IDENT PAREN_LEFT param_list PAREN_RIGHT ARROW function_type_decl
 
 param_list
   :


### PR DESCRIPTION
Part of #1219