### PR TITLE
Remove the block attribute on structures

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -230,21 +230,6 @@ literal_or_ident
     Specifies the binding number of the resource in a bind [=attribute/group=].
     See [[#resource-interface]].
 
-  <tr><td><dfn noexport dfn-for="attribute">`block`</dfn>
-    <td>*None*
-    <td>Must only be applied to a [=structure=] type.
-
-    Indicates this structure type represents the contents of a buffer
-    resource occupying a single binding slot in the [=resource interface of a
-    shader|shader's resource interface=].
-
-    The `block` attribute must be applied to a structure type used as the
-    [=store type=] of a [=uniform buffer=] or [=storage buffer=] variable.
-
-    A structure type with the block attribute must not be:
-    * the element type of an [=array=] type
-    * the member type in another structure
-
   <tr><td><dfn noexport dfn-for="attribute">`builtin`
     <td>a builtin variable identifier
     <td>Must only be applied to an entry point function parameter, entry point
@@ -676,9 +661,6 @@ struct_member
   : attribute_list* variable_ident_decl SEMICOLON
 </pre>
 
-[SHORTNAME] defines the following attributes that can be applied to structure types:
- * [=attribute/block=]
-
 [SHORTNAME] defines the following attributes that can be applied to structure members:
  * [=attribute/builtin=]
  * [=attribute/location=]
@@ -713,7 +695,7 @@ to define a [=uniform buffer=] or a [=storage buffer=]. See [[#memory-layouts]].
   <xmp>
     // Runtime Array
     type RTArr = [[stride(16)]] array<vec4<f32>>;
-    [[block]] struct S {
+    struct S {
       a : f32;
       b : f32;
       data : RTArr;
@@ -1066,7 +1048,7 @@ rounded to the next multiple of the structure's alignment:
 
 <div class='example wgsl' heading='Layout of structures using implicit member sizes, alignments and strides'>
   <xmp highlight='rust'>
-    [[block]] struct A {                           //             align(8)  size(24)
+    struct A {                           //             align(8)  size(24)
         u : f32;                                   // offset(0)   align(4)  size(4)
         v : f32;                                   // offset(4)   align(4)  size(4)
         w : vec2<f32>;                             // offset(8)   align(8)  size(8)
@@ -1074,7 +1056,7 @@ rounded to the next multiple of the structure's alignment:
         // -- implicit struct size padding --      // offset(20)            size(4)
     };
 
-    [[block]] struct B {                           //             align(16) size(160)
+    struct B {                           //             align(16) size(160)
         a : vec2<f32>;                             // offset(0)   align(8)  size(8)
         // -- implicit member alignment padding -- // offset(8)             size(8)
         b : vec3<f32>;                             // offset(16)  align(16) size(12)
@@ -1096,14 +1078,14 @@ rounded to the next multiple of the structure's alignment:
 
 <div class='example wgsl' heading='Layout of structures with explicit member sizes, alignments and strides'>
   <xmp highlight='rust'>
-    [[block]] struct A {                           //             align(8)  size(32)
+    struct A {                           //             align(8)  size(32)
         u : f32;                                   // offset(0)   align(4)  size(4)
         v : f32;                                   // offset(4)   align(4)  size(4)
         w : vec2<f32>;                             // offset(8)   align(8)  size(8)
        [[size(16)]] x: f32;                        // offset(16)  align(4)  size(16)
     };
 
-    [[block]] struct B {                           //             align(16) size(208)
+    struct B {                           //             align(16) size(208)
         a : vec2<f32>;                             // offset(0)   align(8)  size(8)
         // -- implicit member alignment padding -- // offset(8)             size(8)
         b : vec3<f32>;                             // offset(16)  align(16) size(12)
@@ -2020,11 +2002,11 @@ Variables at [=module scope=] are restricted as follows:
     have a storage class decoration.  The storage class will always be [=storage classes/handle=].
 
 A variable in the [=storage classes/uniform=] storage class is a <dfn noexport>uniform buffer</dfn> variable.
-Its [=store type=] must be a [=host-shareable=] structure type with [=attribute/block=] attribute,
+Its [=store type=] must be a [=host-shareable=] structure type,
 satisfying the [storage class constraints](#storage-class-constraints).
 
 A variable in the [=storage classes/storage=] storage class is a <dfn noexport>storage buffer</dfn> variable.
-Its [=store type=] must be a [=host-shareable=] structure type with [=attribute/block=] attribute,
+Its [=store type=] must be a [=host-shareable=] structure type,
 satisfying the [storage class constraints](#storage-class-constraints).
 
 As described in [[#resource-interface]],
@@ -2037,14 +2019,14 @@ Such variables are declared with [=attribute/group=] and [=attribute/binding=] d
     var<private> decibels: f32;
     var<workgroup> worklist: array<i32,10>;
 
-    [[block]] struct Params {
+    struct Params {
       specular: f32;
       count: i32;
     };
     [[group(0)]], binding(2)]]
     var<uniform> param: Params;          // A uniform buffer
 
-    [[block]] struct PositionsBuffer {
+    struct PositionsBuffer {
       pos: array<vec2<f32>>;
     };
     [[group(0), binding(0)]]
@@ -4717,7 +4699,6 @@ I've written what an NVIDIA GPU does.  See https://github.com/google/amber/pull/
     <tr><td>Token<td>Definition
   </thead>
   <tr><td>`BITCAST`<td>bitcast
-  <tr><td>`BLOCK`<td>block
   <tr><td>`BREAK`<td>break
   <tr><td>`CASE`<td>case
   <tr><td>`CONST`<td>const


### PR DESCRIPTION
Closes #1398
Closes #1008

TL;DR: `[[block]]` doesn't help either an implementation or the user today. There is no use of this attribute right now.
If we ever find a good use for it, we should re-introduce it.