### PR TITLE
Fix uniform struct size requirement

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1303,8 +1303,6 @@ multiple of [=RequiredAlignOf=](|T|, |C|) for the storage class |C|:
 The [=storage classes/uniform=] storage class also requires that:
 
 * Array elements are aligned to 16 byte boundaries.
-* Structures that are members of a structure must have a size that is divisible
-    by 16 bytes.
 
 Note: When underlying the target is a Vulkan device, we assume the device does
 not support the `scalarBlockLayout` feature.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1303,7 +1303,8 @@ multiple of [=RequiredAlignOf=](|T|, |C|) for the storage class |C|:
 The [=storage classes/uniform=] storage class also requires that:
 
 * Array elements are aligned to 16 byte boundaries.
-* Structures must have a size that is divisible by 16 bytes.
+* Structures that are members of a structure must have a size that is divisible
+    by 16 bytes.
 
 Note: When underlying the target is a Vulkan device, we assume the device does
 not support the `scalarBlockLayout` feature.


### PR DESCRIPTION
Fixes #1558

* Only require nested structures in uniform storage class to have a size
  that is a multiple of 16 bytes