### PR TITLE
Allow inter-scope shadowing

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -321,7 +321,7 @@ the following kinds of objects:
 In other words, a declaration introduces a <dfn noexport>name</dfn> for an object.
 
 The <dfn noexport>scope</dfn> of a declaration is the set of
-program locations where a use of the declared identifier would denote
+program locations where a use of the declared identifier potentially denotes
 its associated object.
 We say the identifier is <dfn noexport>in scope</dfn>
 (of the declaration) at those source locations.
@@ -340,12 +340,18 @@ Examples of predeclared objects are:
 
 A declaration must not introduce a name when that identifier is
 already in scope with the same end scope as another instance of that name.
-When an identifier is referenced and multiple declarations are in scope, the
-reference is resolved to the closest preceding in scope declaration.
+When an identifier is used in scope of one or more declarations for that name,
+the identifier will denote the object of the declaration appearing closest to
+that use.
+We say the identifier use <dfn noexport>resolves</dfn> to that declaration.
+
+Note: A declaration always precedes its identifier's scope.
+Therefore, the nearest in scope declaration of an identifier always precedes the
+use of the identifier.
 
 <div class='example' heading='Valid and invalid declarations'>
   <xmp>
-    // Invalid, cannot reuse built-in function names. See [[#builtin-functions]].
+    // Invalid, cannot reuse built-in function names.
     var<private> modf : f32 = 0.0;
 
     // Valid, foo_1 is in scope until the end of the program.
@@ -355,14 +361,14 @@ reference is resolved to the closest preceding in scope declaration.
     var<private> bar : u32 = 0u; // bar_1
 
     // Valid, my_func_1 is in scope until the end of the program.
-    // Valid, foo_2 is in scope until the end of the program.
+    // Valid, foo_2 is in scope until the end of the function.
     fn my_func(foo : f32) { // my_func_1, foo_2
       // Any reference to 'foo' resolves to the function parameter.
 
       // Invalid, the scope of foo_3 ends at the of the function.
       var foo : f32; // foo_3
 
-      // Valid, bar_2 is in scope until the end of the program.
+      // Valid, bar_2 is in scope until the end of the function.
       var bar : u32; // bar_2
       // References to 'bar' resolve to bar_2
       {

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -169,11 +169,6 @@ See [[#keyword-summary]] for a list of keywords.
   <tr><td>`IDENT`<td>`[a-zA-Z][0-9a-zA-Z_]*`
 </table>
 
-Note: literals are parsed greedy. This means that for statements like `a -5`
-      this will *not* parse as `a` `minus` `5` but instead as `a` `-5` which
-      may be unexpected. A space must be inserted after the `-` if the first
-      expression is desired.
-
 An identifier must not have the same spelling as a keyword or as a reserved keyword.
 
 ## Attributes ## {#attributes}
@@ -344,10 +339,64 @@ Examples of predeclared objects are:
 * built-in types.
 
 A declaration must not introduce a name when that identifier is
-already in scope at the start of the declaration.
-That is, shadow names are not allowed in [SHORTNAME].
+already in scope with the same end scope as another instance of that name.
+When an identifier is referenced and multiple declarations are in scope, the
+reference is resolved to the closest preceding in scope declaration.
 
-Issue: PR [1472](https://github.com/gpuweb/gpuweb/pull/1472) is intended to relax this constraint.
+<div class='example' heading='Valid and invalid declarations'>
+  <xmp>
+    // Invalid, cannot reuse built-in function names. See [[#builtin-functions]].
+    var<private> modf : f32 = 0.0;
+
+    // Valid, foo_1 is in scope until the end of the program.
+    var<private> foo : f32 = 0.0; // foo_1
+
+    // Valid, bar_1 is in scope until the end of the program.
+    var<private> bar : u32 = 0u; // bar_1
+
+    // Valid, my_func_1 is in scope until the end of the program.
+    // Valid, foo_2 is in scope until the end of the program.
+    fn my_func(foo : f32) { // my_func_1, foo_2
+      // Any reference to 'foo' resolves to the function parameter.
+
+      // Invalid, the scope of foo_3 ends at the of the function.
+      var foo : f32; // foo_3
+
+      // Valid, bar_2 is in scope until the end of the program.
+      var bar : u32; // bar_2
+      // References to 'bar' resolve to bar_2
+      {
+        // Valid, bar_3 is in scope until the end of the compound statement.
+        var bar : u32; // bar_3
+        // References to 'bar' resolve to bar_3
+
+        // Invalid, bar_4 has the same end scope as bar_3.
+        var bar : i32; // bar_4
+
+        // Valid, i_1 is in scope until the end of the for loop
+        for (var i : i32 = 0; i < 10; i = i + 1) { // i_1
+          // Invalid, i_2 has the same end scope as i_1.
+          var i : i32 = 1; // i_2.
+        }
+      }
+
+      // Invalid, bar_5 has the same end scope as bar_2.
+      var bar : u32; // bar_5
+    }
+
+    // Invalid, bar_6 has the same end scope as bar_1.
+    var<private> bar : u32 = 1u; // bar_6
+
+    // Invalid, my_func_2 has the same end scope as my_func_1.
+    fn my_func() { } // my_func_2
+
+    // Valid, my_foo_1 is in scope until the end of the program.
+    fn my_foo(
+      // Valid, my_foo_2 is in scope until the end of the function.
+      my_foo : i32 // my_foo_2
+    ) { }
+  </xmp>
+</div>
 
 There are multiple levels of scoping depending on how and where things are
 declared.
@@ -3995,25 +4044,17 @@ A function declaration must only occur at [=module scope=].
 The function name is [=in scope=] from the start of the formal parameter list
 until the end of the program.
 
-The function name must be different from the name of every other declared object, including
-those declared inside other functions.
-
-Note: This restriction is in addition to the rules in [[#declaration-and-scope]].
-
-Issue: PR [#1472](https://github.com/gpuweb/gpuweb/pull/1472) is intended to relax this constraint.
-
 A <dfn noexport>formal parameter</dfn> declaration specifies an identifier name and a type for a value that must be
 provided when invoking the function.
 A formal parameter may have attributes.
 See [[#function-calls]].
-The scope of the identifier is the whole function body.
+The identifier is [=in scope=] until the end of the function.
 Two formal parameters for a given function must not have the same name.
 
 If the function declaration does not specify a return type, then the function return type is [=void=].
 
 If the return type is not [=void=],
 then the last statement in the function body must be a [=return=] statement.
-
 
 <pre class='def'>
 function_decl


### PR DESCRIPTION
Fixes #1556

* Allows identifiers to be reused so long as the end of the scope is
  different
  * practically, this works very much like c-style scoping
  * one difference is that a function parameter can shadow its
    function's name
  * covers resolution when multiple declarations are in scope
* add examples
* function names no longer must be unique
* clarify scope of function parameters
* remove a duplicated note
