### PR TITLE
Rename "Value types" to "Plain types"

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -549,7 +549,12 @@ For convenience, the type tables use the following shorthands:
 
 TODO(dneto): Do we still need all these shorthands?
 
-## Value Types ## {#value-types}
+## Plain Types ## {#plain-types-section}
+
+<dfn noexport>Plain types</dfn> are the types for representing boolean values, numbers, vectors,
+matrices, or aggregations of such values.
+
+Note: Plain types in [SHORTNAME] are analogous to Plain-Old-Data types in C++.
 
 ### Boolean Type ### {#bool-type}
 


### PR DESCRIPTION
Plain types are like C++ POD types.

It didn't make sense to call something a "value" type (and exclude other
types), becuase *every* type is a set of values.