### PR TITLE
    WGSL: describe ref ptr

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1408,16 +1408,18 @@ together with an interpretation of the contents of those locations as a [SHORTNA
 
 <div class='example wgsl' heading='Pointer type (program fragment)'>
   <xmp highlight='rust'>
-    // The type of a pointer value that references storage for keeping
-    // an 'i32' value, using memory locations in the 'uniform' storage class.
-    // Here 'i32' is the pointee type.
-    ptr<uniform, i32>              // Note: This is not a valid expression on its own.
+    fn my_function(
+      // 'ptr<function,i32>' is the type of a pointer value that references storage
+      // for keeping an 'i32' value, using memory locations in the 'function' storage
+      // class.  Here 'i32' is the pointee type.
+      ptr_int: ptr<function,i32>,
 
-    // The type of a pointer value that references storage for keeping an array
-    // of 50 elements of type 'f32', using memory locations in the 'private'
-    // storage class.
-    // Here the pointee type is 'array<f32,50>'.
-    ptr<private, array<f32, 50>>   // Note: This is not a valid expression on its own.
+      // 'ptr<private,array<f32,50>>' is the type of a pointer value that refers to
+      // storage for keeping an array of 50 elements of type 'f32', using memory
+      // locations in the 'private' storage class.
+      // Here the pointee type is 'array<f32,50>'.
+      ptr_array: ptr<private, array<f32, 50>>
+    ) { }
   </xmp>
 </div>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1586,7 +1586,7 @@ A reference value is formed in one of the following ways:
     };
     var<private> person : S;
 
-    fn f() -> void {
+    fn f() {
         var uv: vec2<f32>;
         // Evaluate the left-hand side of the assignment:
         //   Evaluate 'uv.x' to yield a reference:
@@ -1673,7 +1673,7 @@ A pointer value is formed in one of the following ways:
     // Declare a variable in the private storage class, for storing an f32 value.
     var<private> x: f32;
 
-    fn f() -> void {
+    fn f() {
         // Declare a variable in the function storage class, for storing an i32 value.
         var y: i32;
 
@@ -4040,7 +4040,7 @@ name of a variable.  See [[#forming-a-reference-value]] for other cases.
         };
         var<private> person : S;
 
-        fn f() -> void {
+        fn f() {
             var a: i32 = 20;
             a = 30;           // Replace the contents of 'a' with 30.
 
@@ -4941,13 +4941,13 @@ User-defined IO can be mixed with builtin variables in the same structure. For e
 
     [[stage(fragment)]]
     // Invalid, location cannot be applied to a structure type.
-    fn fragShader1([[location(0)]] in1 : D) -> void {
+    fn fragShader1([[location(0)]] in1 : D) {
       // ...
     }
 
     [[stage(fragment)]]
     // Invalid, in1 and in2 cannot share a location.
-    fn fragShader2([location(0)]] in1 : f32, [[location(0)]] in2 : f32) -> void {
+    fn fragShader2([location(0)]] in1 : f32, [[location(0)]] in2 : f32) {
       // ...
     }
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3377,7 +3377,7 @@ Issue: Which index is used when it's out of bounds?
 </table>
 
 <table class='data'>
-  <caption>Getting a reference to an array element from a reference to an array</caption>
+  <caption>Getting a reference to a structure member from a reference to a structure</caption>
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Description
   </thead>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3843,7 +3843,7 @@ TODO: *Stub*. Call to function that has a [=return type=] is an expression.
   </thead>
   <tr algorithm="formal parameter value">
        <td>
-          |a| is an identifier resolving to
+          |a| is an identifier [=resolves|resolving=] to
           an [=in scope|in-scope=] formal paramter declaration with type |T|
        <td class="nowrap">
           |a| : |T|

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1451,7 +1451,7 @@ References and pointers are distinguished by how they are used:
     * The left-hand side of the assignment statement must be of reference type.
     * The right-hand side of the assignment statement must evaluate to the store type of the left-hand side.
 * The <dfn noexport>Load Rule</dfn>: Inside a function, a reference is automatically dereferenced (read from) to satisfy type rules:
-    * In a functio, when a reference expression |r| with store type |T| is used in a statement or an expression, where
+    * In a function, when a reference expression |r| with store type |T| is used in a statement or an expression, where
     * The only potentially matching type rules require |r| to have a value of type |T|, then
     * That type rule requirement is considered to have been met, and
     * The result of evaluating |r| in that context is the value (of type |T|) stored in the memory locations
@@ -1479,6 +1479,29 @@ Defining references in this way enables simple idiomatic use of variables:
       // Update the value in the locations referenced by 'i' so they hold the value 5.
       // The evaluation of the right-hand-side occurs before the assignment takes effect.
       i = i + 3;
+    }
+  </xmp>
+</div>
+
+<div class='example wgsl' heading='Returning a reference returns the value loaded from the reference'>
+  <xmp highlight='rust'>
+    var<private> age: i32;
+    fn get_age() -> i32 {
+      // The type of the expression in the return statement must be 'i32' since it
+      // must match the declared return type of the function.
+      // The 'age' expression is of type ref<private,i32>.
+      // Apply the Load Rule, since the store type of the reference matches the
+      // required type of the expression, and no other type rule applies.
+      // The evaluation of 'age' in this context is the i32 value loaded from the
+      // memory locations referenced by 'age' at the time the return statement is
+      // executed.
+      return age;
+    }
+
+    fn caller() {
+      age = 21;
+      // The copy_age constant will get the i32 value 21.
+      const copy_age: i32 = get_age();
     }
   </xmp>
 </div>
@@ -1557,9 +1580,9 @@ A reference value is formed in one of the following ways:
 * The identifer [=resolves|resolving=] to an [=in scope|in-scope=] variable *v* denotes the reference value for *v*'s storage.
     * The resolved variable is the [=originating variable=] for the reference.
 * Use the unary `*` operator on a pointer.
-        See #indirection-expr.
+        See [[#indirection-expr]].
     * The originating variable of the result is defined as the originating variable of the pointer.
-* Use a <dfn noexport>composite value reference sub-expression</dfn> expression.  
+* Use a <dfn noexport>composite component reference expression</dfn>.
     In each case the originating variable of the result is defined as the originating variable of the
     original reference.
     * Given a reference with a vector store type, appending a single-letter vector access phrase
@@ -1578,7 +1601,7 @@ A reference value is formed in one of the following ways:
         results in a reference to the named member of the structure.
         See [[#struct-access-expr]].
 
-<div class='example wgsl' heading='Component reference from a composite value reference'>
+<div class='example wgsl' heading='Component reference from a composite reference'>
   <xmp highlight='rust'>
     struct S {
         age: i32;
@@ -1623,7 +1646,7 @@ A reference value is formed in one of the following ways:
         // statement requires the initializer to be of type vec2<f32>.
         // The Load Rule applies (because no other type rule can apply), and
         // the evaluation of the initializer yields the vec2<f32> value loaded
-        // from the memory locations referenced by m[2] at the time the declaration
+        // from the memory locations referenced by 'm[2]' at the time the declaration
         // is executed.
         const p_m_col2: vec2<f32> = m[2];
 
@@ -1635,11 +1658,13 @@ A reference value is formed in one of the following ways:
         //    the storage for the fifth element of the array referenced by
         //    the reference value from the previous step.
         //    The result value has type ref<function,i32>.
-        // The const declaration requires the right-hand-side to be of type i32.
-        // Apply the Load Rule, so the initializer evaluates to the i32 value loaded
-        // from the memory reference computed in step 2, at the time the the
-        // declaration is executed.
-        const p_A_4: ptr<function,i32> = A[4];
+        // The const declaration requires the right-hand-side to be of type
+        // ptr<function,i32>.
+        // The Load Rule applies (because no other type rule can apply), and
+        // the evaluation of the initializer yields the i32 value loaded from
+        // the memory locations referenced by 'A[5]' at the time the declaration
+        // is executed.
+        const A_4_value: i32 = A[4];
 
         // When evaluating 'person.weight'
         // 1. First evaluate 'person', yielding a reference to the storage for
@@ -1649,18 +1674,20 @@ A reference value is formed in one of the following ways:
         //    the storage for the second member of the memory referenced by
         //    the reference value from the previous step.
         //    The result has type ref<private,f32>.
-        // The const declaration requires the right-hand-side to be of type f32.
-        // Apply the Load Rule, so the initializer evaluates to the i32 value loaded
-        // from the memory reference computed in step 2, at the time the the
+        // The const declaration requires the right-hand-side to be of type
+        // ptr<private,f32>.
+        // The Load Rule applies (because no other type rule can apply), and
+        // the evaluation of the initializer yields the f32 value loaded from
+        // the memory locations referenced by 'person.weight' at the time the
         // declaration is executed.
-        const person_weight_reference: ptr<private,f32> = person.weight;
+        const person_weight: f32 = person.weight;
     }
   </xmp>
 </div>
 
 A pointer value is formed in one of the following ways:
 
-* Use the unary '&' operator on a reference.  See #address-of-expr.
+* Use the unary '&' operator on a reference.  See [[#address-of-expr]].
     * The originating variable of the result is defined as the originating variable of the reference.
 * If a function [=formal parameter=] has pointer type, then when the function is invoked
     at runtime the uses of the formal parameter denote the pointer value
@@ -1713,10 +1740,10 @@ In particular:
 * In [SHORTNAME] a function must not return a pointer or reference.
 * In [SHORTNAME] there is no way to convert between integer values and pointer values.
 * In [SHORTNAME] there is no way to forcibly change the type of a pointer value into another pointer type.
-    * A composite value pointer sub-access expression is different:
-        it takes a pointer to a composite value and yields a pointer to
+    * A composite component reference expression is different:
+        it takes a reference to a composite value and yields a reference to
         one of the components or elements inside the composite value.
-        These are considered different pointers in [SHORTNAME], even though they may
+        These are considered different references in [SHORTNAME], even though they may
         have the same machine address at a lower level of implementation abstraction.
 * In [SHORTNAME] there is no way to forcibly change the type of a reference value into another reference type.
 * In [SHORTNAME] there is no way to allocate new storage from a "heap".
@@ -4633,6 +4660,9 @@ A function call is a statement or expression which invokes a function.
 TODO: explain how invocation works: supply operands matching formal parameter types,
 "suspend" execution of the caller, then resume after
 the callee is done (unless discard). Describe return value.
+
+TODO: A function call site is a dynamic context. This matters when discussing the originating
+variable for the dynamic value provided as the operand for a formal argument having pointer type.
 
 The names in the parameter list of a function definition are available for use in the body
 of the function.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -445,7 +445,7 @@ Some [SHORTNAME] types are only used for analyzing a source program and
 for determining the program's runtime behaviour.
 This specification will describe such types, but they do not appear in [SHORTNAME] source text.
 
-Note: [SHORTNAME] reference types are not written in [SHORTNAME] programs. See TODO forward reference to ptr/ref.
+Note: [SHORTNAME] [=reference types=] are not written in [SHORTNAME] programs. See TODO forward reference to ptr/ref.
 
 ## Type Checking ## {#type-checking-section}
 
@@ -469,7 +469,7 @@ The rules of [SHORTNAME] are designed so that the static type of an expression d
 Statements often use expressions, and may place requirements on the static types of those expressions.
 For example:
 * The condition expression of an `if` statement must be of type [=bool=].
-* In a `let` declaration, the type of the initializer value must be the same as the declared type of the declaration.
+* In a `let` declaration, the initializer must evaluate to the declared type of the constant.
 
 <dfn noexport>Type checking</dfn> a successfully parsed [SHORTNAME] program is the process of mapping
 each expression to its static type,
@@ -494,6 +494,7 @@ A <dfn noexport>type rule</dfn> has two parts:
 * Preconditions, consisting of:
     * Type assertions for subexpressions, when there are subexpressions.
     * Conditions on the other schematic parameters, if any.
+    * How the expression is used in a statement.
     * Optionally, other static context.
 
 A <dfn noexport>type rule applies to an expression</dfn> when:
@@ -502,7 +503,7 @@ A <dfn noexport>type rule applies to an expression</dfn> when:
 
 TODO: write an example such as `1+2`, or `3 - a`, where `a` is in-scope of a let declaration with `i32` type.
 
-The type rules are designed so if parsing succeeds, at most one type rule will apply to each expression.
+The type rules are designed so that if parsing succeeds, at most one type rule will apply to each expression.
 If a type rule applies to an expression, then the conclusion is asserted, and therefore determines the static type of the expression.
 
 A [SHORTNAME] source program is <dfn noexport>well-typed</dfn> when:
@@ -794,19 +795,22 @@ to define a [=uniform buffer=] or a [=storage buffer=]. See [[#memory-layouts]].
 </div>
 
 
-## Memory TODO ## {#memory}
-
-TODO: This section is a stub.
+## Memory ## {#memory}
 
 In [SHORTNAME], a value of [=storable=] type may be stored in memory, for later retrieval.
+This section describes the structure of memory, and how [SHORTNAME] types are used to
+describe the contents of memory.
 
 In general [SHORTNAME] follows the [[!VulkanMemoryModel|Vulkan Memory Model]].
 
-### Memory Locations ### {#memory-locations}
+### Memory Locations ### {#memory-locations-section}
 
-Memory consists of a set of distinct locations. Each memory location is 8-bits
+Memory consists of a set of distinct <dfn noexport>memory locations</dfn>.
+Each memory location is 8-bits
 in size. An operation affecting memory interacts with a set of one or more
-memory locations. Two sets of memory locations overlap if the intersection of
+memory locations.
+
+Two sets of memory locations <dfn noexport>overlap</dfn> if the intersection of
 their sets of memory locations is non-empty. Each variable declaration has a
 set of memory locations that does not overlap with the sets of memory locations of
 any other variable declaration. Memory operations on structures and arrays may
@@ -1368,86 +1372,360 @@ Therefore, a data value must not be placed in the padding at the end of a struct
 nor in the padding at the last element of an array.
 Counting such padding as part of the size allows [SHORTNAME] to capture this constraint.
 
-## Pointer Types TODO ## {#pointer-types}
+## Memory View Types ## {#memory-view-types}
+
+In addition to calculating with [=plain types|plain=] values, a [SHORTNAME] program will
+also often read values from memory or write values to memory.
+Operations that read or write to memory are called <dfn noexport>memory accesses</dfn>.
+Each memory access is performed via a [=memory view=].
+
+A <dfn noexport>memory view</dfn> is a set of [=memory locations=] in a particular [=storage class=],
+together with an interpretation of the contents of those locations as a [SHORTNAME] [=type=].
+
+
+[SHORTNAME] has two kinds of types for representing memory views:
+[=reference types=] and [=pointer types=].
+
 <table class='data'>
   <thead>
-    <tr><th>Type<th>Description
+    <tr><th>Constraint<th>Type<th>Description
   </thead>
-  <tr><td>ptr<*SC*,*T*><td>Pointer (or reference) to storage in [=storage class=] *SC*
-                            which can hold a value of the [=storable=] *T*.
-                            Here, *T* is the known as the *pointee* type.
+  <tr algorithm="memory reference type">
+    <td>|SC| is a [=storage class=],<br>|T| is a [=storable=] type
+    <td>ref&lt;|SC|,|T|&gt;
+    <td>The <dfn noexport>reference type</dfn>
+        identified with the set of [=memory views=] for memory locations in |SC| holding values of type |T|.<br>
+        In this context |T| is known as the <dfn noexport>store type</dfn>.<br>
+        Reference types are not written [SHORTNAME] progam source; instead they are used to analyze a [SHORTNAME] program.
+  <tr algorithm="pointer type">
+    <td>|SC| is a [=storage class=],<br>|T| is a [=storable=] type
+    <td>ptr&lt;|SC|,|T|&gt;
+    <td>The <dfn noexport>pointer type</dfn> 
+        identified with the set of [=memory views=] for memory locations in |SC| holding values of type |T|.<br>
+        In this context |T| is known as the <dfn noexport>pointee type</dfn>.<br>
+        Pointer types appear in [SHORTNAME] progam source.
 </table>
 
-Note: We've described a SPIR-V logical pointer type.
-
-Note: Pointers are not storable.
-
-<div class='example wgsl' heading='Pointer'>
+<div class='example wgsl' heading='Pointer type (program fragment)'>
   <xmp highlight='rust'>
-    ptr<storage, i32>
-    ptr<private, array<i32, 12>>
+    // The type of a pointer value that references storage for keeping
+    // an 'i32' value, using memory locations in the 'uniform' storage class.
+    // Here 'i32' is the pointee type.
+    ptr<uniform, i32>              // Note: This is not a valid expression on its own.
+
+    // The type of a pointer value that references storage for keeping an array
+    // of 50 elements of type 'f32', using memory locations in the 'private'
+    // storage class.
+    // Here the pointee type is 'array<f32,50>'.
+    ptr<private, array<f32, 50>>   // Note: This is not a valid expression on its own.
   </xmp>
 </div>
 
-### Abstract Operations on Pointers TODO ### {#abstract-pointer-operations}
+Reference types and pointer types are both sets of memory views:
+a particular memory view is associated with a unique reference value and also a unique pointer value:
 
-A pointer value *P* supports the following operations:
+<blockquote algorithm="pointer reference correspondence">
+Each pointer value |p| of type ptr&lt;|SC|,|T|&gt; corresponds to a unique reference value |r| of type ref&lt;|SC|,|T|&gt;,
+and vice versa,
+where |p| and |r| describe the same memory view.
+</blockquote>
 
-<table class='data'>
-  <tr><td>P.Write(V)<td>Place a value V into the referenced storage.
-               V’s type must match P’s pointee type.
-  <tr><td>P.Read()<td>An evaluation yielding the value currently in the P’s
-             referenced storage.  The result type is P's pointee type.
-  <tr><td>P.Subaccess(K)<td>Valid for pointers with a composite pointee type where
-                   *K* must evaluate to an integer between 0 and one
-                   less than the number of components in *P*’s pointee type.
-                   The subaccess evaluation yields a pointer to the storage for
-                   the K’th component within P’s referenced storage,
-                   using zero-based indexing. If P's [=storage class=] is SC, and
-                   the K'th member of P's pointee type is of type T, then
-                   the result type is `ptr<SC,T>`.
-</table>
+In [SHORTNAME] a reference value always corresponds to the memory view
+for some or all of the memory locations for some variable.
+This defines the <dfn noexport>originating variable</dfn> for the reference value.
+A pointer value always corresponds to a reference value, and so the originating variable
+of a pointer is the same as the originating variable of the corresponding reference.
 
-Note: Assignment of swizzled values is not permitted (SubaccessSwizzle).<br>
-           e.g. `vec4<i32> v; v.xz = vec2<i32>(0, 1);` is not allowed.
+Note: The originating variable is a dynamic concept.
+The originating variable for a formal parameter of a function depends on the call sites for the function.
+Different call sites may supply pointers into different originating variables.
 
-### Pointer Evaluation TODO ### {#pointer-evaluation}
+References and pointers are distinguished by how they are used:
 
-TODO: *This is a stub*: Using pointers in context. Disambiguating which abstract operation occurs based on context:
-pointer semantics vs. dereferenced value semantics.
+* The type of a [=variable=] is a reference type.
+* The unary `&` operation converts a reference value to its corresponding pointer value.
+* The unary `*` operation converts a pointer value to its corresponding reference value.
+* A const declaration can be of pointer type, but not of reference type.
+* A [=formal parameter=] can be of pointer type, but not of reference type.
+* An [=assignment statement=] updates the contents of memory via a reference:
+    * The left-hand side of the assignment statement must be of reference type.
+    * The right-hand side of the assignment statement must evaluate to the store type of the left-hand side.
+* The <dfn noexport>Load Rule</dfn>: Inside a function, a reference is automatically dereferenced (read from) to satisfy type rules:
+    * In a functio, when a reference expression |r| with store type |T| is used in a statement or an expression, where
+    * The only potentially matching type rules require |r| to have a value of type |T|, then
+    * That type rule requirement is considered to have been met, and
+    * The result of evaluating |r| in that context is the value (of type |T|) stored in the memory locations
+        referenced by |r| at the time of evaluation.
 
----
+Defining references in this way enables simple idiomatic use of variables:
 
-A pointer may appear in exactly the following contexts
+<div class='example wgsl' heading='Reference types enable simple use of variables'>
+  <xmp highlight='rust'>
+    [[stage(compute)]]
+    fn main() {
+      // 'i' has reference type ref<function,i32>
+      // The memory locations for 'i' store the i32 value 0.
+      var i: i32 = 0;
 
-<table class='data'>
-  <tr><td>Indexing<td>
-A subaccessing evaluation
-* E.g. `a[12]`
-    * If `a` is a pointer to an array, this evaluates to *a.Subaccess(12)*
+      // 'i + 1' can only match a type rule where the 'i' subexpression is of type i32.
+      // So the expression 'i + 1' has type i32, and at evaluation, the 'i' subexpression
+      // evaluates to the i32 value stored in the memory locations for 'i' at the time
+      // of evaluation.
+      const one: i32 = i + 1;
 
-* E.g. `s.foo`
-    * If `s` is a pointer to a structure of type *S*, `k` is the index of the `foo` element of *S*, this evaluates to *s.Subaccess(k)*
+      // Update the value in the locations referenced by 'i' so they hold the value 2.
+      i = one + 1;
 
-  <tr><td>Assigning (L-Value)<td>
-On the left hand side of an assignment operation, and the right hand side
-matches the pointee type of the pointer.
-* E.g. `v = 12;` assuming prior declaration `var v : i32`
+      // Update the value in the locations referenced by 'i' so they hold the value 5.
+      // The evaluation of the right-hand-side occurs before the assignment takes effect.
+      i = i + 3;
+    }
+  </xmp>
+</div>
 
-  <tr><td>Copying<td>
-On the right hand side of a let-declaration, and the type of the
-let-declaration matches the pointer type.
-* E.g. `let v2 : ptr<private,i32> = v;`  assuming prior declaration
-        `var<private> v:i32`
+Defining pointers in this way enables two key use cases:
 
-  <tr><td>Parameter<td>
-Used in a function call, where the function’s parameter type matches the
-pointer type.
+* Using a const declaration with pointer type, to form a short name for part of the contents of a variable.
+* Using a formal parameter of a function to refer to the storage of a variable that is accessible to the calling function.
+    * The call to such a function must supply a pointer value for that operand.
+        This often requires using the unary & operation to get a pointer to the variable's contents.
 
-  <tr><td>Reading (R-Value)<td>
-Any other context.  Evaluates to *P.Read()*, yielding a value of *P*’s pointee
-type.
-</table>
+Note: The following examples use [SHORTNAME] features explained later in this specification.
+
+<div class='example wgsl' heading='Using a pointer as a short name for part of a variable'>
+  <xmp highlight='rust'>
+    struct Particle {
+      position: vec3<f32>;
+      velocity: vec3<f32>;
+    };
+    [[block]] struct System {
+      active_index: i32;
+      timestep: f32;
+      particles: array<Particle,100>;
+    };
+    [[group(0), binding(0)]] var<storage> system: System;
+
+    [[stage(compute)]]
+    fn main() {
+      // Form a pointer to a specific Particle in storage memory.
+      const active_particle: ptr<storage,Particle> =
+          &system.particles[system.active_index];
+
+      const delta_position: vec3<f32> = (*active_particle).velocity * system.timestep;
+      const current_position: vec3<f32>  = (*active_particle).position;
+      (*active_particle).position = delta_position + current_position;
+    }
+  </xmp>
+</div>
+
+<div class='example wgsl' heading='Using a pointer as a formal parameter'>
+  <xmp highlight='rust'>
+    fn add_one(x: ptr<function,i32>) {
+      // Update the locations for 'x' to contain the next higher integer value,
+      // (or to wrap around to the largest negative i32 value).
+      // On the left-hand side, unary '*' converts the pointer to a reference that
+      // can then be assigned to.
+      // On the right-hand side:
+      //    - Unary '*' converts the pointer to a reference
+      //    - The only matching type rule is for addition (+) and requires '*x' to
+      //      have type i32, which is the store type for '*x'.  So the Load Rule
+      //      applies and '*x' evaluates to the value stored in the memory for '*x'
+      //      at the time of evaluation, which is the i32 value for 0.
+      //    - Add 1 to 0, to produce a final value of 1 for the right-hand side.
+      // Store 1 into the memory for '*x'.
+      *x = *x + 1u;
+    }
+
+    [[stage(compute)]]
+    fn main() {
+      var i: i32 = 0;
+
+      // Modify the contents of 'i' so it will contain 1.
+      // Use unary '&' to get a pointer value for 'i'.
+      // This is a clear signal that the called function has access to the storage
+      // for 'i', and may modify it.
+      add_one(&i);
+      const one: i32 = i;  // 'one' has value 1.
+    }
+  </xmp>
+</div>
+
+### Forming reference and pointer values ### {#forming-a-reference-value}
+
+A reference value is formed in one of the following ways:
+
+* The identifer [=resolves|resolving=] to an [=in scope|in-scope=] variable *v* denotes the reference value for *v*'s storage.
+    * The resolved variable is the [=originating variable=] for the reference.
+* Use the unary `*` operator on a pointer.
+        See #indirection-expr.
+    * The originating variable of the result is defined as the originating variable of the pointer.
+* Use a <dfn noexport>composite value reference sub-expression</dfn> expression.  
+    In each case the originating variable of the result is defined as the originating variable of the
+    original reference.
+    * Given a reference with a vector store type, appending a single-letter vector access phrase
+        results in a reference to the named component of the vector.
+        See [[#component-reference-from-vector-reference]].
+    * Given a reference with a vector store type, appending an array index access phrase
+        results in a reference to the indexed component of the vector.
+        See [[#component-reference-from-vector-reference]].
+    * Given a reference with a matrix store type, appending an array index access phrase
+        results in a reference to the indexed column vector of the matrix.
+        See [[#matrix-access-expr]].
+    * Given a reference with an array store type, appending an array index access phrase
+        results in a reference to the indexed element of the array.
+        See [[#array-access-expr]].
+    * Given a reference with a structure store type, appending a member access phrase
+        results in a reference to the named member of the structure.
+        See [[#struct-access-expr]].
+
+<div class='example wgsl' heading='Component reference from a composite value reference'>
+  <xmp highlight='rust'>
+    struct S {
+        age: i32;
+        weight: f32;
+    };
+    var<private> person : S;
+
+    fn f() -> void {
+        var uv: vec2<f32>;
+        // Evaluate the left-hand side of the assignment:
+        //   Evaluate 'uv.x' to yield a reference:
+        //   1. First evaluate 'uv', yielding a reference to the storage for
+        //      the 'uv' variable. The result has type ref<function,vec2<f32>>.
+        //   2. Then apply the '.x' vector access phrase, yielding a reference to
+        //      the storage for the first component of the vector pointed at by the
+        //      reference value from the previous step.
+        //      The result has type ref<function,f32>.
+        // Evaluating the right-hand side of the assignment yields the f32 value 1.0.
+        // Store the f32 value 1.0 into the storage memory locations referenced by uv.x.
+        uv.x = 1.0;
+
+        // Evaluate the left-hand side of the assignment:
+        //   Evaluate 'uv[1]' to yield a reference:
+        //   1. First evaluate 'uv', yielding a reference to the storage for
+        //      the 'uv' variable. The result has type ref<function,vec2<f32>>.
+        //   2. Then apply the '[1]' array index phrase, yielding a reference to
+        //      the storage for second component of the vector referenced from
+        //      the previous step.  The result has type ref<function,f32>.
+        // Evaluating the right-hand side of the assignment yields the f32 value 2.0.
+        // Store the f32 value 2.0 into the storage memory locations referenced by uv[1].
+        uv[1] = 2.0;
+
+        var m: mat3x2<f32>;
+        // When evaluating 'm[2]':
+        // 1. First evaluate 'm', yielding a reference to the storage for
+        //    the 'm' variable. The result has type ref<function,mat3x2<f32>>.
+        // 2. Then apply the '[2]' array index phrase, yielding a reference to
+        //    the storage for the third column vector pointed at by the reference
+        //    value from the previous step.
+        //    Therefore the 'm[2]' expression has type ref<function,vec2<f32>>.
+        // The 'const' declaration is for type vec2<f32>, so the declaration
+        // statement requires the initializer to be of type vec2<f32>.
+        // The Load Rule applies (because no other type rule can apply), and
+        // the evaluation of the initializer yields the vec2<f32> value loaded
+        // from the memory locations referenced by m[2] at the time the declaration
+        // is executed.
+        const p_m_col2: vec2<f32> = m[2];
+
+        var A: array<i32,5>;
+        // When evaluating 'A[4]'
+        // 1. First evaluate 'A', yielding a reference to the storage for
+        //    the 'A' variable. The result has type ptr<function,array<i32,5>>.
+        // 2. Then apply the '[4]' array index phrase, yielding a reference to
+        //    the storage for the fifth element of the array referenced by
+        //    the reference value from the previous step.
+        //    The result value has type ref<function,i32>.
+        // The const declaration requires the right-hand-side to be of type i32.
+        // Apply the Load Rule, so the initializer evaluates to the i32 value loaded
+        // from the memory reference computed in step 2, at the time the the
+        // declaration is executed.
+        const p_A_4: ptr<function,i32> = A[4];
+
+        // When evaluating 'person.weight'
+        // 1. First evaluate 'person', yielding a reference to the storage for
+        //    the 'person' variable declared at module scope.
+        //    The result has type ref<private,S>.
+        // 2. Then apply the '.weight' member access phrase, yielding a reference to
+        //    the storage for the second member of the memory referenced by
+        //    the reference value from the previous step.
+        //    The result has type ref<private,f32>.
+        // The const declaration requires the right-hand-side to be of type f32.
+        // Apply the Load Rule, so the initializer evaluates to the i32 value loaded
+        // from the memory reference computed in step 2, at the time the the
+        // declaration is executed.
+        const person_weight_reference: ptr<private,f32> = person.weight;
+    }
+  </xmp>
+</div>
+
+A pointer value is formed in one of the following ways:
+
+* Use the unary '&' operator on a reference.  See #address-of-expr.
+    * The originating variable of the result is defined as the originating variable of the reference.
+* If a function [=formal parameter=] has pointer type, then when the function is invoked
+    at runtime the uses of the formal parameter denote the pointer value
+    provided to the corresponding operand at the call site in the calling function.
+    * The originating variable of the formal parameter (at runtime) is defined as
+        the originating variable of the pointer operand at the call site.
+
+<div class='example wgsl' heading='Pointer from a variable'>
+  <xmp highlight='rust'>
+    // Declare a variable in the private storage class, for storing an f32 value.
+    var<private> x: f32;
+
+    fn f() -> void {
+        // Declare a variable in the function storage class, for storing an i32 value.
+        var y: i32;
+
+        // The name 'x' resolves to the module-scope variable 'x',
+        // and has reference type ref<private,f32>.
+        // Applying the unary '&' operator converts the reference to a pointer.
+        const x_ptr: ptr<private,f32> = &x;
+
+        // The name 'y' resolves to the function-scope variable 'y',
+        // and has reference type ref<private,i32>.
+        // Applying the unary '&' operator converts the reference to a pointer.
+        const y_ptr: ptr<function,i32> = &y;
+
+        // A new variable, distinct from the variable declared at module scope.
+        var x: u32;
+
+        // Here, the name 'x' resolves to the function-scope variable 'x' declared in
+        // the previous statement, and has type ref<function,u32>.
+        // Applying the unary '&' operator converts the reference to a pointer.
+        const inner_x_ptr: ptr<function,u32> = &x;
+    }
+  </xmp>
+</div>
+
+
+### Comparison with references and pointers in other languages ### {#pointers-other-languages}
+
+This section is informative, not normative.
+
+References and pointers in [SHORTNAME] are more restricted than in other languages.
+In particular:
+
+* In [SHORTNAME] a reference can't directly be declared as an alias to another reference or variable,
+    either as a variable or as a formal parameter.
+* In [SHORTNAME] pointers and references are not [=storable=].
+    That is, the content of a [SHORTNAME] variable may not contain a pointer or a reference.
+* In [SHORTNAME] a function must not return a pointer or reference.
+* In [SHORTNAME] there is no way to convert between integer values and pointer values.
+* In [SHORTNAME] there is no way to forcibly change the type of a pointer value into another pointer type.
+    * A composite value pointer sub-access expression is different:
+        it takes a pointer to a composite value and yields a pointer to
+        one of the components or elements inside the composite value.
+        These are considered different pointers in [SHORTNAME], even though they may
+        have the same machine address at a lower level of implementation abstraction.
+* In [SHORTNAME] there is no way to forcibly change the type of a reference value into another reference type.
+* In [SHORTNAME] there is no way to allocate new storage from a "heap".
+* In [SHORTNAME] there is no way to explicitly destroy a variable.
+    The storage for a [SHORTNAME] variable becomes inaccessible only when the variable goes out of scope.
+
+Note: From the above rules, it is not possible to form a "dangling" pointer,
+i.e. a pointer that does not reference the storage for a valid (or "live")
+originating variable.
 
 ## Texture and Sampler Types ## {#texture-types}
 
@@ -1974,14 +2252,14 @@ the pointer-to-array and the pointer-to-struct.
 A <dfn dfn noexport>variable</dfn> is a named reference to storage that can contain a value of a
 particular storable type.
 
-Two types are associated with a variable: its <dfn noexport>store type</dfn> (the type of value
-that may be placed in the referenced storage) and its <dfn noexport>reference type</dfn> (the type
+Two types are associated with a variable: its [=store type=] (the type of value
+that may be placed in the referenced storage) and its [=reference type=] (the type
 of the variable itself).  If a variable has store type *T* and [=storage class=] *S*,
 then its reference type is pointer-to-*T*-in-*S*.
 
 A <dfn dfn noexport>variable declaration</dfn>:
 
-* Determines the variable’s name, storage class, and store type (and hence its reference type).
+* Determines the variable’s name, storage class, and store type (and hence its [=reference type=]).
 * Ensures the execution environment allocates storage for a value of the store type, for the lifetime of the variable.
 * Optionally have an *initializer* expression, if the variable is in the [=storage classes/private=] or [=storage classes/function=] storage classes.
     If present, the initializer's type must match the store type of the variable.
@@ -2752,7 +3030,7 @@ value in one type as a value in another type.
 
 </table>
 
-## Composite Value Expressions TODO ## {#composite-value-expr}
+## Composite Value Decomposition Expressions ## {#composite-value-decomposition-expr}
 
 ### Vector Access Expression ### {#vector-access-expr}
 
@@ -2917,7 +3195,63 @@ Issue: Which index is used when it's out of bounds?
            (OpVectorShuffle)
 </table>
 
-### Matrix Access Expression TODO ### {#matrix-access-expr}
+#### Component reference from vector reference #### {#component-reference-from-vector-reference}
+
+<table class='data'>
+  <caption>Getting a reference to a component from a reference to a vector</caption>
+  <thead>
+    <tr><th>Precondition<th>Conclusion<th>Description
+  </thead>
+  <tr algorithm="first vector component reference selection">
+       <td>|r| : ref&lt;|SC|,vec|N|&lt;|T|&gt;&gt;<br>
+       <td class="nowrap">
+           |r|`.x` : ref&lt;|SC|,|T|&gt;<br>
+           |r|`.r` : ref&lt;|SC|,|T|&gt;<br>
+       <td>Compute a reference to the first component of the vector referenced by the reference |r|.<br>
+           The [=originating variable=] of the resulting reference is
+           the same as the originating variable of |r|.<br>
+           (OpAccessChain with index value 0)
+  <tr algorithm="second vector component reference selection">
+       <td>|r| : ref&lt;|SC|,vec|N|&lt;|T|&gt;&gt;<br>
+       <td class="nowrap">
+           |r|`.y` : ref&lt;|SC|,|T|&gt;<br>
+           |r|`.g` : ref&lt;|SC|,|T|&gt;<br>
+       <td>Compute a reference to the second component of the vector referenced by the reference |r|.<br>
+           The [=originating variable=] of the resulting reference is
+           the same as the originating variable of |r|.<br>
+           (OpAccessChain with index value 1)
+  <tr algorithm="third vector component reference selection">
+       <td>|r| : ref&lt;|SC|,vec|N|&lt;|T|&gt;&gt;<br>
+           |N| is 3 or 4
+       <td class="nowrap">
+           |r|`.z` : ref&lt;|SC|,|T|&gt;<br>
+           |r|`.b` : ref&lt;|SC|,|T|&gt;<br>
+       <td>Compute a reference to the third component of the vector referenced by the reference |r|.<br>
+           The [=originating variable=] of the resulting reference is
+           the same as the originating variable of |r|.<br>
+           (OpAccessChain with index value 2)
+  <tr algorithm="fourth vector component reference selection">
+       <td>|r| : ref&lt;|SC|,vec4&lt;|T|&gt;&gt;<br>
+       <td class="nowrap">
+           |r|`.w` : ref&lt;|SC|,|T|&gt;<br>
+           |r|`.a` : ref&lt;|SC|,|T|&gt;<br>
+       <td>Compute a reference to the fourth component of the vector referenced by the reference |r|.<br>
+           The [=originating variable=] of the resulting reference is
+           the same as the originating variable of |r|.<br>
+           (OpAccessChain with index value 3)
+  <tr algorithm="vector indexed component reference selection">
+       <td>|r| : ref&lt;|SC|,vec|N|&lt;|T|&gt;&gt;<br>
+          |i| : *Int*
+       <td class="nowrap">
+           |r|[|i|] : ref&lt;|SC|,|T|&gt;
+       <td>Compute a reference to the |i|'<sup>th</sup> component of the vector referenced by the reference |r|.<br>
+           If |i| is outside the range [0,|N|-1], then an index in the range [0, |N|-1] is used instead.<br>
+           The [=originating variable=] of the resulting reference is
+           the same as the originating variable of |r|.<br>
+           (OpAccessChain)
+</table>
+
+### Matrix Access Expression ### {#matrix-access-expr}
 
 <table class='data'>
   <caption>Column vector extraction</caption>
@@ -2931,14 +3265,29 @@ Issue: Which index is used when it's out of bounds?
        <td class="nowrap">
            |e|[|i|] : vec|M|&lt;|T|&gt;
        <td>The result is the |i|'<sup>th</sup> column vector of |e|.<br>
-           The first column vector is at index |i|=0.<br>
            If |i| is outside the range [0,|N|-1], then an index in the range [0, |N|-1] is used instead.<br>
            (OpCompositeExtract)
 </table>
 
-Issue: Which index is used when it's out of bounds?
+<table class='data'>
+  <caption>Getting a reference to a column vector from a reference to a matrix</caption>
+  <thead>
+    <tr><th>Precondition<th>Conclusion<th>Description
+  </thead>
+  <tr algorithm="matrix indexed column vector reference selection">
+       <td class="nowrap">
+          |r| : ref&lt;|SC|,mat|N|x|M|&lt;|T|&gt;&gt;<br>
+          |i| : *Int*
+       <td class="nowrap">
+           |r|[|i|] : ref&lt;vec|M|&lt;|SC|,|T|&gt;&gt;
+       <td>Compute a reference to the |i|'<sup>th</sup> column vector of the matrix referenced by the reference |r|.<br>
+           If |i| is outside the range [0,|N|-1], then an index in the range [0, |N|-1] is used instead.<br>
+           The [=originating variable=] of the resulting reference is
+           the same as the originating variable of |r|.<br>
+           (OpAccessChain)
+</table>
 
-### Array Access Expression TODO ### {#array-access-expr}
+### Array Access Expression ### {#array-access-expr}
 
 <table class='data'>
   <caption>Array element extraction</caption>
@@ -2952,22 +3301,40 @@ Issue: Which index is used when it's out of bounds?
        <td class="nowrap">
            |e|[|i|] : |T|
        <td>The result is the value of the |i|'<sup>th</sup> element of the array value |e|.<br>
-           The first element is at index |i|=0.<br>
            If |i| is outside the range [0,|N|-1], then an index in the range [0, |N|-1] is used instead.<br>
-  <tr algorithm="runtime-sized array indexed element selection">
-       <td class="nowrap">
-          |e| : array&lt;|T|&gt;<br>
-          |i| : *Int*
-       <td class="nowrap">
-           |e|[|i|] : |T|
-       <td>The result is the value of the |i|'<sup>th</sup> element of the array value |e|.<br>
-           The first element is at index |i|=0.<br>
-           If |i| is outside the range [0,arrayLength(|e|)-1], then an index in the range [0, arrayLength(|e|)-1] is used instead.<br>
+           (OpCompositeExtract)
 </table>
 
-Issue: Which index is used when it's out of bounds?
+<table class='data'>
+  <caption>Getting a reference to an array element from a reference to an array</caption>
+  <thead>
+    <tr><th>Precondition<th>Conclusion<th>Description
+  </thead>
+  <tr algorithm="sized array indexed column vector reference selection">
+       <td class="nowrap">
+          |r| : ref&lt;|SC|,array&lt;|T|,|N|&gt;&gt;<br>
+          |i| : *Int*
+       <td class="nowrap">
+           |r|[|i|] : ref&lt;|SC|,|T|&gt;
+       <td>Compute a reference to the |i|'<sup>th</sup> element of the array referenced by the reference |r|.<br>
+           If |i| is outside the range [0,|N|-1], then an index in the range [0, |N|-1] is used instead.<br>
+           The [=originating variable=] of the resulting reference is
+           the same as the originating variable of |r|.<br>
+           (OpAccessChain)
+  <tr algorithm="array indexed column vector reference selection">
+       <td>|r| : ref&lt;|SC|,array&lt;|T|&gt;&gt;<br>
+          |i| : *Int*
+       <td class="nowrap">
+           |r|[|i|] : ref&lt;|SC|,|T|&gt;
+       <td>Compute a reference to the |i|'<sup>th</sup> element of the runtime-sized array referenced by the reference |r|.<br>
+           If at runtime the array has |N| elements, and |i| is outside the range [0,|N|-1], then an index in the
+           range [0, |N|-1] is used instead.<br>
+           The [=originating variable=] of the resulting reference is
+           the same as the originating variable of |r|.<br>
+           (OpAccessChain)
+</table>
 
-### Structure Access Expression TODO ### {#struct-access-expr}
+### Structure Access Expression ### {#struct-access-expr}
 
 <table class='data'>
   <caption>Structure member extraction</caption>
@@ -2983,6 +3350,24 @@ Issue: Which index is used when it's out of bounds?
            |e|.|M| : |T|
        <td>The result is the value of the member with name |M| from the structure value |e|.<br>
            (OpCompositeExtract, using the member index)
+</table>
+
+<table class='data'>
+  <caption>Getting a reference to an array element from a reference to an array</caption>
+  <thead>
+    <tr><th>Precondition<th>Conclusion<th>Description
+  </thead>
+  <tr algorithm="structure member reference selection">
+       <td class="nowrap">
+          |S| is a structure type<br>
+          |M| is the name of a member of |S|, having type |T|<br>
+          |r| : ref&lt;|SC|,|S|&gt;<br>
+       <td class="nowrap">
+           |r|.|M| : ref&lt;|SC|,|T|&gt;
+       <td>Given a reference to a structure, the result is a reference to the structure member with identifier name |M|.<br>
+           The [=originating variable=] of the resulting reference is
+           the same as the originating variable of |r|.<br>
+           (OpAccessChain, using the index of the structure member)
 </table>
 
 ## Logical Expressions TODO ## {#logical-expr}
@@ -3406,11 +3791,91 @@ Issue: Which index is used when it's out of bounds?
 
 TODO: *Stub*. Call to function that has a [=return type=] is an expression.
 
-## `var` or `let` reference TODO ## {#var-let-ref-expr}
+## Variable Identifier Expression ## {#var-identifier-expr}
 
-## Pointer Expressions TODO ## {#pointer-expr}
+<table class='data'>
+  <caption>Getting a reference from a variable name</caption>
+  <thead>
+    <tr><th>Precondition<th>Conclusion<th>Description
+  </thead>
+  <tr algorithm="variable reference">
+       <td>
+          |v| is an identifier [=resolves|resolving=] to
+          an [=in scope|in-scope=] variable declared in [=storage class=] |SC|
+          with [=store type=] |T|
+       <td class="nowrap">
+          |v| : ref&lt;|SC|,|T|&gt;
+       <td>Result is a reference to the storage for the named variable |v|.
+</table>
 
-TODO: *Stub*: how to write each of the abstract pointer operations
+## Const Identifier Expression  ## {#const-identifier-expr}
+
+<table class='data'>
+  <caption>Getting the value of a const-declared identifier</caption>
+  <thead>
+    <tr><th>Precondition<th>Conclusion<th>Description
+  </thead>
+  <tr algorithm="const value">
+       <td>
+          |c| is an identifier resolving to
+          an [=in scope|in-scope=] const declaration with type |T|
+       <td class="nowrap">
+          |c| : |T|
+       <td>Result is the value computed for the initializer when the `const` declaration
+           was executed.
+           For a const declaration at module scope, that occurs before the shader begins execution.
+           For a const declaration inside a function, that occurs each time control reaches
+           the declaration.<br>
+</table>
+
+## Formal Parameter Expression  ## {#formal-parameter-expr}
+
+<table class='data'>
+  <caption>Getting the value of an identifier declared as a formal parameter to a function</caption>
+  <thead>
+    <tr><th>Precondition<th>Conclusion<th>Description
+  </thead>
+  <tr algorithm="formal parameter value">
+       <td>
+          |a| is an identifier resolving to
+          an [=in scope|in-scope=] formal paramter declaration with type |T|
+       <td class="nowrap">
+          |a| : |T|
+       <td>Result is the value supplied for the corresponding function call operand at the call site
+           invoking this instance of the function.
+</table>
+
+## Address-Of Expression  ## {#address-of-expr}
+
+<table class='data'>
+  <caption>Getting a pointer from a reference</caption>
+  <thead>
+    <tr><th>Precondition<th>Conclusion<th>Description
+  </thead>
+  <tr algorithm="address-of expression">
+       <td>
+          |r| : ref&lt;|SC|,|T|&gt;
+       <td class="nowrap">
+          `&`|r| : ptr&lt;|SC|,|T|&gt;
+       <td>Result is the pointer value corresponding to the
+           same [=memory view=] as the reference value |r|.
+</table>
+
+## Indirection Expression  ## {#indirection-expr}
+
+<table class='data'>
+  <caption>Getting a reference from a pointer</caption>
+  <thead>
+    <tr><th>Precondition<th>Conclusion<th>Description
+  </thead>
+  <tr algorithm="indirection expression">
+       <td>
+          |p| : ptr&lt;|SC|,|T|&gt;
+       <td class="nowrap">
+          `*`|p| : ref&lt;|SC|,|T|&gt;
+       <td>Result is the reference value corresponding to the
+           same [=memory view=] as the pointer value |p|.
+</table>
 
 ## Expression Grammar Summary ## {#expression-grammar}
 
@@ -3538,7 +4003,61 @@ compound_statement
   : BRACE_LEFT statements BRACE_RIGHT
 </pre>
 
-## Assignment TODO ## {#assignment}
+## Assignment ## {#assignment}
+
+An <dfn noexport>assignment statement</dfn> replaces the contents of a variable,
+or a portion of a variable, with a new value.
+
+The
+expression to the left of the equals token is the <dfn noexport>left-hand side</dfn>,
+and the
+expression to the right of the equals token is the <dfn noexport>right-hand side</dfn>.
+
+<table class='data'>
+  <thead>
+    <tr><th>Precondition<th>Statement<th>Description
+  </thead>
+  <tr algorithm="assignment">
+    <td>|r| : ref<|SC|,|T|>,<br>
+        |e| : |T|,<br>
+        |T| is [=storable=],<br>
+        |SC| is a writable [=storage class=]
+    <td class="nowrap">|r| = |e|;
+    <td>Evaluates |e|, evaluates |r|, then replaces the contents of memory referenced by |r| with the value computed for |e|.<br>
+        (OpStore)
+</table>
+
+The [=originating variable=] of the left-hand side must not have an `access(read)` access attribute.
+
+In the simplest case, the left hand side of the assignment statement is the
+name of a variable.  See [[#forming-a-reference-value]] for other cases.
+
+    <div class='example wgsl' heading='Assignments'>
+      <xmp highlight='rust'>
+        struct S {
+            age: i32;
+            weight: f32;
+        };
+        var<private> person : S;
+
+        fn f() -> void {
+            var a: i32 = 20;
+            a = 30;           // Replace the contents of 'a' with 30.
+
+            person.age = 31;  // Write 31 into the age field of the person variable.
+
+            var uv: vec2<f32>;
+            uv.y = 1.25;      // Place 1.25 into the second component of uv.
+
+            const uv_x_reference: ref<function,f32> = uv.x;
+            uv_x_reference = 2.5;   // Place 2.5 into the first component of uv.
+
+            var friend : S;
+            // Copy the contents of the 'person' variable into the 'friend' variable.
+            friend = person;
+        }
+      </xmp>
+    </div>
 
 <pre class='def'>
 assignment_statement
@@ -3547,10 +4066,6 @@ assignment_statement
       Otherwise, singular expression is a pointer expression in an Assigning (L-value) context
       which maps to OpAccessChain followed by OpStore
 </pre>
-
-### Writing to a variable TODO ### {#writing-to-var}
-
-### Writing to a part of a composite variable TODO ### {#writing-to-part-of-composite}
 
 ## Control flow TODO ## {#control-flow}
 
@@ -4125,6 +4640,10 @@ During a particular function evaluation,
 the parameter names denote the values specified to the function call expression or statement
 which initiated the function evaluation;
 the names and values are associated by position.
+
+TODO: define 'formal parameter'.
+
+## Function calls TODO ## {#func-call-semantics}
 
 ## Restrictions TODO ## {#function-restriction}
 TODO: *This is a stub*

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1483,7 +1483,7 @@ Defining references in this way enables simple idiomatic use of variables:
   </xmp>
 </div>
 
-<div class='example wgsl' heading='Returning a reference returns the value loaded from the reference'>
+<div class='example wgsl' heading='Returning a reference returns the value loaded via the reference'>
   <xmp highlight='rust'>
     var<private> age: i32;
     fn get_age() -> i32 {

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1526,7 +1526,7 @@ Note: The following examples use [SHORTNAME] features explained later in this sp
       timestep: f32;
       particles: array<Particle,100>;
     };
-    [[group(0), binding(0)]] var<storage> system: System;
+    [[group(0), binding(0)]] var<storage> system: [[access(read_write)]] System;
 
     [[stage(compute)]]
     fn main() {

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1556,7 +1556,7 @@ Note: The following examples use [SHORTNAME] features explained later in this sp
       //      at the time of evaluation, which is the i32 value for 0.
       //    - Add 1 to 0, to produce a final value of 1 for the right-hand side.
       // Store 1 into the memory for '*x'.
-      *x = *x + 1u;
+      *x = *x + 1;
     }
 
     [[stage(compute)]]

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1443,8 +1443,8 @@ Different call sites may supply pointers into different originating variables.
 References and pointers are distinguished by how they are used:
 
 * The type of a [=variable=] is a reference type.
-* The unary `&` operation converts a reference value to its corresponding pointer value.
-* The unary `*` operation converts a pointer value to its corresponding reference value.
+* The [=address-of=] operation (unary `&`) converts a reference value to its corresponding pointer value.
+* The [=indirection=] operation (unary `*`) converts a pointer value to its corresponding reference value.
 * A const declaration can be of pointer type, but not of reference type.
 * A [=formal parameter=] can be of pointer type, but not of reference type.
 * An [=assignment statement=] updates the contents of memory via a reference:
@@ -1511,7 +1511,7 @@ Defining pointers in this way enables two key use cases:
 * Using a const declaration with pointer type, to form a short name for part of the contents of a variable.
 * Using a formal parameter of a function to refer to the storage of a variable that is accessible to the calling function.
     * The call to such a function must supply a pointer value for that operand.
-        This often requires using the unary & operation to get a pointer to the variable's contents.
+        This often requires using the unary `&` operation to get a pointer to the variable's contents.
 
 Note: The following examples use [SHORTNAME] features explained later in this specification.
 
@@ -1579,8 +1579,7 @@ A reference value is formed in one of the following ways:
 
 * The identifer [=resolves|resolving=] to an [=in scope|in-scope=] variable *v* denotes the reference value for *v*'s storage.
     * The resolved variable is the [=originating variable=] for the reference.
-* Use the unary `*` operator on a pointer.
-        See [[#indirection-expr]].
+* Use the [=indirection=] (unary `*`) operation on a pointer.
     * The originating variable of the result is defined as the originating variable of the pointer.
 * Use a <dfn noexport>composite component reference expression</dfn>.
     In each case the originating variable of the result is defined as the originating variable of the
@@ -1685,7 +1684,7 @@ A reference value is formed in one of the following ways:
 
 A pointer value is formed in one of the following ways:
 
-* Use the unary '&' operator on a reference.  See [[#address-of-expr]].
+* Use the [=address-of=] (unary '&') operator on a reference.
     * The originating variable of the result is defined as the originating variable of the reference.
 * If a function [=formal parameter=] has pointer type, then when the function is invoked
     at runtime the uses of the formal parameter denote the pointer value
@@ -3872,6 +3871,8 @@ TODO: *Stub*. Call to function that has a [=return type=] is an expression.
 
 ## Address-Of Expression  ## {#address-of-expr}
 
+The <dfn noexport>address-of</dfn> operator converts a reference to its corresponding pointer.
+
 <table class='data'>
   <caption>Getting a pointer from a reference</caption>
   <thead>
@@ -3887,6 +3888,8 @@ TODO: *Stub*. Call to function that has a [=return type=] is an expression.
 </table>
 
 ## Indirection Expression  ## {#indirection-expr}
+
+The <dfn noexport>indirection</dfn> operator converts a pointer to its corresponding reference.
 
 <table class='data'>
   <caption>Getting a reference from a pointer</caption>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1581,7 +1581,7 @@ A reference value is formed in one of the following ways:
     * The resolved variable is the [=originating variable=] for the reference.
 * Use the [=indirection=] (unary `*`) operation on a pointer.
     * The originating variable of the result is defined as the originating variable of the pointer.
-* Use a <dfn noexport>composite component reference expression</dfn>.
+* Use a <dfn noexport>composite reference component expression</dfn>.
     In each case the originating variable of the result is defined as the originating variable of the
     original reference.
     * Given a reference with a vector store type, appending a single-letter vector access phrase

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1573,7 +1573,7 @@ Note: The following examples use [SHORTNAME] features explained later in this sp
   </xmp>
 </div>
 
-### Forming reference and pointer values ### {#forming-a-reference-value}
+### Forming reference and pointer values ### {#forming-references-and-pointers}
 
 A reference value is formed in one of the following ways:
 
@@ -3335,7 +3335,7 @@ Issue: Which index is used when it's out of bounds?
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Description
   </thead>
-  <tr algorithm="sized array indexed column vector reference selection">
+  <tr algorithm="sized array indexed reference selection">
        <td class="nowrap">
           |r| : ref&lt;|SC|,array&lt;|T|,|N|&gt;&gt;<br>
           |i| : *Int*
@@ -3346,7 +3346,7 @@ Issue: Which index is used when it's out of bounds?
            The [=originating variable=] of the resulting reference is
            the same as the originating variable of |r|.<br>
            (OpAccessChain)
-  <tr algorithm="array indexed column vector reference selection">
+  <tr algorithm="array indexed reference selection">
        <td>|r| : ref&lt;|SC|,array&lt;|T|&gt;&gt;<br>
           |i| : *Int*
        <td class="nowrap">
@@ -3930,6 +3930,8 @@ unary_expression
       OpLogicalNot
   | TILDE unary_expression
       OpNot
+  | STAR unary_expression
+  | AND unary_expression
 
 singular_expression
   : primary_expression postfix_expression
@@ -4055,7 +4057,7 @@ expression to the right of the equals token is the <dfn noexport>right-hand side
 The [=originating variable=] of the left-hand side must not have an `access(read)` access attribute.
 
 In the simplest case, the left hand side of the assignment statement is the
-name of a variable.  See [[#forming-a-reference-value]] for other cases.
+name of a variable.  See [[#forming-references-and-pointers]] for other cases.
 
     <div class='example wgsl' heading='Assignments'>
       <xmp highlight='rust'>
@@ -4074,8 +4076,8 @@ name of a variable.  See [[#forming-a-reference-value]] for other cases.
             var uv: vec2<f32>;
             uv.y = 1.25;      // Place 1.25 into the second component of uv.
 
-            const uv_x_reference: ref<function,f32> = uv.x;
-            uv_x_reference = 2.5;   // Place 2.5 into the first component of uv.
+            const uv_x_ptr: ptr<function,f32> = &uv.x;
+            *uv_x_ptr = 2.5;   // Place 2.5 into the first component of uv.
 
             var friend : S;
             // Copy the contents of the 'person' variable into the 'friend' variable.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4015,7 +4015,7 @@ compound_statement
   : BRACE_LEFT statements BRACE_RIGHT
 </pre>
 
-## Assignment ## {#assignment}
+## Assignment Statement ## {#assignment}
 
 An <dfn noexport>assignment statement</dfn> replaces the contents of a variable,
 or a portion of a variable, with a new value.
@@ -4035,7 +4035,8 @@ expression to the right of the equals token is the <dfn noexport>right-hand side
         |T| is [=storable=],<br>
         |SC| is a writable [=storage class=]
     <td class="nowrap">|r| = |e|;
-    <td>Evaluates |e|, evaluates |r|, then replaces the contents of memory referenced by |r| with the value computed for |e|.<br>
+    <td>Evaluates |e|, evaluates |r|, then writes the value computed for |e| into
+        the [=memory locations=] referenced by |r|.<br>
         (OpStore)
 </table>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1658,8 +1658,7 @@ A reference value is formed in one of the following ways:
         //    the storage for the fifth element of the array referenced by
         //    the reference value from the previous step.
         //    The result value has type ref<function,i32>.
-        // The const declaration requires the right-hand-side to be of type
-        // ptr<function,i32>.
+        // The const declaration requires the right-hand-side to be of type i32.
         // The Load Rule applies (because no other type rule can apply), and
         // the evaluation of the initializer yields the i32 value loaded from
         // the memory locations referenced by 'A[5]' at the time the declaration
@@ -1674,8 +1673,7 @@ A reference value is formed in one of the following ways:
         //    the storage for the second member of the memory referenced by
         //    the reference value from the previous step.
         //    The result has type ref<private,f32>.
-        // The const declaration requires the right-hand-side to be of type
-        // ptr<private,f32>.
+        // The const declaration requires the right-hand-side to be of type f32.
         // The Load Rule applies (because no other type rule can apply), and
         // the evaluation of the initializer yields the f32 value loaded from
         // the memory locations referenced by 'person.weight' at the time the

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3834,26 +3834,6 @@ TODO: *Stub*. Call to function that has a [=return type=] is an expression.
        <td>Result is a reference to the storage for the named variable |v|.
 </table>
 
-## Const Identifier Expression  ## {#const-identifier-expr}
-
-<table class='data'>
-  <caption>Getting the value of a const-declared identifier</caption>
-  <thead>
-    <tr><th>Precondition<th>Conclusion<th>Description
-  </thead>
-  <tr algorithm="const value">
-       <td>
-          |c| is an identifier resolving to
-          an [=in scope|in-scope=] const declaration with type |T|
-       <td class="nowrap">
-          |c| : |T|
-       <td>Result is the value computed for the initializer when the `const` declaration
-           was executed.
-           For a const declaration at module scope, that occurs before the shader begins execution.
-           For a const declaration inside a function, that occurs each time control reaches
-           the declaration.<br>
-</table>
-
 ## Formal Parameter Expression  ## {#formal-parameter-expr}
 
 <table class='data'>


### PR DESCRIPTION
    
    - Add "memory view types" section
      - Defines reference type and pointer type
      - gives use cases and examples
      - Compares to other lanaguages
    - Adds:
      - composite reference sub-expressions
      - address-of expression (unary &)
      - indirection expression (unary *)
      - variable identifier expression
      - const identifier expression
      - formal parmaeter identifier expression
    
    TODO: grammar update for unary * and unary &

Alternate to #1368
Fixes: #1456

Builds on #1568 (rename "value types" to "plain types")