### PR TITLE
function return type must be plain (or void)

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -549,7 +549,12 @@ For convenience, the type tables use the following shorthands:
 
 TODO(dneto): Do we still need all these shorthands?
 
-## Value Types ## {#value-types}
+## Plain Types ## {#plain-types-section}
+
+<dfn noexport>Plain types</dfn> are the types for representing boolean values, numbers, vectors,
+matrices, or aggregations of such values.
+
+Note: Plain types in [SHORTNAME] are analogous to Plain-Old-Data types in C++.
 
 ### Boolean Type ### {#bool-type}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4059,8 +4059,9 @@ See [[#function-calls]].
 The identifier is [=in scope=] until the end of the function.
 Two formal parameters for a given function must not have the same name.
 
-If the return type of the function is specified, then the last statement
-in the function body must be a [=return=] statement. 
+If the return type is specified, then:
+* The return type must be a [=plain type=].
+* The last statement in the function body must be a [=return=] statement.
 
 <pre class='def'>
 function_decl


### PR DESCRIPTION
In particular, a function return type can't be:
- a sampler, texture, pointer, or reference