### PR TITLE
Replace `const` with `let`.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -469,7 +469,7 @@ The rules of [SHORTNAME] are designed so that the static type of an expression d
 Statements often use expressions, and may place requirements on the static types of those expressions.
 For example:
 * The condition expression of an `if` statement must be of type [=bool=].
-* In a `const` declaration, the type of the initializer value must be the same as the declared type of the constant.
+* In a `let` declaration, the type of the initializer value must be the same as the declared type of the declaration.
 
 <dfn noexport>Type checking</dfn> a successfully parsed [SHORTNAME] program is the process of mapping
 each expression to its static type,
@@ -500,7 +500,7 @@ A <dfn noexport>type rule applies to an expression</dfn> when:
 * The rule's conclusion matches a valid parse of the expression, and
 * The rule's preconditions are satisfied.
 
-TODO: write an example such as `1+2`, or `3 - a`, where `a` is in-scope of a const declaration with `i32` type.
+TODO: write an example such as `1+2`, or `3 - a`, where `a` is in-scope of a let declaration with `i32` type.
 
 The type rules are designed so if parsing succeeds, at most one type rule will apply to each expression.
 If a type rule applies to an expression, then the conclusion is asserted, and therefore determines the static type of the expression.
@@ -1435,9 +1435,9 @@ matches the pointee type of the pointer.
 * E.g. `v = 12;` assuming prior declaration `var v : i32`
 
   <tr><td>Copying<td>
-On the right hand side of a const-declaration, and the type of the
-const-declaration matches the pointer type.
-* E.g. `const v2 : ptr<private,i32> = v;`  assuming prior declaration
+On the right hand side of a let-declaration, and the type of the
+let-declaration matches the pointer type.
+* E.g. `let v2 : ptr<private,i32> = v;`  assuming prior declaration
         `var<private> v:i32`
 
   <tr><td>Parameter<td>
@@ -1960,12 +1960,12 @@ declaration of the identifier as a type alias or structure type.
   </xmp>
 </div>
 
-# Variable and const # {#variables}
+# `var` and `let` # {#variables}
 
-TODO: *Stub* (describe what a constant is): A constant is a name for a value, declared via a `const` declaration.
+TODO: *Stub* (describe what a constant is): A constant is a name for a value, declared via a `let` declaration.
 What types are permitted?  Storable, plus pointer to store type.
 
-TODO(dneto): A const may not be of type pointer-to-handle. A function parameter may not have type pointer-to-handle.
+TODO(dneto): A `let` may not be of type pointer-to-handle. A function parameter may not have type pointer-to-handle.
 Otherwise we'd have a need to make a pointer-to-handle type expression. But we've reserved the [=storage classes/handle=] keyword.
 When translating from SPIR-V, you must trace through
 the OpCopyObject (or no-index OpAccessChain) instructions that might be between
@@ -1994,7 +1994,7 @@ and when the storage class decoration is required, optional, or forbidden.
 variable_statement
   : variable_decl
   | variable_decl EQUAL short_circuit_or_expression
-  | CONST (IDENT | variable_ident_decl) EQUAL short_circuit_or_expression
+  | LET (IDENT | variable_ident_decl) EQUAL short_circuit_or_expression
 
 variable_decl
   : VAR variable_storage_decoration? variable_ident_decl
@@ -2007,10 +2007,10 @@ variable_storage_decoration
 
 </pre>
 
-The `const` identifiers denote values that are immutable.
-When a `const` identifier is declared without the corresponding type,
-e.g. `const foo = 4`, the type is automatically inferred from the expression to the right of `=`.
-If the type is provided, e.g `const foo: i32 = 4`, it has to match exactly to the type of the initializer expression.
+The `let` identifiers denote values that are immutable.
+When a `let` identifier is declared without the corresponding type,
+e.g. `let foo = 4`, the type is automatically inferred from the expression to the right of `=`.
+If the type is provided, e.g `let foo: i32 = 4`, it has to match exactly to the type of the initializer expression.
 
 Variables in the [=storage classes/storage=] storage class and variables with a
 [storage texture](#texture-storage) type must have an [=access=] attribute
@@ -2043,7 +2043,7 @@ Consider the following snippet of WGSL:
 <div class='example wsgl function-scope'>
   <xmp highlight='rust'>
     var x : f32 = 1.0;
-    const y = x * x + x + 1;
+    let y = x * x + x + 1;
   </xmp>
 </div>
 Because `x` is a variable, all accesses to it turn into load and store operations.
@@ -2143,8 +2143,8 @@ and the name denotes the value of that expression.
 
 <div class='example wgsl global-scope' heading='Module constants'>
   <xmp>
-    const golden : f32 = 1.61803398875;       // The golden ratio
-    const e2 : vec3<i32> = vec3<i32>(0,1,0);  // The second unit vector for three dimensions.
+    let golden : f32 = 1.61803398875;       // The golden ratio
+    let e2 : vec3<i32> = vec3<i32>(0,1,0);  // The second unit vector for three dimensions.
   </xmp>
 </div>
 
@@ -2168,9 +2168,9 @@ Proposal: pipeline creation fails with an error.
 
 <div class='example wgsl global-scope' heading='Module constants, pipeline-overrideable'>
   <xmp>
-    [[constant_id(0)]]    const has_point_light : bool = true;      // Algorithmic control
-    [[constant_id(1200)]] const specular_param : f32 = 2.3;         // Numeric control
-    [[constant_id(1300)]] const gain : f32;                         // Must be overridden
+    [[constant_id(0)]]    let has_point_light : bool = true;      // Algorithmic control
+    [[constant_id(1200)]] let specular_param : f32 = 2.3;         // Numeric control
+    [[constant_id(1300)]] let gain : f32;                         // Must be overridden
   </xmp>
 </div>
 
@@ -2182,7 +2182,7 @@ is the one from the constant's declaration or from a pipeline override.
 
 <pre class='def'>
 global_constant_decl
-  : attribute_list* CONST variable_ident_decl global_const_initializer?
+  : attribute_list* LET variable_ident_decl global_const_initializer?
 
 global_const_initializer
   : EQUAL const_expr
@@ -2238,7 +2238,7 @@ The variable's [=store type=] must be [=storable=].
        var<function> count : u32;  // A variable in function storage class.
        var delta : i32;            // Another variable in the function storage class.
        var sum : f32 = 0.0;        // A function storage class variable with initializer.
-       const unit : i32 = 1;       // A constant. Const declarations don't use a storage class.
+       let unit : i32 = 1;       // A constant. Let declarations don't use a storage class.
     }
   </xmp>
 </div>
@@ -3406,7 +3406,7 @@ Issue: Which index is used when it's out of bounds?
 
 TODO: *Stub*. Call to function that has a [=return type=] is an expression.
 
-## Variable or const reference TODO ## {#var-const-ref-expr}
+## `var` or `let` reference TODO ## {#var-let-ref-expr}
 
 ## Pointer Expressions TODO ## {#pointer-expr}
 
@@ -3659,7 +3659,7 @@ allows them to naturally use values defined in the loop body.
 
 <div class='example wgsl function-scope' heading="[SHORTNAME] Loop">
   <xmp>
-    const a : i32 = 2;
+    let a : i32 = 2;
     var i : i32 = 0;      // <1>
     loop {
       if (i >= 4) { break; }
@@ -3690,7 +3690,7 @@ allows them to naturally use values defined in the loop body.
     loop {
       if (i >= 4) { break; }
 
-      const step : i32 = 1;
+      let step : i32 = 1;
 
       i = i + 1;
       if (i % 2 == 0) { continue; }
@@ -3707,7 +3707,7 @@ allows them to naturally use values defined in the loop body.
     loop {
       if (i >= 4) { break; }
 
-      const step : i32 = 1;
+      let step : i32 = 1;
 
       if (i % 2 == 0) { continue; }
 
@@ -3812,7 +3812,7 @@ then:
     var a : i32 = 2;
     var i : i32 = 0;
     loop {
-      const step : i32 = 1;
+      let step : i32 = 1;
 
       if (i % 2 == 0) { continue; }
 
@@ -3831,7 +3831,7 @@ then:
     var a : i32 = 2;
     var i : i32 = 0;
     loop {
-      const step : i32 = 1;
+      let step : i32 = 1;
 
       if (i % 2 == 0) { continue; }
 
@@ -3851,7 +3851,7 @@ then:
     var i : i32 = 0;
 
     loop {
-      const step : i32 = 1;
+      let step : i32 = 1;
 
       if (i % 2 == 0) { continue; }
 
@@ -3893,7 +3893,7 @@ control past a declaration used in the targeted continuing construct.
       if (i >= 4) { break; }
       if (i % 2 == 0) { continue; } // <3>
 
-      const step : i32 = 2;
+      let step : i32 = 2;
 
       continuing {
         i = i + step;
@@ -4106,7 +4106,7 @@ parameters and return types:
     // It invokes the ordinary_two function, and captures
     // the resulting value in the named value 'two'.
     [[stage(compute)]] fn main() {
-       const six: i32 = add_two(4, 5.0);
+       let six: i32 = add_two(4, 5.0);
     }
   </xmp>
 </div>
@@ -4592,11 +4592,11 @@ the implementation can issue a clear diagnostic.
 
     // Assuming the f16 extension enables use of the f16 type:
     //    - as function return value
-    //    - as the type for const declaration
+    //    - as the type for let declaration
     //    - as a type constructor, with an i32 argument
     //    - as operands to the division operator: /
     fn halve_it(x: f16) -> f16 {
-       const two: f16 = f16(2);
+       let two: f16 = f16(2);
        return x / two;
     };
 
@@ -4867,7 +4867,6 @@ I've written what an NVIDIA GPU does.  See https://github.com/google/amber/pull/
   <tr><td>`BLOCK`<td>block
   <tr><td>`BREAK`<td>break
   <tr><td>`CASE`<td>case
-  <tr><td>`CONST`<td>const
   <tr><td>`CONTINUE`<td>continue
   <tr><td>`CONTINUING`<td>continuing
   <tr><td>`DEFAULT`<td>default
@@ -4881,6 +4880,7 @@ I've written what an NVIDIA GPU does.  See https://github.com/google/amber/pull/
   <tr><td>`FOR`<td>for
   <tr><td>`FUNCTION`<td>function
   <tr><td>`IF`<td>if
+  <tr><td>`LET`<td>let
   <tr><td>`LOOP`<td>loop
   <tr><td>`PRIVATE`<td>private
   <tr><td>`RETURN`<td>return
@@ -4952,7 +4952,7 @@ The following is a list of keywords which are reserved for future expansion.
     <td>i8
     <td>i16
     <td>i64
-    <td>let
+    <td>const
   <tr>
     <td>typedef
     <td>u8


### PR DESCRIPTION
`let` is shorter and more tolerable to repetitively type than `const`.
`let` is used this way in Rust, which we already crib heavily from.
`let` does exist in JS, and although its use in WGSL will be more
similar to JS's `const`, we don't feel that this will be confusing.

We continue to reserve `const`.

Satisfies and closes #1552.