### PR TITLE
Move clampDepth to GPUPrimitiveState.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4234,9 +4234,9 @@ Issue: link to the semantics of SV_SampleIndex and SV_Coverage in WGSL spec.
                 - If the output SV_Coverage semantics is [=statically used=] by
                     |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
                     - |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/alphaToCoverageEnabled}} is `false`.
-            - [$validating GPUPrimitiveState$](|descriptor|.{{GPURenderPipelineDescriptor/primitive}}) succeeds.
+            - [$validating GPUPrimitiveState$](|descriptor|.{{GPURenderPipelineDescriptor/primitive}}, |device|.{{device/[[features]]}}) succeeds.
             - if |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}} is not `null`:
-                - [$validating GPUDepthStencilState$](|descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}, |device|.{{device/[[features]]}}) succeeds.
+                - [$validating GPUDepthStencilState$](|descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}) succeeds.
             - [$validating GPUMultisampleState$](|descriptor|.{{GPURenderPipelineDescriptor/multisample}}) succeeds.
 </div>
 
@@ -4266,13 +4266,17 @@ dictionary GPUPrimitiveState {
     GPUIndexFormat stripIndexFormat;
     GPUFrontFace frontFace = "ccw";
     GPUCullMode cullMode = "none";
+
+    // Enable depth clamping (requires "depth-clamping" feature)
+    boolean clampDepth = false;
 };
 </script>
 
 <div algorithm>
-    <dfn abstract-op>validating GPUPrimitiveState</dfn>(|descriptor|)
+    <dfn abstract-op>validating GPUPrimitiveState</dfn>(|descriptor|, |features|)
         **Arguments:**
             - {{GPUPrimitiveState}} |descriptor|
+            - [=list=]&lt;{{GPUFeatureName}}&gt; |features|
 
         Return `true` if all of the following conditions are satisfied:
             - If |descriptor|.{{GPUPrimitiveState/topology}} is:
@@ -4283,6 +4287,8 @@ dictionary GPUPrimitiveState {
                     : Otherwise
                     :: |descriptor|.{{GPUPrimitiveState/stripIndexFormat}} is `undefined`
                 </dl>
+            - If |descriptor|.{{GPUPrimitiveState/clampDepth}} is `true`:
+                - |features| must [=list/contain=] {{GPUFeatureName/"depth-clamping"}}.
 </div>
 
 <script type=idl>
@@ -4432,9 +4438,6 @@ dictionary GPUDepthStencilState {
     GPUDepthBias depthBias = 0;
     float depthBiasSlopeScale = 0;
     float depthBiasClamp = 0;
-
-    // Enable depth clamping (requires "depth-clamping" feature)
-    boolean clampDepth = false;
 };
 </script>
 
@@ -4461,10 +4464,9 @@ enum GPUStencilOperation {
 </script>
 
 <div algorithm>
-    <dfn abstract-op>validating GPUDepthStencilState</dfn>(descriptor, features)
+    <dfn abstract-op>validating GPUDepthStencilState</dfn>(descriptor)
     **Arguments:**
         - {{GPUDepthStencilState}} |descriptor|
-        - [=list=]&lt;{{GPUFeatureName}}&gt; |features|
 
     Return `true`, if and only if, all of the following conditions are satisfied:
 
@@ -4475,8 +4477,6 @@ enum GPUStencilOperation {
         - if |descriptor|.{{GPUDepthStencilState/stencilFront}} or
             |descriptor|.{{GPUDepthStencilState/stencilBack}} are not default values:
             - |descriptor|.{{GPUDepthStencilState/format}} must have a stencil component.
-        - If |descriptor|.{{GPUDepthStencilState/clampDepth}} is `true`:
-            - |features| must [=list/contain=] {{GPUFeatureName/"depth-clamping"}}.
 
     Issue: how can this algorithm support depth/stencil formats that are added in extensions?
 </div>
@@ -7755,9 +7755,9 @@ The following dictionary values are supported if and only if the {{GPUFeatureNam
 [=feature=] is enabled, otherwise they must be set to their default values:
 
 <dl>
-    : {{GPUDepthStencilState}}
+    : {{GPUPrimitiveState}}
     ::
-        * {{GPUDepthStencilState/clampDepth}}
+        * {{GPUPrimitiveState/clampDepth}}
 </dl>
 
 ## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>depth24unorm-stencil8</dfn> ## {#depth24unorm-stencil8}


### PR DESCRIPTION
GPUDepthStencilState contains state that's useful only when a depth
stencil attachment is present. However clampDepth clamps the depth
instead of clipping pixels even when there are no depth-stencil
attachments. That's why we move it to GPUPrimitiveState.

This is based on a comment @kvark made in passing that clampDepth should
be moved.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/1583.html" title="Last updated on Mar 31, 2021, 1:13 PM UTC (cb6abc2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1583/1efe52a...Kangz:cb6abc2.html" title="Last updated on Mar 31, 2021, 1:13 PM UTC (cb6abc2)">Diff</a>