### PR TITLE
Allow comma at the end of the parameter list

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3424,7 +3424,7 @@ primary_expression
       OpBitcast
 
 argument_expression_list
-  : PAREN_LEFT ((short_circuit_or_expression COMMA)* short_circuit_or_expression)? PAREN_RIGHT
+  : PAREN_LEFT ((short_circuit_or_expression COMMA)* short_circuit_or_expression COMMA?)? PAREN_RIGHT
 
 postfix_expression
   :


### PR DESCRIPTION
Related to #1493
Helps to write code like this (we got a complaint/feedback from a user):
```rust
var rot_matrix: mat2x2<f32> = mat2x2<f32>(
    vec2<f32>(cos_angle, sin_angle),
    vec2<f32>(-sin_angle, cos_angle),
);
```
It also matches Rust.