### PR TITLE
Add section for "Constant Identifier Expression"

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3426,35 +3426,35 @@ TODO: *Stub*. Call to function that has a [=return type=] is an expression.
 
 TODO: *Stub*: how to write each of the abstract pointer operations
 
-## Const Identifier Expression  ## {#const-identifier-expr}
+## Constant Identifier Expression  ## {#constant-identifier-expr}
 
 <table class='data'>
-  <caption>Getting the value of a const-declared identifier</caption>
+  <caption>Getting the value of a `let`-declared identifier</caption>
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Description
   </thead>
-  <tr algorithm="pipeline-overridable const value">
+  <tr algorithm="pipeline-overridable constant value">
        <td>
           |c| is an identifier [=resolves|resolving=] to
-          an [=in scope|in-scope=] [=pipeline-overridable=] const declaration with type |T|
+          an [=in scope|in-scope=] [=pipeline-overridable=] `let` declaration with type |T|
        <td class="nowrap">
           |c| : |T|
        <td>If pipeline creation specified a value for the constant ID, then the result is
            that value.<br>
            Otherwise, the result is the value computed for the initializer expression.<br>
-           Note: pipeline-overridable constants occur at module-scope, so evaluation occurs
+           Note: pipeline-overridable constants appear at module-scope, so evaluation occurs
            before the shader begins execution.
-  <tr algorithm="const value">
+  <tr algorithm="constant value">
        <td>
           |c| is an identifier [=resolves|resolving=] to
-          an [=in scope|in-scope=] const declaration with type |T|,
+          an [=in scope|in-scope=] `let` declaration with type |T|,
           and is not pipeline-overridable
        <td class="nowrap">
           |c| : |T|
-       <td>Result is the value computed for the initializer expression when the `const` declaration
+       <td>Result is the value computed for the initializer expression when the `let` declaration
            was executed.<br>
-           For a const declaration at module scope, that occurs before the shader begins execution.<br>
-           For a const declaration inside a function, that occurs each time control reaches
+           For a `let` declaration at module scope, that occurs before the shader begins execution.<br>
+           For a `let` declaration inside a function, that occurs each time control reaches
            the declaration.<br>
 </table>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2167,7 +2167,7 @@ the constant is <dfn noexport>pipeline-overridable</dfn>. In this case:
 
   * The type must one of the [=scalar=] types.
   * The initializer expression is optional.
-  * The attribute's literal operand is known as the *pipeline constant ID*,
+  * The attribute's literal operand is known as the <dfn noexport>pipeline constant ID</dfn>,
     and must be a non-negative integer value representable in 32 bits.
   * Pipeline constant IDs must be unique within the [SHORTNAME] program: Two module constants
     must not use the same pipeline constant ID.
@@ -3439,10 +3439,11 @@ TODO: *Stub*: how to write each of the abstract pointer operations
           an [=in scope|in-scope=] [=pipeline-overridable=] `let` declaration with type |T|
        <td class="nowrap">
           |c| : |T|
-       <td>If pipeline creation specified a value for the constant ID, then the result is
-           that value.<br>
-           Otherwise, the result is the value computed for the initializer expression.<br>
-           Note: pipeline-overridable constants appear at module-scope, so evaluation occurs
+       <td>If pipeline creation specified a value for the [=pipeline constant ID|constant ID=],
+           then the result is that value.
+           This value may be different for different pipeline instances.<br>
+           Otherwise, the result is the value computed for the initializer expression.
+           Pipeline-overridable constants appear at module-scope, so evaluation occurs
            before the shader begins execution.
   <tr algorithm="constant value">
        <td>
@@ -3451,10 +3452,9 @@ TODO: *Stub*: how to write each of the abstract pointer operations
           and is not pipeline-overridable
        <td class="nowrap">
           |c| : |T|
-       <td>Result is the value computed for the initializer expression when the `let` declaration
-           was executed.<br>
-           For a `let` declaration at module scope, that occurs before the shader begins execution.<br>
-           For a `let` declaration inside a function, that occurs each time control reaches
+       <td>Result is the value computed for the initializer expression.<br>
+           For a `let` declaration at module scope, evaluation occurs before the shader begins execution.<br>
+           For a `let` declaration inside a function, evaluation occurs each time control reaches
            the declaration.<br>
 </table>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3444,7 +3444,9 @@ TODO: *Stub*: how to write each of the abstract pointer operations
            This value may be different for different pipeline instances.<br>
            Otherwise, the result is the value computed for the initializer expression.
            Pipeline-overridable constants appear at module-scope, so evaluation occurs
-           before the shader begins execution.
+           before the shader begins execution.<br>
+           Note: Pipeline creation fails if no initial value was specified in the API call
+           and the `let`-declaration has no intializer expression.
   <tr algorithm="constant value">
        <td>
           |c| is an identifier [=resolves|resolving=] to

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3426,6 +3426,39 @@ TODO: *Stub*. Call to function that has a [=return type=] is an expression.
 
 TODO: *Stub*: how to write each of the abstract pointer operations
 
+## Const Identifier Expression  ## {#const-identifier-expr}
+
+<table class='data'>
+  <caption>Getting the value of a const-declared identifier</caption>
+  <thead>
+    <tr><th>Precondition<th>Conclusion<th>Description
+  </thead>
+  <tr algorithm="pipeline-overridable const value">
+       <td>
+          |c| is an identifier [=resolves|resolving=] to
+          an [=in scope|in-scope=] [=pipeline-overridable=] const declaration with type |T|
+       <td class="nowrap">
+          |c| : |T|
+       <td>If pipeline creation specified a value for the constant ID, then the result is
+           that value.<br>
+           Otherwise, the result is the value computed for the initializer expression.<br>
+           Note: pipeline-overridable constants occur at module-scope, so evaluation occurs
+           before the shader begins execution.
+  <tr algorithm="const value">
+       <td>
+          |c| is an identifier [=resolves|resolving=] to
+          an [=in scope|in-scope=] const declaration with type |T|,
+          and is not pipeline-overridable
+       <td class="nowrap">
+          |c| : |T|
+       <td>Result is the value computed for the initializer expression when the `const` declaration
+           was executed.<br>
+           For a const declaration at module scope, that occurs before the shader begins execution.<br>
+           For a const declaration inside a function, that occurs each time control reaches
+           the declaration.<br>
+</table>
+
+
 ## Expression Grammar Summary ## {#expression-grammar}
 
 <pre class='def'>


### PR DESCRIPTION
This captures the case of pipeline-overridable constants as well.

TODO: modify this when the 'const' -> 'let' change lands.