### PR TITLE
Fix the use of clampDepth

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4144,7 +4144,7 @@ inside a primitive, is defined by the following inequalities:
   - &minus;|p|.w &le; |p|.y &le; |p|.w
   - 0 &le; |p|.z &le; |p|.w (<dfn dfn>depth clipping</dfn>)
 
-If |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}.{{GPUDepthStencilState/clampDepth}} is `true`,
+If |descriptor|.{{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/clampDepth}} is `true`,
 the [=depth clipping=] restriction of the [=clip volume=] is not applied.
 
 A primitive passes through this stage unchanged if every one of its edges


### PR DESCRIPTION
Follow-up to #1583 and #1564


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 5, 2021, 7:20 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fgpuweb%2Fgpuweb%2Fpull%2F1598%2Fcb355a2.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fkvark%2Fgpuweb%2Fpull%2F1598.html)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 sysreq@w3.org to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%231598.)._
</details>
