### PR TITLE
Explainer: Use <object> instead of <img> for SVG

### DIFF
--- a/explainer/index.bs
+++ b/explainer/index.bs
@@ -79,7 +79,7 @@ As a result, if a call takes one WebGPU object and returns a new one, the new ob
     <figcaption>
         Timeline diagram of messages passing between processes, demonstrating how errors are propagated without synchronization.
     </figcaption>
-    <img alt="diagram" src="img/error_monad_timeline_diagram.svg">
+    <object type="image/svg+xml" data="img/error_monad_timeline_diagram.svg"></object>
 </figure>
 
 <div class=example>


### PR DESCRIPTION
Makes the text in the SVG accessible/selectable.