### PR TITLE
Add interpolation section and attribute

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -348,6 +348,19 @@ literal_or_ident
     Specifies the binding group of the resource.
     See [[#resource-interface]].
 
+  <tr><td><dfn noexport dfn-for="attribute">`interpolate`
+    <td>One or two parameters.
+
+    The first parameter must be an [=interpolation type=].
+    The second parameter, if present, must specify the [=interpolation sampling=].
+    <td>Must only be applied to an entry point function parameter, entry point
+    return type, or member of a [=structure=] type.
+    Must only be applied to declarations of scalars or vectors of floating-point type.
+    Must not be used with the [=compute=] shader stage.
+    If the first parameter is `flat`, the second parameter must not be specified.
+
+    Specifies how the user-defined IO must be interpolated. See [[#interpolation]].
+
   <tr><td><dfn noexport dfn-for="attribute">`location`
     <td>non-negative i32 literal
     <td>Must only be applied to an entry point function parameter, entry point
@@ -379,8 +392,10 @@ literal_or_ident
     start of the next element.
 
   <tr><td><dfn noexport dfn-for="attribute">`workgroup_size`</dfn>
-    <td>One, two or three parameters. Each parameter is either a positive i32
-    literal or the name of a [=pipeline-overridable=] constant of i32 type.
+    <td>One, two or three parameters.
+
+    Each parameter is either a positive i32 literal or the name of a
+    [=pipeline-overridable=] constant of i32 type.
     <td>Must only be applied to a [=compute shader stage=] function declaration.
 
     Specifies the x, y, and z dimensions of the [=workgroup grid=] for the compute shader.
@@ -4482,6 +4497,34 @@ between stages of a pipeline or output from the end of a pipeline.
 User-defined IO must not be passed to [=compute=] shader entry points.
 User-defined IO must be [=numeric scalar=] or [=numeric vector=] types .
 All user defined IO must be assigned locations (See [[#input-output-locations]]).
+
+#### Interpolation #### {#interpolation}
+
+Authors can control how user-defined IO data is interpolated through the use of
+the [=attribute/interpolate=] attribute.
+[SHORTNAME] offers two aspects of interpolation to control: the type of
+interpolation, and the sampling of the interpolation.
+
+The <dfn noexport>interpolation type</dfn> must be one of:
+* `perspective` - Values are interpolated in a perspective correct manner.
+* `linear` - Values are interpolated in a linear, non-perspective correct manner.
+* `flat` - Values are not interpolated.
+    Interpolation sampling is not used with `flat` interpolation.
+
+The <dfn noexport>interpolation sampling</dfn> must be one of:
+* `center` - Interpolation is performed at the center of the pixel.
+* `centroid` - Interpolation is performed within both the fragment and samples
+    covered by the primitive. This value is the same for all samples in the primitive.
+* `sample` - Interpolation is performed per sample. The [=fragment=] shader is
+    invoked once per sample when this attribute is applied.
+
+The default interpolation of user-defined IO of scalar or vector floating-point
+type is `[[interpolate(perspective, center)]]`.
+User-defined IO of scalar or vector integer type is always
+`[[interpolate(flat)]]` and, therefore, must not be specified in a [SHORTNAME] program.
+
+Interpolation attributes must match between [=vertex=] outputs and [=fragment=]
+inputs with the same [=attribute/location=] assignment within the same [=pipeline=].
 
 #### Input-output Locations #### {#input-output-locations}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -361,7 +361,7 @@ literal_or_ident
 
     Specifies how the user-defined IO must be interpolated.
     The attribute is only significant on user-defined [=vertex=] outputs
-    [=fragment=] inputs.
+    and [=fragment=] inputs.
     See [[#interpolation]].
 
   <tr><td><dfn noexport dfn-for="attribute">`location`
@@ -4516,11 +4516,12 @@ The <dfn noexport>interpolation type</dfn> must be one of:
 
 The <dfn noexport>interpolation sampling</dfn> must be one of:
 * `center` - Interpolation is performed at the center of the pixel.
-* `centroid` - Interpolation is performed at the average point of all the
-    samples covered by the primitive. This value is the same for all samples
-    in the primitive.
-* `sample` - Interpolation is performed per sample. The [=fragment=] shader is
-    invoked once per sample when this attribute is applied.
+* `centroid` - Interpolation is performed at a point that lies within all the
+    samples covered by the fragment within the current primitive.
+    This value is the same for all samples in the primitive.
+* `sample` - Interpolation is performed per sample.
+    The [=fragment=] shader is invoked once per sample when this attribute is
+    applied.
 
 The default interpolation of user-defined IO of scalar or vector floating-point
 type is `[[interpolate(perspective, center)]]`.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -359,7 +359,10 @@ literal_or_ident
     Must not be used with the [=compute=] shader stage.
     If the first parameter is `flat`, the second parameter must not be specified.
 
-    Specifies how the user-defined IO must be interpolated. See [[#interpolation]].
+    Specifies how the user-defined IO must be interpolated.
+    The attribute is only significant on user-defined [=vertex=] outputs
+    [=fragment=] inputs.
+    See [[#interpolation]].
 
   <tr><td><dfn noexport dfn-for="attribute">`location`
     <td>non-negative i32 literal
@@ -4513,8 +4516,9 @@ The <dfn noexport>interpolation type</dfn> must be one of:
 
 The <dfn noexport>interpolation sampling</dfn> must be one of:
 * `center` - Interpolation is performed at the center of the pixel.
-* `centroid` - Interpolation is performed within both the fragment and samples
-    covered by the primitive. This value is the same for all samples in the primitive.
+* `centroid` - Interpolation is performed at the average point of all the
+    samples covered by the primitive. This value is the same for all samples
+    in the primitive.
 * `sample` - Interpolation is performed per sample. The [=fragment=] shader is
     invoked once per sample when this attribute is applied.
 


### PR DESCRIPTION
Fixes #802

* Adds interpolate attribute
  * takes 1 or 2 parameters to specify interpolation type and,
    optionally, the sampling
* Adds section describing interpolation and requirements