### PR TITLE
Rasterization of points, more general wording

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4018,6 +4018,7 @@ of the current {{GPURenderPassEncoder}} during command encoding.
         1. **Clip primitives**. See [[#primitive-clipping]].
 
         1. Rasterize. See [[#rasterization]].
+
         1. Process fragments.
             Issue: fill out the section
         1. Process depth/stencil.
@@ -4057,7 +4058,7 @@ of the current {{GPURenderPassEncoder}} during command encoding.
     the fragment shader entry point of the [=pipeline=] and its output colors.
     If it's `null`, the [[#no-color-output]] mode is enabled.
 
-### Vertex processing ### {#vertex-processing}
+### Vertex Processing ### {#vertex-processing}
 
 Vertex processing stage is a programmable stage of the render [=pipeline=] that
 processes the vertex attribute data, and produces
@@ -4121,7 +4122,7 @@ clip space positions for {#primitive-clipping}, as well as other data for the
             will only be processed once.
 </div>
 
-### Primitive assembly ### {#primitive-assembly}
+### Primitive Assembly ### {#primitive-assembly}
 
 Primitives are assembled by a fixed-function stage of GPUs.
 
@@ -4179,7 +4180,7 @@ Primitives are assembled by a fixed-function stage of GPUs.
 
 </div>
 
-### Primitive clipping ### {#primitive-clipping}
+### Primitive Clipping ### {#primitive-clipping}
 
 Vertex shaders have to produce a built-in "position" (of type `vec4<f32>`),
 which denotes the <dfn dfn>clip position</dfn> of a vertex.
@@ -4248,6 +4249,13 @@ Issue: link to interpolation qualifiers in WGSL
 Rasterization is the hardware processing stage that maps the generated primitives
 to the 2-dimensional rendering area of the <dfn dfn>framebuffer</dfn> -
 the set of render attachments in the current {{GPURenderPassEncoder}}.
+This rendering area is split into an even grid of pixels.
+
+Rasterization determines the set of pixels affected by a primitive. In case of multi-sampling,
+each pixel is further split into |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/count}}
+samples. The locations of samples are the same for each pixel, but not defined in this spec.
+
+Issue: do we want to force-enable the "Standard sample locations" in Vulkan?
 
 The [=framebuffer=] coordinates start from the top-left corner of the render targets.
 Each unit corresponds exactly to a pixel. See {#coordinate-systems} for more information.
@@ -4257,11 +4265,53 @@ Each unit corresponds exactly to a pixel. See {#coordinate-systems} for more inf
 
     ndc(|p|) = vector(|p|.x &divide; |p|.w, |p|.y &divide; |p|.w, |p|.z &divide; |p|.w)
 
-2. Let |viewport| be {{GPURenderPassEncoder/[[viewport]]}} of the current render pass.
+1. Let |viewport| be {{GPURenderPassEncoder/[[viewport]]}} of the current render pass.
     Then the [=NDC=] coordinates |n| are converted into [=framebuffer=] coordinates, based on the size of the render targets:
 
     framebufferCoords(n) = vector(|viewport|.`x` &plus; 0.5&times;(|n|.x&plus;1)&times;|viewport|.`width`, |viewport|.`y` &plus; 0.5&times;(|n|.y&plus;1)&times;|viewport|.`height`)
 
+1. The specific rasterization algorithm depends on {{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/topology}}:
+    <dl class="switch">
+        : {{GPUPrimitiveTopology/"point-list"}}
+        :: The point, if not filtered by [[#primitive-clipping]], goes into [[#point-rasterization]].
+        : {{GPUPrimitiveTopology/"line-list"}} or {{GPUPrimitiveTopology/"line-strip"}}
+        :: The line cut by [[#primitive-clipping]] goes into [[#line-rasterization]].
+        : {{GPUPrimitiveTopology/"triangle-list"}} or {{GPUPrimitiveTopology/"triangle-strip"}}
+        :: The polygon produced in [[#primitive-clipping]] goes into [[#polygon-rasterization]].
+    </dl>
+
+Issue: reword the "goes into" part
+
+Let's define <dfn dfn>fragment destination</dfn> to be a combination of the pixel position with
+the sample index, in case [[#sample-frequency-shading]] is active.
+
+The result of rasterization is a set of points, each associated with the following data:
+  - [=fragment destination=]
+  - multisample coverage mask (see {#sample-masking})
+  - depth, in [=NDC=] coordinates.
+  - barycentric coordinates
+
+Issue: define barycentric coordinates
+Issue: define the depth computation algorithm
+
+#### Point Rasterization #### {#point-rasterization}
+
+A single [=fragment destination=] is selected within the pixel containing the
+[=framebuffer=] coordinates of the point.
+
+The coverage mask depends on multi-sampling mode:
+<dl class="switch">
+    : sample-frequency
+    :: coverageMask = 1 &Lt; `sampleIndex`
+    : pixel-frequency multi-sampling
+    :: coverageMask = 1 &Lt; |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/count}} &minus; 1
+    : no multi-sampling
+    :: coverageMask = 1
+</dl>
+
+#### Line Rasterization #### {#line-rasterization}
+
+Issue: fill out this section
 
 #### Polygon Rasterization #### {#polygon-rasterization}
 
@@ -4269,7 +4319,7 @@ Let |v|(|i|) be the [=framebuffer=] coordinates for the clipped vertex number |i
 in a rasterized polygon of |n| vertices.
 
 Note: this section uses the term "polygon" instead of a "triangle",
-since {#primitive-clipping} stage may have introduced additional vertices.
+since [[#primitive-clipping]] stage may have introduced additional vertices.
 This is non-observable by the application.
 
 The first step of polygon rasterization is determining if the polygon is <dfn dfn>front-facing</dfn> or <dfn dfn>back-facing</dfn>.
@@ -4316,11 +4366,9 @@ The determination is based on |descriptor|.{{GPURenderPipelineDescriptor/multisa
 
         The rasterizer builds a mask of locations being hit inside each pixel and provides is as "sample-mask"
         built-in to the fragment shader.
-
-        Issue: do we want to force-enable the "Standard sample locations" in Vulkan?
 </dl>
 
-### Fragment processing ### {#fragment-processing}
+### Fragment Processing ### {#fragment-processing}
 
 TODO: fill out this section
 
@@ -4343,6 +4391,10 @@ It guarantees that:
   - if |alpha| is 1.0 or greater, the result is 0xFFFFFFFF
   - if |alpha| is greater than some other |alpha1|,
     then the produced sample mask has at least as many bits set to 1 as the mask for |alpha1|
+
+### Sample frequency shading ### {#sample-frequency-shading}
+
+TODO: fill out the section
 
 ### Sample Masking ### {#sample-masking}
 


### PR DESCRIPTION
Following up on #1603


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 7, 2021, 8:49 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fgpuweb%2Fgpuweb%2Fpull%2F1606%2F81d441a.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fkvark%2Fgpuweb%2Fpull%2F1606.html)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 sysreq@w3.org to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%231606.)._
</details>
