### PR TITLE
Vector-matrix arithmetic extended with scalar "splats"

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3662,35 +3662,55 @@ Issue: Which index is used when it's out of bounds?
   <tr><td>*e1* : *T*<br> *e2* : *T*<br> *T* is *FloatVec*<td>`e1 % e2` : *T*<td>Component-wise floating point modulus (OpFMod)
 </table>
 
+
 <table class='data'>
-  <caption>Binary arithmetic expressions with mixed scalar, vector, and matrix operands</caption>
+  <caption>Binary arithmetic expressions</caption>
   <thead>
-    <tr><th>Precondition<th>Conclusion<th>Notes
+    <tr><th>Category<th>Preconditions<th>Conclusions
   </thead>
-  <tr><td>*e1* : f32<br>
-          *e2* : *T*<br>
-          *T* is *FloatVec*
-      <td>`e1 * e2` : *T*<br>
-          `e2 * e1` : *T*
-      <td>Multiplication of a vector and a scalar (OpVectorTimesScalar)
-  <tr><td>*e1* : f32<br>
-          *e2* : *T*<br>
-          *T* is mat*N*x*M*&lt;f32&gt;
-      <td>`e1 * e2` : *T*<br>
-          `e2 * e1` : *T*
-      <td>Multiplication of a matrix and a scalar (OpMatrixTimesScalar)
-  <tr><td>*e1* : vec*M*&lt;f32&gt;<br>
-          *e2* : mat*N*x*M*&lt;f32&gt;
-      <td>`e1 * e2` : vec*N*&lt;f32&gt;<br>
-      <td>Vector times matrix (OpVectorTimesMatrix)
-  <tr><td>*e1* : mat*N*x*M*&lt;f32&gt;<br>
-          *e2* : vec*N*&lt;f32&gt;
-      <td>`e1 * e2` : vec*M*&lt;f32&gt;<br>
-      <td>Matrix times vector (OpMatrixTimesVector)
-  <tr><td>*e1* : mat*K*x*N*&lt;f32&gt;<br>
-          *e2* : mat*M*x*K*&lt;f32&gt;<br>
-      <td>`e1 * e2` : mat*M*x*N*&lt;f32&gt;<br>
-      <td>Matrix times matrix (OpMatrixTimesMatrix)
+  <tr>
+    <td>Vector OP Scalar "splats"
+    <td>V: vecN<S>; S: f32 or i32 or u32
+    <td>
+      <ul>
+        <li>`(V + S) -> (V    + V(S)) -> V`
+        <li>`(S + V) -> (V(S) + V   ) -> V`
+        <li>`(V - S) -> (V    - V(S)) -> V`
+        <li>`(S - V) -> (V(S) - V   ) -> V`
+        <li>`(V * S) -> (V    * V(S)) -> V` (e.g. OpVectorTimesScalar)
+        <li>`(S * V) -> (V(S) * V   ) -> V` (e.g. OpVectorTimesScalar)
+        <li>`(V / S) -> (V    / V(S)) -> V`
+        <li>`(S / V) -> (V(S) / V   ) -> V`
+        <li>`(V % S) -> (V    % V(S)) -> V`
+        <li>`(S % V) -> (V(S) % V   ) -> V`
+      </ul>
+  <tr>
+    <td>Vector OP Scalar integer-only "splats"
+    <td>V: vecN<S>; S: i32 or u32
+    <td>
+      <ul>
+        <li>`(V % S) -> (V    % V(S)) -> V`
+        <li>`(S % V) -> (V(S) % V   ) -> V`
+      </ul>
+  <tr>
+    <td>Matrix arithmetic
+    <td>S: f32
+    <td>
+      <ul>
+        <li>`(matAxB<S> + matAxB<S>) -> matAxB<S>` (component-wise)
+        <li>`(matAxB<S> - matAxB<S>) -> matAxB<S>` (component-wise)
+        <li>`(matBxC<S> * matAxB<S>) -> matAxC<S>` (linear-algebraic, e.g. OpMatrixTimesMatrix)
+        <li>`(matAxB<S> * vecA<S>) -> vecB<S>` (linear-algebraic, vec as column-vector, e.g. OpMatrixTimesVector)
+        <li>`(vecB<S> * matAxB<S>) -> vecA<S>` (linear-algebraic, vec as row-vector, e.g. OpVectorTimesMatrix)
+      </ul>
+  <tr>
+    <td>Matrix OP Scalar "splats"
+    <td>M: matAxB<S>; S: f32
+    <td>
+      <ul>
+        <li>`(M * S) -> M(M[0]*S, M[1]*S, ...)` (component-wise, e.g. OpMatrixTimesScalar)
+        <li>`(S * M) -> M(M[0]*S, M[1]*S, ...)` (component-wise, e.g. OpMatrixTimesScalar)
+      </ul>
 </table>
 
 ## Comparison Expressions TODO ## {#comparison-expr}
@@ -6022,76 +6042,6 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
    );
   </xmp>
 </div>
-
-# Operators # {#operators}
-
-[SHORTNAME] has symbol-based operators, such as the `+` in `a + b`.
-
-## Arithmatic operators ## {#arithmatic-operators}
-
-<table class='data'>
-  <caption>Binary operators</caption>
-  <thead>
-    <tr><th>Category<th>Preconditions<th>Conclusions
-  </thead>
-  <tr>
-    <td>Scalar arithmatic
-    <td>S: f32 or i32 or u32
-    <td>
-      <ul>
-        <li>`(S + S) -> S` (e.g. OpFAdd)
-        <li>`(S - S) -> S` (e.g. OpFSub)
-        <li>`(S * S) -> S` (e.g. OpFMul)
-        <li>`(S / S) -> S` (e.g. OpFDiv)
-        <li>`(S % S) -> S` (e.g. OpFMod)
-      </ul>
-  <tr>
-    <td>Vector arithmatic
-    <td>V: vecN<S>; S: f32 or i32 or u32
-    <td>
-      <ul>
-        <li>`(V + V) -> V` (component-wise, e.g. OpFAdd)
-        <li>`(V - V) -> V` (component-wise, e.g. OpFSub)
-        <li>`(V * V) -> V` (component-wise, e.g. OpFMul)
-        <li>`(V / V) -> V` (component-wise, e.g. OpFDiv)
-        <li>`(V % V) -> V` (component-wise, e.g. OpFMod)
-      </ul>
-  <tr>
-    <td>Vector OP Scalar "splats"
-    <td>V: vecN<S>; S: f32 or i32 or u32
-    <td>
-      <ul>
-        <li>`(V + S) -> (V    + V(S)) -> V`
-        <li>`(S + V) -> (V(S) + V   ) -> V`
-        <li>`(V - S) -> (V    - V(S)) -> V`
-        <li>`(S - V) -> (V(S) - V   ) -> V`
-        <li>`(V * S) -> (V    * V(S)) -> V` (e.g. OpVectorTimesScalar)
-        <li>`(S * V) -> (V(S) * V   ) -> V` (e.g. OpVectorTimesScalar)
-        <li>`(V / S) -> (V    / V(S)) -> V`
-        <li>`(S / V) -> (V(S) / V   ) -> V`
-        <li>`(V % S) -> (V    % V(S)) -> V`
-        <li>`(S % V) -> (V(S) % V   ) -> V`
-      </ul>
-  <tr>
-    <td>Matrix arithmatic
-    <td>S: f32
-    <td>
-      <ul>
-        <li>`(matAxB<S> + matAxB<S>) -> matAxB<S>` (component-wise)
-        <li>`(matAxB<S> - matAxB<S>) -> matAxB<S>` (component-wise)
-        <li>`(matAxB<S> * matCxA<S>) -> matCxB<S>` (linear-algebraic, e.g. OpMatrixTimesMatrix)
-        <li>`(matAxB<S> * vecA<S>) -> vecB<S>` (linear-algebraic, vec as column-vector, e.g. OpMatrixTimesVector)
-        <li>`(vecB<S> * matAxB<S>) -> vecA<S>` (linear-algebraic, vec as row-vector, e.g. OpVectorTimesMatrix)
-      </ul>
-  <tr>
-    <td>Matrix OP Scalar "splats"
-    <td>M: matAxB<S>; S: f32
-    <td>
-      <ul>
-        <li>`(M * S) -> (M    * M(S)) -> M` (e.g. OpMatrixTimesScalar)
-        <li>`(S * M) -> (M(S) * M   ) -> M` (e.g. OpMatrixTimesScalar)
-      </ul>
-</table>
 
 # Built-in functions # {#builtin-functions}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6088,10 +6088,6 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
     <td>M: matAxB<S>; S: f32
     <td>
       <ul>
-        <li>`(M + S) -> (M    + M(S)) -> M`
-        <li>`(S + M) -> (M(S) + M   ) -> M`
-        <li>`(M - S) -> (M    - M(S)) -> M`
-        <li>`(S - M) -> (M(S) - M   ) -> M`
         <li>`(M * S) -> (M    * M(S)) -> M` (e.g. OpMatrixTimesScalar)
         <li>`(S * M) -> (M(S) * M   ) -> M` (e.g. OpMatrixTimesScalar)
       </ul>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3723,21 +3723,18 @@ Issue: Which index is used when it's out of bounds?
     <th>Preconditions<th>Conclusions<th>Semantics
   </thead>
   <tr algorithm="matrix addition">
-    <td>|e1|, |e2|: mat|M|x|N|&lt;f32&gt
+    <td rowspan=2>|e1|, |e2|: mat|M|x|N|&lt;f32&gt
     <td>|e1| `+` |e2|: mat|M|x|N|&lt;f32&gt<br>
     <td>Matrix addition: column |i| of the result is |e1|[i] + |e2|[i]
   <tr algorithm="matrix subtraction">
-    <td>|e1|, |e2|: mat|M|x|N|&lt;f32&gt
     <td>|e1| `-` |e2|: mat|M|x|N|&lt;f32&gt
     <td>Matrix subtraction: column |i| of the result is |e1|[|i|] - |e2|[|i|]
   <tr algorithm="matrix-scalar multiply">
-    <td>|m|: mat|M|x|N|&lt;f32&gt<br>
+    <td rowspan=2>|m|: mat|M|x|N|&lt;f32&gt<br>
         |s|: f32
     <td>|m| `*` |s| :  mat|M|x|N|&lt;f32&gt<br>
     <td>Component-wise scaling: (|m| `*` |s|)[i][j] is |m|[i][j] `*` |s|
   <tr algorithm="scalar-matrix multiply">
-    <td>|m|: mat|M|x|N|&lt;f32&gt<br>
-        |s|: f32
     <td>|s| `*` |m| :  mat|M|x|N|&lt;f32&gt<br>
     <td>Component-wise scaling: (|s| `*` |m|)[i][j] is |m|[i][j] `*` |s|
   <tr algorithm="matrix-column-vector multiply">

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6023,6 +6023,80 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
   </xmp>
 </div>
 
+# Operators # {#operators}
+
+[SHORTNAME] has symbol-based operators, such as the `+` in `a + b`.
+
+## Arithmatic operators ## {#arithmatic-operators}
+
+<table class='data'>
+  <caption>Binary operators</caption>
+  <thead>
+    <tr><th>Category<th>Preconditions<th>Conclusions
+  </thead>
+  <tr>
+    <td>Scalar arithmatic
+    <td>S: f32 or i32 or u32
+    <td>
+      <ul>
+        <li>`(S + S) -> S` (e.g. OpFAdd)
+        <li>`(S - S) -> S` (e.g. OpFSub)
+        <li>`(S * S) -> S` (e.g. OpFMul)
+        <li>`(S / S) -> S` (e.g. OpFDiv)
+        <li>`(S % S) -> S` (e.g. OpFMod)
+      </ul>
+  <tr>
+    <td>Vector arithmatic
+    <td>V: vecN<S>; S: f32 or i32 or u32
+    <td>
+      <ul>
+        <li>`(V + V) -> V` (component-wise, e.g. OpFAdd)
+        <li>`(V - V) -> V` (component-wise, e.g. OpFSub)
+        <li>`(V * V) -> V` (component-wise, e.g. OpFMul)
+        <li>`(V / V) -> V` (component-wise, e.g. OpFDiv)
+        <li>`(V % V) -> V` (component-wise, e.g. OpFMod)
+      </ul>
+  <tr>
+    <td>Vector OP Scalar "splats"
+    <td>V: vecN<S>; S: f32 or i32 or u32
+    <td>
+      <ul>
+        <li>`(V + S) -> (V    + V(S)) -> V`
+        <li>`(S + V) -> (V(S) + V   ) -> V`
+        <li>`(V - S) -> (V    - V(S)) -> V`
+        <li>`(S - V) -> (V(S) - V   ) -> V`
+        <li>`(V * S) -> (V    * V(S)) -> V` (e.g. OpVectorTimesScalar)
+        <li>`(S * V) -> (V(S) * V   ) -> V` (e.g. OpVectorTimesScalar)
+        <li>`(V / S) -> (V    / V(S)) -> V`
+        <li>`(S / V) -> (V(S) / V   ) -> V`
+        <li>`(V % S) -> (V    % V(S)) -> V`
+        <li>`(S % V) -> (V(S) % V   ) -> V`
+      </ul>
+  <tr>
+    <td>Matrix arithmatic
+    <td>S: f32
+    <td>
+      <ul>
+        <li>`(matAxB<S> + matAxB<S>) -> matAxB<S>` (component-wise)
+        <li>`(matAxB<S> - matAxB<S>) -> matAxB<S>` (component-wise)
+        <li>`(matAxB<S> * matCxA<S>) -> matCxB<S>` (linear-algebraic, e.g. OpMatrixTimesMatrix)
+        <li>`(matAxB<S> * vecA<S>) -> vecB<S>` (linear-algebraic, vec as column-vector, e.g. OpMatrixTimesVector)
+        <li>`(vecB<S> * matAxB<S>) -> vecA<S>` (linear-algebraic, vec as row-vector, e.g. OpVectorTimesMatrix)
+      </ul>
+  <tr>
+    <td>Matrix OP Scalar "splats"
+    <td>M: matAxB<S>; S: f32
+    <td>
+      <ul>
+        <li>`(M + S) -> (M    + M(S)) -> M`
+        <li>`(S + M) -> (M(S) + M   ) -> M`
+        <li>`(M - S) -> (M    - M(S)) -> M`
+        <li>`(S - M) -> (M(S) - M   ) -> M`
+        <li>`(M * S) -> (M    * M(S)) -> M` (e.g. OpMatrixTimesScalar)
+        <li>`(S * M) -> (M(S) * M   ) -> M` (e.g. OpMatrixTimesScalar)
+      </ul>
+</table>
+
 # Built-in functions # {#builtin-functions}
 
 Certain functions are always available in a [SHORTNAME] program,

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -193,6 +193,15 @@ The <dfn noexport>roundUp</dfn> function is defined for positive integers |k| an
 
 * roundUp(|k|, |n|) = &lceil;|n| &div; |k|&rceil; &times; |k|
 
+The <dfn noexport>transpose</dfn> of an |n|-column |m|-row matrix |A| is the |m|-column |n|-row matrix
+|A|<sup>T</sup> formed by copying the rows of |A| as the columns of |A|<sup>T</sup>:
+
+* transpose(|A|) = |A|<sup>T</sup>
+* transpose(|A|)<sub>|i|,|j|</sub> = |A|<sub>|j|,|i|</sub>
+
+The transpose of a column vector is defined by interpreting the column vector as a 1-row matrix.
+Similarly, the transpose of a row vector is defined by interpreting the row vector as a 1-column matrix.
+
 # Shader Lifecycle # {#program-lifecycle}
 
 There are four key events in the lifecycle of a [SHORTNAME] program and the shaders it may contain.
@@ -3664,51 +3673,96 @@ Issue: Which index is used when it's out of bounds?
 
 
 <table class='data'>
-  <caption>Binary arithmetic expressions</caption>
+  <caption>Binary arithmetic expressions with mixed scalar and vector operands</caption>
   <thead>
-    <tr><th>Category<th>Preconditions<th>Conclusions
+    <tr><th>Category<th>Preconditions<th>Conclusions<th>Semantics
   </thead>
+  <tr algorithm="vector-scalar arithmetic, any scalar type">
+    <td rowspan="8">Vector-scalar arithmetic
+    <td rowspan="8">|S| is one of f32, i32, u32<br>
+        |V| is vec|N|&lt;|S|&gt<br>
+        |es|: |S|<br>
+        |ev|: |V|
+    <td>|ev| `+` |es|: |V|
+    <td>|ev| `+` |V|(|es|)
   <tr>
-    <td>Vector OP Scalar "splats"
-    <td>`V: vecN<S>;`<br>`S: f32 or i32 or u32;`
-    <td>
-      <ul>
-        <li>`(V + S) -> (V    + V(S)) -> V`
-        <li>`(S + V) -> (V(S) + V   ) -> V`
-        <li>`(V - S) -> (V    - V(S)) -> V`
-        <li>`(S - V) -> (V(S) - V   ) -> V`
-        <li>`(V * S) -> (V    * V(S)) -> V` (e.g. OpVectorTimesScalar)
-        <li>`(S * V) -> (V(S) * V   ) -> V` (e.g. OpVectorTimesScalar)
-        <li>`(V / S) -> (V    / V(S)) -> V`
-        <li>`(S / V) -> (V(S) / V   ) -> V`
-      </ul>
+    <td>|es| `+` |ev|: |V|
+    <td>|V|(|es|) `+` |ev|
   <tr>
-    <td>Vector OP Scalar integer-only "splats"
-    <td>`V: vecN<S>;`<br>`S: i32 or u32;`
-    <td>
-      <ul>
-        <li>`(V % S) -> (V    % V(S)) -> V`
-        <li>`(S % V) -> (V(S) % V   ) -> V`
-      </ul>
+    <td>|ev| `-` |es|: |V|
+    <td>|ev| `-` |V|(|es|)
   <tr>
-    <td>Matrix arithmetic
-    <td>`S: f32;`
-    <td>
-      <ul>
-        <li>`(matAxB<S> + matAxB<S>) -> matAxB<S>` (component-wise)
-        <li>`(matAxB<S> - matAxB<S>) -> matAxB<S>` (component-wise)
-        <li>`(matBxC<S> * matAxB<S>) -> matAxC<S>` (linear-algebraic, e.g. OpMatrixTimesMatrix)
-        <li>`(matAxB<S> * vecA<S>) -> vecB<S>` (linear-algebraic, vec as column-vector, e.g. OpMatrixTimesVector)
-        <li>`(vecB<S> * matAxB<S>) -> vecA<S>` (linear-algebraic, vec as row-vector, e.g. OpVectorTimesMatrix)
-      </ul>
+    <td>|es| `-` |ev|: |V|
+    <td>|V|(|es|) `-` |ev|
   <tr>
-    <td>Matrix OP Scalar "splats"
-    <td>`M: matAxB<S>;`<br>`S: f32;`
+    <td>|ev| `*` |es|: |V|
+    <td>|ev| `*` |V|(|es|)
+  <tr>
+    <td>|es| `*` |ev|: |V|
+    <td>|V|(|es|) `*` |ev|
+  <tr>
+    <td>|ev| `/` |es|: |V|
+    <td>|ev| `/` |V|(|es|)
+  <tr>
+    <td>|es| `/` |ev|: |V|
+    <td>|V|(|es|) `/` |ev|
+  <tr algorithm="vector-scalar integer arithmetic">
+    <td rowspan="2">Vector-scalar integer arithmetic
+    <td rowspan="2">|S| is one of i32, u32<br>
+        |V| is vec|N|&lt;|S|&gt<br>
+        |es|: |S|<br>
+        |ev|: |V|
+    <td>|ev| `%` |es|: |V|
+    <td>|ev| `%` |V|(|es|)
+  <tr>
+    <td>|es| `%` |ev|: |V|
+    <td>|V|(|es|) `%` |ev|
+</table>
+
+<table class='data'>
+  <caption>Matrix arithmetic</caption>
+  <thead>
+    <th>Preconditions<th>Conclusions<th>Semantics
+  </thead>
+  <tr algorithm="matrix addition">
+    <td>|e1|, |e2|: mat|M|x|N|&lt;f32&gt
+    <td>|e1| `+` |e2|: mat|M|x|N|&lt;f32&gt<br>
+    <td>Matrix addition: column |i| of the result is |e1|[i] + |e2|[i]
+  <tr algorithm="matrix subtraction">
+    <td>|e1|, |e2|: mat|M|x|N|&lt;f32&gt
+    <td>|e1| `-` |e2|: mat|M|x|N|&lt;f32&gt
+    <td>Matrix subtraction: column |i| of the result is |e1|[|i|] - |e2|[|i|]
+  <tr algorithm="matrix-scalar multiply">
+    <td>|m|: mat|M|x|N|&lt;f32&gt<br>
+        |s|: f32
+    <td>|m| `*` |s| :  mat|M|x|N|&lt;f32&gt<br>
+    <td>Component-wise scaling: (|m| `*` |s|)[i][j] is |m|[i][j] `*` |s|
+  <tr algorithm="scalar-matrix multiply">
+    <td>|m|: mat|M|x|N|&lt;f32&gt<br>
+        |s|: f32
+    <td>|s| `*` |m| :  mat|M|x|N|&lt;f32&gt<br>
+    <td>Component-wise scaling: (|s| `*` |m|)[i][j] is |m|[i][j] `*` |s|
+  <tr algorithm="matrix-column-vector multiply">
+    <td>|m|: mat|M|x|N|&lt;f32&gt<br>
+        |v|: vec|M|&lt;f32&gt
+    <td>|m| `*` |v| :  vec|N|&lt;f32&gt<br>
+    <td>Linear algebra matrix-column-vector product:
+        Component |i| of the result is `dot`(|m|[|i|],|v|)
+       <br>OpMatrixTimesVector
+  <tr algorithm="matrix-row-vector multiply">
     <td>
-      <ul>
-        <li>`(M * S) -> M(M[0]*S, M[1]*S, ...)` (component-wise, e.g. OpMatrixTimesScalar)
-        <li>`(S * M) -> M(M[0]*S, M[1]*S, ...)` (component-wise, e.g. OpMatrixTimesScalar)
-      </ul>
+        |m|: mat|M|x|N|&lt;f32&gt<br>
+        |v|: vec|N|&lt;f32&gt
+    <td>|v| `*` |m| :  vec|M|&lt;f32&gt<br>
+    <td>Linear algebra row-vector-matrix product:<br>
+        [=transpose=](transpose(|m|) `*` transpose(|v|))
+       <br>OpVectorTimesMatrix
+  <tr algorithm="matrix-matrix multiply">
+    <td>|e1|: mat|K|x|N|&lt;f32&gt<br>
+        |e2|: mat|M|x|K|&lt;f32&gt
+    <td>|e1| `*` |e2| :  mat|M|x|N|&lt;f32&gt<br>
+    <td>Linear algebra matrix product.<br>OpMatrixTimesMatrix
+
 </table>
 
 ## Comparison Expressions TODO ## {#comparison-expr}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3670,7 +3670,7 @@ Issue: Which index is used when it's out of bounds?
   </thead>
   <tr>
     <td>Vector OP Scalar "splats"
-    <td>V: vecN<S>; S: f32 or i32 or u32
+    <td>`V: vecN<S>;`<br>`S: f32 or i32 or u32;`
     <td>
       <ul>
         <li>`(V + S) -> (V    + V(S)) -> V`
@@ -3681,12 +3681,10 @@ Issue: Which index is used when it's out of bounds?
         <li>`(S * V) -> (V(S) * V   ) -> V` (e.g. OpVectorTimesScalar)
         <li>`(V / S) -> (V    / V(S)) -> V`
         <li>`(S / V) -> (V(S) / V   ) -> V`
-        <li>`(V % S) -> (V    % V(S)) -> V`
-        <li>`(S % V) -> (V(S) % V   ) -> V`
       </ul>
   <tr>
     <td>Vector OP Scalar integer-only "splats"
-    <td>V: vecN<S>; S: i32 or u32
+    <td>`V: vecN<S>;`<br>`S: i32 or u32;`
     <td>
       <ul>
         <li>`(V % S) -> (V    % V(S)) -> V`
@@ -3694,7 +3692,7 @@ Issue: Which index is used when it's out of bounds?
       </ul>
   <tr>
     <td>Matrix arithmetic
-    <td>S: f32
+    <td>`S: f32;`
     <td>
       <ul>
         <li>`(matAxB<S> + matAxB<S>) -> matAxB<S>` (component-wise)
@@ -3705,7 +3703,7 @@ Issue: Which index is used when it's out of bounds?
       </ul>
   <tr>
     <td>Matrix OP Scalar "splats"
-    <td>M: matAxB<S>; S: f32
+    <td>`M: matAxB<S>;`<br>`S: f32;`
     <td>
       <ul>
         <li>`(M * S) -> M(M[0]*S, M[1]*S, ...)` (component-wise, e.g. OpMatrixTimesScalar)

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3675,10 +3675,9 @@ Issue: Which index is used when it's out of bounds?
 <table class='data'>
   <caption>Binary arithmetic expressions with mixed scalar and vector operands</caption>
   <thead>
-    <tr><th>Category<th>Preconditions<th>Conclusions<th>Semantics
+    <th>Preconditions<th>Conclusions<th>Semantics
   </thead>
   <tr algorithm="vector-scalar arithmetic, any scalar type">
-    <td rowspan="8">Vector-scalar arithmetic
     <td rowspan="8">|S| is one of f32, i32, u32<br>
         |V| is vec|N|&lt;|S|&gt<br>
         |es|: |S|<br>
@@ -3707,7 +3706,6 @@ Issue: Which index is used when it's out of bounds?
     <td>|es| `/` |ev|: |V|
     <td>|V|(|es|) `/` |ev|
   <tr algorithm="vector-scalar integer arithmetic">
-    <td rowspan="2">Vector-scalar integer arithmetic
     <td rowspan="2">|S| is one of i32, u32<br>
         |V| is vec|N|&lt;|S|&gt<br>
         |es|: |S|<br>


### PR DESCRIPTION
This rewrites @jdashg's PR to use the standard notations used in other tables.

Supercedes #1575 
