### PR TITLE
Naming changes for GPUBlendFactor

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6581,8 +6581,8 @@ attachments used by this encoder.
 
     : <dfn>setBlendColor(color)</dfn>
     ::
-        Sets the constant blend color and alpha values used with {{GPUBlendFactor/"blend-color"}}
-        and {{GPUBlendFactor/"one-minus-blend-color"}} {{GPUBlendFactor}}s.
+        Sets the constant blend color and alpha values used with {{GPUBlendFactor/"blendcolor-component"}}
+        and {{GPUBlendFactor/"one-minus-blendcolor-component"}} {{GPUBlendFactor}}s.
 
         <div algorithm="GPURenderPassEncoder.setBlendColor">
             **Called on:** {{GPURenderPassEncoder}} this.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4238,19 +4238,24 @@ dictionary GPUBlendComponent {
 enum GPUBlendFactor {
     "zero",
     "one",
-    "src-color",
-    "one-minus-src-color",
-    "src-alpha",
-    "one-minus-src-alpha",
-    "dst-color",
-    "one-minus-dst-color",
+    "src0-componentwise",
+    "one-minus-src0-componentwise",
+    "src0-alpha",
+    "one-minus-src0-alpha",
+    "dst-componentwise",
+    "one-minus-dst-componentwise",
     "dst-alpha",
     "one-minus-dst-alpha",
-    "src-alpha-saturated",
-    "blend-color",
-    "one-minus-blend-color"
+    "src0-alpha-saturated",
+    "blendcolor-componentwise",
+    "one-minus-blendcolor-componentwise"
 };
 </script>
+
+Issue: {{GPUBlendOperation}}s "min" and "max" actually ignore the {{GPUBlendFactor}}.
+Should we validate the `srcFactor`/`dstFactor` both must be "one" with "min"/"max"?
+
+Issue: If we add holes to {{GPUFragmentState/targets}}, what does `src0`(/`src1`) mean?
 
 <script type=idl>
 enum GPUBlendOperation {

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4238,24 +4238,22 @@ dictionary GPUBlendComponent {
 enum GPUBlendFactor {
     "zero",
     "one",
-    "src0-componentwise",
-    "one-minus-src0-componentwise",
-    "src0-alpha",
-    "one-minus-src0-alpha",
-    "dst-componentwise",
-    "one-minus-dst-componentwise",
+    "src-component",
+    "one-minus-src-component",
+    "src-alpha",
+    "one-minus-src-alpha",
+    "dst-component",
+    "one-minus-dst-component",
     "dst-alpha",
     "one-minus-dst-alpha",
-    "src0-alpha-saturated",
-    "blendcolor-componentwise",
-    "one-minus-blendcolor-componentwise"
+    "src-alpha-saturated",
+    "blendcolor-component",
+    "one-minus-blendcolor-component"
 };
 </script>
 
 Issue: {{GPUBlendOperation}}s "min" and "max" actually ignore the {{GPUBlendFactor}}.
 Should we validate the `srcFactor`/`dstFactor` both must be "one" with "min"/"max"?
-
-Issue: If we add holes to {{GPUFragmentState/targets}}, what does `src0`(/`src1`) mean?
 
 <script type=idl>
 enum GPUBlendOperation {


### PR DESCRIPTION
- Rename "color" to "componentwise" which actually describes the behavior (on vulkan/metal; d3d12 just disallows these).
- Rename "blend-color" to "blendcolor-componentwise".
- Rename "src" to "src0" to be precise about which src is used (and to be consistent with "src1" for future dual source blending if any).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 12, 2021, 9:36 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fgpuweb%2Fgpuweb%2Fpull%2F1614%2F5f46921.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fkainino0x%2Fgpuweb%2Fpull%2F1614.html)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 sysreq@w3.org to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%231614.)._
</details>
