### PR TITLE
arrayLength acts on poitner-to-runtime-array

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6173,8 +6173,9 @@ That's not a full user-defined function declaration.
     <td>|e| : |T|, |T| is *FloatVec*
     <td>`isNormal(`|e|`)` : vec|N|&lt;bool&gt;, where |N| = *Arity(*|T|*)*<td>Component-wise test for normal number. Component *i* of the result is *isNormal(e[i])*. (emulated)
   <tr algorithm="runtime array length">
-    <td>|e| : array<|T|>
-    <td>`arrayLength(`|e|`)` : u32<td>Returns the length of the runtime array. (OpArrayLength)
+    <td>|e| : ptr&lt;storage,array&lt;|T|&gt;&gt;
+    <td>`arrayLength(`|e|`)` : u32<td>Returns the number of elements in the runtime array.<br>
+        (OpArrayLength, but you have to trace back to get the pointer to the enclosing struct.)
 </table>
 
 ## Float built-in functions ## {#float-builtin-functions}


### PR DESCRIPTION
We already have the rule that no expression has static
type that is a runtime-size array.
The previous definition of arrayLength violated that rule.