### PR TITLE
Use a setlike for GPUDevice features

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1157,14 +1157,15 @@ interface GPUAdapterLimits {
 };
 </script>
 
-#### <dfn interface>GPUAdapterFeatures</dfn> #### {#gpu-adapterfeatures}
+#### <dfn interface>GPUSupportedFeatures</dfn> #### {#gpu-supportedfeatures}
 
-{{GPUAdapterFeatures}} is a [=setlike=] interface. Its [=set entries=] are
-the {{GPUFeatureName}} values of the [=features=] supported by an adapter.
+{{GPUSupportedFeatures}} is a [=setlike=] interface. Its [=set entries=] are
+the {{GPUFeatureName}} values of the [=features=] supported by an adapter or
+device.
 
 <script type=idl>
 [Exposed=Window]
-interface GPUAdapterFeatures {
+interface GPUSupportedFeatures {
     readonly setlike<GPUFeatureName>;
 };
 </script>
@@ -1333,7 +1334,7 @@ To get a {{GPUAdapter}}, use {{GPU/requestAdapter()}}.
 [Exposed=Window]
 interface GPUAdapter {
     readonly attribute DOMString name;
-    [SameObject] readonly attribute GPUAdapterFeatures features;
+    [SameObject] readonly attribute GPUSupportedFeatures features;
     [SameObject] readonly attribute GPUAdapterLimits limits;
 
     Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor = {});
@@ -1484,7 +1485,7 @@ To get a {{GPUDevice}}, use {{GPUAdapter/requestDevice()}}.
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), Serializable]
 interface GPUDevice : EventTarget {
-    readonly attribute FrozenArray<GPUFeatureName> features;
+    [SameObject] readonly attribute GPUSupportedFeatures features;
     readonly attribute object limits;
 
     [SameObject] readonly attribute GPUQueue queue;
@@ -1518,11 +1519,8 @@ GPUDevice includes GPUObjectBase;
 <dl dfn-type=attribute dfn-for=GPUDevice>
     : <dfn>features</dfn>
     ::
-        A sequence containing the {{GPUFeatureName}} values of the features
+        A set containing the {{GPUFeatureName}} values of the features
         supported by the device (i.e. the ones with which it was created).
-
-        Issue: Should this be {{GPUAdapterFeatures}} (which would be renamed to
-        GPUSupportedFeatures)?
 
     : <dfn>limits</dfn>
     ::


### PR DESCRIPTION
Fixes #1613, if we choose to go that route.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 9, 2021, 4:32 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fgpuweb%2Fgpuweb%2Fpull%2F1620%2F5f46921.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fgpuweb%2Fgpuweb%2Fpull%2F1620.html)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 sysreq@w3.org to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%231620.)._
</details>
