### PR TITLE
rename setBlendColor -> setBlendConstant

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -236,7 +236,7 @@ which is a mix of fixed-function and programmable stages. Programmable stages ex
 Most of the state of a [=pipeline=] is defined by
 a {{GPURenderPipeline}} or a {{GPUComputePipeline}} object. The state not included
 in these [=pipeline=] objects is set during encoding with commands,
-such as {{GPUCommandEncoder/beginRenderPass()}} or {{GPURenderPassEncoder/setBlendColor()}}.
+such as {{GPUCommandEncoder/beginRenderPass()}} or {{GPURenderPassEncoder/setBlendConstant()}}.
 
 
 # Malicious use considerations # {#malicious-use}
@@ -4245,8 +4245,8 @@ enum GPUBlendFactor {
     "dst-alpha",
     "one-minus-dst-alpha",
     "src-alpha-saturated",
-    "blendcolor-component",
-    "one-minus-blendcolor-component"
+    "constant-component",
+    "one-minus-constant-component"
 };
 </script>
 
@@ -5895,7 +5895,7 @@ interface GPURenderPassEncoder {
     undefined setScissorRect(GPUIntegerCoordinate x, GPUIntegerCoordinate y,
                         GPUIntegerCoordinate width, GPUIntegerCoordinate height);
 
-    undefined setBlendColor(GPUColor color);
+    undefined setBlendConstant(GPUColor color);
     undefined setStencilReference(GPUStencilValue reference);
 
     undefined beginOcclusionQuery(GPUSize32 queryIndex);
@@ -6577,16 +6577,16 @@ attachments used by this encoder.
             </div>
         </div>
 
-    : <dfn>setBlendColor(color)</dfn>
+    : <dfn>setBlendConstant(color)</dfn>
     ::
-        Sets the constant blend color and alpha values used with {{GPUBlendFactor/"blendcolor-component"}}
-        and {{GPUBlendFactor/"one-minus-blendcolor-component"}} {{GPUBlendFactor}}s.
+        Sets the constant blend color and alpha values used with {{GPUBlendFactor/"constant-component"}}
+        and {{GPUBlendFactor/"one-minus-constant-component"}} {{GPUBlendFactor}}s.
 
-        <div algorithm="GPURenderPassEncoder.setBlendColor">
+        <div algorithm="GPURenderPassEncoder.setBlendConstant">
             **Called on:** {{GPURenderPassEncoder}} this.
 
             **Arguments:**
-            <pre class=argumentdef for="GPURenderPassEncoder/setBlendColor(color)">
+            <pre class=argumentdef for="GPURenderPassEncoder/setBlendConstant(color)">
                 color: The color to use when blending.
             </pre>
         </div>


### PR DESCRIPTION
"Blend color" is confusing because there are other places "blend" and "color" are used together:

- "src-color" (formerly, and in other APIs)
- GPUBlendState { GPUBlendComponent color; }

And it's not clear that using the "blendcolor" as a blend factor uses the dynamic constant instead of some other value. This makes it clearer.

- Metal: `setBlendColor()` and e.g. `MTLBlendFactor.oneMinusBlendColor`
- D3D12: `OMSetBlendFactor()` and e.g. `D3D12_BLEND_INV_BLEND_FACTOR`
- Vulkan: `vkCmdSetBlendConstants()` and e.g. `VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_COLOR`. (Note Vulkan also has `VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_ALPHA` which, if exposed in WebGPU, would become `"one-minus-constant-alpha"`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 12, 2021, 10:13 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fgpuweb%2Fgpuweb%2Fpull%2F1627%2F889e02c.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fkainino0x%2Fgpuweb%2Fpull%2F1627.html)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 sysreq@w3.org to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%231627.)._
</details>
