### PR TITLE
Require srcFactor=dstFactor="one" for min/max blend op

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4245,7 +4245,7 @@ dictionary GPUFragmentState: GPUProgrammableStage {
             - |colorState|.{{GPUColorTargetState/format}} must be listed in [[#plain-color-formats]]
                 with {{GPUTextureUsage/RENDER_ATTACHMENT}} capability.
             - If |colorState|.{{GPUColorTargetState/blend}} is not `undefined`:
-                - The |colorState|.{{GPUColorTargetState/format}} is filterable
+                - The |colorState|.{{GPUColorTargetState/format}} must be filterable
                     according to the [[#plain-color-formats]] table.
                 - |colorState|.{{GPUColorTargetState/blend}}.{{GPUBlendState/color}}
                     must be a [=valid GPUBlendComponent=].

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -934,9 +934,6 @@ A [=device=] has the following internal slots:
         No [=limit/better=] limits can be used, even if the underlying [=adapter=] can support them.
 </dl>
 
-Issue: [=device=] is already an internal concept. Having slots be marked as internal is redundant
-and adds extra `[[`/`]]` in spec text. Consider removing the brackets.
-
 <div algorithm>
     When <dfn dfn>a new device</dfn> |device| is created from [=adapter=] |adapter|
     with {{GPUDeviceDescriptor}} |descriptor|:
@@ -4241,19 +4238,32 @@ dictionary GPUFragmentState: GPUProgrammableStage {
 
 <div algorithm>
     <dfn abstract-op>validating GPUFragmentState</dfn>(|descriptor|)
-        Return `true` if all of the following conditions are satisfied:
+        Return `true` if all of the following requirements are met:
 
-            - |descriptor|.{{GPUFragmentState/targets}}.length is less than or equal to 4.
-            - For each |colorState| layout descriptor in the list |descriptor|.{{GPUFragmentState/targets}}:
-                - |colorState|.{{GPUColorTargetState/format}} is listed in {#plain-color-formats}
-                    with {{GPUTextureUsage/RENDER_ATTACHMENT}} capability.
-                - |colorState|.{{GPUColorTargetState/blend}} is either `undefined`,
-                    or the |colorState|.{{GPUColorTargetState/format}} is filterable
-                    according to the {#plain-color-formats} table.
-                - |colorState|.{{GPUColorTargetState/writeMask}} is less than 16.
-                - |descriptor|.{{GPUProgrammableStage/module}} contains an output variable
-                    that is [=statically used=] by |descriptor|.{{GPUProgrammableStage/entryPoint}},
-                    and has a type that is compatible with |colorState|.{{GPUColorTargetState/format}}.
+        - |descriptor|.{{GPUFragmentState/targets}}.length must be &le; 4.
+        - For each |colorState| layout descriptor in the list |descriptor|.{{GPUFragmentState/targets}}:
+            - |colorState|.{{GPUColorTargetState/format}} must be listed in [[#plain-color-formats]]
+                with {{GPUTextureUsage/RENDER_ATTACHMENT}} capability.
+            - If |colorState|.{{GPUColorTargetState/blend}} is not `undefined`:
+                - The |colorState|.{{GPUColorTargetState/format}} is filterable
+                    according to the [[#plain-color-formats]] table.
+                - |colorState|.{{GPUColorTargetState/blend}}.{{GPUBlendState/color}}
+                    must be a [=valid GPUBlendComponent=].
+                - |colorState|.{{GPUColorTargetState/blend}}.{{GPUBlendState/alpha}}
+                    must be a [=valid GPUBlendComponent=].
+            - |colorState|.{{GPUColorTargetState/writeMask}} must be &lt; 16.
+            - |descriptor|.{{GPUProgrammableStage/module}} must contain an output variable that:
+                - is [=statically used=] by |descriptor|.{{GPUProgrammableStage/entryPoint}}, and
+                - has a type that is compatible with |colorState|.{{GPUColorTargetState/format}}.
+</div>
+
+<div algorithm>
+    |component| is a <dfn>valid GPUBlendComponent</dfn> if it meets the following requirements:
+
+    - If |component|.{{GPUBlendComponent/operation}} is
+        {{GPUBlendOperation/"min"}} or {{GPUBlendOperation/"max"}}:
+        - |component|.{{GPUBlendComponent/srcFactor}} and
+            |component|.{{GPUBlendComponent/dstFactor}} must both be {{GPUBlendFactor/"one"}}.
 </div>
 
 Issue: define the area of reach for "statically used" things of `GPUProgrammableStage`
@@ -4315,9 +4325,6 @@ enum GPUBlendFactor {
     "one-minus-constant"
 };
 </script>
-
-Issue: {{GPUBlendOperation}}s "min" and "max" actually ignore the {{GPUBlendFactor}}.
-Should we validate the `srcFactor`/`dstFactor` both must be "one" with "min"/"max"?
 
 <script type=idl>
 enum GPUBlendOperation {


### PR DESCRIPTION
See https://github.com/gpuweb/gpuweb/pull/1614#discussion_r611737059


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 14, 2021, 11:44 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fgpuweb%2Fgpuweb%2Fpull%2F1635%2F1fb1ba4.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fkainino0x%2Fgpuweb%2Fpull%2F1635.html)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 sysreq@w3.org to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%231635.)._
</details>
