### PR TITLE
Explainer: command encoding

### DIFF
--- a/explainer/index.bs
+++ b/explainer/index.bs
@@ -378,6 +378,9 @@ provide information for debugging tools (error messages, native profilers like X
 Every WebGPU object creation descriptor has a member `label` which sets the initial value of the
 attribute.
 
+Additionally, parts of command buffers can be labeled with debug markers and debug groups.
+See [[#command-encoding-debug]].
+
 For both debugging (dev tools messages) and telemetry, implementations can choose to report some
 kind of "stack trace" in their error messages, taking advantage of object debug labels.
 For example:
@@ -385,6 +388,8 @@ For example:
 ```
 <myQueue>.submit failed:
 - commands[0] (<mainColorPass>) was invalid:
+- in the debug group <environment>:
+- in the debug group <tree 123>:
 - in setIndexBuffer, indexBuffer (<mesh3.indices>) was invalid:
 - in createBuffer, desc.usage was invalid (0x89)
 ```
@@ -786,6 +791,31 @@ Some alternatives are mentioned in issue [#747](https://github.com/gpuweb/gpuweb
 
 
 ## Command Encoding and Submission ## {#command-encoding}
+
+Many operations in WebGPU are purely GPU-side operations that don't use data from the CPU.
+These operations are not issued directly; instead, they are encoded into `GPUCommandBuffer`s
+via the builder-like `GPUCommandEncoder` interface, then later sent to the GPU with
+`gpuQueue.submit()`.
+This design is used by the underlying native APIs as well. It provides several benefits:
+
+- Command buffer encoding is independent of other state, allowing encoding (and command buffer
+    validation) work to utilize multiple CPU threads.
+- Provides a larger chunk of work at once, allowing the GPU driver to do more global
+    optimization, especially in how it schedules work across the GPU hardware.
+
+### Debug Markers and Debug Groups ### {#command-encoding-debug}
+
+For error messages and debugging tools, it is possible to label work inside a command buffer.
+(See [[#errors-errorscopes-labels]].)
+
+- `insertDebugMarker(markerLabel)` marks a point in a stream of commands.
+- `pushDebugGroup(groupLabel)`/`popDebugGroup()` nestably demarcate sub-streams of commands.
+    This can be used e.g. to label which part of a command buffer corresponds to different objects
+    or parts of a scene.
+
+### Passes ### {#command-encoding-passes}
+
+Issue: Briefly explain passes?
 
 
 ## Pipelines ## {#pipelines}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5338,7 +5338,7 @@ must be well nested.
 
     : <dfn>insertDebugMarker(markerLabel)</dfn>
     ::
-        Marks the end of a labeled group of commands for the {{GPUCommandEncoder}}.
+        Marks a point in a stream of commands with a label string.
 
         <div algorithm=GPUCommandEncoder.insertDebugMarker>
             **Called on:** {{GPUCommandEncoder}} |this|.


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 15, 2021, 1:48 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fgpuweb%2Fgpuweb%2Fpull%2F1637%2F1fb1ba4.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fkainino0x%2Fgpuweb%2Fpull%2F1637.html)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 sysreq@w3.org to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%231637.)._
</details>
