### PR TITLE
Add derivatives on vector.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6697,17 +6697,17 @@ That's not a full user-defined function declaration.
 
 <table class='data'>
   <thead>
-    <tr><th>Derivative built-in functions<th>SPIR-V
+    <tr><th>Precondition<th>Derivative built-in functions<th>SPIR-V
   </thead>
-  <tr><td>dpdx(IDENT) -&gt; float<td>OpDPdx
-  <tr><td>dpdxCoarse(IDENT) -&gt; float<td>OpDPdxCoarse
-  <tr><td>dpdxFine(IDENT) -&gt; float<td>OpDPdxFine
-  <tr><td>dpdy(IDENT) -&gt; float<td>OpDPdy
-  <tr><td>dpdyCoarse(IDENT) -&gt; float<td>OpDPdyCoarse
-  <tr><td>dpdyFine(IDENT) -&gt; float<td>OpDPdyFine
-  <tr><td>fwidth(IDENT) -&gt; float<td>OpFwidth
-  <tr><td>fwidthCoarse(IDENT) -&gt; float<td>OpFwidthCoarse
-  <tr><td>fwidthFine(IDENT) -&gt; float<td>OpFwidthFine
+  <tr><td rowspan=9>|T| is f32 or vecN&lt;f32&gt;<td>dpdx(T) -&gt; T<td>OpDPdx
+  <tr><td>dpdxCoarse(T) -&gt; T<td>OpDPdxCoarse
+  <tr><td>dpdxFine(T) -&gt; T<td>OpDPdxFine
+  <tr><td>dpdy(T) -&gt; T<td>OpDPdy
+  <tr><td>dpdyCoarse(T) -&gt; T<td>OpDPdyCoarse
+  <tr><td>dpdyFine(T) -&gt; T<td>OpDPdyFine
+  <tr><td>fwidth(T) -&gt; T<td>OpFwidth
+  <tr><td>fwidthCoarse(T) -&gt; T<td>OpFwidthCoarse
+  <tr><td>fwidthFine(T) -&gt; T<td>OpFwidthFine
 </table>
 
 ## Texture built-in functions ## {#texture-builtin-functions}


### PR DESCRIPTION
In SPIR-V all derivative instructions can operate on vectors of f32.
In HLSL all derivative builtins can operate on vectors and matrices
of floats.
In MSL all derivative buitins can operate on vectors of f32 and f16.
In GLSL all derivative builtins can operate on "genFType".

Since all shading languages can do derivatives on vectors, let's have
that in WGSL too.