### PR TITLE
Added offset, length to GPUCompilationMessage

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3563,8 +3563,8 @@ interface GPUCompilationMessage {
     readonly attribute GPUCompilationMessageType type;
     readonly attribute unsigned long long lineNum;
     readonly attribute unsigned long long linePos;
-    readonly attribute unsigned long long spanOffset;
-    readonly attribute unsigned long long spanLength;
+    readonly attribute unsigned long long offset;
+    readonly attribute unsigned long long length;
 };
 
 [Exposed=Window, Serializable]
@@ -3587,36 +3587,37 @@ interface GPUCompilationInfo {
     : <dfn>lineNum</dfn>
     ::
         The line number in the shader {{GPUShaderModuleDescriptor/code}} the
-        {{GPUCompilationMessage/message}} corresponds to. Lines are delimeted by the `\n` character.
-        If {{GPUCompilationMessage/message}} corresponds to a span of characters
-        this points to the line one which the span begins.
+        {{GPUCompilationMessage/message}} corresponds to. If {{GPUCompilationMessage/message}}
+        corresponds to a span of characters this points to the line one which the span begins.
+
+        Issue: Reference WGSL spec when it [defines what a line is](https://gpuweb.github.io/gpuweb/wgsl/#comments).
 
     : <dfn>linePos</dfn>
     ::
-        The number of characters, in code units, on line {{GPUCompilationMessage/lineNum}}
+        The offset, in UTF-16 code units, from the beginning of line {{GPUCompilationMessage/lineNum}}
         of the shader {{GPUShaderModuleDescriptor/code}} that the {{GPUCompilationMessage/message}}
         corresponds to. If {{GPUCompilationMessage/message}} corresponds to a span of characters
         this points to the first character of the span.
 
-    : <dfn>spanOffset</dfn>
+    : <dfn>offset</dfn>
     ::
-        The offset from the beginning of the shader {{GPUShaderModuleDescriptor/code}} in code units
-        to the beginning of the span of characters that {{GPUCompilationMessage/message}}
+        The offset from the beginning of the shader {{GPUShaderModuleDescriptor/code}} in UTF-16
+        code units to the beginning of the span of characters that {{GPUCompilationMessage/message}}
         corresponds to. Must reference the same position as {{GPUCompilationMessage/lineNum}} and
         {{GPUCompilationMessage/linePos}}.
 
-    : <dfn>spanLength</dfn>
+    : <dfn>length</dfn>
     ::
-        The number of code units in the span of characters that {{GPUCompilationMessage/message}}
-        corresponds to. If the message refers to a single point in the shader
-        {{GPUShaderModuleDescriptor/code}} rather than a span of characters then
-        {{GPUCompilationMessage/spanLength}} must be 0.
+        The number of UTF-16 code units in the span of characters that
+        {{GPUCompilationMessage/message}} corresponds to. If the message refers to a single point
+        in the shader {{GPUShaderModuleDescriptor/code}} rather than a span of characters then
+        {{GPUCompilationMessage/length}} must be 0.
 </dl>
 
-Note: {{GPUCompilationMessage}}.{{GPUCompilationMessage/spanOffset}} and
-{{GPUCompilationMessage}}.{{GPUCompilationMessage/spanLength}} are appropriate to pass to
-`substr()` in order to retrieve the substring of the shader
-{{GPUShaderModuleDescriptor/code}} the {{GPUCompilationMessage/message}} corresponds to.
+Note: {{GPUCompilationMessage}}.{{GPUCompilationMessage/offset}} and
+{{GPUCompilationMessage}}.{{GPUCompilationMessage/length}} are appropriate to pass to
+`substr()` in order to retrieve the substring of the shader {{GPUShaderModuleDescriptor/code}} the
+{{GPUCompilationMessage/message}} corresponds to.
 
 <dl dfn-type=method dfn-for=GPUShaderModule>
     : <dfn>compilationInfo()</dfn>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3563,8 +3563,8 @@ interface GPUCompilationMessage {
     readonly attribute GPUCompilationMessageType type;
     readonly attribute unsigned long long lineNum;
     readonly attribute unsigned long long linePos;
-    readonly attribute unsigned long long spanStart;
-    readonly attribute unsigned long long spanEnd;
+    readonly attribute unsigned long long spanOffset;
+    readonly attribute unsigned long long spanLength;
 };
 
 [Exposed=Window, Serializable]
@@ -3593,30 +3593,29 @@ interface GPUCompilationInfo {
 
     : <dfn>linePos</dfn>
     ::
-        The number of characters in UTF-16 code units on line {{GPUCompilationMessage/lineNum}}
+        The number of characters, in code units, on line {{GPUCompilationMessage/lineNum}}
         of the shader {{GPUShaderModuleDescriptor/code}} that the {{GPUCompilationMessage/message}}
         corresponds to. If {{GPUCompilationMessage/message}} corresponds to a span of characters
         this points to the first character of the span.
 
-    : <dfn>spanStart</dfn>
+    : <dfn>spanOffset</dfn>
     ::
-        The offset from the beginning of the shader {{GPUShaderModuleDescriptor/code}} in UTF-16
-        code units to the beginning of the span of characters that {{GPUCompilationMessage/message}}
+        The offset from the beginning of the shader {{GPUShaderModuleDescriptor/code}} in code units
+        to the beginning of the span of characters that {{GPUCompilationMessage/message}}
         corresponds to. Must reference the same position as {{GPUCompilationMessage/lineNum}} and
         {{GPUCompilationMessage/linePos}}.
 
-    : <dfn>spanEnd</dfn>
+    : <dfn>spanLength</dfn>
     ::
-        The offset from the beginning of the shader {{GPUShaderModuleDescriptor/code}} in UTF-16
-        code units to the end of the span of characters that {{GPUCompilationMessage/message}}
-        corresponds to, exclusively. If the message refers to a single point in the shader
+        The number of code units in the span of characters that {{GPUCompilationMessage/message}}
+        corresponds to. If the message refers to a single point in the shader
         {{GPUShaderModuleDescriptor/code}} rather than a span of characters then
-        {{GPUCompilationMessage/spanEnd}} must equal {{GPUCompilationMessage/spanStart}}.
+        {{GPUCompilationMessage/spanLength}} must be 0.
 </dl>
 
-Note: {{GPUCompilationMessage}}.{{GPUCompilationMessage/spanStart}} and
-{{GPUCompilationMessage}}.{{GPUCompilationMessage/spanEnd}} are appropriate to pass to
-`substring()` or `slice()` in order to retrieve the substring of the shader
+Note: {{GPUCompilationMessage}}.{{GPUCompilationMessage/spanOffset}} and
+{{GPUCompilationMessage}}.{{GPUCompilationMessage/spanLength}} are appropriate to pass to
+`substr()` in order to retrieve the substring of the shader
 {{GPUShaderModuleDescriptor/code}} the {{GPUCompilationMessage/message}} corresponds to.
 
 <dl dfn-type=method dfn-for=GPUShaderModule>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3502,25 +3502,6 @@ if their internal {{GPUPipelineLayout/[[bindGroupLayouts]]}} sequences contain
 ## <dfn interface>GPUShaderModule</dfn> ## {#shader-module}
 
 <script type=idl>
-enum GPUCompilationMessageType {
-    "error",
-    "warning",
-    "info"
-};
-
-[Exposed=Window, Serializable]
-interface GPUCompilationMessage {
-    readonly attribute DOMString message;
-    readonly attribute GPUCompilationMessageType type;
-    readonly attribute unsigned long long lineNum;
-    readonly attribute unsigned long long linePos;
-};
-
-[Exposed=Window, Serializable]
-interface GPUCompilationInfo {
-    readonly attribute FrozenArray<GPUCompilationMessage> messages;
-};
-
 [Exposed=Window, Serializable]
 interface GPUShaderModule {
     Promise<GPUCompilationInfo> compilationInfo();
@@ -3568,6 +3549,75 @@ integration such as source-language debugging.
 </dl>
 
 ### Shader Module Compilation Information ### {#shader-module-compilation-information}
+
+<script type=idl>
+enum GPUCompilationMessageType {
+    "error",
+    "warning",
+    "info"
+};
+
+[Exposed=Window, Serializable]
+interface GPUCompilationMessage {
+    readonly attribute DOMString message;
+    readonly attribute GPUCompilationMessageType type;
+    readonly attribute unsigned long long lineNum;
+    readonly attribute unsigned long long linePos;
+    readonly attribute unsigned long long spanStart;
+    readonly attribute unsigned long long spanEnd;
+};
+
+[Exposed=Window, Serializable]
+interface GPUCompilationInfo {
+    readonly attribute FrozenArray<GPUCompilationMessage> messages;
+};
+</script>
+
+{{GPUCompilationMessage}} has the following attributes:
+
+<dl dfn-type=attribute dfn-for=GPUCompilationMessage>
+    : <dfn>message</dfn>
+    ::
+        A human-readable string containing the message generated during the shader compilation.
+    
+    : <dfn>type</dfn>
+    ::
+        The severity level of the message.
+
+    : <dfn>lineNum</dfn>
+    ::
+        The line number in the shader {{GPUShaderModuleDescriptor/code}} the
+        {{GPUCompilationMessage/message}} corresponds to. Lines are delimeted by the `\n` character.
+        If {{GPUCompilationMessage/message}} corresponds to a span of characters
+        this points to the line one which the span begins.
+
+    : <dfn>linePos</dfn>
+    ::
+        The number of characters in UTF-16 code units on line {{GPUCompilationMessage/lineNum}}
+        of the shader {{GPUShaderModuleDescriptor/code}} that the {{GPUCompilationMessage/message}}
+        corresponds to. If {{GPUCompilationMessage/message}} corresponds to a span of characters
+        this points to the first character of the span.
+
+    : <dfn>spanStart</dfn>
+    ::
+        The offset from the beginning of the shader {{GPUShaderModuleDescriptor/code}} in UTF-16
+        code units to the beginning of the span of characters that {{GPUCompilationMessage/message}}
+        corresponds to. Must reference the same position as {{GPUCompilationMessage/lineNum}} and
+        {{GPUCompilationMessage/linePos}}.
+
+    : <dfn>spanEnd</dfn>
+    ::
+        The offset from the beginning of the shader {{GPUShaderModuleDescriptor/code}} in UTF-16
+        code units to the end of the span of characters that {{GPUCompilationMessage/message}}
+        corresponds to, exclusively. If the message refers to a single point in the shader
+        {{GPUShaderModuleDescriptor/code}} rather than a span of characters then
+        {{GPUCompilationMessage/spanEnd}} must equal {{GPUCompilationMessage/spanStart}}.
+</dl>
+
+Note: {{GPUCompilationMessage}}.{{GPUCompilationMessage/spanStart}} and
+{{GPUCompilationMessage}}.{{GPUCompilationMessage/spanEnd}} are appropriate to pass to
+`substring()` or `slice()` in order to retrieve the substring of the shader
+{{GPUShaderModuleDescriptor/code}} the {{GPUCompilationMessage/message}} corresponds to.
 
 <dl dfn-type=method dfn-for=GPUShaderModule>
     : <dfn>compilationInfo()</dfn>


### PR DESCRIPTION
Also added some definitions for the fields that were previously missing.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/1643.html" title="Last updated on Apr 23, 2021, 6:45 PM UTC (fe34a12)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1643/36aeace...fe34a12.html" title="Last updated on Apr 23, 2021, 6:45 PM UTC (fe34a12)">Diff</a>