### PR TITLE
Move <Buffer Usage> to a subsection of <Buffer Creation>

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1785,7 +1785,7 @@ dictionary GPUBufferDescriptor : GPUObjectDescriptorBase {
         1. Return `true`.
 </div>
 
-## Buffer Usage ## {#buffer-usage}
+### Buffer Usage ### {#buffer-usage}
 
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUBufferUsageFlags;


### PR DESCRIPTION
We are still talking about buffer creation in this context: You can read the text before and after `Buffer Usage`. So `Buffer Usage` should be a subsection of `Buffer Creation`. They are not peers.

I even think we should move the idl for buffer usage to the place right after GPUBufferDescripter. Because buffer usage is a parameter of GPUBufferDescripter.

WDYT?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Richard-Yunchao/gpuweb/pull/1645.html" title="Last updated on Apr 20, 2021, 6:46 AM UTC (d18cf1d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1645/4aa7e32...Richard-Yunchao:d18cf1d.html" title="Last updated on Apr 20, 2021, 6:46 AM UTC (d18cf1d)">Diff</a>