### PR TITLE
UTF-8 is always a valid encoding for WGSL

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -273,6 +273,10 @@ TODO: This is a stub.
 
 A [SHORTNAME] program is text.
 This specification does not prescribe a particular encoding for that text.
+However, UTF-8 is always a valid encoding for a [SHORTNAME] program.
+
+Note: The intent of promoting UTF-8 like this is to simplify interchange of [SHORTNAME] programs
+and to encourage interoperability among tools.
 
 ## Comments ## {#comments}
 


### PR DESCRIPTION
Replaces: #1626