### PR TITLE
copyExternalImageToTexture for HTMLVideoElement

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5091,7 +5091,7 @@ Issue(gpuweb/gpuweb#69): Define the copies with {{GPUTextureDimension/1d}} and {
 
 <script type=idl>
 dictionary GPUImageCopyExternalImage {
-    required (ImageBitmap or HTMLCanvasElement or OffscreenCanvas) source;
+    required (ImageBitmap or HTMLVideoElement or HTMLCanvasElement or OffscreenCanvas) source;
     GPUOrigin2D origin = {};
 };
 </script>
@@ -5118,6 +5118,9 @@ used by the browser for unmanaged content?), but eventually we'll want to add kn
 
 Issue: Once that's figured out, generally define (and test) the encoding of color values into the
 various formats allowed by {{GPUQueue/copyExternalImageToTexture()}}.
+
+Issue: Do we need to define what rectangle of the decoded video ("natural size" etc.) is used for
+this copy? (On cursory inspection, WebGL doesn't seem to.)
 
 ### Buffer Copies ### {#buffer-copies}
 
@@ -7237,7 +7240,7 @@ GPUQueue includes GPUObjectBase;
 
     : <dfn>copyExternalImageToTexture(source, destination, copySize)</dfn>
     ::
-        Issues a copy operation of the contents of a platform image/canvas
+        Issues a copy operation of the contents of a platform image/video/canvas
         into the destination texture.
 
         <div algorithm=GPUQueue.copyExternalImageToTexture>


### PR DESCRIPTION
Split from #1581, because it's not immediately clear whether this overload is useful.

- It is somewhat fragile, because videos can change resolution between frames, but application code could easily (accidentally) not handle this.
- GPUExternalTexture is a more straightforward and less error-prone way of using video data on a per-frame basis, with the caveat that it has lifetime restrictions and can only be sampled from.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1647.html" title="Last updated on Apr 27, 2021, 12:23 AM UTC (a4aaf1e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1647/dcda8fe...kainino0x:a4aaf1e.html" title="Last updated on Apr 27, 2021, 12:23 AM UTC (a4aaf1e)">Diff</a>