### PR TITLE
Add the definition of renderable format

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2544,12 +2544,10 @@ note that the set of representable values is not exactly the same:
 for depth24unorm, 1 ULP has a constant value of 1 / (2<sup>24</sup> &minus; 1);
 for depth32float, 1 ULP has a variable value no greater than 1 / (2<sup>24</sup>).
 
-A renderable format is either <dfn>color renderable format</dfn>,
-or <dfn>depth or stencil renderable format</dfn>.
-  - If a format is listed in [[#plain-color-formats]] with {{GPUTextureUsage/RENDER_ATTACHMENT}}
-    capability, it is a color renderable format. Any other format is not a color renderable format.
-  - Any depth/stencil format is a depth or stencil renderable format. Any other format is not
-    a depth or stencil renderable format.
+A renderable format is either <dfn>color renderable format</dfn>, or <dfn>depth or stencil renderable format</dfn>.
+If a format is listed in [[#plain-color-formats]] with {{GPUTextureUsage/RENDER_ATTACHMENT}} capability, it is a
+color renderable format. Any other format is not a color renderable format. Any depth/stencil format is a
+depth or stencil renderable format. Any other format is not a depth or stencil renderable format.
 
 # Samplers # {#samplers}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2546,7 +2546,7 @@ for depth32float, 1 ULP has a variable value no greater than 1 / (2<sup>24</sup>
 
 A renderable format is either <dfn>color renderable format</dfn>,
 or <dfn>depth or stencil renderable format</dfn>.
-  - If a format is listed in {#plain-color-formats} with {{GPUTextureUsage/RENDER_ATTACHMENT}}
+  - If a format is listed in [[#plain-color-formats]] with {{GPUTextureUsage/RENDER_ATTACHMENT}}
     capability, it is a color renderable format. Any other format is not a color renderable format.
   - Any depth/stencil format is a depth or stencil renderable format. Any other format is not
     a depth or stencil renderable format.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2544,7 +2544,12 @@ note that the set of representable values is not exactly the same:
 for depth24unorm, 1 ULP has a constant value of 1 / (2<sup>24</sup> &minus; 1);
 for depth32float, 1 ULP has a variable value no greater than 1 / (2<sup>24</sup>).
 
-Issue: {{GPUTextureFormat/"rgb9e5ufloat"}} cannot be used as a color attachment.
+A renderable format is either <dfn>color renderable format</dfn>,
+or <dfn>depth or stencil renderable format</dfn>.
+  - If a format is listed in {#plain-color-formats} with {{GPUTextureUsage/RENDER_ATTACHMENT}}
+    capability, it is a color renderable format. Any other format is not a color renderable format.
+  - Any depth/stencil format is a depth or stencil renderable format. Any other format is not
+    a depth or stencil renderable format.
 
 # Samplers # {#samplers}
 
@@ -6153,7 +6158,7 @@ dictionary GPURenderPassColorAttachment {
     Given a {{GPURenderPassColorAttachment}} |this| the following validation rules
     apply:
 
-    1. |this|.{{GPURenderPassColorAttachment/view}} must have a renderable color format.
+    1. |this|.{{GPURenderPassColorAttachment/view}} must have a [=color renderable format=].
     1. |this|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[textureUsage]]}}
         must contain {{GPUTextureUsage/RENDER_ATTACHMENT}}.
     1. |this|.{{GPURenderPassColorAttachment/view}} must be a view of a single [=subresource=].
@@ -6244,8 +6249,8 @@ dictionary GPURenderPassDepthStencilAttachment {
     Given a {{GPURenderPassDepthStencilAttachment}} |this| the following validation
     rules apply:
 
-    1. |this|.{{GPURenderPassDepthStencilAttachment/view}} must have a renderable
-        depth-and/or-stencil format.
+    1. |this|.{{GPURenderPassDepthStencilAttachment/view}} must have a [=depth or stencil renderable
+        format=].
     1. |this|.{{GPURenderPassDepthStencilAttachment/view}} must be a view of a
         single [=texture subresource=].
     1. |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTexture/[[textureUsage]]}}
@@ -8328,6 +8333,9 @@ Only formats with {{GPUTextureSampleType}} {{GPUTextureSampleType/"float"}} can 
 
 The {{GPUTextureUsage/STORAGE|GPUTextureUsage.STORAGE}} column specifies the support for {{GPUTextureUsage/STORAGE}}
 usage in the core API, including both {{GPUStorageTextureAccess/"read-only"}} and {{GPUStorageTextureAccess/"write-only"}}.
+
+The {{GPUTextureUsage/STORAGE|GPUTextureUsage.RENDER_ATTACHMENT}} column specifies the support for
+{{GPUTextureUsage/RENDER_ATTACHMENT}} usage in the core API.
 
 <table class='data'>
     <thead class=stickyheader>


### PR DESCRIPTION
It defines renderable format, and color renderable format, and
depth or stencil renderable format as well.

It removes one issue that rgb9e5unorm cannot be used as a color
attachment because rgb9e5unorm is not color renderable. Any
format has a -snorm suffix or any compressed format cannot used
as a color attachment because all of them are not color
renderable. We have already added this validation rule in
`GPURenderPassColorAttachment Valid Usage`. We don't need to
have separate text in the spec for rgb9e5unorm particularly.

renderable format definition is also needed for texture creation.
If a format is not a renderable format, it will fail with its
sampleCount > 1, or when its usage include `RENDER_ATTACHMENT`.
The later validation rule also make rgb9e5unorm + color attachment
combination fail.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Richard-Yunchao/gpuweb/pull/1653.html" title="Last updated on Apr 22, 2021, 4:16 PM UTC (f0bd562)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1653/4aa7e32...Richard-Yunchao:f0bd562.html" title="Last updated on Apr 22, 2021, 4:16 PM UTC (f0bd562)">Diff</a>