### PR TITLE
Fix description of a variable's reference type

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2553,8 +2553,9 @@ particular storable type.
 
 Two types are associated with a variable: its [=store type=] (the type of value
 that may be placed in the referenced storage) and its [=reference type=] (the type
-of the variable itself).  If a variable has store type *T* and [=storage class=] *S*,
-then its reference type is pointer-to-*T*-in-*S*.
+of the variable itself).
+If a variable has store type *T* and [=storage class=] *S*,
+then its reference type is ref&lt;*S*,*T*&gt;.
 
 A <dfn dfn noexport>variable declaration</dfn>:
 
@@ -2562,6 +2563,11 @@ A <dfn dfn noexport>variable declaration</dfn>:
 * Ensures the execution environment allocates storage for a value of the store type, for the lifetime of the variable.
 * Optionally have an *initializer* expression, if the variable is in the [=storage classes/private=] or [=storage classes/function=] storage classes.
     If present, the initializer's type must match the store type of the variable.
+
+When an identifier use [=resolves=] to a variable declaration,
+the identifer is an expression denoting the reference [=memory view=] for the variable's storage,
+and its type is the variable's reference type.
+See [[#var-identifier-expr]].
 
 See [[#module-scope-variables]] and [[#function-scope-variables]] for rules about where
 a variable in a particular storage class can be declared,


### PR DESCRIPTION
It still had the old "there are only pointers" way of describing it.

Also add a statement in "var and let" about what a variable
identifier's use denotes.