### PR TITLE
Add sections on User Agent State for Privacy

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -455,6 +455,24 @@ WebGPU compute pipelines expose access to GPU unobstructed by the fixed-function
 This poses an additional risk for unique device fingerprinting. User agents can take steps
 to dissociate logical GPU invocations with actual compute units to reduce this risk.
 
+### User Agent State ### {#security-user-agent-state}
+
+This specification doesn't define any additional user-agent state for an origin.
+However it is expected that user agents will have compilation caches for the result of expensive
+compilation like {{GPUShaderModule}}, {{GPURenderPipeline}} and {{GPUComputePipeline}}.
+These caches are important to improve the loading time of WebGPU applications after the first
+visit.
+
+For the specification, these caches are indifferentiable from incredibly fast compilation, but
+for applications it would be easy to measure how long {{GPUDevice/createComputePipelineAsync()}}
+takes to resolve. This can leak information across origins (like "did the user access a site with
+this specific shader") so user agents should follow the best practices in
+[storage partitioning](https://github.com/privacycg/storage-partitioning).
+
+The system's GPU driver may also have its own cache of compiled shaders and pipelines. User agents
+may want to disable these when at all possible, or add per-partition data to shaders in ways that
+will make the GPU driver consider them different.
+
 # Fundamentals # {#fundamentals}
 
 ## Conventions ## {#api-conventions}


### PR DESCRIPTION
This is about shader caches potentially leaking cross-origin
information.

FYI @domenic


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/1656.html" title="Last updated on Apr 22, 2021, 9:09 AM UTC (0b73e43)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1656/40f3712...Kangz:0b73e43.html" title="Last updated on Apr 22, 2021, 9:09 AM UTC (0b73e43)">Diff</a>