### PR TITLE
[editorial] Remove vector short convenience names

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -717,13 +717,10 @@ For convenience, the type tables use the following shorthands:
 
 <table class='data'>
   <tr><td>*Scalar*<td>[=scalar=] types: one of bool, i32, u32, f32
-  <tr><td>*BoolVec*<td>[[#vector-types]] with bool component
   <tr><td>*Int*<td>i32 or u32
-  <tr><td>*IntVec*<td>[[#vector-types]] with an *Int* component
   <tr><td>*Integral*<td>*Int* or [[#vector-types]] with an *Int* component
   <tr><td>*SignedIntegral*<td>i32 or [[#vector-types]] with an i32 component
-  <tr><td>*FloatVec*<td>[[#vector-types]] with f32 component
-  <tr><td>*Floating*<td>f32 or *FloatVec*
+  <tr><td>*Floating*<td>f32 or [[#vector-types]] with an f32 component
   <tr><td>*Arity(T)*<td>number of components in [[#vector-types]] *T*
 </table>
 
@@ -3690,8 +3687,10 @@ Issue: Which index is used when it's out of bounds?
     Logical "or". Evaluates both `e1` and `e2`; yields `true` if either are `true`.
   <tr><td>*e1* : bool<br>*e2* : bool<td>`e1 & e2` : bool<td>
     Logical "and". Evaluates both `e1` and `e2`; yields `true` if both are `true`.
-  <tr><td>*e1* : *T*<br>*e2* : *T*<br>*T* is *BoolVec*<td>`e1 | e2` : *T*<td>Component-wise logical "or"
-  <tr><td>*e1* : *T*<br>*e2* : *T*<br>*T* is *BoolVec*<td>`e1 & e2` : *T*<td>Component-wise logical "and"
+  <tr><td>*e1* : *T*<br>*e2* : *T*<br>*T* is *vecN*&lt;bool&gt;
+    <td>`e1 | e2` : *T*<td>Component-wise logical "or"
+  <tr><td>*e1* : *T*<br>*e2* : *T*<br>*T* is *vecN*&lt;bool&gt;
+    <td>`e1 & e2` : *T*<td>Component-wise logical "and"
 </table>
 
 
@@ -3733,18 +3732,30 @@ Issue: Which index is used when it's out of bounds?
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
-  <tr><td>*e1* : *T*<br> *e2* : *T*<br> *T* is *IntVec*<td class="nowrap">`e1 + e2` : *T*<td>Component-wise integer addition (OpIAdd)
-  <tr><td>*e1* : *T*<br> *e2* : *T*<br> *T* is *FloatVec*<td class="nowrap">`e1 + e2` : *T*<td>Component-wise floating point addition (OpIAdd)
-  <tr><td>*e1* : *T*<br> *e2* : *T*<br> *T* is *IntVec*<td class="nowrap">`e1 - e2` : *T*<td>Component-wise integer subtraction (OpISub)
-  <tr><td>*e1* : *T*<br> *e2* : *T*<br> *T* is *FloatVec*<td>`e1 - e2` : *T*<td>Component-wise floating point subtraction (OpISub)
-  <tr><td>*e1* : *T*<br> *e2* : *T*<br> *T* is *IntVec*<td>`e1 * e2` : *T*<td>Component-wise integer multiplication (OpIMul)
-  <tr><td>*e1* : *T*<br> *e2* : *T*<br> *T* is *FloatVec*<td>`e1 * e2` : *T*<td>Component-wise floating point multiplication (OpIMul)
-  <tr><td>*e1* : *T*<br> *e2* : *T*<br> *T* is *IntVec* with unsigned component<td>`e1 / e2` : *T*<td>Component-wise unsigned integer division (OpUDiv)
-  <tr><td>*e1* : *T*<br> *e2* : *T*<br> *T* is *IntVec* with signed component<td>`e1 / e2` : *T*<td>Component-wise signed integer division (OpSDiv)
-  <tr><td>*e1* : *T*<br> *e2* : *T*<br> *T* is *FloatVec*<td>`e1 / e2` : *T*<td>Component-wise floating point division (OpFDiv)
-  <tr><td>*e1* : *T*<br> *e2* : *T*<br> *T* is *IntVec* with unsigned component<td>`e1 % e2` : *T*<td>Component-wise unsigned integer modulus (OpUMod)
-  <tr><td>*e1* : *T*<br> *e2* : *T*<br> *T* is *IntVec* with signed component<td>`e1 % e2` : *T*<td>Component-wise signed integer remainder (OpSMod)
-  <tr><td>*e1* : *T*<br> *e2* : *T*<br> *T* is *FloatVec*<td>`e1 % e2` : *T*<td>Component-wise floating point modulus (OpFMod)
+  <tr><td>*e1* : *T*<br> *e2* : *T*<br> *T* is *vecN*&lt;*Int*&gt;
+    <td class="nowrap">`e1 + e2` : *T*<td>Component-wise integer addition (OpIAdd)
+  <tr><td>*e1* : *T*<br> *e2* : *T*<br> *T* is *vecN*&lt;f32&gt;
+    <td class="nowrap">`e1 + e2` : *T*<td>Component-wise floating point addition (OpIAdd)
+  <tr><td>*e1* : *T*<br> *e2* : *T*<br> *T* is *vecN*&lt;*Int*&gt;
+    <td class="nowrap">`e1 - e2` : *T*<td>Component-wise integer subtraction (OpISub)
+  <tr><td>*e1* : *T*<br> *e2* : *T*<br> *T* is *vecN*&lt;f32&gt;
+    <td>`e1 - e2` : *T*<td>Component-wise floating point subtraction (OpISub)
+  <tr><td>*e1* : *T*<br> *e2* : *T*<br> *T* is *vecN*&lt;*Int*&gt;
+    <td>`e1 * e2` : *T*<td>Component-wise integer multiplication (OpIMul)
+  <tr><td>*e1* : *T*<br> *e2* : *T*<br> *T* is *vecN*&lt;f32&gt;
+    <td>`e1 * e2` : *T*<td>Component-wise floating point multiplication (OpIMul)
+  <tr><td>*e1* : *T*<br> *e2* : *T*<br> *T* is *vecN*&lt;u32&gt;
+    <td>`e1 / e2` : *T*<td>Component-wise unsigned integer division (OpUDiv)
+  <tr><td>*e1* : *T*<br> *e2* : *T*<br> *T* is *vecN*&lt;i32&gt;
+    <td>`e1 / e2` : *T*<td>Component-wise signed integer division (OpSDiv)
+  <tr><td>*e1* : *T*<br> *e2* : *T*<br> *T* is *vecN*&lt;f32&gt;
+    <td>`e1 / e2` : *T*<td>Component-wise floating point division (OpFDiv)
+  <tr><td>*e1* : *T*<br> *e2* : *T*<br> *T* is *vecN*&lt;u32&gt;
+    <td>`e1 % e2` : *T*<td>Component-wise unsigned integer modulus (OpUMod)
+  <tr><td>*e1* : *T*<br> *e2* : *T*<br> *T* is *vecN*&lt;i32&gt;
+    <td>`e1 % e2` : *T*<td>Component-wise signed integer remainder (OpSMod)
+  <tr><td>*e1* : *T*<br> *e2* : *T*<br> *T* is *vecN*&lt;f32&gt;
+    <td>`e1 % e2` : *T*<td>Component-wise floating point modulus (OpFMod)
 </table>
 
 
@@ -6197,8 +6208,8 @@ That's not a full user-defined function declaration.
   <thead>
     <tr><th>Logical built-in functions<td>SPIR-V
   </thead>
-  <tr><td>all(BoolVec) -&gt; bool<td>OpAll
-  <tr><td>any(BoolVec) -&gt; bool<td>OpAny
+  <tr><td>all(*vecN*&lt;bool&gt;) -&gt; bool<td>OpAll
+  <tr><td>any(*vecN*&lt;bool&gt;) -&gt; bool<td>OpAny
   <tr><td>select(*T*,*T*,bool) -&gt; *T*<td>
        For scalar or vector type *T*.
        `select(a,b,c)` evaluates to *a* when *c* is true, and *b* otherwise.<br>
@@ -6219,25 +6230,25 @@ That's not a full user-defined function declaration.
     <td>|e| : f32<td>`isNan(`|e|`)` : bool
     <td>Returns true if |e| is NaN according to IEEE. (OpIsNan)
   <tr algorithm="vector case, test for NaN">
-    <td>|e| : |T|, |T| is *FloatVec*
+    <td>|e| : |T|, |T| is *vecN*&lt;f32&gt;
     <td>`isNan(`|e|`)` : vec|N|&lt;bool&gt;, where |N| = *Arity(*|T|*)*<td>Component-wise test for NaN. Component *i* of the result is *isNan(e[i])*. (OpIsNan)
   <tr algorithm="scalar case, test for infinity">
     <td>|e| : f32<td>`isInf(`|e|`)` : bool
     <td>Returns true if |e| is an infinity according to IEEE. (OpIsInf)
   <tr algorithm="vector case, test for infinity">
-    <td>|e| : |T|, |T| is *FloatVec*
+    <td>|e| : |T|, |T| is *vecN*&lt;f32&gt;
     <td>`isInf(`|e|`)` : vec|N|&lt;bool&gt;, where |N| = *Arity(*|T|*)*<td>Component-wise test for inifinity. Component *i* of the result is *isInf(e[i])*. (OpIsInf)
   <tr algorithm="scalar case, test value is finite">
     <td>|e| : f32<td>`isFinite(`|e|`)` : bool
     <td>Returns true if |e| is finite according to IEEE. (emulated)
   <tr algorithm="vector case, test value is finite">
-    <td>|e| : |T|, |T| is *FloatVec*
+    <td>|e| : |T|, |T| is *vecN*&lt;f32&gt;
     <td>`isFinite(`|e|`)` : vec|N|&lt;bool&gt;, where |N| = *Arity(*|T|*)*<td>Component-wise finite value test. Component *i* of the result is *isFinite(e[i])*. (emulated)
   <tr algorithm="scalar case, test value is normal">
     <td>|e| : f32<td>`isNormal(`|e|`)` : bool
     <td>Returns true if |e| is a normal number according to IEEE. (emulated)
   <tr algorithm="vector case, test value is normal">
-    <td>|e| : |T|, |T| is *FloatVec*
+    <td>|e| : |T|, |T| is *vecN*&lt;f32&gt;
     <td>`isNormal(`|e|`)` : vec|N|&lt;bool&gt;, where |N| = *Arity(*|T|*)*<td>Component-wise test for normal number. Component *i* of the result is *isNormal(e[i])*. (emulated)
   <tr algorithm="runtime array length">
     <td>|e| : ptr&lt;storage,array&lt;|T|&gt;&gt;


### PR DESCRIPTION
* Remove FloatVec, IntVec and BoolVec from the spec as they are
  unnecessary
  * replace uses with appropriate vecN<T>