### PR TITLE
Add spec for texture creation

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2211,9 +2211,9 @@ interface GPUTextureUsage {
 
             1. Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
-                    1. If |descriptor|.{{GPUTextureDescriptor/format}} is a {{GPUTextureFormat}} that requires a feature,
-                        but |this|.{{GPUDevice/[[device]]}}.{{device/[[features]]}} does not [=list/contain=] the feature,
-                        throw a {{TypeError}}.
+                    1. If |descriptor|.{{GPUTextureDescriptor/format}} is a {{GPUTextureFormat}} that requires a feature (also see
+                        [[#texture-format-caps]]),but |this|.{{GPUDevice/[[device]]}}.{{device/[[features]]}} does not
+                        [=list/contain=] the feature, throw a {{TypeError}}.
                     1. If any of the following requirements are unmet:
                         <div class=validusage>
                             - |this| must be a [=valid=] {{GPUDevice}}.
@@ -8490,8 +8490,6 @@ The following enums are supported if and only if the {{GPUFeatureName/"timestamp
 # Appendices # {#appendices}
 
 ## Texture Format Capabilities ## {#texture-format-caps}
-
-Issue: Add multisampling to the tables below.
 
 ### Plain color formats ### {#plain-color-formats}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2255,7 +2255,7 @@ interface GPUTextureUsage {
                                     :: |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
                                     :: |descriptor|.{{GPUTextureDescriptor/format}} must not be a compressed format or depth/stencil format.
                                 </dl>
-                            - If |descriptor|.{{GPUTextureDescriptor/sampleCount}} > 1 (|descriptor|.{{GPUTextureDescriptor/sampleCount}} is 4):
+                            - If |descriptor|.{{GPUTextureDescriptor/sampleCount}} > 1:
                                 - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be 1.
                                 - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be 1.
                                 - |descriptor|.{{GPUTextureDescriptor/usage}} must not include the {{GPUTextureUsage/STORAGE}} bit.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2229,9 +2229,10 @@ interface GPUTextureUsage {
                             - If |descriptor|.{{GPUTextureDescriptor/dimension}} is:
                                 <dl class="switch">
                                     : {{GPUTextureDimension/"1d"}}
-                                    :: |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be less than or equal to
-                                        |this|.{{GPUAdapterLimits/maxTextureDimension1D}}.
-                                    :: |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be 1.
+                                    ::
+                                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be less than or equal to
+                                            |this|.{{GPUAdapterLimits/maxTextureDimension1D}}.
+                                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be 1.
                                     :: |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be 1.
                                     :: |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
                                     :: |descriptor|.{{GPUTextureDescriptor/format}} must not be a compressed format or depth/stencil format.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2079,6 +2079,10 @@ Issue: define <dfn dfn>mipmap level</dfn>, <dfn dfn>array layer</dfn>, <dfn dfn>
 
 ## <dfn interface>GPUTexture</dfn> ## {#texture-interface}
 
+{{GPUTexture|GPUTextures}} are created via
+{{GPUDevice/createTexture(descriptor)|GPUDevice.createTexture(descriptor)}}
+that returns a new texture.
+
 <script type=idl>
 [Exposed=Window, Serializable]
 interface GPUTexture {
@@ -2169,6 +2173,34 @@ interface GPUTextureUsage {
 };
 </script>
 
+<div algorithm>
+    <dfn abstract-op>maximum mipLevel count</dfn>(dimension, size)
+    **Arguments:**
+        - {{GPUTextureDescriptor/dimension}} |dimension|
+        - {{GPUTextureDescriptor/size}} |size|
+
+    1. Calculate the values of |w|, |h|, and |d|:
+        - If |dimension| is:
+            <dl class="switch">
+                : {{GPUTextureDimension/"1d"}}
+                :: Let |w| = |size|.[=Extent3D/width=].
+                :: Let |h| = 1.
+                :: Let |d| = 1.
+
+                : {{GPUTextureDimension/"2d"}}
+                :: Let |w| = |size|.[=Extent3D/width=].
+                :: Let |h| = |size|.[=Extent3D/height=].
+                :: Let |d| = 1.
+
+                : {{GPUTextureDimension/"3d"}}
+                :: Let |w| = |size|.[=Extent3D/width=].
+                :: Let |h| = |size|.[=Extent3D/height=].
+                :: Let |d| = |size|.[=Extent3D/depthOrArrayLayer=].
+            </dl>
+    1. Let |m| = the maximum value of |w|, |h|, and |d|.
+    1. Return one plus the greatest integral value of |x| for which 2<sup>|x|</sup> < |m|.
+</div>
+
 <dl dfn-type=method dfn-for=GPUDevice>
     : <dfn>createTexture(descriptor)</dfn>
     ::
@@ -2179,12 +2211,83 @@ interface GPUTextureUsage {
 
             **Arguments:**
             <pre class=argumentdef for="GPUDevice/createTexture(descriptor)">
-                descriptor: Description of the {{GPUTexture}} to create.
+                |descriptor|: Description of the {{GPUTexture}} to create.
             </pre>
 
             **Returns:** {{GPUTexture}}
 
-            Issue: Describe {{GPUDevice/createTexture()}} algorithm steps.
+            1. Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
+                    1. If any of the following requirements are unmet:
+                        <div class=validusage>
+                            - |this| must be a [=valid=] {{GPUDevice}}.
+                            - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=],
+                                |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=],
+                                and |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be greater than zero.
+                            - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be greater than zero.
+                            - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be either 1 or 4.
+                            - If |descriptor|.{{GPUTextureDescriptor/dimension}} is:
+                                <dl class="switch">
+                                    : {{GPUTextureDimension/"1d"}}
+                                    :: |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be less than or equal to
+                                        |this|.{{GPUAdapterLimits/maxTextureDimension1D}}.
+                                    :: |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be 1.
+                                    :: |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be 1.
+                                    :: |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
+                                    :: |descriptor|.{{GPUTextureDescriptor/format}} must not be a compressed format or depth/stencil format.
+
+                                    : {{GPUTextureDimension/"2d"}}
+                                    :: |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be less than or equal to
+                                        |this|.{{GPUAdapterLimits/maxTextureDimension2D}}.
+                                    :: |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be less than or equal to
+                                        |this|.{{GPUAdapterLimits/maxTextureDimension2D}}.
+                                    :: |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be less than
+                                        or equal to |this|.{{GPUAdapterLimits/maxTextureArrayLayers}}.
+
+                                    : {{GPUTextureDimension/"3d"}}
+                                    :: |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be less than or equal to
+                                        |this|.{{GPUAdapterLimits/maxTextureDimension3D}}.
+                                    :: |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be less than or equal to
+                                        |this|.{{GPUAdapterLimits/maxTextureDimension3D}}.
+                                    :: |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be less than
+                                        or equal to |this|.{{GPUAdapterLimits/maxTextureDimension3D}}.
+                                    :: |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
+                                    :: |descriptor|.{{GPUTextureDescriptor/format}} must not be a compressed format or depth/stencil format.
+                                </dl>
+                            - If |descriptor|.{{GPUTextureDescriptor/sampleCount}} > 1 (|descriptor|.{{GPUTextureDescriptor/sampleCount}} is 4):
+                                - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be 1.
+                                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be 1.
+                                - |descriptor|.{{GPUTextureDescriptor/usage}} must not include the {{GPUTextureUsage/STORAGE}} bit.
+                                - |descriptor|.{{GPUTextureDescriptor/format}} must be a [=renderable format=].
+                            - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be less than or equal to
+                                [$maximum mipLevel count$](|descriptor|.{{GPUTextureDescriptor/dimension}}, |descriptor|.{{GPUTextureDescriptor/size}}).
+                            - |descriptor|.{{GPUTextureDescriptor/usage}} must be a combination of {{GPUTextureUsage}} values.
+                            - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/RENDER_ATTACHMENT}} bit,
+                                |descriptor|.{{GPUTextureDescriptor/format}} must be a [=renderable format=].
+                            - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/STORAGE}} bit,
+                                |descriptor|.{{GPUTextureDescriptor/format}} must be listed in [[#plain-color-formats]] table
+                                with {{GPUTextureUsage/STORAGE}} capability.
+                            - Some |descriptor|.{{GPUTextureDescriptor/format}}s require [=feature=]s when creating a {{GPUDevice}}:
+                                - {{GPUTextureFormat/"depth24unorm-stencil8"}} requires [[#depth24unorm-stencil8]].
+                                - {{GPUTextureFormat/"depth32float-stencil8"}} requires [[#depth32float-stencil8]].
+                                - BC compressed format requires [[#texture-compression-bc]].
+                            - If |descriptor|.{{GPUTextureDescriptor/format}} is a compressed format:
+                                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be multiple of [=texel block width=].
+                                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be multiple of [=texel block height=].
+                        </div>
+
+                        Then:
+                            1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
+                            1. Return a new [=invalid=] {{GPUTexture}}.
+
+                    1. Let |t| be a new {{GPUTexture}} object.
+                    1. Set |t|.{{GPUTexture/[[textureSize]]}} to |descriptor|.{{GPUTextureDescriptor/size}}.
+                    1. Set |t|.{{GPUTexture/[[sampleCount]]}} to |descriptor|.{{GPUTextureDescriptor/sampleCount}}.
+                    1. Set |t|.{{GPUTexture/[[dimension]]}} to |descriptor|.{{GPUTextureDescriptor/dimension}}.
+                    1. Set |t|.{{GPUTexture/[[format]]}} to |descriptor|.{{GPUTextureDescriptor/format}}.
+                    1. Set |t|.{{GPUTexture/[[textureUsage]]}} to |descriptor|.{{GPUTextureDescriptor/usage}}.
+                    1. Return |t|.
+                </div>
         </div>
 </dl>
 
@@ -2541,7 +2644,7 @@ note that the set of representable values is not exactly the same:
 for depth24unorm, 1 ULP has a constant value of 1 / (2<sup>24</sup> &minus; 1);
 for depth32float, 1 ULP has a variable value no greater than 1 / (2<sup>24</sup>).
 
-A renderable format is either <dfn>color renderable format</dfn>, or <dfn>depth or stencil renderable format</dfn>.
+A <dfn>renderable format</dfn> is either <dfn>color renderable format</dfn>, or <dfn>depth or stencil renderable format</dfn>.
 If a format is listed in [[#plain-color-formats]] with {{GPUTextureUsage/RENDER_ATTACHMENT}} capability, it is a
 color renderable format. Any other format is not a color renderable format. Any depth/stencil format is a
 depth or stencil renderable format. Any other format is not a depth or stencil renderable format.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2211,8 +2211,8 @@ interface GPUTextureUsage {
 
             1. Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
-                    1. If |descriptor|.{{GPUTextureDescriptor/format}} is a {{GPUTextureFormat}} that requires a feature (also see
-                        [[#texture-format-caps]]),but |this|.{{GPUDevice/[[device]]}}.{{device/[[features]]}} does not
+                    1. If |descriptor|.{{GPUTextureDescriptor/format}} is a {{GPUTextureFormat}} that requires a feature (see
+                        [[#texture-format-caps]]), but |this|.{{GPUDevice/[[device]]}}.{{device/[[features]]}} does not
                         [=list/contain=] the feature, throw a {{TypeError}}.
                     1. If any of the following requirements are unmet:
                         <div class=validusage>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2179,26 +2179,19 @@ interface GPUTextureUsage {
         - {{GPUTextureDescriptor/dimension}} |dimension|
         - {{GPUTextureDescriptor/size}} |size|
 
-    1. Calculate the values of |w|, |h|, and |d|:
+    1. Calculate the max dimension value |m|:
         - If |dimension| is:
             <dl class="switch">
                 : {{GPUTextureDimension/"1d"}}
-                :: Let |w| = |size|.[=Extent3D/width=].
-                :: Let |h| = 1.
-                :: Let |d| = 1.
+                :: Let |m| = |size|.[=Extent3D/width=].
 
                 : {{GPUTextureDimension/"2d"}}
-                :: Let |w| = |size|.[=Extent3D/width=].
-                :: Let |h| = |size|.[=Extent3D/height=].
-                :: Let |d| = 1.
+                :: Let |m| = max(|size|.[=Extent3D/width=], |size|.[=Extent3D/height=]).
 
                 : {{GPUTextureDimension/"3d"}}
-                :: Let |w| = |size|.[=Extent3D/width=].
-                :: Let |h| = |size|.[=Extent3D/height=].
-                :: Let |d| = |size|.[=Extent3D/depthOrArrayLayer=].
+                :: Let |m| = max(max(|size|.[=Extent3D/width=], |size|.[=Extent3D/height=]), |size|.[=Extent3D/depthOrArrayLayer=]).
             </dl>
-    1. Let |m| = the maximum value of |w|, |h|, and |d|.
-    1. Return one plus the greatest integral value of |x| for which 2<sup>|x|</sup> < |m|.
+    1. Return floor(log<sub>2</sub>(|m|)) + 1.
 </div>
 
 <dl dfn-type=method dfn-for=GPUDevice>
@@ -2218,6 +2211,9 @@ interface GPUTextureUsage {
 
             1. Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
+                    1. If |descriptor|.{{GPUTextureDescriptor/format}} is a {{GPUTextureFormat}} that requires a feature,
+                        but |this|.{{GPUDevice/[[device]]}}.{{device/[[features]]}} does not [=list/contain=] the feature,
+                        throw a {{TypeError}}.
                     1. If any of the following requirements are unmet:
                         <div class=validusage>
                             - |this| must be a [=valid=] {{GPUDevice}}.
@@ -2226,6 +2222,7 @@ interface GPUTextureUsage {
                                 and |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be greater than zero.
                             - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be greater than zero.
                             - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be either 1 or 4.
+
                             - If |descriptor|.{{GPUTextureDescriptor/dimension}} is:
                                 <dl class="switch">
                                     : {{GPUTextureDimension/"1d"}}
@@ -2233,48 +2230,48 @@ interface GPUTextureUsage {
                                         - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be less than or equal to
                                             |this|.{{GPUAdapterLimits/maxTextureDimension1D}}.
                                         - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be 1.
-                                    :: |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be 1.
-                                    :: |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
-                                    :: |descriptor|.{{GPUTextureDescriptor/format}} must not be a compressed format or depth/stencil format.
+                                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be 1.
+                                        - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
+                                        - |descriptor|.{{GPUTextureDescriptor/format}} must not be a compressed format or depth/stencil format.
 
                                     : {{GPUTextureDimension/"2d"}}
-                                    :: |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be less than or equal to
-                                        |this|.{{GPUAdapterLimits/maxTextureDimension2D}}.
-                                    :: |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be less than or equal to
-                                        |this|.{{GPUAdapterLimits/maxTextureDimension2D}}.
-                                    :: |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be less than
-                                        or equal to |this|.{{GPUAdapterLimits/maxTextureArrayLayers}}.
+                                    ::
+                                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be less than or equal to
+                                            |this|.{{GPUAdapterLimits/maxTextureDimension2D}}.
+                                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be less than or equal to
+                                            |this|.{{GPUAdapterLimits/maxTextureDimension2D}}.
+                                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be less than
+                                            or equal to |this|.{{GPUAdapterLimits/maxTextureArrayLayers}}.
 
                                     : {{GPUTextureDimension/"3d"}}
-                                    :: |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be less than or equal to
-                                        |this|.{{GPUAdapterLimits/maxTextureDimension3D}}.
-                                    :: |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be less than or equal to
-                                        |this|.{{GPUAdapterLimits/maxTextureDimension3D}}.
-                                    :: |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be less than
-                                        or equal to |this|.{{GPUAdapterLimits/maxTextureDimension3D}}.
-                                    :: |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
-                                    :: |descriptor|.{{GPUTextureDescriptor/format}} must not be a compressed format or depth/stencil format.
+                                    ::
+                                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be less than or equal to
+                                            |this|.{{GPUAdapterLimits/maxTextureDimension3D}}.
+                                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be less than or equal to
+                                            |this|.{{GPUAdapterLimits/maxTextureDimension3D}}.
+                                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be less than
+                                            or equal to |this|.{{GPUAdapterLimits/maxTextureDimension3D}}.
+                                        - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
+                                        - |descriptor|.{{GPUTextureDescriptor/format}} must not be a compressed format or depth/stencil format.
                                 </dl>
+                            - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be multiple of [=texel block width=].
+                            - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be multiple of [=texel block height=].
+
                             - If |descriptor|.{{GPUTextureDescriptor/sampleCount}} > 1:
                                 - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be 1.
                                 - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be 1.
                                 - |descriptor|.{{GPUTextureDescriptor/usage}} must not include the {{GPUTextureUsage/STORAGE}} bit.
                                 - |descriptor|.{{GPUTextureDescriptor/format}} must be a [=renderable format=].
+
                             - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be less than or equal to
                                 [$maximum mipLevel count$](|descriptor|.{{GPUTextureDescriptor/dimension}}, |descriptor|.{{GPUTextureDescriptor/size}}).
+
                             - |descriptor|.{{GPUTextureDescriptor/usage}} must be a combination of {{GPUTextureUsage}} values.
                             - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/RENDER_ATTACHMENT}} bit,
                                 |descriptor|.{{GPUTextureDescriptor/format}} must be a [=renderable format=].
                             - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/STORAGE}} bit,
                                 |descriptor|.{{GPUTextureDescriptor/format}} must be listed in [[#plain-color-formats]] table
                                 with {{GPUTextureUsage/STORAGE}} capability.
-                            - Some |descriptor|.{{GPUTextureDescriptor/format}}s require [=feature=]s when creating a {{GPUDevice}}:
-                                - {{GPUTextureFormat/"depth24unorm-stencil8"}} requires [[#depth24unorm-stencil8]].
-                                - {{GPUTextureFormat/"depth32float-stencil8"}} requires [[#depth32float-stencil8]].
-                                - BC compressed format requires [[#texture-compression-bc]].
-                            - If |descriptor|.{{GPUTextureDescriptor/format}} is a compressed format:
-                                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be multiple of [=texel block width=].
-                                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be multiple of [=texel block height=].
                         </div>
 
                         Then:


### PR DESCRIPTION
This PR adds validation rules for texture creation. It is based on:
 - PR 799 (https://github.com/gpuweb/gpuweb/pull/799) from Myles,
   and the comments.
 - Issue 1522 (https://github.com/gpuweb/gpuweb/issues/1522) I
   investigated when I was implementing 3D textures on Dawn project,
   and the comments.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Richard-Yunchao/gpuweb/pull/1658.html" title="Last updated on Apr 27, 2021, 5:51 PM UTC (c65e8cf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1658/ae42b6b...Richard-Yunchao:c65e8cf.html" title="Last updated on Apr 27, 2021, 5:51 PM UTC (c65e8cf)">Diff</a>