### PR TITLE
Make GPUSupportedFeatures `setlike<DOMString>`

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1206,14 +1206,17 @@ interface GPUAdapterLimits {
 
 #### <dfn interface>GPUSupportedFeatures</dfn> #### {#gpu-supportedfeatures}
 
-{{GPUSupportedFeatures}} is a [=setlike=] interface. Its [=set entries=] are
-the {{GPUFeatureName}} values of the [=features=] supported by an adapter or
-device.
+{{GPUSupportedFeatures}} is a [=setlike=] interface.
+Its [=set entries=] are the {{GPUFeatureName}} values of the [=features=]
+supported by an adapter or device.
+
+The interface allows querying (`.has()`) any string, for portability between
+implementations that understand different sets of {{GPUFeatureName}} values.
 
 <script type=idl>
 [Exposed=Window]
 interface GPUSupportedFeatures {
-    readonly setlike<GPUFeatureName>;
+    readonly setlike<DOMString>;
 };
 </script>
 


### PR DESCRIPTION
Turns out this was making `.has('unknownfeaturename')` throw an exception, which is not desired.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1659.html" title="Last updated on Apr 22, 2021, 5:41 PM UTC (84f779b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1659/6cd1913...kainino0x:84f779b.html" title="Last updated on Apr 22, 2021, 5:41 PM UTC (84f779b)">Diff</a>