### PR TITLE
Adding workload simulator as a sample.

### DIFF
--- a/samples/workload-simulator.html
+++ b/samples/workload-simulator.html
@@ -597,7 +597,10 @@ async function render(fromRaf, fromPostMessage) {
             features: Array.from(adapter.features || []).slice().sort(),
             limits: adapter.limits
           }, 0, 2);
-        device = await adapter.requestDevice({nonGuaranteedFeatures:['timestamp-query']});
+        const useTimestampQueries = adapter.features.has('timestamp-query');
+        device = await adapter.requestDevice({
+          nonGuaranteedFeatures: useTimestampQueries ? ['timestamp-query'] : [],
+        });
         device.addEventListener('uncapturederror', (e)=>{
           console.log(e);
           if (!errorMessage.textContent) errorMessage.textContent = 'Uncaptured error: ' + e.error.message;
@@ -717,7 +720,7 @@ async function render(fromRaf, fromPostMessage) {
             { binding: 2, resource: texture.createView() },
           ],
         });
-        if (device.createQuerySet) {
+        if (useTimestampQueries && device.createQuerySet) {
           querySet = device.createQuerySet({type: 'timestamp', count: 2});
           queryResolveBuffer = device.createBuffer({
             size: 16,
@@ -745,7 +748,7 @@ async function render(fromRaf, fromPostMessage) {
 
       // Start off by writing a timestamp for the beginning of the frame.
       const timestampEncoder = device.createCommandEncoder();
-      if (timestampEncoder.writeTimestamp) timestampEncoder.writeTimestamp(querySet, 0);
+      if (querySet) timestampEncoder.writeTimestamp(querySet, 0);
       device.queue.submit([timestampEncoder.finish()]);
 
       // Upload data using createBuffer with mappedAtCreation.
@@ -898,7 +901,7 @@ async function render(fromRaf, fromPostMessage) {
       passEncoder.endPass();
       if (buffer) buffer.destroy();
       let queryBuffer;
-      if (commandEncoder.writeTimestamp) {
+      if (querySet) {
         // Timestamp for the end of the frame.
         commandEncoder.writeTimestamp(querySet, 1);
         // We create a queue of staging buffers to hold the timestamps while we
@@ -917,7 +920,7 @@ async function render(fromRaf, fromPostMessage) {
       }
       commandBuffers.push(commandEncoder.finish());
       device.queue.submit(commandBuffers);
-      if (commandEncoder.writeTimestamp) {
+      if (querySet) {
         // Once the staging buffer is mapped we can finally calculate the frame duration
         // and put the staging buffer back into the queue.
         queryBuffer.mapAsync(GPUMapMode.READ).then(()=>{

--- a/samples/workload-simulator.html
+++ b/samples/workload-simulator.html
@@ -418,6 +418,14 @@ let renderBundle;
 let renderBundleAfterScissor;
 let renderBundleNumDrawCalls;
 let renderBundleInstances;
+let querySet;
+let queryBuffers = [];
+let queryResolveBuffer;
+let mapAsyncArray = new Float32Array(0);
+let mapAsyncTargetBuffer;
+let mapAsyncBufferSize = 0;
+let mapAsyncReady = [];
+let mapAsyncBuffersOutstanding = 0;
 const swapChainFormat = 'bgra8unorm';
 
 let bitmapRenderer;
@@ -434,16 +442,14 @@ const vertices = [0, 0, 1, 0, 0, 1, 1, 1];
 const readPixelsArray = new Uint8Array(4);
 let bufferDataArray = new Float32Array(0);
 let bufferSubDataArray = new Float32Array(0);
-let mapAsyncArray = new Float32Array(0);
-let mapAsyncBuffer;
-let mapAsyncBufferSize = 0;
-let mapAsyncReady = [];
-let mapAsyncBuffersOutstanding = 0;
+
 let interval;
 let intervalFps;
 let timeout = null;
 let rafPending = 0;
 let postMessagePending = 0;
+let timeQueryResultsMs = [];
+let lastTimeQueryTime = 0;
 
 const animationDirection = [1, 1];
 async function render(fromRaf, fromPostMessage) {
@@ -591,8 +597,11 @@ async function render(fromRaf, fromPostMessage) {
             features: Array.from(adapter.features || []).slice().sort(),
             limits: adapter.limits
           }, 0, 2);
-        device = await adapter.requestDevice();
-        device.addEventListener('uncapturederror', (e)=>errorMessage.textContent = 'Uncaptured error: ' + e.error.message);
+        device = await adapter.requestDevice({nonGuaranteedFeatures:['timestamp-query']});
+        device.addEventListener('uncapturederror', (e)=>{
+          console.log(e);
+          if (!errorMessage.textContent) errorMessage.textContent = 'Uncaptured error: ' + e.error.message;
+        });
         gpuPresent = webGPUCanvas.getContext('gpupresent');
         swapChain = gpuPresent.configureSwapChain({device, format: swapChainFormat});
         const bindGroupLayout = device.createBindGroupLayout({
@@ -651,7 +660,7 @@ async function render(fromRaf, fromPostMessage) {
           };
           
           [[stage(vertex)]]
-          fn vs([[builtin(vertex_index)]] VertexIndex : i32) -> Output {
+          fn vs([[builtin(vertex_index)]] VertexIndex : u32) -> Output {
             var output : Output;
             output.Position = vec4<f32>(pos[VertexIndex] / vec2<f32>(2.,2.) + uniforms.xy, 0.0, 1.0);
             output.uv = pos[VertexIndex] / vec2<f32>(2., -2.) + vec2<f32>(.5, .5);
@@ -661,7 +670,9 @@ async function render(fromRaf, fromPostMessage) {
           [[stage(fragment)]]
           fn fs([[location(0)]] uv: vec2<f32>) -> [[location(0)]] vec4<f32> {
             return textureSample(texture1, sampler1, uv);
-          }`, });
+          }
+          `, });
+
         if (shaderModule.compilationInfo)
           shaderModule.compilationInfo().then((e)=>console.log(e));
         pipeline = device.createRenderPipeline({
@@ -706,8 +717,15 @@ async function render(fromRaf, fromPostMessage) {
             { binding: 2, resource: texture.createView() },
           ],
         });
+        if (device.createQuerySet) {
+          querySet = device.createQuerySet({type: 'timestamp', count: 2});
+          queryResolveBuffer = device.createBuffer({
+            size: 16,
+            usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.COPY_SRC,
+          });
+        }
       } catch(e) {
-        errorMessage.textContent = "Error initializing WebGPU: " + e;
+        if (!errorMessage.textContent) errorMessage.textContent = "Error initializing WebGPU: " + e;
         return;
       }
     }
@@ -716,7 +734,7 @@ async function render(fromRaf, fromPostMessage) {
     // Begin WebGPU rendering.
 
     if (!device) {
-      errorMessage.textContent = "Error: WebGPU not supported.";
+      if (!errorMessage.textContent) errorMessage.textContent = "Error: WebGPU not supported.";
       return;
     }
     try {
@@ -724,6 +742,11 @@ async function render(fromRaf, fromPostMessage) {
       const commandBuffers = [];
       device.queue.writeBuffer(uniformBuffer, 0, new Float32Array([position[0]/size*2 - 0.5, -position[1]*2/size + 0.5]));
       let buffer = null;
+
+      // Start off by writing a timestamp for the beginning of the frame.
+      const timestampEncoder = device.createCommandEncoder();
+      if (timestampEncoder.writeTimestamp) timestampEncoder.writeTimestamp(querySet, 0);
+      device.queue.submit([timestampEncoder.finish()]);
 
       // Upload data using createBuffer with mappedAtCreation.
       if (bufferData.value > 0) {
@@ -743,6 +766,7 @@ async function render(fromRaf, fromPostMessage) {
             usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
           });
         }
+        // TODO: Use the uploaded data during rendering.
         device.queue.writeBuffer(uploadBuffer, 0, bufferSubDataArray);
       }
 
@@ -750,8 +774,8 @@ async function render(fromRaf, fromPostMessage) {
       if (mapAsyncArray.length > 0) {
         if (mapAsyncBufferSize != mapAsyncArray.byteLength) {
           mapAsyncBufferSize = mapAsyncArray.byteLength;
-          if (mapAsyncBuffer) mapAsyncBuffer.destroy();
-          mapAsyncBuffer = device.createBuffer({size: mapAsyncArray.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST});
+          if (mapAsyncTargetBuffer) mapAsyncTargetBuffer.destroy();
+          mapAsyncTargetBuffer = device.createBuffer({size: mapAsyncArray.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST});
         }
         let buffer = null;
         while (mapAsyncReady.length) {
@@ -778,7 +802,7 @@ async function render(fromRaf, fromPostMessage) {
         new Float32Array(buffer.getMappedRange()).set(mapAsyncArray);
         buffer.unmap();
         const commandEncoder = device.createCommandEncoder();
-        commandEncoder.copyBufferToBuffer(buffer, 0, mapAsyncBuffer, 0, mapAsyncArray.byteLength);
+        commandEncoder.copyBufferToBuffer(buffer, 0, mapAsyncTargetBuffer, 0, mapAsyncArray.byteLength);
         // TODO: combine this submit with the main one, but we'll have to delay calling mapAsync until after the submit.
         device.queue.submit([commandEncoder.finish()]);
         // TODO: use this data during rendering.
@@ -793,7 +817,6 @@ async function render(fromRaf, fromPostMessage) {
       }
       const passEncoder = commandEncoder.beginRenderPass({
         colorAttachments: [ {
-          attachment: renderAttachment,
           view: renderAttachment,
           resolveTarget: multisampling.checked ? swapChainView : undefined,
           loadValue: { r: 1, g: 1, b: 1, a: 1 },
@@ -874,10 +897,41 @@ async function render(fromRaf, fromPostMessage) {
       }
       passEncoder.endPass();
       if (buffer) buffer.destroy();
+      let queryBuffer;
+      if (commandEncoder.writeTimestamp) {
+        // Timestamp for the end of the frame.
+        commandEncoder.writeTimestamp(querySet, 1);
+        // We create a queue of staging buffers to hold the timestamps while we
+        // map them into CPU memory. If the queue is empty, create a new buffer.
+        if (queryBuffers.length == 0) {
+          const buffer = device.createBuffer({
+            size: 16,
+            usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+          });
+          queryBuffers.push(buffer);
+        }
+        // Write the timestamps into a GPU side buffer and copy into the staging buffer.
+        queryBuffer = queryBuffers.shift();
+        commandEncoder.resolveQuerySet(querySet, 0, 2, queryResolveBuffer, 0);
+        commandEncoder.copyBufferToBuffer(queryResolveBuffer, 0, queryBuffer, 0, 16);
+      }
       commandBuffers.push(commandEncoder.finish());
       device.queue.submit(commandBuffers);
+      if (commandEncoder.writeTimestamp) {
+        // Once the staging buffer is mapped we can finally calculate the frame duration
+        // and put the staging buffer back into the queue.
+        queryBuffer.mapAsync(GPUMapMode.READ).then(()=>{
+          let array = new BigInt64Array(queryBuffer.getMappedRange());
+          let nanoseconds = Number(array[1] - array[0]);
+          if (timeQueryResultsMs.length > 10) timeQueryResultsMs.shift();
+          timeQueryResultsMs.push(nanoseconds / 1000000);
+          lastTimeQueryTime = performance.now();
+          queryBuffer.unmap();
+          queryBuffers.push(queryBuffer);
+        });
+      }
     } catch(e) {
-      errorMessage.textContent = "Error: " + e;
+      if (!errorMessage.textContent) errorMessage.textContent = "Error: " + e;
       throw e;
     }
     return; // Done with WebGPU rendering.
@@ -1127,7 +1181,12 @@ function countFps(name, mouseEventsThisFrame) {
   }
 
   if (showFps.checked) {
-    fpsSpan.textContent = counters['render'].fps.toFixed();
+    if (performance.now() - lastTimeQueryTime < 1000 && timeQueryResultsMs.length) {
+      const averageTime = timeQueryResultsMs.reduce((x, y) => x + y) / timeQueryResultsMs.length;
+      fpsSpan.textContent = `${counters['render'].fps.toFixed()}, ${averageTime.toFixed(1)} ms GPU time`;
+    } else {
+      fpsSpan.textContent = counters['render'].fps.toFixed();
+    }
     if (showStats.checked) {
       let text = "";
       for (let key in counters) {

--- a/samples/workload-simulator.html
+++ b/samples/workload-simulator.html
@@ -594,7 +594,7 @@ async function render(fromRaf, fromPostMessage) {
         featuresAndLimits.textContent = JSON.stringify(
           {
             name: adapter.name,
-            features: Array.from(adapter.features || []).slice().sort(),
+            features: Array.from(adapter.features || []).sort(),
             limits: adapter.limits
           }, 0, 2);
         const useTimestampQueries = adapter.features.has('timestamp-query');

--- a/tools/workload-simulator.html
+++ b/tools/workload-simulator.html
@@ -1,0 +1,1160 @@
+<!DOCTYPE html><meta charset="utf-8">
+<meta name=viewport content="width=900">
+<title>Web graphics workload simulator</title>
+<style>
+body {
+  margin: 0;
+  font-family: monospace;
+  user-select: none;
+  font-size: 16px;
+  text-size-adjust: none;
+}
+pre { margin: 0; display: inline}
+.square img { position: relative; }
+.square {
+  overflow: hidden;
+  border-bottom: 20px solid black;
+  border-left: 20px solid black;
+  display: block;
+  float: right;
+  margin-left: 40px;
+  margin-bottom: 20px;
+}
+
+summary {
+  font-weight:  bold;
+  font-size:  130%;
+  position: relative;
+  left: -20px;
+}
+details {
+  margin-left: 20px;
+  padding: 15px 0px;
+}
+
+#fpsSpan { font-size: 30px; }
+
+input, label { white-space: pre; pointer-events: auto; }
+input { margin: 10px 10px;  transform: scale(2); }
+input[type="number"] { width: 50px; }
+input[type="number"] { margin:  20px 20px; }
+input[type="range"] {
+    width: 200px;
+    margin: 10px 110px;
+    padding: 0px;
+    margin-right:  110px;
+}
+
+@media (pointer: coarse) {
+  .square {
+    float: none;
+    border-left: none;
+    border-right:  20px solid black;
+    margin-left: 0;
+  }
+  input[type="radio"] { margin:  15px 15px; }
+  input[type="range"] {
+      width: 100px;
+      margin: 30px 200px;
+      padding: 0px;
+      transform: scale(4);
+  }
+  body {
+    font-size: 22px;
+  }
+}
+
+.rotate { animation: rotating 2s linear infinite; }
+@keyframes rotating {
+  from { transform: scale(2) rotate(0deg); }
+  to { transform: scale(2) rotate(360deg); }
+}
+
+.bad { color: red; user-select: text; }
+.light { color: #CCCCCC; }
+</style>
+<canvas id=webglCanvas class=square></canvas>
+<canvas id=webGPUCanvas class=square></canvas>
+<canvas id=canvas class=square style=display:none;></canvas>
+<div id=dom class=square style=display:none;background:white>
+  <img id=img style=width:256px;height:256px;background:black></img>
+</div>
+<div style="margin:0 2em; padding-top:2em">
+<h2 style=margin-top:0>Drag the logo, or choose "Animate".</h2>
+<label for=animate><input type=checkbox name=animate id=animate>Animate</label>
+<span id=continuousOptions>
+  <label for=useRaf><input type=radio name=loop id=useRaf checked>requestAnimationFrame</label>
+  <label for=usePostMessage><input type=radio name=loop id=usePostMessage>postMessage</label>
+  <label for=useSetTimeout><input type=radio name=loop id=useSetTimeout>setTimeout</label>
+  <label for=useSetInterval><input type=radio name=loop id=useSetInterval>setInterval</label>
+  <br>
+  <div id=fpsOptions>
+    <input id=fpsSlider type=range min=10 max=370 step=10 value=60>
+    <pre>Target FPS: <span id=fpsLabel>60</span></pre>
+  </div>
+</span>
+<div id=fpsPanel>
+  <label for=showFps><input type=checkbox id=showFps checked>Show FPS</label>
+  <span id=fps>
+    <span id=fpsSpan></span>
+    <br>
+    <label for=showStats><input type=checkbox id=showStats>More performance info</label>
+    <div id=stats></div>
+  </span>
+</div>
+<p><span class=bad id=errorMessage></span><span class=bad id=bufferWarning></span></p>
+<label for=useWebGPU>Renderer: <input type=radio name=renderer id=useWebGPU checked>WebGPU</label>
+<label for=useGl><input type=radio name=renderer id=useGl>WebGL</label>
+<label for=use2D><input type=radio name=renderer id=use2D>Canvas 2D</label>
+<label for=useDom><input type=radio name=renderer id=useDom>DOM</label>
+<br>
+<details id=canvasOptions>
+  <summary>Canvas options</summary>
+    Canvas size <input type=number id=canvasSize value=512 min=1> pixels<sup>2</sup>
+  <div id=offscreenCanvasOptions>
+    <label for=onscreen><input type=radio name=onscreen id=onscreen checked>Regular canvas</label>
+    <label for=offscreen><input type=radio name=onscreen id=offscreen>OffscreenCanvas (on main thread)</label>
+    <!-- <label for=offscreenWorker><input type=radio name=offscreen id=offscreenWorker>OffscreenCanvas on worker</label> -->
+    <br>
+    <label for=transferControlToOffscreen><input type=checkbox id=transferControlToOffscreen checked>Use transferControlToOffscreen</label>
+  </div>
+</details>
+<div id=renderingOptions>
+  <details id=renderingWork>
+    <summary>Extra rendering work</summary>
+    <div id=pixelsWrapper>
+      <input type=range id=pixels min=65536 max=65536000 value=65536 step=65536>
+      <pre>draw <span id=pixelsLabel>64K</span> pixels</pre>
+    </div>
+    <input type=range id=drawCalls min=0 max=10000 value=0 step=10>
+    <pre>using <span id=drawCallsLabel>1</span> draw call(s)</pre>
+    <br>
+    Multiply the above slider values by:
+    <label for=x1><input type=radio name=multiplier id=x1 checked>1 </label>
+    <label for=x10><input type=radio name=multiplier id=x10>10 </label>
+    <label for=x100><input type=radio name=multiplier id=x100>100 </label>
+    <br>
+    <label for=useRenderBundles id=useRenderBundlesLabel><input type=checkbox name=useRenderBundles id=useRenderBundles> use RenderBundles</label>
+  </details>
+  <details id=uploadOptions>
+    <summary>Data uploads (e.g. bufferData, mapAsync)</summary>
+    <input type=range id=bufferData min=0 max=256 value=0 step=0.25>
+    <pre><span id=bufferDataLabel>0.00</span> MB mappedAtCreation/bufferData per frame</pre>
+    <br>
+    <input type=range id=bufferSubData min=0 max=256 value=0 step=0.25>
+    <pre><span id=bufferSubDataLabel>0.00</span> MB queue.writeBuffer/bufferSubData per frame</pre>
+    <br>
+    <input type=range id=mapAsync min=0 max=256 value=0 step=0.25>
+    <pre><span id=mapAsyncLabel>0.00</span> MB mapAsync/bufferData per frame</pre>
+    <br>
+    <label for=finish><input type=checkbox id=finish>glFinish</label>
+    <br>
+    <label for=readPixels><input type=checkbox id=readPixels>glReadPixels</label>
+  </details>
+  <details id=webglContextCreation>
+    <summary>WebGL context creation options</summary>
+    <label for=useWebGL2><input type=checkbox id=useWebGL2 checked>Use WebGL 2 if available</label>
+    <label for=antialias><input type=checkbox id=antialias checked>Antialias</label>
+    <label for=alpha><input type=checkbox id=alpha checked>Alpha</label>
+    <label for=depth><input type=checkbox id=depth checked>Depth</label>
+    <label for=stencil><input type=checkbox id=stencil>Stencil</label>
+    <label for=premultipliedAlpha><input type=checkbox id=premultipliedAlpha checked>Premultiplied Alpha</label>
+    <label for=preserveDrawingBuffer><input type=checkbox id=preserveDrawingBuffer>Preserve Drawing Buffer</label>
+    <label for=desynchronized><input type=checkbox id=desynchronized>Desynchronized</label>
+    <br>
+    Power preference
+    <label for=ppDefault><input type=radio name=pp id=ppDefault checked>default</label>
+    <label for=lowPower><input type=radio name=pp id=lowPower>low-power</label>
+    <label for=highPerformance><input type=radio name=pp id=highPerformance>high-performance</label>
+    <br>
+    <label for=separateHighPowerContext><input type=checkbox id=separateHighPowerContext>Activate high power GPU (by creating a separate high power context)</label>
+  </details>
+  </pre>
+  <details id=swapChainOptions>
+    <summary>WebGPU swap chain options</summary>
+      <label for=multisampling><input type=checkbox name=multisampling id=multisampling checked>4x Multisampling</label>
+  </details>
+  <details id=contextAttributes>
+    <summary>WebGL Context attributes</summary>
+    <pre style=user-select:text></pre>
+    <pre id=contextVersion style=user-select:text>
+  </details>
+  <details id=supportedExtensions>
+    <summary>Supported WebGL Extensions</summary>
+  </details>
+  <details id=adapterInfo>
+    <summary>WebGPU Adapter information</summary>
+    <pre id=featuresAndLimits style=user-select:text></pre>
+  </details>
+</div>
+<br>
+<input type=range id=jsWork min=0 max=100 value=0>
+<pre><span id=jsWorkLabel>0</span> ms extra Javascript work per frame</pre>
+<br>
+<label for=animation><input type=checkbox id=animation>CSS animation</label>
+
+<iframe id=highPowerFrame style=display:none></iframe>
+
+<h2><center>Web graphics workload simulator</center></h2>
+</div>
+
+<script>
+'use strict';
+
+
+/************\
+* Options UI *
+\************/
+
+
+// Set all input elements with values from the query string.
+const controls = document.querySelectorAll('input, details');
+const defaultChecked = {};
+const defaultValues = {};
+const defaultMaxes = {};
+for (const control of controls) {
+  if (!control.id) continue;
+  defaultChecked[control.id] = control.checked;
+  defaultValues[control.id] = control.value;
+  defaultMaxes[control.id] = control.max;
+  const param = window.location.search.match(control.id + '(?:=([^&]*))?');
+  if (param) {
+    if (control.type == 'radio')
+      control.checked = true;
+    else if (control.type == 'checkbox')
+      control.checked = param[1] != 'false';
+    else if (control instanceof HTMLDetailsElement)
+      control.open = true;
+    else
+      control.value = param[1];
+  }
+  control.oninput = updateControls;
+  if (control instanceof HTMLDetailsElement)
+    control.onclick = ()=>setTimeout(updateControls, 0);
+}
+// Some controls require a page reload when changed.
+let reloadingPage = false;
+const reloadControls = ['useWebGL2', 'antialias', 'alpha', 'depth', 'stencil', 'premultipliedAlpha', 'preserveDrawingBuffer', 'desynchronized', 'ppDefault', 'lowPower', 'highPerformance', 'canvasSize', 'onscreen', 'offscreen', 'transferControlToOffscreen', 'multisampling'].map(x=>window[x]);
+for (let control of reloadControls) {
+  control.oninput = null;
+  control.onchange = ()=>{
+    reloadingPage = true;
+    updateControls();
+    callReplaceStateThrottled();
+    location.reload();
+  };
+}
+
+separateHighPowerContext.onchange = ()=>{
+  if (!separateHighPowerContext.checked)
+    highPowerFrame.contentDocument.location.reload();
+  else {
+    const doc = highPowerFrame.contentDocument;
+    const canvas = doc.createElement('canvas');
+    doc.body.appendChild(canvas);
+    canvas.getContext('webgl', {powerPreference: 'high-performance'});
+  }
+}
+separateHighPowerContext.onchange();
+
+animate.addEventListener('change', ()=>render());
+
+let queryString = window.location.search;
+let previousQueryString = queryString;
+let replaceStateScheduled = false;
+function callReplaceStateThrottled() {
+  replaceStateScheduled = false;
+  if (queryString == previousQueryString)
+    return;
+  previousQueryString = queryString;
+  let path = window.location.pathname;
+  history.replaceState(null, null, queryString == '?' ? path : path + queryString);
+}
+const suffixes = ['', 'K', 'M', 'G', 'E']
+const divisors = [];
+for (let i = 0; i < suffixes.length; i++)
+  divisors[i] = Math.pow(10, i * 3);
+const formatSI = (x) => {
+  const order = Math.min(Math.log10(Math.abs(x)) / 3 | 0, suffixes.length);
+  return (x / divisors[order]).toFixed(1) + suffixes[order];
+}
+var multiplier;
+
+function updateControls() {
+  multiplier = x1.checked ? 1 : x10.checked ? 10 : 100;
+  webGPUCanvas.style.display = useWebGPU.checked ? 'block' : 'none';
+  webglCanvas.style.display = useGl.checked ? 'block' : 'none';
+  canvas.style.display = use2D.checked ? 'block' : 'none';
+  dom.style.display = useDom.checked ? 'block' : 'none';
+  animation.className = animation.checked ? 'rotate' : null;
+  canvasOptions.style.display = useGl.checked || useWebGPU.checked || use2D.checked ? '' : 'none';
+  transferControlToOffscreen.parentElement.style.display = onscreen.checked ? 'none' : '';
+  continuousOptions.style.display = animate.checked ? '' : 'none';
+  renderingOptions.style.display = useGl.checked || useWebGPU.checked ? '' : 'none';
+  contextAttributes.style.display = useGl.checked ? '' : 'none';
+  supportedExtensions.style.display = useGl.checked ? '' : 'none';
+  webglContextCreation.style.display = useGl.checked ? '' : 'none';
+  contextVersion.style.display = useGl.checked ? '' : 'none';
+  finish.parentElement.style.display = useGl.checked ? '' : 'none';
+  readPixels.parentElement.style.display = useGl.checked ? '' : 'none';
+  offscreenCanvasOptions.style.display = useGl.checked || use2D.checked ? '' : 'none';
+  swapChainOptions.style.display = useWebGPU.checked ? '' : 'none';
+  adapterInfo.style.display = useWebGPU.checked ? '' : 'none';
+  fpsOptions.style.display =
+      animate.checked && (useSetTimeout.checked || useSetInterval.checked) ? '' : 'none';
+  fps.style.visibility = showFps.checked ? 'visible' : 'hidden';
+  stats.style.display = showStats.checked ? 'block' : 'none';
+  drawCallsLabel.textContent = Math.max(1, drawCalls.value * multiplier);
+  useRenderBundlesLabel.style.display = useWebGPU.checked ? '' : 'none';
+  pixelsLabel.textContent = formatSI(pixels.value * multiplier);
+  jsWorkLabel.textContent = jsWork.value;
+  fpsLabel.textContent = fpsSlider.value == fpsSlider.max ? '∞' : fpsSlider.value;
+  bufferDataLabel.textContent = parseFloat(bufferData.value).toFixed(2);
+  bufferSubDataLabel.textContent = parseFloat(bufferSubData.value).toFixed(2);
+  mapAsyncLabel.textContent = parseFloat(mapAsync.value).toFixed(2);
+
+  const queryParams = [];
+  for (const control of controls) {
+    if (control.type == 'radio') {
+      if (!defaultChecked[control.id] && control.checked)
+        queryParams.push(control.id);
+    } else if (control.type == 'checkbox') {
+      if (control.checked != defaultChecked[control.id])
+        queryParams.push(defaultChecked[control.id] ? control.id + '=' + control.checked : control.id);
+    } else if (control instanceof HTMLDetailsElement) {
+      if (control.open)
+        queryParams.push(control.id);
+    } else if (control.value != defaultValues[control.id]) {
+      queryParams.push(control.id + '=' + control.value);
+    }
+  }
+  queryString = '?' + queryParams.join('&');
+  if (!replaceStateScheduled) {
+    replaceStateScheduled = true;
+    setTimeout(callReplaceStateThrottled, 200);
+  }
+  if (!animate.checked)
+    render();
+};
+
+
+/**********************\
+* Input event handling *
+\**********************/
+
+
+const imgSize = 256;
+const size = parseInt(canvasSize.value);
+let webglVersion;
+
+let mouseDown = false;
+const lastPos = [0, 0];
+document.onmouseup = (e) => { mouseDown = false; }
+document.onmousedown = (e) => {
+  mouseDown = true;
+  lastPos[0] = e.pageX;
+  lastPos[1] = e.pageY;
+};
+document.ontouchstart = (e) => {
+  lastPos[0] = e.touches[0].pageX;
+  lastPos[1] = e.touches[0].pageY;
+}
+const position = [(size - imgSize) / 2, (size - imgSize) / 2];
+let continuousRunning = false;
+let mouseUpdatesThisFrame = 0;
+function mouseMove(e) {
+  mouseUpdatesThisFrame++;
+  countFps("mouse/touchmove event");
+  const xy = [0, 0];
+  if (e.touches) {
+    xy[0] = e.touches[0].pageX;
+    xy[1] = e.touches[0].pageY;
+  } else {
+    xy[0] = e.pageX;
+    xy[1] = e.pageY;
+  }
+  if ((e.touches || mouseDown) && !continuousRunning) {
+    for (let i = 0; i < 2; ++i) {
+      position[i] += xy[i] - lastPos[i];
+      position[i] = Math.max(0, Math.min(size - imgSize, position[i]));
+      lastPos[i] = xy[i];
+    }
+    if (!continuousRunning) {
+      render();
+    }
+  }
+}
+document.addEventListener("mousemove", mouseMove, true);
+document.body.addEventListener("touchmove", mouseMove, true);
+for (const element of [dom, canvas, webglCanvas, webGPUCanvas, img])
+  element.onmousedown = element.ontouchstart = (e)=>e.preventDefault();
+
+
+/***********\
+* Rendering *
+\***********/
+
+
+webGPUCanvas.width = webGPUCanvas.height = webglCanvas.width = webglCanvas.height = canvas.width = canvas.height = size;
+dom.style.width = dom.style.height = size + 'px';
+
+window.onmessage = () => render(false /* fromRaf */, true /* fromPostMessage */);
+
+let ctx;
+
+let deviceRequested = false;
+let device;
+let gpuPresent;
+let swapChain;
+let multisampleRenderAttachment;
+let sampleCount = 4;
+let pipeline;
+let sampler;
+let bindGroup;
+let uniformBuffer;
+let uploadBuffer;
+let uploadBufferSize;
+let renderBundle;
+let renderBundleAfterScissor;
+let renderBundleNumDrawCalls;
+let renderBundleInstances;
+const swapChainFormat = 'bgra8unorm';
+
+let bitmapRenderer;
+let offscreenCanvas;
+let gl;
+let glBitmapRenderer;
+let glOffscreenCanvas;
+let program;
+let buffer;
+let bufferForSubData;
+let bufferForSubDataSize = 0;
+const borderSize = 10;
+const vertices = [0, 0, 1, 0, 0, 1, 1, 1];
+const readPixelsArray = new Uint8Array(4);
+let bufferDataArray = new Float32Array(0);
+let bufferSubDataArray = new Float32Array(0);
+let mapAsyncArray = new Float32Array(0);
+let mapAsyncBuffer;
+let mapAsyncBufferSize = 0;
+let mapAsyncReady = [];
+let mapAsyncBuffersOutstanding = 0;
+let interval;
+let intervalFps;
+let timeout = null;
+let rafPending = 0;
+let postMessagePending = 0;
+
+const animationDirection = [1, 1];
+async function render(fromRaf, fromPostMessage) {
+  if (reloadingPage) return;
+  if (fromRaf) rafPending--;
+  if (fromPostMessage) postMessagePending--;
+
+  // Set up the appropriate render loop callback as specified by the UI, if
+  // continuous rendering is enabled.
+  continuousRunning = animate.checked;
+  if (continuousRunning) {
+    for (let i = 0; i < 2; ++i) {
+      position[i] += animationDirection[i] * 2;
+      if (position[i] > size - imgSize) {
+        position[i] = size - imgSize;
+        animationDirection[i] = -1;
+      }
+      if (position[i] < 0) {
+        position[i] = 0;
+        animationDirection[i] = 1;
+      }
+    }
+    if (useRaf.checked && rafPending == 0) {
+      (window.requestAnimationFrame || window.mozRequestAnimationFrame ||
+          window.webkitRequestAnimationFrame)(function() { render(true); });
+      rafPending++;
+    }
+    if (useSetTimeout.checked) {
+      clearTimeout(timeout);
+      let time = 1 / fpsSlider.value * 1000;
+      if (fpsSlider.value == fpsSlider.max)
+        time = 0;
+      timeout = setTimeout(render, time);
+    }
+    if (useSetInterval.checked) {
+      if (!interval || intervalFps != fpsSlider.value) {
+        clearInterval(interval);
+        intervalFps = fpsSlider.value;
+        let time = 1 / fpsSlider.value * 1000;
+        if (fpsSlider.value == fpsSlider.max)
+          time = 0;
+        interval = setInterval(render, time);
+      }
+    } else {
+      clearInterval(interval);
+      interval = null;
+    }
+    if (usePostMessage.checked) {
+      if (postMessagePending == 0) {
+        ++postMessagePending;
+        window.postMessage('', '*');
+      }
+    }
+  } else {
+    clearInterval(interval);
+    interval = null;
+  }
+
+  countFps("render", mouseUpdatesThisFrame);
+  mouseUpdatesThisFrame = 0;
+
+  // Busy wait for a configurable amount of time.
+  const startMs = Date.now();
+  while (Date.now() - startMs < jsWork.value);
+
+  // DOM rendering.
+  if (useDom.checked) {
+    img.style.left = position[0] + 'px';
+    img.style.top = position[1] + 'px';
+    return; // Done with DOM rendering.
+  }
+  // 2D canvas rendering.
+  if (use2D.checked) {
+    if (!ctx) {
+      if (offscreen.checked) {
+        if (transferControlToOffscreen.checked) {
+          offscreenCanvas = canvas.transferControlToOffscreen();
+        } else {
+          bitmapRenderer = canvas.getContext('bitmaprenderer');
+          offscreenCanvas = new OffscreenCanvas(size, size);
+        }
+        ctx = offscreenCanvas.getContext('2d');
+      } else {
+        ctx = canvas.getContext('2d');
+      }
+    }
+    ctx.fillStyle = 'white';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    try {
+      ctx.drawImage(img, position[0], position[1]);
+    } catch (e) {
+      ctx.fillStyle = 'black';
+      ctx.fillRect(position[0], position[1], imgSize, imgSize);
+    }
+    if (offscreen.checked && !transferControlToOffscreen.checked && bitmapRenderer && offscreenCanvas) {
+      bitmapRenderer.transferFromImageBitmap(offscreenCanvas.transferToImageBitmap());
+    }
+    return; // Done with 2D canvas rendering.
+  }
+
+  // Set up data to upload into buffers, if requested.
+  if (bufferData.value > 0) {
+    if (bufferDataArray.length * 4 != bufferData.value * 1024 * 1024) {
+      bufferDataArray = new Float32Array(bufferData.value * 1024 * 1024 / 4);
+      // We want to actually use this data in rendering so the graphics driver
+      // can't optimize away the upload. Fill the first few bytes with our real
+      // vertex data.
+      bufferDataArray.set(vertices, 0);
+    }
+  }
+
+  if (bufferSubDataArray.length * 4 != bufferSubData.value * 1024 * 1024) {
+    bufferSubDataArray = new Float32Array(bufferSubData.value * 1024 * 1024 / 4);
+    if (bufferSubDataArray.length > 0)
+      bufferSubDataArray.set(vertices, 0);
+  }
+
+  if (mapAsyncArray.length * 4 != mapAsync.value * 1024 * 1024) {
+    mapAsyncArray = new Float32Array(mapAsync.value * 1024 * 1024 / 4);
+    mapAsyncArray.set(vertices, 0);
+  }
+
+  // Calculate how many instances and draw calls we need based on slider values.
+  const numDrawCalls = Math.max(1, drawCalls.value * multiplier);
+  const instances = pixels.value / 64000 * multiplier | 0;
+  const instancesPerCall = Math.max(1, instances / numDrawCalls | 0);
+  const instancesFirstCall = instancesPerCall + numDrawCalls % instancesPerCall;
+
+
+  /******************\
+  * WebGPU rendering *
+  \******************/
+
+
+  if (useWebGPU.checked) {
+    // Initialize WebGPU.
+    if (!device && navigator.gpu) {
+      try {
+        if (deviceRequested) return;
+        deviceRequested = true;
+        let adapter = await navigator.gpu.requestAdapter();
+        featuresAndLimits.textContent = JSON.stringify(
+          {
+            name: adapter.name,
+            features: Array.from(adapter.features || []).slice().sort(),
+            limits: adapter.limits
+          }, 0, 2);
+        device = await adapter.requestDevice();
+        device.addEventListener('uncapturederror', (e)=>errorMessage.textContent = 'Uncaptured error: ' + e.error.message);
+        gpuPresent = webGPUCanvas.getContext('gpupresent');
+        swapChain = gpuPresent.configureSwapChain({device, format: swapChainFormat});
+        const bindGroupLayout = device.createBindGroupLayout({
+          entries: [
+            {
+              binding: 0,
+              // TODO: These shouldn't need to be visible to both stages. There's a bug in Dawn that
+              // incorrectly requires variables that are unused in one stage to be visible to all stages.
+              visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+              buffer: { type: 'uniform', },
+            },
+            {
+              binding: 1,
+              visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+              sampler: { type: 'filtering', },
+            },
+            {
+              binding: 2,
+              visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+              texture: { sampleType: 'float', },
+            },
+          ],
+        });
+        const pipelineLayout = device.createPipelineLayout({
+          bindGroupLayouts: [bindGroupLayout],
+        });
+        if (multisampling.checked) {
+          multisampleRenderAttachment = device.createTexture({
+            size: { width: size, height: size },
+            sampleCount,
+            format: swapChainFormat,
+            usage: GPUTextureUsage.RENDER_ATTACHMENT,
+          })
+          if (!multisampleRenderAttachment)
+            errorMessage.textContent = 'Failed to allocate multisample render attachment.';
+        }
+        let shaderModule = device.createShaderModule({ code: `
+          let pos : array<vec2<f32>, 6> = array<vec2<f32>, 6>(
+              vec2<f32>(-1., 1.),
+              vec2<f32>(-1., -1.),
+              vec2<f32>(1., -1.),
+              vec2<f32>(-1., 1.),
+              vec2<f32>(1., -1.),
+              vec2<f32>(1., 1.));
+
+          [[block]] struct Uniforms {
+            xy: vec2<f32>;
+          };
+          [[binding(0), group(0)]] var<uniform> uniforms: Uniforms;
+          [[binding(1), group(0)]] var sampler1: sampler;
+          [[binding(2), group(0)]] var texture1: texture_2d<f32>;
+
+          struct Output {
+            [[builtin(position)]] Position : vec4<f32>;
+            [[location(0)]] uv : vec2<f32>;
+          };
+          
+          [[stage(vertex)]]
+          fn vs([[builtin(vertex_index)]] VertexIndex : i32) -> Output {
+            var output : Output;
+            output.Position = vec4<f32>(pos[VertexIndex] / vec2<f32>(2.,2.) + uniforms.xy, 0.0, 1.0);
+            output.uv = pos[VertexIndex] / vec2<f32>(2., -2.) + vec2<f32>(.5, .5);
+            return output;
+          }
+
+          [[stage(fragment)]]
+          fn fs([[location(0)]] uv: vec2<f32>) -> [[location(0)]] vec4<f32> {
+            return textureSample(texture1, sampler1, uv);
+          }`, });
+        if (shaderModule.compilationInfo)
+          shaderModule.compilationInfo().then((e)=>console.log(e));
+        pipeline = device.createRenderPipeline({
+          primitive: { topology: 'triangle-list' },
+          layout: pipelineLayout,
+          multisample: { count: multisampling.checked ? sampleCount : 1, },
+          vertex: {
+            entryPoint: 'vs',
+            module: shaderModule,
+          },
+          fragment: {
+            entryPoint: 'fs',
+            targets: [ { format: swapChainFormat, }, ],
+            module: shaderModule,
+          },
+        });
+        sampler = device.createSampler({
+          magFilter: 'linear',
+          minFilter: 'linear',
+        });
+        const texture = device.createTexture({
+          size: [256, 256, 1],
+          format: 'rgba8unorm',
+          usage: GPUTextureUsage.SAMPLED | GPUTextureUsage.COPY_DST,
+        });
+        const loadImage = async () => {
+          const imageBitmap = await createImageBitmap(img);
+          device.queue.copyImageBitmapToTexture(
+            { imageBitmap }, { texture }, [256, 256, 1]);
+          render();
+        };
+        if (img.complete) loadImage(); else img.addEventListener('load', loadImage);
+        uniformBuffer = device.createBuffer({
+          size: 2 * 4,
+          usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+        });
+        bindGroup = device.createBindGroup({
+          layout: bindGroupLayout,
+          entries: [
+            { binding: 0, resource: { buffer: uniformBuffer } },
+            { binding: 1, resource: sampler },
+            { binding: 2, resource: texture.createView() },
+          ],
+        });
+      } catch(e) {
+        errorMessage.textContent = "Error initializing WebGPU: " + e;
+        return;
+      }
+    }
+
+    // End WebGPU init.
+    // Begin WebGPU rendering.
+
+    if (!device) {
+      errorMessage.textContent = "Error: WebGPU not supported.";
+      return;
+    }
+    try {
+      const swapChainView = swapChain.getCurrentTexture().createView();
+      const commandBuffers = [];
+      device.queue.writeBuffer(uniformBuffer, 0, new Float32Array([position[0]/size*2 - 0.5, -position[1]*2/size + 0.5]));
+      let buffer = null;
+
+      // Upload data using createBuffer with mappedAtCreation.
+      if (bufferData.value > 0) {
+        buffer = device.createBuffer({ size: bufferDataArray.byteLength, usage: GPUBufferUsage.VERTEX, mappedAtCreation: true });
+        new Float32Array(buffer.getMappedRange()).set(bufferDataArray);
+        buffer.unmap();
+        // TODO: use this data in rendering so it can't be optimized away
+      }
+
+      // Upload data using queue.writeBuffer.
+      if (bufferSubData.value > 0) {
+        if (!uploadBuffer || uploadBufferSize != bufferSubDataArray.byteLength) {
+          if (uploadBuffer) uploadBuffer.destroy();
+          uploadBufferSize = bufferSubDataArray.byteLength;
+          uploadBuffer = device.createBuffer({
+            size: bufferSubDataArray.byteLength,
+            usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+          });
+        }
+        device.queue.writeBuffer(uploadBuffer, 0, bufferSubDataArray);
+      }
+
+      // Upload data using mapAsync and a queue of staging buffers.
+      if (mapAsyncArray.length > 0) {
+        if (mapAsyncBufferSize != mapAsyncArray.byteLength) {
+          mapAsyncBufferSize = mapAsyncArray.byteLength;
+          if (mapAsyncBuffer) mapAsyncBuffer.destroy();
+          mapAsyncBuffer = device.createBuffer({size: mapAsyncArray.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST});
+        }
+        let buffer = null;
+        while (mapAsyncReady.length) {
+          buffer = mapAsyncReady.shift();
+          if (buffer.size == mapAsyncArray.byteLength)
+            break;
+          buffer.destroy();
+          mapAsyncBuffersOutstanding--;
+          buffer = null;
+          bufferWarning.textContent = '';
+        }
+        if (!buffer) {
+          buffer = device.createBuffer({
+            size: mapAsyncArray.byteLength,
+            usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+            mappedAtCreation: true,
+          });
+          buffer.size = mapAsyncArray.byteLength;
+          mapAsyncBuffersOutstanding++;
+          if (mapAsyncBuffersOutstanding > 10) {
+            bufferWarning.textContent = ` Warning: mapAsync requests from ${mapAsyncBuffersOutstanding} frames ago have not resolved yet. ${(mapAsync.value * mapAsyncBuffersOutstanding).toFixed(2)} MB of staging buffers allocated.`;
+          }
+        }
+        new Float32Array(buffer.getMappedRange()).set(mapAsyncArray);
+        buffer.unmap();
+        const commandEncoder = device.createCommandEncoder();
+        commandEncoder.copyBufferToBuffer(buffer, 0, mapAsyncBuffer, 0, mapAsyncArray.byteLength);
+        // TODO: combine this submit with the main one, but we'll have to delay calling mapAsync until after the submit.
+        device.queue.submit([commandEncoder.finish()]);
+        // TODO: use this data during rendering.
+        buffer.mapAsync(GPUMapMode.WRITE).then(()=>mapAsyncReady.push(buffer));
+      }
+
+      // Record command buffer.
+      const commandEncoder = device.createCommandEncoder();
+      let renderAttachment = swapChainView;
+      if (multisampling.checked) {
+        renderAttachment = multisampleRenderAttachment.createView();
+      }
+      const passEncoder = commandEncoder.beginRenderPass({
+        colorAttachments: [ {
+          attachment: renderAttachment,
+          view: renderAttachment,
+          resolveTarget: multisampling.checked ? swapChainView : undefined,
+          loadValue: { r: 1, g: 1, b: 1, a: 1 },
+          storeOp: multisampling.checked ? 'clear' : 'store',
+        }, ],
+      });
+      if (useRenderBundles.checked && renderBundle && instances == renderBundleInstances && renderBundleNumDrawCalls == numDrawCalls) {
+        // If we have valid RenderBundles to use, execute them and we're done.
+        // We have two RenderBundles, one for normal rendering and one for
+        // scissored rendering.
+        passEncoder.executeBundles([renderBundle]);
+        passEncoder.setScissorRect(position[0], position[1], 2, 2);
+        if (renderBundleAfterScissor) {
+          passEncoder.executeBundles([renderBundleAfterScissor]);
+        }
+      } else {
+        let passOrBundleEncoder = passEncoder;
+        // If not using render bundles, we'll record directly to the pass encoder.
+        // If render bundles are enabled and we get here, that means we need to
+        // update our render bundles. Replace the pass encoder with a render bundle
+        // encoder, and once the render bundles are recorded then we'll execute them
+        // on the pass encoder.
+        if (useRenderBundles.checked) {
+          // We need to record a new RenderBundle.
+          renderBundleInstances = instances;
+          renderBundleNumDrawCalls = numDrawCalls;
+          passOrBundleEncoder = device.createRenderBundleEncoder({
+            colorFormats: [swapChainFormat],
+            sampleCount,
+          });
+        }
+        passOrBundleEncoder.setPipeline(pipeline);
+        passOrBundleEncoder.setBindGroup(0, bindGroup);
+        passOrBundleEncoder.draw(6, instancesFirstCall);
+        let instancesDrawn = instancesFirstCall;
+        let scissorEnabled = false;
+        for (let i = 1; i < numDrawCalls; i++) {
+          if (!scissorEnabled && instancesDrawn > instances) {
+            // If we've drawn all of the requested pixels already, enable the scissor
+            // test so we only draw one pixel per draw call for the rest of the calls.
+            scissorEnabled = true;
+            if (useRenderBundles.checked) {
+              // Scissor state is not a part of the render bundle. So we must use
+              // two render bundles: one for the draw calls before we enable scissor,
+              // and a separate one for the draw calls after we enable scissor.
+              // Finish the first render bundle here and start recording the second
+              // one.
+              renderBundle = passOrBundleEncoder.finish();
+              passOrBundleEncoder = device.createRenderBundleEncoder({
+                colorFormats: [swapChainFormat],
+                sampleCount,
+              });
+              passOrBundleEncoder.setPipeline(pipeline);
+              passOrBundleEncoder.setBindGroup(0, bindGroup);
+            } else {
+              // 1x1 scissor rect seems to fail on my macbook, also in webgl, driver bug?
+              passEncoder.setScissorRect(position[0], position[1], 2, 2);
+            }
+          }
+          passOrBundleEncoder.draw(6, instancesPerCall);
+          instancesDrawn += instancesPerCall;
+        }
+        // If we're not using render bundles, we're done. If we're using render bundles,
+        // we need to finish and then execute them on the pass encoder.
+        if (useRenderBundles.checked) {
+          if (scissorEnabled) {
+            renderBundleAfterScissor = passOrBundleEncoder.finish();
+          } else {
+            renderBundle = passOrBundleEncoder.finish();
+            renderBundleAfterScissor = null;
+          }
+          passEncoder.executeBundles([renderBundle]);
+          passEncoder.setScissorRect(position[0], position[1], 2, 2);
+          if (renderBundleAfterScissor) {
+            passEncoder.executeBundles([renderBundleAfterScissor]);
+          }
+        }
+      }
+      passEncoder.endPass();
+      if (buffer) buffer.destroy();
+      commandBuffers.push(commandEncoder.finish());
+      device.queue.submit(commandBuffers);
+    } catch(e) {
+      errorMessage.textContent = "Error: " + e;
+      throw e;
+    }
+    return; // Done with WebGPU rendering.
+  }
+
+
+  /*****************\
+  * WebGL rendering *
+  \*****************/
+
+
+  // Initialize WebGL.
+  if (!gl) {
+    const options = {};
+    for (let option of ['antialias', 'alpha', 'depth', 'stencil', 'premultipliedAlpha', 'preserveDrawingBuffer', 'desynchronized'])
+      options[option] = window[option].checked;
+    options.powerPreference = ppDefault.checked ? 'default' : lowPower.checked ? 'low-power' : 'high-performance';
+    let renderCanvas = webglCanvas;
+    if (offscreen.checked) {
+      if (transferControlToOffscreen.checked) {
+        renderCanvas = webglCanvas.transferControlToOffscreen();
+      } else {
+        glBitmapRenderer = webglCanvas.getContext('bitmaprenderer')
+        renderCanvas = glOffscreenCanvas = new OffscreenCanvas(size, size);
+      }
+    }
+    renderCanvas.width = renderCanvas.height = size;
+    if (useWebGL2.checked)
+      gl = renderCanvas.getContext('webgl2', options);
+    if (gl) {
+      webglVersion = 2;
+    } else {
+      webglVersion = 1;
+      gl = renderCanvas.getContext('webgl', options);
+      const aia = gl.getExtension('ANGLE_instanced_arrays');
+      if (aia)
+        gl.drawArraysInstanced = (a, b, c, d)=>aia.drawArraysInstancedANGLE(a, b, c, d);
+      else {
+        pixels.value = pixels.min;
+        pixelsWrapper.style.display = 'none';
+        gl.drawArraysInstanced = (a, b, c, d)=>gl.drawArrays(a, b, c);
+      }
+    }
+    // Read context info like renderer string and extensions.
+    let renderer = gl.getParameter(gl.RENDERER);
+    let debugRendererInfo = gl.getExtension('WEBGL_debug_renderer_info');
+    if (debugRendererInfo)
+      renderer = gl.getParameter(debugRendererInfo.UNMASKED_RENDERER_WEBGL);
+    contextVersion.textContent = `WebGL Version: ${gl.getParameter(gl.VERSION)}\nRenderer: `;
+    const a = document.createElement('a');
+    a.textContent = renderer;
+    a.href = `https://www.google.com/search?q=${encodeURIComponent(renderer)}`
+    contextVersion.appendChild(a);
+    contextAttributes.getElementsByTagName('pre')[0].textContent = JSON.stringify(gl.getContextAttributes(), 0, 2);
+    for (const e of gl.getSupportedExtensions()) {
+      const a = document.createElement('a');
+      a.textContent = e;
+      a.href = `https://www.khronos.org/registry/webgl/extensions/${e}/`;
+      supportedExtensions.appendChild(a);
+      supportedExtensions.appendChild(document.createElement('br'));
+    }
+
+    // Setup texture
+    const tex = gl.createTexture();
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array([0, 0, 0, 255]));
+    img.onload = ()=>{
+      gl.activeTexture(gl.TEXTURE0);
+      gl.bindTexture(gl.TEXTURE_2D, tex);
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, img);
+      gl.generateMipmap(gl.TEXTURE_2D);
+      setTimeout(render, 0);
+    };
+    if (img.complete) img.onload();
+
+    function setupProgram(vsSource, fsSource, attribs, uniforms) {
+      let prog = gl.createProgram();
+      function compileShader(source, type) {
+        const shader = gl.createShader(type);
+        gl.shaderSource(shader, source);
+        gl.compileShader(shader);
+        if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS))
+          console.log(gl.getShaderInfoLog(shader));
+        gl.attachShader(prog, shader);
+      }
+      compileShader(vsSource, gl.VERTEX_SHADER);
+      compileShader(fsSource, gl.FRAGMENT_SHADER);
+      for (let i = 0; i < attribs.length; ++i)
+        gl.bindAttribLocation(prog, i, attribs[i]);
+      gl.linkProgram(prog);
+      if (!gl.getProgramParameter(prog, gl.LINK_STATUS))
+        console.log(gl.getProgramInfoLog(prog));
+      for (const attrib of attribs)
+        prog[attrib] = gl.getAttribLocation(prog, attrib);
+      for (const uniform of uniforms)
+        prog[uniform] = gl.getUniformLocation(prog, uniform);
+      return prog;
+    }
+
+    program = setupProgram(`
+      attribute vec2 position;
+      varying vec2 texCoord;
+      uniform vec2 offset;
+      uniform float size;
+      void main() {
+        gl_Position = vec4(position * size + offset + vec2(size - 1., 1. - size), 0, 1);
+        texCoord = vec2(position.x, 1. - position.y);
+      }`,`
+      precision mediump float;
+      varying vec2 texCoord;
+      uniform sampler2D tex;
+      void main() {
+        gl_FragColor = texture2D(tex, texCoord);
+      }`,
+      ['position', 'texCoordIn'], ['offset', 'tex', 'size']);
+    gl.useProgram(program);
+    gl.uniform1i(program.tex, 0);
+
+    // Setup vertex buffer
+    buffer = gl.createBuffer();
+    bufferForSubData = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(vertices), gl.STREAM_DRAW);
+    gl.enableVertexAttribArray(program.position);
+    gl.vertexAttribPointer(program.position, 2, gl.FLOAT, false, 0, 0);
+
+    // Setup drawing state
+    gl.viewport(0, 0, size, size);
+    gl.clearColor(1, 1, 1, 1);
+    gl.disable(gl.SCISSOR_TEST);
+    gl.disable(gl.DEPTH_TEST);
+    gl.disable(gl.STENCIL_TEST);
+    gl.disable(gl.BLEND);
+    gl.disable(gl.CULL_FACE);
+
+    updateControls();
+  }
+
+  // End WebGL init.
+  // Begin WebGL rendering.
+
+  // Upload data to buffers if requested by the user.
+  if (bufferData.value > 0) {
+    gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+    gl.bufferData(gl.ARRAY_BUFFER, bufferDataArray, gl.STREAM_DRAW);
+  }
+
+  if (mapAsyncArray.length > 0) {
+    // WebGL doesn't have mapAsync, so just do bufferData
+    gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+    gl.bufferData(gl.ARRAY_BUFFER, mapAsyncArray, gl.STREAM_DRAW);
+  }
+  if (bufferSubDataArray.length > 0) {
+    gl.bindBuffer(gl.ARRAY_BUFFER, bufferForSubData);
+    if (bufferForSubDataSize != bufferSubDataArray.byteLength) {
+      bufferForSubDataSize = bufferSubDataArray.byteLength;
+      // Make the buffer bigger than the upload so the driver doesn't try to optimize it into a bufferData call. Just in case.
+      gl.bufferData(gl.ARRAY_BUFFER, bufferForSubDataSize + 1, gl.DYNAMIC_DRAW)
+    }
+    gl.bufferSubData(gl.ARRAY_BUFFER, 0, bufferSubDataArray);
+    gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+  }
+
+  // Actually draw the texture.
+  // Set up to scissor out all but one pixel of the texture.
+  gl.scissor(position[0], size - position[1] - imgSize, 2, 2);
+
+  let usedProgram = program;
+  gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+
+  gl.useProgram(usedProgram);
+  gl.uniform2f(usedProgram.offset,
+               (position[0] - imgSize) / size * 2,
+               -position[1] / size * 2);
+  gl.uniform1f(usedProgram.size, imgSize * 2 / size);
+
+  let scissorEnabled = false;
+  gl.clearColor(1, 1, 1, 1);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+  gl.drawArraysInstanced(gl.TRIANGLE_STRIP, 0, 4, instancesFirstCall);
+  var instancesDrawn = instancesFirstCall;
+  for (let i = 1; i < numDrawCalls; i++) {
+    if (instancesDrawn > instances && !scissorEnabled) {
+      // If we've drawn all of the requested pixels already, enable the scissor
+      // test so we only draw one pixel per draw call for the rest of the calls.
+      scissorEnabled = true;
+      gl.enable(gl.SCISSOR_TEST);
+    }
+    gl.drawArraysInstanced(gl.TRIANGLE_STRIP, 0, 4, instancesPerCall);
+    instancesDrawn += instancesPerCall;
+  }
+  gl.disable(gl.SCISSOR_TEST);
+
+  if (finish.checked) {
+    gl.finish();
+  }
+  if (readPixels.checked) {
+    gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, readPixelsArray);
+  }
+  if (offscreen.checked && !transferControlToOffscreen.checked && glOffscreenCanvas && glBitmapRenderer) {
+    glBitmapRenderer.transferFromImageBitmap(glOffscreenCanvas.transferToImageBitmap());
+  }
+}
+
+
+/**************\
+* FPS counters *
+\**************/
+
+
+const counters = {};
+function countFps(name, mouseEventsThisFrame) {
+  let counter = counters[name];
+  if (!counter) {
+    counter = { history: [Date.now() - 16], name: name, count: 0 };
+    counters[name] = counter;
+  }
+  const history = counter.history;
+  history.push(Date.now());
+  while (history.length > 2 &&
+      history[0] + 1000 < history[history.length - 1]) {
+    counter.history.shift();
+  }
+  let averageMs = 0;
+  let maxMs = .1;
+  let minMs = 99999999;
+  for (let i = 1; i < history.length; i++) {
+    let diff = history[i] - history[i - 1];
+    averageMs += diff;
+    maxMs = Math.max(maxMs, diff);
+    minMs = Math.min(minMs, diff);
+  }
+  averageMs /= history.length - 1;
+  counter.fps = 1000 / averageMs;
+  counter.minFps = 1000 / maxMs;
+  counter.maxFps = 1000 / minMs;
+  counter.count++;
+
+  if (mouseEventsThisFrame !== undefined) {
+    counter.mouseEvents = counter.mouseEvents || { multiple: 0, zero: 0 };
+    if (mouseEventsThisFrame > 1) {
+      counter.mouseEvents.multiple++;
+    } else if (mouseEventsThisFrame == 0) {
+      counter.mouseEvents.zero++;
+    }
+  }
+
+  if (showFps.checked) {
+    fpsSpan.textContent = counters['render'].fps.toFixed();
+    if (showStats.checked) {
+      let text = "";
+      for (let key in counters) {
+        counter = counters[key];
+        text += "<b>" + counter.name + "</b><br>";
+        text += counter.fps.toFixed() + " avg FPS<br>";
+        text += "<div class=" +
+                (counter.maxFps - counter.fps > 10 ? "bad" : "") + ">" +
+                counter.maxFps.toFixed() + " max FPS</div>";
+        text += "<div class=" +
+                (counter.fps - counter.minFps > 10 ? "bad" : "") + ">" +
+                counter.minFps.toFixed() + " min FPS</div>";
+        if (counter.mouseEvents) {
+          text += "<div>" + counter.mouseEvents.zero +
+                  " frame(s) with no mouse/touch events";
+          text += "<div>" + counter.mouseEvents.multiple +
+                  " frame(s) with multiple mouse/touch events";
+        }
+        text += "<div class=light>" + counter.count + " frames</div>";
+      }
+      stats.innerHTML = text;
+    }
+  }
+}
+
+updateControls();
+render();
+
+img.src = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAMAAABrrFhUAAADAFBMVEUAAAAAAYsACIsADosAFIwAGIwAGowAHI0AHo0AII0AIo0AJI4AJo4AJ44AKo8ALI8ALo8AMJAAMpAAM5EANJAANZEANpEAN5EAOJIAOZIAOpIAPJIAPJMAPpMAP5MAP5sAQJQAQpQAQ5QARJUARZUARpUAR5UAR5YAR6AAR6cASJYASZYASpUASpYASqcAS5UAS5YAS5cAS6gATJcATZcATacATagAT6gAUJ0AUKgAUagAUbEAUqkAUqoAU6kAVKkAVaQAVaoAVasAVcYAVqoAV6sAV8YAWLMAWawAWcYAW60AW8cAXccAXrYAXsgAYMgAYcgAY8kAZMkAZskAZ8oAaMoAasoAassAa8sAbMwAbcwAbdcAceYAct8Ac+cAdecAdugAd+gAeegAeekAefEAeukAf/IAgf8Agv8Ag/8Ahf8Ah/8Aif8LMJANDQ0NYskObMwRIY4RW8cTOpIWFhYXTJcZh/8beegcHBwdY8kgbsshM5EiIiImP5QmV6soKCguYa4vjP8wasoxMTEySZcydc40f+g1V5s5OTk+Pj4+ccxBkf9CQkJDVJtFZ7BGRkZLS0tLes9OYaBQUFBRi+pVVVVYWFhZaKNZdbZZm/9cg9FeXl5ecKZifrlkZGRlc6hqampqjtVvfKxvm+1wcHB0qP91dXV2i794ltZ6h7J7e3uBgYGFhYWGkrmIo9uJiYmKsfiOjo6PnL+SkpKVlZWYpcSZsN+bm5ubvfyhoaGircmnp6envOSqqqqqtc6qx/qrq6uvr6+0tLS1v9W1xue6urq81P6/yNvAwMDAz+vDxNXDxdbFxcXJycnJ0N/Nzc3N2vDQ4P7S0tLT2OXW1tba3+nb29vb4/Te6f7f39/h5e3i4uLk5OTl6vPn8P7o6Ojq6urr6+vr7/bs7Ozt7e3u8vvv7+/w8PDw9f3x8fHx8/fy8vLz8/P09PT09/v19fX29vb39/f3+fz4+Pj4+/75+fn6+vr7+/v7/P78/Pz8/f/9/f39/v7+/v7+//////8lGgMEAAAblUlEQVR42u2dfUAVVd7HJ8usrKfWLHejV0qLctE1RXtxy7dCIbWe9unpac1qX3zttq3kUmFsYoWuBmngJi2hISsoGoLe0LRAUXwCQUDwCooivoDyKnjFy2X2nJkzM+ecOXO5l8t40Tu//knwzp3v5/xezu/MmSNX7eXGVZ/ybgMATnuzCQDOeq8hAOe81WQAdd5pGIAGbzQCQKP3GQWgydtMBeC8dxkDQKs3mQGACeCCt5gmAKt3mAHAAYC2q98MAAaATgDYrmYzABgAnAJgvzrNAGAAMAAYAAwABgAXAPBXixkADAAGAAOAAcAAYAAwABgADAAGAAOAawCqfv7/Tu1nfYz8kuKOzkS2dOgBoHbNNaL16tXr2muvu+663r179+nT54Ybbrzxpr59+9588y23/Be0W4HddtsvJOsn2O2S3aFt/UXrJxu6wm3Q4FVvhZe/5RefH+lM//dH9QBgL/6Q0A8AXI/pv0XUT8jHtCORdzoyjILMQcXg1vv8tlx0DODA/O8v6ZEDmlMRAFy/KL/vzWr5snhF+IBOTfx7TAoIwi/9/D466FD/mbUzPj6kSxI8vIwIAHH8cfcn5ePikb5fSvYr3DQ4EBBkBI/4+fn9u96B/kt7Zs2YsbZZDwDt23qx9cvuj+SjwRfFy8olvXexjEGDhiAguA/o9wvY6wDA0a9mzpgxf48eAOxVK5UAQPGv6IfDj4++rF7SfpdTRmGQIYgM7vAT7J9V2g7w/cyZgMBXZ3SZB/z8ruwAfaQEQOtX5CviCYk+bGNwoCCAK9/n7w8B+O9s1wJw6OOZkMDMH9v1AFCbjAeAnP8x/ZR8XLyPz91apgFCgYAY3O0/zF9A8PlhrRK4dtZMgcA/DukyEyxeIDuAkgAI/bJ8YfBl8Zjae9imgQFncOcjw4AJCDZrZLk982chAt+16AHAuplyAJZ+Sr4PpfxeDZNIqCjIsXC//7BhCMFHxewS+NWsWSKBGR8f0KUXOLyMdACVfmn4kXwfXPu9zhhFATGA+u9C+gUC/65lqGv/cfasWRKCtWf0AGDf2RuVAKkCiPUP06+Sj2u/X8tYGHAGPgPuui8gIEAmMHIXY8J/6B+zFAAz93To0Q1WfYM5gFo/PvyyfJb2BzDT4EAxuGdEQICMwN//n+qWoOU75AAiga+O6gHAvv9D3AFY+jH5knqmbl/RHlCzICBIwfDIyJEBCgJ//22qCf+Bj2cTBFgtgfvrAfXJIgDKART/F/Vj8kntvg6MSQExeHDkEyNxBP6fH1Q1AbNnEwRYLUE3LIgcXKREAOEAav2KfFr7g8AcY8AhAAT3jHgCGIEglSyFHXvmzCYJzFrbogeAi1ukCKAdQNbvIw8/pf5ByR4ijQ0BR/Dw06NH4wgAgI/2U03AbAIAIMBoCbpjSezIciwCcP13wvwn68flK+IJ3QMHDnRAQoQgAnjgidHAnsadIGDYv2qJJkB0AMIF1C1BdwCw7+pLRwAKAIZ+JB8XP1DL1BRkBI+MFuxpHMGwgF12vARKAHACqpagWxZFa9dgESBmADwAkH5p+JF8Uvsg2mgMBIN7H3pytERARCAQGKmsjnW0fDdnDoOAqiXonlXh/QtupCNAcACGfky+hnQWBoqB76gxYygCIgJldezA/DkKAawS0C1B9wBoTqVSgOQAYgAQ+nH5osqHH35UMW0KGINHx4wdIyF4WkAgEhj2d1QKO06unTOHSYBuCbrpucDhZWQKEACoHADpx+Q/TIh3QEFi4DsQ6H/o2bFjIYExEgAlDNDqWPuPcwkAsxUXoFqCbgJwcdvNCAARAaQDKPpF+Yr4x9Q2GBiLge8gX99RY8dqEBg5WlwdO/TVnDlsF5gxn2wJuuvJUNVKCoAUAdABGPoV+Y9p2mAVBPhB34GDnhkrExhDE/gXXB27+N3cuWwCoC8mW4LuAmDf+zadAoQIUByA1I/kS1p/zTKEgIAAPjpw1IQJBIHfEgR2XoJNwFyZgDoPEi1Btz0brE1WA6AdQNIvDb8D8ZINVjHw/c34CRMQAoLA0yKBzw/z9WvnztV2AbIUdhsAe/EiCUA/AgDhAGr9ktKhtNEIIAOBw7OBgRKBMQwfGLm5ec/8uXO1XAAuEeOlsPueDls3YwCEabAMQHAAFACy/2Pyh2oaQUBEMGpCoEhggkLgtziBj3Z/NXeuIwIz5x/Q5fH44WU4ADEH+kgRIDkAoR/J/w1uDAiDMRs0+JlACQAkMB4n8KQwHxj5wZ9J++Of/0jZd5f0ANC+81YcgNAH3I0BQA5A6ZfkP66YCgFOYFRgIE5ABDDmtxiBgKem/elPf/jDW2+K9sYb06dPfx3Z7wX7tEyfDRJV3zgAgDkApl+tnolgyBBJ/+PjAx0QeFIgMCL4LUDgrbcwACSB7y7qtENk/zwcAF4ElAiQHUDR/zjDVAQQgmcDCQATxo4XCTyDCAguMPo1zAXeULnAl0f12iJTn8wEQEWAtv7hij2uAjAECwAFwITxCgHFBV6YTrsADuDHDt32CB1c5AgAEQEq/cNVRhMYMnio7AAqAqILiAACRr7qAMC3Z/TbJGXdgucAFgAhAnAH0JRPIhAADBk1aZKKgASAcIHnp2kmgb8V6rlL7MhycSZIJEENAJj+4ZpGEBg+YZKawHiRwDO4C4wYMfUtmQCVBKgFgW4GYNv1tjgVRhMhBgAiAjrTryCAAJ6dNAknwHIBCcDoaewY+P2nh/TdJ1i7hugFugHAcBnA8EASAMsFnpQIvPAmOwnQD0e6faPk/gV4FvRRyqA2gOHDnSAwZMhQ0QFULsCOgZGvMQF8eVTvnaLNqc4A+LUrAIaLAEZNogEEygDGQwBEDIx4fjojC07fo/9W2YPLpCyImiE0E2QmQRcADB8/aRLTBWgAT4oAAl5+S86CEoDp39brD+DSFgHAHQNQEhC7QXEm6A4A2QE0AIxRADwBAYx4apqqDHx64HJslq5aicWADACPga4AQBmQEQPj2VlwxIjgNykARBOgH4COXfOcSgJDnawCIoBnJ7kMYORrFIAvj16e7fL1a5hJwLerZQDqxwLAaQDDXphOAmBtldPlfYHiRfhMAE8CRAwMdX4mNPzZTgE8owIwYtgrBIBvz1yuFyaaN7tYCB/vbBbgwAEcAXhqGgaAagJ0fWPk8DJ2DEACgwaR7ZDDbghNA7ES6BwAQf8If/+pMoDXX2dvFNQHQPvO2/s5Mxse6lw/PFzDAZQIIOcBCIC/v3/ANNkDPj10Od8ZqvraQRrEXGDoUK0VEXwxAC+BtH41ADkCAAB/mAdFD9B4aUKvl6b2zrtdeypAEBhKr4mpFwTZJVA1D2IA8Bv2GgLw5dHL+9ZYfbIqDZKFACOAeQHj0QBoAgI708/OgdAD/J+fJgD4256OywvAfnCRMB3+FcsFCAIOHougLnA8Uz7WC6pSQIAMwM/vxTcggG/rL/d7g9bNjlyAWBt3rJ/VBTL1YxEQIDuAn99T0wCATw9c/hcnjywnl0XIxfFB1NMhTflSFxgYyNJPZgB1DoTvEkyc/sZ0jb3yugKw77xTXQjESiAQGEQ9HmXKh08COtVPpEASgB8g4P/aG1/q89ZYJ1a7BrjAAFUQEAQepR6QYw9F0aMgsQSy5VP6mREA7PnXf+zwyLvD+xeonpITD8kxBI9p7QsY/PcXnLDnVfYUbqtPeubl6frU2/E8SBOgEDzGUD94yNe7P/k/pv0vZv8D7HeC/bdgL0F78cWp0IKnTH6/0FNvjx/8jP2c3BcjMIjaJzSYsPf2tmx1Qb8awJQpkydvbPYUANsWxl4ZtFcS3ygoYKCkC/ZYci1/5Au1/Fdx/a840A8BLCnz3PkBR1ZqbJbxxXbLObDPikFj9QOtnpSP6WcCmLL1kgcPUNg1jwgCjIAvtV2UaZut4BonV+PiX3VRf/CqKk+eIFG7pp/GjjkcgRaD5eLrkIUfKOJJ+Zr65Qww5Z3dHR49QqN4gRIEPsqueRUCFoXB4guxHfUbX1WMlI/rf1mlHzrAunrPniHSnIptGSMIoBdmHLwy8I3kvGWfaMh/RZGP9EsBIAFYWOjpQ1TQ6pg2AYkBheGhh96T3oDpuLRVJf8VSj6hHysBG1s8DaB9W3/13nkaAQZBsWTFeatW4fJfQYbJ19A/5YsjvKcBCKtjDAL3Ym8PMe0z7C24S7v/Qomn5FP6ZQA/tPeAc4T2zqMIUAg0GBBHo5xZ/Qplv3NC/+RVJ3vAQUr2+uR+BAHFCe5V3p+k5Q9cTjpv4QcO5Gvon/r+vp5xklTxIuUtyrtIJ8BfJCTsoZ3kV7Rs1JaP1z9ZP3SAzkrg5QJg3dyPIuCDvUPNfIP8gTX02/BlXzDUK/JZ+heW9ZSzxA4vp9+kRQjwEwQIAO/tVz1z/oE5+A70T956sacAaN95u/wu7QCJgM/dKgaKpao62I6qVWrxlHxcvzMl8PKdJlf1DeN1eoWBCsJnjLOhOvb9hdSukk/onzx1d0fPAcDvXYARGCAfKOEjUqDPT7l3i421wLTuZdJI9VA+pn/y6pN8DwLQnIyO1BESgRQHqjOE0HkhK9nOW/iJA/m0/vcL+Z4EgD+4SDpUSHSCAcqJQqojlO7fxXbeSxsJ+S+9xJQv6ne8DuYBABe33CYTUCGgMKyp1Vpg+gKpf4kyTD7Sv6SM71kA0DZqEsEA1pFiPouKNbdf/fDyS2p78UVy+KH+YMfrYJ4A0LHr7dvkk+XukBGIEAgMqdrOe3I1W/5Ucvgnd7YO5gkA9to1yulq/bHD5XAMwHyWHXZwlX0fqMeekC8Mf/A7zpXAywoAPijCzhfsTxwviNmvtjly3uZ1pHZMPaY/2Jkm4PIDaE6VT5gUDgPs3591uubXjp237JMXMZuqlg/1LyzkeyIA+GYlecQoYCBCUA5Xnbe3k2qylakelx8c3Ok6mGcA2C9uu5U6ZhRBwCy5M+et+oKtXpAv6l9yhO+ZHsBXrZROWiUZKBi0S6BcTXa/w1CPyQ8O7nwdzFMAbHvflg+bVc5a7oeZ8Ciok2ctq2nxonpJfvCqk3xPBcDXrsFPm8bOm0Yklh924iKFH2DaVfKDnFkH8xgAvngBduC2wADn0H+nM87bspHSrqgPDgoKcqEEegCAdbN06LCIQGYg2DfOzd/KlmDaMfWC/oVlfE8GAEohJCAikCBIIObtd+4al36YwhAvyA8KcmodzIMA2nfeIpy8LSHAISQ767xVqzTUBwV9cYTv2QD4qq/R4eM4BAHEooNON1b73iHVS/KDgp1vAjwFgN/7Yd++CgMMwhbnnbd+HUM8tNUn+R4PoD75pptuQgwQBMGWu+K8hQvV4oOCJr5fyPd8APzBRTfeKDGAEEQMb+9y5ZptG4NomwjM2XUwzwJo23wjtJtkCIJproNprY6p5U9cUsZfCQD4I8tvgCfxiwwQhg/3u1hNflDJnzjR6XUwDwOw7+zb5wbEQKKQ6qrz1q6i1E98zvl1MA8D4Gu/uV7492gUCssOu3yRfe/j6oH91eUS6DEA/P4Pr78eMpApbHHdeVvWYeInPvfccy42AR4FcD61d+/e10sQ+vRZ2RXnLVuoiAe2sJC/cgCAUthbMAjh+hve3dUV5724VdIumCvrYJ4HYNsi/tNUorlYApVSiOl3uQnwLICO6uXXIevde0FxFy+yO0gB4NI6mOcB8B273r1WQpDa3MWLnFktih83btyqk/yVBYCvXXOtYNdd14USKN184fvjBHvur/v4Kw0AX/whIrCtvcvXaNkoAhi3rvnKA9Ca2kv4d7q+rnLjImVLBP0Ly/grDwB/eBkk8O5ed65xaasAwNV1sJ4BoG1br2uu6ZVc79ZFqlYB/V0tgR4GwFetvOaarpZAZXXsr+PGdakJ6AEA7D+/e83mi25eo37duNUn+SsTAF+/ZtkRty9SuKSQv1IB8MW73L9Qy76WKxdAu7UbLnKJv3IB9AAzABgADAAGAAOAAcAAYAAwABgADAAGAAOAkwBsVqtVTQD8uk19efAZxwuDjA+xbrPpWGlBXm5eUflpK+M7SLPZnbsHG/xFVwAcz0hPL6KvVpqenm6upn+am56e7ajnr8tMN5/qVP4Fy/bEqHATx3GhEbEbcqtJgeXplGVk5loalN/np6fvYN2DHdxcVltXANTEcVw6BdWeCW+vgPqO80kc95OjcDm1gous7ES+zZIWyWFmis0imJVwKjOFJ+TUSHf2E8cltrIAmDluvbUrAKzpHBdfR16tMRF+sZnCciyKCy/h3QPQkB0FrhwRn7YjJyfbnLQU6ksstZMAwjALDREYJFl0A2DPM3ER5eTVKiI58L0JDeRPC0K42FPuAahOA9ddbC6tE9jaWyuz44G86AI7DiCywKJYaVHOJsgszqIbgIrFnCmHCnYTlxJDY4FxscnqFoDTG8BgppRimdJenRkBCJTgAJYeJz9lLU8LBbJP6wWgEYR2GpG929I4Uz6IjBw6LmhQLgJoyuC4EPNZSl4+GOC4SgcAwAd3hHKmbLtOAGxgZOOIuzody0VVgsjYQIw38BQ6VFwDYM8N40zmRtWPC0BWzLjgCADfCFwn/qxOAPiiEC7cQhTBMC7lfOVSLoYohPkmVVZwDUBlDLjHs4zZQxbIQqUOAfAlYVxYqU4A7NUrKG8HX5LFNyVxYXjOtwH/NdvdAAA9LcrC+s1ZUHQy2hwCqIkV71EXABeAf+Hefj6FCwe0t3PcdkxwQwIXUoDP5o5bSksriKmcDMDeWGkptVQ2EHW0EnDOZM8UQdKVvE0DQGsKwK8XAHsOx8Wexu40iourEQIhqQmbokVw0cfkr6v8KTEqIjw8ImZTQSMNwFaxPXEp+N3ShEwLxifHxEVVaARHFBda4hBAGxikDLteACwRwpBjwQ6rAkiFiyvI0tgqT2dWyPO0sPXldgJAQ1a0/MtIZT4Nx1Crip7fkZFR5BCAdb2eAOrAbCQbD3ZTHiqGecoQpMPEgKoEnM5Ep2Xn5+1ICgfeU2THAJxLD+EiU3bk5uea48GEP6lCmUdil6Pzg03qeTQANCaAgNQtBNoy4IflliYejTwY8zQ5is/FiWkYjn8ax4WbK4VwbiwCCWxFqQKgPNMUuski3KL9dDbwhQSUFkGtWVzReaeoAQDUJC5fNwB24PQrZF8FASHGPij8yvwA/DRW7EhsWSFcRK5Ut/kTIDoTT8kAciLCs+SsYCsBlW+TmEiy1C2HCwCyTSI+nQBgSQh8l5T9mxKx1JAjTxcrormQbCybV4MZYpYdAQiLNWVewO6rKJILy5eq6HprVwGUA5AbWvUDABvdHVK7vkGq/3Dyn4VCs20TZ8oVRxV+EzEhKgHOUY0AgNurIbI3+NtJjVIWs3UNgK0UZIDIEl4/AHDqI6V4MC2KQT1fSaj8UzARiRQjuDqGboqtm1B6gwBC86nGMlp0owtJ5LQC3LKNNAVAJb4iZK2zZIJuIWS7VU8AJeFc9AnktKFytQJapdJfGs4lNkpNcSLdJ4eK4QEBxNVQ9StNFH4+UXEydEkzYdsbJABhG7AFobT18RGw2JobeD0BgJofigox8PtcbGgL5MSQaZfiYgc1Iz4excWfQwBUbo7mD60qD8gzEes+K05prQiBFjou9zyvKwAQ4krmiyzHJm/i9P/Cei5EBHQhRUaFF+nFlQhALn1noHzEgGmmNYVeYsoLDVGMAICvCIWFR8aszz1h5/UFwOeCXHUeLQYlyGWsHPyhTgqGE9IsIaLoxHHiv4okMc5hFVCtmVVHC/NjMK2iJoKnShUriMIAECtClvLKGuxjugEAUqOOIY/NtGNDG2FB3ej6C1KO5BYvpSxE7JMAAPWKQUOccA076K0SGjWXilZgAFjzAN0BAKlCuIOBCsE83IwWgX6S58rVURwzSvO12uGmeNE9wGQr6piWrmNRLgBIOM/6RYZ7AGCzDke+Jo6LxpZBwPwVNsog8KUVC+DR4ebtarMgAKrZbiMCAGJLlTyURBHuJABhQslyJFsa7Om7DsAOqh+sc6Dc4fM14PBwjnwiWp4Uwx6xUntBBO8q0QwCra7CdsasNRMCgeckANi61/DsdjHd5sazQaARCsvC+0LhsiElwtwgvU1OC+EWbQCmAlUbs5iLgvkTJoHYao1HammcswDANIQ5AA1Cu+gGAFjo8mHTHmGhgGfawb3Lnaw87aOeCdpRGfyJ/h2AJy4lWiJBQmGvqR1b4TSAigh2JAHOoF105+lwNvRQkIzIlg1U8cRG0CoosZ2l9uQGc1rGcQQghUrRcOBF72kFc434E8zMBno9ZwGciwdDwogkkGPBPboDAER/QiNwMFJdHZjjVIBmPFFeHAN/L456PlQaIa5ZQwCLqTp4LkH2mNJIwO4Ca1RjOKcBwF4sTv18qhU05aCJdwfA2TgwBTSL9Ywor6bcAnxuAJCEkNM9awYaFKEbNJM9b34otwIJsoJKE56rHr2zG7j4GGcBQNriMxKe6khhwXYHQFs6uHCCqlYD8Zsy8LCzgflxHFHswMhGWlASDA2NJOaC1QnYUvAp0A8szqMXBc5mmCIKUpwG0JqmLEHJdgK0Wgmn3dwhApqTmHBVDB8H1SEKWy8SNa3H/nwMrupbEYC49Vw8FgTn0kHqV5J2OQjgiB1EFbNXbDCZMps2OA1ACJj4UsIHKkENjChyd4sMzKPKwie+mEut5RSBWE4pR65sK0+SH+0BAImlAEKRFOjH0kxcBF4zLAnwcXj+WSkOLlT+BErnprP2dOcB8AVLOS46+4R0S7aaPMA1LMvqLoAmuClAPZHJhgCyiaKXAx/oZpaeaqirLs2MVh7uQgCNeZFcRFpB5bmGmvLsODAw5J6Syk1hHBcab84tLS+3FGVvAJ8OST8Fm2znAdgKgA+YYtJySizl5SW55vhQ0EBlt7q/SQpuC4k7y0g69NTHlh8LWa2Ii4sOB/8TX6Isiyc2tcFfhiyNjYuJAMUtJpcK+aa8BLgOYAoJjwgT9j7E5DQKxdV5ALy9fFM4ukZ4iLDXJqmkrRt2iZXExcaYVc+uzqXExqaco6cdmbGhYhMUFrdDru01iTEbmuAvYwRpXMgKc4V65nM6LyUqBLVQEQlZlcLfyItNEp9NlcbGJlR3unLYVJK2IhQtqIQsTck71y3b5Nrq6uoYjVZjXZ26+7CdKsk2Z2Rk5pTWKBLtDXXCnM9WXZRlzjBnFVWzHwW2VhZlZ2ZkmHfklTegT1+oQ/9nBTfhxNopb60uydkO7yC7qLLVrW1yXd8naLfZtD8pr3JqfrjNxrtpdht9B8ZGSQOAAcAAYAAwABgADAAGAAOAAcAAYAAwADgP4GozA4ABwABgADAAGACcAXD1mgHAANA5gKvdDAAGAEcAvMIMAJoAvMW0AHiRGQAYALzL1AC8zWgA3mckAG80HIB3mgLAW00C4L0mAvBmgwC82/4DfoPUbBGLvS4AAAAASUVORK5CYII=';
+</script>


### PR DESCRIPTION
The workload simulator is a single-page WebGPU test case that lets you vary parameters such as number of pixels drawn and number of draw calls among many others. It also lets you compare performance directly vs WebGL. You can configure it with URL parameters and send a link to investigate issues on someone else's browser, and it's also a good testbed for trying out new API features and checking their impact on performance.