### PR TITLE
Add function restrictions

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5089,7 +5089,7 @@ See [[#discard-statement]].
 
 * Recursion is not permitted.
     That is, there must be no cycles in the call graph.
-* A [=fragment=] shader must return the `position` [=built-in output variable|built-in variable=].
+* A [=vertex=] shader must return the `position` [=built-in output variable|built-in variable=].
     See [[#builtin-variables]].
 * An entry point must never be the target of a [=function call=].
 * Functions must not return a [=pointer type=].

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5097,7 +5097,6 @@ See [[#discard-statement]].
     the following storage classes:
     * [=storage classes/function=]
     * [=storage classes/private=]
-    * [=storage classes/handle=]
     * [=storage classes/workgroup=]
 * Each argument of a function call of pointer type must be one of:
     * An [[#address-of-expr|address-of expression]] of a

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5102,15 +5102,18 @@ See [[#discard-statement]].
     * An [[#address-of-expr|address-of expression]] of a
         [[#var-identifier-expr|variable identifier expression]]
     * A function parameter
-* [SHORTNAME] assumes no aliasing is present in the program. As such,
-    a function parameter of pointer type must not be used to read or write to
-    any [=memory locations=] of its [=originating variable=] that are also
-    written via:
+* [SHORTNAME] assumes no aliasing is present between any combination of
+    function parameters and variables.
+    As such, a function parameter of pointer type must not be used to read or
+    write to any [=memory locations=] of its [=originating variable=] that are
+    also written via:
     * Another function parameter in the same function
     * A statement or expression in the function using the originating variable directly
 
 Note: the aliasing restriction applies to memory location written by function
 calls in the function.
+
+Issue: Revisit aliasing rules for clarity.
 
 # Entry Points TODO # {#entry-points}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5085,15 +5085,32 @@ Note: The current function will not resume execution if the called function or
 any descendent called function executes a `discard` statement.
 See [[#discard-statement]].
 
-## Restrictions TODO ## {#function-restriction}
-TODO: *This is a stub*
+## Restrictions ## {#function-restriction}
 
-* Recursion is not permitted. (No cycle in the call graph.)
-* Function call parameters
- * Match type and number
- * Restrictions on pointers
- * Aliasing (?)
+* Recursion is not permitted.
+    That is, there must be no cycles in the call graph.
+* A [=fragment=] shader must return the `position` [=built-in output variable|built-in variable=].
+    See [[#builtin-variables]].
+* An entry point must never be the target of a [=function call=].
+* Functions must not return a [=pointer type=].
+* A [=formal parameter|function parameter=] of pointer type must be in one of
+    the following storage classes:
+    * [=storage classes/function=]
+    * [=storage classes/private=]
+    * [=storage classes/handle=]
+    * [=storage classes/workgroup=]
+* Each argument of a function call of pointer type must be one of:
+    * An [[#address-of-expr|address-of expression]] of a
+        [[#var-identifier-expr|variable identifier expression]]
+    * A function parameter
+* [SHORTNAME] assumes no aliasing is present in the program. As such,
+    a function parameter of pointer type must not read or write to any
+    [=memory locations=] of the [=originating variable=] that are written by:
+    * Another function parameter in the same function
+    * A statement or expression in the function using the originating variable directly
 
+Note: the aliasing restriction applies to memory location written by function
+calls in the function.
 
 # Entry Points TODO # {#entry-points}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5092,7 +5092,7 @@ See [[#discard-statement]].
 * A [=vertex=] shader must return the `position` [=built-in output variable|built-in variable=].
     See [[#builtin-variables]].
 * An entry point must never be the target of a [=function call=].
-* Functions must not return a [=pointer type=].
+* If a function has a return type, it must be a [=plain types|plain type=]
 * A [=formal parameter|function parameter=] of pointer type must be in one of
     the following storage classes:
     * [=storage classes/function=]
@@ -5104,8 +5104,9 @@ See [[#discard-statement]].
         [[#var-identifier-expr|variable identifier expression]]
     * A function parameter
 * [SHORTNAME] assumes no aliasing is present in the program. As such,
-    a function parameter of pointer type must not read or write to any
-    [=memory locations=] of the [=originating variable=] that are written by:
+    a function parameter of pointer type must not be used to read or write to
+    any [=memory locations=] of its [=originating variable=] that are also
+    written via:
     * Another function parameter in the same function
     * A statement or expression in the function using the originating variable directly
 


### PR DESCRIPTION
Fixes #1567, #1471, #1457, #1139

* No recursion
* No calling entry points
* fragment shader must return position
* aliasing restrictions
* pointer restrictions

The allowance handle pointer parameters is somewhat debatable, but I've included it since we don't have a clear alternative at the moment.