### PR TITLE
Update grammar for constexpr type constructors

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2768,7 +2768,7 @@ global_const_initializer
   : EQUAL const_expr
 
 const_expr
-  : type_decl PAREN_LEFT (const_expr COMMA)* const_expr PAREN_RIGHT
+  : type_decl PAREN_LEFT ((const_expr COMMA)* const_expr COMMA?)? PAREN_RIGHT
   | const_literal
 </pre>
 


### PR DESCRIPTION
Allow zero-valued constructors and trailing commas.

I assume the trailing comma part was just an omission from #1493, and I couldn't find or think of any reason not to allow zero-value constructors for global constant initializers.