### PR TITLE
Rename constant_id to override

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -413,12 +413,6 @@ literal_or_ident
     Declares a builtin variable.
     See [[#builtin-variables]].
 
-  <tr><td><dfn noexport dfn-for="attribute">`constant_id`
-    <td>non-negative i32 literal
-    <td>Must only be applied to module scope constant declaration of [=scalar=] type.
-
-    Specifies a [=pipeline-overridable=] constant.
-
   <tr><td><dfn noexport dfn-for="attribute">`group`
     <td>non-negative i32 literal
     <td>Must only be applied to a [=resource=] variable.
@@ -452,6 +446,16 @@ literal_or_ident
 
     Specifies a part of the user-defined IO of an entry point.
     See [[#input-output-locations]].
+
+  <tr><td><dfn noexport dfn-for="attribute">`override`
+    <td>An optional, non-negative i32 literal
+    <td>Must only be applied to module scope constant declaration of [=scalar=] type.
+
+    Specifies a [=pipeline-overridable=] constant.
+    In the WebGPU API, pipeline overridable constants are specified by the identifier
+    of the constant the attribute is applied to.
+    If the optional parameter is specified, the pipeline overridable constant
+    is referred to by the numeric id specified instead.
 
   <tr><td><dfn noexport dfn-for="attribute">`size`</dfn>
     <td>positive i32 literal
@@ -2728,19 +2732,21 @@ and the name denotes the value of that expression.
   </xmp>
 </div>
 
-When the declaration uses the [=constant_id=] attribute,
+When the declaration uses the [=override=] attribute,
 the constant is <dfn noexport>pipeline-overridable</dfn>. In this case:
 
   * The type must one of the [=scalar=] types.
   * The initializer expression is optional.
-  * The attribute's literal operand is known as the <dfn noexport>pipeline constant ID</dfn>,
+  * The attribute's literal operand, if present, is known as the <dfn noexport>pipeline constant ID</dfn>,
     and must be a non-negative integer value representable in 32 bits.
   * Pipeline constant IDs must be unique within the [SHORTNAME] program: Two module constants
     must not use the same pipeline constant ID.
   * The application can specify its own value for the name at pipeline-creation time.
-    The pipeline creation API accepts a mapping from the pipeline constant ID
-    to a value of the constant's type.
-    If the mapping has an entry for the ID, the value in the mapping is used.
+    The pipeline creation API accepts a mapping from overridable constant to a
+    value of the constant's type.
+    The constant is specified by the pipeline constant ID if it was specified
+    or by the constant's identifier otherwise.
+    If the mapping has an entry for the constant, the value in the mapping is used.
     Otherwise, the initializer expression must be present, and its value is used.
 
 Issue(dneto): What happens if the application supplies a constant ID that is not in the program?
@@ -2748,9 +2754,14 @@ Proposal: pipeline creation fails with an error.
 
 <div class='example wgsl global-scope' heading='Module constants, pipeline-overrideable'>
   <xmp>
-    [[constant_id(0)]]    let has_point_light : bool = true;      // Algorithmic control
-    [[constant_id(1200)]] let specular_param : f32 = 2.3;         // Numeric control
-    [[constant_id(1300)]] let gain : f32;                         // Must be overridden
+    [[override(0)]]    let has_point_light : bool = true;  // Algorithmic control
+    [[override(1200)]] let specular_param : f32 = 2.3;     // Numeric control
+    [[override(1300)]] let gain : f32;                     // Must be overridden
+    [[override]]       let width : f32 = 0.0;              // Specifed at the API level using
+                                                           // the name "width".
+    [[override]]       let depth : f32;                    // Specifed at the API level using
+                                                           // the name "depth".
+                                                           // Must be overridden.
   </xmp>
 </div>
 


### PR DESCRIPTION
Contributes to #1608

* Renames constant_id to override and makes the parameter optional
* Updates pipeline overridable constant description to describe that the
  name can be used unless an id is specified in the attribute