### PR TITLE
Add external_texture luminance functions

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2732,7 +2732,14 @@ dictionary GPUExternalTextureDescriptor : GPUObjectDescriptorBase {
 ### Sampling External Textures ### {#external-texture-sampling}
 
 External textures are represented in WGSL with `texture_external` and may be sampled using
-usual texture load/sample functions.
+usual texture load/sample functions, plus `textureLoadLuminance` and `textureSampleLuminance`.
+The latter return luminance values, potentially avoiding loading from the UV plane(s).
+
+Issue: What does this mean? Is it actually Luminance (Y) or is it Luma (Y')?
+How is it defined? The internal encoding of a decoded video is supposed to be an implementation
+detail. Can the definition of "luminance" differ based on the implementation, or is it a
+property of the media? Is there a common definiton of "luminance" that we can use to achieve the
+bandwidth savings for *most* videos?
 
 The provided `sampler` is used to sample any underlying texture(s).
 If there is one RGBA underlying texture, this behaves as usual.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -485,8 +485,13 @@ will make the GPU driver consider them different.
 In this specification, the `.` ("dot") syntax, common in programming languages, is used.
 The phrasing "`Foo.Bar`" means "the `Bar` member of the value (or interface) `Foo`."
 
-For example, where `buffer` is a {{GPUBuffer}}, `buffer.[[device]].[[adapter]]` means
-"the `[[adapter]]` internal slot of the `[[device]]` internal slot of `buffer`.
+The `?.` ("optional chaining") syntax, adopted from JavaScript, is also used.
+The phrasing "`Foo?.Bar`" means
+"if `Foo` is `null` or `undefined`, `Foo`; otherwise, `Foo.Bar`".
+
+For example, where `buffer` is a {{GPUBuffer}}, `buffer?.[[device]].[[adapter]]` means
+"if `buffer` is `null` or `undefined`, then `undefined`, otherwise,
+the `[[adapter]]` internal slot of the `[[device]]` internal slot of `buffer`.
 
 ### Internal Objects ### {#webgpu-internal-objects}
 
@@ -3057,15 +3062,18 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
             <th><dfn dfn lt="Binding Resource Type">Resource type</dfn>
             <th><dfn dfn>Binding type</dfn><br>
             <th><dfn dfn>Binding usage</dfn>
+            <th><dfn dfn>Binding cost</dfn> toward [=Limit=]
     </thead>
     <tr>
         <td rowspan=3>{{GPUBindGroupLayoutEntry/buffer}}
         <td rowspan=3>{{GPUBufferBinding}}
         <td>{{GPUBufferBindingType/"uniform"}}
         <td>[=internal usage/constant=]
+        <td>1 &rarr; {{supported limits/maxUniformBuffersPerShaderStage}}
     <tr>
         <td>{{GPUBufferBindingType/"storage"}}
         <td>[=internal usage/storage=]
+        <td rowspan=2>1 &rarr; {{supported limits/maxStorageBuffersPerShaderStage}}
     <tr>
         <td>{{GPUBufferBindingType/"read-only-storage"}}
         <td>[=internal usage/storage-read=]
@@ -3074,37 +3082,34 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
         <td rowspan=3>{{GPUBindGroupLayoutEntry/sampler}}
         <td rowspan=3>{{GPUSampler}}
         <td>{{GPUSamplerBindingType/"filtering"}}
-        <td>[=internal usage/constant=]
+        <td rowspan=3>[=internal usage/constant=]
+        <td rowspan=3>1 &rarr; {{supported limits/maxSamplersPerShaderStage}}
     <tr>
         <td>{{GPUSamplerBindingType/"non-filtering"}}
-        <td>[=internal usage/constant=]
     <tr>
         <td>{{GPUSamplerBindingType/"comparison"}}
-        <td>[=internal usage/constant=]
 
     <tr>
         <td rowspan=5>{{GPUBindGroupLayoutEntry/texture}}
         <td rowspan=5>{{GPUTextureView}}
         <td>{{GPUTextureSampleType/"float"}}
-        <td>[=internal usage/constant=]
+        <td rowspan=5>[=internal usage/constant=]
+        <td rowspan=5>1 &rarr; {{supported limits/maxSampledTexturesPerShaderStage}}
     <tr>
         <td>{{GPUTextureSampleType/"unfilterable-float"}}
-        <td>[=internal usage/constant=]
     <tr>
         <td>{{GPUTextureSampleType/"depth"}}
-        <td>[=internal usage/constant=]
     <tr>
         <td>{{GPUTextureSampleType/"sint"}}
-        <td>[=internal usage/constant=]
     <tr>
         <td>{{GPUTextureSampleType/"uint"}}
-        <td>[=internal usage/constant=]
 
     <tr>
         <td rowspan=2>{{GPUBindGroupLayoutEntry/storageTexture}}
         <td rowspan=2>{{GPUTextureView}}
         <td>{{GPUStorageTextureAccess/"read-only"}}
         <td>[=internal usage/storage-read=]
+        <td rowspan=2>1 &rarr; {{supported limits/maxStorageTexturesPerShaderStage}}
     <tr>
         <td>{{GPUStorageTextureAccess/"write-only"}}
         <td>[=internal usage/storage-write=]
@@ -3114,6 +3119,9 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
         <td rowspan=2>{{GPUExternalTexture}}
         <td>
         <td>[=internal usage/constant=]
+        <td>1 &rarr; {{supported limits/maxUniformBuffersPerShaderStage}}
+            <br>and<br>
+            3 &rarr; {{supported limits/maxSampledTexturesPerShaderStage}}
 </table>
 
 <div algorithm>
@@ -3300,28 +3308,27 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                         <div class=validusage>
                             - |this| is a [=valid=] {{GPUDevice}}.
                             - The {{GPUBindGroupLayoutEntry/binding}} of each entry in |descriptor| is unique.
-                            - For each shader stage, the number of entries in |descriptor| with a [$layout entry binding type$] of
-                                {{GPUBufferBindingType/"uniform"}} &le;
-                                |limits|.{{supported limits/maxUniformBuffersPerShaderStage}}.
-                            - For each shader stage, the number of entries in |descriptor| with a [$layout entry binding type$] of
-                                {{GPUBufferBindingType/"storage"}} &le;
-                                |limits|.{{supported limits/maxStorageBuffersPerShaderStage}}.
-                            - For each shader stage, the number of entries in |descriptor| with a [=binding member=] of
-                                {{GPUBindGroupLayoutEntry/texture}} &le;
-                                |limits|.{{supported limits/maxSampledTexturesPerShaderStage}}.
-                            - For each shader stage, the number of entries in |descriptor| with a [=binding member=] of
-                                {{GPUBindGroupLayoutEntry/storageTexture}} &le;
-                                |limits|.{{supported limits/maxStorageTexturesPerShaderStage}}.
-                            - For each shader stage, the number of entries in |descriptor| with a [=binding member=] of
-                                {{GPUBindGroupLayoutEntry/sampler}} &le;
-                                |limits|.{{supported limits/maxSamplersPerShaderStage}}.
-                            - The number of entries in |descriptor| with a [$layout entry binding type$] of
-                                {{GPUBufferBindingType/"uniform"}} and {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}} `true` &le;
-                                |limits|.{{supported limits/maxDynamicUniformBuffersPerPipelineLayout}}.
-                            - The number of entries in |descriptor| with a [$layout entry binding type$] of
-                                {{GPUBufferBindingType/"storage"}} and {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}} `true` &le;
-                                |limits|.{{supported limits/maxDynamicStorageBuffersPerPipelineLayout}}.
+                            - For each shader stage |stage| in
+                                &laquo; {{GPUShaderStage/VERTEX}}, {{GPUShaderStage/FRAGMENT}}, {{GPUShaderStage/COMPUTE}} &raquo;,
+                                the sums of the [=binding costs=], over the entries |entry| in
+                                |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}
+                                for which |entry|.{{GPUBindGroupLayoutEntry/visibility}} contains |stage|,
+                                must not exceed the corresponding limits in |limits|.
+                            - The **number** of entries |entry| in
+                                |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}, for which:
+                                <dl class=switch>
+                                    : |entry|.{{GPUBindGroupLayoutEntry/buffer}}?.{{GPUBufferBindingLayout/type}}
+                                        is {{GPUBufferBindingType/"uniform"}} and
+                                        |entry|.{{GPUBindGroupLayoutEntry/buffer}}?.{{GPUBufferBindingLayout/hasDynamicOffset}}
+                                        is `true`,
+                                    :: must be &le; |limits|.{{supported limits/maxDynamicUniformBuffersPerPipelineLayout}}.
 
+                                    : |entry|.{{GPUBindGroupLayoutEntry/buffer}}?.{{GPUBufferBindingLayout/type}}
+                                        is {{GPUBufferBindingType/"storage"}} and
+                                        |entry|.{{GPUBindGroupLayoutEntry/buffer}}?.{{GPUBufferBindingLayout/hasDynamicOffset}}
+                                        is `true`,
+                                    :: must be &le; |limits|.{{supported limits/maxDynamicStorageBuffersPerPipelineLayout}}.
+                                </dl>
                             - For each {{GPUBindGroupLayoutEntry}} |bindingDescriptor| in |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
                                 - Let |bufferLayout| be |bindingDescriptor|.{{GPUBindGroupLayoutEntry/buffer}}
                                 - Let |samplerLayout| be |bindingDescriptor|.{{GPUBindGroupLayoutEntry/sampler}}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7794,6 +7794,10 @@ dictionary GPUSwapChainDescriptor : GPUObjectDescriptorBase {
 </script>
 
 Issue: A {{GPUPredefinedColorSpace}} is necessary here.
+We may want this to default to "extended-srgb" if possible.
+It would be the same for non-float-format swapchains, but for float-format swapchains,
+"extended-srgb" is probably the most reasonable behavior:
+float + clamped-srgb just gets you high-bit-depth, but not high-dynamic-range.
 
 ## GPUSwapChain ## {#swapchain}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1255,6 +1255,34 @@ For more information on issuing CORS requests for image and video elements, cons
 - [[html#the-img-element]] <{img}>
 - [[html#media-elements]] {{HTMLMediaElement}}
 
+## Color Spaces ## {#color-spaces}
+
+WebGPU does not provide color management. All values within WebGPU (such as texture elements)
+are raw numeric values, not color-managed color values.
+
+WebGPU *does* interface with color-managed outputs (via {{GPUCanvasContext}}) and inputs
+(via {{GPUQueue/copyExternalImageToTexture()}} and {{GPUDevice/importExternalTexture()}}).
+Color conversion must be performed between the WebGPU numeric values and the external color values.
+These interface points locally define a color space, in which the WebGPU numeric values are to be
+interpreted, from options defined in [[css-color-4#predefined]].
+
+<script type=idl>
+enum GPUPredefinedColorSpace {
+    "srgb",
+};
+</script>
+
+Issue: Replace this with the `PredefinedColorSpaceEnum` from the
+[canvas color space proposal](https://github.com/WICG/canvas-color-space/blob/main/CanvasColorSpaceProposal.md).
+
+Issue: The most urgent additional option to add here is "srgb-linear", needed to decode
+nonlinearly encoded data into linearly-encoded textures (e.g. float16 textures).
+
+<dl dfn-type=enum-value dfn-for=GPUPredefinedColorSpace>
+    : <dfn>"srgb"</dfn>
+    :: The CSS predefined color space <a value for=color()>srgb</a>.
+</dl>
+
 
 # Initialization # {#initialization}
 
@@ -1619,6 +1647,7 @@ interface GPUDevice : EventTarget {
     GPUBuffer createBuffer(GPUBufferDescriptor descriptor);
     GPUTexture createTexture(GPUTextureDescriptor descriptor);
     GPUSampler createSampler(optional GPUSamplerDescriptor descriptor = {});
+    GPUExternalTexture importExternalTexture(GPUExternalTextureDescriptor descriptor);
 
     GPUBindGroupLayout createBindGroupLayout(GPUBindGroupLayoutDescriptor descriptor);
     GPUPipelineLayout createPipelineLayout(GPUPipelineLayoutDescriptor descriptor);
@@ -1762,7 +1791,7 @@ GPUBuffer includes GPUObjectBase;
         Issue(gpuweb/gpuweb#605): Specify {{GPUBuffer/[[mapping]]}} in term of `DataBlock` similarly
         to `AllocateArrayBuffer`?
 
-    : <dfn>\[[mapping_range]]</dfn> of type [=list=]&lt;[=Number=]&gt; or `null`.
+    : <dfn>\[[mapping_range]]</dfn> of type [=list=]&lt;{{unsigned long long}}&gt; or `null`.
     ::
         The range of this {{GPUBuffer}} that is mapped.
 
@@ -2602,6 +2631,102 @@ If a format is listed in [[#plain-color-formats]] with {{GPUTextureUsage/RENDER_
 color renderable format. Any other format is not a color renderable format. Any depth/stencil format is a
 depth or stencil renderable format. Any other format is not a depth or stencil renderable format.
 
+## <dfn interface>GPUExternalTexture</dfn> ## {#gpu-external-texture}
+
+A {{GPUExternalTexture}} is a sampleable texture wrapping an external video object.
+The contents of a {{GPUExternalTexture}} object may not change, either from inside WebGPU
+(it is only sampleable) or from outside WebGPU (e.g. video frame advancement).
+
+Issue: Update this description with canvas.
+
+Note: External textures *can* be implemented without creating a copy of the imported source,
+but a user agent may not always implement this for all cases.
+
+<script type=idl>
+[Exposed=Window]
+interface GPUExternalTexture {
+};
+GPUExternalTexture includes GPUObjectBase;
+</script>
+
+{{GPUExternalTexture}} has the following internal slots:
+
+<dl dfn-type=attribute dfn-for="GPUExternalTexture">
+    : <dfn>\[[destroyed]]</dfn>, of type `boolean`
+    ::
+        Indicates whether the object has been destroyed (can no longer be used).
+        Initially set to `false`.
+
+        <!-- Move this to an internal object if GPUExternalTexture becomes Serializable. -->
+</dl>
+
+### Importing External Textures ### {#external-texture-creation}
+
+An external texture is created from an external video object
+using {{GPUDevice/importExternalTexture()}}.
+
+Issue: Update this description with canvas.
+
+External textures are destroyed automatically, as a microtask,
+instead of manually or upon garbage collection like other resources.
+
+<script type=idl>
+dictionary GPUExternalTextureDescriptor : GPUObjectDescriptorBase {
+    required HTMLVideoElement source;
+    GPUPredefinedColorSpace colorSpace = "srgb";
+};
+</script>
+
+<dl dfn-type=method dfn-for=GPUDevice>
+    : <dfn>importExternalTexture(descriptor)</dfn>
+    ::
+        Creates a {{GPUExternalTexture}} wrapping the provided image source.
+
+        <div algorithm=GPUDevice.importExternalTexture>
+            **Called on:** {{GPUDevice}} this.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPUDevice/importExternalTexture(descriptor)">
+                |descriptor|: Provides the external image source object (and any creation options).
+            </pre>
+
+            **Returns:** {{GPUExternalTexture}}
+
+            1. Let |source| be |descriptor|.{{GPUExternalTextureDescriptor/source}}.
+
+            1. If |source| <l spec=html>[=is not origin-clean=]</l>,
+                throw a {{SecurityError}} and stop.
+
+            1. Let |data| be the result of converting the current image contents of |source| into
+                the color space |descriptor|.{{GPUExternalTextureDescriptor/colorSpace}}.
+
+                Note: This is described like a copy, but may be implemented as a reference to
+                read-only underlying data plus appropriate metadata to perform conversion later.
+
+            1. Let |result| be a new {{GPUExternalTexture}} object wrapping |data|.
+
+            1. [=Queue a microtask=] to set |result|.{{GPUExternalTexture/[[destroyed]]}} to `true`,
+                releasing the underlying resource.
+
+                Issue: Is this too restrictive?
+
+            1. Return |result|.
+        </div>
+</dl>
+
+### Sampling External Textures ### {#external-texture-sampling}
+
+External textures are represented in WGSL with `texture_external` and may be sampled using
+usual texture load/sample functions.
+
+The provided `sampler` is used to sample any underlying texture(s).
+If there is one RGBA underlying texture, this behaves as usual.
+If there are several underlying textures (Y+U+V or Y+UV), the sampler is used to sample each
+underlying texture separately, prior to conversion from YUV to the sampled value.
+
+The loaded/sampled values are in the color space set by {{GPUExternalTextureDescriptor/colorSpace}}.
+
+
 # Samplers # {#samplers}
 
 ## <dfn interface>GPUSampler</dfn> ## {#sampler-interface}
@@ -2871,6 +2996,7 @@ dictionary GPUBindGroupLayoutEntry {
     GPUSamplerBindingLayout sampler;
     GPUTextureBindingLayout texture;
     GPUStorageTextureBindingLayout storageTexture;
+    GPUExternalTextureBindingLayout externalTexture;
 };
 </script>
 
@@ -2891,29 +3017,37 @@ dictionary GPUBindGroupLayoutEntry {
 
     : <dfn>buffer</dfn>
     ::
-        When not `undefined` indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
+        When not `undefined`, indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
         is {{GPUBufferBinding}}.
 
     : <dfn>sampler</dfn>
     ::
-        When not `undefined` indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
+        When not `undefined`, indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
         is {{GPUSampler}}.
 
     : <dfn>texture</dfn>
     ::
-        When not `undefined` indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
+        When not `undefined`, indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
         is {{GPUTextureView}}.
 
     : <dfn>storageTexture</dfn>
     ::
-        When not `undefined` indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
+        When not `undefined`, indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
         is {{GPUTextureView}}.
+
+    : <dfn>externalTexture</dfn>
+    ::
+        When not `undefined`, indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
+        is {{GPUExternalTexture}}.
 </dl>
 
-The [=binding member=] of a {{GPUBindGroupLayoutEntry}} is determined by which member of the {{GPUBindGroupLayoutEntry}}
-is defined: {{GPUBindGroupLayoutEntry/buffer}}, {{GPUBindGroupLayoutEntry/sampler}},
-{{GPUBindGroupLayoutEntry/texture}}, or {{GPUBindGroupLayoutEntry/storageTexture}}. Only one may be
-defined for any given {{GPUBindGroupLayoutEntry}}. Each member has an associated {{GPUBindingResource}}
+The [=binding member=] of a {{GPUBindGroupLayoutEntry}} is determined by which member of the
+{{GPUBindGroupLayoutEntry}} is defined:
+{{GPUBindGroupLayoutEntry/buffer}}, {{GPUBindGroupLayoutEntry/sampler}},
+{{GPUBindGroupLayoutEntry/texture}}, {{GPUBindGroupLayoutEntry/storageTexture}}, or
+{{GPUBindGroupLayoutEntry/externalTexture}}.
+Only one may be defined for any given {{GPUBindGroupLayoutEntry}}.
+Each member has an associated {{GPUBindingResource}}
 type and each [=binding type=] has an associated [=internal usage=], given by this table:
 
 <table class="data" style="white-space: nowrap">
@@ -2974,6 +3108,12 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
     <tr>
         <td>{{GPUStorageTextureAccess/"write-only"}}
         <td>[=internal usage/storage-write=]
+
+    <tr>
+        <td rowspan=2>{{GPUBindGroupLayoutEntry/externalTexture}}
+        <td rowspan=2>{{GPUExternalTexture}}
+        <td>
+        <td>[=internal usage/constant=]
 </table>
 
 <div algorithm>
@@ -2987,6 +3127,8 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
         1. Return |entry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/sampleType}}.
     1. If |entry|.{{GPUBindGroupLayoutEntry/storageTexture}} is not `undefined`:
         1. Return |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/access}}.
+    1. If |entry|.{{GPUBindGroupLayoutEntry/externalTexture}} is not `undefined`:
+        1. Return {{GPUTextureSampleType/"float"}}.
 </div>
 
 <script type=idl>
@@ -3116,6 +3258,11 @@ truly optional.
             This enables Metal-based WebGPU implementations to back the respective bind groups with
             `MTLArgumentBuffer` objects that are more efficient to bind at run-time.
 </dl>
+
+<script type=idl>
+dictionary GPUExternalTextureBindingLayout {
+};
+</script>
 
 A {{GPUBindGroupLayout}} object has the following internal slots:
 
@@ -3258,7 +3405,7 @@ dictionary GPUBindGroupDescriptor : GPUObjectDescriptorBase {
 A {{GPUBindGroupEntry}} describes a single resource to be bound in a {{GPUBindGroup}}.
 
 <script type=idl>
-typedef (GPUSampler or GPUTextureView or GPUBufferBinding) GPUBindingResource;
+typedef (GPUSampler or GPUTextureView or GPUBufferBinding or GPUExternalTexture) GPUBindingResource;
 
 dictionary GPUBindGroupEntry {
     required GPUIndex32 binding;
@@ -7240,6 +7387,10 @@ GPUQueue includes GPUObjectBase;
         Issues a copy operation of the contents of a platform image/canvas
         into the destination texture.
 
+        Issue: A color conversion to a {{GPUPredefinedColorSpace}} is necessary here.
+        Temporarily disallow float targets until there is an upstream decision on whether "srgb"
+        means extended-srgb or clamped-srgb.
+
         <div algorithm=GPUQueue.copyExternalImageToTexture>
             **Called on:** {{GPUQueue}} this.
 
@@ -7624,6 +7775,8 @@ dictionary GPUSwapChainDescriptor : GPUObjectDescriptorBase {
     GPUCanvasCompositingAlphaMode compositingAlphaMode = "opaque";
 };
 </script>
+
+Issue: A {{GPUPredefinedColorSpace}} is necessary here.
 
 ## GPUSwapChain ## {#swapchain}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2708,6 +2708,16 @@ dictionary GPUExternalTextureDescriptor : GPUObjectDescriptorBase {
                 Note: This is described like a copy, but may be implemented as a reference to
                 read-only underlying data plus appropriate metadata to perform conversion later.
 
+                Issue: It is currently undetermined whether the default colorSpace, "srgb", is
+                extended-srgb or clamped-srgb.
+                This will be determined upstream as the semantics around super-srgb image sources
+                get defined. Unfortunately we can't sidestep it for now because video sources
+                can go already go outside the srgb range.
+                The upstream determination will change whether using the default colorSpace
+                option can result in sampling values greater than 1.0 or not.
+                If upstream decides to make "srgb" mean clamped-srgb, we also have the option
+                of changing our default to `"extended-srgb"`.
+
             1. Let |result| be a new {{GPUExternalTexture}} object wrapping |data|.
 
             1. [=Queue a microtask=] to set |result|.{{GPUExternalTexture/[[destroyed]]}} to `true`,

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -212,7 +212,7 @@ The last two are the start and end of execution of a shader.
 The events are:
 
 1. <dfn noexport>Shader module creation</dfn>
-    * This occurs when the 
+    * This occurs when the
         [[WebGPU#dom-gpudevice-createshadermodule|WebGPU createShaderModule]] method
         is called.
         The source text for a [SHORTNAME] program is provided at this time.
@@ -2154,6 +2154,17 @@ The following table lists the correspondence between WGSL texel formats and
 * The parameterized type for the images is the type after conversion from sampling.
     E.g. you can have an image with texels with 8bit unorm components, but when you sample
     them you get a 32-bit float result (or vec-of-f32).
+
+### External Sampled Texture Types ### {#external-texture-type}
+
+<pre class='def'>
+`texture_external`
+</pre>
+
+`texture_external` is an opaque type which can encapsulate multiple 2D planes of data (e.g. RGBA, Y+UV),
+metadata about how to convert coordinates before sampling or loading from those planes (crop and rotation),
+and metadata about how to convert those intermediate values into the appropriate color space
+before they are returned by the sample/load function.
 
 ### Multisampled Texture Types ### {#multisampled-texture-type}
 
@@ -6808,6 +6819,7 @@ textureDimensions(t : texture_storage_1d<F>) -> i32
 textureDimensions(t : texture_storage_2d<F>) -> vec2<i32>
 textureDimensions(t : texture_storage_2d_array<F>) -> vec2<i32>
 textureDimensions(t : texture_storage_3d<F>) -> vec3<i32>
+textureDimensions(t : texture_external) -> vec2<i32>
 ```
 
 **Parameters:**
@@ -6815,8 +6827,8 @@ textureDimensions(t : texture_storage_3d<F>) -> vec3<i32>
 <table class='data'>
   <tr><td>`t`<td>
   The [sampled](#sampled-texture-type),
-  [multisampled](#multisampled-texture-type), [depth](#texture-depth), or
-  [storage](#texture-storage) texture.
+  [multisampled](#multisampled-texture-type), [depth](#texture-depth),
+  [storage](#texture-storage), or [external](#external-texture-type) texture.
   <tr><td>`level`<td>
   The mip level, with level 0 containing a full size version of the texture.<br>
   If omitted, the dimensions of level 0 are returned.
@@ -6844,6 +6856,7 @@ textureLoad(t : [[access(read)]] texture_storage_1d<F>, coords : i32) -> vec4<T>
 textureLoad(t : [[access(read)]] texture_storage_2d<F>, coords : vec2<i32>) -> vec4<T>
 textureLoad(t : [[access(read)]] texture_storage_2d_array<F>, coords : vec2<i32>, array_index : i32) -> vec4<T>
 textureLoad(t : [[access(read)]] texture_storage_3d<F>, coords : vec3<i32>) -> vec4<T>
+textureLoad(t : texture_external, coords : vec2<i32>) -> vec4<f32>
 ```
 
 For [read-only storage textures](#texture-storage) the returned channel format `T`
@@ -6856,8 +6869,8 @@ format to channel format.
 <table class='data'>
   <tr><td>`t`<td>
   The [sampled](#sampled-texture-type),
-  [multisampled](#multisampled-texture-type), [depth](#texture-depth) or
-  [read-only storage](#texture-storage) texture.
+  [multisampled](#multisampled-texture-type), [depth](#texture-depth),
+  [read-only storage](#texture-storage), or [external](#external-texture-type) texture.
   <tr><td>`coords`<td>
   The 0-based texel coordinate.
   <tr><td>`array_index`<td>
@@ -6872,7 +6885,6 @@ format to channel format.
 
 If all the parameters are within bounds, the unfiltered texel data.<br>
 If any of the parameters are out of bounds, then zero in all components.
-
 
 ### `textureNumLayers` ### {#texturenumlayers}
 
@@ -6971,14 +6983,17 @@ textureSample(t : texture_depth_2d_array, s : sampler, coords : vec2<f32>, array
 textureSample(t : texture_depth_2d_array, s : sampler, coords : vec2<f32>, array_index : i32, offset : vec2<i32>) -> f32
 textureSample(t : texture_depth_cube, s : sampler, coords : vec3<f32>) -> f32
 textureSample(t : texture_depth_cube_array, s : sampler, coords : vec3<f32>, array_index : i32) -> f32
+textureSample(t : texture_external, s : sampler, coords : vec2<f32>) -> vec4<f32>
+textureSample(t : texture_external, s : sampler, coords : vec2<f32>, offset : vec2<i32>) -> vec4<f32>
 ```
 
 **Parameters:**
 
 <table class='data'>
   <tr><td>`t`<td>
-  The [sampled](#sampled-texture-type) or [depth](#texture-depth) texture to
-  sample.
+  The [sampled](#sampled-texture-type), [depth](#texture-depth),
+  or [external](#external-texture-type)
+  texture to sample.
   <tr><td>`s`<td>
   The [sampler type](#sampler-type).
   <tr><td>`coords`<td>
@@ -6998,7 +7013,6 @@ textureSample(t : texture_depth_cube_array, s : sampler, coords : vec3<f32>, arr
 **Returns:**
 
 The sampled value.
-
 
 ### `textureSampleBias` ### {#texturesamplebias}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2166,6 +2166,10 @@ metadata about how to convert coordinates before sampling or loading from those 
 and metadata about how to convert those intermediate values into the appropriate color space
 before they are returned by the sample/load function.
 
+External textures can uniquely provide luminance values in addition to RGBA values.
+If the internal representation of the external texture is suitable (e.g. multiplanar YUV data),
+this can save significant memory and compute overhead.
+
 ### Multisampled Texture Types ### {#multisampled-texture-type}
 
 <pre class='def'>
@@ -6886,6 +6890,14 @@ format to channel format.
 If all the parameters are within bounds, the unfiltered texel data.<br>
 If any of the parameters are out of bounds, then zero in all components.
 
+### `textureLoadLuminance` ### {#textureloadluminance}
+
+Reads a single texel's luminance value from a `texture_external`, without sampling or filtering.
+
+```rust
+textureLoadLuminance(t : texture_external, coords : vec2<i32>) -> f32
+```
+
 ### `textureNumLayers` ### {#texturenumlayers}
 
 Returns the number of layers (elements) of an array texture.
@@ -7013,6 +7025,17 @@ textureSample(t : texture_external, s : sampler, coords : vec2<f32>, offset : ve
 **Returns:**
 
 The sampled value.
+
+### `textureSampleLuminance` ### {#texturesampleluminance}
+
+Samples a luminance value from a `texture_external`,
+where 1.0 is the maximum luminance of an SDR source.
+Must only be used in a [=fragment=] shader stage.
+
+```rust
+textureSampleLuminance(t : texture_external, s : sampler, coords : vec2<f32>) -> f32
+textureSampleLuminance(t : texture_external, s : sampler, coords : vec2<f32>, offset : vec2<i32>) -> f32
+```
 
 ### `textureSampleBias` ### {#texturesamplebias}
 


### PR DESCRIPTION
## Draft, dependent on #1666

There are some big open questions with this proposal, as discovered when I was trying to write spec for it. It's very possible that speccing a portable behavior for this isn't going to be tractable. We could do a non-portable behavior (where the definition of luminance isn't 100% consistent but is as close as we can get). However the value of this addition may not be worth the spec effort right now, at least until we have some concrete experiments showing performance benefits.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1681.html" title="Last updated on Apr 28, 2021, 1:13 AM UTC (ccd3d69)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1681/dc7773d...kainino0x:ccd3d69.html" title="Last updated on Apr 28, 2021, 1:13 AM UTC (ccd3d69)">Diff</a>