### PR TITLE
Add vertex and fragment interface matching rules

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4249,9 +4249,24 @@ details.
             - if |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}} is not `null`:
                 - [$validating GPUDepthStencilState$](|descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}) succeeds.
             - [$validating GPUMultisampleState$](|descriptor|.{{GPURenderPipelineDescriptor/multisample}}) succeeds.
+            - For each user-defined output of
+                |descriptor|.{{GPURenderPipelineDescriptor/vertex}} there must
+                be a user-defined input of
+                |descriptor|.{{GPURenderPipelineDescriptor/fragment}} that
+                matches the
+                [location](https://gpuweb.github.io/gpuweb/wgsl/#input-output-locations),
+                type, and
+                [interpolation](https://gpuweb.github.io/gpuweb/wgsl/#interpolation)
+                of the output.
+            - For each user-defined input of
+                |descriptor|.{{GPURenderPipelineDescriptor/fragment}} there
+                must be a user-defined output of
+                |descriptor|.{{GPURenderPipelineDescriptor/vertex}} that
+                [location](https://gpuweb.github.io/gpuweb/wgsl/#input-output-locations),
+                type, and
+                [interpolation](https://gpuweb.github.io/gpuweb/wgsl/#interpolation)
+                of the input.
 </div>
-
-Issue: validate interface matching rules between VS and FS.
 
 Issue: should we validate that `cullMode` is none for points and lines?
 


### PR DESCRIPTION
Fixes #1563

* Requires each user-defined vertex output and user-defined fragment
  input to match a user-defined fragment input or vertex output
  respectively in terms of location, type and interpolation


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/alan-baker/gpuweb/pull/1683.html" title="Last updated on Apr 28, 2021, 1:53 PM UTC (2672443)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1683/dc7773d...alan-baker:2672443.html" title="Last updated on Apr 28, 2021, 1:53 PM UTC (2672443)">Diff</a>