### PR TITLE
Clarify type matching for var initializer

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2571,7 +2571,7 @@ A <dfn dfn noexport>variable declaration</dfn>:
 * Determines the variable’s name, storage class, and store type (and hence its [=reference type=]).
 * Ensures the execution environment allocates storage for a value of the store type, for the lifetime of the variable.
 * Optionally have an *initializer* expression, if the variable is in the [=storage classes/private=] or [=storage classes/function=] storage classes.
-    If present, the initializer's type must match the store type of the variable.
+    If present, the initializer expression must evaluate to the variable's store type.
 
 When an identifier use [=resolves=] to a variable declaration,
 the identifer is an expression denoting the reference [=memory view=] for the variable's storage,


### PR DESCRIPTION
This implicitly accommodates the Load Rule.