### PR TITLE
wgsl: Fix typo in vertex_index

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6073,7 +6073,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
       <td width="50%">Index of the current vertex within the current API-level draw command,
          independent of draw instancing.
 
-         For a non-indexed draw, the first vertex has an index equal to the `firstIndex` argument
+         For a non-indexed draw, the first vertex has an index equal to the `firstVertex` argument
          of the draw, whether provided directly or indirectly.
          The index is incremented by one for each additional vertex in the draw instance.
 


### PR DESCRIPTION
`firstIndex` should be `firstVertex` as there are no indices in non-indexed draws.