### PR TITLE
wgsl: only atomic modifications are mutually ordered

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2371,21 +2371,9 @@ texel_format
 
 ## Atomic Types ## {#atomic-types}
 
-Operations on atomic objects in [SHORTNAME] are mutually ordered for each object.
-That is, during execution of a shader stage, for each atomic object A, all
-agents observe the same order of operations applied to A.
-The ordering for distinct atomic objects may not be related in any way; no
-causality is implied.
-Note that variables in [=storage classes/workgroup=] storage are shared within a
-[=compute shader stage/workgroup=], but are not shared between different
-workgroups.
-
-Atomic objects may only be operated on by the
-[[#atomic-builtin-functions|atomic builtin functions]].
-
-Atomic types may only be instantiated by variables in the [=storage
-classes/workgroup=] storage class or `read_write` [=attribute/access=] variables in the
-[=storage classes/storage=] storage class.
+An <dfn noexport>atomic type</dfn> encapsulates a [=scalar=] type such that:
+* atomic objects provide certain guarantees to concurrent observers, and
+* the only valid operations on atomic objects are the [[#atomic-builtin-functions|atomic builtin functions]].
 
 <table class='data'>
   <thead>
@@ -2394,6 +2382,22 @@ classes/workgroup=] storage class or `read_write` [=attribute/access=] variables
   <tr algorith="atomic type"><td>atomic&lt;|T|&gt;
     <td>Atomic of type |T|. |T| must be either [=u32=] or [=i32=].
 </table>
+
+Atomic types may only be instantiated by variables in the [=storage
+classes/workgroup=] storage class or `read_write` [=attribute/access=] variables in the
+[=storage classes/storage=] storage class.
+
+An <dfn noexport>atomic modification</dfn> is any operation on an atomic object which sets the content of the object.
+The operation counts as a modification even if the new value is the same as the object's existing value.
+
+In [SHORTNAME], atomic modifications are mutually ordered, for each object.
+That is, during execution of a shader stage, for each atomic object *A*, all
+agents observe the same order of modification operations applied to *A*.
+The ordering for distinct atomic objects may not be related in any way; no
+causality is implied.
+Note that variables in [=storage classes/workgroup=] storage are shared within a
+[=compute shader stage/workgroup=], but are not shared between different
+workgroups.
 
 TODO: Add links the eventual memory model descriptions.
 
@@ -7279,6 +7283,7 @@ atomicLoad(atomic_ptr : ptr<SC, atomic<T>>) -> T
 ```
 
 Returns the atomically loaded the value pointed to by `atomic_ptr`.
+It does not [=atomic modification|modify=] the object.
 
 ### Atomic Store ### {#atomic-store}
 


### PR DESCRIPTION
It's a fact of life:  relaxed atomic loads are not mutually ordered.  This is weird, but true.
Mutual ordering only exists among modifications.

This also adds a linkable definition for "atomic type", and reorganizes just a little bit.