### PR TITLE
add atomic type, texture type, store type to storable; adjust rules for var and let. issue #1686

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1196,13 +1196,13 @@ and how to use variables with it.
       <td>Read-write
       <td>Invocations in the same [=compute shader stage|compute shader=] [=compute shader stage/workgroup=]
       <td>[=Module scope=]
-      <td>[=Storable=], except for texture and [=sampler=] types
+      <td>[=Storable=] types, except for texture and [=sampler=] types
       <td>
   <tr><td><dfn noexport dfn-for="storage classes">uniform</dfn>
       <td>Read-only
       <td>Invocations in the same [=shader stage=]
       <td>[=Module scope=]
-      <td>[=Atomic-free=] [=host-shareable=]
+      <td>[=Atomic-free=] [=host-shareable=] types
       <td>For [=uniform buffer=] variables
   <tr><td><dfn noexport dfn-for="storage classes">storage</dfn>
       <td>Readable.<br>
@@ -1215,7 +1215,7 @@ and how to use variables with it.
       <td>Read-only
       <td>Invocations in the same shader stage
       <td>[=Module scope=]
-      <td>Opaque representation of handle to a [=sampler=] or [=texture=]
+      <td>[=Sampler=] types or [=texture=] types
       <td>Used for sampler and texture variables<br>
           The token `handle` is reserved: it is never used in a [SHORTNAME] program.
 </table>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -836,11 +836,11 @@ An <dfn noexport>atomic type</dfn> encapsulates a [=scalar=] type such that:
   <thead>
     <tr><th>Type<th>Description
   </thead>
-  <tr algorith="atomic type"><td>atomic&lt;|T|&gt;
+  <tr algorithm="atomic type"><td>atomic&lt;|T|&gt;
     <td>Atomic of type |T|. |T| must be either [=u32=] or [=i32=].
 </table>
 
-The type of an expression must not be an atomic type.
+An expression must not evaluate to an atomic type.
 
 Atomic types may only be instantiated by variables in the [=storage
 classes/workgroup=] storage class or `read_write` [=attribute/access=] variables in the
@@ -936,7 +936,7 @@ Restrictions on runtime-sized arrays:
     for a variable in the [=storage classes/storage=] storage class may be a runtime-sized array.
 * A runtime-sized array must not be used as the store type or contained within
     a store type in any other cases.
-* The type of an expression must not be a runtime-sized array type.
+* An expression must not evaluate to a runtime-sized array type.
 
 Issue: (dneto): Complete description of `Array<E,N>`
 
@@ -1068,7 +1068,7 @@ The composite types are:
 
 ### Atomic-Free Types ### {#atomic-free-types}
 
-A [=plain type=] is <dfn>atomic-free</dfn> if it is:
+A [=plain type=] is <dfn>atomic-free</dfn> if it is one of:
 * a [=scalar=] type
 * a [=vector=] type
 * a [=matrix=] type
@@ -1099,14 +1099,18 @@ structure or array.
 
 ### Storable Types ### {#storable-types}
 
-The following types are <dfn dfn noexport>storable</dfn>:
+A type is <dfn dfn noexport>storable</dfn> if it is one of:
 
-* [[#scalar-types]]
-* [[#vector-types]]
-* [[#matrix-types]]
-* [[#array-types]] if its element type is storable.
-* [[#struct-types]] if all its members are storable.
-* [[#atomic-types]]
+* a [=scalar=] type
+* a [=vector=] type
+* a [=matrix=] type
+* an [=atomic type|atomic=] type
+* an [=array=] type, if its element type is storable.
+* a [=structure=] type, if each of member is storable.
+* a [=texture=] type
+* a [=sampler=] type
+
+Note: [=Atomic-free=] [=plain types=] are storable.
 
 ### IO-shareable Types ### {#io-shareable-types}
 
@@ -1137,14 +1141,14 @@ as described in [[#memory-layouts]].
 We will see in [[#module-scope-variables]] that the [=store type=] of [=uniform buffer=] and [=storage buffer=]
 variables must be host-shareable.
 
-The following types are <dfn dfn noexport>host-shareable</dfn>:
+A type is <dfn dfn noexport>host-shareable</dfn> if it is one of:
 
-* [=numeric scalar=] types
-* [=numeric vector=] types
-* [[#matrix-types]]
-* [[#array-types]] if the array element type is host-shareable
-* [[#struct-types]] if each member is host-shareable
-* [[#atomic-types]]
+* a [=numeric scalar=] type
+* a [=numeric vector=] type
+* a [=matrix=] type
+* an [=atomic type|atomic=] type
+* an [=array=] type, if its element type is host-shareable
+* a [=structure=] type, if all its members are host-shareable
 
 [SHORTNAME] defines the following attributes that affect memory layouts:
  * [=attribute/stride=]
@@ -1180,25 +1184,25 @@ and how to use variables with it.
       <td>Read-write
       <td>Same invocation only
       <td>[=Function scope=]
-      <td>[=Storable=]
+      <td>[=Atomic-free=] [=plain type=]
       <td>
   <tr><td><dfn noexport dfn-for="storage classes">private</dfn>
       <td>Read-write
       <td>Same invocation only
       <td>[=Module scope=]
-      <td>[=Storable=]
+      <td>[=Atomic-free=] [=plain type=]
       <td>
   <tr><td><dfn noexport dfn-for="storage classes">workgroup</dfn>
       <td>Read-write
       <td>Invocations in the same [=compute shader stage|compute shader=] [=compute shader stage/workgroup=]
       <td>[=Module scope=]
-      <td>[=Storable=]
+      <td>[=Storable=], except for texture and [=sampler=] types
       <td>
   <tr><td><dfn noexport dfn-for="storage classes">uniform</dfn>
       <td>Read-only
       <td>Invocations in the same [=shader stage=]
       <td>[=Module scope=]
-      <td>[=Host-shareable=]
+      <td>[=Atomic-free=] [=host-shareable=]
       <td>For [=uniform buffer=] variables
   <tr><td><dfn noexport dfn-for="storage classes">storage</dfn>
       <td>Readable.<br>
@@ -1211,7 +1215,7 @@ and how to use variables with it.
       <td>Read-only
       <td>Invocations in the same shader stage
       <td>[=Module scope=]
-      <td>Opaque representation of handle to a sampler or texture
+      <td>Opaque representation of handle to a [=sampler=] or [=texture=]
       <td>Used for sampler and texture variables<br>
           The token `handle` is reserved: it is never used in a [SHORTNAME] program.
 </table>
@@ -2335,6 +2339,31 @@ For example:
 </pre>
 
 ### Sampler Type ### {#sampler-type}
+
+A <dfn>sampler</dfn> mediates access to a sampled texture or a depth texture, by performing a combination of:
+* coordinate transformation.
+* optionally modifying mip-level selection.
+* for a sampled texture, optionally filtering retrieved texel values.
+* for a depth texture, determinining the comparison function applied to the retrieved texel.
+
+<table class='data'>
+  <thead>
+    <tr><th>Type<th>Description
+  </thead>
+  <tr algorithmm="sampler type">
+    <td>sampler
+    <td>Sampler. Mediates access to a sampled texture.</td>
+  <tr algorithmm="comparisong sampler type">
+    <td>sampler_comparison
+    <td>Comparison sampler.
+        Mediates access to a depth texture.</td>
+</table>
+
+Samplers are parameterized when created in the WebGPU API.
+They cannot be modified by a [SHORTNAME] program.
+
+Samplers can only be used by the [[#texture-builtin-functions|texture builtin functions]].
+
 <pre class='def'>
 sampler
   OpTypeSampler
@@ -2843,7 +2872,7 @@ A function-scope let-declared constant must be of [=atomic-free=] [=plain type=]
 
 A variable declared in function scope is always in the [=storage classes/function=] storage class.
 The variable storage decoration is optional.
-The variable's [=store type=] must be [=storable=].
+The variable's [=store type=] must be a [=atomic-free=] [=plain type=].
 
 <div class='example wgsl global-scope' heading="Function scope variables and constants">
   <xmp highlight='rust'>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -732,10 +732,12 @@ TODO(dneto): Do we still need all these shorthands?
 
 ## Plain Types ## {#plain-types-section}
 
-<dfn noexport>Plain types</dfn> are the types for representing boolean values, numbers, vectors,
+[=Plain types=] are the types for representing boolean values, numbers, vectors,
 matrices, or aggregations of such values.
 
-Note: Plain types in [SHORTNAME] are analogous to Plain-Old-Data types in C++.
+A <dfn>plain type</dfn> is either a [=scalar=] type, an [=atomic type|atomic=] type, or a [=composite=] type.
+
+Note: Plain types in [SHORTNAME] are similar to Plain-Old-Data types in C++, but also include atomic types.
 
 ### Boolean Type ### {#bool-type}
 
@@ -824,6 +826,81 @@ See [[#arithmetic-expr]].
   </xmp>
 </div>
 
+### Atomic Types ### {#atomic-types}
+
+An <dfn noexport>atomic type</dfn> encapsulates a [=scalar=] type such that:
+* atomic objects provide certain guarantees to concurrent observers, and
+* the only valid operations on atomic objects are the [[#atomic-builtin-functions|atomic builtin functions]].
+
+<table class='data'>
+  <thead>
+    <tr><th>Type<th>Description
+  </thead>
+  <tr algorith="atomic type"><td>atomic&lt;|T|&gt;
+    <td>Atomic of type |T|. |T| must be either [=u32=] or [=i32=].
+</table>
+
+The type of an expression must not be an atomic type.
+
+Atomic types may only be instantiated by variables in the [=storage
+classes/workgroup=] storage class or `read_write` [=attribute/access=] variables in the
+[=storage classes/storage=] storage class.
+
+An <dfn noexport>atomic modification</dfn> is any operation on an atomic object which sets the content of the object.
+The operation counts as a modification even if the new value is the same as the object's existing value.
+
+In [SHORTNAME], atomic modifications are mutually ordered, for each object.
+That is, during execution of a shader stage, for each atomic object *A*, all
+agents observe the same order of modification operations applied to *A*.
+The ordering for distinct atomic objects may not be related in any way; no
+causality is implied.
+Note that variables in [=storage classes/workgroup=] storage are shared within a
+[=compute shader stage/workgroup=], but are not shared between different
+workgroups.
+
+TODO: Add links the eventual memory model descriptions.
+
+<pre class='example storage atomic' heading='Mapping atomics in a storage variable to SPIR-V'>
+  <xmp>
+    [[block]] struct S {
+      a : atomic<i32>;
+      b : atomic<u32>;
+    };
+
+    [[group(0), binding(0)]]
+    var<storage> x : [[access(read_write)]] S;
+
+    // Maps to the following SPIR-V:
+    // - When atomic types are members of a struct, the Volatile decoration
+    //   is annotated on the member.
+    // OpDecorate %S Block
+    // OpMemberDecorate %S 0 Volatile
+    // OpMemberDecorate %S 1 Volatile
+    // ...
+    // %i32 = OpTypeInt 32 1
+    // %u32 = OpTypeInt 32 0
+    // %S = OpTypeStruct %i32 %u32
+    // %ptr_storage_S = OpTypePointer StorageBuffer %S
+    // %x = OpVariable %ptr_storage_S StorageBuffer
+  </xmp>
+</pre>
+
+<pre class='example workgroup atomic' heading='Mapping atomics in a workgroup variable to SPIR-V'>
+  <xmp>
+    var<workgroup> x : atomic<u32>;
+
+    // Maps to the following SPIR-V:
+    // - When atomic types are directly instantiated by a variable,  the Volatile
+    //   decoration is annotated on the OpVariable.
+    // OpDecorate %x Volatile
+    // ...
+    // %u32 = OpTypeInt 32 0
+    // %ptr_workgroup_u32 = OpTypePointer Workgroup %S
+    // %x = OpVariable %ptr_workgroup_u32 Workgroup
+  </xmp>
+</pre>
+
+
 ### Array Types ### {#array-types}
 
 An <dfn noexport>array</dfn> is an indexable grouping of element values.
@@ -847,6 +924,7 @@ An array element type must be one of:
 * a [=scalar=] type
 * a vector type
 * a matrix type
+* an [=atomic type|atomic=] type
 * an array type
 * a [=structure=] type
 
@@ -882,6 +960,7 @@ A structure member type must be one of:
 * a [=scalar=] type
 * a vector type
 * a matrix type
+* an [=atomic type|atomic=] type
 * an array type
 * a [=structure=] type
 
@@ -987,7 +1066,14 @@ The composite types are:
 * [=array=] type
 * [=structure=] type
 
-A [=plain type|plain=] type is either [=composite=] or [=scalar=].
+### Atomic-Free Types ### {#atomic-free-types}
+
+A [=plain type=] is <dfn>atomic-free</dfn> if it is:
+* a [=scalar=] type
+* a [=vector=] type
+* a [=matrix=] type
+* an [=array=] type, if its element type is atomic-free
+* a [=structure=] type, if all its members are atomic-free.
 
 ## Memory ## {#memory}
 
@@ -2369,78 +2455,6 @@ texel_format
 
 </pre>
 
-## Atomic Types ## {#atomic-types}
-
-An <dfn noexport>atomic type</dfn> encapsulates a [=scalar=] type such that:
-* atomic objects provide certain guarantees to concurrent observers, and
-* the only valid operations on atomic objects are the [[#atomic-builtin-functions|atomic builtin functions]].
-
-<table class='data'>
-  <thead>
-    <tr><th>Type<th>Description
-  </thead>
-  <tr algorith="atomic type"><td>atomic&lt;|T|&gt;
-    <td>Atomic of type |T|. |T| must be either [=u32=] or [=i32=].
-</table>
-
-Atomic types may only be instantiated by variables in the [=storage
-classes/workgroup=] storage class or `read_write` [=attribute/access=] variables in the
-[=storage classes/storage=] storage class.
-
-An <dfn noexport>atomic modification</dfn> is any operation on an atomic object which sets the content of the object.
-The operation counts as a modification even if the new value is the same as the object's existing value.
-
-In [SHORTNAME], atomic modifications are mutually ordered, for each object.
-That is, during execution of a shader stage, for each atomic object *A*, all
-agents observe the same order of modification operations applied to *A*.
-The ordering for distinct atomic objects may not be related in any way; no
-causality is implied.
-Note that variables in [=storage classes/workgroup=] storage are shared within a
-[=compute shader stage/workgroup=], but are not shared between different
-workgroups.
-
-TODO: Add links the eventual memory model descriptions.
-
-<pre class='example storage atomic' heading='Mapping atomics in a storage variable to SPIR-V'>
-  <xmp>
-    [[block]] struct S {
-      a : atomic<i32>;
-      b : atomic<u32>;
-    };
-    
-    [[group(0), binding(0)]]
-    var<storage> x : [[access(read_write)]] S;
-    
-    // Maps to the following SPIR-V:
-    // - When atomic types are members of a struct, the Volatile decoration
-    //   is annotated on the member.
-    // OpDecorate %S Block
-    // OpMemberDecorate %S 0 Volatile
-    // OpMemberDecorate %S 1 Volatile
-    // ...
-    // %i32 = OpTypeInt 32 1
-    // %u32 = OpTypeInt 32 0
-    // %S = OpTypeStruct %i32 %u32
-    // %ptr_storage_S = OpTypePointer StorageBuffer %S
-    // %x = OpVariable %ptr_storage_S StorageBuffer
-  </xmp>
-</pre>
-
-<pre class='example workgroup atomic' heading='Mapping atomics in a workgroup variable to SPIR-V'>
-  <xmp>
-    var<workgroup> x : atomic<u32>;
-    
-    // Maps to the following SPIR-V:
-    // - When atomic types are directly instantiated by a variable,  the Volatile
-    //   decoration is annotated on the OpVariable.
-    // OpDecorate %x Volatile
-    // ...
-    // %u32 = OpTypeInt 32 0
-    // %ptr_workgroup_u32 = OpTypePointer Workgroup %S
-    // %x = OpVariable %ptr_workgroup_u32 Workgroup
-  </xmp>
-</pre>
-
 ## Type Aliases TODO ## {#type-aliases}
 
 <pre class='def'>
@@ -2730,7 +2744,7 @@ A `let`-declaration appearing outside all functions declares a
 The name is available for use after the end of the declaration,
 until the end of the [SHORTNAME] program.
 
-A module-scope let-declared constant must be of [=plain type=].
+A module-scope let-declared constant must be of [=atomic-free=] [=plain type=].
 
 When the declaration has no attributes, an initializer expression must be present,
 and the name denotes the value of that expression.
@@ -2825,7 +2839,7 @@ A variable or constant declared in a declaration statement in a function body is
 The name is available for use immediately after its declaration statement,
 and until the end of the brace-delimited list of statements immediately enclosing the declaration.
 
-A function-scope let-declared constant must be of [=plain type=] or [=pointer type=].
+A function-scope let-declared constant must be of [=atomic-free=] [=plain type=], or of [=pointer type=].
 
 A variable declared in function scope is always in the [=storage classes/function=] storage class.
 The variable storage decoration is optional.
@@ -5015,7 +5029,7 @@ The identifier is [=in scope=] until the end of the function.
 Two formal parameters for a given function must not have the same name.
 
 If the return type is specified, then:
-* The return type must be a [=plain type=].
+* The return type must be an [=atomic-free=] [=plain type=].
 * The last statement in the function body must be a [=return=] statement.
 
 <pre class='def'>


### PR DESCRIPTION
Builds on #1688 
Two commits on top of that:


Author: David Neto <dneto@google.com>
Date:   Wed Apr 28 20:55:22 2021 -0400

    wgsl: Fix store types
    
    * Add textures and samplers to storable types
    * Add atomic type to plain types
    * No expression can evaluate to an atomic type.
      * Phrase that carefully to accommodate Load Rule
      * Modify the restriction on runtime-sized array accordingly
    * Define "atomic-free" plain types.  Most uses of plain types are of
      atomic-free plain types.
    * Restrict what types can be used for let-declared constants.
    * Restrict what types can be used as store type for var, based on
      storage class:
         atomic can only appear in workgroup and storage
         texture and sampler can only appear in handle (be more explicit
         about this)
    
Fixes: #1686

commit 301212c072cd853fe7f8500628ba19e2582ec0c7
Author: David Neto <dneto@google.com>
Date:   Wed Apr 28 18:48:19 2021 -0400

    Allow atomic types in arrays and structures