### PR TITLE
Merge texture's internal slots

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -791,12 +791,12 @@ to form complete [=texel blocks=] in the [=subresource=].
 
   - For pixel-based {{GPUTextureFormat|GPUTextureFormats}}, the [=physical size=] is always equal to the size of the [=texture subresource=]
     used in the sampling hardwares.
-  - [=Textures=] in block-based compressed {{GPUTextureFormat|GPUTextureFormats}} always have a [=mipmap level=] 0 whose {{GPUTexture/[[textureSize]]}}
+  - [=Textures=] in block-based compressed {{GPUTextureFormat|GPUTextureFormats}} always have a [=mipmap level=] 0 whose {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}
     is a multiple of the [=texel block size=], but the lower mipmap levels might not be
     multiples of the [=texel block size=] and can have paddings.
 
 <div class="example">
-Considering a {{GPUTexture}} in BC format whose {{GPUTexture/[[textureSize]]}} is {60, 60, 1}, when sampling
+Considering a {{GPUTexture}} in BC format whose {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}} is {60, 60, 1}, when sampling
 the {{GPUTexture}} at [=mipmap level=] 2, the sampling hardware uses {15, 15, 1} as the size of the [=texture subresource=],
 while its [=physical size=] is {16, 16, 1} as the block-compression algorithm can only operate on 4x4 [=texel blocks=].
 </div>
@@ -1776,7 +1776,7 @@ GPUBuffer includes GPUObjectBase;
         The {{GPUMapModeFlags}} of the last call to {{GPUBuffer/mapAsync()}} (if any).
 </dl>
 
-Issue: {{GPUBuffer/[[usage]]}} is differently named from {{GPUTexture/[[textureUsage]]}}.
+Issue: {{GPUBuffer/[[usage]]}} is differently named from {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}}.
 We should make it consistent.
 
 Each {{GPUBuffer}} has a current <dfn dfn>buffer state</dfn> on the [=Content timeline=]
@@ -2152,30 +2152,11 @@ GPUTexture includes GPUObjectBase;
 {{GPUTexture}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUTexture">
-    : <dfn>\[[textureSize]]</dfn> of type {{GPUExtent3D}}.
+    : <dfn>\[[descriptor]]</dfn>
     ::
-        The size of the {{GPUTexture}} in texels in [=mipmap level=] 0.
+        The {{GPUTextureDescriptor}} describing this texture.
 
-    : <dfn>\[[mipLevelCount]]</dfn> of type {{GPUIntegerCoordinate}}.
-    ::
-        The total number of the mipmap levels of the {{GPUTexture}}.
-
-    : <dfn>\[[sampleCount]]</dfn> of type {{GPUSize32}}.
-    ::
-        The number of samples in each texel of the {{GPUTexture}}.
-
-    : <dfn>\[[dimension]]</dfn> of type {{GPUTextureDimension}}.
-    ::
-        The dimension of the {{GPUTexture}}.
-
-    : <dfn>\[[format]]</dfn> of type {{GPUTextureFormat}}.
-    ::
-        The format of the {{GPUTexture}}.
-
-    : <dfn>\[[textureUsage]]</dfn> of type {{GPUTextureUsageFlags}}.
-    ::
-        The allowed usages for this {{GPUTexture}}.
-
+        All optional fields of {{GPUTextureDescriptor}} are defined.
 </dl>
 
 <div algorithm>
@@ -2335,11 +2316,7 @@ interface GPUTextureUsage {
                             1. Return a new [=invalid=] {{GPUTexture}}.
 
                     1. Let |t| be a new {{GPUTexture}} object.
-                    1. Set |t|.{{GPUTexture/[[textureSize]]}} to |descriptor|.{{GPUTextureDescriptor/size}}.
-                    1. Set |t|.{{GPUTexture/[[sampleCount]]}} to |descriptor|.{{GPUTextureDescriptor/sampleCount}}.
-                    1. Set |t|.{{GPUTexture/[[dimension]]}} to |descriptor|.{{GPUTextureDescriptor/dimension}}.
-                    1. Set |t|.{{GPUTexture/[[format]]}} to |descriptor|.{{GPUTextureDescriptor/format}}.
-                    1. Set |t|.{{GPUTexture/[[textureUsage]]}} to |descriptor|.{{GPUTextureDescriptor/usage}}.
+                    1. Set |t|.{{GPUTexture/[[descriptor]]}} to |descriptor|.
                     1. Return |t|.
                 </div>
         </div>
@@ -2453,50 +2430,50 @@ enum GPUTextureAspect {
                             - If the |descriptor|.{{GPUTextureViewDescriptor/aspect}} is
                                 <dl class="switch">
                                     : {{GPUTextureAspect/"stencil-only"}}
-                                    :: |this|.{{GPUTexture/[[format]]}} must be a [[#depth-formats|depth-stencil format]]
+                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}} must be a [[#depth-formats|depth-stencil format]]
                                         which contains a stencil aspect.
 
                                     : {{GPUTextureAspect/"depth-only"}}
-                                    :: |this|.{{GPUTexture/[[format]]}} must be a [[#depth-formats|depth-stencil format]]
+                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}} must be a [[#depth-formats|depth-stencil format]]
                                         which contains a depth aspect.
                                 </dl>
                             - |descriptor|.{{GPUTextureViewDescriptor/mipLevelCount}} must be &gt; 0.
                             - |descriptor|.{{GPUTextureViewDescriptor/baseMipLevel}} +
                                 |descriptor|.{{GPUTextureViewDescriptor/mipLevelCount}} must be &le;
-                                |this|.{{GPUTexture/[[mipLevelCount]]}}.
+                                |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/mipLevelCount}}.
                             - |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be &gt; 0.
                             - |descriptor|.{{GPUTextureViewDescriptor/baseArrayLayer}} +
                                 |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be &le;
                                 the [$array layer count$] of |this|.
-                            - |descriptor|.{{GPUTextureViewDescriptor/format}} must be |this|.{{GPUTexture/[[format]]}}.
+                            - |descriptor|.{{GPUTextureViewDescriptor/format}} must be |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
                                 <div class="issue">Allow for creating views with compatible formats as well.</div>
                             - If |descriptor|.{{GPUTextureViewDescriptor/dimension}} is:
                                 <dl class="switch">
                                     : {{GPUTextureViewDimension/"1d"}}
-                                    :: |this|.{{GPUTexture/[[dimension]]}} must be {{GPUTextureDimension/"1d"}}.
+                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"1d"}}.
                                     :: |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `1`.
 
                                     : {{GPUTextureViewDimension/"2d"}}
-                                    :: |this|.{{GPUTexture/[[dimension]]}} must be {{GPUTextureDimension/"2d"}}.
+                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"2d"}}.
                                     :: |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `1`.
 
                                     : {{GPUTextureViewDimension/"2d-array"}}
-                                    :: |this|.{{GPUTexture/[[dimension]]}} must be {{GPUTextureDimension/"2d"}}.
+                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"2d"}}.
 
                                     : {{GPUTextureViewDimension/"cube"}}
-                                    :: |this|.{{GPUTexture/[[dimension]]}} must be {{GPUTextureDimension/"2d"}}.
+                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"2d"}}.
                                     :: |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `6`.
-                                    :: |this|.{{GPUTexture/[[textureSize]]}}.[=Extent3D/width=] must be
-                                        |this|.{{GPUTexture/[[textureSize]]}}.[=Extent3D/height=].
+                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be
+                                        |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}.[=Extent3D/height=].
 
                                     : {{GPUTextureViewDimension/"cube-array"}}
-                                    :: |this|.{{GPUTexture/[[dimension]]}} must be {{GPUTextureDimension/"2d"}}.
+                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"2d"}}.
                                     :: |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be a multiple of `6`.
-                                    :: |this|.{{GPUTexture/[[textureSize]]}}.[=Extent3D/width=] must be
-                                        |this|.{{GPUTexture/[[textureSize]]}}.[=Extent3D/height=].
+                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be
+                                        |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}.[=Extent3D/height=].
 
                                     : {{GPUTextureViewDimension/"3d"}}
-                                    :: |this|.{{GPUTexture/[[dimension]]}} must be {{GPUTextureDimension/"3d"}}.
+                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"3d"}}.
                                     :: |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `1`.
                                 </dl>
                         </div>
@@ -2508,8 +2485,8 @@ enum GPUTextureAspect {
                     1. Let |view| be a new {{GPUTextureView}} object.
                     1. Set |view|.{{GPUTextureView/[[texture]]}} to |this|.
                     1. Set |view|.{{GPUTextureView/[[descriptor]]}} to |descriptor|.
-                    1. If |this|.{{GPUTexture/[[textureUsage]]}} contains {{GPUTextureUsage/RENDER_ATTACHMENT}}:
-                        1. Let |renderExtent| be [$compute render extent$](|this|.{{GPUTexture/[[textureSize]]}}, |descriptor|.{{GPUTextureViewDescriptor/baseMipLevel}}).
+                    1. If |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}} contains {{GPUTextureUsage/RENDER_ATTACHMENT}}:
+                        1. Let |renderExtent| be [$compute render extent$](|this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}, |descriptor|.{{GPUTextureViewDescriptor/baseMipLevel}}).
                         1. Set |view|.{{GPUTextureView/[[renderExtent]]}} to |renderExtent|.
                     1. Return |view|.
                 </div>
@@ -2522,12 +2499,12 @@ enum GPUTextureAspect {
 
     1. Let |resolved| be a copy of |descriptor|.
     1. If |resolved|.{{GPUTextureViewDescriptor/format}} is `undefined`,
-        set |resolved|.{{GPUTextureViewDescriptor/format}} to |texture|.{{GPUTexture/[[format]]}}.
+        set |resolved|.{{GPUTextureViewDescriptor/format}} to |texture|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
     1. If |resolved|.{{GPUTextureViewDescriptor/mipLevelCount}} is `undefined`,
-        set |resolved|.{{GPUTextureViewDescriptor/mipLevelCount}} to |texture|.{{GPUTexture/[[mipLevelCount]]}}
+        set |resolved|.{{GPUTextureViewDescriptor/mipLevelCount}} to |texture|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/mipLevelCount}}
         &minus; {{GPUTextureViewDescriptor/baseMipLevel}}.
     1. If |resolved|.{{GPUTextureViewDescriptor/dimension}} is `undefined` and
-        |texture|.{{GPUTexture/[[dimension]]}} is:
+        |texture|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} is:
         <dl class="switch">
             : {{GPUTextureDimension/"1d"}}
             :: Set |resolved|.{{GPUTextureViewDescriptor/dimension}} to {{GPUTextureViewDimension/"1d"}}.
@@ -2550,7 +2527,7 @@ enum GPUTextureAspect {
 
             : {{GPUTextureViewDimension/"2d-array"}} or {{GPUTextureViewDimension/"cube-array"}}
             :: Set |resolved|.{{GPUTextureViewDescriptor/arrayLayerCount}} to
-                |texture|.{{GPUTexture/[[textureSize]]}}.[=Extent3D/depthOrArrayLayers=] &minus;
+                |texture|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] &minus;
                 {{GPUTextureViewDescriptor/baseArrayLayer}}.
         </dl>
 
@@ -2561,13 +2538,13 @@ enum GPUTextureAspect {
     To determine the <dfn abstract-op>array layer count</dfn> of {{GPUTexture}} |texture|, run the
     following steps:
 
-        1. If |texture|.{{GPUTexture/[[dimension]]}} is:
+        1. If |texture|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} is:
             <dl class="switch">
                 : {{GPUTextureDimension/"1d"}} or {{GPUTextureDimension/"3d"}}
                 :: Return `1`.
 
                 : {{GPUTextureDimension/"2d"}}
-                :: Return |texture|.{{GPUTexture/[[textureSize]]}}.[=Extent3D/depthOrArrayLayers=].
+                :: Return |texture|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=].
             </dl>
 </div>
 
@@ -5170,19 +5147,19 @@ dictionary GPUImageCopyTexture {
   **Returns:** {{boolean}}
 
   Let:
-  - |blockWidth| be the [=texel block width=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}.
-  - |blockHeight| be the [=texel block height=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}.
+  - |blockWidth| be the [=texel block width=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
+  - |blockHeight| be the [=texel block height=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
 
   Return `true` if and only if all of the following conditions apply:
   - |imageCopyTexture|.{{GPUImageCopyTexture/texture}} must be a [=valid=] {{GPUTexture}}.
-  - |imageCopyTexture|.{{GPUImageCopyTexture/mipLevel}} must be less than the {{GPUTexture/[[mipLevelCount]]}} of
+  - |imageCopyTexture|.{{GPUImageCopyTexture/mipLevel}} must be less than the {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/mipLevelCount}} of
     |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.
   - |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/x=] must be a multiple of |blockWidth|.
   - |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/y=] must be a multiple of |blockHeight|.
   - The [=imageCopyTexture subresource size=] of |imageCopyTexture| is equal to |copySize| if either of
       the following conditions is true:
-        - |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format.
-        - |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[sampleCount]]}} is greater than 1.
+        - |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}} is a depth-stencil format.
+        - |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}} is greater than 1.
 
 </div>
 
@@ -5362,15 +5339,15 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
 <dfn dfn>Valid Texture Copy Range</dfn>
 
 Given a {{GPUImageCopyTexture}} |imageCopyTexture| and a {{GPUExtent3D}} |copySize|, let
-  - |blockWidth| be the [=texel block width=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}.
-  - |blockHeight| be the [=texel block height=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}.
+  - |blockWidth| be the [=texel block width=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
+  - |blockHeight| be the [=texel block height=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
 
 The following validation rules apply:
 
-  - If the {{GPUTexture/[[dimension]]}} of |imageCopyTexture|.{{GPUImageCopyTexture/texture}} is
+  - If the {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} of |imageCopyTexture|.{{GPUImageCopyTexture/texture}} is
     {{GPUTextureDimension/1d}}:
     - Both |copySize|.[=Extent3D/height=] and [=Extent3D/depthOrArrayLayers=] must be 1.
-  - If the {{GPUTexture/[[dimension]]}} of |imageCopyTexture|.{{GPUImageCopyTexture/texture}} is
+  - If the {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} of |imageCopyTexture|.{{GPUImageCopyTexture/texture}} is
     {{GPUTextureDimension/2d}}:
      -  (|imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/x=] + |copySize|.[=Extent3D/width=]),
         (|imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/y=] + |copySize|.[=Extent3D/height=]), and
@@ -5418,22 +5395,22 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
                 - |source|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[usage]]}} contains
                     {{GPUBufferUsage/COPY_SRC}}.
                 - [$validating GPUImageCopyTexture$](|destination|, |copySize|) returns `true`.
-                - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[textureUsage]]}} contains
+                - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}} contains
                     {{GPUTextureUsage/COPY_DST}}.
-                - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[sampleCount]]}} is 1.
-                - If |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format:
+                - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}} is 1.
+                - If |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}} is a depth-stencil format:
                     - |destination|.{{GPUImageCopyTexture/aspect}} must refer to a single copyable aspect of
-                        |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}.
+                        |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
                         See [[#depth-formats|depth-formats]].
                 - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
-                - If |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}} is not a depth/stencil format:
+                - If |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}} is not a depth/stencil format:
                     - |source|.{{GPUImageDataLayout/offset}} is a multiple of the [=texel block size=] of
-                        |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}.
-                - If |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}} is a depth/stencil format:
+                        |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
+                - If |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}} is a depth/stencil format:
                     - |source|.{{GPUImageDataLayout/offset}} is a multiple of 4.
                 - [$validating linear texture data$](|source|,
                     |source|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[size]]}},
-                    |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}},
+                    |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}},
                     |copySize|) succeeds.
             </div>
         </div>
@@ -5459,25 +5436,25 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
             <div class=validusage>
                 - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
                 - [$validating GPUImageCopyTexture$](|source|, |copySize|) returns `true`.
-                - |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[textureUsage]]}} contains
+                - |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}} contains
                     {{GPUTextureUsage/COPY_SRC}}.
-                - |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[sampleCount]]}} is 1.
-                - If |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format:
+                - |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}} is 1.
+                - If |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}} is a depth-stencil format:
                     - |source|.{{GPUImageCopyTexture/aspect}} must refer to a single copyable aspect of
-                        |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}.
+                        |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
                         See [[#depth-formats|depth-formats]].
                 - [$validating GPUImageCopyBuffer$](|destination|) returns `true`.
                 - |destination|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[usage]]}} contains
                     {{GPUBufferUsage/COPY_DST}}.
                 - [=Valid Texture Copy Range=] applies to |source| and |copySize|.
-                - If |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}} is not a depth/stencil format:
+                - If |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}} is not a depth/stencil format:
                     - |destination|.{{GPUImageDataLayout/offset}} is a multiple of the [=texel block size=] of
-                        |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}.
-                - If |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}} is a depth/stencil format:
+                        |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
+                - If |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}} is a depth/stencil format:
                     - |destination|.{{GPUImageDataLayout/offset}} is a multiple of 4.
                 - [$validating linear texture data$](|destination|,
                     |destination|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[size]]}},
-                    |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}},
+                    |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}},
                     |copySize|) succeeds.
             </div>
         </div>
@@ -5504,19 +5481,19 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
                 <div class=validusage>
                     - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
                     - [$validating GPUImageCopyTexture$](|source|, |copySize|) returns `true`.
-                    - |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[textureUsage]]}} contains
+                    - |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}} contains
                         {{GPUTextureUsage/COPY_SRC}}.
                     - [$validating GPUImageCopyTexture$](|destination|, |copySize|) returns `true`.
-                    - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[textureUsage]]}} contains
+                    - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}} contains
                         {{GPUTextureUsage/COPY_DST}}.
-                    - |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[sampleCount]]}} is equal to |destination|.
-                        {{GPUImageCopyTexture/texture}}.{{GPUTexture/[[sampleCount]]}}.
-                    - |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}} is equal to |destination|.
-                        {{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}.
-                    - If |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}} is a depth-stencil format:
+                    - |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}} is equal to |destination|.
+                        {{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}}.
+                    - |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}} is equal to |destination|.
+                        {{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
+                    - If |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}} is a depth-stencil format:
                         - |source|.{{GPUImageCopyTexture/aspect}} and |destination|.{{GPUImageCopyTexture/aspect}}
-                            must both refer to all aspects of |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}
-                            and |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}, respectively.
+                            must both refer to all aspects of |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}
+                            and |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}, respectively.
                     - [=Valid Texture Copy Range=] applies to |source| and |copySize|.
                     - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
                     - The [$set of subresources for texture copy$](|source|, |copySize|) and
@@ -5529,7 +5506,7 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
     The <dfn abstract-op>set of subresources for texture copy</dfn>(|imageCopyTexture|, |copySize|)
     is the set containing:
 
-      - If |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[dimension]]}}
+      - If |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}}
         is {{GPUTextureDimension/"2d"}}:
           - For each |arrayLayer| of the |copySize|.[=Extent3D/depthOrArrayLayers=] [=array layers=]
             starting at |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/z=]:
@@ -6349,7 +6326,7 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
 
     1. Each {{GPURenderPassColorAttachment/view}} in |this|.{{GPURenderPassDescriptor/colorAttachments}}
         and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachment/view}},
-        if present, must have all have the same {{GPUTexture/[[sampleCount]]}}.
+        if present, must have all have the same {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}}.
 
     1. For each {{GPURenderPassColorAttachment/view}} in |this|.{{GPURenderPassDescriptor/colorAttachments}}
         and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachment/view}},
@@ -6425,21 +6402,21 @@ dictionary GPURenderPassColorAttachment {
     apply:
 
     1. |this|.{{GPURenderPassColorAttachment/view}} must have a [=color renderable format=].
-    1. |this|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[textureUsage]]}}
+    1. |this|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}}
         must contain {{GPUTextureUsage/RENDER_ATTACHMENT}}.
     1. |this|.{{GPURenderPassColorAttachment/view}} must be a view of a single [=subresource=].
     1. If |this|.{{GPURenderPassColorAttachment/resolveTarget}} is not `null`:
 
         1. |this|.{{GPURenderPassColorAttachment/view}} must be multisampled.
         1. |this|.{{GPURenderPassColorAttachment/resolveTarget}} must not be multisampled.
-        1. |this|.{{GPURenderPassColorAttachment/resolveTarget}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[textureUsage]]}}
+        1. |this|.{{GPURenderPassColorAttachment/resolveTarget}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}}
             must contain {{GPUTextureUsage/RENDER_ATTACHMENT}}.
         1. |this|.{{GPURenderPassColorAttachment/resolveTarget}} must be a view of a single [=subresource=].
 
         1. The dimensions of the [=subresource=]s seen by |this|.{{GPURenderPassColorAttachment/resolveTarget}}
             and |this|.{{GPURenderPassColorAttachment/view}} must match.
-        1. |this|.{{GPURenderPassColorAttachment/resolveTarget}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[format]]}}
-            must match |this|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[format]]}}.
+        1. |this|.{{GPURenderPassColorAttachment/resolveTarget}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}
+            must match |this|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
         1. Issue: Describe any remaining resolveTarget validation
 
     Issue: Describe the remaining validation rules for this type.
@@ -6519,7 +6496,7 @@ dictionary GPURenderPassDepthStencilAttachment {
         format=].
     1. |this|.{{GPURenderPassDepthStencilAttachment/view}} must be a view of a
         single [=texture subresource=].
-    1. |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTexture/[[textureUsage]]}}
+    1. |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}}
         must contain {{GPUTextureUsage/RENDER_ATTACHMENT}}.
     1. |this|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} is `true`,
         |this|.{{GPURenderPassDepthStencilAttachment/depthLoadValue}} must be
@@ -7303,7 +7280,7 @@ GPUQueue includes GPUObjectBase;
                 <div class=validusage>
                     - [$validating linear texture data$](|dataLayout|,
                         |dataByteSize|,
-                        |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}},
+                        |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}},
                         |size|) succeeds.
                 </div>
             1. Let |contents| be the contents of the [=images=] seen by
@@ -7316,13 +7293,13 @@ GPUQueue includes GPUObjectBase;
                         generate a validation error and stop.
                         <div class=validusage>
                             - [$validating GPUImageCopyTexture$](|destination|, |size|) returns `true`.
-                            - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[textureUsage]]}}
+                            - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}}
                                 includes {{GPUTextureUsage/COPY_DST}}.
-                            - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[sampleCount]]}} is 1.
+                            - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}} is 1.
                             - [=Valid Texture Copy Range=](|destination|, |size|)
                                 is satisfied.
                             - |destination|.{{GPUImageCopyTexture/aspect}} refers to a single copyable aspect
-                                of |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}.
+                                of |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
                                 See [[#depth-formats|depth-formats]].
 
                             Note: unlike
@@ -7360,12 +7337,12 @@ GPUQueue includes GPUObjectBase;
             If any of the following requirements are unmet, throw an {{OperationError}} and stop.
             <div class=validusage>
                 - |copySize|.[=Extent3D/depthOrArrayLayers=] must be `1`.
-                - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[textureUsage]]}}
+                - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}}
                     must include both {{GPUTextureUsage/RENDER_ATTACHMENT}} and
                     {{GPUTextureUsage/COPY_DST}}.
-                - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[dimension]]}}
+                - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}}
                     must be {{GPUTextureDimension/"2d"}}.
-                - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[format]]}}
+                - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}
                     must be one of the following:
                     - {{GPUTextureFormat/"rgba8unorm"}}
                     - {{GPUTextureFormat/"rgba8unorm-srgb"}}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7269,7 +7269,7 @@ GPUQueue includes GPUObjectBase;
 
             1. Let |dataBytes| be [=get a copy of the buffer source|a copy of the bytes held by the buffer source=] |data|.
             1. Let |dataByteSize| be the number of bytes in |dataBytes|.
-            1. Let |textureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]].
+            1. Let |textureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
             1. If any of the following conditions are unsatisfied,
                 throw {{OperationError}} and stop.
                 <div class=validusage>
@@ -7328,7 +7328,7 @@ GPUQueue includes GPUObjectBase;
 
             If any of the following requirements are unmet, throw an {{OperationError}} and stop.
             <div class=validusage>
-                - Let |textureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]].
+                - Let |textureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
                 - |copySize|.[=Extent3D/depthOrArrayLayers=] must be `1`.
                 - |textureDesc|.{{GPUTextureDescriptor/usage}} must include both {{GPUTextureUsage/RENDER_ATTACHMENT}} and {{GPUTextureUsage/COPY_DST}}.
                 - |textureDesc|.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"2d"}}.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5390,27 +5390,25 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
 
             If any of the following conditions are unsatisfied, generate a validation error and stop.
             <div class=validusage>
+                - Let |dstTextureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
                 - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
                 - [$validating GPUImageCopyBuffer$](|source|) returns `true`.
-                - |source|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[usage]]}} contains
-                    {{GPUBufferUsage/COPY_SRC}}.
+                - |source|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/COPY_SRC}}.
                 - [$validating GPUImageCopyTexture$](|destination|, |copySize|) returns `true`.
-                - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}} contains
-                    {{GPUTextureUsage/COPY_DST}}.
-                - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}} is 1.
-                - If |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}} is a depth-stencil format:
+                - |dstTextureDesc|.{{GPUTextureDescriptor/usage}} contains {{GPUTextureUsage/COPY_DST}}.
+                - |dstTextureDesc|.{{GPUTextureDescriptor/sampleCount}} is 1.
+                - If |dstTextureDesc|.{{GPUTextureDescriptor/format}} is a depth-stencil format:
                     - |destination|.{{GPUImageCopyTexture/aspect}} must refer to a single copyable aspect of
-                        |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
-                        See [[#depth-formats|depth-formats]].
+                        |dstTextureDesc|.{{GPUTextureDescriptor/format}}. See [[#depth-formats|depth-formats]].
                 - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
-                - If |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}} is not a depth/stencil format:
+                - If |dstTextureDesc|.{{GPUTextureDescriptor/format}} is not a depth/stencil format:
                     - |source|.{{GPUImageDataLayout/offset}} is a multiple of the [=texel block size=] of
-                        |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
-                - If |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}} is a depth/stencil format:
+                        |dstTextureDesc|.{{GPUTextureDescriptor/format}}.
+                - If |dstTextureDesc|.{{GPUTextureDescriptor/format}} is a depth/stencil format:
                     - |source|.{{GPUImageDataLayout/offset}} is a multiple of 4.
                 - [$validating linear texture data$](|source|,
                     |source|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[size]]}},
-                    |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}},
+                    |dstTextureDesc|.{{GPUTextureDescriptor/format}},
                     |copySize|) succeeds.
             </div>
         </div>
@@ -5434,27 +5432,26 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
 
             If any of the following conditions are unsatisfied, generate a validation error and stop.
             <div class=validusage>
+                - Let |srcTextureDesc| be |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
                 - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
                 - [$validating GPUImageCopyTexture$](|source|, |copySize|) returns `true`.
-                - |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}} contains
-                    {{GPUTextureUsage/COPY_SRC}}.
-                - |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}} is 1.
-                - If |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}} is a depth-stencil format:
+                - |srcTextureDesc|.{{GPUTextureDescriptor/usage}} contains {{GPUTextureUsage/COPY_SRC}}.
+                - |srcTextureDesc|.{{GPUTextureDescriptor/sampleCount}} is 1.
+                - If |srcTextureDesc|.{{GPUTextureDescriptor/format}} is a depth-stencil format:
                     - |source|.{{GPUImageCopyTexture/aspect}} must refer to a single copyable aspect of
-                        |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
-                        See [[#depth-formats|depth-formats]].
+                        |srcTextureDesc|.{{GPUTextureDescriptor/format}}. See [[#depth-formats|depth-formats]].
                 - [$validating GPUImageCopyBuffer$](|destination|) returns `true`.
                 - |destination|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[usage]]}} contains
                     {{GPUBufferUsage/COPY_DST}}.
                 - [=Valid Texture Copy Range=] applies to |source| and |copySize|.
-                - If |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}} is not a depth/stencil format:
+                - If |srcTextureDesc|.{{GPUTextureDescriptor/format}} is not a depth/stencil format:
                     - |destination|.{{GPUImageDataLayout/offset}} is a multiple of the [=texel block size=] of
-                        |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
-                - If |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}} is a depth/stencil format:
+                        |srcTextureDesc|.{{GPUTextureDescriptor/format}}.
+                - If |srcTextureDesc|.{{GPUTextureDescriptor/format}} is a depth/stencil format:
                     - |destination|.{{GPUImageDataLayout/offset}} is a multiple of 4.
                 - [$validating linear texture data$](|destination|,
                     |destination|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[size]]}},
-                    |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}},
+                    |srcTextureDesc|.{{GPUTextureDescriptor/format}},
                     |copySize|) succeeds.
             </div>
         </div>
@@ -5479,21 +5476,19 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
 
             1. If any of the following conditions are unsatisfied, generate a validation error and stop.
                 <div class=validusage>
+                    - Let |srcTextureDesc| be |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
+                    - Let |dstTextureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
                     - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
                     - [$validating GPUImageCopyTexture$](|source|, |copySize|) returns `true`.
-                    - |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}} contains
-                        {{GPUTextureUsage/COPY_SRC}}.
+                    - |srcTextureDesc|.{{GPUTextureDescriptor/usage}} contains {{GPUTextureUsage/COPY_SRC}}.
                     - [$validating GPUImageCopyTexture$](|destination|, |copySize|) returns `true`.
-                    - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}} contains
-                        {{GPUTextureUsage/COPY_DST}}.
-                    - |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}} is equal to |destination|.
-                        {{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}}.
-                    - |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}} is equal to |destination|.
-                        {{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
-                    - If |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}} is a depth-stencil format:
+                    - |dstTextureDesc|.{{GPUTextureDescriptor/usage}} contains {{GPUTextureUsage/COPY_DST}}.
+                    - |srcTextureDesc|.{{GPUTextureDescriptor/sampleCount}} is equal to |dstTextureDesc|.{{GPUTextureDescriptor/sampleCount}}.
+                    - |srcTextureDesc|.{{GPUTextureDescriptor/format}} is equal to |dstTextureDesc|.{{GPUTextureDescriptor/format}}.
+                    - If |srcTextureDesc|.{{GPUTextureDescriptor/format}} is a depth-stencil format:
                         - |source|.{{GPUImageCopyTexture/aspect}} and |destination|.{{GPUImageCopyTexture/aspect}}
-                            must both refer to all aspects of |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}
-                            and |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}, respectively.
+                            must both refer to all aspects of |srcTextureDesc|.{{GPUTextureDescriptor/format}}
+                            and |dstTextureDesc|.{{GPUTextureDescriptor/format}}, respectively.
                     - [=Valid Texture Copy Range=] applies to |source| and |copySize|.
                     - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
                     - The [$set of subresources for texture copy$](|source|, |copySize|) and
@@ -6401,22 +6396,21 @@ dictionary GPURenderPassColorAttachment {
     Given a {{GPURenderPassColorAttachment}} |this| the following validation rules
     apply:
 
+    1. Let |renderTextureDesc| be |this|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.
+    1. Let |resolveTextureDesc| be |this|.{{GPURenderPassColorAttachment/resolveTarget}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.
     1. |this|.{{GPURenderPassColorAttachment/view}} must have a [=color renderable format=].
-    1. |this|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}}
-        must contain {{GPUTextureUsage/RENDER_ATTACHMENT}}.
+    1. |renderTextureDesc|.{{GPUTextureDescriptor/usage}} must contain {{GPUTextureUsage/RENDER_ATTACHMENT}}.
     1. |this|.{{GPURenderPassColorAttachment/view}} must be a view of a single [=subresource=].
     1. If |this|.{{GPURenderPassColorAttachment/resolveTarget}} is not `null`:
 
         1. |this|.{{GPURenderPassColorAttachment/view}} must be multisampled.
         1. |this|.{{GPURenderPassColorAttachment/resolveTarget}} must not be multisampled.
-        1. |this|.{{GPURenderPassColorAttachment/resolveTarget}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}}
-            must contain {{GPUTextureUsage/RENDER_ATTACHMENT}}.
+        1. |resolveTextureDesc|.{{GPUTextureDescriptor/usage}} must contain {{GPUTextureUsage/RENDER_ATTACHMENT}}.
         1. |this|.{{GPURenderPassColorAttachment/resolveTarget}} must be a view of a single [=subresource=].
 
         1. The dimensions of the [=subresource=]s seen by |this|.{{GPURenderPassColorAttachment/resolveTarget}}
             and |this|.{{GPURenderPassColorAttachment/view}} must match.
-        1. |this|.{{GPURenderPassColorAttachment/resolveTarget}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}
-            must match |this|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
+        1. |resolveTextureDesc|.{{GPUTextureDescriptor/format}} must match |renderTextureDesc|.{{GPUTextureDescriptor/format}}.
         1. Issue: Describe any remaining resolveTarget validation
 
     Issue: Describe the remaining validation rules for this type.
@@ -7275,12 +7269,13 @@ GPUQueue includes GPUObjectBase;
 
             1. Let |dataBytes| be [=get a copy of the buffer source|a copy of the bytes held by the buffer source=] |data|.
             1. Let |dataByteSize| be the number of bytes in |dataBytes|.
+            1. Let |textureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]].
             1. If any of the following conditions are unsatisfied,
                 throw {{OperationError}} and stop.
                 <div class=validusage>
                     - [$validating linear texture data$](|dataLayout|,
                         |dataByteSize|,
-                        |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}},
+                        |textureDesc|.{{GPUTextureDescriptor/format}},
                         |size|) succeeds.
                 </div>
             1. Let |contents| be the contents of the [=images=] seen by
@@ -7293,14 +7288,11 @@ GPUQueue includes GPUObjectBase;
                         generate a validation error and stop.
                         <div class=validusage>
                             - [$validating GPUImageCopyTexture$](|destination|, |size|) returns `true`.
-                            - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}}
-                                includes {{GPUTextureUsage/COPY_DST}}.
-                            - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}} is 1.
-                            - [=Valid Texture Copy Range=](|destination|, |size|)
-                                is satisfied.
+                            - |textureDesc|.{{GPUTextureDescriptor/usage}} includes {{GPUTextureUsage/COPY_DST}}.
+                            - |textureDesc|.{{GPUTextureDescriptor/sampleCount}} is 1.
+                            - [=Valid Texture Copy Range=](|destination|, |size|) is satisfied.
                             - |destination|.{{GPUImageCopyTexture/aspect}} refers to a single copyable aspect
-                                of |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
-                                See [[#depth-formats|depth-formats]].
+                                of |textureDesc|.{{GPUTextureDescriptor/format}}. See [[#depth-formats|depth-formats]].
 
                             Note: unlike
                             {{GPUCommandEncoder}}.{{GPUCommandEncoder/copyBufferToTexture()}},
@@ -7336,14 +7328,11 @@ GPUQueue includes GPUObjectBase;
 
             If any of the following requirements are unmet, throw an {{OperationError}} and stop.
             <div class=validusage>
+                - Let |textureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]].
                 - |copySize|.[=Extent3D/depthOrArrayLayers=] must be `1`.
-                - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}}
-                    must include both {{GPUTextureUsage/RENDER_ATTACHMENT}} and
-                    {{GPUTextureUsage/COPY_DST}}.
-                - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}}
-                    must be {{GPUTextureDimension/"2d"}}.
-                - |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}
-                    must be one of the following:
+                - |textureDesc|.{{GPUTextureDescriptor/usage}} must include both {{GPUTextureUsage/RENDER_ATTACHMENT}} and {{GPUTextureUsage/COPY_DST}}.
+                - |textureDesc|.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"2d"}}.
+                - |textureDesc|.{{GPUTextureDescriptor/format}} must be one of the following:
                     - {{GPUTextureFormat/"rgba8unorm"}}
                     - {{GPUTextureFormat/"rgba8unorm-srgb"}}
                     - {{GPUTextureFormat/"bgra8unorm"}}


### PR DESCRIPTION
GPUTexture's internal slots contain all member parameters of
GPUTextureDescriptor object. So it makes more sense to merge
these internal slots into a GPUTextureDescriptor instance.
Other GPUObjects also follow this way and use a single descriptor
in their internal slots.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 4, 2021, 5:10 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FRichard-Yunchao%2Fgpuweb%2Fb1cc5498a8e14d4fd97c85ca286b77aef127c55d%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%231694.)._
</details>
