### PR TITLE
[CI] Reduce expire field to 10 days

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -75,7 +75,7 @@ jobs:
         if: ${{ github.event.workflow_run.event == 'pull_request' && env.PR }}
         with:
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
-          expires: 30d
+          expires: 10d
           channelId: prs-${{ env.PR }}-${{ github.event.workflow_run.head_sha }}
 
       # Comments on PR


### PR DESCRIPTION
This can help with reducing the number of build errors by reducing live time to be just enough for discussions.