### PR TITLE
Clarify that CompilationMessage line/pos numbers should be 1-based

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3776,7 +3776,7 @@ interface GPUCompilationInfo {
         of the line.
         
         If {{GPUCompilationMessage/message}} corresponds to a span of characters this points to the
-        first character of the span. Must be `0` if the {{GPUCompilationMessage/message}}
+        first UTF-16 code unit of the span. Must be `0` if the {{GPUCompilationMessage/message}}
         does not correspond to any specific point in the shader {{GPUShaderModuleDescriptor/code}}.
 
     : <dfn>offset</dfn>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3763,7 +3763,7 @@ interface GPUCompilationInfo {
         `1` indicates the first line of the shader {{GPUShaderModuleDescriptor/code}}.
         
         If the {{GPUCompilationMessage/message}} corresponds to a span of characters this points to
-        the line one which the span begins. Must be `0` if the {{GPUCompilationMessage/message}}
+        the line on which the span begins. Must be `0` if the {{GPUCompilationMessage/message}}
         does not correspond to any specific point in the shader {{GPUShaderModuleDescriptor/code}}.
 
         Issue: Reference WGSL spec when it [defines what a line is](https://gpuweb.github.io/gpuweb/wgsl/#comments).

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3759,8 +3759,12 @@ interface GPUCompilationInfo {
     : <dfn>lineNum</dfn>
     ::
         The line number in the shader {{GPUShaderModuleDescriptor/code}} the
-        {{GPUCompilationMessage/message}} corresponds to. If {{GPUCompilationMessage/message}}
-        corresponds to a span of characters this points to the line one which the span begins.
+        {{GPUCompilationMessage/message}} corresponds to. Value is one-based, such that a lineNum of
+        `1` indicates the first line of the shader {{GPUShaderModuleDescriptor/code}}.
+        
+        If the {{GPUCompilationMessage/message}} corresponds to a span of characters this points to
+        the line one which the span begins. Must be `0` if the {{GPUCompilationMessage/message}}
+        does not correspond to any specific point in the shader {{GPUShaderModuleDescriptor/code}}.
 
         Issue: Reference WGSL spec when it [defines what a line is](https://gpuweb.github.io/gpuweb/wgsl/#comments).
 
@@ -3768,8 +3772,12 @@ interface GPUCompilationInfo {
     ::
         The offset, in UTF-16 code units, from the beginning of line {{GPUCompilationMessage/lineNum}}
         of the shader {{GPUShaderModuleDescriptor/code}} that the {{GPUCompilationMessage/message}}
-        corresponds to. If {{GPUCompilationMessage/message}} corresponds to a span of characters
-        this points to the first character of the span.
+        corresponds to. Value is one-based, such that a linePos of `1` indicates the first character
+        of the line.
+        
+        If {{GPUCompilationMessage/message}} corresponds to a span of characters this points to the
+        first character of the span. Must be `0` if the {{GPUCompilationMessage/message}}
+        does not correspond to any specific point in the shader {{GPUShaderModuleDescriptor/code}}.
 
     : <dfn>offset</dfn>
     ::
@@ -3785,6 +3793,11 @@ interface GPUCompilationInfo {
         in the shader {{GPUShaderModuleDescriptor/code}} rather than a span of characters then
         {{GPUCompilationMessage/length}} must be 0.
 </dl>
+
+Note: {{GPUCompilationMessage}}.{{GPUCompilationMessage/lineNum}} and
+{{GPUCompilationMessage}}.{{GPUCompilationMessage/linePos}} are one-based since the most common use
+for them is expected to be printing human readable messages that can be correlated with the line and
+column numbers shown in many text editors.
 
 Note: {{GPUCompilationMessage}}.{{GPUCompilationMessage/offset}} and
 {{GPUCompilationMessage}}.{{GPUCompilationMessage/length}} are appropriate to pass to


### PR DESCRIPTION
I know as developers we all universally recoil at one-based anything, but as I've been working on Chrome's implementation of CompilationMessages I realized that having line/pos be one-based was likely the most intuitive behavior for many developers. Especially since it's going to be common to want to just print them out directly as `${message.lineNum}:${message.linePos}`. Basically: these values feel like they should favor being human readable. Happy to discuss more!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/1700.html" title="Last updated on May 4, 2021, 4:43 PM UTC (784a84e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1700/d7774ae...784a84e.html" title="Last updated on May 4, 2021, 4:43 PM UTC (784a84e)">Diff</a>