### PR TITLE
wgsl: "Structure Layout Rules": Remove forbidden [[block]] attrs.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1330,7 +1330,7 @@ rounded to the next multiple of the structure's alignment:
 
 <div class='example wgsl' heading='Layout of structures using implicit member sizes, alignments and strides'>
   <xmp highlight='rust'>
-    [[block]] struct A {                           //             align(8)  size(24)
+    struct A {                                     //             align(8)  size(24)
         u : f32;                                   // offset(0)   align(4)  size(4)
         v : f32;                                   // offset(4)   align(4)  size(4)
         w : vec2<f32>;                             // offset(8)   align(8)  size(8)
@@ -1360,7 +1360,7 @@ rounded to the next multiple of the structure's alignment:
 
 <div class='example wgsl' heading='Layout of structures with explicit member sizes, alignments and strides'>
   <xmp highlight='rust'>
-    [[block]] struct A {                           //             align(8)  size(32)
+    struct A {                                     //             align(8)  size(32)
         u : f32;                                   // offset(0)   align(4)  size(4)
         v : f32;                                   // offset(4)   align(4)  size(4)
         w : vec2<f32>;                             // offset(8)   align(8)  size(8)


### PR DESCRIPTION
Fixes #1702.