### PR TITLE
WebGPU: Fix markup, broken links, adjust metadata for publication to /TR

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1,10 +1,12 @@
 <pre class='metadata'>
 Title: WebGPU
 Shortname: webgpu
-Level: 1
+Level: None
 Status: w3c/ED
 Group: webgpu
-URL: https://gpuweb.github.io/gpuweb/
+ED: https://gpuweb.github.io/gpuweb/
+TR: https://www.w3.org/TR/webgpu/
+Repository: gpuweb/gpuweb
 
 !Participate: <a href="https://github.com/gpuweb/gpuweb/issues/new">File an issue</a> (<a href="https://github.com/gpuweb/gpuweb/issues">open issues</a>)
 
@@ -19,13 +21,41 @@ Markup Shorthands: css no
 Assume Explicit For: yes
 </pre>
 
+<pre class=biblio>
+{
+  "WGSL": {
+    "authors": [
+      "David Neto",
+      "Myles C. Maxfield"
+    ],
+    "href": "https://gpuweb.github.io/gpuweb/wgsl/",
+    "title": "WebGPU Shading Language",
+    "status": "Editor's Draft",
+    "publisher": "W3C",
+    "deliveredBy": [
+      "https://github.com/gpuweb/gpuweb"
+    ]
+  },
+  "SourceMap": {
+    "authors": [
+      "John Lenz",
+      "Nick Fitzgerald"
+    ],
+    "href": "https://sourcemaps.info/spec.html",
+    "title": "Source Map Revision 3 Proposal"
+  }
+}
+</pre>
+
 <pre class="link-defaults">
 spec:html;
     type:interface; text:Navigator
+spec:webidl;
+    type:interface; text:Promise
 </pre>
 
 <pre class='anchors'>
-spec: ECMA-262; urlPrefix: https://tc39.github.io/ecma262/#
+spec: ECMA-262; urlPrefix: https://tc39.es/ecma262/#
     type: dfn
         text: agent; url: agent
         text: surrounding agent; url: surrounding-agent
@@ -35,15 +65,19 @@ spec: webidl; urlPrefix: https://heycam.github.io/webidl/#
         text: resolve; url: resolve
 spec: web-apis; urlPrefix: https://html.spec.whatwg.org/multipage/webappapis.html#
     type: dfn
-        text: cross-origin isolated; url: cross-origin-isolated
+        text: cross-origin isolated capability; url: concept-settings-object-cross-origin-isolated-capability
 spec: canvas; urlPrefix: https://html.spec.whatwg.org/multipage/canvas.html#
     type: dfn
         text: origin-clean; url: concept-canvas-origin-clean
+spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
+    type: dfn
+        text: location; url: input-output-locations
+        text: interpolation; url: interpolation
 </pre>
 
 <style>
 /* Make <dl> blocks more distinct from their surroundings. */
-dl:not(.switch) {
+main dl:not(.switch) {
     border-left: thin solid #f3e48c;
     padding-left: .5em;
 }
@@ -256,7 +290,7 @@ ensuring that a page can only work with its own data.
 
 A WebGPU implementation translates the workloads issued by the user into API commands specific
 to the target platform. Native APIs specify the valid usage for the commands
-(for example, see [vkCreateDescriptorSetLayout](https://www.khronos.org/registry/vulkan/specs/1.1-extensions/man/html/vkCreateDescriptorSetLayout.html))
+(for example, see [vkCreateDescriptorSetLayout](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateDescriptorSetLayout.html))
 and generally don't guarantee any outcome if the valid usage rules are not followed.
 This is called "undefined behavior", and it can be exploited by an attacker to access memory
 they don't own, or force the driver to execute arbitrary code.
@@ -1693,7 +1727,7 @@ Those not defined here are defined elsewhere in this document.
     <dfn abstract-op>The steps to serialize a GPUDevice object</dfn>,
     given |value|, |serialized|, and |forStorage|, are:
      1. Set |serialized|.agentCluster to be the [=surrounding agent=]'s [=agent cluster=].
-     1. If |serialized|.agentCluster's [=cross-origin isolated=] is false, throw a "{{DataCloneError}}".
+     1. If |serialized|.agentCluster's [=cross-origin isolated capability=] is false, throw a "{{DataCloneError}}".
      1. If |forStorage| is `true`, throw a "{{DataCloneError}}".
      1. Set |serialized|.device to the value of |value|.{{GPUDevice/[[device]]}}.
 </div>
@@ -2901,33 +2935,33 @@ enum GPUCompareFunction {
     ::
         Creates a {{GPUBindGroupLayout}}.
 
-    <div algorithm=GPUDevice.createSampler>
-        **Called on:** {{GPUDevice}} this.
+        <div algorithm=GPUDevice.createSampler>
+            **Called on:** {{GPUDevice}} this.
 
-        **Arguments:**
-        <pre class=argumentdef for="GPUDevice/createSampler(descriptor)">
-            |descriptor|: Description of the {{GPUSampler}} to create.
-        </pre>
+            **Arguments:**
+            <pre class=argumentdef for="GPUDevice/createSampler(descriptor)">
+                |descriptor|: Description of the {{GPUSampler}} to create.
+            </pre>
 
-        **Returns:** {{GPUSampler}}
+            **Returns:** {{GPUSampler}}
 
-        1. Let |s| be a new {{GPUSampler}} object.
-        1. Set |s|.{{GPUSampler/[[descriptor]]}} to |descriptor|.
-        1. Set |s|.{{GPUSampler/[[isComparison]]}} to `false` if the {{GPUSamplerDescriptor/compare}} attribute
-                of |s|.{{GPUSampler/[[descriptor]]}} is `null` or undefined. Otherwise, set it to `true`.
-        1. Set |s|.{{GPUSampler/[[isFiltering]]}} to `false` if none of {{GPUSamplerDescriptor/minFilter}},
-            {{GPUSamplerDescriptor/magFilter}}, or {{GPUSamplerDescriptor/mipmapFilter}} has the value of
-            {{GPUFilterMode/"linear"}}. Otherwise, set it to `true`.
-        1. Return |s|.
+            1. Let |s| be a new {{GPUSampler}} object.
+            1. Set |s|.{{GPUSampler/[[descriptor]]}} to |descriptor|.
+            1. Set |s|.{{GPUSampler/[[isComparison]]}} to `false` if the {{GPUSamplerDescriptor/compare}} attribute
+                    of |s|.{{GPUSampler/[[descriptor]]}} is `null` or undefined. Otherwise, set it to `true`.
+            1. Set |s|.{{GPUSampler/[[isFiltering]]}} to `false` if none of {{GPUSamplerDescriptor/minFilter}},
+                {{GPUSamplerDescriptor/magFilter}}, or {{GPUSamplerDescriptor/mipmapFilter}} has the value of
+                {{GPUFilterMode/"linear"}}. Otherwise, set it to `true`.
+            1. Return |s|.
 
-        <div class=validusage dfn-for=GPUDevice.createSampler>
-            <dfn abstract-op>Valid Usage</dfn>
-            - If |descriptor| is not `null` or undefined:
-                - If [$validating GPUSamplerDescriptor$](this, |descriptor|) returns `false`:
-                    1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
-                    1. Create a new [=invalid=] {{GPUSampler}} and return the result.
+            <div class=validusage dfn-for=GPUDevice.createSampler>
+                <dfn abstract-op>Valid Usage</dfn>
+                - If |descriptor| is not `null` or undefined:
+                    - If [$validating GPUSamplerDescriptor$](this, |descriptor|) returns `false`:
+                        1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
+                        1. Create a new [=invalid=] {{GPUSampler}} and return the result.
+            </div>
         </div>
-    </div>
 </dl>
 
 # Resource Binding # {#bindings}
@@ -3664,9 +3698,9 @@ dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
 </script>
 
 {{GPUShaderModuleDescriptor/sourceMap}}, if defined, MAY be interpreted as a
-source-map-v3 format. (https://sourcemaps.info/spec.html)
+source-map-v3 format.
 Source maps are optional, but serve as a standardized way to support dev-tool
-integration such as source-language debugging.
+integration such as source-language debugging. [[SourceMap]]
 
 <dl dfn-type=method dfn-for=GPUDevice>
     : <dfn>createShaderModule(descriptor)</dfn>
@@ -4355,17 +4389,17 @@ details.
                 be a user-defined input of
                 |descriptor|.{{GPURenderPipelineDescriptor/fragment}} that
                 matches the
-                [location](https://gpuweb.github.io/gpuweb/wgsl/#input-output-locations),
+                [=location=],
                 type, and
-                [interpolation](https://gpuweb.github.io/gpuweb/wgsl/#interpolation)
+                [=interpolation=]
                 of the output.
             - For each user-defined input of
                 |descriptor|.{{GPURenderPipelineDescriptor/fragment}} there
                 must be a user-defined output of
                 |descriptor|.{{GPURenderPipelineDescriptor/vertex}} that
-                [location](https://gpuweb.github.io/gpuweb/wgsl/#input-output-locations),
+                [=location=],
                 type, and
-                [interpolation](https://gpuweb.github.io/gpuweb/wgsl/#interpolation)
+                [=interpolation=]
                 of the input.
 </div>
 
@@ -8364,6 +8398,7 @@ The sign of |area| is interpreted based on the {{GPURenderPipelineDescriptor/pri
     : {{GPUFrontFace/"cw"}}
     :: |area| &lt; 0 is considered [=front-facing=], otherwise [=back-facing=]
     : "linear"
+    ::
 </dl>
 
 The polygon can be culled by {{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/cullMode}}:
@@ -8690,7 +8725,7 @@ The {{GPUTextureUsage/STORAGE|GPUTextureUsage.RENDER_ATTACHMENT}} column specifi
             <th>{{GPUTextureUsage/RENDER_ATTACHMENT}}
             <th>{{GPUTextureUsage/STORAGE}}
     </thead>
-    <tr><th class=stickyheader>8-bit per component<th><th><th><th>
+    <tr><th class=stickyheader>8-bit per component<th><th><th>
     <tr>
         <td>{{GPUTextureFormat/r8unorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -8766,7 +8801,7 @@ The {{GPUTextureUsage/STORAGE|GPUTextureUsage.RENDER_ATTACHMENT}} column specifi
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>
-    <tr><th class=stickyheader>16-bit per component<th><th><th><th>
+    <tr><th class=stickyheader>16-bit per component<th><th><th>
     <tr>
         <td>{{GPUTextureFormat/r16uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -8812,7 +8847,7 @@ The {{GPUTextureUsage/STORAGE|GPUTextureUsage.RENDER_ATTACHMENT}} column specifi
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>&checkmark;
-    <tr><th class=stickyheader>32-bit per component<th><th><th><th>
+    <tr><th class=stickyheader>32-bit per component<th><th><th>
     <tr>
         <td>{{GPUTextureFormat/r32uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -8858,7 +8893,7 @@ The {{GPUTextureUsage/STORAGE|GPUTextureUsage.RENDER_ATTACHMENT}} column specifi
         <td>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
         <td>&checkmark;
-    <tr><th class=stickyheader>mixed component width<th><th><th><th>
+    <tr><th class=stickyheader>mixed component width<th><th><th>
     <tr>
         <td>{{GPUTextureFormat/rgb10a2unorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7,7 +7,6 @@ Group: webgpu
 ED: https://gpuweb.github.io/gpuweb/
 TR: https://www.w3.org/TR/webgpu/
 Repository: gpuweb/gpuweb
-
 !Participate: <a href="https://github.com/gpuweb/gpuweb/issues/new">File an issue</a> (<a href="https://github.com/gpuweb/gpuweb/issues">open issues</a>)
 
 Editor: Dzmitry Malyshau, Mozilla https://www.mozilla.org, dmalyshau@mozilla.com


### PR DESCRIPTION
This makes the following editorial updates to make sure that the WebGPU document passes W3C publication rules:

- Metadata: switch level to `None` not to create a `webgpu-1` shortname for now
- Metadata: Add ED, TR and Repository entries (needed for publication to /TR)
- Add a proper WGSL entry to the list of normative references, and properly reference terms defined in WGSL
- Add Source Map spec to the list of informative references
- Make sure `Promise` gets resolved to the WebIDL spec (Bikeshed issues a warning when status is FPWD/WD otherwise)
- Update URL of ECMA 263 spec to avoid permanent redirect
- Fix broken link to cross-origin isolated capability in HTML
- Avoid left border in front matter
- Fix tab padding in createSampler algorithm to generate valid HTML
- Make sure that all `<dt>` are always followed by a `<dd>`, invalid HTML otherwise
- Fix number of heading columns in table

Note: There are references to other external documents in the Malicious use considerations section which should eventually appear as proper references at the end of the document, but the section is information, so no need to do that for now.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/gpuweb/pull/1706.html" title="Last updated on May 3, 2021, 3:57 PM UTC (9184aec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1706/ed40e00...tidoust:9184aec.html" title="Last updated on May 3, 2021, 3:57 PM UTC (9184aec)">Diff</a>