### PR TITLE
wgsl: Fix markup, broken links, adjust metadata for publication to /TR

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1,10 +1,12 @@
 <pre class='metadata'>
 Title: WebGPU Shading Language
-Shortname: WGSL
-Level: 1
+Shortname: wgsl
+Level: None
 Status: w3c/ED
 Group: webgpu
-URL: https://gpuweb.github.io/gpuweb/wgsl/
+ED: https://gpuweb.github.io/gpuweb/wgsl/
+TR: https://www.w3.org/TR/webgpu/
+Repository: gpuweb/gpuweb
 Ignored Vars: i, e, e1, e2, e3, N, M, v, Stride, Offset, Align, Extent, S, T, T1
 
 !Participate: <a href="https://github.com/gpuweb/gpuweb/issues/new?labels=wgsl">File an issue</a> (<a href="https://github.com/gpuweb/gpuweb/issues?q=is%3Aissue+is%3Aopen+label%3Awgsl">open issues</a>)
@@ -50,6 +52,16 @@ thead {
       "https://github.com/gpuweb/gpuweb"
     ]
   },
+  "SPIR-V": {
+    "authors": [
+      "John Kessenich",
+      "Boaz Ouriel",
+      "Raun Krisch"
+    ],
+    "href": "https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html",
+    "title": "SPIR-V Specification",
+    "publisher": "Khronos Group"
+  },
   "VulkanMemoryModel": {
     "authors": [
       "Jeff Bolz",
@@ -64,6 +76,12 @@ thead {
     "publisher": "Khronos Group"
   }
 }
+</pre>
+
+<pre class='anchors'>
+spec: SPIR-V; urlPrefix: https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#
+    type: dfn
+        text: image formats; url: _a_id_image_format_a_image_format
 </pre>
 
 # Introduction # {#intro}
@@ -84,11 +102,11 @@ that run on the GPU.
 
 ## Goals ## {#goals}
 
- * Trivially convertable to SPIR-V
- * Constructs are defined as normative references to their SPIR-V counterparts
- * All features in [SHORTNAME] are directly translatable to SPIR-V. (No polymorphism, no general pointers, no overloads, etc)
- * Features and semantics are exactly the ones of SPIR-V
- * Each item in this spec *must* provide the mapping to SPIR-V for the construct
+ * Trivially convertable to [[!SPIR-V]]
+ * Constructs are defined as normative references to their [[!SPIR-V]] counterparts
+ * All features in [SHORTNAME] are directly translatable to [[!SPIR-V]]. (No polymorphism, no general pointers, no overloads, etc)
+ * Features and semantics are exactly the ones of [[!SPIR-V]]
+ * Each item in this spec *must* provide the mapping to [[!SPIR-V]] for the construct
 
 ## Technical Overview ## {#technical-overview}
 
@@ -220,7 +238,7 @@ The events are:
     * This occurs when the
         [[WebGPU#dom-gpudevice-createcomputepipeline|WebGPU createComputePipeline]] method
         or the
-        [[WebGPU#dom-gpudevice-createrenderputepipeline|WebGPU createRenderPipeline]] method
+        [[WebGPU#dom-gpudevice-createrenderpipeline|WebGPU createRenderPipeline]] method
         is invoked.
         These methods use one or more previously created shader modules, together with other
         configuration information.
@@ -2046,7 +2064,7 @@ This is also known as the <dfn noexport>channel transfer function</dfn>, or CTF.
     <tr><th>Channel format
         <th>Number of stored bits
         <th>Interpetation of stored bits
-        <th>Shader type<td width="25%">Shader value
+        <th>Shader type<td style="width:25%">Shader value
 (Channel Transfer Function)
   </thead>
   <tr><td>8unorm<td>8<td>unsigned integer |v| &isinv; {0,...,255}<td>f32<td> |v| &div; 255
@@ -2085,7 +2103,7 @@ The last column in the table below uses the format-specific
     <tr><th>Texel format
         <th>Channel format
         <th>Channels in memory order
-        <th width="50%">Corresponding shader value
+        <th style="width:50%">Corresponding shader value
   </thead>
   <tr><td>rgba8unorm<td>8unorm<td>r, g, b, a<td>vec4&lt;f32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
   <tr><td>rgba8snorm<td>8snorm<td>r, g, b, a<td>vec4&lt;f32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
@@ -2106,7 +2124,7 @@ The last column in the table below uses the format-specific
 </table>
 
 The following table lists the correspondence between WGSL texel formats and
-[SPIR-V image formats](https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#_a_id_image_format_a_image_format).
+SPIR-V [=image formats=].
 
 <table class='data'>
   <caption>Mapping texel formats to SPIR-V</caption>
@@ -2383,7 +2401,7 @@ An <dfn noexport>atomic type</dfn> encapsulates a [=scalar=] type such that:
   <thead>
     <tr><th>Type<th>Description
   </thead>
-  <tr algorith="atomic type"><td>atomic&lt;|T|&gt;
+  <tr algorithm="atomic type"><td>atomic&lt;|T|&gt;
     <td>Atomic of type |T|. |T| must be either [=u32=] or [=i32=].
 </table>
 
@@ -2405,7 +2423,7 @@ workgroups.
 
 TODO: Add links the eventual memory model descriptions.
 
-<pre class='example storage atomic' heading='Mapping atomics in a storage variable to SPIR-V'>
+<div class='example storage atomic' heading='Mapping atomics in a storage variable to SPIR-V'>
   <xmp>
     [[block]] struct S {
       a : atomic<i32>;
@@ -2428,9 +2446,9 @@ TODO: Add links the eventual memory model descriptions.
     // %ptr_storage_S = OpTypePointer StorageBuffer %S
     // %x = OpVariable %ptr_storage_S StorageBuffer
   </xmp>
-</pre>
+</div>
 
-<pre class='example workgroup atomic' heading='Mapping atomics in a workgroup variable to SPIR-V'>
+<div class='example workgroup atomic' heading='Mapping atomics in a workgroup variable to SPIR-V'>
   <xmp>
     var<workgroup> x : atomic<u32>;
     
@@ -2443,7 +2461,7 @@ TODO: Add links the eventual memory model descriptions.
     // %ptr_workgroup_u32 = OpTypePointer Workgroup %S
     // %x = OpVariable %ptr_workgroup_u32 Workgroup
   </xmp>
-</pre>
+</div>
 
 ## Type Aliases TODO ## {#type-aliases}
 
@@ -2621,7 +2639,7 @@ When a variable is created, its storage contains an initial value as follows:
 * For variables in other storage classes, the execution environment provides the initial value.
 
 Consider the following snippet of WGSL:
-<div class='example wsgl function-scope' header='Variable initial values'>
+<div class='example wsgl function-scope' heading='Variable initial values'>
   <xmp highlight='rust'>
     var i: i32;         // Initial value is 0.  Not recommended style.
     loop {
@@ -2960,33 +2978,33 @@ and third clauses and in the body of the `for` statement.
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr>
-    <td>*e1* : vec2<f32><br>
-        *e2* : vec2<f32><br>
-        *e3* : vec2<f32><br>
-        *e4* : vec2<f32>
-    <td>`mat2x2<f32>(e1,e2)` : mat2x2<f32><br>
-        `mat3x2<f32>(e1,e2,e3)` : mat3x2<f32><br>
-        `mat4x2<f32>(e1,e2,e3,e4)` : mat4x2<f32>
+    <td>*e1* : vec2&lt;f32&gt;<br>
+        *e2* : vec2&lt;f32&gt;<br>
+        *e3* : vec2&lt;f32&gt;<br>
+        *e4* : vec2&lt;f32&gt;
+    <td>`mat2x2<f32>(e1,e2)` : mat2x2&lt;f32&gt;<br>
+        `mat3x2<f32>(e1,e2,e3)` : mat3x2&lt;f32&gt;<br>
+        `mat4x2<f32>(e1,e2,e3,e4)` : mat4x2&lt;f32&gt;
     <td>Column by column construction.<br>
         OpCompositeConstruct
   <tr>
-    <td>*e1* : vec3<f32><br>
-        *e2* : vec3<f32><br>
-        *e3* : vec3<f32><br>
-        *e4* : vec3<f32>
-    <td>`mat2x3<f32>(e1,e2)` : mat2x3<f32><br>
-        `mat3x3<f32>(e1,e2,e3)` : mat3x3<f32><br>
-        `mat4x3<f32>(e1,e2,e3,e4)` : mat4x3<f32>
+    <td>*e1* : vec3&lt;f32&gt;<br>
+        *e2* : vec3&lt;f32&gt;<br>
+        *e3* : vec3&lt;f32&gt;<br>
+        *e4* : vec3&lt;f32&gt;
+    <td>`mat2x3<f32>(e1,e2)` : mat2x3&lt;f32&gt;<br>
+        `mat3x3<f32>(e1,e2,e3)` : mat3x3&lt;f32&gt;<br>
+        `mat4x3<f32>(e1,e2,e3,e4)` : mat4x3&lt;f32&gt;
     <td>Column by column construction.<br>
         OpCompositeConstruct
   <tr>
-    <td>*e1* : vec4<f32><br>
-        *e2* : vec4<f32><br>
-        *e3* : vec4<f32><br>
-        *e4* : vec4<f32>
-    <td>`mat2x4<f32>(e1,e2)` : mat2x4<f32><br>
-        `mat3x4<f32>(e1,e2,e3)` : mat3x4<f32><br>
-        `mat4x4<f32>(e1,e2,e3,e4)` : mat4x4<f32>
+    <td>*e1* : vec4&lt;f32&gt;<br>
+        *e2* : vec4&lt;f32&gt;<br>
+        *e3* : vec4&lt;f32&gt;<br>
+        *e4* : vec4&lt;f32&gt;
+    <td>`mat2x4<f32>(e1,e2)` : mat2x4&lt;f32&gt;<br>
+        `mat3x4<f32>(e1,e2,e3)` : mat3x4&lt;f32&gt;<br>
+        `mat4x4<f32>(e1,e2,e3,e4)` : mat4x4&lt;f32&gt;
     <td>Column by column construction.<br>
         OpCompositeConstruct
 </table>
@@ -3021,7 +3039,6 @@ TODO: Should this only work for storable sized arrays?  https://github.com/gpuwe
         The expression is in the scope of declaration of S.
     <td>`S(e1,...,eN)` : S
     <td>Construction of a structure from members
-  <tr>
 </table>
 
 
@@ -3063,16 +3080,13 @@ The zero values are as follows:
     <td>`vec2<T>()` : vec2<*T*>
     <td>Zero value (OpConstantNull)
   <tr>
-  <tr>
     <td>
     <td>`vec3<T>()` : vec3<*T*>
     <td>Zero value (OpConstantNull)
   <tr>
-  <tr>
     <td>
     <td>`vec4<T>()` : vec4<*T*>
     <td>Zero value (OpConstantNull)
-  <tr>
 </table>
 
 
@@ -3093,23 +3107,21 @@ The zero values are as follows:
   </thead>
   <tr>
     <td>
-    <td>`mat2x2<f32>()` : mat2x2<f32><br>
-        `mat3x2<f32>()` : mat3x2<f32><br>
-        `mat4x2<f32>()` : mat4x2<f32>
+    <td>`mat2x2<f32>()` : mat2x2&lt;f32&gt;<br>
+        `mat3x2<f32>()` : mat3x2&lt;f32&gt;<br>
+        `mat4x2<f32>()` : mat4x2&lt;f32&gt;
     <td>Zero value (OpConstantNull)
   <tr>
-  <tr>
     <td>
-    <td>`mat2x3<f32>()` : mat2x3<f32><br>
-        `mat3x3<f32>()` : mat3x3<f32><br>
-        `mat4x3<f32>()` : mat4x3<f32>
+    <td>`mat2x3<f32>()` : mat2x3&lt;f32&gt;<br>
+        `mat3x3<f32>()` : mat3x3&lt;f32&gt;<br>
+        `mat4x3<f32>()` : mat4x3&lt;f32&gt;
     <td>Zero value (OpConstantNull)
   <tr>
-  <tr>
     <td>
-    <td>`mat2x4<f32>()` : mat2x4<f32><br>
-        `mat3x4<f32>()` : mat3x4<f32><br>
-        `mat4x4<f32>()` : mat4x4<f32>
+    <td>`mat2x4<f32>()` : mat2x4&lt;f32&gt;<br>
+        `mat3x4<f32>()` : mat3x4&lt;f32&gt;<br>
+        `mat4x4<f32>()` : mat4x4&lt;f32&gt;
     <td>Zero value (OpConstantNull)
 </table>
 
@@ -3143,7 +3155,6 @@ The zero values are as follows:
     <td>Zero-valued structure: a structure of type S where each member is the zero value for its member type.
 <br>
  (OpConstantNull)
-  <tr>
 </table>
 
 <div class='example wgsl global-scope' heading="Zero-valued structures">
@@ -6085,7 +6096,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
       <td>vertex
       <td>in
       <td>u32
-      <td width="50%">Index of the current vertex within the current API-level draw command,
+      <td style="width:50%">Index of the current vertex within the current API-level draw command,
          independent of draw instancing.
 
          For a non-indexed draw, the first vertex has an index equal to the `firstIndex` argument
@@ -6099,7 +6110,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
       <td>vertex
       <td>in
       <td>u32
-      <td width="50%">Instance index of the current vertex within the current API-level draw command.
+      <td style="width:50%">Instance index of the current vertex within the current API-level draw command.
 
          The first instance has an index equal to the `firstInstance` argument of the draw,
          whether provided directly or indirectly.
@@ -6109,7 +6120,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
       <td>vertex
       <td>out
       <td>vec4&lt;f32&gt;
-      <td width="50%">Output position of the current vertex, using homogeneous coordinates.
+      <td style="width:50%">Output position of the current vertex, using homogeneous coordinates.
       After homogeneous normalization (where each of the *x*, *y*, and *z* components
       are divided by the *w* component), the position is in the WebGPU normalized device
       coordinate space.
@@ -6119,7 +6130,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
       <td>fragment
       <td>in
       <td>vec4&lt;f32&gt;
-      <td width="50%">Framebuffer position of the current fragment, using normalized homogeneous
+      <td style="width:50%">Framebuffer position of the current fragment, using normalized homogeneous
       coordinates.
       (The *x*, *y*, and *z* components have already been scaled such that *w* is now 1.)
       See [[WebGPU#coordinate-systems|WebGPU &sect; Coordinate Systems]].
@@ -6128,50 +6139,50 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
       <td>fragment
       <td>in
       <td>bool
-      <td width="50%">True when the current fragment is on a front-facing primitive.
+      <td style="width:50%">True when the current fragment is on a front-facing primitive.
          False otherwise.
-         See [[WebGPU#dom-gpurasterizationstatedescriptor-frontface|WebGPU &sect; Rasterization State]].
+         See [[WebGPU#front-facing|WebGPU &sect; Front-facing]].
 
   <tr><td>`frag_depth`
       <td>fragment
       <td>out
       <td>f32
-      <td width="50%">Updated depth of the fragment, in the viewport depth range.
+      <td style="width:50%">Updated depth of the fragment, in the viewport depth range.
       See [[WebGPU#coordinate-systems|WebGPU &sect; Coordinate Systems]].
 
   <tr><td>`local_invocation_id`
       <td>compute
       <td>in
       <td>vec3&lt;u32&gt;
-      <td width="50%">The current invocation's [=local invocation ID=],
+      <td style="width:50%">The current invocation's [=local invocation ID=],
             i.e. its position in the [=workgroup grid=].
 
   <tr><td>`local_invocation_index`
       <td>compute
       <td>in
       <td>u32
-      <td width="50%">The current invocation's [=local invocation index=], a linearized index of
+      <td style="width:50%">The current invocation's [=local invocation index=], a linearized index of
           the invocation's position within the [=workgroup grid=].
 
   <tr><td>`global_invocation_id`
       <td>compute
       <td>in
       <td>vec3&lt;u32&gt;
-      <td width="50%">The current invocation's [=global invocation ID=],
+      <td style="width:50%">The current invocation's [=global invocation ID=],
           i.e. its position in the [=compute shader grid=].
 
   <tr><td>`workgroup_id`
       <td>compute
       <td>in
       <td>vec3&lt;u32&gt;
-      <td width="50%">The current invocation's [=workgroup ID=],
+      <td style="width:50%">The current invocation's [=workgroup ID=],
           i.e. the position of the workgroup in the [=workgroup grid=].
 
   <tr><td>`num_workgroups`
       <td>compute
       <td>in
       <td>vec3&lt;u32&gt;
-      <td width="50%">The [=dispatch size=], `vec<u32>(group_count_x,
+      <td style="width:50%">The [=dispatch size=], `vec<u32>(group_count_x,
       group_count_y, group_count_z)`, of the compute shader
       [[WebGPU#dom-gpucomputepassencoder-dispatch|dispatched]] by the API.
 
@@ -6179,23 +6190,23 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
       <td>compute
       <td>in
       <td>vec3&lt;u32&gt;
-      <td width="50%">The [=workgroup_size=] of the current entry point.
+      <td style="width:50%">The [=workgroup_size=] of the current entry point.
 
   <tr><td>`sample_index`
       <td>fragment
       <td>in
       <td>u32
-      <td width="50%">Sample index for the current fragment.
+      <td style="width:50%">Sample index for the current fragment.
          The value is least 0 and at most `sampleCount`-1, where
          [[WebGPU#dom-gpurenderpipelinedescriptor-samplecount|sampleCount]]
          is the number of MSAA samples specified for the GPU render pipeline.
-         <br>See [[WebGPU#gpurenderpipe|WebGPU &sect; GPURenderPipeline]].
+         <br>See [[WebGPU#render-pipeline|WebGPU &sect; GPURenderPipeline]].
 
   <tr><td>`sample_mask`
       <td>fragment
       <td>in
       <td>u32
-      <td width="50%">Sample coverage mask for the current fragment.
+      <td style="width:50%">Sample coverage mask for the current fragment.
          It contains a bitmask indicating which samples in this fragment are covered
          by the primitive being rendered.
          <br>See [[WebGPU#sample-masking|WebGPU &sect; Sample Masking]].
@@ -6204,7 +6215,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
       <td>fragment
       <td>out
       <td>u32
-      <td width="50%">Sample coverage mask control for the current fragment.
+      <td style="width:50%">Sample coverage mask control for the current fragment.
          The last value written to this variable becomes the
          [[WebGPU#shader-output-mask|shader-output mask]].
          Zero bits in the written value will cause corresponding samples in


### PR DESCRIPTION
- Metadata: switch level to `None` not to create a `wgsl-1` shortname for now
- Metadata: Add ED, TR and Repository entries (needed for publication to /TR)
- Add a proper SPIR-V entry to the list of normative references, and properly reference the term "image formats" there
- Replace `width="50%"` table cell attributes with `style="width:50%` attributes to fix HTML markup
- Fix typo on "algorith"
- Make sure all examples start as `<div>` to avoid nesting HTML markup in `<pre>` blocks, since that is invalid. Fix one example heading
- Properly escape occurrences of `<f32>` that get otherwise interpreted as tags (and ignored)
- Drop empty lines from tables to avoid generating invalid HTML markup
- Fix some broken links to WebGPU fragments

There are a few remaining broken links to the WebGPU that should be fixed and that do not strike me as completely straightforward, in particular the references to the now gone `GPUBindingType` in [Resource layout compatibility](https://gpuweb.github.io/gpuweb/wgsl/#resource-layout-compatibility) See result of [running the link validator on the spec](https://validator.w3.org/checklink?uri=https%3A%2F%2Fgpuweb.github.io%2Fgpuweb%2Fwgsl%2F&hide_type=all&recursive=on&depth=&check=Check). How should the spec be updated?