### PR TITLE
Fix a bug in GPUExtent3D

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8570,7 +8570,7 @@ An <dfn dfn>Extent3D</dfn> is a {{GPUExtent3D}}.
 
       - |extent|.<dfn dfn>width</dfn> refers to
         either {{GPUExtent3DDict}}.{{GPUExtent3DDict/width}}
-        or the first item of the sequence (1 if not present).
+        or the first item of the sequence.
       - |extent|.<dfn dfn>height</dfn> refers to
         either {{GPUExtent3DDict}}.{{GPUExtent3DDict/height}}
         or the second item of the sequence (1 if not present).


### PR DESCRIPTION
GPUExtent3D.width doesn't have a default value. If we don't assign
a value to width before it is used, it should fail, with an validation error generated (because it is `undefined`).

In addition, width in https://gpuweb.github.io/gpuweb/#dictdef-gpuextent3ddict doesn't have a default value,
which contradicts with this statement.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Richard-Yunchao/gpuweb/pull/1712.html" title="Last updated on May 4, 2021, 11:54 PM UTC (92369eb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1712/557f0c2...Richard-Yunchao:92369eb.html" title="Last updated on May 4, 2021, 11:54 PM UTC (92369eb)">Diff</a>