### PR TITLE
explainer: Put the security section after the JS section

### DIFF
--- a/explainer/index.bs
+++ b/explainer/index.bs
@@ -78,121 +78,6 @@ WebGL 1.0 and WebGL 2.0 are Javascript projections of the OpenGL ES 2.0 and Open
 
 However, this also means that WebGL doesn't match the design of modern GPUs, causing CPU performance and GPU performance issues. It also makes it increasingly hard to implement WebGL on top of modern native GPU APIs. [WebGL 2.0 Compute](https://www.khronos.org/registry/webgl/specs/latest/2.0-compute/) was an attempt at adding general compute functionality to WebGL but the impedance mismatch with native APIs made the effort incredibly difficult. Contributors to WebGL 2.0 Compute decided to focus their efforts on WebGPU instead.
 
-# Security and Privacy (self-review) # {#questionnaire}
-
-This section is the Security and Privacry self-review.
-You can also see the [Malicious use considerations](https://gpuweb.github.io/gpuweb/#malicious-use) section of the specification.
-
-## What information might this feature expose to Web sites or other parties, and for what purposes is that exposure necessary? ## {#questionnaire-1}
-
-The feature exposes information about the system's GPUs (or lack thereof).
-
-It allows determining if one of the GPUs in the system supports WebGPU by requesting a `GPUAdapter` without software fallback.
-This is necessary for sites to be able to fallback to hardware-accelerated WebGL if the system doesn't support hardware-accelerated WebGPU.
-
-For requested adapters the feature exposes a name, set of optional WebGPU capabilities that the `GPUAdapter` supports, as well as a set of numeric limits that the `GPUAdapter` supports.
-This is necessary because there is a lot of diversity in GPU hardware and while WebGPU target the lowest common denominator it is meant to scale to expose more powerful features when the hardware allows it.
-The name can be surfaced to the user when choosing, for example to let it choose an adapter and can be used by sites to do GPU-specific workarounds (this was critical in the past for WebGL).
-
-Note that the user agent controls which name, optional features, and limits are exposed.
-It is not possible for sites to differentiate between hardware not supporting a feature and the user agent choosing not to expose it.
-User agents are expected to bucket the actual capabilities of the GPU and only expose a limited number of such buckets to the site.
-
-## Do features in your specification expose the minimum amount of information necessary to enable their intended uses? ## {#questionnaire-2}
-
-Yes.
-WebGPU only requires exposing if hardware-accelerated WebGPU is available, not why, or if the browser chose to not expose it etc.
-
-For the name, optional features, and limits the information exposed is not specified to be minimal because each site might require a different subset of the limits and optional features.
-Instead the information exposed is controlled by the user-agent that is expected to only expose a small number of buckets that all expose the same information.
-
-## How do the features in your specification deal with personal information, personally-identifiable information (PII), or information derived from them? ## {#questionnaire-3}
-
-WebGPU doesn't deal with PII unless the site puts PII inside the API, which means that Javascript got access to the PII before WebGPU could.
-
-## How do the features in your specification deal with sensitive information? ## {#questionnaire-4}
-
-WebGPU doesn't deal with sensitive information.
-However some of the information it exposes could be correlated with sensitive information: the presence of powerful optional features or a high speed of GPU computation would allow deducing access to "high-end" GPUs which itself correlates with other information.
-
-## Do the features in your specification introduce new state for an origin that persists across browsing sessions? ## {#questionnaire-5}
-
-The WebGPU specification doesn't introduce new state.
-However implementations are expected to cache the result of compiling shaders and pipelines.
-This introduces state that could be inspected by measuring how long compilation of a set of shaders and pipelines take.
-Note that GPU drivers also have their own caches so user-agents will have to find ways to disable that cache (otherwise state could be leaked across origins).
-
-## Do the features in your specification expose information about the underlying platform to origins? ## {#questionnaire-6}
-
-Yes.
-The specification exposes whether hardware-accelerated WebGPU is available and a user-agent controlled name and set of optional features and limits each `GPUAdapter` supports.
-Different requests for adapters returning adapters with different capabilities would also indicate the system contains multiple GPUs.
-
-## Does this specification allow an origin to send data to the underlying platform? ## {#questionnaire-7}
-
-WebGPU allows sending data to the system's GPU.
-The WebGPU specification prevents ill-formed GPU commands from being sent to the hardware.
-It is also expected that user-agents will have work-arounds for bugs in the driver that could cause issue even with well-formed GPU commands.
-
-## Do features in this specification allow an origin access to sensors on a user’s device? ## {#questionnaire-8}
-
-No.
-
-## What data do the features in this specification expose to an origin? Please also document what data is identical to data exposed by other features, in the same or different contexts. ## {#questionnaire-9}
-
-WebGPU exposes whether hardware-accelerated WebGPU is available, which is a new piece of data.
-The adapter's name, optional features, and limits has a large intersection with WebGL's RENDERER_STRING, limits and extensions: even limits not in WebGL can mostly be deduced from the other limits exposed by WebGL (by deducing what GPU model the system has).
-
-## Do features in this specification enable new script execution/loading mechanisms? ## {#questionnaire-10}
-
-Yes.
-WebGPU allows running arbitrary GPU computations specified with the WebGPU Shading Language (WGSL).
-WGSL is compiled into a `GPUShaderModule` objects that are then used to specify "pipelines" that run computations on the GPU.
-
-## Do features in this specification allow an origin to access other devices? ## {#questionnaire-11}
-
-No.
-WebGPU allows access to PCI-e and external GPUs plugged into the system but these are just part of the system.
-
-## Do features in this specification allow an origin some measure of control over a user agent's native UI? ## {#questionnaire-12}
-
-No.
-However WebGPU can be used to render to fullscreen or WebXR which does change the UI.
-WebGPU can also run GPU computations that take too long and cause of device timeout and a restart of GPU (TDR), which can produce a couple system-wide black frames.
-Note that this is possible with "just" HTML / CSS but WebGPU makes it easier to cause a TDR.
-
-## What temporary identifiers do the features in this specification create or expose to the web? ## {#questionnaire-13}
-
-None.
-
-## How does this specification distinguish between behavior in first-party and third-party contexts? ## {#questionnaire-14}
-
-There are no specific behavior difference between first-party and third-party contexts.
-However the user-agent can decide to limit the `GPUAdapters` returned to third-party contexts: by using fewer buckets, by using a single bucket, or by not exposing WebGPU.
-
-## How do the features in this specification work in the context of a browser’s Private Browsing or Incognito mode? ## {#questionnaire-15}
-
-There is no difference in Incognito mode, but the user-agent can decide to limit the `GPUAdapters` returned.
-User-agents will need to be careful not to reuse the shader compilation caches when in Incognito mode.
-
-## Does this specification have both "Security Considerations" and "Privacy Considerations" sections? ## {#questionnaire-16}
-
-Yes.
-They are both under the [Malicious use considerations](https://gpuweb.github.io/gpuweb/#malicious-use) section.
-
-## Do features in your specification enable origins to downgrade default security protections? ## {#questionnaire-17}
-
-No.
-Except that WebGPU can be used to render to fullscreen or WebXR.
-
-## What should this questionnaire have asked? ## {#questionnaire-18}
-
-Does the specification allow interacting with cross-origin data? With DRM data?
-
-At the moment WebGPU cannot do that but it is likely that someone will request these features in the future.
-It might be possible to introduce the concept of "protected queues" that only allow computations to end up on the screen, and not into Javascript.
-However investigation in WebGL show that GPU timings can be used to leak from such protected queues.
-
 # Additional Background # {#background}
 
 ## Sandboxed GPU Processes in Web Browsers ## {#gpu-process}
@@ -1236,6 +1121,122 @@ which mentions that strongly-typed bitflags in JavaScript would be useful.
 
 Issue(gpuweb/gpuweb#304): This is a known misuse of `interface`; see issue.
 Update this section if that issue is resolved.
+
+
+# Security and Privacy (self-review) # {#questionnaire}
+
+This section is the Security and Privacry self-review.
+You can also see the [Malicious use considerations](https://gpuweb.github.io/gpuweb/#malicious-use) section of the specification.
+
+## What information might this feature expose to Web sites or other parties, and for what purposes is that exposure necessary? ## {#questionnaire-1}
+
+The feature exposes information about the system's GPUs (or lack thereof).
+
+It allows determining if one of the GPUs in the system supports WebGPU by requesting a `GPUAdapter` without software fallback.
+This is necessary for sites to be able to fallback to hardware-accelerated WebGL if the system doesn't support hardware-accelerated WebGPU.
+
+For requested adapters the feature exposes a name, set of optional WebGPU capabilities that the `GPUAdapter` supports, as well as a set of numeric limits that the `GPUAdapter` supports.
+This is necessary because there is a lot of diversity in GPU hardware and while WebGPU target the lowest common denominator it is meant to scale to expose more powerful features when the hardware allows it.
+The name can be surfaced to the user when choosing, for example to let it choose an adapter and can be used by sites to do GPU-specific workarounds (this was critical in the past for WebGL).
+
+Note that the user agent controls which name, optional features, and limits are exposed.
+It is not possible for sites to differentiate between hardware not supporting a feature and the user agent choosing not to expose it.
+User agents are expected to bucket the actual capabilities of the GPU and only expose a limited number of such buckets to the site.
+
+## Do features in your specification expose the minimum amount of information necessary to enable their intended uses? ## {#questionnaire-2}
+
+Yes.
+WebGPU only requires exposing if hardware-accelerated WebGPU is available, not why, or if the browser chose to not expose it etc.
+
+For the name, optional features, and limits the information exposed is not specified to be minimal because each site might require a different subset of the limits and optional features.
+Instead the information exposed is controlled by the user-agent that is expected to only expose a small number of buckets that all expose the same information.
+
+## How do the features in your specification deal with personal information, personally-identifiable information (PII), or information derived from them? ## {#questionnaire-3}
+
+WebGPU doesn't deal with PII unless the site puts PII inside the API, which means that Javascript got access to the PII before WebGPU could.
+
+## How do the features in your specification deal with sensitive information? ## {#questionnaire-4}
+
+WebGPU doesn't deal with sensitive information.
+However some of the information it exposes could be correlated with sensitive information: the presence of powerful optional features or a high speed of GPU computation would allow deducing access to "high-end" GPUs which itself correlates with other information.
+
+## Do the features in your specification introduce new state for an origin that persists across browsing sessions? ## {#questionnaire-5}
+
+The WebGPU specification doesn't introduce new state.
+However implementations are expected to cache the result of compiling shaders and pipelines.
+This introduces state that could be inspected by measuring how long compilation of a set of shaders and pipelines take.
+Note that GPU drivers also have their own caches so user-agents will have to find ways to disable that cache (otherwise state could be leaked across origins).
+
+## Do the features in your specification expose information about the underlying platform to origins? ## {#questionnaire-6}
+
+Yes.
+The specification exposes whether hardware-accelerated WebGPU is available and a user-agent controlled name and set of optional features and limits each `GPUAdapter` supports.
+Different requests for adapters returning adapters with different capabilities would also indicate the system contains multiple GPUs.
+
+## Does this specification allow an origin to send data to the underlying platform? ## {#questionnaire-7}
+
+WebGPU allows sending data to the system's GPU.
+The WebGPU specification prevents ill-formed GPU commands from being sent to the hardware.
+It is also expected that user-agents will have work-arounds for bugs in the driver that could cause issue even with well-formed GPU commands.
+
+## Do features in this specification allow an origin access to sensors on a user’s device? ## {#questionnaire-8}
+
+No.
+
+## What data do the features in this specification expose to an origin? Please also document what data is identical to data exposed by other features, in the same or different contexts. ## {#questionnaire-9}
+
+WebGPU exposes whether hardware-accelerated WebGPU is available, which is a new piece of data.
+The adapter's name, optional features, and limits has a large intersection with WebGL's RENDERER_STRING, limits and extensions: even limits not in WebGL can mostly be deduced from the other limits exposed by WebGL (by deducing what GPU model the system has).
+
+## Do features in this specification enable new script execution/loading mechanisms? ## {#questionnaire-10}
+
+Yes.
+WebGPU allows running arbitrary GPU computations specified with the WebGPU Shading Language (WGSL).
+WGSL is compiled into a `GPUShaderModule` objects that are then used to specify "pipelines" that run computations on the GPU.
+
+## Do features in this specification allow an origin to access other devices? ## {#questionnaire-11}
+
+No.
+WebGPU allows access to PCI-e and external GPUs plugged into the system but these are just part of the system.
+
+## Do features in this specification allow an origin some measure of control over a user agent's native UI? ## {#questionnaire-12}
+
+No.
+However WebGPU can be used to render to fullscreen or WebXR which does change the UI.
+WebGPU can also run GPU computations that take too long and cause of device timeout and a restart of GPU (TDR), which can produce a couple system-wide black frames.
+Note that this is possible with "just" HTML / CSS but WebGPU makes it easier to cause a TDR.
+
+## What temporary identifiers do the features in this specification create or expose to the web? ## {#questionnaire-13}
+
+None.
+
+## How does this specification distinguish between behavior in first-party and third-party contexts? ## {#questionnaire-14}
+
+There are no specific behavior difference between first-party and third-party contexts.
+However the user-agent can decide to limit the `GPUAdapters` returned to third-party contexts: by using fewer buckets, by using a single bucket, or by not exposing WebGPU.
+
+## How do the features in this specification work in the context of a browser’s Private Browsing or Incognito mode? ## {#questionnaire-15}
+
+There is no difference in Incognito mode, but the user-agent can decide to limit the `GPUAdapters` returned.
+User-agents will need to be careful not to reuse the shader compilation caches when in Incognito mode.
+
+## Does this specification have both "Security Considerations" and "Privacy Considerations" sections? ## {#questionnaire-16}
+
+Yes.
+They are both under the [Malicious use considerations](https://gpuweb.github.io/gpuweb/#malicious-use) section.
+
+## Do features in your specification enable origins to downgrade default security protections? ## {#questionnaire-17}
+
+No.
+Except that WebGPU can be used to render to fullscreen or WebXR.
+
+## What should this questionnaire have asked? ## {#questionnaire-18}
+
+Does the specification allow interacting with cross-origin data? With DRM data?
+
+At the moment WebGPU cannot do that but it is likely that someone will request these features in the future.
+It might be possible to introduce the concept of "protected queues" that only allow computations to end up on the screen, and not into Javascript.
+However investigation in WebGL show that GPU timings can be used to leak from such protected queues.
 
 
 # WebGPU Shading Language # {#wgsl}


### PR DESCRIPTION
This was suggested by a Blink API owner in the "Intent to Experiement: WebGPU" thread in blink-dev. @kainino0x @kvark WDYT?