### PR TITLE
Clarify function parameter and return types

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5181,8 +5181,13 @@ See [[#discard-statement]].
 * A [=vertex=] shader must return the `position` [=built-in output variable|built-in variable=].
     See [[#builtin-variables]].
 * An entry point must never be the target of a [=function call=].
-* If a function has a return type, it must be a [=plain types|plain type=]
-* A [=formal parameter|function parameter=] of pointer type must be in one of
+* If a function has a return type, it must be an [=atomic-free=] [=plain types|plain type=]
+* A [=formal parameter|function parameter=] must one the following types:
+    * atomic-free plain type
+    * a pointer type
+    * a texture type
+    * a sampler type
+* A function parameter of pointer type must be in one of
     the following storage classes:
     * [=storage classes/function=]
     * [=storage classes/private=]


### PR DESCRIPTION
* parameters must be atomic free plain types, pointers, textures, or
  samplers
* return types must be atomic free plain type

Follow up to #1693 and #1674