### PR TITLE
wgsl: fix typo in module scope variables example

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2752,7 +2752,7 @@ Such variables are declared with [=attribute/group=] and [=attribute/binding=] d
       specular: f32;
       count: i32;
     };
-    [[group(0)]], binding(2)]]
+    [[group(0), binding(2)]]
     var<uniform> param: Params;          // A uniform buffer
 
     [[block]] struct PositionsBuffer {


### PR DESCRIPTION
remove extraneous braces in attribute