### PR TITLE
Limit pipeline constant IDs to between 0 and 65535

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2813,7 +2813,7 @@ the constant is <dfn noexport>pipeline-overridable</dfn>. In this case:
   * The type must one of the [=scalar=] types.
   * The initializer expression is optional.
   * The attribute's literal operand, if present, is known as the <dfn noexport>pipeline constant ID</dfn>,
-    and must be a non-negative integer value representable in 32 bits.
+    and must be an integer value between 0 and 65535.
   * Pipeline constant IDs must be unique within the [SHORTNAME] program: Two module constants
     must not use the same pipeline constant ID.
   * The application can specify its own value for the name at pipeline-creation time.


### PR DESCRIPTION
This matches the limitation that exists in MSL.