### PR TITLE
Clarify out of bounds behavior

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1832,13 +1832,15 @@ Different call sites may supply pointers into different originating variables.
 If a reference or pointer access is out of bounds, an <dfn noexport>invalid
 memory reference</dfn> is produced.
 [=Load Rule|Loads=] from an invalid reference return one of:
-    * a value from any [=memory locations|memory location=] of the [=originating variable=]
+    * a value from any [=memory locations|memory location(s)=] of the [[WebGPU#buffers|WebGPU buffer]]
+        bound to the [=originating variable=]
     * the zero value for store type of the reference
     * if the loaded value is a vector, the value (0, 0, 0, x), where x is:
         * 0, 1, or the maximum positive value for integer components
         * 0.0 or 1.0 for floating-point components
 [=assignment statement|Stores=] to an invalid reference may either:
-    * store the value to any [=memory locations|memory location=] of the [=originating variable=]
+    * store the value to any [=memory locations|memory location(s)=] of the
+        [[WebGPU#buffers|WebGPU buffer]] bound to the [=originating variable=]
     * not be executed
 
 ### Use cases for references and pointers ### {#ref-ptr-use-cases}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1829,6 +1829,18 @@ The originating variable for a formal parameter of a function depends on the
 [=call site|call sites=] for the function.
 Different call sites may supply pointers into different originating variables.
 
+If a reference or pointer access is out of bounds, an <dfn noexport>invalid
+memory reference</dfn> is produced.
+[=Load Rule|Loads=] from an invalid reference return one of:
+    * a value from any [=memory locations|memory location=] of the [=originating variable=]
+    * the zero value for store type of the reference
+    * if the loaded value is a vector, the value (0, 0, 0, x), where x is:
+        * 0, 1, or the maximum positive value for integer components
+        * 0.0 or 1.0 for floating-point components
+[=assignment statement|Stores=] to an invalid reference may either:
+    * store the value to any [=memory locations|memory location=] of the [=originating variable=]
+    * not be executed
+
 ### Use cases for references and pointers ### {#ref-ptr-use-cases}
 
 References and pointers are distinguished by how they are used:
@@ -3595,11 +3607,10 @@ The result type depends on the number of letters provided. Assuming a `vec4<f32>
            |e|[|i|]: |T|
        <td>Select the |i|'<sup>th</sup> component of vector<br>
            The first component is at index |i|=0.<br>
-           If |i| is outside the range [0,|N|-1], then an index in the range [0, |N|-1] is used instead.
+           If |i| is outside the range [0,|N|-1], then any valid value for |T|
+           may be returned.
            (OpVectorExtractDynamic)
 </table>
-
-Issue: Which index is used when it's out of bounds?
 
 #### Vector multiple component selection #### {#vector-multi-component}
 
@@ -3730,9 +3741,13 @@ Issue: Which index is used when it's out of bounds?
        <td>|r|: ref&lt;|SC|,vec|N|&lt;|T|&gt;&gt;<br>
           |i|: [INT]
        <td class="nowrap">
-           |r|[|i|]: ref&lt;|SC|,|T|&gt;
-       <td>Compute a reference to the |i|'<sup>th</sup> component of the vector referenced by the reference |r|.<br>
-           If |i| is outside the range [0,|N|-1], then an index in the range [0, |N|-1] is used instead.<br>
+           |r|[|i|] : ref&lt;|SC|,|T|&gt;
+       <td>Compute a reference to the |i|'<sup>th</sup> component of the vector
+           referenced by the reference |r|.
+
+           If |i| is outside the range [0,|N|-1], then the expression evaluates
+           to [=invalid memory reference=].
+
            The [=originating variable=] of the resulting reference is
            the same as the originating variable of |r|.<br>
            (OpAccessChain)
@@ -3753,7 +3768,8 @@ Issue: Which index is used when it's out of bounds?
        <td class="nowrap">
            |e|[|i|]: vec|M|&lt;|T|&gt;
        <td>The result is the |i|'<sup>th</sup> column vector of |e|.<br>
-           If |i| is outside the range [0,|N|-1], then an index in the range [0, |N|-1] is used instead.<br>
+           If |i| is outside the range [0,|N|-1], then any valid value for
+           vec|M|&lt;|T|&gt; may be returned.
            (OpCompositeExtract)
 </table>
 
@@ -3767,9 +3783,13 @@ Issue: Which index is used when it's out of bounds?
           |r|: ref&lt;|SC|,mat|N|x|M|&lt;|T|&gt;&gt;<br>
           |i|: [INT]
        <td class="nowrap">
-           |r|[|i|]: ref&lt;vec|M|&lt;|SC|,|T|&gt;&gt;
-       <td>Compute a reference to the |i|'<sup>th</sup> column vector of the matrix referenced by the reference |r|.<br>
-           If |i| is outside the range [0,|N|-1], then an index in the range [0, |N|-1] is used instead.<br>
+           |r|[|i|] : ref&lt;vec|M|&lt;|SC|,|T|&gt;&gt;
+       <td>Compute a reference to the |i|'<sup>th</sup> column vector of the
+           matrix referenced by the reference |r|.
+
+           If |i| is outside the range [0,|N|-1], then the expression evaluates to
+           [=invalid memory reference=].
+
            The [=originating variable=] of the resulting reference is
            the same as the originating variable of |r|.<br>
            (OpAccessChain)
@@ -3796,9 +3816,11 @@ the variable's value, as required.
           |i|: [INT]<br>
           |i| is a `const_expr` expression
        <td class="nowrap">
-           |e|[|i|]: |T|
-       <td>The result is the value of the |i|'<sup>th</sup> element of the array value |e|.<br>
-           If |i| is outside the range [0,|N|-1], then an index in the range [0, |N|-1] is used instead.<br>
+           |e|[|i|] : |T|
+       <td>The result is the value of the |i|'<sup>th</sup> element of the array value |e|.
+
+           If |i| is outside the range [0,|N|-1], then any valid value for |T|
+           may be returned.
            (OpCompositeExtract)
 </table>
 
@@ -3812,9 +3834,13 @@ the variable's value, as required.
           |r|: ref&lt;|SC|,array&lt;|T|,|N|&gt;&gt;<br>
           |i|: [INT]
        <td class="nowrap">
-           |r|[|i|]: ref&lt;|SC|,|T|&gt;
-       <td>Compute a reference to the |i|'<sup>th</sup> element of the array referenced by the reference |r|.<br>
-           If |i| is outside the range [0,|N|-1], then an index in the range [0, |N|-1] is used instead.<br>
+           |r|[|i|] : ref&lt;|SC|,|T|&gt;
+       <td>Compute a reference to the |i|'<sup>th</sup> element of the array
+           referenced by the reference |r|.
+
+           If |i| is outside the range [0,|N|-1], then the expression evaluates
+           to an [=invalid memory reference=].
+
            The [=originating variable=] of the resulting reference is
            the same as the originating variable of |r|.<br>
            (OpAccessChain)
@@ -3822,10 +3848,14 @@ the variable's value, as required.
        <td>|r|: ref&lt;|SC|,array&lt;|T|&gt;&gt;<br>
           |i|: [INT]
        <td class="nowrap">
-           |r|[|i|]: ref&lt;|SC|,|T|&gt;
-       <td>Compute a reference to the |i|'<sup>th</sup> element of the runtime-sized array referenced by the reference |r|.<br>
-           If at runtime the array has |N| elements, and |i| is outside the range [0,|N|-1], then an index in the
-           range [0, |N|-1] is used instead.<br>
+           |r|[|i|] : ref&lt;|SC|,|T|&gt;
+       <td>Compute a reference to the |i|'<sup>th</sup> element of the
+           runtime-sized array referenced by the reference |r|.
+
+           If at runtime the array has |N| elements, and |i| is outside the range
+           [0,|N|-1], then the expression evaluates to an [=invalid memory
+           reference=].
+
            The [=originating variable=] of the resulting reference is
            the same as the originating variable of |r|.<br>
            (OpAccessChain)
@@ -4344,6 +4374,10 @@ The <dfn noexport>address-of</dfn> operator converts a reference to its correspo
           `&`|r|: ptr&lt;|SC|,|T|,|A|&gt;
        <td>Result is the pointer value corresponding to the
            same [=memory view=] as the reference value |r|.
+
+           If |r| is an [=invalid memory reference=], then the resulting
+           pointer is also an invalid memory reference.
+
 </table>
 
 ## Indirection Expression  ## {#indirection-expr}
@@ -4362,6 +4396,10 @@ The <dfn noexport>indirection</dfn> operator converts a pointer to its correspon
           `*`|p|: ref&lt;|SC|,|T|,|A|&gt;
        <td>Result is the reference value corresponding to the
            same [=memory view=] as the pointer value |p|.
+
+           If |p| is an [=invalid memory reference=], then the resulting
+           reference is also an invalid memory reference.
+
 </table>
 
 ## Constant Identifier Expression  ## {#constant-identifier-expr}
@@ -4549,7 +4587,12 @@ expression to the right of the equals token is the <dfn noexport>right-hand side
         |SC| is a writable [=storage class=]
     <td class="nowrap">|r| = |e|;
     <td>Evaluates |e|, evaluates |r|, then writes the value computed for |e| into
-        the [=memory locations=] referenced by |r|.<br>
+        the [=memory locations=] referenced by |r|.
+
+        Note: if the reference is an [=invalid memory reference=], the write
+        may not execute, or may write to a different memory location than
+        expected.
+
         (OpStore)
 </table>
 


### PR DESCRIPTION
Contributes to #1649

* Update out of bounds behaviour
  * loads can return any in bounds index or 0
  * stores can store to any in bounds index or not execute
* For pointer and reference, introduces the concept of an invalid memory
  reference that covers those behaviours when used
  * necessary since the load/store does not occur at the indexing
    expression necessarily