### PR TITLE
Add w3cid to editors and fix new invalid markup

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9,9 +9,9 @@ TR: https://www.w3.org/TR/webgpu/
 Repository: gpuweb/gpuweb
 !Participate: <a href="https://github.com/gpuweb/gpuweb/issues/new">File an issue</a> (<a href="https://github.com/gpuweb/gpuweb/issues">open issues</a>)
 
-Editor: Dzmitry Malyshau, Mozilla https://www.mozilla.org, dmalyshau@mozilla.com
-Editor: Kai Ninomiya, Google https://www.google.com, kainino@google.com
-Former Editor: Justin Fan, Apple https://www.apple.com, justin_fan@apple.com
+Editor: Dzmitry Malyshau, Mozilla https://www.mozilla.org, dmalyshau@mozilla.com, w3cid 96977
+Editor: Kai Ninomiya, Google https://www.google.com, kainino@google.com, w3cid 99487
+Former Editor: Justin Fan, Apple https://www.apple.com, justin_fan@apple.com, w3cid 115633
 Abstract: WebGPU exposes an API for performing operations, such as rendering and computation, on a Graphics Processing Unit.
 Markup Shorthands: markdown yes
 Markup Shorthands: dfn yes
@@ -3102,6 +3102,7 @@ GPUBindGroupLayout includes GPUObjectBase;
 
 <dl dfn-type=attribute dfn-for=GPUBindGroupLayout>
     : <dfn>\[[descriptor]]</dfn>
+    ::
 </dl>
 
 ### Creation ### {#bind-group-layout-creation}
@@ -3241,8 +3242,8 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
         <td>[=internal usage/storage-write=]
 
     <tr>
-        <td rowspan=2>{{GPUBindGroupLayoutEntry/externalTexture}}
-        <td rowspan=2>{{GPUExternalTexture}}
+        <td>{{GPUBindGroupLayoutEntry/externalTexture}}
+        <td>{{GPUExternalTexture}}
         <td>
         <td>[=internal usage/constant=]
 </table>


### PR DESCRIPTION
- Pubrules requires the W3C ID of editors to be specified.
- A couple of markup constructs were invalid: `<dd>` is always required after `<dt>`, and table cannot end with cells that have a `rowspan=2` attribute


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/gpuweb/pull/1725.html" title="Last updated on May 12, 2021, 6:19 PM UTC (32293e3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1725/8d4036a...tidoust:32293e3.html" title="Last updated on May 12, 2021, 6:19 PM UTC (32293e3)">Diff</a>