### PR TITLE
wgsl: Add missing w3cid, fix invalid markup and link to /TR document

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5,13 +5,13 @@ Level: None
 Status: w3c/ED
 Group: webgpu
 ED: https://gpuweb.github.io/gpuweb/wgsl/
-TR: https://www.w3.org/TR/webgpu/
+TR: https://www.w3.org/TR/WGSL/
 Repository: gpuweb/gpuweb
 Ignored Vars: i, e, e1, e2, e3, N, M, v, Stride, Offset, Align, Extent, S, T, T1
 
 !Participate: <a href="https://github.com/gpuweb/gpuweb/issues/new?labels=wgsl">File an issue</a> (<a href="https://github.com/gpuweb/gpuweb/issues?q=is%3Aissue+is%3Aopen+label%3Awgsl">open issues</a>)
 
-Editor: David Neto, Google https://www.google.com, dneto@google.com
+Editor: David Neto, Google https://www.google.com, dneto@google.com, w3cid 99785
 Editor: Myles C. Maxfield, Apple Inc., mmaxfield@apple.com, w3cid 77180
 Former Editor: dan sinclair, Google https://www.google.com, dsinclair@google.com
 Abstract: Shading language for WebGPU.
@@ -899,7 +899,7 @@ workgroups.
 
 TODO: Add links the eventual memory model descriptions.
 
-<pre class='example storage atomic' heading='Mapping atomics in a storage variable to SPIR-V'>
+<div class='example storage atomic' heading='Mapping atomics in a storage variable to SPIR-V'>
   <xmp>
     [[block]] struct S {
       a : atomic<i32>;
@@ -922,9 +922,9 @@ TODO: Add links the eventual memory model descriptions.
     // %ptr_storage_S = OpTypePointer StorageBuffer %S
     // %x = OpVariable %ptr_storage_S StorageBuffer
   </xmp>
-</pre>
+</div>
 
-<pre class='example workgroup atomic' heading='Mapping atomics in a workgroup variable to SPIR-V'>
+<div class='example workgroup atomic' heading='Mapping atomics in a workgroup variable to SPIR-V'>
   <xmp>
     var<workgroup> x : atomic<u32>;
 
@@ -937,7 +937,7 @@ TODO: Add links the eventual memory model descriptions.
     // %ptr_workgroup_u32 = OpTypePointer Workgroup %S
     // %x = OpVariable %ptr_workgroup_u32 Workgroup
   </xmp>
-</pre>
+</div>
 
 
 ### Array Types ### {#array-types}
@@ -2400,10 +2400,10 @@ A <dfn>sampler</dfn> mediates access to a sampled texture or a depth texture, by
   <thead>
     <tr><th>Type<th>Description
   </thead>
-  <tr algorithmm="sampler type">
+  <tr algorithm="sampler type">
     <td>sampler
     <td>Sampler. Mediates access to a sampled texture.</td>
-  <tr algorithmm="comparisong sampler type">
+  <tr algorithm="comparison sampler type">
     <td>sampler_comparison
     <td>Comparison sampler.
         Mediates access to a depth texture.</td>


### PR DESCRIPTION
- Pubrules requires the W3C ID of editors to be specified in the spec
- Examples should not start with `<pre>` to avoid invalid markup nesting
- Fix typo in `algorithm` attributes
- Link to /TR was targeting the WebGPU spec... (FWIW, targeted URL will be created once spec has been published as FPWD)