### PR TITLE
[editorial] Leverage component-wise to reduce number of table entries

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3747,7 +3747,9 @@ Issue: Which index is used when it's out of bounds?
   </thead>
   <tr algorithm="boolean negation"><td>|e|: bool<br>|T| is bool or vec|N|&lt;bool&gt;
   <td>`!`|e|: |T|
-  <td>Logical negation. [=Component-wise=] when |T| is a vector.
+  <td>Logical negation.
+  The result is `true` if |e| when `false` and `false` when |e| is `true`.
+  [=Component-wise=] when |T| is a vector.
   (OpLogicalNot)
 </table>
 
@@ -4033,7 +4035,8 @@ Issue: Which index is used when it's out of bounds?
     <td>|e|: |T|<br>
     |T| is *Integral*
     <td class="nowrap">`~`|e| : |T|
-    <td>Bitwise complement on |e|. Inverts all the bits of |e|.
+    <td>Bitwise complement on |e|.
+    Each bit in the result is the opposite of the corresponding bit in |e|.
     [=Component-wise=] when |T| is a vector. (OpNot)
 </table>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3748,7 +3748,7 @@ Issue: Which index is used when it's out of bounds?
   <tr algorithm="boolean negation"><td>|e|: bool<br>|T| is bool or vec|N|&lt;bool&gt;
   <td>`!`|e|: |T|
   <td>Logical negation.
-  The result is `true` if |e| when `false` and `false` when |e| is `true`.
+  The result is `true` when |e| is `false` and `false` when |e| is `true`.
   [=Component-wise=] when |T| is a vector.
   (OpLogicalNot)
 </table>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -824,12 +824,21 @@ Key use cases of a vector include:
     For example, the components could be intensities of red, green, and blue,
     while the fourth component could be an alpha (opacity) value.
 
-Many operations on vectors act component-wise, i.e. the result vector is
-formed by operating on each component independently.
+Many operations on vectors act <dfn noexport>component-wise</dfn>, i.e. the
+result vector is formed by operating on each component independently.
 
 <div class='example wgsl' heading='Vector'>
   <xmp highlight='rust'>
     vec2<f32>  // is a vector of two f32s.
+  </xmp>
+</div>
+
+<div class='example component-wise addition' heading='Component-wise addition'>
+  <xmp highlight='rust'>
+    let x : vec3<f32> = a + b; // a and b are vec3<f32>
+    // x[0] = a[0] + b[0]
+    // x[1] = a[1] + b[1]
+    // x[2] = a[2] + b[2]
   </xmp>
 </div>
 
@@ -3306,64 +3315,56 @@ Details of conversion to and from floating point are explained in [[#floating-po
   <tr algorithm="vector coercion of unsigned integer to boolean">
      <td>|e|: vec|N|&lt;u32&gt;
      <td>`vec`|N|&lt;`bool`&gt;`(`|e|`)`: vec|N|&lt;bool&gt
-     <td>Component-wise coercion of a unsigned integer vector to a boolean vector.<br>
-         Component |i| of the result is `bool(`|e|`[`|i|`])`<br>
+     <td>[=Component-wise=] coercion of a unsigned integer vector to a boolean vector.<br>
          (OpINotEqual to compare |e| against a zero vector.)
 
   <tr algorithm="vector coercion of signed integer to boolean">
      <td>|e|: vec|N|&lt;i32&gt;
      <td>`vec`|N|&lt;`bool`&gt;`(`|e|`)`: vec|N|&lt;bool&gt
-     <td>Component-wise coercion of a signed integer vector to a boolean vector.<br>
-         Component |i| of the result is `bool(`|e|`[`|i|`])`<br>
+     <td>[=Component-wise=] coercion of a signed integer vector to a boolean vector.<br>
          (OpINotEqual to compare |e| against a zero vector.)
 
   <tr algorithm="vector coercion of floating point to boolean">
      <td>|e|: vec|N|&lt;f32&gt;
      <td>`vec`|N|&lt;`bool`&gt;`(`|e|`)`: vec|N|&lt;bool&gt
-     <td>Component-wise coercion of a floating point vector to a boolean vector.<br>
-         Component |i| of the result is `bool(`|e|`[`|i|`])`<br>
+     <td>[=Component-wise=] coercion of a floating point vector to a boolean vector.<br>
          (OpFUnordNotEqual to compare |e| against a zero vector.)
 
   <tr algorithm="vector reinterpretation from unsigned to signed">
      <td>|e|: vec|N|&lt;u32&gt;
      <td>`vec`|N|&lt;`i32`&gt;`(`|e|`)`: vec|N|&lt;i32&gt
-     <td>Component-wise reinterpretation of bits.<br>
+     <td>[=Component-wise=] reinterpretation of bits.<br>
          Component |i| of the result is `i32(`|e|`[`|i|`])`<br>
          (OpBitcast)
 
   <tr algorithm="vector conversion from floating point to signed integer">
      <td>|e|: vec|N|&lt;f32&gt;
      <td>`vec`|N|&lt;`i32`&gt;`(`|e|`)`: vec|N|&lt;i32&gt;
-     <td>Component-wise value conversion to signed integer, including invalid cases.<br>
-         Component |i| of the result is `i32(`|e|`[`|i|`])`<br>
+     <td>[=Component-wise=] value conversion to signed integer, including invalid cases.<br>
         (OpConvertFToS)
 
   <tr algorithm="vector reinterpretation from signed to unsigned">
      <td>|e|: vec|N|&lt;i32&gt;
      <td>`vec`|N|&lt;`u32`&gt;`(`|e|`)`: vec|N|&lt;u32&gt;
-     <td>Component-wise reinterpretation of bits.<br>
-         Component |i| of the result is `u32(`|e|`[`|i|`])`<br>
+     <td>[=Component-wise=] reinterpretation of bits.<br>
         (OpBitcast)
 
   <tr algorithm="vector conversion from floating point to unsigned integer">
      <td>|e|: vec|N|&lt;f32&gt;
      <td>`vec`|N|&lt;`u32`&gt;`(`|e|`)`: vec|N|&lt;u32&gt;
-     <td>Component-wise value conversion to unsigned integer, including invalid cases.<br>
-         Component |i| of the result is `u32(`|e|`[`|i|`])`<br>
+     <td>[=Component-wise=] value conversion to unsigned integer, including invalid cases.<br>
         (OpConvertFToU)
 
   <tr algorithm="vector conversion from signed integer to floating point">
      <td>|e|: vec|N|&lt;i32&gt;
      <td>`vec`|N|&lt;`f32`&gt;`(`|e|`)`: vec|N|&lt;f32&gt;
-     <td>Component-wise value conversion to floating point, including invalid cases.<br>
-         Component |i| of the result is `f32(`|e|`[`|i|`])`<br>
+     <td>[=Component-wise=] value conversion to floating point, including invalid cases.<br>
         (OpConvertSToF)
 
   <tr algorithm="vector conversion from unsigned integer to floating point">
      <td>|e|: vec|N|&lt;u32&gt;
      <td>`vec`|N|&lt;`f32`&gt;`(`|e|`)`: vec|N|&lt;f32&gt;
-     <td>Component-wise value conversion to floating point, including invalid cases.<br>
-         Component |i| of the result is `f32(`|e|`[`|i|`])`<br>
+     <td>[=Component-wise=] value conversion to floating point, including invalid cases.<br>
         (ConvertUToF)
 
 </table>
@@ -3374,74 +3375,28 @@ A `bitcast` expression is used to reinterpet the bit representation of a
 value in one type as a value in another type.
 
 <table class='data'>
-  <caption>Scalar bitcast type rules</caption>
+  <caption>Bitcast type rules</caption>
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
-  <tr algorithm="scalar identity reinterpretation">
-      <td>|e|: |T|,<br>
-          |T| is one of i32, u32, f32
-      <td>bitcast&lt;|T|&gt;(|e|): |T|
-      <td>Identity transform.<br>
-          The result is |e|.
-          <br>In the SPIR-V translation, the ID of this expression reuses the ID of the operand.
-  <tr algorithm="scalar reinterpretation as signed integer">
-      <td>|e|: |T|,<br>
-          |T| is one of u32, f32
-      <td>bitcast&lt;i32&gt;(|e|): i32
-      <td>Reinterpretation of bits as a signed integer.<br>
-          The result is the reinterpretation of the 32 bits in the representation of |e| as a [=i32=] value.
-          (OpBitcast)
-  <tr algorithm="scalar reinterpretation as unsigned integer">
-      <td>|e|: |T|,<br>
-          |T| is one of i32, f32
-      <td>bitcast&lt;u32&gt;(|e|): u32
-      <td>Reinterpretation of bits as an unsigned integer.<br>
-          The result is the reinterpretation of the 32 bits in the representation of |e| as a [=u32=] value.
-          (OpBitcast)
-  <tr algorithm="scalar reinterpretation as floating point">
-      <td>|e|: |T|,<br>
-          |T| is one of i32, u32
-      <td>bitcast&lt;f32&gt;(|e|): f32
-      <td>Reinterpretation of bits as a floating point value.<br>
-          The result is the reinterpretation of the 32 bits in the representation of |e| as a [=f32=] value.
-          (OpBitcast)
-</table>
 
-<table class='data'>
-  <caption>Vector bitcast type rules</caption>
-  <thead>
-    <tr><th>Precondition<th>Conclusion<th>Notes
-  </thead>
-  <tr algorithm="vector identity reinterpretation">
-      <td>|e|: vec&lt;|N|&gt;|T|&gt;,<br>
-          |T| is one of i32, u32, f32
-      <td>bitcast&lt;vec|N|&lt;|T|&gt;&gt;(|e|): |T|
-      <td>Identity transform.<br>
-          The result is |e|.
-          <br>In the SPIR-V translation, the ID of this expression reuses the ID of the operand.
-  <tr algorithm="vector reinterpretation as signed integer">
-      <td>|e|: vec&lt;|N|&gt;|T|&gt;,<br>
-          |T| is one of u32, f32
-      <td>bitcast&lt;vec|N|&lt;i32&gt;&gt;(|e|): vec|N|&lt;i32&gt;
-      <td>Component-wise reinterpretation of bits.<br>
-          Component |i| of the result is `bitcast<i32>(`|e|`[`|i|`])`<br>
-          (OpBitcast)
-  <tr algorithm="vector reinterpretation as unsigned integer">
-      <td>|e|: vec&lt;|N|&gt;|T|&gt;,<br>
-          |T| is one of i32, f32
-      <td>bitcast&lt;vec|N|&lt;u32&gt;&gt;(|e|): vec|N|&lt;u32&gt;
-      <td>Component-wise reinterpretation of bits.<br>
-          Component |i| of the result is `bitcast<u32>(`|e|`[`|i|`])`<br>
-          (OpBitcast)
-  <tr algorithm="vector reinterpretation as floating point">
-      <td>|e|: vec&lt;|N|&gt;|T|&gt;,<br>
-          |T| is one of i32, u32
-      <td>bitcast&lt;vec|N|&lt;f32&gt;&gt;(|e|): vec|N|&lt;f32&gt;
-      <td>Component-wise Reinterpretation of bits.<br>
-          Component |i| of the result is `bitcast<f32>(`|e|`[`|i|`])`<br>
-          (OpBitcast)
+  <tr algorithm="identity reinterpretation">
+    <td>|e|: |T|<br>
+    |T| is a [=numeric scalar=] or [=numeric vector=] type
+    <td class="nowrap">bitcast&lt;|T|&gt;(|e|): |T|
+    <td>Identity transform. [=Component-wise=] when |T| is a vector.<br>
+    The result is |e|.<br>
+    In the SPIR-V translation, the ID of this expression reuses the ID of the operand.
 
+  <tr algorithm="general reinterpretation">
+    <td>|e|: |T1|<br>
+    |T1| is a [=numeric scalar=] or [=numeric vector=] type<br>
+    |T2| is not |T1| and is a numeric scalar type if |T1| is a scalar, or<br>
+    a numeric vector type if |T1| is a vector
+    <td class="nowrap">bitcast&lt;|T2|&gt;(|e|): |T2|
+    <td>Reinterpretation of bits as |T2|. [=Component-wise=] when |T1| is a vector.<br>
+    The result is the reinterpretation of the bits in |e| as a |T2| value.<br>
+    (OpBitcast)
 </table>
 
 ## Composite Value Decomposition Expressions ## {#composite-value-decomposition-expr}
@@ -3784,16 +3739,16 @@ Issue: Which index is used when it's out of bounds?
            (OpAccessChain, using the index of the structure member)
 </table>
 
-## Logical Expressions TODO ## {#logical-expr}
+## Logical Expressions ## {#logical-expr}
 <table class='data'>
   <caption>Unary logical operations</caption>
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
-  <tr algorithm="scalar boolean negation"><td>|e|: bool<td>`!`|e|: *bool*
-      <td>Logical negation. Yields true when |e| is false, and false when |e| is true.<br>(OpLogicalNot)
-  <tr algorithm="vector boolean negation"><td>|e|: vec|N|&lt;bool&gt;<td>`!`|e|: vec|N|&lt;bool&gt;
-      <td>Component-wise logical negation. Component |i| of the result is `!(`|e|`[`|i|`])`.<br>(OpLogicalNot)
+  <tr algorithm="boolean negation"><td>|e|: bool<br>|T| is bool or vec|N|&lt;bool&gt;
+  <td>`!`|e|: |T|
+  <td>Logical negation. [=Component-wise=] when |T| is a vector.
+  (OpLogicalNot)
 </table>
 
 <table class='data'>
@@ -3801,85 +3756,101 @@ Issue: Which index is used when it's out of bounds?
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
-  <tr><td>*e1*: bool<br>*e2*: bool<td>`e1 || e2`: bool<td>
-    Short-circuiting "or". Yields `true` if either `e1` or `e2` are true; evaluates `e2` only if `e1` is false.
-  <tr><td>*e1*: bool<br>*e2*: bool<td>`e1 && e2`: bool<td>
-    Short-circuiting "and". Yields `true` if both `e1` and `e2` are true; evaluates `e2` only if `e1` is true.
-  <tr><td>*e1*: bool<br>*e2*: bool<td>`e1 | e2`: bool<td>
-    Logical "or". Evaluates both `e1` and `e2`; yields `true` if either are `true`.
-  <tr><td>*e1*: bool<br>*e2*: bool<td>`e1 & e2`: bool<td>
-    Logical "and". Evaluates both `e1` and `e2`; yields `true` if both are `true`.
-  <tr><td>*e1*: *T*<br>*e2*: *T*<br>*T* is *vecN*&lt;bool&gt;
-    <td>`e1 | e2`: *T*<td>Component-wise logical "or"
-  <tr><td>*e1*: *T*<br>*e2*: *T*<br>*T* is *vecN*&lt;bool&gt;
-    <td>`e1 & e2`: *T*<td>Component-wise logical "and"
+  <tr algorithm="short-circuiting or"><td>|e1|: bool<br>|e2|: bool<td>|e1| `||` |e2|`: bool`
+  <td>Short-circuiting "or". Yields `true` if either |e1| or |e2| are true;
+  evaluates |e2| only if |e1| is false.
+
+  <tr algorithm="short-circuiting and"><td>|e1|: bool<br>|e2|: bool
+  <td>|e1| `&&` |e2|`: bool`
+  <td>Short-circuiting "and". Yields `true` if both |e1| and |e2| are true;
+  evaluates |e2| only if |e1| is true.
+
+  <tr algorithm="logical or"><td>|e1|: |T|<br>|e2|: |T|<br>|T| is bool or vec|N|&lt;bool&gt;
+  <td>|e1| `|` |e2|`:` |T|
+  <td>Logical "or". [=Component-wise=] when |T| is a vector. Evaluates both |e1| and |e2|.
+
+  <tr algorithm="logical and"><td>|e1|: |T|<br>|e2|: |T|<br>|T| is bool or vec|N|&lt;bool&gt;
+  <td>|e1| `&` |e2|`:` |T|
+  <td>Logical "and". [=Component-wise=] when |T| is a vector. Evaluates both |e1| and |e2|.
 </table>
 
 
-## Arithmetic Expressions TODO ## {#arithmetic-expr}
+## Arithmetic Expressions ## {#arithmetic-expr}
 
 <table class='data'>
   <caption>Unary arithmetic expressions</caption>
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
-  <tr><td>*e*: *T*, *T* is *SignedIntegral*<td>`-e`: *T*<td>Signed integer negation. OpSNegate
-  <tr><td>*e*: *T*, *T* is *Floating*<td>`-e`: *T*<td>Floating point negation. OpFNegate
+  <tr algorithm="integer negation"><td>|e|: |T|, |T| is *SignedIntegral*
+  <td>`-`|e|`:` |T|
+  <td>Signed integer negation. [=Component-wise=] when |T| is a vector. (OpSNegate)
+
+  <tr algorithm="floating point negation"><td>|e|: |T|, |T| is *Floating*
+  <td>`-`|e|`:` |T|
+  <td>Floating point negation. [=Component-wise=] when |T| is a vector. (OpFNegate)
 </table>
 
 <table class='data'>
-  <caption>Binary arithmetic expressions over scalars</caption>
+  <caption>Binary arithmetic expressions</caption>
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
-  <tr><td>*e1*: u32<br> *e2*: u32<td class="nowrap">`e1 + e2`: u32<td>Integer addition, modulo 2<sup>32</sup> (OpIAdd)
-  <tr><td>*e1*: i32<br> *e2*: i32<td>`e1 + e2`: i32<td>Integer addition, modulo 2<sup>32</sup> (OpIAdd)
-  <tr><td>*e1*: f32<br> *e2*: f32<td>`e1 + e2`: f32<td>Floating point addition (OpFAdd)
-  <tr><td>*e1*: u32<br> *e2*: u32<td>`e1 - e2`: u32<td>Integer subtraction, modulo 2<sup>32</sup> (OpISub)
-  <tr><td>*e1*: i32<br> *e2*: i32<td>`e1 - e2`: i32<td>Integer subtraction, modulo 2<sup>32</sup> (OpISub)
-  <tr><td>*e1*: f32<br> *e2*: f32<td>`e1 - e2`: f32<td>Floating point subtraction (OpFSub)
-  <tr><td>*e1*: u32<br> *e2*: u32<td>`e1 * e2`: u32<td>Integer multiplication, modulo 2<sup>32</sup> (OpIMul)
-  <tr><td>*e1*: i32<br> *e2*: i32<td>`e1 * e2`: i32<td>Integer multiplication, modulo 2<sup>32</sup> (OpIMul)
-  <tr><td>*e1*: f32<br> *e2*: f32<td>`e1 * e2`: f32<td>Floating point multiplication (OpFMul)
-  <tr><td>*e1*: u32<br> *e2*: u32<td>`e1 / e2`: u32<td>Unsigned integer division (OpUDiv)
-  <tr><td>*e1*: i32<br> *e2*: i32<td>`e1 / e2`: i32<td>Signed integer division (OpSDiv)
-  <tr><td>*e1*: f32<br> *e2*: f32<td>`e1 / e2`: f32<td>Floating point division (OpFDiv)
-  <tr><td>*e1*: u32<br> *e2*: u32<td>`e1 % e2`: u32<td>Unsigned integer modulus (OpUMod)
-  <tr><td>*e1*: i32<br> *e2*: i32<td>`e1 % e2`: i32<td>Signed integer remainder, where sign of non-zero result matches sign of *e2* (OpSMod)
-  <tr><td>*e1*: f32<br> *e2*: f32<td>`e1 % e2`: f32<td>Floating point modulus, where sign of non-zero result matches sign of *e2* (OpFMod)
-</table>
 
-<table class='data'>
-  <caption>Binary arithmetic expressions over vectors</caption>
-  <thead>
-    <tr><th>Precondition<th>Conclusion<th>Notes
-  </thead>
-  <tr><td>*e1*: *T*<br> *e2*: *T*<br> *T* is *vecN*&lt;*Int*&gt;
-    <td class="nowrap">`e1 + e2`: *T*<td>Component-wise integer addition (OpIAdd)
-  <tr><td>*e1*: *T*<br> *e2*: *T*<br> *T* is *vecN*&lt;f32&gt;
-    <td class="nowrap">`e1 + e2`: *T*<td>Component-wise floating point addition (OpIAdd)
-  <tr><td>*e1*: *T*<br> *e2*: *T*<br> *T* is *vecN*&lt;*Int*&gt;
-    <td class="nowrap">`e1 - e2`: *T*<td>Component-wise integer subtraction (OpISub)
-  <tr><td>*e1*: *T*<br> *e2*: *T*<br> *T* is *vecN*&lt;f32&gt;
-    <td>`e1 - e2`: *T*<td>Component-wise floating point subtraction (OpISub)
-  <tr><td>*e1*: *T*<br> *e2*: *T*<br> *T* is *vecN*&lt;*Int*&gt;
-    <td>`e1 * e2`: *T*<td>Component-wise integer multiplication (OpIMul)
-  <tr><td>*e1*: *T*<br> *e2*: *T*<br> *T* is *vecN*&lt;f32&gt;
-    <td>`e1 * e2`: *T*<td>Component-wise floating point multiplication (OpIMul)
-  <tr><td>*e1*: *T*<br> *e2*: *T*<br> *T* is *vecN*&lt;u32&gt;
-    <td>`e1 / e2`: *T*<td>Component-wise unsigned integer division (OpUDiv)
-  <tr><td>*e1*: *T*<br> *e2*: *T*<br> *T* is *vecN*&lt;i32&gt;
-    <td>`e1 / e2`: *T*<td>Component-wise signed integer division (OpSDiv)
-  <tr><td>*e1*: *T*<br> *e2*: *T*<br> *T* is *vecN*&lt;f32&gt;
-    <td>`e1 / e2`: *T*<td>Component-wise floating point division (OpFDiv)
-  <tr><td>*e1*: *T*<br> *e2*: *T*<br> *T* is *vecN*&lt;u32&gt;
-    <td>`e1 % e2`: *T*<td>Component-wise unsigned integer modulus (OpUMod)
-  <tr><td>*e1*: *T*<br> *e2*: *T*<br> *T* is *vecN*&lt;i32&gt;
-    <td>`e1 % e2`: *T*<td>Component-wise signed integer remainder (OpSMod)
-  <tr><td>*e1*: *T*<br> *e2*: *T*<br> *T* is *vecN*&lt;f32&gt;
-    <td>`e1 % e2`: *T*<td>Component-wise floating point modulus (OpFMod)
-</table>
+  <tr algorithm="integer addition">
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is *Integral*
+    <td>|e1| `+` |e2| : |T|
+    <td>Integer addition, modulo 2<sup>32</sup>. [=Component-wise=] when |T| is a vector. (OpIAdd)
+  <tr algorithm="floating point addition">
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is *Floating*
+    <td>|e1| `+` |e2| : |T|
+    <td>Floating point addition. [=Component-wise=] when |T| is a vector. (OpFAdd)
 
+  <tr algorithm="integer subtraction">
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is *Integral*
+    <td>|e1| `-` |e2| : |T|
+    <td>Integer subtraction, modulo 2<sup>32</sup>. [=Component-wise=] when |T| is a vector. (OpISub)
+  <tr algorithm="floating point subtraction">
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is *Floating*
+    <td>|e1| `-` |e2| : |T|
+    <td>Floating point subtraction. [=Component-wise=] when |T| is a vector. (OpFSub)
+
+  <tr algorithm="integer multiplication">
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is *Integral*
+    <td>|e1| `*` |e2| : |T|
+    <td>Integer multiplication, modulo 2<sup>32</sup>. [=Component-wise=] when |T| is a vector. (OpIMul)
+  <tr algorithm="floating point multiplication">
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is *Floating*
+    <td>|e1| `*` |e2| : |T|
+    <td>Floating point multiplication. [=Component-wise=] when |T| is a vector. (OpFMul)
+
+  <tr algorithm="signed integer division">
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is *SignedIntegral*
+    <td>|e1| `/` |e2| : |T|
+    <td>Signed integer division. [=Component-wise=] when |T| is a vector. (OpSDiv)
+  <tr algorithm="unsigned integer division">
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is u32 or vec|N|&lt;u32&gt;
+    <td>|e1| `/` |e2| : |T|
+    <td>Unsigned integer division. [=Component-wise=] when |T| is a vector. (OpUDiv)
+  <tr algorithm="floating point division">
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is *Floating*
+    <td>|e1| `/` |e2| : |T|
+    <td>Floating point division. [=Component-wise=] when |T| is a vector. (OpFDiv)
+
+  <tr algorithm="signed integer remainder">
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is *SignedIntegral*
+    <td>|e1| `%` |e2| : |T|
+    <td>Signed integer remainder. [=Component-wise=] when |T| is a vector. (OpSMod)
+  <tr algorithm="unsigned integer modulus">
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is u32 or vec|N|&lt;u32&gt;
+    <td>|e1| `%` |e2| : |T|
+    <td>Signed integer remainder, where sign of non-zero result matches sign of |e2|. [=Component-wise=] when |T| is a vector. (OpUMod)
+  <tr algorithm="floating point remainder">
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is *Floating*
+    <td>|e1| `%` |e2| : |T|
+    <td>Floating point remainder, where sign of non-zero result matches sign of |e2|. [=Component-wise=] when |T| is a vector. (OpFMod)
+
+</table>
 
 <table class='data'>
   <caption>Binary arithmetic expressions with mixed scalar and vector operands</caption>
@@ -3972,202 +3943,83 @@ Issue: Which index is used when it's out of bounds?
 ## Comparison Expressions TODO ## {#comparison-expr}
 
 <table class='data'>
-  <caption>Comparisons over scalars</caption>
+  <caption>Comparisons</caption>
   <thead>
-    <tr><th>Precondition<th>Conclusion<th>Notes
+    <tr><th>Precondtion<th>Conclusion<th>Notes
   </thead>
-  <tr><td>*e1*: bool<br>
-          *e2*: bool<br>
-       <td class="nowrap">`e1 == e2`: bool
-       <td>Equality (OpLogicalEqual)
-  <tr><td>*e1*: bool<br>
-          *e2*: bool<br>
-       <td class="nowrap">`e1 != e2`: bool
-       <td>Inequality (OpLogicalNotEqual)
-  <tr><td>*e1*: i32<br>
-          *e2*: i32<br>
-       <td class="nowrap">`e1 == e2`: bool
-       <td>Equality (OpIEqual)
-  <tr><td>*e1*: i32<br>
-          *e2*: i32<br>
-       <td class="nowrap">`e1 != e2`: bool
-       <td>Inequality (OpINotEqual)
-  <tr><td>*e1*: i32<br>
-          *e2*: i32<br>
-       <td class="nowrap">`e1 < e2`: bool
-       <td>Less than (OpSLessThan)
-  <tr><td>*e1*: i32<br>
-          *e2*: i32<br>
-       <td class="nowrap">`e1 <= e2`: bool
-       <td>Less than or equal (OpSLessThanEqual)
-  <tr><td>*e1*: i32<br>
-          *e2*: i32<br>
-       <td class="nowrap">`e1 >= e2`: bool
-       <td>Greater than or equal (OpSGreaterThanEqual)
-  <tr><td>*e1*: i32<br>
-          *e2*: i32<br>
-       <td class="nowrap">`e1 > e2`: bool
-       <td>Greater than (OpSGreaterThan)
-  <tr><td>*e1*: u32<br>
-          *e2*: u32<br>
-       <td class="nowrap">`e1 == e2`: bool
-       <td>Equality (OpIEqual)
-  <tr><td>*e1*: u32<br>
-          *e2*: u32<br>
-       <td class="nowrap">`e1 != e2`: bool
-       <td>Inequality (OpINotEqual)
-  <tr><td>*e1*: u32<br>
-          *e2*: u32<br>
-       <td class="nowrap">`e1 < e2`: bool
-       <td>Less than (OpULessThan)
-  <tr><td>*e1*: u32<br>
-          *e2*: u32<br>
-       <td class="nowrap">`e1 <= e2`: bool
-       <td>Less than or equal (OpULessThanEqual)
-  <tr><td>*e1*: u32<br>
-          *e2*: u32<br>
-       <td class="nowrap">`e1 >= e2`: bool
-       <td>Greater than or equal (OpUGreaterThanEqual)
-  <tr><td>*e1*: u32<br>
-          *e2*: u32<br>
-       <td class="nowrap">`e1 > e2`: bool
-       <td>Greater than (OpUGreaterThan)
-  <tr><td>*e1*: f32<br>
-          *e2*: f32<br>
-       <td class="nowrap">`e1 == e2`: bool
-       <td>Equality (OpFOrdEqual)
-  <tr><td>*e1*: f32<br>
-          *e2*: f32<br>
-       <td class="nowrap">`e1 != e2`: bool
-       <td>Equality (OpFOrdNotEqual)
-  <tr><td>*e1*: f32<br>
-          *e2*: f32<br>
-       <td class="nowrap">`e1 < e2`: bool
-       <td>Less than (OpFOrdLessThan)
-  <tr><td>*e1*: f32<br>
-          *e2*: f32<br>
-       <td class="nowrap">`e1 <= e2`: bool
-       <td>Less than or equal (OpFOrdLessThanEqual)
-  <tr><td>*e1*: f32<br>
-          *e2*: f32<br>
-       <td class="nowrap">`e1 >= e2`: bool
-       <td>Greater than or equal (OpFOrdGreaterThanEqual)
-  <tr><td>*e1*: f32<br>
-          *e2*: f32<br>
-       <td class="nowrap">`e1 > e2`: bool
-       <td>Greater than (OpFOrdGreaterThan)
-</table>
 
-<table class='data'>
-  <caption>Comparisons over vectors</caption>
-  <thead>
-    <tr><th>Precondition<th>Conclusion<th>Notes
-  </thead>
-  <tr><td>*e1*: *T*<br>
-          *e2*: *T*<br>
-          *T* is vec*N*&lt;bool&gt;
-       <td class="nowrap">`e1 == e2`: vec*N*&lt;bool&gt;
-       <td>Component-wise equality<br>
-           Component |i| of the result is `(`|e1|`[`|i|`] == `|e2|`[`|i|`])`<br>
-           (OpLogicalEqual)
-  <tr><td>*e1*: *T*<br>
-          *e2*: *T*<br>
-          *T* is vec*N*&lt;bool&gt;
-       <td class="nowrap">`e1 != e2`: vec*N*&lt;bool&gt;
-       <td>Component-wise inequality<br>
-           Component |i| of the result is `(`|e1|`[`|i|`] != `|e2|`[`|i|`])`<br>
-           (OpLogicalNotEqual)
-  <tr><td>*e1*: *T*<br>
-          *e2*: *T*<br>
-          *T* is vec*N*&lt;i32&gt;
-       <td class="nowrap">`e1 == e2`: vec*N*&lt;bool&gt;
-       <td>Component-wise equality (OpIEqual)
-  <tr><td>*e1*: *T*<br>
-          *e2*: *T*<br>
-          *T* is vec*N*&lt;i32&gt;
-       <td class="nowrap">`e1 != e2`: vec*N*&lt;bool&gt;
-       <td>Component-wise inequality (OpINotEqual)
-  <tr><td>*e1*: *T*<br>
-          *e2*: *T*<br>
-          *T* is vec*N*&lt;i32&gt;
-       <td class="nowrap">`e1 < e2`: vec*N*&lt;bool&gt;
-       <td>Component-wise less than (OpSLessThan)
-  <tr><td>*e1*: *T*<br>
-          *e2*: *T*<br>
-          *T* is vec*N*&lt;i32&gt;
-       <td class="nowrap">`e1 <= e2`: vec*N*&lt;bool&gt;
-       <td>Component-wise less than or equal (OpSLessThanEqual)
-  <tr><td>*e1*: *T*<br>
-          *e2*: *T*<br>
-          *T* is vec*N*&lt;i32&gt;
-       <td class="nowrap">`e1 >= e2`: vec*N*&lt;bool&gt;
-       <td>Component-wise greater than or equal (OpSGreaterThanEqual)
-  <tr><td>*e1*: *T*<br>
-          *e2*: *T*<br>
-          *T* is vec*N*&lt;i32&gt;
-       <td class="nowrap">`e1 > e2`: vec*N*&lt;bool&gt;
-       <td>Component-wise greater than (OpSGreaterThan)
-  <tr><td>*e1*: *T*<br>
-          *e2*: *T*<br>
-          *T* is vec*N*&lt;u32&gt;
-       <td class="nowrap">`e1 == e2`: vec*N*&lt;bool&gt;
-       <td>Component-wise equality (OpIEqual)
-  <tr><td>*e1*: *T*<br>
-          *e2*: *T*<br>
-          *T* is vec*N*&lt;u32&gt;
-       <td class="nowrap">`e1 != e2`: vec*N*&lt;bool&gt;
-       <td>Component-wise inequality (OpINotEqual)
-  <tr><td>*e1*: *T*<br>
-          *e2*: *T*<br>
-          *T* is vec*N*&lt;u32&gt;
-       <td class="nowrap">`e1 < e2`: vec*N*&lt;bool&gt;
-       <td>Component-wise less than (OpULessThan)
-  <tr><td>*e1*: *T*<br>
-          *e2*: *T*<br>
-          *T* is vec*N*&lt;u32&gt;
-       <td class="nowrap">`e1 <= e2`: vec*N*&lt;bool&gt;
-       <td>Component-wise less than or equal (OpULessThanEqual)
-  <tr><td>*e1*: *T*<br>
-          *e2*: *T*<br>
-          *T* is vec*N*&lt;u32&gt;
-       <td class="nowrap">`e1 >= e2`: vec*N*&lt;bool&gt;
-       <td>Component-wise greater than or equal (OpUGreaterThanEqual)
-  <tr><td>*e1*: *T*<br>
-          *e2*: *T*<br>
-          *T* is vec*N*&lt;u32&gt;
-       <td class="nowrap">`e1 > e2`: vec*N*&lt;bool&gt;
-       <td>Component-wise greater than (OpUGreaterThan)
-          *T* is vec*N*&lt;u32&gt;
-  <tr><td>*e1*: *T*<br>
-          *e2*: *T*<br>
-          *T* is vec*N*&lt;f32&gt;
-       <td class="nowrap">`e1 == e2`: vec*N*&lt;bool&gt;
-       <td>Component-wise equality (OpFOrdEqual)
-  <tr><td>*e1*: *T*<br>
-          *e2*: *T*<br>
-          *T* is vec*N*&lt;f32&gt;
-       <td class="nowrap">`e1 != e2`: vec*N*&lt;bool&gt;
-       <td>Component-wise inequality (OpFOrdNotEqual)
-  <tr><td>*e1*: *T*<br>
-          *e2*: *T*<br>
-          *T* is vec*N*&lt;f32&gt;
-       <td class="nowrap">`e1 < e2`: vec*N*&lt;bool&gt;
-       <td>Component-wise less than (OpFOrdLessThan)
-  <tr><td>*e1*: *T*<br>
-          *e2*: *T*<br>
-          *T* is vec*N*&lt;f32&gt;
-       <td class="nowrap">`e1 <= e2`: vec*N*&lt;bool&gt;
-       <td>Component-wise less than or equal (OpFOrdLessThanEqual)
-  <tr><td>*e1*: *T*<br>
-          *e2*: *T*<br>
-          *T* is vec*N*&lt;f32&gt;
-       <td class="nowrap">`e1 >= e2`: vec*N*&lt;bool&gt;
-       <td>Component-wise greater than or equal (OpFOrdGreaterThanEqual)
-  <tr><td>*e1*: *T*<br>
-          *e2*: *T*<br>
-          *T* is vec*N*&lt;f32&gt;
-       <td class="nowrap">`e1 > e2`: vec*N*&lt;bool&gt;
-       <td>Component-wise greater than (OpFOrdGreaterThan)
+  <tr algorithm="bool equality">
+    <td>|e1|: |T|<br>|e2|: |T|<br>|T| is bool or vec|N|&lt;bool&gt;
+    <td class="nowrap">|e1| `==` |e2|`:` |T|
+    <td>Equality. [=Component-wise=] when |T| is a vector. (OpLogicalEqual)
+  <tr algorithm="bool inequality">
+    <td>|e1|: |T|<br>|e2|: |T|<br>|T| is bool or vec|N|&lt;bool&gt;
+    <td class="nowrap">|e1| `==` |e2|`:` |T|
+    <td>Inequality. [=Component-wise=] when |T| is a vector. (OpLogicalNotEqual)
+
+  <tr algorithm="integer equality">
+    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is
+    *Integral*<br>|TB| is bool if |TI| is scalar, or<br>
+    vec|N|&lt;bool&gt; (where |N| = *Arity(*|TI|*)*) if |TI| is a vector
+    <td class="nowrap">|e1| `==` |e2|`:` |TB|
+    <td>Equality. [=Component-wise=] when |TI| is a vector. (OpIEqual)
+  <tr algorithm="integer inequality">
+    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is
+    *Integral*<br>|TB| is bool if |TI| is scalar, or<br>
+    vec|N|&lt;bool&gt; (where |N| = *Arity(*|TI|*)*) if |TI| is a vector
+    <td class="nowrap">|e1| `!=` |e2|`:` |TB|
+    <td>Inequality. [=Component-wise=] when |TI| is a vector. (OpINotEqual)
+
+  <tr algorithm="signed integer less than">
+    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is
+    *SignedIntegral*<br>|TB| is bool if |TI| is scalar, or<br>
+    vec|N|&lt;bool&gt; (where |N| = *Arity(*|TI|*)*) if |TI| is a vector
+    <td class="nowrap">|e1| `<` |e2|`:` |TB|
+    <td>Less than. [=Component-wise=] when |TI| is a vector. (OpSLessThan)
+  <tr algorithm="signed integer less than equal">
+    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is
+    *SignedIntegral*<br>|TB| is bool if |TI| is scalar, or<br>
+    vec|N|&lt;bool&gt; (where |N| = *Arity(*|TI|*)*) if |TI| is a vector
+    <td class="nowrap">|e1| `<=` |e2|`:` |TB|
+    <td>Less than or equal. [=Component-wise=] when |TI| is a vector. (OpSLessThanEqual)
+  <tr algorithm="signed integer greater than">
+    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is
+    *SignedIntegral*<br>|TB| is bool if |TI| is scalar, or<br>
+    vec|N|&lt;bool&gt; (where |N| = *Arity(*|TI|*)*) if |TI| is a vector
+    <td class="nowrap">|e1| `<` |e2|`:` |TB|
+    <td>Greater than. [=Component-wise=] when |TI| is a vector. (OpSGreaterThan)
+  <tr algorithm="signed integer greater than equal">
+    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is
+    *SignedIntegral*<br>|TB| is bool if |TI| is scalar, or<br>
+    vec|N|&lt;bool&gt; (where |N| = *Arity(*|TI|*)*) if |TI| is a vector
+    <td class="nowrap">|e1| `<=` |e2|`:` |TB|
+    <td>Greater than or equal. [=Component-wise=] when |TI| is a vector. (OpSGreaterThanEqual)
+
+  <tr algorithm="unsigned integer less than">
+    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is
+    *SignedIntegral*<br>|TB| is bool if |TI| is scalar, or<br>
+    vec|N|&lt;bool&gt; (where |N| = *Arity(*|TI|*)*) if |TI| is a vector
+    <td class="nowrap">|e1| `<` |e2|`:` |TB|
+    <td>Less than. [=Component-wise=] when |TI| is a vector. (OpSLessThan)
+  <tr algorithm="unsigned integer less than equal">
+    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is
+    *SignedIntegral*<br>|TB| is bool if |TI| is scalar, or<br>
+    vec|N|&lt;bool&gt; (where |N| = *Arity(*|TI|*)*) if |TI| is a vector
+    <td class="nowrap">|e1| `<=` |e2|`:` |TB|
+    <td>Less than or equal. [=Component-wise=] when |TI| is a vector. (OpSLessThanEqual)
+  <tr algorithm="unsigned integer greater than">
+    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is
+    *SignedIntegral*<br>|TB| is bool if |TI| is scalar, or<br>
+    vec|N|&lt;bool&gt; (where |N| = *Arity(*|TI|*)*) if |TI| is a vector
+    <td class="nowrap">|e1| `<` |e2|`:` |TB|
+    <td>Greater than. [=Component-wise=] when |TI| is a vector. (OpSGreaterThan)
+  <tr algorithm="unsigned integer greater than equal">
+    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is
+    *SignedIntegral*<br>|TB| is bool if |TI| is scalar, or<br>
+    vec|N|&lt;bool&gt; (where |N| = *Arity(*|TI|*)*) if |TI| is a vector
+    <td class="nowrap">|e1| `<=` |e2|`:` |TB|
+    <td>Greater than or equal. [=Component-wise=] when |TI| is vector. (OpSGreaterThanEqual)
+
 </table>
 
 ## Bit Expressions TODO ## {#bit-expr}
@@ -4177,26 +4029,12 @@ Issue: Which index is used when it's out of bounds?
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
-  <tr algorithm="scalar unsigned complement">
-       <td>|e|: u32<br>
-       <td class="nowrap">`~`|e|: u32
-       <td>Bitwise complement on unsigned integers. Result is the mathematical value (2<sup>32</sup> - 1  - |e|).
-          <br>OpNot
-  <tr algorithm="vector unsigned complement">
-      <td>|e|: vec|N|&lt;u32&gt;
-      <td>`~`|e|: vec|N|&lt;u32&gt;
-      <td>Component-wise unsigned complement. Component |i| of the result is `~(`|e|`[`|i|`])`.
-          <br>OpNot
-  <tr algorithm="scalar signed complement">
-       <td>|e|: i32<br>
-       <td class="nowrap">`~`|e|: i32
-       <td>Bitwise complement on signed integers. Result is i32(~u32(|e|)).
-          <br>OpNot
-  <tr algorithm="vector signed complement">
-      <td>|e|: vec|N|&lt;i32&gt;
-      <td>`~`|e|: vec|N|&lt;i32&gt;
-      <td>Component-wise signed complement. Component |i| of the result is `~(`|e|`[`|i|`])`.
-          <br>OpNot
+  <tr algorithm="complement">
+    <td>|e|: |T|<br>
+    |T| is *Integral*
+    <td class="nowrap">`~`|e| : |T|
+    <td>Bitwise complement on |e|. Inverts all the bits of |e|.
+    [=Component-wise=] when |T| is a vector. (OpNot)
 </table>
 
 <table class='data'>
@@ -4204,21 +4042,24 @@ Issue: Which index is used when it's out of bounds?
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
-  <tr><td>*e1*: *T*<br>
-          *e2*: *T*<br>
-          *T* is *Integral*
-       <td class="nowrap">`e1 | e2`: *T*
-       <td>Bitwise-or
-  <tr><td>*e1*: *T*<br>
-          *e2*: *T*<br>
-          *T* is *Integral*
-       <td class="nowrap">`e1 & e2`: *T*
-       <td>Bitwise-and
-  <tr><td>*e1*: *T*<br>
-          *e2*: *T*<br>
-          *T* is *Integral*
-       <td class="nowrap">`e1 ^ e2`: *T*
-       <td>Bitwise-exclusive-or
+  <tr algorithm="bitwise or">
+    <td>*e1*: *T*<br>
+       *e2*: *T*<br>
+       *T* is *Integral*
+    <td class="nowrap">`e1 | e2`: *T*
+    <td>Bitwise-or. [=Component-wise=] when |T| is a vector.
+  <tr algorithm="bitwise and">
+    <td>*e1*: *T*<br>
+       *e2*: *T*<br>
+       *T* is *Integral*
+    <td class="nowrap">`e1 & e2`: *T*
+    <td>Bitwise-and. [=Component-wise=] when |T| is a vector.
+  <tr algorithm="bitwise exclusive or">
+    <td>*e1*: *T*<br>
+       *e2*: *T*<br>
+       *T* is *Integral*
+    <td class="nowrap">`e1 ^ e2`: *T*
+    <td>Bitwise-exclusive-or. [=Component-wise=] when |T| is a vector.
 </table>
 
 
@@ -4227,50 +4068,46 @@ Issue: Which index is used when it's out of bounds?
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
-  <tr algorithm="scalar shift left"><td>|e1|: |T|<br>
-          |e2|: u32<br>
-          |T| is *Int*
-       <td class="nowrap">|e1| `<<` |e2|: |T|
-       <td>Shift left:<br>
-           Shift |e1| left, inserting zero bits at the least significant positions,
-           and discarding the most significant bits.
-           The number of bits to shift is the value of |e2| modulo the bit width of |e1|.<br>
-           (OpShiftLeftLogical)
-  <tr algorithm="vector shift left"><td>|e1|: vec|N|&lt;|T|&gt;<br>
-          |e2|: vec|N|&lt;u32&gt;<br>
-          |T| is *Int*
-       <td class="nowrap">|e1| `<<` |e2|: vec|N|&lt;|T|&gt;
-       <td>Component-wise shift left:<br>
-           Component |i| of the result is `(`|e1|`[`|i|`] << `|e2|`[`|i|`])`<br>
-           (OpShiftLeftLogical)
-  <tr algorithm="scalar logical shift right"><td>|e1|: u32<br>
-          |e2|: u32<br>
-       <td class="nowrap">|e1| `>>` |e2| `: u32`
-       <td >Logical shift right:<br>
-           Shift |e1| right, inserting zero bits at the most significant positions,
-           and discarding the least significant bits.
-           The number of bits to shift is the value of |e2| modulo the bit width of |e1|.
-           (OpShiftRightLogical)
-  <tr algorithm="vector logical shift right"><td>|e1|: vec|N|&lt;u32&gt;<br>
-          |e2|: vec|N|&lt;u32&gt;<br>
-       <td class="nowrap">|e1| `>>` |e2|: vec|N|&lt;u32&gt;
-       <td>Component-wise logical shift right:<br>
-           Component |i| of the result is `(`|e1|`[`|i|`] >> `|e2|`[`|i|`])`
-           (OpShiftRightLogical)
-  <tr algorithm="scalar arithmetic shift right"><td>|e1|: i32<br>
-          |e2|: u32<br>
-       <td class="nowrap">|e1| `>>` |e2|: i32
-       <td>Arithmetic shift right:<br>
-           Shift |e1| right, copying the sign bit of |e1| into the most significant positions,
-           and discarding the least significant bits.
-           The number of bits to shift is the value of |e2| modulo the bit width of |e1|.
-           (OpShiftRightArithmetic)
-  <tr algorithm="vector arithmetic shift right"><td>|e1|: vec|N|&lt;i32&gt;<br>
-          |e2|: vec|N|&lt;u32&gt;<br>
-       <td class="nowrap">|e1| `>>` |e2|: vec|N|&lt;i32&gt;
-       <td>Component-wise arithmetic shift right:<br>
-           Component |i| of the result is `(`|e1|`[`|i|`] >> `|e2|`[`|i|`])`
-           (OpShiftRightArithmetic)
+
+  <tr algorithm="shift left">
+    <td>|e1|: |T|<br>
+    |e2|: |TS|<br>
+    |T| is *SignedIntegral*<br>
+    |TS| is u32 if |e1| is a scalar, or<br>
+    vec|N|&lt;u32&gt; (where |N| = *Arity(*|T|*)*).
+    <td class="nowrap">|e1| `<<` |e2|: |T|
+    <td>Shift left:<br>
+        Shift |e1| left, inserting zero bits at the least significant positions,
+        and discarding the most significant bits.
+        The number of bits to shift is the value of |e2| modulo the bit width of |e1|.<br>
+        [=Component-wise=] when |T| is a vector.
+        (OpShiftLeftLogical)
+
+  <tr algorithm="logical shift right">
+    <td>|e1|: |T|<br>
+    |e2|: |T|<br>
+    |T| is u32 or vec|N|&lt;u32&gt;
+    <td class="nowrap">|e1| >> |e2|: |T|
+    <td>Logical shift right:<br>
+        Shift |e1| right, inserting zero bits at the most significant positions,
+        and discarding the least significant bits.
+        The number of bits to shift is the value of |e2| modulo the bit width of |e1|.
+        [=Component-wise=] when |T| is a vector.
+        (OpShiftRightLogical)
+
+  <tr algorithm="arithmetic shift right">
+    <td>|e1|: |T|<br>
+    |e2|: |TS|<br>
+    |T| is *SignedIntegral*<br>
+    |TS| is u32 if |e1| is a scalar, or<br>
+    vec|N|&lt;u32&gt; (where |N| = *Arity(*|T|*)*).
+    <td class="nowrap">|e1| >> |e2|: |T|
+    <td>Arithmetic shift right:<br>
+        Shift |e1| right, copying the sign bit of |e1| into the most significant positions,
+        and discarding the least significant bits.
+        The number of bits to shift is the value of |e2| modulo the bit width of |e1|.
+        [=Component-wise=] when |T| is a vector.
+        (OpShiftRightArithmetic)
 </table>
 
 ## Function Call Expression ## {#function-call-expr}
@@ -6420,7 +6257,7 @@ That's not a full user-defined function declaration.
   <tr algorithm="vector select">
     <td>|T| is a scalar
     <td>`select(vecN<`|T|`>,vecN<`|T|`>,vecN<bool>`: `vecN<`|T|`>`
-    <td>Component-wise selection. Result component |i| is evaluated as `select(a[`|i|`],b[`|i|`],c[`|i|`])`.
+    <td>[=Component-wise=] selection. Result component |i| is evaluated as `select(a[`|i|`],b[`|i|`],c[`|i|`])`.
     (OpSelect)
 </table>
 
@@ -6430,30 +6267,25 @@ That's not a full user-defined function declaration.
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
-  <tr algorithm="scalar case, test for NaN">
-    <td>|e|: f32<td>`isNan(`|e|`)`: bool
-    <td>Returns true if |e| is NaN according to IEEE. (OpIsNan)
-  <tr algorithm="vector case, test for NaN">
-    <td>|e|: |T|, |T| is *vecN*&lt;f32&gt;
-    <td>`isNan(`|e|`)`: vec|N|&lt;bool&gt;, where |N| = *Arity(*|T|*)*<td>Component-wise test for NaN. Component *i* of the result is *isNan(e[i])*. (OpIsNan)
-  <tr algorithm="scalar case, test for infinity">
-    <td>|e|: f32<td>`isInf(`|e|`)`: bool
-    <td>Returns true if |e| is an infinity according to IEEE. (OpIsInf)
-  <tr algorithm="vector case, test for infinity">
-    <td>|e|: |T|, |T| is *vecN*&lt;f32&gt;
-    <td>`isInf(`|e|`)`: vec|N|&lt;bool&gt;, where |N| = *Arity(*|T|*)*<td>Component-wise test for inifinity. Component *i* of the result is *isInf(e[i])*. (OpIsInf)
-  <tr algorithm="scalar case, test value is finite">
-    <td>|e|: f32<td>`isFinite(`|e|`)`: bool
-    <td>Returns true if |e| is finite according to IEEE. (emulated)
-  <tr algorithm="vector case, test value is finite">
-    <td>|e|: |T|, |T| is *vecN*&lt;f32&gt;
-    <td>`isFinite(`|e|`)`: vec|N|&lt;bool&gt;, where |N| = *Arity(*|T|*)*<td>Component-wise finite value test. Component *i* of the result is *isFinite(e[i])*. (emulated)
-  <tr algorithm="scalar case, test value is normal">
-    <td>|e|: f32<td>`isNormal(`|e|`)`: bool
-    <td>Returns true if |e| is a normal number according to IEEE. (emulated)
-  <tr algorithm="vector case, test value is normal">
-    <td>|e|: |T|, |T| is *vecN*&lt;f32&gt;
-    <td>`isNormal(`|e|`)`: vec|N|&lt;bool&gt;, where |N| = *Arity(*|T|*)*<td>Component-wise test for normal number. Component *i* of the result is *isNormal(e[i])*. (emulated)
+  <tr><td rowspan=4>
+    |e|: |T|<br>
+    |T| is *Floating*<br>
+    |TR| is bool if |T| is a scalar, or<br>
+    vec|N|&lt;bool&gt; (where |N| = *Arity(*|T|*)*) if |T| is a vector
+
+    <td class="nowrap">`isNan(`|e|`) -> `|TR|
+    <td>Test for NaN according to IEEE.
+    [=Component-wise=] when |T| is a vector. (OpIsNan)
+  <tr><td class="nowrap">`isInf(`|e|`) -> `|TR|
+    <td>Test for infinity according to IEEE.
+    [=Component-wise=] when |T| is a vector. (OpIsInf)
+  <tr><td class="nowrap">`isFinite(`|e|`) -> `|TR|
+    <td>Test a finite value according to IEEE.
+    [=Component-wise=] when |T| is a vector.
+  <tr><td class="nowrap">`isNormal(`|e|`) -> `|TR|
+    <td>Test a normal value according to IEEE.
+    [=Component-wise=] when |T| is a vector.
+
   <tr algorithm="runtime array length">
     <td>|e|: ptr&lt;storage,array&lt;|T|&gt;&gt;
     <td>`arrayLength(`|e|`)`: u32<td>Returns the number of elements in the runtime array.<br>
@@ -6466,104 +6298,67 @@ That's not a full user-defined function declaration.
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Description
   </thead>
-  <tr algorithm="scalar case, float abs">
-    <td>|T| is f32
+  <tr algorithm="float abs">
+    <td>|T| is *Floating*
     <td class="nowrap">`abs(`|e|`:` |T| `) -> ` |T|
     <td>Returns the absolute value of |e| (e.g. |e| with a positive sign bit).
-    (GLSLstd450FAbs)
-  <tr algorithm="vector case, float abs">
-    <td>|T| is f32
-    <td class="nowrap">`abs(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
-    <td>Component-wise absolute value.
-    Component |i| of the result is `abs(`|e|`[i])`.
-    (GLSLstd450FAbs)
+    [=Component-wise=] when |T| is a vector.
+    (GLSLstd450Fabs)
 
-  <tr algorithm="scalar case, acos">
-    <td>|T| is f32
+  <tr algorithm="acos">
+    <td>|T| is *Floating*
     <td class="nowrap">`acos(`|e|`:` |T| `) -> ` |T|
-    <td>Returns the arc cosine of |e|. (GLSLstd450Acos)
-  <tr algorithm="vector case, acos">
-    <td>|T| is f32
-    <td class="nowrap">`acos(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
-    <td>Component-wise arc cosine.
-    Component |i| of the result is `acos(`|e|`[i])`.
+    <td>Returns the arc cosine of |e|.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450Acos)
 
-  <tr algorithm="scalar case, asin">
-    <td>|T| is f32
+  <tr algorithm="asin">
+    <td>|T| is *Floating*
     <td class="nowrap">`asin(`|e|`:` |T| `) -> ` |T|
-    <td>Returns the arc sine of |e|. (GLSLstd450Asin)
-  <tr algorithm="vector case, asin">
-    <td>|T| is f32
-    <td class="nowrap">`asin(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
-    <td>Component-wise arc sine.
-    Component |i| of the result is `asin(`|e|`[i])`.
-    (GLSLstd450ASin)
+    <td>Returns the arc sine of |e|.
+    [=Component-wise=] when |T| is a vector.
+    (GLSLstd450Asin)
 
-  <tr algorithm="scalar case, atan">
-    <td>|T| is f32
+  <tr algorithm="atan">
+    <td>|T| is *Floating*
     <td class="nowrap">`atan(`|e|`:` |T| `) -> ` |T|
-    <td>Returns the arc tangent of |e|. (GLSLstd450Atan)
-  <tr algorithm="vector case, atan">
-    <td>|T| is f32
-    <td class="nowrap">`atan(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
-    <td>Component-wise arc tanget.
-    Component |i| of the result is `atan(`|e|`[i])`.
+    <td>Returns the arc tangent of |e|.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450Atan)
 
-  <tr algorithm="scalar case, atan2">
-    <td>|T| is f32
+  <tr algorithm="atan2">
+    <td>|T| is *Floating*
     <td class="nowrap">`atan2(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
-    <td>Returns the arc tangent of |e1| over |e2|. (GLSLstd450Atan2)
-  <tr algorithm="vector case, atan2">
-    <td>|T| is f32
-    <td class="nowrap">`atan2(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
-    <td>Component-wise arc tangent of two inputs.
-    Component |i| of the result is `atan2(`|e|`[i])`.
+    <td>Returns the arc tangent of |e1| over |e2|.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450Atan2)
 
-  <tr algorithm="scalar case, ceil">
-    <td>|T| is f32
+  <tr algorithm="ceil">
+    <td>|T| is *Floating*
     <td class="nowrap">`ceil(`|e|`:` |T| `) -> ` |T|
-    <td>Returns the [=ceiling expression|ceiling=] of |e|. (GLSLstd450Ceil)
-  <tr algorithm="vector case, ceil">
-    <td>|T| is f32
-    <td class="nowrap">`ceil(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
-    <td>Component-wise ceiling.
-    Component |i| of the result is `ceil(`|e|`[i])`.
+    <td>Returns the [=ceiling expression|ceiling=] of |e|.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450Ceil)
 
-  <tr algorithm="scalar case, clamp">
-    <td>|T| is f32
+  <tr algorithm="clamp">
+    <td>|T| is *Floating*
     <td class="nowrap">`clamp(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T|`) -> ` |T|
-    <td>Returns `min(max(`|e1|`,`|e2|`),`|e3|`)`. (GLSLstd450NClamp)
-  <tr algorithm="vector case, clamp">
-    <td>|T| is f32
-    <td class="nowrap">`clamp(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`, `|e3|`:` vec|N|<|T|>`) -> ` vec|N|<|T|>
-    <td>Component-wise clamp.
-    Component |i| of the result is `clamp(`|e1|`[i], `|e2|`[i], `|e3|`[i])`.
+    <td>Returns `min(max(`|e1|`,`|e2|`),`|e3|`)`.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450NClamp)
 
-  <tr algorithm="scalar case, cos">
-    <td>|T| is f32
+  <tr algorithm="cos">
+    <td>|T| is *Floating*
     <td class="nowrap">`cos(`|e|`:` |T| `) -> ` |T|
-    <td>Returns the cosine of |e|. (GLSLstd450Cos)
-  <tr algorithm="vector case, cos">
-    <td>|T| is f32
-    <td class="nowrap">`cos(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
-    <td>Component-wise cosine.
-    Component |i| of the result is `cos(`|e|`)`.
+    <td>Returns the cosine of |e|.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450Cos)
 
-  <tr algorithm="scalar case, cosh">
-    <td>|T| is f32
+  <tr algorithm="cosh">
+    <td>|T| is *Floating*
     <td class="nowrap">`cosh(`|e|`:` |T| `) -> ` |T|
-    <td>Returns the hyperbolic cosine of |e|. (GLSLstd450Cosh)
-  <tr algorithm="vector case, cosh">
-    <td>|T| is f32
-    <td class="nowrap">`cosh(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
-    <td>Component-wise hyperbolic cosine.
-    Component |i| of the result is `cosh(`|e|`[i])`.
+    <td>Returns the hyperbolic cosine of |e|.
+    [=Component-wise=] when |T| is a vector
     (GLSLstd450Cosh)
 
   <tr algorithm="vector case, cross">
@@ -6571,200 +6366,132 @@ That's not a full user-defined function declaration.
     <td class="nowrap">`cross(`|e1|`:` vec3<|T|> `, `|e2|`:` vec3<|T|>`) -> ` vec3<|T|>
     <td>Returns the cross product of |e1| and |e2|. (GLSLstd450Cross)
 
-  <tr algorithm="scalar case, distance">
-    <td>|T| is f32
+  <tr algorithm="distance">
+    <td>|T| is *Floating*
     <td class="nowrap">`distance(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
-    <td>Returns the distance between |e1| and |e2| (e.g. `length(`|e1|` - `|e2|`)`). (GLSLstd450Distance)
-  <tr algorithm="vector case, distance">
-    <td>|T| is f32
-    <td class="nowrap">`distance(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`) -> ` |T|
-    <td>Component-wise distance.
-    Component |i| of the result is `distance(`|e1|`[i], `|e2|`[i])`.
+    <td>Returns the distance between |e1| and |e2| (e.g. `length(`|e1|` - `|e2|`)`).
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450Distance)
 
-  <tr algorithm="scalar case, exp">
-    <td>|T| is f32
+  <tr algorithm="exp">
+    <td>|T| is *Floating*
     <td class="nowrap">`exp(`|e1|`:` |T| `) -> ` |T|
-    <td>Returns the natural exponentiation of |e1| (e.g. `e`<sup>|e1|</sup>). (GLSLstd450Exp)
-  <tr algorithm="vector case, exp">
-    <td>|T| is f32
-    <td class="nowrap">`exp(`|e1|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
-    <td>Component-wise natural exponentiation.
-    Component |i| of the result is `exp(`|e1|`[i])`.
+    <td>Returns the natural exponentiation of |e1| (e.g. `e`<sup>|e1|</sup>).
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450Exp)
 
-  <tr algorithm="scalar case, exp2">
-    <td>|T| is f32
+  <tr algorithm="exp2">
+    <td>|T| is *Floating*
     <td class="nowrap">`exp2(`|e|`:` |T| `) -> ` |T|
-    <td>Returns 2 raised to the power |e| (e.g. `2`<sup>|e|</sup>). (GLSLstd450Exp2)
-  <tr algorithm="vector case, exp2">
-    <td>|T| is f32
-    <td class="nowrap">`exp2(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
-    <td>Component-wise base-2 exponentiation.
-    Component |i| of the result is `exp2(`|e|`[i])`.
+    <td>Returns 2 raised to the power |e| (e.g. `2`<sup>|e|</sup>).
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450Exp2)
 
-  <tr algorithm="scalar case, faceForward">
-    <td>|T| is f32
+  <tr algorithm="faceForward">
+    <td>|T| is *Floating*
     <td class="nowrap">`faceForward(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T| `) -> ` |T|
-    <td>Returns |e1| if `dot(`|e2|`,`|e3|`)` is negative, and `-`|e1| otherwise. (GLSLstd450FaceForward)
-  <tr algorithm="vector case, faceForward">
-    <td>|T| is f32
-    <td class="nowrap">`faceForward(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`, `|e3|`:` vec|N|<|T|>`) -> ` vec|N|<|T|>
-    <td>Component-wise face forward.
-    Component |i| of the result is `faceForward(`|e1|`[i], `|e2|`[i], `|e3|`[i])`.
+    <td>Returns |e1| if `dot(`|e2|`,`|e3|`)` is negative, and `-`|e1| otherwise.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450FaceForward)
 
-  <tr algorithm="scalar case, floor">
-    <td>|T| is f32
+  <tr algorithm="floor">
+    <td>|T| is *Floating*
     <td class="nowrap">`floor(`|e|`:` |T| `) -> ` |T|
-    <td>Returns the [=floor expression|floor=] of |e|. (GLSLstd450Floor)
-  <tr algorithm="vector case, floor">
-    <td>|T| is f32
-    <td class="nowrap">`floor(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
-    <td>Component-wise floor.
-    Component |i| of the result is `floor(`|e|`[i])`.
+    <td>Returns the [=floor expression|floor=] of |e|.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450Floor)
 
-  <tr algorithm="scalar case, fma">
+  <tr algorithm="fma">
     <td>|T| is f32
     <td class="nowrap">`fma(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T| `) -> ` |T|
-    <td>Returns |e1| `*` |e2| `+` |e3|. (GLSLstd450Fma)
-  <tr algorithm="vector case, fma">
-    <td>|T| is f32
-    <td class="nowrap">`fma(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`, `|e3|`:` vec|N|<|T|>`) -> ` vec|N|<|T|>
-    <td>Component-wise fast multiple add.
-    Component |i| of the result is `fma(`|e1|`[i], `|e2|`[i], `|e3|`[i])`.
+    <td>Returns |e1| `*` |e2| `+` |e3|.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450Fma)
 
-  <tr algorithm="scalar case, fract">
-    <td>|T| is f32
+  <tr algorithm="fract">
+    <td>|T| is *Floating*
     <td class="nowrap">`fract(`|e|`:` |T| `) -> ` |T|
-    <td>Returns the fractional bits of |e| (e.g. |e| `- floor(`|e|`)`). (GLSLstd450Fract)
-  <tr algorithm="vector case, fract">
-    <td>|T| is f32
-    <td class="nowrap">`fract(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
-    <td>Component-wise fractional.
-    Component |i| of the result is `fract(`|e|`[i])`.
+    <td>Returns the fractional bits of |e| (e.g. |e| `- floor(`|e|`)`).
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450Fract)
 
-  <tr algorithm="scalar case, frexp">
-    <td>|T| is f32<br>
-        |I| is i32 or u32
+  <tr algorithm="frexp">
+    <td>|T| is *Floating*<br>
+        |I| is *Integral*, where<br>
+        |I| is a scalar if |T| is a scalar, or<br>
+        a vector when |T| is a vector (with equal *Arity*)
     <td class="nowrap">`frexp(`|e1|`:` |T| `, `|e2|`:` ptr<|I|> `) -> ` |T|
     <td>Splits |e1| into a signficand and exponent of the form `significand * 2`<sup>`exponent`</sup> and returns the significand.
     The magnitude of the signficand is in the range of [0.5, 1.0) or 0.
-    The exponent is stored through the pointer |e2|. (GLSLstd450Frexp)
-  <tr algorithm="vector case, frexp">
-    <td>|T| is f32<br>
-        |I| is i32 or u32
-    <td class="nowrap">`frexp(`|e1|`:` vec|N|<|T|> `, `|e2|`:` ptr&lt;vec|N|&lt;|I|&gt;&gt;`) -> ` vec|N|<|T|>
-    <td>Component-wise fraction and exponent.
-    Component |i| of the result is `frexp(`|e1|`[i], &(*`|e2|`).[i])`.
+    The exponent is stored through the pointer |e2|.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450Frexp)
 
-  <tr algorithm="scalar case, inverseSqrt">
-    <td>|T| is f32
+  <tr algorithm="inverseSqrt">
+    <td>|T| is *Floating*
     <td class="nowrap">`inverseSqrt(`|e|`:` |T| `) -> ` |T|
-    <td>Returns the reciprocal of `sqrt(`|e|`)`. (GLSLstd450InverseSqrt)
-  <tr algorithm="vector case, inverseSqrt">
-    <td>|T| is f32
-    <td class="nowrap">`inverseSqrt(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
-    <td>Component-wise reciprocal square root.
-    Component |i| of the result is `inverseSqrt(`|e1|`[i])`.
+    <td>Returns the reciprocal of `sqrt(`|e|`)`.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450InverseSqrt)
 
-  <tr algorithm="scalar case, ldexp">
-    <td>|T| is f32<br>
-        |I| is i32 or u32
+  <tr algorithm="ldexp">
+    <td>|T| is *Floating*<br>
+        |I| is *Integral*, where<br>
+        |I| is a scalar if |T| is a scalar, or<br>
+        a vector when |T| is a vector (with equal *Arity*)
     <td class="nowrap">`ldexp(`|e1|`:` |T| `, `|e2|`:` |I| `) -> ` |T|
-    <td>Returns |e1| `* 2`<sup>|e2|</sup>. (GLSLstd450Ldexp)
-  <tr algorithm="vector case, ldexp">
-    <td>|T| is f32<br>
-        |I| is i32 or u32
-    <td class="nowrap">`ldexp(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|&lt;|I|&gt;`) -> ` vec|N|<|T|>
-    <td>Component-wise floating-point number composition.
-    Component |i| of the result is `ldexp(`|e1|`[i], `|e2|`[i])`.
+    <td>Returns |e1| `* 2`<sup>|e2|</sup>.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450Ldexp)
 
-  <tr algorithm="scalar case, length">
-    <td>|T| is f32
+  <tr algorithm="length">
+    <td>|T| is *Floating*
     <td class="nowrap">`length(`|e|`:` |T| `) -> ` |T|
-    <td>Returns `abs(`|e|`)`.
-    (GLSLstd450Length)
-  <tr algorithm="vector case, length">
-    <td>|T| is f32
-    <td class="nowrap">`length(`|e|`:` vec|N|<|T|> `) -> ` |T|
-    <td>Returns the length |e| (e.g. `sqrt(`|e|`[0]`<sup>`2`</sup> `+` |e|`[1]`<sup>`2`</sup> `+ ...)`).
+    <td>Returns the length of |e| (e.g. `abs(`|e|`)` if |T| is a scalar, or `sqrt(`|e|`[0]`<sup>`2`</sup> `+` |e|`[1]`<sup>`2`</sup> `+ ...)` if |T| is a vector).
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450Length)
 
-  <tr algorithm="scalar case, log">
-    <td>|T| is f32
+  <tr algorithm="log">
+    <td>|T| is *Floating*
     <td class="nowrap">`log(`|e|`:` |T| `) -> ` |T|
-    <td>Returns the natural logaritm of |e|. (GLSLstd450Log)
-  <tr algorithm="vector case, log">
-    <td>|T| is f32
-    <td class="nowrap">`log(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
-    <td>Component-wise natural logarithm.
-    Component |i| of the result is `log(`|e|`[i])`.
+    <td>Returns the natural logaritm of |e|.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450Log)
 
-  <tr algorithm="scalar case, log2">
-    <td>|T| is f32
+  <tr algorithm="log2">
+    <td>|T| is *Floating*
     <td class="nowrap">`log2(`|e|`:` |T| `) -> ` |T|
-    <td>Returns the base-2 logarithm of |e|. (GLSLstd450Log2)
-  <tr algorithm="vector case, log2">
-    <td>|T| is f32
-    <td class="nowrap">`log2(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
-    <td>Component-wise base-2 logarithm.
-    Component |i| of the result is `log2(`|e|`[i])`.
+    <td>Returns the base-2 logarithm of |e|.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450Log2)
 
-  <tr algorithm="scalar case, max">
-    <td>|T| is f32
+  <tr algorithm="max">
+    <td>|T| is *Floating*
     <td class="nowrap">`max(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
-    <td>Returns |e2| if |e1| is less than |e2|, and |e1| otherwise. (GLSLstd450NMax)
-  <tr algorithm="vector case, max">
-    <td>|T| is f32
-    <td class="nowrap">`max(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`) -> ` vec|N|<|T|>
-    <td>Component-wise maximum.
-    Component |i| of the result is `max(`|e1|`[i], `|e2|`[i])`.
+    <td>Returns |e2| if |e1| is less than |e2|, and |e1| otherwise.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450NMax)
 
-  <tr algorithm="scalar case, min">
-    <td>|T| is f32
+  <tr algorithm="min">
+    <td>|T| is *Floating*
     <td class="nowrap">`min(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
-    <td>Returns |e2| if |e2| is less than |e1|, and |e1| otherwise. (GLSLstd450NMin)
-  <tr algorithm="vector case, min">
-    <td>|T| is f32
-    <td class="nowrap">`min(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`) -> ` vec|N|<|T|>
-    <td>Component-wise minimum.
-    Component |i| of the result is `min(`|e1|`[i], `|e2|`[i])`.
+    <td>Returns |e2| if |e2| is less than |e1|, and |e1| otherwise.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450NMin)
 
-  <tr algorithm="scalar case, mix">
-    <td>|T| is f32
+  <tr algorithm="mix">
+    <td>|T| is *Floating*
     <td class="nowrap">`mix(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T|`) -> ` |T|
     <td>Returns the linear blend of |e1| and |e2| (e.g. |e1|`*(1-`|e3|`)+`|e2|`*`|e3|).
-    (GLSLstd450FMix)
-  <tr algorithm="vector case, mix">
-    <td>|T| is f32
-    <td class="nowrap">`mix(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`, `|e3|`:` vec|N|<|T|>`) -> ` vec|N|<|T|>
-    <td>Component-wise mix.
-    Component |i| of the result is `mix(`|e1|`[i], `|e2|`[i], `|e3|`[i])`.
+    [=Component-wise=] with |T| is a vector.
     (GLSLstd450FMix)
 
   <tr algorithm="scalar case, modf">
-    <td>|T| is f32<br>
+    <td>|T| is *Floating*
     <td class="nowrap">`modf(`|e1|`:` |T| `, `|e2|`:` ptr<|T|> `) -> ` |T|
     <td>Splits |e1| into fractional and whole number parts.
     Returns the fractional part and stores the whole number through the pointer |e2|.
-    (GLSLstd450Modf)
-  <tr algorithm="vector case, modf">
-    <td>|T| is f32
-    <td class="nowrap">`modf(`|e1|`:` vec|N|<|T|> `, `|e2|`:` ptr&lt;vec|N|&lt;|T|&gt;&gt;`) -> ` vec|N|<|T|>
-    <td>Component-wise fractional and whole number splitting.
-    Component |i| of the result is `modf(`|e1|`[i], &(*`|e2|`).[i])`.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450Modf)
 
   <tr algorithm="vector case, normalize">
@@ -6773,151 +6500,91 @@ That's not a full user-defined function declaration.
     <td>Returns a unit vector in the same direction as |e|.
     (GLSLstd450Normalize)
 
-  <tr algorithm="scalar case, pow">
-    <td>|T| is f32
+  <tr algorithm="pow">
+    <td>|T| is *Floating*
     <td class="nowrap">`pow(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>Returns |e1| raised to the power |e2|.
-    (GLSLstd450Pow)
-  <tr algorithm="vector case, pow">
-    <td>|T| is f32
-    <td class="nowrap">`pow(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
-    <td>Component-wise power.
-    Component |i| of the result is `pow(`|e1|`[i],`|e2|`[i])`.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450Pow)
 
-  <tr algorithm="scalar case, reflect">
-    <td>|T| is f32
+  <tr algorithm="reflect">
+    <td>|T| is *Floating*
     <td class="nowrap">`reflect(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>For the incident vector |e1| and surface orientation |e2|, returns the reflection direction
     |e1|`-2*dot(`|e2|`,`|e1|`)*|e2|`.
-    (GLSLstd450Reflect)
-  <tr algorithm="vector case, reflect">
-    <td>|T| is f32
-    <td class="nowrap">`reflect(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`) -> ` vec|N|<|T|>
-    <td>Component-wise reflection direction.
-    Component |i| of the result is `reflect(`|e1|`[i],`|e2|`[i])`.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450Reflect)
 
-  <tr algorithm="scalar case, round">
-    <td>|T| is f32
+  <tr algorithm="round">
+    <td>|T| is *Floating*
     <td class="nowrap">`round(`|e|`:` |T| `) -> ` |T|
     <td>Result is the integer |k| nearest to |e|, as a floating point value.<br>
         When |e| lies halfway between integers |k| and |k|+1,
         the result is |k| when |k| is even, and |k|+1 when |k| is odd.<br>
-        (GLSLstd450RoundEven)
-  <tr algorithm="vector case, round">
-    <td>|T| is f32
-    <td class="nowrap">`round(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
-    <td>Component-wise rounding.<br>
-         Component |i| of the result is `round`(|e|[|i|])<br>
+        [=Component-wise=] when |T| is a vector.
         (GLSLstd450RoundEven)
 
-  <tr algorithm="scalar case, float sign">
-    <td>|T| is f32
+  <tr algorithm="float sign">
+    <td>|T| is *Floating*
     <td class="nowrap">`sign(`|e|`:` |T| `) -> ` |T|
     <td>Returns the sign of |e|.
-    (GLSLstd450FSign)
-  <tr algorithm="vector case, float sign">
-    <td>|T| is f32
-    <td class="nowrap">`sign(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
-    <td>Component-wise sign.
-    Component |i| of the result is `sign(`|e|`[i])`.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450FSign)
 
-  <tr algorithm="scalar case, sin">
-    <td>|T| is f32
+  <tr algorithm="sin">
+    <td>|T| is *Floating*
     <td class="nowrap">`sin(`|e|`:` |T| `) -> ` |T|
     <td>Returns the sine of |e|.
-    (GLSLstd450Sin)
-  <tr algorithm="vector case, sin">
-    <td>|T| is f32
-    <td class="nowrap">`sin(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
-    <td>Component-wise sine.
-    Component |i| of the result is `sin(`|e|`[i])`.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450Sin)
 
-  <tr algorithm="scalar case, sinh">
-    <td>|T| is f32
+  <tr algorithm="sinh">
+    <td>|T| is *Floating*
     <td class="nowrap">`sinh(`|e|`:` |T| `) -> ` |T|
     <td>Returns the hyperbolic sine of |e|.
-    (GLSLstd450Sinh)
-  <tr algorithm="vector case, sinh">
-    <td>|T| is f32
-    <td class="nowrap">`sinh(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
-    <td>Component-wise hyperbolic sine.
-    Component |i| of the result is `sinh(`|e|`[i])`.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450Sinh)
 
-  <tr algorithm="scalar case, smoothStep">
-    <td>|T| is f32
+  <tr algorithm="smoothStep">
+    <td>|T| is *Floating*
     <td class="nowrap">`smoothStep(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T| `) -> ` |T|
     <td>Returns the smooth Hermite interpolation between 0 and 1.
-    (GLSLstd450SmoothStep)
-  <tr algorithm="vector case, smoothStep">
-    <td>|T| is f32
-    <td class="nowrap">`smoothStep(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`, `|e3|`:` vec|N|<|T|>`) -> ` vec|N|<|T|>
-    <td>Component-wise smooth Hermite interpolation.
-    Component |i| of the result is `smoothStep(`|e1|`[i],`|e2|`[i],`|e3|`[i])`.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450SmoothStep)
 
-  <tr algorithm="scalar case, sqrt">
-    <td>|T| is f32
+  <tr algorithm="sqrt">
+    <td>|T| is *Floating*
     <td class="nowrap">`sqrt(`|e|`:` |T| `) -> ` |T|
     <td>Returns the square root of |e|.
-    (GLSLstd450Sqrt)
-  <tr algorithm="vector case, sqrt">
-    <td>|T| is f32
-    <td class="nowrap">`sqrt(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
-    <td>Component-wise square root.
-    Component |i| of the result is `sqrt(`|e|`[i])`.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450Sqrt)
 
-  <tr algorithm="scalar case, step">
-    <td>|T| is f32
+  <tr algorithm="step">
+    <td>|T| is *Floating*
     <td class="nowrap">`step(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>Returns 0.0 if |e1| is less than |e2|, and 1.0 otherwise.
-    (GLSLstd450Step)
-  <tr algorithm="vector case, step">
-    <td>|T| is f32
-    <td class="nowrap">`step(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`) -> ` vec|N|<|T|>
-    <td>Component-wise step.
-    Component |i| of the result is `step(`|e1|`[i],`|e1|`[i])`.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450Step)
 
-  <tr algorithm="scalar case, tan">
-    <td>|T| is f32
+  <tr algorithm="tan">
+    <td>|T| is *Floating*
     <td class="nowrap">`tan(`|e|`:` |T| `) -> ` |T|
     <td>Returns the tangent of |e|.
-    (GLSLstd450Tan)
-  <tr algorithm="vector case, tan">
-    <td>|T| is f32
-    <td class="nowrap">`tan(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
-    <td>Component-wise tangent.
-    Component |i| of the result is `tan(`|e|`[i])`.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450Tan)
 
-  <tr algorithm="scalar case, tanh">
-    <td>|T| is f32
+  <tr algorithm="tanh">
+    <td>|T| is *Floating*
     <td class="nowrap">`tanh(`|e|`:` |T| `) -> ` |T|
     <td>Returns the hyperbolic tangent of |e|.
-    (GLSLstd450Tanh)
-  <tr algorithm="vector case, tanh">
-    <td>|T| is f32
-    <td class="nowrap">`tanh(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
-    <td>Component-wise hyperbolic tangent.
-    Component |i| of the result is `tanh(`|e|`[i])`.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450Tanh)
 
-  <tr algorithm="scalar case, trunc">
-    <td>|T| is f32
+  <tr algorithm="trunc">
+    <td>|T| is *Floating*
     <td class="nowrap">`trunc(`|e|`:` |T| `) -> ` |T|
     <td>Returns the nearest whole number whose absolute value is less than or equal to |e|.
-    (GLSLstd450Trunc)
-  <tr algorithm="vector case, trunc">
-    <td>|T| is f32
-    <td class="nowrap">`trunc(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
-    <td>Component-wise truncate.
-    Component |i| of the result is `trunc(`|e|`[i])`.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450Trunc)
 </table>
 
@@ -6927,123 +6594,75 @@ That's not a full user-defined function declaration.
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Description
   </thead>
-  <tr algorithm="scalar case, signed abs">
-    <td>
-    <td class="nowrap">`abs`(|e|: i32 ) -> i32
-    <td>The absolute value of |e|.<br>
-        (GLSLstd450SAbs)
-  <tr algorithm="vector case, signed abs">
-    <td>
-    <td class="nowrap">`abs`(|e|: vec|N|&lt;i32&gt; ) -> vec|N|&lt;i32&gt;
-    <td>Component-wise absolute value:
-        Component |i| of the result is `abs(`|e|`[`|i|`])`<br>
+  <tr algorithm="signed abs">
+    <td>|T| is *SignedIntegral*
+    <td class="nowrap">`abs`(|e|: |T| ) -> |T|
+    <td>The absolute value of |e|.
+        [=Component-wise=] when |T| is a vector.
         (GLSLstd450SAbs)
 
   <tr algorithm="scalar case, unsigned abs">
-    <td>
-    <td class="nowrap">`abs`(|e|: u32 ) -> u32
+    <td>|T| is u32 or vec|N|&lt;u32&gt;
+    <td class="nowrap">`abs`(|e|: |T| ) -> |T|
     <td>Result is |e|.  This is provided for symmetry with `abs` for signed integers.
-  <tr algorithm="vector case, unsgined abs">
-    <td>
-    <td class="nowrap">`abs(`|e|`:` vec|N|&lt;u32&gt; `) ->` vec|N|&lt;u32&gt;
-    <td>Result is |e|.  This is provided for symmetry with `abs` for signed integer vectors.
+    [=Component-wise=] when |T| is a vector.
 
-  <tr algorithm="scalar case, unsigned clamp">
-    <td>|T| is u32
+  <tr algorithm="unsigned clamp">
+    <td>|T| is u32 or vec|N|&lt;u32&gt;
     <td class="nowrap">`clamp(`|e1|`:` |T| `, `|e2|`:` |T|`, `|e3|`:` |T|`) ->` |T|
     <td>Returns `min(max(`|e1|`,`|e2|`),`|e3|`)`.
-    (GLSLstd450UClamp)
-  <tr algorithm="vector case, unsigned clamp">
-    <td>|T| is u32
-    <td class="nowrap">`clamp(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`, `|e3|`:`vec|N|<|T|> `) ->` vec|N|<|T|>
-    <td>Component-wise clamp.
-    Component |i| of the result is `clamp(`|e1|`[i],`|e2|`[i],`|e3|`[i])`.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450UClamp)
 
-  <tr algorithm="scalar case, signed clamp">
-    <td>|T| is i32
+  <tr algorithm="signed clamp">
+    <td>|T| is *SignedIntegral*
     <td class="nowrap">`clamp(`|e1|`:` |T| `, `|e2|`:` |T|`, `|e3|`:` |T|`) ->` |T|
     <td>Returns `min(max(`|e1|`,`|e2|`),`|e3|`)`.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450SClamp)
-  <tr algorithm="vector case, signed clamp">
-    <td>|T| is i32
-    <td class="nowrap">`clamp(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`, `|e3|`:`vec|N|<|T|> `) ->` vec|N|<|T|>
-    <td>Component-wise clamp.
-    Component |i| of the result is `clamp(`|e1|`[i],`|e2|`[i],`|e3|`[i])`.
-    (GLSLstd450UClamp)
 
-  <tr algorithm="scalar case, count 1 bits">
-    <td>|T| is u32 or i32<br>
+  <tr algorithm="count 1 bits">
+    <td>|T| is *Integral*
     <td class="nowrap">`countOneBits(`|e|`:` |T| `) ->` |T|
     <td>The number of 1 bits in the representation of |e|.<br>
         Also known as "population count".<br>
-        (SPIR-V OpBitCount)
-  <tr algorithm="vector case, count 1 bits">
-    <td>|T| is u32 or i32
-    <td class="nowrap">`countOneBits(`|e|`:` vec|N|<|T|>`) ->` vec|N|<|T|><br>
-    <td>Component-wise population count:
-        Component |i| of the result is `countOneBits(`|e|`[`|i|`])`<br>
+        [=Component-wise=] when |T| is a vector.
         (SPIR-V OpBitCount)
 
-  <tr algorithm="scalar case, unsigned max">
-    <td>|T| is u32
+  <tr algorithm="unsigned max">
+    <td>|T| is u32 or vec|N|&lt;u32&gt;
     <td class="nowrap">`max(`|e1|`:` |T| `, `|e2|`:` |T|`) ->` |T|
     <td>Returns |e2| if |e1| is less than |e2|, and |e1| otherwise.
-    (GLSLstd450UMax)
-  <tr algorithm="vector case, unsigned max">
-    <td>|T| is u32
-    <td class="nowrap">`max(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`) ->` vec|N|<|T|>
-    <td>Component-wise maximum.
-    Component |i| of the result is `max(`|e1|`[i],`|e2|`[i])`.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450UMax)
 
-  <tr algorithm="scalar case, signed max">
-    <td>|T| is i32
+  <tr algorithm="signed max">
+    <td>|T| is *SignedIntegral*
     <td class="nowrap">`max(`|e1|`:` |T| `, `|e2|`:` |T|`) ->` |T|
     <td>Returns |e2| if |e1| is less than |e2|, and |e1| otherwise.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450SMax)
-  <tr algorithm="vector case, signed max">
-    <td>|T| is i32
-    <td class="nowrap">`max(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`) ->` vec|N|<|T|>
-    <td>Component-wise maximum.
-    Component |i| of the result is `max(`|e1|`[i],`|e2|`[i])`.
-    (GLSLstd45SUMax)
 
-  <tr algorithm="scalar case, unsigned min">
-    <td>|T| is u32
+  <tr algorithm="unsigned min">
+    <td>|T| is u32 or vec|N|&lt;u32&gt;
     <td class="nowrap">`min(`|e1|`:` |T| `, `|e2|`:` |T|`) ->` |T|
     <td>Returns |e1| if |e1| is less than |e2|, and |e2| otherwise.
-    (GLSLstd450UMin)
-  <tr algorithm="vector case, unsigned min">
-    <td>|T| is u32
-    <td class="nowrap">`min(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`) ->` vec|N|<|T|>
-    <td>Component-wise minimum.
-    Component |i| of the result is `min(`|e1|`[i],`|e2|`[i])`.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd450UMin)
 
-  <tr algorithm="scalar case, signed min">
-    <td>|T| is i32
+  <tr algorithm="signed min">
+    <td>|T| is *SignedIntegral*
     <td class="nowrap">`min(`|e1|`:` |T| `, `|e2|`:` |T|`) ->` |T|
     <td>Returns |e1| if |e1| is less than |e2|, and |e2| otherwise.
+    [=Component-wise=] when |T| is a vector.
     (GLSLstd45SUMin)
-  <tr algorithm="vector case, signed min">
-    <td>|T| is i32
-    <td class="nowrap">`min(`|e1|`:` vec|N|<|T|> `, `|e2|`:` vec|N|<|T|>`) ->` vec|N|<|T|>
-    <td>Component-wise minimum.
-    Component |i| of the result is `min(`|e1|`[i],`|e2|`[i])`.
-    (GLSLstd450SMin)
 
-  <tr algorithm="scalar bit reversal">
-    <td>|T| is u32 or i32<br>
+  <tr algorithm="bit reversal">
+    <td>|T| is *Integral*
     <td class="nowrap">`reverseBits(`|e|`:` |T| `) ->`  |T|
     <td>Reverses the bits in |e|:  The bit at position |k| of the result equals the
         bit at position 31-|k| of |e|.<br>
-        (SPIR-V OpBitReverse)
-  <tr algorithm="vector bit reversal">
-    <td>|T| is u32 or i32
-    <td class="nowrap">`reverseBits(`|e|`:` vec|N|<|T|> `) ->` vec|N|<|T|><br>
-    <td>Component-wise bit reversal:
-        Component |i| of the result is `reverseBits(`|e|`[`|i|`])`<br>
+        [=Component-wise=] when |T| is a vector.
         (SPIR-V OpBitReverse)
 </table>
 


### PR DESCRIPTION
* Make component-wise a definition and provide an example
* De-duplicate scalar and vector entries where possible and say the
  vector version is performed component-wise
* Greatly reduces the number of rows in expression and builtin function
  tables