### PR TITLE
wgsl: Workgroup storage holds plain types

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1235,7 +1235,7 @@ and how to use variables with it.
       <td>Read-write
       <td>Invocations in the same [=compute shader stage|compute shader=] [=compute shader stage/workgroup=]
       <td>[=Module scope=]
-      <td>[=Storable=] types, except for texture and [=sampler=] types
+      <td>[=Plain type=]
       <td>
   <tr><td><dfn noexport dfn-for="storage classes">uniform</dfn>
       <td>Read-only


### PR DESCRIPTION
This is a simplification I missed when doing #1693