### PR TITLE
wgsl editorial: clean up IO-shareable, storable

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1153,8 +1153,8 @@ A type is <dfn dfn noexport>storable</dfn> if it is one of:
 * a [=vector=] type
 * a [=matrix=] type
 * an [=atomic type|atomic=] type
-* an [=array=] type, if its element type is storable.
-* a [=structure=] type, if each of member is storable.
+* an [=array=] type, if its element type is storable
+* a [=structure=] type, if all its members are storable
 * a [=texture=] type
 * a [=sampler=] type
 
@@ -1162,13 +1162,13 @@ Note: [=Atomic-free=] [=plain types=] are storable.
 
 ### IO-shareable Types ### {#io-shareable-types}
 
-The following types are <dfn dfn noexport>IO-shareable</dfn>:
+A type is <dfn dfn noexport>IO-shareable</dfn> if it is one of:
 
-* [=scalar=] types
-* [=numeric vector=] types
-* [[#matrix-types]]
-* [[#array-types]] if its element type is IO-shareable, and the array is not [=runtime-sized=]
-* [[#struct-types]] if all its members are IO-shareable
+* a [=scalar=] type
+* a [=numeric vector=] type
+* a [=matrix=] type
+* an [=array=] type, if its element type is IO-shareable, and the array is not [=runtime-sized=]
+* a [=structure=] type, if all its members are IO-shareable
 
 The following kinds of values must be of IO-shareable type:
 


### PR DESCRIPTION
* Link to the definitions for matrix, array, structure instead of the
section.
* Express array and structure constraints with consistent wording