### PR TITLE
Add forceSoftware adapter option and isSoftware adapter attribute

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -958,6 +958,11 @@ An [=adapter=] has the following internal slots:
         reinitialization due to an unplugged adapter, reinitialization due to a test
         {{GPUDevice/destroy()|GPUDevice.destroy()}} call, etc. It also ensures applications use
         the latest system state to make decisions about which adapter to use.
+
+    : <dfn>\[[software]]</dfn>, of type boolean
+    ::
+        If set to `true` indicates that the adapter is backed by a software implementation of an
+        appropriate graphics API rather than physical GPU hardware.
 </dl>
 
 [=Adapters=] are exposed via {{GPUAdapter}}.
@@ -1355,10 +1360,12 @@ interface GPU {
             1. Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
                     1. If the user agent chooses to return an adapter, it should:
+                        1. Create an [=adapter=] |adapter| with {{adapter/[[current]]}} set to
+                            `true`, chosen according to the rules in [[#adapter-selection]] and the
+                            criteria in |options|.
 
-                        1. Create an [=adapter=] |adapter| with {{adapter/[[current]]}} set to `true`,
-                            chosen according to the rules in
-                            [[#adapter-selection]] and the criteria in |options|.
+                        1. If |adapter| is backed by a software graphics API implementation set
+                            |adapter|.{{adapter/[[software]]}} to `true`.
 
                         1. [=Resolve=] |promise| with a new {{GPUAdapter}} encapsulating |adapter|.
 
@@ -1421,6 +1428,7 @@ configuration is suitable for the application.
 <script type=idl>
 dictionary GPURequestAdapterOptions {
     GPUPowerPreference powerPreference;
+    boolean forceSoftware = false;
 };
 </script>
 
@@ -1483,6 +1491,20 @@ enum GPUPowerPreference {
                 Developers are encouraged to only specify this value if they believe it is absolutely
                 necessary, since it may significantly decrease battery life on portable devices.
         </dl>
+
+    : <dfn>forceSoftware</dfn>
+    ::
+        When set to `true` indicates that only software [=adapters=] may be returned. If the user
+        agent does not support a software [=adapter=], will cause {{GPU/requestAdapter()}} to
+        resolve to `null`.
+
+        Note:
+        {{GPU/requestAdapter()}} may still return a software [=adapter=] is
+        {{GPURequestAdapterOptions/forceSoftware}} is set to `false` and either no appropriate
+        hardware [=adapter=] is available or the user agent chooses not to return a hardware
+        [=adapter=]. Developers that wish to prevent their applications from running on software
+        [=adapters=] should check the {{GPUAdapter}}.{{GPUAdapter/isSoftware}} attribute prior to
+        requesting a {{GPUDevice}}.
 </dl>
 
 ## <dfn interface>GPUAdapter</dfn> ## {#gpu-adapter}
@@ -1498,6 +1520,7 @@ interface GPUAdapter {
     readonly attribute DOMString name;
     [SameObject] readonly attribute GPUSupportedFeatures features;
     [SameObject] readonly attribute GPUSupportedLimits limits;
+    readonly attribute boolean isSoftware;
 
     Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor = {});
 };
@@ -1518,6 +1541,10 @@ interface GPUAdapter {
     : <dfn>limits</dfn>
     ::
         The limits in `this`.{{GPUAdapter/[[adapter]]}}.{{adapter/[[limits]]}}.
+
+    : <dfn>isSoftware</dfn>
+    ::
+        Returns the value of {{GPUAdapter/[[adapter]]}}.{{adapter/[[software]]}}.
 </dl>
 
 {{GPUAdapter}} has the following internal slots:


### PR DESCRIPTION
An alternative to #1660 and #1314, [suggested here](https://github.com/gpuweb/gpuweb/pull/1660#issuecomment-837367703).

Adds a 'forceSoftware' option to `GPURequestAdapterOptions` and an `isSoftware` boolean attribute to `GPUAdapter`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/1734.html" title="Last updated on Jun 7, 2021, 7:47 PM UTC (0d604d1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1734/c7c816e...0d604d1.html" title="Last updated on Jun 7, 2021, 7:47 PM UTC (0d604d1)">Diff</a>