### PR TITLE
copyExternalImageToTexture: disallow detached ImageBitmap, add todo

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7575,31 +7575,36 @@ GPUQueue includes GPUObjectBase;
 
             **Returns:** {{undefined}}
 
-            - If |source|.{{GPUImageCopyExternalImage/source}}
-                <l spec=html>[=is not origin-clean=]</l>,
+            1. Let |sourceImage| be |source|.{{GPUImageCopyExternalImage/source}}
+            1. If |sourceImage| <l spec=html>[=is not origin-clean=]</l>,
                 throw a {{SecurityError}} and stop.
+            1. If |sourceImage| is an {{ImageBitmap}} and
+                |sourceImage|.{{platform object/[[Detached]]}} is true,
+                throw an {{InvalidStateError}} and stop.
 
-            If any of the following requirements are unmet, throw an {{OperationError}} and stop.
-            <div class=validusage>
-                - Let |textureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
-                - |copySize|.[=Extent3D/depthOrArrayLayers=] must be `1`.
-                - |textureDesc|.{{GPUTextureDescriptor/usage}} must include both {{GPUTextureUsage/RENDER_ATTACHMENT}} and {{GPUTextureUsage/COPY_DST}}.
-                - |textureDesc|.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"2d"}}.
-                - |textureDesc|.{{GPUTextureDescriptor/format}} must be one of the following:
-                    - {{GPUTextureFormat/"rgba8unorm"}}
-                    - {{GPUTextureFormat/"rgba8unorm-srgb"}}
-                    - {{GPUTextureFormat/"bgra8unorm"}}
-                    - {{GPUTextureFormat/"bgra8unorm-srgb"}}
-                    - {{GPUTextureFormat/"rgb10a2unorm"}}
-                    - {{GPUTextureFormat/"rgba16float"}}
-                    - {{GPUTextureFormat/"rgba32float"}}
-                    - {{GPUTextureFormat/"rg8unorm"}}
-                    - {{GPUTextureFormat/"rg16float"}}
-            </div>
+            1. If any of the following requirements are unmet, throw an {{OperationError}} and stop.
+                <div class=validusage>
+                    - Let |textureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
+                    - |copySize|.[=Extent3D/depthOrArrayLayers=] must be `1`.
+                    - |textureDesc|.{{GPUTextureDescriptor/usage}} must include both {{GPUTextureUsage/RENDER_ATTACHMENT}} and {{GPUTextureUsage/COPY_DST}}.
+                    - |textureDesc|.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"2d"}}.
+                    - |textureDesc|.{{GPUTextureDescriptor/format}} must be one of the following:
+                        - {{GPUTextureFormat/"rgba8unorm"}}
+                        - {{GPUTextureFormat/"rgba8unorm-srgb"}}
+                        - {{GPUTextureFormat/"bgra8unorm"}}
+                        - {{GPUTextureFormat/"bgra8unorm-srgb"}}
+                        - {{GPUTextureFormat/"rgb10a2unorm"}}
+                        - {{GPUTextureFormat/"rgba16float"}}
+                        - {{GPUTextureFormat/"rgba32float"}}
+                        - {{GPUTextureFormat/"rg8unorm"}}
+                        - {{GPUTextureFormat/"rg16float"}}
 
-            Issue: The above list was written just for ImageBitmap.
-            Re-evaluate it for canvas (and video).
-            (It's probably still fine, though `rgb10a2unorm` is a bit of an outlier.)
+                        Issue: This list was written just for ImageBitmap.
+                        Re-evaluate it for canvas (and video).
+                        (It's probably still fine, though `rgb10a2unorm` is a bit of an outlier.)
+                </div>
+
+                Issue: Some of this probably should be asynchronous validation.
         </div>
 
     : <dfn>submit(commandBuffers)</dfn>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 17, 2021, 11:10 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fgpuweb%2Fgpuweb%2F68e68fd3873d0873bd44a54950d4371ea5c102a8%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)

```
<html><body><p><strong>WARNING: </strong>mysqli_connect(): (HY000/2002): Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (111)</p></body></html>
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%231736.)._
</details>
