### PR TITLE
Document new resizing logic for GPUSwapChain

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7992,7 +7992,7 @@ will be scaled to fit the canvas element.
         if not overridden.
 </div>
 
-In order to match the dimensions of the canvas after it is resized, the {{GPUSwapChain}} must be
+If it is desired to match the dimensions of the canvas after it is resized, the {{GPUSwapChain}} must be
 reconfigured by calling {{GPUCanvasContext/configureSwapChain()}} again with the new dimensions.
 Once the {{GPUSwapChain}} is reconfigured the previously returned {{GPUSwapChain}} will become
 [=invalid=] and only the newly returned {{GPUSwapChain}} may be used.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7889,13 +7889,13 @@ interface GPUCanvasContext {
             **Returns:** {{GPUSwapChain}}
 
             1. Let |swapChain| be a new valid {{GPUSwapChain}}.
-            1. Let |device| be |descriptor|.{{GPUSwapChainDescriptor/device}};
+            1. Let |device| be |descriptor|.{{GPUSwapChainDescriptor/device}}.
             1. Let |canvas| be |this|.{{GPUCanvasContext/[[canvas]]}}.
             1. Set |swapChain|.{{GPUSwapChain/[[context]]}} to |this|.
             1. Set |swapChain|.{{GPUSwapChain/[[descriptor]]}} to |descriptor|.
             1. If |descriptor|.{{GPUSwapChainDescriptor/size}} is `undefined` set
-                |swapChain|.{{GPUSwapChain/[[descriptor]]}}.{{GPUSwapChainDescriptor/size}} to
-                [|canvas|.width, |canvas|.height, 1]
+                |swapChain|.{{GPUSwapChain/[[size]]}} to [|canvas|.width, |canvas|.height, 1],
+                otherwise set |swapChain|.{{GPUSwapChain/[[size]]}} to |descriptor|.{{GPUSwapChainDescriptor/size}}.
 
             1. If |this|.{{GPUCanvasContext/[[currentSwapChain]]}} is not `null`, [$destroy the swap chain$].
             1. Set |this|.{{GPUCanvasContext/[[currentSwapChain]]}} to |swapChain|.
@@ -7907,11 +7907,11 @@ interface GPUCanvasContext {
                             - |device| is a [=valid=] {{GPUDevice}}.
                             - [=Supported swap chain formats=] [=set/contains=]
                                 |descriptor|.{{GPUSwapChainDescriptor/format}}.
-                            - |descriptor|.{{GPUSwapChainDescriptor/size}}.[=Extent3D/width=] &le;
-                                |device|.{{GPUAdapterLimits/maxTextureDimension2D}}.
-                            - |descriptor|.{{GPUSwapChainDescriptor/size}}.[=Extent3D/height=] &le;
-                                |device|.{{GPUAdapterLimits/maxTextureDimension2D}}.
-                            - |descriptor|.{{GPUSwapChainDescriptor/size}}.[=Extent3D/depthOrArrayLayers=]
+                            - |swapChain|.{{GPUSwapChain/[[size]]}}.[=Extent3D/width=] &le;
+                                |device|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
+                            - |swapChain|.{{GPUSwapChain/[[size]]}}.[=Extent3D/height=] &le;
+                                |device|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
+                            - |swapChain|.{{GPUSwapChain/[[size]]}}.[=Extent3D/depthOrArrayLayers=]
                                 is 1;
                         </div>
 
@@ -7977,25 +7977,25 @@ and clamped-srgb: they're the same for SDR, but different for HDR).
 
 ### GPUSwapChain sizing ### {#swapchain-sizing}
 
-A {{GPUSwapChain}}'s {{GPUSwapChainDescriptor/size}} is immutable, set by the {{GPUSwapChainDescriptor}}
+A {{GPUSwapChain}}'s {{GPUSwapChain/[[size]]}} is immutable, set by the {{GPUSwapChainDescriptor}}
 passed to {{GPUCanvasContext/configureSwapChain()}}. If a {{GPUSwapChainDescriptor/size}} is not
 specified then the width and height attributes of the {{GPUCanvasContext}}.{{GPUCanvasContext/[[canvas]]}}
-at the time {{GPUCanvasContext/configureSwapChain()}} is called will be used. If the {{GPUSwapChain}}'s
-size does not match the dimensions of the canvas the textures produced by the {{GPUSwapChain}}
-will be scaled to fit the canvas element.
+at the time {{GPUCanvasContext/configureSwapChain()}} is called will be used. If
+{{GPUSwapChain}}.{{GPUSwapChain/[[size]]}} does not match the dimensions of the canvas the textures
+produced by the {{GPUSwapChain}} will be scaled to fit the canvas element.
 
 <div class="note">
     Note: Unlike `'webgl'` or `'2d'` contexts, `width` and `height` attributes of canvases with a
     `'gpupresent'` context only affect:
     - Default layout size, if not overridden by CSS.
-    - Default {{GPUSwapChainDescriptor/size}} when calling {{GPUCanvasContext/configureSwapChain()}},
-        if not overridden.
+    - Default {{GPUSwapChainDescriptor}}.{{GPUSwapChainDescriptor/size}} when calling
+        {{GPUCanvasContext/configureSwapChain()}}, if not overridden.
 </div>
 
-If it is desired to match the dimensions of the canvas after it is resized, the {{GPUSwapChain}} must be
-reconfigured by calling {{GPUCanvasContext/configureSwapChain()}} again with the new dimensions.
-Once the {{GPUSwapChain}} is reconfigured the previously returned {{GPUSwapChain}} will become
-[=invalid=] and only the newly returned {{GPUSwapChain}} may be used.
+If it is desired to match the dimensions of the canvas after it is resized, the {{GPUSwapChain}}
+must be reconfigured by calling {{GPUCanvasContext/configureSwapChain()}} again with the new
+dimensions. Once the {{GPUSwapChain}} is reconfigured the previously returned {{GPUSwapChain}} will
+become [=invalid=] and only the newly returned {{GPUSwapChain}} may be used.
 
 <div class="example">
     Reconfigure a {{GPUSwapChain}} in response to canvas resize, monitored using
@@ -8045,6 +8045,11 @@ GPUSwapChain includes GPUObjectBase;
     : <dfn>\[[descriptor]]</dfn> of type {{GPUSwapChainDescriptor}}
     ::
         The descriptor this swap chain was created with.
+
+    : <dfn>\[[size]]</dfn> of type {{GPUExtent3D}}
+    ::
+        The size of {{GPUTexture}}s returned from this swap chain.
+        [=Extent3D/depthOrArrayLayers=] must be `0`.
 
     : <dfn>\[[currentTexture]]</dfn> of type {{GPUTexture}}, nullable
     ::
@@ -8104,8 +8109,7 @@ GPUSwapChain includes GPUObjectBase;
             1. Return a new [=invalid=] {{GPUTexture}}.
         1. Let |device| be |swapChain|.{{GPUSwapChain/[[descriptor]]}}.{{GPUSwapChainDescriptor/device}}.
         1. Let |descriptor| be a new {{GPUTextureDescriptor}}.
-        1. Set |descriptor|.{{GPUTextureDescriptor/size}} to
-            |swapChain|.{{GPUSwapChain/[[descriptor]]}}.{{GPUSwapChainDescriptor/size}}.
+        1. Set |descriptor|.{{GPUTextureDescriptor/size}} to |swapChain|.{{GPUSwapChain/[[size]]}}.
         1. Set |descriptor|.{{GPUTextureDescriptor/format}} to
             |swapChain|.{{GPUSwapChain/[[descriptor]]}}.{{GPUSwapChainDescriptor/format}}.
         1. Set |descriptor|.{{GPUTextureDescriptor/usage}} to

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7893,12 +7893,9 @@ interface GPUCanvasContext {
             1. Let |canvas| be |this|.{{GPUCanvasContext/[[canvas]]}}.
             1. Set |swapChain|.{{GPUSwapChain/[[context]]}} to |this|.
             1. Set |swapChain|.{{GPUSwapChain/[[descriptor]]}} to |descriptor|.
-            1. If |descriptor|.{{GPUSwapChainDescriptor/width}} is `undefined` set
-                |swapChain|.{{GPUSwapChain/[[descriptor]]}}.{{GPUSwapChainDescriptor/width}} to
-                |canvas|.width.
-            1. If |descriptor|.{{GPUSwapChainDescriptor/height}} is `undefined` set
-                |swapChain|.{{GPUSwapChain/[[descriptor]]}}.{{GPUSwapChainDescriptor/height}} to
-                |canvas|.height.
+            1. If |descriptor|.{{GPUSwapChainDescriptor/size}} is `undefined` set
+                |swapChain|.{{GPUSwapChain/[[descriptor]]}}.{{GPUSwapChainDescriptor/size}} to
+                [|canvas|.width, |canvas|.height, 1]
 
             1. If |this|.{{GPUCanvasContext/[[currentSwapChain]]}} is not `null`, [$destroy the swap chain$].
             1. Set |this|.{{GPUCanvasContext/[[currentSwapChain]]}} to |swapChain|.
@@ -7908,9 +7905,14 @@ interface GPUCanvasContext {
                     1. If any of the following conditions are unsatisfied:
                         <div class=validusage>
                             - |device| is a [=valid=] {{GPUDevice}}.
-                            - [=Supported swap chain formats=] [=set/contains=] |descriptor|.{{GPUSwapChainDescriptor/format}}.
-                            - |descriptor|.{{GPUSwapChainDescriptor/width}} &le; |device|.{{GPUAdapterLimits/maxTextureDimension2D}}.
-                            - |descriptor|.{{GPUSwapChainDescriptor/height}} &le; |device|.{{GPUAdapterLimits/maxTextureDimension2D}}
+                            - [=Supported swap chain formats=] [=set/contains=]
+                                |descriptor|.{{GPUSwapChainDescriptor/format}}.
+                            - |descriptor|.{{GPUSwapChainDescriptor/size}}.[=Extent3D/width=] &le;
+                                |device|.{{GPUAdapterLimits/maxTextureDimension2D}}.
+                            - |descriptor|.{{GPUSwapChainDescriptor/size}}.[=Extent3D/height=] &le;
+                                |device|.{{GPUAdapterLimits/maxTextureDimension2D}}.
+                            - |descriptor|.{{GPUSwapChainDescriptor/size}}.[=Extent3D/depthOrArrayLayers=]
+                                is 1;
                         </div>
 
                         Then:
@@ -7963,8 +7965,7 @@ dictionary GPUSwapChainDescriptor : GPUObjectDescriptorBase {
     required GPUTextureFormat format;
     GPUTextureUsageFlags usage = 0x10;  // GPUTextureUsage.RENDER_ATTACHMENT
     GPUCanvasCompositingAlphaMode compositingAlphaMode = "opaque";
-    GPUIntegerCoordinate width;
-    GPUIntegerCoordinate height;
+    GPUExtent3D size;
 };
 </script>
 
@@ -7976,19 +7977,19 @@ and clamped-srgb: they're the same for SDR, but different for HDR).
 
 ### GPUSwapChain sizing ### {#swapchain-sizing}
 
-A {{GPUSwapChain}}'s {{GPUSwapChainDescriptor/width}} and {{GPUSwapChainDescriptor/height}} are
-immutable, set by the {{GPUSwapChainDescriptor}} passed to {{GPUCanvasContext/configureSwapChain()}}.
-If a {{GPUSwapChainDescriptor/width}} or {{GPUSwapChainDescriptor/height}} is not provided then
-the width or height attributes of the {{GPUCanvasContext}}.{{GPUCanvasContext/[[canvas]]}} at the
-time {{GPUCanvasContext/configureSwapChain()}} is called will be used. If the {{GPUSwapChain}}'s
-dimensions do not match the dimensions of the canvas the textures produced by the {{GPUSwapChain}}
+A {{GPUSwapChain}}'s {{GPUSwapChainDescriptor/size}} is immutable, set by the {{GPUSwapChainDescriptor}}
+passed to {{GPUCanvasContext/configureSwapChain()}}. If a {{GPUSwapChainDescriptor/size}} is not
+specified then the width and height attributes of the {{GPUCanvasContext}}.{{GPUCanvasContext/[[canvas]]}}
+at the time {{GPUCanvasContext/configureSwapChain()}} is called will be used. If the {{GPUSwapChain}}'s
+size does not match the dimensions of the canvas the textures produced by the {{GPUSwapChain}}
 will be scaled to fit the canvas element.
 
 <div class="note">
     Note: Unlike `'webgl'` or `'2d'` contexts, `width` and `height` attributes of canvases with a
     `'gpupresent'` context only affect:
-    - Default layout size if not overridden by CSS.
-    - Default size in {{GPUCanvasContext/configureSwapChain()}} if not overridden.
+    - Default layout size, if not overridden by CSS.
+    - Default {{GPUSwapChainDescriptor/size}} when calling {{GPUCanvasContext/configureSwapChain()}},
+        if not overridden.
 </div>
 
 In order to match the dimensions of the canvas after it is resized, the {{GPUSwapChain}} must be
@@ -8011,9 +8012,12 @@ Once the {{GPUSwapChain}} is reconfigured the previously returned {{GPUSwapChain
                 if (entry != canvas) { continue; }
                 swapChain = context.configureSwapChain({
                     device: someDevice,
-                    // This reports the size of the canvas element in pixels
-                    width: entry.devicePixelContentBoxSize[0].inlineSize,
-                    height: entry.devicePixelContentBoxSize[0].blockSize,
+                    format: 'bgra8unorm',
+                    size: {
+                        // This reports the size of the canvas element in pixels
+                        width: entry.devicePixelContentBoxSize[0].inlineSize,
+                        height: entry.devicePixelContentBoxSize[0].blockSize,
+                    }
                 });
             }
         });
@@ -8100,10 +8104,8 @@ GPUSwapChain includes GPUObjectBase;
             1. Return a new [=invalid=] {{GPUTexture}}.
         1. Let |device| be |swapChain|.{{GPUSwapChain/[[descriptor]]}}.{{GPUSwapChainDescriptor/device}}.
         1. Let |descriptor| be a new {{GPUTextureDescriptor}}.
-        1. Set |descriptor|.{{GPUTextureDescriptor/size}} to [
-            |swapChain|.{{GPUSwapChain/[[descriptor]]}}.{{GPUSwapChainDescriptor/width}},
-            |swapChain|.{{GPUSwapChain/[[descriptor]]}}.{{GPUSwapChainDescriptor/height}},
-            1].
+        1. Set |descriptor|.{{GPUTextureDescriptor/size}} to
+            |swapChain|.{{GPUSwapChain/[[descriptor]]}}.{{GPUSwapChainDescriptor/size}}.
         1. Set |descriptor|.{{GPUTextureDescriptor/format}} to
             |swapChain|.{{GPUSwapChain/[[descriptor]]}}.{{GPUSwapChainDescriptor/format}}.
         1. Set |descriptor|.{{GPUTextureDescriptor/usage}} to

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7862,6 +7862,10 @@ interface GPUCanvasContext {
     : <dfn>\[[canvas]]</dfn> of type {{HTMLCanvasElement}}.
     ::
         The canvas this context was created from.
+
+    : <dfn>\[[currentSwapChain]]</dfn> of type {{GPUSwapChain}}, initially `null`.
+    ::
+        The currently configured {{GPUSwapChain}} for this context.
 </dl>
 
 {{GPUCanvasContext}} has the following methods:
@@ -7884,16 +7888,37 @@ interface GPUCanvasContext {
 
             **Returns:** {{GPUSwapChain}}
 
+            1. Let |swapChain| be a new valid {{GPUSwapChain}}.
+            1. Let |device| be |descriptor|.{{GPUSwapChainDescriptor/device}};
+            1. Let |canvas| be |this|.{{GPUCanvasContext/[[canvas]]}}.
+            1. Set |swapChain|.{{GPUSwapChain/[[context]]}} to |this|.
+            1. Set |swapChain|.{{GPUSwapChain/[[descriptor]]}} to |descriptor|.
+            1. If |descriptor|.{{GPUSwapChainDescriptor/width}} is `0` set
+                |swapChain|.{{GPUSwapChain/[[descriptor]]}}.{{GPUSwapChainDescriptor/width}} to
+                |canvas|.width.
+            1. If |descriptor|.{{GPUSwapChainDescriptor/height}} is `0` set
+                |swapChain|.{{GPUSwapChain/[[descriptor]]}}.{{GPUSwapChainDescriptor/height}} to
+                |canvas|.height.
+
+            1. If |this|.{{GPUCanvasContext/[[currentSwapChain]]}} is not `null`, [$destroy the swap chain$].
+            1. Set |this|.{{GPUCanvasContext/[[currentSwapChain]]}} to |swapChain|.
+
             1. Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
-                    1. If any of the following conditions are unsatisfied, generate a validation error and stop.
+                    1. If any of the following conditions are unsatisfied:
                         <div class=validusage>
-                            - |descriptor|.{{GPUSwapChainDescriptor/device}} is a [=valid=] {{GPUDevice}}.
+                            - |device| is a [=valid=] {{GPUDevice}}.
                             - [=Supported swap chain formats=] [=set/contains=] |descriptor|.{{GPUSwapChainDescriptor/format}}.
+                            - |descriptor|.{{GPUSwapChainDescriptor/width}} &le; |device|.{{GPUAdapterLimits/maxTextureDimension2D}}.
+                            - |descriptor|.{{GPUSwapChainDescriptor/height}} &le; |device|.{{GPUAdapterLimits/maxTextureDimension2D}}
                         </div>
 
-                    Issue: Describe remaining {{GPUCanvasContext/configureSwapChain()}} algorithm steps.
+                        Then:
+                            1. Generate a {{GPUValidationError}} in the current scope with appropriate
+                                error message.
+                            1. Make |swapChain| [=invalid=] and return |swapChain|.
                 </div>
+            1. Return |swapChain|.
         </div>
 
     : <dfn>getSwapChainPreferredFormat(adapter)</dfn>
@@ -7938,6 +7963,8 @@ dictionary GPUSwapChainDescriptor : GPUObjectDescriptorBase {
     required GPUTextureFormat format;
     GPUTextureUsageFlags usage = 0x10;  // GPUTextureUsage.RENDER_ATTACHMENT
     GPUCanvasCompositingAlphaMode compositingAlphaMode = "opaque";
+    GPUIntegerCoordinate width = 0;
+    GPUIntegerCoordinate height = 0;
 };
 </script>
 
@@ -7946,6 +7973,46 @@ Initially, for SDR, it can default to simply "srgb".
 When we add HDR canvas output (pixel values > 1), some clarification may be needed depending on
 upstream changes to canvas for color and HDR (e.g. to make sure we choose between extended-srgb
 and clamped-srgb: they're the same for SDR, but different for HDR).
+
+### GPUSwapChain sizing ### {#swapchain-sizing}
+
+A {{GPUSwapChain}}'s {{GPUSwapChainDescriptor/width}} and {{GPUSwapChainDescriptor/height}} are
+immutable, set by the {{GPUSwapChainDescriptor}} passed to {{GPUCanvasContext/configureSwapChain()}}.
+If a {{GPUSwapChainDescriptor/width}} or {{GPUSwapChainDescriptor/height}} is not provided then
+the width or height attributes of the {{GPUCanvasContext}}.{{GPUCanvasContext/[[canvas]]}} at the
+time {{GPUCanvasContext/configureSwapChain()}} is called will be used. If the {{GPUSwapChain}}'s
+dimensions do not match the dimensions of the canvas the textures produced by the {{GPUSwapChain}}
+will be scaled to fit the canvas element.
+
+In order to match the dimensions of the canvas after it is resized, the {{GPUSwapChain}} must be
+reconfigured by calling {{GPUCanvasContext/configureSwapChain()}} again with the new dimensions.
+Once the {{GPUSwapChain}} is reconfigured the previously returned {{GPUSwapChain}} will become
+[=invalid=] and only the newly returned {{GPUSwapChain}} may be used.
+
+<div class="example">
+    Reconfigure a {{GPUSwapChain}} in response to canvas resize, monitored using
+    [ResizeObserver](https://www.w3.org/TR/resize-observer/) to get the exact pixel dimensions of
+    the canvas:
+
+    <pre highlight="js">
+        const canvas = document.createElement('canvas');
+        const context =  canvas.getContext('gpupresent');
+        let swapChain = null;
+
+        const resizeObserver = new ResizeObserver(entries => {
+            for (const entry of entries) {
+                if (entry != canvas) { continue; }
+                swapChain = context.configureSwapChain({
+                    device: someDevice,
+                    // This reports the size of the canvas element in pixels
+                    width: entry.devicePixelContentBoxSize[0].inlineSize,
+                    height: entry.devicePixelContentBoxSize[0].blockSize,
+                });
+            }
+        });
+        resizeObserver.observe(canvas);
+    </pre>
+</div>
 
 ## GPUSwapChain ## {#swapchain}
 
@@ -8021,10 +8088,12 @@ GPUSwapChain includes GPUObjectBase;
     To <dfn abstract-op lt='allocating a new swap chain texture'>Allocate a new swap chain texture</dfn>
     for {{GPUSwapChain}} |swapChain| run the following steps:
 
-        1. Let |canvas| be |swapChain|.{{GPUSwapChain/[[context]]}}.{{GPUCanvasContext/[[canvas]]}}.
         1. Let |device| be |swapChain|.{{GPUSwapChain/[[descriptor]]}}.{{GPUSwapChainDescriptor/device}}.
         1. Let |descriptor| be a new {{GPUTextureDescriptor}}.
-        1. Set |descriptor|.{{GPUTextureDescriptor/size}} to [|canvas|.width, |canvas|.height, 1].
+        1. Set |descriptor|.{{GPUTextureDescriptor/size}} to [
+            |swapChain|.{{GPUSwapChain/[[descriptor]]}}.{{GPUSwapChainDescriptor/width}},
+            |swapChain|.{{GPUSwapChain/[[descriptor]]}}.{{GPUSwapChainDescriptor/height}},
+            1].
         1. Set |descriptor|.{{GPUTextureDescriptor/format}} to
             |swapChain|.{{GPUSwapChain/[[descriptor]]}}.{{GPUSwapChainDescriptor/format}}.
         1. Set |descriptor|.{{GPUTextureDescriptor/usage}} to
@@ -8035,6 +8104,16 @@ GPUSwapChain includes GPUObjectBase;
             its GPU memory may be re-used.</div>
         1. Ensure |texture| is cleared to `(0, 0, 0, 0)`.
         1. Return |texture|.
+</div>
+
+<div algorithm>
+    To <dfn abstract-op lt='destroy the swap chain'>Destroy a swap chain</dfn>
+    for {{GPUSwapChain}} |swapChain| run the following steps:
+
+        1. If |swapChain|.{{GPUSwapChain/[[currentTexture]]}} is not `null` call
+            {{GPUTexture/destroy()}} on |swapChain|.{{GPUSwapChain/[[currentTexture]]}}.
+        1. Set |swapChain|.{{GPUSwapChain/[[currentTexture]]}} to `null`.
+        1. Make |swapChain| [=invalid=].
 </div>
 
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8100,7 +8100,7 @@ GPUSwapChain includes GPUObjectBase;
     for {{GPUSwapChain}} |swapChain| run the following steps:
 
         1. If |swapChain| is [=invalid=]:
-            1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
+            1. Generate a {{GPUValidationError}} in the current scope with an appropriate error message.
             1. Return a new [=invalid=] {{GPUTexture}}.
         1. Let |device| be |swapChain|.{{GPUSwapChain/[[descriptor]]}}.{{GPUSwapChainDescriptor/device}}.
         1. Let |descriptor| be a new {{GPUTextureDescriptor}}.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7893,17 +7893,17 @@ interface GPUCanvasContext {
             1. Let |canvas| be |this|.{{GPUCanvasContext/[[canvas]]}}.
             1. Set |swapChain|.{{GPUSwapChain/[[context]]}} to |this|.
             1. Set |swapChain|.{{GPUSwapChain/[[descriptor]]}} to |descriptor|.
-            1. If |descriptor|.{{GPUSwapChainDescriptor/width}} is `0` set
+            1. If |descriptor|.{{GPUSwapChainDescriptor/width}} is `undefined` set
                 |swapChain|.{{GPUSwapChain/[[descriptor]]}}.{{GPUSwapChainDescriptor/width}} to
                 |canvas|.width.
-            1. If |descriptor|.{{GPUSwapChainDescriptor/height}} is `0` set
+            1. If |descriptor|.{{GPUSwapChainDescriptor/height}} is `undefined` set
                 |swapChain|.{{GPUSwapChain/[[descriptor]]}}.{{GPUSwapChainDescriptor/height}} to
                 |canvas|.height.
 
             1. If |this|.{{GPUCanvasContext/[[currentSwapChain]]}} is not `null`, [$destroy the swap chain$].
             1. Set |this|.{{GPUCanvasContext/[[currentSwapChain]]}} to |swapChain|.
 
-            1. Issue the following steps on the [=Device timeline=] of |this|:
+            1. Issue the following steps on the [=Device timeline=] of |device|:
                 <div class=device-timeline>
                     1. If any of the following conditions are unsatisfied:
                         <div class=validusage>
@@ -7963,8 +7963,8 @@ dictionary GPUSwapChainDescriptor : GPUObjectDescriptorBase {
     required GPUTextureFormat format;
     GPUTextureUsageFlags usage = 0x10;  // GPUTextureUsage.RENDER_ATTACHMENT
     GPUCanvasCompositingAlphaMode compositingAlphaMode = "opaque";
-    GPUIntegerCoordinate width = 0;
-    GPUIntegerCoordinate height = 0;
+    GPUIntegerCoordinate width;
+    GPUIntegerCoordinate height;
 };
 </script>
 
@@ -7983,6 +7983,13 @@ the width or height attributes of the {{GPUCanvasContext}}.{{GPUCanvasContext/[[
 time {{GPUCanvasContext/configureSwapChain()}} is called will be used. If the {{GPUSwapChain}}'s
 dimensions do not match the dimensions of the canvas the textures produced by the {{GPUSwapChain}}
 will be scaled to fit the canvas element.
+
+<div class="note">
+    Note: Unlike `'webgl'` or `'2d'` contexts, `width` and `height` attributes of canvases with a
+    `'gpupresent'` context only affect:
+    - Default layout size if not overridden by CSS.
+    - Default size in {{GPUCanvasContext/configureSwapChain()}} if not overridden.
+</div>
 
 In order to match the dimensions of the canvas after it is resized, the {{GPUSwapChain}} must be
 reconfigured by calling {{GPUCanvasContext/configureSwapChain()}} again with the new dimensions.
@@ -8088,6 +8095,9 @@ GPUSwapChain includes GPUObjectBase;
     To <dfn abstract-op lt='allocating a new swap chain texture'>Allocate a new swap chain texture</dfn>
     for {{GPUSwapChain}} |swapChain| run the following steps:
 
+        1. If |swapChain| is [=invalid=]:
+            1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
+            1. Return a new [=invalid=] {{GPUTexture}}.
         1. Let |device| be |swapChain|.{{GPUSwapChain/[[descriptor]]}}.{{GPUSwapChainDescriptor/device}}.
         1. Let |descriptor| be a new {{GPUTextureDescriptor}}.
         1. Set |descriptor|.{{GPUTextureDescriptor/size}} to [


### PR DESCRIPTION
Fixes #1691
Closes #1779

This changes updates the logic for GPUSwapChain, changing it to accept a width and height on creation that is then immutable until the swap chain has been reconfigured. The width and height will default to the canvas.width and canvas.height attributes if not provided explicitly.

This PR also fleshes out a bit of the `configureSwapChain` algorithm that was previously underspecified and adds an example demonstrating one way to respond to canvas resizes (using [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver), since that's the new hotness.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/1738.html" title="Last updated on Jun 2, 2021, 8:34 PM UTC (ac23886)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1738/de6eefd...ac23886.html" title="Last updated on Jun 2, 2021, 8:34 PM UTC (ac23886)">Diff</a>