### PR TITLE
Remove texture_multisampled_2d_array builtins

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6819,7 +6819,6 @@ textureDimensions(t: texture_cube<T>, level: i32) -> vec3<i32>
 textureDimensions(t: texture_cube_array<T>) -> vec3<i32>
 textureDimensions(t: texture_cube_array<T>, level: i32) -> vec3<i32>
 textureDimensions(t: texture_multisampled_2d<T>)-> vec2<i32>
-textureDimensions(t: texture_multisampled_2d_array<T>)-> vec2<i32>
 textureDimensions(t: texture_depth_2d) -> vec2<i32>
 textureDimensions(t: texture_depth_2d, level: i32) -> vec2<i32>
 textureDimensions(t: texture_depth_2d_array) -> vec2<i32>
@@ -6862,7 +6861,6 @@ textureLoad(t: texture_2d<T>, coords: vec2<i32>, level: i32) -> vec4<T>
 textureLoad(t: texture_2d_array<T>, coords: vec2<i32>, array_index: i32, level: i32) -> vec4<T>
 textureLoad(t: texture_3d<T>, coords: vec3<i32>, level: i32) -> vec4<T>
 textureLoad(t: texture_multisampled_2d<T>, coords: vec2<i32>, sample_index: i32)-> vec4<T>
-textureLoad(t: texture_multisampled_2d_array<T>, coords: vec2<i32>, array_index: i32, sample_index: i32)-> vec4<T>
 textureLoad(t: texture_depth_2d, coords: vec2<i32>, level: i32) -> f32
 textureLoad(t: texture_depth_2d_array, coords: vec2<i32>, array_index: i32, level: i32) -> f32
 textureLoad(t: [[access(read)]] texture_storage_1d<F>, coords: i32) -> vec4<T>
@@ -6906,7 +6904,6 @@ Returns the number of layers (elements) of an array texture.
 ```rust
 textureNumLayers(t: texture_2d_array<T>) -> i32
 textureNumLayers(t: texture_cube_array<T>) -> i32
-textureNumLayers(t: texture_multisampled_2d_array<T>) -> i32
 textureNumLayers(t: texture_depth_2d_array) -> i32
 textureNumLayers(t: texture_depth_cube_array) -> i32
 textureNumLayers(t: texture_storage_2d_array<F>) -> i32
@@ -6960,7 +6957,6 @@ Returns the number samples per texel in a multisampled texture.
 
 ```rust
 textureNumSamples(t: texture_multisampled_2d<T>) -> i32
-textureNumSamples(t: texture_multisampled_2d_array<T>) -> i32
 ```
 
 **Parameters:**


### PR DESCRIPTION
This type does not exist in WGSL.