### PR TITLE
Allow non-overridable constants in workgroup_size

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -514,7 +514,7 @@ literal_or_ident
     <td>One, two or three parameters.
 
     Each parameter is either a positive i32 literal or the name of a
-    [=pipeline-overridable=] constant of i32 type.
+    module-scope constant of i32 type.
     <td>Must only be applied to a [=compute shader stage=] function declaration.
 
     Specifies the x, y, and z dimensions of the [=workgroup grid=] for the compute shader.


### PR DESCRIPTION
There's no good reason to only allow constants that are overridable.