### PR TITLE
Remove redundant type info on executionTime

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5035,7 +5035,7 @@ GPUCommandBuffer includes GPUObjectBase;
 {{GPUCommandBuffer}} has the following attributes:
 
 <dl dfn-type=attribute dfn-for="GPUCommandBuffer">
-    : <dfn>executionTime</dfn> of type Promise<{{double}}>, readonly
+    : <dfn>executionTime</dfn>
     ::
         The total time, in seconds, that the GPU took to execute this command buffer.
 


### PR DESCRIPTION
Previously renders incorrectly as:
> executionTime of type Promise<, of type Promise<double>, readonlydouble>, readonly

Now:
> executionTime, of type Promise<double>, readonly


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/1744.html" title="Last updated on May 19, 2021, 1:03 AM UTC (a148c00)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1744/29b715b...a148c00.html" title="Last updated on May 19, 2021, 1:03 AM UTC (a148c00)">Diff</a>