### PR TITLE
Add some text to describe function variables going out of scope

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2954,6 +2954,13 @@ The variable's [=store type=] must be a [=atomic-free=] [=plain type=].
 A variable or constant declared in the first clause of a `for` statement is available for use in the second
 and third clauses and in the body of the `for` statement.
 
+An instance of a function scope variable is a [=dynamic context=]. Each
+variable that is [=in scope=] for some invocation has a unique [=memory view=].
+When a variable goes out of scope, the [=memory location|memory locations=]
+associated with its memory view are reclaimed.
+New instances of an out of scope variable are not guaranteed to occupy the same
+memory locations.
+Other variable instances may reuse the memory locations of an out of scope variable.
 
 ## Never-alias assumption TODO ## {#never-alias-assumption}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2675,7 +2675,7 @@ then its reference type is ref&lt;*S*,*T*&gt;.
 A <dfn dfn noexport>variable declaration</dfn>:
 
 * Determines the variable’s name, storage class, and store type (and hence its [=reference type=]).
-* Ensures the execution environment allocates storage for a value of the store type, for the lifetime of the variable.
+* Ensures the execution environment allocates storage for a value of the store type, for the [=lifetime=] of the variable.
 * Optionally have an *initializer* expression, if the variable is in the [=storage classes/private=] or [=storage classes/function=] storage classes.
     If present, the initializer expression must evaluate to the variable's store type.
 
@@ -2709,7 +2709,12 @@ Variables in the [=storage classes/storage=] storage class and variables with a
 [storage texture](#texture-storage) type must have an [=access=] attribute
 applied to the store type.
 
+The <dfn noexport>lifetime</dfn> of a variable is determined by its scope.
+It begins at the declaration of the variable and ends when the variable is no
+longer [=in scope=].
+Therefore, the lifetime of a [=module scope=] variable is entire program.
 Two variables with overlapping lifetimes will not have overlapping storage.
+When a variables'lifetime ends, its storage may be used for another variable.
 
 When a variable is created, its storage contains an initial value as follows:
 
@@ -2954,13 +2959,12 @@ The variable's [=store type=] must be a [=atomic-free=] [=plain type=].
 A variable or constant declared in the first clause of a `for` statement is available for use in the second
 and third clauses and in the body of the `for` statement.
 
-An instance of a function scope variable is a [=dynamic context=]. Each
-variable that is [=in scope=] for some invocation has a unique [=memory view=].
-When a variable goes out of scope, the [=memory location|memory locations=]
-associated with its memory view are reclaimed.
-New instances of an out of scope variable are not guaranteed to occupy the same
-memory locations.
-Other variable instances may reuse the memory locations of an out of scope variable.
+An instance of a function scope variable is a [=dynamic context=].
+Each variable that is [=in scope=] for some invocation has an overlapping
+[=lifetime=] and, therefore, has non-overlapping storage.
+Variables with non-overlapping lifetimes may reuse the storage of previous
+variables; however, new instances of the same variable are not guaranteed to
+use the same storage.
 
 ## Never-alias assumption TODO ## {#never-alias-assumption}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2709,12 +2709,20 @@ Variables in the [=storage classes/storage=] storage class and variables with a
 [storage texture](#texture-storage) type must have an [=access=] attribute
 applied to the store type.
 
-The <dfn noexport>lifetime</dfn> of a variable is determined by its scope.
-It begins at the declaration of the variable and ends when the variable is no
-longer [=in scope=].
-Therefore, the lifetime of a [=module scope=] variable is entire program.
+The <dfn noexport>lifetime</dfn> of a variable is the period during shader
+execution for which the variable exists.
+The lifetime of a [=module scope=] variable is the entire execution of the shader stage.
+
+For a [=function scope=] variable, each invocation has its own indepdendent
+version of the variable.
+The lifetime of the variable is determined by its scope:
+* It begins when control enters the variable's decalaration.
+* It includes the entire execution of any function called from within the variable's scope.
+* It ends when control leaves the variable's scope, other than calling a function from
+    within the variable's scope.
+
 Two variables with overlapping lifetimes will not have overlapping storage.
-When a variables'lifetime ends, its storage may be used for another variable.
+When a variable's lifetime ends, its storage may be used for another variable.
 
 When a variable is created, its storage contains an initial value as follows:
 


### PR DESCRIPTION
Covers that variables are a dynamic context and that instances of those variables may mix and match memory locations with other out of scope variable, but all in scope variable must have unique memory views.