### PR TITLE
[editorial] Remove type shorthands

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7,6 +7,11 @@ Group: webgpu
 ED: https://gpuweb.github.io/gpuweb/wgsl/
 TR: https://www.w3.org/TR/WGSL/
 Repository: gpuweb/gpuweb
+Text Macro: INT i32 or u32
+Text Macro: UNSIGNEDINTEGRAL u32 or vec|N|&lt;u32&gt;
+Text Macro: SIGNEDINTEGRAL i32 or vec|N|&lt;i32&gt;
+Text Macro: INTEGRAL i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;
+Text Macro: FLOATING f32 or vec|N|&lt;f32&gt;
 Ignored Vars: i, e, e1, e2, e3, N, M, v, Stride, Offset, Align, Extent, S, T, T1
 
 !Participate: <a href="https://github.com/gpuweb/gpuweb/issues/new?labels=wgsl">File an issue</a> (<a href="https://github.com/gpuweb/gpuweb/issues?q=is%3Aissue+is%3Aopen+label%3Awgsl">open issues</a>)
@@ -3459,7 +3464,7 @@ The result type depends on the number of letters provided. Assuming a `vec4<f32>
        <td>Select the fourth component of |e|<br>
            (OpCompositeExtract with selection index 3)
   <tr algorithm="vector indexed component selection"><td>|e|: vec|N|&lt;|T|&gt;<br>
-          |i|: i32 or u32
+          |i|: [INT]
        <td class="nowrap">
            |e|[|i|]: |T|
        <td>Select the |i|'<sup>th</sup> component of vector<br>
@@ -3597,7 +3602,7 @@ Issue: Which index is used when it's out of bounds?
            (OpAccessChain with index value 3)
   <tr algorithm="vector indexed component reference selection">
        <td>|r|: ref&lt;|SC|,vec|N|&lt;|T|&gt;&gt;<br>
-          |i|: i32 or u32
+          |i|: [INT]
        <td class="nowrap">
            |r|[|i|]: ref&lt;|SC|,|T|&gt;
        <td>Compute a reference to the |i|'<sup>th</sup> component of the vector referenced by the reference |r|.<br>
@@ -3617,7 +3622,7 @@ Issue: Which index is used when it's out of bounds?
   <tr algorithm="matrix indexed column vector selection">
        <td class="nowrap">
           |e|: mat|N|x|M|&lt;|T|&gt;<br>
-          |i|: i32 or u32
+          |i|: [INT]
        <td class="nowrap">
            |e|[|i|]: vec|M|&lt;|T|&gt;
        <td>The result is the |i|'<sup>th</sup> column vector of |e|.<br>
@@ -3633,7 +3638,7 @@ Issue: Which index is used when it's out of bounds?
   <tr algorithm="matrix indexed column vector reference selection">
        <td class="nowrap">
           |r|: ref&lt;|SC|,mat|N|x|M|&lt;|T|&gt;&gt;<br>
-          |i|: i32 or u32
+          |i|: [INT]
        <td class="nowrap">
            |r|[|i|]: ref&lt;vec|M|&lt;|SC|,|T|&gt;&gt;
        <td>Compute a reference to the |i|'<sup>th</sup> column vector of the matrix referenced by the reference |r|.<br>
@@ -3653,7 +3658,7 @@ Issue: Which index is used when it's out of bounds?
   <tr algorithm="sized array indexed element selection">
        <td class="nowrap">
           |e|: array&lt;|T|,|N|&gt;<br>
-          |i|: i32 or u32
+          |i|: [INT]
        <td class="nowrap">
            |e|[|i|]: |T|
        <td>The result is the value of the |i|'<sup>th</sup> element of the array value |e|.<br>
@@ -3669,7 +3674,7 @@ Issue: Which index is used when it's out of bounds?
   <tr algorithm="sized array indexed reference selection">
        <td class="nowrap">
           |r|: ref&lt;|SC|,array&lt;|T|,|N|&gt;&gt;<br>
-          |i|: i32 or u32
+          |i|: [INT]
        <td class="nowrap">
            |r|[|i|]: ref&lt;|SC|,|T|&gt;
        <td>Compute a reference to the |i|'<sup>th</sup> element of the array referenced by the reference |r|.<br>
@@ -3679,7 +3684,7 @@ Issue: Which index is used when it's out of bounds?
            (OpAccessChain)
   <tr algorithm="array indexed reference selection">
        <td>|r|: ref&lt;|SC|,array&lt;|T|&gt;&gt;<br>
-          |i|: i32 or u32
+          |i|: [INT]
        <td class="nowrap">
            |r|[|i|]: ref&lt;|SC|,|T|&gt;
        <td>Compute a reference to the |i|'<sup>th</sup> element of the runtime-sized array referenced by the reference |r|.<br>
@@ -3772,11 +3777,11 @@ Issue: Which index is used when it's out of bounds?
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr algorithm="integer negation"><td>|e|: |T|<br>
-  |T| is i32 or vec|N|&lt;i32&gt;
+  |T| is [SIGNEDINTEGRAL]
   <td>`-`|e|`:` |T|
   <td>Signed integer negation. [=Component-wise=] when |T| is a vector. (OpSNegate)
 
-  <tr algorithm="floating point negation"><td>|e|: |T|, |T| is f32 or vec|N|&lt;f32&gt;
+  <tr algorithm="floating point negation"><td>|e|: |T|<br>|T| is [FLOATING]
   <td>`-`|e|`:` |T|
   <td>Floating point negation. [=Component-wise=] when |T| is a vector. (OpFNegate)
 </table>
@@ -3788,55 +3793,55 @@ Issue: Which index is used when it's out of bounds?
   </thead>
 
   <tr algorithm="integer addition">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [INTEGRAL]
     <td>|e1| `+` |e2| : |T|
     <td>Integer addition, modulo 2<sup>32</sup>. [=Component-wise=] when |T| is a vector. (OpIAdd)
   <tr algorithm="floating point addition">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [FLOATING]
     <td>|e1| `+` |e2| : |T|
     <td>Floating point addition. [=Component-wise=] when |T| is a vector. (OpFAdd)
 
   <tr algorithm="integer subtraction">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [INTEGRAL]
     <td>|e1| `-` |e2| : |T|
     <td>Integer subtraction, modulo 2<sup>32</sup>. [=Component-wise=] when |T| is a vector. (OpISub)
   <tr algorithm="floating point subtraction">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [FLOATING]
     <td>|e1| `-` |e2| : |T|
     <td>Floating point subtraction. [=Component-wise=] when |T| is a vector. (OpFSub)
 
   <tr algorithm="integer multiplication">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [INTEGRAL]
     <td>|e1| `*` |e2| : |T|
     <td>Integer multiplication, modulo 2<sup>32</sup>. [=Component-wise=] when |T| is a vector. (OpIMul)
   <tr algorithm="floating point multiplication">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [FLOATING]
     <td>|e1| `*` |e2| : |T|
     <td>Floating point multiplication. [=Component-wise=] when |T| is a vector. (OpFMul)
 
   <tr algorithm="signed integer division">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is i32 or vec|N|&lt;i32&gt;
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [SIGNEDINTEGRAL]
     <td>|e1| `/` |e2| : |T|
     <td>Signed integer division. [=Component-wise=] when |T| is a vector. (OpSDiv)
   <tr algorithm="unsigned integer division">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is u32 or vec|N|&lt;u32&gt;
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [UNSIGNEDINTEGRAL]
     <td>|e1| `/` |e2| : |T|
     <td>Unsigned integer division. [=Component-wise=] when |T| is a vector. (OpUDiv)
   <tr algorithm="floating point division">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [FLOATING]
     <td>|e1| `/` |e2| : |T|
     <td>Floating point division. [=Component-wise=] when |T| is a vector. (OpFDiv)
 
   <tr algorithm="signed integer remainder">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is i32 or vec|N|&lt;i32&gt;
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [SIGNEDINTEGRAL]
     <td>|e1| `%` |e2| : |T|
     <td>Signed integer remainder. [=Component-wise=] when |T| is a vector. (OpSMod)
   <tr algorithm="unsigned integer modulus">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is u32 or vec|N|&lt;u32&gt;
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [UNSIGNEDINTEGRAL]
     <td>|e1| `%` |e2| : |T|
     <td>Signed integer remainder, where sign of non-zero result matches sign of |e2|. [=Component-wise=] when |T| is a vector. (OpUMod)
   <tr algorithm="floating point remainder">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [FLOATING]
     <td>|e1| `%` |e2| : |T|
     <td>Floating point remainder, where sign of non-zero result matches sign of |e2|. [=Component-wise=] when |T| is a vector. (OpFMod)
 
@@ -3949,101 +3954,101 @@ Issue: Which index is used when it's out of bounds?
 
   <tr algorithm="integer equality">
     <td>|e1|: |TI|<br>|e2|: |TI|<br>
-    |TI| is i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;<br>
+    |TI| is [INTEGRAL]<br>
     |TB| is bool if |TI| is scalar, or<br>
     vec|N|&lt;bool&gt; if |TI| is a vector
     <td class="nowrap">|e1| `==` |e2|`:` |TB|
     <td>Equality. [=Component-wise=] when |TI| is a vector. (OpIEqual)
   <tr algorithm="integer inequality">
     <td>|e1|: |TI|<br>|e2|: |TI|<br>
-    |TI| is i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;<br>
+    |TI| is [INTEGRAL]<br>
     |TB| is bool if |TI| is scalar, or<br>
     vec|N|&lt;bool&gt; if |TI| is a vector
     <td class="nowrap">|e1| `!=` |e2|`:` |TB|
     <td>Inequality. [=Component-wise=] when |TI| is a vector. (OpINotEqual)
 
   <tr algorithm="signed integer less than">
-    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is i32 or vec|N|&lt;i32&gt;<br>
+    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is [SIGNEDINTEGRAL]<br>
     |TB| is bool if |TI| is scalar, or<br>
     vec|N|&lt;bool&gt; if |TI| is a vector
     <td class="nowrap">|e1| `<` |e2|`:` |TB|
     <td>Less than. [=Component-wise=] when |TI| is a vector. (OpSLessThan)
   <tr algorithm="signed integer less than equal">
-    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is i32 or vec|N|&lt;i32&gt;<br>
+    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is [SIGNEDINTEGRAL]<br>
     |TB| is bool if |TI| is scalar, or<br>
     vec|N|&lt;bool&gt; if |TI| is a vector
     <td class="nowrap">|e1| `<=` |e2|`:` |TB|
     <td>Less than or equal. [=Component-wise=] when |TI| is a vector. (OpSLessThanEqual)
   <tr algorithm="signed integer greater than">
-    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is i32 or vec|N|&lt;i32&gt;<br>
+    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is [SIGNEDINTEGRAL]<br>
     |TB| is bool if |TI| is scalar, or<br>
     vec|N|&lt;bool&gt; if |TI| is a vector
     <td class="nowrap">|e1| `<` |e2|`:` |TB|
     <td>Greater than. [=Component-wise=] when |TI| is a vector. (OpSGreaterThan)
   <tr algorithm="signed integer greater than equal">
-    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is i32 or vec|N|&lt;i32&gt;<br>
+    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is [SIGNEDINTEGRAL]<br>
     |TB| is bool if |TI| is scalar, or<br>
     vec|N|&lt;bool&gt; if |TI| is a vector
     <td class="nowrap">|e1| `<=` |e2|`:` |TB|
     <td>Greater than or equal. [=Component-wise=] when |TI| is a vector. (OpSGreaterThanEqual)
 
   <tr algorithm="unsigned integer less than">
-    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is u32 or vec|N|&lt;u32&gt;<br>
+    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is [UNSIGNEDINTEGRAL]<br>
     |TB| is bool if |TI| is scalar, or<br>
     vec|N|&lt;bool&gt; if |TI| is a vector
     <td class="nowrap">|e1| `<` |e2|`:` |TB|
     <td>Less than. [=Component-wise=] when |TI| is a vector. (OpULessThan)
   <tr algorithm="unsigned integer less than equal">
-    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is u32 or vec|N|&lt;u32&gt;<br>
+    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is [UNSIGNEDINTEGRAL]<br>
     |TB| is bool if |TI| is scalar, or<br>
     vec|N|&lt;bool&gt; if |TI| is a vector
     <td class="nowrap">|e1| `<=` |e2|`:` |TB|
     <td>Less than or equal. [=Component-wise=] when |TI| is a vector. (OpULessThanEqual)
   <tr algorithm="unsigned integer greater than">
-    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is u32 or vec|N|&lt;u32&gt;<br>
+    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is [UNSIGNEDINTEGRAL]<br>
     |TB| is bool if |TI| is scalar, or<br>
     vec|N|&lt;bool&gt; if |TI| is a vector
     <td class="nowrap">|e1| `<` |e2|`:` |TB|
     <td>Greater than. [=Component-wise=] when |TI| is a vector. (OpUGreaterThan)
   <tr algorithm="unsigned integer greater than equal">
-    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is u32 or vec|N|&lt;u32&gt;<br>
+    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is [UNSIGNEDINTEGRAL]<br>
     |TB| is bool if |TI| is scalar, or<br>
     vec|N|&lt;bool&gt; if |TI| is a vector
     <td class="nowrap">|e1| `<=` |e2|`:` |TB|
     <td>Greater than or equal. [=Component-wise=] when |TI| is vector. (OpUGreaterThanEqual)
 
   <tr algorithm="floating point equality">
-    <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is f32 or vec|N|&lt;f32&gt;<br>
+    <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is [FLOATING]<br>
     |TB| is bool if |TF| is scalar, or<br>
     vec|N|&lt;bool&gt; if |TF| is a vector.
     <td class="nowrap">|e1| == |e2|: |TB|
     <td>Equality. [=Component-wise=] when |TF| is a vector. (OpFOrdEqual)
   <tr algorithm="floating point inequality">
-    <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is f32 or vec|N|&lt;f32&gt;<br>
+    <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is [FLOATING]<br>
     |TB| is bool if |TF| is scalar, or<br>
     vec|N|&lt;bool&gt; if |TF| is a vector.
     <td class="nowrap">|e1| != |e2|: |TB|
     <td>Inequality. [=Component-wise=] when |TF| is a vector. (OpFOrdEqual)
   <tr algorithm="floating point less than">
-    <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is f32 or vec|N|&lt;f32&gt;<br>
+    <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is [FLOATING]<br>
     |TB| is bool if |TF| is scalar, or<br>
     vec|N|&lt;bool&gt; if |TF| is a vector.
     <td class="nowrap">|e1| < |e2|: |TB|
     <td>Less than. [=Component-wise=] when |TF| is a vector. (OpFOrdLessThan)
   <tr algorithm="floating point less than equal">
-    <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is f32 or vec|N|&lt;f32&gt;<br>
+    <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is [FLOATING]<br>
     |TB| is bool if |TF| is scalar, or<br>
     vec|N|&lt;bool&gt; if |TF| is a vector.
     <td class="nowrap">|e1| <= |e2|: |TB|
     <td>Less than or equal. [=Component-wise=] when |TF| is a vector. (OpFOrdLessThanEqual)
   <tr algorithm="floating point greater than">
-    <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is f32 or vec|N|&lt;f32&gt;<br>
+    <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is [FLOATING]<br>
     |TB| is bool if |TF| is scalar, or<br>
     vec|N|&lt;bool&gt; if |TF| is a vector.
     <td class="nowrap">|e1| > |e2|: |TB|
     <td>Greater than. [=Component-wise=] when |TF| is a vector. (OpFOrdGreaterThan)
   <tr algorithm="floating point greater than equal">
-    <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is f32 or vec|N|&lt;f32&gt;<br>
+    <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is [FLOATING]<br>
     |TB| is bool if |TF| is scalar, or<br>
     vec|N|&lt;bool&gt; if |TF| is a vector.
     <td class="nowrap">|e1| >= |e2|: |TB|
@@ -4060,7 +4065,7 @@ Issue: Which index is used when it's out of bounds?
   </thead>
   <tr algorithm="complement">
     <td>|e|: |T|<br>
-    |T| is i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;
+    |T| is [INTEGRAL]
     <td class="nowrap">`~`|e| : |T|
     <td>Bitwise complement on |e|.
     Each bit in the result is the opposite of the corresponding bit in |e|.
@@ -4075,19 +4080,19 @@ Issue: Which index is used when it's out of bounds?
   <tr algorithm="bitwise or">
     <td>*e1*: *T*<br>
        *e2*: *T*<br>
-       *T* is i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;
+       *T* is [INTEGRAL]
     <td class="nowrap">`e1 | e2`: *T*
     <td>Bitwise-or. [=Component-wise=] when |T| is a vector.
   <tr algorithm="bitwise and">
     <td>*e1*: *T*<br>
        *e2*: *T*<br>
-       *T* is i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;
+       *T* is [INTEGRAL]
     <td class="nowrap">`e1 & e2`: *T*
     <td>Bitwise-and. [=Component-wise=] when |T| is a vector.
   <tr algorithm="bitwise exclusive or">
     <td>*e1*: *T*<br>
        *e2*: *T*<br>
-       *T* is i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;
+       *T* is [INTEGRAL]
     <td class="nowrap">`e1 ^ e2`: *T*
     <td>Bitwise-exclusive-or. [=Component-wise=] when |T| is a vector.
 </table>
@@ -4102,7 +4107,7 @@ Issue: Which index is used when it's out of bounds?
   <tr algorithm="shift left">
     <td>|e1|: |T|<br>
     |e2|: |TS|<br>
-    |T| is i32 or vec|N|&lt;i32&gt;<br>
+    |T| is [SIGNEDINTEGRAL]<br>
     |TS| is u32 if |e1| is a scalar, or<br>
     vec|N|&lt;u32&gt;.
     <td class="nowrap">|e1| `<<` |e2|: |T|
@@ -4116,7 +4121,7 @@ Issue: Which index is used when it's out of bounds?
   <tr algorithm="logical shift right">
     <td>|e1|: |T|<br>
     |e2|: |T|<br>
-    |T| is u32 or vec|N|&lt;u32&gt;
+    |T| is [UNSIGNEDINTEGRAL]
     <td class="nowrap">|e1| >> |e2|: |T|
     <td>Logical shift right:<br>
         Shift |e1| right, inserting zero bits at the most significant positions,
@@ -4128,7 +4133,7 @@ Issue: Which index is used when it's out of bounds?
   <tr algorithm="arithmetic shift right">
     <td>|e1|: |T|<br>
     |e2|: |TS|<br>
-    |T| is i32 or vec|N|&lt;i32&gt;<br>
+    |T| is [SIGNEDINTEGRAL]<br>
     |TS| is u32 if |e1| is a scalar, or<br>
     vec|N|&lt;u32&gt;.
     <td class="nowrap">|e1| >> |e2|: |T|
@@ -6322,7 +6327,7 @@ That's not a full user-defined function declaration.
   </thead>
   <tr><td rowspan=4>
     |e|: |T|<br>
-    |T| is f32 or vec|N|&lt;f32&gt;<br>
+    |T| is [FLOATING]<br>
     |TR| is bool if |T| is a scalar, or<br>
     vec|N|&lt;bool&gt; if |T| is a vector
 
@@ -6352,63 +6357,63 @@ That's not a full user-defined function declaration.
     <tr><th>Precondition<th>Conclusion<th>Description
   </thead>
   <tr algorithm="float abs">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`abs(`|e|`:` |T| `) -> ` |T|
     <td>Returns the absolute value of |e| (e.g. |e| with a positive sign bit).
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Fabs)
 
   <tr algorithm="acos">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`acos(`|e|`:` |T| `) -> ` |T|
     <td>Returns the arc cosine of |e|.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Acos)
 
   <tr algorithm="asin">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`asin(`|e|`:` |T| `) -> ` |T|
     <td>Returns the arc sine of |e|.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Asin)
 
   <tr algorithm="atan">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`atan(`|e|`:` |T| `) -> ` |T|
     <td>Returns the arc tangent of |e|.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Atan)
 
   <tr algorithm="atan2">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`atan2(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>Returns the arc tangent of |e1| over |e2|.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Atan2)
 
   <tr algorithm="ceil">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`ceil(`|e|`:` |T| `) -> ` |T|
     <td>Returns the [=ceiling expression|ceiling=] of |e|.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Ceil)
 
   <tr algorithm="clamp">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`clamp(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T|`) -> ` |T|
     <td>Returns `min(max(`|e1|`,`|e2|`),`|e3|`)`.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450NClamp)
 
   <tr algorithm="cos">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`cos(`|e|`:` |T| `) -> ` |T|
     <td>Returns the cosine of |e|.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Cos)
 
   <tr algorithm="cosh">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`cosh(`|e|`:` |T| `) -> ` |T|
     <td>Returns the hyperbolic cosine of |e|.
     [=Component-wise=] when |T| is a vector
@@ -6420,35 +6425,35 @@ That's not a full user-defined function declaration.
     <td>Returns the cross product of |e1| and |e2|. (GLSLstd450Cross)
 
   <tr algorithm="distance">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`distance(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>Returns the distance between |e1| and |e2| (e.g. `length(`|e1|` - `|e2|`)`).
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Distance)
 
   <tr algorithm="exp">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`exp(`|e1|`:` |T| `) -> ` |T|
     <td>Returns the natural exponentiation of |e1| (e.g. `e`<sup>|e1|</sup>).
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Exp)
 
   <tr algorithm="exp2">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`exp2(`|e|`:` |T| `) -> ` |T|
     <td>Returns 2 raised to the power |e| (e.g. `2`<sup>|e|</sup>).
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Exp2)
 
   <tr algorithm="faceForward">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`faceForward(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T| `) -> ` |T|
     <td>Returns |e1| if `dot(`|e2|`,`|e3|`)` is negative, and `-`|e1| otherwise.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450FaceForward)
 
   <tr algorithm="floor">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`floor(`|e|`:` |T| `) -> ` |T|
     <td>Returns the [=floor expression|floor=] of |e|.
     [=Component-wise=] when |T| is a vector.
@@ -6462,15 +6467,15 @@ That's not a full user-defined function declaration.
     (GLSLstd450Fma)
 
   <tr algorithm="fract">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`fract(`|e|`:` |T| `) -> ` |T|
     <td>Returns the fractional bits of |e| (e.g. |e| `- floor(`|e|`)`).
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Fract)
 
   <tr algorithm="frexp">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;<br>
-        |I| is i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;, where<br>
+    <td>|T| is [FLOATING]<br>
+        |I| is [INTEGRAL], where<br>
         |I| is a scalar if |T| is a scalar, or<br>
         a vector when |T| is a vector
     <td class="nowrap">`frexp(`|e1|`:` |T| `, `|e2|`:` ptr<|I|> `) -> ` |T|
@@ -6481,15 +6486,15 @@ That's not a full user-defined function declaration.
     (GLSLstd450Frexp)
 
   <tr algorithm="inverseSqrt">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`inverseSqrt(`|e|`:` |T| `) -> ` |T|
     <td>Returns the reciprocal of `sqrt(`|e|`)`.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450InverseSqrt)
 
   <tr algorithm="ldexp">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;<br>
-        |I| is i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;, where<br>
+    <td>|T| is [FLOATING]<br>
+        |I| is [INTEGRAL], where<br>
         |I| is a scalar if |T| is a scalar, or<br>
         a vector when |T| is a vector
     <td class="nowrap">`ldexp(`|e1|`:` |T| `, `|e2|`:` |I| `) -> ` |T|
@@ -6498,49 +6503,49 @@ That's not a full user-defined function declaration.
     (GLSLstd450Ldexp)
 
   <tr algorithm="length">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`length(`|e|`:` |T| `) -> ` |T|
     <td>Returns the length of |e| (e.g. `abs(`|e|`)` if |T| is a scalar, or `sqrt(`|e|`[0]`<sup>`2`</sup> `+` |e|`[1]`<sup>`2`</sup> `+ ...)` if |T| is a vector).
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Length)
 
   <tr algorithm="log">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`log(`|e|`:` |T| `) -> ` |T|
     <td>Returns the natural logaritm of |e|.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Log)
 
   <tr algorithm="log2">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`log2(`|e|`:` |T| `) -> ` |T|
     <td>Returns the base-2 logarithm of |e|.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Log2)
 
   <tr algorithm="max">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`max(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>Returns |e2| if |e1| is less than |e2|, and |e1| otherwise.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450NMax)
 
   <tr algorithm="min">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`min(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>Returns |e2| if |e2| is less than |e1|, and |e1| otherwise.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450NMin)
 
   <tr algorithm="mix">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`mix(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T|`) -> ` |T|
     <td>Returns the linear blend of |e1| and |e2| (e.g. |e1|`*(1-`|e3|`)+`|e2|`*`|e3|).
     [=Component-wise=] with |T| is a vector.
     (GLSLstd450FMix)
 
   <tr algorithm="scalar case, modf">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`modf(`|e1|`:` |T| `, `|e2|`:` ptr<|T|> `) -> ` |T|
     <td>Splits |e1| into fractional and whole number parts.
     Returns the fractional part and stores the whole number through the pointer |e2|.
@@ -6554,14 +6559,14 @@ That's not a full user-defined function declaration.
     (GLSLstd450Normalize)
 
   <tr algorithm="pow">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`pow(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>Returns |e1| raised to the power |e2|.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Pow)
 
   <tr algorithm="reflect">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`reflect(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>For the incident vector |e1| and surface orientation |e2|, returns the reflection direction
     |e1|`-2*dot(`|e2|`,`|e1|`)*|e2|`.
@@ -6569,7 +6574,7 @@ That's not a full user-defined function declaration.
     (GLSLstd450Reflect)
 
   <tr algorithm="round">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`round(`|e|`:` |T| `) -> ` |T|
     <td>Result is the integer |k| nearest to |e|, as a floating point value.<br>
         When |e| lies halfway between integers |k| and |k|+1,
@@ -6578,63 +6583,63 @@ That's not a full user-defined function declaration.
         (GLSLstd450RoundEven)
 
   <tr algorithm="float sign">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`sign(`|e|`:` |T| `) -> ` |T|
     <td>Returns the sign of |e|.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450FSign)
 
   <tr algorithm="sin">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`sin(`|e|`:` |T| `) -> ` |T|
     <td>Returns the sine of |e|.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Sin)
 
   <tr algorithm="sinh">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`sinh(`|e|`:` |T| `) -> ` |T|
     <td>Returns the hyperbolic sine of |e|.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Sinh)
 
   <tr algorithm="smoothStep">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`smoothStep(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T| `) -> ` |T|
     <td>Returns the smooth Hermite interpolation between 0 and 1.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450SmoothStep)
 
   <tr algorithm="sqrt">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`sqrt(`|e|`:` |T| `) -> ` |T|
     <td>Returns the square root of |e|.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Sqrt)
 
   <tr algorithm="step">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`step(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>Returns 0.0 if |e1| is less than |e2|, and 1.0 otherwise.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Step)
 
   <tr algorithm="tan">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`tan(`|e|`:` |T| `) -> ` |T|
     <td>Returns the tangent of |e|.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Tan)
 
   <tr algorithm="tanh">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`tanh(`|e|`:` |T| `) -> ` |T|
     <td>Returns the hyperbolic tangent of |e|.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Tanh)
 
   <tr algorithm="trunc">
-    <td>|T| is f32 or vec|N|&lt;f32&gt;
+    <td>|T| is [FLOATING]
     <td class="nowrap">`trunc(`|e|`:` |T| `) -> ` |T|
     <td>Returns the nearest whole number whose absolute value is less than or equal to |e|.
     [=Component-wise=] when |T| is a vector.
@@ -6648,34 +6653,34 @@ That's not a full user-defined function declaration.
     <tr><th>Precondition<th>Conclusion<th>Description
   </thead>
   <tr algorithm="signed abs">
-    <td>|T| is i32 or vec|N|&lt;i32&gt;
+    <td>|T| is [SIGNEDINTEGRAL]
     <td class="nowrap">`abs`(|e|: |T| ) -> |T|
     <td>The absolute value of |e|.
         [=Component-wise=] when |T| is a vector.
         (GLSLstd450SAbs)
 
   <tr algorithm="scalar case, unsigned abs">
-    <td>|T| is u32 or vec|N|&lt;u32&gt;
+    <td>|T| is [UNSIGNEDINTEGRAL]
     <td class="nowrap">`abs`(|e|: |T| ) -> |T|
     <td>Result is |e|.  This is provided for symmetry with `abs` for signed integers.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="unsigned clamp">
-    <td>|T| is u32 or vec|N|&lt;u32&gt;
+    <td>|T| is [UNSIGNEDINTEGRAL]
     <td class="nowrap">`clamp(`|e1|`:` |T| `, `|e2|`:` |T|`, `|e3|`:` |T|`) ->` |T|
     <td>Returns `min(max(`|e1|`,`|e2|`),`|e3|`)`.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450UClamp)
 
   <tr algorithm="signed clamp">
-    <td>|T| is i32 or vec|N|&lt;i32&gt;
+    <td>|T| is [SIGNEDINTEGRAL]
     <td class="nowrap">`clamp(`|e1|`:` |T| `, `|e2|`:` |T|`, `|e3|`:` |T|`) ->` |T|
     <td>Returns `min(max(`|e1|`,`|e2|`),`|e3|`)`.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450SClamp)
 
   <tr algorithm="count 1 bits">
-    <td>|T| is i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;
+    <td>|T| is [INTEGRAL]
     <td class="nowrap">`countOneBits(`|e|`:` |T| `) ->` |T|
     <td>The number of 1 bits in the representation of |e|.<br>
         Also known as "population count".<br>
@@ -6683,35 +6688,35 @@ That's not a full user-defined function declaration.
         (SPIR-V OpBitCount)
 
   <tr algorithm="unsigned max">
-    <td>|T| is u32 or vec|N|&lt;u32&gt;
+    <td>|T| is [UNSIGNEDINTEGRAL]
     <td class="nowrap">`max(`|e1|`:` |T| `, `|e2|`:` |T|`) ->` |T|
     <td>Returns |e2| if |e1| is less than |e2|, and |e1| otherwise.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450UMax)
 
   <tr algorithm="signed max">
-    <td>|T| is i32 or vec|N|&lt;i32&gt;
+    <td>|T| is [SIGNEDINTEGRAL]
     <td class="nowrap">`max(`|e1|`:` |T| `, `|e2|`:` |T|`) ->` |T|
     <td>Returns |e2| if |e1| is less than |e2|, and |e1| otherwise.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450SMax)
 
   <tr algorithm="unsigned min">
-    <td>|T| is u32 or vec|N|&lt;u32&gt;
+    <td>|T| is [UNSIGNEDINTEGRAL]
     <td class="nowrap">`min(`|e1|`:` |T| `, `|e2|`:` |T|`) ->` |T|
     <td>Returns |e1| if |e1| is less than |e2|, and |e2| otherwise.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450UMin)
 
   <tr algorithm="signed min">
-    <td>|T| is i32 or vec|N|&lt;i32&gt;
+    <td>|T| is [SIGNEDINTEGRAL]
     <td class="nowrap">`min(`|e1|`:` |T| `, `|e2|`:` |T|`) ->` |T|
     <td>Returns |e1| if |e1| is less than |e2|, and |e2| otherwise.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd45SUMin)
 
   <tr algorithm="bit reversal">
-    <td>|T| is i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;
+    <td>|T| is [INTEGRAL]
     <td class="nowrap">`reverseBits(`|e|`:` |T| `) ->`  |T|
     <td>Reverses the bits in |e|:  The bit at position |k| of the result equals the
         bit at position 31-|k| of |e|.<br>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -756,19 +756,6 @@ a result value, such as the non-result-value effects of its subexpressions.
 
 TODO: example: non-result-value effect is any side effect of a function call subexpression.
 
-For convenience, the type tables use the following shorthands:
-
-<table class='data'>
-  <tr><td>*Scalar*<td>[=scalar=] types: one of bool, i32, u32, f32
-  <tr><td>*Int*<td>i32 or u32
-  <tr><td>*Integral*<td>*Int* or [[#vector-types]] with an *Int* component
-  <tr><td>*SignedIntegral*<td>i32 or [[#vector-types]] with an i32 component
-  <tr><td>*Floating*<td>f32 or [[#vector-types]] with an f32 component
-  <tr><td>*Arity(T)*<td>number of components in [[#vector-types]] *T*
-</table>
-
-TODO(dneto): Do we still need all these shorthands?
-
 ## Plain Types ## {#plain-types-section}
 
 [=Plain types=] are the types for representing boolean values, numbers, vectors,
@@ -3472,7 +3459,7 @@ The result type depends on the number of letters provided. Assuming a `vec4<f32>
        <td>Select the fourth component of |e|<br>
            (OpCompositeExtract with selection index 3)
   <tr algorithm="vector indexed component selection"><td>|e|: vec|N|&lt;|T|&gt;<br>
-          |i|: *Int*
+          |i|: i32 or u32
        <td class="nowrap">
            |e|[|i|]: |T|
        <td>Select the |i|'<sup>th</sup> component of vector<br>
@@ -3610,7 +3597,7 @@ Issue: Which index is used when it's out of bounds?
            (OpAccessChain with index value 3)
   <tr algorithm="vector indexed component reference selection">
        <td>|r|: ref&lt;|SC|,vec|N|&lt;|T|&gt;&gt;<br>
-          |i|: *Int*
+          |i|: i32 or u32
        <td class="nowrap">
            |r|[|i|]: ref&lt;|SC|,|T|&gt;
        <td>Compute a reference to the |i|'<sup>th</sup> component of the vector referenced by the reference |r|.<br>
@@ -3630,7 +3617,7 @@ Issue: Which index is used when it's out of bounds?
   <tr algorithm="matrix indexed column vector selection">
        <td class="nowrap">
           |e|: mat|N|x|M|&lt;|T|&gt;<br>
-          |i|: *Int*
+          |i|: i32 or u32
        <td class="nowrap">
            |e|[|i|]: vec|M|&lt;|T|&gt;
        <td>The result is the |i|'<sup>th</sup> column vector of |e|.<br>
@@ -3646,7 +3633,7 @@ Issue: Which index is used when it's out of bounds?
   <tr algorithm="matrix indexed column vector reference selection">
        <td class="nowrap">
           |r|: ref&lt;|SC|,mat|N|x|M|&lt;|T|&gt;&gt;<br>
-          |i|: *Int*
+          |i|: i32 or u32
        <td class="nowrap">
            |r|[|i|]: ref&lt;vec|M|&lt;|SC|,|T|&gt;&gt;
        <td>Compute a reference to the |i|'<sup>th</sup> column vector of the matrix referenced by the reference |r|.<br>
@@ -3666,7 +3653,7 @@ Issue: Which index is used when it's out of bounds?
   <tr algorithm="sized array indexed element selection">
        <td class="nowrap">
           |e|: array&lt;|T|,|N|&gt;<br>
-          |i|: *Int*
+          |i|: i32 or u32
        <td class="nowrap">
            |e|[|i|]: |T|
        <td>The result is the value of the |i|'<sup>th</sup> element of the array value |e|.<br>
@@ -3682,7 +3669,7 @@ Issue: Which index is used when it's out of bounds?
   <tr algorithm="sized array indexed reference selection">
        <td class="nowrap">
           |r|: ref&lt;|SC|,array&lt;|T|,|N|&gt;&gt;<br>
-          |i|: *Int*
+          |i|: i32 or u32
        <td class="nowrap">
            |r|[|i|]: ref&lt;|SC|,|T|&gt;
        <td>Compute a reference to the |i|'<sup>th</sup> element of the array referenced by the reference |r|.<br>
@@ -3692,7 +3679,7 @@ Issue: Which index is used when it's out of bounds?
            (OpAccessChain)
   <tr algorithm="array indexed reference selection">
        <td>|r|: ref&lt;|SC|,array&lt;|T|&gt;&gt;<br>
-          |i|: *Int*
+          |i|: i32 or u32
        <td class="nowrap">
            |r|[|i|]: ref&lt;|SC|,|T|&gt;
        <td>Compute a reference to the |i|'<sup>th</sup> element of the runtime-sized array referenced by the reference |r|.<br>
@@ -3784,11 +3771,12 @@ Issue: Which index is used when it's out of bounds?
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
-  <tr algorithm="integer negation"><td>|e|: |T|, |T| is *SignedIntegral*
+  <tr algorithm="integer negation"><td>|e|: |T|<br>
+  |T| is i32 or vec|N|&lt;i32&gt;
   <td>`-`|e|`:` |T|
   <td>Signed integer negation. [=Component-wise=] when |T| is a vector. (OpSNegate)
 
-  <tr algorithm="floating point negation"><td>|e|: |T|, |T| is *Floating*
+  <tr algorithm="floating point negation"><td>|e|: |T|, |T| is f32 or vec|N|&lt;f32&gt;
   <td>`-`|e|`:` |T|
   <td>Floating point negation. [=Component-wise=] when |T| is a vector. (OpFNegate)
 </table>
@@ -3800,34 +3788,34 @@ Issue: Which index is used when it's out of bounds?
   </thead>
 
   <tr algorithm="integer addition">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is *Integral*
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;
     <td>|e1| `+` |e2| : |T|
     <td>Integer addition, modulo 2<sup>32</sup>. [=Component-wise=] when |T| is a vector. (OpIAdd)
   <tr algorithm="floating point addition">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is *Floating*
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is f32 or vec|N|&lt;f32&gt;
     <td>|e1| `+` |e2| : |T|
     <td>Floating point addition. [=Component-wise=] when |T| is a vector. (OpFAdd)
 
   <tr algorithm="integer subtraction">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is *Integral*
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;
     <td>|e1| `-` |e2| : |T|
     <td>Integer subtraction, modulo 2<sup>32</sup>. [=Component-wise=] when |T| is a vector. (OpISub)
   <tr algorithm="floating point subtraction">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is *Floating*
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is f32 or vec|N|&lt;f32&gt;
     <td>|e1| `-` |e2| : |T|
     <td>Floating point subtraction. [=Component-wise=] when |T| is a vector. (OpFSub)
 
   <tr algorithm="integer multiplication">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is *Integral*
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;
     <td>|e1| `*` |e2| : |T|
     <td>Integer multiplication, modulo 2<sup>32</sup>. [=Component-wise=] when |T| is a vector. (OpIMul)
   <tr algorithm="floating point multiplication">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is *Floating*
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is f32 or vec|N|&lt;f32&gt;
     <td>|e1| `*` |e2| : |T|
     <td>Floating point multiplication. [=Component-wise=] when |T| is a vector. (OpFMul)
 
   <tr algorithm="signed integer division">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is *SignedIntegral*
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is i32 or vec|N|&lt;i32&gt;
     <td>|e1| `/` |e2| : |T|
     <td>Signed integer division. [=Component-wise=] when |T| is a vector. (OpSDiv)
   <tr algorithm="unsigned integer division">
@@ -3835,12 +3823,12 @@ Issue: Which index is used when it's out of bounds?
     <td>|e1| `/` |e2| : |T|
     <td>Unsigned integer division. [=Component-wise=] when |T| is a vector. (OpUDiv)
   <tr algorithm="floating point division">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is *Floating*
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is f32 or vec|N|&lt;f32&gt;
     <td>|e1| `/` |e2| : |T|
     <td>Floating point division. [=Component-wise=] when |T| is a vector. (OpFDiv)
 
   <tr algorithm="signed integer remainder">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is *SignedIntegral*
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is i32 or vec|N|&lt;i32&gt;
     <td>|e1| `%` |e2| : |T|
     <td>Signed integer remainder. [=Component-wise=] when |T| is a vector. (OpSMod)
   <tr algorithm="unsigned integer modulus">
@@ -3848,7 +3836,7 @@ Issue: Which index is used when it's out of bounds?
     <td>|e1| `%` |e2| : |T|
     <td>Signed integer remainder, where sign of non-zero result matches sign of |e2|. [=Component-wise=] when |T| is a vector. (OpUMod)
   <tr algorithm="floating point remainder">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is *Floating*
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is f32 or vec|N|&lt;f32&gt;
     <td>|e1| `%` |e2| : |T|
     <td>Floating point remainder, where sign of non-zero result matches sign of |e2|. [=Component-wise=] when |T| is a vector. (OpFMod)
 
@@ -3960,102 +3948,104 @@ Issue: Which index is used when it's out of bounds?
     <td>Inequality. [=Component-wise=] when |T| is a vector. (OpLogicalNotEqual)
 
   <tr algorithm="integer equality">
-    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is
-    *Integral*<br>|TB| is bool if |TI| is scalar, or<br>
-    vec|N|&lt;bool&gt; (where |N| = *Arity(*|TI|*)*) if |TI| is a vector
+    <td>|e1|: |TI|<br>|e2|: |TI|<br>
+    |TI| is i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;<br>
+    |TB| is bool if |TI| is scalar, or<br>
+    vec|N|&lt;bool&gt; if |TI| is a vector
     <td class="nowrap">|e1| `==` |e2|`:` |TB|
     <td>Equality. [=Component-wise=] when |TI| is a vector. (OpIEqual)
   <tr algorithm="integer inequality">
-    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is
-    *Integral*<br>|TB| is bool if |TI| is scalar, or<br>
-    vec|N|&lt;bool&gt; (where |N| = *Arity(*|TI|*)*) if |TI| is a vector
+    <td>|e1|: |TI|<br>|e2|: |TI|<br>
+    |TI| is i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;<br>
+    |TB| is bool if |TI| is scalar, or<br>
+    vec|N|&lt;bool&gt; if |TI| is a vector
     <td class="nowrap">|e1| `!=` |e2|`:` |TB|
     <td>Inequality. [=Component-wise=] when |TI| is a vector. (OpINotEqual)
 
   <tr algorithm="signed integer less than">
-    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is
-    *SignedIntegral*<br>|TB| is bool if |TI| is scalar, or<br>
-    vec|N|&lt;bool&gt; (where |N| = *Arity(*|TI|*)*) if |TI| is a vector
+    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is i32 or vec|N|&lt;i32&gt;<br>
+    |TB| is bool if |TI| is scalar, or<br>
+    vec|N|&lt;bool&gt; if |TI| is a vector
     <td class="nowrap">|e1| `<` |e2|`:` |TB|
     <td>Less than. [=Component-wise=] when |TI| is a vector. (OpSLessThan)
   <tr algorithm="signed integer less than equal">
-    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is
-    *SignedIntegral*<br>|TB| is bool if |TI| is scalar, or<br>
-    vec|N|&lt;bool&gt; (where |N| = *Arity(*|TI|*)*) if |TI| is a vector
+    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is i32 or vec|N|&lt;i32&gt;<br>
+    |TB| is bool if |TI| is scalar, or<br>
+    vec|N|&lt;bool&gt; if |TI| is a vector
     <td class="nowrap">|e1| `<=` |e2|`:` |TB|
     <td>Less than or equal. [=Component-wise=] when |TI| is a vector. (OpSLessThanEqual)
   <tr algorithm="signed integer greater than">
-    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is
-    *SignedIntegral*<br>|TB| is bool if |TI| is scalar, or<br>
-    vec|N|&lt;bool&gt; (where |N| = *Arity(*|TI|*)*) if |TI| is a vector
+    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is i32 or vec|N|&lt;i32&gt;<br>
+    |TB| is bool if |TI| is scalar, or<br>
+    vec|N|&lt;bool&gt; if |TI| is a vector
     <td class="nowrap">|e1| `<` |e2|`:` |TB|
     <td>Greater than. [=Component-wise=] when |TI| is a vector. (OpSGreaterThan)
   <tr algorithm="signed integer greater than equal">
-    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is
-    *SignedIntegral*<br>|TB| is bool if |TI| is scalar, or<br>
-    vec|N|&lt;bool&gt; (where |N| = *Arity(*|TI|*)*) if |TI| is a vector
+    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is i32 or vec|N|&lt;i32&gt;<br>
+    |TB| is bool if |TI| is scalar, or<br>
+    vec|N|&lt;bool&gt; if |TI| is a vector
     <td class="nowrap">|e1| `<=` |e2|`:` |TB|
     <td>Greater than or equal. [=Component-wise=] when |TI| is a vector. (OpSGreaterThanEqual)
 
   <tr algorithm="unsigned integer less than">
-    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is
-    *SignedIntegral*<br>|TB| is bool if |TI| is scalar, or<br>
-    vec|N|&lt;bool&gt; (where |N| = *Arity(*|TI|*)*) if |TI| is a vector
+    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is u32 or vec|N|&lt;u32&gt;<br>
+    |TB| is bool if |TI| is scalar, or<br>
+    vec|N|&lt;bool&gt; if |TI| is a vector
     <td class="nowrap">|e1| `<` |e2|`:` |TB|
-    <td>Less than. [=Component-wise=] when |TI| is a vector. (OpSLessThan)
+    <td>Less than. [=Component-wise=] when |TI| is a vector. (OpULessThan)
   <tr algorithm="unsigned integer less than equal">
-    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is
-    *SignedIntegral*<br>|TB| is bool if |TI| is scalar, or<br>
-    vec|N|&lt;bool&gt; (where |N| = *Arity(*|TI|*)*) if |TI| is a vector
+    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is u32 or vec|N|&lt;u32&gt;<br>
+    |TB| is bool if |TI| is scalar, or<br>
+    vec|N|&lt;bool&gt; if |TI| is a vector
     <td class="nowrap">|e1| `<=` |e2|`:` |TB|
-    <td>Less than or equal. [=Component-wise=] when |TI| is a vector. (OpSLessThanEqual)
+    <td>Less than or equal. [=Component-wise=] when |TI| is a vector. (OpULessThanEqual)
   <tr algorithm="unsigned integer greater than">
-    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is
-    *SignedIntegral*<br>|TB| is bool if |TI| is scalar, or<br>
-    vec|N|&lt;bool&gt; (where |N| = *Arity(*|TI|*)*) if |TI| is a vector
+    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is u32 or vec|N|&lt;u32&gt;<br>
+    |TB| is bool if |TI| is scalar, or<br>
+    vec|N|&lt;bool&gt; if |TI| is a vector
     <td class="nowrap">|e1| `<` |e2|`:` |TB|
-    <td>Greater than. [=Component-wise=] when |TI| is a vector. (OpSGreaterThan)
+    <td>Greater than. [=Component-wise=] when |TI| is a vector. (OpUGreaterThan)
   <tr algorithm="unsigned integer greater than equal">
-    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is
-    *SignedIntegral*<br>|TB| is bool if |TI| is scalar, or<br>
-    vec|N|&lt;bool&gt; (where |N| = *Arity(*|TI|*)*) if |TI| is a vector
+    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is u32 or vec|N|&lt;u32&gt;<br>
+    |TB| is bool if |TI| is scalar, or<br>
+    vec|N|&lt;bool&gt; if |TI| is a vector
     <td class="nowrap">|e1| `<=` |e2|`:` |TB|
-    <td>Greater than or equal. [=Component-wise=] when |TI| is vector. (OpSGreaterThanEqual)
+    <td>Greater than or equal. [=Component-wise=] when |TI| is vector. (OpUGreaterThanEqual)
 
   <tr algorithm="floating point equality">
-    <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is *Floating*<br>
+    <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is f32 or vec|N|&lt;f32&gt;<br>
     |TB| is bool if |TF| is scalar, or<br>
-    vec|N|&lt;bool&gt; (where |N| = `Arity(`|TF|`)`) if |TF| is a vector.
+    vec|N|&lt;bool&gt; if |TF| is a vector.
     <td class="nowrap">|e1| == |e2|: |TB|
     <td>Equality. [=Component-wise=] when |TF| is a vector. (OpFOrdEqual)
   <tr algorithm="floating point inequality">
-    <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is *Floating*<br>
+    <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is f32 or vec|N|&lt;f32&gt;<br>
     |TB| is bool if |TF| is scalar, or<br>
-    vec|N|&lt;bool&gt; (where |N| = `Arity(`|TF|`)`) if |TF| is a vector.
+    vec|N|&lt;bool&gt; if |TF| is a vector.
     <td class="nowrap">|e1| != |e2|: |TB|
     <td>Inequality. [=Component-wise=] when |TF| is a vector. (OpFOrdEqual)
   <tr algorithm="floating point less than">
-    <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is *Floating*<br>
+    <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is f32 or vec|N|&lt;f32&gt;<br>
     |TB| is bool if |TF| is scalar, or<br>
-    vec|N|&lt;bool&gt; (where |N| = `Arity(`|TF|`)`) if |TF| is a vector.
+    vec|N|&lt;bool&gt; if |TF| is a vector.
     <td class="nowrap">|e1| < |e2|: |TB|
     <td>Less than. [=Component-wise=] when |TF| is a vector. (OpFOrdLessThan)
   <tr algorithm="floating point less than equal">
-    <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is *Floating*<br>
+    <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is f32 or vec|N|&lt;f32&gt;<br>
     |TB| is bool if |TF| is scalar, or<br>
-    vec|N|&lt;bool&gt; (where |N| = `Arity(`|TF|`)`) if |TF| is a vector.
+    vec|N|&lt;bool&gt; if |TF| is a vector.
     <td class="nowrap">|e1| <= |e2|: |TB|
     <td>Less than or equal. [=Component-wise=] when |TF| is a vector. (OpFOrdLessThanEqual)
   <tr algorithm="floating point greater than">
-    <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is *Floating*<br>
+    <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is f32 or vec|N|&lt;f32&gt;<br>
     |TB| is bool if |TF| is scalar, or<br>
-    vec|N|&lt;bool&gt; (where |N| = `Arity(`|TF|`)`) if |TF| is a vector.
+    vec|N|&lt;bool&gt; if |TF| is a vector.
     <td class="nowrap">|e1| > |e2|: |TB|
     <td>Greater than. [=Component-wise=] when |TF| is a vector. (OpFOrdGreaterThan)
   <tr algorithm="floating point greater than equal">
-    <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is *Floating*<br>
+    <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is f32 or vec|N|&lt;f32&gt;<br>
     |TB| is bool if |TF| is scalar, or<br>
-    vec|N|&lt;bool&gt; (where |N| = `Arity(`|TF|`)`) if |TF| is a vector.
+    vec|N|&lt;bool&gt; if |TF| is a vector.
     <td class="nowrap">|e1| >= |e2|: |TB|
     <td>Greater than or equal. [=Component-wise=] when |TF| is a vector. (OpFOrdGreaterThanEqual)
 
@@ -4070,7 +4060,7 @@ Issue: Which index is used when it's out of bounds?
   </thead>
   <tr algorithm="complement">
     <td>|e|: |T|<br>
-    |T| is *Integral*
+    |T| is i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;
     <td class="nowrap">`~`|e| : |T|
     <td>Bitwise complement on |e|.
     Each bit in the result is the opposite of the corresponding bit in |e|.
@@ -4085,19 +4075,19 @@ Issue: Which index is used when it's out of bounds?
   <tr algorithm="bitwise or">
     <td>*e1*: *T*<br>
        *e2*: *T*<br>
-       *T* is *Integral*
+       *T* is i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;
     <td class="nowrap">`e1 | e2`: *T*
     <td>Bitwise-or. [=Component-wise=] when |T| is a vector.
   <tr algorithm="bitwise and">
     <td>*e1*: *T*<br>
        *e2*: *T*<br>
-       *T* is *Integral*
+       *T* is i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;
     <td class="nowrap">`e1 & e2`: *T*
     <td>Bitwise-and. [=Component-wise=] when |T| is a vector.
   <tr algorithm="bitwise exclusive or">
     <td>*e1*: *T*<br>
        *e2*: *T*<br>
-       *T* is *Integral*
+       *T* is i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;
     <td class="nowrap">`e1 ^ e2`: *T*
     <td>Bitwise-exclusive-or. [=Component-wise=] when |T| is a vector.
 </table>
@@ -4112,9 +4102,9 @@ Issue: Which index is used when it's out of bounds?
   <tr algorithm="shift left">
     <td>|e1|: |T|<br>
     |e2|: |TS|<br>
-    |T| is *SignedIntegral*<br>
+    |T| is i32 or vec|N|&lt;i32&gt;<br>
     |TS| is u32 if |e1| is a scalar, or<br>
-    vec|N|&lt;u32&gt; (where |N| = *Arity(*|T|*)*).
+    vec|N|&lt;u32&gt;.
     <td class="nowrap">|e1| `<<` |e2|: |T|
     <td>Shift left:<br>
         Shift |e1| left, inserting zero bits at the least significant positions,
@@ -4138,9 +4128,9 @@ Issue: Which index is used when it's out of bounds?
   <tr algorithm="arithmetic shift right">
     <td>|e1|: |T|<br>
     |e2|: |TS|<br>
-    |T| is *SignedIntegral*<br>
+    |T| is i32 or vec|N|&lt;i32&gt;<br>
     |TS| is u32 if |e1| is a scalar, or<br>
-    vec|N|&lt;u32&gt; (where |N| = *Arity(*|T|*)*).
+    vec|N|&lt;u32&gt;.
     <td class="nowrap">|e1| >> |e2|: |T|
     <td>Arithmetic shift right:<br>
         Shift |e1| right, copying the sign bit of |e1| into the most significant positions,
@@ -6332,9 +6322,9 @@ That's not a full user-defined function declaration.
   </thead>
   <tr><td rowspan=4>
     |e|: |T|<br>
-    |T| is *Floating*<br>
+    |T| is f32 or vec|N|&lt;f32&gt;<br>
     |TR| is bool if |T| is a scalar, or<br>
-    vec|N|&lt;bool&gt; (where |N| = *Arity(*|T|*)*) if |T| is a vector
+    vec|N|&lt;bool&gt; if |T| is a vector
 
     <td class="nowrap">`isNan(`|e|`) -> `|TR|
     <td>Test for NaN according to IEEE.
@@ -6362,63 +6352,63 @@ That's not a full user-defined function declaration.
     <tr><th>Precondition<th>Conclusion<th>Description
   </thead>
   <tr algorithm="float abs">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`abs(`|e|`:` |T| `) -> ` |T|
     <td>Returns the absolute value of |e| (e.g. |e| with a positive sign bit).
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Fabs)
 
   <tr algorithm="acos">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`acos(`|e|`:` |T| `) -> ` |T|
     <td>Returns the arc cosine of |e|.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Acos)
 
   <tr algorithm="asin">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`asin(`|e|`:` |T| `) -> ` |T|
     <td>Returns the arc sine of |e|.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Asin)
 
   <tr algorithm="atan">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`atan(`|e|`:` |T| `) -> ` |T|
     <td>Returns the arc tangent of |e|.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Atan)
 
   <tr algorithm="atan2">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`atan2(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>Returns the arc tangent of |e1| over |e2|.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Atan2)
 
   <tr algorithm="ceil">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`ceil(`|e|`:` |T| `) -> ` |T|
     <td>Returns the [=ceiling expression|ceiling=] of |e|.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Ceil)
 
   <tr algorithm="clamp">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`clamp(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T|`) -> ` |T|
     <td>Returns `min(max(`|e1|`,`|e2|`),`|e3|`)`.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450NClamp)
 
   <tr algorithm="cos">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`cos(`|e|`:` |T| `) -> ` |T|
     <td>Returns the cosine of |e|.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Cos)
 
   <tr algorithm="cosh">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`cosh(`|e|`:` |T| `) -> ` |T|
     <td>Returns the hyperbolic cosine of |e|.
     [=Component-wise=] when |T| is a vector
@@ -6430,35 +6420,35 @@ That's not a full user-defined function declaration.
     <td>Returns the cross product of |e1| and |e2|. (GLSLstd450Cross)
 
   <tr algorithm="distance">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`distance(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>Returns the distance between |e1| and |e2| (e.g. `length(`|e1|` - `|e2|`)`).
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Distance)
 
   <tr algorithm="exp">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`exp(`|e1|`:` |T| `) -> ` |T|
     <td>Returns the natural exponentiation of |e1| (e.g. `e`<sup>|e1|</sup>).
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Exp)
 
   <tr algorithm="exp2">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`exp2(`|e|`:` |T| `) -> ` |T|
     <td>Returns 2 raised to the power |e| (e.g. `2`<sup>|e|</sup>).
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Exp2)
 
   <tr algorithm="faceForward">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`faceForward(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T| `) -> ` |T|
     <td>Returns |e1| if `dot(`|e2|`,`|e3|`)` is negative, and `-`|e1| otherwise.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450FaceForward)
 
   <tr algorithm="floor">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`floor(`|e|`:` |T| `) -> ` |T|
     <td>Returns the [=floor expression|floor=] of |e|.
     [=Component-wise=] when |T| is a vector.
@@ -6472,17 +6462,17 @@ That's not a full user-defined function declaration.
     (GLSLstd450Fma)
 
   <tr algorithm="fract">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`fract(`|e|`:` |T| `) -> ` |T|
     <td>Returns the fractional bits of |e| (e.g. |e| `- floor(`|e|`)`).
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Fract)
 
   <tr algorithm="frexp">
-    <td>|T| is *Floating*<br>
-        |I| is *Integral*, where<br>
+    <td>|T| is f32 or vec|N|&lt;f32&gt;<br>
+        |I| is i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;, where<br>
         |I| is a scalar if |T| is a scalar, or<br>
-        a vector when |T| is a vector (with equal *Arity*)
+        a vector when |T| is a vector
     <td class="nowrap">`frexp(`|e1|`:` |T| `, `|e2|`:` ptr<|I|> `) -> ` |T|
     <td>Splits |e1| into a signficand and exponent of the form `significand * 2`<sup>`exponent`</sup> and returns the significand.
     The magnitude of the signficand is in the range of [0.5, 1.0) or 0.
@@ -6491,66 +6481,66 @@ That's not a full user-defined function declaration.
     (GLSLstd450Frexp)
 
   <tr algorithm="inverseSqrt">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`inverseSqrt(`|e|`:` |T| `) -> ` |T|
     <td>Returns the reciprocal of `sqrt(`|e|`)`.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450InverseSqrt)
 
   <tr algorithm="ldexp">
-    <td>|T| is *Floating*<br>
-        |I| is *Integral*, where<br>
+    <td>|T| is f32 or vec|N|&lt;f32&gt;<br>
+        |I| is i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;, where<br>
         |I| is a scalar if |T| is a scalar, or<br>
-        a vector when |T| is a vector (with equal *Arity*)
+        a vector when |T| is a vector
     <td class="nowrap">`ldexp(`|e1|`:` |T| `, `|e2|`:` |I| `) -> ` |T|
     <td>Returns |e1| `* 2`<sup>|e2|</sup>.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Ldexp)
 
   <tr algorithm="length">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`length(`|e|`:` |T| `) -> ` |T|
     <td>Returns the length of |e| (e.g. `abs(`|e|`)` if |T| is a scalar, or `sqrt(`|e|`[0]`<sup>`2`</sup> `+` |e|`[1]`<sup>`2`</sup> `+ ...)` if |T| is a vector).
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Length)
 
   <tr algorithm="log">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`log(`|e|`:` |T| `) -> ` |T|
     <td>Returns the natural logaritm of |e|.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Log)
 
   <tr algorithm="log2">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`log2(`|e|`:` |T| `) -> ` |T|
     <td>Returns the base-2 logarithm of |e|.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Log2)
 
   <tr algorithm="max">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`max(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>Returns |e2| if |e1| is less than |e2|, and |e1| otherwise.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450NMax)
 
   <tr algorithm="min">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`min(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>Returns |e2| if |e2| is less than |e1|, and |e1| otherwise.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450NMin)
 
   <tr algorithm="mix">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`mix(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T|`) -> ` |T|
     <td>Returns the linear blend of |e1| and |e2| (e.g. |e1|`*(1-`|e3|`)+`|e2|`*`|e3|).
     [=Component-wise=] with |T| is a vector.
     (GLSLstd450FMix)
 
   <tr algorithm="scalar case, modf">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`modf(`|e1|`:` |T| `, `|e2|`:` ptr<|T|> `) -> ` |T|
     <td>Splits |e1| into fractional and whole number parts.
     Returns the fractional part and stores the whole number through the pointer |e2|.
@@ -6564,14 +6554,14 @@ That's not a full user-defined function declaration.
     (GLSLstd450Normalize)
 
   <tr algorithm="pow">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`pow(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>Returns |e1| raised to the power |e2|.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Pow)
 
   <tr algorithm="reflect">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`reflect(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>For the incident vector |e1| and surface orientation |e2|, returns the reflection direction
     |e1|`-2*dot(`|e2|`,`|e1|`)*|e2|`.
@@ -6579,7 +6569,7 @@ That's not a full user-defined function declaration.
     (GLSLstd450Reflect)
 
   <tr algorithm="round">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`round(`|e|`:` |T| `) -> ` |T|
     <td>Result is the integer |k| nearest to |e|, as a floating point value.<br>
         When |e| lies halfway between integers |k| and |k|+1,
@@ -6588,63 +6578,63 @@ That's not a full user-defined function declaration.
         (GLSLstd450RoundEven)
 
   <tr algorithm="float sign">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`sign(`|e|`:` |T| `) -> ` |T|
     <td>Returns the sign of |e|.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450FSign)
 
   <tr algorithm="sin">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`sin(`|e|`:` |T| `) -> ` |T|
     <td>Returns the sine of |e|.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Sin)
 
   <tr algorithm="sinh">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`sinh(`|e|`:` |T| `) -> ` |T|
     <td>Returns the hyperbolic sine of |e|.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Sinh)
 
   <tr algorithm="smoothStep">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`smoothStep(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T| `) -> ` |T|
     <td>Returns the smooth Hermite interpolation between 0 and 1.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450SmoothStep)
 
   <tr algorithm="sqrt">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`sqrt(`|e|`:` |T| `) -> ` |T|
     <td>Returns the square root of |e|.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Sqrt)
 
   <tr algorithm="step">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`step(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>Returns 0.0 if |e1| is less than |e2|, and 1.0 otherwise.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Step)
 
   <tr algorithm="tan">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`tan(`|e|`:` |T| `) -> ` |T|
     <td>Returns the tangent of |e|.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Tan)
 
   <tr algorithm="tanh">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`tanh(`|e|`:` |T| `) -> ` |T|
     <td>Returns the hyperbolic tangent of |e|.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Tanh)
 
   <tr algorithm="trunc">
-    <td>|T| is *Floating*
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`trunc(`|e|`:` |T| `) -> ` |T|
     <td>Returns the nearest whole number whose absolute value is less than or equal to |e|.
     [=Component-wise=] when |T| is a vector.
@@ -6658,7 +6648,7 @@ That's not a full user-defined function declaration.
     <tr><th>Precondition<th>Conclusion<th>Description
   </thead>
   <tr algorithm="signed abs">
-    <td>|T| is *SignedIntegral*
+    <td>|T| is i32 or vec|N|&lt;i32&gt;
     <td class="nowrap">`abs`(|e|: |T| ) -> |T|
     <td>The absolute value of |e|.
         [=Component-wise=] when |T| is a vector.
@@ -6678,14 +6668,14 @@ That's not a full user-defined function declaration.
     (GLSLstd450UClamp)
 
   <tr algorithm="signed clamp">
-    <td>|T| is *SignedIntegral*
+    <td>|T| is i32 or vec|N|&lt;i32&gt;
     <td class="nowrap">`clamp(`|e1|`:` |T| `, `|e2|`:` |T|`, `|e3|`:` |T|`) ->` |T|
     <td>Returns `min(max(`|e1|`,`|e2|`),`|e3|`)`.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450SClamp)
 
   <tr algorithm="count 1 bits">
-    <td>|T| is *Integral*
+    <td>|T| is i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;
     <td class="nowrap">`countOneBits(`|e|`:` |T| `) ->` |T|
     <td>The number of 1 bits in the representation of |e|.<br>
         Also known as "population count".<br>
@@ -6700,7 +6690,7 @@ That's not a full user-defined function declaration.
     (GLSLstd450UMax)
 
   <tr algorithm="signed max">
-    <td>|T| is *SignedIntegral*
+    <td>|T| is i32 or vec|N|&lt;i32&gt;
     <td class="nowrap">`max(`|e1|`:` |T| `, `|e2|`:` |T|`) ->` |T|
     <td>Returns |e2| if |e1| is less than |e2|, and |e1| otherwise.
     [=Component-wise=] when |T| is a vector.
@@ -6714,14 +6704,14 @@ That's not a full user-defined function declaration.
     (GLSLstd450UMin)
 
   <tr algorithm="signed min">
-    <td>|T| is *SignedIntegral*
+    <td>|T| is i32 or vec|N|&lt;i32&gt;
     <td class="nowrap">`min(`|e1|`:` |T| `, `|e2|`:` |T|`) ->` |T|
     <td>Returns |e1| if |e1| is less than |e2|, and |e2| otherwise.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd45SUMin)
 
   <tr algorithm="bit reversal">
-    <td>|T| is *Integral*
+    <td>|T| is i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;
     <td class="nowrap">`reverseBits(`|e|`:` |T| `) ->`  |T|
     <td>Reverses the bits in |e|:  The bit at position |k| of the result equals the
         bit at position 31-|k| of |e|.<br>


### PR DESCRIPTION
* Change duplicate signed integer comparisons to have a set of unsigned
  integer comparisons instead
* remove type shorthands and instead spell out explicitly the types