### PR TITLE
Add a validation rule for buffer offset during B2T/T2B copy

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7545,8 +7545,8 @@ GPUQueue includes GPUObjectBase;
 
                             Note: unlike
                             {{GPUCommandEncoder}}.{{GPUCommandEncoder/copyBufferToTexture()}},
-                            there is no alignment requirement on
-                            |dataLayout|.{{GPUImageDataLayout/bytesPerRow}}.
+                            there is no alignment requirement on either
+                            |dataLayout|.{{GPUImageDataLayout/bytesPerRow}} or |dataLayout|.{{GPUImageDataLayout/offset}}.
                         </div>
                     1. Write |contents| into |destination|.
 


### PR DESCRIPTION
buffer offset in B2T/T2B copy must be a multiple of blockWidth of
copied texture's format


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Richard-Yunchao/gpuweb/pull/1750.html" title="Last updated on May 20, 2021, 7:34 PM UTC (4c936e2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1750/7c0dada...Richard-Yunchao:4c936e2.html" title="Last updated on May 20, 2021, 7:34 PM UTC (4c936e2)">Diff</a>