### PR TITLE
Restrict barriers to compute shader stage

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7509,6 +7509,7 @@ operations program-ordered before the synchronization function must be visible
 to all other threads in the workgroup before any affected memory or atomic
 operation program-ordered after the synchronization function is executed by a
 member of the workgroup.
+All synchronization functions must only be used in the [=compute=] shader stage.
 
 storageBarrier affects memory and atomic operations in the [=storage
 classes/storage=] storage class.


### PR DESCRIPTION
We only have workgroup barriers so restrict barrier to compute shader stage.