### PR TITLE
wgsl: Remove stale "location" decoration example

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2812,9 +2812,6 @@ global_variable_decl
 
 <div class='example' heading="Variable Decorations">
   <xmp>
-    [[location(2)]]
-       OpDecorate %variable Location 2
-
     [[group(4), binding(3)]]
        OpDecorate %variable DescriptorSet 4
        OpDecorate %variable Binding 3


### PR DESCRIPTION
Fixes: #1746