### PR TITLE
wgsl: Clarify coordinate use by cube textures

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2115,7 +2115,10 @@ A texture has the following features:
 :  dimensionality
 :: The number of dimensions in the grid coordinates, and how the coordinates are interpreted.
     The number of dimensions is 1, 2, or 3.
-    In some cases the third coordinate is decomposed so as to specify a cube face and a layer index.
+    Most textures use cartesian coordinates.
+    Cube textures have six square faces, and are sampled with
+    a three dimensional coordinate interpreted as a direction vector from the origin toward
+    the cube centered on the orgin.
 : size
 :: The extent of grid coordinates along each dimension
 : mipmap levels


### PR DESCRIPTION
This is a companion to #1754 which clarifies the result
of textureDimensions for cube textures.

Also, the case where the third dimension is decoded to compute
a face index only applies to SPIR-V's OpImageTexelPointer
which is only used with image atomics.  Image atomics are not
supported by WGSL.