### PR TITLE
wgsl: infer var store type from initializer

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2933,9 +2933,12 @@ and until the end of the brace-delimited list of statements immediately enclosin
 
 A function-scope let-declared constant must be of [=atomic-free=] [=plain type=], or of [=pointer type=].
 
-A variable declared in function scope is always in the [=storage classes/function=] storage class.
-The variable storage decoration is optional.
-The variable's [=store type=] must be a [=atomic-free=] [=plain type=].
+For a variable declared in function scope:
+* The variable is always in the [=storage classes/function=] storage class.
+* The storage decoration is optional.
+* The [=store type=] must be an [=atomic-free=] [=plain type=].
+* When an initializer is specified, the store type may be omitted from the declaration.
+    In this case the store type is the type of the result of evaluating the initializer.
 
 <div class='example wgsl global-scope' heading="Function scope variables and constants">
   <xmp highlight='rust'>
@@ -2943,7 +2946,8 @@ The variable's [=store type=] must be a [=atomic-free=] [=plain type=].
        var<function> count: u32;  // A variable in function storage class.
        var delta: i32;            // Another variable in the function storage class.
        var sum: f32 = 0.0;        // A function storage class variable with initializer.
-       let unit: i32 = 1;       // A constant. Let declarations don't use a storage class.
+       var pi: = 3.14159;         // Infer the f32 store type from the initializer.
+       let unit: i32 = 1;         // Let-declared constants don't use a storage class.
     }
   </xmp>
 </div>


### PR DESCRIPTION
This only occurs for variables declared in function scope.

Fixes: #1550