### PR TITLE
Remove colliding [[device]] slot from GPUDevice

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -618,10 +618,9 @@ This would let validity be immutable, and only operations involving devices, buf
 
         1. If any of the following conditions are unsatisfied return `false`:
             <div class=validusage>
-                - |object| is [=valid=].
+                - |object| is [=valid=]
                 - |object|.{{GPUObjectBase/[[device]]}} is [=valid=].
-                - If |targetObject| is a {{GPUDevice}} |object|.{{GPUObjectBase/[[device]]}} is |targetObject|.
-                - Otherwise |object|.{{GPUObjectBase/[[device]]}} is |targetObject|.{{GPUObjectBase/[[device]]}}.
+                - |object|.{{GPUObjectBase/[[device]]}} is |targetObject|.{{GPUObjectBase/[[device]]}}.
             </div>
         1. Return `true`.
 </div>
@@ -1702,13 +1701,8 @@ GPUDevice includes GPUObjectBase;
         The primary {{GPUQueue}} for this device.
 </dl>
 
-{{GPUDevice}} has the following internal slots:
-
-<dl dfn-type=attribute dfn-for=GPUDevice>
-    : <dfn>\[[device]]</dfn>, of type [=device=], readonly
-    ::
-        The [=device=] that this {{GPUDevice}} refers to.
-</dl>
+The {{GPUObjectBase/[[device]]}} for a {{GPUDevice}} is the [=device=] that the {{GPUDevice}} refers
+to.
 
 {{GPUDevice}} has the methods listed in its WebIDL definition above.
 Those not defined here are defined elsewhere in this document.
@@ -1722,7 +1716,7 @@ Those not defined here are defined elsewhere in this document.
         <div algorithm=GPUDevice.destroy()>
             **Called on:** {{GPUDevice}} |this|.
 
-            1. [=Lose the device=](|this|.{{GPUDevice/[[device]]}},
+            1. [=Lose the device=](|this|.{{GPUObjectBase/[[device]]}},
                 {{GPUDeviceLostReason/"destroyed"}}).
         </div>
 
@@ -1739,14 +1733,14 @@ Those not defined here are defined elsewhere in this document.
      1. Set |serialized|.agentCluster to be the [=surrounding agent=]'s [=agent cluster=].
      1. If |serialized|.agentCluster's [=cross-origin isolated capability=] is false, throw a "{{DataCloneError}}".
      1. If |forStorage| is `true`, throw a "{{DataCloneError}}".
-     1. Set |serialized|.device to the value of |value|.{{GPUDevice/[[device]]}}.
+     1. Set |serialized|.device to the value of |value|.{{GPUObjectBase/[[device]]}}.
 </div>
 
 <div algorithm>
     <dfn abstract-op>The steps to deserialize a GPUDevice object</dfn>,
     given |serialized| and |value|, are:
      1. If |serialized|.agentCluster is not the [=surrounding agent=]'s [=agent cluster=], throw a "{{DataCloneError}}".
-     1. Set |value|.{{GPUDevice/[[device]]}} to |serialized|.device.
+     1. Set |value|.{{GPUObjectBase/[[device]]}} to |serialized|.device.
 </div>
 
 Issue: `GPUDevice` doesn't really need the cross-origin policy restriction.
@@ -2293,7 +2287,7 @@ interface GPUTextureUsage {
             1. Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
                     1. If |descriptor|.{{GPUTextureDescriptor/format}} is a {{GPUTextureFormat}} that requires a feature (see
-                        [[#texture-format-caps]]), but |this|.{{GPUDevice/[[device]]}}.{{device/[[features]]}} does not
+                        [[#texture-format-caps]]), but |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} does not
                         [=list/contain=] the feature, throw a {{TypeError}}.
                     1. If any of the following requirements are unmet:
                         <div class=validusage>
@@ -3462,7 +3456,7 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                             - The {{GPUBindGroupLayoutEntry/binding}} of each entry in |descriptor| is unique.
                             - |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}} must not
                                 [=exceeds the binding slot limits|exceed the binding slot limits=]
-                                of |this|.{{GPUDevice/[[device]]}}.{{device/[[limits]]}}.
+                                of |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.
                             - For each {{GPUBindGroupLayoutEntry}} |entry| in |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
                                 - Let |bufferLayout| be |entry|.{{GPUBindGroupLayoutEntry/buffer}}
                                 - Let |samplerLayout| be |entry|.{{GPUBindGroupLayoutEntry/sampler}}
@@ -3600,7 +3594,7 @@ A {{GPUBindGroup}} object has the following internal slots:
             **Returns:** {{GPUBindGroup}}
 
             1. Let |bindGroup| be a new valid {{GPUBindGroup}} object.
-            1. Let |limits| be |this|.{{GPUDevice/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxUniformBufferBindingSize}}.
+            1. Let |limits| be |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxUniformBufferBindingSize}}.
             1. Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
                     1. If any of the following conditions are unsatisfied:
@@ -3798,7 +3792,7 @@ dictionary GPUPipelineLayoutDescriptor : GPUObjectDescriptorBase {
 
             1. If any of the following requirements are unmet:
                 <div class=validusage>
-                    Let |limits| be |this|.{{GPUDevice/[[device]]}}.{{device/[[limits]]}}.
+                    Let |limits| be |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.
 
                     Let |allEntries| be the result of concatenating
                         |bgl|.{{GPUBindGroupLayout/[[descriptor]]}}.{{GPUBindGroupLayoutDescriptor/entries}}
@@ -4969,12 +4963,12 @@ dictionary GPUVertexAttribute {
     Return `true`, if and only if, all of the following conditions are satisfied:
 
         - |descriptor|.{{GPUVertexBufferLayout/arrayStride}} &le;
-            |device|.{{GPUDevice/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBufferArrayStride}}.
+            |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBufferArrayStride}}.
         - |descriptor|.{{GPUVertexBufferLayout/arrayStride}} is a multiple of 4.
         - For each attribute |attrib| in the list |descriptor|.{{GPUVertexBufferLayout/attributes}}:
             - If |descriptor|.{{GPUVertexBufferLayout/arrayStride}} is zero:
                 - |attrib|.{{GPUVertexAttribute/offset}} + sizeof(|attrib|.{{GPUVertexAttribute/format}}) &le;
-                    |device|.{{GPUDevice/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBufferArrayStride}}.
+                    |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBufferArrayStride}}.
 
                 Otherwise:
                 - |attrib|.{{GPUVertexAttribute/offset}} + sizeof(|attrib|.{{GPUVertexAttribute/format}}) &le;
@@ -4982,7 +4976,7 @@ dictionary GPUVertexAttribute {
             - |attrib|.{{GPUVertexAttribute/offset}} is a multiple of the size of one component of
                 |attrib|.{{GPUVertexAttribute/format}}.
             - |attrib|.{{GPUVertexAttribute/shaderLocation}} is less than
-                |device|.{{GPUDevice/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexAttributes}}.
+                |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexAttributes}}.
         - For every vertex attribute in the shader reflection of |vertexStage|.{{GPUProgrammableStage/module}}
             that is know to be [=statically used=] by |vertexStage|.{{GPUProgrammableStage/entryPoint}},
             there is a corresponding |attrib| element of |descriptor|.{{GPUVertexBufferLayout/attributes}} for which
@@ -5000,13 +4994,13 @@ dictionary GPUVertexAttribute {
     Return `true`, if and only if, all of the following conditions are satisfied:
 
         - |descriptor|.{{GPUVertexState/buffers}}.length is less than or equal to
-            |device|.{{GPUDevice/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBuffers}}.
+            |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBuffers}}.
         - Each |vertexBuffer| layout descriptor in the list |descriptor|.{{GPUVertexState/buffers}}
             passes [$validating GPUVertexBufferLayout$](|device|, |vertexBuffer|, |descriptor|)
         - The sum of |vertexBuffer|.{{GPUVertexBufferLayout/attributes}}.length,
             over every |vertexBuffer| in |descriptor|.{{GPUVertexState/buffers}},
             is less than or equal to
-            |device|.{{GPUDevice/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexAttributes}}.
+            |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexAttributes}}.
         - Each |attrib| in the union of all {{GPUVertexAttribute}}
             across |descriptor|.{{GPUVertexState/buffers}} has a distinct
             |attrib|.{{GPUVertexAttribute/shaderLocation}} value.
@@ -5856,7 +5850,7 @@ must be well nested.
 
             **Returns:** {{undefined}}
 
-            1. If |this|.{{GPUDevice/[[device]]}}.{{device/[[features]]}} does not [=list/contain=]
+            1. If |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} does not [=list/contain=]
                 {{GPUFeatureName/"timestamp-query"}}, throw a {{TypeError}}.
             1. If any of the following conditions are unsatisfied, generate a validation error and stop.
                 <div class=validusage>
@@ -6341,7 +6335,7 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
 
             **Returns:** {{undefined}}
 
-            1. If |this|.{{GPUDevice/[[device]]}}.{{device/[[features]]}} does not [=list/contain=]
+            1. If |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} does not [=list/contain=]
                 {{GPUFeatureName/"pipeline-statistics-query"}}, throw a {{TypeError}}.
 
             Issue: Describe {{GPUComputePassEncoder/beginPipelineStatisticsQuery()}} algorithm steps.
@@ -6355,7 +6349,7 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
 
             **Returns:** {{undefined}}
 
-            1. If |this|.{{GPUDevice/[[device]]}}.{{device/[[features]]}} does not [=list/contain=]
+            1. If |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} does not [=list/contain=]
                 {{GPUFeatureName/"pipeline-statistics-query"}}, throw a {{TypeError}}.
 
             Issue: Describe {{GPUComputePassEncoder/endPipelineStatisticsQuery()}} algorithm steps.
@@ -6376,7 +6370,7 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
 
             **Returns:** {{undefined}}
 
-            1. If |this|.{{GPUDevice/[[device]]}}.{{device/[[features]]}} does not [=list/contain=]
+            1. If |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} does not [=list/contain=]
                 {{GPUFeatureName/"timestamp-query"}}, throw a {{TypeError}}.
             1. If any of the following conditions are unsatisfied, generate a validation error and stop.
                 <div class=validusage>
@@ -7222,7 +7216,7 @@ attachments used by this encoder.
 
             **Returns:** {{undefined}}
 
-            1. If |this|.{{GPUDevice/[[device]]}}.{{device/[[features]]}} does not [=list/contain=]
+            1. If |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} does not [=list/contain=]
                 {{GPUFeatureName/"pipeline-statistics-query"}}, throw a {{TypeError}}.
 
             Issue: Describe {{GPURenderPassEncoder/beginPipelineStatisticsQuery()}} algorithm steps.
@@ -7236,7 +7230,7 @@ attachments used by this encoder.
 
             **Returns:** {{undefined}}
 
-            1. If |this|.{{GPUDevice/[[device]]}}.{{device/[[features]]}} does not [=list/contain=]
+            1. If |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} does not [=list/contain=]
                 {{GPUFeatureName/"pipeline-statistics-query"}}, throw a {{TypeError}}.
 
             Issue: Describe {{GPURenderPassEncoder/endPipelineStatisticsQuery()}} algorithm steps.
@@ -7257,7 +7251,7 @@ attachments used by this encoder.
 
             **Returns:** {{undefined}}
 
-            1. If |this|.{{GPUDevice/[[device]]}}.{{device/[[features]]}} does not [=list/contain=]
+            1. If |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} does not [=list/contain=]
                 {{GPUFeatureName/"timestamp-query"}}, throw a {{TypeError}}.
             1. If any of the following conditions are unsatisfied, generate a validation error and stop.
                 <div class=validusage>
@@ -7728,10 +7722,10 @@ dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
             **Returns:** {{GPUQuerySet}}
 
             1. If |descriptor|.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/"pipeline-statistics"}},
-                but |this|.{{GPUDevice/[[device]]}}.{{device/[[features]]}} does not [=list/contain=]
+                but |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} does not [=list/contain=]
                 {{GPUFeatureName/"pipeline-statistics-query"}}, throw a {{TypeError}}.
             1. If |descriptor|.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/"timestamp"}},
-                but |this|.{{GPUDevice/[[device]]}}.{{device/[[features]]}} does not [=list/contain=]
+                but |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} does not [=list/contain=]
                 {{GPUFeatureName/"timestamp-query"}}, throw a {{TypeError}}.
             1. If any of the following requirements are unmet, return an error query set and stop.
                 <div class=validusage>


### PR DESCRIPTION
GPUDevice implements GPUObjectBase, which means it implicitly has
a [[device]] slot already. Updates any instances referring to
GPUDevice.[[device]] to point at the GPUObjectBase version instead
and simplifies the "valid to use with" algorithm as a result.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/1758.html" title="Last updated on Jun 1, 2021, 4:44 PM UTC (15959f6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1758/de6eefd...15959f6.html" title="Last updated on Jun 1, 2021, 4:44 PM UTC (15959f6)">Diff</a>