### PR TITLE
publish-specs: run on all PRs, remove special syntax from matrix

### DIFF
--- a/.github/workflows/publish-specs.yml
+++ b/.github/workflows/publish-specs.yml
@@ -12,11 +12,6 @@ name: Build, validate and publish spec to GitHub Pages and /TR
 
 on:
   pull_request:
-    paths:
-      - '.github/**'
-      - 'spec/**'
-      - 'wgsl/**'
-      - 'explainer/**'
   push:
     branches: [main]
     paths:
@@ -38,15 +33,11 @@ jobs:
           - source: spec/index.bs
             destination: index.html
             echidna_token: ECHIDNA_TOKEN_WEBGPU
-            w3c_build_override: |
-              group: gpuwg
-              status: WD
+            w3c_build_override_status: WD
           - source: wgsl/index.bs
             destination: wgsl/index.html
             echidna_token: ECHIDNA_TOKEN_WGSL
-            w3c_build_override: |
-              group: gpuwg
-              status: WD
+            w3c_build_override_status: WD
           - source: explainer/index.bs
             destination: explainer/index.html
             # Explainer is not published to /TR, no echidna_token
@@ -65,4 +56,6 @@ jobs:
           GH_PAGES_BRANCH: gh-pages
           W3C_ECHIDNA_TOKEN: ${{ secrets[matrix.echidna_token] }}
           W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-gpu/2021Apr/0004.html
-          W3C_BUILD_OVERRIDE: ${{ matrix.w3c_build_override }}
+          W3C_BUILD_OVERRIDE: |
+            group: gpuwg
+            status: ${{ matrix.w3c_build_override_status }}


### PR DESCRIPTION
Run on all PRs, so we can make it required by github branch protection.

Remove special syntax from the matrix in an attempt to make github
actually allow us to reference these checks in the branch protection
settings.