### PR TITLE
Remove % for signed integral

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3855,10 +3855,6 @@ Issue: Which index is used when it's out of bounds?
     <td>|e1| `/` |e2| : |T|
     <td>Floating point division. [=Component-wise=] when |T| is a vector. (OpFDiv)
 
-  <tr algorithm="signed integer remainder">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [SIGNEDINTEGRAL]
-    <td>|e1| `%` |e2| : |T|
-    <td>Signed integer remainder. [=Component-wise=] when |T| is a vector. (OpSMod)
   <tr algorithm="unsigned integer modulus">
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [UNSIGNEDINTEGRAL]
     <td>|e1| `%` |e2| : |T|
@@ -4331,7 +4327,6 @@ multiplicative_expression
       OpFDiv
   | multiplicative_expression MODULO unary_expression
       OpUMOd
-      OpSMod
       OpFMod
 
 additive_expression


### PR DESCRIPTION
In Vulkan, OpSMod is undefined if either operand is negative. The spec
explicit says it's no more functional than OpUMod.
https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#spirvenv-precision-operation