### PR TITLE
Update GPUAdapterLimits to GPUSupportedLimits

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1004,7 +1004,8 @@ A [=device=] has the following internal slots:
 
     - Let |device|.{{device/[[limits]]}} be a [=supported limits=] object with the default values.
         For each (|key|, |value|) pair in |descriptor|.{{GPUDeviceDescriptor/nonGuaranteedLimits}}, set the
-        member corresponding to |key| in |device|.{{device/[[limits]]}} to the value |value|.
+        member corresponding to |key| in |device|.{{device/[[limits]]}} to the [=limit/better=]
+        value of |value| or the default value in [=supported limits=].
 </div>
 
 Any time the user agent needs to revoke access to a device, it calls
@@ -1194,14 +1195,14 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
         when creating a {{GPURenderPipeline}}.
 </table>
 
-#### <dfn interface>GPUAdapterLimits</dfn> #### {#gpu-adapterlimits}
+#### <dfn interface>GPUSupportedLimits</dfn> #### {#gpu-supportedlimits}
 
-{{GPUAdapterLimits}} exposes the [=limits=] supported by an adapter.
-See {{GPUAdapter/limits|GPUAdapter.limits}}.
+{{GPUSupportedLimits}} exposes the [=limits=] supported by an adapter or device.
+See {{GPUAdapter/limits|GPUAdapter.limits}} and {{GPUDevice/limits|GPUDevice.limits}}.
 
 <script type=idl>
 [Exposed=Window]
-interface GPUAdapterLimits {
+interface GPUSupportedLimits {
     readonly attribute unsigned long maxTextureDimension1D;
     readonly attribute unsigned long maxTextureDimension2D;
     readonly attribute unsigned long maxTextureDimension3D;
@@ -1496,7 +1497,7 @@ To get a {{GPUAdapter}}, use {{GPU/requestAdapter()}}.
 interface GPUAdapter {
     readonly attribute DOMString name;
     [SameObject] readonly attribute GPUSupportedFeatures features;
-    [SameObject] readonly attribute GPUAdapterLimits limits;
+    [SameObject] readonly attribute GPUSupportedLimits limits;
 
     Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor = {});
 };
@@ -1653,7 +1654,7 @@ To get a {{GPUDevice}}, use {{GPUAdapter/requestDevice()}}.
 [Exposed=(Window, DedicatedWorker), Serializable]
 interface GPUDevice : EventTarget {
     [SameObject] readonly attribute GPUSupportedFeatures features;
-    readonly attribute object limits;
+    [SameObject] readonly attribute GPUSupportedLimits limits;
 
     [SameObject] readonly attribute GPUQueue queue;
 
@@ -1694,8 +1695,6 @@ GPUDevice includes GPUObjectBase;
     ::
         Exposes the limits supported by the device
         (which are exactly the ones with which it was created).
-
-        Issue: Should this be an `interface GPUSupportedLimits`?
 
     : <dfn>queue</dfn>
     ::
@@ -2309,7 +2308,7 @@ interface GPUTextureUsage {
                                     : {{GPUTextureDimension/"1d"}}
                                     ::
                                         - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be less than or equal to
-                                            |this|.{{GPUAdapterLimits/maxTextureDimension1D}}.
+                                            |this|.{{GPUSupportedLimits/maxTextureDimension1D}}.
                                         - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be 1.
                                         - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be 1.
                                         - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
@@ -2318,20 +2317,20 @@ interface GPUTextureUsage {
                                     : {{GPUTextureDimension/"2d"}}
                                     ::
                                         - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be less than or equal to
-                                            |this|.{{GPUAdapterLimits/maxTextureDimension2D}}.
+                                            |this|.{{GPUSupportedLimits/maxTextureDimension2D}}.
                                         - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be less than or equal to
-                                            |this|.{{GPUAdapterLimits/maxTextureDimension2D}}.
+                                            |this|.{{GPUSupportedLimits/maxTextureDimension2D}}.
                                         - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be less than
-                                            or equal to |this|.{{GPUAdapterLimits/maxTextureArrayLayers}}.
+                                            or equal to |this|.{{GPUSupportedLimits/maxTextureArrayLayers}}.
 
                                     : {{GPUTextureDimension/"3d"}}
                                     ::
                                         - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be less than or equal to
-                                            |this|.{{GPUAdapterLimits/maxTextureDimension3D}}.
+                                            |this|.{{GPUSupportedLimits/maxTextureDimension3D}}.
                                         - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be less than or equal to
-                                            |this|.{{GPUAdapterLimits/maxTextureDimension3D}}.
+                                            |this|.{{GPUSupportedLimits/maxTextureDimension3D}}.
                                         - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be less than
-                                            or equal to |this|.{{GPUAdapterLimits/maxTextureDimension3D}}.
+                                            or equal to |this|.{{GPUSupportedLimits/maxTextureDimension3D}}.
                                         - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
                                         - |descriptor|.{{GPUTextureDescriptor/format}} must not be a compressed format or depth/stencil format.
                                 </dl>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2308,7 +2308,7 @@ interface GPUTextureUsage {
                                     : {{GPUTextureDimension/"1d"}}
                                     ::
                                         - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be less than or equal to
-                                            |this|.{{GPUSupportedLimits/maxTextureDimension1D}}.
+                                            |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension1D}}.
                                         - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be 1.
                                         - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be 1.
                                         - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
@@ -2317,20 +2317,20 @@ interface GPUTextureUsage {
                                     : {{GPUTextureDimension/"2d"}}
                                     ::
                                         - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be less than or equal to
-                                            |this|.{{GPUSupportedLimits/maxTextureDimension2D}}.
+                                            |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
                                         - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be less than or equal to
-                                            |this|.{{GPUSupportedLimits/maxTextureDimension2D}}.
+                                            |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
                                         - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be less than
-                                            or equal to |this|.{{GPUSupportedLimits/maxTextureArrayLayers}}.
+                                            or equal to |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureArrayLayers}}.
 
                                     : {{GPUTextureDimension/"3d"}}
                                     ::
                                         - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be less than or equal to
-                                            |this|.{{GPUSupportedLimits/maxTextureDimension3D}}.
+                                            |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension3D}}.
                                         - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be less than or equal to
-                                            |this|.{{GPUSupportedLimits/maxTextureDimension3D}}.
+                                            |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension3D}}.
                                         - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be less than
-                                            or equal to |this|.{{GPUSupportedLimits/maxTextureDimension3D}}.
+                                            or equal to |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension3D}}.
                                         - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
                                         - |descriptor|.{{GPUTextureDescriptor/format}} must not be a compressed format or depth/stencil format.
                                 </dl>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1555,15 +1555,15 @@ interface GPUAdapter {
                         <div class=validusage>
                             - The set of values in |descriptor|.{{GPUDeviceDescriptor/nonGuaranteedFeatures}}
                                 must be a subset of those in |adapter|.{{adapter/[[features]]}}.
-
-                            - Each key in |descriptor|.{{GPUDeviceDescriptor/nonGuaranteedLimits}}
-                                must be the name of a member of [=supported limits=].
                         </div>
 
                     1. If any of the following requirements are unmet,
                         [=reject=] |promise| with an {{OperationError}} and stop.
 
                         <div class=validusage>
+                            - Each key in |descriptor|.{{GPUDeviceDescriptor/nonGuaranteedLimits}}
+                                must be the name of a member of [=supported limits=].
+
                             - For each type of limit in [=supported limits=], the value of that
                                 limit in |descriptor|.{{GPUDeviceDescriptor/nonGuaranteedLimits}}
                                 must be no [=limit/better=] than the value of that limit in


### PR DESCRIPTION
Previously the `GPUDevice` had a `limits` attribute that was of type `object`, but there doesn't seem to be any reason why it can't share an interface with the `GPUAdapter`'s limits. To reflect that shared use that interface gets renamed to `GPUSupportedLimits` like the `GPUSupportedFeatures` before it.

Additionally, there's been some discussion about what should happen when the user defines limits that are worse than the default limits. This change adds some logic to clamp them to the default value, but we shouldn't land it till we agree on what should happen. I just wanted to demonstrate how one approach to that problem could work.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/1765.html" title="Last updated on May 27, 2021, 6:30 PM UTC (ed539b8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1765/8d8c931...ed539b8.html" title="Last updated on May 27, 2021, 6:30 PM UTC (ed539b8)">Diff</a>