### PR TITLE
Add `void` to the reserved keywords list

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6047,6 +6047,8 @@ The following is a list of keywords which are reserved for future expansion.
     <td>regardless
     <td>premerge
     <td>handle
+  <tr>
+    <td>void
 </table>
 
 ## Syntactic Tokens ## {#syntactic-tokens}


### PR DESCRIPTION
The `void` type was removed in [this PR](https://github.com/gpuweb/gpuweb/pull/1460), which includes this comment:
> If we ever feel that the type is needed, we can bring it back.

We should make this a reserved keyword in case we do indeed need to bring it back.