### PR TITLE
copyExternalImageToTexture: add colorSpace and premultipliedAlpha

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1287,8 +1287,8 @@ enum GPUPredefinedColorSpace {
 };
 </script>
 
-Issue: Replace this with the `PredefinedColorSpaceEnum` from the
-[canvas color space proposal](https://github.com/WICG/canvas-color-space/blob/main/CanvasColorSpaceProposal.md).
+Issue: Possibly replace this with {{PredefinedColorSpace}}, but note that doing so would mean new
+WebGPU functionality gets added automatically when items are added to that enum in the upstream spec.
 
 Issue(gpuweb/gpuweb#1715):
 Consider a path for uploading srgb-encoded images into linearly-encoded textures.
@@ -5414,6 +5414,48 @@ dictionary GPUImageCopyTexture {
 
 Issue(gpuweb/gpuweb#69): Define the copies with {{GPUTextureDimension/1d}} and {{GPUTextureDimension/3d}} textures.
 
+### <dfn dictionary>GPUImageCopyTextureTagged</dfn> ### {#gpu-image-copy-texture-tagged}
+
+WebGPU textures hold raw numeric data, and are not tagged with semantic metadata describing colors.
+However, {{GPUQueue/copyExternalImageToTexture()}} copies from sources that describe colors.
+
+A {{GPUImageCopyTextureTagged}} is a {{GPUImageCopyTexture}} which is additionally tagged with
+color space/encoding and alpha-premultiplication metadata, so that semantic color data may be
+preserved during copies.
+This metadata only affects the semantics of the {{GPUQueue/copyExternalImageToTexture()}} call.
+
+<script type=idl>
+dictionary GPUImageCopyTextureTagged : GPUImageCopyTexture {
+    GPUPredefinedColorSpace colorSpace = "srgb";
+    boolean premultipliedAlpha = false;
+};
+</script>
+
+<dl dfn-type=dict-member dfn-for=GPUImageCopyTextureTagged>
+    : <dfn>colorSpace</dfn>
+    ::
+        Describes the color space and encoding used to encode data into the destination texture.
+
+        Note:
+        If {{GPUImageCopyTextureTagged/colorSpace}} matches the source image, no conversion occurs.
+        {{ImageBitmap}} color space tagging and conversion can be controlled via {{ImageBitmapOptions}}.
+
+    : <dfn>premultipliedAlpha</dfn>
+    ::
+        Describes whether the data written into the texture should be have its RGB channels
+        premultiplied by the alpha channel, or not.
+
+        If this option is set to `true` and the {{GPUImageCopyExternalImage/source}} is also
+        premultiplied, the source RGB values must be preserved even if they exceed their
+        corresponding alpha values.
+
+        Note:
+        If {{GPUImageCopyTextureTagged/premultipliedAlpha}} matches the source image, no conversion occurs.
+        2d canvases are [[html#premultiplied-alpha-and-the-2d-rendering-context|always premultiplied]],
+        while WebGL canvases can be controlled via <l spec=html>[=WebGLContextAttributes=]</l>.
+        {{ImageBitmap}} premultiplication can be controlled via {{ImageBitmapOptions}}.
+</dl>
+
 ### <dfn dictionary>GPUImageCopyExternalImage</dfn> ### {#gpu-image-copy-external-image}
 
 <script type=idl>
@@ -7437,7 +7479,7 @@ interface GPUQueue {
 
     undefined copyExternalImageToTexture(
         GPUImageCopyExternalImage source,
-        GPUImageCopyTexture destination,
+        GPUImageCopyTextureTagged destination,
         GPUExtent3D copySize);
 };
 GPUQueue includes GPUObjectBase;
@@ -7559,17 +7601,13 @@ GPUQueue includes GPUObjectBase;
         Issues a copy operation of the contents of a platform image/canvas
         into the destination texture.
 
-        Issue: A color conversion to a {{GPUPredefinedColorSpace}} is necessary here.
-        Temporarily disallow float targets until there is an upstream decision on whether "srgb"
-        means extended-srgb or clamped-srgb.
-
         <div algorithm=GPUQueue.copyExternalImageToTexture>
             **Called on:** {{GPUQueue}} this.
 
             **Arguments:**
             <pre class=argumentdef for="GPUQueue/copyExternalImageToTexture(source, destination, copySize)">
                 |source|: source image and origin to copy to |destination|.
-                |destination|: The [=texture subresource=] and origin to write to.
+                |destination|: The [=texture subresource=] and origin to write to, and its encoding metadata.
                 |copySize|: Extents of the content to write from |source| to |destination|.
             </pre>
 
@@ -7591,15 +7629,15 @@ GPUQueue includes GPUObjectBase;
                     - {{GPUTextureFormat/"bgra8unorm"}}
                     - {{GPUTextureFormat/"bgra8unorm-srgb"}}
                     - {{GPUTextureFormat/"rgb10a2unorm"}}
-                    - {{GPUTextureFormat/"rgba16float"}}
-                    - {{GPUTextureFormat/"rgba32float"}}
                     - {{GPUTextureFormat/"rg8unorm"}}
-                    - {{GPUTextureFormat/"rg16float"}}
             </div>
 
             Issue: The above list was written just for ImageBitmap.
             Re-evaluate it for canvas (and video).
             (It's probably still fine, though `rgb10a2unorm` is a bit of an outlier.)
+
+            Issue: Add float formats once the behavior can be defined - need an upstream
+            clarification on whether "srgb" means extended-srgb or clamped-srgb.
         </div>
 
     : <dfn>submit(commandBuffers)</dfn>


### PR DESCRIPTION
Issues: #1483, #1762


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1768.html" title="Last updated on May 26, 2021, 2:12 AM UTC (ef94dff)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1768/7609f1e...kainino0x:ef94dff.html" title="Last updated on May 26, 2021, 2:12 AM UTC (ef94dff)">Diff</a>