### PR TITLE
Remove workgroup_size builtin

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6195,12 +6195,6 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
       group_count_y, group_count_z)`, of the compute shader
       [[WebGPU#dom-gpucomputepassencoder-dispatch|dispatched]] by the API.
 
-  <tr><td>`workgroup_size`
-      <td>compute
-      <td>in
-      <td>vec3&lt;u32&gt;
-      <td style="width:50%">The [=workgroup_size=] of the current entry point.
-
   <tr><td>`sample_index`
       <td>fragment
       <td>in


### PR DESCRIPTION
This provides no functionality, and no longer provides any convenience
either now that builtins are specified as entry point parameters.

See [here](https://github.com/gpuweb/gpuweb/issues/1590) for more context.