### PR TITLE
wgsl: Fix typo for modf pointer type

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6677,7 +6677,7 @@ That's not a full user-defined function declaration.
     <td>|T| is [FLOATING]
         |SC| is a storage class<br>
         |A| is [=access/write=] or [=access/read_write=]
-    <td class="nowrap">`modf(`|e1|`:` |T| `, `|e2|`:` ptr&gt;|SC|,|T|,|A|&gt; `) -> ` |T|
+    <td class="nowrap">`modf(`|e1|`:` |T| `, `|e2|`:` ptr&lt;|SC|,|T|,|A|&gt; `) -> ` |T|
     <td>Splits |e1| into fractional and whole number parts.
     Returns the fractional part and stores the whole number through the pointer |e2|.
     [=Component-wise=] when |T| is a vector.


### PR DESCRIPTION
Needed &lt; instead of &gt;