### PR TITLE
wgsl: define texture type parameterization

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6928,6 +6928,13 @@ That's not a full user-defined function declaration.
 
 ## Texture built-in functions ## {#texture-builtin-functions}
 
+In this section, texture types are shown with the following parameters:
+* |T|, a sampled type.
+* <var ignore>F</var>, a texel format.
+* <var ignore>A</var>, an access mode.
+
+Parameter values must be valid for the respective texture types.
+
 ### `textureDimensions` ### {#texturedimensions}
 
 Returns the dimensions of a texture, or texture's mip level in texels.
@@ -6953,10 +6960,10 @@ textureDimensions(t: texture_depth_cube) -> vec2<i32>
 textureDimensions(t: texture_depth_cube, level: i32) -> vec2<i32>
 textureDimensions(t: texture_depth_cube_array) -> vec2<i32>
 textureDimensions(t: texture_depth_cube_array, level: i32) -> vec2<i32>
-textureDimensions(t: texture_storage_1d<F>) -> i32
-textureDimensions(t: texture_storage_2d<F>) -> vec2<i32>
-textureDimensions(t: texture_storage_2d_array<F>) -> vec2<i32>
-textureDimensions(t: texture_storage_3d<F>) -> vec3<i32>
+textureDimensions(t: texture_storage_1d<F,A>) -> i32
+textureDimensions(t: texture_storage_2d<F,A>) -> vec2<i32>
+textureDimensions(t: texture_storage_2d_array<F,A>) -> vec2<i32>
+textureDimensions(t: texture_storage_3d<F,A>) -> vec3<i32>
 textureDimensions(t: texture_external) -> vec2<i32>
 ```
 
@@ -7034,7 +7041,7 @@ textureNumLayers(t: texture_2d_array<T>) -> i32
 textureNumLayers(t: texture_cube_array<T>) -> i32
 textureNumLayers(t: texture_depth_2d_array) -> i32
 textureNumLayers(t: texture_depth_cube_array) -> i32
-textureNumLayers(t: texture_storage_2d_array<F>) -> i32
+textureNumLayers(t: texture_storage_2d_array<F,A>) -> i32
 ```
 
 **Parameters:**

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6930,8 +6930,8 @@ That's not a full user-defined function declaration.
 
 In this section, texture types are shown with the following parameters:
 * |T|, a sampled type.
-* <var ignore>F</var>, a texel format.
-* <var ignore>A</var>, an access mode.
+* <var ignore>F</var>, a [=texel format=].
+* <var ignore>A</var>, an [=access mode=].
 
 Parameter values must be valid for the respective texture types.
 


### PR DESCRIPTION
In texture built-ins section, define the parameterization
of the texture types by T, F, and A.

Also, add the access mode (A) parameterization for storage textures
in textureDimensions and textureNumLayers