### PR TITLE
wsgl: remove dead section

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5915,8 +5915,6 @@ However, how do we handle an indirect dispatch that specifies a group count of z
 
 ### Barrier TODO ### {#barrier}
 
-### Image Operations Requiring Uniformity TODO ### {#image-operations-requiring-uniformity}
-
 ### Derivatives ### {#derivatives}
 
 A <dfn noexport>partial derivative</dfn> is the rate of change of a value along an axis.


### PR DESCRIPTION
Remove The "Image operations requiring uniformity (TODO)" section
because its intended content is already covered by the "Derivatives"
section just below it.