### PR TITLE
create_PipelineAsync rejects when failure

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4354,8 +4354,7 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
         Creates a {{GPUComputePipeline}}. The returned {{Promise}} resolves when the created pipeline
         is ready to be used without additional delay.
 
-        If pipeline creation fails, the returned {{Promise}} resolves to an [=invalid=]
-        {{GPUComputePipeline}} object.
+        If pipeline creation fails, the returned {{Promise}} rejects with an {{OperationError}}.
 
         Note: Use of this method is preferred whenever possible, as it prevents blocking the
         [=queue timeline=] work on pipeline compilation.
@@ -4505,8 +4504,7 @@ details.
         Creates a {{GPURenderPipeline}}. The returned {{Promise}} resolves when the created pipeline
         is ready to be used without additional delay.
 
-        If pipeline creation fails, the returned {{Promise}} resolves to an [=invalid=]
-        {{GPURenderPipeline}} object.
+        If pipeline creation fails, the returned {{Promise}} rejects with an {{OperationError}}.
 
         Note: Use of this method is preferred whenever possible, as it prevents blocking the
         [=queue timeline=] work on pipeline compilation.


### PR DESCRIPTION
Change the behavior of createComputePipelineAsync and createRenderPipelineAsync.
If pipeline creation fails, the returned Promise should reject with an OperationError,
rather than return an invalid pipeline.

Fixes #1049


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jzm-intel/gpuweb/pull/1787.html" title="Last updated on Jun 1, 2021, 9:39 PM UTC (a2a3062)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1787/96f50ee...jzm-intel:a2a3062.html" title="Last updated on Jun 1, 2021, 9:39 PM UTC (a2a3062)">Diff</a>