### PR TITLE
wgsl: fix description of correctly rounded

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5963,25 +5963,26 @@ the following exceptions:
 
 ### Floating Point Accuracy ### {#floating-point-accuracy}
 
-An operation is <dfn noexport>correctly rounded</dfn> if its result is a
-floating point number nearest to the exact result computed with infinite
-precision.
-The rounding mode is unspecified for [SHORTNAME].
-If the result, `x`, is exactly representable in floating point, then `x` must be
-returned.
-Otherwise, the floating point value closest to `x` must be returned.
+<div algorithm="correctly rounded">
+Let |x| be the exact real-valued or infinite result of an operation when computed with unbounded precision.
+The <dfn>correctly rounded</dfn> result of the operation for floating point type |T| is:
+* |x|, when |x| is in |T|,
+* Otherwise:
+    * the smallest value in |T| greater than |x|, or
+    * the largest value in |T| less than |x|.
 
-Note: When two floating point values are equally close to `x`, the result can be either.
+</div>
+
+That is, the result may be rounded up or down:
+[SHORTNAME] does not specify a rounding mode.
+
+Note: Floating point types include positive and negative infinity, so
+the correctly rounded result may be finite or infinite.
 
 The units in the last place, <dfn noexport>ULP</dfn>, for a floating point
 number `x` is the minimum distance between two non-equal floating point numbers
 `a` and `b` such that `a` &le; `x` &le; `b` (i.e. `ulp(x) =
 min`<sub>`a,b`</sub>`|b - a|`).
-
-If an allowable return value for any operation is greater in magnitude than the
-largest representable finite floating-point value, then that operation may
-additionally return either the infinity with the same sign or the largest finite
-value with the same sign.
 
 In the following tables, the accuracy of an operation is provided among five
 possibilities:
@@ -5994,6 +5995,11 @@ possibilities:
 
 For any accuracy values specified over a range, the accuracy is undefined for
 results outside that range.
+
+If an allowable return value for any operation is greater in magnitude than the
+largest representable finite floating-point value, then that operation may additionally
+return either the infinity with the same sign or the largest finite
+value with the same sign.
 
 <table class='data'>
   <caption>Accuracy of expressions</caption>


### PR DESCRIPTION
No rounding mode is specified.
Avoid accidentally specifying round-to-nearest.