### PR TITLE
Add texture_depth_multisampled_2d

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3586,7 +3586,7 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                                     - |textureLayout|.{{GPUTextureBindingLayout/viewDimension}} is
                                         {{GPUTextureViewDimension/"2d"}}.
                                     - |textureLayout|.{{GPUTextureBindingLayout/sampleType}} is not
-                                        {{GPUTextureSampleType/"float"}}.
+                                        {{GPUTextureSampleType/"float"}} or {{GPUTextureSampleType/"depth"}}.
 
                                 - If |storageTextureLayout| is not `undefined`:
                                     - |storageTextureLayout|.{{GPUStorageTextureBindingLayout/viewDimension}} is not

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2561,6 +2561,9 @@ For example:
 
 `texture_depth_cube_array`
   %1 = OpTypeImage %f32 Cube 1 1 0 1 Unknown
+
+`texture_depth_multisampled_2d`
+  %1 = OpTypeImage %f32 2D 1 0 1 1 Unknown
 </pre>
 
 ### Sampler Type ### {#sampler-type}
@@ -2634,6 +2637,7 @@ depth_texture_type
   | TEXTURE_DEPTH_2D_ARRAY
   | TEXTURE_DEPTH_CUBE
   | TEXTURE_DEPTH_CUBE_ARRAY
+  | TEXTURE_DEPTH_MULTISAMPLED_2D
 
 texel_format
   : R8UNORM
@@ -6377,6 +6381,7 @@ I've written what an NVIDIA GPU does.  See https://github.com/google/amber/pull/
   <tr><td>`TEXTURE_DEPTH_2D_ARRAY`<td>texture_depth_2d_array
   <tr><td>`TEXTURE_DEPTH_CUBE`<td>texture_depth_cube
   <tr><td>`TEXTURE_DEPTH_CUBE_ARRAY`<td>texture_depth_cube_array
+  <tr><td>`TEXTURE_DEPTH_MULTISAMPLED_2D`<td>texture_depth_multisampled_2d
   <tr><td>`UINT32`<td>u32
   <tr><td>`VEC2`<td>vec2
   <tr><td>`VEC3`<td>vec3
@@ -7331,6 +7336,7 @@ textureDimensions(t: texture_depth_cube) -> vec2<i32>
 textureDimensions(t: texture_depth_cube, level: i32) -> vec2<i32>
 textureDimensions(t: texture_depth_cube_array) -> vec2<i32>
 textureDimensions(t: texture_depth_cube_array, level: i32) -> vec2<i32>
+textureDimensions(t: texture_depth_multisampled_2d)-> vec2<i32>
 textureDimensions(t: texture_storage_1d<F,A>) -> i32
 textureDimensions(t: texture_storage_2d<F,A>) -> vec2<i32>
 textureDimensions(t: texture_storage_2d_array<F,A>) -> vec2<i32>
@@ -7372,6 +7378,7 @@ textureLoad(t: texture_3d<T>, coords: vec3<i32>, level: i32) -> vec4<T>
 textureLoad(t: texture_multisampled_2d<T>, coords: vec2<i32>, sample_index: i32)-> vec4<T>
 textureLoad(t: texture_depth_2d, coords: vec2<i32>, level: i32) -> f32
 textureLoad(t: texture_depth_2d_array, coords: vec2<i32>, array_index: i32, level: i32) -> f32
+textureLoad(t: texture_depth_multisampled_2d, coords: vec2<i32>, sample_index: i32)-> f32
 textureLoad(t: texture_external, coords: vec2<i32>) -> vec4<f32>
 ```
 
@@ -7468,6 +7475,7 @@ Returns the number samples per texel in a multisampled texture.
 
 ```rust
 textureNumSamples(t: texture_multisampled_2d<T>) -> i32
+textureNumSamples(t: texture_depth_multisampled_2d) -> i32
 ```
 
 **Parameters:**


### PR DESCRIPTION
Closes #1924
Fills the gap of https://github.com/gpuweb/gpuweb/issues/1198#issuecomment-852655364

~~If we decide that depth-formatted textures can only be bound as "depth" sample type (so that we don't introduce any overhead for "float" sample types), then we need a way for the shader to read MSAA depth data (in order to resolve it). `texture_depth_multisampled_2d` is a bit weird in this sense, since it can't be comparison-sampled.~~

The group decided to proceed with this on the call today.

~~Consider this a strawman approach!~~


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/1793.html" title="Last updated on Jul 19, 2021, 8:55 PM UTC (ad2eb0d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1793/444482b...kvark:ad2eb0d.html" title="Last updated on Jul 19, 2021, 8:55 PM UTC (ad2eb0d)">Diff</a>