### PR TITLE
Remove the read-only texture storage bindings

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3223,8 +3223,8 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
         <td>{{GPUTextureSampleType/"uint"}}
 
     <tr>
-        <td rowspan=1>{{GPUBindGroupLayoutEntry/storageTexture}}
-        <td rowspan=1>{{GPUTextureView}}
+        <td>{{GPUBindGroupLayoutEntry/storageTexture}}
+        <td>{{GPUTextureView}}
         <td>{{GPUStorageTextureAccess/"write-only"}}
         <td>[=internal usage/storage=]
 
@@ -8861,11 +8861,11 @@ All plain color formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/
 
 Only formats with {{GPUTextureSampleType}} {{GPUTextureSampleType/"float"}} can be blended.
 
-The {{GPUTextureUsage/RENDER_ATTACHMENT|GPUTextureUsage.RENDER_ATTACHMENT}} column specifies the support for
-{{GPUTextureUsage/RENDER_ATTACHMENT}} usage in the host API.
+The {{GPUTextureUsage/RENDER_ATTACHMENT|GPUTextureUsage.RENDER_ATTACHMENT}} column specifies support for
+{{GPUTextureUsage/RENDER_ATTACHMENT}} usage.
 
-The {{GPUTextureUsage/STORAGE|GPUTextureUsage.STORAGE}} column specifies the support for {{GPUTextureUsage/STORAGE}}
-usage in the host API.
+The {{GPUTextureUsage/STORAGE|GPUTextureUsage.STORAGE}} column specifies support for {{GPUTextureUsage/STORAGE}}
+usage.
 
 <table class='data'>
     <thead class=stickyheader>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -760,10 +760,10 @@ A [=physical resource=] can be used on GPU with an <dfn dfn>internal usage</dfn>
         Allowed by buffer {{GPUBufferUsage/INDEX}}, buffer {{GPUBufferUsage/VERTEX}}, or buffer {{GPUBufferUsage/INDIRECT}}.
     : <dfn>constant</dfn>
     ::  Resource bindings that are constant from the shader point of view. Preserves the contents.
-        Allowed by buffer {{GPUBufferUsage/UNIFORM}} or texture {{GPUTextureUsage/SAMPLED}}.
+        Allowed by buffer {{GPUBufferUsage/UNIFORM}} or texture {{GPUTextureUsage/SHADER_READ}}.
     : <dfn>storage</dfn>
     ::  Writable storage resource binding.
-        Allowed by buffer {{GPUBufferUsage/STORAGE}} or texture {{GPUTextureUsage/STORAGE}}.
+        Allowed by buffer {{GPUBufferUsage/STORAGE}} or texture {{GPUTextureUsage/SHADER_WRITE}}.
     : <dfn>storage-read</dfn>
     ::  Read-only storage resource bindings. Preserves the contents.
         Allowed by buffer {{GPUBufferUsage/STORAGE}}.
@@ -2238,8 +2238,8 @@ typedef [EnforceRange] unsigned long GPUTextureUsageFlags;
 interface GPUTextureUsage {
     const GPUFlagsConstant COPY_SRC          = 0x01;
     const GPUFlagsConstant COPY_DST          = 0x02;
-    const GPUFlagsConstant SAMPLED           = 0x04;
-    const GPUFlagsConstant STORAGE           = 0x08;
+    const GPUFlagsConstant SHADER_READ       = 0x04;
+    const GPUFlagsConstant SHADER_WRITE      = 0x08;
     const GPUFlagsConstant RENDER_ATTACHMENT = 0x10;
 };
 </script>
@@ -2331,7 +2331,7 @@ interface GPUTextureUsage {
                             - If |descriptor|.{{GPUTextureDescriptor/sampleCount}} > 1:
                                 - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be 1.
                                 - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be 1.
-                                - |descriptor|.{{GPUTextureDescriptor/usage}} must not include the {{GPUTextureUsage/STORAGE}} bit.
+                                - |descriptor|.{{GPUTextureDescriptor/usage}} must not include the {{GPUTextureUsage/SHADER_WRITE}} bit.
                                 - |descriptor|.{{GPUTextureDescriptor/format}} must be a [=renderable format=].
 
                             - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be less than or equal to
@@ -2340,9 +2340,9 @@ interface GPUTextureUsage {
                             - |descriptor|.{{GPUTextureDescriptor/usage}} must be a combination of {{GPUTextureUsage}} values.
                             - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/RENDER_ATTACHMENT}} bit,
                                 |descriptor|.{{GPUTextureDescriptor/format}} must be a [=renderable format=].
-                            - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/STORAGE}} bit,
+                            - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/SHADER_WRITE}} bit,
                                 |descriptor|.{{GPUTextureDescriptor/format}} must be listed in [[#plain-color-formats]] table
-                                with {{GPUTextureUsage/STORAGE}} capability.
+                                with {{GPUTextureUsage/SHADER_WRITE}} capability.
                         </div>
 
                         Then:
@@ -3633,7 +3633,7 @@ A {{GPUBindGroup}} object has the following internal slots:
                                                 is equal to |resource|'s {{GPUTextureViewDescriptor/dimension}}.
                                             - |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/sampleType}}
                                                 is compatible with |resource|'s {{GPUTextureViewDescriptor/format}}.
-                                            - |texture|'s {{GPUTextureDescriptor/usage}} includes {{GPUTextureUsage/SAMPLED}}.
+                                            - |texture|'s {{GPUTextureDescriptor/usage}} includes {{GPUTextureUsage/SHADER_READ}}.
                                             - If |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/multisampled}}
                                                 is `true`, |texture|'s {{GPUTextureDescriptor/sampleCount}}
                                                 &gt; `1`, Otherwise |texture|'s {{GPUTextureDescriptor/sampleCount}} is `1`.
@@ -3647,7 +3647,7 @@ A {{GPUBindGroup}} object has the following internal slots:
                                                 is equal to |resource|'s {{GPUTextureViewDescriptor/dimension}}.
                                             - |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/format}}
                                                 is equal to |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
-                                            - |texture|'s {{GPUTextureDescriptor/usage}} includes {{GPUTextureUsage/STORAGE}}.
+                                            - |texture|'s {{GPUTextureDescriptor/usage}} includes {{GPUTextureUsage/SHADER_WRITE}}.
 
                                         :  {{GPUBindGroupLayoutEntry/buffer}}
                                         ::
@@ -8857,14 +8857,14 @@ The following enums are supported if and only if the {{GPUFeatureName/"timestamp
 
 ### Plain color formats ### {#plain-color-formats}
 
-All plain color formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, and {{GPUTextureUsage/SAMPLED}} usage.
+All plain color formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, and {{GPUTextureUsage/SHADER_READ}} usage.
 
 Only formats with {{GPUTextureSampleType}} {{GPUTextureSampleType/"float"}} can be blended.
 
-The {{GPUTextureUsage/STORAGE|GPUTextureUsage.STORAGE}} column specifies the support for {{GPUTextureUsage/STORAGE}}
+The {{GPUTextureUsage/SHADER_WRITE|GPUTextureUsage.SHADER_WRITE}} column specifies the support for {{GPUTextureUsage/SHADER_WRITE}}
 usage in the host API.
 
-The {{GPUTextureUsage/STORAGE|GPUTextureUsage.RENDER_ATTACHMENT}} column specifies the support for
+The {{GPUTextureUsage/RENDER_ATTACHMENT|GPUTextureUsage.RENDER_ATTACHMENT}} column specifies the support for
 {{GPUTextureUsage/RENDER_ATTACHMENT}} usage in the host API.
 
 <table class='data'>
@@ -8873,7 +8873,7 @@ The {{GPUTextureUsage/STORAGE|GPUTextureUsage.RENDER_ATTACHMENT}} column specifi
             <th>Format
             <th>{{GPUTextureSampleType}}
             <th>{{GPUTextureUsage/RENDER_ATTACHMENT}}
-            <th>{{GPUTextureUsage/STORAGE}}
+            <th>{{GPUTextureUsage/SHADER_WRITE}}
     </thead>
     <tr><th class=stickyheader>8-bit per component<th><th><th>
     <tr>
@@ -9059,7 +9059,7 @@ The {{GPUTextureUsage/STORAGE|GPUTextureUsage.RENDER_ATTACHMENT}} column specifi
 
 ### Depth/stencil formats ### {#depth-formats}
 
-All depth formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/SAMPLED}}, and {{GPUTextureUsage/RENDER_ATTACHMENT}} usage. However, the source/destination is restricted based on the format.
+All depth formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/SHADER_READ}}, and {{GPUTextureUsage/RENDER_ATTACHMENT}} usage. However, the source/destination is restricted based on the format.
 
 None of the depth formats can be filtered.
 
@@ -9125,7 +9125,7 @@ Issue: clarify if `depth24plus-stencil8` is copyable into `depth24plus` in Metal
 
 ### Packed formats ### {#packed-formats}
 
-All packed texture formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, and {{GPUTextureUsage/SAMPLED}} usages. All of these formats have {{GPUTextureSampleType/"float"}} type and can be filtered on sampling.
+All packed texture formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, and {{GPUTextureUsage/SHADER_READ}} usages. All of these formats have {{GPUTextureSampleType/"float"}} type and can be filtered on sampling.
 
 <table class='data'>
     <thead class=stickyheader>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -763,7 +763,7 @@ A [=physical resource=] can be used on GPU with an <dfn dfn>internal usage</dfn>
         Allowed by buffer {{GPUBufferUsage/UNIFORM}} or texture {{GPUTextureUsage/SHADER_READ}}.
     : <dfn>storage</dfn>
     ::  Writable storage resource binding.
-        Allowed by buffer {{GPUBufferUsage/STORAGE}} or texture {{GPUTextureUsage/SHADER_WRITE}}.
+        Allowed by buffer {{GPUBufferUsage/STORAGE}} or texture {{GPUTextureUsage/STORAGE}}.
     : <dfn>storage-read</dfn>
     ::  Read-only storage resource bindings. Preserves the contents.
         Allowed by buffer {{GPUBufferUsage/STORAGE}}.
@@ -2239,7 +2239,7 @@ interface GPUTextureUsage {
     const GPUFlagsConstant COPY_SRC          = 0x01;
     const GPUFlagsConstant COPY_DST          = 0x02;
     const GPUFlagsConstant SHADER_READ       = 0x04;
-    const GPUFlagsConstant SHADER_WRITE      = 0x08;
+    const GPUFlagsConstant STORAGE           = 0x08;
     const GPUFlagsConstant RENDER_ATTACHMENT = 0x10;
 };
 </script>
@@ -2331,7 +2331,7 @@ interface GPUTextureUsage {
                             - If |descriptor|.{{GPUTextureDescriptor/sampleCount}} > 1:
                                 - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be 1.
                                 - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be 1.
-                                - |descriptor|.{{GPUTextureDescriptor/usage}} must not include the {{GPUTextureUsage/SHADER_WRITE}} bit.
+                                - |descriptor|.{{GPUTextureDescriptor/usage}} must not include the {{GPUTextureUsage/STORAGE}} bit.
                                 - |descriptor|.{{GPUTextureDescriptor/format}} must be a [=renderable format=].
 
                             - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be less than or equal to
@@ -2340,9 +2340,9 @@ interface GPUTextureUsage {
                             - |descriptor|.{{GPUTextureDescriptor/usage}} must be a combination of {{GPUTextureUsage}} values.
                             - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/RENDER_ATTACHMENT}} bit,
                                 |descriptor|.{{GPUTextureDescriptor/format}} must be a [=renderable format=].
-                            - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/SHADER_WRITE}} bit,
+                            - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/STORAGE}} bit,
                                 |descriptor|.{{GPUTextureDescriptor/format}} must be listed in [[#plain-color-formats]] table
-                                with {{GPUTextureUsage/SHADER_WRITE}} capability.
+                                with {{GPUTextureUsage/STORAGE}} capability.
                         </div>
 
                         Then:
@@ -3647,7 +3647,7 @@ A {{GPUBindGroup}} object has the following internal slots:
                                                 is equal to |resource|'s {{GPUTextureViewDescriptor/dimension}}.
                                             - |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/format}}
                                                 is equal to |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
-                                            - |texture|'s {{GPUTextureDescriptor/usage}} includes {{GPUTextureUsage/SHADER_WRITE}}.
+                                            - |texture|'s {{GPUTextureDescriptor/usage}} includes {{GPUTextureUsage/STORAGE}}.
 
                                         :  {{GPUBindGroupLayoutEntry/buffer}}
                                         ::
@@ -8861,11 +8861,11 @@ All plain color formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/
 
 Only formats with {{GPUTextureSampleType}} {{GPUTextureSampleType/"float"}} can be blended.
 
-The {{GPUTextureUsage/SHADER_WRITE|GPUTextureUsage.SHADER_WRITE}} column specifies the support for {{GPUTextureUsage/SHADER_WRITE}}
-usage in the host API.
-
 The {{GPUTextureUsage/RENDER_ATTACHMENT|GPUTextureUsage.RENDER_ATTACHMENT}} column specifies the support for
 {{GPUTextureUsage/RENDER_ATTACHMENT}} usage in the host API.
+
+The {{GPUTextureUsage/STORAGE|GPUTextureUsage.STORAGE}} column specifies the support for {{GPUTextureUsage/STORAGE}}
+usage in the host API.
 
 <table class='data'>
     <thead class=stickyheader>
@@ -8873,7 +8873,7 @@ The {{GPUTextureUsage/RENDER_ATTACHMENT|GPUTextureUsage.RENDER_ATTACHMENT}} colu
             <th>Format
             <th>{{GPUTextureSampleType}}
             <th>{{GPUTextureUsage/RENDER_ATTACHMENT}}
-            <th>{{GPUTextureUsage/SHADER_WRITE}}
+            <th>{{GPUTextureUsage/STORAGE}}
     </thead>
     <tr><th class=stickyheader>8-bit per component<th><th><th>
     <tr>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -762,14 +762,11 @@ A [=physical resource=] can be used on GPU with an <dfn dfn>internal usage</dfn>
     ::  Resource bindings that are constant from the shader point of view. Preserves the contents.
         Allowed by buffer {{GPUBufferUsage/UNIFORM}} or texture {{GPUTextureUsage/SAMPLED}}.
     : <dfn>storage</dfn>
-    ::  Read-write storage resource binding.
-        Allowed by buffer {{GPUBufferUsage/STORAGE}}.
+    ::  Writable storage resource binding.
+        Allowed by buffer {{GPUBufferUsage/STORAGE}} or texture {{GPUTextureUsage/STORAGE}}.
     : <dfn>storage-read</dfn>
     ::  Read-only storage resource bindings. Preserves the contents.
-        Allowed by buffer {{GPUBufferUsage/STORAGE}} or texture {{GPUTextureUsage/STORAGE}}.
-    : <dfn>storage-write</dfn>
-    ::  Write-only storage resource bindings.
-        Allowed by texture {{GPUTextureUsage/STORAGE}}.
+        Allowed by buffer {{GPUBufferUsage/STORAGE}}.
     : <dfn>attachment</dfn>
     :: Texture used as an output attachment in a render pass.
         Allowed by texture {{GPUTextureUsage/RENDER_ATTACHMENT}}.
@@ -793,7 +790,6 @@ that combines multiple usages together. We consider a list |U| to be
 a <dfn dfn>compatible usage list</dfn> if (and only if) it satisfies any of the following rules:
     - Each usage in |U| is [=internal usage/input=], [=internal usage/constant=], [=internal usage/storage-read=], or [=internal usage/attachment-read=].
     - Each usage in |U| is [=internal usage/storage=].
-    - Each usage in |U| is [=internal usage/storage-write=].
     - |U| contains exactly one element: [=internal usage/attachment=].
 </div>
 
@@ -3227,13 +3223,10 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
         <td>{{GPUTextureSampleType/"uint"}}
 
     <tr>
-        <td rowspan=2>{{GPUBindGroupLayoutEntry/storageTexture}}
-        <td rowspan=2>{{GPUTextureView}}
-        <td>{{GPUStorageTextureAccess/"read-only"}}
-        <td>[=internal usage/storage-read=]
-    <tr>
+        <td rowspan=1>{{GPUBindGroupLayoutEntry/storageTexture}}
+        <td rowspan=1>{{GPUTextureView}}
         <td>{{GPUStorageTextureAccess/"write-only"}}
-        <td>[=internal usage/storage-write=]
+        <td>[=internal usage/storage=]
 
     <tr>
         <td>{{GPUBindGroupLayoutEntry/externalTexture}}
@@ -3377,12 +3370,11 @@ truly optional.
 
 <script type=idl>
 enum GPUStorageTextureAccess {
-    "read-only",
     "write-only",
 };
 
 dictionary GPUStorageTextureBindingLayout {
-    required GPUStorageTextureAccess access;
+    GPUStorageTextureAccess access = "write-only";
     required GPUTextureFormat format;
     GPUTextureViewDimension viewDimension = "2d";
 };
@@ -4129,10 +4121,6 @@ has a default layout created and used instead.
                 1. Set |storageTextureLayout|.{{GPUStorageTextureBindingLayout/format}} to |resource|'s format.
                 1. Set |storageTextureLayout|.{{GPUStorageTextureBindingLayout/viewDimension}} to |resource|'s dimension.
 
-                1. If |resource| is for a read-only storage texture:
-
-                    1. Set |storageTextureLayout|.{{GPUStorageTextureBindingLayout/access}} to {{GPUStorageTextureAccess/"read-only"}}.
-
                 1. If |resource| is for a write-only storage texture:
 
                     1. Set |storageTextureLayout|.{{GPUStorageTextureBindingLayout/access}} to {{GPUStorageTextureAccess/"write-only"}}.
@@ -4268,8 +4256,6 @@ A {{GPUProgrammableStage}} describes the entry point in the user-provided
                 : {{GPUBindGroupLayoutEntry/storageTexture}}
                 :: If |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/access}} is:
                     <dl class=switch>
-                        : {{GPUStorageTextureAccess/"read-only"}}
-                        :: The |binding| is a read-only storage texture.
                         : {{GPUStorageTextureAccess/"write-only"}}
                         :: The |binding| is a writable storage texture.
                     </dl>
@@ -8876,10 +8862,10 @@ All plain color formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/
 Only formats with {{GPUTextureSampleType}} {{GPUTextureSampleType/"float"}} can be blended.
 
 The {{GPUTextureUsage/STORAGE|GPUTextureUsage.STORAGE}} column specifies the support for {{GPUTextureUsage/STORAGE}}
-usage in the core API, including both {{GPUStorageTextureAccess/"read-only"}} and {{GPUStorageTextureAccess/"write-only"}}.
+usage in the host API.
 
 The {{GPUTextureUsage/STORAGE|GPUTextureUsage.RENDER_ATTACHMENT}} column specifies the support for
-{{GPUTextureUsage/RENDER_ATTACHMENT}} usage in the core API.
+{{GPUTextureUsage/RENDER_ATTACHMENT}} usage in the host API.
 
 <table class='data'>
     <thead class=stickyheader>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2276,7 +2276,7 @@ This is also known as the <dfn noexport>channel transfer function</dfn>, or CTF.
 The texel formats listed in the
 <dfn dfn lt="storage-texel-formats">Texel Formats for Storage Textures</dfn> table
 correspond to the [[WebGPU#plain-color-formats|WebGPU plain color formats]]
-which support the [[WebGPU#dom-gputextureusage-storage|WebGPU SHADER_WRITE]] usage.
+which support the [[WebGPU#dom-gputextureusage-storage|WebGPU STORAGE]] usage.
 These texel formats are used to parameterize the storage texture types defined
 in [[#texture-storage]].
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2276,7 +2276,7 @@ This is also known as the <dfn noexport>channel transfer function</dfn>, or CTF.
 The texel formats listed in the
 <dfn dfn lt="storage-texel-formats">Texel Formats for Storage Textures</dfn> table
 correspond to the [[WebGPU#plain-color-formats|WebGPU plain color formats]]
-which support the [[WebGPU#dom-gputextureusage-storage|WebGPU STORAGE]] usage.
+which support the [[WebGPU#dom-gputextureusage-storage|WebGPU SHADER_WRITE]] usage.
 These texel formats are used to parameterize the storage texture types defined
 in [[#texture-storage]].
 
@@ -2396,9 +2396,6 @@ See [`GPUExternalTexture`](https://gpuweb.github.io/gpuweb/#gpu-external-texture
 
 A <dfn noexport>storage texture</dfn> supports accessing a single texel without the use of a sampler.
 
-* A <dfn noexport>read-only storage texture</dfn>
-     supports reading a single texel without the use of a sampler,
-     with automatic conversion of the stored texel value to a usable shader value.
 * A <dfn noexport>write-only storage texture</dfn>
      supports writing a single texel, with automatic conversion of the shader value to a
      stored texel value.
@@ -2429,8 +2426,7 @@ TODO(dneto): Move description of the conversion to the builtin function that act
 </pre>
 
 * `texel_format` must be one of the texel types specified in [=storage-texel-formats=]
-* `access` must be [=access/read=] for a read-only storage texture,
-    and [=access/write=] for a write-only storage texture.
+* `access` must be [=access/write=], if specified.
 
 In the SPIR-V mapping:
 * The *Image Format* parameter of the image type declaration is
@@ -2438,8 +2434,7 @@ In the SPIR-V mapping:
 * The *Sampled Type* parameter of the image type declaration is
     the SPIR-V scalar type corresponding to the channel format for the texel format.
 
-When mapping to SPIR-V, a read-only storage texture variable must have a `NonWritable` decoration and
-a write-only storage texture variable must have a `NonReadable` decoration.
+When mapping to SPIR-V, a write-only storage texture variable must have a `NonReadable` decoration.
 
 For example:
 
@@ -5654,11 +5649,9 @@ where compatibility is defined by the following table.
       <td>[[WebGPU#dom-gputexturesampletype-uint|uint]]
   <tr>
       <td>[[WebGPU#dom-gputexturesampletype-depth|depth]]
-  <tr><td>[=read-only storage texture=]
-      <td rowspan=2>[[WebGPU#gputextureview|GPUTextureView]]
-      <td rowspan=2>GPUStorageTextureAccess
-      <td>[[WebGPU#dom-gpustoragetextureaccess-read-only|read-only]]
   <tr><td>[=write-only storage texture=]
+      <td rowspan=1>[[WebGPU#gputextureview|GPUTextureView]]
+      <td rowspan=1>GPUStorageTextureAccess
       <td>[[WebGPU#dom-gpustoragetextureaccess-write-only|write-only]]
 </table>
 
@@ -7126,17 +7119,8 @@ textureLoad(t: texture_3d<T>, coords: vec3<i32>, level: i32) -> vec4<T>
 textureLoad(t: texture_multisampled_2d<T>, coords: vec2<i32>, sample_index: i32)-> vec4<T>
 textureLoad(t: texture_depth_2d, coords: vec2<i32>, level: i32) -> f32
 textureLoad(t: texture_depth_2d_array, coords: vec2<i32>, array_index: i32, level: i32) -> f32
-textureLoad(t: texture_storage_1d<F,read>, coords: i32) -> vec4<T>
-textureLoad(t: texture_storage_2d<F,read>, coords: vec2<i32>) -> vec4<T>
-textureLoad(t: texture_storage_2d_array<F,read>, coords: vec2<i32>, array_index: i32) -> vec4<T>
-textureLoad(t: texture_storage_3d<F,read>, coords: vec3<i32>) -> vec4<T>
 textureLoad(t: texture_external, coords: vec2<i32>) -> vec4<f32>
 ```
-
-For [read-only storage textures](#texture-storage) the returned channel format `T`
-depends on the texel format `F`.
-See the See the [texel format table](#storage-texel-formats) for the mapping of texel
-format to channel format.
 
 **Parameters:**
 
@@ -7144,7 +7128,7 @@ format to channel format.
   <tr><td>`t`<td>
   The [sampled](#sampled-texture-type),
   [multisampled](#multisampled-texture-type), [depth](#texture-depth),
-  [read-only storage](#texture-storage), or [external](#external-texture-type) texture.
+  or [external](#external-texture-type) texture.
   <tr><td>`coords`<td>
   The 0-based texel coordinate.
   <tr><td>`array_index`<td>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5650,8 +5650,8 @@ where compatibility is defined by the following table.
   <tr>
       <td>[[WebGPU#dom-gputexturesampletype-depth|depth]]
   <tr><td>[=write-only storage texture=]
-      <td rowspan=1>[[WebGPU#gputextureview|GPUTextureView]]
-      <td rowspan=1>GPUStorageTextureAccess
+      <td>[[WebGPU#gputextureview|GPUTextureView]]
+      <td>GPUStorageTextureAccess
       <td>[[WebGPU#dom-gpustoragetextureaccess-write-only|write-only]]
 </table>
 


### PR DESCRIPTION
Closes #1785
I think, it's another case of: if you have trouble naming something, then it's not a naming problem, it's an architecture problem. So in this case, the confusion is resolved by removing one of the ambiguous variants, and aligning the naming accordingly (`SHADER_READ`/`SHADER_WRITE` usages).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/1794.html" title="Last updated on Jul 13, 2021, 10:25 PM UTC (51dc84f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1794/d2cdb97...kvark:51dc84f.html" title="Last updated on Jul 13, 2021, 10:25 PM UTC (51dc84f)">Diff</a>