### PR TITLE
wgsl: derivatives can only be invoked in fragment stage

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5938,7 +5938,7 @@ built-in functions described in [[#derivative-builtin-functions]]:
 * fwidth, fwidthCoarse, and fwidthFine compute the Manhattan metric over the associated x and y partial derivatives.
 
 Because neighbouring invocations must collaborate to compute derivatives,
-these functions must only be invoked in uniform control flow.
+these functions must only be invoked in uniform control flow in a fragment shader.
 
 ### Arrayed resource access TODO ### {#arrayed-resource-access}
 
@@ -7020,6 +7020,12 @@ That's not a full user-defined function declaration.
 </table>
 
 ## Derivative built-in functions ## {#derivative-builtin-functions}
+
+See [[#derivatives]].
+
+These functions:
+* Must only be used in a [=fragment=] shader stage.
+* Must only be invoked in uniform control flow.
 
 <table class='data'>
   <thead>


### PR DESCRIPTION
Fixes: #1795