### PR TITLE
wgsl: assignment only works on atomic-free plain type

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4525,9 +4525,9 @@ expression to the right of the equals token is the <dfn noexport>right-hand side
   </thead>
   <tr algorithm="assignment">
     <td>|r|: ref<|SC|,|T|,|A|>,<br>
-        |A| is [=access/write=] or [=access/read_write=]
+        |A| is [=access/write=] or [=access/read_write=]<br>
         |e|: |T|,<br>
-        |T| is [=storable=],<br>
+        |T| is an [=atomic-free=] [=plain type=],<br>
         |SC| is a writable [=storage class=]
     <td class="nowrap">|r| = |e|;
     <td>Evaluates |e|, evaluates |r|, then writes the value computed for |e| into


### PR DESCRIPTION
This fixes an oversight.

Before: only storable type was allowed
After: only atomic-free plain type is allowed

The difference is that this bans assigning:
- texture
- sampler
- atomic
- or any types containing the above.

That's the restriction we want.