### PR TITLE
wgsl: Limit dynamic indexes to references to matrices and arrrays.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3745,7 +3745,8 @@ Issue: Which index is used when it's out of bounds?
   <tr algorithm="matrix indexed column vector selection">
        <td class="nowrap">
           |e|: mat|N|x|M|&lt;|T|&gt;<br>
-          |i|: [INT]
+          |i|: [INT]<br>
+          |i| is a `const_expr` expression
        <td class="nowrap">
            |e|[|i|]: vec|M|&lt;|T|&gt;
        <td>The result is the |i|'<sup>th</sup> column vector of |e|.<br>
@@ -3771,6 +3772,14 @@ Issue: Which index is used when it's out of bounds?
            (OpAccessChain)
 </table>
 
+Note: Reflecting the limitations of the languages WGSL is meant to be translated
+into, it is only possible to use dynamically computed indices to subscript
+references to matrices. A matrix not behind a reference may only be indexed by a
+`const_expr`. To work around this restriction, consider storing the matrix in a
+temporary variable, and then subscripting the variable: a
+[[#var-identifier-expr|variable identifier expression]] produces a reference to
+the variable's value, as required.
+
 ### Array Access Expression ### {#array-access-expr}
 
 <table class='data'>
@@ -3781,7 +3790,8 @@ Issue: Which index is used when it's out of bounds?
   <tr algorithm="sized array indexed element selection">
        <td class="nowrap">
           |e|: array&lt;|T|,|N|&gt;<br>
-          |i|: [INT]
+          |i|: [INT]<br>
+          |i| is a `const_expr` expression
        <td class="nowrap">
            |e|[|i|]: |T|
        <td>The result is the value of the |i|'<sup>th</sup> element of the array value |e|.<br>
@@ -3817,6 +3827,11 @@ Issue: Which index is used when it's out of bounds?
            the same as the originating variable of |r|.<br>
            (OpAccessChain)
 </table>
+
+Note: Reflecting the limitations of the languages WGSL is meant to be translated
+into, it is only possible to use dynamically computed indices to subscript
+references to arrays. An array not behind a reference may only be indexed by a
+`const_expr`.
 
 ### Structure Access Expression ### {#struct-access-expr}
 


### PR DESCRIPTION
Fixes #1782.

Note that dynamic indexing of vectors is allowed, since SPIR-V does have the
OpVectorExtractDynamic instruction.

At present, this simply requires that indices for subscripting arrays and
matrices by value must be i32 or u32 literals. Once #1272 is resolved, then that
will provide a more flexible concept of "constant" that we can use instead.