### PR TITLE
Increase maxStorageBuffer/TexturePerShaderStage to 8.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1134,7 +1134,7 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
         See [=Exceeds the binding slot limits=].
 
     <tr><td><dfn>maxStorageBuffersPerShaderStage</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>4
+        <td>{{GPUSize32}} <td>Higher <td>8
     <tr class=row-continuation><td colspan=4>
         For each possible {{GPUShaderStage}} `stage`,
         the maximum number of {{GPUBindGroupLayoutEntry}} entries across a {{GPUPipelineLayout}}
@@ -1142,7 +1142,7 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
         See [=Exceeds the binding slot limits=].
 
     <tr><td><dfn>maxStorageTexturesPerShaderStage</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>4
+        <td>{{GPUSize32}} <td>Higher <td>8
     <tr class=row-continuation><td colspan=4>
         For each possible {{GPUShaderStage}} `stage`,
         the maximum number of {{GPUBindGroupLayoutEntry}} entries across a {{GPUPipelineLayout}}


### PR DESCRIPTION
Metal supports 31 textures in the texture table, which fits
maxStorageTexturePerShaderStage + maxSampleTexturePerShaderStage
(8 + 12 = 24).

D3D12 supports 64 UAVs for feature level 11.1 and above. FL11.0 supports
only 8 UAVs, but could be moved to a WebGPU-compat that supports less
storage resources together (and with more complicated limits).

Vulkan guarantees support for only 4, but all desktop devices support 8,
and about 30% of devices support only 4. These devices could be moved to
WeBGPU-compat. GL ES 3.1 guarantees supports for 8 in the compute stage
and 4 in the others, making the limit more useful there.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/1802.html" title="Last updated on Jun 3, 2021, 10:37 AM UTC (57ed10a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1802/7d2888c...Kangz:57ed10a.html" title="Last updated on Jun 3, 2021, 10:37 AM UTC (57ed10a)">Diff</a>