### PR TITLE
Rename misleading nonGuaranteed* names

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1000,10 +1000,10 @@ A [=device=] has the following internal slots:
     - Set |device|.{{device/[[adapter]]}} to |adapter|.
 
     - Set |device|.{{device/[[features]]}} to the [=ordered set|set=] of values in
-        |descriptor|.{{GPUDeviceDescriptor/nonUniversalFeatures}}.
+        |descriptor|.{{GPUDeviceDescriptor/requiredFeatures}}.
 
     - Let |device|.{{device/[[limits]]}} be a [=supported limits=] object with the default values.
-        For each (|key|, |value|) pair in |descriptor|.{{GPUDeviceDescriptor/nonUniversalLimits}}, set the
+        For each (|key|, |value|) pair in |descriptor|.{{GPUDeviceDescriptor/requiredLimits}}, set the
         member corresponding to |key| in |device|.{{device/[[limits]]}} to the [=limit/better=]
         value of |value| or the default value in [=supported limits=].
 </div>
@@ -1051,7 +1051,7 @@ Each <dfn dfn>limit</dfn> is a numeric limit on the usage of WebGPU on a device.
 
 A <dfn dfn>supported limits</dfn> object has a value for every defined limit.
 Each [=adapter=] has a set of [=supported limits=], and
-[=devices=] are {{GPUDeviceDescriptor/nonUniversalLimits|created}} with specific [=supported limits=] in place.
+[=devices=] are {{GPUDeviceDescriptor/requiredLimits|created}} with specific [=supported limits=] in place.
 The device limits are enforced regardless of the adapter's limits.
 
 One limit value may be <dfn dfn for=limit>better</dfn> than another.
@@ -1066,7 +1066,7 @@ applications should generally request the "worst" limits that work for their con
 
 Each limit also has a <dfn dfn for=limit>default</dfn> value.
 Every [=adapter=] is guaranteed to support the default value or [=limit/better=].
-The default is used if a value is not explicitly specified in {{GPUDeviceDescriptor/nonUniversalLimits}}.
+The default is used if a value is not explicitly specified in {{GPUDeviceDescriptor/requiredLimits}}.
 
 <table class="data no-colspan-center" dfn-type=attribute dfn-for="supported limits">
     <thead>
@@ -1553,7 +1553,7 @@ interface GPUAdapter {
                         [=reject=] |promise| with a {{TypeError}} and stop.
 
                         <div class=validusage>
-                            - The set of values in |descriptor|.{{GPUDeviceDescriptor/nonUniversalFeatures}}
+                            - The set of values in |descriptor|.{{GPUDeviceDescriptor/requiredFeatures}}
                                 must be a subset of those in |adapter|.{{adapter/[[features]]}}.
                         </div>
 
@@ -1561,11 +1561,11 @@ interface GPUAdapter {
                         [=reject=] |promise| with an {{OperationError}} and stop.
 
                         <div class=validusage>
-                            - Each key in |descriptor|.{{GPUDeviceDescriptor/nonUniversalLimits}}
+                            - Each key in |descriptor|.{{GPUDeviceDescriptor/requiredLimits}}
                                 must be the name of a member of [=supported limits=].
 
                             - For each type of limit in [=supported limits=], the value of that
-                                limit in |descriptor|.{{GPUDeviceDescriptor/nonUniversalLimits}}
+                                limit in |descriptor|.{{GPUDeviceDescriptor/requiredLimits}}
                                 must be no [=limit/better=] than the value of that limit in
                                 |adapter|.{{adapter/[[limits]]}}.
                         </div>
@@ -1601,23 +1601,30 @@ interface GPUAdapter {
 
 <script type=idl>
 dictionary GPUDeviceDescriptor : GPUObjectDescriptorBase {
-    sequence<GPUFeatureName> nonUniversalFeatures = [];
-    record<DOMString, GPUSize32> nonUniversalLimits = {};
+    sequence<GPUFeatureName> requiredFeatures = [];
+    record<DOMString, GPUSize32> requiredLimits = {};
 };
 </script>
 
 {{GPUDeviceDescriptor}} has the following members:
 
 <dl dfn-type=dict-member dfn-for=GPUDeviceDescriptor>
-    : <dfn>nonUniversalFeatures</dfn>
+    : <dfn>requiredFeatures</dfn>
     ::
-        The set of {{GPUFeatureName}} values in this sequence defines the exact set of
-        [=features=] that must be enabled on the device.
+        Specifies the [=features=] that are required by the device request.
+        The request will fail if the adapter cannot provide these features.
 
-    : <dfn>nonUniversalLimits</dfn>
+        Exactly the specified set of features, and no more or less, will be allowed in validation
+        of API calls on the resulting device.
+
+    : <dfn>requiredLimits</dfn>
     ::
-        Defines the exact [=limits=] that must be enabled on the device.
+        Specifies the [=limits=] that are required by the device request.
+        The request will fail if the adapter cannot provide these limits.
+
         Each key must be the name of a member of [=supported limits=].
+        Exactly the specified limits, and no [=better=] or worse, will be allowed in validation
+        of API calls on the resulting device.
 
         <!-- If we ever need limit types other than GPUSize32, we can change the value type to
         `double` or `any` in the future and write out the type conversion explicitly (by reference

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1000,10 +1000,10 @@ A [=device=] has the following internal slots:
     - Set |device|.{{device/[[adapter]]}} to |adapter|.
 
     - Set |device|.{{device/[[features]]}} to the [=ordered set|set=] of values in
-        |descriptor|.{{GPUDeviceDescriptor/nonGuaranteedFeatures}}.
+        |descriptor|.{{GPUDeviceDescriptor/nonUniversalFeatures}}.
 
     - Let |device|.{{device/[[limits]]}} be a [=supported limits=] object with the default values.
-        For each (|key|, |value|) pair in |descriptor|.{{GPUDeviceDescriptor/nonGuaranteedLimits}}, set the
+        For each (|key|, |value|) pair in |descriptor|.{{GPUDeviceDescriptor/nonUniversalLimits}}, set the
         member corresponding to |key| in |device|.{{device/[[limits]]}} to the [=limit/better=]
         value of |value| or the default value in [=supported limits=].
 </div>
@@ -1051,7 +1051,7 @@ Each <dfn dfn>limit</dfn> is a numeric limit on the usage of WebGPU on a device.
 
 A <dfn dfn>supported limits</dfn> object has a value for every defined limit.
 Each [=adapter=] has a set of [=supported limits=], and
-[=devices=] are {{GPUDeviceDescriptor/nonGuaranteedLimits|created}} with specific [=supported limits=] in place.
+[=devices=] are {{GPUDeviceDescriptor/nonUniversalLimits|created}} with specific [=supported limits=] in place.
 The device limits are enforced regardless of the adapter's limits.
 
 One limit value may be <dfn dfn for=limit>better</dfn> than another.
@@ -1066,7 +1066,7 @@ applications should generally request the "worst" limits that work for their con
 
 Each limit also has a <dfn dfn for=limit>default</dfn> value.
 Every [=adapter=] is guaranteed to support the default value or [=limit/better=].
-The default is used if a value is not explicitly specified in {{GPUDeviceDescriptor/nonGuaranteedLimits}}.
+The default is used if a value is not explicitly specified in {{GPUDeviceDescriptor/nonUniversalLimits}}.
 
 <table class="data no-colspan-center" dfn-type=attribute dfn-for="supported limits">
     <thead>
@@ -1553,7 +1553,7 @@ interface GPUAdapter {
                         [=reject=] |promise| with a {{TypeError}} and stop.
 
                         <div class=validusage>
-                            - The set of values in |descriptor|.{{GPUDeviceDescriptor/nonGuaranteedFeatures}}
+                            - The set of values in |descriptor|.{{GPUDeviceDescriptor/nonUniversalFeatures}}
                                 must be a subset of those in |adapter|.{{adapter/[[features]]}}.
                         </div>
 
@@ -1561,11 +1561,11 @@ interface GPUAdapter {
                         [=reject=] |promise| with an {{OperationError}} and stop.
 
                         <div class=validusage>
-                            - Each key in |descriptor|.{{GPUDeviceDescriptor/nonGuaranteedLimits}}
+                            - Each key in |descriptor|.{{GPUDeviceDescriptor/nonUniversalLimits}}
                                 must be the name of a member of [=supported limits=].
 
                             - For each type of limit in [=supported limits=], the value of that
-                                limit in |descriptor|.{{GPUDeviceDescriptor/nonGuaranteedLimits}}
+                                limit in |descriptor|.{{GPUDeviceDescriptor/nonUniversalLimits}}
                                 must be no [=limit/better=] than the value of that limit in
                                 |adapter|.{{adapter/[[limits]]}}.
                         </div>
@@ -1601,20 +1601,20 @@ interface GPUAdapter {
 
 <script type=idl>
 dictionary GPUDeviceDescriptor : GPUObjectDescriptorBase {
-    sequence<GPUFeatureName> nonGuaranteedFeatures = [];
-    record<DOMString, GPUSize32> nonGuaranteedLimits = {};
+    sequence<GPUFeatureName> nonUniversalFeatures = [];
+    record<DOMString, GPUSize32> nonUniversalLimits = {};
 };
 </script>
 
 {{GPUDeviceDescriptor}} has the following members:
 
 <dl dfn-type=dict-member dfn-for=GPUDeviceDescriptor>
-    : <dfn>nonGuaranteedFeatures</dfn>
+    : <dfn>nonUniversalFeatures</dfn>
     ::
         The set of {{GPUFeatureName}} values in this sequence defines the exact set of
         [=features=] that must be enabled on the device.
 
-    : <dfn>nonGuaranteedLimits</dfn>
+    : <dfn>nonUniversalLimits</dfn>
     ::
         Defines the exact [=limits=] that must be enabled on the device.
         Each key must be the name of a member of [=supported limits=].

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1623,8 +1623,8 @@ dictionary GPUDeviceDescriptor : GPUObjectDescriptorBase {
         The request will fail if the adapter cannot provide these limits.
 
         Each key must be the name of a member of [=supported limits=].
-        Exactly the specified limits, and no [=better=] or worse, will be allowed in validation
-        of API calls on the resulting device.
+        Exactly the specified limits, and no [=limit/better=] or worse,
+        will be allowed in validation of API calls on the resulting device.
 
         <!-- If we ever need limit types other than GPUSize32, we can change the value type to
         `double` or `any` in the future and write out the type conversion explicitly (by reference


### PR DESCRIPTION
The nonGuaranteedLimits/nonGuaranteedFeatures names have turned out to be misleading, because it really sounds like you can get a device that doesn't have the limits/features you asked for.

We probably should have thought about this more before we landed the changes, but it may still be worth changing. Here's a possible alternative.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1804.html" title="Last updated on Jun 9, 2021, 10:06 PM UTC (92ff033)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1804/b23fee6...kainino0x:92ff033.html" title="Last updated on Jun 9, 2021, 10:06 PM UTC (92ff033)">Diff</a>