### PR TITLE
wgsl: fix grammar: access mode is optional

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2798,7 +2798,7 @@ variable_ident_decl
   : IDENT COLON attribute_list* type_decl
 
 variable_qualifier
-  : LESS_THAN storage_class ( COMMA access_mode ) GREATER_THAN
+  : LESS_THAN storage_class ( COMMA access_mode )? GREATER_THAN
 </pre>
 
 The <dfn noexport>lifetime</dfn> of a variable is the period during shader


### PR DESCRIPTION
Add the missing '?' in the grammar production for variable_qualifier.