### PR TITLE
setBindGroup: make start+length check synchronous

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6026,7 +6026,7 @@ interface mixin GPUProgrammablePassEncoder {
         of a {{Uint32Array}}.
 
         <div algorithm=GPUProgrammablePassEncoder.setBindGroup2>
-            **Called on:** {{GPUProgrammablePassEncoder}} this.
+            **Called on:** {{GPUProgrammablePassEncoder}} |this|.
 
             **Arguments:**
             <pre class=argumentdef for="GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsetsData, dynamicOffsetsDataStart, dynamicOffsetsDataLength)">
@@ -6041,29 +6041,17 @@ interface mixin GPUProgrammablePassEncoder {
 
             **Returns:** {{undefined}}
 
-            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
-            <div class=device-timeline>
-                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
-                    <div class=validusage>
-                        - |bindGroup| is [$valid to use with$] |this|.
-                        - |index| &lt; |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroups}}.
-                        - |dynamicOffsetsDataLength| is
-                            |bindGroup|.{{GPUBindGroup/[[layout]]}}.{{GPUBindGroupLayout/[[dynamicOffsetCount]]}}.
-                        - |dynamicOffsetsDataStart| + |dynamicOffsetsDataLength| &le; |dynamicOffsetsData|.length.
-
-                        - [$Iterate over each dynamic binding offset$] in |bindGroup| and
-                            run the following steps for each |bufferBinding|, |minBindingSize|,
-                            and |dynamicOffsetIndex|:
-
-                            - Let |bufferDynamicOffset| be
-                                |dynamicOffsetsData|[|dynamicOffsetIndex| + |dynamicOffsetsDataStart|].
-                            - |bufferBinding|.{{GPUBufferBinding/offset}} + |bufferDynamicOffset| +
-                                |minBindingSize| &le;
-                                |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBuffer/[[size]]}}.
-                    </div>
-                1. Set |this|.{{GPUProgrammablePassEncoder/[[bind_groups]]}}[|index|] to be |bindGroup|.
-            </div>
-        </div>
+            1. If any of the following requirements are unmet, throw an {{OperationError}} and stop.
+                <div class=validusage>
+                    - |dynamicOffsetsDataStart| must be &ge; 0.
+                    - |dynamicOffsetsDataStart| + |dynamicOffsetsDataLength| must be &le;
+                        |dynamicOffsetsData|.`length`.
+                </div>
+            1. Let |dynamicOffsets| be a [=list=] containing the range, starting at index
+                |dynamicOffsetsDataStart|, of |dynamicOffsetsDataLength| elements of
+                [=get a copy of the buffer source|a copy of=] |dynamicOffsetsData|.
+            1. Call |this|.{{GPUProgrammablePassEncoder/setBindGroup(index,
+                bindGroup, dynamicOffsets)|setBindGroup}}(|index|, |bindGroup|, |dynamicOffsets|).
 </dl>
 
 <div algorithm>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6041,7 +6041,7 @@ interface mixin GPUProgrammablePassEncoder {
 
             **Returns:** {{undefined}}
 
-            1. If any of the following requirements are unmet, throw an {{OperationError}} and stop.
+            1. If any of the following requirements are unmet, throw a {{RangeError}} and stop.
                 <div class=validusage>
                     - |dynamicOffsetsDataStart| must be &ge; 0.
                     - |dynamicOffsetsDataStart| + |dynamicOffsetsDataLength| must be &le;


### PR DESCRIPTION
The `dynamicOffsetsDataStart` and `dynamicOffsetsDataLength` are used to select a range of the `dynamicOffsetsData`. If they are out of bounds, this should be an exception, because it's analogous to constructing a `new Uint32Array` pointing at a subrange of `dynamicOffsetsData`.

Also deduplicates the rest of the implementation by calling into the other overload.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1811.html" title="Last updated on Jun 4, 2021, 9:49 PM UTC (4e3edba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1811/c7c816e...kainino0x:4e3edba.html" title="Last updated on Jun 4, 2021, 9:49 PM UTC (4e3edba)">Diff</a>