### PR TITLE
Make use of [=map/exists=] where appropriate

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3063,7 +3063,7 @@ enum GPUCompareFunction {
             1. Let |s| be a new {{GPUSampler}} object.
             1. Set |s|.{{GPUSampler/[[descriptor]]}} to |descriptor|.
             1. Set |s|.{{GPUSampler/[[isComparison]]}} to `false` if the {{GPUSamplerDescriptor/compare}} attribute
-                    of |s|.{{GPUSampler/[[descriptor]]}} does not [=map/exist=]. Otherwise, set it to `true`.
+                    of |s|.{{GPUSampler/[[descriptor]]}} does not [=map/exist=] or is `null`. Otherwise, set it to `true`.
             1. Set |s|.{{GPUSampler/[[isFiltering]]}} to `false` if none of {{GPUSamplerDescriptor/minFilter}},
                 {{GPUSamplerDescriptor/magFilter}}, or {{GPUSamplerDescriptor/mipmapFilter}} has the value of
                 {{GPUFilterMode/"linear"}}. Otherwise, set it to `true`.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1066,7 +1066,8 @@ applications should generally request the "worst" limits that work for their con
 
 Each limit also has a <dfn dfn for=limit>default</dfn> value.
 Every [=adapter=] is guaranteed to support the default value or [=limit/better=].
-The default is used if a value does not [=map/exist=] in {{GPUDeviceDescriptor/nonGuaranteedLimits}}.
+If a limit name does not [=map/exist=] in {{GPUDeviceDescriptor/nonGuaranteedLimits}},
+the default value is used for that limit.
 
 <table class="data no-colspan-center" dfn-type=attribute dfn-for="supported limits">
     <thead>
@@ -3063,7 +3064,7 @@ enum GPUCompareFunction {
             1. Let |s| be a new {{GPUSampler}} object.
             1. Set |s|.{{GPUSampler/[[descriptor]]}} to |descriptor|.
             1. Set |s|.{{GPUSampler/[[isComparison]]}} to `false` if the {{GPUSamplerDescriptor/compare}} attribute
-                    of |s|.{{GPUSampler/[[descriptor]]}} does not [=map/exist=] or is `null`. Otherwise, set it to `true`.
+                    of |s|.{{GPUSampler/[[descriptor]]}} does not [=map/exist=]. Otherwise, set it to `true`.
             1. Set |s|.{{GPUSampler/[[isFiltering]]}} to `false` if none of {{GPUSamplerDescriptor/minFilter}},
                 {{GPUSamplerDescriptor/magFilter}}, or {{GPUSamplerDescriptor/mipmapFilter}} has the value of
                 {{GPUFilterMode/"linear"}}. Otherwise, set it to `true`.
@@ -7029,7 +7030,7 @@ enum GPUStoreOp {
             - It must be [$valid to draw$] with |encoder|.
 
             - |encoder|.{{GPURenderEncoderBase/[[index_buffer]]}} must not be `null`.
-            - Let |pipeline| be |encoder|.{{GPURenderEncoderBase/[[pipeline]]}}
+            - Let |pipeline| be |encoder|.{{GPURenderEncoderBase/[[pipeline]]}}.
             - If |pipeline|.{{GPURenderPipeline/[[strip_index_format]]}} [=map/exists=]:
                 - |encoder|.{{GPURenderEncoderBase/[[index_format]]}} must be
                     |pipeline|.{{GPURenderPipeline/[[strip_index_format]]}}.
@@ -7883,7 +7884,7 @@ interface GPUCanvasContext {
             1. Let |canvas| be |this|.{{GPUCanvasContext/[[canvas]]}}.
             1. Set |swapChain|.{{GPUSwapChain/[[context]]}} to |this|.
             1. Set |swapChain|.{{GPUSwapChain/[[descriptor]]}} to |descriptor|.
-            1. If |descriptor|.{{GPUSwapChainDescriptor/size}} does not [=map/exist=] set
+            1. If |descriptor|.{{GPUSwapChainDescriptor/size}} does not [=map/exist=], set
                 |swapChain|.{{GPUSwapChain/[[size]]}} to [|canvas|.width, |canvas|.height, 1],
                 otherwise set |swapChain|.{{GPUSwapChain/[[size]]}} to |descriptor|.{{GPUSwapChainDescriptor/size}}.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1066,7 +1066,7 @@ applications should generally request the "worst" limits that work for their con
 
 Each limit also has a <dfn dfn for=limit>default</dfn> value.
 Every [=adapter=] is guaranteed to support the default value or [=limit/better=].
-The default is used if a value is not explicitly specified in {{GPUDeviceDescriptor/nonGuaranteedLimits}}.
+The default is used if a value does not [=map/exist=] in {{GPUDeviceDescriptor/nonGuaranteedLimits}}.
 
 <table class="data no-colspan-center" dfn-type=attribute dfn-for="supported limits">
     <thead>
@@ -2536,12 +2536,12 @@ enum GPUTextureAspect {
     |descriptor| run the following steps:
 
     1. Let |resolved| be a copy of |descriptor|.
-    1. If |resolved|.{{GPUTextureViewDescriptor/format}} is `undefined`,
+    1. If |resolved|.{{GPUTextureViewDescriptor/format}} does not [=map/exist=],
         set |resolved|.{{GPUTextureViewDescriptor/format}} to |texture|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
-    1. If |resolved|.{{GPUTextureViewDescriptor/mipLevelCount}} is `undefined`,
+    1. If |resolved|.{{GPUTextureViewDescriptor/mipLevelCount}} does not [=map/exist=],
         set |resolved|.{{GPUTextureViewDescriptor/mipLevelCount}} to |texture|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/mipLevelCount}}
         &minus; {{GPUTextureViewDescriptor/baseMipLevel}}.
-    1. If |resolved|.{{GPUTextureViewDescriptor/dimension}} is `undefined` and
+    1. If |resolved|.{{GPUTextureViewDescriptor/dimension}} does not [=map/exist=] and
         |texture|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} is:
         <dl class="switch">
             : {{GPUTextureDimension/"1d"}}
@@ -2553,7 +2553,7 @@ enum GPUTextureAspect {
             : {{GPUTextureDimension/"3d"}}
             :: Set |resolved|.{{GPUTextureViewDescriptor/dimension}} to {{GPUTextureViewDimension/"3d"}}.
         </dl>
-    1. If |resolved|.{{GPUTextureViewDescriptor/arrayLayerCount}} is `undefined` and
+    1. If |resolved|.{{GPUTextureViewDescriptor/arrayLayerCount}} does not [=map/exist=] and
         |resolved|.{{GPUTextureViewDescriptor/dimension}} is:
         <dl class="switch">
             : {{GPUTextureViewDimension/"1d"}}, {{GPUTextureViewDimension/"2d"}}, or
@@ -3063,7 +3063,7 @@ enum GPUCompareFunction {
             1. Let |s| be a new {{GPUSampler}} object.
             1. Set |s|.{{GPUSampler/[[descriptor]]}} to |descriptor|.
             1. Set |s|.{{GPUSampler/[[isComparison]]}} to `false` if the {{GPUSamplerDescriptor/compare}} attribute
-                    of |s|.{{GPUSampler/[[descriptor]]}} is `null` or undefined. Otherwise, set it to `true`.
+                    of |s|.{{GPUSampler/[[descriptor]]}} does not [=map/exist=]. Otherwise, set it to `true`.
             1. Set |s|.{{GPUSampler/[[isFiltering]]}} to `false` if none of {{GPUSamplerDescriptor/minFilter}},
                 {{GPUSamplerDescriptor/magFilter}}, or {{GPUSamplerDescriptor/mipmapFilter}} has the value of
                 {{GPUFilterMode/"linear"}}. Otherwise, set it to `true`.
@@ -3149,36 +3149,36 @@ dictionary GPUBindGroupLayoutEntry {
 
     : <dfn>buffer</dfn>
     ::
-        When not `undefined`, indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
-        is {{GPUBufferBinding}}.
+        Indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}} is
+        {{GPUBufferBinding}} if it [=map/exists=].
 
     : <dfn>sampler</dfn>
     ::
-        When not `undefined`, indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
-        is {{GPUSampler}}.
+        Indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}} is
+        {{GPUSampler}} if it [=map/exists=].
 
     : <dfn>texture</dfn>
     ::
-        When not `undefined`, indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
-        is {{GPUTextureView}}.
+        Indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}} is
+        {{GPUTextureView}} if it [=map/exists=].
 
     : <dfn>storageTexture</dfn>
     ::
-        When not `undefined`, indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
-        is {{GPUTextureView}}.
+        Indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}} is
+        {{GPUTextureView}} if it [=map/exists=].
 
     : <dfn>externalTexture</dfn>
     ::
-        When not `undefined`, indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
-        is {{GPUExternalTexture}}.
+        Indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}} is
+        {{GPUExternalTexture}} if it [=map/exists=].
 </dl>
 
 The [=binding member=] of a {{GPUBindGroupLayoutEntry}} is determined by which member of the
-{{GPUBindGroupLayoutEntry}} is defined:
+{{GPUBindGroupLayoutEntry}} [=map/exists=]:
 {{GPUBindGroupLayoutEntry/buffer}}, {{GPUBindGroupLayoutEntry/sampler}},
 {{GPUBindGroupLayoutEntry/texture}}, {{GPUBindGroupLayoutEntry/storageTexture}}, or
 {{GPUBindGroupLayoutEntry/externalTexture}}.
-Only one may be defined for any given {{GPUBindGroupLayoutEntry}}.
+Only one may [=map/exist=] for any given {{GPUBindGroupLayoutEntry}}.
 Each member has an associated {{GPUBindingResource}}
 type and each [=binding type=] has an associated [=internal usage=], given by this table:
 
@@ -3270,13 +3270,13 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
                 : |entry|.{{GPUBindGroupLayoutEntry/buffer}}?.{{GPUBufferBindingLayout/type}}
                     is {{GPUBufferBindingType/"storage"}} or {{GPUBufferBindingType/"read-only-storage"}}
                 :: Consider 1 {{supported limits/maxStorageBuffersPerShaderStage}} slot to be used.
-                : |entry|.{{GPUBindGroupLayoutEntry/sampler}} is not `undefined`
+                : |entry|.{{GPUBindGroupLayoutEntry/sampler}} [=map/exists=]
                 :: Consider 1 {{supported limits/maxSamplersPerShaderStage}} slot to be used.
-                : |entry|.{{GPUBindGroupLayoutEntry/texture}} is not `undefined`
+                : |entry|.{{GPUBindGroupLayoutEntry/texture}} [=map/exists=]
                 :: Consider 1 {{supported limits/maxSampledTexturesPerShaderStage}} slot to be used.
-                : |entry|.{{GPUBindGroupLayoutEntry/storageTexture}} is not `undefined`
+                : |entry|.{{GPUBindGroupLayoutEntry/storageTexture}} [=map/exists=]
                 :: Consider 1 {{supported limits/maxStorageTexturesPerShaderStage}} slot to be used.
-                : |entry|.{{GPUBindGroupLayoutEntry/externalTexture}} is not `undefined`
+                : |entry|.{{GPUBindGroupLayoutEntry/externalTexture}} [=map/exists=]
                 :: Consider
                     4 {{supported limits/maxSampledTexturesPerShaderStage}} slot,
                     1 {{supported limits/maxSamplersPerShaderStage}} slot, and
@@ -3464,7 +3464,7 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                                 - Let |storageTextureLayout| be |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}
 
                                 - Exactly one of |bufferLayout|, |samplerLayout|, |textureLayout|,
-                                    or |storageTextureLayout| are not `undefined`.
+                                    or |storageTextureLayout| [=map/exists=].
 
                                 - If |entry|.{{GPUBindGroupLayoutEntry/visibility}} includes
                                     {{GPUShaderStage/VERTEX}}:
@@ -3473,14 +3473,14 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                                     - |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}?.{{GPUStorageTextureBindingLayout/access}}
                                         must not be {{GPUStorageTextureAccess/"write-only"}}.
 
-                                - If the |textureLayout| is not `undefined` and
+                                - If |textureLayout| [=map/exists=] and
                                     |textureLayout|.{{GPUTextureBindingLayout/multisampled}} is `true`:
                                     - |textureLayout|.{{GPUTextureBindingLayout/viewDimension}} is
                                         {{GPUTextureViewDimension/"2d"}}.
                                     - |textureLayout|.{{GPUTextureBindingLayout/sampleType}} is not
                                         {{GPUTextureSampleType/"float"}}.
 
-                                - If |storageTextureLayout| is not `undefined`:
+                                - If |storageTextureLayout| [=map/exists=]:
                                     - |storageTextureLayout|.{{GPUStorageTextureBindingLayout/viewDimension}} is not
                                         {{GPUTextureViewDimension/"cube"}} or {{GPUTextureViewDimension/"cube-array"}}.
                                     - |storageTextureLayout|.{{GPUStorageTextureBindingLayout/format}} must be a format
@@ -3493,7 +3493,7 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                             1. Make |layout| [=invalid=] and return |layout|.
 
                     1. Set |layout|.{{GPUBindGroupLayout/[[dynamicOffsetCount]]}} to the number of
-                        entries in |descriptor| where {{GPUBindGroupLayoutEntry/buffer}} is not `undefined` and
+                        entries in |descriptor| where {{GPUBindGroupLayoutEntry/buffer}} [=map/exists=] and
                         {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}} is `true`.
                     1. For each {{GPUBindGroupLayoutEntry}} |entry| in
                         |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
@@ -3664,7 +3664,7 @@ A {{GPUBindGroup}} object has the following internal slots:
                                             - The bound part designated by |resource|.{{GPUBufferBinding/offset}} and
                                                 |resource|.{{GPUBufferBinding/size}} resides inside the buffer.
                                             - If |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}}
-                                                is not `undefined`:
+                                                [=map/exists=]:
                                                 - The effective binding size, that is either explict in
                                                     |resource|.{{GPUBufferBinding/size}} or derived from
                                                     |resource|.{{GPUBufferBinding/offset}} and the full
@@ -4609,9 +4609,9 @@ dictionary GPUPrimitiveState {
                 <dl class="switch">
                     : {{GPUPrimitiveTopology/"line-strip"}} or
                         {{GPUPrimitiveTopology/"triangle-strip"}}
-                    :: |descriptor|.{{GPUPrimitiveState/stripIndexFormat}} is not `undefined`
+                    :: |descriptor|.{{GPUPrimitiveState/stripIndexFormat}} [=map/exists=].
                     : Otherwise
-                    :: |descriptor|.{{GPUPrimitiveState/stripIndexFormat}} is `undefined`
+                    :: |descriptor|.{{GPUPrimitiveState/stripIndexFormat}} does not [=map/exist=].
                 </dl>
             - If |descriptor|.{{GPUPrimitiveState/clampDepth}} is `true`:
                 - |features| must [=list/contain=] {{GPUFeatureName/"depth-clamping"}}.
@@ -4668,7 +4668,7 @@ dictionary GPUFragmentState: GPUProgrammableStage {
         - For each |colorState| layout descriptor in the list |descriptor|.{{GPUFragmentState/targets}}:
             - |colorState|.{{GPUColorTargetState/format}} must be listed in [[#plain-color-formats]]
                 with {{GPUTextureUsage/RENDER_ATTACHMENT}} capability.
-            - If |colorState|.{{GPUColorTargetState/blend}} is not `undefined`:
+            - If |colorState|.{{GPUColorTargetState/blend}} [=map/exists=]:
                 - The |colorState|.{{GPUColorTargetState/format}} must be filterable
                     according to the [[#plain-color-formats]] table.
                 - |colorState|.{{GPUColorTargetState/blend}}.{{GPUBlendState/color}}
@@ -5535,13 +5535,13 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
     1. Fail if the following conditions are not satisfied:
         <div class=validusage>
             - If |heightInBlocks| &gt; 1,
-                |layout|.{{GPUImageDataLayout/bytesPerRow}} must be specified.
+                |layout|.{{GPUImageDataLayout/bytesPerRow}} must [=map/exist=].
             - If |copyExtent|.[=Extent3D/depthOrArrayLayers=] &gt; 1,
                 |layout|.{{GPUImageDataLayout/bytesPerRow}} and
-                |layout|.{{GPUImageDataLayout/rowsPerImage}} must be specified.
-            - If specified, |layout|.{{GPUImageDataLayout/bytesPerRow}}
+                |layout|.{{GPUImageDataLayout/rowsPerImage}} must [=map/exist=].
+            - If |layout|.{{GPUImageDataLayout/bytesPerRow}} [=map/exists=] it
                 must be greater than or equal to |bytesInLastRow|.
-            - If specified, |layout|.{{GPUImageDataLayout/rowsPerImage}}
+            - If |layout|.{{GPUImageDataLayout/rowsPerImage}} [=map/exists=] it
                 must be greater than or equal to |heightInBlocks|.
         </div>
 
@@ -6075,8 +6075,8 @@ interface mixin GPUProgrammablePassEncoder {
     1. For each {{GPUBindGroupEntry}} |entry| in |bindGroup|.{{GPUBindGroup/[[entries]]}}:
         1. Let |bindingDescriptor| be the {{GPUBindGroupLayoutEntry}} at
             |layout|.{{GPUBindGroupLayout/[[entryMap]]}}[|entry|.{{GPUBindGroupEntry/binding}}]:
-        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/buffer}} is not `undefined` and
-            |bindingDescriptor|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}} is `true`:
+        1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/buffer}}?.{{GPUBufferBindingLayout/hasDynamicOffset}}
+            is `true`:
             1. Let |bufferBinding| be |entry|.{{GPUBindGroupEntry/resource}}.
             1. Let |minBindingSize| be |bindingDescriptor|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}}.
             1. Call |steps| with |bufferBinding|, |minBindingSize|, and |dynamicOffsetIndex|.
@@ -7033,7 +7033,7 @@ enum GPUStoreOp {
 
             - |encoder|.{{GPURenderEncoderBase/[[index_buffer]]}} must not be `null`.
             - Let |stripIndexFormat| be |encoder|.{{GPURenderEncoderBase/[[pipeline]]}}.{{GPURenderPipeline/[[strip_index_format]]}}.
-            - If |stripIndexFormat| is not `undefined`:
+            - If |stripIndexFormat| [=map/exists=]:
                 - |encoder|.{{GPURenderEncoderBase/[[index_format]]}} must be |stripIndexFormat|.
         </div>
 
@@ -7885,7 +7885,7 @@ interface GPUCanvasContext {
             1. Let |canvas| be |this|.{{GPUCanvasContext/[[canvas]]}}.
             1. Set |swapChain|.{{GPUSwapChain/[[context]]}} to |this|.
             1. Set |swapChain|.{{GPUSwapChain/[[descriptor]]}} to |descriptor|.
-            1. If |descriptor|.{{GPUSwapChainDescriptor/size}} is `undefined` set
+            1. If |descriptor|.{{GPUSwapChainDescriptor/size}} does not [=map/exist=] set
                 |swapChain|.{{GPUSwapChain/[[size]]}} to [|canvas|.width, |canvas|.height, 1],
                 otherwise set |swapChain|.{{GPUSwapChain/[[size]]}} to |descriptor|.{{GPUSwapChainDescriptor/size}}.
 
@@ -7970,8 +7970,8 @@ and clamped-srgb: they're the same for SDR, but different for HDR).
 ### GPUSwapChain sizing ### {#swapchain-sizing}
 
 A {{GPUSwapChain}}'s {{GPUSwapChain/[[size]]}} is immutable, set by the {{GPUSwapChainDescriptor}}
-passed to {{GPUCanvasContext/configureSwapChain()}}. If a {{GPUSwapChainDescriptor/size}} is not
-specified then the width and height attributes of the {{GPUCanvasContext}}.{{GPUCanvasContext/[[canvas]]}}
+passed to {{GPUCanvasContext/configureSwapChain()}}. If a {{GPUSwapChainDescriptor/size}} does not
+[=map/exist=] then the width and height attributes of the {{GPUCanvasContext}}.{{GPUCanvasContext/[[canvas]]}}
 at the time {{GPUCanvasContext/configureSwapChain()}} is called will be used. If
 {{GPUSwapChain}}.{{GPUSwapChain/[[size]]}} does not match the dimensions of the canvas the textures
 produced by the {{GPUSwapChain}} will be scaled to fit the canvas element.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3458,14 +3458,9 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                                 [=exceeds the binding slot limits|exceed the binding slot limits=]
                                 of |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.
                             - For each {{GPUBindGroupLayoutEntry}} |entry| in |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
-                                - Let |bufferLayout| be |entry|.{{GPUBindGroupLayoutEntry/buffer}}
-                                - Let |samplerLayout| be |entry|.{{GPUBindGroupLayoutEntry/sampler}}
-                                - Let |textureLayout| be |entry|.{{GPUBindGroupLayoutEntry/texture}}
-                                - Let |storageTextureLayout| be |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}
-
-                                - Exactly one of |bufferLayout|, |samplerLayout|, |textureLayout|,
-                                    or |storageTextureLayout| [=map/exists=].
-
+                                - Exactly one of |entry|["buffer"], |entry|["sampler"], |entry|["texture"], or
+                                    |entry|["storageTexture"] [=map/exists=].
+                                
                                 - If |entry|.{{GPUBindGroupLayoutEntry/visibility}} includes
                                     {{GPUShaderStage/VERTEX}}:
                                     - |entry|.{{GPUBindGroupLayoutEntry/buffer}}?.{{GPUBufferBindingLayout/type}}
@@ -3473,14 +3468,16 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                                     - |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}?.{{GPUStorageTextureBindingLayout/access}}
                                         must not be {{GPUStorageTextureAccess/"write-only"}}.
 
-                                - If |textureLayout| [=map/exists=] and
-                                    |textureLayout|.{{GPUTextureBindingLayout/multisampled}} is `true`:
+                                - If |entry|.{{GPUBindGroupLayoutEntry/texture}}?.{{GPUTextureBindingLayout/multisampled}}
+                                    is `true`:
+                                    - Let |textureLayout| be |entry|.{{GPUBindGroupLayoutEntry/texture}}
                                     - |textureLayout|.{{GPUTextureBindingLayout/viewDimension}} is
                                         {{GPUTextureViewDimension/"2d"}}.
                                     - |textureLayout|.{{GPUTextureBindingLayout/sampleType}} is not
                                         {{GPUTextureSampleType/"float"}}.
 
-                                - If |storageTextureLayout| [=map/exists=]:
+                                - If |entry|.{{GPUBindGroupLayoutEntry/storageTexture}} [=map/exists=]:
+                                    - Let |storageTextureLayout| be |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}.
                                     - |storageTextureLayout|.{{GPUStorageTextureBindingLayout/viewDimension}} is not
                                         {{GPUTextureViewDimension/"cube"}} or {{GPUTextureViewDimension/"cube-array"}}.
                                     - |storageTextureLayout|.{{GPUStorageTextureBindingLayout/format}} must be a format
@@ -7032,9 +7029,10 @@ enum GPUStoreOp {
             - It must be [$valid to draw$] with |encoder|.
 
             - |encoder|.{{GPURenderEncoderBase/[[index_buffer]]}} must not be `null`.
-            - Let |stripIndexFormat| be |encoder|.{{GPURenderEncoderBase/[[pipeline]]}}.{{GPURenderPipeline/[[strip_index_format]]}}.
-            - If |stripIndexFormat| [=map/exists=]:
-                - |encoder|.{{GPURenderEncoderBase/[[index_format]]}} must be |stripIndexFormat|.
+            - Let |pipeline| be |encoder|.{{GPURenderEncoderBase/[[pipeline]]}}
+            - If |pipeline|.{{GPURenderPipeline/[[strip_index_format]]}} [=map/exists=]:
+                - |encoder|.{{GPURenderEncoderBase/[[index_format]]}} must be
+                    |pipeline|.{{GPURenderPipeline/[[strip_index_format]]}}.
         </div>
 
     Otherwise return `true`.


### PR DESCRIPTION
Fixes #1512.

Tried to update as many places as I could find to use `[=map/exists=]` or some variant thereof.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/1812.html" title="Last updated on Jun 8, 2021, 2:35 AM UTC (66fff8f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1812/c365257...66fff8f.html" title="Last updated on Jun 8, 2021, 2:35 AM UTC (66fff8f)">Diff</a>