### PR TITLE
wgsl: Remove level from 1D texture load intrinsic

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7147,12 +7147,17 @@ Cube faces are square, so the x and y components of the result are equal.
 Reads a single texel from a texture without sampling or filtering.
 
 ```rust
-textureLoad(t: texture_1d<T>, coords: i32, level: i32) -> vec4<T>
+textureLoad(t: texture_1d<T>, coords: i32) -> vec4<T>
+textureLoad(t: texture_2d<T>, coords: vec2<i32>) -> vec4<T>
 textureLoad(t: texture_2d<T>, coords: vec2<i32>, level: i32) -> vec4<T>
+textureLoad(t: texture_2d_array<T>, coords: vec2<i32>, array_index: i32) -> vec4<T>
 textureLoad(t: texture_2d_array<T>, coords: vec2<i32>, array_index: i32, level: i32) -> vec4<T>
+textureLoad(t: texture_3d<T>, coords: vec3<i32>) -> vec4<T>
 textureLoad(t: texture_3d<T>, coords: vec3<i32>, level: i32) -> vec4<T>
 textureLoad(t: texture_multisampled_2d<T>, coords: vec2<i32>, sample_index: i32)-> vec4<T>
+textureLoad(t: texture_depth_2d, coords: vec2<i32>) -> f32
 textureLoad(t: texture_depth_2d, coords: vec2<i32>, level: i32) -> f32
+textureLoad(t: texture_depth_2d_array, coords: vec2<i32>, array_index: i32) -> f32
 textureLoad(t: texture_depth_2d_array, coords: vec2<i32>, array_index: i32, level: i32) -> f32
 textureLoad(t: texture_storage_1d<F,read>, coords: i32) -> vec4<T>
 textureLoad(t: texture_storage_2d<F,read>, coords: vec2<i32>) -> vec4<T>
@@ -7178,7 +7183,7 @@ format to channel format.
   <tr><td>`array_index`<td>
   The 0-based texture array index.
   <tr><td>`level`<td>
-  The mip level, with level 0 containing a full size version of the texture.
+  The mip level, with level 0 containing a full size version of the texture. When not specified, the texel will be loaded from mip level 0.
   <tr><td>`sample_index`<td>
   The 0-based sample index of the multisampled texture.
 </table>


### PR DESCRIPTION
Not all targets support mipmaps for 1D textures.

The 1D `textureDimensions` intrinsic has no `level` parameter, and we do not include a 1D overload for `textureSampleLevel` either.