### PR TITLE
wgsl: Add notes reinforcing where plain types go

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -960,6 +960,8 @@ An array element type must be one of:
 * an array type
 * a [=structure=] type
 
+Note: That is, the element type must be a [=plain type=].
+
 [SHORTNAME] defines the following attributes that can be applied to array types:
 * [=attribute/stride=]
 
@@ -995,6 +997,8 @@ A structure member type must be one of:
 * an [=atomic type|atomic=] type
 * an array type
 * a [=structure=] type
+
+Note: That is, each member type must be a [=plain type=].
 
 Note: The structure member type restriction and the array element type restriction are
 mutually reinforcing.
@@ -1163,12 +1167,12 @@ A type is <dfn dfn noexport>storable</dfn> if it is one of:
 * a [=vector=] type
 * a [=matrix=] type
 * an [=atomic type|atomic=] type
-* an [=array=] type, if its element type is storable
-* a [=structure=] type, if all its members are storable
+* an [=array=] type
+* a [=structure=] type
 * a [=texture=] type
 * a [=sampler=] type
 
-Note: [=Atomic-free=] [=plain types=] are storable.
+Note: That is, the storable types are the [=plain types=], texture types, and sampler types.
 
 ### IO-shareable Types ### {#io-shareable-types}
 


### PR DESCRIPTION
- The contents of arrays and structures must be plain types.
- Array and struct contents are always storable, so we don't have to
  call that out specially.