### PR TITLE
wgsl: fix typo in var type inference example

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3057,7 +3057,7 @@ For a variable declared in function scope:
        var<function> count: u32;  // A variable in function storage class.
        var delta: i32;            // Another variable in the function storage class.
        var sum: f32 = 0.0;        // A function storage class variable with initializer.
-       var pi: = 3.14159;         // Infer the f32 store type from the initializer.
+       var pi = 3.14159;          // Infer the f32 store type from the initializer.
        let unit: i32 = 1;         // Let-declared constants don't use a storage class.
     }
   </xmp>


### PR DESCRIPTION
Thanks to @vasniktel for noticing this.