### PR TITLE
wgsl: type rule for parenthesized expr

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3091,6 +3091,20 @@ use the same storage.
   <tr><td><td>*FLOAT_LITERAL*: f32<td>OpConstant %float *literal*
 </table>
 
+## Parenthesized Expressions ## {#parenthesized-expressions}
+
+<table class='data'>
+  <caption>Parenthesized expression type rules</caption>
+  <thead>
+    <tr><th>Precondition<th>Conclusion<th>Description
+  </thead>
+  <tr algorithm="parenthesized expression">
+      <td>|e| : |T|
+      <td>`(` |e| `)` : |T|
+      <td>Evaluates to |e|.<br>
+          Use parentheses to isolate an expression from the surrounding text.
+</table>
+
 ## Type Constructor Expressions TODO ## {#type-constructor-expr}
 
 <table class='data'>
@@ -4406,9 +4420,12 @@ primary_expression
   : IDENT argument_expression_list?
   | type_decl argument_expression_list
   | const_literal
-  | paren_rhs_statement
-  | BITCAST LESS_THAN type_decl GREATER_THAN paren_rhs_statement
+  | paren_expression
+  | BITCAST LESS_THAN type_decl GREATER_THAN paren_expression
       OpBitcast
+
+paren_expression
+  : PAREN_LEFT short_circuit_or_expression PAREN_RIGHT
 
 argument_expression_list
   : PAREN_LEFT ((short_circuit_or_expression COMMA)* short_circuit_or_expression COMMA?)? PAREN_RIGHT
@@ -4599,10 +4616,10 @@ assignment_statement
 
 <pre class='def'>
 if_statement
-  : IF paren_rhs_statement compound_statement elseif_statement? else_statement?
+  : IF paren_expression compound_statement elseif_statement? else_statement?
 
 elseif_statement
-  : ELSE_IF paren_rhs_statement compound_statement elseif_statement?
+  : ELSE_IF paren_expression compound_statement elseif_statement?
 
 else_statement
   : ELSE compound_statement
@@ -4628,7 +4645,7 @@ An if statement is executed as follows:
 
 <pre class='def'>
 switch_statement
-  : SWITCH paren_rhs_statement BRACE_LEFT switch_body+ BRACE_RIGHT
+  : SWITCH paren_expression BRACE_LEFT switch_body+ BRACE_RIGHT
 
 switch_body
   : CASE case_selectors COLON BRACE_LEFT case_body BRACE_RIGHT
@@ -5059,9 +5076,6 @@ through assignment, evaluation in another expression or through use of the
 <pre class='def'>
 compound_statement
   : BRACE_LEFT statements BRACE_RIGHT
-
-paren_rhs_statement
-  : PAREN_LEFT short_circuit_or_expression PAREN_RIGHT
 
 statements
   : statement*


### PR DESCRIPTION
Also rename the grammar production