### PR TITLE
wgsl: detailed semantics of integer division and remainder

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4581,6 +4581,7 @@ See [[#sync-builtin-functions]].
     <td>Signed integer division. [=Component-wise=] when |T| is a vector.
 
         In the scalar case, evaluates to:
+        * |e1|, when |e2| is zero.
         * |e1|, when |e1| is the most negative value in |T|, and |e2| is -1.
         * [=truncate=](|x|) otherwise, where |x| is the
             real-valued quotient |e1|&nbsp;&div;&nbsp;|e2|.
@@ -4590,18 +4591,24 @@ See [[#sync-builtin-functions]].
         to perform more operations than when computing an unsigned division.
         Use unsigned division when both operands are known to have the same sign.
 
-        Produces a [=dynamic error=] when |e2| evaluates to zero.
+        <!--
+               where MINIT = most negative value in |T|
+               where Divisor = select(e2, 1, (e2==0) | ((e1 == MININT) & (e2 == -1)))
+               result is truncate(e1/Divisor)
+        -->
 
-        (OpSDiv)
   <tr algorithm="unsigned integer division">
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [UNSIGNEDINTEGRAL]
     <td>|e1| `/` |e2| : |T|
     <td>Unsigned integer division. [=Component-wise=] when |T| is a vector.
-        <br>In the scalar case, evaluates to the integer |q| such that
-        |e1|&nbsp;=&nbsp;|q|&nbsp;&times;&nbsp;|e2|&nbsp;+&nbsp;|r|,
-        where 0 &le; |r| &lt; |e2|.
-        <br>Produces a [=dynamic error=] when |e2| evaluates to zero.
-        <br>(OpUDiv)
+
+        In the scalar case, evaluates to:
+        * |e1|, when |e2| is zero.
+        * Otherwise, the integer |q| such that
+            |e1|&nbsp;=&nbsp;|q|&nbsp;&times;&nbsp;|e2|&nbsp;+&nbsp;|r|,
+            where 0 &le; |r| &lt; |e2|.
+
+        (OpUDiv, with OpSelect to avoid division by zero)
   <tr algorithm="floating point division">
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [FLOATING]
     <td>|e1| `/` |e2| : |T|
@@ -4612,9 +4619,11 @@ See [[#sync-builtin-functions]].
     <td>|e1| `%` |e2| : |T|
     <td>Signed integer remainder. [=Component-wise=] when |T| is a vector.
 
-       In the scalar case, evaluates |e1| and |e2| once, and evaluates to
-       |e1|&nbsp;-&nbsp;[=truncate=](|e1|&nbsp;&div;&nbsp;|e2|)&nbsp;&times;&nbsp;|e2|
-       where the quotient is computed as a real value.
+       In the scalar case, evaluates |e1| and |e2| once, and evaluates to:
+       * 0, when |e2| is zero.
+       * 0, when |e1| is the most negative value in |T|, and |e2| is -1.
+       * Otherwise, |e1|&nbsp;-&nbsp;[=truncate=](|e1|&nbsp;&div;&nbsp;|e2|)&nbsp;&times;&nbsp;|e2|
+           where the quotient is computed as a real value.
 
        Note:
        When non-zero, the result has the same sign as |e1|.
@@ -4623,18 +4632,24 @@ See [[#sync-builtin-functions]].
        The need to ensure consistent behaviour may require an implementation
        to perform more operations than when computing an unsigned remainder.
 
-       Produces a [=dynamic error=] when |e2| evaluates to zero.
+        <!--
+               where MINIT = most negative value in |T|
+               where Divisor = select(e2, 1, (e2==0) | ((e1 == MININT) & (e2 == -1)))
+               result is e1 - truncate(e1/Divisor) * Divisor
+        -->
 
-       (OpSRem)
   <tr algorithm="unsigned integer remainder">
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [UNSIGNEDINTEGRAL]
     <td>|e1| `%` |e2| : |T|
     <td>Unsigned integer remainder. [=Component-wise=] when |T| is a vector.
-        <br>In the scalar case, evaluates to the integer |r| such that
-        |e1|&nbsp;=&nbsp;|q|&nbsp;&times;&nbsp;|e2|&nbsp;+&nbsp;|r|,
-        where |q| is an integer and 0 &le; |r| &lt; |e2|.
-        <br>Produces a [=dynamic error=] when |e2| evaluates to zero.
-        <br>(OpUMod)
+
+        In the scalar case, evaluates to:
+        * 0, when |e2| is zero.
+        * Otherwise, the integer |r| such that
+            |e1|&nbsp;=&nbsp;|q|&nbsp;&times;&nbsp;|e2|&nbsp;+&nbsp;|r|,
+            where |q| is an integer and 0 &le; |r| &lt; |e2|.
+
+       (OpUMod, with OpSelect to avoid division by zero)
   <tr algorithm="floating point remainder">
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [FLOATING]
     <td>|e1| `%` |e2| : |T|

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -265,6 +265,10 @@ The <dfn noexport>ceiling expression</dfn> is defined over real numbers |x|:
 
 * &lceil;|x|&rceil; = |k|, where |k| is the unique integer such that |k|-1 &lt; |x| &le; |k|
 
+The <dfn noexport>truncate</dfn> function is defined over real numbers |x|:
+
+* truncate(|x|) = &lfloor;|x|&rfloor; if |x| &ge; 0, and &lceil;|x|&rceil; if |x| &lt; 0.
+
 The <dfn noexport>roundUp</dfn> function is defined for positive integers |k| and |n| as:
 
 * roundUp(|k|, |n|) = &lceil;|n| &div; |k|&rceil; &times; |k|
@@ -4574,11 +4578,28 @@ See [[#sync-builtin-functions]].
   <tr algorithm="signed integer division">
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [SIGNEDINTEGRAL]
     <td>|e1| `/` |e2| : |T|
-    <td>Signed integer division. [=Component-wise=] when |T| is a vector. (OpSDiv)
+    <td>Signed integer division. [=Component-wise=] when |T| is a vector.
+        <br>In the scalar case, evaluates to [=truncate=](|x|) where |x| is the
+        real-valued quotient |e1|&nbsp;&div;&nbsp;|e2|.
+        <p class="note" role="note"><span>Note:</span>
+        The need to ensure truncation behaviour may require an implementation
+        to perform more operations than in the unsigned division case.
+        Use unsigned division when both operands are known to have the same sign.</p>
+        Produces a [=dynamic error=] when:
+        * |e2| evaluates to zero, or
+        * |e1| is the most negative value in |T|, and |e2| is -1.
+            The quotient overflows |T| in this case.
+
+        (OpSDiv)
   <tr algorithm="unsigned integer division">
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [UNSIGNEDINTEGRAL]
     <td>|e1| `/` |e2| : |T|
-    <td>Unsigned integer division. [=Component-wise=] when |T| is a vector. (OpUDiv)
+    <td>Unsigned integer division. [=Component-wise=] when |T| is a vector.
+        <br>In the scalar case, evaluates to the integer |q| such that
+        |e1|&nbsp;=&nbsp;|q|&nbsp;&times;&nbsp;|e2|&nbsp;+&nbsp;|r|,
+        where 0 &le; |r| &lt; |e2|.
+        <br>Produces a [=dynamic error=] when |e2| evaluates to zero.
+        <br>(OpUDiv)
   <tr algorithm="floating point division">
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [FLOATING]
     <td>|e1| `/` |e2| : |T|
@@ -4587,11 +4608,29 @@ See [[#sync-builtin-functions]].
   <tr algorithm="signed integer remainder">
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [SIGNEDINTEGRAL]
     <td>|e1| `%` |e2| : |T|
-    <td>Signed integer remainder. [=Component-wise=] when |T| is a vector. (OpSRem)
+    <td>Signed integer remainder. [=Component-wise=] when |T| is a vector.
+       <br>In the scalar case, evaluates |e1| and |e2| once, and results in the integer
+       |e1|&nbsp;-&nbsp;[=truncate=](|e1|&nbsp;&div;&nbsp;|e2|)&nbsp;&times;&nbsp;|e2|,
+       where the quotient is computed as a real value.
+       <p class="note" role="note"><span>Note:</span>
+       The result has the same sign as |e1|.
+       </p>
+       <p class="note" role="note"><span>Note:</span>
+       The need to ensure consistent behaviour may require an implementation
+       to perform more operations than in the unsigned modulus case.
+       </p>
+       Produces a [=dynamic error=] under the same conditions as for
+       signed integer division.
+       <br>(OpSRem)
   <tr algorithm="unsigned integer modulus">
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [UNSIGNEDINTEGRAL]
     <td>|e1| `%` |e2| : |T|
-    <td>Unsigned integer remainder. [=Component-wise=] when |T| is a vector. (OpUMod)
+    <td>Unsigned integer remainder. [=Component-wise=] when |T| is a vector.
+        <br>In the scalar case, evaluates to the integer |r| such that
+        |e1|&nbsp;=&nbsp;|q|&nbsp;&times;&nbsp;|e2|&nbsp;+&nbsp;|r|,
+        where |q| is an integer and 0 &le; |r| &lt; |e2|.
+        <br>Produces a [=dynamic error=] when |e2| evaluates to zero.
+        <br>(OpUMod)
   <tr algorithm="floating point remainder">
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [FLOATING]
     <td>|e1| `%` |e2| : |T|

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4579,16 +4579,18 @@ See [[#sync-builtin-functions]].
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [SIGNEDINTEGRAL]
     <td>|e1| `/` |e2| : |T|
     <td>Signed integer division. [=Component-wise=] when |T| is a vector.
-        <br>In the scalar case, evaluates to [=truncate=](|x|) where |x| is the
-        real-valued quotient |e1|&nbsp;&div;&nbsp;|e2|.
-        <p class="note" role="note"><span>Note:</span>
+
+        In the scalar case, evaluates to:
+        * |e1|, when |e1| is the most negative value in |T|, and |e2| is -1.
+        * [=truncate=](|x|) otherwise, where |x| is the
+            real-valued quotient |e1|&nbsp;&div;&nbsp;|e2|.
+
+        Note:
         The need to ensure truncation behaviour may require an implementation
-        to perform more operations than in the unsigned division case.
-        Use unsigned division when both operands are known to have the same sign.</p>
-        Produces a [=dynamic error=] when:
-        * |e2| evaluates to zero, or
-        * |e1| is the most negative value in |T|, and |e2| is -1.
-            The quotient overflows |T| in this case.
+        to perform more operations than when computing an unsigned division.
+        Use unsigned division when both operands are known to have the same sign.
+
+        Produces a [=dynamic error=] when |e2| evaluates to zero.
 
         (OpSDiv)
   <tr algorithm="unsigned integer division">
@@ -4609,20 +4611,22 @@ See [[#sync-builtin-functions]].
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [SIGNEDINTEGRAL]
     <td>|e1| `%` |e2| : |T|
     <td>Signed integer remainder. [=Component-wise=] when |T| is a vector.
-       <br>In the scalar case, evaluates |e1| and |e2| once, and results in the integer
-       |e1|&nbsp;-&nbsp;[=truncate=](|e1|&nbsp;&div;&nbsp;|e2|)&nbsp;&times;&nbsp;|e2|,
+
+       In the scalar case, evaluates |e1| and |e2| once, and evaluates to
+       |e1|&nbsp;-&nbsp;[=truncate=](|e1|&nbsp;&div;&nbsp;|e2|)&nbsp;&times;&nbsp;|e2|
        where the quotient is computed as a real value.
-       <p class="note" role="note"><span>Note:</span>
-       The result has the same sign as |e1|.
-       </p>
-       <p class="note" role="note"><span>Note:</span>
+
+       Note:
+       When non-zero, the result has the same sign as |e1|.
+
+       Note:
        The need to ensure consistent behaviour may require an implementation
-       to perform more operations than in the unsigned modulus case.
-       </p>
-       Produces a [=dynamic error=] under the same conditions as for
-       signed integer division.
-       <br>(OpSRem)
-  <tr algorithm="unsigned integer modulus">
+       to perform more operations than when computing an unsigned remainder.
+
+       Produces a [=dynamic error=] when |e2| evaluates to zero.
+
+       (OpSRem)
+  <tr algorithm="unsigned integer remainder">
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [UNSIGNEDINTEGRAL]
     <td>|e1| `%` |e2| : |T|
     <td>Unsigned integer remainder. [=Component-wise=] when |T| is a vector.


### PR DESCRIPTION
Adds definition for `truncate`

For divide by zero and signed integer division overlow, say they
produce a "dynamic error".

Fixes: #1774

-------------
Update 2022-01-18:   Group wants to avoid dynamic error on divide by zero. So now the PR specifies definite answers for divide by zero and % by zero.