### PR TITLE
Describe integer negation corner case

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3934,7 +3934,9 @@ references to arrays. An array not behind a reference may only be indexed by a
   <tr algorithm="integer negation"><td>|e|: |T|<br>
   |T| is [SIGNEDINTEGRAL]
   <td>`-`|e|`:` |T|
-  <td>Signed integer negation. [=Component-wise=] when |T| is a vector. (OpSNegate)
+  <td>Signed integer negation. [=Component-wise=] when |T| is a vector.
+  If |e| evaluates to the largest negative value, then the result is |e|.
+  (OpSNegate)
 
   <tr algorithm="floating point negation"><td>|e|: |T|<br>|T| is [FLOATING]
   <td>`-`|e|`:` |T|
@@ -6949,6 +6951,7 @@ That's not a full user-defined function declaration.
     <td class="nowrap">`abs`(|e|: |T| ) -> |T|
     <td>The absolute value of |e|.
         [=Component-wise=] when |T| is a vector.
+        If |e| evaluates to the largest negative value, then the result is |e|.
         (GLSLstd450SAbs)
 
   <tr algorithm="scalar case, unsigned abs">


### PR DESCRIPTION
* -INT_MIN and abs(INT_MIN) both return INT_MIN because signed integers
  are two's complement in WGSL