### PR TITLE
Add note that sized and runtime-sized arrays are distinct types

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -941,13 +941,14 @@ An <dfn noexport>array</dfn> is an indexable grouping of element values.
   <thead>
     <tr><th>Type<th>Description
   </thead>
-  <tr><td algorithm="sized array type">array<|E|,|N|><td>An |N|-element array of elements of type |E|.<br>
+  <tr><td algorithm="sized array type">array&lt;|E|,|N|&gt;<td>An |N|-element array of elements of type |E|.<br>
                     |N| must be 1 or larger.
-  <tr><td algorithm="runtime-sized array type">array<|E|><td>A <dfn noexport>runtime-sized</dfn> array of elements of type |E|,
-                       also known as a runtime array.
+  <tr><td algorithm="runtime-sized array type">array&lt;|E|&gt;<td>A <dfn noexport>runtime-sized</dfn> array of elements of type |E|.
                        These may only appear in specific contexts.<br>
 </table>
 
+Note: Sized arrays and runtime-sized arrays are always distinct types.
+That is, `array`&lt;|E|,|N|&gt; and `array`&lt;|E|&gt; are different.
 
 The first element in an array is at index 0, and each successive element is at the next integer index.
 See [[#array-access-expr]].
@@ -6676,10 +6677,10 @@ That's not a full user-defined function declaration.
     <td>Test a normal value according to IEEE.
     [=Component-wise=] when |T| is a vector.
 
-  <tr algorithm="runtime array length">
+  <tr algorithm="runtime-sized array length">
     <td>|e|: ptr&lt;storage,array&lt;|T|&gt;&gt;
-    <td>`arrayLength(`|e|`)`: u32<td>Returns the number of elements in the runtime array.<br>
-        (OpArrayLength, but you have to trace back to get the pointer to the enclosing struct.)
+    <td>`arrayLength(`|e|`)`: u32<td>Returns the number of elements in the [=runtime-sized=] array.<br>
+        (OpArrayLength, but the implementation has to trace back to get the pointer to the enclosing struct.)
 </table>
 
 ## Float built-in functions ## {#float-builtin-functions}


### PR DESCRIPTION
Also:
* Add cross-link to runtime-sized array, from arrayLength
* Convert the only use of "runtime array" to runtime-sized array, and
  remove the definition of "runtime array".