### PR TITLE
Define index/vertex buffer OOB behavior

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -78,6 +78,7 @@ spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
         text: statically accessed; url: statically-accessed
         text: wgsl-declaration; url: declaration
         text: wgsl-type; url: type
+        text: invalid memory reference; url: invalid-memory-reference
 </pre>
 
 <style>
@@ -8403,50 +8404,58 @@ a list of vertices to process for each instance.
 <div algorithm>
     <dfn abstract-op>resolve indices</dfn>(drawCall, state)
 
-        **Arguments:**
-            - |drawCall|: The draw call parameters.
-            - |state|: The active [=RenderState=].
+    **Arguments:**
+    - |drawCall|: The draw call parameters.
+    - |state|: The active [=RenderState=].
 
-        **Returns:** list of integer indices.
+    **Returns:** list of integer indices.
 
-        1. Let |vertexIndexList| be an empty list of indices.
-        1. If |drawCall| is an indexed draw call:
-            1. initialize the |vertexIndexList| with |drawCall|.indexCount integers.
-            1. for |i| in range 0 .. |drawCall|.indexCount (non-inclusive):
-                1. let |vertexIndex| be [$fetch index$](|i| + |drawCall|.firstIndex,
-                    |state|.[=RenderState/indexBuffer=].buffer, |state|.[=RenderState/indexBuffer=].offset,
-                    |state|.[=RenderState/indexBuffer=].format) + |drawCall|.baseVertex
-                1. append |vertexIndex| to the |vertexIndexList|
-        1. Otherwise:
-            1. initialize the |vertexIndexList| with |drawCall|.vertexCount integers.
-            1. assign the |vertexIndexList| item |i| to be |drawCall|.firstVertex + |i|
-        1. Return |vertexIndexList|.
+    1. Let |vertexIndexList| be an empty list of indices.
+    1. If |drawCall| is an indexed draw call:
+        1. Initialize the |vertexIndexList| with |drawCall|.indexCount integers.
+        1. For |i| in range 0 .. |drawCall|.indexCount (non-inclusive):
+            1. Let |relativeVertexIndex| be [$fetch index$](|i| + |drawCall|.`firstIndex`,
+                |state|.[=RenderState/indexBuffer=].`buffer`, |state|.[=RenderState/indexBuffer=].`offset`,
+                |state|.[=RenderState/indexBuffer=].`format`).
+            1. If |relativeVertexIndex| is `"out of bounds"`, stop and return the empty list.
 
-        Note: in case of indirect draw calls, the `indexCount`, `vertexCount`,
-        and other properties of |drawCall| are read from the indirect buffer
-        instead of the draw command itself.
+                Note: Implementations may choose to display a warning when this occurs,
+                especially when it is easy to detect (like in non-indirect indexed draw calls).
+            1. Append |drawCall|.`baseVertex` + |relativeVertexIndex| to the |vertexIndexList|.
+    1. Otherwise:
+        1. initialize the |vertexIndexList| with |drawCall|.vertexCount integers.
+        1. assign the |vertexIndexList| item |i| to be |drawCall|.firstVertex + |i|
+    1. Return |vertexIndexList|.
 
-        Issue: specify indirect commands better.
+    Note: in case of indirect draw calls, the `indexCount`, `vertexCount`,
+    and other properties of |drawCall| are read from the indirect buffer
+    instead of the draw command itself.
+
+    Issue: specify indirect commands better.
 </div>
 
 <div algorithm>
     <dfn abstract-op>fetch index</dfn>(i, buffer, offset, format)
 
-        **Arguments:**
-            - |i|: Index of a vertex index to fetch.
-            - |buffer|: {{GPUBuffer}} containing index data.
-            - |offset|: Base offset into the |buffer|.
-            - |format|: {{GPUIndexFormat}} of the index.
+    **Arguments:**
+    - |i|: Index of a vertex index to fetch.
+    - |buffer|: {{GPUBuffer}} containing index data.
+    - |offset|: Base offset into the |buffer|.
+    - |format|: {{GPUIndexFormat}} of the index.
 
-        Let |stride| be defined by the |format|:
+    **Returns:** unsigned integer or `"out of bounds"`
+
+    1. Let |elementByteSize| be defined by the |format|:
         <dl class="switch">
             : {{GPUIndexFormat/"uint16"}}
             :: 2
             : {{GPUIndexFormat/"uint32"}}
             :: 4
         </dl>
-        Interpret the data in |buffer| starting with |offset| + |i| * |stride|
-        of size |stride| bytes as an unsigned integer and return it.
+    1. If |offset| + |i + 1| &times; |elementByteSize| &gt; |buffer|.{{GPUBuffer/[[size]]}},
+        return `"out of bounds"`.
+    1. Interpret the data in |buffer| starting with |offset| + |i| &times; |elementByteSize|
+        of size |elementByteSize| bytes as an unsigned integer and return it.
 </div>
 
 ### Vertex Processing ### {#vertex-processing}
@@ -8459,58 +8468,67 @@ clip space positions for [[#primitive-clipping]], as well as other data for the
 <div algorithm>
     <dfn abstract-op>process vertices</dfn>(vertexIndexList, drawCall, desc, state)
 
-        **Arguments:**
-            - |vertexIndexList|: List of vertex indices to process.
-            - |drawCall|: The draw call parameters.
-            - |desc|: The descriptor of type {{GPUVertexState}}.
-            - |state|: The active [=RenderState=].
+    **Arguments:**
+    - |vertexIndexList|: List of vertex indices to process (mutable, passed by reference).
+    - |drawCall|: The draw call parameters.
+    - |desc|: The descriptor of type {{GPUVertexState}}.
+    - |state|: The active [=RenderState=].
 
-        Each vertex |vertexIndex| in the |vertexIndexList|,
-        in each instance of index |rawInstanceIndex|, is processed independently.
-        The |rawInstanceIndex| is in range from 0 to |drawCall|.instanceCount - 1, inclusive.
-        This processing happens in parallel, and any side effects, such as
-        writes into {{GPUBufferBindingType/"storage"|GPUBufferBindingType."storage"}} bindings,
-        may happen in any order.
-        1. Let |instanceIndex| be |rawInstanceIndex| + |drawCall|.baseInstance.
-        1. For each non-`null` |vertexBufferLayout| in the list of |desc|.{{GPUVertexState/buffers}}:
-            1. Let |i| be the index of the buffer layout in this list.
-            1. Let |vertexBuffer| and |vertexBufferOffset| be the buffer and offset in
-                |state|.[=RenderState/vertexBuffers=] bindings at slot |i|
-            1. Let |vertexElementIndex| be dependent on |vertexBufferLayout|.{{GPUVertexBufferLayout/stepMode}}:
-                <dl class="switch">
-                    : {{GPUInputStepMode/"vertex"}}
-                    :: |vertexIndex|
-                    : {{GPUInputStepMode/"instance"}}
-                    :: |instanceIndex|
-                </dl>
-            1. For each |attributeDesc| in |vertexBufferLayout|.{{GPUVertexBufferLayout/attributes}}:
-                1. Let |attributeOffset| be |vertexBufferOffset| +
-                    |vertexElementIndex| * |vertexBufferLayout|.{{GPUVertexBufferLayout/arrayStride}} +
-                    |attributeDesc|.{{GPUVertexAttribute/offset}}.
-                1. Load the attribute |data| of format |attributeDesc|.{{GPUVertexAttribute/format}}
-                    from |vertexBuffer| starting at offset |attributeOffset|.
-                1. Convert the |data| into a shader-visible format.
-                    <div class="example">
-                        An attribute of type {{GPUVertexFormat/"unorm8x2"}} will be converted from
-                        2 bytes of fixed-point unsigned 8-bit integers into 2 floating-point values
-                        as `vec2<f32>` in WGSL.
-                    </div>
-                1. Bind the |data| to vertex shader input
-                    location |attributeDesc|.{{GPUVertexAttribute/shaderLocation}}.
-        1. For each {{GPUBindGroup}} group at |index| in |state|.[=RenderState/bindGroups=]:
-            1. For each resource {{GPUBindingResource}} in the bind group:
-                1. Let |entry| be the corresponding {{GPUBindGroupLayoutEntry}} for this resource.
-                1. If |entry|.{{GPUBindGroupLayoutEntry}}.visibility includes {{GPUShaderStage/VERTEX}}:
-                    - Bind the resource to the shader under group |index| and binding {{GPUBindGroupLayoutEntry/binding|GPUBindGroupLayoutEntry.binding}}.
-        1. Set the shader builtins:
-            - Set the `VertexIndex` builtin, if any, to |vertexIndex|.
-            - Set the `InstanceIndex` builtin, if any, to |instanceIndex|.
-        1. Invoke vertex shader entry point described by |desc|.
+    Each vertex |vertexIndex| in the |vertexIndexList|,
+    in each instance of index |rawInstanceIndex|, is processed independently.
+    The |rawInstanceIndex| is in range from 0 to |drawCall|.instanceCount - 1, inclusive.
+    This processing happens in parallel, and any side effects, such as
+    writes into {{GPUBufferBindingType/"storage"|GPUBufferBindingType."storage"}} bindings,
+    may happen in any order.
+    1. Let |instanceIndex| be |rawInstanceIndex| + |drawCall|.baseInstance.
+    1. For each non-`null` |vertexBufferLayout| in the list of |desc|.{{GPUVertexState/buffers}}:
+        1. Let |i| be the index of the buffer layout in this list.
+        1. Let |vertexBuffer| and |vertexBufferOffset| be the buffer and offset in
+            |state|.[=RenderState/vertexBuffers=] bindings at slot |i|
+        1. Let |vertexElementIndex| be dependent on |vertexBufferLayout|.{{GPUVertexBufferLayout/stepMode}}:
+            <dl class="switch">
+                : {{GPUInputStepMode/"vertex"}}
+                :: |vertexIndex|
+                : {{GPUInputStepMode/"instance"}}
+                :: |instanceIndex|
+            </dl>
+        1. For each |attributeDesc| in |vertexBufferLayout|.{{GPUVertexBufferLayout/attributes}}:
+            1. Let |attributeOffset| be |vertexBufferOffset| +
+                |vertexElementIndex| * |vertexBufferLayout|.{{GPUVertexBufferLayout/arrayStride}} +
+                |attributeDesc|.{{GPUVertexAttribute/offset}}.
+            1. Load the attribute |data| of format |attributeDesc|.{{GPUVertexAttribute/format}}
+                from |vertexBuffer| starting at offset |attributeOffset|.
+                If this results in an out-of-bounds access, the resulting value is determined
+                according to WGSL's [=invalid memory reference=] behavior.
+            1. **Optionally (implementation-defined):**
+                If |attributeOffset| + sizeof(|attributeDesc|.{{GPUVertexAttribute/format}} &gt;
+                |vertexBuffer|.{{GPUBuffer/[[size]]}},
+                [=list/empty=] |vertexIndexList| and stop, cancelling the draw call.
 
-            Note: The target platform caches the results of vertex shader invocations.
-            There is no guarantee that any |vertexIndex| that repeats more than once will
-            result in multiple invocations. Similarly, there is no guarantee that a single |vertexIndex|
-            will only be processed once.
+                Note: This allows implementations to detect out-of-bounds values in the index buffer
+                before issuing a draw call, instead of using [=invalid memory reference=] behavior.
+            1. Convert the |data| into a shader-visible format.
+                <div class="example">
+                    An attribute of type {{GPUVertexFormat/"unorm8x2"}} will be converted from
+                    2 bytes of fixed-point unsigned 8-bit integers into 2 floating-point values
+                    as `vec2<f32>` in WGSL.
+                </div>
+            1. Bind the |data| to vertex shader input
+                location |attributeDesc|.{{GPUVertexAttribute/shaderLocation}}.
+    1. For each {{GPUBindGroup}} group at |index| in |state|.[=RenderState/bindGroups=]:
+        1. For each resource {{GPUBindingResource}} in the bind group:
+            1. Let |entry| be the corresponding {{GPUBindGroupLayoutEntry}} for this resource.
+            1. If |entry|.{{GPUBindGroupLayoutEntry}}.visibility includes {{GPUShaderStage/VERTEX}}:
+                - Bind the resource to the shader under group |index| and binding {{GPUBindGroupLayoutEntry/binding|GPUBindGroupLayoutEntry.binding}}.
+    1. Set the shader builtins:
+        - Set the `VertexIndex` builtin, if any, to |vertexIndex|.
+        - Set the `InstanceIndex` builtin, if any, to |instanceIndex|.
+    1. Invoke vertex shader entry point described by |desc|.
+
+        Note: The target platform caches the results of vertex shader invocations.
+        There is no guarantee that any |vertexIndex| that repeats more than once will
+        result in multiple invocations. Similarly, there is no guarantee that a single |vertexIndex|
+        will only be processed once.
 </div>
 
 ### Primitive Assembly ### {#primitive-assembly}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8417,14 +8417,15 @@ a list of vertices to process for each instance.
             1. Let |relativeVertexIndex| be [$fetch index$](|i| + |drawCall|.`firstIndex`,
                 |state|.[=RenderState/indexBuffer=].`buffer`, |state|.[=RenderState/indexBuffer=].`offset`,
                 |state|.[=RenderState/indexBuffer=].`format`).
-            1. If |relativeVertexIndex| is `"out of bounds"`, stop and return the empty list.
+            1. If |relativeVertexIndex| has the special value `"out of bounds"`,
+                stop and return the empty list.
 
                 Note: Implementations may choose to display a warning when this occurs,
                 especially when it is easy to detect (like in non-indirect indexed draw calls).
             1. Append |drawCall|.`baseVertex` + |relativeVertexIndex| to the |vertexIndexList|.
     1. Otherwise:
-        1. initialize the |vertexIndexList| with |drawCall|.vertexCount integers.
-        1. assign the |vertexIndexList| item |i| to be |drawCall|.firstVertex + |i|
+        1. Initialize the |vertexIndexList| with |drawCall|.vertexCount integers.
+        1. Set each |vertexIndexList| item |i| to the value |drawCall|.firstVertex + |i|.
     1. Return |vertexIndexList|.
 
     Note: in case of indirect draw calls, the `indexCount`, `vertexCount`,
@@ -8453,7 +8454,7 @@ a list of vertices to process for each instance.
             :: 4
         </dl>
     1. If |offset| + |i + 1| &times; |elementByteSize| &gt; |buffer|.{{GPUBuffer/[[size]]}},
-        return `"out of bounds"`.
+        return the special value `"out of bounds"`.
     1. Interpret the data in |buffer| starting with |offset| + |i| &times; |elementByteSize|
         of size |elementByteSize| bytes as an unsigned integer and return it.
 </div>
@@ -8483,8 +8484,8 @@ clip space positions for [[#primitive-clipping]], as well as other data for the
     1. Let |instanceIndex| be |rawInstanceIndex| + |drawCall|.baseInstance.
     1. For each non-`null` |vertexBufferLayout| in the list of |desc|.{{GPUVertexState/buffers}}:
         1. Let |i| be the index of the buffer layout in this list.
-        1. Let |vertexBuffer| and |vertexBufferOffset| be the buffer and offset in
-            |state|.[=RenderState/vertexBuffers=] bindings at slot |i|
+        1. Let |vertexBuffer|, |vertexBufferOffset|, and |vertexBufferBindingSize| be the
+            buffer, offset, and size at slot |i| of |state|.[=RenderState/vertexBuffers=].
         1. Let |vertexElementIndex| be dependent on |vertexBufferLayout|.{{GPUVertexBufferLayout/stepMode}}:
             <dl class="switch">
                 : {{GPUInputStepMode/"vertex"}}
@@ -8501,8 +8502,8 @@ clip space positions for [[#primitive-clipping]], as well as other data for the
                 If this results in an out-of-bounds access, the resulting value is determined
                 according to WGSL's [=invalid memory reference=] behavior.
             1. **Optionally (implementation-defined):**
-                If |attributeOffset| + sizeof(|attributeDesc|.{{GPUVertexAttribute/format}} &gt;
-                |vertexBuffer|.{{GPUBuffer/[[size]]}},
+                If |attributeOffset| + sizeof(|attributeDesc|.{{GPUVertexAttribute/format}}) &gt;
+                |vertexBufferOffset| + |vertexBufferBindingSize|,
                 [=list/empty=] |vertexIndexList| and stop, cancelling the draw call.
 
                 Note: This allows implementations to detect out-of-bounds values in the index buffer

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8680,8 +8680,7 @@ a list of vertices to process for each instance.
         1. Initialize the |vertexIndexList| with |drawCall|.indexCount integers.
         1. For |i| in range 0 .. |drawCall|.indexCount (non-inclusive):
             1. Let |relativeVertexIndex| be [$fetch index$](|i| + |drawCall|.`firstIndex`,
-                |state|.[=RenderState/indexBuffer=].`buffer`, |state|.[=RenderState/indexBuffer=].`offset`,
-                |state|.[=RenderState/indexBuffer=].`format`).
+                |state|.[=RenderState/indexBuffer=]).
             1. If |relativeVertexIndex| has the special value `"out of bounds"`,
                 stop and return the empty list.
 
@@ -8705,23 +8704,22 @@ a list of vertices to process for each instance.
 
     **Arguments:**
     - |i|: Index of a vertex index to fetch.
-    - |buffer|: {{GPUBuffer}} containing index data.
-    - |offset|: Base offset into the |buffer|.
-    - |format|: {{GPUIndexFormat}} of the index.
+    - |indexBufferState|: A value of [=RenderState/indexBuffer=] (buffer, format, offset, and size).
 
     **Returns:** unsigned integer or `"out of bounds"`
 
-    1. Let |elementByteSize| be defined by the |format|:
+    1. Let |indexSize| be defined by the |indexBufferState|.`format`:
         <dl class="switch">
             : {{GPUIndexFormat/"uint16"}}
             :: 2
             : {{GPUIndexFormat/"uint32"}}
             :: 4
         </dl>
-    1. If |offset| + |i + 1| &times; |elementByteSize| &gt; |buffer|.{{GPUBuffer/[[size]]}},
+    1. If |indexBufferState|.`offset` + |i + 1| &times; |indexSize| &gt; |indexBufferState|.`size`,
         return the special value `"out of bounds"`.
-    1. Interpret the data in |buffer| starting with |offset| + |i| &times; |elementByteSize|
-        of size |elementByteSize| bytes as an unsigned integer and return it.
+    1. Interpret the data in |indexBufferState|.`buffer`, starting at offset
+        |indexBufferState|.`offset` + |i| &times; |indexSize|,
+        of size |indexSize| bytes, as an unsigned integer and return it.
 </div>
 
 ### Vertex Processing ### {#vertex-processing}


### PR DESCRIPTION
(Note: Can review with whitespace changes ignored.)

I believe these are the semantics agreed upon as recorded in #955.
Takes advantage of the robustness behavior defined by WGSL in #1722.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1835.html" title="Last updated on Jul 19, 2021, 11:55 PM UTC (000362b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1835/150002c...kainino0x:000362b.html" title="Last updated on Jul 19, 2021, 11:55 PM UTC (000362b)">Diff</a>