### PR TITLE
Expand allowable type for ignore()

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7859,7 +7859,7 @@ TODO: Add links to the eventual memory model.
     <td class="nowrap">
         `ignore`(|e|: |T|)
     <td>Evaluates |e|, and then ignores the result.<br>
-        Type |T| is any type that can be returned from a function.<br>
+        Type |T| is any non-reference type.
 </table>
 
 # Glossary # {#glossary}


### PR DESCRIPTION
* Expands allowable types to ignore() so that it can also be used to
  silence unused variable warnings more generally