### PR TITLE
Add unconfigure() to GPUPresentationContext

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7947,7 +7947,8 @@ method of an {{HTMLCanvasElement}} instance by passing the string literal `'gpup
 <script type=idl>
 [Exposed=Window]
 interface GPUPresentationContext {
-    undefined configure(GPUPresentationConfiguration? configuration);
+    undefined configure(GPUPresentationConfiguration configuration);
+    undefined unconfigure();
 
     GPUTextureFormat getPreferredFormat(GPUAdapter adapter);
     GPUTexture getCurrentTexture();
@@ -8006,7 +8007,6 @@ interface GPUPresentationContext {
             1. If |this|.{{GPUPresentationContext/[[currentTexture]]}} is not `null` call
                 {{GPUTexture/destroy()}} on |this|.{{GPUPresentationContext/[[currentTexture]]}}.
             1. Set |this|.{{GPUPresentationContext/[[currentTexture]]}} to `null`.
-            1. If |configuration| is `null` return.
             1. Let |device| be |configuration|.{{GPUPresentationConfiguration/device}}.
             1. Let |canvas| be |this|.{{GPUPresentationContext/[[canvas]]}}.
             1. If |configuration|.{{GPUPresentationConfiguration/size}} is `undefined` set
@@ -8035,6 +8035,22 @@ interface GPUPresentationContext {
                             1. Return.
                 </div>
             1. Set |this|.{{GPUPresentationContext/[[validConfiguration]]}} to `true`.
+        </div>
+
+    : <dfn>unconfigure()</dfn>
+    ::
+        Removes the presentation context configuration. Destroys any textures produced while configured.
+
+        <div algorithm="GPUPresentationContext.unconfigure">
+            **Called on:** {{GPUPresentationContext}} |this|.
+
+            **Returns:** undefined
+
+            1. Set |this|.{{GPUPresentationContext/[[validConfiguration]]}} to `false`.
+            1. Set |this|.{{GPUPresentationContext/[[configuration]]}} to `null`.
+            1. If |this|.{{GPUPresentationContext/[[currentTexture]]}} is not `null` call
+                {{GPUTexture/destroy()}} on |this|.{{GPUPresentationContext/[[currentTexture]]}}.
+            1. Set |this|.{{GPUPresentationContext/[[currentTexture]]}} to `null`.
         </div>
 
     : <dfn>getPreferredFormat(adapter)</dfn>


### PR DESCRIPTION
Fixes #1822

Adds an explicit `unconfigure()` to `GPUPresentationContext` and removes the ability to pass `null` to `configure()` (which apparently WebIDL doesn't allow anyway.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/1843.html" title="Last updated on Jun 15, 2021, 5:17 PM UTC (2e8266a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1843/6a8917c...2e8266a.html" title="Last updated on Jun 15, 2021, 5:17 PM UTC (2e8266a)">Diff</a>