### PR TITLE
Resolve missing color space and alpha issues

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1283,7 +1283,7 @@ For more information on issuing CORS requests for image and video elements, cons
 - [[html#the-img-element]] <{img}>
 - [[html#media-elements]] {{HTMLMediaElement}}
 
-## Color Spaces ## {#color-spaces}
+## Color Spaces and Encoding ## {#color-spaces}
 
 WebGPU does not provide color management. All values within WebGPU (such as texture elements)
 are raw numeric values, not color-managed color values.
@@ -1291,8 +1291,8 @@ are raw numeric values, not color-managed color values.
 WebGPU *does* interface with color-managed outputs (via {{GPUPresentationConfiguration}}) and inputs
 (via {{GPUQueue/copyExternalImageToTexture()}} and {{GPUDevice/importExternalTexture()}}).
 Color conversion must be performed between the WebGPU numeric values and the external color values.
-These interface points locally define a color space, in which the WebGPU numeric values are to be
-interpreted, from options defined in [[css-color-4#predefined]].
+Each such interface point locally defines an encoding (color space, transfer function, and alpha
+premultiplication) in which the WebGPU numeric values are to be interpreted.
 
 <script type=idl>
 enum GPUPredefinedColorSpace {
@@ -2856,7 +2856,8 @@ dictionary GPUExternalTextureDescriptor : GPUObjectDescriptorBase {
                 throw a {{SecurityError}} and stop.
 
             1. Let |data| be the result of converting the current image contents of |source| into
-                the color space |descriptor|.{{GPUExternalTextureDescriptor/colorSpace}}.
+                the color space |descriptor|.{{GPUExternalTextureDescriptor/colorSpace}}
+                with unpremultiplied alpha.
 
                 Note: This is described like a copy, but may be implemented as a reference to
                 read-only underlying data plus appropriate metadata to perform conversion later.
@@ -5567,6 +5568,9 @@ dictionary GPUImageCopyTextureTagged : GPUImageCopyTexture {
         {{ImageBitmap}} premultiplication can be controlled via {{ImageBitmapOptions}}.
 </dl>
 
+Issue: Define (and test) the encoding of color values into the
+various encodings allowed by {{GPUQueue/copyExternalImageToTexture()}}.
+
 ### <dfn dictionary>GPUImageCopyExternalImage</dfn> ### {#gpu-image-copy-external-image}
 
 <script type=idl>
@@ -5589,15 +5593,6 @@ dictionary GPUImageCopyExternalImage {
         Defines the origin of the copy - the minimum corner of the source sub-region to copy from.
         Together with `copySize`, defines the full copy sub-region.
 </dl>
-
-Issue(gpuweb/gpuweb#1483): Needs optional information about the target color encoding.
-ImageBitmap and canvas (and VideoElement) are color-managed: they encode colors.
-GPUTexture is not color-managed: it encodes raw numbers. Producing raw numbers requires knowing
-the target encoding. Probably there should be a particular default value (e.g. the default profile
-used by the browser for unmanaged content?), but eventually we'll want to add knobs.
-
-Issue: Once that's figured out, generally define (and test) the encoding of color values into the
-various formats allowed by {{GPUQueue/copyExternalImageToTexture()}}.
 
 ### Buffer Copies ### {#buffer-copies}
 
@@ -8194,10 +8189,10 @@ interface GPUPresentationContext {
         </div>
     1. Ensure that all submitted work items (e.g. queue submissions) have
         completed writing to |texture|.
-    1. Return the contents of |texture|.
+    1. Return the contents of |texture|, tagged as having alpha premultiplied, and with the color space
+        |context|.{{GPUPresentationContext/[[configuration]]}}.{{GPUPresentationConfiguration/colorSpace}}.
 
-        Issue: These contents need to be tagged with the currently-configured
-        colorSpace and premultipliedAlpha mode.
+        Issue(gpuweb/gpuweb#1847): Does compositingAlphaMode=opaque make this return opaque contents?
 </div>
 
 <div algorithm>
@@ -8238,20 +8233,20 @@ enum GPUCanvasCompositingAlphaMode {
     "premultiplied",
 };
 
-dictionary GPUPresentationConfiguration : GPUObjectDescriptorBase {
+dictionary GPUPresentationConfiguration {
     required GPUDevice device;
     required GPUTextureFormat format;
     GPUTextureUsageFlags usage = 0x10;  // GPUTextureUsage.RENDER_ATTACHMENT
+    GPUPredefinedColorSpace colorSpace = "srgb";
     GPUCanvasCompositingAlphaMode compositingAlphaMode = "opaque";
     GPUExtent3D size;
 };
 </script>
 
-Issue: A {{GPUPredefinedColorSpace}} is necessary here.
-Initially, for SDR, it can default to simply "srgb".
-When we add HDR canvas output (pixel values > 1), some clarification may be needed depending on
-upstream changes to canvas for color and HDR (e.g. to make sure we choose between extended-srgb
-and clamped-srgb: they're the same for SDR, but different for HDR).
+Issue: For SDR, it doesn't matter whether the default colorSpace of "srgb" means extended-srgb
+or clamped-srgb. However, when we add HDR canvas output (representing pixel values > 1),
+we need to choose which of those two is the default. Currently the upstream specs haven't worked
+out this question just yet.
 
 ### Presentation Context sizing ### {#presentation-context-sizing}
 


### PR DESCRIPTION
- Add colorSpace to GPUPresentationConfiguration
- Specify GPUExternalTexture is always unpremultiplied
- Remove stale issue on GPUImageCopyExternalImage
- Tag canvas image contents metadata

Also: Remove GPUObjectDescriptorBase from GPUPresentationConfiguration

Fixes #1762
Issues: #1483, #1847


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1848.html" title="Last updated on Jun 16, 2021, 11:31 PM UTC (1a73bf9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1848/eee1e8c...kainino0x:1a73bf9.html" title="Last updated on Jun 16, 2021, 11:31 PM UTC (1a73bf9)">Diff</a>