### PR TITLE
Add setVertex/IndexBuffer offset alignment rules.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4970,16 +4970,19 @@ format passed to {{GPURenderEncoderBase/setIndexBuffer()}} when rendering.
   <thead>
     <tr>
       <th>Index format</th>
+      <th>Byte size</th>
       <th>Primitive restart value</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>{{GPUIndexFormat/"uint16"}}</td>
+      <td>2</td>
       <td>0xFFFF</td>
     </tr>
     <tr>
       <td>{{GPUIndexFormat/"uint32"}}</td>
+      <td>4</td>
       <td>0xFFFFFFFF</td>
     </tr>
   </tbody>
@@ -6975,6 +6978,7 @@ enum GPUStoreOp {
                     <div class=validusage>
                         - |buffer| is [$valid to use with$] |this|.
                         - |buffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDEX}}.
+                        - |offset| is a multiple of |indexFormat|'s byte size.
                         - |offset| + |size| &le; |buffer|.{{GPUBuffer/[[size]]}}.
                     </div>
                 1. Add |buffer| to the [=usage scope=] as [=internal usage/input=].
@@ -7008,6 +7012,7 @@ enum GPUStoreOp {
                         - |buffer| is [$valid to use with$] |this|.
                         - |buffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/VERTEX}}.
                         - |slot| &lt; |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBuffers}}.
+                        - |offset| is a multiple of 4.
                         - |offset| + |size| &le; |buffer|.{{GPUBuffer/[[size]]}}.
                     </div>
                 1. Add |buffer| to the [=usage scope=] as [=internal usage/input=].


### PR DESCRIPTION
Fixes #1849


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/1853.html" title="Last updated on Jun 17, 2021, 3:36 PM UTC (5dd2aee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1853/eee1e8c...Kangz:5dd2aee.html" title="Last updated on Jun 17, 2021, 3:36 PM UTC (5dd2aee)">Diff</a>