### PR TITLE
wgsl: refine pointer function call restrictions

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5297,12 +5297,18 @@ See [[#discard-statement]].
     function parameter.
     * In particular, an argument that is a pointer must agree with the formal parameter
         on storage class, pointee type, and access mode.
-* A function parameter of pointer type must be in one of
+* For [=user-defined functions=], a parameter of pointer type must be in one of
     the following storage classes:
     * [=storage classes/function=]
     * [=storage classes/private=]
     * [=storage classes/workgroup=]
-* Each argument of a function call of pointer type must be one of:
+* For [=built-in functions=], a parameter of pointer type must be in one of
+    the following storage classes:
+    * [=storage classes/function=]
+    * [=storage classes/private=]
+    * [=storage classes/workgroup=]
+    * [=storage classes/storage=]
+* Each argument of pointer type to a [=user-defined function=] must be one of:
     * An [[#address-of-expr|address-of expression]] of a
         [[#var-identifier-expr|variable identifier expression]]
     * A function parameter


### PR DESCRIPTION
* built-in functions can have pointer-to-storage parameters
* only user-defined functions constrain where the pointer came from

Fixes: #1850