### PR TITLE
wgsl: can't type-construct or zero-value-construct aggregates containing atomics

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1838,7 +1838,7 @@ memory reference</dfn> is produced.
 [=Load Rule|Loads=] from an invalid reference return one of:
     * a value from any [=memory locations|memory location(s)=] of the [[WebGPU#buffers|WebGPU buffer]]
         bound to the [=originating variable=]
-    * the zero value for store type of the reference
+    * the [=zero value=] for store type of the reference
     * if the loaded value is a vector, the value (0, 0, 0, x), where x is:
         * 0, 1, or the maximum positive value for integer components
         * 0.0 or 1.0 for floating-point components
@@ -2842,7 +2842,7 @@ When a variable's lifetime ends, its storage may be used for another variable.
 When a variable is created, its storage contains an initial value as follows:
 
 * For variables in the [=storage classes/private=] or [=storage classes/function=] storage classes:
-    * The zero value for the store type, if the variable declaration has no initializer.
+    * The [=zero value=] for the store type, if the variable declaration has no initializer.
     * Otherwise, it is the result of evaluating the initializer expression at that point in the program execution.
 * For variables in other storage classes, the execution environment provides the initial value.
 
@@ -3245,39 +3245,34 @@ use the same storage.
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
-  <tr>
-    <td>*e1*: *T*<br>
+  <tr algorithm="array value construction">
+    <td>|e1|: |T|<br>
         ...<br>
-        *eN*: *T*<br>
-    <td>`array<`*T*,*N*`>(e1,...,eN)`: array<*T*, *N*>
-    <td>Construction of an array from elements
+        |eN|: |T|,<br>
+        |T| is an [=atomic-free=] [=plain type=]
+    <td>`array<`|T|,|N|`>(`|e1|,...,|eN|`)` : array&lt;|T|,|N|&gt;
+    <td>Construction of an array from elements.
 </table>
-TODO: Should this only work for storable sized arrays?  https://github.com/gpuweb/gpuweb/issues/982
 
 <table class='data'>
   <caption>Structure constructor type rules</caption>
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
-  <tr>
-    <td>*e1*: *T1*<br>
+  <tr algorithm="structure value construction">
+    <td>|e1|: |T1|<br>
         ...<br>
-        *eN*: *TN*<br>
-        *T1* is storable<br>
-        ...<br>
-        *TN* is storable<br>
-        S is a structure type with members having types *T1* ... *TN*.<br>
-        The expression is in the scope of declaration of S.
-    <td>`S(e1,...,eN)`: S
-    <td>Construction of a structure from members
+        |eN|: |TN|<br>
+        |S| is an [=atomic-free=] structure type with members having types |T1| ... |TN|.<br>
+        The expression is in the scope of declaration of |S|.
+    <td>|S|`(`|e1|,...,|eN|`)`: |S|
+    <td>Construction of a structure from members.
 </table>
-
 
 ## Zero Value Expressions ## {#zero-value-expr}
 
-Each storable type *T* has a unique *zero value*, written in WGSL as the type followed by an empty pair of parentheses: *T* `()`.
-
-Issue: We should exclude being able to write the zero value for an [=runtime-sized=] array. https://github.com/gpuweb/gpuweb/issues/981
+Each [=atomic-free=] [=plain type=] *T* has a unique <dfn noexport>zero value</dfn>
+written in WGSL as the type followed by an empty pair of parentheses: *T* `()`.
 
 The zero values are as follows:
 
@@ -3287,8 +3282,10 @@ The zero values are as follows:
 * `f32()` is 0.0
 * The zero value for an *N*-element vector of type *T* is the *N*-element vector of the zero value for *T*.
 * The zero value for an *N*-column *M*-row matrix of `f32` is the matrix of those dimensions filled with 0.0 entries.
-* The zero value for an *N*-element array with storable element type *E* is an array of *N* elements of the zero value for *E*.
-* The zero value for a storable structure type *S* is the structure value *S* with zero-valued members.
+* The zero value for an *N*-element array with atomic-free plain element type *E* is an array of *N* elements of the zero value for *E*.
+* The zero value for a atomic-free structure type *S* is the structure value *S* with zero-valued members.
+
+Note: WGSL does not have a need to define the zero value for an atomic type.
 
 <table class='data'>
   <caption>Scalar zero value type rules</caption>
@@ -3361,9 +3358,9 @@ The zero values are as follows:
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
-  <tr>
-    <td>*T* is storable
-    <td>`array<`*T*,*N*`>()`: array<*T*, *N*>
+  <tr algorithm="array zero value">
+    <td>|T| is an [=atomic-free=] [=plain type=]
+    <td>`array<`|T|,|N|`>()`: array&lt;|T|,|N|&gt;
     <td>Zero-valued array (OpConstantNull)
 </table>
 
@@ -3379,11 +3376,11 @@ The zero values are as follows:
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
-  <tr>
-    <td>`S` is a storable structure type.<br>
-         The expression is in the scope of declaration of S.
-    <td>`S()`: S
-    <td>Zero-valued structure: a structure of type S where each member is the zero value for its member type.
+  <tr algorithm="structure zero value">
+    <td>|S| is an [=atomic-free=] structure type.<br>
+         The expression is in the scope of declaration of |S|.
+    <td>|S|`()`: |S|
+    <td>Zero-valued structure: a structure of type |S| where each member is the zero value for its member type.
 <br>
  (OpConstantNull)
 </table>


### PR DESCRIPTION
…ing atomics

This is needed to keep the restriction that atomics can only be operated
on via atomic builtin functions.

Fixes: #1859