### PR TITLE
wgsl: Fix channel transfer functions for `8uint` and `8sint`.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2292,8 +2292,8 @@ This is also known as the <dfn noexport>channel transfer function</dfn>, or CTF.
   </thead>
   <tr><td>8unorm<td>8<td>unsigned integer |v| &isinv; {0,...,255}<td>f32<td> |v| &div; 255
   <tr><td>8snorm<td>8<td>signed integer |v| &isinv; {-128,...,127}<td>f32<td> max(-1, |v| &div; 127)
-  <tr><td>8uint<td>8<td>unsigned integer |v| &isinv; {0,...,255}<td>u32<td> |v| &div; 255
-  <tr><td>8sint<td>8<td>signed integer |v| &isinv; {-128,...,127}<td>i32<td> max(-1, |v| &div; 127)
+  <tr><td>8uint<td>8<td>unsigned integer |v| &isinv; {0,...,255}<td>u32<td> |v|
+  <tr><td>8sint<td>8<td>signed integer |v| &isinv; {-128,...,127}<td>i32<td> |v|
   <tr><td>16uint<td>16<td>unsigned integer |v| &isinv; {0,...,65535}<td>u32<td> |v|
   <tr><td>16sint<td>16<td>signed integer |v| &isinv; {-32768,...,32767}<td>i32<td> |v|
   <tr><td>16float<td>16<td>IEEE 754 16-bit floating point value |v|, with 1 sign bit, 5 exponent bits, 10 mantissa bits<td>f32<td>|v|


### PR DESCRIPTION
These are not normalized formats, so the channel transfer function should not
try to convert the range of the stored bits to `[0, 1]`.