### PR TITLE
Add a bunch of limits.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1187,6 +1187,23 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
         is {{GPUBufferBindingType/"storage"}}
         or {{GPUBufferBindingType/"read-only-storage"}}.
 
+    <tr><td><dfn>minUniformBufferOffsetAlignment</dfn>
+        <td>{{GPUSize32}} <td>Lower <td>256
+    <tr class=row-continuation><td colspan=4>
+        The required alignment for {{GPUBufferBinding/offset}} for bindings with a
+        {{GPUBindGroupLayoutEntry}} |entry| for which
+        |entry|.{{GPUBindGroupLayoutEntry/buffer}}?.{{GPUBufferBindingLayout/type}}
+        is {{GPUBufferBindingType/"uniform"}}.
+
+    <tr><td><dfn>minStorageBufferOffsetAlignment</dfn>
+        <td>{{GPUSize32}} <td>Lower <td>256
+    <tr class=row-continuation><td colspan=4>
+        The required alignment for {{GPUBufferBinding/offset}} for bindings with a
+        {{GPUBindGroupLayoutEntry}} |entry| for which
+        |entry|.{{GPUBindGroupLayoutEntry/buffer}}?.{{GPUBufferBindingLayout/type}}
+        is {{GPUBufferBindingType/"storage"}}
+        or {{GPUBufferBindingType/"read-only-storage"}}.
+
     <tr><td><dfn>maxVertexBuffers</dfn>
         <td>{{GPUSize32}} <td>Higher <td>8
     <tr class=row-continuation><td colspan=4>
@@ -1205,6 +1222,44 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
     <tr class=row-continuation><td colspan=4>
         The maximum allowed {{GPUVertexBufferLayout/arrayStride}}
         when creating a {{GPURenderPipeline}}.
+
+    <tr><td><dfn>maxVertexOutputComponents</dfn>
+        <td>{{GPUSize32}} <td>Higher <td>64
+    <tr class=row-continuation><td colspan=4>
+        The maximum allowed number of components of output variables for a
+        vertex stage {{GPUShaderModule}} entry-point.
+
+    <tr><td><dfn>maxFragmentInputComponents</dfn>
+        <td>{{GPUSize32}} <td>Higher <td>60
+    <tr class=row-continuation><td colspan=4>
+        The maximum allowed number of components of input variables for a
+        fragment stage {{GPUShaderModule}} entry-point.
+
+    <tr><td><dfn>maxColorAttachments</dfn>
+        <td>{{GPUSize32}} <td>Higher <td>4
+    <tr class=row-continuation><td colspan=4>
+        The maximum size of {{GPURenderPassDescriptor/colorAttachments}} and
+        {{GPUFragmentState/targets}}.
+
+        Issue: Do we need to have a max per-pixel render target size?
+
+    <tr><td><dfn>maxComputeWorkgroupStorageSize</dfn>
+        <td>{{GPUSize32}} <td>Higher <td>16352
+    <tr class=row-continuation><td colspan=4>
+        The maximum number of bytes used for a compute stage
+        {{GPUShaderModule}} entry-point.
+
+    <tr><td><dfn>maxComputeWorkgroupInvocations</dfn>
+        <td>{{GPUSize32}} <td>Higher <td>256
+    <tr class=row-continuation><td colspan=4>
+        The maximum value of the product of the `workgroup_size` values for a
+        compute stage {{GPUShaderModule}} entry-point.
+
+    <tr><td><dfn>maxComputePerDimensionDispatchSize</dfn>
+        <td>{{GPUSize32}} <td>Higher <td>65535
+    <tr class=row-continuation><td colspan=4>
+        The maximum value for the arguments of {{GPUComputePassEncoder/dispatch(x, y, z)}}.
+
 </table>
 
 #### <dfn interface>GPUSupportedLimits</dfn> #### {#gpu-supportedlimits}
@@ -1229,9 +1284,17 @@ interface GPUSupportedLimits {
     readonly attribute unsigned long maxUniformBuffersPerShaderStage;
     readonly attribute unsigned long maxUniformBufferBindingSize;
     readonly attribute unsigned long maxStorageBufferBindingSize;
+    readonly attribute unsigned long minUniformBufferOffsetAlignment;
+    readonly attribute unsigned long minStorageBufferOffsetAlignment;
     readonly attribute unsigned long maxVertexBuffers;
     readonly attribute unsigned long maxVertexAttributes;
     readonly attribute unsigned long maxVertexBufferArrayStride;
+    readonly attribute unsigned long maxVertexOuputComponents;
+    readonly attribute unsigned long maxFragmentInputComponents;
+    readonly attribute unsigned long maxColorAttachments;
+    readonly attribute unsigned long maxComputeWorkgroupStorageSize;
+    readonly attribute unsigned long maxComputeWorkgroupInvocations;
+    readonly attribute unsigned long maxComputePerDimensionDispatchSize;
 };
 </script>
 
@@ -3640,7 +3703,6 @@ A {{GPUBindGroup}} object has the following internal slots:
             **Returns:** {{GPUBindGroup}}
 
             1. Let |bindGroup| be a new valid {{GPUBindGroup}} object.
-            1. Let |limits| be |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxUniformBufferBindingSize}}.
             1. Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
                     1. If any of the following conditions are unsatisfied:
@@ -3724,6 +3786,8 @@ A {{GPUBindGroup}} object has the following internal slots:
                                                         includes {{GPUBufferUsage/UNIFORM}}.
                                                     :: |resource|.{{GPUBufferBinding/size}} &le;
                                                         |limits|.{{supported limits/maxUniformBufferBindingSize}}.
+                                                    :: |resource|.{{GPUBufferBinding/offset}} is a multiple of
+                                                        |limits|.{{supported limits/minUniformBufferOffsetAlignment}}.
                                                     :: Issue: This validation should take into account the default when  {{GPUBufferBinding/size}} is not set.
                                                         Also should {{GPUBufferBinding/size}} default to the `buffer.byteLength - offset` or
                                                         `min(buffer.byteLength - offset, limits.maxUniformBufferBindingSize)`?
@@ -3734,6 +3798,8 @@ A {{GPUBindGroup}} object has the following internal slots:
                                                         includes {{GPUBufferUsage/STORAGE}}.
                                                     :: |resource|.{{GPUBufferBinding/size}} &le;
                                                         |limits|.{{supported limits/maxStorageBufferBindingSize}}.
+                                                    :: |resource|.{{GPUBufferBinding/offset}} is a multiple of
+                                                        |limits|.{{supported limits/minStorageBufferOffsetAlignment}}.
                                                 </dl>
 
                                     </dl>
@@ -4458,6 +4524,14 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
                     - [$validating GPUProgrammableStage$]({{GPUShaderStage/COMPUTE}},
                         |descriptor|.{{GPUComputePipelineDescriptor/compute}},
                         |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
+                    - |descriptor|.{{GPUComputePipelineDescriptor/compute}} uses more than
+                        |device|.limits.{{supported limits/maxComputeWorkgroupStorageSize}} bytes of
+                        workgroup storage.
+
+                        Issue: Better define using static use, etc.
+                    - |descriptor|.{{GPUComputePipelineDescriptor/compute}} uses more than
+                        |device|.limits.{{supported limits/maxComputeWorkgroupInvocations}} per
+                        workgroup.
                 </div>
 
             Then:
@@ -4664,7 +4738,7 @@ details.
                 - [$validating GPUProgrammableStage$]({{GPUShaderStage/FRAGMENT}},
                     |descriptor|.{{GPURenderPipelineDescriptor/fragment}},
                     |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
-                - [$validating GPUFragmentState$](|descriptor|.{{GPURenderPipelineDescriptor/fragment}}) succeeds.
+                - [$validating GPUFragmentState$](|descriptor|.{{GPURenderPipelineDescriptor/fragment}}, |device|) succeeds.
                 - If the output SV_Coverage semantics is [=statically used=] by
                     |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
                     - |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/alphaToCoverageEnabled}} is `false`.
@@ -4689,6 +4763,10 @@ details.
                 type, and
                 [=interpolation=]
                 of the input.
+            - There is less than |device|.limits.{{supported limits/maxVertexOutputComponents}}
+                components of user-defined outputs for |descriptor|.{{GPURenderPipelineDescriptor/vertex}}.
+            - There is less than |device|.limits.{{supported limits/maxFragmentInputComponents}}
+                components of user-defined inputs for |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.
 </div>
 
 Issue: should we validate that `cullMode` is none for points and lines?
@@ -4784,10 +4862,11 @@ dictionary GPUFragmentState: GPUProgrammableStage {
 </script>
 
 <div algorithm>
-    <dfn abstract-op>validating GPUFragmentState</dfn>(|descriptor|)
+    <dfn abstract-op>validating GPUFragmentState</dfn>(|descriptor|, |device|)
         Return `true` if all of the following requirements are met:
 
-        - |descriptor|.{{GPUFragmentState/targets}}.length must be &le; 4.
+        - |descriptor|.{{GPUFragmentState/targets}}.length must be &le;
+            |device|.limits.{{supported limits/maxColorAttachments}}.
         - For each |colorState| layout descriptor in the list |descriptor|.{{GPUFragmentState/targets}}:
             - |colorState|.{{GPUColorTargetState/format}} must be listed in [[#plain-color-formats]]
                 with {{GPUTextureUsage/RENDER_ATTACHMENT}} capability.
@@ -6413,6 +6492,8 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
                     <div class=validusage>
                         - [$Validate encoder bind groups$](|this|, |this|.{{GPUComputePassEncoder/[[pipeline]]}})
                             is `true`.
+                        - all of |x|, |y| and |z| are less than
+                            |this|.device.limits.{{supported limits/maxComputePerDimensionDispatchSize}}.
                     </div>
 
                 1. [=list/Append=] a [=GPU command=] to
@@ -6469,6 +6550,8 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
                     </div>
                 1. Add |indirectBuffer| to the [=usage scope=] as {{GPUBufferUsage/INDIRECT}}.
             </div>
+
+            Issue: add some validation related to {{supported limits/maxComputePerDimensionDispatchSize}}.
         </div>
 </dl>
 
@@ -6701,7 +6784,7 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
     Given a {{GPURenderPassDescriptor}} |this| the following validation rules apply:
 
     1. |this|.{{GPURenderPassDescriptor/colorAttachments}}.length must be less than or equal to the
-        [=maximum color attachments=].
+        {{supported limits/maxColorAttachments}}.
     1. |this|.{{GPURenderPassDescriptor/colorAttachments}}.length must greater than `0` or
         |this|.{{GPURenderPassDescriptor/depthStencilAttachment}} must not be `null`.
     1. For each |colorAttachment| in |this|.{{GPURenderPassDescriptor/colorAttachments}}:
@@ -6724,8 +6807,6 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
 
         1. |this|.{{GPURenderPassDescriptor/occlusionQuerySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/type}}
             must be {{GPUQueryType/occlusion}}.
-
-    Issue: Define <dfn for=>maximum color attachments</dfn>
 
     Issue(gpuweb/gpuweb#503): support for no attachments
 </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1225,8 +1225,8 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
         The maximum allowed {{GPUVertexBufferLayout/arrayStride}}
         when creating a {{GPURenderPipeline}}.
 
-    <tr><td><dfn>maxInterStageShaderLocations</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>64
+    <tr><td><dfn>maxInterStageShaderComponents</dfn>
+        <td>{{GPUSize32}} <td>Higher <td>60
     <tr class=row-continuation><td colspan=4>
         The maximum allowed number of components of input or output variables
         for inter-stage communication (like vertex outputs or fragment inputs).
@@ -1285,7 +1285,7 @@ interface GPUSupportedLimits {
     readonly attribute unsigned long maxVertexBuffers;
     readonly attribute unsigned long maxVertexAttributes;
     readonly attribute unsigned long maxVertexBufferArrayStride;
-    readonly attribute unsigned long maxInterStageShaderLocations;
+    readonly attribute unsigned long maxInterStageShaderComponents;
     readonly attribute unsigned long maxComputeWorkgroupStorageSize;
     readonly attribute unsigned long maxComputeWorkgroupInvocations;
     readonly attribute unsigned long maxComputePerDimensionDispatchSize;
@@ -4758,9 +4758,9 @@ details.
                 type, and
                 [=interpolation=]
                 of the input.
-            - There is less than |device|.limits.{{supported limits/maxInterStageShaderLocations}}
+            - There is less than |device|.limits.{{supported limits/maxInterStageShaderComponents}}
                 components of user-defined outputs for |descriptor|.{{GPURenderPipelineDescriptor/vertex}}.
-            - There is less than |device|.limits.{{supported limits/maxInterStageShaderLocations}}
+            - There is less than |device|.limits.{{supported limits/maxInterStageShaderComponents}}
                 components of user-defined inputs for |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.
 </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1225,11 +1225,11 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
         The maximum allowed {{GPUVertexBufferLayout/arrayStride}}
         when creating a {{GPURenderPipeline}}.
 
-    <tr><td><dfn>maxVertexOutputComponents</dfn>
+    <tr><td><dfn>maxInterStageShaderLocations</dfn>
         <td>{{GPUSize32}} <td>Higher <td>64
     <tr class=row-continuation><td colspan=4>
-        The maximum allowed number of components of output variables for a
-        vertex stage {{GPUShaderModule}} entry-point.
+        The maximum allowed number of components of input or output variables
+        for inter-stage communication (like vertex outputs or fragment inputs).
 
     <tr><td><dfn>maxFragmentInputComponents</dfn>
         <td>{{GPUSize32}} <td>Higher <td>60
@@ -1285,8 +1285,7 @@ interface GPUSupportedLimits {
     readonly attribute unsigned long maxVertexBuffers;
     readonly attribute unsigned long maxVertexAttributes;
     readonly attribute unsigned long maxVertexBufferArrayStride;
-    readonly attribute unsigned long maxVertexOuputComponents;
-    readonly attribute unsigned long maxFragmentInputComponents;
+    readonly attribute unsigned long maxInterStageShaderLocations;
     readonly attribute unsigned long maxComputeWorkgroupStorageSize;
     readonly attribute unsigned long maxComputeWorkgroupInvocations;
     readonly attribute unsigned long maxComputePerDimensionDispatchSize;
@@ -4759,9 +4758,9 @@ details.
                 type, and
                 [=interpolation=]
                 of the input.
-            - There is less than |device|.limits.{{supported limits/maxVertexOutputComponents}}
+            - There is less than |device|.limits.{{supported limits/maxInterStageShaderLocations}}
                 components of user-defined outputs for |descriptor|.{{GPURenderPipelineDescriptor/vertex}}.
-            - There is less than |device|.limits.{{supported limits/maxFragmentInputComponents}}
+            - There is less than |device|.limits.{{supported limits/maxInterStageShaderLocations}}
                 components of user-defined inputs for |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.
 </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1190,16 +1190,18 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
     <tr><td><dfn>minUniformBufferOffsetAlignment</dfn>
         <td>{{GPUSize32}} <td>Lower <td>256
     <tr class=row-continuation><td colspan=4>
-        The required alignment for {{GPUBufferBinding/offset}} for bindings with a
-        {{GPUBindGroupLayoutEntry}} |entry| for which
+        The required alignment for {{GPUBufferBinding}}.{{GPUBufferBinding/offset}} and
+        {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup}}
+        |dynamicOffsets| arguments for binding with a {{GPUBindGroupLayoutEntry}} |entry| for which
         |entry|.{{GPUBindGroupLayoutEntry/buffer}}?.{{GPUBufferBindingLayout/type}}
         is {{GPUBufferBindingType/"uniform"}}.
 
     <tr><td><dfn>minStorageBufferOffsetAlignment</dfn>
         <td>{{GPUSize32}} <td>Lower <td>256
     <tr class=row-continuation><td colspan=4>
-        The required alignment for {{GPUBufferBinding/offset}} for bindings with a
-        {{GPUBindGroupLayoutEntry}} |entry| for which
+        The required alignment for {{GPUBufferBinding}}.{{GPUBufferBinding/offset}} and
+        {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup}}
+        |dynamicOffsets| arguments for binding with a {{GPUBindGroupLayoutEntry}} |entry| for which
         |entry|.{{GPUBindGroupLayoutEntry/buffer}}?.{{GPUBufferBindingLayout/type}}
         is {{GPUBufferBindingType/"storage"}}
         or {{GPUBufferBindingType/"read-only-storage"}}.
@@ -1235,14 +1237,6 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
         The maximum allowed number of components of input variables for a
         fragment stage {{GPUShaderModule}} entry-point.
 
-    <tr><td><dfn>maxColorAttachments</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>4
-    <tr class=row-continuation><td colspan=4>
-        The maximum size of {{GPURenderPassDescriptor/colorAttachments}} and
-        {{GPUFragmentState/targets}}.
-
-        Issue: Do we need to have a max per-pixel render target size?
-
     <tr><td><dfn>maxComputeWorkgroupStorageSize</dfn>
         <td>{{GPUSize32}} <td>Higher <td>16352
     <tr class=row-continuation><td colspan=4>
@@ -1261,6 +1255,8 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
         The maximum value for the arguments of {{GPUComputePassEncoder/dispatch(x, y, z)}}.
 
 </table>
+
+Issue: Do we need to have a max per-pixel render target size?
 
 #### <dfn interface>GPUSupportedLimits</dfn> #### {#gpu-supportedlimits}
 
@@ -1291,7 +1287,6 @@ interface GPUSupportedLimits {
     readonly attribute unsigned long maxVertexBufferArrayStride;
     readonly attribute unsigned long maxVertexOuputComponents;
     readonly attribute unsigned long maxFragmentInputComponents;
-    readonly attribute unsigned long maxColorAttachments;
     readonly attribute unsigned long maxComputeWorkgroupStorageSize;
     readonly attribute unsigned long maxComputeWorkgroupInvocations;
     readonly attribute unsigned long maxComputePerDimensionDispatchSize;
@@ -3703,6 +3698,7 @@ A {{GPUBindGroup}} object has the following internal slots:
             **Returns:** {{GPUBindGroup}}
 
             1. Let |bindGroup| be a new valid {{GPUBindGroup}} object.
+            1. Let |limits| be |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.
             1. Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
                     1. If any of the following conditions are unsatisfied:
@@ -4738,7 +4734,7 @@ details.
                 - [$validating GPUProgrammableStage$]({{GPUShaderStage/FRAGMENT}},
                     |descriptor|.{{GPURenderPipelineDescriptor/fragment}},
                     |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
-                - [$validating GPUFragmentState$](|descriptor|.{{GPURenderPipelineDescriptor/fragment}}, |device|) succeeds.
+                - [$validating GPUFragmentState$](|descriptor|.{{GPURenderPipelineDescriptor/fragment}}) succeeds.
                 - If the output SV_Coverage semantics is [=statically used=] by
                     |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
                     - |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/alphaToCoverageEnabled}} is `false`.
@@ -4862,11 +4858,10 @@ dictionary GPUFragmentState: GPUProgrammableStage {
 </script>
 
 <div algorithm>
-    <dfn abstract-op>validating GPUFragmentState</dfn>(|descriptor|, |device|)
+    <dfn abstract-op>validating GPUFragmentState</dfn>(|descriptor|)
         Return `true` if all of the following requirements are met:
 
-        - |descriptor|.{{GPUFragmentState/targets}}.length must be &le;
-            |device|.limits.{{supported limits/maxColorAttachments}}.
+        - |descriptor|.{{GPUFragmentState/targets}}.length must be &le; 8.
         - For each |colorState| layout descriptor in the list |descriptor|.{{GPUFragmentState/targets}}:
             - |colorState|.{{GPUColorTargetState/format}} must be listed in [[#plain-color-formats]]
                 with {{GPUTextureUsage/RENDER_ATTACHMENT}} capability.
@@ -6255,13 +6250,22 @@ interface mixin GPUProgrammablePassEncoder {
                             |bindGroup|.{{GPUBindGroup/[[layout]]}}.{{GPUBindGroupLayout/[[dynamicOffsetCount]]}}.
 
                         - [$Iterate over each dynamic binding offset$] in |bindGroup| and
-                            run the following steps for each |bufferBinding|, |minBindingSize|,
+                            run the following steps for each |bufferBinding|, |bufferLayout|,
                             and |dynamicOffsetIndex|:
 
                             - Let |bufferDynamicOffset| be |dynamicOffsets|[|dynamicOffsetIndex|].
                             - |bufferBinding|.{{GPUBufferBinding/offset}} + |bufferDynamicOffset| +
-                                |minBindingSize| &le;
+                                |bufferLayout|.{{GPUBufferBindingLayout/minBindingSize}} &le;
                                 |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBuffer/[[size]]}}.
+                            - if |bufferLayout|.{{GPUBufferBindingLayout/type}} is {{GPUBufferBindingType/"uniform"}}:
+
+                                - |dynamicOffset| is a multiple of {{supported limits/minUniformBufferOffsetAlignment}}.
+
+                            - if |bufferLayout|.{{GPUBufferBindingLayout/type}} is {{GPUBufferBindingType/"storage"}}
+                                or {{GPUBufferBindingType/"read-only-storage"}}:
+
+                                - |dynamicOffset| is a multiple of {{supported limits/minStorageBufferOffsetAlignment}}.
+
                     </div>
                 1. Set |this|.{{GPUProgrammablePassEncoder/[[bind_groups]]}}[|index|] to be |bindGroup|.
             </div>
@@ -6313,8 +6317,8 @@ interface mixin GPUProgrammablePassEncoder {
         1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/buffer}} is not `undefined` and
             |bindingDescriptor|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}} is `true`:
             1. Let |bufferBinding| be |entry|.{{GPUBindGroupEntry/resource}}.
-            1. Let |minBindingSize| be |bindingDescriptor|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}}.
-            1. Call |steps| with |bufferBinding|, |minBindingSize|, and |dynamicOffsetIndex|.
+            1. Let |bufferLayout| be |bindingDescriptor|.{{GPUBindGroupLayoutEntry/buffer}}.
+            1. Call |steps| with |bufferBinding|, |bufferLayout|, and |dynamicOffsetIndex|.
             1. Let |dynamicOffsetIndex| be |dynamicOffsetIndex| + `1`
 </div>
 
@@ -6783,8 +6787,7 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
 
     Given a {{GPURenderPassDescriptor}} |this| the following validation rules apply:
 
-    1. |this|.{{GPURenderPassDescriptor/colorAttachments}}.length must be less than or equal to the
-        {{supported limits/maxColorAttachments}}.
+    1. |this|.{{GPURenderPassDescriptor/colorAttachments}}.length must be less than or equal to 8.
     1. |this|.{{GPURenderPassDescriptor/colorAttachments}}.length must greater than `0` or
         |this|.{{GPURenderPassDescriptor/depthStencilAttachment}} must not be `null`.
     1. For each |colorAttachment| in |this|.{{GPURenderPassDescriptor/colorAttachments}}:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1231,12 +1231,6 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
         The maximum allowed number of components of input or output variables
         for inter-stage communication (like vertex outputs or fragment inputs).
 
-    <tr><td><dfn>maxFragmentInputComponents</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>60
-    <tr class=row-continuation><td colspan=4>
-        The maximum allowed number of components of input variables for a
-        fragment stage {{GPUShaderModule}} entry-point.
-
     <tr><td><dfn>maxComputeWorkgroupStorageSize</dfn>
         <td>{{GPUSize32}} <td>Higher <td>16352
     <tr class=row-continuation><td colspan=4>


### PR DESCRIPTION
- `minUniformBufferOffsetAlignment` at 256. Required from all APIs.
- `minStorageBufferOffsetAlignment` at 256. Required for most Vulkan
  Android devices.
- `maxVertexOutputComponents` at 64. Required for early Apple GPUs
  on Metal.
- `maxFragmentInputComponents` at 60. Required for early Apple GPUs
  on Metal.
- `maxColorAttachments` at 4. Required for early Apple GPUs on Metal
  and many Android Vulkan devices.
- `maxComputeWorkgroupStorageSize` at 16352. Required for early
  Apple GPUs on Metal and many Android Vulkan devices.
- `maxComputeWorkgroupInvocations` at 256. Required for many Android
  Vulkan devices. Chose to not have per-dimension limits as they would
  be more constraining and can be worked around when translating from
  WGSL to SPIR-V.
- `maxComputePerDimensionDispatchSize` at 65535. Required for many
  Android Vulkan devices.

See #1343


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/1863.html" title="Last updated on Jun 24, 2021, 6:15 PM UTC (0003eb1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1863/528f011...Kangz:0003eb1.html" title="Last updated on Jun 24, 2021, 6:15 PM UTC (0003eb1)">Diff</a>