### PR TITLE
Change RO texture usage to be restricted

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9161,7 +9161,7 @@ All plain color formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/
 Only formats with {{GPUTextureSampleType}} {{GPUTextureSampleType/"float"}} can be blended.
 
 The {{GPUTextureUsage/STORAGE|GPUTextureUsage.STORAGE}} column specifies the support for {{GPUTextureUsage/STORAGE}}
-usage in the core API, including both {{GPUStorageTextureAccess/"read-only"}} and {{GPUStorageTextureAccess/"write-only"}}.
+usage in the core API, and lists the allowed {{GPUStorageTextureAccess}} types for texture bindings.
 
 The {{GPUTextureUsage/STORAGE|GPUTextureUsage.RENDER_ATTACHMENT}} column specifies the support for
 {{GPUTextureUsage/RENDER_ATTACHMENT}} usage in the core API.
@@ -9172,7 +9172,7 @@ The {{GPUTextureUsage/STORAGE|GPUTextureUsage.RENDER_ATTACHMENT}} column specifi
             <th>Format
             <th>{{GPUTextureSampleType}}
             <th>{{GPUTextureUsage/RENDER_ATTACHMENT}}
-            <th>{{GPUTextureUsage/STORAGE}}
+            <th>{{GPUTextureUsage/STORAGE}} allowed {{GPUStorageTextureAccess}}
     </thead>
     <tr><th class=stickyheader>8-bit per component<th><th><th>
     <tr>
@@ -9219,7 +9219,7 @@ The {{GPUTextureUsage/STORAGE|GPUTextureUsage.RENDER_ATTACHMENT}} column specifi
         <td>{{GPUTextureFormat/rgba8unorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
-        <td>&checkmark;
+        <td>{{GPUStorageTextureAccess/"write-only"}},<br/>{{GPUStorageTextureAccess/"read-only"}}
     <tr>
         <td>{{GPUTextureFormat/rgba8unorm-srgb}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -9229,17 +9229,17 @@ The {{GPUTextureUsage/STORAGE|GPUTextureUsage.RENDER_ATTACHMENT}} column specifi
         <td>{{GPUTextureFormat/rgba8snorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>
-        <td>&checkmark;
+        <td>{{GPUStorageTextureAccess/"write-only"}}
     <tr>
         <td>{{GPUTextureFormat/rgba8uint}}
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
-        <td>&checkmark;
+        <td>{{GPUStorageTextureAccess/"write-only"}},<br/>{{GPUStorageTextureAccess/"read-only"}}
     <tr>
         <td>{{GPUTextureFormat/rgba8sint}}
         <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
-        <td>&checkmark;
+        <td>{{GPUStorageTextureAccess/"write-only"}},<br/>{{GPUStorageTextureAccess/"read-only"}}
     <tr>
         <td>{{GPUTextureFormat/bgra8unorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -9285,63 +9285,63 @@ The {{GPUTextureUsage/STORAGE|GPUTextureUsage.RENDER_ATTACHMENT}} column specifi
         <td>{{GPUTextureFormat/rgba16uint}}
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
-        <td>&checkmark;
+        <td>{{GPUStorageTextureAccess/"write-only"}},<br/>{{GPUStorageTextureAccess/"read-only"}}
     <tr>
         <td>{{GPUTextureFormat/rgba16sint}}
         <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
-        <td>&checkmark;
+        <td>{{GPUStorageTextureAccess/"write-only"}},<br/>{{GPUStorageTextureAccess/"read-only"}}
     <tr>
         <td>{{GPUTextureFormat/rgba16float}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
-        <td>&checkmark;
+        <td>{{GPUStorageTextureAccess/"write-only"}},<br/>{{GPUStorageTextureAccess/"read-only"}}
     <tr><th class=stickyheader>32-bit per component<th><th><th>
     <tr>
         <td>{{GPUTextureFormat/r32uint}}
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
-        <td>&checkmark;
+        <td>{{GPUStorageTextureAccess/"write-only"}},<br/>{{GPUStorageTextureAccess/"read-only"}}
     <tr>
         <td>{{GPUTextureFormat/r32sint}}
         <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
-        <td>&checkmark;
+        <td>{{GPUStorageTextureAccess/"write-only"}},<br/>{{GPUStorageTextureAccess/"read-only"}}
     <tr>
         <td>{{GPUTextureFormat/r32float}}
         <td>{{GPUTextureSampleType/"unfilterable-float"}}<!-- Metal -->
         <td>&checkmark;
-        <td>&checkmark;
+        <td>{{GPUStorageTextureAccess/"write-only"}},<br/>{{GPUStorageTextureAccess/"read-only"}}
     <tr>
         <td>{{GPUTextureFormat/rg32uint}}
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
-        <td>&checkmark;
+        <td>{{GPUStorageTextureAccess/"write-only"}}
     <tr>
         <td>{{GPUTextureFormat/rg32sint}}
         <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
-        <td>&checkmark;
+        <td>{{GPUStorageTextureAccess/"write-only"}}
     <tr>
         <td>{{GPUTextureFormat/rg32float}}
         <td>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
-        <td>&checkmark;
+        <td>{{GPUStorageTextureAccess/"write-only"}}
     <tr>
         <td>{{GPUTextureFormat/rgba32uint}}
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
-        <td>&checkmark;
+        <td>{{GPUStorageTextureAccess/"write-only"}},<br/>{{GPUStorageTextureAccess/"read-only"}}
     <tr>
         <td>{{GPUTextureFormat/rgba32sint}}
         <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
-        <td>&checkmark;
+        <td>{{GPUStorageTextureAccess/"write-only"}},<br/>{{GPUStorageTextureAccess/"read-only"}}
     <tr>
         <td>{{GPUTextureFormat/rgba32float}}
         <td>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
-        <td>&checkmark;
+        <td>{{GPUStorageTextureAccess/"write-only"}},<br/>{{GPUStorageTextureAccess/"read-only"}}
     <tr><th class=stickyheader>mixed component width<th><th><th>
     <tr>
         <td>{{GPUTextureFormat/rgb10a2unorm}}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -767,19 +767,23 @@ A [=physical resource=] can be used on GPU with an <dfn dfn>internal usage</dfn>
         Allowed by buffer {{GPUBufferUsage/INDEX}}, buffer {{GPUBufferUsage/VERTEX}}, or buffer {{GPUBufferUsage/INDIRECT}}.
     : <dfn>constant</dfn>
     ::  Resource bindings that are constant from the shader point of view. Preserves the contents.
-        Allowed by buffer {{GPUBufferUsage/UNIFORM}} or texture {{GPUTextureUsage/SAMPLED}}.
-    : <dfn>storage</dfn>
+        Allowed by buffer {{GPUBufferUsage/UNIFORM}}, {{GPUBufferUsage/STORAGE}}, or texture {{GPUTextureUsage/SAMPLED}}.
+    : <dfn>buffer-storage-rw</dfn>
     ::  Read-write storage resource binding.
         Allowed by buffer {{GPUBufferUsage/STORAGE}}.
-    : <dfn>storage-read</dfn>
-    ::  Read-only storage resource bindings. Preserves the contents.
-        Allowed by buffer {{GPUBufferUsage/STORAGE}} or texture {{GPUTextureUsage/STORAGE}}.
-    : <dfn>storage-write</dfn>
-    ::  Write-only storage resource bindings.
+        Only compatible with itself.
+    : <dfn>texture-storage-read</dfn>
+    ::  Read-only texture storage bindings. Preserves the contents.
         Allowed by texture {{GPUTextureUsage/STORAGE}}.
+        Only compatible with itself.
+    : <dfn>texture-storage-write</dfn>
+    ::  Write-only texture storage resource bindings.
+        Allowed by texture {{GPUTextureUsage/STORAGE}}.
+        Only compatible with itself.
     : <dfn>attachment</dfn>
     :: Texture used as an output attachment in a render pass.
         Allowed by texture {{GPUTextureUsage/RENDER_ATTACHMENT}}.
+        Incompatible with any other usage. If present in a usage scope, has to be unique.
     : <dfn>attachment-read</dfn>
     ::  Texture used as a read-only attachment in a render pass. Preserves the contents.
         Allowed by texture {{GPUTextureUsage/RENDER_ATTACHMENT}}.
@@ -798,11 +802,16 @@ We define <dfn dfn>subresource</dfn> to be either a whole buffer, or a [=texture
 Some [=internal usages=] are compatible with others. A [=subresource=] can be in a state
 that combines multiple usages together. We consider a list |U| to be
 a <dfn dfn>compatible usage list</dfn> if (and only if) it satisfies any of the following rules:
-    - Each usage in |U| is [=internal usage/input=], [=internal usage/constant=], [=internal usage/storage-read=], or [=internal usage/attachment-read=].
-    - Each usage in |U| is [=internal usage/storage=].
-    - Each usage in |U| is [=internal usage/storage-write=].
+    - Each usage in |U| is [=internal usage/input=], [=internal usage/constant=], or [=internal usage/attachment-read=].
+    - Each usage in |U| is [=internal usage/buffer-storage-rw=].
+    - Each usage in |U| is [=internal usage/texture-storage-read=].
+    - Each usage in |U| is [=internal usage/texture-storage-write=].
     - |U| contains exactly one element: [=internal usage/attachment=].
 </div>
+
+Note: on D3D12, [=internal usage/texture-storage-read=] corresponds to an
+unoredered access view (UAV). It can not be mixed with shader resource views (SRV)
+of the same subresource.
 
 Enforcing that the usages are only combined into a [=compatible usage list=]
 allows the API to limit when data races can occur in working with memory.
@@ -818,8 +827,8 @@ We define these places as <dfn dfn>usage scopes</dfn>.
 The **main usage rule** is, for any one [=subresource=], its list of [=internal usages=]
 within one [=usage scope=] must be a [=compatible usage list=].
 
-For example, binding the same buffer for [=internal usage/storage=] as well as for
-[=internal usage/input=] within the same {{GPURenderPassEncoder}} would put the encoder
+For example, binding the same buffer for [=internal usage/buffer-storage-rw=]
+ as well as for [=internal usage/input=] within the same {{GPURenderPassEncoder}} would put the encoder
 as well as the owning {{GPUCommandEncoder}} into the error state.
 This combination of usages does not make a [=compatible usage list=].
 
@@ -3243,10 +3252,10 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
         <td>[=internal usage/constant=]
     <tr>
         <td>{{GPUBufferBindingType/"storage"}}
-        <td>[=internal usage/storage=]
+        <td>[=internal usage/buffer-storage-rw=]
     <tr>
         <td>{{GPUBufferBindingType/"read-only-storage"}}
-        <td>[=internal usage/storage-read=]
+        <td>[=internal usage/constant=]
 
     <tr>
         <td rowspan=3>{{GPUBindGroupLayoutEntry/sampler}}
@@ -3276,10 +3285,10 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
         <td rowspan=2>{{GPUBindGroupLayoutEntry/storageTexture}}
         <td rowspan=2>{{GPUTextureView}}
         <td>{{GPUStorageTextureAccess/"read-only"}}
-        <td>[=internal usage/storage-read=]
+        <td>[=internal usage/texture-storage-read=]
     <tr>
         <td>{{GPUStorageTextureAccess/"write-only"}}
-        <td>[=internal usage/storage-write=]
+        <td>[=internal usage/texture-storage-write=]
 
     <tr>
         <td>{{GPUBindGroupLayoutEntry/externalTexture}}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9219,7 +9219,7 @@ The {{GPUTextureUsage/STORAGE|GPUTextureUsage.RENDER_ATTACHMENT}} column specifi
         <td>{{GPUTextureFormat/rgba8unorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
-        <td>{{GPUStorageTextureAccess/"write-only"}},<br/>{{GPUStorageTextureAccess/"read-only"}}
+        <td>{{GPUStorageTextureAccess/"write-only"}}
     <tr>
         <td>{{GPUTextureFormat/rgba8unorm-srgb}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -9234,12 +9234,12 @@ The {{GPUTextureUsage/STORAGE|GPUTextureUsage.RENDER_ATTACHMENT}} column specifi
         <td>{{GPUTextureFormat/rgba8uint}}
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
-        <td>{{GPUStorageTextureAccess/"write-only"}},<br/>{{GPUStorageTextureAccess/"read-only"}}
+        <td>{{GPUStorageTextureAccess/"write-only"}}
     <tr>
         <td>{{GPUTextureFormat/rgba8sint}}
         <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
-        <td>{{GPUStorageTextureAccess/"write-only"}},<br/>{{GPUStorageTextureAccess/"read-only"}}
+        <td>{{GPUStorageTextureAccess/"write-only"}}
     <tr>
         <td>{{GPUTextureFormat/bgra8unorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -9285,17 +9285,17 @@ The {{GPUTextureUsage/STORAGE|GPUTextureUsage.RENDER_ATTACHMENT}} column specifi
         <td>{{GPUTextureFormat/rgba16uint}}
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
-        <td>{{GPUStorageTextureAccess/"write-only"}},<br/>{{GPUStorageTextureAccess/"read-only"}}
+        <td>{{GPUStorageTextureAccess/"write-only"}}
     <tr>
         <td>{{GPUTextureFormat/rgba16sint}}
         <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
-        <td>{{GPUStorageTextureAccess/"write-only"}},<br/>{{GPUStorageTextureAccess/"read-only"}}
+        <td>{{GPUStorageTextureAccess/"write-only"}}
     <tr>
         <td>{{GPUTextureFormat/rgba16float}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
-        <td>{{GPUStorageTextureAccess/"write-only"}},<br/>{{GPUStorageTextureAccess/"read-only"}}
+        <td>{{GPUStorageTextureAccess/"write-only"}}
     <tr><th class=stickyheader>32-bit per component<th><th><th>
     <tr>
         <td>{{GPUTextureFormat/r32uint}}
@@ -9331,17 +9331,17 @@ The {{GPUTextureUsage/STORAGE|GPUTextureUsage.RENDER_ATTACHMENT}} column specifi
         <td>{{GPUTextureFormat/rgba32uint}}
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
-        <td>{{GPUStorageTextureAccess/"write-only"}},<br/>{{GPUStorageTextureAccess/"read-only"}}
+        <td>{{GPUStorageTextureAccess/"write-only"}}
     <tr>
         <td>{{GPUTextureFormat/rgba32sint}}
         <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
-        <td>{{GPUStorageTextureAccess/"write-only"}},<br/>{{GPUStorageTextureAccess/"read-only"}}
+        <td>{{GPUStorageTextureAccess/"write-only"}}
     <tr>
         <td>{{GPUTextureFormat/rgba32float}}
         <td>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
-        <td>{{GPUStorageTextureAccess/"write-only"}},<br/>{{GPUStorageTextureAccess/"read-only"}}
+        <td>{{GPUStorageTextureAccess/"write-only"}}
     <tr><th class=stickyheader>mixed component width<th><th><th>
     <tr>
         <td>{{GPUTextureFormat/rgb10a2unorm}}


### PR DESCRIPTION
Alternative to #1794 

It completely changes the semantics of RO texture bindings, so that:
  - their usage scoping is restricted, it's not compatible with `SAMPLED`
  - it's available only on a subset of texture formats

The idea here, which @Kangz has been trying to convey, is that RO usage is still going to be potentially useful, even with those extra restrictions. It takes a different code path from `SAMPLED` in the driver, changes the caching policy of obtained samples, and it can't be replaced by "read-write" because we don't have it today.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/1864.html" title="Last updated on Jun 21, 2021, 8:14 PM UTC (42a6ec0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1864/528f011...kvark:42a6ec0.html" title="Last updated on Jun 21, 2021, 8:14 PM UTC (42a6ec0)">Diff</a>