### PR TITLE
Add OOB checks to draw and drawIndexed

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6984,7 +6984,7 @@ enum GPUStoreOp {
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. If |size| is `0` set |size| to |buffer|.{{GPUBuffer/[[size]]}} - |offset| is used.
+                1. If |size| is `0`, set |size| to |buffer|.{{GPUBuffer/[[size]]}} - |offset| is used.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |buffer| is [$valid to use with$] |this|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6634,9 +6634,19 @@ GPURenderPassEncoder includes GPURenderEncoderBase;
     ::
         The format of the index data in {{GPURenderEncoderBase/[[index_buffer]]}}.
 
+    : <dfn>\[[index_buffer_size]]</dfn>, of type {{GPUSize64}}
+    ::
+        The size in bytes of the section of {{GPURenderEncoderBase/[[index_buffer]]}} currently set,
+        initially `0`.
+
     : <dfn>\[[vertex_buffers]]</dfn>, of type [=ordered map=]&lt;slot, {{GPUBuffer}}&gt;
     ::
         The current {{GPUBuffer}}s to read vertex data from for each slot, initially empty.
+
+    : <dfn>\[[vertex_buffer_sizes]]</dfn>, of type [=ordered map=]&lt;slot, {{GPUSize64}}&gt;
+    ::
+        The size in bytes of the section of {{GPUBuffer}} currently set for each slot, initially
+        empty.
 </dl>
 
 {{GPURenderPassEncoder}} has the following internal slots:
@@ -6984,6 +6994,7 @@ enum GPUStoreOp {
                 1. Add |buffer| to the [=usage scope=] as [=internal usage/input=].
                 1. Set |this|.{{GPURenderEncoderBase/[[index_buffer]]}} to be |buffer|.
                 1. Set |this|.{{GPURenderEncoderBase/[[index_format]]}} to be |indexFormat|.
+                1. Set |this|.{{GPURenderEncoderBase/[[index_buffer_size]]}} to be |size|.
             </div>
         </div>
 
@@ -7017,6 +7028,7 @@ enum GPUStoreOp {
                     </div>
                 1. Add |buffer| to the [=usage scope=] as [=internal usage/input=].
                 1. Set |this|.{{GPURenderEncoderBase/[[vertex_buffers]]}}[|slot|] to be |buffer|.
+                1. Set |this|.{{GPURenderEncoderBase/[[vertex_buffer_sizes]]}}[|slot|] to be |size|.
             </div>
         </div>
 
@@ -7030,10 +7042,10 @@ enum GPUStoreOp {
 
             **Arguments:**
             <pre class=argumentdef for="GPURenderEncoderBase/draw(vertexCount, instanceCount, firstVertex, firstInstance)">
-                vertexCount: The number of vertices to draw.
-                instanceCount: The number of instances to draw.
-                firstVertex: Offset into the vertex buffers, in vertices, to begin drawing from.
-                firstInstance: First instance to draw.
+                |vertexCount|: The number of vertices to draw.
+                |instanceCount|: The number of instances to draw.
+                |firstVertex|: Offset into the vertex buffers, in vertices, to begin drawing from.
+                |firstInstance|: First instance to draw.
             </pre>
 
             **Returns:** {{undefined}}
@@ -7043,6 +7055,17 @@ enum GPUStoreOp {
                 If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                 <div class=validusage>
                     - It is [$valid to draw$] with |this|.
+                    - Let |buffers| be |this|.{{GPURenderEncoderBase/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}.
+                    - For each {{GPUIndex32}} |slot| `0` to |buffers|.length:
+                        - Let |bufferSize| be |this|.{{GPURenderEncoderBase/[[vertex_buffer_sizes]]}}[|slot|].
+                        - Let |stride| be |buffers|[|slot|].{{GPUVertexBufferLayout/arrayStride}}.
+                        - If |buffers|[|slot|].{{GPUVertexBufferLayout/stepMode}}:
+                            <dl class="switch">
+                                : {{GPUInputStepMode/"vertex"}}
+                                :: |firstVertex| + |vertexCount| &le; |bufferSize| &div; |stride|.
+                                : {{GPUInputStepMode/"instance"}}
+                                :: |firstInstance| + |instanceCount| &le; |bufferSize| &div; |stride|.
+                            </dl>
                 </div>
             </div>
         </div>
@@ -7057,11 +7080,11 @@ enum GPUStoreOp {
 
             **Arguments:**
             <pre class=argumentdef for="GPURenderEncoderBase/drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance)">
-                indexCount: The number of indices to draw.
-                instanceCount: The number of instances to draw.
-                firstIndex: Offset into the index buffer, in indices, begin drawing from.
+                |indexCount|: The number of indices to draw.
+                |instanceCount|: The number of instances to draw.
+                |firstIndex|: Offset into the index buffer, in indices, begin drawing from.
                 baseVertex: Added to each index value before indexing into the vertex buffers.
-                firstInstance: First instance to draw.
+                |firstInstance|: First instance to draw.
             </pre>
 
             **Returns:** {{undefined}}
@@ -7071,6 +7094,14 @@ enum GPUStoreOp {
                 If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                 <div class=validusage>
                     - It is [$valid to draw indexed$] with |this|.
+                    - |firstIndex| + |indexCount| &le; |this|.{{GPURenderEncoderBase/[[index_format]]}}
+                        &div; |this|.{{GPURenderEncoderBase/[[index_format]]}}'s byte size;
+                    - Let |buffers| be |this|.{{GPURenderEncoderBase/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}.
+                    - For each {{GPUIndex32}} |slot| `0` to |buffers|.length:
+                        - If |buffers|[|slot|].{{GPUVertexBufferLayout/stepMode}} is {{GPUInputStepMode/"instance"}}:
+                            - Let |bufferSize| be |this|.{{GPURenderEncoderBase/[[vertex_buffer_sizes]]}}[|slot|].
+                            - Let |stride| be |buffers|[|slot|].{{GPUVertexBufferLayout/arrayStride}}.
+                            - |firstInstance| + |instanceCount| &le; |bufferSize| &div; |stride|.
                 </div>
             </div>
         </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7094,7 +7094,7 @@ enum GPUStoreOp {
                 If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                 <div class=validusage>
                     - It is [$valid to draw indexed$] with |this|.
-                    - |firstIndex| + |indexCount| &le; |this|.{{GPURenderEncoderBase/[[index_format]]}}
+                    - |firstIndex| + |indexCount| &le; |this|.{{GPURenderEncoderBase/[[index_buffer_size]]}}
                         &div; |this|.{{GPURenderEncoderBase/[[index_format]]}}'s byte size;
                     - Let |buffers| be |this|.{{GPURenderEncoderBase/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}.
                     - For each {{GPUIndex32}} |slot| `0` to |buffers|.length:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7062,9 +7062,9 @@ enum GPUStoreOp {
                         - If |buffers|[|slot|].{{GPUVertexBufferLayout/stepMode}}:
                             <dl class="switch">
                                 : {{GPUInputStepMode/"vertex"}}
-                                :: |firstVertex| + |vertexCount| &le; |bufferSize| &div; |stride|.
+                                :: (|firstVertex| + |vertexCount|) * |stride| &le; |bufferSize|.
                                 : {{GPUInputStepMode/"instance"}}
-                                :: |firstInstance| + |instanceCount| &le; |bufferSize| &div; |stride|.
+                                :: (|firstInstance| + |instanceCount|) * |stride| &le; |bufferSize|.
                             </dl>
                 </div>
             </div>
@@ -7101,7 +7101,7 @@ enum GPUStoreOp {
                         - If |buffers|[|slot|].{{GPUVertexBufferLayout/stepMode}} is {{GPUInputStepMode/"instance"}}:
                             - Let |bufferSize| be |this|.{{GPURenderEncoderBase/[[vertex_buffer_sizes]]}}[|slot|].
                             - Let |stride| be |buffers|[|slot|].{{GPUVertexBufferLayout/arrayStride}}.
-                            - |firstInstance| + |instanceCount| &le; |bufferSize| &div; |stride|.
+                            - (|firstInstance| + |instanceCount|) * |stride| &le; |bufferSize|.
                 </div>
             </div>
         </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6975,15 +6975,16 @@ enum GPUStoreOp {
             <pre class=argumentdef for="GPURenderEncoderBase/setIndexBuffer(buffer, indexFormat, offset, size)">
                 |buffer|: Buffer containing index data to use for subsequent drawing commands.
                 |indexFormat|: Format of the index data contained in |buffer|.
-                |offset|: Offset in bytes into |buffer| where the index data begins.
+                |offset|: Offset in bytes into |buffer| where the index data begins. Defaults to `0`.
                 |size|: Size in bytes of the index data in |buffer|.
-                    If `0`, |buffer|.{{GPUBuffer/[[size]]}} - |offset| is used.
+                    If `0`, defaults to the size of the buffer minus the offset.
             </pre>
 
             **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
+                1. If |size| is `0` set |size| to |buffer|.{{GPUBuffer/[[size]]}} - |offset| is used.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |buffer| is [$valid to use with$] |this|.
@@ -7009,15 +7010,16 @@ enum GPUStoreOp {
             <pre class=argumentdef for="GPURenderEncoderBase/setVertexBuffer(slot, buffer, offset, size)">
                 |slot|: The vertex buffer slot to set the vertex buffer for.
                 |buffer|: Buffer containing vertex data to use for subsequent drawing commands.
-                |offset|: Offset in bytes into |buffer| where the vertex data begins.
+                |offset|: Offset in bytes into |buffer| where the vertex data begins. Defaults to `0`.
                 |size|: Size in bytes of the vertex data in |buffer|.
-                    If `0`, |buffer|.{{GPUBuffer/[[size]]}} - |offset| is used.
+                    If `0`, defaults to the size of the buffer minus the offset.
             </pre>
 
             **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
+                1. If |size| is `0` set |size| to |buffer|.{{GPUBuffer/[[size]]}} - |offset| is used.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |buffer| is [$valid to use with$] |this|.
@@ -7059,7 +7061,7 @@ enum GPUStoreOp {
                     - For each {{GPUIndex32}} |slot| `0` to |buffers|.length:
                         - Let |bufferSize| be |this|.{{GPURenderEncoderBase/[[vertex_buffer_sizes]]}}[|slot|].
                         - Let |stride| be |buffers|[|slot|].{{GPUVertexBufferLayout/arrayStride}}.
-                        - If |buffers|[|slot|].{{GPUVertexBufferLayout/stepMode}}:
+                        - If |buffers|[|slot|].{{GPUVertexBufferLayout/stepMode}} is:
                             <dl class="switch">
                                 : {{GPUInputStepMode/"vertex"}}
                                 :: (|firstVertex| + |vertexCount|) * |stride| &le; |bufferSize|.


### PR DESCRIPTION
Fixes #1834

Adds validation steps to `draw()` and `drawIndexed()` to check that any CPU-verifiable buffer range checks are performed. Trivial bounds checks were already in place for the indirect draw calls, so no change needs to be made there.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/1866.html" title="Last updated on Jun 22, 2021, 7:45 PM UTC (8f5747a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1866/528f011...8f5747a.html" title="Last updated on Jun 22, 2021, 7:45 PM UTC (8f5747a)">Diff</a>