### PR TITLE
fix << operator: first operand can be unsigned

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4308,7 +4308,7 @@ references to arrays. An array not behind a reference may only be indexed by a
   <tr algorithm="shift left">
     <td>|e1|: |T|<br>
     |e2|: |TS|<br>
-    |T| is [SIGNEDINTEGRAL]<br>
+    |T| is [INTEGRAL]<br>
     |TS| is u32 if |e1| is a scalar, or<br>
     vec|N|&lt;u32&gt;.
     <td class="nowrap">|e1| `<<` |e2|: |T|


### PR DESCRIPTION
Fixes a bug introduced by #1730