### PR TITLE
wgsl: cleanup old text, discuss conversions/constructions

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -173,6 +173,12 @@ determined only by examining the program source.
 of these in the form of arrays and structures.
 Additional types describe memory.
 
+[SHORTNAME] does not have implicit conversions or promotions between numeric types.
+Converting a value from one numeric type to another requires
+an explicit [[#conversion-expr|conversion]],
+[[#type-constructor-expr|construction]], or [[#bitcast-expr|reinterpretation of bits]].
+This also applies to vector types.
+
 [SHORTNAME] has texture and sampler types.
 Together with their associated built-in functions, these support functionality
 commonly used for graphics rendering, and commonly provided by GPUs.
@@ -3142,7 +3148,17 @@ use the same storage.
           Use parentheses to isolate an expression from the surrounding text.
 </table>
 
-## Type Constructor Expressions TODO ## {#type-constructor-expr}
+## Type Constructor Expressions ## {#type-constructor-expr}
+
+Type constructor expressions explicitly create a value of a given type.
+
+The scalar forms are redundant, but provide symmetry with scalar [[#conversion-expr|conversion expressions]],
+and can be used to enhance readability.
+
+The vector forms construct vector values from various combinations of components and subvectors
+with matching component types.
+
+See also [[#zero-value-expr]] and [[#conversion-expr]].
 
 <table class='data'>
   <caption>Scalar constructor type rules</caption>
@@ -3429,6 +3445,11 @@ Note: WGSL does not have zero expression for [=atomic types=],
 
 
 ## Conversion Expressions ## {#conversion-expr}
+
+[SHORTNAME] does not implicitly convert or promote a numeric or boolean value to another type.
+Instead use conversion expressions as defined in the tables below.
+
+See also [[#type-constructor-expr]].
 
 <table class='data'>
   <caption>Scalar conversion type rules</caption>
@@ -7941,51 +7962,10 @@ TODO: Add links to the eventual memory model.
         Type |T| is any non-reference type.
 </table>
 
-# Glossary # {#glossary}
-
-TODO: Remove terms unused in the rest of the specification.
-
-<table class='data'>
-  <thead>
-    <tr><th>Term<th>Definition
-  </thead>
-  <tr><td>Dominates
-      <td>Basic block `A` *dominates* basic block `B` if:
-          * `A` and `B` are both in the same function `F`
-          * Every control flow path in `F` that goes to `B` must also to through `A`
-  <tr><td>Strictly dominates
-      <td>`A` *strictly dominates* `B` if `A` dominates `B` and `A != B`
-  <tr><td>DomBy(A)
-      <td>The basic blocks dominated by `A`
-</table>
 
 # MATERIAL TO BE MOVED TO A NEW HOME OR DELETED # {#junkyard}
 
 
 [SHORTNAME] has operations for:
 
-* extracting one of the components of a composite value
 * creating a new composite value from an old one by replacing one of its components
-* creating a new composite value from components
-
-## Type Promotions ## {#type-promotions}
-There are no implicit type promotions in [SHORTNAME]. If you want to convert between
-types you must use the cast syntax to do it.
-
-<div class='example wgsl function-scope'>
-  <xmp highlight='rust'>
-    var e: f32 = 3;    // error: literal is the wrong type
-
-    var f: f32 = 1.0;
-
-    var t: i32 = i32(f);
-  </xmp>
-</div>
-
-The non-promotion extends to vector classes as well. There are no overrides to
-shorten vector declarations based on the type or number of elements provided.
-If you want `vec4<f32>` you must provide 4 float values in the constructor.
-
-## Precedence ## {#precedence}
-
-Issue: (dsinclair) Write out precedence rules. Matches c and glsl rules ....

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -173,8 +173,8 @@ determined only by examining the program source.
 of these in the form of arrays and structures.
 Additional types describe memory.
 
-[SHORTNAME] does not have implicit conversions or promotions between numeric types.
-Converting a value from one numeric type to another requires
+[SHORTNAME] does not have implicit conversions or promotions between numeric or boolean types.
+Converting a value from one numeric or boolean type to another requires
 an explicit [[#conversion-expr|conversion]],
 [[#type-constructor-expr|construction]], or [[#bitcast-expr|reinterpretation of bits]].
 This also applies to vector types.


### PR DESCRIPTION

    - Remove the Glossary
    - Remove the old text about "no implicit promotion or conversion"
      - Add short prose to the overview, pointing at relevant sections
      - Add introductory prose in type-constructor section and conversions section.

