### PR TITLE
wgsl: define 'constructible' types, and apply it

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -941,8 +941,9 @@ An <dfn noexport>array</dfn> is an indexable grouping of element values.
   <thead>
     <tr><th>Type<th>Description
   </thead>
-  <tr><td algorithm="sized array type">array&lt;|E|,|N|&gt;<td>An |N|-element array of elements of type |E|.<br>
-                    |N| must be 1 or larger.
+  <tr><td algorithm="sized array type">array&lt;|E|,|N|&gt;
+      <td>A <dfn>sized array</dfn> with |N| elements of type |E|.<br>
+                |N| must be 1 or larger.
   <tr><td algorithm="runtime-sized array type">array&lt;|E|&gt;<td>A <dfn noexport>runtime-sized</dfn> array of elements of type |E|.
                        These may only appear in specific contexts.<br>
 </table>
@@ -972,8 +973,6 @@ Restrictions on runtime-sized arrays:
 * A runtime-sized array must not be used as the store type or contained within
     a store type in any other cases.
 * An expression must not evaluate to a runtime-sized array type.
-
-Issue: (dneto): Complete description of `Array<E,N>`
 
 ### Structure Types ### {#struct-types}
 
@@ -1103,14 +1102,24 @@ The composite types are:
 * [=array=] type
 * [=structure=] type
 
-### Atomic-Free Types ### {#atomic-free-types}
+### Constructible Types ### {#constructible-types}
 
-A [=plain type=] is <dfn>atomic-free</dfn> if it is one of:
+Many kinds of values can be created, loaded, stored, passed into functions,
+and returned from functions.
+We call these [=constructible=].
+
+A type is <dfn>constructible</dfn> if it is one of:
+
 * a [=scalar=] type
 * a [=vector=] type
 * a [=matrix=] type
-* an [=array=] type, if its element type is atomic-free
-* a [=structure=] type, if all its members are atomic-free.
+* a [=sized array=] type, if its element type is constructible.
+* a [=structure=] type, if all its members are constructible.
+
+Note: All constructible types are [=plain types|plain=].
+
+Note: Atomic types and runtime-sized array types are not constructible.
+Composite types containing atomics and runtime-sized arrays are not constructible.
 
 ## Memory ## {#memory}
 
@@ -1254,25 +1263,27 @@ and how to use variables with it.
       <td>Same invocation only
       <td>[=read_write=]
       <td>[=Function scope=]
-      <td>[=Atomic-free=] [=plain type=]
+      <td>[=Constructible=] type
       <td>
   <tr><td><dfn noexport dfn-for="storage classes">private</dfn>
       <td>Same invocation only
       <td>[=read_write=]
       <td>[=Module scope=]
-      <td>[=Atomic-free=] [=plain type=]
+      <td>[=Constructible=] type
+      <td>
       <td>
   <tr><td><dfn noexport dfn-for="storage classes">workgroup</dfn>
       <td>Invocations in the same [=compute shader stage|compute shader=] [=compute shader stage/workgroup=]
       <td>[=read_write=]
       <td>[=Module scope=]
-      <td>[=Plain type=]
+      <td>[=Plain type=],
+          excluding [=runtime-sized=] arrays, or [=composite=] types containing runtime-sized arrays
       <td>
   <tr><td><dfn noexport dfn-for="storage classes">uniform</dfn>
       <td>Invocations in the same [=shader stage=]
       <td>[=read=]
       <td>[=Module scope=]
-      <td>[=Atomic-free=] [=host-shareable=] types
+      <td>[=Constructible=] [=host-shareable=] types
       <td>For [=uniform buffer=] variables
   <tr><td><dfn noexport dfn-for="storage classes">storage</dfn>
       <td>Invocations in the same [=shader stage=]
@@ -1845,7 +1856,7 @@ memory reference</dfn> is produced.
 [=Load Rule|Loads=] from an invalid reference return one of:
     * a value from any [=memory locations|memory location(s)=] of the [[WebGPU#buffers|WebGPU buffer]]
         bound to the [=originating variable=]
-    * the zero value for store type of the reference
+    * the [=zero value=] for store type of the reference
     * if the loaded value is a vector, the value (0, 0, 0, x), where x is:
         * 0, 1, or the maximum positive value for integer components
         * 0.0 or 1.0 for floating-point components
@@ -2849,7 +2860,7 @@ When a variable's lifetime ends, its storage may be used for another variable.
 When a variable is created, its storage contains an initial value as follows:
 
 * For variables in the [=storage classes/private=] or [=storage classes/function=] storage classes:
-    * The zero value for the store type, if the variable declaration has no initializer.
+    * The [=zero value=] for the store type, if the variable declaration has no initializer.
     * Otherwise, it is the result of evaluating the initializer expression at that point in the program execution.
 * For variables in other storage classes, the execution environment provides the initial value.
 
@@ -2967,7 +2978,7 @@ A `let`-declaration appearing outside all functions declares a
 The name is available for use after the end of the declaration,
 until the end of the [SHORTNAME] program.
 
-A module-scope let-declared constant must be of [=atomic-free=] [=plain type=].
+A module-scope let-declared constant must be of [=constructible=] type.
 
 When the declaration has no attributes, an initializer expression must be present,
 and the name denotes the value of that expression.
@@ -3068,12 +3079,12 @@ A variable or constant declared in a declaration statement in a function body is
 The name is available for use immediately after its declaration statement,
 and until the end of the brace-delimited list of statements immediately enclosing the declaration.
 
-A function-scope let-declared constant must be of [=atomic-free=] [=plain type=], or of [=pointer type=].
+A function-scope let-declared constant must be of [=constructible=] type, or of [=pointer type=].
 
 For a variable declared in function scope:
 * The variable is always in the [=storage classes/function=] storage class.
 * The storage decoration is optional.
-* The [=store type=] must be an [=atomic-free=] [=plain type=].
+* The [=store type=] must be a [=constructible=] type.
 * When an initializer is specified, the store type may be omitted from the declaration.
     In this case the store type is the type of the result of evaluating the initializer.
 
@@ -3252,39 +3263,34 @@ use the same storage.
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
-  <tr>
-    <td>*e1*: *T*<br>
+  <tr algorithm="array value construction">
+    <td>|e1|: |T|<br>
         ...<br>
-        *eN*: *T*<br>
-    <td>`array<`*T*,*N*`>(e1,...,eN)`: array<*T*, *N*>
-    <td>Construction of an array from elements
+        |eN|: |T|,<br>
+        |T| is a [=constructible=] type.
+    <td>`array<`|T|,|N|`>(`|e1|,...,|eN|`)` : array&lt;|T|,|N|&gt;
+    <td>Construction of an array from elements.
 </table>
-TODO: Should this only work for storable sized arrays?  https://github.com/gpuweb/gpuweb/issues/982
 
 <table class='data'>
   <caption>Structure constructor type rules</caption>
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
-  <tr>
-    <td>*e1*: *T1*<br>
+  <tr algorithm="structure value construction">
+    <td>|e1|: |T1|<br>
         ...<br>
-        *eN*: *TN*<br>
-        *T1* is storable<br>
-        ...<br>
-        *TN* is storable<br>
-        S is a structure type with members having types *T1* ... *TN*.<br>
-        The expression is in the scope of declaration of S.
-    <td>`S(e1,...,eN)`: S
-    <td>Construction of a structure from members
+        |eN|: |TN|,<br>
+        |S| is a [=constructible=] structure type with members having types |T1| ... |TN|.<br>
+        The expression is in the scope of declaration of |S|.
+    <td>|S|`(`|e1|,...,|eN|`)`: |S|
+    <td>Construction of a structure from members.
 </table>
-
 
 ## Zero Value Expressions ## {#zero-value-expr}
 
-Each storable type *T* has a unique *zero value*, written in WGSL as the type followed by an empty pair of parentheses: *T* `()`.
-
-Issue: We should exclude being able to write the zero value for an [=runtime-sized=] array. https://github.com/gpuweb/gpuweb/issues/981
+Each [=constructible=] *T* has a unique <dfn noexport>zero value</dfn>
+written in WGSL as the type followed by an empty pair of parentheses: *T* `()`.
 
 The zero values are as follows:
 
@@ -3294,8 +3300,11 @@ The zero values are as follows:
 * `f32()` is 0.0
 * The zero value for an *N*-element vector of type *T* is the *N*-element vector of the zero value for *T*.
 * The zero value for an *N*-column *M*-row matrix of `f32` is the matrix of those dimensions filled with 0.0 entries.
-* The zero value for an *N*-element array with storable element type *E* is an array of *N* elements of the zero value for *E*.
-* The zero value for a storable structure type *S* is the structure value *S* with zero-valued members.
+* The zero value for an *N*-element array with [=constructible=] element type *E* is an array of *N* elements of the zero value for *E*.
+* The zero value for a [=constructible=] structure type *S* is the structure value *S* with zero-valued members.
+
+Note: WGSL does not have zero expression for [=atomic types=],
+[=runtime-sized=] arrays, or other types that are not [=constructible=].
 
 <table class='data'>
   <caption>Scalar zero value type rules</caption>
@@ -3368,9 +3377,9 @@ The zero values are as follows:
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
-  <tr>
-    <td>*T* is storable
-    <td>`array<`*T*,*N*`>()`: array<*T*, *N*>
+  <tr algorithm="array zero value">
+    <td>|T| is a [=constructible=]
+    <td>`array<`|T|,|N|`>()`: array&lt;|T|,|N|&gt;
     <td>Zero-valued array (OpConstantNull)
 </table>
 
@@ -3386,11 +3395,11 @@ The zero values are as follows:
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
-  <tr>
-    <td>`S` is a storable structure type.<br>
-         The expression is in the scope of declaration of S.
-    <td>`S()`: S
-    <td>Zero-valued structure: a structure of type S where each member is the zero value for its member type.
+  <tr algorithm="structure zero value">
+    <td>|S| is a [=constructible=] structure type.<br>
+         The expression is in the scope of declaration of |S|.
+    <td>|S|`()`: |S|
+    <td>Zero-valued structure: a structure of type |S| where each member is the zero value for its member type.
 <br>
  (OpConstantNull)
 </table>
@@ -4616,7 +4625,7 @@ expression to the right of the equals token is the <dfn noexport>right-hand side
     <td>|r|: ref<|SC|,|T|,|A|>,<br>
         |A| is [=access/write=] or [=access/read_write=]<br>
         |e|: |T|,<br>
-        |T| is an [=atomic-free=] [=plain type=],<br>
+        |T| is a [=constructible=] type,<br>
         |SC| is a writable [=storage class=]
     <td class="nowrap">|r| = |e|;
     <td>Evaluates |e|, evaluates |r|, then writes the value computed for |e| into
@@ -5196,7 +5205,7 @@ The identifier is [=in scope=] until the end of the function.
 Two formal parameters for a given function must not have the same name.
 
 If the return type is specified, then:
-* The return type must be an [=atomic-free=] [=plain type=].
+* The return type must be [=constructible=].
 * The last statement in the function body must be a [=return=] statement.
 
 <pre class='def'>
@@ -5294,9 +5303,9 @@ See [[#discard-statement]].
 * A [=vertex=] shader must return the `position` [=built-in output variable|built-in variable=].
     See [[#builtin-variables]].
 * An entry point must never be the target of a [=function call=].
-* If a function has a return type, it must be an [=atomic-free=] [=plain types|plain type=]
+* If a function has a return type, it must be a [=constructible=] type.
 * A [=formal parameter|function parameter=] must one the following types:
-    * atomic-free plain type
+    * a constructible type
     * a pointer type
     * a texture type
     * a sampler type


### PR DESCRIPTION
- Define 'sized array' type as a term.
- Add a new "Constructible types" section, replacing "Atomic-free types"
  - Defines 'constructible' types recursively as
    plain types without atomics or runtime-sized arrays.
- Replace all uses of "atomic-free plain type" with "constructible type".
  - You can't make a zero-value for any composite type containing an atomic.
    This is needed to keep the restriction that atomics can only be operated
    on via atomic builtin functions.
  - This also fixes some holes, e.g.:
     - you can't have a zero-value expression for a composite containing a runtime-sized array
     - you can't load from store to a whole buffer variable that
       contains a runtime-sized array.
- array value construction: the array must be a sized array, and
  elements constructible
- structure value construction: the elements must be constructible, not
  just storable.
- In the storage classes table, clarify that a variable in Workgroup
  storage can't have store type that is runtime-sized array or any
  composite containing a runtime-sized array.   This reinforces the
  a restriction already stated at the definition of runtime-sized array.

Fixes: #1859