### PR TITLE
Reduce maxStorageTexturePerStage from 8 to 4.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1155,7 +1155,7 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
         See [=Exceeds the binding slot limits=].
 
     <tr><td><dfn>maxStorageTexturesPerShaderStage</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>8
+        <td>{{GPUSize32}} <td>Higher <td>4
     <tr class=row-continuation><td colspan=4>
         For each possible {{GPUShaderStage}} `stage`,
         the maximum number of {{GPUBindGroupLayoutEntry}} entries across a {{GPUPipelineLayout}}


### PR DESCRIPTION
Looking at vulkan.gpuinfo.org, 60% of Android devices only support 4.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/1879.html" title="Last updated on Jun 25, 2021, 9:51 AM UTC (0a00c82)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1879/528f011...Kangz:0a00c82.html" title="Last updated on Jun 25, 2021, 9:51 AM UTC (0a00c82)">Diff</a>