### PR TITLE
wgsl: clarify interpolation defaulting

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -450,7 +450,6 @@ literal_or_ident
     return type, or member of a [=structure=] type.
     Must only be applied to declarations of scalars or vectors of floating-point type.
     Must not be used with the [=compute=] shader stage.
-    If the first parameter is `flat`, the second parameter must not be specified.
 
     Specifies how the user-defined IO must be interpolated.
     The attribute is only significant on user-defined [=vertex=] outputs
@@ -5602,8 +5601,14 @@ The <dfn noexport>interpolation sampling</dfn> must be one of:
     The [=fragment=] shader is invoked once per sample when this attribute is
     applied.
 
-The default interpolation of user-defined IO of scalar or vector floating-point
-type is `[[interpolate(perspective, center)]]`.
+For user-defined IO of scalar or vector floating-point type:
+* If the interpolation attribute is not specified, then `[[interpolate(perspective, center)]]` is assumed.
+* If the interpolation attribute is specified with an interpolation type:
+    * If the interpolation type is `flat`, then interpolation sampling must not be specified.
+    * If the interpolation type is `perspective` or `linear`, then:
+         * Any interpolation sampling is valid.
+         * If interpolation sampling is not specified, `center` is assumed.
+
 User-defined IO of scalar or vector integer type is always
 `[[interpolate(flat)]]` and, therefore, must not be specified in a [SHORTNAME] program.
 


### PR DESCRIPTION
This also pulls the "if flat, then no sampling" rule together with the
defaulting rules, so there's only one place to look.