### PR TITLE
Expose all interfaces to DedicatedWorker

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1692,7 +1692,7 @@ the functionality of that device.
 To get a {{GPUDevice}}, use {{GPUAdapter/requestDevice()}}.
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker), Serializable]
+[Exposed=(Window, DedicatedWorker)]
 interface GPUDevice : EventTarget {
     [SameObject] readonly attribute GPUSupportedFeatures features;
     [SameObject] readonly attribute GPUSupportedLimits limits;
@@ -1768,6 +1768,8 @@ Those not defined here are defined elsewhere in this document.
 
 {{GPUDevice}} objects are [=serializable objects=].
 
+Issue(gpuweb/gpuweb#354): Finish defining multithreading API and add `[Serializable]` back to the interface.
+
 <div algorithm>
     <dfn abstract-op>The steps to serialize a GPUDevice object</dfn>,
     given |value|, |serialized|, and |forStorage|, are:
@@ -1806,7 +1808,7 @@ its mapping.
 that returns a new buffer in the [=buffer state/mapped=] or [=buffer state/unmapped=] state.
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker), Serializable]
+[Exposed=(Window, DedicatedWorker)]
 interface GPUBuffer {
     Promise<undefined> mapAsync(GPUMapModeFlags mode, optional GPUSize64 offset = 0, optional GPUSize64 size);
     ArrayBuffer getMappedRange(optional GPUSize64 offset = 0, optional GPUSize64 size);
@@ -1894,6 +1896,8 @@ object, and {{Serializable}} means that the reference can be *copied* between
 realms (threads/workers), allowing multiple realms to access it concurrently.
 Since {{GPUBuffer}} has internal state (mapped, destroyed), that state is
 internally-synchronized - these state changes occur atomically across realms.
+
+Issue(gpuweb/gpuweb#354): Finish defining multithreading API and add `[Serializable]` back to the interface.
 
 ## Buffer Creation ## {#buffer-creation}
 
@@ -2219,7 +2223,7 @@ Issue: define <dfn dfn>mipmap level</dfn>, <dfn dfn>array layer</dfn>, <dfn dfn>
 that returns a new texture.
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker), Serializable]
+[Exposed=(Window, DedicatedWorker)]
 interface GPUTexture {
     GPUTextureView createView(optional GPUTextureViewDescriptor descriptor = {});
 
@@ -3132,7 +3136,7 @@ enum GPUCompareFunction {
 A {{GPUBindGroupLayout}} defines the interface between a set of resources bound in a {{GPUBindGroup}} and their accessibility in shader stages.
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker), Serializable]
+[Exposed=(Window, DedicatedWorker)]
 interface GPUBindGroupLayout {
 };
 GPUBindGroupLayout includes GPUObjectBase;
@@ -3776,7 +3780,7 @@ The full binding address of a resource can be defined as a trio of:
 The components of this address can also be seen as the binding space of a pipeline. A {{GPUBindGroup}} (with the corresponding {{GPUBindGroupLayout}}) covers that space for a fixed bind group index. The contained bindings need to be a superset of the resources used by the shader at this bind group index.
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker), Serializable]
+[Exposed=(Window, DedicatedWorker)]
 interface GPUPipelineLayout {
 };
 GPUPipelineLayout includes GPUObjectBase;
@@ -3871,7 +3875,7 @@ if their internal {{GPUPipelineLayout/[[bindGroupLayouts]]}} sequences contain
 ## <dfn interface>GPUShaderModule</dfn> ## {#shader-module}
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker), Serializable]
+[Exposed=(Window, DedicatedWorker)]
 interface GPUShaderModule {
     Promise<GPUCompilationInfo> compilationInfo();
 };
@@ -3883,6 +3887,8 @@ shader module object, and {{Serializable}} means that the reference can be
 *copied* between realms (threads/workers), allowing multiple realms to access
 it concurrently. Since {{GPUShaderModule}} is immutable, there are no race
 conditions.
+
+Issue(gpuweb/gpuweb#354): Finish defining multithreading API and add `[Serializable]` back to the interface.
 
 ### Shader Module Creation ### {#shader-module-creation}
 
@@ -4422,7 +4428,7 @@ Stages of a compute [=pipeline=]:
   1. Compute shader
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker), Serializable]
+[Exposed=(Window, DedicatedWorker)]
 interface GPUComputePipeline {
 };
 GPUComputePipeline includes GPUObjectBase;
@@ -4526,7 +4532,7 @@ A render [=pipeline=] is comprised of the following <dfn dfn>render stages</dfn>
   8. Output merging, controlled by {{GPUFragmentState/targets|GPUFragmentState.targets}}
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker), Serializable]
+[Exposed=(Window, DedicatedWorker)]
 interface GPURenderPipeline {
 };
 GPURenderPipeline includes GPUObjectBase;

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1213,7 +1213,7 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
 See {{GPUAdapter/limits|GPUAdapter.limits}} and {{GPUDevice/limits|GPUDevice.limits}}.
 
 <script type=idl>
-[Exposed=Window]
+[Exposed=(Window, DedicatedWorker)]
 interface GPUSupportedLimits {
     readonly attribute unsigned long maxTextureDimension1D;
     readonly attribute unsigned long maxTextureDimension2D;
@@ -1242,7 +1242,7 @@ the {{GPUFeatureName}} values of the [=features=] supported by an adapter or
 device. It must only contain strings from the {{GPUFeatureName}} enum.
 
 <script type=idl>
-[Exposed=Window]
+[Exposed=(Window, DedicatedWorker)]
 interface GPUSupportedFeatures {
     readonly setlike<DOMString>;
 };
@@ -1522,7 +1522,7 @@ and describes its capabilities ([=features=] and [=limits=]).
 To get a {{GPUAdapter}}, use {{GPU/requestAdapter()}}.
 
 <script type=idl>
-[Exposed=Window]
+[Exposed=(Window, DedicatedWorker)]
 interface GPUAdapter {
     readonly attribute DOMString name;
     [SameObject] readonly attribute GPUSupportedFeatures features;
@@ -1806,7 +1806,7 @@ its mapping.
 that returns a new buffer in the [=buffer state/mapped=] or [=buffer state/unmapped=] state.
 
 <script type=idl>
-[Exposed=Window, Serializable]
+[Exposed=(Window, DedicatedWorker), Serializable]
 interface GPUBuffer {
     Promise<undefined> mapAsync(GPUMapModeFlags mode, optional GPUSize64 offset = 0, optional GPUSize64 size);
     ArrayBuffer getMappedRange(optional GPUSize64 offset = 0, optional GPUSize64 size);
@@ -1921,7 +1921,7 @@ dictionary GPUBufferDescriptor : GPUObjectDescriptorBase {
 
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUBufferUsageFlags;
-[Exposed=Window]
+[Exposed=(Window, DedicatedWorker)]
 interface GPUBufferUsage {
     const GPUFlagsConstant MAP_READ      = 0x0001;
     const GPUFlagsConstant MAP_WRITE     = 0x0002;
@@ -2042,7 +2042,7 @@ Issue(gpuweb/gpuweb#605): Add client-side validation that a mapped buffer can
 
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUMapModeFlags;
-[Exposed=Window]
+[Exposed=(Window, DedicatedWorker)]
 interface GPUMapMode {
     const GPUFlagsConstant READ  = 0x0001;
     const GPUFlagsConstant WRITE = 0x0002;
@@ -2219,7 +2219,7 @@ Issue: define <dfn dfn>mipmap level</dfn>, <dfn dfn>array layer</dfn>, <dfn dfn>
 that returns a new texture.
 
 <script type=idl>
-[Exposed=Window, Serializable]
+[Exposed=(Window, DedicatedWorker), Serializable]
 interface GPUTexture {
     GPUTextureView createView(optional GPUTextureViewDescriptor descriptor = {});
 
@@ -2284,7 +2284,7 @@ enum GPUTextureDimension {
 
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUTextureUsageFlags;
-[Exposed=Window]
+[Exposed=(Window, DedicatedWorker)]
 interface GPUTextureUsage {
     const GPUFlagsConstant COPY_SRC          = 0x01;
     const GPUFlagsConstant COPY_DST          = 0x02;
@@ -2431,7 +2431,7 @@ all previously submitted operations using it are complete.
 ## <dfn interface>GPUTextureView</dfn> ## {#gpu-textureview}
 
 <script type=idl>
-[Exposed=Window]
+[Exposed=(Window, DedicatedWorker)]
 interface GPUTextureView {
 };
 GPUTextureView includes GPUObjectBase;
@@ -2801,7 +2801,7 @@ External textures use several binding slots: see [=Exceeds the binding slot limi
 </div>
 
 <script type=idl>
-[Exposed=Window]
+[Exposed=(Window, DedicatedWorker)]
 interface GPUExternalTexture {
 };
 GPUExternalTexture includes GPUObjectBase;
@@ -2909,7 +2909,7 @@ be used in a shader to interpret texture resource data.
 that returns a new sampler object.
 
 <script type=idl>
-[Exposed=Window]
+[Exposed=(Window, DedicatedWorker)]
 interface GPUSampler {
 };
 GPUSampler includes GPUObjectBase;
@@ -3132,7 +3132,7 @@ enum GPUCompareFunction {
 A {{GPUBindGroupLayout}} defines the interface between a set of resources bound in a {{GPUBindGroup}} and their accessibility in shader stages.
 
 <script type=idl>
-[Exposed=Window, Serializable]
+[Exposed=(Window, DedicatedWorker), Serializable]
 interface GPUBindGroupLayout {
 };
 GPUBindGroupLayout includes GPUObjectBase;
@@ -3159,7 +3159,7 @@ A {{GPUBindGroupLayoutEntry}} describes a single shader resource binding to be i
 
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUShaderStageFlags;
-[Exposed=Window]
+[Exposed=(Window, DedicatedWorker)]
 interface GPUShaderStage {
     const GPUFlagsConstant VERTEX   = 0x1;
     const GPUFlagsConstant FRAGMENT = 0x2;
@@ -3568,7 +3568,7 @@ A {{GPUBindGroup}} defines a set of resources to be bound together in a group
     and how the resources are used in shader stages.
 
 <script type=idl>
-[Exposed=Window]
+[Exposed=(Window, DedicatedWorker)]
 interface GPUBindGroup {
 };
 GPUBindGroup includes GPUObjectBase;
@@ -3776,7 +3776,7 @@ The full binding address of a resource can be defined as a trio of:
 The components of this address can also be seen as the binding space of a pipeline. A {{GPUBindGroup}} (with the corresponding {{GPUBindGroupLayout}}) covers that space for a fixed bind group index. The contained bindings need to be a superset of the resources used by the shader at this bind group index.
 
 <script type=idl>
-[Exposed=Window, Serializable]
+[Exposed=(Window, DedicatedWorker), Serializable]
 interface GPUPipelineLayout {
 };
 GPUPipelineLayout includes GPUObjectBase;
@@ -3871,7 +3871,7 @@ if their internal {{GPUPipelineLayout/[[bindGroupLayouts]]}} sequences contain
 ## <dfn interface>GPUShaderModule</dfn> ## {#shader-module}
 
 <script type=idl>
-[Exposed=Window, Serializable]
+[Exposed=(Window, DedicatedWorker), Serializable]
 interface GPUShaderModule {
     Promise<GPUCompilationInfo> compilationInfo();
 };
@@ -3926,7 +3926,7 @@ enum GPUCompilationMessageType {
     "info"
 };
 
-[Exposed=Window, Serializable]
+[Exposed=(Window, DedicatedWorker), Serializable]
 interface GPUCompilationMessage {
     readonly attribute DOMString message;
     readonly attribute GPUCompilationMessageType type;
@@ -3936,7 +3936,7 @@ interface GPUCompilationMessage {
     readonly attribute unsigned long long length;
 };
 
-[Exposed=Window, Serializable]
+[Exposed=(Window, DedicatedWorker), Serializable]
 interface GPUCompilationInfo {
     readonly attribute FrozenArray<GPUCompilationMessage> messages;
 };
@@ -4422,7 +4422,7 @@ Stages of a compute [=pipeline=]:
   1. Compute shader
 
 <script type=idl>
-[Exposed=Window, Serializable]
+[Exposed=(Window, DedicatedWorker), Serializable]
 interface GPUComputePipeline {
 };
 GPUComputePipeline includes GPUObjectBase;
@@ -4526,7 +4526,7 @@ A render [=pipeline=] is comprised of the following <dfn dfn>render stages</dfn>
   8. Output merging, controlled by {{GPUFragmentState/targets|GPUFragmentState.targets}}
 
 <script type=idl>
-[Exposed=Window, Serializable]
+[Exposed=(Window, DedicatedWorker), Serializable]
 interface GPURenderPipeline {
 };
 GPURenderPipeline includes GPUObjectBase;
@@ -4835,7 +4835,7 @@ dictionary GPUBlendState {
 
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUColorWriteFlags;
-[Exposed=Window]
+[Exposed=(Window, DedicatedWorker)]
 interface GPUColorWrite {
     const GPUFlagsConstant RED   = 0x1;
     const GPUFlagsConstant GREEN = 0x2;
@@ -5139,7 +5139,7 @@ setting state, drawing, copying resources, etc.
 ## <dfn interface>GPUCommandBuffer</dfn> ## {#command-buffer}
 
 <script type=idl>
-[Exposed=Window]
+[Exposed=(Window, DedicatedWorker)]
 interface GPUCommandBuffer {
     readonly attribute Promise<double> executionTime;
 };
@@ -5196,7 +5196,7 @@ dictionary GPUCommandBufferDescriptor : GPUObjectDescriptorBase {
 ## <dfn interface>GPUCommandEncoder</dfn> ## {#command-encoder}
 
 <script type=idl>
-[Exposed=Window]
+[Exposed=(Window, DedicatedWorker)]
 interface GPUCommandEncoder {
     GPURenderPassEncoder beginRenderPass(GPURenderPassDescriptor descriptor);
     GPUComputePassEncoder beginComputePass(optional GPUComputePassDescriptor descriptor = {});
@@ -6331,7 +6331,7 @@ pass.
 ## <dfn interface>GPUComputePassEncoder</dfn> ## {#compute-pass-encoder}
 
 <script type=idl>
-[Exposed=Window]
+[Exposed=(Window, DedicatedWorker)]
 interface GPUComputePassEncoder {
     undefined setPipeline(GPUComputePipeline pipeline);
     undefined dispatch(GPUSize32 x, optional GPUSize32 y = 1, optional GPUSize32 z = 1);
@@ -6588,7 +6588,7 @@ interface mixin GPURenderEncoderBase {
     undefined drawIndexedIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
 };
 
-[Exposed=Window]
+[Exposed=(Window, DedicatedWorker)]
 interface GPURenderPassEncoder {
     undefined setViewport(float x, float y,
                      float width, float height,
@@ -7519,7 +7519,7 @@ called the render pass encoder can no longer be used.
 ## <dfn interface>GPURenderBundle</dfn> ## {#render-bundle}
 
 <script type=idl>
-[Exposed=Window]
+[Exposed=(Window, DedicatedWorker)]
 interface GPURenderBundle {
 };
 GPURenderBundle includes GPUObjectBase;
@@ -7533,7 +7533,7 @@ dictionary GPURenderBundleDescriptor : GPUObjectDescriptorBase {
 </script>
 
 <script type=idl>
-[Exposed=Window]
+[Exposed=(Window, DedicatedWorker)]
 interface GPURenderBundleEncoder {
     GPURenderBundle finish(optional GPURenderBundleDescriptor descriptor = {});
 };
@@ -7595,7 +7595,7 @@ dictionary GPURenderBundleEncoderDescriptor : GPUObjectDescriptorBase {
 # Queues # {#queues}
 
 <script type=idl>
-[Exposed=Window]
+[Exposed=(Window, DedicatedWorker)]
 interface GPUQueue {
     undefined submit(sequence<GPUCommandBuffer> commandBuffers);
 
@@ -7836,7 +7836,7 @@ Queries {#queries}
 ## <dfn interface>GPUQuerySet</dfn> ## {#queryset}
 
 <script type=idl>
-[Exposed=Window]
+[Exposed=(Window, DedicatedWorker)]
 interface GPUQuerySet {
     undefined destroy();
 };
@@ -8027,7 +8027,7 @@ method of an {{HTMLCanvasElement}} instance by passing the string literal `'gpup
 ## GPUPresentationContext ## {#presentation-context}
 
 <script type=idl>
-[Exposed=Window]
+[Exposed=(Window, DedicatedWorker)]
 interface GPUPresentationContext {
     undefined configure(GPUPresentationConfiguration configuration);
     undefined unconfigure();
@@ -8376,7 +8376,7 @@ enum GPUDeviceLostReason {
     "destroyed",
 };
 
-[Exposed=Window]
+[Exposed=(Window, DedicatedWorker)]
 interface GPUDeviceLostInfo {
     readonly attribute (GPUDeviceLostReason or undefined) reason;
     readonly attribute DOMString message;
@@ -8398,12 +8398,12 @@ enum GPUErrorFilter {
 </script>
 
 <script type=idl>
-[Exposed=Window]
+[Exposed=(Window, DedicatedWorker)]
 interface GPUOutOfMemoryError {
     constructor();
 };
 
-[Exposed=Window]
+[Exposed=(Window, DedicatedWorker)]
 interface GPUValidationError {
     constructor(DOMString message);
     readonly attribute DOMString message;


### PR DESCRIPTION
Exposes the whole WebGPU API to DedicatedWorker. There's no reason this can't be exposed now (and in fact Chromium already exposes it). This doesn't require multithreading support - just single-threaded access from a worker.

In the second commit, I also tentatively remove the `[Serializable]` attribute from all of the interfaces. We already agreed on adding these, but we still have yet to actually fully write down how it works. We should figure out whether we want to keep the partially-defined multithreading in the spec for now. If we do, I'll just cut that commit from the PR.

Fixes #1882


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1883.html" title="Last updated on Jun 28, 2021, 9:47 PM UTC (052dac9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1883/f8f6c29...kainino0x:052dac9.html" title="Last updated on Jun 28, 2021, 9:47 PM UTC (052dac9)">Diff</a>