### PR TITLE
Remove sentinel value in setVertex/IndexBuffer

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2120,7 +2120,7 @@ interface GPUMapMode {
 
             Issue(gpuweb/gpuweb#605): Handle error buffers once we have a description of the error monad.
 
-            1. If |size| is unspecified:
+            1. If |size| is missing:
                 1. Let |rangeSize| be max(0, |this|.{{GPUBuffer/[[size]]}} - |offset|).
 
                 Otherwise, let |rangeSize| be |size|.
@@ -2178,7 +2178,7 @@ interface GPUMapMode {
 
             **Returns:** {{ArrayBuffer}}
 
-            1. If |size| is unspecified:
+            1. If |size| is missing:
                 1. Let |rangeSize| be max(0, |this|.{{GPUBuffer/[[size]]}} - |offset|).
 
                 Otherwise, let |rangeSize| be |size|.
@@ -6654,8 +6654,8 @@ called the compute pass encoder can no longer be used.
 interface mixin GPURenderEncoderBase {
     undefined setPipeline(GPURenderPipeline pipeline);
 
-    undefined setIndexBuffer(GPUBuffer buffer, GPUIndexFormat indexFormat, optional GPUSize64 offset = 0, optional GPUSize64 size = 0);
-    undefined setVertexBuffer(GPUIndex32 slot, GPUBuffer buffer, optional GPUSize64 offset = 0, optional GPUSize64 size = 0);
+    undefined setIndexBuffer(GPUBuffer buffer, GPUIndexFormat indexFormat, optional GPUSize64 offset = 0, optional GPUSize64 size);
+    undefined setVertexBuffer(GPUIndex32 slot, GPUBuffer buffer, optional GPUSize64 offset = 0, optional GPUSize64 size);
 
     undefined draw(GPUSize32 vertexCount, optional GPUSize32 instanceCount = 1,
               optional GPUSize32 firstVertex = 0, optional GPUSize32 firstInstance = 0);
@@ -7054,14 +7054,14 @@ enum GPUStoreOp {
                 |indexFormat|: Format of the index data contained in |buffer|.
                 |offset|: Offset in bytes into |buffer| where the index data begins. Defaults to `0`.
                 |size|: Size in bytes of the index data in |buffer|.
-                    If `0`, defaults to the size of the buffer minus the offset.
+                    Defaults to the size of the buffer minus the offset.
             </pre>
 
             **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. If |size| is `0`, set |size| to |buffer|.{{GPUBuffer/[[size]]}} - |offset| is used.
+                1. If |size| is missing, set |size| to |buffer|.{{GPUBuffer/[[size]]}} - |offset| is used.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |buffer| is [$valid to use with$] |this|.
@@ -7089,14 +7089,14 @@ enum GPUStoreOp {
                 |buffer|: Buffer containing vertex data to use for subsequent drawing commands.
                 |offset|: Offset in bytes into |buffer| where the vertex data begins. Defaults to `0`.
                 |size|: Size in bytes of the vertex data in |buffer|.
-                    If `0`, defaults to the size of the buffer minus the offset.
+                    Defaults to the size of the buffer minus the offset.
             </pre>
 
             **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. If |size| is `0` set |size| to |buffer|.{{GPUBuffer/[[size]]}} - |offset| is used.
+                1. If |size| is missing, set |size| to |buffer|.{{GPUBuffer/[[size]]}} - |offset| is used.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |buffer| is [$valid to use with$] |this|.
@@ -7725,7 +7725,7 @@ GPUQueue includes GPUObjectBase;
             1. If |data| is an {{ArrayBuffer}} or {{DataView}}, let the element type be "byte".
                 Otherwise, |data| is a TypedArray; let the element type be the type of the TypedArray.
             1. Let |dataSize| be the size of |data|, in elements.
-            1. If |size| is unspecified,
+            1. If |size| is missing,
                 let |contentsSize| be |dataSize| &minus; |dataOffset|.
                 Otherwise, let |contentsSize| be |size|.
             1. If any of the following conditions are unsatisfied,


### PR DESCRIPTION
And use the term "missing" for optional arguments:
https://heycam.github.io/webidl/#web-idl-arguments-list


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1885.html" title="Last updated on Jun 29, 2021, 4:32 PM UTC (b9b3cde)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1885/5d7ec15...kainino0x:b9b3cde.html" title="Last updated on Jun 29, 2021, 4:32 PM UTC (b9b3cde)">Diff</a>