### PR TITLE
Match introduction with title

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -91,7 +91,7 @@ spec: SPIR-V; urlPrefix: https://www.khronos.org/registry/spir-v/specs/unified1/
 
 # Introduction # {#intro}
 
-WebGPU Shader Language ([SHORTNAME]) is the shader language for [[!WebGPU]].
+WebGPU Shading Language ([SHORTNAME]) is the shader language for [[!WebGPU]].
 That is, an application using the WebGPU API uses [SHORTNAME] to express the programs, known as shaders,
 that run on the GPU.
 


### PR DESCRIPTION
The title expands WGSL's short name to WebGPU Shading Language, whereas the introduction expands to WebGPU Shader Language; this PR aims to fix that.