### PR TITLE
Update size range of "stencil8" format

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9470,7 +9470,7 @@ None of the depth formats can be filtered.
     </thead>
     <tr>
         <td>{{GPUTextureFormat/stencil8}}
-        <td>1 &minus; 5
+        <td>1 &minus; 4
         <td>stencil
         <td>{{GPUTextureSampleType/"uint"}}
         <td colspan=2>&checkmark;


### PR DESCRIPTION
As documented already in the texture format section, "stencil8" can be
either real stencil8 or x24-stencil8. They don't need to be able to be
x32-stencil8:

- On Metal, stencil8 is available on all [hardware](https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf) and [OSes](https://developer.apple.com/documentation/metal/mtlpixelformat/mtlpixelformatstencil8).
- On D3D FL11_0, D24_UNORM_S8_UINT is [required](https://docs.google.com/spreadsheets/d/1ALlgyOA5BXXhJDZXPyEQ-vXV_E8IKZfe1xcNmhIM4Mw/edit?usp=sharing).
- Vulkan technically requires neither, but according to vulkan.gpuinfo.org:
  - S8_UINT is always available [on AMD](http://vulkan.gpuinfo.org/listdevicescoverage.php?optimalformat=S8_UINT&platform=windows&option=not).
  - D24_UNORM_S8_UINT is always available on [Intel, NVIDIA](http://vulkan.gpuinfo.org/listdevicescoverage.php?optimalformat=D24_UNORM_S8_UINT&platform=windows&option=not), and [Android](http://vulkan.gpuinfo.org/listformats.php?platform=android).

(As a side note, I think the "5" was wrong. We correctly allow up to 8 bytes for depth24plus-stencil8, which `VK_FORMAT_D32_SFLOAT_S8_UINT` allows.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1888.html" title="Last updated on Jun 29, 2021, 9:09 PM UTC (1583823)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1888/7d98e53...kainino0x:1583823.html" title="Last updated on Jun 29, 2021, 9:09 PM UTC (1583823)">Diff</a>