### PR TITLE
wgsl: Reserve `vec` and `mat` keywords

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2951,11 +2951,11 @@ Such variables are declared with [=attribute/group=] and [=attribute/binding=] d
     };
     // A storage buffer, for reading and writing
     [[group(0), binding(0)]]
-    var<storage,read_write> pbuf: PositionsBuffer;  
+    var<storage,read_write> pbuf: PositionsBuffer;
 
     // Textures and samplers are always in "handle" storage.
     [[group(0), binding(1)]]
-    var filter_params: sampler;   
+    var filter_params: sampler;
   </xmp>
 </div>
 
@@ -6141,7 +6141,7 @@ value with the same sign.
   <thead>
     <tr><th>Expression<th>Accuracy<th>
   </thead>
-  
+
   <tr><td>`x + y`<td>Correctly rounded
   <tr><td>`x - y`<td>Correctly rounded
   <tr><td>`x * y`<td>Correctly rounded
@@ -6395,29 +6395,31 @@ The following is a list of keywords which are reserved for future expansion.
   <tr>
     <td>asm
     <td>bf16
+    <td>const
     <td>do
     <td>enum
-    <td>f16
   <tr>
+    <td>f16
     <td>f64
+    <td>handle
     <td>i8
     <td>i16
-    <td>i64
-    <td>const
   <tr>
+    <td>i64
+    <td>mat
+    <td>premerge
+    <td>regardless
     <td>typedef
+  <tr>
     <td>u8
     <td>u16
     <td>u64
     <td>unless
-  <tr>
     <td>using
-    <td>while
-    <td>regardless
-    <td>premerge
-    <td>handle
   <tr>
+    <td>vec
     <td>void
+    <td>while
 </table>
 
 ## Syntactic Tokens ## {#syntactic-tokens}


### PR DESCRIPTION
Also sort the keywords lexicographically.

Fixes: #1862