### PR TITLE
Fix the compute limits, adds maxComputeWorkgroupSize

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4530,7 +4530,7 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
                         |device|.limits.{{supported limits/maxComputeWorkgroupInvocations}} per
                         workgroup.
 
-                    - |descriptor|.{{GPUComputePipelineDescriptor/compute}}'s `workgroup_size` decoration
+                    - |descriptor|.{{GPUComputePipelineDescriptor/compute}}'s `workgroup_size` attribute
                         has each component &le; the corresponding component in
                         |device|.limits.{{supported limits/maxComputeWorkgroupInvocations}}.
                 </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4521,7 +4521,7 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
                     - [$validating GPUProgrammableStage$]({{GPUShaderStage/COMPUTE}},
                         |descriptor|.{{GPUComputePipelineDescriptor/compute}},
                         |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
-                    - |descriptor|.{{GPUComputePipelineDescriptor/compute}} uses at most than
+                    - |descriptor|.{{GPUComputePipelineDescriptor/compute}} uses &le;
                         |device|.limits.{{supported limits/maxComputeWorkgroupStorageSize}} bytes of
                         workgroup storage.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4526,7 +4526,7 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
                         workgroup storage.
 
                         Issue: Better define using static use, etc.
-                    - |descriptor|.{{GPUComputePipelineDescriptor/compute}} uses at most than
+                    - |descriptor|.{{GPUComputePipelineDescriptor/compute}} uses &le;
                         |device|.limits.{{supported limits/maxComputeWorkgroupInvocations}} per
                         workgroup.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1243,6 +1243,12 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
         The maximum value of the product of the `workgroup_size` values for a
         compute stage {{GPUShaderModule}} entry-point.
 
+    <tr><td><dfn>maxComputeWorkgroupSize</dfn>
+        <td>{{GPUExtent3D}} <td>Per-component Higher <td>[256, 256, 64]
+    <tr class=row-continuation><td colspan=4>
+        The maximum value of the product of the `workgroup_size` values for a
+        compute stage {{GPUShaderModule}} entry-point.
+
     <tr><td><dfn>maxComputePerDimensionDispatchSize</dfn>
         <td>{{GPUSize32}} <td>Higher <td>65535
     <tr class=row-continuation><td colspan=4>
@@ -1282,6 +1288,7 @@ interface GPUSupportedLimits {
     readonly attribute unsigned long maxInterStageShaderComponents;
     readonly attribute unsigned long maxComputeWorkgroupStorageSize;
     readonly attribute unsigned long maxComputeWorkgroupInvocations;
+    readonly attribute GPUExtent3D maxComputeWorkgroupSize;
     readonly attribute unsigned long maxComputePerDimensionDispatchSize;
 };
 </script>
@@ -4514,14 +4521,18 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
                     - [$validating GPUProgrammableStage$]({{GPUShaderStage/COMPUTE}},
                         |descriptor|.{{GPUComputePipelineDescriptor/compute}},
                         |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
-                    - |descriptor|.{{GPUComputePipelineDescriptor/compute}} uses more than
+                    - |descriptor|.{{GPUComputePipelineDescriptor/compute}} uses at most than
                         |device|.limits.{{supported limits/maxComputeWorkgroupStorageSize}} bytes of
                         workgroup storage.
 
                         Issue: Better define using static use, etc.
-                    - |descriptor|.{{GPUComputePipelineDescriptor/compute}} uses more than
+                    - |descriptor|.{{GPUComputePipelineDescriptor/compute}} uses at most than
                         |device|.limits.{{supported limits/maxComputeWorkgroupInvocations}} per
                         workgroup.
+
+                    - |descriptor|.{{GPUComputePipelineDescriptor/compute}}'s `workgroup_size` decoration
+                        has each component at most the respective component in
+                        |device|.limits.{{supported limits/maxComputeWorkgroupInvocations}}.
                 </div>
 
             Then:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4531,7 +4531,7 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
                         workgroup.
 
                     - |descriptor|.{{GPUComputePipelineDescriptor/compute}}'s `workgroup_size` decoration
-                        has each component at most the respective component in
+                        has each component &le; the corresponding component in
                         |device|.limits.{{supported limits/maxComputeWorkgroupInvocations}}.
                 </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4532,7 +4532,7 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
 
                     - |descriptor|.{{GPUComputePipelineDescriptor/compute}}'s `workgroup_size` attribute
                         has each component &le; the corresponding component in
-                        |device|.limits.{{supported limits/maxComputeWorkgroupInvocations}}.
+                        |device|.limits.{{supported limits/maxComputeWorkgroupSize}}.
                 </div>
 
             Then:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1246,7 +1246,7 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
     <tr><td><dfn>maxComputeWorkgroupSize</dfn>
         <td>{{GPUExtent3D}} <td>Per-component Higher <td>[256, 256, 64]
     <tr class=row-continuation><td colspan=4>
-        The maximum value of the product of the `workgroup_size` values for a
+        The maximum values of the `workgroup_size` values for a
         compute stage {{GPUShaderModule}} entry-point.
 
     <tr><td><dfn>maxComputePerDimensionDispatchSize</dfn>


### PR DESCRIPTION
Validation was incorrectly checking values were above limits instead of
below limits.

maxComputeWorkgroupSize is necessary because the 3rd component of
workgroup_size is almost always 64 in Vulkan devices (on mobile and
desktop).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/1898.html" title="Last updated on Jul 12, 2021, 9:42 PM UTC (2479ab4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1898/73b20b5...Kangz:2479ab4.html" title="Last updated on Jul 12, 2021, 9:42 PM UTC (2479ab4)">Diff</a>