### PR TITLE
Add GPUExternalTexture Destroy

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2854,6 +2854,7 @@ External textures use several binding slots: see [=Exceeds the binding slot limi
 <script type=idl>
 [Exposed=Window]
 interface GPUExternalTexture {
+    undefined destroy();
 };
 GPUExternalTexture includes GPUObjectBase;
 </script>
@@ -2949,6 +2950,27 @@ If the internal representation is an RGBA plane, sampling behaves as on a regula
 If there are several underlying planes (e.g. Y+UV), the sampler is used to sample each
 underlying texture separately, prior to conversion from YUV to the specified color space.
 
+### External Texture Destruction ### {#external-texture-destruction}
+
+An application that no longer requires a {{GPUExternalTexture}} can choose to lose access to it before
+garbage collection by calling {{GPUExternalTexture/destroy()}}.
+
+Note: This allows the user agent to reclaim the GPU memory associated with the {{GPUExternalTexture}} 
+once all previously submitted operations using it are complete.
+
+<dl dfn-type=method dfn-for=GPUExternalTexture>
+    : <dfn>destroy()</dfn>
+    ::
+        Destroys the {{GPUExternalTexture}}.
+
+        <div algorithm=GPUExternalTexture.destroy>
+            **Called on:** {{GPUExternalTexture}} |this|.
+
+            **Returns:** {{undefined}}
+
+            1. Set |this|.{{GPUExternalTexture/[[destroyed]]}} to true.
+        </div>
+</dl>
 
 # Samplers # {#samplers}
 


### PR DESCRIPTION
Adds GPUExternalTexture Destroy. This is important for releasing memory between GCs. 

***
<a href="https://pr-preview.s3.amazonaws.com/bjjones/gpuweb/pull/1899.html" title="Last updated on Jul 1, 2021, 9:26 PM UTC (78067cb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1899/73b20b5...bjjones:78067cb.html" title="Last updated on Jul 1, 2021, 9:26 PM UTC (78067cb)">Diff</a>


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bjjones/gpuweb/pull/1899.html" title="Last updated on Jul 1, 2021, 9:42 PM UTC (78067cb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1899/73b20b5...bjjones:78067cb.html" title="Last updated on Jul 1, 2021, 9:42 PM UTC (78067cb)">Diff</a>