### PR TITLE
wgsl: add refract as a built-in function

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6193,6 +6193,7 @@ value with the same sign.
   <tr><td>`normalize(x)`<td>Inherited from `x - length(x)`
   <tr><td>`pow(x, y)`<td>Inherited from `exp2(y * log2(x))`
   <tr><td>`reflect(x, y)`<td>Inherited from `x - 2.0 * dot(x, y) * y`
+  <tr><td>`refract(x, y, z)`<td>Inherited from `z * x - (z * dot(y, x) + sqrt(k)) * y`,<br>where `k = 1.0 - z * z * (1.0 - dot(y, x) * dot(y, x))`<br>If `k < 0.0` the result is precisely 0.0
   <tr><td>`round(x)`<td>Correctly rounded
   <tr><td>`sign(x)`<td>Correctly rounded
   <tr><td>`sin(x)`<td>Absolute error &le; 2<sup>-11</sup> inside the range [-&pi;, &pi;]
@@ -6965,9 +6966,18 @@ That's not a full user-defined function declaration.
     <td>|T| is [FLOATING]
     <td class="nowrap">`reflect(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>For the incident vector |e1| and surface orientation |e2|, returns the reflection direction
-    |e1|`-2*dot(`|e2|`,`|e1|`)*|e2|`.
+    |e1|`-2*dot(`|e2|`,`|e1|`)*`|e2|.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Reflect)
+
+  <tr algorithm="refract">
+    <td>|T| is [floating]<br>I is f32
+    <td class="nowrap">`refract(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |I| `) -> ` |T|
+    <td>For the incident vector |e1| and surface normal |e2|, and the ratio of indices of refraction |e3|, 
+    let `k = 1.0 - `|e3|` * `|e3|` * (1.0 - dot(`|e2|`, `|e1|`) * dot(`|e2|`, `|e1|`))`. If `k < 0.0`, returns the 
+    refraction vector 0.0, otherwise return the refraction vector 
+    |e3|` * `|e1|` - (`|e3|` * dot(`|e2|`, `|e1|`) + sqrt(k)) * `|e2|.
+    (GLSLstd450Refract)
 
   <tr algorithm="round">
     <td>|T| is [FLOATING]

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6971,7 +6971,7 @@ That's not a full user-defined function declaration.
     (GLSLstd450Reflect)
 
   <tr algorithm="refract">
-    <td>|T| is [floating]<br>I is f32
+    <td>|T| is vec|N|&lt;f32&gt;<br>I is f32
     <td class="nowrap">`refract(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |I| `) -> ` |T|
     <td>For the incident vector |e1| and surface normal |e2|, and the ratio of indices of refraction |e3|, 
     let `k = 1.0 - `|e3|` * `|e3|` * (1.0 - dot(`|e2|`, `|e1|`) * dot(`|e2|`, `|e1|`))`. If `k < 0.0`, returns the 


### PR DESCRIPTION
Add the refract into WGSL, which is already a built in function in GLSL, HLSL and MSL. Please see [https://github.com/gpuweb/gpuweb/issues/1087#issuecomment-871877774](https://github.com/gpuweb/gpuweb/issues/1087#issuecomment-871877774).
Also correct a mistyping in the description of reflect.

A problem is that while [GLSL](https://www.khronos.org/registry/spir-v/specs/1.0/GLSL.std.450.html) said "The type of I and N (the first two operands) must be a **scalar** or vector with a floating-point component type", [HLSL](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-refract)  said they must be "vector", rather than "scale or vector".  The situation is the same for reflect.