### PR TITLE
Clarify out of bounds texture operations

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7304,7 +7304,7 @@ format to channel format.
 The unfiltered texel data.
 
 An out-of-bounds access occurs if:
-* any element of `coords` is outside the range `[0, textureDimensions(t))`
+* any element of `coords` is outside the range `[0, textureDimensions(t, level))`
     for the corresponding element
 * `array_index` is outside the range `[0, textureNumLayers(t))`
 * `level` is outside the range `[0, textureNumLevels(t))`

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7258,6 +7258,9 @@ The dimensions of the texture in texels.
 For textures based on cubes, the results are the dimensions of each face of the cube.
 Cube faces are square, so the x and y components of the result are equal.
 
+If `level` is outside the range `[0, textureNumLevels(t))` then any valid value
+for the return type may be returned.
+
 ### `textureLoad` ### {#textureload}
 
 Reads a single texel from a texture without sampling or filtering.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7301,8 +7301,18 @@ format to channel format.
 
 **Returns:**
 
-If all the parameters are within bounds, the unfiltered texel data.<br>
-If any of the parameters are out of bounds, then zero in all components.
+The unfiltered texel data.
+
+An out-of-bounds access occurs if:
+* any element of `coords` is outside the range `[0, textureDimensions(t))`
+    for the corresponding element
+* `array_index` is outside the range `[0, textureNumLayers(t))`
+* `level` is outside the range `[0, textureNumLevels(t))`
+
+If an out-of-bounds access occurs, the built-in function returns one of:
+* The data for some texel within bounds of the texture
+* A vector (0,0,0,0) or (0,0,0,1) of the appropriate type for non-depth textures
+* 0.0 for depth textures
 
 ### `textureNumLayers` ### {#texturenumlayers}
 
@@ -7679,9 +7689,14 @@ format to channel format.
 
 **Note:**
 
-If any of the parameters are out of bounds, then the call to `textureStore()`
-does nothing.
+An out-of-bounds access occurs if:
+* any element of `coords` is outside the range `[0, textureDimensions(t))`
+    for the corresponding element
+* `array_index` is outside the range of `[0, textureNumLayers(t))`
 
+If an out-of-bounds access occurs, the built-in function may do any of the following:
+* not be executed
+* store `value` to some in bounds texel
 
 **TODO:**
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7303,13 +7303,13 @@ format to channel format.
 
 The unfiltered texel data.
 
-An out-of-bounds access occurs if:
+An out of bounds access occurs if:
 * any element of `coords` is outside the range `[0, textureDimensions(t, level))`
     for the corresponding element
 * `array_index` is outside the range `[0, textureNumLayers(t))`
 * `level` is outside the range `[0, textureNumLevels(t))`
 
-If an out-of-bounds access occurs, the built-in function returns one of:
+If an out of bounds access occurs, the built-in function returns one of:
 * The data for some texel within bounds of the texture
 * A vector (0,0,0,0) or (0,0,0,1) of the appropriate type for non-depth textures
 * 0.0 for depth textures

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7305,8 +7305,8 @@ The unfiltered texel data.
 
 An out of bounds access occurs if:
 * any element of `coords` is outside the range `[0, textureDimensions(t, level))`
-    for the corresponding element
-* `array_index` is outside the range `[0, textureNumLayers(t))`
+    for the corresponding element, or
+* `array_index` is outside the range `[0, textureNumLayers(t))`, or
 * `level` is outside the range `[0, textureNumLevels(t))`
 
 If an out of bounds access occurs, the built-in function returns one of:
@@ -7691,7 +7691,7 @@ format to channel format.
 
 An out-of-bounds access occurs if:
 * any element of `coords` is outside the range `[0, textureDimensions(t))`
-    for the corresponding element
+    for the corresponding element, or
 * `array_index` is outside the range of `[0, textureNumLayers(t))`
 
 If an out-of-bounds access occurs, the built-in function may do any of the following:


### PR DESCRIPTION
Fixes #1895

* Defines out of bounds behaviour for textureLoad and textureStore that
  is compatible with each underlying API