### PR TITLE
Add round_up_size attribute

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -493,6 +493,16 @@ literal_or_ident
     If the optional parameter is specified, the pipeline overridable constant
     is referred to by the numeric id specified instead.
 
+  <tr><td><dfn noexport dfn-for="attribute">`round_up_size`</dfn>
+    <td>positive i32 literal
+    <td>Must only be applied to a member of a [=structure=] type.
+
+    The number of bytes reserved in the struct for this member satifies the formula:<br>
+    [=roundUp=]`(SizeOf(T), Multiple)`
+
+    where `T` is the type of the field and `Multiple` is the argument to the
+    attribute.
+
   <tr><td><dfn noexport dfn-for="attribute">`size`</dfn>
     <td>positive i32 literal
     <td>Must only be applied to a member of a [=structure=] type.
@@ -1043,6 +1053,7 @@ struct_member
  * [=attribute/stride=]
  * [=attribute/align=]
  * [=attribute/size=]
+ * [=attribute/round_up_size=]
 
 Note: Layout attributes may be required if the structure type is used
 to define a [=uniform buffer=] or a [=storage buffer=]. See [[#memory-layouts]].


### PR DESCRIPTION
* Structure member attribute that sets the size requirement on a
  structure field to multiple of the specified value
  * Very useful for structures in the uniform storage class