### PR TITLE
wgsl: specify the input type of reflect to be vector

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6965,11 +6965,10 @@ That's not a full user-defined function declaration.
     (GLSLstd450Pow)
 
   <tr algorithm="reflect">
-    <td>|T| is [FLOATING]
+    <td>|T| is vec|N|&lt;f32&gt;
     <td class="nowrap">`reflect(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>For the incident vector |e1| and surface orientation |e2|, returns the reflection direction
     |e1|`-2*dot(`|e2|`,`|e1|`)*`|e2|.
-    [=Component-wise=] when |T| is a vector.
     (GLSLstd450Reflect)
 
   <tr algorithm="refract">


### PR DESCRIPTION
Specifies the input of reflect should be vector of float.
while [GLSL](https://www.khronos.org/registry/spir-v/specs/1.0/GLSL.std.450.html) said "The operands must all be a scalar or vector whose component type is floating-point.", [HLSL](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-reflect) said they must be "vector", rather than "scale or vector".