### PR TITLE
[wgsl]: Add `fmod()`, `frem()` builtins

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4070,10 +4070,6 @@ references to arrays. An array not behind a reference may only be indexed by a
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [UNSIGNEDINTEGRAL]
     <td>|e1| `%` |e2| : |T|
     <td>Unsigned integer remainder. [=Component-wise=] when |T| is a vector. (OpUMod)
-  <tr algorithm="floating point remainder">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [FLOATING]
-    <td>|e1| `%` |e2| : |T|
-    <td>Floating point remainder, where sign of non-zero result matches sign of |e2|. [=Component-wise=] when |T| is a vector. (OpFMod)
 
 </table>
 
@@ -6857,6 +6853,20 @@ That's not a full user-defined function declaration.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Fma)
 
+  <tr algorithm="fmod">
+    <td>|T| is [FLOATING]
+    <td class="nowrap">`fmod(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
+    <td>Returns the floating point remainder of |e1| divided by |e2|, where sign of non-zero result matches sign of |e2|.
+    [=Component-wise=] when |T| is a vector.
+    (OpFMod)
+
+  <tr algorithm="frem">
+    <td>|T| is [FLOATING]
+    <td class="nowrap">`frem(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
+    <td>Returns the floating point remainder of |e1| divided by |e2|, where sign of non-zero result matches sign of |e1|.
+    [=Component-wise=] when |T| is a vector.
+    (OpFRem)
+
   <tr algorithm="fract">
     <td>|T| is [FLOATING]
     <td class="nowrap">`fract(`|e|`:` |T| `) -> ` |T|
@@ -6975,9 +6985,9 @@ That's not a full user-defined function declaration.
   <tr algorithm="refract">
     <td>|T| is vec|N|&lt;f32&gt;<br>I is f32
     <td class="nowrap">`refract(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |I| `) -> ` |T|
-    <td>For the incident vector |e1| and surface normal |e2|, and the ratio of indices of refraction |e3|, 
-    let `k = 1.0 - `|e3|` * `|e3|` * (1.0 - dot(`|e2|`, `|e1|`) * dot(`|e2|`, `|e1|`))`. If `k < 0.0`, returns the 
-    refraction vector 0.0, otherwise return the refraction vector 
+    <td>For the incident vector |e1| and surface normal |e2|, and the ratio of indices of refraction |e3|,
+    let `k = 1.0 - `|e3|` * `|e3|` * (1.0 - dot(`|e2|`, `|e1|`) * dot(`|e2|`, `|e1|`))`. If `k < 0.0`, returns the
+    refraction vector 0.0, otherwise return the refraction vector
     |e3|` * `|e1|` - (`|e3|` * dot(`|e2|`, `|e1|`) + sqrt(k)) * `|e2|.
     (GLSLstd450Refract)
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4546,7 +4546,6 @@ multiplicative_expression
   | multiplicative_expression MODULO unary_expression
       OpUMOd
       OpSMod
-      OpFMod
 
 additive_expression
   : multiplicative_expression
@@ -6853,16 +6852,16 @@ That's not a full user-defined function declaration.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Fma)
 
-  <tr algorithm="fmod">
+  <tr algorithm="frem">
     <td>|T| is [FLOATING]
-    <td class="nowrap">`fmod(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
+    <td class="nowrap">`frem(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>Returns the floating point remainder of |e1| divided by |e2|, where sign of non-zero result matches sign of |e2|.
     [=Component-wise=] when |T| is a vector.
     (OpFMod)
 
-  <tr algorithm="frem">
+  <tr algorithm="fmod">
     <td>|T| is [FLOATING]
-    <td class="nowrap">`frem(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
+    <td class="nowrap">`fmod(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>Returns the floating point remainder of |e1| divided by |e2|, where sign of non-zero result matches sign of |e1|.
     [=Component-wise=] when |T| is a vector.
     (OpFRem)

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6858,6 +6858,8 @@ That's not a full user-defined function declaration.
     <td>Returns the floating point remainder of |e1| divided by |e2|, where sign of non-zero result matches sign of |e2|.
     [=Component-wise=] when |T| is a vector.
     (OpFMod)
+    <!-- Note: 'frem' mapping to 'OpFMod' is not a mistake. -->
+    <!-- See https://github.com/gpuweb/gpuweb/pull/1913#discussion_r669053280 -->
 
   <tr algorithm="fmod">
     <td>|T| is [FLOATING]
@@ -6865,6 +6867,8 @@ That's not a full user-defined function declaration.
     <td>Returns the floating point remainder of |e1| divided by |e2|, where sign of non-zero result matches sign of |e1|.
     [=Component-wise=] when |T| is a vector.
     (OpFRem)
+    <!-- Note: 'fmod' mapping to 'OpFRem' is not a mistake. -->
+    <!-- See https://github.com/gpuweb/gpuweb/pull/1913#discussion_r669053280 -->
 
   <tr algorithm="fract">
     <td>|T| is [FLOATING]


### PR DESCRIPTION
And remove operator `%` for floats.

Fixes: #1696