### PR TITLE
[wgsl]: Remove scalar overloads of `faceForward` and `reflect`

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6837,10 +6837,9 @@ That's not a full user-defined function declaration.
     (GLSLstd450Exp2)
 
   <tr algorithm="faceForward">
-    <td>|T| is [FLOATING]
+    <td>|T| is vec|N|&lt;f32&gt;
     <td class="nowrap">`faceForward(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T| `) -> ` |T|
     <td>Returns |e1| if `dot(`|e2|`,`|e3|`)` is negative, and `-`|e1| otherwise.
-    [=Component-wise=] when |T| is a vector.
     (GLSLstd450FaceForward)
 
   <tr algorithm="floor">
@@ -6965,19 +6964,18 @@ That's not a full user-defined function declaration.
     (GLSLstd450Pow)
 
   <tr algorithm="reflect">
-    <td>|T| is [FLOATING]
+    <td>|T| is vec|N|&lt;f32&gt;
     <td class="nowrap">`reflect(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>For the incident vector |e1| and surface orientation |e2|, returns the reflection direction
     |e1|`-2*dot(`|e2|`,`|e1|`)*`|e2|.
-    [=Component-wise=] when |T| is a vector.
     (GLSLstd450Reflect)
 
   <tr algorithm="refract">
     <td>|T| is vec|N|&lt;f32&gt;<br>I is f32
     <td class="nowrap">`refract(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |I| `) -> ` |T|
-    <td>For the incident vector |e1| and surface normal |e2|, and the ratio of indices of refraction |e3|, 
-    let `k = 1.0 - `|e3|` * `|e3|` * (1.0 - dot(`|e2|`, `|e1|`) * dot(`|e2|`, `|e1|`))`. If `k < 0.0`, returns the 
-    refraction vector 0.0, otherwise return the refraction vector 
+    <td>For the incident vector |e1| and surface normal |e2|, and the ratio of indices of refraction |e3|,
+    let `k = 1.0 - `|e3|` * `|e3|` * (1.0 - dot(`|e2|`, `|e1|`) * dot(`|e2|`, `|e1|`))`. If `k < 0.0`, returns the
+    refraction vector 0.0, otherwise return the refraction vector
     |e3|` * `|e1|` - (`|e3|` * dot(`|e2|`, `|e1|`) + sqrt(k)) * `|e2|.
     (GLSLstd450Refract)
 


### PR DESCRIPTION
MSL does not have scalar overloads for these, as they have little practical use for scalar arguments.

Note: MSL also does not have scalar overloads for `distance` or `length`, but these make some sense in scalar form, and might be useful if we supported generic / templated functions.