### PR TITLE
[wgsl] Improve the Memory Layout sections

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1493,7 +1493,7 @@ Structure members must not overlap. If a structure member is decorated with the
 size of the member's type:
 
 <p algorithm="member size constraint">
-  [=SizeOfMember=](|S|, M<sub>N</sub>) >= [=SizeOf=](T)<br>
+  [=SizeOfMember=](|S|, M<sub>N</sub>) &ge; [=SizeOf=](T)<br>
   Where |T| is the type of member M<sub>N</sub>.
 </p>
 
@@ -1753,15 +1753,17 @@ multiple of the [=RequiredAlignOf=](|T|, |C|) for the storage class |C|:
     Where |k| is a non-negative integer
 </p>
 
-Note: It is not required for [=AlignOf=](|T|) to be a multiple of [=RequiredAlignOf=](|T|, |C|),
-nor for a [=align=] decoration on a member of type |T| to be a multiple of [=RequiredAlignOf=](|T|, |C|),
-so long as each value of type |T| has a byte offset from the start of the structure that is a
-multiple of [=RequiredAlignOf=](|T|, |C|).
+Note: [=RequiredAlignOf=](|T|, |C|) does not impose any additional restrictions
+on the values permitted for an [=align=] decoration, nor does it affect the rules
+of [=AlignOf=](|T|). Data is laid out with the rules defined in previous
+sections and then the resulting layout is validated against the
+[=RequiredAlignOf=](|T|, |C|) rules.
 
 The [=storage classes/uniform=] storage class also requires that:
 * Array elements are aligned to 16 byte boundaries.
-* The number of bytes between a start of a structure member of a structure type `S` and
-    the next structure member must be at least [=roundUp=](16, [=SizeOf=](S)).
+* If a structure member itself has a structure type `S`, then the number of
+    bytes between the start of that member and the start of any following member
+    must be at least [=roundUp=](16, [=SizeOf=](S)).
 
 <div class='example wgsl global-scope' heading='invalid structure layout for uniform storage class'>
   <xmp highlight='rust'>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1358,18 +1358,17 @@ The terms defined in this section express counts of 8-bit bytes.
 
 We will use the following notation:
 * <dfn noexport>AlignOf</dfn>(|T|) is the alignment of host-shareable type |T|.
-* AlignOf(|S|, |M|) is the alignment of member |M| of the host-shareable structure |S|.
+* <dfn noexport>AlignOfMember</dfn>(|S|, |M|) is the alignment of member |M| of the host-shareable structure |S|.
 * <dfn noexport>SizeOf</dfn>(|T|) is the size of host-shareable type |T|.
-* SizeOf(|S|, |M|) is the size of member |M| of the host-shareable structure |S|.
+* <dfn noexport>SizeOfMember</dfn>(|S|, |M|) is the size of member |M| of the host-shareable structure |S|.
 * <dfn noexport>StrideOf</dfn>(|A|) is the element stride of host-shareable array type |A|.
-* <dfn noexport>OffsetOf</dfn>(|S|, |M|) is the offset of member |M| from the start of the host-shareable structure |S|.
+* <dfn noexport>OffsetOfMember</dfn>(|S|, |M|) is the offset of member |M| from the start of the host-shareable structure |S|.
 
 
 #### Alignment and Size ####  {#alignment-and-size}
 
-Each [=host-shareable=] data type has a default alignment and size value.
-The alignment and size values for a given structure member can differ from the
-defaults if the [=attribute/align=] and / or [=attribute/size=] decorations are used.
+Each [=host-shareable=] data type |T| has an alignment and size value, denoted
+by [=AlignOf=](|T|) and [=SizeOf=](|T|), respectively.
 
 Alignment guarantees that a value's address in memory will be a multiple of the
 specified value. This can enable more efficient hardware instructions to be used
@@ -1390,7 +1389,7 @@ following table:
 
 <table class='data'>
   <caption>
-    Default alignment and size for host-shareable types<br>
+    Alignment and size for host-shareable types<br>
   </caption>
   <thead>
     <tr><th>Host-shareable type |T|
@@ -1441,8 +1440,8 @@ following table:
       <td>16
       <td>64
   <tr><td>struct |S|
-      <td>max([=AlignOf=](S, M<sub>1</sub>), ... , [=AlignOf=](S, M<sub>n</sub>))<br>
-      <td>[=roundUp=]([=AlignOf=](|S|), [=OffsetOf=](|S|, |L|) + [=SizeOf=](|S|, |L|))<br><br>
+      <td>max([=AlignOfMember=](S, M<sub>1</sub>), ... , [=AlignOfMember=](S, M<sub>N</sub>))<br>
+      <td>[=roundUp=]([=AlignOf=](|S|), [=OffsetOfMember=](|S|, |L|) + [=SizeOfMember=](|S|, |L|))<br><br>
           Where |L| is the last member of the structure
   <tr><td>array<|E|, |N|><br>
       <p class="small">(Implicit stride)</p>
@@ -1467,37 +1466,48 @@ following table:
 
 #### Structure Layout Rules ####  {#structure-layout-rules}
 
-Each structure member has a default size and alignment value. These values are
-used to calculate each member's byte offset from the start of the structure.
+Each structure |S| member M<sub>N</sub> has a size and alignment value, denoted
+by [=SizeOfMember=](|S|, M<sub>N</sub>) and [=AlignOfMember=](|S|, M<sub>N</sub>), respectively.
+The member sizes and alignments are used to calculate each member's byte offset from the start of the structure.
 
-Structure members will use their type's size and alignment, unless the
-structure member is explicitly annotated with [=attribute/size=] and / or
-[=attribute/align=].  decorations, in which case those member decorations take
-precedence.
+Structures member size and alignment values default to the member type `T`'s
+[=SizeOf=](T) and [=AlignOf=](T) values.
+
+If a structure member is decorated with the [=attribute/size=] decoration, then the structure
+member will use the value of the decoration for its size instead of its type's size.
+
+If a structure member is decorated with the [=attribute/align=] decoration, then the structure
+member will use the value of the decoration for its alignment instead of its type's alignment.
 
 The first structure member always has a zero byte offset from the start of the
 structure.
 
 Subsequent members have the following byte offset from the start of the structure:
 <p algorithm="structure member offset">
-  [=OffsetOf=](|S|, M<sub>N</sub>) = [=roundUp=]([=AlignOf=](|S|, M<sub>N</sub>), [=OffsetOf=](|S|, M<sub>N-1</sub>) + [=SizeOf=](|S|, M<sub>N-1</sub>)<br>
+  [=OffsetOfMember=](|S|, M<sub>N</sub>) = [=roundUp=]([=AlignOfMember=](|S|, M<sub>N</sub>), [=OffsetOfMember=](|S|, M<sub>N-1</sub>) + [=SizeOfMember=](|S|, M<sub>N-1</sub>)<br>
   Where M<sub>N</sub> is the current member and M<sub>N-1</sub> is the previous member
 </p>
 
 Structure members must not overlap. If a structure member is decorated with the
 [=attribute/size=] attribute, the value must be at least as large as the
-default size of the member's type.
+size of the member's type:
+
+<p algorithm="member size constraint">
+  [=SizeOfMember=](|S|, M<sub>N</sub>) >= [=SizeOf=](T)<br>
+  Where |T| is the type of member M<sub>N</sub>.
+</p>
+
 
 The alignment of a structure is equal to the largest alignment of all of its
 members:
 <p algorithm="structure alignment">
-  [=AlignOf=](|S|) = max([=AlignOf=](|S|, M<sub>1</sub>), ... , [=AlignOf=](|S|, M<sub>N</sub>))
+  [=AlignOf=](|S|) = max([=AlignOfMember=](|S|, M<sub>1</sub>), ... , [=AlignOfMember=](|S|, M<sub>N</sub>))
 </p>
 
 The size of a structure is equal to the offset plus the size of its last member,
 rounded to the next multiple of the structure's alignment:
 <p algorithm="structure size">
-  [=SizeOf=](|S|) = [=roundUp=]([=AlignOf=](|S|), [=OffsetOf=](|S|, |L|) + [=SizeOf=](|S|, |L|))<br>
+  [=SizeOf=](|S|) = [=roundUp=]([=AlignOf=](|S|), [=OffsetOfMember=](|S|, |L|) + [=SizeOfMember=](|S|, |L|))<br>
   Where |L| is the last member of the structure
 </p>
 
@@ -1673,7 +1683,7 @@ then:
 
 When a value of structure type |S| is placed at byte offset |k| of a host-shared memory buffer,
 then:
-   * The |i|'<sup>th</sup> member of the structure value is placed at byte offset |k| + [=OffsetOf=](|S|,|i|)
+   * The |i|'<sup>th</sup> member of the structure value is placed at byte offset |k| + [=OffsetOfMember=](|S|,|i|)
 
 
 #### Storage Class Layout Constraints ####  {#storage-class-layout-constraints}
@@ -1686,7 +1696,8 @@ must obey the constraints of the variable's storage class.
 Violations of a storage class constraint result in a compile-time error.
 
 In this section we define <dfn noexport>RequiredAlignOf</dfn>(|S|, |C|) as the
-required alignment of host-shareable type |S| when used by storage class |C|.
+required byte offset alignment of values of host-shareable type |S| when
+used by storage class |C|.
 
 <table class='data'>
   <caption>
@@ -1730,9 +1741,13 @@ structure that is a multiple of the [=RequiredAlignOf=](|T|, |C|) for the storag
 class |C|:
 
 <p algorithm="structure member minimum alignment">
-    [=OffsetOf=](|S|, |M|) = |k| &times; [=RequiredAlignOf=](|T|, C)<br>
+    [=OffsetOfMember=](|S|, |M|) = |k| &times; [=RequiredAlignOf=](|T|, C)<br>
     Where |k| is a non-negative integer and |M| is a member of structure |S| with type |T|
 </p>
+
+Note: It is not required for [=AlignOf=](|T|) to be a multiple of [=RequiredAlignOf=](|T|, |C|),
+nor for a [=align=] decoration on a member of type |T| to be a multiple of [=RequiredAlignOf=](|T|, |C|),
+so long as each value of type |T| has a byte offset that is a multiple of [=RequiredAlignOf=](|T|, |C|).
 
 All arrays of element type |T| must have an element [=stride=] that is a
 multiple of [=RequiredAlignOf=](|T|, |C|) for the storage class |C|:
@@ -1746,12 +1761,8 @@ multiple of [=RequiredAlignOf=](|T|, |C|) for the storage class |C|:
 The [=storage classes/uniform=] storage class also requires that:
 
 * Array elements are aligned to 16 byte boundaries.
-
-Note: When underlying the target is a Vulkan device, we assume the device does
-not support the `scalarBlockLayout` feature.
-Therefore, a data value must not be placed in the padding at the end of a structure or matrix,
-nor in the padding at the last element of an array.
-Counting such padding as part of the size allows [SHORTNAME] to capture this constraint.
+* The number of bytes between a start of a structure member of a structure type `S`
+    and the next structure member must be at least [=roundUp=](16, [=SizeOf=](S)).
 
 ## Memory View Types ## {#memory-view-types}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1399,6 +1399,9 @@ following table:
   <tr><td>[=i32=], [=u32=], or [=f32=]
       <td>4
       <td>4
+  <tr><td>atomic&lt;|T|&gt;
+      <td>4
+      <td>4
   <tr><td>vec2&lt;|T|&gt;
       <td>8
       <td>8
@@ -1458,9 +1461,6 @@ following table:
   <tr><td>[[[=stride=](|Q|)]]<br> array<|E|>
       <td>[=AlignOf=](|E|)
       <td>N<sub>runtime</sub> * |Q|
-  <tr><td>atomic<|T|>
-      <td>[=AlignOf=](|T|)
-      <td>[=SizeOf=](|T|)
 </table>
 
 
@@ -1712,57 +1712,74 @@ used by storage class |C|.
   <tr><td>[=i32=], [=u32=], or [=f32=]
       <td>[=AlignOf=](|S|)
       <td>[=AlignOf=](|S|)
-  <tr><td>vec|N|&lt;`T`&gt;
+  <tr><td>atomic&lt;T&gt;
+      <td>[=AlignOf=](|S|)
+      <td>[=AlignOf=](|S|)
+  <tr><td>vecN&lt;T&gt;
       <td>[=AlignOf=](|S|)
       <td>[=AlignOf=](|S|)
   <tr algorithm="alignment of a matrix with N columns and M rows">
-      <td>mat|N|x|M|&lt;f32&gt;
+      <td>matNxM&lt;f32&gt;
       <td>[=AlignOf=](|S|)
       <td>[=AlignOf=](|S|)
   <tr algorithm="alignment of an array">
-      <td>array<|T|,|N|>
-      <td>[=AlignOf=](|T|)
-      <td>[=roundUp=](16, [=AlignOf=](|T|))
+      <td>array&lt;T, N&gt;
+      <td>[=AlignOf=](|S|)
+      <td>[=roundUp=](16, [=AlignOf=](|S|))
   <tr algorithm="alignment of an runtime-sized array">
-      <td>array<|T|>
-      <td>[=AlignOf=](|T|)
-      <td>[=roundUp=](16, [=AlignOf=](|T|))
+      <td>array&lt;T&gt;
+      <td>[=AlignOf=](|S|)
+      <td>[=roundUp=](16, [=AlignOf=](|S|))
   <tr algorithm="alignment of a structure">
-      <td>struct&lt;T<sub>0</sub>, ..., T<sub>N</sub>&gt;
-      <td>max([=AlignOf=](T<sub>0</sub>), ..., [=AlignOf=](T<sub>N</sub>))
-      <td>[=roundUp=](16, max([=AlignOf=](T<sub>0</sub>), ..., [=AlignOf=](T<sub>N</sub>)))<br>
-  <tr><td>atomic<|T|>
-      <td>[=AlignOf=](|T|)
-      <td>[=AlignOf=](|T|)
+      <td>struct |S|
+      <td>[=AlignOf=](|S|)
+      <td>[=roundUp=](16, [=AlignOf=](|S|))<br>
 </table>
 
-All structure members of type |T| must have a byte offset from the start of the
-structure that is a multiple of the [=RequiredAlignOf=](|T|, |C|) for the storage
-class |C|:
+Structure members of type |T| must have a byte offset
+from the start of the structure that is a multiple of the [=RequiredAlignOf=](|T|, |C|)
+for the storage class |C|:
 
 <p algorithm="structure member minimum alignment">
     [=OffsetOfMember=](|S|, |M|) = |k| &times; [=RequiredAlignOf=](|T|, C)<br>
     Where |k| is a non-negative integer and |M| is a member of structure |S| with type |T|
 </p>
 
-Note: It is not required for [=AlignOf=](|T|) to be a multiple of [=RequiredAlignOf=](|T|, |C|),
-nor for a [=align=] decoration on a member of type |T| to be a multiple of [=RequiredAlignOf=](|T|, |C|),
-so long as each value of type |T| has a byte offset that is a multiple of [=RequiredAlignOf=](|T|, |C|).
-
-All arrays of element type |T| must have an element [=stride=] that is a
-multiple of [=RequiredAlignOf=](|T|, |C|) for the storage class |C|:
+Arrays of element type |T| must have an element [=stride=] that is a
+multiple of the [=RequiredAlignOf=](|T|, |C|) for the storage class |C|:
 
 <p algorithm="array element minimum alignment">
     [=StrideOf=](array<|T|[, |N|]>) = |k| &times; [=RequiredAlignOf=](|T|, C)<br>
     Where |k| is a non-negative integer
 </p>
 
+Note: It is not required for [=AlignOf=](|T|) to be a multiple of [=RequiredAlignOf=](|T|, |C|),
+nor for a [=align=] decoration on a member of type |T| to be a multiple of [=RequiredAlignOf=](|T|, |C|),
+so long as each value of type |T| has a byte offset from the start of the structure that is a
+multiple of [=RequiredAlignOf=](|T|, |C|).
 
 The [=storage classes/uniform=] storage class also requires that:
-
 * Array elements are aligned to 16 byte boundaries.
-* The number of bytes between a start of a structure member of a structure type `S`
-    and the next structure member must be at least [=roundUp=](16, [=SizeOf=](S)).
+* The number of bytes between a start of a structure member of a structure type `S` and
+    the next structure member must be at least [=roundUp=](16, [=SizeOf=](S)).
+
+<div class='example wgsl global-scope' heading='invalid structure layout for uniform storage class'>
+  <xmp highlight='rust'>
+    struct S {
+      x: f32;
+    };
+    struct Invalid {
+      a: S;
+      b: f32; // invalid: offset between a and b is 4 bytes, but must be at least 16
+    };
+    struct Valid {
+      a: S;
+      [[align(16)]] b: f32; // valid: offset between a and b is 16 bytes
+    };
+    [[group(0), binding(0)]] var<uniform> invalid: Invalid;
+    [[group(0), binding(1)]] var<uniform> valid: Valid;
+  </xmp>
+</div>
 
 ## Memory View Types ## {#memory-view-types}
 
@@ -6986,9 +7003,9 @@ That's not a full user-defined function declaration.
   <tr algorithm="refract">
     <td>|T| is vec|N|&lt;f32&gt;<br>I is f32
     <td class="nowrap">`refract(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |I| `) -> ` |T|
-    <td>For the incident vector |e1| and surface normal |e2|, and the ratio of indices of refraction |e3|, 
-    let `k = 1.0 - `|e3|` * `|e3|` * (1.0 - dot(`|e2|`, `|e1|`) * dot(`|e2|`, `|e1|`))`. If `k < 0.0`, returns the 
-    refraction vector 0.0, otherwise return the refraction vector 
+    <td>For the incident vector |e1| and surface normal |e2|, and the ratio of indices of refraction |e3|,
+    let `k = 1.0 - `|e3|` * `|e3|` * (1.0 - dot(`|e2|`, `|e1|`) * dot(`|e2|`, `|e1|`))`. If `k < 0.0`, returns the
+    refraction vector 0.0, otherwise return the refraction vector
     |e3|` * `|e1|` - (`|e3|` * dot(`|e2|`, `|e1|`) + sqrt(k)) * `|e2|.
     (GLSLstd450Refract)
 


### PR DESCRIPTION
* Rename the `AlignOf(S, M)` and `SizeOf(S, M)` notations to `AlignOfMember(S, M)` and `SizeOfMember(S, M)`. This makes it clearer that the alignment and size of a member is not the same as its type. It also lets us link to the definitions, which was not possible before due to the overloading with `AlignOf(T)` and `SizeOf(T)`.

* Attempt to clarify the distinction between member size / alignment vs member type size / alignment

* Drop more uses of 'default' from the type size / alignment.

* Improve the definition of `RequiredAlignOf`, and make it explicit that this is a restriction on the actual byte-offset of values, not a restriction on the values of AlignOf(T) or AlignOfMember(S, M).

* Replace the note about `scalarBlockLayout` with an explicit UBO rule that nothing must be packed at the end of structure with size rounded to 16 bytes. The note mentions 'padding' which has no mention elsewhere, and didn't really cover this SPIR-V UBO restriction.