### PR TITLE
Add canvas to GPUPresentationContext

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8101,6 +8101,8 @@ method of an {{HTMLCanvasElement}} instance by passing the string literal `'gpup
 <script type=idl>
 [Exposed=Window]
 interface GPUPresentationContext {
+    readonly attribute (HTMLCanvasElement or OffscreenCanvas) canvas;
+
     undefined configure(GPUPresentationConfiguration configuration);
     undefined unconfigure();
 
@@ -8109,13 +8111,17 @@ interface GPUPresentationContext {
 };
 </script>
 
+{{GPUPresentationContext}} has the following attributes:
+
+<dl dfn-type=attribute dfn-for=GPUPresentationContext>
+    : <dfn>canvas</dfn>
+    ::
+        The canvas this presentation context was created from.
+</dl>
+
 {{GPUPresentationContext}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUPresentationContext">
-    : <dfn>\[[canvas]]</dfn> of type {{HTMLCanvasElement}}.
-    ::
-        The canvas this presentation context was created from.
-
     : <dfn>\[[validConfiguration]]</dfn> of type boolean, initially `false`.
     ::
         Indicates if the presentation context currently has a valid configuration.
@@ -8162,7 +8168,7 @@ interface GPUPresentationContext {
                 {{GPUTexture/destroy()}} on |this|.{{GPUPresentationContext/[[currentTexture]]}}.
             1. Set |this|.{{GPUPresentationContext/[[currentTexture]]}} to `null`.
             1. Let |device| be |configuration|.{{GPUPresentationConfiguration/device}}.
-            1. Let |canvas| be |this|.{{GPUPresentationContext/[[canvas]]}}.
+            1. Let |canvas| be |this|.{{GPUPresentationContext/canvas}}.
             1. If |configuration|.{{GPUPresentationConfiguration/size}} is `undefined` set
                 |this|.{{GPUPresentationContext/[[size]]}} to [|canvas|.width, |canvas|.height, 1],
                 otherwise set |this|.{{GPUPresentationContext/[[size]]}} to
@@ -8262,7 +8268,7 @@ interface GPUPresentationContext {
         1. Let |imageContents| be
             [$get a copy of the image contents of a presentation context|a copy of the image contents$]
             of |context|.
-        1. Update |context|.{{GPUPresentationContext/[[canvas]]}} with |imageContents|.
+        1. Update |context|.{{GPUPresentationContext/canvas}} with |imageContents|.
         1. Call |context|.{{GPUPresentationContext/[[currentTexture]]}}.{{GPUTexture/destroy()}}.
     1. Set |context|.{{GPUPresentationContext/[[currentTexture]]}} to `null`.
 </div>
@@ -8297,7 +8303,7 @@ interface GPUPresentationContext {
         <div class=validusage>
             - |texture| must not be `null`.
             - |texture|.{{GPUTexture/[[destroyed]]}} must be false.
-            - If |context|.{{GPUPresentationContext/[[canvas]]}} is an {{OffscreenCanvas}},
+            - If |context|.{{GPUPresentationContext/canvas}} is an {{OffscreenCanvas}},
                 it must not be linked to a [=placeholder canvas element=].
 
                 Issue: If added, canvas must also not be `desynchronized`.
@@ -8368,7 +8374,7 @@ out this question just yet.
 A {{GPUPresentationContext}}'s {{GPUPresentationContext/[[size]]}} is set by the {{GPUPresentationConfiguration}}
 passed to {{GPUPresentationContext/configure()}}, and remains the same until {{GPUPresentationContext/configure()}}
 is called again with a new size. If a {{GPUPresentationConfiguration/size}} is not specified then the
-width and height attributes of the {{GPUPresentationContext}}.{{GPUPresentationContext/[[canvas]]}}
+width and height attributes of the {{GPUPresentationContext}}.{{GPUPresentationContext/canvas}}
 at the time {{GPUPresentationContext/configure()}} is called will be used. If
 {{GPUPresentationContext}}.{{GPUPresentationContext/[[size]]}} does not match the dimensions of the canvas
 the textures produced by the {{GPUPresentationContext}} will be scaled to fit the canvas element.


### PR DESCRIPTION
Every other `RenderingContext` type exposes the `canvas` that created it as read only attribute.
  - [CanvasRenderingContext2D](https://html.spec.whatwg.org/multipage/canvas.html#canvasrenderingcontext2d)
  - [WebGL(2)RenderingContext](https://www.khronos.org/registry/webgl/specs/latest/1.0/#context-canvas)
  - [ImageBitmapRenderingContext](https://html.spec.whatwg.org/multipage/canvas.html#imagebitmaprenderingcontext)

As such, the `GPUPresentationContext` should also expose it's `canvas` as a read only attribute for consistency.

Previously the canvas element that created the context was tracked as an internal slot. This change changes the internal slot an accessible attribute. Also, previously the internal slot was defined explicitly as an `HTMLCanvasElement` but then elsewhere in the spec checked to see if it was an instance of an `OffscreenCanvas`. This change allows the canvas to be either.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/1916.html" title="Last updated on Jul 7, 2021, 5:23 PM UTC (6f2899b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1916/73c5ac1...6f2899b.html" title="Last updated on Jul 7, 2021, 5:23 PM UTC (6f2899b)">Diff</a>