### PR TITLE
Fix inconsistency in draw call parameter name

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8704,7 +8704,7 @@ clip space positions for [[#primitive-clipping]], as well as other data for the
         This processing happens in parallel, and any side effects, such as
         writes into {{GPUBufferBindingType/"storage"|GPUBufferBindingType."storage"}} bindings,
         may happen in any order.
-        1. Let |instanceIndex| be |rawInstanceIndex| + |drawCall|.baseInstance.
+        1. Let |instanceIndex| be |rawInstanceIndex| + |drawCall|.firstInstance.
         1. For each non-`null` |vertexBufferLayout| in the list of |desc|.{{GPUVertexState/buffers}}:
             1. Let |i| be the index of the buffer layout in this list.
             1. Let |vertexBuffer| and |vertexBufferOffset| be the buffer and offset in


### PR DESCRIPTION
There was a lone reference to a `baseInstance` parameter on draw calls.
It's named `firstInstance` everywhere else.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/krockot/gpuweb/pull/1917.html" title="Last updated on Jul 7, 2021, 7:50 PM UTC (0822cc8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1917/8666061...krockot:0822cc8.html" title="Last updated on Jul 7, 2021, 7:50 PM UTC (0822cc8)">Diff</a>