### PR TITLE
Loosen pipeline fragment output validation

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4870,10 +4870,13 @@ dictionary GPUFragmentState: GPUProgrammableStage {
                 - |colorState|.{{GPUColorTargetState/blend}}.{{GPUBlendState/alpha}}
                     must be a [=valid GPUBlendComponent=].
             - |colorState|.{{GPUColorTargetState/writeMask}} must be &lt; 16.
-            - |descriptor|.{{GPUProgrammableStage/entryPoint}} must have a [=pipeline output=] value:
-                - with [=location=] attribute equal to the index of the |colorState|
-                    in the |descriptor|.{{GPUFragmentState/targets}} list
-                - has a type that is compatible with |colorState|.{{GPUColorTargetState/format}}.
+            - If |descriptor|.{{GPUProgrammableStage/entryPoint}} has a [=pipeline output=] value
+                with [=location=] attribute equal to the index of the |colorState|
+                in the |descriptor|.{{GPUFragmentState/targets}} list:
+                - The [=pipeline output=] type must be compatible with |colorState|.{{GPUColorTargetState/format}}.
+
+                Otherwise:
+                - |colorState|.{{GPUColorTargetState/writeMask}} must be 0.
 </div>
 
 <div algorithm>


### PR DESCRIPTION
This loosens validation so that fragment shaders do not need
to include an output location for color targets that cannot be written
to (have a writeMask of 0). This allows better shader reuse so that
the shader fragment outputs do not need to match the pipeline
color targets exactly if the pipeline does not intend to write
to those targets.

Resolves #1900


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/austinEng/gpuweb/pull/1918.html" title="Last updated on Jul 7, 2021, 9:59 PM UTC (daadec8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1918/f4e6260...austinEng:daadec8.html" title="Last updated on Jul 7, 2021, 9:59 PM UTC (daadec8)">Diff</a>