### PR TITLE
Validate configured context width/height is > 0

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8190,8 +8190,10 @@ interface GPUPresentationContext {
                             - |device| is a [=valid=] {{GPUDevice}}.
                             - [=Supported presentation context formats=] [=set/contains=]
                                 |configuration|.{{GPUPresentationConfiguration/format}}.
+                            - |this|.{{GPUPresentationContext/[[size]]}}.[=Extent3D/width=] &gt; 0.
                             - |this|.{{GPUPresentationContext/[[size]]}}.[=Extent3D/width=] &le;
                                 |device|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
+                            - |this|.{{GPUPresentationContext/[[size]]}}.[=Extent3D/height=] &gt; 0.
                             - |this|.{{GPUPresentationContext/[[size]]}}.[=Extent3D/height=] &le;
                                 |device|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
                             - |this|.{{GPUPresentationContext/[[size]]}}.[=Extent3D/depthOrArrayLayers=]


### PR DESCRIPTION
Found that this edge case was causing problems in Chrome. Given that this is already a limitation in `createTexture()` it makes sense to mirror it here. (Alternately, if we consider the fact that `createTexture()` already validates this sufficient then we should probably remove the `maxTextureDimension2D` validation as well, since it's also duplicated in `createTexture()`.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/1919.html" title="Last updated on Jul 8, 2021, 5:42 PM UTC (9e0dc7d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1919/2fe61c0...9e0dc7d.html" title="Last updated on Jul 8, 2021, 5:42 PM UTC (9e0dc7d)">Diff</a>