### PR TITLE
wgsl: fix typo on zero-valued vectors example

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3357,7 +3357,7 @@ Note: WGSL does not have zero expression for [=atomic types=],
     vec2<f32>()                 // The zero-valued vector of two f32 elements.
     vec2<f32>(0.0, 0.0)         // The same value, written explicitly.
 
-    vec3<i32>()                 // The zero-valued vector of four i32 elements.
+    vec3<i32>()                 // The zero-valued vector of three i32 elements.
     vec3<i32>(0, 0, 0)          // The same value, written explicitly.
   </xmp>
 </div>


### PR DESCRIPTION
Just what it says on the tin :)