### PR TITLE
[wgsl] Add `textureNumLevels` overload for texture_1d

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7345,6 +7345,7 @@ If the number of layers (elements) of the array texture.
 Returns the number of mip levels of a texture.
 
 ```rust
+textureNumLevels(t: texture_1d<T>) -> i32
 textureNumLevels(t: texture_2d<T>) -> i32
 textureNumLevels(t: texture_2d_array<T>) -> i32
 textureNumLevels(t: texture_3d<T>) -> i32


### PR DESCRIPTION
This will always return 1, but provides symmetry with `textureLoad` which has a `level` parameter.