### PR TITLE
Rename GPUInputStepMode to GPUVertexStepMode

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5116,11 +5116,21 @@ The multi-component formats specify the number of components after "x".
 As such, {{GPUVertexFormat/"sint32x3"}} denotes a 3-component vector of `i32` values in the shader.
 
 <script type=idl>
-enum GPUInputStepMode {
+enum GPUVertexStepMode {
     "vertex",
     "instance"
 };
 </script>
+
+The step mode configures how an address for vertex buffer data is computed, based on the
+current vertex or instance index:
+<dl class="switch">
+    : {{GPUVertexStepMode/"vertex"}}
+    :: The address is advanced by {{GPUVertexBufferLayout/arrayStride}} for each vertex,
+        and reset between instances.
+    : {{GPUVertexStepMode/"instance"}}
+    :: The address is advanced by {{GPUVertexBufferLayout/arrayStride}} for each instance.
+</dl>
 
 <script type=idl>
 dictionary GPUVertexState: GPUProgrammableStage {
@@ -5144,7 +5154,7 @@ Every location must be unique within the {{GPUVertexState}}.
 <script type=idl>
 dictionary GPUVertexBufferLayout {
     required GPUSize64 arrayStride;
-    GPUInputStepMode stepMode = "vertex";
+    GPUVertexStepMode stepMode = "vertex";
     required sequence<GPUVertexAttribute> attributes;
 };
 </script>
@@ -7156,9 +7166,9 @@ enum GPUStoreOp {
                         - Let |stride| be |buffers|[|slot|].{{GPUVertexBufferLayout/arrayStride}}.
                         - If |buffers|[|slot|].{{GPUVertexBufferLayout/stepMode}} is:
                             <dl class="switch">
-                                : {{GPUInputStepMode/"vertex"}}
+                                : {{GPUVertexStepMode/"vertex"}}
                                 :: (|firstVertex| + |vertexCount|) * |stride| &le; |bufferSize|.
-                                : {{GPUInputStepMode/"instance"}}
+                                : {{GPUVertexStepMode/"instance"}}
                                 :: (|firstInstance| + |instanceCount|) * |stride| &le; |bufferSize|.
                             </dl>
                 </div>
@@ -7193,7 +7203,7 @@ enum GPUStoreOp {
                         &div; |this|.{{GPURenderEncoderBase/[[index_format]]}}'s byte size;
                     - Let |buffers| be |this|.{{GPURenderEncoderBase/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}.
                     - For each {{GPUIndex32}} |slot| `0` to |buffers|.length:
-                        - If |buffers|[|slot|].{{GPUVertexBufferLayout/stepMode}} is {{GPUInputStepMode/"instance"}}:
+                        - If |buffers|[|slot|].{{GPUVertexBufferLayout/stepMode}} is {{GPUVertexStepMode/"instance"}}:
                             - Let |bufferSize| be |this|.{{GPURenderEncoderBase/[[vertex_buffer_sizes]]}}[|slot|].
                             - Let |stride| be |buffers|[|slot|].{{GPUVertexBufferLayout/arrayStride}}.
                             - (|firstInstance| + |instanceCount|) * |stride| &le; |bufferSize|.
@@ -8725,9 +8735,9 @@ clip space positions for [[#primitive-clipping]], as well as other data for the
                 |state|.[=RenderState/vertexBuffers=] bindings at slot |i|
             1. Let |vertexElementIndex| be dependent on |vertexBufferLayout|.{{GPUVertexBufferLayout/stepMode}}:
                 <dl class="switch">
-                    : {{GPUInputStepMode/"vertex"}}
+                    : {{GPUVertexStepMode/"vertex"}}
                     :: |vertexIndex|
-                    : {{GPUInputStepMode/"instance"}}
+                    : {{GPUVertexStepMode/"instance"}}
                     :: |instanceIndex|
                 </dl>
             1. For each |attributeDesc| in |vertexBufferLayout|.{{GPUVertexBufferLayout/attributes}}:


### PR DESCRIPTION
Background: `GPUInputStepMode` is not a good name, since it's not about some ambiguous "input" but rather for vertex buffers specifically.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/1927.html" title="Last updated on Jul 13, 2021, 4:44 PM UTC (3ed82a2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1927/0717c2d...kvark:3ed82a2.html" title="Last updated on Jul 13, 2021, 4:44 PM UTC (3ed82a2)">Diff</a>