### PR TITLE
Require indirect draw calls use a firstInstance of 0

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7215,8 +7215,11 @@ enum GPUStoreOp {
             drawIndirectParameters[0] = vertexCount;
             drawIndirectParameters[1] = instanceCount;
             drawIndirectParameters[2] = firstVertex;
-            drawIndirectParameters[3] = firstInstance;
+            drawIndirectParameters[3] = 0; // firstInstance. Must be 0.
         </pre>
+
+        The value corresponding to `firstInstance` is reserved for future use and must be zero. If
+        it is not zero the {{GPURenderEncoderBase/drawIndirect()}} call will be treated as a no-op.
 
         <div algorithm="GPURenderEncoderBase.drawIndirect">
             **Called on:** {{GPURenderEncoderBase}} this.
@@ -7259,8 +7262,12 @@ enum GPUStoreOp {
             drawIndexedIndirectParameters[1] = instanceCount;
             drawIndexedIndirectParameters[2] = firstIndex;
             drawIndexedIndirectParameters[3] = baseVertex;
-            drawIndexedIndirectParameters[4] = firstInstance;
+            drawIndexedIndirectParameters[4] = 0; // firstInstance. Must be 0.
         </pre>
+
+        The value corresponding to `firstInstance` is reserved for future use and must be zero. If
+        it is not zero the {{GPURenderEncoderBase/drawIndexedIndirect()}} call will be treated as a
+        no-op.
 
         <div algorithm="GPURenderEncoderBase.drawIndexedIndirect">
             **Called on:** {{GPURenderEncoderBase}} this.
@@ -7288,6 +7295,10 @@ enum GPUStoreOp {
             </div>
         </div>
 </dl>
+
+Note: The ability to set a `firstInstance` for indirect draw calls is initially disabled to expand
+the hardware that supports WebGPU. It is likely to be added as a feature in the future along with
+other new indirect drawing features.
 
 <div algorithm>
     To determine if it's <dfn abstract-op>valid to draw</dfn> with {{GPURenderEncoderBase}} |encoder|


### PR DESCRIPTION
Fixes #1878

Could use a bit more "validation" at the queue level to make the no-op behavior explicit, but given that the whole spec needs to be better about that this didn't seem like the right place to start blazing that particular trail.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/1928.html" title="Last updated on Jul 13, 2021, 5:30 PM UTC (7daef36)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1928/0717c2d...7daef36.html" title="Last updated on Jul 13, 2021, 5:30 PM UTC (7daef36)">Diff</a>