### PR TITLE
Change context type to 'webgpu'

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1350,7 +1350,7 @@ For more information on issuing CORS requests for image and video elements, cons
 WebGPU does not provide color management. All values within WebGPU (such as texture elements)
 are raw numeric values, not color-managed color values.
 
-WebGPU *does* interface with color-managed outputs (via {{GPUContextConfiguration}}) and inputs
+WebGPU *does* interface with color-managed outputs (via {{GPUCanvasConfiguration}}) and inputs
 (via {{GPUQueue/copyExternalImageToTexture()}} and {{GPUDevice/importExternalTexture()}}).
 Color conversion must be performed between the WebGPU numeric values and the external color values.
 Each such interface point locally defines an encoding (color space, transfer function, and alpha
@@ -8156,7 +8156,7 @@ method of an {{HTMLCanvasElement}} instance by passing the string literal `'webg
 interface GPUCanvasContext {
     readonly attribute (HTMLCanvasElement or OffscreenCanvas) canvas;
 
-    undefined configure(GPUContextConfiguration configuration);
+    undefined configure(GPUCanvasConfiguration configuration);
     undefined unconfigure();
 
     GPUTextureFormat getPreferredFormat(GPUAdapter adapter);
@@ -8179,7 +8179,7 @@ interface GPUCanvasContext {
     ::
         Indicates if the context currently has a valid configuration.
 
-    : <dfn>\[[configuration]]</dfn> of type {{GPUContextConfiguration}}, initially `null`.
+    : <dfn>\[[configuration]]</dfn> of type {{GPUCanvasConfiguration}}, initially `null`.
     ::
         The options this context is configured with. `null` if the context has not been configured
         or the configuration has been removed.
@@ -8220,12 +8220,12 @@ interface GPUCanvasContext {
             1. If |this|.{{GPUCanvasContext/[[currentTexture]]}} is not `null` call
                 {{GPUTexture/destroy()}} on |this|.{{GPUCanvasContext/[[currentTexture]]}}.
             1. Set |this|.{{GPUCanvasContext/[[currentTexture]]}} to `null`.
-            1. Let |device| be |configuration|.{{GPUContextConfiguration/device}}.
+            1. Let |device| be |configuration|.{{GPUCanvasConfiguration/device}}.
             1. Let |canvas| be |this|.{{GPUCanvasContext/canvas}}.
-            1. If |configuration|.{{GPUContextConfiguration/size}} is `undefined` set
+            1. If |configuration|.{{GPUCanvasConfiguration/size}} is `undefined` set
                 |this|.{{GPUCanvasContext/[[size]]}} to [|canvas|.width, |canvas|.height, 1],
                 otherwise set |this|.{{GPUCanvasContext/[[size]]}} to
-                |configuration|.{{GPUContextConfiguration/size}}.
+                |configuration|.{{GPUCanvasConfiguration/size}}.
 
             1. Issue the following steps on the [=Device timeline=] of |device|:
                 <div class=device-timeline>
@@ -8233,7 +8233,7 @@ interface GPUCanvasContext {
                         <div class=validusage>
                             - |device| is a [=valid=] {{GPUDevice}}.
                             - [=Supported context formats=] [=set/contains=]
-                                |configuration|.{{GPUContextConfiguration/format}}.
+                                |configuration|.{{GPUCanvasConfiguration/format}}.
                             - |this|.{{GPUCanvasContext/[[size]]}}.[=Extent3D/width=] &gt; 0.
                             - |this|.{{GPUCanvasContext/[[size]]}}.[=Extent3D/width=] &le;
                                 |device|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
@@ -8366,7 +8366,7 @@ interface GPUCanvasContext {
     1. Ensure that all submitted work items (e.g. queue submissions) have
         completed writing to |texture|.
     1. Return the contents of |texture|, tagged as having alpha premultiplied, and with the color space
-        |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUContextConfiguration/colorSpace}}.
+        |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/colorSpace}}.
 
         Issue(gpuweb/gpuweb#1847): Does compositingAlphaMode=opaque make this return opaque contents?
 </div>
@@ -8375,16 +8375,16 @@ interface GPUCanvasContext {
     To <dfn abstract-op lt='allocating a new context texture'>allocate a new context texture</dfn>
     for {{GPUCanvasContext}} |context| run the following steps:
 
-        1. Let |device| be |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUContextConfiguration/device}}.
+        1. Let |device| be |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/device}}.
         1. If |context|.{{GPUCanvasContext/[[validConfiguration]]}} is `false`:
             1. Generate a {{GPUValidationError}} in the current scope of |device| with an appropriate error message.
             1. Return a new [=invalid=] {{GPUTexture}}.
         1. Let |textureDescriptor| be a new {{GPUTextureDescriptor}}.
         1. Set |textureDescriptor|.{{GPUTextureDescriptor/size}} to |context|.{{GPUCanvasContext/[[size]]}}.
         1. Set |textureDescriptor|.{{GPUTextureDescriptor/format}} to
-            |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUContextConfiguration/format}}.
+            |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/format}}.
         1. Set |textureDescriptor|.{{GPUTextureDescriptor/usage}} to
-            |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUContextConfiguration/usage}}.
+            |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/usage}}.
         1. Let |texture| be a new {{GPUTexture}} created as if |device|.{{GPUDevice/createTexture()}}
             were called with |textureDescriptor|.
             <div class='note'>If a previously presented texture from |context| matches the required criteria,
@@ -8393,11 +8393,11 @@ interface GPUCanvasContext {
         1. Return |texture|.
 </div>
 
-## GPUContextConfiguration ## {#canvas-configuration}
+## GPUCanvasConfiguration ## {#canvas-configuration}
 
 The <dfn dfn>supported context formats</dfn> are a [=set=] of {{GPUTextureFormat}}s that must be
-supported when specified as a {{GPUContextConfiguration}}.{{GPUContextConfiguration/format}}
-regardless of the given {{GPUContextConfiguration}}.{{GPUContextConfiguration/device}},
+supported when specified as a {{GPUCanvasConfiguration}}.{{GPUCanvasConfiguration/format}}
+regardless of the given {{GPUCanvasConfiguration}}.{{GPUCanvasConfiguration/device}},
 initially set to: &laquo;{{GPUTextureFormat/"bgra8unorm"}}, {{GPUTextureFormat/"bgra8unorm-srgb"}},
 {{GPUTextureFormat/"rgba8unorm"}}, {{GPUTextureFormat/"rgba8unorm-srgb"}}&raquo;.
 
@@ -8408,7 +8408,7 @@ enum GPUCanvasCompositingAlphaMode {
     "premultiplied",
 };
 
-dictionary GPUContextConfiguration {
+dictionary GPUCanvasConfiguration {
     required GPUDevice device;
     required GPUTextureFormat format;
     GPUTextureUsageFlags usage = 0x10;  // GPUTextureUsage.RENDER_ATTACHMENT
@@ -8425,9 +8425,9 @@ out this question just yet.
 
 ### Canvas Context sizing ### {#context-sizing}
 
-A {{GPUCanvasContext}}'s {{GPUCanvasContext/[[size]]}} is set by the {{GPUContextConfiguration}}
+A {{GPUCanvasContext}}'s {{GPUCanvasContext/[[size]]}} is set by the {{GPUCanvasConfiguration}}
 passed to {{GPUCanvasContext/configure()}}, and remains the same until {{GPUCanvasContext/configure()}}
-is called again with a new size. If a {{GPUContextConfiguration/size}} is not specified then the
+is called again with a new size. If a {{GPUCanvasConfiguration/size}} is not specified then the
 width and height attributes of the {{GPUCanvasContext}}.{{GPUCanvasContext/canvas}}
 at the time {{GPUCanvasContext/configure()}} is called will be used. If
 {{GPUCanvasContext}}.{{GPUCanvasContext/[[size]]}} does not match the dimensions of the canvas
@@ -8437,7 +8437,7 @@ the textures produced by the {{GPUCanvasContext}} will be scaled to fit the canv
     Note: Unlike `'webgl'` or `'2d'` contexts, `width` and `height` attributes of canvases with a
     `'webgpu'` context only affect:
     - Default layout size, if not overridden by CSS.
-    - Default {{GPUContextConfiguration}}.{{GPUContextConfiguration/size}} when calling
+    - Default {{GPUCanvasConfiguration}}.{{GPUCanvasConfiguration/size}} when calling
         {{GPUCanvasContext/configure()}}, if not overridden.
 </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1350,7 +1350,7 @@ For more information on issuing CORS requests for image and video elements, cons
 WebGPU does not provide color management. All values within WebGPU (such as texture elements)
 are raw numeric values, not color-managed color values.
 
-WebGPU *does* interface with color-managed outputs (via {{GPUPresentationConfiguration}}) and inputs
+WebGPU *does* interface with color-managed outputs (via {{GPUContextConfiguration}}) and inputs
 (via {{GPUQueue/copyExternalImageToTexture()}} and {{GPUDevice/importExternalTexture()}}).
 Color conversion must be performed between the WebGPU numeric values and the external color values.
 Each such interface point locally defines an encoding (color space, transfer function, and alpha
@@ -8135,28 +8135,28 @@ Issue: Because timestamp query provides high-resolution GPU timestamp, we need t
 
 ## {{HTMLCanvasElement/getContext()|HTMLCanvasElement.getContext()}} ## {#canvas-getcontext}
 
-A {{GPUPresentationContext}} object can be obtained via the {{HTMLCanvasElement/getContext()}}
-method of an {{HTMLCanvasElement}} instance by passing the string literal `'gpupresent'` as its
+A {{GPUCanvasContext}} object can be obtained via the {{HTMLCanvasElement/getContext()}}
+method of an {{HTMLCanvasElement}} instance by passing the string literal `'webgpu'` as its
 `contextType` argument.
 
 <div class="example">
-    Get a {{GPUPresentationContext}} from an offscreen {{HTMLCanvasElement}}:
+    Get a {{GPUCanvasContext}} from an offscreen {{HTMLCanvasElement}}:
     <pre highlight="js">
         const canvas = document.createElement('canvas');
-        const context = canvas.getContext('gpupresent');
+        const context = canvas.getContext('webgpu');
         context.configure(/* ... */);
         // ...
     </pre>
 </div>
 
-## GPUPresentationContext ## {#presentation-context}
+## GPUCanvasContext ## {#canvas-context}
 
 <script type=idl>
 [Exposed=(Window, DedicatedWorker)]
-interface GPUPresentationContext {
+interface GPUCanvasContext {
     readonly attribute (HTMLCanvasElement or OffscreenCanvas) canvas;
 
-    undefined configure(GPUPresentationConfiguration configuration);
+    undefined configure(GPUContextConfiguration configuration);
     undefined unconfigure();
 
     GPUTextureFormat getPreferredFormat(GPUAdapter adapter);
@@ -8164,83 +8164,83 @@ interface GPUPresentationContext {
 };
 </script>
 
-{{GPUPresentationContext}} has the following attributes:
+{{GPUCanvasContext}} has the following attributes:
 
-<dl dfn-type=attribute dfn-for=GPUPresentationContext>
+<dl dfn-type=attribute dfn-for=GPUCanvasContext>
     : <dfn>canvas</dfn>
     ::
-        The canvas this presentation context was created from.
+        The canvas this context was created from.
 </dl>
 
-{{GPUPresentationContext}} has the following internal slots:
+{{GPUCanvasContext}} has the following internal slots:
 
-<dl dfn-type=attribute dfn-for="GPUPresentationContext">
+<dl dfn-type=attribute dfn-for="GPUCanvasContext">
     : <dfn>\[[validConfiguration]]</dfn> of type boolean, initially `false`.
     ::
-        Indicates if the presentation context currently has a valid configuration.
+        Indicates if the context currently has a valid configuration.
 
-    : <dfn>\[[configuration]]</dfn> of type {{GPUPresentationConfiguration}}, initially `null`.
+    : <dfn>\[[configuration]]</dfn> of type {{GPUContextConfiguration}}, initially `null`.
     ::
-        The options this presentation context is configured with. `null` if the presentation
-        context has not been configured or the configuration has been removed.
+        The options this context is configured with. `null` if the context has not been configured
+        or the configuration has been removed.
 
     : <dfn>\[[size]]</dfn> of type {{GPUExtent3D}}
     ::
-        The size of {{GPUTexture}}s returned from this presentation context.
+        The size of {{GPUTexture}}s returned from this context.
         [=Extent3D/depthOrArrayLayers=] is always `1`.
 
     : <dfn>\[[currentTexture]]</dfn> of type {{GPUTexture}}?, initially `null`
     ::
-        The current texture that will be returned by the presentation context when calling
-        {{GPUPresentationContext/getCurrentTexture()}}, and the next one to be composited to the
-        document. Initially set to the result of [$allocating a new presentation context texture$]
-        for this presentation context.
+        The current texture that will be returned by the context when calling
+        {{GPUCanvasContext/getCurrentTexture()}}, and the next one to be composited to the
+        document. Initially set to the result of [$allocating a new context texture$] for this
+        context.
 </dl>
 
-{{GPUPresentationContext}} has the following methods:
+{{GPUCanvasContext}} has the following methods:
 
-<dl dfn-type=method dfn-for=GPUPresentationContext>
+<dl dfn-type=method dfn-for=GPUCanvasContext>
     : <dfn>configure(configuration)</dfn>
     ::
-        Configures the presentation context for this canvas. Destroys any textures produced with a
-        previous configuration.
+        Configures the context for this canvas. Destroys any textures produced with a previous
+        configuration.
 
-        <div algorithm="GPUPresentationContext.configure">
-            **Called on:** {{GPUPresentationContext}} |this|.
+        <div algorithm="GPUCanvasContext.configure">
+            **Called on:** {{GPUCanvasContext}} |this|.
 
             **Arguments:**
-            <pre class=argumentdef for="GPUPresentationContext/configure(configuration)">
-                |configuration|: Desired configuration for the presentation context.
+            <pre class=argumentdef for="GPUCanvasContext/configure(configuration)">
+                |configuration|: Desired configuration for the context.
             </pre>
 
             **Returns:** undefined
 
-            1. Set |this|.{{GPUPresentationContext/[[validConfiguration]]}} to `false`.
-            1. Set |this|.{{GPUPresentationContext/[[configuration]]}} to |configuration|.
-            1. If |this|.{{GPUPresentationContext/[[currentTexture]]}} is not `null` call
-                {{GPUTexture/destroy()}} on |this|.{{GPUPresentationContext/[[currentTexture]]}}.
-            1. Set |this|.{{GPUPresentationContext/[[currentTexture]]}} to `null`.
-            1. Let |device| be |configuration|.{{GPUPresentationConfiguration/device}}.
-            1. Let |canvas| be |this|.{{GPUPresentationContext/canvas}}.
-            1. If |configuration|.{{GPUPresentationConfiguration/size}} is `undefined` set
-                |this|.{{GPUPresentationContext/[[size]]}} to [|canvas|.width, |canvas|.height, 1],
-                otherwise set |this|.{{GPUPresentationContext/[[size]]}} to
-                |configuration|.{{GPUPresentationConfiguration/size}}.
+            1. Set |this|.{{GPUCanvasContext/[[validConfiguration]]}} to `false`.
+            1. Set |this|.{{GPUCanvasContext/[[configuration]]}} to |configuration|.
+            1. If |this|.{{GPUCanvasContext/[[currentTexture]]}} is not `null` call
+                {{GPUTexture/destroy()}} on |this|.{{GPUCanvasContext/[[currentTexture]]}}.
+            1. Set |this|.{{GPUCanvasContext/[[currentTexture]]}} to `null`.
+            1. Let |device| be |configuration|.{{GPUContextConfiguration/device}}.
+            1. Let |canvas| be |this|.{{GPUCanvasContext/canvas}}.
+            1. If |configuration|.{{GPUContextConfiguration/size}} is `undefined` set
+                |this|.{{GPUCanvasContext/[[size]]}} to [|canvas|.width, |canvas|.height, 1],
+                otherwise set |this|.{{GPUCanvasContext/[[size]]}} to
+                |configuration|.{{GPUContextConfiguration/size}}.
 
             1. Issue the following steps on the [=Device timeline=] of |device|:
                 <div class=device-timeline>
                     1. If any of the following conditions are unsatisfied:
                         <div class=validusage>
                             - |device| is a [=valid=] {{GPUDevice}}.
-                            - [=Supported presentation context formats=] [=set/contains=]
-                                |configuration|.{{GPUPresentationConfiguration/format}}.
-                            - |this|.{{GPUPresentationContext/[[size]]}}.[=Extent3D/width=] &gt; 0.
-                            - |this|.{{GPUPresentationContext/[[size]]}}.[=Extent3D/width=] &le;
+                            - [=Supported context formats=] [=set/contains=]
+                                |configuration|.{{GPUContextConfiguration/format}}.
+                            - |this|.{{GPUCanvasContext/[[size]]}}.[=Extent3D/width=] &gt; 0.
+                            - |this|.{{GPUCanvasContext/[[size]]}}.[=Extent3D/width=] &le;
                                 |device|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
-                            - |this|.{{GPUPresentationContext/[[size]]}}.[=Extent3D/height=] &gt; 0.
-                            - |this|.{{GPUPresentationContext/[[size]]}}.[=Extent3D/height=] &le;
+                            - |this|.{{GPUCanvasContext/[[size]]}}.[=Extent3D/height=] &gt; 0.
+                            - |this|.{{GPUCanvasContext/[[size]]}}.[=Extent3D/height=] &le;
                                 |device|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
-                            - |this|.{{GPUPresentationContext/[[size]]}}.[=Extent3D/depthOrArrayLayers=]
+                            - |this|.{{GPUCanvasContext/[[size]]}}.[=Extent3D/depthOrArrayLayers=]
                                 is 1;
                         </div>
 
@@ -8249,95 +8249,95 @@ interface GPUPresentationContext {
                                 error message.
                             1. Return.
                 </div>
-            1. Set |this|.{{GPUPresentationContext/[[validConfiguration]]}} to `true`.
+            1. Set |this|.{{GPUCanvasContext/[[validConfiguration]]}} to `true`.
         </div>
 
     : <dfn>unconfigure()</dfn>
     ::
-        Removes the presentation context configuration. Destroys any textures produced while configured.
+        Removes the context configuration. Destroys any textures produced while configured.
 
-        <div algorithm="GPUPresentationContext.unconfigure">
-            **Called on:** {{GPUPresentationContext}} |this|.
+        <div algorithm="GPUCanvasContext.unconfigure">
+            **Called on:** {{GPUCanvasContext}} |this|.
 
             **Returns:** undefined
 
-            1. Set |this|.{{GPUPresentationContext/[[validConfiguration]]}} to `false`.
-            1. Set |this|.{{GPUPresentationContext/[[configuration]]}} to `null`.
-            1. If |this|.{{GPUPresentationContext/[[currentTexture]]}} is not `null` call
-                {{GPUTexture/destroy()}} on |this|.{{GPUPresentationContext/[[currentTexture]]}}.
-            1. Set |this|.{{GPUPresentationContext/[[currentTexture]]}} to `null`.
+            1. Set |this|.{{GPUCanvasContext/[[validConfiguration]]}} to `false`.
+            1. Set |this|.{{GPUCanvasContext/[[configuration]]}} to `null`.
+            1. If |this|.{{GPUCanvasContext/[[currentTexture]]}} is not `null` call
+                {{GPUTexture/destroy()}} on |this|.{{GPUCanvasContext/[[currentTexture]]}}.
+            1. Set |this|.{{GPUCanvasContext/[[currentTexture]]}} to `null`.
         </div>
 
     : <dfn>getPreferredFormat(adapter)</dfn>
     ::
-        Returns an optimal {{GPUTextureFormat}} to use with this presentation context and devices
-        created from the given adapter.
+        Returns an optimal {{GPUTextureFormat}} to use with this context and devices created from
+        the given adapter.
 
-        <div algorithm="GPUPresentationContext.getPreferredFormat">
-            **Called on:** {{GPUPresentationContext}} this.
+        <div algorithm="GPUCanvasContext.getPreferredFormat">
+            **Called on:** {{GPUCanvasContext}} this.
 
             **Arguments:**
-            <pre class=argumentdef for="GPUPresentationContext/getPreferredFormat(adapter)">
+            <pre class=argumentdef for="GPUCanvasContext/getPreferredFormat(adapter)">
                 |adapter|: Adapter the format should be queried for.
             </pre>
 
             **Returns:** {{GPUTextureFormat}}
 
             <div class=content-timeline>
-                1. Return an optimal {{GPUTextureFormat}} to use when calling {{GPUPresentationContext/configure()}}
-                    with the given |adapter|. Must be one of the [=supported presentation context formats=].
+                1. Return an optimal {{GPUTextureFormat}} to use when calling {{GPUCanvasContext/configure()}}
+                    with the given |adapter|. Must be one of the [=supported context formats=].
             </div>
         </div>
 
     : <dfn>getCurrentTexture()</dfn>
     ::
-        Get the {{GPUTexture}} that will be composited to the document by the {{GPUPresentationContext}}
+        Get the {{GPUTexture}} that will be composited to the document by the {{GPUCanvasContext}}
         next.
 
-        <div algorithm="GPUPresentationContext.getCurrentTexture">
-            **Called on:** {{GPUPresentationContext}} |this|.
+        <div algorithm="GPUCanvasContext.getCurrentTexture">
+            **Called on:** {{GPUCanvasContext}} |this|.
 
             **Returns:** {{GPUTexture}}
 
-            1. If |this|.{{GPUPresentationContext/[[configuration]]}} is `null`:
+            1. If |this|.{{GPUCanvasContext/[[configuration]]}} is `null`:
                 1. Throw an {{OperationError}} and stop.
-            1. If |this|.{{GPUPresentationContext/[[currentTexture]]}} is `null` or
-                |this|.{{GPUPresentationContext/[[currentTexture]]}}.{{GPUTexture/[[destroyed]]}} is true:
-                1. Set |this|.{{GPUPresentationContext/[[currentTexture]]}} to the result of [$allocating a
-                    new presentation context texture$] for |this|.
-            1. Return |this|.{{GPUPresentationContext/[[currentTexture]]}}.
+            1. If |this|.{{GPUCanvasContext/[[currentTexture]]}} is `null` or
+                |this|.{{GPUCanvasContext/[[currentTexture]]}}.{{GPUTexture/[[destroyed]]}} is true:
+                1. Set |this|.{{GPUCanvasContext/[[currentTexture]]}} to the result of [$allocating
+                    a new context texture$] for |this|.
+            1. Return |this|.{{GPUCanvasContext/[[currentTexture]]}}.
         </div>
 
         Note: Developers can expect that the same {{GPUTexture}} object will be returned by every
-        call to {{GPUPresentationContext/getCurrentTexture()}} made within the same frame (i.e. between
-        invocations of [=Update the rendering=]) unless {{GPUPresentationContext/configure()}} is called.
+        call to {{GPUCanvasContext/getCurrentTexture()}} made within the same frame (i.e. between
+        invocations of [=Update the rendering=]) unless {{GPUCanvasContext/configure()}} is called.
 </dl>
 
 <div algorithm>
     During the "update the rendering [of the] `Document`" step of the "[=Update the rendering=]"
-    HTML processing model, each {{GPUPresentationContext}} |context| must <dfn abstract-op>present the
-    presentation context content to the canvas</dfn> by running the following steps:
+    HTML processing model, each {{GPUCanvasContext}} |context| must <dfn abstract-op>present the
+    context content to the canvas</dfn> by running the following steps:
 
-    1. If |context|.{{GPUPresentationContext/[[currentTexture]]}} is not `null` and
-        |context|.{{GPUPresentationContext/[[currentTexture]]}}.{{GPUTexture/[[destroyed]]}} is `false`:
+    1. If |context|.{{GPUCanvasContext/[[currentTexture]]}} is not `null` and
+        |context|.{{GPUCanvasContext/[[currentTexture]]}}.{{GPUTexture/[[destroyed]]}} is `false`:
         1. Let |imageContents| be
-            [$get a copy of the image contents of a presentation context|a copy of the image contents$]
+            [$get a copy of the image contents of a context|a copy of the image contents$]
             of |context|.
-        1. Update |context|.{{GPUPresentationContext/canvas}} with |imageContents|.
-        1. Call |context|.{{GPUPresentationContext/[[currentTexture]]}}.{{GPUTexture/destroy()}}.
-    1. Set |context|.{{GPUPresentationContext/[[currentTexture]]}} to `null`.
+        1. Update |context|.{{GPUCanvasContext/canvas}} with |imageContents|.
+        1. Call |context|.{{GPUCanvasContext/[[currentTexture]]}}.{{GPUTexture/destroy()}}.
+    1. Set |context|.{{GPUCanvasContext/[[currentTexture]]}} to `null`.
 </div>
 
 <div algorithm="transferToImageBitmap from WebGPU">
     When {{OffscreenCanvas/transferToImageBitmap()}} is called on a canvas with
-    {{GPUPresentationContext}} |context|:
+    {{GPUCanvasContext}} |context|:
 
     1. Let |imageContents| be
-        [$get a copy of the image contents of a presentation context|a copy of the image contents$]
+        [$get a copy of the image contents of a context|a copy of the image contents$]
         of |context|.
-    1. If |context|.{{GPUPresentationContext/[[currentTexture]]}} is not `null`:
-        1. Call |context|.{{GPUPresentationContext/[[currentTexture]]}}.{{GPUTexture/destroy()}}.
-    1. Set |context|.{{GPUPresentationContext/[[currentTexture]]}} to `null`.
+    1. If |context|.{{GPUCanvasContext/[[currentTexture]]}} is not `null`:
+        1. Call |context|.{{GPUCanvasContext/[[currentTexture]]}}.{{GPUTexture/destroy()}}.
+    1. Set |context|.{{GPUCanvasContext/[[currentTexture]]}} to `null`.
     1. Return a new {{ImageBitmap}} containing the |imageContents|.
 </div>
 
@@ -8345,20 +8345,20 @@ interface GPUPresentationContext {
     When WebGPU canvas contents are read using other Web APIs, like
     {{CanvasDrawImage/drawImage()}}, `texImage2D()`, `texSubImage2D()`,
     {{HTMLCanvasElement/toDataURL()}}, {{HTMLCanvasElement/toBlob()}}, and so on,
-    they <dfn abstract-op>get a copy of the image contents of a presentation context</dfn>:
+    they <dfn abstract-op>get a copy of the image contents of a context</dfn>:
 
     **Arguments:**
-    |context|: the {{GPUPresentationContext}}
+    |context|: the {{GPUCanvasContext}}
 
     **Returns:** image contents
 
-    1. Let |texture| be |context|.{{GPUPresentationContext/[[currentTexture]]}}.
+    1. Let |texture| be |context|.{{GPUCanvasContext/[[currentTexture]]}}.
     1. If any of the following requirements is unmet, return a transparent black image of size
-        |context|.{{GPUPresentationContext/[[size]]}} and stop.
+        |context|.{{GPUCanvasContext/[[size]]}} and stop.
         <div class=validusage>
             - |texture| must not be `null`.
             - |texture|.{{GPUTexture/[[destroyed]]}} must be false.
-            - If |context|.{{GPUPresentationContext/canvas}} is an {{OffscreenCanvas}},
+            - If |context|.{{GPUCanvasContext/canvas}} is an {{OffscreenCanvas}},
                 it must not be linked to a [=placeholder canvas element=].
 
                 Issue: If added, canvas must also not be `desynchronized`.
@@ -8366,26 +8366,25 @@ interface GPUPresentationContext {
     1. Ensure that all submitted work items (e.g. queue submissions) have
         completed writing to |texture|.
     1. Return the contents of |texture|, tagged as having alpha premultiplied, and with the color space
-        |context|.{{GPUPresentationContext/[[configuration]]}}.{{GPUPresentationConfiguration/colorSpace}}.
+        |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUContextConfiguration/colorSpace}}.
 
         Issue(gpuweb/gpuweb#1847): Does compositingAlphaMode=opaque make this return opaque contents?
 </div>
 
 <div algorithm>
-    To <dfn abstract-op lt='allocating a new presentation context texture'>allocate a new
-    presentation context texture</dfn>
-    for {{GPUPresentationContext}} |context| run the following steps:
+    To <dfn abstract-op lt='allocating a new context texture'>allocate a new context texture</dfn>
+    for {{GPUCanvasContext}} |context| run the following steps:
 
-        1. Let |device| be |context|.{{GPUPresentationContext/[[configuration]]}}.{{GPUPresentationConfiguration/device}}.
-        1. If |context|.{{GPUPresentationContext/[[validConfiguration]]}} is `false`:
+        1. Let |device| be |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUContextConfiguration/device}}.
+        1. If |context|.{{GPUCanvasContext/[[validConfiguration]]}} is `false`:
             1. Generate a {{GPUValidationError}} in the current scope of |device| with an appropriate error message.
             1. Return a new [=invalid=] {{GPUTexture}}.
         1. Let |textureDescriptor| be a new {{GPUTextureDescriptor}}.
-        1. Set |textureDescriptor|.{{GPUTextureDescriptor/size}} to |context|.{{GPUPresentationContext/[[size]]}}.
+        1. Set |textureDescriptor|.{{GPUTextureDescriptor/size}} to |context|.{{GPUCanvasContext/[[size]]}}.
         1. Set |textureDescriptor|.{{GPUTextureDescriptor/format}} to
-            |context|.{{GPUPresentationContext/[[configuration]]}}.{{GPUPresentationConfiguration/format}}.
+            |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUContextConfiguration/format}}.
         1. Set |textureDescriptor|.{{GPUTextureDescriptor/usage}} to
-            |context|.{{GPUPresentationContext/[[configuration]]}}.{{GPUPresentationConfiguration/usage}}.
+            |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUContextConfiguration/usage}}.
         1. Let |texture| be a new {{GPUTexture}} created as if |device|.{{GPUDevice/createTexture()}}
             were called with |textureDescriptor|.
             <div class='note'>If a previously presented texture from |context| matches the required criteria,
@@ -8394,11 +8393,11 @@ interface GPUPresentationContext {
         1. Return |texture|.
 </div>
 
-## GPUPresentationConfiguration ## {#presentation-configuration}
+## GPUContextConfiguration ## {#canvas-configuration}
 
-The <dfn dfn>supported presentation context formats</dfn> are a [=set=] of {{GPUTextureFormat}}s
-that must be supported when specified as a {{GPUPresentationConfiguration}}.{{GPUPresentationConfiguration/format}}
-regardless of the given {{GPUPresentationConfiguration}}.{{GPUPresentationConfiguration/device}},
+The <dfn dfn>supported context formats</dfn> are a [=set=] of {{GPUTextureFormat}}s that must be
+supported when specified as a {{GPUContextConfiguration}}.{{GPUContextConfiguration/format}}
+regardless of the given {{GPUContextConfiguration}}.{{GPUContextConfiguration/device}},
 initially set to: &laquo;{{GPUTextureFormat/"bgra8unorm"}}, {{GPUTextureFormat/"bgra8unorm-srgb"}},
 {{GPUTextureFormat/"rgba8unorm"}}, {{GPUTextureFormat/"rgba8unorm-srgb"}}&raquo;.
 
@@ -8409,7 +8408,7 @@ enum GPUCanvasCompositingAlphaMode {
     "premultiplied",
 };
 
-dictionary GPUPresentationConfiguration {
+dictionary GPUContextConfiguration {
     required GPUDevice device;
     required GPUTextureFormat format;
     GPUTextureUsageFlags usage = 0x10;  // GPUTextureUsage.RENDER_ATTACHMENT
@@ -8424,35 +8423,35 @@ or clamped-srgb. However, when we add HDR canvas output (representing pixel valu
 we need to choose which of those two is the default. Currently the upstream specs haven't worked
 out this question just yet.
 
-### Presentation Context sizing ### {#presentation-context-sizing}
+### Canvas Context sizing ### {#context-sizing}
 
-A {{GPUPresentationContext}}'s {{GPUPresentationContext/[[size]]}} is set by the {{GPUPresentationConfiguration}}
-passed to {{GPUPresentationContext/configure()}}, and remains the same until {{GPUPresentationContext/configure()}}
-is called again with a new size. If a {{GPUPresentationConfiguration/size}} is not specified then the
-width and height attributes of the {{GPUPresentationContext}}.{{GPUPresentationContext/canvas}}
-at the time {{GPUPresentationContext/configure()}} is called will be used. If
-{{GPUPresentationContext}}.{{GPUPresentationContext/[[size]]}} does not match the dimensions of the canvas
-the textures produced by the {{GPUPresentationContext}} will be scaled to fit the canvas element.
+A {{GPUCanvasContext}}'s {{GPUCanvasContext/[[size]]}} is set by the {{GPUContextConfiguration}}
+passed to {{GPUCanvasContext/configure()}}, and remains the same until {{GPUCanvasContext/configure()}}
+is called again with a new size. If a {{GPUContextConfiguration/size}} is not specified then the
+width and height attributes of the {{GPUCanvasContext}}.{{GPUCanvasContext/canvas}}
+at the time {{GPUCanvasContext/configure()}} is called will be used. If
+{{GPUCanvasContext}}.{{GPUCanvasContext/[[size]]}} does not match the dimensions of the canvas
+the textures produced by the {{GPUCanvasContext}} will be scaled to fit the canvas element.
 
 <div class="note">
     Note: Unlike `'webgl'` or `'2d'` contexts, `width` and `height` attributes of canvases with a
-    `'gpupresent'` context only affect:
+    `'webgpu'` context only affect:
     - Default layout size, if not overridden by CSS.
-    - Default {{GPUPresentationConfiguration}}.{{GPUPresentationConfiguration/size}} when calling
-        {{GPUPresentationContext/configure()}}, if not overridden.
+    - Default {{GPUContextConfiguration}}.{{GPUContextConfiguration/size}} when calling
+        {{GPUCanvasContext/configure()}}, if not overridden.
 </div>
 
-If it is desired to match the dimensions of the canvas after it is resized, the {{GPUPresentationContext}}
-must be reconfigured by calling {{GPUPresentationContext/configure()}} again with the new dimensions.
+If it is desired to match the dimensions of the canvas after it is resized, the {{GPUCanvasContext}}
+must be reconfigured by calling {{GPUCanvasContext/configure()}} again with the new dimensions.
 
 <div class="example">
-    Reconfigure a {{GPUPresentationContext}} in response to canvas resize, monitored using
+    Reconfigure a {{GPUCanvasContext}} in response to canvas resize, monitored using
     [ResizeObserver](https://www.w3.org/TR/resize-observer/) to get the exact pixel dimensions of
     the canvas:
 
     <pre highlight="js">
         const canvas = document.createElement('canvas');
-        const context =  canvas.getContext('gpupresent');
+        const context =  canvas.getContext('webgpu');
 
         const resizeObserver = new ResizeObserver(entries => {
             for (const entry of entries) {
@@ -8474,7 +8473,7 @@ must be reconfigured by calling {{GPUPresentationContext/configure()}} again wit
 
 ## <dfn dfn-type=enum-value dfn-for=GPUCanvasCompositingAlphaMode>GPUCanvasCompositingAlphaMode</dfn> ## {#GPUCanvasCompositingAlphaMode}
 
-This enum selects how the contents of the canvas' presentation context will paint onto the page.
+This enum selects how the contents of the canvas' context will paint onto the page.
 
 <table class='data'>
     <thead>


### PR DESCRIPTION
Fixes #131

Updates the relevant string and interfaces, if `'webgpu'` is indeed the context type string that we go with. Given the concerns voiced in the thread about the verb 'present' or 'presentation' I also opted to revert back to `GPUCanvasContext` for the interface name, since that felt like it matched the new context type string a bit better. (Also, neither Firefox nor Chrome has adopted the interface name `GPUPresentationContext` yet so, hey! Less work!)

(Kai suggested "WebGPUCanvasContext" at some point, since it's not a GPU object in the same way that, say, a texture is. I don't mind that logic, and it would allow it to map more directly to `'webgpu'`, but it a distinction that probably not significant to developers and it would mean that this interface wouldn't get grouped with the others properly on, for example, pages that list interfaces alphabetically.)

Similarly I've renamed `GPUPresentationConfiguration` (previously `GPUSwapChainDescriptor`) to `GPUContextConfiguration`, though I'd be just as happy with `GPUCanvasConfiguration` or the verbose `GPUCanvasContextConfiguration` if anyone has strong a preference for either of those alternatives.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/1930.html" title="Last updated on Jul 13, 2021, 11:38 PM UTC (f367f23)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1930/4e3f29e...f367f23.html" title="Last updated on Jul 13, 2021, 11:38 PM UTC (f367f23)">Diff</a>