### PR TITLE
[wgsl] Add `textureDimensions(t: texture_1d<T>, level: i32)`

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7246,6 +7246,7 @@ Returns the dimensions of a texture, or texture's mip level in texels.
 
 ```rust
 textureDimensions(t: texture_1d<T>) -> i32
+textureDimensions(t: texture_1d<T>, level: i32) -> i32
 textureDimensions(t: texture_2d<T>) -> vec2<i32>
 textureDimensions(t: texture_2d<T>, level: i32) -> vec2<i32>
 textureDimensions(t: texture_2d_array<T>) -> vec2<i32>


### PR DESCRIPTION
Robustness will ensure that `level` is 0, but provides symmetry with `textureLoad` which has a `level` parameter.