### PR TITLE
wgsl: Properly reference IEEE 754

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -57,6 +57,15 @@ thead {
       "https://github.com/gpuweb/gpuweb"
     ]
   },
+  "IEEE-754":{
+    "href":"http://ieeexplore.ieee.org/servlet/opac?punumber=4610933",
+    "title":"IEEE Standard for Floating-Point Arithmetic",
+    "publisher":"Institute of Electrical and Electronics Engineers",
+    "isbn":"978-0-7381-5752-8",
+    "versions":["IEEE-754-2008","IEEE-754-1985"],
+    "id":"IEEE-754",
+    "date":"29 August 2008"
+  },
   "SPIR-V": {
     "authors": [
       "John Kessenich",
@@ -781,7 +790,7 @@ It uses a two's complementation representation, with the sign bit in the most si
 
 ### Floating Point Type ### {#floating-point-types}
 
-The <dfn noexport>f32</dfn> type is the set of 32-bit floating point values of the IEEE 754 binary32 (single precision) format.
+The <dfn noexport>f32</dfn> type is the set of 32-bit floating point values of the [[!IEEE-754|IEEE-754]] binary32 (single precision) format.
 See [[#floating-point-evaluation]] for details.
 
 ### Scalar Types ### {#scalar-types}
@@ -1648,7 +1657,7 @@ host-shared buffer, then:
 Note: Recall that [=i32=] uses twos-complement representation, so the sign bit
 is in bit position 31.
 
-A value |V| of type [=f32=] is represented in IEEE 754 binary32 format.
+A value |V| of type [=f32=] is represented in [[!IEEE-754|IEEE-754]] binary32 format.
 It has one sign bit, 8 exponent bits, and 23 fraction bits.
 When |V| is placed at byte offset |k| of host-shared buffer, then:
    * Byte |k| contains bits 0 through 7 of the fraction.
@@ -2342,10 +2351,10 @@ This is also known as the <dfn noexport>channel transfer function</dfn>, or CTF.
   <tr><td>8sint<td>8<td>signed integer |v| &isinv; {-128,...,127}<td>i32<td> |v|
   <tr><td>16uint<td>16<td>unsigned integer |v| &isinv; {0,...,65535}<td>u32<td> |v|
   <tr><td>16sint<td>16<td>signed integer |v| &isinv; {-32768,...,32767}<td>i32<td> |v|
-  <tr><td>16float<td>16<td>IEEE 754 16-bit floating point value |v|, with 1 sign bit, 5 exponent bits, 10 mantissa bits<td>f32<td>|v|
+  <tr><td>16float<td>16<td>[[!IEEE-754|IEEE-754]] binary16 16-bit floating point value |v|, with 1 sign bit, 5 exponent bits, 10 mantissa bits<td>f32<td>|v|
   <tr><td>32uint<td>32<td>32-bit unsigned integer value |v|<td>u32<td>|v|
   <tr><td>32sint<td>32<td>32-bit signed integer value |v|<td>i32<td>|v|
-  <tr><td>32float<td>32<td>IEEE 754 32-bit floating point value |v|<td>f32<td>|v|
+  <tr><td>32float<td>32<td>[[!IEEE-754|IEEE-754]] binary32 32-bit floating point value |v|<td>f32<td>|v|
 </table>
 
 The texel formats listed in the
@@ -5911,7 +5920,7 @@ the implementation can issue a clear diagnostic.
 
 <div class='example using extensions' heading="Using hypothetical extensions">
   <xmp>
-    // Enable a hypothetical IEEE binary16 floating point extension.
+    // Enable a hypothetical IEEE-754 binary16 floating point extension.
     enable f16;
 
     // Assuming the f16 extension enables use of the f16 type:
@@ -6109,7 +6118,7 @@ these functions must only be invoked in uniform control flow in a fragment shade
 
 ## Floating Point Evaluation ## {#floating-point-evaluation}
 
-[SHORTNAME] follows the IEEE 754 standard for floating point computation with
+[SHORTNAME] follows the [[!IEEE-754|IEEE-754]] standard for floating point computation with
 the following exceptions:
 * No floating point exceptions are generated.
 * Signaling NaNs may not be generated.
@@ -6251,6 +6260,15 @@ An implementation may reassociate and/or fuse operations if the optimization is
 at least as accurate as the original formulation.
 
 ### Floating point conversion ### {#floating-point-conversion}
+
+In this section, a floating point type may be any of:
+* The [=f32=] type in WGSL.
+* A hypothetical type corresponding to a binary format defined by the [[!IEEE-754|IEEE-754]]
+    floating point standard.
+
+    Note: The binary16 format is referenced in this way.
+
+Note: Recall that the [=f32=] WGSL type corresponds to the IEEE-754 binary32 format.
 
 When converting a floating point scalar value to an integral type:
 * If the original value is exactly representable in the destination type, then the result is that value.
@@ -6753,16 +6771,16 @@ That's not a full user-defined function declaration.
     vec|N|&lt;bool&gt; if |T| is a vector
 
     <td class="nowrap">`isNan(`|e|`) -> `|TR|
-    <td>Test for NaN according to IEEE.
+    <td>Test for NaN according to [[!IEEE-754|IEEE-754]].<br>
     [=Component-wise=] when |T| is a vector. (OpIsNan)
   <tr><td class="nowrap">`isInf(`|e|`) -> `|TR|
-    <td>Test for infinity according to IEEE.
+    <td>Test for infinity according to [[!IEEE-754|IEEE-754]].<br>
     [=Component-wise=] when |T| is a vector. (OpIsInf)
   <tr><td class="nowrap">`isFinite(`|e|`) -> `|TR|
-    <td>Test a finite value according to IEEE.
+    <td>Test a finite value according to [[!IEEE-754|IEEE-754]].<br>
     [=Component-wise=] when |T| is a vector.
   <tr><td class="nowrap">`isNormal(`|e|`) -> `|TR|
-    <td>Test a normal value according to IEEE.
+    <td>Test a normal value according to [[!IEEE-754|IEEE-754]].<br>
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="runtime-sized array length">
@@ -7900,11 +7918,11 @@ reduce a shader's memory bandwidth demand.
     <td class="nowrap">`pack2x16float`(|e|: vec2&lt;f32&gt;) -> u32
     <td>Converts two floating point values to half-precision floating point numbers, and then combines
         them into one one `u32` value.<br>
-        Component |e|[|i|] of the input is converted to a IEEE 754 binary16 value, which is then
+        Component |e|[|i|] of the input is converted to a [[!IEEE-754|IEEE-754]] binary16 value, which is then
         placed in bits
         16 &times; |i| through
         16 &times; |i| + 15 of the result.
-        See [[#floating-point-conversion]] for edge case behaviour.
+        See [[#floating-point-conversion]].
 </table>
 
 ## Data unpacking built-in functions ## {#unpack-builtin-functions}
@@ -7952,8 +7970,8 @@ reduce a shader's memory bandwidth demand.
         as a floating point value.<br>
         Component |i| of the result is the f32 representation of |v|,
         where |v| is the interpretation of bits 16&times;|i| through 16&times;|i|+15 of |e|
-        as an IEEE 754 binary16 value.
-        See [[#floating-point-conversion]] for edge case behaviour.
+        as an [[!IEEE-754|IEEE-754]] binary16 value.
+        See [[#floating-point-conversion]].
 </table>
 
 ## Synchronization built-in functions ## {#sync-builtin-functions}


### PR DESCRIPTION
Clarify that the floating point conversions section also
applies to a hypothetical type corresponding to IEEE 754 binary16.

This is needed already to describe pack2x16float and unpack2x16float,
and also reading/writing 16float channels in textures.