### PR TITLE
Fix module-scope constant declarations wrt type inference

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3018,6 +3018,7 @@ The name is available for use after the end of the declaration,
 until the end of the [SHORTNAME] program.
 
 A module-scope let-declared constant must be of [=constructible=] type.
+The type must always be specified.
 
 When the declaration has no attributes, an initializer expression must be present,
 and the name denotes the value of that expression.
@@ -3027,8 +3028,8 @@ and the name denotes the value of that expression.
     // The golden ratio.
     let golden: f32 = 1.61803398875;
 
-    // The second unit vector for three dimensions, with inferred type.
-    let e2 = vec3<i32>(0,1,0);
+    // The second unit vector for three dimensions.
+    let e2: vec3<i32> = vec3<i32>(0,1,0);
   </xmp>
 </div>
 


### PR DESCRIPTION
This reverts the part of #1679 which perhaps got in by accident?

Previously, we only agreed to infer types in local declarations, not module scopes. We also discussed type inference for global scope variables in #1550.

Also note that the current grammar doesn't allow module-scoped constants to omit types, anyway, so the examples are incorrect:
```
global_constant_decl
  : attribute_list* LET variable_ident_decl global_const_initializer?

variable_ident_decl
  : IDENT COLON attribute_list* type_decl
```

We can revisit this and discuss again, but we shouldn't have something in the spec that we didn't agree on.