### PR TITLE
wgsl: Change `operator%(f32,32)` to use `OpFRem`

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4143,7 +4143,9 @@ references to arrays. An array not behind a reference may only be indexed by a
   <tr algorithm="floating point remainder">
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [FLOATING]
     <td>|e1| `%` |e2| : |T|
-    <td>Floating point remainder, where sign of non-zero result matches sign of |e2|. [=Component-wise=] when |T| is a vector. (OpFMod)
+    <td>Floating point remainder, where sign of non-zero result matches sign of |e1|. [=Component-wise=] when |T| is a vector.<br>
+        Result equal to: |e1| - |e2| * trunc(|e1| / |e2|)<br>
+        (OpFRem)
 
 </table>
 
@@ -4620,7 +4622,7 @@ multiplicative_expression
   | multiplicative_expression MODULO unary_expression
       OpUMOd
       OpSMod
-      OpFMod
+      OpFRem
 
 additive_expression
   : multiplicative_expression


### PR DESCRIPTION
Instead of `OpFMod`.

Bug: #1696
See also: #1913