### PR TITLE
Simplify IO-shareable

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1211,9 +1211,7 @@ A type is <dfn dfn noexport>IO-shareable</dfn> if it is one of:
 
 * a [=scalar=] type
 * a [=numeric vector=] type
-* a [=matrix=] type
-* an [=array=] type, if its element type is IO-shareable, and the array is not [=runtime-sized=]
-* a [=structure=] type, if all its members are IO-shareable
+* a [=structure=] type, if all its members are [=scalars=] or [=numeric vectors=]
 
 The following kinds of values must be of IO-shareable type:
 
@@ -5588,7 +5586,7 @@ More precisely, the <dfn noexport>interface of a shader stage</dfn> consists of:
 
 The <dfn dfn>Entry point IO type</dfn>s include the following:
   - Built-in variables. See [[#builtin-inputs-outputs]].
-  - User-defined IO. See [[#user-data-attributes]]
+  - User-defined IO. See [[#user-defined-inputs-outputs]]
   - Structures containing only built-in variables and user-defined IO.
     The structure must not contain a nested structure.
 
@@ -5601,9 +5599,9 @@ A pipeline output is denoted by the return type of the entry point.
 Each pipeline input or output is one of:
 
 * A built-in variable. See [[#builtin-inputs-outputs]].
-* A user data attribute. See [[#user-data-attributes]].
+* A user-defined value. See [[#user-defined-inputs-outputs]].
 
-#### Built-in inputs and outputs #### {#builtin-inputs-outputs}
+#### Built-in Inputs and Outputs #### {#builtin-inputs-outputs}
 
 A <dfn noexport>built-in input variable</dfn> provides access to system-generated control information.
 The set of built-in inputs are listed in [[#builtin-variables]].
@@ -5641,13 +5639,14 @@ result type, then *F* must be a [=functions in a shader stage|function in a shad
 
 Issue: in Vulkan, builtin variables occoupy I/O location slots counting toward limits.
 
-#### User Data Attribute TODO #### {#user-data-attributes}
+#### User-defined Inputs and Outputs #### {#user-defined-inputs-outputs}
 
 User-defined data can be passed as input to the start of a pipeline, passed
 between stages of a pipeline or output from the end of a pipeline.
 User-defined IO must not be passed to [=compute=] shader entry points.
-User-defined IO must be [=numeric scalar=] or [=numeric vector=] types .
-All user defined IO must be assigned locations (See [[#input-output-locations]]).
+User-defined IO must be of [=numeric scalar=] or [=numeric vector=] type,
+or of a structure type whose members are numeric scalars or vectors.
+All user-defined IO must be assigned locations (See [[#input-output-locations]]).
 
 #### Interpolation #### {#interpolation}
 


### PR DESCRIPTION
Also clarify the types allowed for that user-defined IO.

Fixes: #1877