### PR TITLE
wgsl: tighten constraints on 'offset' param to texture sampling

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7525,10 +7525,9 @@ textureSample(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, array_
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  `offset` must be compile time constant, and may only be provided as a
-  [literal](#literals) or `const_expr` expression (e.g. `vec2<i32>(1, 2)`).<br>
+  The `offset` expression must be a `const_expr` expression (e.g. `vec2<i32>(1, 2)`).<br>
   Each `offset` component must be at least `-8` and at most `7`. Values outside
-  of this range will be treated as a compile time error.
+  of this range will result in a [=shader-creation error=].
 </table>
 
 **Returns:**
@@ -7571,10 +7570,9 @@ textureSampleBias(t: texture_cube_array<f32>, s: sampler, coords: vec3<f32>, arr
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  `offset` must be compile time constant, and may only be provided as a
-  [literal](#literals) or `const_expr` expression (e.g. `vec2<i32>(1, 2)`).<br>
+  The `offset` expression must be a `const_expr` expression (e.g. `vec2<i32>(1, 2)`).<br>
   Each `offset` component must be at least `-8` and at most `7`. Values outside
-  of this range will be treated as a compile time error.
+  of this range will result in a [=shader-creation error=].
 </table>
 
 **Returns:**
@@ -7615,10 +7613,9 @@ textureSampleCompare(t: texture_depth_cube_array, s: sampler_comparison, coords:
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  `offset` must be compile time constant, and may only be provided as a
-  [literal](#literals) or `const_expr` expression (e.g. `vec2<i32>(1, 2)`).<br>
+  The `offset` expression must be a `const_expr` expression (e.g. `vec2<i32>(1, 2)`).<br>
   Each `offset` component must be at least `-8` and at most `7`. Values outside
-  of this range will be treated as a compile time error.
+  of this range will result in a [=shader-creation error=].
 </table>
 
 **Returns:**
@@ -7688,10 +7685,9 @@ textureSampleGrad(t: texture_cube_array<f32>, s: sampler, coords: vec3<f32>, arr
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  `offset` must be compile time constant, and may only be provided as a
-  [literal](#literals) or `const_expr` expression (e.g. `vec2<i32>(1, 2)`).<br>
+  The `offset` expression must be a `const_expr` expression (e.g. `vec2<i32>(1, 2)`).<br>
   Each `offset` component must be at least `-8` and at most `7`. Values outside
-  of this range will be treated as a compile time error.
+  of this range will result in a [=shader-creation error=].
 </table>
 
 **Returns:**
@@ -7743,10 +7739,9 @@ textureSampleLevel(t: texture_external, s: sampler, coords: vec2<f32>) -> vec4<f
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  `offset` must be compile time constant, and may only be provided as a
-  [literal](#literals) or `const_expr` expression (e.g. `vec2<i32>(1, 2)`).<br>
+  The `offset` expression must be a `const_expr` expression (e.g. `vec2<i32>(1, 2)`).<br>
   Each `offset` component must be at least `-8` and at most `7`. Values outside
-  of this range will be treated as a compile time error.
+  of this range will result in a [=shader-creation error=].
 </table>
 
 **Returns:**


### PR DESCRIPTION
Since the 1-d case doesn't exist, remove the 'literal' case.

Also, there's no clear meaning of "compile-time", so remove mentions
of that for "compile time constant" and also "compile time error".

Since all the info is known at shader creation time, say that using
an out-of-bounds value results in a shader-creation error.

Fixes: #1948