### PR TITLE
Clarify dispatch usage scope

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -864,9 +864,10 @@ This specification defines the following [=usage scopes=]:
     (e.g. {{GPUCommandEncoder/copyBufferToTexture()}}).
 - In a compute pass, each dispatch command ({{GPUComputePassEncoder/dispatch()}} or
     {{GPUComputePassEncoder/dispatchIndirect()}}) is one usage scope.
-    A subresource is "used" in the usage scope if it's accessible by the command.
-    Within a dispatch, every subresource in every currently bound {{GPUBindGroup}}
-    is "used" in the usage scope.
+    A subresource is "used" in the usage scope if it is potentially accessible by the command.
+    Within a dispatch, for each bind group slot that is used by the current {{GPUComputePipeline}}'s
+    {{GPUPipelineBase/[[layout]]}}, every [=subresource=] referenced by
+    that bind group is "used" in the usage scope.
     State-setting compute pass commands, like
     {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)}},
     do not contribute directly to a usage scope; they instead change the


### PR DESCRIPTION
Only the bind groups used by the current pipeline's layout - not all
currently-set bind groups - should be part of the usage scope.

Related test issue: https://crbug.com/dawn/997


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1954.html" title="Last updated on Jul 16, 2021, 1:27 AM UTC (03d0178)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1954/150002c...kainino0x:03d0178.html" title="Last updated on Jul 16, 2021, 1:27 AM UTC (03d0178)">Diff</a>