### PR TITLE
Require copyExternalImageToTexture canvases to be 2d/webgl/webgl2

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -69,6 +69,8 @@ spec: canvas; urlPrefix: https://html.spec.whatwg.org/multipage/canvas.html#
     type: dfn
         text: origin-clean; url: concept-canvas-origin-clean
         text: placeholder canvas element; url: offscreencanvas-placeholder
+        text: canvas context mode; url: concept-canvas-context-mode
+        text: OffscreenCanvas context mode; url: offscreencanvas-context-mode
 spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
     type: dfn
         text: location; url: input-output-locations
@@ -7879,6 +7881,10 @@ GPUQueue includes GPUObjectBase;
                     - {{GPUTextureFormat/"bgra8unorm-srgb"}}
                     - {{GPUTextureFormat/"rgb10a2unorm"}}
                     - {{GPUTextureFormat/"rg8unorm"}}
+                - If |source|.{{GPUImageCopyExternalImage/source}} is an {{HTMLCanvasElement}}:
+                    Its [=canvas context mode=] must be `"2d"`, `"webgl"`, or `"webgl2"`.
+                - If |source|.{{GPUImageCopyExternalImage/source}} is an {{OffscreenCanvas}}:
+                    Its [=OffscreenCanvas context mode=] must be `"2d"`, `"webgl"`, or `"webgl2"`.
             </div>
 
             Issue: The above list was written just for ImageBitmap.


### PR DESCRIPTION
Other overloads would have implementation burden, but would be of
minimal use to developers (especially since WebGPU allows using multiple
canvases from one GPUDevice), and can be added back later.

> I think of it this way: if we allowed webgpu->webgpu, we might be shipping a useless feature no one needs, and committing to maintaining it. Better to find out later that people _do_ need it, and add it, than to have an unnecessary feature in the platform.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jul 16, 2021, 2:40 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fgpuweb%2Fgpuweb%2F150002c024f98ec453bed00bec025b0db56aad26%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%231955.)._
</details>
