### PR TITLE
[wgsl] Fix parameter order of `select()`

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6244,7 +6244,7 @@ value with the same sign.
   <tr><td>`distance(x, y)`<td>Inherited from `length(x - y)`
   <tr><td>`exp(x)`<td>3 + 2 * |x| ULP
   <tr><td>`exp2(x)`<td>3 + 2 * |x| ULP
-  <tr><td class="nowrap">`faceForward(x, y, z)`<td>Inherited from `select(x, -x, dot(z, y) < 0.0)`
+  <tr><td class="nowrap">`faceForward(x, y, z)`<td>Inherited from `select(-x, x, dot(z, y) < 0.0)`
   <tr><td>`floor(x)`<td>Correctly rounded
   <tr><td>`fma(x, y, z)`<td>Inherited from `x * y + z`
   <tr><td>`fract(x)`<td>Correctly rounded
@@ -6775,15 +6775,15 @@ That's not a full user-defined function declaration.
     (OpAny)
 
   <tr algorithm="scalar select">
-    <td>|T| is a scalar or vector
-    <td>`select(`|T|`,`|T|`,bool)`: |T|
-    <td>`select(a,b,c)` evaluates to `a` when `c` is true, and `b` otherwise.
+    <td>|T| is a scalar
+    <td>`select(`|f|`: `|T|` , `|t|`: `|T|`, `|cond|`: bool)`: |T|
+    <td>Returns |t| when |cond| is true, and |f| otherwise.
     (OpSelect)
 
   <tr algorithm="vector select">
     <td>|T| is a scalar
-    <td>`select(vecN<`|T|`>,vecN<`|T|`>,vecN<bool>`: `vecN<`|T|`>`
-    <td>[=Component-wise=] selection. Result component |i| is evaluated as `select(a[`|i|`],b[`|i|`],c[`|i|`])`.
+    <td>`select(`|f|`: vecN<`|T|`>, `|t|`: vecN<`|T|`, `|cond|`: vecN<bool>>)`
+    <td>[=Component-wise=] selection. Result component |i| is evaluated as `select(`|f|`[`|i|`], `|t|`[`|i|`], `|cond|`[`|i|`])`.
     (OpSelect)
 </table>
 


### PR DESCRIPTION
The WGSL parameter order of `select()` was (`true-value`, `false-value`, `condition`)

`select()` across all the common shader languages either has the parameter order (`false-value`, `true-value`, `condition`), or the order reversed:

| language | op                     |
|----------|------------------------|
|MSL       | [`select(f, t, cond)`](https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf) |
|SPIR-V    | [`OpSelect(cond, t, f)`](https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#OpSelect) |
|GLSL      | [`cond ? t : f`](https://www.khronos.org/registry/OpenGL/specs/gl/GLSLangSpec.1.20.pdf) |
|HLSL      | [`cond ? t : f`](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-operators) |
|OpenCL    | [`select(f, t, cond)`](https://www.khronos.org/registry/OpenCL/sdk/1.1/docs/man/xhtml/select.html) |

Similarly, `mix()` behaves the same:
| language | op                     |
|----------|------------------------|
| WGSL     | [`mix(zero, one, s)`](https://www.w3.org/TR/WGSL/#float-builtin-functions) |
| GLSL     | [`mix(zero, one, s)`](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/mix.xhtml) |
| HLSL     | [`lerp(zero, one, s)`](https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-lerp) |

This PR changes the order to match the existing languages.