### PR TITLE
[wgsl] Fix definition of length and distance

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6893,9 +6893,8 @@ That's not a full user-defined function declaration.
 
   <tr algorithm="distance">
     <td>|T| is [FLOATING]
-    <td class="nowrap">`distance(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
+    <td class="nowrap">`distance(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` f32
     <td>Returns the distance between |e1| and |e2| (e.g. `length(`|e1|` - `|e2|`)`).
-    [=Component-wise=] when |T| is a vector.
     (GLSLstd450Distance)
 
   <tr algorithm="exp">
@@ -6972,9 +6971,8 @@ That's not a full user-defined function declaration.
 
   <tr algorithm="length">
     <td>|T| is [FLOATING]
-    <td class="nowrap">`length(`|e|`:` |T| `) -> ` |T|
+    <td class="nowrap">`length(`|e|`:` |T| `) -> ` f32
     <td>Returns the length of |e| (e.g. `abs(`|e|`)` if |T| is a scalar, or `sqrt(`|e|`[0]`<sup>`2`</sup> `+` |e|`[1]`<sup>`2`</sup> `+ ...)` if |T| is a vector).
-    [=Component-wise=] when |T| is a vector.
     (GLSLstd450Length)
 
   <tr algorithm="log">


### PR DESCRIPTION
These always return a scalar f32, and do not operate component wise.