### PR TITLE
Describe pipeline-renderpass compatibility

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7710,12 +7710,12 @@ dictionary GPURenderBundleEncoderDescriptor : GPUObjectDescriptorBase {
 </script>
 
 <div algorithm>
-<dfn abstract-op>derive render encoder descriptor from pass</dfn>
+    <dfn abstract-op>derive render encoder descriptor from pass</dfn>
 
-  **Arguments:**
+    **Arguments:**
     - {{GPURenderPassDescriptor}} |descriptor|
 
-  **Returns:** {{GPURenderBundleEncoderDescriptor}}
+    **Returns:** {{GPURenderBundleEncoderDescriptor}}
 
     1. Let |d| be a new {{GPURenderBundleEncoderDescriptor}} object.
     1. For each |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
@@ -7730,12 +7730,12 @@ dictionary GPURenderBundleEncoderDescriptor : GPUObjectDescriptorBase {
 </div>
 
 <div algorithm>
-<dfn abstract-op>derive render encoder descriptor from pipeline</dfn>
+    <dfn abstract-op>derive render encoder descriptor from pipeline</dfn>
 
-  **Arguments:**
+    **Arguments:**
     - {{GPURenderPipelineDescriptor}} |descriptor|
 
-  **Returns:** {{GPURenderBundleEncoderDescriptor}}
+    **Returns:** {{GPURenderBundleEncoderDescriptor}}
 
     1. Let |d| be a new {{GPURenderBundleEncoderDescriptor}} object.
     1. Set |d|.{{GPURenderBundleEncoderDescriptor/sampleCount}} to |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/count}}.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5464,6 +5464,9 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                             are considered to be used as [=internal usage/attachment-read=] for the duration of the render pass.
                     1. Else, the [=texture subresource=] seen by |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/view}}
                         is considered to be used as [=internal usage/attachment=] for the duration of the render pass.
+                1. Let |pass| be a new {{GPURenderPassEncoder}} object.
+                1. Set |pass|.{{GPURenderEncoderBase/[[descriptor]]}} to [$derive render encoder descriptor from pass$](|descriptor|).
+                1. Return |pass|.
             </div>
 
             Issue: specify the behavior of read-only depth/stencil
@@ -5492,6 +5495,8 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                         - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
                     </div>
                 1. Set |this|.{{GPUCommandEncoder/[[state]]}} to {{encoder state/encoding a compute pass}}.
+                1. Let |pass| be a new {{GPUComputePassEncoder}} object.
+                1. Return |pass|.
             </div>
         </div>
 </dl>
@@ -6729,6 +6734,10 @@ GPURenderPassEncoder includes GPURenderEncoderBase;
 {{GPURenderEncoderBase}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPURenderEncoderBase">
+    : <dfn>\[[descriptor]]</dfn>, of type {{GPURenderBundleEncoderDescriptor}}
+    ::
+        The render pass descriptor.
+
     : <dfn>\[[pipeline]]</dfn>, of type {{GPURenderPipeline}}
     ::
         The current {{GPURenderPipeline}}, initially `null`.
@@ -7058,13 +7067,15 @@ enum GPUStoreOp {
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
+                1. Let |pipelineEncoderDesc| be [$derive render encoder descriptor from pipeline$](|pipeline|.{{GPURenderPipeline/[[descriptor]]}}).
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |pipeline| is [$valid to use with$] |this|.
-
-                        Issue: Validate that |pipeline| is compatible with the render pass descriptor.
+                        - |this|.{{GPURenderEncoderBase/[[descriptor]]}} equals |pipelineEncoderDesc|.
                     </div>
                 1. Set |this|.{{GPURenderEncoderBase/[[pipeline]]}} to be |pipeline|.
+
+                Issue: check read-only depth/stencil versus the pipeline state
             </div>
         </div>
 
@@ -7663,16 +7674,28 @@ GPURenderBundleEncoder includes GPURenderEncoderBase;
         Creates a {{GPURenderBundleEncoder}}.
 
         <div algorithm=GPUDevice.createRenderBundleEncoder>
-            **Called on:** {{GPUDevice}} this.
+            **Called on:** {{GPUDevice}} |this|.
 
             **Arguments:**
             <pre class=argumentdef for="GPUDevice/createRenderBundleEncoder(descriptor)">
-                descriptor: Description of the {{GPURenderBundleEncoder}} to create.
+                |descriptor|: Description of the {{GPURenderBundleEncoder}} to create.
             </pre>
 
             **Returns:** {{GPURenderBundleEncoder}}
 
-            Issue: Describe {{GPUDevice/createRenderBundleEncoder()}} algorithm steps.
+            Issue the following steps on the [=Device timeline=] of |this|:
+            <div class=device-timeline>
+                1. If any of the following conditions are unsatisfied, generate a validation
+                    error and stop.
+                    <div class=validusage>
+                        Issue: Add remaining validation.
+                    </div>
+                1. Let |e| be a new {{GPURenderBundleEncoder}} object.
+                1. Set |e|.{{GPURenderEncoderBase/[[descriptor]]}} to |descriptor|.
+                1. Return |e|.
+
+                Issue: Describe the reset of the steps for {{GPUDevice/createRenderBundleEncoder()}}.
+            </div>
         </div>
 </dl>
 
@@ -7685,6 +7708,45 @@ dictionary GPURenderBundleEncoderDescriptor : GPUObjectDescriptorBase {
     GPUSize32 sampleCount = 1;
 };
 </script>
+
+<div algorithm>
+<dfn abstract-op>derive render encoder descriptor from pass</dfn>
+
+  **Arguments:**
+    - {{GPURenderPassDescriptor}} |descriptor|
+
+  **Returns:** {{GPURenderBundleEncoderDescriptor}}
+
+    1. Let |d| be a new {{GPURenderBundleEncoderDescriptor}} object.
+    1. For each |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
+        1. Set |d|.{{GPURenderBundleEncoderDescriptor/sampleCount}} to |colorAttachment|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}}.
+        1. Append |colorAttachment|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}} to |d|.{{GPURenderBundleEncoderDescriptor/colorFormats}}.
+    1. Let |depthStencilAttachment| be |descriptor|.{{GPURenderPassDescriptor/depthStencilAttachment}}.
+    1. If |depthStencilAttachment| is not `null`:
+        1. Set |d|.{{GPURenderBundleEncoderDescriptor/sampleCount}} to |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}}.
+        1. Set |d|.{{GPURenderBundleEncoderDescriptor/depthStencilFormat}} to |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
+    1. Return |d|.
+
+</div>
+
+<div algorithm>
+<dfn abstract-op>derive render encoder descriptor from pipeline</dfn>
+
+  **Arguments:**
+    - {{GPURenderPipelineDescriptor}} |descriptor|
+
+  **Returns:** {{GPURenderBundleEncoderDescriptor}}
+
+    1. Let |d| be a new {{GPURenderBundleEncoderDescriptor}} object.
+    1. Set |d|.{{GPURenderBundleEncoderDescriptor/sampleCount}} to |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/count}}.
+    1. If |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}} is not `null`:
+        1. Set |d|.{{GPURenderBundleEncoderDescriptor/depthStencilFormat}} to |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}/{{GPUDepthStencilState/format}}.
+    1. If |descriptor|.{{GPURenderPipelineDescriptor/fragment}} is not `null`:
+        1. For each |colorTarget| in |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.{{GPUFragmentState/targets}}:
+            1. Append |colorTarget|.{{GPUColorTargetState/format}} to |d|.{{GPURenderBundleEncoderDescriptor/colorFormats}}
+    1. Return |d|.
+
+</div>
 
 ### Finalization ### {#render-bundle-finalization}
 


### PR DESCRIPTION
Addresses the TODO item in the spec about pipeline vs render pass compatibility, which was discussed on the last call.

The way it's structured is by using `GPURenderBundleEncoderDescriptor` as the descriptor of pipeline compatibility.
As such, there are internal algorithms introduced to convert `GPURenderPipelineDescriptor` and `GPURenderPassDescriptor` into this least common denominator.

I'm not particularly attached to `GPURenderBundleEncoderDescriptor` as the name here - we could introduce a specific name for this concept instead, and define the conversion from `GPURenderBundleEncoderDescriptor` alternatively.

But generally I think it works very well for the spec: saying "this descriptor has to be equal to that other one" is way easier than actually writing all the prose about matching the fields of different descriptors.

TL;DR: when binding a render pipeline in a pass, the formats of all pipeline attachments must match exactly with the pass, and the sample count must match.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/1967.html" title="Last updated on Jul 20, 2021, 9:37 PM UTC (a0ebce7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1967/444482b...kvark:a0ebce7.html" title="Last updated on Jul 20, 2021, 9:37 PM UTC (a0ebce7)">Diff</a>