### PR TITLE
wgsl: Change `modf` and `frexp` to return a structure

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6946,15 +6946,15 @@ That's not a full user-defined function declaration.
   <tr algorithm="scalar case, frexp">
     <td>|T| is f32
     <td class="nowrap">`frexp(`|e|`: `|T|`) -> _frexp_result`<br>
-    <td>Splits |e| into a signficand and exponent of the form `significand * 2`<sup>`exponent`</sup>.
+    <td>Splits |e| into a significand and exponent of the form `significand * 2`<sup>`exponent`</sup>.
     Returns the `_frexp_result` built-in structure, defined as:
     ```rust
 struct _frexp_result {
-  sig : f32; // signficand part
+  sig : f32; // significand part
   exp : i32; // exponent part
 };
     ```
-    The magnitude of the signficand is in the range of [0.5, 1.0) or 0.
+    The magnitude of the significand is in the range of [0.5, 1.0) or 0.
 
     Note: A value cannot be explicitly declared with the type `_frexp_result`, but a value may infer the type.
 
@@ -6963,15 +6963,15 @@ struct _frexp_result {
   <tr algorithm="vector case, frexp">
     <td>|T| is vec|N|&lt;f32&gt;
     <td class="nowrap">`frexp(`|e|`: `|T|`) -> _frexp_result_vec`|N|<br>
-    <td>Splits the components of |e| into a signficand and exponent of the form `significand * 2`<sup>`exponent`</sup>.
+    <td>Splits the components of |e| into a significand and exponent of the form `significand * 2`<sup>`exponent`</sup>.
     Returns the `_frexp_result_vec`|N| built-in structure, defined as:
     ```rust
 struct _frexp_result_vecN {
-  sig : vecN<f32>; // signficand part
+  sig : vecN<f32>; // significand part
   exp : vecN<i32>; // exponent part
 };
     ```
-    The magnitude of each component of the signficand is in the range of [0.5, 1.0) or 0.
+    The magnitude of each component of the significand is in the range of [0.5, 1.0) or 0.
 
     Note: A value cannot be explicitly declared with the type `_frexp_result_vec`|N|, but a value may infer the type.
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6251,7 +6251,7 @@ value with the same sign.
   <tr><td>`floor(x)`<td>Correctly rounded
   <tr><td>`fma(x, y, z)`<td>Inherited from `x * y + z`
   <tr><td>`fract(x)`<td>Correctly rounded
-  <tr><td>`frexp(x, y)`<td>Correctly rounded
+  <tr><td>`frexp(x)`<td>Correctly rounded
   <tr><td>`inverseSqrt(x)`<td>2 ULP
   <tr><td>`ldexp(x, y)`<td>Correctly rounded
   <tr><td>`length(x)`<td>Inherited from `sqrt(dot(x, x))`
@@ -6260,7 +6260,7 @@ value with the same sign.
   <tr><td>`max(x, y)`<td>Correctly rounded
   <tr><td>`min(x, y)`<td>Correctly rounded
   <tr><td>`mix(x, y, z)`<td>Inherited from `x - (1.0 - z) + y * z`
-  <tr><td>`modf(x, y)`<td>Correctly rounded
+  <tr><td>`modf(x)`<td>Correctly rounded
   <tr><td>`normalize(x)`<td>Inherited from `x - length(x)`
   <tr><td>`pow(x, y)`<td>Inherited from `exp2(y * log2(x))`
   <tr><td>`reflect(x, y)`<td>Inherited from `x - 2.0 * dot(x, y) * y`
@@ -6943,19 +6943,39 @@ That's not a full user-defined function declaration.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450Fract)
 
-  <tr algorithm="frexp">
-    <td>|T| is [FLOATING]<br>
-        |I| is [SIGNEDINTEGRAL], where<br>
-        |I| is a scalar if |T| is a scalar, or<br>
-        a vector when |T| is a vector<br>
-        |SC| is a storage class<br>
-        |A| is [=access/write=] or [=access/read_write=]
-    <td class="nowrap">`frexp(`|e1|`:` |T| `, `|e2|`:` ptr&lt;|SC|,|I|,|A|&gt; `) -> ` |T|
-    <td>Splits |e1| into a signficand and exponent of the form `significand * 2`<sup>`exponent`</sup> and returns the significand.
+  <tr algorithm="scalar case, frexp">
+    <td>|T| is f32
+    <td class="nowrap">`frexp(`|e|`: `|T|`) -> _frexp_result`<br>
+    <td>Splits |e| into a signficand and exponent of the form `significand * 2`<sup>`exponent`</sup>.
+    Returns the `_frexp_result` built-in structure, defined as:
+    ```rust
+struct _frexp_result {
+  sig : f32; // signficand part
+  exp : i32; // exponent part
+};
+    ```
     The magnitude of the signficand is in the range of [0.5, 1.0) or 0.
-    The exponent is stored through the pointer |e2|.
-    [=Component-wise=] when |T| is a vector.
-    (GLSLstd450Frexp)
+
+    Note: A value cannot be explicitly declared with the type `_frexp_result`, but a value may infer the type.
+
+    (GLSLstd450FrexpStruct)
+
+  <tr algorithm="vector case, frexp">
+    <td>|T| is vec|N|&lt;f32&gt;
+    <td class="nowrap">`frexp(`|e|`: `|T|`) -> _frexp_result_vec`|N|<br>
+    <td>Splits the components of |e| into a signficand and exponent of the form `significand * 2`<sup>`exponent`</sup>.
+    Returns the `_frexp_result_vec`|N| built-in structure, defined as:
+    ```rust
+struct _frexp_result_vecN {
+  sig : vecN<f32>; // signficand part
+  exp : vecN<i32>; // exponent part
+};
+    ```
+    The magnitude of each component of the signficand is in the range of [0.5, 1.0) or 0.
+
+    Note: A value cannot be explicitly declared with the type `_frexp_result_vec`|N|, but a value may infer the type.
+
+    (GLSLstd450FrexpStruct)
 
   <tr algorithm="inverseSqrt">
     <td>|T| is [FLOATING]
@@ -7020,14 +7040,36 @@ That's not a full user-defined function declaration.
     (GLSLstd450FMix)
 
   <tr algorithm="scalar case, modf">
-    <td>|T| is [FLOATING]
-        |SC| is a storage class<br>
-        |A| is [=access/write=] or [=access/read_write=]
-    <td class="nowrap">`modf(`|e1|`:` |T| `, `|e2|`:` ptr&lt;|SC|,|T|,|A|&gt; `) -> ` |T|
-    <td>Splits |e1| into fractional and whole number parts.
-    Returns the fractional part and stores the whole number through the pointer |e2|.
-    [=Component-wise=] when |T| is a vector.
-    (GLSLstd450Modf)
+    <td>|T| is f32
+    <td class="nowrap">`modf(`|e|`: `|T|`) -> _modf_result`<br>
+    <td>Splits |e| into fractional and whole number parts.
+    Returns the `_modf_result` built-in structure, defined as:
+    ```rust
+struct _modf_result {
+  fract : f32; // fractional part
+  whole : f32; // whole part
+};
+    ```
+
+    Note: A value cannot be explicitly declared with the type `_modf_result`, but a value may infer the type.
+
+    (GLSLstd450ModfStruct)
+
+  <tr algorithm="vector case, modf">
+    <td>|T| is vec|N|&lt;f32&gt;
+    <td class="nowrap">`modf(`|e|`: `|T|`) -> _modf_result_vec`|N|<br>
+    <td>Splits the components of |e| into fractional and whole number parts.
+    Returns the `_modf_result_vec`|N| built-in structure, defined as:
+    ```rust
+struct _modf_result_vecN {
+  fract : vecN<f32>; // fractional part
+  whole : vecN<f32>; // whole part
+};
+    ```
+
+    Note: A value cannot be explicitly declared with the type `_modf_result_vec`|N|, but a value may infer the type.
+
+    (GLSLstd450ModfStruct)
 
   <tr algorithm="vector case, normalize">
     <td>|T| is f32


### PR DESCRIPTION
Each overload of these built-ins return a named structure, their name starting with a leading `_`.
The grammar for `IDENT` prevents these types from being explicitly used in WGSL, which allows the language to redefine these types at a later date.

Bug: #1480