### PR TITLE
Add mix(vec, vec, f32) overload

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7010,8 +7010,9 @@ That's not a full user-defined function declaration.
     (GLSLstd450NMin)
 
   <tr algorithm="mix">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`mix(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T|`) -> ` |T|
+    <td>|T| is [FLOATING]<br>
+        |U| is |T| or f32
+    <td class="nowrap">`mix(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |U|`) -> ` |T|
     <td>Returns the linear blend of |e1| and |e2| (e.g. |e1|`*(1-`|e3|`)+`|e2|`*`|e3|).
     [=Component-wise=] with |T| is a vector.
     (GLSLstd450FMix)


### PR DESCRIPTION
Fixes #1588

No strong feelings here. It seemed that there was an agreement to add it, hence I'm following up.