### PR TITLE
Stencil reads are S,X,X,X. (but expect S,S,S,S or S,0,0,1)

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2810,7 +2810,7 @@ or a 32-bit IEEE 754 floating point value ("depth32float").
 
 Issue: add something on GPUAdapter(?) that gives an estimate of the bytes per texel of "stencil8"
 
-The {{GPUTextureFormat/stencil8}}) format may be implemented as
+The {{GPUTextureFormat/stencil8}} format may be implemented as
 either a real "stencil8", or "depth24stencil8", where the depth aspect is
 hidden and inaccessible.
 
@@ -4019,7 +4019,7 @@ any specific point in the code at all.
     : <dfn>message</dfn>
     ::
         A human-readable string containing the message generated during the shader compilation.
-    
+
     : <dfn>type</dfn>
     ::
         The severity level of the message.
@@ -4029,7 +4029,7 @@ any specific point in the code at all.
         The line number in the shader {{GPUShaderModuleDescriptor/code}} the
         {{GPUCompilationMessage/message}} corresponds to. Value is one-based, such that a lineNum of
         `1` indicates the first line of the shader {{GPUShaderModuleDescriptor/code}}.
-        
+
         If the {{GPUCompilationMessage/message}} corresponds to a substring this points to
         the line on which the substring begins. Must be `0` if the {{GPUCompilationMessage/message}}
         does not correspond to any specific point in the shader {{GPUShaderModuleDescriptor/code}}.
@@ -9524,6 +9524,7 @@ None of the depth formats can be filtered.
             <th>Bytes per texel
             <th>Aspect
             <th>{{GPUTextureSampleType}}
+            <th>Returned in shaders as...
             <th>Copy aspect from Buffer
             <th>Copy aspect into Buffer
     </thead>
@@ -9532,37 +9533,51 @@ None of the depth formats can be filtered.
         <td>1 &minus; 4
         <td>stencil
         <td>{{GPUTextureSampleType/"uint"}}
+        <td>`vec4<u32>(S, X, X, X)`
         <td colspan=2>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/depth16unorm}}
         <td>2
         <td>depth
         <td>{{GPUTextureSampleType/"depth"}}
+        <td>`f32(D)`
         <td colspan=2>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/depth24plus}}
         <td>4
         <td>depth
         <td>{{GPUTextureSampleType/"depth"}}
+        <td>`f32(D)`
         <td colspan=2>&cross;
     <tr>
         <td rowspan=2 style='white-space:nowrap'>{{GPUTextureFormat/depth24plus-stencil8}}
         <td rowspan=2>4 &minus; 8
         <td>depth
         <td>{{GPUTextureSampleType/"depth"}}
+        <td>`f32(D)`
         <td colspan=2>&cross;
     <tr>
         <td>stencil
         <td>{{GPUTextureSampleType/"uint"}}
+        <td>`vec4<u32>(S, X, X, X)`
         <td colspan=2>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/depth32float}}
         <td>4
         <td>depth
         <td>{{GPUTextureSampleType/"depth"}}
+        <td>`f32(D)`
         <td colspan=1>&cross;
         <td colspan=1>&checkmark;
 </table>
+
+Stencil formats must sample as `vec4<u32>(S, X, X, X)`, where S is the stencil value and each X is an implementation-defined unspecified value.
+Authors must not rely on these `.y`, `.z`, and `.w` components, as their behavior is non-portable.
+
+Note:
+Short of adding a new more constrained stencil sampler type (like depth), it's infeasible for implementations to efficiently paper over the driver differences for stencil reads.
+As this was not a portability pain point for WebGL, it's not expected to be problematic in WebGPU.
+In practice, expect either `vec4<u32>(S, S, S, S)` or `vec4<u32>(S, 0, 0, 1)`, depending on hardware.
 
 <dfn dfn>Copies of depth and stencil textures</dfn> can only happen within the following sets of formats:
   - {{GPUTextureFormat/stencil8}}, {{GPUTextureFormat/depth24plus-stencil8}} (stencil component), {{GPUTextureFormat/r8uint}}


### PR DESCRIPTION
Closes #1198.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jdashg/gpuweb/pull/1978.html" title="Last updated on Aug 4, 2021, 5:11 PM UTC (7307ee0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1978/7439a4d...jdashg:7307ee0.html" title="Last updated on Aug 4, 2021, 5:11 PM UTC (7307ee0)">Diff</a>