### PR TITLE
Refactor the pipeline-pass compatibility and check RODS

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5514,11 +5514,12 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                         duration of the render pass.
                 1. Let |depthStencilAttachment| be |descriptor|.{{GPURenderPassDescriptor/depthStencilAttachment}}.
                 1. If |depthStencilAttachment| is not `null`:
-                    1. if |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} and
+                    1. Let |depthStencilView| be |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/view}}.
+                    1. If |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} and
                         {{GPURenderPassDepthStencilAttachment/stencilReadOnly}} are set
-                        1. The [=texture subresources=] seen by |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/view}}
+                        1. The [=texture subresources=] seen by |depthStencilView|
                             are considered to be used as [=internal usage/attachment-read=] for the duration of the render pass.
-                    1. Else, the [=texture subresource=] seen by |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/view}}
+                    1. Else, the [=texture subresource=] seen by |depthStencilView|
                         is considered to be used as [=internal usage/attachment=] for the duration of the render pass.
                 1. Let |pass| be a new {{GPURenderPassEncoder}} object.
                 1. Set |pass|.{{GPURenderEncoderBase/[[descriptor]]}} to [$derive render encoder descriptor from pass$](|descriptor|).
@@ -7058,17 +7059,19 @@ dictionary GPURenderPassDepthStencilAttachment {
     Given a {{GPURenderPassDepthStencilAttachment}} |this| the following validation
     rules apply:
 
-    1. |this|.{{GPURenderPassDepthStencilAttachment/view}} must have a [=depth or stencil renderable
+    - |this|.{{GPURenderPassDepthStencilAttachment/view}} must have a [=depth or stencil renderable
         format=].
-    1. |this|.{{GPURenderPassDepthStencilAttachment/view}} must be a view of a
+    - |this|.{{GPURenderPassDepthStencilAttachment/view}} must be a view of a
         single [=texture subresource=].
-    1. |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}}
+    - |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}}
         must contain {{GPUTextureUsage/RENDER_ATTACHMENT}}.
-    1. |this|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} is `true`,
-        |this|.{{GPURenderPassDepthStencilAttachment/depthLoadValue}} must be
-        {{GPULoadOp/"load"}} and |this|.{{GPURenderPassDepthStencilAttachment/depthStoreOp}}
-        must be {{GPUStoreOp/"store"}}.
-    1. |this|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}} is `true`,
+    - If |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}
+        contains both depth and stencil aspects (See [[#depth-formats|depth-stencil formats]]):
+        - |this|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} must be equal to |this|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}}
+    - If |this|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} is `true`:
+        - |this|.{{GPURenderPassDepthStencilAttachment/depthLoadValue}} must be {{GPULoadOp/"load"}}.
+        - |this|.{{GPURenderPassDepthStencilAttachment/depthStoreOp}} must be {{GPUStoreOp/"store"}}.
+    - If |this|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}} is `true`,
         |this|.{{GPURenderPassDepthStencilAttachment/stencilLoadValue}} must be
         {{GPULoadOp/"load"}} and |this|.{{GPURenderPassDepthStencilAttachment/stencilStoreOp}}
         must be {{GPUStoreOp/"store"}}.
@@ -7762,6 +7765,8 @@ dictionary GPURenderBundleEncoderDescriptor : GPUObjectDescriptorBase {
     required sequence<GPUTextureFormat> colorFormats;
     GPUTextureFormat depthStencilFormat;
     GPUSize32 sampleCount = 1;
+    boolean depthReadOnly = false;
+    boolean stencilReadOnly = false;
 };
 </script>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5522,7 +5522,7 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                     1. Else, the [=texture subresource=] seen by |depthStencilView|
                         is considered to be used as [=internal usage/attachment=] for the duration of the render pass.
                 1. Let |pass| be a new {{GPURenderPassEncoder}} object.
-                1. Set |pass|.{{GPURenderEncoderBase/[[descriptor]]}} to [$derive render encoder descriptor from pass$](|descriptor|).
+                1. Set |pass|.{{GPURenderEncoderBase/[[layout]]}} to [$derive render targets layout from pass$](|descriptor|).
                 1. Return |pass|.
             </div>
 
@@ -6791,9 +6791,9 @@ GPURenderPassEncoder includes GPURenderEncoderBase;
 {{GPURenderEncoderBase}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPURenderEncoderBase">
-    : <dfn>\[[descriptor]]</dfn>, of type {{GPURenderBundleEncoderDescriptor}}
+    : <dfn>\[[layout]]</dfn>, of type {{GPURenderTargetsLayout}}
     ::
-        The render pass descriptor.
+        The layout of the render targets.
 
     : <dfn>\[[pipeline]]</dfn>, of type {{GPURenderPipeline}}
     ::
@@ -7107,6 +7107,59 @@ enum GPUStoreOp {
 };
 </script>
 
+#### Render Targets Layout #### {#render-targets-layout}
+
+{{GPURenderTargetsLayout}} contains the layout of the render targets for the current pass,
+which determines the compatibility of the pass with render pipelines.
+
+<script type=idl>
+dictionary GPURenderTargetsLayout {
+    required sequence<GPUTextureFormat> colorFormats;
+    GPUTextureFormat depthStencilFormat;
+    GPUSize32 sampleCount = 1;
+};
+</script>
+
+<div algorithm>
+    <dfn abstract-op>derive render targets layout from pass</dfn>
+
+    **Arguments:**
+    - {{GPURenderPassDescriptor}} |descriptor|
+
+    **Returns:** {{GPURenderTargetsLayout}}
+
+    1. Let |layout| be a new {{GPURenderTargetsLayout}} object.
+    1. For each |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
+        1. Set |layout|.{{GPURenderTargetsLayout/sampleCount}} to |colorAttachment|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}}.
+        1. Append |colorAttachment|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}} to |layout|.{{GPURenderTargetsLayout/colorFormats}}.
+    1. Let |depthStencilAttachment| be |descriptor|.{{GPURenderPassDescriptor/depthStencilAttachment}}.
+    1. If |depthStencilAttachment| is not `null`:
+        1. Let |view| be |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/view}}
+        1. Set |layout|.{{GPURenderTargetsLayout/sampleCount}} to |view|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}}.
+        1. Set |layout|.{{GPURenderTargetsLayout/depthStencilFormat}} to |view|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
+    1. Return |layout|.
+
+</div>
+
+<div algorithm>
+    <dfn abstract-op>derive render targets layout from pipeline</dfn>
+
+    **Arguments:**
+    - {{GPURenderPipelineDescriptor}} |descriptor|
+
+    **Returns:** {{GPURenderTargetsLayout}}
+
+    1. Let |layout| be a new {{GPURenderTargetsLayout}} object.
+    1. Set |layout|.{{GPURenderTargetsLayout/sampleCount}} to |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/count}}.
+    1. If |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}} is not `null`:
+        1. Set |layout|.{{GPURenderTargetsLayout/depthStencilFormat}} to |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}/{{GPUDepthStencilState/format}}.
+    1. If |descriptor|.{{GPURenderPipelineDescriptor/fragment}} is not `null`:
+        1. For each |colorTarget| in |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.{{GPUFragmentState/targets}}:
+            1. Append |colorTarget|.{{GPUColorTargetState/format}} to |layout|.{{GPURenderTargetsLayout/colorFormats}}
+    1. Return |layout|.
+
+</div>
+
 ### Drawing ### {#render-pass-encoder-drawing}
 
 <dl dfn-type=method dfn-for=GPURenderEncoderBase>
@@ -7126,15 +7179,16 @@ enum GPUStoreOp {
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. Let |pipelineEncoderDesc| be [$derive render encoder descriptor from pipeline$](|pipeline|.{{GPURenderPipeline/[[descriptor]]}}).
+                1. Let |pipelineTargetsLayout| be [$derive render targets layout from pipeline$](|pipeline|.{{GPURenderPipeline/[[descriptor]]}}).
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |pipeline| is [$valid to use with$] |this|.
-                        - |this|.{{GPURenderEncoderBase/[[descriptor]]}} equals |pipelineEncoderDesc|.
+                        - |this|.{{GPURenderEncoderBase/[[layout]]}} equals |pipelineTargetsLayout|.
                     </div>
                 1. Set |this|.{{GPURenderEncoderBase/[[pipeline]]}} to be |pipeline|.
 
-                Issue: check read-only depth/stencil versus the pipeline state
+                Issue: check read-only depth/stencil versus the pipeline state.
+                Issue: define what "equals" means for {{GPURenderTargetsLayout}} here.
             </div>
         </div>
 
@@ -7750,7 +7804,7 @@ GPURenderBundleEncoder includes GPURenderEncoderBase;
                         Issue: Add remaining validation.
                     </div>
                 1. Let |e| be a new {{GPURenderBundleEncoder}} object.
-                1. Set |e|.{{GPURenderEncoderBase/[[descriptor]]}} to |descriptor|.
+                1. Set |e|.{{GPURenderEncoderBase/[[layout]]}} to |descriptor|.{{GPURenderTargetsLayout}}.
                 1. Return |e|.
 
                 Issue: Describe the reset of the steps for {{GPUDevice/createRenderBundleEncoder()}}.
@@ -7761,53 +7815,11 @@ GPURenderBundleEncoder includes GPURenderEncoderBase;
 ### Encoding ### {#render-bundle-encoding}
 
 <script type=idl>
-dictionary GPURenderBundleEncoderDescriptor : GPUObjectDescriptorBase {
-    required sequence<GPUTextureFormat> colorFormats;
-    GPUTextureFormat depthStencilFormat;
-    GPUSize32 sampleCount = 1;
+dictionary GPURenderBundleEncoderDescriptor : GPURenderTargetsLayout, GPUObjectDescriptorBase {
     boolean depthReadOnly = false;
     boolean stencilReadOnly = false;
 };
 </script>
-
-<div algorithm>
-    <dfn abstract-op>derive render encoder descriptor from pass</dfn>
-
-    **Arguments:**
-    - {{GPURenderPassDescriptor}} |descriptor|
-
-    **Returns:** {{GPURenderBundleEncoderDescriptor}}
-
-    1. Let |d| be a new {{GPURenderBundleEncoderDescriptor}} object.
-    1. For each |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
-        1. Set |d|.{{GPURenderBundleEncoderDescriptor/sampleCount}} to |colorAttachment|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}}.
-        1. Append |colorAttachment|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}} to |d|.{{GPURenderBundleEncoderDescriptor/colorFormats}}.
-    1. Let |depthStencilAttachment| be |descriptor|.{{GPURenderPassDescriptor/depthStencilAttachment}}.
-    1. If |depthStencilAttachment| is not `null`:
-        1. Set |d|.{{GPURenderBundleEncoderDescriptor/sampleCount}} to |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}}.
-        1. Set |d|.{{GPURenderBundleEncoderDescriptor/depthStencilFormat}} to |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
-    1. Return |d|.
-
-</div>
-
-<div algorithm>
-    <dfn abstract-op>derive render encoder descriptor from pipeline</dfn>
-
-    **Arguments:**
-    - {{GPURenderPipelineDescriptor}} |descriptor|
-
-    **Returns:** {{GPURenderBundleEncoderDescriptor}}
-
-    1. Let |d| be a new {{GPURenderBundleEncoderDescriptor}} object.
-    1. Set |d|.{{GPURenderBundleEncoderDescriptor/sampleCount}} to |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/count}}.
-    1. If |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}} is not `null`:
-        1. Set |d|.{{GPURenderBundleEncoderDescriptor/depthStencilFormat}} to |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}/{{GPUDepthStencilState/format}}.
-    1. If |descriptor|.{{GPURenderPipelineDescriptor/fragment}} is not `null`:
-        1. For each |colorTarget| in |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.{{GPUFragmentState/targets}}:
-            1. Append |colorTarget|.{{GPUColorTargetState/format}} to |d|.{{GPURenderBundleEncoderDescriptor/colorFormats}}
-    1. Return |d|.
-
-</div>
 
 ### Finalization ### {#render-bundle-finalization}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5539,7 +5539,7 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                 1. If |depthStencilAttachment| is not `null`:
                     1. Let |depthStencilView| be |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/view}}.
                     1. If |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} and
-                        {{GPURenderPassDepthStencilAttachment/stencilReadOnly}} are set
+                        {{GPURenderPassDepthStencilAttachment/stencilReadOnly}} are set:
                         1. The [=texture subresources=] seen by |depthStencilView|
                             are considered to be used as [=internal usage/attachment-read=] for the duration of the render pass.
                     1. Else, the [=texture subresource=] seen by |depthStencilView|
@@ -6815,9 +6815,9 @@ GPURenderPassEncoder includes GPURenderEncoderBase;
 {{GPURenderEncoderBase}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPURenderEncoderBase">
-    : <dfn>\[[layout]]</dfn>, of type {{GPURenderTargetsLayout}}
+    : <dfn>\[[layout]]</dfn>, of type {{GPURenderPassLayout}}
     ::
-        The layout of the render targets.
+        The layout of the render pass.
 
     : <dfn>\[[depthReadOnly]]</dfn>, of type boolean?
     ::
@@ -7139,13 +7139,13 @@ enum GPUStoreOp {
 };
 </script>
 
-#### Render Targets Layout #### {#render-targets-layout}
+#### Render Pass Layout #### {#render-pass-layout}
 
-{{GPURenderTargetsLayout}} contains the layout of the render targets for the current pass,
+{{GPURenderPassLayout}} contains the layout of the render targets for the current pass,
 which determines the compatibility of the pass with render pipelines.
 
 <script type=idl>
-dictionary GPURenderTargetsLayout {
+dictionary GPURenderPassLayout: GPUObjectDescriptorBase {
     required sequence<GPUTextureFormat> colorFormats;
     GPUTextureFormat depthStencilFormat;
     GPUSize32 sampleCount = 1;
@@ -7158,17 +7158,17 @@ dictionary GPURenderTargetsLayout {
     **Arguments:**
     - {{GPURenderPassDescriptor}} |descriptor|
 
-    **Returns:** {{GPURenderTargetsLayout}}
+    **Returns:** {{GPURenderPassLayout}}
 
-    1. Let |layout| be a new {{GPURenderTargetsLayout}} object.
+    1. Let |layout| be a new {{GPURenderPassLayout}} object.
     1. For each |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
-        1. Set |layout|.{{GPURenderTargetsLayout/sampleCount}} to |colorAttachment|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}}.
-        1. Append |colorAttachment|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}} to |layout|.{{GPURenderTargetsLayout/colorFormats}}.
+        1. Set |layout|.{{GPURenderPassLayout/sampleCount}} to |colorAttachment|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}}.
+        1. Append |colorAttachment|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}} to |layout|.{{GPURenderPassLayout/colorFormats}}.
     1. Let |depthStencilAttachment| be |descriptor|.{{GPURenderPassDescriptor/depthStencilAttachment}}.
     1. If |depthStencilAttachment| is not `null`:
         1. Let |view| be |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/view}}
-        1. Set |layout|.{{GPURenderTargetsLayout/sampleCount}} to |view|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}}.
-        1. Set |layout|.{{GPURenderTargetsLayout/depthStencilFormat}} to |view|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
+        1. Set |layout|.{{GPURenderPassLayout/sampleCount}} to |view|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}}.
+        1. Set |layout|.{{GPURenderPassLayout/depthStencilFormat}} to |view|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
     1. Return |layout|.
 
 </div>
@@ -7179,15 +7179,15 @@ dictionary GPURenderTargetsLayout {
     **Arguments:**
     - {{GPURenderPipelineDescriptor}} |descriptor|
 
-    **Returns:** {{GPURenderTargetsLayout}}
+    **Returns:** {{GPURenderPassLayout}}
 
-    1. Let |layout| be a new {{GPURenderTargetsLayout}} object.
-    1. Set |layout|.{{GPURenderTargetsLayout/sampleCount}} to |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/count}}.
+    1. Let |layout| be a new {{GPURenderPassLayout}} object.
+    1. Set |layout|.{{GPURenderPassLayout/sampleCount}} to |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/count}}.
     1. If |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}} is not `null`:
-        1. Set |layout|.{{GPURenderTargetsLayout/depthStencilFormat}} to |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}/{{GPUDepthStencilState/format}}.
+        1. Set |layout|.{{GPURenderPassLayout/depthStencilFormat}} to |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}/{{GPUDepthStencilState/format}}.
     1. If |descriptor|.{{GPURenderPipelineDescriptor/fragment}} is not `null`:
         1. For each |colorTarget| in |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.{{GPUFragmentState/targets}}:
-            1. Append |colorTarget|.{{GPUColorTargetState/format}} to |layout|.{{GPURenderTargetsLayout/colorFormats}}
+            1. Append |colorTarget|.{{GPUColorTargetState/format}} to |layout|.{{GPURenderPassLayout/colorFormats}}
     1. Return |layout|.
 
 </div>
@@ -7223,7 +7223,7 @@ dictionary GPURenderTargetsLayout {
                     </div>
                 1. Set |this|.{{GPURenderEncoderBase/[[pipeline]]}} to be |pipeline|.
 
-                Issue: define what "equals" means for {{GPURenderTargetsLayout}} here.
+                Issue: define what "equals" means for {{GPURenderPassLayout}} here.
             </div>
         </div>
 
@@ -7839,7 +7839,7 @@ GPURenderBundleEncoder includes GPURenderEncoderBase;
                         Issue: Add remaining validation.
                     </div>
                 1. Let |e| be a new {{GPURenderBundleEncoder}} object.
-                1. Set |e|.{{GPURenderEncoderBase/[[layout]]}} to |descriptor|.{{GPURenderTargetsLayout}}.
+                1. Set |e|.{{GPURenderEncoderBase/[[layout]]}} to |descriptor|.{{GPURenderPassLayout}}.
                 1. Set |e|.{{GPURenderEncoderBase/[[depthReadOnly]]}} to |descriptor|.{{GPURenderBundleEncoderDescriptor/depthReadOnly}}.
                 1. Set |e|.{{GPURenderEncoderBase/[[stencilReadOnly]]}} to |descriptor|.{{GPURenderBundleEncoderDescriptor/stencilReadOnly}}.
                 1. Return |e|.
@@ -7852,7 +7852,7 @@ GPURenderBundleEncoder includes GPURenderEncoderBase;
 ### Encoding ### {#render-bundle-encoding}
 
 <script type=idl>
-dictionary GPURenderBundleEncoderDescriptor : GPURenderTargetsLayout, GPUObjectDescriptorBase {
+dictionary GPURenderBundleEncoderDescriptor : GPURenderPassLayout {
     boolean depthReadOnly = false;
     boolean stencilReadOnly = false;
 };

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4673,6 +4673,12 @@ GPURenderPipeline includes GPUPipelineBase;
     ::
         The format index data this pipeline requires if using a strip primitive topology,
         initially `undefined`.
+
+    : <dfn>\[[writesDepth]]</dfn>, of type boolean
+    :: True if the pipeline writes to the depth component of the depth/stencil attachment
+
+    : <dfn>\[[writesStencil]]</dfn>, of type boolean
+    :: True if the pipeline writes to the stencil component of the depth/stencil attachment
 </dl>
 
 ### Creation ### {#render-pipeline-creation}
@@ -4735,7 +4741,23 @@ details.
                     1. Set |pipeline|.{{GPURenderPipeline/[[descriptor]]}} to |descriptor|.
                     1. Set |pipeline|.{{GPURenderPipeline/[[strip_index_format]]}} to
                         |descriptor|.{{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/stripIndexFormat}}.
-
+                    1. Set |pipeline|.{{GPURenderPipeline/[[writesDepth]]}} to false.
+                    1. Set |pipeline|.{{GPURenderPipeline/[[writesStencil]]}} to false.
+                    1. Let |depthStencil| be |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}.
+                    1. If |depthStencil| is not null:
+                        1. Set |pipeline|.{{GPURenderPipeline/[[writesDepth]]}} to |depthStencil|.{{GPUDepthStencilState/depthWriteEnabled}}.
+                        1. If |depthStencil|.{{GPUDepthStencilState/stencilWriteMask}} is not 0:
+                            1. Let |stencilFront| be |depthStencil|.{{GPUDepthStencilState/stencilFront}}.
+                            1. Let |stencilBack| be |depthStencil|.{{GPUDepthStencilState/stencilBack}}.
+                            1. Let |cullMode| be |descriptor|.{{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/cullMode}}.
+                            1. If |cullMode| is not {{GPUCullMode/"front"}}, and any of |stencilFront|.{{GPUStencilFaceState/passOp}},
+                                |stencilFront|.{{GPUStencilFaceState/depthFailOp}}, or |stencilFront|.{{GPUStencilFaceState/failOp}}
+                                is not {{GPUStencilOperation/"keep"}}:
+                                1. Set |pipeline|.{{GPURenderPipeline/[[writesStencil]]}} to true.
+                            1. If |cullMode| is not {{GPUCullMode/"back"}}, and any of |stencilBack|.{{GPUStencilFaceState/passOp}},
+                                |stencilBack|.{{GPUStencilFaceState/depthFailOp}}, or |stencilBack|.{{GPUStencilFaceState/failOp}}
+                                is not {{GPUStencilOperation/"keep"}}:
+                                1. Set |pipeline|.{{GPURenderPipeline/[[writesStencil]]}} to true.
                 </div>
             1. Return |pipeline|.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5522,6 +5522,7 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
+                1. Let |pass| be a new {{GPURenderPassEncoder}} object.
                 1. If any of the following conditions are unsatisfied, generate a validation
                     error and stop.
                     <div class=validusage>
@@ -5543,7 +5544,8 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                             are considered to be used as [=internal usage/attachment-read=] for the duration of the render pass.
                     1. Else, the [=texture subresource=] seen by |depthStencilView|
                         is considered to be used as [=internal usage/attachment=] for the duration of the render pass.
-                1. Let |pass| be a new {{GPURenderPassEncoder}} object.
+                    1. Set |pass|.{{GPURenderEncoderBase/[[depthReadOnly]]}} to |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}}.
+                    1. Set |pass|.{{GPURenderEncoderBase/[[stencilReadOnly]]}} to |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}}.
                 1. Set |pass|.{{GPURenderEncoderBase/[[layout]]}} to [$derive render targets layout from pass$](|descriptor|).
                 1. Return |pass|.
             </div>
@@ -6817,6 +6819,14 @@ GPURenderPassEncoder includes GPURenderEncoderBase;
     ::
         The layout of the render targets.
 
+    : <dfn>\[[depthReadOnly]]</dfn>, of type boolean?
+    ::
+        If present, the flag indicates that the depth component is not modified.
+
+    : <dfn>\[[stencilReadOnly]]</dfn>, of type boolean?
+    ::
+        If present, the flag indicates that the stencil component is not modified.
+
     : <dfn>\[[pipeline]]</dfn>, of type {{GPURenderPipeline}}
     ::
         The current {{GPURenderPipeline}}, initially `null`.
@@ -7206,10 +7216,13 @@ dictionary GPURenderTargetsLayout {
                     <div class=validusage>
                         - |pipeline| is [$valid to use with$] |this|.
                         - |this|.{{GPURenderEncoderBase/[[layout]]}} equals |pipelineTargetsLayout|.
+                        - If |pipeline|.{{GPURenderPipeline/[[writesDepth]]}}:
+                            |this|.{{GPURenderEncoderBase/[[depthReadOnly]]}} must be `false`.
+                        - If |pipeline|.{{GPURenderPipeline/[[writesStencil]]}}:
+                            |this|.{{GPURenderEncoderBase/[[stencilReadOnly]]}} must be `false`.
                     </div>
                 1. Set |this|.{{GPURenderEncoderBase/[[pipeline]]}} to be |pipeline|.
 
-                Issue: check read-only depth/stencil versus the pipeline state.
                 Issue: define what "equals" means for {{GPURenderTargetsLayout}} here.
             </div>
         </div>
@@ -7827,6 +7840,8 @@ GPURenderBundleEncoder includes GPURenderEncoderBase;
                     </div>
                 1. Let |e| be a new {{GPURenderBundleEncoder}} object.
                 1. Set |e|.{{GPURenderEncoderBase/[[layout]]}} to |descriptor|.{{GPURenderTargetsLayout}}.
+                1. Set |e|.{{GPURenderEncoderBase/[[depthReadOnly]]}} to |descriptor|.{{GPURenderBundleEncoderDescriptor/depthReadOnly}}.
+                1. Set |e|.{{GPURenderEncoderBase/[[stencilReadOnly]]}} to |descriptor|.{{GPURenderBundleEncoderDescriptor/stencilReadOnly}}.
                 1. Return |e|.
 
                 Issue: Describe the reset of the steps for {{GPUDevice/createRenderBundleEncoder()}}.


### PR DESCRIPTION
Follow-up to #1967, where I wanted to also add the checks for read-only depth/stencil (RODS). It turns out that piggy-backing on `GPURenderBundleEncoderDescriptor` isn't needed, after all, since the RODS checks are not for equality anyway.
So this PR introduces a new dictionary for this - `GPURenderTargetsLayout`. I'm not attached to the name, open to suggestions.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/1979.html" title="Last updated on Jul 22, 2021, 8:01 PM UTC (497f1f5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1979/bdc3428...kvark:497f1f5.html" title="Last updated on Jul 22, 2021, 8:01 PM UTC (497f1f5)">Diff</a>