### PR TITLE
Fix GPUVertexAttribute.offset alignment requirements for D3D12

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5245,8 +5245,8 @@ dictionary GPUVertexAttribute {
                 Otherwise:
                 - |attrib|.{{GPUVertexAttribute/offset}} + sizeof(|attrib|.{{GPUVertexAttribute/format}}) &le;
                     |descriptor|.{{GPUVertexBufferLayout/arrayStride}}.
-            - |attrib|.{{GPUVertexAttribute/offset}} is a multiple of the size of one component of
-                |attrib|.{{GPUVertexAttribute/format}}.
+            - |attrib|.{{GPUVertexAttribute/offset}} is a multiple of the minimum of 4 and
+                sizeof(|attrib|.{{GPUVertexAttribute/format}}).
             - |attrib|.{{GPUVertexAttribute/shaderLocation}} is less than
                 |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexAttributes}}.
         - For every vertex attribute in the shader reflection of |vertexStage|.{{GPUProgrammableStage/module}}


### PR DESCRIPTION
D3D12 requires that the alignment of this offset is
min(4, formatSize). This is coming from three source:
 - The D3D11 functional spec that generally applies to D3D12 as well.
 - ANGLE's D3D11 backend having specific workarounds when vertex strides
   aren't following this constraint.
 - Experimentally the D3D12 drivers failing to create pipelines that
   don't specify this constraint. (found with the WebGPU CTS)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/1980.html" title="Last updated on Jul 22, 2021, 4:56 PM UTC (1337281)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1980/6f2040f...Kangz:1337281.html" title="Last updated on Jul 22, 2021, 4:56 PM UTC (1337281)">Diff</a>