### PR TITLE
Rename texture usage flags to bindings

### DIFF
--- a/samples/workload-simulator.html
+++ b/samples/workload-simulator.html
@@ -699,7 +699,7 @@ async function render(fromRaf, fromPostMessage) {
         const texture = device.createTexture({
           size: [256, 256, 1],
           format: 'rgba8unorm',
-          usage: GPUTextureUsage.SAMPLED | GPUTextureUsage.COPY_DST,
+          usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST,
         });
         const loadImage = async () => {
           const imageBitmap = await createImageBitmap(img);

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -779,10 +779,10 @@ A [=physical resource=] can be used on GPU with an <dfn dfn>internal usage</dfn>
         Allowed by buffer {{GPUBufferUsage/INDEX}}, buffer {{GPUBufferUsage/VERTEX}}, or buffer {{GPUBufferUsage/INDIRECT}}.
     : <dfn>constant</dfn>
     ::  Resource bindings that are constant from the shader point of view. Preserves the contents.
-        Allowed by buffer {{GPUBufferUsage/UNIFORM}} or texture {{GPUTextureUsage/SHADER_READ}}.
+        Allowed by buffer {{GPUBufferUsage/UNIFORM}} or texture {{GPUTextureUsage/TEXTURE_BINDING}}.
     : <dfn>storage</dfn>
     ::  Writable storage resource binding.
-        Allowed by buffer {{GPUBufferUsage/STORAGE}} or texture {{GPUTextureUsage/STORAGE}}.
+        Allowed by buffer {{GPUBufferUsage/STORAGE}} or texture {{GPUTextureUsage/STORAGE_BINDING}}.
     : <dfn>storage-read</dfn>
     ::  Read-only storage resource bindings. Preserves the contents.
         Allowed by buffer {{GPUBufferUsage/STORAGE}}.
@@ -2359,8 +2359,8 @@ typedef [EnforceRange] unsigned long GPUTextureUsageFlags;
 interface GPUTextureUsage {
     const GPUFlagsConstant COPY_SRC          = 0x01;
     const GPUFlagsConstant COPY_DST          = 0x02;
-    const GPUFlagsConstant SHADER_READ       = 0x04;
-    const GPUFlagsConstant STORAGE           = 0x08;
+    const GPUFlagsConstant TEXTURE_BINDING   = 0x04;
+    const GPUFlagsConstant STORAGE_BINDING   = 0x08;
     const GPUFlagsConstant RENDER_ATTACHMENT = 0x10;
 };
 </script>
@@ -2452,7 +2452,7 @@ interface GPUTextureUsage {
                             - If |descriptor|.{{GPUTextureDescriptor/sampleCount}} > 1:
                                 - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be 1.
                                 - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be 1.
-                                - |descriptor|.{{GPUTextureDescriptor/usage}} must not include the {{GPUTextureUsage/STORAGE}} bit.
+                                - |descriptor|.{{GPUTextureDescriptor/usage}} must not include the {{GPUTextureUsage/STORAGE_BINDING}} bit.
                                 - |descriptor|.{{GPUTextureDescriptor/format}} must be a [=renderable format=].
 
                             - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be less than or equal to
@@ -2461,9 +2461,9 @@ interface GPUTextureUsage {
                             - |descriptor|.{{GPUTextureDescriptor/usage}} must be a combination of {{GPUTextureUsage}} values.
                             - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/RENDER_ATTACHMENT}} bit,
                                 |descriptor|.{{GPUTextureDescriptor/format}} must be a [=renderable format=].
-                            - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/STORAGE}} bit,
+                            - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/STORAGE_BINDING}} bit,
                                 |descriptor|.{{GPUTextureDescriptor/format}} must be listed in [[#plain-color-formats]] table
-                                with {{GPUTextureUsage/STORAGE}} capability.
+                                with {{GPUTextureUsage/STORAGE_BINDING}} capability.
                         </div>
 
                         Then:
@@ -3756,7 +3756,7 @@ A {{GPUBindGroup}} object has the following internal slots:
                                             - |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/sampleType}}
                                                 is [[#texture-format-caps|compatible]] with
                                                 |resource|'s {{GPUTextureViewDescriptor/format}}.
-                                            - |texture|'s {{GPUTextureDescriptor/usage}} includes {{GPUTextureUsage/SHADER_READ}}.
+                                            - |texture|'s {{GPUTextureDescriptor/usage}} includes {{GPUTextureUsage/TEXTURE_BINDING}}.
                                             - If |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/multisampled}}
                                                 is `true`, |texture|'s {{GPUTextureDescriptor/sampleCount}}
                                                 &gt; `1`, Otherwise |texture|'s {{GPUTextureDescriptor/sampleCount}} is `1`.
@@ -3770,7 +3770,7 @@ A {{GPUBindGroup}} object has the following internal slots:
                                                 is equal to |resource|'s {{GPUTextureViewDescriptor/dimension}}.
                                             - |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/format}}
                                                 is equal to |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
-                                            - |texture|'s {{GPUTextureDescriptor/usage}} includes {{GPUTextureUsage/STORAGE}}.
+                                            - |texture|'s {{GPUTextureDescriptor/usage}} includes {{GPUTextureUsage/STORAGE_BINDING}}.
 
                                         :  {{GPUBindGroupLayoutEntry/buffer}}
                                         ::
@@ -9508,15 +9508,13 @@ The following enums are supported if and only if the {{GPUFeatureName/"timestamp
 
 ### Plain color formats ### {#plain-color-formats}
 
-All plain color formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, and {{GPUTextureUsage/SHADER_READ}} usage.
+All plain color formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, and {{GPUTextureUsage/TEXTURE_BINDING}} usage.
 
 Only formats with {{GPUTextureSampleType}} {{GPUTextureSampleType/"float"}} can be blended.
 
-The {{GPUTextureUsage/RENDER_ATTACHMENT|GPUTextureUsage.RENDER_ATTACHMENT}} column specifies support for
-{{GPUTextureUsage/RENDER_ATTACHMENT}} usage.
-
-The {{GPUTextureUsage/STORAGE|GPUTextureUsage.STORAGE}} column specifies support for {{GPUTextureUsage/STORAGE}}
-usage.
+The {{GPUTextureUsage/RENDER_ATTACHMENT}} and {{GPUTextureUsage/STORAGE_BINDING}} columns
+specify support for {{GPUTextureUsage/RENDER_ATTACHMENT|GPUTextureUsage.RENDER_ATTACHMENT}}
+and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage respectively.
 
 <table class='data'>
     <thead class=stickyheader>
@@ -9524,7 +9522,7 @@ usage.
             <th>Format
             <th>{{GPUTextureSampleType}}
             <th>{{GPUTextureUsage/RENDER_ATTACHMENT}}
-            <th>{{GPUTextureUsage/STORAGE}}
+            <th>{{GPUTextureUsage/STORAGE_BINDING}}
     </thead>
     <tr><th class=stickyheader>8-bit per component<th><th><th>
     <tr>
@@ -9710,7 +9708,7 @@ usage.
 
 ### Depth/stencil formats ### {#depth-formats}
 
-All depth formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/SHADER_READ}}, and {{GPUTextureUsage/RENDER_ATTACHMENT}} usage. However, the source/destination is restricted based on the format.
+All depth formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, {{GPUTextureUsage/TEXTURE_BINDING}}, and {{GPUTextureUsage/RENDER_ATTACHMENT}} usage. However, the source/destination is restricted based on the format.
 
 None of the depth formats can be filtered.
 
@@ -9776,7 +9774,7 @@ Issue: clarify if `depth24plus-stencil8` is copyable into `depth24plus` in Metal
 
 ### Packed formats ### {#packed-formats}
 
-All packed texture formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, and {{GPUTextureUsage/SHADER_READ}} usages. All of these formats have {{GPUTextureSampleType/"float"}} type and can be filtered on sampling.
+All packed texture formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, and {{GPUTextureUsage/TEXTURE_BINDING}} usages. All of these formats have {{GPUTextureSampleType/"float"}} type and can be filtered on sampling.
 
 <table class='data'>
     <thead class=stickyheader>


### PR DESCRIPTION
Closes #1963
Would be nice to have a place in the spec where each of the flag bits is specified separately, but this is more general, and we'll need to follow-up.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jul 26, 2021, 8:42 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fkvark%2Fgpuweb%2F0033f6ab1500a542308f6291c25537908d8e13b0%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%231989.)._
</details>
