### PR TITLE
Change lodMaxClamp default to 32

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3018,7 +3018,7 @@ dictionary GPUSamplerDescriptor : GPUObjectDescriptorBase {
     GPUFilterMode minFilter = "nearest";
     GPUFilterMode mipmapFilter = "nearest";
     float lodMinClamp = 0;
-    float lodMaxClamp = 0xffffffff; // TODO: What should this be? Was Number.MAX_VALUE.
+    float lodMaxClamp = 32;
     GPUCompareFunction compare;
     [Clamp] unsigned short maxAnisotropy = 1;
 };
@@ -3041,6 +3041,7 @@ dictionary GPUSamplerDescriptor : GPUObjectDescriptorBase {
     Note: most implementations support {{GPUSamplerDescriptor/maxAnisotropy}} values in range between 1 and 16, inclusive.
 
 Issue: explain how LOD is calculated and if there are differences here between platforms.
+
 Issue: explain what anisotropic sampling is
 
 {{GPUAddressMode}} describes the behavior of the sampler if the sample footprint extends beyond
@@ -5474,8 +5475,6 @@ which may be one of the following:
 <script type=idl>
 dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
     boolean measureExecutionTime = false;
-
-    // TODO: reusability flag?
 };
 </script>
 
@@ -9238,7 +9237,7 @@ The determination is based on |descriptor|.{{GPURenderPipelineDescriptor/multisa
 
 ### Fragment Processing ### {#fragment-processing}
 
-TODO: fill out this section
+Issue: fill out this section
 
 ### No Color Output ### {#no-color-output}
 
@@ -9262,7 +9261,7 @@ It guarantees that:
 
 ### Sample frequency shading ### {#sample-frequency-shading}
 
-TODO: fill out the section
+Issue: fill out the section
 
 ### Sample Masking ### {#sample-masking}
 


### PR DESCRIPTION
Addresses a very old (and unimportant) TODO comment.
This PR also clean up a few other TODOs.

Texture dimensions are expressed as GPUIntegerCoordinate, aka "unsigned
long" aka "uint32_t". Therefore, the theoretical maximum mip level is
32 (i.e. the maximum mip level count is 33). For a texture of size 2**32:

- mip level 0: `2**32`
- mip level 1: `2**31`
- mip level 31: `2**1`
- mip level 32: `2**0` = 1

Therefore an lodMaxClamp of 32 is indistinguishable from any larger value,
even at the theoretical limit.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/1990.html" title="Last updated on Jul 26, 2021, 10:10 PM UTC (8f615b6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/1990/15144d5...kainino0x:8f615b6.html" title="Last updated on Jul 26, 2021, 10:10 PM UTC (8f615b6)">Diff</a>