### PR TITLE
Require storage texture access

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2508,7 +2508,7 @@ TODO(dneto): Move description of the conversion to the builtin function that act
 </pre>
 
 * `texel_format` must be one of the texel types specified in [=storage-texel-formats=]
-* `access` must be [=access/write=], if specified.
+* `access` must be [=access/write=].
 
 In the SPIR-V mapping:
 * The *Image Format* parameter of the image type declaration is


### PR DESCRIPTION
Another small thing pointed by @pyrotechnick - the grammar requires the access, but the prose doesn't.