### PR TITLE
Clarify IO location overlap

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5712,11 +5712,20 @@ locations.
 Each structure member in the entry point IO must be one of either a builtin variable
 (see [[#builtin-inputs-outputs]]), or assigned a location.
 
-For a given entry point, the locations of the return type are distinct from
-the locations of the function parameters.
-Within each set of locations, there must be no overlap.
+Locations must not overlap within each of the following sets:
+* Members within a structure type.
+    This applies to any structure, not just those used in pipeline inputs or outputs.
+* An entry point's pipeline inputs,
+    i.e. locations for its formal parameters, or for the members of its formal parameters of structure type.
 
-Note: the number of available locations for an entry point is defined by the WebGPU API.
+Note: Location numbering is distinct between inputs and outputs: 
+Location numbers for an entry point's pipeline inputs do not conflict with location numbers for the entry point's pipeline outputs.
+
+Note: No additional rule is required to prevent location overlap within an entry point's outputs.
+When the outptut is a structure, the first rule above prevents overlap.
+Otherwise, the output is a scalar or a vector, and can have only a single location assigned to it.
+
+Note: The number of available locations for an entry point is defined by the WebGPU API.
 
 <div class='example applying location attribute' heading='Applying location attributes'>
   <xmp>


### PR DESCRIPTION
Make it clear that no two members of *any* structure may have the same
location.