### PR TITLE
Add new matrix constructors

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12,7 +12,7 @@ Text Macro: UNSIGNEDINTEGRAL u32 or vec|N|&lt;u32&gt;
 Text Macro: SIGNEDINTEGRAL i32 or vec|N|&lt;i32&gt;
 Text Macro: INTEGRAL i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;
 Text Macro: FLOATING f32 or vec|N|&lt;f32&gt;
-Ignored Vars: i, e, e1, e2, e3, N, M, v, Stride, Offset, Align, Extent, S, T, T1
+Ignored Vars: i, e, e1, e2, e3, eN, N, M, v, Stride, Offset, Align, Extent, S, T, T1
 
 !Participate: <a href="https://github.com/gpuweb/gpuweb/issues/new?labels=wgsl">File an issue</a> (<a href="https://github.com/gpuweb/gpuweb/issues?q=is%3Aissue+is%3Aopen+label%3Awgsl">open issues</a>)
 
@@ -3277,6 +3277,21 @@ See also [[#zero-value-expr]] and [[#conversion-expr]].
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
+  <tr>
+    <td>|e1|: |f32|<br>
+        ...<br>
+        |eN|: |f32|
+    <td>`mat2x2<f32>(e1,e2,e3,e4)`: mat2x2&lt;f32&gt;<br>
+        `mat3x2<f32>(e1,...,e6)`: mat3x2&lt;f32&gt;<br>
+        `mat2x3<f32>(e1,...,e6)`: mat2x3&lt;f32&gt;<br>
+        `mat4x2<f32>(e1,...,e8)`: mat4x2&lt;f32&gt;<br>
+        `mat2x4<f32>(e1,...,e8)`: mat2x4&lt;f32&gt;<br>
+        `mat3x3<f32>(e1,...,e9)`: mat3x3&lt;f32&gt;<br>
+        `mat4x3<f32>(e1,...,e12)`: mat4x3&lt;f32&gt;<br>
+        `mat3x4<f32>(e1,...,e12)`: mat3x4&lt;f32&gt;<br>
+        `mat4x4<f32>(e1,...,e16)`: mat4x4&lt;f32&gt;
+    <td>Column-major construction by elements.<br>
+        OpCompositeConstruct
   <tr>
     <td>*e1*: vec2&lt;f32&gt;<br>
         *e2*: vec2&lt;f32&gt;<br>


### PR DESCRIPTION
#### Fixes: #1964

This commit adds new constructors by f32 elements (mat2x2, mat3x2, mat2x3, mat3x3, mat2x4, mat4x2, mat4x3, mat3x4, mat4x4).

#### Motivatiion

It's handy, explicit and exist in other shading languages.

#### Details

IMHO this is not related how actually matrices stored in memory and just improve WGSL in WGSL way. After that programmers should not make 9 functions like that by hands.

```rs
fn mat44_f32(a1: f32, a2: f32, a3: f32, a4: f32, b1: f32, b2: f32, b3: f32, b4: f32,
             c1: f32, c2: f32, c3: f32, c4: f32, d1: f32, d2: f32, d3: f32, d4: f32) -> mat4x4<f32> {
  return mat4x4<f32>(vec4<f32>(a1, a2, a3, a4), vec4<f32>(b1, b2, b3, b4),
                     vec4<f32>(c1, c2, c3, c4), vec4<f32>(d1, d2, d3, d4));
}
```