### PR TITLE
The reference to Metal's coordinate system should be non-normative

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -647,7 +647,6 @@ This would let validity be immutable, and only operations involving devices, buf
 
 ## Coordinate Systems ## {#coordinate-systems}
 
-WebGPU's coordinate systems match DirectX and Metal's coordinate systems in a graphics pipeline.
   - Y-axis is up in normalized device coordinate (NDC): point(-1.0, -1.0) in NDC is located at the bottom-left corner of NDC.
     In addition, x and y in NDC should be between -1.0 and 1.0 inclusive, while z in NDC should be between 0.0 and 1.0 inclusive.
     Vertices out of this range in NDC will not introduce any errors, but they will be clipped.
@@ -656,6 +655,7 @@ WebGPU's coordinate systems match DirectX and Metal's coordinate systems in a gr
   - Window/present coordinate matches [=framebuffer=] coordinate.
   - UV of origin(0, 0) in texture coordinate represents the first texel (the lowest byte) in texture memory.
 
+Note: WebGPU's coordinate systems match DirectX and Metal's coordinate systems in a graphics pipeline.
 
 ## Programming Model ## {#programming-model}
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/litherum/gpuweb/pull/2011.html" title="Last updated on Aug 3, 2021, 3:12 AM UTC (2e2521b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2011/7a2d148...litherum:2e2521b.html" title="Last updated on Aug 3, 2021, 3:12 AM UTC (2e2521b)">Diff</a>