### PR TITLE
A 0x1 literal is ambiguously either a HEX_FLOAT_LITERAL or an INT_LITERAL

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -331,7 +331,7 @@ TODO: What indicates the end of a line?  (E.g. A line ends at the next linefeed 
     <tr><th>Token<th>Definition
   </thead>
   <tr><td>`DECIMAL_FLOAT_LITERAL`<td>`(-?[0-9]*.[0-9]+ | -?[0-9]+.[0-9]*)((e|E)(+|-)?[0-9]+)?`
-  <tr><td>`HEX_FLOAT_LITERAL`<td>`-?0x([0-9a-fA-F]*.?[0-9a-fA-F]+ | [0-9a-fA-F]+.[0-9a-fA-F]*)(p|P)(+|-)?[0-9]+`
+  <tr><td>`HEX_FLOAT_LITERAL`<td>`-?0x([0-9a-fA-F]*.[0-9a-fA-F]+ | [0-9a-fA-F]+.[0-9a-fA-F]*)(p|P)(+|-)?[0-9]+`
   <tr><td>`INT_LITERAL`<td>`-?0x[0-9a-fA-F]+ | 0 | -?[1-9][0-9]*`
   <tr><td>`UINT_LITERAL`<td>`0x[0-9a-fA-F]+u | 0u | [1-9][0-9]*u`
 </table>


### PR DESCRIPTION
The current grammar for `HEX_FLOAT_LITERAL` is

```
-?0x([0-9a-fA-F]*.?[0-9a-fA-F]+ | [0-9a-fA-F]+.[0-9a-fA-F]*)(p|P)(+|-)?[0-9]+
  0x                         1
```

The decimal point should be required.