### PR TITLE
Restrict out-of-bounds behaviour for RMW

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1906,6 +1906,10 @@ memory reference</dfn> is produced.
     * store the value to any [=memory locations|memory location(s)=] of the
         [[WebGPU#buffers|WebGPU buffer]] bound to the [=originating variable=]
     * not be executed
+Statements and expressions that perform both a load and a store using the same
+invalid memory reference (e.g. [[#atomic-rmw|read-modify-write atomics]]) must
+load and store from the same [=memory locations|memory location(s)=] if they
+access memory.
 
 ### Use cases for references and pointers ### {#ref-ptr-use-cases}
 


### PR DESCRIPTION
Fixes #1868

* Add a restriction for RMW statements and expressions that prevents
  different memory locations being used for the load and store
  * statements are included for the eventual addition of more
    complicated assignments