### PR TITLE
Updating limits to only use GPUSize32/GPUSize64

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1253,22 +1253,22 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
         The maximum value of the product of the `workgroup_size` dimensions for a
         compute stage {{GPUShaderModule}} entry-point.
 
-    <tr><td><dfn>maxComputeWorkgroupX</dfn>
-        <td>{{GPUSize32}} <td>Per-component Higher <td>256
+    <tr><td><dfn>maxComputeWorkgroupSizeX</dfn>
+        <td>{{GPUSize32}} <td>Higher <td>256
     <tr class=row-continuation><td colspan=4>
-        The maximum values of the `workgroup_size` X dimension for a
+        The maximum value of the `workgroup_size` X dimension for a
         compute stage {{GPUShaderModule}} entry-point.
 
-    <tr><td><dfn>maxComputeWorkgroupY</dfn>
-        <td>{{GPUSize32}} <td>Per-component Higher <td>256
+    <tr><td><dfn>maxComputeWorkgroupSizeY</dfn>
+        <td>{{GPUSize32}} <td>Higher <td>256
     <tr class=row-continuation><td colspan=4>
-        The maximum values of the `workgroup_size` Y dimensions for a
+        The maximum value of the `workgroup_size` Y dimensions for a
         compute stage {{GPUShaderModule}} entry-point.
 
-    <tr><td><dfn>maxComputeWorkgroupZ</dfn>
-        <td>{{GPUSize32}} <td>Per-component Higher <td>64
+    <tr><td><dfn>maxComputeWorkgroupSizeZ</dfn>
+        <td>{{GPUSize32}} <td>Higher <td>64
     <tr class=row-continuation><td colspan=4>
-        The maximum values of the `workgroup_size` Z dimensions for a
+        The maximum value of the `workgroup_size` Z dimensions for a
         compute stage {{GPUShaderModule}} entry-point.
 
     <tr><td><dfn>maxComputeWorkgroupsPerDimension</dfn>
@@ -1288,32 +1288,32 @@ See {{GPUAdapter/limits|GPUAdapter.limits}} and {{GPUDevice/limits|GPUDevice.lim
 <script type=idl>
 [Exposed=(Window, DedicatedWorker)]
 interface GPUSupportedLimits {
-    readonly attribute GPUSize32 maxTextureDimension1D;
-    readonly attribute GPUSize32 maxTextureDimension2D;
-    readonly attribute GPUSize32 maxTextureDimension3D;
-    readonly attribute GPUSize32 maxTextureArrayLayers;
-    readonly attribute GPUSize32 maxBindGroups;
-    readonly attribute GPUSize32 maxDynamicUniformBuffersPerPipelineLayout;
-    readonly attribute GPUSize32 maxDynamicStorageBuffersPerPipelineLayout;
-    readonly attribute GPUSize32 maxSampledTexturesPerShaderStage;
-    readonly attribute GPUSize32 maxSamplersPerShaderStage;
-    readonly attribute GPUSize32 maxStorageBuffersPerShaderStage;
-    readonly attribute GPUSize32 maxStorageTexturesPerShaderStage;
-    readonly attribute GPUSize32 maxUniformBuffersPerShaderStage;
-    readonly attribute GPUSize64 maxUniformBufferBindingSize;
-    readonly attribute GPUSize64 maxStorageBufferBindingSize;
-    readonly attribute GPUSize32 minUniformBufferOffsetAlignment;
-    readonly attribute GPUSize32 minStorageBufferOffsetAlignment;
-    readonly attribute GPUSize32 maxVertexBuffers;
-    readonly attribute GPUSize32 maxVertexAttributes;
-    readonly attribute GPUSize32 maxVertexBufferArrayStride;
-    readonly attribute GPUSize32 maxInterStageShaderComponents;
-    readonly attribute GPUSize32 maxComputeWorkgroupStorageSize;
-    readonly attribute GPUSize32 maxComputeInvocationsPerWorkgroup;
-    readonly attribute GPUSize32 maxComputeWorkgroupX;
-    readonly attribute GPUSize32 maxComputeWorkgroupY;
-    readonly attribute GPUSize32 maxComputeWorkgroupZ;
-    readonly attribute GPUSize32 maxComputeWorkgroupsPerDimension;
+    readonly attribute unsigned long maxTextureDimension1D;
+    readonly attribute unsigned long maxTextureDimension2D;
+    readonly attribute unsigned long maxTextureDimension3D;
+    readonly attribute unsigned long maxTextureArrayLayers;
+    readonly attribute unsigned long maxBindGroups;
+    readonly attribute unsigned long maxDynamicUniformBuffersPerPipelineLayout;
+    readonly attribute unsigned long maxDynamicStorageBuffersPerPipelineLayout;
+    readonly attribute unsigned long maxSampledTexturesPerShaderStage;
+    readonly attribute unsigned long maxSamplersPerShaderStage;
+    readonly attribute unsigned long maxStorageBuffersPerShaderStage;
+    readonly attribute unsigned long maxStorageTexturesPerShaderStage;
+    readonly attribute unsigned long maxUniformBuffersPerShaderStage;
+    readonly attribute unsigned long long maxUniformBufferBindingSize;
+    readonly attribute unsigned long long maxStorageBufferBindingSize;
+    readonly attribute unsigned long minUniformBufferOffsetAlignment;
+    readonly attribute unsigned long minStorageBufferOffsetAlignment;
+    readonly attribute unsigned long maxVertexBuffers;
+    readonly attribute unsigned long maxVertexAttributes;
+    readonly attribute unsigned long maxVertexBufferArrayStride;
+    readonly attribute unsigned long maxInterStageShaderComponents;
+    readonly attribute unsigned long maxComputeWorkgroupStorageSize;
+    readonly attribute unsigned long maxComputeInvocationsPerWorkgroup;
+    readonly attribute unsigned long maxComputeWorkgroupSizeX;
+    readonly attribute unsigned long maxComputeWorkgroupSizeY;
+    readonly attribute unsigned long maxComputeWorkgroupSizeZ;
+    readonly attribute unsigned long maxComputeWorkgroupsPerDimension;
 };
 </script>
 
@@ -4607,9 +4607,9 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
 
                     - |descriptor|.{{GPUComputePipelineDescriptor/compute}}'s `workgroup_size` attribute
                         has each component &le; the corresponding component in
-                        [|device|.limits.{{supported limits/maxComputeWorkgroupX}},
-                        |device|.limits.{{supported limits/maxComputeWorkgroupY}},
-                        |device|.limits.{{supported limits/maxComputeWorkgroupZ}}].
+                        [|device|.limits.{{supported limits/maxComputeWorkgroupSizeX}},
+                        |device|.limits.{{supported limits/maxComputeWorkgroupSizeY}},
+                        |device|.limits.{{supported limits/maxComputeWorkgroupSizeZ}}].
                 </div>
 
             Then:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1253,10 +1253,22 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
         The maximum value of the product of the `workgroup_size` dimensions for a
         compute stage {{GPUShaderModule}} entry-point.
 
-    <tr><td><dfn>maxComputeWorkgroupDimensions</dfn>
-        <td>{{GPUExtent3D}} <td>Per-component Higher <td>[256, 256, 64]
+    <tr><td><dfn>maxComputeWorkgroupX</dfn>
+        <td>{{GPUSize32}} <td>Per-component Higher <td>256
     <tr class=row-continuation><td colspan=4>
-        The maximum values of the `workgroup_size` dimensions for a
+        The maximum values of the `workgroup_size` X dimension for a
+        compute stage {{GPUShaderModule}} entry-point.
+
+    <tr><td><dfn>maxComputeWorkgroupY</dfn>
+        <td>{{GPUSize32}} <td>Per-component Higher <td>256
+    <tr class=row-continuation><td colspan=4>
+        The maximum values of the `workgroup_size` Y dimensions for a
+        compute stage {{GPUShaderModule}} entry-point.
+
+    <tr><td><dfn>maxComputeWorkgroupZ</dfn>
+        <td>{{GPUSize32}} <td>Per-component Higher <td>64
+    <tr class=row-continuation><td colspan=4>
+        The maximum values of the `workgroup_size` Z dimensions for a
         compute stage {{GPUShaderModule}} entry-point.
 
     <tr><td><dfn>maxComputeWorkgroupsPerDimension</dfn>
@@ -1276,30 +1288,32 @@ See {{GPUAdapter/limits|GPUAdapter.limits}} and {{GPUDevice/limits|GPUDevice.lim
 <script type=idl>
 [Exposed=(Window, DedicatedWorker)]
 interface GPUSupportedLimits {
-    readonly attribute unsigned long maxTextureDimension1D;
-    readonly attribute unsigned long maxTextureDimension2D;
-    readonly attribute unsigned long maxTextureDimension3D;
-    readonly attribute unsigned long maxTextureArrayLayers;
-    readonly attribute unsigned long maxBindGroups;
-    readonly attribute unsigned long maxDynamicUniformBuffersPerPipelineLayout;
-    readonly attribute unsigned long maxDynamicStorageBuffersPerPipelineLayout;
-    readonly attribute unsigned long maxSampledTexturesPerShaderStage;
-    readonly attribute unsigned long maxSamplersPerShaderStage;
-    readonly attribute unsigned long maxStorageBuffersPerShaderStage;
-    readonly attribute unsigned long maxStorageTexturesPerShaderStage;
-    readonly attribute unsigned long maxUniformBuffersPerShaderStage;
-    readonly attribute unsigned long long maxUniformBufferBindingSize;
-    readonly attribute unsigned long long maxStorageBufferBindingSize;
-    readonly attribute unsigned long minUniformBufferOffsetAlignment;
-    readonly attribute unsigned long minStorageBufferOffsetAlignment;
-    readonly attribute unsigned long maxVertexBuffers;
-    readonly attribute unsigned long maxVertexAttributes;
-    readonly attribute unsigned long maxVertexBufferArrayStride;
-    readonly attribute unsigned long maxInterStageShaderComponents;
-    readonly attribute unsigned long maxComputeWorkgroupStorageSize;
-    readonly attribute unsigned long maxComputeInvocationsPerWorkgroup;
-    readonly attribute GPUExtent3D maxComputeWorkgroupDimensions;
-    readonly attribute unsigned long maxComputeWorkgroupsPerDimension;
+    readonly attribute GPUSize32 maxTextureDimension1D;
+    readonly attribute GPUSize32 maxTextureDimension2D;
+    readonly attribute GPUSize32 maxTextureDimension3D;
+    readonly attribute GPUSize32 maxTextureArrayLayers;
+    readonly attribute GPUSize32 maxBindGroups;
+    readonly attribute GPUSize32 maxDynamicUniformBuffersPerPipelineLayout;
+    readonly attribute GPUSize32 maxDynamicStorageBuffersPerPipelineLayout;
+    readonly attribute GPUSize32 maxSampledTexturesPerShaderStage;
+    readonly attribute GPUSize32 maxSamplersPerShaderStage;
+    readonly attribute GPUSize32 maxStorageBuffersPerShaderStage;
+    readonly attribute GPUSize32 maxStorageTexturesPerShaderStage;
+    readonly attribute GPUSize32 maxUniformBuffersPerShaderStage;
+    readonly attribute GPUSize64 maxUniformBufferBindingSize;
+    readonly attribute GPUSize64 maxStorageBufferBindingSize;
+    readonly attribute GPUSize32 minUniformBufferOffsetAlignment;
+    readonly attribute GPUSize32 minStorageBufferOffsetAlignment;
+    readonly attribute GPUSize32 maxVertexBuffers;
+    readonly attribute GPUSize32 maxVertexAttributes;
+    readonly attribute GPUSize32 maxVertexBufferArrayStride;
+    readonly attribute GPUSize32 maxInterStageShaderComponents;
+    readonly attribute GPUSize32 maxComputeWorkgroupStorageSize;
+    readonly attribute GPUSize32 maxComputeInvocationsPerWorkgroup;
+    readonly attribute GPUSize32 maxComputeWorkgroupX;
+    readonly attribute GPUSize32 maxComputeWorkgroupY;
+    readonly attribute GPUSize32 maxComputeWorkgroupZ;
+    readonly attribute GPUSize32 maxComputeWorkgroupsPerDimension;
 };
 </script>
 
@@ -1704,7 +1718,7 @@ interface GPUAdapter {
 <script type=idl>
 dictionary GPUDeviceDescriptor : GPUObjectDescriptorBase {
     sequence<GPUFeatureName> requiredFeatures = [];
-    record<DOMString, GPUSize32> requiredLimits = {};
+    record<DOMString, GPUSize64> requiredLimits = {};
 };
 </script>
 
@@ -1728,10 +1742,10 @@ dictionary GPUDeviceDescriptor : GPUObjectDescriptorBase {
         Exactly the specified limits, and no [=limit/better=] or worse,
         will be allowed in validation of API calls on the resulting device.
 
-        <!-- If we ever need limit types other than GPUSize32, we can change the value type to
-        `double` or `any` in the future and write out the type conversion explicitly (by reference
-        to WebIDL spec). Or change the entire type to `any` and add back a `dictionary GPULimits`
-        and define the conversion of the whole object by reference to WebIDL. -->
+        <!-- If we ever need limit types other than GPUSize32/GPUSize64, we can change the value
+        type to `double` or `any` in the future and write out the type conversion explicitly (by
+        reference to WebIDL spec). Or change the entire type to `any` and add back a `dictionary
+        GPULimits` and define the conversion of the whole object by reference to WebIDL. -->
 </dl>
 
 #### <dfn enum>GPUFeatureName</dfn> #### {#gpufeaturename}
@@ -4593,7 +4607,9 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
 
                     - |descriptor|.{{GPUComputePipelineDescriptor/compute}}'s `workgroup_size` attribute
                         has each component &le; the corresponding component in
-                        |device|.limits.{{supported limits/maxComputeWorkgroupDimensions}}.
+                        [|device|.limits.{{supported limits/maxComputeWorkgroupX}},
+                        |device|.limits.{{supported limits/maxComputeWorkgroupY}},
+                        |device|.limits.{{supported limits/maxComputeWorkgroupZ}}].
                 </div>
 
             Then:


### PR DESCRIPTION
Fixes #2018

 - Changes GPUSupportedLimits to use `GPUSize32/64` rather than `unsigned long (long)` for consistency.
 - Updated `requiredLimits` to be a `record<DOMString, GPUSize64>` to allow larger limits to be specified where appropriate.
 - Splits `maxComputeWorkgroupDimensions` into `maxComputeWorkgroupX`, `maxComputeWorkgroupY`, and `maxComputeWorkgroupZ` so that they can be set via `requiredLimits`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Aug 5, 2021, 10:52 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fgpuweb%2Fgpuweb%2Fa6da332b93e651905874b08d379a0904794a3aca%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%232020.)._
</details>
