### PR TITLE
Add indirect-first-instance feature.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1781,6 +1781,7 @@ enum GPUFeatureName {
     "texture-compression-etc2",
     "texture-compression-astc",
     "timestamp-query",
+    "indirect-first-instance",
 };
 </script>
 
@@ -7596,11 +7597,12 @@ dictionary GPURenderPassLayout: GPUObjectDescriptorBase {
             drawIndirectParameters[0] = vertexCount;
             drawIndirectParameters[1] = instanceCount;
             drawIndirectParameters[2] = firstVertex;
-            drawIndirectParameters[3] = 0; // firstInstance. Must be 0.
+            drawIndirectParameters[3] = firstInstance;
         </pre>
 
-        The value corresponding to `firstInstance` is reserved for future use and must be zero. If
-        it is not zero the {{GPURenderEncoderBase/drawIndirect()}} call will be treated as a no-op.
+        The value corresponding to `firstInstance` must be 0, unless the {{GPUFeatureName/"indirect-first-instance"}}
+        [=feature=] is enabled.  If the {{GPUFeatureName/"indirect-first-instance"}} [=feature=] is not enabled and
+        `firstInstance` is not zero the {{GPURenderEncoderBase/drawIndirect()}} call will be treated as a no-op.
 
         <div algorithm="GPURenderEncoderBase.drawIndirect">
             **Called on:** {{GPURenderEncoderBase}} this.
@@ -7643,12 +7645,12 @@ dictionary GPURenderPassLayout: GPUObjectDescriptorBase {
             drawIndexedIndirectParameters[1] = instanceCount;
             drawIndexedIndirectParameters[2] = firstIndex;
             drawIndexedIndirectParameters[3] = baseVertex;
-            drawIndexedIndirectParameters[4] = 0; // firstInstance. Must be 0.
+            drawIndexedIndirectParameters[4] = firstInstance;
         </pre>
 
-        The value corresponding to `firstInstance` is reserved for future use and must be zero. If
-        it is not zero the {{GPURenderEncoderBase/drawIndexedIndirect()}} call will be treated as a
-        no-op.
+        The value corresponding to `firstInstance` must be 0, unless the {{GPUFeatureName/"indirect-first-instance"}}
+        [=feature=] is enabled.  If the {{GPUFeatureName/"indirect-first-instance"}} [=feature=] is not enabled and
+        `firstInstance` is not zero the {{GPURenderEncoderBase/drawIndexedIndirect()}} call will be treated as a no-op.
 
         <div algorithm="GPURenderEncoderBase.drawIndexedIndirect">
             **Called on:** {{GPURenderEncoderBase}} this.
@@ -9861,6 +9863,11 @@ The following enums are supported if and only if the {{GPUFeatureName/"timestamp
     ::
         * {{GPUQueryType/"timestamp"}}
 </dl>
+
+## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>indirect-first-instance</dfn> ## {#indirect-first-instance}
+
+Removes the zero value restriction on `firstInstance` in [=indirect draw parameters=] and [=indirect drawIndexed parameters=].
+`firstInstance` is allowed to be non-zero if and only if the {{GPUFeatureName/"indirect-first-instance"}} [=feature=] is enabled.
 
 # Appendices # {#appendices}
 


### PR DESCRIPTION
Combining indirect drawing with render bundles is a powerful way to shift work to the GPU.  However, with `firstInstance` locked to 0 the bundle must use dynamic uniform/storage buffer offsets which cannot be changed once the bundle is encoded.  With non-zero values of `firstInstance` the `instance_index` can be used to index into uniform/storage arrays inside the shader, allowing the GPU to change what is rendered each frame, greatly adding to the flexibility of render bundles.

This PR addresses adding an `indirect-first-instance` feature which aims to relax the requirement on `firstInstance = 0` for `drawIndirect` and `drawIndexedIndirect` on hardware which supports `firstInstance > 0`.

NOTE: The decision to split this feature off from https://github.com/gpuweb/gpuweb/pull/1949 was made during the [meeting on 2021-08-02](https://docs.google.com/document/d/1PTyLomUvNd8TyL2a44ZsbjmAprsYM9JE4WYEw0xurH0)

NOTE: This was removed from core (https://github.com/gpuweb/gpuweb/issues/1878) due to the 36% of Android devices which do not support `firstInstance > 0`.

The required backend capabilities to implement `indirect-first-instance` are available on:
* 99% of Vulkan capable desktop GPUs
* 64% of Vulkan capable Android devices
* All DX12 devices
* All Metal devices


In particular, the required capabilities are core to DX12 and Metal, but requires the `drawIndirectFirstInstance` feature on Vulkan.  The corresponding parameter for each backend API are given in the table below:

| Vulkan | DX12 | Metal |
| ------ | ---- | ----- |
| `firstInstance` | `StartInstanceLocation` | `baseInstance` |


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mrshannon/gpuweb/pull/2022.html" title="Last updated on Nov 9, 2021, 9:16 AM UTC (6fb73a5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2022/25ce630...mrshannon:6fb73a5.html" title="Last updated on Nov 9, 2021, 9:16 AM UTC (6fb73a5)">Diff</a>