### PR TITLE
Tweak the description of adapters to not mention accelerators or GPUs explicitly

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -928,8 +928,9 @@ generates a {{GPUValidationError}} in the current error scope.
 ### Adapters ### {#adapters}
 
 An <dfn dfn>adapter</dfn> represents an implementation of WebGPU on the system.
-Each adapter identifies both an instance of a hardware accelerator (e.g. GPU or CPU) and
-an instance of a browser's implementation of WebGPU on top of that accelerator.
+Each adapter identifies both an instance of compute/rendering functionality on a
+platform underlying a browser, and an instance of a browser's implementation of
+WebGPU on top of that functionality.
 
 If an [=adapter=] becomes unavailable, it becomes [=invalid=].
 Once invalid, it never becomes valid again.


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/litherum/gpuweb/pull/2029.html" title="Last updated on Aug 11, 2021, 2:13 AM UTC (91b4317)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2029/ef3fbc5...litherum:91b4317.html" title="Last updated on Aug 11, 2021, 2:13 AM UTC (91b4317)">Diff</a>