### PR TITLE
Clarify out-of-bounds RMW atomics

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1906,8 +1906,9 @@ memory reference</dfn> is produced.
     * store the value to any [=memory locations|memory location(s)=] of the
         [[WebGPU#buffers|WebGPU buffer]] bound to the [=originating variable=]
     * not be executed
-[[#atomic-rmw|Read-modify-write atomics]] must load and store from the same
-[=memory locations|memory locations=] if they access memory.
+[[#atomic-rmw|Read-modify-write atomics]] that operate on an invalid memory
+reference must load and store from the same [=memory locations|memory
+locations=] if they access memory.
 
 ### Use cases for references and pointers ### {#ref-ptr-use-cases}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1906,6 +1906,8 @@ memory reference</dfn> is produced.
     * store the value to any [=memory locations|memory location(s)=] of the
         [[WebGPU#buffers|WebGPU buffer]] bound to the [=originating variable=]
     * not be executed
+[[#atomic-rmw|Read-modify-write atomics]] must load and store from the same
+[=memory locations|memory locations=] if they access memory.
 
 ### Use cases for references and pointers ### {#ref-ptr-use-cases}
 


### PR DESCRIPTION
* RMW atomics must load and store from the same memory address if they
  access memory