### PR TITLE
Clarify the types that are valid for ignore()

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8187,7 +8187,9 @@ TODO: Add links to the eventual memory model.
     <td class="nowrap">
         `ignore`(|e|: |T|)
     <td>Evaluates |e|, and then ignores the result.<br>
-        Type |T| is any non-reference type.
+        Type |T| is any type that is valid as a function parameter.
+
+        Note: An argument to `ignore()` cannot have an atomic or runtime-sized array type, but pointers to these types can be used.
 </table>
 
 


### PR DESCRIPTION
The previous wording suggested that atomics and runtime-sized arrays
are valid, despite the blanket restriction on the use of these types
as function parameters.