### PR TITLE
[WGSL] Escape RegEx characters

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -330,10 +330,10 @@ TODO: What indicates the end of a line?  (E.g. A line ends at the next linefeed 
   <thead>
     <tr><th>Token<th>Definition
   </thead>
-  <tr><td>`DECIMAL_FLOAT_LITERAL`<td>`(-?[0-9]*\.[0-9]+ | -?[0-9]+\.[0-9]*)((e|E)(\+|-)?[0-9]+)?`
-  <tr><td>`HEX_FLOAT_LITERAL`<td>`-?0x([0-9a-fA-F]*\.?[0-9a-fA-F]+ | [0-9a-fA-F]+\.[0-9a-fA-F]*)(p|P)(\+|-)?[0-9]+`
-  <tr><td>`INT_LITERAL`<td>`-?0x[0-9a-fA-F]+ | 0 | -?[1-9][0-9]*`
-  <tr><td>`UINT_LITERAL`<td>`0x[0-9a-fA-F]+u | 0u | [1-9][0-9]*u`
+  <tr><td>`DECIMAL_FLOAT_LITERAL`<td>`(-?[0-9]*\.[0-9]+|-?[0-9]+\.[0-9]*)((e|E)(\+|-)?[0-9]+)?`
+  <tr><td>`HEX_FLOAT_LITERAL`<td>`-?0x([0-9a-fA-F]*\.?[0-9a-fA-F]+|[0-9a-fA-F]+\.[0-9a-fA-F]*)(p|P)(\+|-)?[0-9]+`
+  <tr><td>`INT_LITERAL`<td>`-?0x[0-9a-fA-F]+|0|-?[1-9][0-9]*`
+  <tr><td>`UINT_LITERAL`<td>`0x[0-9a-fA-F]+u|0u|[1-9][0-9]*u`
 </table>
 
 Note: literals are parsed greedily. This means that for statements like `a -5`

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -330,8 +330,8 @@ TODO: What indicates the end of a line?  (E.g. A line ends at the next linefeed 
   <thead>
     <tr><th>Token<th>Definition
   </thead>
-  <tr><td>`DECIMAL_FLOAT_LITERAL`<td>`(-?[0-9]*.[0-9]+ | -?[0-9]+.[0-9]*)((e|E)(+|-)?[0-9]+)?`
-  <tr><td>`HEX_FLOAT_LITERAL`<td>`-?0x([0-9a-fA-F]*.?[0-9a-fA-F]+ | [0-9a-fA-F]+.[0-9a-fA-F]*)(p|P)(+|-)?[0-9]+`
+  <tr><td>`DECIMAL_FLOAT_LITERAL`<td>`(-?[0-9]*\.[0-9]+ | -?[0-9]+\.[0-9]*)((e|E)(\+|-)?[0-9]+)?`
+  <tr><td>`HEX_FLOAT_LITERAL`<td>`-?0x([0-9a-fA-F]*\.?[0-9a-fA-F]+ | [0-9a-fA-F]+\.[0-9a-fA-F]*)(p|P)(\+|-)?[0-9]+`
   <tr><td>`INT_LITERAL`<td>`-?0x[0-9a-fA-F]+ | 0 | -?[1-9][0-9]*`
   <tr><td>`UINT_LITERAL`<td>`0x[0-9a-fA-F]+u | 0u | [1-9][0-9]*u`
 </table>


### PR DESCRIPTION
Removing ` ` and escaping `+` and `.` makes it possible to depend on these rows as RegEx.