### PR TITLE
Match attribute grammar with attributes

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -389,7 +389,7 @@ attribute_list
   : ATTR_LEFT (attribute COMMA)* attribute ATTR_RIGHT
 
 attribute
-  : IDENT PAREN_LEFT literal_or_ident PAREN_RIGHT
+  : IDENT PAREN_LEFT (literal_or_ident COMMA)* literal_or_ident PAREN_RIGHT
   | IDENT
 
 literal_or_ident


### PR DESCRIPTION
Some attributes take more than one parameter if I am not misreading, while grammar is only a single-parameter attribute definition. This PR aims to match that.