### PR TITLE
Changed isSoftware/forceSoftware to use the term 'fallback'

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1584,7 +1584,7 @@ enum GPUPowerPreference {
 
     : <dfn>forceFallbackAdapter</dfn>
     ::
-        When set to `true` indicates that only [=fallback adapter=] may be returned. If the user
+        When set to `true` indicates that only a [=fallback adapter=] may be returned. If the user
         agent does not support a [=fallback adapter=], will cause {{GPU/requestAdapter()}} to
         resolve to `null`.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -944,6 +944,10 @@ Applications can hold onto multiple [=adapters=] at once (via {{GPUAdapter}})
 and two of these could refer to different instances of the same physical
 configuration (e.g. if the GPU was reset or disconnected and reconnected).
 
+An [=adapter=] may be considered a <dfn>fallback adapter</dfn> if it has significant performance
+caveats in exchange for some combination of wider compatibility, more predictable behavior, or
+improved privacy. It is not required that a [=fallback adapter=] is available on every system.
+
 An [=adapter=] has the following internal slots:
 
 <dl dfn-type=attribute dfn-for=adapter>
@@ -974,10 +978,9 @@ An [=adapter=] has the following internal slots:
         {{GPUDevice/destroy()|GPUDevice.destroy()}} call, etc. It also ensures applications use
         the latest system state to make decisions about which adapter to use.
 
-    : <dfn>\[[software]]</dfn>, of type boolean
+    : <dfn>\[[fallback]]</dfn>, of type boolean
     ::
-        If set to `true` indicates that the adapter is backed by a software implementation of an
-        appropriate graphics API rather than physical GPU hardware.
+        If set to `true` indicates that the adapter is a [=fallback adapter=].
 </dl>
 
 [=Adapters=] are exposed via {{GPUAdapter}}.
@@ -1451,8 +1454,8 @@ interface GPU {
                             `true`, chosen according to the rules in [[#adapter-selection]] and the
                             criteria in |options|.
 
-                        1. If |adapter| is backed by a software graphics API implementation set
-                            |adapter|.{{adapter/[[software]]}} to `true`.
+                        1. If |adapter| meets the criteria of a [=fallback adapter=] set
+                            |adapter|.{{adapter/[[fallback]]}} to `true`.
 
                         1. [=Resolve=] |promise| with a new {{GPUAdapter}} encapsulating |adapter|.
 
@@ -1515,7 +1518,7 @@ configuration is suitable for the application.
 <script type=idl>
 dictionary GPURequestAdapterOptions {
     GPUPowerPreference powerPreference;
-    boolean forceSoftware = false;
+    boolean forceFallbackAdapter = false;
 };
 </script>
 
@@ -1579,19 +1582,19 @@ enum GPUPowerPreference {
                 necessary, since it may significantly decrease battery life on portable devices.
         </dl>
 
-    : <dfn>forceSoftware</dfn>
+    : <dfn>forceFallbackAdapter</dfn>
     ::
-        When set to `true` indicates that only software [=adapters=] may be returned. If the user
-        agent does not support a software [=adapter=], will cause {{GPU/requestAdapter()}} to
+        When set to `true` indicates that only [=fallback adapter=] may be returned. If the user
+        agent does not support a [=fallback adapter=], will cause {{GPU/requestAdapter()}} to
         resolve to `null`.
 
         Note:
-        {{GPU/requestAdapter()}} may still return a software [=adapter=] is
-        {{GPURequestAdapterOptions/forceSoftware}} is set to `false` and either no appropriate
-        hardware [=adapter=] is available or the user agent chooses not to return a hardware
-        [=adapter=]. Developers that wish to prevent their applications from running on software
-        [=adapters=] should check the {{GPUAdapter}}.{{GPUAdapter/isSoftware}} attribute prior to
-        requesting a {{GPUDevice}}.
+        {{GPU/requestAdapter()}} may still return a [=fallback adapter=] if
+        {{GPURequestAdapterOptions/forceFallbackAdapter}} is set to `false` and either no
+        other appropriate [=adapter=] is available or the user agent chooses to return a
+        [=fallback adapter=]. Developers that wish to prevent their applications from running on
+        [=fallback adapters=] should check the {{GPUAdapter}}.{{GPUAdapter/isFallbackAdapter}}
+        attribute prior to requesting a {{GPUDevice}}.
 </dl>
 
 ## <dfn interface>GPUAdapter</dfn> ## {#gpu-adapter}
@@ -1607,7 +1610,7 @@ interface GPUAdapter {
     readonly attribute DOMString name;
     [SameObject] readonly attribute GPUSupportedFeatures features;
     [SameObject] readonly attribute GPUSupportedLimits limits;
-    readonly attribute boolean isSoftware;
+    readonly attribute boolean isFallbackAdapter;
 
     Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor = {});
 };
@@ -1629,9 +1632,9 @@ interface GPUAdapter {
     ::
         The limits in `this`.{{GPUAdapter/[[adapter]]}}.{{adapter/[[limits]]}}.
 
-    : <dfn>isSoftware</dfn>
+    : <dfn>isFallbackAdapter</dfn>
     ::
-        Returns the value of {{GPUAdapter/[[adapter]]}}.{{adapter/[[software]]}}.
+        Returns the value of {{GPUAdapter/[[adapter]]}}.{{adapter/[[fallback]]}}.
 </dl>
 
 {{GPUAdapter}} has the following internal slots:


### PR DESCRIPTION
Fixes #2030.

This change replaces the flags `isSoftware` and `forceSoftware` with `isFallbackAdapter` and `forceFallbackAdapter` respectively, as well as changing up the language around the internal slots. "Fallback" was the term the editors felt most comfortable with after discussing the matter earlier today.

I find the change to be an unfortunate step backwards in terms of intuitiveness, but hopefully the definition offered as part of this change helps clear things up for developers while satisfying the desire expressed in #2030 to not use the terms "software" or "hardware". I do like that these terms allow the behavior and meaning of the flags to remain functionally identical.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/2039.html" title="Last updated on Aug 17, 2021, 1:51 AM UTC (75e7eb2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2039/6831bfa...75e7eb2.html" title="Last updated on Aug 17, 2021, 1:51 AM UTC (75e7eb2)">Diff</a>