### PR TITLE
Fixing VB OOB validation in draw and drawIndexed for zero stride

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7339,13 +7339,20 @@ dictionary GPURenderPassLayout: GPUObjectDescriptorBase {
                     - For each {{GPUIndex32}} |slot| `0` to |buffers|.length:
                         - Let |bufferSize| be |this|.{{GPURenderEncoderBase/[[vertex_buffer_sizes]]}}[|slot|].
                         - Let |stride| be |buffers|[|slot|].{{GPUVertexBufferLayout/arrayStride}}.
-                        - If |buffers|[|slot|].{{GPUVertexBufferLayout/stepMode}} is:
-                            <dl class="switch">
-                                : {{GPUVertexStepMode/"vertex"}}
-                                :: (|firstVertex| + |vertexCount|) * |stride| &le; |bufferSize|.
-                                : {{GPUVertexStepMode/"instance"}}
-                                :: (|firstInstance| + |instanceCount|) * |stride| &le; |bufferSize|.
-                            </dl>
+                        - If |stride| is zero:
+                            - For each attribute |attrib| in the list |this|.{{GPURenderEncoderBase/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}.{{GPUVertexBufferLayout/attributes}}:
+                                - |attrib|.{{GPUVertexAttribute/offset}} + sizeof(|attrib|.{{GPUVertexAttribute/format}}) &le;
+                                    |bufferSize|
+
+                            Otherwise:
+
+                            - If |buffers|[|slot|].{{GPUVertexBufferLayout/stepMode}} is:
+                                <dl class="switch">
+                                    : {{GPUVertexStepMode/"vertex"}}
+                                    :: (|firstVertex| + |vertexCount|) * |stride| &le; |bufferSize|.
+                                    : {{GPUVertexStepMode/"instance"}}
+                                    :: (|firstInstance| + |instanceCount|) * |stride| &le; |bufferSize|.
+                                </dl>
                 </div>
             </div>
         </div>
@@ -7378,10 +7385,17 @@ dictionary GPURenderPassLayout: GPUObjectDescriptorBase {
                         &div; |this|.{{GPURenderEncoderBase/[[index_format]]}}'s byte size;
                     - Let |buffers| be |this|.{{GPURenderEncoderBase/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}.
                     - For each {{GPUIndex32}} |slot| `0` to |buffers|.length:
-                        - If |buffers|[|slot|].{{GPUVertexBufferLayout/stepMode}} is {{GPUVertexStepMode/"instance"}}:
-                            - Let |bufferSize| be |this|.{{GPURenderEncoderBase/[[vertex_buffer_sizes]]}}[|slot|].
-                            - Let |stride| be |buffers|[|slot|].{{GPUVertexBufferLayout/arrayStride}}.
-                            - (|firstInstance| + |instanceCount|) * |stride| &le; |bufferSize|.
+                        - Let |bufferSize| be |this|.{{GPURenderEncoderBase/[[vertex_buffer_sizes]]}}[|slot|].
+                        - Let |stride| be |buffers|[|slot|].{{GPUVertexBufferLayout/arrayStride}}.
+                        - If |stride| is zero:
+                            - For each attribute |attrib| in the list |this|.{{GPURenderEncoderBase/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}.{{GPUVertexBufferLayout/attributes}}:
+                                - |attrib|.{{GPUVertexAttribute/offset}} + sizeof(|attrib|.{{GPUVertexAttribute/format}}) &le;
+                                    |bufferSize|
+
+                            Otherwise:
+
+                            - If |buffers|[|slot|].{{GPUVertexBufferLayout/stepMode}} is {{GPUVertexStepMode/"instance"}}:
+                                - (|firstInstance| + |instanceCount|) * |stride| &le; |bufferSize|.
                 </div>
             </div>
         </div>


### PR DESCRIPTION
In this patch vertex buffer OOB validation are fixed to take the zero-stride buffer situation into consideration.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jzm-intel/gpuweb/pull/2040.html" title="Last updated on Aug 17, 2021, 6:44 AM UTC (915522c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2040/6831bfa...jzm-intel:915522c.html" title="Last updated on Aug 17, 2021, 6:44 AM UTC (915522c)">Diff</a>