### PR TITLE
Restrict statements from matching empty string

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5293,9 +5293,6 @@ through assignment, evaluation in another expression or through use of the
 ## Statements Grammar Summary ## {#statements-summary}
 
 <pre class='def'>
-compound_statement
-  : BRACE_LEFT statements? BRACE_RIGHT
-
 statements
   : statement+
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4755,7 +4755,7 @@ from the start of the next statement until the end of the compound statement.
 
 <pre class='def'>
 compound_statement
-  : BRACE_LEFT statements BRACE_RIGHT
+  : BRACE_LEFT statements? BRACE_RIGHT
 </pre>
 
 ## Assignment Statement ## {#assignment}
@@ -4913,7 +4913,7 @@ which are reachable via a `fallthrough` statement.
 
 <pre class='def'>
 loop_statement
-  : LOOP BRACE_LEFT statements continuing_statement? BRACE_RIGHT
+  : LOOP BRACE_LEFT statements? continuing_statement? BRACE_RIGHT
 </pre>
 
 The <dfn noexport>loop body</dfn> is special form [compound
@@ -5294,10 +5294,10 @@ through assignment, evaluation in another expression or through use of the
 
 <pre class='def'>
 compound_statement
-  : BRACE_LEFT statements BRACE_RIGHT
+  : BRACE_LEFT statements? BRACE_RIGHT
 
 statements
-  : statement*
+  : statement+
 
 statement
   : SEMICOLON


### PR DESCRIPTION
Not restricting statements to be at least one makes it possible to match an empty string when generating parsers that depend on the spec text itself. Some parser generators do not like this to be the case. This PR extends the compatibility of the spec by requiring statements to be at least one statement, and if statements are not necessary to be at least of one count, then they are, by this PR, optional at places where they sit inside.

This PR also removes the duplicate `compound_statement` definition. That's the only duplicate edge case; it is better for a further dependent to not need to workaround this one instance, which can introduce errors.