### PR TITLE
Match let declarations for inferred types

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3113,7 +3113,7 @@ is the one from the constant's declaration or from a pipeline override.
 
 <pre class='def'>
 global_constant_decl
-  : attribute_list* LET variable_ident_decl global_const_initializer?
+  : attribute_list* LET (IDENT | variable_ident_decl) global_const_initializer?
 
 global_const_initializer
   : EQUAL const_expression


### PR DESCRIPTION
The spec states that module constants can be of inferred type. This PR aims to allow that in grammar by matching the definition of `global_constant_decl`'s with `variable_statement`'s.