### PR TITLE
Queries: Update destinationOffset alignment to 256

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6252,7 +6252,7 @@ must be well nested.
                 - |destination|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/QUERY_RESOLVE}}.
                 - |firstQuery| is less than the number of queries in |querySet|.
                 - (|firstQuery| + |queryCount|) is less than or equal to the number of queries in |querySet|.
-                - |destinationOffset| is a multiple of 8.
+                - |destinationOffset| is a multiple of 256.
                 - |destinationOffset| + 8 &times; |queryCount| &le; |destination|.{{GPUBuffer/[[size]]}}.
             </div>
 


### PR DESCRIPTION
From macOS 11.0+, Metal requires the destinationOffset of resolveQuerySet
to be a multiple of 256 bytes, this limit comes from the "Minimum buffer
offset alignment" in https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/haoxli/gpuweb/pull/2054.html" title="Last updated on Aug 23, 2021, 5:59 AM UTC (9254f23)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2054/f43505f...haoxli:9254f23.html" title="Last updated on Aug 23, 2021, 5:59 AM UTC (9254f23)">Diff</a>