### PR TITLE
editorial: move "operation" first in GPUBlendComponent

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5025,9 +5025,9 @@ interface GPUColorWrite {
 
 <script type=idl>
 dictionary GPUBlendComponent {
+    GPUBlendOperation operation = "add";
     GPUBlendFactor srcFactor = "one";
     GPUBlendFactor dstFactor = "zero";
-    GPUBlendOperation operation = "add";
 };
 </script>
 


### PR DESCRIPTION
Changes it to a prefix instead of postfix operation, like the (subjectively) more natural: `operation(srcFactor * src, dstFactor * dst)`


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2056.html" title="Last updated on Aug 23, 2021, 10:17 PM UTC (8fb24c4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2056/c1223ca...kainino0x:8fb24c4.html" title="Last updated on Aug 23, 2021, 10:17 PM UTC (8fb24c4)">Diff</a>