### PR TITLE
Fix atan2() params

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6312,7 +6312,7 @@ value with the same sign.
   <tr><td>`acos(x)`<td>Inherited from `atan2(sqrt(1.0 - x * x), x)`
   <tr><td>`asin(x)`<td>Inherited from `atan2(x, sqrt(1.0 - x * x))`
   <tr><td>`atan(x)`<td>4096 ULP
-  <tr><td>`atan2(x)`<td>4096 ULP
+  <tr><td>`atan2(y, x)`<td>4096 ULP
   <tr><td>`ceil(x)`<td>Correctly rounded
   <tr><td>`clamp(x)`<td>Correctly rounded
   <tr><td>`cos(x)`<td>Absolute error &le; 2<sup>-11</sup> inside the range of [-&pi;, &pi;]


### PR DESCRIPTION
x, y not in alphabetical order here because they also coordinates like in [OpenGL](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/atan.xhtml)/[C++](https://en.cppreference.com/w/cpp/numeric/math/atan2)/[MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/atan2) specifications.