### PR TITLE
Describe resource aliasing rules

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6507,7 +6507,7 @@ interface mixin GPUProgrammablePassEncoder {
                         - Append |textureView| to |textureViews|.
                     - Otherwise, continue.
 
-            Issue(#1842): Revisit this and figure out if we should add a validation error.
+            Issue(gpuweb/gpuweb#1842): Revisit this and figure out if we should add a validation error.
         </div>
 
     Otherwise return `true`.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6488,7 +6488,7 @@ interface mixin GPUProgrammablePassEncoder {
             - Let |textureViews| be an sequence<{{GPUTextureView}} |textureView|>.
             - For each {{GPUBindGroup}} |bindGroup| in |encoder|.{{GPUProgrammablePassEncoder/[[bind_groups]]}}.
                 - Let {{GPUBindGroupLayoutDescriptor}} |bindGroupLayoutDescriptor| be |bindGroup|.{{GPUBindGroup/[[layout]]}}.{{GPUBindGroupLayout/[[descriptor]]}}.
-                - For each {{GPUBindGroupEntry}} |bindGroupEntry| in |bindGroup|.
+                - For each {{GPUBindGroupEntry}} |bindGroupEntry| in |bindGroup|.{{GPUBindGroup/[[entries]]}}:
                     - Let {{GPUBindGroupLayoutEntry}} |bindGroupLayoutEntry| be the {{GPUBindGroupLayoutEntry}} inside |bindGroupLayoutDescriptor|.{{GPUBindGroupLayoutDescriptor/entries}} whose {{GPUBindGroupLayoutEntry/binding}} entry is equal to |bindGroupEntry|.{{GPUBindGroupEntry/binding}}.
                     - If |bindGroupEntry|.{{GPUBindGroupEntry/resource}} is a {{GPUBufferBinding}},
                         - Let {{GPUBufferBinding}} |bufferBinding| be |bindGroupEntry|.{{GPUBindGroupEntry/resource}}.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2719,6 +2719,16 @@ enum GPUTextureAspect {
             </dl>
 </div>
 
+<div algorithm>
+    Two {{GPUTextureView}} objects |a| and |b| are considered <dfn dfn>texture-view-aliasing</dfn> if and only if all of the following are true:
+        - |a|.{{GPUTextureView/[[texture]]}} == |b|.{{GPUTextureView/[[texture]]}}.
+        - Let {{GPUTextureViewDescriptor}} |aDescriptor| = |a|.{{GPUTextureView/[[descriptor]]}}.
+        - Let {{GPUTextureViewDescriptor}} |bDescriptor| = |b|.{{GPUTextureView/[[descriptor]]}}.
+        - |aDescriptor|.{{GPUTextureViewDescriptor/aspect}} == {{GPUTextureAspect/"all"}}, or |bDescriptor|.{{GPUTextureViewDescriptor/aspect}} == {{GPUTextureAspect/"all"}}, or |aDescriptor|.{{GPUTextureViewDescriptor/aspect}} == |bDescriptor|.{{GPUTextureViewDescriptor/aspect}}.
+        - The range formed by |aDescriptor|.{{GPUTextureViewDescriptor/baseMipLevel}} and |aDescriptor|.{{GPUTextureViewDescriptor/mipLevelCount}} intersects the range formed by |bDescriptor|.{{GPUTextureViewDescriptor/baseMipLevel}} and |bDescriptor|.{{GPUTextureViewDescriptor/mipLevelCount}}.
+        - The range formed by |aDescriptor|.{{GPUTextureViewDescriptor/baseArrayLayer}} and |aDescriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} intersects the range formed by |bDescriptor|.{{GPUTextureViewDescriptor/baseArrayLayer}} and |bDescriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}}.
+</div>
+
 ## Texture Formats ## {#texture-formats}
 
 The name of the format specifies the order of components, bits per component,
@@ -3851,6 +3861,12 @@ A {{GPUBindGroup}} object has the following internal slots:
             Issue: define the "effective buffer binding size" separately.
         </div>
 </dl>
+
+<div algorithm>
+    Two {{GPUBufferBinding}} objects |a| and |b| are considered <dfn dfn>buffer-binding-aliasing</dfn> if and only if all of the following are true:
+        - |a|.{{GPUBufferBinding/buffer}} == |b|.{{GPUBufferBinding/buffer}}
+        - The range formed by |a|.{{GPUBufferBinding/offset}} and |a|.{{GPUBufferBinding/size}} intersects the range formed by |b|.{{GPUBufferBinding/offset}} and |b|.{{GPUBufferBinding/size}}.
+</div>
 
 ## <dfn interface>GPUPipelineLayout</dfn> ## {#pipeline-layout}
 
@@ -6465,6 +6481,33 @@ interface mixin GPUProgrammablePassEncoder {
                 - |bindGroup|.{{GPUBindGroup/[[layout]]}} must be [=group-equivalent=] with |bindGroupLayout|.
 
             Issue: Check buffer bindings against `minBindingSize` if present.
+        </div>
+
+        <div class=validusage>
+            - Let |bufferBindings| be a sequence<{{GPUBufferBinding}} |bufferBinding|>.
+            - Let |textureViews| be an sequence<{{GPUTextureView}} |textureView|>.
+            - For each {{GPUBindGroup}} |bindGroup| in |encoder|.{{GPUProgrammablePassEncoder/[[bind_groups]]}}.
+                - Let {{GPUBindGroupLayoutDescriptor}} |bindGroupLayoutDescriptor| be |bindGroup|.{{GPUBindGroup/[[layout]]}}.{{GPUBindGroupLayout/[[descriptor]]}}.
+                - For each {{GPUBindGroupEntry}} |bindGroupEntry| in |bindGroup|.
+                    - Let {{GPUBindGroupLayoutEntry}} |bindGroupLayoutEntry| be the {{GPUBindGroupLayoutEntry}} inside |bindGroupLayoutDescriptor|.{{GPUBindGroupLayoutDescriptor/entries}} whose {{GPUBindGroupLayoutEntry/binding}} entry is equal to |bindGroupEntry|.{{GPUBindGroupEntry/binding}}.
+                    - If |bindGroupEntry|.{{GPUBindGroupEntry/resource}} is a {{GPUBufferBinding}},
+                        - Let {{GPUBufferBinding}} |bufferBinding| be |bindGroupEntry|.{{GPUBindGroupEntry/resource}}.
+                        - Let {{GPUBufferBindingLayout}} |bufferBindingLayout| be |bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/buffer}}. It must not be `null`.
+                        - If |bufferBindingLayout|.{{GPUBufferBindingLayout/type}} is not {{GPUBufferBindingType/"storage"}}, continue.
+                        - For each {{GPUBufferBinding}} |existingBufferBinding| in |bufferBindings|,
+                            - |existingBufferBinding| and |bufferBinding| must not be [=buffer-binding-aliasing=].
+                        - Append |bufferBinding| to |bufferBindings|.
+                    - Otherwise, if |bindGroupEntry|.{{GPUBindGroupEntry/resource}} is a {{GPUTextureView}},
+                        - Let {{GPUTextureView}} |textureView| be |bindGroupEntry|.{{GPUBindGroupEntry/resource}}.
+                        - If |bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/storageTexture}} is `null`, continue.
+                        - Let {{GPUStorageTextureBindingLayout}} |storageTextureBindingLayout| be |bindGroupLayoutEntry|.{{GPUBindGroupLayoutEntry/storageTexture}}.
+                        - If |storageTextureBindingLayout|.{{GPUStorageTextureBindingLayout/access}} is not {{GPUStorageTextureAccess/"write-only"}}, continue.
+                        - For each {{GPUTextureView}} |existingTextureView| in |textureViews|,
+                            - |existingTextureView| and |textureView| must not be [=texture-view-aliasing=].
+                        - Append |textureView| to |textureViews|.
+                    - Otherwise, continue.
+
+            Issue(#1842): Revisit this and figure out if we should add a validation error.
         </div>
 
     Otherwise return `true`.


### PR DESCRIPTION
Fixes https://github.com/gpuweb/gpuweb/issues/1842

From that issue:

> Resolution:
> For now, add something to the spec that says "bindings must not alias", but don't add an actual validation error. Add an "Issue(#1842):" that says to revisit this and figure out if we should add a validation error.

This patch does exactly that.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/litherum/gpuweb/pull/2065.html" title="Last updated on Aug 25, 2021, 4:07 AM UTC (c48a696)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2065/11e3392...litherum:c48a696.html" title="Last updated on Aug 25, 2021, 4:07 AM UTC (c48a696)">Diff</a>