### PR TITLE
Changing Float32Array to GPUBuffer in copyBufferToBuffer

### DIFF
--- a/explainer/index.bs
+++ b/explainer/index.bs
@@ -846,7 +846,7 @@ When using advanced methods to transfer data to the GPU (with a rolling list of 
 
                 const {uniformBuffer, uniformOffset} = getUniformsForDraw(i);
                 copyEncoder.copyBufferToBuffer(
-                    stagingData, i * 16,
+                    stagingBuffer, i * 16,
                     uniformBuffer, uniformOffset,
                     16);
 


### PR DESCRIPTION
I noticed the current explainer has stagingData (a Float32Array) as the first argument in `copyEncoder.copyBufferToBuffer`. I believe `stagingBuffer` was the intended argument here.