### PR TITLE
fix mix and fma builtins to match GLSLstd450

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7001,7 +7001,7 @@ That's not a full user-defined function declaration.
     (GLSLstd450Floor)
 
   <tr algorithm="fma">
-    <td>|T| is f32
+    <td>|T| is [FLOATING]
     <td class="nowrap">`fma(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T| `) -> ` |T|
     <td>Returns |e1| `*` |e2| `+` |e3|.
     [=Component-wise=] when |T| is a vector.
@@ -7105,8 +7105,7 @@ struct _frexp_result_vecN {
 
   <tr algorithm="mix">
     <td>|T| is [FLOATING]<br>
-        |U| is |T| or f32
-    <td class="nowrap">`mix(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |U|`) -> ` |T|
+    <td class="nowrap">`mix(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T|`) -> ` |T|
     <td>Returns the linear blend of |e1| and |e2| (e.g. |e1|`*(1-`|e3|`)+`|e2|`*`|e3|).
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450FMix)


### PR DESCRIPTION
FMix:
The operands must all be a scalar or vector whose component type is floating-point.
Result Type and the type of **all operands must be the same type**.

Fma:
The operands must all be **a scalar or vector whose component type is floating-point**.
Result Type and the type of all operands must be the same type.