### PR TITLE
Prevent PipelineLayouts from using implicitly created BindGroupLayouts

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3942,7 +3942,8 @@ dictionary GPUPipelineLayoutDescriptor : GPUObjectDescriptorBase {
                         for all |bgl| in |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}.
 
                     - Every {{GPUBindGroupLayout}} in |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
-                        must be [$valid to use with$] |this|.
+                        must be [$valid to use with$] |this| and have a {{GPUBindGroupLayout/[[exclusivePipeline]]}}
+                        of `null`.
                     - The [=list/size=] of |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
                         must be &le; |limits|.{{supported limits/maxBindGroups}}.
                     - |allEntries| must not [=exceeds the binding slot limits|exceed the binding slot limits=] of |limits|.


### PR DESCRIPTION
One important piece of my fix for #1806 that I accidentally left out of #2057: We need to prevent PipelineLayouts from being created with BindGroupLayouts that were produced by another pipeline's default layout. Otherwise the new checks would allow you to create pipelines that could never be used because their bind group layouts only work with a different pipline.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/2068.html" title="Last updated on Aug 26, 2021, 7:43 PM UTC (b7812f1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2068/8b132c4...b7812f1.html" title="Last updated on Aug 26, 2021, 7:43 PM UTC (b7812f1)">Diff</a>