### PR TITLE
Add defaults for GPUTextureSampleType in the default pipeline layout

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4265,16 +4265,26 @@ run the following steps:
                 1. Let |textureLayout| be a new {{GPUTextureBindingLayout}}.
 
                 1. If |resource| is a depth texture binding:
-                    1. Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"depth"}}
-                1. Else if the sampled type of |resource| is `f32`, and |resource| is statically used with a
-                    textureSample* builtin in the shader:
-                    1. Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"float"}}
-                1. Else if the sampled type of |resource| is `f32`:
-                    1. Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"unfilterable-float"}}
-                1. Else if the sampled type of |resource| is `i32`:
-                    1. Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"sint"}}
-                1. Else if the sampled type of |resource| is `u32`:
-                    1. Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"uint"}}
+                    - Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"depth"}}
+
+                    Else if the sampled type of |resource| is:
+
+                    -
+                        <dl class=switch>
+                            : `f32`
+                            :: If |resource| is statically used with a textureSample* builtin in the shader:
+                                - Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to
+                                    {{GPUTextureSampleType/"float"}}
+
+                                Else:
+
+                                - Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to
+                                    {{GPUTextureSampleType/"unfilterable-float"}}
+                            : `i32`
+                            :: Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"sint"}}
+                            : `u32`
+                            :: Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"uint"}}
+                        </dl>
 
                 1. Set |textureLayout|.{{GPUTextureBindingLayout/viewDimension}} to |resource|'s dimension.
                 1. If |resource| is for a multisampled texture:
@@ -4312,7 +4322,8 @@ run the following steps:
                     {{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/sampleType}} than |previousEntry|
                     and both |entry| and |previousEntry| have {{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/sampleType}}
                     of either {{GPUTextureSampleType/"float"}} or {{GPUTextureSampleType/"unfilterable-float"}}:
-                    1. Set {{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"float"}}.
+                    1. Set |previousEntry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/sampleType}} to
+                        {{GPUTextureSampleType/"float"}}.
 
                 1. If any other property is unequal between |entry| and |previousEntry|:
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4264,9 +4264,17 @@ run the following steps:
 
                 1. Let |textureLayout| be a new {{GPUTextureBindingLayout}}.
 
-                1. Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to |resource|'s component type.
-
-                    Issue: Detail how the sampleType is chosen from the binding.
+                1. If |resource| is a depth texture binding:
+                    1. Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"depth"}}
+                1. Else if the sampled type of |resource| is `f32`, and |resource| is statically used with a
+                    textureSample* builtin in the shader:
+                    1. Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"float"}}
+                1. Else if the sampled type of |resource| is `f32`:
+                    1. Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"unfilterable-float"}}
+                1. Else if the sampled type of |resource| is `i32`:
+                    1. Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"sint"}}
+                1. Else if the sampled type of |resource| is `u32`:
+                    1. Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"uint"}}
 
                 1. Set |textureLayout|.{{GPUTextureBindingLayout/viewDimension}} to |resource|'s dimension.
                 1. If |resource| is for a multisampled texture:
@@ -4299,6 +4307,12 @@ run the following steps:
 
                     1. Set |previousEntry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}}
                         to |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}}.
+
+                1. If |resource| is a sampled texture binding and |entry| has different
+                    {{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/sampleType}} than |previousEntry|
+                    and both |entry| and |previousEntry| have {{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/sampleType}}
+                    of either {{GPUTextureSampleType/"float"}} or {{GPUTextureSampleType/"unfilterable-float"}}:
+                    1. Set {{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"float"}}.
 
                 1. If any other property is unequal between |entry| and |previousEntry|:
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4271,15 +4271,10 @@ run the following steps:
 
                     -
                         <dl class=switch>
-                            : `f32`
-                            :: If |resource| is statically used with a textureSample* builtin in the shader:
-                                - Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to
-                                    {{GPUTextureSampleType/"float"}}
-
-                                Else:
-
-                                - Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to
-                                    {{GPUTextureSampleType/"unfilterable-float"}}
+                            : `f32` and |resource| is statically used with a textureSample* builtin in the shader
+                            :: Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"float"}}
+                            : `f32` otherwise
+                            :: Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"unfilterable-float"}}
                             : `i32`
                             :: Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"sint"}}
                             : `u32`


### PR DESCRIPTION
Closes #2064


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/austinEng/gpuweb/pull/2078.html" title="Last updated on Sep 2, 2021, 6:22 PM UTC (188d239)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2078/20a8bfd...austinEng:188d239.html" title="Last updated on Sep 2, 2021, 6:22 PM UTC (188d239)">Diff</a>