### PR TITLE
Require GPURenderPassDepthStencilAttachments to reference all aspects

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7145,7 +7145,7 @@ dictionary GPURenderPassDepthStencilAttachment {
     - |this|.{{GPURenderPassDepthStencilAttachment/view}} must have a [=depth or stencil renderable
         format=].
     - |this|.{{GPURenderPassDepthStencilAttachment/view}} must be a view of
-         all the [=texture subresources=] in the texture.
+         a single [=mipmap level=], single [=array layer=], and all the [=aspects=] in the texture.
     - |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}}
         must contain {{GPUTextureUsage/RENDER_ATTACHMENT}}.
     - If |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7144,8 +7144,8 @@ dictionary GPURenderPassDepthStencilAttachment {
 
     - |this|.{{GPURenderPassDepthStencilAttachment/view}} must have a [=depth or stencil renderable
         format=].
-    - |this|.{{GPURenderPassDepthStencilAttachment/view}} must be a view of a
-        single [=texture subresource=].
+    - |this|.{{GPURenderPassDepthStencilAttachment/view}} must be a view of
+         all the [=texture subresources=] in the texture.
     - |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}}
         must contain {{GPUTextureUsage/RENDER_ATTACHMENT}}.
     - If |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}


### PR DESCRIPTION
Closes #2062


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/austinEng/gpuweb/pull/2079.html" title="Last updated on Sep 17, 2021, 4:35 PM UTC (1887441)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2079/20a8bfd...austinEng:1887441.html" title="Last updated on Sep 17, 2021, 4:35 PM UTC (1887441)">Diff</a>