### PR TITLE
precise_math attribute on functions

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -541,9 +541,9 @@ literal_or_ident
     Indicates that the arithmetic computations in the function should be performed
     under stricter [[#floating-point-evaluation]]:
       * without [=Reassociation|reassociating=] subexpressions
-      * while preserving infinities, NaNs, and signed zeroes
 
-    The exact nature of the reduced optimizations is platform-dependent.
+    Note: this translates to `NoContraction` decoration in SPIR-V, `precise` qualifier in HLSL,
+    and a subset of `"-fno-fast-math" group of compile options in MSL.
 
     This attribute doesn't recursively affect other functions called from the current function.
 
@@ -5373,10 +5373,11 @@ function_decl
   : attribute_list* function_header compound_statement
 
 function_header
-  : FN IDENT PAREN_LEFT param_list PAREN_RIGHT function_return_type_decl?
+  : FN IDENT PAREN_LEFT param_list PAREN_RIGHT function_return_type_decl_optional
 
-function_return_type_decl
-  : ARROW attribute_list* type_decl
+function_return_type_decl_optional
+  :
+  | ARROW attribute_list* type_decl
 
 param_list
   :

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -535,6 +535,20 @@ literal_or_ident
     The third parameter, if provided, specifies the z dimension, otherwise is assumed to be 1.
     Each dimension must be at least 1 and at most an upper bound specified by the WebGPU API.
 
+  <tr><td><dfn noexport dfn-for="attribute">`precise_math`</dfn>
+    <td>*None*
+
+    Indicates that the arithmetic computations in the function need to be performed with
+    extra precision. As such, the WebGPU implementation would attempt to avoid optimizations
+    based on [[#floating-point-evaluation]] assumptions.
+
+    In addition, no operand re-ordering is done based on associative and distributive properties
+    of the operations.
+
+    The exact nature of the reduced optimizations is platform-dependent.
+
+    This attribute doesn't recursively affect other functions called from the current functions.
+
 </table>
 
 
@@ -5361,11 +5375,10 @@ function_decl
   : attribute_list* function_header compound_statement
 
 function_header
-  : FN IDENT PAREN_LEFT param_list PAREN_RIGHT function_return_type_decl_optional
+  : FN IDENT PAREN_LEFT param_list PAREN_RIGHT function_return_type_decl?
 
-function_return_type_decl_optional
-  :
-  | ARROW attribute_list* type_decl
+function_return_type_decl
+  : ARROW attribute_list* type_decl
 
 param_list
   :
@@ -5378,6 +5391,7 @@ param
 [SHORTNAME] defines the following attributes that can be applied to function declarations:
  * [=attribute/stage=]
  * [=attribute/workgroup_size=]
+ * [=attribute/precise_math=]
 
 [SHORTNAME] defines the following attributes that can be applied to function
 parameters and return types:
@@ -6237,6 +6251,9 @@ the following exceptions:
     any operation listed in [[#floating-point-accuracy]].
     * Other operations are required to preserve denormalized numbers.
 * The accuracy of operations is given in [[#floating-point-accuracy]].
+
+[SHORTNAME] attemps to reduce the scope of applied exceptions to floating-point operations
+in functions with [=attribute/precise_math=] attributes.
 
 ### Floating Point Accuracy ### {#floating-point-accuracy}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -538,16 +538,14 @@ literal_or_ident
   <tr><td><dfn noexport dfn-for="attribute">`precise_math`</dfn>
     <td>*None*
 
-    Indicates that the arithmetic computations in the function need to be performed with
-    extra precision. As such, the WebGPU implementation would attempt to avoid optimizations
-    based on [[#floating-point-evaluation]] assumptions.
-
-    In addition, no operand re-ordering is done based on associative and distributive properties
-    of the operations.
+    Indicates that the arithmetic computations in the function should be performed
+    under stricter [[#floating-point-evaluation]]:
+      * without [=Reassociation|reassociating=] subexpressions
+      * while preserving infinities, NaNs, and signed zeroes
 
     The exact nature of the reduced optimizations is platform-dependent.
 
-    This attribute doesn't recursively affect other functions called from the current functions.
+    This attribute doesn't recursively affect other functions called from the current function.
 
 </table>
 


### PR DESCRIPTION
Closes #2077 
Fixes #2076 

- On SPIR-V, this would decorate affected expressions with `NoContraction`.
- On Metal, this would add "-fno-fast-math" (or a subset of it) to the affected `MTLLibrary`.
- On DX12 this would add `precise` to the variable declarations used by the affected functions.

Note: `SignedZeroInfNanPreserve` and other features of `VK_KHR_shader_float_controls` are intentionally not included.