### PR TITLE
Rewrite select() for scalar condition and add missing algorithm tags

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6901,31 +6901,36 @@ That's not a full user-defined function declaration.
 
 <table class='data'>
   <thead>
-    <tr><th>Precondition<td>Conclusion<td>Notes
+    <tr><th>Precondition<th style="width:45%">Conclusion<td>Description
   </thead>
   <tr algorithm="vector all">
-    <td>|e|: vecN&lt;bool&gt;
-    <td>`all(`|e|`)`: bool
+    <td>|T| is bool
+    <td>`all(`|e|`:` vecN<|T|`> ) -> ` |T|
     <td>Returns true if each component of |e| is true.
     (OpAll)
 
   <tr algorithm="vector any">
-    <td>|e|: vecN&lt;bool&gt;
-    <td>`any(`|e|`)`: bool
+    <td>|T| is bool
+    <td>`any(`|e|`:` vecN<|T|`> ) -> ` |T|
     <td>Returns true if any component of |e| is true.
     (OpAny)
 
   <tr algorithm="scalar select">
-    <td>|T| is a scalar
-    <td>`select(`|f|`: `|T|` , `|t|`: `|T|`, `|cond|`: bool)`: |T|
-    <td>Returns |t| when |cond| is true, and |f| otherwise.
+    <td>|T| is a scalar<br>|I| is bool
+    <td>`select(`|e1|`: ` |T|` , `|e2|`: ` |T|`, `|e3|`: ` |I|` ) -> ` |T|
+    <td>Returns |e1| when |e3| is true, and |e2| otherwise.
     (OpSelect)
 
   <tr algorithm="vector select">
-    <td>|T| is a scalar
-    <td>`select(`|f|`: vecN<`|T|`>, `|t|`: vecN<`|T|`, `|cond|`: vecN<bool>>)`
-    <td>[=Component-wise=] selection. Result component |i| is evaluated as `select(`|f|`[`|i|`], `|t|`[`|i|`], `|cond|`[`|i|`])`.
+    <td>|T| is a scalar<br>|I| is bool
+    <td>`select(`|e1|`: vecN<`|T|`>, `|e2|`: vecN<`|T|`>, `|e3|`: vecN<`|I|`>) -> ` vecN<|T|>
+    <td>[=Component-wise=] selection. Result component |i| is evaluated as `select(`|e1|`[`|i|`], `|e2|`[`|i|`], `|e3|`[`|i|`])`.
     (OpSelect)
+
+  <tr algorithm="vector select with scalar condiction">
+    <td>|T| is a scalar<br>|I| is bool
+    <td>`select(`|e1|`: vecN<`|T|`>, `|e2|`: vecN<`|T|`>, `|e3|`: ` |I|`) -> ` vecN<|T|>
+    <td>Returns the [=Component-wise=] selection, using bool |e3| as condition for each component. Same as `select(`|e1|`[`|i|`], `|e2|`[`|i|`], `|T|`(`|e3|`))`.
 </table>
 
 ## Value-testing built-in functions ## {#value-testing-builtin-functions}
@@ -6934,28 +6939,30 @@ That's not a full user-defined function declaration.
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
-  <tr><td rowspan=4>
-    |e|: |T|<br>
-    |T| is [FLOATING]<br>
-    |TR| is bool if |T| is a scalar, or<br>
-    vec|N|&lt;bool&gt; if |T| is a vector
-
-    <td class="nowrap">`isNan(`|e|`) -> `|TR|
+  <tr algorithm="isNan">
+  <td rowspan=4>
+    |I| is [FLOATING]<br>
+    |T| is bool if |I| is a scalar, or<br>
+    vec|N|&lt;bool&gt; if |I| is a vector
+    <td class="nowrap">`isNan(`|e|`:` |I| `) -> ` |T|
     <td>Test for NaN according to [[!IEEE-754|IEEE-754]].<br>
-    [=Component-wise=] when |T| is a vector. (OpIsNan)
-  <tr><td class="nowrap">`isInf(`|e|`) -> `|TR|
+    [=Component-wise=] when |I| is a vector. (OpIsNan)
+  <tr algorithm="isInf">
+    <td class="nowrap">`isInf(`|e|`:` |I| `) -> ` |T|
     <td>Test for infinity according to [[!IEEE-754|IEEE-754]].<br>
-    [=Component-wise=] when |T| is a vector. (OpIsInf)
-  <tr><td class="nowrap">`isFinite(`|e|`) -> `|TR|
+    [=Component-wise=] when |I| is a vector. (OpIsInf)
+  <tr algorithm="isFinite">
+    <td class="nowrap">`isFinite(`|e|`:` |I| `) -> ` |T|
     <td>Test a finite value according to [[!IEEE-754|IEEE-754]].<br>
-    [=Component-wise=] when |T| is a vector.
-  <tr><td class="nowrap">`isNormal(`|e|`) -> `|TR|
+    [=Component-wise=] when |I| is a vector.
+  <tr algorithm="isNormal">
+    <td class="nowrap">`isNormal(`|e|`:` |I| `) -> ` |T|
     <td>Test a normal value according to [[!IEEE-754|IEEE-754]].<br>
-    [=Component-wise=] when |T| is a vector.
+    [=Component-wise=] when |I| is a vector.
 
   <tr algorithm="runtime-sized array length">
-    <td>|e|: ptr&lt;storage,array&lt;|T|&gt;&gt;
-    <td>`arrayLength(`|e|`)`: u32<td>Returns the number of elements in the [=runtime-sized=] array.<br>
+    <td>|T| is u32
+    <td>`arrayLength(`|e|`:` ptr&lt;storage,array&lt;|I|&gt;&gt; `) -> ` |T|<td>Returns the number of elements in the [=runtime-sized=] array.<br>
         (OpArrayLength, but the implementation has to trace back to get the pointer to the enclosing struct.)
 </table>
 
@@ -7450,40 +7457,47 @@ These functions:
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
-  <tr><td rowspan=9>|T| is f32 or vecN&lt;f32&gt;
-  <td>`dpdx(`|e|`: `|T|`) ->` |T|
-  <td>Partial derivative of |e| with respect to window x coordinates.
-  The result is the same as either `dpdxFine(`|e|`)` or `dpdxCoarse(`|e|`)`.
-  (OpDPdx)
-  <tr><td>`dpdxCoarse(`|e|`: `|T|`) -> `|T|
-  <td>Returns the partial derivative of |e| with respect to window x coordinates using local differences.
-  This may result in fewer unique positions that `dpdxFine(`|e|`)`.
-  (OpDPdxCoarse)
-  <tr><td>`dpdxFine(`|e|`: `|T|`) -> `|T|
-  <td>Returns the partial derivative of |e| with respect to window x coordinates.
-  (OpDPdxFine)
-
-  <tr><td>`dpdy(`|e|`: `|T|`) -> `|T|
-  <td>Partial derivative of |e| with respect to window y coordinates.
-  The result is the same as either `dpdyFine(`|e|`)` or `dpdyCoarse(`|e|`)`.
-  (OpDPdy)
-  <tr><td>`dpdyCoarse(`|e|`: `|T|`) -> `|T|
-  <td>Returns the partial derivative of |e| with respect to window y coordinates using local differences.
-  This may result in fewer unique positions that `dpdyFine(`|e|`)`.
-  (OpDPdyCoarse)
-  <tr><td>`dpdyFine(`|e|`: `|T|`) -> `|T|
-  <td>Returns the partial derivative of |e| with respect to window y coordinates.
-  (OpDPdyFine)
-
-  <tr><td>`fwidth(`|e|`: `|T|`) -> `|T|
-  <td>Returns `abs(dpdx(`|e|`)) + abs(dpdy(`|e|`))`.
-  (OpFwidth)
-  <tr><td>`fwidthCoarse(`|e|`: `|T|`) -> `|T|
-  <td>Returns `abs(dpdxCoarse(`|e|`)) + abs(dpdyCoarse(`|e|`))`.
-  (OpFwidthCoarse)
-  <tr><td>`fwidthFine(`|e|`: `|T|`) -> `|T|
-  <td>Returns `abs(dpdxFine(`|e|`)) + abs(dpdyFine(`|e|`))`.
-  (OpFwidthFine)
+  <tr algorithm="dpdx">
+  <td rowspan=9>|T| is f32 or vecN&lt;f32&gt;
+    <td>`dpdx(`|e|`: `|T|`) ->` |T|
+    <td>Partial derivative of |e| with respect to window x coordinates.
+    The result is the same as either `dpdxFine(`|e|`)` or `dpdxCoarse(`|e|`)`.
+    (OpDPdx)
+  <tr algorithm="dpdxCoarse">
+    <td>`dpdxCoarse(`|e|`: `|T|`) -> `|T|
+    <td>Returns the partial derivative of |e| with respect to window x coordinates using local differences.
+    This may result in fewer unique positions that `dpdxFine(`|e|`)`.
+    (OpDPdxCoarse)
+  <tr algorithm="dpdxFine">
+    <td>`dpdxFine(`|e|`: `|T|`) -> `|T|
+    <td>Returns the partial derivative of |e| with respect to window x coordinates.
+    (OpDPdxFine)
+  <tr algorithm="dpdy">
+    <td>`dpdy(`|e|`: `|T|`) -> `|T|
+    <td>Partial derivative of |e| with respect to window y coordinates.
+    The result is the same as either `dpdyFine(`|e|`)` or `dpdyCoarse(`|e|`)`.
+    (OpDPdy)
+  <tr algorithm="dpdyCoarse">
+    <td>`dpdyCoarse(`|e|`: `|T|`) -> `|T|
+    <td>Returns the partial derivative of |e| with respect to window y coordinates using local differences.
+    This may result in fewer unique positions that `dpdyFine(`|e|`)`.
+    (OpDPdyCoarse)
+  <tr algorithm="dpdyFine">
+    <td>`dpdyFine(`|e|`: `|T|`) -> `|T|
+    <td>Returns the partial derivative of |e| with respect to window y coordinates.
+    (OpDPdyFine)
+  <tr algorithm="fwidth">
+    <td>`fwidth(`|e|`: `|T|`) -> `|T|
+    <td>Returns `abs(dpdx(`|e|`)) + abs(dpdy(`|e|`))`.
+    (OpFwidth)
+  <tr algorithm="fwidthCoarse">
+    <td>`fwidthCoarse(`|e|`: `|T|`) -> `|T|
+    <td>Returns `abs(dpdxCoarse(`|e|`)) + abs(dpdyCoarse(`|e|`))`.
+    (OpFwidthCoarse)
+  <tr algorithm="fwidthFine">
+    <td>`fwidthFine(`|e|`: `|T|`) -> `|T|
+    <td>Returns `abs(dpdxFine(`|e|`)) + abs(dpdyFine(`|e|`))`.
+    (OpFwidthFine)
 </table>
 
 ## Texture built-in functions ## {#texture-builtin-functions}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6956,8 +6956,8 @@ That's not a full user-defined function declaration.
     [=Component-wise=] when |I| is a vector.
 
   <tr algorithm="runtime-sized array length">
-    <td>|T| is u32
-    <td>`arrayLength(`|e|`:` ptr&lt;storage,array&lt;|I|&gt;&gt; `) -> ` |T|<td>Returns the number of elements in the [=runtime-sized=] array.<br>
+    <td>|e|: ptr&lt;storage,array&lt;|T|&gt;&gt;
+    <td>`arrayLength(`|e|`)`: u32<td>Returns the number of elements in the [=runtime-sized=] array.<br>
         (OpArrayLength, but the implementation has to trace back to get the pointer to the enclosing struct.)
 </table>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6901,36 +6901,31 @@ That's not a full user-defined function declaration.
 
 <table class='data'>
   <thead>
-    <tr><th>Precondition<th style="width:45%">Conclusion<td>Description
+    <tr><th>Precondition<td>Conclusion<td>Notes
   </thead>
   <tr algorithm="vector all">
-    <td>|T| is bool
-    <td>`all(`|e|`:` vecN<|T|`> ) -> ` |T|
+    <td>|e|: vecN&lt;bool&gt;
+    <td>`all(`|e|`)`: bool
     <td>Returns true if each component of |e| is true.
     (OpAll)
 
   <tr algorithm="vector any">
-    <td>|T| is bool
-    <td>`any(`|e|`:` vecN<|T|`> ) -> ` |T|
+    <td>|e|: vecN&lt;bool&gt;
+    <td>`any(`|e|`)`: bool
     <td>Returns true if any component of |e| is true.
     (OpAny)
 
   <tr algorithm="scalar select">
-    <td>|T| is a scalar<br>|I| is bool
-    <td>`select(`|e1|`: ` |T|` , `|e2|`: ` |T|`, `|e3|`: ` |I|` ) -> ` |T|
-    <td>Returns |e1| when |e3| is true, and |e2| otherwise.
+    <td>|T| is a scalar or a vector
+    <td>`select(`|f|`: `|T|` , `|t|`: `|T|`, `|cond|`: bool)`: |T|
+    <td>Returns |t| when |cond| is true, and |f| otherwise.
     (OpSelect)
 
   <tr algorithm="vector select">
-    <td>|T| is a scalar<br>|I| is bool
-    <td>`select(`|e1|`: vecN<`|T|`>, `|e2|`: vecN<`|T|`>, `|e3|`: vecN<`|I|`>) -> ` vecN<|T|>
-    <td>[=Component-wise=] selection. Result component |i| is evaluated as `select(`|e1|`[`|i|`], `|e2|`[`|i|`], `|e3|`[`|i|`])`.
+    <td>|T| is a scalar
+    <td>`select(`|f|`: vecN<`|T|`>, `|t|`: vecN<`|T|`, `|cond|`: vecN<bool>>)`
+    <td>[=Component-wise=] selection. Result component |i| is evaluated as `select(`|f|`[`|i|`], `|t|`[`|i|`], `|cond|`[`|i|`])`.
     (OpSelect)
-
-  <tr algorithm="vector select with scalar condiction">
-    <td>|T| is a scalar<br>|I| is bool
-    <td>`select(`|e1|`: vecN<`|T|`>, `|e2|`: vecN<`|T|`>, `|e3|`: ` |I|`) -> ` vecN<|T|>
-    <td>Returns the [=Component-wise=] selection, using bool |e3| as condition for each component. Same as `select(`|e1|`[`|i|`], `|e2|`[`|i|`], `|T|`(`|e3|`))`.
 </table>
 
 ## Value-testing built-in functions ## {#value-testing-builtin-functions}


### PR DESCRIPTION
Add select()  overload back in:  the third component can be a scalar[ #826](https://github.com/gpuweb/gpuweb/issues/826) (accidentally removed in #1957).

Add missing algorithm tag to value-testing and derivative built-in functions to follow [this](https://www.w3.org/TR/WGSL/#w3c-conformant-algorithms). Which also helps with parsing the spec (eg. to extract builtin function names).

