### PR TITLE
Fill out "Textual structure", eliminating several TODOs

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -305,9 +305,7 @@ The WebGPU specification describes the consequences of each kind of error.
 
 TODO: Update the WebGPU spec, referring back to the three kinds of errors defined here.
 
-# Textual structure TODO # {#textual-structure}
-
-TODO: This is a stub.
+# Textual structure # {#textual-structure}
 
 A [SHORTNAME] program is text.
 This specification does not prescribe a particular encoding for that text.
@@ -316,19 +314,75 @@ However, UTF-8 is always a valid encoding for a [SHORTNAME] program.
 Note: The intent of promoting UTF-8 like this is to simplify interchange of [SHORTNAME] programs
 and to encourage interoperability among tools.
 
+[SHORTNAME] program text consists of a sequence of characters, grouped into contiguous non-empty sets forming:
+* [=comments=]
+* [=tokens=]
+* [=blankspace=]
+
+<dfn>Blankspace</dfn> is any combination of one or more of the following characters:
+* space
+* tab
+* linefeed
+* vertical tab
+* formfeed
+* carriage return
+
+Issue: What else should be blankspace? Anything in the Unicode Separator category?
+
+To parse a [SHORTNAME] program:
+1. Remove comments:
+    * Replace the first comment with a space character.
+    * Repeat until no comments remain.
+2. Scanning from beginning to end, group the remaining characters into tokens and blankspace
+    in greedy fashion:
+    * The next group is formed from the longest
+        non-empty prefix of the remaining ungrouped characters, that is either:
+        * a valid token, or
+        * blankspace
+    * Repeat until no ungrouped characters remain.
+3. Discard the blankspace, leaving only tokens.
+3. Parse the token sequence, attempting to match the `translation_unit` grammar rule.
+
+<pre class='def'>
+translation_unit
+  : global_decl_or_directive*
+</pre>
+
+A [=shader-creation error=] results if:
+* the entire source text cannot be converted into a finite sequence of valid tokens, or
+* the `translation_unit` grammar rule does not match the entire token sequence.
+
 ## Comments ## {#comments}
 
-Comments begin with `//` and continue to the end of the current line. There are no multi-line comments.
+A <dfn>comment</dfn> is a span of text that does not influence the validity or meaning of a [SHORTNAME]
+program, except that a comment can separate [=tokens=].
+Shader authors can use comments to document their programs.
 
-TODO: What indicates the end of a line?  (E.g. A line ends at the next linefeed or at the end of the program)
+A <dfn noexport>line-ending comment</dfn> is a kind of [=comment=] consisting
+of the two characters `//` and the characters that follow,
+up until the next linefeed or the end of the program.
 
-## Tokens TODO ## {#tokens}
+TODO(dneto): Incorporate block comments, per https://github.com/gpuweb/gpuweb/pull/1470
 
-## Literals TODO ## {#literals}
+## Tokens ## {#tokens}
 
+A <dfn>token</dfn> is a contiguous sequence of characters forming one of:
+* a [=literal=].
+* a [=keyword=].
+* a [=reserved word=].
+* a [=syntactic token=].
+* an [=identifier=].
+
+## Literals ## {#literals}
+
+A <dfn>literal</dfn> is one of:
+* a <dfn>numeric literal</dfn>, used to represent a number.
+* a <dfn noexport>boolean literal</dfn>: either `true` or `false`.
+
+The form of a [=numeric literal=] is defined via pattern-matching:
 <table class='data'>
   <thead>
-    <tr><th>Token<th>Definition
+    <tr><th>Numeric literal<th>Textual pattern
   </thead>
   <tr><td>`DECIMAL_FLOAT_LITERAL`<td>`(-?[0-9]*\.[0-9]+|-?[0-9]+\.[0-9]*)((e|E)(\+|-)?[0-9]+)?`
   <tr><td>`HEX_FLOAT_LITERAL`<td>`-?0x([0-9a-fA-F]*\.?[0-9a-fA-F]+|[0-9a-fA-F]+\.[0-9a-fA-F]*)(p|P)(\+|-)?[0-9]+`
@@ -340,6 +394,8 @@ Note: literals are parsed greedily. This means that for statements like `a -5`
       this will *not* parse as `a` `minus` `5` but instead as `a` `-5` which
       may be unexpected. A space must be inserted after the `-` if the first
       expression is desired.
+
+TODO(dneto): Describe how numeric literal tokens map to idealized values, and then to typed values.
 
 <pre class='def'>
 const_literal
@@ -357,22 +413,25 @@ FLOAT_LITERAL
 </pre>
 
 
-## Keywords TODO ## {#keywords}
+## Keywords ## {#keywords}
 
-TODO: *Stub*
+A <dfn>keyword</dfn> is a [=token=] which always refers to a predefined language concept.
+See [[#keyword-summary]] for the list of [SHORTNAME] keywords.
 
-See [[#keyword-summary]] for a list of keywords.
+## Identifiers ## {#identifiers}
 
-## Identifiers TODO ## {#identifiers}
+An <dfn>identifier</dfn> is a kind of [=token=] used as a name.
+See [[#declaration-and-scope]] and [[#directives]].
+
+The form of an identifier is defined via pattern-matching, except that
+an identifier must not have the same spelling as a [=keyword=] or as a [=reserved word=].
 
 <table class='data'>
   <thead>
-    <tr><th>Token<th>Definition
+    <tr><th>Token<th>Textual pattern
   </thead>
   <tr><td>`IDENT`<td>`[a-zA-Z][0-9a-zA-Z_]*`
 </table>
-
-An identifier must not have the same spelling as a keyword or as a reserved keyword.
 
 ## Attributes ## {#attributes}
 
@@ -538,15 +597,15 @@ literal_or_ident
 </table>
 
 
-## Directives TODO ## {#directives}
+## Directives ## {#directives}
 
-A <dfn noexport>directive</dfn> is a token sequence which modifies how a [SHORTNAME]
+A <dfn noexport>directive</dfn> is a [=token=] sequence which modifies how a [SHORTNAME]
 program is processed by a WebGPU implementation.
 See [[#enable-directive-section]].
 
 ## Declaration and scope ## {#declaration-and-scope}
 
-A <dfn noexport>declaration</dfn> associates an identifier with one of
+A <dfn noexport>declaration</dfn> associates an [=identifier=] with one of
 the following kinds of objects:
 * a type
 * a value
@@ -1048,7 +1107,7 @@ A <dfn noexport>structure</dfn> is a grouping of named member values.
       <td>struct&lt;|T|<sub>1</sub>,...,|T|<sub>N</sub>&gt;
       <td>An ordered tuple of *N* members of types
           |T|<sub>1</sub> through |T|<sub>N</sub>, with |N| being an integer greater than 0.
-          A structure type declaration specifies an identifier name for each member.
+          A structure type declaration specifies an [=identifier=] name for each member.
           Two members of the same structure type must not have the same name.
 </table>
 
@@ -2102,7 +2161,7 @@ Note: The following examples use [SHORTNAME] features explained later in this sp
 
 A reference value is formed in one of the following ways:
 
-* The identifer [=resolves|resolving=] to an [=in scope|in-scope=] variable *v* denotes the reference value for *v*'s storage.
+* The [=identifier=] [=resolves|resolving=] to an [=in scope|in-scope=] variable *v* denotes the reference value for *v*'s storage.
     * The resolved variable is the [=originating variable=] for the reference.
 * Use the [=indirection=] (unary `*`) operation on a pointer.
     * The originating variable of the result is defined as the originating variable of the pointer.
@@ -2794,8 +2853,8 @@ type_decl
   | texture_sampler_types
 </pre>
 
-When the type declaration is an identifer, then the expression must be in scope of a
-declaration of the identifier as a type alias or structure type.
+When the type declaration is an [=identifier=], then the expression must be in scope of a
+[=declaration=] of the identifier as a type alias or structure type.
 
 <div class='example' heading="Type Declarations">
   <xmp>
@@ -2856,7 +2915,7 @@ declaration of the identifier as a type alias or structure type.
 
 A <dfn noexport>let declaration</dfn> specifies a name for a value.
 Once the value for a let-declaration is computed, it is immutable.
-When an identifier use [=resolves=] to a let-declaration, the identifier denotes that value.
+When an [=identifier=] use [=resolves=] to a let-declaration, the identifier denotes that value.
 
 When a `let` identifier is declared without an explicitly specified type,
 e.g. `let foo = 4`, the type is automatically inferred from the expression to the right of the equals token (`=`).
@@ -2894,8 +2953,8 @@ A <dfn dfn noexport>variable declaration</dfn>:
 * Optionally has an *initializer* expression, if the variable is in the [=storage classes/private=] or [=storage classes/function=] storage classes.
     If present, the initializer expression must evaluate to the variable's store type.
 
-When an identifier use [=resolves=] to a variable declaration,
-the identifer is an expression denoting the reference [=memory view=] for the variable's storage,
+When an [=identifier=] use [=resolves=] to a variable declaration,
+the identifier is an expression denoting the reference [=memory view=] for the variable's storage,
 and its type is the variable's reference type.
 See [[#var-identifier-expr]].
 
@@ -4520,7 +4579,7 @@ See [[#function-call-statement]].
   </thead>
   <tr algorithm="variable reference">
        <td>
-          |v| is an identifier [=resolves|resolving=] to
+          |v| is an [=identifier=] [=resolves|resolving=] to
           an [=in scope|in-scope=] variable declared in [=storage class=] |SC|
           with [=store type=] |T|
        <td class="nowrap">
@@ -4537,7 +4596,7 @@ See [[#function-call-statement]].
   </thead>
   <tr algorithm="formal parameter value">
        <td>
-          |a| is an identifier [=resolves|resolving=] to
+          |a| is an [=identifier=] [=resolves|resolving=] to
           an [=in scope|in-scope=] formal paramter declaration with type |T|
        <td class="nowrap">
           |a|: |T|
@@ -4601,7 +4660,7 @@ The <dfn noexport>indirection</dfn> operator converts a pointer to its correspon
   </thead>
   <tr algorithm="pipeline-overridable constant value">
        <td>
-          |c| is an identifier [=resolves|resolving=] to
+          |c| is an [=identifier=] [=resolves|resolving=] to
           an [=in scope|in-scope=] [=pipeline-overridable=] `let` declaration with type |T|
        <td class="nowrap">
           |c|: |T|
@@ -4615,7 +4674,7 @@ The <dfn noexport>indirection</dfn> operator converts a pointer to its correspon
            and the `let`-declaration has no intializer expression.
   <tr algorithm="constant value">
        <td>
-          |c| is an identifier [=resolves|resolving=] to
+          |c| is an [=identifier=] [=resolves|resolving=] to
           an [=in scope|in-scope=] `let` declaration with type |T|,
           and is not pipeline-overridable
        <td class="nowrap">
@@ -4750,7 +4809,7 @@ short_circuit_or_expression
 ## Compound Statement ## {#compound-statement}
 
 A compound statement is a brace-enclosed group of zero or more statements.
-When a declaration is one of those statements, its identifier is [=in scope=]
+When a [=declaration=] is one of those statements, its [=identifier=] is [=in scope=]
 from the start of the next statement until the end of the compound statement.
 
 <pre class='def'>
@@ -4902,7 +4961,7 @@ after the switch statement.
 Alternately, executing a `fallthrough` statement transfers control to the body of the next case clause or
 default clause, whichever appears next in the switch body.
 A `fallthrough` statement must not appear as the last statement in the last clause of a switch.
-When a declaration appears in a case body, its identifier is [=in scope=] from
+When a [=declaration=] appears in a case body, its [=identifier=] is [=in scope=] from
 the start of the next statement until the end of the case body.
 
 Note: Identifiers declared in a case body are not [=in scope=] of case bodies
@@ -4920,7 +4979,7 @@ The <dfn noexport>loop body</dfn> is special form [compound
 statement](#compound-statement) that executes repeatedly.
 Each execution of the loop body is called an <dfn noexport>iteration</dfn>.
 
-The identifier of a declaration in a loop is [=in scope=] from the start of the
+The [=identifier=] of a [=declaration=] in a loop is [=in scope=] from the start of the
 next statement until the end of the loop body.
 The declaration is executed each time it is reached, so each new iteration
 creates a new instance of the variable or constant, and re-initializes it.
@@ -5029,7 +5088,7 @@ The `for(initializer; condition; continuing) { body }` statement is syntactic su
 * If `continuing` is non-empty, it becomes a [[#continuing-statement]] at the end of the loop body.
 
 The `initializer` of a for loop is executed once prior to executing the loop.
-When a declaration appears in the initializer, its identifier is [=in scope=] until the end of the `body`.
+When a [=declaration=] appears in the initializer, its [=identifier=] is [=in scope=] until the end of the `body`.
 Unlike declarations in the `body`, the declaration is not re-initialized each iteration.
 
 The `condition`, `body` and `continuing` execute in that order to form a loop [=iteration=].
@@ -5345,7 +5404,7 @@ A function declaration must only occur at [=module scope=].
 The function name is [=in scope=] from the start of the formal parameter list
 until the end of the program.
 
-A <dfn noexport>formal parameter</dfn> declaration specifies an identifier name and a type for a value that must be
+A <dfn noexport>formal parameter</dfn> [=declaration=] specifies an [=identifier=] name and a type for a value that must be
 provided when invoking the function.
 A formal parameter may have attributes.
 See [[#function-calls]].
@@ -5636,7 +5695,7 @@ The interface includes:
 These objects are represented by module-scope variables in certain [=storage classes=].
 
 We say a variable is <dfn noexport>statically accessed</dfn> by a function if any subexpression
-in the body of the function uses the variable's identifier,
+in the body of the function uses the variable's [=identifier=],
 and that subexpression is [=in scope=] of the variable's declaration.
 Static access of a `let`-declared constant is defined similarly.
 Note that being statically accessed is independent of whether an execution of the shader
@@ -6005,7 +6064,7 @@ source text after the `enable` directive.
 The directive must not appear inside the text of any [=declaration=].
 (If it were a declaration, it would be at [=module scope=].)
 
-The directive uses an identifier to name the extension, but does not
+The directive uses an [=identifier=] to name the extension, but does not
 create a [=scope=] for the identifier.
 Use of the identifier by the directive does not conflict with the
 use of that identifier as the name in any [=declaration=].
@@ -6052,11 +6111,6 @@ the implementation can issue a clear diagnostic.
 # WGSL program TODO # {#wgsl-module}
 
 TODO: *Stub* A WGSL program is a sequence of [=directives=] and [=module scope=] [=declarations=].
-
-<pre class='def'>
-translation_unit
-  : global_decl_or_directive* EOF
-</pre>
 
 <pre class='def'>
 global_decl_or_directive
@@ -6541,8 +6595,12 @@ Issue: Should read, write, and read_write be not completely reserved?  They are 
 TODO(dneto): Eliminate the image formats that are not used in storage images.
 For example SRGB formats (bgra8unorm_srgb), mixed channel widths (rg11b10float), out-of-order channels (bgra8unorm)
 
-## Reserved Keywords ## {#reserved-keywords}
-The following is a list of keywords which are reserved for future expansion.
+## Reserved Words ## {#reserved-words}
+
+A <dfn>reserved word</dfn> is a [=token=] which is reserved for future use.
+A [SHORTNAME] program must not contain a reserved word.
+
+The following are reserved words:
 
 <table class='data'>
   <tr>
@@ -6576,6 +6634,11 @@ The following is a list of keywords which are reserved for future expansion.
 </table>
 
 ## Syntactic Tokens ## {#syntactic-tokens}
+
+A <dfn>syntactic token</dfn> is a sequence of special characters, used:
+* to spell an expression operator, or
+* as punctuation: to group, sequence, or separate other grammar elements.
+
 <table class='data'>
   <tr><td>`AND`<td>`&`
   <tr><td>`AND_AND`<td>`&&`
@@ -6813,7 +6876,7 @@ and are provided by the implementation.
 These are called <dfn noexport>built-in functions</dfn>.
 
 Since a built-in function is always in scope, it is an error to attempt to redefine
-one or to use the name of a built-in function as an identifier for any other
+one or to use the name of a built-in function as an [=identifier=] for any other
 kind of declaration.
 
 Unlike ordinary functions defined in a [SHORTNAME] program,


### PR DESCRIPTION
- Describe how to break down source text so it can be parsed.
   - carefully sequence removal of comments, then blankspace
   - describe left-right greedy formation of tokens
- Rename "reserved keyword" -> "reserved word"
- Define various terms: token, literal, numeric literal, boolean
  literal, identifier.
- Add various cross-references

Change-Id: I2e8da80398586a7e33dc70755d192bb73de93f05