### PR TITLE
Fix error in optional chaning description

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -540,7 +540,7 @@ The phrasing "`Foo?.Bar`" means
 "if `Foo` is `null` or `undefined`, `undefined`; otherwise, `Foo.Bar`".
 
 For example, where `buffer` is a {{GPUBuffer}}, `buffer?.[[device]].[[adapter]]` means
-"if `buffer` is `null` or `undefined`, then `undefined`, otherwise,
+"if `buffer` is `null` or `undefined`, then `undefined`; otherwise,
 the `[[adapter]]` internal slot of the `[[device]]` internal slot of `buffer`.
 
 ### Internal Objects ### {#webgpu-internal-objects}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -537,7 +537,7 @@ The phrasing "`Foo.Bar`" means "the `Bar` member of the value (or interface) `Fo
 
 The `?.` ("optional chaining") syntax, adopted from JavaScript, is also used.
 The phrasing "`Foo?.Bar`" means
-"if `Foo` is `null` or `undefined`, `Foo`; otherwise, `Foo.Bar`".
+"if `Foo` is `null` or `undefined`, `undefined`; otherwise, `Foo.Bar`".
 
 For example, where `buffer` is a {{GPUBuffer}}, `buffer?.[[device]].[[adapter]]` means
 "if `buffer` is `null` or `undefined`, then `undefined`, otherwise,


### PR DESCRIPTION
As is, the current description is inconsistent with the example ("if `buffer` is `null` or `undefined`, then `undefined` ...", where you'd expect "if `buffer` is `null` or `undefined`, then `buffer` ...").

This change makes the description consistent with [the ECMAScript spec](https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-optional-chaining-evaluation), which states:
> If *baseValue* is **undefined** or **null**, then
> &nbsp;&nbsp;&nbsp;&nbsp; a. Return **undefined**.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/samsamson33/gpuweb/pull/2089.html" title="Last updated on Sep 7, 2021, 10:29 PM UTC (5cd02af)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2089/20a8bfd...samsamson33:5cd02af.html" title="Last updated on Sep 7, 2021, 10:29 PM UTC (5cd02af)">Diff</a>