### PR TITLE
wgsl: editorial fixes: control flow statements

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4903,8 +4903,8 @@ else_statement
   : ELSE compound_statement
 </pre>
 
-An <dfn>if</dfn> statement either executes or skips execution of a [=compound statement=] based on
-the evaluation of a condition expression.
+An <dfn noexport dfn-for="statement">if</dfn> statement conditionally executes at most one [=compound statement=] based on
+the evaluation of the condition expressions.
 
 The `if` statements in [SHORTNAME] use an if/elseif/else structure, that contains a single required
 `if` clause, zero or more `elseif` clauses and a single optional `else` clause.
@@ -4939,7 +4939,7 @@ case_body
   | FALLTHROUGH SEMICOLON
 </pre>
 
-A <dfn>switch</dfn> statement transfers control to one of a set of case clauses, or to the `default` clause,
+A <dfn noexport dfn-for="statement">switch</dfn> statement transfers control to one of a set of case clauses, or to the `default` clause,
 depending on the evaluation of a selector expression.
 
 The selector expression must be of a scalar integer type.
@@ -4959,7 +4959,8 @@ For example `0`, `00`, and `0x0000` all denote the zero value.
 
 When control reaches the end of a case body, control normally transfers to the first statement
 after the switch statement.
-Alternately, executing a <dfn>fallthrough</dfn> statement transfers control to the body of the next case clause or
+Alternately, executing a <dfn noexport dfn-for="statement">fallthrough</dfn> statement
+transfers control to the body of the next case clause or
 default clause, whichever appears next in the switch body.
 A `fallthrough` statement must not appear as the last statement in the last clause of a switch.
 When a [=declaration=] appears in a case body, its [=identifier=] is [=in scope=] from
@@ -4976,7 +4977,7 @@ loop_statement
   : LOOP BRACE_LEFT statements? continuing_statement? BRACE_RIGHT
 </pre>
 
-A <dfn noexport>loop</dfn> statement repeatedly executes a <dfn noexport>loop body</dfn>;
+A <dfn noexport dfn-for="statement">loop</dfn> statement repeatedly executes a <dfn noexport>loop body</dfn>;
 the loop body is specified as a [=compound statement=].
 Each execution of the loop body is called an <dfn noexport>iteration</dfn>.
 
@@ -4985,8 +4986,8 @@ next statement until the end of the loop body.
 The declaration is executed each time it is reached, so each new iteration
 creates a new instance of the variable or constant, and re-initializes it.
 
-This repetition can be interrupted by a [=break], [=return=], or
-[=discard=] statement.
+This repetition can be interrupted by a [=break=], [=return=], or
+[=statement/discard=] statement.
 
 Optionally, the last statement in the loop body may be a
 [=continuing=] statement.
@@ -5083,7 +5084,7 @@ for_header
      (assignment_statement | func_call_statement)?
 </pre>
 
-The <dfn>for</dfn> statement takes the form
+The <dfn dfn-for="statement">for</dfn> statement takes the form
 `for(initializer; condition; continuing_part) { body }` and is syntactic sugar on top of a [=loop=] statement with the same `body`.
 Additionally:
 * If `initializer` is non-empty, it is executed inside an additional scope before the first [=iteration=].
@@ -5145,7 +5146,7 @@ break_statement
   : BREAK
 </pre>
 
-A <dfn noexport>break</dfn> statement transfers control to the first statement
+A <dfn noexport dfn-for="statement">break</dfn> statement transfers control to the first statement
 after the body of the nearest-enclosing [=loop=]
 or [=switch=] statement.
 A `break` statement must only be used within [=loop=], [=for=], and [=switch=] statements.
@@ -5227,12 +5228,12 @@ continue_statement
   : CONTINUE
 </pre>
 
-A `continue` statement transfers control in the nearest-enclosing [[#loop-statement]]:
+A <dfn noexport dfn-for="statement">continue</dfn> statement transfers control in the nearest-enclosing [=loop=]:
 
 *  forward to the [=continuing=] statement at the end of the body of that loop, if it exists.
 *  otherwise backward to the first statement in the loop body, starting the next [=iteration=].
 
-A `continue` statement must only be used in a loop or for statement.
+A `continue` statement must only be used in a [=loop=] or [=for=] statement.
 A `continue` statement must not be placed such that it would transfer
 control to an enclosing [=continuing=] statement.
 (It is a *forward* branch when branching to a `continuing` statement.)
@@ -5264,10 +5265,10 @@ continuing_statement
   : CONTINUING compound_statement
 </pre>
 
-A <dfn>continuing</dfn> statement specifies a [=compound statement=] to be executed at the end of a loop [=iteration=].
+A <dfn dfn-for="statement">continuing</dfn> statement specifies a [=compound statement=] to be executed at the end of a loop [=iteration=].
 The construct is optional.
 
-The compound statement must not contain a [=return=] or [=discard=] statement, at any compound statement nesting level.
+The compound statement must not contain a [=return=] or [=statement/discard=] statement, at any compound statement nesting level.
 
 ### Return Statement ### {#return-statement}
 
@@ -5276,7 +5277,7 @@ return_statement
   : RETURN short_circuit_or_expression?
 </pre>
 
-A <dfn noexport>return</dfn> statement ends execution of the current function.
+A <dfn noexport dfn-for="statement">return</dfn> statement ends execution of the current function.
 If the function is an [=entry point=], then the current shader invocation
 is terminated.
 Otherwise, evaluation continues with the next expression or statement after
@@ -5291,7 +5292,7 @@ The type of the return value must match the return type of the function.
 
 ### Discard Statement ### {#discard-statement}
 
-A <dfn>discard</dfn> statement immediately ends execution of a fragment shader invocation and throws away the fragment.
+A <dfn dfn-for="statement">discard</dfn> statement immediately ends execution of a fragment shader invocation and throws away the fragment.
 The `discard` statement must only be used in a [=fragment=] shader stage.
 
 More precisely, executing a `discard` statement will:
@@ -5503,7 +5504,7 @@ Note: There are no default parameter values in [SHORTNAME].
 Built-in functions described this way are really overloaded functions.
 
 Note: The current function will not resume execution if the called function or
-any descendent called function executes a [=discard=] statement.
+any descendent called function executes a [=statement/discard=] statement.
 
 ## Restrictions on functions ## {#function-restriction}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4806,9 +4806,9 @@ short_circuit_or_expression
 
 # Statements TODO # {#statements}
 
-## Compound Statement ## {#compound-statement}
+## Compound Statement ## {#compound-statement-section}
 
-A compound statement is a brace-enclosed group of zero or more statements.
+A <dfn>compound statement</dfn> is a brace-enclosed sequence of zero or more statements.
 When a [=declaration=] is one of those statements, its [=identifier=] is [=in scope=]
 from the start of the next statement until the end of the compound statement.
 
@@ -4903,16 +4903,17 @@ else_statement
   : ELSE compound_statement
 </pre>
 
-An if statement provides provides predicated execution of a compound statement based on
-the evaluation of an expression.
+An <dfn>if</dfn> statement either executes or skips execution of a [=compound statement=] based on
+the evaluation of a condition expression.
 
-If statements in [SHORTNAME] use an if/elseif/else structure, that contains a single required
+The `if` statements in [SHORTNAME] use an if/elseif/else structure, that contains a single required
 `if` clause, zero or more `elseif` clauses and a single optional `else` clause.
 Each of the expressions for the `if` and `elseif` clause conditions must be a scalar boolean expression.
 
-An if statement is executed as follows:
-* The condition associated with the `if` clause is evaluated and, if the result is `true`,
-    control transfers to the associated compound statement.
+An `if` statement is executed as follows:
+* The condition associated with the `if` clause is evaluated.
+    If the result is `true`,
+    control transfers to the first compound statement (immediately after the parenthesized condition experession).
 * Otherwise, the condition of the next `elseif` clause in textual order (if one exists) is evaluated
      and, if the result is `true`, control transfers to the associated compound statement.
      * This behavior is repeated for all `elseif` clauses until one of the conditions evaluates to `true`.
@@ -4938,7 +4939,7 @@ case_body
   | FALLTHROUGH SEMICOLON
 </pre>
 
-A switch statement transfers control to one of a set of case clauses, or to the `default` clause,
+A <dfn>switch</dfn> statement transfers control to one of a set of case clauses, or to the `default` clause,
 depending on the evaluation of a selector expression.
 
 The selector expression must be of a scalar integer type.
@@ -4958,7 +4959,7 @@ For example `0`, `00`, and `0x0000` all denote the zero value.
 
 When control reaches the end of a case body, control normally transfers to the first statement
 after the switch statement.
-Alternately, executing a `fallthrough` statement transfers control to the body of the next case clause or
+Alternately, executing a <dfn>fallthrough</dfn> statement transfers control to the body of the next case clause or
 default clause, whichever appears next in the switch body.
 A `fallthrough` statement must not appear as the last statement in the last clause of a switch.
 When a [=declaration=] appears in a case body, its [=identifier=] is [=in scope=] from
@@ -4975,8 +4976,8 @@ loop_statement
   : LOOP BRACE_LEFT statements? continuing_statement? BRACE_RIGHT
 </pre>
 
-The <dfn noexport>loop body</dfn> is special form [compound
-statement](#compound-statement) that executes repeatedly.
+A <dfn noexport>loop</dfn> statement repeatedly executes a <dfn noexport>loop body</dfn>;
+the loop body is specified as a [=compound statement=].
 Each execution of the loop body is called an <dfn noexport>iteration</dfn>.
 
 The [=identifier=] of a [=declaration=] in a loop is [=in scope=] from the start of the
@@ -4984,11 +4985,11 @@ next statement until the end of the loop body.
 The declaration is executed each time it is reached, so each new iteration
 creates a new instance of the variable or constant, and re-initializes it.
 
-This repetition can be interrupted by a [[#break-statement]], `return`, or
-`discard`.
+This repetition can be interrupted by a [=break], [=return=], or
+[=discard=] statement.
 
 Optionally, the last statement in the loop body may be a
-[[#continuing-statement]].
+[=continuing=] statement.
 
 Note: The loop statement is one of the biggest differences from other shader
 languages.
@@ -5082,17 +5083,19 @@ for_header
      (assignment_statement | func_call_statement)?
 </pre>
 
-The `for(initializer; condition; continuing) { body }` statement is syntactic sugar on top of a [[#loop-statement]] with the same `body`. Additionally:
-* If `initializer` is non-empty, it is executed inside an additional scope before the first iteration.
+The <dfn>for</dfn> statement takes the form
+`for(initializer; condition; continuing_part) { body }` and is syntactic sugar on top of a [=loop=] statement with the same `body`.
+Additionally:
+* If `initializer` is non-empty, it is executed inside an additional scope before the first [=iteration=].
 * If `condition` is non-empty, it is checked at the beginning of the loop body and if unsatisfied then a [[#break-statement]] is executed.
-* If `continuing` is non-empty, it becomes a [[#continuing-statement]] at the end of the loop body.
+* If `continuing_part` is non-empty, it becomes a [=continuing=] statement at the end of the loop body.
 
 The `initializer` of a for loop is executed once prior to executing the loop.
 When a [=declaration=] appears in the initializer, its [=identifier=] is [=in scope=] until the end of the `body`.
 Unlike declarations in the `body`, the declaration is not re-initialized each iteration.
 
-The `condition`, `body` and `continuing` execute in that order to form a loop [=iteration=].
-The `body` is a special form of [compound statement](#compound-statement).
+The `condition`, `body` and `continuing_part` execute in that order to form a loop [=iteration=].
+The `body` is a special form of [=compound statement=].
 The identifier of a declaration in the `body` is [=in scope=] from the start of
 the next statement until the end of the `body`.
 The declaration is executed each time it is reached, so each new iteration
@@ -5135,19 +5138,19 @@ Converts to:
 </div>
 
 
-### Break ### {#break-statement}
+### Break Statement ### {#break-statement}
 
 <pre class='def'>
 break_statement
   : BREAK
 </pre>
 
-Use a `break` statement to transfer control to the first statement
-after the body of the nearest-enclosing [[#loop-statement]]
-or [[#switch-statement]].
-A `break` statement must only be used in loop, for, and switch statements.
+A <dfn noexport>break</dfn> statement transfers control to the first statement
+after the body of the nearest-enclosing [=loop=]
+or [=switch=] statement.
+A `break` statement must only be used within [=loop=], [=for=], and [=switch=] statements.
 
-When a `break` statement is placed such that it would exit from a loop's [[#continuing-statement]],
+When a `break` statement is placed such that it would exit from a loop's [=continuing=] statement,
 then:
 
 * The `break` statement must appear as either:
@@ -5217,25 +5220,25 @@ then:
   </xmp>
 </div>
 
-### Continue ### {#continue-statement}
+### Continue Statement ### {#continue-statement}
 
 <pre class='def'>
 continue_statement
   : CONTINUE
 </pre>
 
-Use a `continue` statement to transfer control in the nearest-enclosing [[#loop-statement]]:
+A `continue` statement transfers control in the nearest-enclosing [[#loop-statement]]:
 
-*  forward to the [[#continuing-statement]] at the end of the body of that loop, if it exists.
-*  otherwise backward to the first statement in the loop body, starting the next iteration
+*  forward to the [=continuing=] statement at the end of the body of that loop, if it exists.
+*  otherwise backward to the first statement in the loop body, starting the next [=iteration=].
 
 A `continue` statement must only be used in a loop or for statement.
 A `continue` statement must not be placed such that it would transfer
-control to an enclosing [[#continuing-statement]].
+control to an enclosing [=continuing=] statement.
 (It is a *forward* branch when branching to a `continuing` statement.)
 
 A `continue` statement must not be placed such that it would transfer
-control past a declaration used in the targeted continuing construct.
+control past a declaration used in the targeted [=continuing=] statement.
 
 <div class='example wgsl function-scope expect-error' heading="Invalid continue bypasses declaration">
   <xmp>
@@ -5261,10 +5264,10 @@ continuing_statement
   : CONTINUING compound_statement
 </pre>
 
-A *continuing* construct is a block of statements to be executed at the end of a loop iteration.
+A <dfn>continuing</dfn> statement specifies a [=compound statement=] to be executed at the end of a loop [=iteration=].
 The construct is optional.
 
-The block of statements must not contain a return or discard statement.
+The compound statement must not contain a [=return=] or [=discard=] statement, at any compound statement nesting level.
 
 ### Return Statement ### {#return-statement}
 
@@ -5285,13 +5288,13 @@ supply a value.
 Otherwise the expression must be present, and is called the *return value*.
 In this case the call site of this function invocation evaluates to the return value.
 The type of the return value must match the return type of the function.
-If a return statement is present, it must be the last statement in the
-enclosing compound statement.
 
 ### Discard Statement ### {#discard-statement}
 
+A <dfn>discard</dfn> statement immediately ends execution of a fragment shader invocation and throws away the fragment.
 The `discard` statement must only be used in a [=fragment=] shader stage.
-Executing a `discard` statement will:
+
+More precisely, executing a `discard` statement will:
 
 * immediately terminate the current invocation, and
 * prevent evaluation and generation of a return value for the [=entry point=], and
@@ -5500,8 +5503,7 @@ Note: There are no default parameter values in [SHORTNAME].
 Built-in functions described this way are really overloaded functions.
 
 Note: The current function will not resume execution if the called function or
-any descendent called function executes a `discard` statement.
-See [[#discard-statement]].
+any descendent called function executes a [=discard=] statement.
 
 ## Restrictions on functions ## {#function-restriction}
 


### PR DESCRIPTION
- More consistently introduce a control flow statement with a definition
  phrased as:

     "A <dfn>FOO</dfn> statement DOES SOMETHING".

- Add cross-references.
- Other editorial cleanups.