### PR TITLE
    wgsl: more restrictions on control flow interruption

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5340,6 +5340,145 @@ Issue: [[#uniform-control-flow]] needs to state whether all invocations being di
   </xmp>
 </div>
 
+### Control Flow Interruption ### {#control-flow-interruption-section}
+
+A <dfn>control flow interruption</dfn> is any one of the following statements:
+* a [=statement/break=] statement
+* a [=statement/continue=] statement
+* a [=statement/fallthrough=] statement
+* a [=statement/return=] statement
+* a [=statement/discard=] statement
+* a [=compound statement=], if one of its members is a [=control flow interruption=].
+
+A control flow interruption must:
+* be a [=continue=] statement immediately followed by a [=continuing=] statement, or
+* appear last in its immediately enclosing compound statement.
+
+Note: In the cases forbidden by this rule, there are statements that immediately
+follow the control flow interruption.
+Those statements can never be executed, which may indicate a programming error.
+
+[=Switch=], [=if=], [=loop=], and [=for=] statements *contain* [=compound statements=],
+but are not themselves compound statements.
+(That is, they do not match the `compound_statement` grammar rule.)
+They are never classified as control flow interruptions.
+
+<div class='example wgsl' heading='A simple invalid control flow interruption'>
+  <xmp highlight='rust'>
+   fn simple() -> i32 {
+     var a: i32;
+     return 0;  // Error: A control flow interruption, not appearing last.
+     a = 1;     // This is never executed.
+     return 2;
+   }
+  </xmp>
+</div>
+
+<div class='example wgsl' heading='An invalid nested control flow interruption'>
+  <xmp highlight='rust'>
+   fn nested() -> i32 {
+     var a: i32;
+     {             // The start of a compound statement.
+       a = 2;
+       return 1;   // Valid: A control flow interruption appearing last in its
+                   // enclosing compound statement.
+
+     }             // Error: The compound statement is a control flow interruption,
+                   // not appearing last.
+     a = 1;        // This is never executed.
+     return 2;
+   }
+  </xmp>
+</div>
+
+<div class='example wgsl' heading='An if is not a control flow interruption'>
+  <xmp highlight='rust'>
+   fn if_example() {
+     var a: i32 = 0;
+     loop {
+       // This if statement contains a control flow interruption.
+       // But a whole if statement is never a control flow interruption.
+       if (a == 5) {
+         break; // A control flow interruption.
+       }
+       a = a + 1;
+     }
+   }
+  </xmp>
+</div>
+
+<div class='example wgsl' heading='A switch is not a control flow interruption'>
+  <xmp highlight='rust'>
+   fn switch_example() {
+     var a: i32 = 0;
+     switch (a) {
+       // This default clause contains a control flow interruption.
+       // But a whole switch statement is never a control flow interruption.
+       default: {
+         return; // A control flow interruption.
+       }
+     } // Valid. Not a control flow interruption.
+     a = 5;
+   }
+  </xmp>
+</div>
+
+<div class='example wgsl' heading='An invalid continue'>
+  <xmp highlight='rust'>
+   fn invalid_continue() {
+     var a: i32;
+     loop {
+       if (a == 5) { break; }  // Valid
+       continue;               // Error: Invalid control flow interruption.
+       a = a + 1;
+     }                         // Valid
+   }
+  </xmp>
+</div>
+
+<div class='example wgsl' heading='A conditional continue with continuing statement'>
+  <xmp highlight='rust'>
+   fn conditional_continue() {
+     var a: i32;
+     loop {
+       if (a == 5) { break; }
+       if (a % 2 == 1) {
+         continue; // Valid: A control flow interruption.
+       }           // Valid: Not a control flow interruption.
+       a = a * 2;
+       continuing {
+         a = a + 1;
+       }
+     }
+   }
+  </xmp>
+</div>
+
+<div class='example wgsl' heading='A redundant continue with continuing statement'>
+  <xmp highlight='rust'>
+   fn redundant_continue_with_continuing() {
+     var a: i32;
+     loop {
+       if (a == 5) { break; }
+       continue;   // Valid. This is redundant, branching to the next statement.
+       continuing {
+         a = a + 1;
+       }
+     }
+   }
+  </xmp>
+</div>
+
+<div class='example wgsl' heading='A continue at the end of a loop body'>
+  <xmp highlight='rust'>
+   fn continue_end_of_loop_body() {
+     for (var i: i32 = 0; i < 5; i = i + 1 ) {
+       continue;   // Valid. This is redundant, branching to the end of the loop body.
+     }
+   }
+  </xmp>
+</div>
+
 ## Function Call Statement ## {#function-call-statement}
 
 <pre class='def'>


### PR DESCRIPTION
    - define control-flow interruption. It is a ageneralization of a branch
      or return that redirects control flow from executing the next
      statement in textual order.
    - A control flow interruption must appear last in its immediately
      enclosing compound statement.
    
Fixes: #2093

Builds on #2095 