### PR TITLE
Syntactic CI for Grammar

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Build Bikeshed
         if: ${{ github.event.workflow_run.event == 'pull_request' && env.PR }}
         run: |
-          pip3 install bikeshed==3.0.3
+          pip3 install bikeshed==3.0.3 tree_sitter==0.19.0
           export PATH="$(python3 -m site --user-base)/bin:${PATH}"
           bikeshed update
           mkdir out

--- a/.github/workflows/publish-specs.yml
+++ b/.github/workflows/publish-specs.yml
@@ -59,3 +59,11 @@ jobs:
           W3C_BUILD_OVERRIDE: |
             group: gpuwg
             status: ${{ matrix.w3c_build_override_status }}
+
+      - name: Validate WGSL grammar
+        run: |
+          pip3 install bikeshed==3.0.3 tree_sitter==0.19.0
+          export PATH="$(python3 -m site --user-base)/bin:${PATH}"
+          bikeshed update
+          mkdir out
+          ./compile.sh

--- a/.github/workflows/publish-specs.yml
+++ b/.github/workflows/publish-specs.yml
@@ -60,6 +60,13 @@ jobs:
             group: gpuwg
             status: ${{ matrix.w3c_build_override_status }}
 
+  wgsl-grammar:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
       - name: Validate WGSL grammar
         run: |
           pip3 install bikeshed==3.0.3 tree_sitter==0.19.0

--- a/.github/workflows/publish-specs.yml
+++ b/.github/workflows/publish-specs.yml
@@ -45,6 +45,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        
+      - name: Update dependencies
+        run: |
+          pip3 install bikeshed==3.0.3 tree_sitter==0.19.0
 
       - name: Build and validate spec, publish to GitHub Pages and /TR
         uses: w3c/spec-prod@v2

--- a/.github/workflows/publish-static.yml
+++ b/.github/workflows/publish-static.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Copy static files to the "out" folder
         run: |
           export PATH="$(python3 -m site --user-base)/bin:${PATH}"
+          pip3 install bikeshed==3.0.3 tree_sitter==0.19.0
           mkdir ./out
           ./compile.sh static
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 out/
 spec/index.html
 spec/webgpu.idl
+wgsl/grammar/
 wgsl/index.html
 explainer/index.html
 tools/node_modules/

--- a/wgsl/Makefile
+++ b/wgsl/Makefile
@@ -1,7 +1,10 @@
-all: index.html
+all: index.html grammar/grammar.js
 
 index.html: index.bs
 	bikeshed --die-on=everything spec index.bs
+
+grammar/grammar.js: index.bs extract-grammar.py
+	python3 extract-grammar.py index.bs grammar/grammar.js
 
 online:
 	curl https://api.csswg.org/bikeshed/ -F file=@index.bs -F output=err

--- a/wgsl/extract-grammar.py
+++ b/wgsl/extract-grammar.py
@@ -1,0 +1,741 @@
+#!/usr/bin/env python3
+
+from datetime import date
+from string import Template
+
+import os
+import re
+import subprocess
+import sys
+
+from tree_sitter import Language, Parser
+
+HEADER = """
+// Copyright (C) [$YEAR] World Wide Web Consortium,
+// (Massachusetts Institute of Technology, European Research Consortium for
+// Informatics and Mathematics, Keio University, Beihang).
+// All Rights Reserved.
+//
+// This work is distributed under the W3C (R) Software License [1] in the hope
+// that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+// warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+// [1] http://www.w3.org/Consortium/Legal/copyright-software
+
+// **** This file is auto-generated. Do not edit. ****
+
+""".lstrip()
+
+scanner_filename = sys.argv[1]
+scanner_file = open(scanner_filename, "r")
+scanner_lines = [j for i in [i.split("\n")
+                             for i in scanner_file.readlines()] for j in i if len(j) > 0]
+
+grammar_filename = sys.argv[2]
+grammar_path = os.path.dirname(grammar_filename)
+os.makedirs(grammar_path, exist_ok=True)
+grammar_file = open(grammar_filename, "w")
+
+
+def scanner_escape_name(name):
+    return name.strip().replace("`", "").replace('-', '_').lower().strip()
+
+
+def scanner_escape_regex(regex):
+    return re.escape(regex.strip()).strip().replace("/", "\\/").replace("\\_", "_").replace("\\%", "%").replace("\\;", ";").replace("\\<", "<").replace("\\>", ">").replace("\\=", "=").replace("\\,", ",").replace("\\:", ":").replace("\\!", "!")
+
+
+class scanner_constituent:
+    @staticmethod
+    def name():
+        return "constituent"
+
+    @staticmethod
+    def begin(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        return ("<pre class='def'>" in line, None, 1)
+
+    @staticmethod
+    def end(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        return ("</pre>" in line, 0)
+
+    @staticmethod
+    def record(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        return (True, 0)
+
+    @staticmethod
+    def skip(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        return (False, 0)
+
+    @staticmethod
+    def valid(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        result = len(line.strip()) > 0
+        if not result:
+            return result
+        result = result and line[0] != "`"
+        result = result and not line.startswith("TODO")
+        if line[0] == " ":
+            result = result and (line.lstrip()[0] in [":", "|"] or
+                                 (line.startswith("     ") and
+                                  line[5] != " " and
+                                  lines[i-1].rstrip().endswith("SEMICOLON")))
+        else:
+            if len(lines) > i+1:
+                result = result and scanner_constituent.valid(lines, i+1)
+            else:
+                result = False
+        return result
+
+    @staticmethod
+    def parse(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        if line[0] != " ":
+            # Append new key
+            return (scanner_escape_name(line.strip()), None, 0)
+        else:
+            if line.lstrip()[0] in [":", "|"]:
+                # Append new value
+                return (None, scanner_escape_name(
+                    line.strip()[1:].strip())
+                    .replace("(", " ( ")
+                    .replace(")", " ) ")
+                    .replace("*", " * ")
+                    .replace("+", " + ")
+                    .replace("?", " ? ")
+                    .replace("|", " | ")
+                    .replace(" ", "  "), 0)
+            else:
+                # Extend last value
+                return (None, " " + scanner_escape_name(line.strip())
+                        .replace("(", " ( ")
+                        .replace(")", " ) ")
+                        .replace("*", " * ")
+                        .replace("+", " + ")
+                        .replace("?", " ? ")
+                        .replace("|", " | ")
+                        .replace(" ", "  "), -1)
+
+
+class scanner_literal:
+    @staticmethod
+    def name():
+        return "literal"
+
+    @staticmethod
+    def begin(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        return ("## Literals" in line, None, 1)
+
+    @staticmethod
+    def end(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        return ("</table>" in line, 0)
+
+    @staticmethod
+    def record(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        return ("</thead>" in line, 1)
+
+    @staticmethod
+    def skip(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        return (False, 0)
+
+    @staticmethod
+    def valid(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        result = len(line.strip()) > 0
+        result = result and "Token<td>Definition" not in line
+        return result
+
+    @staticmethod
+    def parse(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        split = line.split("<td>")
+        return (scanner_escape_name(split[1]), "/" + split[2].replace("`", "") + "/", 0)
+
+
+class scanner_identifier:
+    @staticmethod
+    def name():
+        return "identifier"
+
+    @staticmethod
+    def begin(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        return ("## Identifiers" in line, None, 1)
+
+    @staticmethod
+    def end(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        return ("</table>" in line, 0)
+
+    @staticmethod
+    def record(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        return ("</thead>" in line, 1)
+
+    @staticmethod
+    def skip(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        return (False, 0)
+
+    @staticmethod
+    def valid(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        result = len(line.strip()) > 0
+        result = result and "Token<td>Definition" not in line
+        return result
+
+    @staticmethod
+    def parse(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        split = line.split("<td>")
+        return (scanner_escape_name(split[1]), "/" + split[2].replace("`", "") + "/", 0)
+
+
+class scanner_keyword:
+    @staticmethod
+    def name():
+        return "keyword"
+
+    @staticmethod
+    def begin(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        return ("## Keyword Summary" in line, None, 1)
+
+    @staticmethod
+    def end(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        return (False, 0)  # TODO Recognize end of keywords
+
+    @staticmethod
+    def record(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        return ("<table class='data'>" in line, 1)
+
+    @staticmethod
+    def skip(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        return ("</table>" in line, 0)
+
+    @staticmethod
+    def valid(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        result = len(line.strip()) > 0
+        result = result and "Token<td>Definition" not in line
+        result = result and len(line.split("<td>")) > 2
+        return result
+
+    @staticmethod
+    def parse(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        split = line.split("<td>")
+        return (scanner_escape_name(split[1]), "/" + scanner_escape_regex(split[2].replace("`", "")) + "/", 0)
+
+
+class scanner_reserved:
+    @staticmethod
+    def name():
+        return "reserved"
+
+    @staticmethod
+    def begin(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        return ("## Reserved Words" in line, None, 1)
+
+    @staticmethod
+    def end(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        return ("</table>" in line, 0)
+
+    @staticmethod
+    def record(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        return ("<table class='data'>" in line, 1)
+
+    @staticmethod
+    def skip(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        return (False, 0)
+
+    @staticmethod
+    def valid(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        result = len(line.strip()) > 0
+        result = result and "Token<td>Definition" not in line
+        result = result and not line.strip().startswith("<tr>")
+        result = result and len(line.split("<td>")) > 1
+        return result
+
+    @staticmethod
+    def parse(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        split = line.split("<td>")
+        return ("_reserved", "/" + scanner_escape_regex(split[1].replace("`", "")) + "/", 0)
+
+
+class scanner_token:
+    @staticmethod
+    def name():
+        return "token"
+
+    @staticmethod
+    def begin(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        return ("## Syntactic Tokens" in line, None, 1)
+
+    @staticmethod
+    def end(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        return ("</table>" in line, 0)
+
+    @staticmethod
+    def record(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        return ("<table class='data'>" in line, 1)
+
+    @staticmethod
+    def skip(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        return (False, 0)
+
+    @staticmethod
+    def valid(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        result = len(line.strip()) > 0
+        result = result and "Token<td>Definition" not in line
+        result = result and len(line.split("<td>")) > 2
+        return result
+
+    @staticmethod
+    def parse(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        split = line.split("<td>")
+        return (scanner_escape_name(split[1]), "/" + scanner_escape_regex(split[2].replace("`", "")) + "/", 0)
+
+
+class scanner_example:  # Not an example of a scanner, scanner of examples from specification
+    @staticmethod
+    def name():
+        return "example"
+
+    @staticmethod
+    def begin(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        result = "<div class=" in line and "example" in line and "wgsl" in line
+        key = None
+        if result:
+            key = line[5:-1]
+        return (result, key, 1)
+
+    @staticmethod
+    def end(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        return ("</div>" in line, 0)
+
+    @staticmethod
+    def record(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        return ("<xmp" in line, 1)
+
+    @staticmethod
+    def skip(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        return ("</xmp>" in line, 0)
+
+    @staticmethod
+    def valid(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        return True
+
+    @staticmethod
+    def parse(lines, i):
+        line = lines[i].split("//")[0].rstrip()
+        return (None, line, 0)
+
+
+scanner_spans = [scanner_constituent,
+                 scanner_literal,
+                 scanner_identifier,
+                 scanner_keyword,
+                 scanner_reserved,
+                 scanner_token,
+                 scanner_example]
+
+
+scanner_components = {i.name(): {} for i in scanner_spans}
+scanner_components["comment"] = {"_comment": ["/\\/\\// /.*/"]}
+scanner_components["space"] = {"_space": ["/\\s/"]}
+
+scanner_i = 0
+scanner_span = None
+scanner_record = False
+last_key = None
+last_value = None
+while scanner_i < len(scanner_lines):
+    for j in scanner_spans:
+        scanner_begin = j.begin(scanner_lines, scanner_i)
+        if scanner_begin[0]:
+            scanner_span = None
+            scanner_record = False
+            last_key = None
+            last_value = None
+            scanner_span = j
+            if scanner_begin[1] != None:
+                last_key = scanner_begin[1]
+            scanner_i += scanner_begin[-1]
+        if scanner_span == j:
+            scanner_end = j.end(scanner_lines, scanner_i)
+            if scanner_end[0]:
+                scanner_span = None
+                scanner_record = False
+                last_key = None
+                last_value = None
+                scanner_i += scanner_end[-1]
+    if scanner_span != None:
+        if scanner_record:
+            scanner_skip = scanner_span.skip(scanner_lines, scanner_i)
+            if scanner_skip[0]:
+                scanner_record = False
+                scanner_i += scanner_skip[-1]
+        else:
+            scanner_record_value = scanner_span.record(
+                scanner_lines, scanner_i)
+            if scanner_record_value[0]:
+                scanner_record = True
+                if last_key != None and scanner_span.name() == "example":  # TODO Remove special case
+                    if last_key in scanner_components[scanner_span.name()]:
+                        last_key += "_next"
+                        if last_key not in scanner_components[scanner_span.name()]:
+                            scanner_components[scanner_span.name()][last_key] = [
+                            ]
+                    else:
+                        scanner_components[scanner_span.name()][last_key] = []
+                scanner_i += scanner_record_value[-1]
+        if scanner_record and scanner_span.valid(scanner_lines, scanner_i):
+            scanner_parse = scanner_span.parse(scanner_lines, scanner_i)
+            if scanner_parse[2] < 0:
+                if (scanner_parse[1] != None and
+                        last_key != None and
+                        last_value != None and
+                        last_key in scanner_components[scanner_span.name()] and
+                        len(scanner_components[scanner_span.name()][last_key]) > 0):
+                    scanner_components[scanner_span.name(
+                    )][last_key][-1] += scanner_parse[1]
+            else:
+                if scanner_parse[0] != None:
+                    if scanner_parse[1] != None:
+                        last_key = scanner_parse[0]
+                        last_value = scanner_parse[1]
+                        if last_key not in scanner_components[scanner_span.name()]:
+                            scanner_components[scanner_span.name()][last_key] = [
+                                last_value]
+                        else:
+                            scanner_components[scanner_span.name()][last_key].append(
+                                last_value)
+                    else:
+                        last_key = scanner_parse[0]
+                        last_value = None
+                        scanner_components[scanner_span.name()][last_key] = []
+                else:
+                    if scanner_parse[1] != None:
+                        last_value = scanner_parse[1]
+                        scanner_components[scanner_span.name()][last_key].append(
+                            last_value)
+                scanner_i += scanner_parse[-1]
+    scanner_i += 1
+
+
+grammar_source = ""
+
+grammar_source += r"""
+module.exports = grammar({
+    name: 'wgsl',
+
+    extras: $ => [
+        $._comment,
+        $._space,
+    ],
+
+    inline: $ => [
+        $.global_decl_or_directive,
+        $._reserved,
+    ],
+
+    conflicts: $ => [
+        [$.array_type_decl],
+        [$.type_decl,$.primary_expression],
+        [$.type_decl,$.primary_expression,$.func_call_statement],
+    ],
+
+    word: $ => $.ident,
+
+    rules: {
+"""[1:-1]
+grammar_source += "\n"
+
+
+grammar_constituents_optional = {key for key, value in scanner_components[scanner_constituent.name(
+)].items() if "" in value or value[0].rstrip().endswith("*")}
+
+
+def grammar_sequence_from_element(element):
+    sequence = ""
+    subsequences = element.split()
+    sequence_i = 0
+    sequence_type = "seq"
+    while sequence_i < len(subsequences):
+        if "(" in subsequences[sequence_i]:
+            subelements = [subsequences[sequence_i].replace("(", "")]
+            sequence_i += 1
+            subexpressions = 1
+            while subexpressions > 0:
+                if "(" in subsequences[sequence_i]:
+                    subexpressions += 1
+                if ")" in subsequences[sequence_i]:
+                    subexpressions -= 1
+                subelements.append(subsequences[sequence_i])
+                sequence_i += 1
+            sequence_i -= 1
+            subelements = [i for i in subelements if len(i.strip()) > 0]
+            if sequence_i + 1 < len(subsequences):
+                if subsequences[sequence_i + 1] == "*":
+                    subsequence = grammar_sequence_from_element(
+                        " ".join(subelements))
+                    sequence += "optional(repeat("
+                    if subsequence[1] == "choice":
+                        sequence += "choice("
+                    elif subsequence[1] == "seq":
+                        sequence += "seq("
+                    sequence += subsequence[0]
+                    if subsequence[1] == "choice":
+                        sequence += "),"
+                    elif subsequence[1] == "seq":
+                        sequence += "),"
+                    sequence += ")),"
+                    sequence_i += 1
+                elif subsequences[sequence_i + 1] == "+":
+                    subsequence = grammar_sequence_from_element(
+                        " ".join(subelements))
+                    sequence += "repeat1("
+                    if subsequence[1] == "choice":
+                        sequence += "choice("
+                    elif subsequence[1] == "seq":
+                        sequence += "seq("
+                    sequence += subsequence[0]
+                    if subsequence[1] == "choice":
+                        sequence += "),"
+                    elif subsequence[1] == "seq":
+                        sequence += "),"
+                    sequence += "),"
+                    sequence_i += 1
+                elif subsequences[sequence_i + 1] == "?":
+                    subsequence = grammar_sequence_from_element(
+                        " ".join(subelements))
+                    sequence += "optional("
+                    if subsequence[1] == "choice":
+                        sequence += "choice("
+                    elif subsequence[1] == "seq":
+                        sequence += "seq("
+                    sequence += subsequence[0]
+                    if subsequence[1] == "choice":
+                        sequence += "),"
+                    elif subsequence[1] == "seq":
+                        sequence += "),"
+                    sequence += "),"
+                    sequence_i += 1
+                else:
+                    subsequence = grammar_sequence_from_element(
+                        " ".join(subelements))
+                    if subsequence[1] == "choice":
+                        sequence += "choice("
+                    elif subsequence[1] == "seq":
+                        sequence += "seq("
+                    sequence += subsequence[0]
+                    if subsequence[1] == "choice":
+                        sequence += "),"
+                    elif subsequence[1] == "seq":
+                        sequence += "),"
+            else:
+                subsequence = grammar_sequence_from_element(
+                    " ".join(subelements))
+                if subsequence[1] == "choice":
+                    sequence += "choice("
+                elif subsequence[1] == "seq":
+                    sequence += "seq("
+                sequence += subsequence[0]
+                if subsequence[1] == "choice":
+                    sequence += "),"
+                elif subsequence[1] == "seq":
+                    sequence += "),"
+        else:
+            if "|" in subsequences[sequence_i]:
+                sequence_type = "choice"
+            else:
+                enforce_optional = subsequences[sequence_i] in grammar_constituents_optional
+                if enforce_optional:
+                    sequence += "optional("
+                if sequence_i + 1 < len(subsequences):
+                    if subsequences[sequence_i + 1] == "*":
+                        sequence += "optional(repeat("
+                        sequence += "$." + subsequences[sequence_i] + ","
+                        sequence += ")),"
+                        sequence_i += 1
+                    elif subsequences[sequence_i + 1] == "+":
+                        sequence += "repeat1("
+                        sequence += "$." + subsequences[sequence_i] + ","
+                        sequence += "),"
+                        sequence_i += 1
+                    elif subsequences[sequence_i + 1] == "?":
+                        sequence += "optional("
+                        sequence += "$." + subsequences[sequence_i] + ","
+                        sequence += "),"
+                        sequence_i += 1
+                    else:
+                        if len(subsequences[sequence_i].strip()) > 0 and ")" not in subsequences[sequence_i]:
+                            sequence += "$." + subsequences[sequence_i] + ","
+                else:
+                    if len(subsequences[sequence_i].strip()) > 0 and ")" not in subsequences[sequence_i]:
+                        sequence += "$." + subsequences[sequence_i] + ","
+                if enforce_optional:
+                    sequence += "),"
+        sequence_i += 1
+    sequence += ""
+    return (sequence, sequence_type)
+
+
+def grammar_from_constituent(key, value):
+    return "        {}: $ => choice(\n            {}\n        ),".format(key, ",\n            ".join(["seq(" + grammar_sequence_from_element(element)[0] + ")" for element in value if len(element.strip()) > 0]))
+
+
+grammar_source += grammar_from_constituent(
+    "translation_unit", scanner_components[scanner_constituent.name()]["translation_unit"]) + "\n"
+del scanner_components[scanner_constituent.name()]["translation_unit"]
+
+
+grammar_source += grammar_from_constituent("global_decl_or_directive",
+                                           scanner_components[scanner_constituent.name()]["global_decl_or_directive"]) + "\n\n"
+del scanner_components[scanner_constituent.name()]["global_decl_or_directive"]
+
+
+def grammar_from_literal(key, value):
+    return "        {}: $ => token({}),".format(key, value)
+
+
+grammar_source += "\n".join([grammar_from_literal(key, value[0])
+                            for key, value in scanner_components[scanner_literal.name()].items()]) + "\n\n"
+
+
+grammar_source += "\n".join([grammar_from_constituent(key, value)
+                             for key, value in scanner_components[scanner_constituent.name()].items()]) + "\n\n"
+
+
+grammar_source += "\n".join([grammar_from_literal(key, value[0])
+                            for key, value in scanner_components[scanner_keyword.name()].items()]) + "\n\n"
+
+
+grammar_source += "\n".join([grammar_from_literal(key, value[0])
+                            for key, value in scanner_components[scanner_token.name()].items()]) + "\n\n"
+
+
+def grammar_from_reserved(key, value):
+    return "        {}: $ => choice(\n            {}\n        ),".format(key, ",\n            ".join(value))
+
+
+grammar_source += "\n".join([grammar_from_reserved(key, value)
+                            for key, value in scanner_components[scanner_reserved.name()].items()]) + "\n\n"
+
+
+def grammar_from_identifier(key, value):
+    return "        ident: $ => token({}),".format(",".join(value))
+
+
+grammar_source += "\n".join([grammar_from_identifier(key, value)
+                            for key, value in scanner_components[scanner_identifier.name()].items()]) + "\n\n"
+
+
+def grammar_from_comment(key, value):
+    return "        _comment: $ => seq({}),".format(",".join(value[0].split()))
+
+
+grammar_source += "\n".join([grammar_from_comment(key, value)
+                            for key, value in scanner_components["comment"].items()]) + "\n"
+
+
+def grammar_from_space(key, value):
+    return "        _space: $ => {},".format(",".join(value))
+
+
+grammar_source += "\n".join([grammar_from_space(key, value)
+                            for key, value in scanner_components["space"].items()])
+
+
+grammar_source += "\n"
+grammar_source += r"""
+    },
+});
+"""[1:-1]
+
+headerTemplate = Template(HEADER)
+grammar_file.write(headerTemplate.substitute(
+    YEAR=date.today().year) + grammar_source + "\n")
+grammar_file.close()
+
+with open(grammar_path + "/package.json", "w") as grammar_package:
+    grammar_package.write('{\n')
+    grammar_package.write('    "name": "tree-sitter-wgsl",\n')
+    grammar_package.write('    "dependencies": {\n')
+    grammar_package.write('        "nan": "^2.15.0"\n')
+    grammar_package.write('    },\n')
+    grammar_package.write('    "devDependencies": {\n')
+    grammar_package.write('        "tree-sitter-cli": "^0.20.0"\n')
+    grammar_package.write('    },\n')
+    grammar_package.write('    "main": "bindings/node"\n')
+    grammar_package.write('}\n')
+
+subprocess.run(["npm", "install"], cwd=grammar_path, check=True)
+subprocess.run(["npx", "tree-sitter", "generate"],
+               cwd=grammar_path, check=True)
+subprocess.run(["npx", "tree-sitter", "build-wasm"],
+               cwd=grammar_path, check=True)
+
+Language.build_library(
+    grammar_path + "/build/wgsl.so",
+    [
+        grammar_path,
+    ]
+)
+
+WGSL_LANGUAGE = Language(grammar_path + "/build/wgsl.so", "wgsl")
+
+parser = Parser()
+parser.set_language(WGSL_LANGUAGE)
+
+error_list = []
+
+for key, value in scanner_components[scanner_example.name()].items():
+    if "expect-error" in key:
+        continue
+    value = value[:]
+    if "function-scope" in key:
+        value = ["fn function__scope____() {"] + value + ["}"]
+    if "type-scope" in key:
+        value = ["let type_scope____: "] + value + [";"]
+    program = "\n".join(value)
+    tree = parser.parse(bytes(program, "utf8"))
+    if tree.root_node.has_error:
+        error_list.append((program, tree))
+    # TODO Semantic CI
+
+if len(error_list) > 0:
+    for error in error_list:
+        print("Example:")
+        print(error[0])
+        print("Tree:")
+        print(error[1].root_node.sexp())
+    raise Exception("Grammar is not compatible with examples!")

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6838,7 +6838,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
       //   %my_index = OpVariable %ptr Input
       [[builtin(instance_index)]] my_inst_index: u32,
       //    OpDecorate %my_inst_index BuiltIn InstanceIndex
-    ) -> VertexOutput {};
+    ) -> VertexOutput {}
 
     struct FragmentOutput {
       [[builtin(frag_depth)]] depth: f32;
@@ -6858,7 +6858,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
       [[builtin(sample_mask_in)]] mask_in: u32,
       //      OpDecorate %mask_in BuiltIn SampleMask ; an input variable
       //      OpDecorate %mask_in Flat
-    ) -> FragmentOutput {};
+    ) -> FragmentOutput {}
 
     [[stage(compute)]]
     fn cs_main(
@@ -6868,7 +6868,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
       //     OpDecorate %local_index BuiltIn LocalInvocationIndex
       [[builtin(global_invocation_id)]] global_id: vec3<u32>,
       //      OpDecorate %global_id BuiltIn GlobalInvocationId
-   ) {};
+   ) {}
   </xmp>
 </div>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -886,7 +886,7 @@ Key use cases of a vector include:
 Many operations on vectors act <dfn noexport>component-wise</dfn>, i.e. the
 result vector is formed by operating on each component independently.
 
-<div class='example wgsl' heading='Vector'>
+<div class='example wgsl type-scope' heading='Vector'>
   <xmp highlight='rust'>
     vec2<f32>  // is a vector of two f32s.
   </xmp>
@@ -926,7 +926,7 @@ The product operator (`*`) is used to either:
 
 See [[#arithmetic-expr]].
 
-<div class='example wgsl' heading='Matrix'>
+<div class='example wgsl type-scope' heading='Matrix'>
   <xmp highlight='rust'>
     mat2x3<f32>  // This is a 2 column, 3 row matrix of 32-bit floats.
                  // Equivalently, it is 2 column vectors of type vec3<f32>.
@@ -2972,7 +2972,7 @@ variable_statement
   | LET (IDENT | variable_ident_decl) EQUAL short_circuit_or_expression
 
 variable_decl
-  : VAR variable_qualifier? variable_ident_decl
+  : VAR variable_qualifier? (IDENT | variable_ident_decl)
 
 variable_ident_decl
   : IDENT COLON attribute_list* type_decl
@@ -5034,7 +5034,7 @@ allows them to naturally use values defined in the loop body.
   </xmp>
 </div>
 
-<div class='example wgsl' heading="[SHORTNAME] Loop with continue">
+<div class='example wgsl function-scope' heading="[SHORTNAME] Loop with continue">
   <xmp>
     var a: i32 = 2;
     var i: i32 = 0;
@@ -5051,7 +5051,7 @@ allows them to naturally use values defined in the loop body.
   </xmp>
 </div>
 
-<div class='example wgsl' heading="[SHORTNAME] Loop with continue and continuing">
+<div class='example wgsl function-scope' heading="[SHORTNAME] Loop with continue and continuing">
   <xmp>
     var a: i32 = 2;
     var i: i32 = 0;
@@ -6838,7 +6838,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
       //   %my_index = OpVariable %ptr Input
       [[builtin(instance_index)]] my_inst_index: u32,
       //    OpDecorate %my_inst_index BuiltIn InstanceIndex
-    ) -> VertexOutput;
+    ) -> VertexOutput {};
 
     struct FragmentOutput {
       [[builtin(frag_depth)]] depth: f32;
@@ -6858,7 +6858,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
       [[builtin(sample_mask_in)]] mask_in: u32,
       //      OpDecorate %mask_in BuiltIn SampleMask ; an input variable
       //      OpDecorate %mask_in Flat
-    ) -> FragmentOutput;
+    ) -> FragmentOutput {};
 
     [[stage(compute)]]
     fn cs_main(
@@ -6868,7 +6868,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in variable.
       //     OpDecorate %local_index BuiltIn LocalInvocationIndex
       [[builtin(global_invocation_id)]] global_id: vec3<u32>,
       //      OpDecorate %global_id BuiltIn GlobalInvocationId
-   );
+   ) {};
   </xmp>
 </div>
 


### PR DESCRIPTION
## Brief

This pull request adds primary syntactic CI for checking grammar and example changes of contributions. The mechanism adopts tree-sitter at https://github.com/tree-sitter/tree-sitter because:
- Applied to many languages with success, including Rust, C, JavaScript
- Already has adoption in the industry
- Rich feature-set, including tree queries, bindings to different languages, and also a playground for testing
- Exports a reusable grammar.json file which WGSL developers can later use to adopt any other backend easier than parsing the grammar from spec text directly
- Has a vibrant community which possibly can add more visibility to the aspects of grammar in WGSL and increase informed feedback

The mechanism currently supports four tags for example elements:
- expect-error (meaning the example won't get checked by grammar)
- global-scope (meaning the example will be directly checked by grammar as-is)
- function-scope (meaning the example will get decorated by a minimal context for it to be checkable by grammar)
- type-scope (meaning the example will get decorated by a minimal context for it to be checkable by grammar)

PR also includes some minor changes to spec to prevent build failures on landing.

## Playground

![3979B1F2-16E8-4E14-98B6-3A50B659E186](https://user-images.githubusercontent.com/5333693/132989065-3d4755bd-2481-4f8d-8b7d-7358b192d62d.png)

Once the PR lands, you will have the ability to launch a tree-sitter playground that can help detect issues quickly. If the group likes it, we can deploy this to our PR previews. Commands:

```
pip3 install bikeshed==3.0.3 tree_sitter==0.19.0
git clone ...
cd gpuweb/wgsl
make
cd grammar
npx tree-sitter playground
```

## Future Steps

I expect there to be issues with parsed results (check passes but the tree not correct kind of); we can improve those as we encounter them. Also, there are ambiguities in the grammar mainly due to lack of concept of precedence; tree-sitter has a nice mechanism for this which we can incorporate if we define them in the spec. Finally, this is merely a syntactic check, but the query interface provided by the tree-sitter inside Python can prove fruitful if we build semantic checks.