### PR TITLE
wgsl: replace stride attribute with array type parameter

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1134,6 +1134,7 @@ See [[#array-access-expr]].
           These may only appear in specific contexts.<br>
           The [=element count=] is not specified by the program source.
           Instead, the element count is determined by the size of the
+          binding range of the 
           buffer resource bound to the associated [=storage buffer=] variable.
           See [[#resource-interface]].<br>
 </table>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -668,13 +668,6 @@ An attribute must not be specified more than once per object or type.
 
     Declares an entry point by specifying its pipeline stage.
 
-  <tr><td><dfn noexport dfn-for="attribute">`stride`</dfn>
-    <td>positive i32 literal
-    <td>Must only be applied to an [=array=] type.
-
-    The number of bytes from the start of one element of the array to the
-    start of the next element.
-
   <tr><td><dfn noexport dfn-for="attribute">`workgroup_size`</dfn>
     <td>One, two or three parameters.
 
@@ -1105,61 +1098,32 @@ TODO: Add links the eventual memory model descriptions.
 
 ### Array Types ### {#array-types}
 
-An <dfn noexport>array</dfn> is an indexable grouping of element values.
+An <dfn noexport>array</dfn> is an indexable grouping of one or more element values.
+
+The <dfn>element count</dfn> of an array value is the number of elements in the array.
+
+The first element in an array is at index 0, and each successive element is at the next integer index.
+See [[#array-access-expr]].
 
 <table class='data'>
   <thead>
     <tr><th>Type<th>Description
   </thead>
-  <tr><td algorithm="fixed-size array type">array&lt;|E|,|N|&gt;
-      <td>A <dfn>fixed-size array</dfn> with |N| elements of type |E|.<br>
-          |N| is called the <dfn noexport>element count</dfn> of the array.
-  <tr><td algorithm="runtime-sized array type">array&lt;|E|&gt;
-      <td>A <dfn noexport>runtime-sized</dfn> array of elements of type |E|.
+  <tr algorithm="fixed-size array type">
+      <td>array&lt;|E|,|N|,|S|&gt;
+      <td>A <dfn>fixed-size array</dfn> with elements of type |E|,
+          [=element count=] |N|, and [=element stride=] |S|.<br>
+  <tr algorithm="dynamically-sized array type">
+      <td>dynamic_array&lt;|E|,|S|&gt;
+      <td>A <dfn noexport>dynamically-sized</dfn> array of elements of type |E|, with [=element stride=] |S|.
           These may only appear in specific contexts.<br>
+          The [=element count=] is not specified by the program source.
+          Instead, the element count is determined by the size of the
+          buffer resource bound to the associated [=storage buffer=] variable.
+          See [[#resource-interface]].<br>
 </table>
 
-When specified, an element count expression |N| must:
-* be a literal, or the name of a [[#module-constants|module-scope constant]] that is not [=pipeline-overridable=], and
-* evaluate to an [=integer scalar=] with value greater than zero.
-
-Note:  The element count value is fully determined at [=shader module creation=] time.
-
-Two array types are the same if and only if all of the following are true:
-* They have the same element type.
-* Their element count specifications match, i.e. either of the following is true:
-    * They are both runtime-sized.
-    * They are both fixed-sized with equal-valued element counts,
-        even if one is signed and the other is unsigned.
-        (Signed and unsigned values are comparable in this case because element counts must
-        be greater than zero.)
-
-Issue: Array types should differ if they have different element strides.
-See https://github.com/gpuweb/gpuweb/issues/1534
-
-<div class='example fixed-size array types' heading='Example fixed-size array types'>
-  <xmp>
-    // array<f32,8> and array<i32,8> are different types:
-    // different element types
-    var<private> a: array<f32,8>;
-    var<private> b: array<i32,8>;
-    var<private> c: array<i32,8u>;  // array<i32,8> and array<i32,8u> are the same type
-
-    let width = 8;
-    let height = 8;
-
-    // array<i32,8>, array<i32,8u>, and array<i32,width> are the same type.
-    // Their element counts evaluate to 8.
-    var<private> d: array<i32,width>;
-
-    // array<i32,height> and array<i32,width> are the same type.
-    var<private> e: array<i32,width>;
-    var<private> f: array<i32,height>;
-  </xmp>
-</div>
-
-The first element in an array is at index 0, and each successive element is at the next integer index.
-See [[#array-access-expr]].
+Issue: Let's bikeshed the name `dynamic_array`. Other options mentioned include `unsized_array`.
 
 An array element type must be one of:
 * a [=scalar=] type
@@ -1171,15 +1135,63 @@ An array element type must be one of:
 
 Note: That is, the element type must be a [=plain type=].
 
-[SHORTNAME] defines the following attributes that can be applied to array types:
-* [=attribute/stride=]
+The [=element count=] expression |N| for a fixed-size array must:
+* be a literal, or the name of a [[#module-constants|module-scope constant]] that is not [=pipeline-overridable=], and
+* evaluate to an [=integer scalar=] with value greater than zero.
 
-Restrictions on runtime-sized arrays:
+Note: The element count value for a fixed-size array is fully determined at [=shader module creation=] time.
+
+When spelling an array type in [SHORTNAME] program source, specifying the [=element stride=] |S| is optional,
+and defaults to the [=implicit stride=] computed from the array element type. See [[#array-layout-rules]].
+When specified, |S| must be a positive [=integer scalar=] literal.
+
+Note: Specifying an explicit [=element stride=] can make it easier to satisfy
+layout constraints for the [=storage classes/uniform=] storage storage class.
+See [[#storage-class-layout-constraints]].
+
+Two array types are the same if and only if all of the following are true:
+* They have the same element type.
+* Their element count specifications match, i.e. either of the following is true:
+    * They are both runtime-sized.
+    * They are both fixed-sized with equal-valued element counts,
+        even if one is signed and the other is unsigned.
+        (Signed and unsigned values are comparable in this case because element counts must
+        be greater than zero.)
+* They have the same [=element stride=].
+
+<div class='example fixed-size array types' heading='Example fixed-size array types'>
+  <xmp highlight='rust'>
+    // array<f32,5> and array<i32,5> are different types because they have
+    // different element types
+    var<private> a: array<f32,5>;
+    var<private> b: array<i32,5>;
+    var<private> c: array<i32,5u>;  // array<i32,5> and array<i32,5u> are the same type
+
+    let width = 5;
+    let height = 5;
+
+    // array<i32,5>, array<i32,5u>, and array<i32,width> are the same type.
+    // Their element counts evaluate to 5.
+    var<private> d: array<i32,width>;
+
+    // array<i32,height> and array<i32,width> are the same type.
+    var<private> e: array<i32,width>;
+    var<private> f: array<i32,height>;
+
+    // array<i32,5,4> and array<i32,5> are the same type because the implicit stride of
+    // array<i32,5> is 4.
+    var<private> g: array<i32,5,4>;
+    // array<i32,5,8> and array<i32,5,4> are different due to different strides.
+    var<private> h: array<i32,5,8>;
+  </xmp>
+</div>
+
+Restrictions on dynamically-sized arrays:
 * The last member of the structure type defining the [=store type=]
-    for a variable in the [=storage classes/storage=] storage class may be a runtime-sized array.
-* A runtime-sized array must not be used as the store type or contained within
+    for a variable in the [=storage classes/storage=] storage class may be a dynamically-sized array.
+* A dynamically-sized array must not be used as the store type or contained within
     a store type in any other cases.
-* An expression must not evaluate to a runtime-sized array type.
+* An expression must not evaluate to a dynamically-sized array type.
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>array_type_decl</dfn> :
@@ -1194,6 +1206,50 @@ Restrictions on runtime-sized arrays:
     | [=syntax/uint_literal=]
 
     | [=syntax/ident=]
+</div>
+
+
+<div class='example fixed-size array types' heading='Advanced array stride examples'>
+  <xmp highlight='rust'>
+  var<private> a_implicit: array<i32,5>;
+  var<private> a_explicit: array<i32,5,4>; // Explicit stride equals implicit stride.
+  var<private> bigger_stride: array<i32,5,16>;
+
+  fn assignments() {
+    a_implicit = a_explicit;    // Valid assignment of an array<i32,5,4> value.
+    bigger_stride = a_explicit; // Error: different array types due to strides
+    let first = a_implicit;     // Valid: has type array<i32,5,4> (same as array<i32,5>)
+    let second = a_explicit;    // Valid: has type array<i32,5,4> (same as array<i32,5>)
+    let third = bigger_stride;  // Valid: has type array<i32,5,16>
+  }
+
+  fn zeroes() {
+    a_implicit = array<i32,5>();       // Valid.
+    a_implicit = array<i32,5,4>();     // Valid. array<i32,5,4> is same as array<i32,5>
+    a_explicit = array<i32,5>();       // Valid. array<i32,5,4> is same as array<i32,5>
+    a_explicit = array<i32,5,4>();     // Valid.
+    bigger_stride = array<i32,5>();    // Error: wrong stride
+    bigger_stride = array<i32,5,4>();  // Error: wrong stride
+    bigger_stride = array<i32,5,16>(); // Valid.
+  }
+
+  fn zero_it(p: ptr<array<i32,5>,private>) {
+    *p = array<i32,5>();
+  }
+
+  fn zero_it_wide(p: ptr<array<i32,5,16>,private>) {
+    *p = array<i32,5,16>();
+  }
+
+  fn zero_them() {
+    zero_it(&a_implicit);         // Valid
+    zero_it(&a_explicit);         // Valid
+    zero_it(&bigger_stride);      // Error: different stride
+    zero_it_wide(&a_implicit);    // Error: different stride
+    zero_it_wide(&a_explicit);    // Error: different stride
+    zero_it_wide(&bigger_stride); // Valid
+  }
+  </xmp>
 </div>
 
 ### Structure Types ### {#struct-types}
@@ -1260,7 +1316,6 @@ Similarly, the same limitations apply to textures and samplers.
 [SHORTNAME] defines the following attributes that can be applied to structure members:
  * [=attribute/builtin=]
  * [=attribute/location=]
- * [=attribute/stride=]
  * [=attribute/align=]
  * [=attribute/size=]
 
@@ -1289,12 +1344,12 @@ to define a [=uniform buffer=] or a [=storage buffer=]. See [[#memory-layouts]].
 
 <div class='example wgsl global-scope' heading='Structure WGSL'>
   <xmp>
-    // Runtime Array
-    type RTArr = [[stride(16)]] array<vec4<f32>>;
+    // A dynamically-sized array with array stride 16.
+    type DynArr = dynamic_array<vec4<f32>,16>;
     [[block]] struct S {
       a: f32;
       b: f32;
-      data: RTArr;
+      data: DynArr;
     };
   </xmp>
 </div>
@@ -1351,8 +1406,8 @@ A type is <dfn>constructible</dfn> if it is one of:
 
 Note: All constructible types are [=plain types|plain=].
 
-Note: Atomic types and runtime-sized array types are not constructible.
-Composite types containing atomics and runtime-sized arrays are not constructible.
+Note: Atomic types and dynamically-sized array types are not constructible.
+Composite types containing atomics and dynamically-sized arrays are not constructible.
 
 ## Memory ## {#memory}
 
@@ -1461,17 +1516,16 @@ A type is <dfn dfn noexport>host-shareable</dfn> if it is one of:
 * a [=matrix=] type
 * an [=atomic type|atomic=] type
 * a [=fixed-size array=] type, if its element type is host-shareable
-* a [=runtime-sized=] array type, if its element type is host-shareable
+* a [=dynamically-sized=] array type, if its element type is host-shareable
 * a [=structure=] type, if all its members are host-shareable
 
 [SHORTNAME] defines the following attributes that affect memory layouts:
- * [=attribute/stride=]
  * [=attribute/align=]
  * [=attribute/size=]
 
-Note: An [=IO-shareable=] type *T* is host-shareable if *T* is not [=bool=] and does not contain [=bool=].
+Note: An [=IO-shareable=] type *T* is host-shareable if *T* is not [=bool=] and is not a composite containing [=bool=].
 Many types are host-shareable, but not IO-shareable, including [=atomic types=],
-[=runtime-sized=] arrays, and any composite types containing them.
+[=dynamically-sized=] arrays and any composite types containing them.
 
 Note: Both IO-shareable and host-shareable types have concrete sizes, but counted differently.
 IO-shareable types are sized by a location-count metric, see [[#input-output-locations]].
@@ -1512,7 +1566,7 @@ and how to use variables with it.
       <td>[=access/read_write=]
       <td>[=Module scope=]
       <td>[=Plain type=],
-          excluding [=runtime-sized=] arrays, or [=composite=] types containing runtime-sized arrays
+          excluding [=dynamically-sized=] arrays, or [=composite=] types containing dynamically-sized arrays
       <td>
   <tr><td><dfn noexport dfn-for="storage classes">uniform</dfn>
       <td>Invocations in the same [=shader stage=]
@@ -1596,7 +1650,7 @@ We will use the following notation:
 * <dfn noexport>AlignOfMember</dfn>(|S|, |M|) is the alignment of member |M| of the host-shareable structure |S|.
 * <dfn noexport>SizeOf</dfn>(|T|) is the size of host-shareable type |T|.
 * <dfn noexport>SizeOfMember</dfn>(|S|, |M|) is the size of member |M| of the host-shareable structure |S|.
-* <dfn noexport>StrideOf</dfn>(|A|) is the [=element stride=] of host-shareable array type |A|.
+* <dfn noexport>StrideOf</dfn>(|A|) is the [=element stride=] of array type |A|.
 * <dfn noexport>OffsetOfMember</dfn>(|S|, |M|) is the offset of member |M| from the start of the host-shareable structure |S|.
 
 
@@ -1634,16 +1688,16 @@ following table:
   <tr><td>[=i32=], [=u32=], or [=f32=]
       <td>4
       <td>4
-  <tr><td>atomic&lt;|T|&gt;
+  <tr><td>atomic&lt;|E|&gt;
       <td>4
       <td>4
-  <tr><td>vec2&lt;|T|&gt;
+  <tr><td>vec2&lt;|E|&gt;
       <td>8
       <td>8
-  <tr><td>vec3&lt;|T|&gt;
+  <tr><td>vec3&lt;|E|&gt;
       <td>16
       <td>12
-  <tr><td>vec4&lt;|T|&gt;
+  <tr><td>vec4&lt;|E|&gt;
       <td>16
       <td>16
   <tr><td>mat|N|x|M| (col-major)<br>
@@ -1681,21 +1735,21 @@ following table:
       <td>max([=AlignOfMember=](S, M<sub>1</sub>), ... , [=AlignOfMember=](S, M<sub>N</sub>))<br>
       <td>[=roundUp=]([=AlignOf=](|S|), [=OffsetOfMember=](|S|, |L|) + [=SizeOfMember=](|S|, |L|))<br><br>
           Where |L| is the last member of the structure
-  <tr><td>array<|E|, |N|><br>
+  <tr><td>array&lt;|E|,|N|&gt;<br>
       <p class="small">(Implicit stride)</p>
       <td>[=AlignOf=](|E|)
       <td>|N| * [=roundUp=]([=AlignOf=](|E|), [=SizeOf=](|E|))
-  <tr><td>array<|E|><br>
+  <tr><td>dynamic_array&lt;|E|&gt;<br>
       <p class="small">(Implicit stride)</p>
       <td>[=AlignOf=](|E|)
-      <td>N<sub>runtime</sub> * [=roundUp=]([=AlignOf=](|E|), [=SizeOf=](|E|))<br><br>
-          Where N<sub>runtime</sub> is the runtime-determined number of elements of |T|
-  <tr><td>[[[=attribute/stride=](|Q|)]]<br> array<|E|, |N|>
+      <td>N<sub>dynamic</sub> * [=roundUp=]([=AlignOf=](|E|), [=SizeOf=](|E|))<br><br>
+          Where N<sub>dynamic</sub> is the dynamically-determined number of elements of |T|
+  <tr><td>array&lt;|E|,|N|,|Q|&gt;
       <td>[=AlignOf=](|E|)
       <td>|N| * |Q|
-  <tr><td>[[[=attribute/stride=](|Q|)]]<br> array<|E|>
+  <tr><td><br> dynamic_array&lt;|E|,|Q|&gt;
       <td>[=AlignOf=](|E|)
-      <td>N<sub>runtime</sub> * |Q|
+      <td>N<sub>dynamic</sub> * |Q|
 </table>
 
 
@@ -1766,7 +1820,7 @@ rounded to the next multiple of the structure's alignment:
         e: A;                                      // offset(40)  align(8)  size(24)
         f: vec3<f32>;                              // offset(64)  align(16) size(12)
         // -- implicit member alignment padding -- // offset(76)            size(4)
-        g: array<A, 3>;                            // offset(80)  align(8)  size(72) stride(24)
+        g: array<A, 3>;                            // offset(80)  align(8)  size(72) implicit stride 24
         h: i32;                                    // offset(152) align(4)  size(4)
         // -- implicit struct size padding --      // offset(156)           size(4)
     };
@@ -1795,7 +1849,7 @@ rounded to the next multiple of the structure's alignment:
         [[align(16)]] e: A;                        // offset(48)  align(16) size(32)
         f: vec3<f32>;                              // offset(80)  align(16) size(12)
         // -- implicit member alignment padding -- // offset(92)            size(4)
-        g: [[stride(32)]] array<A, 3>;             // offset(96)  align(8)  size(96)
+        g: array<A, 3, 32>;                        // offset(96)  align(8)  size(96)
         h: i32;                                    // offset(192) align(4)  size(4)
         // -- implicit struct size padding --      // offset(196)           size(12)
     };
@@ -1813,14 +1867,18 @@ array.
 The <dfn noexport>element stride</dfn> of an array is the number of bytes from the
 start of one array element to the start of the next element.
 It is determined as follows:
-* It is the value of an explicit [=attribute/stride=] attribute on the type, if specified.
+* It is the value of the explicit stride parameter on the type, if specified.
+    <p algorithm="array explicit element stride">
+      [=StrideOf=](array&lt;|E|,|N|,|S|&gt;) = |S|<br>
+      [=StrideOf=](dynamic_array&lt;|E|,|S|&gt;) = |S|
+    </p>
 * Otherwise, it is the <dfn noexport>implicit stride</dfn>,
     equal to the size of the array's element type, rounded up to the alignment of
     the element type:
-
-<p algorithm="array implicit element stride">
-  [=StrideOf=](array<|T|[, |N|]>) = [=roundUp=]([=AlignOf=](T), [=SizeOf=](T))
-</p>
+    <p algorithm="array implicit element stride">
+      [=StrideOf=](array&lt;|E|,|N|&gt;) = [=roundUp=]([=AlignOf=](|E|), [=SizeOf=](|E|))<br>
+      [=StrideOf=](dynamic_array&lt;|E|&gt;) = [=roundUp=]([=AlignOf=](|E|), [=SizeOf=](|E|))
+    </p>
 
 In all cases, the array element stride must be a multiple of the element alignment.
 
@@ -1830,35 +1888,37 @@ In all cases, the array element stride must be a multiple of the element alignme
     var implicit_stride: array<vec3<f32>, 8>;
 
     // Array with an explicit element stride of 32 bytes
-    var explicit_stride: [[stride(32)]] array<vec3<f32>, 8>;
+    var explicit_stride: array<vec3<f32>, 8, 32>;
   </xmp>
 </div>
 
-Arrays decorated with the [=attribute/stride=] attribute must have a stride that is at
+When specified, the explicit stride type parameter must have a value at
 least the size of the element type, and be a multiple of the element type's
 alignment value.
 
 The array size (in bytes) is equal to the array's element stride multiplied by the number of
 elements:
 <p algorithm="array element stride">
-  [=SizeOf=](array<|T|, |N|>) = [=StrideOf=](array<|T|, |N|>) &times; |N|<br>
-  [=SizeOf=](array<|T|>) = [=StrideOf=](array<|T|>) &times; N<sub>runtime</sub>
+  [=SizeOf=](array&lt;|E|,|N|,|S|&gt;) = [=StrideOf=](array&lt;|E|,|N|,|S|&gt;) &times; |N|<br>
+  [=SizeOf=](dynamic_array&lt;|E|,|S|&gt;) = [=StrideOf=](dynamic_array&lt;|E|,|S|&gt;) &times; N<sub>dynamic</sub><br>
 </p>
+Here N<sub>dynamic</sub> is the dynamically-determined number of elements of the given [=dynamically-sized=] array.
 
 The array alignment is equal to the element alignment:
 <p algorithm="array alignment">
-  [=AlignOf=](array<|T|[, N]>) = [=AlignOf=](|T|)
+  [=AlignOf=](array<|E|,|N|,|S|>) = [=AlignOf=](|E|)<br>
+  [=AlignOf=](dynamic_array<|E|,|S|>) = [=AlignOf=](|E|)
 </p>
 
-For example, the layout for a `[[stride(S)]] array<T, 3>` type is equivalent to
+For example, the layout for an `array<E, 3, 24>` type is equivalent to
 the following structure:
 
-<div class='example wgsl global-scope' heading='Structure equivalent of a three element array'>
+<div class='example wgsl global-scope' heading='Structure equivalent of a three element array with a 24-byte stride'>
   <xmp highlight='rust'>
     struct Array {
-      [[size(S)]] element_0: T;
-      [[size(S)]] element_1: T;
-      [[size(S)]] element_2: T;
+      [[size(24)]] element_0: E;
+      [[size(24)]] element_1: E;
+      [[size(24)]] element_2: E;
     };
   </xmp>
 </div>
@@ -1867,8 +1927,8 @@ the following structure:
 
 This section describes how the internals of a value are placed in the byte locations
 of a buffer, given an assumed placement of the overall value.
-These layouts depend on the value's type, the [=attribute/stride=] attribute on
-array types, and the [=attribute/align=] and [=attribute/size=] attributes on
+These layouts depend on the value's type, the [=element stride=] of an array type,
+and the [=attribute/align=] and [=attribute/size=] attributes on
 structure type members.
 
 The data will appear identically regardless of storage class.
@@ -1940,35 +2000,35 @@ used by storage class |C|.
     [=storage classes/storage=] and [=storage classes/uniform=] storage classes
   </caption>
   <thead>
-    <tr><th>Host-shareable type |S|
-        <th>[=RequiredAlignOf=](|S|, [=storage classes/storage=])
-        <th>[=RequiredAlignOf=](|S|, [=storage classes/uniform=])
+    <tr><th>Host-shareable type |T|
+        <th>[=RequiredAlignOf=](|T|, [=storage classes/storage=])
+        <th>[=RequiredAlignOf=](|T|, [=storage classes/uniform=])
   </thead>
   <tr><td>[=i32=], [=u32=], or [=f32=]
-      <td>[=AlignOf=](|S|)
-      <td>[=AlignOf=](|S|)
-  <tr><td>atomic&lt;T&gt;
-      <td>[=AlignOf=](|S|)
-      <td>[=AlignOf=](|S|)
+      <td>[=AlignOf=](|T|)
+      <td>[=AlignOf=](|T|)
+  <tr><td>atomic&lt;|E|&gt;
+      <td>[=AlignOf=](|T|)
+      <td>[=AlignOf=](|T|)
   <tr><td>vecN&lt;T&gt;
-      <td>[=AlignOf=](|S|)
-      <td>[=AlignOf=](|S|)
+      <td>[=AlignOf=](|T|)
+      <td>[=AlignOf=](|T|)
   <tr algorithm="alignment of a matrix with N columns and M rows">
       <td>matNxM&lt;f32&gt;
-      <td>[=AlignOf=](|S|)
-      <td>[=AlignOf=](|S|)
-  <tr algorithm="alignment of an array">
-      <td>array&lt;T, N&gt;
-      <td>[=AlignOf=](|S|)
-      <td>[=roundUp=](16, [=AlignOf=](|S|))
-  <tr algorithm="alignment of an runtime-sized array">
-      <td>array&lt;T&gt;
-      <td>[=AlignOf=](|S|)
-      <td>[=roundUp=](16, [=AlignOf=](|S|))
+      <td>[=AlignOf=](|T|)
+      <td>[=AlignOf=](|T|)
+  <tr algorithm="alignment of a fixed-size array">
+      <td>array&lt;|E|,|N|,|S|&gt;
+      <td>[=AlignOf=](|T|)
+      <td>[=roundUp=](16, [=AlignOf=](|T|))
+  <tr algorithm="alignment of a dynamically-sized array">
+      <td>dynamic_array&lt;|E|,|S|&gt;
+      <td>[=AlignOf=](|T|)
+      <td>not applicable: a dynamic_array must not appear in uniform storage.
   <tr algorithm="alignment of a structure">
       <td>struct |S|
-      <td>[=AlignOf=](|S|)
-      <td>[=roundUp=](16, [=AlignOf=](|S|))<br>
+      <td>[=AlignOf=](|T|)
+      <td>[=roundUp=](16, [=AlignOf=](|T|))<br>
 </table>
 
 Structure members of type |T| must have a byte offset
@@ -1984,8 +2044,9 @@ Arrays of element type |T| must have an [=element stride=] that is a
 multiple of the [=RequiredAlignOf=](|T|, |C|) for the storage class |C|:
 
 <p algorithm="array element minimum alignment">
-    [=StrideOf=](array<|T|[, |N|]>) = |k| &times; [=RequiredAlignOf=](|T|, C)<br>
-    Where |k| is a positive integer
+    [=StrideOf=](array<|E|,|N|,|S|>) = |k| &times; [=RequiredAlignOf=](|E|, C)<br>
+    [=StrideOf=](dynamic_array<|E|,|S|>) = |k| &times; [=RequiredAlignOf=](|E|, C)<br>
+    Where |k| is some positive integer
 </p>
 
 Note: [=RequiredAlignOf=](|T|, |C|) does not impose any additional restrictions
@@ -1996,7 +2057,7 @@ sections and then the resulting layout is validated against the
 
 The [=storage classes/uniform=] storage class also requires that:
 * Array elements are aligned to 16 byte boundaries.
-    That is, [=StrideOf=](array&lt;|T|,|N|&gt;) = 16 &times; |k|' for some positive integer |k|'.
+    That is, [=StrideOf=](array&lt;|E|,|N|,|S|&gt;) = 16 &times; |k|' for some positive integer |k|'.
 * If a structure member itself has a structure type `S`, then the number of
     bytes between the start of that member and the start of any following member
     must be at least [=roundUp=](16, [=SizeOf=](S)).
@@ -2971,7 +3032,7 @@ TODO: Add texture usage validation rules.
   <xmp>
     type Arr = array<i32, 5>;
 
-    type RTArr = [[stride(16)]] array<vec4<f32>>;
+    type DynArr = dynamic_array<vec4<f32>, 16>;
   </xmp>
 </div>
 
@@ -3050,12 +3111,12 @@ When the type declaration is an [=identifier=], then the expression must be in s
        %uint_4 = OpConstant %uint 4
             %9 = OpTypeArray %float %uint_4
 
-    [[stride(32)]] array<f32, 4>
+    array<f32, 4, 32>
                  OpDecorate %9 ArrayStride 32
        %uint_4 = OpConstant %uint 4
             %9 = OpTypeArray %float %uint_4
 
-    array<f32>
+    dynamic_array<f32>
        %rtarr = OpTypeRuntimeArray %float
 
     mat2x3<f32>
@@ -3260,7 +3321,7 @@ Such variables are declared with [=attribute/group=] and [=attribute/binding=] d
     var<uniform> param: Params;    // A uniform buffer
 
     [[block]] struct PositionsBuffer {
-      pos: array<vec2<f32>>;
+      pos: dynamic_array<vec2<f32>>;
     };
     // A storage buffer, for reading and writing
     [[group(0), binding(0)]]
@@ -3612,13 +3673,22 @@ See also [[#zero-value-expr]] and [[#conversion-expr]].
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr algorithm="array value construction">
-    <td>|e1|: |T|<br>
+    <td>|e1|: |E|<br>
         ...<br>
-        |eN|: |T|,<br>
-        |T| is a [=constructible=] type.
-    <td>`array<`|T|,|N|`>(`|e1|,...,|eN|`)` : array&lt;|T|,|N|&gt;
+        |eN|: |E|,<br>
+        |E| is a [=constructible=] type.
+    <td>`array<`|E|,|N|`>(`|e1|,...,|eN|`)` : array&lt;|E|,|N|&gt;
     <td>Construction of an array from elements.
+  <tr algorithm="strided array value construction">
+    <td>|e1|: |E|<br>
+        ...<br>
+        |eN|: |E|,<br>
+        |E| is a [=constructible=] type.
+    <td>`array<`|E|,|N|,|S|`>(`|e1|,...,|eN|`)` : array&lt;|E|,|N|,|S|&gt;
+    <td>Construction of an explicitly-strided array, from elements.
 </table>
+
+Note: There is no constructor for a [=dynamically-sized=] array.
 
 <table class='data'>
   <caption>Structure constructor type rules</caption>
@@ -3652,7 +3722,7 @@ The zero values are as follows:
 * The zero value for a [=constructible=] structure type *S* is the structure value *S* with zero-valued members.
 
 Note: WGSL does not have zero expression for [=atomic types=],
-[=runtime-sized=] arrays, or other types that are not [=constructible=].
+[=dynamically-sized=] arrays, or other types that are not [=constructible=].
 
 <table class='data'>
   <caption>Scalar zero value type rules</caption>
@@ -3725,10 +3795,14 @@ Note: WGSL does not have zero expression for [=atomic types=],
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
-  <tr algorithm="array zero value">
+  <tr algorithm="array zero value with implicit stride">
+    <td>|E| is a [=constructible=]
+    <td>`array<`|E|,|N|`>()`: array&lt;|E|,|N|&gt;
+    <td>Zero-valued array with implicit stride.<br>(OpConstantNull)
+  <tr algorithm="array zero value with explicit stride">
     <td>|T| is a [=constructible=]
-    <td>`array<`|T|,|N|`>()`: array&lt;|T|,|N|&gt;
-    <td>Zero-valued array (OpConstantNull)
+    <td>`array<`|E|,|N|,|S|`>()`: array&lt;|E|,|N|,|S|&gt;
+    <td>Zero-valued array with explicit stride.<br>(OpConstantNull)
 </table>
 
 <div class='example' heading="Zero-valued arrays">
@@ -4245,14 +4319,14 @@ the variable's value, as required.
   </thead>
   <tr algorithm="fixed-size array indexed element selection">
        <td class="nowrap">
-          |e|: array&lt;|T|,|N|&gt;<br>
-          |i|: [INT]<br>
+          |e| : array&lt;|E|,|N|,|S|&gt;<br>
+          |i| : [INT]<br>
           |i| is a `const_expression` expression
        <td class="nowrap">
-           |e|[|i|] : |T|
+           |e|[|i|] : |E|
        <td>The result is the value of the |i|'<sup>th</sup> element of the array value |e|.
 
-           If |i| is outside the range [0,|N|-1], then any valid value for |T|
+           If |i| is outside the range [0,|N|-1], then any valid value for |E|
            may be returned.
            (OpCompositeExtract)
 </table>
@@ -4264,10 +4338,10 @@ the variable's value, as required.
   </thead>
   <tr algorithm="fixed-size array indexed reference selection">
        <td class="nowrap">
-          |r|: ref&lt;|SC|,array&lt;|T|,|N|&gt;&gt;<br>
-          |i|: [INT]
+          |r| : ref&lt;|SC|,array&lt|E|,|N|,|S|&gt;&gt;<br>
+          |i| : [INT]
        <td class="nowrap">
-           |r|[|i|] : ref&lt;|SC|,|T|&gt;
+           |r|[|i|] : ref&lt;|SC|,|E|&gt;
        <td>Compute a reference to the |i|'<sup>th</sup> element of the array
            referenced by the reference |r|.
 
@@ -4277,13 +4351,13 @@ the variable's value, as required.
            The [=originating variable=] of the resulting reference is
            the same as the originating variable of |r|.<br>
            (OpAccessChain)
-  <tr algorithm="array indexed reference selection">
-       <td>|r|: ref&lt;|SC|,array&lt;|T|&gt;&gt;<br>
-          |i|: [INT]
+  <tr algorithm="dynamically-sized array indexed reference selection">
+       <td>|r| : ref&lt;|SC|,dynamic_array&lt;|E|,|S|&gt;&gt;<br>
+           |i| : [INT]
        <td class="nowrap">
-           |r|[|i|] : ref&lt;|SC|,|T|&gt;
+           |r|[|i|] : ref&lt;|SC|,|E|&gt;
        <td>Compute a reference to the |i|'<sup>th</sup> element of the
-           runtime-sized array referenced by the reference |r|.
+           dynamically-sized array referenced by the reference |r|.
 
            If at runtime the array has |N| elements, and |i| is outside the range
            [0,|N|-1], then the expression evaluates to an [=invalid memory
@@ -6328,16 +6402,16 @@ and |WB| is the [[WebGPU#buffer-interface|WebGPU GPUBuffer]] bound to |B|, then:
 
 If |B| is a [=storage buffer=] variable in a resource interface,
 and |WB| is the [[WebGPU#buffer-interface|WebGPU GPUBuffer]] bound to |B|, then:
-* If the [=store type=] |S| of |B| does not contain a [=runtime-sized=] array, then
+* If the [=store type=] |S| of |B| does not contain a [=dynamically-sized=] array, then
     the size of |WB| must be at least as large as the size
     of |S| in the [=storage classes/storage=] storage class.
-* If the [=store type=] |S| of |B| contains a [=runtime-sized=] array as its last member,
+* If the [=store type=] |S| of |B| contains a [=dynamically-sized=] array as its last member,
     then:
-    * The runtime-determined array length of that member must be at least 1.
+    * The dynamically-determined element count of that member must be at least 1.
     * The size of |WB| must be at least as large as the size in
         storage class [=storage classes/storage=] of the value stored in |B|.
 
-Note: Recall that a [=runtime-sized=] array may only appear as the last element in the structure
+Note: Recall that a [=dynamically-sized=] array may only appear as the last element in the structure
 type that is the store type of a storage buffer variable.
 
 TODO: Describe other interface matching requirements, e.g. for images?
@@ -7851,9 +7925,9 @@ That's not a full user-defined function declaration.
     <td>Test a normal value according to [[!IEEE-754|IEEE-754]].<br>
     [=Component-wise=] when |I| is a vector.
 
-  <tr algorithm="runtime-sized array length">
-    <td>|e|: ptr&lt;storage,array&lt;|T|&gt;&gt;
-    <td>`arrayLength(`|e|`)`: u32<td>Returns the number of elements in the [=runtime-sized=] array.<br>
+  <tr algorithm="dynamically-sized element count">
+    <td>|e|: ptr&lt;storage,dynamic_array&lt;|E|,|S|&gt;&gt;<br>
+    <td>`arrayLength(`|e|`)`: u32<td>Returns the number of elements in the [=dynamically-sized=] array.<br>
         (OpArrayLength, but the implementation has to trace back to get the pointer to the enclosing struct.)
 </table>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1123,8 +1123,6 @@ See [[#array-access-expr]].
           See [[#resource-interface]].<br>
 </table>
 
-Issue: Let's bikeshed the name `dynamic_array`. Other options mentioned include `unsized_array`.
-
 An array element type must be one of:
 * a [=scalar=] type
 * a vector type

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -441,6 +441,7 @@ A <dfn>token</dfn> is a contiguous sequence of characters forming one of:
 * a [=reserved word=].
 * a [=syntactic token=].
 * an [=identifier=].
+* a [=modifier word=].
 
 ## Literals ## {#literals}
 
@@ -519,6 +520,20 @@ an identifier must not have the same spelling as a [=keyword=] or as a [=reserve
 
     | `/[a-zA-Z][0-9a-zA-Z_]*/`
 </div>
+
+## Modifier Words ## {#modifier-words}
+
+A <dfn>modifier word</dfn> is a [=token=] which has a distinguished meaning only in certain contexts.
+Outside those contexts, the token is classified as an [=identifier=].
+
+The modifier-words are:
+
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>stride</dfn> :
+
+    | `/stride/`
+</div>
+
 
 ## Attributes ## {#attributes}
 
@@ -1110,11 +1125,11 @@ See [[#array-access-expr]].
     <tr><th>Type<th>Description
   </thead>
   <tr algorithm="fixed-size array type">
-      <td>array&lt;|E|,|N|,|S|&gt;
+      <td>array&lt;|E|,|N|,stride=|S|&gt;
       <td>A <dfn>fixed-size array</dfn> with elements of type |E|,
           [=element count=] |N|, and [=element stride=] |S|.<br>
   <tr algorithm="dynamically-sized array type">
-      <td>dynamic_array&lt;|E|,|S|&gt;
+      <td>dynamic_array&lt;|E|,stride=|S|&gt;
       <td>A <dfn noexport>dynamically-sized</dfn> array of elements of type |E|, with [=element stride=] |S|.
           These may only appear in specific contexts.<br>
           The [=element count=] is not specified by the program source.
@@ -1139,7 +1154,7 @@ The [=element count=] expression |N| for a fixed-size array must:
 
 Note: The element count value for a fixed-size array is fully determined at [=shader module creation=] time.
 
-When spelling an array type in [SHORTNAME] program source, specifying the [=element stride=] |S| is optional,
+When spelling an array type in [SHORTNAME] program source, specifying the [=element stride=] `stride=`|S| is optional,
 and defaults to the [=implicit stride=] computed from the array element type. See [[#array-layout-rules]].
 When specified, |S| must be a positive [=integer scalar=] literal.
 
@@ -1178,9 +1193,9 @@ Two array types are the same if and only if all of the following are true:
 
     // array<i32,5,4> and array<i32,5> are the same type because the implicit stride of
     // array<i32,5> is 4.
-    var<private> g: array<i32,5,4>;
+    var<private> g: array<i32,5,stride=4>;
     // array<i32,5,8> and array<i32,5,4> are different due to different strides.
-    var<private> h: array<i32,5,8>;
+    var<private> h: array<i32,5,stride=8>;
   </xmp>
 </div>
 
@@ -1194,8 +1209,23 @@ Restrictions on dynamically-sized arrays:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>array_type_decl</dfn> :
 
-    | [=syntax/attribute_lists=] ? [=syntax/array=] [=syntax/less_than=] [=syntax/type_decl=] ( [=syntax/comma=] [=syntax/element_count_expression=] ) ? [=syntax/greater_than=]
+    | [=syntax/fixed_size_array_type_decl=]
+
+    | [=syntax/dynamic_size_array_type_decl=]
 </div>
+
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>fixed_size_array_type_decl</dfn> :
+
+    | [=syntax/array=] [=syntax/less_than=] [=syntax/type_decl=] [=syntax/comma=] [=syntax/element_count_expression=] [=syntax/explicit_stride=] ? [=syntax/greater_than=]
+</div>
+
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>dynamic_size_array_type_decl</dfn> :
+
+    | [=syntax/dynamic_array=] [=syntax/less_than=] [=syntax/type_decl=] [=syntax/explicit_stride=] ? [=syntax/greater_than=]
+</div>
+
 <div class='syntax' noexport='true'>
   <dfn for=syntax>element_count_expression</dfn> :
 
@@ -1206,29 +1236,35 @@ Restrictions on dynamically-sized arrays:
     | [=syntax/ident=]
 </div>
 
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>explicit_stride</dfn> :
+
+    | [=syntax/comma=] [=syntax/stride=] [=syntax/equal=] [=syntax/int_literal=]
+</div>
+
 
 <div class='example fixed-size array types' heading='Advanced array stride examples'>
   <xmp highlight='rust'>
   var<private> a_implicit: array<i32,5>;
-  var<private> a_explicit: array<i32,5,4>; // Explicit stride equals implicit stride.
-  var<private> bigger_stride: array<i32,5,16>;
+  var<private> a_explicit: array<i32,5,stride=4>; // Explicit stride equals implicit stride.
+  var<private> bigger_stride: array<i32,5,stride=16>;
 
   fn assignments() {
-    a_implicit = a_explicit;    // Valid assignment of an array<i32,5,4> value.
+    a_implicit = a_explicit;    // Valid assignment of an array<i32,5,stride=4> value.
     bigger_stride = a_explicit; // Error: different array types due to strides
-    let first = a_implicit;     // Valid: has type array<i32,5,4> (same as array<i32,5>)
-    let second = a_explicit;    // Valid: has type array<i32,5,4> (same as array<i32,5>)
-    let third = bigger_stride;  // Valid: has type array<i32,5,16>
+    let first = a_implicit;     // Valid: has type array<i32,5,stride=4> (same as array<i32,5>)
+    let second = a_explicit;    // Valid: has type array<i32,5,stride=4> (same as array<i32,5>)
+    let third = bigger_stride;  // Valid: has type array<i32,5,stride=16>
   }
 
   fn zeroes() {
-    a_implicit = array<i32,5>();       // Valid.
-    a_implicit = array<i32,5,4>();     // Valid. array<i32,5,4> is same as array<i32,5>
-    a_explicit = array<i32,5>();       // Valid. array<i32,5,4> is same as array<i32,5>
-    a_explicit = array<i32,5,4>();     // Valid.
-    bigger_stride = array<i32,5>();    // Error: wrong stride
-    bigger_stride = array<i32,5,4>();  // Error: wrong stride
-    bigger_stride = array<i32,5,16>(); // Valid.
+    a_implicit = array<i32,5>();              // Valid.
+    a_implicit = array<i32,5,stride=4>();     // Valid. array<i32,5,stride=4> is same as array<i32,5>
+    a_explicit = array<i32,5>();              // Valid. array<i32,5,stride=4> is same as array<i32,5>
+    a_explicit = array<i32,5,stride=4>();     // Valid.
+    bigger_stride = array<i32,5>();           // Error: wrong stride
+    bigger_stride = array<i32,5,stride=4>();  // Error: wrong stride
+    bigger_stride = array<i32,5,stride=16>(); // Valid.
   }
 
   fn zero_it(p: ptr<array<i32,5>,private>) {
@@ -1236,7 +1272,7 @@ Restrictions on dynamically-sized arrays:
   }
 
   fn zero_it_wide(p: ptr<array<i32,5,16>,private>) {
-    *p = array<i32,5,16>();
+    *p = array<i32,5,stride=16>();
   }
 
   fn zero_them() {
@@ -1343,7 +1379,7 @@ to define a [=uniform buffer=] or a [=storage buffer=]. See [[#memory-layouts]].
 <div class='example wgsl global-scope' heading='Structure WGSL'>
   <xmp>
     // A dynamically-sized array with array stride 16.
-    type DynArr = dynamic_array<vec4<f32>,16>;
+    type DynArr = dynamic_array<vec4<f32>,stride=16>;
     [[block]] struct S {
       a: f32;
       b: f32;
@@ -1742,10 +1778,10 @@ following table:
       <td>[=AlignOf=](|E|)
       <td>N<sub>dynamic</sub> * [=roundUp=]([=AlignOf=](|E|), [=SizeOf=](|E|))<br><br>
           Where N<sub>dynamic</sub> is the dynamically-determined number of elements of |T|
-  <tr><td>array&lt;|E|,|N|,|Q|&gt;
+  <tr><td>array&lt;|E|,|N|,stride=|Q|&gt;
       <td>[=AlignOf=](|E|)
       <td>|N| * |Q|
-  <tr><td><br> dynamic_array&lt;|E|,|Q|&gt;
+  <tr><td><br> dynamic_array&lt;|E|,stride=|Q|&gt;
       <td>[=AlignOf=](|E|)
       <td>N<sub>dynamic</sub> * |Q|
 </table>
@@ -1847,7 +1883,7 @@ rounded to the next multiple of the structure's alignment:
         [[align(16)]] e: A;                        // offset(48)  align(16) size(32)
         f: vec3<f32>;                              // offset(80)  align(16) size(12)
         // -- implicit member alignment padding -- // offset(92)            size(4)
-        g: array<A, 3, 32>;                        // offset(96)  align(8)  size(96)
+        g: array<A, 3, stride=32>;                 // offset(96)  align(8)  size(96)
         h: i32;                                    // offset(192) align(4)  size(4)
         // -- implicit struct size padding --      // offset(196)           size(12)
     };
@@ -1867,8 +1903,8 @@ start of one array element to the start of the next element.
 It is determined as follows:
 * It is the value of the explicit stride parameter on the type, if specified.
     <p algorithm="array explicit element stride">
-      [=StrideOf=](array&lt;|E|,|N|,|S|&gt;) = |S|<br>
-      [=StrideOf=](dynamic_array&lt;|E|,|S|&gt;) = |S|
+      [=StrideOf=](array&lt;|E|,|N|,stride=|S|&gt;) = |S|<br>
+      [=StrideOf=](dynamic_array&lt;|E|,stride=|S|&gt;) = |S|
     </p>
 * Otherwise, it is the <dfn noexport>implicit stride</dfn>,
     equal to the size of the array's element type, rounded up to the alignment of
@@ -1886,7 +1922,7 @@ In all cases, the array element stride must be a multiple of the element alignme
     var implicit_stride: array<vec3<f32>, 8>;
 
     // Array with an explicit element stride of 32 bytes
-    var explicit_stride: array<vec3<f32>, 8, 32>;
+    var explicit_stride: array<vec3<f32>, 8, stride=32>;
   </xmp>
 </div>
 
@@ -1897,18 +1933,18 @@ alignment value.
 The array size (in bytes) is equal to the array's element stride multiplied by the number of
 elements:
 <p algorithm="array element stride">
-  [=SizeOf=](array&lt;|E|,|N|,|S|&gt;) = [=StrideOf=](array&lt;|E|,|N|,|S|&gt;) &times; |N|<br>
-  [=SizeOf=](dynamic_array&lt;|E|,|S|&gt;) = [=StrideOf=](dynamic_array&lt;|E|,|S|&gt;) &times; N<sub>dynamic</sub><br>
+  [=SizeOf=](array&lt;|E|,|N|,stride=|S|&gt;) = [=StrideOf=](array&lt;|E|,|N|,stride=|S|&gt;) &times; |N|<br>
+  [=SizeOf=](dynamic_array&lt;|E|,stride=|S|&gt;) = [=StrideOf=](dynamic_array&lt;|E|,stride=|S|&gt;) &times; N<sub>dynamic</sub><br>
 </p>
 Here N<sub>dynamic</sub> is the dynamically-determined number of elements of the given [=dynamically-sized=] array.
 
 The array alignment is equal to the element alignment:
 <p algorithm="array alignment">
-  [=AlignOf=](array<|E|,|N|,|S|>) = [=AlignOf=](|E|)<br>
-  [=AlignOf=](dynamic_array<|E|,|S|>) = [=AlignOf=](|E|)
+  [=AlignOf=](array<|E|,|N|,stride=|S|>) = [=AlignOf=](|E|)<br>
+  [=AlignOf=](dynamic_array<|E|,stride=|S|>) = [=AlignOf=](|E|)
 </p>
 
-For example, the layout for an `array<E, 3, 24>` type is equivalent to
+For example, the layout for an `array<E, 3, stride=24>` type is equivalent to
 the following structure:
 
 <div class='example wgsl global-scope' heading='Structure equivalent of a three element array with a 24-byte stride'>
@@ -2016,11 +2052,11 @@ used by storage class |C|.
       <td>[=AlignOf=](|T|)
       <td>[=AlignOf=](|T|)
   <tr algorithm="alignment of a fixed-size array">
-      <td>array&lt;|E|,|N|,|S|&gt;
+      <td>array&lt;|E|,|N|,stride=|S|&gt;
       <td>[=AlignOf=](|T|)
       <td>[=roundUp=](16, [=AlignOf=](|T|))
   <tr algorithm="alignment of a dynamically-sized array">
-      <td>dynamic_array&lt;|E|,|S|&gt;
+      <td>dynamic_array&lt;|E|,stride=|S|&gt;
       <td>[=AlignOf=](|T|)
       <td>not applicable: a dynamic_array must not appear in uniform storage.
   <tr algorithm="alignment of a structure">
@@ -2042,8 +2078,8 @@ Arrays of element type |T| must have an [=element stride=] that is a
 multiple of the [=RequiredAlignOf=](|T|, |C|) for the storage class |C|:
 
 <p algorithm="array element minimum alignment">
-    [=StrideOf=](array<|E|,|N|,|S|>) = |k| &times; [=RequiredAlignOf=](|E|, C)<br>
-    [=StrideOf=](dynamic_array<|E|,|S|>) = |k| &times; [=RequiredAlignOf=](|E|, C)<br>
+    [=StrideOf=](array<|E|,|N|,stride=|S|>) = |k| &times; [=RequiredAlignOf=](|E|, C)<br>
+    [=StrideOf=](dynamic_array<|E|,stride=|S|>) = |k| &times; [=RequiredAlignOf=](|E|, C)<br>
     Where |k| is some positive integer
 </p>
 
@@ -2055,7 +2091,7 @@ sections and then the resulting layout is validated against the
 
 The [=storage classes/uniform=] storage class also requires that:
 * Array elements are aligned to 16 byte boundaries.
-    That is, [=StrideOf=](array&lt;|E|,|N|,|S|&gt;) = 16 &times; |k|' for some positive integer |k|'.
+    That is, [=StrideOf=](array&lt;|E|,|N|,stride=|S|&gt;) = 16 &times; |k|' for some positive integer |k|'.
 * If a structure member itself has a structure type `S`, then the number of
     bytes between the start of that member and the start of any following member
     must be at least [=roundUp=](16, [=SizeOf=](S)).
@@ -3030,7 +3066,7 @@ TODO: Add texture usage validation rules.
   <xmp>
     type Arr = array<i32, 5>;
 
-    type DynArr = dynamic_array<vec4<f32>, 16>;
+    type DynArr = dynamic_array<vec4<f32>, stride=16>;
   </xmp>
 </div>
 
@@ -3682,7 +3718,7 @@ See also [[#zero-value-expr]] and [[#conversion-expr]].
         ...<br>
         |eN|: |E|,<br>
         |E| is a [=constructible=] type.
-    <td>`array<`|E|,|N|,|S|`>(`|e1|,...,|eN|`)` : array&lt;|E|,|N|,|S|&gt;
+    <td>`array<`|E|,|N|,stride=|S|`>(`|e1|,...,|eN|`)` : array&lt;|E|,|N|,|S|&gt;
     <td>Construction of an explicitly-strided array, from elements.
 </table>
 
@@ -3799,7 +3835,7 @@ Note: WGSL does not have zero expression for [=atomic types=],
     <td>Zero-valued array with implicit stride.<br>(OpConstantNull)
   <tr algorithm="array zero value with explicit stride">
     <td>|T| is a [=constructible=]
-    <td>`array<`|E|,|N|,|S|`>()`: array&lt;|E|,|N|,|S|&gt;
+    <td>`array<`|E|,|N|,stride=|S|`>()`: array&lt;|E|,|N|,|S|&gt;
     <td>Zero-valued array with explicit stride.<br>(OpConstantNull)
 </table>
 
@@ -5226,7 +5262,7 @@ A phony-assignment is useful for:
   <xmp highlight=rust>
     [[block]] struct BufferContents {
         counter: atomic<u32>;
-        data: array<vec4<f32>>;
+        data: dynamic_array<vec4<f32>>;
     };
     [[group(0),binding(0)]] var<storage> buf: BufferContents;
     [[group(0),binding(1)]] var t: texture_2d<f32>;
@@ -6882,6 +6918,11 @@ I've written what an NVIDIA GPU does.  See https://github.com/google/amber/pull/
   <dfn for=syntax>bool</dfn> :
 
     | `/bool/`
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>dynamic_array</dfn> :
+
+    | `/dynamic_array/`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>float32</dfn> :


### PR DESCRIPTION
- Update related grammar rules and examples
- Rename 'runtime-sized' array to 'dyanmically-sized'.
  Change its declaration syntax to use `dynamic_array` instead of
  `array` without an element count.
- Add examples showing array type compatibility based on stride

Editorial:
- Rearrange text in Array Types section
- More consistently use 'E' for element array type placeholder

Part of #1534

Change-Id: I09082c257fbc325e20a0e28fe16f7744e882a61e