### PR TITLE
Allow non-overriable constants in texel offsets

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7717,7 +7717,9 @@ textureSample(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, array_
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  The `offset` expression must be a `const_expression` expression (e.g. `vec2<i32>(1, 2)`).<br>
+  The `offset` expression must be either:
+    * a `const_expression` expression (e.g. `vec2<i32>(1, 2)`).<br>
+    * a name of a [[#module-constants|module-scope constant]] that is not [=pipeline-overridable=]
   Each `offset` component must be at least `-8` and at most `7`. Values outside
   of this range will result in a [=shader-creation error=].
 </table>


### PR DESCRIPTION
Spawned from #1272, very similar to #2031
More specifically, it separates the issue of const expressions from the exact use case of texel offsets.
With this in, we can give the texel offsets a name without opting into any const expression mechanics.