### PR TITLE
Fix typos in normalize(), mix(), cross()

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5831,7 +5831,7 @@ Locations must not overlap within each of the following sets:
 * An entry point's pipeline inputs,
     i.e. locations for its formal parameters, or for the members of its formal parameters of structure type.
 
-Note: Location numbering is distinct between inputs and outputs: 
+Note: Location numbering is distinct between inputs and outputs:
 Location numbers for an entry point's pipeline inputs do not conflict with location numbers for the entry point's pipeline outputs.
 
 Note: No additional rule is required to prevent location overlap within an entry point's outputs.
@@ -6371,7 +6371,7 @@ value with the same sign.
   <tr><td>`clamp(x)`<td>Correctly rounded
   <tr><td>`cos(x)`<td>Absolute error &le; 2<sup>-11</sup> inside the range of [-&pi;, &pi;]
   <tr><td>`cosh(x)`<td>Inherited from `(exp(x) - exp(-x)) * 0.5`
-  <tr><td>`cross(x, y)`<td>Inherited from `(x[i] * y[j] - x[j] * y[j])`
+  <tr><td>`cross(x, y)`<td>Inherited from `(x[i] * y[j] - x[j] * y[i])`
   <tr><td>`distance(x, y)`<td>Inherited from `length(x - y)`
   <tr><td>`exp(x)`<td>3 + 2 * |x| ULP
   <tr><td>`exp2(x)`<td>3 + 2 * |x| ULP
@@ -6387,9 +6387,9 @@ value with the same sign.
   <tr><td>`log2(x)`<td>3 ULP outside the range [0.5, 2.0].<br>Absolute error &lt; 2<sup>-21</sup> inside the range [0.5, 2.0]
   <tr><td>`max(x, y)`<td>Correctly rounded
   <tr><td>`min(x, y)`<td>Correctly rounded
-  <tr><td>`mix(x, y, z)`<td>Inherited from `x - (1.0 - z) + y * z`
+  <tr><td>`mix(x, y, z)`<td>Inherited from `x * (1.0 - z) + y * z`
   <tr><td>`modf(x)`<td>Correctly rounded
-  <tr><td>`normalize(x)`<td>Inherited from `x - length(x)`
+  <tr><td>`normalize(x)`<td>Inherited from `x / length(x)`
   <tr><td>`pow(x, y)`<td>Inherited from `exp2(y * log2(x))`
   <tr><td>`reflect(x, y)`<td>Inherited from `x - 2.0 * dot(x, y) * y`
   <tr><td>`refract(x, y, z)`<td>Inherited from `z * x - (z * dot(y, x) + sqrt(k)) * y`,<br>where `k = 1.0 - z * z * (1.0 - dot(y, x) * dot(y, x))`<br>If `k < 0.0` the result is precisely 0.0


### PR DESCRIPTION
* Typos in normalize(), mix(), cross() definition.
*  N̶o̶t̶ ̶o̶b̶v̶i̶o̶u̶s̶ ̶t̶h̶a̶t̶ ̶f̶m̶a̶ ̶u̶s̶u̶a̶l̶l̶y̶ ̶w̶i̶t̶h̶ ̶c̶o̶r̶r̶e̶c̶t̶ ̶r̶o̶u̶n̶d̶i̶n̶g̶,̶ ̶b̶e̶c̶a̶u̶s̶e̶ ̶i̶n̶h̶e̶r̶i̶t̶e̶d̶ ̶f̶r̶o̶m̶ ̶x̶ ̶*̶ ̶y̶ ̶+̶ ̶z̶ ̶s̶o̶u̶n̶d̶s̶ ̶a̶s̶ ̶R̶N̶(̶R̶N̶(̶x̶ ̶*̶ ̶y̶)̶ ̶+̶ ̶z̶)̶

Requesting review from @alan-baker