### PR TITLE
Make atomicCompareExchangeWeak return a structure

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8071,10 +8071,17 @@ Atomically stores the value `v` in the atomic object pointed to
 `atomic_ptr` and returns the original value stored in the atomic object.
 
 ```rust
-atomicCompareExchangeWeak(atomic_ptr: ptr<SC, atomic<T>, A>, cmp: T, v: T) -> vec2<T>
+atomicCompareExchangeWeak(atomic_ptr: ptr<SC, atomic<T>, A>, cmp: T, v: T) -> _atomic_compare_exchange_result<T>
+
+struct _atomic_compare_exchange_result<T> {
+  old_value : T; // old value stored in the atomic
+  exchanged : bool; // true if the exchange was done
+};
 
 // Maps to the SPIR-V instruction OpAtomicCompareExchange.
 ```
+
+Note: A value cannot be explicitly declared with the type `_atomic_compare_exchange_result`, but a value may infer the type.
 
 Performs the following steps atomically:
 


### PR DESCRIPTION
Fixes #2021

It looks a bit more advanced than the `frexp` stuff because it returns a structure that's generic over `T`.