### PR TITLE
Fix a few typos and styling issues in RenderPassDescriptor validation

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6967,7 +6967,7 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
     Given a {{GPURenderPassDescriptor}} |this| the following validation rules apply:
 
     1. |this|.{{GPURenderPassDescriptor/colorAttachments}}.length must be less than or equal to 8.
-    1. |this|.{{GPURenderPassDescriptor/colorAttachments}}.length must greater than `0` or
+    1. |this|.{{GPURenderPassDescriptor/colorAttachments}}.length must be greater than `0` or
         |this|.{{GPURenderPassDescriptor/depthStencilAttachment}} must not be `null`.
     1. For each |colorAttachment| in |this|.{{GPURenderPassDescriptor/colorAttachments}}:
 
@@ -6979,7 +6979,7 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
 
     1. Each {{GPURenderPassColorAttachment/view}} in |this|.{{GPURenderPassDescriptor/colorAttachments}}
         and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachment/view}},
-        if present, must have all have the same {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}}.
+        if present, must all have the same {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}}.
 
     1. For each {{GPURenderPassColorAttachment/view}} in |this|.{{GPURenderPassDescriptor/colorAttachments}}
         and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachment/view}},
@@ -7142,22 +7142,21 @@ dictionary GPURenderPassDepthStencilAttachment {
     Given a {{GPURenderPassDepthStencilAttachment}} |this| the following validation
     rules apply:
 
-    - |this|.{{GPURenderPassDepthStencilAttachment/view}} must have a [=depth or stencil renderable
+    1. |this|.{{GPURenderPassDepthStencilAttachment/view}} must have a [=depth or stencil renderable
         format=].
-    - |this|.{{GPURenderPassDepthStencilAttachment/view}} must be a view of a
+    1. |this|.{{GPURenderPassDepthStencilAttachment/view}} must be a view of a
         single [=texture subresource=].
-    - |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}}
+    1. |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}}
         must contain {{GPUTextureUsage/RENDER_ATTACHMENT}}.
-    - If |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}
+    1. If |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}
         contains both depth and stencil aspects (See [[#depth-formats|depth-stencil formats]]):
-        - |this|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} must be equal to |this|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}}
-    - If |this|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} is `true`:
-        - |this|.{{GPURenderPassDepthStencilAttachment/depthLoadValue}} must be {{GPULoadOp/"load"}}.
-        - |this|.{{GPURenderPassDepthStencilAttachment/depthStoreOp}} must be {{GPUStoreOp/"store"}}.
-    - If |this|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}} is `true`,
-        |this|.{{GPURenderPassDepthStencilAttachment/stencilLoadValue}} must be
-        {{GPULoadOp/"load"}} and |this|.{{GPURenderPassDepthStencilAttachment/stencilStoreOp}}
-        must be {{GPUStoreOp/"store"}}.
+        1. |this|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} must be equal to |this|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}}
+    1. If |this|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} is `true`:
+        1. |this|.{{GPURenderPassDepthStencilAttachment/depthLoadValue}} must be {{GPULoadOp/"load"}}.
+        1. |this|.{{GPURenderPassDepthStencilAttachment/depthStoreOp}} must be {{GPUStoreOp/"store"}}.
+    1. If |this|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}} is `true`:
+        1. |this|.{{GPURenderPassDepthStencilAttachment/stencilLoadValue}} must be {{GPULoadOp/"load"}}.
+        1. |this|.{{GPURenderPassDepthStencilAttachment/stencilStoreOp}} must be {{GPUStoreOp/"store"}}.
 
     Issue: Describe the remaining validation rules for this type.
 </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7152,11 +7152,9 @@ dictionary GPURenderPassDepthStencilAttachment {
         contains both depth and stencil aspects (See [[#depth-formats|depth-stencil formats]]):
         - |this|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} must be equal to |this|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}}
     - If |this|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} is `true`:
-        - |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}} must contain a depth aspect.
         - |this|.{{GPURenderPassDepthStencilAttachment/depthLoadValue}} must be {{GPULoadOp/"load"}}.
         - |this|.{{GPURenderPassDepthStencilAttachment/depthStoreOp}} must be {{GPUStoreOp/"store"}}.
     - If |this|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}} is `true`:
-        - |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}} must contain a stencil aspect.
         - |this|.{{GPURenderPassDepthStencilAttachment/stencilLoadValue}} must be {{GPULoadOp/"load"}}.
         - |this|.{{GPURenderPassDepthStencilAttachment/stencilStoreOp}} must be {{GPUStoreOp/"store"}}.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6977,9 +6977,9 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
 
         1. |this|.{{GPURenderPassDescriptor/depthStencilAttachment}} must meet the [$GPURenderPassDepthStencilAttachment/GPURenderPassDepthStencilAttachment Valid Usage$] rules.
 
-    1. Each {{GPURenderPassColorAttachment/view}} in |this|.{{GPURenderPassDescriptor/colorAttachments}}
-        and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachment/view}},
-        if present, must all have the same {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}}.
+    1. All {{GPURenderPassColorAttachment/view}}s in |this|.{{GPURenderPassDescriptor/colorAttachments}},
+        and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachment/view}}
+        if present, must have equal {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}}s.
 
     1. For each {{GPURenderPassColorAttachment/view}} in |this|.{{GPURenderPassDescriptor/colorAttachments}}
         and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachment/view}},
@@ -7152,11 +7152,11 @@ dictionary GPURenderPassDepthStencilAttachment {
         contains both depth and stencil aspects (See [[#depth-formats|depth-stencil formats]]):
         - |this|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} must be equal to |this|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}}
     - If |this|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} is `true`:
-        - |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}} must contain depth aspect.
+        - |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}} must contain a depth aspect.
         - |this|.{{GPURenderPassDepthStencilAttachment/depthLoadValue}} must be {{GPULoadOp/"load"}}.
         - |this|.{{GPURenderPassDepthStencilAttachment/depthStoreOp}} must be {{GPUStoreOp/"store"}}.
     - If |this|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}} is `true`:
-        - |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}} must contain stencil aspect.
+        - |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}} must contain a stencil aspect.
         - |this|.{{GPURenderPassDepthStencilAttachment/stencilLoadValue}} must be {{GPULoadOp/"load"}}.
         - |this|.{{GPURenderPassDepthStencilAttachment/stencilStoreOp}} must be {{GPUStoreOp/"store"}}.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7142,21 +7142,23 @@ dictionary GPURenderPassDepthStencilAttachment {
     Given a {{GPURenderPassDepthStencilAttachment}} |this| the following validation
     rules apply:
 
-    1. |this|.{{GPURenderPassDepthStencilAttachment/view}} must have a [=depth or stencil renderable
+    - |this|.{{GPURenderPassDepthStencilAttachment/view}} must have a [=depth or stencil renderable
         format=].
-    1. |this|.{{GPURenderPassDepthStencilAttachment/view}} must be a view of a
+    - |this|.{{GPURenderPassDepthStencilAttachment/view}} must be a view of a
         single [=texture subresource=].
-    1. |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}}
+    - |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}}
         must contain {{GPUTextureUsage/RENDER_ATTACHMENT}}.
-    1. If |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}
+    - If |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}
         contains both depth and stencil aspects (See [[#depth-formats|depth-stencil formats]]):
-        1. |this|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} must be equal to |this|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}}
-    1. If |this|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} is `true`:
-        1. |this|.{{GPURenderPassDepthStencilAttachment/depthLoadValue}} must be {{GPULoadOp/"load"}}.
-        1. |this|.{{GPURenderPassDepthStencilAttachment/depthStoreOp}} must be {{GPUStoreOp/"store"}}.
-    1. If |this|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}} is `true`:
-        1. |this|.{{GPURenderPassDepthStencilAttachment/stencilLoadValue}} must be {{GPULoadOp/"load"}}.
-        1. |this|.{{GPURenderPassDepthStencilAttachment/stencilStoreOp}} must be {{GPUStoreOp/"store"}}.
+        - |this|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} must be equal to |this|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}}
+    - If |this|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} is `true`:
+        - |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}} must contain depth aspect.
+        - |this|.{{GPURenderPassDepthStencilAttachment/depthLoadValue}} must be {{GPULoadOp/"load"}}.
+        - |this|.{{GPURenderPassDepthStencilAttachment/depthStoreOp}} must be {{GPUStoreOp/"store"}}.
+    - If |this|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}} is `true`:
+        - |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}} must contain stencil aspect.
+        - |this|.{{GPURenderPassDepthStencilAttachment/stencilLoadValue}} must be {{GPULoadOp/"load"}}.
+        - |this|.{{GPURenderPassDepthStencilAttachment/stencilStoreOp}} must be {{GPUStoreOp/"store"}}.
 
     Issue: Describe the remaining validation rules for this type.
 </div>


### PR DESCRIPTION
It also fixed a couple styling issues, and typos, etc.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Sep 20, 2021, 6:20 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FRichard-Yunchao%2Fgpuweb%2Fce356baee8fc93e8d91b0ed14ce59f0cb0955015%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%232121.)._
</details>
