### PR TITLE
Clarify line-ending comment

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -321,7 +321,7 @@ and to encourage interoperability among tools.
 
 <dfn>Blankspace</dfn> is any combination of one or more of the following characters:
 * space
-* tab
+* horizontal tab
 * linefeed
 * vertical tab
 * formfeed
@@ -360,7 +360,9 @@ Shader authors can use comments to document their programs.
 
 A <dfn noexport>line-ending comment</dfn> is a kind of [=comment=] consisting
 of the two characters `//` and the characters that follow,
-up until the next linefeed or the end of the program.
+up until but not including:
+* the next [=blankspace=] character other than a space or a horizontal tab, or
+* the end of the program.
 
 TODO(dneto): Incorporate block comments, per https://github.com/gpuweb/gpuweb/pull/1470
 


### PR DESCRIPTION
They end at any blankspace other than space or horizontal tab.
So, for example, a form-feed character ends a line-ending comment.

Also, clarify "tab" as "horizontal tab"