### PR TITLE
Enable Assume Explicit For

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -23,6 +23,7 @@ Abstract: Shading language for WebGPU.
 Markup Shorthands: markdown yes
 Markup Shorthands: biblio yes
 Markup Shorthands: idl no
+Assume Explicit For: yes
 </pre>
 
 <style>
@@ -1383,39 +1384,39 @@ and how to use variables with it.
   </thead>
   <tr><td><dfn noexport dfn-for="storage classes">function</dfn>
       <td>Same invocation only
-      <td>[=read_write=]
+      <td>[=access/read_write=]
       <td>[=Function scope=]
       <td>[=Constructible=] type
       <td>
   <tr><td><dfn noexport dfn-for="storage classes">private</dfn>
       <td>Same invocation only
-      <td>[=read_write=]
+      <td>[=access/read_write=]
       <td>[=Module scope=]
       <td>[=Constructible=] type
       <td>
       <td>
   <tr><td><dfn noexport dfn-for="storage classes">workgroup</dfn>
       <td>Invocations in the same [=compute shader stage|compute shader=] [=compute shader stage/workgroup=]
-      <td>[=read_write=]
+      <td>[=access/read_write=]
       <td>[=Module scope=]
       <td>[=Plain type=],
           excluding [=runtime-sized=] arrays, or [=composite=] types containing runtime-sized arrays
       <td>
   <tr><td><dfn noexport dfn-for="storage classes">uniform</dfn>
       <td>Invocations in the same [=shader stage=]
-      <td>[=read=]
+      <td>[=access/read=]
       <td>[=Module scope=]
       <td>[=Constructible=] [=host-shareable=] types
       <td>For [=uniform buffer=] variables
   <tr><td><dfn noexport dfn-for="storage classes">storage</dfn>
       <td>Invocations in the same [=shader stage=]
-      <td> [=read_write=], [=read=] (default)
+      <td> [=access/read_write=], [=access/read=] (default)
       <td>[=Module scope=]
       <td>[=Host-shareable=]
       <td>For [=storage buffer=] variables
   <tr><td><dfn noexport dfn-for="storage classes">handle</dfn>
       <td>Invocations in the same shader stage
-      <td>[=read=]
+      <td>[=access/read=]
       <td>[=Module scope=]
       <td>[=Sampler=] types or [=texture=] types
       <td>For [=sampler=] and texture variables.<br>
@@ -1572,10 +1573,10 @@ following table:
       <td>[=AlignOf=](|E|)
       <td>N<sub>runtime</sub> * [=roundUp=]([=AlignOf=](|E|), [=SizeOf=](|E|))<br><br>
           Where N<sub>runtime</sub> is the runtime-determined number of elements of |T|
-  <tr><td>[[[=stride=](|Q|)]]<br> array<|E|, |N|>
+  <tr><td>[[[=attribute/stride=](|Q|)]]<br> array<|E|, |N|>
       <td>[=AlignOf=](|E|)
       <td>|N| * |Q|
-  <tr><td>[[[=stride=](|Q|)]]<br> array<|E|>
+  <tr><td>[[[=attribute/stride=](|Q|)]]<br> array<|E|>
       <td>[=AlignOf=](|E|)
       <td>N<sub>runtime</sub> * |Q|
 </table>
@@ -1695,7 +1696,7 @@ array.
 The <dfn noexport>element stride</dfn> of an array is the number of bytes from the
 start of one array element to the start of the next element.
 It is determined as follows:
-* It is the value of an explicit [=stride=] attribute on the type, if specified.
+* It is the value of an explicit [=attribute/stride=] attribute on the type, if specified.
 * Otherwise, it is the <dfn noexport>implicit stride</dfn>,
     equal to the size of the array's element type, rounded up to the alignment of
     the element type:
@@ -1716,7 +1717,7 @@ In all cases, the array element stride must be a multiple of the element alignme
   </xmp>
 </div>
 
-Arrays decorated with the [=stride=] attribute must have a stride that is at
+Arrays decorated with the [=attribute/stride=] attribute must have a stride that is at
 least the size of the element type, and be a multiple of the element type's
 alignment value.
 
@@ -1871,7 +1872,7 @@ multiple of the [=RequiredAlignOf=](|T|, |C|) for the storage class |C|:
 </p>
 
 Note: [=RequiredAlignOf=](|T|, |C|) does not impose any additional restrictions
-on the values permitted for an [=align=] decoration, nor does it affect the rules
+on the values permitted for an [=attribute/align=] decoration, nor does it affect the rules
 of [=AlignOf=](|T|). Data is laid out with the rules defined in previous
 sections and then the resulting layout is validated against the
 [=RequiredAlignOf=](|T|, |C|) rules.
@@ -1983,7 +1984,7 @@ where |p| and |r| describe the same memory view.
 
 The access mode for a memory view is often determined by context:
 
-* The [=storage classes/storage=] storage class supports both [=read=] and [=read_write=] access modes.
+* The [=storage classes/storage=] storage class supports both [=access/read=] and [=access/read_write=] access modes.
 * Each other storage class supports only one access mode, as described in the <a href="#storage-class-table">storage class</a> table.
 
 When writing a [=variable declaration=] or a [=pointer type=] in [SHORTNAME] source:
@@ -2031,11 +2032,11 @@ References and pointers are distinguished by how they are used:
 * A [=let declaration=] can be of pointer type, but not of reference type.
 * A [=formal parameter=] can be of pointer type, but not of reference type.
 * An [=assignment statement=] performs a [=write access=] to update the contents of memory via a reference, where:
-    * The left-hand side of the assignment statement must be of reference type, with access mode [=write=] or [=read_write=].
+    * The left-hand side of the assignment statement must be of reference type, with access mode [=access/write=] or [=access/read_write=].
     * The right-hand side of the assignment statement must evaluate to the store type of the left-hand side.
 * The <dfn noexport>Load Rule</dfn>: Inside a function, a reference is automatically dereferenced (read from) to satisfy type rules:
     * In a function, when a reference expression |r| with store type |T| is used in a statement or an expression, where
-    * |r| has an access mode of [=read=] or [=read_write=], and
+    * |r| has an access mode of [=access/read=] or [=access/read_write=], and
     * The only potentially matching type rules require |r| to have a value of type |T|, then
     * That type rule requirement is considered to have been met, and
     * The result of evaluating |r| in that context is the value (of type |T|) stored in the memory locations
@@ -3134,7 +3135,7 @@ and the name denotes the value of that expression.
   </xmp>
 </div>
 
-When the declaration uses the [=override=] attribute,
+When the declaration uses the [=attribute/override=] attribute,
 the constant is <dfn noexport>pipeline-overridable</dfn>. In this case:
 
   * The type must be one of the [=scalar=] types.
@@ -4988,11 +4989,11 @@ next statement until the end of the loop body.
 The declaration is executed each time it is reached, so each new iteration
 creates a new instance of the variable or constant, and re-initializes it.
 
-This repetition can be interrupted by a [=break=], [=return=], or
+This repetition can be interrupted by a [=statement/break=], [=statement/return=], or
 [=statement/discard=] statement.
 
 Optionally, the last statement in the loop body may be a
-[=continuing=] statement.
+[=statement/continuing=] statement.
 
 Note: The loop statement is one of the biggest differences from other shader
 languages.
@@ -5087,11 +5088,11 @@ for_header
 </pre>
 
 The <dfn dfn-for="statement">for</dfn> statement takes the form
-`for(initializer; condition; continuing_part) { body }` and is syntactic sugar on top of a [=loop=] statement with the same `body`.
+`for(initializer; condition; continuing_part) { body }` and is syntactic sugar on top of a [=statement/loop=] statement with the same `body`.
 Additionally:
 * If `initializer` is non-empty, it is executed inside an additional scope before the first [=iteration=].
 * If `condition` is non-empty, it is checked at the beginning of the loop body and if unsatisfied then a [[#break-statement]] is executed.
-* If `continuing_part` is non-empty, it becomes a [=continuing=] statement at the end of the loop body.
+* If `continuing_part` is non-empty, it becomes a [=statement/continuing=] statement at the end of the loop body.
 
 The `initializer` of a for loop is executed once prior to executing the loop.
 When a [=declaration=] appears in the initializer, its [=identifier=] is [=in scope=] until the end of the `body`.
@@ -5149,11 +5150,11 @@ break_statement
 </pre>
 
 A <dfn noexport dfn-for="statement">break</dfn> statement transfers control to the first statement
-after the body of the nearest-enclosing [=loop=]
-or [=switch=] statement.
-A `break` statement must only be used within [=loop=], [=for=], and [=switch=] statements.
+after the body of the nearest-enclosing [=statement/loop=]
+or [=statement/switch=] statement.
+A `break` statement must only be used within [=statement/loop=], [=statement/for=], and [=statement/switch=] statements.
 
-When a `break` statement is placed such that it would exit from a loop's [=continuing=] statement,
+When a `break` statement is placed such that it would exit from a loop's [=statement/continuing=] statement,
 then:
 
 * The `break` statement must appear as either:
@@ -5230,18 +5231,18 @@ continue_statement
   : CONTINUE
 </pre>
 
-A <dfn noexport dfn-for="statement">continue</dfn> statement transfers control in the nearest-enclosing [=loop=]:
+A <dfn noexport dfn-for="statement">continue</dfn> statement transfers control in the nearest-enclosing [=statement/loop=]:
 
-*  forward to the [=continuing=] statement at the end of the body of that loop, if it exists.
+*  forward to the [=statement/continuing=] statement at the end of the body of that loop, if it exists.
 *  otherwise backward to the first statement in the loop body, starting the next [=iteration=].
 
-A `continue` statement must only be used in a [=loop=] or [=for=] statement.
+A `continue` statement must only be used in a [=statement/loop=] or [=statement/for=] statement.
 A `continue` statement must not be placed such that it would transfer
-control to an enclosing [=continuing=] statement.
+control to an enclosing [=statement/continuing=] statement.
 (It is a *forward* branch when branching to a `continuing` statement.)
 
 A `continue` statement must not be placed such that it would transfer
-control past a declaration used in the targeted [=continuing=] statement.
+control past a declaration used in the targeted [=statement/continuing=] statement.
 
 <div class='example wgsl function-scope expect-error' heading="Invalid continue bypasses declaration">
   <xmp>
@@ -5270,7 +5271,7 @@ continuing_statement
 A <dfn dfn-for="statement">continuing</dfn> statement specifies a [=compound statement=] to be executed at the end of a loop [=iteration=].
 The construct is optional.
 
-The compound statement must not contain a [=return=] or [=statement/discard=] statement, at any compound statement nesting level.
+The compound statement must not contain a [=statement/return=] or [=statement/discard=] statement, at any compound statement nesting level.
 
 ### Return Statement ### {#return-statement}
 
@@ -5285,7 +5286,7 @@ is terminated.
 Otherwise, evaluation continues with the next expression or statement after
 the evaluation of the [=call site=] of the current function invocation.
 
-If the function doesn't have a [=return type=], then the [=return=] statement is
+If the function doesn't have a [=return type=], then the [=statement/return=] statement is
 optional. If the return statement is provided for such a function, it must not
 supply a value.
 Otherwise the expression must be present, and is called the *return value*.
@@ -5419,7 +5420,7 @@ Two formal parameters for a given function must not have the same name.
 
 If the return type is specified, then:
 * The return type must be [=constructible=].
-* The last statement in the function body must be a [=return=] statement.
+* The last statement in the function body must be a [=statement/return=] statement.
 
 <pre class='def'>
 function_decl
@@ -5491,7 +5492,7 @@ When a function call is executed the following steps occur:
     the value of the first argument at the [=call site=].
 * Control is transferred to the first statement in the called function.
 * The called function is executed.
-* When the called function returns, by either executing a [=return=] statement or reaching
+* When the called function returns, by either executing a [=statement/return=] statement or reaching
     the end of the called function (if the function does not return a value),
     control is transferred back the calling function, and the called function's execution is
     unsuspended.
@@ -5942,7 +5943,7 @@ The <dfn noexport>resource interface of a shader</dfn> is the set of module-scop
 resource variables [=statically accessed=] by
 [=functions in a shader stage|functions in the shader stage=].
 
-Each resource variable must be declared with both [=group=] and [=binding=]
+Each resource variable must be declared with both [=attribute/group=] and [=attribute/binding=]
 attributes.
 Together with the shader's stage, these identify the binding address
 of the resource on the shader's pipeline.
@@ -6174,7 +6175,7 @@ with integer coordinates *(i,j,k)* with:
 *  0 &leq; k &lt; workgroup_size_z
 
 where *(workgroup_size_x, workgroup_size_y, workgroup_size_z)* is
-the value specified for the [=workgroup_size=] attribute of the
+the value specified for the [=attribute/workgroup_size=] attribute of the
 entry point.
 
 There is exactly one invocation in a workgroup for each point in the workgroup grid.


### PR DESCRIPTION
This bikeshed key makes it possible to refer to definitions easily while having different namespaces containing the same names inside them. The main WebGPU spec also enables this. There were a few problematic/inconsistent references to definitions in the spec; PR also aims to fix them.