### PR TITLE
Сlarify rounding

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6292,7 +6292,7 @@ the following exceptions:
         of NaNs and infinities.
 * Implementations may ignore the sign of a zero.
     That is, a zero with a positive sign may behave like a zero a with a negative sign, and vice versa.
-* No rounding mode is specified.
+* Rounding mode is round-to-nearest even, but implementation may truncate results to zero.
 * Implementations may flush denormalized value on the input and/or output of
     any operation listed in [[#floating-point-accuracy]].
     * Other operations are required to preserve denormalized numbers.
@@ -6309,9 +6309,6 @@ The <dfn>correctly rounded</dfn> result of the operation for floating point type
     * the largest value in |T| less than |x|.
 
 </div>
-
-That is, the result may be rounded up or down:
-[SHORTNAME] does not specify a rounding mode.
 
 Note: Floating point types include positive and negative infinity, so
 the correctly rounded result may be finite or infinite.
@@ -6419,8 +6416,9 @@ However, the result may not be the same when computed in floating point.
 The reassociated result may be inaccurate due to approximation, or may trigger
 an overflow or NaN when computing intermediate results.
 
-An implementation may reassociate and/or fuse operations if the optimization is
-at least as accurate as the original formulation.
+<dfn noexport>Fusing</dfn> occur when two floating-point operation performed in one step.
+
+* `a * b + c` is calculated with one or sequence of two correctly rounded operations.
 
 ### Floating point conversion ### {#floating-point-conversion}
 
@@ -6462,8 +6460,6 @@ the set of fractional bits together with an extra 1-bit at the most significant 
 Then, for example, integers 2<sup>28</sup> and 1+2<sup>28</sup> both map to the same floating point value: the difference in the
 least significant 1 bit is not representable by the floating point format.
 This kind of collision occurs for pairs of adjacent integers with a magnitude of at least 2<sup>25</sup>.
-
-Issue: (dneto) Default rounding mode is an implementation choice.  Is that what we want?
 
 Issue: Check behaviour of the f32 to f16 conversion for numbers just beyond the max normal f16 values.
 I've written what an NVIDIA GPU does.  See https://github.com/google/amber/pull/918 for an executable test case.


### PR DESCRIPTION
* Solving inlined into spec issue (currently UB)
```
Issue 9. Default rounding mode is an implementation choice. Is that what we want?
```

* Making WGSL more clear about a*b+c expression in GLSL way (Paragraph 4.7.1 Range and precision)