### PR TITLE
Remove no-op minBindingSize text

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3804,13 +3804,11 @@ A {{GPUBindGroup}} object has the following internal slots:
                                             - |resource|.{{GPUBufferBinding/buffer}} is [$valid to use with$] |this|.
                                             - The bound part designated by |resource|.{{GPUBufferBinding/offset}} and
                                                 |resource|.{{GPUBufferBinding/size}} resides inside the buffer.
-                                            - If |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}}
-                                                is not `undefined`:
-                                                - The effective binding size, that is either explict in
-                                                    |resource|.{{GPUBufferBinding/size}} or derived from
-                                                    |resource|.{{GPUBufferBinding/offset}} and the full
-                                                    size of the buffer, is greater than or equal to
-                                                    |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}}.
+                                            - The effective binding size, that is either explict in
+                                                |resource|.{{GPUBufferBinding/size}} or derived from
+                                                |resource|.{{GPUBufferBinding/offset}} and the full
+                                                size of the buffer, is greater than or equal to
+                                                |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}}.
 
                                             - If |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/type}} is
                                                 <dl class="switch">


### PR DESCRIPTION
minBindingSize is never undefined (it defaults to 0), so this "if"
wasn't doing anything.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2141.html" title="Last updated on Sep 24, 2021, 11:47 PM UTC (3071215)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2141/086c770...kainino0x:3071215.html" title="Last updated on Sep 24, 2021, 11:47 PM UTC (3071215)">Diff</a>