### PR TITLE
Allow syntactic navigation and styling

### DIFF
--- a/wgsl/extract-grammar.py
+++ b/wgsl/extract-grammar.py
@@ -45,278 +45,50 @@ def scanner_escape_regex(regex):
     return re.escape(regex.strip()).strip().replace("/", "\\/").replace("\\_", "_").replace("\\%", "%").replace("\\;", ";").replace("\\<", "<").replace("\\>", ">").replace("\\=", "=").replace("\\,", ",").replace("\\:", ":").replace("\\!", "!")
 
 
-class scanner_constituent:
+class scanner_rule:
     @staticmethod
     def name():
-        return "constituent"
+        return "rule"
 
     @staticmethod
     def begin(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        return ("<pre class='def'>" in line, None, 1)
+        line = lines[i].rstrip()
+        return (line.startswith("<div class='syntactic-rule"), None, 1)
 
     @staticmethod
     def end(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        return ("</pre>" in line, 0)
+        line = lines[i].rstrip()
+        return (line.startswith("</div> <!-- syntactic-rule"), 0)
 
     @staticmethod
     def record(lines, i):
-        line = lines[i].split("//")[0].rstrip()
+        line = lines[i].rstrip()
         return (True, 0)
 
     @staticmethod
     def skip(lines, i):
-        line = lines[i].split("//")[0].rstrip()
+        line = lines[i].rstrip()
         return (False, 0)
 
     @staticmethod
     def valid(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        result = len(line.strip()) > 0
-        if not result:
-            return result
-        result = result and line[0] != "`"
-        result = result and not line.startswith("TODO")
-        if line[0] == " ":
-            result = result and (line.lstrip()[0] in [":", "|"] or
-                                 (line.startswith("     ") and
-                                  line[5] != " " and
-                                  lines[i-1].rstrip().endswith("SEMICOLON")))
-        else:
-            if len(lines) > i+1:
-                result = result and scanner_constituent.valid(lines, i+1)
-            else:
-                result = False
-        return result
+        line = lines[i].rstrip()
+        return len(line.strip()) > 0
 
     @staticmethod
     def parse(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        if line[0] != " ":
-            # Append new key
-            return (scanner_escape_name(line.strip()), None, 0)
-        else:
-            if line.lstrip()[0] in [":", "|"]:
-                # Append new value
-                return (None, scanner_escape_name(
-                    line.strip()[1:].strip())
-                    .replace("(", " ( ")
-                    .replace(")", " ) ")
-                    .replace("*", " * ")
-                    .replace("+", " + ")
-                    .replace("?", " ? ")
-                    .replace("|", " | ")
-                    .replace(" ", "  "), 0)
-            else:
-                # Extend last value
-                return (None, " " + scanner_escape_name(line.strip())
-                        .replace("(", " ( ")
-                        .replace(")", " ) ")
-                        .replace("*", " * ")
-                        .replace("+", " + ")
-                        .replace("?", " ? ")
-                        .replace("|", " | ")
-                        .replace(" ", "  "), -1)
-
-
-class scanner_literal:
-    @staticmethod
-    def name():
-        return "literal"
-
-    @staticmethod
-    def begin(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        return ("## Literals" in line, None, 1)
-
-    @staticmethod
-    def end(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        return ("</table>" in line, 0)
-
-    @staticmethod
-    def record(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        return ("</thead>" in line, 1)
-
-    @staticmethod
-    def skip(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        return (False, 0)
-
-    @staticmethod
-    def valid(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        result = len(line.strip()) > 0
-        result = result and "Token<td>Definition" not in line
-        return result
-
-    @staticmethod
-    def parse(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        split = line.split("<td>")
-        return (scanner_escape_name(split[1]), "/" + split[2].replace("`", "") + "/", 0)
-
-
-class scanner_identifier:
-    @staticmethod
-    def name():
-        return "identifier"
-
-    @staticmethod
-    def begin(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        return ("## Identifiers" in line, None, 1)
-
-    @staticmethod
-    def end(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        return ("</table>" in line, 0)
-
-    @staticmethod
-    def record(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        return ("</thead>" in line, 1)
-
-    @staticmethod
-    def skip(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        return (False, 0)
-
-    @staticmethod
-    def valid(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        result = len(line.strip()) > 0
-        result = result and "Token<td>Definition" not in line
-        return result
-
-    @staticmethod
-    def parse(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        split = line.split("<td>")
-        return (scanner_escape_name(split[1]), "/" + split[2].replace("`", "") + "/", 0)
-
-
-class scanner_keyword:
-    @staticmethod
-    def name():
-        return "keyword"
-
-    @staticmethod
-    def begin(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        return ("## Keyword Summary" in line, None, 1)
-
-    @staticmethod
-    def end(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        return (False, 0)  # TODO Recognize end of keywords
-
-    @staticmethod
-    def record(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        return ("<table class='data'>" in line, 1)
-
-    @staticmethod
-    def skip(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        return ("</table>" in line, 0)
-
-    @staticmethod
-    def valid(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        result = len(line.strip()) > 0
-        result = result and "Token<td>Definition" not in line
-        result = result and len(line.split("<td>")) > 2
-        return result
-
-    @staticmethod
-    def parse(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        split = line.split("<td>")
-        return (scanner_escape_name(split[1]), "/" + scanner_escape_regex(split[2].replace("`", "")) + "/", 0)
-
-
-class scanner_reserved:
-    @staticmethod
-    def name():
-        return "reserved"
-
-    @staticmethod
-    def begin(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        return ("## Reserved Words" in line, None, 1)
-
-    @staticmethod
-    def end(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        return ("</table>" in line, 0)
-
-    @staticmethod
-    def record(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        return ("<table class='data'>" in line, 1)
-
-    @staticmethod
-    def skip(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        return (False, 0)
-
-    @staticmethod
-    def valid(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        result = len(line.strip()) > 0
-        result = result and "Token<td>Definition" not in line
-        result = result and not line.strip().startswith("<tr>")
-        result = result and len(line.split("<td>")) > 1
-        return result
-
-    @staticmethod
-    def parse(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        split = line.split("<td>")
-        return ("_reserved", "/" + scanner_escape_regex(split[1].replace("`", "")) + "/", 0)
-
-
-class scanner_token:
-    @staticmethod
-    def name():
-        return "token"
-
-    @staticmethod
-    def begin(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        return ("## Syntactic Tokens" in line, None, 1)
-
-    @staticmethod
-    def end(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        return ("</table>" in line, 0)
-
-    @staticmethod
-    def record(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        return ("<table class='data'>" in line, 1)
-
-    @staticmethod
-    def skip(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        return (False, 0)
-
-    @staticmethod
-    def valid(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        result = len(line.strip()) > 0
-        result = result and "Token<td>Definition" not in line
-        result = result and len(line.split("<td>")) > 2
-        return result
-
-    @staticmethod
-    def parse(lines, i):
-        line = lines[i].split("//")[0].rstrip()
-        split = line.split("<td>")
-        return (scanner_escape_name(split[1]), "/" + scanner_escape_regex(split[2].replace("`", "")) + "/", 0)
+        line = lines[i].rstrip()
+        if line[2:].startswith("<dfn dfn for=syntactic_rule>"):
+            rule_name = line[2:].split("<dfn dfn for=syntactic_rule>")[1]
+            rule_name = rule_name.split("</dfn>")[0].strip()
+            return (rule_name, None, 0)
+        elif line[4:].startswith("| "):
+            rule_value = line[6:]
+            return (None, rule_value.split(" "), 0)
+        elif line[4:].startswith("  "):
+            rule_value = line[6:]
+            return (None, rule_value.split(" "), -1)
+        return (None, None, None)
 
 
 class scanner_example:  # Not an example of a scanner, scanner of examples from specification
@@ -359,18 +131,11 @@ class scanner_example:  # Not an example of a scanner, scanner of examples from 
         return (None, line, 0)
 
 
-scanner_spans = [scanner_constituent,
-                 scanner_literal,
-                 scanner_identifier,
-                 scanner_keyword,
-                 scanner_reserved,
-                 scanner_token,
+scanner_spans = [scanner_rule,
                  scanner_example]
 
 
 scanner_components = {i.name(): {} for i in scanner_spans}
-scanner_components["comment"] = {"_comment": ["/\\/\\// /.*/"]}
-scanner_components["space"] = {"_space": ["/\\s/"]}
 
 scanner_i = 0
 scanner_span = None
@@ -480,199 +245,172 @@ module.exports = grammar({
 grammar_source += "\n"
 
 
-grammar_constituents_optional = {key for key, value in scanner_components[scanner_constituent.name(
-)].items() if "" in value or value[0].rstrip().endswith("*")}
-
-
-def grammar_sequence_from_element(element):
-    sequence = ""
-    subsequences = element.split()
-    sequence_i = 0
-    sequence_type = "seq"
-    while sequence_i < len(subsequences):
-        if "(" in subsequences[sequence_i]:
-            subelements = [subsequences[sequence_i].replace("(", "")]
-            sequence_i += 1
-            subexpressions = 1
-            while subexpressions > 0:
-                if "(" in subsequences[sequence_i]:
-                    subexpressions += 1
-                if ")" in subsequences[sequence_i]:
-                    subexpressions -= 1
-                subelements.append(subsequences[sequence_i])
-                sequence_i += 1
-            sequence_i -= 1
-            subelements = [i for i in subelements if len(i.strip()) > 0]
-            if sequence_i + 1 < len(subsequences):
-                if subsequences[sequence_i + 1] == "*":
-                    subsequence = grammar_sequence_from_element(
-                        " ".join(subelements))
-                    sequence += "optional(repeat("
-                    if subsequence[1] == "choice":
-                        sequence += "choice("
-                    elif subsequence[1] == "seq":
-                        sequence += "seq("
-                    sequence += subsequence[0]
-                    if subsequence[1] == "choice":
-                        sequence += "),"
-                    elif subsequence[1] == "seq":
-                        sequence += "),"
-                    sequence += ")),"
-                    sequence_i += 1
-                elif subsequences[sequence_i + 1] == "+":
-                    subsequence = grammar_sequence_from_element(
-                        " ".join(subelements))
-                    sequence += "repeat1("
-                    if subsequence[1] == "choice":
-                        sequence += "choice("
-                    elif subsequence[1] == "seq":
-                        sequence += "seq("
-                    sequence += subsequence[0]
-                    if subsequence[1] == "choice":
-                        sequence += "),"
-                    elif subsequence[1] == "seq":
-                        sequence += "),"
-                    sequence += "),"
-                    sequence_i += 1
-                elif subsequences[sequence_i + 1] == "?":
-                    subsequence = grammar_sequence_from_element(
-                        " ".join(subelements))
-                    sequence += "optional("
-                    if subsequence[1] == "choice":
-                        sequence += "choice("
-                    elif subsequence[1] == "seq":
-                        sequence += "seq("
-                    sequence += subsequence[0]
-                    if subsequence[1] == "choice":
-                        sequence += "),"
-                    elif subsequence[1] == "seq":
-                        sequence += "),"
-                    sequence += "),"
-                    sequence_i += 1
-                else:
-                    subsequence = grammar_sequence_from_element(
-                        " ".join(subelements))
-                    if subsequence[1] == "choice":
-                        sequence += "choice("
-                    elif subsequence[1] == "seq":
-                        sequence += "seq("
-                    sequence += subsequence[0]
-                    if subsequence[1] == "choice":
-                        sequence += "),"
-                    elif subsequence[1] == "seq":
-                        sequence += "),"
-            else:
-                subsequence = grammar_sequence_from_element(
-                    " ".join(subelements))
-                if subsequence[1] == "choice":
-                    sequence += "choice("
-                elif subsequence[1] == "seq":
-                    sequence += "seq("
-                sequence += subsequence[0]
-                if subsequence[1] == "choice":
-                    sequence += "),"
-                elif subsequence[1] == "seq":
-                    sequence += "),"
+def grammar_from_rule_item(rule_item):
+    result = ""
+    item_choice = False
+    items = []
+    i = 0
+    while i < len(rule_item):
+        i_optional = False
+        i_repeatone = False
+        i_skip = 0
+        i_item = ""
+        if rule_item[i].startswith("[=syntactic_rule/"):
+            i_item = rule_item[i].split("[=syntactic_rule/")[1].split("=]")[0]
+            if i_item.endswith("s") and i_item[:-1] in scanner_components[scanner_rule.name()]:
+                i_item = i_item[:-1]
+                i_repeatone = True
+            elif i_item.endswith("es") and i_item[:-2] in scanner_components[scanner_rule.name()]:
+                i_item = i_item[:-2]
+                i_repeatone = True
+            i_item = f"$.{i_item}"
+        elif rule_item[i].startswith("`/"):
+            i_item = f"token({rule_item[i][1:-1]})"
+        elif rule_item[i].startswith("`'"):
+            i_item = f"token({rule_item[i][1:-1]})"
+        elif rule_item[i] == "(":
+            j = i + 1
+            j_span = 0
+            rule_subitem = []
+            while j < len(rule_item):
+                if rule_item[j] == "(":
+                    j_span += 1
+                elif rule_item[j] == ")":
+                    j_span -= 1
+                rule_subitem.append(rule_item[j])
+                j += 1
+                if rule_item[j] == ")" and j_span == 0:
+                    break
+            i_item = grammar_from_rule_item(rule_subitem)
+            i = j
+        if len(rule_item) - i > 1:
+            if rule_item[i + 1] == "+":
+                i_repeatone = True
+                i_skip += 1
+            elif rule_item[i + 1] == "?":
+                i_optional = True
+                i_skip += 1
+            elif rule_item[i + 1] == "*":
+                i_repeatone = True
+                i_optional = True
+                i_skip += 1
+            elif rule_item[i + 1] == "|":
+                item_choice = True
+                i_skip += 1
+        if i_repeatone:
+            i_item = f"repeat1({i_item})"
+        if i_optional:
+            i_item = f"optional({i_item})"
+        items.append(i_item)
+        i += 1 + i_skip
+    if item_choice == True:
+        result = f"choice({', '.join(items)})"
+    else:
+        if len(items) == 1:
+            result = items[0]
         else:
-            if "|" in subsequences[sequence_i]:
-                sequence_type = "choice"
-            else:
-                enforce_optional = subsequences[sequence_i] in grammar_constituents_optional
-                if enforce_optional:
-                    sequence += "optional("
-                if sequence_i + 1 < len(subsequences):
-                    if subsequences[sequence_i + 1] == "*":
-                        sequence += "optional(repeat("
-                        sequence += "$." + subsequences[sequence_i] + ","
-                        sequence += ")),"
-                        sequence_i += 1
-                    elif subsequences[sequence_i + 1] == "+":
-                        sequence += "repeat1("
-                        sequence += "$." + subsequences[sequence_i] + ","
-                        sequence += "),"
-                        sequence_i += 1
-                    elif subsequences[sequence_i + 1] == "?":
-                        sequence += "optional("
-                        sequence += "$." + subsequences[sequence_i] + ","
-                        sequence += "),"
-                        sequence_i += 1
-                    else:
-                        if len(subsequences[sequence_i].strip()) > 0 and ")" not in subsequences[sequence_i]:
-                            sequence += "$." + subsequences[sequence_i] + ","
-                else:
-                    if len(subsequences[sequence_i].strip()) > 0 and ")" not in subsequences[sequence_i]:
-                        sequence += "$." + subsequences[sequence_i] + ","
-                if enforce_optional:
-                    sequence += "),"
-        sequence_i += 1
-    sequence += ""
-    return (sequence, sequence_type)
+            result = f"seq({', '.join(items)})"
+    return result
 
 
-def grammar_from_constituent(key, value):
-    return "        {}: $ => choice(\n            {}\n        ),".format(key, ",\n            ".join(["seq(" + grammar_sequence_from_element(element)[0] + ")" for element in value if len(element.strip()) > 0]))
+def grammar_from_rule(key, value):
+    result = f"        {key}: $ =>"
+    if len(value) == 1:
+        result += f" {grammar_from_rule_item(value[0])}"
+    else:
+        result += " choice(\n            {}\n        )".format(
+            ',\n            '.join([grammar_from_rule_item(i) for i in value]))
+    return result
 
 
-grammar_source += grammar_from_constituent(
-    "translation_unit", scanner_components[scanner_constituent.name()]["translation_unit"]) + "\n"
-del scanner_components[scanner_constituent.name()]["translation_unit"]
+# Following sections are to allow out-of-order per syntactic grammar appearance of rules
 
 
-grammar_source += grammar_from_constituent("global_decl_or_directive",
-                                           scanner_components[scanner_constituent.name()]["global_decl_or_directive"]) + "\n\n"
-del scanner_components[scanner_constituent.name()]["global_decl_or_directive"]
+rule_skip = set()
 
 
-def grammar_from_literal(key, value):
-    return "        {}: $ => token({}),".format(key, value)
+# Extract translation_unit
 
 
-grammar_source += "\n".join([grammar_from_literal(key, value[0])
-                            for key, value in scanner_components[scanner_literal.name()].items()]) + "\n\n"
+grammar_source += grammar_from_rule(
+    "translation_unit", scanner_components[scanner_rule.name()]["translation_unit"]) + ",\n"
+rule_skip.add("translation_unit")
 
 
-grammar_source += "\n".join([grammar_from_constituent(key, value)
-                             for key, value in scanner_components[scanner_constituent.name()].items()]) + "\n\n"
+# Extract global_decl_or_directive
 
 
-grammar_source += "\n".join([grammar_from_literal(key, value[0])
-                            for key, value in scanner_components[scanner_keyword.name()].items()]) + "\n\n"
+grammar_source += grammar_from_rule(
+    "global_decl_or_directive", scanner_components[scanner_rule.name()]["global_decl_or_directive"]) + ",\n"
+rule_skip.add("global_decl_or_directive")
 
 
-grammar_source += "\n".join([grammar_from_literal(key, value[0])
-                            for key, value in scanner_components[scanner_token.name()].items()]) + "\n\n"
+# Extract literals
 
 
-def grammar_from_reserved(key, value):
-    return "        {}: $ => choice(\n            {}\n        ),".format(key, ",\n            ".join(value))
+for key, value in scanner_components[scanner_rule.name()].items():
+    if key.endswith("_literal") and key not in rule_skip:
+        grammar_source += grammar_from_rule(key, value) + ",\n"
+        rule_skip.add(key)
 
 
-grammar_source += "\n".join([grammar_from_reserved(key, value)
-                            for key, value in scanner_components[scanner_reserved.name()].items()]) + "\n\n"
+# Extract constituents
 
 
-def grammar_from_identifier(key, value):
-    return "        ident: $ => token({}),".format(",".join(value))
+def not_token_only(value):
+    result = False
+    for i in value:
+        result = result or len(
+            [j for j in i if not j.startswith("`/") and not j.startswith("`'")]) > 0
+    return result
 
 
-grammar_source += "\n".join([grammar_from_identifier(key, value)
-                            for key, value in scanner_components[scanner_identifier.name()].items()]) + "\n\n"
+for key, value in scanner_components[scanner_rule.name()].items():
+    if not key.startswith("_") and key != "ident" and not_token_only(value) and key not in rule_skip:
+        grammar_source += grammar_from_rule(key, value) + ",\n"
+        rule_skip.add(key)
 
 
-def grammar_from_comment(key, value):
-    return "        _comment: $ => seq({}),".format(",".join(value[0].split()))
+# Extract tokens
 
 
-grammar_source += "\n".join([grammar_from_comment(key, value)
-                            for key, value in scanner_components["comment"].items()]) + "\n"
+for key, value in scanner_components[scanner_rule.name()].items():
+    if not key.startswith("_") and key != "ident" and key not in rule_skip:
+        grammar_source += grammar_from_rule(key, value) + ",\n"
+        rule_skip.add(key)
 
 
-def grammar_from_space(key, value):
-    return "        _space: $ => {},".format(",".join(value))
+# Extract underscore
 
 
-grammar_source += "\n".join([grammar_from_space(key, value)
-                            for key, value in scanner_components["space"].items()])
+for key, value in scanner_components[scanner_rule.name()].items():
+    if key.startswith("_") and key != "_comment" and key != "_space" and key not in rule_skip:
+        grammar_source += grammar_from_rule(key, value) + ",\n"
+        rule_skip.add(key)
+
+
+# Extract ident
+
+
+grammar_source += grammar_from_rule(
+    "ident", scanner_components[scanner_rule.name()]["ident"]) + ",\n"
+rule_skip.add("ident")
+
+
+# Extract comment
+
+
+grammar_source += grammar_from_rule(
+    "_comment", scanner_components[scanner_rule.name()]["_comment"]) + ",\n"
+rule_skip.add("_comment")
+
+
+# Extract space
+
+
+grammar_source += grammar_from_rule(
+    "_space", scanner_components[scanner_rule.name()]["_space"])
+rule_skip.add("_space")
 
 
 grammar_source += "\n"

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -40,6 +40,29 @@ thead {
 .small {
   font-size: smaller;
 }
+div.syntactic-rule {
+  margin-block-start: 1em;
+  margin-block-end: 1em;
+  margin-inline-start: 2em;
+  margin-inline-end: 0em;
+}
+div.syntactic-rule > p {
+  margin-block-start: 0em;
+  margin-block-end: 0em;
+  margin-inline-start: 1em;
+  margin-inline-end: 0em;
+}
+div.syntactic-rule > p::first-letter {
+  letter-spacing: 0.5em;
+}
+div.syntactic-rule > p > a {
+  margin-inline-start: 0.1em;
+  margin-inline-end: 0.1em;
+}
+div.syntactic-rule > p > code {
+  margin-inline-start: 0.1em;
+  margin-inline-end: 0.1em;
+}
 </style>
 
 <pre class=biblio>
@@ -328,6 +351,12 @@ and to encourage interoperability among tools.
 * formfeed
 * carriage return
 
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>_space</dfn> :
+
+    | `/\s/`
+</div> <!-- syntactic-rule -->
+
 Issue: What else should be blankspace? Anything in the Unicode Separator category?
 
 To parse a [SHORTNAME] program:
@@ -344,10 +373,11 @@ To parse a [SHORTNAME] program:
 3. Discard the blankspace, leaving only tokens.
 3. Parse the token sequence, attempting to match the `translation_unit` grammar rule.
 
-<pre class='def'>
-translation_unit
-  : global_decl_or_directive*
-</pre>
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>translation_unit</dfn> :
+
+    | [=syntactic_rule/global_decl_or_directives=] ?
+</div> <!-- syntactic-rule -->
 
 A [=shader-creation error=] results if:
 * the entire source text cannot be converted into a finite sequence of valid tokens, or
@@ -364,6 +394,12 @@ of the two characters `//` and the characters that follow,
 up until but not including:
 * the next [=blankspace=] character other than a space or a horizontal tab, or
 * the end of the program.
+
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>_comment</dfn> :
+
+    | `/\/\//` `/.*/`
+</div> <!-- syntactic-rule -->
 
 TODO(dneto): Incorporate block comments, per https://github.com/gpuweb/gpuweb/pull/1470
 
@@ -383,15 +419,26 @@ A <dfn>literal</dfn> is one of:
 * a <dfn noexport>boolean literal</dfn>: either `true` or `false`.
 
 The form of a [=numeric literal=] is defined via pattern-matching:
-<table class='data'>
-  <thead>
-    <tr><th>Numeric literal<th>Textual pattern
-  </thead>
-  <tr><td>`DECIMAL_FLOAT_LITERAL`<td>`(-?[0-9]*\.[0-9]+|-?[0-9]+\.[0-9]*)((e|E)(\+|-)?[0-9]+)?`
-  <tr><td>`HEX_FLOAT_LITERAL`<td>`-?0x([0-9a-fA-F]*\.?[0-9a-fA-F]+|[0-9a-fA-F]+\.[0-9a-fA-F]*)(p|P)(\+|-)?[0-9]+`
-  <tr><td>`INT_LITERAL`<td>`-?0x[0-9a-fA-F]+|0|-?[1-9][0-9]*`
-  <tr><td>`UINT_LITERAL`<td>`0x[0-9a-fA-F]+u|0u|[1-9][0-9]*u`
-</table>
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>decimal_float_literal</dfn> :
+
+    | `/(-?[0-9]*\.[0-9]+|-?[0-9]+\.[0-9]*)((e|E)(\+|-)?[0-9]+)?/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>hex_float_literal</dfn> :
+
+    | `/-?0x([0-9a-fA-F]*\.?[0-9a-fA-F]+|[0-9a-fA-F]+\.[0-9a-fA-F]*)(p|P)(\+|-)?[0-9]+/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>int_literal</dfn> :
+
+    | `/-?0x[0-9a-fA-F]+|0|-?[1-9][0-9]*/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>uint_literal</dfn> :
+
+    | `/0x[0-9a-fA-F]+u|0u|[1-9][0-9]*u/`
+</div> <!-- syntactic-rule -->
 
 Note: literals are parsed greedily. This means that for statements like `a -5`
       this will *not* parse as `a` `minus` `5` but instead as `a` `-5` which
@@ -400,20 +447,27 @@ Note: literals are parsed greedily. This means that for statements like `a -5`
 
 TODO(dneto): Describe how numeric literal tokens map to idealized values, and then to typed values.
 
-<pre class='def'>
-const_literal
-  : INT_LITERAL
-  | UINT_LITERAL
-  | FLOAT_LITERAL
-  | TRUE
-  | FALSE
-</pre>
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>const_literal</dfn> :
 
-<pre class='def'>
-FLOAT_LITERAL
-  : DECIMAL_FLOAT_LITERAL
-  | HEX_FLOAT_LITERAL
-</pre>
+    | [=syntactic_rule/int_literal=]
+
+    | [=syntactic_rule/uint_literal=]
+
+    | [=syntactic_rule/float_literal=]
+
+    | [=syntactic_rule/true=]
+
+    | [=syntactic_rule/false=]
+</div> <!-- syntactic-rule -->
+
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>float_literal</dfn> :
+
+    | [=syntactic_rule/decimal_float_literal=]
+
+    | [=syntactic_rule/hex_float_literal=]
+</div> <!-- syntactic-rule -->
 
 
 ## Keywords ## {#keywords}
@@ -429,12 +483,11 @@ See [[#declaration-and-scope]] and [[#directives]].
 The form of an identifier is defined via pattern-matching, except that
 an identifier must not have the same spelling as a [=keyword=] or as a [=reserved word=].
 
-<table class='data'>
-  <thead>
-    <tr><th>Token<th>Textual pattern
-  </thead>
-  <tr><td>`IDENT`<td>`[a-zA-Z][0-9a-zA-Z_]*`
-</table>
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>ident</dfn> :
+
+    | `/[a-zA-Z][0-9a-zA-Z_]*/`
+</div> <!-- syntactic-rule -->
 
 ## Attributes ## {#attributes}
 
@@ -446,20 +499,29 @@ ignored for the purposes of type and semantic checking.
 
 An attribute must not be specified more than once per object or type.
 
-<pre class='def'>
-attribute_list
-  : ATTR_LEFT (attribute COMMA)* attribute ATTR_RIGHT
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>attribute_list</dfn> :
 
-attribute
-  : IDENT PAREN_LEFT (literal_or_ident COMMA)* literal_or_ident PAREN_RIGHT
-  | IDENT
+    | [=syntactic_rule/attr_left=] ( [=syntactic_rule/attribute=] [=syntactic_rule/comma=] ) * [=syntactic_rule/attribute=] [=syntactic_rule/attr_right=]
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>attribute</dfn> :
 
-literal_or_ident
-  : FLOAT_LITERAL
-  | INT_LITERAL
-  | UINT_LITERAL
-  | IDENT
-</pre>
+    | [=syntactic_rule/ident=] [=syntactic_rule/paren_left=] ( [=syntactic_rule/literal_or_ident=] [=syntactic_rule/comma=] ) * [=syntactic_rule/literal_or_ident=] [=syntactic_rule/paren_right=]
+
+    | [=syntactic_rule/ident=]
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>literal_or_ident</dfn> :
+
+    | [=syntactic_rule/float_literal=]
+
+    | [=syntactic_rule/int_literal=]
+
+    | [=syntactic_rule/uint_literal=]
+
+    | [=syntactic_rule/ident=]
+</div> <!-- syntactic-rule -->
 
 <table class='data'>
   <caption>Attributes defined in [SHORTNAME]</caption>
@@ -1088,15 +1150,20 @@ Restrictions on runtime-sized arrays:
     a store type in any other cases.
 * An expression must not evaluate to a runtime-sized array type.
 
-<pre class='def'>
-array_type_decl
-  | attribute_list* ARRAY LESS_THAN type_decl (COMMA element_count_expression)? GREATER_THAN
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>array_type_decl</dfn> :
 
-element_count_expression
-  : INT_LITERAL
-  | UINT_LITERAL
-  | IDENT
-</pre>
+    | [=syntactic_rule/attribute_lists=] ? [=syntactic_rule/array=] [=syntactic_rule/less_than=] [=syntactic_rule/type_decl=] ( [=syntactic_rule/comma=] [=syntactic_rule/element_count_expression=] ) ? [=syntactic_rule/greater_than=]
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>element_count_expression</dfn> :
+
+    | [=syntactic_rule/int_literal=]
+
+    | [=syntactic_rule/uint_literal=]
+
+    | [=syntactic_rule/ident=]
+</div> <!-- syntactic-rule -->
 
 ### Structure Types ### {#struct-types}
 
@@ -1140,18 +1207,21 @@ Similarly, the same limitations apply to textures and samplers.
   </xmp>
 </div>
 
-<pre class='def'>
-struct_decl
-  : attribute_list* STRUCT IDENT struct_body_decl
-</pre>
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>struct_decl</dfn> :
 
-<pre class='def'>
-struct_body_decl
-  : BRACE_LEFT struct_member* BRACE_RIGHT
+    | [=syntactic_rule/attribute_lists=] ? [=syntactic_rule/struct=] [=syntactic_rule/ident=] [=syntactic_rule/struct_body_decl=]
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>struct_body_decl</dfn> :
 
-struct_member
-  : attribute_list* variable_ident_decl SEMICOLON
-</pre>
+    | [=syntactic_rule/brace_left=] [=syntactic_rule/struct_members=] ? [=syntactic_rule/brace_right=]
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>struct_member</dfn> :
+
+    | [=syntactic_rule/attribute_lists=] ? [=syntactic_rule/variable_ident_decl=] [=syntactic_rule/semicolon=]
+</div> <!-- syntactic-rule -->
 
 [SHORTNAME] defines the following attributes that can be applied to structure types:
  * [=attribute/block=]
@@ -1286,12 +1356,15 @@ as the memory's <dfn noexport>access mode</dfn>:
 : <dfn noexport dfn-for="access">read_write</dfn>
 :: Supports both read and write accesses.
 
-<pre class='def'>
-access_mode
-  : READ
-  | WRITE
-  | READ_WRITE
-</pre>
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>access_mode</dfn> :
+
+    | [=syntactic_rule/read=]
+
+    | [=syntactic_rule/write=]
+
+    | [=syntactic_rule/read_write=]
+</div> <!-- syntactic-rule -->
 
 ### Storable Types ### {#storable-types}
 
@@ -1430,14 +1503,19 @@ The handle itself is always read-only.
 In most cases the underlying texels are read-only.
 For a write-only storage texture, the underlying texels are write-only.
 
-<pre class='def'>
-storage_class
-  | FUNCTION
-  | PRIVATE
-  | WORKGROUP
-  | UNIFORM
-  | STORAGE
-</pre>
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>storage_class</dfn> :
+
+    | [=syntactic_rule/function=]
+
+    | [=syntactic_rule/private=]
+
+    | [=syntactic_rule/workgroup=]
+
+    | [=syntactic_rule/uniform=]
+
+    | [=syntactic_rule/storage=]
+</div> <!-- syntactic-rule -->
 
 <table class='data'>
   <thead>
@@ -2704,122 +2782,151 @@ sampler_comparison
 ### Texture Types Grammar ### {#texture-types-grammar}
 TODO: Add texture usage validation rules.
 
-<pre class='def'>
-texture_sampler_types
-  : sampler_type
-  | depth_texture_type
-  | sampled_texture_type LESS_THAN type_decl GREATER_THAN
-  | multisampled_texture_type LESS_THAN type_decl GREATER_THAN
-  | storage_texture_type LESS_THAN texel_format COMMA access_mode GREATER_THAN
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>texture_sampler_types</dfn> :
 
-sampler_type
-  : SAMPLER
-  | SAMPLER_COMPARISON
+    | [=syntactic_rule/sampler_type=]
 
-sampled_texture_type
-  : TEXTURE_1D
-  | TEXTURE_2D
-  | TEXTURE_2D_ARRAY
-  | TEXTURE_3D
-  | TEXTURE_CUBE
-  | TEXTURE_CUBE_ARRAY
+    | [=syntactic_rule/depth_texture_type=]
 
-multisampled_texture_type
-  : TEXTURE_MULTISAMPLED_2D
+    | [=syntactic_rule/sampled_texture_type=] [=syntactic_rule/less_than=] [=syntactic_rule/type_decl=] [=syntactic_rule/greater_than=]
 
-storage_texture_type
-  : TEXTURE_STORAGE_1D
-  | TEXTURE_STORAGE_2D
-  | TEXTURE_STORAGE_2D_ARRAY
-  | TEXTURE_STORAGE_3D
+    | [=syntactic_rule/multisampled_texture_type=] [=syntactic_rule/less_than=] [=syntactic_rule/type_decl=] [=syntactic_rule/greater_than=]
 
-depth_texture_type
-  : TEXTURE_DEPTH_2D
-  | TEXTURE_DEPTH_2D_ARRAY
-  | TEXTURE_DEPTH_CUBE
-  | TEXTURE_DEPTH_CUBE_ARRAY
-  | TEXTURE_DEPTH_MULTISAMPLED_2D
+    | [=syntactic_rule/storage_texture_type=] [=syntactic_rule/less_than=] [=syntactic_rule/texel_format=] [=syntactic_rule/comma=] [=syntactic_rule/access_mode=] [=syntactic_rule/greater_than=]
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>sampler_type</dfn> :
 
-texel_format
-  : R8UNORM
-     R8  -- Capability: StorageImageExtendedFormats
-  | R8SNORM
-     R8Snorm  -- Capability: StorageImageExtendedFormats
-  | R8UINT
-     R8ui  -- Capability: StorageImageExtendedFormats
-  | R8SINT
-     R8i  -- Capability: StorageImageExtendedFormats
-  | R16UINT
-     R16ui  -- Capability: StorageImageExtendedFormats
-  | R16SINT
-     R16i  -- Capability: StorageImageExtendedFormats
-  | R16FLOAT
-     R16f  -- Capability: StorageImageExtendedFormats
-  | RG8UNORM
-     Rg8  -- Capability: StorageImageExtendedFormats
-  | RG8SNORM
-     Rg8Snorm  -- Capability: StorageImageExtendedFormats
-  | RG8UINT
-     Rg8ui  -- Capability: StorageImageExtendedFormats
-  | RG8SINT
-     Rg8i  -- Capability: StorageImageExtendedFormats
-  | R32UINT
-     R32ui
-  | R32SINT
-     R32i
-  | R32FLOAT
-     R32f
-  | RG16UINT
-     Rg16ui  -- Capability: StorageImageExtendedFormats
-  | RG16SINT
-     Rg16i  -- Capability: StorageImageExtendedFormats
-  | RG16FLOAT
-     Rg16f  -- Capability: StorageImageExtendedFormats
-  | RGBA8UNORM
-     Rgba8
-  | RGBA8UNORM-SRGB
-     ???
-  | RGBA8SNORM
-     Rgba8Snorm
-  | RGBA8UINT
-     Rgba8ui
-  | RGBA8SINT
-     Rgba8i
-  | BGRA8UNORM
-     Rgba8  ???
-  | BGRA8UNORM-SRGB
-     ???
-  | RGB10A2UNORM
-     Rgb10A2  -- Capability: StorageImageExtendedFormats
-  | RG11B10FLOAT
-     R11fG11fB10f  -- Capability: StorageImageExtendedFormats
-  | RG32UINT
-     Rg32ui  -- Capability: StorageImageExtendedFormats
-  | RG32SINT
-     Rg32i  -- Capability: StorageImageExtendedFormats
-  | RG32FLOAT
-     Rg32f  -- Capability: StorageImageExtendedFormats
-  | RGBA16UINT
-     Rgba16ui
-  | RGBA16SINT
-     Rgba16i
-  | RGBA16FLOAT
-     Rgba16f
-  | RGBA32UINT
-     Rgba32ui
-  | RGBA32SINT
-     Rgba32i
-  | RGBA32FLOAT
-     Rgba32f
+    | [=syntactic_rule/sampler=]
 
-</pre>
+    | [=syntactic_rule/sampler_comparison=]
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>sampled_texture_type</dfn> :
+
+    | [=syntactic_rule/texture_1d=]
+
+    | [=syntactic_rule/texture_2d=]
+
+    | [=syntactic_rule/texture_2d_array=]
+
+    | [=syntactic_rule/texture_3d=]
+
+    | [=syntactic_rule/texture_cube=]
+
+    | [=syntactic_rule/texture_cube_array=]
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>multisampled_texture_type</dfn> :
+
+    | [=syntactic_rule/texture_multisampled_2d=]
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>storage_texture_type</dfn> :
+
+    | [=syntactic_rule/texture_storage_1d=]
+
+    | [=syntactic_rule/texture_storage_2d=]
+
+    | [=syntactic_rule/texture_storage_2d_array=]
+
+    | [=syntactic_rule/texture_storage_3d=]
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>depth_texture_type</dfn> :
+
+    | [=syntactic_rule/texture_depth_2d=]
+
+    | [=syntactic_rule/texture_depth_2d_array=]
+
+    | [=syntactic_rule/texture_depth_cube=]
+
+    | [=syntactic_rule/texture_depth_cube_array=]
+
+    | [=syntactic_rule/texture_depth_multisampled_2d=]
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>texel_format</dfn> :
+
+    | [=syntactic_rule/r8unorm=]
+
+    | [=syntactic_rule/r8snorm=]
+
+    | [=syntactic_rule/r8uint=]
+
+    | [=syntactic_rule/r8sint=]
+
+    | [=syntactic_rule/r16uint=]
+
+    | [=syntactic_rule/r16sint=]
+
+    | [=syntactic_rule/r16float=]
+
+    | [=syntactic_rule/rg8unorm=]
+
+    | [=syntactic_rule/rg8snorm=]
+
+    | [=syntactic_rule/rg8uint=]
+
+    | [=syntactic_rule/rg8sint=]
+
+    | [=syntactic_rule/r32uint=]
+
+    | [=syntactic_rule/r32sint=]
+
+    | [=syntactic_rule/r32float=]
+
+    | [=syntactic_rule/rg16uint=]
+
+    | [=syntactic_rule/rg16sint=]
+
+    | [=syntactic_rule/rg16float=]
+
+    | [=syntactic_rule/rgba8unorm=]
+
+    | [=syntactic_rule/rgba8unorm_srgb=]
+
+    | [=syntactic_rule/rgba8snorm=]
+
+    | [=syntactic_rule/rgba8uint=]
+
+    | [=syntactic_rule/rgba8sint=]
+
+    | [=syntactic_rule/bgra8unorm=]
+
+    | [=syntactic_rule/bgra8unorm_srgb=]
+
+    | [=syntactic_rule/rgb10a2unorm=]
+
+    | [=syntactic_rule/rg11b10float=]
+
+    | [=syntactic_rule/rg32uint=]
+
+    | [=syntactic_rule/rg32sint=]
+
+    | [=syntactic_rule/rg32float=]
+
+    | [=syntactic_rule/rgba16uint=]
+
+    | [=syntactic_rule/rgba16sint=]
+
+    | [=syntactic_rule/rgba16float=]
+
+    | [=syntactic_rule/rgba32uint=]
+
+    | [=syntactic_rule/rgba32sint=]
+
+    | [=syntactic_rule/rgba32float=]
+</div> <!-- syntactic-rule -->
 
 ## Type Aliases TODO ## {#type-aliases}
 
-<pre class='def'>
-type_alias
-  : TYPE IDENT EQUAL type_decl
-</pre>
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>type_alias</dfn> :
+
+    | [=syntactic_rule/type=] [=syntactic_rule/ident=] [=syntactic_rule/equal=] [=syntactic_rule/type_decl=]
+</div> <!-- syntactic-rule -->
 
 <div class='example wgsl global-scope' heading='Type Alias'>
   <xmp>
@@ -2831,30 +2938,51 @@ type_alias
 
 ## Type Declaration Grammar ## {#type-declarations}
 
-<pre class='def'>
-type_decl
-  : IDENT
-  | BOOL
-  | FLOAT32
-  | INT32
-  | UINT32
-  | VEC2 LESS_THAN type_decl GREATER_THAN
-  | VEC3 LESS_THAN type_decl GREATER_THAN
-  | VEC4 LESS_THAN type_decl GREATER_THAN
-  | POINTER LESS_THAN storage_class COMMA type_decl (COMMA access_mode)? GREATER_THAN
-  | array_type_decl
-  | MAT2x2 LESS_THAN type_decl GREATER_THAN
-  | MAT2x3 LESS_THAN type_decl GREATER_THAN
-  | MAT2x4 LESS_THAN type_decl GREATER_THAN
-  | MAT3x2 LESS_THAN type_decl GREATER_THAN
-  | MAT3x3 LESS_THAN type_decl GREATER_THAN
-  | MAT3x4 LESS_THAN type_decl GREATER_THAN
-  | MAT4x2 LESS_THAN type_decl GREATER_THAN
-  | MAT4x3 LESS_THAN type_decl GREATER_THAN
-  | MAT4x4 LESS_THAN type_decl GREATER_THAN
-  | ATOMIC LESS_THAN type_decl GREATER_THAN
-  | texture_sampler_types
-</pre>
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>type_decl</dfn> :
+
+    | [=syntactic_rule/ident=]
+
+    | [=syntactic_rule/bool=]
+
+    | [=syntactic_rule/float32=]
+
+    | [=syntactic_rule/int32=]
+
+    | [=syntactic_rule/uint32=]
+
+    | [=syntactic_rule/vec2=] [=syntactic_rule/less_than=] [=syntactic_rule/type_decl=] [=syntactic_rule/greater_than=]
+
+    | [=syntactic_rule/vec3=] [=syntactic_rule/less_than=] [=syntactic_rule/type_decl=] [=syntactic_rule/greater_than=]
+
+    | [=syntactic_rule/vec4=] [=syntactic_rule/less_than=] [=syntactic_rule/type_decl=] [=syntactic_rule/greater_than=]
+
+    | [=syntactic_rule/pointer=] [=syntactic_rule/less_than=] [=syntactic_rule/storage_class=] [=syntactic_rule/comma=] [=syntactic_rule/type_decl=] ( [=syntactic_rule/comma=] [=syntactic_rule/access_mode=] ) ? [=syntactic_rule/greater_than=]
+
+    | [=syntactic_rule/array_type_decl=]
+
+    | [=syntactic_rule/mat2x2=] [=syntactic_rule/less_than=] [=syntactic_rule/type_decl=] [=syntactic_rule/greater_than=]
+
+    | [=syntactic_rule/mat2x3=] [=syntactic_rule/less_than=] [=syntactic_rule/type_decl=] [=syntactic_rule/greater_than=]
+
+    | [=syntactic_rule/mat2x4=] [=syntactic_rule/less_than=] [=syntactic_rule/type_decl=] [=syntactic_rule/greater_than=]
+
+    | [=syntactic_rule/mat3x2=] [=syntactic_rule/less_than=] [=syntactic_rule/type_decl=] [=syntactic_rule/greater_than=]
+
+    | [=syntactic_rule/mat3x3=] [=syntactic_rule/less_than=] [=syntactic_rule/type_decl=] [=syntactic_rule/greater_than=]
+
+    | [=syntactic_rule/mat3x4=] [=syntactic_rule/less_than=] [=syntactic_rule/type_decl=] [=syntactic_rule/greater_than=]
+
+    | [=syntactic_rule/mat4x2=] [=syntactic_rule/less_than=] [=syntactic_rule/type_decl=] [=syntactic_rule/greater_than=]
+
+    | [=syntactic_rule/mat4x3=] [=syntactic_rule/less_than=] [=syntactic_rule/type_decl=] [=syntactic_rule/greater_than=]
+
+    | [=syntactic_rule/mat4x4=] [=syntactic_rule/less_than=] [=syntactic_rule/type_decl=] [=syntactic_rule/greater_than=]
+
+    | [=syntactic_rule/atomic=] [=syntactic_rule/less_than=] [=syntactic_rule/type_decl=] [=syntactic_rule/greater_than=]
+
+    | [=syntactic_rule/texture_sampler_types=]
+</div> <!-- syntactic-rule -->
 
 When the type declaration is an [=identifier=], then the expression must be in scope of a
 [=declaration=] of the identifier as a type alias or structure type.
@@ -2968,21 +3096,30 @@ and when the storage class decoration is required, optional, or forbidden.
 The access mode always has a default, and except for variables in the [=storage classes/storage=] storage class,
 must not be written. See [[#access-mode-defaults]].
 
-<pre class='def'>
-variable_statement
-  : variable_decl
-  | variable_decl EQUAL short_circuit_or_expression
-  | LET (IDENT | variable_ident_decl) EQUAL short_circuit_or_expression
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>variable_statement</dfn> :
 
-variable_decl
-  : VAR variable_qualifier? (IDENT | variable_ident_decl)
+    | [=syntactic_rule/variable_decl=]
 
-variable_ident_decl
-  : IDENT COLON attribute_list* type_decl
+    | [=syntactic_rule/variable_decl=] [=syntactic_rule/equal=] [=syntactic_rule/short_circuit_or_expression=]
 
-variable_qualifier
-  : LESS_THAN storage_class ( COMMA access_mode )? GREATER_THAN
-</pre>
+    | [=syntactic_rule/let=] ( [=syntactic_rule/ident=] | [=syntactic_rule/variable_ident_decl=] ) [=syntactic_rule/equal=] [=syntactic_rule/short_circuit_or_expression=]
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>variable_decl</dfn> :
+
+    | [=syntactic_rule/var=] [=syntactic_rule/variable_qualifier=] ? ( [=syntactic_rule/ident=] | [=syntactic_rule/variable_ident_decl=] )
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>variable_ident_decl</dfn> :
+
+    | [=syntactic_rule/ident=] [=syntactic_rule/colon=] [=syntactic_rule/attribute_lists=] ? [=syntactic_rule/type_decl=]
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>variable_qualifier</dfn> :
+
+    | [=syntactic_rule/less_than=] [=syntactic_rule/storage_class=] ( [=syntactic_rule/comma=] [=syntactic_rule/access_mode=] ) ? [=syntactic_rule/greater_than=]
+</div> <!-- syntactic-rule -->
 
 The <dfn noexport>lifetime</dfn> of a variable is the period during shader
 execution for which the variable exists.
@@ -3096,10 +3233,11 @@ Such variables are declared with [=attribute/group=] and [=attribute/binding=] d
   </xmp>
 </div>
 
-<pre class='def'>
-global_variable_decl
-  : attribute_list* variable_decl (EQUAL const_expression)?
-</pre>
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>global_variable_decl</dfn> :
+
+    | [=syntactic_rule/attribute_lists=] ? [=syntactic_rule/variable_decl=] ( [=syntactic_rule/equal=] [=syntactic_rule/const_expression=] ) ?
+</div> <!-- syntactic-rule -->
 
 <div class='example' heading="Variable Decorations">
   <xmp>
@@ -3173,17 +3311,23 @@ program.
 This is true regardless of the value of the constant, whether that value
 is the one from the constant's declaration or from a pipeline override.
 
-<pre class='def'>
-global_constant_decl
-  : attribute_list* LET (IDENT | variable_ident_decl) global_const_initializer?
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>global_constant_decl</dfn> :
 
-global_const_initializer
-  : EQUAL const_expression
+    | [=syntactic_rule/attribute_lists=] ? [=syntactic_rule/let=] ( [=syntactic_rule/ident=] | [=syntactic_rule/variable_ident_decl=] ) [=syntactic_rule/global_const_initializer=] ?
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>global_const_initializer</dfn> :
 
-const_expression
-  : type_decl PAREN_LEFT ((const_expression COMMA)* const_expression COMMA?)? PAREN_RIGHT
-  | const_literal
-</pre>
+    | [=syntactic_rule/equal=] [=syntactic_rule/const_expression=]
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>const_expression</dfn> :
+
+    | [=syntactic_rule/type_decl=] [=syntactic_rule/paren_left=] ( ( [=syntactic_rule/const_expression=] [=syntactic_rule/comma=] ) * [=syntactic_rule/const_expression=] [=syntactic_rule/comma=] ? ) ? [=syntactic_rule/paren_right=]
+
+    | [=syntactic_rule/const_literal=]
+</div> <!-- syntactic-rule -->
 
 <div class='example' heading='Constants'>
   <xmp>
@@ -4691,120 +4835,142 @@ The <dfn noexport>indirection</dfn> operator converts a pointer to its correspon
 
 ## Expression Grammar Summary ## {#expression-grammar}
 
-<pre class='def'>
-primary_expression
-  : IDENT argument_expression_list?
-  | type_decl argument_expression_list
-  | const_literal
-  | paren_expression
-  | BITCAST LESS_THAN type_decl GREATER_THAN paren_expression
-      OpBitcast
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>primary_expression</dfn> :
 
-paren_expression
-  : PAREN_LEFT short_circuit_or_expression PAREN_RIGHT
+    | [=syntactic_rule/ident=] [=syntactic_rule/argument_expression_list=] ?
 
-argument_expression_list
-  : PAREN_LEFT ((short_circuit_or_expression COMMA)* short_circuit_or_expression COMMA?)? PAREN_RIGHT
+    | [=syntactic_rule/type_decl=] [=syntactic_rule/argument_expression_list=]
 
-postfix_expression
-  :
-  | BRACKET_LEFT short_circuit_or_expression BRACKET_RIGHT postfix_expression
-  | PERIOD IDENT postfix_expression
+    | [=syntactic_rule/const_literal=]
 
-unary_expression
-  : singular_expression
-  | MINUS unary_expression
-      OpSNegate
-      OpFNegate
-  | BANG unary_expression
-      OpLogicalNot
-  | TILDE unary_expression
-      OpNot
-  | STAR unary_expression
-  | AND unary_expression
+    | [=syntactic_rule/paren_expression=]
 
-singular_expression
-  : primary_expression postfix_expression
+    | [=syntactic_rule/bitcast=] [=syntactic_rule/less_than=] [=syntactic_rule/type_decl=] [=syntactic_rule/greater_than=] [=syntactic_rule/paren_expression=]
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>paren_expression</dfn> :
 
-multiplicative_expression
-  : unary_expression
-  | multiplicative_expression STAR unary_expression
-      OpVectorTimesScalar
-      OpMatrixTimesScalar
-      OpVectorTimesMatrix
-      OpMatrixTimesVector
-      OpMatrixTimesMatrix
-      OpIMul
-      OpFMul
-  | multiplicative_expression FORWARD_SLASH unary_expression
-      OpUDiv
-      OpSDiv
-      OpFDiv
-  | multiplicative_expression MODULO unary_expression
-      OpUMOd
-      OpSMod
-      OpFRem
+    | [=syntactic_rule/paren_left=] [=syntactic_rule/short_circuit_or_expression=] [=syntactic_rule/paren_right=]
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>argument_expression_list</dfn> :
 
-additive_expression
-  : multiplicative_expression
-  | additive_expression PLUS multiplicative_expression
-      OpIAdd
-      OpFAdd
-  | additive_expression MINUS multiplicative_expression
-      OpFSub
-      OpISub
+    | [=syntactic_rule/paren_left=] ( ( [=syntactic_rule/short_circuit_or_expression=] [=syntactic_rule/comma=] ) * [=syntactic_rule/short_circuit_or_expression=] [=syntactic_rule/comma=] ? ) ? [=syntactic_rule/paren_right=]
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>postfix_expression</dfn> :
 
-shift_expression
-  : additive_expression
-  | shift_expression SHIFT_LEFT additive_expression
-        OpShiftLeftLogical
-  | shift_expression SHIFT_RIGHT additive_expression
-        OpShiftRightLogical or OpShiftRightArithmetic
+    | [=syntactic_rule/bracket_left=] [=syntactic_rule/short_circuit_or_expression=] [=syntactic_rule/bracket_right=] [=syntactic_rule/postfix_expression=] ?
 
-relational_expression
-  : shift_expression
-  | relational_expression LESS_THAN shift_expression
-        OpULessThan
-        OpFOrdLessThan
-  | relational_expression GREATER_THAN shift_expression
-        OpUGreaterThan
-        OpFOrdGreaterThan
-  | relational_expression LESS_THAN_EQUAL shift_expression
-        OpULessThanEqual
-        OpFOrdLessThanEqual
-  | relational_expression GREATER_THAN_EQUAL shift_expression
-        OpUGreaterThanEqual
-        OpFOrdGreaterThanEqual
+    | [=syntactic_rule/period=] [=syntactic_rule/ident=] [=syntactic_rule/postfix_expression=] ?
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>unary_expression</dfn> :
 
-equality_expression
-  : relational_expression
-  | relational_expression EQUAL_EQUAL relational_expression
-        OpIEqual
-        OpFOrdEqual
-  | relational_expression NOT_EQUAL relational_expression
-        OpINotEqual
-        OpFOrdNotEqual
+    | [=syntactic_rule/singular_expression=]
 
-and_expression
-  : equality_expression
-  | and_expression AND equality_expression
+    | [=syntactic_rule/minus=] [=syntactic_rule/unary_expression=]
 
-exclusive_or_expression
-  : and_expression
-  | exclusive_or_expression XOR and_expression
+    | [=syntactic_rule/bang=] [=syntactic_rule/unary_expression=]
 
-inclusive_or_expression
-  : exclusive_or_expression
-  | inclusive_or_expression OR exclusive_or_expression
+    | [=syntactic_rule/tilde=] [=syntactic_rule/unary_expression=]
 
-short_circuit_and_expression
-  : inclusive_or_expression
-  | short_circuit_and_expression AND_AND inclusive_or_expression
+    | [=syntactic_rule/star=] [=syntactic_rule/unary_expression=]
 
-short_circuit_or_expression
-  : short_circuit_and_expression
-  | short_circuit_or_expression OR_OR short_circuit_and_expression
-</pre>
+    | [=syntactic_rule/and=] [=syntactic_rule/unary_expression=]
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>singular_expression</dfn> :
+
+    | [=syntactic_rule/primary_expression=] [=syntactic_rule/postfix_expression=] ?
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>multiplicative_expression</dfn> :
+
+    | [=syntactic_rule/unary_expression=]
+
+    | [=syntactic_rule/multiplicative_expression=] [=syntactic_rule/star=] [=syntactic_rule/unary_expression=]
+
+    | [=syntactic_rule/multiplicative_expression=] [=syntactic_rule/forward_slash=] [=syntactic_rule/unary_expression=]
+
+    | [=syntactic_rule/multiplicative_expression=] [=syntactic_rule/modulo=] [=syntactic_rule/unary_expression=]
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>additive_expression</dfn> :
+
+    | [=syntactic_rule/multiplicative_expression=]
+
+    | [=syntactic_rule/additive_expression=] [=syntactic_rule/plus=] [=syntactic_rule/multiplicative_expression=]
+
+    | [=syntactic_rule/additive_expression=] [=syntactic_rule/minus=] [=syntactic_rule/multiplicative_expression=]
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>shift_expression</dfn> :
+
+    | [=syntactic_rule/additive_expression=]
+
+    | [=syntactic_rule/shift_expression=] [=syntactic_rule/shift_left=] [=syntactic_rule/additive_expression=]
+
+    | [=syntactic_rule/shift_expression=] [=syntactic_rule/shift_right=] [=syntactic_rule/additive_expression=]
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>relational_expression</dfn> :
+
+    | [=syntactic_rule/shift_expression=]
+
+    | [=syntactic_rule/relational_expression=] [=syntactic_rule/less_than=] [=syntactic_rule/shift_expression=]
+
+    | [=syntactic_rule/relational_expression=] [=syntactic_rule/greater_than=] [=syntactic_rule/shift_expression=]
+
+    | [=syntactic_rule/relational_expression=] [=syntactic_rule/less_than_equal=] [=syntactic_rule/shift_expression=]
+
+    | [=syntactic_rule/relational_expression=] [=syntactic_rule/greater_than_equal=] [=syntactic_rule/shift_expression=]
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>equality_expression</dfn> :
+
+    | [=syntactic_rule/relational_expression=]
+
+    | [=syntactic_rule/relational_expression=] [=syntactic_rule/equal_equal=] [=syntactic_rule/relational_expression=]
+
+    | [=syntactic_rule/relational_expression=] [=syntactic_rule/not_equal=] [=syntactic_rule/relational_expression=]
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>and_expression</dfn> :
+
+    | [=syntactic_rule/equality_expression=]
+
+    | [=syntactic_rule/and_expression=] [=syntactic_rule/and=] [=syntactic_rule/equality_expression=]
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>exclusive_or_expression</dfn> :
+
+    | [=syntactic_rule/and_expression=]
+
+    | [=syntactic_rule/exclusive_or_expression=] [=syntactic_rule/xor=] [=syntactic_rule/and_expression=]
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>inclusive_or_expression</dfn> :
+
+    | [=syntactic_rule/exclusive_or_expression=]
+
+    | [=syntactic_rule/inclusive_or_expression=] [=syntactic_rule/or=] [=syntactic_rule/exclusive_or_expression=]
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>short_circuit_and_expression</dfn> :
+
+    | [=syntactic_rule/inclusive_or_expression=]
+
+    | [=syntactic_rule/short_circuit_and_expression=] [=syntactic_rule/and_and=] [=syntactic_rule/inclusive_or_expression=]
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>short_circuit_or_expression</dfn> :
+
+    | [=syntactic_rule/short_circuit_and_expression=]
+
+    | [=syntactic_rule/short_circuit_or_expression=] [=syntactic_rule/or_or=] [=syntactic_rule/short_circuit_and_expression=]
+</div> <!-- syntactic-rule -->
 
 
 # Statements TODO # {#statements}
@@ -4815,10 +4981,11 @@ A <dfn>compound statement</dfn> is a brace-enclosed sequence of zero or more sta
 When a [=declaration=] is one of those statements, its [=identifier=] is [=in scope=]
 from the start of the next statement until the end of the compound statement.
 
-<pre class='def'>
-compound_statement
-  : BRACE_LEFT statements? BRACE_RIGHT
-</pre>
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>compound_statement</dfn> :
+
+    | [=syntactic_rule/brace_left=] [=syntactic_rule/statements=] ? [=syntactic_rule/brace_right=]
+</div> <!-- syntactic-rule -->
 
 ## Assignment Statement ## {#assignment}
 
@@ -4881,13 +5048,11 @@ name of a variable.  See [[#forming-references-and-pointers]] for other cases.
       </xmp>
     </div>
 
-<pre class='def'>
-assignment_statement
-  : unary_expression EQUAL short_circuit_or_expression
-      If unary_expression is a variable, this maps to OpStore to the variable.
-      Otherwise, unary expression is a pointer expression in an Assigning (L-value) context
-      which maps to OpAccessChain followed by OpStore
-</pre>
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>assignment_statement</dfn> :
+
+    | [=syntactic_rule/unary_expression=] [=syntactic_rule/equal=] [=syntactic_rule/short_circuit_or_expression=]
+</div> <!-- syntactic-rule -->
 
 ## Control flow TODO ## {#control-flow}
 
@@ -4895,16 +5060,21 @@ assignment_statement
 
 ### If Statement ### {#if-statement}
 
-<pre class='def'>
-if_statement
-  : IF paren_expression compound_statement elseif_statement? else_statement?
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>if_statement</dfn> :
 
-elseif_statement
-  : ELSE_IF paren_expression compound_statement elseif_statement?
+    | [=syntactic_rule/if=] [=syntactic_rule/paren_expression=] [=syntactic_rule/compound_statement=] [=syntactic_rule/elseif_statement=] ? [=syntactic_rule/else_statement=] ?
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>elseif_statement</dfn> :
 
-else_statement
-  : ELSE compound_statement
-</pre>
+    | [=syntactic_rule/else_if=] [=syntactic_rule/paren_expression=] [=syntactic_rule/compound_statement=] [=syntactic_rule/elseif_statement=] ?
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>else_statement</dfn> :
+
+    | [=syntactic_rule/else=] [=syntactic_rule/compound_statement=]
+</div> <!-- syntactic-rule -->
 
 An <dfn noexport dfn-for="statement">if</dfn> statement conditionally executes at most one [=compound statement=] based on
 the evaluation of the condition expressions.
@@ -4925,22 +5095,30 @@ An `if` statement is executed as follows:
 
 ### Switch Statement ### {#switch-statement}
 
-<pre class='def'>
-switch_statement
-  : SWITCH paren_expression BRACE_LEFT switch_body+ BRACE_RIGHT
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>switch_statement</dfn> :
 
-switch_body
-  : CASE case_selectors COLON BRACE_LEFT case_body BRACE_RIGHT
-  | DEFAULT COLON BRACE_LEFT case_body BRACE_RIGHT
+    | [=syntactic_rule/switch=] [=syntactic_rule/paren_expression=] [=syntactic_rule/brace_left=] [=syntactic_rule/switch_bodys=] [=syntactic_rule/brace_right=]
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>switch_body</dfn> :
 
-case_selectors
-  : const_literal (COMMA const_literal)* COMMA?
+    | [=syntactic_rule/case=] [=syntactic_rule/case_selectors=] [=syntactic_rule/colon=] [=syntactic_rule/brace_left=] [=syntactic_rule/case_body=] ? [=syntactic_rule/brace_right=]
 
-case_body
-  :
-  | statement case_body
-  | FALLTHROUGH SEMICOLON
-</pre>
+    | [=syntactic_rule/default=] [=syntactic_rule/colon=] [=syntactic_rule/brace_left=] [=syntactic_rule/case_body=] ? [=syntactic_rule/brace_right=]
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>case_selectors</dfn> :
+
+    | [=syntactic_rule/const_literal=] ( [=syntactic_rule/comma=] [=syntactic_rule/const_literal=] ) * [=syntactic_rule/comma=] ?
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>case_body</dfn> :
+
+    | [=syntactic_rule/statement=] [=syntactic_rule/case_body=] ?
+
+    | [=syntactic_rule/fallthrough=] [=syntactic_rule/semicolon=]
+</div> <!-- syntactic-rule -->
 
 A <dfn noexport dfn-for="statement">switch</dfn> statement transfers control to one of a set of case clauses, or to the `default` clause,
 depending on the evaluation of a selector expression.
@@ -4975,10 +5153,11 @@ which are reachable via a `fallthrough` statement.
 
 ### Loop Statement ### {#loop-statement}
 
-<pre class='def'>
-loop_statement
-  : LOOP BRACE_LEFT statements? continuing_statement? BRACE_RIGHT
-</pre>
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>loop_statement</dfn> :
+
+    | [=syntactic_rule/loop=] [=syntactic_rule/brace_left=] [=syntactic_rule/statements=] ? [=syntactic_rule/continuing_statement=] ? [=syntactic_rule/brace_right=]
+</div> <!-- syntactic-rule -->
 
 A <dfn noexport dfn-for="statement">loop</dfn> statement repeatedly executes a <dfn noexport>loop body</dfn>;
 the loop body is specified as a [=compound statement=].
@@ -5077,15 +5256,16 @@ allows them to naturally use values defined in the loop body.
 
 ### For Statement ### {#for-statement}
 
-<pre class='def'>
-for_statement
-  : FOR PAREN_LEFT for_header PAREN_RIGHT compound_statement
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>for_statement</dfn> :
 
-for_header
-  : (variable_statement | assignment_statement | func_call_statement)? SEMICOLON
-     short_circuit_or_expression? SEMICOLON
-     (assignment_statement | func_call_statement)?
-</pre>
+    | [=syntactic_rule/for=] [=syntactic_rule/paren_left=] [=syntactic_rule/for_header=] [=syntactic_rule/paren_right=] [=syntactic_rule/compound_statement=]
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>for_header</dfn> :
+
+    | ( [=syntactic_rule/variable_statement=] | [=syntactic_rule/assignment_statement=] | [=syntactic_rule/func_call_statement=] ) ? [=syntactic_rule/semicolon=] [=syntactic_rule/short_circuit_or_expression=] ? [=syntactic_rule/semicolon=] ( [=syntactic_rule/assignment_statement=] | [=syntactic_rule/func_call_statement=] ) ?
+</div> <!-- syntactic-rule -->
 
 The <dfn dfn-for="statement">for</dfn> statement takes the form
 `for(initializer; condition; continuing_part) { body }` and is syntactic sugar on top of a [=statement/loop=] statement with the same `body`.
@@ -5144,10 +5324,11 @@ Converts to:
 
 ### Break Statement ### {#break-statement}
 
-<pre class='def'>
-break_statement
-  : BREAK
-</pre>
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>break_statement</dfn> :
+
+    | [=syntactic_rule/break=]
+</div> <!-- syntactic-rule -->
 
 A <dfn noexport dfn-for="statement">break</dfn> statement transfers control to the first statement
 after the body of the nearest-enclosing [=statement/loop=]
@@ -5226,10 +5407,11 @@ then:
 
 ### Continue Statement ### {#continue-statement}
 
-<pre class='def'>
-continue_statement
-  : CONTINUE
-</pre>
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>continue_statement</dfn> :
+
+    | [=syntactic_rule/continue=]
+</div> <!-- syntactic-rule -->
 
 A <dfn noexport dfn-for="statement">continue</dfn> statement transfers control in the nearest-enclosing [=statement/loop=]:
 
@@ -5263,10 +5445,11 @@ control past a declaration used in the targeted [=statement/continuing=] stateme
 
 ### Continuing Statement ### {#continuing-statement}
 
-<pre class='def'>
-continuing_statement
-  : CONTINUING compound_statement
-</pre>
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>continuing_statement</dfn> :
+
+    | [=syntactic_rule/continuing=] [=syntactic_rule/compound_statement=]
+</div> <!-- syntactic-rule -->
 
 A <dfn dfn-for="statement">continuing</dfn> statement specifies a [=compound statement=] to be executed at the end of a loop [=iteration=].
 The construct is optional.
@@ -5275,10 +5458,11 @@ The compound statement must not contain a [=statement/return=] or [=statement/di
 
 ### Return Statement ### {#return-statement}
 
-<pre class='def'>
-return_statement
-  : RETURN short_circuit_or_expression?
-</pre>
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>return_statement</dfn> :
+
+    | [=syntactic_rule/return=] [=syntactic_rule/short_circuit_or_expression=] ?
+</div> <!-- syntactic-rule -->
 
 A <dfn noexport dfn-for="statement">return</dfn> statement ends execution of the current function.
 If the function is an [=entry point=], then the current shader invocation
@@ -5345,10 +5529,11 @@ Issue: [[#uniform-control-flow]] needs to state whether all invocations being di
 
 ## Function Call Statement ## {#function-call-statement}
 
-<pre class='def'>
-func_call_statement
-  : IDENT argument_expression_list
-</pre>
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>func_call_statement</dfn> :
+
+    | [=syntactic_rule/ident=] [=syntactic_rule/argument_expression_list=]
+</div> <!-- syntactic-rule -->
 
 A function call statement executes a [=function call=] where the called
 function does not return a value.
@@ -5358,25 +5543,35 @@ through assignment, evaluation in another expression or through use of the
 
 ## Statements Grammar Summary ## {#statements-summary}
 
-<pre class='def'>
-statements
-  : statement+
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>statement</dfn> :
 
-statement
-  : SEMICOLON
-  | return_statement SEMICOLON
-  | if_statement
-  | switch_statement
-  | loop_statement
-  | for_statement
-  | func_call_statement SEMICOLON
-  | variable_statement SEMICOLON
-  | break_statement SEMICOLON
-  | continue_statement SEMICOLON
-  | DISCARD SEMICOLON
-  | assignment_statement SEMICOLON
-  | compound_statement
-</pre>
+    | [=syntactic_rule/semicolon=]
+
+    | [=syntactic_rule/return_statement=] [=syntactic_rule/semicolon=]
+
+    | [=syntactic_rule/if_statement=]
+
+    | [=syntactic_rule/switch_statement=]
+
+    | [=syntactic_rule/loop_statement=]
+
+    | [=syntactic_rule/for_statement=]
+
+    | [=syntactic_rule/func_call_statement=] [=syntactic_rule/semicolon=]
+
+    | [=syntactic_rule/variable_statement=] [=syntactic_rule/semicolon=]
+
+    | [=syntactic_rule/break_statement=] [=syntactic_rule/semicolon=]
+
+    | [=syntactic_rule/continue_statement=] [=syntactic_rule/semicolon=]
+
+    | [=syntactic_rule/discard=] [=syntactic_rule/semicolon=]
+
+    | [=syntactic_rule/assignment_statement=] [=syntactic_rule/semicolon=]
+
+    | [=syntactic_rule/compound_statement=]
+</div> <!-- syntactic-rule -->
 
 
 # Functions # {#functions}
@@ -5422,24 +5617,26 @@ If the return type is specified, then:
 * The return type must be [=constructible=].
 * The last statement in the function body must be a [=statement/return=] statement.
 
-<pre class='def'>
-function_decl
-  : attribute_list* function_header compound_statement
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>function_decl</dfn> :
 
-function_header
-  : FN IDENT PAREN_LEFT param_list PAREN_RIGHT function_return_type_decl_optional
+    | [=syntactic_rule/attribute_lists=] ? [=syntactic_rule/function_header=] [=syntactic_rule/compound_statement=]
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>function_header</dfn> :
 
-function_return_type_decl_optional
-  :
-  | ARROW attribute_list* type_decl
+    | [=syntactic_rule/fn=] [=syntactic_rule/ident=] [=syntactic_rule/paren_left=] [=syntactic_rule/param_list=] ? [=syntactic_rule/paren_right=] ( [=syntactic_rule/arrow=] [=syntactic_rule/attribute_lists=] ? [=syntactic_rule/type_decl=] ) ?
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>param_list</dfn> :
 
-param_list
-  :
-  | (param COMMA)* param COMMA?
+    | ( [=syntactic_rule/param=] [=syntactic_rule/comma=] ) * [=syntactic_rule/param=] [=syntactic_rule/comma=] ?
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>param</dfn> :
 
-param
-  : attribute_list* variable_ident_decl
-</pre>
+    | [=syntactic_rule/attribute_lists=] ? [=syntactic_rule/variable_ident_decl=]
+</div> <!-- syntactic-rule -->
 
 [SHORTNAME] defines the following attributes that can be applied to function declarations:
  * [=attribute/stage=]
@@ -6075,10 +6272,11 @@ create a [=scope=] for the identifier.
 Use of the identifier by the directive does not conflict with the
 use of that identifier as the name in any [=declaration=].
 
-<pre class='def'>
-enable_directive
-  : ENABLE IDENT SEMICOLON
-</pre>
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>enable_directive</dfn> :
+
+    | [=syntactic_rule/enable=] [=syntactic_rule/ident=] [=syntactic_rule/semicolon=]
+</div> <!-- syntactic-rule -->
 
 Note: The grammar rule includes the terminating semicolon token,
 ensuring the additional functionality is usable only after that semicolon.
@@ -6118,16 +6316,23 @@ the implementation can issue a clear diagnostic.
 
 TODO: *Stub* A WGSL program is a sequence of [=directives=] and [=module scope=] [=declarations=].
 
-<pre class='def'>
-global_decl_or_directive
-  : SEMICOLON
-  | global_variable_decl SEMICOLON
-  | global_constant_decl SEMICOLON
-  | type_alias SEMICOLON
-  | struct_decl SEMICOLON
-  | function_decl
-  | enable_directive
-</pre>
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>global_decl_or_directive</dfn> :
+
+    | [=syntactic_rule/semicolon=]
+
+    | [=syntactic_rule/global_variable_decl=] [=syntactic_rule/semicolon=]
+
+    | [=syntactic_rule/global_constant_decl=] [=syntactic_rule/semicolon=]
+
+    | [=syntactic_rule/type_alias=] [=syntactic_rule/semicolon=]
+
+    | [=syntactic_rule/struct_decl=] [=syntactic_rule/semicolon=]
+
+    | [=syntactic_rule/function_decl=]
+
+    | [=syntactic_rule/enable_directive=]
+</div> <!-- syntactic-rule -->
 
 # Execution TODO # {#execution}
 
@@ -6474,129 +6679,536 @@ I've written what an NVIDIA GPU does.  See https://github.com/google/amber/pull/
 
 ## Keyword Summary ## {#keyword-summary}
 
-<table class='data'>
-  <caption>Type-defining keywords</caption>
-  <thead>
-    <tr><th>Token<th>Definition
-  </thead>
-  <tr><td>`ARRAY`<td>array
-  <tr><td>`ATOMIC`<td>atomic
-  <tr><td>`BOOL`<td>bool
-  <tr><td>`FLOAT32`<td>f32
-  <tr><td>`INT32`<td>i32
-  <tr><td>`MAT2x2`<td>mat2x2  // 2 column x 2 row
-  <tr><td>`MAT2x3`<td>mat2x3  // 2 column x 3 row
-  <tr><td>`MAT2x4`<td>mat2x4  // 2 column x 4 row
-  <tr><td>`MAT3x2`<td>mat3x2  // 3 column x 2 row
-  <tr><td>`MAT3x3`<td>mat3x3  // 3 column x 3 row
-  <tr><td>`MAT3x4`<td>mat3x4  // 3 column x 4 row
-  <tr><td>`MAT4x2`<td>mat4x2  // 4 column x 2 row
-  <tr><td>`MAT4x3`<td>mat4x3  // 4 column x 3 row
-  <tr><td>`MAT4x4`<td>mat4x4  // 4 column x 4 row
-  <tr><td>`POINTER`<td>ptr
-  <tr><td>`SAMPLER`<td>sampler
-  <tr><td>`SAMPLER_COMPARISON`<td>sampler_comparison
-  <tr><td>`STRUCT`<td>struct
-  <tr><td>`TEXTURE_1D`<td>texture_1d
-  <tr><td>`TEXTURE_2D`<td>texture_2d
-  <tr><td>`TEXTURE_2D_ARRAY`<td>texture_2d_array
-  <tr><td>`TEXTURE_3D`<td>texture_3d
-  <tr><td>`TEXTURE_CUBE`<td>texture_cube
-  <tr><td>`TEXTURE_CUBE_ARRAY`<td>texture_cube_array
-  <tr><td>`TEXTURE_MULTISAMPLED_2D`<td>texture_multisampled_2d
-  <tr><td>`TEXTURE_STORAGE_1D`<td>texture_storage_1d
-  <tr><td>`TEXTURE_STORAGE_2D`<td>texture_storage_2d
-  <tr><td>`TEXTURE_STORAGE_2D_ARRAY`<td>texture_storage_2d_array
-  <tr><td>`TEXTURE_STORAGE_3D`<td>texture_storage_3d
-  <tr><td>`TEXTURE_DEPTH_2D`<td>texture_depth_2d
-  <tr><td>`TEXTURE_DEPTH_2D_ARRAY`<td>texture_depth_2d_array
-  <tr><td>`TEXTURE_DEPTH_CUBE`<td>texture_depth_cube
-  <tr><td>`TEXTURE_DEPTH_CUBE_ARRAY`<td>texture_depth_cube_array
-  <tr><td>`TEXTURE_DEPTH_MULTISAMPLED_2D`<td>texture_depth_multisampled_2d
-  <tr><td>`UINT32`<td>u32
-  <tr><td>`VEC2`<td>vec2
-  <tr><td>`VEC3`<td>vec3
-  <tr><td>`VEC4`<td>vec4
-</table>
-<table class='data'>
-  <caption>Other keywords</caption>
-  <thead>
-    <tr><td>Token<td>Definition
-  </thead>
-  <tr><td>`BITCAST`<td>bitcast
-  <tr><td>`BLOCK`<td>block
-  <tr><td>`BREAK`<td>break
-  <tr><td>`CASE`<td>case
-  <tr><td>`CONTINUE`<td>continue
-  <tr><td>`CONTINUING`<td>continuing
-  <tr><td>`DEFAULT`<td>default
-  <tr><td>`DISCARD`<td>discard
-  <tr><td>`ELSE`<td>else
-  <tr><td>`ELSE_IF`<td>elseif
-  <tr><td>`ENABLE`<td>enable
-  <tr><td>`FALLTHROUGH`<td>fallthrough
-  <tr><td>`FALSE`<td>false
-  <tr><td>`FN`<td>fn
-  <tr><td>`FOR`<td>for
-  <tr><td>`FUNCTION`<td>function
-  <tr><td>`IF`<td>if
-  <tr><td>`LET`<td>let
-  <tr><td>`LOOP`<td>loop
-  <tr><td>`PRIVATE`<td>private
-  <tr><td>`READ`<td>read
-  <tr><td>`READ_WRITE`<td>read_write
-  <tr><td>`RETURN`<td>return
-  <tr><td>`STORAGE`<td>storage
-  <tr><td>`SWITCH`<td>switch
-  <tr><td>`TRUE`<td>true
-  <tr><td>`TYPE`<td>type
-  <tr><td>`UNIFORM`<td>uniform
-  <tr><td>`VAR`<td>var
-  <tr><td>`WORKGROUP`<td>workgroup
-  <tr><td>`WRITE`<td>write
-</table>
+### Type-defining Keywords ### {#type-defining-keywords}
+
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>array</dfn> :
+
+    | `/array/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>atomic</dfn> :
+
+    | `/atomic/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>bool</dfn> :
+
+    | `/bool/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>float32</dfn> :
+
+    | `/f32/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>int32</dfn> :
+
+    | `/i32/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>mat2x2</dfn> :
+
+    | `/mat2x2/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>mat2x3</dfn> :
+
+    | `/mat2x3/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>mat2x4</dfn> :
+
+    | `/mat2x4/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>mat3x2</dfn> :
+
+    | `/mat3x2/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>mat3x3</dfn> :
+
+    | `/mat3x3/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>mat3x4</dfn> :
+
+    | `/mat3x4/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>mat4x2</dfn> :
+
+    | `/mat4x2/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>mat4x3</dfn> :
+
+    | `/mat4x3/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>mat4x4</dfn> :
+
+    | `/mat4x4/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>pointer</dfn> :
+
+    | `/ptr/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>sampler</dfn> :
+
+    | `/sampler/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>sampler_comparison</dfn> :
+
+    | `/sampler_comparison/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>struct</dfn> :
+
+    | `/struct/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>texture_1d</dfn> :
+
+    | `/texture_1d/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>texture_2d</dfn> :
+
+    | `/texture_2d/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>texture_2d_array</dfn> :
+
+    | `/texture_2d_array/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>texture_3d</dfn> :
+
+    | `/texture_3d/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>texture_cube</dfn> :
+
+    | `/texture_cube/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>texture_cube_array</dfn> :
+
+    | `/texture_cube_array/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>texture_multisampled_2d</dfn> :
+
+    | `/texture_multisampled_2d/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>texture_storage_1d</dfn> :
+
+    | `/texture_storage_1d/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>texture_storage_2d</dfn> :
+
+    | `/texture_storage_2d/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>texture_storage_2d_array</dfn> :
+
+    | `/texture_storage_2d_array/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>texture_storage_3d</dfn> :
+
+    | `/texture_storage_3d/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>texture_depth_2d</dfn> :
+
+    | `/texture_depth_2d/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>texture_depth_2d_array</dfn> :
+
+    | `/texture_depth_2d_array/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>texture_depth_cube</dfn> :
+
+    | `/texture_depth_cube/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>texture_depth_cube_array</dfn> :
+
+    | `/texture_depth_cube_array/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>texture_depth_multisampled_2d</dfn> :
+
+    | `/texture_depth_multisampled_2d/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>uint32</dfn> :
+
+    | `/u32/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>vec2</dfn> :
+
+    | `/vec2/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>vec3</dfn> :
+
+    | `/vec3/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>vec4</dfn> :
+
+    | `/vec4/`
+</div> <!-- syntactic-rule -->
+
+### Other Keywords ### {#other-keywords}
+
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>bitcast</dfn> :
+
+    | `/bitcast/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>block</dfn> :
+
+    | `/block/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>break</dfn> :
+
+    | `/break/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>case</dfn> :
+
+    | `/case/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>continue</dfn> :
+
+    | `/continue/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>continuing</dfn> :
+
+    | `/continuing/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>default</dfn> :
+
+    | `/default/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>discard</dfn> :
+
+    | `/discard/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>else</dfn> :
+
+    | `/else/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>else_if</dfn> :
+
+    | `/elseif/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>enable</dfn> :
+
+    | `/enable/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>fallthrough</dfn> :
+
+    | `/fallthrough/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>false</dfn> :
+
+    | `/false/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>fn</dfn> :
+
+    | `/fn/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>for</dfn> :
+
+    | `/for/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>function</dfn> :
+
+    | `/function/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>if</dfn> :
+
+    | `/if/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>let</dfn> :
+
+    | `/let/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>loop</dfn> :
+
+    | `/loop/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>private</dfn> :
+
+    | `/private/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>read</dfn> :
+
+    | `/read/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>read_write</dfn> :
+
+    | `/read_write/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>return</dfn> :
+
+    | `/return/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>storage</dfn> :
+
+    | `/storage/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>switch</dfn> :
+
+    | `/switch/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>true</dfn> :
+
+    | `/true/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>type</dfn> :
+
+    | `/type/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>uniform</dfn> :
+
+    | `/uniform/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>var</dfn> :
+
+    | `/var/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>workgroup</dfn> :
+
+    | `/workgroup/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>write</dfn> :
+
+    | `/write/`
+</div> <!-- syntactic-rule -->
+
 Issue: Should read, write, and read_write be not completely reserved?  They are only used in specific contexts.
-<table class='data'>
-  <caption>Image format keywords</caption>
-  <thead>
-    <tr><td>Token<td>Definition
-  </thead>
-  <tr><td>`R8UNORM`<td>r8unorm
-  <tr><td>`R8SNORM`<td>r8snorm
-  <tr><td>`R8UINT`<td>r8uint
-  <tr><td>`R8SINT`<td>r8sint
-  <tr><td>`R16UINT`<td>r16uint
-  <tr><td>`R16SINT`<td>r16sint
-  <tr><td>`R16FLOAT`<td>r16float
-  <tr><td>`RG8UNORM`<td>rg8unorm
-  <tr><td>`RG8SNORM`<td>rg8snorm
-  <tr><td>`RG8UINT`<td>rg8uint
-  <tr><td>`RG8SINT`<td>rg8sint
-  <tr><td>`R32UINT`<td>r32uint
-  <tr><td>`R32SINT`<td>r32sint
-  <tr><td>`R32FLOAT`<td>r32float
-  <tr><td>`RG16UINT`<td>rg16uint
-  <tr><td>`RG16SINT`<td>rg16sint
-  <tr><td>`RG16FLOAT`<td>rg16float
-  <tr><td>`RGBA8UNORM`<td>rgba8unorm
-  <tr><td>`RGBA8UNORM-SRGB`<td>rgba8unorm_srgb
-  <tr><td>`RGBA8SNORM`<td>rgba8snorm
-  <tr><td>`RGBA8UINT`<td>rgba8uint
-  <tr><td>`RGBA8SINT`<td>rgba8sint
-  <tr><td>`BGRA8UNORM`<td>bgra8unorm
-  <tr><td>`BGRA8UNORM-SRGB`<td>bgra8unorm_srgb
-  <tr><td>`RGB10A2UNORM`<td>rgb10a2unorm
-  <tr><td>`RG11B10FLOAT`<td>rg11b10float
-  <tr><td>`RG32UINT`<td>rg32uint
-  <tr><td>`RG32SINT`<td>rg32sint
-  <tr><td>`RG32FLOAT`<td>rg32float
-  <tr><td>`RGBA16UINT`<td>rgba16uint
-  <tr><td>`RGBA16SINT`<td>rgba16sint
-  <tr><td>`RGBA16FLOAT`<td>rgba16float
-  <tr><td>`RGBA32UINT`<td>rgba32uint
-  <tr><td>`RGBA32SINT`<td>rgba32sint
-  <tr><td>`RGBA32FLOAT`<td>rgba32float
-</table>
+
+### Image Format Keywords ### {#image-format-keywords}
+
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>r8unorm</dfn> :
+
+    | `/r8unorm/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>r8snorm</dfn> :
+
+    | `/r8snorm/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>r8uint</dfn> :
+
+    | `/r8uint/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>r8sint</dfn> :
+
+    | `/r8sint/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>r16uint</dfn> :
+
+    | `/r16uint/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>r16sint</dfn> :
+
+    | `/r16sint/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>r16float</dfn> :
+
+    | `/r16float/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>rg8unorm</dfn> :
+
+    | `/rg8unorm/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>rg8snorm</dfn> :
+
+    | `/rg8snorm/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>rg8uint</dfn> :
+
+    | `/rg8uint/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>rg8sint</dfn> :
+
+    | `/rg8sint/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>r32uint</dfn> :
+
+    | `/r32uint/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>r32sint</dfn> :
+
+    | `/r32sint/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>r32float</dfn> :
+
+    | `/r32float/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>rg16uint</dfn> :
+
+    | `/rg16uint/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>rg16sint</dfn> :
+
+    | `/rg16sint/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>rg16float</dfn> :
+
+    | `/rg16float/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>rgba8unorm</dfn> :
+
+    | `/rgba8unorm/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>rgba8unorm_srgb</dfn> :
+
+    | `/rgba8unorm_srgb/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>rgba8snorm</dfn> :
+
+    | `/rgba8snorm/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>rgba8uint</dfn> :
+
+    | `/rgba8uint/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>rgba8sint</dfn> :
+
+    | `/rgba8sint/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>bgra8unorm</dfn> :
+
+    | `/bgra8unorm/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>bgra8unorm_srgb</dfn> :
+
+    | `/bgra8unorm_srgb/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>rgb10a2unorm</dfn> :
+
+    | `/rgb10a2unorm/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>rg11b10float</dfn> :
+
+    | `/rg11b10float/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>rg32uint</dfn> :
+
+    | `/rg32uint/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>rg32sint</dfn> :
+
+    | `/rg32sint/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>rg32float</dfn> :
+
+    | `/rg32float/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>rgba16uint</dfn> :
+
+    | `/rgba16uint/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>rgba16sint</dfn> :
+
+    | `/rgba16sint/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>rgba16float</dfn> :
+
+    | `/rgba16float/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>rgba32uint</dfn> :
+
+    | `/rgba32uint/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>rgba32sint</dfn> :
+
+    | `/rgba32sint/`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>rgba32float</dfn> :
+
+    | `/rgba32float/`
+</div> <!-- syntactic-rule -->
 
 TODO(dneto): Eliminate the image formats that are not used in storage images.
 For example SRGB formats (bgra8unorm_srgb), mixed channel widths (rg11b10float), out-of-order channels (bgra8unorm)
@@ -6608,36 +7220,55 @@ A [SHORTNAME] program must not contain a reserved word.
 
 The following are reserved words:
 
-<table class='data'>
-  <tr>
-    <td>asm
-    <td>bf16
-    <td>const
-    <td>do
-    <td>enum
-  <tr>
-    <td>f16
-    <td>f64
-    <td>handle
-    <td>i8
-    <td>i16
-  <tr>
-    <td>i64
-    <td>mat
-    <td>premerge
-    <td>regardless
-    <td>typedef
-  <tr>
-    <td>u8
-    <td>u16
-    <td>u64
-    <td>unless
-    <td>using
-  <tr>
-    <td>vec
-    <td>void
-    <td>while
-</table>
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>_reserved</dfn> :
+
+    | `/asm/`
+
+    | `/bf16/`
+
+    | `/const/`
+
+    | `/do/`
+
+    | `/enum/`
+
+    | `/f16/`
+
+    | `/f64/`
+
+    | `/handle/`
+
+    | `/i8/`
+
+    | `/i16/`
+
+    | `/i64/`
+
+    | `/mat/`
+
+    | `/premerge/`
+
+    | `/regardless/`
+
+    | `/typedef/`
+
+    | `/u8/`
+
+    | `/u16/`
+
+    | `/u64/`
+
+    | `/unless/`
+
+    | `/using/`
+
+    | `/vec/`
+
+    | `/void/`
+
+    | `/while/`
+</div> <!-- syntactic-rule -->
 
 ## Syntactic Tokens ## {#syntactic-tokens}
 
@@ -6645,44 +7276,186 @@ A <dfn>syntactic token</dfn> is a sequence of special characters, used:
 * to spell an expression operator, or
 * as punctuation: to group, sequence, or separate other grammar elements.
 
-<table class='data'>
-  <tr><td>`AND`<td>`&`
-  <tr><td>`AND_AND`<td>`&&`
-  <tr><td>`ARROW`<td>`->`
-  <tr><td>`ATTR_LEFT`<td>`[[`
-  <tr><td>`ATTR_RIGHT`<td>`]]`
-  <tr><td>`FORWARD_SLASH`<td>`/`
-  <tr><td>`BANG`<td>`!`
-  <tr><td>`BRACKET_LEFT`<td>`[`
-  <tr><td>`BRACKET_RIGHT`<td>`]`
-  <tr><td>`BRACE_LEFT`<td>`{`
-  <tr><td>`BRACE_RIGHT`<td>`}`
-  <tr><td>`COLON`<td>`:`
-  <tr><td>`COMMA`<td>`,`
-  <tr><td>`EQUAL`<td>`=`
-  <tr><td>`EQUAL_EQUAL`<td>`==`
-  <tr><td>`NOT_EQUAL`<td>`!=`
-  <tr><td>`GREATER_THAN`<td>`>`
-  <tr><td>`GREATER_THAN_EQUAL`<td>`>=`
-  <tr><td>`SHIFT_RIGHT`<td>`>>`
-  <tr><td>`LESS_THAN`<td>`<`
-  <tr><td>`LESS_THAN_EQUAL`<td>`<=`
-  <tr><td>`SHIFT_LEFT`<td>`<<`
-  <tr><td>`MODULO`<td>`%`
-  <tr><td>`MINUS`<td>`-`
-  <tr><td>`MINUS_MINUS`<td>`--`
-  <tr><td>`PERIOD`<td>`.`
-  <tr><td>`PLUS`<td>`+`
-  <tr><td>`PLUS_PLUS`<td>`++`
-  <tr><td>`OR`<td>`|`
-  <tr><td>`OR_OR`<td>`||`
-  <tr><td>`PAREN_LEFT`<td>`(`
-  <tr><td>`PAREN_RIGHT`<td>`)`
-  <tr><td>`SEMICOLON`<td>`;`
-  <tr><td>`STAR`<td>`*`
-  <tr><td>`TILDE`<td>`~`
-  <tr><td>`XOR`<td>`^`
-</table>
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>and</dfn> :
+
+    | `'&'`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>and_and</dfn> :
+
+    | `'&&'`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>arrow</dfn> :
+
+    | `'->'`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>attr_left</dfn> :
+
+    | `'[['`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>attr_right</dfn> :
+
+    | `']]'`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>forward_slash</dfn> :
+
+    | `'/'`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>bang</dfn> :
+
+    | `'!'`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>bracket_left</dfn> :
+
+    | `'['`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>bracket_right</dfn> :
+
+    | `']'`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>brace_left</dfn> :
+
+    | `'{'`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>brace_right</dfn> :
+
+    | `'}'`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>colon</dfn> :
+
+    | `':'`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>comma</dfn> :
+
+    | `','`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>equal</dfn> :
+
+    | `'='`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>equal_equal</dfn> :
+
+    | `'=='`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>not_equal</dfn> :
+
+    | `'!='`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>greater_than</dfn> :
+
+    | `'>'`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>greater_than_equal</dfn> :
+
+    | `'>='`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>shift_right</dfn> :
+
+    | `'>>'`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>less_than</dfn> :
+
+    | `'<'`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>less_than_equal</dfn> :
+
+    | `'<='`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>shift_left</dfn> :
+
+    | `'<<'`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>modulo</dfn> :
+
+    | `'%'`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>minus</dfn> :
+
+    | `'-'`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>minus_minus</dfn> :
+
+    | `'--'`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>period</dfn> :
+
+    | `'.'`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>plus</dfn> :
+
+    | `'+'`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>plus_plus</dfn> :
+
+    | `'++'`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>or</dfn> :
+
+    | `'|'`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>or_or</dfn> :
+
+    | `'||'`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>paren_left</dfn> :
+
+    | `'('`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>paren_right</dfn> :
+
+    | `')'`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>semicolon</dfn> :
+
+    | `';'`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>star</dfn> :
+
+    | `'*'`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>tilde</dfn> :
+
+    | `'~'`
+</div> <!-- syntactic-rule -->
+<div class='syntactic-rule' noexport='true'>
+  <dfn dfn for=syntactic_rule>xor</dfn> :
+
+    | `'^'`
+</div> <!-- syntactic-rule -->
 
 Note: The `MINUS_MINUS` and `PLUS_PLUS` tokens are reserved, i.e. they are not used in any grammar productions.
 For example `x--` and `++i` are not syntactically valid expressions in [SHORTNAME].

--- a/wgsl/wgsl_spec_style_guide.md
+++ b/wgsl/wgsl_spec_style_guide.md
@@ -83,6 +83,29 @@ Use the [serial comma](https://en.wikipedia.org/wiki/Serial_comma), also known a
 In Markdown, no two sentences (or parts of sentences) should be on the same text line.
 This makes it easier to edit and review changes.
 
+Authoring syntactic rules:
+* Each syntactic rule should start with a line which only contains `` <div class='syntactic-rule' noexport='true'> ``
+and end with a line which only contains `` </div> <!-- syntactic-rule --> ``. There must be only one
+syntactic rule between these lines.
+* Each syntactic rule must define itself for Bikeshed. Each syntactic rule definition must start with two spaces
+and then place the rule name between `` <dfn dfn for=syntactic_rule> `` and `` </dfn> : `` on the same line.
+* Each syntactic rule item must start with four spaces and then list members after `` | `` followed by a space.
+    * Syntactic rule items can be split to multiple lines. For this, start the next line with six spaces.
+* Each syntactic rule item must be surrounded by only a space before and after,
+trailing space at the end of the line being redundant.
+* Members of syntactic rules items can be references to existing rules. These must be placed between
+`` [=syntactic_rule/ `` and `` =] ``, and the referenced name can be suffixed by pluralizing `` s `` or `` es ``
+to be repeating as at least one or more of the rule.
+* Members of syntactic rules can contain groups which should contain the group members between `` ( `` and `` ) ``.
+* Members of syntactic rule items which denote a string should start with `` `' ``
+and end with `` '` `` and not contain any space character or line break between these two.
+* Members of syntactic rule items which denote a regular expression should start with `` `/ ``
+and end with `` /` `` and not contain any space character or line break between these two.
+* If a member is optional, then it must be followed by a `` ? `` member token.
+* If a member can repeat and must appear at least once, then it must be followed by a `` + `` member token.
+* If a member can repeat and does not have to appear, then it must be followed by a `` * `` member token.
+    * To realize this with pluralized reference, follow the reference member by a `` ? `` member token.
+
 ## Tagging conventions
 
 Several tools process the specification source, extracting things for further processing.


### PR DESCRIPTION
!! If anybody has trouble with this PR's change causing another PR to regress with their progression, feel free to ping or mention me !!

!! I do not bloat this PR with screenshots of output because GitHub Actions will follow this post by a built preview !!

This PR enables navigation for syntactic rules and styling through CSS while updating the grammar extractor to recognize this approach. Key characteristics:
- Only use Bikeshed.
- Support pluralizing morpheme, which Bikeshed supports for referencing definitions inside syntactic rules.
- More readable on different displays, especially if too narrow to show the entire item (smartwatch, phone).
- Allow for extensive styling through CSS.
- Support for multi-line rule items.
- Unify all rule types (extractor halves in lines of code).
- Distinguish string tokens and regex tokens explicitly.
- Style guide syntactic rule authoring.
- Eliminate one-use rules that are simple inflections.

In the https://github.com/gpuweb/gpuweb/issues/2114 issue, @dneto0 has listed great goals for a visual work of WGSL to consider. I do not claim this PR takes us there completely, but it does the manual labor to kickstart the process.

## Tiny Background

This PR was made easy by utilization of grammar.json (not grammar.js) artifact of tree-sitter found under the grammar folder. The following script did the transformation (only at an older commit before the commit of this PR!), which acts as proof that eventually, we might be able to use this file to check against our style guide (by going from the spec to grammar.json, and back to rules' formatting in the spec and making sure they are the same):

```python
import json

grammar_json = json.load(
    open("grammar.json", "r", encoding="utf-8"))

rejected_rules = set()
for existing_rule in grammar_json["rules"].keys():
    if existing_rule.endswith("s"):
        if existing_rule[:-1] in grammar_json["rules"]:
            rejected_rules.add(existing_rule)
    if existing_rule.endswith("es"):
        if existing_rule[:-2] in grammar_json["rules"]:
            rejected_rules.add(existing_rule)
    if existing_rule.endswith("optional"):
        rejected_rules.add(existing_rule)
    if "members" in grammar_json["rules"][existing_rule]:
        for item in grammar_json["rules"][existing_rule]["members"]:
            if item["type"] == "BLANK":
                rejected_rules.add(existing_rule)
if len(rejected_rules) > 0:
    pass  # print(f"Rejected Rules: {rejected_rules}")

rule = """
<div class='syntactic-rule' noexport='true'>
  <dfn dfn for=syntactic_rule>{}</dfn> :
{}
</div> <!-- syntactic-rule -->
""".strip()

rule_item = """\n    | {}"""

rule_regex = """`/{}/`"""

rule_string = """`'{}'`"""


def existing_constituent_is_parenthetical(existing_constituent):
    return len([i for i in existing_constituent if i not in ["+", "?", "|", "(", ")"]]) > 1 and not (existing_constituent[0] == "(" and existing_constituent[-1] == ")")


def existing_constituent_to_components(existing_constituent):
    components = []
    if existing_constituent["type"] in ["CHOICE", "SEQ"]:
        if len(existing_constituent["members"]) == 1:
            return existing_constituent_to_components(existing_constituent["members"][0])
    if existing_constituent["type"] == "SEQ":
        for member in existing_constituent["members"]:
            subcomponents = existing_constituent_to_components(member)
            components += subcomponents
    is_optional = False
    if existing_constituent["type"] == "CHOICE":
        for member in existing_constituent["members"]:
            if member["type"] == "BLANK":
                is_optional = True
            else:
                if len(components) > 0:
                    components += ["|"]
                subcomponents = existing_constituent_to_components(member)
                if existing_constituent_is_parenthetical(subcomponents):
                    components += ["("] + subcomponents + [")"]
                else:
                    components += subcomponents
        if existing_constituent_is_parenthetical(components):
            components = ["("] + components + [")"]
        if is_optional:
            if len(existing_constituent["members"]) == 2:
                for member in existing_constituent["members"]:
                    if member["type"] == "REPEAT":
                        return existing_constituent_to_components(member)
    if existing_constituent["type"] == "SYMBOL":
        if existing_constituent["name"] in rejected_rules and existing_constituent["name"].endswith("s"):
            return [f"[=syntactic_rule/{existing_constituent['name'][:-1]}s=]"]
        if existing_constituent["name"] in rejected_rules and existing_constituent["name"].endswith("es"):
            return [f"[=syntactic_rule/{existing_constituent['name'][:-2]}es=]"]
        if existing_constituent["name"] in rejected_rules and existing_constituent["name"].endswith("optional"):
            return existing_constituent_to_components({"type": "CHOICE", "members": [grammar_json["rules"][existing_constituent["name"]]]})
        return [f"[=syntactic_rule/{existing_constituent['name']}=]"]
    if existing_constituent["type"] == "TOKEN":
        if existing_constituent["content"]["type"] == "PATTERN":
            return [f"`/{existing_constituent['content']['value']}/`"]
        if existing_constituent["content"]["type"] == "STRING":
            return [f"`'{existing_constituent['content']['value']}'`"]
    if existing_constituent["type"] == "PATTERN":
        return [f"`/{existing_constituent['value']}/`"]
    if existing_constituent["type"] == "STRING":
        return [f"`'{existing_constituent['value']}'`"]
    if existing_constituent["type"] == "REPEAT":
        is_optional = True
    if existing_constituent["type"] in ["REPEAT", "REPEAT1"]:
        subcomponents = existing_constituent_to_components(
            existing_constituent["content"])
        is_symbolic_repetitive = False
        if existing_constituent["content"]["type"] == "SYMBOL":
            is_symbolic_repetitive = True
            if existing_constituent["content"]["name"] in rejected_rules:
                subcomponents = existing_constituent_to_components(
                    existing_constituent["content"])
            elif existing_constituent["content"]["name"].endswith("s"):
                subcomponents = [
                    f"[=syntactic_rule/{existing_constituent['content']['name']}es=]"]
            else:
                subcomponents = [
                    f"[=syntactic_rule/{existing_constituent['content']['name']}s=]"]
        if existing_constituent_is_parenthetical(subcomponents):
            components += ["("] + subcomponents + [")"]
        else:
            components += subcomponents
        if not is_symbolic_repetitive:
            components += ["+"]
    if is_optional:
        components.append("?")
    return components


def existing_rule_to_components(existing_rule):
    existing_constituent = grammar_json["rules"][existing_rule]
    is_optional = False
    if existing_constituent["type"] == "CHOICE":
        for member in existing_constituent["members"]:
            if member["type"] == "BLANK":
                is_optional = True
        if is_optional:
            if len(existing_constituent["members"]) == 2:
                for member in existing_constituent["members"]:
                    if member["type"] == "REPEAT":
                        return [existing_constituent_to_components(member)]
            else:
                raise Exception("Forbidden rule type")
        else:
            return [existing_constituent_to_components(member) for member in existing_constituent["members"]]
    else:
        return [existing_constituent_to_components(existing_constituent)]


for existing_rule in grammar_json["rules"].keys():
    if existing_rule in rejected_rules:
        continue
    print(rule.format(existing_rule, "\n".join([rule_item.format(
        " ".join(item)) for item in existing_rule_to_components(existing_rule)])).replace("+ ?", "*"))
```