### PR TITLE
Clarify copies into -srgb formats

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8111,8 +8111,8 @@ GPUQueue includes GPUObjectBase;
 
         Copying into a `-srgb` texture results in the same texture bytes, not the same decoded
         values, as copying into the corresponding non-`-srgb` format.
-        Thus, after an otherwise unchanged copy operation, sampling the destination texture has
-        different results depending on whether the format is `-srgb`.
+        Thus, after a copy operation, sampling the destination texture has
+        different results depending on whether its format is `-srgb`, all else unchanged.
 
         Issue: If an srgb-linear color space is added, explain here how it interacts.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8109,6 +8109,13 @@ GPUQueue includes GPUObjectBase;
         Issues a copy operation of the contents of a platform image/canvas
         into the destination texture.
 
+        Copying into a `-srgb` texture results in the same texture bytes, not the same decoded
+        values, as copying into the corresponding non-`-srgb` format.
+        Thus, after an otherwise unchanged copy operation, sampling the destination texture has
+        different results depending on whether the format is `-srgb`.
+
+        Issue: If an srgb-linear color space is added, explain here how it interacts.
+
         <div algorithm=GPUQueue.copyExternalImageToTexture>
             **Called on:** {{GPUQueue}} |this|.
 


### PR DESCRIPTION
This matches WebGL's semantics, see http://webglsamples.org/WebGL2Samples/#texture_srgb for an example
(note it samples an srgb texture to get a linear value, then explicitly converts back to srgb before drawing to the canvas).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2146.html" title="Last updated on Sep 28, 2021, 2:17 AM UTC (4d2e3fd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2146/086c770...kainino0x:4d2e3fd.html" title="Last updated on Sep 28, 2021, 2:17 AM UTC (4d2e3fd)">Diff</a>