### PR TITLE
wgsl: Function call statement may call non-void functions

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -149,7 +149,7 @@ When executing a shader stage, the implementation:
 * Allocates storage for other [=module scope|module-scope=] variables,
     and populates that storage with the specified initial values.
 * Populates the formal parameters of the entry point, if they exist, with the stage's pipeline inputs.
-* Connects the entry point return value, if one exists, to the stage's pipeline outputs.
+* Connects the entry point [=return value=], if one exists, to the stage's pipeline outputs.
 * Then it invokes the entry point.
 
 A [SHORTNAME] program is organized into:
@@ -5286,10 +5286,10 @@ is terminated.
 Otherwise, evaluation continues with the next expression or statement after
 the evaluation of the [=call site=] of the current function invocation.
 
-If the function doesn't have a [=return type=], then the [=statement/return=] statement is
+If the function does not have a [=return type=], then the [=statement/return=] statement is
 optional. If the return statement is provided for such a function, it must not
 supply a value.
-Otherwise the expression must be present, and is called the *return value*.
+Otherwise the expression must be present, and is called the <dfn>return value</dfn>.
 In this case the call site of this function invocation evaluates to the return value.
 The type of the return value must match the return type of the function.
 
@@ -5301,7 +5301,7 @@ The `discard` statement must only be used in a [=fragment=] shader stage.
 More precisely, executing a `discard` statement will:
 
 * immediately terminate the current invocation, and
-* prevent evaluation and generation of a return value for the [=entry point=], and
+* prevent evaluation and generation of a [=return value=] for the [=entry point=], and
 * prevent the current fragment from being processed downstream in the [=GPURenderPipeline=].
 
 Only statements
@@ -5350,11 +5350,9 @@ func_call_statement
   : IDENT argument_expression_list
 </pre>
 
-A function call statement executes a [=function call=] where the called
-function does not return a value.
-If the called function returns a value, that value must be consumed either
-through assignment, evaluation in another expression or through use of the
-`ignore` built-in function (see [[#value-steering-functions]]).
+A function call statement executes a [=function call=].
+
+Note: If the function [=return value|returns a value=], that value is ignored.
 
 ## Statements Grammar Summary ## {#statements-summary}
 
@@ -5493,10 +5491,10 @@ When a function call is executed the following steps occur:
 * Control is transferred to the first statement in the called function.
 * The called function is executed.
 * When the called function returns, by either executing a [=statement/return=] statement or reaching
-    the end of the called function (if the function does not return a value),
+    the end of the called function (if the function does not [=return value|return a value=]),
     control is transferred back the calling function, and the called function's execution is
     unsuspended.
-    If the called function returns a value, that value is supplied for the
+    If the called function [=return value|returns a value=], that value is supplied for the
     value of the function call expression.
 
 The location of a function call is referred to as a <dfn noexport>call site</dfn>.


### PR DESCRIPTION
Also, define "return value", and cross-reference to it.

Fixes: #2138