### PR TITLE
Clarify memory locations accessed when writing a vector component

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3940,6 +3940,13 @@ The result type depends on the number of letters provided. Assuming a `vec4<f32>
 
 #### Component reference from vector reference #### {#component-reference-from-vector-reference}
 
+A [=write access=] to component of a vector **may** access all of the [=memory
+location|memory locations=] associated with that vector.
+
+Note: This means accesses to different components of a vector by different
+invocations must be synchronized if at least one access is a [=write access=].
+See [[#sync-builtin-functions]].
+
 <table class='data'>
   <caption>Getting a reference to a component from a reference to a vector</caption>
   <thead>


### PR DESCRIPTION
Fixes #2112

* Write accesses to a vector component may access all memory locations
  associated with the vector