### PR TITLE
Fix inequality symbol in compute shader grid bound

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6202,9 +6202,9 @@ indicating the number of workgroups to be executed, as described in the followin
 The <dfn noexport>compute shader grid</dfn> for a particular dispatch
 is the set of points with integer coordinates *(CSi,CSj,CSk)* with:
 
-*  0 &leq; CSi &le; workgroup_size_x &times; group_count_x
-*  0 &leq; CSj &le; workgroup_size_y &times; group_count_y
-*  0 &leq; CSk &le; workgroup_size_z &times; group_count_z
+*  0 &leq; CSi &lt; workgroup_size_x &times; group_count_x
+*  0 &leq; CSj &lt; workgroup_size_y &times; group_count_y
+*  0 &leq; CSk &lt; workgroup_size_z &times; group_count_z
 
 where *workgroup_size_x*,
 *workgroup_size_y*, and


### PR DESCRIPTION
`&le;` is rendering as "less-than-or-equal-to", whereas this should be a "less-than".