### PR TITLE
wgsl: editorial cleanup: memory vs. storage

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -146,8 +146,8 @@ A shader comprises:
 When executing a shader stage, the implementation:
 * Binds [=resources=] to variables in the shader's [=resource interface of a shader|resource interface=],
     making the contents of those resources available to the shader during execution.
-* Allocates storage for other [=module scope|module-scope=] variables,
-    and populates that storage with the specified initial values.
+* Allocates memory for other [=module scope|module-scope=] variables,
+    and populates that memory with the specified initial values.
 * Populates the formal parameters of the entry point, if they exist, with the stage's pipeline inputs.
 * Connects the entry point [=return value=], if one exists, to the stage's pipeline outputs.
 * Then it invokes the entry point.
@@ -157,7 +157,7 @@ A [SHORTNAME] program is organized into:
 * Statements, which are declarations or units of executable behaviour.
 * Literals, which are text representations for pure mathematical values.
 * Constants, each providing a name for a value computed at a specific time.
-* Variables, each providing a name for storage for holding a value.
+* Variables, each providing a name for memory storage for holding a value.
 * Expressions, each of which combines a set of values to produce a result value.
 * Types, each of which describes:
     * A set of values.
@@ -204,7 +204,7 @@ Invocations in a shader stage share access to certain variables:
 
 However, the invocations act on different sets of pipeline inputs, including built-in inputs
 that provide an identifying value to distinguish an invocation from its peers.
-Also, each invocation has its own independent storage space in the form
+Also, each invocation has its own independent memory storage space in the form
 of variables in the [=storage classes/private=] and [=storage classes/function=] storage classes.
 
 Invocations within a shader stage execute concurrently, and may often execute in parallel.
@@ -2937,28 +2937,28 @@ See [[#module-constants]] and [[#function-scope-variables]].
   </xmp>
 </div>
 
-A <dfn dfn noexport>variable</dfn> is a named reference to storage that can contain a value of a
+A <dfn dfn noexport>variable</dfn> is a named reference to memory that can contain a value of a
 particular [=storable=] type.
 
 Two types are associated with a variable: its [=store type=] (the type of value
-that may be placed in the referenced storage) and its [=reference type=] (the type
+that may be placed in the referenced memory) and its [=reference type=] (the type
 of the variable itself).
-If a variable has store type *T* and [=storage class=] *S*,
-then its reference type is ref&lt;*S*,*T*&gt;.
+If a variable has store type *T*, [=storage class=] *S*, and [=access mode=] *A*,
+then its reference type is ref&lt;*S*,*T*,*A*&gt;.
 
 A <dfn dfn noexport>variable declaration</dfn>:
 
 * Specifies the variable’s name.
 * Specifies the [=storage class=], [=store type=], and [=access mode=].
     Together these comprise the variable's [=reference type=].
-* Ensures the execution environment allocates storage for a value of the store type,
+* Ensures the execution environment allocates memory for a value of the store type, in the specified storage class,
     supporting the given access mode, for the [=lifetime=] of the variable.
 * Optionally has an *initializer* expression, if the variable is in the [=storage classes/private=] or [=storage classes/function=] storage classes.
     If present, the initializer expression must evaluate to the variable's store type.
 
 When an [=identifier=] use [=resolves=] to a variable declaration,
-the identifier is an expression denoting the reference [=memory view=] for the variable's storage,
-and its type is the variable's reference type.
+the identifier is an expression denoting the reference [=memory view=] for the variable's memory,
+and its type is the variable's [=reference type=].
 See [[#var-identifier-expr]].
 
 See [[#module-scope-variables]] and [[#function-scope-variables]] for rules about where
@@ -2966,7 +2966,7 @@ a variable in a particular storage class can be declared,
 and when the storage class decoration is required, optional, or forbidden.
 
 The access mode always has a default, and except for variables in the [=storage classes/storage=] storage class,
-must not be written. See [[#access-mode-defaults]].
+must not be written in [SHORTNAME] source text. See [[#access-mode-defaults]].
 
 <pre class='def'>
 variable_statement
@@ -2991,15 +2991,15 @@ The lifetime of a [=module scope=] variable is the entire execution of the shade
 For a [=function scope=] variable, each invocation has its own independent
 version of the variable.
 The lifetime of the variable is determined by its scope:
-* It begins when control enters the variable's decalaration.
+* It begins when control enters the variable's declaration.
 * It includes the entire execution of any function called from within the variable's scope.
 * It ends when control leaves the variable's scope, other than calling a function from
     within the variable's scope.
 
-Two variables with overlapping lifetimes will not have overlapping storage.
-When a variable's lifetime ends, its storage may be used for another variable.
+Two variables with overlapping lifetimes will not have [=overlap|overlapping memory=].
+When a variable's lifetime ends, its memory may be used for another variable.
 
-When a variable is created, its storage contains an initial value as follows:
+When a variable is created, its memory contains an initial value as follows:
 
 * For variables in the [=storage classes/private=] or [=storage classes/function=] storage classes:
     * The [=zero value=] for the store type, if the variable declaration has no initializer.
@@ -3247,12 +3247,10 @@ and third clauses and in the body of the `for` statement.
 
 An instance of a function scope variable is a [=dynamic context=].
 Each variable that is [=in scope=] for some invocation has an overlapping
-[=lifetime=] and, therefore, has non-overlapping storage.
-Variables with non-overlapping lifetimes may reuse the storage of previous
+[=lifetime=] and, therefore, has non-overlapping memory.
+Variables with non-overlapping lifetimes may reuse the memory of previous
 variables; however, new instances of the same variable are not guaranteed to
-use the same storage.
-
-## Never-alias assumption TODO ## {#never-alias-assumption}
+use the same memory.
 
 # Expressions TODO # {#expressions}
 
@@ -6146,7 +6144,6 @@ TODO: *Stub*
 * External-interface variables have initialized backing storage
 * Internal module-scope variables have backing storage
   * Initializers evaluated in textual order
-* No two variables have overlapping storage (might already be covered earlier?)
 
 ### Program order (within an invocation) TODO ### {#program-order}
 


### PR DESCRIPTION
- In the technical overview, use "memory storage" to tie the two
  concepts together, informally.

- In the rest of the spec, more consistently use "memory" for where
  a variable keeps its values, rather than "storage".
  This fixes an apparent disconnect between the sections describing memory
  (how it's structured, etc.) and the description of variables.

- Remove the empty  "Never-alias assumption TODO" section because that
  intended material is already covered:
     - "Two variables with overlapping lifetimes...."
     - function parameter aliasing is already described