### PR TITLE
Make copyExternalImageToTexture orientation configurable

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5832,6 +5832,7 @@ various encodings allowed by {{GPUQueue/copyExternalImageToTexture()}}.
 <script type=idl>
 dictionary GPUImageCopyExternalImage {
     required (ImageBitmap or HTMLCanvasElement or OffscreenCanvas) source;
+    boolean originBottomLeft = false;
     GPUOrigin2D origin = {};
 };
 </script>
@@ -5844,10 +5845,22 @@ dictionary GPUImageCopyExternalImage {
         The source of the image copy. The copy source data is captured at the moment that
         {{GPUQueue/copyExternalImageToTexture()}} is issued.
 
+    : <dfn>originBottomLeft</dfn>
+    ::
+        If true, {{GPUImageCopyExternalImage/source}} is copied starting from the bottom row
+        (so that the minimum corner of the destination corresponds to the bottom-left of the
+        source). Otherwise, {{GPUImageCopyExternaImage/source}} is copied starting from the top row
+
+        Note:
+        WebGL canvases natively use a bottom-left origin, so setting this option for copies from
+        WebGL may be more efficient.
+
     : <dfn>origin</dfn>
     ::
         Defines the origin of the copy - the minimum corner of the source sub-region to copy from.
-        Together with `copySize`, defines the full copy sub-region.
+        If `originBottomLeft` is set, this is measured from the bottom-left corner of the
+        {{GPUImageCopyExternalImage/source}}; otherwise, from the top-left.
+        Together with `copySize`, this defines the full copy sub-region.
 </dl>
 
 ### Buffer Copies ### {#buffer-copies}


### PR DESCRIPTION
Note that importExternalTexture is not made configurable.
- Assuming zero-copy or non-flipped sources, there is no cost to a y-flip because it just changes the sampling coordinates, and users can trivially y-flip inside their shader.
- I think videos are probably always non-flipped, so it's probably not needed right now? If we add canvas support to importExternalTexture (#1670), then in the non-zero-copy case, it can still improve performance for the same reason, so we could add it.

Fixes #2110


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2158.html" title="Last updated on Oct 1, 2021, 8:19 PM UTC (38a355d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2158/af8f601...kainino0x:38a355d.html" title="Last updated on Oct 1, 2021, 8:19 PM UTC (38a355d)">Diff</a>