### PR TITLE
Raise maxUniformBufferBindingSize to 64k

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1182,7 +1182,7 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
         See [=Exceeds the binding slot limits=].
 
     <tr><td><dfn>maxUniformBufferBindingSize</dfn>
-        <td>{{GPUSize64}} <td>Higher <td>16384
+        <td>{{GPUSize64}} <td>Higher <td>65536
     <tr class=row-continuation><td colspan=4>
         The maximum {{GPUBufferBinding}}.{{GPUBufferBinding/size}} for bindings with a
         {{GPUBindGroupLayoutEntry}} |entry| for which


### PR DESCRIPTION
This loses support for exactly 0 gpuinfo.org reports that were still
supported with our other requirements.

```
Beginning with 944 unique deviceNames in 10808 reports.

(..., see #1069)
Requirement "maxUniformBufferRange >= 16384" loses 1 further deviceNames:
  In ALL reports:
  In SOME reports:
    Apple M1: 5 of 12 (10469 10529 10541 10576 10588; ok: 11048 11395 11396 11632 11689 11884 12086)
Requirement "maxUniformBufferRange >= 65536" loses 0 further deviceNames:
```