### PR TITLE
Make hex exponent suffix optional for floats

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -388,7 +388,7 @@ The form of a [=numeric literal=] is defined via pattern-matching:
     <tr><th>Numeric literal<th>Textual pattern
   </thead>
   <tr><td>`DECIMAL_FLOAT_LITERAL`<td>`(-?[0-9]*\.[0-9]+|-?[0-9]+\.[0-9]*)((e|E)(\+|-)?[0-9]+)?`
-  <tr><td>`HEX_FLOAT_LITERAL`<td>`-?0x([0-9a-fA-F]*\.?[0-9a-fA-F]+|[0-9a-fA-F]+\.[0-9a-fA-F]*)(p|P)(\+|-)?[0-9]+`
+  <tr><td>`HEX_FLOAT_LITERAL`<td>`-?0x([0-9a-fA-F]*\.?[0-9a-fA-F]+|[0-9a-fA-F]+\.[0-9a-fA-F]*)((p|P)(\+|-)?[0-9]+)?`
   <tr><td>`INT_LITERAL`<td>`-?0x[0-9a-fA-F]+|0|-?[1-9][0-9]*`
   <tr><td>`UINT_LITERAL`<td>`0x[0-9a-fA-F]+u|0u|[1-9][0-9]*u`
 </table>


### PR DESCRIPTION
This PR makes the exponent suffix optional for floats, increasing the consistency between literal definitions and helping newcomers use this literal without the suffix being a mystery to discover. The impact of not having one at the end will be in the effect of a hidden `p0` suffix.

Resolves https://github.com/gpuweb/gpuweb/issues/2036 issue.