### PR TITLE
wgsl: 0x123p0 is a hex float     

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -419,7 +419,7 @@ The form of a [=numeric literal=] is defined via pattern-matching:
     <tr><th>Numeric literal<th>Textual pattern
   </thead>
   <tr><td>`DECIMAL_FLOAT_LITERAL`<td>`(-?[0-9]*\.[0-9]+|-?[0-9]+\.[0-9]*)((e|E)(\+|-)?[0-9]+)?`
-  <tr><td>`HEX_FLOAT_LITERAL`<td>`-?0x([0-9a-fA-F]*\.?[0-9a-fA-F]+|[0-9a-fA-F]+\.[0-9a-fA-F]*)((p|P)(\+|-)?[0-9]+)?`
+  <tr><td>`HEX_FLOAT_LITERAL`<td>`-?0x((([0-9a-fA-F]*\.?[0-9a-fA-F]+|[0-9a-fA-F]+\.[0-9a-fA-F]*)((p|P)(\+|-)?[0-9]+)?)|([0-9a-fA-F]+(p|P)(\+|-)?[0-9]+))`
   <tr><td>`INT_LITERAL`<td>`-?0x[0-9a-fA-F]+|0|-?[1-9][0-9]*`
   <tr><td>`UINT_LITERAL`<td>`0x[0-9a-fA-F]+u|0u|[1-9][0-9]*u`
 </table>
@@ -428,6 +428,15 @@ Note: literals are parsed greedily. This means that for statements like `a -5`
       this will *not* parse as `a` `minus` `5` but instead as `a` `-5` which
       may be unexpected. A space must be inserted after the `-` if the first
       expression is desired.
+
+<div class='example wsgl function-scope' heading='Hex float literals'>
+  <xmp highlight='rust'>
+     let half = 0x.8;
+     let thirty_two = 0x1p5;
+     let one_eigth = 0x1p-3;
+     let negative_six = -0x1.8p+2;
+  </xmp>
+</div>
 
 TODO(dneto): Describe how numeric literal tokens map to idealized values, and then to typed values.
 


### PR DESCRIPTION

    Allow a hex float to have no hex-point (.), when it has the binary
    exponent part.
    
    Fixes: #2169

    Split the HEX_FLOAT rule into three rows
