### PR TITLE
Remove COPY buffer usages

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2012,14 +2012,12 @@ typedef [EnforceRange] unsigned long GPUBufferUsageFlags;
 namespace GPUBufferUsage {
     const GPUFlagsConstant MAP_READ      = 0x0001;
     const GPUFlagsConstant MAP_WRITE     = 0x0002;
-    const GPUFlagsConstant COPY_SRC      = 0x0004;
-    const GPUFlagsConstant COPY_DST      = 0x0008;
-    const GPUFlagsConstant INDEX         = 0x0010;
-    const GPUFlagsConstant VERTEX        = 0x0020;
-    const GPUFlagsConstant UNIFORM       = 0x0040;
-    const GPUFlagsConstant STORAGE       = 0x0080;
-    const GPUFlagsConstant INDIRECT      = 0x0100;
-    const GPUFlagsConstant QUERY_RESOLVE = 0x0200;
+    const GPUFlagsConstant INDEX         = 0x0004;
+    const GPUFlagsConstant VERTEX        = 0x0008;
+    const GPUFlagsConstant UNIFORM       = 0x0010;
+    const GPUFlagsConstant STORAGE       = 0x0020;
+    const GPUFlagsConstant INDIRECT      = 0x0040;
+    const GPUFlagsConstant QUERY_RESOLVE = 0x0080;
 };
 </script>
 
@@ -2043,11 +2041,9 @@ namespace GPUBufferUsage {
                     - |this| is a [=valid=] {{GPUDevice}}.
                     - |descriptor|.{{GPUBufferDescriptor/usage}} is a subset of |this|.[[allowed buffer usages]].
                     - If |descriptor|.{{GPUBufferDescriptor/usage}} contains {{GPUBufferUsage/MAP_READ}}:
-                        - |descriptor|.{{GPUBufferDescriptor/usage}} contains no other flags
-                            except {{GPUBufferUsage/COPY_DST}}.
+                        - |descriptor|.{{GPUBufferDescriptor/usage}} contains no other flags.
                     - If |descriptor|.{{GPUBufferDescriptor/usage}} contains {{GPUBufferUsage/MAP_WRITE}}:
-                        - |descriptor|.{{GPUBufferDescriptor/usage}} contains no other flags
-                            except {{GPUBufferUsage/COPY_SRC}}.
+                        - |descriptor|.{{GPUBufferDescriptor/usage}} contains no other flags.
                     - If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`:
                         - |descriptor|.{{GPUBufferDescriptor/size}} is a multiple of 4.
 
@@ -5877,8 +5873,8 @@ dictionary GPUImageCopyExternalImage {
                 - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
                 - |source| is [$valid to use with$] |this|.
                 - |destination| is [$valid to use with$] |this|.
-                - |source|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/COPY_SRC}}.
-                - |destination|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/COPY_DST}}.
+                - |source|.{{GPUBuffer/[[usage]]}} must not contain {{GPUBufferUsage/MAP_READ}}.
+                - |destination|.{{GPUBuffer/[[usage]]}} must not contain {{GPUBufferUsage/MAP_WRITE}}.
                 - |size| is a multiple of 4.
                 - |sourceOffset| is a multiple of 4.
                 - |destinationOffset| is a multiple of 4.
@@ -6046,7 +6042,7 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
                 - Let |dstTextureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
                 - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
                 - [$validating GPUImageCopyBuffer$](|source|) returns `true`.
-                - |source|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/COPY_SRC}}.
+                - |source|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[usage]]}} must not contain {{GPUBufferUsage/MAP_READ}}.
                 - [$validating GPUImageCopyTexture$](|destination|, |copySize|) returns `true`.
                 - |dstTextureDesc|.{{GPUTextureDescriptor/usage}} contains {{GPUTextureUsage/COPY_DST}}.
                 - |dstTextureDesc|.{{GPUTextureDescriptor/sampleCount}} is 1.
@@ -6094,8 +6090,8 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
                     - |source|.{{GPUImageCopyTexture/aspect}} must refer to a single copyable aspect of
                         |srcTextureDesc|.{{GPUTextureDescriptor/format}}. See [[#depth-formats|depth-formats]].
                 - [$validating GPUImageCopyBuffer$](|destination|) returns `true`.
-                - |destination|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[usage]]}} contains
-                    {{GPUBufferUsage/COPY_DST}}.
+                - |destination|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[usage]]}} must not contain
+                    {{GPUBufferUsage/MAP_WRITE}}.
                 - [=Valid Texture Copy Range=] applies to |source| and |copySize|.
                 - If |srcTextureDesc|.{{GPUTextureDescriptor/format}} is not a depth/stencil format:
                     - |destination|.{{GPUImageDataLayout/offset}} is a multiple of the [=texel block size=] of
@@ -6133,7 +6129,7 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
                     - Let |dstTextureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
                     - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
                     - [$validating GPUImageCopyTexture$](|source|, |copySize|) returns `true`.
-                    - |srcTextureDesc|.{{GPUTextureDescriptor/usage}} contains {{GPUTextureUsage/COPY_SRC}}.
+                    - |srcTextureDesc|.{{GPUTextureDescriptor/usage}} must not contain {{GPUTextureUsage/MAP_READ}}.
                     - [$validating GPUImageCopyTexture$](|destination|, |copySize|) returns `true`.
                     - |dstTextureDesc|.{{GPUTextureDescriptor/usage}} contains {{GPUTextureUsage/COPY_DST}}.
                     - |srcTextureDesc|.{{GPUTextureDescriptor/sampleCount}} is equal to |dstTextureDesc|.{{GPUTextureDescriptor/sampleCount}}.


### PR DESCRIPTION
Proposal: instead of requiring usages, always allow buffers to be copied (except preserving the requirement that MAP_READ only be used with COPY_DST and MAP_WRITE only be used with COPY_SRC).

In practice, adding these usages probably has no performance penalty, but more importantly, implementations (probably) end up adding at least the COPY_DST usage to every buffer anyway, for zero-init.

Related: #150


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2172.html" title="Last updated on Oct 8, 2021, 11:34 PM UTC (9175580)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2172/bcf134e...kainino0x:9175580.html" title="Last updated on Oct 8, 2021, 11:34 PM UTC (9175580)">Diff</a>