### PR TITLE
wgsl: Add scalar overloads of any() and all()

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7025,11 +7025,21 @@ That's not a full user-defined function declaration.
     <td>Returns true if each component of |e| is true.
     (OpAll)
 
+  <tr algorithm="scalar all">
+    <td>|e|: bool
+    <td>`all(`|e|`)`: bool
+    <td>Returns |e|.
+
   <tr algorithm="vector any">
     <td>|e|: vecN&lt;bool&gt;
     <td>`any(`|e|`)`: bool
     <td>Returns true if any component of |e| is true.
     (OpAny)
+
+  <tr algorithm="scalar any">
+    <td>|e|: bool
+    <td>`any(`|e|`)`: bool
+    <td>Returns |e|.
 
   <tr algorithm="scalar select">
     <td>|T| is a scalar or a vector


### PR DESCRIPTION
Both of these builtins just return the boolean argument, which logically is how a single-element vector would behave.

This reduces friction when writing generic / generated code.