### PR TITLE
wgsl: Rename `smoothStep` to `smoothstep`

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7624,7 +7624,7 @@ value with the same sign.
   <tr><td>`sign(x)`<td>Correctly rounded
   <tr><td>`sin(x)`<td>Absolute error &le; 2<sup>-11</sup> inside the range [-&pi;, &pi;]
   <tr><td>`sinh(x)`<td>Inherited from `(exp(x) - exp(-x)) * 0.5`
-  <tr><td>`smoothStep(low, high, x)`<td>Inherited from `t * t * (3.0 - 2.0 * t)`,<br>where `t = clamp((x - low) / (high - low), 0.0, 1.0)`
+  <tr><td>`smoothstep(low, high, x)`<td>Inherited from `t * t * (3.0 - 2.0 * t)`,<br>where `t = clamp((x - low) / (high - low), 0.0, 1.0)`
   <tr><td>`sqrt(x)`<td>Inherited from `1.0 / inverseSqrt(x)`
   <tr><td>`step(edge, x)`<td>Correctly rounded
   <tr><td>`tan(x)`<td>Inherited from `sin(x) / cos(x)`
@@ -9038,9 +9038,9 @@ struct __modf_result_vecN {
     <td>Returns the hyperbolic sine of |e|.
     [=Component-wise=] when |T| is a vector.
 
-  <tr algorithm="smoothStep">
+  <tr algorithm="smoothstep">
     <td>|T| is [FLOATING]
-    <td class="nowrap">`smoothStep(`|low|`:` |T| `,` |high|`:` |T| `,` |x|`:` |T| `) -> ` |T|
+    <td class="nowrap">`smoothstep(`|low|`:` |T| `,` |high|`:` |T| `,` |x|`:` |T| `) -> ` |T|
     <td>Returns the smooth Hermite interpolation between 0 and 1.
     [=Component-wise=] when |T| is a vector.
 


### PR DESCRIPTION
HLSL, GLSL and MSL all use `smoothstep`.
There's no good reason for WGSL to be different.