### PR TITLE
wgsl: Function call section accommodates built-in functions

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5801,9 +5801,9 @@ Each argument value must evaluate to the same type as the corresponding formal
 parameter, by position.
 
 In summary, when calling a function:
-1. Execution of the [=caller=] function is suspended.
+1. Execution of the [=calling function=] is suspended.
 2. The [=called function=] executes until it [=returns=].
-3. Execution of the [=caller=] function resumes.
+3. Execution of the [=calling function=] resumes.
 
 A called function <dfn>returns</dfn> as follows:
 * A [=built-in function=] returns when its work has completed.
@@ -5814,7 +5814,7 @@ A called function <dfn>returns</dfn> as follows:
 In detail, when a function call is executed the following steps occur:
 1. Function call argument values are evaluated.
     The relative order of evaluation is not specified.
-2. Execution of the [=caller=] function is suspended.
+2. Execution of the [=calling function=] is suspended.
     All [=function scope=] variables and constants maintain their current values.
 3. If the called function is [=user-defined function|user-defined=],
     storage is allocated for each function scope variable in the called function.


### PR DESCRIPTION
- Define when a functiom "returns"
- Accomodate builtin functions in when describing details
  of how a function call happens

- Resolve TODOs in built-in function section:
  - Define "overload"
  - Say how each overload is defined, in the tables
  - Change heders in tables for built-in functions from:
      Precondition, Conclusion, Notes
    to:
      Parameterization, Overload, Description
    This is better because these are no longer type assertion tables.
    Instead, for type checking rely on the rule that the type of
    a function call expression is the return type of the called
    function.

Fixes: #2157