### PR TITLE
Add ETC2 and ASTC texture formats and feature name documentation

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -10070,7 +10070,7 @@ All packed texture formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsa
         <td>{{GPUTextureFormat/etc2-rgb8unorm-srgb}}
     <tr>
         <td>{{GPUTextureFormat/etc2-rgb8a1unorm}}
-	<td rowspan=2>8
+        <td rowspan=2>8
     <tr>
         <td>{{GPUTextureFormat/etc2-rgb8a1unorm-srgb}}
     <tr>
@@ -10090,7 +10090,7 @@ All packed texture formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsa
         <td>{{GPUTextureFormat/eac-rg11snorm}}
     <tr>
         <td>{{GPUTextureFormat/astc-4x4-unorm}}
-	<td rowspan=2>16
+        <td rowspan=2>16
         <td rowspan=28>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td rowspan=2>4 &times; 4
         <td rowspan=28>{{GPUFeatureName/texture-compression-astc}}
@@ -10099,78 +10099,79 @@ All packed texture formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsa
     <tr>
         <td>{{GPUTextureFormat/astc-5x4-unorm}}
         <td rowspan=2>16
-	<td rowspan=2>5 &times; 4
+        <td rowspan=2>5 &times; 4
     <tr>
         <td>{{GPUTextureFormat/astc-5x4-unorm-srgb}}
     <tr>
         <td>{{GPUTextureFormat/astc-5x5-unorm}}
         <td rowspan=2>16
-	<td rowspan=2>5 &times; 5
+        <td rowspan=2>5 &times; 5
     <tr>
         <td>{{GPUTextureFormat/astc-5x5-unorm-srgb}}
     <tr>
         <td>{{GPUTextureFormat/astc-6x5-unorm}}
         <td rowspan=2>16
-	<td rowspan=2>6 &times; 5
+        <td rowspan=2>6 &times; 5
     <tr>
         <td>{{GPUTextureFormat/astc-6x5-unorm-srgb}}
     <tr>
         <td>{{GPUTextureFormat/astc-6x6-unorm}}
         <td rowspan=2>16
-	<td rowspan=2>6 &times; 6
+        <td rowspan=2>6 &times; 6
     <tr>
         <td>{{GPUTextureFormat/astc-6x6-unorm-srgb}}
     <tr>
         <td>{{GPUTextureFormat/astc-8x5-unorm}}
         <td rowspan=2>16
-	<td rowspan=2>8 &times; 5
+        <td rowspan=2>8 &times; 5
     <tr>
         <td>{{GPUTextureFormat/astc-8x5-unorm-srgb}}
     <tr>
         <td>{{GPUTextureFormat/astc-8x6-unorm}}
         <td rowspan=2>16
-	<td rowspan=2>8 &times; 6
+        <td rowspan=2>8 &times; 6
     <tr>
         <td>{{GPUTextureFormat/astc-8x6-unorm-srgb}}
     <tr>
         <td>{{GPUTextureFormat/astc-8x8-unorm}}
         <td rowspan=2>16
-	<td rowspan=2>8 &times; 8
+        <td rowspan=2>8 &times; 8
     <tr>
         <td>{{GPUTextureFormat/astc-8x8-unorm-srgb}}
     <tr>
         <td>{{GPUTextureFormat/astc-10x5-unorm}}
         <td rowspan=2>16
-	<td rowspan=2>10 &times; 5
+        <td rowspan=2>10 &times; 5
     <tr>
         <td>{{GPUTextureFormat/astc-10x5-unorm-srgb}}
     <tr>
         <td>{{GPUTextureFormat/astc-10x6-unorm}}
         <td rowspan=2>16
-	<td rowspan=2>10 &times; 6
+        <td rowspan=2>10 &times; 6
     <tr>
         <td>{{GPUTextureFormat/astc-10x6-unorm-srgb}}
     <tr>
         <td>{{GPUTextureFormat/astc-10x8-unorm}}
         <td rowspan=2>16
-	<td rowspan=2>10 &times; 8
+        <td rowspan=2>10 &times; 8
     <tr>
         <td>{{GPUTextureFormat/astc-10x8-unorm-srgb}}
     <tr>
         <td>{{GPUTextureFormat/astc-10x10-unorm}}
-	<td rowspan=2>10 &times; 10
+        <td rowspan=2>16
+        <td rowspan=2>10 &times; 10
     <tr>
         <td>{{GPUTextureFormat/astc-10x10-unorm-srgb}}
     <tr>
         <td>{{GPUTextureFormat/astc-12x10-unorm}}
         <td rowspan=2>16
-	<td rowspan=2>12 &times; 10
+        <td rowspan=2>12 &times; 10
     <tr>
         <td>{{GPUTextureFormat/astc-12x10-unorm-srgb}}
     <tr>
         <td>{{GPUTextureFormat/astc-12x12-unorm}}
         <td rowspan=2>16
-	<td rowspan=2>12 &times; 12
+        <td rowspan=2>12 &times; 12
     <tr>
         <td>{{GPUTextureFormat/astc-12x12-unorm-srgb}}
 </table>


### PR DESCRIPTION
* Updates feature name sections to use quotes to remove redundant entries added in the index


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lokokung/gpuweb/pull/2180.html" title="Last updated on Oct 13, 2021, 6:20 PM UTC (1e77d58)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2180/52c1f0d...lokokung:1e77d58.html" title="Last updated on Oct 13, 2021, 6:20 PM UTC (1e77d58)">Diff</a>