### PR TITLE
Integral pipeline IO must be specified interpolate(flat)

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6122,8 +6122,8 @@ For user-defined IO of scalar or vector floating-point type:
          * Any interpolation sampling is valid.
          * If interpolation sampling is not specified, `center` is assumed.
 
-User-defined IO of scalar or vector integer type is always
-`[[interpolate(flat)]]` and, therefore, must not be specified in a [SHORTNAME] program.
+User-defined IO of scalar or vector integer type must always be specified as
+`[[interpolate(flat)]]`.
 
 Interpolation attributes must match between [=vertex=] outputs and [=fragment=]
 inputs with the same [=attribute/location=] assignment within the same [=pipeline=].
@@ -6182,7 +6182,7 @@ User-defined IO can be mixed with builtin variables in the same structure. For e
     struct MyInputs {
       [[location(0)]] x: vec4<f32>;
       [[builtin(front_facing)]] y: bool;
-      [[location(1)]] z: u32;
+      [[location(1),interpolate(flat)]] z: u32;
     };
 
     struct MyOutputs {
@@ -6200,9 +6200,9 @@ User-defined IO can be mixed with builtin variables in the same structure. For e
 <div class='example invalid locations' heading='Invalid location assignments'>
   <xmp>
     struct A {
-      [[location(0)]] x: u32;
+      [[location(0)]] x: f32;
       // Invalid, x and y cannot share a location.
-      [[location(0)]] y: u32;
+      [[location(0)]] y: f32;
     };
 
     struct B {


### PR DESCRIPTION
Fixes: #2061