### PR TITLE
Use consistent repeat expression

### DIFF
--- a/wgsl/extract-grammar.py
+++ b/wgsl/extract-grammar.py
@@ -257,12 +257,6 @@ def grammar_from_rule_item(rule_item):
         i_item = ""
         if rule_item[i].startswith("[=syntax/"):
             i_item = rule_item[i].split("[=syntax/")[1].split("=]")[0]
-            if i_item.endswith("s") and i_item[:-1] in scanner_components[scanner_rule.name()]:
-                i_item = i_item[:-1]
-                i_repeatone = True
-            elif i_item.endswith("es") and i_item[:-2] in scanner_components[scanner_rule.name()]:
-                i_item = i_item[:-2]
-                i_repeatone = True
             i_item = f"$.{i_item}"
         elif rule_item[i].startswith("`/"):
             i_item = f"token({rule_item[i][1:-1]})"

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -412,7 +412,7 @@ To parse a [SHORTNAME] program:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>translation_unit</dfn> :
 
-    | [=syntax/global_decl_or_directives=] ?
+    | [=syntax/global_decl_or_directive=] *
 </div>
 
 A [=shader-creation error=] results if:
@@ -1184,7 +1184,7 @@ Restrictions on runtime-sized arrays:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>array_type_decl</dfn> :
 
-    | [=syntax/attribute_lists=] ? [=syntax/array=] [=syntax/less_than=] [=syntax/type_decl=] ( [=syntax/comma=] [=syntax/element_count_expression=] ) ? [=syntax/greater_than=]
+    | [=syntax/attribute_list=] * [=syntax/array=] [=syntax/less_than=] [=syntax/type_decl=] ( [=syntax/comma=] [=syntax/element_count_expression=] ) ? [=syntax/greater_than=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>element_count_expression</dfn> :
@@ -1241,17 +1241,17 @@ Similarly, the same limitations apply to textures and samplers.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>struct_decl</dfn> :
 
-    | [=syntax/attribute_lists=] ? [=syntax/struct=] [=syntax/ident=] [=syntax/struct_body_decl=]
+    | [=syntax/attribute_list=] * [=syntax/struct=] [=syntax/ident=] [=syntax/struct_body_decl=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>struct_body_decl</dfn> :
 
-    | [=syntax/brace_left=] [=syntax/struct_members=] ? [=syntax/brace_right=]
+    | [=syntax/brace_left=] [=syntax/struct_member=] * [=syntax/brace_right=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>struct_member</dfn> :
 
-    | [=syntax/attribute_lists=] ? [=syntax/variable_ident_decl=] [=syntax/semicolon=]
+    | [=syntax/attribute_list=] * [=syntax/variable_ident_decl=] [=syntax/semicolon=]
 </div>
 
 [SHORTNAME] defines the following attributes that can be applied to structure types:
@@ -3152,7 +3152,7 @@ must not be written in [SHORTNAME] source text. See [[#access-mode-defaults]].
 <div class='syntax' noexport='true'>
   <dfn for=syntax>variable_ident_decl</dfn> :
 
-    | [=syntax/ident=] [=syntax/colon=] [=syntax/attribute_lists=] ? [=syntax/type_decl=]
+    | [=syntax/ident=] [=syntax/colon=] [=syntax/attribute_list=] * [=syntax/type_decl=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>variable_qualifier</dfn> :
@@ -3275,7 +3275,7 @@ Such variables are declared with [=attribute/group=] and [=attribute/binding=] d
 <div class='syntax' noexport='true'>
   <dfn for=syntax>global_variable_decl</dfn> :
 
-    | [=syntax/attribute_lists=] ? [=syntax/variable_decl=] ( [=syntax/equal=] [=syntax/const_expression=] ) ?
+    | [=syntax/attribute_list=] * [=syntax/variable_decl=] ( [=syntax/equal=] [=syntax/const_expression=] ) ?
 </div>
 
 <div class='example' heading="Variable Decorations">
@@ -3353,7 +3353,7 @@ is the one from the constant's declaration or from a pipeline override.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>global_constant_decl</dfn> :
 
-    | [=syntax/attribute_lists=] ? [=syntax/let=] ( [=syntax/ident=] | [=syntax/variable_ident_decl=] ) [=syntax/global_const_initializer=] ?
+    | [=syntax/attribute_list=] * [=syntax/let=] ( [=syntax/ident=] | [=syntax/variable_ident_decl=] ) [=syntax/global_const_initializer=] ?
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>global_const_initializer</dfn> :
@@ -5028,7 +5028,7 @@ from the start of the next statement until the end of the compound statement.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>compound_statement</dfn> :
 
-    | [=syntax/brace_left=] [=syntax/statements=] ? [=syntax/brace_right=]
+    | [=syntax/brace_left=] [=syntax/statement=] * [=syntax/brace_right=]
 </div>
 
 ## Assignment Statement ## {#assignment}
@@ -5216,7 +5216,7 @@ An `if` statement is executed as follows:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>switch_statement</dfn> :
 
-    | [=syntax/switch=] [=syntax/paren_expression=] [=syntax/brace_left=] [=syntax/switch_bodys=] [=syntax/brace_right=]
+    | [=syntax/switch=] [=syntax/paren_expression=] [=syntax/brace_left=] [=syntax/switch_body=] + [=syntax/brace_right=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>switch_body</dfn> :
@@ -5274,7 +5274,7 @@ which are reachable via a `fallthrough` statement.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>loop_statement</dfn> :
 
-    | [=syntax/loop=] [=syntax/brace_left=] [=syntax/statements=] ? [=syntax/continuing_statement=] ? [=syntax/brace_right=]
+    | [=syntax/loop=] [=syntax/brace_left=] [=syntax/statement=] * [=syntax/continuing_statement=] ? [=syntax/brace_right=]
 </div>
 
 A <dfn noexport dfn-for="statement">loop</dfn> statement repeatedly executes a <dfn noexport>loop body</dfn>;
@@ -5736,12 +5736,12 @@ If the return type is specified, then:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>function_decl</dfn> :
 
-    | [=syntax/attribute_lists=] ? [=syntax/function_header=] [=syntax/compound_statement=]
+    | [=syntax/attribute_list=] * [=syntax/function_header=] [=syntax/compound_statement=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>function_header</dfn> :
 
-    | [=syntax/fn=] [=syntax/ident=] [=syntax/paren_left=] [=syntax/param_list=] ? [=syntax/paren_right=] ( [=syntax/arrow=] [=syntax/attribute_lists=] ? [=syntax/type_decl=] ) ?
+    | [=syntax/fn=] [=syntax/ident=] [=syntax/paren_left=] [=syntax/param_list=] ? [=syntax/paren_right=] ( [=syntax/arrow=] [=syntax/attribute_list=] * [=syntax/type_decl=] ) ?
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>param_list</dfn> :
@@ -5751,7 +5751,7 @@ If the return type is specified, then:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>param</dfn> :
 
-    | [=syntax/attribute_lists=] ? [=syntax/variable_ident_decl=]
+    | [=syntax/attribute_list=] * [=syntax/variable_ident_decl=]
 </div>
 
 [SHORTNAME] defines the following attributes that can be applied to function declarations:

--- a/wgsl/wgsl_spec_style_guide.md
+++ b/wgsl/wgsl_spec_style_guide.md
@@ -98,8 +98,7 @@ and then place the rule name between `` <dfn for=syntax> `` and `` </dfn> : `` o
 * Each syntactic rule item must be surrounded by only a space before and after,
 trailing space at the end of the line being redundant.
 * Members of syntactic rules items can be references to existing rules. These must be placed between
-`` [=syntax/ `` and `` =] ``, and the referenced name can be suffixed by pluralizing `` s `` or `` es ``
-to be repeating as at least one or more of the rule.
+`` [=syntax/ `` and `` =] ``.
 * Members of syntactic rules can contain groups which should contain the group members between `` ( `` and `` ) ``.
 * Members of syntactic rule items which denote a string should start with `` `' ``
 and end with `` '` `` and not contain any space character or line break between these two.
@@ -108,7 +107,6 @@ and end with `` /` `` and not contain any space character or line break between 
 * If a member is optional, then it must be followed by a `` ? `` member token.
 * If a member can repeat and must appear at least once, then it must be followed by a `` + `` member token.
 * If a member can repeat and does not have to appear, then it must be followed by a `` * `` member token.
-    * To realize this with pluralized reference, follow the reference member by a `` ? `` member token.
 
 ## Tagging conventions
 


### PR DESCRIPTION
This PR makes the spec not give meaning to pluralizing morpheme in syntactic rules and always use + or * for repeat rules.

For https://github.com/gpuweb/gpuweb/issues/2184 issue.