### PR TITLE
Add validation rules for RenderBundleEncoderDescriptor

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7918,7 +7918,17 @@ GPURenderBundleEncoder includes GPURenderEncoderBase;
                 1. If any of the following conditions are unsatisfied, generate a validation
                     error and stop.
                     <div class=validusage>
-                        Issue: Add remaining validation.
+                        - |descriptor|.{{GPURenderPassLayout/colorFormats}}.length must be less than or equal to 8.
+                        - |descriptor|.{{GPURenderPassLayout/colorFormats}}.length must be greater than `0` or
+                            |descriptor|.{{GPURenderPassLayout/depthStencilFormat}} must not be `null`.
+                        - For each |colorFormat| in |descriptor|.{{GPURenderPassLayout/colorFormats}}:
+                            - |colorFormat| must be a [=color renderable format=].
+                        - Let |depthStencilFormat| be |descriptor|.{{GPURenderPassLayout/depthStencilFormat}}.
+                        - If |depthStencilFormat| is not `null`:
+                            - |depthStencilFormat| must be a [=depth or stencil renderable format=].
+                            - If |depthStencilFormat| contains both depth and stencil aspects (See [[#depth-formats|depth-stencil formats]]):
+                                - |descriptor|.{{GPURenderBundleEncoderDescriptor/depthReadOnly}} must be equal to
+                                    |descriptor|.{{GPURenderBundleEncoderDescriptor/stencilReadOnly}}
                     </div>
                 1. Let |e| be a new {{GPURenderBundleEncoder}} object.
                 1. Set |e|.{{GPURenderEncoderBase/[[layout]]}} to |descriptor|.{{GPURenderPassLayout}}.


### PR DESCRIPTION
The validation rules for RenderBundleEncoderDescriptor are quite
similar to validation rules for RenderPassDescriptor. The validation
rules for the latter is more complicated because RenderPassDescriptor
has more parameters for validation, though.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Richard-Yunchao/gpuweb/pull/2186.html" title="Last updated on Oct 15, 2021, 1:07 AM UTC (6134f4c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2186/775b924...Richard-Yunchao:6134f4c.html" title="Last updated on Oct 15, 2021, 1:07 AM UTC (6134f4c)">Diff</a>