### PR TITLE
wgsl: OpXMod -> OpXRem for integers

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4441,11 +4441,11 @@ references to arrays. An array not behind a reference may only be indexed by a
   <tr algorithm="signed integer remainder">
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [SIGNEDINTEGRAL]
     <td>|e1| `%` |e2| : |T|
-    <td>Signed integer remainder. [=Component-wise=] when |T| is a vector. (OpSMod)
+    <td>Signed integer remainder. [=Component-wise=] when |T| is a vector. (OpSRem)
   <tr algorithm="unsigned integer modulus">
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [UNSIGNEDINTEGRAL]
     <td>|e1| `%` |e2| : |T|
-    <td>Unsigned integer remainder. [=Component-wise=] when |T| is a vector. (OpUMod)
+    <td>Unsigned integer remainder. [=Component-wise=] when |T| is a vector. (OpURem)
   <tr algorithm="floating point remainder">
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [FLOATING]
     <td>|e1| `%` |e2| : |T|


### PR DESCRIPTION
Should we change OpSMod -> OpSRem and OpUMod -> OpURem for *integers*?

Motivation:
1. Making WGSL more consistent. Currently we have different conventions for floats and int's.
2. C/Javascript using OpXRem for integers. Spir-V require non-negative numbers so OpSRem===OpSMod there.
3. You not removing OpSMod operation according to https://github.com/gpuweb/gpuweb/pull/1763#issuecomment-857767108

Conclusion:

* OpUMod and OpURem is literally the same so just editorial change.

* OpSRem not defined in Spir-V for non-negative numbers so basically the same too with exception.
If you going to emulate it. OpSRem looks simple `x - y * (x / y)`, but proper emulation for OpSMod looks wierd: `if (y < 0) { x = -x; y = -y; }; r = (x >= 0) ? x / y : ((x + 1) / x) - 1; r = x - y * r;`. I believe that all shader languages uses the same rounding in division? Because otherwise we will have problems with emulation and integer division consistency between backends.

Little bit related issue: #1696, #1763.
This issue not related to float fmod (which is much more useful for webgl users and frequently requested)