### PR TITLE
timestamp-query is unimplementable on TBDR architectures

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5644,11 +5644,11 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                         - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
                         - |descriptor| meets the
                             [$GPURenderPassDescriptor/Valid Usage$] rules.
-                        - |descriptor|.{{GPURenderPassDescriptor/timestampAttachments}} is empty, or
+                        - |descriptor|.{{GPURenderPassDescriptor/timestampWrites}} is empty, or
                             |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} [=list/contain=]s
                             {{GPUFeatureName/"timestamp-query"}}.
-                        - For each |timestampAttachment| in |descriptor|.{{GPURenderPassDescriptor/timestampAttachments}},
-                            - |timestampAttachment|.{{GPURenderPassTimestampAttachment/querySet}} is [$valid to use with$] |this|.
+                        - For each |timestampWrite| in |descriptor|.{{GPURenderPassDescriptor/timestampWrites}},
+                            - |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}} is [$valid to use with$] |this|.
                     </div>
                 1. Set |this|.{{GPUCommandEncoder/[[state]]}} to {{encoder state/encoding a render pass}}.
                 1. For each |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
@@ -5667,14 +5667,14 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                     1. Set |pass|.{{GPURenderEncoderBase/[[depthReadOnly]]}} to |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}}.
                     1. Set |pass|.{{GPURenderEncoderBase/[[stencilReadOnly]]}} to |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}}.
                 1. Set |pass|.{{GPURenderEncoderBase/[[layout]]}} to [$derive render targets layout from pass$](|descriptor|).
-                1. For each |timestampAttachment| in |descriptor|.{{GPURenderPassDescriptor/timestampAttachments}},
-                    1. If |timestampAttachment|.{{GPURenderPassTimestampAttachment/location}} is {{GPURenderPassTimestampLocation/"beginning"}},
+                1. For each |timestampWrite| in |descriptor|.{{GPURenderPassDescriptor/timestampWrites}},
+                    1. If |timestampWrite|.{{GPURenderPassTimestampWrite/location}} is {{GPURenderPassTimestampLocation/"beginning"}},
                         [=list/Append=] a [=GPU command=] to
                         |pass|.{{GPUProgrammablePassEncoder/[[command_encoder]]}}.{{GPUCommandEncoder/[[command_list]]}}
-                        that writes the GPU's timestamp value into the |timestampAttachment|.{{GPURenderPassTimestampAttachment/queryIndex}}th
-                        index in |timestampAttachment|.{{GPURenderPassTimestampAttachment/querySet}}.
-                    1. Otherwise, if |timestampAttachment|.{{GPURenderPassTimestampAttachment/location}} is {{GPURenderPassTimestampLocation/"end"}},
-                        [=list/Append=] |timestampAttachment| to |pass|.{{GPURenderPassEncoder/[[endTimestampAttachments]]}}.
+                        that writes the GPU's timestamp value into the |timestampWrite|.{{GPURenderPassTimestampWrite/queryIndex}}th
+                        index in |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}}.
+                    1. Otherwise, if |timestampWrite|.{{GPURenderPassTimestampWrite/location}} is {{GPURenderPassTimestampLocation/"end"}},
+                        [=list/Append=] |timestampWrite| to |pass|.{{GPURenderPassEncoder/[[endTimestampWrites]]}}.
                 1. Return |pass|.
             </div>
 
@@ -5702,22 +5702,22 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                     error and stop.
                     <div class=validusage>
                         - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
-                        - |descriptor|.{{GPUComputePassDescriptor/timestampAttachments}} is empty, or
+                        - |descriptor|.{{GPUComputePassDescriptor/timestampWrites}} is empty, or
                             |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} [=list/contain=]s
                             {{GPUFeatureName/"timestamp-query"}}.
-                        - For each |timestampAttachment| in |descriptor|.{{GPUComputePassDescriptor/timestampAttachments}},
-                            - |timestampAttachment|.{{GPUComputePassTimestampAttachment/querySet}} is [$valid to use with$] |this|.
+                        - For each |timestampWrite| in |descriptor|.{{GPUComputePassDescriptor/timestampWrites}},
+                            - |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}} is [$valid to use with$] |this|.
                     </div>
                 1. Set |this|.{{GPUCommandEncoder/[[state]]}} to {{encoder state/encoding a compute pass}}.
                 1. Let |pass| be a new {{GPUComputePassEncoder}} object.
-                1. For each |timestampAttachment| in |descriptor|.{{GPUComputePassDescriptor/timestampAttachments}},
-                    1. If |timestampAttachment|.{{GPUComputePassTimestampAttachment/location}} is {{GPUComputePassTimestampLocation/"beginning"}},
+                1. For each |timestampWrite| in |descriptor|.{{GPUComputePassDescriptor/timestampWrites}},
+                    1. If |timestampWrite|.{{GPUComputePassTimestampWrite/location}} is {{GPUComputePassTimestampLocation/"beginning"}},
                         [=list/Append=] a [=GPU command=] to
                         |pass|.{{GPUProgrammablePassEncoder/[[command_encoder]]}}.{{GPUCommandEncoder/[[command_list]]}}
-                        that writes the GPU's timestamp value into the |timestampAttachment|.{{GPUComputePassTimestampAttachment/queryIndex}}th
-                        index in |timestampAttachment|.{{GPUComputePassTimestampAttachment/querySet}}.
-                    1. Otherwise, if |timestampAttachment|.{{GPUComputePassTimestampAttachment/location}} is {{GPUComputePassTimestampLocation/"end"}},
-                        [=list/Append=] |timestampAttachment| to |pass|.{{GPUComputePassEncoder/[[endTimestampAttachments]]}}.
+                        that writes the GPU's timestamp value into the |timestampWrite|.{{GPUComputePassTimestampWrite/queryIndex}}th
+                        index in |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}}.
+                    1. Otherwise, if |timestampWrite|.{{GPUComputePassTimestampWrite/location}} is {{GPUComputePassTimestampLocation/"end"}},
+                        [=list/Append=] |timestampWrite| to |pass|.{{GPUComputePassEncoder/[[endTimestampWrites]]}}.
                 1. Return |pass|.
             </div>
         </div>
@@ -6683,7 +6683,7 @@ GPUComputePassEncoder includes GPUProgrammablePassEncoder;
     ::
         The current {{GPUComputePipeline}}, initially `null`.
 
-    : <dfn>\[[endTimestampAttachments]]</dfn>, of type sequence<{{GPUComputePassTimestampAttachment}}>
+    : <dfn>\[[endTimestampWrites]]</dfn>, of type {{GPUComputePassTimestampWrites}}
     ::
         The timestamp attachments which need to be executed when the pass ends.
 </dl>
@@ -6696,21 +6696,23 @@ enum GPUComputePassTimestampLocation {
     "end"
 };
 
-dictionary GPUComputePassTimestampAttachment {
+dictionary GPUComputePassTimestampWrite {
     required GPUQuerySet querySet;
     required GPUSize32 queryIndex;
     required GPUComputePassTimestampLocation location;
 };
 
+typedef sequence<GPUComputePassTimestampWrite> GPUComputePassTimestampWrites;
+
 dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
-    sequence<GPUComputePassTimestampAttachment> timestampAttachments = [];
+    GPUComputePassTimestampWrites timestampWrites = [];
 };
 </script>
 
 <dl dfn-type=dict-member dfn-for=GPUComputePassDescriptor>
-    : <dfn>timestampAttachments</dfn>
+    : <dfn>timestampWrites</dfn>
     ::
-        A sequence of {{GPUComputePassTimestampAttachment}} values define where and when timestamp values will be written for this pass.
+        A sequence of {{GPUComputePassTimestampWrite}} values define where and when timestamp values will be written for this pass.
 </dl>
 
 <div class=validusage dfn-for=GPUComputePassDescriptor>
@@ -6718,11 +6720,11 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
 
     Given a {{GPUComputePassDescriptor}} |this| the following validation rules apply:
 
-    1. For each |timestampAttachment| in |this|.{{GPUComputePassDescriptor/timestampAttachments}}:
+    1. For each |timestampWrite| in |this|.{{GPUComputePassDescriptor/timestampWrites}}:
 
-        1. |timestampAttachment|.{{GPUComputePassTimestampAttachment/querySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/"timestamp"}}.
+        1. |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/"timestamp"}}.
 
-        1. |timestampAttachment|.{{GPUComputePassTimestampAttachment/queryIndex}} &lt; |timestampAttachment|.{{GPUComputePassTimestampAttachment/querySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}}.
+        1. |timestampWrite|.{{GPUComputePassTimestampWrite/queryIndex}} &lt; |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}}.
 </div>
 
 ### Dispatch ### {#compute-pass-encoder-dispatch}
@@ -6901,12 +6903,12 @@ called the compute pass encoder can no longer be used.
 
                         Issue: Add remaining validation.
                     </div>
-                1. For each |timestampAttachment| in |this|.{{GPUComputePassEncoder/[[endTimestampAttachments]]}},
-                    1. (|timestampAttachment|.{{GPUComputePassTimestampAttachment/location}} must equal {{GPUComputePassTimestampLocation/"end"}}.)
+                1. For each |timestampWrite| in |this|.{{GPUComputePassEncoder/[[endTimestampWrites]]}},
+                    1. (|timestampWrite|.{{GPUComputePassTimestampWrite/location}} must equal {{GPUComputePassTimestampLocation/"end"}}.)
                     1. [=list/Append=] a [=GPU command=] to
                         |this|.{{GPUProgrammablePassEncoder/[[command_encoder]]}}.{{GPUCommandEncoder/[[command_list]]}}
-                        that writes the GPU's timestamp value into the |timestampAttachment|.{{GPUComputePassTimestampAttachment/queryIndex}}th
-                        index in |timestampAttachment|.{{GPUComputePassTimestampAttachment/querySet}}.
+                        that writes the GPU's timestamp value into the |timestampWrite|.{{GPUComputePassTimestampWrite/queryIndex}}th
+                        index in |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}}.
             </div>
         </div>
 </dl>
@@ -7024,7 +7026,7 @@ GPURenderPassEncoder includes GPURenderEncoderBase;
     : <dfn>\[[viewport]]</dfn>
     ::  Current viewport rectangle and depth range.
 
-    : <dfn>\[[endTimestampAttachments]]</dfn>, of type sequence<{{GPURenderPassTimestampAttachment}}>
+    : <dfn>\[[endTimestampWrites]]</dfn>, of type {{GPURenderPassTimestampWrites}}
     ::
         The timestamp attachments which need to be executed when the pass ends.
 </dl>
@@ -7046,17 +7048,19 @@ enum GPURenderPassTimestampLocation {
     "end"
 };
 
-dictionary GPURenderPassTimestampAttachment {
+dictionary GPURenderPassTimestampWrite {
     required GPUQuerySet querySet;
     required GPUSize32 queryIndex;
     required GPURenderPassTimestampLocation location;
 };
 
+typedef sequence<GPURenderPassTimestampWrite> GPURenderPassTimestampWrites;
+
 dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
     required sequence<GPURenderPassColorAttachment> colorAttachments;
     GPURenderPassDepthStencilAttachment depthStencilAttachment;
     GPUQuerySet occlusionQuerySet;
-    sequence<GPURenderPassTimestampAttachment> timestampAttachments = [];
+    GPURenderPassTimestampWrites timestampWrites = [];
 };
 </script>
 
@@ -7075,9 +7079,9 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
     ::
         The {{GPUQuerySet}} value defines where the occlusion query results will be stored for this pass.
 
-    : <dfn>timestampAttachments</dfn>
+    : <dfn>timestampWrites</dfn>
     ::
-        A sequence of {{GPURenderPassTimestampAttachment}} values define where and when timestamp values will be written for this pass.
+        A sequence of {{GPURenderPassTimestampWrite}} values defines where and when timestamp values will be written for this pass.
 </dl>
 
 <div class=validusage dfn-for=GPURenderPassDescriptor>
@@ -7109,11 +7113,11 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
         1. |this|.{{GPURenderPassDescriptor/occlusionQuerySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/type}}
             must be {{GPUQueryType/occlusion}}.
 
-    1. For each |timestampAttachment| in |this|.{{GPURenderPassDescriptor/timestampAttachments}}:
+    1. For each |timestampWrite| in |this|.{{GPURenderPassDescriptor/timestampWrites}}:
 
-        1. |timestampAttachment|.{{GPURenderPassTimestampAttachment/querySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/"timestamp"}}.
+        1. |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/"timestamp"}}.
 
-        1. |timestampAttachment|.{{GPURenderPassTimestampAttachment/queryIndex}} &lt; |timestampAttachment|.{{GPURenderPassTimestampAttachment/querySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}}.
+        1. |timestampWrite|.{{GPURenderPassTimestampWrite/queryIndex}} &lt; |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}}.
 
     Issue(gpuweb/gpuweb#503): support for no attachments
 </div>
@@ -7943,12 +7947,12 @@ called the render pass encoder can no longer be used.
 
                         Issue: Add remaining validation.
                     </div>
-                1. For each |timestampAttachment| in |this|.{{GPURenderPassEncoder/[[endTimestampAttachments]]}},
-                    1. (|timestampAttachment|.{{GPURenderPassTimestampAttachment/location}} must equal {{GPURenderPassTimestampLocation/"end"}}.)
+                1. For each |timestampWrite| in |this|.{{GPURenderPassEncoder/[[endTimestampWrites]]}},
+                    1. (|timestampWrite|.{{GPURenderPassTimestampWrite/location}} must equal {{GPURenderPassTimestampLocation/"end"}}.)
                     1. [=list/Append=] a [=GPU command=] to
                         |this|.{{GPUProgrammablePassEncoder/[[command_encoder]]}}.{{GPUCommandEncoder/[[command_list]]}}
-                        that writes the GPU's timestamp value into the |timestampAttachment|.{{GPURenderPassTimestampAttachment/queryIndex}}th
-                        index in |timestampAttachment|.{{GPURenderPassTimestampAttachment/querySet}}.
+                        that writes the GPU's timestamp value into the |timestampWrite|.{{GPURenderPassTimestampWrite/queryIndex}}th
+                        index in |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}}.
 
                 Issue: Enqueue the attachment stores (with storeOp clear).
             </div>


### PR DESCRIPTION
There are 2 patches in this pull request:

1. The first half of https://github.com/gpuweb/gpuweb/issues/2046#issuecomment-928546660. This patch removes `GPUComputePassEncoder/writeTimestamp()` and `GPURenderPassEncoder/writeTimestamp()`, but leaves in `GPUCommandEncoder/writeTimestamp()`.
2. The second half of https://github.com/gpuweb/gpuweb/issues/2046#issuecomment-928546660. This patch adds in the changes described in https://github.com/gpuweb/gpuweb/issues/2046#issuecomment-905184438.

Fixes https://github.com/gpuweb/gpuweb/issues/2046.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/litherum/gpuweb/pull/2190.html" title="Last updated on Oct 22, 2021, 7:08 PM UTC (05a21f1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2190/21de381...litherum:05a21f1.html" title="Last updated on Oct 22, 2021, 7:08 PM UTC (05a21f1)">Diff</a>