### PR TITLE
Minor typo "a memory allocations"

### DIFF
--- a/explainer/index.bs
+++ b/explainer/index.bs
@@ -607,7 +607,7 @@ Issue: Finish this explainer (see [ErrorHandling.md](https://github.com/gpuweb/g
 
 ## Buffer Mapping ## {#buffer-mapping}
 
-A `GPUBuffer` represents a memory allocations usable by other GPU operations.
+A `GPUBuffer` represents a memory allocation usable by other GPU operations.
 This memory can be accessed linearly, contrary to `GPUTexture` for which the actual memory layout of sequences of texels are unknown. Think of `GPUBuffers` as the result of `gpu_malloc()`.
 
 **CPU&rarr;GPU:** When using WebGPU, applications need to transfer data from JavaScript to `GPUBuffer` very often and potentially in large quantities.


### PR DESCRIPTION
Just fixing a minor typo in the following sentence in the buffer mapping section of the WebGPU explainer (https://gpuweb.github.io/gpuweb/explainer/#buffer-mapping):

> A `GPUBuffer` represents a memory allocations usable by other GPU operations.

