### PR TITLE
Add validation rules for RenderBundleEncoder.finish()

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8057,7 +8057,7 @@ dictionary GPURenderBundleEncoderDescriptor : GPURenderPassLayout {
                             - |this| must be [=valid=].
                             - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}'s [=stack/size=] must be 0.
                             - |this|.{{GPURenderBundleEncoder/[[state]]}} must be [=render bundle state/open=].
-                            - Every [=usage scope=] contained in |this| satisfies the [=usage scope validation=].
+                            - Every [=usage scope=] contained in |this| must satisfy the [=usage scope validation=].
                         </div>
 
                     1. Set |this|.{{GPURenderBundleEncoder/[[state]]}} to [=render bundle state/closed=].


### PR DESCRIPTION
It also adds some internal slots in RenderBundleEncoder and
RenderBundle.

The validation rules are very similar to CommandEncoder.finish().


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Richard-Yunchao/gpuweb/pull/2198.html" title="Last updated on Oct 29, 2021, 1:34 AM UTC (b6d5a32)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2198/f568815...Richard-Yunchao:b6d5a32.html" title="Last updated on Oct 29, 2021, 1:34 AM UTC (b6d5a32)">Diff</a>