### PR TITLE
wgsl: decimal point is optional in float literal having an exponent

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -453,7 +453,7 @@ The form of a [=numeric literal=] is defined via pattern-matching:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>decimal_float_literal</dfn> :
 
-    | `/(-?[0-9]*\.[0-9]+|-?[0-9]+\.[0-9]*)((e|E)(\+|-)?[0-9]+)?/`
+    | `/((-?[0-9]*\.[0-9]+|-?[0-9]+\.[0-9]*)((e|E)(\+|-)?[0-9]+)?)|(-?[0-9]+(e|E)(\+|-)?[0-9]+)/`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>hex_float_literal</dfn> :


### PR DESCRIPTION
Resolves the original complaint of #775