### PR TITLE
Remove pipeline compability section

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6358,14 +6358,6 @@ type that is the store type of a storage buffer variable.
 
 TODO: Describe other interface matching requirements, e.g. for images?
 
-## Pipeline compatibility TODO ## {#pipeline-compatibility}
-
-TODO: match flat attribute
-
-TODO: user data inputs of fragment stage must be subset of user data outputs of vertex stage
-
-### Input-output matching rules TODO ### {#input-output-matching}
-
 # Language extensions # {#language-extensions}
 
 The [SHORTNAME] language is expected to evolve over time.


### PR DESCRIPTION
* Rules are fully documented and more appropriate in the API spec