### PR TITLE
Add GPUComandEncoder.fillBuffer()

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5999,7 +5999,6 @@ dictionary GPUImageCopyExternalImage {
                 - |destination|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/COPY_DST}}.
                 - |size| is a multiple of 4.
                 - |destinationOffset| is a multiple of 4.
-                - (|destinationOffset| + |size|) does not overflow a {{GPUSize64}}.
                 - |destination|.{{GPUBuffer/[[size]]}} is greater than or equal to (|destinationOffset| + |size|).
             </div>
         </div>


### PR DESCRIPTION
Fixes https://github.com/gpuweb/gpuweb/issues/1968.

In the future, we can add a 4th parameter, `value`, of type `octet` or `byte`. For now, though, the group seems to have just agreed on zeroing, rather than filling with a particular byte.

There are two commits in this PR, one that requires `GPUBufferUsage.STORAGE` on the buffer, and a second that relaxes this requirement because of https://github.com/gpuweb/gpuweb/issues/1968#issuecomment-886988850.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/litherum/gpuweb/pull/2208.html" title="Last updated on Oct 26, 2021, 10:48 PM UTC (6f9ec61)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2208/b374906...litherum:6f9ec61.html" title="Last updated on Oct 26, 2021, 10:48 PM UTC (6f9ec61)">Diff</a>