### PR TITLE
Remove GPUCommandBuffer.executionTime

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5435,38 +5435,9 @@ setting state, drawing, copying resources, etc.
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUCommandBuffer {
-    readonly attribute Promise<double> executionTime;
 };
 GPUCommandBuffer includes GPUObjectBase;
 </script>
-
-{{GPUCommandBuffer}} has the following attributes:
-
-<dl dfn-type=attribute dfn-for="GPUCommandBuffer">
-    : <dfn>executionTime</dfn>
-    ::
-        The total time, in seconds, that the GPU took to execute this command buffer.
-
-        Note:
-        If {{GPUCommandEncoderDescriptor/measureExecutionTime}} is `true`,
-        this resolves after the command buffer executes.
-        Otherwise, this rejects with an {{OperationError}}.
-
-        <div class=issue>
-            Specify the creation and resolution of the promise.
-
-            In {{GPUCommandEncoder/finish()}}, it should be specified that a
-            new promise is created and stored in this attribute.
-            The promise starts rejected if {{GPUCommandEncoderDescriptor/measureExecutionTime}}
-            is `false`. If the finish() fails, then the promise resolves to 0.
-
-            In {{GPUQueue/submit()}}, it should be specified that (if
-            {{GPUCommandEncoderDescriptor/measureExecutionTime}} is set), work
-            is issued to read back the execution time, and, when that completes,
-            the promise is resolved with that value.
-            If the submit() fails, then the promise resolves to 0.
-        </div>
-</dl>
 
 {{GPUCommandBuffer}} has the following internal slots:
 
@@ -5589,15 +5560,8 @@ which may be one of the following:
 
 <script type=idl>
 dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
-    boolean measureExecutionTime = false;
 };
 </script>
-
-<dl dfn-type=dict-member dfn-for=GPUCommandEncoderDescriptor>
-    : <dfn>measureExecutionTime</dfn>
-    ::
-        Enable measurement of the GPU execution time of the entire command buffer.
-</dl>
 
 <dl dfn-type=method dfn-for=GPUDevice>
     : <dfn>createCommandEncoder(descriptor)</dfn>


### PR DESCRIPTION
Fixes #2156


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/2214.html" title="Last updated on Oct 25, 2021, 8:43 PM UTC (b1d2ba4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2214/b374906...b1d2ba4.html" title="Last updated on Oct 25, 2021, 8:43 PM UTC (b1d2ba4)">Diff</a>