### PR TITLE
Behaviours analysis

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5752,7 +5752,7 @@ The reason is that only functions without a return type can have such a behavior
   <tr>
     <td class="nowrap">*s1* ; *s2*
     <td class="nowrap">*s1*: *B1*<br>
-        Default in B1<br>
+        Default in *B1*<br>
         *s2*: *B2*
     <td class="nowrap">*B1*\{Default} U *B2*
   <tr>
@@ -5818,6 +5818,7 @@ The reason is that only functions without a return type can have such a behavior
         *s_1*: *B_1*<br>
         ...<br>
         *s_n*: *B_n*<br>
+        Fallthrough is not in *B_n*
     <td class="nowrap">let b = *B* \ {Default} U B_1 U ... U B_n;<br>
         if (Fallthrough in b) b = b \ {Fallthrough};<br>
         if (Break in b) b = b \ {Break} U {Default};<br>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5709,6 +5709,332 @@ Note: If the function [=return value|returns a value=], that value is ignored.
 </div>
 
 
+## Statements behavior analysis ## {#behaviors}
+
+Some statements affecting control-flow are only valid in some contexts.
+For example, `fallthrough` is invalid outside of a switch, and `continue` is invalid outside of a loop.
+Additionally, the uniformity analysis (see [[#uniformity]]) needs to know when control flow can exit a statement in two different ways.
+Both of these goals are achieved by a simple type system applied to statements.
+To avoid confusion with the types of expressions, we call the types of statements behaviors.
+
+A behavior is simply a set, whose elements may be:
+- Return
+- Discard
+- Break
+- Continue
+- Fallthrough
+- Default
+
+Each of those correspond with a way to exit a compound statement: either through a keyword, or by simply falling to the next statement ("Default").
+
+We note "*s*: *B*" to say that *s* respects the rules regarding behaviors, and has behavior *B*.
+
+For each function:
+- its body must be a valid statement by these rules
+- if it has a return type, its behavior must be one of {Return} or {Return, Discard}
+- otherwise, its behavior must be a subset of {Default, Return, Discard}
+
+We assign a behavior to each function: it is its body's behavior, with any "Return" replaced by "Default".
+As a consequence of the rules above, a function behavior is always one of {Default}, {Discard} or {Default, Discard}.
+
+
+Similarly, we assign a behavior to each expression, since expressions can include function calls, which can discard.
+Expression behaviors are always one of {Default}, {Discard}, or {Default, Discard}.
+
+Note: There is currently no valid program with an expression that has a behavior of {Discard}.
+The reason is that only functions without a return type can have such a behavior, and there is no compound expression in which such a function can be called.
+
+<table class='data'>
+  <caption>Rules for analyzing and validating the behaviors of statements</caption>
+  <thead>
+    <tr><th>Statement<th>Preconditions<th>Resulting behavior
+  </thead>
+  <tr>
+    <td class="nowrap">*s1* ; *s2*
+    <td class="nowrap">*s1*: *B1*<br>
+        Default in B1<br>
+        *s2*: *B2*
+    <td class="nowrap">*B1*\{Default} U *B2*
+  <tr>
+    <td class="nowrap">A variable declaration or assignment
+    <td>
+    <td>{Default}
+  <tr>
+    <td class="nowrap">f(*e_1*, ..., *e_n*);
+    <td class="nowrap">*e_1*: *B_1*<br>
+        ...<br>
+        *e_n*: *B_n*<br>
+        *f*'s body has behavior *B*
+    <td class="nowrap">*B* U (*B_1* U ... U *B_n*)\{Default}
+  <tr>
+    <td>return;
+    <td>
+    <td>{Return}
+  <tr>
+    <td class="nowrap">return *e*;
+    <td class="nowrap">*e*: *B*<br>
+    <td class="nowrap">*B*\{Default} U {Return}
+  <tr>
+    <td>discard;
+    <td>
+    <td>{Discard}
+  <tr>
+    <td>break;
+    <td>
+    <td>{Break}
+  <tr>
+    <td>continue;
+    <td>
+    <td>{Continue}
+  <tr>
+    <td>fallthrough;
+    <td>
+    <td>{Fallthrough}
+  <tr>
+    <td class="nowrap">if (*e*) *s1* else *s2*
+    <td class="nowrap">*e: B*<br>
+        *s1*: *B1*<br>
+        *s2*: *B2*
+    <td class="nowrap">*B*\{Default} U B1 U B2
+  <tr>
+    <td class="nowrap">loop {*s*}
+    <td class="nowrap">*s*: *B*
+    <td class="nowrap">let b = *B* \ {Default};<br>
+        if (Continue in b) b = b \ {Continue};<br>
+        if (Break in b) b = b \ {Break} U {Default};<br>
+        b
+  <tr>
+    <td class="nowrap">loop {*s1* continuing {*s2*}}
+    <td class="nowrap">*s1*: *B1*<br>
+        *s2*: *B2*<br>
+        None of {Break, Continue, Discard, Return} are in *B2*
+    <td class="nowrap">let b = (*B1* U *B2*) \ {Default};<br>
+        if (Continue in b) b = b \ {Continue};<br>
+        if (Break in b) b = b \ {Break} U {Default};<br>
+        b
+  <tr>
+    <td class="nowrap">switch(*e*) {case _: *s_1* ... case _: *s_n*}
+    <td class="nowrap">*e*: *B*<br>
+        *s_1*: *B_1*<br>
+        ...<br>
+        *s_n*: *B_n*<br>
+    <td class="nowrap">let b = *B* \ {Default} U B_1 U ... U B_n;<br>
+        if (Fallthrough in b) b = b \ {Fallthrough};<br>
+        if (Break in b) b = b \ {Break} U {Default};<br>
+        b
+</table>
+
+<table class='data'>
+  <caption>Rules for analyzing and validating the behaviors of expressions</caption>
+  <thead>
+    <tr><th>Expression<th>Preconditions<th>Resulting behavior
+  </thead>
+  <tr>
+    <td class="nowrap">f(*e_1*, ..., *e_n*)
+    <td class="nowrap">*e_1*: *B_1*<br>
+        ...<br>
+        *e_n*: *B_n*<br>
+        *f*'s body has behavior *B*
+    <td class="nowrap">*B* U (*B_1* U ... U *B_n*)\{Default}
+  <tr>
+    <td class="nowrap">Any literal
+    <td>
+    <td class="nowrap">{Default}
+  <tr>
+    <td class="nowrap">Any variable reference
+    <td>
+    <td class="nowrap">{Default}
+  <tr>
+    <td class="nowrap">e1[e2]
+    <td class="nowrap">*e1*: *B1*<br>
+        *e2*: *B2*
+    <td class="nowrap">*B1* U *B2*
+  <tr>
+    <td class="nowrap">e.field
+    <td class="nowrap">*e*: *B*
+    <td class="nowrap">*B*
+  <tr>
+    <td class="nowrap">e1 || e2
+    <td class="nowrap">*e1*: *B1*<br>
+        *e2*: *B2*
+    <td class="nowrap">*B1* U *B2*
+  <tr>
+    <td class="nowrap">e1 && e2
+    <td class="nowrap">*e1*: *B1*<br>
+        *e2*: *B2*
+    <td class="nowrap">*B1* U *B2*
+</table>
+
+All functions in the standard library count as having a body with behavior {Default}.
+
+This analysis can be run in linear time, by analyzing the call-graph bottom-up (since the behavior of a function call can depend on the function's code).
+
+Here are some examples showing this analysis in action:
+<div class='example wgsl expect-error' heading='Trivially dead code is rejected'>
+   <xmp highlight='rust'>
+    fn simple() -> i32 {
+      var a: i32;
+      return 0;  // Behaviours: {Return}
+      a = 1;     // Error: by the rule for sequences of statements, the previous statement should have a behavior that include "Default"
+      return 2;
+    }
+   </xmp>
+</div>
+
+<div class='example wgsl expect-error' heading='Compound statements are supported'>
+   <xmp highlight='rust'>
+    fn nested() -> i32 {
+      var a: i32;
+      {             // The start of a compound statement.
+        a = 2;      // Behaviours: {Default}
+        return 1;   // Behaviours: {Return}
+      }             // The compound statement as a whole has behavior {Return}
+      a = 1;        // Error: for the same reason as in the previous example, the previous statement is missing "Default" in its behavior
+      return 2;
+    }
+   </xmp>
+</div>
+
+<div class='example wgsl' heading='if/then behaves as if there is an empty else'>
+   <xmp highlight='rust'>
+    fn if_example() {
+      var a: i32 = 0;
+      loop {
+        if (a == 5) {
+          break;      // Behaviours: {Break}
+        }             // Behaviours of the whole if compound statement: {Break, Default}, as the if has an implicit empty else
+        a = a + 1;    // valid, as the previous statement had "Default" in its behavior
+      }
+    }
+   </xmp>
+</div>
+
+<div class='example wgsl expect-error' heading='if/then/else has the behavior of both sides'>
+   <xmp highlight='rust'>
+    fn if_example() {
+      var a: i32 = 0;
+      loop {
+        if (a == 5) {
+          break;      // Behaviours: {Break}
+        } else {
+          continue;   // Behaviours: {Continue}
+        }             // Behaviours of the whole if compound statement: {Break, Continue}
+        a = a + 1;    // Error: the previous statement is missing "Default" in its behavior
+      }
+    }
+   </xmp>
+</div>
+
+<div class='example wgsl' heading='Break in switch becomes Default'>
+   <xmp highlight='rust'>
+    fn switch_example() {
+      var a: i32 = 0;
+      switch (a) {
+        default: {
+          break;   // Behaviours: {Break}
+        }
+      }            // Behaviours: {Default}, as switch replaces Break by Default
+      a = 5;       // valid, as the previous statement had Default in its behavior
+    }
+   </xmp>
+</div>
+
+<div class='example wgsl' heading='A conditional continue with continuing statement'>
+   <xmp highlight='rust'>
+    fn conditional_continue() {
+      var a: i32;
+      loop {
+        if (a == 5) { break; } // Behaviours: {Break, Default}
+        if (a % 2 == 1) {      // valid, as the previous statement has Default in its behavior
+          continue;            // Behaviours: {Continue}
+        }                      // Behaviours: {Continue, Default}
+        a = a * 2;             // valid, as the previous statement has Default in its behavior
+        continuing {           // valid as the continuing statement has behavior {Default} which does not include any of {Break, Continue, Discard, Return}
+          a = a + 1;
+        }
+      }                        // The loop as a whole has behavior {Default}, as it absorbs "Continue" and "Default", then replaces "Break" with "Default"
+    }
+   </xmp>
+</div>
+
+<div class='example wgsl' heading='A redundant continue with continuing statement'>
+   <xmp highlight='rust'>
+    fn redundant_continue_with_continuing() {
+      var a: i32;
+      loop {
+        if (a == 5) { break; }
+        continue;   // Valid. This is redundant, branching to the next statement.
+        continuing {
+          a = a + 1;
+        }
+      }
+    }
+   </xmp>
+</div>
+
+<div class='example wgsl' heading='A continue at the end of a loop body'>
+   <xmp highlight='rust'>
+    fn continue_end_of_loop_body() {
+      for (var i: i32 = 0; i < 5; i = i + 1 ) {
+        continue;   // Valid. This is redundant, branching to the end of the loop body.
+      }             // Behaviours: {Default}, as loops absorb "Continue", and "for" loops always add "Default"
+    }
+   </xmp>
+</div>
+"for" loops desugar to "loop" with a conditional break. As shown in a previous example, the conditional break has behavior {Break, Default}, which leads to adding "Default" to the loop's behavior.
+
+<div class='example wgsl expect-error' heading='Effect of a function that discards unconditionally'>
+   <xmp highlight='rust'>
+    fn always_discard() {
+      discard;
+    }                   // The whole function has behavior {Discard}
+    fn code_after_discard() {
+      var a: i32;
+      always_discard(); // Behaviours: {Discard}
+      a = a + 1;        // Error: the previous statement is missing "Default" in its behavior
+    }
+   </xmp>
+</div>
+
+<div class='example wgsl' heading='Effect of a function that discards conditionally'>
+   <xmp highlight='rust'>
+    fn sometimes_discard(a: i32) {
+      if (a) {
+        discard;        // Behaviours: {Discard}
+      }                 // Behaviours: {Default, Discard}
+    }                   // The whole function has behavior {Default, Discard}
+    fn code_after_discard() {
+      var a: i32;
+      a = 42;
+      sometimes_discard(a);  // Behaviours: {Default, Discard}
+      a = a + 1;             // Valid
+    }                        // The whole function has behavior {Default, Discard}
+   </xmp>
+</div>
+
+<div class='example wgsl expect-error' heading='return required in functions that have a return type'>
+   <xmp highlight='rust'>
+    fn missing_return () -> i32 {
+      var a: i32 = 0;
+      if (42) {
+        return a;       // Behaviours: {Return}
+      }                 // Behaviours: {Default, Return}
+    }                   // Error: Default is invalid in the body of a function with a return type
+   </xmp>
+</div>
+
+<div class='example wgsl expect-error' heading='continue must be in a loop'>
+   <xmp highlight='rust'>
+    fn continue_out_of_loop () {
+      var a: i32 = 0;
+      if (a) {
+        continue;       // Behaviours: {Continue}
+      }                 // Behaviours: {Default, Continue}
+    }                   // Error: Continue is invalid in the body of a function
+   </xmp>
+</div>
+The same example would also be invalid for the same reason if continue was replaced by break or fallthrough.
+
 # Functions # {#functions}
 
 A <dfn dfn-for="function" noexport>function</dfn> performs computational work when invoked.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5755,18 +5755,30 @@ The reason is that only functions without a return type can have such a behavior
     <td class="nowrap">*s1*: *B1*<br>
         Default in *B1*<br>
         *s2*: *B2*
-    <td class="nowrap">*B1*∖{Default} ∪ *B2*
+    <td class="nowrap">*B1*∖{Default} &cup; *B2*
   <tr>
-    <td class="nowrap">A variable declaration or assignment
+    <td class="nowrap">var x:T;
     <td>
     <td>{Default}
+  <tr>
+    <td class="nowrap">let x = *e*;
+    <td class="nowrap">*e*: *B*
+    <td>*B*
+  <tr>
+    <td class="nowrap">var x = *e*;
+    <td class="nowrap">*e*: *B*
+    <td>*B*
+  <tr>
+    <td class="nowrap">x = *e*;
+    <td class="nowrap">*e*: *B*
+    <td>*B*
   <tr>
     <td class="nowrap">f(*e_1*, ..., *e_n*);
     <td class="nowrap">*e_1*: *B_1*<br>
         ...<br>
         *e_n*: *B_n*<br>
         *f*'s body has behavior *B*
-    <td class="nowrap">*B* ∪ (*B_1* ∪ ... ∪ *B_n*)∖{Default}
+    <td class="nowrap">*B* &cup; (*B_1* &cup; ... &cup; *B_n*)∖{Default}
   <tr>
     <td>return;
     <td>
@@ -5774,7 +5786,7 @@ The reason is that only functions without a return type can have such a behavior
   <tr>
     <td class="nowrap">return *e*;
     <td class="nowrap">*e*: *B*<br>
-    <td class="nowrap">*B*∖{Default} ∪ {Return}
+    <td class="nowrap">*B*∖{Default} &cup; {Return}
   <tr>
     <td>discard;
     <td>
@@ -5796,23 +5808,21 @@ The reason is that only functions without a return type can have such a behavior
     <td class="nowrap">*e: B*<br>
         *s1*: *B1*<br>
         *s2*: *B2*
-    <td class="nowrap">*B*∖{Default} ∪ B1 ∪ B2
+    <td class="nowrap">*B*∖{Default} &cup; B1 &cup; B2
   <tr>
     <td class="nowrap">loop {*s*}
     <td class="nowrap">*s*: *B*
     <td class="nowrap">let b = *B*∖{Default};<br>
-        if (Continue in b) b = b∖{Continue};<br>
-        if (Break in b) b = b∖{Break} ∪ {Default};<br>
-        b
+        if (Break in b) b = b∖{Break} &cup; {Default};<br>
+        b∖{Continue}
   <tr>
     <td class="nowrap">loop {*s1* continuing {*s2*}}
     <td class="nowrap">*s1*: *B1*<br>
         *s2*: *B2*<br>
-        None of {Break, Continue, Discard, Return} are in *B2*
-    <td class="nowrap">let b = (*B1* ∪ *B2*)∖{Default};<br>
-        if (Continue in b) b = b∖{Continue};<br>
-        if (Break in b) b = b∖{Break} ∪ {Default};<br>
-        b
+        Neither Continue nor Return are in *B2*
+    <td class="nowrap">let b = (*B1* &cup; *B2*)∖{Default};<br>
+        if (Break in b) b = b∖{Break} &cup; {Default};<br>
+        b∖{Continue}
   <tr>
     <td class="nowrap">switch(*e*) {case _: *s_1* ... case _: *s_n*}
     <td class="nowrap">*e*: *B*<br>
@@ -5820,11 +5830,13 @@ The reason is that only functions without a return type can have such a behavior
         ...<br>
         *s_n*: *B_n*<br>
         Fallthrough is not in *B_n*
-    <td class="nowrap">let b = *B*∖{Default} ∪ B_1 ∪ ... ∪ B_n;<br>
-        if (Fallthrough in b) b = b∖{Fallthrough};<br>
-        if (Break in b) b = b∖{Break} ∪ {Default};<br>
-        b
+    <td class="nowrap">let b = *B*∖{Default} &cup; B_1 &cup; ... &cup; B_n;<br>
+        if (Break in b) b = b∖{Break} &cup; {Default};<br>
+        b∖{Fallthrough}
 </table>
+
+for loops get desugared before this analysis is performed, see [[#for-statement]].
+Similarly, if statements without an else branch are treated as if they had an empty else branch (which adds Default to their behavior).
 
 <table class='data'>
   <caption>Rules for analyzing and validating the behaviors of expressions</caption>
@@ -5837,7 +5849,7 @@ The reason is that only functions without a return type can have such a behavior
         ...<br>
         *e_n*: *B_n*<br>
         *f*'s body has behavior *B*
-    <td class="nowrap">*B* ∪ (*B_1* ∪ ... ∪ *B_n*)∖{Default}
+    <td class="nowrap">*B* &cup; (*B_1* &cup; ... &cup; *B_n*)∖{Default}
   <tr>
     <td class="nowrap">Any literal
     <td>
@@ -5850,7 +5862,7 @@ The reason is that only functions without a return type can have such a behavior
     <td class="nowrap">e1[e2]
     <td class="nowrap">*e1*: *B1*<br>
         *e2*: *B2*
-    <td class="nowrap">*B1* ∪ *B2*
+    <td class="nowrap">*B1* &cup; *B2*
   <tr>
     <td class="nowrap">e.field
     <td class="nowrap">*e*: *B*
@@ -5859,25 +5871,25 @@ The reason is that only functions without a return type can have such a behavior
     <td class="nowrap">e1 || e2
     <td class="nowrap">*e1*: *B1*<br>
         *e2*: *B2*
-    <td class="nowrap">*B1* ∪ *B2*
+    <td class="nowrap">*B1* &cup; *B2*
   <tr>
     <td class="nowrap">e1 && e2
     <td class="nowrap">*e1*: *B1*<br>
         *e2*: *B2*
-    <td class="nowrap">*B1* ∪ *B2*
+    <td class="nowrap">*B1* &cup; *B2*
 </table>
 
 All functions in the standard library count as having a body with behavior {Default}.
 
 The shader must be rejected if it violates the rules for functions (above) or if it contains a statement or expression where none of the rules above apply because of preconditions.
 
-### Notes ### {#behaviours-notes}
+### Notes ### {#behaviors-notes}
 
 Here is the full list of ways that these rules can cause a program to be rejected (this is just restating information already listed above):
 - The body of a function (treated as a regular statement) has a behavior not included in {Default, Return, Discard}.
 - The body of a function with a return type has a behavior which is neither {Return} nor {Return, Discard}
 - A statement without Default in its behavior is not the last in a sequence of statements
-- The behavior of a continuing block contains any of {Break, Continue, Return, Discard}
+- The behavior of a continuing block contains either Continue or Return
 - The behavior of the last case of a switch contains Fallthrough
 
 This analysis can be run in linear time, by analyzing the call-graph bottom-up (since the behavior of a function call can depend on the function's code).
@@ -5889,7 +5901,7 @@ Here are some examples showing this analysis in action:
    <xmp highlight='rust'>
     fn simple() -> i32 {
       var a: i32;
-      return 0;  // Behaviours: {Return}
+      return 0;  // Behavior: {Return}
       a = 1;     // Error: by the rule for sequences of statements, the previous statement should have a behavior that include "Default"
       return 2;
     }
@@ -5901,8 +5913,8 @@ Here are some examples showing this analysis in action:
     fn nested() -> i32 {
       var a: i32;
       {             // The start of a compound statement.
-        a = 2;      // Behaviours: {Default}
-        return 1;   // Behaviours: {Return}
+        a = 2;      // Behavior: {Default}
+        return 1;   // Behavior: {Return}
       }             // The compound statement as a whole has behavior {Return}
       a = 1;        // Error: for the same reason as in the previous example, the previous statement is missing "Default" in its behavior
       return 2;
@@ -5916,8 +5928,8 @@ Here are some examples showing this analysis in action:
       var a: i32 = 0;
       loop {
         if (a == 5) {
-          break;      // Behaviours: {Break}
-        }             // Behaviours of the whole if compound statement: {Break, Default}, as the if has an implicit empty else
+          break;      // Behavior: {Break}
+        }             // Behavior of the whole if compound statement: {Break, Default}, as the if has an implicit empty else
         a = a + 1;    // valid, as the previous statement had "Default" in its behavior
       }
     }
@@ -5930,10 +5942,10 @@ Here are some examples showing this analysis in action:
       var a: i32 = 0;
       loop {
         if (a == 5) {
-          break;      // Behaviours: {Break}
+          break;      // Behavior: {Break}
         } else {
-          continue;   // Behaviours: {Continue}
-        }             // Behaviours of the whole if compound statement: {Break, Continue}
+          continue;   // Behavior: {Continue}
+        }             // Behavior of the whole if compound statement: {Break, Continue}
         a = a + 1;    // Error: the previous statement is missing "Default" in its behavior
       }
     }
@@ -5946,9 +5958,9 @@ Here are some examples showing this analysis in action:
       var a: i32 = 0;
       switch (a) {
         default: {
-          break;   // Behaviours: {Break}
+          break;   // Behavior: {Break}
         }
-      }            // Behaviours: {Default}, as switch replaces Break by Default
+      }            // Behavior: {Default}, as switch replaces Break by Default
       a = 5;       // valid, as the previous statement had Default in its behavior
     }
    </xmp>
@@ -5959,10 +5971,10 @@ Here are some examples showing this analysis in action:
     fn conditional_continue() {
       var a: i32;
       loop {
-        if (a == 5) { break; } // Behaviours: {Break, Default}
+        if (a == 5) { break; } // Behavior: {Break, Default}
         if (a % 2 == 1) {      // valid, as the previous statement has Default in its behavior
-          continue;            // Behaviours: {Continue}
-        }                      // Behaviours: {Continue, Default}
+          continue;            // Behavior: {Continue}
+        }                      // Behavior: {Continue, Default}
         a = a * 2;             // valid, as the previous statement has Default in its behavior
         continuing {           // valid as the continuing statement has behavior {Default} which does not include any of {Break, Continue, Discard, Return}
           a = a + 1;
@@ -5992,7 +6004,7 @@ Here are some examples showing this analysis in action:
     fn continue_end_of_loop_body() {
       for (var i: i32 = 0; i < 5; i = i + 1 ) {
         continue;   // Valid. This is redundant, branching to the end of the loop body.
-      }             // Behaviours: {Default}, as loops absorb "Continue", and "for" loops always add "Default"
+      }             // Behavior: {Default}, as loops absorb "Continue", and "for" loops always add "Default"
     }
    </xmp>
 </div>
@@ -6005,7 +6017,7 @@ Here are some examples showing this analysis in action:
     }                   // The whole function has behavior {Discard}
     fn code_after_discard() {
       var a: i32;
-      always_discard(); // Behaviours: {Discard}
+      always_discard(); // Behavior: {Discard}
       a = a + 1;        // Error: the previous statement is missing "Default" in its behavior
     }
    </xmp>
@@ -6015,13 +6027,13 @@ Here are some examples showing this analysis in action:
    <xmp highlight='rust'>
     fn sometimes_discard(a: i32) {
       if (a) {
-        discard;        // Behaviours: {Discard}
-      }                 // Behaviours: {Default, Discard}
+        discard;        // Behavior: {Discard}
+      }                 // Behavior: {Default, Discard}
     }                   // The whole function has behavior {Default, Discard}
     fn code_after_discard() {
       var a: i32;
       a = 42;
-      sometimes_discard(a);  // Behaviours: {Default, Discard}
+      sometimes_discard(a);  // Behavior: {Default, Discard}
       a = a + 1;             // Valid
     }                        // The whole function has behavior {Default, Discard}
    </xmp>
@@ -6032,8 +6044,8 @@ Here are some examples showing this analysis in action:
     fn missing_return () -> i32 {
       var a: i32 = 0;
       if (42) {
-        return a;       // Behaviours: {Return}
-      }                 // Behaviours: {Default, Return}
+        return a;       // Behavior: {Return}
+      }                 // Behavior: {Default, Return}
     }                   // Error: Default is invalid in the body of a function with a return type
    </xmp>
 </div>
@@ -6043,8 +6055,8 @@ Here are some examples showing this analysis in action:
     fn continue_out_of_loop () {
       var a: i32 = 0;
       if (a) {
-        continue;       // Behaviours: {Continue}
-      }                 // Behaviours: {Default, Continue}
+        continue;       // Behavior: {Continue}
+      }                 // Behavior: {Default, Continue}
     }                   // Error: Continue is invalid in the body of a function
    </xmp>
 </div>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5716,31 +5716,32 @@ Note: If the function [=return value|returns a value=], that value is ignored.
 Some statements affecting control-flow are only valid in some contexts.
 For example, `fallthrough` is invalid outside of a switch, and `continue` is invalid outside of a loop.
 Additionally, the uniformity analysis (see [[#uniformity]]) needs to know when control flow can exit a statement in multiple different ways.
-Both of these goals are achieved by a simple type system applied to statements.
-To avoid confusion with the types of expressions, we call the type of a statement its <dfn export>behavior</dfn>.
 
-A [=behavior=] is simply a set, whose elements may be:
+Both goals are achieved by a system for summarizing execution behaviors of statements and expressions. Behavior analysis maps each statement and expression to the set of possible ways execution proceeds after evaluation of the statement or expression completes.
+As with type analysis for values and expressions, behavior analysis proceeds bottom up: first determine behaviors for certain basic statements, and then determine behavior for higher level constructs by applying combining rules.
+
+A <dfn expor>behavior</dfn> is a set, whose elements may be:
 - Return
 - Discard
 - Break
 - Continue
 - Fallthrough
-- Default
+- Next
 
-Each of those correspond to a way to exit a compound statement: either through a keyword, or by simply falling to the next statement ("Default").
+Each of those correspond to a way to exit a compound statement: either through a keyword, or by falling to the next statement ("Next").
 
 We note "*s*: *B*" to say that *s* respects the rules regarding behaviors, and has [=behavior=] *B*.
 
 For each function:
 - its body must be a valid statement by these rules
 - if it has a return type, its [=behavior=] must be one of {Return} or {Return, Discard}
-- otherwise, its [=behavior=] must be a subset of {Default, Return, Discard}
+- otherwise, its [=behavior=] must be a subset of {Next, Return, Discard}
 
-We assign a [=behavior=] to each function: it is its body's [=behavior=] (treating the body as a regular statement), with any "Return" replaced by "Default".
-As a consequence of the rules above, a function behavior is always one of {Default}, {Discard} or {Default, Discard}.
+We assign a [=behavior=] to each function: it is its body's [=behavior=] (treating the body as a regular statement), with any "Return" replaced by "Next".
+As a consequence of the rules above, a function behavior is always one of {Next}, {Discard} or {Next, Discard}.
 
 Similarly, we assign a [=behavior=] to each expression, since expressions can include function calls, which can discard.
-Like functions, expression behaviors are always one of {Default}, {Discard}, or {Default, Discard}.
+Like functions, expression behaviors are always one of {Next}, {Discard}, or {Next, Discard}.
 
 Note: There is currently no valid program with an expression that has a [=behavior=] of {Discard}.
 The reason is that only functions without a return type can have such a [=behavior=], and there is no compound expression in which such a function can be called.
@@ -5753,13 +5754,13 @@ The reason is that only functions without a return type can have such a [=behavi
   <tr>
     <td class="nowrap">*s1* ; *s2*
     <td class="nowrap">*s1*: *B1*<br>
-        Default in *B1*<br>
+        Next in *B1*<br>
         *s2*: *B2*
-    <td class="nowrap">*B1*&#x2216;{Default} &cup; *B2*
+    <td class="nowrap">*B1*&#x2216;{Next} &cup; *B2*
   <tr>
     <td class="nowrap">var x:T;
     <td>
-    <td>{Default}
+    <td>{Next}
   <tr>
     <td class="nowrap">let x = *e*;
     <td class="nowrap">*e*: *B*
@@ -5778,7 +5779,7 @@ The reason is that only functions without a return type can have such a [=behavi
         ...<br>
         *e_n*: *B_n*<br>
         *f*'s body has behavior *B*
-    <td class="nowrap">*B* &cup; (*B_1* &cup; ... &cup; *B_n*)&#x2216;{Default}
+    <td class="nowrap">*B* &cup; (*B_1* &cup; ... &cup; *B_n*)&#x2216;{Next}
   <tr>
     <td>return;
     <td>
@@ -5786,7 +5787,7 @@ The reason is that only functions without a return type can have such a [=behavi
   <tr>
     <td class="nowrap">return *e*;
     <td class="nowrap">*e*: *B*<br>
-    <td class="nowrap">*B*&#x2216;{Default} &cup; {Return}
+    <td class="nowrap">*B*&#x2216;{Next} &cup; {Return}
   <tr>
     <td>discard;
     <td>
@@ -5809,20 +5810,20 @@ The reason is that only functions without a return type can have such a [=behavi
         *s1*: *B1*<br>
         ...<br>
         *sn*: *Bn*
-    <td class="nowrap">*B*&#x2216;{Default} &cup; B1 &cup; ... &cup; Bn
+    <td class="nowrap">*B*&#x2216;{Next} &cup; B1 &cup; ... &cup; Bn
   <tr>
     <td class="nowrap">loop {*s*}
     <td class="nowrap">*s*: *B*
-    <td class="nowrap">let b = *B*&#x2216;{Default};<br>
-        if (Break in b) b = b&#x2216;{Break} &cup; {Default};<br>
+    <td class="nowrap">let b = *B*&#x2216;{Next};<br>
+        if (Break in b) b = b&#x2216;{Break} &cup; {Next};<br>
         b&#x2216;{Continue}
   <tr>
     <td class="nowrap">loop {*s1* continuing {*s2*}}
     <td class="nowrap">*s1*: *B1*<br>
         *s2*: *B2*<br>
         Neither Continue nor Return are in *B2*
-    <td class="nowrap">let b = (*B1* &cup; *B2*)&#x2216;{Default};<br>
-        if (Break in b) b = b&#x2216;{Break} &cup; {Default};<br>
+    <td class="nowrap">let b = (*B1* &cup; *B2*)&#x2216;{Next};<br>
+        if (Break in b) b = b&#x2216;{Break} &cup; {Next};<br>
         b&#x2216;{Continue}
   <tr>
     <td class="nowrap">switch(*e*) {case _: *s1* ... case _: *sn*}
@@ -5831,13 +5832,13 @@ The reason is that only functions without a return type can have such a [=behavi
         ...<br>
         *sn*: *Bn*<br>
         Fallthrough is not in *Bn*
-    <td class="nowrap">let b = *B*&#x2216;{Default} &cup; B1 &cup; ... &cup; Bn;<br>
-        if (Break in b) b = b&#x2216;{Break} &cup; {Default};<br>
+    <td class="nowrap">let b = *B*&#x2216;{Next} &cup; B1 &cup; ... &cup; Bn;<br>
+        if (Break in b) b = b&#x2216;{Break} &cup; {Next};<br>
         b&#x2216;{Fallthrough}
 </table>
 
 `for` loops get desugared before this analysis is performed, see [[#for-statement]].
-Similarly, if statements without an else branch are treated as if they had an empty else branch (which adds Default to their [=behavior=]).
+Similarly, if statements without an else branch are treated as if they had an empty else branch (which adds Next to their [=behavior=]).
 
 <table class='data'>
   <caption>Rules for analyzing and validating the behaviors of expressions</caption>
@@ -5850,15 +5851,15 @@ Similarly, if statements without an else branch are treated as if they had an em
         ...<br>
         *e_n*: *B_n*<br>
         *f*'s body has behavior *B*
-    <td class="nowrap">*B* &cup; (*B_1* &cup; ... &cup; *B_n*)&#x2216;{Default}
+    <td class="nowrap">*B* &cup; (*B_1* &cup; ... &cup; *B_n*)&#x2216;{Next}
   <tr>
     <td class="nowrap">Any literal
     <td>
-    <td class="nowrap">{Default}
+    <td class="nowrap">{Next}
   <tr>
     <td class="nowrap">Any variable reference
     <td>
-    <td class="nowrap">{Default}
+    <td class="nowrap">{Next}
   <tr>
     <td class="nowrap">e1[e2]
     <td class="nowrap">*e1*: *B1*<br>
@@ -5880,23 +5881,29 @@ Similarly, if statements without an else branch are treated as if they had an em
     <td class="nowrap">*B1* &cup; *B2*
 </table>
 
-All functions in the standard library have [=behavior=] {Default}.
-And all operators other than `||` and `&&` behave as function calls with [=behavior=] {Default}.
+Any other expression (not listed in the table above), and each [=built-in function=] has a [=behavior=] of {Next}.
 
-It is a [=shader-creation error=] if any of the rules for functions (above) are violated or if it contains a statement or expression where none of the rules above apply because of preconditions.
+A [=shader-creation error=] results if behavior analysis fails:
+- Behavior analysis must be able to determine a [=behavior=] for each statement, expression, and function.
+  This can only fail if preconditions are not met.
+- The function behaviors must satisfy the rules given above.
+- The behaviors of compute and vertex entry points must not contain Discard.
 
 ### Notes ### {#behaviors-notes}
 
 This section is informative, non-normative.
 
 Here is the full list of ways that these rules can cause a program to be rejected (this is just restating information already listed above):
-- The body of a function (treated as a regular statement) has a behavior not included in {Default, Return, Discard}.
+- The body of a function (treated as a regular statement) has a behavior not included in {Next, Return, Discard}.
 - The body of a function with a return type has a behavior which is neither {Return} nor {Return, Discard}
-- A statement without Default in its behavior is not the last in a sequence of statements
+- A statement without Next in its behavior is not the last in a sequence of statements
 - The behavior of a continuing block contains either Continue or Return
 - The behavior of the last case of a switch contains Fallthrough
+- The behavior of a compute or vertex entry point function contains Discard
 
 This analysis can be run in linear time, by analyzing the call-graph bottom-up (since the behavior of a function call can depend on the function's code).
+
+As a result of the rules above, no expression, statement, or function can have an empty [=behavior=].
 
 ### Examples ### {#behaviors-examples}
 
@@ -5906,7 +5913,7 @@ Here are some examples showing this analysis in action:
     fn simple() -> i32 {
       var a: i32;
       return 0;  // Behavior: {Return}
-      a = 1;     // Error: by the rule for sequences of statements, the previous statement should have a behavior that include "Default"
+      a = 1;     // Error: by the rule for sequences of statements, the previous statement should have a behavior that include "Next"
       return 2;
     }
    </xmp>
@@ -5917,10 +5924,10 @@ Here are some examples showing this analysis in action:
     fn nested() -> i32 {
       var a: i32;
       {             // The start of a compound statement.
-        a = 2;      // Behavior: {Default}
+        a = 2;      // Behavior: {Next}
         return 1;   // Behavior: {Return}
       }             // The compound statement as a whole has behavior {Return}
-      a = 1;        // Error: for the same reason as in the previous example, the previous statement is missing "Default" in its behavior
+      a = 1;        // Error: for the same reason as in the previous example, the previous statement is missing "Next" in its behavior
       return 2;
     }
    </xmp>
@@ -5933,8 +5940,8 @@ Here are some examples showing this analysis in action:
       loop {
         if (a == 5) {
           break;      // Behavior: {Break}
-        }             // Behavior of the whole if compound statement: {Break, Default}, as the if has an implicit empty else
-        a = a + 1;    // valid, as the previous statement had "Default" in its behavior
+        }             // Behavior of the whole if compound statement: {Break, Next}, as the if has an implicit empty else
+        a = a + 1;    // valid, as the previous statement had "Next" in its behavior
       }
     }
    </xmp>
@@ -5950,13 +5957,13 @@ Here are some examples showing this analysis in action:
         } else {
           continue;   // Behavior: {Continue}
         }             // Behavior of the whole if compound statement: {Break, Continue}
-        a = a + 1;    // Error: the previous statement is missing "Default" in its behavior
+        a = a + 1;    // Error: the previous statement is missing "Next" in its behavior
       }
     }
    </xmp>
 </div>
 
-<div class='example wgsl' heading='Break in switch becomes Default'>
+<div class='example wgsl' heading='Break in switch becomes Next'>
    <xmp highlight='rust'>
     fn switch_example() {
       var a: i32 = 0;
@@ -5964,8 +5971,8 @@ Here are some examples showing this analysis in action:
         default: {
           break;   // Behavior: {Break}
         }
-      }            // Behavior: {Default}, as switch replaces Break by Default
-      a = 5;       // valid, as the previous statement had Default in its behavior
+      }            // Behavior: {Next}, as switch replaces Break by Next
+      a = 5;       // valid, as the previous statement had Next in its behavior
     }
    </xmp>
 </div>
@@ -5975,15 +5982,15 @@ Here are some examples showing this analysis in action:
     fn conditional_continue() {
       var a: i32;
       loop {
-        if (a == 5) { break; } // Behavior: {Break, Default}
-        if (a % 2 == 1) {      // valid, as the previous statement has Default in its behavior
+        if (a == 5) { break; } // Behavior: {Break, Next}
+        if (a % 2 == 1) {      // valid, as the previous statement has Next in its behavior
           continue;            // Behavior: {Continue}
-        }                      // Behavior: {Continue, Default}
-        a = a * 2;             // valid, as the previous statement has Default in its behavior
-        continuing {           // valid as the continuing statement has behavior {Default} which does not include any of {Break, Continue, Discard, Return}
+        }                      // Behavior: {Continue, Next}
+        a = a * 2;             // valid, as the previous statement has Next in its behavior
+        continuing {           // valid as the continuing statement has behavior {Next} which does not include any of {Break, Continue, Discard, Return}
           a = a + 1;
         }
-      }                        // The loop as a whole has behavior {Default}, as it absorbs "Continue" and "Default", then replaces "Break" with "Default"
+      }                        // The loop as a whole has behavior {Next}, as it absorbs "Continue" and "Next", then replaces "Break" with "Next"
     }
    </xmp>
 </div>
@@ -6008,11 +6015,11 @@ Here are some examples showing this analysis in action:
     fn continue_end_of_loop_body() {
       for (var i: i32 = 0; i < 5; i = i + 1 ) {
         continue;   // Valid. This is redundant, branching to the end of the loop body.
-      }             // Behavior: {Default}, as loops absorb "Continue", and "for" loops always add "Default"
+      }             // Behavior: {Next}, as loops absorb "Continue", and "for" loops always add "Next"
     }
    </xmp>
 </div>
-`for` loops desugar to `loop` with a conditional break. As shown in a previous example, the conditional break has [=behavior=] {Break, Default}, which leads to adding "Default" to the loop's [=behavior=].
+`for` loops desugar to `loop` with a conditional break. As shown in a previous example, the conditional break has [=behavior=] {Break, Next}, which leads to adding "Next" to the loop's [=behavior=].
 
 <div class='example wgsl expect-error' heading='Effect of a function that discards unconditionally'>
    <xmp highlight='rust'>
@@ -6022,7 +6029,7 @@ Here are some examples showing this analysis in action:
     fn code_after_discard() {
       var a: i32;
       always_discard(); // Behavior: {Discard}
-      a = a + 1;        // Error: the previous statement is missing "Default" in its behavior
+      a = a + 1;        // Error: the previous statement is missing "Next" in its behavior
     }
    </xmp>
 </div>
@@ -6032,14 +6039,14 @@ Here are some examples showing this analysis in action:
     fn sometimes_discard(a: i32) {
       if (a) {
         discard;        // Behavior: {Discard}
-      }                 // Behavior: {Default, Discard}
-    }                   // The whole function has behavior {Default, Discard}
+      }                 // Behavior: {Next, Discard}
+    }                   // The whole function has behavior {Next, Discard}
     fn code_after_discard() {
       var a: i32;
       a = 42;
-      sometimes_discard(a);  // Behavior: {Default, Discard}
+      sometimes_discard(a);  // Behavior: {Next, Discard}
       a = a + 1;             // Valid
-    }                        // The whole function has behavior {Default, Discard}
+    }                        // The whole function has behavior {Next, Discard}
    </xmp>
 </div>
 
@@ -6049,8 +6056,8 @@ Here are some examples showing this analysis in action:
       var a: i32 = 0;
       if (42) {
         return a;       // Behavior: {Return}
-      }                 // Behavior: {Default, Return}
-    }                   // Error: Default is invalid in the body of a function with a return type
+      }                 // Behavior: {Next, Return}
+    }                   // Error: Next is invalid in the body of a function with a return type
    </xmp>
 </div>
 
@@ -6060,7 +6067,7 @@ Here are some examples showing this analysis in action:
       var a: i32 = 0;
       if (a) {
         continue;       // Behavior: {Continue}
-      }                 // Behavior: {Default, Continue}
+      }                 // Behavior: {Next, Continue}
     }                   // Error: Continue is invalid in the body of a function
    </xmp>
 </div>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5997,7 +5997,7 @@ Here are some examples showing this analysis in action:
         // if (e1) else { if (e2) s2 else s3 }
         if (a == 5) {
           break;      // Behavior: {Break}
-        } else if (a == 42) {
+        } elseif (a == 42) {
           continue;   // Behavior: {Continue}
         } else {
           return;     // Behavior {Return}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5591,7 +5591,10 @@ control past a declaration used in the targeted [=statement/continuing=] stateme
 A <dfn dfn-for="statement">continuing</dfn> statement specifies a [=compound statement=] to be executed at the end of a loop [=iteration=].
 The construct is optional.
 
-The compound statement must not contain a [=statement/return=] or [=statement/discard=] statement, at any compound statement nesting level.
+The compound statement must not contain a [=statement/return=] at any compound statement nesting level.
+
+The compound statement must not contain a [=statement/discard=] at any compound statement nesting level nor through function calls.
+See [[#behaviors]] for a more formal description of this rule.
 
 ### Return Statement ### {#return-statement}
 
@@ -5720,7 +5723,7 @@ Additionally, the uniformity analysis (see [[#uniformity]]) needs to know when c
 Both goals are achieved by a system for summarizing execution behaviors of statements and expressions. Behavior analysis maps each statement and expression to the set of possible ways execution proceeds after evaluation of the statement or expression completes.
 As with type analysis for values and expressions, behavior analysis proceeds bottom up: first determine behaviors for certain basic statements, and then determine behavior for higher level constructs by applying combining rules.
 
-A <dfn expor>behavior</dfn> is a set, whose elements may be:
+A <dfn export>behavior</dfn> is a set, whose elements may be:
 - Return
 - Discard
 - Break
@@ -5821,7 +5824,7 @@ The reason is that only functions without a return type can have such a [=behavi
     <td class="nowrap">loop {*s1* continuing {*s2*}}
     <td class="nowrap">*s1*: *B1*<br>
         *s2*: *B2*<br>
-        Neither Continue nor Return are in *B2*
+        None of {Continue, Return, Discard} are in *B2*
     <td class="nowrap">let b = (*B1* &cup; *B2*)&#x2216;{Next};<br>
         if (Break in b) b = b&#x2216;{Break} &cup; {Next};<br>
         b&#x2216;{Continue}
@@ -5896,7 +5899,7 @@ Here is the full list of ways that these rules can cause a program to be rejecte
 - The body of a function (treated as a regular statement) has a behavior not included in {Next, Return, Discard}.
 - The body of a function with a return type has a behavior which is neither {Return} nor {Return, Discard}
 - A statement without Next in its behavior is not the last in a sequence of statements
-- The behavior of a continuing block contains either Continue or Return
+- The behavior of a continuing block contains any of Continue, Return, or Discard
 - The behavior of the last case of a switch contains Fallthrough
 - The behavior of a compute or vertex entry point function contains Discard
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5715,11 +5715,11 @@ Note: If the function [=return value|returns a value=], that value is ignored.
 
 Some statements affecting control-flow are only valid in some contexts.
 For example, `fallthrough` is invalid outside of a switch, and `continue` is invalid outside of a loop.
-Additionally, the uniformity analysis (see [[#uniformity]]) needs to know when control flow can exit a statement in two different ways.
+Additionally, the uniformity analysis (see [[#uniformity]]) needs to know when control flow can exit a statement in multiple different ways.
 Both of these goals are achieved by a simple type system applied to statements.
-To avoid confusion with the types of expressions, we call the types of statements behaviors.
+To avoid confusion with the types of expressions, we call the type of a statement its <dfn export>behavior</dfn>.
 
-A behavior is simply a set, whose elements may be:
+A [=behavior=] is simply a set, whose elements may be:
 - Return
 - Discard
 - Break
@@ -5727,23 +5727,23 @@ A behavior is simply a set, whose elements may be:
 - Fallthrough
 - Default
 
-Each of those correspond with a way to exit a compound statement: either through a keyword, or by simply falling to the next statement ("Default").
+Each of those correspond to a way to exit a compound statement: either through a keyword, or by simply falling to the next statement ("Default").
 
-We note "*s*: *B*" to say that *s* respects the rules regarding behaviors, and has behavior *B*.
+We note "*s*: *B*" to say that *s* respects the rules regarding behaviors, and has [=behavior=] *B*.
 
 For each function:
 - its body must be a valid statement by these rules
-- if it has a return type, its behavior must be one of {Return} or {Return, Discard}
-- otherwise, its behavior must be a subset of {Default, Return, Discard}
+- if it has a return type, its [=behavior=] must be one of {Return} or {Return, Discard}
+- otherwise, its [=behavior=] must be a subset of {Default, Return, Discard}
 
-We assign a behavior to each function: it is its body's behavior, with any "Return" replaced by "Default".
+We assign a [=behavior=] to each function: it is its body's [=behavior=] (treating the body as a regular statement), with any "Return" replaced by "Default".
 As a consequence of the rules above, a function behavior is always one of {Default}, {Discard} or {Default, Discard}.
 
-Similarly, we assign a behavior to each expression, since expressions can include function calls, which can discard.
-Expression behaviors are always one of {Default}, {Discard}, or {Default, Discard}.
+Similarly, we assign a [=behavior=] to each expression, since expressions can include function calls, which can discard.
+Like functions, expression behaviors are always one of {Default}, {Discard}, or {Default, Discard}.
 
-Note: There is currently no valid program with an expression that has a behavior of {Discard}.
-The reason is that only functions without a return type can have such a behavior, and there is no compound expression in which such a function can be called.
+Note: There is currently no valid program with an expression that has a [=behavior=] of {Discard}.
+The reason is that only functions without a return type can have such a [=behavior=], and there is no compound expression in which such a function can be called.
 
 <table class='data'>
   <caption>Rules for analyzing and validating the behaviors of statements</caption>
@@ -5755,7 +5755,7 @@ The reason is that only functions without a return type can have such a behavior
     <td class="nowrap">*s1*: *B1*<br>
         Default in *B1*<br>
         *s2*: *B2*
-    <td class="nowrap">*B1*∖{Default} &cup; *B2*
+    <td class="nowrap">*B1*&#x2216;{Default} &cup; *B2*
   <tr>
     <td class="nowrap">var x:T;
     <td>
@@ -5778,7 +5778,7 @@ The reason is that only functions without a return type can have such a behavior
         ...<br>
         *e_n*: *B_n*<br>
         *f*'s body has behavior *B*
-    <td class="nowrap">*B* &cup; (*B_1* &cup; ... &cup; *B_n*)∖{Default}
+    <td class="nowrap">*B* &cup; (*B_1* &cup; ... &cup; *B_n*)&#x2216;{Default}
   <tr>
     <td>return;
     <td>
@@ -5786,7 +5786,7 @@ The reason is that only functions without a return type can have such a behavior
   <tr>
     <td class="nowrap">return *e*;
     <td class="nowrap">*e*: *B*<br>
-    <td class="nowrap">*B*∖{Default} &cup; {Return}
+    <td class="nowrap">*B*&#x2216;{Default} &cup; {Return}
   <tr>
     <td>discard;
     <td>
@@ -5804,39 +5804,40 @@ The reason is that only functions without a return type can have such a behavior
     <td>
     <td>{Fallthrough}
   <tr>
-    <td class="nowrap">if (*e*) *s1* else *s2*
+    <td class="nowrap">if (*e*) *s1* elseif *s2* ...  else *sn*
     <td class="nowrap">*e: B*<br>
         *s1*: *B1*<br>
-        *s2*: *B2*
-    <td class="nowrap">*B*∖{Default} &cup; B1 &cup; B2
+        ...<br>
+        *sn*: *Bn*
+    <td class="nowrap">*B*&#x2216;{Default} &cup; B1 &cup; ... &cup; Bn
   <tr>
     <td class="nowrap">loop {*s*}
     <td class="nowrap">*s*: *B*
-    <td class="nowrap">let b = *B*∖{Default};<br>
-        if (Break in b) b = b∖{Break} &cup; {Default};<br>
-        b∖{Continue}
+    <td class="nowrap">let b = *B*&#x2216;{Default};<br>
+        if (Break in b) b = b&#x2216;{Break} &cup; {Default};<br>
+        b&#x2216;{Continue}
   <tr>
     <td class="nowrap">loop {*s1* continuing {*s2*}}
     <td class="nowrap">*s1*: *B1*<br>
         *s2*: *B2*<br>
         Neither Continue nor Return are in *B2*
-    <td class="nowrap">let b = (*B1* &cup; *B2*)∖{Default};<br>
-        if (Break in b) b = b∖{Break} &cup; {Default};<br>
-        b∖{Continue}
+    <td class="nowrap">let b = (*B1* &cup; *B2*)&#x2216;{Default};<br>
+        if (Break in b) b = b&#x2216;{Break} &cup; {Default};<br>
+        b&#x2216;{Continue}
   <tr>
-    <td class="nowrap">switch(*e*) {case _: *s_1* ... case _: *s_n*}
+    <td class="nowrap">switch(*e*) {case _: *s1* ... case _: *sn*}
     <td class="nowrap">*e*: *B*<br>
-        *s_1*: *B_1*<br>
+        *s1*: *B1*<br>
         ...<br>
-        *s_n*: *B_n*<br>
-        Fallthrough is not in *B_n*
-    <td class="nowrap">let b = *B*∖{Default} &cup; B_1 &cup; ... &cup; B_n;<br>
-        if (Break in b) b = b∖{Break} &cup; {Default};<br>
-        b∖{Fallthrough}
+        *sn*: *Bn*<br>
+        Fallthrough is not in *Bn*
+    <td class="nowrap">let b = *B*&#x2216;{Default} &cup; B1 &cup; ... &cup; Bn;<br>
+        if (Break in b) b = b&#x2216;{Break} &cup; {Default};<br>
+        b&#x2216;{Fallthrough}
 </table>
 
-for loops get desugared before this analysis is performed, see [[#for-statement]].
-Similarly, if statements without an else branch are treated as if they had an empty else branch (which adds Default to their behavior).
+`for` loops get desugared before this analysis is performed, see [[#for-statement]].
+Similarly, if statements without an else branch are treated as if they had an empty else branch (which adds Default to their [=behavior=]).
 
 <table class='data'>
   <caption>Rules for analyzing and validating the behaviors of expressions</caption>
@@ -5849,7 +5850,7 @@ Similarly, if statements without an else branch are treated as if they had an em
         ...<br>
         *e_n*: *B_n*<br>
         *f*'s body has behavior *B*
-    <td class="nowrap">*B* &cup; (*B_1* &cup; ... &cup; *B_n*)∖{Default}
+    <td class="nowrap">*B* &cup; (*B_1* &cup; ... &cup; *B_n*)&#x2216;{Default}
   <tr>
     <td class="nowrap">Any literal
     <td>
@@ -5879,11 +5880,14 @@ Similarly, if statements without an else branch are treated as if they had an em
     <td class="nowrap">*B1* &cup; *B2*
 </table>
 
-All functions in the standard library count as having a body with behavior {Default}.
+All functions in the standard library have [=behavior=] {Default}.
+And all operators other than `||` and `&&` behave as function calls with [=behavior=] {Default}.
 
 The shader must be rejected if it violates the rules for functions (above) or if it contains a statement or expression where none of the rules above apply because of preconditions.
 
 ### Notes ### {#behaviors-notes}
+
+This section is informative, non-normative.
 
 Here is the full list of ways that these rules can cause a program to be rejected (this is just restating information already listed above):
 - The body of a function (treated as a regular statement) has a behavior not included in {Default, Return, Discard}.
@@ -6008,7 +6012,7 @@ Here are some examples showing this analysis in action:
     }
    </xmp>
 </div>
-"for" loops desugar to "loop" with a conditional break. As shown in a previous example, the conditional break has behavior {Break, Default}, which leads to adding "Default" to the loop's behavior.
+`for` loops desugar to `loop` with a conditional break. As shown in a previous example, the conditional break has [=behavior=] {Break, Default}, which leads to adding "Default" to the loop's [=behavior=].
 
 <div class='example wgsl expect-error' heading='Effect of a function that discards unconditionally'>
    <xmp highlight='rust'>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5878,6 +5878,7 @@ Here is the full list of ways that these rules can cause a program to be rejecte
 - The body of a function with a return type has a behavior which is neither {Return} nor {Return, Discard}
 - A statement without Default in its behavior is not the last in a sequence of statements
 - The behavior of a continuing block contains any of {Break, Continue, Return, Discard}
+- The behavior of the last case of a switch contains Fallthrough
 
 This analysis can be run in linear time, by analyzing the call-graph bottom-up (since the behavior of a function call can depend on the function's code).
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5741,12 +5741,12 @@ For each function:
 - otherwise, its [=behavior=] must be a subset of {Next, Return, Discard}
 
 We assign a [=behavior=] to each function: it is its body's [=behavior=] (treating the body as a regular statement), with any "Return" replaced by "Next".
-As a consequence of the rules above, a function behavior is always one of {Next}, {Discard} or {Next, Discard}.
+As a consequence of the rules above, a function behavior is always one of {}, {Next}, {Discard}, or {Next, Discard}.
 
 Similarly, we assign a [=behavior=] to each expression, since expressions can include function calls, which can discard.
-Like functions, expression behaviors are always one of {Next}, {Discard}, or {Next, Discard}.
+Like functions, expression behaviors are always one of {}, {Next}, {Discard}, or {Next, Discard}.
 
-Note: There is currently no valid program with an expression that has a [=behavior=] of {Discard}.
+Note: There is currently no valid program with an expression that does not have Next in its [=behavior=].
 The reason is that only functions without a return type can have such a [=behavior=], and there is no compound expression in which such a function can be called.
 
 <table class='data'>
@@ -5755,11 +5755,19 @@ The reason is that only functions without a return type can have such a [=behavi
     <tr><th>Statement<th>Preconditions<th>Resulting behavior
   </thead>
   <tr>
+    <td class="nowrap">{ }
+    <td>
+    <td class="nowrap">{Next}
+  <tr>
+    <td class="nowrap">{|s|}
+    <td>|s|: |B|
+    <td class="nowrap">B
+  <tr>
     <td class="nowrap">|s1| ; |s2|
     <td class="nowrap">|s1|: |B1|<br>
         Next in |B1|<br>
         |s2|: |B2|
-    <td class="nowrap">|B1|&#x2216;{Next} &cup; |B2|
+    <td class="nowrap">(|B1|&#x2216;{Next}) &cup; |B2|
   <tr>
     <td class="nowrap">var x:T;
     <td>
@@ -5773,16 +5781,22 @@ The reason is that only functions without a return type can have such a [=behavi
     <td class="nowrap">|e|: |B|
     <td>|B|
   <tr>
-    <td class="nowrap">x = |e|;
-    <td class="nowrap">*e*: |B|
+    <td class="nowrap">|x| = |e|;
+    <td class="nowrap">|x|: |B1|<br>
+      |e|: |B2|<br>
+      |x| is not `_`
+    <td>|B1| &cup; |B2|
+  <tr>
+    <td class="nowrap">_ = |e|;
+    <td class="nowrap">|e|: |B|
     <td>|B|
   <tr>
     <td class="nowrap">|f|(|e1|, ..., |en|);
     <td class="nowrap">|e1|: |B1|<br>
         ...<br>
         |en|: |Bn|<br>
-        |f|'s body has behavior |B|
-    <td class="nowrap">|B| &cup; (|B1| &cup; ... &cup; |Bn|)&#x2216;{Next}
+        |f|'s has behavior |B|
+    <td class="nowrap">|B| &cup; ((|B1| &cup; ... &cup; |Bn|)&#x2216;{Next})
   <tr>
     <td>return;
     <td>
@@ -5790,7 +5804,7 @@ The reason is that only functions without a return type can have such a [=behavi
   <tr>
     <td class="nowrap">return |e|;
     <td class="nowrap">|e|: |B|<br>
-    <td class="nowrap">|B|&#x2216;{Next} &cup; {Return}
+    <td class="nowrap">(|B|&#x2216;{Next}) &cup; {Return}
   <tr>
     <td>discard;
     <td>
@@ -5808,12 +5822,11 @@ The reason is that only functions without a return type can have such a [=behavi
     <td>
     <td>{Fallthrough}
   <tr>
-    <td class="nowrap">if (|e|) |s1| elseif |s2| ...  else |sn|
+    <td class="nowrap">if (|e|) |s1| else |s2|
     <td class="nowrap">|e|: |B|<br>
         |s1|: |B1|<br>
-        ...<br>
-        |sn|: |Bn|
-    <td class="nowrap">|B|&#x2216;{Next} &cup; |B1| &cup; ... &cup; |Bn|
+        |s2|: |B2|
+    <td class="nowrap">(|B|&#x2216;{Next}) &cup; |B1| &cup; |B2|
   <tr>
     <td class="nowrap" rowspan=2>loop {|s1| continuing {|s2|}}
     <td class="nowrap">|s1|: |B1|<br>
@@ -5828,7 +5841,7 @@ The reason is that only functions without a return type can have such a [=behavi
         Break is in (|B1| &cup; |B2|)
     <td class="nowrap">(|B1| &cup; |B2| &cup; {Next})&#x2216;{Break, Continue}
   <tr>
-    <td class="nowrap" rowspan=2>switch(|e|) {case _: |s1| ... case _: |sn|}
+    <td class="nowrap" rowspan=2>switch(|e|) {case <var ignore>c1</var>: |s1| ... case <var ignore>cn</var>: |sn|}
     <td class="nowrap">|e|: |B|<br>
         |s1|: |B1|<br>
         ...<br>
@@ -5850,6 +5863,7 @@ For the purpose of this analysis:
 - `for` loops get desugared (see [[#for-statement]])
 - `loop {s}` is treated as `loop {s continuing {}}`
 - `if` statements without an `else` branch are treated as if they had an empty else branch (which adds Next to their [=behavior=])
+- `if` statements with `elseif` branches are treated as if they were nested simple `if/else` statements
 - a [=syntax/switch_body=] starting with `default` behaves just like a [=syntax/switch_body=] starting with `case _:`
 
 <table class='data'>
@@ -5862,8 +5876,8 @@ For the purpose of this analysis:
     <td class="nowrap">|e1|: |B1|<br>
         ...<br>
         |en|: |Bn|<br>
-        |f|'s body has behavior |B|
-    <td class="nowrap">|B| &cup; (|B1| &cup; ... &cup; |Bn|)&#x2216;{Next}
+        |f|'s has behavior |B|
+    <td class="nowrap">|B| &cup; ((|B1| &cup; ... &cup; |Bn|)&#x2216;{Next})
   <tr>
     <td class="nowrap">Any literal
     <td>
@@ -5970,6 +5984,26 @@ Here are some examples showing this analysis in action:
         a = a + 1;    // Error: the previous statement is missing "Next" in its behavior
       }
     }
+   </xmp>
+</div>
+
+<div class='example wgsl' heading='if/elseif/else behaves like a nested if/else'>
+   <xmp highlight='rust'>
+    fn if_example() {
+      var a: i32 = 0;
+      loop {
+        // if (e1) s1 elseif (e2) s2 else s3
+        // is identical to
+        // if (e1) else { if (e2) s2 else s3 }
+        if (a == 5) {
+          break;      // Behavior: {Break}
+        } else if (a == 42) {
+          continue;   // Behavior: {Continue}
+        } else {
+          return;     // Behavior {Return}
+        }             // Behavior of the whole if compound statement {Break, Continue, Return}
+      }               // Behavior of the whole loop compound statement {Next, Return}
+    }                 // Behavior of the whole function {Next}
    </xmp>
 </div>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5883,7 +5883,7 @@ Similarly, if statements without an else branch are treated as if they had an em
 All functions in the standard library have [=behavior=] {Default}.
 And all operators other than `||` and `&&` behave as function calls with [=behavior=] {Default}.
 
-The shader must be rejected if it violates the rules for functions (above) or if it contains a statement or expression where none of the rules above apply because of preconditions.
+It is a [=shader-creation error=] if any of the rules for functions (above) are violated or if it contains a statement or expression where none of the rules above apply because of preconditions.
 
 ### Notes ### {#behaviors-notes}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5709,9 +5709,9 @@ Note: If the function [=return value|returns a value=], that value is ignored.
 </div>
 
 
-## Statements behavior analysis ## {#behaviors}
+## Statements Behavior Analysis ## {#behaviors}
 
-### Rules
+### Rules ### {#behaviors-rules}
 
 Some statements affecting control-flow are only valid in some contexts.
 For example, `fallthrough` is invalid outside of a switch, and `continue` is invalid outside of a loop.
@@ -5871,7 +5871,7 @@ All functions in the standard library count as having a body with behavior {Defa
 
 The shader must be rejected if it violates the rules for functions (above) or if it contains a statement or expression where none of the rules above apply because of preconditions.
 
-### Notes
+### Notes ### {#behaviours-notes}
 
 Here is the full list of ways that these rules can cause a program to be rejected (this is just restating information already listed above):
 - The body of a function (treated as a regular statement) has a behavior not included in {Default, Return, Discard}.
@@ -5882,7 +5882,7 @@ Here is the full list of ways that these rules can cause a program to be rejecte
 
 This analysis can be run in linear time, by analyzing the call-graph bottom-up (since the behavior of a function call can depend on the function's code).
 
-### Examples
+### Examples ### {#behaviors-examples}
 
 Here are some examples showing this analysis in action:
 <div class='example wgsl expect-error' heading='Trivially dead code is rejected'>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5815,33 +5815,42 @@ The reason is that only functions without a return type can have such a [=behavi
         *sn*: *Bn*
     <td class="nowrap">*B*&#x2216;{Next} &cup; B1 &cup; ... &cup; Bn
   <tr>
-    <td class="nowrap">loop {*s*}
-    <td class="nowrap">*s*: *B*
-    <td class="nowrap">let b = *B*&#x2216;{Next};<br>
-        if (Break in b) b = b&#x2216;{Break} &cup; {Next};<br>
-        b&#x2216;{Continue}
-  <tr>
-    <td class="nowrap">loop {*s1* continuing {*s2*}}
+    <td class="nowrap" rowspan=2>loop {*s1* continuing {*s2*}}
     <td class="nowrap">*s1*: *B1*<br>
         *s2*: *B2*<br>
-        None of {Continue, Return, Discard} are in *B2*
-    <td class="nowrap">let b = (*B1* &cup; *B2*)&#x2216;{Next};<br>
-        if (Break in b) b = b&#x2216;{Break} &cup; {Next};<br>
-        b&#x2216;{Continue}
+        None of {Continue, Return, Discard} are in *B2*<br>
+        Break is not in (*B1* &cup; *B2*)
+    <td class="nowrap">(*B1*&#x2216;{Continue}) &cup; (*B2*&#x2216{Next})
   <tr>
-    <td class="nowrap">switch(*e*) {case _: *s1* ... case _: *sn*}
+    <td class="nowrap">*s1*: *B1*<br>
+        *s2*: *B2*<br>
+        None of {Continue, Return, Discard} are in *B2*<br/>
+        Break is in (*B1* &cup; *B2*)
+    <td class="nowrap">(*B1* &cup; *B2* &cup; {Next})&#x2216;{Break, Continue}
+  <tr>
+    <td class="nowrap" rowspan=2>switch(*e*) {case _: *s1* ... case _: *sn*}
     <td class="nowrap">*e*: *B*<br>
         *s1*: *B1*<br>
         ...<br>
         *sn*: *Bn*<br>
-        Fallthrough is not in *Bn*
-    <td class="nowrap">let b = *B*&#x2216;{Next} &cup; B1 &cup; ... &cup; Bn;<br>
-        if (Break in b) b = b&#x2216;{Break} &cup; {Next};<br>
-        b&#x2216;{Fallthrough}
+        Fallthrough is not in *Bn*<br>
+        Break is not in (B1 &cup; ... &cup; Bn)
+    <td class="nowrap">(*B* &cup; B1 &cup; ... &cup; Bn)&#x2216;{Fallthrough}
+  <tr>
+    <td class="nowrap">*e*: *B*<br>
+        *s1*: *B1*<br>
+        ...<br>
+        *sn*: *Bn*<br>
+        Fallthrough is not in *Bn*<br>
+        Break is in (B1 &cup; ... &cup; Bn)
+    <td class="nowrap">(*B* &cup; B1 &cup; ... &cup; Bn &cup; {Next})&#x2216;{Break, Fallthrough}
 </table>
 
-`for` loops get desugared before this analysis is performed, see [[#for-statement]].
-Similarly, if statements without an else branch are treated as if they had an empty else branch (which adds Next to their [=behavior=]).
+For the purpose of this analysis:
+- `for` loops get desugared (see [[#for-statement]])
+- `loop {s}` is treated as `loop {s continuing {}}`
+- `if` statements without an `else` branch are treated as if they had an empty else branch (which adds Next to their [=behavior=])
+- a [=syntax/switch_body=] starting with `default` behaves just like a [=syntax/switch_body=] starting with `case _:`
 
 <table class='data'>
   <caption>Rules for analyzing and validating the behaviors of expressions</caption>
@@ -5884,7 +5893,8 @@ Similarly, if statements without an else branch are treated as if they had an em
     <td class="nowrap">*B1* &cup; *B2*
 </table>
 
-Any other expression (not listed in the table above), and each [=built-in function=] has a [=behavior=] of {Next}.
+Each [=built-in function=] has a [=behavior=] of {Next}.
+And each operator application not listed in the table above has the same [=behavior=] as if it were a function call with the same operands and with a function's [=behavior=] of {Next}.
 
 A [=shader-creation error=] results if behavior analysis fails:
 - Behavior analysis must be able to determine a [=behavior=] for each statement, expression, and function. This can only fail if preconditions are not met.
@@ -5904,8 +5914,6 @@ Here is the full list of ways that these rules can cause a program to be rejecte
 - The behavior of a compute or vertex entry point function contains Discard
 
 This analysis can be run in linear time, by analyzing the call-graph bottom-up (since the behavior of a function call can depend on the function's code).
-
-As a result of the rules above, no expression, statement, or function can have an empty [=behavior=].
 
 ### Examples ### {#behaviors-examples}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5755,42 +5755,42 @@ The reason is that only functions without a return type can have such a [=behavi
     <tr><th>Statement<th>Preconditions<th>Resulting behavior
   </thead>
   <tr>
-    <td class="nowrap">*s1* ; *s2*
-    <td class="nowrap">*s1*: *B1*<br>
-        Next in *B1*<br>
-        *s2*: *B2*
-    <td class="nowrap">*B1*&#x2216;{Next} &cup; *B2*
+    <td class="nowrap">|s1| ; |s2|
+    <td class="nowrap">|s1|: |B1|<br>
+        Next in |B1|<br>
+        |s2|: |B2|
+    <td class="nowrap">|B1|&#x2216;{Next} &cup; |B2|
   <tr>
     <td class="nowrap">var x:T;
     <td>
     <td>{Next}
   <tr>
-    <td class="nowrap">let x = *e*;
-    <td class="nowrap">*e*: *B*
-    <td>*B*
+    <td class="nowrap">let x = |e|;
+    <td class="nowrap">|e|: |B|
+    <td>|B|
   <tr>
-    <td class="nowrap">var x = *e*;
-    <td class="nowrap">*e*: *B*
-    <td>*B*
+    <td class="nowrap">var x = |e|;
+    <td class="nowrap">|e|: |B|
+    <td>|B|
   <tr>
-    <td class="nowrap">x = *e*;
-    <td class="nowrap">*e*: *B*
-    <td>*B*
+    <td class="nowrap">x = |e|;
+    <td class="nowrap">*e*: |B|
+    <td>|B|
   <tr>
-    <td class="nowrap">f(*e_1*, ..., *e_n*);
-    <td class="nowrap">*e_1*: *B_1*<br>
+    <td class="nowrap">|f|(|e1|, ..., |en|);
+    <td class="nowrap">|e1|: |B1|<br>
         ...<br>
-        *e_n*: *B_n*<br>
-        *f*'s body has behavior *B*
-    <td class="nowrap">*B* &cup; (*B_1* &cup; ... &cup; *B_n*)&#x2216;{Next}
+        |en|: |Bn|<br>
+        |f|'s body has behavior |B|
+    <td class="nowrap">|B| &cup; (|B1| &cup; ... &cup; |Bn|)&#x2216;{Next}
   <tr>
     <td>return;
     <td>
     <td>{Return}
   <tr>
-    <td class="nowrap">return *e*;
-    <td class="nowrap">*e*: *B*<br>
-    <td class="nowrap">*B*&#x2216;{Next} &cup; {Return}
+    <td class="nowrap">return |e|;
+    <td class="nowrap">|e|: |B|<br>
+    <td class="nowrap">|B|&#x2216;{Next} &cup; {Return}
   <tr>
     <td>discard;
     <td>
@@ -5808,42 +5808,42 @@ The reason is that only functions without a return type can have such a [=behavi
     <td>
     <td>{Fallthrough}
   <tr>
-    <td class="nowrap">if (*e*) *s1* elseif *s2* ...  else *sn*
-    <td class="nowrap">*e: B*<br>
-        *s1*: *B1*<br>
+    <td class="nowrap">if (|e|) |s1| elseif |s2| ...  else |sn|
+    <td class="nowrap">|e|: |B|<br>
+        |s1|: |B1|<br>
         ...<br>
-        *sn*: *Bn*
-    <td class="nowrap">*B*&#x2216;{Next} &cup; B1 &cup; ... &cup; Bn
+        |sn|: |Bn|
+    <td class="nowrap">|B|&#x2216;{Next} &cup; |B1| &cup; ... &cup; |Bn|
   <tr>
-    <td class="nowrap" rowspan=2>loop {*s1* continuing {*s2*}}
-    <td class="nowrap">*s1*: *B1*<br>
-        *s2*: *B2*<br>
-        None of {Continue, Return, Discard} are in *B2*<br>
-        Break is not in (*B1* &cup; *B2*)
-    <td class="nowrap">(*B1*&#x2216;{Continue}) &cup; (*B2*&#x2216{Next})
+    <td class="nowrap" rowspan=2>loop {|s1| continuing {|s2|}}
+    <td class="nowrap">|s1|: |B1|<br>
+        |s2|: |B2|<br>
+        None of {Continue, Return, Discard} are in |B2|<br>
+        Break is not in (|B1| &cup; |B2|)
+    <td class="nowrap">(|B1|&#x2216;{Continue}) &cup; (|B2|&#x2216{Next})
   <tr>
-    <td class="nowrap">*s1*: *B1*<br>
-        *s2*: *B2*<br>
-        None of {Continue, Return, Discard} are in *B2*<br/>
-        Break is in (*B1* &cup; *B2*)
-    <td class="nowrap">(*B1* &cup; *B2* &cup; {Next})&#x2216;{Break, Continue}
+    <td class="nowrap">|s1|: |B1|<br>
+        |s2|: |B2|<br>
+        None of {Continue, Return, Discard} are in |B2|<br/>
+        Break is in (|B1| &cup; |B2|)
+    <td class="nowrap">(|B1| &cup; |B2| &cup; {Next})&#x2216;{Break, Continue}
   <tr>
-    <td class="nowrap" rowspan=2>switch(*e*) {case _: *s1* ... case _: *sn*}
-    <td class="nowrap">*e*: *B*<br>
-        *s1*: *B1*<br>
+    <td class="nowrap" rowspan=2>switch(|e|) {case _: |s1| ... case _: |sn|}
+    <td class="nowrap">|e|: |B|<br>
+        |s1|: |B1|<br>
         ...<br>
-        *sn*: *Bn*<br>
-        Fallthrough is not in *Bn*<br>
-        Break is not in (B1 &cup; ... &cup; Bn)
-    <td class="nowrap">(*B* &cup; B1 &cup; ... &cup; Bn)&#x2216;{Fallthrough}
+        |sn|: |Bn|<br>
+        Fallthrough is not in |Bn|<br>
+        Break is not in (|B1| &cup; ... &cup; |Bn|)
+    <td class="nowrap">(|B| &cup; |B1| &cup; ... &cup; |Bn|)&#x2216;{Fallthrough}
   <tr>
-    <td class="nowrap">*e*: *B*<br>
-        *s1*: *B1*<br>
+    <td class="nowrap">|e|: |B|<br>
+        |s1|: |B1|<br>
         ...<br>
-        *sn*: *Bn*<br>
-        Fallthrough is not in *Bn*<br>
-        Break is in (B1 &cup; ... &cup; Bn)
-    <td class="nowrap">(*B* &cup; B1 &cup; ... &cup; Bn &cup; {Next})&#x2216;{Break, Fallthrough}
+        |sn|: |Bn|<br>
+        Fallthrough is not in |Bn|<br>
+        Break is in (|B1| &cup; ... &cup; |Bn|)
+    <td class="nowrap">(|B| &cup; |B1| &cup; ... &cup; |Bn| &cup; {Next})&#x2216;{Break, Fallthrough}
 </table>
 
 For the purpose of this analysis:
@@ -5858,12 +5858,12 @@ For the purpose of this analysis:
     <tr><th>Expression<th>Preconditions<th>Resulting behavior
   </thead>
   <tr>
-    <td class="nowrap">f(*e_1*, ..., *e_n*)
-    <td class="nowrap">*e_1*: *B_1*<br>
+    <td class="nowrap">|f|(|e1|, ..., |en|)
+    <td class="nowrap">|e1|: |B1|<br>
         ...<br>
-        *e_n*: *B_n*<br>
-        *f*'s body has behavior *B*
-    <td class="nowrap">*B* &cup; (*B_1* &cup; ... &cup; *B_n*)&#x2216;{Next}
+        |en|: |Bn|<br>
+        |f|'s body has behavior |B|
+    <td class="nowrap">|B| &cup; (|B1| &cup; ... &cup; |Bn|)&#x2216;{Next}
   <tr>
     <td class="nowrap">Any literal
     <td>
@@ -5873,24 +5873,24 @@ For the purpose of this analysis:
     <td>
     <td class="nowrap">{Next}
   <tr>
-    <td class="nowrap">e1[e2]
-    <td class="nowrap">*e1*: *B1*<br>
-        *e2*: *B2*
-    <td class="nowrap">*B1* &cup; *B2*
+    <td class="nowrap">|e1|[|e2|]
+    <td class="nowrap">|e1|: |B1|<br>
+        |e2|: |B2|
+    <td class="nowrap">|B1| &cup; |B2|
   <tr>
-    <td class="nowrap">e.field
-    <td class="nowrap">*e*: *B*
-    <td class="nowrap">*B*
+    <td class="nowrap">|e|.field
+    <td class="nowrap">|e|: |B|
+    <td class="nowrap">|B|
   <tr>
-    <td class="nowrap">e1 || e2
-    <td class="nowrap">*e1*: *B1*<br>
-        *e2*: *B2*
-    <td class="nowrap">*B1* &cup; *B2*
+    <td class="nowrap">|e1| || |e2|
+    <td class="nowrap">|e1|: |B1|<br>
+        |e2|: |B2|
+    <td class="nowrap">|B1| &cup; |B2|
   <tr>
-    <td class="nowrap">e1 && e2
-    <td class="nowrap">*e1*: *B1*<br>
-        *e2*: *B2*
-    <td class="nowrap">*B1* &cup; *B2*
+    <td class="nowrap">|e1| && |e2|
+    <td class="nowrap">|e1|: |B1|<br>
+        |e2|: |B2|
+    <td class="nowrap">|B1| &cup; |B2|
 </table>
 
 Each [=built-in function=] has a [=behavior=] of {Next}.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5711,6 +5711,8 @@ Note: If the function [=return value|returns a value=], that value is ignored.
 
 ## Statements behavior analysis ## {#behaviors}
 
+### Rules
+
 Some statements affecting control-flow are only valid in some contexts.
 For example, `fallthrough` is invalid outside of a switch, and `continue` is invalid outside of a loop.
 Additionally, the uniformity analysis (see [[#uniformity]]) needs to know when control flow can exit a statement in two different ways.
@@ -5737,7 +5739,6 @@ For each function:
 We assign a behavior to each function: it is its body's behavior, with any "Return" replaced by "Default".
 As a consequence of the rules above, a function behavior is always one of {Default}, {Discard} or {Default, Discard}.
 
-
 Similarly, we assign a behavior to each expression, since expressions can include function calls, which can discard.
 Expression behaviors are always one of {Default}, {Discard}, or {Default, Discard}.
 
@@ -5754,7 +5755,7 @@ The reason is that only functions without a return type can have such a behavior
     <td class="nowrap">*s1*: *B1*<br>
         Default in *B1*<br>
         *s2*: *B2*
-    <td class="nowrap">*B1*\{Default} U *B2*
+    <td class="nowrap">*B1*∖{Default} ∪ *B2*
   <tr>
     <td class="nowrap">A variable declaration or assignment
     <td>
@@ -5765,7 +5766,7 @@ The reason is that only functions without a return type can have such a behavior
         ...<br>
         *e_n*: *B_n*<br>
         *f*'s body has behavior *B*
-    <td class="nowrap">*B* U (*B_1* U ... U *B_n*)\{Default}
+    <td class="nowrap">*B* ∪ (*B_1* ∪ ... ∪ *B_n*)∖{Default}
   <tr>
     <td>return;
     <td>
@@ -5773,7 +5774,7 @@ The reason is that only functions without a return type can have such a behavior
   <tr>
     <td class="nowrap">return *e*;
     <td class="nowrap">*e*: *B*<br>
-    <td class="nowrap">*B*\{Default} U {Return}
+    <td class="nowrap">*B*∖{Default} ∪ {Return}
   <tr>
     <td>discard;
     <td>
@@ -5795,22 +5796,22 @@ The reason is that only functions without a return type can have such a behavior
     <td class="nowrap">*e: B*<br>
         *s1*: *B1*<br>
         *s2*: *B2*
-    <td class="nowrap">*B*\{Default} U B1 U B2
+    <td class="nowrap">*B*∖{Default} ∪ B1 ∪ B2
   <tr>
     <td class="nowrap">loop {*s*}
     <td class="nowrap">*s*: *B*
-    <td class="nowrap">let b = *B* \ {Default};<br>
-        if (Continue in b) b = b \ {Continue};<br>
-        if (Break in b) b = b \ {Break} U {Default};<br>
+    <td class="nowrap">let b = *B*∖{Default};<br>
+        if (Continue in b) b = b∖{Continue};<br>
+        if (Break in b) b = b∖{Break} ∪ {Default};<br>
         b
   <tr>
     <td class="nowrap">loop {*s1* continuing {*s2*}}
     <td class="nowrap">*s1*: *B1*<br>
         *s2*: *B2*<br>
         None of {Break, Continue, Discard, Return} are in *B2*
-    <td class="nowrap">let b = (*B1* U *B2*) \ {Default};<br>
-        if (Continue in b) b = b \ {Continue};<br>
-        if (Break in b) b = b \ {Break} U {Default};<br>
+    <td class="nowrap">let b = (*B1* ∪ *B2*)∖{Default};<br>
+        if (Continue in b) b = b∖{Continue};<br>
+        if (Break in b) b = b∖{Break} ∪ {Default};<br>
         b
   <tr>
     <td class="nowrap">switch(*e*) {case _: *s_1* ... case _: *s_n*}
@@ -5819,9 +5820,9 @@ The reason is that only functions without a return type can have such a behavior
         ...<br>
         *s_n*: *B_n*<br>
         Fallthrough is not in *B_n*
-    <td class="nowrap">let b = *B* \ {Default} U B_1 U ... U B_n;<br>
-        if (Fallthrough in b) b = b \ {Fallthrough};<br>
-        if (Break in b) b = b \ {Break} U {Default};<br>
+    <td class="nowrap">let b = *B*∖{Default} ∪ B_1 ∪ ... ∪ B_n;<br>
+        if (Fallthrough in b) b = b∖{Fallthrough};<br>
+        if (Break in b) b = b∖{Break} ∪ {Default};<br>
         b
 </table>
 
@@ -5836,7 +5837,7 @@ The reason is that only functions without a return type can have such a behavior
         ...<br>
         *e_n*: *B_n*<br>
         *f*'s body has behavior *B*
-    <td class="nowrap">*B* U (*B_1* U ... U *B_n*)\{Default}
+    <td class="nowrap">*B* ∪ (*B_1* ∪ ... ∪ *B_n*)∖{Default}
   <tr>
     <td class="nowrap">Any literal
     <td>
@@ -5849,7 +5850,7 @@ The reason is that only functions without a return type can have such a behavior
     <td class="nowrap">e1[e2]
     <td class="nowrap">*e1*: *B1*<br>
         *e2*: *B2*
-    <td class="nowrap">*B1* U *B2*
+    <td class="nowrap">*B1* ∪ *B2*
   <tr>
     <td class="nowrap">e.field
     <td class="nowrap">*e*: *B*
@@ -5858,17 +5859,29 @@ The reason is that only functions without a return type can have such a behavior
     <td class="nowrap">e1 || e2
     <td class="nowrap">*e1*: *B1*<br>
         *e2*: *B2*
-    <td class="nowrap">*B1* U *B2*
+    <td class="nowrap">*B1* ∪ *B2*
   <tr>
     <td class="nowrap">e1 && e2
     <td class="nowrap">*e1*: *B1*<br>
         *e2*: *B2*
-    <td class="nowrap">*B1* U *B2*
+    <td class="nowrap">*B1* ∪ *B2*
 </table>
 
 All functions in the standard library count as having a body with behavior {Default}.
 
+The shader must be rejected if it violates the rules for functions (above) or if it contains a statement or expression where none of the rules above apply because of preconditions.
+
+### Notes
+
+Here is the full list of ways that these rules can cause a program to be rejected (this is just restating information already listed above):
+- The body of a function (treated as a regular statement) has a behavior not included in {Default, Return, Discard}.
+- The body of a function with a return type has a behavior which is neither {Return} nor {Return, Discard}
+- A statement without Default in its behavior is not the last in a sequence of statements
+- The behavior of a continuing block contains any of {Break, Continue, Return, Discard}
+
 This analysis can be run in linear time, by analyzing the call-graph bottom-up (since the behavior of a function call can depend on the function's code).
+
+### Examples
 
 Here are some examples showing this analysis in action:
 <div class='example wgsl expect-error' heading='Trivially dead code is rejected'>
@@ -6960,7 +6973,7 @@ the following exceptions:
 * No floating point exceptions are generated.
 * Signaling NaNs may not be generated.
     Any signaling NaN may be converted to a quiet NaN.
-* Implementations may assume that NaNs, inifinities are not present
+* Implementations may assume that NaNs, infinities are not present
     * Note: This means some functions (e.g. `isInf`, `isNan`, `min` and `max`)
         may not return the expected result due to optimizations about the presence
         of NaNs and infinities.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5884,8 +5884,7 @@ Similarly, if statements without an else branch are treated as if they had an em
 Any other expression (not listed in the table above), and each [=built-in function=] has a [=behavior=] of {Next}.
 
 A [=shader-creation error=] results if behavior analysis fails:
-- Behavior analysis must be able to determine a [=behavior=] for each statement, expression, and function.
-  This can only fail if preconditions are not met.
+- Behavior analysis must be able to determine a [=behavior=] for each statement, expression, and function. This can only fail if preconditions are not met.
 - The function behaviors must satisfy the rules given above.
 - The behaviors of compute and vertex entry points must not contain Discard.
 


### PR DESCRIPTION
As discussed two weeks ago (https://docs.google.com/document/d/1jeskYAgEa8ay-RlEnlfkDXXGvKIVkxF-QQqw9Idr1Xc/edit#heading=h.hp3f2zbslxr9), the behaviors analysis I originally wrote for the uniformity analysis also subsumes the rules about control-flow interruption proposed in https://github.com/gpuweb/gpuweb/pull/2096.

I borrowed the examples from that PR, and added a few more. It is interesting to note that there are a few cases where a program is rejected by my analysis, despite being accepted by that PR (code which is syntactically dead, but not so trivially that it is detected by that PR).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Nov 4, 2021, 1:04 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fgpuweb%2Fgpuweb%2F7d275f59d93697c8e4cda348d9e0e8a5a3333a9d%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%232216.)._
</details>
