### PR TITLE
Trailing commas in WebIDL enums are not allowed

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1382,7 +1382,7 @@ to represent color values outside of its space (in both chrominance and luminanc
 
 <script type=idl>
 enum GPUPredefinedColorSpace {
-    "srgb",
+    "srgb"
 };
 </script>
 
@@ -1780,7 +1780,7 @@ enum GPUFeatureName {
     "texture-compression-bc",
     "texture-compression-etc2",
     "texture-compression-astc",
-    "timestamp-query",
+    "timestamp-query"
 };
 </script>
 
@@ -2384,7 +2384,7 @@ dictionary GPUTextureDescriptor : GPUObjectDescriptorBase {
 enum GPUTextureDimension {
     "1d",
     "2d",
-    "3d",
+    "3d"
 };
 </script>
 
@@ -2888,7 +2888,7 @@ enum GPUTextureFormat {
     "depth24unorm-stencil8",
 
     // "depth32float-stencil8" feature
-    "depth32float-stencil8",
+    "depth32float-stencil8"
 };
 </script>
 
@@ -3483,7 +3483,7 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
 enum GPUBufferBindingType {
     "uniform",
     "storage",
-    "read-only-storage",
+    "read-only-storage"
 };
 
 dictionary GPUBufferBindingLayout {
@@ -3513,7 +3513,7 @@ dictionary GPUBufferBindingLayout {
 enum GPUSamplerBindingType {
     "filtering",
     "non-filtering",
-    "comparison",
+    "comparison"
 };
 
 dictionary GPUSamplerBindingLayout {
@@ -3535,7 +3535,7 @@ enum GPUTextureSampleType {
   "unfilterable-float",
   "depth",
   "sint",
-  "uint",
+  "uint"
 };
 
 dictionary GPUTextureBindingLayout {
@@ -3568,7 +3568,7 @@ truly optional.
 
 <script type=idl>
 enum GPUStorageTextureAccess {
-    "write-only",
+    "write-only"
 };
 
 dictionary GPUStorageTextureBindingLayout {
@@ -5313,7 +5313,7 @@ enum GPUVertexFormat {
     "sint32",
     "sint32x2",
     "sint32x3",
-    "sint32x4",
+    "sint32x4"
 };
 </script>
 
@@ -8886,7 +8886,7 @@ initially set to: &laquo;{{GPUTextureFormat/"bgra8unorm"}}, {{GPUTextureFormat/"
 
 enum GPUCanvasCompositingAlphaMode {
     "opaque",
-    "premultiplied",
+    "premultiplied"
 };
 
 dictionary GPUCanvasConfiguration {
@@ -8994,7 +8994,7 @@ This enum selects how the contents of the canvas' context will paint onto the pa
 
 <script type=idl>
 enum GPUDeviceLostReason {
-    "destroyed",
+    "destroyed"
 };
 
 [Exposed=(Window, DedicatedWorker)]


### PR DESCRIPTION
They are contrary to the WebIDL spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/litherum/gpuweb/pull/2230.html" title="Last updated on Oct 31, 2021, 8:26 PM UTC (f41e03d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2230/f6cb66a...litherum:f41e03d.html" title="Last updated on Oct 31, 2021, 8:26 PM UTC (f41e03d)">Diff</a>