### PR TITLE
Style: make whitespace consistent

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3531,11 +3531,11 @@ dictionary GPUSamplerBindingLayout {
 
 <script type=idl>
 enum GPUTextureSampleType {
-  "float",
-  "unfilterable-float",
-  "depth",
-  "sint",
-  "uint",
+    "float",
+    "unfilterable-float",
+    "depth",
+    "sint",
+    "uint",
 };
 
 dictionary GPUTextureBindingLayout {


### PR DESCRIPTION
Everywhere else uses 4 spaces for indentation, so this one place should too.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/litherum/gpuweb/pull/2232.html" title="Last updated on Nov 1, 2021, 5:52 AM UTC (05745ce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2232/f6cb66a...litherum:05745ce.html" title="Last updated on Nov 1, 2021, 5:52 AM UTC (05745ce)">Diff</a>