### PR TITLE
Style changes about command encoder state

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5555,49 +5555,48 @@ GPUCommandEncoder includes GPUObjectBase;
 <dl dfn-type=attribute dfn-for="GPUCommandEncoder">
     : <dfn>\[[command_list]]</dfn> of type [=list=]&lt;[=GPU command=]&gt;.
     ::
-        A [=list=] of [=GPU command=] to be executed on the [=Queue timeline=] when the
+        A [=list=] of [=GPU commands=] to be executed on the [=Queue timeline=] when the
         {{GPUCommandBuffer}} this encoder produces is submitted.
 
-    : <dfn>\[[state]]</dfn> of type {{encoder state}}.
+    : <dfn>\[[state]]</dfn> of type [=encoder state=].
     ::
-        The current state of the {{GPUCommandEncoder}}, initially set to {{encoder state/open}}.
+        The current state of the {{GPUCommandEncoder}}, initially set to [=encoder state/open=].
 
     : <dfn>\[[debug_group_stack]]</dfn> of type [=stack=]&lt;{{USVString}}&gt;.
     ::
         A stack of active debug group labels.
 </dl>
 
-Each {{GPUCommandEncoder}} has a current <dfn dfn-type="enum">encoder state</dfn> on the [=Content timeline=]
+Each {{GPUCommandEncoder}} has a current <dfn dfn>encoder state</dfn> on the [=Content timeline=]
 which may be one of the following:
 
-<dl dfn-type="enum-value" dfn-for="encoder state">
-    : "<dfn>open</dfn>"
+<dl dfn-type=dfn dfn-for="encoder state">
+    : <dfn>open</dfn>
     ::
         Indicates the {{GPUCommandEncoder}} is available to begin new operations. The {{GPUCommandEncoder/[[state]]}} is
-        {{encoder state/open}} any time the {{GPUCommandEncoder}} is [=valid=] and has no active
+        [=encoder state/open=] any time the {{GPUCommandEncoder}} is [=valid=] and has no active
         {{GPURenderPassEncoder}} or {{GPUComputePassEncoder}}.
 
-    : "<dfn>encoding a render pass</dfn>"
+    : <dfn>encoding a render pass</dfn>
     ::
         Indicates the {{GPUCommandEncoder}} has an active {{GPURenderPassEncoder}}. The
-        {{GPUCommandEncoder/[[state]]}} becomes {{encoder state/encoding a render pass}} once
+        {{GPUCommandEncoder/[[state]]}} becomes [=encoder state/encoding a render pass=] once
         {{GPUCommandEncoder/beginRenderPass()}} is called sucessfully until {{GPURenderPassEncoder/endPass()}} is called
         on the returned {{GPURenderPassEncoder}}, at which point the {{GPUCommandEncoder/[[state]]}}
-        (if the encoder is still valid) reverts to {{encoder state/open}}.
+        (if the encoder is still valid) reverts to [=encoder state/open=].
 
-    : "<dfn>encoding a compute pass</dfn>"
+    : <dfn>encoding a compute pass</dfn>
     ::
         Indicates the {{GPUCommandEncoder}} has an active {{GPUComputePassEncoder}}.  The
-        {{GPUCommandEncoder/[[state]]}} becomes {{encoder state/encoding a compute pass}} once
+        {{GPUCommandEncoder/[[state]]}} becomes [=encoder state/encoding a compute pass=] once
         {{GPUCommandEncoder/beginComputePass()}} is called sucessfully until {{GPUComputePassEncoder/endPass()}} is
         called on the returned {{GPUComputePassEncoder}}, at which point the {{GPUCommandEncoder/[[state]]}}
-        (if the encoder is still valid) reverts to {{encoder state/open}}.
+        (if the encoder is still valid) reverts to [=encoder state/open=].
 
-    : "<dfn>closed</dfn>"
+    : <dfn>closed</dfn>
     ::
         Indicates the {{GPUCommandEncoder}} is no longer available for any operations. The
-        {{GPUCommandEncoder/[[state]]}} becomes {{encoder state/closed}} once {{GPUCommandEncoder/finish()}} is called
-        or the {{GPUCommandEncoder}} otherwise becomes [=invalid=].
+        {{GPUCommandEncoder/[[state]]}} becomes [=encoder state/closed=] once {{GPUCommandEncoder/finish()}} is called.
 </dl>
 
 ### Creation ### {#command-encoder-creation}
@@ -5656,7 +5655,7 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                 1. If any of the following conditions are unsatisfied, generate a validation
                     error and stop.
                     <div class=validusage>
-                        - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
+                        - |this|.{{GPUCommandEncoder/[[state]]}} is [=encoder state/open}}.
                         - |descriptor| meets the
                             [$GPURenderPassDescriptor/Valid Usage$] rules.
                         - |descriptor|.{{GPURenderPassDescriptor/timestampWrites}} is empty, or
@@ -5665,7 +5664,7 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                         - For each |timestampWrite| in |descriptor|.{{GPURenderPassDescriptor/timestampWrites}},
                             - |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}} is [$valid to use with$] |this|.
                     </div>
-                1. Set |this|.{{GPUCommandEncoder/[[state]]}} to {{encoder state/encoding a render pass}}.
+                1. Set |this|.{{GPUCommandEncoder/[[state]]}} to [=encoder state/encoding a render pass}}.
                 1. For each |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
                     1. The [=texture subresource=] seen by |colorAttachment|.{{GPURenderPassColorAttachment/view}}
                         is considered to be used as [=internal usage/attachment=] for the
@@ -5716,14 +5715,14 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                 1. If any of the following conditions are unsatisfied, generate a validation
                     error and stop.
                     <div class=validusage>
-                        - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
+                        - |this|.{{GPUCommandEncoder/[[state]]}} is [=encoder state/open}}.
                         - |descriptor|.{{GPUComputePassDescriptor/timestampWrites}} is empty, or
                             |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} [=list/contain=]s
                             {{GPUFeatureName/"timestamp-query"}}.
                         - For each |timestampWrite| in |descriptor|.{{GPUComputePassDescriptor/timestampWrites}},
                             - |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}} is [$valid to use with$] |this|.
                     </div>
-                1. Set |this|.{{GPUCommandEncoder/[[state]]}} to {{encoder state/encoding a compute pass}}.
+                1. Set |this|.{{GPUCommandEncoder/[[state]]}} to [=encoder state/encoding a compute pass}}.
                 1. Let |pass| be a new {{GPUComputePassEncoder}} object.
                 1. For each |timestampWrite| in |descriptor|.{{GPUComputePassDescriptor/timestampWrites}},
                     1. If |timestampWrite|.{{GPUComputePassTimestampWrite/location}} is {{GPUComputePassTimestampLocation/"beginning"}},
@@ -5966,7 +5965,7 @@ dictionary GPUImageCopyExternalImage {
 
             If any of the following conditions are unsatisfied, generate a validation error and stop.
             <div class=validusage>
-                - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
+                - |this|.{{GPUCommandEncoder/[[state]]}} is [=encoder state/open=].
                 - |source| is [$valid to use with$] |this|.
                 - |destination| is [$valid to use with$] |this|.
                 - |source|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/COPY_SRC}}.
@@ -6009,7 +6008,7 @@ dictionary GPUImageCopyExternalImage {
 
             If any of the following conditions are unsatisfied, generate a validation error and stop.
             <div class=validusage>
-                - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
+                - |this|.{{GPUCommandEncoder/[[state]]}} is [=encoder state/open=].
                 - |destination| is [$valid to use with$] |this|.
                 - |destination|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/COPY_DST}}.
                 - |size| is a multiple of 4.
@@ -6168,7 +6167,7 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
             If any of the following conditions are unsatisfied, generate a validation error and stop.
             <div class=validusage>
                 - Let |dstTextureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
-                - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
+                - |this|.{{GPUCommandEncoder/[[state]]}} is [=encoder state/open=].
                 - [$validating GPUImageCopyBuffer$](|source|) returns `true`.
                 - |source|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/COPY_SRC}}.
                 - [$validating GPUImageCopyTexture$](|destination|, |copySize|) returns `true`.
@@ -6210,7 +6209,7 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
             If any of the following conditions are unsatisfied, generate a validation error and stop.
             <div class=validusage>
                 - Let |srcTextureDesc| be |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
-                - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
+                - |this|.{{GPUCommandEncoder/[[state]]}} is [=encoder state/open=].
                 - [$validating GPUImageCopyTexture$](|source|, |copySize|) returns `true`.
                 - |srcTextureDesc|.{{GPUTextureDescriptor/usage}} contains {{GPUTextureUsage/COPY_SRC}}.
                 - |srcTextureDesc|.{{GPUTextureDescriptor/sampleCount}} is 1.
@@ -6255,7 +6254,7 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
                 <div class=validusage>
                     - Let |srcTextureDesc| be |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
                     - Let |dstTextureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
-                    - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
+                    - |this|.{{GPUCommandEncoder/[[state]]}} is [=encoder state/open=].
                     - [$validating GPUImageCopyTexture$](|source|, |copySize|) returns `true`.
                     - |srcTextureDesc|.{{GPUTextureDescriptor/usage}} contains {{GPUTextureUsage/COPY_SRC}}.
                     - [$validating GPUImageCopyTexture$](|destination|, |copySize|) returns `true`.
@@ -6321,7 +6320,7 @@ must be well nested.
             <div class=device-timeline>
                 - If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
-                        - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
+                        - |this|.{{GPUCommandEncoder/[[state]]}} is [=encoder state/open=].
                     </div>
                 - [=stack/Push=] |groupLabel| onto |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.
             </div>
@@ -6340,7 +6339,7 @@ must be well nested.
             <div class=device-timeline>
                 - If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
-                        - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
+                        - |this|.{{GPUCommandEncoder/[[state]]}} is [=encoder state/open=].
                         - |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}'s [=stack/size=] is greater than 0.
                     </div>
                 - [=stack/Pop=] an entry off |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}.
@@ -6365,7 +6364,7 @@ must be well nested.
             <div class=device-timeline>
                 - If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
-                        - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
+                        - |this|.{{GPUCommandEncoder/[[state]]}} is [=encoder state/open=].
                     </div>
             </div>
         </div>
@@ -6393,7 +6392,7 @@ must be well nested.
                 {{GPUFeatureName/"timestamp-query"}}, throw a {{TypeError}}.
             1. If any of the following conditions are unsatisfied, generate a validation error and stop.
                 <div class=validusage>
-                    - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
+                    - |this|.{{GPUCommandEncoder/[[state]]}} is [=encoder state/open=].
                     - |querySet| is [$valid to use with$] |this|.
                     - |querySet|.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/"timestamp"}}.
                     - |queryIndex| &lt; |querySet|.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}}.
@@ -6421,7 +6420,7 @@ must be well nested.
 
             If any of the following conditions are unsatisfied, generate a {{GPUValidationError}} and stop.
             <div class=validusage>
-                - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
+                - |this|.{{GPUCommandEncoder/[[state]]}} is [=encoder state/open=].
                 - |querySet| is [$valid to use with$] |this|.
                 - |destination| is [$valid to use with$] |this|.
                 - |destination|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/QUERY_RESOLVE}}.
@@ -6462,15 +6461,15 @@ command encoder can no longer be used.
                     1. If any of the following conditions are unsatisfied, generate a validation
                         error and stop.
                         <div class=validusage>
-                            - |this| is [=valid=].
-                            - |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}'s [=stack/size=] is 0.
-                            - |this|.{{GPUCommandEncoder/[[state]]}} is {{encoder state/open}}.
-                            - Every [=usage scope=] contained in |this| satisfies the [=usage scope validation=].
+                            - |this| must be [=valid=].
+                            - |this|.{{GPUCommandEncoder/[[debug_group_stack]]}}'s [=stack/size=] must be 0.
+                            - |this|.{{GPUCommandEncoder/[[state]]}} must be [=encoder state/open=].
+                            - Every [=usage scope=] contained in |this| must satisfy the [=usage scope validation=].
                         </div>
 
-                    1. Set |this|.{{GPUCommandEncoder/[[state]]}} to {{encoder state/closed}}.
-                    1. Let |commandBuffer|.{{GPUCommandBuffer/[[command_list]]}} be a [=list/clone=]
-                        of |this|.{{GPUCommandEncoder/[[command_list]]}}.
+                    1. Set |this|.{{GPUCommandEncoder/[[state]]}} to [=encoder state/closed=].
+                    1. Set |commandBuffer|.{{GPUCommandBuffer/[[command_list]]}} to
+                        |this|.{{GPUCommandEncoder/[[command_list]]}}.
                 </div>
 
             1. Return |commandBuffer|.


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Nov 1, 2021, 4:52 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fgpuweb%2Fgpuweb%2Ff6cb66a15e28156c2a47b1e6f718014da1abdaf9%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%232234.)._
</details>
