### PR TITLE
Use trailing commas in enums

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1542,7 +1542,7 @@ dictionary GPURequestAdapterOptions {
 <script type=idl>
 enum GPUPowerPreference {
     "low-power",
-    "high-performance"
+    "high-performance",
 };
 </script>
 
@@ -2584,7 +2584,7 @@ enum GPUTextureViewDimension {
     "2d-array",
     "cube",
     "cube-array",
-    "3d"
+    "3d",
 };
 </script>
 
@@ -2592,7 +2592,7 @@ enum GPUTextureViewDimension {
 enum GPUTextureAspect {
     "all",
     "stencil-only",
-    "depth-only"
+    "depth-only",
 };
 </script>
 
@@ -3131,7 +3131,7 @@ Issue: Describe a "sample footprint" in greater detail.
 enum GPUAddressMode {
     "clamp-to-edge",
     "repeat",
-    "mirror-repeat"
+    "mirror-repeat",
 };
 </script>
 
@@ -3156,7 +3156,7 @@ match one texel.
 <script type=idl>
 enum GPUFilterMode {
     "nearest",
-    "linear"
+    "linear",
 };
 </script>
 
@@ -3185,7 +3185,7 @@ enum GPUCompareFunction {
     "greater",
     "not-equal",
     "greater-equal",
-    "always"
+    "always",
 };
 </script>
 
@@ -4077,7 +4077,7 @@ integration such as source-language debugging. [[SourceMap]]
 enum GPUCompilationMessageType {
     "error",
     "warning",
-    "info"
+    "info",
 };
 
 [Exposed=(Window, DedicatedWorker), Serializable, SecureContext]
@@ -4984,7 +4984,7 @@ enum GPUPrimitiveTopology {
     "line-list",
     "line-strip",
     "triangle-list",
-    "triangle-strip"
+    "triangle-strip",
 };
 </script>
 
@@ -5022,7 +5022,7 @@ dictionary GPUPrimitiveState {
 <script type=idl>
 enum GPUFrontFace {
     "ccw",
-    "cw"
+    "cw",
 };
 </script>
 
@@ -5030,7 +5030,7 @@ enum GPUFrontFace {
 enum GPUCullMode {
     "none",
     "front",
-    "back"
+    "back",
 };
 </script>
 
@@ -5152,7 +5152,7 @@ enum GPUBlendFactor {
     "one-minus-dst-alpha",
     "src-alpha-saturated",
     "constant",
-    "one-minus-constant"
+    "one-minus-constant",
 };
 </script>
 
@@ -5162,7 +5162,7 @@ enum GPUBlendOperation {
     "subtract",
     "reverse-subtract",
     "min",
-    "max"
+    "max",
 };
 </script>
 
@@ -5205,7 +5205,7 @@ enum GPUStencilOperation {
     "increment-clamp",
     "decrement-clamp",
     "increment-wrap",
-    "decrement-wrap"
+    "decrement-wrap",
 };
 </script>
 
@@ -5232,7 +5232,7 @@ enum GPUStencilOperation {
 <script type=idl>
 enum GPUIndexFormat {
     "uint16",
-    "uint32"
+    "uint32",
 };
 </script>
 
@@ -5323,7 +5323,7 @@ As such, {{GPUVertexFormat/"sint32x3"}} denotes a 3-component vector of `i32` va
 <script type=idl>
 enum GPUVertexStepMode {
     "vertex",
-    "instance"
+    "instance",
 };
 </script>
 
@@ -6708,7 +6708,7 @@ GPUComputePassEncoder includes GPUProgrammablePassEncoder;
 <script type=idl>
 enum GPUComputePassTimestampLocation {
     "beginning",
-    "end"
+    "end",
 };
 
 dictionary GPUComputePassTimestampWrite {
@@ -7060,7 +7060,7 @@ When a {{GPURenderPassEncoder}} is created, it has the following default state:
 <script type=idl>
 enum GPURenderPassTimestampLocation {
     "beginning",
-    "end"
+    "end",
 };
 
 dictionary GPURenderPassTimestampWrite {
@@ -7309,7 +7309,7 @@ dictionary GPURenderPassDepthStencilAttachment {
 
 <script type=idl>
 enum GPULoadOp {
-    "load"
+    "load",
 };
 </script>
 
@@ -7329,7 +7329,7 @@ enum GPULoadOp {
 <script type=idl>
 enum GPUStoreOp {
     "store",
-    "discard"
+    "discard",
 };
 </script>
 
@@ -8528,7 +8528,7 @@ garbage collection by calling {{GPUQuerySet/destroy()}}.
 enum GPUQueryType {
     "occlusion",
     "pipeline-statistics",
-    "timestamp"
+    "timestamp",
 };
 </script>
 
@@ -8553,7 +8553,7 @@ enum GPUPipelineStatisticName {
     "clipper-invocations",
     "clipper-primitives-out",
     "fragment-shader-invocations",
-    "compute-shader-invocations"
+    "compute-shader-invocations",
 };
 </script>
 
@@ -8977,7 +8977,7 @@ partial interface GPUDevice {
 <script type=idl>
 enum GPUErrorFilter {
     "out-of-memory",
-    "validation"
+    "validation",
 };
 </script>
 


### PR DESCRIPTION
They're better for diffs.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/litherum/gpuweb/pull/2235.html" title="Last updated on Nov 2, 2021, 6:25 AM UTC (e913a47)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2235/dd3e6fc...litherum:e913a47.html" title="Last updated on Nov 2, 2021, 6:25 AM UTC (e913a47)">Diff</a>