### PR TITLE
Add validation rules for RenderPassEncoder.executeBundles()

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7964,12 +7964,24 @@ attachments used by this encoder.
 
             **Arguments:**
             <pre class=argumentdef for="GPURenderPassEncoder/executeBundles(bundles)">
-                bundles: List of render bundles to execute.
+                |bundles|: List of render bundles to execute.
             </pre>
 
             **Returns:** {{undefined}}
 
-            Issue: Describe {{GPURenderPassEncoder/executeBundles()}} algorithm steps.
+            Issue the following steps on the [=Device timeline=] of |this|:
+            <div class=device-timeline>
+                1. If any of the following conditions are unsatisfied, generate a validation
+                    error and stop.
+                    <div class=validusage>
+                        - For each |bundle| in |bundles|:
+                            - |bundle| must be [$valid to use with$] |this|.
+                            - |this|.{{GPURenderEncoderBase/[[layout]]}} must equal |bundle|.{{GPURenderBundle/[[layout]]}}.
+                            - |this|.{{GPURenderEncoderBase/[[depthReadOnly]]}} must equal to |bundle|.{{GPURenderBundle/[[depthReadOnly]]}}.
+                            - |this|.{{GPURenderEncoderBase/[[stencilReadOnly]]}} must equal to |bundle|.{{GPURenderBundle/[[stencilReadOnly]]}}.
+                    </div>
+            </div>
+
         </div>
 </dl>
 
@@ -8027,6 +8039,18 @@ GPURenderBundle includes GPUObjectBase;
     ::
         A [=list=] of [=GPU commands=] to be submitted to the {{GPURenderPassEncoder}} when the
         {{GPURenderBundle}} is executed.
+
+    : <dfn>\[[layout]]</dfn>, of type {{GPURenderPassLayout}}
+    ::
+        The layout of the render bundle.
+
+    : <dfn>\[[depthReadOnly]]</dfn>, of type boolean?
+    ::
+        If present, the flag indicates that the depth component of this render bundle is not modified.
+
+    : <dfn>\[[stencilReadOnly]]</dfn>, of type boolean?
+    ::
+        If present, the flag indicates that the stencil component of this render bundle is not modified.
 </dl>
 
 ### Creation ### {#render-bundle-creation}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7977,8 +7977,8 @@ attachments used by this encoder.
                         - For each |bundle| in |bundles|:
                             - |bundle| must be [$valid to use with$] |this|.
                             - |this|.{{GPURenderEncoderBase/[[layout]]}} must equal |bundle|.{{GPURenderBundle/[[layout]]}}.
-                            - |this|.{{GPURenderEncoderBase/[[depthReadOnly]]}} must equal to |bundle|.{{GPURenderBundle/[[depthReadOnly]]}}.
-                            - |this|.{{GPURenderEncoderBase/[[stencilReadOnly]]}} must equal to |bundle|.{{GPURenderBundle/[[stencilReadOnly]]}}.
+                            - If |this|.{{GPURenderEncoderBase/[[depthReadOnly]]}} is true, |bundle|.{{GPURenderBundle/[[depthReadOnly]]}} must be true.
+                            - If |this|.{{GPURenderEncoderBase/[[stencilReadOnly]]}} is true, |bundle|.{{GPURenderBundle/[[stencilReadOnly]]}} must be true.
                     </div>
             </div>
 


### PR DESCRIPTION
It also adds a few internal slots for render bundle.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Richard-Yunchao/gpuweb/pull/2240.html" title="Last updated on Nov 9, 2021, 8:02 PM UTC (f0309cc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2240/f6cb66a...Richard-Yunchao:f0309cc.html" title="Last updated on Nov 9, 2021, 8:02 PM UTC (f0309cc)">Diff</a>