### PR TITLE
Allow out of order module scope declarations

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -699,7 +699,7 @@ A <dfn noexport>directive</dfn> is a [=token=] sequence which modifies how a [SH
 program is processed by a WebGPU implementation.
 See [[#enable-directive-section]].
 
-## Declaration and scope ## {#declaration-and-scope}
+## Declaration and Scope ## {#declaration-and-scope}
 
 A <dfn noexport>declaration</dfn> associates an [=identifier=] with one of
 the following kinds of objects:
@@ -719,11 +719,11 @@ We say the identifier is <dfn noexport>in scope</dfn>
 (of the declaration) at those source locations.
 
 Each kind of declaration has its own rule for determining its scope.
-In general the scope is a span of text beginning immediately after the end of the
-declaration.
+In general, the scope is a span of text beginning immediately after the end of
+the declaration.
 
-Certain objects are provided by the WebGPU implementation,
-and are treated as if they have already been declared at the start of a [SHORTNAME] program.
+Certain objects are provided by the WebGPU implementation, and are treated as
+if they have been declared by every [SHORTNAME] program.
 We say such objects are <dfn noexport>predeclared</dfn>.
 Their scope is the entire [SHORTNAME] program.
 Examples of predeclared objects are:
@@ -737,22 +737,42 @@ the identifier will denote the object of the declaration appearing closest to
 that use.
 We say the identifier use <dfn noexport>resolves</dfn> to that declaration.
 
-Note: A declaration always precedes its identifier's scope.
-Therefore, the nearest in scope declaration of an identifier always precedes the
-use of the identifier.
+There are multiple levels of scoping depending on how and where things are
+declared.
+
+When an identifier is used, it must be in scope for some declaration, or as part of a directive.
+
+A declaration is at <dfn noexport>module scope</dfn> if the declaration appears outside
+the text of any other declaration.
+Module scope declarations are [=in scope=] of the entire program.
+That is, declarations at module scope may be referenced by statements and
+expressions that precede that declaration textually.
+
+It is a [=shader-creation error=] if any module scope declaration is recursive.
+That is, there must be no cycles among the module scope declarations.
+
+Note: The [=function body=] is part of the [=function declaration=], thus
+functions may not be recursive.
+
+Note: Use of a non-[=module scope=] identifier must succeed the declaration of
+that identifier in the text.
+This is not true, however, for [=module scope=] declarations, which may be
+referenced out of order in the text.
+
+Note: Only a [=function declaration=] can contain other declarations.
 
 <div class='example' heading='Valid and invalid declarations'>
   <xmp>
     // Invalid, cannot reuse built-in function names.
     var<private> modf: f32 = 0.0;
 
-    // Valid, foo_1 is in scope until the end of the program.
+    // Valid, foo_1 is in scope of the entire program.
     var<private> foo: f32 = 0.0; // foo_1
 
-    // Valid, bar_1 is in scope until the end of the program.
+    // Valid, bar_1 is in scope of the entire program.
     var<private> bar: u32 = 0u; // bar_1
 
-    // Valid, my_func_1 is in scope until the end of the program.
+    // Valid, my_func_1 is in scope of the entire program.
     // Valid, foo_2 is in scope until the end of the function.
     fn my_func(foo: f32) { // my_func_1, foo_2
       // Any reference to 'foo' resolves to the function parameter.
@@ -782,29 +802,23 @@ use of the identifier.
       var bar: u32; // bar_5
     }
 
-    // Invalid, bar_6 has the same end scope as bar_1.
+    // Invalid, bar_6 has the same scope as bar_1.
     var<private> bar: u32 = 1u; // bar_6
 
     // Invalid, my_func_2 has the same end scope as my_func_1.
     fn my_func() { } // my_func_2
 
-    // Valid, my_foo_1 is in scope until the end of the program.
-    fn my_foo(
+    // Valid, my_foo_1 is in scope of the entire program.
+    fn my_foo( //my_foo_1
       // Valid, my_foo_2 is in scope until the end of the function.
       my_foo: i32 // my_foo_2
     ) { }
+
+    // Valid, module scope declarations are in scope of the entire program.
+    var<private> early_use : i32 = later_def;
+    var<private> later_def : i32 = 1;
   </xmp>
 </div>
-
-There are multiple levels of scoping depending on how and where things are
-declared.
-
-When an identifier is used, it must be in scope for some declaration, or as part of a directive.
-
-A declaration is at <dfn noexport>module scope</dfn> if the declaration appears outside
-the text of any other declaration.
-
-Note: Only a [=function declaration=] can contain other declarations.
 
 # Types # {#types}
 
@@ -3230,8 +3244,7 @@ such that the redundant loads are eliminated.
 ## Module Scope Variables ## {#module-scope-variables}
 
 A variable declared outside all functions is at [=module scope=].
-The variable name is available for use immediately after its declaration statement, until the end
-of the program.
+The variable name is [=in scope=] of the entire program.
 
 Variables at [=module scope=] are restricted as follows:
 
@@ -5739,8 +5752,7 @@ A <dfn noexport>function declaration</dfn> creates a user-defined function, by s
     This is the set of statements to be executed when the function is [=function call|called=].
 
 A function declaration must only occur at [=module scope=].
-The function name is [=in scope=] from the start of the formal parameter list
-until the end of the program.
+A function name is [=in scope=] of the entire prgoram.
 
 A <dfn noexport>formal parameter</dfn> [=declaration=] specifies an [=identifier=] name and a type for a value that must be
 provided when invoking the function.
@@ -5859,8 +5871,6 @@ As such, the same textual location may represent multiple call sites.
 
 ## Restrictions on functions ## {#function-restriction}
 
-* Recursion is not permitted.
-    That is, there must be no cycles in the call graph.
 * A [=vertex=] shader must return the `position` [=built-in output variable|built-in variable=].
     See [[#builtin-variables]].
 * An entry point must never be the target of a [=function call=].


### PR DESCRIPTION
Fixes #875

* Changes the scoping of module scope declarations to be the entire
  program instead of from declaration to end of program
  * add an example of using out of order declarations
* Generalizes the no recursion rule and moves it to the declaration
  section