### PR TITLE
Add missing brackets for double brackets

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6241,7 +6241,7 @@ User-defined IO can be mixed with builtin variables in the same structure. For e
     };
 
     struct B {
-      [location(0)]] x: f32;
+      [[location(0)]] x: f32;
     };
 
     struct C {
@@ -6261,7 +6261,7 @@ User-defined IO can be mixed with builtin variables in the same structure. For e
 
     [[stage(fragment)]]
     // Invalid, in1 and in2 cannot share a location.
-    fn fragShader2([location(0)]] in1: f32, [[location(0)]] in2: f32) {
+    fn fragShader2([[location(0)]] in1: f32, [[location(0)]] in2: f32) {
       // ...
     }
 


### PR DESCRIPTION
A few CI unchecked examples in the spec (leftover from past, will look at them entirely later); in one of them, double brackets were missing to be attributed.