### PR TITLE
Support dot() on vecN<i32> and vecN<u32>

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8369,10 +8369,18 @@ struct _modf_result_vecN {
   <thead>
     <tr><th>Parameterization<td>Overload<td>Description
   </thead>
-  <tr algorithm="dot"><td>|T| is f32
-  <td>`dot(`|e1|`: vecN<`|T|`>, `|e2|`: vecN<`|T|`>) ->` |T|
-  <td>Returns the dot product of |e1| and |e2|.
-  (OpDot)
+  <tr algorithm="f32 dot"><td>|T| is f32
+    <td>`dot(`|e1|`: vecN<`|T|`>, `|e2|`: vecN<`|T|`>) ->` |T|
+    <td>Returns the dot product of |e1| and |e2|.
+    (OpDot)
+  <tr algorithm="signed dot"><td>|T| is i32
+    <td>`dot(`|e1|`: vecN<`|T|`>, `|e2|`: vecN<`|T|`>) ->` |T|
+    <td>Returns the dot product of |e1| and |e2|.
+    (SPV_KHR_integer_dot_product OpSDotKHR)
+  <tr algorithm="unsigned dot"><td>|T| is u32
+    <td>`dot(`|e1|`: vecN<`|T|`>, `|e2|`: vecN<`|T|`>) ->` |T|
+    <td>Returns the dot product of |e1| and |e2|.
+    (SPV_KHR_integer_dot_product OpUDotKHR)
 </table>
 
 ## Derivative built-in functions ## {#derivative-builtin-functions}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8369,7 +8369,7 @@ struct _modf_result_vecN {
   <thead>
     <tr><th>Parameterization<td>Overload<td>Description
   </thead>
-  <tr algorithm="f32 dot"><td>|T| is f32
+  <tr algorithm="float dot"><td>|T| is f32
     <td>`dot(`|e1|`: vecN<`|T|`>, `|e2|`: vecN<`|T|`>) ->` |T|
     <td>Returns the dot product of |e1| and |e2|.
     (OpDot)


### PR DESCRIPTION
Fixes #2231 