### PR TITLE
wgsl: Require [[location]] for [[interpolate]]

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -610,10 +610,8 @@ An attribute must not be specified more than once per object or type.
 
     The first parameter must be an [=interpolation type=].
     The second parameter, if present, must specify the [=interpolation sampling=].
-    <td>Must only be applied to an entry point function parameter, entry point
-    return type, or member of a [=structure=] type.
-    Must only be applied to declarations of scalars or vectors of floating-point type.
-    Must not be used with the [=compute=] shader stage.
+    <td>Must only be applied to a declaration that is decorated with a
+    [=attribute/location=] attribute.
 
     Specifies how the user-defined IO must be interpolated.
     The attribute is only significant on user-defined [=vertex=] outputs


### PR DESCRIPTION
Also removes a sentence that required the target of `[[interpolate]]` to be floating-point, since we now also [require its use with integral types](https://github.com/gpuweb/gpuweb/pull/2183).

Fixes #2017