### PR TITLE
Whitespace nits

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5057,7 +5057,7 @@ dictionary GPUMultisampleState {
 ### Fragment State ### {#fragment-state}
 
 <script type=idl>
-dictionary GPUFragmentState: GPUProgrammableStage {
+dictionary GPUFragmentState : GPUProgrammableStage {
     required sequence<GPUColorTargetState> targets;
 };
 </script>
@@ -5338,7 +5338,7 @@ current vertex or instance index:
 </dl>
 
 <script type=idl>
-dictionary GPUVertexState: GPUProgrammableStage {
+dictionary GPUVertexState : GPUProgrammableStage {
     sequence<GPUVertexBufferLayout?> buffers = [];
 };
 </script>
@@ -8144,10 +8144,10 @@ interface GPUQueue {
         optional GPUSize64 size);
 
     undefined writeTexture(
-      GPUImageCopyTexture destination,
-      [AllowShared] BufferSource data,
-      GPUImageDataLayout dataLayout,
-      GPUExtent3D size);
+        GPUImageCopyTexture destination,
+        [AllowShared] BufferSource data,
+        GPUImageDataLayout dataLayout,
+        GPUExtent3D size);
 
     undefined copyExternalImageToTexture(
         GPUImageCopyExternalImage source,


### PR DESCRIPTION
We seem to be putting whitespace around both sides of a colon " : "  and we seem to be using a 4-space indent. This patch just applies those rules more consistently.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/litherum/gpuweb/pull/2254.html" title="Last updated on Nov 4, 2021, 8:59 PM UTC (c9e5395)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2254/09030b6...litherum:c9e5395.html" title="Last updated on Nov 4, 2021, 8:59 PM UTC (c9e5395)">Diff</a>