### PR TITLE
Secure context

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1287,7 +1287,7 @@ Issue: Do we need to have a max per-pixel render target size?
 See {{GPUAdapter/limits|GPUAdapter.limits}} and {{GPUDevice/limits|GPUDevice.limits}}.
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker)]
+[Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUSupportedLimits {
     readonly attribute unsigned long maxTextureDimension1D;
     readonly attribute unsigned long maxTextureDimension2D;
@@ -1325,7 +1325,7 @@ the {{GPUFeatureName}} values of the [=features=] supported by an adapter or
 device. It must only contain strings from the {{GPUFeatureName}} enum.
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker)]
+[Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUSupportedFeatures {
     readonly setlike<DOMString>;
 };
@@ -8960,7 +8960,7 @@ enum GPUDeviceLostReason {
     "destroyed",
 };
 
-[Exposed=(Window, DedicatedWorker)]
+[Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUDeviceLostInfo {
     readonly attribute (GPUDeviceLostReason or undefined) reason;
     readonly attribute DOMString message;
@@ -8982,12 +8982,12 @@ enum GPUErrorFilter {
 </script>
 
 <script type=idl>
-[Exposed=(Window, DedicatedWorker)]
+[Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUOutOfMemoryError {
     constructor();
 };
 
-[Exposed=(Window, DedicatedWorker)]
+[Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUValidationError {
     constructor(DOMString message);
     readonly attribute DOMString message;
@@ -9021,9 +9021,7 @@ partial interface GPUDevice {
 ## Telemetry ## {#telemetry}
 
 <script type=idl>
-[
-    Exposed=(Window, DedicatedWorker)
-]
+[Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUUncapturedErrorEvent : Event {
     constructor(
         DOMString type,


### PR DESCRIPTION
From https://github.com/gpuweb/gpuweb/pull/1363#issuecomment-765883910:

> Yeah, [SecureContext] should go on all interfaces.

There were some interfaces that didn't have it. (I still think SecureContext is a bad idea, but having it inconsistently applied is even worse than having it at all.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/litherum/gpuweb/pull/2255.html" title="Last updated on Nov 4, 2021, 11:01 PM UTC (69e55cb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2255/09030b6...litherum:69e55cb.html" title="Last updated on Nov 4, 2021, 11:01 PM UTC (69e55cb)">Diff</a>