### PR TITLE
Neither GPUBuffer nor GPUShaderModule is actually serializable

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1993,11 +1993,7 @@ Note:
      - [=buffer state/mapping pending=] with a {{Promise}} typed {{GPUBuffer/[[mapping]]}}.
 </div>
 
-{{GPUBuffer}} is {{Serializable}}. It is a reference to an internal buffer
-object, and {{Serializable}} means that the reference can be *copied* between
-realms (threads/workers), allowing multiple realms to access it concurrently.
-Since {{GPUBuffer}} has internal state (mapped, destroyed), that state is
-internally-synchronized - these state changes occur atomically across realms.
+{{GPUBuffer}} is a reference to an internal buffer object.
 
 Issue(gpuweb/gpuweb#354): Finish defining multithreading API and add `[Serializable]` back to the interface.
 
@@ -4030,11 +4026,7 @@ interface GPUShaderModule {
 GPUShaderModule includes GPUObjectBase;
 </script>
 
-{{GPUShaderModule}} is {{Serializable}}. It is a reference to an internal
-shader module object, and {{Serializable}} means that the reference can be
-*copied* between realms (threads/workers), allowing multiple realms to access
-it concurrently. Since {{GPUShaderModule}} is immutable, there are no race
-conditions.
+{{GPUShaderModule}} is a reference to an internal shader module object.
 
 Issue(gpuweb/gpuweb#354): Finish defining multithreading API and add `[Serializable]` back to the interface.
 


### PR DESCRIPTION
The spec says these things are serializable when they actually aren't.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/litherum/gpuweb/pull/2256.html" title="Last updated on Nov 5, 2021, 8:39 AM UTC (c9b0d12)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2256/955e41c...litherum:c9b0d12.html" title="Last updated on Nov 5, 2021, 8:39 AM UTC (c9b0d12)">Diff</a>