### PR TITLE
Describe the effective size of a buffer binding.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3860,10 +3860,7 @@ A {{GPUBindGroup}} object has the following internal slots:
                                             - |resource|.{{GPUBufferBinding/buffer}} is [$valid to use with$] |this|.
                                             - The bound part designated by |resource|.{{GPUBufferBinding/offset}} and
                                                 |resource|.{{GPUBufferBinding/size}} resides inside the buffer.
-                                            - The effective binding size, that is either explict in
-                                                |resource|.{{GPUBufferBinding/size}} or derived from
-                                                |resource|.{{GPUBufferBinding/offset}} and the full
-                                                size of the buffer, is greater than or equal to
+                                            - [$effective buffer binding size$](|resource|), is greater than or equal to
                                                 |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}}.
 
                                             - If |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/type}} is
@@ -3871,26 +3868,26 @@ A {{GPUBindGroup}} object has the following internal slots:
                                                     : {{GPUBufferBindingType/"uniform"}}
                                                     :: |resource|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
                                                         includes {{GPUBufferUsage/UNIFORM}}.
-                                                    :: |resource|.{{GPUBufferBinding/size}} &le;
+                                                    :: [$effective buffer binding size$](|resource|) &le;
                                                         |limits|.{{supported limits/maxUniformBufferBindingSize}}.
                                                     :: |resource|.{{GPUBufferBinding/offset}} is a multiple of
                                                         |limits|.{{supported limits/minUniformBufferOffsetAlignment}}.
-                                                    :: Issue: This validation should take into account the default when  {{GPUBufferBinding/size}} is not set.
-                                                        Also should {{GPUBufferBinding/size}} default to the `buffer.byteLength - offset` or
-                                                        `min(buffer.byteLength - offset, limits.maxUniformBufferBindingSize)`?
 
                                                     : {{GPUBufferBindingType/"storage"}} or
                                                         {{GPUBufferBindingType/"read-only-storage"}}
                                                     :: |resource|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
                                                         includes {{GPUBufferUsage/STORAGE}}.
-                                                    :: |resource|.{{GPUBufferBinding/size}} &le;
+                                                    :: [$effective buffer binding size$](|resource|) &le;
                                                         |limits|.{{supported limits/maxStorageBufferBindingSize}}.
                                                     :: |resource|.{{GPUBufferBinding/offset}} is a multiple of
                                                         |limits|.{{supported limits/minStorageBufferOffsetAlignment}}.
                                                 </dl>
 
+                                        :  {{GPUBindGroupLayoutEntry/externalTexture}}
+                                        ::
+                                            - |resource| is a {{GPUExternalTexture}}.
+                                            - |resource| is [$valid to use with$] |this|.
                                     </dl>
-
                         </div>
 
                         Then:
@@ -3909,11 +3906,17 @@ A {{GPUBindGroup}} object has the following internal slots:
                         1. Let |internalUsage| be the [=binding usage=] for |layoutBinding|.
                         1. Each [=subresource=] seen by |resource| is added to {{GPUBindGroup/[[usedResources]]}} as |internalUsage|.
                 </div>
-            1. Return |bindGroup|.
 
-            Issue: define the "effective buffer binding size" separately.
+            1. Return |bindGroup|.
         </div>
 </dl>
+
+<div algorithm>
+    <dfn abstract-op>effective buffer binding size</dfn>(binding)
+        1. If |binding|.{{GPUBufferBinding/size}} is `undefined`:
+            1. Return max(0, |binding|.{{GPUBufferBinding/buffer}}.{{GPUBuffer/[[size]]}} - |binding|.{{GPUBufferBinding/offset}});
+        1. Return |binding|.{{GPUBufferBinding/size}}.
+</div>
 
 ## <dfn interface>GPUPipelineLayout</dfn> ## {#pipeline-layout}
 


### PR DESCRIPTION
Also add validation that a bind group has a GPUExternalTexture resource
if the layout is for an external texture.

If size is not set, it is max(0, buffer.size - offset).

Issue: #686


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/2258.html" title="Last updated on Nov 9, 2021, 12:29 AM UTC (540a395)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2258/955e41c...Kangz:540a395.html" title="Last updated on Nov 9, 2021, 12:29 AM UTC (540a395)">Diff</a>