### PR TITLE
Fix setIndex/VertexBuffer size defaulting allowing any offset.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7441,7 +7441,7 @@ dictionary GPURenderPassLayout: GPUObjectDescriptorBase {
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. If |size| is missing, set |size| to |buffer|.{{GPUBuffer/[[size]]}} - |offset|.
+                1. If |size| is missing, set |size| to max(0, |buffer|.{{GPUBuffer/[[size]]}} - |offset|).
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |buffer| is [$valid to use with$] |this|.
@@ -7476,7 +7476,7 @@ dictionary GPURenderPassLayout: GPUObjectDescriptorBase {
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. If |size| is missing, set |size| to |buffer|.{{GPUBuffer/[[size]]}} - |offset|.
+                1. If |size| is missing, set |size| to max(0, |buffer|.{{GPUBuffer/[[size]]}} - |offset|).
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |buffer| is [$valid to use with$] |this|.


### PR DESCRIPTION
PTAL!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/2260.html" title="Last updated on Nov 5, 2021, 5:50 PM UTC (fc966f3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2260/955e41c...Kangz:fc966f3.html" title="Last updated on Nov 5, 2021, 5:50 PM UTC (fc966f3)">Diff</a>