### PR TITLE
Go from `attribute_list *` to `attribute_list ?` in the grammar

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1214,7 +1214,7 @@ Restrictions on runtime-sized arrays:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>array_type_decl</dfn> :
 
-    | [=syntax/attribute_list=] * [=syntax/array=] [=syntax/less_than=] [=syntax/type_decl=] ( [=syntax/comma=] [=syntax/element_count_expression=] ) ? [=syntax/greater_than=]
+    | [=syntax/attribute_list=] ? [=syntax/array=] [=syntax/less_than=] [=syntax/type_decl=] ( [=syntax/comma=] [=syntax/element_count_expression=] ) ? [=syntax/greater_than=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>element_count_expression</dfn> :
@@ -1271,7 +1271,7 @@ Similarly, the same limitations apply to textures and samplers.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>struct_decl</dfn> :
 
-    | [=syntax/attribute_list=] * [=syntax/struct=] [=syntax/ident=] [=syntax/struct_body_decl=]
+    | [=syntax/attribute_list=] ? [=syntax/struct=] [=syntax/ident=] [=syntax/struct_body_decl=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>struct_body_decl</dfn> :
@@ -1281,7 +1281,7 @@ Similarly, the same limitations apply to textures and samplers.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>struct_member</dfn> :
 
-    | [=syntax/attribute_list=] * [=syntax/variable_ident_decl=] [=syntax/semicolon=]
+    | [=syntax/attribute_list=] ? [=syntax/variable_ident_decl=] [=syntax/semicolon=]
 </div>
 
 [SHORTNAME] defines the following attributes that can be applied to structure types:
@@ -3180,7 +3180,7 @@ must not be written in [SHORTNAME] source text. See [[#access-mode-defaults]].
 <div class='syntax' noexport='true'>
   <dfn for=syntax>variable_ident_decl</dfn> :
 
-    | [=syntax/ident=] [=syntax/colon=] [=syntax/attribute_list=] * [=syntax/type_decl=]
+    | [=syntax/ident=] [=syntax/colon=] [=syntax/attribute_list=] ? [=syntax/type_decl=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>variable_qualifier</dfn> :
@@ -3302,7 +3302,7 @@ Such variables are declared with [=attribute/group=] and [=attribute/binding=] d
 <div class='syntax' noexport='true'>
   <dfn for=syntax>global_variable_decl</dfn> :
 
-    | [=syntax/attribute_list=] * [=syntax/variable_decl=] ( [=syntax/equal=] [=syntax/const_expression=] ) ?
+    | [=syntax/attribute_list=] ? [=syntax/variable_decl=] ( [=syntax/equal=] [=syntax/const_expression=] ) ?
 </div>
 
 <div class='example' heading="Variable Decorations">
@@ -3380,7 +3380,7 @@ is the one from the constant's declaration or from a pipeline override.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>global_constant_decl</dfn> :
 
-    | [=syntax/attribute_list=] * [=syntax/let=] ( [=syntax/ident=] | [=syntax/variable_ident_decl=] ) [=syntax/global_const_initializer=] ?
+    | [=syntax/attribute_list=] ? [=syntax/let=] ( [=syntax/ident=] | [=syntax/variable_ident_decl=] ) [=syntax/global_const_initializer=] ?
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>global_const_initializer</dfn> :
@@ -5773,12 +5773,12 @@ If the return type is specified, then:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>function_decl</dfn> :
 
-    | [=syntax/attribute_list=] * [=syntax/function_header=] [=syntax/compound_statement=]
+    | [=syntax/attribute_list=] ? [=syntax/function_header=] [=syntax/compound_statement=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>function_header</dfn> :
 
-    | [=syntax/fn=] [=syntax/ident=] [=syntax/paren_left=] [=syntax/param_list=] ? [=syntax/paren_right=] ( [=syntax/arrow=] [=syntax/attribute_list=] * [=syntax/type_decl=] ) ?
+    | [=syntax/fn=] [=syntax/ident=] [=syntax/paren_left=] [=syntax/param_list=] ? [=syntax/paren_right=] ( [=syntax/arrow=] [=syntax/attribute_list=] ? [=syntax/type_decl=] ) ?
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>param_list</dfn> :
@@ -5788,7 +5788,7 @@ If the return type is specified, then:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>param</dfn> :
 
-    | [=syntax/attribute_list=] * [=syntax/variable_ident_decl=]
+    | [=syntax/attribute_list=] ? [=syntax/variable_ident_decl=]
 </div>
 
 [SHORTNAME] defines the following attributes that can be applied to function declarations:


### PR DESCRIPTION
Currently, every place that allows `[[attribute1, attribute2]]` also allows `[[attribute1]] [[attribute2]]`.
I could not find any use of it in our examples, nor did @Kangz see it anywhere, so I am proposing to remove this unnecessary feature.