### PR TITLE
Remove obsolete attribute_list in variable_ident_decl

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3180,7 +3180,7 @@ must not be written in [SHORTNAME] source text. See [[#access-mode-defaults]].
 <div class='syntax' noexport='true'>
   <dfn for=syntax>variable_ident_decl</dfn> :
 
-    | [=syntax/ident=] [=syntax/colon=] [=syntax/attribute_list=] * [=syntax/type_decl=]
+    | [=syntax/ident=] [=syntax/colon=] [=syntax/type_decl=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>variable_qualifier</dfn> :


### PR DESCRIPTION
### Justification
It was introduced in https://github.com/gpuweb/gpuweb/commit/360380078d66fadab2c69c3db59cd7517ced6296 for the `access(read)` and `access(read_write)` attribute. Since we now put that information directly after `var`:
```
var<storage,read_write> x: S;
```
instead of
```
var<storage> x: [[access(read_write)]] S;
```
it is no longer useful and can be removed.

### Extra benefit
This is especially valuable as it is the cause of one of the two ambiguities in the grammar hidden by the line `[$.array_type_decl],` in `extract-grammar.py`. The ambiguity appears on examples like the following:
```
var x: [[attribute]] array<u32, 42>;
```
where the parser does not know whether to attach the attribute list to the type (which it should for `[[stride(4)]]`) or to the variable declaration (which it should for `[[access(read_write)]]`).

### Testing
I verified that all of our examples still parse and that the grammar does not gain new ambiguities.