### PR TITLE
Update operator precedence rules

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3168,9 +3168,9 @@ must not be written in [SHORTNAME] source text. See [[#access-mode-defaults]].
 
     | [=syntax/variable_decl=]
 
-    | [=syntax/variable_decl=] [=syntax/equal=] [=syntax/short_circuit_or_expression=]
+    | [=syntax/variable_decl=] [=syntax/equal=] [=syntax/expression=]
 
-    | [=syntax/let=] ( [=syntax/ident=] | [=syntax/variable_ident_decl=] ) [=syntax/equal=] [=syntax/short_circuit_or_expression=]
+    | [=syntax/let=] ( [=syntax/ident=] | [=syntax/variable_ident_decl=] ) [=syntax/equal=] [=syntax/expression=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>variable_decl</dfn> :
@@ -4927,17 +4927,17 @@ The <dfn noexport>indirection</dfn> operator converts a pointer to its correspon
 <div class='syntax' noexport='true'>
   <dfn for=syntax>paren_expression</dfn> :
 
-    | [=syntax/paren_left=] [=syntax/short_circuit_or_expression=] [=syntax/paren_right=]
+    | [=syntax/paren_left=] [=syntax/expression=] [=syntax/paren_right=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>argument_expression_list</dfn> :
 
-    | [=syntax/paren_left=] ( ( [=syntax/short_circuit_or_expression=] [=syntax/comma=] ) * [=syntax/short_circuit_or_expression=] [=syntax/comma=] ? ) ? [=syntax/paren_right=]
+    | [=syntax/paren_left=] ( ( [=syntax/expression=] [=syntax/comma=] ) * [=syntax/expression=] [=syntax/comma=] ? ) ? [=syntax/paren_right=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>postfix_expression</dfn> :
 
-    | [=syntax/bracket_left=] [=syntax/short_circuit_or_expression=] [=syntax/bracket_right=] [=syntax/postfix_expression=] ?
+    | [=syntax/bracket_left=] [=syntax/expression=] [=syntax/bracket_right=] [=syntax/postfix_expression=] ?
 
     | [=syntax/period=] [=syntax/ident=] [=syntax/postfix_expression=] ?
 </div>
@@ -4986,66 +4986,55 @@ The <dfn noexport>indirection</dfn> operator converts a pointer to its correspon
 
     | [=syntax/additive_expression=]
 
-    | [=syntax/shift_expression=] [=syntax/shift_left=] [=syntax/additive_expression=]
+    | [=syntax/unary_expression=] [=syntax/shift_left=] [=syntax/unary_expression=]
 
-    | [=syntax/shift_expression=] [=syntax/shift_right=] [=syntax/additive_expression=]
+    | [=syntax/unary_expression=] [=syntax/shift_right=] [=syntax/unary_expression=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>relational_expression</dfn> :
 
     | [=syntax/shift_expression=]
 
-    | [=syntax/relational_expression=] [=syntax/less_than=] [=syntax/shift_expression=]
+    | [=syntax/shift_expression=] [=syntax/less_than=] [=syntax/shift_expression=]
 
-    | [=syntax/relational_expression=] [=syntax/greater_than=] [=syntax/shift_expression=]
+    | [=syntax/shift_expression=] [=syntax/greater_than=] [=syntax/shift_expression=]
 
-    | [=syntax/relational_expression=] [=syntax/less_than_equal=] [=syntax/shift_expression=]
+    | [=syntax/shift_expression=] [=syntax/less_than_equal=] [=syntax/shift_expression=]
 
-    | [=syntax/relational_expression=] [=syntax/greater_than_equal=] [=syntax/shift_expression=]
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>equality_expression</dfn> :
+    | [=syntax/shift_expression=] [=syntax/greater_than_equal=] [=syntax/shift_expression=]
 
-    | [=syntax/relational_expression=]
+    | [=syntax/shift_expression=] [=syntax/equal_equal=] [=syntax/shift_expression=]
 
-    | [=syntax/relational_expression=] [=syntax/equal_equal=] [=syntax/relational_expression=]
-
-    | [=syntax/relational_expression=] [=syntax/not_equal=] [=syntax/relational_expression=]
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>and_expression</dfn> :
-
-    | [=syntax/equality_expression=]
-
-    | [=syntax/and_expression=] [=syntax/and=] [=syntax/equality_expression=]
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>exclusive_or_expression</dfn> :
-
-    | [=syntax/and_expression=]
-
-    | [=syntax/exclusive_or_expression=] [=syntax/xor=] [=syntax/and_expression=]
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>inclusive_or_expression</dfn> :
-
-    | [=syntax/exclusive_or_expression=]
-
-    | [=syntax/inclusive_or_expression=] [=syntax/or=] [=syntax/exclusive_or_expression=]
+    | [=syntax/shift_expression=] [=syntax/not_equal=] [=syntax/shift_expression=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>short_circuit_and_expression</dfn> :
 
-    | [=syntax/inclusive_or_expression=]
+    | [=syntax/relational_expression=]
 
-    | [=syntax/short_circuit_and_expression=] [=syntax/and_and=] [=syntax/inclusive_or_expression=]
+    | [=syntax/short_circuit_and_expression=] [=syntax/and_and=] [=syntax/relational_expression=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>short_circuit_or_expression</dfn> :
 
-    | [=syntax/short_circuit_and_expression=]
+    | [=syntax/relational_expression=]
 
-    | [=syntax/short_circuit_or_expression=] [=syntax/or_or=] [=syntax/short_circuit_and_expression=]
+    | [=syntax/short_circuit_or_expression=] [=syntax/or_or=] [=syntax/relational_expression=]
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>expression</dfn> :
+
+    | [=syntax/relational_expression=]
+
+    | [=syntax/relational_expression=] [=syntax/or_or=] [=syntax/short_circuit_or_expression=]
+
+    | [=syntax/relational_expression=] [=syntax/and_and=] [=syntax/short_circuit_and_expression=]
+
+    | [=syntax/unary_expression=] [=syntax/and=] [=syntax/unary_expression=]
+
+    | [=syntax/unary_expression=] [=syntax/or=] [=syntax/unary_expression=]
+
+    | [=syntax/unary_expression=] [=syntax/xor=] [=syntax/unary_expression=]
 </div>
 
 
@@ -5077,7 +5066,7 @@ and optionally stores it in memory (thus updating the contents of a variable).
 <div class='syntax' noexport='true'>
   <dfn for=syntax>assignment_statement</dfn> :
 
-    | ( [=syntax/unary_expression=] | [=syntax/underscore=] ) [=syntax/equal=] [=syntax/short_circuit_or_expression=]
+    | ( [=syntax/unary_expression=] | [=syntax/underscore=] ) [=syntax/equal=] [=syntax/expression=]
 </div>
 
 
@@ -5419,7 +5408,7 @@ allows them to naturally use values defined in the loop body.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>for_header</dfn> :
 
-    | ( [=syntax/variable_statement=] | [=syntax/assignment_statement=] | [=syntax/func_call_statement=] ) ? [=syntax/semicolon=] [=syntax/short_circuit_or_expression=] ? [=syntax/semicolon=] ( [=syntax/assignment_statement=] | [=syntax/func_call_statement=] ) ?
+    | ( [=syntax/variable_statement=] | [=syntax/assignment_statement=] | [=syntax/func_call_statement=] ) ? [=syntax/semicolon=] [=syntax/expression=] ? [=syntax/semicolon=] ( [=syntax/assignment_statement=] | [=syntax/func_call_statement=] ) ?
 </div>
 
 The <dfn dfn-for="statement">for</dfn> statement takes the form
@@ -5616,7 +5605,7 @@ The compound statement must not contain a [=statement/return=] or [=statement/di
 <div class='syntax' noexport='true'>
   <dfn for=syntax>return_statement</dfn> :
 
-    | [=syntax/return=] [=syntax/short_circuit_or_expression=] ?
+    | [=syntax/return=] [=syntax/expression=] ?
 </div>
 
 A <dfn noexport dfn-for="statement">return</dfn> statement ends execution of the current function.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5022,19 +5022,40 @@ The <dfn noexport>indirection</dfn> operator converts a pointer to its correspon
     | [=syntax/short_circuit_or_expression=] [=syntax/or_or=] [=syntax/relational_expression=]
 </div>
 <div class='syntax' noexport='true'>
+  <dfn for=syntax>binary_or_expression</dfn> :
+
+    | [=syntax/unary_expression=]
+
+    | [=syntax/binary_or_expression=] [=syntax/or=] [=syntax/unary_expression=]
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>binary_and_expression</dfn> :
+
+    | [=syntax/unary_expression=]
+
+    | [=syntax/binary_and_expression=] [=syntax/and=] [=syntax/unary_expression=]
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>binary_xor_expression</dfn> :
+
+    | [=syntax/unary_expression=]
+
+    | [=syntax/binary_xor_expression=] [=syntax/xor=] [=syntax/unary_expression=]
+</div>
+<div class='syntax' noexport='true'>
   <dfn for=syntax>expression</dfn> :
 
     | [=syntax/relational_expression=]
 
-    | [=syntax/relational_expression=] [=syntax/or_or=] [=syntax/short_circuit_or_expression=]
+    | [=syntax/short_circuit_or_expression=] [=syntax/or_or=] [=syntax/relational_expression=]
 
-    | [=syntax/relational_expression=] [=syntax/and_and=] [=syntax/short_circuit_and_expression=]
+    | [=syntax/short_circuit_and_expression=] [=syntax/and_and=] [=syntax/relational_expression=]
 
-    | [=syntax/unary_expression=] [=syntax/and=] [=syntax/unary_expression=]
+    | [=syntax/binary_and_expression=] [=syntax/and=] [=syntax/unary_expression=]
 
-    | [=syntax/unary_expression=] [=syntax/or=] [=syntax/unary_expression=]
+    | [=syntax/binary_or_expression=] [=syntax/or=] [=syntax/unary_expression=]
 
-    | [=syntax/unary_expression=] [=syntax/xor=] [=syntax/unary_expression=]
+    | [=syntax/binary_xor_expression=] [=syntax/xor=] [=syntax/unary_expression=]
 </div>
 
 


### PR DESCRIPTION
Fixes https://github.com/gpuweb/gpuweb/issues/1146.
In that issue we agreed to an overhaul of our operator precedence and associativity rules, minimizing footguns by requiring parenthesizes for the tricky cases. I just realized that it never propagated to the official grammar, and that's what this PR is fixing.