### PR TITLE
wgsl: Fix a wrong padding size in the structures layout example

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1790,7 +1790,7 @@ rounded to the next multiple of the structure's alignment:
         b: vec3<f32>;                              // offset(16)  align(16) size(12)
         c: f32;                                    // offset(28)  align(4)  size(4)
         d: f32;                                    // offset(32)  align(4)  size(4)
-        // -- implicit member alignment padding -- // offset(36)            size(12)
+        // -- implicit member alignment padding -- // offset(36)            size(4)
         e: A;                                      // offset(40)  align(8)  size(24)
         f: vec3<f32>;                              // offset(64)  align(16) size(12)
         // -- implicit member alignment padding -- // offset(76)            size(4)


### PR DESCRIPTION
Fix a little mistake of padding size in the structures layout example.