### PR TITLE
Tweak behaviour analysis

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12,7 +12,7 @@ Text Macro: UNSIGNEDINTEGRAL u32 or vec|N|&lt;u32&gt;
 Text Macro: SIGNEDINTEGRAL i32 or vec|N|&lt;i32&gt;
 Text Macro: INTEGRAL i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;
 Text Macro: FLOATING f32 or vec|N|&lt;f32&gt;
-Ignored Vars: i, e, e1, e2, e3, eN, N, M, v, Stride, Offset, Align, Extent, S, T, T1
+Ignored Vars: i, e, e1, e2, e3, eN, s1, s2, sn, N, M, v, Stride, Offset, Align, Extent, B, S, T, T1
 
 !Participate: <a href="https://github.com/gpuweb/gpuweb/issues/new?labels=wgsl">File an issue</a> (<a href="https://github.com/gpuweb/gpuweb/issues?q=is%3Aissue+is%3Aopen+label%3Awgsl">open issues</a>)
 
@@ -5776,89 +5776,92 @@ The reason is that only functions without a return type can have such a [=behavi
     <td class="nowrap">{ }
     <td>
     <td class="nowrap">{Next}
-  <tr>
+  <tr algorithm="braced statement behaviour">
     <td class="nowrap">{|s|}
     <td>|s|: |B|
     <td class="nowrap">B
-  <tr>
-    <td class="nowrap">|s1| ; |s2|
+  <tr algorithm="statement sequence bheaviour">
+    <td class="nowrap">|s1| |s2|
+
+        Note: |s1| often ends in a semicolon.
+
     <td class="nowrap">|s1|: |B1|<br>
         Next in |B1|<br>
         |s2|: |B2|
     <td class="nowrap">(|B1|&#x2216;{Next}) &cup; |B2|
-  <tr>
+  <tr algorithm="variable declaration behaviour">
     <td class="nowrap">var x:T;
     <td>
     <td>{Next}
-  <tr>
+  <tr algorithm="let declaration behaviour">
     <td class="nowrap">let x = |e|;
     <td class="nowrap">|e|: |B|
     <td>|B|
-  <tr>
+  <tr algorithm="initialized variable declaration behaviour">
     <td class="nowrap">var x = |e|;
     <td class="nowrap">|e|: |B|
     <td>|B|
-  <tr>
+  <tr algorithm="assignment behaviour">
     <td class="nowrap">|x| = |e|;
     <td class="nowrap">|x|: |B1|<br>
       |e|: |B2|<br>
       |x| is not `_`
     <td>|B1| &cup; |B2|
-  <tr>
+  <tr algorithm="phony assignment behaviour">
     <td class="nowrap">_ = |e|;
     <td class="nowrap">|e|: |B|
     <td>|B|
-  <tr>
+  <tr algorithm="function call statement behaviour">
     <td class="nowrap">|f|(|e1|, ..., |en|);
     <td class="nowrap">|e1|: |B1|<br>
         ...<br>
         |en|: |Bn|<br>
-        |f|'s has behavior |B|
+        |f| has behavior |B|
     <td class="nowrap">|B| &cup; ((|B1| &cup; ... &cup; |Bn|)&#x2216;{Next})
-  <tr>
+  <tr algorithm="return baehviour">
     <td>return;
     <td>
     <td>{Return}
-  <tr>
+  <tr algorithm="return value behaviour">
     <td class="nowrap">return |e|;
     <td class="nowrap">|e|: |B|<br>
     <td class="nowrap">(|B|&#x2216;{Next}) &cup; {Return}
-  <tr>
+  <tr algorithm="discard baehviour">
     <td>discard;
     <td>
     <td>{Discard}
-  <tr>
+  <tr algorithm="break behaviour">
     <td>break;
     <td>
     <td>{Break}
-  <tr>
+  <tr algorithm="continue behaviour">
     <td>continue;
     <td>
     <td>{Continue}
-  <tr>
+  <tr algorithm="fallthrough behaviour">
     <td>fallthrough;
     <td>
     <td>{Fallthrough}
-  <tr>
+  <tr algorithm="if statement behaviour">
     <td class="nowrap">if (|e|) |s1| else |s2|
     <td class="nowrap">|e|: |B|<br>
         |s1|: |B1|<br>
         |s2|: |B2|
     <td class="nowrap">(|B|&#x2216;{Next}) &cup; |B1| &cup; |B2|
-  <tr>
+  <tr algorithm="loop with continuing without break behaviour">
     <td class="nowrap" rowspan=2>loop {|s1| continuing {|s2|}}
     <td class="nowrap">|s1|: |B1|<br>
         |s2|: |B2|<br>
         None of {Continue, Return, Discard} are in |B2|<br>
         Break is not in (|B1| &cup; |B2|)
     <td class="nowrap">(|B1|&#x2216;{Continue}) &cup; (|B2|&#x2216{Next})
-  <tr>
+  <tr algorithm="loop with continuing with break behaviour">
     <td class="nowrap">|s1|: |B1|<br>
         |s2|: |B2|<br>
         None of {Continue, Return, Discard} are in |B2|<br/>
         Break is in (|B1| &cup; |B2|)
     <td class="nowrap">(|B1| &cup; |B2| &cup; {Next})&#x2216;{Break, Continue}
-  <tr>
+  <tr algorithm="switch behaviour">
     <td class="nowrap" rowspan=2>switch(|e|) {case <var ignore>c1</var>: |s1| ... case <var ignore>cn</var>: |sn|}
     <td class="nowrap">|e|: |B|<br>
         |s1|: |B1|<br>
@@ -5867,7 +5870,7 @@ The reason is that only functions without a return type can have such a [=behavi
         Fallthrough is not in |Bn|<br>
         Break is not in (|B1| &cup; ... &cup; |Bn|)
     <td class="nowrap">(|B| &cup; |B1| &cup; ... &cup; |Bn|)&#x2216;{Fallthrough}
-  <tr>
+  <tr algorithm="switch with break behaviour">
     <td class="nowrap">|e|: |B|<br>
         |s1|: |B1|<br>
         ...<br>
@@ -5889,36 +5892,36 @@ For the purpose of this analysis:
   <thead>
     <tr><th>Expression<th>Preconditions<th>Resulting behavior
   </thead>
-  <tr>
+  <tr algorithm="function call behaviour">
     <td class="nowrap">|f|(|e1|, ..., |en|)
     <td class="nowrap">|e1|: |B1|<br>
         ...<br>
         |en|: |Bn|<br>
-        |f|'s has behavior |B|
+        |f| has behavior |B|
     <td class="nowrap">|B| &cup; ((|B1| &cup; ... &cup; |Bn|)&#x2216;{Next})
-  <tr>
+  <tr algorithm="literal expression behaviour">
     <td class="nowrap">Any literal
     <td>
     <td class="nowrap">{Next}
-  <tr>
+  <tr algorithm="variable expression behaviour">
     <td class="nowrap">Any variable reference
     <td>
     <td class="nowrap">{Next}
-  <tr>
+  <tr algorithm="array-like index expression behaviour">
     <td class="nowrap">|e1|[|e2|]
     <td class="nowrap">|e1|: |B1|<br>
         |e2|: |B2|
     <td class="nowrap">|B1| &cup; |B2|
-  <tr>
+  <tr algorithm="structure member expression behaviour">
     <td class="nowrap">|e|.field
     <td class="nowrap">|e|: |B|
     <td class="nowrap">|B|
-  <tr>
+  <tr algorithm="short-circuiting or expression behaviour">
     <td class="nowrap">|e1| || |e2|
     <td class="nowrap">|e1|: |B1|<br>
         |e2|: |B2|
     <td class="nowrap">|B1| &cup; |B2|
-  <tr>
+  <tr algorithm="short-circuiting and expression behaviour">
     <td class="nowrap">|e1| && |e2|
     <td class="nowrap">|e1|: |B1|<br>
         |e2|: |B2|

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12,7 +12,7 @@ Text Macro: UNSIGNEDINTEGRAL u32 or vec|N|&lt;u32&gt;
 Text Macro: SIGNEDINTEGRAL i32 or vec|N|&lt;i32&gt;
 Text Macro: INTEGRAL i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;
 Text Macro: FLOATING f32 or vec|N|&lt;f32&gt;
-Ignored Vars: i, e, e1, e2, e3, eN, s1, s2, sn, N, M, v, Stride, Offset, Align, Extent, B, S, T, T1
+Ignored Vars: i, e, e1, e2, e3, eN, s1, s2, sn, N, M, v, Stride, Offset, Align, Extent, S, T, T1
 
 !Participate: <a href="https://github.com/gpuweb/gpuweb/issues/new?labels=wgsl">File an issue</a> (<a href="https://github.com/gpuweb/gpuweb/issues?q=is%3Aissue+is%3Aopen+label%3Awgsl">open issues</a>)
 
@@ -5776,11 +5776,11 @@ The reason is that only functions without a return type can have such a [=behavi
     <td class="nowrap">{ }
     <td>
     <td class="nowrap">{Next}
-  <tr algorithm="braced statement behaviour">
+  <tr algorithm="braced statement behavior">
     <td class="nowrap">{|s|}
     <td>|s|: |B|
-    <td class="nowrap">B
-  <tr algorithm="statement sequence bheaviour">
+    <td class="nowrap">|B|
+  <tr algorithm="statement sequence behavior">
     <td class="nowrap">|s1| |s2|
 
         Note: |s1| often ends in a semicolon.
@@ -5789,29 +5789,29 @@ The reason is that only functions without a return type can have such a [=behavi
         Next in |B1|<br>
         |s2|: |B2|
     <td class="nowrap">(|B1|&#x2216;{Next}) &cup; |B2|
-  <tr algorithm="variable declaration behaviour">
+  <tr algorithm="variable declaration behavior">
     <td class="nowrap">var x:T;
     <td>
     <td>{Next}
-  <tr algorithm="let declaration behaviour">
+  <tr algorithm="let declaration behavior">
     <td class="nowrap">let x = |e|;
     <td class="nowrap">|e|: |B|
     <td>|B|
-  <tr algorithm="initialized variable declaration behaviour">
+  <tr algorithm="initialized variable declaration behavior">
     <td class="nowrap">var x = |e|;
     <td class="nowrap">|e|: |B|
     <td>|B|
-  <tr algorithm="assignment behaviour">
+  <tr algorithm="assignment behavior">
     <td class="nowrap">|x| = |e|;
     <td class="nowrap">|x|: |B1|<br>
       |e|: |B2|<br>
       |x| is not `_`
     <td>|B1| &cup; |B2|
-  <tr algorithm="phony assignment behaviour">
+  <tr algorithm="phony assignment behavior">
     <td class="nowrap">_ = |e|;
     <td class="nowrap">|e|: |B|
     <td>|B|
-  <tr algorithm="function call statement behaviour">
+  <tr algorithm="function call statement behavior">
     <td class="nowrap">|f|(|e1|, ..., |en|);
     <td class="nowrap">|e1|: |B1|<br>
         ...<br>
@@ -5822,7 +5822,7 @@ The reason is that only functions without a return type can have such a [=behavi
     <td>return;
     <td>
     <td>{Return}
-  <tr algorithm="return value behaviour">
+  <tr algorithm="return value behavior">
     <td class="nowrap">return |e|;
     <td class="nowrap">|e|: |B|<br>
     <td class="nowrap">(|B|&#x2216;{Next}) &cup; {Return}
@@ -5830,38 +5830,38 @@ The reason is that only functions without a return type can have such a [=behavi
     <td>discard;
     <td>
     <td>{Discard}
-  <tr algorithm="break behaviour">
+  <tr algorithm="break behavior">
     <td>break;
     <td>
     <td>{Break}
-  <tr algorithm="continue behaviour">
+  <tr algorithm="continue behavior">
     <td>continue;
     <td>
     <td>{Continue}
-  <tr algorithm="fallthrough behaviour">
+  <tr algorithm="fallthrough behavior">
     <td>fallthrough;
     <td>
     <td>{Fallthrough}
-  <tr algorithm="if statement behaviour">
+  <tr algorithm="if statement behavior">
     <td class="nowrap">if (|e|) |s1| else |s2|
     <td class="nowrap">|e|: |B|<br>
         |s1|: |B1|<br>
         |s2|: |B2|
     <td class="nowrap">(|B|&#x2216;{Next}) &cup; |B1| &cup; |B2|
-  <tr algorithm="loop with continuing without break behaviour">
+  <tr algorithm="loop with continuing without break behavior">
     <td class="nowrap" rowspan=2>loop {|s1| continuing {|s2|}}
     <td class="nowrap">|s1|: |B1|<br>
         |s2|: |B2|<br>
         None of {Continue, Return, Discard} are in |B2|<br>
         Break is not in (|B1| &cup; |B2|)
     <td class="nowrap">(|B1|&#x2216;{Continue}) &cup; (|B2|&#x2216{Next})
-  <tr algorithm="loop with continuing with break behaviour">
+  <tr algorithm="loop with continuing with break behavior">
     <td class="nowrap">|s1|: |B1|<br>
         |s2|: |B2|<br>
         None of {Continue, Return, Discard} are in |B2|<br/>
         Break is in (|B1| &cup; |B2|)
     <td class="nowrap">(|B1| &cup; |B2| &cup; {Next})&#x2216;{Break, Continue}
-  <tr algorithm="switch behaviour">
+  <tr algorithm="switch behavior">
     <td class="nowrap" rowspan=2>switch(|e|) {case <var ignore>c1</var>: |s1| ... case <var ignore>cn</var>: |sn|}
     <td class="nowrap">|e|: |B|<br>
         |s1|: |B1|<br>
@@ -5870,7 +5870,7 @@ The reason is that only functions without a return type can have such a [=behavi
         Fallthrough is not in |Bn|<br>
         Break is not in (|B1| &cup; ... &cup; |Bn|)
     <td class="nowrap">(|B| &cup; |B1| &cup; ... &cup; |Bn|)&#x2216;{Fallthrough}
-  <tr algorithm="switch with break behaviour">
+  <tr algorithm="switch with break behavior">
     <td class="nowrap">|e|: |B|<br>
         |s1|: |B1|<br>
         ...<br>
@@ -5892,36 +5892,36 @@ For the purpose of this analysis:
   <thead>
     <tr><th>Expression<th>Preconditions<th>Resulting behavior
   </thead>
-  <tr algorithm="function call behaviour">
+  <tr algorithm="function call behavior">
     <td class="nowrap">|f|(|e1|, ..., |en|)
     <td class="nowrap">|e1|: |B1|<br>
         ...<br>
         |en|: |Bn|<br>
         |f| has behavior |B|
     <td class="nowrap">|B| &cup; ((|B1| &cup; ... &cup; |Bn|)&#x2216;{Next})
-  <tr algorithm="literal expression behaviour">
+  <tr algorithm="literal expression behavior">
     <td class="nowrap">Any literal
     <td>
     <td class="nowrap">{Next}
-  <tr algorithm="variable expression behaviour">
+  <tr algorithm="variable expression behavior">
     <td class="nowrap">Any variable reference
     <td>
     <td class="nowrap">{Next}
-  <tr algorithm="array-like index expression behaviour">
+  <tr algorithm="array-like index expression behavior">
     <td class="nowrap">|e1|[|e2|]
     <td class="nowrap">|e1|: |B1|<br>
         |e2|: |B2|
     <td class="nowrap">|B1| &cup; |B2|
-  <tr algorithm="structure member expression behaviour">
+  <tr algorithm="structure member expression behavior">
     <td class="nowrap">|e|.field
     <td class="nowrap">|e|: |B|
     <td class="nowrap">|B|
-  <tr algorithm="short-circuiting or expression behaviour">
+  <tr algorithm="short-circuiting or expression behavior">
     <td class="nowrap">|e1| || |e2|
     <td class="nowrap">|e1|: |B1|<br>
         |e2|: |B2|
     <td class="nowrap">|B1| &cup; |B2|
-  <tr algorithm="short-circuiting and expression behaviour">
+  <tr algorithm="short-circuiting and expression behavior">
     <td class="nowrap">|e1| && |e2|
     <td class="nowrap">|e1|: |B1|<br>
         |e2|: |B2|


### PR DESCRIPTION
- statement sequence doesn't always have a semicolon between statements
  e.g. this lets s1 be switch, if, loop, for statements.

Editorial:
- Fix phrasing to 'f has behaviour B'.
- Add "algorithm" class info for each behaviour analysis row.
  This lets the reader click on placeholders to colour-code them in the
  other places in a row.