### PR TITLE
Clarify inline issue about minBindingSize in draw-time validation

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6602,7 +6602,9 @@ interface mixin GPUProgrammablePassEncoder {
                 - |bindGroup| must not be `null`.
                 - |bindGroup|.{{GPUBindGroup/[[layout]]}} must be [=group-equivalent=] with |bindGroupLayout|.
 
-            Issue: Check buffer bindings against `minBindingSize` if present.
+            Issue: Add validation that, for buffer bindings that weren't prevalidated with
+            {{GPUBufferBindingLayout/minBindingSize}}, the binding ranges are large enough for
+            the shader's minimum binding size requirements.
         </div>
 
     Otherwise return `true`.


### PR DESCRIPTION
Issue could have been interpreted as the opposite of what it meant.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2273.html" title="Last updated on Nov 13, 2021, 2:29 AM UTC (498eb8f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2273/58f1b04...kainino0x:498eb8f.html" title="Last updated on Nov 13, 2021, 2:29 AM UTC (498eb8f)">Diff</a>