### PR TITLE
wgsl: describe type aliases

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2986,10 +2986,13 @@ TODO: Add texture usage validation rules.
     | [=syntax/rgba32float=]
 </div>
 
-## Type Aliases TODO ## {#type-aliases}
+## Type Aliases ## {#type-aliases}
+
+A <dfn noexport>type alias</dfn> declares a new name for an existing type.
+The declaration must appear at [=module scope=], and its [=scope=] is the entire program.
 
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>type_alias</dfn> :
+  <dfn for=syntax>type_alias_decl</dfn> :
 
     | [=syntax/type=] [=syntax/ident=] [=syntax/equal=] [=syntax/type_decl=]
 </div>
@@ -2999,6 +3002,10 @@ TODO: Add texture usage validation rules.
     type Arr = array<i32, 5>;
 
     type RTArr = [[stride(16)]] array<vec4<f32>>;
+
+    type single = f32;     // Declare an alias for f32
+    let pi_approx: single = 3.1415;
+    let two_pi_approx = single(2) * pi_approx;
   </xmp>
 </div>
 
@@ -6896,7 +6903,7 @@ TODO: *Stub* A WGSL program is a sequence of [=directives=] and [=module scope=]
 
     | [=syntax/global_constant_decl=] [=syntax/semicolon=]
 
-    | [=syntax/type_alias=] [=syntax/semicolon=]
+    | [=syntax/type_alias_decl=] [=syntax/semicolon=]
 
     | [=syntax/struct_decl=] [=syntax/semicolon=]
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3005,7 +3005,9 @@ The declaration must appear at [=module scope=], and its [=scope=] is the entire
 
     type single = f32;     // Declare an alias for f32
     let pi_approx: single = 3.1415;
-    let two_pi_approx = single(2) * pi_approx;
+    fn two_pi() -> single {
+      return single(2) * pi_approx;
+    }
   </xmp>
 </div>
 


### PR DESCRIPTION
Changes the grammar production from "type_alias" to "type_alias_decl"
to be consistent with other top-level declarations.