### PR TITLE
Fix conflict between the PRs: 'else if' & 'Behavior analysis'

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5909,7 +5909,7 @@ For the purpose of this analysis:
 - `for` loops get desugared (see [[#for-statement]])
 - `loop {s}` is treated as `loop {s continuing {}}`
 - `if` statements without an `else` branch are treated as if they had an empty else branch (which adds Next to their [=behavior=])
-- `if` statements with `elseif` branches are treated as if they were nested simple `if/else` statements
+- `if` statements with `else if` branches are treated as if they were nested simple `if/else` statements
 - a [=syntax/switch_body=] starting with `default` behaves just like a [=syntax/switch_body=] starting with `case _:`
 
 <table class='data'>
@@ -6033,17 +6033,17 @@ Here are some examples showing this analysis in action:
    </xmp>
 </div>
 
-<div class='example wgsl' heading='if/elseif/else behaves like a nested if/else'>
+<div class='example wgsl' heading='if/else if/else behaves like a nested if/else'>
    <xmp highlight='rust'>
     fn if_example() {
       var a: i32 = 0;
       loop {
-        // if (e1) s1 elseif (e2) s2 else s3
+        // if (e1) s1 else if (e2) s2 else s3
         // is identical to
         // if (e1) else { if (e2) s2 else s3 }
         if (a == 5) {
           break;      // Behavior: {Break}
-        } elseif (a == 42) {
+        } else if (a == 42) {
           continue;   // Behavior: {Continue}
         } else {
           return;     // Behavior {Return}


### PR DESCRIPTION
#2239 changed the syntax from `elseif` to `else if`.
#2216 has an example that uses `elseif`.

This PR just fixes the conflict by using `else if` in the example.