### PR TITLE
wgsl: all directives appear before any declarations

### DIFF
--- a/wgsl/extract-grammar.py
+++ b/wgsl/extract-grammar.py
@@ -228,7 +228,7 @@ module.exports = grammar({
     ],
 
     inline: $ => [
-        $.global_decl_or_directive,
+        $.global_decl,
         $._reserved,
     ],
 
@@ -322,21 +322,10 @@ scanner_components[scanner_rule.name()]["_comment"] = [["`'//'`", '`/.*/`']]
 
 rule_skip = set()
 
-
-# Extract translation_unit
-
-
-grammar_source += grammar_from_rule(
-    "translation_unit", scanner_components[scanner_rule.name()]["translation_unit"]) + ",\n"
-rule_skip.add("translation_unit")
-
-
-# Extract global_decl_or_directive
-
-
-grammar_source += grammar_from_rule(
-    "global_decl_or_directive", scanner_components[scanner_rule.name()]["global_decl_or_directive"]) + ",\n"
-rule_skip.add("global_decl_or_directive")
+for rule in ["translation_unit", "global_directive", "global_decl"]:
+    grammar_source += grammar_from_rule(
+        rule, scanner_components[scanner_rule.name()][rule]) + ",\n"
+    rule_skip.add(rule)
 
 
 # Extract literals

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6889,6 +6889,10 @@ the implementation can issue a clear diagnostic.
   <xmp>
     // Enable a hypothetical IEEE-754 binary16 floating point extension.
     enable f16;
+    enable f16; // A redundant enable directive is ok.
+    // Enable a hypothetical extension adding syntax for controlling
+    // the rounding mode on f16 arithmetic.
+    enable rounding_mode_f16;
 
     // Assuming the f16 extension enables use of the f16 type:
     //    - as function return value
@@ -6899,11 +6903,6 @@ the implementation can issue a clear diagnostic.
        let two: f16 = f16(2);
        return x / two;
     };
-
-    enable f16; // A redundant enable directive is ok.
-    // Enable a hypothetical extension adding syntax for controlling
-    // the rounding mode on f16 arithmetic.
-    enable rounding_mode_f16;
 
     [[round_to_even_f16]] // Attribute enabled by the rounding_mode_f16 extension
     fn triple_it(x: f16) -> f16 {

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -407,17 +407,11 @@ To parse a [SHORTNAME] program:
         * blankspace
     * Repeat until no ungrouped characters remain.
 3. Discard the blankspace, leaving only tokens.
-3. Parse the token sequence, attempting to match the `translation_unit` grammar rule.
-
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>translation_unit</dfn> :
-
-    | [=syntax/global_decl_or_directive=] *
-</div>
+3. Parse the token sequence, attempting to match the [=syntax/translation_unit=] grammar rule.
 
 A [=shader-creation error=] results if:
 * the entire source text cannot be converted into a finite sequence of valid tokens, or
-* the `translation_unit` grammar rule does not match the entire token sequence.
+* the [=syntax/translation_unit=] grammar rule does not match the entire token sequence.
 
 ## Comments ## {#comments}
 
@@ -695,7 +689,17 @@ An attribute must not be specified more than once per object or type.
 
 A <dfn noexport>directive</dfn> is a [=token=] sequence which modifies how a [SHORTNAME]
 program is processed by a WebGPU implementation.
+
+Directives are optional.
+If present, all directives must appear before any declarations.
+
 See [[#enable-directive-section]].
+
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>global_directive</dfn> :
+
+    | [=syntax/enable_directive=]
+</div>
 
 ## Declaration and Scope ## {#declaration-and-scope}
 
@@ -6909,12 +6913,18 @@ the implementation can issue a clear diagnostic.
 </div>
 
 
-# WGSL program TODO # {#wgsl-module}
+# WGSL Program # {#wgsl-program}
 
-TODO: *Stub* A WGSL program is a sequence of [=directives=] and [=module scope=] [=declarations=].
+A [SHORTNAME] program is a sequence of optional [=directives=] followed by [=module scope=] [=declarations=].
 
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>global_decl_or_directive</dfn> :
+  <dfn for=syntax>translation_unit</dfn> :
+
+    | [=syntax/global_directive=] * [=syntax/global_decl=] *
+</div>
+
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>global_decl</dfn> :
 
     | [=syntax/semicolon=]
 
@@ -6927,8 +6937,6 @@ TODO: *Stub* A WGSL program is a sequence of [=directives=] and [=module scope=]
     | [=syntax/struct_decl=] [=syntax/semicolon=]
 
     | [=syntax/function_decl=]
-
-    | [=syntax/enable_directive=]
 </div>
 
 # Execution TODO # {#execution}


### PR DESCRIPTION
Also:
- Update the grammar to force all directivs to appear before any
  declarations.
- Finish writing "WGSL program" section (resolves a TODO)
- Move the grammar rule for translation_unit into "WGSL program" section
- Add brief explanation at "Directives" section saying they are optional
  and must appear before declarations.  This saves the reader from having
  to decode the grammar.

Addresses a consensus item from #875