### PR TITLE
Require storage texture views to have mipLevelCount == 1

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3850,6 +3850,7 @@ A {{GPUBindGroup}} object has the following internal slots:
                                             - |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/format}}
                                                 is equal to |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
                                             - |texture|'s {{GPUTextureDescriptor/usage}} includes {{GPUTextureUsage/STORAGE_BINDING}}.
+                                            - |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/mipLevelCount}} must be 1.
 
                                         :  {{GPUBindGroupLayoutEntry/buffer}}
                                         ::


### PR DESCRIPTION
Fixes #1576

Note that WGSL already doesn't expose the mip level for the storage textures builtins (nor `textureNumLevels`).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/2285.html" title="Last updated on Nov 10, 2021, 3:33 PM UTC (3391f04)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2285/ba444ff...Kangz:3391f04.html" title="Last updated on Nov 10, 2021, 3:33 PM UTC (3391f04)">Diff</a>