### PR TITLE
Limits binding numbers to 65535

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3645,6 +3645,7 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                         <div class=validusage>
                             - |this| is a [=valid=] {{GPUDevice}}.
                             - The {{GPUBindGroupLayoutEntry/binding}} of each entry in |descriptor| is unique.
+                            - The {{GPUBindGroupLayoutEntry/binding}} of each entry in |descriptor| must be &lt; 65536.
                             - |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}} must not
                                 [=exceeds the binding slot limits|exceed the binding slot limits=]
                                 of |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.


### PR DESCRIPTION
This is done only at layout creation since it is sufficient to cover:

 - Layout creation
 - Default layouts (they go through validation)
 - Bind groups (since they must match the layout)
 - WGSL since a binding won't be usable without being matched with an
   entry in the layout.

Note that it lets developers write binding numbers in WGSL that are too
big, as long as they are unused.

Fixes #1783


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/2286.html" title="Last updated on Nov 10, 2021, 3:58 PM UTC (ca56bfe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2286/ba444ff...Kangz:ca56bfe.html" title="Last updated on Nov 10, 2021, 3:58 PM UTC (ca56bfe)">Diff</a>