### PR TITLE
wgsl: Remove TODO about default rounding mode

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7291,8 +7291,6 @@ Then, for example, integers 2<sup>28</sup> and 1+2<sup>28</sup> both map to the 
 least significant 1 bit is not representable by the floating point format.
 This kind of collision occurs for pairs of adjacent integers with a magnitude of at least 2<sup>25</sup>.
 
-Issue: (dneto) Default rounding mode is an implementation choice.  Is that what we want?
-
 Issue: Check behaviour of the f32 to f16 conversion for numbers just beyond the max normal f16 values.
 I've written what an NVIDIA GPU does.  See https://github.com/google/amber/pull/918 for an executable test case.
 


### PR DESCRIPTION
We already agreed that default rounding mode is an implementation
choice.