### PR TITLE
Added byte value to fillBuffer

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5498,7 +5498,7 @@ interface GPUCommandEncoder {
         GPUBuffer destination,
         GPUSize64 destinationOffset,
         GPUSize64 size,
-        octet value = 0
+        optional octet value = 0
         );
 
     undefined pushDebugGroup(USVString groupLabel);

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5953,7 +5953,7 @@ dictionary GPUImageCopyExternalImage {
 <dl dfn-type=method dfn-for=GPUCommandEncoder>
     : <dfn>fillBuffer(destination, destinationOffset, size, value)</dfn>
     ::
-        Encode a command into the {{GPUCommandEncoder}} that fills a sub-region of a
+        Encode a command into the {{GPUCommandEncoder}} that fills each byte of a sub-region of a
         {{GPUBuffer}} with the given value.
 
         <div algorithm=GPUCommandEncoder.fillBuffer>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5497,7 +5497,9 @@ interface GPUCommandEncoder {
     undefined fillBuffer(
         GPUBuffer destination,
         GPUSize64 destinationOffset,
-        GPUSize64 size);
+        GPUSize64 size,
+        octet value = 0
+        );
 
     undefined pushDebugGroup(USVString groupLabel);
     undefined popDebugGroup();
@@ -5949,10 +5951,10 @@ dictionary GPUImageCopyExternalImage {
 ### Buffer Fills ### {#buffer-fills}
 
 <dl dfn-type=method dfn-for=GPUCommandEncoder>
-    : <dfn>fillBuffer(destination, destinationOffset, size)</dfn>
+    : <dfn>fillBuffer(destination, destinationOffset, size, value)</dfn>
     ::
         Encode a command into the {{GPUCommandEncoder}} that fills a sub-region of a
-        {{GPUBuffer}} with zeros.
+        {{GPUBuffer}} with the given value.
 
         <div algorithm=GPUCommandEncoder.fillBuffer>
             **Called on:** {{GPUCommandEncoder}} |this|.
@@ -5962,6 +5964,7 @@ dictionary GPUImageCopyExternalImage {
                 |destination|: The {{GPUBuffer}} to write to.
                 |destinationOffset|: Offset in bytes into |destination| to place the data.
                 |size|: Bytes to copy.
+                value: Value to place in each byte of the given range.
             </pre>
 
             **Returns:** {{undefined}}


### PR DESCRIPTION
Fixes #2278

Adds a byte value to fillBuffer (defaulting to zero) to place in
the specified buffer range. This is following feedback on the
most recent WebGPU CG call, which Mozilla did not have a
presence at. As such I'd especially appreciate feedback from
@kvark or @jdashg.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/2289.html" title="Last updated on Nov 10, 2021, 11:04 PM UTC (f35005e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2289/e3e0ead...f35005e.html" title="Last updated on Nov 10, 2021, 11:04 PM UTC (f35005e)">Diff</a>