### PR TITLE
Give fillBuffer() a value argument

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5497,7 +5497,8 @@ interface GPUCommandEncoder {
     undefined fillBuffer(
         GPUBuffer destination,
         GPUSize64 destinationOffset,
-        GPUSize64 size);
+        GPUSize64 size,
+        octet value);
 
     undefined pushDebugGroup(USVString groupLabel);
     undefined popDebugGroup();
@@ -5952,7 +5953,7 @@ dictionary GPUImageCopyExternalImage {
     : <dfn>fillBuffer(destination, destinationOffset, size)</dfn>
     ::
         Encode a command into the {{GPUCommandEncoder}} that fills a sub-region of a
-        {{GPUBuffer}} with zeros.
+        {{GPUBuffer}} with a value.
 
         <div algorithm=GPUCommandEncoder.fillBuffer>
             **Called on:** {{GPUCommandEncoder}} |this|.
@@ -5962,6 +5963,7 @@ dictionary GPUImageCopyExternalImage {
                 |destination|: The {{GPUBuffer}} to write to.
                 |destinationOffset|: Offset in bytes into |destination| to place the data.
                 |size|: Bytes to copy.
+                |value|: The value to fill the region with.
             </pre>
 
             **Returns:** {{undefined}}


### PR DESCRIPTION
Fixes https://github.com/gpuweb/gpuweb/issues/2278.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/litherum/gpuweb/pull/2290.html" title="Last updated on Nov 11, 2021, 1:33 AM UTC (4e1c23a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2290/e3e0ead...litherum:4e1c23a.html" title="Last updated on Nov 11, 2021, 1:33 AM UTC (4e1c23a)">Diff</a>