### PR TITLE
Remove reset method and exemplify usage

### DIFF
--- a/wgsl/extract-grammar.py
+++ b/wgsl/extract-grammar.py
@@ -440,7 +440,6 @@ enum TokenType {
 
 void *tree_sitter_wgsl_external_scanner_create() { return NULL; }
 void tree_sitter_wgsl_external_scanner_destroy(void *p) {}
-void tree_sitter_wgsl_external_scanner_reset(void *p) {}
 unsigned tree_sitter_wgsl_external_scanner_serialize(void *p, char *buffer) { return 0; }
 void tree_sitter_wgsl_external_scanner_deserialize(void *p, const char *b, unsigned n) {}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2113,10 +2113,10 @@ However, in [SHORTNAME] *source* text:
 <div class='example wgsl' heading='Pointer type'>
   <xmp highlight='rust'>
     fn my_function(
-      // 'ptr<function,i32,read_write>' is the type of a pointer value that references
-      // storage for keeping an 'i32' value, using memory locations in the 'function'
-      // storage class.  Here 'i32' is the pointee type.
-      // The implied access mode is 'read_write'. See below for access mode defaults.
+      /* 'ptr<function,i32,read_write>' is the type of a pointer value that references
+         storage for keeping an 'i32' value, using memory locations in the 'function'
+         storage class.  Here 'i32' is the pointee type.
+         The implied access mode is 'read_write'. See below for access mode defaults. */
       ptr_int: ptr<function,i32>,
 
       // 'ptr<private,array<f32,50>,read_write>' is the type of a pointer value that
@@ -2288,19 +2288,19 @@ Note: The following examples use [SHORTNAME] features explained later in this sp
 <div class='example wgsl' heading='Using a pointer as a formal parameter'>
   <xmp highlight='rust'>
     fn add_one(x: ptr<function,i32>) {
-      // Update the locations for 'x' to contain the next higher integer value,
-      // (or to wrap around to the largest negative i32 value).
-      // On the left-hand side, unary '*' converts the pointer to a reference that
-      // can then be assigned to. It has a read_write access mode, by default.
-      // On the right-hand side:
-      //    - Unary '*' converts the pointer to a reference, with a read_write
-      //      access mode.
-      //    - The only matching type rule is for addition (+) and requires '*x' to
-      //      have type i32, which is the store type for '*x'.  So the Load Rule
-      //      applies and '*x' evaluates to the value stored in the memory for '*x'
-      //      at the time of evaluation, which is the i32 value for 0.
-      //    - Add 1 to 0, to produce a final value of 1 for the right-hand side.
-      // Store 1 into the memory for '*x'.
+      /* Update the locations for 'x' to contain the next higher integer value,
+         (or to wrap around to the largest negative i32 value).
+         On the left-hand side, unary '*' converts the pointer to a reference that
+         can then be assigned to. It has a read_write access mode, by default.
+         /* On the right-hand side:
+            - Unary '*' converts the pointer to a reference, with a read_write
+              access mode.
+            - The only matching type rule is for addition (+) and requires '*x' to
+              have type i32, which is the store type for '*x'.  So the Load Rule
+              applies and '*x' evaluates to the value stored in the memory for '*x'
+              at the time of evaluation, which is the i32 value for 0.
+            - Add 1 to 0, to produce a final value of 1 for the right-hand side. */
+         Store 1 into the memory for '*x'. */
       *x = *x + 1;
     }
 


### PR DESCRIPTION
This PR makes sure that CI does what is intended when it is in place by converting two tiny examples (of course more can be converted in future by editors). Also removes redundant method.