### PR TITLE
Fixes to memory model for barriers and atomics

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7387,7 +7387,11 @@ for the lifetime of the variable.
 operations](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#memory-model-atomic-operation)
 whose memory
 [scope](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#memory-model-scope)
-is `Workgroup`.
+is:
+* `Workgroup` if the atomic pointer is in the [=storage classes/workgroup=]
+    storage class
+* `QueueFamily` if the atomic pointer is in the [=storage
+    classes/storage=] storage class
 
 [[#sync-builtin-functions|Synchronization built-in functions]] map to control
 barriers whose execution and memory
@@ -7426,7 +7430,7 @@ All non-atomic [=read accesses=] in the [=storage classes/storage=] or
 and correspond to read operations with `NonPrivatePointer | MakePointerVisible`
 memory operands with the following scope:
 * `Workgroup` for the [=storage classes/workgroup=] storage class
-* `Device`/`QueueFamily` for the [=storage classes/storage=] storage class
+* `QueueFamily` for the [=storage classes/storage=] storage class
 
 All non-atomic [=write accesses=] in the [=storage classes/storage=] or
 [=storage classes/workgroup=] storage classes are considered
@@ -7434,7 +7438,7 @@ All non-atomic [=write accesses=] in the [=storage classes/storage=] or
 and correspond to write operations with `NonPrivatePointer |
 MakePointerAvailable` memory operands with the following scope:
 * `Workgroup` for the [=storage classes/workgroup=] storage class
-* `Device`/`QueueFamily` for the [=storage classes/storage=] storage class
+* `QueueFamily` for the [=storage classes/storage=] storage class
 
 Issue: https://github.com/gpuweb/gpuweb/issues/1621
 
@@ -9573,7 +9577,9 @@ Atomic built-in functions `must` not be used in a [=vertex=] shader stage.
 The storage class `SC` of the `atomic_ptr` parameter in all atomic built-in
 functions `must` be either [=storage classes/storage=] or [=storage
 classes/workgroup=].
-All atomics have a **Workgroup** [[#scoped-operations|memory scope]] in SPIR-V
+[=storage classes/workgroup=] atomics have a **Workgroup**
+memory scope in SPIR-V, while [=storage classes/storage=] atomics have a
+**QueueFamily** memory scope in SPIR-V.
 
 The access mode `A` in all atomic built-in functions must be [=access/read_write=].
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7387,23 +7387,12 @@ for the lifetime of the variable.
 operations](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#memory-model-atomic-operation)
 whose memory
 [scope](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#memory-model-scope)
-is:
-* `Workgroup` if the atomic pointer is in the [=storage classes/workgroup=]
-    storage class
-* `QueueFamily` if the atomic pointer is in the [=storage
-    classes/storage=] storage class
+is `Workgroup`.
 
 [[#sync-builtin-functions|Synchronization built-in functions]] map to control
-barriers whose execution
-[scope](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#memory-model-scope)
-is `Workgroup` and whose memory
-[scope](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#memory-model-scope)
-is:
-* `Workgroup` for `workgroupBarrier`
-* `QueueFamily` for `storageBarrier`
-
-Note: If a `workgroupBarrier` and a `storageBarrier` are combined, the
-resulting memory scope is `QueueFamily`.
+barriers whose execution and memory
+[scopes](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#memory-model-scope)
+are `Workgroup`.
 
 Note: When generating SPIR-V that does not enable the `Vulkan` memory model,
 `Device` scope should be used instead of `QueueFamily`.
@@ -9572,25 +9561,21 @@ TODO(dsinclair): Need gather operations
 Atomic built-in functions can be used to read/write/read-modify-write atomic
 objects. They are the only operations allowed on [[#atomic-types]].
 
-All atomic built-in functions use a `relaxed` memory ordering (**0**-value
-integral constant in SPIR-V for all `Memory Semantics` operands).
-This means synchronization and ordering guarantees only apply among atomic
-operations acting on the same [=memory locations=].
-No synchronization or ordering guarantees apply between atomic and
-non-atomic memory accesses, or between atomic accesses acting on different
-memory locations.
+All atomic built-in functions use a `relaxed` [[#memory-semantics|memory
+ordering]] (**0**-value integral constant in SPIR-V for all `Memory Semantics`
+operands).  This means synchronization and ordering guarantees only apply among
+atomic operations acting on the same [=memory locations=].  No synchronization
+or ordering guarantees apply between atomic and non-atomic memory accesses, or
+between atomic accesses acting on different memory locations.
 
 Atomic built-in functions `must` not be used in a [=vertex=] shader stage.
 
 The storage class `SC` of the `atomic_ptr` parameter in all atomic built-in
 functions `must` be either [=storage classes/storage=] or [=storage
-classes/workgroup=]. [=storage classes/workgroup=] atomics have a **Workgroup**
-memory scope in SPIR-V, while [=storage classes/storage=] atomics have a
-**Device** memory scope in SPIR-V.
+classes/workgroup=].
+All atomics have a **Workgroup** [[#scoped-operations|memory scope]] in SPIR-V
 
 The access mode `A` in all atomic built-in functions must be [=access/read_write=].
-
-TODO: Add links to the eventual memory model descriptions.
 
 ### Atomic Load ### {#atomic-load}
 
@@ -9662,20 +9647,21 @@ struct _atomic_compare_exchange_result<T> {
 // Maps to the SPIR-V instruction OpAtomicCompareExchange.
 ```
 
-Note: A value cannot be explicitly declared with the type `_atomic_compare_exchange_result`, but a value may infer the type.
+Note: A value cannot be explicitly declared with the type
+`_atomic_compare_exchange_result`, but a value may infer the type.
 
 Performs the following steps atomically:
 
 1. Load the original value pointed to by `atomic_ptr`.
 2. Compare the original value to the value `v` using an equality operation.
-3. Store the value `v` `only if` the result of the equality comparison was **true**.
+3. Store the value `v` `only if` the result of the equality comparison was `true`.
 
-Returns a two-element vector, where the first element is the original value of
-the atomic object and the second element is whether or not the comparison
-succeeded (**1** if successful, **0** otherwise).
+Returns a two member structure, where the first member, `old_value`, is the
+original value of the atomic object and the second member, `exchanged`, is
+whether or not the comparison succeeded.
 
 Note: the equality comparison may spuriously fail on some implementations. That
-is, the second element of the result vector may be **0** even if the first
+is, the second element of the result vector may be `false` even if the first
 element of the result vector equals `cmp`.
 
 ## Data packing built-in functions ## {#pack-builtin-functions}
@@ -9795,14 +9781,18 @@ workgroupBarrier()
 ```
 
 All synchronization functions execute a control barrier with Acquire/Release
-memory ordering. That is, all synchronization functions, and affected memory
-and atomic operations are ordered in [[#program-order]] relative to the
-synchronization function.  Additionally, the affected memory and atomic
-operations program-ordered before the synchronization function must be visible
-to all other threads in the workgroup before any affected memory or atomic
-operation program-ordered after the synchronization function is executed by a
-member of the workgroup.
-All synchronization functions must only be used in the [=compute=] shader stage.
+[[#memory-semantics|memory ordering]].
+That is, all synchronization functions, and affected memory and atomic
+operations are ordered in [[#program-order|program order]] relative to the
+synchronization function.
+Additionally, the affected memory and atomic operations program-ordered before
+the synchronization function must be visible to all other threads in the
+workgroup before any affected memory or atomic operation program-ordered after
+the synchronization function is executed by a member of the workgroup.
+All synchronization functions use the `Workgroup` [[#scoped-operations|memory
+scope]].
+All synchronization functions must only be used in the [=compute=] shader
+stage.
 
 storageBarrier affects memory and atomic operations in the [=storage
 classes/storage=] storage class.
@@ -9810,16 +9800,14 @@ classes/storage=] storage class.
 workgroupBarrier affects memory and atomic operations in the [=storage
 classes/workgroup=] storage class.
 
-TODO: Add links to the eventual memory model.
-
 <div class='example spirv barrier mapping' heading="Mapping workgroupBarrier to SPIR-V">
   <xmp>
     storageBarrier();
     // Maps to:
     // Execution Scope is Workgroup = %uint_2
-    // Memory Scope is Device = %uint_1
+    // Memory Scope is Workgroup = %uint_2
     // Memory Semantics are AcquireRelease | UniformMemory (0x8 | 0x40) = %uint_72
-    // OpControlBarrier %uint_2 %uint_1 %uint_72
+    // OpControlBarrier %uint_2 %uint_2 %uint_72
 
     workgroupBarrier();
     // Maps to:
@@ -9834,10 +9822,10 @@ TODO: Add links to the eventual memory model.
     workgroupBarrier();
     // Could be mapped to a single OpControlBarrier:
     // Execution scope is Workgroup = %uint_2
-    // Memory Scope is Device = %uint_1
+    // Memory Scope is Workgroup = %uint_2
     // Memory semantics are AcquireRelease | UniformMemory | WorkgroupMemory
     //   (0x8 | 0x40 | 0x100) = %uint_328
-    // OpControlBarrier %uint_2 %uint_1 %uint_328
+    // OpControlBarrier %uint_2 %uint_2 %uint_328
   </xmp>
 </div>
 


### PR DESCRIPTION
* All barriers ~~`and atomics~~ only have a workgroup memory scope
  * This means translations of storageBarrier to HLSL will
    over-synchronize the memory
* Fix links between atomics and barriers and the memory model
* Fix description of compare exchange atomic
* Update remaining uses of Device to use QueueFamily

I realize I made a mistake when reading the Metal docs and unintentionally assumed more functionality than is guaranteed. `threadgroup_barrier` in MSL is effectively OpenCL C 1.2's `barrier` intrinsic which only has a memory scope of `Workgroup`. This means (in the context of #2229) that inter-workgroup communication cannot be support correctly on all underlying platforms.