### PR TITLE
Define intrinsic size / natural dimensions of WebGPU canvases

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8788,7 +8788,7 @@ interface GPUCanvasContext {
     During the "update the rendering [of the] `Document`" step of the
     "[=Update the rendering=]" step of the HTML processing model, each
     {{HTMLCanvasElement}} |canvas| in the DOM that has a {{GPUCanvasContext}} |context|
-    update its rendering.
+    must update its rendering.
 
     To <dfn abstract-op>update the rendering of a WebGPU canvas</dfn>:
 
@@ -8816,7 +8816,7 @@ interface GPUCanvasContext {
 </div>
 
 <div algorithm>
-    When WebGPU canvas contents are read using other Web APIs, like
+    When a WebGPU canvas is used as an image source by other Web APIs, like
     {{CanvasDrawImage/drawImage()}}, `texImage2D()`, `texSubImage2D()`,
     {{HTMLCanvasElement/toDataURL()}}, {{HTMLCanvasElement/toBlob()}}, and so on,
     they <dfn abstract-op>get a copy of the image contents of a context</dfn>:
@@ -8835,17 +8835,22 @@ interface GPUCanvasContext {
         |context|.{{GPUCanvasContext/canvas}}.{{HTMLCanvasElement/height}}].
     1. If |context|.{{GPUCanvasContext/[[configuration]]}} is not `null`, set |defaultSize| to
         |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/size}}.
-    1. If any of the following requirements is unmet, return a transparent black image with the
-        [=natural dimensions of a WebGPU canvas|natural dimensions of=]
-        |context|.{{GPUCanvasContext/canvas}} and stop.
+    1. If any of the following requirements is unmet:
+
         <div class=validusage>
             - |texture| must not be `null`.
             - |texture|.{{GPUTexture/[[destroyed]]}} must be false.
             - If |context|.{{GPUCanvasContext/canvas}} is an {{OffscreenCanvas}},
                 it must not be linked to a [=placeholder canvas element=].
 
-                Issue: If added, canvas must also not be `desynchronized`.
+            Issue: Canvas must also not be `desynchronized`, if that option is added.
         </div>
+
+        Then:
+
+        1. Return a transparent black image with the
+            [=natural dimensions of a WebGPU canvas|natural dimensions of=]
+            |context|.{{GPUCanvasContext/canvas}}.
     1. Ensure that all submitted work items (e.g. queue submissions) have
         completed writing to |texture|.
     1. Return the contents of |texture|, tagged as having alpha premultiplied, and with the color space
@@ -8925,9 +8930,11 @@ The contents of presented {{GPUCanvasContext}} textures will be scaled to fit th
 <div class="note">
     Note: Unlike `'webgl'` or `'2d'` contexts, `width` and `height` attributes of canvases with a
     `'webgpu'` context only affect:
-    - The element's [=intrinsic size=]: its default layout size, if not overridden by CSS.
-    - Default {{GPUCanvasConfiguration}}.{{GPUCanvasConfiguration/size}} when calling
-        {{GPUCanvasContext/configure()}}, if not overridden by
+
+    - The [=intrinsic size of a WebGPU canvas|element's intrinsic size=]:
+        its default layout size, if not overridden by CSS.
+    - The default {{GPUCanvasConfiguration}}.{{GPUCanvasConfiguration/size}} when calling
+        {{GPUCanvasContext/configure()}}, which is used if not overridden by
         {{GPUCanvasConfiguration/size|GPUCanvasConfiguration.size}}.
 </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8640,26 +8640,19 @@ interface GPUCanvasContext {
 {{GPUCanvasContext}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUCanvasContext">
-    : <dfn>\[[validConfiguration]]</dfn> of type boolean, initially `false`.
+    : <dfn>\[[configuration]]</dfn> of type {{GPUCanvasConfiguration}}, nullable, initially `null`
     ::
-        Indicates if the context currently has a valid configuration.
+        The options this context is configured with. `null` if the context has not been configured,
+        configuration failed, or the context has been {{GPUCanvasContext/unconfigure()|unconfigured}}.
 
-    : <dfn>\[[configuration]]</dfn> of type {{GPUCanvasConfiguration}}, initially `null`.
-    ::
-        The options this context is configured with. `null` if the context has not been configured
-        or the configuration has been removed.
-
-    : <dfn>\[[size]]</dfn> of type {{GPUExtent3D}}
-    ::
-        The size of {{GPUTexture}}s returned from this context.
-        [=Extent3D/depthOrArrayLayers=] is always `1`.
-
-    : <dfn>\[[currentTexture]]</dfn> of type {{GPUTexture}}?, initially `null`
+    : <dfn>\[[currentTexture]]</dfn> of type {{GPUTexture}}, nullable, initially `null`
     ::
         The current texture that will be returned by the context when calling
         {{GPUCanvasContext/getCurrentTexture()}}, and the next one to be composited to the
-        document. Initially set to the result of [$allocating a new context texture$] for this
-        context.
+        document.
+
+        When not null, the current texture's size is always
+        {{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/size}}.
 </dl>
 
 {{GPUCanvasContext}} has the following methods:
@@ -8680,41 +8673,36 @@ interface GPUCanvasContext {
 
             **Returns:** undefined
 
-            1. Set |this|.{{GPUCanvasContext/[[validConfiguration]]}} to `false`.
-            1. Set |this|.{{GPUCanvasContext/[[configuration]]}} to |configuration|.
-            1. If |this|.{{GPUCanvasContext/[[currentTexture]]}} is not `null` call
+            1. If |this|.{{GPUCanvasContext/[[currentTexture]]}} is not `null`, call
                 {{GPUTexture/destroy()}} on |this|.{{GPUCanvasContext/[[currentTexture]]}}.
             1. Set |this|.{{GPUCanvasContext/[[currentTexture]]}} to `null`.
-            1. Let |device| be |configuration|.{{GPUCanvasConfiguration/device}}.
+            1. Set |this|.{{GPUCanvasContext/[[configuration]]}} to `null`.
             1. Let |canvas| be |this|.{{GPUCanvasContext/canvas}}.
-            1. If |configuration|.{{GPUCanvasConfiguration/size}} is `undefined` set
-                |this|.{{GPUCanvasContext/[[size]]}} to [|canvas|.width, |canvas|.height, 1],
-                otherwise set |this|.{{GPUCanvasContext/[[size]]}} to
-                |configuration|.{{GPUCanvasConfiguration/size}}.
-
-            1. Issue the following steps on the [=Device timeline=] of |device|:
-                <div class=device-timeline>
-                    1. If any of the following conditions are unsatisfied:
-                        <div class=validusage>
-                            - |device| is a [=valid=] {{GPUDevice}}.
-                            - [=Supported context formats=] [=set/contains=]
-                                |configuration|.{{GPUCanvasConfiguration/format}}.
-                            - |this|.{{GPUCanvasContext/[[size]]}}.[=Extent3D/width=] &gt; 0.
-                            - |this|.{{GPUCanvasContext/[[size]]}}.[=Extent3D/width=] &le;
-                                |device|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
-                            - |this|.{{GPUCanvasContext/[[size]]}}.[=Extent3D/height=] &gt; 0.
-                            - |this|.{{GPUCanvasContext/[[size]]}}.[=Extent3D/height=] &le;
-                                |device|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
-                            - |this|.{{GPUCanvasContext/[[size]]}}.[=Extent3D/depthOrArrayLayers=]
-                                is 1;
-                        </div>
-
-                        Then:
-                            1. Generate a {{GPUValidationError}} in the current scope with appropriate
-                                error message.
-                            1. Return.
+            1. Let |device| be |configuration|.{{GPUCanvasConfiguration/device}}.
+            1. If |configuration|.{{GPUCanvasConfiguration/size}} is `undefined`,
+                let |size| be [|canvas|.width, |canvas|.height, 1].
+                Otherwise, let |size| be |configuration|.{{GPUCanvasConfiguration/size}}.
+            1. If any of the following requirements are unmet:
+                <div class=validusage>
+                    - [=Supported context formats=] [=set/contains=]
+                        |configuration|.{{GPUCanvasConfiguration/format}}.
+                    - |size|.[=Extent3D/width=] must be &gt; 0.
+                    - |size|.[=Extent3D/width=] must be &le;
+                        |device|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
+                    - |size|.[=Extent3D/height=] must be &gt; 0.
+                    - |size|.[=Extent3D/height=] must be &le;
+                        |device|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
+                    - |size|.[=Extent3D/depthOrArrayLayers=] must be 1.
                 </div>
-            1. Set |this|.{{GPUCanvasContext/[[validConfiguration]]}} to `true`.
+
+                Then:
+
+                1. Generate a {{GPUValidationError}} in the current scope of |device| with an appropriate error message.
+                1. Return.
+
+                Issue: Just throw an exception instead?
+            1. Set |this|.{{GPUCanvasContext/[[configuration]]}} to |configuration|.
+            1. Set |this|.{{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/size}} to |size|.
         </div>
 
     : <dfn>unconfigure()</dfn>
@@ -8726,11 +8714,10 @@ interface GPUCanvasContext {
 
             **Returns:** undefined
 
-            1. Set |this|.{{GPUCanvasContext/[[validConfiguration]]}} to `false`.
-            1. Set |this|.{{GPUCanvasContext/[[configuration]]}} to `null`.
-            1. If |this|.{{GPUCanvasContext/[[currentTexture]]}} is not `null` call
+            1. If |this|.{{GPUCanvasContext/[[currentTexture]]}} is not `null`, call
                 {{GPUTexture/destroy()}} on |this|.{{GPUCanvasContext/[[currentTexture]]}}.
             1. Set |this|.{{GPUCanvasContext/[[currentTexture]]}} to `null`.
+            1. Set |this|.{{GPUCanvasContext/[[configuration]]}} to `null`.
         </div>
 
     : <dfn>getPreferredFormat(adapter)</dfn>
@@ -8775,20 +8762,42 @@ interface GPUCanvasContext {
 
         Note: Developers can expect that the same {{GPUTexture}} object will be returned by every
         call to {{GPUCanvasContext/getCurrentTexture()}} made within the same frame (i.e. between
-        invocations of [=Update the rendering=]) unless {{GPUCanvasContext/configure()}} is called.
+        invocations of [=Update the rendering=]), unless {{GPUCanvasContext/configure()}} has been called.
 </dl>
 
 <div algorithm>
-    During the "update the rendering [of the] `Document`" step of the "[=Update the rendering=]"
-    HTML processing model, each {{GPUCanvasContext}} |context| must <dfn abstract-op>present the
-    context content to the canvas</dfn> by running the following steps:
+    <dfn dfn>Intrinsic size of a WebGPU canvas</dfn>
+
+    The [=intrinsic size=] of an {{HTMLCanvasElement}} |canvas| with a {{GPUCanvasContext}} `context`
+    is equal to [|canvas|.{{HTMLCanvasElement/width}}, |canvas|.{{HTMLCanvasElement/height}}].
+</div>
+
+<div algorithm>
+    <dfn dfn>Natural dimensions of a WebGPU canvas</dfn>
+
+    The [=natural dimensions=] of an {{HTMLCanvasElement}} |canvas| with a {{GPUCanvasContext}} `context` are:
+
+    - If {{GPUCanvasContext/[[configuration]]}} is not null,
+        {{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/size}}.
+    - Otherwise, the [=intrinsic size of a WebGPU canvas|intrinsic size of=] |canvas|.
+
+    The algorithm "[$get a copy of the image contents of a context$]" always returns an image of this size.
+</div>
+
+<div algorithm>
+    During the "update the rendering [of the] `Document`" step of the
+    "[=Update the rendering=]" step of the HTML processing model, each
+    {{HTMLCanvasElement}} |canvas| in the DOM that has a {{GPUCanvasContext}} |context|
+    update its rendering.
+
+    To <dfn abstract-op>update the rendering of a WebGPU canvas</dfn>:
 
     1. If |context|.{{GPUCanvasContext/[[currentTexture]]}} is not `null` and
         |context|.{{GPUCanvasContext/[[currentTexture]]}}.{{GPUTexture/[[destroyed]]}} is `false`:
         1. Let |imageContents| be
             [$get a copy of the image contents of a context|a copy of the image contents$]
             of |context|.
-        1. Update |context|.{{GPUCanvasContext/canvas}} with |imageContents|.
+        1. Update |canvas| with |imageContents|.
         1. Call |context|.{{GPUCanvasContext/[[currentTexture]]}}.{{GPUTexture/destroy()}}.
     1. Set |context|.{{GPUCanvasContext/[[currentTexture]]}} to `null`.
 </div>
@@ -8817,9 +8826,18 @@ interface GPUCanvasContext {
 
     **Returns:** image contents
 
+    The returned image's size always matches
+    [=natural dimensions of a WebGPU canvas|the canvas's natural dimensions=].
+
     1. Let |texture| be |context|.{{GPUCanvasContext/[[currentTexture]]}}.
-    1. If any of the following requirements is unmet, return a transparent black image of size
-        |context|.{{GPUCanvasContext/[[size]]}} and stop.
+    1. Let |defaultSize| be
+        [|context|.{{GPUCanvasContext/canvas}}.{{HTMLCanvasElement/width}},
+        |context|.{{GPUCanvasContext/canvas}}.{{HTMLCanvasElement/height}}].
+    1. If |context|.{{GPUCanvasContext/[[configuration]]}} is not `null`, set |defaultSize| to
+        |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/size}}.
+    1. If any of the following requirements is unmet, return a transparent black image with the
+        [=natural dimensions of a WebGPU canvas|natural dimensions of=]
+        |context|.{{GPUCanvasContext/canvas}} and stop.
         <div class=validusage>
             - |texture| must not be `null`.
             - |texture|.{{GPUTexture/[[destroyed]]}} must be false.
@@ -8840,22 +8858,21 @@ interface GPUCanvasContext {
     To <dfn abstract-op lt='allocating a new context texture'>allocate a new context texture</dfn>
     for {{GPUCanvasContext}} |context| run the following steps:
 
-        1. Let |device| be |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/device}}.
-        1. If |context|.{{GPUCanvasContext/[[validConfiguration]]}} is `false`:
-            1. Generate a {{GPUValidationError}} in the current scope of |device| with an appropriate error message.
-            1. Return a new [=invalid=] {{GPUTexture}}.
-        1. Let |textureDescriptor| be a new {{GPUTextureDescriptor}}.
-        1. Set |textureDescriptor|.{{GPUTextureDescriptor/size}} to |context|.{{GPUCanvasContext/[[size]]}}.
-        1. Set |textureDescriptor|.{{GPUTextureDescriptor/format}} to
-            |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/format}}.
-        1. Set |textureDescriptor|.{{GPUTextureDescriptor/usage}} to
-            |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/usage}}.
-        1. Let |texture| be a new {{GPUTexture}} created as if |device|.{{GPUDevice/createTexture()}}
-            were called with |textureDescriptor|.
-            <div class='note'>If a previously presented texture from |context| matches the required criteria,
-            its GPU memory may be re-used.</div>
-        1. Ensure |texture| is cleared to `(0, 0, 0, 0)`.
-        1. Return |texture|.
+    1. Assert |context|.{{GPUCanvasContext/[[configuration]]}} is not `null`.
+    1. Let |device| be |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/device}}.
+    1. Let |textureDescriptor| be a new {{GPUTextureDescriptor}}.
+    1. Set |textureDescriptor|.{{GPUTextureDescriptor/size}} to
+        |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/size}}.
+    1. Set |textureDescriptor|.{{GPUTextureDescriptor/format}} to
+        |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/format}}.
+    1. Set |textureDescriptor|.{{GPUTextureDescriptor/usage}} to
+        |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/usage}}.
+    1. Let |texture| be a new {{GPUTexture}} created as if |device|.{{GPUDevice/createTexture()}}
+        were called with |textureDescriptor|.
+        <div class='note'>If a previously presented texture from |context| matches the required criteria,
+        its GPU memory may be re-used.</div>
+    1. Ensure |texture| is cleared to `(0, 0, 0, 0)`.
+    1. Return |texture|.
 </div>
 
 ## GPUCanvasConfiguration ## {#canvas-configuration}
@@ -8898,20 +8915,20 @@ high dynamic range is explicitly enabled for the canvas element.
 
 ### Canvas Context sizing ### {#context-sizing}
 
-A {{GPUCanvasContext}}'s {{GPUCanvasContext/[[size]]}} is set by the {{GPUCanvasConfiguration}}
+The size of {{GPUCanvasContext}} textures is set by the {{GPUCanvasConfiguration}}
 passed to {{GPUCanvasContext/configure()}}, and remains the same until {{GPUCanvasContext/configure()}}
-is called again with a new size. If a {{GPUCanvasConfiguration/size}} is not specified then the
+is called again. If a {{GPUCanvasConfiguration/size|GPUCanvasConfiguration.size}} is not specified, then the
 width and height attributes of the {{GPUCanvasContext}}.{{GPUCanvasContext/canvas}}
-at the time {{GPUCanvasContext/configure()}} is called will be used. If
-{{GPUCanvasContext}}.{{GPUCanvasContext/[[size]]}} does not match the dimensions of the canvas
-the textures produced by the {{GPUCanvasContext}} will be scaled to fit the canvas element.
+at the time {{GPUCanvasContext/configure()}} is called will be used.
+The contents of presented {{GPUCanvasContext}} textures will be scaled to fit the canvas element.
 
 <div class="note">
     Note: Unlike `'webgl'` or `'2d'` contexts, `width` and `height` attributes of canvases with a
     `'webgpu'` context only affect:
-    - Default layout size, if not overridden by CSS.
+    - The element's [=intrinsic size=]: its default layout size, if not overridden by CSS.
     - Default {{GPUCanvasConfiguration}}.{{GPUCanvasConfiguration/size}} when calling
-        {{GPUCanvasContext/configure()}}, if not overridden.
+        {{GPUCanvasContext/configure()}}, if not overridden by
+        {{GPUCanvasConfiguration/size|GPUCanvasConfiguration.size}}.
 </div>
 
 If it is desired to match the dimensions of the canvas after it is resized, the {{GPUCanvasContext}}


### PR DESCRIPTION
## This is in draft

...while I figure out whether having differing intrinsic size and natural dimensions as defined here makes sense.

This slightly refactors the state of GPUCanvasContext and makes a bunch
of small editorial changes in related areas.

Note the changes in GPUCanvasContext.configure which move all of the
error handling back to the content timeline (instead of the device
timeline). This is because it was previously attempted to early-return
from the device timeline and expected it to terminate the content
timeline steps, which isn't possible.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2300.html" title="Last updated on Nov 13, 2021, 12:37 AM UTC (eddd4b6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2300/8906fe2...kainino0x:eddd4b6.html" title="Last updated on Nov 13, 2021, 12:37 AM UTC (eddd4b6)">Diff</a>