### PR TITLE
Extend lifetime of GPUExternalTexture imported from video element

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2963,6 +2963,19 @@ GPUExternalTexture includes GPUObjectBase;
         Initially set to `false`.
 
         <!-- Move this to an internal object if GPUExternalTexture becomes Serializable. -->
+
+    : <dfn>\[[descriptor]]</dfn>, of type {{GPUExternalTextureDescriptor}}
+    ::
+        The descriptor with which the texture was created.
+</dl>
+
+The {{GPUExternalTexture}} interface object has the following "static" internal slots:
+
+<dl dfn-type=attribute dfn-for=GPUExternalTexture>
+    : <dfn>\[[active_imports]]</dfn>, of type [=list=]&lt;GPUExternalTexture&gt;
+    ::
+        A list of all imported textures which have not yet been closed.
+        The items in list are checked during each animation frame to determine whether to close them.
 </dl>
 
 ### Importing External Textures ### {#external-texture-creation}
@@ -2972,8 +2985,8 @@ using {{GPUDevice/importExternalTexture()}}.
 
 Issue: Update this description with canvas.
 
-External textures are destroyed automatically, as a microtask,
-instead of manually or upon garbage collection like other resources.
+External textures created from {{HTMLVideoElements}} are destroyed automatically after the imported
+frame is no longer current, instead of manually or upon garbage collection like other resources.
 
 <script type=idl>
 dictionary GPUExternalTextureDescriptor : GPUObjectDescriptorBase {
@@ -3020,14 +3033,23 @@ dictionary GPUExternalTextureDescriptor : GPUObjectDescriptorBase {
 
             1. Let |result| be a new {{GPUExternalTexture}} object wrapping |data|.
 
-            1. [=Queue a microtask=] to set |result|.{{GPUExternalTexture/[[destroyed]]}} to `true`,
-                releasing the underlying resource.
-
-                Issue: Is this too restrictive?
+            1. Add |result| to {{GPUExternalTexture}}.{{GPUExternalTexture/[[active_imports]]}}.
 
             1. Return |result|.
         </div>
 </dl>
+
+<div algorithm="destroy stale external textures">
+    Immediately after the "run the animation frame callbacks" step of the "[=Update the rendering=]"
+    step of the HTML processing model, the following steps must be performed:
+
+    1. For each |texture| in {{GPUExternalTexture}}.{{GPUExternalTexture/[[active_imports]]}}:
+        1. Let |video| be |texture|.{{GPUExternalTexture/[[descriptor]]}}.{{GPUExternalTextureDescriptor/source}}.
+        1. Assert |video| is an {{HTMLVideoElement}}.
+        1. If the current active frame of |video| is not the same frame |texture| was imported from:
+            1. Set |texture|.{{GPUExternalTexture/[[destroyed]]}} to `true`, releasing the underlying resource.
+            1. Remove |texture| from {{GPUExternalTexture}}.{{GPUExternalTexture/[[active_imports]]}}.
+</div>
 
 ### Sampling External Textures ### {#external-texture-sampling}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2950,6 +2950,7 @@ External textures use several binding slots: see [=Exceeds the binding slot limi
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUExternalTexture {
+    readonly attribute boolean expired;
 };
 GPUExternalTexture includes GPUObjectBase;
 </script>
@@ -2969,6 +2970,15 @@ GPUExternalTexture includes GPUObjectBase;
         The descriptor with which the texture was created.
 </dl>
 
+{{GPUExternalTexture}} has the following attributes:
+
+<dl dfn-type=attribute dfn-for=GPUExternalTexture>
+    : <dfn>expired</dfn>
+    ::
+        Returns the value of {{GPUExternalTexture/[[destroyed]]}}, which indicates
+        whether the texture has [$expire stale external textures|expired$] or not.
+</dl>
+
 The {{GPUExternalTexture}} interface object has the following "static" internal slots:
 
 <dl dfn-type=attribute dfn-for=GPUExternalTexture>
@@ -2985,8 +2995,11 @@ using {{GPUDevice/importExternalTexture()}}.
 
 Issue: Update this description with canvas.
 
-External textures created from {{HTMLVideoElements}} are destroyed automatically after the imported
+External textures created from {{HTMLVideoElement}}s are destroyed automatically after the imported
 frame is no longer current, instead of manually or upon garbage collection like other resources.
+When an external texture expires, its {{GPUExternalTexture/expired}} attribute changes to `true`.
+Applications can use this to determine whether to re-import or not, if their execution is not
+already scheduled to match the video's frame rate.
 
 <script type=idl>
 dictionary GPUExternalTextureDescriptor : GPUObjectDescriptorBase {
@@ -3039,16 +3052,30 @@ dictionary GPUExternalTextureDescriptor : GPUObjectDescriptorBase {
         </div>
 </dl>
 
-<div algorithm="destroy stale external textures">
-    Immediately after the "run the animation frame callbacks" step of the "[=Update the rendering=]"
-    step of the HTML processing model, the following steps must be performed:
+<div algorithm="expire stale external textures">
+    Immediately before the "run the animation frame callbacks" step of the "[=Update the rendering=]"
+    step of the HTML processing model, run the following steps to
+    <dfn abstract-op>expire stale external textures</dfn>:
 
     1. For each |texture| in {{GPUExternalTexture}}.{{GPUExternalTexture/[[active_imports]]}}:
         1. Let |video| be |texture|.{{GPUExternalTexture/[[descriptor]]}}.{{GPUExternalTextureDescriptor/source}}.
         1. Assert |video| is an {{HTMLVideoElement}}.
-        1. If the current active frame of |video| is not the same frame |texture| was imported from:
-            1. Set |texture|.{{GPUExternalTexture/[[destroyed]]}} to `true`, releasing the underlying resource.
+        1. If the latest presented frame of |video| is not the same frame from which |texture| was imported:
             1. Remove |texture| from {{GPUExternalTexture}}.{{GPUExternalTexture/[[active_imports]]}}.
+            1. Set |texture|.{{GPUExternalTexture/[[destroyed]]}} to `true`, releasing ownership of
+                the underlying resource.
+
+    Note:
+    The steps above occur before `requestVideoFrameCallback` callbacks, if any.
+    If `requestVideoFrameCallback` is implemented, stale {{GPUExternalTexture}}s could equivalently
+    be said to be destroyed in a "priority" `requestVideoFrameCallback` callback that occurs just
+    before user-specified callbacks.
+
+    Note:
+    An external video texture should be imported in the same task that samples the texture
+    (which should generally be scheduled using `requestVideoFrameCallback` or
+    {{AnimationFrameProvider/requestAnimationFrame()}} depending on the application).
+    Otherwise, a texture could get destroyed by these steps before it is used.
 </div>
 
 ### Sampling External Textures ### {#external-texture-sampling}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2914,7 +2914,7 @@ depth or stencil renderable format. Any other format is not a depth or stencil r
 ## <dfn interface>GPUExternalTexture</dfn> ## {#gpu-external-texture}
 
 A {{GPUExternalTexture}} is a sampleable texture wrapping an external video object.
-The contents of a {{GPUExternalTexture}} object may not change, either from inside WebGPU
+The contents of a {{GPUExternalTexture}} object are a snapshot and may not change, either from inside WebGPU
 (it is only sampleable) or from outside WebGPU (e.g. due to video frame advancement).
 
 Issue: Update this description with canvas.
@@ -2992,8 +2992,6 @@ The {{GPUExternalTexture}} interface object has the following "static" internal 
 
 An external texture is created from an external video object
 using {{GPUDevice/importExternalTexture()}}.
-
-Issue: Update this description with canvas.
 
 External textures created from {{HTMLVideoElement}}s are destroyed automatically after the imported
 frame is no longer current, instead of manually or upon garbage collection like other resources.


### PR DESCRIPTION
Original PR: #1666
Discussion: #2124

The change proposed here destroys "stale" textures (those which no longer represent the video's current frame) just **before** rAF callbacks (and before rVFC callbacks, which occur before rAF callbacks, if applicable, because once rVFC fires there's no need for the old texture). It exposes a readonly attribute "expired" which the application can check to know if it should re-import.

Notably, expiry occurs even if the texture was imported _just_ prior to rVFC/rAF. This means it's possible to import on an event (say, "ontimeupdate") and have the texture become invalid before getting a chance to use it. I think this is OK because (1) applications should be importing later, inside their rendering task (rAF or rVFC callback), and (2) the strict timing requirements should mean developers find any such errors immediately.
Alternatively there could be a provision that keeps such textures alive a bit longer, but this could result in applications accidentally introducing an extra (video) frame of latency unnecessarily.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2302.html" title="Last updated on Nov 30, 2021, 12:19 AM UTC (52baf82)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2302/baa0d23...kainino0x:52baf82.html" title="Last updated on Nov 30, 2021, 12:19 AM UTC (52baf82)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2302.html" title="Last updated on Feb 18, 2022, 12:10 AM UTC (a2d998f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2302/0005996...kainino0x:a2d998f.html" title="Last updated on Feb 18, 2022, 12:10 AM UTC (a2d998f)">Diff</a>