### PR TITLE
Typing of literals

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -445,51 +445,26 @@ A <dfn>token</dfn> is a contiguous sequence of characters forming one of:
 ## Literals ## {#literals}
 
 A <dfn>literal</dfn> is one of:
-* a <dfn>numeric literal</dfn>, used to represent a number.
+* A <dfn>numeric literal</dfn> is either an [=syntax/int_literal=] or a [=syntax/float_literal=],
+    and is used to represent a number.
 * a <dfn noexport>boolean literal</dfn>: either `true` or `false`.
 
 The form of a [=numeric literal=] is defined via pattern-matching:
 
 <div class='syntax' noexport='true'>
+  <dfn for=syntax>int_literal</dfn> :
+
+    | `/(0x[0-9a-fA-F]+|0|[1-9][0-9]*)[iu]?/`
+</div>
+<div class='syntax' noexport='true'>
   <dfn for=syntax>decimal_float_literal</dfn> :
 
-    | `/((-?[0-9]*\.[0-9]+|-?[0-9]+\.[0-9]*)((e|E)(\+|-)?[0-9]+)?)|(-?[0-9]+(e|E)(\+|-)?[0-9]+)/`
+    | `/((([0-9]*\.[0-9]+|[0-9]+\.[0-9]*)((e|E)(\+|-)?[0-9]+)?)|([0-9]+(e|E)(\+|-)?[0-9]+))f?|0f|[1-9][0-9]*f/`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>hex_float_literal</dfn> :
 
-    | `/-?0x((([0-9a-fA-F]*\.[0-9a-fA-F]+|[0-9a-fA-F]+\.[0-9a-fA-F]*)((p|P)(\+|-)?[0-9]+)?)|([0-9a-fA-F]+(p|P)(\+|-)?[0-9]+))/`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>int_literal</dfn> :
-
-    | `/-?0x[0-9a-fA-F]+|0|-?[1-9][0-9]*/`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>uint_literal</dfn> :
-
-    | `/0x[0-9a-fA-F]+u|0u|[1-9][0-9]*u/`
-</div>
-
-Note: literals are parsed greedily. This means that for statements like `a -5`
-      this will *not* parse as `a` `minus` `5` but instead as `a` `-5` which
-      may be unexpected. A space must be inserted after the `-` if the first
-      expression is desired.
-
-TODO(dneto): Describe how numeric literal tokens map to idealized values, and then to typed values.
-
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>const_literal</dfn> :
-
-    | [=syntax/int_literal=]
-
-    | [=syntax/uint_literal=]
-
-    | [=syntax/float_literal=]
-
-    | [=syntax/true=]
-
-    | [=syntax/false=]
+    | `/0x((([0-9a-fA-F]*\.[0-9a-fA-F]+|[0-9a-fA-F]+\.[0-9a-fA-F]*)((p|P)(\+|-)?[0-9]+)?)|([0-9a-fA-F]+(p|P)(\+|-)?[0-9]+))/`
 </div>
 
 <div class='syntax' noexport='true'>
@@ -500,6 +475,38 @@ TODO(dneto): Describe how numeric literal tokens map to idealized values, and th
     | [=syntax/hex_float_literal=]
 </div>
 
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>const_literal</dfn> :
+
+    | [=syntax/int_literal=]
+
+    | [=syntax/float_literal=]
+
+    | [=syntax/true=]
+
+    | [=syntax/false=]
+</div>
+
+When a [=numeric literal=] has a suffix, the literal denotes a value in a specific [=scalar=] type.
+<table class=data>
+  <caption>Mapping literals to types</caption>
+  <thead>
+    <tr><th>Literal<th>Suffix<th>Type<th>Examples
+  </thead>
+
+  <tr><td>[=syntax/int_literal=]<td>`i`<td>[=i32=]<td>42i
+  <tr><td>[=syntax/int_literal=]<td>`u`<td>[=u32=]<td>42u
+  <tr><td>[=syntax/int_literal=]<td><td>[=IdealInteger=]<td>124
+  <tr><td>[=syntax/float_literal=]<td>`f`<td>[=f32=]<td>42f 1e5f 1.2f 0x1.0p10f
+  <tr><td>[=syntax/float_literal=]<td><td>[=IdealReal=]<td>1e5 1.2 0x1.0p10
+</table>
+
+A [=shader-creation error=] results if:
+* An [=syntax/int_literal=] with a suffix cannot be exactly represented by the target type.
+* A [=syntax/hex_float_literal=] with a `f` suffix cannot be exactly represented by the target type.
+* A [=syntax/decimal_float_literal=] with a `f` suffix overflows the target type.
+
+Note: 1.1 is not exactly representable by the [=f32=] type.
 
 ## Keywords ## {#keywords}
 
@@ -548,8 +555,6 @@ An attribute must not be specified more than once per object or type.
     | [=syntax/float_literal=]
 
     | [=syntax/int_literal=]
-
-    | [=syntax/uint_literal=]
 
     | [=syntax/ident=]
 </div>
@@ -835,7 +840,7 @@ In [SHORTNAME], a <dfn noexport>type</dfn> is set of values, and each value belo
 A value's type determines the syntax and semantics of operations that can be performed on that value.
 
 For example, the mathematical number 1 corresponds to three distinct values in [SHORTNAME]:
-* the 32-bit signed integer value `1`,
+* the 32-bit signed integer value `1i`,
 * the 32-bit unsigned integer value `1u`, and
 * the 32-bit floating point value `1.0`.
 
@@ -861,8 +866,8 @@ Note: [SHORTNAME] [=reference types=] are not written in [SHORTNAME] programs. S
 A [SHORTNAME] value is computed by evaluating an expression.
 An <dfn noexport>expression</dfn> is a segment of source text
 parsed as one of the [SHORTNAME] grammar rules whose name ends with "`_expression`".
-An expression *E* can contain <dfn noexport>subexpressions</dfn> which are expressions properly contained
-in the outer expression *E*.
+An expression |E| can contain <dfn noexport>subexpressions</dfn> which are expressions properly contained
+in the outer expression |E|.
 
 The particular value produced by an expression evaluation depends on:
 * <dfn noexport>static context</dfn>:

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -496,13 +496,13 @@ When a [=numeric literal=] has a suffix, the literal denotes a value in a specif
 
   <tr><td>[=syntax/int_literal=]<td>`i`<td>[=i32=]<td>42i
   <tr><td>[=syntax/int_literal=]<td>`u`<td>[=u32=]<td>42u
-  <tr><td>[=syntax/int_literal=]<td><td>[=IdealInteger=]<td>124
+  <tr><td>[=syntax/int_literal=]<td><td>Any of [=i32=], [=u32=] or [=f32=], see [[#type-checking-section]]<td>124
   <tr><td>[=syntax/float_literal=]<td>`f`<td>[=f32=]<td>42f 1e5f 1.2f 0x1.0p10f
-  <tr><td>[=syntax/float_literal=]<td><td>[=IdealReal=]<td>1e5 1.2 0x1.0p10
+  <tr><td>[=syntax/float_literal=]<td><td>[=f32=]<td>1e5 1.2 0x1.0p10
 </table>
 
 A [=shader-creation error=] results if:
-* An [=syntax/int_literal=] with a suffix cannot be exactly represented by the target type.
+* An [=syntax/int_literal=] cannot be exactly represented by the target type.
 * A [=syntax/hex_float_literal=] with a `f` suffix cannot be exactly represented by the target type.
 * A [=syntax/decimal_float_literal=] with a `f` suffix overflows the target type.
 
@@ -1024,6 +1024,57 @@ discover a type error, while only having to inspect the program source text.
   </xmp>
 </div>
 
+<div class='example wgsl function-scope' heading='Many less-detailed examples of typing literals'>
+  <xmp highlight='rust'>
+    // Explicitly typed literals
+    var u32_1 = 1u; // variable is a u32
+    var i32_1 = 1i; // variable is an i32
+    var f32_1 = 1f; // variable is an f32
+    var f32_2 = 1.0; // variable is an f32
+
+    // Promotion.
+    var f32_promotion : f32 = 1; // variable is f32
+    var i32_demotion : i32 = 1.0; // invalid, floating point literals are always f32
+
+    // Values must be representable.
+    let u32_too_large : u32 = 1234567890123456890; // invalid, overflow
+    let i32_too_large : i32 = 1234567890123456890; // invalid, overflow
+    let u32_large : u32 = 2147483649; // valid
+    let i32_large : i32 = 2147483649; // invalid, overflow
+    let f32_out_of_range1 = 0x1p500; // invalid, out of range
+    let f32_out_of_range2 = 0x1.0000000001p0; // invalid, not representable in f32
+
+    // Minimum integer.
+    let i32_min = -2147483648;
+    // Corner case values don't change type inference.
+    let i32_value = 0x80000001; // type is i32, so there would be overflow and the program is invalid.
+
+    // All of these are correctly inferred as u32.
+    var u32_expr1 = (1 + (1 + (1 + (1 + 1)))) + 1u;
+    var u32_expr2 = 1u + (1 + (1 + (1 + (1 + 1))));
+    var u32_expr3 = (1 + (1 + (1 + (1u + 1)))) + 1;
+    var u32_expr4 = 1 + (1 + (1 + (1 + (1u + 1))));
+
+    // All of these are correctly inferred as f32.
+    let f32_promotion1 = 1.0 + 2 + 3 + 4;
+    let f32_promotion2 = 2 + 1.0 + 3 + 4;
+    let f32_promotion3 = 1f + ((2 + 3) + 4); // types can propagate down the tree
+    let f32_promotion4 = ((2 + (3 + 1f)) + 4); // types can propagate up the tree
+
+    // Built-in functions use the same rules as operators
+    let u32_clamp = clamp(5, 0, u32_from_expr); // literals are u32
+    let i32_clamp = clamp(1, -5, 5); // literals are i32
+    let f32_clamp = clamp(0, f32_1, 1); // literals are f32
+
+    // Type rule violations.
+    let mismatch : u32 = 1.0 + 1; // invalid, the expression is of type f32, but the statement requires u32
+    let ambiguous_clamp = clamp(1u, 0, 1i); // invalid, there is no overload of clamp that allows mixed sign parameters.
+
+    // Inference completes at the statement level.
+    let some_i32 = 1; // type is i32
+    let some_f32 : f32 = some_i32; // invalid, i32 cannot be assigned to f32
+  </xmp>
+</div>
 ### Type rule tables ### {#typing-tables-section}
 
 The [SHORTNAME] [=type rules=] are organized into <dfn noexport>type rule tables</dfn>,

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -899,7 +899,6 @@ is a type assertion meaning *T* is the static type of [SHORTNAME] expression *e*
 Note: A type assertion is a statement of fact about the text of a program.
 It is not a runtime check.
 
-Finding static types for expressions can be performed by recursively applying type rules.
 A <dfn noexport>type rule</dfn> has two parts:
 * A conclusion, stated as a type assertion for an expression.
     The expression in the type assertion is specified schematically,
@@ -929,18 +928,101 @@ A <dfn noexport>type rule applies to an expression</dfn> when:
 
 TODO: write an example such as `1+2`, or `3 - a`, where `a` is in-scope of a let declaration with `i32` type.
 
-The type rules are designed so that if parsing succeeds, at most one type rule will apply to each expression.
-If a type rule applies to an expression, then the conclusion is asserted, and therefore determines the static type of the expression.
+A <dfn noexport>literal type</dfn> is not an actual type, it is only a temporary placeholder for a type, used in describing the type checking algorithm.
+
+Finding static types for expressions is done in two steps, the first of which is bottom-up and the second of which is top-down:
+* For each expression, either assign it a [=static type=] or mark it as a [=literal type=] purely based on its subexpressions.
+    * First, recursively apply this part of the algorithm to all of its subexpressions
+    * Then compute the set of [=overloads=] of the type rules that apply for this expression, treating any subexpression with a [=literal type=] as if it were all of [=i32=], [=u32=], and [=f32=].
+    * If there is no such overload, the source program is not a valid [SHORTNAME] program.
+    * If there is all such overloads have the same conclusion, then the expression's [=static type=] is given by this conclusion
+    * Otherwise mark the expression as a literal type
+* For each expression with a literal type:
+    * First, apply this part of the algorithm to its parent expression if it has one with a literal type.
+    * Choose a static type for the expression:
+        * If its parent expression can be typed by a single overload, taking into account its conclusion (see next step), then it gives a static type to this expression
+        * Else if it has no parent expression, and the statement this expression is part of requires one of i32, u32, or f32, then it is this expression's type
+        * Else if it has no parent expression, and the statement this expression is part of requires a different type, then the source program is not a valid [SHORTNAME] program.
+        * Else it is of type [=i32=]
+    * Compute the set of [=overloads=] of the type rules that apply for this expression, taking into account both the preconditions (treating any subexpression with a literal type as if it were all of [=i32=], [=u32=], and [=f32=]) and the conclusion (which must match the type picked at the previous step)
+    * If there is either 0 or more than 1 such overload, then the source program is not a valid [SHORTNAME] program.
 
 A [SHORTNAME] source program is <dfn noexport>well-typed</dfn> when:
-* The static type can be determined for each expression in the program by applying the type rules, and
+* The algorithm above successfully assigns a static type to each expression, and
 * The type requirements for each statement are satisfied.
 
 Otherwise there is a <dfn noexport>type error</dfn> and the source program is not a valid [SHORTNAME] program.
 
+Note: If the procedure above succeeded, then adding an `i`, `u`, or `f` suffix to every non-suffixed integer literal in the program based on its type does not change the program's semantics.
+
+Note: If there is no non-suffixed integer-literal in a [SHORTNAME] program, then the first phase of the algorithm above will never give a [=literal type=] to any expression, and the second phase is redundant.
+
 [SHORTNAME] is a <dfn noexport>statically typed language</dfn>
 because type checking a [SHORTNAME] program will either succeed or
 discover a type error, while only having to inspect the program source text.
+
+<div class='example wgsl function-scope' heading='Literal type forced by a statement'>
+  <xmp highlight='rust'>
+    let x : f32 = 42;
+    // '42' is marked as having a literal type by the first half of the algorithm
+    // The second half requires its type to match what is expected by the statement, so it becomes f32
+  </xmp>
+</div>
+
+<div class='example wgsl function-scope' heading='Literal type in an invalid context'>
+  <xmp highlight='rust'>
+    let x : bool = 42;
+    // '42' is marked as having a literal type by the first half of the algorithm
+    // 'bool' is not one of the types that a literal type can match, so this program will give a type error
+  </xmp>
+</div>
+
+<div class='example wgsl function-scope' heading='Literal type in a generic context'>
+  <xmp highlight='rust'>
+    let x = 42;
+    // '42' is marked as having a literal type by the first half of the algorithm
+    // The immediate context puts no requirement on its static type, so it defaults to i32
+  </xmp>
+</div>
+
+<div class='example wgsl function-scope' heading='Typing a comparison with literals'>
+  <xmp highlight='rust'>
+    let x = (1 + 2) < (3 + 4u);
+    // First phase:
+    // 1 has a literal type (since it can be multiple types)
+    // 2 has a literal type (since it can be multiple types)
+    // (1 + 2) has multiple type rule overloads that apply: i32+i32:i32, u32+u32:u32, and f32+f32:f32
+    // They don't share a conclusion, so (1 + 2) has a literal type
+    // 3 has a literal type
+    // 4u is of type u32
+    // (3 + 4u) has a single type rule overload that applies: u32+u32:u32, so it is of type u32
+    // (1 + 2) < (3 + 4u) has a single type rule overload that applies: u32<u32:bool, so it is of type bool
+    // Second phase:
+    // The single type rule overload of the top-level overload forces (1 + 2) to be of type u32
+    // So it now has a single type rule overload that applies when taking into account the conclusion
+    // So 1 and 2 are also of type u32.
+  </xmp>
+</div>
+
+<div class='example wgsl function-scope' heading='Typing a chain of additions with literals'>
+  <xmp highlight='rust'>
+    let x = ((1 + 2) + 3) + 4u;
+    // First phase:
+    // 1 has a literal type
+    // 2 has a literal type
+    // (1 + 2) has multiple type rule overloads that apply: i32+i32:i32, u32+u32:u32, and f32+f32:f32
+    // They don't share a conclusion, so (1 + 2) has a literal type
+    // 3 has a literal type
+    // By the same reasoning as before, ((1 + 2) + 3) has a literal type
+    // 4u is of type u32
+    // So the top-level expression is of type u32 since u32+u32: is the only type rule overload that applies
+    // Second phase:
+    // The single type rule overload of the top-level overload forces ((1 + 2)+ 3) to be of type u32
+    // So it now has a single type rule overload that applies when taking into account the conclusion
+    // So (1 + 2) and 3 are both also of type u32.
+    // And finally (1 + 2) having type u32 ensures that 1 and 2 both have type u32.
+  </xmp>
+</div>
 
 ### Type rule tables ### {#typing-tables-section}
 
@@ -1225,8 +1307,6 @@ Restrictions on runtime-sized arrays:
   <dfn for=syntax>element_count_expression</dfn> :
 
     | [=syntax/int_literal=]
-
-    | [=syntax/uint_literal=]
 
     | [=syntax/ident=]
 </div>


### PR DESCRIPTION
This is an alternative to #2227.

### Goals
It has the following two properties:
- If every integer literal is suffixed with `u` or `i`, then typing proceeds like currently
- If a program is well-typed, then it is possible to add a `u` or `i` suffix to every integer literal in it without changing its semantics.

The second property is the main difference with #2227, and I consider it very beneficial for the following reasons:
- No need for the compiler to know how to execute all relevant operators and built-in functions on the CPU with a special precision
- The following two programs are always equivalent, which I consider key for refactoring to be sane:
```
let x: f32 = e1 + e2;
let y: f32 = x + e3;
```
and 
```
let y: f32 = (e1 + e2) + e3;
```
With the "IdealReal"/"IdealInteger" approach of #2227, replacing either one of these pieces of code by the other could silently change the value computed, as it can change the precision with which the computation are done. For example, with `e1= 16777216.0` and `e2=e3=1.0`, the first code fragment would return 16777216.0, and the second would return 16777218.0.

### Contents of the PR
My proposal is based on a two-step approach: start by the usual bottom-up type-checking, but allow it to say "I'm not sure" for expressions which contain unsuffixed literals, then have a top-down phase to refine the type of those expressions.

This PR also contains the grammar changes of #2227, and I've also borrowed a long list of examples from it.