### PR TITLE
Allow 'f' suffix on floats

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -459,12 +459,12 @@ The form of a [=numeric literal=] is defined via pattern-matching:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>decimal_float_literal</dfn> :
 
-    | `/((-?[0-9]*\.[0-9]+|-?[0-9]+\.[0-9]*)((e|E)(\+|-)?[0-9]+)?)|(-?[0-9]+(e|E)(\+|-)?[0-9]+)/`
+    | `/((-?[0-9]*\.[0-9]+|-?[0-9]+\.[0-9]*)((e|E)(\+|-)?[0-9]+)?f?)|(-?[0-9]+(e|E)(\+|-)?[0-9]+f?)/`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>hex_float_literal</dfn> :
 
-    | `/-?0x((([0-9a-fA-F]*\.[0-9a-fA-F]+|[0-9a-fA-F]+\.[0-9a-fA-F]*)((p|P)(\+|-)?[0-9]+)?)|([0-9a-fA-F]+(p|P)(\+|-)?[0-9]+))/`
+    | `/-?0x((([0-9a-fA-F]*\.[0-9a-fA-F]+|[0-9a-fA-F]+\.[0-9a-fA-F]*)((p|P)(\+|-)?[0-9]+f?)?)|([0-9a-fA-F]+(p|P)(\+|-)?[0-9]+f?))/`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>int_literal</dfn> :


### PR DESCRIPTION
- For decimal floats, allow it after any form
- For hex floats, it must follow an explicitly-written binary exponent.
  Otherwise it's ambiguous, because 'f' is a hex digit.

Fixes: #2210