### PR TITLE
Renames GPUProgrammablePassEncoder to GPUProgrammableEncoder

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -875,13 +875,13 @@ This specification defines the following [=usage scopes=]:
     {{GPUPipelineBase/[[layout]]}}, every [=subresource=] referenced by
     that bind group is "used" in the usage scope.
     State-setting compute pass commands, like
-    {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)}},
+    {{GPUProgrammableEncoder/setBindGroup(index, bindGroup, dynamicOffsets)}},
     do not contribute directly to a usage scope; they instead change the
     state that is checked in dispatch commands.
 - One render pass is one usage scope.
     A subresource is "used" in the usage scope if it's referenced by any
     (state-setting or non-state-setting) command. For example, in
-    {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)}},
+    {{GPUProgrammableEncoder/setBindGroup(index, bindGroup, dynamicOffsets)}},
     every subresource in `bindGroup` is "used" in the render pass's usage scope.
 
 Issue: The above should probably talk about [=GPU commands=]. But we don't have a way to
@@ -892,7 +892,7 @@ reference specific GPU commands (like dispatch) yet.
     included in [=usage scope validation=]:
 
     - In a render pass, subresources used in any
-        {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup()}}
+        {{GPUProgrammableEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup()}}
         call, regardless of whether the currently bound pipeline's
         shader or layout actually depends on these bindings,
         or the bind group is shadowed by another 'set' call.
@@ -1202,7 +1202,7 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
         <td>{{GPUSize32}} <td>Lower <td>256
     <tr class=row-continuation><td colspan=4>
         The required alignment for {{GPUBufferBinding}}.{{GPUBufferBinding/offset}} and
-        {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup}}
+        {{GPUProgrammableEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup}}
         |dynamicOffsets| arguments for binding with a {{GPUBindGroupLayoutEntry}} |entry| for which
         |entry|.{{GPUBindGroupLayoutEntry/buffer}}?.{{GPUBufferBindingLayout/type}}
         is {{GPUBufferBindingType/"uniform"}}.
@@ -1211,7 +1211,7 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
         <td>{{GPUSize32}} <td>Lower <td>256
     <tr class=row-continuation><td colspan=4>
         The required alignment for {{GPUBufferBinding}}.{{GPUBufferBinding/offset}} and
-        {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup}}
+        {{GPUProgrammableEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup}}
         |dynamicOffsets| arguments for binding with a {{GPUBindGroupLayoutEntry}} |entry| for which
         |entry|.{{GPUBindGroupLayoutEntry/buffer}}?.{{GPUBufferBindingLayout/type}}
         is {{GPUBufferBindingType/"storage"}}
@@ -3917,7 +3917,7 @@ A {{GPUBindGroup}} object has the following internal slots:
 
 ## <dfn interface>GPUPipelineLayout</dfn> ## {#pipeline-layout}
 
-A {{GPUPipelineLayout}} defines the mapping between resources of all {{GPUBindGroup}} objects set up during command encoding in {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup}}, and the shaders of the pipeline set by {{GPURenderEncoderBase/setPipeline(pipeline)|GPURenderEncoderBase.setPipeline}} or {{GPUComputePassEncoder/setPipeline(pipeline)|GPUComputePassEncoder.setPipeline}}.
+A {{GPUPipelineLayout}} defines the mapping between resources of all {{GPUBindGroup}} objects set up during command encoding in {{GPUProgrammableEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup}}, and the shaders of the pipeline set by {{GPURenderEncoderBase/setPipeline(pipeline)|GPURenderEncoderBase.setPipeline}} or {{GPUComputePassEncoder/setPipeline(pipeline)|GPUComputePassEncoder.setPipeline}}.
 
 The full binding address of a resource can be defined as a trio of:
   1. shader stage mask, to which the resource is visible
@@ -3946,12 +3946,12 @@ Note: using the same {{GPUPipelineLayout}} for many {{GPURenderPipeline}} or {{G
 <div class="example">
 {{GPUComputePipeline}} object X was created with {{GPUPipelineLayout/[[bindGroupLayouts]]|GPUPipelineLayout.bindGroupLayouts}} A, B, C. {{GPUComputePipeline}} object Y was created with {{GPUPipelineLayout/[[bindGroupLayouts]]|GPUPipelineLayout.bindGroupLayouts}} A, D, C. Supposing the command encoding sequence has two dispatches:
 
-  1. {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup(0, ...)}}
-  1. {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup(1, ...)}}
-  1. {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup(2, ...)}}
+  1. {{GPUProgrammableEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup(0, ...)}}
+  1. {{GPUProgrammableEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup(1, ...)}}
+  1. {{GPUProgrammableEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup(2, ...)}}
   1. {{GPUComputePassEncoder/setPipeline(pipeline)|setPipeline(X)}}
   1. {{GPUComputePassEncoder/dispatch(x, y, z)|dispatch()}}
-  1. {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup(1, ...)}}
+  1. {{GPUProgrammableEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup(1, ...)}}
   1. {{GPUComputePassEncoder/setPipeline(pipeline)|setPipeline(Y)}}
   1. {{GPUComputePassEncoder/dispatch(x, y, z)|dispatch()}}
 
@@ -5644,7 +5644,7 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                 1. For each |timestampWrite| in |descriptor|.{{GPURenderPassDescriptor/timestampWrites}},
                     1. If |timestampWrite|.{{GPURenderPassTimestampWrite/location}} is {{GPURenderPassTimestampLocation/"beginning"}},
                         [=list/Append=] a [=GPU command=] to
-                        |pass|.{{GPUProgrammablePassEncoder/[[command_encoder]]}}.{{GPUCommandEncoder/[[command_list]]}}
+                        |pass|.{{GPUProgrammableEncoder/[[command_encoder]]}}.{{GPUCommandEncoder/[[command_list]]}}
                         that writes the GPU's timestamp value into the |timestampWrite|.{{GPURenderPassTimestampWrite/queryIndex}}th
                         index in |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}}.
                     1. Otherwise, if |timestampWrite|.{{GPURenderPassTimestampWrite/location}} is {{GPURenderPassTimestampLocation/"end"}},
@@ -5687,7 +5687,7 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                 1. For each |timestampWrite| in |descriptor|.{{GPUComputePassDescriptor/timestampWrites}},
                     1. If |timestampWrite|.{{GPUComputePassTimestampWrite/location}} is {{GPUComputePassTimestampLocation/"beginning"}},
                         [=list/Append=] a [=GPU command=] to
-                        |pass|.{{GPUProgrammablePassEncoder/[[command_encoder]]}}.{{GPUCommandEncoder/[[command_list]]}}
+                        |pass|.{{GPUProgrammableEncoder/[[command_encoder]]}}.{{GPUCommandEncoder/[[command_list]]}}
                         that writes the GPU's timestamp value into the |timestampWrite|.{{GPUComputePassTimestampWrite/queryIndex}}th
                         index in |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}}.
                     1. Otherwise, if |timestampWrite|.{{GPUComputePassTimestampWrite/location}} is {{GPUComputePassTimestampLocation/"end"}},
@@ -6258,7 +6258,7 @@ a hierarchy of labeled commands. These labels may be passed to the native API ba
 may be used by the user agent's internal tooling, or may be a no-op when such tooling is not
 available or applicable.
 
-Debug groups in a {{GPUCommandEncoder}} or {{GPUProgrammablePassEncoder}}
+Debug groups in a {{GPUCommandEncoder}} or {{GPUProgrammableEncoder}}
 must be well nested.
 
 <dl dfn-type=method dfn-for=GPUCommandEncoder>
@@ -6440,7 +6440,7 @@ command encoder can no longer be used.
 
 <script type=idl>
 
-interface mixin GPUProgrammablePassEncoder {
+interface mixin GPUProgrammableEncoder {
     undefined setBindGroup(GPUIndex32 index, GPUBindGroup bindGroup,
                       optional sequence<GPUBufferDynamicOffset> dynamicOffsets = []);
 
@@ -6455,9 +6455,9 @@ interface mixin GPUProgrammablePassEncoder {
 };
 </script>
 
-{{GPUProgrammablePassEncoder}} has the following internal slots:
+{{GPUProgrammableEncoder}} has the following internal slots:
 
-<dl dfn-type=attribute dfn-for="GPUProgrammablePassEncoder">
+<dl dfn-type=attribute dfn-for="GPUProgrammableEncoder">
     : <dfn>\[[command_encoder]]</dfn> of type {{GPUCommandEncoder}}.
     ::
         The {{GPUCommandEncoder}} that created this programmable pass.
@@ -6473,16 +6473,16 @@ interface mixin GPUProgrammablePassEncoder {
 
 ## Bind Groups ## {#programmable-passes-bind-groups}
 
-<dl dfn-type=method dfn-for=GPUProgrammablePassEncoder>
+<dl dfn-type=method dfn-for=GPUProgrammableEncoder>
     : <dfn>setBindGroup(index, bindGroup, dynamicOffsets)</dfn>
     ::
         Sets the current {{GPUBindGroup}} for the given index.
 
-        <div algorithm=GPUProgrammablePassEncoder.setBindGroup>
-            **Called on:** {{GPUProgrammablePassEncoder}} this.
+        <div algorithm=GPUProgrammableEncoder.setBindGroup>
+            **Called on:** {{GPUProgrammableEncoder}} this.
 
             **Arguments:**
-            <pre class=argumentdef for="GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)">
+            <pre class=argumentdef for="GPUProgrammableEncoder/setBindGroup(index, bindGroup, dynamicOffsets)">
                 |index|: The index to set the bind group at.
                 |bindGroup|: Bind group to use for subsequent render or compute commands.
 
@@ -6525,7 +6525,7 @@ interface mixin GPUProgrammablePassEncoder {
                                 - |dynamicOffset| is a multiple of {{supported limits/minStorageBufferOffsetAlignment}}.
 
                     </div>
-                1. Set |this|.{{GPUProgrammablePassEncoder/[[bind_groups]]}}[|index|] to be |bindGroup|.
+                1. Set |this|.{{GPUProgrammableEncoder/[[bind_groups]]}}[|index|] to be |bindGroup|.
             </div>
         </div>
 
@@ -6534,11 +6534,11 @@ interface mixin GPUProgrammablePassEncoder {
         Sets the current {{GPUBindGroup}} for the given index, specifying dynamic offsets as a subset
         of a {{Uint32Array}}.
 
-        <div algorithm=GPUProgrammablePassEncoder.setBindGroup2>
-            **Called on:** {{GPUProgrammablePassEncoder}} |this|.
+        <div algorithm=GPUProgrammableEncoder.setBindGroup2>
+            **Called on:** {{GPUProgrammableEncoder}} |this|.
 
             **Arguments:**
-            <pre class=argumentdef for="GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsetsData, dynamicOffsetsDataStart, dynamicOffsetsDataLength)">
+            <pre class=argumentdef for="GPUProgrammableEncoder/setBindGroup(index, bindGroup, dynamicOffsetsData, dynamicOffsetsDataStart, dynamicOffsetsDataLength)">
                 |index|: The index to set the bind group at.
                 |bindGroup|: Bind group to use for subsequent render or compute commands.
                 |dynamicOffsetsData|: Array containing buffer offsets in bytes for each entry in
@@ -6559,7 +6559,7 @@ interface mixin GPUProgrammablePassEncoder {
             1. Let |dynamicOffsets| be a [=list=] containing the range, starting at index
                 |dynamicOffsetsDataStart|, of |dynamicOffsetsDataLength| elements of
                 [=get a copy of the buffer source|a copy of=] |dynamicOffsetsData|.
-            1. Call |this|.{{GPUProgrammablePassEncoder/setBindGroup(index,
+            1. Call |this|.{{GPUProgrammableEncoder/setBindGroup(index,
                 bindGroup, dynamicOffsets)|setBindGroup}}(|index|, |bindGroup|, |dynamicOffsets|).
 </dl>
 
@@ -6584,7 +6584,7 @@ interface mixin GPUProgrammablePassEncoder {
     <dfn abstract-op>Validate encoder bind groups</dfn>(encoder, pipeline)
 
     **Arguments:**
-    : {{GPUProgrammablePassEncoder}} |encoder|
+    : {{GPUProgrammableEncoder}} |encoder|
     :: Encoder who's bind groups are being validated.
     : {{GPUPipelineBase}} |pipeline|
     :: Pipline to validate |encoder|s bind groups are compatible with.
@@ -6594,7 +6594,7 @@ interface mixin GPUProgrammablePassEncoder {
             - |pipeline| must not be `null`.
             - For each pair of ({{GPUIndex32}} |index|, {{GPUBindGroupLayout}} |bindGroupLayout|) in
                 |pipeline|.{{GPUPipelineBase/[[layout]]}}.{{GPUPipelineLayout/[[bindGroupLayouts]]}}.
-                - Let |bindGroup| be |encoder|.{{GPUProgrammablePassEncoder/[[bind_groups]]}}[|index|].
+                - Let |bindGroup| be |encoder|.{{GPUProgrammableEncoder/[[bind_groups]]}}[|index|].
                 - |bindGroup| must not be `null`.
                 - |bindGroup|.{{GPUBindGroup/[[layout]]}} must be [=group-equivalent=] with |bindGroupLayout|.
 
@@ -6610,16 +6610,16 @@ Debug marker methods for programmable pass encoders provide the same functionali
 [[#command-encoder-debug-markers|command encoder debug markers]] while recording a programmable
 pass.
 
-<dl dfn-type=method dfn-for=GPUProgrammablePassEncoder>
+<dl dfn-type=method dfn-for=GPUProgrammableEncoder>
     : <dfn>pushDebugGroup(groupLabel)</dfn>
     ::
-        Marks the beginning of a labeled group of commands for the {{GPUProgrammablePassEncoder}}.
+        Marks the beginning of a labeled group of commands for the {{GPUProgrammableEncoder}}.
 
-        <div algorithm=GPUProgrammablePassEncoder.pushDebugGroup>
-            **Called on:** {{GPUProgrammablePassEncoder}} |this|.
+        <div algorithm=GPUProgrammableEncoder.pushDebugGroup>
+            **Called on:** {{GPUProgrammableEncoder}} |this|.
 
             **Arguments:**
-            <pre class=argumentdef for="GPUProgrammablePassEncoder/pushDebugGroup(groupLabel)">
+            <pre class=argumentdef for="GPUProgrammableEncoder/pushDebugGroup(groupLabel)">
                 |groupLabel|: The label for the command group.
             </pre>
 
@@ -6627,16 +6627,16 @@ pass.
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
-                1. [=stack/Push=] |groupLabel| onto |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.
+                1. [=stack/Push=] |groupLabel| onto |this|.{{GPUProgrammableEncoder/[[debug_group_stack]]}}.
             </div>
         </div>
 
     : <dfn>popDebugGroup()</dfn>
     ::
-        Marks the end of a labeled group of commands for the {{GPUProgrammablePassEncoder}}.
+        Marks the end of a labeled group of commands for the {{GPUProgrammableEncoder}}.
 
-        <div algorithm=GPUProgrammablePassEncoder.popDebugGroup>
-            **Called on:** {{GPUProgrammablePassEncoder}} |this|.
+        <div algorithm=GPUProgrammableEncoder.popDebugGroup>
+            **Called on:** {{GPUProgrammableEncoder}} |this|.
 
             **Returns:** {{undefined}}
 
@@ -6645,21 +6645,21 @@ pass.
                 1. If any of the following conditions are unsatisfied, generate a validation
                     error and stop.
                     <div class=validusage>
-                        - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}'s [=stack/size=] is greater than 0.
+                        - |this|.{{GPUProgrammableEncoder/[[debug_group_stack]]}}'s [=stack/size=] is greater than 0.
                     </div>
-                1. [=stack/Pop=] an entry off of |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}.
+                1. [=stack/Pop=] an entry off of |this|.{{GPUProgrammableEncoder/[[debug_group_stack]]}}.
             </div>
         </div>
 
     : <dfn>insertDebugMarker(markerLabel)</dfn>
     ::
-        Inserts a single debug marker label into the {{GPUProgrammablePassEncoder}}'s commands sequence.
+        Inserts a single debug marker label into the {{GPUProgrammableEncoder}}'s commands sequence.
 
-        <div algorithm=GPUProgrammablePassEncoder.insertDebugMarker>
-            **Called on:** {{GPUProgrammablePassEncoder}} this.
+        <div algorithm=GPUProgrammableEncoder.insertDebugMarker>
+            **Called on:** {{GPUProgrammableEncoder}} this.
 
             **Arguments:**
-            <pre class=argumentdef for="GPUProgrammablePassEncoder/insertDebugMarker(markerLabel)">
+            <pre class=argumentdef for="GPUProgrammableEncoder/insertDebugMarker(markerLabel)">
                 markerLabel: The label to insert.
             </pre>
 
@@ -6681,7 +6681,7 @@ interface GPUComputePassEncoder {
     undefined endPass();
 };
 GPUComputePassEncoder includes GPUObjectBase;
-GPUComputePassEncoder includes GPUProgrammablePassEncoder;
+GPUComputePassEncoder includes GPUProgrammableEncoder;
 </script>
 
 {{GPUComputePassEncoder}} has the following internal slots:
@@ -6790,13 +6790,13 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
                     </div>
 
                 1. [=list/Append=] a [=GPU command=] to
-                    |this|.{{GPUProgrammablePassEncoder/[[command_encoder]]}}.{{GPUCommandEncoder/[[command_list]]}}
+                    |this|.{{GPUProgrammableEncoder/[[command_encoder]]}}.{{GPUCommandEncoder/[[command_list]]}}
                     that captures the {{GPUComputePassEncoder}} state of |this| as |passState| and,
                     when executed, issues the following steps on the appropriate [=Queue timeline=]:
                     <div class=queue-timeline>
                         1. Dispatch a grid of workgroups with dimensions [|x|, |y|, |z|] with
                             |passState|.{{GPUComputePassEncoder/[[pipeline]]}} using
-                            |passState|.{{GPUProgrammablePassEncoder/[[bind_groups]]}}.
+                            |passState|.{{GPUProgrammableEncoder/[[bind_groups]]}}.
                     </div>
             </div>
         </div>
@@ -6869,14 +6869,14 @@ called the compute pass encoder can no longer be used.
                 1. If any of the following conditions are unsatisfied, generate a validation
                     error and stop.
                     <div class=validusage>
-                        - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}'s [=stack/size=] is 0.
+                        - |this|.{{GPUProgrammableEncoder/[[debug_group_stack]]}}'s [=stack/size=] is 0.
 
                         Issue: Add remaining validation.
                     </div>
                 1. For each |timestampWrite| in |this|.{{GPUComputePassEncoder/[[endTimestampWrites]]}},
                     1. (|timestampWrite|.{{GPUComputePassTimestampWrite/location}} must equal {{GPUComputePassTimestampLocation/"end"}}.)
                     1. [=list/Append=] a [=GPU command=] to
-                        |this|.{{GPUProgrammablePassEncoder/[[command_encoder]]}}.{{GPUCommandEncoder/[[command_list]]}}
+                        |this|.{{GPUProgrammableEncoder/[[command_encoder]]}}.{{GPUCommandEncoder/[[command_list]]}}
                         that writes the GPU's timestamp value into the |timestampWrite|.{{GPUComputePassTimestampWrite/queryIndex}}th
                         index in |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}}.
             </div>
@@ -6924,7 +6924,7 @@ interface GPURenderPassEncoder {
     undefined endPass();
 };
 GPURenderPassEncoder includes GPUObjectBase;
-GPURenderPassEncoder includes GPUProgrammablePassEncoder;
+GPURenderPassEncoder includes GPUProgrammableEncoder;
 GPURenderPassEncoder includes GPURenderEncoderBase;
 </script>
 
@@ -7888,7 +7888,7 @@ called the render pass encoder can no longer be used.
                 1. If any of the following conditions are unsatisfied, generate a validation
                     error and stop.
                     <div class=validusage>
-                        - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}'s [=stack/size=] is 0.
+                        - |this|.{{GPUProgrammableEncoder/[[debug_group_stack]]}}'s [=stack/size=] is 0.
                         - |this|.{{GPURenderPassEncoder/[[occlusion_query_active]]}} is `false`.
 
                         Issue: Add remaining validation.
@@ -7896,7 +7896,7 @@ called the render pass encoder can no longer be used.
                 1. For each |timestampWrite| in |this|.{{GPURenderPassEncoder/[[endTimestampWrites]]}},
                     1. (|timestampWrite|.{{GPURenderPassTimestampWrite/location}} must equal {{GPURenderPassTimestampLocation/"end"}}.)
                     1. [=list/Append=] a [=GPU command=] to
-                        |this|.{{GPUProgrammablePassEncoder/[[command_encoder]]}}.{{GPUCommandEncoder/[[command_list]]}}
+                        |this|.{{GPUProgrammableEncoder/[[command_encoder]]}}.{{GPUCommandEncoder/[[command_list]]}}
                         that writes the GPU's timestamp value into the |timestampWrite|.{{GPURenderPassTimestampWrite/queryIndex}}th
                         index in |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}}.
 
@@ -7948,7 +7948,7 @@ interface GPURenderBundleEncoder {
     GPURenderBundle finish(optional GPURenderBundleDescriptor descriptor = {});
 };
 GPURenderBundleEncoder includes GPUObjectBase;
-GPURenderBundleEncoder includes GPUProgrammablePassEncoder;
+GPURenderBundleEncoder includes GPUProgrammableEncoder;
 GPURenderBundleEncoder includes GPURenderEncoderBase;
 </script>
 
@@ -8056,7 +8056,7 @@ dictionary GPURenderBundleEncoderDescriptor : GPURenderPassLayout {
                         error and stop.
                         <div class=validusage>
                             - |this| must be [=valid=].
-                            - |this|.{{GPUProgrammablePassEncoder/[[debug_group_stack]]}}'s [=stack/size=] must be 0.
+                            - |this|.{{GPUProgrammableEncoder/[[debug_group_stack]]}}'s [=stack/size=] must be 0.
                             - |this|.{{GPURenderBundleEncoder/[[state]]}} must be [=render bundle state/open=].
                             - Every [=usage scope=] contained in |this| must satisfy the [=usage scope validation=].
                         </div>
@@ -8992,7 +8992,7 @@ of the current {{GPURenderPassEncoder}} during command encoding.
       - |pass|.<dfn dfn>vertexBuffers</dfn> refers to
         [=list=]&lt;vertex buffer&gt; bound by {{GPURenderEncoderBase/setVertexBuffer()}}.
       - |pass|.<dfn dfn>bindGroups</dfn> refers to
-        [=list=]&lt;{{GPUBindGroup}}&gt; bound by {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)}}.
+        [=list=]&lt;{{GPUBindGroup}}&gt; bound by {{GPUProgrammableEncoder/setBindGroup(index, bindGroup, dynamicOffsets)}}.
 </div>
 
 The main rendering algorithm:


### PR DESCRIPTION
- Updates some documentation on error buffers and their interactions with mappedAtCreation and destroy.
- Renames GPUProgrammablePassEncoder to GPUProgrammableEncoder to reflect changes in https://dawn-review.googlesource.com/c/dawn/+/68461.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lokokung/gpuweb/pull/2312.html" title="Last updated on Nov 16, 2021, 10:38 PM UTC (c69ee52)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2312/cd00966...lokokung:c69ee52.html" title="Last updated on Nov 16, 2021, 10:38 PM UTC (c69ee52)">Diff</a>