### PR TITLE
Updates specs regarding error buffers

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2073,7 +2073,7 @@ namespace GPUBufferUsage {
                 </div>
 
             Note: If buffer creation fails, and |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `false`,
-            it is impossible to call {{GPUBuffer/mapAsync()}}, so any resources allocated to enable mapping can
+            any calls to {{GPUBuffer/mapAsync()}} will reject, so any resources allocated to enable mapping can
             and may be discarded or recycled.
 
             1. Let |b| be a new {{GPUBuffer}} object.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2011,6 +2011,9 @@ dictionary GPUBufferDescriptor : GPUObjectDescriptorBase {
 };
 </script>
 
+- {{GPUBufferDescriptor/mappedAtCreation}} guarantees that even if the buffer eventually fails creation,
+    it will still appear as if the mapped range can be written/read to until it is unmapped.
+
 <div algorithm>
     <dfn abstract-op>validating GPUBufferDescriptor</dfn>(device, descriptor)
         1. If device is lost return `false`.
@@ -2069,17 +2072,14 @@ namespace GPUBufferUsage {
                     Issue(gpuweb/gpuweb#605): Explain what are a {{GPUDevice}}'s `[[allowed buffer usages]]`.
                 </div>
 
+            Note: If buffer creation fails, and |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `false`,
+            it is impossible to call {{GPUBuffer/mapAsync()}}, so any resources allocated to enable mapping can
+            and may be discarded or recycled.
+
             1. Let |b| be a new {{GPUBuffer}} object.
             1. Set |b|.{{GPUBuffer/[[size]]}} to |descriptor|.{{GPUBufferDescriptor/size}}.
             1. Set |b|.{{GPUBuffer/[[usage]]}} to |descriptor|.{{GPUBufferDescriptor/usage}}.
             1. If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`:
-
-                1. If |b| is an error buffer:
-
-                    1. Try to allocate a temporary buffer to appear "mapped". If successfully allocated,
-                         set |b|.{{GPUBuffer/[[state]]}} to [=buffer state/mapped at creation=], otherwise
-                         Set |b|.{{GPUBuffer/[[state]]}} to [=buffer state/unmapped=].
-                    1. Return |b|.
 
                 1. Set |b|.{{GPUBuffer/[[mapping]]}} to a new {{ArrayBuffer}} of size |b|.{{GPUBuffer/[[size]]}}.
                 1. Set |b|.{{GPUBuffer/[[mapping_range]]}} to `[0, descriptor.size]`.
@@ -2107,8 +2107,8 @@ namespace GPUBufferUsage {
 ## Buffer Destruction ## {#buffer-destruction}
 
 An application that no longer requires a {{GPUBuffer}} can choose to lose
-access to it before garbage collection by calling {{GPUBuffer/destroy()}}. Destroying error
-buffers is also valid as it will attempt to reclaim the memory allocated for the temporary buffer.
+access to it before garbage collection by calling {{GPUBuffer/destroy()}}. Destroying a buffer also
+unmaps it, freeing any memory allocated for the mapping.
 
 Note: This allows the user agent to reclaim the GPU memory associated with the {{GPUBuffer}}
 once all previously submitted operations using it are complete.
@@ -2280,7 +2280,8 @@ namespace GPUMapMode {
 
                     Note: It is valid to unmap an [=invalid=] {{GPUBuffer}} that is
                         [=buffer state/mapped at creation=] because the [=Content timeline=]
-                        might not know it is an error {{GPUBuffer}}.
+                        might not know it is an error {{GPUBuffer}}. This allows the temporary
+                        {{GPUBuffer/[[mapping]]}} memory to be freed.
                 </div>
 
             1. If |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapping pending=]:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2066,8 +2066,6 @@ namespace GPUBufferUsage {
                     - If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`:
                         - |descriptor|.{{GPUBufferDescriptor/size}} is a multiple of 4.
 
-                    Issue(gpuweb/gpuweb#605): Explain that the resulting error buffer can still be mapped at creation.
-
                     Issue(gpuweb/gpuweb#605): Explain what are a {{GPUDevice}}'s `[[allowed buffer usages]]`.
                 </div>
 
@@ -2075,6 +2073,13 @@ namespace GPUBufferUsage {
             1. Set |b|.{{GPUBuffer/[[size]]}} to |descriptor|.{{GPUBufferDescriptor/size}}.
             1. Set |b|.{{GPUBuffer/[[usage]]}} to |descriptor|.{{GPUBufferDescriptor/usage}}.
             1. If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`:
+
+                1. If |b| is an error buffer:
+
+                    1. Try to allocate a temporary buffer to appear "mapped". If successfully allocated,
+                         set |b|.{{GPUBuffer/[[state]]}} to [=buffer state/mapped at creation=], otherwise
+                         Set |b|.{{GPUBuffer/[[state]]}} to [=buffer state/unmapped=].
+                    1. Return |b|.
 
                 1. Set |b|.{{GPUBuffer/[[mapping]]}} to a new {{ArrayBuffer}} of size |b|.{{GPUBuffer/[[size]]}}.
                 1. Set |b|.{{GPUBuffer/[[mapping_range]]}} to `[0, descriptor.size]`.
@@ -2102,7 +2107,8 @@ namespace GPUBufferUsage {
 ## Buffer Destruction ## {#buffer-destruction}
 
 An application that no longer requires a {{GPUBuffer}} can choose to lose
-access to it before garbage collection by calling {{GPUBuffer/destroy()}}.
+access to it before garbage collection by calling {{GPUBuffer/destroy()}}. Destroying error
+buffers is also valid as it will attempt to reclaim the memory allocated for the temporary buffer.
 
 Note: This allows the user agent to reclaim the GPU memory associated with the {{GPUBuffer}}
 once all previously submitted operations using it are complete.
@@ -2121,8 +2127,6 @@ once all previously submitted operations using it are complete.
                 1. Run the steps to unmap |this|.
 
             1. Set |this|.{{GPUBuffer/[[state]]}} to [=buffer state/destroyed=].
-
-            Issue: Handle error buffers once we have a description of the error monad.
         </div>
 </dl>
 


### PR DESCRIPTION
- Updates documentation regarding error buffer destruction.
- Updates documentation on mappedAtCreation buffers for error cases.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lokokung/gpuweb/pull/2314.html" title="Last updated on Dec 6, 2021, 11:16 PM UTC (cb845a7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2314/cd00966...lokokung:cb845a7.html" title="Last updated on Dec 6, 2021, 11:16 PM UTC (cb845a7)">Diff</a>