### PR TITLE
Do not require function with return value to end with return.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6226,9 +6226,7 @@ See [[#function-calls]].
 The identifier is [=in scope=] until the end of the function.
 Two formal parameters for a given function must not have the same name.
 
-If the return type is specified, then:
-* The return type must be [=constructible=].
-* The last statement in the function body must be a [=statement/return=] statement.
+The return type, if specified, must be [=constructible=].
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>function_decl</dfn> :


### PR DESCRIPTION
This is superseeded by the bahevior analysis, and make the following
code valid:

 fn isEven(v: u32) -> bool {
   if (v & 1u == 0u) {
     return true;
   } else {
     return false;
   }
 }

Fixes #1897