### PR TITLE
Clarify behaviour of a function

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5803,9 +5803,9 @@ Each of those correspond to a way to exit a compound statement: either through a
 We note "*s*: *B*" to say that *s* respects the rules regarding behaviors, and has [=behavior=] *B*.
 
 For each function:
-- its body must be a valid statement by these rules
-- if it has a return type, its [=behavior=] must be one of {Return} or {Return, Discard}
-- otherwise, its [=behavior=] must be a subset of {Next, Return, Discard}
+- Its body must be a valid statement by these rules.
+- If the function has a return type, the [=behavior=] of its body must be one of {Return} or {Return, Discard}.
+- Otherwise, the [=behavior=] of its body must be a subset of {Next, Return, Discard}.
 
 We assign a [=behavior=] to each function: it is its body's [=behavior=] (treating the body as a regular statement), with any "Return" replaced by "Next".
 As a consequence of the rules above, a function behavior is always one of {}, {Next}, {Discard}, or {Next, Discard}.


### PR DESCRIPTION
Disambiguate "it" and "its" in the same clause.