### PR TITLE
Indirect first instance cleanup

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9749,7 +9749,7 @@ The following enums are supported if and only if the {{GPUFeatureName/"timestamp
         * {{GPUQueryType/"timestamp"}}
 </dl>
 
-## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>indirect-first-instance</dfn> ## {#indirect-first-instance}
+## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>"indirect-first-instance"</dfn> ## {#indirect-first-instance}
 
 Removes the zero value restriction on `firstInstance` in [=indirect draw parameters=] and [=indirect drawIndexed parameters=].
 `firstInstance` is allowed to be non-zero if and only if the {{GPUFeatureName/"indirect-first-instance"}} [=feature=] is enabled.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7627,10 +7627,6 @@ dictionary GPURenderPassLayout: GPUObjectDescriptorBase {
         </div>
 </dl>
 
-Note: The ability to set a `firstInstance` for indirect draw calls is initially disabled to expand
-the hardware that supports WebGPU. It is likely to be added as a feature in the future along with
-other new indirect drawing features.
-
 <div algorithm>
     To determine if it's <dfn abstract-op>valid to draw</dfn> with {{GPURenderEncoderBase}} |encoder|
     run the following steps:


### PR DESCRIPTION
- Fix the consistency of how feature names are formatted (indirect-first-instance -> "indirect-first-instance"
- Remove note regarding drawIndirect/firstInstance which no longer applies


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rconde01/gpuweb/pull/2319.html" title="Last updated on Nov 17, 2021, 3:06 PM UTC (b7e7c2d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2319/559a883...rconde01:b7e7c2d.html" title="Last updated on Nov 17, 2021, 3:06 PM UTC (b7e7c2d)">Diff</a>