### PR TITLE
Remove isFinite, isNormal

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8490,25 +8490,11 @@ See [[#function-calls]].
         (OpSelect)
 </table>
 
-## Value-testing built-in functions ## {#value-testing-builtin-functions}
+## Array built-in functions ## {#array-builtin-functions}
 <table class='data'>
-  <caption>Unary operators</caption>
   <thead>
     <tr><th>Parameterization<th>Overload<th>Description
   </thead>
-  <tr algorithm="isFinite">
-  <td rowspan=2>
-    |I| is [FLOATING]<br>
-    |T| is bool if |I| is a scalar, or<br>
-    vec|N|&lt;bool&gt; if |I| is a vector
-    <td class="nowrap">`isFinite(`|e|`:` |I| `) -> ` |T|
-    <td>Test a finite value according to [[!IEEE-754|IEEE-754]].<br>
-    [=Component-wise=] when |I| is a vector.
-  <tr algorithm="isNormal">
-    <td class="nowrap">`isNormal(`|e|`:` |I| `) -> ` |T|
-    <td>Test a normal value according to [[!IEEE-754|IEEE-754]].<br>
-    [=Component-wise=] when |I| is a vector.
-
   <tr algorithm="runtime-sized array length">
     <td>
     <td>`arrayLength`(|e|: ptr&lt;storage,array&lt;|T|&gt;&gt; ) -> u32


### PR DESCRIPTION
The only remaining function in the section is arrayLength,
so rename the section to "Array built-in functions"
That's more in line with the other secitons like "float..."
"integer...", "matrix...", "vector..."

Fixes: #2309