### PR TITLE
Allow identifiers to start with underscore, with exceptions

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -536,7 +536,7 @@ an identifier:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>ident</dfn> :
 
-    | `/[a-zA-Z]([0-9a-zA-Z][0-9a-zA-Z_]*)?/`
+    | `/([a-zA-Z_][0-9a-zA-Z][0-9a-zA-Z_]*)|([a-zA-Z][0-9a-zA-Z_]*)/`
 </div>
 
 Note: The [=return type=] for some [=built-in functions=] are structure types whose name cannot be used [SHORTNAME] source.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -528,13 +528,21 @@ An <dfn>identifier</dfn> is a kind of [=token=] used as a name.
 See [[#declaration-and-scope]] and [[#directives]].
 
 The form of an identifier is defined via pattern-matching, except that
-an identifier must not have the same spelling as a [=keyword=] or as a [=reserved word=].
+an identifier:
+* must not have the same spelling as a [=keyword=] or as a [=reserved word=].
+* must not be `_` (a single underscore)
+* must not start with two undercores.
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>ident</dfn> :
 
-    | `/[a-zA-Z][0-9a-zA-Z_]*/`
+    | `/[a-zA-Z_][0-9a-zA-Z_]*/`
 </div>
+
+Note: The [=return type=] for some [=built-in functions=] are structure types whose name cannot be used [SHORTNAME] source.
+Those structure types are described as if they were [=predeclared=] with a name starting with two underscores.
+The result value can be saved into newly declared `let` or `var` using type inferencing, or immediately have one of its members
+immediately extracted by name.  See example usages in the description of `frexp` and `modf`.
 
 ## Attributes ## {#attributes}
 
@@ -8639,35 +8647,44 @@ See [[#function-calls]].
 
   <tr algorithm="scalar case, frexp">
     <td>|T| is f32
-    <td class="nowrap">`frexp(`|e|`: `|T|`) -> _frexp_result`<br>
+    <td class="nowrap">`frexp(`|e|`: `|T|`) -> __frexp_result`<br>
     <td>Splits |e| into a significand and exponent of the form `significand * 2`<sup>`exponent`</sup>.
-    Returns the `_frexp_result` built-in structure, defined as:
+    Returns the `__frexp_result` built-in structure, defined as if as follows:
     ```rust
-struct _frexp_result {
+struct __frexp_result {
   sig : f32; // significand part
   exp : i32; // exponent part
 };
     ```
     The magnitude of the significand is in the range of [0.5, 1.0) or 0.
 
-    Note: A value cannot be explicitly declared with the type `_frexp_result`, but a value may infer the type.
+    Note: A value cannot be explicitly declared with the type `__frexp_result`, but a value may infer the type.
+
+    <div class='example wgsl function-scope' heading='frexp usage'>
+    <xmp>
+     // Infers result type
+     let sig_and_exp = frexp(1.5);
+     // Sets fraction_direct to 0.75
+     let fraction_direct = frexp(1.5).sig; 
+    </xmp>
+    </div>
 
     (GLSLstd450FrexpStruct)
 
   <tr algorithm="vector case, frexp">
     <td>|T| is vec|N|&lt;f32&gt;
-    <td class="nowrap">`frexp(`|e|`: `|T|`) -> _frexp_result_vec`|N|<br>
+    <td class="nowrap">`frexp(`|e|`: `|T|`) -> __frexp_result_vec`|N|<br>
     <td>Splits the components of |e| into a significand and exponent of the form `significand * 2`<sup>`exponent`</sup>.
-    Returns the `_frexp_result_vec`|N| built-in structure, defined as:
+    Returns the `__frexp_result_vec`|N| built-in structure, defined as if as follows:
     ```rust
-struct _frexp_result_vecN {
+struct __frexp_result_vecN {
   sig : vecN<f32>; // significand part
   exp : vecN<i32>; // exponent part
 };
     ```
     The magnitude of each component of the significand is in the range of [0.5, 1.0) or 0.
 
-    Note: A value cannot be explicitly declared with the type `_frexp_result_vec`|N|, but a value may infer the type.
+    Note: A value cannot be explicitly declared with the type `__frexp_result_vec`|N|, but a value may infer the type.
 
     (GLSLstd450FrexpStruct)
 
@@ -8743,33 +8760,42 @@ struct _frexp_result_vecN {
 
   <tr algorithm="scalar case, modf">
     <td>|T| is f32
-    <td class="nowrap">`modf(`|e|`: `|T|`) -> _modf_result`<br>
+    <td class="nowrap">`modf(`|e|`: `|T|`) -> __modf_result`<br>
     <td>Splits |e| into fractional and whole number parts.
-    Returns the `_modf_result` built-in structure, defined as:
+    Returns the `__modf_result` built-in structure, defined as if as follows:
     ```rust
-struct _modf_result {
+struct __modf_result {
   fract : f32; // fractional part
   whole : f32; // whole part
 };
     ```
 
-    Note: A value cannot be explicitly declared with the type `_modf_result`, but a value may infer the type.
+    Note: A value cannot be explicitly declared with the type `__modf_result`, but a value may infer the type.
+
+    <div class='example wgsl function-scope' heading='modf usage'>
+    <xmp>
+     // Infers result type
+     let fract_and_whole = modf(1.5);
+     // Sets fract_direct to 0.5
+     let fract_direct = modf(1.5).fract; 
+    </xmp>
+    </div>
 
     (GLSLstd450ModfStruct)
 
   <tr algorithm="vector case, modf">
     <td>|T| is vec|N|&lt;f32&gt;
-    <td class="nowrap">`modf(`|e|`: `|T|`) -> _modf_result_vec`|N|<br>
+    <td class="nowrap">`modf(`|e|`: `|T|`) -> __modf_result_vec`|N|<br>
     <td>Splits the components of |e| into fractional and whole number parts.
-    Returns the `_modf_result_vec`|N| built-in structure, defined as:
+    Returns the `__modf_result_vec`|N| built-in structure, defined as if as follows:
     ```rust
-struct _modf_result_vecN {
+struct __modf_result_vecN {
   fract : vecN<f32>; // fractional part
   whole : vecN<f32>; // whole part
 };
     ```
 
-    Note: A value cannot be explicitly declared with the type `_modf_result_vec`|N|, but a value may infer the type.
+    Note: A value cannot be explicitly declared with the type `__modf_result_vec`|N|, but a value may infer the type.
 
     (GLSLstd450ModfStruct)
 
@@ -9643,9 +9669,9 @@ Atomically stores the value `v` in the atomic object pointed to
 `atomic_ptr` and returns the original value stored in the atomic object.
 
 ```rust
-atomicCompareExchangeWeak(atomic_ptr: ptr<SC, atomic<T>, A>, cmp: T, v: T) -> _atomic_compare_exchange_result<T>
+atomicCompareExchangeWeak(atomic_ptr: ptr<SC, atomic<T>, A>, cmp: T, v: T) -> __atomic_compare_exchange_result<T>
 
-struct _atomic_compare_exchange_result<T> {
+struct __atomic_compare_exchange_result<T> {
   old_value : T; // old value stored in the atomic
   exchanged : bool; // true if the exchange was done
 };
@@ -9654,7 +9680,7 @@ struct _atomic_compare_exchange_result<T> {
 ```
 
 Note: A value cannot be explicitly declared with the type
-`_atomic_compare_exchange_result`, but a value may infer the type.
+`__atomic_compare_exchange_result`, but a value may infer the type.
 
 Performs the following steps atomically:
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -536,7 +536,7 @@ an identifier:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>ident</dfn> :
 
-    | `/[a-zA-Z_][0-9a-zA-Z_]*/`
+    | `/[a-zA-Z]([0-9a-zA-Z][0-9a-zA-Z_]*)?/`
 </div>
 
 Note: The [=return type=] for some [=built-in functions=] are structure types whose name cannot be used [SHORTNAME] source.


### PR DESCRIPTION
- disallow _ as an identifier
- disallow two underscores as a prefix
- change the name for result types for frexp, modf, and
  atomicCompareExchangeWeak to use to underscrores as a prefix

Fixes: #2298