### PR TITLE
wgsl: Clarify "static accessed"

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6536,12 +6536,12 @@ The interface includes:
 
 These objects are represented by module-scope variables in certain [=storage classes=].
 
-We say a variable is <dfn noexport>statically accessed</dfn> by a function if any subexpression
-in the body of the function uses the variable's [=identifier=],
-and that subexpression is [=in scope=] of the variable's declaration.
+When an [=identifier=] used in a [=function declaration=] [=resolves=] to a [=module scope|module-scope=] variable,
+then we say the variable is <dfn>statically accessed</dfn> by the function.
 Static access of a `let`-declared constant is defined similarly.
 Note that being statically accessed is independent of whether an execution of the shader
-will actually evaluate the subexpression, or even execute the enclosing statement.
+will actually evaluate the expression referring to the variable,
+or even execute the statement that may enclose the expression.
 
 More precisely, the <dfn noexport>interface of a shader stage</dfn> consists of:
   - all parameters of the entry point


### PR DESCRIPTION
Static use depends on any expression in a function declaration,
not just those in the body. So this ensures we cover attributes
on function parameters, return type, and the function itself.

This will become increasingly important if we adopt a form of constexpr (#1272)
that can be used in attributes.

Fixes: 2333