### PR TITLE
Explain why minBindingSize is "optional"

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3504,12 +3504,13 @@ dictionary GPUBufferBindingLayout {
     : <dfn>minBindingSize</dfn>
     ::
         Indicates the minimum buffer binding size.
-        Bindings are validated against this size in {{GPUDevice/createBindGroup()}}.
 
-        If this *is not* `0`, pipeline creation [$validating shader binding|validates$]
+        Bindings are always validated against this size in {{GPUDevice/createBindGroup()}}.
+
+        If this *is not* `0`, pipeline creation additionally [$validating shader binding|validates$]
         that this value is large enough for the bindings declared in the shader.
 
-        If this *is* `0`, draw/dispatch commands [$Validate encoder bind groups|validate$]
+        If this *is* `0`, draw/dispatch commands additionally [$Validate encoder bind groups|validate$]
         that each binding in the {{GPUBindGroup}} is large enough for the bindings declared in the shader.
 
         Note:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3503,7 +3503,23 @@ dictionary GPUBufferBindingLayout {
 
     : <dfn>minBindingSize</dfn>
     ::
-        May be used to indicate the minimum buffer binding size.
+        Indicates the minimum buffer binding size.
+        Bindings are validated against this size in {{GPUDevice/createBindGroup()}}.
+
+        If this *is not* `0`, pipeline creation [$validating shader binding|validates$]
+        that this value is large enough for the bindings declared in the shader.
+
+        If this *is* `0`, draw/dispatch commands [$Validate encoder bind groups|validate$]
+        that each binding in the {{GPUBindGroup}} is large enough for the bindings declared in the shader.
+
+        Note:
+        Similar execution-time validation is theoretically possible for other
+        binding-related fields specified for early validation, like
+        {{GPUTextureBindingLayout/sampleType}} and {{GPUStorageTextureBindingLayout/format}},
+        which currently can only be validated in pipeline creation.
+        However, such execution-time validation could be costly or unnecessarily complex, so it is
+        available only for {{GPUBufferBindingLayout/minBindingSize}} which is expected to have the
+        most ergonomic impact.
 </dl>
 
 <script type=idl>


### PR DESCRIPTION
Issue: #851 (Should we close it or just leave it open in post-v1?)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2335.html" title="Last updated on Nov 24, 2021, 10:33 PM UTC (32368aa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2335/baa0d23...kainino0x:32368aa.html" title="Last updated on Nov 24, 2021, 10:33 PM UTC (32368aa)">Diff</a>