### PR TITLE
Add GPUTextureDescriptor option for srgb reinterpretation

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8777,7 +8777,6 @@ initially set to: &laquo;{{GPUTextureFormat/"bgra8unorm"}}, {{GPUTextureFormat/"
 {{GPUTextureFormat/"rgba8unorm"}}, {{GPUTextureFormat/"rgba8unorm-srgb"}}&raquo;.
 
 <script type=idl>
-
 enum GPUCanvasCompositingAlphaMode {
     "opaque",
     "premultiplied",
@@ -8787,6 +8786,7 @@ dictionary GPUCanvasConfiguration {
     required GPUDevice device;
     required GPUTextureFormat format;
     GPUTextureUsageFlags usage = 0x10;  // GPUTextureUsage.RENDER_ATTACHMENT
+    GPUTextureReinterpretationOption viewFormats;
     GPUPredefinedColorSpace colorSpace = "srgb";
     GPUCanvasCompositingAlphaMode compositingAlphaMode = "opaque";
     GPUExtent3D size;

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2373,6 +2373,7 @@ dictionary GPUTextureDescriptor : GPUObjectDescriptorBase {
     GPUTextureDimension dimension = "2d";
     required GPUTextureFormat format;
     required GPUTextureUsageFlags usage;
+    GPUTextureReinterpretationOption viewFormats;
 };
 </script>
 
@@ -2395,6 +2396,29 @@ namespace GPUTextureUsage {
     const GPUFlagsConstant RENDER_ATTACHMENT = 0x10;
 };
 </script>
+
+<dl dfn-type=dict-member dfn-for=GPUTextureDescriptor>
+    : <dfn>viewFormats</dfn>
+    ::
+        Specifies what view {{GPUTextureViewDescriptor/format}} values will be allowed when calling
+        {{GPUTexture/createView()}} on this texture.
+
+        <!-- This could be extended in the future with either more enum options
+        or a union with a sequence of formats (gpuweb/gpuweb#811). -->
+
+        <script type=idl dfn-for=>
+enum GPUTextureReinterpretationOption {
+    "srgb",
+};</script>
+
+        <dl dfn-type=enum-value dfn-for=GPUTextureReinterpretationOption>
+            : <dfn>"srgb"</dfn>
+            ::
+                Allows the texture to be viewed as formats which differ from the
+                {{GPUTexture}}'s format only in whether they are sRGB-encoded
+                (have the `-srgb` suffix).
+        </dl>
+</dl>
 
 <div algorithm>
     <dfn abstract-op>maximum mipLevel count</dfn>(dimension, size)

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2403,16 +2403,18 @@ namespace GPUTextureUsage {
         Specifies what view {{GPUTextureViewDescriptor/format}} values will be allowed when calling
         {{GPUTexture/createView()}} on this texture.
 
+        If undefined, views must have the same {{GPUTextureFormat}} as the texture.
+
         <!-- This could be extended in the future with either more enum options
         or a union with a sequence of formats (gpuweb/gpuweb#811). -->
 
         <script type=idl dfn-for=>
 enum GPUTextureReinterpretationOption {
-    "srgb",
+    "change-srgb",
 };</script>
 
         <dl dfn-type=enum-value dfn-for=GPUTextureReinterpretationOption>
-            : <dfn>"srgb"</dfn>
+            : <dfn>"change-srgb"</dfn>
             ::
                 Allows the texture to be viewed as formats which differ from the
                 {{GPUTexture}}'s format only in whether they are sRGB-encoded

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8773,8 +8773,7 @@ interface GPUCanvasContext {
 The <dfn dfn>supported context formats</dfn> are a [=set=] of {{GPUTextureFormat}}s that must be
 supported when specified as a {{GPUCanvasConfiguration}}.{{GPUCanvasConfiguration/format}}
 regardless of the given {{GPUCanvasConfiguration}}.{{GPUCanvasConfiguration/device}},
-initially set to: &laquo;{{GPUTextureFormat/"bgra8unorm"}}, {{GPUTextureFormat/"bgra8unorm-srgb"}},
-{{GPUTextureFormat/"rgba8unorm"}}, {{GPUTextureFormat/"rgba8unorm-srgb"}}&raquo;.
+initially set to: &laquo;{{GPUTextureFormat/"bgra8unorm"}}, {{GPUTextureFormat/"rgba8unorm"}}&raquo;.
 
 <script type=idl>
 enum GPUCanvasCompositingAlphaMode {


### PR DESCRIPTION
Here's a hopefully-future-proof proposal for how to expose just srgb reinterpretation for now until we figure out how we will expose more flexible texture reinterpretation.

Issue: #168
Related: #744, #811


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2336.html" title="Last updated on Nov 25, 2021, 5:28 AM UTC (bafe152)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2336/baa0d23...kainino0x:bafe152.html" title="Last updated on Nov 25, 2021, 5:28 AM UTC (bafe152)">Diff</a>