### PR TITLE
Add compound assignment (e.g. +=), updated

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5375,17 +5375,20 @@ first a [=read access=] gets the old value, and then a [=write access=] stores t
 Note: A complex assignment can often be implemented by using a pointer to hold
 the result of evaluating the reference once.
 
-<p class="note"> For example, when |e1| is *not* a reference to a component inside a vector, then
-`|e1| += |e2|` can be implemented as
-`let p = &|e1|;
-*p = *p + |e2|;`,
+<p class="note" algorithm="translation complex assignment not vector component">For example,
+when |e1| is *not* a reference to a component inside a vector, then
+|e1|` += `|e2| can be implemented as
+`{let p = &(`|e1|`); *p = *p + (`|e2|`);}`,
 where the identifier `p` is chosen to be different from all other identifiers in the program.
+</p>
 
-<p class="note">When |e1| is a reference to a component inside a vector, the above technique
+<p class="note" algorithm="translation complex assignment vector component">When
+|e1| is a reference to a component inside a vector, the above technique
 needs to be modified because WGSL does not allow [[#address-of-expr|taking the address]] in that case.
-For example, if |ev| is a reference to a vector, the statement `|ev|[c] += |e2|`
-can be implemented as `let p = &|ev|; let c0 = c; (*p)[c0] = (*p)[c0] + |e2|;`, where
-identifiers |c0| and |p| are chosen to be different from all other identifiers in the program.
+For example, if |ev| is a reference to a vector, the statement |ev|`[`|c|`] += ` |e2|
+can be implemented as `{let p = &(`|ev|`); let c0 = ` |c|`; (*p)[c0] = (*p)[c0] + (`|e2|`);}`, where
+identifiers `c0` and `p` are chosen to be different from all other identifiers in the program.
+</p>
 
 ## Control flow ## {#control-flow}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5311,34 +5311,34 @@ it expands as in the following table, except that:
   <thead>
     <tr><th>Statement<th>Expansion
   </thead>
-<tr algoirthm="add-assign">
+<tr algorithm="add-assign">
     <td class="nowrap">|e1| += |e2|
     <td>let old = |e1|; |e1| = old + (|e2|)
-<tr algoirthm="subract-assign">
+<tr algorithm="subract-assign">
     <td class="nowrap">|e1| -= |e2|
     <td>let old = |e1|; |e1| = old - (|e2|)
-<tr algoirthm="multiply-assign">
+<tr algorithm="multiply-assign">
     <td class="nowrap">|e1| *= |e2|
     <td>let old = |e1|; |e1| = old * (|e2|)
-<tr algoirthm="divide-assign">
+<tr algorithm="divide-assign">
     <td class="nowrap">|e1| /= |e2|
     <td>let old = |e1|; |e1| = old / (|e2|)
-<tr algoirthm="modulus-assign">
+<tr algorithm="modulus-assign">
     <td class="nowrap">|e1| %= |e2|
     <td>let old = |e1|; |e1| = old % (|e2|)
-<tr algoirthm="bitwise-and-assign">
+<tr algorithm="bitwise-and-assign">
     <td class="nowrap">|e1| &= |e2|
     <td>let old = |e1|; |e1| = old & (|e2|)
-<tr algoirthm="bitwise-or-assign">
+<tr algorithm="bitwise-or-assign">
     <td class="nowrap">|e1| |= |e2|
     <td>let old = |e1|; |e1| = old | (|e2|)
-<tr algoirthm="bitwise-xor-assign">
+<tr algorithm="bitwise-xor-assign">
     <td class="nowrap">|e1| ^= |e2|
     <td>let old = |e1|; |e1| = old ^ (|e2|)
-<tr algoirthm="bitwise-shiftright-assign">
+<tr algorithm="bitwise-shiftright-assign">
     <td class="nowrap">|e1| >>= |e2|
     <td>let old = |e1|; |e1| = old >> (|e2|)
-<tr algoirthm="bitwise-shiftleft-assign">
+<tr algorithm="bitwise-shiftleft-assign">
     <td class="nowrap">|e1| <<= |e2|
     <td>let old = |e1|; |e1| = old << (|e2|)
 </table>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2207,9 +2207,9 @@ References and pointers are distinguished by how they are used:
 * The [=indirection=] operation (unary `*`) converts a pointer value to its corresponding reference value.
 * A [=let declaration=] can be of pointer type, but not of reference type.
 * A [=formal parameter=] can be of pointer type, but not of reference type.
-* An [=statement/assignment=] statement performs a [=write access=] to update the contents of memory via a reference, where:
-    * The left-hand side of the assignment statement must be of reference type, with access mode [=access/write=] or [=access/read_write=].
-    * The right-hand side of the assignment statement must evaluate to the store type of the left-hand side.
+* An [=simple assignment=] statement performs a [=write access=] to update the contents of memory via a reference, where:
+    * The [=left-hand side=] of the assignment statement must be of reference type, with access mode [=access/write=] or [=access/read_write=].
+    * The [=right-hand side=] of the assignment statement must evaluate to the store type of the left-hand side.
 * The <dfn noexport>Load Rule</dfn>: Inside a function, a reference is automatically dereferenced (read from) to satisfy type rules:
     * In a function, when a reference expression |r| with store type |T| is used in a statement or an expression, where
     * |r| has an access mode of [=access/read=] or [=access/read_write=], and
@@ -5142,18 +5142,21 @@ and optionally stores it in memory (thus updating the contents of a variable).
 <div class='syntax' noexport='true'>
   <dfn for=syntax>assignment_statement</dfn> :
 
-    | ( [=syntax/lhs_expression=] | [=syntax/underscore=] ) [=syntax/equal=] [=syntax/expression=]
+    | [=syntax/lhs_expression=] ( [=syntax/equal=] | [=syntax/complex_assignment_operator=] ) [=syntax/expression=]
+
+    | [=syntax/underscore=] [=syntax/equal=] [=syntax/expression=]
 </div>
 
 
-The text to the left of the equals token is the <dfn noexport>left-hand side</dfn>,
+The text to the left of the operator token is the <dfn noexport>left-hand side</dfn>,
 and the
-expression to the right of the equals token is the <dfn noexport>right-hand side</dfn>.
+expression to the right of the operator token is the <dfn noexport>right-hand side</dfn>.
 
-### Updating Assignment ### {#updating-assignment-section}
+### Simple Assignment ### {#simple-assignment-section}
 
-When the [=left-hand side=] of an assignment is an expression, the assignment is an <dfn noexport>updating assignment</dfn>:
-The value of the right-hand side is written to the memory referenced by the left-hand side.
+An [=statement/assignment=] is a <dfn noexport>simple assignment</dfn> when the 
+[=left-hand side=] is an expression, and the operator is the [=syntax/equal=] token.
+In this case the value of the [=right-hand side=] is written to the memory referenced by the left-hand side.
 
 <table class='data'>
   <thead>
@@ -5207,9 +5210,9 @@ See [[#forming-references-and-pointers]] for other cases.
 
 ### Phony Assignment ### {#phony-assignment-section}
 
-When the [=left-hand side=] of an assignment is an underscore token,
-the assignment is an <dfn noexport>phony assignment</dfn>:
-The right-hand side is evaluated, and then ignored.
+An [=statement/assignment=] is a <dfn noexport>phony assignment</dfn> when the 
+[=left-hand side=] is an underscore token.
+In this case the [=right-hand side=] is evaluated, and then ignored.
 
 <table class='data'>
   <thead>
@@ -5276,34 +5279,35 @@ A phony-assignment is useful for:
 
 ### Complex assignment ### {#complex-assignment-sec}
 
-A <dfn noexport>complex assignment</dfn> is a statement that combines an arithmetic operation and an assignment.
+An [=statement/assignment=] is a <dfn noexport>complex assignment</dfn> when the
+[=left-hand side=] is an expression, and the operator is one of the [=syntax/complex_assignment_operators=].
 
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>complex_assignment_statement</dfn> :
+  <dfn for=syntax>complex_assignment_operator</dfn> :
 
-    | [=syntax/lhs_expression=] [=syntax/plus_equal=] [=syntax/short_circuit_or_expression=]
+    | [=syntax/plus_equal=]
 
-    | [=syntax/lhs_expression=] [=syntax/minus_equal=] [=syntax/short_circuit_or_expression=]
+    | [=syntax/minus_equal=]
 
-    | [=syntax/lhs_expression=] [=syntax/times_equal=] [=syntax/short_circuit_or_expression=]
+    | [=syntax/times_equal=]
 
-    | [=syntax/lhs_expression=] [=syntax/division_equal=] [=syntax/short_circuit_or_expression=]
+    | [=syntax/division_equal=]
 
-    | [=syntax/lhs_expression=] [=syntax/modulo_equal=] [=syntax/short_circuit_or_expression=]
+    | [=syntax/modulo_equal=]
 
-    | [=syntax/lhs_expression=] [=syntax/and_equal=] [=syntax/short_circuit_or_expression=]
+    | [=syntax/and_equal=]
 
-    | [=syntax/lhs_expression=] [=syntax/or_equal=] [=syntax/short_circuit_or_expression=]
+    | [=syntax/or_equal=]
 
-    | [=syntax/lhs_expression=] [=syntax/xor_equal=] [=syntax/short_circuit_or_expression=]
+    | [=syntax/xor_equal=]
 
-    | [=syntax/lhs_expression=] [=syntax/shift_right_equal=] [=syntax/short_circuit_or_expression=]
+    | [=syntax/shift_right_equal=]
 
-    | [=syntax/lhs_expression=] [=syntax/shift_left_equal=] [=syntax/short_circuit_or_expression=]
+    | [=syntax/shift_left_equal=]
 </div>
 
 The type requirements, semantics, and behavior of each statement is defined as if
-it expands as in the following table, except that the reference expression |e1| is evaluated only once.
+the complex assignment expands as in the following table, except that the reference expression |e1| is evaluated only once.
 
 <table class='data'>
   <thead>
@@ -5372,12 +5376,12 @@ first a [=read access=] gets the old value, and then a [=write access=] stores t
   </xmp>
 </div>
 
-Note: A complex assignment can often be implemented by using a pointer to hold
-the result of evaluating the reference once.
+Note: A complex assignment can rewritten as different [SHORTNAME] code that uses a [=simple assignment=] instead.
+The idea is to use a pointer to hold the result of evaluating the reference once.
 
 <p class="note" algorithm="translation complex assignment not vector component">For example,
 when |e1| is *not* a reference to a component inside a vector, then
-|e1|` += `|e2| can be implemented as
+|e1|` += `|e2| can be rewritten as
 `{let p = &(`|e1|`); *p = *p + (`|e2|`);}`,
 where the identifier `p` is chosen to be different from all other identifiers in the program.
 </p>
@@ -5386,7 +5390,7 @@ where the identifier `p` is chosen to be different from all other identifiers in
 |e1| is a reference to a component inside a vector, the above technique
 needs to be modified because WGSL does not allow [[#address-of-expr|taking the address]] in that case.
 For example, if |ev| is a reference to a vector, the statement |ev|`[`|c|`] += ` |e2|
-can be implemented as `{let p = &(`|ev|`); let c0 = ` |c|`; (*p)[c0] = (*p)[c0] + (`|e2|`);}`, where
+can be rewritten as `{let p = &(`|ev|`); let c0 = ` |c|`; (*p)[c0] = (*p)[c0] + (`|e2|`);}`, where
 identifiers `c0` and `p` are chosen to be different from all other identifiers in the program.
 </p>
 
@@ -5597,7 +5601,7 @@ allows them to naturally use values defined in the loop body.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>for_header</dfn> :
 
-    | ( [=syntax/variable_statement=] | [=syntax/assignment_statement=] | [=syntax/func_call_statement=] ) ? [=syntax/semicolon=] [=syntax/expression=] ? [=syntax/semicolon=] ( [=syntax/assignment_statement=] | [=syntax/complex_assignment_statement=] | [=syntax/func_call_statement=] ) ?
+    | ( [=syntax/variable_statement=] | [=syntax/assignment_statement=] | [=syntax/func_call_statement=] ) ? [=syntax/semicolon=] [=syntax/expression=] ? [=syntax/semicolon=] ( [=syntax/assignment_statement=] | [=syntax/func_call_statement=] ) ?
 </div>
 
 The <dfn dfn-for="statement">for</dfn> statement takes the form
@@ -5903,8 +5907,6 @@ Note: If the function [=return value|returns a value=], that value is ignored.
     | [=syntax/discard=] [=syntax/semicolon=]
 
     | [=syntax/assignment_statement=] [=syntax/semicolon=]
-
-    | [=syntax/complex_assignment_statement=] [=syntax/semicolon=]
 
     | [=syntax/compound_statement=]
 </div>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12,7 +12,7 @@ Text Macro: UNSIGNEDINTEGRAL u32 or vec|N|&lt;u32&gt;
 Text Macro: SIGNEDINTEGRAL i32 or vec|N|&lt;i32&gt;
 Text Macro: INTEGRAL i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;
 Text Macro: FLOATING f32 or vec|N|&lt;f32&gt;
-Ignored Vars: i, e, e1, e2, e3, eN, s1, s2, sn, N, M, v, Stride, Offset, Align, Extent, S, T, T1
+Ignored Vars: i, c0, e, e1, e2, e3, eN, p, s1, s2, sn, N, M, v, Stride, Offset, Align, Extent, S, T, T1
 
 !Participate: <a href="https://github.com/gpuweb/gpuweb/issues/new?labels=wgsl">File an issue</a> (<a href="https://github.com/gpuweb/gpuweb/issues?q=is%3Aissue+is%3Aopen+label%3Awgsl">open issues</a>)
 
@@ -5341,10 +5341,10 @@ it expands as in the following table, except that the reference expression |e1| 
     <td>|e1| = |e1| << |e2|
 </table>
 
+Note: The syntax does not allow a [=complex assignment=] to also be a [=phony assignment=].
+
 Note: Even though the reference |e1| is evaluated once, its underlying memory is accessed twice:
 first a [=read access=] gets the old value, and then a [=write access=] stores the updated value.
-
-Note: The syntax does not allow a [=complex assignment=] to also be a [=phony assignment=].
 
 <div class='example wgsl global-scope' heading="Complex assignment">
   <xmp>
@@ -5371,6 +5371,21 @@ Note: The syntax does not allow a [=complex assignment=] to also be a [=phony as
     }
   </xmp>
 </div>
+
+Note: A complex assignment can often be implemented by using a pointer to hold
+the result of evaluating the reference once.
+
+<p class="note"> For example, when |e1| is *not* a reference to a component inside a vector, then
+`|e1| += |e2|` can be implemented as
+`let p = &|e1|;
+*p = *p + |e2|;`,
+where the identifier `p` is chosen to be different from all other identifiers in the program.
+
+<p class="note">When |e1| is a reference to a component inside a vector, the above technique
+needs to be modified because WGSL does not allow [[#address-of-expr|taking the address]] in that case.
+For example, if |ev| is a reference to a vector, the statement `|ev|[c] += |e2|`
+can be implemented as `let p = &|ev|; let c0 = c; (*p)[c0] = (*p)[c0] + |e2|;`, where
+identifiers |c0| and |p| are chosen to be different from all other identifiers in the program.
 
 ## Control flow ## {#control-flow}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5274,6 +5274,77 @@ A phony-assignment is useful for:
   </xmp>
 </div>
 
+### Complex assignment ### {#complex-assignment}
+
+A <dfn noexport>complex assignment</dfn> is a form of syntactic sugar that combines an operator and an assignment.
+
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>complex_assignment_statement</dfn> :
+
+    | [=syntax/unary_expression=] [=syntax/plus_equal=] [=syntax/short_circuit_or_expression=]
+
+    | [=syntax/unary_expression=] [=syntax/minus_equal=] [=syntax/short_circuit_or_expression=]
+
+    | [=syntax/unary_expression=] [=syntax/times_equal=] [=syntax/short_circuit_or_expression=]
+
+    | [=syntax/unary_expression=] [=syntax/division_equal=] [=syntax/short_circuit_or_expression=]
+
+    | [=syntax/unary_expression=] [=syntax/modulo_equal=] [=syntax/short_circuit_or_expression=]
+
+    | [=syntax/unary_expression=] [=syntax/and_equal=] [=syntax/short_circuit_or_expression=]
+
+    | [=syntax/unary_expression=] [=syntax/or_equal=] [=syntax/short_circuit_or_expression=]
+
+    | [=syntax/unary_expression=] [=syntax/xor_equal=] [=syntax/short_circuit_or_expression=]
+
+    | [=syntax/unary_expression=] [=syntax/shift_right_equal=] [=syntax/short_circuit_or_expression=]
+
+    | [=syntax/unary_expression=] [=syntax/shift_left_equal=] [=syntax/short_circuit_or_expression=]
+</div>
+
+It is fully defined by the equivalent code that it expands into:
+
+<table class='data'>
+  <thead>
+    <tr><th>Statement<th>Expansion
+  </thead>
+  <tr>
+    <td class="nowrap">|e1| += |e2|
+    <td>|e1| = |e1| + |e2|
+<tr>
+    <td class="nowrap">|e1| -= |e2|
+    <td>|e1| = |e1| - |e2|
+<tr>
+    <td class="nowrap">|e1| *= |e2|
+    <td>|e1| = |e1| * |e2|
+<tr>
+    <td class="nowrap">|e1| /= |e2|
+    <td>|e1| = |e1| / |e2|
+<tr>
+    <td class="nowrap">|e1| %= |e2|
+    <td>|e1| = |e1| % |e2|
+<tr>
+    <td class="nowrap">|e1| &= |e2|
+    <td>|e1| = |e1| & |e2|
+<tr>
+    <td class="nowrap">|e1| |= |e2|
+    <td>|e1| = |e1| | |e2|
+<tr>
+    <td class="nowrap">|e1| ^= |e2|
+    <td>|e1| = |e1| ^ |e2|
+<tr>
+    <td class="nowrap">|e1| >>= |e2|
+    <td>|e1| = |e1| >> |e2|
+<tr>
+    <td class="nowrap">|e1| <<= |e2|
+    <td>|e1| = |e1| << |e2|
+</table>
+
+Note: in all of the cases above, |e1| is guaranteed by a combination of the syntax and typing rules to be composed of some optional sequence of `*` and `&` followed by an identifier.
+  So its evaluation cannot have side-effects.
+
+Note: the syntax does not allow a [=complex assignment=] to also be a [=phony assignment=].
+
 ## Control flow ## {#control-flow}
 
 Control flow statements may cause the program to execute in non-sequential order.
@@ -8240,8 +8311,58 @@ A <dfn>syntactic token</dfn> is a sequence of special characters, used:
 
     | `'^'`
 </div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>plus_equal</dfn> :
 
-Note: The `MINUS_MINUS` and `PLUS_PLUS` tokens are reserved, i.e. they are not used in any grammar productions.
+    | `'+='`
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>minus_equal</dfn> :
+
+    | `'-='`
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>times_equal</dfn> :
+
+    | `'*='`
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>division_equal</dfn> :
+
+    | `'/='`
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>modulo_equal</dfn> :
+
+    | `'%='`
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>and_equal</dfn> :
+
+    | `'&='`
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>or_equal</dfn> :
+
+    | `'|='`
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>xor_equal</dfn> :
+
+    | `'^='`
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>shift_right_equal</dfn> :
+
+    | `'>>='`
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>shift_left_equal</dfn> :
+
+    | `'<<='`
+</div>
+
+Note: The [=plus_plus=] and [=minus_minus=] tokens are reserved, i.e. they are not used in any grammar productions.
 For example `x--` and `++i` are not syntactically valid expressions in [SHORTNAME].
 
 # Built-in variables # {#builtin-variables}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2207,7 +2207,7 @@ References and pointers are distinguished by how they are used:
 * The [=indirection=] operation (unary `*`) converts a pointer value to its corresponding reference value.
 * A [=let declaration=] can be of pointer type, but not of reference type.
 * A [=formal parameter=] can be of pointer type, but not of reference type.
-* An [=simple assignment=] statement performs a [=write access=] to update the contents of memory via a reference, where:
+* A [=simple assignment=] statement performs a [=write access=] to update the contents of memory via a reference, where:
     * The [=left-hand side=] of the assignment statement must be of reference type, with access mode [=access/write=] or [=access/read_write=].
     * The [=right-hand side=] of the assignment statement must evaluate to the store type of the left-hand side.
 * The <dfn noexport>Load Rule</dfn>: Inside a function, a reference is automatically dereferenced (read from) to satisfy type rules:
@@ -5142,7 +5142,7 @@ and optionally stores it in memory (thus updating the contents of a variable).
 <div class='syntax' noexport='true'>
   <dfn for=syntax>assignment_statement</dfn> :
 
-    | [=syntax/lhs_expression=] ( [=syntax/equal=] | [=syntax/complex_assignment_operator=] ) [=syntax/expression=]
+    | [=syntax/lhs_expression=] ( [=syntax/equal=] | [=syntax/compound_assignment_operator=] ) [=syntax/expression=]
 
     | [=syntax/underscore=] [=syntax/equal=] [=syntax/expression=]
 </div>
@@ -5277,13 +5277,13 @@ A phony-assignment is useful for:
   </xmp>
 </div>
 
-### Complex assignment ### {#complex-assignment-sec}
+### Compound assignment ### {#compound-assignment-sec}
 
-An [=statement/assignment=] is a <dfn noexport>complex assignment</dfn> when the
-[=left-hand side=] is an expression, and the operator is one of the [=syntax/complex_assignment_operators=].
+An [=statement/assignment=] is a <dfn noexport>compound assignment</dfn> when the
+[=left-hand side=] is an expression, and the operator is one of the [=syntax/compound_assignment_operators=].
 
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>complex_assignment_operator</dfn> :
+  <dfn for=syntax>compound_assignment_operator</dfn> :
 
     | [=syntax/plus_equal=]
 
@@ -5307,7 +5307,7 @@ An [=statement/assignment=] is a <dfn noexport>complex assignment</dfn> when the
 </div>
 
 The type requirements, semantics, and behavior of each statement is defined as if
-the complex assignment expands as in the following table, except that the reference expression |e1| is evaluated only once.
+the compound assignment expands as in the following table, except that the reference expression |e1| is evaluated only once.
 
 <table class='data'>
   <thead>
@@ -5345,12 +5345,12 @@ the complex assignment expands as in the following table, except that the refere
     <td>|e1| = |e1| << |e2|
 </table>
 
-Note: The syntax does not allow a [=complex assignment=] to also be a [=phony assignment=].
+Note: The syntax does not allow a [=compound assignment=] to also be a [=phony assignment=].
 
 Note: Even though the reference |e1| is evaluated once, its underlying memory is accessed twice:
 first a [=read access=] gets the old value, and then a [=write access=] stores the updated value.
 
-<div class='example wgsl global-scope' heading="Complex assignment">
+<div class='example wgsl global-scope' heading="Compound assignment">
   <xmp>
     var<private> next_item: i32 = 0;
 
@@ -5369,24 +5369,24 @@ first a [=read access=] gets the old value, and then a [=write access=] stores t
 
     fn precedence_example() {
       var value = 1;
-      // The right-hand side of a complex assignment is its own expression.
+      // The right-hand side of a compound assignment is its own expression.
       value *= 2 + 3; // Same as value = value * (2 + 3);
       // 'value' now holds 5.
     }
   </xmp>
 </div>
 
-Note: A complex assignment can rewritten as different [SHORTNAME] code that uses a [=simple assignment=] instead.
+Note: A compound assignment can rewritten as different [SHORTNAME] code that uses a [=simple assignment=] instead.
 The idea is to use a pointer to hold the result of evaluating the reference once.
 
-<p class="note" algorithm="translation complex assignment not vector component">For example,
+<p class="note" algorithm="translation compound assignment not vector component">For example,
 when |e1| is *not* a reference to a component inside a vector, then
 |e1|` += `|e2| can be rewritten as
 `{let p = &(`|e1|`); *p = *p + (`|e2|`);}`,
 where the identifier `p` is chosen to be different from all other identifiers in the program.
 </p>
 
-<p class="note" algorithm="translation complex assignment vector component">When
+<p class="note" algorithm="translation compound assignment vector component">When
 |e1| is a reference to a component inside a vector, the above technique
 needs to be modified because WGSL does not allow [[#address-of-expr|taking the address]] in that case.
 For example, if |ev| is a reference to a vector, the statement |ev|`[`|c|`] += ` |e2|

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5303,9 +5303,7 @@ A <dfn noexport>complex assignment</dfn> is a statement that combines an arithme
 </div>
 
 The type requirements, semantics, and behavior of each statement is defined as if
-it expands as in the following table, except that:
-* The reference expression |e1| is evaluated only once.
-* The identifier `old` is chosen to be different from any other identifier in the program.
+it expands as in the following table, except that the reference expression |e1| is evaluated only once.
 
 <table class='data'>
   <thead>
@@ -5313,34 +5311,34 @@ it expands as in the following table, except that:
   </thead>
 <tr algorithm="add-assign">
     <td class="nowrap">|e1| += |e2|
-    <td>let old = |e1|; |e1| = old + (|e2|)
+    <td>|e1| = |e1| + |e2|
 <tr algorithm="subract-assign">
     <td class="nowrap">|e1| -= |e2|
-    <td>let old = |e1|; |e1| = old - (|e2|)
+    <td>|e1| = |e1| - |e2|
 <tr algorithm="multiply-assign">
     <td class="nowrap">|e1| *= |e2|
-    <td>let old = |e1|; |e1| = old * (|e2|)
+    <td>|e1| = |e1| * |e2|
 <tr algorithm="divide-assign">
     <td class="nowrap">|e1| /= |e2|
-    <td>let old = |e1|; |e1| = old / (|e2|)
+    <td>|e1| = |e1| / |e2|
 <tr algorithm="modulus-assign">
     <td class="nowrap">|e1| %= |e2|
-    <td>let old = |e1|; |e1| = old % (|e2|)
+    <td>|e1| = |e1| % |e2|
 <tr algorithm="bitwise-and-assign">
     <td class="nowrap">|e1| &= |e2|
-    <td>let old = |e1|; |e1| = old & (|e2|)
+    <td>|e1| = |e1| & |e2|
 <tr algorithm="bitwise-or-assign">
     <td class="nowrap">|e1| |= |e2|
-    <td>let old = |e1|; |e1| = old | (|e2|)
+    <td>|e1| = |e1| | |e2|
 <tr algorithm="bitwise-xor-assign">
     <td class="nowrap">|e1| ^= |e2|
-    <td>let old = |e1|; |e1| = old ^ (|e2|)
+    <td>|e1| = |e1| ^ |e2|
 <tr algorithm="bitwise-shiftright-assign">
     <td class="nowrap">|e1| >>= |e2|
-    <td>let old = |e1|; |e1| = old >> (|e2|)
+    <td>|e1| = |e1| >> |e2|
 <tr algorithm="bitwise-shiftleft-assign">
     <td class="nowrap">|e1| <<= |e2|
-    <td>let old = |e1|; |e1| = old << (|e2|)
+    <td>|e1| = |e1| << |e2|
 </table>
 
 Note: Even though the reference |e1| is evaluated once, its underlying memory is accessed twice:
@@ -5363,6 +5361,13 @@ Note: The syntax does not allow a [=complex assignment=] to also be a [=phony as
       // Adds 5.0 to data[0], calling advance_item() only once.
       data[advance_item()] += 5.0;
       // next_item will be 1 here.
+    }
+
+    fn precedence_example() {
+      var value = 1;
+      // The right-hand side of a complex assignment is its own expression.
+      value *= 2 + 3; // Same as value = value * (2 + 3);
+      // 'value' now holds 5.
     }
   </xmp>
 </div>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5274,76 +5274,98 @@ A phony-assignment is useful for:
   </xmp>
 </div>
 
-### Complex assignment ### {#complex-assignment}
+### Complex assignment ### {#complex-assignment-sec}
 
-A <dfn noexport>complex assignment</dfn> is a form of syntactic sugar that combines an operator and an assignment.
+A <dfn noexport>complex assignment</dfn> is a statement that combines an arithmetic operation and an assignment.
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>complex_assignment_statement</dfn> :
 
-    | [=syntax/unary_expression=] [=syntax/plus_equal=] [=syntax/short_circuit_or_expression=]
+    | [=syntax/lhs_expression=] [=syntax/plus_equal=] [=syntax/short_circuit_or_expression=]
 
-    | [=syntax/unary_expression=] [=syntax/minus_equal=] [=syntax/short_circuit_or_expression=]
+    | [=syntax/lhs_expression=] [=syntax/minus_equal=] [=syntax/short_circuit_or_expression=]
 
-    | [=syntax/unary_expression=] [=syntax/times_equal=] [=syntax/short_circuit_or_expression=]
+    | [=syntax/lhs_expression=] [=syntax/times_equal=] [=syntax/short_circuit_or_expression=]
 
-    | [=syntax/unary_expression=] [=syntax/division_equal=] [=syntax/short_circuit_or_expression=]
+    | [=syntax/lhs_expression=] [=syntax/division_equal=] [=syntax/short_circuit_or_expression=]
 
-    | [=syntax/unary_expression=] [=syntax/modulo_equal=] [=syntax/short_circuit_or_expression=]
+    | [=syntax/lhs_expression=] [=syntax/modulo_equal=] [=syntax/short_circuit_or_expression=]
 
-    | [=syntax/unary_expression=] [=syntax/and_equal=] [=syntax/short_circuit_or_expression=]
+    | [=syntax/lhs_expression=] [=syntax/and_equal=] [=syntax/short_circuit_or_expression=]
 
-    | [=syntax/unary_expression=] [=syntax/or_equal=] [=syntax/short_circuit_or_expression=]
+    | [=syntax/lhs_expression=] [=syntax/or_equal=] [=syntax/short_circuit_or_expression=]
 
-    | [=syntax/unary_expression=] [=syntax/xor_equal=] [=syntax/short_circuit_or_expression=]
+    | [=syntax/lhs_expression=] [=syntax/xor_equal=] [=syntax/short_circuit_or_expression=]
 
-    | [=syntax/unary_expression=] [=syntax/shift_right_equal=] [=syntax/short_circuit_or_expression=]
+    | [=syntax/lhs_expression=] [=syntax/shift_right_equal=] [=syntax/short_circuit_or_expression=]
 
-    | [=syntax/unary_expression=] [=syntax/shift_left_equal=] [=syntax/short_circuit_or_expression=]
+    | [=syntax/lhs_expression=] [=syntax/shift_left_equal=] [=syntax/short_circuit_or_expression=]
 </div>
 
-It is fully defined by the equivalent code that it expands into:
+The type requirements, semantics, and behavior of each statement is defined as if
+it expands as in the following table, except that:
+* The reference expression |e1| is evaluated only once.
+* The identifier `old` is chosen to be different from any other identifier in the program.
 
 <table class='data'>
   <thead>
     <tr><th>Statement<th>Expansion
   </thead>
-  <tr>
+<tr algoirthm="add-assign">
     <td class="nowrap">|e1| += |e2|
-    <td>|e1| = |e1| + |e2|
-<tr>
+    <td>let old = |e1|; |e1| = old + (|e2|)
+<tr algoirthm="subract-assign">
     <td class="nowrap">|e1| -= |e2|
-    <td>|e1| = |e1| - |e2|
-<tr>
+    <td>let old = |e1|; |e1| = old - (|e2|)
+<tr algoirthm="multiply-assign">
     <td class="nowrap">|e1| *= |e2|
-    <td>|e1| = |e1| * |e2|
-<tr>
+    <td>let old = |e1|; |e1| = old * (|e2|)
+<tr algoirthm="divide-assign">
     <td class="nowrap">|e1| /= |e2|
-    <td>|e1| = |e1| / |e2|
-<tr>
+    <td>let old = |e1|; |e1| = old / (|e2|)
+<tr algoirthm="modulus-assign">
     <td class="nowrap">|e1| %= |e2|
-    <td>|e1| = |e1| % |e2|
-<tr>
+    <td>let old = |e1|; |e1| = old % (|e2|)
+<tr algoirthm="bitwise-and-assign">
     <td class="nowrap">|e1| &= |e2|
-    <td>|e1| = |e1| & |e2|
-<tr>
+    <td>let old = |e1|; |e1| = old & (|e2|)
+<tr algoirthm="bitwise-or-assign">
     <td class="nowrap">|e1| |= |e2|
-    <td>|e1| = |e1| | |e2|
-<tr>
+    <td>let old = |e1|; |e1| = old | (|e2|)
+<tr algoirthm="bitwise-xor-assign">
     <td class="nowrap">|e1| ^= |e2|
-    <td>|e1| = |e1| ^ |e2|
-<tr>
+    <td>let old = |e1|; |e1| = old ^ (|e2|)
+<tr algoirthm="bitwise-shiftright-assign">
     <td class="nowrap">|e1| >>= |e2|
-    <td>|e1| = |e1| >> |e2|
-<tr>
+    <td>let old = |e1|; |e1| = old >> (|e2|)
+<tr algoirthm="bitwise-shiftleft-assign">
     <td class="nowrap">|e1| <<= |e2|
-    <td>|e1| = |e1| << |e2|
+    <td>let old = |e1|; |e1| = old << (|e2|)
 </table>
 
-Note: in all of the cases above, |e1| is guaranteed by a combination of the syntax and typing rules to be composed of some optional sequence of `*` and `&` followed by an identifier.
-  So its evaluation cannot have side-effects.
+Note: Even though the reference |e1| is evaluated once, its underlying memory is accessed twice:
+first a [=read access=] gets the old value, and then a [=write access=] stores the updated value.
 
-Note: the syntax does not allow a [=complex assignment=] to also be a [=phony assignment=].
+Note: The syntax does not allow a [=complex assignment=] to also be a [=phony assignment=].
+
+<div class='example wgsl global-scope' heading="Complex assignment">
+  <xmp>
+    var<private> next_item: i32 = 0;
+
+    fn advance_item() -> i32 {
+       next_item += 1;   // Adds 1 to next_item.
+       return next_item - 1;
+    }
+
+    fn bump_item() {
+      var data: array<f32,10>;
+      next_item = 0;
+      // Adds 5.0 to data[0], calling advance_item() only once.
+      data[advance_item()] += 5.0;
+      // next_item will be 1 here.
+    }
+  </xmp>
+</div>
 
 ## Control flow ## {#control-flow}
 
@@ -5552,7 +5574,7 @@ allows them to naturally use values defined in the loop body.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>for_header</dfn> :
 
-    | ( [=syntax/variable_statement=] | [=syntax/assignment_statement=] | [=syntax/func_call_statement=] ) ? [=syntax/semicolon=] [=syntax/expression=] ? [=syntax/semicolon=] ( [=syntax/assignment_statement=] | [=syntax/func_call_statement=] ) ?
+    | ( [=syntax/variable_statement=] | [=syntax/assignment_statement=] | [=syntax/func_call_statement=] ) ? [=syntax/semicolon=] [=syntax/expression=] ? [=syntax/semicolon=] ( [=syntax/assignment_statement=] | [=syntax/complex_assignment_statement=] | [=syntax/func_call_statement=] ) ?
 </div>
 
 The <dfn dfn-for="statement">for</dfn> statement takes the form
@@ -5858,6 +5880,8 @@ Note: If the function [=return value|returns a value=], that value is ignored.
     | [=syntax/discard=] [=syntax/semicolon=]
 
     | [=syntax/assignment_statement=] [=syntax/semicolon=]
+
+    | [=syntax/complex_assignment_statement=] [=syntax/semicolon=]
 
     | [=syntax/compound_statement=]
 </div>
@@ -8362,7 +8386,7 @@ A <dfn>syntactic token</dfn> is a sequence of special characters, used:
     | `'<<='`
 </div>
 
-Note: The [=plus_plus=] and [=minus_minus=] tokens are reserved, i.e. they are not used in any grammar productions.
+Note: The [=syntax/plus_plus=] and [=syntax/minus_minus=] tokens are reserved, i.e. they are not used in any grammar productions.
 For example `x--` and `++i` are not syntactically valid expressions in [SHORTNAME].
 
 # Built-in variables # {#builtin-variables}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5315,34 +5315,34 @@ the compound assignment expands as in the following table, except that the refer
   </thead>
 <tr algorithm="add-assign">
     <td class="nowrap">|e1| += |e2|
-    <td>|e1| = |e1| + |e2|
+    <td>|e1| = |e1| + (|e2|)
 <tr algorithm="subract-assign">
     <td class="nowrap">|e1| -= |e2|
-    <td>|e1| = |e1| - |e2|
+    <td>|e1| = |e1| - (|e2|)
 <tr algorithm="multiply-assign">
     <td class="nowrap">|e1| *= |e2|
-    <td>|e1| = |e1| * |e2|
+    <td>|e1| = |e1| * (|e2|)
 <tr algorithm="divide-assign">
     <td class="nowrap">|e1| /= |e2|
-    <td>|e1| = |e1| / |e2|
+    <td>|e1| = |e1| / (|e2|)
 <tr algorithm="modulus-assign">
     <td class="nowrap">|e1| %= |e2|
-    <td>|e1| = |e1| % |e2|
+    <td>|e1| = |e1| % (|e2|)
 <tr algorithm="bitwise-and-assign">
     <td class="nowrap">|e1| &= |e2|
-    <td>|e1| = |e1| & |e2|
+    <td>|e1| = |e1| & (|e2|)
 <tr algorithm="bitwise-or-assign">
     <td class="nowrap">|e1| |= |e2|
-    <td>|e1| = |e1| | |e2|
+    <td>|e1| = |e1| | (|e2|)
 <tr algorithm="bitwise-xor-assign">
     <td class="nowrap">|e1| ^= |e2|
-    <td>|e1| = |e1| ^ |e2|
+    <td>|e1| = |e1| ^ (|e2|)
 <tr algorithm="bitwise-shiftright-assign">
     <td class="nowrap">|e1| >>= |e2|
-    <td>|e1| = |e1| >> |e2|
+    <td>|e1| = |e1| >> (|e2|)
 <tr algorithm="bitwise-shiftleft-assign">
     <td class="nowrap">|e1| <<= |e2|
-    <td>|e1| = |e1| << |e2|
+    <td>|e1| = |e1| << (|e2|)
 </table>
 
 Note: The syntax does not allow a [=compound assignment=] to also be a [=phony assignment=].


### PR DESCRIPTION
Builds on #2241

    Update complex assignment
    
    * Add complex assignment as an option for 'statement' and the update
      clause of a for loop.
    * Add parentheses around |e2| to fix precedence problems
         x *= 3 + 2;  should expand to x = x * (3+2);
    * The replacement isn't pure syntactic sugar because we have to ensure
      the reference e1 is evaluated only once.
    
      Replacements are now two statements: a let decl with fresh identifier
      to load the value, and an assignment to do the operation and write
      the result.  Need to qualify that the reference is computed at most
      once.  Now this is two statements, so it can't be substituted
      syntactically into for-header update clause. So say that the expansion
      defines all but grammar aspect, i.e. it defines type requirements,
      semantics, and behaviour.
    
    * Fix bikeshed errors

commit 7e822574b52bb0683309c856cc54fa46f506518f
Author: Robin Morisset <rmorisset@apple.com>
Date:   Tue Nov 2 17:03:39 2021 -0700

    Add complex assignments
