### PR TITLE
Fill out scope explanations and collective operations

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7107,9 +7107,16 @@ Issue: [WebGPU issue 1045](https://github.com/gpuweb/gpuweb/issues/1045):
 Dispatch group counts must be positive.
 However, how do we handle an indirect dispatch that specifies a group count of zero.
 
-## Collective operations TODO ## {#collective-operations}
+## Collective operations ## {#collective-operations}
 
-### Barrier TODO ### {#barrier}
+### Barriers ### {#barrier}
+
+A barrier is a [[#sync-builtin-functions|synchronization built-in function]]
+that orders memory operations in a program.
+A <dfn noexport>control barrier</dfn> is executed by all invocations in the
+same [=compute shader stage/workgroup=] as if it were executed concurrently.
+As such, control barriers must only be executed in uniform control flow in a
+[=compute shader stage|compute=] shader.
 
 ### Derivatives ### {#derivatives}
 
@@ -7117,6 +7124,7 @@ A <dfn noexport>partial derivative</dfn> is the rate of change of a value along 
 
 Fragment shader invocations operating on neighbouring fragments (in screen-space coordinates)
 collaborate to compute approximate partial derivatives.
+These neighbouring fragments are referred to as a <dfn noexport>quad</dfn>.
 
 Partial derivatives of the *fragment coordinate* are computed implicitly as part
 of operation of the following built-in functions:
@@ -7135,8 +7143,6 @@ built-in functions described in [[#derivative-builtin-functions]]:
 
 Because neighbouring invocations must collaborate to compute derivatives,
 these functions must only be invoked in uniform control flow in a fragment shader.
-
-### Arrayed resource access TODO ### {#arrayed-resource-access}
 
 ## Floating Point Evaluation ## {#floating-point-evaluation}
 
@@ -7400,6 +7406,17 @@ for the lifetime of the variable.
 
 ## Scoped Operations ## {#scoped-operations}
 
+When an invocation performs a scoped operation, it will affect one or two sets
+of invocations.
+These sets are the <dfn noexport>memory scope</dfn> and the <dfn
+noexport>execution scope</dfn>.
+The memory scope specifies the set of invocations to which the operation will be visible.
+For [[#sync-builtin-functions|synchronization built-in functions]], this also
+means that all affected memory operations program ordered before the function
+are visible to affected operations program ordered after the function.
+The execution scope specifies the set of invocations which may participate in
+an operation (see [[#collective-operations]]).
+
 [[#atomic-builtin-functions|Atomic built-in functions]] map to [atomic
 operations](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#memory-model-atomic-operation)
 whose memory
@@ -7414,6 +7431,8 @@ is:
 barriers whose execution and memory
 [scopes](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#memory-model-scope)
 are `Workgroup`.
+
+Implicit and explicit derivatives have an implicit [=quad=] execution scope.
 
 Note: When generating SPIR-V that does not enable the `Vulkan` memory model,
 `Device` scope should be used instead of `QueueFamily`.
@@ -7445,17 +7464,13 @@ All non-atomic [=read accesses=] in the [=storage classes/storage=] or
 [=storage classes/workgroup=] storage classes are considered
 [non-private](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#memory-model-non-private)
 and correspond to read operations with `NonPrivatePointer | MakePointerVisible`
-memory operands with the following scope:
-* `Workgroup` for the [=storage classes/workgroup=] storage class
-* `QueueFamily` for the [=storage classes/storage=] storage class
+memory operands with the `Workgroup` scope.
 
 All non-atomic [=write accesses=] in the [=storage classes/storage=] or
 [=storage classes/workgroup=] storage classes are considered
 [non-private](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#memory-model-non-private)
 and correspond to write operations with `NonPrivatePointer |
-MakePointerAvailable` memory operands with the following scope:
-* `Workgroup` for the [=storage classes/workgroup=] storage class
-* `QueueFamily` for the [=storage classes/storage=] storage class
+MakePointerAvailable` memory operands with the `Workgroup` scope.
 
 Issue: https://github.com/gpuweb/gpuweb/issues/1621
 
@@ -9591,7 +9606,7 @@ The storage class `SC` of the `atomic_ptr` parameter in all atomic built-in
 functions `must` be either [=storage classes/storage=] or [=storage
 classes/workgroup=].
 [=storage classes/workgroup=] atomics have a **Workgroup**
-memory scope in SPIR-V, while [=storage classes/storage=] atomics have a
+[=memory scope=] in SPIR-V, while [=storage classes/storage=] atomics have a
 **QueueFamily** memory scope in SPIR-V.
 
 The access mode `A` in all atomic built-in functions must be [=access/read_write=].
@@ -9799,8 +9814,8 @@ storageBarrier()
 workgroupBarrier()
 ```
 
-All synchronization functions execute a control barrier with Acquire/Release
-[[#memory-semantics|memory ordering]].
+All synchronization functions execute a [=control barrier=] with
+Acquire/Release [[#memory-semantics|memory ordering]].
 That is, all synchronization functions, and affected memory and atomic
 operations are ordered in [[#program-order|program order]] relative to the
 synchronization function.
@@ -9808,8 +9823,8 @@ Additionally, the affected memory and atomic operations program-ordered before
 the synchronization function must be visible to all other threads in the
 workgroup before any affected memory or atomic operation program-ordered after
 the synchronization function is executed by a member of the workgroup.
-All synchronization functions use the `Workgroup` [[#scoped-operations|memory
-scope]].
+All synchronization functions use the `Workgroup` [=memory scope=].
+All synchronization functions have a `Workgroup` [=execution scope=].
 All synchronization functions must only be used in the [=compute=] shader
 stage.
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7408,14 +7408,14 @@ for the lifetime of the variable.
 
 When an invocation performs a scoped operation, it will affect one or two sets
 of invocations.
-These sets are the <dfn noexport>memory scope</dfn> and the <dfn
-noexport>execution scope</dfn>.
-The memory scope specifies the set of invocations to which the operation will be visible.
+These sets are the memory scope and the execution scope.  The <dfn
+noexport>memory scope</dfn> specifies the set of invocations that will see any
+updates to memory contents affected by the operation.
 For [[#sync-builtin-functions|synchronization built-in functions]], this also
 means that all affected memory operations program ordered before the function
 are visible to affected operations program ordered after the function.
-The execution scope specifies the set of invocations which may participate in
-an operation (see [[#collective-operations]]).
+The <dfn noexport>execution scope</dfn> specifies the set of invocations which
+may participate in an operation (see [[#collective-operations]]).
 
 [[#atomic-builtin-functions|Atomic built-in functions]] map to [atomic
 operations](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#memory-model-atomic-operation)


### PR DESCRIPTION
* Fix the memory scope for non-private reads and writes missed in #2297
  * only atomics have device memory scope
* Define and explain memory and execution scopes
  * add links in atomic and sync built-in function sections
* Define a quad for the purpose of an implicit execution scope on
  derivatives
* Remove todos from collective operations
  * fill out barrier, defining control barrier