### PR TITLE
Cross reference WGSL errors in WebGPU spec

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -87,6 +87,8 @@ spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
         text: builtin; url: builtin-variables
         text: channel formats; url: channel-formats
         text: invalid memory reference; url: invalid-memory-reference
+        text: shader-creation error; url: shader-creation-error
+        text: pipeline-creation error; url: pipeline-creation-error
 </pre>
 
 <style>
@@ -4128,6 +4130,9 @@ any specific point in the code at all.
     ::
         The severity level of the message.
 
+        If the {{GPUCompilationMessage/type}} is "error", it corresponds to a
+        [=shader-creation error=].
+
     : <dfn>lineNum</dfn>
     ::
         The line number in the shader {{GPUShaderModuleDescriptor/code}} the
@@ -4521,6 +4526,8 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         - If the pipeline-overridable constant identified by |key|
             [=pipeline-overridable constant has a default value|does not have a default value=],
             |descriptor|.{{GPUProgrammableStage/constants}} must [=map/contain=] |key|.
+
+    A return value of `false` corresponds to a [=pipeline-creation error=].
 </div>
 
 <div algorithm>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -348,8 +348,6 @@ results in a shader-creation, pipeline-creation, or dynamic error.
 
 The WebGPU specification describes the consequences of each kind of error.
 
-TODO: Update the WebGPU spec, referring back to the three kinds of errors defined here.
-
 ## Limits ## {#limits}
 
 A program must satisfy the following limits:


### PR DESCRIPTION
* Reference shader creation and pipeline creation errors in the WebGPU
  spec
  * do not reference dynamic errors as there is no good place to mention
    them
* remove WGSL todo about cross references


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/alan-baker/gpuweb/pull/2352.html" title="Last updated on Nov 29, 2021, 6:23 PM UTC (1e249b3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2352/9930ca1...alan-baker:1e249b3.html" title="Last updated on Nov 29, 2021, 6:23 PM UTC (1e249b3)">Diff</a>