### PR TITLE
Add memory model links in the atomic type section

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1109,8 +1109,14 @@ An expression must not evaluate to an atomic type.
 
 Atomic types may only be instantiated by variables in the [=storage classes/workgroup=]
 storage class or by [=storage buffer=] variables with a [=access/read_write=] access mode.
+The [=memory scope=] of operations on the type is determined by the storage
+class it is instantiated in.
+Atomic types in the [=storage classes/workgroup=] storage class have a memory
+scope of `Workgroup`, while those in the [=storage classes/storage=] storage
+class have a memory scope of `QueueFamily`.
 
-An <dfn noexport>atomic modification</dfn> is any operation on an atomic object which sets the content of the object.
+An <dfn noexport>atomic modification</dfn> is any [[#memory
+operation|operation]] on an atomic object which sets the content of the object.
 The operation counts as a modification even if the new value is the same as the object's existing value.
 
 In [SHORTNAME], atomic modifications are mutually ordered, for each object.
@@ -1121,8 +1127,6 @@ causality is implied.
 Note that variables in [=storage classes/workgroup=] storage are shared within a
 [=compute shader stage/workgroup=], but are not shared between different
 workgroups.
-
-TODO: Add links the eventual memory model descriptions.
 
 <div class='example storage atomic' heading='Mapping atomics in a storage variable to SPIR-V'>
   <xmp>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1115,9 +1115,11 @@ Atomic types in the [=storage classes/workgroup=] storage class have a memory
 scope of `Workgroup`, while those in the [=storage classes/storage=] storage
 class have a memory scope of `QueueFamily`.
 
-An <dfn noexport>atomic modification</dfn> is any [[#memory
-operation|operation]] on an atomic object which sets the content of the object.
-The operation counts as a modification even if the new value is the same as the object's existing value.
+An <dfn noexport>atomic modification</dfn> is any
+[[#memory-operation|operation]] on an atomic object which sets the content of
+the object.
+The operation counts as a modification even if the new value is the same as the
+object's existing value.
 
 In [SHORTNAME], atomic modifications are mutually ordered, for each object.
 That is, during execution of a shader stage, for each atomic object *A*, all


### PR DESCRIPTION
* Add links for memory scope and memory operation
* Describe atomic memory scope is based on storage class