### PR TITLE
Add git version info to wgsl spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 out/
 spec/index.html
+spec/index.pre.html
 spec/webgpu.idl
 wgsl/grammar/
 wgsl/index.html

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ spec/index.html
 spec/webgpu.idl
 wgsl/grammar/
 wgsl/index.html
+wgsl/index.pre.html
 explainer/index.html
 tools/node_modules/
 .DS_Store

--- a/spec/Makefile
+++ b/spec/Makefile
@@ -1,7 +1,12 @@
 all: index.html webgpu.idl
 
-index.html: index.bs
-	bikeshed --die-on=everything spec index.bs
+GHC=https://github.com/gpuweb/gpuweb/blob
+index.html: index.pre.html Makefile
+	# Append another line to the "This version:" metadata at the top.
+	sed -e "s,gpuweb.github.io/gpuweb/</a>,gpuweb.github.io/gpuweb/</a><br><a href=\"$(GHC)/$(shell git rev-parse HEAD)/spec/index.bs\">$(GHC)/$(shell git rev-parse HEAD)/spec/index.bs</a>," <index.pre.html >index.html
+
+index.pre.html: index.bs
+	bikeshed --die-on=everything spec index.bs index.pre.html
 
 webgpu.idl: index.bs extract-idl.py
 	python extract-idl.py index.bs > webgpu.idl

--- a/wgsl/Makefile
+++ b/wgsl/Makefile
@@ -1,7 +1,13 @@
 all: index.html grammar/grammar.js
 
-index.html: index.bs
-	bikeshed --die-on=everything spec index.bs
+
+GHC=https://github.com/gpuweb/gpuweb/blob
+index.html: index.pre.html Makefile
+	# Append another line to the "This version:" metadata at the top.
+	sed -e "s,gpuweb/wgsl/</a>,gpuweb/wgsl/</a><br><a href=\"$(GHC)/$(shell git rev-parse HEAD)/wgsl/index.bs\">$(GHC)/$(shell git rev-parse HEAD)/wgsl/index.bs</a>," <index.pre.html >index.html
+
+index.pre.html: index.bs Makefile
+	bikeshed --die-on=everything spec index.bs index.pre.html
 
 grammar/grammar.js: index.bs extract-grammar.py
 	python3 extract-grammar.py index.bs grammar/grammar.js


### PR DESCRIPTION
Injects URL based on 'git rev-parse HEAD' into the "This version:"
text.

Fixes: #776