### PR TITLE
Allow GPUShaderModules to contain MTLLibraries

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4040,9 +4040,14 @@ Issue(gpuweb/gpuweb#354): Finish defining multithreading API and add `[Serializa
 ### Shader Module Creation ### {#shader-module-creation}
 
 <script type=idl>
+dictionary GPUShaderModuleCompilationHint {
+    required GPUPipelineLayout layout;
+};
+
 dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
     required USVString code;
     object sourceMap;
+    record<USVString, GPUShaderModuleCompilationHint> hints;
 };
 </script>
 
@@ -4050,6 +4055,39 @@ dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
 source-map-v3 format.
 Source maps are optional, but serve as a standardized way to support dev-tool
 integration such as source-language debugging. [[SourceMap]]
+
+{{GPUShaderModuleDescriptor/hints}}, if defined, maps an entry point name from
+the shader to a {{GPUShaderModuleCompilationHint}}. No validation is performed with
+any of these {{GPUShaderModuleCompilationHint}}. Implementations should use any
+information present in the {{GPUShaderModuleCompilationHint}} to perform as much
+compilation as is possible within {{GPUDevice/createShaderModule()}}.
+
+Note: Supplying information in {{GPUShaderModuleDescriptor/hints}} does not have any
+observable effect, other than performance. Because a single shader module can hold
+multiple entry points, and multiple pipelines can be created from a single shader
+module, it can be more performant for an implementation to do as much compilation as
+possible once in {{GPUDevice/createShaderModule()}} rather than multiple times in
+the multiple calls to {{GPUDevice/createComputePipeline()}} /
+{{GPUDevice/createRenderPipeline()}}.
+
+Note: If possible, authors should be supplying the same information to
+{{GPUDevice/createShaderModule()}} and {{GPUDevice/createComputePipeline()}} /
+{{GPUDevice/createRenderPipeline()}}.
+
+Note: If an author is unable to provide this {{GPUShaderModuleDescriptor/hints}}
+information at the time of calling {{GPUDevice/createShaderModule()}}, they should
+usually not delay calling {{GPUDevice/createShaderModule()}}; but should instead just
+omit the unknown information from {{GPUShaderModuleDescriptor/hints}} or
+{{GPUShaderModuleCompilationHint}}. Omitting this information may cause compilation
+to be deferred to {{GPUDevice/createComputePipeline()}} /
+{{GPUDevice/createRenderPipeline()}}.
+
+Note: If an author is not confident that the information passed to
+{{GPUDevice/createShaderModule()}} will match the information later passed to
+{{GPUDevice/createComputePipeline()}} / {{GPUDevice/createRenderPipeline()}} with that
+same module, they should avoid passing that information to
+{{GPUDevice/createShaderModule()}}, as passing mismatched information to
+{{GPUDevice/createShaderModule()}} may cause unnecessary compilations to occur.
 
 <dl dfn-type=method dfn-for=GPUDevice>
     : <dfn>createShaderModule(descriptor)</dfn>


### PR DESCRIPTION
> The resolution is to add a dictionary of entry point name to pipeline layout to createShaderModule(), which is optional, and implementations can totally ignore it 100% (no validation).

Fixes https://github.com/gpuweb/gpuweb/issues/1064.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/litherum/gpuweb/pull/2363.html" title="Last updated on Dec 5, 2021, 3:45 AM UTC (28b6c44)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2363/dafb8db...litherum:28b6c44.html" title="Last updated on Dec 5, 2021, 3:45 AM UTC (28b6c44)">Diff</a>