### PR TITLE
wgsl: Fix no-break loop behavior

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5916,7 +5916,7 @@ The reason is that only functions without a return type can have such a [=behavi
         |s2|: |B2|<br>
         None of {Continue, Return, Discard} are in |B2|<br>
         Break is not in (|B1| &cup; |B2|)
-    <td class="nowrap">(|B1|&#x2216;{Continue}) &cup; (|B2|&#x2216{Next})
+    <td class="nowrap">(|B1| &cup; |B2|)&#x2216;{Continue, Next}
   <tr algorithm="loop with continuing with break behavior">
     <td class="nowrap">|s1|: |B1|<br>
         |s2|: |B2|<br>
@@ -8662,7 +8662,7 @@ struct __frexp_result {
      // Infers result type
      let sig_and_exp = frexp(1.5);
      // Sets fraction_direct to 0.75
-     let fraction_direct = frexp(1.5).sig; 
+     let fraction_direct = frexp(1.5).sig;
     </xmp>
     </div>
 
@@ -8774,7 +8774,7 @@ struct __modf_result {
      // Infers result type
      let fract_and_whole = modf(1.5);
      // Sets fract_direct to 0.5
-     let fract_direct = modf(1.5).fract; 
+     let fract_direct = modf(1.5).fract;
     </xmp>
     </div>
 


### PR DESCRIPTION
The `loop with continuing without break behavior` algorithm should not result in the loop having a `Next` behavior, but this might bubble up from the `B1` behavior.
Rework the algorithm to remove the `Next` after the union of `B1` and `B2`.