### PR TITLE
Rename fillBuffer to clearBuffer

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5502,10 +5502,10 @@ interface GPUCommandEncoder {
         GPUImageCopyTexture destination,
         GPUExtent3D copySize);
 
-    undefined fillBuffer(
-        GPUBuffer destination,
-        GPUSize64 destinationOffset,
-        GPUSize64 size);
+    undefined clearBuffer(
+        GPUBuffer buffer,
+        optional GPUSize64 offset = 0,
+        optional GPUSize64 size);
 
     undefined pushDebugGroup(USVString groupLabel);
     undefined popDebugGroup();
@@ -5964,31 +5964,35 @@ dictionary GPUImageCopyExternalImage {
 ### Buffer Fills ### {#buffer-fills}
 
 <dl dfn-type=method dfn-for=GPUCommandEncoder>
-    : <dfn>fillBuffer(destination, destinationOffset, size)</dfn>
+    : <dfn>clearBuffer(buffer, offset, size)</dfn>
     ::
         Encode a command into the {{GPUCommandEncoder}} that fills a sub-region of a
         {{GPUBuffer}} with zeros.
 
-        <div algorithm=GPUCommandEncoder.fillBuffer>
+        <div algorithm=GPUCommandEncoder.clearBuffer>
             **Called on:** {{GPUCommandEncoder}} |this|.
 
             **Arguments:**
-            <pre class=argumentdef for="GPUCommandEncoder/fillBuffer(destination, destinationOffset, size)">
-                |destination|: The {{GPUBuffer}} to write to.
-                |destinationOffset|: Offset in bytes into |destination| to place the data.
-                |size|: Bytes to copy.
+            <pre class=argumentdef for="GPUCommandEncoder/clearBuffer(buffer, offset, size)">
+                |buffer|: The {{GPUBuffer}} to clear.
+                |offset|: Offset in bytes into |buffer| where the sub-region to clear begins.
+                |size|: Size in bytes of the sub-region to clear. Defaults to the size of the buffer minus |offset|.
             </pre>
 
             **Returns:** {{undefined}}
 
-            If any of the following conditions are unsatisfied, generate a validation error and stop.
-            <div class=validusage>
-                - |this|.{{GPUCommandEncoder/[[state]]}} is [=encoder state/open=].
-                - |destination| is [$valid to use with$] |this|.
-                - |destination|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/COPY_DST}}.
-                - |size| is a multiple of 4.
-                - |destinationOffset| is a multiple of 4.
-                - |destination|.{{GPUBuffer/[[size]]}} is greater than or equal to (|destinationOffset| + |size|).
+            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+            <div class=device-timeline>
+                1. If |size| is missing, set |size| to `max(0, |buffer|.{{GPUBuffer/[[size]]}} - |offset|)`.
+                1. If any of the following conditions are unsatisfied, generate a validation error and stop.
+                    <div class=validusage>
+                        - |this|.{{GPUCommandEncoder/[[state]]}} is [=encoder state/open=].
+                        - |buffer| is [$valid to use with$] |this|.
+                        - |buffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/COPY_DST}}.
+                        - |size| is a multiple of 4.
+                        - |offset| is a multiple of 4.
+                        - |buffer|.{{GPUBuffer/[[size]]}} is greater than or equal to (|offset| + |size|).
+                    </div>
             </div>
         </div>
 </dl>


### PR DESCRIPTION
An alternative fix to #2278, given feedback from @kvark.

This change renames `fillBuffer` to `clearBuffer` so that a future version of the spec can introduce an explicit `fillBuffer` with a value without there being a difficult-to-detect extension to the function signature. It also takes the liberty of introducing defaults for the offset and size args, so that `.clearBuffer(buffer);` is a convenient shorthand for clearing the entire buffer.

The reason for separating the functionality into two methods rather than simply implementing `fillBuffer` with a value from the beginning as was previously suggested is that there's an identified fast path in all APIs for clearing to zero, but D3D12 lacks a generic "fill the buffer with value X" method that would work against any buffer type (the closest it has is [`ClearUnorderedAccessViewUint()`](https://docs.microsoft.com/en-us/windows/win32/api/d3d12/nf-d3d12-id3d12graphicscommandlist-clearunorderedaccessviewuint) which effectively only works with WebGPU's `storage` usage.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/2368.html" title="Last updated on Dec 1, 2021, 4:52 PM UTC (3c36594)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2368/8ea3aea...3c36594.html" title="Last updated on Dec 1, 2021, 4:52 PM UTC (3c36594)">Diff</a>