### PR TITLE
Include container option

### DIFF
--- a/wgsl/extract-grammar.py
+++ b/wgsl/extract-grammar.py
@@ -506,7 +506,8 @@ subprocess.run(["npm", "install"], cwd=grammar_path, check=True)
 subprocess.run(["npx", "tree-sitter", "generate"],
                cwd=grammar_path, check=True)
 # Following are commented for future reference to expose playground
-# subprocess.run(["npx", "tree-sitter", "build-wasm"],
+# Remove "--docker" if local environment matches with the container
+# subprocess.run(["npx", "tree-sitter", "build-wasm", "--docker"],
 #                cwd=grammar_path, check=True)
 
 Language.build_library(


### PR DESCRIPTION
This prevents getting stuck with a WASM output that fails to execute properly in tandem with playground and does not hint well with the issue.