### PR TITLE
Refactored attachment load/store ops and clear value

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5634,20 +5634,24 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                     </div>
                 1. Set |this|.{{GPUCommandEncoder/[[state]]}} to [=encoder state/encoding a render pass=].
                 1. For each |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
+                    1. If |colorAttachment|.{{GPURenderPassColorAttachment/clearValue}} is not [=map/exist|provided=],
+                        let |colorAttachment|.{{GPURenderPassColorAttachment/clearValue}} be `{r: 0, g: 0, b: 0, a: 0}`.
                     1. The [=texture subresource=] seen by |colorAttachment|.{{GPURenderPassColorAttachment/view}}
                         is considered to be used as [=internal usage/attachment=] for the
                         duration of the render pass.
                 1. Let |depthStencilAttachment| be |descriptor|.{{GPURenderPassDescriptor/depthStencilAttachment}}.
                 1. If |depthStencilAttachment| is not `null`:
                     1. Let |depthStencilView| be |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/view}}.
-                    1. If |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} and
-                        {{GPURenderPassDepthStencilAttachment/stencilReadOnly}} are set:
+                    1. If |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/depthStoreOp}} is {{GPUStoreOp/"read-only"}}
+                        and {{GPURenderPassDepthStencilAttachment/stencilStoreOp}} is {{GPUStoreOp/"read-only"}}:
                         1. The [=texture subresources=] seen by |depthStencilView|
                             are considered to be used as [=internal usage/attachment-read=] for the duration of the render pass.
                     1. Else, the [=texture subresource=] seen by |depthStencilView|
                         is considered to be used as [=internal usage/attachment=] for the duration of the render pass.
-                    1. Set |pass|.{{GPURenderEncoderBase/[[depthReadOnly]]}} to |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}}.
-                    1. Set |pass|.{{GPURenderEncoderBase/[[stencilReadOnly]]}} to |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}}.
+                    1. If |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/depthStoreOp}} is
+                        {{GPUStoreOp/"read-only"}} set |pass|.{{GPURenderEncoderBase/[[depthReadOnly]]}} to `true`.
+                    1. If |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/stencilStoreOp}} is
+                        {{GPUStoreOp/"read-only"}} set |pass|.{{GPURenderEncoderBase/[[stencilReadOnly]]}} to `true`.
                 1. Set |pass|.{{GPURenderEncoderBase/[[layout]]}} to [$derive render targets layout from pass$](|descriptor|).
                 1. For each |timestampWrite| in |descriptor|.{{GPURenderPassDescriptor/timestampWrites}},
                     1. If |timestampWrite|.{{GPURenderPassTimestampWrite/location}} is {{GPURenderPassTimestampLocation/"beginning"}},
@@ -6955,13 +6959,13 @@ GPURenderPassEncoder includes GPURenderEncoderBase;
     ::
         The layout of the render pass.
 
-    : <dfn>\[[depthReadOnly]]</dfn>, of type boolean?
+    : <dfn>\[[depthReadOnly]]</dfn>, of type boolean
     ::
-        If present, the flag indicates that the depth component is not modified.
+        If true, indicates that the depth component is not modified.
 
-    : <dfn>\[[stencilReadOnly]]</dfn>, of type boolean?
+    : <dfn>\[[stencilReadOnly]]</dfn>, of type boolean
     ::
-        If present, the flag indicates that the stencil component is not modified.
+        If true, indicates that the stencil component is not modified.
 
     : <dfn>\[[pipeline]]</dfn>, of type {{GPURenderPipeline}}
     ::
@@ -7127,7 +7131,8 @@ dictionary GPURenderPassColorAttachment {
     required GPUTextureView view;
     GPUTextureView resolveTarget;
 
-    required (GPULoadOp or GPUColor) loadValue;
+    GPUColor clearValue;
+    required GPULoadOp loadOp;
     required GPUStoreOp storeOp;
 };
 </script>
@@ -7144,19 +7149,23 @@ dictionary GPURenderPassColorAttachment {
         output for this color attachment if {{GPURenderPassColorAttachment/view}} is
         multisampled.
 
-    : <dfn>loadValue</dfn>
+    : <dfn>clearValue</dfn>
     ::
-        If a {{GPULoadOp}}, indicates the load operation to perform on
-        {{GPURenderPassColorAttachment/view}} prior to executing the render pass.
-        If a {{GPUColor}}, indicates the value to clear {{GPURenderPassColorAttachment/view}}
-        to prior to executing the render pass.
+        Indicates the value to clear {{GPURenderPassColorAttachment/view}} to prior to executing the
+        render pass. If not [=map/exist|provided=] defaults to `{r: 0, g: 0, b: 0, a: 0}`. Ignored
+        if {{GPURenderPassColorAttachment/loadOp}} if not {{GPULoadOp/"clear"}}.
 
-        Note: It is recommended to prefer a clear-value; see {{GPULoadOp/"load"}}.
+    : <dfn>loadOp</dfn>
+    ::
+        Indicates the load operation to perform on {{GPURenderPassColorAttachment/view}} prior to
+        executing the render pass.
+
+        Note: It is recommended to prefer clearing; see {{GPULoadOp/"clear"}} for details.
 
     : <dfn>storeOp</dfn>
     ::
-        The store operation to perform on {{GPURenderPassColorAttachment/view}}
-        after executing the render pass.
+        The store operation to perform on {{GPURenderPassColorAttachment/view}} after executing the
+        render pass. Must not be {{GPUStoreOp/"read-only"}}
 </dl>
 
 <div class=validusage dfn-for=GPURenderPassColorAttachment>
@@ -7170,6 +7179,7 @@ dictionary GPURenderPassColorAttachment {
     1. |this|.{{GPURenderPassColorAttachment/view}} must have a [=color renderable format=].
     1. |renderTextureDesc|.{{GPUTextureDescriptor/usage}} must contain {{GPUTextureUsage/RENDER_ATTACHMENT}}.
     1. |this|.{{GPURenderPassColorAttachment/view}} must be a view of a single [=subresource=].
+    1. |this|.{{GPURenderPassColorAttachment/storeOp}} must not be {{GPUStoreOp/"read-only"}}.
     1. If |this|.{{GPURenderPassColorAttachment/resolveTarget}} is not `null`:
 
         1. |this|.{{GPURenderPassColorAttachment/view}} must be multisampled.
@@ -7191,13 +7201,13 @@ dictionary GPURenderPassColorAttachment {
 dictionary GPURenderPassDepthStencilAttachment {
     required GPUTextureView view;
 
-    required (GPULoadOp or float) depthLoadValue;
-    required GPUStoreOp depthStoreOp;
-    boolean depthReadOnly = false;
+    float depthClearValue = 0;
+    GPULoadOp depthLoadOp;
+    GPUStoreOp depthStoreOp;
 
-    required (GPULoadOp or GPUStencilValue) stencilLoadValue;
-    required GPUStoreOp stencilStoreOp;
-    boolean stencilReadOnly = false;
+    GPUStencilValue stencilClearValue = 0;
+    GPULoadOp stencilLoadOp;
+    GPUStoreOp stencilStoreOp;
 };
 </script>
 
@@ -7207,46 +7217,41 @@ dictionary GPURenderPassDepthStencilAttachment {
         A {{GPUTextureView}} describing the texture [=subresource=] that will be output to
         and read from for this depth/stencil attachment.
 
-    : <dfn>depthLoadValue</dfn>
+    : <dfn>depthClearValue</dfn>
     ::
-        If a {{GPULoadOp}}, indicates the load operation to perform on
-        {{GPURenderPassDepthStencilAttachment/view}}'s depth component prior to
-        executing the render pass.
-        If a `float`, indicates the value to clear {{GPURenderPassDepthStencilAttachment/view}}'s
-        depth component to prior to executing the render pass.
+        Indicates the value to clear {{GPURenderPassDepthStencilAttachment/view}}'s depth component
+        to prior to executing the render pass. Ignored if {{GPURenderPassDepthStencilAttachment/depthLoadOp}}
+        if not {{GPULoadOp/"clear"}}.
 
-        Note: It is recommended to prefer a clear-value; see {{GPULoadOp/"load"}}.
+    : <dfn>depthLoadOp</dfn>
+    ::
+        Indicates the load operation to perform on {{GPURenderPassDepthStencilAttachment/view}}'s
+        depth component prior to executing the render pass.
+
+        Note: It is recommended to prefer clearing; see {{GPULoadOp/"clear"}} for details.
 
     : <dfn>depthStoreOp</dfn>
     ::
         The store operation to perform on {{GPURenderPassDepthStencilAttachment/view}}'s
         depth component after executing the render pass.
 
-        Note: It is recommended to prefer a clear-value; see {{GPULoadOp/"load"}}.
-
-    : <dfn>depthReadOnly</dfn>
+    : <dfn>stencilClearValue</dfn>
     ::
-        Indicates that the depth component of {{GPURenderPassDepthStencilAttachment/view}}
-        is read only.
+        Indicates the value to clear {{GPURenderPassDepthStencilAttachment/view}}'s stencil component
+        to prior to executing the render pass. Ignored if {{GPURenderPassDepthStencilAttachment/stencilLoadOp}}
+        if not {{GPULoadOp/"clear"}}.
 
-    : <dfn>stencilLoadValue</dfn>
+    : <dfn>stencilLoadOp</dfn>
     ::
-        If a {{GPULoadOp}}, indicates the load operation to perform on
-        {{GPURenderPassDepthStencilAttachment/view}}'s stencil component prior to
-        executing the render pass.
-        If a {{GPUStencilValue}}, indicates the value to clear
-        {{GPURenderPassDepthStencilAttachment/view}}'s stencil component to prior to
-        executing the render pass.
+        Indicates the load operation to perform on {{GPURenderPassDepthStencilAttachment/view}}'s
+        stencil component prior to executing the render pass.
+
+        Note: It is recommended to prefer clearing; see {{GPULoadOp/"clear"}} for details.
 
     : <dfn>stencilStoreOp</dfn>
     ::
         The store operation to perform on {{GPURenderPassDepthStencilAttachment/view}}'s
         stencil component after executing the render pass.
-
-    : <dfn>stencilReadOnly</dfn>
-    ::
-        Indicates that the stencil component of {{GPURenderPassDepthStencilAttachment/view}}
-        is read only.
 </dl>
 
 <div class=validusage dfn-for=GPURenderPassDepthStencilAttachment>
@@ -7262,14 +7267,23 @@ dictionary GPURenderPassDepthStencilAttachment {
     - |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}}
         must contain {{GPUTextureUsage/RENDER_ATTACHMENT}}.
     - If |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}
-        contains both depth and stencil aspects (See [[#depth-formats|depth-stencil formats]]):
-        - |this|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} must be equal to |this|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}}
-    - If |this|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} is `true`:
-        - |this|.{{GPURenderPassDepthStencilAttachment/depthLoadValue}} must be {{GPULoadOp/"load"}}.
-        - |this|.{{GPURenderPassDepthStencilAttachment/depthStoreOp}} must be {{GPUStoreOp/"store"}}.
-    - If |this|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}} is `true`:
-        - |this|.{{GPURenderPassDepthStencilAttachment/stencilLoadValue}} must be {{GPULoadOp/"load"}}.
-        - |this|.{{GPURenderPassDepthStencilAttachment/stencilStoreOp}} must be {{GPUStoreOp/"store"}}.
+        [[#depth-formats|contains a depth aspect]]:
+        - |this|.{{GPURenderPassDepthStencilAttachment/depthStoreOp}} must [=map/exist|be provided=].
+        - If |this|.{{GPURenderPassDepthStencilAttachment/depthStoreOp}} is {{GPUStoreOp/"read-only"}}
+            |this|.{{GPURenderPassDepthStencilAttachment/depthLoadOp}} must not [=map/exist|be provided=].
+        - Otherwise |this|.{{GPURenderPassDepthStencilAttachment/depthLoadOp}} must [=map/exist|be provided=].
+    - If |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}
+        [[#depth-formats|contains a stencil aspect]]:
+        - |this|.{{GPURenderPassDepthStencilAttachment/stencilStoreOp}} must [=map/exist|be provided=].
+        - If |this|.{{GPURenderPassDepthStencilAttachment/stencilStoreOp}} is {{GPUStoreOp/"read-only"}}
+            |this|.{{GPURenderPassDepthStencilAttachment/stencilLoadOp}} must not [=map/exist|be provided=].
+        - Otherwise |this|.{{GPURenderPassDepthStencilAttachment/stencilLoadOp}} must [=map/exist|be provided=].
+    - If |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}
+        contains both depth and stencil aspects (See [[#depth-formats|depth-stencil formats]]) and either
+        |this|.{{GPURenderPassDepthStencilAttachment/depthStoreOp}} or
+        |this|.{{GPURenderPassDepthStencilAttachment/stencilStoreOp}} is {{GPUStoreOp/"read-only"}}:
+        - Both |this|.{{GPURenderPassDepthStencilAttachment/depthStoreOp}} and 
+            |this|.{{GPURenderPassDepthStencilAttachment/stencilStoreOp}} must be {{GPUStoreOp/"read-only"}}.
 
     Issue: Describe the remaining validation rules for this type.
 </div>
@@ -7279,6 +7293,7 @@ dictionary GPURenderPassDepthStencilAttachment {
 <script type=idl>
 enum GPULoadOp {
     "load",
+    "clear",
 };
 </script>
 
@@ -7287,11 +7302,15 @@ enum GPULoadOp {
     ::
         Loads the existing value for this attachment into the render pass.
 
+    : <dfn>"clear"</dfn>
+    ::
+        Loads a clear value for this attachment into the render pass.
+
         Note:
-        On some GPU hardware (primarily mobile), providing a clear-value is significantly cheaper
+        On some GPU hardware (primarily mobile), {{GPULoadOp/"clear"}} is significantly cheaper
         because it avoids loading data from main memory into tile-local memory.
         On other GPU hardware, there isn't a significant difference. As a result, it is
-        recommended to use a clear-value, rather than {{GPULoadOp/"load"}}, in cases where the
+        recommended to use {{GPULoadOp/"clear"}} rather than {{GPULoadOp/"load"}} in cases where the
         initial value doesn't matter (e.g. the render target will be cleared using a skybox).
 </dl>
 
@@ -7299,8 +7318,25 @@ enum GPULoadOp {
 enum GPUStoreOp {
     "store",
     "discard",
+    "read-only",
 };
 </script>
+
+<dl dfn-type=enum-value dfn-for=GPUStoreOp>
+    : <dfn>"store"</dfn>
+    ::
+        Stores the resulting value of the render pass for this attachment.
+
+    : <dfn>"discard"</dfn>
+    ::
+        Discards the resulting value of the render pass for this attachment.
+
+    : <dfn>"read-only"</dfn>
+    ::
+        Indicates that the values of this attachment are immutable during the render pass. When
+        an attachment uses a {{GPUStoreOp}} of {{GPUStoreOp/"read-only"}} the {{GPULoadOp}} for that
+        attachment is implicitly {{GPULoadOp/"load"}}.
+</dl>
 
 #### Render Pass Layout #### {#render-pass-layout}
 
@@ -7940,13 +7976,13 @@ GPURenderBundle includes GPUObjectBase;
     ::
         The layout of the render bundle.
 
-    : <dfn>\[[depthReadOnly]]</dfn>, of type boolean?
+    : <dfn>\[[depthReadOnly]]</dfn>, of type boolean
     ::
-        If present, the flag indicates that the depth component of this render bundle is not modified.
+        If true indicates that the depth component of this render bundle is not modified.
 
-    : <dfn>\[[stencilReadOnly]]</dfn>, of type boolean?
+    : <dfn>\[[stencilReadOnly]]</dfn>, of type boolean
     ::
-        If present, the flag indicates that the stencil component of this render bundle is not modified.
+        If true indicates that the stencil component of this render bundle is not modified.
 </dl>
 
 ### Creation ### {#render-bundle-creation}


### PR DESCRIPTION
Attempts to address #2131.

Based on conversation at the latest editors meeting, this PR flattens out the attachment loadOp/clearValue, gives the clear values defaults, and allows load/store op to be undefined for depth/stencil if the attachment doesn't have those aspects.

Finally, it adds a `"read-only"` value to the `GPUStoreOp` enum to take the place of a separate `*ReadOnly` boolean. This is the part of the PR I feel least confident it. I didn't change the name of the enum/dictionary keys to something like "Mutability" because I feel like it makes the most common case more confusing for developers. That said I recognize that `depthStoreOp: 'read-only'` is a little weird too, though at least in the current set up you can omit the `loadOp` which helps a bit.

```js
depthStencilAttachment: {
  view: depthStencil.createView(),
  depthStoreOp: 'read-only',
  stencilStoreOp: 'read-only',
}
```

Personally, I still think that from a developers point of view it may make more sense to have "read-only" specified as the `loadOp` and omit the `storeOp`, even if that doesn't match the underlying behavior exactly. "Loading and attachment as read only with no store op" reads more intuitively than "Storing the attachment as read only with no load op".
```js
depthStencilAttachment: {
  view: depthStencil.createView(),
  depthLoadOp: 'read-only',
  stencilLoadOp: 'read-only',
}
```


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/2371.html" title="Last updated on Dec 2, 2021, 12:22 AM UTC (f90dd75)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2371/8ea3aea...f90dd75.html" title="Last updated on Dec 2, 2021, 12:22 AM UTC (f90dd75)">Diff</a>