### PR TITLE
CopyExternalImageToTexture: Support copy from webgpu context canvas/offscreenCanvas

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8270,9 +8270,9 @@ GPUQueue includes GPUObjectBase;
             1. If any of the following requirements are unmet, throw an {{OperationError}} and stop.
                 <div class=validusage>
                     - If |source|.{{GPUImageCopyExternalImage/source}} is an {{HTMLCanvasElement}}:
-                        Its [=canvas context mode=] must be `"2d"`, `"webgl"`, or `"webgl2"`.
+                        Its [=canvas context mode=] must be `"2d"`, `"webgl"`, `"webgl2"`, or `"webgpu"`.
                     - If |source|.{{GPUImageCopyExternalImage/source}} is an {{OffscreenCanvas}}:
-                        Its [=OffscreenCanvas context mode=] must be `"2d"`, `"webgl"`, or `"webgl2"`.
+                        Its [=OffscreenCanvas context mode=] must be `"2d"`, `"webgl"`, `"webgl2"`, or `"webgpu"`.
                     - |source|.|origin|.[=Origin3D/x=] + |copySize|.[=Extent3D/width=]
                         must be &le; the width of |sourceImage|.
                     - |source|.|origin|.[=Origin3D/y=] + |copySize|.[=Extent3D/height=]


### PR DESCRIPTION
Address #2350.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shaoboyan/gpuweb/pull/2375.html" title="Last updated on Dec 2, 2021, 5:47 AM UTC (a53bcce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2375/e032ddd...shaoboyan:a53bcce.html" title="Last updated on Dec 2, 2021, 5:47 AM UTC (a53bcce)">Diff</a>