### PR TITLE
Remove Next from switch condition when body doesn't have Next

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5980,7 +5980,7 @@ The reason is that only functions without a return type can have such a [=behavi
         |sn|: |Bn|<br>
         Fallthrough is not in |Bn|<br>
         Break is not in (|B1| &cup; ... &cup; |Bn|)
-    <td class="nowrap">(|B| &cup; |B1| &cup; ... &cup; |Bn|)&#x2216;{Fallthrough}
+    <td class="nowrap">((|B|&#x2216;{Next}) &cup; |B1| &cup; ... &cup; |Bn|)&#x2216;{Fallthrough}
   <tr algorithm="switch with break behavior">
     <td class="nowrap">|e|: |B|<br>
         |s1|: |B1|<br>


### PR DESCRIPTION
An example that needs this rule:

    switch(1) { default: { return; } }

The overall statement should have behaviour {Return}, not {Next, Return}

Fixes: #2366