### PR TITLE
Validate stripIndexFormat at draw-call time.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7711,7 +7711,7 @@ dictionary GPURenderPassLayout: GPUObjectDescriptorBase {
             - |encoder|.{{GPURenderEncoderBase/[[index_buffer]]}} must not be `null`.
             - Let |topology| be |encoder|.{{GPURenderEncoderBase/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.{{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/topology}}.
             - If |topology| is {{GPUPrimitiveTopology/"line-strip"}} or {{GPUPrimitiveTopology/"triangle-strip"}}:
-                - |encoder|.{{GPURenderEncoderBase/[[index_format]]}} must be
+                - |encoder|.{{GPURenderEncoderBase/[[index_format]]}} must equal
                     |encoder|.{{GPURenderEncoderBase/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.{{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/stripIndexFormat}}.
         </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4832,12 +4832,6 @@ GPURenderPipeline includes GPUPipelineBase;
         The {{GPURenderPipelineDescriptor}} describing this pipeline.
 
         All optional fields of {{GPURenderPipelineDescriptor}} are defined.
-
-    : <dfn>\[[strip_index_format]]</dfn>, of type {{GPUIndexFormat}}?
-    ::
-        The format index data this pipeline requires if using a strip primitive topology,
-        initially `undefined`.
-
     : <dfn>\[[writesDepth]]</dfn>, of type boolean
     :: True if the pipeline writes to the depth component of the depth/stencil attachment
 
@@ -4903,8 +4897,6 @@ details.
                             1. Make |pipeline| [=invalid=].
 
                     1. Set |pipeline|.{{GPURenderPipeline/[[descriptor]]}} to |descriptor|.
-                    1. Set |pipeline|.{{GPURenderPipeline/[[strip_index_format]]}} to
-                        |descriptor|.{{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/stripIndexFormat}}.
                     1. Set |pipeline|.{{GPURenderPipeline/[[writesDepth]]}} to false.
                     1. Set |pipeline|.{{GPURenderPipeline/[[writesStencil]]}} to false.
                     1. Let |depthStencil| be |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}.
@@ -5049,14 +5041,6 @@ dictionary GPUPrimitiveState {
             - [=list=]&lt;{{GPUFeatureName}}&gt; |features|
 
         Return `true` if all of the following conditions are satisfied:
-            - If |descriptor|.{{GPUPrimitiveState/topology}} is:
-                <dl class="switch">
-                    : {{GPUPrimitiveTopology/"line-strip"}} or
-                        {{GPUPrimitiveTopology/"triangle-strip"}}
-                    :: |descriptor|.{{GPUPrimitiveState/stripIndexFormat}} is not `undefined`
-                    : Otherwise
-                    :: |descriptor|.{{GPUPrimitiveState/stripIndexFormat}} is `undefined`
-                </dl>
             - If |descriptor|.{{GPUPrimitiveState/unclippedDepth}} is `true`:
                 - |features| must [=list/contain=] {{GPUFeatureName/"depth-clip-control"}}.
 </div>
@@ -5286,10 +5270,11 @@ should be started rather than continuing to construct the triangle strip with th
 vertices.
 
 {{GPUPrimitiveState}}s that specify a strip primitive topology must specify a
-{{GPUPrimitiveState/stripIndexFormat}} so that the [=primitive restart value=] that will be used
-is known at pipeline creation time. {{GPUPrimitiveState}}s that specify a list primitive
-topology must set {{GPUPrimitiveState/stripIndexFormat}} to `undefined`, and will use the index
-format passed to {{GPURenderEncoderBase/setIndexBuffer()}} when rendering.
+{{GPUPrimitiveState/stripIndexFormat}} if they are used for indexed draws
+so that the [=primitive restart value=] that will be used is known at pipeline
+creation time. {{GPUPrimitiveState}}s that specify a list primitive
+topology will use the index format passed to {{GPURenderEncoderBase/setIndexBuffer()}}
+when doing indexed rendering.
 
 <table class="data">
   <thead>
@@ -7724,9 +7709,10 @@ dictionary GPURenderPassLayout: GPUObjectDescriptorBase {
             - It must be [$valid to draw$] with |encoder|.
 
             - |encoder|.{{GPURenderEncoderBase/[[index_buffer]]}} must not be `null`.
-            - Let |stripIndexFormat| be |encoder|.{{GPURenderEncoderBase/[[pipeline]]}}.{{GPURenderPipeline/[[strip_index_format]]}}.
-            - If |stripIndexFormat| is not `undefined`:
-                - |encoder|.{{GPURenderEncoderBase/[[index_format]]}} must be |stripIndexFormat|.
+            - Let |topology| be |encoder|.{{GPURenderEncoderBase/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.{{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/topology}}.
+            - If |topology| is {{GPUPrimitiveTopology/"line-strip"}} or {{GPUPrimitiveTopology/"triangle-strip"}}:
+                - |encoder|.{{GPURenderEncoderBase/[[index_format]]}} must be
+                    |encoder|.{{GPURenderEncoderBase/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.{{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/stripIndexFormat}}.
         </div>
 
     Otherwise return `true`.
@@ -9280,10 +9266,11 @@ Primitives are assembled by a fixed-function stage of GPUs.
     For each instance, the primitives get assembled from the vertices that have been
     processed by the shaders, based on the |vertexIndexList|.
 
-    1. First, if |desc|.{{GPUPrimitiveState/stripIndexFormat}} is not `null`
-        (which means the primitive topology is a strip), and the |drawCall| is indexed,
-        the |vertexIndexList| is split into sub-lists
-        using the maximum value of this index format as a separator.
+    1. First, if the primitive topology is a strip, (which means that
+        |desc|.{{GPUPrimitiveState/stripIndexFormat}} is not undefined)
+        and the |drawCall| is indexed, the |vertexIndexList| is split into
+        sub-lists using the maximum value of |desc|.{{GPUPrimitiveState/stripIndexFormat}}
+        as a separator.
 
         Example: a |vertexIndexList| with values `[1, 2, 65535, 4, 5, 6]` of type {{GPUIndexFormat/"uint16"}}
         will be split in sub-lists `[1, 2]` and `[4, 5, 6]`.


### PR DESCRIPTION
Fixes #2199


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/2385.html" title="Last updated on Dec 6, 2021, 11:26 PM UTC (2b32c2e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2385/62323a8...Kangz:2b32c2e.html" title="Last updated on Dec 6, 2021, 11:26 PM UTC (2b32c2e)">Diff</a>