### PR TITLE
Separate loadOp and clear values

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7641,7 +7641,8 @@ dictionary GPURenderPassColorAttachment {
     required GPUTextureView view;
     GPUTextureView resolveTarget;
 
-    required (GPULoadOp or GPUColor) loadValue;
+    GPUColor clearValue;
+    required GPULoadOp loadOp;
     required GPUStoreOp storeOp;
 };
 </script>
@@ -7658,14 +7659,18 @@ dictionary GPURenderPassColorAttachment {
         output for this color attachment if {{GPURenderPassColorAttachment/view}} is
         multisampled.
 
-    : <dfn>loadValue</dfn>
+    : <dfn>clearValue</dfn>
     ::
-        If a {{GPULoadOp}}, indicates the load operation to perform on
-        {{GPURenderPassColorAttachment/view}} prior to executing the render pass.
-        If a {{GPUColor}}, indicates the value to clear {{GPURenderPassColorAttachment/view}}
-        to prior to executing the render pass.
+        Indicates the value to clear {{GPURenderPassColorAttachment/view}} to prior to executing the
+        render pass. If not [=map/exist|provided=] defaults to `{r: 0, g: 0, b: 0, a: 0}`. Ignored
+        if {{GPURenderPassColorAttachment/loadOp}} if not {{GPULoadOp/"clear"}}.
 
-        Note: It is recommended to prefer a clear-value; see {{GPULoadOp/"load"}}.
+    : <dfn>loadOp</dfn>
+    ::
+        Indicates the load operation to perform on {{GPURenderPassColorAttachment/view}} prior to
+        executing the render pass.
+
+        Note: It is recommended to prefer clearing; see {{GPULoadOp/"clear"}} for details.
 
     : <dfn>storeOp</dfn>
     ::
@@ -7719,11 +7724,13 @@ dictionary GPURenderPassColorAttachment {
 dictionary GPURenderPassDepthStencilAttachment {
     required GPUTextureView view;
 
-    required (GPULoadOp or float) depthLoadValue;
+    float depthClearValue = 0;
+    required GPULoadOp depthLoadOp;
     required GPUStoreOp depthStoreOp;
     boolean depthReadOnly = false;
 
-    required (GPULoadOp or GPUStencilValue) stencilLoadValue;
+    GPUStencilValue stencilClearValue = 0;
+    required GPULoadOp stencilLoadOp;
     required GPUStoreOp stencilStoreOp;
     boolean stencilReadOnly = false;
 };
@@ -7735,17 +7742,19 @@ dictionary GPURenderPassDepthStencilAttachment {
         A {{GPUTextureView}} describing the texture [=subresource=] that will be output to
         and read from for this depth/stencil attachment.
 
-    : <dfn>depthLoadValue</dfn>
+    : <dfn>depthClearValue</dfn>
     ::
-        If this is a {{GPULoadOp}}, it indicates the load operation to perform on
-        {{GPURenderPassDepthStencilAttachment/view}}'s depth component prior to
-        executing the render pass.
+        Indicates the value to clear {{GPURenderPassDepthStencilAttachment/view}}'s depth component
+        to prior to executing the render pass. Ignored if {{GPURenderPassDepthStencilAttachment/depthLoadOp}}
+        if not {{GPULoadOp/"clear"}}. Must be between 0.0 and 1.0, inclusive.
+        <!-- unless unrestricted depth is enabled -->
 
-        Otherwise, this is a `float` indicating the value to clear {{GPURenderPassDepthStencilAttachment/view}}'s
-        depth component to prior to executing the render pass.
-        Must be between 0.0 and 1.0, inclusive. <!-- unless unrestricted depth is enabled -->
+    : <dfn>depthLoadOp</dfn>
+    ::
+        Indicates the load operation to perform on {{GPURenderPassDepthStencilAttachment/view}}'s
+        depth component prior to executing the render pass.
 
-        Note: It is recommended to prefer a clear-value; see {{GPULoadOp/"load"}}.
+        Note: It is recommended to prefer clearing; see {{GPULoadOp/"clear"}} for details.
 
     : <dfn>depthStoreOp</dfn>
     ::
@@ -7759,14 +7768,18 @@ dictionary GPURenderPassDepthStencilAttachment {
         Indicates that the depth component of {{GPURenderPassDepthStencilAttachment/view}}
         is read only.
 
-    : <dfn>stencilLoadValue</dfn>
+    : <dfn>stencilClearValue</dfn>
     ::
-        If a {{GPULoadOp}}, indicates the load operation to perform on
-        {{GPURenderPassDepthStencilAttachment/view}}'s stencil component prior to
-        executing the render pass.
-        If a {{GPUStencilValue}}, indicates the value to clear
-        {{GPURenderPassDepthStencilAttachment/view}}'s stencil component to prior to
-        executing the render pass.
+        Indicates the value to clear {{GPURenderPassDepthStencilAttachment/view}}'s stencil component
+        to prior to executing the render pass. Ignored if {{GPURenderPassDepthStencilAttachment/stencilLoadOp}}
+        if not {{GPULoadOp/"clear"}}.
+
+    : <dfn>stencilLoadOp</dfn>
+    ::
+        Indicates the load operation to perform on {{GPURenderPassDepthStencilAttachment/view}}'s
+        stencil component prior to executing the render pass.
+
+        Note: It is recommended to prefer clearing; see {{GPULoadOp/"clear"}} for details.
 
     : <dfn>stencilStoreOp</dfn>
     ::
@@ -7787,16 +7800,17 @@ dictionary GPURenderPassDepthStencilAttachment {
 
     - |this|.{{GPURenderPassDepthStencilAttachment/view}} must have a [=depth-or-stencil format=].
     - |this|.{{GPURenderPassDepthStencilAttachment/view}} must be a [$renderable texture view$].
-    - If |this|.{{GPURenderPassDepthStencilAttachment/depthLoadValue}} is a clear value (has type `float`),
-        it must be between 0.0 and 1.0, inclusive. <!-- unless unrestricted depth is enabled -->
+    - If |this|.{{GPURenderPassDepthStencilAttachment/depthLoadOp}} is {{GPULoadOp/"clear"}},
+        |this|.{{GPURenderPassDepthStencilAttachment/depthClearValue}} must be between 0.0 and 1.0,
+        inclusive. <!-- unless unrestricted depth is enabled -->
     - If |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}
         is a [=combined depth-stencil format=]:
         - |this|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} must be equal to |this|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}}
     - If |this|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} is `true`:
-        - |this|.{{GPURenderPassDepthStencilAttachment/depthLoadValue}} must be {{GPULoadOp/"load"}}.
+        - |this|.{{GPURenderPassDepthStencilAttachment/depthLoadOp}} must be {{GPULoadOp/"load"}}.
         - |this|.{{GPURenderPassDepthStencilAttachment/depthStoreOp}} must be {{GPUStoreOp/"store"}}.
     - If |this|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}} is `true`:
-        - |this|.{{GPURenderPassDepthStencilAttachment/stencilLoadValue}} must be {{GPULoadOp/"load"}}.
+        - |this|.{{GPURenderPassDepthStencilAttachment/stencilLoadOp}} must be {{GPULoadOp/"load"}}.
         - |this|.{{GPURenderPassDepthStencilAttachment/stencilStoreOp}} must be {{GPUStoreOp/"store"}}.
 </div>
 
@@ -7805,6 +7819,7 @@ dictionary GPURenderPassDepthStencilAttachment {
 <script type=idl>
 enum GPULoadOp {
     "load",
+    "clear",
 };
 </script>
 
@@ -7813,11 +7828,15 @@ enum GPULoadOp {
     ::
         Loads the existing value for this attachment into the render pass.
 
+    : <dfn>"clear"</dfn>
+    ::
+        Loads a clear value for this attachment into the render pass.
+
         Note:
-        On some GPU hardware (primarily mobile), providing a clear-value is significantly cheaper
+        On some GPU hardware (primarily mobile), {{GPULoadOp/"clear"}} is significantly cheaper
         because it avoids loading data from main memory into tile-local memory.
         On other GPU hardware, there isn't a significant difference. As a result, it is
-        recommended to use a clear-value, rather than {{GPULoadOp/"load"}}, in cases where the
+        recommended to use {{GPULoadOp/"clear"}} rather than {{GPULoadOp/"load"}} in cases where the
         initial value doesn't matter (e.g. the render target will be cleared using a skybox).
 </dl>
 
@@ -7827,6 +7846,17 @@ enum GPUStoreOp {
     "discard",
 };
 </script>
+
+<dl dfn-type=enum-value dfn-for=GPUStoreOp>
+    : <dfn>"store"</dfn>
+    ::
+        Stores the resulting value of the render pass for this attachment.
+
+    : <dfn>"discard"</dfn>
+    ::
+        Discards the resulting value of the render pass for this attachment.
+</dl>
+
 
 #### Render Pass Layout #### {#render-pass-layout}
 


### PR DESCRIPTION
Fixes #1377.
Split out from #2371.

Flattens out the attachment loadOp/clearValue and gives the clear values defaults. This should address concerns that developers may pick a potentially less efficient path (`"load"`) simply because it's easier to type. Instead they can use `"clear"` to clear to the default value (zeros) and specify a different clear value if one is needed.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Dec 14, 2021, 9:15 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fgpuweb%2Fgpuweb%2Fae5c97f8d7484b6b4177a7cfdddca7a02e10a97b%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%232386.)._
</details>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/2386.html" title="Last updated on Jan 25, 2022, 12:56 AM UTC (b65c38e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2386/89b0dba...b65c38e.html" title="Last updated on Jan 25, 2022, 12:56 AM UTC (b65c38e)">Diff</a>