### PR TITLE
Validate that stripIndexFormat must be undefined for non-strip topologies

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5046,6 +5046,9 @@ dictionary GPUPrimitiveState {
             - [=list=]&lt;{{GPUFeatureName}}&gt; |features|
 
         Return `true` if all of the following conditions are satisfied:
+            - If |descriptor|.{{GPUPrimitiveState/topology}} is not
+                {{GPUPrimitiveTopology/"line-strip"}} or {{GPUPrimitiveTopology/"triangle-strip"}}:
+                - |descriptor|.{{GPUPrimitiveState/stripIndexFormat}} is `undefined`
             - If |descriptor|.{{GPUPrimitiveState/unclippedDepth}} is `true`:
                 - |features| must [=list/contain=] {{GPUFeatureName/"depth-clip-control"}}.
 </div>


### PR DESCRIPTION
Seems like this restriction shouldn't have been removed as part of #2385.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/2393.html" title="Last updated on Dec 7, 2021, 11:07 PM UTC (59ca766)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2393/e125043...59ca766.html" title="Last updated on Dec 7, 2021, 11:07 PM UTC (59ca766)">Diff</a>