### PR TITLE
Reduce patterns

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7696,192 +7696,192 @@ Issue: https://github.com/gpuweb/gpuweb/issues/1621
 <div class='syntax' noexport='true'>
   <dfn for=syntax>array</dfn> :
 
-    | `/array/`
+    | `'array'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>atomic</dfn> :
 
-    | `/atomic/`
+    | `'atomic'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>bool</dfn> :
 
-    | `/bool/`
+    | `'bool'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>float32</dfn> :
 
-    | `/f32/`
+    | `'f32'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>int32</dfn> :
 
-    | `/i32/`
+    | `'i32'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>mat2x2</dfn> :
 
-    | `/mat2x2/`
+    | `'mat2x2'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>mat2x3</dfn> :
 
-    | `/mat2x3/`
+    | `'mat2x3'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>mat2x4</dfn> :
 
-    | `/mat2x4/`
+    | `'mat2x4'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>mat3x2</dfn> :
 
-    | `/mat3x2/`
+    | `'mat3x2'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>mat3x3</dfn> :
 
-    | `/mat3x3/`
+    | `'mat3x3'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>mat3x4</dfn> :
 
-    | `/mat3x4/`
+    | `'mat3x4'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>mat4x2</dfn> :
 
-    | `/mat4x2/`
+    | `'mat4x2'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>mat4x3</dfn> :
 
-    | `/mat4x3/`
+    | `'mat4x3'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>mat4x4</dfn> :
 
-    | `/mat4x4/`
+    | `'mat4x4'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>pointer</dfn> :
 
-    | `/ptr/`
+    | `'ptr'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>sampler</dfn> :
 
-    | `/sampler/`
+    | `'sampler'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>sampler_comparison</dfn> :
 
-    | `/sampler_comparison/`
+    | `'sampler_comparison'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>struct</dfn> :
 
-    | `/struct/`
+    | `'struct'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>texture_1d</dfn> :
 
-    | `/texture_1d/`
+    | `'texture_1d'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>texture_2d</dfn> :
 
-    | `/texture_2d/`
+    | `'texture_2d'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>texture_2d_array</dfn> :
 
-    | `/texture_2d_array/`
+    | `'texture_2d_array'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>texture_3d</dfn> :
 
-    | `/texture_3d/`
+    | `'texture_3d'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>texture_cube</dfn> :
 
-    | `/texture_cube/`
+    | `'texture_cube'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>texture_cube_array</dfn> :
 
-    | `/texture_cube_array/`
+    | `'texture_cube_array'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>texture_multisampled_2d</dfn> :
 
-    | `/texture_multisampled_2d/`
+    | `'texture_multisampled_2d'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>texture_storage_1d</dfn> :
 
-    | `/texture_storage_1d/`
+    | `'texture_storage_1d'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>texture_storage_2d</dfn> :
 
-    | `/texture_storage_2d/`
+    | `'texture_storage_2d'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>texture_storage_2d_array</dfn> :
 
-    | `/texture_storage_2d_array/`
+    | `'texture_storage_2d_array'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>texture_storage_3d</dfn> :
 
-    | `/texture_storage_3d/`
+    | `'texture_storage_3d'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>texture_depth_2d</dfn> :
 
-    | `/texture_depth_2d/`
+    | `'texture_depth_2d'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>texture_depth_2d_array</dfn> :
 
-    | `/texture_depth_2d_array/`
+    | `'texture_depth_2d_array'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>texture_depth_cube</dfn> :
 
-    | `/texture_depth_cube/`
+    | `'texture_depth_cube'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>texture_depth_cube_array</dfn> :
 
-    | `/texture_depth_cube_array/`
+    | `'texture_depth_cube_array'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>texture_depth_multisampled_2d</dfn> :
 
-    | `/texture_depth_multisampled_2d/`
+    | `'texture_depth_multisampled_2d'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>uint32</dfn> :
 
-    | `/u32/`
+    | `'u32'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>vec2</dfn> :
 
-    | `/vec2/`
+    | `'vec2'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>vec3</dfn> :
 
-    | `/vec3/`
+    | `'vec3'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>vec4</dfn> :
 
-    | `/vec4/`
+    | `'vec4'`
 </div>
 
 ### Other Keywords ### {#other-keywords}
@@ -7889,147 +7889,147 @@ Issue: https://github.com/gpuweb/gpuweb/issues/1621
 <div class='syntax' noexport='true'>
   <dfn for=syntax>bitcast</dfn> :
 
-    | `/bitcast/`
+    | `'bitcast'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>break</dfn> :
 
-    | `/break/`
+    | `'break'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>case</dfn> :
 
-    | `/case/`
+    | `'case'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>continue</dfn> :
 
-    | `/continue/`
+    | `'continue'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>continuing</dfn> :
 
-    | `/continuing/`
+    | `'continuing'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>default</dfn> :
 
-    | `/default/`
+    | `'default'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>discard</dfn> :
 
-    | `/discard/`
+    | `'discard'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>else</dfn> :
 
-    | `/else/`
+    | `'else'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>enable</dfn> :
 
-    | `/enable/`
+    | `'enable'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>fallthrough</dfn> :
 
-    | `/fallthrough/`
+    | `'fallthrough'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>false</dfn> :
 
-    | `/false/`
+    | `'false'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>fn</dfn> :
 
-    | `/fn/`
+    | `'fn'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>for</dfn> :
 
-    | `/for/`
+    | `'for'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>function</dfn> :
 
-    | `/function/`
+    | `'function'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>if</dfn> :
 
-    | `/if/`
+    | `'if'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>let</dfn> :
 
-    | `/let/`
+    | `'let'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>loop</dfn> :
 
-    | `/loop/`
+    | `'loop'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>private</dfn> :
 
-    | `/private/`
+    | `'private'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>read</dfn> :
 
-    | `/read/`
+    | `'read'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>read_write</dfn> :
 
-    | `/read_write/`
+    | `'read_write'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>return</dfn> :
 
-    | `/return/`
+    | `'return'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>storage</dfn> :
 
-    | `/storage/`
+    | `'storage'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>switch</dfn> :
 
-    | `/switch/`
+    | `'switch'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>true</dfn> :
 
-    | `/true/`
+    | `'true'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>type</dfn> :
 
-    | `/type/`
+    | `'type'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>uniform</dfn> :
 
-    | `/uniform/`
+    | `'uniform'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>var</dfn> :
 
-    | `/var/`
+    | `'var'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>workgroup</dfn> :
 
-    | `/workgroup/`
+    | `'workgroup'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>write</dfn> :
 
-    | `/write/`
+    | `'write'`
 </div>
 
 Issue: Should read, write, and read_write be not completely reserved?  They are only used in specific contexts.
@@ -8039,177 +8039,177 @@ Issue: Should read, write, and read_write be not completely reserved?  They are 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>r8unorm</dfn> :
 
-    | `/r8unorm/`
+    | `'r8unorm'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>r8snorm</dfn> :
 
-    | `/r8snorm/`
+    | `'r8snorm'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>r8uint</dfn> :
 
-    | `/r8uint/`
+    | `'r8uint'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>r8sint</dfn> :
 
-    | `/r8sint/`
+    | `'r8sint'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>r16uint</dfn> :
 
-    | `/r16uint/`
+    | `'r16uint'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>r16sint</dfn> :
 
-    | `/r16sint/`
+    | `'r16sint'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>r16float</dfn> :
 
-    | `/r16float/`
+    | `'r16float'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>rg8unorm</dfn> :
 
-    | `/rg8unorm/`
+    | `'rg8unorm'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>rg8snorm</dfn> :
 
-    | `/rg8snorm/`
+    | `'rg8snorm'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>rg8uint</dfn> :
 
-    | `/rg8uint/`
+    | `'rg8uint'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>rg8sint</dfn> :
 
-    | `/rg8sint/`
+    | `'rg8sint'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>r32uint</dfn> :
 
-    | `/r32uint/`
+    | `'r32uint'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>r32sint</dfn> :
 
-    | `/r32sint/`
+    | `'r32sint'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>r32float</dfn> :
 
-    | `/r32float/`
+    | `'r32float'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>rg16uint</dfn> :
 
-    | `/rg16uint/`
+    | `'rg16uint'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>rg16sint</dfn> :
 
-    | `/rg16sint/`
+    | `'rg16sint'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>rg16float</dfn> :
 
-    | `/rg16float/`
+    | `'rg16float'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>rgba8unorm</dfn> :
 
-    | `/rgba8unorm/`
+    | `'rgba8unorm'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>rgba8unorm_srgb</dfn> :
 
-    | `/rgba8unorm_srgb/`
+    | `'rgba8unorm_srgb'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>rgba8snorm</dfn> :
 
-    | `/rgba8snorm/`
+    | `'rgba8snorm'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>rgba8uint</dfn> :
 
-    | `/rgba8uint/`
+    | `'rgba8uint'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>rgba8sint</dfn> :
 
-    | `/rgba8sint/`
+    | `'rgba8sint'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>bgra8unorm</dfn> :
 
-    | `/bgra8unorm/`
+    | `'bgra8unorm'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>bgra8unorm_srgb</dfn> :
 
-    | `/bgra8unorm_srgb/`
+    | `'bgra8unorm_srgb'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>rgb10a2unorm</dfn> :
 
-    | `/rgb10a2unorm/`
+    | `'rgb10a2unorm'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>rg11b10float</dfn> :
 
-    | `/rg11b10float/`
+    | `'rg11b10float'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>rg32uint</dfn> :
 
-    | `/rg32uint/`
+    | `'rg32uint'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>rg32sint</dfn> :
 
-    | `/rg32sint/`
+    | `'rg32sint'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>rg32float</dfn> :
 
-    | `/rg32float/`
+    | `'rg32float'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>rgba16uint</dfn> :
 
-    | `/rgba16uint/`
+    | `'rgba16uint'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>rgba16sint</dfn> :
 
-    | `/rgba16sint/`
+    | `'rgba16sint'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>rgba16float</dfn> :
 
-    | `/rgba16float/`
+    | `'rgba16float'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>rgba32uint</dfn> :
 
-    | `/rgba32uint/`
+    | `'rgba32uint'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>rgba32sint</dfn> :
 
-    | `/rgba32sint/`
+    | `'rgba32sint'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>rgba32float</dfn> :
 
-    | `/rgba32float/`
+    | `'rgba32float'`
 </div>
 
 TODO(dneto): Eliminate the image formats that are not used in storage images.
@@ -8225,51 +8225,51 @@ The following are reserved words:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>_reserved</dfn> :
 
-    | `/asm/`
+    | `'asm'`
 
-    | `/bf16/`
+    | `'bf16'`
 
-    | `/const/`
+    | `'const'`
 
-    | `/do/`
+    | `'do'`
 
-    | `/enum/`
+    | `'enum'`
 
-    | `/f16/`
+    | `'f16'`
 
-    | `/f64/`
+    | `'f64'`
 
-    | `/handle/`
+    | `'handle'`
 
-    | `/i8/`
+    | `'i8'`
 
-    | `/i16/`
+    | `'i16'`
 
-    | `/i64/`
+    | `'i64'`
 
-    | `/mat/`
+    | `'mat'`
 
-    | `/premerge/`
+    | `'premerge'`
 
-    | `/regardless/`
+    | `'regardless'`
 
-    | `/typedef/`
+    | `'typedef'`
 
-    | `/u8/`
+    | `'u8'`
 
-    | `/u16/`
+    | `'u16'`
 
-    | `/u64/`
+    | `'u64'`
 
-    | `/unless/`
+    | `'unless'`
 
-    | `/using/`
+    | `'using'`
 
-    | `/vec/`
+    | `'vec'`
 
-    | `/void/`
+    | `'void'`
 
-    | `/while/`
+    | `'while'`
 </div>
 
 ## Syntactic Tokens ## {#syntactic-tokens}


### PR DESCRIPTION
These are conversion leftovers from past. They should be tokens like the operator strings and not patterns.

cc: @dneto0 (testing CI)