### PR TITLE
Store type for buffer does not have to be structure

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -91,6 +91,8 @@ spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
         text: invalid memory reference; url: invalid-memory-reference
         text: shader-creation error; url: shader-creation-error
         text: pipeline-creation error; url: pipeline-creation-error
+        text: store type; url: store-type
+        text: runtime-sized; url: runtime-sized
 </pre>
 
 <style>
@@ -4939,8 +4941,8 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
                 ::
                     If |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}} is not `0`,
                     then it must be at least the [=minimum binding size=] for the associated buffer variable in the shader.
-                    If the variable has store type |T|, the minimum binding size is max(SizeOf(|T|),AlignOf(|T|)).
-                    In this calculation, if |T| is a runtime-sized array or contains a runtime-sized array,
+                    If the variable has [=store type=] |T|, the minimum binding size is SizeOf(|T|).
+                    In this calculation, if |T| is a [=runtime-sized=] array or contains a runtime-sized array,
                     that array is assumed to have one element.
                     Enforcing this lower bound ensures any memory location accessible via the buffer variable will lie
                     within the mapped buffer region.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4936,12 +4936,14 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
                     </dl>
                 ::
                     If |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}} is not `0`:
-                    - If the last field of the corresponding structure defined in the shader has an unbounded array type,
+                    - If the store type of the corresponding buffer variable in the shader is a structure type, and the
+                        last member of that structure is an runtime-sized array,
                         then the value of |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}}
-                        must be greater than or equal to the byte offset of that field plus the stride of the unbounded array.
-                    - If the corresponding shader structure doesn't end with an unbounded array type,
-                        then the value of |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}}
-                        must be greater than or equal to the size of the structure.
+                        must be greater than or equal to the byte offset of that field plus the element stride of that array.
+                        That is, the binding size must be large enough to cover the whole structure including at least one
+                        element of that array.
+                    - Otherwise, the value of |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}}
+                        must be greater than or equal to the size of the store type of the corresponding buffer variable.
 
                 : {{GPUBindGroupLayoutEntry/sampler}}
                 ::

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -93,6 +93,7 @@ spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
         text: pipeline-creation error; url: pipeline-creation-error
         text: store type; url: store-type
         text: runtime-sized; url: runtime-sized
+        text: SizeOf; url: sizeof
 </pre>
 
 <style>
@@ -4941,11 +4942,13 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
                 ::
                     If |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}} is not `0`,
                     then it must be at least the [=minimum binding size=] for the associated buffer variable in the shader.
-                    If the variable has [=store type=] |T|, the minimum binding size is SizeOf(|T|).
+                    If the variable has [=store type=] |T|, the minimum binding size is [=SizeOf=](|T|).
                     In this calculation, if |T| is a [=runtime-sized=] array or contains a runtime-sized array,
                     that array is assumed to have one element.
-                    Enforcing this lower bound ensures any memory location accessible via the buffer variable will lie
-                    within the mapped buffer region.
+
+                    Enforcing this lower bound ensures that, when this shader is invoked by a draw or dispatch command,
+                    any memory access via the buffer variable will only access memory locations inside the region of the buffer
+                    mapped to the binding in that draw or dispatch command.
 
                 : {{GPUBindGroupLayoutEntry/sampler}}
                 ::

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4945,10 +4945,8 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
                     If the variable has [=store type=] |T|, the minimum binding size is [=SizeOf=](|T|).
                     In this calculation, if |T| is a [=runtime-sized=] array or contains a runtime-sized array,
                     that array is assumed to have one element.
-
-                    Enforcing this lower bound ensures that, when this shader is invoked by a draw or dispatch command,
-                    any memory access via the buffer variable will only access memory locations inside the region of the buffer
-                    mapped to the binding in that draw or dispatch command.
+                    Enforcing this lower bound ensures reads and writes via the buffer variable only access memory locations
+                    within the bound region of the buffer.
 
                 : {{GPUBindGroupLayoutEntry/sampler}}
                 ::

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -77,6 +77,7 @@ spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
     type: dfn
         text: location; url: input-output-locations
         text: interpolation; url: interpolation
+        text: minimum binding size; url: minimum-binding-size
         text: pipeline-overridable; url: pipeline-overridable
         text: pipeline-overridable constant identifier string; url: pipeline-overridable-constant-identifier-string
         text: pipeline-overridable constant has a default value; url: pipeline-overridable-constant-has-a-default-value
@@ -4934,16 +4935,15 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
                         : {{GPUBufferBindingType/"read-only-storage"}}
                         :: |variable| is declared with the storage class `storage` and access mode `read`.
                     </dl>
+
                 ::
-                    If |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}} is not `0`:
-                    - If the store type of the corresponding buffer variable in the shader is a structure type, and the
-                        last member of that structure is an runtime-sized array,
-                        then the value of |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}}
-                        must be greater than or equal to the byte offset of that field plus the element stride of that array.
-                        That is, the binding size must be large enough to cover the whole structure including at least one
-                        element of that array.
-                    - Otherwise, the value of |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}}
-                        must be greater than or equal to the size of the store type of the corresponding buffer variable.
+                    If |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}} is not `0`,
+                    then it must be at least the [=minimum binding size=] for the associated buffer variable in the shader.
+                    If the variable has store type |T|, the minimum binding size is max(SizeOf(|T|),AlignOf(|T|)).
+                    In this calculation, if |T| is a runtime-sized array or contains a runtime-sized array,
+                    that array is assumed to have one element.
+                    Enforcing this lower bound ensures any memory location accessible via the buffer variable will lie
+                    within the mapped buffer region.
 
                 : {{GPUBindGroupLayoutEntry/sampler}}
                 ::

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1267,15 +1267,17 @@ Note: Each member type must be a [=plain type=].
 
 Some consequences of the restrictions structure member and array element types are:
 * A pointer, texture, or sampler must not appear in any level of nesting within an array or structure.
-* A [=runtime-sized=] array must only appear as the last element of a structure, which itself
-    cannot be part of an enclosing array or structure.
+* When a [=runtime-sized=] array is part of a larger type, it may only appear
+    as the last element of a structure, which itself cannot be part of an enclosing array or structure.
 
 <div class='example wgsl global-scope' heading="Structure">
   <xmp highlight='rust'>
-    // A structure with two members.
+    // A structure with four members.
     struct Data {
       a: i32;
       b: vec2<f32>;
+      c: array<i32,10>;
+      d: array<f32>;
     }
   </xmp>
 </div>
@@ -3311,11 +3313,11 @@ Variables at [=module scope=] are restricted as follows:
     have a storage class decoration.  The storage class will always be [=storage classes/handle=].
 
 A variable in the [=storage classes/uniform=] storage class is a <dfn noexport>uniform buffer</dfn> variable.
-Its [=store type=] must be a [=host-shareable=] [=constructible=] structure type,
+Its [=store type=] must be a [=host-shareable=] [=constructible=] type,
 and must satisfy [storage class layout constraints](#storage-class-layout-constraints).
 
 A variable in the [=storage classes/storage=] storage class is a <dfn noexport>storage buffer</dfn> variable.
-Its [=store type=] must be a [=host-shareable=] structure type
+Its [=store type=] must be a [=host-shareable=] type
 and must satisfy [storage class layout constraints](#storage-class-layout-constraints).
 The variable may be declared with a [=access/read=] or [=access/read_write=] access mode; the default is [=access/read=].
 
@@ -3341,13 +3343,9 @@ Such variables are declared with [=attribute/group=] and [=attribute/binding=] d
     @group(0) @binding(2)
     var<uniform> param: Params;    // A uniform buffer
 
-    struct PositionsBuffer {
-      // TODO: runtime-sized array syntax may have changed
-      pos: array<vec2<f32>>;
-    }
     // A storage buffer, for reading and writing
     @group(0) @binding(0)
-    var<storage,read_write> pbuf: PositionsBuffer;
+    var<storage,read_write> pbuf: array<vec2<f32>>;
 
     // Textures and samplers are always in "handle" storage.
     @group(0) @binding(1)

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7094,24 +7094,19 @@ TODO: Describe when filtering or non-filtering samplers are valid.
 
 TODO: Describe when float vs. unfilterable float sampled textures are valid.
 
-If |B| is a [=uniform buffer=] variable in a resource interface,
-and |WB| is the [[WebGPU#buffer-interface|WebGPU GPUBuffer]] bound to |B|, then:
-* The size of |WB| must be at least as large as the size of the [=store type=]
-    of |B| in the [=storage classes/storage=] storage class.
 
-If |B| is a [=storage buffer=] variable in a resource interface,
-and |WB| is the [[WebGPU#buffer-interface|WebGPU GPUBuffer]] bound to |B|, then:
-* If the [=store type=] |S| of |B| does not contain a [=runtime-sized=] array, then
-    the size of |WB| must be at least as large as the size
-    of |S| in the [=storage classes/storage=] storage class.
-* If the [=store type=] |S| of |B| contains a [=runtime-sized=] array as its last member,
-    then:
-    * The runtime-determined array length of that member must be at least 1.
-    * The size of |WB| must be at least as large as the size in
-        storage class [=storage classes/storage=] of the value stored in |B|.
+The region of a [[WebGPU#buffer-interface|WebGPU GPUBuffer]] bound to a buffer variable
+must be large enough to cover all the memory locations accessible via the variable.
+The <dfn noexport>minimium binding size</dfn> of a buffer variable with store type |T| is max([=SizeOf=](|T|),[=AlignOf=](|T|)).
+In this calculation, if |T| is a runtime-sized array or contains a runtime-sized array, that array is assumed
+to have one element.
 
-Note: Recall that a [=runtime-sized=] array may only appear as the last element in the structure
-type that is the store type of a storage buffer variable.
+Note: Naively, a minimum binding size of [=SizeOf=](|T|) should be sufficient.
+However, some underlying implementations require the store type of a buffer variable to be a structure type.
+Requiring the minimum binding size to be at least as large as [=AlignOf=](T) allows an implementation to
+map a non-structure store type |T| in WGSL to a structure type |WrapT| in the underlying shader language, where |WrapT|
+consists of a single member of type |T|.
+The minimum binding sizes of |T| and |WrapT| are equal.
 
 TODO: Describe other interface matching requirements, e.g. for images?
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7097,16 +7097,9 @@ TODO: Describe when float vs. unfilterable float sampled textures are valid.
 
 The region of a [[WebGPU#buffer-interface|WebGPU GPUBuffer]] bound to a buffer variable
 must be large enough to cover all the memory locations accessible via the variable.
-The <dfn noexport>minimium binding size</dfn> of a buffer variable with store type |T| is max([=SizeOf=](|T|),[=AlignOf=](|T|)).
-In this calculation, if |T| is a runtime-sized array or contains a runtime-sized array, that array is assumed
+The <dfn noexport>minimium binding size</dfn> of a buffer variable with store type |T| is [=SizeOf=](|T|).
+In this calculation, if |T| is a [=runtime-sized=] array or contains a runtime-sized array, that array is assumed
 to have one element.
-
-Note: Naively, a minimum binding size of [=SizeOf=](|T|) should be sufficient.
-However, some underlying implementations require the store type of a buffer variable to be a structure type.
-Requiring the minimum binding size to be at least as large as [=AlignOf=](T) allows an implementation to
-map a non-structure store type |T| in WGSL to a structure type |WrapT| in the underlying shader language, where |WrapT|
-consists of a single member of type |T|.
-The minimum binding sizes of |T| and |WrapT| are equal.
 
 TODO: Describe other interface matching requirements, e.g. for images?
 


### PR DESCRIPTION
* Modify an example showing a runtime-sized array as the store type
  for a storage buffer.

Fixes: #2188


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dneto0/gpuweb/pull/2401.html" title="Last updated on Jan 19, 2022, 10:22 PM UTC (bdce411)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2401/66d765b...dneto0:bdce411.html" title="Last updated on Jan 19, 2022, 10:22 PM UTC (bdce411)">Diff</a>