### PR TITLE
Fix size of copyBufferToBuffer command in explainer example.

### DIFF
--- a/explainer/index.bs
+++ b/explainer/index.bs
@@ -848,7 +848,7 @@ When using advanced methods to transfer data to the GPU (with a rolling list of 
                 copyEncoder.copyBufferToBuffer(
                     stagingBuffer, i * 16,
                     uniformBuffer, uniformOffset,
-                    16);
+                    16 * Float32Array.BYTES_PER_ELEMENT);
 
                 encodeDraw(renderPass, {uniformBuffer, uniformOffset});
             }


### PR DESCRIPTION
Double-check me, but since `copyBufferToBuffer` [uses a size expressed in bytes](https://www.w3.org/TR/webgpu/#dom-gpucommandencoder-copybuffertobuffer), and `stagingData` is a `Float32Array`, we should multiply this value by `Float32Array.BYTES_PER_ELEMENT`.