### PR TITLE
Fix GPUBuffer.destroy when "mapping pending"

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2106,7 +2106,8 @@ once all previously submitted operations using it are complete.
 
             **Returns:** {{undefined}}
 
-            1. If the |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapped=] or [=buffer state/mapped at creation=]:
+            1. If the |this|.{{GPUBuffer/[[state]]}} is not either of [=buffer state/unmapped=] or [=buffer state/destroyed=]
+
                 1. Run the steps to unmap |this|.
 
             1. Set |this|.{{GPUBuffer/[[state]]}} to [=buffer state/destroyed=].


### PR DESCRIPTION
Fixes #2410


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/2411.html" title="Last updated on Dec 14, 2021, 8:31 AM UTC (bd7a5ad)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2411/f5ba33b...Kangz:bd7a5ad.html" title="Last updated on Dec 14, 2021, 8:31 AM UTC (bd7a5ad)">Diff</a>