### PR TITLE
Fix classes of examples, globals, and previews

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -70,7 +70,7 @@ jobs:
           export GHC=https://github.com/gpuweb/gpuweb/blob
           export GHCU=https://github.com/${{ github.event.workflow_run.head_repository.full_name }}/blob
           sed -i -e "s,gpuweb/wgsl/</a><br><a href=\"${GHC}/$(git rev-parse HEAD)/wgsl/index.bs\">${GHC}/$(git rev-parse HEAD)/wgsl/index.bs</a>,gpuweb/wgsl/</a><br><a href=\"${GHCU}/${{ github.event.workflow_run.head_sha }}/wgsl/index.bs\">${GHCU}/${{ github.event.workflow_run.head_sha }}/wgsl/index.bs</a>," out/wgsl/index.html
-          sed -i -e "s,gpuweb/spec/</a><br><a href=\"${GHC}/$(git rev-parse HEAD)/spec/index.bs\">${GHC}/$(git rev-parse HEAD)/spec/index.bs</a>,gpuweb/spec/</a><br><a href=\"${GHCU}/${{ github.event.workflow_run.head_sha }}/spec/index.bs\">${GHCU}/${{ github.event.workflow_run.head_sha }}/spec/index.bs</a>," out/index.html
+          sed -i -e "s,gpuweb.github.io/gpuweb/</a><br><a href=\"${GHC}/$(git rev-parse HEAD)/spec/index.bs\">${GHC}/$(git rev-parse HEAD)/spec/index.bs</a>,gpuweb.github.io/gpuweb/</a><br><a href=\"${GHCU}/${{ github.event.workflow_run.head_sha }}/spec/index.bs\">${GHCU}/${{ github.event.workflow_run.head_sha }}/spec/index.bs</a>," out/index.html
 
       # Deploys PR to Firebase
       - name: Deploy PR

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -791,7 +791,7 @@ referenced out of order in the text.
 
 Note: Only a [=function declaration=] can contain other declarations.
 
-<div class='example' heading='Valid and invalid declarations'>
+<div class='example wgsl' heading='Valid and invalid declarations'>
   <xmp>
     // Invalid, cannot reuse built-in function names.
     var<private> modf: f32 = 0.0;
@@ -1041,7 +1041,7 @@ result vector is formed by operating on each component independently.
   </xmp>
 </div>
 
-<div class='example component-wise addition' heading='Component-wise addition'>
+<div class='example wgsl function-scope component-wise addition' heading='Component-wise addition'>
   <xmp highlight='rust'>
     let x : vec3<f32> = a + b; // a and b are vec3<f32>
     // x[0] = a[0] + b[0]
@@ -1121,7 +1121,7 @@ Note that variables in [=storage classes/workgroup=] storage are shared within a
 [=compute shader stage/workgroup=], but are not shared between different
 workgroups.
 
-<div class='example storage atomic' heading='Mapping atomics in a storage variable to SPIR-V'>
+<div class='example wgsl storage atomic' heading='Mapping atomics in a storage variable to SPIR-V'>
   <xmp>
     struct S {
       a: atomic<i32>;
@@ -1146,7 +1146,7 @@ workgroups.
   </xmp>
 </div>
 
-<div class='example workgroup atomic' heading='Mapping atomics in a workgroup variable to SPIR-V'>
+<div class='example wgsl workgroup atomic' heading='Mapping atomics in a workgroup variable to SPIR-V'>
   <xmp>
     var<workgroup> x: atomic<u32>;
 
@@ -1216,7 +1216,7 @@ Two array types are the same if and only if all of the following are true:
 Issue: Array types should differ if they have different element strides.
 See https://github.com/gpuweb/gpuweb/issues/1534
 
-<div class='example fixed-size array types' heading='Example fixed-size array types, non-overridable element count'>
+<div class='example wgsl fixed-size array types' heading='Example fixed-size array types, non-overridable element count'>
   <xmp highlight='rust'>
     // array<f32,8> and array<i32,8> are different types:
     // different element types
@@ -3251,7 +3251,7 @@ When the type is specified, e.g `let foo: i32 = 4`, the initializer expression m
 Some rules about `let`-declarations depend on where the declaration appears.
 See [[#module-constants]] and [[#function-scope-variables]].
 
-<div class='example let declaration at module-scope' heading='let-declared constants at module scope'>
+<div class='example wgsl let declaration at module-scope' heading='let-declared constants at module scope'>
   <xmp highlight='rust'>
     // 'blockSize' denotes the i32 value 1024.
     let blockSize: i32 = 1024;
@@ -3442,7 +3442,7 @@ Such variables are declared with [=attribute/group=] and [=attribute/binding=] d
 <div class='syntax' noexport='true'>
   <dfn for=syntax>global_variable_decl</dfn> :
 
-    | [=syntax/attribute_list=] * [=syntax/variable_decl=] ( [=syntax/equal=] [=syntax/const_expression=] ) ?
+    | [=syntax/attribute_list=] * [=syntax/variable_decl=] ( [=syntax/equal=] ( [=syntax/const_expression=] | [=syntax/ident=] ) ) ?
 </div>
 
 <div class='example' heading="Variable Decorations">
@@ -3521,7 +3521,7 @@ is the one from the constant's declaration or from a pipeline override.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>global_const_initializer</dfn> :
 
-    | [=syntax/equal=] [=syntax/const_expression=]
+    | [=syntax/equal=] ( [=syntax/const_expression=] | [=syntax/ident=] )
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>const_expression</dfn> :
@@ -5992,7 +5992,7 @@ duration of the entry point.
 
 Issue: [[#uniform-control-flow]] needs to state whether all invocations being discarded maintains uniform control flow.
 
-<div class='example' heading='Using the discard statement to throw away a fragment'>
+<div class='example wgsl' heading='Using the discard statement to throw away a fragment'>
   <xmp>
   var<private> will_emit_color: bool = false;
 
@@ -6543,7 +6543,7 @@ parameters and return types:
  * [=attribute/builtin=]
  * [=attribute/location=]
 
-<div class='example' heading='Simple functions'>
+<div class='example wgsl' heading='Simple functions'>
   <xmp>
     // Declare the add_two function.
     // It has two formal paramters, i and b.
@@ -6952,7 +6952,7 @@ Otherwise, the output is a scalar or a vector, and can have only a single locati
 
 Note: The number of available locations for an entry point is defined by the WebGPU API.
 
-<div class='example applying location attribute' heading='Applying location attributes'>
+<div class='example wgsl applying location attribute' heading='Applying location attributes'>
   <xmp>
     struct A {
       [[location(0)]] x: f32;
@@ -6972,7 +6972,7 @@ Note: The number of available locations for an entry point is defined by the Web
 
 User-defined IO can be mixed with builtin variables in the same structure. For example,
 
-<div class='example mixing builtins and user-defined IO' heading='Mixing builtins and user-defined IO'>
+<div class='example wgsl mixing builtins and user-defined IO' heading='Mixing builtins and user-defined IO'>
   <xmp>
     // Mixed builtins and user-defined inputs.
     struct MyInputs {
@@ -6993,7 +6993,7 @@ User-defined IO can be mixed with builtin variables in the same structure. For e
   </xmp>
 </div>
 
-<div class='example invalid locations' heading='Invalid location assignments'>
+<div class='example wgsl invalid locations' heading='Invalid location assignments'>
   <xmp>
     struct A {
       [[location(0)]] x: f32;
@@ -7188,7 +7188,7 @@ Therefore any [SHORTNAME] implementation can parse the entire `enable` directive
 When an implementation encounters an enable directive for an unsupported extension,
 the implementation can issue a clear diagnostic.
 
-<div class='example using extensions' heading="Using hypothetical extensions">
+<div class='example wgsl using extensions' heading="Using hypothetical extensions">
   <xmp>
     // Enable a hypothetical IEEE-754 binary16 floating point extension.
     enable f16;
@@ -7655,7 +7655,7 @@ example, a memory read that accesses a [=u32=] from a struct containing
 multiple members, only reads the memory locations associated with that u32
 member.
 
-<div class='example memory locations accessed' heading="Accessing memory locations">
+<div class='example wgsl memory locations accessed' heading="Accessing memory locations">
   <xmp>
     struct S {
       a : f32;


### PR DESCRIPTION
This PR contains a few fixes and changes. I expect PR checks to fail due to syntax changes.

Fixes are for classes of examples and previews, trivial. Hopefully, all further and new examples will use both "example" and "wgsl" classes to enable the checking.

Changes are for enabling identifier-as-a-value for global declarations for both constants and variables. At least one example wants to demonstrate such use, and I suspect spec already does account for this except for the actual syntax. The syntax does this by going from `| [=syntax/equal=] [=syntax/const_expression=]` to `| [=syntax/equal=] ( [=syntax/const_expression=] | [=syntax/ident=] )`.

I wish everybody a great 2022 with this wrap-up PR!