### PR TITLE
Specify order of evaluation for expressions

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6592,7 +6592,7 @@ A called function <dfn>returns</dfn> as follows:
 
 In detail, when a function call is executed the following steps occur:
 1. Function call argument values are evaluated.
-    The relative order of evaluation is not specified.
+    The relative order of evaluation is left-to-right.
 2. Execution of the [=calling function=] is suspended.
     All [=function scope=] variables and constants maintain their current values.
 3. If the called function is [=user-defined function|user-defined=],
@@ -7269,20 +7269,13 @@ Expression nesting defines data dependencies which must be satisfied to
 complete evaluation.
 That is, a nested expression must be evaluated before the enclosing expression
 can be evaluated.
-The order of evaluation for operands of an expression is not defined by
+The order of evaluation for operands of an expression is left-to-right in
 [SHORTNAME].
-For example, `foo() + bar()` may evaluate either `foo()` or `bar()` first.
+For example, `foo() + bar()` must evaluate `foo()` before `bar()`.
+See [[#expressions]].
 
 Statements in a [SHORTNAME] program are executed in control flow order.
 See [[#statements]] and [[#function-calls]].
-
-#### Function-scope variable lifetime and initialization TODO #### {#function-scope-variable-lifetime}
-
-#### Statement order TODO #### {#statement-order}
-
-#### Intra-statement order (or lack) TODO #### {#intra-statement-order}
-
-TODO: *Stub*: Expression evaluation
 
 ## Uniformity TODO ## {#uniformity}
 


### PR DESCRIPTION
Fixes #2261

* Expressions (and function parameters) are evaluated in left-to-right
  order
* Remove todos that are covered elsewhere in the spec
  * variable lifetime
  * statement and intra-statement order