### PR TITLE
Rely on canvas size instead of allowing size to be configured

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -110,11 +110,20 @@ p, ul, ol, dl {
     margin: 1em 0;
 }
 
-/* Box for Valid Usage requirements. */
-div.validusage {
+/* The new spec template doesn't put a box around algorithms anymore. */
+/* Add a similar box for Valid Usage requirements. */
+div.algorithm, div.validusage {
+    margin: .5em 0;
     padding: .5em;
-    border: thin solid #88e !important;
+    border-width: thin;
+    border-style: solid;
     border-radius: .5em;
+}
+div.validusage {
+    border-color: #88e;
+}
+div.algorithm {
+    border-color: #ddd;
 }
 /*
  * If the Valid Usage requirements are the first child of a *-timeline block give it a larger top
@@ -8598,26 +8607,26 @@ interface GPUCanvasContext {
 {{GPUCanvasContext}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUCanvasContext">
-    : <dfn>\[[validConfiguration]]</dfn> of type boolean, initially `false`.
-    ::
-        Indicates if the context currently has a valid configuration.
-
-    : <dfn>\[[configuration]]</dfn> of type {{GPUCanvasConfiguration}}, initially `null`.
+    : <dfn>\[[configuration]]</dfn> of type {{GPUCanvasConfiguration}}?, initially `null`.
     ::
         The options this context is configured with. `null` if the context has not been configured
-        or the configuration has been removed.
+        or has been {{GPUCanvasContext/unconfigure()|unconfigured}}.
 
-    : <dfn>\[[size]]</dfn> of type {{GPUExtent3D}}
-    ::
-        The size of {{GPUTexture}}s returned from this context.
-        [=Extent3D/depthOrArrayLayers=] is always `1`.
+        Note: The optional {{GPUCanvasConfiguration/width}} and {{GPUCanvasConfiguration/height}}
+        members of this slot are not used. Instead, the size of the canvas
+        (which may be updated during {{GPUCanvasContext/configure()}} or by setting
+        the canvas's `width`/`height` properties) is used.
 
     : <dfn>\[[currentTexture]]</dfn> of type {{GPUTexture}}?, initially `null`
     ::
         The current texture that will be returned by the context when calling
         {{GPUCanvasContext/getCurrentTexture()}}, and the next one to be composited to the
-        document. Initially set to the result of [$allocating a new context texture$] for this
-        context.
+        document.
+
+        When non-`null`, this always has the same dimensions as the canvas and matches the
+        current {{GPUCanvasContext/[[configuration]]}}.
+        Resizing the canvas or calling {{GPUCanvasContext/configure()}}
+        [$invalidate the current texture|invalidates$] this texture.
 </dl>
 
 {{GPUCanvasContext}} has the following methods:
@@ -8638,41 +8647,12 @@ interface GPUCanvasContext {
 
             **Returns:** undefined
 
-            1. Set |this|.{{GPUCanvasContext/[[validConfiguration]]}} to `false`.
+            1. [$invalidate the current texture$] of |this|.
             1. Set |this|.{{GPUCanvasContext/[[configuration]]}} to |configuration|.
-            1. If |this|.{{GPUCanvasContext/[[currentTexture]]}} is not `null` call
-                {{GPUTexture/destroy()}} on |this|.{{GPUCanvasContext/[[currentTexture]]}}.
-            1. Set |this|.{{GPUCanvasContext/[[currentTexture]]}} to `null`.
-            1. Let |device| be |configuration|.{{GPUCanvasConfiguration/device}}.
-            1. Let |canvas| be |this|.{{GPUCanvasContext/canvas}}.
-            1. If |configuration|.{{GPUCanvasConfiguration/size}} is `undefined` set
-                |this|.{{GPUCanvasContext/[[size]]}} to [|canvas|.width, |canvas|.height, 1],
-                otherwise set |this|.{{GPUCanvasContext/[[size]]}} to
-                |configuration|.{{GPUCanvasConfiguration/size}}.
-
-            1. Issue the following steps on the [=Device timeline=] of |device|:
-                <div class=device-timeline>
-                    1. If any of the following conditions are unsatisfied:
-                        <div class=validusage>
-                            - |device| is a [=valid=] {{GPUDevice}}.
-                            - [=Supported context formats=] [=set/contains=]
-                                |configuration|.{{GPUCanvasConfiguration/format}}.
-                            - |this|.{{GPUCanvasContext/[[size]]}}.[=Extent3D/width=] &gt; 0.
-                            - |this|.{{GPUCanvasContext/[[size]]}}.[=Extent3D/width=] &le;
-                                |device|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
-                            - |this|.{{GPUCanvasContext/[[size]]}}.[=Extent3D/height=] &gt; 0.
-                            - |this|.{{GPUCanvasContext/[[size]]}}.[=Extent3D/height=] &le;
-                                |device|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
-                            - |this|.{{GPUCanvasContext/[[size]]}}.[=Extent3D/depthOrArrayLayers=]
-                                is 1;
-                        </div>
-
-                        Then:
-                            1. Generate a {{GPUValidationError}} in the current scope with appropriate
-                                error message.
-                            1. Return.
-                </div>
-            1. Set |this|.{{GPUCanvasContext/[[validConfiguration]]}} to `true`.
+            1. If |configuration|.{{GPUCanvasConfiguration/width}} is [=map/exists|specified=], set
+                |this|.{{GPUCanvasContext/canvas}}.`width` to |configuration|.{{GPUCanvasConfiguration/width}}.
+            1. If |configuration|.{{GPUCanvasConfiguration/height}} is [=map/exists|specified=], set
+                |this|.{{GPUCanvasContext/canvas}}.`height` to |configuration|.{{GPUCanvasConfiguration/height}}.
         </div>
 
     : <dfn>unconfigure()</dfn>
@@ -8684,11 +8664,8 @@ interface GPUCanvasContext {
 
             **Returns:** undefined
 
-            1. Set |this|.{{GPUCanvasContext/[[validConfiguration]]}} to `false`.
+            1. [$invalidate the current texture$] of |this|.
             1. Set |this|.{{GPUCanvasContext/[[configuration]]}} to `null`.
-            1. If |this|.{{GPUCanvasContext/[[currentTexture]]}} is not `null` call
-                {{GPUTexture/destroy()}} on |this|.{{GPUCanvasContext/[[currentTexture]]}}.
-            1. Set |this|.{{GPUCanvasContext/[[currentTexture]]}} to `null`.
         </div>
 
     : <dfn>getPreferredFormat(adapter)</dfn>
@@ -8722,8 +8699,7 @@ interface GPUCanvasContext {
 
             **Returns:** {{GPUTexture}}
 
-            1. If |this|.{{GPUCanvasContext/[[configuration]]}} is `null`:
-                1. Throw an {{OperationError}} and stop.
+            1. If |this|.{{GPUCanvasContext/[[configuration]]}} is `null`, throw an {{InvalidStateError}}.
             1. If |this|.{{GPUCanvasContext/[[currentTexture]]}} is `null` or
                 |this|.{{GPUCanvasContext/[[currentTexture]]}}.{{GPUTexture/[[destroyed]]}} is true:
                 1. Set |this|.{{GPUCanvasContext/[[currentTexture]]}} to the result of [$allocating
@@ -8733,7 +8709,8 @@ interface GPUCanvasContext {
 
         Note: Developers can expect that the same {{GPUTexture}} object will be returned by every
         call to {{GPUCanvasContext/getCurrentTexture()}} made within the same frame (i.e. between
-        invocations of [=Update the rendering=]) unless {{GPUCanvasContext/configure()}} is called.
+        invocations of [=Update the rendering=]) unless the current texture has been
+        [$invalidate the current texture|invalidated$].
 </dl>
 
 <div algorithm>
@@ -8771,21 +8748,23 @@ interface GPUCanvasContext {
     they <dfn abstract-op>get a copy of the image contents of a context</dfn>:
 
     **Arguments:**
-    |context|: the {{GPUCanvasContext}}
+    - |context|: the {{GPUCanvasContext}}
 
     **Returns:** image contents
 
     1. Let |texture| be |context|.{{GPUCanvasContext/[[currentTexture]]}}.
-    1. If any of the following requirements is unmet, return a transparent black image of size
-        |context|.{{GPUCanvasContext/[[size]]}} and stop.
+    1. If any of the following requirements is unmet:
+
         <div class=validusage>
             - |texture| must not be `null`.
             - |texture|.{{GPUTexture/[[destroyed]]}} must be false.
             - If |context|.{{GPUCanvasContext/canvas}} is an {{OffscreenCanvas}},
                 it must not be linked to a [=placeholder canvas element=].
 
-                Issue: If added, canvas must also not be `desynchronized`.
+            Issue: Canvas must also not be desynchronized, if such an option is added.
         </div>
+
+        Then return a transparent black image with the size of the |context|.{{GPUCanvasContext/canvas}}.
     1. Ensure that all submitted work items (e.g. queue submissions) have
         completed writing to |texture|.
     1. Return the contents of |texture|, tagged as having alpha premultiplied, and with the color space
@@ -8798,22 +8777,34 @@ interface GPUCanvasContext {
     To <dfn abstract-op lt='allocating a new context texture'>allocate a new context texture</dfn>
     for {{GPUCanvasContext}} |context| run the following steps:
 
-        1. Let |device| be |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/device}}.
-        1. If |context|.{{GPUCanvasContext/[[validConfiguration]]}} is `false`:
-            1. Generate a {{GPUValidationError}} in the current scope of |device| with an appropriate error message.
-            1. Return a new [=invalid=] {{GPUTexture}}.
-        1. Let |textureDescriptor| be a new {{GPUTextureDescriptor}}.
-        1. Set |textureDescriptor|.{{GPUTextureDescriptor/size}} to |context|.{{GPUCanvasContext/[[size]]}}.
-        1. Set |textureDescriptor|.{{GPUTextureDescriptor/format}} to
-            |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/format}}.
-        1. Set |textureDescriptor|.{{GPUTextureDescriptor/usage}} to
-            |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/usage}}.
-        1. Let |texture| be a new {{GPUTexture}} created as if |device|.{{GPUDevice/createTexture()}}
-            were called with |textureDescriptor|.
-            <div class='note'>If a previously presented texture from |context| matches the required criteria,
-            its GPU memory may be re-used.</div>
-        1. Ensure |texture| is cleared to `(0, 0, 0, 0)`.
-        1. Return |texture|.
+    1. Assert |context|.{{GPUCanvasContext/[[configuration]]}} is not `null`.
+    1. Let |device| be |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/device}}.
+    1. Let |textureDescriptor| be a new {{GPUTextureDescriptor}}.
+    1. Set |textureDescriptor|.{{GPUTextureDescriptor/size}} to
+        [|context|.{{GPUCanvasContext/canvas}}.width, |context|.{{GPUCanvasContext/canvas}}.height].
+    1. Set |textureDescriptor|.{{GPUTextureDescriptor/format}} to
+        |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/format}}.
+    1. Set |textureDescriptor|.{{GPUTextureDescriptor/usage}} to
+        |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/usage}}.
+    1. Let |texture| be a new {{GPUTexture}} created as if |device|.{{GPUDevice/createTexture()}}
+        were called with |textureDescriptor|.
+
+        Note: This results in an [=invalid=] {{GPUTexture}} and generates an error if the
+        texture can't be created (e.g. the texture size is larger than the device's
+        {{GPUSupportedLimits/maxTextureDimension2D}}.
+
+        Note: If a previously presented texture from |context| matches the required criteria,
+        its GPU memory may be re-used.
+    1. Ensure |texture| is cleared to `(0, 0, 0, 0)`.
+    1. Return |texture|.
+</div>
+
+<div algorithm>
+    To <dfn abstract-op>invalidate the current texture</dfn> of a {{GPUCanvasContext}} |context|:
+
+    1. If |context|.{{GPUCanvasContext/[[currentTexture]]}} is not `null`, call its
+        {{GPUTexture/destroy()}} method.
+    1. Set |context|.{{GPUCanvasContext/[[currentTexture]]}} to `null`.
 </div>
 
 ## GPUCanvasConfiguration ## {#canvas-configuration}
@@ -8825,7 +8816,6 @@ initially set to: &laquo;{{GPUTextureFormat/"bgra8unorm"}}, {{GPUTextureFormat/"
 {{GPUTextureFormat/"rgba8unorm"}}, {{GPUTextureFormat/"rgba8unorm-srgb"}}&raquo;.
 
 <script type=idl>
-
 enum GPUCanvasCompositingAlphaMode {
     "opaque",
     "premultiplied",
@@ -8837,7 +8827,8 @@ dictionary GPUCanvasConfiguration {
     GPUTextureUsageFlags usage = 0x10;  // GPUTextureUsage.RENDER_ATTACHMENT
     GPUPredefinedColorSpace colorSpace = "srgb";
     GPUCanvasCompositingAlphaMode compositingAlphaMode = "opaque";
-    GPUExtent3D size;
+    GPUIntegerCoordinate width;
+    GPUIntegerCoordinate height;
 };
 </script>
 
@@ -8856,24 +8847,16 @@ high dynamic range is explicitly enabled for the canvas element.
 
 ### Canvas Context sizing ### {#context-sizing}
 
-A {{GPUCanvasContext}}'s {{GPUCanvasContext/[[size]]}} is set by the {{GPUCanvasConfiguration}}
-passed to {{GPUCanvasContext/configure()}}, and remains the same until {{GPUCanvasContext/configure()}}
-is called again with a new size. If a {{GPUCanvasConfiguration/size}} is not specified then the
-width and height attributes of the {{GPUCanvasContext}}.{{GPUCanvasContext/canvas}}
-at the time {{GPUCanvasContext/configure()}} is called will be used. If
-{{GPUCanvasContext}}.{{GPUCanvasContext/[[size]]}} does not match the dimensions of the canvas
-the textures produced by the {{GPUCanvasContext}} will be scaled to fit the canvas element.
+A WebGPU canvas's size is set by the `width` and `height` properties of the canvas.
+Calling {{GPUCanvasContext/configure()}} with the optional {{GPUCanvasConfiguration/width}} and/or
+{{GPUCanvasConfiguration/height}} members also sets the `width`/`height` properties of the canvas.
 
-<div class="note">
-    Note: Unlike `'webgl'` or `'2d'` contexts, `width` and `height` attributes of canvases with a
-    `'webgpu'` context only affect:
-    - Default layout size, if not overridden by CSS.
-    - Default {{GPUCanvasConfiguration}}.{{GPUCanvasConfiguration/size}} when calling
-        {{GPUCanvasContext/configure()}}, if not overridden.
+<div algorithm="resize a WebGPU canvas">
+    When a canvas with a {{GPUCanvasContext}} |context| is resized (has its `width` or `height`
+    property changed to a new, different value), the current texture gets destroyed:
+
+    1. [$invalidate the current texture$] of |context|.
 </div>
-
-If it is desired to match the dimensions of the canvas after it is resized, the {{GPUCanvasContext}}
-must be reconfigured by calling {{GPUCanvasContext/configure()}} again with the new dimensions.
 
 <div class="example">
     Reconfigure a {{GPUCanvasContext}} in response to canvas resize, monitored using
@@ -8882,20 +8865,15 @@ must be reconfigured by calling {{GPUCanvasContext/configure()}} again with the 
 
     <pre highlight="js">
         const canvas = document.createElement('canvas');
-        const context =  canvas.getContext('webgpu');
+        const context = canvas.getContext('webgpu');
 
         const resizeObserver = new ResizeObserver(entries => {
             for (const entry of entries) {
                 if (entry != canvas) { continue; }
-                context.configure({
-                    device: someDevice,
-                    format: context.getPreferredFormat(someDevice.adapter),
-                    size: {
-                        // This reports the size of the canvas element in pixels
-                        width: entry.devicePixelContentBoxSize[0].inlineSize,
-                        height: entry.devicePixelContentBoxSize[0].blockSize,
-                    }
-                });
+                // This reports the size of the canvas element in pixels
+                canvas.width = entry.devicePixelContentBoxSize[0].inlineSize;
+                canvas.height = entry.devicePixelContentBoxSize[0].blockSize;
+                // (Alternatively, call context.configure() with the new width/height.)
             }
         });
         resizeObserver.observe(canvas);
@@ -8918,16 +8896,16 @@ This enum selects how the contents of the canvas' context will paint onto the pa
         <td>{{GPUCanvasCompositingAlphaMode/opaque}}
         <td>Paint RGB as opaque and ignore alpha values.
             If the content is not already opaque, implementations may need to clear alpha to opaque during presentation.
-        <td>|dst.rgb = src.rgb|
-        <td>|dst.a = 1|
+        <td>`dst.rgb = src.rgb`
+        <td>`dst.a = 1`
     <tr>
         <td>{{GPUCanvasCompositingAlphaMode/premultiplied}}
         <td>Composite assuming color values are premultiplied by their alpha value.
             100% red 50% opaque is [0.5, 0, 0, 0.5].
             Color values must be less than or equal to their alpha value.
             [1.0, 0, 0, 0.5] is "super-luminant" and cannot reliably be displayed.
-        <td>|dst.rgb = src.rgb + dst.rgb*(1-src.a)|
-        <td>|dst.a = src.a + dst.a*(1-src.a)|
+        <td>`dst.rgb = src.rgb + dst.rgb * (1 - src.a)`
+        <td>`dst.a = src.a + dst.a * (1 - src.a)`
 </table>
 
 # Errors &amp; Debugging # {#errors-and-debugging}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8777,7 +8777,7 @@ interface GPUCanvasContext {
     To <dfn abstract-op lt='allocating a new context texture'>allocate a new context texture</dfn>
     for {{GPUCanvasContext}} |context| run the following steps:
 
-    1. Assert |context|.{{GPUCanvasContext/[[configuration]]}} is not `null`.
+    1. [=Assert=]: |context|.{{GPUCanvasContext/[[configuration]]}} is not `null`.
     1. Let |device| be |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/device}}.
     1. Let |textureDescriptor| be a new {{GPUTextureDescriptor}}.
     1. Set |textureDescriptor|.{{GPUTextureDescriptor/size}} to


### PR DESCRIPTION
Notably, this means implementations may want to (at least sometimes) defer allocating underlying textures (or swap chains) until the first getCurrentTexture() call, e.g. after the canvas width changes to avoid reallocating before the canvas height is set.

Related: #2300


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2416.html" title="Last updated on Feb 12, 2022, 1:19 AM UTC (ae4866d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2416/eb39ff6...kainino0x:ae4866d.html" title="Last updated on Feb 12, 2022, 1:19 AM UTC (ae4866d)">Diff</a>