### PR TITLE
Officially add Brandon as a spec editor

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -11,6 +11,7 @@ Repository: gpuweb/gpuweb
 
 Editor: Dzmitry Malyshau, Mozilla https://www.mozilla.org, dmalyshau@mozilla.com, w3cid 96977
 Editor: Kai Ninomiya, Google https://www.google.com, kainino@google.com, w3cid 99487
+Editor: Brandon Jones, Google https://www.google.com, bajones@google.com, w3cid 87824
 Former Editor: Justin Fan, Apple https://www.apple.com, justin_fan@apple.com, w3cid 115633
 Abstract: WebGPU exposes an API for performing operations, such as rendering and computation, on a Graphics Processing Unit.
 Markup Shorthands: markdown yes


### PR DESCRIPTION
Brandon has de facto equal standing as an editor and I think it's time to recognize it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2418.html" title="Last updated on Dec 16, 2021, 12:47 AM UTC (fbc4511)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2418/eb39ff6...kainino0x:fbc4511.html" title="Last updated on Dec 16, 2021, 12:47 AM UTC (fbc4511)">Diff</a>