### PR TITLE
Require buffer bindings to have non-zero size

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3870,7 +3870,7 @@ A {{GPUBindGroup}} object has the following internal slots:
                                             - |resource| is a {{GPUBufferBinding}}.
                                             - |resource|.{{GPUBufferBinding/buffer}} is [$valid to use with$] |this|.
                                             - The bound part designated by |resource|.{{GPUBufferBinding/offset}} and
-                                                |resource|.{{GPUBufferBinding/size}} resides inside the buffer.
+                                                |resource|.{{GPUBufferBinding/size}} resides inside the buffer and has non-zero size.
                                             - [$effective buffer binding size$](|resource|), is greater than or equal to
                                                 |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}}.
 


### PR DESCRIPTION
Fixes #686


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2419.html" title="Last updated on Dec 16, 2021, 12:50 AM UTC (b0d09d7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2419/eb39ff6...kainino0x:b0d09d7.html" title="Last updated on Dec 16, 2021, 12:50 AM UTC (b0d09d7)">Diff</a>