### PR TITLE
Disallow empty buffer/texture usages

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2047,6 +2047,7 @@ namespace GPUBufferUsage {
             1. If any of the following conditions are unsatisfied, return an error buffer and stop.
                 <div class=validusage>
                     - |this| is a [=valid=] {{GPUDevice}}.
+                    - |descriptor|.{{GPUBufferDescriptor/usage}} must not be 0.
                     - |descriptor|.{{GPUBufferDescriptor/usage}} is a subset of |this|.[[allowed buffer usages]].
                     - If |descriptor|.{{GPUBufferDescriptor/usage}} contains {{GPUBufferUsage/MAP_READ}}:
                         - |descriptor|.{{GPUBufferDescriptor/usage}} contains no other flags
@@ -2435,6 +2436,7 @@ namespace GPUTextureUsage {
                     1. If any of the following requirements are unmet:
                         <div class=validusage>
                             - |this| must be a [=valid=] {{GPUDevice}}.
+                            - |descriptor|.{{GPUTextureDescriptor/usage}} must not be 0.
                             - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=],
                                 |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=],
                                 and |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be greater than zero.


### PR DESCRIPTION
Fixes #1001


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2422.html" title="Last updated on Dec 16, 2021, 1:29 AM UTC (935c842)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2422/eb39ff6...kainino0x:935c842.html" title="Last updated on Dec 16, 2021, 1:29 AM UTC (935c842)">Diff</a>