### PR TITLE
Remove [SameObject] from GPUUncapturedErrorEvent.error

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9013,13 +9013,27 @@ interface GPUUncapturedErrorEvent : Event {
         DOMString type,
         GPUUncapturedErrorEventInit gpuUncapturedErrorEventInitDict
     );
-    [SameObject] readonly attribute GPUError error;
+    readonly attribute GPUError error;
 };
 
 dictionary GPUUncapturedErrorEventInit : EventInit {
     required GPUError error;
 };
 </script>
+
+<dl dfn-type=attribute dfn-for=GPUUncapturedErrorEvent>
+    : <dfn>error</dfn>
+    ::
+        Object representing the error that was uncaptured.
+        This has the same type as errors returned by {{GPUDevice/popErrorScope()}}.
+
+        This attribute is backed by an immutable internal slot of the same name, and
+        always returns its value.
+
+        Issue(whatwg/webidl#1077): This attribute should be `[SameObject]`.
+        (If GPUError [becomes an interface](https://github.com/gpuweb/gpuweb/issues/1884) then
+        we can do this without resolving the WebIDL issue.)
+</dl>
 
 <script type=idl>
 partial interface GPUDevice {


### PR DESCRIPTION
Implements the same behavior by prose rather than by WebIDL attribute.
The WebIDL attribute isn't currently valid on union types, and we have
to define this in prose anyway since [SameObject] is pure documentation
(has no behavioral impact on its own).

Fixes #1225


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2423.html" title="Last updated on Dec 24, 2021, 12:58 AM UTC (3cdf3d1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2423/899753b...kainino0x:3cdf3d1.html" title="Last updated on Dec 24, 2021, 12:58 AM UTC (3cdf3d1)">Diff</a>