### PR TITLE
Specify that filtering with comparison is implementation-defined

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5220,8 +5220,8 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         1. Let |texture| be the {{GPUBindGroupLayoutEntry}} corresponding to the sampled texture in the call.
         1. Let |sampler| be the {{GPUBindGroupLayoutEntry}} corresponding to the used sampler in the call.
         1. If |sampler|.{{GPUSamplerBindingLayout/type}} is {{GPUSamplerBindingType/"filtering"}},
-            then |texture|.{{GPUTextureBindingLayout/sampleType}} must not be
-            {{GPUTextureSampleType/"unfilterable-float"}}.
+            then |texture|.{{GPUTextureBindingLayout/sampleType}} must be
+            {{GPUTextureSampleType/"float"}}.
     - For each |key| in [=map/get the keys|the keys=] of
         |descriptor|.{{GPUProgrammableStage/constants}}:
         - |key| must equal the [=pipeline-overridable constant identifier string=] of

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3657,7 +3657,8 @@ dictionary GPUSamplerDescriptor : GPUObjectDescriptorBase {
 - {{GPUSamplerDescriptor/lodMinClamp}} and {{GPUSamplerDescriptor/lodMaxClamp}} specify the minimum and
     maximum levels of detail, respectively, used internally when sampling a texture.
 - If {{GPUSamplerDescriptor/compare}} is provided, the sampler will be a comparison sampler with the specified
-    {{GPUCompareFunction}}.
+    {{GPUCompareFunction}}. Comparison samplers may use filtering, but the sampling results will be
+    implementation-dependent and may differ from the normal filtering rules.
 - {{GPUSamplerDescriptor/maxAnisotropy}} specifies the maximum anisotropy value clamp used by the sampler.
 
     Note: Most implementations support {{GPUSamplerDescriptor/maxAnisotropy}} values in range between 1 and 16, inclusive.
@@ -11575,7 +11576,8 @@ All [=depth-or-stencil formats=] support the {{GPUTextureUsage/COPY_SRC}}, {{GPU
 All of these formats support multisampling.
 However, certain copy operations also restrict the source and destination formats.
 
-None of the depth formats can be filtered.
+Depth textures cannot be used with {{GPUSamplerBindingType/"filtering"}} samplers, but can always
+be used with {{GPUSamplerBindingType/"comparison"}} samplers (which may use filtering).
 
 <table class='data'>
     <thead>


### PR DESCRIPTION
And specify that comparison+filtering is always allowed, but non-comparison+filtering is never allowed. Investigation indicates this is the best we can support on Vulkan for any format.

Fixes #1266


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2425.html" title="Last updated on May 3, 2022, 10:25 PM UTC (4b85a62)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2425/f7f5a0a...kainino0x:4b85a62.html" title="Last updated on May 3, 2022, 10:25 PM UTC (4b85a62)">Diff</a>