### PR TITLE
Behaviour of empty statement is {Next}

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6107,7 +6107,7 @@ The reason is that only functions without a return type can have such a [=behavi
     <tr><th>Statement<th>Preconditions<th>Resulting behavior
   </thead>
   <tr>
-    <td class="nowrap">{ }
+    <td class="nowrap">*empty statement*
     <td>
     <td class="nowrap">{Next}
   <tr algorithm="braced statement behavior">
@@ -6213,6 +6213,8 @@ The reason is that only functions without a return type can have such a [=behavi
         Break is in (|B1| &cup; ... &cup; |Bn|)
     <td class="nowrap">(|B| &cup; |B1| &cup; ... &cup; |Bn| &cup; {Next})&#x2216;{Break, Fallthrough}
 </table>
+
+Note: The empty statement case occurs when a `loop` has an empty body, or when a `for` loop lacks an initialization or update statement.
 
 For the purpose of this analysis:
 - `for` loops get desugared (see [[#for-statement]])


### PR DESCRIPTION
Fixes: #2431