### PR TITLE
wgsl: Fix TODOs in Execution section

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -180,6 +180,7 @@ A shader comprises:
 * The set of types used to define or analyze all those functions, variables, and constants.
 
 When executing a shader stage, the implementation:
+* Computes the values of constants declared at [=module scope|module-scope=].
 * Binds [=resources=] to variables in the shader's [=resource interface of a shader|resource interface=],
     making the contents of those resources available to the shader during execution.
 * Allocates memory for other [=module scope|module-scope=] variables,
@@ -7317,20 +7318,13 @@ A [SHORTNAME] program is a sequence of optional [=directives=] followed by [=mod
     | [=syntax/function_decl=]
 </div>
 
-# Execution TODO # {#execution}
+# Execution # {#execution}
 
-## Invocation of an entry point TODO ## {#invocation-of-an-entry-point}
+[[#technical-overview]] describes how a shader is invoked and partitioned into [=invocations=].
+This section describes further constraints on how invocations execute,
+individually and collectively.
 
-### Before an entry point begins TODO ### {#before-entry-point-begins}
-
-TODO: *Stub*
-
-* Setting values of builtin variables
-* External-interface variables have initialized backing storage
-* Internal module-scope variables have backing storage
-  * Initializers evaluated in textual order
-
-### Program order (within an invocation) ### {#program-order}
+## Program order within an invocation ## {#program-order}
 
 Each statement in a [SHORTNAME] program may be executed zero or more times during
 execution.


### PR DESCRIPTION
- in Technical overiew, say that evaluation of module-scope constants
  is the first thing to be executed
- Remove "Before an entry point begins" because that's now fully covered
  by the Technical overview
- Add introductory prose in the "Execution" top level section
- remove parens from "Program order (within an invocation)" section.