### PR TITLE
Remove [[block]] attribute from sample

### DIFF
--- a/samples/hello-cube.html
+++ b/samples/hello-cube.html
@@ -20,7 +20,6 @@ struct FragmentData {
     [[location(${colorLocation})]] color: vec4<f32>;
 };
 
-[[block]]
 struct Uniforms {
     modelViewProjectionMatrix: mat4x4<f32>;
 };


### PR DESCRIPTION
The [[block]] attribute has been removed late November. Therefore, also remove it from the sample.