### PR TITLE
wgsl: Fix "Entry Point" section TODOs

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -678,9 +678,9 @@ An attribute must not be specified more than once per object or type.
 
   <tr><td><dfn noexport dfn-for="attribute">`stage`</dfn>
     <td>`compute`, `vertex`, or `fragment`
-    <td>Must only be applied to a function declaration.
+    <td>Must only be applied to a [=function declaration=].
 
-    Declares an entry point by specifying its pipeline stage.
+    Declares an [=entry point=] by specifying its [[#shader-stages-sec|pipeline stage]].
 
   <tr><td><dfn noexport dfn-for="attribute">`stride`</dfn>
     <td>positive i32 literal
@@ -6740,7 +6740,10 @@ of declarations.
 
 Issue: Revisit aliasing rules for clarity.
 
-# Entry Points TODO # {#entry-points}
+# Entry Points # {#entry-points}
+
+An <dfn noexport>entry point</dfn> is a [=user-defined function=] that performs
+the work for a particular [=shader stage=].
 
 ## Shader Stages ## {#shader-stages-sec}
 
@@ -6748,7 +6751,7 @@ WebGPU issues work to the GPU in the form of [=draw command|draw=] or [=dispatch
 These commands execute a pipeline in the context of a set of
 [=pipeline input|inputs=], [=pipeline output|outputs=], and attached [=resources=].
 
-A <dfn noexport>pipeline</dfn> describes the behaviour to be performed on the GPU, as a sequence
+A <dfn noexport>pipeline</dfn> describes the work to be performed on the GPU, as a sequence
 of stages, some of which are programmable.
 In WebGPU, a pipeline is created before scheduling a draw or dispatch command for execution.
 There are two kinds of pipelines: GPUComputePipeline, and GPURenderPipeline.
@@ -6783,19 +6786,17 @@ Each shader stage has its own set of features and constraints, described elsewhe
 
 ## Entry point declaration ## {#entry-point-decl}
 
-An <dfn noexport>entry point</dfn> is a [=user-defined function=] that is invoked to perform
-the work for a particular [=shader stage=].
+To create an [=entry point=], declare a [=user-defined function=] with a [=attribute/stage=] attribute.
 
-Specify a `stage` attribute on a [=function declaration=] to declare that function
-as an entry point.
+When configuring a [=pipeline=] in the WebGPU API,
+the entry point's function name maps to the `entryPoint` attribute of the
+[[WebGPU#GPUProgrammableStage]] object.
 
-When configuring the stage in the pipeline, the entry point is specified by providing
-the [SHORTNAME] module and the entry point's function name.
+The entry point's [=formal parameters=] form the stage's [=pipeline inputs=].
+The entry point's [=return type=], if specified, forms the stage's [=pipeline output=].
+Each input and output must be an [=entry point IO type=].
 
-The parameters of an entry point have to be within [=Entry point IO type=]s.
-The return type of an entry point has to be of an [=Entry point IO type=], if specified.
-
-Note: compute entry points never have a return type.
+Note: [=Compute=] entry points never have a return type.
 
 <div class='example wgsl global-scope' heading='Entry Point'>
   <xmp>
@@ -6901,7 +6902,7 @@ More precisely, the <dfn noexport>interface of a shader stage</dfn> consists of:
 
 ### Pipeline Input and Output Interface ### {#pipeline-inputs-outputs}
 
-The <dfn dfn>Entry point IO type</dfn>s include the following:
+The <dfn dfn>entry point IO type</dfn>s include the following:
   - Built-in variables. See [[#builtin-inputs-outputs]].
   - User-defined IO. See [[#user-defined-inputs-outputs]]
   - Structures containing only built-in variables and user-defined IO.


### PR DESCRIPTION
- Link 'stage' attribute text to definitions later on
- Move definition of "entry point" to the top of the "Entry Points"
  section, away from the "Entry point declaration" section.
- Rework and simplify the first part of "Entry point declaration".
  Link to other parts of the spec, e.g. to user-defined function.