### PR TITLE
wgsl: fold expression semantics text into definition of type rule

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -884,8 +884,9 @@ Note: [SHORTNAME] [=reference types=] are not written in [SHORTNAME] programs. S
 
 A [SHORTNAME] value is computed by evaluating an expression.
 An <dfn noexport>expression</dfn> is a segment of source text
-parsed as one of the [SHORTNAME] grammar rules whose name ends with "`_expression`".
-An expression *E* can contain <dfn noexport>subexpressions</dfn> which are expressions properly contained
+parsed as one of the [SHORTNAME] grammar rules whose name ends with "`_expression`".  See [[#expression-grammar]].
+
+An expression *E* can contain <dfn noexport>subexpressions</dfn>, which are the expressions properly contained
 in the outer expression *E*.
 
 The particular value produced by an expression evaluation depends on:
@@ -919,16 +920,27 @@ Note: A type assertion is a statement of fact about the text of a program.
 It is not a runtime check.
 
 Finding static types for expressions can be performed by recursively applying type rules.
-A <dfn noexport>type rule</dfn> has two parts:
-* A conclusion, stated as a type assertion for an expression.
-    The expression in the type assertion is specified schematically,
-    using *italicized* names to denote subexpressions
-    or other syntactically-determined parameters.
-* Preconditions, consisting of:
+A <dfn noexport>type rule</dfn> has three parts:
+* A <dfn noexport lt="type rule conclusion">Conclusion</dfn>, stated as a [=type assertion=] for an expression.
+    * The expression in the type assertion is specified schematically,
+        using *italicized* names to denote subexpressions
+        or other syntactically-determined parameters.
+* <dfn noexport lt="type rule preconditions">Preconditions</dfn>, consisting of:
     * Type assertions for subexpressions, when there are subexpressions.
     * Conditions on the other schematic parameters, if any.
     * How the expression is used in a statement.
     * Optionally, other static context.
+* <dfn noexport lt="semantics of an expression">Semantics</dfn>, which is the effect of evaluating the expression,
+    assuming the preconditions.
+    * The primary effect is the production of a result value.
+    * The semantics usually depends on the values produced by evaluating the [=subexpressions=], when present.
+    * The semantics can include other kinds of effects.
+         When these are visible outside of the production of the result value, they are known as <dfn noexport>side effects</dfn>.
+         For example, when calling a function during evaluation of a subexpression, that function may change
+         the contents of a variable.
+
+The [SHORTNAME] [=type rules=] are organized into <dfn noexport>type rule tables</dfn>,
+with one row per type rule.
 
 Each distinct type parameterization for a type rule is called an <dfn noexport>overload</dfn>.
 For example, [[#arithmetic-expr|unary negation]] (an expression of the form `-`|e|)
@@ -960,21 +972,6 @@ Otherwise there is a <dfn noexport>type error</dfn> and the source program is no
 [SHORTNAME] is a <dfn noexport>statically typed language</dfn>
 because type checking a [SHORTNAME] program will either succeed or
 discover a type error, while only having to inspect the program source text.
-
-### Type rule tables ### {#typing-tables-section}
-
-The [SHORTNAME] [=type rules=] are organized into <dfn noexport>type rule tables</dfn>,
-with one row per type rule.
-
-The <dfn noexport>semantics of an expression</dfn> is the effect of evaluating that expression,
-and is primarily the production of a result value.
-The *Description* column of the type rule that applies to an expression will specify the expression's semantics.
-The semantics usually depends on the values of the type rule parameters, including
-the assumed values of any subexpressions.
-Sometimes the semantics of an expression includes effects other than producing
-a result value, such as the non-result-value effects of its subexpressions.
-
-TODO: example: non-result-value effect is any side effect of a function call subexpression.
 
 ## Plain Types ## {#plain-types-section}
 


### PR DESCRIPTION
Editorial changes only.
Fixes a TODO about describing side effects.

- Move the text about "type rule table" to just after the definition of
  a type rule.  A type rule table is just a bunch of type rules.
- Move the text about expression semantics into the definition of a
  type rule. It belongs there because the semantics is so heavily dependent
  on the other context in the associated type rule.
- Give the the example of side effects as part of the semantics of
  evaluating the expression.
- Eliminate the "Type rule tables" section, because now it would be
  empty.