### PR TITLE
Disallow pipe for hex literals and allow capital

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -481,17 +481,17 @@ The form of a [=numeric literal=] is defined via pattern-matching:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>hex_float_literal</dfn> :
 
-    | `/-?0[x|X]((([0-9a-fA-F]*\.[0-9a-fA-F]+|[0-9a-fA-F]+\.[0-9a-fA-F]*)((p|P)(\+|-)?[0-9]+f?)?)|([0-9a-fA-F]+(p|P)(\+|-)?[0-9]+f?))/`
+    | `/-?0[xX]((([0-9a-fA-F]*\.[0-9a-fA-F]+|[0-9a-fA-F]+\.[0-9a-fA-F]*)((p|P)(\+|-)?[0-9]+f?)?)|([0-9a-fA-F]+(p|P)(\+|-)?[0-9]+f?))/`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>int_literal</dfn> :
 
-    | `/-?0[x|x][0-9a-fA-F]+|0|-?[1-9][0-9]*/`
+    | `/-?0[xX][0-9a-fA-F]+|0|-?[1-9][0-9]*/`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>uint_literal</dfn> :
 
-    | `/0[x|X][0-9a-fA-F]+u|0u|[1-9][0-9]*u/`
+    | `/0[xX][0-9a-fA-F]+u|0u|[1-9][0-9]*u/`
 </div>
 
 Note: literals are parsed greedily. This means that for statements like `a -5`


### PR DESCRIPTION
I just noticed this, I assume `|` was not intended to be a valid character at that location.

cc: @dneto0 