### PR TITLE
Specify compilation message order/locations are impl-defined

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4183,7 +4183,7 @@ any specific point in the code at all.
         the line on which the substring begins. Must be `0` if the {{GPUCompilationMessage/message}}
         does not correspond to any specific point in the shader {{GPUShaderModuleDescriptor/code}}.
 
-        Issue: Reference WGSL spec when it [defines what a line is](https://gpuweb.github.io/gpuweb/wgsl/#comments).
+        Issue(gpuweb/gpuweb#2435): Reference WGSL spec when it [defines what a line is](https://gpuweb.github.io/gpuweb/wgsl/#comments).
 
     : <dfn>linePos</dfn>
     ::
@@ -4225,6 +4225,9 @@ Note: {{GPUCompilationMessage}}.{{GPUCompilationMessage/offset}} and
     : <dfn>compilationInfo()</dfn>
     ::
         Returns any messages generated during the {{GPUShaderModule}}'s compilation.
+
+        The locations, order, and and contents of messages are implementation-defined.
+        In particular, messages may not be ordered by {{GPUCompilationMessage/lineNum}}.
 
         <div algorithm=GPUShaderModule.compilationInfo>
             **Called on:** {{GPUShaderModule}} this.


### PR DESCRIPTION
Issue #2435


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2451.html" title="Last updated on Dec 22, 2021, 8:17 PM UTC (8db6858)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2451/487c74e...kainino0x:8db6858.html" title="Last updated on Dec 22, 2021, 8:17 PM UTC (8db6858)">Diff</a>