### PR TITLE
Restore the box around algorithm divs

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -110,11 +110,20 @@ p, ul, ol, dl {
     margin: 1em 0;
 }
 
-/* Box for Valid Usage requirements. */
-div.validusage {
+/* The new spec template doesn't put a box around algorithms anymore. */
+/* Add a similar box for Valid Usage requirements. */
+div.algorithm, div.validusage {
+    margin: .5em 0;
     padding: .5em;
-    border: thin solid #88e !important;
+    border-width: thin;
+    border-style: solid;
     border-radius: .5em;
+}
+div.validusage {
+    border-color: #88e;
+}
+div.algorithm {
+    border-color: #ddd;
 }
 /*
  * If the Valid Usage requirements are the first child of a *-timeline block give it a larger top


### PR DESCRIPTION
When the spec template changed, algorithms stopped having an outline
around them, which makes the spec hard to read.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2453.html" title="Last updated on Dec 23, 2021, 1:50 AM UTC (f76e82d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2453/899753b...kainino0x:f76e82d.html" title="Last updated on Dec 23, 2021, 1:50 AM UTC (f76e82d)">Diff</a>