### PR TITLE
Define GPUTextureViewDimension values

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2588,6 +2588,68 @@ enum GPUTextureViewDimension {
 };
 </script>
 
+<dl dfn-type=enum-value dfn-for=GPUTextureViewDimension>
+    : <dfn>"1d"</dfn>
+    ::
+        The texture is viewed as a 1-dimensional image.
+
+        Corresponding WGSL types:
+
+        - `texture_1d`
+        - `texture_storage_1d`
+
+    : <dfn>"2d"</dfn>
+    ::
+        The texture is viewed as a single 2-dimensional image.
+
+        Corresponding WGSL types:
+
+        - `texture_2d`
+        - `texture_storage_2d`
+        - `texture_multisampled_2d`
+        - `texture_depth_2d`
+        - `texture_depth_multisampled_2d`
+
+    : <dfn>"2d-array"</dfn>
+    ::
+        The texture view is viewed as an array of 2-dimensional images.
+
+        Corresponding WGSL types:
+
+        - `texture_2d_array`
+        - `texture_storage_2d_array`
+        - `texture_depth_2d_array`
+
+    : <dfn>"cube"</dfn>
+    ::
+        The texture is viewed as a cubemap.
+        The view has 6 array layers, corresponding to the [+X, -X, +Y, -Y, +Z, -Z] faces of the cube.
+
+        Corresponding WGSL types:
+
+        - `texture_cube`
+        - `texture_depth_cube`
+
+    : <dfn>"cube-array"</dfn>
+    ::
+        The texture is viewed as a packed array of `n` cubemaps,
+        each with 6 array layers corresponding to the [+X, -X, +Y, -Y, +Z, -Z] faces of the cube.
+
+        Corresponding WGSL types:
+
+        - `texture_cube_array`
+        - `texture_depth_cube_array`
+
+    : <dfn>"3d"</dfn>
+    ::
+        The texture is viewed as a 3-dimensional image.
+
+        Corresponding WGSL types:
+
+        - `texture_3d`
+        - `texture_storage_3d`
+</dl>
+
 <script type=idl>
 enum GPUTextureAspect {
     "all",


### PR DESCRIPTION
including the order of faces in cube maps.

Fixes #1946


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2455.html" title="Last updated on Dec 23, 2021, 11:44 PM UTC (9f871ef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2455/899753b...kainino0x:9f871ef.html" title="Last updated on Dec 23, 2021, 11:44 PM UTC (9f871ef)">Diff</a>