### PR TITLE
Require alignment limits to be powers of 2

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1068,9 +1068,37 @@ Each [=adapter=] has a set of [=supported limits=], and
 [=devices=] are {{GPUDeviceDescriptor/requiredLimits|created}} with specific [=supported limits=] in place.
 The device limits are enforced regardless of the adapter's limits.
 
+Each limit has a <dfn dfn for=limit>default</dfn> value.
+Every [=adapter=] is guaranteed to support the default value or [=limit/better=].
+The default is used if a value is not explicitly specified in {{GPUDeviceDescriptor/requiredLimits}}.
+
 One limit value may be <dfn dfn for=limit>better</dfn> than another.
 A [=limit/better=] limit value always relaxes validation, enabling strictly
-more programs to be valid. For each limit, "better" is defined.
+more programs to be valid. For each [=limit class=], "better" is defined.
+
+Different limits have different <dfn dfn lt="limit class">limit classes</dfn>:
+
+<dl dfn-type=dfn dfn-for="limit class">
+    : <dfn>maximum</dfn>
+    ::
+        The limit enforces a maximum on some value passed into the API.
+
+        Higher values are [=limit/better=].
+
+        May only be set to values &ge; the [=limit/default=].
+        Lower values are clamped to the [=limit/default=].
+
+    : <dfn>alignment</dfn>
+    ::
+        The limit enforces a minimum alignment on some value passed into the API; that is,
+        the value must be a multiple of the limit.
+
+        Lower values are [=limit/better=].
+
+        May only be set to powers of 2 which are &le; the [=limit/default=].
+        Values which are not powers of 2 are invalid.
+        Higher powers of 2 are clamped to the [=limit/default=].
+</dl>
 
 Note:
 Setting "better" limits may not necessarily be desirable, as they may have a performance impact.
@@ -1078,62 +1106,58 @@ Because of this, and to improve portability across devices and implementations,
 applications should generally request the "worst" limits that work for their content
 (ideally, the default values).
 
-Each limit also has a <dfn dfn for=limit>default</dfn> value.
-Every [=adapter=] is guaranteed to support the default value or [=limit/better=].
-The default is used if a value is not explicitly specified in {{GPUDeviceDescriptor/requiredLimits}}.
-
 <table class="data no-colspan-center" dfn-type=attribute dfn-for="supported limits">
     <thead>
-        <tr><th>Limit name <th>Type <th>[=limit/Better=] <th>[=limit/Default=]
+        <tr><th>Limit name <th>Type <th>[=Limit class=] <th>[=limit/Default=]
     </thead>
 
     <tr><td><dfn>maxTextureDimension1D</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>8192
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>8192
     <tr class=row-continuation><td colspan=4>
         The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=Extent3D/width=]
         of a [=texture=] created with {{GPUTextureDescriptor/dimension}} {{GPUTextureDimension/"1d"}}.
 
     <tr><td><dfn>maxTextureDimension2D</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>8192
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>8192
     <tr class=row-continuation><td colspan=4>
         The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=Extent3D/width=] and {{GPUTextureDescriptor/size}}.[=Extent3D/height=]
         of a [=texture=] created with {{GPUTextureDescriptor/dimension}} {{GPUTextureDimension/"2d"}}.
 
     <tr><td><dfn>maxTextureDimension3D</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>2048
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>2048
     <tr class=row-continuation><td colspan=4>
         The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=Extent3D/width=], {{GPUTextureDescriptor/size}}.[=Extent3D/height=] and {{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=]
         of a [=texture=] created with {{GPUTextureDescriptor/dimension}} {{GPUTextureDimension/"3d"}}.
 
     <tr><td><dfn>maxTextureArrayLayers</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>256
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>256
     <tr class=row-continuation><td colspan=4>
         The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=]
         of a [=texture=] created with {{GPUTextureDescriptor/dimension}} {{GPUTextureDimension/"1d"}} or {{GPUTextureDimension/"2d"}}.
 
     <tr><td><dfn>maxBindGroups</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>4
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>4
     <tr class=row-continuation><td colspan=4>
         The maximum number of {{GPUBindGroupLayout|GPUBindGroupLayouts}}
         allowed in {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
         when creating a {{GPUPipelineLayout}}.
 
     <tr><td><dfn>maxDynamicUniformBuffersPerPipelineLayout</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>8
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>8
     <tr class=row-continuation><td colspan=4>
         The maximum number of {{GPUBindGroupLayoutEntry}} entries across a {{GPUPipelineLayout}}
         which are uniform buffers with dynamic offsets.
         See [=Exceeds the binding slot limits=].
 
     <tr><td><dfn>maxDynamicStorageBuffersPerPipelineLayout</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>4
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>4
     <tr class=row-continuation><td colspan=4>
         The maximum number of {{GPUBindGroupLayoutEntry}} entries across a {{GPUPipelineLayout}}
         which are storage buffers with dynamic offsets.
         See [=Exceeds the binding slot limits=].
 
     <tr><td><dfn>maxSampledTexturesPerShaderStage</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>16
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>16
     <tr class=row-continuation><td colspan=4>
         For each possible {{GPUShaderStage}} `stage`,
         the maximum number of {{GPUBindGroupLayoutEntry}} entries across a {{GPUPipelineLayout}}
@@ -1141,7 +1165,7 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
         See [=Exceeds the binding slot limits=].
 
     <tr><td><dfn>maxSamplersPerShaderStage</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>16
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>16
     <tr class=row-continuation><td colspan=4>
         For each possible {{GPUShaderStage}} `stage`,
         the maximum number of {{GPUBindGroupLayoutEntry}} entries across a {{GPUPipelineLayout}}
@@ -1149,7 +1173,7 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
         See [=Exceeds the binding slot limits=].
 
     <tr><td><dfn>maxStorageBuffersPerShaderStage</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>8
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>8
     <tr class=row-continuation><td colspan=4>
         For each possible {{GPUShaderStage}} `stage`,
         the maximum number of {{GPUBindGroupLayoutEntry}} entries across a {{GPUPipelineLayout}}
@@ -1157,7 +1181,7 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
         See [=Exceeds the binding slot limits=].
 
     <tr><td><dfn>maxStorageTexturesPerShaderStage</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>4
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>4
     <tr class=row-continuation><td colspan=4>
         For each possible {{GPUShaderStage}} `stage`,
         the maximum number of {{GPUBindGroupLayoutEntry}} entries across a {{GPUPipelineLayout}}
@@ -1165,7 +1189,7 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
         See [=Exceeds the binding slot limits=].
 
     <tr><td><dfn>maxUniformBuffersPerShaderStage</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>12
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>12
     <tr class=row-continuation><td colspan=4>
         For each possible {{GPUShaderStage}} `stage`,
         the maximum number of {{GPUBindGroupLayoutEntry}} entries across a {{GPUPipelineLayout}}
@@ -1173,7 +1197,7 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
         See [=Exceeds the binding slot limits=].
 
     <tr><td><dfn>maxUniformBufferBindingSize</dfn>
-        <td>{{GPUSize64}} <td>Higher <td>65536
+        <td>{{GPUSize64}} <td>[=limit class/maximum=] <td>65536
     <tr class=row-continuation><td colspan=4>
         The maximum {{GPUBufferBinding}}.{{GPUBufferBinding/size}} for bindings with a
         {{GPUBindGroupLayoutEntry}} |entry| for which
@@ -1181,7 +1205,7 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
         is {{GPUBufferBindingType/"uniform"}}.
 
     <tr><td><dfn>maxStorageBufferBindingSize</dfn>
-        <td>{{GPUSize64}} <td>Higher <td> 134217728 (128 MiB)
+        <td>{{GPUSize64}} <td>[=limit class/maximum=] <td> 134217728 (128 MiB)
     <tr class=row-continuation><td colspan=4>
         The maximum {{GPUBufferBinding}}.{{GPUBufferBinding/size}} for bindings with a
         {{GPUBindGroupLayoutEntry}} |entry| for which
@@ -1190,7 +1214,7 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
         or {{GPUBufferBindingType/"read-only-storage"}}.
 
     <tr><td><dfn>minUniformBufferOffsetAlignment</dfn>
-        <td>{{GPUSize32}} <td>Lower <td>256
+        <td>{{GPUSize32}} <td>[=limit class/alignment=] <td>256
     <tr class=row-continuation><td colspan=4>
         The required alignment for {{GPUBufferBinding}}.{{GPUBufferBinding/offset}} and
         {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup}}
@@ -1199,7 +1223,7 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
         is {{GPUBufferBindingType/"uniform"}}.
 
     <tr><td><dfn>minStorageBufferOffsetAlignment</dfn>
-        <td>{{GPUSize32}} <td>Lower <td>256
+        <td>{{GPUSize32}} <td>[=limit class/alignment=] <td>256
     <tr class=row-continuation><td colspan=4>
         The required alignment for {{GPUBufferBinding}}.{{GPUBufferBinding/offset}} and
         {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup}}
@@ -1209,62 +1233,62 @@ The default is used if a value is not explicitly specified in {{GPUDeviceDescrip
         or {{GPUBufferBindingType/"read-only-storage"}}.
 
     <tr><td><dfn>maxVertexBuffers</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>8
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>8
     <tr class=row-continuation><td colspan=4>
         The maximum number of {{GPUVertexState/buffers}}
         when creating a {{GPURenderPipeline}}.
 
     <tr><td><dfn>maxVertexAttributes</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>16
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>16
     <tr class=row-continuation><td colspan=4>
         The maximum number of {{GPUVertexBufferLayout/attributes}}
         in total across {{GPUVertexState/buffers}}
         when creating a {{GPURenderPipeline}}.
 
     <tr><td><dfn>maxVertexBufferArrayStride</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>2048
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>2048
     <tr class=row-continuation><td colspan=4>
         The maximum allowed {{GPUVertexBufferLayout/arrayStride}}
         when creating a {{GPURenderPipeline}}.
 
     <tr><td><dfn>maxInterStageShaderComponents</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>60
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>60
     <tr class=row-continuation><td colspan=4>
         The maximum allowed number of components of input or output variables
         for inter-stage communication (like vertex outputs or fragment inputs).
 
     <tr><td><dfn>maxComputeWorkgroupStorageSize</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>16352
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>16352
     <tr class=row-continuation><td colspan=4>
         The maximum number of bytes used for a compute stage
         {{GPUShaderModule}} entry-point.
 
     <tr><td><dfn>maxComputeInvocationsPerWorkgroup</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>256
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>256
     <tr class=row-continuation><td colspan=4>
         The maximum value of the product of the `workgroup_size` dimensions for a
         compute stage {{GPUShaderModule}} entry-point.
 
     <tr><td><dfn>maxComputeWorkgroupSizeX</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>256
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>256
     <tr class=row-continuation><td colspan=4>
         The maximum value of the `workgroup_size` X dimension for a
         compute stage {{GPUShaderModule}} entry-point.
 
     <tr><td><dfn>maxComputeWorkgroupSizeY</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>256
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>256
     <tr class=row-continuation><td colspan=4>
         The maximum value of the `workgroup_size` Y dimensions for a
         compute stage {{GPUShaderModule}} entry-point.
 
     <tr><td><dfn>maxComputeWorkgroupSizeZ</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>64
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>64
     <tr class=row-continuation><td colspan=4>
         The maximum value of the `workgroup_size` Z dimensions for a
         compute stage {{GPUShaderModule}} entry-point.
 
     <tr><td><dfn>maxComputeWorkgroupsPerDimension</dfn>
-        <td>{{GPUSize32}} <td>Higher <td>65535
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>65535
     <tr class=row-continuation><td colspan=4>
         The maximum value for the arguments of {{GPUComputePassEncoder/dispatch(x, y, z)}}.
 
@@ -1693,10 +1717,12 @@ interface GPUAdapter {
                             - Each key in |descriptor|.{{GPUDeviceDescriptor/requiredLimits}}
                                 must be the name of a member of [=supported limits=].
 
-                            - For each type of limit in [=supported limits=], the value of that
-                                limit in |descriptor|.{{GPUDeviceDescriptor/requiredLimits}}
-                                must be no [=limit/better=] than the value of that limit in
-                                |adapter|.{{adapter/[[limits]]}}.
+                            - For each limit name |key| in the keys of [=supported limits=]:
+                                Let |value| be |descriptor|.{{GPUDeviceDescriptor/requiredLimits}}[|key|].
+                                - |value| must be no [=limit/better=] than the value of that limit in
+                                    |adapter|.{{adapter/[[limits]]}}.
+                                - If the limit's [=limit class|class=] is [=limit class/alignment=],
+                                    |value| must be a power of 2.
                         </div>
 
                     1. If |adapter| is [=invalid=],


### PR DESCRIPTION
Fixes #2099


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2456.html" title="Last updated on Dec 24, 2021, 12:57 AM UTC (e6512b0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2456/899753b...kainino0x:e6512b0.html" title="Last updated on Dec 24, 2021, 12:57 AM UTC (e6512b0)">Diff</a>