### PR TITLE
Make GPUDevice.lost return the same Promise object

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1023,7 +1023,7 @@ Any time the user agent needs to revoke access to a device, it calls
     1. Make |device|.{{device/[[adapter]]}} [=invalid=].
     1. Make |device| [=invalid=].
     1. Issue: explain how to get from |device| to its "primary" {{GPUDevice}}.
-    1. Resolve {{GPUDevice/lost|GPUDevice.lost}} with a new {{GPUDeviceLostInfo}} with
+    1. Resolve |device|.{{GPUDevice/lost}} with a new {{GPUDeviceLostInfo}} with
         {{GPUDeviceLostInfo/reason}} set to |reason| and
         {{GPUDeviceLostInfo/message}} set to an implementation-defined value.
 
@@ -8967,6 +8967,18 @@ partial interface GPUDevice {
     readonly attribute Promise<GPUDeviceLostInfo> lost;
 };
 </script>
+
+{{GPUDevice}} has the following additional attributes:
+
+<dl dfn-type=attribute dfn-for=GPUDevice>
+    : <dfn>lost</dfn>
+    ::
+        A promise which is created with the device, remains pending for the lifetime of the device,
+        then resolves when the device is lost.
+
+        This attribute is backed by an immutable internal slot of the same name, initially set
+        to [=a new promise=], and always returns its value.
+</dl>
 
 ## Error Scopes ## {#error-scopes}
 


### PR DESCRIPTION
Fixes #2147


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2457.html" title="Last updated on Dec 24, 2021, 1:13 AM UTC (526efb2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2457/899753b...kainino0x:526efb2.html" title="Last updated on Dec 24, 2021, 1:13 AM UTC (526efb2)">Diff</a>