### PR TITLE
wsgl: Add bit-finding functions.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9338,6 +9338,14 @@ struct __modf_result_vecN {
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450SClamp)
 
+  <tr algorithm="count leading zeroes">
+    <td>|T| is [INTEGRAL]
+    <td class="nowrap">`countLeadingZeros(`|e|`:` |T| `) ->` |T|
+    <td>The number of 0 bits in the most significant bit positions
+        of |e|, when |T| is a scalar type.<br>
+        [=Component-wise=] when |T| is a vector.<br>
+        Also known as "clz" in some languages.<br>
+
   <tr algorithm="count 1 bits">
     <td>|T| is [INTEGRAL]
     <td class="nowrap">`countOneBits(`|e|`:` |T| `) ->` |T|
@@ -9345,6 +9353,51 @@ struct __modf_result_vecN {
         Also known as "population count".<br>
         [=Component-wise=] when |T| is a vector.
         (SPIR-V OpBitCount)
+
+  <tr algorithm="count trailing zeroes">
+    <td>|T| is [INTEGRAL]
+    <td class="nowrap">`countTrailingZeros(`|e|`:` |T| `) ->` |T|
+    <td>The number of 0 bits in the least significant bit positions
+        of |e|, when |T| is a scalar type.<br>
+        [=Component-wise=] when |T| is a vector.<br>
+        Also known as "ctz" in some languages.<br>
+
+  <tr algorithm="signed find most significant one bit">
+    <td>|T| is [SIGNEDINTEGRAL]
+    <td class="nowrap">`firstBitHigh(`|e|`:` |T| `) ->` |T|
+    <td>For scalar |T|, the result is:
+        <ul>
+        <li>|T|(-1) if |e| is zero, or -1.
+        <li>Otherwise the position of the most signficant bit in
+            |e| that is different from |e|'s sign bit.
+        </ul>
+            
+        Note: Since signed integers use twos-complement representation,
+        the sign bit appears in the most significant bit position.
+
+        [=Component-wise=] when |T| is a vector.<br>
+
+  <tr algorithm="unsigned find most significant one bit">
+    <td>|T| is [UNSIGNEDINTEGRAL]
+    <td class="nowrap">`firstBitHigh(`|e|`:` |T| `) ->` |T|
+    <td>For scalar |T|, the result is:
+        <ul>
+        <li>|T|(-1) if |e| is zero.
+        <li>Otherwise the position of the most signficant 1
+            bit in |e|.
+        </ul>
+        [=Component-wise=] when |T| is a vector.<br>
+
+  <tr algorithm="find least significant one bit">
+    <td>|T| is [INTEGRAL]
+    <td class="nowrap">`firstBitLow(`|e|`:` |T| `) ->` |T|
+    <td>For scalar |T|, the result is:
+        <ul>
+        <li>|T|(-1) if |e| is zero.
+        <li>Otherwise the position of the least signficant 1
+            bit in |e|.
+        </ul>
+        [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="unsigned max">
     <td>|T| is [UNSIGNEDINTEGRAL]

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9341,7 +9341,7 @@ struct __modf_result_vecN {
   <tr algorithm="count leading zeroes">
     <td>|T| is [INTEGRAL]
     <td class="nowrap">`countLeadingZeros(`|e|`:` |T| `) ->` |T|
-    <td>The number of 0 bits in the most significant bit positions
+    <td>The number of consectuive 0 bits starting from the most significant bit positions
         of |e|, when |T| is a scalar type.<br>
         [=Component-wise=] when |T| is a vector.<br>
         Also known as "clz" in some languages.<br>
@@ -9357,7 +9357,7 @@ struct __modf_result_vecN {
   <tr algorithm="count trailing zeroes">
     <td>|T| is [INTEGRAL]
     <td class="nowrap">`countTrailingZeros(`|e|`:` |T| `) ->` |T|
-    <td>The number of 0 bits in the least significant bit positions
+    <td>The number of consecutive 0 bits starting from the least significant bit positions
         of |e|, when |T| is a scalar type.<br>
         [=Component-wise=] when |T| is a vector.<br>
         Also known as "ctz" in some languages.<br>
@@ -9367,7 +9367,7 @@ struct __modf_result_vecN {
     <td class="nowrap">`firstBitHigh(`|e|`:` |T| `) ->` |T|
     <td>For scalar |T|, the result is:
         <ul>
-        <li>|T|(-1) if |e| is zero, or -1.
+        <li>-1 if |e| is 0 or -1.
         <li>Otherwise the position of the most signficant bit in
             |e| that is different from |e|'s sign bit.
         </ul>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9341,7 +9341,7 @@ struct __modf_result_vecN {
   <tr algorithm="count leading zeroes">
     <td>|T| is [INTEGRAL]
     <td class="nowrap">`countLeadingZeros(`|e|`:` |T| `) ->` |T|
-    <td>The number of consectuive 0 bits starting from the most significant bit positions
+    <td>The number of consectuive 0 bits starting from the most significant bit
         of |e|, when |T| is a scalar type.<br>
         [=Component-wise=] when |T| is a vector.<br>
         Also known as "clz" in some languages.<br>
@@ -9357,7 +9357,7 @@ struct __modf_result_vecN {
   <tr algorithm="count trailing zeroes">
     <td>|T| is [INTEGRAL]
     <td class="nowrap">`countTrailingZeros(`|e|`:` |T| `) ->` |T|
-    <td>The number of consecutive 0 bits starting from the least significant bit positions
+    <td>The number of consecutive 0 bits starting from the least significant bit
         of |e|, when |T| is a scalar type.<br>
         [=Component-wise=] when |T| is a vector.<br>
         Also known as "ctz" in some languages.<br>


### PR DESCRIPTION
- countLeadingZeros, countTrailingZeros
   - Same as MSL clz, ctz
- firstBitHigh, firstBitLow
   - Same as HLSL firstbithi, firstbitlow
   - Same as GLSL findMSB, findLSB
   - Same as SPIR-V's GLSL.std.450 FindSMsb FindUMsb, FindILsb

Fixes: #2130