### PR TITLE
Fix declaration-and-scope section for out-of-order decls

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -734,7 +734,6 @@ the following kinds of objects:
 * a formal parameter
 
 In other words, a declaration introduces a <dfn noexport>name</dfn> for an object.
-A name cannot be used before it is declared.
 
 The <dfn noexport>scope</dfn> of a declaration is the set of
 program locations where a use of the declared identifier potentially denotes
@@ -742,9 +741,19 @@ its associated object.
 We say the identifier is <dfn noexport>in scope</dfn>
 (of the declaration) at those source locations.
 
-Each kind of declaration has its own rule for determining its scope.
-In general, the scope is a span of text beginning immediately after the end of
+When an identifier is used, it must be in scope for some declaration, or as part of a directive.
+When an identifier is used in scope of one or more declarations for that name,
+the identifier will denote the object of the declaration appearing closest to
+that use.
+We say the identifier use <dfn noexport>resolves</dfn> to that declaration.
+
+Where a declaration appears determines its scope.
+Generally, the scope is a span of text beginning immediately after the end of
 the declaration.
+Declarations at [=module scope=] are the exception, described below.
+
+A declaration must not introduce a name when that identifier is
+already in scope with the same end of scope as another instance of that name.
 
 Certain objects are provided by the WebGPU implementation, and are treated as
 if they have been declared by every [SHORTNAME] program.
@@ -754,23 +763,11 @@ Examples of predeclared objects are:
 * [=built-in functions=], and
 * built-in types.
 
-A declaration must not introduce a name when that identifier is
-already in scope with the same end scope as another instance of that name.
-When an identifier is used in scope of one or more declarations for that name,
-the identifier will denote the object of the declaration appearing closest to
-that use.
-We say the identifier use <dfn noexport>resolves</dfn> to that declaration.
-
-There are multiple levels of scoping depending on how and where things are
-declared.
-
-When an identifier is used, it must be in scope for some declaration, or as part of a directive.
-
 A declaration is at <dfn noexport>module scope</dfn> if the declaration appears outside
 the text of any other declaration.
 Module scope declarations are [=in scope=] for the entire program.
-That is, declarations at module scope may be referenced by statements and
-expressions that precede that declaration textually.
+That is, a declaration at module scope may be referenced by source text
+that follows *or precedes* that declaration.
 
 It is a [=shader-creation error=] if any module scope declaration is recursive.
 That is, there must be no cycles among the declarations:

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -741,10 +741,10 @@ its associated object.
 We say the identifier is <dfn noexport>in scope</dfn>
 (of the declaration) at those source locations.
 
-When an identifier is used, it must be in scope for some declaration, or as part of a directive.
+When an identifier is used, it must be [=in scope=] for some declaration, or as part of a directive.
 When an identifier is used in scope of one or more declarations for that name,
-the identifier will denote the object of the declaration appearing closest to
-that use.
+the identifier will denote the object of the non-[=module scope|module-scope=] declaration appearing closest to
+that use, or the module-scope declaration if no other declaration is in scope.
 We say the identifier use <dfn noexport>resolves</dfn> to that declaration.
 
 Where a declaration appears determines its scope.


### PR DESCRIPTION
Also reorganize to bring "resolves to" closer to the definition of "in scope".

Fixes: #2477