### PR TITLE
wgsl: Remove notes about non-ref dynamic indexing

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4396,14 +4396,6 @@ See [[#sync-builtin-functions]].
            (OpAccessChain)
 </table>
 
-Note: Reflecting the limitations of the languages WGSL is meant to be translated
-into, it is only possible to use dynamically computed indices to subscript
-references to matrices. A matrix not behind a reference may only be indexed by a
-`const_expression`. To work around this restriction, consider storing the matrix in a
-temporary variable, and then subscripting the variable: a
-[[#var-identifier-expr|variable identifier expression]] produces a reference to
-the variable's value, as required.
-
 ### Array Access Expression ### {#array-access-expr}
 
 <table class='data'>
@@ -4461,10 +4453,6 @@ the variable's value, as required.
            (OpAccessChain)
 </table>
 
-Note: Reflecting the limitations of the languages WGSL is meant to be translated
-into, it is only possible to use dynamically computed indices to subscript
-references to arrays. An array not behind a reference may only be indexed by a
-`const_expression`.
 
 ### Structure Access Expression ### {#struct-access-expr}
 


### PR DESCRIPTION
We re-enabled dynamically indexing into non-ref arrays and matrices in
gpuweb/gpuweb#2427, as discussed in #1782.