### PR TITLE
Add pointers back to parent objects for most interfaces

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2239,6 +2239,8 @@ To get a {{GPUDevice}}, use {{GPUAdapter/requestDevice()}}.
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUDevice : EventTarget {
+    [SameObject] readonly attribute GPUAdapter adapter;
+
     [SameObject] readonly attribute GPUSupportedFeatures features;
     [SameObject] readonly attribute GPUSupportedLimits limits;
 
@@ -2272,6 +2274,10 @@ GPUDevice includes GPUObjectBase;
 {{GPUDevice}} has the following attributes:
 
 <dl dfn-type=attribute dfn-for=GPUDevice>
+    : <dfn>adapter</dfn>
+    ::
+        Returns the {{GPUAdapter}} that created this device.
+
     : <dfn>features</dfn>
     ::
         A set containing the {{GPUFeatureName}} values of the features
@@ -2444,6 +2450,7 @@ interface GPUBuffer {
 
     undefined destroy();
 
+    [SameObject] readonly attribute GPUDevice device;
     readonly attribute GPUSize64 size;
     readonly attribute GPUBufferUsageFlags usage;
 };
@@ -2453,6 +2460,10 @@ GPUBuffer includes GPUObjectBase;
 {{GPUBuffer}} has the following attributes:
 
 <dl dfn-type=attribute dfn-for=GPUBuffer>
+    : <dfn>device</dfn>
+    ::
+        Returns the {{GPUDevice}} that created this {{GPUBuffer}}.
+
     : <dfn>size</dfn>
     ::
         The length of the {{GPUBuffer}} allocation in bytes.
@@ -2861,7 +2872,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                 1. Let |rangeSize| be max(0, |this|.{{GPUBuffer/size}} - |offset|).
 
                 Otherwise:
-                
+
                 1. Let |rangeSize| be |size|.
 
             1. If any of the following conditions are unsatisfied:
@@ -3024,6 +3035,7 @@ interface GPUTexture {
 
     undefined destroy();
 
+    [SameObject] readonly attribute GPUDevice device;
     readonly attribute GPUIntegerCoordinate width;
     readonly attribute GPUIntegerCoordinate height;
     readonly attribute GPUIntegerCoordinate depthOrArrayLayers;
@@ -3039,6 +3051,10 @@ GPUTexture includes GPUObjectBase;
 {{GPUTexture}} has the following attributes:
 
 <dl dfn-type=attribute dfn-for=GPUTexture>
+    : <dfn>device</dfn>
+    ::
+        Returns the {{GPUDevice}} that created this {{GPUTexture}}.
+
     : <dfn>width</dfn>
     ::
         The width of this {{GPUTexture}}.
@@ -3429,17 +3445,22 @@ all previously submitted operations using it are complete.
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUTextureView {
+    [SameObject] readonly attribute GPUTexture texture;
 };
 GPUTextureView includes GPUObjectBase;
 </script>
 
+{{GPUTextureView}} has the following attributes:
+
+<dl dfn-type=attribute dfn-for="GPUTextureView">
+    : <dfn>texture</dfn>
+    ::
+        The {{GPUTexture}} into which this is a view.
+</dl>
+
 {{GPUTextureView}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for=GPUTextureView>
-    : <dfn>\[[texture]]</dfn>
-    ::
-        The {{GPUTexture}} into which this is a view.
-
     : <dfn>\[[descriptor]]</dfn>
     ::
         The {{GPUTextureViewDescriptor}} describing this texture view.
@@ -3706,7 +3727,7 @@ enum GPUTextureAspect {
                         </div>
 
                     1. Let |view| be a new {{GPUTextureView}} object.
-                    1. Set |view|.{{GPUTextureView/[[texture]]}} to |this|.
+                    1. Set |view|.{{GPUTextureView/texture}} to |this|.
                     1. Set |view|.{{GPUTextureView/[[descriptor]]}} to |descriptor|.
                     1. If |this|.{{GPUTexture/usage}} contains {{GPUTextureUsage/RENDER_ATTACHMENT}}:
                         1. Let |renderExtent| be [$compute render extent$](|this|.{{GPUTexture/[[size]]}}, |descriptor|.{{GPUTextureViewDescriptor/baseMipLevel}}).
@@ -3798,7 +3819,7 @@ enum GPUTextureAspect {
 
     Two {{GPUTextureView}} objects |a| and |b| are considered <dfn dfn>texture-view-aliasing</dfn> if and only if all of the following are true:
 
-    - |a|.{{GPUTextureView/[[texture]]}} == |b|.{{GPUTextureView/[[texture]]}}.
+    - |a|.{{GPUTextureView/texture}} == |b|.{{GPUTextureView/texture}}.
     - |aDescriptor|.{{GPUTextureViewDescriptor/aspect}} == {{GPUTextureAspect/"all"}}, or
         |bDescriptor|.{{GPUTextureViewDescriptor/aspect}} == {{GPUTextureAspect/"all"}}, or
         |aDescriptor|.{{GPUTextureViewDescriptor/aspect}} == |bDescriptor|.{{GPUTextureViewDescriptor/aspect}}.
@@ -4076,6 +4097,7 @@ External textures use several binding slots: see [=Exceeds the binding slot limi
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUExternalTexture {
+    [SameObject] readonly attribute GPUDevice device;
     readonly attribute boolean expired;
 };
 GPUExternalTexture includes GPUObjectBase;
@@ -4097,6 +4119,10 @@ GPUExternalTexture includes GPUObjectBase;
 {{GPUExternalTexture}} has the following attributes:
 
 <dl dfn-type=attribute dfn-for=GPUExternalTexture>
+    : <dfn>device</dfn>
+    ::
+        Returns the {{GPUDevice}} that created this {{GPUExternalTexture}}.
+
     : <dfn>expired</dfn>
     ::
         Returns the value of {{GPUExternalTexture/[[destroyed]]}}, which indicates
@@ -4271,9 +4297,18 @@ that returns a new sampler object.
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUSampler {
+    [SameObject] readonly attribute GPUDevice device;
 };
 GPUSampler includes GPUObjectBase;
 </script>
+
+{{GPUSampler}} has the following attributes:
+
+<dl dfn-type=attribute dfn-for="GPUSampler">
+    : <dfn>device</dfn>
+    ::
+        Returns the {{GPUDevice}} that created this {{GPUSampler}}.
+</dl>
 
 {{GPUSampler}} has the following internal slots:
 
@@ -4541,9 +4576,18 @@ A {{GPUBindGroupLayout}} defines the interface between a set of resources bound 
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUBindGroupLayout {
+    [SameObject] readonly attribute GPUDevice device;
 };
 GPUBindGroupLayout includes GPUObjectBase;
 </script>
+
+{{GPUBindGroupLayout}} has the following attributes:
+
+<dl dfn-type=attribute dfn-for="GPUBindGroupLayout">
+    : <dfn>device</dfn>
+    ::
+        Returns the {{GPUDevice}} that created this {{GPUBindGroupLayout}}.
+</dl>
 
 {{GPUBindGroupLayout}} has the following internal slots:
 
@@ -5020,9 +5064,18 @@ A {{GPUBindGroup}} defines a set of resources to be bound together in a group
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUBindGroup {
+    [SameObject] readonly attribute GPUDevice device;
 };
 GPUBindGroup includes GPUObjectBase;
 </script>
+
+A {{GPUBindGroup}} has the following attributes:
+
+<dl dfn-type=attribute dfn-for="GPUBindGroup">
+    : <dfn>device</dfn>
+    ::
+        Returns the {{GPUDevice}} that created this {{GPUBindGroup}}.
+</dl>
 
 A {{GPUBindGroup}} object has the following internal slots:
 
@@ -5181,7 +5234,7 @@ following members:
                                         ::
                                             - |resource| is a {{GPUTextureView}}.
                                             - |resource| is [$valid to use with$] |this|.
-                                            - Let |texture| be |resource|.{{GPUTextureView/[[texture]]}}.
+                                            - Let |texture| be |resource|.{{GPUTextureView/texture}}.
                                             - |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/viewDimension}}
                                                 is equal to |resource|'s {{GPUTextureViewDescriptor/dimension}}.
                                             - |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/sampleType}}
@@ -5196,7 +5249,7 @@ following members:
                                         ::
                                             - |resource| is a {{GPUTextureView}}.
                                             - |resource| is [$valid to use with$] |this|.
-                                            - Let |texture| be |resource|.{{GPUTextureView/[[texture]]}}.
+                                            - Let |texture| be |resource|.{{GPUTextureView/texture}}.
                                             - |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/viewDimension}}
                                                 is equal to |resource|'s {{GPUTextureViewDescriptor/dimension}}.
                                             - |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/format}}
@@ -5291,9 +5344,18 @@ The components of this address can also be seen as the binding space of a pipeli
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUPipelineLayout {
+    [SameObject] readonly attribute GPUDevice device;
 };
 GPUPipelineLayout includes GPUObjectBase;
 </script>
+
+{{GPUPipelineLayout}} has the following attributes:
+
+<dl dfn-type=attribute dfn-for="GPUPipelineLayout">
+    : <dfn>device</dfn>
+    ::
+        Returns the {{GPUDevice}} that created this {{GPUPipelineLayout}}.
+</dl>
 
 {{GPUPipelineLayout}} has the following internal slots:
 
@@ -5439,15 +5501,25 @@ if their internal {{GPUPipelineLayout/[[bindGroupLayouts]]}} sequences contain
 
 ## <dfn interface>GPUShaderModule</dfn> ## {#shader-module}
 
+{{GPUShaderModule}} is a reference to an internal shader module object.
+
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUShaderModule {
     Promise<GPUCompilationInfo> compilationInfo();
+
+    [SameObject] readonly attribute GPUDevice device;
 };
 GPUShaderModule includes GPUObjectBase;
 </script>
 
-{{GPUShaderModule}} is a reference to an internal shader module object.
+{{GPUShaderModule}} has the following attributes:
+
+<dl dfn-type=attribute dfn-for="GPUShaderModule">
+    : <dfn>device</dfn>
+    ::
+        Returns the {{GPUDevice}} that created this {{GPUShaderModule}}.
+</dl>
 
 ### Shader Module Creation ### {#shader-module-creation}
 
@@ -6241,10 +6313,19 @@ Stages of a compute [=pipeline=]:
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUComputePipeline {
+    [SameObject] readonly attribute GPUDevice device;
 };
 GPUComputePipeline includes GPUObjectBase;
 GPUComputePipeline includes GPUPipelineBase;
 </script>
+
+{{GPUComputePipeline}} has the following attributes:
+
+<dl dfn-type=attribute dfn-for="GPUComputePipeline">
+    : <dfn>device</dfn>
+    ::
+        Returns the {{GPUDevice}} that created this {{GPUComputePipeline}}.
+</dl>
 
 ### Creation ### {#compute-pipeline-creation}
 
@@ -6401,10 +6482,19 @@ A render [=pipeline=] is comprised of the following <dfn dfn>render stages</dfn>
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPURenderPipeline {
+    [SameObject] readonly attribute GPUDevice device;
 };
 GPURenderPipeline includes GPUObjectBase;
 GPURenderPipeline includes GPUPipelineBase;
 </script>
+
+{{GPURenderPipeline}} has the following attributes:
+
+<dl dfn-type=attribute dfn-for="GPURenderPipeline">
+    : <dfn>device</dfn>
+    ::
+        Returns the {{GPUDevice}} that created this {{GPURenderPipeline}}.
+</dl>
 
 {{GPURenderPipeline}} has the following internal slots:
 
@@ -7814,9 +7904,18 @@ To reuse rendering commands across multiple submissions, use {{GPURenderBundle}}
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUCommandBuffer {
+    [SameObject] readonly attribute GPUDevice device;
 };
 GPUCommandBuffer includes GPUObjectBase;
 </script>
+
+{{GPUCommandBuffer}} has the following attributes:
+
+<dl dfn-type=attribute dfn-for="GPUCommandBuffer">
+    : <dfn>device</dfn>
+    ::
+        Returns the {{GPUDevice}} that created this {{GPUCommandBuffer}}.
+</dl>
 
 {{GPUCommandBuffer}} has the following internal slots:
 
@@ -7944,11 +8043,21 @@ interface GPUCommandEncoder {
         GPUSize64 destinationOffset);
 
     GPUCommandBuffer finish(optional GPUCommandBufferDescriptor descriptor = {});
+
+    [SameObject] readonly attribute GPUDevice device;
 };
 GPUCommandEncoder includes GPUObjectBase;
 GPUCommandEncoder includes GPUCommandsMixin;
 GPUCommandEncoder includes GPUDebugCommandsMixin;
 </script>
+
+{{GPUCommandEncoder}} has the following attributes:
+
+<dl dfn-type=attribute dfn-for="GPUCommandEncoder">
+    : <dfn>device</dfn>
+    ::
+        Returns the {{GPUDevice}} that created this {{GPUCommandEncoder}}.
+</dl>
 
 ### Creation ### {#command-encoder-creation}
 
@@ -9217,6 +9326,8 @@ interface GPUComputePassEncoder {
     undefined dispatchWorkgroupsIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
 
     undefined end();
+
+    [SameObject] readonly attribute GPUCommandEncoder commandEncoder;
 };
 GPUComputePassEncoder includes GPUObjectBase;
 GPUComputePassEncoder includes GPUCommandsMixin;
@@ -9224,13 +9335,17 @@ GPUComputePassEncoder includes GPUDebugCommandsMixin;
 GPUComputePassEncoder includes GPUBindingCommandsMixin;
 </script>
 
+{{GPUComputePassEncoder}} has the following attributes:
+
+<dl dfn-type=attribute dfn-for="GPUComputePassEncoder">
+    : <dfn>commandEncoder</dfn>
+    ::
+        The {{GPUCommandEncoder}} that created this compute pass encoder.
+</dl>
+
 {{GPUComputePassEncoder}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for=GPUComputePassEncoder>
-    : <dfn>\[[command_encoder]]</dfn>, of type {{GPUCommandEncoder}}, readonly
-    ::
-        The {{GPUCommandEncoder}} that created this compute pass encoder.
-
     : <dfn>\[[pipeline]]</dfn>, of type {{GPUComputePipeline}}
     ::
         The current {{GPUComputePipeline}}, initially `null`.
@@ -9450,7 +9565,7 @@ called the compute pass encoder can no longer be used.
                     <div class=validusage>
                         - |this|.{{GPUCommandsMixin/[[state]]}} must be "[=encoder state/open=]",
                     </div>
-                1. Let |parentEncoder| be |this|.{{GPUComputePassEncoder/[[command_encoder]]}}.
+                1. Let |parentEncoder| be |this|.{{GPUComputePassEncoder/commandEncoder}}.
                 1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/ended=]".
                 1. [=Assert=]: |parentEncoder|.{{GPUCommandsMixin/[[state]]}} is "[=encoder state/locked=]".
                 1. Set |parentEncoder|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/open=]".
@@ -9495,6 +9610,8 @@ interface GPURenderPassEncoder {
 
     undefined executeBundles(sequence<GPURenderBundle> bundles);
     undefined end();
+
+    [SameObject] readonly attribute GPUCommandEncoder commandEncoder;
 };
 GPURenderPassEncoder includes GPUObjectBase;
 GPURenderPassEncoder includes GPUCommandsMixin;
@@ -9503,13 +9620,17 @@ GPURenderPassEncoder includes GPUBindingCommandsMixin;
 GPURenderPassEncoder includes GPURenderCommandsMixin;
 </script>
 
+{{GPURenderPassEncoder}} has the following attributes:
+
+<dl dfn-type=attribute dfn-for="GPURenderPassEncoder">
+    : <dfn>commandEncoder</dfn>
+    ::
+        The {{GPUCommandEncoder}} that created this render pass encoder.
+</dl>
+
 {{GPURenderPassEncoder}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for=GPURenderPassEncoder>
-    : <dfn>\[[command_encoder]]</dfn>, of type {{GPUCommandEncoder}}, readonly
-    ::
-        The {{GPUCommandEncoder}} that created this render pass encoder.
-
     : <dfn>\[[attachment_size]]</dfn>
     ::
         Set to the following extents:
@@ -9761,8 +9882,8 @@ dictionary GPURenderPassColorAttachment {
 
     1. Let |renderViewDescriptor| be |this|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.
     1. Let |resolveViewDescriptor| be |this|.{{GPURenderPassColorAttachment/resolveTarget}}.{{GPUTextureView/[[descriptor]]}}.
-    1. Let |renderTexture| be |this|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.
-    1. Let |resolveTexture| be |this|.{{GPURenderPassColorAttachment/resolveTarget}}.{{GPUTextureView/[[texture]]}}.
+    1. Let |renderTexture| be |this|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/texture}}.
+    1. Let |resolveTexture| be |this|.{{GPURenderPassColorAttachment/resolveTarget}}.{{GPUTextureView/texture}}.
 
     The following validation rules apply:
 
@@ -9783,13 +9904,13 @@ dictionary GPURenderPassColorAttachment {
     A {{GPUTextureView}} |view| is a <dfn abstract-op>renderable texture view</dfn>
     if the following requirements are met:
 
-    - |view|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/usage}}
+    - |view|.{{GPUTextureView/texture}}.{{GPUTexture/usage}}
         must contain {{GPUTextureUsage/RENDER_ATTACHMENT}}.
     - |descriptor|.{{GPUTextureViewDescriptor/dimension}} must be {{GPUTextureViewDimension/"2d"}}.
     - |descriptor|.{{GPUTextureViewDescriptor/mipLevelCount}} must be 1.
     - |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be 1.
     - |descriptor|.{{GPUTextureViewDescriptor/aspect}} must refer to all [=aspects=] of
-        |view|.{{GPUTextureView/[[texture]]}}.
+        |view|.{{GPUTextureView/texture}}.
 
     where |descriptor| is |view|.{{GPUTextureView/[[descriptor]]}}.
 </div>
@@ -9968,14 +10089,14 @@ dictionary GPURenderPassLayout: GPUObjectDescriptorBase {
     1. Let |layout| be a new {{GPURenderPassLayout}} object.
     1. For each |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
         1. If |colorAttachment| is not `null`:
-            1. Set |layout|.{{GPURenderPassLayout/sampleCount}} to |colorAttachment|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/sampleCount}}.
+            1. Set |layout|.{{GPURenderPassLayout/sampleCount}} to |colorAttachment|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/texture}}.{{GPUTexture/sampleCount}}.
             1. Append |colorAttachment|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}} to |layout|.{{GPURenderPassLayout/colorFormats}}.
         1. Otherwise:
             1. Append `null` to |layout|.{{GPURenderPassLayout/colorFormats}}.
     1. Let |depthStencilAttachment| be |descriptor|.{{GPURenderPassDescriptor/depthStencilAttachment}}.
     1. If |depthStencilAttachment| is not `null`:
         1. Let |view| be |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/view}}.
-        1. Set |layout|.{{GPURenderPassLayout/sampleCount}} to |view|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/sampleCount}}.
+        1. Set |layout|.{{GPURenderPassLayout/sampleCount}} to |view|.{{GPUTextureView/texture}}.{{GPUTexture/sampleCount}}.
         1. Set |layout|.{{GPURenderPassLayout/depthStencilFormat}} to |view|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
     1. Return |layout|.
 </div>
@@ -10025,7 +10146,7 @@ called the render pass encoder can no longer be used.
                     <div class=validusage>
                         - |this|.{{GPUCommandsMixin/[[state]]}} must be "[=encoder state/open=]",
                     </div>
-                1. Let |parentEncoder| be |this|.{{GPURenderPassEncoder/[[command_encoder]]}}.
+                1. Let |parentEncoder| be |this|.{{GPURenderPassEncoder/commandEncoder}}.
                 1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/ended=]".
                 1. [=Assert=]: |parentEncoder|.{{GPUCommandsMixin/[[state]]}} is "[=encoder state/locked=]".
                 1. Set |parentEncoder|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/open=]".
@@ -10727,9 +10848,18 @@ attachments used by this encoder.
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPURenderBundle {
+    [SameObject] readonly attribute GPUDevice device;
 };
 GPURenderBundle includes GPUObjectBase;
 </script>
+
+{{GPURenderBundle}} has the following attributes:
+
+<dl dfn-type=attribute dfn-for="GPURenderBundle">
+    : <dfn>device</dfn>
+    ::
+        Returns the {{GPUDevice}} that created this {{GPURenderBundle}}.
+</dl>
 
 <dl dfn-type=attribute dfn-for=GPURenderBundle>
     : <dfn>\[[command_list]]</dfn>, of type [=list=]&lt;[=GPU command=]&gt;
@@ -10765,6 +10895,8 @@ dictionary GPURenderBundleDescriptor : GPUObjectDescriptorBase {
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPURenderBundleEncoder {
     GPURenderBundle finish(optional GPURenderBundleDescriptor descriptor = {});
+
+    [SameObject] readonly attribute GPUDevice device;
 };
 GPURenderBundleEncoder includes GPUObjectBase;
 GPURenderBundleEncoder includes GPUCommandsMixin;
@@ -10772,6 +10904,14 @@ GPURenderBundleEncoder includes GPUDebugCommandsMixin;
 GPURenderBundleEncoder includes GPUBindingCommandsMixin;
 GPURenderBundleEncoder includes GPURenderCommandsMixin;
 </script>
+
+{{GPURenderBundleEncoder}} has the following attributes:
+
+<dl dfn-type=attribute dfn-for="GPURenderBundleEncoder">
+    : <dfn>device</dfn>
+    ::
+        Returns the {{GPUDevice}} that created this {{GPURenderBundleEncoder}}.
+</dl>
 
 <dl dfn-type=method dfn-for=GPUDevice>
     : <dfn>createRenderBundleEncoder(descriptor)</dfn>
@@ -11193,6 +11333,7 @@ Queries {#queries}
 interface GPUQuerySet {
     undefined destroy();
 
+    [SameObject] readonly attribute GPUDevice device;
     readonly attribute GPUQueryType type;
     readonly attribute GPUSize32 count;
 };
@@ -11202,6 +11343,10 @@ GPUQuerySet includes GPUObjectBase;
 {{GPUQuerySet}} has the following attributes:
 
 <dl dfn-type=attribute dfn-for=GPUQuerySet>
+    : <dfn>device</dfn>
+    ::
+        Returns the {{GPUDevice}} that created this {{GPUQuerySet}}.
+
     : <dfn>type</dfn>
     ::
         The type of the queries managed by this {{GPUQuerySet}}.


### PR DESCRIPTION
Fixes #1497

Adds an `adapter` attrib to `GPUDevice`, a `texture` attrib to
`GPUTextureView`, a `commandEncoder` attrib to the pass encoders,
and a `device` attrib to most other interfaces.

Also includes a couple of minor cleanups to normalize the formatting/order of the interface definitions.

My initial thought was to put `device` on `GPUObjectBase` but that's also included by `GPUDevice` itself and objects such as `GPUTextureView` where we want a different parent object. Alternatively we could create a new mixin just for adding `device`, but then you'd still have things like `GPUDevice` and `GPUTextureView` which would be exposing the parent attributes directly. As a result I decided to do all of them as direct attributes rather than mixins, but I'm not particularly opinionated about it either way.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 7, 2022, 4:18 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fgpuweb%2Fgpuweb%2Ff9a6df6c4857a660d178cdc4b93aadd4ed2cb036%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%232484.)._
</details>
