### PR TITLE
Add simple examples for create, init, and error handling functions

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1438,12 +1438,6 @@ of the destination color space's gamut (e.g. if a Display P3 image is converted 
 
 # Initialization # {#initialization}
 
-## Examples ## {#initialization-examples}
-
-Issue:
-Need a robust example like the one in ErrorHandling.md, which handles all situations.
-Possibly also include a simple example with no handling.
-
 ## navigator.gpu ## {#navigator-gpu}
 
 A {{GPU}} object is available in the {{Window}} and {{DedicatedWorkerGlobalScope}} contexts through the {{Navigator}}
@@ -1541,11 +1535,9 @@ calling {{GPUAdapter/requestDevice()}}.
 </div>
 
 <div class="example">
-    Request a {{GPUAdapter}}:
+    Requesting a {{GPUAdapter}} with no hints:
     <pre highlight="js">
-        const adapter = await navigator.gpu.requestAdapter(/* ... */);
-        const features = adapter.features;
-        // ...
+        const gpuAdapter = await navigator.gpu.requestAdapter();
     </pre>
 </div>
 
@@ -1636,6 +1628,15 @@ enum GPUPowerPreference {
         [=fallback adapters=] should check the {{GPUAdapter}}.{{GPUAdapter/isFallbackAdapter}}
         attribute prior to requesting a {{GPUDevice}}.
 </dl>
+
+<div class="example">
+    Requesting a {{GPUPowerPreference/"high-performance"}} {{GPUAdapter}}:
+    <pre highlight="js">
+        const gpuAdapter = await navigator.gpu.requestAdapter({
+            powerPreference: 'high-performance'
+        });
+    </pre>
+</div>
 
 ## <dfn interface>GPUAdapter</dfn> ## {#gpu-adapter}
 
@@ -1759,6 +1760,14 @@ interface GPUAdapter {
         </div>
 </dl>
 
+<div class="example">
+    Requesting a {{GPUDevice}} with default features and limits:
+    <pre highlight="js">
+        const gpuAdapter = await navigator.gpu.requestAdapter();
+        const gpuDevice = await gpuAdapter.requestDevice();
+    </pre>
+</div>
+
 ### <dfn dictionary>GPUDeviceDescriptor</dfn> ### {#gpudevicedescriptor}
 
 {{GPUDeviceDescriptor}} describes a device request.
@@ -1795,6 +1804,22 @@ dictionary GPUDeviceDescriptor : GPUObjectDescriptorBase {
         reference to WebIDL spec). Or change the entire type to `any` and add back a `dictionary
         GPULimits` and define the conversion of the whole object by reference to WebIDL. -->
 </dl>
+
+<div class="example">
+    Requesting a {{GPUDevice}} with the {{GPUFeatureName/"texture-compression-astc"}} feature if supported:
+    <pre highlight="js">
+        const gpuAdapter = await navigator.gpu.requestAdapter();
+
+        const requiredFeatures = [];
+        if (gpuAdapter.features.has('texture-compression-astc')) {
+            requiredFeatures.push('texture-compression-astc')
+        }
+
+        const gpuDevice = await gpuAdapter.requestDevice({
+            requiredFeatures
+        });
+    </pre>
+</div>
 
 #### <dfn enum>GPUFeatureName</dfn> #### {#gpufeaturename}
 
@@ -1921,6 +1946,67 @@ Issue(gpuweb/gpuweb#354): Finish defining multithreading API and add `[Serializa
 Issue: `GPUDevice` doesn't really need the cross-origin policy restriction.
 It should be usable from multiple agents regardless. Once we describe the serialization
 of buffers, textures, and queues - the COOP+COEP logic should be moved in there.
+
+## Example ## {#initialization-examples}
+
+<div class="example">
+    A more robust example of requesting a {{GPUAdapter}} and {{GPUDevice}} with error handling:
+    <pre highlight="js">
+        let gpuAdapter = null;
+        let gpuDevice = null;
+
+        async function initializeWebGPU() {
+            try {
+                // Check for WebGPU support.
+                if (!('gpu' in navigator)) {
+                    throw new Error('WebGPU not supported by this user agent.');
+                }
+
+                // Request an adapter.
+                gpuAdapter = await navigator.gpu.requestAdapter();
+
+                // requestAdapter may resolve with null if no suitable adapters are found.
+                if (!gpuAdapter) {
+                    throw new Error('No suitable adapter found.');
+                }
+
+                // Request a device.
+                // The promise will reject if invalid options are passed to the optional dictionary.
+                gpuDevice = await gpuAdapter.requestDevice();
+
+                // requestDevice should never return null, but if a valid device request can't be
+                // fulfilled for some reason it may resolve to a device which has already been lost.
+                gpuDevice.lost.then((info) => {
+                    console.error(\`WebGPU device was lost: ${info.message}\`);
+
+                    gpuAdapter = null;
+                    gpuDevice = null;
+
+                    // Devices may be lost for a variety of reasons, and many are recoverable. It's
+                    // reasonable to try getting a new device once a previous one has been lost.
+                    // Note that any WebGPU resources created with the previous device (buffers,
+                    // textures, etc) will need to be re-created with the new one.
+                    initializeWebGPU();
+                });
+            } catch (error) {
+                console.error(\`WebGPU initialization failed: ${error.message}\`);
+
+                gpuAdapter = null;
+                gpuDevice = null;
+
+                throw error;
+            }
+
+            onWebGPUInitialized();
+        }
+
+        function onWebGPUInitialized() {
+            // Begin creating WebGPU resources here...
+        }
+
+        initializeWebGPU();
+    </pre>
+</div>
 
 # Buffers # {#buffers}
 
@@ -2134,6 +2220,16 @@ namespace GPUBufferUsage {
         </div>
 
 </dl>
+
+<div class="example">
+    Creating a 128 byte uniform buffer that can be written into:
+    <pre highlight="js">
+        const buffer = gpuDevice.createBuffer({
+            size: 128,
+            usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
+        });
+    </pre>
+</div>
 
 ## Buffer Destruction ## {#buffer-destruction}
 
@@ -2546,6 +2642,17 @@ namespace GPUTextureUsage {
                 </div>
         </div>
 </dl>
+
+<div class="example">
+    Creating a 16x16, RGBA, 2D texture:
+    <pre highlight="js">
+        const texture = gpuDevice.createTexture({
+            size: { width: 16, height: 16 },
+            format: 'rgba8unorm',
+            usage: GPUTextureUsage.TEXTURE_BINDING,
+        });
+    </pre>
+</div>
 
 ### Texture Destruction ### {#texture-destruction}
 
@@ -3130,6 +3237,16 @@ dictionary GPUExternalTextureDescriptor : GPUObjectDescriptorBase {
         </div>
 </dl>
 
+<div class="example">
+    Creating an external texture from a video element:
+    <pre highlight="js">
+        const videoElement = document.querySelector('video');
+        const externalTexture = gpuDevice.importExternalTexture({
+            source: videoElement
+        });
+    </pre>
+</div>
+
 ### Sampling External Textures ### {#external-texture-sampling}
 
 External textures are represented in WGSL with `texture_external` and may be read using
@@ -3373,6 +3490,19 @@ enum GPUCompareFunction {
             </div>
         </div>
 </dl>
+
+<div class="example">
+    Creating a {{GPUSampler}} that does trilinear filtering and repeats texture coordinates:
+    <pre highlight="js">
+        const sampler = gpuDevice.createSampler({
+            addressModeU = "repeat";
+            addressModeV = "repeat";
+            magFilter = "linear";
+            minFilter = "linear";
+            mipmapFilter = "linear";
+        });
+    </pre>
+</div>
 
 # Resource Binding # {#bindings}
 
@@ -4138,6 +4268,48 @@ Note: two {{GPUPipelineLayout}} objects are considered equivalent for any usage
 if their internal {{GPUPipelineLayout/[[bindGroupLayouts]]}} sequences contain
 {{GPUBindGroupLayout}} objects that are [=group-equivalent=].
 
+## Example ## {#bindgroup-examples}
+
+<div class="example">
+    Create a {{GPUBindGroupLayout}} that describes a binding with a uniform buffer, a texture, and a sampler.
+    Then create a {{GPUBindGroup}} and a {{GPUPipelineLayout}} using the {{GPUBindGroupLayout}}.
+    <pre highlight="js">
+        const bindGroupLayout = gpuDevice.createBindGroupLayout({
+            entries: [{
+                binding: 0,
+                visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+                buffer: {}
+            }, {
+                binding: 1,
+                visibility: GPUShaderStage.FRAGMENT,
+                texture: {}
+            }, {
+                binding: 2,
+                visibility: GPUShaderStage.FRAGMENT,
+                sampler: {}
+            }]
+        });
+
+        const bindGroup = gpuDevice.createBindGroup({
+            layout: bindGroupLayout,
+            entries: [{
+                binding: 0,
+                resource: { buffer: buffer },
+            }, {
+                binding: 1,
+                resource: texture
+            }, {
+                binding: 2,
+                resource: sampler
+            }]
+        });
+
+        const pipelineLayout = gpuDevice.createPipelineLayout({
+            bindGroupLayouts : [ bindGroupLayout ]
+        });
+    </pre>
+</div>
+
 # Shader Modules # {#shader-modules}
 
 ## <dfn interface>GPUShaderModule</dfn> ## {#shader-module}
@@ -4224,6 +4396,22 @@ same module, they should avoid passing that information to
             Issue: Describe {{GPUDevice/createShaderModule()}} algorithm steps.
         </div>
 </dl>
+
+<div class="example">
+    Create a {{GPUShaderModule}} from WGSL code:
+    <pre highlight="js">
+        const fragmentSource = \`
+            [[stage(fragment)]]
+            fn fragmentMain() -> [[location(0)]] vec4&lt;f32&gt; {
+                return vec4(1.0, 0.0, 0.0, 1.0);
+            }
+        \`;
+
+        const framgmentShaderModule = gpuDevice.createShaderModule({
+            code: fragmentSource,
+        });
+    </pre>
+</div>
 
 ### Shader Module Compilation Information ### {#shader-module-compilation-information}
 
@@ -4908,6 +5096,19 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
         </div>
 </dl>
 
+<div class="example">
+    Creating a simple {{GPUComputePipeline}}:
+    <pre highlight="js">
+        const computePipeline = gpuDevice.createComputePipeline({
+            layout: pipelineLayout,
+            compute: {
+                module: computeShaderModule,
+                entryPoint: 'computeMain',
+            }
+        });
+    </pre>
+</div>
+
 ## <dfn interface>GPURenderPipeline</dfn> ## {#render-pipeline}
 
 A {{GPURenderPipeline}} is a kind of [=pipeline=] that controls the vertex
@@ -5129,6 +5330,26 @@ Issue: should we validate that `cullMode` is none for points and lines?
 Issue: define what "compatible" means for render target formats.
 
 Issue: need a proper limit for the maximum number of color targets.
+
+<div class="example">
+    Creating a simple {{GPURenderPipeline}}:
+    <pre highlight="js">
+        const renderPipeline = gpuDevice.createRenderPipeline({
+            layout: pipelineLayout,
+            vertex: {
+                module: vertexShaderModule,
+                entryPoint: 'vertexMain'
+            },
+            fragment: {
+                module: fragmentShaderModule,
+                entryPoint: 'fragmentMain',
+                targets: [{
+                    format: 'bgra8unorm',
+                }],
+            }
+        });
+    </pre>
+</div>
 
 ### Primitive State ### {#primitive-state}
 
@@ -5756,6 +5977,17 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
         </div>
 </dl>
 
+<div class="example">
+    Creating a {{GPUCommandEncoder}}, encoding a command to clear a buffer, finishing the
+    encoder to get a {{GPUCommandBuffer}}, then submitting it to the {{GPUQueue}}.
+    <pre highlight="js">
+        const commandEncoder = gpuDevice.createCommandEncoder();
+        commandEncoder.clearBuffer(buffer);
+        const commandBuffer = commandEncoder.finish();
+        gpuDevice.queue.submit([commandBuffer]);
+    </pre>
+</div>
+
 ## Pass Encoding ## {#command-encoder-pass-encoding}
 
 <dl dfn-type=method dfn-for=GPUCommandEncoder>
@@ -6071,11 +6303,11 @@ dictionary GPUImageCopyExternalImage {
     ::
         Defines the origin of the copy - the minimum (top-left) corner of the source sub-region to copy from.
         Together with `copySize`, defines the full copy sub-region.
-    
+
     : <dfn>flipY</dfn>
     ::
         Describes whether the source image is vertically flipped, or not.
-       
+
         If this option is set to `true`, the copy is flipped vertically: the bottom row of the source
         region is copied into the first row of the destination region, and so on.
         The {{GPUImageCopyExternalImage/origin}} option is still relative to the top-left corner
@@ -8605,6 +8837,16 @@ dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
         </div>
 </dl>
 
+<div class="example">
+    Creating a {{GPUQuerySet}} which holds 32 occlusion query results.
+    <pre highlight="js">
+        const querySet = gpuDevice.createQuerySet({
+            type: 'occlusion',
+            count: 32
+        });
+    </pre>
+</div>
+
 ### QuerySet Destruction ### {#queryset-destruction}
 
 An application that no longer requires a {{GPUQuerySet}} can choose to lose access to it before
@@ -8671,8 +8913,6 @@ method of an {{HTMLCanvasElement}} instance by passing the string literal `'webg
     <pre highlight="js">
         const canvas = document.createElement('canvas');
         const context = canvas.getContext('webgpu');
-        context.configure(/* ... */);
-        // ...
     </pre>
 </div>
 
@@ -8945,6 +9185,20 @@ dictionary GPUCanvasConfiguration {
 };
 </script>
 
+<div class="example">
+    Configure a {{GPUCanvasContext}} to be used with a specific {{GPUDevice}}, using the preferred
+    format for this context:
+    <pre highlight="js">
+        const canvas = document.createElement('canvas');
+        const context =  canvas.getContext('webgpu');
+
+        context.configure({
+            device: gpuDevice,
+            format: context.getPreferredFormat(gpuAdapter),
+        });
+    </pre>
+</div>
+
 ### Canvas Color Space ### {#canvas-color-space}
 
 During presentation, the chrominance of color values outside of the [0, 1] range is not to be
@@ -8992,8 +9246,8 @@ must be reconfigured by calling {{GPUCanvasContext/configure()}} again with the 
             for (const entry of entries) {
                 if (entry != canvas) { continue; }
                 context.configure({
-                    device: someDevice,
-                    format: context.getPreferredFormat(someDevice.adapter),
+                    device: gpuDevice,
+                    format: context.getPreferredFormat(gpuAdapter),
                     size: {
                         // This reports the size of the canvas element in pixels
                         width: entry.devicePixelContentBoxSize[0].inlineSize,
@@ -9112,6 +9366,24 @@ partial interface GPUDevice {
         - There are no error scopes on the stack.
 </dl>
 
+<div class="example">
+    Using error scopes to capture errors from a {{GPUDevice}} operation that may fail:
+    <pre highlight="js">
+        gpuDevice.pushErrorScope('validation');
+
+        let shadermodule = gpuDevice.createShaderModule({
+            code: 'Invalid WGSL',
+        });
+
+        gpuDevice.popErrorScope().then((error) => {
+            if (error) {
+                shadermodule = null;
+                console.error(\`An error occured while creating shader module: ${error.message}\`);
+            }
+        });
+    </pre>
+</div>
+
 ## Telemetry ## {#telemetry}
 
 <script type=idl>
@@ -9149,6 +9421,17 @@ partial interface GPUDevice {
     attribute EventHandler onuncapturederror;
 };
 </script>
+
+<div class="example">
+    Listening for uncaptured errors from a {{GPUDevice}}:
+    <pre highlight="js">
+        gpuDevice.addEventListener('uncapturederror', (event) => {
+            if (event.error instanceof GPUValidationError) {
+                console.error(\`An uncaught WebGPU error was raised: ${event.error.message}\`);
+            }
+        });
+    </pre>
+</div>
 
 # Detailed Operations # {#detailed-operations}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1952,52 +1952,53 @@ of buffers, textures, and queues - the COOP+COEP logic should be moved in there.
 <div class="example">
     A more robust example of requesting a {{GPUAdapter}} and {{GPUDevice}} with error handling:
     <pre highlight="js">
-        let gpuAdapter = null;
         let gpuDevice = null;
 
         async function initializeWebGPU() {
-            try {
-                // Check for WebGPU support.
-                if (!('gpu' in navigator)) {
-                    throw new Error('WebGPU not supported by this user agent.');
-                }
-
-                // Request an adapter.
-                gpuAdapter = await navigator.gpu.requestAdapter();
-
-                // requestAdapter may resolve with null if no suitable adapters are found.
-                if (!gpuAdapter) {
-                    throw new Error('No suitable adapter found.');
-                }
-
-                // Request a device.
-                // The promise will reject if invalid options are passed to the optional dictionary.
-                gpuDevice = await gpuAdapter.requestDevice();
-
-                // requestDevice should never return null, but if a valid device request can't be
-                // fulfilled for some reason it may resolve to a device which has already been lost.
-                gpuDevice.lost.then((info) => {
-                    console.error(\`WebGPU device was lost: ${info.message}\`);
-
-                    gpuAdapter = null;
-                    gpuDevice = null;
-
-                    // Devices may be lost for a variety of reasons, and many are recoverable. It's
-                    // reasonable to try getting a new device once a previous one has been lost.
-                    // Note that any WebGPU resources created with the previous device (buffers,
-                    // textures, etc) will need to be re-created with the new one.
-                    initializeWebGPU();
-                });
-            } catch (error) {
-                console.error(\`WebGPU initialization failed: ${error.message}\`);
-
-                gpuAdapter = null;
-                gpuDevice = null;
-
-                throw error;
+            // Check to ensure the user agent supports WebGPU.
+            if (!('gpu' in navigator)) {
+                console.error('User agent doesn't support WebGPU.');
+                return false;
             }
 
+            // Request an adapter.
+            const gpuAdapter = await navigator.gpu.requestAdapter();
+
+            // requestAdapter may resolve with null if no suitable adapters are found.
+            if (!gpuAdapter) {
+                console.error('No WebGPU adapters found.');
+                return false;
+            }
+
+            // Request a device.
+            // Note that the promise will reject if invalid options are passed to the optional
+            // dictionary. To avoid the promise rejecting always check any features and limits
+            // against the adapters features and limits prior to calling requestDevice().
+            gpuDevice = await gpuAdapter.requestDevice();
+
+            // requestDevice will never return null, but if a valid device request can't be
+            // fulfilled for some reason it may resolve to a device which has already been lost.
+            // Additionally, devices can be lost at any time after creation, usually for external
+            // reasons (ie: driver updates), so it's a good idea to always handle lost devices
+            // gracefully.
+            gpuDevice.lost.then((info) => {
+                console.error(\`WebGPU device was lost: ${info.message}\`);
+
+                gpuDevice = null;
+
+                // Many causes for lost devices are transient, so applications should try getting a
+                // new device once a previous one has been lost unless the loss was caused by the
+                // application intentionally destroying the device. Note that any WebGPU resources
+                // created with the previous device (buffers, textures, etc) will need to be
+                // re-created with the new one.
+                if (info.reason != 'destroyed') {
+                    initializeWebGPU();
+                }
+            });
+
             onWebGPUInitialized();
+
+            return true;
         }
 
         function onWebGPUInitialized() {
@@ -2644,7 +2645,7 @@ namespace GPUTextureUsage {
 </dl>
 
 <div class="example">
-    Creating a 16x16, RGBA, 2D texture:
+    Creating a 16x16, RGBA, 2D texture with one array layer and one mip level:
     <pre highlight="js">
         const texture = gpuDevice.createTexture({
             size: { width: 16, height: 16 },
@@ -3495,11 +3496,11 @@ enum GPUCompareFunction {
     Creating a {{GPUSampler}} that does trilinear filtering and repeats texture coordinates:
     <pre highlight="js">
         const sampler = gpuDevice.createSampler({
-            addressModeU = "repeat";
-            addressModeV = "repeat";
-            magFilter = "linear";
-            minFilter = "linear";
-            mipmapFilter = "linear";
+            addressModeU: 'repeat',
+            addressModeV: 'repeat',
+            magFilter: 'linear',
+            minFilter: 'linear',
+            mipmapFilter: 'linear',
         });
     </pre>
 </div>
@@ -4305,7 +4306,7 @@ if their internal {{GPUPipelineLayout/[[bindGroupLayouts]]}} sequences contain
         });
 
         const pipelineLayout = gpuDevice.createPipelineLayout({
-            bindGroupLayouts : [ bindGroupLayout ]
+            bindGroupLayouts: [bindGroupLayout]
         });
     </pre>
 </div>
@@ -4400,15 +4401,24 @@ same module, they should avoid passing that information to
 <div class="example">
     Create a {{GPUShaderModule}} from WGSL code:
     <pre highlight="js">
-        const fragmentSource = \`
+        // A simple vertex and fragment shader pair that will fill the viewport with red.
+        const shaderSource = \`
+            var&lt;private&gt; pos : array&lt;vec2&lt;f32&gt;, 3&gt; = array&lt;vec2&lt;f32&gt;, 3&gt;(
+                vec2(-1.0, -1.0), vec2(-1.0, 3.0), vec2(3.0, -1.0));
+
+            [[stage(vertex)]]
+            fn vertexMain([[builtin(vertex_index)]] vertexIndex : u32) -&gt; [[builtin(position)]] vec4&lt;f32&gt; {
+                return vec4(pos[input.vertexIndex], 1.0, 1.0);
+            }
+
             [[stage(fragment)]]
-            fn fragmentMain() -> [[location(0)]] vec4&lt;f32&gt; {
+            fn fragmentMain() -&gt; [[location(0)]] vec4&lt;f32&gt; {
                 return vec4(1.0, 0.0, 0.0, 1.0);
             }
         \`;
 
-        const framgmentShaderModule = gpuDevice.createShaderModule({
-            code: fragmentSource,
+        const shaderModule = gpuDevice.createShaderModule({
+            code: shaderSource,
         });
     </pre>
 </div>
@@ -5337,11 +5347,11 @@ Issue: need a proper limit for the maximum number of color targets.
         const renderPipeline = gpuDevice.createRenderPipeline({
             layout: pipelineLayout,
             vertex: {
-                module: vertexShaderModule,
+                module: shaderModule,
                 entryPoint: 'vertexMain'
             },
             fragment: {
-                module: fragmentShaderModule,
+                module: shaderModule,
                 entryPoint: 'fragmentMain',
                 targets: [{
                     format: 'bgra8unorm',
@@ -9367,18 +9377,19 @@ partial interface GPUDevice {
 </dl>
 
 <div class="example">
-    Using error scopes to capture errors from a {{GPUDevice}} operation that may fail:
+    Using error scopes to capture validation errors from a {{GPUDevice}} operation that may fail:
     <pre highlight="js">
         gpuDevice.pushErrorScope('validation');
 
-        let shadermodule = gpuDevice.createShaderModule({
-            code: 'Invalid WGSL',
+        let sampler = gpuDevice.createSampler({
+            maxAnisotropy: 0, // Invalid, maxAnisotropy must be at least 1.
         });
 
         gpuDevice.popErrorScope().then((error) => {
             if (error) {
-                shadermodule = null;
-                console.error(\`An error occured while creating shader module: ${error.message}\`);
+                // There was an error creating the sampler, so discard it.
+                sampler = null;
+                console.error(\`An error occured while creating sampler: ${error.message}\`);
             }
         });
     </pre>
@@ -9427,7 +9438,7 @@ partial interface GPUDevice {
     <pre highlight="js">
         gpuDevice.addEventListener('uncapturederror', (event) => {
             if (event.error instanceof GPUValidationError) {
-                console.error(\`An uncaught WebGPU error was raised: ${event.error.message}\`);
+                console.error(\`An uncaught WebGPU validation error was raised: ${event.error.message}\`);
             }
         });
     </pre>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1978,9 +1978,9 @@ of buffers, textures, and queues - the COOP+COEP logic should be moved in there.
 
             // requestDevice will never return null, but if a valid device request can't be
             // fulfilled for some reason it may resolve to a device which has already been lost.
-            // Additionally, devices can be lost at any time after creation, usually for external
-            // reasons (ie: driver updates), so it's a good idea to always handle lost devices
-            // gracefully.
+            // Additionally, devices can be lost at any time after creation for a variety of reasons
+            // (ie: browser resource management, driver updates), so it's a good idea to always
+            // handle lost devices gracefully.
             gpuDevice.lost.then((info) => {
                 console.error(\`WebGPU device was lost: ${info.message}\`);
 


### PR DESCRIPTION
Started as trying to address the `Issue:` asking for a robust initialization example and got out of hand. 😄 

None of these example snippets are terribly complex and they're certainly not meant to be exhaustive, but I feel like it's helpful to have little snippets showing how the functions are called in the most basic cases as a way of offsetting the often overwhelming amount of spec prose. I'd also like to start a precedent of having more example code in the spec so that having snippets that demonstrate some of the less obvious cases aren't out of place.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/2488.html" title="Last updated on Jan 10, 2022, 11:39 PM UTC (652dac1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2488/7cd21b5...652dac1.html" title="Last updated on Jan 10, 2022, 11:39 PM UTC (652dac1)">Diff</a>