### PR TITLE
Require 1D texture mipLevelCount to be 1.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2445,7 +2445,7 @@ namespace GPUTextureUsage {
         - If |dimension| is:
             <dl class="switch">
                 : {{GPUTextureDimension/"1d"}}
-                :: Let |m| = |size|.[=Extent3D/width=].
+                :: Return 1.
 
                 : {{GPUTextureDimension/"2d"}}
                 :: Let |m| = max(|size|.[=Extent3D/width=], |size|.[=Extent3D/height=]).


### PR DESCRIPTION
Fixes #2490


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/2491.html" title="Last updated on Jan 10, 2022, 3:47 PM UTC (1566df5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2491/e3a1a60...Kangz:1566df5.html" title="Last updated on Jan 10, 2022, 3:47 PM UTC (1566df5)">Diff</a>