### PR TITLE
Mirror descriptor properties on GPU resources

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2030,8 +2030,8 @@ that returns a new buffer in the [=buffer state/mapped=] or [=buffer state/unmap
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUBuffer {
-    readonly attribute GPUSize64 size;
-    readonly attribute GPUBufferUsageFlags usage;
+    readonly attribute unsigned long long size;
+    readonly attribute unsigned long usage;
 
     Promise<undefined> mapAsync(GPUMapModeFlags mode, optional GPUSize64 offset = 0, optional GPUSize64 size);
     ArrayBuffer getMappedRange(optional GPUSize64 offset = 0, optional GPUSize64 size);
@@ -2475,11 +2475,11 @@ that returns a new texture.
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUTexture {
     [SameObject] readonly attribute GPUExtent3DReadOnly size;
-    readonly attribute GPUIntegerCoordinate mipLevelCount;
-    readonly attribute GPUSize32 sampleCount;
+    readonly attribute unsigned long mipLevelCount;
+    readonly attribute unsigned long sampleCount;
     readonly attribute GPUTextureDimension dimension;
     readonly attribute GPUTextureFormat format;
-    readonly attribute GPUTextureUsageFlags usage;
+    readonly attribute unsigned long usage;
 
     GPUTextureView createView(optional GPUTextureViewDescriptor descriptor = {});
 
@@ -2736,10 +2736,10 @@ interface GPUTextureView {
     readonly attribute GPUTextureFormat format;
     readonly attribute GPUTextureViewDimension dimension;
     readonly attribute GPUTextureAspect aspect;
-    readonly attribute GPUIntegerCoordinate baseMipLevel;
-    readonly attribute GPUIntegerCoordinate mipLevelCount;
-    readonly attribute GPUIntegerCoordinate baseArrayLayer;
-    readonly attribute GPUIntegerCoordinate arrayLayerCount;
+    readonly attribute unsigned long baseMipLevel;
+    readonly attribute unsigned long mipLevelCount;
+    readonly attribute unsigned long baseArrayLayer;
+    readonly attribute unsigned long arrayLayerCount;
 };
 GPUTextureView includes GPUObjectBase;
 </script>
@@ -8914,7 +8914,7 @@ Queries {#queries}
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUQuerySet {
     readonly attribute GPUQueryType type;
-    readonly attribute GPUSize32 count;
+    readonly attribute unsigned long count;
 
     undefined destroy();
 };
@@ -10421,9 +10421,9 @@ typedef (sequence<GPUIntegerCoordinate> or GPUExtent3DDict) GPUExtent3D;
 interface GPUExtent3DReadOnly {
     constructor(GPUExtent3D extent);
 
-    readonly attribute GPUIntegerCoordinate width;
-    readonly attribute GPUIntegerCoordinate height;
-    readonly attribute GPUIntegerCoordinate depthOrArrayLayers;
+    readonly attribute unsigned long width;
+    readonly attribute unsigned long height;
+    readonly attribute unsigned long depthOrArrayLayers;
 };
 </script>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2474,7 +2474,7 @@ that returns a new texture.
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUTexture {
-    readonly attribute GPUExtent3DDict size;
+    [SameObject] readonly attribute GPUExtent3DReadOnly size;
     readonly attribute GPUIntegerCoordinate mipLevelCount;
     readonly attribute GPUSize32 sampleCount;
     readonly attribute GPUTextureDimension dimension;
@@ -2493,8 +2493,7 @@ GPUTexture includes GPUObjectBase;
 <dl dfn-type=attribute dfn-for="GPUTexture">
     : <dfn>size</dfn>
     ::
-        Returns {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}} as a {{GPUExtent3DDict}},
-        accessed as described by [=Extent3D=].
+        Returns a {{GPUExtent3DReadOnly}} initialized with {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}.
 
     : <dfn>mipLevelCount</dfn>
     ::
@@ -10417,6 +10416,15 @@ dictionary GPUExtent3DDict {
     GPUIntegerCoordinate depthOrArrayLayers = 1;
 };
 typedef (sequence<GPUIntegerCoordinate> or GPUExtent3DDict) GPUExtent3D;
+
+[Exposed=(Window, DedicatedWorker), SecureContext]
+interface GPUExtent3DReadOnly {
+    constructor(GPUExtent3D extent);
+
+    readonly attribute GPUIntegerCoordinate width;
+    readonly attribute GPUIntegerCoordinate height;
+    readonly attribute GPUIntegerCoordinate depthOrArrayLayers;
+};
 </script>
 
 An <dfn dfn>Extent3D</dfn> is a {{GPUExtent3D}}.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -850,12 +850,12 @@ to form complete [=texel blocks=] in the [=subresource=].
 
   - For pixel-based {{GPUTextureFormat|GPUTextureFormats}}, the [=physical size=] is always equal to the size of the [=texture subresource=]
     used in the sampling hardwares.
-  - [=Textures=] in block-based compressed {{GPUTextureFormat|GPUTextureFormats}} always have a [=mipmap level=] 0 whose {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}
+  - [=Textures=] in block-based compressed {{GPUTextureFormat|GPUTextureFormats}} always have a [=mipmap level=] 0 whose {{GPUTexture/size}}
     is a multiple of the [=texel block size=], but the lower mipmap levels might not be
     multiples of the [=texel block size=] and can have paddings.
 
 <div class="example">
-Considering a {{GPUTexture}} in BC format whose {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}} is {60, 60, 1}, when sampling
+Considering a {{GPUTexture}} in BC format whose {{GPUTexture/size}} is {60, 60, 1}, when sampling
 the {{GPUTexture}} at [=mipmap level=] 2, the sampling hardware uses {15, 15, 1} as the size of the [=texture subresource=],
 while its [=physical size=] is {16, 16, 1} as the block-compression algorithm can only operate on 4x4 [=texel blocks=].
 </div>
@@ -2030,6 +2030,9 @@ that returns a new buffer in the [=buffer state/mapped=] or [=buffer state/unmap
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUBuffer {
+    readonly attribute GPUSize64 size;
+    readonly attribute GPUBufferUsageFlags usage;
+
     Promise<undefined> mapAsync(GPUMapModeFlags mode, optional GPUSize64 offset = 0, optional GPUSize64 size);
     ArrayBuffer getMappedRange(optional GPUSize64 offset = 0, optional GPUSize64 size);
     undefined unmap();
@@ -2039,17 +2042,21 @@ interface GPUBuffer {
 GPUBuffer includes GPUObjectBase;
 </script>
 
-{{GPUBuffer}} has the following internal slots:
+{{GPUBuffer}} has the following attributes:
 
 <dl dfn-type=attribute dfn-for="GPUBuffer">
-    : <dfn>\[[size]]</dfn> of type {{GPUSize64}}.
+    : <dfn>size</dfn>
     ::
         The length of the {{GPUBuffer}} allocation in bytes.
 
-    : <dfn>\[[usage]]</dfn> of type {{GPUBufferUsageFlags}}.
+    : <dfn>usage</dfn>
     ::
         The allowed usages for this {{GPUBuffer}}.
+</dl>
 
+{{GPUBuffer}} has the following internal slots:
+
+<dl dfn-type=attribute dfn-for="GPUBuffer">
     : <dfn>\[[state]]</dfn> of type [=buffer state=].
     ::
         The current state of the {{GPUBuffer}}.
@@ -2077,7 +2084,7 @@ GPUBuffer includes GPUObjectBase;
         The {{GPUMapModeFlags}} of the last call to {{GPUBuffer/mapAsync()}} (if any).
 </dl>
 
-Issue: {{GPUBuffer/[[usage]]}} is differently named from {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}}.
+Issue: {{GPUBuffer/usage}} is differently named from {{GPUTexture/usage}}.
 We should make it consistent.
 
 Each {{GPUBuffer}} has a current <dfn dfn>buffer state</dfn> on the [=Content timeline=]
@@ -2095,7 +2102,7 @@ which is one of the following:
      no longer available for any operations except {{GPUBuffer/destroy}}.
 
 Note:
-{{GPUBuffer/[[size]]}} and {{GPUBuffer/[[usage]]}} are immutable once the
+{{GPUBuffer/size}} and {{GPUBuffer/usage}} are immutable once the
 {{GPUBuffer}} has been created.
 
 <div class=note>
@@ -2196,11 +2203,11 @@ namespace GPUBufferUsage {
             and may be discarded or recycled.
 
             1. Let |b| be a new {{GPUBuffer}} object.
-            1. Set |b|.{{GPUBuffer/[[size]]}} to |descriptor|.{{GPUBufferDescriptor/size}}.
-            1. Set |b|.{{GPUBuffer/[[usage]]}} to |descriptor|.{{GPUBufferDescriptor/usage}}.
+            1. Set |b|.{{GPUBuffer/size}} to |descriptor|.{{GPUBufferDescriptor/size}}.
+            1. Set |b|.{{GPUBuffer/usage}} to |descriptor|.{{GPUBufferDescriptor/usage}}.
             1. If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`:
 
-                1. Set |b|.{{GPUBuffer/[[mapping]]}} to a new {{ArrayBuffer}} of size |b|.{{GPUBuffer/[[size]]}}.
+                1. Set |b|.{{GPUBuffer/[[mapping]]}} to a new {{ArrayBuffer}} of size |b|.{{GPUBuffer/size}}.
                 1. Set |b|.{{GPUBuffer/[[mapping_range]]}} to `[0, descriptor.size]`.
                 1. Set |b|.{{GPUBuffer/[[mapped_ranges]]}} to `[]`.
                 1. Set |b|.{{GPUBuffer/[[state]]}} to [=buffer state/mapped at creation=].
@@ -2306,7 +2313,7 @@ namespace GPUMapMode {
             Issue(gpuweb/gpuweb#605): Handle error buffers once we have a description of the error monad.
 
             1. If |size| is missing:
-                1. Let |rangeSize| be max(0, |this|.{{GPUBuffer/[[size]]}} - |offset|).
+                1. Let |rangeSize| be max(0, |this|.{{GPUBuffer/size}} - |offset|).
 
                 Otherwise, let |rangeSize| be |size|.
 
@@ -2316,11 +2323,11 @@ namespace GPUMapMode {
                         TODO: check destroyed state?
                     - |offset| is a multiple of 8.
                     - |rangeSize| is a multiple of 4.
-                    - |offset| + |rangeSize| is less or equal to |this|.{{GPUBuffer/[[size]]}}
+                    - |offset| + |rangeSize| is less or equal to |this|.{{GPUBuffer/size}}
                     - |this|.{{GPUBuffer/[[state]]}} is [=buffer state/unmapped=]
                     - |mode| contains exactly one of {{GPUMapMode/READ}} or {{GPUMapMode/WRITE}}.
-                    - If |mode| contains {{GPUMapMode/READ}} then |this|.{{GPUBuffer/[[usage]]}} must contain {{GPUBufferUsage/MAP_READ}}.
-                    - If |mode| contains {{GPUMapMode/WRITE}} then |this|.{{GPUBuffer/[[usage]]}} must contain {{GPUBufferUsage/MAP_WRITE}}.
+                    - If |mode| contains {{GPUMapMode/READ}} then |this|.{{GPUBuffer/usage}} must contain {{GPUBufferUsage/MAP_READ}}.
+                    - If |mode| contains {{GPUMapMode/WRITE}} then |this|.{{GPUBuffer/usage}} must contain {{GPUBufferUsage/MAP_WRITE}}.
 
                     Issue: Do we validate that |mode| contains only valid flags?
                 </div>
@@ -2365,7 +2372,7 @@ namespace GPUMapMode {
             **Returns:** {{ArrayBuffer}}
 
             1. If |size| is missing:
-                1. Let |rangeSize| be max(0, |this|.{{GPUBuffer/[[size]]}} - |offset|).
+                1. Let |rangeSize| be max(0, |this|.{{GPUBuffer/size}} - |offset|).
 
                 Otherwise, let |rangeSize| be |size|.
 
@@ -2459,6 +2466,13 @@ that returns a new texture.
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUTexture {
+    readonly attribute GPUExtent3DDict size;
+    readonly attribute GPUIntegerCoordinate mipLevelCount;
+    readonly attribute GPUSize32 sampleCount;
+    readonly attribute GPUTextureDimension dimension;
+    readonly attribute GPUTextureFormat format;
+    readonly attribute GPUTextureUsageFlags usage;
+
     GPUTextureView createView(optional GPUTextureViewDescriptor descriptor = {});
 
     undefined destroy();
@@ -2466,15 +2480,37 @@ interface GPUTexture {
 GPUTexture includes GPUObjectBase;
 </script>
 
+{{GPUTexture}} has the following attributes:
+
+<dl dfn-type=attribute dfn-for="GPUTexture">
+    : <dfn>size</dfn>
+    ::
+        The dimensions of the {{GPUTexture}} in pixels.
+
+    : <dfn>mipLevelCount</dfn>
+    ::
+        The number of mip levels of the {{GPUTexture}}.
+
+    : <dfn>sampleCount</dfn>
+    ::
+        The number of samples of the {{GPUTexture}}.
+
+    : <dfn>dimension</dfn>
+    ::
+        Whether the {{GPUTexture}} is 1D, 2D, or 3D.
+
+    : <dfn>format</dfn>
+    ::
+        The format of the {{GPUTexture}}.
+
+    : <dfn>usage</dfn>
+    ::
+        The allowed usages for this {{GPUTexture}}.
+</dl>
+
 {{GPUTexture}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUTexture">
-    : <dfn>\[[descriptor]]</dfn>, of type {{GPUTextureDescriptor}}
-    ::
-        The {{GPUTextureDescriptor}} describing this texture.
-
-        All optional fields of {{GPUTextureDescriptor}} are defined.
-
     : <dfn>\[[destroyed]]</dfn>, of type `boolean`, initially false
     ::
         If the texture is destroyed, it can no longer be used in any operation,
@@ -2639,7 +2675,14 @@ namespace GPUTextureUsage {
                             1. Return a new [=invalid=] {{GPUTexture}}.
 
                     1. Let |t| be a new {{GPUTexture}} object.
-                    1. Set |t|.{{GPUTexture/[[descriptor]]}} to |descriptor|.
+                    1. Set |t|.{{GPUTexture/size}}.{{GPUExtent3DDict/width}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=].
+                    1. Set |t|.{{GPUTexture/size}}.{{GPUExtent3DDict/height}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=].
+                    1. Set |t|.{{GPUTexture/size}}.{{GPUExtent3DDict/depthOrArrayLayers}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=].
+                    1. Set |t|.{{GPUTexture/mipLevelCount}} to |descriptor|.{{GPUTextureDescriptor/mipLevelCount}}.
+                    1. Set |t|.{{GPUTexture/sampleCount}} to |descriptor|.{{GPUTextureDescriptor/sampleCount}}.
+                    1. Set |t|.{{GPUTexture/dimension}} to |descriptor|.{{GPUTextureDescriptor/dimension}}.
+                    1. Set |t|.{{GPUTexture/format}} to |descriptor|.{{GPUTextureDescriptor/format}}.
+                    1. Set |t|.{{GPUTexture/usage}} to |descriptor|.{{GPUTextureDescriptor/usage}}.
                     1. Return |t|.
                 </div>
         </div>
@@ -2826,50 +2869,50 @@ enum GPUTextureAspect {
                             - If the |descriptor|.{{GPUTextureViewDescriptor/aspect}} is
                                 <dl class="switch">
                                     : {{GPUTextureAspect/"stencil-only"}}
-                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}} must be a
+                                    :: |this|.{{GPUTexture/format}} must be a
                                         [=depth-or-stencil format=] which has a stencil aspect.
 
                                     : {{GPUTextureAspect/"depth-only"}}
-                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}} must be a
+                                    :: |this|.{{GPUTexture/format}} must be a
                                         [=depth-or-stencil format=] which has a depth aspect.
                                 </dl>
                             - |descriptor|.{{GPUTextureViewDescriptor/mipLevelCount}} must be &gt; 0.
                             - |descriptor|.{{GPUTextureViewDescriptor/baseMipLevel}} +
                                 |descriptor|.{{GPUTextureViewDescriptor/mipLevelCount}} must be &le;
-                                |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/mipLevelCount}}.
+                                |this|.{{GPUTexture/mipLevelCount}}.
                             - |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be &gt; 0.
                             - |descriptor|.{{GPUTextureViewDescriptor/baseArrayLayer}} +
                                 |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be &le;
                                 the [$array layer count$] of |this|.
-                            - |descriptor|.{{GPUTextureViewDescriptor/format}} must be |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
+                            - |descriptor|.{{GPUTextureViewDescriptor/format}} must be |this|.{{GPUTexture/format}}.
                                 <div class="issue">Allow for creating views with compatible formats as well.</div>
                             - If |descriptor|.{{GPUTextureViewDescriptor/dimension}} is:
                                 <dl class="switch">
                                     : {{GPUTextureViewDimension/"1d"}}
-                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"1d"}}.
+                                    :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"1d"}}.
                                     :: |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `1`.
 
                                     : {{GPUTextureViewDimension/"2d"}}
-                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"2d"}}.
+                                    :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
                                     :: |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `1`.
 
                                     : {{GPUTextureViewDimension/"2d-array"}}
-                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"2d"}}.
+                                    :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
 
                                     : {{GPUTextureViewDimension/"cube"}}
-                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"2d"}}.
+                                    :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
                                     :: |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `6`.
-                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be
-                                        |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}.[=Extent3D/height=].
+                                    :: |this|.{{GPUTexture/size}}.[=Extent3D/width=] must be
+                                        |this|.{{GPUTexture/size}}.[=Extent3D/height=].
 
                                     : {{GPUTextureViewDimension/"cube-array"}}
-                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"2d"}}.
+                                    :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
                                     :: |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be a multiple of `6`.
-                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be
-                                        |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}.[=Extent3D/height=].
+                                    :: |this|.{{GPUTexture/size}}.[=Extent3D/width=] must be
+                                        |this|.{{GPUTexture/size}}.[=Extent3D/height=].
 
                                     : {{GPUTextureViewDimension/"3d"}}
-                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"3d"}}.
+                                    :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"3d"}}.
                                     :: |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `1`.
                                 </dl>
                         </div>
@@ -2881,8 +2924,8 @@ enum GPUTextureAspect {
                     1. Let |view| be a new {{GPUTextureView}} object.
                     1. Set |view|.{{GPUTextureView/[[texture]]}} to |this|.
                     1. Set |view|.{{GPUTextureView/[[descriptor]]}} to |descriptor|.
-                    1. If |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}} contains {{GPUTextureUsage/RENDER_ATTACHMENT}}:
-                        1. Let |renderExtent| be [$compute render extent$](|this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}, |descriptor|.{{GPUTextureViewDescriptor/baseMipLevel}}).
+                    1. If |this|.{{GPUTexture/usage}} contains {{GPUTextureUsage/RENDER_ATTACHMENT}}:
+                        1. Let |renderExtent| be [$compute render extent$](|this|.{{GPUTexture/size}}, |descriptor|.{{GPUTextureViewDescriptor/baseMipLevel}}).
                         1. Set |view|.{{GPUTextureView/[[renderExtent]]}} to |renderExtent|.
                     1. Return |view|.
                 </div>
@@ -2895,12 +2938,12 @@ enum GPUTextureAspect {
 
     1. Let |resolved| be a copy of |descriptor|.
     1. If |resolved|.{{GPUTextureViewDescriptor/format}} is `undefined`,
-        set |resolved|.{{GPUTextureViewDescriptor/format}} to |texture|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
+        set |resolved|.{{GPUTextureViewDescriptor/format}} to |texture|.{{GPUTexture/format}}.
     1. If |resolved|.{{GPUTextureViewDescriptor/mipLevelCount}} is `undefined`,
-        set |resolved|.{{GPUTextureViewDescriptor/mipLevelCount}} to |texture|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/mipLevelCount}}
+        set |resolved|.{{GPUTextureViewDescriptor/mipLevelCount}} to |texture|.{{GPUTexture/mipLevelCount}}
         &minus; {{GPUTextureViewDescriptor/baseMipLevel}}.
     1. If |resolved|.{{GPUTextureViewDescriptor/dimension}} is `undefined` and
-        |texture|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} is:
+        |texture|.{{GPUTexture/dimension}} is:
         <dl class="switch">
             : {{GPUTextureDimension/"1d"}}
             :: Set |resolved|.{{GPUTextureViewDescriptor/dimension}} to {{GPUTextureViewDimension/"1d"}}.
@@ -2923,7 +2966,7 @@ enum GPUTextureAspect {
 
             : {{GPUTextureViewDimension/"2d-array"}} or {{GPUTextureViewDimension/"cube-array"}}
             :: Set |resolved|.{{GPUTextureViewDescriptor/arrayLayerCount}} to
-                |texture|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] &minus;
+                |texture|.{{GPUTexture/size}}.[=Extent3D/depthOrArrayLayers=] &minus;
                 {{GPUTextureViewDescriptor/baseArrayLayer}}.
         </dl>
 
@@ -2934,13 +2977,13 @@ enum GPUTextureAspect {
     To determine the <dfn abstract-op>array layer count</dfn> of {{GPUTexture}} |texture|, run the
     following steps:
 
-        1. If |texture|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} is:
+        1. If |texture|.{{GPUTexture/dimension}} is:
             <dl class="switch">
                 : {{GPUTextureDimension/"1d"}} or {{GPUTextureDimension/"3d"}}
                 :: Return `1`.
 
                 : {{GPUTextureDimension/"2d"}}
-                :: Return |texture|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=].
+                :: Return |texture|.{{GPUTexture/size}}.[=Extent3D/depthOrArrayLayers=].
             </dl>
 </div>
 
@@ -4163,7 +4206,7 @@ A {{GPUBindGroup}} object has the following internal slots:
 <div algorithm>
     <dfn abstract-op>effective buffer binding size</dfn>(binding)
         1. If |binding|.{{GPUBufferBinding/size}} is `undefined`:
-            1. Return max(0, |binding|.{{GPUBufferBinding/buffer}}.{{GPUBuffer/[[size]]}} - |binding|.{{GPUBufferBinding/offset}});
+            1. Return max(0, |binding|.{{GPUBufferBinding/buffer}}.{{GPUBuffer/size}} - |binding|.{{GPUBufferBinding/offset}});
         1. Return |binding|.{{GPUBufferBinding/size}}.
 </div>
 
@@ -6224,19 +6267,19 @@ dictionary GPUImageCopyTexture {
   **Returns:** {{boolean}}
 
   Let:
-  - |blockWidth| be the [=texel block width=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
-  - |blockHeight| be the [=texel block height=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
+  - |blockWidth| be the [=texel block width=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}}.
+  - |blockHeight| be the [=texel block height=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}}.
 
   Return `true` if and only if all of the following conditions apply:
   - |imageCopyTexture|.{{GPUImageCopyTexture/texture}} must be a [=valid=] {{GPUTexture}}.
-  - |imageCopyTexture|.{{GPUImageCopyTexture/mipLevel}} must be less than the {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/mipLevelCount}} of
+  - |imageCopyTexture|.{{GPUImageCopyTexture/mipLevel}} must be less than the {{GPUTexture/mipLevelCount}} of
     |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.
   - |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/x=] must be a multiple of |blockWidth|.
   - |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/y=] must be a multiple of |blockHeight|.
   - The [=imageCopyTexture subresource size=] of |imageCopyTexture| is equal to |copySize| if either of
       the following conditions is true:
-        - |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}} is a depth-stencil format.
-        - |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}} is greater than 1.
+        - |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}} is a depth-stencil format.
+        - |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/sampleCount}} is greater than 1.
 
 </div>
 
@@ -6354,15 +6397,15 @@ dictionary GPUImageCopyExternalImage {
                     <div class=validusage>
                         - |source| is [$valid to use with$] |this|.
                         - |destination| is [$valid to use with$] |this|.
-                        - |source|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/COPY_SRC}}.
-                        - |destination|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/COPY_DST}}.
+                        - |source|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/COPY_SRC}}.
+                        - |destination|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/COPY_DST}}.
                         - |size| is a multiple of 4.
                         - |sourceOffset| is a multiple of 4.
                         - |destinationOffset| is a multiple of 4.
                         - (|sourceOffset| + |size|) does not overflow a {{GPUSize64}}.
                         - (|destinationOffset| + |size|) does not overflow a {{GPUSize64}}.
-                        - |source|.{{GPUBuffer/[[size]]}} is greater than or equal to (|sourceOffset| + |size|).
-                        - |destination|.{{GPUBuffer/[[size]]}} is greater than or equal to (|destinationOffset| + |size|).
+                        - |source|.{{GPUBuffer/size}} is greater than or equal to (|sourceOffset| + |size|).
+                        - |destination|.{{GPUBuffer/size}} is greater than or equal to (|destinationOffset| + |size|).
                         - |source| and |destination| are not the same {{GPUBuffer}}.
 
                         Issue(gpuweb/gpuweb#69): figure out how to handle overflows in the spec.
@@ -6395,14 +6438,14 @@ dictionary GPUImageCopyExternalImage {
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
                 1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
-                1. If |size| is missing, set |size| to `max(0, |buffer|.{{GPUBuffer/[[size]]}} - |offset|)`.
+                1. If |size| is missing, set |size| to `max(0, |buffer|.{{GPUBuffer/size}} - |offset|)`.
                 1. If any of the following conditions are unsatisfied, generate a validation error and stop.
                     <div class=validusage>
                         - |buffer| is [$valid to use with$] |this|.
-                        - |buffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/COPY_DST}}.
+                        - |buffer|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/COPY_DST}}.
                         - |size| is a multiple of 4.
                         - |offset| is a multiple of 4.
-                        - |buffer|.{{GPUBuffer/[[size]]}} is greater than or equal to (|offset| + |size|).
+                        - |buffer|.{{GPUBuffer/size}} is greater than or equal to (|offset| + |size|).
                     </div>
             </div>
         </div>
@@ -6508,15 +6551,15 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
 <dfn dfn>Valid Texture Copy Range</dfn>
 
 Given a {{GPUImageCopyTexture}} |imageCopyTexture| and a {{GPUExtent3D}} |copySize|, let
-  - |blockWidth| be the [=texel block width=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
-  - |blockHeight| be the [=texel block height=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
+  - |blockWidth| be the [=texel block width=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}}.
+  - |blockHeight| be the [=texel block height=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}}.
 
 The following validation rules apply:
 
-  - If the {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} of |imageCopyTexture|.{{GPUImageCopyTexture/texture}} is
+  - If the {{GPUTexture/dimension}} of |imageCopyTexture|.{{GPUImageCopyTexture/texture}} is
     {{GPUTextureDimension/1d}}:
     - Both |copySize|.[=Extent3D/height=] and [=Extent3D/depthOrArrayLayers=] must be 1.
-  - If the {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} of |imageCopyTexture|.{{GPUImageCopyTexture/texture}} is
+  - If the {{GPUTexture/dimension}} of |imageCopyTexture|.{{GPUImageCopyTexture/texture}} is
     {{GPUTextureDimension/2d}}:
      -  (|imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/x=] + |copySize|.[=Extent3D/width=]),
         (|imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/y=] + |copySize|.[=Extent3D/height=]), and
@@ -6562,25 +6605,25 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
                 1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, generate a validation error and stop.
                     <div class=validusage>
-                        - Let |dstTextureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
+                        - Let |dstTexture| be |destination|.{{GPUImageCopyTexture/texture}}.
                         - [$validating GPUImageCopyBuffer$](|source|) returns `true`.
-                        - |source|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/COPY_SRC}}.
+                        - |source|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/usage}} contains {{GPUBufferUsage/COPY_SRC}}.
                         - [$validating GPUImageCopyTexture$](|destination|, |copySize|) returns `true`.
-                        - |dstTextureDesc|.{{GPUTextureDescriptor/usage}} contains {{GPUTextureUsage/COPY_DST}}.
-                        - |dstTextureDesc|.{{GPUTextureDescriptor/sampleCount}} is 1.
-                        - If |dstTextureDesc|.{{GPUTextureDescriptor/format}} is a [=depth-or-stencil format=]:
+                        - |dstTexture|.{{GPUTexture/usage}} contains {{GPUTextureUsage/COPY_DST}}.
+                        - |dstTexture|.{{GPUTexture/sampleCount}} is 1.
+                        - If |dstTexture|.{{GPUTexture/format}} is a [=depth-or-stencil format=]:
                             - |destination|.{{GPUImageCopyTexture/aspect}} must refer to a single aspect of
-                                |dstTextureDesc|.{{GPUTextureDescriptor/format}}, and that aspect must be
+                                |dstTexture|.{{GPUTexture/format}}, and that aspect must be
                                 a valid image copy destination according to [[#depth-formats]].
                         - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
-                        - If |dstTextureDesc|.{{GPUTextureDescriptor/format}} is not a [=depth-or-stencil format=]:
+                        - If |dstTexture|.{{GPUTexture/format}} is not a [=depth-or-stencil format=]:
                             - |source|.{{GPUImageDataLayout/offset}} is a multiple of the [=texel block size=] of
-                                |dstTextureDesc|.{{GPUTextureDescriptor/format}}.
-                        - If |dstTextureDesc|.{{GPUTextureDescriptor/format}} is a [=depth-or-stencil format=]:
+                                |dstTexture|.{{GPUTexture/format}}.
+                        - If |dstTexture|.{{GPUTexture/format}} is a [=depth-or-stencil format=]:
                             - |source|.{{GPUImageDataLayout/offset}} is a multiple of 4.
                         - [$validating linear texture data$](|source|,
-                            |source|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[size]]}},
-                            |dstTextureDesc|.{{GPUTextureDescriptor/format}},
+                            |source|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/size}},
+                            |dstTexture|.{{GPUTexture/format}},
                             |copySize|) succeeds.
                     </div>
             </div>
@@ -6608,26 +6651,26 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
                 1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, generate a validation error and stop.
                     <div class=validusage>
-                        - Let |srcTextureDesc| be |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
+                        - Let |srcTexture| be |source|.{{GPUImageCopyTexture/texture}}.
                         - [$validating GPUImageCopyTexture$](|source|, |copySize|) returns `true`.
-                        - |srcTextureDesc|.{{GPUTextureDescriptor/usage}} contains {{GPUTextureUsage/COPY_SRC}}.
-                        - |srcTextureDesc|.{{GPUTextureDescriptor/sampleCount}} is 1.
-                        - If |srcTextureDesc|.{{GPUTextureDescriptor/format}} is a depth-stencil format:
+                        - |srcTexture|.{{GPUTexture/usage}} contains {{GPUTextureUsage/COPY_SRC}}.
+                        - |srcTexture|.{{GPUTexture/sampleCount}} is 1.
+                        - If |srcTexture|.{{GPUTexture/format}} is a depth-stencil format:
                             - |destination|.{{GPUImageCopyTexture/aspect}} must refer to a single aspect of
-                                |srcTextureDesc|.{{GPUTextureDescriptor/format}}, and that aspect must be
+                                |srcTexture|.{{GPUTexture/format}}, and that aspect must be
                                 a valid image copy source according to [[#depth-formats]].
                         - [$validating GPUImageCopyBuffer$](|destination|) returns `true`.
-                        - |destination|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[usage]]}} contains
+                        - |destination|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/usage}} contains
                             {{GPUBufferUsage/COPY_DST}}.
                         - [=Valid Texture Copy Range=] applies to |source| and |copySize|.
-                        - If |srcTextureDesc|.{{GPUTextureDescriptor/format}} is not a [=depth-or-stencil format=]:
+                        - If |srcTexture|.{{GPUTexture/format}} is not a [=depth-or-stencil format=]:
                             - |destination|.{{GPUImageDataLayout/offset}} is a multiple of the [=texel block size=] of
-                                |srcTextureDesc|.{{GPUTextureDescriptor/format}}.
-                        - If |srcTextureDesc|.{{GPUTextureDescriptor/format}} is a [=depth-or-stencil format=]:
+                                |srcTexture|.{{GPUTexture/format}}.
+                        - If |srcTexture|.{{GPUTexture/format}} is a [=depth-or-stencil format=]:
                             - |destination|.{{GPUImageDataLayout/offset}} is a multiple of 4.
                         - [$validating linear texture data$](|destination|,
-                            |destination|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[size]]}},
-                            |srcTextureDesc|.{{GPUTextureDescriptor/format}},
+                            |destination|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/size}},
+                            |srcTexture|.{{GPUTexture/format}},
                             |copySize|) succeeds.
                     </div>
             </div>
@@ -6656,19 +6699,19 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
                 1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, generate a validation error and stop.
                     <div class=validusage>
-                        - Let |srcTextureDesc| be |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
-                        - Let |dstTextureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
+                        - Let |srcTexture| be |source|.{{GPUImageCopyTexture/texture}}.
+                        - Let |dstTexture| be |destination|.{{GPUImageCopyTexture/texture}}.
                         - [$validating GPUImageCopyTexture$](|source|, |copySize|) returns `true`.
-                        - |srcTextureDesc|.{{GPUTextureDescriptor/usage}} contains {{GPUTextureUsage/COPY_SRC}}.
+                        - |srcTexture|.{{GPUTexture/usage}} contains {{GPUTextureUsage/COPY_SRC}}.
                         - [$validating GPUImageCopyTexture$](|destination|, |copySize|) returns `true`.
-                        - |dstTextureDesc|.{{GPUTextureDescriptor/usage}} contains {{GPUTextureUsage/COPY_DST}}.
-                        - |srcTextureDesc|.{{GPUTextureDescriptor/sampleCount}} is equal to |dstTextureDesc|.{{GPUTextureDescriptor/sampleCount}}.
-                        - |srcTextureDesc|.{{GPUTextureDescriptor/format}} and |dstTextureDesc|.{{GPUTextureDescriptor/format}}
+                        - |dstTexture|.{{GPUTexture/usage}} contains {{GPUTextureUsage/COPY_DST}}.
+                        - |srcTexture|.{{GPUTexture/sampleCount}} is equal to |dstTexture|.{{GPUTexture/sampleCount}}.
+                        - |srcTexture|.{{GPUTexture/format}} and |dstTexture|.{{GPUTexture/format}}
                             must be [=copy-compatible=].
-                        - If |srcTextureDesc|.{{GPUTextureDescriptor/format}} is a depth-stencil format:
+                        - If |srcTexture|.{{GPUTexture/format}} is a depth-stencil format:
                             - |source|.{{GPUImageCopyTexture/aspect}} and |destination|.{{GPUImageCopyTexture/aspect}}
-                                must both refer to all aspects of |srcTextureDesc|.{{GPUTextureDescriptor/format}}
-                                and |dstTextureDesc|.{{GPUTextureDescriptor/format}}, respectively.
+                                must both refer to all aspects of |srcTexture|.{{GPUTexture/format}}
+                                and |dstTexture|.{{GPUTexture/format}}, respectively.
                         - [=Valid Texture Copy Range=] applies to |source| and |copySize|.
                         - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
                         - The [$set of subresources for texture copy$](|source|, |copySize|) and
@@ -6689,7 +6732,7 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
     The <dfn abstract-op>set of subresources for texture copy</dfn>(|imageCopyTexture|, |copySize|)
     is the set containing:
 
-      - If |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}}
+      - If |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/dimension}}
         is {{GPUTextureDimension/"2d"}}:
           - For each |arrayLayer| of the |copySize|.[=Extent3D/depthOrArrayLayers=] [=array layers=]
             starting at |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/z=]:
@@ -6727,8 +6770,8 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
                     1. If any of the following conditions are unsatisfied, generate a validation error and stop.
                         <div class=validusage>
                             - |querySet| is [$valid to use with$] |this|.
-                            - |querySet|.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/"timestamp"}}.
-                            - |queryIndex| &lt; |querySet|.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}}.
+                            - |querySet|.{{GPUQuerySet/type}} is {{GPUQueryType/"timestamp"}}.
+                            - |queryIndex| &lt; |querySet|.{{GPUQuerySet/count}}.
                         </div>
 
                     Issue: Describe {{GPUCommandEncoder/writeTimestamp()}} algorithm steps.
@@ -6760,11 +6803,11 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
                     <div class=validusage>
                         - |querySet| is [$valid to use with$] |this|.
                         - |destination| is [$valid to use with$] |this|.
-                        - |destination|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/QUERY_RESOLVE}}.
+                        - |destination|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/QUERY_RESOLVE}}.
                         - |firstQuery| is less than the number of queries in |querySet|.
                         - (|firstQuery| + |queryCount|) is less than or equal to the number of queries in |querySet|.
                         - |destinationOffset| is a multiple of 256.
-                        - |destinationOffset| + 8 &times; |queryCount| &le; |destination|.{{GPUBuffer/[[size]]}}.
+                        - |destinationOffset| + 8 &times; |queryCount| &le; |destination|.{{GPUBuffer/size}}.
                     </div>
 
                 Issue: Describe {{GPUCommandEncoder/resolveQuerySet()}} algorithm steps.
@@ -6886,7 +6929,7 @@ interface mixin GPUProgrammablePassEncoder {
                             - Let |bufferDynamicOffset| be |dynamicOffsets|[|dynamicOffsetIndex|].
                             - |bufferBinding|.{{GPUBufferBinding/offset}} + |bufferDynamicOffset| +
                                 |bufferLayout|.{{GPUBufferBindingLayout/minBindingSize}} &le;
-                                |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBuffer/[[size]]}}.
+                                |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBuffer/size}}.
                             - if |bufferLayout|.{{GPUBufferBindingLayout/type}} is {{GPUBufferBindingType/"uniform"}}:
 
                                 - |dynamicOffset| is a multiple of {{supported limits/minUniformBufferOffsetAlignment}}.
@@ -7137,9 +7180,9 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
 
     1. For each |timestampWrite| in |this|.{{GPUComputePassDescriptor/timestampWrites}}:
 
-        1. |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/"timestamp"}}.
+        1. |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}}.{{GPUQuerySet/type}} is {{GPUQueryType/"timestamp"}}.
 
-        1. |timestampWrite|.{{GPUComputePassTimestampWrite/queryIndex}} &lt; |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}}.
+        1. |timestampWrite|.{{GPUComputePassTimestampWrite/queryIndex}} &lt; |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}}.{{GPUQuerySet/count}}.
 </div>
 
 ### Dispatch ### {#compute-pass-encoder-dispatch}
@@ -7242,9 +7285,9 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
                         - [$Validate encoder bind groups$](|this|, |this|.{{GPUComputePassEncoder/[[pipeline]]}})
                             is `true`.
                         - |indirectBuffer| is [$valid to use with$] |this|.
-                        - |indirectBuffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDIRECT}}.
+                        - |indirectBuffer|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/INDIRECT}}.
                         - |indirectOffset| + sizeof([=indirect dispatch parameters=]) &le;
-                            |indirectBuffer|.{{GPUBuffer/[[size]]}}.
+                            |indirectBuffer|.{{GPUBuffer/size}}.
                         - |indirectOffset| is a multiple of 4.
                     </div>
                 1. Add |indirectBuffer| to the [=usage scope=] as {{GPUBufferUsage/INDIRECT}}.
@@ -7494,7 +7537,7 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
 
     1. All {{GPURenderPassColorAttachment/view}}s in |this|.{{GPURenderPassDescriptor/colorAttachments}},
         and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachment/view}}
-        if present, must have equal {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}}s.
+        if present, must have equal {{GPUTexture/sampleCount}}s.
 
     1. For each {{GPURenderPassColorAttachment/view}} in |this|.{{GPURenderPassDescriptor/colorAttachments}}
         and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachment/view}},
@@ -7502,14 +7545,14 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
 
     1. If |this|.{{GPURenderPassDescriptor/occlusionQuerySet}} is not `null`:
 
-        1. |this|.{{GPURenderPassDescriptor/occlusionQuerySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/type}}
+        1. |this|.{{GPURenderPassDescriptor/occlusionQuerySet}}.{{GPUQuerySet/type}}
             must be {{GPUQueryType/occlusion}}.
 
     1. For each |timestampWrite| in |this|.{{GPURenderPassDescriptor/timestampWrites}}:
 
-        1. |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/"timestamp"}}.
+        1. |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}}.{{GPUQuerySet/type}} is {{GPUQueryType/"timestamp"}}.
 
-        1. |timestampWrite|.{{GPURenderPassTimestampWrite/queryIndex}} &lt; |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}}.
+        1. |timestampWrite|.{{GPURenderPassTimestampWrite/queryIndex}} &lt; |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}}.{{GPUQuerySet/count}}.
 
     Issue(gpuweb/gpuweb#503): support for no attachments
 </div>
@@ -7574,16 +7617,16 @@ dictionary GPURenderPassColorAttachment {
 
     1. Let |renderViewDescriptor| be |this|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.
     1. Let |resolveViewDescriptor| be |this|.{{GPURenderPassColorAttachment/resolveTarget}}.{{GPUTextureView/[[descriptor]]}}.
-    1. Let |renderTextureDescriptor| be |this|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.
-    1. Let |resolveTextureDescriptor| be |this|.{{GPURenderPassColorAttachment/resolveTarget}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.
+    1. Let |renderTexture| be |this|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.
+    1. Let |resolveTexture| be |this|.{{GPURenderPassColorAttachment/resolveTarget}}.{{GPUTextureView/[[texture]]}}.
 
     The following validation rules apply:
 
     - |renderViewDescriptor|.{{GPUTextureViewDescriptor/format}} must be a [=color renderable format=].
     - |this|.{{GPURenderPassColorAttachment/view}} must be a [$renderable texture view$].
     - If |this|.{{GPURenderPassColorAttachment/resolveTarget}} is not `null`:
-        - |renderTextureDescriptor|.{{GPUTextureDescriptor/sampleCount}} must be greater than 1.
-        - |resolveTextureDescriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
+        - |renderTexture|.{{GPUTexture/sampleCount}} must be greater than 1.
+        - |resolveTexture|.{{GPUTexture/sampleCount}} must be 1.
         - |this|.{{GPURenderPassColorAttachment/resolveTarget}} must be a [$renderable texture view$].
         - The sizes of the [=subresource=]s seen by |this|.{{GPURenderPassColorAttachment/resolveTarget}}
             and |this|.{{GPURenderPassColorAttachment/view}} must match.
@@ -7596,7 +7639,7 @@ dictionary GPURenderPassColorAttachment {
     A {{GPUTextureView}} |view| is a <dfn abstract-op>renderable texture view</dfn>
     if the following requirements are met:
 
-    - |view|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}}
+    - |view|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/usage}}
         must contain {{GPUTextureUsage/RENDER_ATTACHMENT}}.
     - |descriptor|.{{GPUTextureViewDescriptor/dimension}} must be {{GPUTextureViewDimension/"2d"}}.
     - |descriptor|.{{GPUTextureViewDescriptor/mipLevelCount}} must be 1.
@@ -7745,12 +7788,12 @@ dictionary GPURenderPassLayout: GPUObjectDescriptorBase {
 
     1. Let |layout| be a new {{GPURenderPassLayout}} object.
     1. For each |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
-        1. Set |layout|.{{GPURenderPassLayout/sampleCount}} to |colorAttachment|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}}.
+        1. Set |layout|.{{GPURenderPassLayout/sampleCount}} to |colorAttachment|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/sampleCount}}.
         1. Append |colorAttachment|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}} to |layout|.{{GPURenderPassLayout/colorFormats}}.
     1. Let |depthStencilAttachment| be |descriptor|.{{GPURenderPassDescriptor/depthStencilAttachment}}.
     1. If |depthStencilAttachment| is not `null`:
         1. Let |view| be |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/view}}
-        1. Set |layout|.{{GPURenderPassLayout/sampleCount}} to |view|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}}.
+        1. Set |layout|.{{GPURenderPassLayout/sampleCount}} to |view|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/sampleCount}}.
         1. Set |layout|.{{GPURenderPassLayout/depthStencilFormat}} to |view|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
     1. Return |layout|.
 
@@ -7830,13 +7873,13 @@ dictionary GPURenderPassLayout: GPUObjectDescriptorBase {
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. If |size| is missing, set |size| to max(0, |buffer|.{{GPUBuffer/[[size]]}} - |offset|).
+                1. If |size| is missing, set |size| to max(0, |buffer|.{{GPUBuffer/size}} - |offset|).
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |buffer| is [$valid to use with$] |this|.
-                        - |buffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDEX}}.
+                        - |buffer|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/INDEX}}.
                         - |offset| is a multiple of |indexFormat|'s byte size.
-                        - |offset| + |size| &le; |buffer|.{{GPUBuffer/[[size]]}}.
+                        - |offset| + |size| &le; |buffer|.{{GPUBuffer/size}}.
                     </div>
                 1. Add |buffer| to the [=usage scope=] as [=internal usage/input=].
                 1. Set |this|.{{GPURenderEncoderBase/[[index_buffer]]}} to be |buffer|.
@@ -7865,14 +7908,14 @@ dictionary GPURenderPassLayout: GPUObjectDescriptorBase {
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. If |size| is missing, set |size| to max(0, |buffer|.{{GPUBuffer/[[size]]}} - |offset|).
+                1. If |size| is missing, set |size| to max(0, |buffer|.{{GPUBuffer/size}} - |offset|).
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |buffer| is [$valid to use with$] |this|.
-                        - |buffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/VERTEX}}.
+                        - |buffer|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/VERTEX}}.
                         - |slot| &lt; |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBuffers}}.
                         - |offset| is a multiple of 4.
-                        - |offset| + |size| &le; |buffer|.{{GPUBuffer/[[size]]}}.
+                        - |offset| + |size| &le; |buffer|.{{GPUBuffer/size}}.
                     </div>
                 1. Add |buffer| to the [=usage scope=] as [=internal usage/input=].
                 1. Set |this|.{{GPURenderEncoderBase/[[vertex_buffers]]}}[|slot|] to be |buffer|.
@@ -8006,9 +8049,9 @@ dictionary GPURenderPassLayout: GPUObjectDescriptorBase {
                     <div class=validusage>
                         - It is [$valid to draw$] with |this|.
                         - |indirectBuffer| is [$valid to use with$] |this|.
-                        - |indirectBuffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDIRECT}}.
+                        - |indirectBuffer|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/INDIRECT}}.
                         - |indirectOffset| + sizeof([=indirect draw parameters=]) &le;
-                            |indirectBuffer|.{{GPUBuffer/[[size]]}}.
+                            |indirectBuffer|.{{GPUBuffer/size}}.
                         - |indirectOffset| is a multiple of 4.
                     </div>
                 1. Add |indirectBuffer| to the [=usage scope=] as [=internal usage/input=].
@@ -8054,9 +8097,9 @@ dictionary GPURenderPassLayout: GPUObjectDescriptorBase {
                     <div class=validusage>
                         - It is [$valid to draw indexed$] with |this|.
                         - |indirectBuffer| is [$valid to use with$] |this|.
-                        - |indirectBuffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDIRECT}}.
+                        - |indirectBuffer|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/INDIRECT}}.
                         - |indirectOffset| + sizeof([=indirect drawIndexed parameters=]) &le;
-                            |indirectBuffer|.{{GPUBuffer/[[size]]}}.
+                            |indirectBuffer|.{{GPUBuffer/size}}.
                         - |indirectOffset| is a multiple of 4.
                     </div>
                 1. Add |indirectBuffer| to the [=usage scope=] as [=internal usage/input=].
@@ -8232,7 +8275,7 @@ attachments used by this encoder.
                 1. If any of the following conditions are unsatisfied, generate a validation error and stop.
                     <div class=validusage>
                         - |this|.{{GPURenderPassEncoder/[[occlusion_query_set]]}} is not `null`.
-                        - |queryIndex| &lt; |this|.{{GPURenderPassEncoder/[[occlusion_query_set]]}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}}.
+                        - |queryIndex| &lt; |this|.{{GPURenderPassEncoder/[[occlusion_query_set]]}}.{{GPUQuerySet/count}}.
                         - The query at same |queryIndex| must not have been previously written to in this pass.
                         - |this|.{{GPURenderPassEncoder/[[occlusion_query_active]]}} is `false`.
                     </div>
@@ -8567,9 +8610,9 @@ GPUQueue includes GPUObjectBase;
                         <div class=validusage>
                             - |buffer| is [$valid to use with$] |this|.
                             - |buffer|.{{GPUBuffer/[[state]]}} is [=buffer state/unmapped=].
-                            - |buffer|.{{GPUBuffer/[[usage]]}} includes {{GPUBufferUsage/COPY_DST}}.
+                            - |buffer|.{{GPUBuffer/usage}} includes {{GPUBufferUsage/COPY_DST}}.
                             - |bufferOffset|, converted to bytes, is a multiple of 4 bytes.
-                            - |bufferOffset| + |contentsSize|, converted to bytes, &le; |buffer|.{{GPUBuffer/[[size]]}} bytes.
+                            - |bufferOffset| + |contentsSize|, converted to bytes, &le; |buffer|.{{GPUBuffer/size}} bytes.
                         </div>
                     1. Write |contents| into |buffer| starting at |bufferOffset|.
                 </div>
@@ -8594,13 +8637,13 @@ GPUQueue includes GPUObjectBase;
 
             1. Let |dataBytes| be [=get a copy of the buffer source|a copy of the bytes held by the buffer source=] |data|.
             1. Let |dataByteSize| be the number of bytes in |dataBytes|.
-            1. Let |textureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
+            1. Let |texture| be |destination|.{{GPUImageCopyTexture/texture}}.
             1. If any of the following conditions are unsatisfied,
                 throw {{OperationError}} and stop.
                 <div class=validusage>
                     - [$validating linear texture data$](|dataLayout|,
                         |dataByteSize|,
-                        |textureDesc|.{{GPUTextureDescriptor/format}},
+                        |texture|.{{GPUTexture/format}},
                         |size|) succeeds.
                 </div>
             1. Let |contents| be the contents of the [=images=] seen by
@@ -8613,11 +8656,11 @@ GPUQueue includes GPUObjectBase;
                         generate a validation error and stop.
                         <div class=validusage>
                             - [$validating GPUImageCopyTexture$](|destination|, |size|) returns `true`.
-                            - |textureDesc|.{{GPUTextureDescriptor/usage}} includes {{GPUTextureUsage/COPY_DST}}.
-                            - |textureDesc|.{{GPUTextureDescriptor/sampleCount}} is 1.
+                            - |texture|.{{GPUTexture/usage}} includes {{GPUTextureUsage/COPY_DST}}.
+                            - |texture|.{{GPUTexture/sampleCount}} is 1.
                             - [=Valid Texture Copy Range=](|destination|, |size|) is satisfied.
                             - |destination|.{{GPUImageCopyTexture/aspect}} must refer to a single aspect of
-                                |textureDesc|.{{GPUTextureDescriptor/format}}, and that aspect must be
+                                |texture|.{{GPUTexture/format}}, and that aspect must be
                                 a valid image copy destination according to [[#depth-formats]].
 
                             Note: unlike
@@ -8679,17 +8722,17 @@ GPUQueue includes GPUObjectBase;
                 </div>
             1. Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
-                    1. Let |textureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
+                    1. Let |texture| be |destination|.{{GPUImageCopyTexture/texture}}.
                     1. If any of the following requirements are unmet, generate a validation error and stop.
                         <div class=validusage>
                             - |destination|.{{GPUImageCopyTexture/texture}} must be [$valid to use with$] |this|.
                             - [$validating GPUImageCopyTexture$](destination, copySize) must return true.
                             - [=Valid Texture Copy Range=](destination, copySize) must be satisfied.
-                            - |textureDesc|.{{GPUTextureDescriptor/usage}} must include both
+                            - |texture|.{{GPUTexture/usage}} must include both
                                 {{GPUTextureUsage/RENDER_ATTACHMENT}} and {{GPUTextureUsage/COPY_DST}}.
-                            - |textureDesc|.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"2d"}}.
-                            - |textureDesc|.{{GPUTextureDescriptor/sampleCount}} must be 1.
-                            - |textureDesc|.{{GPUTextureDescriptor/format}} must be one of the following
+                            - |texture|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
+                            - |texture|.{{GPUTexture/sampleCount}} must be 1.
+                            - |texture|.{{GPUTexture/format}} must be one of the following
                                 formats (which all support {{GPUTextureUsage/RENDER_ATTACHMENT}} usage):
                                 - {{GPUTextureFormat/"r8unorm"}}
                                 - {{GPUTextureFormat/"r16float"}}
@@ -8770,20 +8813,29 @@ Queries {#queries}
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUQuerySet {
+    readonly attribute GPUQueryType type;
+    readonly attribute GPUSize32 count;
+
     undefined destroy();
 };
 GPUQuerySet includes GPUObjectBase;
 </script>
 
+{{GPUQuerySet}} has the following attributes:
+
+<dl dfn-type=attribute dfn-for="GPUQuerySet">
+    : <dfn>type</dfn>
+    ::
+        The type of queries the {{GPUQuerySet}} contains.
+
+    : <dfn>count</dfn>
+    ::
+        The number of queries the {{GPUQuerySet}} contains.
+</dl>
+
 {{GPUQuerySet}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUQuerySet">
-    : <dfn>\[[descriptor]]</dfn>, of type {{GPUQuerySetDescriptor}}
-    ::
-        The {{GPUQuerySetDescriptor}} describing this query set.
-
-        All optional fields of {{GPUTextureViewDescriptor}} are defined.
-
     : <dfn>\[[state]]</dfn> of type [=query set state=].
     ::
         The current state of the {{GPUQuerySet}}.
@@ -8842,7 +8894,8 @@ dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
                     - |descriptor|.{{GPUQuerySetDescriptor/count}} must be &le; 8192.
                 </div>
             1. Let |q| be a new {{GPUQuerySet}} object.
-            1. Set |q|.{{GPUQuerySet/[[descriptor]]}} to |descriptor|.
+            1. Set |q|.{{GPUQuerySet/type}} to |descriptor|.{{GPUQuerySetDescriptor/type}}.
+            1. Set |q|.{{GPUQuerySet/count}} to |descriptor|.{{GPUQuerySetDescriptor/count}}.
             1. Set |q|.{{GPUQuerySet/[[state]]}} to [=query set state/available=].
             1. Return |q|.
         </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2734,9 +2734,48 @@ all previously submitted operations using it are complete.
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUTextureView {
+    readonly attribute GPUTextureFormat format;
+    readonly attribute GPUTextureViewDimension dimension;
+    readonly attribute GPUTextureAspect aspect;
+    readonly attribute GPUIntegerCoordinate baseMipLevel;
+    readonly attribute GPUIntegerCoordinate mipLevelCount;
+    readonly attribute GPUIntegerCoordinate baseArrayLayer;
+    readonly attribute GPUIntegerCoordinate arrayLayerCount;
 };
 GPUTextureView includes GPUObjectBase;
 </script>
+
+{{GPUTextureView}} has the following attributes:
+
+<dl dfn-type=attribute dfn-for="GPUTextureView">
+    : <dfn>format</dfn>
+    ::
+        Returns {{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
+
+    : <dfn>dimension</dfn>
+    ::
+        Returns {{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/dimension}}.
+
+    : <dfn>aspect</dfn>
+    ::
+        Returns {{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/aspect}}.
+
+    : <dfn>baseMipLevel</dfn>
+    ::
+        Returns {{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/baseMipLevel}}.
+
+    : <dfn>mipLevelCount</dfn>
+    ::
+        Returns {{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/mipLevelCount}}.
+
+    : <dfn>baseArrayLayer</dfn>
+    ::
+        Returns {{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/baseArrayLayer}}.
+
+    : <dfn>arrayLayerCount</dfn>
+    ::
+        Returns {{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/arrayLayerCount}}.
+</dl>
 
 {{GPUTextureView}} has the following internal slots:
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -850,12 +850,12 @@ to form complete [=texel blocks=] in the [=subresource=].
 
   - For pixel-based {{GPUTextureFormat|GPUTextureFormats}}, the [=physical size=] is always equal to the size of the [=texture subresource=]
     used in the sampling hardwares.
-  - [=Textures=] in block-based compressed {{GPUTextureFormat|GPUTextureFormats}} always have a [=mipmap level=] 0 whose {{GPUTexture/size}}
+  - [=Textures=] in block-based compressed {{GPUTextureFormat|GPUTextureFormats}} always have a [=mipmap level=] 0 whose {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}
     is a multiple of the [=texel block size=], but the lower mipmap levels might not be
     multiples of the [=texel block size=] and can have paddings.
 
 <div class="example">
-Considering a {{GPUTexture}} in BC format whose {{GPUTexture/size}} is {60, 60, 1}, when sampling
+Considering a {{GPUTexture}} in BC format whose {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}} is {60, 60, 1}, when sampling
 the {{GPUTexture}} at [=mipmap level=] 2, the sampling hardware uses {15, 15, 1} as the size of the [=texture subresource=],
 while its [=physical size=] is {16, 16, 1} as the block-compression algorithm can only operate on 4x4 [=texel blocks=].
 </div>
@@ -2047,16 +2047,24 @@ GPUBuffer includes GPUObjectBase;
 <dl dfn-type=attribute dfn-for="GPUBuffer">
     : <dfn>size</dfn>
     ::
-        The length of the {{GPUBuffer}} allocation in bytes.
+        Returns {{GPUBuffer/[[size]]}}.
 
     : <dfn>usage</dfn>
     ::
-        The allowed usages for this {{GPUBuffer}}.
+        Returns {{GPUBuffer/[[usage]]}}.
 </dl>
 
 {{GPUBuffer}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUBuffer">
+    : <dfn>\[[size]]</dfn> of type {{GPUSize64}}.
+    ::
+        The length of the {{GPUBuffer}} allocation in bytes.
+
+    : <dfn>\[[usage]]</dfn> of type {{GPUBufferUsageFlags}}.
+    ::
+        The allowed usages for this {{GPUBuffer}}.
+
     : <dfn>\[[state]]</dfn> of type [=buffer state=].
     ::
         The current state of the {{GPUBuffer}}.
@@ -2084,7 +2092,7 @@ GPUBuffer includes GPUObjectBase;
         The {{GPUMapModeFlags}} of the last call to {{GPUBuffer/mapAsync()}} (if any).
 </dl>
 
-Issue: {{GPUBuffer/usage}} is differently named from {{GPUTexture/usage}}.
+Issue: {{GPUBuffer/[[usage]]}} is differently named from {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}}.
 We should make it consistent.
 
 Each {{GPUBuffer}} has a current <dfn dfn>buffer state</dfn> on the [=Content timeline=]
@@ -2102,7 +2110,7 @@ which is one of the following:
      no longer available for any operations except {{GPUBuffer/destroy}}.
 
 Note:
-{{GPUBuffer/size}} and {{GPUBuffer/usage}} are immutable once the
+{{GPUBuffer/[[size]]}} and {{GPUBuffer/[[usage]]}} are immutable once the
 {{GPUBuffer}} has been created.
 
 <div class=note>
@@ -2203,11 +2211,11 @@ namespace GPUBufferUsage {
             and may be discarded or recycled.
 
             1. Let |b| be a new {{GPUBuffer}} object.
-            1. Set |b|.{{GPUBuffer/size}} to |descriptor|.{{GPUBufferDescriptor/size}}.
-            1. Set |b|.{{GPUBuffer/usage}} to |descriptor|.{{GPUBufferDescriptor/usage}}.
+            1. Set |b|.{{GPUBuffer/[[size]]}} to |descriptor|.{{GPUBufferDescriptor/size}}.
+            1. Set |b|.{{GPUBuffer/[[usage]]}} to |descriptor|.{{GPUBufferDescriptor/usage}}.
             1. If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`:
 
-                1. Set |b|.{{GPUBuffer/[[mapping]]}} to a new {{ArrayBuffer}} of size |b|.{{GPUBuffer/size}}.
+                1. Set |b|.{{GPUBuffer/[[mapping]]}} to a new {{ArrayBuffer}} of size |b|.{{GPUBuffer/[[size]]}}.
                 1. Set |b|.{{GPUBuffer/[[mapping_range]]}} to `[0, descriptor.size]`.
                 1. Set |b|.{{GPUBuffer/[[mapped_ranges]]}} to `[]`.
                 1. Set |b|.{{GPUBuffer/[[state]]}} to [=buffer state/mapped at creation=].
@@ -2313,7 +2321,7 @@ namespace GPUMapMode {
             Issue(gpuweb/gpuweb#605): Handle error buffers once we have a description of the error monad.
 
             1. If |size| is missing:
-                1. Let |rangeSize| be max(0, |this|.{{GPUBuffer/size}} - |offset|).
+                1. Let |rangeSize| be max(0, |this|.{{GPUBuffer/[[size]]}} - |offset|).
 
                 Otherwise, let |rangeSize| be |size|.
 
@@ -2323,11 +2331,11 @@ namespace GPUMapMode {
                         TODO: check destroyed state?
                     - |offset| is a multiple of 8.
                     - |rangeSize| is a multiple of 4.
-                    - |offset| + |rangeSize| is less or equal to |this|.{{GPUBuffer/size}}
+                    - |offset| + |rangeSize| is less or equal to |this|.{{GPUBuffer/[[size]]}}
                     - |this|.{{GPUBuffer/[[state]]}} is [=buffer state/unmapped=]
                     - |mode| contains exactly one of {{GPUMapMode/READ}} or {{GPUMapMode/WRITE}}.
-                    - If |mode| contains {{GPUMapMode/READ}} then |this|.{{GPUBuffer/usage}} must contain {{GPUBufferUsage/MAP_READ}}.
-                    - If |mode| contains {{GPUMapMode/WRITE}} then |this|.{{GPUBuffer/usage}} must contain {{GPUBufferUsage/MAP_WRITE}}.
+                    - If |mode| contains {{GPUMapMode/READ}} then |this|.{{GPUBuffer/[[usage]]}} must contain {{GPUBufferUsage/MAP_READ}}.
+                    - If |mode| contains {{GPUMapMode/WRITE}} then |this|.{{GPUBuffer/[[usage]]}} must contain {{GPUBufferUsage/MAP_WRITE}}.
 
                     Issue: Do we validate that |mode| contains only valid flags?
                 </div>
@@ -2372,7 +2380,7 @@ namespace GPUMapMode {
             **Returns:** {{ArrayBuffer}}
 
             1. If |size| is missing:
-                1. Let |rangeSize| be max(0, |this|.{{GPUBuffer/size}} - |offset|).
+                1. Let |rangeSize| be max(0, |this|.{{GPUBuffer/[[size]]}} - |offset|).
 
                 Otherwise, let |rangeSize| be |size|.
 
@@ -2485,32 +2493,39 @@ GPUTexture includes GPUObjectBase;
 <dl dfn-type=attribute dfn-for="GPUTexture">
     : <dfn>size</dfn>
     ::
-        The dimensions of the {{GPUTexture}} in pixels.
+        Returns {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}} as a {{GPUExtent3DDict}},
+        accessed as described by [=Extent3D=].
 
     : <dfn>mipLevelCount</dfn>
     ::
-        The number of mip levels of the {{GPUTexture}}.
+        Returns {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/mipLevelCount}}.
 
     : <dfn>sampleCount</dfn>
     ::
-        The number of samples of the {{GPUTexture}}.
+        Returns {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}}.
 
     : <dfn>dimension</dfn>
     ::
-        Whether the {{GPUTexture}} is 1D, 2D, or 3D.
+        Returns {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}}.
 
     : <dfn>format</dfn>
     ::
-        The format of the {{GPUTexture}}.
+        Returns {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
 
     : <dfn>usage</dfn>
     ::
-        The allowed usages for this {{GPUTexture}}.
+        Returns {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}}.
 </dl>
 
 {{GPUTexture}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUTexture">
+    : <dfn>\[[descriptor]]</dfn>, of type {{GPUTextureDescriptor}}
+    ::
+        The {{GPUTextureDescriptor}} describing this texture.
+
+        All optional fields of {{GPUTextureDescriptor}} are defined.
+
     : <dfn>\[[destroyed]]</dfn>, of type `boolean`, initially false
     ::
         If the texture is destroyed, it can no longer be used in any operation,
@@ -2675,14 +2690,7 @@ namespace GPUTextureUsage {
                             1. Return a new [=invalid=] {{GPUTexture}}.
 
                     1. Let |t| be a new {{GPUTexture}} object.
-                    1. Set |t|.{{GPUTexture/size}}.{{GPUExtent3DDict/width}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=].
-                    1. Set |t|.{{GPUTexture/size}}.{{GPUExtent3DDict/height}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=].
-                    1. Set |t|.{{GPUTexture/size}}.{{GPUExtent3DDict/depthOrArrayLayers}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=].
-                    1. Set |t|.{{GPUTexture/mipLevelCount}} to |descriptor|.{{GPUTextureDescriptor/mipLevelCount}}.
-                    1. Set |t|.{{GPUTexture/sampleCount}} to |descriptor|.{{GPUTextureDescriptor/sampleCount}}.
-                    1. Set |t|.{{GPUTexture/dimension}} to |descriptor|.{{GPUTextureDescriptor/dimension}}.
-                    1. Set |t|.{{GPUTexture/format}} to |descriptor|.{{GPUTextureDescriptor/format}}.
-                    1. Set |t|.{{GPUTexture/usage}} to |descriptor|.{{GPUTextureDescriptor/usage}}.
+                    1. Set |t|.{{GPUTexture/[[descriptor]]}} to |descriptor|.
                     1. Return |t|.
                 </div>
         </div>
@@ -2869,50 +2877,50 @@ enum GPUTextureAspect {
                             - If the |descriptor|.{{GPUTextureViewDescriptor/aspect}} is
                                 <dl class="switch">
                                     : {{GPUTextureAspect/"stencil-only"}}
-                                    :: |this|.{{GPUTexture/format}} must be a
+                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}} must be a
                                         [=depth-or-stencil format=] which has a stencil aspect.
 
                                     : {{GPUTextureAspect/"depth-only"}}
-                                    :: |this|.{{GPUTexture/format}} must be a
+                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}} must be a
                                         [=depth-or-stencil format=] which has a depth aspect.
                                 </dl>
                             - |descriptor|.{{GPUTextureViewDescriptor/mipLevelCount}} must be &gt; 0.
                             - |descriptor|.{{GPUTextureViewDescriptor/baseMipLevel}} +
                                 |descriptor|.{{GPUTextureViewDescriptor/mipLevelCount}} must be &le;
-                                |this|.{{GPUTexture/mipLevelCount}}.
+                                |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/mipLevelCount}}.
                             - |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be &gt; 0.
                             - |descriptor|.{{GPUTextureViewDescriptor/baseArrayLayer}} +
                                 |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be &le;
                                 the [$array layer count$] of |this|.
-                            - |descriptor|.{{GPUTextureViewDescriptor/format}} must be |this|.{{GPUTexture/format}}.
+                            - |descriptor|.{{GPUTextureViewDescriptor/format}} must be |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
                                 <div class="issue">Allow for creating views with compatible formats as well.</div>
                             - If |descriptor|.{{GPUTextureViewDescriptor/dimension}} is:
                                 <dl class="switch">
                                     : {{GPUTextureViewDimension/"1d"}}
-                                    :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"1d"}}.
+                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"1d"}}.
                                     :: |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `1`.
 
                                     : {{GPUTextureViewDimension/"2d"}}
-                                    :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
+                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"2d"}}.
                                     :: |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `1`.
 
                                     : {{GPUTextureViewDimension/"2d-array"}}
-                                    :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
+                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"2d"}}.
 
                                     : {{GPUTextureViewDimension/"cube"}}
-                                    :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
+                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"2d"}}.
                                     :: |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `6`.
-                                    :: |this|.{{GPUTexture/size}}.[=Extent3D/width=] must be
-                                        |this|.{{GPUTexture/size}}.[=Extent3D/height=].
+                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be
+                                        |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}.[=Extent3D/height=].
 
                                     : {{GPUTextureViewDimension/"cube-array"}}
-                                    :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
+                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"2d"}}.
                                     :: |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be a multiple of `6`.
-                                    :: |this|.{{GPUTexture/size}}.[=Extent3D/width=] must be
-                                        |this|.{{GPUTexture/size}}.[=Extent3D/height=].
+                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be
+                                        |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}.[=Extent3D/height=].
 
                                     : {{GPUTextureViewDimension/"3d"}}
-                                    :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"3d"}}.
+                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"3d"}}.
                                     :: |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `1`.
                                 </dl>
                         </div>
@@ -2924,8 +2932,8 @@ enum GPUTextureAspect {
                     1. Let |view| be a new {{GPUTextureView}} object.
                     1. Set |view|.{{GPUTextureView/[[texture]]}} to |this|.
                     1. Set |view|.{{GPUTextureView/[[descriptor]]}} to |descriptor|.
-                    1. If |this|.{{GPUTexture/usage}} contains {{GPUTextureUsage/RENDER_ATTACHMENT}}:
-                        1. Let |renderExtent| be [$compute render extent$](|this|.{{GPUTexture/size}}, |descriptor|.{{GPUTextureViewDescriptor/baseMipLevel}}).
+                    1. If |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}} contains {{GPUTextureUsage/RENDER_ATTACHMENT}}:
+                        1. Let |renderExtent| be [$compute render extent$](|this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}, |descriptor|.{{GPUTextureViewDescriptor/baseMipLevel}}).
                         1. Set |view|.{{GPUTextureView/[[renderExtent]]}} to |renderExtent|.
                     1. Return |view|.
                 </div>
@@ -2938,12 +2946,12 @@ enum GPUTextureAspect {
 
     1. Let |resolved| be a copy of |descriptor|.
     1. If |resolved|.{{GPUTextureViewDescriptor/format}} is `undefined`,
-        set |resolved|.{{GPUTextureViewDescriptor/format}} to |texture|.{{GPUTexture/format}}.
+        set |resolved|.{{GPUTextureViewDescriptor/format}} to |texture|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
     1. If |resolved|.{{GPUTextureViewDescriptor/mipLevelCount}} is `undefined`,
-        set |resolved|.{{GPUTextureViewDescriptor/mipLevelCount}} to |texture|.{{GPUTexture/mipLevelCount}}
+        set |resolved|.{{GPUTextureViewDescriptor/mipLevelCount}} to |texture|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/mipLevelCount}}
         &minus; {{GPUTextureViewDescriptor/baseMipLevel}}.
     1. If |resolved|.{{GPUTextureViewDescriptor/dimension}} is `undefined` and
-        |texture|.{{GPUTexture/dimension}} is:
+        |texture|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} is:
         <dl class="switch">
             : {{GPUTextureDimension/"1d"}}
             :: Set |resolved|.{{GPUTextureViewDescriptor/dimension}} to {{GPUTextureViewDimension/"1d"}}.
@@ -2966,7 +2974,7 @@ enum GPUTextureAspect {
 
             : {{GPUTextureViewDimension/"2d-array"}} or {{GPUTextureViewDimension/"cube-array"}}
             :: Set |resolved|.{{GPUTextureViewDescriptor/arrayLayerCount}} to
-                |texture|.{{GPUTexture/size}}.[=Extent3D/depthOrArrayLayers=] &minus;
+                |texture|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] &minus;
                 {{GPUTextureViewDescriptor/baseArrayLayer}}.
         </dl>
 
@@ -2977,13 +2985,13 @@ enum GPUTextureAspect {
     To determine the <dfn abstract-op>array layer count</dfn> of {{GPUTexture}} |texture|, run the
     following steps:
 
-        1. If |texture|.{{GPUTexture/dimension}} is:
+        1. If |texture|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} is:
             <dl class="switch">
                 : {{GPUTextureDimension/"1d"}} or {{GPUTextureDimension/"3d"}}
                 :: Return `1`.
 
                 : {{GPUTextureDimension/"2d"}}
-                :: Return |texture|.{{GPUTexture/size}}.[=Extent3D/depthOrArrayLayers=].
+                :: Return |texture|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=].
             </dl>
 </div>
 
@@ -4206,7 +4214,7 @@ A {{GPUBindGroup}} object has the following internal slots:
 <div algorithm>
     <dfn abstract-op>effective buffer binding size</dfn>(binding)
         1. If |binding|.{{GPUBufferBinding/size}} is `undefined`:
-            1. Return max(0, |binding|.{{GPUBufferBinding/buffer}}.{{GPUBuffer/size}} - |binding|.{{GPUBufferBinding/offset}});
+            1. Return max(0, |binding|.{{GPUBufferBinding/buffer}}.{{GPUBuffer/[[size]]}} - |binding|.{{GPUBufferBinding/offset}});
         1. Return |binding|.{{GPUBufferBinding/size}}.
 </div>
 
@@ -6267,19 +6275,19 @@ dictionary GPUImageCopyTexture {
   **Returns:** {{boolean}}
 
   Let:
-  - |blockWidth| be the [=texel block width=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}}.
-  - |blockHeight| be the [=texel block height=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}}.
+  - |blockWidth| be the [=texel block width=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
+  - |blockHeight| be the [=texel block height=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
 
   Return `true` if and only if all of the following conditions apply:
   - |imageCopyTexture|.{{GPUImageCopyTexture/texture}} must be a [=valid=] {{GPUTexture}}.
-  - |imageCopyTexture|.{{GPUImageCopyTexture/mipLevel}} must be less than the {{GPUTexture/mipLevelCount}} of
+  - |imageCopyTexture|.{{GPUImageCopyTexture/mipLevel}} must be less than the {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/mipLevelCount}} of
     |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.
   - |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/x=] must be a multiple of |blockWidth|.
   - |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/y=] must be a multiple of |blockHeight|.
   - The [=imageCopyTexture subresource size=] of |imageCopyTexture| is equal to |copySize| if either of
       the following conditions is true:
-        - |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}} is a depth-stencil format.
-        - |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/sampleCount}} is greater than 1.
+        - |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}} is a depth-stencil format.
+        - |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}} is greater than 1.
 
 </div>
 
@@ -6397,15 +6405,15 @@ dictionary GPUImageCopyExternalImage {
                     <div class=validusage>
                         - |source| is [$valid to use with$] |this|.
                         - |destination| is [$valid to use with$] |this|.
-                        - |source|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/COPY_SRC}}.
-                        - |destination|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/COPY_DST}}.
+                        - |source|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/COPY_SRC}}.
+                        - |destination|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/COPY_DST}}.
                         - |size| is a multiple of 4.
                         - |sourceOffset| is a multiple of 4.
                         - |destinationOffset| is a multiple of 4.
                         - (|sourceOffset| + |size|) does not overflow a {{GPUSize64}}.
                         - (|destinationOffset| + |size|) does not overflow a {{GPUSize64}}.
-                        - |source|.{{GPUBuffer/size}} is greater than or equal to (|sourceOffset| + |size|).
-                        - |destination|.{{GPUBuffer/size}} is greater than or equal to (|destinationOffset| + |size|).
+                        - |source|.{{GPUBuffer/[[size]]}} is greater than or equal to (|sourceOffset| + |size|).
+                        - |destination|.{{GPUBuffer/[[size]]}} is greater than or equal to (|destinationOffset| + |size|).
                         - |source| and |destination| are not the same {{GPUBuffer}}.
 
                         Issue(gpuweb/gpuweb#69): figure out how to handle overflows in the spec.
@@ -6438,14 +6446,14 @@ dictionary GPUImageCopyExternalImage {
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
                 1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
-                1. If |size| is missing, set |size| to `max(0, |buffer|.{{GPUBuffer/size}} - |offset|)`.
+                1. If |size| is missing, set |size| to `max(0, |buffer|.{{GPUBuffer/[[size]]}} - |offset|)`.
                 1. If any of the following conditions are unsatisfied, generate a validation error and stop.
                     <div class=validusage>
                         - |buffer| is [$valid to use with$] |this|.
-                        - |buffer|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/COPY_DST}}.
+                        - |buffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/COPY_DST}}.
                         - |size| is a multiple of 4.
                         - |offset| is a multiple of 4.
-                        - |buffer|.{{GPUBuffer/size}} is greater than or equal to (|offset| + |size|).
+                        - |buffer|.{{GPUBuffer/[[size]]}} is greater than or equal to (|offset| + |size|).
                     </div>
             </div>
         </div>
@@ -6551,15 +6559,15 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
 <dfn dfn>Valid Texture Copy Range</dfn>
 
 Given a {{GPUImageCopyTexture}} |imageCopyTexture| and a {{GPUExtent3D}} |copySize|, let
-  - |blockWidth| be the [=texel block width=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}}.
-  - |blockHeight| be the [=texel block height=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}}.
+  - |blockWidth| be the [=texel block width=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
+  - |blockHeight| be the [=texel block height=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
 
 The following validation rules apply:
 
-  - If the {{GPUTexture/dimension}} of |imageCopyTexture|.{{GPUImageCopyTexture/texture}} is
+  - If the {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} of |imageCopyTexture|.{{GPUImageCopyTexture/texture}} is
     {{GPUTextureDimension/1d}}:
     - Both |copySize|.[=Extent3D/height=] and [=Extent3D/depthOrArrayLayers=] must be 1.
-  - If the {{GPUTexture/dimension}} of |imageCopyTexture|.{{GPUImageCopyTexture/texture}} is
+  - If the {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} of |imageCopyTexture|.{{GPUImageCopyTexture/texture}} is
     {{GPUTextureDimension/2d}}:
      -  (|imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/x=] + |copySize|.[=Extent3D/width=]),
         (|imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/y=] + |copySize|.[=Extent3D/height=]), and
@@ -6605,25 +6613,25 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
                 1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, generate a validation error and stop.
                     <div class=validusage>
-                        - Let |dstTexture| be |destination|.{{GPUImageCopyTexture/texture}}.
+                        - Let |dstTextureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
                         - [$validating GPUImageCopyBuffer$](|source|) returns `true`.
-                        - |source|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/usage}} contains {{GPUBufferUsage/COPY_SRC}}.
+                        - |source|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/COPY_SRC}}.
                         - [$validating GPUImageCopyTexture$](|destination|, |copySize|) returns `true`.
-                        - |dstTexture|.{{GPUTexture/usage}} contains {{GPUTextureUsage/COPY_DST}}.
-                        - |dstTexture|.{{GPUTexture/sampleCount}} is 1.
-                        - If |dstTexture|.{{GPUTexture/format}} is a [=depth-or-stencil format=]:
+                        - |dstTextureDesc|.{{GPUTextureDescriptor/usage}} contains {{GPUTextureUsage/COPY_DST}}.
+                        - |dstTextureDesc|.{{GPUTextureDescriptor/sampleCount}} is 1.
+                        - If |dstTextureDesc|.{{GPUTextureDescriptor/format}} is a [=depth-or-stencil format=]:
                             - |destination|.{{GPUImageCopyTexture/aspect}} must refer to a single aspect of
-                                |dstTexture|.{{GPUTexture/format}}, and that aspect must be
+                                |dstTextureDesc|.{{GPUTextureDescriptor/format}}, and that aspect must be
                                 a valid image copy destination according to [[#depth-formats]].
                         - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
-                        - If |dstTexture|.{{GPUTexture/format}} is not a [=depth-or-stencil format=]:
+                        - If |dstTextureDesc|.{{GPUTextureDescriptor/format}} is not a [=depth-or-stencil format=]:
                             - |source|.{{GPUImageDataLayout/offset}} is a multiple of the [=texel block size=] of
-                                |dstTexture|.{{GPUTexture/format}}.
-                        - If |dstTexture|.{{GPUTexture/format}} is a [=depth-or-stencil format=]:
+                                |dstTextureDesc|.{{GPUTextureDescriptor/format}}.
+                        - If |dstTextureDesc|.{{GPUTextureDescriptor/format}} is a [=depth-or-stencil format=]:
                             - |source|.{{GPUImageDataLayout/offset}} is a multiple of 4.
                         - [$validating linear texture data$](|source|,
-                            |source|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/size}},
-                            |dstTexture|.{{GPUTexture/format}},
+                            |source|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[size]]}},
+                            |dstTextureDesc|.{{GPUTextureDescriptor/format}},
                             |copySize|) succeeds.
                     </div>
             </div>
@@ -6651,26 +6659,26 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
                 1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, generate a validation error and stop.
                     <div class=validusage>
-                        - Let |srcTexture| be |source|.{{GPUImageCopyTexture/texture}}.
+                        - Let |srcTextureDesc| be |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
                         - [$validating GPUImageCopyTexture$](|source|, |copySize|) returns `true`.
-                        - |srcTexture|.{{GPUTexture/usage}} contains {{GPUTextureUsage/COPY_SRC}}.
-                        - |srcTexture|.{{GPUTexture/sampleCount}} is 1.
-                        - If |srcTexture|.{{GPUTexture/format}} is a depth-stencil format:
+                        - |srcTextureDesc|.{{GPUTextureDescriptor/usage}} contains {{GPUTextureUsage/COPY_SRC}}.
+                        - |srcTextureDesc|.{{GPUTextureDescriptor/sampleCount}} is 1.
+                        - If |srcTextureDesc|.{{GPUTextureDescriptor/format}} is a depth-stencil format:
                             - |destination|.{{GPUImageCopyTexture/aspect}} must refer to a single aspect of
-                                |srcTexture|.{{GPUTexture/format}}, and that aspect must be
+                                |srcTextureDesc|.{{GPUTextureDescriptor/format}}, and that aspect must be
                                 a valid image copy source according to [[#depth-formats]].
                         - [$validating GPUImageCopyBuffer$](|destination|) returns `true`.
-                        - |destination|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/usage}} contains
+                        - |destination|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[usage]]}} contains
                             {{GPUBufferUsage/COPY_DST}}.
                         - [=Valid Texture Copy Range=] applies to |source| and |copySize|.
-                        - If |srcTexture|.{{GPUTexture/format}} is not a [=depth-or-stencil format=]:
+                        - If |srcTextureDesc|.{{GPUTextureDescriptor/format}} is not a [=depth-or-stencil format=]:
                             - |destination|.{{GPUImageDataLayout/offset}} is a multiple of the [=texel block size=] of
-                                |srcTexture|.{{GPUTexture/format}}.
-                        - If |srcTexture|.{{GPUTexture/format}} is a [=depth-or-stencil format=]:
+                                |srcTextureDesc|.{{GPUTextureDescriptor/format}}.
+                        - If |srcTextureDesc|.{{GPUTextureDescriptor/format}} is a [=depth-or-stencil format=]:
                             - |destination|.{{GPUImageDataLayout/offset}} is a multiple of 4.
                         - [$validating linear texture data$](|destination|,
-                            |destination|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/size}},
-                            |srcTexture|.{{GPUTexture/format}},
+                            |destination|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[size]]}},
+                            |srcTextureDesc|.{{GPUTextureDescriptor/format}},
                             |copySize|) succeeds.
                     </div>
             </div>
@@ -6699,19 +6707,19 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
                 1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, generate a validation error and stop.
                     <div class=validusage>
-                        - Let |srcTexture| be |source|.{{GPUImageCopyTexture/texture}}.
-                        - Let |dstTexture| be |destination|.{{GPUImageCopyTexture/texture}}.
+                        - Let |srcTextureDesc| be |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
+                        - Let |dstTextureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
                         - [$validating GPUImageCopyTexture$](|source|, |copySize|) returns `true`.
-                        - |srcTexture|.{{GPUTexture/usage}} contains {{GPUTextureUsage/COPY_SRC}}.
+                        - |srcTextureDesc|.{{GPUTextureDescriptor/usage}} contains {{GPUTextureUsage/COPY_SRC}}.
                         - [$validating GPUImageCopyTexture$](|destination|, |copySize|) returns `true`.
-                        - |dstTexture|.{{GPUTexture/usage}} contains {{GPUTextureUsage/COPY_DST}}.
-                        - |srcTexture|.{{GPUTexture/sampleCount}} is equal to |dstTexture|.{{GPUTexture/sampleCount}}.
-                        - |srcTexture|.{{GPUTexture/format}} and |dstTexture|.{{GPUTexture/format}}
+                        - |dstTextureDesc|.{{GPUTextureDescriptor/usage}} contains {{GPUTextureUsage/COPY_DST}}.
+                        - |srcTextureDesc|.{{GPUTextureDescriptor/sampleCount}} is equal to |dstTextureDesc|.{{GPUTextureDescriptor/sampleCount}}.
+                        - |srcTextureDesc|.{{GPUTextureDescriptor/format}} and |dstTextureDesc|.{{GPUTextureDescriptor/format}}
                             must be [=copy-compatible=].
-                        - If |srcTexture|.{{GPUTexture/format}} is a depth-stencil format:
+                        - If |srcTextureDesc|.{{GPUTextureDescriptor/format}} is a depth-stencil format:
                             - |source|.{{GPUImageCopyTexture/aspect}} and |destination|.{{GPUImageCopyTexture/aspect}}
-                                must both refer to all aspects of |srcTexture|.{{GPUTexture/format}}
-                                and |dstTexture|.{{GPUTexture/format}}, respectively.
+                                must both refer to all aspects of |srcTextureDesc|.{{GPUTextureDescriptor/format}}
+                                and |dstTextureDesc|.{{GPUTextureDescriptor/format}}, respectively.
                         - [=Valid Texture Copy Range=] applies to |source| and |copySize|.
                         - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
                         - The [$set of subresources for texture copy$](|source|, |copySize|) and
@@ -6732,7 +6740,7 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
     The <dfn abstract-op>set of subresources for texture copy</dfn>(|imageCopyTexture|, |copySize|)
     is the set containing:
 
-      - If |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/dimension}}
+      - If |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}}
         is {{GPUTextureDimension/"2d"}}:
           - For each |arrayLayer| of the |copySize|.[=Extent3D/depthOrArrayLayers=] [=array layers=]
             starting at |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/z=]:
@@ -6770,8 +6778,8 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
                     1. If any of the following conditions are unsatisfied, generate a validation error and stop.
                         <div class=validusage>
                             - |querySet| is [$valid to use with$] |this|.
-                            - |querySet|.{{GPUQuerySet/type}} is {{GPUQueryType/"timestamp"}}.
-                            - |queryIndex| &lt; |querySet|.{{GPUQuerySet/count}}.
+                            - |querySet|.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/"timestamp"}}.
+                            - |queryIndex| &lt; |querySet|.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}}.
                         </div>
 
                     Issue: Describe {{GPUCommandEncoder/writeTimestamp()}} algorithm steps.
@@ -6803,11 +6811,11 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
                     <div class=validusage>
                         - |querySet| is [$valid to use with$] |this|.
                         - |destination| is [$valid to use with$] |this|.
-                        - |destination|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/QUERY_RESOLVE}}.
+                        - |destination|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/QUERY_RESOLVE}}.
                         - |firstQuery| is less than the number of queries in |querySet|.
                         - (|firstQuery| + |queryCount|) is less than or equal to the number of queries in |querySet|.
                         - |destinationOffset| is a multiple of 256.
-                        - |destinationOffset| + 8 &times; |queryCount| &le; |destination|.{{GPUBuffer/size}}.
+                        - |destinationOffset| + 8 &times; |queryCount| &le; |destination|.{{GPUBuffer/[[size]]}}.
                     </div>
 
                 Issue: Describe {{GPUCommandEncoder/resolveQuerySet()}} algorithm steps.
@@ -6929,7 +6937,7 @@ interface mixin GPUProgrammablePassEncoder {
                             - Let |bufferDynamicOffset| be |dynamicOffsets|[|dynamicOffsetIndex|].
                             - |bufferBinding|.{{GPUBufferBinding/offset}} + |bufferDynamicOffset| +
                                 |bufferLayout|.{{GPUBufferBindingLayout/minBindingSize}} &le;
-                                |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBuffer/size}}.
+                                |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBuffer/[[size]]}}.
                             - if |bufferLayout|.{{GPUBufferBindingLayout/type}} is {{GPUBufferBindingType/"uniform"}}:
 
                                 - |dynamicOffset| is a multiple of {{supported limits/minUniformBufferOffsetAlignment}}.
@@ -7180,9 +7188,9 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
 
     1. For each |timestampWrite| in |this|.{{GPUComputePassDescriptor/timestampWrites}}:
 
-        1. |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}}.{{GPUQuerySet/type}} is {{GPUQueryType/"timestamp"}}.
+        1. |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/"timestamp"}}.
 
-        1. |timestampWrite|.{{GPUComputePassTimestampWrite/queryIndex}} &lt; |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}}.{{GPUQuerySet/count}}.
+        1. |timestampWrite|.{{GPUComputePassTimestampWrite/queryIndex}} &lt; |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}}.
 </div>
 
 ### Dispatch ### {#compute-pass-encoder-dispatch}
@@ -7285,9 +7293,9 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
                         - [$Validate encoder bind groups$](|this|, |this|.{{GPUComputePassEncoder/[[pipeline]]}})
                             is `true`.
                         - |indirectBuffer| is [$valid to use with$] |this|.
-                        - |indirectBuffer|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/INDIRECT}}.
+                        - |indirectBuffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDIRECT}}.
                         - |indirectOffset| + sizeof([=indirect dispatch parameters=]) &le;
-                            |indirectBuffer|.{{GPUBuffer/size}}.
+                            |indirectBuffer|.{{GPUBuffer/[[size]]}}.
                         - |indirectOffset| is a multiple of 4.
                     </div>
                 1. Add |indirectBuffer| to the [=usage scope=] as {{GPUBufferUsage/INDIRECT}}.
@@ -7537,7 +7545,7 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
 
     1. All {{GPURenderPassColorAttachment/view}}s in |this|.{{GPURenderPassDescriptor/colorAttachments}},
         and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachment/view}}
-        if present, must have equal {{GPUTexture/sampleCount}}s.
+        if present, must have equal {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}}s.
 
     1. For each {{GPURenderPassColorAttachment/view}} in |this|.{{GPURenderPassDescriptor/colorAttachments}}
         and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachment/view}},
@@ -7545,14 +7553,14 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
 
     1. If |this|.{{GPURenderPassDescriptor/occlusionQuerySet}} is not `null`:
 
-        1. |this|.{{GPURenderPassDescriptor/occlusionQuerySet}}.{{GPUQuerySet/type}}
+        1. |this|.{{GPURenderPassDescriptor/occlusionQuerySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/type}}
             must be {{GPUQueryType/occlusion}}.
 
     1. For each |timestampWrite| in |this|.{{GPURenderPassDescriptor/timestampWrites}}:
 
-        1. |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}}.{{GPUQuerySet/type}} is {{GPUQueryType/"timestamp"}}.
+        1. |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/"timestamp"}}.
 
-        1. |timestampWrite|.{{GPURenderPassTimestampWrite/queryIndex}} &lt; |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}}.{{GPUQuerySet/count}}.
+        1. |timestampWrite|.{{GPURenderPassTimestampWrite/queryIndex}} &lt; |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}}.
 
     Issue(gpuweb/gpuweb#503): support for no attachments
 </div>
@@ -7617,16 +7625,16 @@ dictionary GPURenderPassColorAttachment {
 
     1. Let |renderViewDescriptor| be |this|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.
     1. Let |resolveViewDescriptor| be |this|.{{GPURenderPassColorAttachment/resolveTarget}}.{{GPUTextureView/[[descriptor]]}}.
-    1. Let |renderTexture| be |this|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.
-    1. Let |resolveTexture| be |this|.{{GPURenderPassColorAttachment/resolveTarget}}.{{GPUTextureView/[[texture]]}}.
+    1. Let |renderTextureDescriptor| be |this|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.
+    1. Let |resolveTextureDescriptor| be |this|.{{GPURenderPassColorAttachment/resolveTarget}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.
 
     The following validation rules apply:
 
     - |renderViewDescriptor|.{{GPUTextureViewDescriptor/format}} must be a [=color renderable format=].
     - |this|.{{GPURenderPassColorAttachment/view}} must be a [$renderable texture view$].
     - If |this|.{{GPURenderPassColorAttachment/resolveTarget}} is not `null`:
-        - |renderTexture|.{{GPUTexture/sampleCount}} must be greater than 1.
-        - |resolveTexture|.{{GPUTexture/sampleCount}} must be 1.
+        - |renderTextureDescriptor|.{{GPUTextureDescriptor/sampleCount}} must be greater than 1.
+        - |resolveTextureDescriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
         - |this|.{{GPURenderPassColorAttachment/resolveTarget}} must be a [$renderable texture view$].
         - The sizes of the [=subresource=]s seen by |this|.{{GPURenderPassColorAttachment/resolveTarget}}
             and |this|.{{GPURenderPassColorAttachment/view}} must match.
@@ -7639,7 +7647,7 @@ dictionary GPURenderPassColorAttachment {
     A {{GPUTextureView}} |view| is a <dfn abstract-op>renderable texture view</dfn>
     if the following requirements are met:
 
-    - |view|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/usage}}
+    - |view|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}}
         must contain {{GPUTextureUsage/RENDER_ATTACHMENT}}.
     - |descriptor|.{{GPUTextureViewDescriptor/dimension}} must be {{GPUTextureViewDimension/"2d"}}.
     - |descriptor|.{{GPUTextureViewDescriptor/mipLevelCount}} must be 1.
@@ -7788,12 +7796,12 @@ dictionary GPURenderPassLayout: GPUObjectDescriptorBase {
 
     1. Let |layout| be a new {{GPURenderPassLayout}} object.
     1. For each |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
-        1. Set |layout|.{{GPURenderPassLayout/sampleCount}} to |colorAttachment|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/sampleCount}}.
+        1. Set |layout|.{{GPURenderPassLayout/sampleCount}} to |colorAttachment|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}}.
         1. Append |colorAttachment|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}} to |layout|.{{GPURenderPassLayout/colorFormats}}.
     1. Let |depthStencilAttachment| be |descriptor|.{{GPURenderPassDescriptor/depthStencilAttachment}}.
     1. If |depthStencilAttachment| is not `null`:
         1. Let |view| be |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/view}}
-        1. Set |layout|.{{GPURenderPassLayout/sampleCount}} to |view|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/sampleCount}}.
+        1. Set |layout|.{{GPURenderPassLayout/sampleCount}} to |view|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}}.
         1. Set |layout|.{{GPURenderPassLayout/depthStencilFormat}} to |view|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
     1. Return |layout|.
 
@@ -7873,13 +7881,13 @@ dictionary GPURenderPassLayout: GPUObjectDescriptorBase {
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. If |size| is missing, set |size| to max(0, |buffer|.{{GPUBuffer/size}} - |offset|).
+                1. If |size| is missing, set |size| to max(0, |buffer|.{{GPUBuffer/[[size]]}} - |offset|).
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |buffer| is [$valid to use with$] |this|.
-                        - |buffer|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/INDEX}}.
+                        - |buffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDEX}}.
                         - |offset| is a multiple of |indexFormat|'s byte size.
-                        - |offset| + |size| &le; |buffer|.{{GPUBuffer/size}}.
+                        - |offset| + |size| &le; |buffer|.{{GPUBuffer/[[size]]}}.
                     </div>
                 1. Add |buffer| to the [=usage scope=] as [=internal usage/input=].
                 1. Set |this|.{{GPURenderEncoderBase/[[index_buffer]]}} to be |buffer|.
@@ -7908,14 +7916,14 @@ dictionary GPURenderPassLayout: GPUObjectDescriptorBase {
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. If |size| is missing, set |size| to max(0, |buffer|.{{GPUBuffer/size}} - |offset|).
+                1. If |size| is missing, set |size| to max(0, |buffer|.{{GPUBuffer/[[size]]}} - |offset|).
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |buffer| is [$valid to use with$] |this|.
-                        - |buffer|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/VERTEX}}.
+                        - |buffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/VERTEX}}.
                         - |slot| &lt; |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBuffers}}.
                         - |offset| is a multiple of 4.
-                        - |offset| + |size| &le; |buffer|.{{GPUBuffer/size}}.
+                        - |offset| + |size| &le; |buffer|.{{GPUBuffer/[[size]]}}.
                     </div>
                 1. Add |buffer| to the [=usage scope=] as [=internal usage/input=].
                 1. Set |this|.{{GPURenderEncoderBase/[[vertex_buffers]]}}[|slot|] to be |buffer|.
@@ -8049,9 +8057,9 @@ dictionary GPURenderPassLayout: GPUObjectDescriptorBase {
                     <div class=validusage>
                         - It is [$valid to draw$] with |this|.
                         - |indirectBuffer| is [$valid to use with$] |this|.
-                        - |indirectBuffer|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/INDIRECT}}.
+                        - |indirectBuffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDIRECT}}.
                         - |indirectOffset| + sizeof([=indirect draw parameters=]) &le;
-                            |indirectBuffer|.{{GPUBuffer/size}}.
+                            |indirectBuffer|.{{GPUBuffer/[[size]]}}.
                         - |indirectOffset| is a multiple of 4.
                     </div>
                 1. Add |indirectBuffer| to the [=usage scope=] as [=internal usage/input=].
@@ -8097,9 +8105,9 @@ dictionary GPURenderPassLayout: GPUObjectDescriptorBase {
                     <div class=validusage>
                         - It is [$valid to draw indexed$] with |this|.
                         - |indirectBuffer| is [$valid to use with$] |this|.
-                        - |indirectBuffer|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/INDIRECT}}.
+                        - |indirectBuffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDIRECT}}.
                         - |indirectOffset| + sizeof([=indirect drawIndexed parameters=]) &le;
-                            |indirectBuffer|.{{GPUBuffer/size}}.
+                            |indirectBuffer|.{{GPUBuffer/[[size]]}}.
                         - |indirectOffset| is a multiple of 4.
                     </div>
                 1. Add |indirectBuffer| to the [=usage scope=] as [=internal usage/input=].
@@ -8275,7 +8283,7 @@ attachments used by this encoder.
                 1. If any of the following conditions are unsatisfied, generate a validation error and stop.
                     <div class=validusage>
                         - |this|.{{GPURenderPassEncoder/[[occlusion_query_set]]}} is not `null`.
-                        - |queryIndex| &lt; |this|.{{GPURenderPassEncoder/[[occlusion_query_set]]}}.{{GPUQuerySet/count}}.
+                        - |queryIndex| &lt; |this|.{{GPURenderPassEncoder/[[occlusion_query_set]]}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}}.
                         - The query at same |queryIndex| must not have been previously written to in this pass.
                         - |this|.{{GPURenderPassEncoder/[[occlusion_query_active]]}} is `false`.
                     </div>
@@ -8610,9 +8618,9 @@ GPUQueue includes GPUObjectBase;
                         <div class=validusage>
                             - |buffer| is [$valid to use with$] |this|.
                             - |buffer|.{{GPUBuffer/[[state]]}} is [=buffer state/unmapped=].
-                            - |buffer|.{{GPUBuffer/usage}} includes {{GPUBufferUsage/COPY_DST}}.
+                            - |buffer|.{{GPUBuffer/[[usage]]}} includes {{GPUBufferUsage/COPY_DST}}.
                             - |bufferOffset|, converted to bytes, is a multiple of 4 bytes.
-                            - |bufferOffset| + |contentsSize|, converted to bytes, &le; |buffer|.{{GPUBuffer/size}} bytes.
+                            - |bufferOffset| + |contentsSize|, converted to bytes, &le; |buffer|.{{GPUBuffer/[[size]]}} bytes.
                         </div>
                     1. Write |contents| into |buffer| starting at |bufferOffset|.
                 </div>
@@ -8637,13 +8645,13 @@ GPUQueue includes GPUObjectBase;
 
             1. Let |dataBytes| be [=get a copy of the buffer source|a copy of the bytes held by the buffer source=] |data|.
             1. Let |dataByteSize| be the number of bytes in |dataBytes|.
-            1. Let |texture| be |destination|.{{GPUImageCopyTexture/texture}}.
+            1. Let |textureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
             1. If any of the following conditions are unsatisfied,
                 throw {{OperationError}} and stop.
                 <div class=validusage>
                     - [$validating linear texture data$](|dataLayout|,
                         |dataByteSize|,
-                        |texture|.{{GPUTexture/format}},
+                        |textureDesc|.{{GPUTextureDescriptor/format}},
                         |size|) succeeds.
                 </div>
             1. Let |contents| be the contents of the [=images=] seen by
@@ -8656,11 +8664,11 @@ GPUQueue includes GPUObjectBase;
                         generate a validation error and stop.
                         <div class=validusage>
                             - [$validating GPUImageCopyTexture$](|destination|, |size|) returns `true`.
-                            - |texture|.{{GPUTexture/usage}} includes {{GPUTextureUsage/COPY_DST}}.
-                            - |texture|.{{GPUTexture/sampleCount}} is 1.
+                            - |textureDesc|.{{GPUTextureDescriptor/usage}} includes {{GPUTextureUsage/COPY_DST}}.
+                            - |textureDesc|.{{GPUTextureDescriptor/sampleCount}} is 1.
                             - [=Valid Texture Copy Range=](|destination|, |size|) is satisfied.
                             - |destination|.{{GPUImageCopyTexture/aspect}} must refer to a single aspect of
-                                |texture|.{{GPUTexture/format}}, and that aspect must be
+                                |textureDesc|.{{GPUTextureDescriptor/format}}, and that aspect must be
                                 a valid image copy destination according to [[#depth-formats]].
 
                             Note: unlike
@@ -8722,17 +8730,17 @@ GPUQueue includes GPUObjectBase;
                 </div>
             1. Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
-                    1. Let |texture| be |destination|.{{GPUImageCopyTexture/texture}}.
+                    1. Let |textureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
                     1. If any of the following requirements are unmet, generate a validation error and stop.
                         <div class=validusage>
                             - |destination|.{{GPUImageCopyTexture/texture}} must be [$valid to use with$] |this|.
                             - [$validating GPUImageCopyTexture$](destination, copySize) must return true.
                             - [=Valid Texture Copy Range=](destination, copySize) must be satisfied.
-                            - |texture|.{{GPUTexture/usage}} must include both
+                            - |textureDesc|.{{GPUTextureDescriptor/usage}} must include both
                                 {{GPUTextureUsage/RENDER_ATTACHMENT}} and {{GPUTextureUsage/COPY_DST}}.
-                            - |texture|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
-                            - |texture|.{{GPUTexture/sampleCount}} must be 1.
-                            - |texture|.{{GPUTexture/format}} must be one of the following
+                            - |textureDesc|.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"2d"}}.
+                            - |textureDesc|.{{GPUTextureDescriptor/sampleCount}} must be 1.
+                            - |textureDesc|.{{GPUTextureDescriptor/format}} must be one of the following
                                 formats (which all support {{GPUTextureUsage/RENDER_ATTACHMENT}} usage):
                                 - {{GPUTextureFormat/"r8unorm"}}
                                 - {{GPUTextureFormat/"r16float"}}
@@ -8826,16 +8834,22 @@ GPUQuerySet includes GPUObjectBase;
 <dl dfn-type=attribute dfn-for="GPUQuerySet">
     : <dfn>type</dfn>
     ::
-        The type of queries the {{GPUQuerySet}} contains.
+        Returns {{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/type}}.
 
     : <dfn>count</dfn>
     ::
-        The number of queries the {{GPUQuerySet}} contains.
+        Returns {{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}}.
 </dl>
 
 {{GPUQuerySet}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUQuerySet">
+    : <dfn>\[[descriptor]]</dfn>, of type {{GPUQuerySetDescriptor}}
+    ::
+        The {{GPUQuerySetDescriptor}} describing this query set.
+
+        All optional fields of {{GPUTextureViewDescriptor}} are defined.
+
     : <dfn>\[[state]]</dfn> of type [=query set state=].
     ::
         The current state of the {{GPUQuerySet}}.
@@ -8894,8 +8908,7 @@ dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
                     - |descriptor|.{{GPUQuerySetDescriptor/count}} must be &le; 8192.
                 </div>
             1. Let |q| be a new {{GPUQuerySet}} object.
-            1. Set |q|.{{GPUQuerySet/type}} to |descriptor|.{{GPUQuerySetDescriptor/type}}.
-            1. Set |q|.{{GPUQuerySet/count}} to |descriptor|.{{GPUQuerySetDescriptor/count}}.
+            1. Set |q|.{{GPUQuerySet/[[descriptor]]}} to |descriptor|.
             1. Set |q|.{{GPUQuerySet/[[state]]}} to [=query set state/available=].
             1. Return |q|.
         </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3368,9 +3368,63 @@ that returns a new sampler object.
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUSampler {
+    readonly attribute GPUAddressMode addressModeU;
+    readonly attribute GPUAddressMode addressModeV;
+    readonly attribute GPUAddressMode addressModeW;
+    readonly attribute GPUFilterMode magFilter;
+    readonly attribute GPUFilterMode minFilter;
+    readonly attribute GPUFilterMode mipmapFilter;
+    readonly attribute float lodMinClamp;
+    readonly attribute float lodMaxClamp;
+    readonly attribute GPUCompareFunction compare;
+    readonly attribute unsigned short maxAnisotropy;
 };
 GPUSampler includes GPUObjectBase;
 </script>
+
+{{GPUSampler}} has the following attributes:
+
+<dl dfn-type=attribute dfn-for="GPUSampler">
+    : <dfn>addressModeU</dfn>
+    ::
+        Returns {{GPUSampler/[[descriptor]]}}.{{GPUSamplerDescriptor/addressModeU}}.
+
+    : <dfn>addressModeV</dfn>
+    ::
+        Returns {{GPUSampler/[[descriptor]]}}.{{GPUSamplerDescriptor/addressModeV}}.
+
+    : <dfn>addressModeW</dfn>
+    ::
+        Returns {{GPUSampler/[[descriptor]]}}.{{GPUSamplerDescriptor/addressModeW}}.
+
+    : <dfn>magFilter</dfn>
+    ::
+        Returns {{GPUSampler/[[descriptor]]}}.{{GPUSamplerDescriptor/magFilter}}.
+
+    : <dfn>minFilter</dfn>
+    ::
+        Returns {{GPUSampler/[[descriptor]]}}.{{GPUSamplerDescriptor/minFilter}}.
+
+    : <dfn>mipmapFilter</dfn>
+    ::
+        Returns {{GPUSampler/[[descriptor]]}}.{{GPUSamplerDescriptor/mipmapFilter}}.
+
+    : <dfn>lodMinClamp</dfn>
+    ::
+        Returns {{GPUSampler/[[descriptor]]}}.{{GPUSamplerDescriptor/lodMinClamp}}.
+
+    : <dfn>lodMaxClamp</dfn>
+    ::
+        Returns {{GPUSampler/[[descriptor]]}}.{{GPUSamplerDescriptor/lodMaxClamp}}.
+
+    : <dfn>compare</dfn>
+    ::
+        Returns {{GPUSampler/[[descriptor]]}}.{{GPUSamplerDescriptor/compare}}.
+
+    : <dfn>maxAnisotropy</dfn>
+    ::
+        Returns {{GPUSampler/[[descriptor]]}}.{{GPUSamplerDescriptor/maxAnisotropy}}.
+</dl>
 
 {{GPUSampler}} has the following internal slots:
 


### PR DESCRIPTION
Fixes #1498.

Starting to sketch this out to get a better feel for any problems that might come up. Only have done buffer, texture, and queryset. Thoughts so far:
  
 - General guiding principle of what to include and what to not include is "is it mutable".
   - example: `mappedAtCreation` is "mutable" in that the mapped state changes, so it's not exposed here.
   - counter example: a shader module `source` is immutable, but my inclination is that we probably wouldn't want to include it due to size?
 - Being able to reduce some of the indirection in the spec prose is nice.
 - Need to be careful about normalizing things like `GPUExtent3D`
 - Currently returning texture `size` as a dictionary, which incurs copies. Can create an `interface GPUExtent3DReadOnly` and friends if that's a problem (but I don't really think it is.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/2494.html" title="Last updated on Jan 11, 2022, 10:30 PM UTC (89bbd17)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2494/6481473...89bbd17.html" title="Last updated on Jan 11, 2022, 10:30 PM UTC (89bbd17)">Diff</a>