### PR TITLE
Change GPUObjectBase.label from nullable to union-with-undefined

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -574,7 +574,7 @@ Any interface which includes {{GPUObjectBase}} is a [=WebGPU interface=].
 
 <script type=idl>
 interface mixin GPUObjectBase {
-    attribute USVString? label;
+    attribute (USVString or undefined) label;
 };
 </script>
 


### PR DESCRIPTION
This makes it consistent with the input api at GPUObjectDescriptorBase.label which is optional and therefore allows string or undefined (but not null).

Fixes #1400


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2496.html" title="Last updated on Jan 11, 2022, 11:53 PM UTC (766be46)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2496/c2862fb...kainino0x:766be46.html" title="Last updated on Jan 11, 2022, 11:53 PM UTC (766be46)">Diff</a>