### PR TITLE
Remove stride attribute

### DIFF
--- a/wgsl/extract-grammar.py
+++ b/wgsl/extract-grammar.py
@@ -238,7 +238,6 @@ module.exports = grammar({
     ],
 
     conflicts: $ => [
-        [$.array_type_decl],
         [$.type_decl,$.primary_expression],
     ],
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1231,7 +1231,7 @@ of a variable in [=storage classes/workgroup=] storage.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>array_type_decl</dfn> :
 
-    | [=syntax/attribute_list=] * [=syntax/array=] [=syntax/less_than=] [=syntax/type_decl=] ( [=syntax/comma=] [=syntax/element_count_expression=] ) ? [=syntax/greater_than=]
+    | [=syntax/array=] [=syntax/less_than=] [=syntax/type_decl=] ( [=syntax/comma=] [=syntax/element_count_expression=] ) ? [=syntax/greater_than=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>element_count_expression</dfn> :

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -667,13 +667,6 @@ An attribute must not be specified more than once per object or type.
 
     Declares an [=entry point=] by specifying its [[#shader-stages-sec|pipeline stage]].
 
-  <tr><td><dfn noexport dfn-for="attribute">`stride`</dfn>
-    <td>positive i32 literal
-    <td>Must only be applied to an [=array=] type.
-
-    The number of bytes from the start of one element of the array to the
-    start of the next element.
-
   <tr><td><dfn noexport dfn-for="attribute">`workgroup_size`</dfn>
     <td>One, two or three parameters.
 
@@ -1182,9 +1175,6 @@ An array element type must be one of:
 
 Note: The element type must be a [=plain type=].
 
-[SHORTNAME] defines the following attributes that can be applied to array types:
-* [=attribute/stride=]
-
 Two array types are the same if and only if all of the following are true:
 * They have the same element type.
 * Their element count specifications match, i.e. one of the following is true:
@@ -1195,9 +1185,6 @@ Two array types are the same if and only if all of the following are true:
         be greater than zero.)
     * They are both fixed-sized with element count specified as the same
         [=pipeline-overridable=] [=module scope|module-scope-=] constant.
-
-Issue: Array types should differ if they have different element strides.
-See https://github.com/gpuweb/gpuweb/issues/1534
 
 <div class='example wgsl fixed-size array types' heading='Example fixed-size array types, non-overridable element count'>
   <xmp highlight='rust'>
@@ -1317,7 +1304,6 @@ Some consequences of the restrictions structure member and array element types a
 [SHORTNAME] defines the following attributes that can be applied to structure members:
  * [=attribute/builtin=]
  * [=attribute/location=]
- * [=attribute/stride=]
  * [=attribute/align=]
  * [=attribute/size=]
 
@@ -1348,7 +1334,7 @@ to define a [=uniform buffer=] or a [=storage buffer=]. See [[#memory-layouts]].
   <xmp>
     // TODO: runtime-sized array syntax may have changed
     // Runtime Array
-    type RTArr = [[stride(16)]] array<vec4<f32>>;
+    type RTArr = array<vec4<f32>>;
     struct S {
       a: f32;
       b: f32;
@@ -1565,7 +1551,6 @@ A type is <dfn dfn noexport>host-shareable</dfn> if it is one of:
 * a [=structure=] type, if all its members are host-shareable
 
 [SHORTNAME] defines the following attributes that affect memory layouts:
- * [=attribute/stride=]
  * [=attribute/align=]
  * [=attribute/size=]
 
@@ -1780,24 +1765,18 @@ following table:
       <td>[=roundUp=]([=AlignOf=](|S|), [=OffsetOfMember=](|S|, |L|) + [=SizeOfMember=](|S|, |L|))<br><br>
           Where |L| is the last member of the structure
   <tr><td>array<|E|, |N|><br>
-      <p class="small">(Implicit stride)</p>
       <td>[=AlignOf=](|E|)
       <td>|N| * [=roundUp=]([=AlignOf=](|E|), [=SizeOf=](|E|))
   <tr><td>array<|E|><br>
-      <p class="small">(Implicit stride)</p>
       <td>[=AlignOf=](|E|)
       <td>N<sub>runtime</sub> * [=roundUp=]([=AlignOf=](|E|), [=SizeOf=](|E|))<br><br>
           Where N<sub>runtime</sub> is the runtime-determined number of elements of |T|
-  <tr><td>[[[=attribute/stride=](|Q|)]]<br> array<|E|, |N|>
-      <td>[=AlignOf=](|E|)
-      <td>|N| * |Q|
-  <tr><td>[[[=attribute/stride=](|Q|)]]<br> array<|E|>
-      <td>[=AlignOf=](|E|)
-      <td>N<sub>runtime</sub> * |Q|
 </table>
 
 
 #### Structure Layout Rules ####  {#structure-layout-rules}
+
+Issue: [#2493](https://github.com/gpuweb/gpuweb/issues/2493) Portions of this section are redundant with other sections.
 
 Each structure |S| member M<sub>N</sub> has a size and alignment value, denoted
 by [=SizeOfMember=](|S|, M<sub>N</sub>) and [=AlignOfMember=](|S|, M<sub>N</sub>), respectively.
@@ -1844,7 +1823,7 @@ rounded to the next multiple of the structure's alignment:
   Where |L| is the last member of the structure
 </p>
 
-<div class='example wgsl' heading='Layout of structures using implicit member sizes, alignments and strides'>
+<div class='example wgsl' heading='Layout of structures using implicit member sizes and alignments'>
   <xmp highlight='rust'>
     struct A {                                     //             align(8)  size(24)
         u: f32;                                    // offset(0)   align(4)  size(4)
@@ -1864,7 +1843,7 @@ rounded to the next multiple of the structure's alignment:
         e: A;                                      // offset(40)  align(8)  size(24)
         f: vec3<f32>;                              // offset(64)  align(16) size(12)
         // -- implicit member alignment padding -- // offset(76)            size(4)
-        g: array<A, 3>;                            // offset(80)  align(8)  size(72) stride(24)
+        g: array<A, 3>;    // element stride 24       offset(80)  align(8)  size(72)
         h: i32;                                    // offset(152) align(4)  size(4)
         // -- implicit struct size padding --      // offset(156)           size(4)
     };
@@ -1874,7 +1853,7 @@ rounded to the next multiple of the structure's alignment:
   </xmp>
 </div>
 
-<div class='example wgsl' heading='Layout of structures with explicit member sizes, alignments and strides'>
+<div class='example wgsl' heading='Layout of structures with explicit member sizes and alignments'>
   <xmp highlight='rust'>
     struct A {                                     //             align(8)  size(32)
         u: f32;                                    // offset(0)   align(4)  size(4)
@@ -1893,7 +1872,7 @@ rounded to the next multiple of the structure's alignment:
         [[align(16)]] e: A;                        // offset(48)  align(16) size(32)
         f: vec3<f32>;                              // offset(80)  align(16) size(12)
         // -- implicit member alignment padding -- // offset(92)            size(4)
-        g: [[stride(32)]] array<A, 3>;             // offset(96)  align(8)  size(96)
+        g: array<A, 3>;    // element stride 32       offset(96)  align(8)  size(96)
         h: i32;                                    // offset(192) align(4)  size(4)
         // -- implicit struct size padding --      // offset(196)           size(12)
     };
@@ -1905,40 +1884,33 @@ rounded to the next multiple of the structure's alignment:
 
 #### Array Layout Rules ####  {#array-layout-rules}
 
+Issue: [#2493](https://github.com/gpuweb/gpuweb/issues/2493) This section is largely redundant
+
 The first array element always has a zero byte offset from the start of the
 array.
 
 The <dfn noexport>element stride</dfn> of an array is the number of bytes from the
 start of one array element to the start of the next element.
-It is determined as follows:
-* It is the value of an explicit [=attribute/stride=] attribute on the type, if specified.
-* Otherwise, it is the <dfn noexport>implicit stride</dfn>,
-    equal to the size of the array's element type, rounded up to the alignment of
-    the element type:
+It equals the size of the array's element type, rounded up to the alignment of the element type:
 
-<p algorithm="array implicit element stride">
+<p algorithm="array element stride">
   [=StrideOf=](array<|T|[, |N|]>) = [=roundUp=]([=AlignOf=](T), [=SizeOf=](T))
 </p>
 
-In all cases, the array element stride must be a multiple of the element alignment.
-
-<div class='example wgsl' heading='Implicit / explicit array element strides'>
+<div class='example wgsl' heading='Array element strides'>
   <xmp highlight='rust'>
-    // Array with an implicit element stride of 16 bytes
-    var implicit_stride: array<vec3<f32>, 8>;
+    // Array with an element stride of 4 bytes.
+    var small_stride: array<f32, 8>;
 
-    // Array with an explicit element stride of 32 bytes
-    var explicit_stride: [[stride(32)]] array<vec3<f32>, 8>;
+    // Array with an element stride of 16 bytes, inherited from
+    // the alignment of element type vec3<f32>, which is 16 bytes.
+    var bigger_stride: array<vec3<f32>, 8>;
   </xmp>
 </div>
 
-Arrays decorated with the [=attribute/stride=] attribute must have a stride that is at
-least the size of the element type, and be a multiple of the element type's
-alignment value.
-
 The array size (in bytes) is equal to the array's element stride multiplied by the number of
 elements:
-<p algorithm="array element stride">
+<p algorithm="array size">
   [=SizeOf=](array<|T|, |N|>) = [=StrideOf=](array<|T|, |N|>) &times; |N|<br>
   [=SizeOf=](array<|T|>) = [=StrideOf=](array<|T|>) &times; N<sub>runtime</sub>
 </p>
@@ -1948,26 +1920,12 @@ The array alignment is equal to the element alignment:
   [=AlignOf=](array<|T|[, N]>) = [=AlignOf=](|T|)
 </p>
 
-For example, the layout for a `[[stride(S)]] array<T, 3>` type is equivalent to
-the following structure:
-
-<div class='example wgsl global-scope' heading='Structure equivalent of a three element array'>
-  <xmp highlight='rust'>
-    struct Array {
-      [[size(S)]] element_0: T;
-      [[size(S)]] element_1: T;
-      [[size(S)]] element_2: T;
-    };
-  </xmp>
-</div>
-
 #### Internal Layout of Values ####  {#internal-value-layout}
 
 This section describes how the internals of a value are placed in the byte locations
 of a buffer, given an assumed placement of the overall value.
-These layouts depend on the value's type, the [=attribute/stride=] attribute on
-array types, and the [=attribute/align=] and [=attribute/size=] attributes on
-structure type members.
+These layouts depend on the value's type,
+and the [=attribute/align=] and [=attribute/size=] attributes on structure members.
 
 The data will appear identically regardless of storage class.
 
@@ -2099,7 +2057,12 @@ The [=storage classes/uniform=] storage class also requires that:
     bytes between the start of that member and the start of any following member
     must be at least [=roundUp=](16, [=SizeOf=](S)).
 
-<div class='example wgsl global-scope' heading='invalid structure layout for uniform storage class'>
+Note: The following examples show how to use [=attribute/align=] and [=attribute/size=] attributes
+on structure members to satisfy layout requirements for uniform buffers.
+In particular, these techniques can be used mechanically transform a GLSL buffer with std140 layout
+to WGSL.
+
+<div class='example wgsl global-scope' heading='Satisfying offset requirements for uniform storage class'>
   <xmp highlight='rust'>
     struct S {
       x: f32;
@@ -2108,12 +2071,30 @@ The [=storage classes/uniform=] storage class also requires that:
       a: S;
       b: f32; // invalid: offset between a and b is 4 bytes, but must be at least 16
     };
+    [[group(0), binding(0)]] var<uniform> invalid: Invalid;
+
     struct Valid {
       a: S;
       [[align(16)]] b: f32; // valid: offset between a and b is 16 bytes
     };
-    [[group(0), binding(0)]] var<uniform> invalid: Invalid;
     [[group(0), binding(1)]] var<uniform> valid: Valid;
+  </xmp>
+</div>
+
+<div class='example wgsl global-scope' heading='Satisfying stride requirements for uniform storage class'>
+  <xmp highlight='rust'>
+    struct small_stride {
+      a: array<f32,8>; // stride 4
+    };
+    [[group(0), binding(0)]] var<uniform> invalid: small_stride; // Invalid
+
+    struct wrapped_f32 {
+      [[size(16)]] elem: f32;
+    };
+    struct big_stride {
+      a: array<wrapped_f32,8>; // stride 16
+    };
+    [[group(0), binding(1)]] var<uniform> valid: big_stride;     // Valid
   </xmp>
 </div>
 
@@ -3067,7 +3048,7 @@ The declaration must appear at [=module scope=], and its [=scope=] is the entire
   <xmp>
     type Arr = array<i32, 5>;
 
-    type RTArr = [[stride(16)]] array<vec4<f32>>;
+    type RTArr = array<vec4<f32>>;
 
     type single = f32;     // Declare an alias for f32
     let pi_approx: single = 3.1415;
@@ -3149,11 +3130,6 @@ When the type declaration is an [=identifier=], then the expression must be in s
         %7 = OpTypeVector %float 2
 
     array<f32, 4>
-       %uint_4 = OpConstant %uint 4
-            %9 = OpTypeArray %float %uint_4
-
-    [[stride(32)]] array<f32, 4>
-                 OpDecorate %9 ArrayStride 32
        %uint_4 = OpConstant %uint 4
             %9 = OpTypeArray %float %uint_4
 


### PR DESCRIPTION
Fixes: #2493

Rework the examples for satisfying uniform buffer layout, using align
and stride.