### PR TITLE
Complete the Errors & Debugging section

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9705,7 +9705,7 @@ User agents **may** dispatch an <dfn event for="GPUDevice">uncapturederror</dfn>
 event must be of type {{GPUUncapturedErrorEvent}}.
 
 Note: {{GPUDevice/uncapturederror}} events are intended to be used for telemetry and reporting
-unexpected errors, and should not be used for handling known error cases that may occur during
+unexpected errors. They may not be dispatched for all uncaptured errors (for example, there may be a limit on the number of errors surfaced), and should not be used for handling known error cases that may occur during
 normal operation of an application. Prefer using {{GPUDevice/pushErrorScope()}} and
 {{GPUDevice/popErrorScope()}} in those cases.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9590,9 +9590,8 @@ partial interface GPUDevice {
 </dl>
 
 <div algorithm>
-    To <dfn abstract-op lt='to the current error scope'>push an error to the current error scope</dfn>
-    with {{GPUError}} |error| for a {{GPUDevice}} |device|, issue the following steps to the
-    [=Device timeline=]:
+    The <dfn abstract-op>current error scope</dfn> for a {{GPUError}} |error| and {{GPUDevice}}
+    |device| is determined by issuing the following steps to the [=Device timeline=]:
 
     <div class=device-timeline>
         1. If |error| is and instance of:
@@ -9604,29 +9603,36 @@ partial interface GPUDevice {
             </dl>
         1. Let |scope| be the last [=list/item=] of |device|.{{GPUDevice/[[errorScopeStack]]}}.
         1. While |scope| is not `undefined`:
-            1. If |scope|.{{GPU error scope/[[filter]]}} is |type|:
-                1. If |scope|.{{GPU error scope/[[error]]}} is not `null`, set
-                    |scope|.{{GPU error scope/[[error]]}} to |error|.
-                1. Stop.
+            1. If |scope|.{{GPU error scope/[[filter]]}} is |type|, return |scope|.
             1. Set |scope| to the previous [=list/item=] of
                 |device|.{{GPUDevice/[[errorScopeStack]]}}.
-
-        1. If the user agent chooses, [=queue a task=] to fire an {{GPUUncapturedErrorEvent}} named
-            "{{GPUDevice/uncapturederror}}" on |device| with an {{GPUUncapturedErrorEvent/error}} of
-            |error|.
+        1. Return `undefined`.
     </div>
 </div>
-
-Note: The user agent may choose to throttle or limit the number of {{GPUUncapturedErrorEvent}}s that
-a {{GPUDevice}} can raise to prevent an excessive amount of error handling or logging from impacting
-performance.
 
 <div algorithm>
     To <dfn abstract-op lt="Generate a validation error|generate a validation error">generate a
     validation error</dfn> for {{GPUDevice}} |device|, run the following steps:
 
     1. Let |error| be a new {{GPUValidationError}} with an appropriate error message.
-    1. Push |error| [$to the current error scope$] of |device|.
+    1. Issue the following steps to the [=Device timeline=]:
+        <div class=device-timeline>
+            1. Let |scope| be the [$current error scope$] for |error| and |device|.
+            1. If |scope| is not `undefined`:
+                1. If |scope|.{{GPU error scope/[[error]]}} is not `null`, set
+                    |scope|.{{GPU error scope/[[error]]}} to |error|.
+                1. Stop.
+            1. Otherwise issue the following steps to the [=Content timeline=]:
+                <div class=content-timeline>
+                    1. If the user agent chooses, [=queue a task=] to fire a
+                        {{GPUUncapturedErrorEvent}} named "{{GPUDevice/uncapturederror}}" on
+                        |device| with an {{GPUUncapturedErrorEvent/error}} of |error|.
+                </div>
+        </div>
+
+    Note: The user agent may choose to throttle or limit the number of {{GPUUncapturedErrorEvent}}s
+    that a {{GPUDevice}} can raise to prevent an excessive amount of error handling or logging from
+    impacting performance.
 </div>
 
 <dl dfn-type=method dfn-for=GPUDevice>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9594,26 +9594,27 @@ partial interface GPUDevice {
     with {{GPUError}} |error| for a {{GPUDevice}} |device|, issue the following steps to the
     [=Device timeline=]:
 
-        <div class=device-timeline>:
-            1. If |error| is and instance of:
-                <dl class="switch">
-                    : {{GPUValidationError}}
-                    :: Let |type| be "validation".
-                    : {{GPUOutOfMemoryError}}
-                    :: Let |type| be "out-of-memory".
-                </dl>
-            1. Let |scope| be the last [=list/item=] of |device|.{{GPUDevice/[[errorScopeStack]]}}.
-            1. While |scope| is not `undefined`:
-                1. If |scope|.{{GPU error scope/[[filter]]}} is |type|:
-                    1. If |scope|.{{GPU error scope/[[error]]}} is not `null`, set
-                        |scope|.{{GPU error scope/[[error]]}} to |error|.
-                    1. Stop.
-                1. Set |scope| to the previous [=list/item=] of
-                    |device|.{{GPUDevice/[[errorScopeStack]]}}.
+    <div class=device-timeline>
+        1. If |error| is and instance of:
+            <dl class="switch">
+                : {{GPUValidationError}}
+                :: Let |type| be "validation".
+                : {{GPUOutOfMemoryError}}
+                :: Let |type| be "out-of-memory".
+            </dl>
+        1. Let |scope| be the last [=list/item=] of |device|.{{GPUDevice/[[errorScopeStack]]}}.
+        1. While |scope| is not `undefined`:
+            1. If |scope|.{{GPU error scope/[[filter]]}} is |type|:
+                1. If |scope|.{{GPU error scope/[[error]]}} is not `null`, set
+                    |scope|.{{GPU error scope/[[error]]}} to |error|.
+                1. Stop.
+            1. Set |scope| to the previous [=list/item=] of
+                |device|.{{GPUDevice/[[errorScopeStack]]}}.
 
-            1. [=Queue a task=] to fire a {{GPUUncapturedErrorEvent}} named "uncapturederror" on
-                |device| with an {{GPUUncapturedErrorEvent/error}} of |error|.
-        </div>
+        1. [=Queue a task=] to fire an {{GPUUncapturedErrorEvent}} named
+            "{{GPUDevice/uncapturederror}}" on |device| with an {{GPUUncapturedErrorEvent/error}} of
+            |error|.
+    </div>
 </div>
 
 Note: The user agent may choose to throttle or limit the number of {{GPUUncapturedErrorEvent}}s that
@@ -9666,7 +9667,7 @@ performance.
                         [=reject=] |promise| with an {{OperationError}} and stop.
 
                         <div class=validusage>
-                            - |this| is not [=lose the device|lost=].
+                            - |this| must not be [=lose the device|lost=].
                             - |this|.{{GPUDevice/[[errorScopeStack]]}}.[=list/size=] &gt; 0.
                         </div>
 
@@ -9699,6 +9700,15 @@ performance.
 
 ## Telemetry ## {#telemetry}
 
+User agents must dispatch an <dfn event for="GPUDevice">uncapturederror</dfn> event on a
+{{GPUDevice}} when a {{GPUError}} is generated that is not obverved by any [=GPU error scope=]. The
+event must be of type {{GPUUncapturedErrorEvent}}.
+
+Note: {{GPUDevice/uncapturederror}} events are intended to be used for telemetry and reporting
+unexpected errors, and should not be used for handling known error cases that may occur during
+normal operation of an application. Prefer using {{GPUDevice/pushErrorScope()}} and
+{{GPUDevice/popErrorScope()}} in those cases.
+
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUUncapturedErrorEvent : Event {
@@ -9713,6 +9723,8 @@ dictionary GPUUncapturedErrorEventInit : EventInit {
     required GPUError error;
 };
 </script>
+
+{{GPUUncapturedErrorEvent}} has the following attributes:
 
 <dl dfn-type=attribute dfn-for=GPUUncapturedErrorEvent>
     : <dfn>error</dfn>
@@ -9734,6 +9746,14 @@ partial interface GPUDevice {
     attribute EventHandler onuncapturederror;
 };
 </script>
+
+{{GPUDevice}} has the following attributes:
+
+<dl dfn-type=attribute dfn-for="GPUDevice">
+    : <dfn>onuncapturederror</dfn>
+    ::
+        An [=event handler IDL attribute=] for the {{GPUDevice/uncapturederror}} event type.
+</dl>
 
 <div class="example">
     Listening for uncaptured errors from a {{GPUDevice}}:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9700,8 +9700,8 @@ performance.
 
 ## Telemetry ## {#telemetry}
 
-User agents must dispatch an <dfn event for="GPUDevice">uncapturederror</dfn> event on a
-{{GPUDevice}} when a {{GPUError}} is generated that is not obverved by any [=GPU error scope=]. The
+User agents **may** dispatch an <dfn event for="GPUDevice">uncapturederror</dfn> event on a
+{{GPUDevice}} when a {{GPUError}} is generated that is not observed by any [=GPU error scope=]. The
 event must be of type {{GPUUncapturedErrorEvent}}.
 
 Note: {{GPUDevice/uncapturederror}} events are intended to be used for telemetry and reporting

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2432,8 +2432,7 @@ namespace GPUMapMode {
 
             **Returns:** {{undefined}}
 
-            1. If any of the following requirements are unmet, generate a validation
-                error and stop.
+            1. If any of the following requirements are unmet, [$generate a validation error$] and stop.
                 <div class=validusage>
                     - |this|.{{GPUBuffer/[[state]]}} must be [=buffer state/mapped at creation=],
                         [=buffer state/mapping pending=], or [=buffer state/mapped=].
@@ -2691,7 +2690,7 @@ namespace GPUTextureUsage {
                         </div>
 
                         Then:
-                            1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
+                            1. [$Generate a validation error$].
                             1. Return a new [=invalid=] {{GPUTexture}}.
 
                     1. Let |t| be a new {{GPUTexture}} object.
@@ -2932,7 +2931,7 @@ enum GPUTextureAspect {
                         </div>
 
                         Then:
-                            1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
+                            1. [$Generate a validation error$].
                             1. Return a new [=invalid=] {{GPUTextureView}}.
 
                     1. Let |view| be a new {{GPUTextureView}} object.
@@ -3572,7 +3571,7 @@ enum GPUCompareFunction {
                 <dfn abstract-op>Valid Usage</dfn>
                 - If |descriptor| is not `null` or undefined:
                     - If [$validating GPUSamplerDescriptor$](this, |descriptor|) returns `false`:
-                        1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
+                        1. [$Generate a validation error$].
                         1. Create a new [=invalid=] {{GPUSampler}} and return the result.
             </div>
         </div>
@@ -4015,8 +4014,7 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                         </div>
 
                         Then:
-                            1. Generate a {{GPUValidationError}} in the current scope with appropriate
-                                error message.
+                            1. [$Generate a validation error$].
                             1. Make |layout| [=invalid=] and return |layout|.
 
                     1. Set |layout|.{{GPUBindGroupLayout/[[dynamicOffsetCount]]}} to the number of
@@ -4225,8 +4223,7 @@ A {{GPUBindGroup}} object has the following internal slots:
                         </div>
 
                         Then:
-                            1. Generate a {{GPUValidationError}} in the current scope with appropriate
-                                error message.
+                            1. [$Generate a validation error$].
                             1. Make |bindGroup| [=invalid=] and return |bindGroup|.
 
                     1. Let |bindGroup|.{{GPUBindGroup/[[layout]]}} =
@@ -4351,7 +4348,7 @@ dictionary GPUPipelineLayoutDescriptor : GPUObjectDescriptorBase {
                 </div>
 
                 Then:
-                    1. Generate a {{GPUValidationError}} in the current scope with appropriate error message.
+                    1. [$Generate a validation error$].
                     1. Create a new [=invalid=] {{GPUPipelineLayout}} and return the result.
 
             1. Let |pl| be a new {{GPUPipelineLayout}} object.
@@ -5157,8 +5154,7 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
                         </div>
 
                         Then:
-                            1. Generate a {{GPUValidationError}} in the current scope with appropriate
-                                error message.
+                            1. [$Generate a validation error$]
                             1. Make |pipeline| [=invalid=].
 
                     1. If |descriptor|.{{GPUPipelineDescriptorBase/layout}} is `undefined`:
@@ -5320,8 +5316,7 @@ details.
                         </div>
 
                         Then:
-                            1. Generate a {{GPUValidationError}} in the current scope with appropriate
-                                error message.
+                            1. [$Generate a validation error$].
                             1. Make |pipeline| [=invalid=].
 
                     1. Set |pipeline|.{{GPURenderPipeline/[[descriptor]]}} to |descriptor|.
@@ -6007,7 +6002,7 @@ The <dfn dfn>encoder state</dfn> may be one of the following:
         :: Make |encoder| [=invalid=], and return `false`.
 
         : "[=encoder state/ended=]"
-        :: Generate a {{GPUValidationError}} in the current scope, and return `false`.
+        :: [$Generate a validation error$], and return `false`.
     </dl>
 </div>
 
@@ -6119,8 +6114,8 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
                 1. Let |pass| be a new {{GPURenderPassEncoder}} object.
-                1. If any of the following conditions are unsatisfied, generate a validation
-                    error and stop.
+                1. If any of the following conditions are unsatisfied, [$generate a validation error$]
+                    and stop.
                     <div class=validusage>
                         - |this|.{{GPUCommandsMixin/[[state]]}} is "[=encoder state/open=]".
                         - |descriptor| meets the
@@ -6181,8 +6176,8 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
-                1. If any of the following conditions are unsatisfied, generate a validation
-                    error and stop.
+                1. If any of the following conditions are unsatisfied, [$generate a validation error$]
+                    and stop.
                     <div class=validusage>
                         - |this|.{{GPUCommandsMixin/[[state]]}} is "[=encoder state/open=]".
                         - |descriptor|.{{GPUComputePassDescriptor/timestampWrites}} is empty, or
@@ -6452,7 +6447,7 @@ dictionary GPUImageCopyExternalImage {
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
                 1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, generate a validation error and stop.
+                1. If any of the following conditions are unsatisfied, [$generate a validation error$] and stop.
                     <div class=validusage>
                         - |source| is [$valid to use with$] |this|.
                         - |destination| is [$valid to use with$] |this|.
@@ -6498,7 +6493,7 @@ dictionary GPUImageCopyExternalImage {
             <div class=device-timeline>
                 1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
                 1. If |size| is missing, set |size| to `max(0, |buffer|.{{GPUBuffer/[[size]]}} - |offset|)`.
-                1. If any of the following conditions are unsatisfied, generate a validation error and stop.
+                1. If any of the following conditions are unsatisfied, [$generate a validation error$] and stop.
                     <div class=validusage>
                         - |buffer| is [$valid to use with$] |this|.
                         - |buffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/COPY_DST}}.
@@ -6654,7 +6649,7 @@ Issue(gpuweb/gpuweb#652): Define the copies with {{GPUTextureFormat/"depth24plus
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
                 1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, generate a validation error and stop.
+                1. If any of the following conditions are unsatisfied, [$generate a validation error$] and stop.
                     <div class=validusage>
                         - Let |dstTextureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
                         - [$validating GPUImageCopyBuffer$](|source|) returns `true`.
@@ -6700,7 +6695,7 @@ Issue(gpuweb/gpuweb#652): Define the copies with {{GPUTextureFormat/"depth24plus
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
                 1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, generate a validation error and stop.
+                1. If any of the following conditions are unsatisfied, [$generate a validation error$] and stop.
                     <div class=validusage>
                         - Let |srcTextureDesc| be |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
                         - [$validating GPUImageCopyTexture$](|source|, |copySize|) returns `true`.
@@ -6748,7 +6743,7 @@ Issue(gpuweb/gpuweb#652): Define the copies with {{GPUTextureFormat/"depth24plus
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
                 1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, generate a validation error and stop.
+                1. If any of the following conditions are unsatisfied, [$generate a validation error$] and stop.
                     <div class=validusage>
                         - Let |srcTextureDesc| be |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
                         - Let |dstTextureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
@@ -6821,7 +6816,7 @@ Issue(gpuweb/gpuweb#652): Define the copies with {{GPUTextureFormat/"depth24plus
             1. Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
                 <div class=device-timeline>
                     1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
-                    1. If any of the following conditions are unsatisfied, generate a validation error and stop.
+                    1. If any of the following conditions are unsatisfied, [$generate a validation error$] and stop.
                         <div class=validusage>
                             - |querySet| is [$valid to use with$] |this|.
                             - |querySet|.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/"timestamp"}}.
@@ -6853,7 +6848,7 @@ Issue(gpuweb/gpuweb#652): Define the copies with {{GPUTextureFormat/"depth24plus
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
                 1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, generate a {{GPUValidationError}} and stop.
+                1. If any of the following conditions are unsatisfied, [$generate a validation error$] and stop.
                     <div class=validusage>
                         - |querySet| is [$valid to use with$] |this|.
                         - |destination| is [$valid to use with$] |this|.
@@ -6902,8 +6897,7 @@ command encoder can no longer be used.
                         </div>
                     1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/ended=]".
                     1. If |validationFailed|, then:
-                        1. Generate a {{GPUValidationError}} in the current scope with appropriate
-                            error message.
+                        1. [$Generate a validation error$].
                         1. Return a new [=invalid=] {{GPUCommandBuffer}}.
                     1. Set |commandBuffer|.{{GPUCommandBuffer/[[command_list]]}} to
                         |this|.{{GPUCommandsMixin/[[commands]]}}.
@@ -7446,7 +7440,7 @@ called the compute pass encoder can no longer be used.
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
                 1. If any of the following requirements are unmet,
-                    generate a {{GPUValidationError}} and stop.
+                    [$generate a validation error$] and stop.
                     <div class=validusage>
                         - |this|.{{GPUCommandsMixin/[[state]]}} must be "[=encoder state/open=]",
                     </div>
@@ -8335,8 +8329,8 @@ attachments used by this encoder.
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
-                1. If any of the following conditions are unsatisfied, generate a validation
-                    error and stop.
+                1. If any of the following conditions are unsatisfied, [$generate a validation error$]
+                    and stop.
                     <div class=validusage>
                         - |x| is greater than or equal to `0`.
                         - |y| is greater than or equal to `0`.
@@ -8377,8 +8371,8 @@ attachments used by this encoder.
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
-                1. If any of the following conditions are unsatisfied, generate a validation
-                    error and stop.
+                1. If any of the following conditions are unsatisfied, [$generate a validation error$]
+                    and stop.
                     <div class=validusage>
                         - |x|+|width| is less than or equal to
                             |this|.{{GPURenderPassEncoder/[[attachment_size]]}}.width.
@@ -8436,7 +8430,7 @@ attachments used by this encoder.
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. If any of the following conditions are unsatisfied, generate a validation error and stop.
+                1. If any of the following conditions are unsatisfied, [$generate a validation error$] and stop.
                     <div class=validusage>
                         - |this|.{{GPURenderPassEncoder/[[occlusion_query_set]]}} is not `null`.
                         - |queryIndex| &lt; |this|.{{GPURenderPassEncoder/[[occlusion_query_set]]}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}}.
@@ -8458,7 +8452,7 @@ attachments used by this encoder.
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. If any of the following conditions are unsatisfied, generate a validation error and stop.
+                1. If any of the following conditions are unsatisfied, [$generate a validation error$] and stop.
                     <div class=validusage>
                         - |this|.{{GPURenderPassEncoder/[[occlusion_query_active]]}} is `true`.
                     </div>
@@ -8494,8 +8488,8 @@ attachments used by this encoder.
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
-                1. If any of the following conditions are unsatisfied, generate a validation
-                    error and stop.
+                1. If any of the following conditions are unsatisfied, [$generate a validation error$]
+                    and stop.
                     <div class=validusage>
                         - For each |bundle| in |bundles|:
                             - |bundle| must be [$valid to use with$] |this|.
@@ -8527,7 +8521,7 @@ called the render pass encoder can no longer be used.
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
                 1. If any of the following requirements are unmet,
-                    generate a {{GPUValidationError}} and stop.
+                    [$generate a validation error$] and stop.
                     <div class=validusage>
                         - |this|.{{GPUCommandsMixin/[[state]]}} must be "[=encoder state/open=]",
                     </div>
@@ -8620,8 +8614,7 @@ GPURenderBundleEncoder includes GPURenderEncoderBase;
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
-                1. If any of the following conditions are unsatisfied, generate a validation
-                    error and stop.
+                1. If any of the following conditions are unsatisfied, [$generate a validation error$] and stop.
                     <div class=validusage>
                         - |descriptor|.{{GPURenderPassLayout/colorFormats}}.length must be less than or equal to 8.
                         - If |descriptor|.{{GPURenderPassLayout/colorFormats}} only contains `null` members:
@@ -8685,8 +8678,7 @@ dictionary GPURenderBundleEncoderDescriptor : GPURenderPassLayout {
                         </div>
                     1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/ended=]".
                     1. If |validationFailed|, then:
-                        1. Generate a {{GPUValidationError}} in the current scope with appropriate
-                            error message.
+                        1. [$Generate a validation error$].
                         1. Return a new [=invalid=] {{GPURenderBundle}}.
                     1. Set |renderBundle|.{{GPURenderBundle/[[command_list]]}} to
                         |this|.{{GPUCommandsMixin/[[commands]]}}.
@@ -8770,7 +8762,7 @@ GPUQueue includes GPUObjectBase;
             1. Issue the following steps on the [=Queue timeline=] of |this|:
                 <div class=queue-timeline>
                     1. If any of the following conditions are unsatisfied,
-                        generate a validation error and stop.
+                        [$generate a validation error$] and stop.
                         <div class=validusage>
                             - |buffer| is [$valid to use with$] |this|.
                             - |buffer|.{{GPUBuffer/[[state]]}} is [=buffer state/unmapped=].
@@ -8817,7 +8809,7 @@ GPUQueue includes GPUObjectBase;
             1. Issue the following steps on the [=Queue timeline=] of |this|:
                 <div class=queue-timeline>
                     1. If any of the following conditions are unsatisfied,
-                        generate a validation error and stop.
+                        [$generate a validation error$] and stop.
                         <div class=validusage>
                             - [$validating GPUImageCopyTexture$](|destination|, |size|) returns `true`.
                             - |textureDesc|.{{GPUTextureDescriptor/usage}} includes {{GPUTextureUsage/COPY_DST}}.
@@ -8887,7 +8879,7 @@ GPUQueue includes GPUObjectBase;
             1. Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
                     1. Let |textureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
-                    1. If any of the following requirements are unmet, generate a validation error and stop.
+                    1. If any of the following requirements are unmet, [$generate a validation error$] and stop.
                         <div class=validusage>
                             - |destination|.{{GPUImageCopyTexture/texture}} must be [$valid to use with$] |this|.
                             - [$validating GPUImageCopyTexture$](destination, copySize) must return `true`.
@@ -8932,7 +8924,7 @@ GPUQueue includes GPUObjectBase;
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
-                1. If any of the following conditions are unsatisfied, generate a validation error and stop.
+                1. If any of the following conditions are unsatisfied, [$generate a validation error$] and stop.
                     <div class=validusage>
                         - Every {{GPUBuffer}} referenced in any element of |commandBuffers| is in the
                             `"unmapped"` [=buffer state=].
@@ -9230,8 +9222,7 @@ interface GPUCanvasContext {
                         </div>
 
                         Then:
-                            1. Generate a {{GPUValidationError}} in the current scope with appropriate
-                                error message.
+                            1. [$Generate a validation error$].
                             1. Return.
                 </div>
             1. Set |this|.{{GPUCanvasContext/[[validConfiguration]]}} to `true`.
@@ -9362,7 +9353,7 @@ interface GPUCanvasContext {
 
         1. Let |device| be |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/device}}.
         1. If |context|.{{GPUCanvasContext/[[validConfiguration]]}} is `false`:
-            1. Generate a {{GPUValidationError}} in the current scope of |device| with an appropriate error message.
+            1. [$Generate a validation error$].
             1. Return a new [=invalid=] {{GPUTexture}}.
         1. Let |textureDescriptor| be a new {{GPUTextureDescriptor}}.
         1. Set |textureDescriptor|.{{GPUTextureDescriptor/size}} to |context|.{{GPUCanvasContext/[[size]]}}.
@@ -9546,6 +9537,21 @@ partial interface GPUDevice {
 
 ## Error Scopes ## {#error-scopes}
 
+A <dfn dfn>GPU error scope</dfn> captures {{GPUError}}s that were generated while the
+[=GPU error scope=] was current. Error scopes are used to isolate errors that occur within a set
+of WebGPU calls, typically for debugging purposes or to make an operation more fault tolerant.
+
+[=GPU error scope=] has the following internal slots:
+<dl dfn-type=attribute dfn-for="GPU error scope">
+    : <dfn>\[[error]]</dfn> of type {{GPUError}}?, initially `null`.
+    ::
+        The first {{GPUError}}, if any, observed while the [=GPU error scope=] was current.
+
+    : <dfn>\[[filter]]</dfn> of type {{GPUErrorFilter}}.
+    ::
+        Determines what type of {{GPUError}} this [=GPU error scope=] observes.
+</dl>
+
 <script type=idl>
 enum GPUErrorFilter {
     "out-of-memory",
@@ -9575,19 +9581,101 @@ partial interface GPUDevice {
 };
 </script>
 
+{{GPUDevice}} has the following internal slots:
+
+<dl dfn-type=attribute dfn-for="GPUDevice">
+    : <dfn>\[[errorScopeStack]]</dfn> of type [=stack=]&lt;[=GPU error scope=]&gt;.
+    ::
+        A [=stack=] of [=GPU error scopes=] that have been pushed to the {{GPUDevice}}.
+</dl>
+
+<div algorithm>
+    To <dfn abstract-op lt='to the current error scope'>push an error to the current error scope</dfn>
+    with {{GPUError}} |error| for a {{GPUDevice}} |device|, issue the following steps to the
+    [=Device timeline=]:
+
+        <div class=device-timeline>:
+            1. If |error| is and instance of:
+                <dl class="switch">
+                    : {{GPUValidationError}}
+                    :: Let |type| be "validation".
+                    : {{GPUOutOfMemoryError}}
+                    :: Let |type| be "out-of-memory".
+                </dl>
+            1. Let |scope| be the last [=list/item=] of |device|.{{GPUDevice/[[errorScopeStack]]}}.
+            1. While |scope| is not `undefined`:
+                1. If |scope|.{{GPU error scope/[[filter]]}} is |type|:
+                    1. If |scope|.{{GPU error scope/[[error]]}} is not `null`, set
+                        |scope|.{{GPU error scope/[[error]]}} to |error|.
+                    1. Stop.
+                1. Set |scope| to the previous [=list/item=] of
+                    |device|.{{GPUDevice/[[errorScopeStack]]}}.
+
+            1. [=Queue a task=] to fire a {{GPUUncapturedErrorEvent}} named "uncapturederror" on
+                |device| with an {{GPUUncapturedErrorEvent/error}} of |error|.
+        </div>
+</div>
+
+Note: The user agent may choose to throttle or limit the number of {{GPUUncapturedErrorEvent}}s that
+a {{GPUDevice}} can raise to prevent an excessive amount of error handling or logging from impacting
+performance.
+
+<div algorithm>
+    To <dfn abstract-op lt="Generate a validation error|generate a validation error">generate a
+    validation error</dfn> for {{GPUDevice}} |device|, run the following steps:
+
+    1. Let |error| be a new {{GPUValidationError}} with an appropriate error message.
+    1. Push |error| [$to the current error scope$] of |device|.
+</div>
+
 <dl dfn-type=method dfn-for=GPUDevice>
     : <dfn>pushErrorScope(filter)</dfn>
     ::
-        Issue: Define pushErrorScope.
+        Pushes a new [=GPU error scope=] onto the {{GPUDevice/[[errorScopeStack]]}} for |this|.
+
+        <div algorithm=GPUDevice.pushErrorScope>
+            **Called on:** {{GPUDevice}} |this|.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPUDevice/pushErrorScope(filter)">
+                |filter|: Which class of errors this error scope observes.
+            </pre>
+
+            1. Issue the following steps to the [=Device timeline=]:
+                <div class=device-timeline>
+                    1. Let |scope| be a new [=GPU error scope=].
+                    1. Set |scope|.{{GPU error scope/[[filter]]}} to |filter|.
+                    1. [=stack/Push=] |scope| onto |this|.{{GPUDevice/[[errorScopeStack]]}}.
+                </div>
+        </div>
 
     : <dfn>popErrorScope()</dfn>
     ::
-        Issue: Define popErrorScope.
+        Pops a [=GPU error scope=] off the {{GPUDevice/[[errorScopeStack]]}} for |this|
+        and resolves to a {{GPUError}} if one was observed by the error scope.
 
-        Rejects with {{OperationError}} if:
+        <div algorithm=GPUDevice.popErrorScope>
+            **Called on:** {{GPUDevice}} |this|.
 
-        - The device is lost.
-        - There are no error scopes on the stack.
+            **Returns:** {{Promise}}&lt;{{GPUError}}?&gt;
+
+            1. Let |promise| be [=a new promise=].
+            1. Issue the following steps to the [=Device timeline=]:
+                <div class=device-timeline>
+                    1. If any of the following requirements are unmet,
+                        [=reject=] |promise| with an {{OperationError}} and stop.
+
+                        <div class=validusage>
+                            - |this| is not [=lose the device|lost=].
+                            - |this|.{{GPUDevice/[[errorScopeStack]]}}.[=list/size=] &gt; 0.
+                        </div>
+
+                    1. Let |scope| be the result of [=stack/pop|popping=] an [=list/item=] off of
+                        |this|.{{GPUDevice/[[errorScopeStack]]}}.
+                    1. [=Resolve=] |promise| with |scope|.{{GPU error scope/[[error]]}}.
+                </div>
+            1. Return |promise|.
+        </div>
 </dl>
 
 <div class="example">

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9611,7 +9611,7 @@ partial interface GPUDevice {
             1. Set |scope| to the previous [=list/item=] of
                 |device|.{{GPUDevice/[[errorScopeStack]]}}.
 
-        1. [=Queue a task=] to fire an {{GPUUncapturedErrorEvent}} named
+        1. If the user agent chooses, [=queue a task=] to fire an {{GPUUncapturedErrorEvent}} named
             "{{GPUDevice/uncapturederror}}" on |device| with an {{GPUUncapturedErrorEvent/error}} of
             |error|.
     </div>


### PR DESCRIPTION
Resolves the outstanding issues to define `push/popErrorScope()` and formalizes the definitions of error scopes and how errors get pushed onto them.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/2506.html" title="Last updated on Feb 11, 2022, 11:08 PM UTC (6edd8f9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2506/a4d154e...6edd8f9.html" title="Last updated on Feb 11, 2022, 11:08 PM UTC (6edd8f9)">Diff</a>