### PR TITLE
Fix a typo in packing built-in functions list in WGSL spec

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -10165,7 +10165,7 @@ reduce a shader's memory bandwidth demand.
   <tr algorithm="packing 2x16float">
     <td class="nowrap">`pack2x16float`(|e|: vec2&lt;f32&gt;) -> u32
     <td>Converts two floating point values to half-precision floating point numbers, and then combines
-        them into one one `u32` value.<br>
+        them into one `u32` value.<br>
         Component |e|[|i|] of the input is converted to a [[!IEEE-754|IEEE-754]] binary16 value, which is then
         placed in bits
         16 &times; |i| through


### PR DESCRIPTION
Remove a duplicated "one" in packing built-in functions list.