### PR TITLE
Switch to `@` for Attributes

### DIFF
--- a/samples/hello-cube.html
+++ b/samples/hello-cube.html
@@ -16,26 +16,26 @@ const colorLocation         = 0;
 
 const shader = `
 struct FragmentData {
-    [[builtin(position)]] position: vec4<f32>;
-    [[location(${colorLocation})]] color: vec4<f32>;
+    @builtin(position) position: vec4<f32>;
+    @location(${colorLocation}) color: vec4<f32>;
 };
 
 struct Uniforms {
     modelViewProjectionMatrix: mat4x4<f32>;
 };
 
-[[group(${bindGroupIndex}), binding(${transformBindingNum})]] var<uniform> uniforms: Uniforms;
+@group(${bindGroupIndex}) @binding(${transformBindingNum}) var<uniform> uniforms: Uniforms;
 
 let pos = array<vec2<f32>, 3>(
     vec2<f32>(0.0, 0.5),
     vec2<f32>(-0.5, -0.5),
     vec2<f32>(0.5, -0.5));
 
-[[stage(vertex)]]
+@stage(vertex)
 fn vertex_main(
-    [[builtin(vertex_index)]] VertexIndex : u32,
-    [[location(${positionAttributeNum})]] position: vec4<f32>,
-    [[location(${colorAttributeNum})]] color: vec4<f32>
+    @builtin(vertex_index) VertexIndex : u32,
+    @location(${positionAttributeNum}) position: vec4<f32>,
+    @location(${colorAttributeNum}) color: vec4<f32>
 ) -> FragmentData {
     var outData: FragmentData;
     outData.position = uniforms.modelViewProjectionMatrix * position;
@@ -43,8 +43,8 @@ fn vertex_main(
     return outData;
 }
 
-[[stage(fragment)]]
-fn fragment_main(data: FragmentData) -> [[location(0)]] vec4<f32> {
+@stage(fragment)
+fn fragment_main(data: FragmentData) -> @location(0) vec4<f32> {
     return data.color;
 }
 `;
@@ -127,7 +127,7 @@ async function init() {
     // Bind Group Layout + Pipeline Layout
 
     const transformBufferBindGroupLayoutEntry = {
-        binding: transformBindingNum, // [[group(0), binding(0)]]
+        binding: transformBindingNum, // @group(0) @binding(0)
         visibility: GPUShaderStage.VERTEX,
         buffer: { type: "uniform" },
     };
@@ -162,12 +162,12 @@ async function init() {
     const positionAttributeState = {
         format: "float32x4",
         offset: 0,
-        shaderLocation: positionAttributeNum,  // [[attribute(0)]]
+        shaderLocation: positionAttributeNum,  // @attribute(0)
     };
     const colorAttributeState = {
         format: "float32x4",
         offset: colorOffset,
-        shaderLocation: colorAttributeNum,  // [[attribute(1)]]
+        shaderLocation: colorAttributeNum,  // @attribute(1)
     }
     const vertexBufferState = {
         arrayStride: vertexSize,

--- a/samples/workload-simulator.html
+++ b/samples/workload-simulator.html
@@ -649,28 +649,28 @@ async function render(fromRaf, fromPostMessage) {
               vec2<f32>(1., -1.),
               vec2<f32>(1., 1.));
 
-          [[block]] struct Uniforms {
+          @block struct Uniforms {
             xy: vec2<f32>;
           };
-          [[binding(0), group(0)]] var<uniform> uniforms: Uniforms;
-          [[binding(1), group(0)]] var sampler1: sampler;
-          [[binding(2), group(0)]] var texture1: texture_2d<f32>;
+          @binding(0) @group(0) var<uniform> uniforms: Uniforms;
+          @binding(1) @group(0) var sampler1: sampler;
+          @binding(2) @group(0) var texture1: texture_2d<f32>;
 
           struct Output {
-            [[builtin(position)]] Position : vec4<f32>;
-            [[location(0)]] uv : vec2<f32>;
+            @builtin(position) Position : vec4<f32>;
+            @location(0) uv : vec2<f32>;
           };
           
-          [[stage(vertex)]]
-          fn vs([[builtin(vertex_index)]] VertexIndex : u32) -> Output {
+          @stage(vertex)
+          fn vs(@builtin(vertex_index) VertexIndex : u32) -> Output {
             var output : Output;
             output.Position = vec4<f32>(pos[VertexIndex] / vec2<f32>(2.,2.) + uniforms.xy, 0.0, 1.0);
             output.uv = pos[VertexIndex] / vec2<f32>(2., -2.) + vec2<f32>(.5, .5);
             return output;
           }
 
-          [[stage(fragment)]]
-          fn fs([[location(0)]] uv: vec2<f32>) -> [[location(0)]] vec4<f32> {
+          @stage(fragment)
+          fn fs(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
             return textureSample(texture1, sampler1, uv);
           }
           `, });

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4445,13 +4445,13 @@ same module, they should avoid passing that information to
             var&lt;private&gt; pos : array&lt;vec2&lt;f32&gt;, 3&gt; = array&lt;vec2&lt;f32&gt;, 3&gt;(
                 vec2(-1.0, -1.0), vec2(-1.0, 3.0), vec2(3.0, -1.0));
 
-            [[stage(vertex)]]
-            fn vertexMain([[builtin(vertex_index)]] vertexIndex : u32) -&gt; [[builtin(position)]] vec4&lt;f32&gt; {
+            @stage(vertex)
+            fn vertexMain(@builtin(vertex_index) vertexIndex : u32) -&gt; @builtin(position) vec4&lt;f32&gt; {
                 return vec4(pos[input.vertexIndex], 1.0, 1.0);
             }
 
-            [[stage(fragment)]]
-            fn fragmentMain() -&gt; [[location(0)]] vec4&lt;f32&gt; {
+            @stage(fragment)
+            fn fragmentMain() -&gt; @location(0) vec4&lt;f32&gt; {
                 return vec4(1.0, 0.0, 0.0, 1.0);
             }
         \`;
@@ -4831,14 +4831,14 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
             Pipeline-overridable constants defined in WGSL:
 
             <pre highlight=rust>
-                [[override(0)]]    let has_point_light: bool = true; // Algorithmic control.
-                [[override(1200)]] let specular_param: f32 = 2.3;    // Numeric control.
-                [[override(1300)]] let gain: f32;                    // Must be overridden.
-                [[override]]       let width: f32 = 0.0;             // Specifed at the API level
-                                                                     //   using the name "width".
-                [[override]]       let depth: f32;                   // Specifed at the API level
-                                                                     //   using the name "depth".
-                                                                     //   Must be overridden.
+                @override(0)    let has_point_light: bool = true; // Algorithmic control.
+                @override(1200) let specular_param: f32 = 2.3;    // Numeric control.
+                @override(1300) let gain: f32;                    // Must be overridden.
+                @override       let width: f32 = 0.0;             // Specifed at the API level
+                                                                  //   using the name "width".
+                @override       let depth: f32;                   // Specifed at the API level
+                                                                  //   using the name "depth".
+                                                                  //   Must be overridden.
             </pre>
 
             Corresponding JavaScript code, providing only the overrides which are required

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -143,8 +143,8 @@ that run on the GPU.
 
 <div class='example wgsl global-scope'>
   <xmp highlight='rust'>
-    [[stage(fragment)]]
-    fn main() -> [[location(0)]] vec4<f32> {
+    @stage(fragment)
+    fn main() -> @location(0) vec4<f32> {
         return vec4<f32>(0.4, 0.4, 0.8, 1.0);
     }
   </xmp>
@@ -547,16 +547,11 @@ ignored for the purposes of type and semantic checking.
 An attribute must not be specified more than once per object or type.
 
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>attribute_list</dfn> :
-
-    | [=syntax/attr_left=] ( [=syntax/attribute=] [=syntax/comma=] ) * [=syntax/attribute=] [=syntax/attr_right=]
-</div>
-<div class='syntax' noexport='true'>
   <dfn for=syntax>attribute</dfn> :
 
-    | [=syntax/ident=] [=syntax/paren_left=] ( [=syntax/literal_or_ident=] [=syntax/comma=] ) * [=syntax/literal_or_ident=] [=syntax/paren_right=]
+    | [=syntax/attr=] [=syntax/ident=] [=syntax/paren_left=] ( [=syntax/literal_or_ident=] [=syntax/comma=] ) * [=syntax/literal_or_ident=] [=syntax/paren_right=]
 
-    | [=syntax/ident=]
+    | [=syntax/attr=] [=syntax/ident=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>literal_or_ident</dfn> :
@@ -1111,7 +1106,7 @@ workgroups.
       b: atomic<u32>;
     };
 
-    [[group(0), binding(0)]]
+    @group(0) @binding(0)
     var<storage,read_write> x: S;
 
     // Maps to the following SPIR-V:
@@ -1225,7 +1220,7 @@ of a variable in [=storage classes/workgroup=] storage.
 
 <div class='example wgsl global-scope' heading="Workgroup variables sized by overridable constants">
   <xmp>
-    [[override]] let blockSize = 16;
+    @override let blockSize = 16;
 
     var<workgroup> odds: array<i32,blockSize>;
     var<workgroup> evens: array<i32,blockSize>;
@@ -1244,7 +1239,7 @@ of a variable in [=storage classes/workgroup=] storage.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>array_type_decl</dfn> :
 
-    | [=syntax/attribute_list=] * [=syntax/array=] [=syntax/less_than=] [=syntax/type_decl=] ( [=syntax/comma=] [=syntax/element_count_expression=] ) ? [=syntax/greater_than=]
+    | [=syntax/attribute=] * [=syntax/array=] [=syntax/less_than=] [=syntax/type_decl=] ( [=syntax/comma=] [=syntax/element_count_expression=] ) ? [=syntax/greater_than=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>element_count_expression</dfn> :
@@ -1311,7 +1306,7 @@ Some consequences of the restrictions structure member and array element types a
 <div class='syntax' noexport='true'>
   <dfn for=syntax>struct_member</dfn> :
 
-    | [=syntax/attribute_list=] * [=syntax/variable_ident_decl=] [=syntax/semicolon=]
+    | [=syntax/attribute=] * [=syntax/variable_ident_decl=] [=syntax/semicolon=]
 </div>
 
 [SHORTNAME] defines the following attributes that can be applied to structure members:
@@ -1348,13 +1343,13 @@ to define a [=uniform buffer=] or a [=storage buffer=]. See [[#memory-layouts]].
   <xmp>
     // TODO: runtime-sized array syntax may have changed
     // Runtime Array
-    type RTArr = [[stride(16)]] array<vec4<f32>>;
+    type RTArr = @stride(16) array<vec4<f32>>;
     struct S {
       a: f32;
       b: f32;
       data: RTArr;
     };
-    [[group(0),binding(0)]] var<storage> buffer: S;
+    @group(0) @binding(0) var<storage> buffer: S;
   </xmp>
 </div>
 
@@ -1788,10 +1783,10 @@ following table:
       <td>[=AlignOf=](|E|)
       <td>N<sub>runtime</sub> * [=roundUp=]([=AlignOf=](|E|), [=SizeOf=](|E|))<br><br>
           Where N<sub>runtime</sub> is the runtime-determined number of elements of |T|
-  <tr><td>[[[=attribute/stride=](|Q|)]]<br> array<|E|, |N|>
+  <tr><td>@[=attribute/stride=](|Q|)<br> array<|E|, |N|>
       <td>[=AlignOf=](|E|)
       <td>|N| * |Q|
-  <tr><td>[[[=attribute/stride=](|Q|)]]<br> array<|E|>
+  <tr><td>@[=attribute/stride=](|Q|)<br> array<|E|>
       <td>[=AlignOf=](|E|)
       <td>N<sub>runtime</sub> * |Q|
 </table>
@@ -1869,7 +1864,7 @@ rounded to the next multiple of the structure's alignment:
         // -- implicit struct size padding --      // offset(156)           size(4)
     };
 
-    [[group(0), binding(0)]]
+    @group(0) @binding(0)
     var<storage,read_write> storage_buffer: B;
   </xmp>
 </div>
@@ -1880,7 +1875,7 @@ rounded to the next multiple of the structure's alignment:
         u: f32;                                    // offset(0)   align(4)  size(4)
         v: f32;                                    // offset(4)   align(4)  size(4)
         w: vec2<f32>;                              // offset(8)   align(8)  size(8)
-        [[size(16)]] x: f32;                       // offset(16)  align(4)  size(16)
+        @size(16) x: f32;                       // offset(16)  align(4)  size(16)
     };
 
     struct B {                                     //             align(16) size(208)
@@ -1890,15 +1885,15 @@ rounded to the next multiple of the structure's alignment:
         c: f32;                                    // offset(28)  align(4)  size(4)
         d: f32;                                    // offset(32)  align(4)  size(4)
         // -- implicit member alignment padding -- // offset(36)            size(12)
-        [[align(16)]] e: A;                        // offset(48)  align(16) size(32)
+        @align(16) e: A;                        // offset(48)  align(16) size(32)
         f: vec3<f32>;                              // offset(80)  align(16) size(12)
         // -- implicit member alignment padding -- // offset(92)            size(4)
-        g: [[stride(32)]] array<A, 3>;             // offset(96)  align(8)  size(96)
+        g: @stride(32) array<A, 3>;             // offset(96)  align(8)  size(96)
         h: i32;                                    // offset(192) align(4)  size(4)
         // -- implicit struct size padding --      // offset(196)           size(12)
     };
 
-    [[group(0), binding(0)]]
+    @group(0) @binding(0)
     var<uniform> uniform_buffer: B;
   </xmp>
 </div>
@@ -1928,7 +1923,7 @@ In all cases, the array element stride must be a multiple of the element alignme
     var implicit_stride: array<vec3<f32>, 8>;
 
     // Array with an explicit element stride of 32 bytes
-    var explicit_stride: [[stride(32)]] array<vec3<f32>, 8>;
+    var explicit_stride: @stride(32) array<vec3<f32>, 8>;
   </xmp>
 </div>
 
@@ -1948,15 +1943,15 @@ The array alignment is equal to the element alignment:
   [=AlignOf=](array<|T|[, N]>) = [=AlignOf=](|T|)
 </p>
 
-For example, the layout for a `[[stride(S)]] array<T, 3>` type is equivalent to
+For example, the layout for a `@stride(S) array<T, 3>` type is equivalent to
 the following structure:
 
 <div class='example wgsl global-scope' heading='Structure equivalent of a three element array'>
   <xmp highlight='rust'>
     struct Array {
-      [[size(S)]] element_0: T;
-      [[size(S)]] element_1: T;
-      [[size(S)]] element_2: T;
+      @size(S) element_0: T;
+      @size(S) element_1: T;
+      @size(S) element_2: T;
     };
   </xmp>
 </div>
@@ -2110,10 +2105,10 @@ The [=storage classes/uniform=] storage class also requires that:
     };
     struct Valid {
       a: S;
-      [[align(16)]] b: f32; // valid: offset between a and b is 16 bytes
+      @align(16) b: f32; // valid: offset between a and b is 16 bytes
     };
-    [[group(0), binding(0)]] var<uniform> invalid: Invalid;
-    [[group(0), binding(1)]] var<uniform> valid: Valid;
+    @group(0) @binding(0) var<uniform> invalid: Invalid;
+    @group(0) @binding(1) var<uniform> valid: Valid;
   </xmp>
 </div>
 
@@ -2262,7 +2257,7 @@ Defining references in this way enables simple idiomatic use of variables:
 
 <div class='example wgsl' heading='Reference types enable simple use of variables'>
   <xmp highlight='rust'>
-    [[stage(compute)]]
+    @stage(compute)
     fn main() {
       // 'i' has reference type ref<function,i32,read_write>
       // The memory locations for 'i' store the i32 value 0.
@@ -2327,9 +2322,9 @@ Note: The following examples use [SHORTNAME] features explained later in this sp
       timestep: f32;
       particles: array<Particle,100>;
     };
-    [[group(0), binding(0)]] var<storage,read_write> system: System;
+    @group(0) @binding(0) var<storage,read_write> system: System;
 
-    [[stage(compute)]]
+    @stage(compute)
     fn main() {
       // Form a pointer to a specific Particle in storage memory.
       let active_particle: ptr<storage,Particle> =
@@ -2361,7 +2356,7 @@ Note: The following examples use [SHORTNAME] features explained later in this sp
       *x = *x + 1;
     }
 
-    [[stage(compute)]]
+    @stage(compute)
     fn main() {
       var i: i32 = 0;
 
@@ -3067,7 +3062,7 @@ The declaration must appear at [=module scope=], and its [=scope=] is the entire
   <xmp>
     type Arr = array<i32, 5>;
 
-    type RTArr = [[stride(16)]] array<vec4<f32>>;
+    type RTArr = @stride(16) array<vec4<f32>>;
 
     type single = f32;     // Declare an alias for f32
     let pi_approx: single = 3.1415;
@@ -3152,7 +3147,7 @@ When the type declaration is an [=identifier=], then the expression must be in s
        %uint_4 = OpConstant %uint 4
             %9 = OpTypeArray %float %uint_4
 
-    [[stride(32)]] array<f32, 4>
+    @stride(32) array<f32, 4>
                  OpDecorate %9 ArrayStride 32
        %uint_4 = OpConstant %uint 4
             %9 = OpTypeArray %float %uint_4
@@ -3169,16 +3164,16 @@ When the type declaration is an [=identifier=], then the expression must be in s
 <div class='example wgsl global-scope' heading='Access modes for buffers'>
   <xmp>
     // Storage buffers
-    [[group(0), binding(0)]]
+    @group(0) @binding(0)
     var<storage,read> buf1: Buffer;       // Can read, cannot write.
-    [[group(0), binding(0)]]
+    @group(0) @binding(0)
     var<storage> buf2: Buffer;            // Can read, cannot write.
-    [[group(0), binding(1)]]
+    @group(0) @binding(1)
     var<storage,read_write> buf3: Buffer; // Can both read and write.
 
     // Uniform buffer. Always read-only, and has more restrictive layout rules.
     struct ParamsTable {};
-    [[group(0), binding(2)]]
+    @group(0) @binding(2)
     var<uniform> params: ParamsTable;     // Can read, cannot write.
   </xmp>
 </div>
@@ -3367,7 +3362,7 @@ Such variables are declared with [=attribute/group=] and [=attribute/binding=] d
       specular: f32;
       count: i32;
     };
-    [[group(0), binding(2)]]
+    @group(0) @binding(2)
     var<uniform> param: Params;    // A uniform buffer
 
     struct PositionsBuffer {
@@ -3375,11 +3370,11 @@ Such variables are declared with [=attribute/group=] and [=attribute/binding=] d
       pos: array<vec2<f32>>;
     };
     // A storage buffer, for reading and writing
-    [[group(0), binding(0)]]
+    @group(0) @binding(0)
     var<storage,read_write> pbuf: PositionsBuffer;
 
     // Textures and samplers are always in "handle" storage.
-    [[group(0), binding(1)]]
+    @group(0) @binding(1)
     var filter_params: sampler;
   </xmp>
 </div>
@@ -3387,12 +3382,12 @@ Such variables are declared with [=attribute/group=] and [=attribute/binding=] d
 <div class='syntax' noexport='true'>
   <dfn for=syntax>global_variable_decl</dfn> :
 
-    | [=syntax/attribute_list=] * [=syntax/variable_decl=] ( [=syntax/equal=] ( [=syntax/const_expression=] | [=syntax/ident=] ) ) ?
+    | [=syntax/attribute=] * [=syntax/variable_decl=] ( [=syntax/equal=] ( [=syntax/const_expression=] | [=syntax/ident=] ) ) ?
 </div>
 
 <div class='example' heading="Variable Decorations">
   <xmp>
-    [[group(4), binding(3)]]
+    @group(4) @binding(3)
        OpDecorate %variable DescriptorSet 4
        OpDecorate %variable Binding 3
   </xmp>
@@ -3441,14 +3436,14 @@ the constant is <dfn noexport>pipeline-overridable</dfn>. In this case:
 
 <div class='example wgsl global-scope' heading='Module constants, pipeline-overrideable'>
   <xmp>
-    [[override(0)]]    let has_point_light: bool = true;  // Algorithmic control
-    [[override(1200)]] let specular_param: f32 = 2.3;     // Numeric control
-    [[override(1300)]] let gain: f32;                     // Must be overridden
-    [[override]]       let width: f32 = 0.0;              // Specified at the API level using
-                                                          // the name "width".
-    [[override]]       let depth: f32;                    // Specified at the API level using
-                                                          // the name "depth".
-                                                          // Must be overridden.
+    @override(0)    let has_point_light: bool = true;  // Algorithmic control
+    @override(1200) let specular_param: f32 = 2.3;     // Numeric control
+    @override(1300) let gain: f32;                     // Must be overridden
+    @override       let width: f32 = 0.0;              // Specified at the API level using
+                                                       // the name "width".
+    @override       let depth: f32;                    // Specified at the API level using
+                                                       // the name "depth".
+                                                       // Must be overridden.
   </xmp>
 </div>
 
@@ -3461,7 +3456,7 @@ is the one from the constant's declaration or from a pipeline override.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>global_constant_decl</dfn> :
 
-    | [=syntax/attribute_list=] * [=syntax/let=] ( [=syntax/ident=] | [=syntax/variable_ident_decl=] ) [=syntax/global_const_initializer=] ?
+    | [=syntax/attribute=] * [=syntax/let=] ( [=syntax/ident=] | [=syntax/variable_ident_decl=] ) [=syntax/global_const_initializer=] ?
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>global_const_initializer</dfn> :
@@ -5340,12 +5335,12 @@ A phony-assignment is useful for:
         counter: atomic<u32>;
         data: array<vec4<f32>>;
     };
-    [[group(0),binding(0)]] var<storage> buf: BufferContents;
-    [[group(0),binding(1)]] var t: texture_2d<f32>;
-    [[group(0),binding(2)]] var s: sampler;
+    @group(0) @binding(0) var<storage> buf: BufferContents;
+    @group(0) @binding(1) var t: texture_2d<f32>;
+    @group(0) @binding(2) var s: sampler;
 
-    [[stage(fragment)]]
-    fn shade_it() -> [[location(0)]] vec4<f32> {
+    @stage(fragment)
+    fn shade_it() -> @location(0) vec4<f32> {
       // Declare that buf, t, and s are part of the shader interface, without
       // using them for anything.
       _ = &buf;
@@ -6004,9 +5999,9 @@ Issue: [[#uniform-control-flow]] needs to state whether all invocations being di
     will_emit_color = true;
   }
 
-  [[stage(fragment)]]
-  fn main([[builtin(position)]] coord_in: vec4<f32>)
-    -> [[location(0)]] vec4<f32>
+  @stage(fragment)
+  fn main(@builtin(position) coord_in: vec4<f32>)
+    -> @location(0) vec4<f32>
   {
     discard_if_shallow(coord_in);
 
@@ -6530,12 +6525,12 @@ The return type, if specified, must be [=constructible=].
 <div class='syntax' noexport='true'>
   <dfn for=syntax>function_decl</dfn> :
 
-    | [=syntax/attribute_list=] * [=syntax/function_header=] [=syntax/compound_statement=]
+    | [=syntax/attribute=] * [=syntax/function_header=] [=syntax/compound_statement=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>function_header</dfn> :
 
-    | [=syntax/fn=] [=syntax/ident=] [=syntax/paren_left=] [=syntax/param_list=] ? [=syntax/paren_right=] ( [=syntax/arrow=] [=syntax/attribute_list=] * [=syntax/type_decl=] ) ?
+    | [=syntax/fn=] [=syntax/ident=] [=syntax/paren_left=] [=syntax/param_list=] ? [=syntax/paren_right=] ( [=syntax/arrow=] [=syntax/attribute=] * [=syntax/type_decl=] ) ?
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>param_list</dfn> :
@@ -6545,7 +6540,7 @@ The return type, if specified, must be [=constructible=].
 <div class='syntax' noexport='true'>
   <dfn for=syntax>param</dfn> :
 
-    | [=syntax/attribute_list=] * [=syntax/variable_ident_decl=]
+    | [=syntax/attribute=] * [=syntax/variable_ident_decl=]
 </div>
 
 [SHORTNAME] defines the following attributes that can be applied to function declarations:
@@ -6571,7 +6566,7 @@ parameters and return types:
     // It has no specified return type.
     // It invokes the ordinary_two function, and captures
     // the resulting value in the named value 'two'.
-    [[stage(compute)]] fn main() {
+    @stage(compute) fn main() {
        let six: i32 = add_two(4, 5.0);
     }
   </xmp>
@@ -6737,8 +6732,8 @@ Note: [=Compute=] entry points never have a return type.
 
 <div class='example wgsl global-scope' heading='Entry Point'>
   <xmp>
-    [[stage(vertex)]]
-    fn vert_main() -> [[builtin(position)]] vec4<f32> {
+    @stage(vertex)
+    fn vert_main() -> @builtin(position) vec4<f32> {
       return vec4<f32>(0.0, 0.0, 0.0, 1.0);
     }
        // OpEntryPoint Vertex %vert_main "vert_main" %return_value
@@ -6748,8 +6743,8 @@ Note: [=Compute=] entry points never have a return type.
        // %ptr = OpTypePointer Output %v4float
        // %return_value = OpVariable %ptr Output
 
-    [[stage(fragment)]]
-    fn frag_main([[builtin(position)]] coord_in: vec4<f32>) -> [[location(0)]] vec4<f32> {
+    @stage(fragment)
+    fn frag_main(@builtin(position) coord_in: vec4<f32>) -> @location(0) vec4<f32> {
       return vec4<f32>(coord_in.x, coord_in.y, 0.0, 1.0);
     }
        // OpEntryPoint Fragment %frag_main "frag_main" %return_value %coord_in
@@ -6759,7 +6754,7 @@ Note: [=Compute=] entry points never have a return type.
        // %ptr = OpTypePointer Output %v4float
        // %return_value = OpVariable %ptr Output
 
-    [[stage(compute)]]
+    @stage(compute)
     fn comp_main() { }
        // OpEntryPoint GLCompute %comp_main "comp_main"
   </xmp>
@@ -6785,19 +6780,19 @@ ISSUE: Can we query upper bounds on workgroup size dimensions?  Is it independen
 
 <div class='example wgsl global-scope' heading='workgroup_size Attribute'>
   <xmp>
-    [[ stage(compute), workgroup_size(8,4,1) ]]
+    @stage(compute) @workgroup_size(8,4,1)
     fn sorter() { }
        // OpEntryPoint GLCompute %sorter "sorter"
        // OpExecutionMode %sorter LocalSize 8 4 1
 
-    [[ stage(compute), workgroup_size(8u) ]]
+    @stage(compute) @workgroup_size(8u)
     fn reverser() { }
        // OpEntryPoint GLCompute %reverser "reverser"
        // OpExecutionMode %reverser LocalSize 8 1 1
 
     // Using an pipeline-overridable constant.
-    [[override(42)]] let block_width = 12u;
-    [[ stage(compute), workgroup_size(block_width) ]]
+    @override(42) let block_width = 12u;
+    @stage(compute) @workgroup_size(block_width)
     fn shuffler() { }
        // The SPIR-V translation uses a WorkgroupSize-decorated constant,
        // where the first component is an OpSpecConstant decorated with
@@ -6805,7 +6800,7 @@ ISSUE: Can we query upper bounds on workgroup size dimensions?  Is it independen
        // use defaulted values of 1.
 
     // Error: workgroup_size must be specified on compute shader
-    [[ stage(compute) ]]
+    @stage(compute)
     fn bad_shader() { }
   </xmp>
 </div>
@@ -6919,7 +6914,7 @@ The <dfn noexport>interpolation sampling</dfn> must be one of:
     applied.
 
 For user-defined IO of scalar or vector floating-point type:
-* If the interpolation attribute is not specified, then `[[interpolate(perspective, center)]]` is assumed.
+* If the interpolation attribute is not specified, then `@interpolate(perspective, center)` is assumed.
 * If the interpolation attribute is specified with an interpolation type:
     * If the interpolation type is `flat`, then interpolation sampling must not be specified.
     * If the interpolation type is `perspective` or `linear`, then:
@@ -6927,7 +6922,7 @@ For user-defined IO of scalar or vector floating-point type:
          * If interpolation sampling is not specified, `center` is assumed.
 
 User-defined IO of scalar or vector integer type must always be specified as
-`[[interpolate(flat)]]`.
+`@interpolate(flat)`.
 
 Interpolation attributes must match between [=vertex=] outputs and [=fragment=]
 inputs with the same [=attribute/location=] assignment within the same [=pipeline=].
@@ -6963,16 +6958,16 @@ Note: The number of available locations for an entry point is defined by the Web
 <div class='example wgsl applying location attribute' heading='Applying location attributes'>
   <xmp>
     struct A {
-      [[location(0)]] x: f32;
+      @location(0) x: f32;
       // Despite locations being 16-bytes, x and y cannot share a location
-      [[location(1)]] y: f32;
+      @location(1) y: f32;
     };
 
     // in1 occupies locations 0 and 1.
     // in2 occupies location 2.
     // The return value occupies location 0.
-    [[stage(fragment)]]
-    fn fragShader(in1: A, [[location(2)]] in2: f32) -> [[location(0)]] vec4<f32> {
+    @stage(fragment)
+    fn fragShader(in1: A, @location(2) in2: f32) -> @location(0) vec4<f32> {
      // ...
     }
   </xmp>
@@ -6984,17 +6979,17 @@ User-defined IO can be mixed with built-in values in the same structure. For exa
   <xmp>
     // Mixed builtins and user-defined inputs.
     struct MyInputs {
-      [[location(0)]] x: vec4<f32>;
-      [[builtin(front_facing)]] y: bool;
-      [[location(1),interpolate(flat)]] z: u32;
+      @location(0) x: vec4<f32>;
+      @builtin(front_facing) y: bool;
+      @location(1) @interpolate(flat) z: u32;
     };
 
     struct MyOutputs {
-      [[builtin(frag_depth)]] x: f32;
-      [[location(0)]] y: vec4<f32>;
+      @builtin(frag_depth) x: f32;
+      @location(0) y: vec4<f32>;
     };
 
-    [[stage(fragment)]]
+    @stage(fragment)
     fn fragShader(in1: MyInputs) -> MyOutputs {
       // ...
     }
@@ -7004,13 +6999,13 @@ User-defined IO can be mixed with built-in values in the same structure. For exa
 <div class='example wgsl invalid locations' heading='Invalid location assignments'>
   <xmp>
     struct A {
-      [[location(0)]] x: f32;
+      @location(0) x: f32;
       // Invalid, x and y cannot share a location.
-      [[location(0)]] y: f32;
+      @location(0) y: f32;
     };
 
     struct B {
-      [[location(0)]] x: f32;
+      @location(0) x: f32;
     };
 
     struct C {
@@ -7022,21 +7017,21 @@ User-defined IO can be mixed with built-in values in the same structure. For exa
       x: vec4<f32>;
     };
 
-    [[stage(fragment)]]
+    @stage(fragment)
     // Invalid, location cannot be applied to a structure type.
-    fn fragShader1([[location(0)]] in1: D) {
+    fn fragShader1(@location(0) in1: D) {
       // ...
     }
 
-    [[stage(fragment)]]
+    @stage(fragment)
     // Invalid, in1 and in2 cannot share a location.
-    fn fragShader2([[location(0)]] in1: f32, [[location(0)]] in2: f32) {
+    fn fragShader2(@location(0) in1: f32, @location(0) in2: f32) {
       // ...
     }
 
-    [[stage(fragment)]]
+    @stage(fragment)
     // Invalid, location cannot be applied to a structure.
-    fn fragShader3([[location(0)]] in1: vec4<f32>) -> [[location(0)]] D {
+    fn fragShader3(@location(0) in1: vec4<f32>) -> @location(0) D {
       // ...
     }
   </xmp>
@@ -7215,7 +7210,7 @@ the implementation can issue a clear diagnostic.
        return x / two;
     };
 
-    [[round_to_even_f16]] // Attribute enabled by the rounding_mode_f16 extension
+    @round_to_even_f16 // Attribute enabled by the rounding_mode_f16 extension
     fn triple_it(x: f16) -> f16 {
        return x * f16(3); // Uses round-to-even.
     };
@@ -7672,7 +7667,7 @@ member.
       c : f32;
     };
 
-    [[group(0), binding(0)]]
+    @group(0) @binding(0)
     var<storage> v : S;
 
     fn foo() {
@@ -8161,14 +8156,9 @@ A <dfn>syntactic token</dfn> is a sequence of special characters, used:
     | `'->'`
 </div>
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>attr_left</dfn> :
+  <dfn for=syntax>attr</dfn> :
 
-    | `'[['`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>attr_right</dfn> :
-
-    | `']]'`
+    | `'@'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>forward_slash</dfn> :
@@ -8521,7 +8511,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in value.
 <div class='example wgsl global-scope' heading="Declaring built-in values">
   <xmp>
     struct VertexOutput {
-      [[builtin(position)]] my_pos: vec4<f32>;
+      @builtin(position) my_pos: vec4<f32>;
       //   OpDecorate %my_pos BuiltIn Position
       //   %float = OpTypeFloat 32
       //   %v4float = OpTypeVector %float 4
@@ -8529,44 +8519,44 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in value.
       //   %my_pos = OpVariable %ptr Output
     };
 
-    [[stage(vertex)]]
+    @stage(vertex)
     fn vs_main(
-      [[builtin(vertex_index)]] my_index: u32,
+      @builtin(vertex_index) my_index: u32,
       //   OpDecorate %my_index BuiltIn VertexIndex
       //   %uint = OpTypeInt 32 0
       //   %ptr = OpTypePointer Input %uint
       //   %my_index = OpVariable %ptr Input
-      [[builtin(instance_index)]] my_inst_index: u32,
+      @builtin(instance_index) my_inst_index: u32,
       //    OpDecorate %my_inst_index BuiltIn InstanceIndex
     ) -> VertexOutput {}
 
     struct FragmentOutput {
-      [[builtin(frag_depth)]] depth: f32;
+      @builtin(frag_depth) depth: f32;
       //     OpDecorate %depth BuiltIn FragDepth
-      [[builtin(sample_mask)]] mask_out: u32;
+      @builtin(sample_mask) mask_out: u32;
       //      OpDecorate %mask_out BuiltIn SampleMask ; an output variable
     };
 
-    [[stage(fragment)]]
+    @stage(fragment)
     fn fs_main(
-      [[builtin(front_facing)]] is_front: bool,
+      @builtin(front_facing) is_front: bool,
       //     OpDecorate %is_front BuiltIn FrontFacing
-      [[builtin(position)]] coord: vec4<f32>,
+      @builtin(position) coord: vec4<f32>,
       //     OpDecorate %coord BuiltIn FragCoord
-      [[builtin(sample_index)]] my_sample_index: u32,
+      @builtin(sample_index) my_sample_index: u32,
       //      OpDecorate %my_sample_index BuiltIn SampleId
-      [[builtin(sample_mask_in)]] mask_in: u32,
+      @builtin(sample_mask_in) mask_in: u32,
       //      OpDecorate %mask_in BuiltIn SampleMask ; an input variable
       //      OpDecorate %mask_in Flat
     ) -> FragmentOutput {}
 
-    [[stage(compute)]]
+    @stage(compute)
     fn cs_main(
-      [[builtin(local_invocation_id)]] local_id: vec3<u32>,
+      @builtin(local_invocation_id) local_id: vec3<u32>,
       //     OpDecorate %local_id BuiltIn LocalInvocationId
-      [[builtin(local_invocation_index)]] local_index: u32,
+      @builtin(local_invocation_index) local_index: u32,
       //     OpDecorate %local_index BuiltIn LocalInvocationIndex
-      [[builtin(global_invocation_id)]] global_id: vec3<u32>,
+      @builtin(global_invocation_id) global_id: vec3<u32>,
       //      OpDecorate %global_id BuiltIn GlobalInvocationId
    ) {}
   </xmp>
@@ -9479,9 +9469,9 @@ A four element vector with components extracted from the specified channel from 
 
 <div class='example wgsl global-scope' heading="Gather components from texels in 2D texture">
   <xmp>
-    [[group(0),binding(0)]] var t: texture_2d<f32>;
-    [[group(0),binding(1)]] var dt: texture_depth_2d;
-    [[group(0),binding(2)]] var s: sampler;
+    @group(0) @binding(0) var t: texture_2d<f32>;
+    @group(0) @binding(1) var dt: texture_depth_2d;
+    @group(0) @binding(2) var s: sampler;
 
     fn gather_x_components(c: vec2<f32>) -> vec4<f32> {
       return textureGather(0,t,s,c);
@@ -9559,8 +9549,8 @@ A four element vector with comparison result for the selected texels, as describ
 
 <div class='example wgsl global-scope' heading="Gather depth comparison">
   <xmp>
-    [[group(0),binding(0)]] var dt: texture_depth_2d;
-    [[group(0),binding(1)]] var s: sampler;
+    @group(0) @binding(0) var dt: texture_depth_2d;
+    @group(0) @binding(1) var s: sampler;
 
     fn gather_depth_compare(c: vec2<f32>, depth_ref: f32) -> vec4<f32> {
       return textureGatherCompare(dt,s,c,depth_ref);

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2081,15 +2081,15 @@ to WGSL.
     struct small_stride {
       a: array<f32,8>; // stride 4
     };
-    [[group(0), binding(0)]] var<uniform> invalid: small_stride; // Invalid
+    @group(0) @binding(0) var<uniform> invalid: small_stride; // Invalid
 
     struct wrapped_f32 {
-      [[size(16)]] elem: f32;
+      @size(16) elem: f32;
     };
     struct big_stride {
       a: array<wrapped_f32,8>; // stride 16
     };
-    [[group(0), binding(1)]] var<uniform> valid: big_stride;     // Valid
+    @group(0) @binding(1) var<uniform> valid: big_stride;     // Valid
   </xmp>
 </div>
 

--- a/wgsl/wgsl_spec_style_guide.md
+++ b/wgsl/wgsl_spec_style_guide.md
@@ -156,8 +156,8 @@ For example:
 
     <div class='example wgsl global-scope' heading='Trivial fragment shader'>
       <xmp highlight='rust'>
-        [[stage(fragment)]]
-        fn main() -> [[location(0)]] vec4<f32> {
+        @stage(fragment)
+        fn main() -> @location(0) vec4<f32> {
           return vec4<f32>(0.4,0.4,0.8,1.0);
         }
       </xmp>


### PR DESCRIPTION
This PR implements 2022 January 19 consensus to use `@` for attributes as reasoned in https://github.com/gpuweb/gpuweb/issues/2243 issue.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mehmetoguzderin/gpuweb/pull/2517.html" title="Last updated on Jan 19, 2022, 2:22 AM UTC (8d33e28)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2517/4349dce...mehmetoguzderin:8d33e28.html" title="Last updated on Jan 19, 2022, 2:22 AM UTC (8d33e28)">Diff</a>