### PR TITLE
integer division corresponds to OpSRem

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4596,11 +4596,11 @@ See [[#sync-builtin-functions]].
   <tr algorithm="signed integer remainder">
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [SIGNEDINTEGRAL]
     <td>|e1| `%` |e2| : |T|
-    <td>Signed integer remainder. [=Component-wise=] when |T| is a vector. (OpSMod)
+    <td>Signed integer remainder. [=Component-wise=] when |T| is a vector. (OpSRem)
   <tr algorithm="unsigned integer modulus">
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [UNSIGNEDINTEGRAL]
     <td>|e1| `%` |e2| : |T|
-    <td>Unsigned integer remainder. [=Component-wise=] when |T| is a vector. (OpUMod)
+    <td>Unsigned integer remainder. [=Component-wise=] when |T| is a vector. (OpURem)
   <tr algorithm="floating point remainder">
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [FLOATING]
     <td>|e1| `%` |e2| : |T|

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4600,7 +4600,7 @@ See [[#sync-builtin-functions]].
   <tr algorithm="unsigned integer modulus">
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [UNSIGNEDINTEGRAL]
     <td>|e1| `%` |e2| : |T|
-    <td>Unsigned integer remainder. [=Component-wise=] when |T| is a vector. (OpURem)
+    <td>Unsigned integer remainder. [=Component-wise=] when |T| is a vector. (OpUMod)
   <tr algorithm="floating point remainder">
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [FLOATING]
     <td>|e1| `%` |e2| : |T|


### PR DESCRIPTION
This is the same as #2187, but keeps OpUMod as itself. (There is no OpURem)