### PR TITLE
Add note explaining how dispatch args and workgroup sizes interact

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -705,7 +705,7 @@ depends on work that happens on any timeline other than the [=Content timeline=]
 They are represented by callbacks and promises in JavaScript.
 
 <div class="example">
-{{GPUComputePassEncoder/dispatch(x, y, z)|GPUComputePassEncoder.dispatch()}}:
+{{GPUComputePassEncoder/dispatch(workgroupCountX, workgroupCountY, workgroupCountZ)|GPUComputePassEncoder.dispatch()}}:
 
   1. User encodes a `dispatch` command by calling a method of the
     {{GPUComputePassEncoder}} which happens on the [=Content timeline=].
@@ -1300,7 +1300,8 @@ applications should generally request the "worst" limits that work for their con
     <tr><td><dfn>maxComputeWorkgroupsPerDimension</dfn>
         <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>65535
     <tr class=row-continuation><td colspan=4>
-        The maximum value for the arguments of {{GPUComputePassEncoder/dispatch(x, y, z)}}.
+        The maximum value for the arguments of
+        {{GPUComputePassEncoder/dispatch(workgroupCountX, workgroupCountY, workgroupCountZ)}}.
 
 </table>
 
@@ -4240,10 +4241,10 @@ Note: using the same {{GPUPipelineLayout}} for many {{GPURenderPipeline}} or {{G
   1. {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup(1, ...)}}
   1. {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup(2, ...)}}
   1. {{GPUComputePassEncoder/setPipeline(pipeline)|setPipeline(X)}}
-  1. {{GPUComputePassEncoder/dispatch(x, y, z)|dispatch()}}
+  1. {{GPUComputePassEncoder/dispatch(workgroupCountX, workgroupCountY, workgroupCountZ)|dispatch()}}
   1. {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup(1, ...)}}
   1. {{GPUComputePassEncoder/setPipeline(pipeline)|setPipeline(Y)}}
-  1. {{GPUComputePassEncoder/dispatch(x, y, z)|dispatch()}}
+  1. {{GPUComputePassEncoder/dispatch(workgroupCountX, workgroupCountY, workgroupCountZ)|dispatch()}}
 
 In this scenario, the user agent would have to re-bind the group slot 2 for the second dispatch, even though neither the {{GPUBindGroupLayout}} at index 2 of {{GPUPipelineLayout/[[bindGroupLayouts]]|GPUPipelineLayout.bindGrouplayouts}}, or the {{GPUBindGroup}} at slot 2, change.
 </div>
@@ -7181,7 +7182,7 @@ interface mixin GPUDebugCommandsMixin {
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUComputePassEncoder {
     undefined setPipeline(GPUComputePipeline pipeline);
-    undefined dispatch(GPUSize32 x, optional GPUSize32 y = 1, optional GPUSize32 z = 1);
+    undefined dispatch(GPUSize32 workgroupCountX, optional GPUSize32 workgroupCountY = 1, optional GPUSize32 workgroupCountZ = 1);
     undefined dispatchIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
 
     undefined endPass();
@@ -7270,7 +7271,7 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
             </div>
         </div>
 
-    : <dfn>dispatch(x, y, z)</dfn>
+    : <dfn>dispatch(workgroupCountX, workgroupCountY, workgroupCountZ)</dfn>
     ::
         Dispatch work to be performed with the current {{GPUComputePipeline}}.
         See [[#computing-operations]] for the detailed specification.
@@ -7279,10 +7280,10 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
             **Called on:** {{GPUComputePassEncoder}} this.
 
             **Arguments:**
-            <pre class=argumentdef for="GPUComputePassEncoder/dispatch(x, y, z)">
-                |x|: X dimension of the grid of workgroups to dispatch.
-                |y|: Y dimension of the grid of workgroups to dispatch.
-                |z|: Z dimension of the grid of workgroups to dispatch.
+            <pre class=argumentdef for="GPUComputePassEncoder/dispatch(workgroupCountX, workgroupCountY, workgroupCountZ)">
+                |workgroupCountX|: X dimension of the grid of workgroups to dispatch.
+                |workgroupCountY|: Y dimension of the grid of workgroups to dispatch.
+                |workgroupCountZ|: Z dimension of the grid of workgroups to dispatch.
             </pre>
 
             **Returns:** {{undefined}}
@@ -7293,7 +7294,7 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
                     <div class=validusage>
                         - [$Validate encoder bind groups$](|this|, |this|.{{GPUComputePassEncoder/[[pipeline]]}})
                             is `true`.
-                        - all of |x|, |y| and |z| are less than or equal to
+                        - all of |workgroupCountX|, |workgroupCountY| and |workgroupCountZ| are less than or equal to
                             |this|.device.limits.{{supported limits/maxComputeWorkgroupsPerDimension}}.
                     </div>
 
@@ -7301,7 +7302,8 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
                 1. [=list/Append=] a [=GPU command=] to |this|.{{GPUCommandsMixin/[[commands]]}}
                     executing the following [=queue timeline=] steps:
                     <div class=queue-timeline>
-                        1. Dispatch a grid of workgroups with dimensions [|x|, |y|, |z|] with
+                        1. Dispatch a grid of workgroups with dimensions [|workgroupCountX|, |workgroupCountY|,
+                            |workgroupCountZ|] with
                             |passState|.{{GPUComputePassEncoder/[[pipeline]]}} using
                             |passState|.{{GPUProgrammablePassEncoder/[[bind_groups]]}}.
                     </div>
@@ -7320,9 +7322,9 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
 
         <pre highlight="js">
             let dispatchIndirectParameters = new Uint32Array(3);
-            dispatchIndirectParameters[0] = x;
-            dispatchIndirectParameters[1] = y;
-            dispatchIndirectParameters[2] = z;
+            dispatchIndirectParameters[0] = workgroupCountX;
+            dispatchIndirectParameters[1] = workgroupCountY;
+            dispatchIndirectParameters[2] = workgroupCountZ;
         </pre>
 
         <div algorithm="GPUComputePassEncoder.dispatchIndirect">
@@ -7359,7 +7361,7 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
 
 <div class=note>
 Note: The `x`, `y`, and `z` values passed to {{GPUComputePassEncoder/dispatch()}} and
-{{GPUComputePassEncoder/dispatchIndirect()}} are the number of _workgroups_ to dispatch for each
+{{GPUComputePassEncoder/dispatchIndirect()}} are the number of *workgroups* to dispatch for each
 dimension, *not* the number of shader invocations to perform across each dimension. This matches the
 behavior of modern native GPU APIs, but differs from the behavior of OpenCL.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7357,6 +7357,18 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
         </div>
 </dl>
 
+<div class=note>
+Note: The `x`, `y`, and `z` values passed to {{GPUComputePassEncoder/dispatch()}} and
+{{GPUComputePassEncoder/dispatchIndirect()}} are the number of _workgroups_ do dispatch for each
+dimension, *not* the number of shader invocations to perform across each dimension. This matches the
+behavior of modern native GPU APIs, but differs from the behavior of OpenCL.
+
+This means that if a {{GPUShaderModule}} defines an entry point with `@workgroup_size(4, 4)`, and
+work is dispatched to it with the call `computePass.dispatch(8, 8);` the entry point will be invoked
+1024 times total: 4 dispatches of a workgroup size of 8 along both the X and Y axes.
+(`4*8*4*8=1024`)
+</div>
+
 ### Finalization ### {#compute-pass-encoder-finalization}
 
 The compute pass encoder can be ended by calling {{GPUComputePassEncoder/endPass()}} once the user

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7359,14 +7359,14 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
 
 <div class=note>
 Note: The `x`, `y`, and `z` values passed to {{GPUComputePassEncoder/dispatch()}} and
-{{GPUComputePassEncoder/dispatchIndirect()}} are the number of _workgroups_ do dispatch for each
+{{GPUComputePassEncoder/dispatchIndirect()}} are the number of _workgroups_ to dispatch for each
 dimension, *not* the number of shader invocations to perform across each dimension. This matches the
 behavior of modern native GPU APIs, but differs from the behavior of OpenCL.
 
 This means that if a {{GPUShaderModule}} defines an entry point with `@workgroup_size(4, 4)`, and
 work is dispatched to it with the call `computePass.dispatch(8, 8);` the entry point will be invoked
-1024 times total: 4 dispatches of a workgroup size of 8 along both the X and Y axes.
-(`4*8*4*8=1024`)
+1024 times total: Dispatching of a 4x4 workgroup 8 times along both the X and Y axes.
+(`4*4*8*8=1024`)
 </div>
 
 ### Finalization ### {#compute-pass-encoder-finalization}


### PR DESCRIPTION
This has proven to be a point of confusion for several developers (including myself), and it does differ from the behavior of some older compute APIs, so a clarifying note seems appropriate.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/2519.html" title="Last updated on Jan 24, 2022, 4:55 PM UTC (cf2eb60)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2519/66d765b...cf2eb60.html" title="Last updated on Jan 24, 2022, 4:55 PM UTC (cf2eb60)">Diff</a>