### PR TITLE
editorial: streamline array and structure layout descriptions

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -575,9 +575,18 @@ An attribute must not be specified more than once per object or type.
     <td>positive i32 literal
     <td>Must only be applied to a member of a [=structure=] type.
 
-    Must be a power of 2.
+    Must be a power of 2, and must satisfy the required-alignment for the member type:
 
-    See memory layout [alignment and size](#alignment-and-size).
+    <p algorithm="align constraint">
+    If `align(`|n|`)` is applied to a member of |S|
+    with type |T|, and |S| is the [=store type=]
+    or contained in the store type for a variable in storage class |C|,
+    then |n| must satisfy:
+    |n|&nbsp;=&nbsp;|k|&nbsp;&times;&nbsp;[=RequiredAlignOf=](|T|,|C|)
+    for some positive integer |k|.
+    </p>
+
+    See [[#memory-layouts]]
 
   <tr><td><dfn noexport dfn-for="attribute">`binding`
     <td>non-negative i32 literal
@@ -655,6 +664,13 @@ An attribute must not be specified more than once per object or type.
     <td>Must only be applied to a member of a [=structure=] type.
 
     The number of bytes reserved in the struct for this member.
+    
+    This number must be at least the [=byte-size=] of the type of the member:
+    <p algorithm="byte-size constraint">
+    If `size(`|n|`)` is applied to a member with type |T|, then [=SizeOf=](|T|)&nbsp;&leq;&nbsp;|n|.
+    </p>
+
+    See [[#memory-layouts]]
 
   <tr><td><dfn noexport dfn-for="attribute">`stage`</dfn>
     <td>`compute`, `vertex`, or `fragment`
@@ -1674,7 +1690,7 @@ The terms defined in this section express counts of 8-bit bytes.
 We will use the following notation:
 * <dfn noexport>AlignOf</dfn>(|T|) is the [=alignment=] of host-shareable type |T|.
 * <dfn noexport>AlignOfMember</dfn>(|S|, |M|) is the alignment of member |M| of the host-shareable structure |S|.
-* <dfn noexport>SizeOf</dfn>(|T|) is the [=size=] of host-shareable type |T|.
+* <dfn noexport>SizeOf</dfn>(|T|) is the [=byte-size=] of host-shareable type |T|.
 * <dfn noexport>SizeOfMember</dfn>(|S|, |M|) is the size of member |M| of the host-shareable structure |S|.
 * <dfn noexport>OffsetOfMember</dfn>(|S|, |M|) is the offset of member |M| from the start of the host-shareable structure |S|.
 * <dfn noexport>StrideOf</dfn>(|A|) is the <dfn>element stride</dfn> of host-shareable array type |A|, defined
@@ -1690,15 +1706,18 @@ We will use the following notation:
 
 Each [=host-shareable=] data type |T| has an alignment and size.
 
-The <dfn>alignment</dfn> of a type is a constraint on where values of that type may be placed in memory:
-the memory address (in bytes) of a value of that type must be evenly divisible by the type's alignment.
+The <dfn>alignment</dfn> of a type is a constraint on where values of that type may be placed in memory, expressed
+as an integer:
+a type's alignment must evenly divide
+the byte address of the starting [=memory location=] of a value of that type.
+must be evenly divisible by the type's alignment.
 Alignments enable use of more efficient hardware instructions for accessing the values,
 or satisfy more restrictive hardware requirements on certain
 storage classes. (See [storage class layout constraints](#storage-class-layout-constraints)).
 
 Note: Each alignment value is always a power of two, by construction.
 
-The <dfn>size</dfn> of a type or structure member is the number of contiguous bytes
+The <dfn>byte-size</dfn> of a type or structure member is the number of contiguous bytes
 reserved in host-shareable memory for the purpose of storing a value of the type
 or structure member.
 The size may include non-addressable padding at the end of the type.
@@ -1765,8 +1784,8 @@ following table:
       <td>64
   <tr><td>struct |S| with members M<sub>1</sub>...M<sub>N</sub>
       <td>max([=AlignOfMember=](S, M<sub>1</sub>), ... , [=AlignOfMember=](S, M<sub>N</sub>))<br>
-      <td>[=roundUp=]([=AlignOf=](|S|), lastOffset)<br><br>
-          where lastOffset = [=OffsetOfMember=](|S|,M<sub>N</sub>) + [=SizeOfMember=](|S|,M<sub>N</sub>)
+      <td>[=roundUp=]([=AlignOf=](|S|), justPastLastMember)<br><br>
+          where justPastLastMember = [=OffsetOfMember=](|S|,M<sub>N</sub>) + [=SizeOfMember=](|S|,M<sub>N</sub>)
   <tr><td>array<|E|, |N|><br>
       <td>[=AlignOf=](|E|)
       <td>|N| &times; [=roundUp=]([=AlignOf=](|E|), [=SizeOf=](|E|))
@@ -1923,6 +1942,10 @@ This section describes how the internals of a value are placed in the byte locat
 of a buffer, given an assumed placement of the overall value.
 These layouts depend on the value's type,
 and the [=attribute/align=] and [=attribute/size=] attributes on structure members.
+
+The buffer byte offset at which a value is placed must satisfy the type alignment requirement:
+If a value of type |T| is placed
+at buffer offset |k|, then |k| = |c| &times; [=AlignOf=](|T|), for some non-negative integer |c|.
 
 The data will appear identically regardless of storage class.
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1676,7 +1676,13 @@ We will use the following notation:
 * <dfn noexport>AlignOfMember</dfn>(|S|, |M|) is the alignment of member |M| of the host-shareable structure |S|.
 * <dfn noexport>SizeOf</dfn>(|T|) is the size of host-shareable type |T|.
 * <dfn noexport>SizeOfMember</dfn>(|S|, |M|) is the size of member |M| of the host-shareable structure |S|.
-* <dfn noexport>StrideOf</dfn>(|A|) is the [=element stride=] of host-shareable array type |A|.
+* <dfn noexport>StrideOf</dfn>(|A|) is the <dfn>element stride</dfn> of host-shareable array type |A|, defined
+    as the number of bytes from the start of one array element to the start of the next element.
+    It equals the size of the array's element type, rounded up to the alignment of the element type:
+        <p algorithm="array element stride">
+          [=StrideOf=](array<|E|, |N|>) = [=roundUp=]([=AlignOf=](E), [=SizeOf=](E))<br>
+          [=StrideOf=](array<|E|>) = [=roundUp=]([=AlignOf=](E), [=SizeOf=](E))
+        </p>
 * <dfn noexport>OffsetOfMember</dfn>(|S|, |M|) is the offset of member |M| from the start of the host-shareable structure |S|.
 
 
@@ -1773,7 +1779,7 @@ following table:
 
 #### Structure Layout Rules ####  {#structure-layout-rules}
 
-Issue: [#2493](https://github.com/gpuweb/gpuweb/issues/2493) Portions of this section are redundant with other sections.
+Issue: [#2497](https://github.com/gpuweb/gpuweb/issues/2497) Portions of this section are redundant with other sections.
 
 Each structure |S| member M<sub>N</sub> has a size and alignment value, denoted
 by [=SizeOfMember=](|S|, M<sub>N</sub>) and [=AlignOfMember=](|S|, M<sub>N</sub>), respectively.
@@ -1879,43 +1885,46 @@ rounded to the next multiple of the structure's alignment:
   </xmp>
 </div>
 
-#### Array Layout Rules ####  {#array-layout-rules}
+#### Array Layout Examples ####  {#array-layout-examples}
 
-Issue: [#2493](https://github.com/gpuweb/gpuweb/issues/2493) This section is largely redundant
-
-The first array element always has a zero byte offset from the start of the
-array.
-
-The <dfn noexport>element stride</dfn> of an array is the number of bytes from the
-start of one array element to the start of the next element.
-It equals the size of the array's element type, rounded up to the alignment of the element type:
-
-<p algorithm="array element stride">
-  [=StrideOf=](array<|T|[, |N|]>) = [=roundUp=]([=AlignOf=](T), [=SizeOf=](T))
-</p>
-
-<div class='example wgsl' heading='Array element strides'>
+<div class='example wgsl function-scope' heading='Fixed-size array layout examples'>
   <xmp highlight='rust'>
-    // Array with an element stride of 4 bytes.
+    // Array where:
+    //   - alignment is 4 = AlignOf(f32)
+    //   - element stride is 4 = roundUp(AlignOf(f32),SizeOf(f32)) = roundUp(4,4)
+    //   - size is 32 = stride * number_of_elements = 4 * 8
     var small_stride: array<f32, 8>;
 
-    // Array with an element stride of 16 bytes, inherited from
-    // the alignment of element type vec3<f32>, which is 16 bytes.
+    // Array where:
+    //   - alignment is 16 = AlignOf(vec3<f32>) = 16
+    //   - element stride is 16 = roundUp(AlignOf(vec3<f32>), SizeOf(vec3<f32>))
+    //                          = roundUp(16,12)
+    //   - size is 128 = stride * number_of_elements = 16 * 8
     var bigger_stride: array<vec3<f32>, 8>;
   </xmp>
 </div>
 
-The array size (in bytes) is equal to the array's element stride multiplied by the number of
-elements:
-<p algorithm="array size">
-  [=SizeOf=](array<|T|, |N|>) = [=StrideOf=](array<|T|, |N|>) &times; |N|<br>
-  [=SizeOf=](array<|T|>) = [=StrideOf=](array<|T|>) &times; N<sub>runtime</sub>
-</p>
+<div class='example wgsl global-scope' heading='Runtime-sized array layout examples'>
+  <xmp highlight='rust'>
+    // Array where:
+    //   - alignment is 4 = AlignOf(f32)
+    //   - element stride is 4 = roundUp(AlignOf(f32),SizeOf(f32)) = 4
+    // If B is the effective buffer binding size for the binding on the
+    // draw or dispach command, the number of elements is:
+    //   N_runtime = floor(B / element stride) = floor(B / 4)
+    @group(0) @binding(0)
+    var<storage> weights: array<f32>;
 
-The array alignment is equal to the element alignment:
-<p algorithm="array alignment">
-  [=AlignOf=](array<|T|[, N]>) = [=AlignOf=](|T|)
-</p>
+    // Array where:
+    //   - alignment is 16 = AlignOf(vec3<f32>) = 16
+    //   - element stride is 16 = roundUp(AlignOf(vec3<f32>), SizeOf(vec3<f32>))
+    //                          = roundUp(16,12)
+    // If B is the effective buffer binding size for the binding on the
+    // draw or dispach command, the number of elements is:
+    //   N_runtime = floor(B / element stride) = floor(B / 16)
+    var<uniform> directions: array<vec3<f32>>;
+  </xmp>
+</div>
 
 #### Internal Layout of Values ####  {#internal-value-layout}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1672,10 +1672,11 @@ An 8-bit byte is the most basic unit of [=host-shareable=] memory.
 The terms defined in this section express counts of 8-bit bytes.
 
 We will use the following notation:
-* <dfn noexport>AlignOf</dfn>(|T|) is the alignment of host-shareable type |T|.
+* <dfn noexport>AlignOf</dfn>(|T|) is the [=alignment=] of host-shareable type |T|.
 * <dfn noexport>AlignOfMember</dfn>(|S|, |M|) is the alignment of member |M| of the host-shareable structure |S|.
-* <dfn noexport>SizeOf</dfn>(|T|) is the size of host-shareable type |T|.
+* <dfn noexport>SizeOf</dfn>(|T|) is the [=size=] of host-shareable type |T|.
 * <dfn noexport>SizeOfMember</dfn>(|S|, |M|) is the size of member |M| of the host-shareable structure |S|.
+* <dfn noexport>OffsetOfMember</dfn>(|S|, |M|) is the offset of member |M| from the start of the host-shareable structure |S|.
 * <dfn noexport>StrideOf</dfn>(|A|) is the <dfn>element stride</dfn> of host-shareable array type |A|, defined
     as the number of bytes from the start of one array element to the start of the next element.
     It equals the size of the array's element type, rounded up to the alignment of the element type:
@@ -1683,22 +1684,21 @@ We will use the following notation:
           [=StrideOf=](array<|E|, |N|>) = [=roundUp=]([=AlignOf=](E), [=SizeOf=](E))<br>
           [=StrideOf=](array<|E|>) = [=roundUp=]([=AlignOf=](E), [=SizeOf=](E))
         </p>
-* <dfn noexport>OffsetOfMember</dfn>(|S|, |M|) is the offset of member |M| from the start of the host-shareable structure |S|.
 
 
 #### Alignment and Size ####  {#alignment-and-size}
 
-Each [=host-shareable=] data type |T| has an alignment and size value, denoted
-by [=AlignOf=](|T|) and [=SizeOf=](|T|), respectively.
+Each [=host-shareable=] data type |T| has an alignment and size.
 
-Alignment guarantees that a value's address in memory will be a multiple of the
-specified value. This can enable more efficient hardware instructions to be used
-to access the value or satisfy more restrictive hardware requirements on certain
-storage classes. (see [storage class layout constraints](#storage-class-layout-constraints)).
+The <dfn>alignment</dfn> of a type is a constraint on where values of that type may be placed in memory:
+the memory address (in bytes) of a value of that type must be evenly divisible by the type's alignment.
+Alignments enable use of more efficient hardware instructions for accessing the values,
+or satisfy more restrictive hardware requirements on certain
+storage classes. (See [storage class layout constraints](#storage-class-layout-constraints)).
 
 Note: Each alignment value is always a power of two, by construction.
 
-The size of a type or structure member is the number of contiguous bytes
+The <dfn>size</dfn> of a type or structure member is the number of contiguous bytes
 reserved in host-shareable memory for the purpose of storing a value of the type
 or structure member.
 The size may include non-addressable padding at the end of the type.
@@ -1763,67 +1763,58 @@ following table:
   <tr><td>mat4x4&lt;f32&gt;
       <td>16
       <td>64
-  <tr><td>struct |S|
+  <tr><td>struct |S| with members M<sub>1</sub>...M<sub>N</sub>
       <td>max([=AlignOfMember=](S, M<sub>1</sub>), ... , [=AlignOfMember=](S, M<sub>N</sub>))<br>
-      <td>[=roundUp=]([=AlignOf=](|S|), [=OffsetOfMember=](|S|, |L|) + [=SizeOfMember=](|S|, |L|))<br><br>
-          Where |L| is the last member of the structure
+      <td>[=roundUp=]([=AlignOf=](|S|), lastOffset)<br><br>
+          where lastOffset = [=OffsetOfMember=](|S|,M<sub>N</sub>) + [=SizeOfMember=](|S|,M<sub>N</sub>)
   <tr><td>array<|E|, |N|><br>
       <td>[=AlignOf=](|E|)
-      <td>|N| * [=roundUp=]([=AlignOf=](|E|), [=SizeOf=](|E|))
+      <td>|N| &times; [=roundUp=]([=AlignOf=](|E|), [=SizeOf=](|E|))
   <tr><td>array<|E|><br>
       <td>[=AlignOf=](|E|)
-      <td>N<sub>runtime</sub> * [=roundUp=]([=AlignOf=](|E|), [=SizeOf=](|E|))<br><br>
-          Where N<sub>runtime</sub> is the runtime-determined number of elements of |T|
+      <td>N<sub>runtime</sub> &times; [=roundUp=]([=AlignOf=](|E|),[=SizeOf=](|E|))<br><br>
+          where N<sub>runtime</sub> is the runtime-determined number of elements of |T|
 </table>
 
 
-#### Structure Layout Rules ####  {#structure-layout-rules}
+#### Structure Member Layout ####  {#structure-member-layout}
 
-Issue: [#2497](https://github.com/gpuweb/gpuweb/issues/2497) Portions of this section are redundant with other sections.
+Each structure |S| member M<sub>i</sub> has a size and alignment, denoted
+by [=SizeOfMember=](|S|, M<sub>i</sub>) and [=AlignOfMember=](|S|, M<sub>i</sub>), respectively.
+The member sizes and alignments are used to calculate each member's byte offset from the start of the structure,
+as described in [[#internal-value-layout]].
 
-Each structure |S| member M<sub>N</sub> has a size and alignment value, denoted
-by [=SizeOfMember=](|S|, M<sub>N</sub>) and [=AlignOfMember=](|S|, M<sub>N</sub>), respectively.
-The member sizes and alignments are used to calculate each member's byte offset from the start of the structure.
-
-Structures member size and alignment values default to the member type `T`'s
-[=SizeOf=](T) and [=AlignOf=](T) values.
-
-If a structure member is decorated with the [=attribute/size=] decoration, then the structure
-member will use the value of the decoration for its size instead of its type's size.
-
-If a structure member is decorated with the [=attribute/align=] decoration, then the structure
-member will use the value of the decoration for its alignment instead of its type's alignment.
-
-The first structure member always has a zero byte offset from the start of the
-structure.
-
-Subsequent members have the following byte offset from the start of the structure:
-<p algorithm="structure member offset">
-  [=OffsetOfMember=](|S|, M<sub>N</sub>) = [=roundUp=]([=AlignOfMember=](|S|, M<sub>N</sub>), [=OffsetOfMember=](|S|, M<sub>N-1</sub>) + [=SizeOfMember=](|S|, M<sub>N-1</sub>)<br>
-  Where M<sub>N</sub> is the current member and M<sub>N-1</sub> is the previous member
+<p algorithm="structure member size">
+  [=SizeOfMember=](|S|, M<sub>i</sub>) is |k| if member M<sub>i</sub> has attribute [=attribute/size=](|k|).
+  Otherwise, it is [=SizeOf=](|T|) where |T| is the type of member M<sub>i</sub>.
 </p>
 
-Structure members must not overlap. If a structure member is decorated with the
+<p algorithm="structure member alignment">
+  [=AlignOfMember=](|S|, M<sub>i</sub>) is |k| if member M<sub>i</sub> has attribute [=attribute/align=](|k|).
+  Otherwise, it is [=AlignOf=](|T|) where |T| is the type of member M<sub>i</sub>.
+</p>
+
+If a structure member is decorated with the
 [=attribute/size=] attribute, the value must be at least as large as the
 size of the member's type:
 
 <p algorithm="member size constraint">
-  [=SizeOfMember=](|S|, M<sub>N</sub>) &ge; [=SizeOf=](T)<br>
-  Where |T| is the type of member M<sub>N</sub>.
+  [=SizeOfMember=](|S|, M<sub>i</sub>) &ge; [=SizeOf=](T)<br>
+  Where |T| is the type of member M<sub>i</sub>.
 </p>
 
-
-The alignment of a structure is equal to the largest alignment of all of its
-members:
-<p algorithm="structure alignment">
-  [=AlignOf=](|S|) = max([=AlignOfMember=](|S|, M<sub>1</sub>), ... , [=AlignOfMember=](|S|, M<sub>N</sub>))
+The first structure member always has a zero byte offset from the start of the
+structure:
+<p algorithm="offset of first structure member">
+  [=OffsetOfMember=](|S|, M<sub>1</sub>) = 0
 </p>
 
-The size of a structure is equal to the offset plus the size of its last member,
-rounded to the next multiple of the structure's alignment:
-<p algorithm="structure size">
-  [=SizeOf=](|S|) = [=roundUp=]([=AlignOf=](|S|), [=OffsetOfMember=](|S|, |L|) + [=SizeOfMember=](|S|, |L|))<br>
-  Where |L| is the last member of the structure
+Each subsequent member is placed at the lowest offset that satisfies the member type alignment,
+and which avoids overlap with the previous member.
+For each member index |i| > 1:
+<p algorithm="structure member offset">
+  [=OffsetOfMember=](|S|, M<sub>i</sub>) = [=roundUp=]([=AlignOfMember=](|S|, M<sub>i</sub>), [=OffsetOfMember=](|S|, M<sub>i-1</sub>) + [=SizeOfMember=](|S|, M<sub>i-1</sub>))<br>
+  Where M<sub>i</sub> is the current member and M<sub>i-1</sub> is the previous member.
 </p>
 
 <div class='example wgsl' heading='Layout of structures using implicit member sizes and alignments'>
@@ -1980,8 +1971,8 @@ then:
 
 When a value of structure type |S| is placed at byte offset |k| of a host-shared memory buffer,
 then:
-   * The |i|'<sup>th</sup> member of the structure value is placed at byte offset |k| + [=OffsetOfMember=](|S|,|i|)
-
+   * The |i|'<sup>th</sup> member of the structure value is placed at byte offset |k| + [=OffsetOfMember=](|S|,|i|).
+    See [[#structure-member-layout]].
 
 #### Storage Class Layout Constraints ####  {#storage-class-layout-constraints}
 
@@ -1990,11 +1981,11 @@ have different buffer layout constraints which are described in this section.
 
 All structure and array types directly or indirectly referenced by a variable
 must obey the constraints of the variable's storage class.
-Violations of a storage class constraint result in a compile-time error.
+Violations of a storage class constraint results in a [=shader-creation error=].
 
 In this section we define <dfn noexport>RequiredAlignOf</dfn>(|S|, |C|) as the
-required byte offset alignment of values of host-shareable type |S| when
-used by storage class |C|.
+byte offset [=alignment=] requirement of values of host-shareable type |S| when
+used in storage class |C|.
 
 <table class='data'>
   <caption>
@@ -2046,7 +2037,8 @@ Arrays of element type |T| must have an [=element stride=] that is a
 multiple of the [=RequiredAlignOf=](|T|, |C|) for the storage class |C|:
 
 <p algorithm="array element minimum alignment">
-    [=StrideOf=](array<|T|[, |N|]>) = |k| &times; [=RequiredAlignOf=](|T|, C)<br>
+    [=StrideOf=](array<|T|, |N|>) = |k| &times; [=RequiredAlignOf=](|T|, C)<br>
+    [=StrideOf=](array<|T|>) = |k| &times; [=RequiredAlignOf=](|T|, C)<br>
     Where |k| is a positive integer
 </p>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1689,10 +1689,10 @@ The terms defined in this section express counts of 8-bit bytes.
 
 We will use the following notation:
 * <dfn noexport>AlignOf</dfn>(|T|) is the [=alignment=] of host-shareable type |T|.
-* <dfn noexport>AlignOfMember</dfn>(|S|, |M|) is the alignment of member |M| of the host-shareable structure |S|.
+* <dfn noexport>AlignOfMember</dfn>(|S|, |i|) is the alignment of the |i|'th member of the host-shareable structure |S|.
 * <dfn noexport>SizeOf</dfn>(|T|) is the [=byte-size=] of host-shareable type |T|.
-* <dfn noexport>SizeOfMember</dfn>(|S|, |M|) is the size of member |M| of the host-shareable structure |S|.
-* <dfn noexport>OffsetOfMember</dfn>(|S|, |M|) is the offset of member |M| from the start of the host-shareable structure |S|.
+* <dfn noexport>SizeOfMember</dfn>(|S|, |i|) is the size of the |i|'th member of the host-shareable structure |S|.
+* <dfn noexport>OffsetOfMember</dfn>(|S|, |i|) is the offset of the |i|'th member from the start of the host-shareable structure |S|.
 * <dfn noexport>StrideOf</dfn>(|A|) is the <dfn>element stride</dfn> of host-shareable array type |A|, defined
     as the number of bytes from the start of one array element to the start of the next element.
     It equals the size of the array's element type, rounded up to the alignment of the element type:
@@ -1783,9 +1783,9 @@ following table:
       <td>16
       <td>64
   <tr><td>struct |S| with members M<sub>1</sub>...M<sub>N</sub>
-      <td>max([=AlignOfMember=](S, M<sub>1</sub>), ... , [=AlignOfMember=](S, M<sub>N</sub>))<br>
+      <td>max([=AlignOfMember=](S,1), ... , [=AlignOfMember=](S,N))<br>
       <td>[=roundUp=]([=AlignOf=](|S|), justPastLastMember)<br><br>
-          where justPastLastMember = [=OffsetOfMember=](|S|,M<sub>N</sub>) + [=SizeOfMember=](|S|,M<sub>N</sub>)
+          where justPastLastMember = [=OffsetOfMember=](|S|,N) + [=SizeOfMember=](|S|,N)
   <tr><td>array<|E|, |N|><br>
       <td>[=AlignOf=](|E|)
       <td>|N| &times; [=roundUp=]([=AlignOf=](|E|), [=SizeOf=](|E|))
@@ -1798,19 +1798,19 @@ following table:
 
 #### Structure Member Layout ####  {#structure-member-layout}
 
-Each structure |S| member M<sub>i</sub> has a size and alignment, denoted
-by [=SizeOfMember=](|S|, M<sub>i</sub>) and [=AlignOfMember=](|S|, M<sub>i</sub>), respectively.
+The |i|'th member of structure |S| has a size and alignment, denoted
+by [=SizeOfMember=](|S|, |i|) and [=AlignOfMember=](|S|, |i|), respectively.
 The member sizes and alignments are used to calculate each member's byte offset from the start of the structure,
 as described in [[#internal-value-layout]].
 
 <p algorithm="structure member size">
-  [=SizeOfMember=](|S|, M<sub>i</sub>) is |k| if member M<sub>i</sub> has attribute [=attribute/size=](|k|).
-  Otherwise, it is [=SizeOf=](|T|) where |T| is the type of member M<sub>i</sub>.
+  [=SizeOfMember=](|S|, |i|) is |k| if the |i|'th member of |S| has attribute [=attribute/size=](|k|).
+  Otherwise, it is [=SizeOf=](|T|) where |T| is the type of the member.
 </p>
 
 <p algorithm="structure member alignment">
-  [=AlignOfMember=](|S|, M<sub>i</sub>) is |k| if member M<sub>i</sub> has attribute [=attribute/align=](|k|).
-  Otherwise, it is [=AlignOf=](|T|) where |T| is the type of member M<sub>i</sub>.
+  [=AlignOfMember=](|S|, |i|) is |k| if the |i|'th member has attribute [=attribute/align=](|k|).
+  Otherwise, it is [=AlignOf=](|T|) where |T| is the type of the member.
 </p>
 
 If a structure member is decorated with the
@@ -1818,22 +1818,21 @@ If a structure member is decorated with the
 size of the member's type:
 
 <p algorithm="member size constraint">
-  [=SizeOfMember=](|S|, M<sub>i</sub>) &ge; [=SizeOf=](T)<br>
-  Where |T| is the type of member M<sub>i</sub>.
+  [=SizeOfMember=](|S|, |i|) &ge; [=SizeOf=](T)<br>
+  Where |T| is the type of the |i|'th member of |S|.
 </p>
 
 The first structure member always has a zero byte offset from the start of the
 structure:
 <p algorithm="offset of first structure member">
-  [=OffsetOfMember=](|S|, M<sub>1</sub>) = 0
+  [=OffsetOfMember=](|S|, 1) = 0
 </p>
 
 Each subsequent member is placed at the lowest offset that satisfies the member type alignment,
 and which avoids overlap with the previous member.
 For each member index |i| > 1:
 <p algorithm="structure member offset">
-  [=OffsetOfMember=](|S|, M<sub>i</sub>) = [=roundUp=]([=AlignOfMember=](|S|, M<sub>i</sub>), [=OffsetOfMember=](|S|, M<sub>i-1</sub>) + [=SizeOfMember=](|S|, M<sub>i-1</sub>))<br>
-  Where M<sub>i</sub> is the current member and M<sub>i-1</sub> is the previous member.
+  [=OffsetOfMember=](|S|, |i|) = [=roundUp=]([=AlignOfMember=](|S|, |i| ), [=OffsetOfMember=](|S|, |i|-1) + [=SizeOfMember=](|S|, |i|-1))<br>
 </p>
 
 <div class='example wgsl' heading='Layout of structures using implicit member sizes and alignments'>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1710,7 +1710,6 @@ The <dfn>alignment</dfn> of a type is a constraint on where values of that type 
 as an integer:
 a type's alignment must evenly divide
 the byte address of the starting [=memory location=] of a value of that type.
-must be evenly divisible by the type's alignment.
 Alignments enable use of more efficient hardware instructions for accessing the values,
 or satisfy more restrictive hardware requirements on certain
 storage classes. (See [storage class layout constraints](#storage-class-layout-constraints)).


### PR DESCRIPTION


    Streamline structure layout section
    
    - Make 'alignment' and 'size' defined terms
    - Don't repeat the rule for overall struct alignment and size.
    - Rename "Structure Layout Rules" to "Structure Member Layout" because
      that's all that remains.
      - Streamline the text in this section.


    Simplify array layout section
    
    - move definition of element stride to start of memory layout section
    - remove redundant explanation of array size and alignment
    - remaining material in that example is just examples
    - Add more detail to examples, including computing N_runtime for
      runtime-sized array


Fixes: #2497