### PR TITLE
Refine the supported swapchain formats

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9282,8 +9282,8 @@ interface GPUCanvasContext {
 The <dfn dfn>supported context formats</dfn> are a [=set=] of {{GPUTextureFormat}}s that must be
 supported when specified as a {{GPUCanvasConfiguration}}.{{GPUCanvasConfiguration/format}}
 regardless of the given {{GPUCanvasConfiguration}}.{{GPUCanvasConfiguration/device}},
-initially set to: &laquo;{{GPUTextureFormat/"bgra8unorm"}}, {{GPUTextureFormat/"bgra8unorm-srgb"}},
-{{GPUTextureFormat/"rgba8unorm"}}, {{GPUTextureFormat/"rgba8unorm-srgb"}}&raquo;.
+initially set to: &laquo;{{GPUTextureFormat/"bgra8unorm"}}, {{GPUTextureFormat/"rgba8unorm"}},
+{{GPUTextureFormat/"rgba16float"}}&raquo;.
 
 <script type=idl>
 


### PR DESCRIPTION
This removes the "-srgb" formats, and adds "rgba16float" and "rgb10a2unorm".

Fixes: #1231


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jchen10/gpuweb/pull/2522.html" title="Last updated on Jan 21, 2022, 5:55 AM UTC (0549a5d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2522/5a0cbb2...jchen10:0549a5d.html" title="Last updated on Jan 21, 2022, 5:55 AM UTC (0549a5d)">Diff</a>