### PR TITLE
Rename storage class into address space

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4933,11 +4933,11 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
                     If |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/type}} is:
                     <dl class=switch>
                         : {{GPUBufferBindingType/"uniform"}}
-                        :: |variable| is declared with the storage class `uniform`.
+                        :: |variable| is declared with the address space `uniform`.
                         : {{GPUBufferBindingType/"storage"}}
-                        :: |variable| is declared with the storage class `storage` and access mode `read_write`.
+                        :: |variable| is declared with the address space `storage` and access mode `read_write`.
                         : {{GPUBufferBindingType/"read-only-storage"}}
-                        :: |variable| is declared with the storage class `storage` and access mode `read`.
+                        :: |variable| is declared with the address space `storage` and access mode `read`.
                     </dl>
 
                 ::

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4933,11 +4933,11 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
                     If |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/type}} is:
                     <dl class=switch>
                         : {{GPUBufferBindingType/"uniform"}}
-                        :: |variable| is declared with the address space `uniform`.
+                        :: |variable| is declared with address space `uniform`.
                         : {{GPUBufferBindingType/"storage"}}
-                        :: |variable| is declared with the address space `storage` and access mode `read_write`.
+                        :: |variable| is declared with address space `storage` and access mode `read_write`.
                         : {{GPUBufferBindingType/"read-only-storage"}}
-                        :: |variable| is declared with the address space `storage` and access mode `read`.
+                        :: |variable| is declared with address space `storage` and access mode `read`.
                     </dl>
 
                 ::

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1088,12 +1088,12 @@ An <dfn noexport>atomic type</dfn> encapsulates a [=scalar=] type such that:
 An expression must not evaluate to an atomic type.
 
 Atomic types may only be instantiated by variables in the [=address spaces/workgroup=]
-space or by [=storage buffer=] variables with a [=access/read_write=] access mode.
-The [=memory scope=] of operations on the type is determined by the memory
-class it is instantiated in.
-Atomic types in the [=address spaces/workgroup=] s[ace] have a memory
+address space or by [=storage buffer=] variables with a [=access/read_write=] access mode.
+The [=memory scope=] of operations on the type is determined by the [=address space=]
+it is instantiated in.
+Atomic types in the [=address spaces/workgroup=] address space have a memory
 scope of `Workgroup`, while those in the [=address spaces/storage=]
-class have a memory scope of `QueueFamily`.
+address space have a memory scope of `QueueFamily`.
 
 An <dfn noexport>atomic modification</dfn> is any
 [[#memory-operation|operation]] on an atomic object which sets the content of
@@ -1656,7 +1656,7 @@ For a write-only storage texture, the underlying texels are write-only.
 
 <table class='data'>
   <thead>
-    <tr><th>WGSL address space<th>SPIR-V address space
+    <tr><th>WGSL address space<th>SPIR-V storage class
   </thead>
   <tr><td>uniform<td>Uniform
   <tr><td>workgroup<td>Workgroup
@@ -2004,7 +2004,7 @@ have different buffer layout constraints which are described in this section.
 
 All structure and array types directly or indirectly referenced by a variable
 must obey the constraints of the variable's address space.
-Violations of a address space constraint results in a [=shader-creation error=].
+Violations of an address space constraint results in a [=shader-creation error=].
 
 In this section we define <dfn noexport>RequiredAlignOf</dfn>(|S|, |C|) as the
 byte offset [=alignment=] requirement of values of host-shareable type |S| when
@@ -2140,26 +2140,26 @@ The access mode of a memory view must be supported by the address space. See [[#
     <tr><th>Constraint<th>Type<th>Description
   </thead>
   <tr algorithm="memory reference type">
-    <td style="width:25%">|SC| is a [=address space=],<br>|T| is a [=storable=] type,<br>|A| is an [=access mode=]
-    <td>ref&lt;|SC|,|T|,|A|&gt;
+    <td style="width:25%">|S| is a [=address space=],<br>|T| is a [=storable=] type,<br>|A| is an [=access mode=]
+    <td>ref&lt;|S|,|T|,|A|&gt;
     <td>The <dfn noexport>reference type</dfn>
-        identified with the set of [=memory views=] for memory locations in |SC| holding values of type |T|,
+        identified with the set of [=memory views=] for memory locations in |S| holding values of type |T|,
         supporting memory accesses described by mode |A|.<br>
         In this context |T| is known as the <dfn noexport>store type</dfn>.<br>
         Reference types are not written in [SHORTNAME] program source;
         instead they are used to analyze a [SHORTNAME] program.
   <tr algorithm="pointer type">
-    <td>|SC| is a [=address space=],<br>|T| is a [=storable=] type,<br>|A| is an [=access mode=]
-    <td>ptr&lt;|SC|,|T|,|A|&gt;
+    <td>|S| is a [=address space=],<br>|T| is a [=storable=] type,<br>|A| is an [=access mode=]
+    <td>ptr&lt;|S|,|T|,|A|&gt;
     <td>The <dfn noexport>pointer type</dfn>
-        identified with the set of [=memory views=] for memory locations in |SC| holding values of type |T|,
+        identified with the set of [=memory views=] for memory locations in |S| holding values of type |T|,
         supporting memory accesses described by mode |A|.<br>
         In this context |T| is known as the <dfn noexport>pointee type</dfn>.<br>
         Pointer types may appear in [SHORTNAME] program source.
 </table>
 
-When *analyzing* a [SHORTNAME] program, reference and pointer types are fully parameterized by a address space,
-a storable type, and an access mode.
+When *analyzing* a [SHORTNAME] program, reference and pointer types are fully parameterized by
+an address space, a storable type, and an access mode.
 In code examples in this specification, the comments show this fully parameterized form.
 
 However, in [SHORTNAME] *source* text:
@@ -2192,7 +2192,7 @@ Reference types and pointer types are both sets of memory views:
 a particular memory view is associated with a unique reference value and also a unique pointer value:
 
 <blockquote algorithm="pointer reference correspondence">
-Each pointer value |p| of type ptr&lt;|SC|,|T|,|A|&gt; corresponds to a unique reference value |r| of type ref&lt;|SC|,|T|,|A|&gt;,
+Each pointer value |p| of type ptr&lt;|S|,|T|,|A|&gt; corresponds to a unique reference value |r| of type ref&lt;|S|,|T|,|A|&gt;,
 and vice versa,
 where |p| and |r| describe the same memory view.
 </blockquote>
@@ -3376,7 +3376,7 @@ Variables at [=module scope=] are restricted as follows:
     * Must be declared with an explicit address space decoration.
     * Must use a [=store type=] as described in [[#address-space]].
 * If the [=store type=] is a texture type or a sampler type, then the variable declaration must not
-    have a address space decoration.  The address space will always be [=address spaces/handle=].
+    have an address space decoration.  The address space will always be [=address spaces/handle=].
 
 A variable in the [=address spaces/uniform=] address space is a <dfn noexport>uniform buffer</dfn> variable.
 Its [=store type=] must be a [=host-shareable=] [=constructible=] type,
@@ -3513,7 +3513,7 @@ For a variable declared in function scope:
        var delta: i32;            // Another variable in the function address space.
        var sum: f32 = 0.0;        // A function address space variable with initializer.
        var pi = 3.14159;          // Infer the f32 store type from the initializer.
-       let unit: i32 = 1;         // Let-declared constants don't use a address space.
+       let unit: i32 = 1;         // Let-declared constants don't use an address space.
     }
   </xmp>
 </div>
@@ -4340,47 +4340,47 @@ See [[#sync-builtin-functions]].
     <tr><th>Precondition<th>Conclusion<th>Description
   </thead>
   <tr algorithm="first vector component reference selection">
-       <td>|r|: ref&lt;|SC|,vec|N|&lt;|T|&gt;&gt;<br>
+       <td>|r|: ref&lt;|S|,vec|N|&lt;|T|&gt;&gt;<br>
        <td class="nowrap">
-           |r|`.x`: ref&lt;|SC|,|T|&gt;<br>
-           |r|`.r`: ref&lt;|SC|,|T|&gt;<br>
+           |r|`.x`: ref&lt;|S|,|T|&gt;<br>
+           |r|`.r`: ref&lt;|S|,|T|&gt;<br>
        <td>Compute a reference to the first component of the vector referenced by the reference |r|.<br>
            The [=originating variable=] of the resulting reference is
            the same as the originating variable of |r|.<br>
            (OpAccessChain with index value 0)
   <tr algorithm="second vector component reference selection">
-       <td>|r|: ref&lt;|SC|,vec|N|&lt;|T|&gt;&gt;<br>
+       <td>|r|: ref&lt;|S|,vec|N|&lt;|T|&gt;&gt;<br>
        <td class="nowrap">
-           |r|`.y`: ref&lt;|SC|,|T|&gt;<br>
-           |r|`.g`: ref&lt;|SC|,|T|&gt;<br>
+           |r|`.y`: ref&lt;|S|,|T|&gt;<br>
+           |r|`.g`: ref&lt;|S|,|T|&gt;<br>
        <td>Compute a reference to the second component of the vector referenced by the reference |r|.<br>
            The [=originating variable=] of the resulting reference is
            the same as the originating variable of |r|.<br>
            (OpAccessChain with index value 1)
   <tr algorithm="third vector component reference selection">
-       <td>|r|: ref&lt;|SC|,vec|N|&lt;|T|&gt;&gt;<br>
+       <td>|r|: ref&lt;|S|,vec|N|&lt;|T|&gt;&gt;<br>
            |N| is 3 or 4
        <td class="nowrap">
-           |r|`.z`: ref&lt;|SC|,|T|&gt;<br>
-           |r|`.b`: ref&lt;|SC|,|T|&gt;<br>
+           |r|`.z`: ref&lt;|S|,|T|&gt;<br>
+           |r|`.b`: ref&lt;|S|,|T|&gt;<br>
        <td>Compute a reference to the third component of the vector referenced by the reference |r|.<br>
            The [=originating variable=] of the resulting reference is
            the same as the originating variable of |r|.<br>
            (OpAccessChain with index value 2)
   <tr algorithm="fourth vector component reference selection">
-       <td>|r|: ref&lt;|SC|,vec4&lt;|T|&gt;&gt;<br>
+       <td>|r|: ref&lt;|S|,vec4&lt;|T|&gt;&gt;<br>
        <td class="nowrap">
-           |r|`.w`: ref&lt;|SC|,|T|&gt;<br>
-           |r|`.a`: ref&lt;|SC|,|T|&gt;<br>
+           |r|`.w`: ref&lt;|S|,|T|&gt;<br>
+           |r|`.a`: ref&lt;|S|,|T|&gt;<br>
        <td>Compute a reference to the fourth component of the vector referenced by the reference |r|.<br>
            The [=originating variable=] of the resulting reference is
            the same as the originating variable of |r|.<br>
            (OpAccessChain with index value 3)
   <tr algorithm="vector indexed component reference selection">
-       <td>|r|: ref&lt;|SC|,vec|N|&lt;|T|&gt;&gt;<br>
+       <td>|r|: ref&lt;|S|,vec|N|&lt;|T|&gt;&gt;<br>
           |i|: [INT]
        <td class="nowrap">
-           |r|[|i|] : ref&lt;|SC|,|T|&gt;
+           |r|[|i|] : ref&lt;|S|,|T|&gt;
        <td>Compute a reference to the |i|'<sup>th</sup> component of the vector
            referenced by the reference |r|.
 
@@ -4419,10 +4419,10 @@ See [[#sync-builtin-functions]].
   </thead>
   <tr algorithm="matrix indexed column vector reference selection">
        <td class="nowrap">
-          |r|: ref&lt;|SC|,mat|N|x|M|&lt;|T|&gt;&gt;<br>
+          |r|: ref&lt;|S|,mat|N|x|M|&lt;|T|&gt;&gt;<br>
           |i|: [INT]
        <td class="nowrap">
-           |r|[|i|] : ref&lt;vec|M|&lt;|SC|,|T|&gt;&gt;
+           |r|[|i|] : ref&lt;vec|M|&lt;|S|,|T|&gt;&gt;
        <td>Compute a reference to the |i|'<sup>th</sup> column vector of the
            matrix referenced by the reference |r|.
 
@@ -4461,10 +4461,10 @@ See [[#sync-builtin-functions]].
   </thead>
   <tr algorithm="fixed-size array indexed reference selection">
        <td class="nowrap">
-          |r|: ref&lt;|SC|,array&lt;|T|,|N|&gt;&gt;<br>
+          |r|: ref&lt;|S|,array&lt;|T|,|N|&gt;&gt;<br>
           |i|: [INT]
        <td class="nowrap">
-           |r|[|i|] : ref&lt;|SC|,|T|&gt;
+           |r|[|i|] : ref&lt;|S|,|T|&gt;
        <td>Compute a reference to the |i|'<sup>th</sup> element of the array
            referenced by the reference |r|.
 
@@ -4475,10 +4475,10 @@ See [[#sync-builtin-functions]].
            the same as the originating variable of |r|.<br>
            (OpAccessChain)
   <tr algorithm="array indexed reference selection">
-       <td>|r|: ref&lt;|SC|,array&lt;|T|&gt;&gt;<br>
+       <td>|r|: ref&lt;|S|,array&lt;|T|&gt;&gt;<br>
           |i|: [INT]
        <td class="nowrap">
-           |r|[|i|] : ref&lt;|SC|,|T|&gt;
+           |r|[|i|] : ref&lt;|S|,|T|&gt;
        <td>Compute a reference to the |i|'<sup>th</sup> element of the
            runtime-sized array referenced by the reference |r|.
 
@@ -4519,9 +4519,9 @@ See [[#sync-builtin-functions]].
        <td class="nowrap">
           |S| is a structure type<br>
           |M| is the name of a member of |S|, having type |T|<br>
-          |r|: ref&lt;|SC|,|S|&gt;<br>
+          |r|: ref&lt;|S|,|S|&gt;<br>
        <td class="nowrap">
-           |r|.|M|: ref&lt;|SC|,|T|&gt;
+           |r|.|M|: ref&lt;|S|,|T|&gt;
        <td>Given a reference to a structure, the result is a reference to the structure member with identifier name |M|.<br>
            The [=originating variable=] of the resulting reference is
            the same as the originating variable of |r|.<br>
@@ -5014,10 +5014,10 @@ See [[#function-call-statement]].
   <tr algorithm="variable reference">
        <td>
           |v| is an [=identifier=] [=resolves|resolving=] to
-          an [=in scope|in-scope=] variable declared in [=address space=] |SC|
+          an [=in scope|in-scope=] variable declared in [=address space=] |S|
           with [=store type=] |T|
        <td class="nowrap">
-          |v|: ref&lt;|SC|,|T|&gt;
+          |v|: ref&lt;|S|,|T|&gt;
        <td>Result is a reference to the memory for the named variable |v|.
 </table>
 
@@ -5049,16 +5049,16 @@ The <dfn noexport>address-of</dfn> operator converts a reference to its correspo
   </thead>
   <tr algorithm="address-of expression">
        <td>
-          |r|: ref&lt;|SC|,|T|,|A|&gt;
+          |r|: ref&lt;|S|,|T|,|A|&gt;
        <td class="nowrap">
-          `&`|r|: ptr&lt;|SC|,|T|,|A|&gt;
+          `&`|r|: ptr&lt;|S|,|T|,|A|&gt;
        <td>Result is the pointer value corresponding to the
            same [=memory view=] as the reference value |r|.
 
            If |r| is an [=invalid memory reference=], then the resulting
            pointer is also an invalid memory reference.
 
-           It is a [=shader-creation error=] if |SC| is the [=address spaces/handle=] address space.
+           It is a [=shader-creation error=] if |S| is the [=address spaces/handle=] address space.
 
            It is a [=shader-creation error=] if |r| is a
            [[#component-reference-from-vector-reference|reference to a vector component]].
@@ -5076,9 +5076,9 @@ The <dfn noexport>indirection</dfn> operator converts a pointer to its correspon
   </thead>
   <tr algorithm="indirection expression">
        <td>
-          |p|: ptr&lt;|SC|,|T|,|A|&gt;
+          |p|: ptr&lt;|S|,|T|,|A|&gt;
        <td class="nowrap">
-          `*`|p|: ref&lt;|SC|,|T|,|A|&gt;
+          `*`|p|: ref&lt;|S|,|T|,|A|&gt;
        <td>Result is the reference value corresponding to the
            same [=memory view=] as the pointer value |p|.
 
@@ -5332,11 +5332,11 @@ In this case the value of the [=right-hand side=] is written to the memory refer
     <tr><th style="width:40%">Precondition<th>Statement<th>Description
   </thead>
   <tr algorithm="updating assignment">
-    <td>|r|: ref<|SC|,|T|,|A|>,<br>
+    <td>|r|: ref<|S|,|T|,|A|>,<br>
         |A| is [=access/write=] or [=access/read_write=]<br>
         |e|: |T|,<br>
         |T| is a [=constructible=] type,<br>
-        |SC| is a writable [=address space=]
+        |S| is a writable [=address space=]
     <td class="nowrap">|r| = |e|
     <td>Evaluates |e|, evaluates |r|, then writes the value computed for |e| into
         the [=memory locations=] referenced by |r|.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -194,7 +194,7 @@ A [SHORTNAME] program is organized into:
 * Statements, which are declarations or units of executable behaviour.
 * Literals, which are text representations for pure mathematical values.
 * Constants, each providing a name for a value computed at a specific time.
-* Variables, each providing a name for memory storage for holding a value.
+* Variables, each providing a name for memory holding a value.
 * Expressions, each of which combines a set of values to produce a result value.
 * Types, each of which describes:
     * A set of values.
@@ -236,13 +236,13 @@ Invocations in a shader stage share access to certain variables:
 * All invocations in the stage share the resources in the shader interface.
 * In a [=compute shader stage|compute shader=], invocations in the same
      [=compute shader stage/workgroup=] share
-     variables in the [=storage classes/workgroup=] [=storage class=].
+     variables in the [=address spaces/workgroup=] [=address space=].
      Invocations in different workgroups do not share those variables.
 
 However, the invocations act on different sets of pipeline inputs, including built-in inputs
 that provide an identifying value to distinguish an invocation from its peers.
-Also, each invocation has its own independent memory storage space in the form
-of variables in the [=storage classes/private=] and [=storage classes/function=] storage classes.
+Also, each invocation has its own independent memory space in the form
+of variables in the [=address spaces/private=] and [=address spaces/function=] address spaces.
 
 Invocations within a shader stage execute concurrently, and may often execute in parallel.
 The shader author is responsible for ensuring the dynamic behaviour of the invocations
@@ -584,7 +584,7 @@ An attribute must not be specified more than once per object or type.
     <p algorithm="align constraint">
     If `align(`|n|`)` is applied to a member of |S|
     with type |T|, and |S| is the [=store type=]
-    or contained in the store type for a variable in storage class |C|,
+    or contained in the store type for a variable in address space |C|,
     then |n| must satisfy:
     |n|&nbsp;=&nbsp;|k|&nbsp;&times;&nbsp;[=RequiredAlignOf=](|T|,|C|)
     for some positive integer |k|.
@@ -1087,12 +1087,12 @@ An <dfn noexport>atomic type</dfn> encapsulates a [=scalar=] type such that:
 
 An expression must not evaluate to an atomic type.
 
-Atomic types may only be instantiated by variables in the [=storage classes/workgroup=]
-storage class or by [=storage buffer=] variables with a [=access/read_write=] access mode.
-The [=memory scope=] of operations on the type is determined by the storage
+Atomic types may only be instantiated by variables in the [=address spaces/workgroup=]
+space or by [=storage buffer=] variables with a [=access/read_write=] access mode.
+The [=memory scope=] of operations on the type is determined by the memory
 class it is instantiated in.
-Atomic types in the [=storage classes/workgroup=] storage class have a memory
-scope of `Workgroup`, while those in the [=storage classes/storage=] storage
+Atomic types in the [=address spaces/workgroup=] s[ace] have a memory
+scope of `Workgroup`, while those in the [=address spaces/storage=]
 class have a memory scope of `QueueFamily`.
 
 An <dfn noexport>atomic modification</dfn> is any
@@ -1106,7 +1106,7 @@ That is, during execution of a shader stage, for each atomic object *A*, all
 agents observe the same order of modification operations applied to *A*.
 The ordering for distinct atomic objects may not be related in any way; no
 causality is implied.
-Note that variables in [=storage classes/workgroup=] storage are shared within a
+Note that variables in [=address spaces/workgroup=] space are shared within a
 [=compute shader stage/workgroup=], but are not shared between different
 workgroups.
 
@@ -1221,7 +1221,7 @@ Two array types are the same if and only if all of the following are true:
 </div>
 
 Note: The valid use of an array sized by an overridable constant is as the store type
-of a variable in [=storage classes/workgroup=] storage.
+of a variable in [=address spaces/workgroup=] space.
 
 <div class='example wgsl global-scope' heading="Workgroup variables sized by overridable constants">
   <xmp>
@@ -1236,7 +1236,7 @@ of a variable in [=storage classes/workgroup=] storage.
 
     // An invalid example, because the overridable element count is only
     // valid for workgroup variables.
-    // var<private> bad_storage_class: array<i32,blockSize>;
+    // var<private> bad_address_space: array<i32,blockSize>;
   </xmp>
 </div>
 
@@ -1449,7 +1449,7 @@ The plain types with [=fixed footprint=] are any of:
 * a [=fixed-size array=] type, where its [=element count=] is a [=pipeline-overridable=]  constant.
 
 Note: The only valid use of a fixed-size array with an element count that is a pipeline-overridable constant is
-as the [=store type=] for a [=storage classes/workgroup=] variable.
+as the [=store type=] for a [=address spaces/workgroup=] variable.
 
 Note: A fixed-footprint type may contain an [=atomic type|atomic=] type, either directly or
 indirectly, while a [=constructible=] type must not.
@@ -1577,54 +1577,54 @@ Note: Both IO-shareable and host-shareable types have concrete sizes, but counte
 IO-shareable types are sized by a location-count metric, see [[#input-output-locations]].
 Host-shareable types are sized by a byte-count metric, see [[#memory-layouts]].
 
-### Storage Classes ### {#storage-class}
+### Address spaces ### {#address-space}
 
-Memory locations are partitioned into <dfn noexport>storage classes</dfn>.
-Each storage class has unique properties determining
+Memory locations are partitioned into <dfn noexport>address spaces</dfn>.
+Each address space has unique properties determining
 mutability, visibility, the values it may contain,
 and how to use variables with it.
 
-<table class='data' id="storage-class-table">
-  <caption>Storage Classes</caption>
+<table class='data' id="address-space-table">
+  <caption>Address Spaces</caption>
   <thead>
-    <tr><th>Storage class
+    <tr><th>Address space
         <th>Sharing among invocations
         <th>Supported access modes
         <th>Variable scope
         <th>Restrictions on stored values
         <th>Notes
   </thead>
-  <tr><td><dfn noexport dfn-for="storage classes">function</dfn>
+  <tr><td><dfn noexport dfn-for="address spaces">function</dfn>
       <td>Same invocation only
       <td>[=access/read_write=]
       <td>[=Function scope=]
       <td>[=Constructible=] type
       <td>
-  <tr><td><dfn noexport dfn-for="storage classes">private</dfn>
+  <tr><td><dfn noexport dfn-for="address spaces">private</dfn>
       <td>Same invocation only
       <td>[=access/read_write=]
       <td>[=Module scope=]
       <td>[=Constructible=] type
       <td>
-  <tr><td><dfn noexport dfn-for="storage classes">workgroup</dfn>
+  <tr><td><dfn noexport dfn-for="address spaces">workgroup</dfn>
       <td>Invocations in the same [=compute shader stage|compute shader=] [=compute shader stage/workgroup=]
       <td>[=access/read_write=]
       <td>[=Module scope=]
       <td>[=Plain type=] with [=fixed footprint=]
       <td>The [=element count=] of an outermost array may be a [=pipeline-overridable=] constant.
-  <tr><td><dfn noexport dfn-for="storage classes">uniform</dfn>
+  <tr><td><dfn noexport dfn-for="address spaces">uniform</dfn>
       <td>Invocations in the same [=shader stage=]
       <td>[=access/read=]
       <td>[=Module scope=]
       <td>[=Constructible=] [=host-shareable=] types
       <td>For [=uniform buffer=] variables
-  <tr><td><dfn noexport dfn-for="storage classes">storage</dfn>
+  <tr><td><dfn noexport dfn-for="address spaces">storage</dfn>
       <td>Invocations in the same [=shader stage=]
       <td> [=access/read_write=], [=access/read=] (default)
       <td>[=Module scope=]
       <td>[=Host-shareable=]
       <td>For [=storage buffer=] variables
-  <tr><td><dfn noexport dfn-for="storage classes">handle</dfn>
+  <tr><td><dfn noexport dfn-for="address spaces">handle</dfn>
       <td>Invocations in the same shader stage
       <td>[=access/read=]
       <td>[=Module scope=]
@@ -1641,7 +1641,7 @@ In most cases the underlying texels are read-only.
 For a write-only storage texture, the underlying texels are write-only.
 
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>storage_class</dfn> :
+  <dfn for=syntax>address_space</dfn> :
 
     | [=syntax/function=]
 
@@ -1656,7 +1656,7 @@ For a write-only storage texture, the underlying texels are write-only.
 
 <table class='data'>
   <thead>
-    <tr><th>WGSL storage class<th>SPIR-V storage class
+    <tr><th>WGSL address space<th>SPIR-V address space
   </thead>
   <tr><td>uniform<td>Uniform
   <tr><td>workgroup<td>Workgroup
@@ -1680,11 +1680,11 @@ which is the description of how the bytes in a buffer are organized into typed [
 
 The [=store type=] of a buffer variable must be [=host-shareable=], with fully elaborated memory layout, as described below.
 
-Each buffer variable must be declared in either the [=storage classes/uniform=] or [=storage classes/storage=] storage classes.
+Each buffer variable must be declared in either the [=address spaces/uniform=] or [=address spaces/storage=] address spaces.
 
 The memory layout of a type is significant only when evaluating an expression with:
-* a variable in the [=storage classes/uniform=] or [=storage classes/storage=] storage class, or
-* a pointer into the [=storage classes/uniform=] or [=storage classes/storage=] storage class.
+* a variable in the [=address spaces/uniform=] or [=address spaces/storage=] address space, or
+* a pointer into the [=address spaces/uniform=] or [=address spaces/storage=] address space.
 
 An 8-bit byte is the most basic unit of [=host-shareable=] memory.
 The terms defined in this section express counts of 8-bit bytes.
@@ -1714,7 +1714,7 @@ a type's alignment must evenly divide
 the byte address of the starting [=memory location=] of a value of that type.
 Alignments enable use of more efficient hardware instructions for accessing the values,
 or satisfy more restrictive hardware requirements on certain
-storage classes. (See [storage class layout constraints](#storage-class-layout-constraints)).
+address spaces. (See [address space layout constraints](#address-space-layout-constraints)).
 
 Note: Each alignment value is always a power of two, by construction.
 
@@ -1947,7 +1947,7 @@ The buffer byte offset at which a value is placed must satisfy the type alignmen
 If a value of type |T| is placed
 at buffer offset |k|, then |k| = |c| &times; [=AlignOf=](|T|), for some non-negative integer |c|.
 
-The data will appear identically regardless of storage class.
+The data will appear identically regardless of the address space.
 
 When a value |V| of type [=u32=] or [=i32=] is placed at byte offset |k| of a
 host-shared buffer, then:
@@ -1997,28 +1997,28 @@ then:
    * The |i|'<sup>th</sup> member of the structure value is placed at byte offset |k| + [=OffsetOfMember=](|S|,|i|).
     See [[#structure-member-layout]].
 
-#### Storage Class Layout Constraints ####  {#storage-class-layout-constraints}
+#### Address Space Layout Constraints ####  {#address-space-layout-constraints}
 
-The [=storage classes/storage=] and [=storage classes/uniform=] storage classes
+The [=address spaces/storage=] and [=address spaces/uniform=] address spaces
 have different buffer layout constraints which are described in this section.
 
 All structure and array types directly or indirectly referenced by a variable
-must obey the constraints of the variable's storage class.
-Violations of a storage class constraint results in a [=shader-creation error=].
+must obey the constraints of the variable's address space.
+Violations of a address space constraint results in a [=shader-creation error=].
 
 In this section we define <dfn noexport>RequiredAlignOf</dfn>(|S|, |C|) as the
 byte offset [=alignment=] requirement of values of host-shareable type |S| when
-used in storage class |C|.
+used in address space |C|.
 
 <table class='data'>
   <caption>
     Alignment requirements of a host-shareable type for
-    [=storage classes/storage=] and [=storage classes/uniform=] storage classes
+    [=address spaces/storage=] and [=address spaces/uniform=] address spaces
   </caption>
   <thead>
     <tr><th>Host-shareable type |S|
-        <th>[=RequiredAlignOf=](|S|, [=storage classes/storage=])
-        <th>[=RequiredAlignOf=](|S|, [=storage classes/uniform=])
+        <th>[=RequiredAlignOf=](|S|, [=address spaces/storage=])
+        <th>[=RequiredAlignOf=](|S|, [=address spaces/uniform=])
   </thead>
   <tr><td>[=i32=], [=u32=], or [=f32=]
       <td>[=AlignOf=](|S|)
@@ -2049,7 +2049,7 @@ used in storage class |C|.
 
 Structure members of type |T| must have a byte offset
 from the start of the structure that is a multiple of the [=RequiredAlignOf=](|T|, |C|)
-for the storage class |C|:
+for the address space |C|:
 
 <p algorithm="structure member minimum alignment">
     [=OffsetOfMember=](|S|, |M|) = |k| &times; [=RequiredAlignOf=](|T|, C)<br>
@@ -2057,7 +2057,7 @@ for the storage class |C|:
 </p>
 
 Arrays of element type |T| must have an [=element stride=] that is a
-multiple of the [=RequiredAlignOf=](|T|, |C|) for the storage class |C|:
+multiple of the [=RequiredAlignOf=](|T|, |C|) for the address space |C|:
 
 <p algorithm="array element minimum alignment">
     [=StrideOf=](array<|T|, |N|>) = |k| &times; [=RequiredAlignOf=](|T|, C)<br>
@@ -2071,7 +2071,7 @@ of [=AlignOf=](|T|). Data is laid out with the rules defined in previous
 sections and then the resulting layout is validated against the
 [=RequiredAlignOf=](|T|, |C|) rules.
 
-The [=storage classes/uniform=] storage class also requires that:
+The [=address spaces/uniform=] address space also requires that:
 * Array elements are aligned to 16 byte boundaries.
     That is, [=StrideOf=](array&lt;|T|,|N|&gt;) = 16 &times; |k|' for some positive integer |k|'.
 * If a structure member itself has a structure type `S`, then the number of
@@ -2083,7 +2083,7 @@ on structure members to satisfy layout requirements for uniform buffers.
 In particular, these techniques can be used mechanically transform a GLSL buffer with std140 layout
 to WGSL.
 
-<div class='example wgsl global-scope' heading='Satisfying offset requirements for uniform storage class'>
+<div class='example wgsl global-scope' heading='Satisfying offset requirements for uniform address space'>
   <xmp highlight='rust'>
     struct S {
       x: f32;
@@ -2102,7 +2102,7 @@ to WGSL.
   </xmp>
 </div>
 
-<div class='example wgsl global-scope' heading='Satisfying stride requirements for uniform storage class'>
+<div class='example wgsl global-scope' heading='Satisfying stride requirements for uniform address space'>
   <xmp highlight='rust'>
     struct small_stride {
       a: array<f32,8>; // stride 4
@@ -2126,11 +2126,11 @@ also often read values from memory or write values to memory, via [=memory acces
 Each memory access is performed via a [=memory view=].
 
 A <dfn noexport>memory view</dfn> comprises:
-* a set of [=memory locations=] in a particular [=storage class=],
+* a set of [=memory locations=] in a particular [=address space=],
 * an interpretation of the contents of those locations as a [SHORTNAME] [=type=], and
 * an [=access mode=].
 
-The access mode of a memory view must be supported by the storage class. See [[#storage-class]].
+The access mode of a memory view must be supported by the address space. See [[#address-space]].
 
 [SHORTNAME] has two kinds of types for representing memory views:
 [=reference types=] and [=pointer types=].
@@ -2140,7 +2140,7 @@ The access mode of a memory view must be supported by the storage class. See [[#
     <tr><th>Constraint<th>Type<th>Description
   </thead>
   <tr algorithm="memory reference type">
-    <td style="width:25%">|SC| is a [=storage class=],<br>|T| is a [=storable=] type,<br>|A| is an [=access mode=]
+    <td style="width:25%">|SC| is a [=address space=],<br>|T| is a [=storable=] type,<br>|A| is an [=access mode=]
     <td>ref&lt;|SC|,|T|,|A|&gt;
     <td>The <dfn noexport>reference type</dfn>
         identified with the set of [=memory views=] for memory locations in |SC| holding values of type |T|,
@@ -2149,7 +2149,7 @@ The access mode of a memory view must be supported by the storage class. See [[#
         Reference types are not written in [SHORTNAME] program source;
         instead they are used to analyze a [SHORTNAME] program.
   <tr algorithm="pointer type">
-    <td>|SC| is a [=storage class=],<br>|T| is a [=storable=] type,<br>|A| is an [=access mode=]
+    <td>|SC| is a [=address space=],<br>|T| is a [=storable=] type,<br>|A| is an [=access mode=]
     <td>ptr&lt;|SC|,|T|,|A|&gt;
     <td>The <dfn noexport>pointer type</dfn>
         identified with the set of [=memory views=] for memory locations in |SC| holding values of type |T|,
@@ -2158,14 +2158,14 @@ The access mode of a memory view must be supported by the storage class. See [[#
         Pointer types may appear in [SHORTNAME] program source.
 </table>
 
-When *analyzing* a [SHORTNAME] program, reference and pointer types are fully parameterized by a storage class,
+When *analyzing* a [SHORTNAME] program, reference and pointer types are fully parameterized by a address space,
 a storable type, and an access mode.
 In code examples in this specification, the comments show this fully parameterized form.
 
 However, in [SHORTNAME] *source* text:
 * Reference types must not appear.
 * Pointer types may appear.  A pointer type is spelled with parameterization by:
-    * storage class,
+    * address space,
     * store type, and
     * sometimes by access mode, as specified in [[#access-mode-defaults]].
 
@@ -2173,14 +2173,14 @@ However, in [SHORTNAME] *source* text:
   <xmp highlight='rust'>
     fn my_function(
       /* 'ptr<function,i32,read_write>' is the type of a pointer value that references
-         storage for keeping an 'i32' value, using memory locations in the 'function'
-         storage class.  Here 'i32' is the pointee type.
+         memory for keeping an 'i32' value, using memory locations in the 'function'
+         address space.  Here 'i32' is the pointee type.
          The implied access mode is 'read_write'. See below for access mode defaults. */
       ptr_int: ptr<function,i32>,
 
       // 'ptr<private,array<f32,50>,read_write>' is the type of a pointer value that
-      // refers to storage for keeping an array of 50 elements of type 'f32', using
-      // memory locations in the 'private' storage class.
+      // refers to memory for keeping an array of 50 elements of type 'f32', using
+      // memory locations in the 'private' address space.
       // Here the pointee type is 'array<f32,50>'.
       // The implied access mode is 'read_write'. See below for access mode defaults.
       ptr_array: ptr<private, array<f32, 50>>
@@ -2201,12 +2201,12 @@ where |p| and |r| describe the same memory view.
 
 The access mode for a memory view is often determined by context:
 
-* The [=storage classes/storage=] storage class supports both [=access/read=] and [=access/read_write=] access modes.
-* Each other storage class supports only one access mode, as described in the <a href="#storage-class-table">storage class</a> table.
+* The [=address spaces/storage=] address space supports both [=access/read=] and [=access/read_write=] access modes.
+* Each other address space supports only one access mode, as described in the <a href="#address-space-table">address space</a> table.
 
 When writing a [=variable declaration=] or a [=pointer type=] in [SHORTNAME] source:
-* For the [=storage classes/storage=] storage class, the access mode is optional, and defaults to [=access/read=].
-* For other storage classes, the access mode must not be written.
+* For the [=address spaces/storage=] address space, the access mode is optional, and defaults to [=access/read=].
+* For other address spaces, the access mode must not be written.
 
 ### Originating variable ### {#originating-variable-section}
 
@@ -2312,7 +2312,7 @@ Defining references in this way enables simple idiomatic use of variables:
 Defining pointers in this way enables two key use cases:
 
 * Using a let declaration with pointer type, to form a short name for part of the contents of a variable.
-* Using a formal parameter of a function to refer to the storage of a variable that is accessible to the [=calling function=].
+* Using a formal parameter of a function to refer to the memory of a variable that is accessible to the [=calling function=].
     * The call to such a function must supply a pointer value for that operand.
         This often requires using an [=address-of=] operation (unary `&`) to get a pointer to the variable's contents.
 
@@ -2369,7 +2369,7 @@ Note: The following examples use [SHORTNAME] features explained later in this sp
 
       // Modify the contents of 'i' so it will contain 1.
       // Use unary '&' to get a pointer value for 'i'.
-      // This is a clear signal that the called function has access to the storage
+      // This is a clear signal that the called function has access to the memory
       // for 'i', and may modify it.
       add_one(&i);
       let one: i32 = i;  // 'one' has value 1.
@@ -2381,7 +2381,7 @@ Note: The following examples use [SHORTNAME] features explained later in this sp
 
 A reference value is formed in one of the following ways:
 
-* The [=identifier=] [=resolves|resolving=] to an [=in scope|in-scope=] variable *v* denotes the reference value for *v*'s storage.
+* The [=identifier=] [=resolves|resolving=] to an [=in scope|in-scope=] variable *v* denotes the reference value for *v*'s memory.
     * The resolved variable is the [=originating variable=] for the reference.
 * Use the [=indirection=] (unary `*`) operation on a pointer.
     * The originating variable of the result is defined as the originating variable of the pointer.
@@ -2413,20 +2413,20 @@ In all cases, the access mode of the result is the same as the access mode of th
         weight: f32;
     }
     var<private> person: S;
-    // Uses of 'person' denote the reference to the storage underlying the variable,
+    // Uses of 'person' denote the reference to the memory underlying the variable,
     // and will have type ref<private,S,read_write>.
 
     fn f() {
         var uv: vec2<f32>;
-        // Uses of 'uv' denote the reference to the storage underlying the variable,
+        // Uses of 'uv' denote the reference to the memory underlying the variable,
         // and will have type ref<function,vec2<f32>,read_write>.
 
         // Evaluate the left-hand side of the assignment:
         //   Evaluate 'uv.x' to yield a reference:
-        //   1. First evaluate 'uv', yielding a reference to the storage for
+        //   1. First evaluate 'uv', yielding a reference to the memory for
         //      the 'uv' variable. The result has type ref<function,vec2<f32>,read_write>.
         //   2. Then apply the '.x' vector access phrase, yielding a reference to
-        //      the storage for the first component of the vector pointed at by the
+        //      the memory for the first component of the vector pointed at by the
         //      reference value from the previous step.
         //      The result has type ref<function,f32,read_write>.
         // Evaluating the right-hand side of the assignment yields the f32 value 1.0.
@@ -2435,10 +2435,10 @@ In all cases, the access mode of the result is the same as the access mode of th
 
         // Evaluate the left-hand side of the assignment:
         //   Evaluate 'uv[1]' to yield a reference:
-        //   1. First evaluate 'uv', yielding a reference to the storage for
+        //   1. First evaluate 'uv', yielding a reference to the memory for
         //      the 'uv' variable. The result has type ref<function,vec2<f32>,read_write>.
         //   2. Then apply the '[1]' array index phrase, yielding a reference to
-        //      the storage for second component of the vector referenced from
+        //      the memory for second component of the vector referenced from
         //      the previous step.  The result has type ref<function,f32,read_write>.
         // Evaluating the right-hand side of the assignment yields the f32 value 2.0.
         // Store the f32 value 2.0 into the storage memory locations referenced by uv[1].
@@ -2446,10 +2446,10 @@ In all cases, the access mode of the result is the same as the access mode of th
 
         var m: mat3x2<f32>;
         // When evaluating 'm[2]':
-        // 1. First evaluate 'm', yielding a reference to the storage for
+        // 1. First evaluate 'm', yielding a reference to the memory for
         //    the 'm' variable. The result has type ref<function,mat3x2<f32>,read_write>.
         // 2. Then apply the '[2]' array index phrase, yielding a reference to
-        //    the storage for the third column vector pointed at by the reference
+        //    the memory for the third column vector pointed at by the reference
         //    value from the previous step.
         //    Therefore the 'm[2]' expression has type ref<function,vec2<f32>,read_write>.
         // The 'let' declaration is for type vec2<f32>, so the declaration
@@ -2462,10 +2462,10 @@ In all cases, the access mode of the result is the same as the access mode of th
 
         var A: array<i32,5>;
         // When evaluating 'A[4]'
-        // 1. First evaluate 'A', yielding a reference to the storage for
+        // 1. First evaluate 'A', yielding a reference to the memory for
         //    the 'A' variable. The result has type ref<function,array<i32,5>,read_write>.
         // 2. Then apply the '[4]' array index phrase, yielding a reference to
-        //    the storage for the fifth element of the array referenced by
+        //    the memory for the fifth element of the array referenced by
         //    the reference value from the previous step.
         //    The result value has type ref<function,i32,read_write>.
         // The let declaration requires the right-hand-side to be of type i32.
@@ -2476,11 +2476,11 @@ In all cases, the access mode of the result is the same as the access mode of th
         let A_4_value: i32 = A[4];
 
         // When evaluating 'person.weight'
-        // 1. First evaluate 'person', yielding a reference to the storage for
+        // 1. First evaluate 'person', yielding a reference to the memory for
         //    the 'person' variable declared at module scope.
         //    The result has type ref<private,S,read_write>.
         // 2. Then apply the '.weight' member access phrase, yielding a reference to
-        //    the storage for the second member of the memory referenced by
+        //    the memory for the second member of the memory referenced by
         //    the reference value from the previous step.
         //    The result has type ref<private,f32,read_write>.
         // The let declaration requires the right-hand-side to be of type f32.
@@ -2507,11 +2507,11 @@ In all cases, the access mode of the result is the same as the access mode of th
 
 <div class='example wgsl' heading='Pointer from a variable'>
   <xmp highlight='rust'>
-    // Declare a variable in the private storage class, for storing an f32 value.
+    // Declare a variable in the private address space, for storing an f32 value.
     var<private> x: f32;
 
     fn f() {
-        // Declare a variable in the function storage class, for storing an i32 value.
+        // Declare a variable in the function address space, for storing an i32 value.
         var y: i32;
 
         // The name 'x' resolves to the module-scope variable 'x',
@@ -2519,7 +2519,7 @@ In all cases, the access mode of the result is the same as the access mode of th
         // Applying the unary '&' operator converts the reference to a pointer.
         // The access mode is the same as the access mode of the original variable, so
         // the fully specified type is ptr<private,f32,read_write>.  But read_write
-        // is the default access mode for function storage class, so read_write does not
+        // is the default access mode for function address space, so read_write does not
         // have to be spelled in this case
         let x_ptr: ptr<private,f32> = &x;
 
@@ -2564,12 +2564,12 @@ In particular:
 * In [SHORTNAME] there is no way to change the access mode of a pointer or reference.
     * By comparison, C++ automatically converts a non-const pointer to a const pointer,
         and has a `const_cast` to convert a const value to a non-const value.
-* In [SHORTNAME] there is no way to allocate new storage from a "heap".
+* In [SHORTNAME] there is no way to allocate new memory from a "heap".
 * In [SHORTNAME] there is no way to explicitly destroy a variable.
-    The storage for a [SHORTNAME] variable becomes inaccessible only when the variable goes out of scope.
+    The memory for a [SHORTNAME] variable becomes inaccessible only when the variable goes out of scope.
 
 Note: From the above rules, it is not possible to form a "dangling" pointer,
-i.e. a pointer that does not reference the storage for a valid (or "live")
+i.e. a pointer that does not reference the memory for a valid (or "live")
 originating variable.
 
 ## Texture and Sampler Types ## {#texture-types}
@@ -2619,14 +2619,14 @@ A texture's representation is typically optimized for rendering operations.
 To achieve this, many details are hidden from the programmer, including data layouts, data types, and
 internal operations that cannot be expressed directly in the shader language.
 
-As a consequence, a shader does not have direct access to the texel storage within a texture variable.
+As a consequence, a shader does not have direct access to the texel memory within a texture variable.
 Instead, access is mediated through an opaque handle:
 
 * Within the shader:
     * Declare a module-scope variable
         where the [=store type=] is one of the texture types described in later sections.
         The variable stores an opaque handle to the underlying texture memory, and is
-        automatically placed in the [=storage classes/handle=] storage class.
+        automatically placed in the [=address spaces/handle=] address space.
     * Inside a function, call one of the texture builtin functions, and provide
         the texture variable or function parameter as the builtin function's
         first parameter.
@@ -3100,7 +3100,7 @@ The declaration must appear at [=module scope=], and its [=scope=] is the entire
 
     | [=syntax/vec4=] [=syntax/less_than=] [=syntax/type_decl=] [=syntax/greater_than=]
 
-    | [=syntax/pointer=] [=syntax/less_than=] [=syntax/storage_class=] [=syntax/comma=] [=syntax/type_decl=] ( [=syntax/comma=] [=syntax/access_mode=] ) ? [=syntax/greater_than=]
+    | [=syntax/pointer=] [=syntax/less_than=] [=syntax/address_space=] [=syntax/comma=] [=syntax/type_decl=] ( [=syntax/comma=] [=syntax/access_mode=] ) ? [=syntax/greater_than=]
 
     | [=syntax/array_type_decl=]
 
@@ -3276,17 +3276,17 @@ particular [=storable=] type.
 Two types are associated with a variable: its [=store type=] (the type of value
 that may be placed in the referenced memory) and its [=reference type=] (the type
 of the variable itself).
-If a variable has store type *T*, [=storage class=] *S*, and [=access mode=] *A*,
+If a variable has store type *T*, [=address space=] *S*, and [=access mode=] *A*,
 then its reference type is ref&lt;*S*,*T*,*A*&gt;.
 
 A <dfn dfn noexport>variable declaration</dfn>:
 
 * Specifies the variable’s name.
-* Specifies the [=storage class=], [=store type=], and [=access mode=].
+* Specifies the [=address space=], [=store type=], and [=access mode=].
     Together these comprise the variable's [=reference type=].
-* Ensures the execution environment allocates memory for a value of the store type, in the specified storage class,
+* Ensures the execution environment allocates memory for a value of the store type, in the specified address space,
     supporting the given access mode, for the [=lifetime=] of the variable.
-* Optionally has an *initializer* expression, if the variable is in the [=storage classes/private=] or [=storage classes/function=] storage classes.
+* Optionally has an *initializer* expression, if the variable is in the [=address spaces/private=] or [=address spaces/function=] address spaces.
     If present, the initializer expression must evaluate to the variable's store type.
 
 When an [=identifier=] use [=resolves=] to a variable declaration,
@@ -3295,10 +3295,10 @@ and its type is the variable's [=reference type=].
 See [[#var-identifier-expr]].
 
 See [[#module-scope-variables]] and [[#function-scope-variables]] for rules about where
-a variable in a particular storage class can be declared,
-and when the storage class decoration is required, optional, or forbidden.
+a variable in a particular address space can be declared,
+and when the address space decoration is required, optional, or forbidden.
 
-The access mode always has a default, and except for variables in the [=storage classes/storage=] storage class,
+The access mode always has a default, and except for variables in the [=address spaces/storage=] address space,
 must not be written in [SHORTNAME] source text. See [[#access-mode-defaults]].
 
 The <dfn noexport>lifetime</dfn> of a variable is the period during shader
@@ -3318,14 +3318,14 @@ When a variable's lifetime ends, its memory may be used for another variable.
 
 When a variable is created, its memory contains an initial value as follows:
 
-* For variables in the [=storage classes/private=] or [=storage classes/function=] storage classes:
+* For variables in the [=address spaces/private=] or [=address spaces/function=] address spaces:
     * The [=zero value=] for the store type, if the variable declaration has no initializer.
     * Otherwise, it is the result of evaluating the initializer expression at that point in the program execution.
-* For variables in the [=storage classes/workgroup=] storage class:
+* For variables in the [=address spaces/workgroup=] address space:
     * When the store type is [=constructible=], the [=zero value=] for the store type.
     * Otherwise, the store type is an array of construcible elements, and each element
         is initialized to its zero value.
-* Variables in other storage classes are [=resources=]
+* Variables in other address spaces are [=resources=]
     set by bindings in the [=draw command=] or [=dispatch command=].
 
 Consider the following snippet of WGSL:
@@ -3371,20 +3371,20 @@ The variable name is [=in scope=] for the entire program.
 
 Variables at [=module scope=] are restricted as follows:
 
-* The variable must not be in the [=storage classes/function=] storage class.
-* A variable in the [=storage classes/private=], [=storage classes/workgroup=], [=storage classes/uniform=], or [=storage classes/storage=] storage classes:
-    * Must be declared with an explicit storage class decoration.
-    * Must use a [=store type=] as described in [[#storage-class]].
+* The variable must not be in the [=address spaces/function=] address space.
+* A variable in the [=address spaces/private=], [=address spaces/workgroup=], [=address spaces/uniform=], or [=address spaces/storage=] address spaces:
+    * Must be declared with an explicit address space decoration.
+    * Must use a [=store type=] as described in [[#address-space]].
 * If the [=store type=] is a texture type or a sampler type, then the variable declaration must not
-    have a storage class decoration.  The storage class will always be [=storage classes/handle=].
+    have a address space decoration.  The address space will always be [=address spaces/handle=].
 
-A variable in the [=storage classes/uniform=] storage class is a <dfn noexport>uniform buffer</dfn> variable.
+A variable in the [=address spaces/uniform=] address space is a <dfn noexport>uniform buffer</dfn> variable.
 Its [=store type=] must be a [=host-shareable=] [=constructible=] type,
-and must satisfy [storage class layout constraints](#storage-class-layout-constraints).
+and must satisfy [address space layout constraints](#address-space-layout-constraints).
 
-A variable in the [=storage classes/storage=] storage class is a <dfn noexport>storage buffer</dfn> variable.
+A variable in the [=address spaces/storage=] address space is a <dfn noexport>storage buffer</dfn> variable.
 Its [=store type=] must be a [=host-shareable=] type
-and must satisfy [storage class layout constraints](#storage-class-layout-constraints).
+and must satisfy [address space layout constraints](#address-space-layout-constraints).
 The variable may be declared with a [=access/read=] or [=access/read_write=] access mode; the default is [=access/read=].
 
 As described in [[#resource-interface]],
@@ -3413,7 +3413,7 @@ Such variables are declared with [=attribute/group=] and [=attribute/binding=] d
     @group(0) @binding(0)
     var<storage,read_write> pbuf: array<vec2<f32>>;
 
-    // Textures and samplers are always in "handle" storage.
+    // Textures and samplers are always in "handle" space.
     @group(0) @binding(1)
     var filter_params: sampler;
   </xmp>
@@ -3500,8 +3500,8 @@ A function-scope [=let declaration|let-declared=] constant must be of
 [=constructible=] type, or of [=pointer type=].
 
 For a variable declared in function scope:
-* The variable is always in the [=storage classes/function=] storage class.
-* The storage decoration is optional.
+* The variable is always in the [=address spaces/function=] address space.
+* The address space decoration is optional.
 * The [=store type=] must be a [=constructible=] type.
 * When an initializer is specified, the store type may be omitted from the declaration.
     In this case the store type is the type of the result of evaluating the initializer.
@@ -3509,11 +3509,11 @@ For a variable declared in function scope:
 <div class='example wgsl global-scope' heading="Function scope variables and constants">
   <xmp highlight='rust'>
     fn f() {
-       var<function> count: u32;  // A variable in function storage class.
-       var delta: i32;            // Another variable in the function storage class.
-       var sum: f32 = 0.0;        // A function storage class variable with initializer.
+       var<function> count: u32;  // A variable in function address space.
+       var delta: i32;            // Another variable in the function address space.
+       var sum: f32 = 0.0;        // A function address space variable with initializer.
        var pi = 3.14159;          // Infer the f32 store type from the initializer.
-       let unit: i32 = 1;         // Let-declared constants don't use a storage class.
+       let unit: i32 = 1;         // Let-declared constants don't use a address space.
     }
   </xmp>
 </div>
@@ -3552,7 +3552,7 @@ use the same memory.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>variable_qualifier</dfn> :
 
-    | [=syntax/less_than=] [=syntax/storage_class=] ( [=syntax/comma=] [=syntax/access_mode=] ) ? [=syntax/greater_than=]
+    | [=syntax/less_than=] [=syntax/address_space=] ( [=syntax/comma=] [=syntax/access_mode=] ) ? [=syntax/greater_than=]
 </div>
 
 <div class='syntax' noexport='true'>
@@ -5014,11 +5014,11 @@ See [[#function-call-statement]].
   <tr algorithm="variable reference">
        <td>
           |v| is an [=identifier=] [=resolves|resolving=] to
-          an [=in scope|in-scope=] variable declared in [=storage class=] |SC|
+          an [=in scope|in-scope=] variable declared in [=address space=] |SC|
           with [=store type=] |T|
        <td class="nowrap">
           |v|: ref&lt;|SC|,|T|&gt;
-       <td>Result is a reference to the storage for the named variable |v|.
+       <td>Result is a reference to the memory for the named variable |v|.
 </table>
 
 ## Formal Parameter Expression  ## {#formal-parameter-expr}
@@ -5058,8 +5058,7 @@ The <dfn noexport>address-of</dfn> operator converts a reference to its correspo
            If |r| is an [=invalid memory reference=], then the resulting
            pointer is also an invalid memory reference.
 
-           It is a [=shader-creation error=] if |SC| is  the [=storage
-           classes/handle=] storage class.
+           It is a [=shader-creation error=] if |SC| is the [=address spaces/handle=] address space.
 
            It is a [=shader-creation error=] if |r| is a
            [[#component-reference-from-vector-reference|reference to a vector component]].
@@ -5337,7 +5336,7 @@ In this case the value of the [=right-hand side=] is written to the memory refer
         |A| is [=access/write=] or [=access/read_write=]<br>
         |e|: |T|,<br>
         |T| is a [=constructible=] type,<br>
-        |SC| is a writable [=storage class=]
+        |SC| is a writable [=address space=]
     <td class="nowrap">|r| = |e|
     <td>Evaluates |e|, evaluates |r|, then writes the value computed for |e| into
         the [=memory locations=] referenced by |r|.
@@ -6701,7 +6700,7 @@ In detail, when a function call is executed the following steps occur:
 2. Execution of the [=calling function=] is suspended.
     All [=function scope=] variables and constants maintain their current values.
 3. If the called function is [=user-defined function|user-defined=],
-    storage is allocated for each function scope variable in the called function.
+    memory is allocated for each function scope variable in the called function.
     * Initialization occurs as described in [[#var-and-value]].
 4. Values for the formal parameters of the called function are determined
     by matching the function call argument values by position.
@@ -6736,18 +6735,18 @@ As such, the same textual location may represent multiple call sites.
 * Each function call argument must evaluate to the type of the corresponding
     function parameter.
     * In particular, an argument that is a pointer must agree with the formal parameter
-        on storage class, pointee type, and access mode.
+        on address space, pointee type, and access mode.
 * For [=user-defined functions=], a parameter of pointer type must be in one of
-    the following storage classes:
-    * [=storage classes/function=]
-    * [=storage classes/private=]
-    * [=storage classes/workgroup=]
+    the following address spaces:
+    * [=address spaces/function=]
+    * [=address spaces/private=]
+    * [=address spaces/workgroup=]
 * For [=built-in functions=], a parameter of pointer type must be in one of
-    the following storage classes:
-    * [=storage classes/function=]
-    * [=storage classes/private=]
-    * [=storage classes/workgroup=]
-    * [=storage classes/storage=]
+    the following address spaces:
+    * [=address spaces/function=]
+    * [=address spaces/private=]
+    * [=address spaces/workgroup=]
+    * [=address spaces/storage=]
 * Each argument of pointer type to a [=user-defined function=] must be one of:
     * An [[#address-of-expr|address-of expression]] of a
         [[#var-identifier-expr|variable identifier expression]]
@@ -6913,7 +6912,7 @@ The interface includes:
 * Texture resources
 * Sampler resources
 
-These objects are represented by module-scope variables in certain [=storage classes=].
+These objects are represented by module-scope variables in certain [=address spaces=].
 
 When an [=identifier=] used in a [=function declaration=] [=resolves=] to a [=module scope|module-scope=] variable,
 then we say the variable is <dfn>statically accessed</dfn> by the function.
@@ -6926,7 +6925,7 @@ More precisely, the <dfn noexport>interface of a shader stage</dfn> consists of:
   - all parameters of the entry point
   - the result value of the entry point
   - all [=module scope=] variables that are [=statically accessed=] by [=functions in a shader stage|functions in the shader stage=],
-    and which are in storage classes [=storage classes/uniform=], [=storage classes/storage=], or [=storage classes/handle=].
+    and which are in address spaces [=address spaces/uniform=], [=address spaces/storage=], or [=address spaces/handle=].
 
 ### Pipeline Input and Output Interface ### {#pipeline-inputs-outputs}
 
@@ -7384,7 +7383,7 @@ See [[#statements]] and [[#function-calls]].
 
 A <dfn noexport for="compute shader stage">workgroup</dfn> is a set of invocations which
 concurrently execute a [=compute shader stage=] [=entry point=],
-and share access to shader variables in the [=storage classes/workgroup=] storage class.
+and share access to shader variables in the [=address spaces/workgroup=] address space.
 
 The <dfn noexport>workgroup grid</dfn> for a compute shader is the set of points
 with integer coordinates *(i,j,k)* with:
@@ -7792,10 +7791,10 @@ may participate in an operation (see [[#collective-operations]]).
 
 [[#atomic-builtin-functions|Atomic built-in functions]] map to [=memory model atomic
 operation|atomic operations=] whose memory [=memory model scope|scope=] is:
-* `Workgroup` if the atomic pointer is in the [=storage classes/workgroup=]
-    storage class
-* `QueueFamily` if the atomic pointer is in the [=storage
-    classes/storage=] storage class
+* `Workgroup` if the atomic pointer is in the [=address spaces/workgroup=]
+    address space
+* `QueueFamily` if the atomic pointer is in the [=address spaces/storage=]
+    address space
 
 [[#sync-builtin-functions|Synchronization built-in functions]] map to control
 barriers whose execution and memory [=memory model scope|scopes=] are
@@ -7809,14 +7808,13 @@ Note: When generating SPIR-V that does not enable the `Vulkan` memory model,
 ## Memory Semantics ## {#memory-semantics}
 
 All [[#atomic-builtin-functions|Atomic built-in functions]] use `Relaxed`
-[=memory model memory semantics|memory semantics=] and, thus, no storage class
+[=memory model memory semantics|memory semantics=] and, thus, no address space
 semantics.
 
 [[#sync-builtin-functions|workgroupBarrier]] uses `AcquireRelease` [=memory
-model memory semantics|memory semantics=] and `WorkgroupMemory` storage
-semantics.
+model memory semantics|memory semantics=] and `WorkgroupMemory` semantics.
 [[#sync-builtin-functions|storageBarrier]] uses `AcquireRelease` [=memory model
-memory semantics|memory semantics=] and `UniformMemory` storage semantics.
+memory semantics|memory semantics=] and `UniformMemory` semantics.
 
 Note: A combined `workgroupBarrier` and `storageBarrier` uses `AcquireRelease`
 ordering semantics and both `WorkgroupMemory` and `UniformMemory` memory
@@ -7827,14 +7825,14 @@ Note: No atomic or synchronization built-in functions use `MakeAvailable` or
 
 ## Private vs Non-Private ## {#private-vs-non-private}
 
-All non-atomic [=read accesses=] in the [=storage classes/storage=] or
-[=storage classes/workgroup=] storage classes are considered
+All non-atomic [=read accesses=] in the [=address spaces/storage=] or
+[=address spaces/workgroup=] address spaces are considered
 [=memory model non-private|non-private=] and correspond to read operations with
 `NonPrivatePointer | MakePointerVisible` memory operands with the `Workgroup`
 scope.
 
-All non-atomic [=write accesses=] in the [=storage classes/storage=] or
-[=storage classes/workgroup=] storage classes are considered
+All non-atomic [=write accesses=] in the [=address spaces/storage=] or
+[=address spaces/workgroup=] address spaces are considered
 [=memory model non-private|non-private=] and correspond to write operations
 with `NonPrivatePointer | MakePointerAvailable` memory operands with the
 `Workgroup` scope.
@@ -10116,11 +10114,10 @@ between atomic accesses acting on different memory locations.
 
 Atomic built-in functions `must` not be used in a [=vertex=] shader stage.
 
-The storage class `SC` of the `atomic_ptr` parameter in all atomic built-in
-functions `must` be either [=storage classes/storage=] or [=storage
-classes/workgroup=].
-[=storage classes/workgroup=] atomics have a **Workgroup**
-[=memory scope=] in SPIR-V, while [=storage classes/storage=] atomics have a
+The address space `SC` of the `atomic_ptr` parameter in all atomic built-in
+functions `must` be either [=address spaces/storage=] or [=address spaces/workgroup=].
+[=address spaces/workgroup=] atomics have a **Workgroup**
+[=memory scope=] in SPIR-V, while [=address spaces/storage=] atomics have a
 **QueueFamily** memory scope in SPIR-V.
 
 The access mode `A` in all atomic built-in functions must be [=access/read_write=].
@@ -10342,11 +10339,9 @@ All synchronization functions have a `Workgroup` [=execution scope=].
 All synchronization functions must only be used in the [=compute=] shader
 stage.
 
-storageBarrier affects memory and atomic operations in the [=storage
-classes/storage=] storage class.
+storageBarrier affects memory and atomic operations in the [=address spaces/storage=] address space.
 
-workgroupBarrier affects memory and atomic operations in the [=storage
-classes/workgroup=] storage class.
+workgroupBarrier affects memory and atomic operations in the [=address spaces/workgroup=] address space.
 
 <div class='example spirv barrier mapping' heading="Mapping workgroupBarrier to SPIR-V">
   <xmp>


### PR DESCRIPTION
Closes #2440
I have no hard feelings about "memory class" as a name, as long as it's not colliding with the other uses of "storage" in the spec. Currently, it's used in 3 different things:
- "storage class" as a term
- "storage" storage class as one of the variants, used for buffers
- "texture_storage" aka the storage texture

Edit: new name is "address space"


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/2524.html" title="Last updated on Jan 25, 2022, 10:15 PM UTC (acd0b72)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2524/483d761...kvark:acd0b72.html" title="Last updated on Jan 25, 2022, 10:15 PM UTC (acd0b72)">Diff</a>