### PR TITLE
Remove duplicated words

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5232,7 +5232,7 @@ details.
 
 - {{GPURenderPipelineDescriptor/vertex}} describes
     the vertex shader entry point of the [=pipeline=] and its input buffer layouts.
-- {{GPURenderPipelineDescriptor/primitive}} describes the
+- {{GPURenderPipelineDescriptor/primitive}} describes
     the primitive-related properties of the [=pipeline=].
 - {{GPURenderPipelineDescriptor/depthStencil}} describes
     the optional depth-stencil properties, including the testing, operations, and bias.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7392,7 +7392,7 @@ called the compute pass encoder can no longer be used.
                     |this|.{{GPUProgrammablePassEncoder/[[command_encoder]]}} [=invalid=] and stop.
                     <div class=validusage>
                         - |this| must be [=valid=].
-                        - |this|.{{GPUDebugCommandsMixin/[[debug_group_stack]]}} must be [=list/is empty|be empty=].
+                        - |this|.{{GPUDebugCommandsMixin/[[debug_group_stack]]}} must [=list/is empty|be empty=].
                     </div>
                 1. [=list/Extend=] |this|.{{GPUProgrammablePassEncoder/[[command_encoder]]}}.{{GPUCommandsMixin/[[commands]]}}
                     with |this|.{{GPUCommandsMixin/[[commands]]}}.
@@ -8437,7 +8437,7 @@ called the render pass encoder can no longer be used.
                     |this|.{{GPUProgrammablePassEncoder/[[command_encoder]]}} [=invalid=] and stop.
                     <div class=validusage>
                         - |this| must be [=valid=].
-                        - |this|.{{GPUDebugCommandsMixin/[[debug_group_stack]]}} must be [=list/is empty|be empty=].
+                        - |this|.{{GPUDebugCommandsMixin/[[debug_group_stack]]}} must [=list/is empty|be empty=].
                         - |this|.{{GPURenderPassEncoder/[[occlusion_query_active]]}} must be `false`.
                     </div>
                 1. [=list/Extend=] |this|.{{GPUProgrammablePassEncoder/[[command_encoder]]}}.{{GPUCommandsMixin/[[commands]]}}


### PR DESCRIPTION
Remove two duplicated `be` from the WebGPU spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jzm-intel/gpuweb/pull/2529.html" title="Last updated on Jan 24, 2022, 7:37 AM UTC (4015e2a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2529/5a0cbb2...jzm-intel:4015e2a.html" title="Last updated on Jan 24, 2022, 7:37 AM UTC (4015e2a)">Diff</a>