### PR TITLE
wgsl: Fix example's builtin name

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8539,7 +8539,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in value.
       //     OpDecorate %coord BuiltIn FragCoord
       @builtin(sample_index) my_sample_index: u32,
       //      OpDecorate %my_sample_index BuiltIn SampleId
-      @builtin(sample_mask_in) mask_in: u32,
+      @builtin(sample_mask) mask_in: u32,
       //      OpDecorate %mask_in BuiltIn SampleMask ; an input variable
       //      OpDecorate %mask_in Flat
     ) -> FragmentOutput {}


### PR DESCRIPTION
`sample_mask_in` -> `sample_mask`