### PR TITLE
Fix clamp arity in error bounds section

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7596,7 +7596,7 @@ value with the same sign.
   <tr><td>`atan(x)`<td>4096 ULP
   <tr><td>`atan2(y, x)`<td>4096 ULP
   <tr><td>`ceil(x)`<td>Correctly rounded
-  <tr><td>`clamp(x)`<td>Correctly rounded
+  <tr><td>`clamp(x,low,high)`<td>Correctly rounded
   <tr><td>`cos(x)`<td>Absolute error &le; 2<sup>-11</sup> inside the range of [-&pi;, &pi;]
   <tr><td>`cosh(x)`<td>Inherited from `(exp(x) - exp(-x)) * 0.5`
   <tr><td>`cross(x, y)`<td>Inherited from `(x[i] * y[j] - x[j] * y[i])`
@@ -8790,8 +8790,8 @@ See [[#function-calls]].
 
   <tr algorithm="clamp">
     <td>|T| is [FLOATING]
-    <td class="nowrap">`clamp(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T|`) -> ` |T|
-    <td>Returns `min(max(`|e1|`,`|e2|`),`|e3|`)`.
+    <td class="nowrap">`clamp(`|e|`:` |T| `,` |low|`:` |T| `,` |high|`:` |T|`) -> ` |T|
+    <td>Returns `min(max(`|e|`,`|low|`),`|high|`)`.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450NClamp)
 
@@ -9165,15 +9165,15 @@ struct __modf_result_vecN {
 
   <tr algorithm="unsigned clamp">
     <td>|T| is [UNSIGNEDINTEGRAL]
-    <td class="nowrap">`clamp(`|e1|`:` |T| `, `|e2|`:` |T|`, `|e3|`:` |T|`) ->` |T|
-    <td>Returns `min(max(`|e1|`,`|e2|`),`|e3|`)`.
+    <td class="nowrap">`clamp(`|e|`:` |T| `,` |low|`:` |T|`,` |high|`:` |T|`) ->` |T|
+    <td>Returns `min(max(`|e|`,`|low|`),`|high|`)`.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450UClamp)
 
   <tr algorithm="signed clamp">
     <td>|T| is [SIGNEDINTEGRAL]
-    <td class="nowrap">`clamp(`|e1|`:` |T| `, `|e2|`:` |T|`, `|e3|`:` |T|`) ->` |T|
-    <td>Returns `min(max(`|e1|`,`|e2|`),`|e3|`)`.
+    <td class="nowrap">`clamp(`|e|`:` |T| `,` |low|`:` |T|`,` |high|`:` |T|`) ->` |T|
+    <td>Returns `min(max(`|e|`,`|low|`),`|high|`)`.
     [=Component-wise=] when |T| is a vector.
     (GLSLstd450SClamp)
 


### PR DESCRIPTION
Also at the definitions, use more suggestive formal parameter names (e,low,high)
instead of the less readable (e1,e2,e3)