### PR TITLE
Explain smoothStep better

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7627,7 +7627,7 @@ value with the same sign.
   <tr><td>`sign(x)`<td>Correctly rounded
   <tr><td>`sin(x)`<td>Absolute error &le; 2<sup>-11</sup> inside the range [-&pi;, &pi;]
   <tr><td>`sinh(x)`<td>Inherited from `(exp(x) - exp(-x)) * 0.5`
-  <tr><td>`smoothStep(x, y, z)`<td>Inherited from `t * t * (3.0 - 2.0 * t)`,<br>where `t = clamp((z - x) / (y - x), 0.0, 1.0)`
+  <tr><td>`smoothStep(low, high, x)`<td>Inherited from `t * t * (3.0 - 2.0 * t)`,<br>where `t = clamp((x - low) / (high - low), 0.0, 1.0)`
   <tr><td>`sqrt(x)`<td>Inherited from `1.0 / inverseSqrt(x)`
   <tr><td>`step(x, y)`<td>Correctly rounded
   <tr><td>`tan(x)`<td>Inherited from `sin(x) / cos(x)`
@@ -9102,9 +9102,14 @@ struct __modf_result_vecN {
 
   <tr algorithm="smoothStep">
     <td>|T| is [FLOATING]
-    <td class="nowrap">`smoothStep(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T| `) -> ` |T|
+    <td class="nowrap">`smoothStep(`|low|`:` |T| `,` |high|`:` |T| `,` |x|`:` |T| `) -> ` |T|
     <td>Returns the smooth Hermite interpolation between 0 and 1.
     [=Component-wise=] when |T| is a vector.
+
+    For scalar |T|, the result is
+    |t| * |t| * (3.0 - 2.0 * |t|),
+    where |t| = clamp((|x| - |low|) / (|high| - |low|), 0.0, 1.0).
+
     (GLSLstd450SmoothStep)
 
   <tr algorithm="sqrt">


### PR DESCRIPTION
- Use more suggestive formal parameter names
- Give the formula at the function definition, not just at the
  error bounds explanation.