### PR TITLE
Enforce presence of an initializer for module-scope let

### DIFF
--- a/wgsl/extract-grammar.py
+++ b/wgsl/extract-grammar.py
@@ -530,7 +530,7 @@ for key, value in scanner_components[scanner_example.name()].items():
     if "function-scope" in key:
         value = ["fn function__scope____() {"] + value + ["}"]
     if "type-scope" in key:
-        # Intiailize with zero-value expression.
+        # Initiailize with zero-value expression.
         value = ["let type_scope____: "] + value + ["="] + value + ["()"] + [";"]
     program = "\n".join(value)
     tree = parser.parse(bytes(program, "utf8"))

--- a/wgsl/extract-grammar.py
+++ b/wgsl/extract-grammar.py
@@ -530,7 +530,8 @@ for key, value in scanner_components[scanner_example.name()].items():
     if "function-scope" in key:
         value = ["fn function__scope____() {"] + value + ["}"]
     if "type-scope" in key:
-        value = ["let type_scope____: "] + value + [";"]
+        # Intiailize with zero-value expression.
+        value = ["let type_scope____: "] + value + ["="] + value + ["()"] + [";"]
     program = "\n".join(value)
     tree = parser.parse(bytes(program, "utf8"))
     if tree.root_node.has_error:

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5102,7 +5102,7 @@ The <dfn noexport>indirection</dfn> operator converts a pointer to its correspon
            Pipeline-overridable constants appear at module-scope, so evaluation occurs
            before the shader begins execution.<br>
            Note: Pipeline creation fails if no initial value was specified in the API call
-           and the `let`-declaration has no intializer expression.
+           and the `let`-declaration has no initializer expression.
   <tr algorithm="constant value">
        <td>
           |c| is an [=identifier=] [=resolves|resolving=] to
@@ -5856,7 +5856,7 @@ The `body` is a special form of [=compound statement=].
 The identifier of a declaration in the `body` is [=in scope=] from the start of
 the next statement until the end of the `body`.
 The declaration is executed each time it is reached, so each new iteration
-creates a new instance of the variable or constant, and re-intializes it.
+creates a new instance of the variable or constant, and re-initializes it.
 
 <div class='example glsl' heading="For to Loop transformation">
   <xmp>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3564,14 +3564,9 @@ use the same memory.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>global_constant_decl</dfn> :
 
-    | [=syntax/let=] ( [=syntax/ident=] | [=syntax/variable_ident_decl=] ) [=syntax/global_const_initializer=] ?
+    | [=syntax/let=] ( [=syntax/ident=] | [=syntax/variable_ident_decl=] ) [=syntax/equal=] [=syntax/const_expression=]
 
     | [=syntax/attribute=] * [=syntax/override=] ( [=syntax/ident=] | [=syntax/variable_ident_decl=] ) ( [=syntax/equal=] [=syntax/expression=] ) ?
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>global_const_initializer</dfn> :
-
-    | [=syntax/equal=] [=syntax/const_expression=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>const_expression</dfn> :


### PR DESCRIPTION
* Since pipeline-overridable constants were split from let declarations
  the grammar for let declarations can enforce the presence of an
  initializer
* Remove global_const_intiailizer since it was only used in for a single
  grammar production (module-scope let) and only had a single grammar
  itself
* Update extract_grammar to initialize type declarations with zero-value
  expressions