### PR TITLE
editorial: discuss parsing ambiguity: type construction, function call

### DIFF
--- a/wgsl/extract-grammar.py
+++ b/wgsl/extract-grammar.py
@@ -241,7 +241,7 @@ module.exports = grammar({
     ],
 
     conflicts: $ => [
-        [$.type_decl,$.primary_expression],
+        [$.type_decl,$.function_call_expression],
     ],
 
     word: $ => $.ident,

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3432,7 +3432,7 @@ with matching component types.
 There are [=overloads=] for constructing vectors and matrices that specify the dimensions of the target type without having to
 specify the component type; the component type is inferred from the constructor arguments.
 
-See also [[#zero-value-expr]] and [[#conversion-expr]] for other specialized kinds type constructor expressions.
+See also [[#zero-value-expr]] and [[#conversion-expr]] for other specialized kinds of type constructor expressions.
 
 <table class='data'>
   <caption>Scalar constructor type rules</caption>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3422,7 +3422,17 @@ Expressions specify how values are computed.
 ## Type Constructor Expressions ## {#type-constructor-expr}
 
 A type constructor expression explicitly creates a value of a given [=constructible=] type.
-It must match the [=syntax/constructor_expression=] grammar rule.
+
+There are three kinds of constructor expressions:
+* [[#construction-from-components]]
+* [[#zero-value-expr]]
+* [[#conversion-expr]]
+
+### Construction From Components ### {#construction-from-components}
+
+The expressions defined in this section create a [=constructible=] value by:
+* Copying an existing value of the same type (i.e. the identity function), or
+* Creating a composite value from an explicit list of components.
 
 The scalar forms given here are redundant, but provide symmetry with scalar [=conversion expressions=],
 and can be used to enhance readability.
@@ -3431,8 +3441,6 @@ The vector and matrix forms construct vector and matrix values from various comb
 with matching component types.
 There are [=overloads=] for constructing vectors and matrices that specify the dimensions of the target type without having to
 specify the component type; the component type is inferred from the constructor arguments.
-
-See also [[#zero-value-expr]] and [[#conversion-expr]] for other specialized kinds of type constructor expressions.
 
 <table class='data'>
   <caption>Scalar constructor type rules</caption>
@@ -3640,11 +3648,10 @@ See also [[#zero-value-expr]] and [[#conversion-expr]] for other specialized kin
     <td>Construction of a structure from members.
 </table>
 
-## Zero Value Expressions ## {#zero-value-expr}
+### Zero Value Expressions ### {#zero-value-expr}
 
 Each [=constructible=] *T* has a unique <dfn noexport>zero value</dfn>
 written in WGSL as the type followed by an empty pair of parentheses: *T* `()`.
-This is a special case of a [[#type-constructor-expr|type constructor expression]].
 
 The zero values are as follows:
 
@@ -3780,14 +3787,12 @@ Note: WGSL does not have zero expression for [=atomic types=],
 </div>
 
 
-## Conversion Expressions ## {#conversion-expr}
+### Conversion Expressions ### {#conversion-expr}
 
 WGSL does not implicitly convert or promote a numeric or boolean value to another type.
 Instead use a <dfn>conversion expression</dfn> as defined in the tables below.
 
 For details on conversion to and from floating point types, see [[#floating-point-conversion]].
-
-A conversion expression is a special case of a [[#type-constructor-expr|type constructor expression]].
 
 <table class='data'>
   <caption>Scalar conversion type rules</caption>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2961,37 +2961,47 @@ The declaration must appear at [=module scope=], and its [=scope=] is the entire
 
     | [=syntax/uint32=]
 
-    | [=syntax/vec2=] [=syntax/less_than=] [=syntax/type_decl=] [=syntax/greater_than=]
+    | [=syntax/vec_prefix=] [=syntax/less_than=] [=syntax/type_decl=] [=syntax/greater_than=]
 
-    | [=syntax/vec3=] [=syntax/less_than=] [=syntax/type_decl=] [=syntax/greater_than=]
-
-    | [=syntax/vec4=] [=syntax/less_than=] [=syntax/type_decl=] [=syntax/greater_than=]
+    | [=syntax/mat_prefix=] [=syntax/less_than=] [=syntax/type_decl=] [=syntax/greater_than=]
 
     | [=syntax/pointer=] [=syntax/less_than=] [=syntax/address_space=] [=syntax/comma=] [=syntax/type_decl=] ( [=syntax/comma=] [=syntax/access_mode=] ) ? [=syntax/greater_than=]
 
     | [=syntax/array_type_decl=]
 
-    | [=syntax/mat2x2=] [=syntax/less_than=] [=syntax/type_decl=] [=syntax/greater_than=]
-
-    | [=syntax/mat2x3=] [=syntax/less_than=] [=syntax/type_decl=] [=syntax/greater_than=]
-
-    | [=syntax/mat2x4=] [=syntax/less_than=] [=syntax/type_decl=] [=syntax/greater_than=]
-
-    | [=syntax/mat3x2=] [=syntax/less_than=] [=syntax/type_decl=] [=syntax/greater_than=]
-
-    | [=syntax/mat3x3=] [=syntax/less_than=] [=syntax/type_decl=] [=syntax/greater_than=]
-
-    | [=syntax/mat3x4=] [=syntax/less_than=] [=syntax/type_decl=] [=syntax/greater_than=]
-
-    | [=syntax/mat4x2=] [=syntax/less_than=] [=syntax/type_decl=] [=syntax/greater_than=]
-
-    | [=syntax/mat4x3=] [=syntax/less_than=] [=syntax/type_decl=] [=syntax/greater_than=]
-
-    | [=syntax/mat4x4=] [=syntax/less_than=] [=syntax/type_decl=] [=syntax/greater_than=]
-
     | [=syntax/atomic=] [=syntax/less_than=] [=syntax/type_decl=] [=syntax/greater_than=]
 
     | [=syntax/texture_sampler_types=]
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>vec_prefix</dfn> :
+
+    | [=syntax/vec2=]
+
+    | [=syntax/vec3=]
+
+    | [=syntax/vec4=]
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>mat_prefix</dfn> :
+
+    | [=syntax/mat2x2=]
+
+    | [=syntax/mat2x3=]
+
+    | [=syntax/mat2x4=]
+
+    | [=syntax/mat3x2=]
+
+    | [=syntax/mat3x3=]
+
+    | [=syntax/mat3x4=]
+
+    | [=syntax/mat4x2=]
+
+    | [=syntax/mat4x3=]
+
+    | [=syntax/mat4x4=]
 </div>
 
 When the type declaration is an [=identifier=], then the expression must be in scope of a
@@ -3411,18 +3421,18 @@ Expressions specify how values are computed.
 
 ## Type Constructor Expressions ## {#type-constructor-expr}
 
-Type constructor expressions explicitly create a value of a given [=constructible=] type.
-Type constructor expressions explicitly create a value of a given type.
+A type constructor expression explicitly creates a value of a given [=constructible=] type.
+It must match the [=syntax/constructor_expression=] grammar rule.
 
-The scalar forms are redundant, but provide symmetry with scalar [[#conversion-expr|conversion expressions]],
+The scalar forms given here are redundant, but provide symmetry with scalar [=conversion expressions=],
 and can be used to enhance readability.
 
 The vector and matrix forms construct vector and matrix values from various combinations of components and subvectors
 with matching component types.
-There are overloads for constructing vectors and matrices that specify the dimensions of the target type without having to
+There are [=overloads=] for constructing vectors and matrices that specify the dimensions of the target type without having to
 specify the component type; the component type is inferred from the constructor arguments.
 
-See also [[#zero-value-expr]] and [[#conversion-expr]].
+See also [[#zero-value-expr]] and [[#conversion-expr]] for other specialized kinds type constructor expressions.
 
 <table class='data'>
   <caption>Scalar constructor type rules</caption>
@@ -3634,6 +3644,7 @@ See also [[#zero-value-expr]] and [[#conversion-expr]].
 
 Each [=constructible=] *T* has a unique <dfn noexport>zero value</dfn>
 written in WGSL as the type followed by an empty pair of parentheses: *T* `()`.
+This is a special case of a [[#type-constructor-expr|type constructor expression]].
 
 The zero values are as follows:
 
@@ -3772,11 +3783,11 @@ Note: WGSL does not have zero expression for [=atomic types=],
 ## Conversion Expressions ## {#conversion-expr}
 
 WGSL does not implicitly convert or promote a numeric or boolean value to another type.
-Instead use conversion expressions as defined in the tables below.
+Instead use a <dfn>conversion expression</dfn> as defined in the tables below.
 
 For details on conversion to and from floating point types, see [[#floating-point-conversion]].
 
-See also [[#type-constructor-expr]].
+A conversion expression is a special case of a [[#type-constructor-expr|type constructor expression]].
 
 <table class='data'>
   <caption>Scalar conversion type rules</caption>
@@ -4754,18 +4765,40 @@ The <dfn noexport>indirection</dfn> operator converts a pointer to its correspon
 
 ## Expression Grammar Summary ## {#expression-grammar}
 
+Note: There is a parsing ambiguity between the [=syntax/constructor_expression=]
+and [=syntax/function_call_expression=] grammar rules.
+In particular the name of a structure type or a type alias is an [=identifier=],
+and so are the names of both [=user-defined function|user-defined=] and [=built-in functions=].
+However, [[#declaration-and-scope|declaration and scope]] rules ensure those names are always distinct.
+
 <div class='syntax' noexport='true'>
   <dfn for=syntax>primary_expression</dfn> :
 
-    | [=syntax/ident=] [=syntax/argument_expression_list=] ?
+    | [=syntax/ident=]
 
-    | [=syntax/type_decl=] [=syntax/argument_expression_list=]
+    | [=syntax/constructor_expression=]
+
+    | [=syntax/function_call_expression=]
 
     | [=syntax/const_literal=]
 
     | [=syntax/paren_expression=]
 
     | [=syntax/bitcast=] [=syntax/less_than=] [=syntax/type_decl=] [=syntax/greater_than=] [=syntax/paren_expression=]
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>constructor_expression</dfn> :
+
+    | [=syntax/type_decl=] [=syntax/argument_expression_list=]
+
+    | [=syntax/vec_prefix=] [=syntax/argument_expression_list=]
+
+    | [=syntax/mat_prefix=] [=syntax/argument_expression_list=]
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>function_call_expression</dfn> :
+
+    | [=syntax/ident=] [=syntax/argument_expression_list=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>paren_expression</dfn> :


### PR DESCRIPTION
- Refactor the grammar:
  - Make vec_prefix and mat_prefix rules.
  - Make a constructor_expression rule.
  - Make a function_call_expression rule.
- Say that a type constructor matches the constructor_expression rule.
- In the expression grammar summary, state there is a known parsing
  ambiguity due to both rules using "identifier", but the set of
  identifiers never overlap.

- Describe zero-value expressions and conversion expressions as special
  cases of type construction.

- Update the conflict list in extract-grammra.py