### PR TITLE
Add GPUTextureDescriptor viewFormats list

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2514,8 +2514,32 @@ dictionary GPUTextureDescriptor : GPUObjectDescriptorBase {
     GPUTextureDimension dimension = "2d";
     required GPUTextureFormat format;
     required GPUTextureUsageFlags usage;
+    sequence<GPUTextureFormat> viewFormats = [];
 };
 </script>
+
+<dl dfn-type=dict-member dfn-for=GPUTextureDescriptor>
+    : <dfn>viewFormats</dfn>
+    ::
+        Specifies what view {{GPUTextureViewDescriptor/format}} values will be allowed when calling
+        {{GPUTexture/createView()}} on this texture (in addition to the texture's actual
+        {{GPUTextureDescriptor/format}}).
+
+        Note: Adding formats to this list may have a sizable performance impact, depending on the
+        user's system. It is best to avoid adding formats unnecessarily.
+
+        Formats in this list must be [=texture view format compatible=] with the texture format.
+
+        <div algorithm>
+            Two {{GPUTextureFormat}}s |format| and |viewFormat| are <dfn dfn for=>texture view format compatible</dfn> if:
+
+            - |format| equals |viewFormat|, or
+            - |format| and |viewFormat| differ only in whether they are `srgb` formats (have the `-srgb` suffix).
+
+            Issue(gpuweb/gpuweb#168): Define larger compatibility classes.
+        </div>
+
+</dl>
 
 <script type=idl>
 enum GPUTextureDimension {
@@ -2637,6 +2661,9 @@ namespace GPUTextureUsage {
                             - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/STORAGE_BINDING}} bit,
                                 |descriptor|.{{GPUTextureDescriptor/format}} must be listed in [[#plain-color-formats]] table
                                 with {{GPUTextureUsage/STORAGE_BINDING}} capability.
+                            - For each |viewFormat| in |descriptor|.{{GPUTextureDescriptor/viewFormats}},
+                                |descriptor|.{{GPUTextureDescriptor/format}} and |viewFormat| must be
+                                [=texture view format compatible=].
                         </div>
 
                         Then:
@@ -2846,8 +2873,9 @@ enum GPUTextureAspect {
                             - |descriptor|.{{GPUTextureViewDescriptor/baseArrayLayer}} +
                                 |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be &le;
                                 the [$array layer count$] of |this|.
-                            - |descriptor|.{{GPUTextureViewDescriptor/format}} must be |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
-                                <div class="issue">Allow for creating views with compatible formats as well.</div>
+                            - |descriptor|.{{GPUTextureViewDescriptor/format}} must be equal to either
+                                |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}
+                                or one of the formats in |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/viewFormats}}.
                             - If |descriptor|.{{GPUTextureViewDescriptor/dimension}} is:
                                 <dl class="switch">
                                     : {{GPUTextureViewDimension/"1d"}}
@@ -6729,6 +6757,9 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
 
     - |format1| equals |format2|, or
     - |format1| and |format2| differ only in whether they are `srgb` formats (have the `-srgb` suffix).
+
+    Issue(gpuweb/gpuweb#2322): Once more formats are allowed in {{GPUTextureDescriptor/viewFormats}},
+    consider making two textures copy-compatible when there's any overlap in the viewFormats.
 </div>
 
 <div algorithm>
@@ -9340,6 +9371,7 @@ dictionary GPUCanvasConfiguration {
     required GPUDevice device;
     required GPUTextureFormat format;
     GPUTextureUsageFlags usage = 0x10;  // GPUTextureUsage.RENDER_ATTACHMENT
+    sequence<GPUTextureFormat> viewFormats = [];
     GPUPredefinedColorSpace colorSpace = "srgb";
     GPUCanvasCompositingAlphaMode compositingAlphaMode = "opaque";
     GPUExtent3D size;

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9360,6 +9360,11 @@ regardless of the given {{GPUCanvasConfiguration}}.{{GPUCanvasConfiguration/devi
 initially set to: &laquo;{{GPUTextureFormat/"bgra8unorm"}}, {{GPUTextureFormat/"rgba8unorm"}},
 {{GPUTextureFormat/"rgba16float"}}&raquo;.
 
+Note: Canvas configuration cannot use `srgb` formats like {{GPUTextureFormat/"bgra8unorm-srgb"}}.
+Instead, use the non-`srgb` equivalent ({{GPUTextureFormat/"bgra8unorm"}}), specify the `srgb`
+format in the {{GPUCanvasConfiguration/viewFormats}}, and use {{GPUTexture/createView()}} to create
+a view with an `srgb` format.
+
 <script type=idl>
 
 enum GPUCanvasCompositingAlphaMode {


### PR DESCRIPTION
Initially allows only srgb formats; further rules for format compatibility can follow.

Issue: #168
CC: #2322


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2540.html" title="Last updated on Jan 26, 2022, 10:43 PM UTC (221ae48)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2540/60fd419...kainino0x:221ae48.html" title="Last updated on Jan 26, 2022, 10:43 PM UTC (221ae48)">Diff</a>