### PR TITLE
Remove unnecessary todos

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1347,7 +1347,6 @@ to define a [=uniform buffer=] or a [=storage buffer=]. See [[#memory-layouts]].
 
 <div class='example wgsl global-scope' heading='Structure WGSL'>
   <xmp>
-    // TODO: runtime-sized array syntax may have changed
     // Runtime Array
     type RTArr = array<vec4<f32>>;
     struct S {
@@ -2952,7 +2951,6 @@ sampler_comparison
 </pre>
 
 ### Texture Types Grammar ### {#texture-types-grammar}
-TODO: Add texture usage validation rules.
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>texture_sampler_types</dfn> :
@@ -3484,11 +3482,6 @@ is the one from the constant's declaration or from a pipeline override.
          %f = OpConstantComposite %v4float %f0 %f1 %f2 %f1
   </xmp>
 </div>
-
-Issue(dneto): The WebGPU pipeline creation API must specify how API-supplied values are mapped to
-shader scalar values.  For booleans, I suggest using a 32-bit integer, where only 0 maps to `false`.
-If [SHORTNAME] gains non-32-bit numeric scalars, I recommend overridable constants continue being 32-bit
-numeric types.
 
 ## Function Scope Variables and Constants ## {#function-scope-variables}
 
@@ -6975,8 +6968,6 @@ the corresponding builtin must be an output for the entry point's shader stage.
 
 Note: The `position` built-in is both an output of a vertex shader, and an input to the fragement shader.
 
-Issue: in Vulkan, built-in variables occupy I/O location slots counting toward limits.
-
 #### User-defined Inputs and Outputs #### {#user-defined-inputs-outputs}
 
 User-defined data can be passed as input to the start of a pipeline, passed
@@ -7211,18 +7202,8 @@ where compatibility is defined by the following table.
       <td>[[WebGPU#dom-gpustoragetextureaccess-write-only|write-only]]
 </table>
 
-TODO: Describe when filtering or non-filtering samplers are valid.
-
-TODO: Describe when float vs. unfilterable float sampled textures are valid.
-
-
-The region of a [[WebGPU#buffer-interface|WebGPU GPUBuffer]] bound to a buffer variable
-must be large enough to cover all the memory locations accessible via the variable.
-The <dfn noexport>minimium binding size</dfn> of a buffer variable with store type |T| is [=SizeOf=](|T|).
-In this calculation, if |T| is a [=runtime-sized=] array or contains a runtime-sized array, that array is assumed
-to have one element.
-
-TODO: Describe other interface matching requirements, e.g. for images?
+See the [[WebGPU#abstract-opdef-validating-gpuprogrammablestage|WebGPU API]]
+specification for interface validation requirements.
 
 # Language extensions # {#language-extensions}
 
@@ -7461,10 +7442,6 @@ WebGPU provides no guarantees about:
 * Whether invocations from one particular workgroup begin executing before
     the invocations of another workgroup.
     That is, you cannot assume that workgroups are launched in a particular order.
-
-Issue: [WebGPU issue 1045](https://github.com/gpuweb/gpuweb/issues/1045):
-Dispatch group counts must be positive.
-However, how do we handle an indirect dispatch that specifies a group count of zero.
 
 ## Collective operations ## {#collective-operations}
 


### PR DESCRIPTION
* Defer API linkage issues to the API spec
* remove issues and todos that are covered in the API
* remove todo about array syntax