### PR TITLE
[editorial] Use consistent capitalisation in section titles

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -318,7 +318,7 @@ The events are ordered due to:
 *  data dependencies: shader execution requires a pipeline, and a pipeline requires a shader module.
 *  causality: the shader must start executing before it can finish executing.
 
-## Processing errors ## {#processing-errors}
+## Processing Errors ## {#processing-errors}
 
 A WebGPU implementation may fail to process a shader for two reasons:
 
@@ -361,7 +361,7 @@ results in a shader-creation, pipeline-creation, or dynamic error.
 
 The WebGPU specification describes the consequences of each kind of error.
 
-# Textual structure # {#textual-structure}
+# Textual Structure # {#textual-structure}
 
 A [SHORTNAME] program is text.
 This specification does not prescribe a particular encoding for that text.
@@ -949,7 +949,7 @@ Otherwise there is a <dfn noexport>type error</dfn> and the source program is no
 because type checking a [SHORTNAME] program will either succeed or
 discover a type error, while only having to inspect the program source text.
 
-### Type rule tables ### {#typing-tables-section}
+### Type Rule Tables ### {#typing-tables-section}
 
 The [SHORTNAME] [=type rules=] are organized into <dfn noexport>type rule tables</dfn>,
 with one row per type rule.
@@ -975,11 +975,11 @@ Note: Plain types in [SHORTNAME] are similar to Plain-Old-Data types in C++, but
 
 ### Boolean Type ### {#bool-type}
 
-The <dfn dfn noexport>bool</dfn> type contains the values `true` and `false`.
+The <dfn noexport>bool</dfn> type contains the values `true` and `false`.
 
 ### Integer Types ### {#integer-types}
 
-The <dfn dfn noexport>u32</dfn> type is the set of 32-bit unsigned integers.
+The <dfn noexport>u32</dfn> type is the set of 32-bit unsigned integers.
 
 The <dfn noexport>i32</dfn> type is the set of 32-bit signed integers.
 It uses a two's complementation representation, with the sign bit in the most significant bit position.
@@ -991,11 +991,11 @@ See [[#floating-point-evaluation]] for details.
 
 ### Scalar Types ### {#scalar-types}
 
-The <dfn dfn noexport>scalar</dfn> types are [=bool=], [=i32=], [=u32=], and [=f32=].
+The <dfn noexport>scalar</dfn> types are [=bool=], [=i32=], [=u32=], and [=f32=].
 
-The <dfn dfn noexport>numeric scalar</dfn> types are [=i32=], [=u32=], and [=f32=].
+The <dfn noexport>numeric scalar</dfn> types are [=i32=], [=u32=], and [=f32=].
 
-The <dfn dfn noexport>integer scalar</dfn> types are [=i32=] and [=u32=].
+The <dfn noexport>integer scalar</dfn> types are [=i32=] and [=u32=].
 
 ### Vector Types ### {#vector-types}
 
@@ -1513,7 +1513,7 @@ A storable type may have an explicit representation defined by WGSL,
 as described in [[#internal-value-layout]],
 or it may be opaque, such as for textures and samplers.
 
-A type is <dfn dfn noexport>storable</dfn> if it is one of:
+A type is <dfn noexport>storable</dfn> if it is one of:
 
 * a [=scalar=] type
 * a [=vector=] type
@@ -1530,7 +1530,7 @@ Note: That is, the storable types are the [=plain types=], texture types, and sa
 
 Pipeline input and output values must be of IO-shareable type.
 
-A type is <dfn dfn noexport>IO-shareable</dfn> if it is one of:
+A type is <dfn noexport>IO-shareable</dfn> if it is one of:
 
 * a [=scalar=] type
 * a [=numeric vector=] type
@@ -1555,7 +1555,7 @@ as described in [[#memory-layouts]].
 We will see in [[#module-scope-variables]] that the [=store type=] of [=uniform buffer=] and [=storage buffer=]
 variables must be host-shareable.
 
-A type is <dfn dfn noexport>host-shareable</dfn> if it is one of:
+A type is <dfn noexport>host-shareable</dfn> if it is one of:
 
 * a [=numeric scalar=] type
 * a [=numeric vector=] type
@@ -2208,7 +2208,7 @@ When writing a [=variable declaration=] or a [=pointer type=] in [SHORTNAME] sou
 * For the [=address spaces/storage=] address space, the access mode is optional, and defaults to [=access/read=].
 * For other address spaces, the access mode must not be written.
 
-### Originating variable ### {#originating-variable-section}
+### Originating Variable ### {#originating-variable-section}
 
 In [SHORTNAME] a reference value always corresponds to the memory view
 for some or all of the memory locations for some variable.
@@ -2239,7 +2239,7 @@ memory reference</dfn> is produced.
 reference must load and store from the same [=memory locations|memory
 locations=] if they access memory.
 
-### Use cases for references and pointers ### {#ref-ptr-use-cases}
+### Use Cases for References and Pointers ### {#ref-ptr-use-cases}
 
 References and pointers are distinguished by how they are used:
 
@@ -2377,7 +2377,7 @@ Note: The following examples use [SHORTNAME] features explained later in this sp
   </xmp>
 </div>
 
-### Forming reference and pointer values ### {#forming-references-and-pointers}
+### Forming Reference and Pointer Values ### {#forming-references-and-pointers}
 
 A reference value is formed in one of the following ways:
 
@@ -2541,7 +2541,7 @@ In all cases, the access mode of the result is the same as the access mode of th
   </xmp>
 </div>
 
-### Comparison with references and pointers in other languages ### {#pointers-other-languages}
+### Comparison with References and Pointers in Other Languages ### {#pointers-other-languages}
 
 This section is informative, not normative.
 
@@ -2677,7 +2677,7 @@ format.
 
 Note: The handle stored by a sampler variable cannot be changed by the shader.
 
-### Texel formats ### {#texel-formats}
+### Texel Formats ### {#texel-formats}
 
 In [SHORTNAME], certain texture types are parameterized by texel format.
 
@@ -2721,7 +2721,7 @@ This is also known as the <dfn noexport>channel transfer function</dfn>, or CTF.
 </table>
 
 The texel formats listed in the
-<dfn dfn lt="storage-texel-formats">Texel Formats for Storage Textures</dfn> table
+<dfn lt="storage-texel-formats">Texel Formats for Storage Textures</dfn> table
 correspond to the [[WebGPU#plain-color-formats|WebGPU plain color formats]]
 which support the [[WebGPU#dom-gputextureusage-storage|WebGPU STORAGE]] usage.
 These texel formats are used to parameterize the storage texture types defined
@@ -3270,7 +3270,7 @@ When an [=identifier=] use [=resolves=] to a override-declaration, the identifie
 
 ## `var` Declarations ## {#var-decls}
 
-A <dfn dfn noexport>variable</dfn> is a named reference to memory that can contain a value of a
+A <dfn noexport>variable</dfn> is a named reference to memory that can contain a value of a
 particular [=storable=] type.
 
 Two types are associated with a variable: its [=store type=] (the type of value
@@ -3279,7 +3279,7 @@ of the variable itself).
 If a variable has store type *T*, [=address space=] *S*, and [=access mode=] *A*,
 then its reference type is ref&lt;*S*,*T*,*A*&gt;.
 
-A <dfn dfn noexport>variable declaration</dfn>:
+A <dfn noexport>variable declaration</dfn>:
 
 * Specifies the variable’s name.
 * Specifies the [=address space=], [=store type=], and [=access mode=].
@@ -4201,7 +4201,7 @@ The result type depends on the number of letters provided. Assuming a `vec4<f32>
   </xmp>
 </div>
 
-#### Vector single component selection #### {#vector-single-component}
+#### Vector Single Component Selection #### {#vector-single-component}
 
 <table class='data'>
   <caption>Vector decomposition: single component selection</caption>
@@ -4244,7 +4244,7 @@ The result type depends on the number of letters provided. Assuming a `vec4<f32>
            (OpVectorExtractDynamic)
 </table>
 
-#### Vector multiple component selection #### {#vector-multi-component}
+#### Vector Multiple Component Selection #### {#vector-multi-component}
 
 <table class='data'>
   <caption>Vector decomposition: multiple component selection
@@ -4325,7 +4325,7 @@ The result type depends on the number of letters provided. Assuming a `vec4<f32>
            (OpVectorShuffle)
 </table>
 
-#### Component reference from vector reference #### {#component-reference-from-vector-reference}
+#### Component Reference from Vector Reference #### {#component-reference-from-vector-reference}
 
 A [=write access=] to component of a vector **may** access all of the [=memory
 location|memory locations=] associated with that vector.
@@ -5612,7 +5612,7 @@ The expression must evaluate to a reference with an [=integer scalar=] [=store t
       </xmp>
     </div>
 
-## Control flow ## {#control-flow}
+## Control Flow ## {#control-flow}
 
 Control flow statements may cause the program to execute in non-sequential order.
 
@@ -6592,7 +6592,7 @@ There are two kinds of functions:
     See [[#builtin-functions]].
 * A <dfn noexport>user-defined function</dfn> is declared in a [SHORTNAME] program.
 
-## Declaring a user-defined function ## {#function-declaration-sec}
+## Declaring a User-defined Function ## {#function-declaration-sec}
 
 A <dfn noexport>function declaration</dfn> creates a user-defined function, by specifying:
 * An optional set of attributes.
@@ -6811,7 +6811,7 @@ programmable parts of pipelines:
 
 Each shader stage has its own set of features and constraints, described elsewhere.
 
-## Entry point declaration ## {#entry-point-decl}
+## Entry Point Declaration ## {#entry-point-decl}
 
 To create an [=entry point=], declare a [=user-defined function=] with a [=attribute/stage=] attribute.
 
@@ -6864,7 +6864,7 @@ The set of <dfn noexport>functions in a shader stage</dfn> is the union of:
 The union is applied repeatedly until it stabilizes.
 It will stabilize in a finite number of steps.
 
-### Function attributes for entry points ### {#entry-point-attributes}
+### Function Attributes for Entry Points ### {#entry-point-attributes}
 
 [SHORTNAME] defines the following attributes that can be applied to entry point declarations:
  * [=attribute/stage=]
@@ -7132,7 +7132,7 @@ User-defined IO can be mixed with built-in values in the same structure. For exa
   </xmp>
 </div>
 
-### Resource interface ### {#resource-interface}
+### Resource Interface ### {#resource-interface}
 
 A <dfn noexport>resource</dfn> is an object,
 other than a [[#pipeline-inputs-outputs|pipeline input or output]],
@@ -7160,7 +7160,7 @@ Bindings must not alias within a shader stage:
 two different variables in the resource interface of a given
 shader must not have the same group and binding values, when considered as a pair of values.
 
-### Resource layout compatibility ### {#resource-layout-compatibility}
+### Resource Layout Compatibility ### {#resource-layout-compatibility}
 
 WebGPU requires that a shader's resource interface match the [[WebGPU#pipeline-layout|layout of the pipeline]]
 using the shader.
@@ -7224,7 +7224,7 @@ to have one element.
 
 TODO: Describe other interface matching requirements, e.g. for images?
 
-# Language extensions # {#language-extensions}
+# Language Extensions # {#language-extensions}
 
 The [SHORTNAME] language is expected to evolve over time.
 
@@ -7348,7 +7348,7 @@ A program must satisfy the following limits:
 This section describes further constraints on how invocations execute,
 individually and collectively.
 
-## Program order within an invocation ## {#program-order}
+## Program Order Within an Invocation ## {#program-order}
 
 Each statement in a [SHORTNAME] program may be executed zero or more times during
 execution.
@@ -7373,11 +7373,11 @@ See [[#statements]] and [[#function-calls]].
 
 ## Uniformity TODO ## {#uniformity}
 
-### Uniform control flow TODO ### {#uniform-control-flow}
+### Uniform Control Flow TODO ### {#uniform-control-flow}
 
-### Divergence and reconvergence TODO ### {#divergence-reconvergence}
+### Divergence and Reconvergence TODO ### {#divergence-reconvergence}
 
-### Uniformity restrictions TODO ### {#uniformity-restrictions}
+### Uniformity Restrictions TODO ### {#uniformity-restrictions}
 
 ## Compute Shaders and Workgroups ## {#compute-shader-workgroups}
 
@@ -7466,7 +7466,7 @@ Issue: [WebGPU issue 1045](https://github.com/gpuweb/gpuweb/issues/1045):
 Dispatch group counts must be positive.
 However, how do we handle an indirect dispatch that specifies a group count of zero.
 
-## Collective operations ## {#collective-operations}
+## Collective Operations ## {#collective-operations}
 
 ### Barriers ### {#barrier}
 
@@ -7652,7 +7652,7 @@ at least as accurate as the original formulation.
 For example, some fused multiply-add implementations can be more accurate
 than performing a multiply followed by an addition.
 
-### Floating point conversion ### {#floating-point-conversion}
+### Floating Point Conversion ### {#floating-point-conversion}
 
 In this section, a floating point type may be any of:
 * The [=f32=] type in WGSL.
@@ -7823,7 +7823,7 @@ semantics.
 Note: No atomic or synchronization built-in functions use `MakeAvailable` or
 `MakeVisible` semantics.
 
-## Private vs Non-Private ## {#private-vs-non-private}
+## Private vs Non-private ## {#private-vs-non-private}
 
 All non-atomic [=read accesses=] in the [=address spaces/storage=] or
 [=address spaces/workgroup=] address spaces are considered
@@ -8468,7 +8468,7 @@ A <dfn>syntactic token</dfn> is a sequence of special characters, used:
     | `'<<='`
 </div>
 
-# Built-in values # {#builtin-values}
+# Built-in Values # {#builtin-values}
 
 The following table lists the available [=built-in input values=] and [=built-in output values=].
 
@@ -8659,7 +8659,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in value.
   </xmp>
 </div>
 
-# Built-in functions # {#builtin-functions}
+# Built-in Functions # {#builtin-functions}
 
 Certain functions are [=predeclared=], provided by the implementation, and
 therefore always available for use in a [SHORTNAME] program.
@@ -8684,7 +8684,7 @@ When calling a built-in function, all arguments to the function are evaluated
 before function evaluation begins.
 See [[#function-calls]].
 
-## Logical built-in functions ## {#logical-builtin-functions}
+## Logical Built-in Functions ## {#logical-builtin-functions}
 
 <table class='data'>
   <thead>
@@ -8726,7 +8726,7 @@ See [[#function-calls]].
         (OpSelect)
 </table>
 
-## Array built-in functions ## {#array-builtin-functions}
+## Array Built-in Functions ## {#array-builtin-functions}
 <table class='data'>
   <thead>
     <tr><th>Parameterization<th>Overload<th>Description
@@ -8738,7 +8738,7 @@ See [[#function-calls]].
         (OpArrayLength, but the implementation has to trace back to get the pointer to the enclosing struct.)
 </table>
 
-## Float built-in functions ## {#float-builtin-functions}
+## Float Built-in Functions ## {#float-builtin-functions}
 
 <table class='data'>
   <thead>
@@ -9146,7 +9146,7 @@ struct __modf_result_vecN {
     (GLSLstd450Trunc)
 </table>
 
-## Integer built-in functions ## {#integer-builtin-functions}
+## Integer Built-in Functions ## {#integer-builtin-functions}
 
 <table class='data'>
   <thead>
@@ -9332,7 +9332,7 @@ struct __modf_result_vecN {
         (SPIR-V OpBitReverse)
 </table>
 
-## Matrix built-in functions ## {#matrix-builtin-functions}
+## Matrix Built-in Functions ## {#matrix-builtin-functions}
 <table class='data'>
   <thead>
     <tr><th>Parameterization<th>Overload<th>Description
@@ -9349,7 +9349,7 @@ struct __modf_result_vecN {
     (OpTranspose)
 </table>
 
-## Vector built-in functions ## {#vector-builtin-functions}
+## Vector Built-in Functions ## {#vector-builtin-functions}
 
 <table class='data'>
   <thead>
@@ -9369,7 +9369,7 @@ struct __modf_result_vecN {
     (SPV_KHR_integer_dot_product OpUDotKHR)
 </table>
 
-## Derivative built-in functions ## {#derivative-builtin-functions}
+## Derivative Built-in Functions ## {#derivative-builtin-functions}
 
 See [[#derivatives]].
 
@@ -9424,7 +9424,7 @@ These functions:
     (OpFwidthFine)
 </table>
 
-## Texture built-in functions ## {#texture-builtin-functions}
+## Texture Built-in Functions ## {#texture-builtin-functions}
 
 In this section, texture types are shown with the following parameters:
 * |T|, a sampled type.
@@ -10105,7 +10105,7 @@ If an out-of-bounds access occurs, the built-in function may do any of the follo
 TODO(dsinclair): Need gather operations
 </pre>
 
-## Atomic built-in functions ## {#atomic-builtin-functions}
+## Atomic Built-in Functions ## {#atomic-builtin-functions}
 
 Atomic built-in functions can be used to read/write/read-modify-write atomic
 objects. They are the only operations allowed on [[#atomic-types]].
@@ -10148,7 +10148,7 @@ atomicStore(atomic_ptr: ptr<SC, atomic<T>, A>, v: T)
 
 Atomically stores the value `v` in the atomic object pointed to by `atomic_ptr`.
 
-### Atomic Read-Modify-Write ### {#atomic-rmw}
+### Atomic Read-modify-write ### {#atomic-rmw}
 
 ```rust
 atomicAdd(atomic_ptr: ptr<SC, atomic<T>, A>, v: T) -> T
@@ -10214,7 +10214,7 @@ Note: the equality comparison may spuriously fail on some implementations. That
 is, the second element of the result vector may be `false` even if the first
 element of the result vector equals `cmp`.
 
-## Data packing built-in functions ## {#pack-builtin-functions}
+## Data Packing Built-in Functions ## {#pack-builtin-functions}
 
 Data packing builtin functions can be used to encode values using data formats that
 do not correspond directly to types in [SHORTNAME].
@@ -10272,7 +10272,7 @@ reduce a shader's memory bandwidth demand.
         See [[#floating-point-conversion]].
 </table>
 
-## Data unpacking built-in functions ## {#unpack-builtin-functions}
+## Data Unpacking Built-in Functions ## {#unpack-builtin-functions}
 
 Data unpacking builtin functions can be used to decode values in
 data formats that do not correspond directly to types in [SHORTNAME].
@@ -10321,7 +10321,7 @@ reduce a shader's memory bandwidth demand.
         See [[#floating-point-conversion]].
 </table>
 
-## Synchronization built-in functions ## {#sync-builtin-functions}
+## Synchronization Built-in Functions ## {#sync-builtin-functions}
 
 [SHORTNAME] provides the following synchronization functions:
 
@@ -10377,10 +10377,3 @@ workgroupBarrier affects memory and atomic operations in the [=address spaces/wo
   </xmp>
 </div>
 
-
-# MATERIAL TO BE MOVED TO A NEW HOME OR DELETED # {#junkyard}
-
-
-[SHORTNAME] has operations for:
-
-* creating a new composite value from an old one by replacing one of its components


### PR DESCRIPTION
* remove some unnecessary `dfn` tags