### PR TITLE
Rework "validating texture copy range" for 1D/3D textures.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6465,7 +6465,7 @@ The following definitions and validation rules are used by these methods, as wel
 
 Issue: Does the term "image copy" include copyTextureToTexture?
 
-[=imageCopyTexture subresource size=] and [=Valid Texture Copy Range=] also applies to
+[=imageCopyTexture subresource size=] and [=validating texture copy range=] also applies to
 {{GPUCommandEncoder/copyTextureToTexture()}}.
 
 <div algorithm="imageCopyTexture subresource size">
@@ -6550,40 +6550,32 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
 </div>
 
 <div algorithm class=validusage>
+    <dfn dfn>validating texture copy range</dfn>(imageCopyTexture, copSize)
 
-<dfn dfn>Valid Texture Copy Range</dfn>
+    **Arguments:**
+    : {{GPUImageCopyTexture}} |imageCopyTexture|
+    :: The texture subresource being copied into and copy origin.
+    : {{GPUExtent3D}} |copySize|
+    :: The size of the texture.
 
-Given a {{GPUImageCopyTexture}} |imageCopyTexture| and a {{GPUExtent3D}} |copySize|, let
-  - |blockWidth| be the [=texel block width=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
-  - |blockHeight| be the [=texel block height=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
+    1. Let |blockWidth| be the [=texel block width=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
+    1. Let |blockHeight| be the [=texel block height=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
+    1. Let |subresourceSize| be the [=imageCopyTexture subresource size=] of |imageCopyTexture|.
 
-The following validation rules apply:
+    1. Return whether all the conditions below are satisfied:
 
-  - If the {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} of |imageCopyTexture|.{{GPUImageCopyTexture/texture}} is
-    {{GPUTextureDimension/1d}}:
-    - Both |copySize|.[=Extent3D/height=] and [=Extent3D/depthOrArrayLayers=] must be 1.
-  - If the {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} of |imageCopyTexture|.{{GPUImageCopyTexture/texture}} is
-    {{GPUTextureDimension/2d}}:
-     -  (|imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/x=] + |copySize|.[=Extent3D/width=]),
-        (|imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/y=] + |copySize|.[=Extent3D/height=]), and
-        (|imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/z=] + |copySize|.[=Extent3D/depthOrArrayLayers=])
-        must be less than or equal to the
-        [=Extent3D/width=], [=Extent3D/height=], and [=Extent3D/depthOrArrayLayers=], respectively,
-        of the [=imageCopyTexture subresource size=] of |imageCopyTexture|.
-  - |copySize|.[=Extent3D/width=] must be a multiple of |blockWidth|.
-  - |copySize|.[=Extent3D/height=] must be a multiple of |blockHeight|.
+      - (|imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/x=] + |copySize|.[=Extent3D/width=]) &le; |subresourceSize|.[=Extent3D/width=]
+      - (|imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/y=] + |copySize|.[=Extent3D/height=]) &le; |subresourceSize|.[=Extent3D/height=]
+      - (|imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/z=] + |copySize|.[=Extent3D/depthOrArrayLayers=]) &le; |subresourceSize|.[=Extent3D/depthOrArrayLayers=]
+      - |copySize|.[=Extent3D/width=] must be a multiple of |blockWidth|.
+      - |copySize|.[=Extent3D/height=] must be a multiple of |blockHeight|.
 
 </div>
-
-Issue(gpuweb/gpuweb#69): Define the copies with {{GPUTextureDimension/1d}} and
-{{GPUTextureDimension/3d}} textures.
 
 Issue(gpuweb/gpuweb#537): Additional restrictions on rowsPerImage if needed.
 
 Issue(gpuweb/gpuweb#652): Define the copies with {{GPUTextureFormat/"depth24plus"}},
 {{GPUTextureFormat/"depth24plus-stencil8"}}, and {{GPUTextureFormat/"stencil8"}}.
-
-Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, similar to "validating linear texture data"
 
 <dl dfn-type=method dfn-for=GPUCommandEncoder>
     : <dfn>copyBufferToTexture(source, destination, copySize)</dfn>
@@ -6618,7 +6610,7 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
                             - |destination|.{{GPUImageCopyTexture/aspect}} must refer to a single aspect of
                                 |dstTextureDesc|.{{GPUTextureDescriptor/format}}, and that aspect must be
                                 a valid image copy destination according to [[#depth-formats]].
-                        - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
+                        - [=validating texture copy range=](|destination|, |copySize|) return `true`.
                         - If |dstTextureDesc|.{{GPUTextureDescriptor/format}} is not a [=depth-or-stencil format=]:
                             - |source|.{{GPUImageDataLayout/offset}} is a multiple of the [=texel block size=] of
                                 |dstTextureDesc|.{{GPUTextureDescriptor/format}}.
@@ -6665,7 +6657,7 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
                         - [$validating GPUImageCopyBuffer$](|destination|) returns `true`.
                         - |destination|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[usage]]}} contains
                             {{GPUBufferUsage/COPY_DST}}.
-                        - [=Valid Texture Copy Range=] applies to |source| and |copySize|.
+                        - [=validating texture copy range=](|source|, |copySize|) returns `true`.
                         - If |srcTextureDesc|.{{GPUTextureDescriptor/format}} is not a [=depth-or-stencil format=]:
                             - |destination|.{{GPUImageDataLayout/offset}} is a multiple of the [=texel block size=] of
                                 |srcTextureDesc|.{{GPUTextureDescriptor/format}}.
@@ -6715,8 +6707,8 @@ Issue: convert "Valid Texture Copy Range" into an algorithm with parameters, sim
                             - |source|.{{GPUImageCopyTexture/aspect}} and |destination|.{{GPUImageCopyTexture/aspect}}
                                 must both refer to all aspects of |srcTextureDesc|.{{GPUTextureDescriptor/format}}
                                 and |dstTextureDesc|.{{GPUTextureDescriptor/format}}, respectively.
-                        - [=Valid Texture Copy Range=] applies to |source| and |copySize|.
-                        - [=Valid Texture Copy Range=] applies to |destination| and |copySize|.
+                        - [=validating texture copy range=](|source|, |copySize|) return `true`.
+                        - [=validating texture copy range=](|destination|, |copySize|) returns `true`.
                         - The [$set of subresources for texture copy$](|source|, |copySize|) and
                             the [$set of subresources for texture copy$](|destination|, |copySize|) is disjoint.
                     </div>
@@ -8765,7 +8757,7 @@ GPUQueue includes GPUObjectBase;
                             - [$validating GPUImageCopyTexture$](|destination|, |size|) returns `true`.
                             - |textureDesc|.{{GPUTextureDescriptor/usage}} includes {{GPUTextureUsage/COPY_DST}}.
                             - |textureDesc|.{{GPUTextureDescriptor/sampleCount}} is 1.
-                            - [=Valid Texture Copy Range=](|destination|, |size|) is satisfied.
+                            - [=validating texture copy range=](|destination|, |size|) return `true`.
                             - |destination|.{{GPUImageCopyTexture/aspect}} must refer to a single aspect of
                                 |textureDesc|.{{GPUTextureDescriptor/format}}, and that aspect must be
                                 a valid image copy destination according to [[#depth-formats]].
@@ -8833,8 +8825,8 @@ GPUQueue includes GPUObjectBase;
                     1. If any of the following requirements are unmet, generate a validation error and stop.
                         <div class=validusage>
                             - |destination|.{{GPUImageCopyTexture/texture}} must be [$valid to use with$] |this|.
-                            - [$validating GPUImageCopyTexture$](destination, copySize) must return true.
-                            - [=Valid Texture Copy Range=](destination, copySize) must be satisfied.
+                            - [$validating GPUImageCopyTexture$](destination, copySize) must return `true`.
+                            - [=validating texture copy range=](destination, copySize) must return `true`.
                             - |textureDesc|.{{GPUTextureDescriptor/usage}} must include both
                                 {{GPUTextureUsage/RENDER_ATTACHMENT}} and {{GPUTextureUsage/COPY_DST}}.
                             - |textureDesc|.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"2d"}}.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6707,7 +6707,7 @@ Issue(gpuweb/gpuweb#652): Define the copies with {{GPUTextureFormat/"depth24plus
                             - |source|.{{GPUImageCopyTexture/aspect}} and |destination|.{{GPUImageCopyTexture/aspect}}
                                 must both refer to all aspects of |srcTextureDesc|.{{GPUTextureDescriptor/format}}
                                 and |dstTextureDesc|.{{GPUTextureDescriptor/format}}, respectively.
-                        - [=validating texture copy range=](|source|, |copySize|) return `true`.
+                        - [=validating texture copy range=](|source|, |copySize|) returns `true`.
                         - [=validating texture copy range=](|destination|, |copySize|) returns `true`.
                         - The [$set of subresources for texture copy$](|source|, |copySize|) and
                             the [$set of subresources for texture copy$](|destination|, |copySize|) is disjoint.


### PR DESCRIPTION
That algorithm special cased 1D and 2D textures, making empty copies
valid for 2D and not for 1D. 3D textures where just not discussed.

Fix this by just checking that the copy fits in the subresource size,
and also turn "validating texture copy range" into an algorithm with
arguments.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Feb 7, 2022, 8:17 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FKangz%2Fgpuweb%2F67f54ea2eae28d7e217b238d6445336061e2e1ef%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%232548.)._
</details>
