### PR TITLE
Fix canvas resizing example

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9405,7 +9405,7 @@ must be reconfigured by calling {{GPUCanvasContext/configure()}} again with the 
 
         const resizeObserver = new ResizeObserver(entries => {
             for (const entry of entries) {
-                if (entry != canvas) { continue; }
+                if (entry.target != canvas) { continue; }
                 context.configure({
                     device: gpuDevice,
                     format: context.getPreferredFormat(gpuAdapter),


### PR DESCRIPTION
It seems like it should be the `target` property, see [https://www.w3.org/TR/resize-observer/#dom-resizeobserverentry-target](https://www.w3.org/TR/resize-observer/#dom-resizeobserverentry-target).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bbbbx/gpuweb/pull/2549.html" title="Last updated on Jan 28, 2022, 5:00 PM UTC (ec825a8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2549/ddccd82...bbbbx:ec825a8.html" title="Last updated on Jan 28, 2022, 5:00 PM UTC (ec825a8)">Diff</a>