### PR TITLE
Resurrect canvas srgb formats

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9357,13 +9357,9 @@ interface GPUCanvasContext {
 The <dfn dfn>supported context formats</dfn> are a [=set=] of {{GPUTextureFormat}}s that must be
 supported when specified as a {{GPUCanvasConfiguration}}.{{GPUCanvasConfiguration/format}}
 regardless of the given {{GPUCanvasConfiguration}}.{{GPUCanvasConfiguration/device}},
-initially set to: &laquo;{{GPUTextureFormat/"bgra8unorm"}}, {{GPUTextureFormat/"rgba8unorm"}},
+initially set to: &laquo;{{GPUTextureFormat/"bgra8unorm"}}, {{GPUTextureFormat/"bgra8unorm-srgb"}},
+{{GPUTextureFormat/"rgba8unorm"}}, {{GPUTextureFormat/"rgba8unorm-srgb"}},
 {{GPUTextureFormat/"rgba16float"}}&raquo;.
-
-Note: Canvas configuration cannot use `srgb` formats like {{GPUTextureFormat/"bgra8unorm-srgb"}}.
-Instead, use the non-`srgb` equivalent ({{GPUTextureFormat/"bgra8unorm"}}), specify the `srgb`
-format in the {{GPUCanvasConfiguration/viewFormats}}, and use {{GPUTexture/createView()}} to create
-a view with an `srgb` format.
 
 <script type=idl>
 


### PR DESCRIPTION
We just removed these in #2522 with the intent of just using viewFormat to get `-srgb` texture views into the canvas.

But I'm proposing adding them back because on some systems (current D3D12, Vulkan without extension), enabling srgb viewFormats are likely more costly than just returning an srgb format. Internally, it may need to be reinterpreted, but hopefully sometimes it doesn't.

Implementation cost should be small (hopefully) and this is slightly more convenient for developers also.

https://github.com/gpuweb/gpuweb/discussions/2537#discussioncomment-2062936
https://github.com/gpuweb/gpuweb/pull/2540#discussion_r794095160


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2551.html" title="Last updated on Feb 7, 2022, 11:47 PM UTC (f9bbe88)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2551/26e16be...kainino0x:f9bbe88.html" title="Last updated on Feb 7, 2022, 11:47 PM UTC (f9bbe88)">Diff</a>