### PR TITLE
Vectors consist of components

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1005,7 +1005,7 @@ A <dfn noexport>vector</dfn> is a grouped sequence of 2, 3, or 4 [=scalar=] comp
   <thead>
     <tr><th>Type<th>Description
   </thead>
-  <tr><td>vec*N*<*T*><td>Vector of *N* elements of type *T*.
+  <tr><td>vec*N*<*T*><td>Vector of *N* components of type *T*.
                           *N* must be in {2, 3, 4} and *T*
                           must be one of the [=scalar=] types.
                           We say *T* is the <dfn noexport>component type</dfn> of the vector.
@@ -3640,7 +3640,7 @@ See also [[#zero-value-expr]] and [[#conversion-expr]].
   <tr algorithm="construct a vector from copies of a single scalar">
     <td rowspan=2>|e|: |T|
     <td>`vec`|N|`<`|T|`>(`|e|`)`: vec|N|&lt;|T|&gt;
-    <td rowspan=2>Evaluates |e| once. Results in the |N|-element vector where each component has the value of |e|.
+    <td rowspan=2>Evaluates |e| once. Results in the |N|-component vector where each component has the value of |e|.
   <tr>
     <td>`vec`|N|`(`|e|`)`: vec|N|&lt;|T|&gt;
   <tr>
@@ -3842,7 +3842,7 @@ The zero values are as follows:
 * `i32()` is 0
 * `u32()` is 0
 * `f32()` is 0.0
-* The zero value for an *N*-element vector of type *T* is the *N*-element vector of the zero value for *T*.
+* The zero value for an *N*-component vector of type *T* is the *N*-component vector of the zero value for *T*.
 * The zero value for an *N*-column *M*-row matrix of `f32` is the matrix of those dimensions filled with 0.0 entries.
 * The zero value for a [=constructible=] *N*-element array with element type *E* is an array of *N* elements of the zero value for *E*.
 * The zero value for a [=constructible=] structure type *S* is the structure value *S* with zero-valued members.
@@ -3883,10 +3883,10 @@ Note: WGSL does not have zero expression for [=atomic types=],
 
 <div class='example' heading="Zero-valued vectors">
   <xmp highlight='rust'>
-    vec2<f32>()                 // The zero-valued vector of two f32 elements.
+    vec2<f32>()                 // The zero-valued vector of two f32 components.
     vec2<f32>(0.0, 0.0)         // The same value, written explicitly.
 
-    vec3<i32>()                 // The zero-valued vector of three i32 elements.
+    vec3<i32>()                 // The zero-valued vector of three i32 components.
     vec3<i32>(0, 0, 0)          // The same value, written explicitly.
   </xmp>
 </div>
@@ -4158,18 +4158,18 @@ value in one type as a value in another type.
 
 ### Vector Access Expression ### {#vector-access-expr}
 
-Accessing members of a vector can be done either using array subscripting (e.g. `a[2]`) or using a sequence of convenience names, each mapping to an element of the source vector.
+Accessing members of a vector can be done either using array subscripting (e.g. `a[2]`) or using a sequence of convenience names, each mapping to a component of the source vector.
 
 <ul>
-  <li>The colour set of convenience names: `r`, `g`, `b`, `a` for vector elements 0, 1, 2, and 3 respectively.
-  <li>The dimensional set of convenience names: `x`, `y`, `z`, `w` for vector elements 0, 1, 2, and 3, respectively.
+  <li>The colour set of convenience names: `r`, `g`, `b`, `a` for vector components 0, 1, 2, and 3 respectively.
+  <li>The dimensional set of convenience names: `x`, `y`, `z`, `w` for vector components 0, 1, 2, and 3, respectively.
 </ul>
 
 The convenience names are accessed using the `.` notation. (e.g. `color.bgra`).
 
 NOTE: the convenience letterings can not be mixed. (i.e. you can not use `rybw`).
 
-Using a convenience letter, or array subscript, which accesses an element past the end of the vector is an error.
+Using a convenience letter, or array subscript, which accesses a component past the end of the vector is an error.
 
 The convenience letterings can be applied in any order, including duplicating letters as needed. You can provide 1 to 4 letters when extracting components from a vector. Providing more then 4 letters is an error.
 
@@ -4251,7 +4251,7 @@ The result type depends on the number of letters provided. Assuming a `vec4<f32>
           |J| is the letter `x`, `y`, `z`, or `w`<br>
        <td class="nowrap">
            |e|`.`|I||J|: vec2&lt;|T|&gt;<br>
-       <td>Computes the two-element vector with first component |e|.|I|, and second component |e|.|J|.<br>
+       <td>Computes the two-component vector with first component |e|.|I|, and second component |e|.|J|.<br>
            Letter `z` is valid only when |N| is 3 or 4.<br>
            Letter `w` is valid only when |N| is 4.<br>
            (OpVectorShuffle)
@@ -4262,7 +4262,7 @@ The result type depends on the number of letters provided. Assuming a `vec4<f32>
           |J| is the letter `r`, `g`, `b`, or `a`<br>
        <td class="nowrap">
            |e|`.`|I||J|: vec2&lt;|T|&gt;<br>
-       <td>Computes the two-element vector with first component |e|.|I|, and second component |e|.|J|.<br>
+       <td>Computes the two-component vector with first component |e|.|I|, and second component |e|.|J|.<br>
            Letter `b` is valid only when |N| is 3 or 4.<br>
            Letter `a` is valid only when |N| is 4.<br>
            (OpVectorShuffle)
@@ -4274,7 +4274,7 @@ The result type depends on the number of letters provided. Assuming a `vec4<f32>
           |K| is the letter `x`, `y`, `z`, or `w`<br>
        <td class="nowrap">
            |e|`.`|I||J||K|: vec3&lt;|T|&gt;<br>
-       <td>Computes the three-element vector with first component |e|.|I|, second component |e|.|J|, and third component |e|.|K|.<br>
+       <td>Computes the three-component vector with first component |e|.|I|, second component |e|.|J|, and third component |e|.|K|.<br>
            Letter `z` is valid only when |N| is 3 or 4.<br>
            Letter `w` is valid only when |N| is 4.<br>
            (OpVectorShuffle)
@@ -4286,7 +4286,7 @@ The result type depends on the number of letters provided. Assuming a `vec4<f32>
           |K| is the letter `r`, `g`, `b`, or `a`<br>
        <td class="nowrap">
            |e|`.`|I||J||K|: vec3&lt;|T|&gt;<br>
-       <td>Computes the three-element vector with first component |e|.|I|, second component |e|.|J|, and third component |e|.|K|.<br>
+       <td>Computes the three-component vector with first component |e|.|I|, second component |e|.|J|, and third component |e|.|K|.<br>
            Letter `b` is only valid when |N| is 3 or 4.<br>
            Letter `a` is only valid when |N| is 4.<br>
            (OpVectorShuffle)
@@ -4299,7 +4299,7 @@ The result type depends on the number of letters provided. Assuming a `vec4<f32>
           |L| is the letter `x`, `y`, `z`, or `w`<br>
        <td class="nowrap">
            |e|`.`|I||J||K||L|: vec4&lt;|T|&gt;<br>
-       <td>Computes the four-element vector with first component |e|.|I|, second component |e|.|J|, third component |e|.|K|, and fourth component |e|.|L|.<br>
+       <td>Computes the four-component vector with first component |e|.|I|, second component |e|.|J|, third component |e|.|K|, and fourth component |e|.|L|.<br>
            Letter `z` is valid only when |N| is 3 or 4.<br>
            Letter `w` is valid only when |N| is 4.<br>
            (OpVectorShuffle)
@@ -4312,7 +4312,7 @@ The result type depends on the number of letters provided. Assuming a `vec4<f32>
           |L| is the letter `r`, `g`, `b`, or `a`<br>
        <td class="nowrap">
            |e|`.`|I||J||K||L|: vec4&lt;|T|&gt;<br>
-       <td>Computes the four-element vector with first component |e|.|I|, second component |e|.|J|, third component |e|.|K|, and fourth component |e|.|L|.<br>
+       <td>Computes the four-component vector with first component |e|.|I|, second component |e|.|J|, third component |e|.|K|, and fourth component |e|.|L|.<br>
            Letter `b` is only valid when |N| is 3 or 4.<br>
            Letter `a` is only valid when |N| is 4.<br>
            (OpVectorShuffle)
@@ -7017,7 +7017,7 @@ inputs with the same [=attribute/location=] assignment within the same [=pipelin
 
 Each location can store a value up to 16 bytes in size.
 The byte size of a type is defined using the *SizeOf* column in [[#alignment-and-size]].
-For example, a four-element vector of floating-point values occupies a single location.
+For example, a four-component vector of floating-point values occupies a single location.
 
 Locations are specified via the [=attribute/location=] attribute.
 
@@ -9469,7 +9469,7 @@ for the return type may be returned.
 ### `textureGather` ### {#texturegather}
 
 A <dfn noexport>texture gather</dfn> operation reads from a 2D, 2D array, cube, or cube array texture,
-computing a four-element vector as follows:
+computing a four-component vector as follows:
 * Find the four texels that would be used in a sampling operation with linear filtering,
     from [=mip level=] 0:
     * Use the specified coordinate, array index (when present), and offset (when present).
@@ -9484,7 +9484,7 @@ computing a four-element vector as follows:
              * Yield 0.0 when `component` is 1 or 2.
              * Yield 1.0 when `component` is 3 (the alpha channel).
     * For depth textures, yield the texel value. (Depth textures only have one channel.)
-* Yield the four-element vector, arranging scalars produced by the previous step into components
+* Yield the four-component vector, arranging scalars produced by the previous step into components
     according to the relative coordinates of the texels, as follows:
     * <table>
         <thead class='data'><td>Result component<td>Relative texel coordinate</thead>
@@ -9544,7 +9544,7 @@ textureGather(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, array_
 
 **Returns:**
 
-A four element vector with components extracted from the specified channel from the selected texels, as described above.
+A four component vector with components extracted from the specified channel from the selected texels, as described above.
 
 <div class='example wgsl global-scope' heading="Gather components from texels in 2D texture">
   <xmp>
@@ -9580,7 +9580,7 @@ texture and collects the results into a single vector, as follows:
         as in ordinary texture sampling.
 * For each texel, perform a comparison against the depth reference value,
     yielding a 0.0 or 1.0 value, as controlled by the comparison sampler parameters.
-* Yield the four-element vector where the components are the comparison results with the texels with
+* Yield the four-component vector where the components are the comparison results with the texels with
        relative texel coordinates as follows:
     * <table>
         <thead class='data'><td>Result component<td>Relative texel coordinate</thead>
@@ -9624,7 +9624,7 @@ textureGatherCompare(t: texture_depth_cube_array, s: sampler_comparison, coords:
 
 **Returns:**
 
-A four element vector with comparison result for the selected texels, as described above.
+A four component vector with comparison result for the selected texels, as described above.
 
 <div class='example wgsl global-scope' heading="Gather depth comparison">
   <xmp>
@@ -10188,8 +10188,8 @@ original value of the atomic object and the second member, `exchanged`, is
 whether or not the comparison succeeded.
 
 Note: the equality comparison may spuriously fail on some implementations. That
-is, the second element of the result vector may be `false` even if the first
-element of the result vector equals `cmp`.
+is, the second component of the result vector may be `false` even if the first
+component of the result vector equals `cmp`.
 
 ## Data Packing Built-in Functions ## {#pack-builtin-functions}
 


### PR DESCRIPTION
The WGSL specification, when describing vector, uses the element word and the component word interchangeably, which other specs do too (components of the vector and elements of a vector). Although presence of only element would be a plus for localization, the element is easier to find correspondence for, such would be an "innovation" in shader specs space and also could make some people sad (like vector is a "single entity" so it has components rather than elements); also for accounting internationalization there are more outstanding issues like allowed identifiers. Still, even using a consistent word could be a helping hand for other languages where an individual looking for correspondence to the concept vector of WGSL can take note of the nuance and not deal with interchangeability in their target languages. Therefore, in my opinion, as WGSL is to preserve both terms, the spec should eliminate interchangeable uses of the element with the component word in the context of vectors.