### PR TITLE
Relax vertex stride requirements

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8085,23 +8085,20 @@ dictionary GPURenderPassLayout: GPUObjectDescriptorBase {
                 <div class=validusage>
                     - It is [$valid to draw$] with |this|.
                     - Let |buffers| be |this|.{{GPURenderEncoderBase/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}.
-                    - For each {{GPUIndex32}} |slot| `0` to |buffers|.length:
+                    - For each {{GPUIndex32}} |slot| from `0` to |buffers|.length (non-inclusive):
                         - Let |bufferSize| be |this|.{{GPURenderEncoderBase/[[vertex_buffer_sizes]]}}[|slot|].
                         - Let |stride| be |buffers|[|slot|].{{GPUVertexBufferLayout/arrayStride}}.
-                        - If |stride| is zero:
-                            - For each attribute |attrib| in the list |this|.{{GPURenderEncoderBase/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}.{{GPUVertexBufferLayout/attributes}}:
-                                - |attrib|.{{GPUVertexAttribute/offset}} + sizeof(|attrib|.{{GPUVertexAttribute/format}}) &le;
-                                    |bufferSize|
-
-                            Otherwise:
-
-                            - If |buffers|[|slot|].{{GPUVertexBufferLayout/stepMode}} is:
-                                <dl class="switch">
-                                    : {{GPUVertexStepMode/"vertex"}}
-                                    :: (|firstVertex| + |vertexCount|) * |stride| &le; |bufferSize|.
-                                    : {{GPUVertexStepMode/"instance"}}
-                                    :: (|firstInstance| + |instanceCount|) * |stride| &le; |bufferSize|.
-                                </dl>
+                        - Let |lastStride| be max(|attribute|.{{GPUVertexAttribute/offset}} &plus; sizeof(|attribute|.{{GPUVertexAttribute/format}}))
+                            for each |attribute| in |buffers|[|slot|].{{GPUVertexBufferLayout/attributes}}.
+                        - Let |strideCount| be computed based on |buffers|[|slot|].{{GPUVertexBufferLayout/stepMode}}:
+                            <dl class="switch">
+                                : {{GPUVertexStepMode/"vertex"}}
+                                :: |firstVertex| &plus; |vertexCount|
+                                : {{GPUVertexStepMode/"instance"}}
+                                :: |firstInstance| &plus; |instanceCount|
+                            </dl>
+                        - If |strideCount| &ne; `0`
+                            - Ensure (|strideCount| &minus; `1`) &times; |stride| &plus; |lastStride| &le; |bufferSize|.
                 </div>
             </div>
         </div>
@@ -8133,20 +8130,23 @@ dictionary GPURenderPassLayout: GPUObjectDescriptorBase {
                     - |firstIndex| + |indexCount| &le; |this|.{{GPURenderEncoderBase/[[index_buffer_size]]}}
                         &div; |this|.{{GPURenderEncoderBase/[[index_format]]}}'s byte size;
                     - Let |buffers| be |this|.{{GPURenderEncoderBase/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}.
-                    - For each {{GPUIndex32}} |slot| `0` to |buffers|.length:
+                    - For each {{GPUIndex32}} |slot| from `0` to |buffers|.length (non-inclusive):
                         - Let |bufferSize| be |this|.{{GPURenderEncoderBase/[[vertex_buffer_sizes]]}}[|slot|].
                         - Let |stride| be |buffers|[|slot|].{{GPUVertexBufferLayout/arrayStride}}.
-                        - If |stride| is zero:
-                            - For each attribute |attrib| in the list |this|.{{GPURenderEncoderBase/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}.{{GPUVertexBufferLayout/attributes}}:
-                                - |attrib|.{{GPUVertexAttribute/offset}} + sizeof(|attrib|.{{GPUVertexAttribute/format}}) &le;
-                                    |bufferSize|
-
-                            Otherwise:
-
-                            - If |buffers|[|slot|].{{GPUVertexBufferLayout/stepMode}} is {{GPUVertexStepMode/"instance"}}:
-                                - (|firstInstance| + |instanceCount|) * |stride| &le; |bufferSize|.
+                        - Let |lastStride| be max(|attribute|.{{GPUVertexAttribute/offset}} &plus; sizeof(|attribute|.{{GPUVertexAttribute/format}}))
+                            for each |attribute| in |buffers|[|slot|].{{GPUVertexBufferLayout/attributes}}.
+                        - Let |strideCount| be |firstInstance| &plus; |instanceCount|.
+                        - If |buffers|[|slot|].{{GPUVertexBufferLayout/stepMode}} is {{GPUVertexStepMode/"instance"}} and |strideCount| &ne; `0`:
+                            - Ensure (|strideCount| &minus; `1`) &times; |stride| &plus; |lastStride| &le; |bufferSize|.
                 </div>
             </div>
+
+            Note: a valid program should also never use vertex indices with
+            {{GPUVertexStepMode/"vertex"|GPUVertexStepMode."vertex"}} that are out of bounds.
+            WebGPU implementations have different ways of handling this,
+            and therefore a range of behaviors is allowed.
+            Either the whole draw call is discarded, or the access to those attributes
+            out of bounds is described by WGSL's [=invalid memory reference=].
         </div>
 
     : <dfn>drawIndirect(indirectBuffer, indirectOffset)</dfn>


### PR DESCRIPTION
Fixes #2359 
Makes the validation code more unified (less branching), uses temporary definitions much nicer, and does overall refactor of these algorithms. Also adds a note about validating the vertex ranges in indexed calls.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/2554.html" title="Last updated on Jan 31, 2022, 10:04 PM UTC (70b2c95)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2554/e36e277...kvark:70b2c95.html" title="Last updated on Jan 31, 2022, 10:04 PM UTC (70b2c95)">Diff</a>