### PR TITLE
Rename 'override' to 'param'

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4861,15 +4861,15 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         ({{boolean}}, {{long}}, {{unsigned long}}, or {{float}}).
 
         <div class=example>
-            Pipeline-overridable constants defined in WGSL:
+            Pipeline-parametrized constants defined in WGSL:
 
             <pre highlight=rust>
-                @override(0)    let has_point_light: bool = true; // Algorithmic control.
-                @override(1200) let specular_param: f32 = 2.3;    // Numeric control.
-                @override(1300) let gain: f32;                    // Must be overridden.
-                @override       let width: f32 = 0.0;             // Specifed at the API level
+                @id(0)    param has_point_light: bool = true; // Algorithmic control.
+                @id(1200) param specular_param: f32 = 2.3;    // Numeric control.
+                @id(1300) param gain: f32;                    // Must be overridden.
+                          param width: f32 = 0.0;             // Specifed at the API level
                                                                   //   using the name "width".
-                @override       let depth: f32;                   // Specifed at the API level
+                          param depth: f32;                   // Specifed at the API level
                                                                   //   using the name "depth".
                                                                   //   Must be overridden.
             </pre>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -616,10 +616,10 @@ An attribute must not be specified more than once per object or type.
 
   <tr><td><dfn noexport dfn-for="attribute">`id`
     <td>non-negative i32 literal
-    <td>Must only be applied to an [=override declaration=] of [=scalar=] type.
+    <td>Must only be applied to an [=param declaration=] of [=scalar=] type.
 
     Specifies a numeric identifier as an alternate name for a
-    [=pipeline-overridable=] constant.
+    [=pipeline-parameter=].
 
   <tr><td><dfn noexport dfn-for="attribute">`interpolate`
     <td>One or two parameters.
@@ -1173,7 +1173,7 @@ See [[#array-access-expr]].
 An expression must not evaluate to a runtime-sized array type.
 
 The element count expression |N| of a fixed-size array must:
-* be a literal, or the name of a [[#module-constants|module-scope constant]] (possibly [=pipeline-overridable=]), and
+* be a literal, or the name of a [[#module-constants|module-scope constant]] (possibly [=pipeline-parameter=]), and
 * evaluate to an [=integer scalar=] with value greater than zero.
 
 Note:  The element count value is fully determined at [=pipeline creation=] time.
@@ -1197,9 +1197,9 @@ Two array types are the same if and only if all of the following are true:
         (Signed and unsigned values are comparable in this case because element counts must
         be greater than zero.)
     * They are both fixed-sized with element count specified as the same
-        [=pipeline-overridable=] constant.
+        [=pipeline-parameter=] constant.
 
-<div class='example wgsl fixed-size array types' heading='Example fixed-size array types, non-overridable element count'>
+<div class='example wgsl fixed-size array types' heading='Example fixed-size array types, non-parameter element count'>
   <xmp highlight='rust'>
     // array<f32,8> and array<i32,8> are different types:
     // different element types
@@ -1220,21 +1220,21 @@ Two array types are the same if and only if all of the following are true:
   </xmp>
 </div>
 
-Note: The valid use of an array sized by an overridable constant is as the store type
+Note: The valid use of an array sized by an parameter constant is as the store type
 of a variable in [=address spaces/workgroup=] space.
 
-<div class='example wgsl global-scope' heading="Workgroup variables sized by overridable constants">
+<div class='example wgsl global-scope' heading="Workgroup variables sized by parameter constants">
   <xmp>
-    override blockSize = 16;
+    param blockSize = 16;
 
     var<workgroup> odds: array<i32,blockSize>;
     var<workgroup> evens: array<i32,blockSize>;
 
-    // An invalid example, because the overridable element count may only occur
+    // An invalid example, because the parameter element count may only occur
     // at the outer level.
     // var<workgroup> both: array<array<i32,blockSize>,2>;
 
-    // An invalid example, because the overridable element count is only
+    // An invalid example, because the parameter element count is only
     // valid for workgroup variables.
     // var<private> bad_address_space: array<i32,blockSize>;
   </xmp>
@@ -1445,9 +1445,9 @@ Note: A [=constructible=] type has [=creation-fixed footprint=].
 
 The plain types with [=fixed footprint=] are any of:
 * a type with [=creation-fixed footprint=]
-* a [=fixed-size array=] type, where its [=element count=] is a [=pipeline-overridable=]  constant.
+* a [=fixed-size array=] type, where its [=element count=] is a [=pipeline-parameter=]  constant.
 
-Note: The only valid use of a fixed-size array with an element count that is a pipeline-overridable constant is
+Note: The only valid use of a fixed-size array with an element count that is a pipeline-parameter constant is
 as the [=store type=] for a [=address spaces/workgroup=] variable.
 
 Note: A fixed-footprint type may contain an [=atomic type|atomic=] type, either directly or
@@ -1610,7 +1610,7 @@ and how to use variables with it.
       <td>[=access/read_write=]
       <td>[=Module scope=]
       <td>[=Plain type=] with [=fixed footprint=]
-      <td>The [=element count=] of an outermost array may be a [=pipeline-overridable=] constant.
+      <td>The [=element count=] of an outermost array may be a [=pipeline-parameter=] constant.
   <tr><td><dfn noexport dfn-for="address spaces">uniform</dfn>
       <td>Invocations in the same [=shader stage=]
       <td>[=access/read=]
@@ -3185,7 +3185,7 @@ When the type declaration is an [=identifier=], then the expression must be in s
 [SHORTNAME] authors can declare names for immutable values using one of the following methods:
 
   * [=let declarations=]
-  * [=override declarations=]
+  * [=param declarations=]
 
 Value declarations do not have any associated storage.
 That is, there are no [=memory locations=] associated with the declaration.
@@ -3213,16 +3213,16 @@ See [[#module-constants]] and [[#function-scope-variables]].
   </xmp>
 </div>
 
-### `override` Declarations ### {#override-decls}
+### `param` Declarations ### {#param-decls}
 
-An <dfn noexport>override declaration</dfn> specifies a name for a
-[=pipeline-overridable=] constant value.
-The value of a <dfn noexport>pipeline-overridable</dfn> constant is fixed at
+An <dfn noexport>param declaration</dfn> specifies a name for a
+[=pipeline-parameter=] constant value.
+The value of a <dfn noexport>pipeline-parameter</dfn> constant is fixed at
 pipeline-creation time.
 The value is the one specified by the WebGPU pipeline-creation method, if
 specified, and otherwise is the value of its initializer expression.
-When an [=identifier=] use [=resolves=] to a override-declaration, the identifier denotes that value.
-`override`-declarations must meet the following restrictions:
+When an [=identifier=] use [=resolves=] to a param-declaration, the identifier denotes that value.
+`param`-declarations must meet the following restrictions:
 
   * The declaration must only occur at [=module scope=].
   * The declaration must have at least one of a declared type, an initializer
@@ -3232,36 +3232,36 @@ When an [=identifier=] use [=resolves=] to a override-declaration, the identifie
       * evaluate to a [=scalar=] type.
       * evaluate to the declared type if it is present.
       * be composed only [=syntax/const_expression|const_expressions=] or
-          expressions where all identifiers [=resolve=] to overridable constants.
+          expressions where all identifiers [=resolve=] to parameter constants.
   * If the declaration has the [=attribute/id=] applied, the literal operand is
       known as the <dfn noexport>pipeline constant ID</dfn>, and must be an
       integer value between 0 and 65535.
-  * Pipeline constant IDs must be unique within the [SHORTNAME] program: Two `override`-declarations
+  * Pipeline constant IDs must be unique within the [SHORTNAME] program: Two `param`-declarations
     must not use the same pipeline constant ID.
   * The application can specify its own value for the constant at pipeline-creation time.
-    The pipeline creation API accepts a mapping from overridable constant to a
+    The pipeline creation API accepts a mapping from parameter constant to a
     value of the constant's type.
-    The constant is identified by a <dfn export>pipeline-overridable constant identifier string</dfn>,
+    The constant is identified by a <dfn export>pipeline-parameter constant identifier string</dfn>,
     which is the base-10 representation of the [=pipeline constant ID=] if specified, and otherwise
     the declared [=name=] of the constant.
-  * The <dfn export>pipeline-overridable constant has a default value</dfn> if
+  * The <dfn export>pipeline-parameter constant has a default value</dfn> if
     its declaration has an initializer expression.
     If it doesn't, a value must be provided at pipeline-creation time.
 
-<div class='example wgsl global-scope' heading='Module constants, pipeline-overrideable'>
+<div class='example wgsl global-scope' heading='Module constants, pipeline-parametrizable'>
   <xmp>
-    @id(0)    override has_point_light: bool = true;  // Algorithmic control
-    @id(1200) override specular_param: f32 = 2.3;     // Numeric control
-    @id(1300) override gain: f32;                     // Must be overridden
-              override width: f32 = 0.0;              // Specified at the API level using
+    @id(0)    param has_point_light: bool = true;  // Algorithmic control
+    @id(1200) param specular_param: f32 = 2.3;     // Numeric control
+    @id(1300) param gain: f32;                     // Must be provided at link time
+              param width: f32 = 0.0;              // Specified at the API level using
                                                       // the name "width".
-              override depth: f32;                    // Specified at the API level using
+              param depth: f32;                    // Specified at the API level using
                                                       // the name "depth".
-                                                      // Must be overridden.
-              override height = 2 * depth;            // The default value
+                                                      // Must be provided at link time
+              param height = 2 * depth;            // The default value
                                                       // (if not set at the API level),
                                                       // depends on another
-                                                      // overridable constant.
+                                                      // parameter constant.
 
   </xmp>
 </div>
@@ -3439,8 +3439,8 @@ and the name denotes the value of that expression.
 TODO: define creation-time constant that allows const_expression and module
 scope let declarations.
 
-A [=pipeline-overridable=] constant must be one of the [=scalar=] types.
-An initializer expression is optional for pipeline-overridable constants.
+A [=pipeline-parameter=] constant must be one of the [=scalar=] types.
+An initializer expression is optional for pipeline-parameter constants.
 
 <div class='example wgsl global-scope' heading='Module constants'>
   <xmp>
@@ -3456,7 +3456,7 @@ When a variable or feature is used within control flow that depends on the
 value of a constant, then that variable or feature is considered to be used by the
 program.
 This is true regardless of the value of the constant, whether that value
-is the one from the constant's declaration or from a pipeline override.
+is the one from the constant's declaration or from a pipeline param.
 
 <div class='example' heading='Constants'>
   <xmp>
@@ -3559,7 +3559,7 @@ use the same memory.
 
     | [=syntax/let=] ( [=syntax/ident=] | [=syntax/variable_ident_decl=] ) [=syntax/equal=] [=syntax/const_expression=]
 
-    | [=syntax/attribute=] * [=syntax/override=] ( [=syntax/ident=] | [=syntax/variable_ident_decl=] ) ( [=syntax/equal=] [=syntax/expression=] ) ?
+    | [=syntax/attribute=] * [=syntax/param=] ( [=syntax/ident=] | [=syntax/variable_ident_decl=] ) ( [=syntax/equal=] [=syntax/expression=] ) ?
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>const_expression</dfn> :
@@ -5082,17 +5082,17 @@ The <dfn noexport>indirection</dfn> operator converts a pointer to its correspon
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Description
   </thead>
-  <tr algorithm="pipeline-overridable constant value">
+  <tr algorithm="pipeline-parameter constant value">
        <td>
           |c| is an [=identifier=] [=resolves|resolving=] to
-          an [=in scope|in-scope=] [=override declaration=] with type |T|
+          an [=in scope|in-scope=] [=param declaration=] with type |T|
        <td class="nowrap">
           |c|: |T|
        <td>If pipeline creation specified a value for the [=pipeline constant ID|constant ID=],
            then the result is that value.
            This value may be different for different pipeline instances.<br>
            Otherwise, the result is the value computed for the initializer expression.
-           Pipeline-overridable constants appear at module-scope, so evaluation occurs
+           Pipeline-parameter constants appear at module-scope, so evaluation occurs
            before the shader begins execution.<br>
            Note: Pipeline creation fails if no initial value was specified in the API call
            and the `let`-declaration has no initializer expression.
@@ -6613,15 +6613,15 @@ The return type, if specified, must be [=constructible=].
 <div class='syntax' noexport='true'>
   <dfn for=syntax>function_header</dfn> :
 
-    | [=syntax/fn=] [=syntax/ident=] [=syntax/paren_left=] [=syntax/param_list=] ? [=syntax/paren_right=] ( [=syntax/arrow=] [=syntax/attribute=] * [=syntax/type_decl=] ) ?
+    | [=syntax/fn=] [=syntax/ident=] [=syntax/paren_left=] [=syntax/argument_list=] ? [=syntax/paren_right=] ( [=syntax/arrow=] [=syntax/attribute=] * [=syntax/type_decl=] ) ?
 </div>
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>param_list</dfn> :
+  <dfn for=syntax>argument_list</dfn> :
 
-    | ( [=syntax/param=] [=syntax/comma=] ) * [=syntax/param=] [=syntax/comma=] ?
+    | ( [=syntax/argument=] [=syntax/comma=] ) * [=syntax/argument=] [=syntax/comma=] ?
 </div>
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>param</dfn> :
+  <dfn for=syntax>argument</dfn> :
 
     | [=syntax/attribute=] * [=syntax/variable_ident_decl=]
 </div>
@@ -6873,8 +6873,8 @@ ISSUE: Can we query upper bounds on workgroup size dimensions?  Is it independen
        // OpEntryPoint GLCompute %reverser "reverser"
        // OpExecutionMode %reverser LocalSize 8 1 1
 
-    // Using an pipeline-overridable constant.
-    @id(42) override block_width = 12u;
+    // Using a pipeline-parametrized constant.
+    @id(42) param block_width = 12u;
     @stage(compute) @workgroup_size(block_width)
     fn shuffler() { }
        // The SPIR-V translation uses a WorkgroupSize-decorated constant,
@@ -7888,9 +7888,9 @@ Issue: https://github.com/gpuweb/gpuweb/issues/1621
     | `'mat4x4'`
 </div>
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>override</dfn> :
+  <dfn for=syntax>param</dfn> :
 
-    | `'override'`
+    | `'param'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>pointer</dfn> :


### PR DESCRIPTION
Follow-up to #2404

## What's wrong with "override"?

It's not necessarily an override!
```
override foo: i32;
```

This isn't **overriding** any value. It's just a value coming from the pipeline.

This PR changes this perspective into: "it's just a parameter provided at pipeline linking time".

## What's the meaning of "param"?

It's a parameter of the shader provided by pipeline linking from the host side.
I think of it as a [const generic](https://blog.rust-lang.org/2021/02/26/const-generics-mvp-beta.html).
There haven't been a lot of other candidates for this name, so I think "param" is our best bet.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kvark/gpuweb/pull/2556.html" title="Last updated on Feb 1, 2022, 8:15 PM UTC (f563746)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2556/e36e277...kvark:f563746.html" title="Last updated on Feb 1, 2022, 8:15 PM UTC (f563746)">Diff</a>