### PR TITLE
s/endPass/end/ for pass encoders

### DIFF
--- a/design/CommandSubmission.md
+++ b/design/CommandSubmission.md
@@ -29,7 +29,7 @@ The command buffer is expected to be in "recording" state, or otherwise a synchr
 No operations may be done on the `WebGPUCommandBuffer` if there is an open pass being encoded to it.
 Calling any methods on the command buffer with an open pass, or submitting it to the command queue, triggers a synchronous error.
 A pass encoding consists of state setting code and draw/dispatch calls, which are all methods on the corresponding encoder object.
-In order to close a pass, the user calls `WebGPUProgrammablePassEncoder::endPass`, which returns the owner `WebGPUCommandBuffer` object.
+In order to close a pass, the user calls `WebGPUProgrammablePassEncoder::end`, which returns the owner `WebGPUCommandBuffer` object.
 Passes cannot straddle command buffers, and a command buffer may contain multiple passes.
 
 In order to finish recording a command buffer, the user calls `WebGPUCommandBuffer::finish` method, which transitions it from "recording" to the "ready" state.

--- a/explainer/index.bs
+++ b/explainer/index.bs
@@ -852,7 +852,7 @@ When using advanced methods to transfer data to the GPU (with a rolling list of 
 
                 encodeDraw(renderPass, {uniformBuffer, uniformOffset});
             }
-            renderPass.endPass();
+            renderPass.end();
 
             // We are finished filling the staging buffer, unmap() it so
             // we can submit commands that use it.

--- a/samples/hello-cube.html
+++ b/samples/hello-cube.html
@@ -301,7 +301,7 @@ function render() {
     passEncoder.setBindGroup(bindGroupIndex, bindGroup);
     // 36 vertices, 1 instance, 0th vertex, 0th instance.
     passEncoder.draw(36, 1, 0, 0);
-    passEncoder.endPass();
+    passEncoder.end();
 
     device.queue.submit([commandEncoder.finish()]);
 

--- a/samples/workload-simulator.html
+++ b/samples/workload-simulator.html
@@ -896,7 +896,7 @@ async function render(fromRaf, fromPostMessage) {
           }
         }
       }
-      passEncoder.endPass();
+      passEncoder.end();
       if (buffer) buffer.destroy();
       let queryBuffer;
       if (querySet) {

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7221,7 +7221,7 @@ interface GPUComputePassEncoder {
     undefined dispatch(GPUSize32 workgroupCountX, optional GPUSize32 workgroupCountY = 1, optional GPUSize32 workgroupCountZ = 1);
     undefined dispatchIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
 
-    undefined endPass();
+    undefined end();
 };
 GPUComputePassEncoder includes GPUObjectBase;
 GPUComputePassEncoder includes GPUCommandsMixin;
@@ -7409,16 +7409,16 @@ work is dispatched to it with the call `computePass.dispatch(8, 8);` the entry p
 
 ### Finalization ### {#compute-pass-encoder-finalization}
 
-The compute pass encoder can be ended by calling {{GPUComputePassEncoder/endPass()}} once the user
-has finished recording commands for the pass. Once {{GPUComputePassEncoder/endPass()}} has been
+The compute pass encoder can be ended by calling {{GPUComputePassEncoder/end()}} once the user
+has finished recording commands for the pass. Once {{GPUComputePassEncoder/end()}} has been
 called the compute pass encoder can no longer be used.
 
 <dl dfn-type=method dfn-for=GPUComputePassEncoder>
-    : <dfn>endPass()</dfn>
+    : <dfn>end()</dfn>
     ::
         Completes recording of the compute pass commands sequence.
 
-        <div algorithm="GPUComputePassEncoder.endPass">
+        <div algorithm="GPUComputePassEncoder.end">
             **Called on:** {{GPUComputePassEncoder}} |this|.
 
             **Returns:** {{undefined}}
@@ -7489,7 +7489,7 @@ interface GPURenderPassEncoder {
     undefined endOcclusionQuery();
 
     undefined executeBundles(sequence<GPURenderBundle> bundles);
-    undefined endPass();
+    undefined end();
 };
 GPURenderPassEncoder includes GPUObjectBase;
 GPURenderPassEncoder includes GPUCommandsMixin;
@@ -8484,16 +8484,16 @@ attachments used by this encoder.
 
 ### Finalization ### {#render-pass-encoder-finalization}
 
-The render pass encoder can be ended by calling {{GPURenderPassEncoder/endPass()}} once the user
-has finished recording commands for the pass. Once {{GPURenderPassEncoder/endPass()}} has been
+The render pass encoder can be ended by calling {{GPURenderPassEncoder/end()}} once the user
+has finished recording commands for the pass. Once {{GPURenderPassEncoder/end()}} has been
 called the render pass encoder can no longer be used.
 
 <dl dfn-type=method dfn-for=GPURenderPassEncoder>
-    : <dfn>endPass()</dfn>
+    : <dfn>end()</dfn>
     ::
         Completes recording of the render pass commands sequence.
 
-        <div algorithm="GPURenderPassEncoder.endPass">
+        <div algorithm="GPURenderPassEncoder.end">
             **Called on:** {{GPURenderPassEncoder}} |this|.
 
             **Returns:** {{undefined}}


### PR DESCRIPTION
Fixes #2555


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Feb 3, 2022, 10:03 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fgpuweb%2Fgpuweb%2F1f44144bc7b39e392519983adf5d5c42ca47dcad%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%232560.)._
</details>
