### PR TITLE
Rename GPUTextureSampleTypes to match WGSL

### DIFF
--- a/samples/workload-simulator.html
+++ b/samples/workload-simulator.html
@@ -623,7 +623,7 @@ async function render(fromRaf, fromPostMessage) {
             {
               binding: 2,
               visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
-              texture: { sampleType: 'float', },
+              texture: { sampleType: 'f32', },
             },
           ],
         });

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3703,16 +3703,16 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
     <tr>
         <td rowspan=5>{{GPUBindGroupLayoutEntry/texture}}
         <td rowspan=5>{{GPUTextureView}}
-        <td>{{GPUTextureSampleType/"float"}}
+        <td>{{GPUTextureSampleType/"f32"}}
         <td rowspan=5>[=internal usage/constant=]
     <tr>
-        <td>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"unfilterable-f32"}}
     <tr>
         <td>{{GPUTextureSampleType/"depth"}}
     <tr>
-        <td>{{GPUTextureSampleType/"sint"}}
+        <td>{{GPUTextureSampleType/"i32"}}
     <tr>
-        <td>{{GPUTextureSampleType/"uint"}}
+        <td>{{GPUTextureSampleType/"u32"}}
 
     <tr>
         <td>{{GPUBindGroupLayoutEntry/storageTexture}}
@@ -3839,15 +3839,15 @@ dictionary GPUSamplerBindingLayout {
 
 <script type=idl>
 enum GPUTextureSampleType {
-    "float",
-    "unfilterable-float",
+    "f32",
+    "unfilterable-f32",
     "depth",
-    "sint",
-    "uint",
+    "i32",
+    "u32",
 };
 
 dictionary GPUTextureBindingLayout {
-    GPUTextureSampleType sampleType = "float";
+    GPUTextureSampleType sampleType = "f32";
     GPUTextureViewDimension viewDimension = "2d";
     boolean multisampled = false;
 };
@@ -3981,7 +3981,7 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                                     - |textureLayout|.{{GPUTextureBindingLayout/viewDimension}} is
                                         {{GPUTextureViewDimension/"2d"}}.
                                     - |textureLayout|.{{GPUTextureBindingLayout/sampleType}} is not
-                                        {{GPUTextureSampleType/"float"}} or {{GPUTextureSampleType/"depth"}}.
+                                        {{GPUTextureSampleType/"f32"}} or {{GPUTextureSampleType/"depth"}}.
 
                                 - If |storageTextureLayout| is not `undefined`:
                                     - |storageTextureLayout|.{{GPUStorageTextureBindingLayout/viewDimension}} is not
@@ -4756,13 +4756,13 @@ run the following steps:
                     -
                         <dl class=switch>
                             : `f32` and |resource| is statically used with a textureSample* builtin in the shader
-                            :: Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"float"}}
+                            :: Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"f32"}}
                             : `f32` otherwise
-                            :: Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"unfilterable-float"}}
+                            :: Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"unfilterable-f32"}}
                             : `i32`
-                            :: Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"sint"}}
+                            :: Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"i32"}}
                             : `u32`
-                            :: Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"uint"}}
+                            :: Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"u32"}}
                         </dl>
 
                 1. Set |textureLayout|.{{GPUTextureBindingLayout/viewDimension}} to |resource|'s dimension.
@@ -4800,9 +4800,9 @@ run the following steps:
                 1. If |resource| is a sampled texture binding and |entry| has different
                     {{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/sampleType}} than |previousEntry|
                     and both |entry| and |previousEntry| have {{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/sampleType}}
-                    of either {{GPUTextureSampleType/"float"}} or {{GPUTextureSampleType/"unfilterable-float"}}:
+                    of either {{GPUTextureSampleType/"f32"}} or {{GPUTextureSampleType/"unfilterable-f32"}}:
                     1. Set |previousEntry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/sampleType}} to
-                        {{GPUTextureSampleType/"float"}}.
+                        {{GPUTextureSampleType/"f32"}}.
 
                 1. If any other property is unequal between |entry| and |previousEntry|:
 
@@ -4925,7 +4925,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         1. Let |sampler| be the {{GPUBindGroupLayoutEntry}} corresponding to the used sampler in the call.
         1. If |sampler|.{{GPUSamplerBindingLayout/type}} is {{GPUSamplerBindingType/"filtering"}},
             then |texture|.{{GPUTextureBindingLayout/sampleType}} must not be
-            {{GPUTextureSampleType/"unfilterable-float"}}.
+            {{GPUTextureSampleType/"unfilterable-f32"}}.
     - For each |key| in [=map/get the keys|the keys=] of
         |descriptor|.{{GPUProgrammableStage/constants}}:
         - |key| must equal the [=pipeline-overridable constant identifier string=] of
@@ -4995,8 +4995,8 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
                 ::
                     If |entry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/sampleType}} is:
                     <dl class=switch>
-                        : {{GPUTextureSampleType/"float"}}, {{GPUTextureSampleType/"unfilterable-float"}},
-                            {{GPUTextureSampleType/"sint"}} or {{GPUTextureSampleType/"uint"}}
+                        : {{GPUTextureSampleType/"f32"}}, {{GPUTextureSampleType/"unfilterable-f32"}},
+                            {{GPUTextureSampleType/"i32"}} or {{GPUTextureSampleType/"u32"}}
                         ::
                             |variable| has type `texture_1d<T>`, `texture_2d<T>`, `texture_2d_array<T>`,
                             `texture_cube<T>`, `texture_cube_array<T>`, `texture_3d<T>`, or
@@ -5004,11 +5004,11 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
                         ::
                             If |entry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/sampleType}} is:
                             <dl class=switch>
-                                : {{GPUTextureSampleType/"float"}} or {{GPUTextureSampleType/"unfilterable-float"}}
+                                : {{GPUTextureSampleType/"f32"}} or {{GPUTextureSampleType/"unfilterable-f32"}}
                                 :: The sampled type `T` is `f32`.
-                                : {{GPUTextureSampleType/"sint"}}
+                                : {{GPUTextureSampleType/"i32"}}
                                 :: The sampled type `T` is `i32`.
-                                : {{GPUTextureSampleType/"uint"}}
+                                : {{GPUTextureSampleType/"u32"}}
                                 :: The sampled type `T` is `u32`.
                             </dl>
 
@@ -10634,7 +10634,7 @@ Removes the zero value restriction on `firstInstance` in [=indirect draw paramet
 
 All plain color formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, and {{GPUTextureUsage/TEXTURE_BINDING}} usage.
 
-Only formats with {{GPUTextureSampleType}} {{GPUTextureSampleType/"float"}} can be blended.
+Only formats with {{GPUTextureSampleType}} {{GPUTextureSampleType/"f32"}} can be blended.
 
 The {{GPUTextureUsage/RENDER_ATTACHMENT}} and {{GPUTextureUsage/STORAGE_BINDING}} columns
 specify support for {{GPUTextureUsage/RENDER_ATTACHMENT|GPUTextureUsage.RENDER_ATTACHMENT}}
@@ -10653,105 +10653,105 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
     <tr><th class=stickyheader>8-bit per component<th><th><th><th><th>
     <tr>
         <td>{{GPUTextureFormat/r8unorm}}
-        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"f32"}},<br/>{{GPUTextureSampleType/"unfilterable-f32"}}
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/r8snorm}}
-        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"f32"}},<br/>{{GPUTextureSampleType/"unfilterable-f32"}}
         <td><!-- Vulkan -->
         <td>&checkmark;
         <td>
         <td><!-- Vulkan -->
     <tr>
         <td>{{GPUTextureFormat/r8uint}}
-        <td>{{GPUTextureSampleType/"uint"}}
+        <td>{{GPUTextureSampleType/"u32"}}
         <td>&checkmark;
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
     <tr>
         <td>{{GPUTextureFormat/r8sint}}
-        <td>{{GPUTextureSampleType/"sint"}}
+        <td>{{GPUTextureSampleType/"i32"}}
         <td>&checkmark;
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
     <tr>
         <td>{{GPUTextureFormat/rg8unorm}}
-        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"f32"}},<br/>{{GPUTextureSampleType/"unfilterable-f32"}}
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
         <td><!-- Vulkan -->
     <tr>
         <td>{{GPUTextureFormat/rg8snorm}}
-        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"f32"}},<br/>{{GPUTextureSampleType/"unfilterable-f32"}}
         <td><!-- Vulkan -->
         <td>&checkmark;
         <td>
         <td><!-- Vulkan -->
     <tr>
         <td>{{GPUTextureFormat/rg8uint}}
-        <td>{{GPUTextureSampleType/"uint"}}
+        <td>{{GPUTextureSampleType/"u32"}}
         <td>&checkmark;
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
     <tr>
         <td>{{GPUTextureFormat/rg8sint}}
-        <td>{{GPUTextureSampleType/"sint"}}
+        <td>{{GPUTextureSampleType/"i32"}}
         <td>&checkmark;
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
     <tr>
         <td>{{GPUTextureFormat/rgba8unorm}}
-        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"f32"}},<br/>{{GPUTextureSampleType/"unfilterable-f32"}}
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rgba8unorm-srgb}}
-        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"f32"}},<br/>{{GPUTextureSampleType/"unfilterable-f32"}}
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/rgba8snorm}}
-        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"f32"}},<br/>{{GPUTextureSampleType/"unfilterable-f32"}}
         <td><!-- Vulkan -->
         <td>&checkmark;
         <td>
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rgba8uint}}
-        <td>{{GPUTextureSampleType/"uint"}}
+        <td>{{GPUTextureSampleType/"u32"}}
         <td>&checkmark;
         <td>&checkmark;
         <td><!-- Metal -->
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rgba8sint}}
-        <td>{{GPUTextureSampleType/"sint"}}
+        <td>{{GPUTextureSampleType/"i32"}}
         <td>&checkmark;
         <td>&checkmark;
         <td><!-- Metal -->
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/bgra8unorm}}
-        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"f32"}},<br/>{{GPUTextureSampleType/"unfilterable-f32"}}
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/bgra8unorm-srgb}}
-        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"f32"}},<br/>{{GPUTextureSampleType/"unfilterable-f32"}}
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
@@ -10759,63 +10759,63 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
     <tr><th class=stickyheader>16-bit per component<th><th><th><th><th>
     <tr>
         <td>{{GPUTextureFormat/r16uint}}
-        <td>{{GPUTextureSampleType/"uint"}}
+        <td>{{GPUTextureSampleType/"u32"}}
         <td>&checkmark;
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
     <tr>
         <td>{{GPUTextureFormat/r16sint}}
-        <td>{{GPUTextureSampleType/"sint"}}
+        <td>{{GPUTextureSampleType/"i32"}}
         <td>&checkmark;
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
     <tr>
         <td>{{GPUTextureFormat/r16float}}
-        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"f32"}},<br/>{{GPUTextureSampleType/"unfilterable-f32"}}
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/rg16uint}}
-        <td>{{GPUTextureSampleType/"uint"}}
+        <td>{{GPUTextureSampleType/"u32"}}
         <td>&checkmark;
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
     <tr>
         <td>{{GPUTextureFormat/rg16sint}}
-        <td>{{GPUTextureSampleType/"sint"}}
+        <td>{{GPUTextureSampleType/"i32"}}
         <td>&checkmark;
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
     <tr>
         <td>{{GPUTextureFormat/rg16float}}
-        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"f32"}},<br/>{{GPUTextureSampleType/"unfilterable-f32"}}
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
         <td><!-- Vulkan -->
     <tr>
         <td>{{GPUTextureFormat/rgba16uint}}
-        <td>{{GPUTextureSampleType/"uint"}}
+        <td>{{GPUTextureSampleType/"u32"}}
         <td>&checkmark;
         <td>&checkmark;
         <td><!-- Metal -->
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rgba16sint}}
-        <td>{{GPUTextureSampleType/"sint"}}
+        <td>{{GPUTextureSampleType/"i32"}}
         <td>&checkmark;
         <td>&checkmark;
         <td><!-- Metal -->
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rgba16float}}
-        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"f32"}},<br/>{{GPUTextureSampleType/"unfilterable-f32"}}
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
@@ -10823,63 +10823,63 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
     <tr><th class=stickyheader>32-bit per component<th><th><th><th><th>
     <tr>
         <td>{{GPUTextureFormat/r32uint}}
-        <td>{{GPUTextureSampleType/"uint"}}
+        <td>{{GPUTextureSampleType/"u32"}}
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/r32sint}}
-        <td>{{GPUTextureSampleType/"sint"}}
+        <td>{{GPUTextureSampleType/"i32"}}
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/r32float}}
-        <td>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"unfilterable-f32"}}
         <td>&checkmark;
         <td>&checkmark;
         <td><!-- Metal -->
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rg32uint}}
-        <td>{{GPUTextureSampleType/"uint"}}
+        <td>{{GPUTextureSampleType/"u32"}}
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rg32sint}}
-        <td>{{GPUTextureSampleType/"sint"}}
+        <td>{{GPUTextureSampleType/"i32"}}
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rg32float}}
-        <td>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"unfilterable-f32"}}
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rgba32uint}}
-        <td>{{GPUTextureSampleType/"uint"}}
+        <td>{{GPUTextureSampleType/"u32"}}
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rgba32sint}}
-        <td>{{GPUTextureSampleType/"sint"}}
+        <td>{{GPUTextureSampleType/"i32"}}
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/rgba32float}}
-        <td>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"unfilterable-f32"}}
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
@@ -10887,14 +10887,14 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
     <tr><th class=stickyheader>mixed component width<th><th><th><th><th>
     <tr>
         <td>{{GPUTextureFormat/rgb10a2unorm}}
-        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"f32"}},<br/>{{GPUTextureSampleType/"unfilterable-f32"}}
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
         <td>
     <tr>
         <td>{{GPUTextureFormat/rg11b10ufloat}}
-        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"f32"}},<br/>{{GPUTextureSampleType/"unfilterable-f32"}}
         <td><!-- Vulkan -->
         <td>&checkmark;
         <td>
@@ -10929,7 +10929,7 @@ None of the depth formats can be filtered.
         <td>{{GPUTextureFormat/stencil8}}
         <td>1 &minus; 4
         <td>stencil
-        <td>{{GPUTextureSampleType/"uint"}}
+        <td>{{GPUTextureSampleType/"u32"}}
         <td colspan=2>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/depth16unorm}}
@@ -10951,7 +10951,7 @@ None of the depth formats can be filtered.
         <td colspan=2>&cross;
     <tr>
         <td>stencil
-        <td>{{GPUTextureSampleType/"uint"}}
+        <td>{{GPUTextureSampleType/"u32"}}
         <td colspan=2>&checkmark;
     <tr>
         <td>{{GPUTextureFormat/depth32float}}
@@ -10968,7 +10968,7 @@ None of the depth formats can be filtered.
         <td colspan=2>&cross;
     <tr>
         <td>stencil
-        <td>{{GPUTextureSampleType/"uint"}}
+        <td>{{GPUTextureSampleType/"u32"}}
         <td colspan=2>&checkmark;
     <tr>
         <td rowspan=2 style='white-space:nowrap'>{{GPUTextureFormat/depth32float-stencil8}}
@@ -10979,7 +10979,7 @@ None of the depth formats can be filtered.
         <td colspan=1>&cross;
     <tr>
         <td>stencil
-        <td>{{GPUTextureSampleType/"uint"}}
+        <td>{{GPUTextureSampleType/"u32"}}
         <td colspan=2>&checkmark;
 </table>
 
@@ -11030,7 +11030,7 @@ As a result, depth-aspect [=image copies=] are not allowed with these formats.
 ### Packed formats ### {#packed-formats}
 
 All packed texture formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}},
-and {{GPUTextureUsage/TEXTURE_BINDING}} usages. All of these formats have {{GPUTextureSampleType/"float"}}
+and {{GPUTextureUsage/TEXTURE_BINDING}} usages. All of these formats have {{GPUTextureSampleType/"f32"}}
 type and can be filtered on sampling. None of these formats support multisampling.
 
 A <dfn dfn>compressed format</dfn> is any format with a block size greater than 1 &times; 1.
@@ -11047,13 +11047,13 @@ A <dfn dfn>compressed format</dfn> is any format with a block size greater than 
     <tr>
         <td>{{GPUTextureFormat/rgb9e5ufloat}}
         <td>4
-        <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>{{GPUTextureSampleType/"f32"}},<br/>{{GPUTextureSampleType/"unfilterable-f32"}}
         <td>1 &times; 1
         <td>
     <tr>
         <td>{{GPUTextureFormat/bc1-rgba-unorm}}
         <td rowspan=2>8
-        <td rowspan=14>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td rowspan=14>{{GPUTextureSampleType/"f32"}},<br/>{{GPUTextureSampleType/"unfilterable-f32"}}
         <td rowspan=14>4 &times; 4
         <td rowspan=14>{{GPUFeatureName/texture-compression-bc}}
     <tr>
@@ -11091,7 +11091,7 @@ A <dfn dfn>compressed format</dfn> is any format with a block size greater than 
     <tr>
         <td>{{GPUTextureFormat/etc2-rgb8unorm}}
         <td rowspan=2>8
-        <td rowspan=10>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td rowspan=10>{{GPUTextureSampleType/"f32"}},<br/>{{GPUTextureSampleType/"unfilterable-f32"}}
         <td rowspan=10>4 &times; 4
         <td rowspan=10>{{GPUFeatureName/texture-compression-etc2}}
     <tr>
@@ -11119,7 +11119,7 @@ A <dfn dfn>compressed format</dfn> is any format with a block size greater than 
     <tr>
         <td>{{GPUTextureFormat/astc-4x4-unorm}}
         <td rowspan=2>16
-        <td rowspan=28>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td rowspan=28>{{GPUTextureSampleType/"f32"}},<br/>{{GPUTextureSampleType/"unfilterable-f32"}}
         <td rowspan=2>4 &times; 4
         <td rowspan=28>{{GPUFeatureName/texture-compression-astc}}
     <tr>


### PR DESCRIPTION
- uint -> u32
 - sint -> i32
 - float -> f32
 - unfilterable-float -> unfilterateble-f32

Fixes #2469


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/2561.html" title="Last updated on Feb 3, 2022, 10:13 AM UTC (36782ee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2561/1f44144...Kangz:36782ee.html" title="Last updated on Feb 3, 2022, 10:13 AM UTC (36782ee)">Diff</a>