### PR TITLE
Allow sparse color attachments and ignored FS outputs

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5511,7 +5511,7 @@ dictionary GPUMultisampleState {
 
 <script type=idl>
 dictionary GPUFragmentState : GPUProgrammableStage {
-    required sequence<GPUColorTargetState> targets;
+    required sequence<GPUColorTargetState?> targets;
 };
 </script>
 
@@ -5520,7 +5520,7 @@ dictionary GPUFragmentState : GPUProgrammableStage {
         Return `true` if all of the following requirements are met:
 
         - |descriptor|.{{GPUFragmentState/targets}}.length must be &le; 8.
-        - For each |colorState| layout descriptor in the list |descriptor|.{{GPUFragmentState/targets}}:
+        - For each non-`null` |colorState| layout descriptor in the list |descriptor|.{{GPUFragmentState/targets}}:
             - |colorState|.{{GPUColorTargetState/format}} must be listed in [[#plain-color-formats]]
                 with {{GPUTextureUsage/RENDER_ATTACHMENT}} capability.
             - If |colorState|.{{GPUColorTargetState/blend}} is not `undefined`:
@@ -5539,6 +5539,10 @@ dictionary GPUFragmentState : GPUProgrammableStage {
                 Otherwise:
                 - |colorState|.{{GPUColorTargetState/writeMask}} must be 0.
 </div>
+
+Note:
+The fragment shader may output more values than what the pipeline uses. If that is the case
+the values are ignored.
 
 <div algorithm>
     |component| is a <dfn>valid GPUBlendComponent</dfn> if it meets the following requirements:
@@ -6104,7 +6108,7 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                             - |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}} is [$valid to use with$] |this|.
                     </div>
                 1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/locked=]".
-                1. For each |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
+                1. For each non-`null` |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
                     1. The [=texture subresource=] seen by |colorAttachment|.{{GPURenderPassColorAttachment/view}}
                         is considered to be used as [=internal usage/attachment=] for the
                         duration of the render pass.
@@ -7586,7 +7590,7 @@ dictionary GPURenderPassTimestampWrite {
 typedef sequence<GPURenderPassTimestampWrite> GPURenderPassTimestampWrites;
 
 dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
-    required sequence<GPURenderPassColorAttachment> colorAttachments;
+    required sequence<GPURenderPassColorAttachment?> colorAttachments;
     GPURenderPassDepthStencilAttachment depthStencilAttachment;
     GPUQuerySet occlusionQuerySet;
     GPURenderPassTimestampWrites timestampWrites = [];
@@ -7627,7 +7631,7 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
     1. |this|.{{GPURenderPassDescriptor/colorAttachments}}.length must be less than or equal to 8.
     1. |this|.{{GPURenderPassDescriptor/colorAttachments}}.length must be greater than `0` or
         |this|.{{GPURenderPassDescriptor/depthStencilAttachment}} must not be `null`.
-    1. For each |colorAttachment| in |this|.{{GPURenderPassDescriptor/colorAttachments}}:
+    1. For each non-`null` |colorAttachment| in |this|.{{GPURenderPassDescriptor/colorAttachments}}:
 
         1. |colorAttachment| must meet the [$GPURenderPassColorAttachment/GPURenderPassColorAttachment Valid Usage$] rules.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7629,8 +7629,10 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
     Given a {{GPURenderPassDescriptor}} |this| the following validation rules apply:
 
     1. |this|.{{GPURenderPassDescriptor/colorAttachments}}.length must be less than or equal to 8.
-    1. |this|.{{GPURenderPassDescriptor/colorAttachments}}.length must be greater than `0` or
-        |this|.{{GPURenderPassDescriptor/depthStencilAttachment}} must not be `null`.
+    1. If |this|.{{GPURenderPassDescriptor/colorAttachments}} has all values be `null` (or the sequence is empty):
+
+        1. |this|.{{GPURenderPassDescriptor/depthStencilAttachment}} must not be `null`.
+
     1. For each non-`null` |colorAttachment| in |this|.{{GPURenderPassDescriptor/colorAttachments}}:
 
         1. |colorAttachment| must meet the [$GPURenderPassColorAttachment/GPURenderPassColorAttachment Valid Usage$] rules.
@@ -7639,11 +7641,11 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
 
         1. |this|.{{GPURenderPassDescriptor/depthStencilAttachment}} must meet the [$GPURenderPassDepthStencilAttachment/GPURenderPassDepthStencilAttachment Valid Usage$] rules.
 
-    1. All {{GPURenderPassColorAttachment/view}}s in |this|.{{GPURenderPassDescriptor/colorAttachments}},
+    1. All {{GPURenderPassColorAttachment/view}}s in non-`null` members of |this|.{{GPURenderPassDescriptor/colorAttachments}},
         and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachment/view}}
         if present, must have equal {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}}s.
 
-    1. For each {{GPURenderPassColorAttachment/view}} in |this|.{{GPURenderPassDescriptor/colorAttachments}}
+    1. For each {{GPURenderPassColorAttachment/view}} in non-`null` members of |this|.{{GPURenderPassDescriptor/colorAttachments}}
         and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachment/view}},
         if present, the {{GPUTextureView/[[renderExtent]]}} must match.
 
@@ -7906,7 +7908,7 @@ which determines the compatibility of the pass with render pipelines.
 
 <script type=idl>
 dictionary GPURenderPassLayout: GPUObjectDescriptorBase {
-    required sequence<GPUTextureFormat> colorFormats;
+    required sequence<GPUTextureFormat?> colorFormats;
     GPUTextureFormat depthStencilFormat;
     GPUSize32 sampleCount = 1;
 };
@@ -7922,11 +7924,14 @@ dictionary GPURenderPassLayout: GPUObjectDescriptorBase {
 
     1. Let |layout| be a new {{GPURenderPassLayout}} object.
     1. For each |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
-        1. Set |layout|.{{GPURenderPassLayout/sampleCount}} to |colorAttachment|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}}.
-        1. Append |colorAttachment|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}} to |layout|.{{GPURenderPassLayout/colorFormats}}.
+        1. If |colorAttachment| is not `null`:
+            1. Set |layout|.{{GPURenderPassLayout/sampleCount}} to |colorAttachment|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}}.
+            1. Append |colorAttachment|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}} to |layout|.{{GPURenderPassLayout/colorFormats}}.
+        1. Otherwise:
+            1. Append `null` to |layout|.{{GPURenderPassLayout/colorFormats}}.
     1. Let |depthStencilAttachment| be |descriptor|.{{GPURenderPassDescriptor/depthStencilAttachment}}.
     1. If |depthStencilAttachment| is not `null`:
-        1. Let |view| be |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/view}}
+        1. Let |view| be |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/view}}.
         1. Set |layout|.{{GPURenderPassLayout/sampleCount}} to |view|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}}.
         1. Set |layout|.{{GPURenderPassLayout/depthStencilFormat}} to |view|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
     1. Return |layout|.
@@ -7948,6 +7953,7 @@ dictionary GPURenderPassLayout: GPUObjectDescriptorBase {
     1. If |descriptor|.{{GPURenderPipelineDescriptor/fragment}} is not `null`:
         1. For each |colorTarget| in |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.{{GPUFragmentState/targets}}:
             1. Append |colorTarget|.{{GPUColorTargetState/format}} to |layout|.{{GPURenderPassLayout/colorFormats}}
+                if |colorTarget| is not `null`, or append `null` otherwise.
     1. Return |layout|.
 
 </div>
@@ -8594,10 +8600,10 @@ GPURenderBundleEncoder includes GPURenderEncoderBase;
                     error and stop.
                     <div class=validusage>
                         - |descriptor|.{{GPURenderPassLayout/colorFormats}}.length must be less than or equal to 8.
-                        - |descriptor|.{{GPURenderPassLayout/colorFormats}}.length must be greater than `0` or
-                            |descriptor|.{{GPURenderPassLayout/depthStencilFormat}} must not be `null`.
+                        - If |descriptor|.{{GPURenderPassLayout/colorFormats}} only contains `null` members:
+                            - |descriptor|.{{GPURenderPassLayout/depthStencilFormat}} must not be `null`.
                         - For each |colorFormat| in |descriptor|.{{GPURenderPassLayout/colorFormats}}:
-                            - |colorFormat| must be a [=color renderable format=].
+                            - |colorFormat| is `null`, or it must be a [=color renderable format=].
                         - Let |depthStencilFormat| be |descriptor|.{{GPURenderPassLayout/depthStencilFormat}}.
                         - If |depthStencilFormat| is not `null`:
                             - |depthStencilFormat| must be a [=depth-or-stencil format=].


### PR DESCRIPTION
Fixes #1250
Fixes #2060


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/2562.html" title="Last updated on Feb 9, 2022, 9:53 PM UTC (e822402)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2562/4cb81f5...Kangz:e822402.html" title="Last updated on Feb 9, 2022, 9:53 PM UTC (e822402)">Diff</a>