### PR TITLE
Add optional trailing comma for the attribute syntax.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -553,7 +553,7 @@ An attribute must not be specified more than once per object or type.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>attribute</dfn> :
 
-    | [=syntax/attr=] [=syntax/ident=] [=syntax/paren_left=] ( [=syntax/literal_or_ident=] [=syntax/comma=] ) * [=syntax/literal_or_ident=] [=syntax/paren_right=]
+    | [=syntax/attr=] [=syntax/ident=] [=syntax/paren_left=] ( [=syntax/literal_or_ident=] [=syntax/comma=] ) * [=syntax/literal_or_ident=] [=syntax/comma=] ? [=syntax/paren_right=]
 
     | [=syntax/attr=] [=syntax/ident=]
 </div>


### PR DESCRIPTION
All places that use a variable number of comma-separated things now
support trailing commas. However things with a fixed number of
comma-separated arguments don't. They are:

 - array_type_decl
 - texture_sampler_types
 - type_decl
 - variable_qualifier

Fixes #1243