### PR TITLE
Add isReady(), remove create*PipelineAsync()

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -534,8 +534,8 @@ These caches are important to improve the loading time of WebGPU applications af
 visit.
 
 For the specification, these caches are indifferentiable from incredibly fast compilation, but
-for applications it would be easy to measure how long {{GPUDevice/createComputePipelineAsync()}}
-takes to resolve. This can leak information across origins (like "did the user access a site with
+for applications it would be easy to measure how long {{GPUDevice/isReady()}} takes to resolve for
+a given pipeline. This can leak information across origins (like "did the user access a site with
 this specific shader") so user agents should follow the best practices in
 [storage partitioning](https://github.com/privacycg/storage-partitioning).
 
@@ -1876,13 +1876,13 @@ interface GPUDevice : EventTarget {
     GPUShaderModule createShaderModule(GPUShaderModuleDescriptor descriptor);
     GPUComputePipeline createComputePipeline(GPUComputePipelineDescriptor descriptor);
     GPURenderPipeline createRenderPipeline(GPURenderPipelineDescriptor descriptor);
-    Promise<GPUComputePipeline> createComputePipelineAsync(GPUComputePipelineDescriptor descriptor);
-    Promise<GPURenderPipeline> createRenderPipelineAsync(GPURenderPipelineDescriptor descriptor);
 
     GPUCommandEncoder createCommandEncoder(optional GPUCommandEncoderDescriptor descriptor = {});
     GPURenderBundleEncoder createRenderBundleEncoder(GPURenderBundleEncoderDescriptor descriptor);
 
     GPUQuerySet createQuerySet(GPUQuerySetDescriptor descriptor);
+
+    Promise<undefined> isReady(GPUObjectBase... objects);
 };
 GPUDevice includes GPUObjectBase;
 </script>
@@ -1927,6 +1927,43 @@ Those not defined here are defined elsewhere in this document.
         Note:
         Since no further operations can occur on this device, implementations can free resource
         allocations and abort outstanding asynchronous operations immediately.
+
+    : <dfn>isReady(...objects)</dfn>
+    ::
+        Returns a {{Promise}} that resolves when every object passed is ready to be used without
+        additional delay.
+
+        Note: Use of this method to schedule an object's first use is recommended whenever using
+        objects which are potentially expensive to create, such as {{GPURenderPipeline}} or
+        {{GPUComputePipeline}}, as it prevents blocking the [=queue timeline=] work on pipeline
+        compilation.
+
+        <div algorithm=GPUDevice.isReady>
+            **Called on:** {{GPUDevice}} |this|.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPUDevice/isReady(...objects)">
+                |objects|: List of {{GPUObjectBase}}s that must be ready to use before the promise resolves.
+            </pre>
+
+            **Returns:** {{Promise}}&lt;undefined&gt;
+
+            1. Let |promise| be [=a new promise=].
+            1. Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
+                    1. If any of the following requirements are unmet,
+                        [=reject=] |promise| with a {{OperationError}} and stop.
+
+                        <div class=validusage>
+                            - |this| is a [=valid=] {{GPUDevice}}.
+                            - For each |object| in |objects|, |object|.{{GPUObjectBase/[[device]]}}
+                                must equal |this|.
+                        </div>
+
+                    1. When every object in |objects| is ready to be used, [=resolve=] |promise|.
+                </div>
+            1. Return |promise|.
+        </div>
 </dl>
 
 {{GPUDevice}} objects are [=serializable objects=].
@@ -5146,37 +5183,6 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
             1. Return |pipeline|.
 
         </div>
-
-    : <dfn>createComputePipelineAsync(descriptor)</dfn>
-    ::
-        Creates a {{GPUComputePipeline}}. The returned {{Promise}} resolves when the created pipeline
-        is ready to be used without additional delay.
-
-        If pipeline creation fails, the returned {{Promise}} rejects with an {{OperationError}}.
-
-        Note: Use of this method is preferred whenever possible, as it prevents blocking the
-        [=queue timeline=] work on pipeline compilation.
-
-        <div algorithm=GPUDevice.createComputePipelineAsync>
-            **Called on:** {{GPUDevice}} |this|.
-
-            **Arguments:**
-            <pre class=argumentdef for="GPUDevice/createComputePipelineAsync(descriptor)">
-                |descriptor|: Description of the {{GPUComputePipeline}} to create.
-            </pre>
-
-            **Returns:** {{Promise}}&lt;{{GPUComputePipeline}}&gt;
-
-            1. Let |promise| be [=a new promise=].
-            1. Issue the following steps on the [=Device timeline=] of |this|:
-                <div class=device-timeline>
-                    1. Let |pipeline| be a new {{GPUComputePipeline}} created as if
-                        |this|.{{GPUDevice/createComputePipeline()}} was called with |descriptor|;
-
-                    1. When |pipeline| is ready to be used, [=resolve=] |promise| with |pipeline|.
-                </div>
-            1. Return |promise|.
-        </div>
 </dl>
 
 <div class="example">
@@ -5327,37 +5333,6 @@ details.
             1. Return |pipeline|.
 
             Issue: need description of the render states.
-        </div>
-
-    : <dfn>createRenderPipelineAsync(descriptor)</dfn>
-    ::
-        Creates a {{GPURenderPipeline}}. The returned {{Promise}} resolves when the created pipeline
-        is ready to be used without additional delay.
-
-        If pipeline creation fails, the returned {{Promise}} rejects with an {{OperationError}}.
-
-        Note: Use of this method is preferred whenever possible, as it prevents blocking the
-        [=queue timeline=] work on pipeline compilation.
-
-        <div algorithm=GPUDevice.createRenderPipelineAsync>
-            **Called on:** {{GPUDevice}} |this|.
-
-            **Arguments:**
-            <pre class=argumentdef for="GPUDevice/createRenderPipelineAsync(descriptor)">
-                |descriptor|: Description of the {{GPURenderPipeline}} to create.
-            </pre>
-
-            **Returns:** {{Promise}}&lt;{{GPURenderPipeline}}&gt;
-
-            1. Let |promise| be [=a new promise=].
-            1. Issue the following steps on the [=Device timeline=] of |this|:
-                <div class=device-timeline>
-                    1. Let |pipeline| be a new {{GPURenderPipeline}} created as if
-                        |this|.{{GPUDevice/createRenderPipeline()}} was called with |descriptor|;
-
-                    1. When |pipeline| is ready to be used, [=resolve=] |promise| with |pipeline|.
-                </div>
-            1. Return |promise|.
         </div>
 </dl>
 


### PR DESCRIPTION
A design that the editors have been discussing to resolve https://github.com/gpuweb/gpuweb/discussions/2085 and some of https://github.com/gpuweb/gpuweb/issues/2119. Specifically, this design allows developers to both wait on the object (say, a pipeline) to be ready AND, if needed, pre-emptively use them anyway before the promise resolves and accept the stall that it may incur.

This also prevents the addition of `...Async()` variants of every possible object in the future if we decide that we need them down the line.

One thing that's not explicitly mentioned in this CL but probably should be is an underlying assumption that the spec begins treating all GPU object creation as scheduling tasks. As Kai describes in https://hackmd.io/@webgpu/r1mBAEGCK#What-if-we-try-to-change-as-little-as-possible :

> Describe everything in WebGPU in an async task model where nothing is ordered until an operation creates a dependency. In this model ALL shader/pipeline creation occurs on independent “threads” that just get "await"ed when you need them.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/2583.html" title="Last updated on Feb 9, 2022, 12:34 AM UTC (ddde53f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2583/4cb81f5...ddde53f.html" title="Last updated on Feb 9, 2022, 12:34 AM UTC (ddde53f)">Diff</a>