### PR TITLE
Remove SPIR-V mappings

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -95,16 +95,6 @@ div.syntax > p > code {
     "id":"IEEE-754",
     "date":"29 August 2008"
   },
-  "SPIR-V": {
-    "authors": [
-      "John Kessenich",
-      "Boaz Ouriel",
-      "Raun Krisch"
-    ],
-    "href": "https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html",
-    "title": "SPIR-V Specification",
-    "publisher": "Khronos Group"
-  },
   "VulkanMemoryModel": {
     "authors": [
       "Jeff Bolz",
@@ -122,9 +112,6 @@ div.syntax > p > code {
 </pre>
 
 <pre class='anchors'>
-spec: SPIR-V; urlPrefix: https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#
-    type: dfn
-        text: image formats; url: _a_id_image_format_a_image_format
 spec: Vulkan ; urlPrefix: https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#
     type: dfn
         text: memory model memory operation; url: memory-model-memory-operation
@@ -149,15 +136,6 @@ that run on the GPU.
     }
   </xmp>
 </div>
-
-
-## Goals ## {#goals}
-
- * Trivially convertable to [[!SPIR-V]]
- * Constructs are defined as normative references to their [[!SPIR-V]] counterparts
- * All features in WGSL are directly translatable to [[!SPIR-V]]. (No polymorphism, no general pointers, no overloads, etc)
- * Features and semantics are exactly the ones of [[!SPIR-V]]
- * Each item in this spec *must* provide the mapping to [[!SPIR-V]] for the construct
 
 ## Technical Overview ## {#technical-overview}
 
@@ -646,8 +624,8 @@ An attribute must not be specified more than once per object or type.
     same.
     There is no affect on a `position` [=built-in input value=].
 
-    Note: this attribute maps to the `Invariant` decoration in SPIR-V, the
-    `precise` qualifier in HLSL, and the `invariant` qualifier in GLSL.
+    Note: this attribute maps to the `precise` qualifier in HLSL, and the
+    `invariant` qualifier in GLSL.
 
   <tr><td><dfn noexport dfn-for="attribute">`location`
     <td>non-negative i32 literal
@@ -1110,46 +1088,6 @@ Note that variables in [=address spaces/workgroup=] space are shared within a
 [=compute shader stage/workgroup=], but are not shared between different
 workgroups.
 
-<div class='example wgsl storage atomic' heading='Mapping atomics in a storage variable to SPIR-V'>
-  <xmp>
-    struct S {
-      a: atomic<i32>;
-      b: atomic<u32>;
-    }
-
-    @group(0) @binding(0)
-    var<storage,read_write> x: S;
-
-    // Maps to the following SPIR-V:
-    // - When atomic types are members of a struct, the Volatile decoration
-    //   is annotated on the member.
-    // OpDecorate %S Block
-    // OpMemberDecorate %S 0 Volatile
-    // OpMemberDecorate %S 1 Volatile
-    // ...
-    // %i32 = OpTypeInt 32 1
-    // %u32 = OpTypeInt 32 0
-    // %S = OpTypeStruct %i32 %u32
-    // %ptr_storage_S = OpTypePointer StorageBuffer %S
-    // %x = OpVariable %ptr_storage_S StorageBuffer
-  </xmp>
-</div>
-
-<div class='example wgsl workgroup atomic' heading='Mapping atomics in a workgroup variable to SPIR-V'>
-  <xmp>
-    var<workgroup> x: atomic<u32>;
-
-    // Maps to the following SPIR-V:
-    // - When atomic types are directly instantiated by a variable,  the Volatile
-    //   decoration is annotated on the OpVariable.
-    // OpDecorate %x Volatile
-    // ...
-    // %u32 = OpTypeInt 32 0
-    // %ptr_workgroup_u32 = OpTypePointer Workgroup %S
-    // %x = OpVariable %ptr_workgroup_u32 Workgroup
-  </xmp>
-</div>
-
 
 ### Array Types ### {#array-types}
 
@@ -1334,17 +1272,6 @@ to define a [=uniform buffer=] or a [=storage buffer=]. See [[#memory-layouts]].
   </xmp>
 </div>
 
-<div class='example spirv' heading='Structure SPIR-V'>
-  <xmp>
-                  OpName %my_struct "my_struct"
-                  OpMemberName %my_struct 0 "a"
-                  OpMemberDecorate %my_struct 0 Offset 0
-                  OpMemberName %my_struct 1 "b"
-                  OpMemberDecorate %my_struct 1 Offset 4
-     %my_struct = OpTypeStruct %float %v4float
-  </xmp>
-</div>
-
 <div class='example wgsl global-scope' heading='Structure WGSL'>
   <xmp>
     // Runtime Array
@@ -1355,21 +1282,6 @@ to define a [=uniform buffer=] or a [=storage buffer=]. See [[#memory-layouts]].
       data: RTArr;
     }
     @group(0) @binding(0) var<storage> buffer: S;
-  </xmp>
-</div>
-
-<div class='example spirv' heading='Structure SPIR-V'>
-  <xmp>
-                  OpName %my_struct "my_struct"
-                  OpMemberName %my_struct 0 "a"
-                  OpMemberDecorate %my_struct 0 Offset 0
-                  OpMemberName %my_struct 1 "b"
-                  OpMemberDecorate %my_struct 1 Offset 4
-                  OpMemberName %my_struct 2 "data"
-                  OpMemberDecorate %my_struct 2 Offset 16
-                  OpDecorate %rt_arr ArrayStride 16
-        %rt_arr = OpTypeRuntimeArray %v4float
-     %my_struct = OpTypeStruct %float %v4float %rt_arr
   </xmp>
 </div>
 
@@ -1652,19 +1564,6 @@ For a write-only storage texture, the underlying texels are write-only.
 
     | [=syntax/storage=]
 </div>
-
-<table class='data'>
-  <thead>
-    <tr><th>WGSL address space<th>SPIR-V storage class
-  </thead>
-  <tr><td>uniform<td>Uniform
-  <tr><td>workgroup<td>Workgroup
-  <tr><td>handle<td>UniformConstant
-  <tr><td>storage<td>StorageBuffer
-  <tr><td>private<td>Private
-  <tr><td>function<td>Function
-</table>
-
 
 ### Memory Layout ### {#memory-layouts}
 
@@ -2763,54 +2662,15 @@ The last column in the table below uses the format-specific
   <tr><td>rgba32float<td>32float<td>r, g, b, a<td>vec4&lt;f32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
 </table>
 
-The following table lists the correspondence between WGSL texel formats and
-SPIR-V [=image formats=].
-
-<table class='data'>
-  <caption>Mapping texel formats to SPIR-V</caption>
-  <thead>
-    <tr><th>Texel format
-        <th>SPIR-V Image Format
-        <th>SPIR-V Enabling Capability
-  </thead>
-  <tr><td>rgba8unorm<td>Rgba8<td>Shader
-  <tr><td>rgba8snorm<td>Rgba8Snorm<td>Shader
-  <tr><td>rgba8uint<td>Rgba8ui<td>Shader
-  <tr><td>rgba8sint<td>Rgba8i<td>Shader
-  <tr><td>rgba16uint<td>Rgba16ui<td>Shader
-  <tr><td>rgba16sint<td>Rgba16i<td>Shader
-  <tr><td>rgba16float<td>Rgba16f<td>Shader
-  <tr><td>r32uint<td>R32ui<td>Shader
-  <tr><td>r32sint<td>R32i<td>Shader
-  <tr><td>r32float<td>R32f<td>Shader
-  <tr><td>rg32uint<td>Rg32ui<td>StorageImageExtendedFormats
-  <tr><td>rg32sint<td>Rg32i<td>StorageImageExtendedFormats
-  <tr><td>rg32float<td>Rg32f<td>StorageImageExtendedFormats
-  <tr><td>rgba32uint<td>Rgba32ui<td>Shader
-  <tr><td>rgba32sint<td>Rgba32i<td>Shader
-  <tr><td>rgba32float<td>Rgba32f<td>Shader
-</table>
-
 ### Sampled Texture Types ### {#sampled-texture-type}
 
 <pre class='def'>
 `texture_1d<type>`
-  %1 = OpTypeImage %type 1D 0 0 0 1 Unknown
-
 `texture_2d<type>`
-  %1 = OpTypeImage %type 2D 0 0 0 1 Unknown
-
 `texture_2d_array<type>`
-  %1 = OpTypeImage %type 2D 0 1 0 1 Unknown
-
 `texture_3d<type>`
-  %1 = OpTypeImage %type 3D 0 0 0 1 Unknown
-
 `texture_cube<type>`
-  %1 = OpTypeImage %type Cube 0 0 0 1 Unknown
-
 `texture_cube_array<type>`
-  %1 = OpTypeImage %type Cube 0 1 0 1 Unknown
 </pre>
 * type must be `f32`, `i32` or `u32`
 * The parameterized type for the images is the type after conversion from sampling.
@@ -2821,7 +2681,6 @@ SPIR-V [=image formats=].
 
 <pre class='def'>
 `texture_multisampled_2d<type>`
-  %1 = OpTypeImage %type 2D 0 0 1 1 Unknown
 </pre>
 * type must be `f32`, `i32` or `u32`
 
@@ -2836,7 +2695,7 @@ but potentially with a different representation.
 It can be read using `textureLoad` or `textureSampleLevel`,
 which handle these different representations opaquely.
 
-See [`GPUExternalTexture`](https://gpuweb.github.io/gpuweb/#gpu-external-texture) for details.
+See [[WebGPU#GPUExternalTexture]].
 
 ### Storage Texture Types ### {#texture-storage}
 
@@ -2859,61 +2718,21 @@ TODO(dneto): Move description of the conversion to the builtin function that act
 
 <pre class='def'>
 `texture_storage_1d<texel_format,access>`
-  // %1 = OpTypeImage sampled_type 1D 0 0 0 2 image_format
-
 `texture_storage_2d<texel_format,access>`
-  // %1 = OpTypeImage sampled_type 2D 0 0 0 2 image_format
-
 `texture_storage_2d_array<texel_format,access>`
-  // %1 = OpTypeImage sampled_type 2D 0 1 0 2 image_format
-
 `texture_storage_3d<texel_format,access>`
-  // %1 = OpTypeImage sampled_type 3D 0 0 0 2 image_format
 </pre>
 
 * `texel_format` must be one of the texel types specified in [=storage-texel-formats=]
 * `access` must be [=access/write=].
 
-In the SPIR-V mapping:
-* The *Image Format* parameter of the image type declaration is
-    as specified by the SPIR-V texel format correspondence table in [[#texel-formats]].
-* The *Sampled Type* parameter of the image type declaration is
-    the SPIR-V scalar type corresponding to the channel format for the texel format.
-
-When mapping to SPIR-V, a write-only storage texture variable must have a `NonReadable` decoration.
-
-For example:
-
-<div class='example wgsl global-scope' heading='Mapping a writable texture_storage_1d variable to SPIR-V'>
-  <xmp>
-      var tbuf: texture_storage_1d<rgba8unorm,write>;
-
-      // Maps to the following SPIR-V:
-      //  OpDecorate %tbuf NonReadable
-      //  ...
-      //  %float = OpTypeFloat 32
-      //  %image_type = OpTypeImage %float 1D 0 0 0 2 Rgba8
-      //  %image_ptr_type = OpTypePointer UniformConstant %image_type
-      //  %tbuf = OpVariable %image_ptr_type UniformConstant
-  </xmp>
-</div>
-
 ### Depth Texture Types ### {#texture-depth}
 <pre class='def'>
 `texture_depth_2d`
-  %1 = OpTypeImage %f32 2D 1 0 0 1 Unknown
-
 `texture_depth_2d_array`
-  %1 = OpTypeImage %f32 2D 1 1 0 1 Unknown
-
 `texture_depth_cube`
-  %1 = OpTypeImage %f32 Cube 1 0 0 1 Unknown
-
 `texture_depth_cube_array`
-  %1 = OpTypeImage %f32 Cube 1 1 0 1 Unknown
-
 `texture_depth_multisampled_2d`
-  %1 = OpTypeImage %f32 2D 1 0 1 1 Unknown
 </pre>
 
 ### Sampler Type ### {#sampler-type}
@@ -2944,10 +2763,7 @@ Samplers can only be used by the [[#texture-builtin-functions|texture builtin fu
 
 <pre class='def'>
 sampler
-  OpTypeSampler
-
 sampler_comparison
-  OpTypeSampler
 </pre>
 
 ### Texture Types Grammar ### {#texture-types-grammar}
@@ -3134,30 +2950,13 @@ When the type declaration is an [=identifier=], then the expression must be in s
       Allows to specify types created by the type command
 
     bool
-       %1 = OpTypeBool
-
     f32
-       %2 = OpTypeFloat 32
-
     i32
-       %3 = OpTypeInt 32 1
-
     u32
-       %4 = OpTypeInt 32 0
-
     vec2<f32>
-        %7 = OpTypeVector %float 2
-
     array<f32, 4>
-       %uint_4 = OpConstant %uint 4
-            %9 = OpTypeArray %float %uint_4
-
     array<f32>
-       %rtarr = OpTypeRuntimeArray %float
-
     mat2x3<f32>
-       %vec = OpTypeVector %float 3
-         %6 = OpTypeMatrix %vec 2
   </xmp>
 </div>
 
@@ -3348,17 +3147,6 @@ Consider the following snippet of WGSL:
   </xmp>
 </div>
 Because `x` is a variable, all accesses to it turn into load and store operations.
-If this snippet was compiled to SPIR-V, it would be represented as
-<div class='example spirv' heading='Sample translation for reading a variable multiple times'>
-  <xmp highlight='asm'>
-    %temp_1 = OpLoad %float %x
-    %temp_2 = OpLoad %float %x
-    %temp_3 = OpFMul %float %temp_1 %temp_2
-    %temp_4 = OpLoad %float %x
-    %temp_5 = OpFAdd %float %temp_3 %temp_4
-    %y      = OpFAdd %float %temp_5 %one
-  </xmp>
-</div>
 However, it is expected that either the browser or the driver optimizes this intermediate representation
 such that the redundant loads are eliminated.
 
@@ -3417,14 +3205,6 @@ WGSL defines the following attributes that can be applied to global variables:
   </xmp>
 </div>
 
-<div class='example' heading="Variable Decorations">
-  <xmp>
-    @group(4) @binding(3)
-       OpDecorate %variable DescriptorSet 4
-       OpDecorate %variable Binding 3
-  </xmp>
-</div>
-
 ## Module Constants ## {#module-constants}
 
 A [[#value-decls|value declaration]] appearing outside all functions declares a
@@ -3457,31 +3237,6 @@ value of a constant, then that variable or feature is considered to be used by t
 program.
 This is true regardless of the value of the constant, whether that value
 is the one from the constant's declaration or from a pipeline override.
-
-<div class='example' heading='Constants'>
-  <xmp>
-    -1
-       %a = OpConstant %int -1
-
-    2
-       %b = OpConstant %uint 2
-
-    3.2
-       %c = OpConstant %float 3.2
-
-    true
-        %d = OpConstantTrue
-
-    false
-        %e = OpConstant False
-
-    vec4<f32>(1.2, 2.3, 3.4, 2.3)
-        %f0 = OpConstant %float 1.2
-        %f1 = OpConstant %float 2.3
-        %f2 = OpConstant %float 3.4
-         %f = OpConstantComposite %v4float %f0 %f1 %f2 %f1
-  </xmp>
-</div>
 
 ## Function Scope Variables and Constants ## {#function-scope-variables}
 
@@ -3580,11 +3335,11 @@ Expressions specify how values are computed.
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
-  <tr><td><td>`true`: bool<td>`true` boolean value. (OpConstantTrue)
-  <tr><td><td>`false`: bool<td>`false` boolean value. (OpConstantFalse)
-  <tr><td><td>*INT_LITERAL*: i32<td>Signed integer value. (OpConstant)
-  <tr><td><td>*UINT_LITERAL*: u32<td>Unsigned integer value. (OpConstant)
-  <tr><td><td>*FLOAT_LITERAL*: f32<td>Floating-point value. (OpConstant)
+  <tr><td><td>`true`: bool<td>`true` boolean value.
+  <tr><td><td>`false`: bool<td>`false` boolean value.
+  <tr><td><td>*INT_LITERAL*: i32<td>Signed integer value.
+  <tr><td><td>*UINT_LITERAL*: u32<td>Unsigned integer value.
+  <tr><td><td>*FLOAT_LITERAL*: f32<td>Floating-point value.
 </table>
 
 ## Parenthesized Expressions ## {#parenthesized-expressions}
@@ -3619,12 +3374,12 @@ See also [[#zero-value-expr]] and [[#conversion-expr]].
 <table class='data'>
   <caption>Scalar constructor type rules</caption>
   <thead>
-    <tr><th>Precondition<th>Conclusion<th>Notes
+    <tr><th>Precondition<th>Conclusion
   </thead>
-  <tr><td>*e*: bool<td>`bool(e)`: bool<td>Identity.<br>In the SPIR-V translation, the ID of this expression reuses the ID of the operand.
-  <tr><td>*e*: i32<td>`i32(e)`: i32<td>Identity.<br>In the SPIR-V translation, the ID of this expression reuses the ID of the operand.
-  <tr><td>*e*: u32<td>`u32(e)`: u32<td>Identity.<br>In the SPIR-V translation, the ID of this expression reuses the ID of the operand.
-  <tr><td>*e*: f32<td>`f32(e)`: f32<td>Identity.<br>In the SPIR-V translation, the ID of this expression reuses the ID of the operand.
+  <tr><td>*e*: bool<td>`bool(e)`: bool<td>Identity.
+  <tr><td>*e*: i32<td>`i32(e)`: i32<td>Identity.
+  <tr><td>*e*: u32<td>`u32(e)`: u32<td>Identity.
+  <tr><td>*e*: f32<td>`f32(e)`: f32<td>Identity.
 </table>
 
 <table class='data'>
@@ -3642,7 +3397,7 @@ See also [[#zero-value-expr]] and [[#conversion-expr]].
     <td rowspan=2>*e1*: *T*<br>
         *e2*: *T*
     <td>`vec2<T>(e1,e2)`: vec2<*T*>
-    <td rowspan=2>OpCompositeConstruct
+    <td rowspan=2>
   <tr>
     <td>`vec2(e1,e2)`: vec2<*T*>
   <tr>
@@ -3656,7 +3411,7 @@ See also [[#zero-value-expr]] and [[#conversion-expr]].
         *e2*: *T*<br>
         *e3*: *T*
     <td>`vec3<T>(e1,e2,e3)`: vec3<*T*>
-    <td rowspan=2>OpCompositeConstruct
+    <td rowspan=2>
   <tr>
     <td>`vec3(e1,e2,e3)`: vec3<*T*>
   <tr>
@@ -3664,7 +3419,7 @@ See also [[#zero-value-expr]] and [[#conversion-expr]].
         *e2*: vec2<*T*>
     <td>`vec3<T>(e1,e2)`: vec3<*T*><br>
         `vec3<T>(e2,e1)`: vec3<*T*>
-    <td rowspan=2>OpCompositeConstruct
+    <td rowspan=2>
   <tr>
     <td>`vec3(e1,e2)`: vec3<*T*><br>
         `vec3(e2,e1)`: vec3<*T*>
@@ -3680,7 +3435,7 @@ See also [[#zero-value-expr]] and [[#conversion-expr]].
         *e3*: *T*<br>
         *e4*: *T*
     <td class=nowrap>`vec4<T>(e1,e2,e3,e4)`: vec4<*T*>
-    <td rowspan=2>OpCompositeConstruct
+    <td rowspan=2>
   <tr>
     <td class=nowrap>`vec4(e1,e2,e3,e4)`: vec4<*T*>
   <tr>
@@ -3690,7 +3445,7 @@ See also [[#zero-value-expr]] and [[#conversion-expr]].
     <td class=nowrap>`vec4<T>(e1,e2,e3)`: vec4<*T*><br>
         `vec4<T>(e1,e3,e2)`: vec4<*T*><br>
         `vec4<T>(e3,e1,e2)`: vec4<*T*>
-    <td rowspan=2>OpCompositeConstruct
+    <td rowspan=2>
   <tr>
     <td class=nowrap>`vec4(e1,e2,e3)`: vec4<*T*><br>
         `vec4(e1,e3,e2)`: vec4<*T*><br>
@@ -3699,7 +3454,7 @@ See also [[#zero-value-expr]] and [[#conversion-expr]].
     <td rowspan=2>*e1*: vec2<*T*><br>
         *e2*: vec2<*T*>
     <td class=nowrap>`vec4<T>(e1,e2)`: vec4<*T*>
-    <td rowspan=2>OpCompositeConstruct
+    <td rowspan=2>
   <tr>
     <td class=nowrap>`vec4(e1,e2)`: vec4<*T*>
   <tr>
@@ -3707,7 +3462,7 @@ See also [[#zero-value-expr]] and [[#conversion-expr]].
         *e2*: vec3<*T*>
     <td class=nowrap>`vec4<T>(e1,e2)`: vec4<*T*><br>
         `vec4<T>(e2,e1)`: vec4<*T*>
-    <td rowspan=2>OpCompositeConstruct
+    <td rowspan=2>
   <tr>
     <td>`vec4(e1,e2)`: vec4<*T*><br>
         `vec4(e2,e1)`: vec4<*T*>
@@ -3738,7 +3493,6 @@ See also [[#zero-value-expr]] and [[#conversion-expr]].
         `mat3x4<f32>(e1,...,e12)`: mat3x4&lt;f32&gt;<br>
         `mat4x4<f32>(e1,...,e16)`: mat4x4&lt;f32&gt;
     <td rowspan=2>Column-major construction by elements.<br>
-        OpCompositeConstruct
   <tr>
     <td>`mat2x2(e1,e2,e3,e4)`: mat2x2&lt;f32&gt;<br>
         `mat3x2(e1,...,e6)`: mat3x2&lt;f32&gt;<br>
@@ -3758,7 +3512,6 @@ See also [[#zero-value-expr]] and [[#conversion-expr]].
         `mat3x2<f32>(e1,e2,e3)`: mat3x2&lt;f32&gt;<br>
         `mat4x2<f32>(e1,e2,e3,e4)`: mat4x2&lt;f32&gt;
     <td rowspan=2>Column by column construction.<br>
-        OpCompositeConstruct
   <tr>
     <td>`mat2x2(e1,e2)`: mat2x2&lt;f32&gt;<br>
         `mat3x2(e1,e2,e3)`: mat3x2&lt;f32&gt;<br>
@@ -3772,7 +3525,6 @@ See also [[#zero-value-expr]] and [[#conversion-expr]].
         `mat3x3<f32>(e1,e2,e3)`: mat3x3&lt;f32&gt;<br>
         `mat4x3<f32>(e1,e2,e3,e4)`: mat4x3&lt;f32&gt;
     <td rowspan=2>Column by column construction.<br>
-        OpCompositeConstruct
   <tr>
     <td>`mat2x3(e1,e2)`: mat2x3&lt;f32&gt;<br>
         `mat3x3(e1,e2,e3)`: mat3x3&lt;f32&gt;<br>
@@ -3786,7 +3538,6 @@ See also [[#zero-value-expr]] and [[#conversion-expr]].
         `mat3x4<f32>(e1,e2,e3)`: mat3x4&lt;f32&gt;<br>
         `mat4x4<f32>(e1,e2,e3,e4)`: mat4x4&lt;f32&gt;
     <td rowspan=2>Column by column construction.<br>
-        OpCompositeConstruct
   <tr>
     <td>`mat2x4(e1,e2)`: mat2x4&lt;f32&gt;<br>
         `mat3x4(e1,e2,e3)`: mat3x4&lt;f32&gt;<br>
@@ -3850,10 +3601,10 @@ Note: WGSL does not have zero expression for [=atomic types=],
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
-  <tr><td><td>`bool()`: bool<td>false<br>Zero value (OpConstantNull for bool)
-  <tr><td><td>`i32()`: i32<td>0<br>Zero value (OpConstantNull for i32)
-  <tr><td><td>`u32()`: u32<td>0u<br>Zero value (OpConstantNull for u32)
-  <tr><td><td>`f32()`: f32<td>0.0<br>Zero value (OpConstantNull for f32)
+  <tr><td><td>`bool()`: bool<td>false<br>Zero value
+  <tr><td><td>`i32()`: i32<td>0<br>Zero value
+  <tr><td><td>`u32()`: u32<td>0u<br>Zero value
+  <tr><td><td>`f32()`: f32<td>0.0<br>Zero value
 </table>
 
 <table class='data'>
@@ -3864,15 +3615,15 @@ Note: WGSL does not have zero expression for [=atomic types=],
   <tr>
     <td>
     <td>`vec2<T>()`: vec2<*T*>
-    <td>Zero value (OpConstantNull)
+    <td>Zero value
   <tr>
     <td>
     <td>`vec3<T>()`: vec3<*T*>
-    <td>Zero value (OpConstantNull)
+    <td>Zero value
   <tr>
     <td>
     <td>`vec4<T>()`: vec4<*T*>
-    <td>Zero value (OpConstantNull)
+    <td>Zero value
 </table>
 
 
@@ -3896,19 +3647,19 @@ Note: WGSL does not have zero expression for [=atomic types=],
     <td>`mat2x2<f32>()`: mat2x2&lt;f32&gt;<br>
         `mat3x2<f32>()`: mat3x2&lt;f32&gt;<br>
         `mat4x2<f32>()`: mat4x2&lt;f32&gt;
-    <td>Zero value (OpConstantNull)
+    <td>Zero value
   <tr>
     <td>
     <td>`mat2x3<f32>()`: mat2x3&lt;f32&gt;<br>
         `mat3x3<f32>()`: mat3x3&lt;f32&gt;<br>
         `mat4x3<f32>()`: mat4x3&lt;f32&gt;
-    <td>Zero value (OpConstantNull)
+    <td>Zero value
   <tr>
     <td>
     <td>`mat2x4<f32>()`: mat2x4&lt;f32&gt;<br>
         `mat3x4<f32>()`: mat3x4&lt;f32&gt;<br>
         `mat4x4<f32>()`: mat4x4&lt;f32&gt;
-    <td>Zero value (OpConstantNull)
+    <td>Zero value
 </table>
 
 <table class='data'>
@@ -3919,7 +3670,7 @@ Note: WGSL does not have zero expression for [=atomic types=],
   <tr algorithm="array zero value">
     <td>|T| is a [=constructible=]
     <td>`array<`|T|,|N|`>()`: array&lt;|T|,|N|&gt;
-    <td>Zero-valued array (OpConstantNull)
+    <td>Zero-valued array
 </table>
 
 <div class='example' heading="Zero-valued arrays">
@@ -3939,8 +3690,6 @@ Note: WGSL does not have zero expression for [=atomic types=],
          The expression is in the scope of declaration of |S|.
     <td>|S|`()`: |S|
     <td>Zero-valued structure: a structure of type |S| where each member is the zero value for its member type.
-<br>
- (OpConstantNull)
 </table>
 
 <div class='example wgsl global-scope' heading="Zero-valued structures">
@@ -3984,54 +3733,46 @@ See also [[#type-constructor-expr]].
   <tr algorithm="coercion to boolean from unsigned">
       <td>|e|: u32<td>`bool(`|e|`)`: bool
       <td>Coercion to boolean.<br>
-          The result is false if |e| is 0, and true otherwise.<br>
-          (Use OpINotEqual to compare |e| against 0.)
+          The result is false if |e| is 0, and true otherwise.
   <tr algorithm="coercion to boolean from signed">
       <td>|e|: i32<td>`bool(`|e|`)`: bool
       <td>Coercion to boolean.<br>
-          The result is false if |e| is 0, and true otherwise.<br>
-          (Use OpINotEqual to compare |e| against 0.)
+          The result is false if |e| is 0, and true otherwise.
   <tr algorithm="coercion to boolean from floating point">
       <td>|e|: f32<td>`bool(`|e|`)`: bool
       <td>Coercion to boolean.<br>
           The result is false if |e| is 0.0 or -0.0, and true otherwise.
-          In particular NaN and infinity values map to true.<br>
-          (Use OpFUnordNotEqual to compare |e| against `0.0`.)
+          In particular NaN and infinity values map to true.
   <tr algorithm="conversion from boolean to signed">
       <td>|e|: bool<td>`i32(`|e|`)`: i32
       <td>Conversion of a boolean value to a signed integer<br>
           The result is 1 if |e| is true and 0 otherwise.<br>
-          (Use OpSelect with |e| as the condition, selecting between 1 and 0.)
   <tr algorithm="scalar reinterpretation from unsigned to signed">
       <td>|e|: u32<td>`i32(`|e|`)`: i32
       <td>Reinterpretation of bits.<br>
-          The result is the unique value in [=i32=] that is equal to (|e| mod 2<sup>32</sup>).<br>
-          (OpBitcast)
+          The result is the unique value in [=i32=] that is equal to (|e| mod 2<sup>32</sup>).
   <tr algorithm="scalar conversion from floating point to signed integer">
       <td>|e|: f32<td>`i32(`|e|`)`: i32
-      <td>Value conversion, rounding toward zero.<br>(OpConvertFToS)
+      <td>Value conversion, rounding toward zero.
   <tr algorithm="conversion from boolean to unsigned">
       <td>|e|: bool<td>`u32(`|e|`)`: u32
       <td>Conversion of a boolean value to an unsigned integer<br>
-          The result is 1u if |e| is true and 0u otherwise.<br>
-          (Use OpSelect with |e| as the condition, selecting between 1u and 0u.)
+          The result is 1u if |e| is true and 0u otherwise.
   <tr algorithm="scalar conversion from signed integer to unsigned integer">
       <td>|e|: i32<td>`u32(`|e|`)`: u32
       <td>Reinterpretation of bits.<br>
-          The result is the unique value in [=u32=] that is equal to (|e| mod 2<sup>32</sup>).<br>
-          (OpBitcast)
+          The result is the unique value in [=u32=] that is equal to (|e| mod 2<sup>32</sup>).
   <tr algorithm="scalar conversion from floating point to unsigned integer">
       <td>|e|: f32<td>`u32(`|e|`)`: u32
-      <td>Value conversion, rounding toward zero.<br>(OpConvertFToU)
+      <td>Value conversion, rounding toward zero.
   <tr algorithm="conversion from boolean to floating point">
       <td>|e|: bool<td>`f32(`|e|`)`: f32
       <td>Conversion of a boolean value to floating point<br>
-          The result is 1.0 if |e| is true and 0.0 otherwise.<br>
-          (Use OpSelect with |e| as the condition, selecting between 1.0 and 0.0.)
+          The result is 1.0 if |e| is true and 0.0 otherwise.
   <tr algorithm="scalar conversion from signed integer to floating point">
-      <td>|e|: i32<td>`f32(`|e|`)`: f32<td>Value conversion, including invalid cases. (OpConvertSToF)
+      <td>|e|: i32<td>`f32(`|e|`)`: f32<td>Value conversion, including invalid cases.
   <tr algorithm="scalar conversion from unsigned integer to floating point">
-      <td>|e|: u32<td>`f32(`|e|`)`: f32<td>Value conversion, including invalid cases. (OpConvertUToF)
+      <td>|e|: u32<td>`f32(`|e|`)`: f32<td>Value conversion, including invalid cases.
 </table>
 
 Details of conversion to and from floating point are explained in [[#floating-point-conversion]].
@@ -4044,78 +3785,66 @@ Details of conversion to and from floating point are explained in [[#floating-po
   <tr algorithm="vector coercion of unsigned integer to boolean">
      <td>|e|: vec|N|&lt;u32&gt;
      <td>`vec`|N|&lt;`bool`&gt;`(`|e|`)`: vec|N|&lt;bool&gt
-     <td>[=Component-wise=] coercion of a unsigned integer vector to a boolean vector.<br>
-         (OpINotEqual to compare |e| against a zero vector.)
+     <td>[=Component-wise=] coercion of a unsigned integer vector to a boolean vector.
 
   <tr algorithm="vector coercion of signed integer to boolean">
      <td>|e|: vec|N|&lt;i32&gt;
      <td>`vec`|N|&lt;`bool`&gt;`(`|e|`)`: vec|N|&lt;bool&gt
-     <td>[=Component-wise=] coercion of a signed integer vector to a boolean vector.<br>
-         (OpINotEqual to compare |e| against a zero vector.)
+     <td>[=Component-wise=] coercion of a signed integer vector to a boolean vector.
 
   <tr algorithm="vector coercion of floating point to boolean">
      <td>|e|: vec|N|&lt;f32&gt;
      <td>`vec`|N|&lt;`bool`&gt;`(`|e|`)`: vec|N|&lt;bool&gt
-     <td>[=Component-wise=] coercion of a floating point vector to a boolean vector.<br>
-         (OpFUnordNotEqual to compare |e| against a zero vector.)
+     <td>[=Component-wise=] coercion of a floating point vector to a boolean vector.
 
   <tr algorithm="vector conversion from bool to signed">
      <td>|e|: vec|N|&lt;bool&gt;
      <td>`vec`|N|&lt;`i32`&gt;`(`|e|`)`: vec|N|&lt;i32&gt
      <td>[=Component-wise=] conversion of a boolean vector to signed.<br>
-         Component |i| of the result is `i32(`|e|`[`|i|`])`<br>
-         (OpSelect, with |e| as the condition, selecting between `vec`|N|(1) and `vec`|N|(0).)
+         Component |i| of the result is `i32(`|e|`[`|i|`])`
 
   <tr algorithm="vector reinterpretation from unsigned to signed">
      <td>|e|: vec|N|&lt;u32&gt;
      <td>`vec`|N|&lt;`i32`&gt;`(`|e|`)`: vec|N|&lt;i32&gt
      <td>[=Component-wise=] reinterpretation of bits.<br>
-         Component |i| of the result is `i32(`|e|`[`|i|`])`<br>
-         (OpBitcast)
+         Component |i| of the result is `i32(`|e|`[`|i|`])`
 
   <tr algorithm="vector conversion from floating point to signed integer">
      <td>|e|: vec|N|&lt;f32&gt;
      <td>`vec`|N|&lt;`i32`&gt;`(`|e|`)`: vec|N|&lt;i32&gt;
-     <td>[=Component-wise=] value conversion to signed integer, including invalid cases.<br>
-        (OpConvertFToS)
+     <td>[=Component-wise=] value conversion to signed integer, including invalid cases.
 
   <tr algorithm="vector conversion from bool to unsigned">
      <td>|e|: vec|N|&lt;bool&gt;
      <td>`vec`|N|&lt;`u32`&gt;`(`|e|`)`: vec|N|&lt;u32&gt
      <td>[=Component-wise=] conversion of a boolean vector to unsigned.<br>
-         Component |i| of the result is `u32(`|e|`[`|i|`])`<br>
-         (OpSelect, with |e| as the condition, selecting between `vec`|N|(1u) and `vec`|N|(0u).)
+         Component |i| of the result is `u32(`|e|`[`|i|`])`
 
   <tr algorithm="vector reinterpretation from signed to unsigned">
      <td>|e|: vec|N|&lt;i32&gt;
      <td>`vec`|N|&lt;`u32`&gt;`(`|e|`)`: vec|N|&lt;u32&gt;
-     <td>[=Component-wise=] reinterpretation of bits.<br>
-        (OpBitcast)
+     <td>[=Component-wise=] reinterpretation of bits.
 
   <tr algorithm="vector conversion from floating point to unsigned integer">
      <td>|e|: vec|N|&lt;f32&gt;
      <td>`vec`|N|&lt;`u32`&gt;`(`|e|`)`: vec|N|&lt;u32&gt;
-     <td>[=Component-wise=] value conversion to unsigned integer, including invalid cases.<br>
-        (OpConvertFToU)
+     <td>[=Component-wise=] value conversion to unsigned integer, including invalid cases.
 
   <tr algorithm="vector conversion from bool to floating point">
      <td>|e|: vec|N|&lt;bool&gt;
      <td>`vec`|N|&lt;`u32`&gt;`(`|e|`)`: vec|N|&lt;u32&gt
      <td>[=Component-wise=] conversion of a boolean vector to floating point.<br>
-         Component |i| of the result is `f32(`|e|`[`|i|`])`<br>
-         (OpSelect, with |e| as the condition, selecting between `vec`|N|(1.0) and `vec`|N|(0.0).)
+         Component |i| of the result is `f32(`|e|`[`|i|`])`
 
   <tr algorithm="vector conversion from signed integer to floating point">
      <td>|e|: vec|N|&lt;i32&gt;
      <td>`vec`|N|&lt;`f32`&gt;`(`|e|`)`: vec|N|&lt;f32&gt;
-     <td>[=Component-wise=] value conversion to floating point, including invalid cases.<br>
-        (OpConvertSToF)
+     <td>[=Component-wise=] value conversion to floating point, including invalid cases.
 
   <tr algorithm="vector conversion from unsigned integer to floating point">
      <td>|e|: vec|N|&lt;u32&gt;
      <td>`vec`|N|&lt;`f32`&gt;`(`|e|`)`: vec|N|&lt;f32&gt;
-     <td>[=Component-wise=] value conversion to floating point, including invalid cases.<br>
-        (ConvertUToF)
+     <td>[=Component-wise=] value conversion to floating point, including invalid cases.
 
 </table>
 
@@ -4135,8 +3864,7 @@ value in one type as a value in another type.
     |T| is a [=numeric scalar=] or [=numeric vector=] type
     <td class="nowrap">bitcast&lt;|T|&gt;(|e|): |T|
     <td>Identity transform. [=Component-wise=] when |T| is a vector.<br>
-    The result is |e|.<br>
-    In the SPIR-V translation, the ID of this expression reuses the ID of the operand.
+    The result is |e|.
 
   <tr algorithm="general reinterpretation">
     <td>|e|: |T1|<br>
@@ -4145,8 +3873,7 @@ value in one type as a value in another type.
     a numeric vector type if |T1| is a vector
     <td class="nowrap">bitcast&lt;|T2|&gt;(|e|): |T2|
     <td>Reinterpretation of bits as |T2|. [=Component-wise=] when |T1| is a vector.<br>
-    The result is the reinterpretation of the bits in |e| as a |T2| value.<br>
-    (OpBitcast)
+    The result is the reinterpretation of the bits in |e| as a |T2| value.
 </table>
 
 ## Composite Value Decomposition Expressions ## {#composite-value-decomposition-expr}
@@ -4200,27 +3927,23 @@ The result type depends on the number of letters provided. Assuming a `vec4<f32>
        <td class="nowrap">
            |e|`.x`: |T|<br>
            |e|`.r`: |T|
-       <td>Select the first component of |e|<br>
-           (OpCompositeExtract with selection index 0)
+       <td>Select the first component of |e|
   <tr algorithm="second vector component selection"><td>|e|: vec|N|&lt;|T|&gt;<br>
        <td class="nowrap">
            |e|`.y`: |T|<br>
            |e|`.g`: |T|
-       <td>Select the second component of |e|<br>
-           (OpCompositeExtract with selection index 1)
+       <td>Select the second component of |e|
   <tr algorithm="third vector component selection"><td>|e|: vec|N|&lt;|T|&gt;<br>
           |N| is 3 or 4
        <td class="nowrap">
            |e|`.z`: |T|<br>
            |e|`.b`: |T|
-       <td>Select the third component of |e|<br>
-           (OpCompositeExtract with selection index 2)
+       <td>Select the third component of |e|
   <tr algorithm="fourth vector component selection"><td>|e|: vec4&lt;|T|&gt;
        <td class="nowrap">
            |e|`.w`: |T|<br>
            |e|`.a`: |T|
-       <td>Select the fourth component of |e|<br>
-           (OpCompositeExtract with selection index 3)
+       <td>Select the fourth component of |e|
   <tr algorithm="vector indexed component selection"><td>|e|: vec|N|&lt;|T|&gt;<br>
           |i|: [INT]
        <td class="nowrap">
@@ -4229,7 +3952,6 @@ The result type depends on the number of letters provided. Assuming a `vec4<f32>
            The first component is at index |i|=0.<br>
            If |i| is outside the range [0,|N|-1], then any valid value for |T|
            may be returned.
-           (OpVectorExtractDynamic)
 </table>
 
 #### Vector Multiple Component Selection #### {#vector-multi-component}
@@ -4248,8 +3970,7 @@ The result type depends on the number of letters provided. Assuming a `vec4<f32>
            |e|`.`|I||J|: vec2&lt;|T|&gt;<br>
        <td>Computes the two-component vector with first component |e|.|I|, and second component |e|.|J|.<br>
            Letter `z` is valid only when |N| is 3 or 4.<br>
-           Letter `w` is valid only when |N| is 4.<br>
-           (OpVectorShuffle)
+           Letter `w` is valid only when |N| is 4.
   <tr algorithm="two component vector selection using .r .g">
        <td class="nowrap">
           |e|: vec|N|&lt;|T|&gt;<br>
@@ -4259,8 +3980,7 @@ The result type depends on the number of letters provided. Assuming a `vec4<f32>
            |e|`.`|I||J|: vec2&lt;|T|&gt;<br>
        <td>Computes the two-component vector with first component |e|.|I|, and second component |e|.|J|.<br>
            Letter `b` is valid only when |N| is 3 or 4.<br>
-           Letter `a` is valid only when |N| is 4.<br>
-           (OpVectorShuffle)
+           Letter `a` is valid only when |N| is 4.
   <tr algorithm="three component vector selection using .x .y">
        <td class="nowrap">
           |e|: vec|N|&lt;|T|&gt;<br>
@@ -4271,8 +3991,7 @@ The result type depends on the number of letters provided. Assuming a `vec4<f32>
            |e|`.`|I||J||K|: vec3&lt;|T|&gt;<br>
        <td>Computes the three-component vector with first component |e|.|I|, second component |e|.|J|, and third component |e|.|K|.<br>
            Letter `z` is valid only when |N| is 3 or 4.<br>
-           Letter `w` is valid only when |N| is 4.<br>
-           (OpVectorShuffle)
+           Letter `w` is valid only when |N| is 4.
   <tr algorithm="three component vector selection using .r .g">
        <td class="nowrap">
           |e|: vec|N|&lt;|T|&gt;<br>
@@ -4283,8 +4002,7 @@ The result type depends on the number of letters provided. Assuming a `vec4<f32>
            |e|`.`|I||J||K|: vec3&lt;|T|&gt;<br>
        <td>Computes the three-component vector with first component |e|.|I|, second component |e|.|J|, and third component |e|.|K|.<br>
            Letter `b` is only valid when |N| is 3 or 4.<br>
-           Letter `a` is only valid when |N| is 4.<br>
-           (OpVectorShuffle)
+           Letter `a` is only valid when |N| is 4.
   <tr algorithm="four component vector selection using .x .y">
        <td class="nowrap">
           |e|: vec|N|&lt;|T|&gt;<br>
@@ -4296,8 +4014,7 @@ The result type depends on the number of letters provided. Assuming a `vec4<f32>
            |e|`.`|I||J||K||L|: vec4&lt;|T|&gt;<br>
        <td>Computes the four-component vector with first component |e|.|I|, second component |e|.|J|, third component |e|.|K|, and fourth component |e|.|L|.<br>
            Letter `z` is valid only when |N| is 3 or 4.<br>
-           Letter `w` is valid only when |N| is 4.<br>
-           (OpVectorShuffle)
+           Letter `w` is valid only when |N| is 4.
   <tr algorithm="four component vector selection using .r .g">
        <td class="nowrap">
           |e|: vec|N|&lt;|T|&gt;<br>
@@ -4309,8 +4026,7 @@ The result type depends on the number of letters provided. Assuming a `vec4<f32>
            |e|`.`|I||J||K||L|: vec4&lt;|T|&gt;<br>
        <td>Computes the four-component vector with first component |e|.|I|, second component |e|.|J|, third component |e|.|K|, and fourth component |e|.|L|.<br>
            Letter `b` is only valid when |N| is 3 or 4.<br>
-           Letter `a` is only valid when |N| is 4.<br>
-           (OpVectorShuffle)
+           Letter `a` is only valid when |N| is 4.
 </table>
 
 #### Component Reference from Vector Reference #### {#component-reference-from-vector-reference}
@@ -4334,8 +4050,7 @@ See [[#sync-builtin-functions]].
            |r|`.r`: ref&lt;|S|,|T|&gt;<br>
        <td>Compute a reference to the first component of the vector referenced by the reference |r|.<br>
            The [=originating variable=] of the resulting reference is
-           the same as the originating variable of |r|.<br>
-           (OpAccessChain with index value 0)
+           the same as the originating variable of |r|.
   <tr algorithm="second vector component reference selection">
        <td>|r|: ref&lt;|S|,vec|N|&lt;|T|&gt;&gt;<br>
        <td class="nowrap">
@@ -4343,8 +4058,7 @@ See [[#sync-builtin-functions]].
            |r|`.g`: ref&lt;|S|,|T|&gt;<br>
        <td>Compute a reference to the second component of the vector referenced by the reference |r|.<br>
            The [=originating variable=] of the resulting reference is
-           the same as the originating variable of |r|.<br>
-           (OpAccessChain with index value 1)
+           the same as the originating variable of |r|.
   <tr algorithm="third vector component reference selection">
        <td>|r|: ref&lt;|S|,vec|N|&lt;|T|&gt;&gt;<br>
            |N| is 3 or 4
@@ -4353,8 +4067,7 @@ See [[#sync-builtin-functions]].
            |r|`.b`: ref&lt;|S|,|T|&gt;<br>
        <td>Compute a reference to the third component of the vector referenced by the reference |r|.<br>
            The [=originating variable=] of the resulting reference is
-           the same as the originating variable of |r|.<br>
-           (OpAccessChain with index value 2)
+           the same as the originating variable of |r|.
   <tr algorithm="fourth vector component reference selection">
        <td>|r|: ref&lt;|S|,vec4&lt;|T|&gt;&gt;<br>
        <td class="nowrap">
@@ -4362,8 +4075,7 @@ See [[#sync-builtin-functions]].
            |r|`.a`: ref&lt;|S|,|T|&gt;<br>
        <td>Compute a reference to the fourth component of the vector referenced by the reference |r|.<br>
            The [=originating variable=] of the resulting reference is
-           the same as the originating variable of |r|.<br>
-           (OpAccessChain with index value 3)
+           the same as the originating variable of |r|.
   <tr algorithm="vector indexed component reference selection">
        <td>|r|: ref&lt;|S|,vec|N|&lt;|T|&gt;&gt;<br>
           |i|: [INT]
@@ -4376,8 +4088,7 @@ See [[#sync-builtin-functions]].
            to [=invalid memory reference=].
 
            The [=originating variable=] of the resulting reference is
-           the same as the originating variable of |r|.<br>
-           (OpAccessChain)
+           the same as the originating variable of |r|.
 </table>
 
 ### Matrix Access Expression ### {#matrix-access-expr}
@@ -4396,8 +4107,7 @@ See [[#sync-builtin-functions]].
        <td>The result is the |i|'<sup>th</sup> column vector of |e|.
 
            If |i| is outside the range [0,|N|-1], then any valid value for
-           vec|M|&lt;|T|&gt; may be returned.<br>
-           (OpCompositeExtract)
+           vec|M|&lt;|T|&gt; may be returned.
 </table>
 
 <table class='data'>
@@ -4418,8 +4128,7 @@ See [[#sync-builtin-functions]].
            [=invalid memory reference=].
 
            The [=originating variable=] of the resulting reference is
-           the same as the originating variable of |r|.<br>
-           (OpAccessChain)
+           the same as the originating variable of |r|.
 </table>
 
 ### Array Access Expression ### {#array-access-expr}
@@ -4438,8 +4147,7 @@ See [[#sync-builtin-functions]].
        <td>The result is the value of the |i|'<sup>th</sup> element of the array value |e|.
 
            If |i| is outside the range [0,|N|-1], then any valid value for |T|
-           may be returned.<br>
-           (OpCompositeExtract)
+           may be returned.
 </table>
 
 <table class='data'>
@@ -4460,8 +4168,7 @@ See [[#sync-builtin-functions]].
            to an [=invalid memory reference=].
 
            The [=originating variable=] of the resulting reference is
-           the same as the originating variable of |r|.<br>
-           (OpAccessChain)
+           the same as the originating variable of |r|.
   <tr algorithm="array indexed reference selection">
        <td>|r|: ref&lt;|S|,array&lt;|T|&gt;&gt;<br>
           |i|: [INT]
@@ -4475,8 +4182,7 @@ See [[#sync-builtin-functions]].
            reference=].
 
            The [=originating variable=] of the resulting reference is
-           the same as the originating variable of |r|.<br>
-           (OpAccessChain)
+           the same as the originating variable of |r|.
 </table>
 
 
@@ -4494,8 +4200,7 @@ See [[#sync-builtin-functions]].
           |e|: |S|<br>
        <td class="nowrap">
            |e|.|M|: |T|
-       <td>The result is the value of the member with name |M| from the structure value |e|.<br>
-           (OpCompositeExtract, using the member index)
+       <td>The result is the value of the member with name |M| from the structure value |e|.
 </table>
 
 <table class='data'>
@@ -4512,8 +4217,7 @@ See [[#sync-builtin-functions]].
            |r|.|M|: ref&lt;|S|,|T|&gt;
        <td>Given a reference to a structure, the result is a reference to the structure member with identifier name |M|.<br>
            The [=originating variable=] of the resulting reference is
-           the same as the originating variable of |r|.<br>
-           (OpAccessChain, using the index of the structure member)
+           the same as the originating variable of |r|.
 </table>
 
 ## Logical Expressions ## {#logical-expr}
@@ -4527,7 +4231,6 @@ See [[#sync-builtin-functions]].
   <td>Logical negation.
   The result is `true` when |e| is `false` and `false` when |e| is `true`.
   [=Component-wise=] when |T| is a vector.
-  (OpLogicalNot)
 </table>
 
 <table class='data'>
@@ -4566,11 +4269,10 @@ See [[#sync-builtin-functions]].
   <td>`-`|e|`:` |T|
   <td>Signed integer negation. [=Component-wise=] when |T| is a vector.
   If |e| evaluates to the largest negative value, then the result is |e|.
-  (OpSNegate)
 
   <tr algorithm="floating point negation"><td>|e|: |T|<br>|T| is [FLOATING]
   <td>`-`|e|`:` |T|
-  <td>Floating point negation. [=Component-wise=] when |T| is a vector. (OpFNegate)
+  <td>Floating point negation. [=Component-wise=] when |T| is a vector.
 </table>
 
 <table class='data'>
@@ -4582,29 +4284,29 @@ See [[#sync-builtin-functions]].
   <tr algorithm="integer addition">
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [INTEGRAL]
     <td>|e1| `+` |e2| : |T|
-    <td>Integer addition, modulo 2<sup>32</sup>. [=Component-wise=] when |T| is a vector. (OpIAdd)
+    <td>Integer addition, modulo 2<sup>32</sup>. [=Component-wise=] when |T| is a vector.
   <tr algorithm="floating point addition">
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [FLOATING]
     <td>|e1| `+` |e2| : |T|
-    <td>Floating point addition. [=Component-wise=] when |T| is a vector. (OpFAdd)
+    <td>Floating point addition. [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="integer subtraction">
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [INTEGRAL]
     <td>|e1| `-` |e2| : |T|
-    <td>Integer subtraction, modulo 2<sup>32</sup>. [=Component-wise=] when |T| is a vector. (OpISub)
+    <td>Integer subtraction, modulo 2<sup>32</sup>. [=Component-wise=] when |T| is a vector.
   <tr algorithm="floating point subtraction">
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [FLOATING]
     <td>|e1| `-` |e2| : |T|
-    <td>Floating point subtraction. [=Component-wise=] when |T| is a vector. (OpFSub)
+    <td>Floating point subtraction. [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="integer multiplication">
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [INTEGRAL]
     <td>|e1| `*` |e2| : |T|
-    <td>Integer multiplication, modulo 2<sup>32</sup>. [=Component-wise=] when |T| is a vector. (OpIMul)
+    <td>Integer multiplication, modulo 2<sup>32</sup>. [=Component-wise=] when |T| is a vector.
   <tr algorithm="floating point multiplication">
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [FLOATING]
     <td>|e1| `*` |e2| : |T|
-    <td>Floating point multiplication. [=Component-wise=] when |T| is a vector. (OpFMul)
+    <td>Floating point multiplication. [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="signed integer division">
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [SIGNEDINTEGRAL]
@@ -4639,11 +4341,10 @@ See [[#sync-builtin-functions]].
             |e1|&nbsp;=&nbsp;|q|&nbsp;&times;&nbsp;|e2|&nbsp;+&nbsp;|r|,
             where 0 &le; |r| &lt; |e2|.
 
-        (OpUDiv, with OpSelect to avoid division by zero)
   <tr algorithm="floating point division">
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [FLOATING]
     <td>|e1| `/` |e2| : |T|
-    <td>Floating point division. [=Component-wise=] when |T| is a vector. (OpFDiv)
+    <td>Floating point division. [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="signed integer remainder">
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [SIGNEDINTEGRAL]
@@ -4680,13 +4381,11 @@ See [[#sync-builtin-functions]].
             |e1|&nbsp;=&nbsp;|q|&nbsp;&times;&nbsp;|e2|&nbsp;+&nbsp;|r|,
             where |q| is an integer and 0 &le; |r| &lt; |e2|.
 
-       (OpUMod, with OpSelect to avoid division by zero)
   <tr algorithm="floating point remainder">
     <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [FLOATING]
     <td>|e1| `%` |e2| : |T|
     <td>Floating point remainder, where sign of non-zero result matches sign of |e1|. [=Component-wise=] when |T| is a vector.<br>
         Result equal to: |e1| - |e2| * trunc(|e1| / |e2|)<br>
-        (OpFRem)
 
 </table>
 
@@ -4757,7 +4456,6 @@ See [[#sync-builtin-functions]].
     <td>|m| `*` |v|:  vec|N|&lt;f32&gt<br>
     <td>Linear algebra matrix-column-vector product:
         Component |i| of the result is `dot`(|m|[|i|],|v|)
-       <br>OpMatrixTimesVector
   <tr algorithm="matrix-row-vector multiply">
     <td>
         |m|: mat|M|x|N|&lt;f32&gt<br>
@@ -4765,12 +4463,11 @@ See [[#sync-builtin-functions]].
     <td>|v| `*` |m|:  vec|M|&lt;f32&gt<br>
     <td>Linear algebra row-vector-matrix product:<br>
         [=transpose=](transpose(|m|) `*` transpose(|v|))
-       <br>OpVectorTimesMatrix
   <tr algorithm="matrix-matrix multiply">
     <td>|e1|: mat|K|x|N|&lt;f32&gt<br>
         |e2|: mat|M|x|K|&lt;f32&gt
     <td>|e1| `*` |e2|:  mat|M|x|N|&lt;f32&gt<br>
-    <td>Linear algebra matrix product.<br>OpMatrixTimesMatrix
+    <td>Linear algebra matrix product.
 
 </table>
 
@@ -4785,11 +4482,11 @@ See [[#sync-builtin-functions]].
   <tr algorithm="bool equality">
     <td>|e1|: |T|<br>|e2|: |T|<br>|T| is bool or vec|N|&lt;bool&gt;
     <td class="nowrap">|e1| `==` |e2|`:` |T|
-    <td>Equality. [=Component-wise=] when |T| is a vector. (OpLogicalEqual)
+    <td>Equality. [=Component-wise=] when |T| is a vector.
   <tr algorithm="bool inequality">
     <td>|e1|: |T|<br>|e2|: |T|<br>|T| is bool or vec|N|&lt;bool&gt;
     <td class="nowrap">|e1| `!=` |e2|`:` |T|
-    <td>Inequality. [=Component-wise=] when |T| is a vector. (OpLogicalNotEqual)
+    <td>Inequality. [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="integer equality">
     <td>|e1|: |TI|<br>|e2|: |TI|<br>
@@ -4797,101 +4494,101 @@ See [[#sync-builtin-functions]].
     |TB| is bool if |TI| is scalar, or<br>
     vec|N|&lt;bool&gt; if |TI| is a vector
     <td class="nowrap">|e1| `==` |e2|`:` |TB|
-    <td>Equality. [=Component-wise=] when |TI| is a vector. (OpIEqual)
+    <td>Equality. [=Component-wise=] when |TI| is a vector.
   <tr algorithm="integer inequality">
     <td>|e1|: |TI|<br>|e2|: |TI|<br>
     |TI| is [INTEGRAL]<br>
     |TB| is bool if |TI| is scalar, or<br>
     vec|N|&lt;bool&gt; if |TI| is a vector
     <td class="nowrap">|e1| `!=` |e2|`:` |TB|
-    <td>Inequality. [=Component-wise=] when |TI| is a vector. (OpINotEqual)
+    <td>Inequality. [=Component-wise=] when |TI| is a vector.
 
   <tr algorithm="signed integer less than">
     <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is [SIGNEDINTEGRAL]<br>
     |TB| is bool if |TI| is scalar, or<br>
     vec|N|&lt;bool&gt; if |TI| is a vector
     <td class="nowrap">|e1| `<` |e2|`:` |TB|
-    <td>Less than. [=Component-wise=] when |TI| is a vector. (OpSLessThan)
+    <td>Less than. [=Component-wise=] when |TI| is a vector.
   <tr algorithm="signed integer less than equal">
     <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is [SIGNEDINTEGRAL]<br>
     |TB| is bool if |TI| is scalar, or<br>
     vec|N|&lt;bool&gt; if |TI| is a vector
     <td class="nowrap">|e1| `<=` |e2|`:` |TB|
-    <td>Less than or equal. [=Component-wise=] when |TI| is a vector. (OpSLessThanEqual)
+    <td>Less than or equal. [=Component-wise=] when |TI| is a vector.
   <tr algorithm="signed integer greater than">
     <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is [SIGNEDINTEGRAL]<br>
     |TB| is bool if |TI| is scalar, or<br>
     vec|N|&lt;bool&gt; if |TI| is a vector
     <td class="nowrap">|e1| `>` |e2|`:` |TB|
-    <td>Greater than. [=Component-wise=] when |TI| is a vector. (OpSGreaterThan)
+    <td>Greater than. [=Component-wise=] when |TI| is a vector.
   <tr algorithm="signed integer greater than equal">
     <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is [SIGNEDINTEGRAL]<br>
     |TB| is bool if |TI| is scalar, or<br>
     vec|N|&lt;bool&gt; if |TI| is a vector
     <td class="nowrap">|e1| `>=` |e2|`:` |TB|
-    <td>Greater than or equal. [=Component-wise=] when |TI| is a vector. (OpSGreaterThanEqual)
+    <td>Greater than or equal. [=Component-wise=] when |TI| is a vector.
 
   <tr algorithm="unsigned integer less than">
     <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is [UNSIGNEDINTEGRAL]<br>
     |TB| is bool if |TI| is scalar, or<br>
     vec|N|&lt;bool&gt; if |TI| is a vector
     <td class="nowrap">|e1| `<` |e2|`:` |TB|
-    <td>Less than. [=Component-wise=] when |TI| is a vector. (OpULessThan)
+    <td>Less than. [=Component-wise=] when |TI| is a vector.
   <tr algorithm="unsigned integer less than equal">
     <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is [UNSIGNEDINTEGRAL]<br>
     |TB| is bool if |TI| is scalar, or<br>
     vec|N|&lt;bool&gt; if |TI| is a vector
     <td class="nowrap">|e1| `<=` |e2|`:` |TB|
-    <td>Less than or equal. [=Component-wise=] when |TI| is a vector. (OpULessThanEqual)
+    <td>Less than or equal. [=Component-wise=] when |TI| is a vector.
   <tr algorithm="unsigned integer greater than">
     <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is [UNSIGNEDINTEGRAL]<br>
     |TB| is bool if |TI| is scalar, or<br>
     vec|N|&lt;bool&gt; if |TI| is a vector
     <td class="nowrap">|e1| `>` |e2|`:` |TB|
-    <td>Greater than. [=Component-wise=] when |TI| is a vector. (OpUGreaterThan)
+    <td>Greater than. [=Component-wise=] when |TI| is a vector.
   <tr algorithm="unsigned integer greater than equal">
     <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is [UNSIGNEDINTEGRAL]<br>
     |TB| is bool if |TI| is scalar, or<br>
     vec|N|&lt;bool&gt; if |TI| is a vector
     <td class="nowrap">|e1| `>=` |e2|`:` |TB|
-    <td>Greater than or equal. [=Component-wise=] when |TI| is vector. (OpUGreaterThanEqual)
+    <td>Greater than or equal. [=Component-wise=] when |TI| is vector.
 
   <tr algorithm="floating point equality">
     <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is [FLOATING]<br>
     |TB| is bool if |TF| is scalar, or<br>
     vec|N|&lt;bool&gt; if |TF| is a vector.
     <td class="nowrap">|e1| == |e2|: |TB|
-    <td>Equality. [=Component-wise=] when |TF| is a vector. (OpFOrdEqual)
+    <td>Equality. [=Component-wise=] when |TF| is a vector.
   <tr algorithm="floating point inequality">
     <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is [FLOATING]<br>
     |TB| is bool if |TF| is scalar, or<br>
     vec|N|&lt;bool&gt; if |TF| is a vector.
     <td class="nowrap">|e1| != |e2|: |TB|
-    <td>Inequality. [=Component-wise=] when |TF| is a vector. (OpFOrdEqual)
+    <td>Inequality. [=Component-wise=] when |TF| is a vector.
   <tr algorithm="floating point less than">
     <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is [FLOATING]<br>
     |TB| is bool if |TF| is scalar, or<br>
     vec|N|&lt;bool&gt; if |TF| is a vector.
     <td class="nowrap">|e1| < |e2|: |TB|
-    <td>Less than. [=Component-wise=] when |TF| is a vector. (OpFOrdLessThan)
+    <td>Less than. [=Component-wise=] when |TF| is a vector.
   <tr algorithm="floating point less than equal">
     <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is [FLOATING]<br>
     |TB| is bool if |TF| is scalar, or<br>
     vec|N|&lt;bool&gt; if |TF| is a vector.
     <td class="nowrap">|e1| <= |e2|: |TB|
-    <td>Less than or equal. [=Component-wise=] when |TF| is a vector. (OpFOrdLessThanEqual)
+    <td>Less than or equal. [=Component-wise=] when |TF| is a vector.
   <tr algorithm="floating point greater than">
     <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is [FLOATING]<br>
     |TB| is bool if |TF| is scalar, or<br>
     vec|N|&lt;bool&gt; if |TF| is a vector.
     <td class="nowrap">|e1| > |e2|: |TB|
-    <td>Greater than. [=Component-wise=] when |TF| is a vector. (OpFOrdGreaterThan)
+    <td>Greater than. [=Component-wise=] when |TF| is a vector.
   <tr algorithm="floating point greater than equal">
     <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is [FLOATING]<br>
     |TB| is bool if |TF| is scalar, or<br>
     vec|N|&lt;bool&gt; if |TF| is a vector.
     <td class="nowrap">|e1| >= |e2|: |TB|
-    <td>Greater than or equal. [=Component-wise=] when |TF| is a vector. (OpFOrdGreaterThanEqual)
+    <td>Greater than or equal. [=Component-wise=] when |TF| is a vector.
 
 </table>
 
@@ -4908,7 +4605,7 @@ See [[#sync-builtin-functions]].
     <td class="nowrap">`~`|e| : |T|
     <td>Bitwise complement on |e|.
     Each bit in the result is the opposite of the corresponding bit in |e|.
-    [=Component-wise=] when |T| is a vector. (OpNot)
+    [=Component-wise=] when |T| is a vector.
 </table>
 
 <table class='data'>
@@ -4955,7 +4652,6 @@ See [[#sync-builtin-functions]].
         and discarding the most significant bits.
         The number of bits to shift is the value of |e2| modulo the bit width of |e1|.<br>
         [=Component-wise=] when |T| is a vector.
-        (OpShiftLeftLogical)
 
   <tr algorithm="logical shift right">
     <td>|e1|: |T|<br>
@@ -4967,7 +4663,6 @@ See [[#sync-builtin-functions]].
         and discarding the least significant bits.
         The number of bits to shift is the value of |e2| modulo the bit width of |e1|.
         [=Component-wise=] when |T| is a vector.
-        (OpShiftRightLogical)
 
   <tr algorithm="arithmetic shift right">
     <td>|e1|: |T|<br>
@@ -4981,7 +4676,6 @@ See [[#sync-builtin-functions]].
         and discarding the least significant bits.
         The number of bits to shift is the value of |e2| modulo the bit width of |e1|.
         [=Component-wise=] when |T| is a vector.
-        (OpShiftRightArithmetic)
 </table>
 
 ## Function Call Expression ## {#function-call-expr}
@@ -5331,8 +5025,6 @@ In this case the value of the [=right-hand side=] is written to the memory refer
         Note: if the reference is an [=invalid memory reference=], the write
         may not execute, or may write to a different memory location than
         expected.
-
-        (OpStore)
 </table>
 
 In the simplest case, the left hand side is the name of a variable.
@@ -6838,27 +6530,14 @@ Note: [=Compute=] entry points never have a return type.
     fn vert_main() -> @builtin(position) vec4<f32> {
       return vec4<f32>(0.0, 0.0, 0.0, 1.0);
     }
-       // OpEntryPoint Vertex %vert_main "vert_main" %return_value
-       // OpDecorate %return_value BuiltIn Position
-       // %float = OpTypeFloat 32
-       // %v4float = OpTypeVector %float 4
-       // %ptr = OpTypePointer Output %v4float
-       // %return_value = OpVariable %ptr Output
 
     @stage(fragment)
     fn frag_main(@builtin(position) coord_in: vec4<f32>) -> @location(0) vec4<f32> {
       return vec4<f32>(coord_in.x, coord_in.y, 0.0, 1.0);
     }
-       // OpEntryPoint Fragment %frag_main "frag_main" %return_value %coord_in
-       // OpDecorate %return_value Location 0
-       // %float = OpTypeFloat 32
-       // %v4float = OpTypeVector %float 4
-       // %ptr = OpTypePointer Output %v4float
-       // %return_value = OpVariable %ptr Output
 
     @stage(compute)
     fn comp_main() { }
-       // OpEntryPoint GLCompute %comp_main "comp_main"
   </xmp>
 </div>
 
@@ -6884,22 +6563,14 @@ ISSUE: Can we query upper bounds on workgroup size dimensions?  Is it independen
   <xmp>
     @stage(compute) @workgroup_size(8,4,1)
     fn sorter() { }
-       // OpEntryPoint GLCompute %sorter "sorter"
-       // OpExecutionMode %sorter LocalSize 8 4 1
 
     @stage(compute) @workgroup_size(8u)
     fn reverser() { }
-       // OpEntryPoint GLCompute %reverser "reverser"
-       // OpExecutionMode %reverser LocalSize 8 1 1
 
     // Using an pipeline-overridable constant.
     @id(42) override block_width = 12u;
     @stage(compute) @workgroup_size(block_width)
     fn shuffler() { }
-       // The SPIR-V translation uses a WorkgroupSize-decorated constant,
-       // where the first component is an OpSpecConstant decorated with
-       // SpecID 42, and with default value 12, and second and third components
-       // use defaulted values of 1.
 
     // Error: workgroup_size must be specified on compute shader
     @stage(compute)
@@ -8129,8 +7800,8 @@ barriers whose execution and memory [=memory model scope|scopes=] are
 
 Implicit and explicit derivatives have an implicit [=quad=] execution scope.
 
-Note: When generating SPIR-V that does not enable the `Vulkan` memory model,
-`Device` scope should be used instead of `QueueFamily`.
+Note: If the Vulkan memory model is not enabled in generated shaders, `Device`
+scope should be used instead of `QueueFamily`.
 
 ## Memory Semantics ## {#memory-semantics}
 
@@ -8943,52 +8614,32 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in value.
   <xmp>
     struct VertexOutput {
       @builtin(position) my_pos: vec4<f32>;
-      //   OpDecorate %my_pos BuiltIn Position
-      //   %float = OpTypeFloat 32
-      //   %v4float = OpTypeVector %float 4
-      //   %ptr = OpTypePointer Output %v4float
-      //   %my_pos = OpVariable %ptr Output
     }
 
     @stage(vertex)
     fn vs_main(
       @builtin(vertex_index) my_index: u32,
-      //   OpDecorate %my_index BuiltIn VertexIndex
-      //   %uint = OpTypeInt 32 0
-      //   %ptr = OpTypePointer Input %uint
-      //   %my_index = OpVariable %ptr Input
       @builtin(instance_index) my_inst_index: u32,
-      //    OpDecorate %my_inst_index BuiltIn InstanceIndex
     ) -> VertexOutput {}
 
     struct FragmentOutput {
       @builtin(frag_depth) depth: f32;
-      //     OpDecorate %depth BuiltIn FragDepth
       @builtin(sample_mask) mask_out: u32;
-      //      OpDecorate %mask_out BuiltIn SampleMask ; an output variable
     }
 
     @stage(fragment)
     fn fs_main(
       @builtin(front_facing) is_front: bool,
-      //     OpDecorate %is_front BuiltIn FrontFacing
       @builtin(position) coord: vec4<f32>,
-      //     OpDecorate %coord BuiltIn FragCoord
       @builtin(sample_index) my_sample_index: u32,
-      //      OpDecorate %my_sample_index BuiltIn SampleId
       @builtin(sample_mask) mask_in: u32,
-      //      OpDecorate %mask_in BuiltIn SampleMask ; an input variable
-      //      OpDecorate %mask_in Flat
     ) -> FragmentOutput {}
 
     @stage(compute)
     fn cs_main(
       @builtin(local_invocation_id) local_id: vec3<u32>,
-      //     OpDecorate %local_id BuiltIn LocalInvocationId
       @builtin(local_invocation_index) local_index: u32,
-      //     OpDecorate %local_index BuiltIn LocalInvocationIndex
       @builtin(global_invocation_id) global_id: vec3<u32>,
-      //      OpDecorate %global_id BuiltIn GlobalInvocationId
    ) {}
   </xmp>
 </div>
@@ -9027,8 +8678,7 @@ See [[#function-calls]].
   <tr algorithm="vector all">
     <td>
     <td>`all`(|e|: vec|N|&lt;bool&gt;) -> bool
-    <td>Returns true if each component of |e| is true.<br>
-        (OpAll)
+    <td>Returns true if each component of |e| is true.
 
   <tr algorithm="scalar all">
     <td>|e|: bool
@@ -9038,8 +8688,7 @@ See [[#function-calls]].
   <tr algorithm="vector any">
     <td>
     <td>`any`(|e|: vec|N|&lt;bool&gt;) -> bool
-    <td>Returns true if any component of |e| is true.<br>
-        (OpAny)
+    <td>Returns true if any component of |e| is true.
 
   <tr algorithm="scalar any">
     <td>|e|: bool
@@ -9049,15 +8698,13 @@ See [[#function-calls]].
   <tr algorithm="scalar select">
     <td>|T| is [=scalar=] or [=vector=]
     <td>`select`(|f|: |T|, |t|: |T|, |cond|: bool) -> |T|
-    <td>Returns |t| when |cond| is true, and |f| otherwise.<br>
-        (OpSelect)
+    <td>Returns |t| when |cond| is true, and |f| otherwise.
 
   <tr algorithm="vector select">
     <td>|T| is [=scalar=]
     <td>`select`(|f|: vec|N|&lt;|T|&gt;, |t|: vec|N|&lt;|T|&gt;, |cond|: vec|N|&lt;bool&gt;) -> vec|N|&lt;|T|&gt;
     <td>[=Component-wise=] selection. Result component |i| is evaluated
-        as `select(`|f|`[`|i|`], `|t|`[`|i|`], `|cond|`[`|i|`])`.<br>
-        (OpSelect)
+        as `select(`|f|`[`|i|`], `|t|`[`|i|`], `|cond|`[`|i|`])`.
 </table>
 
 ## Array Built-in Functions ## {#array-builtin-functions}
@@ -9068,8 +8715,7 @@ See [[#function-calls]].
   <tr algorithm="runtime-sized array length">
     <td>
     <td>`arrayLength`(|e|: ptr&lt;storage,array&lt;|T|&gt;&gt; ) -> u32
-        <td>Returns the number of elements in the [=runtime-sized=] array.<br>
-        (OpArrayLength, but the implementation has to trace back to get the pointer to the enclosing struct.)
+        <td>Returns the number of elements in the [=runtime-sized=] array.
 </table>
 
 ## Float Built-in Functions ## {#float-builtin-functions}
@@ -9083,122 +8729,105 @@ See [[#function-calls]].
     <td class="nowrap">`abs(`|e|`:` |T| `) -> ` |T|
     <td>Returns the absolute value of |e| (e.g. |e| with a positive sign bit).
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450Fabs)
 
   <tr algorithm="acos">
     <td>|T| is [FLOATING]
     <td class="nowrap">`acos(`|e|`:` |T| `) -> ` |T|
     <td>Returns the arc cosine of |e|.
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450Acos)
 
   <tr algorithm="asin">
     <td>|T| is [FLOATING]
     <td class="nowrap">`asin(`|e|`:` |T| `) -> ` |T|
     <td>Returns the arc sine of |e|.
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450Asin)
 
   <tr algorithm="atan">
     <td>|T| is [FLOATING]
     <td class="nowrap">`atan(`|e|`:` |T| `) -> ` |T|
     <td>Returns the arc tangent of |e|.
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450Atan)
 
   <tr algorithm="atan2">
     <td>|T| is [FLOATING]
     <td class="nowrap">`atan2(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>Returns the arc tangent of |e1| over |e2|.
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450Atan2)
 
   <tr algorithm="ceil">
     <td>|T| is [FLOATING]
     <td class="nowrap">`ceil(`|e|`:` |T| `) -> ` |T|
     <td>Returns the [=ceiling expression|ceiling=] of |e|.
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450Ceil)
 
   <tr algorithm="clamp">
     <td>|T| is [FLOATING]
     <td class="nowrap">`clamp(`|e|`:` |T| `,` |low|`:` |T| `,` |high|`:` |T|`) -> ` |T|
     <td>Returns `min(max(`|e|`,`|low|`),`|high|`)`.
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450NClamp)
 
   <tr algorithm="cos">
     <td>|T| is [FLOATING]
     <td class="nowrap">`cos(`|e|`:` |T| `) -> ` |T|
     <td>Returns the cosine of |e|.
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450Cos)
 
   <tr algorithm="cosh">
     <td>|T| is [FLOATING]
     <td class="nowrap">`cosh(`|e|`:` |T| `) -> ` |T|
     <td>Returns the hyperbolic cosine of |e|.
     [=Component-wise=] when |T| is a vector
-    (GLSLstd450Cosh)
 
   <tr algorithm="vector case, cross">
     <td>|T| is f32
     <td class="nowrap">`cross(`|e1|`:` vec3<|T|> `, `|e2|`:` vec3<|T|>`) -> ` vec3<|T|>
-    <td>Returns the cross product of |e1| and |e2|. (GLSLstd450Cross)
+    <td>Returns the cross product of |e1| and |e2|.
 
   <tr algorithm="degrees">
     <td>|T| is [FLOATING]
     <td class="nowrap">`degrees(`|e1|`:` |T| `) -> ` |T|
     <td>Converts radians to degrees, approximating |e1|&nbsp;&times;&nbsp;180&nbsp;&div;&nbsp;&pi;.
     [=Component-wise=] when |T| is a vector<br>
-    (GLSLstd450Degrees)
 
   <tr algorithm="distance">
     <td>|T| is [FLOATING]
     <td class="nowrap">`distance(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` f32
     <td>Returns the distance between |e1| and |e2| (e.g. `length(`|e1|` - `|e2|`)`).
-    (GLSLstd450Distance)
 
   <tr algorithm="exp">
     <td>|T| is [FLOATING]
     <td class="nowrap">`exp(`|e1|`:` |T| `) -> ` |T|
     <td>Returns the natural exponentiation of |e1| (e.g. `e`<sup>|e1|</sup>).
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450Exp)
 
   <tr algorithm="exp2">
     <td>|T| is [FLOATING]
     <td class="nowrap">`exp2(`|e|`:` |T| `) -> ` |T|
     <td>Returns 2 raised to the power |e| (e.g. `2`<sup>|e|</sup>).
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450Exp2)
 
   <tr algorithm="faceForward">
     <td>|T| is vec|N|&lt;f32&gt;
     <td class="nowrap">`faceForward(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T| `) -> ` |T|
     <td>Returns |e1| if `dot(`|e2|`,`|e3|`)` is negative, and `-`|e1| otherwise.
-    (GLSLstd450FaceForward)
 
   <tr algorithm="floor">
     <td>|T| is [FLOATING]
     <td class="nowrap">`floor(`|e|`:` |T| `) -> ` |T|
     <td>Returns the [=floor expression|floor=] of |e|.
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450Floor)
 
   <tr algorithm="fma">
     <td>|T| is [FLOATING]
     <td class="nowrap">`fma(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T| `) -> ` |T|
     <td>Returns |e1| `*` |e2| `+` |e3|.
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450Fma)
 
   <tr algorithm="fract">
     <td>|T| is [FLOATING]
     <td class="nowrap">`fract(`|e|`:` |T| `) -> ` |T|
     <td>Returns the fractional part of |e|, computed as |e| `- floor(`|e|`)`.<br>
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450Fract)
 
   <tr algorithm="scalar case, frexp">
     <td>|T| is f32
@@ -9224,8 +8853,6 @@ struct __frexp_result {
     </xmp>
     </div>
 
-    (GLSLstd450FrexpStruct)
-
   <tr algorithm="vector case, frexp">
     <td>|T| is vec|N|&lt;f32&gt;
     <td class="nowrap">`frexp(`|e|`: `|T|`) -> __frexp_result_vec`|N|<br>
@@ -9241,14 +8868,11 @@ struct __frexp_result_vecN {
 
     Note: A value cannot be explicitly declared with the type `__frexp_result_vec`|N|, but a value may infer the type.
 
-    (GLSLstd450FrexpStruct)
-
   <tr algorithm="inverseSqrt">
     <td>|T| is [FLOATING]
     <td class="nowrap">`inverseSqrt(`|e|`:` |T| `) -> ` |T|
     <td>Returns the reciprocal of `sqrt(`|e|`)`.
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450InverseSqrt)
 
   <tr algorithm="ldexp">
     <td>|T| is [FLOATING]<br>
@@ -9258,27 +8882,23 @@ struct __frexp_result_vecN {
     <td class="nowrap">`ldexp(`|e1|`:` |T| `, `|e2|`:` |I| `) -> ` |T|
     <td>Returns |e1| `* 2`<sup>|e2|</sup>.
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450Ldexp)
 
   <tr algorithm="length">
     <td>|T| is [FLOATING]
     <td class="nowrap">`length(`|e|`:` |T| `) -> ` f32
     <td>Returns the length of |e| (e.g. `abs(`|e|`)` if |T| is a scalar, or `sqrt(`|e|`[0]`<sup>`2`</sup> `+` |e|`[1]`<sup>`2`</sup> `+ ...)` if |T| is a vector).
-    (GLSLstd450Length)
 
   <tr algorithm="log">
     <td>|T| is [FLOATING]
     <td class="nowrap">`log(`|e|`:` |T| `) -> ` |T|
     <td>Returns the natural logarithm of |e|.
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450Log)
 
   <tr algorithm="log2">
     <td>|T| is [FLOATING]
     <td class="nowrap">`log2(`|e|`:` |T| `) -> ` |T|
     <td>Returns the base-2 logarithm of |e|.
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450Log2)
 
   <tr algorithm="max">
     <td>|T| is [FLOATING]
@@ -9287,7 +8907,6 @@ struct __frexp_result_vecN {
     If one operand is a NaN, the other is returned.
     If both operands are NaNs, a NaN is returned.
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450NMax)
 
   <tr algorithm="min">
     <td>|T| is [FLOATING]
@@ -9296,7 +8915,6 @@ struct __frexp_result_vecN {
     If one operand is a NaN, the other is returned.
     If both operands are NaNs, a NaN is returned.
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450NMin)
 
   <tr algorithm="mix all same type operands">
     <td>|T| is [FLOATING]
@@ -9304,7 +8922,6 @@ struct __frexp_result_vecN {
     <td>Returns the linear blend of |e1| and |e2| (e.g. |e1|`*(1-`|e3|`)+`|e2|`*`|e3|).
     [=Component-wise=] when |T| is a vector.
     <br>
-    (GLSLstd450FMix)
 
   <tr algorithm="vector mix with scalar blending factor">
     <td>|T| is vec|N|&lt;f32&gt;
@@ -9336,8 +8953,6 @@ struct __modf_result {
     </xmp>
     </div>
 
-    (GLSLstd450ModfStruct)
-
   <tr algorithm="vector case, modf">
     <td>|T| is vec|N|&lt;f32&gt;
     <td class="nowrap">`modf(`|e|`: `|T|`) -> __modf_result_vec`|N|<br>
@@ -9352,20 +8967,16 @@ struct __modf_result_vecN {
 
     Note: A value cannot be explicitly declared with the type `__modf_result_vec`|N|, but a value may infer the type.
 
-    (GLSLstd450ModfStruct)
-
   <tr algorithm="vector case, normalize">
     <td>|T| is f32
     <td class="nowrap">`normalize(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
     <td>Returns a unit vector in the same direction as |e|.
-    (GLSLstd450Normalize)
 
   <tr algorithm="pow">
     <td>|T| is [FLOATING]
     <td class="nowrap">`pow(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>Returns |e1| raised to the power |e2|.
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450Pow)
 
   <tr algorithm="quantize to f16">
     <td>|T| is [FLOATING]
@@ -9377,21 +8988,17 @@ struct __modf_result_vecN {
 
         Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(`|e|`))`.
 
-        (OpQuantizeToF16)
-
   <tr algorithm="radians">
     <td>|T| is [FLOATING]
     <td class="nowrap">`radians(`|e1|`:` |T| `) -> ` |T|
     <td>Converts degrees to radians, approximating |e1|&nbsp;&times;&nbsp;&pi;&nbsp;&div;&nbsp;180.
     [=Component-wise=] when |T| is a vector<br>
-    (GLSLstd450Radians)
 
   <tr algorithm="reflect">
     <td>|T| is vec|N|&lt;f32&gt;
     <td class="nowrap">`reflect(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>For the incident vector |e1| and surface orientation |e2|, returns the reflection direction
     |e1|`-2*dot(`|e2|`,`|e1|`)*`|e2|.
-    (GLSLstd450Reflect)
 
   <tr algorithm="refract">
     <td>|T| is vec|N|&lt;f32&gt;<br>I is f32
@@ -9400,7 +9007,6 @@ struct __modf_result_vecN {
     let `k = 1.0 - `|e3|` * `|e3|` * (1.0 - dot(`|e2|`, `|e1|`) * dot(`|e2|`, `|e1|`))`. If `k < 0.0`, returns the
     refraction vector 0.0, otherwise return the refraction vector
     |e3|` * `|e1|` - (`|e3|` * dot(`|e2|`, `|e1|`) + sqrt(k)) * `|e2|.
-    (GLSLstd450Refract)
 
   <tr algorithm="round">
     <td>|T| is [FLOATING]
@@ -9409,28 +9015,24 @@ struct __modf_result_vecN {
         When |e| lies halfway between integers |k| and |k|+1,
         the result is |k| when |k| is even, and |k|+1 when |k| is odd.<br>
         [=Component-wise=] when |T| is a vector.
-        (GLSLstd450RoundEven)
 
   <tr algorithm="float sign">
     <td>|T| is [FLOATING]
     <td class="nowrap">`sign(`|e|`:` |T| `) -> ` |T|
     <td>Returns the sign of |e|.
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450FSign)
 
   <tr algorithm="sin">
     <td>|T| is [FLOATING]
     <td class="nowrap">`sin(`|e|`:` |T| `) -> ` |T|
     <td>Returns the sine of |e|.
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450Sin)
 
   <tr algorithm="sinh">
     <td>|T| is [FLOATING]
     <td class="nowrap">`sinh(`|e|`:` |T| `) -> ` |T|
     <td>Returns the hyperbolic sine of |e|.
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450Sinh)
 
   <tr algorithm="smoothStep">
     <td>|T| is [FLOATING]
@@ -9442,42 +9044,35 @@ struct __modf_result_vecN {
     |t| * |t| * (3.0 - 2.0 * |t|),
     where |t| = clamp((|x| - |low|) / (|high| - |low|), 0.0, 1.0).
 
-    (GLSLstd450SmoothStep)
-
   <tr algorithm="sqrt">
     <td>|T| is [FLOATING]
     <td class="nowrap">`sqrt(`|e|`:` |T| `) -> ` |T|
     <td>Returns the square root of |e|.
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450Sqrt)
 
   <tr algorithm="step">
     <td>|T| is [FLOATING]
     <td class="nowrap">`step(`|edge|`:` |T| `, `|x|`:` |T| `) -> ` |T|
     <td>Returns 1.0 if |edge| &le; |x|, and 0.0 otherwise.
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450Step)
 
   <tr algorithm="tan">
     <td>|T| is [FLOATING]
     <td class="nowrap">`tan(`|e|`:` |T| `) -> ` |T|
     <td>Returns the tangent of |e|.
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450Tan)
 
   <tr algorithm="tanh">
     <td>|T| is [FLOATING]
     <td class="nowrap">`tanh(`|e|`:` |T| `) -> ` |T|
     <td>Returns the hyperbolic tangent of |e|.
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450Tanh)
 
   <tr algorithm="trunc">
     <td>|T| is [FLOATING]
     <td class="nowrap">`trunc(`|e|`:` |T| `) -> ` |T|
     <td>Returns the nearest whole number whose absolute value is less than or equal to |e|.
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450Trunc)
 </table>
 
 ## Integer Built-in Functions ## {#integer-builtin-functions}
@@ -9492,7 +9087,6 @@ struct __modf_result_vecN {
     <td>The absolute value of |e|.
         [=Component-wise=] when |T| is a vector.
         If |e| evaluates to the largest negative value, then the result is |e|.
-        (GLSLstd450SAbs)
 
   <tr algorithm="scalar case, unsigned abs">
     <td>|T| is [UNSIGNEDINTEGRAL]
@@ -9505,14 +9099,12 @@ struct __modf_result_vecN {
     <td class="nowrap">`clamp(`|e|`:` |T| `,` |low|`:` |T|`,` |high|`:` |T|`) ->` |T|
     <td>Returns `min(max(`|e|`,`|low|`),`|high|`)`.
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450UClamp)
 
   <tr algorithm="signed clamp">
     <td>|T| is [SIGNEDINTEGRAL]
     <td class="nowrap">`clamp(`|e|`:` |T| `,` |low|`:` |T|`,` |high|`:` |T|`) ->` |T|
     <td>Returns `min(max(`|e|`,`|low|`),`|high|`)`.
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450SClamp)
 
   <tr algorithm="count leading zeroes">
     <td>|T| is [INTEGRAL]
@@ -9528,7 +9120,6 @@ struct __modf_result_vecN {
     <td>The number of 1 bits in the representation of |e|.<br>
         Also known as "population count".<br>
         [=Component-wise=] when |T| is a vector.
-        (SPIR-V OpBitCount)
 
   <tr algorithm="count trailing zeroes">
     <td>|T| is [INTEGRAL]
@@ -9591,7 +9182,6 @@ struct __modf_result_vecN {
        Other bits of the result are the same as bit |c|-1 of the result.
     </ul>
     [=Component-wise=] when |T| is a vector.
-    <br>(OpBitFieldSExtract)
 
   <tr algorithm="unsigned extract bits">
     <td>|T| is [UNSIGNEDINTEGRAL]
@@ -9609,7 +9199,6 @@ struct __modf_result_vecN {
        Other bits of the result are 0.
     </ul>
     [=Component-wise=] when |T| is a vector.
-    <br>(OpBitFieldUExtract)
 
   <tr algorithm="insert bits">
     <td>|T| is [INTEGRAL]
@@ -9627,35 +9216,30 @@ struct __modf_result_vecN {
        Other bits of the result are copied from |e|.
     </ul>
     [=Component-wise=] when |T| is a vector.
-    <br>(OpBitFieldInsert)
 
   <tr algorithm="unsigned max">
     <td>|T| is [UNSIGNEDINTEGRAL]
     <td class="nowrap">`max(`|e1|`:` |T| `, `|e2|`:` |T|`) ->` |T|
     <td>Returns |e2| if |e1| is less than |e2|, and |e1| otherwise.
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450UMax)
 
   <tr algorithm="signed max">
     <td>|T| is [SIGNEDINTEGRAL]
     <td class="nowrap">`max(`|e1|`:` |T| `, `|e2|`:` |T|`) ->` |T|
     <td>Returns |e2| if |e1| is less than |e2|, and |e1| otherwise.
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450SMax)
 
   <tr algorithm="unsigned min">
     <td>|T| is [UNSIGNEDINTEGRAL]
     <td class="nowrap">`min(`|e1|`:` |T| `, `|e2|`:` |T|`) ->` |T|
     <td>Returns |e1| if |e1| is less than |e2|, and |e2| otherwise.
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd450UMin)
 
   <tr algorithm="signed min">
     <td>|T| is [SIGNEDINTEGRAL]
     <td class="nowrap">`min(`|e1|`:` |T| `, `|e2|`:` |T|`) ->` |T|
     <td>Returns |e1| if |e1| is less than |e2|, and |e2| otherwise.
     [=Component-wise=] when |T| is a vector.
-    (GLSLstd45SUMin)
 
   <tr algorithm="bit reversal">
     <td>|T| is [INTEGRAL]
@@ -9663,7 +9247,6 @@ struct __modf_result_vecN {
     <td>Reverses the bits in |e|:  The bit at position |k| of the result equals the
         bit at position 31-|k| of |e|.<br>
         [=Component-wise=] when |T| is a vector.
-        (SPIR-V OpBitReverse)
 </table>
 
 ## Matrix Built-in Functions ## {#matrix-builtin-functions}
@@ -9675,12 +9258,10 @@ struct __modf_result_vecN {
     <td>|T| is f32
     <td class="nowrap">`determinant(`|e|`:` mat|N|x|N|<|T|> `) -> ` |T|
     <td>Returns the determinant of |e|.
-    (GLSLstd450Determinant)
   <tr algorithm="transpose">
     <td>|T| is f32
     <td class="nowrap">`transpose(`|e|`:` mat|M|x|N|<|T|> `) -> ` mat|N|x|M|<|T|>
     <td>Returns the transpose of |e|.
-    (OpTranspose)
 </table>
 
 ## Vector Built-in Functions ## {#vector-builtin-functions}
@@ -9692,15 +9273,12 @@ struct __modf_result_vecN {
   <tr algorithm="float dot"><td>|T| is f32
     <td>`dot(`|e1|`: vecN<`|T|`>, `|e2|`: vecN<`|T|`>) ->` |T|
     <td>Returns the dot product of |e1| and |e2|.
-    (OpDot)
   <tr algorithm="signed dot"><td>|T| is i32
     <td>`dot(`|e1|`: vecN<`|T|`>, `|e2|`: vecN<`|T|`>) ->` |T|
     <td>Returns the dot product of |e1| and |e2|.
-    (SPV_KHR_integer_dot_product OpSDotKHR)
   <tr algorithm="unsigned dot"><td>|T| is u32
     <td>`dot(`|e1|`: vecN<`|T|`>, `|e2|`: vecN<`|T|`>) ->` |T|
     <td>Returns the dot product of |e1| and |e2|.
-    (SPV_KHR_integer_dot_product OpUDotKHR)
 </table>
 
 ## Derivative Built-in Functions ## {#derivative-builtin-functions}
@@ -9720,42 +9298,33 @@ These functions:
     <td>`dpdx(`|e|`: `|T|`) ->` |T|
     <td>Partial derivative of |e| with respect to window x coordinates.
     The result is the same as either `dpdxFine(`|e|`)` or `dpdxCoarse(`|e|`)`.
-    (OpDPdx)
   <tr algorithm="dpdxCoarse">
     <td>`dpdxCoarse(`|e|`: `|T|`) -> `|T|
     <td>Returns the partial derivative of |e| with respect to window x coordinates using local differences.
     This may result in fewer unique positions that `dpdxFine(`|e|`)`.
-    (OpDPdxCoarse)
   <tr algorithm="dpdxFine">
     <td>`dpdxFine(`|e|`: `|T|`) -> `|T|
     <td>Returns the partial derivative of |e| with respect to window x coordinates.
-    (OpDPdxFine)
   <tr algorithm="dpdy">
     <td>`dpdy(`|e|`: `|T|`) -> `|T|
     <td>Partial derivative of |e| with respect to window y coordinates.
     The result is the same as either `dpdyFine(`|e|`)` or `dpdyCoarse(`|e|`)`.
-    (OpDPdy)
   <tr algorithm="dpdyCoarse">
     <td>`dpdyCoarse(`|e|`: `|T|`) -> `|T|
     <td>Returns the partial derivative of |e| with respect to window y coordinates using local differences.
     This may result in fewer unique positions that `dpdyFine(`|e|`)`.
-    (OpDPdyCoarse)
   <tr algorithm="dpdyFine">
     <td>`dpdyFine(`|e|`: `|T|`) -> `|T|
     <td>Returns the partial derivative of |e| with respect to window y coordinates.
-    (OpDPdyFine)
   <tr algorithm="fwidth">
     <td>`fwidth(`|e|`: `|T|`) -> `|T|
     <td>Returns `abs(dpdx(`|e|`)) + abs(dpdy(`|e|`))`.
-    (OpFwidth)
   <tr algorithm="fwidthCoarse">
     <td>`fwidthCoarse(`|e|`: `|T|`) -> `|T|
     <td>Returns `abs(dpdxCoarse(`|e|`)) + abs(dpdyCoarse(`|e|`))`.
-    (OpFwidthCoarse)
   <tr algorithm="fwidthFine">
     <td>`fwidthFine(`|e|`: `|T|`) -> `|T|
     <td>Returns `abs(dpdxFine(`|e|`)) + abs(dpdyFine(`|e|`))`.
-    (OpFwidthFine)
 </table>
 
 ## Texture Built-in Functions ## {#texture-builtin-functions}
@@ -10445,8 +10014,7 @@ Atomic built-in functions can be used to read/write/read-modify-write atomic
 objects. They are the only operations allowed on [[#atomic-types]].
 
 All atomic built-in functions use a `relaxed` [[#memory-semantics|memory
-ordering]] (**0**-value integral constant in SPIR-V for all `Memory Semantics`
-operands).  This means synchronization and ordering guarantees only apply among
+ordering]].  This means synchronization and ordering guarantees only apply among
 atomic operations acting on the same [=memory locations=].  No synchronization
 or ordering guarantees apply between atomic and non-atomic memory accesses, or
 between atomic accesses acting on different memory locations.
@@ -10455,9 +10023,6 @@ Atomic built-in functions `must` not be used in a [=vertex=] shader stage.
 
 The address space `SC` of the `atomic_ptr` parameter in all atomic built-in
 functions `must` be either [=address spaces/storage=] or [=address spaces/workgroup=].
-[=address spaces/workgroup=] atomics have a **Workgroup**
-[=memory scope=] in SPIR-V, while [=address spaces/storage=] atomics have a
-**QueueFamily** memory scope in SPIR-V.
 
 The access mode `A` in all atomic built-in functions must be [=access/read_write=].
 
@@ -10465,8 +10030,6 @@ The access mode `A` in all atomic built-in functions must be [=access/read_write
 
 ```rust
 atomicLoad(atomic_ptr: ptr<SC, atomic<T>, A>) -> T
-
-// Maps to the SPIR-V instruction OpAtomicLoad.
 ```
 
 Returns the atomically loaded the value pointed to by `atomic_ptr`.
@@ -10476,8 +10039,6 @@ It does not [=atomic modification|modify=] the object.
 
 ```rust
 atomicStore(atomic_ptr: ptr<SC, atomic<T>, A>, v: T)
-
-// Maps to the SPIR-V instruction OpAtomicStore.
 ```
 
 Atomically stores the value `v` in the atomic object pointed to by `atomic_ptr`.
@@ -10492,15 +10053,6 @@ atomicMin(atomic_ptr: ptr<SC, atomic<T>, A>, v: T) -> T
 atomicAnd(atomic_ptr: ptr<SC, atomic<T>, A>, v: T) -> T
 atomicOr(atomic_ptr: ptr<SC, atomic<T>, A>, v: T) -> T
 atomicXor(atomic_ptr: ptr<SC, atomic<T>, A>, v: T) -> T
-
-// Mappings to SPIR-V instructions:
-// atomicAdd -> OpAtomicIAdd
-// atomicSub -> OpAtomicISub
-// atomicMax -> OpAtomicSMax or OpAtomicUMax (depending on the signedness of T)
-// atomicMin -> OpAtomicSMin or OpAtomicUMin (depending on the signedness of T)
-// atomicAnd -> OpAtomicAnd
-// atomicOr  -> OpAtomicOr
-// atomicXor -> OpAtomicXor
 ```
 Each function performs the following steps atomically:
 
@@ -10513,8 +10065,6 @@ Each function returns the original value stored in the atomic object.
 
 ```rust
 atomicExchange(atomic_ptr: ptr<SC, atomic<T>, A>, v: T) -> T
-
-// Maps to the SPIR-V instruction OpAtomicExchange.
 ```
 
 Atomically stores the value `v` in the atomic object pointed to
@@ -10527,8 +10077,6 @@ struct __atomic_compare_exchange_result<T> {
   old_value : T; // old value stored in the atomic
   exchanged : bool; // true if the exchange was done
 }
-
-// Maps to the SPIR-V instruction OpAtomicCompareExchange.
 ```
 
 Note: A value cannot be explicitly declared with the type
@@ -10681,33 +10229,4 @@ stage.
 storageBarrier affects memory and atomic operations in the [=address spaces/storage=] address space.
 
 workgroupBarrier affects memory and atomic operations in the [=address spaces/workgroup=] address space.
-
-<div class='example spirv barrier mapping' heading="Mapping workgroupBarrier to SPIR-V">
-  <xmp>
-    storageBarrier();
-    // Maps to:
-    // Execution Scope is Workgroup = %uint_2
-    // Memory Scope is Workgroup = %uint_2
-    // Memory Semantics are AcquireRelease | UniformMemory (0x8 | 0x40) = %uint_72
-    // OpControlBarrier %uint_2 %uint_2 %uint_72
-
-    workgroupBarrier();
-    // Maps to:
-    // Execution and Memory Scope are Workgroup = %uint_2
-    // Memory semantics are AcquireRelease | WorkgroupMemory (0x8 | 0x100) = %uint_264
-    // OpControlBarrier %uint_2 %uint_2 %uint_264
-
-    workgroupBarrier();
-    storageBarrier();
-    // Or, equivalently:
-    storageBarrier();
-    workgroupBarrier();
-    // Could be mapped to a single OpControlBarrier:
-    // Execution scope is Workgroup = %uint_2
-    // Memory Scope is Workgroup = %uint_2
-    // Memory semantics are AcquireRelease | UniformMemory | WorkgroupMemory
-    //   (0x8 | 0x40 | 0x100) = %uint_328
-    // OpControlBarrier %uint_2 %uint_2 %uint_328
-  </xmp>
-</div>
 


### PR DESCRIPTION
* Remove most references to SPIR-V opcodes and types in the
  specification
* References remain transitively in the Memory Model section as it is
  necessary for the specification
* Removed goal section as they only described SPIR-V