### PR TITLE
Allow Unicode Identifiers

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -101,11 +101,11 @@ spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
         text: store type; url: store-type
         text: runtime-sized; url: runtime-sized
         text: SizeOf; url: sizeof
-        text: normalization of identifiers; url: identifier-normalization
 spec: UAX15; urlPrefix: https://www.unicode.org/reports/tr15/tr15-51.html
     type: dfn
         text: Unicode Standard Annex #15 for Unicode Version 14.0.0
         text: UAX15 Normalization Forms; url: Normalization_Forms_Table
+        text: UAX15 Equivalences; url: Canon_Compat_Equivalence
 </pre>
 
 <style>
@@ -4453,18 +4453,21 @@ dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
 source-map-v3 format.
 Source maps are optional, but serve as a standardized way to support dev-tool
 integration such as source-language debugging [[SourceMap]].
-WGSL names in source maps are normalized to their [=UAX15 Normalization Forms|Normalization Form C (NFC)=]
-for [[!UnicodeVersion14|Unicode Version 14.0.0]] according to [=normalization of identifiers=].
-This normalization does not impact line/column data of offsets to avoid
-misalignments with the original.
+WGSL names in source maps compare by their code points and
+do not follow [=UAX15 Equivalences=] for [[!UnicodeVersion14|Unicode Version 14.0.0]].
+
+Note: User agents should consider issuing developer-visible warnings in most or all
+situations where display of two names with different code point sequences
+look the same to the reader, such as ones same under canonical equivalence with
+[=UAX15 Normalization Forms|Normalization Form C (NFC)=] or characters that look similarly.
 
 {{GPUShaderModuleDescriptor/hints}}, if defined, maps an entry point name from
 the shader to a {{GPUShaderModuleCompilationHint}}. No validation is performed with
 any of these {{GPUShaderModuleCompilationHint}}. Implementations should use any
 information present in the {{GPUShaderModuleCompilationHint}} to perform as much
 compilation as is possible within {{GPUDevice/createShaderModule()}}.
-Entry point names are normalized to their [=UAX15 Normalization Forms|Normalization Form C (NFC)=]
-for [[!UnicodeVersion14|Unicode Version 14.0.0]] according to [=normalization of identifiers=].
+Entry point names compare by their code points and
+do not follow [=UAX15 Equivalences=] for [[!UnicodeVersion14|Unicode Version 14.0.0]].
 
 Note: Supplying information in {{GPUShaderModuleDescriptor/hints}} does not have any
 observable effect, other than performance. Because a single shader module can hold
@@ -4873,8 +4876,13 @@ run the following steps:
 
 A {{GPUProgrammableStage}} describes the entry point in the user-provided
 {{GPUShaderModule}} that controls one of the programmable stages of a [=pipeline=].
-Entry point names are normalized to their [=UAX15 Normalization Forms|Normalization Form C (NFC)=]
-for [[!UnicodeVersion14|Unicode Version 14.0.0]] according to [=normalization of identifiers=].
+Entry point names compare by their code points and
+do not follow [=UAX15 Equivalences=] for [[!UnicodeVersion14|Unicode Version 14.0.0]].
+
+Note: User agents should consider issuing developer-visible warnings in most or all
+situations where display of two names with different code point sequences
+look the same to the reader, such as ones same under canonical equivalence with
+[=UAX15 Normalization Forms|Normalization Form C (NFC)=] or characters that look similarly.
 
 <script type=idl>
 dictionary GPUProgrammableStage {
@@ -4895,11 +4903,16 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         Each such [=pipeline-overridable=] constant is uniquely identified by a single
         [=pipeline-overridable constant identifier string=] (representing the numeric ID of the
         constant, if one is specified, and otherwise the constant's identifier name).
-        The names are normalized to their [=UAX15 Normalization Forms|Normalization Form C (NFC)=]
-        for [[!UnicodeVersion14|Unicode Version 14.0.0]] according to [=normalization of identifiers=].
+        The names compare by their code points and
+        do not follow [=UAX15 Equivalences=] for [[!UnicodeVersion14|Unicode Version 14.0.0]].
 
         The key of each key-value pair must equal the identifier string of one such constant.
         When the pipeline is executed, that constant will have the specified value.
+
+        Note: User agents should consider issuing developer-visible warnings in most or all
+        situations where display of two names with different code point sequences
+        look the same to the reader, such as ones same under canonical equivalence with
+        [=UAX15 Normalization Forms|Normalization Form C (NFC)=] or characters that look similarly.
 
         Values are specified as <dfn typedef for=>GPUPipelineConstantValue</dfn>, which is a
         `double` which is converted to the WGSL data type of the corresponding pipeline-overridable
@@ -4963,8 +4976,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
     - |descriptor|.{{GPUProgrammableStage/module}} must be a [=valid=] {{GPUShaderModule}}.
     - |descriptor|.{{GPUProgrammableStage/module}} must contain
         an entry point, for shader stage |stage|,
-        named |descriptor|.{{GPUProgrammableStage/entryPoint}} under [=UAX15 Normalization Forms|Normalization Form C (NFC)=]
-        for [[!UnicodeVersion14|Unicode Version 14.0.0]] according to [=normalization of identifiers=].
+        named |descriptor|.{{GPUProgrammableStage/entryPoint}}.
     - For each |binding| that is [=statically used=] by the shader entry point:
         - [$validating shader binding$](|binding|, |layout|) must return `true`.
     - For each texture sampling shader call that is [=statically used=] by the entry point:
@@ -4977,8 +4989,13 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         |descriptor|.{{GPUProgrammableStage/constants}}:
         - |key| must equal the [=pipeline-overridable constant identifier string=] of
             some [=pipeline-overridable=] constant defined in the shader module
-            |descriptor|.{{GPUProgrammableStage/module}} under [=UAX15 Normalization Forms|Normalization Form C (NFC)=]
-            for [[!UnicodeVersion14|Unicode Version 14.0.0]] according to [=normalization of identifiers=].
+            |descriptor|.{{GPUProgrammableStage/module}} by code points and
+            not by [=UAX15 Equivalences=] for [[!UnicodeVersion14|Unicode Version 14.0.0]].
+            
+            Note: User agents should consider issuing developer-visible warnings in most or all
+            situations where display of two names with different code point sequences
+            look the same to the reader, such as ones same under canonical equivalence with
+            [=UAX15 Normalization Forms|Normalization Form C (NFC)=] or characters that look similarly.
     - For each [=pipeline-overridable constant identifier string=] |key| which is
         [=statically accessed=] by the shader entry point:
         - If the pipeline-overridable constant identified by |key|

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -43,6 +43,13 @@ Assume Explicit For: yes
     ],
     "href": "https://sourcemaps.info/spec.html",
     "title": "Source Map Revision 3 Proposal"
+  },
+  "UnicodeVersion14": {
+    "href":"http://www.unicode.org/versions/Unicode14.0.0/",
+    "author":"The Unicode Consortium",
+    "title":"The Unicode Standard, Version 14.0.0",
+    "isbn":"978-1-936213-29-0",
+    "id":"UnicodeVersion14"
   }
 }
 </pre>
@@ -94,6 +101,10 @@ spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
         text: store type; url: store-type
         text: runtime-sized; url: runtime-sized
         text: SizeOf; url: sizeof
+spec: UAX15; urlPrefix: https://www.unicode.org/reports/tr15/tr15-51.html
+    type: dfn
+        text: Unicode Standard Annex #15 for Unicode Version 14.0.0
+        text: UAX15 Normalization Forms; url: Normalization_Forms_Table
 </pre>
 
 <style>
@@ -4440,13 +4451,19 @@ dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
 {{GPUShaderModuleDescriptor/sourceMap}}, if defined, MAY be interpreted as a
 source-map-v3 format.
 Source maps are optional, but serve as a standardized way to support dev-tool
-integration such as source-language debugging. [[SourceMap]]
+integration such as source-language debugging [[SourceMap]].
+WGSL names in source maps are interpreted under [=UAX15 Normalization Forms|Normalization Form C (NFC)=]
+for [[!UnicodeVersion14|Unicode Version 14.0.0]].
+This normalization does not impact line/column data of offsets to avoid
+misalignments with the original.
 
 {{GPUShaderModuleDescriptor/hints}}, if defined, maps an entry point name from
 the shader to a {{GPUShaderModuleCompilationHint}}. No validation is performed with
 any of these {{GPUShaderModuleCompilationHint}}. Implementations should use any
 information present in the {{GPUShaderModuleCompilationHint}} to perform as much
 compilation as is possible within {{GPUDevice/createShaderModule()}}.
+Entry point names are interpreted under [=UAX15 Normalization Forms|Normalization Form C (NFC)=]
+for [[!UnicodeVersion14|Unicode Version 14.0.0]].
 
 Note: Supplying information in {{GPUShaderModuleDescriptor/hints}} does not have any
 observable effect, other than performance. Because a single shader module can hold
@@ -4855,6 +4872,9 @@ run the following steps:
 
 A {{GPUProgrammableStage}} describes the entry point in the user-provided
 {{GPUShaderModule}} that controls one of the programmable stages of a [=pipeline=].
+Entry point names are interpreted
+under [=UAX15 Normalization Forms|Normalization Form C (NFC)=]
+for [[!UnicodeVersion14|Unicode Version 14.0.0]].
 
 <script type=idl>
 dictionary GPUProgrammableStage {
@@ -4875,6 +4895,8 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         Each such [=pipeline-overridable=] constant is uniquely identified by a single
         [=pipeline-overridable constant identifier string=] (representing the numeric ID of the
         constant, if one is specified, and otherwise the constant's identifier name).
+        The names are interpreted under [=UAX15 Normalization Forms|Normalization Form C (NFC)=]
+        for [[!UnicodeVersion14|Unicode Version 14.0.0]].
 
         The key of each key-value pair must equal the identifier string of one such constant.
         When the pipeline is executed, that constant will have the specified value.
@@ -4941,7 +4963,8 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
     - |descriptor|.{{GPUProgrammableStage/module}} must be a [=valid=] {{GPUShaderModule}}.
     - |descriptor|.{{GPUProgrammableStage/module}} must contain
         an entry point, for shader stage |stage|,
-        named |descriptor|.{{GPUProgrammableStage/entryPoint}}.
+        named |descriptor|.{{GPUProgrammableStage/entryPoint}} under [=UAX15 Normalization Forms|Normalization Form C (NFC)=]
+        for [[!UnicodeVersion14|Unicode Version 14.0.0]]..
     - For each |binding| that is [=statically used=] by the shader entry point:
         - [$validating shader binding$](|binding|, |layout|) must return `true`.
     - For each texture sampling shader call that is [=statically used=] by the entry point:
@@ -4954,7 +4977,8 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         |descriptor|.{{GPUProgrammableStage/constants}}:
         - |key| must equal the [=pipeline-overridable constant identifier string=] of
             some [=pipeline-overridable=] constant defined in the shader module
-            |descriptor|.{{GPUProgrammableStage/module}}.
+            |descriptor|.{{GPUProgrammableStage/module}} under [=UAX15 Normalization Forms|Normalization Form C (NFC)=]
+            for [[!UnicodeVersion14|Unicode Version 14.0.0]]..
     - For each [=pipeline-overridable constant identifier string=] |key| which is
         [=statically accessed=] by the shader entry point:
         - If the pipeline-overridable constant identified by |key|

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -101,6 +101,7 @@ spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
         text: store type; url: store-type
         text: runtime-sized; url: runtime-sized
         text: SizeOf; url: sizeof
+        text: normalization of identifiers; url: identifier-normalization
 spec: UAX15; urlPrefix: https://www.unicode.org/reports/tr15/tr15-51.html
     type: dfn
         text: Unicode Standard Annex #15 for Unicode Version 14.0.0
@@ -4453,7 +4454,7 @@ source-map-v3 format.
 Source maps are optional, but serve as a standardized way to support dev-tool
 integration such as source-language debugging [[SourceMap]].
 WGSL names in source maps are normalized to their [=UAX15 Normalization Forms|Normalization Form C (NFC)=]
-for [[!UnicodeVersion14|Unicode Version 14.0.0]].
+for [[!UnicodeVersion14|Unicode Version 14.0.0]] according to [=normalization of identifiers=].
 This normalization does not impact line/column data of offsets to avoid
 misalignments with the original.
 
@@ -4463,7 +4464,7 @@ any of these {{GPUShaderModuleCompilationHint}}. Implementations should use any
 information present in the {{GPUShaderModuleCompilationHint}} to perform as much
 compilation as is possible within {{GPUDevice/createShaderModule()}}.
 Entry point names are normalized to their [=UAX15 Normalization Forms|Normalization Form C (NFC)=]
-for [[!UnicodeVersion14|Unicode Version 14.0.0]].
+for [[!UnicodeVersion14|Unicode Version 14.0.0]] according to [=normalization of identifiers=].
 
 Note: Supplying information in {{GPUShaderModuleDescriptor/hints}} does not have any
 observable effect, other than performance. Because a single shader module can hold
@@ -4872,9 +4873,8 @@ run the following steps:
 
 A {{GPUProgrammableStage}} describes the entry point in the user-provided
 {{GPUShaderModule}} that controls one of the programmable stages of a [=pipeline=].
-Entry point names are interpreted
-under [=UAX15 Normalization Forms|Normalization Form C (NFC)=]
-for [[!UnicodeVersion14|Unicode Version 14.0.0]].
+Entry point names are normalized to their [=UAX15 Normalization Forms|Normalization Form C (NFC)=]
+for [[!UnicodeVersion14|Unicode Version 14.0.0]] according to [=normalization of identifiers=].
 
 <script type=idl>
 dictionary GPUProgrammableStage {
@@ -4896,7 +4896,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         [=pipeline-overridable constant identifier string=] (representing the numeric ID of the
         constant, if one is specified, and otherwise the constant's identifier name).
         The names are normalized to their [=UAX15 Normalization Forms|Normalization Form C (NFC)=]
-        for [[!UnicodeVersion14|Unicode Version 14.0.0]].
+        for [[!UnicodeVersion14|Unicode Version 14.0.0]] according to [=normalization of identifiers=].
 
         The key of each key-value pair must equal the identifier string of one such constant.
         When the pipeline is executed, that constant will have the specified value.
@@ -4964,7 +4964,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
     - |descriptor|.{{GPUProgrammableStage/module}} must contain
         an entry point, for shader stage |stage|,
         named |descriptor|.{{GPUProgrammableStage/entryPoint}} under [=UAX15 Normalization Forms|Normalization Form C (NFC)=]
-        for [[!UnicodeVersion14|Unicode Version 14.0.0]].
+        for [[!UnicodeVersion14|Unicode Version 14.0.0]] according to [=normalization of identifiers=].
     - For each |binding| that is [=statically used=] by the shader entry point:
         - [$validating shader binding$](|binding|, |layout|) must return `true`.
     - For each texture sampling shader call that is [=statically used=] by the entry point:
@@ -4978,7 +4978,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         - |key| must equal the [=pipeline-overridable constant identifier string=] of
             some [=pipeline-overridable=] constant defined in the shader module
             |descriptor|.{{GPUProgrammableStage/module}} under [=UAX15 Normalization Forms|Normalization Form C (NFC)=]
-            for [[!UnicodeVersion14|Unicode Version 14.0.0]].
+            for [[!UnicodeVersion14|Unicode Version 14.0.0]] according to [=normalization of identifiers=].
     - For each [=pipeline-overridable constant identifier string=] |key| which is
         [=statically accessed=] by the shader entry point:
         - If the pipeline-overridable constant identified by |key|

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4452,7 +4452,7 @@ dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
 source-map-v3 format.
 Source maps are optional, but serve as a standardized way to support dev-tool
 integration such as source-language debugging [[SourceMap]].
-WGSL names in source maps are interpreted under [=UAX15 Normalization Forms|Normalization Form C (NFC)=]
+WGSL names in source maps are normalized to their [=UAX15 Normalization Forms|Normalization Form C (NFC)=]
 for [[!UnicodeVersion14|Unicode Version 14.0.0]].
 This normalization does not impact line/column data of offsets to avoid
 misalignments with the original.
@@ -4462,7 +4462,7 @@ the shader to a {{GPUShaderModuleCompilationHint}}. No validation is performed w
 any of these {{GPUShaderModuleCompilationHint}}. Implementations should use any
 information present in the {{GPUShaderModuleCompilationHint}} to perform as much
 compilation as is possible within {{GPUDevice/createShaderModule()}}.
-Entry point names are interpreted under [=UAX15 Normalization Forms|Normalization Form C (NFC)=]
+Entry point names are normalized to their [=UAX15 Normalization Forms|Normalization Form C (NFC)=]
 for [[!UnicodeVersion14|Unicode Version 14.0.0]].
 
 Note: Supplying information in {{GPUShaderModuleDescriptor/hints}} does not have any
@@ -4895,7 +4895,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         Each such [=pipeline-overridable=] constant is uniquely identified by a single
         [=pipeline-overridable constant identifier string=] (representing the numeric ID of the
         constant, if one is specified, and otherwise the constant's identifier name).
-        The names are interpreted under [=UAX15 Normalization Forms|Normalization Form C (NFC)=]
+        The names are normalized to their [=UAX15 Normalization Forms|Normalization Form C (NFC)=]
         for [[!UnicodeVersion14|Unicode Version 14.0.0]].
 
         The key of each key-value pair must equal the identifier string of one such constant.
@@ -4964,7 +4964,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
     - |descriptor|.{{GPUProgrammableStage/module}} must contain
         an entry point, for shader stage |stage|,
         named |descriptor|.{{GPUProgrammableStage/entryPoint}} under [=UAX15 Normalization Forms|Normalization Form C (NFC)=]
-        for [[!UnicodeVersion14|Unicode Version 14.0.0]]..
+        for [[!UnicodeVersion14|Unicode Version 14.0.0]].
     - For each |binding| that is [=statically used=] by the shader entry point:
         - [$validating shader binding$](|binding|, |layout|) must return `true`.
     - For each texture sampling shader call that is [=statically used=] by the entry point:
@@ -4978,7 +4978,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         - |key| must equal the [=pipeline-overridable constant identifier string=] of
             some [=pipeline-overridable=] constant defined in the shader module
             |descriptor|.{{GPUProgrammableStage/module}} under [=UAX15 Normalization Forms|Normalization Form C (NFC)=]
-            for [[!UnicodeVersion14|Unicode Version 14.0.0]]..
+            for [[!UnicodeVersion14|Unicode Version 14.0.0]].
     - For each [=pipeline-overridable constant identifier string=] |key| which is
         [=statically accessed=] by the shader entry point:
         - If the pipeline-overridable constant identified by |key|

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4879,11 +4879,6 @@ A {{GPUProgrammableStage}} describes the entry point in the user-provided
 Entry point names compare by their code points and
 do not follow [=UAX15 Equivalences=] for [[!UnicodeVersion14|Unicode Version 14.0.0]].
 
-Note: User agents should consider issuing developer-visible warnings in most or all
-situations where display of two names with different code point sequences
-look the same to the reader, such as ones same under canonical equivalence with
-[=UAX15 Normalization Forms|Normalization Form C (NFC)=] or characters that look similarly.
-
 <script type=idl>
 dictionary GPUProgrammableStage {
     required GPUShaderModule module;
@@ -4909,10 +4904,10 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         The key of each key-value pair must equal the identifier string of one such constant.
         When the pipeline is executed, that constant will have the specified value.
 
-        Note: User agents should consider issuing developer-visible warnings in most or all
-        situations where display of two names with different code point sequences
-        look the same to the reader, such as ones same under canonical equivalence with
-        [=UAX15 Normalization Forms|Normalization Form C (NFC)=] or characters that look similarly.
+        Note: A user agent or should issue developer-visible warnings when the meaning of a
+        WGSL program would change if all instances of an identifier spelled with a specific
+        codepoint sequence are replaced by another codepoint sequence
+        that would appear the same to a reader.
 
         Values are specified as <dfn typedef for=>GPUPipelineConstantValue</dfn>, which is a
         `double` which is converted to the WGSL data type of the corresponding pipeline-overridable

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -537,6 +537,9 @@ Identifiers use the following profile described in terms of [=UAX31 Grammar=]:
 <Medial> :=
 ```
 
+This means identifiers with non-ASCII characters like these are
+valid: `Δέλτα`, `réflexion`, `Кызыл`, `𐰓𐰏𐰇`, `朝焼け`, `سلام`, `검정`, `שָׁלוֹם`, `गुलाबी`, `փիրուզ`.
+
 With the following exceptions:
 * An identifier must not have the same spelling as a [=keyword=] or as a [=reserved word=].
 * An identifier must not be `_` (a single underscore)

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -510,7 +510,7 @@ an identifier:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>ident</dfn> :
 
-    | `/([a-zA-Z_][0-9a-zA-Z][0-9a-zA-Z_]*)|([a-zA-Z][0-9a-zA-Z_]*)/`
+    | `/([\p{XID_Start}])|([_\p{XID_Start}][\p{XID_Continue}]+)/`
 </div>
 
 Note: The [=return type=] for some [=built-in functions=] are structure types whose name cannot be used WGSL source.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -400,9 +400,7 @@ To parse a WGSL program:
         * blankspace
     * Repeat until no ungrouped characters remain.
 3. Discard the blankspace, leaving only tokens.
-4. Normalize identifiers with [=UAX15 Normalization Forms|Normalization Form C (NFC)=] from 
-    [=Unicode Standard Annex #15 for Unicode Version 14.0.0=].
-5. Parse the token sequence, attempting to match the [=syntax/translation_unit=] grammar rule.
+4. Parse the token sequence, attempting to match the [=syntax/translation_unit=] grammar rule.
 
 A [=shader-creation error=] results if:
 * the entire source text cannot be converted into a finite sequence of valid tokens, or
@@ -525,7 +523,11 @@ See [[#declaration-and-scope]] and [[#directives]].
 The form of an identifier is based on the
 [=Unicode Standard Annex #31 for Unicode Version 14.0.0|Unicode Standard Annex #31=] for
 [[!UnicodeVersion14|Unicode Version 14.0.0]],
-with the following elaborations.
+with the following elaborations. Identifiers do not compare under canonical equivalence
+and they are not normalized otherwise,
+meaning that single accented code points are distinct from the same characters constructed
+by an accent and a letter, and Unicode code points that look similar are not
+treated as the same and they compare by their code points.
 
 Identifiers use the following profile described in terms of [=UAX31 Grammar=]:
 
@@ -556,20 +558,15 @@ with all valid characters
 of both [=UAX31 Lexical Classes|XID_Start=] and
 [=UAX31 Lexical Classes|XID_Continue=].
 
+Note: User agents should consider issuing developer-visible warnings in most or all
+situations where display of two identifiers with different code point sequences
+look the same to the reader, such as ones same under canonical equivalence with
+[=UAX15 Normalization Forms|Normalization Form C (NFC)=] or characters that look similarly.
+
 Note: The [=return type=] for some [=built-in functions=] are structure types whose name cannot be used WGSL source.
 Those structure types are described as if they were [=predeclared=] with a name starting with two underscores.
 The result value can be saved into newly declared `let` or `var` using type inferencing, or immediately have one of its members
 immediately extracted by name.  See example usages in the description of `frexp` and `modf`.
-
-### Normalization of Identifiers ### {#identifier-normalization}
-
-The [=UAX15 Normalization Forms|Normalization Form C (NFC)=] from 
-[=Unicode Standard Annex #15 for Unicode Version 14.0.0=]
-is used to compare identifiers.
-As such, only the identifiers that are same under [=UAX15 Normalization Forms|NFC=] considered equal.
-This normalization avoids characters that look and mean the same but can be either precomposed or decomposed
-(for example, in encoding, `á` can be directly `á` or an `a` followed by a combining `´`) to be the same
-in WGSL, effectively enabling collaboration by neutralizing the impact of different input systems.
 
 ## Attributes ## {#attributes}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -550,7 +550,7 @@ With the following exceptions:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>ident</dfn> :
 
-    | `/([\p{XID_Start}])|([_\p{XID_Start}][\p{XID_Continue}]+)/`
+    | `/([_\p{XID_Start}][\p{XID_Continue}]+)|([\p{XID_Start}])/uy`
 </div>
 
 [=Unicode Character Database for Unicode Version 14.0.0=] includes non-normative listing
@@ -558,10 +558,14 @@ with all valid characters
 of both [=UAX31 Lexical Classes|XID_Start=] and
 [=UAX31 Lexical Classes|XID_Continue=].
 
-Note: User agents should consider issuing developer-visible warnings in most or all
-situations where display of two identifiers with different code point sequences
-look the same to the reader, such as ones same under canonical equivalence with
-[=UAX15 Normalization Forms|Normalization Form C (NFC)=] or characters that look similarly.
+Note: A user agent or should issue developer-visible warnings when
+the meaning of a WGSL program would change if all instances of an
+identifier spelled with a specific codepoint sequence are replaced
+by another codepoint sequence that would appear the same to a reader.
+For example, remapping each identifier to its canonical equivalent
+spelling under [=UAX15 Normalization Forms|Normaliztaion Form C (NFC)=]
+must permit the same set of declarations (avoiding new identifier collisions),
+and must not change how identifier uses [=resolve=] to their declarations.
 
 Note: The [=return type=] for some [=built-in functions=] are structure types whose name cannot be used WGSL source.
 Those structure types are described as if they were [=predeclared=] with a name starting with two underscores.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -401,7 +401,7 @@ To parse a WGSL program:
     * Repeat until no ungrouped characters remain.
 3. Discard the blankspace, leaving only tokens.
 4. Normalize identifiers with [=UAX15 Normalization Forms|Normalization Form C (NFC)=] from 
-   [=Unicode Standard Annex #15 for Unicode Version 14.0.0=].
+    [=Unicode Standard Annex #15 for Unicode Version 14.0.0=].
 5. Parse the token sequence, attempting to match the [=syntax/translation_unit=] grammar rule.
 
 A [=shader-creation error=] results if:

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -400,7 +400,9 @@ To parse a WGSL program:
         * blankspace
     * Repeat until no ungrouped characters remain.
 3. Discard the blankspace, leaving only tokens.
-3. Parse the token sequence, attempting to match the [=syntax/translation_unit=] grammar rule.
+4. Normalize identifiers with [=UAX15 Normalization Forms|Normalization Form C (NFC)=] from 
+[=Unicode Standard Annex #15 for Unicode Version 14.0.0=].
+5. Parse the token sequence, attempting to match the [=syntax/translation_unit=] grammar rule.
 
 A [=shader-creation error=] results if:
 * the entire source text cannot be converted into a finite sequence of valid tokens, or
@@ -562,6 +564,9 @@ The [=UAX15 Normalization Forms|Normalization Form C (NFC)=] from
 [=Unicode Standard Annex #15 for Unicode Version 14.0.0=]
 is used to compare identifiers.
 As such, only the identifiers that are same under [=UAX15 Normalization Forms|NFC=] considered equal.
+This normalization avoids characters that look and mean the same but can be either precomposed or decomposed
+(for example, in encoding, `á` can be directly `á` or an `a` followed by a combining `´`) to be the same
+in WGSL, effectively enabling collaboration by neutralizing the impact of different input systems.
 
 ## Attributes ## {#attributes}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -563,7 +563,7 @@ the meaning of a WGSL program would change if all instances of an
 identifier spelled with a specific codepoint sequence are replaced
 by another codepoint sequence that would appear the same to a reader.
 For example, remapping each identifier to its canonical equivalent
-spelling under [=UAX15 Normalization Forms|Normaliztaion Form C (NFC)=]
+spelling under [=UAX15 Normalization Forms|Normalization Form C (NFC)=]
 must permit the same set of declarations (avoiding new identifier collisions),
 and must not change how identifier uses [=resolve=] to their declarations.
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -107,6 +107,13 @@ div.syntax > p > code {
     "href": "https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#memory-model",
     "title": "Vulkan Memory Model",
     "publisher": "Khronos Group"
+  },
+  "UnicodeVersion14": {
+    "href":"http://www.unicode.org/versions/Unicode14.0.0/",
+    "author":"The Unicode Consortium",
+    "title":"The Unicode Standard, Version 14.0.0",
+    "isbn":"978-1-936213-29-0",
+    "id":"UnicodeVersion14"
   }
 }
 </pre>
@@ -120,6 +127,18 @@ spec: Vulkan ; urlPrefix: https://www.khronos.org/registry/vulkan/specs/1.2-exte
         text: memory model scope; url:memory-model-scope
         text: memory model memory semantics; url:memory-model-memory-semantics
         text: memory model non-private; url: memory-model-non-private
+spec: UAX15; urlPrefix: https://www.unicode.org/reports/tr15/tr15-51.html
+    type: dfn
+        text: Unicode Standard Annex #15 for Unicode Version 14.0.0
+        text: UAX15 Normalization Forms; url: Normalization_Forms_Table
+spec: UAX31; urlPrefix: https://www.unicode.org/reports/tr31/tr31-35.html
+    type: dfn
+        text: Unicode Standard Annex #31 for Unicode Version 14.0.0
+        text: UAX31 Lexical Classes; url: Table_Lexical_Classes_for_Identifiers
+        text: UAX31 Grammar; url: D1
+spec: Unicode Character Database for Unicode Version 14.0.0; urlPrefix: https://www.unicode.org/Public/14.0.0/ucd/DerivedCoreProperties.txt
+    type: dfn
+        text: Unicode Character Database for Unicode Version 14.0.0
 </pre>
 
 # Introduction # {#intro}
@@ -501,11 +520,25 @@ See [[#keyword-summary]] for the list of WGSL keywords.
 An <dfn>identifier</dfn> is a kind of [=token=] used as a name.
 See [[#declaration-and-scope]] and [[#directives]].
 
-The form of an identifier is defined via pattern-matching, except that
-an identifier:
-* must not have the same spelling as a [=keyword=] or as a [=reserved word=].
-* must not be `_` (a single underscore)
-* must not start with two underscores.
+The form of an identifier is based on the
+[=Unicode Standard Annex #31 for Unicode Version 14.0.0|Unicode Standard Annex #31=] for
+[[!UnicodeVersion14|Unicode Version 14.0.0]],
+with the following elaborations.
+
+Identifiers use the following profile described in terms of [=UAX31 Grammar=]:
+
+```
+<Identifier> := <Start> <Continue>* (<Medial> <Continue>+)*
+
+<Start> := XID_Start + U+005F
+<Continue> := <Start> + XID_Continue
+<Medial> :=
+```
+
+With the following exceptions:
+* An identifier must not have the same spelling as a [=keyword=] or as a [=reserved word=].
+* An identifier must not be `_` (a single underscore)
+* An identifier must not start with two underscores.
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>ident</dfn> :
@@ -513,10 +546,22 @@ an identifier:
     | `/([\p{XID_Start}])|([_\p{XID_Start}][\p{XID_Continue}]+)/`
 </div>
 
+[=Unicode Character Database for Unicode Version 14.0.0=] includes non-normative listing
+with all valid characters
+of both [=UAX31 Lexical Classes|XID_Start=] and
+[=UAX31 Lexical Classes|XID_Continue=].
+
 Note: The [=return type=] for some [=built-in functions=] are structure types whose name cannot be used WGSL source.
 Those structure types are described as if they were [=predeclared=] with a name starting with two underscores.
 The result value can be saved into newly declared `let` or `var` using type inferencing, or immediately have one of its members
 immediately extracted by name.  See example usages in the description of `frexp` and `modf`.
+
+### Normalization of Identifiers ### {#identifier-normalization}
+
+The [=UAX15 Normalization Forms|Normalization Form C (NFC)=] from 
+[=Unicode Standard Annex #15 for Unicode Version 14.0.0=]
+is used to compare identifiers.
+As such, only the identifiers that are same under [=UAX15 Normalization Forms|NFC=] considered equal.
 
 ## Attributes ## {#attributes}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -401,7 +401,7 @@ To parse a WGSL program:
     * Repeat until no ungrouped characters remain.
 3. Discard the blankspace, leaving only tokens.
 4. Normalize identifiers with [=UAX15 Normalization Forms|Normalization Form C (NFC)=] from 
-[=Unicode Standard Annex #15 for Unicode Version 14.0.0=].
+   [=Unicode Standard Annex #15 for Unicode Version 14.0.0=].
 5. Parse the token sequence, attempting to match the [=syntax/translation_unit=] grammar rule.
 
 A [=shader-creation error=] results if:


### PR DESCRIPTION
Tries to apply https://github.com/gpuweb/gpuweb/issues/1160 consensus.

This PR applies the accepted form of Unicode Identifiers to WGSL and WebGPU specifications where characters are constrained by XID_Start and XID_Continue from UAX31 and does not follow canonical equivalence, all Unicode references per version 14.0.0.

There is a caveat in the spec's identifier regex such that generated parser can recognize double underscore as a correct start for an identifier. This issue stems from the fact that the underlying library does not allow for look-ahead constructions in RegEx. Otherwise, the definition of accepting the second character as XID_Continue without underscore would require a set difference operation from the Unicode Set. Although there has always been the caveat of reserved words that will go away (see https://github.com/tree-sitter/tree-sitter/pull/1635 change), still bundling other missing aspects skipped by grammar definitions beg for a paragraph that clarifies that spec is only entirely understood with the surrounding text and not the syntactic definitions isolated. The undertaking of such a paragraph is not in this PR as it should be done with further discussion.

There is the possibility of defining identifier as a custom scanner in C to avoid double underscore identifiers in the generated parser. Should we remove the identifier syntax definition from spec and do that instead (I kept it due to considerations given in the prior paragraph and given that support for XID_Start and XID_Continue in RegEx makes it an easy to understand one for readers)?

On top of WGSL deficiencies in my attempt, I think I would genuinely benefit from guidance on how to improve the WebGPU spec side, as I did a terrible job there beyond including citations.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mehmetoguzderin/gpuweb/pull/2595.html" title="Last updated on Mar 23, 2022, 7:39 PM UTC (ae48b22)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2595/a4d154e...mehmetoguzderin:ae48b22.html" title="Last updated on Mar 23, 2022, 7:39 PM UTC (ae48b22)">Diff</a>