### PR TITLE
Fix typo in "validating texture copy range" argument

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6601,7 +6601,7 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
 </div>
 
 <div algorithm class=validusage>
-    <dfn dfn>validating texture copy range</dfn>(imageCopyTexture, copSize)
+    <dfn dfn>validating texture copy range</dfn>
 
     **Arguments:**
     : {{GPUImageCopyTexture}} |imageCopyTexture|


### PR DESCRIPTION
Was fixing "copSize" but then realized other similar algorithms don't even list arguments this way.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/2596.html" title="Last updated on Feb 13, 2022, 5:07 AM UTC (601c976)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2596/a5033bc...601c976.html" title="Last updated on Feb 13, 2022, 5:07 AM UTC (601c976)">Diff</a>