### PR TITLE
Disallow renderable 3D textures

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2679,11 +2679,12 @@ namespace GPUTextureUsage {
                                 [$maximum mipLevel count$](|descriptor|.{{GPUTextureDescriptor/dimension}}, |descriptor|.{{GPUTextureDescriptor/size}}).
 
                             - |descriptor|.{{GPUTextureDescriptor/usage}} must be a combination of {{GPUTextureUsage}} values.
-                            - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/RENDER_ATTACHMENT}} bit,
-                                |descriptor|.{{GPUTextureDescriptor/format}} must be a [=renderable format=].
-                            - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/STORAGE_BINDING}} bit,
-                                |descriptor|.{{GPUTextureDescriptor/format}} must be listed in [[#plain-color-formats]] table
-                                with {{GPUTextureUsage/STORAGE_BINDING}} capability.
+                            - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/RENDER_ATTACHMENT}} bit:
+                                - |descriptor|.{{GPUTextureDescriptor/format}} must be a [=renderable format=].
+                                - |descriptor|.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"2d"}}.
+                            - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/STORAGE_BINDING}} bit:
+                                - |descriptor|.{{GPUTextureDescriptor/format}} must be listed in [[#plain-color-formats]] table
+                                    with {{GPUTextureUsage/STORAGE_BINDING}} capability.
                             - For each |viewFormat| in |descriptor|.{{GPUTextureDescriptor/viewFormats}},
                                 |descriptor|.{{GPUTextureDescriptor/format}} and |viewFormat| must be
                                 [=texture view format compatible=].


### PR DESCRIPTION
Closes #2303 for sure.
Looks like #2458 didn't address this in full.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Feb 15, 2022, 11:09 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fkvark%2Fgpuweb%2Fee3027fd1b52a491f2d5593963dbe3933f4016d4%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%232603.)._
</details>
