### PR TITLE
`createSampler` creates a `GPUSampler`

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3547,7 +3547,7 @@ enum GPUCompareFunction {
 <dl dfn-type=method dfn-for=GPUDevice>
     : <dfn>createSampler(descriptor)</dfn>
     ::
-        Creates a {{GPUBindGroupLayout}}.
+        Creates a {{GPUSampler}}.
 
         <div algorithm=GPUDevice.createSampler>
             **Called on:** {{GPUDevice}} this.


### PR DESCRIPTION
Correct the link that errantly pointed to `GPUBindGroupLayout`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bollenberger/gpuweb/pull/2604.html" title="Last updated on Feb 16, 2022, 10:33 PM UTC (5cafac6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2604/e44c5fa...bollenberger:5cafac6.html" title="Last updated on Feb 16, 2022, 10:33 PM UTC (5cafac6)">Diff</a>