### PR TITLE
Add importExternalTexture examples with rAF/rVFC rendering

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3372,12 +3372,49 @@ dictionary GPUExternalTextureDescriptor : GPUObjectDescriptorBase {
 </div>
 
 <div class="example">
-    Creating an external texture from a video element:
+    Rendering using an video element external texture at the page animation frame rate:
+
     <pre highlight="js">
-        const videoElement = document.querySelector('video');
-        const externalTexture = gpuDevice.importExternalTexture({
-            source: videoElement
-        });
+        const videoElement = document.createElement('video');
+        // ... set up videoElement, wait for it to be ready...
+
+        let externalTexture;
+
+        function frame() {
+            requestAnimationFrame(frame);
+
+            // Re-import only if necessary
+            if (!externalTexture || externalTexture.expired) {
+                externalTexture = gpuDevice.importExternalTexture({
+                    source: videoElement
+                });
+            }
+
+            // ... render using externalTexture...
+        }
+        requestAnimationFrame(frame);
+    </pre>
+</div>
+
+<div class="example">
+    Rendering using an video element external texture at the video's frame rate, if
+    `requestVideoFrameCallback` is available:
+
+    <pre highlight="js">
+        const videoElement = document.createElement('video');
+        // ... set up videoElement...
+
+        function frame() {
+            videoElement.requestVideoFrameCallback(frame);
+
+            // Always re-import, because we know the video frame has advanced
+            const externalTexture = gpuDevice.importExternalTexture({
+                source: videoElement
+            });
+
+            // ... render using externalTexture...
+        }
+        videoElement.requestVideoFrameCallback(frame);
     </pre>
 </div>
 


### PR DESCRIPTION
Followup to #2302


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2605.html" title="Last updated on Feb 18, 2022, 12:18 AM UTC (7141a37)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2605/3b3e617...kainino0x:7141a37.html" title="Last updated on Feb 18, 2022, 12:18 AM UTC (7141a37)">Diff</a>