### PR TITLE
wgsl: Fix typos

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -643,7 +643,7 @@ An attribute must not be specified more than once per object or type.
     <td>Must only be applied to a member of a [=structure=] type.
 
     The number of bytes reserved in the struct for this member.
-    
+
     This number must be at least the [=byte-size=] of the type of the member:
     <p algorithm="byte-size constraint">
     If `size(`|n|`)` is applied to a member with type |T|, then [=SizeOf=](|T|)&nbsp;&leq;&nbsp;|n|.
@@ -1130,7 +1130,7 @@ Two array types are the same if and only if all of the following are true:
 * They have the same element type.
 * Their element count specifications match, i.e. one of the following is true:
     * They are both runtime-sized.
-    * They are both fixed-sized with [=creation-fixed footprint=], and 
+    * They are both fixed-sized with [=creation-fixed footprint=], and
         equal-valued element counts, even if one is signed and the other is unsigned.
         (Signed and unsigned values are comparable in this case because element counts must
         be greater than zero.)
@@ -5005,7 +5005,7 @@ expression to the right of the operator token is the <dfn noexport>right-hand si
 
 ### Simple Assignment ### {#simple-assignment-section}
 
-An [=statement/assignment=] is a <dfn noexport>simple assignment</dfn> when the 
+An [=statement/assignment=] is a <dfn noexport>simple assignment</dfn> when the
 [=left-hand side=] is an expression, and the operator is the [=syntax/equal=] token.
 In this case the value of the [=right-hand side=] is written to the memory referenced by the left-hand side.
 
@@ -5059,7 +5059,7 @@ See [[#forming-references-and-pointers]] for other cases.
 
 ### Phony Assignment ### {#phony-assignment-section}
 
-An [=statement/assignment=] is a <dfn noexport>phony assignment</dfn> when the 
+An [=statement/assignment=] is a <dfn noexport>phony assignment</dfn> when the
 [=left-hand side=] is an underscore token.
 In this case the [=right-hand side=] is evaluated, and then ignored.
 
@@ -9113,7 +9113,7 @@ struct __modf_result_vecN {
   <tr algorithm="count leading zeroes">
     <td>|T| is [INTEGRAL]
     <td class="nowrap">`countLeadingZeros(`|e|`:` |T| `) ->` |T|
-    <td>The number of consectuive 0 bits starting from the most significant bit
+    <td>The number of consecutive 0 bits starting from the most significant bit
         of |e|, when |T| is a scalar type.<br>
         [=Component-wise=] when |T| is a vector.<br>
         Also known as "clz" in some languages.<br>
@@ -9139,10 +9139,10 @@ struct __modf_result_vecN {
     <td>For scalar |T|, the result is:
         <ul>
         <li>-1 if |e| is 0 or -1.
-        <li>Otherwise the position of the most signficant bit in
+        <li>Otherwise the position of the most significant bit in
             |e| that is different from |e|'s sign bit.
         </ul>
-            
+
         Note: Since signed integers use twos-complement representation,
         the sign bit appears in the most significant bit position.
 
@@ -9154,7 +9154,7 @@ struct __modf_result_vecN {
     <td>For scalar |T|, the result is:
         <ul>
         <li>|T|(-1) if |e| is zero.
-        <li>Otherwise the position of the most signficant 1
+        <li>Otherwise the position of the most significant 1
             bit in |e|.
         </ul>
         [=Component-wise=] when |T| is a vector.<br>
@@ -9165,7 +9165,7 @@ struct __modf_result_vecN {
     <td>For scalar |T|, the result is:
         <ul>
         <li>|T|(-1) if |e| is zero.
-        <li>Otherwise the position of the least signficant 1
+        <li>Otherwise the position of the least significant 1
             bit in |e|.
         </ul>
         [=Component-wise=] when |T| is a vector.
@@ -9215,7 +9215,7 @@ struct __modf_result_vecN {
     <li>|o| = min(|offset|,|w|)
     <li>|c| = min(|count|, |w| - |o|)
     <li>The result is |e| if |c| is 0.
-    <li>Otherwise, 
+    <li>Otherwise,
        bits |o|..|o|+|c|-1 of the result are copied from bits 0..|c|-1 of |newbits|.
        Other bits of the result are copied from |e|.
     </ul>


### PR DESCRIPTION
`signficant` -> `significant`
`consectuive` -> `consecutive`

Also remove trailing line whitespace that has accumulated over time.