### PR TITLE
wgsl: Rename `firstBitHigh` and `firstBitLow`

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9135,7 +9135,7 @@ struct __modf_result_vecN {
 
   <tr algorithm="signed find most significant one bit">
     <td>|T| is [SIGNEDINTEGRAL]
-    <td class="nowrap">`firstBitHigh(`|e|`:` |T| `) ->` |T|
+    <td class="nowrap">`firstLeadingBit(`|e|`:` |T| `) ->` |T|
     <td>For scalar |T|, the result is:
         <ul>
         <li>-1 if |e| is 0 or -1.
@@ -9150,7 +9150,7 @@ struct __modf_result_vecN {
 
   <tr algorithm="unsigned find most significant one bit">
     <td>|T| is [UNSIGNEDINTEGRAL]
-    <td class="nowrap">`firstBitHigh(`|e|`:` |T| `) ->` |T|
+    <td class="nowrap">`firstLeadingBit(`|e|`:` |T| `) ->` |T|
     <td>For scalar |T|, the result is:
         <ul>
         <li>|T|(-1) if |e| is zero.
@@ -9161,7 +9161,7 @@ struct __modf_result_vecN {
 
   <tr algorithm="find least significant one bit">
     <td>|T| is [INTEGRAL]
-    <td class="nowrap">`firstBitLow(`|e|`:` |T| `) ->` |T|
+    <td class="nowrap">`firstTrailingBit(`|e|`:` |T| `) ->` |T|
     <td>For scalar |T|, the result is:
         <ul>
         <li>|T|(-1) if |e| is zero.


### PR DESCRIPTION
The current names are confusing, as `High` or `Low` may refer to scanning from the MSB or LSB, or that it is scanning for the bits `1` or `0`.

By renaming to `firstLeadingBit` and `firstTrailingBit` the ambiguity is reduced, and we have a consistent terminology with `countLeadingZeros` / `countTrailingZeros`.