### PR TITLE
Fix a typo in FP32 internal layout

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1863,7 +1863,7 @@ When |V| is placed at byte offset |k| of host-shared buffer, then:
    * Byte |k| contains bits 0 through 7 of the fraction.
    * Byte |k|+1 contains bits 8 through 15 of the fraction.
    * Bits 0 through 6 of byte |k|+2 contain bits 16 through 22 of the fraction.
-   * Bit 7 of byte |k|+2 contains bit 0 bit of the exponent.
+   * Bit 7 of byte |k|+2 contains bit 0 of the exponent.
    * Bits 0 through 6 of byte |k|+3 contain bits 1 through 7 of the exponent.
    * Bit 7 of byte |k|+3 contains the sign bit.
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1862,7 +1862,7 @@ It has one sign bit, 8 exponent bits, and 23 fraction bits.
 When |V| is placed at byte offset |k| of host-shared buffer, then:
    * Byte |k| contains bits 0 through 7 of the fraction.
    * Byte |k|+1 contains bits 8 through 15 of the fraction.
-   * Bits 0 through 6 of byte |k|+2 contain bits 16 through 23 of the fraction.
+   * Bits 0 through 6 of byte |k|+2 contain bits 16 through 22 of the fraction.
    * Bit 7 of byte |k|+2 contains bit 0 bit of the exponent.
    * Bits 0 through 6 of byte |k|+3 contain bits 1 through 7 of the exponent.
    * Bit 7 of byte |k|+3 contains the sign bit.


### PR DESCRIPTION
In the internal layout of float32, Bits 0 through 6 of byte k+2 contain bits 16 through 22 of the fraction, which has a total of 23 bits (0 through 22).