### PR TITLE
wgsl: Reserve words from common programming languages

### DIFF
--- a/wgsl/extract-grammar.py
+++ b/wgsl/extract-grammar.py
@@ -28,8 +28,11 @@ HEADER = """
 
 scanner_filename = sys.argv[1]
 scanner_file = open(scanner_filename, "r")
+# Break up the input into lines, and skip empty lines.
 scanner_lines = [j for i in [i.split("\n")
                              for i in scanner_file.readlines()] for j in i if len(j) > 0]
+# Replace comments in rule text
+scanner_lines = [re.sub('<!--.*-->', '', line) for line in scanner_lines]
 
 grammar_filename = sys.argv[2]
 grammar_path = os.path.dirname(grammar_filename)

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8211,13 +8211,19 @@ The following are reserved words:
 
     | `'abstract'`   <!-- Rust -->
 
+    | `'active'`   <!-- GLSL(reserved) -->
+
     | `'alignas'`   <!-- C++ -->
 
     | `'alignof'`   <!-- C++ -->
 
     | `'as'`   <!-- Rust -->
 
-    | `'asm'`   <!-- C++ WGSL -->
+    | `'asm'`   <!-- C++ GLSL(reserved) WGSL -->
+
+    | `'atomic_uint'`   <!-- GLSL -->
+
+    | `'attribute'`   <!-- GLSL -->
 
     | `'auto'`   <!-- C++ -->
 
@@ -8227,7 +8233,19 @@ The following are reserved words:
 
     | `'box'`   <!-- Rust -->
 
+    | `'buffer'`   <!-- GLSL -->
+
+    | `'bvec2'`   <!-- GLSL -->
+
+    | `'bvec3'`   <!-- GLSL -->
+
+    | `'bvec4'`   <!-- GLSL -->
+
+    | `'cast'`   <!-- GLSL(reserved) -->
+
     | `'catch'`   <!-- C++ ECMAScript -->
+
+    | `'centroid'`   <!-- GLSL -->
 
     | `'char'`   <!-- C++ -->
 
@@ -8237,7 +8255,7 @@ The following are reserved words:
 
     | `'char8_t'`   <!-- C++ -->
 
-    | `'class'`   <!-- C++ ECMAScript -->
+    | `'class'`   <!-- C++ ECMAScript GLSL(reserved) -->
 
     | `'co_await'`   <!-- C++ -->
 
@@ -8245,9 +8263,13 @@ The following are reserved words:
 
     | `'co_yield'`   <!-- C++ -->
 
+    | `'coherent'`   <!-- GLSL -->
+
+    | `'common'`   <!-- GLSL(reserved) -->
+
     | `'concept'`   <!-- C++ -->
 
-    | `'const'`   <!-- C++ ECMAScript Rust WGSL -->
+    | `'const'`   <!-- C++ ECMAScript Rust GLSL WGSL -->
 
     | `'const_cast'`   <!-- C++ -->
 
@@ -8269,13 +8291,43 @@ The following are reserved words:
 
     | `'demote_to_helper'`   <!-- WGSL -->
 
-    | `'do'`   <!-- C++ ECMAScript Rust WGSL -->
+    | `'dmat2'`   <!-- GLSL -->
 
-    | `'double'`   <!-- C++ -->
+    | `'dmat2x2'`   <!-- GLSL -->
+
+    | `'dmat2x3'`   <!-- GLSL -->
+
+    | `'dmat2x4'`   <!-- GLSL -->
+
+    | `'dmat3'`   <!-- GLSL -->
+
+    | `'dmat3x2'`   <!-- GLSL -->
+
+    | `'dmat3x3'`   <!-- GLSL -->
+
+    | `'dmat3x4'`   <!-- GLSL -->
+
+    | `'dmat4'`   <!-- GLSL -->
+
+    | `'dmat4x2'`   <!-- GLSL -->
+
+    | `'dmat4x3'`   <!-- GLSL -->
+
+    | `'dmat4x4'`   <!-- GLSL -->
+
+    | `'do'`   <!-- C++ ECMAScript Rust GLSL WGSL -->
+
+    | `'double'`   <!-- C++ GLSL -->
+
+    | `'dvec2'`   <!-- GLSL -->
+
+    | `'dvec3'`   <!-- GLSL -->
+
+    | `'dvec4'`   <!-- GLSL -->
 
     | `'dynamic_cast'`   <!-- C++ -->
 
-    | `'enum'`   <!-- C++ ECMAScript Rust WGSL -->
+    | `'enum'`   <!-- C++ ECMAScript Rust GLSL(reserved) WGSL -->
 
     | `'explicit'`   <!-- C++ -->
 
@@ -8283,23 +8335,47 @@ The following are reserved words:
 
     | `'extends'`   <!-- ECMAScript -->
 
-    | `'extern'`   <!-- C++ Rust -->
+    | `'extern'`   <!-- C++ Rust GLSL(reserved) -->
+
+    | `'external'`   <!-- GLSL(reserved) -->
 
     | `'f16'`   <!-- WGSL -->
 
     | `'f64'`   <!-- WGSL -->
 
+    | `'filter'`   <!-- GLSL(reserved) -->
+
     | `'final'`   <!-- Rust -->
 
     | `'finally'`   <!-- ECMAScript -->
 
-    | `'float'`   <!-- C++ -->
+    | `'fixed'`   <!-- GLSL(reserved) -->
+
+    | `'flat'`   <!-- GLSL -->
+
+    | `'float'`   <!-- C++ GLSL -->
 
     | `'friend'`   <!-- C++ -->
 
-    | `'goto'`   <!-- C++ -->
+    | `'fvec2'`   <!-- GLSL(reserved) -->
+
+    | `'fvec3'`   <!-- GLSL(reserved) -->
+
+    | `'fvec4'`   <!-- GLSL(reserved) -->
+
+    | `'goto'`   <!-- C++ GLSL(reserved) -->
+
+    | `'half'`   <!-- GLSL(reserved) -->
 
     | `'handle'`   <!-- WGSL -->
+
+    | `'highp'`   <!-- GLSL -->
+
+    | `'hvec2'`   <!-- GLSL(reserved) -->
+
+    | `'hvec3'`   <!-- GLSL(reserved) -->
+
+    | `'hvec4'`   <!-- GLSL(reserved) -->
 
     | `'i16'`   <!-- WGSL -->
 
@@ -8307,23 +8383,131 @@ The following are reserved words:
 
     | `'i8'`   <!-- WGSL -->
 
+    | `'iimage1D'`   <!-- GLSL -->
+
+    | `'iimage1DArray'`   <!-- GLSL -->
+
+    | `'iimage2D'`   <!-- GLSL -->
+
+    | `'iimage2DArray'`   <!-- GLSL -->
+
+    | `'iimage2DMS'`   <!-- GLSL -->
+
+    | `'iimage2DMSArray'`   <!-- GLSL -->
+
+    | `'iimage2DRect'`   <!-- GLSL -->
+
+    | `'iimage3D'`   <!-- GLSL -->
+
+    | `'iimageBuffer'`   <!-- GLSL -->
+
+    | `'iimageCube'`   <!-- GLSL -->
+
+    | `'iimageCubeArray'`   <!-- GLSL -->
+
+    | `'image1D'`   <!-- GLSL -->
+
+    | `'image1DArray'`   <!-- GLSL -->
+
+    | `'image2D'`   <!-- GLSL -->
+
+    | `'image2DArray'`   <!-- GLSL -->
+
+    | `'image2DMS'`   <!-- GLSL -->
+
+    | `'image2DMSArray'`   <!-- GLSL -->
+
+    | `'image2DRect'`   <!-- GLSL -->
+
+    | `'image3D'`   <!-- GLSL -->
+
+    | `'imageBuffer'`   <!-- GLSL -->
+
+    | `'imageCube'`   <!-- GLSL -->
+
+    | `'imageCubeArray'`   <!-- GLSL -->
+
     | `'impl'`   <!-- Rust -->
 
     | `'implements'`   <!-- ECMAScript -->
 
     | `'import'`   <!-- C++ ECMAScript -->
 
-    | `'in'`   <!-- ECMAScript Rust -->
+    | `'in'`   <!-- ECMAScript Rust GLSL -->
 
-    | `'inline'`   <!-- C++ -->
+    | `'inline'`   <!-- C++ GLSL(reserved) -->
+
+    | `'inout'`   <!-- GLSL -->
+
+    | `'input'`   <!-- GLSL(reserved) -->
 
     | `'instanceof'`   <!-- ECMAScript -->
 
-    | `'int'`   <!-- C++ -->
+    | `'int'`   <!-- C++ GLSL -->
 
-    | `'interface'`   <!-- ECMAScript -->
+    | `'interface'`   <!-- ECMAScript GLSL(reserved) -->
 
-    | `'long'`   <!-- C++ -->
+    | `'invariant'`   <!-- GLSL -->
+
+    | `'isampler1D'`   <!-- GLSL -->
+
+    | `'isampler1DArray'`   <!-- GLSL -->
+
+    | `'isampler2D'`   <!-- GLSL -->
+
+    | `'isampler2DArray'`   <!-- GLSL -->
+
+    | `'isampler2DMS'`   <!-- GLSL -->
+
+    | `'isampler2DMSArray'`   <!-- GLSL -->
+
+    | `'isampler2DRect'`   <!-- GLSL -->
+
+    | `'isampler3D'`   <!-- GLSL -->
+
+    | `'isamplerBuffer'`   <!-- GLSL -->
+
+    | `'isamplerCube'`   <!-- GLSL -->
+
+    | `'isamplerCubeArray'`   <!-- GLSL -->
+
+    | `'isubpassInput'`   <!-- GLSL -->
+
+    | `'isubpassInputMS'`   <!-- GLSL -->
+
+    | `'itexture1D'`   <!-- GLSL -->
+
+    | `'itexture1DArray'`   <!-- GLSL -->
+
+    | `'itexture2D'`   <!-- GLSL -->
+
+    | `'itexture2DArray'`   <!-- GLSL -->
+
+    | `'itexture2DMS'`   <!-- GLSL -->
+
+    | `'itexture2DMSArray'`   <!-- GLSL -->
+
+    | `'itexture2DRect'`   <!-- GLSL -->
+
+    | `'itexture3D'`   <!-- GLSL -->
+
+    | `'itextureBuffer'`   <!-- GLSL -->
+
+    | `'itextureCube'`   <!-- GLSL -->
+
+    | `'itextureCubeArray'`   <!-- GLSL -->
+
+    | `'ivec2'`   <!-- GLSL -->
+
+    | `'ivec3'`   <!-- GLSL -->
+
+    | `'ivec4'`   <!-- GLSL -->
+
+    | `'layout'`   <!-- GLSL -->
+
+    | `'long'`   <!-- C++ GLSL(reserved) -->
+
+    | `'lowp'`   <!-- GLSL -->
 
     | `'macro'`   <!-- Rust -->
 
@@ -8331,7 +8515,15 @@ The following are reserved words:
 
     | `'mat'`   <!-- WGSL -->
 
+    | `'mat2'`   <!-- GLSL -->
+
+    | `'mat3'`   <!-- GLSL -->
+
+    | `'mat4'`   <!-- GLSL -->
+
     | `'match'`   <!-- Rust -->
+
+    | `'mediump'`   <!-- GLSL -->
 
     | `'mod'`   <!-- Rust -->
 
@@ -8343,7 +8535,7 @@ The following are reserved words:
 
     | `'mutable'`   <!-- C++ -->
 
-    | `'namespace'`   <!-- C++ -->
+    | `'namespace'`   <!-- C++ GLSL(reserved) -->
 
     | `'new'`   <!-- C++ ECMAScript -->
 
@@ -8351,11 +8543,29 @@ The following are reserved words:
 
     | `'noexcept'`   <!-- C++ -->
 
+    | `'noinline'`   <!-- GLSL(reserved) -->
+
+    | `'noperspective'`   <!-- GLSL -->
+
+    | `'null'`   <!-- WGSL -->
+
     | `'nullptr'`   <!-- C++ -->
 
     | `'operator'`   <!-- C++ -->
 
+    | `'out'`   <!-- GLSL -->
+
+    | `'output'`   <!-- GLSL(reserved) -->
+
     | `'package'`   <!-- ECMAScript -->
+
+    | `'partition'`   <!-- GLSL(reserved) -->
+
+    | `'patch'`   <!-- GLSL -->
+
+    | `'precise'`   <!-- GLSL -->
+
+    | `'precision'`   <!-- GLSL -->
 
     | `'premerge'`   <!-- WGSL -->
 
@@ -8365,7 +8575,9 @@ The following are reserved words:
 
     | `'pub'`   <!-- Rust -->
 
-    | `'public'`   <!-- C++ ECMAScript -->
+    | `'public'`   <!-- C++ ECMAScript GLSL(reserved) -->
+
+    | `'readonly'`   <!-- GLSL -->
 
     | `'ref'`   <!-- Rust -->
 
@@ -8377,15 +8589,65 @@ The following are reserved words:
 
     | `'requires'`   <!-- C++ -->
 
+    | `'resource'`   <!-- GLSL(reserved) -->
+
+    | `'restrict'`   <!-- GLSL -->
+
+    | `'sample'`   <!-- GLSL -->
+
+    | `'sampler1D'`   <!-- GLSL -->
+
+    | `'sampler1DArray'`   <!-- GLSL -->
+
+    | `'sampler1DArrayShadow'`   <!-- GLSL -->
+
+    | `'sampler1DShadow'`   <!-- GLSL -->
+
+    | `'sampler2D'`   <!-- GLSL -->
+
+    | `'sampler2DArray'`   <!-- GLSL -->
+
+    | `'sampler2DArrayShadow'`   <!-- GLSL -->
+
+    | `'sampler2DMS'`   <!-- GLSL -->
+
+    | `'sampler2DMSArray'`   <!-- GLSL -->
+
+    | `'sampler2DRect'`   <!-- GLSL -->
+
+    | `'sampler2DRectShadow'`   <!-- GLSL -->
+
+    | `'sampler2DShadow'`   <!-- GLSL -->
+
+    | `'sampler3D'`   <!-- GLSL -->
+
+    | `'sampler3DRect'`   <!-- GLSL(reserved) -->
+
+    | `'samplerBuffer'`   <!-- GLSL -->
+
+    | `'samplerCube'`   <!-- GLSL -->
+
+    | `'samplerCubeArray'`   <!-- GLSL -->
+
+    | `'samplerCubeArrayShadow'`   <!-- GLSL -->
+
+    | `'samplerCubeShadow'`   <!-- GLSL -->
+
+    | `'samplerShadow'`   <!-- GLSL -->
+
     | `'self'`   <!-- Rust Smalltalk -->
 
-    | `'short'`   <!-- C++ -->
+    | `'shared'`   <!-- GLSL -->
+
+    | `'short'`   <!-- C++ GLSL(reserved) -->
 
     | `'signed'`   <!-- C++ -->
 
-    | `'sizeof'`   <!-- C++ -->
+    | `'sizeof'`   <!-- C++ GLSL(reserved) -->
 
-    | `'static'`   <!-- C++ ECMAScript Rust -->
+    | `'smooth'`   <!-- GLSL -->
+
+    | `'static'`   <!-- C++ ECMAScript Rust GLSL(reserved) -->
 
     | `'static_assert'`   <!-- C++ -->
 
@@ -8393,11 +8655,41 @@ The following are reserved words:
 
     | `'std'`   <!-- WGSL -->
 
+    | `'subpassInput'`   <!-- GLSL -->
+
+    | `'subpassInputMS'`   <!-- GLSL -->
+
+    | `'subroutine'`   <!-- GLSL -->
+
     | `'super'`   <!-- ECMAScript Rust Smalltalk -->
 
-    | `'template'`   <!-- C++ -->
+    | `'superp'`   <!-- GLSL(reserved) -->
 
-    | `'this'`   <!-- C++ ECMAScript -->
+    | `'template'`   <!-- C++ GLSL(reserved) -->
+
+    | `'texture1D'`   <!-- GLSL -->
+
+    | `'texture1DArray'`   <!-- GLSL -->
+
+    | `'texture2D'`   <!-- GLSL -->
+
+    | `'texture2DArray'`   <!-- GLSL -->
+
+    | `'texture2DMS'`   <!-- GLSL -->
+
+    | `'texture2DMSArray'`   <!-- GLSL -->
+
+    | `'texture2DRect'`   <!-- GLSL -->
+
+    | `'texture3D'`   <!-- GLSL -->
+
+    | `'textureBuffer'`   <!-- GLSL -->
+
+    | `'textureCube'`   <!-- GLSL -->
+
+    | `'textureCubeArray'`   <!-- GLSL -->
+
+    | `'this'`   <!-- C++ ECMAScript GLSL(reserved) -->
 
     | `'thread_local'`   <!-- C++ -->
 
@@ -8407,7 +8699,7 @@ The following are reserved words:
 
     | `'try'`   <!-- C++ ECMAScript -->
 
-    | `'typedef'`   <!-- C++ WGSL -->
+    | `'typedef'`   <!-- C++ GLSL(reserved) WGSL -->
 
     | `'typeid'`   <!-- C++ -->
 
@@ -8421,27 +8713,107 @@ The following are reserved words:
 
     | `'u8'`   <!-- WGSL -->
 
-    | `'union'`   <!-- C++ Rust -->
+    | `'uimage1D'`   <!-- GLSL -->
+
+    | `'uimage1DArray'`   <!-- GLSL -->
+
+    | `'uimage2D'`   <!-- GLSL -->
+
+    | `'uimage2DArray'`   <!-- GLSL -->
+
+    | `'uimage2DMS'`   <!-- GLSL -->
+
+    | `'uimage2DMSArray'`   <!-- GLSL -->
+
+    | `'uimage2DRect'`   <!-- GLSL -->
+
+    | `'uimage3D'`   <!-- GLSL -->
+
+    | `'uimageBuffer'`   <!-- GLSL -->
+
+    | `'uimageCube'`   <!-- GLSL -->
+
+    | `'uimageCubeArray'`   <!-- GLSL -->
+
+    | `'uint'`   <!-- GLSL -->
+
+    | `'union'`   <!-- C++ Rust GLSL(reserved) -->
 
     | `'unless'`   <!-- WGSL -->
 
     | `'unsafe'`   <!-- Rust -->
 
-    | `'unsigned'`   <!-- C++ -->
+    | `'unsigned'`   <!-- C++ GLSL(reserved) -->
 
     | `'unsized'`   <!-- Rust -->
 
+    | `'usampler1D'`   <!-- GLSL -->
+
+    | `'usampler1DArray'`   <!-- GLSL -->
+
+    | `'usampler2D'`   <!-- GLSL -->
+
+    | `'usampler2DArray'`   <!-- GLSL -->
+
+    | `'usampler2DMS'`   <!-- GLSL -->
+
+    | `'usampler2DMSArray'`   <!-- GLSL -->
+
+    | `'usampler2DRect'`   <!-- GLSL -->
+
+    | `'usampler3D'`   <!-- GLSL -->
+
+    | `'usamplerBuffer'`   <!-- GLSL -->
+
+    | `'usamplerCube'`   <!-- GLSL -->
+
+    | `'usamplerCubeArray'`   <!-- GLSL -->
+
     | `'use'`   <!-- Rust -->
 
-    | `'using'`   <!-- C++ WGSL -->
+    | `'using'`   <!-- C++ GLSL(reserved) WGSL -->
+
+    | `'usubpassInput'`   <!-- GLSL -->
+
+    | `'usubpassInputMS'`   <!-- GLSL -->
+
+    | `'utexture1D'`   <!-- GLSL -->
+
+    | `'utexture1DArray'`   <!-- GLSL -->
+
+    | `'utexture2D'`   <!-- GLSL -->
+
+    | `'utexture2DArray'`   <!-- GLSL -->
+
+    | `'utexture2DMS'`   <!-- GLSL -->
+
+    | `'utexture2DMSArray'`   <!-- GLSL -->
+
+    | `'utexture2DRect'`   <!-- GLSL -->
+
+    | `'utexture3D'`   <!-- GLSL -->
+
+    | `'utextureBuffer'`   <!-- GLSL -->
+
+    | `'utextureCube'`   <!-- GLSL -->
+
+    | `'utextureCubeArray'`   <!-- GLSL -->
+
+    | `'uvec2'`   <!-- GLSL -->
+
+    | `'uvec3'`   <!-- GLSL -->
+
+    | `'uvec4'`   <!-- GLSL -->
+
+    | `'varying'`   <!-- GLSL -->
 
     | `'vec'`   <!-- WGSL -->
 
     | `'virtual'`   <!-- C++ Rust -->
 
-    | `'void'`   <!-- C++ ECMAScript WGSL -->
+    | `'void'`   <!-- C++ ECMAScript GLSL WGSL -->
 
-    | `'volatile'`   <!-- C++ -->
+    | `'volatile'`   <!-- C++ GLSL -->
 
     | `'wchar_t'`   <!-- C++ -->
 
@@ -8450,6 +8822,8 @@ The following are reserved words:
     | `'where'`   <!-- Rust -->
 
     | `'with'`   <!-- ECMAScript -->
+
+    | `'writeonly'`   <!-- GLSL -->
 
     | `'yield'`   <!-- ECMAScript Rust -->
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8207,57 +8207,252 @@ The following are reserved words:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>_reserved</dfn> :
 
-    | `'asm'`
+    | `'Self'`   <!-- Rust -->
 
-    | `'bf16'`
+    | `'abstract'`   <!-- Rust -->
 
-    | `'const'`
+    | `'alignas'`   <!-- C++ -->
 
-    | `'demote'`
+    | `'alignof'`   <!-- C++ -->
 
-    | `'demote_to_helper'`
+    | `'as'`   <!-- Rust -->
 
-    | `'do'`
+    | `'asm'`   <!--  -->
 
-    | `'enum'`
+    | `'auto'`   <!-- C++ -->
 
-    | `'f16'`
+    | `'become'`   <!-- Rust -->
 
-    | `'f64'`
+    | `'bf16'`   <!--  -->
 
-    | `'handle'`
+    | `'box'`   <!-- Rust -->
 
-    | `'i8'`
+    | `'catch'`   <!-- C++ ECMAScript -->
 
-    | `'i16'`
+    | `'char'`   <!-- C++ -->
 
-    | `'i64'`
+    | `'char16_t'`   <!-- C++ -->
 
-    | `'mat'`
+    | `'char32_t'`   <!-- C++ -->
 
-    | `'premerge'`
+    | `'char8_t'`   <!-- C++ -->
 
-    | `'regardless'`
+    | `'class'`   <!-- C++ ECMAScript -->
 
-    | `'std'`
+    | `'co_await'`   <!-- C++ -->
 
-    | `'typedef'`
+    | `'co_return'`   <!-- C++ -->
 
-    | `'u8'`
+    | `'co_yield'`   <!-- C++ -->
 
-    | `'u16'`
+    | `'concept'`   <!-- C++ -->
 
-    | `'u64'`
+    | `'const'`   <!--  -->
 
-    | `'unless'`
+    | `'const_cast'`   <!-- C++ -->
 
-    | `'using'`
+    | `'consteval'`   <!-- C++ -->
 
-    | `'vec'`
+    | `'constexpr'`   <!-- C++ -->
 
-    | `'void'`
+    | `'constinit'`   <!-- C++ -->
 
-    | `'wgsl'`
+    | `'crate'`   <!-- Rust -->
+
+    | `'debugger'`   <!-- ECMAScript -->
+
+    | `'decltype'`   <!-- C++ -->
+
+    | `'delete'`   <!-- C++ ECMAScript -->
+
+    | `'demote'`   <!--  -->
+
+    | `'demote_to_helper'`   <!--  -->
+
+    | `'do'`   <!--  -->
+
+    | `'double'`   <!-- C++ -->
+
+    | `'dynamic_cast'`   <!-- C++ -->
+
+    | `'enum'`   <!--  -->
+
+    | `'explicit'`   <!-- C++ -->
+
+    | `'export'`   <!-- C++ C++ ECMAScript -->
+
+    | `'extends'`   <!-- ECMAScript -->
+
+    | `'extern'`   <!-- C++ Rust -->
+
+    | `'f16'`   <!--  -->
+
+    | `'f64'`   <!--  -->
+
+    | `'final'`   <!-- Rust -->
+
+    | `'finally'`   <!-- ECMAScript -->
+
+    | `'float'`   <!-- C++ -->
+
+    | `'friend'`   <!-- C++ -->
+
+    | `'goto'`   <!-- C++ -->
+
+    | `'handle'`   <!--  -->
+
+    | `'i16'`   <!--  -->
+
+    | `'i64'`   <!--  -->
+
+    | `'i8'`   <!--  -->
+
+    | `'impl'`   <!-- Rust -->
+
+    | `'implements'`   <!-- ECMAScript -->
+
+    | `'import'`   <!-- C++ ECMAScript -->
+
+    | `'in'`   <!-- ECMAScript Rust -->
+
+    | `'inline'`   <!-- C++ -->
+
+    | `'instanceof'`   <!-- ECMAScript -->
+
+    | `'int'`   <!-- C++ -->
+
+    | `'interface'`   <!-- ECMAScript -->
+
+    | `'long'`   <!-- C++ -->
+
+    | `'macro'`   <!-- Rust -->
+
+    | `'macro_rules'`   <!-- Rust -->
+
+    | `'mat'`   <!--  -->
+
+    | `'match'`   <!-- Rust -->
+
+    | `'mod'`   <!-- Rust -->
+
+    | `'module'`   <!-- C++ -->
+
+    | `'move'`   <!-- Rust -->
+
+    | `'mut'`   <!-- Rust -->
+
+    | `'mutable'`   <!-- C++ -->
+
+    | `'namespace'`   <!-- C++ -->
+
+    | `'new'`   <!-- C++ ECMAScript -->
+
+    | `'nil'`   <!-- Smalltalk -->
+
+    | `'noexcept'`   <!-- C++ -->
+
+    | `'nullptr'`   <!-- C++ -->
+
+    | `'operator'`   <!-- C++ -->
+
+    | `'package'`   <!-- ECMAScript -->
+
+    | `'premerge'`   <!--  -->
+
+    | `'priv'`   <!-- Rust -->
+
+    | `'protected'`   <!-- C++ ECMAScript -->
+
+    | `'pub'`   <!-- Rust -->
+
+    | `'public'`   <!-- C++ ECMAScript -->
+
+    | `'ref'`   <!-- Rust -->
+
+    | `'regardless'`   <!--  -->
+
+    | `'register'`   <!-- C++ -->
+
+    | `'reinterpret_cast'`   <!-- C++ -->
+
+    | `'requires'`   <!-- C++ -->
+
+    | `'self'`   <!-- Rust Smalltalk -->
+
+    | `'short'`   <!-- C++ -->
+
+    | `'signed'`   <!-- C++ -->
+
+    | `'sizeof'`   <!-- C++ -->
+
+    | `'static'`   <!-- C++ ECMAScript Rust -->
+
+    | `'static_assert'`   <!-- C++ -->
+
+    | `'static_cast'`   <!-- C++ -->
+
+    | `'std'`   <!--  -->
+
+    | `'super'`   <!-- ECMAScript Rust Smalltalk -->
+
+    | `'template'`   <!-- C++ -->
+
+    | `'this'`   <!-- C++ ECMAScript -->
+
+    | `'thread_local'`   <!-- C++ -->
+
+    | `'throw'`   <!-- C++ ECMAScript -->
+
+    | `'trait'`   <!-- Rust -->
+
+    | `'try'`   <!-- C++ ECMAScript -->
+
+    | `'typedef'`   <!--  -->
+
+    | `'typeid'`   <!-- C++ -->
+
+    | `'typename'`   <!-- C++ -->
+
+    | `'typeof'`   <!-- ECMAScript Rust -->
+
+    | `'u16'`   <!--  -->
+
+    | `'u64'`   <!--  -->
+
+    | `'u8'`   <!--  -->
+
+    | `'union'`   <!-- C++ Rust -->
+
+    | `'unless'`   <!--  -->
+
+    | `'unsafe'`   <!-- Rust -->
+
+    | `'unsigned'`   <!-- C++ -->
+
+    | `'unsized'`   <!-- Rust -->
+
+    | `'use'`   <!-- Rust -->
+
+    | `'using'`   <!--  -->
+
+    | `'vec'`   <!--  -->
+
+    | `'virtual'`   <!-- C++ Rust -->
+
+    | `'void'`   <!--  -->
+
+    | `'volatile'`   <!-- C++ -->
+
+    | `'wchar_t'`   <!-- C++ -->
+
+    | `'wgsl'`   <!--  -->
+
+    | `'where'`   <!-- Rust -->
+
+    | `'with'`   <!-- ECMAScript -->
+
+    | `'yield'`   <!-- ECMAScript Rust -->
+
 </div>
 
 ## Syntactic Tokens ## {#syntactic-tokens}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8217,13 +8217,13 @@ The following are reserved words:
 
     | `'as'`   <!-- Rust -->
 
-    | `'asm'`   <!--  -->
+    | `'asm'`   <!-- C++ WGSL -->
 
     | `'auto'`   <!-- C++ -->
 
     | `'become'`   <!-- Rust -->
 
-    | `'bf16'`   <!--  -->
+    | `'bf16'`   <!-- WGSL -->
 
     | `'box'`   <!-- Rust -->
 
@@ -8247,7 +8247,7 @@ The following are reserved words:
 
     | `'concept'`   <!-- C++ -->
 
-    | `'const'`   <!--  -->
+    | `'const'`   <!-- C++ ECMAScript Rust WGSL -->
 
     | `'const_cast'`   <!-- C++ -->
 
@@ -8265,17 +8265,17 @@ The following are reserved words:
 
     | `'delete'`   <!-- C++ ECMAScript -->
 
-    | `'demote'`   <!--  -->
+    | `'demote'`   <!-- WGSL -->
 
-    | `'demote_to_helper'`   <!--  -->
+    | `'demote_to_helper'`   <!-- WGSL -->
 
-    | `'do'`   <!--  -->
+    | `'do'`   <!-- C++ ECMAScript Rust WGSL -->
 
     | `'double'`   <!-- C++ -->
 
     | `'dynamic_cast'`   <!-- C++ -->
 
-    | `'enum'`   <!--  -->
+    | `'enum'`   <!-- C++ ECMAScript Rust WGSL -->
 
     | `'explicit'`   <!-- C++ -->
 
@@ -8285,9 +8285,9 @@ The following are reserved words:
 
     | `'extern'`   <!-- C++ Rust -->
 
-    | `'f16'`   <!--  -->
+    | `'f16'`   <!-- WGSL -->
 
-    | `'f64'`   <!--  -->
+    | `'f64'`   <!-- WGSL -->
 
     | `'final'`   <!-- Rust -->
 
@@ -8299,13 +8299,13 @@ The following are reserved words:
 
     | `'goto'`   <!-- C++ -->
 
-    | `'handle'`   <!--  -->
+    | `'handle'`   <!-- WGSL -->
 
-    | `'i16'`   <!--  -->
+    | `'i16'`   <!-- WGSL -->
 
-    | `'i64'`   <!--  -->
+    | `'i64'`   <!-- WGSL -->
 
-    | `'i8'`   <!--  -->
+    | `'i8'`   <!-- WGSL -->
 
     | `'impl'`   <!-- Rust -->
 
@@ -8329,7 +8329,7 @@ The following are reserved words:
 
     | `'macro_rules'`   <!-- Rust -->
 
-    | `'mat'`   <!--  -->
+    | `'mat'`   <!-- WGSL -->
 
     | `'match'`   <!-- Rust -->
 
@@ -8357,7 +8357,7 @@ The following are reserved words:
 
     | `'package'`   <!-- ECMAScript -->
 
-    | `'premerge'`   <!--  -->
+    | `'premerge'`   <!-- WGSL -->
 
     | `'priv'`   <!-- Rust -->
 
@@ -8369,7 +8369,7 @@ The following are reserved words:
 
     | `'ref'`   <!-- Rust -->
 
-    | `'regardless'`   <!--  -->
+    | `'regardless'`   <!-- WGSL -->
 
     | `'register'`   <!-- C++ -->
 
@@ -8391,7 +8391,7 @@ The following are reserved words:
 
     | `'static_cast'`   <!-- C++ -->
 
-    | `'std'`   <!--  -->
+    | `'std'`   <!-- WGSL -->
 
     | `'super'`   <!-- ECMAScript Rust Smalltalk -->
 
@@ -8407,7 +8407,7 @@ The following are reserved words:
 
     | `'try'`   <!-- C++ ECMAScript -->
 
-    | `'typedef'`   <!--  -->
+    | `'typedef'`   <!-- C++ WGSL -->
 
     | `'typeid'`   <!-- C++ -->
 
@@ -8415,15 +8415,15 @@ The following are reserved words:
 
     | `'typeof'`   <!-- ECMAScript Rust -->
 
-    | `'u16'`   <!--  -->
+    | `'u16'`   <!-- WGSL -->
 
-    | `'u64'`   <!--  -->
+    | `'u64'`   <!-- WGSL -->
 
-    | `'u8'`   <!--  -->
+    | `'u8'`   <!-- WGSL -->
 
     | `'union'`   <!-- C++ Rust -->
 
-    | `'unless'`   <!--  -->
+    | `'unless'`   <!-- WGSL -->
 
     | `'unsafe'`   <!-- Rust -->
 
@@ -8433,19 +8433,19 @@ The following are reserved words:
 
     | `'use'`   <!-- Rust -->
 
-    | `'using'`   <!--  -->
+    | `'using'`   <!-- C++ WGSL -->
 
-    | `'vec'`   <!--  -->
+    | `'vec'`   <!-- WGSL -->
 
     | `'virtual'`   <!-- C++ Rust -->
 
-    | `'void'`   <!--  -->
+    | `'void'`   <!-- C++ ECMAScript WGSL -->
 
     | `'volatile'`   <!-- C++ -->
 
     | `'wchar_t'`   <!-- C++ -->
 
-    | `'wgsl'`   <!--  -->
+    | `'wgsl'`   <!-- WGSL -->
 
     | `'where'`   <!-- Rust -->
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8217,15 +8217,19 @@ The following are reserved words:
 
     | `'alignof'`   <!-- C++ -->
 
-    | `'as'`   <!-- Rust -->
+    | `'as'`   <!-- ECMAScript2022 Rust -->
 
     | `'asm'`   <!-- C++ GLSL(reserved) WGSL -->
+
+    | `'async'`   <!-- ECMAScript2022 -->
 
     | `'atomic_uint'`   <!-- GLSL -->
 
     | `'attribute'`   <!-- GLSL -->
 
     | `'auto'`   <!-- C++ -->
+
+    | `'await'`   <!-- ECMAScript2022 -->
 
     | `'become'`   <!-- Rust -->
 
@@ -8243,7 +8247,7 @@ The following are reserved words:
 
     | `'cast'`   <!-- GLSL(reserved) -->
 
-    | `'catch'`   <!-- C++ ECMAScript -->
+    | `'catch'`   <!-- C++ ECMAScript2022 -->
 
     | `'centroid'`   <!-- GLSL -->
 
@@ -8255,7 +8259,7 @@ The following are reserved words:
 
     | `'char8_t'`   <!-- C++ -->
 
-    | `'class'`   <!-- C++ ECMAScript GLSL(reserved) -->
+    | `'class'`   <!-- C++ ECMAScript2022 GLSL(reserved) -->
 
     | `'co_await'`   <!-- C++ -->
 
@@ -8269,7 +8273,7 @@ The following are reserved words:
 
     | `'concept'`   <!-- C++ -->
 
-    | `'const'`   <!-- C++ ECMAScript Rust GLSL WGSL -->
+    | `'const'`   <!-- C++ ECMAScript2022 Rust GLSL WGSL -->
 
     | `'const_cast'`   <!-- C++ -->
 
@@ -8281,11 +8285,11 @@ The following are reserved words:
 
     | `'crate'`   <!-- Rust -->
 
-    | `'debugger'`   <!-- ECMAScript -->
+    | `'debugger'`   <!-- ECMAScript2022 -->
 
     | `'decltype'`   <!-- C++ -->
 
-    | `'delete'`   <!-- C++ ECMAScript -->
+    | `'delete'`   <!-- C++ ECMAScript2022 -->
 
     | `'demote'`   <!-- WGSL -->
 
@@ -8315,7 +8319,7 @@ The following are reserved words:
 
     | `'dmat4x4'`   <!-- GLSL -->
 
-    | `'do'`   <!-- C++ ECMAScript Rust GLSL WGSL -->
+    | `'do'`   <!-- C++ ECMAScript2022 Rust GLSL WGSL -->
 
     | `'double'`   <!-- C++ GLSL -->
 
@@ -8327,13 +8331,13 @@ The following are reserved words:
 
     | `'dynamic_cast'`   <!-- C++ -->
 
-    | `'enum'`   <!-- C++ ECMAScript Rust GLSL(reserved) WGSL -->
+    | `'enum'`   <!-- C++ ECMAScript2022 Rust GLSL(reserved) WGSL -->
 
     | `'explicit'`   <!-- C++ -->
 
-    | `'export'`   <!-- C++ C++ ECMAScript -->
+    | `'export'`   <!-- C++ C++ ECMAScript2022 -->
 
-    | `'extends'`   <!-- ECMAScript -->
+    | `'extends'`   <!-- ECMAScript2022 -->
 
     | `'extern'`   <!-- C++ Rust GLSL(reserved) -->
 
@@ -8347,7 +8351,7 @@ The following are reserved words:
 
     | `'final'`   <!-- Rust -->
 
-    | `'finally'`   <!-- ECMAScript -->
+    | `'finally'`   <!-- ECMAScript2022 -->
 
     | `'fixed'`   <!-- GLSL(reserved) -->
 
@@ -8357,11 +8361,15 @@ The following are reserved words:
 
     | `'friend'`   <!-- C++ -->
 
+    | `'from'`   <!-- ECMAScript2022 -->
+
     | `'fvec2'`   <!-- GLSL(reserved) -->
 
     | `'fvec3'`   <!-- GLSL(reserved) -->
 
     | `'fvec4'`   <!-- GLSL(reserved) -->
+
+    | `'get'`   <!-- ECMAScript2022 -->
 
     | `'goto'`   <!-- C++ GLSL(reserved) -->
 
@@ -8429,11 +8437,11 @@ The following are reserved words:
 
     | `'impl'`   <!-- Rust -->
 
-    | `'implements'`   <!-- ECMAScript -->
+    | `'implements'`   <!-- ECMAScript2022 -->
 
-    | `'import'`   <!-- C++ ECMAScript -->
+    | `'import'`   <!-- C++ ECMAScript2022 -->
 
-    | `'in'`   <!-- ECMAScript Rust GLSL -->
+    | `'in'`   <!-- ECMAScript2022 Rust GLSL -->
 
     | `'inline'`   <!-- C++ GLSL(reserved) -->
 
@@ -8441,11 +8449,11 @@ The following are reserved words:
 
     | `'input'`   <!-- GLSL(reserved) -->
 
-    | `'instanceof'`   <!-- ECMAScript -->
+    | `'instanceof'`   <!-- ECMAScript2022 -->
 
     | `'int'`   <!-- C++ GLSL -->
 
-    | `'interface'`   <!-- ECMAScript GLSL(reserved) -->
+    | `'interface'`   <!-- ECMAScript2022 GLSL(reserved) -->
 
     | `'invariant'`   <!-- GLSL -->
 
@@ -8525,6 +8533,8 @@ The following are reserved words:
 
     | `'mediump'`   <!-- GLSL -->
 
+    | `'meta'`   <!-- ECMAScript2022 -->
+
     | `'mod'`   <!-- Rust -->
 
     | `'module'`   <!-- C++ -->
@@ -8537,7 +8547,7 @@ The following are reserved words:
 
     | `'namespace'`   <!-- C++ GLSL(reserved) -->
 
-    | `'new'`   <!-- C++ ECMAScript -->
+    | `'new'`   <!-- C++ ECMAScript2022 -->
 
     | `'nil'`   <!-- Smalltalk -->
 
@@ -8547,9 +8557,11 @@ The following are reserved words:
 
     | `'noperspective'`   <!-- GLSL -->
 
-    | `'null'`   <!-- WGSL -->
+    | `'null'`   <!-- ECMAScript2022 WGSL -->
 
     | `'nullptr'`   <!-- C++ -->
+
+    | `'of'`   <!-- ECMAScript2022 -->
 
     | `'operator'`   <!-- C++ -->
 
@@ -8557,7 +8569,7 @@ The following are reserved words:
 
     | `'output'`   <!-- GLSL(reserved) -->
 
-    | `'package'`   <!-- ECMAScript -->
+    | `'package'`   <!-- ECMAScript2022 -->
 
     | `'partition'`   <!-- GLSL(reserved) -->
 
@@ -8571,11 +8583,11 @@ The following are reserved words:
 
     | `'priv'`   <!-- Rust -->
 
-    | `'protected'`   <!-- C++ ECMAScript -->
+    | `'protected'`   <!-- C++ ECMAScript2022 -->
 
     | `'pub'`   <!-- Rust -->
 
-    | `'public'`   <!-- C++ ECMAScript GLSL(reserved) -->
+    | `'public'`   <!-- C++ ECMAScript2022 GLSL(reserved) -->
 
     | `'readonly'`   <!-- GLSL -->
 
@@ -8637,6 +8649,8 @@ The following are reserved words:
 
     | `'self'`   <!-- Rust Smalltalk -->
 
+    | `'set'`   <!-- ECMAScript2022 -->
+
     | `'shared'`   <!-- GLSL -->
 
     | `'short'`   <!-- C++ GLSL(reserved) -->
@@ -8647,7 +8661,7 @@ The following are reserved words:
 
     | `'smooth'`   <!-- GLSL -->
 
-    | `'static'`   <!-- C++ ECMAScript Rust GLSL(reserved) -->
+    | `'static'`   <!-- C++ ECMAScript2022 Rust GLSL(reserved) -->
 
     | `'static_assert'`   <!-- C++ -->
 
@@ -8661,9 +8675,11 @@ The following are reserved words:
 
     | `'subroutine'`   <!-- GLSL -->
 
-    | `'super'`   <!-- ECMAScript Rust Smalltalk -->
+    | `'super'`   <!-- ECMAScript2022 Rust Smalltalk -->
 
     | `'superp'`   <!-- GLSL(reserved) -->
+
+    | `'target'`   <!-- ECMAScript2022 -->
 
     | `'template'`   <!-- C++ GLSL(reserved) -->
 
@@ -8689,15 +8705,15 @@ The following are reserved words:
 
     | `'textureCubeArray'`   <!-- GLSL -->
 
-    | `'this'`   <!-- C++ ECMAScript GLSL(reserved) -->
+    | `'this'`   <!-- C++ ECMAScript2022 GLSL(reserved) -->
 
     | `'thread_local'`   <!-- C++ -->
 
-    | `'throw'`   <!-- C++ ECMAScript -->
+    | `'throw'`   <!-- C++ ECMAScript2022 -->
 
     | `'trait'`   <!-- Rust -->
 
-    | `'try'`   <!-- C++ ECMAScript -->
+    | `'try'`   <!-- C++ ECMAScript2022 -->
 
     | `'typedef'`   <!-- C++ GLSL(reserved) WGSL -->
 
@@ -8705,7 +8721,7 @@ The following are reserved words:
 
     | `'typename'`   <!-- C++ -->
 
-    | `'typeof'`   <!-- ECMAScript Rust -->
+    | `'typeof'`   <!-- ECMAScript2022 Rust -->
 
     | `'u16'`   <!-- WGSL -->
 
@@ -8811,7 +8827,7 @@ The following are reserved words:
 
     | `'virtual'`   <!-- C++ Rust -->
 
-    | `'void'`   <!-- C++ ECMAScript GLSL WGSL -->
+    | `'void'`   <!-- C++ ECMAScript2022 GLSL WGSL -->
 
     | `'volatile'`   <!-- C++ GLSL -->
 
@@ -8821,11 +8837,11 @@ The following are reserved words:
 
     | `'where'`   <!-- Rust -->
 
-    | `'with'`   <!-- ECMAScript -->
+    | `'with'`   <!-- ECMAScript2022 -->
 
     | `'writeonly'`   <!-- GLSL -->
 
-    | `'yield'`   <!-- ECMAScript Rust -->
+    | `'yield'`   <!-- ECMAScript2022 Rust -->
 
 </div>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8207,7 +8207,91 @@ The following are reserved words:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>_reserved</dfn> :
 
+    | `'AppendStructuredBuffer'`   <!-- HLSL -->
+
+    | `'BlendState'`   <!-- HLSL -->
+
+    | `'Buffer'`   <!-- HLSL -->
+
+    | `'ByteAddressBuffer'`   <!-- HLSL -->
+
+    | `'CompileShader'`   <!-- HLSL -->
+
+    | `'ComputeShader'`   <!-- HLSL -->
+
+    | `'ConsumeStructuredBuffer'`   <!-- HLSL -->
+
+    | `'DepthStencilState'`   <!-- HLSL -->
+
+    | `'DepthStencilView'`   <!-- HLSL -->
+
+    | `'DomainShader'`   <!-- HLSL -->
+
+    | `'GeometryShader'`   <!-- HLSL -->
+
+    | `'Hullshader'`   <!-- HLSL -->
+
+    | `'InputPatch'`   <!-- HLSL -->
+
+    | `'LineStream'`   <!-- HLSL -->
+
+    | `'NULL'`   <!-- HLSL -->
+
+    | `'OutputPatch'`   <!-- HLSL -->
+
+    | `'PixelShader'`   <!-- HLSL -->
+
+    | `'PointStream'`   <!-- HLSL -->
+
+    | `'RWBuffer'`   <!-- HLSL -->
+
+    | `'RWByteAddressBuffer'`   <!-- HLSL -->
+
+    | `'RWStructuredBuffer'`   <!-- HLSL -->
+
+    | `'RWTexture1D'`   <!-- HLSL -->
+
+    | `'RWTexture1DArray'`   <!-- HLSL -->
+
+    | `'RWTexture2D'`   <!-- HLSL -->
+
+    | `'RWTexture2DArray'`   <!-- HLSL -->
+
+    | `'RWTexture3D'`   <!-- HLSL -->
+
+    | `'RasterizerState'`   <!-- HLSL -->
+
+    | `'RenderTargetView'`   <!-- HLSL -->
+
+    | `'SamplerComparisonState'`   <!-- HLSL -->
+
+    | `'SamplerState'`   <!-- HLSL -->
+
     | `'Self'`   <!-- Rust -->
+
+    | `'StructuredBuffer'`   <!-- HLSL -->
+
+    | `'Texture1D'`   <!-- HLSL -->
+
+    | `'Texture1DArray'`   <!-- HLSL -->
+
+    | `'Texture2D'`   <!-- HLSL -->
+
+    | `'Texture2DArray'`   <!-- HLSL -->
+
+    | `'Texture2DMS'`   <!-- HLSL -->
+
+    | `'Texture2DMSArray'`   <!-- HLSL -->
+
+    | `'Texture3D'`   <!-- HLSL -->
+
+    | `'TextureCube'`   <!-- HLSL -->
+
+    | `'TextureCubeArray'`   <!-- HLSL -->
+
+    | `'TriangleStream'`   <!-- HLSL -->
+
+    | `'VertexShader'`   <!-- HLSL -->
 
     | `'abstract'`   <!-- Rust -->
 
@@ -8219,7 +8303,9 @@ The following are reserved words:
 
     | `'as'`   <!-- ECMAScript2022 Rust -->
 
-    | `'asm'`   <!-- C++ GLSL(reserved) WGSL -->
+    | `'asm'`   <!-- C++ HLSL GLSL(reserved) WGSL -->
+
+    | `'asm_fragment'`   <!-- HLSL -->
 
     | `'async'`   <!-- ECMAScript2022 -->
 
@@ -8235,6 +8321,46 @@ The following are reserved words:
 
     | `'bf16'`   <!-- WGSL -->
 
+    | `'bool1'`   <!-- HLSL -->
+
+    | `'bool1x1'`   <!-- HLSL -->
+
+    | `'bool1x2'`   <!-- HLSL -->
+
+    | `'bool1x3'`   <!-- HLSL -->
+
+    | `'bool1x4'`   <!-- HLSL -->
+
+    | `'bool2'`   <!-- HLSL -->
+
+    | `'bool2x1'`   <!-- HLSL -->
+
+    | `'bool2x2'`   <!-- HLSL -->
+
+    | `'bool2x3'`   <!-- HLSL -->
+
+    | `'bool2x4'`   <!-- HLSL -->
+
+    | `'bool3'`   <!-- HLSL -->
+
+    | `'bool3x1'`   <!-- HLSL -->
+
+    | `'bool3x2'`   <!-- HLSL -->
+
+    | `'bool3x3'`   <!-- HLSL -->
+
+    | `'bool3x4'`   <!-- HLSL -->
+
+    | `'bool4'`   <!-- HLSL -->
+
+    | `'bool4x1'`   <!-- HLSL -->
+
+    | `'bool4x2'`   <!-- HLSL -->
+
+    | `'bool4x3'`   <!-- HLSL -->
+
+    | `'bool4x4'`   <!-- HLSL -->
+
     | `'box'`   <!-- Rust -->
 
     | `'buffer'`   <!-- GLSL -->
@@ -8249,7 +8375,9 @@ The following are reserved words:
 
     | `'catch'`   <!-- C++ ECMAScript2022 -->
 
-    | `'centroid'`   <!-- GLSL -->
+    | `'cbuffer'`   <!-- HLSL -->
+
+    | `'centroid'`   <!-- HLSL GLSL -->
 
     | `'char'`   <!-- C++ -->
 
@@ -8259,7 +8387,7 @@ The following are reserved words:
 
     | `'char8_t'`   <!-- C++ -->
 
-    | `'class'`   <!-- C++ ECMAScript2022 GLSL(reserved) -->
+    | `'class'`   <!-- C++ ECMAScript2022 HLSL GLSL(reserved) -->
 
     | `'co_await'`   <!-- C++ -->
 
@@ -8269,11 +8397,17 @@ The following are reserved words:
 
     | `'coherent'`   <!-- GLSL -->
 
+    | `'column_major'`   <!-- HLSL -->
+
     | `'common'`   <!-- GLSL(reserved) -->
+
+    | `'compile'`   <!-- HLSL -->
+
+    | `'compile_fragment'`   <!-- HLSL -->
 
     | `'concept'`   <!-- C++ -->
 
-    | `'const'`   <!-- C++ ECMAScript2022 Rust GLSL WGSL -->
+    | `'const'`   <!-- C++ ECMAScript2022 Rust HLSL GLSL WGSL -->
 
     | `'const_cast'`   <!-- C++ -->
 
@@ -8319,9 +8453,9 @@ The following are reserved words:
 
     | `'dmat4x4'`   <!-- GLSL -->
 
-    | `'do'`   <!-- C++ ECMAScript2022 Rust GLSL WGSL -->
+    | `'do'`   <!-- C++ ECMAScript2022 Rust HLSL GLSL WGSL -->
 
-    | `'double'`   <!-- C++ GLSL -->
+    | `'double'`   <!-- C++ HLSL GLSL -->
 
     | `'dvec2'`   <!-- GLSL -->
 
@@ -8329,17 +8463,19 @@ The following are reserved words:
 
     | `'dvec4'`   <!-- GLSL -->
 
+    | `'dword'`   <!-- HLSL -->
+
     | `'dynamic_cast'`   <!-- C++ -->
 
     | `'enum'`   <!-- C++ ECMAScript2022 Rust GLSL(reserved) WGSL -->
 
     | `'explicit'`   <!-- C++ -->
 
-    | `'export'`   <!-- C++ C++ ECMAScript2022 -->
+    | `'export'`   <!-- C++ C++ ECMAScript2022 HLSL -->
 
     | `'extends'`   <!-- ECMAScript2022 -->
 
-    | `'extern'`   <!-- C++ Rust GLSL(reserved) -->
+    | `'extern'`   <!-- C++ Rust HLSL GLSL(reserved) -->
 
     | `'external'`   <!-- GLSL(reserved) -->
 
@@ -8357,7 +8493,47 @@ The following are reserved words:
 
     | `'flat'`   <!-- GLSL -->
 
-    | `'float'`   <!-- C++ GLSL -->
+    | `'float'`   <!-- C++ HLSL HLSL GLSL -->
+
+    | `'float1'`   <!-- HLSL -->
+
+    | `'float1x1'`   <!-- HLSL -->
+
+    | `'float1x2'`   <!-- HLSL -->
+
+    | `'float1x3'`   <!-- HLSL -->
+
+    | `'float1x4'`   <!-- HLSL -->
+
+    | `'float2'`   <!-- HLSL -->
+
+    | `'float2x1'`   <!-- HLSL -->
+
+    | `'float2x2'`   <!-- HLSL -->
+
+    | `'float2x3'`   <!-- HLSL -->
+
+    | `'float2x4'`   <!-- HLSL -->
+
+    | `'float3'`   <!-- HLSL -->
+
+    | `'float3x1'`   <!-- HLSL -->
+
+    | `'float3x2'`   <!-- HLSL -->
+
+    | `'float3x3'`   <!-- HLSL -->
+
+    | `'float3x4'`   <!-- HLSL -->
+
+    | `'float4'`   <!-- HLSL -->
+
+    | `'float4x1'`   <!-- HLSL -->
+
+    | `'float4x2'`   <!-- HLSL -->
+
+    | `'float4x3'`   <!-- HLSL -->
+
+    | `'float4x4'`   <!-- HLSL -->
 
     | `'friend'`   <!-- C++ -->
 
@@ -8369,11 +8545,15 @@ The following are reserved words:
 
     | `'fvec4'`   <!-- GLSL(reserved) -->
 
+    | `'fxgroup'`   <!-- HLSL -->
+
     | `'get'`   <!-- ECMAScript2022 -->
 
     | `'goto'`   <!-- C++ GLSL(reserved) -->
 
-    | `'half'`   <!-- GLSL(reserved) -->
+    | `'groupshared'`   <!-- HLSL -->
+
+    | `'half'`   <!-- HLSL GLSL(reserved) -->
 
     | `'handle'`   <!-- WGSL -->
 
@@ -8441,19 +8621,59 @@ The following are reserved words:
 
     | `'import'`   <!-- C++ ECMAScript2022 -->
 
-    | `'in'`   <!-- ECMAScript2022 Rust GLSL -->
+    | `'in'`   <!-- ECMAScript2022 Rust HLSL GLSL -->
 
-    | `'inline'`   <!-- C++ GLSL(reserved) -->
+    | `'inline'`   <!-- C++ HLSL GLSL(reserved) -->
 
-    | `'inout'`   <!-- GLSL -->
+    | `'inout'`   <!-- HLSL GLSL -->
 
     | `'input'`   <!-- GLSL(reserved) -->
 
     | `'instanceof'`   <!-- ECMAScript2022 -->
 
-    | `'int'`   <!-- C++ GLSL -->
+    | `'int'`   <!-- C++ HLSL HLSL GLSL -->
 
-    | `'interface'`   <!-- ECMAScript2022 GLSL(reserved) -->
+    | `'int1'`   <!-- HLSL -->
+
+    | `'int1x1'`   <!-- HLSL -->
+
+    | `'int1x2'`   <!-- HLSL -->
+
+    | `'int1x3'`   <!-- HLSL -->
+
+    | `'int1x4'`   <!-- HLSL -->
+
+    | `'int2'`   <!-- HLSL -->
+
+    | `'int2x1'`   <!-- HLSL -->
+
+    | `'int2x2'`   <!-- HLSL -->
+
+    | `'int2x3'`   <!-- HLSL -->
+
+    | `'int2x4'`   <!-- HLSL -->
+
+    | `'int3'`   <!-- HLSL -->
+
+    | `'int3x1'`   <!-- HLSL -->
+
+    | `'int3x2'`   <!-- HLSL -->
+
+    | `'int3x3'`   <!-- HLSL -->
+
+    | `'int3x4'`   <!-- HLSL -->
+
+    | `'int4'`   <!-- HLSL -->
+
+    | `'int4x1'`   <!-- HLSL -->
+
+    | `'int4x2'`   <!-- HLSL -->
+
+    | `'int4x3'`   <!-- HLSL -->
+
+    | `'int4x4'`   <!-- HLSL -->
+
+    | `'interface'`   <!-- ECMAScript2022 HLSL GLSL(reserved) -->
 
     | `'invariant'`   <!-- GLSL -->
 
@@ -8513,6 +8733,12 @@ The following are reserved words:
 
     | `'layout'`   <!-- GLSL -->
 
+    | `'line'`   <!-- HLSL -->
+
+    | `'lineadj'`   <!-- HLSL -->
+
+    | `'linear'`   <!-- HLSL -->
+
     | `'long'`   <!-- C++ GLSL(reserved) -->
 
     | `'lowp'`   <!-- GLSL -->
@@ -8531,9 +8757,221 @@ The following are reserved words:
 
     | `'match'`   <!-- Rust -->
 
+    | `'matrix'`   <!-- HLSL -->
+
     | `'mediump'`   <!-- GLSL -->
 
     | `'meta'`   <!-- ECMAScript2022 -->
+
+    | `'min10float'`   <!-- HLSL HLSL -->
+
+    | `'min10float1'`   <!-- HLSL -->
+
+    | `'min10float1x1'`   <!-- HLSL -->
+
+    | `'min10float1x2'`   <!-- HLSL -->
+
+    | `'min10float1x3'`   <!-- HLSL -->
+
+    | `'min10float1x4'`   <!-- HLSL -->
+
+    | `'min10float2'`   <!-- HLSL -->
+
+    | `'min10float2x1'`   <!-- HLSL -->
+
+    | `'min10float2x2'`   <!-- HLSL -->
+
+    | `'min10float2x3'`   <!-- HLSL -->
+
+    | `'min10float2x4'`   <!-- HLSL -->
+
+    | `'min10float3'`   <!-- HLSL -->
+
+    | `'min10float3x1'`   <!-- HLSL -->
+
+    | `'min10float3x2'`   <!-- HLSL -->
+
+    | `'min10float3x3'`   <!-- HLSL -->
+
+    | `'min10float3x4'`   <!-- HLSL -->
+
+    | `'min10float4'`   <!-- HLSL -->
+
+    | `'min10float4x1'`   <!-- HLSL -->
+
+    | `'min10float4x2'`   <!-- HLSL -->
+
+    | `'min10float4x3'`   <!-- HLSL -->
+
+    | `'min10float4x4'`   <!-- HLSL -->
+
+    | `'min12int'`   <!-- HLSL HLSL -->
+
+    | `'min12int1'`   <!-- HLSL -->
+
+    | `'min12int1x1'`   <!-- HLSL -->
+
+    | `'min12int1x2'`   <!-- HLSL -->
+
+    | `'min12int1x3'`   <!-- HLSL -->
+
+    | `'min12int1x4'`   <!-- HLSL -->
+
+    | `'min12int2'`   <!-- HLSL -->
+
+    | `'min12int2x1'`   <!-- HLSL -->
+
+    | `'min12int2x2'`   <!-- HLSL -->
+
+    | `'min12int2x3'`   <!-- HLSL -->
+
+    | `'min12int2x4'`   <!-- HLSL -->
+
+    | `'min12int3'`   <!-- HLSL -->
+
+    | `'min12int3x1'`   <!-- HLSL -->
+
+    | `'min12int3x2'`   <!-- HLSL -->
+
+    | `'min12int3x3'`   <!-- HLSL -->
+
+    | `'min12int3x4'`   <!-- HLSL -->
+
+    | `'min12int4'`   <!-- HLSL -->
+
+    | `'min12int4x1'`   <!-- HLSL -->
+
+    | `'min12int4x2'`   <!-- HLSL -->
+
+    | `'min12int4x3'`   <!-- HLSL -->
+
+    | `'min12int4x4'`   <!-- HLSL -->
+
+    | `'min16float'`   <!-- HLSL HLSL -->
+
+    | `'min16float1'`   <!-- HLSL -->
+
+    | `'min16float1x1'`   <!-- HLSL -->
+
+    | `'min16float1x2'`   <!-- HLSL -->
+
+    | `'min16float1x3'`   <!-- HLSL -->
+
+    | `'min16float1x4'`   <!-- HLSL -->
+
+    | `'min16float2'`   <!-- HLSL -->
+
+    | `'min16float2x1'`   <!-- HLSL -->
+
+    | `'min16float2x2'`   <!-- HLSL -->
+
+    | `'min16float2x3'`   <!-- HLSL -->
+
+    | `'min16float2x4'`   <!-- HLSL -->
+
+    | `'min16float3'`   <!-- HLSL -->
+
+    | `'min16float3x1'`   <!-- HLSL -->
+
+    | `'min16float3x2'`   <!-- HLSL -->
+
+    | `'min16float3x3'`   <!-- HLSL -->
+
+    | `'min16float3x4'`   <!-- HLSL -->
+
+    | `'min16float4'`   <!-- HLSL -->
+
+    | `'min16float4x1'`   <!-- HLSL -->
+
+    | `'min16float4x2'`   <!-- HLSL -->
+
+    | `'min16float4x3'`   <!-- HLSL -->
+
+    | `'min16float4x4'`   <!-- HLSL -->
+
+    | `'min16int'`   <!-- HLSL HLSL -->
+
+    | `'min16int1'`   <!-- HLSL -->
+
+    | `'min16int1x1'`   <!-- HLSL -->
+
+    | `'min16int1x2'`   <!-- HLSL -->
+
+    | `'min16int1x3'`   <!-- HLSL -->
+
+    | `'min16int1x4'`   <!-- HLSL -->
+
+    | `'min16int2'`   <!-- HLSL -->
+
+    | `'min16int2x1'`   <!-- HLSL -->
+
+    | `'min16int2x2'`   <!-- HLSL -->
+
+    | `'min16int2x3'`   <!-- HLSL -->
+
+    | `'min16int2x4'`   <!-- HLSL -->
+
+    | `'min16int3'`   <!-- HLSL -->
+
+    | `'min16int3x1'`   <!-- HLSL -->
+
+    | `'min16int3x2'`   <!-- HLSL -->
+
+    | `'min16int3x3'`   <!-- HLSL -->
+
+    | `'min16int3x4'`   <!-- HLSL -->
+
+    | `'min16int4'`   <!-- HLSL -->
+
+    | `'min16int4x1'`   <!-- HLSL -->
+
+    | `'min16int4x2'`   <!-- HLSL -->
+
+    | `'min16int4x3'`   <!-- HLSL -->
+
+    | `'min16int4x4'`   <!-- HLSL -->
+
+    | `'min16uint'`   <!-- HLSL HLSL -->
+
+    | `'min16uint1'`   <!-- HLSL -->
+
+    | `'min16uint1x1'`   <!-- HLSL -->
+
+    | `'min16uint1x2'`   <!-- HLSL -->
+
+    | `'min16uint1x3'`   <!-- HLSL -->
+
+    | `'min16uint1x4'`   <!-- HLSL -->
+
+    | `'min16uint2'`   <!-- HLSL -->
+
+    | `'min16uint2x1'`   <!-- HLSL -->
+
+    | `'min16uint2x2'`   <!-- HLSL -->
+
+    | `'min16uint2x3'`   <!-- HLSL -->
+
+    | `'min16uint2x4'`   <!-- HLSL -->
+
+    | `'min16uint3'`   <!-- HLSL -->
+
+    | `'min16uint3x1'`   <!-- HLSL -->
+
+    | `'min16uint3x2'`   <!-- HLSL -->
+
+    | `'min16uint3x3'`   <!-- HLSL -->
+
+    | `'min16uint3x4'`   <!-- HLSL -->
+
+    | `'min16uint4'`   <!-- HLSL -->
+
+    | `'min16uint4x1'`   <!-- HLSL -->
+
+    | `'min16uint4x2'`   <!-- HLSL -->
+
+    | `'min16uint4x3'`   <!-- HLSL -->
+
+    | `'min16uint4x4'`   <!-- HLSL -->
 
     | `'mod'`   <!-- Rust -->
 
@@ -8545,7 +8983,7 @@ The following are reserved words:
 
     | `'mutable'`   <!-- C++ -->
 
-    | `'namespace'`   <!-- C++ GLSL(reserved) -->
+    | `'namespace'`   <!-- C++ HLSL GLSL(reserved) -->
 
     | `'new'`   <!-- C++ ECMAScript2022 -->
 
@@ -8555,7 +8993,9 @@ The following are reserved words:
 
     | `'noinline'`   <!-- GLSL(reserved) -->
 
-    | `'noperspective'`   <!-- GLSL -->
+    | `'nointerpolation'`   <!-- HLSL -->
+
+    | `'noperspective'`   <!-- HLSL GLSL -->
 
     | `'null'`   <!-- ECMAScript2022 WGSL -->
 
@@ -8565,17 +9005,25 @@ The following are reserved words:
 
     | `'operator'`   <!-- C++ -->
 
-    | `'out'`   <!-- GLSL -->
+    | `'out'`   <!-- HLSL GLSL -->
 
     | `'output'`   <!-- GLSL(reserved) -->
 
     | `'package'`   <!-- ECMAScript2022 -->
 
+    | `'packoffset'`   <!-- HLSL -->
+
     | `'partition'`   <!-- GLSL(reserved) -->
+
+    | `'pass'`   <!-- HLSL -->
 
     | `'patch'`   <!-- GLSL -->
 
-    | `'precise'`   <!-- GLSL -->
+    | `'pixelfragment'`   <!-- HLSL -->
+
+    | `'point'`   <!-- HLSL -->
+
+    | `'precise'`   <!-- HLSL GLSL -->
 
     | `'precision'`   <!-- GLSL -->
 
@@ -8595,7 +9043,7 @@ The following are reserved words:
 
     | `'regardless'`   <!-- WGSL -->
 
-    | `'register'`   <!-- C++ -->
+    | `'register'`   <!-- C++ HLSL -->
 
     | `'reinterpret_cast'`   <!-- C++ -->
 
@@ -8605,7 +9053,11 @@ The following are reserved words:
 
     | `'restrict'`   <!-- GLSL -->
 
-    | `'sample'`   <!-- GLSL -->
+    | `'row_major'`   <!-- HLSL -->
+
+    | `'samper'`   <!-- HLSL -->
+
+    | `'sample'`   <!-- HLSL GLSL -->
 
     | `'sampler1D'`   <!-- GLSL -->
 
@@ -8651,7 +9103,7 @@ The following are reserved words:
 
     | `'set'`   <!-- ECMAScript2022 -->
 
-    | `'shared'`   <!-- GLSL -->
+    | `'shared'`   <!-- HLSL GLSL -->
 
     | `'short'`   <!-- C++ GLSL(reserved) -->
 
@@ -8661,13 +9113,21 @@ The following are reserved words:
 
     | `'smooth'`   <!-- GLSL -->
 
-    | `'static'`   <!-- C++ ECMAScript2022 Rust GLSL(reserved) -->
+    | `'snorm'`   <!-- HLSL -->
+
+    | `'stateblock'`   <!-- HLSL -->
+
+    | `'stateblock_state'`   <!-- HLSL -->
+
+    | `'static'`   <!-- C++ ECMAScript2022 Rust HLSL GLSL(reserved) -->
 
     | `'static_assert'`   <!-- C++ -->
 
     | `'static_cast'`   <!-- C++ -->
 
     | `'std'`   <!-- WGSL -->
+
+    | `'string'`   <!-- HLSL -->
 
     | `'subpassInput'`   <!-- GLSL -->
 
@@ -8681,7 +9141,17 @@ The following are reserved words:
 
     | `'target'`   <!-- ECMAScript2022 -->
 
+    | `'tbuffer'`   <!-- HLSL -->
+
+    | `'technique'`   <!-- HLSL -->
+
+    | `'technique10'`   <!-- HLSL -->
+
+    | `'technique11'`   <!-- HLSL -->
+
     | `'template'`   <!-- C++ GLSL(reserved) -->
+
+    | `'texture'`   <!-- HLSL HLSL -->
 
     | `'texture1D'`   <!-- GLSL -->
 
@@ -8713,9 +9183,13 @@ The following are reserved words:
 
     | `'trait'`   <!-- Rust -->
 
+    | `'triangle'`   <!-- HLSL -->
+
+    | `'triangleadj'`   <!-- HLSL -->
+
     | `'try'`   <!-- C++ ECMAScript2022 -->
 
-    | `'typedef'`   <!-- C++ GLSL(reserved) WGSL -->
+    | `'typedef'`   <!-- C++ HLSL GLSL(reserved) WGSL -->
 
     | `'typeid'`   <!-- C++ -->
 
@@ -8751,15 +9225,57 @@ The following are reserved words:
 
     | `'uimageCubeArray'`   <!-- GLSL -->
 
-    | `'uint'`   <!-- GLSL -->
+    | `'uint'`   <!-- HLSL HLSL GLSL -->
+
+    | `'uint1'`   <!-- HLSL -->
+
+    | `'uint1x1'`   <!-- HLSL -->
+
+    | `'uint1x2'`   <!-- HLSL -->
+
+    | `'uint1x3'`   <!-- HLSL -->
+
+    | `'uint1x4'`   <!-- HLSL -->
+
+    | `'uint2'`   <!-- HLSL -->
+
+    | `'uint2x1'`   <!-- HLSL -->
+
+    | `'uint2x2'`   <!-- HLSL -->
+
+    | `'uint2x3'`   <!-- HLSL -->
+
+    | `'uint2x4'`   <!-- HLSL -->
+
+    | `'uint3'`   <!-- HLSL -->
+
+    | `'uint3x1'`   <!-- HLSL -->
+
+    | `'uint3x2'`   <!-- HLSL -->
+
+    | `'uint3x3'`   <!-- HLSL -->
+
+    | `'uint3x4'`   <!-- HLSL -->
+
+    | `'uint4'`   <!-- HLSL -->
+
+    | `'uint4x1'`   <!-- HLSL -->
+
+    | `'uint4x2'`   <!-- HLSL -->
+
+    | `'uint4x3'`   <!-- HLSL -->
+
+    | `'uint4x4'`   <!-- HLSL -->
 
     | `'union'`   <!-- C++ Rust GLSL(reserved) -->
 
     | `'unless'`   <!-- WGSL -->
 
+    | `'unorm'`   <!-- HLSL -->
+
     | `'unsafe'`   <!-- Rust -->
 
-    | `'unsigned'`   <!-- C++ GLSL(reserved) -->
+    | `'unsigned'`   <!-- C++ HLSL GLSL(reserved) -->
 
     | `'unsized'`   <!-- Rust -->
 
@@ -8825,11 +9341,15 @@ The following are reserved words:
 
     | `'vec'`   <!-- WGSL -->
 
+    | `'vector'`   <!-- HLSL -->
+
+    | `'vertexfragment'`   <!-- HLSL -->
+
     | `'virtual'`   <!-- C++ Rust -->
 
-    | `'void'`   <!-- C++ ECMAScript2022 GLSL WGSL -->
+    | `'void'`   <!-- C++ ECMAScript2022 HLSL GLSL WGSL -->
 
-    | `'volatile'`   <!-- C++ GLSL -->
+    | `'volatile'`   <!-- C++ HLSL GLSL -->
 
     | `'wchar_t'`   <!-- C++ -->
 

--- a/wgsl/keywords
+++ b/wgsl/keywords
@@ -1,10 +1,11 @@
 #!/usr/bin/env perl
+use strict;
 
 # A script to print the contents of a grammar rule for a list
 # of reserved words.
 
 # C++ keywords
-# Extracted from working draft at https://eel.is/c++draft/ 
+# Extracted from working draft at https://eel.is/c++draft/
 #  https://eel.is/c++draft/gram.lex#nt:keyword
 #   "Any identifier listed in Table 5" plus import, module, export
 #        https://eel.is/c++draft/tab:lex.key
@@ -168,10 +169,10 @@ my @smalltalk = qw(
 
 
 # ECMAScript
-#  https://262.ecma-international.org/5.1/#sec-7.6.1.1 
+#  https://262.ecma-international.org/5.1/#sec-7.6.1.1
 # Keywords, Reserved, FutureReserved
 
-my @ecmascript = qw(
+my @ecmascript_5_1 = qw(
     break
     case
     catch
@@ -219,6 +220,18 @@ public
 static
 yield
 
+);
+
+# https://tc39.es/ecma262/ retrieved 2022-02-24
+my @ecmascript_2022 = qw(
+break case catch class const continue debugger default delete
+do else enum export extends false finally for function if import
+in instanceof new null return super switch this throw true try
+typeof var void while with
+
+await yield
+let static implements interface package private protected public
+as async from get meta of set target
 );
 
 # GLSL 4.6
@@ -420,7 +433,7 @@ workgroup
 
 
 # Deliberately reserved by WGSL
-@wgsl_reserved = qw(
+my @wgsl_reserved = qw(
 asm
 bf16
 const
@@ -466,7 +479,7 @@ sub add_from($@) {
 }
 
 add_from('C++', @cpp);
-add_from('ECMAScript', @ecmascript);
+add_from('ECMAScript2022', @ecmascript_2022);
 add_from('Rust', @rust);
 add_from('Smalltalk', @smalltalk);
 add_from('GLSL', @glsl);
@@ -474,7 +487,7 @@ add_from('GLSL(reserved)', @glsl_reserved);
 add_from('WGSL', @wgsl_reserved);
 
 # Remove keywords already used in WGSL.
-foreach my $word (@wgsl) { 
+foreach my $word (@wgsl) {
   delete $words{$word};
 }
 

--- a/wgsl/keywords
+++ b/wgsl/keywords
@@ -322,33 +322,33 @@ sampler3DRect
 # https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-appendix-keywords
 # retrieved 2022-02-24
 my @hlsl = qw(
-AppendStructuredBuffer, asm, asm_fragment
-BlendState, bool, break, Buffer, ByteAddressBuffer
-case, cbuffer, centroid, class, column_major, compile, compile_fragment, CompileShader, const, continue, ComputeShader, ConsumeStructuredBuffer
-default, DepthStencilState, DepthStencilView, discard, do, double, DomainShader, dword
-else, export, extern
-false, float, for, fxgroup
-GeometryShader, groupshared
-half, Hullshader
-if, in, inline, inout, InputPatch, int, interface
-line, lineadj, linear, LineStream
-matrix, min16float, min10float, min16int, min12int, min16uint
-namespace, nointerpolation, noperspective, NULL
-out, OutputPatch
-packoffset, pass, pixelfragment, PixelShader, point, PointStream, precise
-RasterizerState, RenderTargetView, return, register, row_major, RWBuffer, RWByteAddressBuffer, RWStructuredBuffer, RWTexture1D, RWTexture1DArray, RWTexture2D, RWTexture2DArray, RWTexture3D
-sample, sampler, SamplerState, SamplerComparisonState, shared, snorm, stateblock, stateblock_state, static, string, struct, switch, StructuredBuffer
-tbuffer, technique, technique10, technique11, texture, Texture1D, Texture1DArray, Texture2D, Texture2DArray, Texture2DMS, Texture2DMSArray, Texture3D, TextureCube, TextureCubeArray, true, typedef, triangle, triangleadj, TriangleStream
-uint, uniform, unorm, unsigned
-vector, vertexfragment, VertexShader, void, volatile
+AppendStructuredBuffer asm asm_fragment
+BlendState bool break Buffer ByteAddressBuffer
+case cbuffer centroid class column_major compile compile_fragment CompileShader const continue ComputeShader ConsumeStructuredBuffer
+default DepthStencilState DepthStencilView discard do double DomainShader dword
+else export extern
+false float for fxgroup
+GeometryShader groupshared
+half Hullshader
+if in inline inout InputPatch int interface
+line lineadj linear LineStream
+matrix min16float min10float min16int min12int min16uint
+namespace nointerpolation noperspective NULL
+out OutputPatch
+packoffset pass pixelfragment PixelShader point PointStream precise
+RasterizerState RenderTargetView return register row_major RWBuffer RWByteAddressBuffer RWStructuredBuffer RWTexture1D RWTexture1DArray RWTexture2D RWTexture2DArray RWTexture3D
+sample sampler SamplerState SamplerComparisonState shared snorm stateblock stateblock_state static string struct switch StructuredBuffer
+tbuffer technique technique10 technique11 texture Texture1D Texture1DArray Texture2D Texture2DArray Texture2DMS Texture2DMSArray Texture3D TextureCube TextureCubeArray true typedef triangle triangleadj TriangleStream
+uint uniform unorm unsigned
+vector vertexfragment VertexShader void volatile
 while
 texture
 samper
 );
 
-foreach my $type (qw(float, int, uint, bool
-  min10float, min16float
-  min12int, min16int
+foreach my $type (qw(float int uint bool
+  min10float min16float
+  min12int min16int
   min16uint)) {
   push @hlsl, $type;
   foreach my $i (qw(1 2 3 4)) {
@@ -356,7 +356,7 @@ foreach my $type (qw(float, int, uint, bool
   }
   foreach my $row (qw(1 2 3 4)) {
     foreach my $col (qw(1 2 3 4)) {
-      push @hlsl, "$type$row$col";
+      push @hlsl, "$type${row}x$col";
     }
   }
 }
@@ -482,6 +482,7 @@ add_from('C++', @cpp);
 add_from('ECMAScript2022', @ecmascript_2022);
 add_from('Rust', @rust);
 add_from('Smalltalk', @smalltalk);
+add_from('HLSL', @hlsl);
 add_from('GLSL', @glsl);
 add_from('GLSL(reserved)', @glsl_reserved);
 add_from('WGSL', @wgsl_reserved);

--- a/wgsl/keywords
+++ b/wgsl/keywords
@@ -1,0 +1,359 @@
+#!/usr/bin/env perl
+
+# A script to print the contents of a grammar rule for a list
+# of reserved words.
+
+# C++ keywords
+# Extracted from working draft at https://eel.is/c++draft/ 
+#  https://eel.is/c++draft/gram.lex#nt:keyword
+#   "Any identifier listed in Table 5" plus import, module, export
+#        https://eel.is/c++draft/tab:lex.key
+#
+
+my  @cpp = qw(
+export
+import
+module
+
+alignas
+alignof
+asm
+auto
+bool
+break
+case
+catch
+char
+char16_t
+char32_t
+char8_t
+class
+co_await
+co_return
+co_yield
+concept
+const
+const_cast
+consteval
+constexpr
+constinit
+continue
+decltype
+default
+delete
+do
+double
+dynamic_cast
+else
+enum
+explicit
+export
+extern
+false
+float
+for
+friend
+goto
+if
+inline
+int
+long
+mutable
+namespace
+new
+noexcept
+nullptr
+operator
+private
+protected
+public
+register
+reinterpret_cast
+requires
+return
+short
+signed
+sizeof
+static
+static_assert
+static_cast
+struct
+switch
+template
+this
+thread_local
+throw
+true
+try
+typedef
+typeid
+typename
+union
+unsigned
+using
+virtual
+void
+volatile
+wchar_t
+while
+);
+
+# Rust
+# https://doc.rust-lang.org/reference/keywords.html#reserved-keywords
+# We include strict, reserved, and weak
+# Excludes 'strict because it starts with a single quote.
+
+my @rust = qw(
+  as
+  break
+  const
+  continue
+  crate
+  else
+  enum
+  extern
+  false
+  fn
+  for
+  if
+  impl
+  in
+  let
+  loop
+  match
+  mod
+  move
+  mut
+  pub
+  ref
+  return
+  self
+  Self
+  static
+  struct
+  super
+  trait
+  true
+  type
+  unsafe
+  use
+  where
+  while
+
+  abstract
+  become
+  box
+  do
+  final
+  macro
+  override
+  priv
+  typeof
+  unsized
+  virtual
+  yield
+
+  macro_rules
+  union
+);
+
+
+my @smalltalk = qw(
+  nil
+  self
+  super
+  true
+  false );
+
+
+
+# ECMAScript
+#  https://262.ecma-international.org/5.1/#sec-7.6.1.1 
+# Keywords, Reserved, FutureReserved
+
+my @ecmascript = qw(
+    break
+    case
+    catch
+    continue
+    debugger
+    default
+    delete
+    do
+    else
+    finally
+    for
+    function
+    if
+    in
+    instanceof
+    new
+    return
+    switch
+    this
+    throw
+    try
+    typeof
+    var
+    void
+    while
+    with
+
+
+class
+const
+enum
+export
+extends
+import
+super
+
+
+implements
+interface
+let
+package
+private
+protected
+public
+static
+yield
+
+);
+
+
+# Already in use by WGSL
+my @wgsl = qw(
+array
+atomic
+bitcast
+bool
+break
+case
+continue
+continuing
+default
+discard
+else
+enable
+f32
+fallthrough
+false
+fn
+for
+function
+i32
+if
+let
+loop
+mat2x2
+mat2x3
+mat2x4
+mat3x2
+mat3x3
+mat3x4
+mat4x2
+mat4x3
+mat4x4
+override
+private
+ptr
+return
+sampler
+sampler_comparison
+storage
+struct
+switch
+texture_1d
+texture_2d
+texture_2d_array
+texture_3d
+texture_cube
+texture_cube_array
+texture_depth_2d
+texture_depth_2d_array
+texture_depth_cube
+texture_depth_cube_array
+texture_depth_multisampled_2d
+texture_multisampled_2d
+texture_storage_1d
+texture_storage_2d
+texture_storage_2d_array
+texture_storage_3d
+true
+type
+u32
+uniform
+var
+vec2
+vec3
+vec4
+while
+workgroup
+);
+
+
+# Already reserved by WGSL
+@wgsl_reserved = qw(
+asm
+bf16
+const
+demote
+demote_to_helper
+do
+enum
+f16
+f64
+handle
+i16
+i64
+i8
+mat
+premerge
+regardless
+std
+typedef
+u16
+u64
+u8
+unless
+using
+vec
+void
+wgsl
+);
+
+
+# Key is a keyword.
+# Value is a list of non-WGSL languages that reserve the word in some way.
+# The value can be empty, when only WGSL reserves the word.
+my %words = ();
+
+# Adds a list of keywords, from a given language.
+# $lang should be empty when the given language is WGSL.
+sub add_from($@) {
+  my ($lang, @keywords) = @_;
+  foreach my $word (@keywords) {
+    if (defined $words{$word} && $lang) {
+      push @{$words{$word}}, $lang;
+    } else {
+      $words{$word} = ($lang ? [$lang] : []);
+    }
+  }
+}
+
+add_from('C++', @cpp);
+add_from('ECMAScript', @ecmascript);
+add_from('Rust', @rust);
+add_from('Smalltalk', @smalltalk);
+add_from('', @wgsl_reserved);
+
+# Remove keywords already used in WGSL.
+foreach my $word (@wgsl) { 
+  delete $words{$word};
+}
+
+# Print the contents of the _reserved grammar rule.
+foreach my $word (sort {$a cmp $b} keys %words) {
+  print "    | `'$word'`   <!-- ", join(' ',@{$words{$word}}), " -->\n\n";
+}

--- a/wgsl/keywords
+++ b/wgsl/keywords
@@ -221,6 +221,132 @@ yield
 
 );
 
+# GLSL 4.6
+my @glsl = qw(
+const uniform buffer shared attribute varying
+coherent volatile restrict readonly writeonly
+atomic_uint
+layout
+centroid flat smooth noperspective
+patch sample
+invariant precise
+break continue do for while switch case default
+if else
+subroutine
+in out inout
+int void bool true false float double
+discard return
+vec2 vec3 vec4 ivec2 ivec3 ivec4 bvec2 bvec3 bvec4
+uint uvec2 uvec3 uvec4
+dvec2 dvec3 dvec4
+mat2 mat3 mat4
+mat2x2 mat2x3 mat2x4
+mat3x2 mat3x3 mat3x4
+mat4x2 mat4x3 mat4x4
+dmat2 dmat3 dmat4
+dmat2x2 dmat2x3 dmat2x4
+dmat3x2 dmat3x3 dmat3x4
+dmat4x2 dmat4x3 dmat4x4
+lowp mediump highp precision
+sampler1D sampler1DShadow sampler1DArray sampler1DArrayShadow
+isampler1D isampler1DArray usampler1D usampler1DArray
+sampler2D sampler2DShadow sampler2DArray sampler2DArrayShadow
+isampler2D isampler2DArray usampler2D usampler2DArray
+sampler2DRect sampler2DRectShadow isampler2DRect usampler2DRect
+sampler2DMS isampler2DMS usampler2DMS
+sampler2DMSArray isampler2DMSArray usampler2DMSArray
+sampler3D isampler3D usampler3D
+samplerCube samplerCubeShadow isamplerCube usamplerCube
+samplerCubeArray samplerCubeArrayShadow
+isamplerCubeArray usamplerCubeArray
+samplerBuffer isamplerBuffer usamplerBuffer
+image1D iimage1D uimage1D
+image1DArray iimage1DArray uimage1DArray
+image2D iimage2D uimage2D
+image2DArray iimage2DArray uimage2DArray
+image2DRect iimage2DRect uimage2DRect
+image2DMS iimage2DMS uimage2DMS
+image2DMSArray iimage2DMSArray uimage2DMSArray
+image3D iimage3D uimage3D
+imageCube iimageCube uimageCube
+imageCubeArray iimageCubeArray uimageCubeArray
+imageBuffer iimageBuffer uimageBuffer
+struct
+texture1D texture1DArray
+itexture1D itexture1DArray utexture1D utexture1DArray
+texture2D texture2DArray
+itexture2D itexture2DArray utexture2D utexture2DArray
+texture2DRect itexture2DRect utexture2DRect
+texture2DMS itexture2DMS utexture2DMS
+texture2DMSArray itexture2DMSArray utexture2DMSArray
+texture3D itexture3D utexture3D
+textureCube itextureCube utextureCube
+textureCubeArray itextureCubeArray utextureCubeArray
+textureBuffer itextureBuffer utextureBuffer
+sampler samplerShadow
+subpassInput isubpassInput usubpassInput
+subpassInputMS isubpassInputMS usubpassInputMS
+);
+
+# GLSL 4.6
+my @glsl_reserved = qw(
+common partition active
+asm
+class union enum typedef template this
+resource
+goto
+inline noinline public static extern external interface
+long short half fixed unsigned superp
+input output
+hvec2 hvec3 hvec4 fvec2 fvec3 fvec4
+filter
+sizeof cast
+namespace using
+sampler3DRect
+);
+
+# HLSL
+# https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-appendix-keywords
+# retrieved 2022-02-24
+my @hlsl = qw(
+AppendStructuredBuffer, asm, asm_fragment
+BlendState, bool, break, Buffer, ByteAddressBuffer
+case, cbuffer, centroid, class, column_major, compile, compile_fragment, CompileShader, const, continue, ComputeShader, ConsumeStructuredBuffer
+default, DepthStencilState, DepthStencilView, discard, do, double, DomainShader, dword
+else, export, extern
+false, float, for, fxgroup
+GeometryShader, groupshared
+half, Hullshader
+if, in, inline, inout, InputPatch, int, interface
+line, lineadj, linear, LineStream
+matrix, min16float, min10float, min16int, min12int, min16uint
+namespace, nointerpolation, noperspective, NULL
+out, OutputPatch
+packoffset, pass, pixelfragment, PixelShader, point, PointStream, precise
+RasterizerState, RenderTargetView, return, register, row_major, RWBuffer, RWByteAddressBuffer, RWStructuredBuffer, RWTexture1D, RWTexture1DArray, RWTexture2D, RWTexture2DArray, RWTexture3D
+sample, sampler, SamplerState, SamplerComparisonState, shared, snorm, stateblock, stateblock_state, static, string, struct, switch, StructuredBuffer
+tbuffer, technique, technique10, technique11, texture, Texture1D, Texture1DArray, Texture2D, Texture2DArray, Texture2DMS, Texture2DMSArray, Texture3D, TextureCube, TextureCubeArray, true, typedef, triangle, triangleadj, TriangleStream
+uint, uniform, unorm, unsigned
+vector, vertexfragment, VertexShader, void, volatile
+while
+texture
+samper
+);
+
+foreach my $type (qw(float, int, uint, bool
+  min10float, min16float
+  min12int, min16int
+  min16uint)) {
+  push @hlsl, $type;
+  foreach my $i (qw(1 2 3 4)) {
+    push @hlsl, "$type$i";
+  }
+  foreach my $row (qw(1 2 3 4)) {
+    foreach my $col (qw(1 2 3 4)) {
+      push @hlsl, "$type$row$col";
+    }
+  }
+}
 
 # Already in use by WGSL
 my @wgsl = qw(
@@ -343,6 +469,8 @@ add_from('C++', @cpp);
 add_from('ECMAScript', @ecmascript);
 add_from('Rust', @rust);
 add_from('Smalltalk', @smalltalk);
+add_from('GLSL', @glsl);
+add_from('GLSL(reserved)', @glsl_reserved);
 add_from('WGSL', @wgsl_reserved);
 
 # Remove keywords already used in WGSL.

--- a/wgsl/keywords
+++ b/wgsl/keywords
@@ -325,8 +325,7 @@ wgsl
 
 
 # Key is a keyword.
-# Value is a list of non-WGSL languages that reserve the word in some way.
-# The value can be empty, when only WGSL reserves the word.
+# Value is a list of languages that reserve the word in some way.
 my %words = ();
 
 # Adds a list of keywords, from a given language.
@@ -334,11 +333,8 @@ my %words = ();
 sub add_from($@) {
   my ($lang, @keywords) = @_;
   foreach my $word (@keywords) {
-    if (defined $words{$word} && $lang) {
-      push @{$words{$word}}, $lang;
-    } else {
-      $words{$word} = ($lang ? [$lang] : []);
-    }
+    $words{$word} = [] unless defined $words{$word};
+    push(@{$words{$word}}, $lang);
   }
 }
 
@@ -346,7 +342,7 @@ add_from('C++', @cpp);
 add_from('ECMAScript', @ecmascript);
 add_from('Rust', @rust);
 add_from('Smalltalk', @smalltalk);
-add_from('', @wgsl_reserved);
+add_from('WGSL', @wgsl_reserved);
 
 # Remove keywords already used in WGSL.
 foreach my $word (@wgsl) { 

--- a/wgsl/keywords
+++ b/wgsl/keywords
@@ -293,7 +293,7 @@ workgroup
 );
 
 
-# Already reserved by WGSL
+# Deliberately reserved by WGSL
 @wgsl_reserved = qw(
 asm
 bf16
@@ -309,6 +309,7 @@ i16
 i64
 i8
 mat
+null
 premerge
 regardless
 std


### PR DESCRIPTION
Reserves words from C++, Rust, ECMAScript, and Smalltalk

Add a script to automatically generate the contents of the _reserved
grammar rule.

Update extract-grammar.py to strip HTML comments before processing.