### PR TITLE
Add break-if as optional at end of continuing

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4984,6 +4984,12 @@ from the start of the next statement until the end of the compound statement.
     | [=syntax/brace_left=] [=syntax/statement=] * [=syntax/brace_right=]
 </div>
 
+There are two special forms of compound statement:
+* a [=syntax/continuing_compound_statement=] forms the body of a [[#continuing-statement|continuing]] statement,
+     and allows an optional [[#break-if-statement|break-if]] statement at the end.
+* a [=syntax/case_compound_statement=] forms the body of a `case` or `default` clause in a [[#switch-statement|switch]] statement,
+     and allows an optional [=syntax/fallthrough_statement|fallthrough=] statement at the end.
+
 ## Assignment Statement ## {#assignment}
 
 An <dfn noexport dfn-for="statement">assignment</dfn> evaluates an expression,
@@ -5338,9 +5344,9 @@ An `if` statement is executed as follows:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>switch_body</dfn> :
 
-    | [=syntax/case=] [=syntax/case_selectors=] [=syntax/colon=] [=syntax/brace_left=] [=syntax/case_body=] ? [=syntax/brace_right=]
+    | [=syntax/case=] [=syntax/case_selectors=] [=syntax/colon=] [=syntax/case_compound_statement=]
 
-    | [=syntax/default=] [=syntax/colon=] [=syntax/brace_left=] [=syntax/case_body=] ? [=syntax/brace_right=]
+    | [=syntax/default=] [=syntax/colon=] [=syntax/case_compound_statement=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>case_selectors</dfn> :
@@ -5348,9 +5354,12 @@ An `if` statement is executed as follows:
     | [=syntax/const_literal=] ( [=syntax/comma=] [=syntax/const_literal=] ) * [=syntax/comma=] ?
 </div>
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>case_body</dfn> :
+  <dfn for=syntax>case_compound_statement</dfn> :
 
-    | [=syntax/statement=] [=syntax/case_body=] ?
+    | [=syntax/brace_left=] [=syntax/statement=] * [=syntax/fallthrough_statement=] ? [=syntax/brace_right=]
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>fallthrough_statement</dfn> :
 
     | [=syntax/fallthrough=] [=syntax/semicolon=]
 </div>
@@ -5609,19 +5618,13 @@ The following statement forms are equivalent:
 A <dfn noexport dfn-for="statement">break</dfn> statement transfers control to the first statement
 after the body of the nearest-enclosing [=statement/loop=]
 or [=statement/switch=] statement.
+
 A `break` statement must only be used within [=statement/loop=], [=statement/for=], and [=statement/switch=] statements.
 
-When a `break` statement is placed such that it would exit from a loop's [=statement/continuing=] statement,
-then:
+A `break` statement must not placed such that it would exit from a loop's [[#continuing-statement|continuing]] statement.
+Use a [[#break-if-statement|break-if]] statement instead.
 
-* The `break` statement must appear as either:
-    * The only statement in the `if` clause of an `if` statement that has:
-        * no `else` clause or an empty `else` clause
-        * no `else if` clauses
-    * The only statement in the `else` clause of an `if` statement that has an empty `if` clause and no `else if` clauses.
-* That `if` statement must appear last in the `continuing` clause.
-
-<div class='example wgsl function-scope' heading="WGSL Valid loop if-break from a continuing clause">
+<div class='example wgsl function-scope' heading="WGSL Invalid loop break from a continuing clause">
   <xmp>
     var a: i32 = 2;
     var i: i32 = 0;
@@ -5634,36 +5637,30 @@ then:
 
       continuing {
         i = i + step;
-        if i >= 4 { break; }
+        if i >= 4 { break; } // Invalid.  Use break-if instead.
       }
     }
   </xmp>
 </div>
 
-<div class='example wgsl function-scope' heading="WGSL Valid loop if-else-break from a continuing clause">
-  <xmp>
-    var a: i32 = 2;
-    var i: i32 = 0;
-    loop {
-      let step: i32 = 1;
+### Break-If Statement ### {#break-if-statement}
 
-      if i % 2 == 0 { continue; }
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>break_if_statement</dfn> :
 
-      a = a * 2;
-
-      continuing {
-        i = i + step;
-        if i < 4 {} else { break; }
-      }
-    }
-  </xmp>
+    | [=syntax/break=] [=syntax/if=] [=syntax/expression=] [=syntax/semicolon=]
 </div>
 
-<div class='example wgsl function-scope expect-error' heading="WGSL Invalid breaks from a continuing clause">
+A <dfn noexport dfn-for="statement">break-if</dfn> statement evaluates a boolean condition, and if the condition
+is true, transfers control to the first statement after the body of the nearest-enclosing [=statement/loop=] statement.
+
+Note: A break-if statement may only appear as the last statement in the body of a [[#continuing-statement|continuing]]
+statement.
+
+<div class='example wgsl function-scope' heading="WGSL Valid loop break-if from a continuing clause">
   <xmp>
     var a: i32 = 2;
     var i: i32 = 0;
-
     loop {
       let step: i32 = 1;
 
@@ -5673,9 +5670,7 @@ then:
 
       continuing {
         i = i + step;
-        break;                               // Invalid: too early
-        if i < 4 { i++; } else { break; }  // Invalid: if is too complex, and too early
-        if i >= 4 { break; } else { i++; } // Invalid: if is too complex
+        break if i >= 4;
       }
     }
   </xmp>
@@ -5724,7 +5719,13 @@ control past a declaration used in the targeted [=statement/continuing=] stateme
 <div class='syntax' noexport='true'>
   <dfn for=syntax>continuing_statement</dfn> :
 
-    | [=syntax/continuing=] [=syntax/compound_statement=]
+    | [=syntax/continuing=] [=syntax/continuing_compound_statement=]
+</div>
+
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>continuing_compound_statement</dfn> :
+
+    | [=syntax/brace_left=] [=syntax/statement=] * [=syntax/break_if_statement=] ? [=syntax/brace_right=]
 </div>
 
 A <dfn dfn-for="statement">continuing</dfn> statement specifies a [=compound statement=] to be executed at the end of a loop [=iteration=].
@@ -5818,6 +5819,8 @@ Note: If the function [=return value|returns a value=], that value is ignored.
 
 ## Statements Grammar Summary ## {#statements-summary}
 
+The [=syntax/statement=] rule matches statements that can be used in most places inside a function body.
+
 <div class='syntax' noexport='true'>
   <dfn for=syntax>statement</dfn> :
 
@@ -5854,6 +5857,11 @@ Note: If the function [=return value|returns a value=], that value is ignored.
     | [=syntax/decrement_statement=] [=syntax/semicolon=]
 </div>
 
+Additionally, certain statements may only be used in very specific contexts:
+* [=syntax/break_if_statement=]
+* [=syntax/case_compound_statement=]
+* [=syntax/continuing_compound_statement=]
+* [=syntax/fallthrough_statement=]
 
 ## Statements Behavior Analysis ## {#behaviors}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5615,7 +5615,7 @@ The following statement forms are equivalent:
     | [=syntax/break=]
 </div>
 
-A <dfn noexport dfn-for="statement">break</dfn> statement transfers control to immediately after
+A <dfn noexport dfn-for="statement">break</dfn> statement transfers control to immediately
 after the body of the nearest-enclosing loop
 or [=statement/switch=] statement, thus ending execution of the loop or switch statement.
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7207,12 +7207,21 @@ When several edges have to be created we use `X -> {Y, Z}` as a short-hand for `
       <td>*CFend*
       <td class="nowrap">*CFend* -> {*CF_1*, ..., *CF_n*}
   <tr><td class="nowrap">var x: T;
-      <td rowspan=5>
-      <td rowspan=5>
-      <td rowspan=5>*CF*
-      <td rowspan=5>
+      <td rowspan=2>
+      <td rowspan=2>
+      <td rowspan=2>*CF*
+      <td rowspan=2>
   <tr><td class="nowrap">break;
+  <tr><td class="nowrap">break if *e*;
+      <td>
+      <td class="nowrap">(*CF*, *e*) => (*CF'*, *V*)
+      <td>*CF'*
+      <td>
   <tr><td class="nowrap">continue;
+      <td rowspan=3>
+      <td rowspan=3>
+      <td rowspan=3>*CF*
+      <td rowspan=3>
   <tr><td class="nowrap">fallthrough;
   <tr><td class="nowrap">discard;
   <tr><td class="nowrap">return;

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5615,11 +5615,11 @@ The following statement forms are equivalent:
     | [=syntax/break=]
 </div>
 
-A <dfn noexport dfn-for="statement">break</dfn> statement transfers control to the first statement
-after the body of the nearest-enclosing [=statement/loop=]
-or [=statement/switch=] statement.
+A <dfn noexport dfn-for="statement">break</dfn> statement transfers control to immediately after
+after the body of the nearest-enclosing loop
+or [=statement/switch=] statement, thus ending execution of the loop or switch statement.
 
-A `break` statement must only be used within [=statement/loop=], [=statement/for=], and [=statement/switch=] statements.
+A `break` statement must only be used within [=statement/loop=], [=statement/for=], [=statement/while=], and [=statement/switch=] statements.
 
 A `break` statement must not placed such that it would exit from a loop's [[#continuing-statement|continuing]] statement.
 Use a [[#break-if-statement|break-if]] statement instead.
@@ -5651,8 +5651,9 @@ Use a [[#break-if-statement|break-if]] statement instead.
     | [=syntax/break=] [=syntax/if=] [=syntax/expression=] [=syntax/semicolon=]
 </div>
 
-A <dfn noexport dfn-for="statement">break-if</dfn> statement evaluates a boolean condition, and if the condition
-is true, transfers control to the first statement after the body of the nearest-enclosing [=statement/loop=] statement.
+A <dfn noexport dfn-for="statement">break-if</dfn> statement evaluates a boolean condition;
+If the condition is true, control is transferred to immediately after the body of the nearest-enclosing [=statement/loop=]
+statement, ending execution of that loop.
 
 Note: A break-if statement may only appear as the last statement in the body of a [[#continuing-statement|continuing]]
 statement.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5967,6 +5967,10 @@ The reason is that only functions without a return type can have such a [=behavi
     <td>break;
     <td>
     <td>{Break}
+  <tr algorithm="break if behavior">
+    <td>break if |e|;
+    <td class="nowrap">|e|: |B|
+    <td>|B| &cup; {Break}
   <tr algorithm="continue behavior">
     <td>continue;
     <td>


### PR DESCRIPTION
A break-if can only appear as the last statement in a continuing
clause.

Simplifies the rule about where a bare 'break' can occur: It
must not be placed such that it would exit a continuing clause.

Fixes: #1867

Also refactor the grammar to make:
  continuing_compound_statement
  case_compound_statement
These are called out as special forms of compound statement, so
that the scope rule of declarations within a compound statement
also clearly apply to them.