### PR TITLE
wgsl: Cleanup internal layout of matrix type

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1882,7 +1882,7 @@ byte offset |k| of a host-shared buffer, then:
 
 When a value |V| of matrix type mat|N|x|M|&lt;|T|&gt; is placed at
 byte offset |k| of a host-shared buffer, then:
-  * Column vector |i| of |V| is placed at byte offset |k| + [=AlignOf=](vec|M|&lt;|T|&gt;) &times; |i|
+  * Column vector |i| of |V| is placed at byte offset |k| + |i| &times; [=AlignOf=](vec|M|&lt;|T|&gt;)
 
 When a value of array type |A| is placed at byte offset |k| of a host-shared memory buffer,
 then:

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1880,11 +1880,9 @@ byte offset |k| of a host-shared buffer, then:
    * If |N| &ge; 3, then |V|.z is placed at byte offset |k|+8
    * If |N| &ge; 4, then |V|.w is placed at byte offset |k|+12
 
-When a matrix value |M| is placed at byte offset |k| of a host-shared memory buffer, then:
-   * If |M| has 2 rows, then:
-      * Column vector |i| of |M| is placed at byte offset |k| + 8 &times; |i|
-   * If |M| has 3 or 4 rows, then:
-      * Column vector |i| of |M| is placed at byte offset |k| + 16 &times; |i|
+When a value |V| of matrix type mat|N|x|M|&lt;|T|&gt; is placed at
+byte offset |k| of a host-shared buffer, then:
+  * Column vector |i| of |V| is placed at byte offset |k| + [=AlignOf=](vec|M|&lt;|T|&gt;) &times; |i|
 
 When a value of array type |A| is placed at byte offset |k| of a host-shared memory buffer,
 then:


### PR DESCRIPTION
Use alignOf() to cleanup the description of internal layout of matrix type.