### PR TITLE
Correct the definition of fragment-stage position builtin

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8547,7 +8547,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in value.
       <td>fragment
       <td>input
       <td>vec4&lt;f32&gt;
-      <td style="width:50%">Framebuffer position of the current fragment in framebuffer space.
+      <td style="width:50%">Framebuffer position of the current fragment in [[WebGPU#rasterization|framebuffer space]].
       (The *x*, *y*, and *z* components have already been scaled such that *w* is now 1.)
       See [[WebGPU#coordinate-systems|WebGPU &sect; Coordinate Systems]].
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8547,8 +8547,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in value.
       <td>fragment
       <td>input
       <td>vec4&lt;f32&gt;
-      <td style="width:50%">Framebuffer position of the current fragment, using normalized homogeneous
-      coordinates.
+      <td style="width:50%">Framebuffer position of the current fragment in framebuffer space.
       (The *x*, *y*, and *z* components have already been scaled such that *w* is now 1.)
       See [[WebGPU#coordinate-systems|WebGPU &sect; Coordinate Systems]].
 


### PR DESCRIPTION
`@builtin(position)` at the fragment stage does _not_ use normalized coordinates, but uses framebuffer space.