### PR TITLE
wgsl: Cleanup the internal memory layout of vector using SizeOf

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1876,9 +1876,9 @@ it has the same internal layout as a value of the underlying type |T|.
 When a value |V| of vector type vec|N|&lt;|T|&gt; is placed at
 byte offset |k| of a host-shared buffer, then:
    * |V|.x is placed at byte offset |k|
-   * |V|.y is placed at byte offset |k|+4
-   * If |N| &ge; 3, then |V|.z is placed at byte offset |k|+8
-   * If |N| &ge; 4, then |V|.w is placed at byte offset |k|+12
+   * |V|.y is placed at byte offset |k| + [=SizeOf=](&lt;|T|&gt;)
+   * If |N| &ge; 3, then |V|.z is placed at byte offset |k| + 2 &times; [=SizeOf=](&lt;|T|&gt;)
+   * If |N| &ge; 4, then |V|.w is placed at byte offset |k| + 3 &times; [=SizeOf=](&lt;|T|&gt;)
 
 When a value |V| of matrix type mat|N|x|M|&lt;|T|&gt; is placed at
 byte offset |k| of a host-shared buffer, then:

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1876,9 +1876,9 @@ it has the same internal layout as a value of the underlying type |T|.
 When a value |V| of vector type vec|N|&lt;|T|&gt; is placed at
 byte offset |k| of a host-shared buffer, then:
    * |V|.x is placed at byte offset |k|
-   * |V|.y is placed at byte offset |k| + [=SizeOf=](&lt;|T|&gt;)
-   * If |N| &ge; 3, then |V|.z is placed at byte offset |k| + 2 &times; [=SizeOf=](&lt;|T|&gt;)
-   * If |N| &ge; 4, then |V|.w is placed at byte offset |k| + 3 &times; [=SizeOf=](&lt;|T|&gt;)
+   * |V|.y is placed at byte offset |k| + [=SizeOf=](|T|)
+   * If |N| &ge; 3, then |V|.z is placed at byte offset |k| + 2 &times; [=SizeOf=](|T|)
+   * If |N| &ge; 4, then |V|.w is placed at byte offset |k| + 3 &times; [=SizeOf=](|T|)
 
 When a value |V| of matrix type mat|N|x|M|&lt;|T|&gt; is placed at
 byte offset |k| of a host-shared buffer, then:


### PR DESCRIPTION
Descript the internal memory layout of vector types vecN<T> with SizeOf(T) rather than literal number.