### PR TITLE
Validate query index overwrite in timestampWrites of render pass

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7731,6 +7731,8 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
 
         1. |timestampWrite|.{{GPURenderPassTimestampWrite/queryIndex}} &lt; |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}}.
 
+        1. |timestampWrite|.{{GPURenderPassTimestampWrite/queryIndex}} is written at most once in the same |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}} in this render pass.
+
     Issue(gpuweb/gpuweb#503): support for no attachments
 </div>
 


### PR DESCRIPTION
Vulkan requires each queries must be reset between uses and the reset
command must be called outside render pass, which makes it impossable to
overwrite a query index in same query set in a render pass,  we only can
do that in different query set or different render pass.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/haoxli/gpuweb/pull/2627.html" title="Last updated on Feb 28, 2022, 9:16 AM UTC (38200ae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2627/1df8ded...haoxli:38200ae.html" title="Last updated on Feb 28, 2022, 9:16 AM UTC (38200ae)">Diff</a>