### PR TITLE
wgsl: Fix typos of accuracy of exp and exp2

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7622,8 +7622,8 @@ value with the same sign.
   <tr><td>`cross(x, y)`<td>Inherited from `(x[i] * y[j] - x[j] * y[i])`
   <tr><td>`degrees(x)`<td>Inherited from `x * 57.295779513082322865`
   <tr><td>`distance(x, y)`<td>Inherited from `length(x - y)`
-  <tr><td>`exp(x)`<td>3 + 2 * |x| ULP
-  <tr><td>`exp2(x)`<td>3 + 2 * |x| ULP
+  <tr><td>`exp(x)`<td>`3 + 2 * |x|` ULP
+  <tr><td>`exp2(x)`<td>`3 + 2 * |x|` ULP
   <tr><td class="nowrap">`faceForward(x, y, z)`<td>Inherited from `select(-x, x, dot(z, y) < 0.0)`
   <tr><td>`floor(x)`<td>Correctly rounded
   <tr><td>`fma(x, y, z)`<td>Inherited from `x * y + z`


### PR DESCRIPTION
Fix the accuracy requirement of exp and exp2 to 3 + 2 * abs(x) ULP.

Corresponding to Vulkan spec: https://www.khronos.org/registry/vulkan/specs/1.2-khr-extensions/html/chap42.html#:~:text=Table%2072.%20Precision%20of%20GLSL.std.450%20Instructions