### PR TITLE
Allow unmasked adapter info fields to be requested individually.

### DIFF
--- a/design/AdapterIdentifiers.md
+++ b/design/AdapterIdentifiers.md
@@ -94,7 +94,7 @@ console.log(unmaskedAdapterInfo);
 }
 ```
 
-Because the unmasked values may contain higher entropy identifying information, the bar for querying it is quite a bit higher. Calling `requestUnmaskedAdapterInfo()` requires user activation, and will reject the promise otherwise. If the `hints` array contains any previously masked value it also requires that user consent be given before returning, and as such may display a prompt to the user asking if the page can access the newly requested GPU details before allowing the promise to resolve.
+Because the unmasked values may contain higher entropy identifying information, the bar for querying it is quite a bit higher. Calling `requestUnmaskedAdapterInfo()` requires user activation, and will reject the promise otherwise. If the `hints` array contains any previously masked value it also requires that user consent be given before returning, and as such may display a prompt to the user asking if the page can access the newly requested GPU details before allowing the promise to resolve. If the user declines to give consent then the promise is rejected.
 
 Once the user has given their consent the `info` attribute of the `GPUAdapter` should be updated to reflect the newly unmasked fields and future instances of the same underlying adapter returned from `navigator.requestAdapter()` on that page load should also contain unmasked data without requiring another call to `requestUnmaskedAdapterInfo()`.
 

--- a/design/AdapterIdentifiers.md
+++ b/design/AdapterIdentifiers.md
@@ -96,7 +96,7 @@ console.log(unmaskedAdapterInfo);
 
 Because the unmasked values may contain higher entropy identifying information, the bar for querying it is quite a bit higher. Calling `requestUnmaskedAdapterInfo()` requires user activation, and will reject the promise otherwise. If the `hints` array contains any previously masked value it also requires that user consent be given before returning, and as such may display a prompt to the user asking if the page can access the newly requested GPU details before allowing the promise to resolve.
 
-Once the user has given their consent the `info` attribute of the `GPUAdapter` should be updated to reflect the newly unmasked fields and future instances of the `GPUAdapter` queried from `navigator.requestAdapter()` by that page should also contain unmasked data without requiring another call to `requestUnmaskedAdapterInfo()`.
+Once the user has given their consent the `info` attribute of the `GPUAdapter` should be updated to reflect the newly unmasked fields and future instances of the same underlying adapter returned from `navigator.requestAdapter()` on that page load should also contain unmasked data without requiring another call to `requestUnmaskedAdapterInfo()`.
 
 Even after `requestUnmaskedAdapterInfo()` is called the UA is still allowed to return `null` for attributes requested in the `hints` array if the UA cannot determine the value in question or decides not to reveal it. (UAs should not request user consent when unmasking is requested for attributes that will be left as `null`.)
 


### PR DESCRIPTION
Updates the Adapter identifiers proposal based on feedback from yesterday's call. Changes specifically include:

-  New values have to be requested by name, passed as a "hints" array. This moves the design of this API closer to that of [navigator.userAgentData.getHighEntropyValues()](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/getHighEntropyValues)
- Made all values nullable, where previously `vendor` was not and it was assumed that `"unknown"` would be returned in cases where the UA did not wish to report the value. Given that Myles stated that Apple doesn't want to return the vendor by default I feel it's more important to give developers a clear sense of which values have not been reported than to always give them a string, regardless of it's accuracy.
- Called out specifically that the values may be masked or bucketed by the UA prior to requesting the unmasked version, and that the UA could choose to not reveal the actual values even after a call to `requestUnmaskedAdapterInfo()`.
- Changed `adapter.info` to no longer be `[SameObject]` and for it to update in-place when `requestUnmaskedAdapterInfo()` is called.

I'd very much appreciate if Myles or another representative from Apple could give this a look and see if it addresses the changes that were requested.

Additionally, something I meant to ask on the call but forgot: Would Apple consider exposing any of these identifying values after user consent has been explicitly given in response to a `requestUnmaskedAdapterInfo()`? I understand that the intent prior to that is to return `null` for everything (which is allowed by this proposal).