### PR TITLE
Reland: Only allow depth/stencil load/store ops when they have an effect

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6188,7 +6188,7 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                 1. If |depthStencilAttachment| is not `null`:
                     1. Let |depthStencilView| be |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/view}}.
                     1. If |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} and
-                        {{GPURenderPassDepthStencilAttachment/stencilReadOnly}} are set:
+                        {{GPURenderPassDepthStencilAttachment/stencilReadOnly}} are `true`:
                         1. The [=texture subresources=] seen by |depthStencilView|
                             are considered to be used as [=internal usage/attachment-read=] for the duration of the render pass.
 
@@ -7575,13 +7575,13 @@ GPURenderPassEncoder includes GPURenderEncoderBase;
     ::
         The layout of the render pass.
 
-    : <dfn>\[[depthReadOnly]]</dfn>, of type boolean?
+    : <dfn>\[[depthReadOnly]]</dfn>, of type boolean
     ::
-        If present, indicates that the depth component is not modified.
+        If `true`, indicates that the depth component is not modified.
 
-    : <dfn>\[[stencilReadOnly]]</dfn>, of type boolean?
+    : <dfn>\[[stencilReadOnly]]</dfn>, of type boolean
     ::
-        If present, indicates that the stencil component is not modified.
+        If `true`, indicates that the stencil component is not modified.
 
     : <dfn>\[[pipeline]]</dfn>, of type {{GPURenderPipeline}}
     ::
@@ -7917,13 +7917,19 @@ dictionary GPURenderPassDepthStencilAttachment {
     - If |this|.{{GPURenderPassDepthStencilAttachment/depthLoadOp}} is {{GPULoadOp/"clear"}},
         |this|.{{GPURenderPassDepthStencilAttachment/depthClearValue}} must be between 0.0 and 1.0,
         inclusive. <!-- unless unrestricted depth is enabled -->
-    - If |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}
-        is a [=combined depth-stencil format=]:
+    - Let |format| be |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
+    - If |format| is a [=combined depth-stencil format=]:
         - |this|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} must be equal to |this|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}}
-    - If |this|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} is `true`:
+    - If |format| has a depth aspect and |this|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} is not `true`:
+        - |this|.{{GPURenderPassDepthStencilAttachment/depthLoadOp}} must [=map/exist|be provided=].
+        - |this|.{{GPURenderPassDepthStencilAttachment/depthStoreOp}} must [=map/exist|be provided=].
+    - Otherwise:
         - |this|.{{GPURenderPassDepthStencilAttachment/depthLoadOp}} must not [=map/exist|be provided=].
         - |this|.{{GPURenderPassDepthStencilAttachment/depthStoreOp}} must not [=map/exist|be provided=].
-    - If |this|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}} is `true`:
+    - If |format| has a stencil aspect and |this|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}} is not `true`:
+        - |this|.{{GPURenderPassDepthStencilAttachment/depthLoadOp}} must [=map/exist|be provided=].
+        - |this|.{{GPURenderPassDepthStencilAttachment/depthStoreOp}} must [=map/exist|be provided=].
+    - Otherwise:
         - |this|.{{GPURenderPassDepthStencilAttachment/stencilLoadOp}} must not [=map/exist|be provided=].
         - |this|.{{GPURenderPassDepthStencilAttachment/stencilStoreOp}} must not [=map/exist|be provided=].
 </div>
@@ -8622,13 +8628,13 @@ GPURenderBundle includes GPUObjectBase;
     ::
         The layout of the render bundle.
 
-    : <dfn>\[[depthReadOnly]]</dfn>, of type boolean?
+    : <dfn>\[[depthReadOnly]]</dfn>, of type boolean
     ::
-        If present, indicates that the depth component is not modified by executing this render bundle.
+        If `true`, indicates that the depth component is not modified by executing this render bundle.
 
-    : <dfn>\[[stencilReadOnly]]</dfn>, of type boolean?
+    : <dfn>\[[stencilReadOnly]]</dfn>, of type boolean
     ::
-        If present, indicates that the stencil component is not modified by executing this render bundle.
+        If `true`, indicates that the stencil component is not modified by executing this render bundle.
 </dl>
 
 ### Creation ### {#render-bundle-creation}


### PR DESCRIPTION
These changes were already approved as part of #2387, which was accidentally merged into a branch other than main, effectively losing the changes in the process. This PR re-lands them (aside from a small portion of the IDL change that was already re-landed separately.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 4, 2022, 8:30 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fgpuweb%2Fgpuweb%2Fb003493fa422cdd93338bb755c9c4fdbdbbca62d%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%232639.)._
</details>
