### PR TITLE
GPUDevice.createBuffer() requires a valid GPUBufferDescriptor

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2206,6 +2206,7 @@ namespace GPUBufferUsage {
             1. If any of the following conditions are unsatisfied, return an error buffer and stop.
                 <div class=validusage>
                     - |this| is a [=valid=] {{GPUDevice}}.
+                    - [$validating GPUBufferDescriptor$](|this|, |descriptor|) returns true.
                     - |descriptor|.{{GPUBufferDescriptor/usage}} must not be 0.
                     - |descriptor|.{{GPUBufferDescriptor/usage}} is a subset of |this|.[[allowed buffer usages]].
                     - If |descriptor|.{{GPUBufferDescriptor/usage}} contains {{GPUBufferUsage/MAP_READ}}:


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/litherum/gpuweb/pull/2643.html" title="Last updated on Mar 7, 2022, 2:46 AM UTC (c739f77)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2643/3382f32...litherum:c739f77.html" title="Last updated on Mar 7, 2022, 2:46 AM UTC (c739f77)">Diff</a>