### PR TITLE
Add a way of setting the initial label for the default queue

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1806,6 +1806,7 @@ interface GPUAdapter {
 dictionary GPUDeviceDescriptor : GPUObjectDescriptorBase {
     sequence<GPUFeatureName> requiredFeatures = [];
     record<DOMString, GPUSize64> requiredLimits = {};
+    GPUQueueDescriptor defaultQueue = {};
 };
 </script>
 
@@ -1833,6 +1834,10 @@ dictionary GPUDeviceDescriptor : GPUObjectDescriptorBase {
         type to `double` or `any` in the future and write out the type conversion explicitly (by
         reference to WebIDL spec). Or change the entire type to `any` and add back a `dictionary
         GPULimits` and define the conversion of the whole object by reference to WebIDL. -->
+
+    : <dfn>defaultQueue</dfn>
+    ::
+        The descriptor for the default {{GPUQueue}}.
 </dl>
 
 <div class="example">
@@ -8750,6 +8755,17 @@ dictionary GPURenderBundleEncoderDescriptor : GPURenderPassLayout {
 </dl>
 
 # Queues # {#queues}
+
+## <dfn dictionary>GPUQueueDescriptor</dfn> ## {#gpuqueuedescriptor}
+
+{{GPUQueueDescriptor}} describes a queue request.
+
+<script type=idl>
+dictionary GPUQueueDescriptor : GPUObjectDescriptorBase {
+};
+</script>
+
+## <dfn interface>GPUQueue</dfn> ## {#gpu-queue}
 
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/litherum/gpuweb/pull/2645.html" title="Last updated on Mar 15, 2022, 8:14 PM UTC (b938754)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2645/3382f32...litherum:b938754.html" title="Last updated on Mar 15, 2022, 8:14 PM UTC (b938754)">Diff</a>