### PR TITLE
Name in enable directive can be a keyword or reserved word

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6927,14 +6927,12 @@ Hypothetically, extensions could be used to:
 
 An <dfn noexport>enable directive</dfn> indicates that the functionality
 described by a particular named
-[=extension=] may be used in the source text after the directive itself.
-That is, language functionality described by the extension may be used in any
-source text after the `enable` directive.
+[=extension=] may be used.
+The grammar rules imply that all enable directives must appear before any [=declarations=].
 
-The directive must not appear inside the text of any [=declaration=].
-(If it were a declaration, it would be at [=module scope=].)
+The directive uses an [=identifier=], [=keyword=], or [=reserved word=] to name the extension.
 
-The directive uses an [=identifier=] to name the extension, but does not
+If the name is an identifier, the directive does not
 create a [=scope=] for the identifier.
 Use of the identifier by the directive does not conflict with the
 use of that identifier as the name in any [=declaration=].


### PR DESCRIPTION
Fixes: #2649

Also simplify description of where an enable directive can appear.
They must appear before any declaration.