### PR TITLE
Use concise forms for entry point stage attributes.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -131,7 +131,7 @@ that run on the GPU.
 
 <div class='example wgsl global-scope'>
   <xmp highlight='rust'>
-    @stage(fragment)
+    @fragment
     fn main() -> @location(0) vec4<f32> {
         return vec4<f32>(0.4, 0.4, 0.8, 1.0);
     }
@@ -652,12 +652,6 @@ An attribute must not be specified more than once per object or type.
 
     See [[#memory-layouts]]
 
-  <tr><td><dfn noexport dfn-for="attribute">`stage`</dfn>
-    <td>`compute`, `vertex`, or `fragment`
-    <td>Must only be applied to a [=function declaration=].
-
-    Declares an [=entry point=] by specifying its [[#shader-stages-sec|pipeline stage]].
-
   <tr><td><dfn noexport dfn-for="attribute">`workgroup_size`</dfn>
     <td>One, two or three parameters.
 
@@ -675,6 +669,31 @@ An attribute must not be specified more than once per object or type.
 
 </table>
 
+The <dfn noexport>pipeline stage attributes</dfn> below
+designate a function as an [=entry point=] for a particular [=shader stage=].
+These attributes may only be applied to [=function declarations=],
+and at most one may be present on a given function.
+They take no parameters.
+
+<table class='data'>
+  <caption>Pipeline Stage Attributes</caption>
+  <thead>
+    <tr><th>Attribute<th>Description
+  </thead>
+
+  <tr><td><dfn noexport dfn-for="attribute">`vertex`</dfn><br>
+    <td>Declares the function to be an [=entry point=] for the [=vertex shader stage=]
+    of a [=GPURenderPipeline|render pipeline=].
+
+  <tr><td><dfn noexport dfn-for="attribute">`fragment`</dfn><br>
+    <td>Declares the function to be an [=entry point=] for the [=fragment shader stage=]
+    of a [=GPURenderPipeline|render pipeline=].
+
+  <tr><td><dfn noexport dfn-for="attribute">`compute`</dfn><br>
+    <td>Declares the function to be an [=entry point=] for the [=compute shader stage=]
+    of a [=GPUComputePipeline|compute pipeline=].
+
+</table>
 
 ## Directives ## {#directives}
 
@@ -2161,7 +2180,7 @@ Defining references in this way enables simple idiomatic use of variables:
 
 <div class='example wgsl' heading='Reference types enable simple use of variables'>
   <xmp highlight='rust'>
-    @stage(compute)
+    @compute
     fn main() {
       // 'i' has reference type ref<function,i32,read_write>
       // The memory locations for 'i' store the i32 value 0.
@@ -2228,7 +2247,7 @@ Note: The following examples use WGSL features explained later in this specifica
     }
     @group(0) @binding(0) var<storage,read_write> system: System;
 
-    @stage(compute)
+    @compute
     fn main() {
       // Form a pointer to a specific Particle in storage memory.
       let active_particle: ptr<storage,Particle> =
@@ -2260,7 +2279,7 @@ Note: The following examples use WGSL features explained later in this specifica
       *x = *x + 1;
     }
 
-    @stage(compute)
+    @compute
     fn main() {
       var i: i32 = 0;
 
@@ -5015,7 +5034,7 @@ A phony-assignment is useful for:
     @group(0) @binding(1) var t: texture_2d<f32>;
     @group(0) @binding(2) var s: sampler;
 
-    @stage(fragment)
+    @fragment
     fn shade_it() -> @location(0) vec4<f32> {
       // Declare that buf, t, and s are part of the shader interface, without
       // using them for anything.
@@ -5687,7 +5706,7 @@ duration of the entry point.
     will_emit_color = true;
   }
 
-  @stage(fragment)
+  @fragment
   fn main(@builtin(position) coord_in: vec4<f32>)
     -> @location(0) vec4<f32>
   {
@@ -6268,7 +6287,7 @@ The return type, if specified, must be [=constructible=].
 </div>
 
 WGSL defines the following attributes that can be applied to function declarations:
- * [=attribute/stage=]
+ * the [=pipeline stage attributes=]: [=attribute/vertex=], [=attribute/fragment=], and [=attribute/compute=]
  * [=attribute/workgroup_size=]
 
 WGSL defines the following attributes that can be applied to function
@@ -6290,7 +6309,7 @@ parameters and return types:
     // It has no specified return type.
     // It invokes the ordinary_two function, and captures
     // the resulting value in the named value 'two'.
-    @stage(compute) fn main() {
+    @compute fn main() {
        let six: i32 = add_two(4, 5.0);
     }
   </xmp>
@@ -6442,7 +6461,7 @@ Each shader stage has its own set of features and constraints, described elsewhe
 
 ## Entry Point Declaration ## {#entry-point-decl}
 
-To create an [=entry point=], declare a [=user-defined function=] with a [=attribute/stage=] attribute.
+To create an [=entry point=], declare a [=user-defined function=] with a [=pipeline stage attribute=].
 
 When configuring a [=pipeline=] in the WebGPU API,
 the entry point's function name maps to the `entryPoint` attribute of the
@@ -6456,17 +6475,17 @@ Note: [=Compute=] entry points never have a return type.
 
 <div class='example wgsl global-scope' heading='Entry Point'>
   <xmp>
-    @stage(vertex)
+    @vertex
     fn vert_main() -> @builtin(position) vec4<f32> {
       return vec4<f32>(0.0, 0.0, 0.0, 1.0);
     }
 
-    @stage(fragment)
+    @fragment
     fn frag_main(@builtin(position) coord_in: vec4<f32>) -> @location(0) vec4<f32> {
       return vec4<f32>(coord_in.x, coord_in.y, 0.0, 1.0);
     }
 
-    @stage(compute)
+    @compute
     fn comp_main() { }
   </xmp>
 </div>
@@ -6483,7 +6502,7 @@ It will stabilize in a finite number of steps.
 ### Function Attributes for Entry Points ### {#entry-point-attributes}
 
 WGSL defines the following attributes that can be applied to entry point declarations:
- * [=attribute/stage=]
+ * the [=pipeline stage attributes=]: [=attribute/vertex=], [=attribute/fragment=], and [=attribute/compute=]
  * [=attribute/workgroup_size=]
 
 ISSUE: Can we query upper bounds on workgroup size dimensions?  Is it independent of the shader, or
@@ -6491,19 +6510,19 @@ ISSUE: Can we query upper bounds on workgroup size dimensions?  Is it independen
 
 <div class='example wgsl global-scope' heading='workgroup_size Attribute'>
   <xmp>
-    @stage(compute) @workgroup_size(8,4,1)
+    @compute @workgroup_size(8,4,1)
     fn sorter() { }
 
-    @stage(compute) @workgroup_size(8u)
+    @compute @workgroup_size(8u)
     fn reverser() { }
 
     // Using an pipeline-overridable constant.
     @id(42) override block_width = 12u;
-    @stage(compute) @workgroup_size(block_width)
+    @compute @workgroup_size(block_width)
     fn shuffler() { }
 
     // Error: workgroup_size must be specified on compute shader
-    @stage(compute)
+    @compute
     fn bad_shader() { }
   </xmp>
 </div>
@@ -6667,7 +6686,7 @@ Note: The number of available locations for an entry point is defined by the Web
     // in1 occupies locations 0 and 1.
     // in2 occupies location 2.
     // The return value occupies location 0.
-    @stage(fragment)
+    @fragment
     fn fragShader(in1: A, @location(2) in2: f32) -> @location(0) vec4<f32> {
      // ...
     }
@@ -6690,7 +6709,7 @@ User-defined IO can be mixed with built-in values in the same structure. For exa
       @location(0) y: vec4<f32>
     }
 
-    @stage(fragment)
+    @fragment
     fn fragShader(in1: MyInputs) -> MyOutputs {
       // ...
     }
@@ -6718,19 +6737,19 @@ User-defined IO can be mixed with built-in values in the same structure. For exa
       x: vec4<f32>
     }
 
-    @stage(fragment)
+    @fragment
     // Invalid, location cannot be applied to a structure type.
     fn fragShader1(@location(0) in1: D) {
       // ...
     }
 
-    @stage(fragment)
+    @fragment
     // Invalid, in1 and in2 cannot share a location.
     fn fragShader2(@location(0) in1: f32, @location(0) in2: f32) {
       // ...
     }
 
-    @stage(fragment)
+    @fragment
     // Invalid, location cannot be applied to a structure.
     fn fragShader3(@location(0) in1: vec4<f32>) -> @location(0) D {
       // ...
@@ -9685,7 +9704,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in value.
       @builtin(position) my_pos: vec4<f32>
     }
 
-    @stage(vertex)
+    @vertex
     fn vs_main(
       @builtin(vertex_index) my_index: u32,
       @builtin(instance_index) my_inst_index: u32,
@@ -9696,7 +9715,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in value.
       @builtin(sample_mask) mask_out: u32
     }
 
-    @stage(fragment)
+    @fragment
     fn fs_main(
       @builtin(front_facing) is_front: bool,
       @builtin(position) coord: vec4<f32>,
@@ -9704,7 +9723,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in value.
       @builtin(sample_mask) mask_in: u32,
     ) -> FragmentOutput {}
 
-    @stage(compute)
+    @compute
     fn cs_main(
       @builtin(local_invocation_id) local_id: vec3<u32>,
       @builtin(local_invocation_index) local_index: u32,


### PR DESCRIPTION
`@stage(vertex)` becomes `@vertex`.

`@stage(fragment)` becomes `@fragment`.

`@stage(compute)` becomes `@compute`.

Introduces the new category "pipeline stage attribute".