### PR TITLE
Typo in definition of finish()

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6942,7 +6942,7 @@ command encoder can no longer be used.
             1. Let |commandBuffer| be a new {{GPUCommandBuffer}}.
             1. Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
-                    1. Let |validationFailed| be `true` if all of the following requirements are met, and `false` otherwise.
+                    1. Let |validationSucceeded| be `true` if all of the following requirements are met, and `false` otherwise.
                         <div class=validusage>
                             - |this| must be [=valid=].
                             - |this|.{{GPUCommandsMixin/[[state]]}} must be "[=encoder state/open=]".
@@ -6950,7 +6950,7 @@ command encoder can no longer be used.
                             - Every [=usage scope=] contained in |this| must satisfy the [=usage scope validation=].
                         </div>
                     1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/ended=]".
-                    1. If |validationFailed|, then:
+                    1. If |validationSucceeded| is `false`, then:
                         1. [$Generate a validation error$].
                         1. Return a new [=invalid=] {{GPUCommandBuffer}}.
                     1. Set |commandBuffer|.{{GPUCommandBuffer/[[command_list]]}} to


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 9, 2022, 7:04 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Flitherum%2Fgpuweb%2Fee5e7cc7e86305c04a9b54399713a0098ea305fc%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%232655.)._
</details>
