### PR TITLE
Uses commas to separate struct members intead of semicolons

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1230,10 +1230,10 @@ Some consequences of the restrictions structure member and array element types a
   <xmp highlight='rust'>
     // A structure with four members.
     struct Data {
-      a: i32;
-      b: vec2<f32>;
-      c: array<i32,10>;
-      d: array<f32>;
+      a: i32,
+      b: vec2<f32>,
+      c: array<i32,10>,
+      d: array<f32>, // last comma is optional
     }
   </xmp>
 </div>
@@ -1246,12 +1246,12 @@ Some consequences of the restrictions structure member and array element types a
 <div class='syntax' noexport='true'>
   <dfn for=syntax>struct_body_decl</dfn> :
 
-    | [=syntax/brace_left=] [=syntax/struct_member=] * [=syntax/brace_right=]
+    | [=syntax/brace_left=] ( [=syntax/struct_member=] [=syntax/comma=] ) * [=syntax/struct_member=] [=syntax/comma=] ? [=syntax/brace_right=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>struct_member</dfn> :
 
-    | [=syntax/attribute=] * [=syntax/variable_ident_decl=] [=syntax/semicolon=]
+    | [=syntax/attribute=] * [=syntax/variable_ident_decl=]
 </div>
 
 WGSL defines the following attributes that can be applied to structure members:
@@ -1266,8 +1266,8 @@ to define a [=uniform buffer=] or a [=storage buffer=]. See [[#memory-layouts]].
 <div class='example wgsl global-scope' heading='Structure WGSL'>
   <xmp>
     struct my_struct {
-      a: f32;
-      b: vec4<f32>;
+      a: f32,
+      b: vec4<f32>
     }
   </xmp>
 </div>
@@ -1277,9 +1277,9 @@ to define a [=uniform buffer=] or a [=storage buffer=]. See [[#memory-layouts]].
     // Runtime Array
     type RTArr = array<vec4<f32>>;
     struct S {
-      a: f32;
-      b: f32;
-      data: RTArr;
+      a: f32,
+      b: f32,
+      data: RTArr
     }
     @group(0) @binding(0) var<storage> buffer: S;
   </xmp>
@@ -1737,25 +1737,25 @@ For each member index |i| > 1:
 <div class='example wgsl' heading='Layout of structures using implicit member sizes and alignments'>
   <xmp highlight='rust'>
     struct A {                                     //             align(8)  size(24)
-        u: f32;                                    // offset(0)   align(4)  size(4)
-        v: f32;                                    // offset(4)   align(4)  size(4)
-        w: vec2<f32>;                              // offset(8)   align(8)  size(8)
-        x: f32;                                    // offset(16)  align(4)  size(4)
+        u: f32,                                    // offset(0)   align(4)  size(4)
+        v: f32,                                    // offset(4)   align(4)  size(4)
+        w: vec2<f32>,                              // offset(8)   align(8)  size(8)
+        x: f32                                     // offset(16)  align(4)  size(4)
         // -- implicit struct size padding --      // offset(20)            size(4)
     }
 
     struct B {                                     //             align(16) size(160)
-        a: vec2<f32>;                              // offset(0)   align(8)  size(8)
+        a: vec2<f32>,                              // offset(0)   align(8)  size(8)
         // -- implicit member alignment padding -- // offset(8)             size(8)
-        b: vec3<f32>;                              // offset(16)  align(16) size(12)
-        c: f32;                                    // offset(28)  align(4)  size(4)
-        d: f32;                                    // offset(32)  align(4)  size(4)
+        b: vec3<f32>,                              // offset(16)  align(16) size(12)
+        c: f32,                                    // offset(28)  align(4)  size(4)
+        d: f32,                                    // offset(32)  align(4)  size(4)
         // -- implicit member alignment padding -- // offset(36)            size(4)
-        e: A;                                      // offset(40)  align(8)  size(24)
-        f: vec3<f32>;                              // offset(64)  align(16) size(12)
+        e: A,                                      // offset(40)  align(8)  size(24)
+        f: vec3<f32>,                              // offset(64)  align(16) size(12)
         // -- implicit member alignment padding -- // offset(76)            size(4)
-        g: array<A, 3>;    // element stride 24       offset(80)  align(8)  size(72)
-        h: i32;                                    // offset(152) align(4)  size(4)
+        g: array<A, 3>,    // element stride 24       offset(80)  align(8)  size(72)
+        h: i32                                     // offset(152) align(4)  size(4)
         // -- implicit struct size padding --      // offset(156)           size(4)
     }
 
@@ -1767,24 +1767,24 @@ For each member index |i| > 1:
 <div class='example wgsl' heading='Layout of structures with explicit member sizes and alignments'>
   <xmp highlight='rust'>
     struct A {                                     //             align(8)  size(32)
-        u: f32;                                    // offset(0)   align(4)  size(4)
-        v: f32;                                    // offset(4)   align(4)  size(4)
-        w: vec2<f32>;                              // offset(8)   align(8)  size(8)
-        @size(16) x: f32;                          // offset(16)  align(4)  size(16)
+        u: f32,                                    // offset(0)   align(4)  size(4)
+        v: f32,                                    // offset(4)   align(4)  size(4)
+        w: vec2<f32>,                              // offset(8)   align(8)  size(8)
+        @size(16) x: f32                           // offset(16)  align(4)  size(16)
     }
 
     struct B {                                     //             align(16) size(208)
-        a: vec2<f32>;                              // offset(0)   align(8)  size(8)
+        a: vec2<f32>,                              // offset(0)   align(8)  size(8)
         // -- implicit member alignment padding -- // offset(8)             size(8)
-        b: vec3<f32>;                              // offset(16)  align(16) size(12)
-        c: f32;                                    // offset(28)  align(4)  size(4)
-        d: f32;                                    // offset(32)  align(4)  size(4)
+        b: vec3<f32>,                              // offset(16)  align(16) size(12)
+        c: f32,                                    // offset(28)  align(4)  size(4)
+        d: f32,                                    // offset(32)  align(4)  size(4)
         // -- implicit member alignment padding -- // offset(36)            size(12)
-        @align(16) e: A;                           // offset(48)  align(16) size(32)
-        f: vec3<f32>;                              // offset(80)  align(16) size(12)
+        @align(16) e: A,                           // offset(48)  align(16) size(32)
+        f: vec3<f32>,                              // offset(80)  align(16) size(12)
         // -- implicit member alignment padding -- // offset(92)            size(4)
-        g: array<A, 3>;    // element stride 32       offset(96)  align(8)  size(96)
-        h: i32;                                    // offset(192) align(4)  size(4)
+        g: array<A, 3>,    // element stride 32       offset(96)  align(8)  size(96)
+        h: i32                                     // offset(192) align(4)  size(4)
         // -- implicit struct size padding --      // offset(196)           size(12)
     }
 
@@ -1982,17 +1982,17 @@ to WGSL.
 <div class='example wgsl global-scope' heading='Satisfying offset requirements for uniform address space'>
   <xmp highlight='rust'>
     struct S {
-      x: f32;
+      x: f32
     }
     struct Invalid {
-      a: S;
-      b: f32; // invalid: offset between a and b is 4 bytes, but must be at least 16
+      a: S,
+      b: f32 // invalid: offset between a and b is 4 bytes, but must be at least 16
     }
     @group(0) @binding(0) var<uniform> invalid: Invalid;
 
     struct Valid {
-      a: S;
-      @align(16) b: f32; // valid: offset between a and b is 16 bytes
+      a: S,
+      @align(16) b: f32 // valid: offset between a and b is 16 bytes
     }
     @group(0) @binding(1) var<uniform> valid: Valid;
   </xmp>
@@ -2001,15 +2001,15 @@ to WGSL.
 <div class='example wgsl global-scope' heading='Satisfying stride requirements for uniform address space'>
   <xmp highlight='rust'>
     struct small_stride {
-      a: array<f32,8>; // stride 4
+      a: array<f32,8> // stride 4
     }
     @group(0) @binding(0) var<uniform> invalid: small_stride; // Invalid
 
     struct wrapped_f32 {
-      @size(16) elem: f32;
+      @size(16) elem: f32
     }
     struct big_stride {
-      a: array<wrapped_f32,8>; // stride 16
+      a: array<wrapped_f32,8> // stride 16
     }
     @group(0) @binding(1) var<uniform> valid: big_stride;     // Valid
   </xmp>
@@ -2217,13 +2217,13 @@ Note: The following examples use WGSL features explained later in this specifica
 <div class='example wgsl' heading='Using a pointer as a short name for part of a variable'>
   <xmp highlight='rust'>
     struct Particle {
-      position: vec3<f32>;
-      velocity: vec3<f32>;
+      position: vec3<f32>,
+      velocity: vec3<f32>
     }
     struct System {
-      active_index: i32;
-      timestep: f32;
-      particles: array<Particle,100>;
+      active_index: i32,
+      timestep: f32,
+      particles: array<Particle,100>
     }
     @group(0) @binding(0) var<storage,read_write> system: System;
 
@@ -2305,8 +2305,8 @@ In all cases, the access mode of the result is the same as the access mode of th
 <div class='example wgsl' heading='Component reference from a composite reference'>
   <xmp highlight='rust'>
     struct S {
-        age: i32;
-        weight: f32;
+        age: i32,
+        weight: f32
     }
     var<private> person: S;
     // Uses of 'person' denote the reference to the memory underlying the variable,
@@ -2969,7 +2969,7 @@ When the type declaration is an [=identifier=], then the expression must be in s
     var<storage,read_write> buf3: Buffer; // Can both read and write.
 
     // Uniform buffer. Always read-only, and has more restrictive layout rules.
-    struct ParamsTable {weight: f32;}
+    struct ParamsTable {weight: f32}
     @group(0) @binding(2)
     var<uniform> params: ParamsTable;     // Can read, cannot write.
   </xmp>
@@ -3187,8 +3187,8 @@ WGSL defines the following attributes that can be applied to global variables:
     var<workgroup> worklist: array<i32,10>;
 
     struct Params {
-      specular: f32;
-      count: i32;
+      specular: f32,
+      count: i32
     }
     @group(0) @binding(2)
     var<uniform> param: Params;    // A uniform buffer
@@ -3693,9 +3693,9 @@ Note: WGSL does not have zero expression for [=atomic types=],
 <div class='example wgsl global-scope' heading="Zero-valued structures">
   <xmp highlight='rust'>
     struct Student {
-      grade: i32;
-      GPA: f32;
-      attendance: array<bool,4>;
+      grade: i32,
+      GPA: f32,
+      attendance: array<bool,4>
     }
 
     fn func() {
@@ -5037,8 +5037,8 @@ See [[#forming-references-and-pointers]] for other cases.
     <div class='example wgsl' heading='Assignments'>
       <xmp highlight='rust'>
         struct S {
-            age: i32;
-            weight: f32;
+            age: i32,
+            weight: f32
         }
         var<private> person: S;
 
@@ -5111,8 +5111,8 @@ A phony-assignment is useful for:
 <div class='example wgsl global-scope' heading='Using phony-assignment to occupy bindings without using them'>
   <xmp highlight=rust>
     struct BufferContents {
-        counter: atomic<u32>;
-        data: array<vec4<f32>>;
+        counter: atomic<u32>,
+        data: array<vec4<f32>>
     }
     @group(0) @binding(0) var<storage> buf: BufferContents;
     @group(0) @binding(1) var t: texture_2d<f32>;
@@ -6762,9 +6762,9 @@ Note: The number of available locations for an entry point is defined by the Web
 <div class='example wgsl applying location attribute' heading='Applying location attributes'>
   <xmp>
     struct A {
-      @location(0) x: f32;
+      @location(0) x: f32,
       // Despite locations being 16-bytes, x and y cannot share a location
-      @location(1) y: f32;
+      @location(1) y: f32
     }
 
     // in1 occupies locations 0 and 1.
@@ -6783,14 +6783,14 @@ User-defined IO can be mixed with built-in values in the same structure. For exa
   <xmp>
     // Mixed builtins and user-defined inputs.
     struct MyInputs {
-      @location(0) x: vec4<f32>;
-      @builtin(front_facing) y: bool;
-      @location(1) @interpolate(flat) z: u32;
+      @location(0) x: vec4<f32>,
+      @builtin(front_facing) y: bool,
+      @location(1) @interpolate(flat) z: u32
     }
 
     struct MyOutputs {
-      @builtin(frag_depth) x: f32;
-      @location(0) y: vec4<f32>;
+      @builtin(frag_depth) x: f32,
+      @location(0) y: vec4<f32>
     }
 
     @stage(fragment)
@@ -6803,22 +6803,22 @@ User-defined IO can be mixed with built-in values in the same structure. For exa
 <div class='example wgsl invalid locations' heading='Invalid location assignments'>
   <xmp>
     struct A {
-      @location(0) x: f32;
+      @location(0) x: f32,
       // Invalid, x and y cannot share a location.
-      @location(0) y: f32;
+      @location(0) y: f32
     }
 
     struct B {
-      @location(0) x: f32;
+      @location(0) x: f32
     }
 
     struct C {
       // Invalid, structures with user-defined IO cannot be nested.
-      b: B;
+      b: B
     }
 
     struct D {
-      x: vec4<f32>;
+      x: vec4<f32>
     }
 
     @stage(fragment)
@@ -7816,9 +7816,9 @@ member.
 <div class='example wgsl memory locations accessed' heading="Accessing memory locations">
   <xmp>
     struct S {
-      a : f32;
-      b : u32;
-      c : f32;
+      a : f32,
+      b : u32,
+      c : f32
     }
 
     @group(0) @binding(0)
@@ -9785,7 +9785,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in value.
 <div class='example wgsl global-scope' heading="Declaring built-in values">
   <xmp>
     struct VertexOutput {
-      @builtin(position) my_pos: vec4<f32>;
+      @builtin(position) my_pos: vec4<f32>
     }
 
     @stage(vertex)
@@ -9795,8 +9795,8 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in value.
     ) -> VertexOutput {}
 
     struct FragmentOutput {
-      @builtin(frag_depth) depth: f32;
-      @builtin(sample_mask) mask_out: u32;
+      @builtin(frag_depth) depth: f32,
+      @builtin(sample_mask) mask_out: u32
     }
 
     @stage(fragment)
@@ -10034,8 +10034,8 @@ See [[#function-calls]].
     Returns the `__frexp_result` built-in structure, defined as if as follows:
     ```rust
 struct __frexp_result {
-  sig : f32; // significand part
-  exp : i32; // exponent part
+  sig : f32, // significand part
+  exp : i32  // exponent part
 }
     ```
     The magnitude of the significand is in the range of [0.5, 1.0) or 0.
@@ -10058,8 +10058,8 @@ struct __frexp_result {
     Returns the `__frexp_result_vec`|N| built-in structure, defined as if as follows:
     ```rust
 struct __frexp_result_vecN {
-  sig : vecN<f32>; // significand part
-  exp : vecN<i32>; // exponent part
+  sig : vecN<f32>, // significand part
+  exp : vecN<i32>  // exponent part
 }
     ```
     The magnitude of each component of the significand is in the range of [0.5, 1.0) or 0.
@@ -10135,8 +10135,8 @@ struct __frexp_result_vecN {
     Returns the `__modf_result` built-in structure, defined as if as follows:
     ```rust
 struct __modf_result {
-  fract : f32; // fractional part
-  whole : f32; // whole part
+  fract : f32, // fractional part
+  whole : f32  // whole part
 }
     ```
 
@@ -10158,8 +10158,8 @@ struct __modf_result {
     Returns the `__modf_result_vec`|N| built-in structure, defined as if as follows:
     ```rust
 struct __modf_result_vecN {
-  fract : vecN<f32>; // fractional part
-  whole : vecN<f32>; // whole part
+  fract : vecN<f32>, // fractional part
+  whole : vecN<f32>  // whole part
 }
     ```
 


### PR DESCRIPTION
Fixes #2587

* Change the separator for struct members from semicolons to commas
  * Comma is optional after the last member
* Changes the grammar to require one or more struct members
  * Already required by the prose of the spec