### PR TITLE
Make use of automatic pipeline layouts explicit

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4698,8 +4698,12 @@ and switched as one
 ## Base pipelines ## {#pipeline-base}
 
 <script type=idl>
+enum GPUAutoLayoutMode {
+    "auto",
+};
+
 dictionary GPUPipelineDescriptorBase : GPUObjectDescriptorBase {
-    GPUPipelineLayout layout;
+    required (GPUPipelineLayout or GPUAutoLayoutMode) layout;
 };
 
 interface mixin GPUPipelineBase {
@@ -4754,8 +4758,13 @@ interface mixin GPUPipelineBase {
 
 ### Default pipeline layout ### {#default-pipeline-layout}
 
-A {{GPUPipelineBase}} object that was created without a {{GPUPipelineDescriptorBase/layout}}
-has a default layout created and used instead.
+A {{GPUPipelineBase}} object that was created with a {{GPUPipelineDescriptorBase/layout}} set to
+{{GPUAutoLayoutMode/"auto"}} has a default layout created and used instead.
+
+Note: Default layouts are provided as a convenience for simple pipelines, but use of explicit layouts
+is recommended in most cases. Bind groups created from default layouts cannot be used with other
+pipelines, and the structure of the default layout may change when altering shaders, causing
+unexpected bind group creation errors.
 
 <div algorithm="default pipeline layout creation">
 
@@ -5184,13 +5193,16 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
 
             1. Let |pipeline| be a new valid {{GPUComputePipeline}} object.
             1. Issue the following steps on the [=Device timeline=] of |this|:
+                1. Let |layout| be a new [$default pipeline layout$] for |pipeline| if
+                    |descriptor|.{{GPUPipelineDescriptorBase/layout}} is {{GPUAutoLayoutMode/"auto"}},
+                    and |descriptor|.{{GPUPipelineDescriptorBase/layout}} otherwise.
+
                 <div class=device-timeline>
                     1. If any of the following conditions are unsatisfied:
                         <div class=validusage>
-                            - |descriptor|.{{GPUPipelineDescriptorBase/layout}} is [$valid to use with$] |this|.
+                            - |layout| is [$valid to use with$] |this|.
                             - [$validating GPUProgrammableStage$]({{GPUShaderStage/COMPUTE}},
-                                |descriptor|.{{GPUComputePipelineDescriptor/compute}},
-                                |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
+                                |descriptor|.{{GPUComputePipelineDescriptor/compute}}, |layout|) succeeds.
                             - |descriptor|.{{GPUComputePipelineDescriptor/compute}} uses &le;
                                 |device|.limits.{{supported limits/maxComputeWorkgroupStorageSize}} bytes of
                                 workgroup storage.
@@ -5211,11 +5223,7 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
                             1. [$Generate a validation error$]
                             1. Make |pipeline| [=invalid=].
 
-                    1. If |descriptor|.{{GPUPipelineDescriptorBase/layout}} is `undefined`:
-                        1. Set |pipeline|.{{GPUPipelineBase/[[layout]]}} to a new [$default pipeline layout$]
-                            for |pipeline|.
-
-                        Otherwise set |pipeline|.{{GPUPipelineBase/[[layout]]}} to |descriptor|.{{GPUPipelineDescriptorBase/layout}}.
+                    1. Set |pipeline|.{{GPUPipelineBase/[[layout]]}} to |layout|.
                 </div>
             1. Return |pipeline|.
 
@@ -5363,10 +5371,14 @@ details.
             1. Let |pipeline| be a new valid {{GPURenderPipeline}} object.
             1. Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
+                    1. Let |layout| be a new [$default pipeline layout$] for |pipeline| if
+                        |descriptor|.{{GPUPipelineDescriptorBase/layout}} is {{GPUAutoLayoutMode/"auto"}},
+                        and |descriptor|.{{GPUPipelineDescriptorBase/layout}} otherwise.
+
                     1. If any of the following conditions are unsatisfied:
                         <div class=validusage>
-                            - |descriptor|.{{GPUPipelineDescriptorBase/layout}} is [$valid to use with$] |this|.
-                            - [$validating GPURenderPipelineDescriptor$](|descriptor|, |this|) succeeds.
+                            - |layout| is [$valid to use with$] |this|.
+                            - [$validating GPURenderPipelineDescriptor$](|descriptor|, |layout|, |this|) succeeds.
                         </div>
 
                         Then:
@@ -5391,11 +5403,7 @@ details.
                                 |stencilBack|.{{GPUStencilFaceState/depthFailOp}}, or |stencilBack|.{{GPUStencilFaceState/failOp}}
                                 is not {{GPUStencilOperation/"keep"}}:
                                 1. Set |pipeline|.{{GPURenderPipeline/[[writesStencil]]}} to true.
-                    1. If |descriptor|.{{GPUPipelineDescriptorBase/layout}} is `undefined`:
-                        1. Set |pipeline|.{{GPUPipelineBase/[[layout]]}} to a new [$default pipeline layout$]
-                            for |pipeline|.
-
-                        Otherwise set |pipeline|.{{GPUPipelineBase/[[layout]]}} to |descriptor|.{{GPUPipelineDescriptorBase/layout}}.
+                    1. Set |pipeline|.{{GPUPipelineBase/[[layout]]}} to |layout|.
                 </div>
             1. Return |pipeline|.
 
@@ -5435,22 +5443,21 @@ details.
 </dl>
 
 <div algorithm>
-    <dfn abstract-op>validating GPURenderPipelineDescriptor</dfn>(descriptor, device)
+    <dfn abstract-op>validating GPURenderPipelineDescriptor</dfn>(descriptor, layout, device)
         **Arguments:**
             - {{GPURenderPipelineDescriptor}} |descriptor|
+            - {{GPUPipelineLayout}} |layout|
             - {{GPUDevice}} |device|
 
         Return `true` if all of the following conditions are satisfied:
 
             - [$validating GPUProgrammableStage$]({{GPUShaderStage/VERTEX}},
-                |descriptor|.{{GPURenderPipelineDescriptor/vertex}},
-                |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
+                |descriptor|.{{GPURenderPipelineDescriptor/vertex}}, |layout|) succeeds.
             - [$validating GPUVertexState$](|device|, |descriptor|.{{GPURenderPipelineDescriptor/vertex}},
                 |descriptor|.{{GPURenderPipelineDescriptor/vertex}}) succeeds.
             - If |descriptor|.{{GPURenderPipelineDescriptor/fragment}} is not `null`:
                 - [$validating GPUProgrammableStage$]({{GPUShaderStage/FRAGMENT}},
-                    |descriptor|.{{GPURenderPipelineDescriptor/fragment}},
-                    |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
+                    |descriptor|.{{GPURenderPipelineDescriptor/fragment}}, |layout|) succeeds.
                 - [$validating GPUFragmentState$](|descriptor|.{{GPURenderPipelineDescriptor/fragment}}) succeeds.
                 - If the "sample_mask" [=builtin=] is a [=pipeline output=] of |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
                     - |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/alphaToCoverageEnabled}} is `false`.


### PR DESCRIPTION
Fixes #2636

Changed default pipeline layout creation to be something that is explicitly requested with the `"auto"` enum. Along the way, fixes a minor but in which some of the validation algorithms were previously not operating on the actual layouts when using a default layout.

Also adds a note to explain that default layouts are not recommended in most cases.