### PR TITLE
[editorial] Compress expression tables

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4327,7 +4327,7 @@ See [[#sync-builtin-functions]].
     <td>|e1| `%` |e2| : |T|
     <td>Remainder. [=Component-wise=] when |T| is a vector.
 
-       If |T| is a signed integral type, the scalar case, evaluates |e1| and |e2| once, and evaluates to:
+       If |T| is a signed integral scalar type, evaluates |e1| and |e2| once, and evaluates to:
        * 0, when |e2| is zero.
        * 0, when |e1| is the most negative value in |T|, and |e2| is -1.
        * Otherwise, |e1|&nbsp;-&nbsp;[=truncate=](|e1|&nbsp;&div;&nbsp;|e2|)&nbsp;&times;&nbsp;|e2|
@@ -4346,7 +4346,7 @@ See [[#sync-builtin-functions]].
                result is e1 - truncate(e1/Divisor) * Divisor
         -->
 
-        If |T| is an unsigned integral type, the scalar case, evaluates to:
+        If |T| is an unsigned integral scalar type, evaluates to:
         * 0, when |e2| is zero.
         * Otherwise, the integer |r| such that
             |e1|&nbsp;=&nbsp;|q|&nbsp;&times;&nbsp;|e2|&nbsp;+&nbsp;|r|,

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12,6 +12,7 @@ Text Macro: UNSIGNEDINTEGRAL u32 or vec|N|&lt;u32&gt;
 Text Macro: SIGNEDINTEGRAL i32 or vec|N|&lt;i32&gt;
 Text Macro: INTEGRAL i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;
 Text Macro: FLOATING f32 or vec|N|&lt;f32&gt;
+Text Macro: NUMERIC i32, u32, f32, vec|N|&lt;i32&gt;, vec|N|&lt;u32&gt;, or vec|N|&lt;f32&gt;
 Ignored Vars: i, c0, e, e1, e2, e3, eN, p, s1, s2, sn, N, M, v, Stride, Offset, Align, Extent, S, T, T1
 
 !Participate: <a href="https://github.com/gpuweb/gpuweb/issues/new?labels=wgsl">File an issue</a> (<a href="https://github.com/gpuweb/gpuweb/issues?q=is%3Aissue+is%3Aopen+label%3Awgsl">open issues</a>)
@@ -4262,15 +4263,11 @@ See [[#sync-builtin-functions]].
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
-  <tr algorithm="integer negation"><td>|e|: |T|<br>
-  |T| is [SIGNEDINTEGRAL]
+  <tr algorithm="negation"><td>|e|: |T|<br>
+  |T| is i32, f32, vec|N|&lt;i32&gt;, or vec|N|&lt;f32&gt;
   <td>`-`|e|`:` |T|
-  <td>Signed integer negation. [=Component-wise=] when |T| is a vector.
-  If |e| evaluates to the largest negative value, then the result is |e|.
-
-  <tr algorithm="floating point negation"><td>|e|: |T|<br>|T| is [FLOATING]
-  <td>`-`|e|`:` |T|
-  <td>Floating point negation. [=Component-wise=] when |T| is a vector.
+  <td>Negation. [=Component-wise=] when |T| is a vector.
+  If |T| is an integral type and |e| evaluates to the largest negative value, then the result is |e|.
 </table>
 
 <table class='data'>
@@ -4279,39 +4276,30 @@ See [[#sync-builtin-functions]].
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
 
-  <tr algorithm="integer addition">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [INTEGRAL]
+  <tr algorithm="addition">
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [NUMERIC]
     <td>|e1| `+` |e2| : |T|
-    <td>Integer addition, modulo 2<sup>32</sup>. [=Component-wise=] when |T| is a vector.
-  <tr algorithm="floating point addition">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [FLOATING]
-    <td>|e1| `+` |e2| : |T|
-    <td>Floating point addition. [=Component-wise=] when |T| is a vector.
+    <td>Addition. [=Component-wise=] when |T| is a vector.
+    If |T| is an integral type, then the result is modulo 2<sup>32</sup>.
 
-  <tr algorithm="integer subtraction">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [INTEGRAL]
+  <tr algorithm="subtraction">
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [NUMERIC]
     <td>|e1| `-` |e2| : |T|
-    <td>Integer subtraction, modulo 2<sup>32</sup>. [=Component-wise=] when |T| is a vector.
-  <tr algorithm="floating point subtraction">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [FLOATING]
-    <td>|e1| `-` |e2| : |T|
-    <td>Floating point subtraction. [=Component-wise=] when |T| is a vector.
+    <td>Subtraction [=Component-wise=] when |T| is a vector.
+    If |T| is an integral type, then the result is modulo 2<sup>32</sup>.
 
-  <tr algorithm="integer multiplication">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [INTEGRAL]
+  <tr algorithm="multiplication">
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [NUMERIC]
     <td>|e1| `*` |e2| : |T|
-    <td>Integer multiplication, modulo 2<sup>32</sup>. [=Component-wise=] when |T| is a vector.
-  <tr algorithm="floating point multiplication">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [FLOATING]
-    <td>|e1| `*` |e2| : |T|
-    <td>Floating point multiplication. [=Component-wise=] when |T| is a vector.
+    <td>Multiplication. [=Component-wise=] when |T| is a vector.
+    If |T| is an integral type, then the result is modulo 2<sup>32</sup>.
 
-  <tr algorithm="signed integer division">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [SIGNEDINTEGRAL]
+  <tr algorithm="division">
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [NUMERIC]
     <td>|e1| `/` |e2| : |T|
-    <td>Signed integer division. [=Component-wise=] when |T| is a vector.
+    <td>Division. [=Component-wise=] when |T| is a vector.
 
-        In the scalar case, evaluates to:
+        If |T| is a signed integral type, the scalar case, evaluates to:
         * |e1|, when |e2| is zero.
         * |e1|, when |e1| is the most negative value in |T|, and |e2| is -1.
         * [=truncate=](|x|) otherwise, where |x| is the
@@ -4328,28 +4316,18 @@ See [[#sync-builtin-functions]].
                result is truncate(e1/Divisor)
         -->
 
-  <tr algorithm="unsigned integer division">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [UNSIGNEDINTEGRAL]
-    <td>|e1| `/` |e2| : |T|
-    <td>Unsigned integer division. [=Component-wise=] when |T| is a vector.
-
-        In the scalar case, evaluates to:
+        If |T| is an unsigned integral type, the scalar case, evaluates to:
         * |e1|, when |e2| is zero.
         * Otherwise, the integer |q| such that
             |e1|&nbsp;=&nbsp;|q|&nbsp;&times;&nbsp;|e2|&nbsp;+&nbsp;|r|,
             where 0 &le; |r| &lt; |e2|.
 
-  <tr algorithm="floating point division">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [FLOATING]
-    <td>|e1| `/` |e2| : |T|
-    <td>Floating point division. [=Component-wise=] when |T| is a vector.
-
-  <tr algorithm="signed integer remainder">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [SIGNEDINTEGRAL]
+  <tr algorithm="Remainder">
+    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [NUMERIC]
     <td>|e1| `%` |e2| : |T|
-    <td>Signed integer remainder. [=Component-wise=] when |T| is a vector.
+    <td>Remainder. [=Component-wise=] when |T| is a vector.
 
-       In the scalar case, evaluates |e1| and |e2| once, and evaluates to:
+       If |T| is a signed integral type, the scalar case, evaluates |e1| and |e2| once, and evaluates to:
        * 0, when |e2| is zero.
        * 0, when |e1| is the most negative value in |T|, and |e2| is -1.
        * Otherwise, |e1|&nbsp;-&nbsp;[=truncate=](|e1|&nbsp;&div;&nbsp;|e2|)&nbsp;&times;&nbsp;|e2|
@@ -4368,22 +4346,13 @@ See [[#sync-builtin-functions]].
                result is e1 - truncate(e1/Divisor) * Divisor
         -->
 
-  <tr algorithm="unsigned integer remainder">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [UNSIGNEDINTEGRAL]
-    <td>|e1| `%` |e2| : |T|
-    <td>Unsigned integer remainder. [=Component-wise=] when |T| is a vector.
-
-        In the scalar case, evaluates to:
+        If |T| is an unsigned integral type, the scalar case, evaluates to:
         * 0, when |e2| is zero.
         * Otherwise, the integer |r| such that
             |e1|&nbsp;=&nbsp;|q|&nbsp;&times;&nbsp;|e2|&nbsp;+&nbsp;|r|,
             where |q| is an integer and 0 &le; |r| &lt; |e2|.
 
-  <tr algorithm="floating point remainder">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [FLOATING]
-    <td>|e1| `%` |e2| : |T|
-    <td>Floating point remainder, where sign of non-zero result matches sign of |e1|. [=Component-wise=] when |T| is a vector.<br>
-        Result equal to: |e1| - |e2| * trunc(|e1| / |e2|)<br>
+        If |T| is a floating point type, the result is equal to:<br> |e1| - |e2| * trunc(|e1| / |e2|)
 
 </table>
 
@@ -4477,116 +4446,44 @@ See [[#sync-builtin-functions]].
     <tr><th>Precondtion<th>Conclusion<th>Notes
   </thead>
 
-  <tr algorithm="bool equality">
-    <td>|e1|: |T|<br>|e2|: |T|<br>|T| is bool or vec|N|&lt;bool&gt;
-    <td class="nowrap">|e1| `==` |e2|`:` |T|
-    <td>Equality. [=Component-wise=] when |T| is a vector.
-  <tr algorithm="bool inequality">
-    <td>|e1|: |T|<br>|e2|: |T|<br>|T| is bool or vec|N|&lt;bool&gt;
-    <td class="nowrap">|e1| `!=` |e2|`:` |T|
-    <td>Inequality. [=Component-wise=] when |T| is a vector.
-
-  <tr algorithm="integer equality">
-    <td>|e1|: |TI|<br>|e2|: |TI|<br>
-    |TI| is [INTEGRAL]<br>
-    |TB| is bool if |TI| is scalar, or<br>
-    vec|N|&lt;bool&gt; if |TI| is a vector
+  <tr algorithm="equality">
+    <td>|e1|: |T|<br>|e2|: |T|<br>
+    |T| is bool, i32, u32, f32, vec|N|&lt;bool&gt;, vec|N|&lt;i32&gt;, vec|N|&lt;u32&gt;, or vec|N|&lt;f32&gt;<br>
+    |TB| is bool if |T| is scalar, or<br>
+    vec|N|&lt;bool&gt; if |T| is a vector
     <td class="nowrap">|e1| `==` |e2|`:` |TB|
-    <td>Equality. [=Component-wise=] when |TI| is a vector.
-  <tr algorithm="integer inequality">
-    <td>|e1|: |TI|<br>|e2|: |TI|<br>
-    |TI| is [INTEGRAL]<br>
-    |TB| is bool if |TI| is scalar, or<br>
-    vec|N|&lt;bool&gt; if |TI| is a vector
+    <td>Equality. [=Component-wise=] when |T| is a vector.
+  <tr algorithm="inequality">
+    <td>|e1|: |T|<br>|e2|: |T|<br>
+    |T| is [NUMERIC]<br>
+    |TB| is bool if |T| is scalar, or<br>
+    vec|N|&lt;bool&gt; if |T| is a vector
     <td class="nowrap">|e1| `!=` |e2|`:` |TB|
-    <td>Inequality. [=Component-wise=] when |TI| is a vector.
-
-  <tr algorithm="signed integer less than">
-    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is [SIGNEDINTEGRAL]<br>
-    |TB| is bool if |TI| is scalar, or<br>
-    vec|N|&lt;bool&gt; if |TI| is a vector
+    <td>Inequality. [=Component-wise=] when |T| is a vector.
+  <tr algorithm="less than">
+    <td>|e1|: |T|<br>|e2|: |T|<br>|T| is [NUMERIC]<br>
+    |TB| is bool if |T| is scalar, or<br>
+    vec|N|&lt;bool&gt; if |T| is a vector
     <td class="nowrap">|e1| `<` |e2|`:` |TB|
-    <td>Less than. [=Component-wise=] when |TI| is a vector.
-  <tr algorithm="signed integer less than equal">
-    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is [SIGNEDINTEGRAL]<br>
-    |TB| is bool if |TI| is scalar, or<br>
-    vec|N|&lt;bool&gt; if |TI| is a vector
+    <td>Less than. [=Component-wise=] when |T| is a vector.
+  <tr algorithm="less than equal">
+    <td>|e1|: |T|<br>|e2|: |T|<br>|T| is [NUMERIC]<br>
+    |TB| is bool if |T| is scalar, or<br>
+    vec|N|&lt;bool&gt; if |T| is a vector
     <td class="nowrap">|e1| `<=` |e2|`:` |TB|
-    <td>Less than or equal. [=Component-wise=] when |TI| is a vector.
-  <tr algorithm="signed integer greater than">
-    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is [SIGNEDINTEGRAL]<br>
-    |TB| is bool if |TI| is scalar, or<br>
-    vec|N|&lt;bool&gt; if |TI| is a vector
+    <td>Less than or equal. [=Component-wise=] when |T| is a vector.
+  <tr algorithm="greater than">
+    <td>|e1|: |T|<br>|e2|: |T|<br>|T| is [NUMERIC]<br>
+    |TB| is bool if |T| is scalar, or<br>
+    vec|N|&lt;bool&gt; if |T| is a vector
     <td class="nowrap">|e1| `>` |e2|`:` |TB|
-    <td>Greater than. [=Component-wise=] when |TI| is a vector.
-  <tr algorithm="signed integer greater than equal">
-    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is [SIGNEDINTEGRAL]<br>
-    |TB| is bool if |TI| is scalar, or<br>
-    vec|N|&lt;bool&gt; if |TI| is a vector
+    <td>Greater than. [=Component-wise=] when |T| is a vector.
+  <tr algorithm="greater than equal">
+    <td>|e1|: |T|<br>|e2|: |T|<br>|T| is [NUMERIC]<br>
+    |TB| is bool if |T| is scalar, or<br>
+    vec|N|&lt;bool&gt; if |T| is a vector
     <td class="nowrap">|e1| `>=` |e2|`:` |TB|
-    <td>Greater than or equal. [=Component-wise=] when |TI| is a vector.
-
-  <tr algorithm="unsigned integer less than">
-    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is [UNSIGNEDINTEGRAL]<br>
-    |TB| is bool if |TI| is scalar, or<br>
-    vec|N|&lt;bool&gt; if |TI| is a vector
-    <td class="nowrap">|e1| `<` |e2|`:` |TB|
-    <td>Less than. [=Component-wise=] when |TI| is a vector.
-  <tr algorithm="unsigned integer less than equal">
-    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is [UNSIGNEDINTEGRAL]<br>
-    |TB| is bool if |TI| is scalar, or<br>
-    vec|N|&lt;bool&gt; if |TI| is a vector
-    <td class="nowrap">|e1| `<=` |e2|`:` |TB|
-    <td>Less than or equal. [=Component-wise=] when |TI| is a vector.
-  <tr algorithm="unsigned integer greater than">
-    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is [UNSIGNEDINTEGRAL]<br>
-    |TB| is bool if |TI| is scalar, or<br>
-    vec|N|&lt;bool&gt; if |TI| is a vector
-    <td class="nowrap">|e1| `>` |e2|`:` |TB|
-    <td>Greater than. [=Component-wise=] when |TI| is a vector.
-  <tr algorithm="unsigned integer greater than equal">
-    <td>|e1|: |TI|<br>|e2|: |TI|<br>|TI| is [UNSIGNEDINTEGRAL]<br>
-    |TB| is bool if |TI| is scalar, or<br>
-    vec|N|&lt;bool&gt; if |TI| is a vector
-    <td class="nowrap">|e1| `>=` |e2|`:` |TB|
-    <td>Greater than or equal. [=Component-wise=] when |TI| is vector.
-
-  <tr algorithm="floating point equality">
-    <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is [FLOATING]<br>
-    |TB| is bool if |TF| is scalar, or<br>
-    vec|N|&lt;bool&gt; if |TF| is a vector.
-    <td class="nowrap">|e1| == |e2|: |TB|
-    <td>Equality. [=Component-wise=] when |TF| is a vector.
-  <tr algorithm="floating point inequality">
-    <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is [FLOATING]<br>
-    |TB| is bool if |TF| is scalar, or<br>
-    vec|N|&lt;bool&gt; if |TF| is a vector.
-    <td class="nowrap">|e1| != |e2|: |TB|
-    <td>Inequality. [=Component-wise=] when |TF| is a vector.
-  <tr algorithm="floating point less than">
-    <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is [FLOATING]<br>
-    |TB| is bool if |TF| is scalar, or<br>
-    vec|N|&lt;bool&gt; if |TF| is a vector.
-    <td class="nowrap">|e1| < |e2|: |TB|
-    <td>Less than. [=Component-wise=] when |TF| is a vector.
-  <tr algorithm="floating point less than equal">
-    <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is [FLOATING]<br>
-    |TB| is bool if |TF| is scalar, or<br>
-    vec|N|&lt;bool&gt; if |TF| is a vector.
-    <td class="nowrap">|e1| <= |e2|: |TB|
-    <td>Less than or equal. [=Component-wise=] when |TF| is a vector.
-  <tr algorithm="floating point greater than">
-    <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is [FLOATING]<br>
-    |TB| is bool if |TF| is scalar, or<br>
-    vec|N|&lt;bool&gt; if |TF| is a vector.
-    <td class="nowrap">|e1| > |e2|: |TB|
-    <td>Greater than. [=Component-wise=] when |TF| is a vector.
-  <tr algorithm="floating point greater than equal">
-    <td>|e1|: |TF|<br>|e2|: |TF|<br>|TF| is [FLOATING]<br>
-    |TB| is bool if |TF| is scalar, or<br>
-    vec|N|&lt;bool&gt; if |TF| is a vector.
-    <td class="nowrap">|e1| >= |e2|: |TB|
-    <td>Greater than or equal. [=Component-wise=] when |TF| is a vector.
+    <td>Greater than or equal. [=Component-wise=] when |T| is a vector.
 
 </table>
 


### PR DESCRIPTION
* Combine arithmetic and comparison expression table entries for
  integral and floating-point entries
  * since SPIR-V mappings were removed there is no strong need to have
    separate entries