### PR TITLE
Add GPUAdaperInfo to the spec

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1530,10 +1530,10 @@ but which the user agent has not been updated to recognize yet. If the [=set ent
 
 {{GPUAdapterInfo}} exposes various identifying information about an adapter.
 
-Note: None of the values in {{GPUAdapterInfo}} are guaranteed to be populated. It is at the user
+None of the members in {{GPUAdapterInfo}} are guaranteed to be populated. It is at the user
 agent's discretion which values to reveal, and it is likely that on some devices none of the values
-will be populated. As such applications should not be dependent on any values from {{GPUAdapterInfo}}
-to function.
+will be populated. As such, applications **must** be able to handle any possible {{GPUAdapterInfo}} values,
+including the absence of those values.
 
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
@@ -1586,23 +1586,39 @@ interface GPUAdapterInfo {
     1. If |unmaskedValues| [=set/contains=] `"vendor"` and the vendor is known:
         1. Set |adapterInfo|.{{GPUAdapterInfo/vendor}} to the name of |adapter|'s vendor as a
             [$normalized identifier string$].
-        1. Otherwise set |adapterInfo|.{{GPUAdapterInfo/vendor}} to the empty string or a
+        
+        Otherwise:
+        
+        1. Set |adapterInfo|.{{GPUAdapterInfo/vendor}} to the empty string or a
             reasonable approximation of the vendor as a [$normalized identifier string$].
+
     1. If |unmaskedValues| [=set/contains=] `"architecture"` and the architecture is known:
         1. Set |adapterInfo|.{{GPUAdapterInfo/architecture}} to a [$normalized identifier string$]
             representing the family or class of adapters to which |adapter| belongs.
-        1. Otherwise set |adapterInfo|.{{GPUAdapterInfo/architecture}} to the empty string or a
+
+        Otherwise:
+
+        1. Set |adapterInfo|.{{GPUAdapterInfo/architecture}} to the empty string or a
             reasonable approximation of the architecture as a [$normalized identifier string$].
+
     1. If |unmaskedValues| [=set/contains=] `"deviceId"` and the deviceId is known:
         1. Set |adapterInfo|.{{GPUAdapterInfo/deviceId}} to a vendor-specific numeric ID for
             |adapter|.
-        1. Otherwise set |adapterInfo|.{{GPUAdapterInfo/deviceId}} to `0` or a reasonable
+
+        Otherwise:
+
+        1. Set |adapterInfo|.{{GPUAdapterInfo/deviceId}} to `0` or a reasonable
             approximation of the vendor-specific numeric ID for |adapter|.
+
     1. If |unmaskedValues| [=set/contains=] `"description"` and a description is known:
         1. Set |adapterInfo|.{{GPUAdapterInfo/description}} to a description of the |adapter| as
             reported by the driver.
-        1. Otherwise set |adapterInfo|.{{GPUAdapterInfo/vendor}} to the empty string or a
+
+        Otherwise:
+
+        1. Set |adapterInfo|.{{GPUAdapterInfo/description}} to the empty string or a
             reasonable approximation of a description.
+            
     1. Return |adapterInfo|.
 </div>
 
@@ -1895,9 +1911,9 @@ interface GPUAdapter {
     [SameObject] readonly attribute GPUSupportedFeatures features;
     [SameObject] readonly attribute GPUSupportedLimits limits;
     readonly attribute boolean isFallbackAdapter;
-    readonly attribute GPUAdapterInfo info;
 
     Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor = {});
+    GPUAdapterInfo getAdapterInfo();
     Promise<GPUAdapterInfo> requestUnmaskedAdapterInfo(sequence<DOMString> hints);
 };
 </script>
@@ -1916,11 +1932,6 @@ interface GPUAdapter {
     : <dfn>isFallbackAdapter</dfn>
     ::
         Returns the value of {{GPUAdapter/[[adapter]]}}.{{adapter/[[fallback]]}}.
-
-    : <dfn>info</dfn>
-    ::
-        Returns a [$new adapter info$] for `this`.{{GPUAdapter/[[adapter]]}}.
-
 </dl>
 
 {{GPUAdapter}} has the following internal slots:
@@ -2001,6 +2012,19 @@ interface GPUAdapter {
                         [=a new device=] with the capabilities described by |descriptor|.
                 </div>
             1. Return |promise|.
+
+        </div>
+
+    : <dfn>getAdapterInfo()</dfn>
+    ::
+        Returns the currently available {{GPUAdapterInfo}} for this {{GPUAdapter}}.
+
+        <div algorithm=GPUAdapter.getAdapterInfo>
+            **Called on:** {{GPUAdapter}} |this|.
+
+            **Returns:** {{Promise}}&lt;{{GPUAdapterInfo}}&gt;
+
+            1. Return a [$new adapter info$] for |this|.{{GPUAdapter/[[adapter]]}}.
 
         </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1585,21 +1585,21 @@ interface GPUAdapterInfo {
     1. Let |unmaskedValues| be |adapter|.{{adapter/[[unmaskedIdentifiers]]}}
     1. If |unmaskedValues| [=set/contains=] `"vendor"` and the vendor is known:
         1. Set |adapterInfo|.{{GPUAdapterInfo/vendor}} to the name of |adapter|'s vendor as a
-            [$normalized identifier string$].
+            [=normalized identifier string=].
         
         Otherwise:
         
         1. Set |adapterInfo|.{{GPUAdapterInfo/vendor}} to the empty string or a
-            reasonable approximation of the vendor as a [$normalized identifier string$].
+            reasonable approximation of the vendor as a [=normalized identifier string=].
 
     1. If |unmaskedValues| [=set/contains=] `"architecture"` and the architecture is known:
-        1. Set |adapterInfo|.{{GPUAdapterInfo/architecture}} to a [$normalized identifier string$]
+        1. Set |adapterInfo|.{{GPUAdapterInfo/architecture}} to a [=normalized identifier string=]
             representing the family or class of adapters to which |adapter| belongs.
 
         Otherwise:
 
         1. Set |adapterInfo|.{{GPUAdapterInfo/architecture}} to the empty string or a
-            reasonable approximation of the architecture as a [$normalized identifier string$].
+            reasonable approximation of the architecture as a [=normalized identifier string=].
 
     1. If |unmaskedValues| [=set/contains=] `"deviceId"` and the deviceId is known:
         1. Set |adapterInfo|.{{GPUAdapterInfo/deviceId}} to a vendor-specific numeric ID for
@@ -1623,14 +1623,22 @@ interface GPUAdapterInfo {
 </div>
 
 <div algorithm>
-    To generate a <dfn abstract-op>normalized identifier string</dfn> for a given {{DOMString}}
-    |identifier|, run the following steps:
+    A <dfn>normalized identifier string</dfn> is one that follows the following pattern:
 
-    1. Let |normalized| be a copy of |identifier|.
-    1. Remove any non-ASCII characters from |normalized|.
-    1. Convert |normalized| to lowercase.
-    1. Replace any spaces in |normalized| with a hyphen character. (`"-"`)
-    1. Return |normalized|.
+    <pre class='railroad'>
+    OneOrMore:
+        OneOrMore:
+            T: a-z 0-9
+        T: -
+    </pre>
+
+    <div class="example">
+    Examples of valid normalized identifier strings include:
+        - `gpu`
+        - `3d`
+        - `next-gen`
+        - `series-x20-ultra`
+    </div>
 </div>
 
 ## Origin Restrictions ## {#origin-restrictions}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -594,7 +594,7 @@ available, so there's a desire to limit the precision with which we identify the
 
 There are several mitigations that can be applied to strike a balance between enabling robust
 content and preserving privacy. First is that user agents can reduce the burden on developers by
-identifying and working around known driver issues, as they have since browser began making use of
+identifying and working around known driver issues, as they have since browsers began making use of
 GPUs.
 
 When adapter identifiers are exposed by default they should be as broad as possible while still
@@ -607,7 +607,7 @@ bug reports) the user can be asked for consent to reveal additional information 
 to the page.
 
 Finally, the user agent will always have the discretion to not report adapter identifiers at all if
-if considers it appropriate, such as in enhanced privacy modes.
+it considers it appropriate, such as in enhanced privacy modes.
 
 # Fundamentals # {#fundamentals}
 
@@ -2044,10 +2044,14 @@ interface GPUAdapter {
 
             1. Let |promise| be [=a new promise=].
             1. Let |adapter| be |this|.{{GPUAdapter/[[adapter]]}}.
+            1. Let |hasActivation| be `true` if the [=relevant global object=] for |this| has
+                [=transient activation=], and `false` otherwise.
             1. Run the following steps [=in parallel=]:
                 1. If |unmaskHints|.length &gt; `0`:
-                    1. Let |unmaskedKeys| be a [=list=] of the fields specified in |unmaskHints| which the
-                        user agent decides to unmask, if any.
+                    1. If |hasActivation| is `false` [=reject=] |promise| with a {{NotAllowedError}}
+                        and abort these steps.
+                    1. Let |unmaskedKeys| be a [=list=] of the fields specified in |unmaskHints|
+                        which the user agent decides to unmask, if any.
 
                         Note: The user agent is free to use any method it deems appropriate to
                         decide which fields to unmask.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1618,7 +1618,7 @@ interface GPUAdapterInfo {
 
         1. Set |adapterInfo|.{{GPUAdapterInfo/description}} to the empty string or a
             reasonable approximation of a description.
-            
+
     1. Return |adapterInfo|.
 </div>
 
@@ -1913,8 +1913,7 @@ interface GPUAdapter {
     readonly attribute boolean isFallbackAdapter;
 
     Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor = {});
-    GPUAdapterInfo getAdapterInfo();
-    Promise<GPUAdapterInfo> requestUnmaskedAdapterInfo(sequence<DOMString> hints);
+    Promise<GPUAdapterInfo> requestAdapterInfo(optional sequence<DOMString> unmaskHints = []);
 };
 </script>
 
@@ -2015,33 +2014,22 @@ interface GPUAdapter {
 
         </div>
 
-    : <dfn>getAdapterInfo()</dfn>
+    : <dfn>requestAdapterInfo()</dfn>
     ::
-        Returns the currently available {{GPUAdapterInfo}} for this {{GPUAdapter}}.
+        Requests the {{GPUAdapterInfo}} for this {{GPUAdapter}}.
 
-        <div algorithm=GPUAdapter.getAdapterInfo>
-            **Called on:** {{GPUAdapter}} |this|.
+        Note: Adapter info values are returned with a Promise to give user agents an
+        opportunity to perform potentially long-running checks when requesting unmasked values,
+        such as asking for user consent before returning. If no `unmaskHints` are specified,
+        however, no dialogs should be displayed to the user.
 
-            **Returns:** {{Promise}}&lt;{{GPUAdapterInfo}}&gt;
-
-            1. Return a [$new adapter info$] for |this|.{{GPUAdapter/[[adapter]]}}.
-
-        </div>
-
-    : <dfn>requestUnmaskedAdapterInfo(hints)</dfn>
-    ::
-        Requests additional {{GPUAdapterInfo}} detail.
-
-        Note: Unmasked adapter info values are returned with a Promise to give user agents an
-        opportunity to perform potentially long-running checks, such as asking for user consent,
-        before returning.
-
-        <div algorithm=GPUAdapter.requestUnmaskedAdapterInfo>
+        <div algorithm=GPUAdapter.requestAdapterInfo>
             **Called on:** {{GPUAdapter}} |this|.
 
             **Arguments:**
-            <pre class=argumentdef for="GPUAdapter/requestUnmaskedAdapterInfo(hints)">
-                |hints|: A list of {{GPUAdapterInfo}} attribute names to update.
+            <pre class=argumentdef for="GPUAdapter/requestAdapterInfo()">
+                |unmaskHints|: A list of {{GPUAdapterInfo}} attribute names for which unmasked
+                    values are desired if available.
             </pre>
 
             **Returns:** {{Promise}}&lt;{{GPUAdapterInfo}}&gt;
@@ -2049,12 +2037,13 @@ interface GPUAdapter {
             1. Let |promise| be [=a new promise=].
             1. Let |adapter| be |this|.{{GPUAdapter/[[adapter]]}}.
             1. Run the following steps [=in parallel=]:
-                1. Let |unmaskHints| be a [=list=] of the fields specified in |hints| which the user
-                    agent decides to unmask, if any.
+                1. If |unmaskHints|.length &gt; `0`:
+                    1. Let |unmaskedKeys| be a [=list=] of the fields specified in |unmaskHints| which the
+                        user agent decides to unmask, if any.
 
-                    Note: The user agent is free to use any method it deems appropriate to decide
-                    which fields to unmask.
-                1. [=set/Append=] |unmaskHints| to |adapter|.{{adapter/[[unmaskedIdentifiers]]}}.
+                        Note: The user agent is free to use any method it deems appropriate to
+                        decide which fields to unmask.
+                    1. [=set/Append=] |unmaskedKeys| to |adapter|.{{adapter/[[unmaskedIdentifiers]]}}.
                 1. [=Resolve=] |promise| with a [$new adapter info$] for |adapter|.
 
             1. Return |promise|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1540,7 +1540,7 @@ including the absence of those values.
 interface GPUAdapterInfo {
   readonly attribute DOMString vendor;
   readonly attribute DOMString architecture;
-  readonly attribute long deviceId;
+  readonly attribute DOMString device;
   readonly attribute DOMString description;
 };
 </script>
@@ -1557,9 +1557,9 @@ interface GPUAdapterInfo {
         The name of the family or class of GPUs the [=adapter=] belongs to, if avaliable. Empty
         string otherwise.
 
-    : <dfn>deviceId</dfn>
+    : <dfn>device</dfn>
     ::
-        A vendor-specific ID for the [=adapter=], if available. `0` otherwise.
+        A vendor-specific identifier for the [=adapter=], if available. Empty string otherwise.
 
         Note: This is a value that represents the type of adapter. For example, it may be a
         [PCI device ID](https://pcisig.com/). It does not uniquely identify a given piece of
@@ -1601,14 +1601,15 @@ interface GPUAdapterInfo {
         1. Set |adapterInfo|.{{GPUAdapterInfo/architecture}} to the empty string or a
             reasonable approximation of the architecture as a [=normalized identifier string=].
 
-    1. If |unmaskedValues| [=set/contains=] `"deviceId"` and the deviceId is known:
-        1. Set |adapterInfo|.{{GPUAdapterInfo/deviceId}} to a vendor-specific numeric ID for
-            |adapter|.
+    1. If |unmaskedValues| [=set/contains=] `"device"` and the device is known:
+        1. Set |adapterInfo|.{{GPUAdapterInfo/device}} to a to a [=normalized identifier string=]
+             reprenting a vendor-specific indetifier for |adapter|.
 
         Otherwise:
 
-        1. Set |adapterInfo|.{{GPUAdapterInfo/deviceId}} to `0` or a reasonable
-            approximation of the vendor-specific numeric ID for |adapter|.
+        1. Set |adapterInfo|.{{GPUAdapterInfo/device}} to to the empty string or a
+            reasonable approximation of a vendor-specific indetifier as a [=normalized identifier
+            string=].
 
     1. If |unmaskedValues| [=set/contains=] `"description"` and a description is known:
         1. Set |adapterInfo|.{{GPUAdapterInfo/description}} to a description of the |adapter| as
@@ -1636,6 +1637,7 @@ interface GPUAdapterInfo {
     Examples of valid normalized identifier strings include:
         - `gpu`
         - `3d`
+        - `0x3b2f`
         - `next-gen`
         - `series-x20-ultra`
     </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -584,12 +584,30 @@ coordinating with GPU vendors and implementing workarounds for known issues in t
 
 ### Adapter Identifiers ### {#privacy-adapter-identifiers}
 
-Issue: Describe considerations for exposing adapter info
+Past experience with WebGL has demonstrated that developers have a legitimate need to be able to
+identify the GPU their code is running on in order to create and maintain robust GPU-based content.
+For example, to identify adapters with known driver bugs in order to work around them or to avoid
+features that perform more poorly than expected on a given class of hardware.
 
-Note: It is expected that WebGPU will expose some level of information identifying the type of GPU
-Adapter in use. This is a potential source of fingerprinting information but past experience with
-WebGL has demonstrated that it is necessary to some degree in order to enable developers to create
-robust applications and respond effectively to user issues.
+But exposing adapter identifiers also naturally expands the amount of fingerprinting information
+available, so there's a desire to limit the precision with which we identify the adapter.
+
+There are several mitigations that can be applied to strike a balance between enabling robust
+content and preserving privacy. First is that user agents can reduce the burden on developers by
+identifying and working around known driver issues, as they have since browser began making use of
+GPUs.
+
+When adapter identifiers are exposed by default they should be as broad as possible while still
+being useful. Possibly identifying, for example, the adapter's vendor and general architecture
+without identifying the specific adapter in use. Similarly, in some cases identifiers for an adapter
+that is considered a reasonable proxy for the actual adapter may be reported.
+
+In cases where full and detailed information about the adapter is useful (for example: when filing
+bug reports) the user can be asked for consent to reveal additional information about their hardware
+to the page.
+
+Finally, the user agent will always have the discretion to not report adapter identifiers at all if
+if considers it appropriate, such as in enhanced privacy modes.
 
 # Fundamentals # {#fundamentals}
 
@@ -1100,6 +1118,12 @@ An [=adapter=] has the following internal slots:
     : <dfn>\[[fallback]]</dfn>, of type boolean
     ::
         If set to `true` indicates that the adapter is a [=fallback adapter=].
+
+    : <dfn>\[[unmaskedIdentifiers]]</dfn>, of type [=ordered set=]&lt;{{DOMString}}&gt;
+    ::
+        A list of names of {{GPUAdapterInfo}} fields the user agent has chosen to report for this
+        adapter. Initially populated with the names of any {{GPUAdapterInfo}} fields the user agent
+        has chosen to report without user consent.
 </dl>
 
 [=Adapters=] are exposed via {{GPUAdapter}}.
@@ -1502,6 +1526,97 @@ but which the user agent has not been updated to recognize yet. If the [=set ent
 </div>
 </div>
 
+#### <dfn interface>GPUAdapterInfo</dfn> #### {#gpu-adapterinfo}
+
+{{GPUAdapterInfo}} exposes various identifying information about an adapter.
+
+Note: None of the values in {{GPUAdapterInfo}} are guaranteed to be populated. It is at the user
+agent's discretion which values to reveal, and it is likely that on some devices none of the values
+will be populated. As such applications should not be dependent on any values from {{GPUAdapterInfo}}
+to function.
+
+<script type=idl>
+[Exposed=(Window, DedicatedWorker), SecureContext]
+interface GPUAdapterInfo {
+  readonly attribute DOMString vendor;
+  readonly attribute DOMString architecture;
+  readonly attribute long deviceId;
+  readonly attribute DOMString description;
+};
+</script>
+
+{{GPUAdapterInfo}} has the following attributes:
+
+<dl dfn-type=attribute dfn-for=GPUAdapterInfo>
+    : <dfn>vendor</dfn>
+    ::
+        The name of the vendor of the [=adapter=], if avaliable. Empty string otherwise.
+
+    : <dfn>architecture</dfn>
+    ::
+        The name of the family or class of GPUs the [=adapter=] belongs to, if avaliable. Empty
+        string otherwise.
+
+    : <dfn>deviceId</dfn>
+    ::
+        A vendor-specific ID for the [=adapter=], if available. `0` otherwise.
+
+        Note: This is a value that represents the type of adapter. For example, it may be a
+        [PCI device ID](https://pcisig.com/). It does not uniquely identify a given piece of
+        hardware like a serial number.
+
+    : <dfn>description</dfn>
+    ::
+        A human readable string describing the [=adapter=] as reported by the driver, if avaliable.
+        Empty string otherwise.
+
+        Note: Because no formatting is applied to {{GPUAdapterInfo/description}} attempting to parse
+        this value is not recommended. Applications which change their behavior based on the
+        {{GPUAdapterInfo}}, such as applying workarounds for known driver issues, should rely on the
+        other fields when possible.
+
+</dl>
+
+<div algorithm>
+    To create a <dfn abstract-op>new adapter info</dfn> for a given [=adapter=] |adapter|, run the
+    following steps:
+
+    1. Let |adapterInfo| be a new {{GPUAdapterInfo}}.
+    1. Let |unmaskedValues| be |adapter|.{{adapter/[[unmaskedIdentifiers]]}}
+    1. If |unmaskedValues| [=set/contains=] `"vendor"` and the vendor is known:
+        1. Set |adapterInfo|.{{GPUAdapterInfo/vendor}} to the name of |adapter|'s vendor as a
+            [$normalized identifier string$].
+        1. Otherwise set |adapterInfo|.{{GPUAdapterInfo/vendor}} to the empty string or a
+            reasonable approximation of the vendor as a [$normalized identifier string$].
+    1. If |unmaskedValues| [=set/contains=] `"architecture"` and the architecture is known:
+        1. Set |adapterInfo|.{{GPUAdapterInfo/architecture}} to a [$normalized identifier string$]
+            representing the family or class of adapters to which |adapter| belongs.
+        1. Otherwise set |adapterInfo|.{{GPUAdapterInfo/architecture}} to the empty string or a
+            reasonable approximation of the architecture as a [$normalized identifier string$].
+    1. If |unmaskedValues| [=set/contains=] `"deviceId"` and the deviceId is known:
+        1. Set |adapterInfo|.{{GPUAdapterInfo/deviceId}} to a vendor-specific numeric ID for
+            |adapter|.
+        1. Otherwise set |adapterInfo|.{{GPUAdapterInfo/deviceId}} to `0` or a reasonable
+            approximation of the vendor-specific numeric ID for |adapter|.
+    1. If |unmaskedValues| [=set/contains=] `"description"` and a description is known:
+        1. Set |adapterInfo|.{{GPUAdapterInfo/description}} to a description of the |adapter| as
+            reported by the driver.
+        1. Otherwise set |adapterInfo|.{{GPUAdapterInfo/vendor}} to the empty string or a
+            reasonable approximation of a description.
+    1. Return |adapterInfo|.
+</div>
+
+<div algorithm>
+    To generate a <dfn abstract-op>normalized identifier string</dfn> for a given {{DOMString}}
+    |identifier|, run the following steps:
+
+    1. Let |normalized| be a copy of |identifier|.
+    1. Remove any non-ASCII characters from |normalized|.
+    1. Convert |normalized| to lowercase.
+    1. Replace any spaces in |normalized| with a hyphen character. (`"-"`)
+    1. Return |normalized|.
+</div>
+
 ## Origin Restrictions ## {#origin-restrictions}
 
 WebGPU allows accessing image data stored in images, videos, and canvases.
@@ -1777,23 +1892,19 @@ To get a {{GPUAdapter}}, use {{GPU/requestAdapter()}}.
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUAdapter {
-    readonly attribute DOMString name;
     [SameObject] readonly attribute GPUSupportedFeatures features;
     [SameObject] readonly attribute GPUSupportedLimits limits;
     readonly attribute boolean isFallbackAdapter;
+    readonly attribute GPUAdapterInfo info;
 
     Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor = {});
+    Promise<GPUAdapterInfo> requestUnmaskedAdapterInfo(sequence<DOMString> hints);
 };
 </script>
 
 {{GPUAdapter}} has the following attributes:
 
 <dl dfn-type=attribute dfn-for=GPUAdapter>
-    : <dfn>name</dfn>
-    ::
-        A human-readable name identifying the adapter.
-        The contents are implementation-defined.
-
     : <dfn>features</dfn>
     ::
         The set of values in `this`.{{GPUAdapter/[[adapter]]}}.{{adapter/[[features]]}}.
@@ -1805,6 +1916,11 @@ interface GPUAdapter {
     : <dfn>isFallbackAdapter</dfn>
     ::
         Returns the value of {{GPUAdapter/[[adapter]]}}.{{adapter/[[fallback]]}}.
+
+    : <dfn>info</dfn>
+    ::
+        Returns a [$new adapter info$] for `this`.{{GPUAdapter/[[adapter]]}}.
+
 </dl>
 
 {{GPUAdapter}} has the following internal slots:
@@ -1884,6 +2000,39 @@ interface GPUAdapter {
                     1. [=Resolve=] |promise| with a new {{GPUDevice}} object encapsulating
                         [=a new device=] with the capabilities described by |descriptor|.
                 </div>
+            1. Return |promise|.
+
+        </div>
+
+    : <dfn>requestUnmaskedAdapterInfo(hints)</dfn>
+    ::
+        Requests additional {{GPUAdapterInfo}} detail.
+
+        Note: Unmasked adapter info values are returned with a Promise to give user agents an
+        opportunity to perform potentially long-running checks, such as asking for user consent,
+        before returning.
+
+        <div algorithm=GPUAdapter.requestUnmaskedAdapterInfo>
+            **Called on:** {{GPUAdapter}} |this|.
+
+            **Arguments:**
+            <pre class=argumentdef for="GPUAdapter/requestUnmaskedAdapterInfo(hints)">
+                |hints|: A list of {{GPUAdapterInfo}} attribute names to update.
+            </pre>
+
+            **Returns:** {{Promise}}&lt;{{GPUAdapterInfo}}&gt;
+
+            1. Let |promise| be [=a new promise=].
+            1. Let |adapter| be |this|.{{GPUAdapter/[[adapter]]}}.
+            1. Run the following steps [=in parallel=]:
+                1. Let |unmaskHints| be a [=list=] of the fields specified in |hints| which the user
+                    agent decides to unmask, if any.
+
+                    Note: The user agent is free to use any method it deems appropriate to decide
+                    which fields to unmask.
+                1. [=set/Append=] |unmaskHints| to |adapter|.{{adapter/[[unmaskedIdentifiers]]}}.
+                1. [=Resolve=] |promise| with a [$new adapter info$] for |adapter|.
+
             1. Return |promise|.
 
         </div>


### PR DESCRIPTION
Fixes #2191
Fixes #2195

First pass at formalizing the [Adapter Identifiers design doc](https://github.com/gpuweb/gpuweb/blob/main/design/AdapterIdentifiers.md) into spec prose. Have taken feedback from the most recent call into account, though I anticipate we'll still need to do some iteration on this.

Things to note:
 - Filled in the "Adapter Identifiers" section under privacy considerations, so be sure to give that a look in addition to the algorithms.
 - Changed `fullName` to `description`. This feels like a more appropriate general term that will hopefully further discourage attempts to parse it. Also coincidentally matches the D3D12 name for the value.
 - Current algorithm doesn't have any scenario under which it rejects, following the sentiment voiced by @kdashg (I think) that it feels less fragile that way.
 - Removed nullable values in favor of either empty string or `0` in all cases.
 - Design doc states that `requestUnmaskedAdapterInfo()` should only be called during user activation, but PR doesn't include that restriction because it's unclear how to enforce that requirement in a worker.
 - As currently written the spec indicates that every call to `adapter.info` would create a new `GPUAdapterInfo`, which is probably not a big deal but worth considering.

Also on my mind:
 - I'm not particularly happy with the attribute name `deviceId` in this `GPUAdaperInfo` because it conflicts with the API's use of the term "Device", but I haven't landed on an alternative that I'm happy with. `adapterId` sounds too much like something that uniquely identifies the adapter _or_ indicates that it's then Nth adapter for the system. `adapterTypeId` just sounds awkward. And in many cases this would literally be the PCI Device ID, plus that's what Vulkan and D3D12 call it. (Metal has no direct equivalent.)
 - I would like to write out a recommended mapping for how these values could surface the equivalents in Vulkan/D3D12/Metal, but I'm not clear where that should go? Maybe in the design doc? In any case, it would be useful to sanity check that we're surfacing approximately the same things across implementations, especially in regards to Metal which is the most unique in how it surfaces device identifiers.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/2660.html" title="Last updated on Apr 28, 2022, 11:03 PM UTC (19d2bd6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2660/498a37e...19d2bd6.html" title="Last updated on Apr 28, 2022, 11:03 PM UTC (19d2bd6)">Diff</a>