### PR TITLE
Add multi-planar-formats feature

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1866,6 +1866,7 @@ enum GPUFeatureName {
     "texture-compression-astc",
     "timestamp-query",
     "indirect-first-instance",
+    "multi-planar-formats",
 };
 </script>
 
@@ -10827,6 +10828,10 @@ The following enums are supported if and only if the {{GPUFeatureName/"timestamp
 
 Removes the zero value restriction on `firstInstance` in [=indirect draw parameters=] and [=indirect drawIndexed parameters=].
 `firstInstance` is allowed to be non-zero if and only if the {{GPUFeatureName/"indirect-first-instance"}} [=feature=] is enabled.
+
+## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>"multi-planar-formats"</dfn> ## {#multi-planar-formats}
+
+Allows for zero-copy {{GPUDevice/importExternalTexture()}}. Without the feature, there might be an in-between copy to convert a multi-planar YUV video frame to single-planar RGBA {{GPUTexture}} internally.
 
 # Appendices # {#appendices}
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 14, 2022, 8:07 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fgpuweb%2Fgpuweb%2F5b823ac0c7bb17db5d161445068bd358c9d5f82b%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%232665.)._
</details>
