### PR TITLE
Commiting GPUCommandBuffers to the wrong GPUDevice is an error

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8988,6 +8988,7 @@ GPUQueue includes GPUObjectBase;
             <div class=device-timeline>
                 1. If any of the following conditions are unsatisfied, [$generate a validation error$] and stop.
                     <div class=validusage>
+                        - Every {{GPUCommandBuffer}} in |commandBuffers| is [$valid to use with$] |this|.
                         - Every {{GPUBuffer}} referenced in any element of |commandBuffers| is in the
                             `"unmapped"` [=buffer state=].
                         - Every {{GPUQuerySet}} referenced in a command in any element of |commandBuffers| is


### PR DESCRIPTION
Eventually we'll want to add more logic to make sure that command buffers are only valid on
the queue they're created from. Right now, though, every device just has exactly one queue,
so matching devices is the same as matching queues.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/litherum/gpuweb/pull/2666.html" title="Last updated on Mar 15, 2022, 2:46 AM UTC (b11bfc8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2666/5b823ac...litherum:b11bfc8.html" title="Last updated on Mar 15, 2022, 2:46 AM UTC (b11bfc8)">Diff</a>