### PR TITLE
Add creation-time expressions

### DIFF
--- a/wgsl/extract-grammar.py
+++ b/wgsl/extract-grammar.py
@@ -623,7 +623,7 @@ for key, value in scanner_components[scanner_example.name()].items():
         value = ["fn function__scope____() {"] + value + ["}"]
     if "type-scope" in key:
         # Initiailize with zero-value expression.
-        value = ["let type_scope____: "] + value + ["="] + value + ["()"] + [";"]
+        value = ["const type_scope____: "] + value + ["="] + value + ["()"] + [";"]
     program = "\n".join(value)
     tree = parser.parse(bytes(program, "utf8"))
     if tree.root_node.has_error:

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -10,9 +10,14 @@ Repository: gpuweb/gpuweb
 Text Macro: INT i32 or u32
 Text Macro: UNSIGNEDINTEGRAL u32 or vec|N|&lt;u32&gt;
 Text Macro: SIGNEDINTEGRAL i32 or vec|N|&lt;i32&gt;
+Text Macro: ALLSIGNEDINTEGRAL AbstractInt, i32, vec|N|&lt;AbstractInt&gt;, or vec|N|&lt;i32&gt;
 Text Macro: INTEGRAL i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;
 Text Macro: FLOATING f32, f16, vec|N|&lt;f32&gt;, or vec|N|&lt;f16&gt;
 Text Macro: NUMERIC i32, u32, f32, f16, vec|N|&lt;i32&gt;, vec|N|&lt;u32&gt;, vec|N|&lt;f32&gt;, or vec|N|&lt;f16&gt;
+Text Macro: ALLINTEGRALDECL |S| is AbstractInt, i32, u32<br>|T| is |S| or vec|N|&lt;|S|&gt; 
+Text Macro: ALLFLOATING AbstractFloat, f32, f16, vec|N|&lt;AbstractFloat&gt;, vec|N|&lt;f32&gt;, or vec|N|&lt;f16&gt;
+Text Macro: ALLNUMERICDECL |S| is AbstractInt, AbstractFloat, i32, u32, f32, or f16<br>|T| is |S|, or vec|N|&lt;|S|&gt;
+Text Macro: ALLINTEGRALDECL |S| is AbstractInt, i32, or u32<br>|T| is |S| or vec|N|&lt;|S|&gt;
 Ignored Vars: i, c0, e, e1, e2, e3, eN, p, s1, s2, sn, N, M, C, R, v, Stride, Offset, Align, Extent, S, T, T1
 
 !Participate: <a href="https://github.com/gpuweb/gpuweb/issues/new?labels=wgsl">File an issue</a> (<a href="https://github.com/gpuweb/gpuweb/issues?q=is%3Aissue+is%3Aopen+label%3Awgsl">open issues</a>)
@@ -434,13 +439,13 @@ This is a consequence of the Pumping Lemma for Regular Languages.
 
 <div class='example wgsl' heading='Comments'>
   <xmp>
-  let f = 1.5;   // This is line-ending comment.
-  let g = 2.5;   /* This is a block comment
-                    that spans lines.
-                    /* Block comments can nest.
-                     */
-                    But all block comments must terminate.
-                  */
+  const f = 1.5; // This is line-ending comment.
+  const g = 2.5; /* This is a block comment
+                  that spans lines.
+                  /* Block comments can nest.
+                   */
+                  But all block comments must terminate.
+                 */
   </xmp>
 </div>
 
@@ -693,6 +698,17 @@ An attribute must not be specified more than once per object or type.
 
     Declares a built-in value.
     See [[#builtin-values]].
+
+  <tr><td><dfn noexport dfn-for="attribute">`const`
+    <td>*None*
+    <td>Must only be applied to function declarations.
+
+    Specifies that the function can be used as a [=creation-time function=].
+    It is a [=shader-creation error=] if this attribute is a applied to a
+    user-defined function.
+
+    Note: This attribute is used as a notational convention to describe which
+    built-in functions can be used in [=creation-time expressions=].
 
   <tr><td><dfn noexport dfn-for="attribute">`group`
     <td>non-negative i32 literal
@@ -1124,7 +1140,7 @@ A <dfn>feasible automatic conversion</dfn> converts a value from type *Src* to t
 Such conversions are value-preserving, subject to limitations described in [[#floating-point-evaluation]].
 
 Note: Automatic conversions only occur in two kinds of situations.
-First, when converting a creation-time constant to its corresponding typed numeric value that can be used on the GPU.
+First, when converting a [=creation-time constant=] to its corresponding typed numeric value that can be used on the GPU.
 Second, when a load from a reference-to-memory occurs, yielding the value stored in that memory.
 
 Note: A conversion of infinite rank is infeasible, i.e. not allowed.
@@ -1242,28 +1258,34 @@ Otherwise, the result is a [=shader-creation error=].
 
 These types cannot be spelled in WGSL source. They are only used by [=type checking=].
 
+A type that is not an abstract numeric type nor contains an abstract numeric
+type is called <dfn noexport>concrete</dfn>.
+
 A [=numeric literal=] without a suffix denotes a value in an [=abstract numeric type=]:
 * An [=integer literal=] without an `i` or `u` suffix denotes an [=AbstractInt=] value.
 * A [=floating point literal=] without an `f` suffix denotes a [=AbstractFloat=] value.
 
 Example:  The expression `log2(32)` is analyzed as follows:
 * `log2(32)` is parsed as a function call to the `log2` builtin function with operand [=AbstractInt=] value 32.
-* There is no overload of `log2` with an [=integer scalar=] formal parameter.
-* Instead [=overload resolution=] applies, using a [=feasible automatic conversion=] from [=AbstractInt=] to [=f32=] value 32.0f.
-* The resulting computation is equivalent to `log2(32.0f)`.
+* There is no overload of `log2` with an integral scalar formal parameter.
+* Instead [=overload resolution=] applies, considering two possible overloads and [=feasible automatic conversions=]:
+    * [=AbstractInt=] to [=AbstractFloat=]. (Conversion rank 4)
+    * [=AbstractInt=] to [=f32=]. (Conversion rank 5)
+* The resulting computation occurs as an [=AbstractFloat=] (e.g. `log2(32.0)`).
 
 Example:  The expression `1 + 2.5` is analyzed as follows:
 * `1 + 2.5` is parsed as an addition operation with subexpressions [=AbstractInt=] value 1, and [=AbstractFloat=] value 2.5.
 * There is no overload for |e|+|f| where |e| is integral and |f| is floating point.
-* However, the overload with both |e| and |f| being of type [=f32=] does apply, using feasible automatic conversions:
-    * 1 is converted from [=AbstractInt=] to [=f32=] value `1.0f`.  (Conversion rank 5).
-    * 2.5 is converted from [=AbstractFloat=] to [=f32=] value `2.5f`.  (Conversion rank 1).
-* There are no other [=overload candidates=], and type checking succeeds.
-* The resulting computation is equivalent to `1.0f + 2.5f`.
+* However, using feasible automic conversions, there are two potential overloads:
+    * `1` is converted to [=AbstractFloat=] value `1.0` (rank 4) and `2.5` remains an [=AbstractFloat=] (rank 0).
+    * `1` is converted to [=f32=] value `1.0f` (rank 5) and `2.5` is converted to [=f32=] value `2.5f` (rank 1).
+* The first overload is the [=preferable candidate=] and type checking succeeds.
+* The resulting computation occurs as an [=AbstractFloat=] `1.0 + 2.5`.
 
 Example:  `let x = 1 + 2.5;`
-* As above, we evaluate the initializer to be the expression `1.0f + 2.5f` with type [=f32=].
-* The effect of the declaration is as if it were written `let x: f32 = 1.0f + 2.5f;`
+* This example is similar to the above, except that `x` cannot resolve to an [=abstract numeric type=].
+* Therefore, there is only one viable overload candidate: addition using [=f32=].
+* The effect of the declaration is as if it were written `let x : f32 = 1.0f + 2.5f;`.
 
 Example:  `1u + 2.5` results in a [=shader-creation error=]:
 * The `1u` term is an expression of type [=u32=].
@@ -1272,37 +1294,7 @@ Example:  `1u + 2.5` results in a [=shader-creation error=]:
     * There is no feaisble automatic conversion from a GPU-materialized integral type to a floating point type.
     * No type rule matches *e*`+`*f* with *e* in an integral type, and *f* in a floating point type.
 
-### Constexpr Expressions ### {#constexpr-expr}
-
-Constxpr expressions support two operations:
-[[#parenthesized-expressions|parenthesization]], and unary negation (see [[#arithmetic-expr]]).
-
-Example:  `(42)` is analyzed as follows:
-* The term `42` is the [=AbstractInt=] value 42.
-* Surrounding that term with parentheses produces a new expression `(42)` that is
-    of type [=AbstractInt=] with value 42.
-
-Example:  `-5` is analyzed as follows:
-* The term `5` is the [=AbstractInt=] value 5.
-* Preceding that term with '`-`' produces a new expression `-5` that is
-    of type [=AbstractInt=] with value -5.
-
-Example:  `-2147483648` is analyzed as follows:
-* The term `2147483648` is the [=AbstractInt=] value 2147483648.
-    Note that this value does **not** fit in a 32-bit signed integer.
-* Preceding that term with '`-`' produces a new expression `-2147483648` that is
-    of type [=AbstractInt=] with value -2147483648.
-
-Example:  `let minint = -2147483648;` is analyzed as follows:
-* As above, `-2147483648` evaluates to a [=AbstractInt=] value -2147483648.
-* A [=let declaration=] requires the initializer to be [=constructible=].
-* The let declaration does not have an explicit type, so [=overload resolution=] is used.
-    The overload candidates that apply use [=feasible automatic conversions=] from [=AbstractInt=] to either [=i32=], [=u32=], or [=f32=].
-    The one of lowest rank is to [=i32=], and so
-    [=AbstractInt=] -2147483648 value is converted to the [=i32=] value -2147483648.
-* The result is that `minint` is declared to be the i32 value -2147483648.
-
-### Constexpr Examples ### {#constexpr-examples}
+### Creation-time Examples ### {#constexpr-examples}
 
 <div class='example literals' heading="Type inference for literals">
   <xmp highlight='rust'>
@@ -1335,7 +1327,6 @@ Example:  `let minint = -2147483648;` is analyzed as follows:
     // Invalid: no feasible conversion from floating point to integer
     var i32_demotion : i32 = 1.0; // Invalid
 
-
     // Inferred from expression.
     var u32_from_expr = 1 + u32_1; // variable holds u32
     var i32_from_expr = 1 + i32_1; // variable holds i32
@@ -1357,35 +1348,12 @@ Example:  `let minint = -2147483648;` is analyzed as follows:
     // range, producing shader-creation error.
     let i32_too_large_2 = 2147483648; // Invalid.
 
-    // TODO: We expect to add support for many constexpr expressions over AbstractInt
-    // or AbstractFloat.  Then constexpr expressions over literals (and their combinations)
-    // will remain in that "abstract" numeric type.
-    // For example, add overloads for basic binary arithmetic operations:
-    //     AbstractInt + AbstractInt -> AbstractInt
-    //     AbstractInt - AbstractInt -> AbstractInt
-    //     AbstractInt * AbstractInt -> AbstractInt
-    //     AbstractInt / AbstractInt -> AbstractInt
-    // Any time the compiler is sees these kinds of expressions over
-    // AbstractInt operands, the most preferred overload will exist and be the one
-    // that keeps the result as AbstractInt. That's because
-    // ConversionRank(AbstractInt,AbstractInt) is 0, and therefore is the most
-    // preferred conversion in each position.
-    // Respectively, the same argument applies to AbstractFloat if we add similar
-    // overloads over AbstractFloat:
-    //     AbstractFloat + AbstractFloat -> AbstractFloat
-    //     AbstractFloat - AbstractFloat -> AbstractFloat
-    //     AbstractFloat * AbstractFloat -> AbstractFloat
-    //     AbstractFloat / AbstractFloat -> AbstractFloat
-    // All such evaluations occur at shader creation time.
-    // Ultimately a final rule somewhere will require a non-Abstract type, and force
-    // the value conversion to a specific numeric type that can be used directly
-    // on the GPU.
-    // TODO: When AbstractInt gains support for addition, then these will become valid,
-    // as follows:
-    // var u32_expr1 = (1 + (1 + (1 + (1 + 1)))) + 1u; // TODO: like var u32_expr1:u32=6u;
-    // var u32_expr2 = 1u + (1 + (1 + (1 + (1 + 1)))); // TODO: like var u32_expr2:u32=6u;
-    // var u32_expr3 = (1 + (1 + (1 + (1u + 1)))) + 1; // TODO: like var u32_expr3:u32=6u;
-    // var u32_expr4 = 1 + (1 + (1 + (1 + (1u + 1)))); // TODO: like var u32_expr4:u32=6u;
+    // Subexpressions can resolve to AbstractInt and AbstractFloat.
+    // The following examples are all valid and the value of the variable is 6u.
+    // var u32_expr1 = (1 + (1 + (1 + (1 + 1)))) + 1u;
+    // var u32_expr2 = 1u + (1 + (1 + (1 + (1 + 1))));
+    // var u32_expr3 = (1 + (1 + (1 + (1u + 1)))) + 1;
+    // var u32_expr4 = 1 + (1 + (1 + (1 + (1u + 1))));
 
     // Inference based on built-in function parameters.
 
@@ -1482,7 +1450,8 @@ The <dfn noexport>integer scalar</dfn> types are [=i32=] and [=u32=].
 
 ### Vector Types ### {#vector-types}
 
-A <dfn noexport>vector</dfn> is a grouped sequence of 2, 3, or 4 [=scalar=] components.
+A <dfn noexport>vector</dfn> is a grouped sequence of 2, 3, or 4 [=scalar=] or
+[=abstract numeric type=] components.
 
 <table class='data'>
   <thead>
@@ -1490,11 +1459,14 @@ A <dfn noexport>vector</dfn> is a grouped sequence of 2, 3, or 4 [=scalar=] comp
   </thead>
   <tr><td>vec*N*<*T*><td>Vector of *N* components of type *T*.
                           *N* must be in {2, 3, 4} and *T*
-                          must be one of the [=scalar=] types.
+                          must be one of the [=scalar=] or [=abstract numeric
+                          type|abstract numeric=] types.
                           We say *T* is the <dfn noexport>component type</dfn> of the vector.
 </table>
 
-A vector is a <dfn dfn>numeric vector</dfn> if its component type is a [=numeric scalar=].
+A vector is a <dfn noexport>numeric vector</dfn> if its component type is a [=numeric scalar=].
+
+A vector is an <dfn noexport>abstract vector</dfn> if its component type is an [=abstract numeric type=].
 
 Key use cases of a vector include:
 
@@ -1532,7 +1504,7 @@ A <dfn noexport>matrix</dfn> is a grouped sequence of 2, 3, or 4 floating point 
   </thead>
   <tr algorithm="matrix type">
     <td>mat|C|x|R|&lt;|T|&gt;
-    <td>Matrix of |C| columns and |R| rows of type |T|, where |C| and |R| are both in {2, 3, 4}, and |T| must be f32 or f16.
+    <td>Matrix of |C| columns and |R| rows of type |T|, where |C| and |R| are both in {2, 3, 4}, and |T| must be [=f32=], [=f16=], or [=AbstractFloat=].
         Equivalently, it can be viewed as |C| column vectors of type vec|R|&lt;*T*&gt;.
 </table>
 
@@ -1556,7 +1528,7 @@ See [[#arithmetic-expr]].
 
 ### Atomic Types ### {#atomic-types}
 
-An <dfn noexport>atomic type</dfn> encapsulates a [=scalar=] type such that:
+An <dfn noexport>atomic type</dfn> encapsulates an [=integer scalar=] type such that:
 * atomic objects provide certain guarantees to concurrent observers, and
 * the only valid operations on atomic objects are the [[#atomic-builtin-functions|atomic builtin functions]].
 
@@ -1616,15 +1588,15 @@ See [[#array-access-expr]].
 An expression must not evaluate to a runtime-sized array type.
 
 The element count expression |N| of a fixed-size array must:
-* be a literal, or the name of a [[#module-constants|module-scope constant]] (possibly [=pipeline-overridable=]), and
+* be an [=override expression=], and
 * evaluate to an [=integer scalar=] with value greater than zero.
 
 Note:  The element count value is fully determined at [=pipeline creation=] time.
 
 An array element type must be one of:
 * a [=scalar=] type
-* a [=vector=] type
-* a [=matrix=] type
+* a [=vector=] type with [=concrete=] components
+* a [=matrix=] type with [=concrete=] components
 * an [=atomic type|atomic=] type
 * an array type having a [=creation-fixed footprint=]
 * a [=structure=] type having a [=creation-fixed footprint=].
@@ -1650,8 +1622,8 @@ Two array types are the same if and only if all of the following are true:
     var<private> b: array<i32,8>;
     var<private> c: array<i32,8u>;  // array<i32,8> and array<i32,8u> are the same type
 
-    let width = 8;
-    let height = 8;
+    const width = 8;
+    const height = 8;
 
     // array<i32,8>, array<i32,8u>, and array<i32,width> are the same type.
     // Their element counts evaluate to 8.
@@ -1663,7 +1635,7 @@ Two array types are the same if and only if all of the following are true:
   </xmp>
 </div>
 
-Note: The valid use of an array sized by an overridable constant is as the store type
+Note: The only valid use of an array sized by an overridable constant is as the store type
 of a variable in [=address spaces/workgroup=] space.
 
 <div class='example wgsl global-scope' heading="Workgroup variables sized by overridable constants">
@@ -1692,9 +1664,9 @@ of a variable in [=address spaces/workgroup=] space.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>element_count_expression</dfn> :
 
-    | [=syntax/int_literal=]
+    | [=syntax/additive_expression=]
 
-    | [=syntax/ident=]
+    | [=syntax/bitwise_expression=]
 </div>
 
 ### Structure Types ### {#struct-types}
@@ -1818,8 +1790,8 @@ We call these [=constructible=].
 A type is <dfn>constructible</dfn> if it is one of:
 
 * a [=scalar=] type
-* a [=vector=] type
-* a [=matrix=] type
+* a [=vector=] type with [=concrete=] components
+* a [=matrix=] type with [=concrete=] components
 * a [=fixed-size array=] type, if it has [=creation-fixed footprint=] and its element type is constructible.
 * a [=structure=] type, if all its members are constructible.
 
@@ -1848,22 +1820,22 @@ Note: Pipeline creation depends on shader creation, so a type with [=creation-fi
 
 The plain types with [=creation-fixed footprint=] are:
 * a [=scalar=] type
-* a [=vector=] type
-* a [=matrix=] type
+* a [=vector=] type with [=concrete=] components
+* a [=matrix=] type with [=concrete=] components
 * an [=atomic type|atomic=] type
 * a [=fixed-size array=] type, when:
-     * its [=element count=] is a literal, or the name of a [[#module-constants|module-scope]]
-        [=let declaration=]
+     * its [=element count=] is a [=creation-time expression=].
 * a [=structure=] type, if all its members have [=creation-fixed footprint=].
 
 Note: A [=constructible=] type has [=creation-fixed footprint=].
 
 The plain types with [=fixed footprint=] are any of:
 * a type with [=creation-fixed footprint=]
-* a [=fixed-size array=] type, where its [=element count=] is a [=pipeline-overridable=]  constant.
+* a [=fixed-size array=] type
 
-Note: The only valid use of a fixed-size array with an element count that is a pipeline-overridable constant is
-as the [=store type=] for a [=address spaces/workgroup=] variable.
+Note: The only valid use of a fixed-size array with an element count that is an
+[=override expression=] that is not a [=creation-time expression=] is as the
+[=store type=] for a [=address spaces/workgroup=] variable.
 
 Note: A fixed-footprint type may contain an [=atomic type|atomic=] type, either directly or
 indirectly, while a [=constructible=] type must not.
@@ -1930,8 +1902,8 @@ or it may be opaque, such as for textures and samplers.
 A type is <dfn noexport>storable</dfn> if it is one of:
 
 * a [=scalar=] type
-* a [=vector=] type
-* a [=matrix=] type
+* a [=vector=] type with [=concrete=] components
+* a [=matrix=] type with [=concrete=] components
 * an [=atomic type|atomic=] type
 * an [=array=] type
 * a [=structure=] type
@@ -3434,7 +3406,7 @@ The declaration must appear at [=module scope=], and its [=scope=] is the entire
     type RTArr = array<vec4<f32>>;
 
     type single = f32;     // Declare an alias for f32
-    let pi_approx: single = 3.1415;
+    const pi_approx: single = 3.1415;
     fn two_pi() -> single {
       return single(2) * pi_approx;
     }
@@ -3550,7 +3522,8 @@ When the type declaration is an [=identifier=], then the expression must be in s
 [SHORTNAME] authors can declare names for immutable values using a <dfn noexport>value declaration</dfn> which either:
 
   * a [=let declaration=], or
-  * a [=override declaration=].
+  * an [=override declaration=], or
+  * a [=creation-time constant=].
 
 Value declarations do not have any associated storage.
 That is, there are no [=memory locations=] associated with the declaration.
@@ -3561,14 +3534,15 @@ A <dfn noexport>let declaration</dfn> specifies a name for a value.
 Once the value for a let-declaration is computed, it is immutable.
 When an [=identifier=] use [=resolves=] to a let-declaration, the identifier denotes that value.
 
-When a `let` identifier is declared without an explicitly specified type,
-e.g. `let foo = 4`, the type is automatically inferred from the expression to the right of the equals token (`=`).
+When a `let` identifier is declared without an explicitly specified type, e.g.
+`let foo = 4`, the type is automatically inferred from the expression to the
+right of the [=syntax/equals=] token.
+The type of a `let` declaration is always [=concrete=].
 When the type is specified, e.g `let foo: i32 = 4`, the initializer expression must evaluate to that type.
 
-Some rules about `let`-declarations depend on where the declaration appears.
-See [[#module-constants]] and [[#function-scope-variables]].
+`let`-declarations can only appear within a function definition.
 
-<div class='example wgsl let declaration at module-scope' heading='let-declared constants at module scope'>
+<div class='example wgsl let declaration at function-scope' heading='let-declared constants at function scope'>
   <xmp highlight='rust'>
     // 'blockSize' denotes the i32 value 1024.
     let blockSize: i32 = 1024;
@@ -3596,8 +3570,10 @@ When an [=identifier=] use [=resolves=] to a override-declaration, the identifie
   * The initializer expression, if present, must:
       * evaluate to a [=scalar=] type.
       * evaluate to the declared type if it is present.
-      * be composed only [=syntax/const_expression|const_expressions=] or
-          expressions where all identifiers [=resolve=] to overridable constants.
+      * be composed only [=creation-time expressions=] or expressions where all
+          identifiers [=resolve=] to overridable constants, [=creation-time
+          constants=], or [=creation-time functions=].
+          Such an expression is called an <dfn noexport>override expression</dfn>.
   * If the declaration has the [=attribute/id=] applied, the literal operand is
       known as the <dfn noexport>pipeline constant ID</dfn>, and must be an
       integer value between 0 and 65535.
@@ -3612,6 +3588,8 @@ When an [=identifier=] use [=resolves=] to a override-declaration, the identifie
   * The <dfn export>pipeline-overridable constant has a default value</dfn> if
     its declaration has an initializer expression.
     If it doesn't, a value must be provided at pipeline-creation time.
+
+Note: Override expressions are a superset of [=creation-time expressions=].
 
 <div class='example wgsl global-scope' heading='Module constants, pipeline-overrideable'>
   <xmp>
@@ -3631,6 +3609,45 @@ When an [=identifier=] use [=resolves=] to a override-declaration, the identifie
   </xmp>
 </div>
 
+### Creation-time Constants ### {#creation-time-consts}
+
+A <dfn noexport>creation-time constant</dfn> specifies a name for value that is
+fixed at [=shader module creation|shader-creation time=].
+Once the constant is declared, its value is immutable.
+When an [=identifier=] use [=resolves=] to a creation-time constant, the
+identifier denotes that value.
+
+When a creation-time constant is declared without an explicitly specified type,
+e.g. `const foo = 4`, the type is automatically inferred from the expression to
+the right of the [=syntax/equals=] token.
+The type of a creation-time constant must be:
+* a [=constructible=] type, or
+* an [=abstract numeric type=], or
+* a [=vector=], or
+* a [=matrix=]
+
+When the type is specified, e.g. `const foo : i32 = 4`, the initializer
+expression must evaluate to that type.
+
+Note: Since [=AbstractInt=] and [=AbstractFloat=] cannot be spelled in
+WGSL source, named values can only utilize them through type inference.
+
+A creation-time constant can be declared at module-scope or function-scope.
+A creation-time constant must be declared with an initializer and be composed
+only of [=creation-time expressions=].
+
+<div class='example wgsl global-scope' heading='Creation-time constants'>
+  <xmp>
+    const a = 4;                  // AbstractInt with a value of 4.
+    const b : i32 = 4;            // i32 with a value of 4.
+    const c : u32 = 4;            // u32 with a value of 4.
+    const d : f32 = 4;            // f32 with a value of 4.
+    const e = vec3(a, a, a);      // vec3 of AbstractInt with a value of (4, 4, 4).
+    const f = 4.0;                // AbstractFloat with a vaue of 4.
+    const g = mat2x2(a, f, a, f); // mat2x2 of AbstractFloat with a value of ((2, 4), (2, 4)).
+  </xmp>
+</div>
+
 ## `var` Declarations ## {#var-decls}
 
 A <dfn noexport>variable</dfn> is a named reference to memory that can contain a value of a
@@ -3641,6 +3658,7 @@ that may be placed in the referenced memory) and its [=reference type=] (the typ
 of the variable itself).
 If a variable has store type *T*, [=address space=] *S*, and [=access mode=] *A*,
 then its reference type is ref&lt;*S*,*T*,*A*&gt;.
+The [=store type=] of a variable is always [=concrete=].
 
 A <dfn noexport>variable declaration</dfn>:
 
@@ -3775,26 +3793,17 @@ WGSL defines the following attributes that can be applied to global variables:
 
 A [[#value-decls|value declaration]] appearing outside all functions declares a
 [=module scope|module-scope=] constant.
+Module-scope constants must be either [=override declarations=] or
+[=creation-time constants=].
 The name is [=in scope=] for the entire program.
-
-A module-scope [=let declaration|let-declared=] constant must be of
-[=constructible=] type.
-An initializer expression must be present for a module-scope `let`-declaration
-and the name denotes the value of that expression.
-
-TODO: define creation-time constant that allows const_expression and module
-scope let declarations.
-
-A [=pipeline-overridable=] constant must be one of the [=scalar=] types.
-An initializer expression is optional for pipeline-overridable constants.
 
 <div class='example wgsl global-scope' heading='Module constants'>
   <xmp>
     // The golden ratio.
-    let golden: f32 = 1.61803398875;
+    const golden: f32 = 1.61803398875;
 
     // The second unit vector for three dimensions, with inferred type.
-    let e2 = vec3<i32>(0,1,0);
+    const e2 = vec3(0,1,0);
   </xmp>
 </div>
 
@@ -3806,12 +3815,14 @@ is the one from the constant's declaration or from a pipeline override.
 
 ## Function Scope Variables and Constants ## {#function-scope-variables}
 
-A variable or constant declared in a declaration statement in a function body is in <dfn noexport>function scope</dfn>.
-The name is available for use immediately after its declaration statement,
-and until the end of the brace-delimited list of statements immediately enclosing the declaration.
+A variable or constant declared in a declaration statement in a function body
+is in <dfn noexport>function scope</dfn>.
+The name is available for use immediately after its declaration statement, and
+until the end of the brace-delimited list of statements immediately enclosing
+the declaration.
 
-A function-scope [=let declaration|let-declared=] constant must be of
-[=constructible=] type, or of [=pointer type=].
+A [=let declaration|let-declared=] constant must be of [=constructible=] type,
+or of [=pointer type=].
 
 For a variable declared in function scope:
 * The variable is always in the [=address spaces/function=] address space.
@@ -3852,6 +3863,8 @@ use the same memory.
     | [=syntax/variable_decl=] [=syntax/equal=] [=syntax/expression=]
 
     | [=syntax/let=] ( [=syntax/ident=] | [=syntax/variable_ident_decl=] ) [=syntax/equal=] [=syntax/expression=]
+
+    | [=syntax/const=] ( [=syntax/ident=] | [=syntax/variable_ident_decl=] ) [=syntax/equal=] [=syntax/expression=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>variable_decl</dfn> :
@@ -3872,27 +3885,61 @@ use the same memory.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>global_variable_decl</dfn> :
 
-    | [=syntax/attribute=] * [=syntax/variable_decl=] ( [=syntax/equal=] [=syntax/const_expression=] ) ?
+    | [=syntax/attribute=] * [=syntax/variable_decl=] ( [=syntax/equal=] [=syntax/expression=] ) ?
 </div>
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>global_constant_decl</dfn> :
 
-    | [=syntax/let=] ( [=syntax/ident=] | [=syntax/variable_ident_decl=] ) [=syntax/equal=] [=syntax/const_expression=]
+    | [=syntax/const=] ( [=syntax/ident=] | [=syntax/variable_ident_decl=] ) [=syntax/equal=] [=syntax/expression=]
 
     | [=syntax/attribute=] * [=syntax/override=] ( [=syntax/ident=] | [=syntax/variable_ident_decl=] ) ( [=syntax/equal=] [=syntax/expression=] ) ?
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>const_expression</dfn> :
-
-    | [=syntax/type_decl=] [=syntax/paren_left=] ( ( [=syntax/const_expression=] [=syntax/comma=] ) * [=syntax/const_expression=] [=syntax/comma=] ? ) ? [=syntax/paren_right=]
-
-    | [=syntax/const_literal=]
 </div>
 
 # Expressions # {#expressions}
 
 Expressions specify how values are computed.
+
+## Creation-time Expressions ## {#creation-time-expr}
+
+Expressions that are evaluated at [=shader module creation|shader-creation
+time=] are called <dfn noexport>creation-time expressions</dfn>.
+In order for an expression to be evaluated at shader-creation time all
+[=identifiers=] used by the expression must [=resolve=] to [=creation-time
+constants=] or [=creation-time functions=].
+
+The types of creation-time expressions can resolve to types that include
+[=abstract numeric types=].
+
+Example:  `(42)` is analyzed as follows:
+* The term `42` is the [=AbstractInt=] value 42.
+* Surrounding that term with parentheses produces a new expression `(42)` that is
+    of type [=AbstractInt=] with value 42.
+
+Example:  `-5` is analyzed as follows:
+* The term `5` is the [=AbstractInt=] value 5.
+* Preceding that term with '`-`' produces a new expression `-5` that is
+    of type [=AbstractInt=] with value -5.
+
+Example:  `-2147483648` is analyzed as follows:
+* The term `2147483648` is the [=AbstractInt=] value 2147483648.
+    Note that this value does **not** fit in a 32-bit signed integer.
+* Preceding that term with '`-`' produces a new expression `-2147483648` that is
+    of type [=AbstractInt=] with value -2147483648.
+
+Example:  `const minint = -2147483648;` is analyzed as follows:
+* As above, `-2147483648` evaluates to a [=AbstractInt=] value -2147483648.
+* A [=creation-time constant=] allows the initializer to be an [=abstract numeric type=].
+* The result is that `minint` is declared to be the [=AbstractInt=] value -2147483648.
+
+Example:  `let minint = -2147483648;` is analyzed as follows:
+* As above, `-2147483648` evaluates to a [=AbstractInt=] value -2147483648.
+* A [=let declaration=] requires the initializer to be [=constructible=].
+* The let declaration does not have an explicit type, so [=overload resolution=] is used.
+    The overload candidates that apply use [=feasible automatic conversions=] from [=AbstractInt=] to either [=i32=], [=u32=], or [=f32=].
+    The one of lowest rank is to [=i32=], and so
+    [=AbstractInt=] -2147483648 value is converted to the [=i32=] value -2147483648.
+* The result is that `minint` is declared to be the i32 value -2147483648.
 
 ## Literal Value Expressions ## {#literal-expressions}
 
@@ -3901,11 +3948,30 @@ Expressions specify how values are computed.
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
-  <tr><td><td>`true`: bool<td>`true` boolean value.
-  <tr><td><td>`false`: bool<td>`false` boolean value.
-  <tr><td>|e| is an [=integer literal=] with `i` suffix<td>|e|: i32<td>32-bit signed integer literal value.
-  <tr><td>|e| is an [=integer literal=] with `u` suffix<td>|e|: u32<td>32-bit unsigned integer literal value.
-  <tr><td>|e| is an [=floating point literal=] with `f` suffix<td>|e|: f32<td>32-bit floating point literal value.
+  <tr><td>
+      <td>`true`: bool
+      <td>`true` boolean value.
+  <tr><td>
+      <td>`false`: bool
+      <td>`false` boolean value.
+  <tr><td>|e| is an [=integer literal=] with no suffix
+      <td>|e|: AbstractInt
+      <td>Abstract integer literal value.
+  <tr><td>|e| is a [=floating point literal=] with no suffix
+      <td>|e|: AbstractFloat
+      <td>Abstract float literal value.
+  <tr><td>|e| is an [=integer literal=] with `i` suffix
+      <td>|e|: i32
+      <td>32-bit signed integer literal value.
+  <tr><td>|e| is an [=integer literal=] with `u` suffix
+      <td>|e|: u32
+      <td>32-bit unsigned integer literal value.
+  <tr><td>|e| is an [=floating point literal=] with `f` suffix
+      <td>|e|: f32
+      <td>32-bit floating point literal value.
+  <tr><td>|e| is an [=floating point literal=] with `h` suffix
+      <td>|e|: f16
+      <td>16-bit floating point literal value.
 </table>
 
 ## Parenthesized Expressions ## {#parenthesized-expressions}
@@ -4055,47 +4121,46 @@ specify the component type; the component type is inferred from the constructor 
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr>
-    <td>|e|: mat2x2&lt;|T|&gt;<br>|T| is f32 or f16
+    <td>|e|: mat2x2&lt;|T|&gt;
     <td>`mat2x2<`|T|`>(`|e|`)`: mat2x2&lt;|T|&gt;<br>
         `mat2x2(`|e|`)`: mat2x2&lt;|T|&gt;<br>
     <td rowspan=9>Identity type conversion. The result is |e|.
   <tr>
-    <td>|e|: mat2x3&lt;|T|&gt;<br>|T| is f32 or f16
+    <td>|e|: mat2x3&lt;|T|&gt;
     <td>`mat2x3<`|T|`>(`|e|`)`: mat2x3&lt;|T|&gt;<br>
         `mat2x3(`|e|`)`: mat2x3&lt;|T|&gt;
   <tr>
-    <td>|e|: mat2x4&lt;|T|&gt;<br>|T| is f32 or f16
+    <td>|e|: mat2x4&lt;|T|&gt;
     <td>`mat2x4<`|T|`>(`|e|`)`: mat2x4&lt;|T|&gt;<br>
         `mat2x4(`|e|`)`: mat2x4&lt;|T|&gt;
   <tr>
-    <td>|e|: mat3x2&lt;|T|&gt;<br>|T| is f32 or f16
+    <td>|e|: mat3x2&lt;|T|&gt;
     <td>`mat3x2<`|T|`>(`|e|`)`: mat3x2&lt;|T|&gt;<br>
         `mat3x2(`|e|`)`: mat3x2&lt;|T|&gt;
   <tr>
-    <td>|e|: mat3x3&lt;|T|&gt;<br>|T| is f32 or f16
+    <td>|e|: mat3x3&lt;|T|&gt;
     <td>`mat3x3<`|T|`>(`|e|`)`: mat3x3&lt;|T|&gt;<br>
         `mat3x3(`|e|`)`: mat3x3&lt;|T|&gt;
   <tr>
-    <td>|e|: mat3x4&lt;|T|&gt;<br>|T| is f32 or f16
+    <td>|e|: mat3x4&lt;|T|&gt;
     <td>`mat3x4<`|T|`>(`|e|`)`: mat3x4&lt;|T|&gt;<br>
         `mat3x4(`|e|`)`: mat3x4&lt;|T|&gt;
   <tr>
-    <td>|e|: mat4x2&lt;|T|&gt;<br>|T| is f32 or f16
+    <td>|e|: mat4x2&lt;|T|&gt;
     <td>`mat4x2<`|T|`>(`|e|`)`: mat4x2&lt;|T|&gt;<br>
         `mat4x2(`|e|`)`: mat4x2&lt;|T|&gt;
   <tr>
-    <td>|e|: mat4x3&lt;|T|&gt;<br>|T| is f32 or f16
+    <td>|e|: mat4x3&lt;|T|&gt;
     <td>`mat4x3<`|T|`>(`|e|`)`: mat4x3&lt;|T|&gt;<br>
         `mat4x3(`|e|`)`: mat4x3&lt;|T|&gt;
   <tr>
-    <td>|e|: mat4x4&lt;|T|&gt;<br>|T| is f32 or f16
+    <td>|e|: mat4x4&lt;|T|&gt;
     <td>`mat4x4<`|T|`>(`|e|`)`: mat4x4&lt;|T|&gt;<br>
         `mat4x4(`|e|`)`: mat4x4&lt;|T|&gt;
   <tr>
     <td rowspan=2>|e1|: |T|<br>
         ...<br>
         |eN|: |T|<br>
-        |T| is f32 or f16
     <td>`mat2x2<T>(e1,e2,e3,e4)`: mat2x2&lt;|T|&gt;<br>
         `mat3x2<T>(e1,...,e6)`: mat3x2&lt;|T|&gt;<br>
         `mat2x3<T>(e1,...,e6)`: mat2x3&lt;|T|&gt;<br>
@@ -4121,7 +4186,6 @@ specify the component type; the component type is inferred from the constructor 
         *e2*: vec2&lt;|T|&gt;<br>
         *e3*: vec2&lt;|T|&gt;<br>
         *e4*: vec2&lt;|T|&gt;<br>
-        |T| is f32 or f16
     <td>`mat2x2<T>(e1,e2)`: mat2x2&lt;|T|&gt;<br>
         `mat3x2<T>(e1,e2,e3)`: mat3x2&lt;|T|&gt;<br>
         `mat4x2<T>(e1,e2,e3,e4)`: mat4x2&lt;|T|&gt;
@@ -4135,7 +4199,6 @@ specify the component type; the component type is inferred from the constructor 
         *e2*: vec3&lt;|T|&gt;<br>
         *e3*: vec3&lt;|T|&gt;<br>
         *e4*: vec3&lt;|T|&gt;<br>
-        |T| is f32 or f16
     <td>`mat2x3<T>(e1,e2)`: mat2x3&lt;|T|&gt;<br>
         `mat3x3<T>(e1,e2,e3)`: mat3x3&lt;|T|&gt;<br>
         `mat4x3<T>(e1,e2,e3,e4)`: mat4x3&lt;|T|&gt;
@@ -4149,7 +4212,6 @@ specify the component type; the component type is inferred from the constructor 
         *e2*: vec4&lt;|T|&gt;<br>
         *e3*: vec4&lt;|T|&gt;<br>
         *e4*: vec4&lt;|T|&gt;<br>
-        |T| is f32 or f16
     <td>`mat2x4<T>(e1,e2)`: mat2x4&lt;|T|&gt;<br>
         `mat3x4<T>(e1,e2,e3)`: mat3x4&lt;|T|&gt;<br>
         `mat4x4<T>(e1,e2,e3,e4)`: mat4x4&lt;|T|&gt;
@@ -4371,8 +4433,8 @@ For details on conversion to and from floating point types, see [[#floating-poin
   <tr algorithm="scalar reinterpretation from unsigned to signed">
       <td>|e|: u32<td>`i32(`|e|`)`: i32
       <td>Reinterpretation of bits.<br>
-          The result is the unique value in [=i32=] that is equal to (|e| mod 2<sup>32</sup>).
-  <tr algorithm="scalar conversion from binary32 floating point to signed integer">
+          The result is the unique value in [=i32=] that has the same bit pattern as |e|.
+  <tr algorithm="scalar conversion from floating point to signed integer">
       <td>|e|: f32<td>`i32(`|e|`)`: i32
       <td>Value conversion, rounding toward zero.
   <tr algorithm="scalar conversion from binary16 floating point to signed integer">
@@ -4383,10 +4445,10 @@ For details on conversion to and from floating point types, see [[#floating-poin
       <td>Conversion of a boolean value to an unsigned integer<br>
           The result is 1u if |e| is true and 0u otherwise.
   <tr algorithm="scalar conversion from signed integer to unsigned integer">
-      <td>|e|: i32<td>`u32(`|e|`)`: u32
+      <td>|e|: AbstractInt or i32<td>`u32(`|e|`)`: u32
       <td>Reinterpretation of bits.<br>
-          The result is the unique value in [=u32=] that is equal to (|e| mod 2<sup>32</sup>).
-  <tr algorithm="scalar conversion from binary32 floating point to unsigned integer">
+          The result is the unique value in [=u32=] that has the same bit pattern as |e|.
+  <tr algorithm="scalar conversion from floating point to unsigned integer">
       <td>|e|: f32<td>`u32(`|e|`)`: u32
       <td>Value conversion, rounding toward zero.
   <tr algorithm="scalar conversion from binary16 floating point to unsigned integer">
@@ -4470,7 +4532,7 @@ Details of conversion to and from floating point are explained in [[#floating-po
          Component |i| of the result is `u32(`|e|`[`|i|`])`
 
   <tr algorithm="vector reinterpretation from signed to unsigned">
-     <td>|e|: vec|N|&lt;i32&gt;
+     <td>|e|: vec|N|&lt;AbstractInt&gt; or vec|N|&lt;i32&gt;
      <td>`vec`|N|&lt;`u32`&gt;`(`|e|`)`: vec|N|&lt;u32&gt;
      <td>[=Component-wise=] reinterpretation of bits.
 
@@ -5000,7 +5062,8 @@ See [[#sync-builtin-functions]].
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr algorithm="negation"><td>|e|: |T|<br>
-  |T| is i32, f32, f16, vec|N|&lt;i32&gt;, vec|N|&lt;f32&gt;, or vec|N|&lt;f16&gt;
+  |T| is AbstractInt, AbstractFloat, i32, f32, f16, vec|N|&lt;AbstractInt&gt;,
+  vec|N|&lt;AbstractFloat&gt;, vec|N|&lt;i32&gt;, vec|N|&lt;f32&gt;, or vec|N|&lt;f16&gt;
   <td>`-`|e|`:` |T|
   <td>Negation. [=Component-wise=] when |T| is a vector.
   If |T| is an integral type and |e| evaluates to the largest negative value, then the result is |e|.
@@ -5013,25 +5076,25 @@ See [[#sync-builtin-functions]].
   </thead>
 
   <tr algorithm="addition">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [NUMERIC]
+    <td>|e1| : |T|<br>|e2| : |T|<br>[ALLNUMERICDECL]
     <td>|e1| `+` |e2| : |T|
     <td>Addition. [=Component-wise=] when |T| is a vector.
-    If |T| is an integral type, then the result is modulo 2<sup>32</sup>.
+    If |T| is a [=concrete=] integral type, then the result is modulo 2<sup>32</sup>.
 
   <tr algorithm="subtraction">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [NUMERIC]
+    <td>|e1| : |T|<br>|e2| : |T|<br>[ALLNUMERICDECL]
     <td>|e1| `-` |e2| : |T|
     <td>Subtraction [=Component-wise=] when |T| is a vector.
-    If |T| is an integral type, then the result is modulo 2<sup>32</sup>.
+    If |T| is a [=concrete=] integral type, then the result is modulo 2<sup>32</sup>.
 
   <tr algorithm="multiplication">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [NUMERIC]
+    <td>|e1| : |T|<br>|e2| : |T|<br>[ALLNUMERICDECL]
     <td>|e1| `*` |e2| : |T|
     <td>Multiplication. [=Component-wise=] when |T| is a vector.
-    If |T| is an integral type, then the result is modulo 2<sup>32</sup>.
+    If |T| is a [=concrete=] integral type, then the result is modulo 2<sup>32</sup>.
 
   <tr algorithm="division">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [NUMERIC]
+    <td>|e1| : |T|<br>|e2| : |T|<br>[ALLNUMERICDECL]
     <td>|e1| `/` |e2| : |T|
     <td>Division. [=Component-wise=] when |T| is a vector.
 
@@ -5059,7 +5122,7 @@ See [[#sync-builtin-functions]].
             where 0 &le; |r| &lt; |e2|.
 
   <tr algorithm="Remainder">
-    <td>|e1| : |T|<br>|e2| : |T|<br>|T| is [NUMERIC]
+    <td>|e1| : |T|<br>|e2| : |T|<br>[ALLNUMERICDECL]
     <td>|e1| `%` |e2| : |T|
     <td>Remainder. [=Component-wise=] when |T| is a vector.
 
@@ -5098,7 +5161,7 @@ See [[#sync-builtin-functions]].
     <th>Preconditions<th>Conclusions<th>Semantics
   </thead>
   <tr algorithm="vector-scalar arithmetic, any scalar type">
-    <td rowspan="10">|S| is one of i32, u32, f32, f16<br>
+    <td rowspan="10">|S| is one of AbstractInt, AbstractFloat, f32, f16, i32, u32<br>
         |V| is vec|N|&lt;|S|&gt<br>
         |es|: |S|<br>
         |ev|: |V|
@@ -5140,7 +5203,7 @@ See [[#sync-builtin-functions]].
   </thead>
   <tr algorithm="matrix addition">
     <td rowspan=2>|e1|, |e2|: mat|C|x|R|&lt;|T|&gt<br>
-        |T| is f32 or f16
+        |T| is AbstractFloat, f32, or f16
     <td>|e1| `+` |e2|: mat|C|x|R|&lt;|T|&gt<br>
     <td>Matrix addition: column |i| of the result is |e1|[i] + |e2|[i]
   <tr algorithm="matrix subtraction">
@@ -5149,7 +5212,7 @@ See [[#sync-builtin-functions]].
   <tr algorithm="matrix-scalar multiply">
     <td rowspan=2>|m|: mat|C|x|R|&lt;|T|&gt<br>
         |s|: |T|<br>
-        |T| is f32 or f16
+        |T| is AbstractFloat, f32, or f16
     <td>|m| `*` |s|:  mat|C|x|R|&lt;|T|&gt<br>
     <td>Component-wise scaling: (|m| `*` |s|)[i][j] is |m|[i][j] `*` |s|
   <tr algorithm="scalar-matrix multiply">
@@ -5158,7 +5221,7 @@ See [[#sync-builtin-functions]].
   <tr algorithm="matrix-column-vector multiply">
     <td>|m|: mat|C|x|R|&lt;|T|&gt<br>
         |v|: vec|C|&lt;|T|&gt<br>
-        |T| is f32 or f16
+        |T| is AbstractFloat, f32, or f16
     <td>|m| `*` |v|:  vec|R|&lt;|T|&gt<br>
     <td>Linear algebra matrix-column-vector product:
         Component |i| of the result is `dot`(|m|[|i|],|v|)
@@ -5166,14 +5229,14 @@ See [[#sync-builtin-functions]].
     <td>
         |m|: mat|C|x|R|&lt;|T|&gt<br>
         |v|: vec|R|&lt;|T|&gt<br>
-        |T| is f32 or f16
+        |T| is AbstractFloat, f32, or f16
     <td>|v| `*` |m|:  vec|C|&lt;|T|&gt<br>
     <td>Linear algebra row-vector-matrix product:<br>
         [=transpose=](transpose(|m|) `*` transpose(|v|))
   <tr algorithm="matrix-matrix multiply">
     <td>|e1|: mat|K|x|R|&lt;|T|&gt<br>
         |e2|: mat|C|x|K|&lt;|T|&gt<br>
-        |T| is f32 or f16
+        |T| is AbstractFloat, f32, or f16
     <td>|e1| `*` |e2|:  mat|C|x|R|&lt;|T|&gt<br>
     <td>Linear algebra matrix product.
 
@@ -5189,38 +5252,40 @@ See [[#sync-builtin-functions]].
 
   <tr algorithm="equality">
     <td>|e1|: |T|<br>|e2|: |T|<br>
-    |T| is bool, i32, u32, f32, f16, vec|N|&lt;bool&gt;, vec|N|&lt;i32&gt;, vec|N|&lt;u32&gt;, vec|N|&lt;f32&gt;, or vec|N|&lt;f16&gt;<br>
-    |TB| is bool if |T| is scalar, or<br>
+    |S| is AbstractInt, AbstractFloat, bool, i32, u32, f32, or f16<br>
+    |T| is |S| or vec|N|&lt;|S|&gt;<br>
+    |TB| is bool if |T| is scalar or<br>
     vec|N|&lt;bool&gt; if |T| is a vector
     <td class="nowrap">|e1| `==` |e2|`:` |TB|
     <td>Equality. [=Component-wise=] when |T| is a vector.
   <tr algorithm="inequality">
     <td>|e1|: |T|<br>|e2|: |T|<br>
-    |T| is [NUMERIC]<br>
-    |TB| is bool if |T| is scalar, or<br>
+    |S| is AbstractInt, AbstractFloat, bool, i32, u32, or f32<br>
+    |T| is |S| or vec|N|&lt;|S|&gt;<br>
+    |TB| is bool if |T| is scalar or<br>
     vec|N|&lt;bool&gt; if |T| is a vector
     <td class="nowrap">|e1| `!=` |e2|`:` |TB|
     <td>Inequality. [=Component-wise=] when |T| is a vector.
   <tr algorithm="less than">
-    <td>|e1|: |T|<br>|e2|: |T|<br>|T| is [NUMERIC]<br>
+    <td>|e1|: |T|<br>|e2|: |T|<br>[ALLNUMERICDECL]<br>
     |TB| is bool if |T| is scalar, or<br>
     vec|N|&lt;bool&gt; if |T| is a vector
     <td class="nowrap">|e1| `<` |e2|`:` |TB|
     <td>Less than. [=Component-wise=] when |T| is a vector.
   <tr algorithm="less than equal">
-    <td>|e1|: |T|<br>|e2|: |T|<br>|T| is [NUMERIC]<br>
+    <td>|e1|: |T|<br>|e2|: |T|<br>[ALLNUMERICDECL]<br>
     |TB| is bool if |T| is scalar, or<br>
     vec|N|&lt;bool&gt; if |T| is a vector
     <td class="nowrap">|e1| `<=` |e2|`:` |TB|
     <td>Less than or equal. [=Component-wise=] when |T| is a vector.
   <tr algorithm="greater than">
-    <td>|e1|: |T|<br>|e2|: |T|<br>|T| is [NUMERIC]<br>
+    <td>|e1|: |T|<br>|e2|: |T|<br>[ALLNUMERICDECL]<br>
     |TB| is bool if |T| is scalar, or<br>
     vec|N|&lt;bool&gt; if |T| is a vector
     <td class="nowrap">|e1| `>` |e2|`:` |TB|
     <td>Greater than. [=Component-wise=] when |T| is a vector.
   <tr algorithm="greater than equal">
-    <td>|e1|: |T|<br>|e2|: |T|<br>|T| is [NUMERIC]<br>
+    <td>|e1|: |T|<br>|e2|: |T|<br>[ALLNUMERICDECL]<br>
     |TB| is bool if |T| is scalar, or<br>
     vec|N|&lt;bool&gt; if |T| is a vector
     <td class="nowrap">|e1| `>=` |e2|`:` |TB|
@@ -5237,7 +5302,7 @@ See [[#sync-builtin-functions]].
   </thead>
   <tr algorithm="complement">
     <td>|e|: |T|<br>
-    |T| is [INTEGRAL]
+    [ALLINTEGRALDECL]
     <td class="nowrap">`~`|e| : |T|
     <td>Bitwise complement on |e|.
     Each bit in the result is the opposite of the corresponding bit in |e|.
@@ -5250,22 +5315,22 @@ See [[#sync-builtin-functions]].
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr algorithm="bitwise or">
-    <td>*e1*: *T*<br>
-       *e2*: *T*<br>
-       *T* is [INTEGRAL]
-    <td class="nowrap">`e1 | e2`: *T*
+    <td>|e1|: |T|<br>
+       |e2|: |T|<br>
+       [ALLINTEGRALDECL]
+    <td class="nowrap">|e1| `|` |e2|: |T|
     <td>Bitwise-or. [=Component-wise=] when |T| is a vector.
   <tr algorithm="bitwise and">
-    <td>*e1*: *T*<br>
-       *e2*: *T*<br>
-       *T* is [INTEGRAL]
-    <td class="nowrap">`e1 & e2`: *T*
+    <td>|e1|: |T|<br>
+       |e2|: |T|<br>
+       [ALLINTEGRALDECL]
+    <td class="nowrap">|e1| `&` |e2|: |T|
     <td>Bitwise-and. [=Component-wise=] when |T| is a vector.
   <tr algorithm="bitwise exclusive or">
-    <td>*e1*: *T*<br>
-       *e2*: *T*<br>
-       *T* is [INTEGRAL]
-    <td class="nowrap">`e1 ^ e2`: *T*
+    <td>|e1|: |T|<br>
+       |e2|: |T|<br>
+       [ALLINTEGRALDECL]
+    <td class="nowrap">|e1| `^` |e2|: |T|
     <td>Bitwise-exclusive-or. [=Component-wise=] when |T| is a vector.
 </table>
 
@@ -5550,6 +5615,15 @@ When an identifier is used as a [=syntax/callable=] item, it is one of:
     | [=syntax/binary_xor_expression=] [=syntax/xor=] [=syntax/unary_expression=]
 </div>
 <div class='syntax' noexport='true'>
+  <dfn for=syntax>bitwise_expression</dfn> :
+
+    | [=syntax/binary_and_expression=] [=syntax/and=] [=syntax/unary_expression=]
+
+    | [=syntax/binary_or_expression=] [=syntax/or=] [=syntax/unary_expression=]
+
+    | [=syntax/binary_xor_expression=] [=syntax/xor=] [=syntax/unary_expression=]
+</div>
+<div class='syntax' noexport='true'>
   <dfn for=syntax>expression</dfn> :
 
     | [=syntax/relational_expression=]
@@ -5558,11 +5632,7 @@ When an identifier is used as a [=syntax/callable=] item, it is one of:
 
     | [=syntax/short_circuit_and_expression=] [=syntax/and_and=] [=syntax/relational_expression=]
 
-    | [=syntax/binary_and_expression=] [=syntax/and=] [=syntax/unary_expression=]
-
-    | [=syntax/binary_or_expression=] [=syntax/or=] [=syntax/unary_expression=]
-
-    | [=syntax/binary_xor_expression=] [=syntax/xor=] [=syntax/unary_expression=]
+    | [=syntax/bitwise_expression=]
 </div>
 
 
@@ -6977,6 +7047,10 @@ See [[#function-calls]].
 The identifier is [=in scope=] until the end of the function.
 Two formal parameters for a given function must not have the same name.
 
+Note: Some built-in functions may allow parameters to be [=abstract numeric types=];
+however, this functionality is not currently supported for user-declared
+functions.
+
 The [=return type=], if specified, must be [=constructible=].
 
 <div class='syntax' noexport='true'>
@@ -7082,6 +7156,40 @@ any descendent called function executes a [=statement/discard=] statement.
 The location of a function call is referred to as a <dfn noexport>call site</dfn>.
 Call sites are a [=dynamic context=].
 As such, the same textual location may represent multiple call sites.
+
+## Creation-time Functions ## {#creation-time-funcs}
+
+A function declared with a [=attribute/const=] attribute can be
+evaluated at [=shader module creation|shader-creation time=].
+These functions are called <dfn noexport>creation-time functions</dfn>.
+Calls to these functions can part of [=creation-time expressions=].
+
+It is a [=shader-creation error=] if the function contains any expressions that
+are not [=creation-time expressions=], or any declarations that are not
+[=creation-time constants=].
+
+Note: The [=attribute/const=] attribute cannot be applied to user-declared functions.
+
+<div class='example wgsl' heading='Creation-time functions'>
+  <xmp>
+    const first_one = firstLeadingBit(1234 + 4567); // Evaluates to 12
+                                                    // first_one has the type i32, because
+                                                    // firstLeadingBit cannot operate on
+                                                    // AbstractInt
+
+    @id(1) override x : i32;
+    override y = firstLeadingBit(x); // Creation-time expressions can be
+                                     // used in override expressions.
+                                     // firstLeadingBit(x) is not a
+                                     // creation-time expression in this context.
+
+    fn foo() {
+      var a : array<i32, firstLeadingBit(257)>; // Creation-time functions can be used in
+                                                // creation-time expressions if all their
+                                                // parameters are creation-time expressions.
+    }
+  </xmp>
+</div>
 
 ## Restrictions on Functions ## {#function-restriction}
 
@@ -8094,7 +8202,8 @@ The rules for analyzing expressions take as argument both the expression itself 
       <td>
       <td class="nowrap">*CF*, *CF*
       <td>
-   <tr><td>reference to function-scope variable, let-declaration, or non-built-in parameter "x"
+   <tr><td>reference to function-scope variable, creation-time constant,
+      let-declaration, or non-built-in parameter "x"
       <td>*Result*
       <td class="nowrap">*X* is the node corresponding to "x"
       <td class="nowrap">*CF*, *Result*
@@ -8145,7 +8254,7 @@ All other ones (see [[#builtin-values]]) are considered non-uniform.
   <thead>
     <tr><th>Expression<th>New nodes<th>Recursive analyses<th>Resulting control flow node, variable node<th>New edges
   </thead>
-  <tr><td>reference to function-scope variable, let-declaration, or parameter "x"
+  <tr><td>reference to function-scope variable, creation-time constant, let-declaration, or parameter "x"
       <td>
       <td class="nowrap">*X* is the node corresponding to "x"
       <td class="nowrap">*CF*, *X*
@@ -8866,6 +8975,11 @@ Issue: https://github.com/gpuweb/gpuweb/issues/1621
     | `'case'`
 </div>
 <div class='syntax' noexport='true'>
+  <dfn for=syntax>const</dfn> :
+
+    | `'const'`
+</div>
+<div class='syntax' noexport='true'>
   <dfn for=syntax>continue</dfn> :
 
     | `'continue'`
@@ -9141,8 +9255,6 @@ The following are reserved words:
     | `'compile_fragment'`   <!-- HLSL -->
 
     | `'concept'`   <!-- C++ -->
-
-    | `'const'`   <!-- C++ ECMAScript2022 Rust HLSL GLSL WGSL -->
 
     | `'const_cast'`   <!-- C++ -->
 
@@ -10126,32 +10238,32 @@ See [[#function-calls]].
   </thead>
   <tr algorithm="vector all">
     <td>
-    <td>`all`(|e|: vec|N|&lt;bool&gt;) -> bool
+    <td>`@const fn`<br>`all`(|e|: vec|N|&lt;bool&gt;) -> bool
     <td>Returns true if each component of |e| is true.
 
   <tr algorithm="scalar all">
-    <td>
-    <td>`all`(|e|: bool) -> bool
+    <td>|e|: bool
+    <td>`@const fn`<br>`all(`|e|`)` -> bool
     <td>Returns |e|.
 
   <tr algorithm="vector any">
     <td>
-    <td>`any`(|e|: vec|N|&lt;bool&gt;) -> bool
+    <td>`@const fn`<br>`any`(|e|: vec|N|&lt;bool&gt;) -> bool
     <td>Returns true if any component of |e| is true.
 
   <tr algorithm="scalar any">
-    <td>
-    <td>`any`(|e|: bool) -> bool
+    <td>|e|: bool
+    <td>`@const fn`<br>`any(`|e|`)` -> bool
     <td>Returns |e|.
 
   <tr algorithm="scalar select">
-    <td>|T| is [=scalar=] or [=vector=]
-    <td>`select`(|f|: |T|, |t|: |T|, |cond|: bool) -> |T|
+    <td>|T| is [=scalar=], [=abstract numeric type=], or [=vector=]
+    <td>`@const fn`<br>`select`(|f|: |T|, |t|: |T|, |cond|: bool) -> |T|
     <td>Returns |t| when |cond| is true, and |f| otherwise.
 
   <tr algorithm="vector select">
-    <td>|T| is [=scalar=]
-    <td>`select`(|f|: vec|N|&lt;|T|&gt;, |t|: vec|N|&lt;|T|&gt;, |cond|: vec|N|&lt;bool&gt;) -> vec|N|&lt;|T|&gt;
+    <td>|T| is [=scalar=] or [=abstract numeric type=]
+    <td class="nowrap">`@const fn`<br>`select`(|f|: vec|N|&lt;|T|&gt;, |t|: vec|N|&lt;|T|&gt;, |cond|: vec|N|&lt;bool&gt;) -> vec|N|&lt;|T|&gt;
     <td>[=Component-wise=] selection. Result component |i| is evaluated
         as `select(`|f|`[`|i|`], `|t|`[`|i|`], `|cond|`[`|i|`])`.
 </table>
@@ -10163,7 +10275,7 @@ See [[#function-calls]].
   </thead>
   <tr algorithm="runtime-sized array length">
     <td>
-    <td>`arrayLength`(|e|: ptr&lt;storage,array&lt;|T|&gt;&gt; ) -> u32
+    <td>`fn arrayLength`(|e|: ptr&lt;storage,array&lt;|T|&gt;&gt; ) -> u32
         <td>Returns the number of elements in the [=runtime-sized=] array.
 </table>
 
@@ -10174,20 +10286,20 @@ See [[#function-calls]].
     <tr><th>Parameterization<th>Overload<th>Description
   </thead>
   <tr algorithm="float abs">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`abs(`|e|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`abs(`|e|`:` |T| `) -> ` |T|
     <td>Returns the absolute value of |e| (e.g. |e| with a positive sign bit).
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="acos">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`acos(`|e|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`acos(`|e|`:` |T| `) -> ` |T|
     <td>Returns the arc cosine of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="acosh">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`acosh(`|e|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`acosh(`|e|`:` |T| `) -> ` |T|
     <td>Returns the hyperbolic arc cosine of |e|.
     The result is 0 when |e| &lt; 1.<br>
     Computes the non-negative functional inverse of `cosh`.<br>
@@ -10195,27 +10307,27 @@ See [[#function-calls]].
 
     Note: The result is not mathematically meaningful when |e| &lt; 1.
   <tr algorithm="asin">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`asin(`|e|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`asin(`|e|`:` |T| `) -> ` |T|
     <td>Returns the arc sine of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="asinh">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`asinh(`|e|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`asinh(`|e|`:` |T| `) -> ` |T|
     <td>Returns the hyperbolic arc sine of |e|.<br>
     Computes the functional inverse of `sinh`.<br>
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="atan">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`atan(`|e|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`atan(`|e|`:` |T| `) -> ` |T|
     <td>Returns the arc tangent of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="atanh">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`atanh(`|e|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`atanh(`|e|`:` |T| `) -> ` |T|
     <td>Returns the hyperbolic arc tangent of |e|.
     The result is 0 when `abs`(|e|) &ge; 1.<br>
     Computes the functional inverse of `tanh`.<br>
@@ -10224,89 +10336,89 @@ See [[#function-calls]].
     Note: The result is not mathematically meaningful when `abs`(|e|) &ge; 1.<br>
 
   <tr algorithm="atan2">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`atan2(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`atan2(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>Returns the arc tangent of |e1| over |e2|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="ceil">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`ceil(`|e|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`ceil(`|e|`:` |T| `) -> ` |T|
     <td>Returns the [=ceiling expression|ceiling=] of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="clamp">
-    <td>|T| is [FLOATING]
+    <td>|T| is [ALLFLOATING]
     <td class="nowrap">`clamp(`|e|`:` |T| `,` |low|`:` |T| `,` |high|`:` |T|`) -> ` |T|
     <td>Returns either `min(max(`|e|`,`|low|`),`|high|`)`, or the median of the three values |e|, |low|, |high|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="cos">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`cos(`|e|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`cos(`|e|`:` |T| `) -> ` |T|
     <td>Returns the cosine of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="cosh">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`cosh(`|e|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`cosh(`|e|`:` |T| `) -> ` |T|
     <td>Returns the hyperbolic cosine of |e|.
     [=Component-wise=] when |T| is a vector
 
   <tr algorithm="vector case, cross">
-    <td>|T| is f32 or f16
-    <td class="nowrap">`cross(`|e1|`:` vec3<|T|> `, `|e2|`:` vec3<|T|>`) -> ` vec3<|T|>
+    <td>|T| is AbstractFloat, f32, or f16
+    <td class="nowrap">`@const fn`<br>`cross(`|e1|`:` vec3<|T|> `, `|e2|`:` vec3<|T|>`) -> ` vec3<|T|>
     <td>Returns the cross product of |e1| and |e2|.
 
   <tr algorithm="degrees">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`degrees(`|e1|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`degrees(`|e1|`:` |T| `) -> ` |T|
     <td>Converts radians to degrees, approximating |e1|&nbsp;&times;&nbsp;180&nbsp;&div;&nbsp;&pi;.
     [=Component-wise=] when |T| is a vector<br>
 
   <tr algorithm="distance">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`distance(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` f32
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`distance(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` f32
     <td>Returns the distance between |e1| and |e2| (e.g. `length(`|e1|` - `|e2|`)`).
 
   <tr algorithm="exp">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`exp(`|e1|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`exp(`|e1|`:` |T| `) -> ` |T|
     <td>Returns the natural exponentiation of |e1| (e.g. `e`<sup>|e1|</sup>).
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="exp2">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`exp2(`|e|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`exp2(`|e|`:` |T| `) -> ` |T|
     <td>Returns 2 raised to the power |e| (e.g. `2`<sup>|e|</sup>).
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="faceForward">
-    <td>|T| is vec|N|&lt;f32&gt; or vec|N|&lt;f16&gt;
-    <td class="nowrap">`faceForward(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T| `) -> ` |T|
+    <td>|T| is vec|N|&lt;AbstractFloat&gt;, vec|N|&lt;f32&gt;, or vec|N|&lt;f16&gt;
+    <td class="nowrap">`@const fn`<br>`faceForward(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T| `) -> ` |T|
     <td>Returns |e1| if `dot(`|e2|`,`|e3|`)` is negative, and `-`|e1| otherwise.
 
   <tr algorithm="floor">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`floor(`|e|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`floor(`|e|`:` |T| `) -> ` |T|
     <td>Returns the [=floor expression|floor=] of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="fma">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`fma(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`fma(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T| `) -> ` |T|
     <td>Returns |e1| `*` |e2| `+` |e3|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="fract">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`fract(`|e|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`fract(`|e|`:` |T| `) -> ` |T|
     <td>Returns the fractional part of |e|, computed as |e| `- floor(`|e|`)`.<br>
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="scalar case, binary32, frexp">
     <td>|T| is f32
-    <td class="nowrap">`frexp(`|e|`: `|T|`) -> __frexp_result`<br>
+    <td class="nowrap">`@const fn`<br>`frexp(`|e|`: `|T|`) -> __frexp_result`<br>
     <td>Splits |e| into a significand and exponent of the form `significand * 2`<sup>`exponent`</sup>.
     Returns the `__frexp_result` built-in structure, defined as if as follows:
     ```rust
@@ -10330,7 +10442,7 @@ struct __frexp_result {
 
   <tr algorithm="scalar case, binary16, frexp">
     <td>|T| is f16
-    <td class="nowrap">`frexp(`|e|`: `|T|`) -> __frexp_result_f16`<br>
+    <td class="nowrap">`@const fn frexp(`|e|`: `|T|`) -> __frexp_result_f16`<br>
     <td>Splits |e| into a significand and exponent of the form `significand * 2`<sup>`exponent`</sup>.
     Returns the `__frexp_result_f16` built-in structure, defined as if as follows:
     ```rust
@@ -10345,7 +10457,7 @@ struct __frexp_result_f16 {
 
   <tr algorithm="vector case, binary32, frexp">
     <td>|T| is vec|N|&lt;f32&gt;
-    <td class="nowrap">`frexp(`|e|`: `|T|`) -> __frexp_result_vec`|N|<br>
+    <td class="nowrap">`@const fn`<br>`frexp(`|e|`: `|T|`) -> __frexp_result_vec`|N|<br>
     <td>Splits the components of |e| into a significand and exponent of the form `significand * 2`<sup>`exponent`</sup>.
     Returns the `__frexp_result_vec`|N| built-in structure, defined as if as follows:
     ```rust
@@ -10360,7 +10472,7 @@ struct __frexp_result_vecN {
 
   <tr algorithm="vector case, binary16, frexp">
     <td>|T| is vec|N|&lt;f16&gt;
-    <td class="nowrap">`frexp(`|e|`: `|T|`) -> __frexp_result_vec`|N|`_f16`<br>
+    <td class="nowrap">`@const fn frexp(`|e|`: `|T|`) -> __frexp_result_vec`|N|`_f16`<br>
     <td>Splits the components of |e| into a significand and exponent of the form `significand * 2`<sup>`exponent`</sup>.
     Returns the `__frexp_result_vec`|N| built-in structure, defined as if as follows:
     ```rust
@@ -10374,70 +10486,71 @@ struct __frexp_result_vecN_f16 {
     Note: A value cannot be explicitly declared with the type `__frexp_result_vec`|N|`_f16`, but a value may infer the type.
 
   <tr algorithm="inverseSqrt">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`inverseSqrt(`|e|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`inverseSqrt(`|e|`:` |T| `) -> ` |T|
     <td>Returns the reciprocal of `sqrt(`|e|`)`.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="ldexp">
-    <td>|T| is [FLOATING]<br>
-        |I| is [SIGNEDINTEGRAL], where<br>
+    <td>|T| is [ALLFLOATING]<br>
+        |I| is [ALLSIGNEDINTEGRAL], where<br>
         |I| is a scalar if |T| is a scalar, or<br>
         a vector when |T| is a vector
-    <td class="nowrap">`ldexp(`|e1|`:` |T| `, `|e2|`:` |I| `) -> ` |T|
+    <td class="nowrap">`@const fn`<br>`ldexp(`|e1|`:` |T| `, `|e2|`:` |I| `) -> ` |T|
     <td>Returns |e1| `* 2`<sup>|e2|</sup>.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="length">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`length(`|e|`:` |T| `) -> ` f32
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`length(`|e|`:` |T| `) -> ` f32
     <td>Returns the length of |e| (e.g. `abs(`|e|`)` if |T| is a scalar, or `sqrt(`|e|`[0]`<sup>`2`</sup> `+` |e|`[1]`<sup>`2`</sup> `+ ...)` if |T| is a vector).
 
   <tr algorithm="log">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`log(`|e|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`log(`|e|`:` |T| `) -> ` |T|
     <td>Returns the natural logarithm of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="log2">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`log2(`|e|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`log2(`|e|`:` |T| `) -> ` |T|
     <td>Returns the base-2 logarithm of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="max">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`max(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`max(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>Returns |e2| if |e1| is less than |e2|, and |e1| otherwise.
     If one operand is a NaN, the other is returned.
     If both operands are NaNs, a NaN is returned.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="min">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`min(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`min(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>Returns |e2| if |e2| is less than |e1|, and |e1| otherwise.
     If one operand is a NaN, the other is returned.
     If both operands are NaNs, a NaN is returned.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="mix all same type operands">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`mix(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T|`) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`mix(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T|`) -> ` |T|
     <td>Returns the linear blend of |e1| and |e2| (e.g. |e1|`*(1-`|e3|`)+`|e2|`*`|e3|).
     [=Component-wise=] when |T| is a vector.
     <br>
 
   <tr algorithm="vector mix with scalar blending factor">
-    <td>|T1| is f32 or f16<br>|T2| is vec|N|&lt;|T|&gt;
-    <td class="nowrap">`mix(`|e1|`:` |T2| `, `|e2|`:` |T2| `, `|e3|`:` |T1| `) -> ` |T2|
+    <td>|T| is AbstractFloat, f32, or f16<br>
+        |T2| is vec|N|&lt;|T|&gt;
+    <td class="nowrap">`@const fn`<br>`mix(`|e1|`:` |T2| `, `|e2|`:` |T2| `, `|e3|`:` f32 `) -> ` |T|
     <td>Returns the component-wise linear blend of |e1| and |e2|,
         using scalar blending factor |e3| for each component.<br>
         Same as `mix(`|e1|`, `|e2|`, `|T2|`(`|e3|`))`.
 
   <tr algorithm="scalar case, binary32, modf">
     <td>|T| is f32
-    <td class="nowrap">`modf(`|e|`: `|T|`) -> __modf_result`<br>
+    <td class="nowrap">`@const fn`<br>`modf(`|e|`: `|T|`) -> __modf_result`<br>
     <td>Splits |e| into fractional and whole number parts.
     Returns the `__modf_result` built-in structure, defined as if as follows:
     ```rust
@@ -10460,7 +10573,7 @@ struct __modf_result {
 
   <tr algorithm="scalar case, binary16, modf">
     <td>|T| is f16
-    <td class="nowrap">`modf(`|e|`: `|T|`) -> __modf_result_f16`<br>
+    <td class="nowrap">`@const fn modf(`|e|`: `|T|`) -> __modf_result_f16`<br>
     <td>Splits |e| into fractional and whole number parts.
     Returns the `__modf_result_f16` built-in structure, defined as if as follows:
     ```rust
@@ -10474,7 +10587,7 @@ struct __modf_result_f16 {
 
   <tr algorithm="vector case, binary32, modf">
     <td>|T| is vec|N|&lt;f32&gt;
-    <td class="nowrap">`modf(`|e|`: `|T|`) -> __modf_result_vec`|N|<br>
+    <td class="nowrap">`@const fn`<br>`modf(`|e|`: `|T|`) -> __modf_result_vec`|N|<br>
     <td>Splits the components of |e| into fractional and whole number parts.
     Returns the `__modf_result_vec`|N| built-in structure, defined as if as follows:
     ```rust
@@ -10488,7 +10601,7 @@ struct __modf_result_vecN {
 
   <tr algorithm="vector case, binary16, modf">
     <td>|T| is vec|N|&lt;f16&gt;
-    <td class="nowrap">`modf(`|e|`: `|T|`) -> __modf_result_vec`|N|`_f16`<br>
+    <td class="nowrap">`@const fn modf(`|e|`: `|T|`) -> __modf_result_vec`|N|`_f16`<br>
     <td>Splits the components of |e| into fractional and whole number parts.
     Returns the `__modf_result_vec`|N|`_f16` built-in structure, defined as if as follows:
     ```rust
@@ -10501,19 +10614,19 @@ struct __modf_result_vecN_f16 {
     Note: A value cannot be explicitly declared with the type `__modf_result_vec`|N|`_f16`, but a value may infer the type.
 
   <tr algorithm="vector case, normalize">
-    <td>|T| is f32 or f16
-    <td class="nowrap">`normalize(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
+    <td>|T| is AbstractFloat, f32, or f16
+    <td class="nowrap">`@const fn`<br>`normalize(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
     <td>Returns a unit vector in the same direction as |e|.
 
   <tr algorithm="pow">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`pow(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`pow(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>Returns |e1| raised to the power |e2|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="quantize to f16">
     <td>|T| is f32 or vec|N|&lt;f32&gt;
-    <td class="nowrap">`quantizeToF16(`|e|`:` |T| `) -> ` |T|
+    <td class="nowrap">`@const fn quantizeToF16(`|e|`:` |T| `) -> ` |T|
     <td>Quantizes a 32-bit floating point value |e| as if |e| were converted to a [[!IEEE-754|IEEE 754]] binary16 value,
         and then converted back to a IEEE 754 binary32 value.<br>
         See [[#floating-point-conversion]].<br>
@@ -10522,54 +10635,54 @@ struct __modf_result_vecN_f16 {
         Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(`|e|`))`.
 
   <tr algorithm="radians">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`radians(`|e1|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`radians(`|e1|`:` |T| `) -> ` |T|
     <td>Converts degrees to radians, approximating |e1|&nbsp;&times;&nbsp;&pi;&nbsp;&div;&nbsp;180.
     [=Component-wise=] when |T| is a vector<br>
 
   <tr algorithm="reflect">
-    <td>|T| is vec|N|&lt;f32&gt; or vec|N|&lt;f16&gt;
-    <td class="nowrap">`reflect(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
+    <td>|T| is vec|N|&lt;AbstractFloat&gt;, vec|N|&lt;f32&gt;, or vec|N|&lt;f16&gt;
+    <td class="nowrap">`@const fn`<br>`reflect(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>For the incident vector |e1| and surface orientation |e2|, returns the reflection direction
     |e1|`-2*dot(`|e2|`,`|e1|`)*`|e2|.
 
   <tr algorithm="refract">
-    <td>|T1| is f32 or f16<br>|T2| is vec|N|&lt;|T1|&gt;
-    <td class="nowrap">`refract(`|e1|`:` |T2| `, `|e2|`:` |T2| `, `|e3|`:` |T1| `) -> ` |T2|
+    <td>|T| is vec|N|&lt;|I|&gt;<br>I is AbstractFloat, f32, or f16
+    <td class="nowrap">`@const fn`<br>`refract(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |I| `) -> ` |T|
     <td>For the incident vector |e1| and surface normal |e2|, and the ratio of indices of refraction |e3|,
     let `k = 1.0 - `|e3|` * `|e3|` * (1.0 - dot(`|e2|`, `|e1|`) * dot(`|e2|`, `|e1|`))`. If `k < 0.0`, returns the
     refraction vector 0.0, otherwise return the refraction vector
     |e3|` * `|e1|` - (`|e3|` * dot(`|e2|`, `|e1|`) + sqrt(k)) * `|e2|.
 
   <tr algorithm="round">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`round(`|e|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`round(`|e|`:` |T| `) -> ` |T|
     <td>Result is the integer |k| nearest to |e|, as a floating point value.<br>
         When |e| lies halfway between integers |k| and |k|+1,
         the result is |k| when |k| is even, and |k|+1 when |k| is odd.<br>
         [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="float sign">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`sign(`|e|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`sign(`|e|`:` |T| `) -> ` |T|
     <td>Returns the sign of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="sin">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`sin(`|e|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`sin(`|e|`:` |T| `) -> ` |T|
     <td>Returns the sine of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="sinh">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`sinh(`|e|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`sinh(`|e|`:` |T| `) -> ` |T|
     <td>Returns the hyperbolic sine of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="smoothstep">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`smoothstep(`|low|`:` |T| `,` |high|`:` |T| `,` |x|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`smoothstep(`|low|`:` |T| `,` |high|`:` |T| `,` |x|`:` |T| `) -> ` |T|
     <td>Returns the smooth Hermite interpolation between 0 and 1.
     [=Component-wise=] when |T| is a vector.
 
@@ -10578,32 +10691,32 @@ struct __modf_result_vecN_f16 {
     where |t| = clamp((|x| - |low|) / (|high| - |low|), 0.0, 1.0).
 
   <tr algorithm="sqrt">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`sqrt(`|e|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`sqrt(`|e|`:` |T| `) -> ` |T|
     <td>Returns the square root of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="step">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`step(`|edge|`:` |T| `, `|x|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`step(`|edge|`:` |T| `, `|x|`:` |T| `) -> ` |T|
     <td>Returns 1.0 if |edge| &le; |x|, and 0.0 otherwise.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="tan">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`tan(`|e|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`tan(`|e|`:` |T| `) -> ` |T|
     <td>Returns the tangent of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="tanh">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`tanh(`|e|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`tanh(`|e|`:` |T| `) -> ` |T|
     <td>Returns the hyperbolic tangent of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="trunc">
-    <td>|T| is [FLOATING]
-    <td class="nowrap">`trunc(`|e|`:` |T| `) -> ` |T|
+    <td>|T| is [ALLFLOATING]
+    <td class="nowrap">`@const fn`<br>`trunc(`|e|`:` |T| `) -> ` |T|
     <td>Returns the nearest whole number whose absolute value is less than or equal to |e|.
     [=Component-wise=] when |T| is a vector.
 </table>
@@ -10614,34 +10727,24 @@ struct __modf_result_vecN_f16 {
   <thead>
     <tr><th>Parameterization<th>Overload<th>Description
   </thead>
-  <tr algorithm="signed abs">
-    <td>|T| is [SIGNEDINTEGRAL]
-    <td class="nowrap">`abs`(|e|: |T| ) -> |T|
+  <tr algorithm="integral abs">
+    <td>[ALLINTEGRALDECL]
+    <td class="nowrap">`@const fn`<br>`abs`(|e|: |T| ) -> |T|
     <td>The absolute value of |e|.
         [=Component-wise=] when |T| is a vector.
-        If |e| evaluates to the largest negative value, then the result is |e|.
+        If |e| is a signed integral scalar type and evaluates to the largest negative
+        value, then the result is |e|.
+        If |e| is an unsigned integral type, then the result is |e|.
 
-  <tr algorithm="scalar case, unsigned abs">
-    <td>|T| is [UNSIGNEDINTEGRAL]
-    <td class="nowrap">`abs`(|e|: |T| ) -> |T|
-    <td>Result is |e|.  This is provided for symmetry with `abs` for signed integers.
-    [=Component-wise=] when |T| is a vector.
-
-  <tr algorithm="unsigned clamp">
-    <td>|T| is [UNSIGNEDINTEGRAL]
-    <td class="nowrap">`clamp(`|e|`:` |T| `,` |low|`:` |T|`,` |high|`:` |T|`) ->` |T|
-    <td>Returns `min(max(`|e|`,`|low|`),`|high|`)`.
-    [=Component-wise=] when |T| is a vector.
-
-  <tr algorithm="signed clamp">
-    <td>|T| is [SIGNEDINTEGRAL]
-    <td class="nowrap">`clamp(`|e|`:` |T| `,` |low|`:` |T|`,` |high|`:` |T|`) ->` |T|
+  <tr algorithm="integral clamp">
+    <td>[ALLINTEGRALDECL]
+    <td class="nowrap">`@const fn`<br>`clamp(`|e|`:` |T| `,` |low|`:` |T|`,` |high|`:` |T|`) ->` |T|
     <td>Returns `min(max(`|e|`,`|low|`),`|high|`)`.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="count leading zeroes">
     <td>|T| is [INTEGRAL]
-    <td class="nowrap">`countLeadingZeros(`|e|`:` |T| `) ->` |T|
+    <td class="nowrap">`@const fn`<br>`countLeadingZeros(`|e|`:` |T| `) ->` |T|
     <td>The number of consecutive 0 bits starting from the most significant bit
         of |e|, when |T| is a scalar type.<br>
         [=Component-wise=] when |T| is a vector.<br>
@@ -10649,14 +10752,14 @@ struct __modf_result_vecN_f16 {
 
   <tr algorithm="count 1 bits">
     <td>|T| is [INTEGRAL]
-    <td class="nowrap">`countOneBits(`|e|`:` |T| `) ->` |T|
+    <td class="nowrap">`@const fn`<br>`countOneBits(`|e|`:` |T| `) ->` |T|
     <td>The number of 1 bits in the representation of |e|.<br>
         Also known as "population count".<br>
         [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="count trailing zeroes">
     <td>|T| is [INTEGRAL]
-    <td class="nowrap">`countTrailingZeros(`|e|`:` |T| `) ->` |T|
+    <td class="nowrap">`@const fn`<br>`countTrailingZeros(`|e|`:` |T| `) ->` |T|
     <td>The number of consecutive 0 bits starting from the least significant bit
         of |e|, when |T| is a scalar type.<br>
         [=Component-wise=] when |T| is a vector.<br>
@@ -10664,7 +10767,7 @@ struct __modf_result_vecN_f16 {
 
   <tr algorithm="signed find most significant one bit">
     <td>|T| is [SIGNEDINTEGRAL]
-    <td class="nowrap">`firstLeadingBit(`|e|`:` |T| `) ->` |T|
+    <td class="nowrap">`@const fn`<br>`firstLeadingBit(`|e|`:` |T| `) ->` |T|
     <td>For scalar |T|, the result is:
         <ul>
         <li>-1 if |e| is 0 or -1.
@@ -10679,7 +10782,7 @@ struct __modf_result_vecN_f16 {
 
   <tr algorithm="unsigned find most significant one bit">
     <td>|T| is [UNSIGNEDINTEGRAL]
-    <td class="nowrap">`firstLeadingBit(`|e|`:` |T| `) ->` |T|
+    <td class="nowrap">`@const fn`<br>`firstLeadingBit(`|e|`:` |T| `) ->` |T|
     <td>For scalar |T|, the result is:
         <ul>
         <li>|T|(-1) if |e| is zero.
@@ -10690,7 +10793,7 @@ struct __modf_result_vecN_f16 {
 
   <tr algorithm="find least significant one bit">
     <td>|T| is [INTEGRAL]
-    <td class="nowrap">`firstTrailingBit(`|e|`:` |T| `) ->` |T|
+    <td class="nowrap">`@const fn`<br>`firstTrailingBit(`|e|`:` |T| `) ->` |T|
     <td>For scalar |T|, the result is:
         <ul>
         <li>|T|(-1) if |e| is zero.
@@ -10701,7 +10804,7 @@ struct __modf_result_vecN_f16 {
 
   <tr algorithm="signed extract bits">
     <td>|T| is [SIGNEDINTEGRAL]
-    <td class="nowrap">`extractBits(`<br>&nbsp;|e|`:` |T|`,`<br>&nbsp;|offset|`: u32,`<br>&nbsp;|count|` : u32) ->` |T|
+    <td class="nowrap">`@const fn`<br>`extractBits(`<br>&nbsp;|e|`:` |T|`,`<br>&nbsp;|offset|`: u32,`<br>&nbsp;|count|` : u32) ->` |T|
     <td>Reads bits from an integer, with sign extension.
 
     When |T| is a scalar type, then:
@@ -10718,7 +10821,7 @@ struct __modf_result_vecN_f16 {
 
   <tr algorithm="unsigned extract bits">
     <td>|T| is [UNSIGNEDINTEGRAL]
-    <td class="nowrap">`extractBits(`<br>&nbsp;|e|`:` |T|`,`<br>&nbsp;|offset|`: u32,`<br>&nbsp;|count|` : u32) ->` |T|
+    <td class="nowrap">`@const fn`<br>`extractBits(`<br>&nbsp;|e|`:` |T|`,`<br>&nbsp;|offset|`: u32,`<br>&nbsp;|count|` : u32) ->` |T|
     <td>Reads bits from an integer, without sign extension.
 
     When |T| is a scalar type, then:
@@ -10735,7 +10838,7 @@ struct __modf_result_vecN_f16 {
 
   <tr algorithm="insert bits">
     <td>|T| is [INTEGRAL]
-    <td class="nowrap">`insertBits(`<br>&nbsp;|e|`:` |T|`,`<br>&nbsp;|newbits|`:`|T|`,`<br>&nbsp;|offset|`: u32,`<br>&nbsp;|count|` : u32) ->` |T|
+    <td class="nowrap">`@const fn`<br>`insertBits(`<br>&nbsp;|e|`:` |T|`,`<br>&nbsp;|newbits|`:`|T|`,`<br>&nbsp;|offset|`: u32,`<br>&nbsp;|count|` : u32) ->` |T|
     <td>Sets bits in an integer.
 
     When |T| is a scalar type, then:
@@ -10750,67 +10853,59 @@ struct __modf_result_vecN_f16 {
     </ul>
     [=Component-wise=] when |T| is a vector.
 
-  <tr algorithm="unsigned max">
-    <td>|T| is [UNSIGNEDINTEGRAL]
-    <td class="nowrap">`max(`|e1|`:` |T| `, `|e2|`:` |T|`) ->` |T|
+  <tr algorithm="integral max">
+    <td>[ALLINTEGRALDECL]
+    <td class="nowrap">`@const fn`<br>`max(`|e1|`:` |T| `, `|e2|`:` |T|`) ->` |T|
     <td>Returns |e2| if |e1| is less than |e2|, and |e1| otherwise.
     [=Component-wise=] when |T| is a vector.
 
-  <tr algorithm="signed max">
-    <td>|T| is [SIGNEDINTEGRAL]
-    <td class="nowrap">`max(`|e1|`:` |T| `, `|e2|`:` |T|`) ->` |T|
-    <td>Returns |e2| if |e1| is less than |e2|, and |e1| otherwise.
-    [=Component-wise=] when |T| is a vector.
-
-  <tr algorithm="unsigned min">
-    <td>|T| is [UNSIGNEDINTEGRAL]
-    <td class="nowrap">`min(`|e1|`:` |T| `, `|e2|`:` |T|`) ->` |T|
-    <td>Returns |e1| if |e1| is less than |e2|, and |e2| otherwise.
-    [=Component-wise=] when |T| is a vector.
-
-  <tr algorithm="signed min">
-    <td>|T| is [SIGNEDINTEGRAL]
-    <td class="nowrap">`min(`|e1|`:` |T| `, `|e2|`:` |T|`) ->` |T|
+  <tr algorithm="integral min">
+    <td>[ALLINTEGRALDECL]
+    <td class="nowrap">`@const fn`<br>`min(`|e1|`:` |T| `, `|e2|`:` |T|`) ->` |T|
     <td>Returns |e1| if |e1| is less than |e2|, and |e2| otherwise.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="bit reversal">
     <td>|T| is [INTEGRAL]
-    <td class="nowrap">`reverseBits(`|e|`:` |T| `) ->`  |T|
+    <td class="nowrap">`@const fn`<br>`reverseBits(`|e|`:` |T| `) ->`  |T|
     <td>Reverses the bits in |e|:  The bit at position |k| of the result equals the
         bit at position 31-|k| of |e|.<br>
         [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="shift left">
-    <td>|T| is [INTEGRAL]<br>
-    |TS| is u32 if |T| is scalar, or<br>
-    vec|N|&lt;u32&gt; otherwise
-    <td class="nowrap">`shiftLeft(`|e1|`:` |T|`,` |e2|`:` |TS|`) ->` |T|
+    <td>[ALLINTEGRALDECL]<br>
+    |TS| is AbstractInt or u32 if |T| is scalar, or<br>
+    vec|N|&lt;AbstractInt&gt;, or vec|N|&lt;u32&gt; otherwise
+    <td class="nowrap">`@const fn shiftLeft(`|e1|`:` |T|`,` |e2|`:` |TS|`) ->` |T|
     <td>Logical shift left.<br>
     Shift |e1| left, inserting zero bits at the least significant positions,
     and discarding the most significant bits.
-    The number of bits to shift is the value of |e2| modulo the bit width of |e1|.<br>
+
+    The number of bits to shift is the value of |e2|.
+    If |e1| has a [=concrete=] type, the shift value is modulo the bit width of |e1|.<br>
     [=Component-wise=] when |T| is a vector.
 
-  <tr algorithm="logical shift right">
-    <td>|T| is [UNSIGNEDINTEGRAL]
-    <td class="nowrap">`shiftRight(`|e1|`:` |T|`,` |e2|`:` |T|`) ->` |T|
+    If |e2| is an [=AbstractInt=] or vec|N|&lt;AbstractInt&gt;, it is a
+    [=shader-creation error=] if any of the values are less than 0.
+
+  <tr algorithm="shift right">
+    <td>[ALLINTEGRALDECL]>br>
+    |TS| is AbstractInt or u32 if |T| is scalar, or<br>
+    vec|N|&lt;AbstractInt&gt;, or vec|N|&lt;u32&gt; otherwise
+    <td class="nowrap">`@const fn shiftRight(`|e1|`:` |T|`,` |e2|`:` |TS|`) ->` |T|
     <td>Logical shift right.<br>
-    Shift |e1| right, inserting zero bits at the most significant positions,
-    and discarding the least significant bits.
-    The number of bits to shift is the value of |e2| modulo the bit width of |e1|.
+    If |e1| is signed, shift |e1| right, inserting zero bits at the most
+    significant positions, and discarding the least significant bits.
+    If |e1| is unsigned, shift |e1| right, copying the sign bit of |e1| into
+    the most significant positions, and discarding the least significant bits.
+
+    The number of bits to shift is the value of |e2|.
+    If |e1| has a [=concrete=] type, the shift value is modulo the bit width of |e1|.<br>
     [=Component-wise=] when |T| is a vector.
 
-  <tr algorithm="arithmetic shift right">
-    <td>|T| is [SIGNEDINTEGRAL]<br>
-    |TS| is u32 if |T| is scalar, or<br>
-    vec|N|&lt;u32&gt; otherwise
-    <td class="nowrap">`shiftRight(`|e1|`:` |T|`,` |e2|`:` |TS|`) ->` |T|
-    <td>Arithmetic shift right.<br>
-    Shift |e1| right, copying the sign bit of |e1| into the most significant positions,
-    and discarding the least significant bits.
-    The number of bits to shift is the value of |e2| modulo the bit width of |e1|.
-    [=Component-wise=] when |T| is a vector.
+    If |e2| is an [=AbstractInt=] or vec|N|&lt;AbstractInt&gt;, it is a
+    [=shader-creation error=] if any of the values are less than 0.
+
 </table>
 
 ## Matrix Built-in Functions ## {#matrix-builtin-functions}
@@ -10819,11 +10914,11 @@ struct __modf_result_vecN_f16 {
     <tr><th>Parameterization<th>Overload<th>Description
   </thead>
   <tr algorithm="determinant">
-    <td>|T| is f32 or f16
+    <td>|T| is AbstractFloat, f32, or f16
     <td class="nowrap">`determinant(`|e|`:` mat|C|x|C|<|T|> `) -> ` |T|
     <td>Returns the determinant of |e|.
   <tr algorithm="transpose">
-    <td>|T| is f32 or f16
+    <td>|T| is AbstractFloat, f32, or f16
     <td class="nowrap">`transpose(`|e|`:` mat|R|x|C|<|T|> `) -> ` mat|C|x|R|<|T|>
     <td>Returns the transpose of |e|.
 </table>
@@ -10834,14 +10929,8 @@ struct __modf_result_vecN_f16 {
   <thead>
     <tr><th>Parameterization<td>Overload<td>Description
   </thead>
-  <tr algorithm="float dot"><td>|T| is f32 or f16
-    <td>`dot(`|e1|`: vecN<`|T|`>, `|e2|`: vecN<`|T|`>) ->` |T|
-    <td>Returns the dot product of |e1| and |e2|.
-  <tr algorithm="signed dot"><td>|T| is i32
-    <td>`dot(`|e1|`: vecN<`|T|`>, `|e2|`: vecN<`|T|`>) ->` |T|
-    <td>Returns the dot product of |e1| and |e2|.
-  <tr algorithm="unsigned dot"><td>|T| is u32
-    <td>`dot(`|e1|`: vecN<`|T|`>, `|e2|`: vecN<`|T|`>) ->` |T|
+  <tr algorithm="dot"><td>|T| is AbstractInt, AbstractFloat, i32, u32, f32, or f16
+    <td class="nowrap">`@const fn`<br>`dot(`|e1|`: vecN<`|T|`>, `|e2|`: vecN<`|T|`>) ->` |T|
     <td>Returns the dot product of |e1| and |e2|.
 </table>
 
@@ -10859,35 +10948,35 @@ These functions:
   </thead>
   <tr algorithm="dpdx">
   <td rowspan=9>|T| is f32 or vecN&lt;f32&gt;
-    <td>`dpdx(`|e|`: `|T|`) ->` |T|
+    <td class="nowrap">`fn dpdx(`|e|`: `|T|`) ->` |T|
     <td>Partial derivative of |e| with respect to window x coordinates.
     The result is the same as either `dpdxFine(`|e|`)` or `dpdxCoarse(`|e|`)`.
   <tr algorithm="dpdxCoarse">
-    <td>`dpdxCoarse(`|e|`: `|T|`) -> `|T|
+    <td class="nowrap">`fn dpdxCoarse(`|e|`: `|T|`) -> `|T|
     <td>Returns the partial derivative of |e| with respect to window x coordinates using local differences.
     This may result in fewer unique positions that `dpdxFine(`|e|`)`.
   <tr algorithm="dpdxFine">
-    <td>`dpdxFine(`|e|`: `|T|`) -> `|T|
+    <td class="nowrap">`fn dpdxFine(`|e|`: `|T|`) -> `|T|
     <td>Returns the partial derivative of |e| with respect to window x coordinates.
   <tr algorithm="dpdy">
-    <td>`dpdy(`|e|`: `|T|`) -> `|T|
+    <td class="nowrap">`fn dpdy(`|e|`: `|T|`) -> `|T|
     <td>Partial derivative of |e| with respect to window y coordinates.
     The result is the same as either `dpdyFine(`|e|`)` or `dpdyCoarse(`|e|`)`.
   <tr algorithm="dpdyCoarse">
-    <td>`dpdyCoarse(`|e|`: `|T|`) -> `|T|
+    <td class="nowrap">`fn dpdyCoarse(`|e|`: `|T|`) -> `|T|
     <td>Returns the partial derivative of |e| with respect to window y coordinates using local differences.
     This may result in fewer unique positions that `dpdyFine(`|e|`)`.
   <tr algorithm="dpdyFine">
-    <td>`dpdyFine(`|e|`: `|T|`) -> `|T|
+    <td class="nowrap">`fn dpdyFine(`|e|`: `|T|`) -> `|T|
     <td>Returns the partial derivative of |e| with respect to window y coordinates.
   <tr algorithm="fwidth">
-    <td>`fwidth(`|e|`: `|T|`) -> `|T|
+    <td class="nowrap">`fn fwidth(`|e|`: `|T|`) -> `|T|
     <td>Returns `abs(dpdx(`|e|`)) + abs(dpdy(`|e|`))`.
   <tr algorithm="fwidthCoarse">
-    <td>`fwidthCoarse(`|e|`: `|T|`) -> `|T|
+    <td class="nowrap">`fn fwidthCoarse(`|e|`: `|T|`) -> `|T|
     <td>Returns `abs(dpdxCoarse(`|e|`)) + abs(dpdyCoarse(`|e|`))`.
   <tr algorithm="fwidthFine">
-    <td>`fwidthFine(`|e|`: `|T|`) -> `|T|
+    <td class="nowrap">`fn fwidthFine(`|e|`: `|T|`) -> `|T|
     <td>Returns `abs(dpdxFine(`|e|`)) + abs(dpdyFine(`|e|`))`.
 </table>
 
@@ -10905,33 +10994,33 @@ Parameter values must be valid for the respective texture types.
 Returns the dimensions of a texture, or texture's mip level in texels.
 
 ```rust
-textureDimensions(t: texture_1d<T>) -> i32
-textureDimensions(t: texture_1d<T>, level: i32) -> i32
-textureDimensions(t: texture_2d<T>) -> vec2<i32>
-textureDimensions(t: texture_2d<T>, level: i32) -> vec2<i32>
-textureDimensions(t: texture_2d_array<T>) -> vec2<i32>
-textureDimensions(t: texture_2d_array<T>, level: i32) -> vec2<i32>
-textureDimensions(t: texture_3d<T>) -> vec3<i32>
-textureDimensions(t: texture_3d<T>, level: i32) -> vec3<i32>
-textureDimensions(t: texture_cube<T>) -> vec2<i32>
-textureDimensions(t: texture_cube<T>, level: i32) -> vec2<i32>
-textureDimensions(t: texture_cube_array<T>) -> vec2<i32>
-textureDimensions(t: texture_cube_array<T>, level: i32) -> vec2<i32>
-textureDimensions(t: texture_multisampled_2d<T>)-> vec2<i32>
-textureDimensions(t: texture_depth_2d) -> vec2<i32>
-textureDimensions(t: texture_depth_2d, level: i32) -> vec2<i32>
-textureDimensions(t: texture_depth_2d_array) -> vec2<i32>
-textureDimensions(t: texture_depth_2d_array, level: i32) -> vec2<i32>
-textureDimensions(t: texture_depth_cube) -> vec2<i32>
-textureDimensions(t: texture_depth_cube, level: i32) -> vec2<i32>
-textureDimensions(t: texture_depth_cube_array) -> vec2<i32>
-textureDimensions(t: texture_depth_cube_array, level: i32) -> vec2<i32>
-textureDimensions(t: texture_depth_multisampled_2d)-> vec2<i32>
-textureDimensions(t: texture_storage_1d<F,A>) -> i32
-textureDimensions(t: texture_storage_2d<F,A>) -> vec2<i32>
-textureDimensions(t: texture_storage_2d_array<F,A>) -> vec2<i32>
-textureDimensions(t: texture_storage_3d<F,A>) -> vec3<i32>
-textureDimensions(t: texture_external) -> vec2<i32>
+fn textureDimensions(t: texture_1d<T>) -> i32
+fn textureDimensions(t: texture_1d<T>, level: i32) -> i32
+fn textureDimensions(t: texture_2d<T>) -> vec2<i32>
+fn textureDimensions(t: texture_2d<T>, level: i32) -> vec2<i32>
+fn textureDimensions(t: texture_2d_array<T>) -> vec2<i32>
+fn textureDimensions(t: texture_2d_array<T>, level: i32) -> vec2<i32>
+fn textureDimensions(t: texture_3d<T>) -> vec3<i32>
+fn textureDimensions(t: texture_3d<T>, level: i32) -> vec3<i32>
+fn textureDimensions(t: texture_cube<T>) -> vec2<i32>
+fn textureDimensions(t: texture_cube<T>, level: i32) -> vec2<i32>
+fn textureDimensions(t: texture_cube_array<T>) -> vec2<i32>
+fn textureDimensions(t: texture_cube_array<T>, level: i32) -> vec2<i32>
+fn textureDimensions(t: texture_multisampled_2d<T>)-> vec2<i32>
+fn textureDimensions(t: texture_depth_2d) -> vec2<i32>
+fn textureDimensions(t: texture_depth_2d, level: i32) -> vec2<i32>
+fn textureDimensions(t: texture_depth_2d_array) -> vec2<i32>
+fn textureDimensions(t: texture_depth_2d_array, level: i32) -> vec2<i32>
+fn textureDimensions(t: texture_depth_cube) -> vec2<i32>
+fn textureDimensions(t: texture_depth_cube, level: i32) -> vec2<i32>
+fn textureDimensions(t: texture_depth_cube_array) -> vec2<i32>
+fn textureDimensions(t: texture_depth_cube_array, level: i32) -> vec2<i32>
+fn textureDimensions(t: texture_depth_multisampled_2d)-> vec2<i32>
+fn textureDimensions(t: texture_storage_1d<F,A>) -> i32
+fn textureDimensions(t: texture_storage_2d<F,A>) -> vec2<i32>
+fn textureDimensions(t: texture_storage_2d_array<F,A>) -> vec2<i32>
+fn textureDimensions(t: texture_storage_3d<F,A>) -> vec3<i32>
+fn textureDimensions(t: texture_external) -> vec2<i32>
 ```
 
 **Parameters:**
@@ -10988,18 +11077,18 @@ TODO: The four texels are the "sample footprint" that should be described by the
 https://github.com/gpuweb/gpuweb/issues/2343
 
 ```rust
-textureGather(component: i32, t: texture_2d<T>, s: sampler, coords: vec2<f32>) -> vec4<T>
-textureGather(component: i32, t: texture_2d<T>, s: sampler, coords: vec2<f32>, offset: vec2<i32>) -> vec4<T>
-textureGather(component: i32, t: texture_2d_array<T>, s: sampler, coords: vec2<f32>, array_index: i32) -> vec4<T>
-textureGather(component: i32, t: texture_2d_array<T>, s: sampler, coords: vec2<f32>, array_index: i32, offset: vec2<i32>) -> vec4<T>
-textureGather(component: i32, t: texture_cube<T>, s: sampler, coords: vec3<f32>) -> vec4<T>
-textureGather(component: i32, t: texture_cube_array<T>, s: sampler, coords: vec3<f32>, array_index: i32) -> vec4<T>
-textureGather(t: texture_depth_2d, s: sampler, coords: vec2<f32>) -> vec4<f32>
-textureGather(t: texture_depth_2d, s: sampler, coords: vec2<f32>, offset: vec2<i32>) -> vec4<f32>
-textureGather(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: i32) -> vec4<f32>
-textureGather(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: i32, offset: vec2<i32>) -> vec4<f32>
-textureGather(t: texture_depth_cube, s: sampler, coords: vec3<f32>) -> vec4<f32>
-textureGather(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, array_index: i32) -> vec4<f32>
+fn textureGather(component: i32, t: texture_2d<T>, s: sampler, coords: vec2<f32>) -> vec4<T>
+fn textureGather(component: i32, t: texture_2d<T>, s: sampler, coords: vec2<f32>, offset: vec2<i32>) -> vec4<T>
+fn textureGather(component: i32, t: texture_2d_array<T>, s: sampler, coords: vec2<f32>, array_index: i32) -> vec4<T>
+fn textureGather(component: i32, t: texture_2d_array<T>, s: sampler, coords: vec2<f32>, array_index: i32, offset: vec2<i32>) -> vec4<T>
+fn textureGather(component: i32, t: texture_cube<T>, s: sampler, coords: vec3<f32>) -> vec4<T>
+fn textureGather(component: i32, t: texture_cube_array<T>, s: sampler, coords: vec3<f32>, array_index: i32) -> vec4<T>
+fn textureGather(t: texture_depth_2d, s: sampler, coords: vec2<f32>) -> vec4<f32>
+fn textureGather(t: texture_depth_2d, s: sampler, coords: vec2<f32>, offset: vec2<i32>) -> vec4<f32>
+fn textureGather(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: i32) -> vec4<f32>
+fn textureGather(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: i32, offset: vec2<i32>) -> vec4<f32>
+fn textureGather(t: texture_depth_cube, s: sampler, coords: vec3<f32>) -> vec4<f32>
+fn textureGather(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, array_index: i32) -> vec4<f32>
 ```
 
 **Parameters:**
@@ -11008,9 +11097,7 @@ textureGather(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, array_
   <tr><td>`component`<td>
   Only applies to non-depth textures.
   <br>The index of the channel to read from the selected texels.
-  <br>When provided, the `component` expression must be either:
-    * a `const_expression` expression (e.g. `1`).<br>
-    * a name of a [=module scope|module-scope=] [=let declaration=]
+  <br>When provided, the `component` expression must a [=creation-time expression=] (e.g. `1`).<br>
   Its value must be at least 0 and at most 3.
   Values outside of this range will result in a [=shader-creation error=].
   <tr><td>`t`<td>
@@ -11025,9 +11112,7 @@ textureGather(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, array_
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  The `offset` expression must be either:
-    * a `const_expression` expression (e.g. `vec2<i32>(1, 2)`).<br>
-    * a name of a [=module scope|module-scope=] [=let declaration=]
+  The `offset` expression must be a [=creation-time expression=] (e.g. `vec2<i32>(1, 2)`).<br>
   Each `offset` component must be at least `-8` and at most `7`. Values outside
   of this range will result in a [=shader-creation error=].
 </table>
@@ -11081,12 +11166,12 @@ texture and collects the results into a single vector, as follows:
         </table>
 
 ```rust
-textureGatherCompare(t: texture_depth_2d, s: sampler_comparison, coords: vec2<f32>, depth_ref: f32) -> vec4<f32>
-textureGatherCompare(t: texture_depth_2d, s: sampler_comparison, coords: vec2<f32>, depth_ref: f32, offset: vec2<i32>) -> vec4<f32>
-textureGatherCompare(t: texture_depth_2d_array, s: sampler_comparison, coords: vec2<f32>, array_index: i32, depth_ref: f32) -> vec4<f32>
-textureGatherCompare(t: texture_depth_2d_array, s: sampler_comparison, coords: vec2<f32>, array_index: i32, depth_ref: f32, offset: vec2<i32>) -> vec4<f32>
-textureGatherCompare(t: texture_depth_cube, s: sampler_comparison, coords: vec3<f32>, depth_ref: f32) -> vec4<f32>
-textureGatherCompare(t: texture_depth_cube_array, s: sampler_comparison, coords: vec3<f32>, array_index: i32, depth_ref: f32) -> vec4<f32>
+fn textureGatherCompare(t: texture_depth_2d, s: sampler_comparison, coords: vec2<f32>, depth_ref: f32) -> vec4<f32>
+fn textureGatherCompare(t: texture_depth_2d, s: sampler_comparison, coords: vec2<f32>, depth_ref: f32, offset: vec2<i32>) -> vec4<f32>
+fn textureGatherCompare(t: texture_depth_2d_array, s: sampler_comparison, coords: vec2<f32>, array_index: i32, depth_ref: f32) -> vec4<f32>
+fn textureGatherCompare(t: texture_depth_2d_array, s: sampler_comparison, coords: vec2<f32>, array_index: i32, depth_ref: f32, offset: vec2<i32>) -> vec4<f32>
+fn textureGatherCompare(t: texture_depth_cube, s: sampler_comparison, coords: vec3<f32>, depth_ref: f32) -> vec4<f32>
+fn textureGatherCompare(t: texture_depth_cube_array, s: sampler_comparison, coords: vec3<f32>, array_index: i32, depth_ref: f32) -> vec4<f32>
 ```
 **Parameters:**
 
@@ -11105,9 +11190,7 @@ textureGatherCompare(t: texture_depth_cube_array, s: sampler_comparison, coords:
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  The `offset` expression must be either:
-    * a `const_expression` expression (e.g. `vec2<i32>(1, 2)`).<br>
-    * a name of a [=module scope|module-scope=] [=let declaration=]
+  The `offset` expression must be a [=creation-time expression=] (e.g. `vec2<i32>(1, 2)`).<br>
   Each `offset` component must be at least `-8` and at most `7`. Values outside
   of this range will result in a [=shader-creation error=].
 </table>
@@ -11132,15 +11215,15 @@ A four component vector with comparison result for the selected texels, as descr
 Reads a single texel from a texture without sampling or filtering.
 
 ```rust
-textureLoad(t: texture_1d<T>, coords: i32, level: i32) -> vec4<T>
-textureLoad(t: texture_2d<T>, coords: vec2<i32>, level: i32) -> vec4<T>
-textureLoad(t: texture_2d_array<T>, coords: vec2<i32>, array_index: i32, level: i32) -> vec4<T>
-textureLoad(t: texture_3d<T>, coords: vec3<i32>, level: i32) -> vec4<T>
-textureLoad(t: texture_multisampled_2d<T>, coords: vec2<i32>, sample_index: i32)-> vec4<T>
-textureLoad(t: texture_depth_2d, coords: vec2<i32>, level: i32) -> f32
-textureLoad(t: texture_depth_2d_array, coords: vec2<i32>, array_index: i32, level: i32) -> f32
-textureLoad(t: texture_depth_multisampled_2d, coords: vec2<i32>, sample_index: i32)-> f32
-textureLoad(t: texture_external, coords: vec2<i32>) -> vec4<f32>
+fn textureLoad(t: texture_1d<T>, coords: i32, level: i32) -> vec4<T>
+fn textureLoad(t: texture_2d<T>, coords: vec2<i32>, level: i32) -> vec4<T>
+fn textureLoad(t: texture_2d_array<T>, coords: vec2<i32>, array_index: i32, level: i32) -> vec4<T>
+fn textureLoad(t: texture_3d<T>, coords: vec3<i32>, level: i32) -> vec4<T>
+fn textureLoad(t: texture_multisampled_2d<T>, coords: vec2<i32>, sample_index: i32)-> vec4<T>
+fn textureLoad(t: texture_depth_2d, coords: vec2<i32>, level: i32) -> f32
+fn textureLoad(t: texture_depth_2d_array, coords: vec2<i32>, array_index: i32, level: i32) -> f32
+fn textureLoad(t: texture_depth_multisampled_2d, coords: vec2<i32>, sample_index: i32)-> f32
+fn textureLoad(t: texture_external, coords: vec2<i32>) -> vec4<f32>
 ```
 
 **Parameters:**
@@ -11180,11 +11263,11 @@ If an out of bounds access occurs, the built-in function returns one of:
 Returns the number of layers (elements) of an array texture.
 
 ```rust
-textureNumLayers(t: texture_2d_array<T>) -> i32
-textureNumLayers(t: texture_cube_array<T>) -> i32
-textureNumLayers(t: texture_depth_2d_array) -> i32
-textureNumLayers(t: texture_depth_cube_array) -> i32
-textureNumLayers(t: texture_storage_2d_array<F,A>) -> i32
+fn textureNumLayers(t: texture_2d_array<T>) -> i32
+fn textureNumLayers(t: texture_cube_array<T>) -> i32
+fn textureNumLayers(t: texture_depth_2d_array) -> i32
+fn textureNumLayers(t: texture_depth_cube_array) -> i32
+fn textureNumLayers(t: texture_storage_2d_array<F,A>) -> i32
 ```
 
 **Parameters:**
@@ -11206,16 +11289,16 @@ If the number of layers (elements) of the array texture.
 Returns the number of mip levels of a texture.
 
 ```rust
-textureNumLevels(t: texture_1d<T>) -> i32
-textureNumLevels(t: texture_2d<T>) -> i32
-textureNumLevels(t: texture_2d_array<T>) -> i32
-textureNumLevels(t: texture_3d<T>) -> i32
-textureNumLevels(t: texture_cube<T>) -> i32
-textureNumLevels(t: texture_cube_array<T>) -> i32
-textureNumLevels(t: texture_depth_2d) -> i32
-textureNumLevels(t: texture_depth_2d_array) -> i32
-textureNumLevels(t: texture_depth_cube) -> i32
-textureNumLevels(t: texture_depth_cube_array) -> i32
+fn textureNumLevels(t: texture_1d<T>) -> i32
+fn textureNumLevels(t: texture_2d<T>) -> i32
+fn textureNumLevels(t: texture_2d_array<T>) -> i32
+fn textureNumLevels(t: texture_3d<T>) -> i32
+fn textureNumLevels(t: texture_cube<T>) -> i32
+fn textureNumLevels(t: texture_cube_array<T>) -> i32
+fn textureNumLevels(t: texture_depth_2d) -> i32
+fn textureNumLevels(t: texture_depth_2d_array) -> i32
+fn textureNumLevels(t: texture_depth_cube) -> i32
+fn textureNumLevels(t: texture_depth_cube_array) -> i32
 ```
 
 **Parameters:**
@@ -11259,21 +11342,21 @@ Must only be used in a [=fragment=] shader stage.
 Must only be invoked in [=uniform control flow=].
 
 ```rust
-textureSample(t: texture_1d<f32>, s: sampler, coords: f32) -> vec4<f32>
-textureSample(t: texture_2d<f32>, s: sampler, coords: vec2<f32>) -> vec4<f32>
-textureSample(t: texture_2d<f32>, s: sampler, coords: vec2<f32>, offset: vec2<i32>) -> vec4<f32>
-textureSample(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: i32) -> vec4<f32>
-textureSample(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: i32, offset: vec2<i32>) -> vec4<f32>
-textureSample(t: texture_3d<f32>, s: sampler, coords: vec3<f32>) -> vec4<f32>
-textureSample(t: texture_3d<f32>, s: sampler, coords: vec3<f32>, offset: vec3<i32>) -> vec4<f32>
-textureSample(t: texture_cube<f32>, s: sampler, coords: vec3<f32>) -> vec4<f32>
-textureSample(t: texture_cube_array<f32>, s: sampler, coords: vec3<f32>, array_index: i32) -> vec4<f32>
-textureSample(t: texture_depth_2d, s: sampler, coords: vec2<f32>) -> f32
-textureSample(t: texture_depth_2d, s: sampler, coords: vec2<f32>, offset: vec2<i32>) -> f32
-textureSample(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: i32) -> f32
-textureSample(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: i32, offset: vec2<i32>) -> f32
-textureSample(t: texture_depth_cube, s: sampler, coords: vec3<f32>) -> f32
-textureSample(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, array_index: i32) -> f32
+fn textureSample(t: texture_1d<f32>, s: sampler, coords: f32) -> vec4<f32>
+fn textureSample(t: texture_2d<f32>, s: sampler, coords: vec2<f32>) -> vec4<f32>
+fn textureSample(t: texture_2d<f32>, s: sampler, coords: vec2<f32>, offset: vec2<i32>) -> vec4<f32>
+fn textureSample(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: i32) -> vec4<f32>
+fn textureSample(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: i32, offset: vec2<i32>) -> vec4<f32>
+fn textureSample(t: texture_3d<f32>, s: sampler, coords: vec3<f32>) -> vec4<f32>
+fn textureSample(t: texture_3d<f32>, s: sampler, coords: vec3<f32>, offset: vec3<i32>) -> vec4<f32>
+fn textureSample(t: texture_cube<f32>, s: sampler, coords: vec3<f32>) -> vec4<f32>
+fn textureSample(t: texture_cube_array<f32>, s: sampler, coords: vec3<f32>, array_index: i32) -> vec4<f32>
+fn textureSample(t: texture_depth_2d, s: sampler, coords: vec2<f32>) -> f32
+fn textureSample(t: texture_depth_2d, s: sampler, coords: vec2<f32>, offset: vec2<i32>) -> f32
+fn textureSample(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: i32) -> f32
+fn textureSample(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: i32, offset: vec2<i32>) -> f32
+fn textureSample(t: texture_depth_cube, s: sampler, coords: vec3<f32>) -> f32
+fn textureSample(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, array_index: i32) -> f32
 ```
 
 **Parameters:**
@@ -11293,9 +11376,7 @@ textureSample(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, array_
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  The `offset` expression must be either:
-    * a `const_expression` expression (e.g. `vec2<i32>(1, 2)`).<br>
-    * a name of a [=module scope|module-scope=] [=let declaration=]
+  The `offset` expression must be a [=creation-time expression=] (e.g. `vec2<i32>(1, 2)`).<br>
   Each `offset` component must be at least `-8` and at most `7`. Values outside
   of this range will result in a [=shader-creation error=].
 </table>
@@ -11312,14 +11393,14 @@ Must only be used in a [=fragment=] shader stage.
 Must only be invoked in [=uniform control flow=].
 
 ```rust
-textureSampleBias(t: texture_2d<f32>, s: sampler, coords: vec2<f32>, bias: f32) -> vec4<f32>
-textureSampleBias(t: texture_2d<f32>, s: sampler, coords: vec2<f32>, bias: f32, offset: vec2<i32>) -> vec4<f32>
-textureSampleBias(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: i32, bias: f32) -> vec4<f32>
-textureSampleBias(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: i32, bias: f32, offset: vec2<i32>) -> vec4<f32>
-textureSampleBias(t: texture_3d<f32>, s: sampler, coords: vec3<f32>, bias: f32) -> vec4<f32>
-textureSampleBias(t: texture_3d<f32>, s: sampler, coords: vec3<f32>, bias: f32, offset: vec3<i32>) -> vec4<f32>
-textureSampleBias(t: texture_cube<f32>, s: sampler, coords: vec3<f32>, bias: f32) -> vec4<f32>
-textureSampleBias(t: texture_cube_array<f32>, s: sampler, coords: vec3<f32>, array_index: i32, bias: f32) -> vec4<f32>
+fn textureSampleBias(t: texture_2d<f32>, s: sampler, coords: vec2<f32>, bias: f32) -> vec4<f32>
+fn textureSampleBias(t: texture_2d<f32>, s: sampler, coords: vec2<f32>, bias: f32, offset: vec2<i32>) -> vec4<f32>
+fn textureSampleBias(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: i32, bias: f32) -> vec4<f32>
+fn textureSampleBias(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: i32, bias: f32, offset: vec2<i32>) -> vec4<f32>
+fn textureSampleBias(t: texture_3d<f32>, s: sampler, coords: vec3<f32>, bias: f32) -> vec4<f32>
+fn textureSampleBias(t: texture_3d<f32>, s: sampler, coords: vec3<f32>, bias: f32, offset: vec3<i32>) -> vec4<f32>
+fn textureSampleBias(t: texture_cube<f32>, s: sampler, coords: vec3<f32>, bias: f32) -> vec4<f32>
+fn textureSampleBias(t: texture_cube_array<f32>, s: sampler, coords: vec3<f32>, array_index: i32, bias: f32) -> vec4<f32>
 ```
 
 **Parameters:**
@@ -11340,9 +11421,7 @@ textureSampleBias(t: texture_cube_array<f32>, s: sampler, coords: vec3<f32>, arr
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  The `offset` expression must be either:
-    * a `const_expression` expression (e.g. `vec2<i32>(1, 2)`).<br>
-    * a name of a [=module scope|module-scope=] [=let declaration=]
+  The `offset` expression must be a [=creation-time expression=] (e.g. `vec2<i32>(1, 2)`).<br>
   Each `offset` component must be at least `-8` and at most `7`. Values outside
   of this range will result in a [=shader-creation error=].
 </table>
@@ -11360,12 +11439,12 @@ Must only be used in a [=fragment=] shader stage.
 Must only be invoked in [=uniform control flow=].
 
 ```rust
-textureSampleCompare(t: texture_depth_2d, s: sampler_comparison, coords: vec2<f32>, depth_ref: f32) -> f32
-textureSampleCompare(t: texture_depth_2d, s: sampler_comparison, coords: vec2<f32>, depth_ref: f32, offset: vec2<i32>) -> f32
-textureSampleCompare(t: texture_depth_2d_array, s: sampler_comparison, coords: vec2<f32>, array_index: i32, depth_ref: f32) -> f32
-textureSampleCompare(t: texture_depth_2d_array, s: sampler_comparison, coords: vec2<f32>, array_index: i32, depth_ref: f32, offset: vec2<i32>) -> f32
-textureSampleCompare(t: texture_depth_cube, s: sampler_comparison, coords: vec3<f32>, depth_ref: f32) -> f32
-textureSampleCompare(t: texture_depth_cube_array, s: sampler_comparison, coords: vec3<f32>, array_index: i32, depth_ref: f32) -> f32
+fn textureSampleCompare(t: texture_depth_2d, s: sampler_comparison, coords: vec2<f32>, depth_ref: f32) -> f32
+fn textureSampleCompare(t: texture_depth_2d, s: sampler_comparison, coords: vec2<f32>, depth_ref: f32, offset: vec2<i32>) -> f32
+fn textureSampleCompare(t: texture_depth_2d_array, s: sampler_comparison, coords: vec2<f32>, array_index: i32, depth_ref: f32) -> f32
+fn textureSampleCompare(t: texture_depth_2d_array, s: sampler_comparison, coords: vec2<f32>, array_index: i32, depth_ref: f32, offset: vec2<i32>) -> f32
+fn textureSampleCompare(t: texture_depth_cube, s: sampler_comparison, coords: vec3<f32>, depth_ref: f32) -> f32
+fn textureSampleCompare(t: texture_depth_cube_array, s: sampler_comparison, coords: vec3<f32>, array_index: i32, depth_ref: f32) -> f32
 ```
 
 **Parameters:**
@@ -11385,9 +11464,7 @@ textureSampleCompare(t: texture_depth_cube_array, s: sampler_comparison, coords:
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  The `offset` expression must be either:
-    * a `const_expression` expression (e.g. `vec2<i32>(1, 2)`).<br>
-    * a name of a [=module scope|module-scope=] [=let declaration=]
+  The `offset` expression must be a [=creation-time expression=] (e.g. `vec2<i32>(1, 2)`).<br>
   Each `offset` component must be at least `-8` and at most `7`. Values outside
   of this range will result in a [=shader-creation error=].
 </table>
@@ -11410,12 +11487,12 @@ single texel is returned.
 Samples a depth texture and compares the sampled depth values against a reference value.
 
 ```rust
-textureSampleCompareLevel(t: texture_depth_2d, s: sampler_comparison, coords: vec2<f32>, depth_ref: f32) -> f32
-textureSampleCompareLevel(t: texture_depth_2d, s: sampler_comparison, coords: vec2<f32>, depth_ref: f32, offset: vec2<i32>) -> f32
-textureSampleCompareLevel(t: texture_depth_2d_array, s: sampler_comparison, coords: vec2<f32>, array_index: i32, depth_ref: f32) -> f32
-textureSampleCompareLevel(t: texture_depth_2d_array, s: sampler_comparison, coords: vec2<f32>, array_index: i32, depth_ref: f32, offset: vec2<i32>) -> f32
-textureSampleCompareLevel(t: texture_depth_cube, s: sampler_comparison, coords: vec3<f32>, depth_ref: f32) -> f32
-textureSampleCompareLevel(t: texture_depth_cube_array, s: sampler_comparison, coords: vec3<f32>, array_index: i32, depth_ref: f32) -> f32
+fn textureSampleCompareLevel(t: texture_depth_2d, s: sampler_comparison, coords: vec2<f32>, depth_ref: f32) -> f32
+fn textureSampleCompareLevel(t: texture_depth_2d, s: sampler_comparison, coords: vec2<f32>, depth_ref: f32, offset: vec2<i32>) -> f32
+fn textureSampleCompareLevel(t: texture_depth_2d_array, s: sampler_comparison, coords: vec2<f32>, array_index: i32, depth_ref: f32) -> f32
+fn textureSampleCompareLevel(t: texture_depth_2d_array, s: sampler_comparison, coords: vec2<f32>, array_index: i32, depth_ref: f32, offset: vec2<i32>) -> f32
+fn textureSampleCompareLevel(t: texture_depth_cube, s: sampler_comparison, coords: vec3<f32>, depth_ref: f32) -> f32
+fn textureSampleCompareLevel(t: texture_depth_cube_array, s: sampler_comparison, coords: vec3<f32>, array_index: i32, depth_ref: f32) -> f32
 ```
 
 The `textureSampleCompareLevel` function is the same as `textureSampleCompare`, except that:
@@ -11430,14 +11507,14 @@ The `textureSampleCompareLevel` function is the same as `textureSampleCompare`, 
 Samples a texture using explicit gradients.
 
 ```rust
-textureSampleGrad(t: texture_2d<f32>, s: sampler, coords: vec2<f32>, ddx: vec2<f32>, ddy: vec2<f32>) -> vec4<f32>
-textureSampleGrad(t: texture_2d<f32>, s: sampler, coords: vec2<f32>, ddx: vec2<f32>, ddy: vec2<f32>, offset: vec2<i32>) -> vec4<f32>
-textureSampleGrad(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: i32, ddx: vec2<f32>, ddy: vec2<f32>) -> vec4<f32>
-textureSampleGrad(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: i32, ddx: vec2<f32>, ddy: vec2<f32>, offset: vec2<i32>) -> vec4<f32>
-textureSampleGrad(t: texture_3d<f32>, s: sampler, coords: vec3<f32>, ddx: vec3<f32>, ddy: vec3<f32>) -> vec4<f32>
-textureSampleGrad(t: texture_3d<f32>, s: sampler, coords: vec3<f32>, ddx: vec3<f32>, ddy: vec3<f32>, offset: vec3<i32>) -> vec4<f32>
-textureSampleGrad(t: texture_cube<f32>, s: sampler, coords: vec3<f32>, ddx: vec3<f32>, ddy: vec3<f32>) -> vec4<f32>
-textureSampleGrad(t: texture_cube_array<f32>, s: sampler, coords: vec3<f32>, array_index: i32, ddx: vec3<f32>, ddy: vec3<f32>) -> vec4<f32>
+fn textureSampleGrad(t: texture_2d<f32>, s: sampler, coords: vec2<f32>, ddx: vec2<f32>, ddy: vec2<f32>) -> vec4<f32>
+fn textureSampleGrad(t: texture_2d<f32>, s: sampler, coords: vec2<f32>, ddx: vec2<f32>, ddy: vec2<f32>, offset: vec2<i32>) -> vec4<f32>
+fn textureSampleGrad(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: i32, ddx: vec2<f32>, ddy: vec2<f32>) -> vec4<f32>
+fn textureSampleGrad(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: i32, ddx: vec2<f32>, ddy: vec2<f32>, offset: vec2<i32>) -> vec4<f32>
+fn textureSampleGrad(t: texture_3d<f32>, s: sampler, coords: vec3<f32>, ddx: vec3<f32>, ddy: vec3<f32>) -> vec4<f32>
+fn textureSampleGrad(t: texture_3d<f32>, s: sampler, coords: vec3<f32>, ddx: vec3<f32>, ddy: vec3<f32>, offset: vec3<i32>) -> vec4<f32>
+fn textureSampleGrad(t: texture_cube<f32>, s: sampler, coords: vec3<f32>, ddx: vec3<f32>, ddy: vec3<f32>) -> vec4<f32>
+fn textureSampleGrad(t: texture_cube_array<f32>, s: sampler, coords: vec3<f32>, array_index: i32, ddx: vec3<f32>, ddy: vec3<f32>) -> vec4<f32>
 ```
 
 **Parameters:**
@@ -11459,9 +11536,7 @@ textureSampleGrad(t: texture_cube_array<f32>, s: sampler, coords: vec3<f32>, arr
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  The `offset` expression must be either:
-    * a `const_expression` expression (e.g. `vec2<i32>(1, 2)`).<br>
-    * a name of a [=module scope|module-scope=] [=let declaration=]
+  The `offset` expression must be a [=creation-time expression=] (e.g. `vec2<i32>(1, 2)`).<br>
   Each `offset` component must be at least `-8` and at most `7`. Values outside
   of this range will result in a [=shader-creation error=].
 </table>
@@ -11476,21 +11551,21 @@ The sampled value.
 Samples a texture using an explicit mip level, or at mip level 0.
 
 ```rust
-textureSampleLevel(t: texture_2d<f32>, s: sampler, coords: vec2<f32>, level: f32) -> vec4<f32>
-textureSampleLevel(t: texture_2d<f32>, s: sampler, coords: vec2<f32>, level: f32, offset: vec2<i32>) -> vec4<f32>
-textureSampleLevel(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: i32, level: f32) -> vec4<f32>
-textureSampleLevel(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: i32, level: f32, offset: vec2<i32>) -> vec4<f32>
-textureSampleLevel(t: texture_3d<f32>, s: sampler, coords: vec3<f32>, level: f32) -> vec4<f32>
-textureSampleLevel(t: texture_3d<f32>, s: sampler, coords: vec3<f32>, level: f32, offset: vec3<i32>) -> vec4<f32>
-textureSampleLevel(t: texture_cube<f32>, s: sampler, coords: vec3<f32>, level: f32) -> vec4<f32>
-textureSampleLevel(t: texture_cube_array<f32>, s: sampler, coords: vec3<f32>, array_index: i32, level: f32) -> vec4<f32>
-textureSampleLevel(t: texture_depth_2d, s: sampler, coords: vec2<f32>, level: i32) -> f32
-textureSampleLevel(t: texture_depth_2d, s: sampler, coords: vec2<f32>, level: i32, offset: vec2<i32>) -> f32
-textureSampleLevel(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: i32, level: i32) -> f32
-textureSampleLevel(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: i32, level: i32, offset: vec2<i32>) -> f32
-textureSampleLevel(t: texture_depth_cube, s: sampler, coords: vec3<f32>, level: i32) -> f32
-textureSampleLevel(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, array_index: i32, level: i32) -> f32
-textureSampleLevel(t: texture_external, s: sampler, coords: vec2<f32>) -> vec4<f32>
+fn textureSampleLevel(t: texture_2d<f32>, s: sampler, coords: vec2<f32>, level: f32) -> vec4<f32>
+fn textureSampleLevel(t: texture_2d<f32>, s: sampler, coords: vec2<f32>, level: f32, offset: vec2<i32>) -> vec4<f32>
+fn textureSampleLevel(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: i32, level: f32) -> vec4<f32>
+fn textureSampleLevel(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: i32, level: f32, offset: vec2<i32>) -> vec4<f32>
+fn textureSampleLevel(t: texture_3d<f32>, s: sampler, coords: vec3<f32>, level: f32) -> vec4<f32>
+fn textureSampleLevel(t: texture_3d<f32>, s: sampler, coords: vec3<f32>, level: f32, offset: vec3<i32>) -> vec4<f32>
+fn textureSampleLevel(t: texture_cube<f32>, s: sampler, coords: vec3<f32>, level: f32) -> vec4<f32>
+fn textureSampleLevel(t: texture_cube_array<f32>, s: sampler, coords: vec3<f32>, array_index: i32, level: f32) -> vec4<f32>
+fn textureSampleLevel(t: texture_depth_2d, s: sampler, coords: vec2<f32>, level: i32) -> f32
+fn textureSampleLevel(t: texture_depth_2d, s: sampler, coords: vec2<f32>, level: i32, offset: vec2<i32>) -> f32
+fn textureSampleLevel(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: i32, level: i32) -> f32
+fn textureSampleLevel(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: i32, level: i32, offset: vec2<i32>) -> f32
+fn textureSampleLevel(t: texture_depth_cube, s: sampler, coords: vec3<f32>, level: i32) -> f32
+fn textureSampleLevel(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, array_index: i32, level: i32) -> f32
+fn textureSampleLevel(t: texture_external, s: sampler, coords: vec2<f32>) -> vec4<f32>
 ```
 
 **Parameters:**
@@ -11515,9 +11590,7 @@ textureSampleLevel(t: texture_external, s: sampler, coords: vec2<f32>) -> vec4<f
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  The `offset` expression must be either:
-    * a `const_expression` expression (e.g. `vec2<i32>(1, 2)`).<br>
-    * a name of a [=module scope|module-scope=] [=let declaration=]
+  The `offset` expression must be a [=creation-time expression=] (e.g. `vec2<i32>(1, 2)`).<br>
   Each `offset` component must be at least `-8` and at most `7`. Values outside
   of this range will result in a [=shader-creation error=].
 </table>
@@ -11532,10 +11605,10 @@ The sampled value.
 Writes a single texel to a texture.
 
 ```rust
-textureStore(t: texture_storage_1d<F,write>, coords: i32, value: vec4<T>)
-textureStore(t: texture_storage_2d<F,write>, coords: vec2<i32>, value: vec4<T>)
-textureStore(t: texture_storage_2d_array<F,write>, coords: vec2<i32>, array_index: i32, value: vec4<T>)
-textureStore(t: texture_storage_3d<F,write>, coords: vec3<i32>, value: vec4<T>)
+fn textureStore(t: texture_storage_1d<F,write>, coords: i32, value: vec4<T>)
+fn textureStore(t: texture_storage_2d<F,write>, coords: vec2<i32>, value: vec4<T>)
+fn textureStore(t: texture_storage_2d_array<F,write>, coords: vec2<i32>, array_index: i32, value: vec4<T>)
+fn textureStore(t: texture_storage_3d<F,write>, coords: vec3<i32>, value: vec4<T>)
 ```
 
 The channel format `T` depends on the storage texel format `F`.
@@ -11566,12 +11639,6 @@ If an out-of-bounds access occurs, the built-in function may do any of the follo
 * not be executed
 * store `value` to some in bounds texel
 
-**TODO:**
-
-<pre class='def'>
-TODO(dsinclair): Need gather operations
-</pre>
-
 ## Atomic Built-in Functions ## {#atomic-builtin-functions}
 
 Atomic built-in functions can be used to read/write/read-modify-write atomic
@@ -11593,7 +11660,7 @@ The access mode `A` in all atomic built-in functions must be [=access/read_write
 ### Atomic Load ### {#atomic-load}
 
 ```rust
-atomicLoad(atomic_ptr: ptr<SC, atomic<T>, A>) -> T
+fn atomicLoad(atomic_ptr: ptr<SC, atomic<T>, A>) -> T
 ```
 
 Returns the atomically loaded the value pointed to by `atomic_ptr`.
@@ -11602,7 +11669,7 @@ It does not [=atomic modification|modify=] the object.
 ### Atomic Store ### {#atomic-store}
 
 ```rust
-atomicStore(atomic_ptr: ptr<SC, atomic<T>, A>, v: T)
+fn atomicStore(atomic_ptr: ptr<SC, atomic<T>, A>, v: T)
 ```
 
 Atomically stores the value `v` in the atomic object pointed to by `atomic_ptr`.
@@ -11610,13 +11677,13 @@ Atomically stores the value `v` in the atomic object pointed to by `atomic_ptr`.
 ### Atomic Read-modify-write ### {#atomic-rmw}
 
 ```rust
-atomicAdd(atomic_ptr: ptr<SC, atomic<T>, A>, v: T) -> T
-atomicSub(atomic_ptr: ptr<SC, atomic<T>, A>, v: T) -> T
-atomicMax(atomic_ptr: ptr<SC, atomic<T>, A>, v: T) -> T
-atomicMin(atomic_ptr: ptr<SC, atomic<T>, A>, v: T) -> T
-atomicAnd(atomic_ptr: ptr<SC, atomic<T>, A>, v: T) -> T
-atomicOr(atomic_ptr: ptr<SC, atomic<T>, A>, v: T) -> T
-atomicXor(atomic_ptr: ptr<SC, atomic<T>, A>, v: T) -> T
+fn atomicAdd(atomic_ptr: ptr<SC, atomic<T>, A>, v: T) -> T
+fn atomicSub(atomic_ptr: ptr<SC, atomic<T>, A>, v: T) -> T
+fn atomicMax(atomic_ptr: ptr<SC, atomic<T>, A>, v: T) -> T
+fn atomicMin(atomic_ptr: ptr<SC, atomic<T>, A>, v: T) -> T
+fn atomicAnd(atomic_ptr: ptr<SC, atomic<T>, A>, v: T) -> T
+fn atomicOr(atomic_ptr: ptr<SC, atomic<T>, A>, v: T) -> T
+fn atomicXor(atomic_ptr: ptr<SC, atomic<T>, A>, v: T) -> T
 ```
 Each function performs the following steps atomically:
 
@@ -11628,14 +11695,14 @@ Each function performs the following steps atomically:
 Each function returns the original value stored in the atomic object.
 
 ```rust
-atomicExchange(atomic_ptr: ptr<SC, atomic<T>, A>, v: T) -> T
+fn atomicExchange(atomic_ptr: ptr<SC, atomic<T>, A>, v: T) -> T
 ```
 
 Atomically stores the value `v` in the atomic object pointed to
 `atomic_ptr` and returns the original value stored in the atomic object.
 
 ```rust
-atomicCompareExchangeWeak(atomic_ptr: ptr<SC, atomic<T>, A>, cmp: T, v: T) -> __atomic_compare_exchange_result<T>
+fn atomicCompareExchangeWeak(atomic_ptr: ptr<SC, atomic<T>, A>, cmp: T, v: T) -> __atomic_compare_exchange_result<T>
 
 struct __atomic_compare_exchange_result<T> {
   old_value : T; // old value stored in the atomic
@@ -11672,7 +11739,7 @@ reduce a shader's memory bandwidth demand.
     <tr><td>Overload<td>Description
   </thead>
   <tr algorithm="packing 4x8snorm">
-    <td class="nowrap">`pack4x8snorm`(|e|: vec4&lt;f32&gt;) -> u32
+    <td class="nowrap">`@const fn pack4x8snorm`(|e|: vec4&lt;f32&gt;) -> u32
     <td>Converts four normalized floating point values to 8-bit signed integers, and then combines them
         into one `u32` value.<br>
         Component |e|[|i|] of the input is converted to an 8-bit twos complement integer value
@@ -11681,7 +11748,7 @@ reduce a shader's memory bandwidth demand.
         8 &times; |i| + 7 of the result.
 
   <tr algorithm="packing 4x8unorm">
-    <td class="nowrap">`pack4x8unorm`(|e|: vec4&lt;f32&gt;) -> u32
+    <td class="nowrap">`@const fn pack4x8unorm`(|e|: vec4&lt;f32&gt;) -> u32
     <td>Converts four normalized floating point values to 8-bit unsigned integers, and then combines them
         into one `u32` value.<br>
         Component |e|[|i|] of the input is converted to an 8-bit unsigned integer value
@@ -11690,7 +11757,7 @@ reduce a shader's memory bandwidth demand.
         8 &times; |i| + 7 of the result.
 
   <tr algorithm="packing 2x16snorm">
-    <td class="nowrap">`pack2x16snorm`(|e|: vec2&lt;f32&gt;) -> u32
+    <td class="nowrap">`@const fn pack2x16snorm`(|e|: vec2&lt;f32&gt;) -> u32
     <td>Converts two normalized floating point values to 16-bit signed integers, and then combines them
         into one `u32` value.<br>
         Component |e|[|i|] of the input is converted to a 16-bit twos complement integer value
@@ -11699,7 +11766,7 @@ reduce a shader's memory bandwidth demand.
         16 &times; |i| + 15 of the result.
 
   <tr algorithm="packing 2x16unorm">
-    <td class="nowrap">`pack2x16unorm`(|e|: vec2&lt;f32&gt;) -> u32
+    <td class="nowrap">`@const fn pack2x16unorm`(|e|: vec2&lt;f32&gt;) -> u32
     <td>Converts two normalized floating point values to 16-bit unsigned integers, and then combines them
         into one `u32` value.<br>
         Component |e|[|i|] of the input is converted to a 16-bit unsigned integer value
@@ -11708,7 +11775,7 @@ reduce a shader's memory bandwidth demand.
         16 &times; |i| + 15 of the result.
 
   <tr algorithm="packing 2x16float">
-    <td class="nowrap">`pack2x16float`(|e|: vec2&lt;f32&gt;) -> u32
+    <td class="nowrap">`@const fn pack2x16float`(|e|: vec2&lt;f32&gt;) -> u32
     <td>Converts two floating point values to half-precision floating point numbers, and then combines
         them into one `u32` value.<br>
         Component |e|[|i|] of the input is converted to a [[!IEEE-754|IEEE-754]] binary16 value, which is then
@@ -11730,35 +11797,35 @@ reduce a shader's memory bandwidth demand.
     <tr><td>Overload<td>Description
   </thead>
   <tr algorithm="unpacking 4x8snorm">
-    <td class="nowrap">`unpack4x8snorm`(|e|: u32) -> vec4&lt;f32&gt;
+    <td class="nowrap">`@const fn unpack4x8snorm`(|e|: u32) -> vec4&lt;f32&gt;
     <td>Decomposes a 32-bit value into four 8-bit chunks, then reinterprets
         each chunk as a signed normalized floating point value.<br>
         Component |i| of the result is max(|v| &div; 127, -1), where |v| is the interpretation of
         bits 8&times;|i| through 8&times;|i|+7 of |e| as a twos-complement signed integer.
 
   <tr algorithm="unpacking 4x8unorm">
-    <td class="nowrap">`unpack4x8unorm`(|e|: u32) -> vec4&lt;f32&gt;
+    <td class="nowrap">`@const fn unpack4x8unorm`(|e|: u32) -> vec4&lt;f32&gt;
     <td>Decomposes a 32-bit value into four 8-bit chunks, then reinterprets
         each chunk as an unsigned normalized floating point value.<br>
         Component |i| of the result is |v| &div; 255, where |v| is the interpretation of
         bits 8&times;|i| through 8&times;|i|+7 of |e| as an unsigned integer.
 
   <tr algorithm="unpacking 2x16snorm">
-    <td class="nowrap">`unpack2x16snorm`(|e|: u32) -> vec2&lt;f32&gt;
+    <td class="nowrap">`@const fn unpack2x16snorm`(|e|: u32) -> vec2&lt;f32&gt;
     <td>Decomposes a 32-bit value into two 16-bit chunks, then reinterprets
         each chunk as a signed normalized floating point value.<br>
         Component |i| of the result is max(|v| &div; 32767, -1), where |v| is the interpretation of
         bits 16&times;|i| through 16&times;|i|+15 of |e| as a twos-complement signed integer.
 
   <tr algorithm="unpacking 2x16unorm">
-    <td class="nowrap">`unpack2x16unorm`(|e|: u32) -> vec2&lt;f32&gt;
+    <td class="nowrap">`@const fn unpack2x16unorm`(|e|: u32) -> vec2&lt;f32&gt;
     <td>Decomposes a 32-bit value into two 16-bit chunks, then reinterprets
         each chunk as an unsigned normalized floating point value.<br>
         Component |i| of the result is |v| &div; 65535, where |v| is the interpretation of
         bits 16&times;|i| through 16&times;|i|+15 of |e| as an unsigned integer.
 
   <tr algorithm="unpacking 2x16float">
-    <td class="nowrap">`unpack2x16float`(|e|: u32) -> vec2&lt;f32&gt;
+    <td class="nowrap">`@const fn unpack2x16float`(|e|: u32) -> vec2&lt;f32&gt;
     <td>Decomposes a 32-bit value into two 16-bit chunks, and reinterpets each chunk
         as a floating point value.<br>
         Component |i| of the result is the f32 representation of |v|,
@@ -11772,8 +11839,8 @@ reduce a shader's memory bandwidth demand.
 WGSL provides the following synchronization functions:
 
 ```rust
-storageBarrier()
-workgroupBarrier()
+fn storageBarrier()
+fn workgroupBarrier()
 ```
 
 All synchronization functions execute a [=control barrier=] with


### PR DESCRIPTION
* Allows vectors and matrices to have abstract components
* Renames constexpr to creation-time expression and greatly expands
  functionality to include most expressions
  * to be creation-time expressions, all identifiers must be
    creation-time constants or creation-time functions
  * removes `const_expression` grammar (replacement for it)
* Add new declaration type: creation-time constant
  * uses `const` keyword
  * usable at module and function scopes
* Restrict `let` to function scope
* Add `@const` attribute to declare creation-time constants
  * only usable for built-in functions currently
* Define override expression in terms of creation-time expressions
* Update fixed-size array declarations to allow creation-time
  expressions
* Update texture functions to use creation-time expressions
* Update builtin functions to specify which are usable with abstract
  types and which are usable with creation-time expressions
* Update expressions to specify which are usable with abstract types
* Clarify that `let` and `var` are always concrete
* De-duplicate some builtin function table entries
* Update some overload resolution examples

----

This builds on #2227 and implements the consensus on constexpr from #1272. Take a look at the last commit.

Does not add support for specifying arguments as required to be creation-time expressions. Does not add staticAssert yet.

Some of the examples use a grammar ambiguity that was pre-existing (e.g. `vec3(...)`).