### PR TITLE
GPUSamplerDescriptor.maxAnisotropy gets clamped to a platform-specific maximum

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3508,7 +3508,9 @@ dictionary GPUSamplerDescriptor : GPUObjectDescriptorBase {
     {{GPUCompareFunction}}.
 - {{GPUSamplerDescriptor/maxAnisotropy}} specifies the maximum anisotropy value clamp used by the sampler.
 
-    Note: most implementations support {{GPUSamplerDescriptor/maxAnisotropy}} values in range between 1 and 16, inclusive.
+    Note: Most implementations support {{GPUSamplerDescriptor/maxAnisotropy}} values in range between 1 and 16, inclusive.
+          The used value of {{GPUSamplerDescriptor/maxAnisotropy}} will be clamped to the maximum value that the platform
+          supports.
 
 Issue: explain how LOD is calculated and if there are differences here between platforms.
 
@@ -3634,6 +3636,11 @@ enum GPUCompareFunction {
         - |descriptor|.{{GPUSamplerDescriptor/lodMaxClamp}} is greater than or equal to
             |descriptor|.{{GPUSamplerDescriptor/lodMinClamp}}.
         - |descriptor|.{{GPUSamplerDescriptor/maxAnisotropy}} is greater than or equal to 1.
+
+              Note: Most implementations support {{GPUSamplerDescriptor/maxAnisotropy}} values in range between 1 and 16, inclusive.
+                    The used value of {{GPUSamplerDescriptor/maxAnisotropy}} will be clamped to the maximum value that the platform
+                    supports.
+
         - When |descriptor|.{{GPUSamplerDescriptor/maxAnisotropy}} is greater than 1,
             |descriptor|.{{GPUSamplerDescriptor/magFilter}}, |descriptor|.{{GPUSamplerDescriptor/minFilter}},
             and |descriptor|.{{GPUSamplerDescriptor/mipmapFilter}} must be equal to {{GPUMipmapFilterMode/"linear"}}.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3638,7 +3638,7 @@ enum GPUCompareFunction {
         - |descriptor|.{{GPUSamplerDescriptor/maxAnisotropy}} is greater than or equal to 1.
 
             Note: Most implementations support {{GPUSamplerDescriptor/maxAnisotropy}} values in range between 1 and 16, inclusive.
-            The used value of {{GPUSamplerDescriptor/maxAnisotropy}} will be clamped to the maximum value that the platform
+            The provided {{GPUSamplerDescriptor/maxAnisotropy}} value will be clamped to the maximum value that the platform
             supports.
 
         - When |descriptor|.{{GPUSamplerDescriptor/maxAnisotropy}} is greater than 1,

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3509,8 +3509,8 @@ dictionary GPUSamplerDescriptor : GPUObjectDescriptorBase {
 - {{GPUSamplerDescriptor/maxAnisotropy}} specifies the maximum anisotropy value clamp used by the sampler.
 
     Note: Most implementations support {{GPUSamplerDescriptor/maxAnisotropy}} values in range between 1 and 16, inclusive.
-          The used value of {{GPUSamplerDescriptor/maxAnisotropy}} will be clamped to the maximum value that the platform
-          supports.
+    The used value of {{GPUSamplerDescriptor/maxAnisotropy}} will be clamped to the maximum value that the platform
+    supports.
 
 Issue: explain how LOD is calculated and if there are differences here between platforms.
 
@@ -3637,9 +3637,9 @@ enum GPUCompareFunction {
             |descriptor|.{{GPUSamplerDescriptor/lodMinClamp}}.
         - |descriptor|.{{GPUSamplerDescriptor/maxAnisotropy}} is greater than or equal to 1.
 
-              Note: Most implementations support {{GPUSamplerDescriptor/maxAnisotropy}} values in range between 1 and 16, inclusive.
-                    The used value of {{GPUSamplerDescriptor/maxAnisotropy}} will be clamped to the maximum value that the platform
-                    supports.
+            Note: Most implementations support {{GPUSamplerDescriptor/maxAnisotropy}} values in range between 1 and 16, inclusive.
+            The used value of {{GPUSamplerDescriptor/maxAnisotropy}} will be clamped to the maximum value that the platform
+            supports.
 
         - When |descriptor|.{{GPUSamplerDescriptor/maxAnisotropy}} is greater than 1,
             |descriptor|.{{GPUSamplerDescriptor/magFilter}}, |descriptor|.{{GPUSamplerDescriptor/minFilter}},


### PR DESCRIPTION
The Metal spec[1] says:

> Values must be between 1 and 16, inclusive.

[1] https://developer.apple.com/documentation/metal/mtlsamplerdescriptor/1516164-maxanisotropy?language=objc


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/litherum/gpuweb/pull/2670.html" title="Last updated on Mar 19, 2022, 3:15 AM UTC (219b4f9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2670/bb2deb9...litherum:219b4f9.html" title="Last updated on Mar 19, 2022, 3:15 AM UTC (219b4f9)">Diff</a>