### PR TITLE
WGSL: Explain parameterized type rules more explicitly.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1144,43 +1144,80 @@ A [=type rule=] has two parts:
     * Conditions on the other schematic parameters, if any.
     * Optionally, other static context.
 
-Each distinct type parameterization for a type rule is called an <dfn noexport>overload</dfn>.
-For example, [[#arithmetic-expr|unary negation]] (an expression of the form `-`|e|)
-has twelve overloads, because its type rules are parameterized by a type |T| that can be any of:
-* [=i32=]
-* [=vector|vec2&lt;i32&gt;=]
-* vec3&lt;i32&gt;
-* vec4&lt;i32&gt;
-* [=f32=]
-* [=vector|vec2&lt;f32&gt;=]
-* vec3&lt;f32&gt;
-* vec4&lt;f32&gt;
-* [=f16=]
-* [=vector|vec2&lt;f16&gt;=]
-* vec3&lt;f16&gt;
-* vec4&lt;f16&gt;
+Type rules may have <dfn noexport>type parameters</dfn> in their preconditions and conclusions.
+When a type rule's conclusion or preconditions contain type parameters,
+we say it is <dfn noexport>parameterized</dfn>.
+When they do not, we say the rule is <dfn noexport>fully elaborated</dfn>.
+We can make a fully elaborated type rule from a parameterized one
+by substituting a type for each of its type parameters,
+using the same type for all occurrences of a given parameter in the rule.
+An assignment of types to a rule's type parameters
+is called a <dfn noexport>substitution</dfn>.
+
+For example, here is the type rule for [[#logical-expr|logical negation]]
+(an expression of the form `!`|e|):
+
+<table class='data'>
+  <thead>
+    <tr><th>Precondition<th>Conclusion
+  </thead>
+  <tr algorithm="example boolean negation"><td>|e|: |T|<br>
+  |T| is bool or vec|N|&lt;bool&gt;
+  <td>`!`|e|`:` |T|
+</table>
+
+This is a parameterized rule, because it contains the type parameter |T|,
+which can represent any one of four types
+[=bool=], `vec2<bool>`, `vec3<bool>`, or `vec4<bool>`.
+Applying the substitution that maps |T| to `vec3<bool>`
+produces the fully elaborated type rule:
+
+<table class='data'>
+  <thead>
+    <tr><th>Precondition<th>Conclusion
+  </thead>
+  <tr algorithm="example2 boolean negation"><td>|e|`: vec3<bool>`<br>
+  <td>`!`|e|`: vec3<bool>`
+</table>
+
+Each fully elaborated rule we can produce from a parameterized rule
+by applying some substitution that meets the rule's other conditions
+is called an <dfn noexport>overload</dfn> of the parameterized rule.
+For example, the boolean negation rule has four overloads,
+because there are four possible ways to assign a type to its type parameter |T|.
+
+Note:
+In other words, a parameterized type rule provides the pattern 
+for a collection of fully elaborated type rules,
+each one produced by applying a different substitution to the parameterized rule.
 
 A <dfn noexport>type rule applies to a syntactic phrase</dfn> when:
 * The rule's conclusion matches a valid parse of the [=syntactic phrase=], and
 * The rule's preconditions are satisfied.
 
+A parameterized type rule applies to an expression
+if there exists a substitution producing a fully elaborated type rule
+that applies to the expression.
+
 Consider the expression, `1u+2u`.
 It has two [[#literal-expressions|literal subexpressions]]: `1u` and `2u`, both of type u32.
 The [=top-level expression=] is an addition.
-Referring to the [[#arithmetic-expr]] rules, the type rule for scalar u32 addition applies to the expression, because:
+Referring to the [[#arithmetic-expr]] rules, the type rule for addition applies to the expression, because:
 * `1u+2u` matches a parse of the form |e1|+|e2|, with |e1| standing for `1u` and |e2| standing for `2u`, and
 * |e1| is of type u32, and
-* |e2| is of type u32.
+* |e2| is of type u32, and
+* we can substitute u32 for the type parameter |T| in the type rule,
+    resulting in a fully elaborated rule that applies to the entire expression.
 
 When analyzing a [=syntactic phrase=], three cases may occur:
 * No type rules apply to the expression.  This results in a [=type error=].
-* Exactly one type rule applies to the expression.
+* Exactly one fully elaborated type rule applies to the expression.
     In this case, the rule's [=type rule conclusion|conclusion=] is asserted, determining the static type for the expression.
 * More than one type rule applies. That is, the preconditions for more than one [=overload=] are satisfied.
     In this case the tie-breaking procedure described in [[#overload-resolution-section]] is used.
-    * If overload resolution succeeds, a single type rule is determined to apply to the expression.
+    * If overload resolution succeeds, a single [=overload=] is determined to apply to the expression.
         The [=type assertions=] in the [=type rule conclusion|conclusion=] for that overload are asserted,
-        and therefore determines the types for the expression or expressions in the [=syntactic phrase=].
+        and therefore determine the types for the expression or expressions in the [=syntactic phrase=].
     * If overload resolution fails, a [=type error=] results.
 
 Continuing the example above, only one type rule applies to the expression `1u+2u`, and so type checking

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1195,23 +1195,23 @@ A <dfn noexport>type rule applies to a syntactic phrase</dfn> when:
 * The rule's conclusion matches a valid parse of the [=syntactic phrase=], and
 * The rule's preconditions are satisfied.
 
-A parameterized type rule applies to an expression
-if there exists a substitution producing a fully elaborated type rule
+A [=parameterized=] type rule applies to an expression
+if there exists a [=substitution=] producing a [=fully elaborated=] type rule
 that applies to the expression.
 
 Consider the expression, `1u+2u`.
 It has two [[#literal-expressions|literal subexpressions]]: `1u` and `2u`, both of type u32.
 The [=top-level expression=] is an addition.
-Referring to the [[#arithmetic-expr]] rules, the type rule for addition applies to the expression, because:
+Referring to the rules in [[#arithmetic-expr]], the type rule for addition applies to the expression, because:
 * `1u+2u` matches a parse of the form |e1|+|e2|, with |e1| standing for `1u` and |e2| standing for `2u`, and
 * |e1| is of type u32, and
 * |e2| is of type u32, and
 * we can substitute u32 for the type parameter |T| in the type rule,
-    resulting in a fully elaborated rule that applies to the entire expression.
+    resulting in a [=fully elaborated=] rule that applies to the entire expression.
 
 When analyzing a [=syntactic phrase=], three cases may occur:
 * No type rules apply to the expression.  This results in a [=type error=].
-* Exactly one fully elaborated type rule applies to the expression.
+* Exactly one [=fully elaborated=] type rule applies to the expression.
     In this case, the rule's [=type rule conclusion|conclusion=] is asserted, determining the static type for the expression.
 * More than one type rule applies. That is, the preconditions for more than one [=overload=] are satisfied.
     In this case the tie-breaking procedure described in [[#overload-resolution-section]] is used.


### PR DESCRIPTION
Introduce the terms "type parameter", "parameterized type rule", "concrete type rule", "substitution", and define "overload" in terms of them.

This text is extracted from #2651.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jimblandy/gpuweb/pull/2682.html" title="Last updated on Apr 28, 2022, 2:14 AM UTC (8d6c081)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2682/819184c...jimblandy:8d6c081.html" title="Last updated on Apr 28, 2022, 2:14 AM UTC (8d6c081)">Diff</a>