### PR TITLE
wgsl: Fix a typo in Vector conversion type rules

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3831,7 +3831,7 @@ Details of conversion to and from floating point are explained in [[#floating-po
 
   <tr algorithm="vector conversion from bool to floating point">
      <td>|e|: vec|N|&lt;bool&gt;
-     <td>`vec`|N|&lt;`u32`&gt;`(`|e|`)`: vec|N|&lt;u32&gt
+     <td>`vec`|N|&lt;`f32`&gt;`(`|e|`)`: vec|N|&lt;f32&gt
      <td>[=Component-wise=] conversion of a boolean vector to floating point.<br>
          Component |i| of the result is `f32(`|e|`[`|i|`])`
 


### PR DESCRIPTION
Fix a typo in vector conversion type rule of bool to f32.