### PR TITLE
Clarify texture view validation and update defaults

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2993,16 +2993,19 @@ enum GPUTextureAspect {
                     1. If any of the following requirements are unmet:
                         <div class=validusage>
                             - |this| is [=valid=]
-                            - If the |descriptor|.{{GPUTextureViewDescriptor/aspect}} is
-                                <dl class="switch">
-                                    : {{GPUTextureAspect/"stencil-only"}}
-                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}} must be a
-                                        [=depth-or-stencil format=] which has a stencil aspect.
+                            - |descriptor|.{{GPUTextureViewDescriptor/aspect}} must be present in
+                                |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
+                            - If the |descriptor|.{{GPUTextureViewDescriptor/aspect}} is {{GPUTextureAspect/"all"}}:
+                                - |descriptor|.{{GPUTextureViewDescriptor/format}} must be equal to either
+                                        |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}} or one
+                                        of the formats in |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/viewFormats}}.
 
-                                    : {{GPUTextureAspect/"depth-only"}}
-                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}} must be a
-                                        [=depth-or-stencil format=] which has a depth aspect.
-                                </dl>
+                                Otherwise:
+
+                                - |descriptor|.{{GPUTextureViewDescriptor/format}} must be equal to the result of [$resolving GPUTextureAspect$](
+                                    |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}},
+                                    |descriptor|.{{GPUTextureViewDescriptor/aspect}}).
+
                             - |descriptor|.{{GPUTextureViewDescriptor/mipLevelCount}} must be &gt; 0.
                             - |descriptor|.{{GPUTextureViewDescriptor/baseMipLevel}} +
                                 |descriptor|.{{GPUTextureViewDescriptor/mipLevelCount}} must be &le;
@@ -3011,9 +3014,6 @@ enum GPUTextureAspect {
                             - |descriptor|.{{GPUTextureViewDescriptor/baseArrayLayer}} +
                                 |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be &le;
                                 the [$array layer count$] of |this|.
-                            - |descriptor|.{{GPUTextureViewDescriptor/format}} must be equal to either
-                                |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}
-                                or one of the formats in |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/viewFormats}}.
                             - If |descriptor|.{{GPUTextureViewDescriptor/dimension}} is:
                                 <dl class="switch">
                                     : {{GPUTextureViewDimension/"1d"}}
@@ -3066,7 +3066,15 @@ enum GPUTextureAspect {
 
     1. Let |resolved| be a copy of |descriptor|.
     1. If |resolved|.{{GPUTextureViewDescriptor/format}} is `undefined`,
-        set |resolved|.{{GPUTextureViewDescriptor/format}} to |texture|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
+        1. Let |format| be the result of [$resolving GPUTextureAspect$](
+                {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}},
+                |descriptor|.{{GPUTextureViewDescriptor/aspect}}).
+        1. If |format| is `null`:
+            - Set |resolved|.{{GPUTextureViewDescriptor/format}} to |texture|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
+
+            Otherwise:
+
+            - Set |resolved|.{{GPUTextureViewDescriptor/format}} to |format|.
     1. If |resolved|.{{GPUTextureViewDescriptor/mipLevelCount}} is `undefined`,
         set |resolved|.{{GPUTextureViewDescriptor/mipLevelCount}} to |texture|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/mipLevelCount}}
         &minus; |resolved|.{{GPUTextureViewDescriptor/baseMipLevel}}.
@@ -3320,6 +3328,29 @@ A <dfn>renderable format</dfn> is either a <dfn>color renderable format</dfn>, o
 If a format is listed in [[#plain-color-formats]] with {{GPUTextureUsage/RENDER_ATTACHMENT}} capability, it is a
 color renderable format. Any other format is not a color renderable format.
 All [=depth-or-stencil formats=] are renderable.
+
+<div algorithm>
+    <dfn abstract-op>resolving GPUTextureAspect</dfn>(format, aspect)
+
+    **Arguments:**
+        - {{GPUTextureFormat}} |format|
+        - {{GPUTextureAspect}} |aspect|
+
+    **Returns:** {{GPUTextureFormat}} or `null`
+
+    1. If |aspect| is:
+        <dl class="switch">
+            : {{GPUTextureAspect/"all"}}
+            :: Return |format|.
+
+            : {{GPUTextureAspect/"depth-only"}}
+            : {{GPUTextureAspect/"stencil-only"}}
+            :: If |format| is a depth-stencil-format:
+                Return the [=aspect-specific format=] of |format| according to [[#depth-formats]] or `null` if
+                    the aspect is not present in |format|.
+        </dl>
+    1. Return `null`.
+</div>
 
 ## <dfn interface>GPUExternalTexture</dfn> ## {#gpu-external-texture}
 
@@ -3733,6 +3764,7 @@ enum GPUCompareFunction {
 
 <div algorithm>
     <dfn abstract-op>validating GPUSamplerDescriptor</dfn>(device, descriptor)
+
     **Arguments:**
         - {{GPUDevice}} |device|
         - {{GPUSamplerDescriptor}} |descriptor|
@@ -5188,7 +5220,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
             some [=pipeline-overridable=] constant defined in the shader module
             |descriptor|.{{GPUProgrammableStage/module}} by code points and
             not by [=UAX15 Equivalences=] for [[!UnicodeVersion14|Unicode Version 14.0.0]].
-            
+
             Note: User agents should consider issuing developer-visible warnings in most or all
             situations where display of two names with different code point sequences
             look the same to the reader, such as ones same under canonical equivalence with
@@ -11385,7 +11417,7 @@ None of the depth formats can be filtered.
         <td>- (<a href="#depthPlus">See prose</a>)
         <td>{{GPUTextureSampleType/"depth"}}
         <td colspan=2>&cross;
-        <td>- (Not a valid image copy source nor a valid image copy destination)
+        <td>{{GPUTextureFormat/depth24plus}}
     <tr>
         <td rowspan=2 style='white-space:nowrap'>{{GPUTextureFormat/depth24plus-stencil8}}
         <td rowspan=2>4 &minus; 8
@@ -11393,7 +11425,7 @@ None of the depth formats can be filtered.
         <td>- (<a href="#depthPlus">See prose</a>)
         <td>{{GPUTextureSampleType/"depth"}}
         <td colspan=2>&cross;
-        <td>- (Not a valid image copy source nor a valid image copy destination)
+        <td>{{GPUTextureFormat/depth24plus}}
     <tr>
         <td>stencil
         <td>1
@@ -11416,7 +11448,7 @@ None of the depth formats can be filtered.
         <td>3
         <td>{{GPUTextureSampleType/"depth"}}
         <td colspan=2>&cross;
-        <td>- (Not a valid image copy source nor a valid image copy destination)
+        <td>{{GPUTextureFormat/depth24plus}}
     <tr>
         <td>stencil
         <td>1


### PR DESCRIPTION
New validation fully checks the view format against the
texture format for depth-stencil formats.
Also, update the default view format such that it is resolved
from the selected aspect.

Closes #2679


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/austinEng/gpuweb/pull/2687.html" title="Last updated on Mar 31, 2022, 4:43 PM UTC (6c747bc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2687/c659d3e...austinEng:6c747bc.html" title="Last updated on Mar 31, 2022, 4:43 PM UTC (6c747bc)">Diff</a>