### PR TITLE
Rename dispatch -> dispatchWorkgroups

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -745,9 +745,9 @@ depends on work that happens on any timeline other than the [=Content timeline=]
 They are represented by callbacks and promises in JavaScript.
 
 <div class="example">
-{{GPUComputePassEncoder/dispatch(workgroupCountX, workgroupCountY, workgroupCountZ)|GPUComputePassEncoder.dispatch()}}:
+{{GPUComputePassEncoder/dispatchWorkgroups()|GPUComputePassEncoder.dispatchWorkgroups()}}:
 
-  1. User encodes a `dispatch` command by calling a method of the
+  1. User encodes a `dispatchWorkgroups` command by calling a method of the
     {{GPUComputePassEncoder}} which happens on the [=Content timeline=].
   2. User issues {{GPUQueue/submit(commandBuffers)|GPUQueue.submit()}} that hands over
     the {{GPUCommandBuffer}} to the user agent, which processes it
@@ -916,8 +916,8 @@ This specification defines the following [=usage scopes=]:
 
 - Outside of a pass (in {{GPUCommandEncoder}}), each (non-state-setting) command is one usage scope
     (e.g. {{GPUCommandEncoder/copyBufferToTexture()}}).
-- In a compute pass, each dispatch command ({{GPUComputePassEncoder/dispatch()}} or
-    {{GPUComputePassEncoder/dispatchIndirect()}}) is one usage scope.
+- In a compute pass, each dispatch command ({{GPUComputePassEncoder/dispatchWorkgroups()}} or
+    {{GPUComputePassEncoder/dispatchWorkgroupsIndirect()}}) is one usage scope.
     A subresource is "used" in the usage scope if it is potentially accessible by the command.
     Within a dispatch, for each bind group slot that is used by the current {{GPUComputePipeline}}'s
     {{GPUPipelineBase/[[layout]]}}, every [=subresource=] referenced by
@@ -1341,7 +1341,7 @@ applications should generally request the "worst" limits that work for their con
         <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>65535
     <tr class=row-continuation><td colspan=4>
         The maximum value for the arguments of
-        {{GPUComputePassEncoder/dispatch(workgroupCountX, workgroupCountY, workgroupCountZ)}}.
+        {{GPUComputePassEncoder/dispatchWorkgroups(workgroupCountX, workgroupCountY, workgroupCountZ)}}.
 
 </table>
 
@@ -4409,10 +4409,10 @@ Note: using the same {{GPUPipelineLayout}} for many {{GPURenderPipeline}} or {{G
   1. {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup(1, ...)}}
   1. {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup(2, ...)}}
   1. {{GPUComputePassEncoder/setPipeline(pipeline)|setPipeline(X)}}
-  1. {{GPUComputePassEncoder/dispatch(workgroupCountX, workgroupCountY, workgroupCountZ)|dispatch()}}
+  1. {{GPUComputePassEncoder/dispatchWorkgroups()|dispatchWorkgroups()}}
   1. {{GPUProgrammablePassEncoder/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup(1, ...)}}
   1. {{GPUComputePassEncoder/setPipeline(pipeline)|setPipeline(Y)}}
-  1. {{GPUComputePassEncoder/dispatch(workgroupCountX, workgroupCountY, workgroupCountZ)|dispatch()}}
+  1. {{GPUComputePassEncoder/dispatchWorkgroups()|dispatchWorkgroups()}}
 
 In this scenario, the user agent would have to re-bind the group slot 2 for the second dispatch, even though neither the {{GPUBindGroupLayout}} at index 2 of {{GPUPipelineLayout/[[bindGroupLayouts]]|GPUPipelineLayout.bindGrouplayouts}}, or the {{GPUBindGroup}} at slot 2, change.
 </div>
@@ -5091,7 +5091,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
             some [=pipeline-overridable=] constant defined in the shader module
             |descriptor|.{{GPUProgrammableStage/module}} by code points and
             not by [=UAX15 Equivalences=] for [[!UnicodeVersion14|Unicode Version 14.0.0]].
-            
+
             Note: User agents should consider issuing developer-visible warnings in most or all
             situations where display of two names with different code point sequences
             look the same to the reader, such as ones same under canonical equivalence with
@@ -7376,8 +7376,8 @@ interface mixin GPUDebugCommandsMixin {
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUComputePassEncoder {
     undefined setPipeline(GPUComputePipeline pipeline);
-    undefined dispatch(GPUSize32 workgroupCountX, optional GPUSize32 workgroupCountY = 1, optional GPUSize32 workgroupCountZ = 1);
-    undefined dispatchIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
+    undefined dispatchWorkgroups(GPUSize32 workgroupCountX, optional GPUSize32 workgroupCountY = 1, optional GPUSize32 workgroupCountZ = 1);
+    undefined dispatchWorkgroupsIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
 
     undefined end();
 };
@@ -7465,7 +7465,7 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
             </div>
         </div>
 
-    : <dfn>dispatch(workgroupCountX, workgroupCountY, workgroupCountZ)</dfn>
+    : <dfn>dispatchWorkgroups(workgroupCountX, workgroupCountY, workgroupCountZ)</dfn>
     ::
         Dispatch work to be performed with the current {{GPUComputePipeline}}.
         See [[#computing-operations]] for the detailed specification.
@@ -7474,11 +7474,25 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
             **Called on:** {{GPUComputePassEncoder}} this.
 
             **Arguments:**
-            <pre class=argumentdef for="GPUComputePassEncoder/dispatch(workgroupCountX, workgroupCountY, workgroupCountZ)">
+            <pre class=argumentdef for="GPUComputePassEncoder/dispatchWorkgroups(workgroupCountX, workgroupCountY, workgroupCountZ)">
                 |workgroupCountX|: X dimension of the grid of workgroups to dispatch.
                 |workgroupCountY|: Y dimension of the grid of workgroups to dispatch.
                 |workgroupCountZ|: Z dimension of the grid of workgroups to dispatch.
             </pre>
+
+            <div class=note>
+                Note: The `x`, `y`, and `z` values passed to {{GPUComputePassEncoder/dispatchWorkgroups()}}
+                and {{GPUComputePassEncoder/dispatchWorkgroupsIndirect()}} are the number of
+                *workgroups* to dispatch for each dimension, *not* the number of shader invocations
+                to perform across each dimension. This matches the behavior of modern native GPU
+                APIs, but differs from the behavior of OpenCL.
+
+                This means that if a {{GPUShaderModule}} defines an entry point with
+                `@workgroup_size(4, 4)`, and work is dispatched to it with the call
+                `computePass.dispatchWorkgroups(8, 8);` the entry point will be invoked 1024 times
+                total: Dispatching a 4x4 workgroup 8 times along both the X and Y axes.
+                (`4*4*8*8=1024`)
+            </div>
 
             **Returns:** {{undefined}}
 
@@ -7504,7 +7518,7 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
             </div>
         </div>
 
-    : <dfn>dispatchIndirect(indirectBuffer, indirectOffset)</dfn>
+    : <dfn>dispatchWorkgroupsIndirect(indirectBuffer, indirectOffset)</dfn>
     ::
         Dispatch work to be performed with the current {{GPUComputePipeline}} using parameters read
         from a {{GPUBuffer}}.
@@ -7512,7 +7526,8 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
 
         The <dfn dfn for=>indirect dispatch parameters</dfn> encoded in the buffer must be a tightly
         packed block of **three 32-bit unsigned integer values (12 bytes total)**,
-        given in the same order as the arguments for {{GPUComputePassEncoder/dispatch()}}. For example:
+        given in the same order as the arguments for {{GPUComputePassEncoder/dispatchWorkgroups()}}.
+        For example:
 
         <pre highlight="js">
             let dispatchIndirectParameters = new Uint32Array(3);
@@ -7525,7 +7540,7 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
             **Called on:** {{GPUComputePassEncoder}} this.
 
             **Arguments:**
-            <pre class=argumentdef for="GPUComputePassEncoder/dispatchIndirect(indirectBuffer, indirectOffset)">
+            <pre class=argumentdef for="GPUComputePassEncoder/dispatchWorkgroupsIndirect(indirectBuffer, indirectOffset)">
                 |indirectBuffer|: Buffer containing the [=indirect dispatch parameters=].
                 |indirectOffset|: Offset in bytes into |indirectBuffer| where the dispatch data begins.
             </pre>
@@ -7552,18 +7567,6 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
             no workgroups will be dispatched.
         </div>
 </dl>
-
-<div class=note>
-Note: The `x`, `y`, and `z` values passed to {{GPUComputePassEncoder/dispatch()}} and
-{{GPUComputePassEncoder/dispatchIndirect()}} are the number of *workgroups* to dispatch for each
-dimension, *not* the number of shader invocations to perform across each dimension. This matches the
-behavior of modern native GPU APIs, but differs from the behavior of OpenCL.
-
-This means that if a {{GPUShaderModule}} defines an entry point with `@workgroup_size(4, 4)`, and
-work is dispatched to it with the call `computePass.dispatch(8, 8);` the entry point will be invoked
-1024 times total: Dispatching of a 4x4 workgroup 8 times along both the X and Y axes.
-(`4*4*8*8=1024`)
-</div>
 
 ### Finalization ### {#compute-pass-encoder-finalization}
 
@@ -9951,8 +9954,8 @@ Compute shaders do not have pipeline inputs or outputs, their results are
 side effects from writing data into storage bindings bound as
 {{GPUBufferBindingType/"storage"|GPUBufferBindingType."storage"}} and {{GPUStorageTextureBindingLayout}}.
 These operations are encoded within {{GPUComputePassEncoder}} as:
-  - {{GPUComputePassEncoder/dispatch()}}
-  - {{GPUComputePassEncoder/dispatchIndirect()}}
+  - {{GPUComputePassEncoder/dispatchWorkgroups()}}
+  - {{GPUComputePassEncoder/dispatchWorkgroupsIndirect()}}
 
 Issue: describe the computing algorithm
 


### PR DESCRIPTION
Fixes #2669

Given that there doesn't seem to be any outrage at the idea of renaming these methods, here's a spec PR to make it happen.

Also took the opportunity to clean up a little bit of formatting and move the note explaining the application of the workgroup counts into the `dispatchWorkgroups()` algorithm description so that it's more easily noticed by anyone looking at the spec for reference.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/2689.html" title="Last updated on Mar 24, 2022, 8:51 PM UTC (311e8d7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2689/3dbb796...311e8d7.html" title="Last updated on Mar 24, 2022, 8:51 PM UTC (311e8d7)">Diff</a>