### PR TITLE
Add texel block size column to format tables

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -10953,8 +10953,9 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
             <th>multisampling
             <th>resolve
             <th>{{GPUTextureUsage/STORAGE_BINDING}}
+            <th>[=Texel block size=]
     </thead>
-    <tr><th class=stickyheader>8-bit per component<th><th><th><th><th>
+    <tr><th class=stickyheader>8-bit per component<th><th><th><th><th><th>
     <tr>
         <td>{{GPUTextureFormat/r8unorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -10962,6 +10963,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>&checkmark;
         <td>
+        <td>1
     <tr>
         <td>{{GPUTextureFormat/r8snorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -10969,6 +10971,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>
         <td><!-- Vulkan -->
+        <td>1
     <tr>
         <td>{{GPUTextureFormat/r8uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -10976,6 +10979,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
+        <td>1
     <tr>
         <td>{{GPUTextureFormat/r8sint}}
         <td>{{GPUTextureSampleType/"sint"}}
@@ -10983,6 +10987,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
+        <td>1
     <tr>
         <td>{{GPUTextureFormat/rg8unorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -10990,6 +10995,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>&checkmark;
         <td><!-- Vulkan -->
+        <td>2
     <tr>
         <td>{{GPUTextureFormat/rg8snorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -10997,6 +11003,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>
         <td><!-- Vulkan -->
+        <td>2
     <tr>
         <td>{{GPUTextureFormat/rg8uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -11004,6 +11011,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
+        <td>2
     <tr>
         <td>{{GPUTextureFormat/rg8sint}}
         <td>{{GPUTextureSampleType/"sint"}}
@@ -11011,6 +11019,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
+        <td>2
     <tr>
         <td>{{GPUTextureFormat/rgba8unorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -11018,6 +11027,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
+        <td>4
     <tr>
         <td>{{GPUTextureFormat/rgba8unorm-srgb}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -11025,6 +11035,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>&checkmark;
         <td>
+        <td>4
     <tr>
         <td>{{GPUTextureFormat/rgba8snorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -11032,6 +11043,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>
         <td>&checkmark;
+        <td>4
     <tr>
         <td>{{GPUTextureFormat/rgba8uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -11039,6 +11051,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td><!-- Metal -->
         <td>&checkmark;
+        <td>4
     <tr>
         <td>{{GPUTextureFormat/rgba8sint}}
         <td>{{GPUTextureSampleType/"sint"}}
@@ -11046,6 +11059,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td><!-- Metal -->
         <td>&checkmark;
+        <td>4
     <tr>
         <td>{{GPUTextureFormat/bgra8unorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -11053,6 +11067,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>&checkmark;
         <td>
+        <td>4
     <tr>
         <td>{{GPUTextureFormat/bgra8unorm-srgb}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -11060,7 +11075,8 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>&checkmark;
         <td>
-    <tr><th class=stickyheader>16-bit per component<th><th><th><th><th>
+        <td>4
+    <tr><th class=stickyheader>16-bit per component<th><th><th><th><th><th>
     <tr>
         <td>{{GPUTextureFormat/r16uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -11068,6 +11084,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
+        <td>2
     <tr>
         <td>{{GPUTextureFormat/r16sint}}
         <td>{{GPUTextureSampleType/"sint"}}
@@ -11075,6 +11092,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
+        <td>2
     <tr>
         <td>{{GPUTextureFormat/r16float}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -11082,6 +11100,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>&checkmark;
         <td>
+        <td>2
     <tr>
         <td>{{GPUTextureFormat/rg16uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -11089,6 +11108,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
+        <td>4
     <tr>
         <td>{{GPUTextureFormat/rg16sint}}
         <td>{{GPUTextureSampleType/"sint"}}
@@ -11096,6 +11116,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
+        <td>4
     <tr>
         <td>{{GPUTextureFormat/rg16float}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -11103,6 +11124,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>&checkmark;
         <td><!-- Vulkan -->
+        <td>4
     <tr>
         <td>{{GPUTextureFormat/rgba16uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -11110,6 +11132,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td><!-- Metal -->
         <td>&checkmark;
+        <td>8
     <tr>
         <td>{{GPUTextureFormat/rgba16sint}}
         <td>{{GPUTextureSampleType/"sint"}}
@@ -11117,6 +11140,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td><!-- Metal -->
         <td>&checkmark;
+        <td>8
     <tr>
         <td>{{GPUTextureFormat/rgba16float}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -11124,7 +11148,8 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
-    <tr><th class=stickyheader>32-bit per component<th><th><th><th><th>
+        <td>8
+    <tr><th class=stickyheader>32-bit per component<th><th><th><th><th><th>
     <tr>
         <td>{{GPUTextureFormat/r32uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -11132,6 +11157,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
+        <td>4
     <tr>
         <td>{{GPUTextureFormat/r32sint}}
         <td>{{GPUTextureSampleType/"sint"}}
@@ -11139,6 +11165,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
+        <td>4
     <tr>
         <td>{{GPUTextureFormat/r32float}}
         <td>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -11146,6 +11173,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td><!-- Metal -->
         <td>&checkmark;
+        <td>4
     <tr>
         <td>{{GPUTextureFormat/rg32uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -11153,6 +11181,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
+        <td>8
     <tr>
         <td>{{GPUTextureFormat/rg32sint}}
         <td>{{GPUTextureSampleType/"sint"}}
@@ -11160,6 +11189,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
+        <td>8
     <tr>
         <td>{{GPUTextureFormat/rg32float}}
         <td>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -11167,6 +11197,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
+        <td>8
     <tr>
         <td>{{GPUTextureFormat/rgba32uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -11174,6 +11205,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
+        <td>16
     <tr>
         <td>{{GPUTextureFormat/rgba32sint}}
         <td>{{GPUTextureSampleType/"sint"}}
@@ -11181,6 +11213,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
+        <td>16
     <tr>
         <td>{{GPUTextureFormat/rgba32float}}
         <td>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -11188,7 +11221,8 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
-    <tr><th class=stickyheader>mixed component width<th><th><th><th><th>
+        <td>16
+    <tr><th class=stickyheader>mixed component width<th><th><th><th><th><th>
     <tr>
         <td>{{GPUTextureFormat/rgb10a2unorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -11196,6 +11230,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>&checkmark;
         <td>
+        <td>4
     <tr>
         <td>{{GPUTextureFormat/rg11b10ufloat}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -11203,6 +11238,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>
         <td><!-- Vulkan -->
+        <td>4
 
 </table>
 
@@ -11228,6 +11264,7 @@ None of the depth formats can be filtered.
             <th>{{GPUTextureSampleType}}
             <th>Valid [=image copy=] source
             <th>Valid [=image copy=] destination
+            <th>[=Texel block size=]
     </thead>
     <tr>
         <td>{{GPUTextureFormat/stencil8}}
@@ -11235,28 +11272,33 @@ None of the depth formats can be filtered.
         <td>stencil
         <td>{{GPUTextureSampleType/"uint"}}
         <td colspan=2>&checkmark;
+        <td>1
     <tr>
         <td>{{GPUTextureFormat/depth16unorm}}
         <td>2
         <td>depth
         <td>{{GPUTextureSampleType/"depth"}}
         <td colspan=2>&checkmark;
+        <td>2
     <tr>
         <td>{{GPUTextureFormat/depth24plus}}
         <td>4
         <td>depth
         <td>{{GPUTextureSampleType/"depth"}}
         <td colspan=2>&cross;
+        <td>See prose
     <tr>
         <td rowspan=2 style='white-space:nowrap'>{{GPUTextureFormat/depth24plus-stencil8}}
         <td rowspan=2>4 &minus; 8
         <td>depth
         <td>{{GPUTextureSampleType/"depth"}}
         <td colspan=2>&cross;
+        <td>See prose
     <tr>
         <td>stencil
         <td>{{GPUTextureSampleType/"uint"}}
         <td colspan=2>&checkmark;
+        <td>1
     <tr>
         <td>{{GPUTextureFormat/depth32float}}
         <td>4
@@ -11264,16 +11306,19 @@ None of the depth formats can be filtered.
         <td>{{GPUTextureSampleType/"depth"}}
         <td colspan=1>&checkmark;
         <td colspan=1>&cross;
+        <td>4
     <tr>
         <td rowspan=2 style='white-space:nowrap'>{{GPUTextureFormat/depth24unorm-stencil8}}
         <td rowspan=2>4
         <td>depth
         <td>{{GPUTextureSampleType/"depth"}}
         <td colspan=2>&cross;
+        <td>3
     <tr>
         <td>stencil
         <td>{{GPUTextureSampleType/"uint"}}
         <td colspan=2>&checkmark;
+        <td>1
     <tr>
         <td rowspan=2 style='white-space:nowrap'>{{GPUTextureFormat/depth32float-stencil8}}
         <td rowspan=2>5 &minus; 8
@@ -11281,10 +11326,12 @@ None of the depth formats can be filtered.
         <td>{{GPUTextureSampleType/"depth"}}
         <td colspan=1>&checkmark;
         <td colspan=1>&cross;
+        <td>4
     <tr>
         <td>stencil
         <td>{{GPUTextureSampleType/"uint"}}
         <td colspan=2>&checkmark;
+        <td>1
 </table>
 
 #### Reading and Sampling Depth/Stencil Textures #### {#reading-depth-stencil}
@@ -11338,6 +11385,8 @@ and {{GPUTextureUsage/TEXTURE_BINDING}} usages. All of these formats have {{GPUT
 type and can be filtered on sampling. None of these formats support multisampling.
 
 A <dfn dfn>compressed format</dfn> is any format with a block size greater than 1 &times; 1.
+
+The [=texel block size=] of a packed format is equal to the Bytes per block column below.
 
 <table class='data'>
     <thead class=stickyheader>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3201,9 +3201,9 @@ enum GPUTextureFormat {
 };
 </script>
 
-The depth component of the {{GPUTextureFormat/"depth24plus"}}) and {{GPUTextureFormat/"depth24plus-stencil8"}})
+<span id="depthPlus">The depth component of the {{GPUTextureFormat/"depth24plus"}}) and {{GPUTextureFormat/"depth24plus-stencil8"}})
 formats may be implemented as either a 24-bit unsigned normalized value (like "depth24unorm" in {{GPUTextureFormat/"depth24unorm-stencil8"}})
-or a 32-bit IEEE 754 floating point value (like {{GPUTextureFormat/"depth32float"}}).
+or a 32-bit IEEE 754 floating point value (like {{GPUTextureFormat/"depth32float"}}).</span>
 
 Issue: add something on GPUAdapter(?) that gives an estimate of the bytes per texel of
 {{GPUTextureFormat/"stencil8"}}, {{GPUTextureFormat/"depth24plus-stencil8"}}, and {{GPUTextureFormat/"depth32float-stencil8"}}.
@@ -10953,7 +10953,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
             <th>multisampling
             <th>resolve
             <th>{{GPUTextureUsage/STORAGE_BINDING}}
-            <th>[=Texel block size=]
+            <th>[=Texel block size=] (Bytes)
     </thead>
     <tr><th class=stickyheader>8-bit per component<th><th><th><th><th><th>
     <tr>
@@ -11261,77 +11261,77 @@ None of the depth formats can be filtered.
             <th>Format
             <th>Bytes per texel
             <th>Aspect
+            <th>[=Texel block size=] (Bytes)
             <th>{{GPUTextureSampleType}}
             <th>Valid [=image copy=] source
             <th>Valid [=image copy=] destination
-            <th>[=Texel block size=]
     </thead>
     <tr>
         <td>{{GPUTextureFormat/stencil8}}
         <td>1 &minus; 4
         <td>stencil
+        <td>1
         <td>{{GPUTextureSampleType/"uint"}}
         <td colspan=2>&checkmark;
-        <td>1
     <tr>
         <td>{{GPUTextureFormat/depth16unorm}}
         <td>2
         <td>depth
+        <td>2
         <td>{{GPUTextureSampleType/"depth"}}
         <td colspan=2>&checkmark;
-        <td>2
     <tr>
         <td>{{GPUTextureFormat/depth24plus}}
         <td>4
         <td>depth
+        <td>- (<a href="#depthPlus">See prose</a>)
         <td>{{GPUTextureSampleType/"depth"}}
         <td colspan=2>&cross;
-        <td>See prose
     <tr>
         <td rowspan=2 style='white-space:nowrap'>{{GPUTextureFormat/depth24plus-stencil8}}
         <td rowspan=2>4 &minus; 8
         <td>depth
+        <td>- (<a href="#depthPlus">See prose</a>)
         <td>{{GPUTextureSampleType/"depth"}}
         <td colspan=2>&cross;
-        <td>See prose
     <tr>
         <td>stencil
+        <td>1
         <td>{{GPUTextureSampleType/"uint"}}
         <td colspan=2>&checkmark;
-        <td>1
     <tr>
         <td>{{GPUTextureFormat/depth32float}}
         <td>4
         <td>depth
+        <td>4
         <td>{{GPUTextureSampleType/"depth"}}
         <td colspan=1>&checkmark;
         <td colspan=1>&cross;
-        <td>4
     <tr>
         <td rowspan=2 style='white-space:nowrap'>{{GPUTextureFormat/depth24unorm-stencil8}}
         <td rowspan=2>4
         <td>depth
+        <td>3
         <td>{{GPUTextureSampleType/"depth"}}
         <td colspan=2>&cross;
-        <td>3
     <tr>
         <td>stencil
+        <td>1
         <td>{{GPUTextureSampleType/"uint"}}
         <td colspan=2>&checkmark;
-        <td>1
     <tr>
         <td rowspan=2 style='white-space:nowrap'>{{GPUTextureFormat/depth32float-stencil8}}
         <td rowspan=2>5 &minus; 8
         <td>depth
+        <td>4
         <td>{{GPUTextureSampleType/"depth"}}
         <td colspan=1>&checkmark;
         <td colspan=1>&cross;
-        <td>4
     <tr>
         <td>stencil
+        <td>1
         <td>{{GPUTextureSampleType/"uint"}}
         <td colspan=2>&checkmark;
-        <td>1
 </table>
 
 #### Reading and Sampling Depth/Stencil Textures #### {#reading-depth-stencil}
@@ -11386,7 +11386,7 @@ type and can be filtered on sampling. None of these formats support multisamplin
 
 A <dfn dfn>compressed format</dfn> is any format with a block size greater than 1 &times; 1.
 
-The [=texel block size=] of a packed format is equal to the Bytes per block column below.
+The [=texel block size=] (in bytes) of a packed format is equal to the Bytes per block column below.
 
 <table class='data'>
     <thead class=stickyheader>


### PR DESCRIPTION
For the "Plain color formats" section, this is new information.

For the "Depth-stencil formats" section, this is different than the existing "Bytes per texel" column. "Bytes per texel" describes the in-memory storage use, whereas "texel block size" describes the values that copy commands validate against.

For the "Packed formats" section, the "Bytes per block" column matches the "texel block size" values, so this patch just adds a single sentence stating that.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/litherum/gpuweb/pull/2693.html" title="Last updated on Mar 25, 2022, 10:02 PM UTC (4a82ec1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2693/edf869a...litherum:4a82ec1.html" title="Last updated on Mar 25, 2022, 10:02 PM UTC (4a82ec1)">Diff</a>