### PR TITLE
Fix typo: Code point should always be split

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5006,7 +5006,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
 
         Note: A user agent or should issue developer-visible warnings when the meaning of a
         WGSL program would change if all instances of an identifier spelled with a specific
-        codepoint sequence are replaced by another codepoint sequence
+        code point sequence are replaced by another code point sequence
         that would appear the same to a reader.
 
         Values are specified as <dfn typedef for=>GPUPipelineConstantValue</dfn>, which is a

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -561,8 +561,8 @@ of both [=UAX31 Lexical Classes|XID_Start=] and
 
 Note: A user agent or should issue developer-visible warnings when
 the meaning of a WGSL program would change if all instances of an
-identifier spelled with a specific codepoint sequence are replaced
-by another codepoint sequence that would appear the same to a reader.
+identifier spelled with a specific code point sequence are replaced
+by another code point sequence that would appear the same to a reader.
 For example, remapping each identifier to its canonical equivalent
 spelling under [=UAX15 Normalization Forms|Normalization Form C (NFC)=]
 must permit the same set of declarations (avoiding new identifier collisions),


### PR DESCRIPTION
Unicode Glossary at https://unicode.org/glossary/ makes it clear that code point should never be codepoint without space.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mehmetoguzderin/gpuweb/pull/2695.html" title="Last updated on Mar 25, 2022, 2:32 PM UTC (40f88b7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2695/edf869a...mehmetoguzderin:40f88b7.html" title="Last updated on Mar 25, 2022, 2:32 PM UTC (40f88b7)">Diff</a>