### PR TITLE
FP16 Extension against spec

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5148,8 +5148,8 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         ({{boolean}}, {{long}}, {{unsigned long}}, or {{float}}).
         If the {{GPUFeatureName/"shader-f16"}} [=feature=] is enabled, a
         pipeline-overridable constant may be of WGSL data type `f16`. The specified
-        {{GPUPipelineConstantValue}} for a pipeline-overridable constant of `f16` is convert to
-        {{float}} via [=converted to an IDL value|an IDL value=], then convert to WGSL type `f16`
+        {{GPUPipelineConstantValue}} for a pipeline-overridable constant of `f16` is converted to
+        {{float}} via [=converted to an IDL value|an IDL value=], then converted to WGSL type `f16`
         via WGSL f32 to f16 conversion defined in [=WGSL floating point conversion|WGSL specification=].
 
         <div class=example>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1883,6 +1883,7 @@ enum GPUFeatureName {
     "texture-compression-astc",
     "timestamp-query",
     "indirect-first-instance",
+    "fp16-in-shader-and-buffer",
 };
 </script>
 
@@ -5013,6 +5014,11 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         `double` which is converted to the WGSL data type of the corresponding pipeline-overridable
         constant (`bool`, `i32`, `u32`, or `f32`) via [=converted to an IDL value|an IDL value=]
         ({{boolean}}, {{long}}, {{unsigned long}}, or {{float}}).
+        If the {{GPUFeatureName/"fp16-in-shader-and-buffer"}} [=feature=] is enabled, a
+        pipeline-overridable constant may be of WGSL data type `f16`. The specified
+        <dfn typedef for=>GPUPipelineConstantValue</dfn> for a pipeline-overridable constant of
+        `f16` is convert to {{float}} via [=converted to an IDL value|an IDL value=], then convert
+        to WGSL type `f16` via IEEE-754 binary32 to IEEE-754 binary16 conversion.
 
         <div class=example>
             Pipeline-overridable constants defined in WGSL:
@@ -10929,6 +10935,10 @@ The following enums are supported if and only if the {{GPUFeatureName/"timestamp
 
 Removes the zero value restriction on `firstInstance` in [=indirect draw parameters=] and [=indirect drawIndexed parameters=].
 `firstInstance` is allowed to be non-zero if and only if the {{GPUFeatureName/"indirect-first-instance"}} [=feature=] is enabled.
+
+## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>"fp16-in-shader-and-buffer"</dfn> ## {#indirect-first-instance}
+
+Using "`enable f16;`" directive in WGSL code for a shader module is allowed if and only if the {{GPUFeatureName/"fp16-in-shader-and-buffer"}} [=feature=] is enabled; otherwise using it must result in a compilation error when creating shader module.
 
 # Appendices # {#appendices}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5016,9 +5016,9 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         ({{boolean}}, {{long}}, {{unsigned long}}, or {{float}}).
         If the {{GPUFeatureName/"fp16-in-shader-and-buffer"}} [=feature=] is enabled, a
         pipeline-overridable constant may be of WGSL data type `f16`. The specified
-        <dfn typedef for=>GPUPipelineConstantValue</dfn> for a pipeline-overridable constant of
-        `f16` is convert to {{float}} via [=converted to an IDL value|an IDL value=], then convert
-        to WGSL type `f16` via IEEE-754 binary32 to IEEE-754 binary16 conversion.
+        [=GPUPipelineConstantValue=] for a pipeline-overridable constant of `f16` is convert to
+        {{float}} via [=converted to an IDL value|an IDL value=], then convert to WGSL type `f16`
+        via IEEE-754 binary32 to IEEE-754 binary16 conversion.
 
         <div class=example>
             Pipeline-overridable constants defined in WGSL:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4987,7 +4987,7 @@ dictionary GPUProgrammableStage {
     record<USVString, GPUPipelineConstantValue> constants;
 };
 
-typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32, u32.
+typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32, u32, and f16 if enabled.
 </script>
 
 <dl dfn-for=GPUProgrammableStage dfn-type=dict-member>
@@ -5016,7 +5016,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         ({{boolean}}, {{long}}, {{unsigned long}}, or {{float}}).
         If the {{GPUFeatureName/"fp16-in-shader-and-buffer"}} [=feature=] is enabled, a
         pipeline-overridable constant may be of WGSL data type `f16`. The specified
-        [=GPUPipelineConstantValue=] for a pipeline-overridable constant of `f16` is convert to
+        {{GPUPipelineConstantValue}} for a pipeline-overridable constant of `f16` is convert to
         {{float}} via [=converted to an IDL value|an IDL value=], then convert to WGSL type `f16`
         via IEEE-754 binary32 to IEEE-754 binary16 conversion.
 
@@ -5026,7 +5026,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
             <pre highlight=rust>
                 @id(0)    override has_point_light: bool = true; // Algorithmic control.
                 @id(1200) override specular_param: f32 = 2.3;    // Numeric control.
-                @id(1300) override gain: f32;                    // Must be overridden.
+                @id(1300) override gain: f32;                    // Muqst be overridden.
                           override width: f32 = 0.0;             // Specifed at the API level
                                                                  //   using the name "width".
                           override depth: f32;                   // Specifed at the API level

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -10936,7 +10936,7 @@ The following enums are supported if and only if the {{GPUFeatureName/"timestamp
 Removes the zero value restriction on `firstInstance` in [=indirect draw parameters=] and [=indirect drawIndexed parameters=].
 `firstInstance` is allowed to be non-zero if and only if the {{GPUFeatureName/"indirect-first-instance"}} [=feature=] is enabled.
 
-## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>"fp16-in-shader-and-buffer"</dfn> ## {#indirect-first-instance}
+## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>"fp16-in-shader-and-buffer"</dfn> ## {#fp16-in-shader-and-buffer}
 
 Using "`enable f16;`" directive in WGSL code for a shader module is allowed if and only if the {{GPUFeatureName/"fp16-in-shader-and-buffer"}} [=feature=] is enabled; otherwise using it must result in a compilation error when creating shader module.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -101,6 +101,7 @@ spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
         text: store type; url: store-type
         text: runtime-sized; url: runtime-sized
         text: SizeOf; url: sizeof
+        text: WGSL floating point conversion; url: floating-point-conversion
 spec: UAX15; urlPrefix: https://www.unicode.org/reports/tr15/tr15-51.html
     type: dfn
         text: Unicode Standard Annex #15 for Unicode Version 14.0.0
@@ -1905,7 +1906,7 @@ enum GPUFeatureName {
     "texture-compression-astc",
     "timestamp-query",
     "indirect-first-instance",
-    "fp16-in-shader-and-buffer",
+    "shader-f16",
 };
 </script>
 
@@ -5038,11 +5039,11 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         `double` which is converted to the WGSL data type of the corresponding pipeline-overridable
         constant (`bool`, `i32`, `u32`, or `f32`) via [=converted to an IDL value|an IDL value=]
         ({{boolean}}, {{long}}, {{unsigned long}}, or {{float}}).
-        If the {{GPUFeatureName/"fp16-in-shader-and-buffer"}} [=feature=] is enabled, a
+        If the {{GPUFeatureName/"shader-f16"}} [=feature=] is enabled, a
         pipeline-overridable constant may be of WGSL data type `f16`. The specified
         {{GPUPipelineConstantValue}} for a pipeline-overridable constant of `f16` is convert to
         {{float}} via [=converted to an IDL value|an IDL value=], then convert to WGSL type `f16`
-        via IEEE-754 binary32 to IEEE-754 binary16 conversion.
+        via WGSL f32 to f16 conversion defined in [=WGSL floating point conversion|WGSL specification=].
 
         <div class=example>
             Pipeline-overridable constants defined in WGSL:
@@ -5050,7 +5051,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
             <pre highlight=rust>
                 @id(0)    override has_point_light: bool = true; // Algorithmic control.
                 @id(1200) override specular_param: f32 = 2.3;    // Numeric control.
-                @id(1300) override gain: f32;                    // Muqst be overridden.
+                @id(1300) override gain: f32;                    // Must be overridden.
                           override width: f32 = 0.0;             // Specifed at the API level
                                                                  //   using the name "width".
                           override depth: f32;                   // Specifed at the API level
@@ -10955,9 +10956,9 @@ The following enums are supported if and only if the {{GPUFeatureName/"timestamp
 Removes the zero value restriction on `firstInstance` in [=indirect draw parameters=] and [=indirect drawIndexed parameters=].
 `firstInstance` is allowed to be non-zero if and only if the {{GPUFeatureName/"indirect-first-instance"}} [=feature=] is enabled.
 
-## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>"fp16-in-shader-and-buffer"</dfn> ## {#fp16-in-shader-and-buffer}
+## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>"shader-f16"</dfn> ## {#shader-f16}
 
-Using "`enable f16;`" directive in WGSL code for a shader module is allowed if and only if the {{GPUFeatureName/"fp16-in-shader-and-buffer"}} [=feature=] is enabled; otherwise using it must result in a compilation error when creating shader module.
+Using "`enable f16;`" directive in WGSL code for a shader module is allowed if and only if the {{GPUFeatureName/"shader-f16"}} [=feature=] is enabled; otherwise using it must result in a compilation error when creating shader module.
 
 # Appendices # {#appendices}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -11,8 +11,8 @@ Text Macro: INT i32 or u32
 Text Macro: UNSIGNEDINTEGRAL u32 or vec|N|&lt;u32&gt;
 Text Macro: SIGNEDINTEGRAL i32 or vec|N|&lt;i32&gt;
 Text Macro: INTEGRAL i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;
-Text Macro: FLOATING f32 or vec|N|&lt;f32&gt;
-Text Macro: NUMERIC i32, u32, f32, vec|N|&lt;i32&gt;, vec|N|&lt;u32&gt;, or vec|N|&lt;f32&gt;
+Text Macro: FLOATING f32, f16, vec|N|&lt;f32&gt;, or vec|N|&lt;f16&gt;
+Text Macro: NUMERIC i32, u32, f32, f16, vec|N|&lt;i32&gt;, vec|N|&lt;u32&gt;, vec|N|&lt;f32&gt;, or vec|N|&lt;f16&gt;
 Ignored Vars: i, c0, e, e1, e2, e3, eN, p, s1, s2, sn, N, M, v, Stride, Offset, Align, Extent, S, T, T1
 
 !Participate: <a href="https://github.com/gpuweb/gpuweb/issues/new?labels=wgsl">File an issue</a> (<a href="https://github.com/gpuweb/gpuweb/issues?q=is%3Aissue+is%3Aopen+label%3Awgsl">open issues</a>)
@@ -827,8 +827,9 @@ A value's type determines the syntax and semantics of operations that can be per
 
 For example, the mathematical number 1 corresponds to three distinct values in WGSL:
 * the 32-bit signed integer value `1`,
-* the 32-bit unsigned integer value `1u`, and
-* the 32-bit floating point value `1.0`.
+* the 32-bit unsigned integer value `1u`,
+* the 32-bit floating point value `1.0`, and
+* the 16-bit floating point value `1.0`, if `f16` extension is enabled.
 
 WGSL treats these as different because their machine representation and operations differ.
 
@@ -899,7 +900,7 @@ A <dfn noexport>type rule</dfn> has two parts:
 
 Each distinct type parameterization for a type rule is called an <dfn noexport>overload</dfn>.
 For example, [[#arithmetic-expr|unary negation]] (an expression of the form `-`|e|)
-has eight overloads, because its type rules are parameterized by a type |T| that can be any of:
+has twelve overloads, because its type rules are parameterized by a type |T| that can be any of:
 * [=i32=]
 * vec2&lt;i32&gt;
 * vec3&lt;i32&gt;
@@ -908,6 +909,10 @@ has eight overloads, because its type rules are parameterized by a type |T| that
 * vec2&lt;f32&gt;
 * vec3&lt;f32&gt;
 * vec4&lt;f32&gt;
+* [=f16=]
+* vec2&lt;f16&gt;
+* vec3&lt;f16&gt;
+* vec4&lt;f16&gt;
 
 A <dfn noexport>type rule applies to an expression</dfn> when:
 * The rule's conclusion matches a valid parse of the expression, and
@@ -968,11 +973,13 @@ It uses a two's complementation representation, with the sign bit in the most si
 The <dfn noexport>f32</dfn> type is the set of 32-bit floating point values of the [[!IEEE-754|IEEE-754]] binary32 (single precision) format.
 See [[#floating-point-evaluation]] for details.
 
+The <dfn noexport>f16</dfn> type is the set of 16-bit floating point values of the [[!IEEE-754|IEEE-754]] binary16 (half precision) format. Using [=f16=] type is allowed if and only if the program has an "enable f16;" directive, otherwise there is a shader-creation error. The support for "enable f16;" directive is optional. See [[#floating-point-evaluation]] for details.
+
 ### Scalar Types ### {#scalar-types}
 
-The <dfn noexport>scalar</dfn> types are [=bool=], [=i32=], [=u32=], and [=f32=].
+The <dfn noexport>scalar</dfn> types are [=bool=], [=i32=], [=u32=], [=f32=], and [=f16=].
 
-The <dfn noexport>numeric scalar</dfn> types are [=i32=], [=u32=], and [=f32=].
+The <dfn noexport>numeric scalar</dfn> types are [=i32=], [=u32=], [=f32=], and [=f16=].
 
 The <dfn noexport>integer scalar</dfn> types are [=i32=] and [=u32=].
 
@@ -1027,9 +1034,9 @@ A <dfn noexport>matrix</dfn> is a grouped sequence of 2, 3, or 4 floating point 
     <tr><th>Type<th>Description
   </thead>
   <tr algorithm="matrix type">
-    <td>mat|N|x|M|&lt;f32&gt;
-    <td>Matrix of |N| columns and |M| rows, where |N| and |M| are both in {2, 3, 4}.
-        Equivalently, it can be viewed as |N| column vectors of type vec|M|&lt;f32&gt;.
+    <td>mat|N|x|M|&lt;|T|&gt;
+    <td>Matrix of |N| columns and |M| rows of type |T|, where |N| and |M| are both in {2, 3, 4}, and |T| must be f32 or f16.
+        Equivalently, it can be viewed as |N| column vectors of type vec|M|&lt;*T*&gt;.
 </table>
 
 The key use case for a matrix is to embody a linear transformation.
@@ -1639,18 +1646,30 @@ following table:
   <tr><td>[=i32=], [=u32=], or [=f32=]
       <td>4
       <td>4
+  <tr><td>[=f16=]
+      <td>2
+      <td>2
   <tr><td>atomic&lt;|T|&gt;
       <td>4
       <td>4
-  <tr><td>vec2&lt;|T|&gt;
+  <tr><td>vec2&lt;|T|&gt;, |T| is [=i32=], [=u32=], or [=f32=]
       <td>8
       <td>8
-  <tr><td>vec3&lt;|T|&gt;
+  <tr><td>vec2&lt;f16&gt;
+      <td>4
+      <td>4
+  <tr><td>vec3&lt;|T|&gt;, |T| is [=i32=], [=u32=], or [=f32=]
       <td>16
       <td>12
-  <tr><td>vec4&lt;|T|&gt;
+  <tr><td>vec3&lt;f16&gt;
+      <td>8
+      <td>6
+  <tr><td>vec4&lt;|T|&gt;, |T| is [=i32=], [=u32=], or [=f32=]
       <td>16
       <td>16
+  <tr><td>vec4&lt;f16&gt;
+      <td>8
+      <td>8
   <tr><td>mat|N|x|M| (col-major)<br>
       <p class="small">(General form)</p>
       <td>[=AlignOf=](vec|M|)
@@ -1658,30 +1677,57 @@ following table:
   <tr><td>mat2x2&lt;f32&gt;
       <td>8
       <td>16
+  <tr><td>mat2x2&lt;f16&gt;
+      <td>4
+      <td>8
   <tr><td>mat3x2&lt;f32&gt;
       <td>8
       <td>24
+  <tr><td>mat3x2&lt;f16&gt;
+      <td>4
+      <td>12
   <tr><td>mat4x2&lt;f32&gt;
       <td>8
       <td>32
+  <tr><td>mat4x2&lt;f16&gt;
+      <td>4
+      <td>16
   <tr><td>mat2x3&lt;f32&gt;
       <td>16
       <td>32
+  <tr><td>mat2x3&lt;f16&gt;
+      <td>8
+      <td>16
   <tr><td>mat3x3&lt;f32&gt;
       <td>16
       <td>48
+  <tr><td>mat3x3&lt;f16&gt;
+      <td>8
+      <td>24
   <tr><td>mat4x3&lt;f32&gt;
       <td>16
       <td>64
+  <tr><td>mat4x3&lt;f16&gt;
+      <td>8
+      <td>32
   <tr><td>mat2x4&lt;f32&gt;
       <td>16
       <td>32
+  <tr><td>mat2x4&lt;f16&gt;
+      <td>8
+      <td>16
   <tr><td>mat3x4&lt;f32&gt;
       <td>16
       <td>48
+  <tr><td>mat3x4&lt;f16&gt;
+      <td>8
+      <td>24
   <tr><td>mat4x4&lt;f32&gt;
       <td>16
       <td>64
+  <tr><td>mat4x4&lt;f16&gt;
+      <td>8
+      <td>32
   <tr><td>struct |S| with members M<sub>1</sub>...M<sub>N</sub>
       <td>max([=AlignOfMember=](S,1), ... , [=AlignOfMember=](S,N))<br>
       <td>[=roundUp=]([=AlignOf=](|S|), justPastLastMember)<br><br>
@@ -1868,6 +1914,14 @@ When |V| is placed at byte offset |k| of host-shared buffer, then:
    * Bits 0 through 6 of byte |k|+3 contain bits 1 through 7 of the exponent.
    * Bit 7 of byte |k|+3 contains the sign bit.
 
+A value |V| of type [=f16=] is represented in [[!IEEE-754|IEEE-754]] binary16 format.
+It has one sign bit, 5 exponent bits, and 10 fraction bits.
+When |V| is placed at byte offset |k| of host-shared buffer, then:
+   * Byte |k| contains bits 0 through 7 of the fraction.
+   * Bits 0 through 1 of byte |k|+1 contains bits 8 through 9 of the fraction.
+   * Bits 2 through 6 of byte |k|+1 contains bits 0 through 4 of the exponent.
+   * Bit 7 of byte |k|+1 contains the sign bit.
+
 Note: The above rules imply that numeric values in host-shared buffers
 are stored in little-endian format.
 
@@ -1917,7 +1971,7 @@ used in address space |C|.
         <th>[=RequiredAlignOf=](|S|, [=address spaces/storage=])
         <th>[=RequiredAlignOf=](|S|, [=address spaces/uniform=])
   </thead>
-  <tr><td>[=i32=], [=u32=], or [=f32=]
+  <tr><td>[=i32=], [=u32=], [=f32=], or [=f16=]
       <td>[=AlignOf=](|S|)
       <td>[=AlignOf=](|S|)
   <tr><td>atomic&lt;T&gt;
@@ -1927,7 +1981,7 @@ used in address space |C|.
       <td>[=AlignOf=](|S|)
       <td>[=AlignOf=](|S|)
   <tr algorithm="alignment of a matrix with N columns and M rows">
-      <td>matNxM&lt;f32&gt;
+      <td>matNxM&lt;T&gt;
       <td>[=AlignOf=](|S|)
       <td>[=AlignOf=](|S|)
   <tr algorithm="alignment of an array">
@@ -2903,6 +2957,8 @@ The declaration must appear at [=module scope=], and its [=scope=] is the entire
 
     | [=syntax/float32=]
 
+    | [=syntax/float16=]
+
     | [=syntax/int32=]
 
     | [=syntax/uint32=]
@@ -3379,6 +3435,7 @@ See also [[#zero-value-expr]] and [[#conversion-expr]].
   <tr><td>*e*: i32<td>`i32(e)`: i32<td>Identity.
   <tr><td>*e*: u32<td>`u32(e)`: u32<td>Identity.
   <tr><td>*e*: f32<td>`f32(e)`: f32<td>Identity.
+  <tr><td>*e*: f16<td>`f16(e)`: f16<td>Identity.
 </table>
 
 <table class='data'>
@@ -3479,68 +3536,72 @@ See also [[#zero-value-expr]] and [[#conversion-expr]].
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr>
-    <td rowspan=2>|e1|: |f32|<br>
+    <td rowspan=2>|e1|: |T|<br>
         ...<br>
-        |eN|: |f32|
-    <td>`mat2x2<f32>(e1,e2,e3,e4)`: mat2x2&lt;f32&gt;<br>
-        `mat3x2<f32>(e1,...,e6)`: mat3x2&lt;f32&gt;<br>
-        `mat2x3<f32>(e1,...,e6)`: mat2x3&lt;f32&gt;<br>
-        `mat4x2<f32>(e1,...,e8)`: mat4x2&lt;f32&gt;<br>
-        `mat2x4<f32>(e1,...,e8)`: mat2x4&lt;f32&gt;<br>
-        `mat3x3<f32>(e1,...,e9)`: mat3x3&lt;f32&gt;<br>
-        `mat4x3<f32>(e1,...,e12)`: mat4x3&lt;f32&gt;<br>
-        `mat3x4<f32>(e1,...,e12)`: mat3x4&lt;f32&gt;<br>
-        `mat4x4<f32>(e1,...,e16)`: mat4x4&lt;f32&gt;
+        |eN|: |T|<br>
+        |T| is f32 or f16
+    <td>`mat2x2<T>(e1,e2,e3,e4)`: mat2x2&lt;|T|&gt;<br>
+        `mat3x2<T>(e1,...,e6)`: mat3x2&lt;|T|&gt;<br>
+        `mat2x3<T>(e1,...,e6)`: mat2x3&lt;|T|&gt;<br>
+        `mat4x2<T>(e1,...,e8)`: mat4x2&lt;|T|&gt;<br>
+        `mat2x4<T>(e1,...,e8)`: mat2x4&lt;|T|&gt;<br>
+        `mat3x3<T>(e1,...,e9)`: mat3x3&lt;|T|&gt;<br>
+        `mat4x3<T>(e1,...,e12)`: mat4x3&lt;|T|&gt;<br>
+        `mat3x4<T>(e1,...,e12)`: mat3x4&lt;|T|&gt;<br>
+        `mat4x4<T>(e1,...,e16)`: mat4x4&lt;|T|&gt;
     <td rowspan=2>Column-major construction by elements.<br>
   <tr>
-    <td>`mat2x2(e1,e2,e3,e4)`: mat2x2&lt;f32&gt;<br>
-        `mat3x2(e1,...,e6)`: mat3x2&lt;f32&gt;<br>
-        `mat2x3(e1,...,e6)`: mat2x3&lt;f32&gt;<br>
-        `mat4x2(e1,...,e8)`: mat4x2&lt;f32&gt;<br>
-        `mat2x4(e1,...,e8)`: mat2x4&lt;f32&gt;<br>
-        `mat3x3(e1,...,e9)`: mat3x3&lt;f32&gt;<br>
-        `mat4x3(e1,...,e12)`: mat4x3&lt;f32&gt;<br>
-        `mat3x4(e1,...,e12)`: mat3x4&lt;f32&gt;<br>
-        `mat4x4(e1,...,e16)`: mat4x4&lt;f32&gt;
+    <td>`mat2x2(e1,e2,e3,e4)`: mat2x2&lt;|T|&gt;<br>
+        `mat3x2(e1,...,e6)`: mat3x2&lt;|T|&gt;<br>
+        `mat2x3(e1,...,e6)`: mat2x3&lt;|T|&gt;<br>
+        `mat4x2(e1,...,e8)`: mat4x2&lt;|T|&gt;<br>
+        `mat2x4(e1,...,e8)`: mat2x4&lt;|T|&gt;<br>
+        `mat3x3(e1,...,e9)`: mat3x3&lt;|T|&gt;<br>
+        `mat4x3(e1,...,e12)`: mat4x3&lt;|T|&gt;<br>
+        `mat3x4(e1,...,e12)`: mat3x4&lt;|T|&gt;<br>
+        `mat4x4(e1,...,e16)`: mat4x4&lt;|T|&gt;
   <tr>
-    <td rowspan=2>*e1*: vec2&lt;f32&gt;<br>
-        *e2*: vec2&lt;f32&gt;<br>
-        *e3*: vec2&lt;f32&gt;<br>
-        *e4*: vec2&lt;f32&gt;
-    <td>`mat2x2<f32>(e1,e2)`: mat2x2&lt;f32&gt;<br>
-        `mat3x2<f32>(e1,e2,e3)`: mat3x2&lt;f32&gt;<br>
-        `mat4x2<f32>(e1,e2,e3,e4)`: mat4x2&lt;f32&gt;
+    <td rowspan=2>*e1*: vec2&lt;*T*&gt;<br>
+        *e2*: vec2&lt;*T*&gt;<br>
+        *e3*: vec2&lt;*T*&gt;<br>
+        *e4*: vec2&lt;*T*&gt;<br>
+        *T* is f32 or f16
+    <td>`mat2x2<T>(e1,e2)`: mat2x2&lt;*T*&gt;<br>
+        `mat3x2<T>(e1,e2,e3)`: mat3x2&lt;*T*&gt;<br>
+        `mat4x2<T>(e1,e2,e3,e4)`: mat4x2&lt;*T*&gt;
     <td rowspan=2>Column by column construction.<br>
   <tr>
-    <td>`mat2x2(e1,e2)`: mat2x2&lt;f32&gt;<br>
-        `mat3x2(e1,e2,e3)`: mat3x2&lt;f32&gt;<br>
-        `mat4x2(e1,e2,e3,e4)`: mat4x2&lt;f32&gt;
+    <td>`mat2x2(e1,e2)`: mat2x2&lt;*T*&gt;<br>
+        `mat3x2(e1,e2,e3)`: mat3x2&lt;*T*&gt;<br>
+        `mat4x2(e1,e2,e3,e4)`: mat4x2&lt;*T*&gt;
   <tr>
-    <td rowspan=2>*e1*: vec3&lt;f32&gt;<br>
-        *e2*: vec3&lt;f32&gt;<br>
-        *e3*: vec3&lt;f32&gt;<br>
-        *e4*: vec3&lt;f32&gt;
-    <td>`mat2x3<f32>(e1,e2)`: mat2x3&lt;f32&gt;<br>
-        `mat3x3<f32>(e1,e2,e3)`: mat3x3&lt;f32&gt;<br>
-        `mat4x3<f32>(e1,e2,e3,e4)`: mat4x3&lt;f32&gt;
+    <td rowspan=2>*e1*: vec3&lt;*T*&gt;<br>
+        *e2*: vec3&lt;*T*&gt;<br>
+        *e3*: vec3&lt;*T*&gt;<br>
+        *e4*: vec3&lt;*T*&gt;<br>
+        *T* is f32 or f16
+    <td>`mat2x3<T>(e1,e2)`: mat2x3&lt;*T*&gt;<br>
+        `mat3x3<T>(e1,e2,e3)`: mat3x3&lt;*T*&gt;<br>
+        `mat4x3<T>(e1,e2,e3,e4)`: mat4x3&lt;*T*&gt;
     <td rowspan=2>Column by column construction.<br>
   <tr>
-    <td>`mat2x3(e1,e2)`: mat2x3&lt;f32&gt;<br>
-        `mat3x3(e1,e2,e3)`: mat3x3&lt;f32&gt;<br>
-        `mat4x3(e1,e2,e3,e4)`: mat4x3&lt;f32&gt;
+    <td>`mat2x3(e1,e2)`: mat2x3&lt;*T*&gt;<br>
+        `mat3x3(e1,e2,e3)`: mat3x3&lt;*T*&gt;<br>
+        `mat4x3(e1,e2,e3,e4)`: mat4x3&lt;*T*&gt;
   <tr>
-    <td rowspan=2>*e1*: vec4&lt;f32&gt;<br>
-        *e2*: vec4&lt;f32&gt;<br>
-        *e3*: vec4&lt;f32&gt;<br>
-        *e4*: vec4&lt;f32&gt;
-    <td>`mat2x4<f32>(e1,e2)`: mat2x4&lt;f32&gt;<br>
-        `mat3x4<f32>(e1,e2,e3)`: mat3x4&lt;f32&gt;<br>
-        `mat4x4<f32>(e1,e2,e3,e4)`: mat4x4&lt;f32&gt;
+    <td rowspan=2>*e1*: vec4&lt;*T*&gt;<br>
+        *e2*: vec4&lt;*T*&gt;<br>
+        *e3*: vec4&lt;*T*&gt;<br>
+        *e4*: vec4&lt;*T*&gt;<br>
+        *T* is f32 or f16
+    <td>`mat2x4<T>(e1,e2)`: mat2x4&lt;*T*&gt;<br>
+        `mat3x4<T>(e1,e2,e3)`: mat3x4&lt;*T*&gt;<br>
+        `mat4x4<T>(e1,e2,e3,e4)`: mat4x4&lt;*T*&gt;
     <td rowspan=2>Column by column construction.<br>
   <tr>
-    <td>`mat2x4(e1,e2)`: mat2x4&lt;f32&gt;<br>
-        `mat3x4(e1,e2,e3)`: mat3x4&lt;f32&gt;<br>
-        `mat4x4(e1,e2,e3,e4)`: mat4x4&lt;f32&gt;
+    <td>`mat2x4(e1,e2)`: mat2x4&lt;*T*&gt;<br>
+        `mat3x4(e1,e2,e3)`: mat3x4&lt;*T*&gt;<br>
+        `mat4x4(e1,e2,e3,e4)`: mat4x4&lt;*T*&gt;
 </table>
 
 <table class='data'>
@@ -3587,8 +3648,9 @@ The zero values are as follows:
 * `i32()` is 0
 * `u32()` is 0
 * `f32()` is 0.0
+* `f16()` is 0.0
 * The zero value for an *N*-component vector of type *T* is the *N*-component vector of the zero value for *T*.
-* The zero value for an *N*-column *M*-row matrix of `f32` is the matrix of those dimensions filled with 0.0 entries.
+* The zero value for an *N*-column *M*-row matrix of `f32` or `f16` is the matrix of those dimensions filled with 0.0 entries.
 * The zero value for a [=constructible=] *N*-element array with element type *E* is an array of *N* elements of the zero value for *E*.
 * The zero value for a [=constructible=] structure type *S* is the structure value *S* with zero-valued members.
 
@@ -3604,6 +3666,7 @@ Note: WGSL does not have zero expression for [=atomic types=],
   <tr><td><td>`i32()`: i32<td>0<br>Zero value
   <tr><td><td>`u32()`: u32<td>0u<br>Zero value
   <tr><td><td>`f32()`: f32<td>0.0<br>Zero value
+  <tr><td><td>`f16()`: f16<td>0.0<br>Zero value
 </table>
 
 <table class='data'>
@@ -3642,22 +3705,22 @@ Note: WGSL does not have zero expression for [=atomic types=],
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr>
-    <td>
-    <td>`mat2x2<f32>()`: mat2x2&lt;f32&gt;<br>
-        `mat3x2<f32>()`: mat3x2&lt;f32&gt;<br>
-        `mat4x2<f32>()`: mat4x2&lt;f32&gt;
+    <td>*T* is f32 or f16
+    <td>`mat2x2<T>()`: mat2x2&lt;*T*&gt;<br>
+        `mat3x2<T>()`: mat3x2&lt;*T*&gt;<br>
+        `mat4x2<T>()`: mat4x2&lt;*T*&gt;
     <td>Zero value
   <tr>
     <td>
-    <td>`mat2x3<f32>()`: mat2x3&lt;f32&gt;<br>
-        `mat3x3<f32>()`: mat3x3&lt;f32&gt;<br>
-        `mat4x3<f32>()`: mat4x3&lt;f32&gt;
+    <td>`mat2x3<T>()`: mat2x3&lt;*T*&gt;<br>
+        `mat3x3<T>()`: mat3x3&lt;*T*&gt;<br>
+        `mat4x3<T>()`: mat4x3&lt;*T*&gt;
     <td>Zero value
   <tr>
     <td>
-    <td>`mat2x4<f32>()`: mat2x4&lt;f32&gt;<br>
-        `mat3x4<f32>()`: mat3x4&lt;f32&gt;<br>
-        `mat4x4<f32>()`: mat4x4&lt;f32&gt;
+    <td>`mat2x4<T>()`: mat2x4&lt;*T*&gt;<br>
+        `mat3x4<T>()`: mat3x4&lt;*T*&gt;<br>
+        `mat4x4<T>()`: mat4x4&lt;*T*&gt;
     <td>Zero value
 </table>
 
@@ -3737,8 +3800,13 @@ See also [[#type-constructor-expr]].
       <td>|e|: i32<td>`bool(`|e|`)`: bool
       <td>Coercion to boolean.<br>
           The result is false if |e| is 0, and true otherwise.
-  <tr algorithm="coercion to boolean from floating point">
+  <tr algorithm="coercion to boolean from binary32 floating point">
       <td>|e|: f32<td>`bool(`|e|`)`: bool
+      <td>Coercion to boolean.<br>
+          The result is false if |e| is 0.0 or -0.0, and true otherwise.
+          In particular NaN and infinity values map to true.
+  <tr algorithm="coercion to boolean from binary16 floating point">
+      <td>|e|: f16<td>`bool(`|e|`)`: bool
       <td>Coercion to boolean.<br>
           The result is false if |e| is 0.0 or -0.0, and true otherwise.
           In particular NaN and infinity values map to true.
@@ -3750,8 +3818,11 @@ See also [[#type-constructor-expr]].
       <td>|e|: u32<td>`i32(`|e|`)`: i32
       <td>Reinterpretation of bits.<br>
           The result is the unique value in [=i32=] that is equal to (|e| mod 2<sup>32</sup>).
-  <tr algorithm="scalar conversion from floating point to signed integer">
+  <tr algorithm="scalar conversion from binary32 floating point to signed integer">
       <td>|e|: f32<td>`i32(`|e|`)`: i32
+      <td>Value conversion, rounding toward zero.
+  <tr algorithm="scalar conversion from binary16 floating point to signed integer">
+      <td>|e|: f16<td>`i32(`|e|`)`: i32
       <td>Value conversion, rounding toward zero.
   <tr algorithm="conversion from boolean to unsigned">
       <td>|e|: bool<td>`u32(`|e|`)`: u32
@@ -3761,17 +3832,32 @@ See also [[#type-constructor-expr]].
       <td>|e|: i32<td>`u32(`|e|`)`: u32
       <td>Reinterpretation of bits.<br>
           The result is the unique value in [=u32=] that is equal to (|e| mod 2<sup>32</sup>).
-  <tr algorithm="scalar conversion from floating point to unsigned integer">
+  <tr algorithm="scalar conversion from binary32 floating point to unsigned integer">
       <td>|e|: f32<td>`u32(`|e|`)`: u32
       <td>Value conversion, rounding toward zero.
-  <tr algorithm="conversion from boolean to floating point">
+  <tr algorithm="scalar conversion from binary16 floating point to unsigned integer">
+      <td>|e|: f16<td>`u32(`|e|`)`: u32
+      <td>Value conversion, rounding toward zero.
+  <tr algorithm="conversion from boolean to binary32 floating point">
       <td>|e|: bool<td>`f32(`|e|`)`: f32
       <td>Conversion of a boolean value to floating point<br>
           The result is 1.0 if |e| is true and 0.0 otherwise.
-  <tr algorithm="scalar conversion from signed integer to floating point">
+  <tr algorithm="scalar conversion from signed integer to binary32 floating point">
       <td>|e|: i32<td>`f32(`|e|`)`: f32<td>Value conversion, including invalid cases.
-  <tr algorithm="scalar conversion from unsigned integer to floating point">
+  <tr algorithm="scalar conversion from unsigned integer to binary32 floating point">
       <td>|e|: u32<td>`f32(`|e|`)`: f32<td>Value conversion, including invalid cases.
+  <tr algorithm="scalar conversion from binary16 floating point to binary32 floating point">
+      <td>|e|: f16<td>`f32(`|e|`)`: f32<td>Exact value conversion.
+  <tr algorithm="conversion from boolean to binary16 floating point">
+      <td>|e|: bool<td>`f16(`|e|`)`: f16
+      <td>Conversion of a boolean value to floating point<br>
+          The result is 1.0 if |e| is true and 0.0 otherwise.
+  <tr algorithm="scalar conversion from signed integer to binary16 floating point">
+      <td>|e|: i32<td>`f16(`|e|`)`: f16<td>Value conversion, including invalid cases.
+  <tr algorithm="scalar conversion from unsigned integer to binary16 floating point">
+      <td>|e|: u32<td>`f16(`|e|`)`: f16<td>Value conversion, including invalid cases.
+  <tr algorithm="scalar conversion from binary32 floating point to binary16 floating point">
+      <td>|e|: f32<td>`f16(`|e|`)`: f16<td>Lossy value conversion.
 </table>
 
 Details of conversion to and from floating point are explained in [[#floating-point-conversion]].
@@ -3791,10 +3877,15 @@ Details of conversion to and from floating point are explained in [[#floating-po
      <td>`vec`|N|&lt;`bool`&gt;`(`|e|`)`: vec|N|&lt;bool&gt
      <td>[=Component-wise=] coercion of a signed integer vector to a boolean vector.
 
-  <tr algorithm="vector coercion of floating point to boolean">
+  <tr algorithm="vector coercion of binary32 floating point to boolean">
      <td>|e|: vec|N|&lt;f32&gt;
      <td>`vec`|N|&lt;`bool`&gt;`(`|e|`)`: vec|N|&lt;bool&gt
-     <td>[=Component-wise=] coercion of a floating point vector to a boolean vector.
+     <td>[=Component-wise=] coercion of a binary32 floating point vector to a boolean vector.
+
+  <tr algorithm="vector coercion of binary16 floating point to boolean">
+     <td>|e|: vec|N|&lt;f16&gt;
+     <td>`vec`|N|&lt;`bool`&gt;`(`|e|`)`: vec|N|&lt;bool&gt
+     <td>[=Component-wise=] coercion of a binary16 floating point vector to a boolean vector.
 
   <tr algorithm="vector conversion from bool to signed">
      <td>|e|: vec|N|&lt;bool&gt;
@@ -3808,8 +3899,13 @@ Details of conversion to and from floating point are explained in [[#floating-po
      <td>[=Component-wise=] reinterpretation of bits.<br>
          Component |i| of the result is `i32(`|e|`[`|i|`])`
 
-  <tr algorithm="vector conversion from floating point to signed integer">
+  <tr algorithm="vector conversion from binary32 floating point to signed integer">
      <td>|e|: vec|N|&lt;f32&gt;
+     <td>`vec`|N|&lt;`i32`&gt;`(`|e|`)`: vec|N|&lt;i32&gt;
+     <td>[=Component-wise=] value conversion to signed integer, including invalid cases.
+
+  <tr algorithm="vector conversion from binary16 floating point to signed integer">
+     <td>|e|: vec|N|&lt;f16&gt;
      <td>`vec`|N|&lt;`i32`&gt;`(`|e|`)`: vec|N|&lt;i32&gt;
      <td>[=Component-wise=] value conversion to signed integer, including invalid cases.
 
@@ -3824,26 +3920,74 @@ Details of conversion to and from floating point are explained in [[#floating-po
      <td>`vec`|N|&lt;`u32`&gt;`(`|e|`)`: vec|N|&lt;u32&gt;
      <td>[=Component-wise=] reinterpretation of bits.
 
-  <tr algorithm="vector conversion from floating point to unsigned integer">
+  <tr algorithm="vector conversion from binary32 floating point to unsigned integer">
      <td>|e|: vec|N|&lt;f32&gt;
      <td>`vec`|N|&lt;`u32`&gt;`(`|e|`)`: vec|N|&lt;u32&gt;
      <td>[=Component-wise=] value conversion to unsigned integer, including invalid cases.
 
-  <tr algorithm="vector conversion from bool to floating point">
+  <tr algorithm="vector conversion from binary16 floating point to unsigned integer">
+     <td>|e|: vec|N|&lt;f16&gt;
+     <td>`vec`|N|&lt;`u32`&gt;`(`|e|`)`: vec|N|&lt;u32&gt;
+     <td>[=Component-wise=] value conversion to unsigned integer, including invalid cases.
+
+  <tr algorithm="vector conversion from bool to binary32 floating point">
      <td>|e|: vec|N|&lt;bool&gt;
      <td>`vec`|N|&lt;`u32`&gt;`(`|e|`)`: vec|N|&lt;u32&gt
-     <td>[=Component-wise=] conversion of a boolean vector to floating point.<br>
+     <td>[=Component-wise=] conversion of a boolean vector to binary32 floating point.<br>
          Component |i| of the result is `f32(`|e|`[`|i|`])`
 
-  <tr algorithm="vector conversion from signed integer to floating point">
+  <tr algorithm="vector conversion from signed integer to binary32 floating point">
      <td>|e|: vec|N|&lt;i32&gt;
      <td>`vec`|N|&lt;`f32`&gt;`(`|e|`)`: vec|N|&lt;f32&gt;
-     <td>[=Component-wise=] value conversion to floating point, including invalid cases.
+     <td>[=Component-wise=] value conversion to binary32 floating point, including invalid cases.
 
-  <tr algorithm="vector conversion from unsigned integer to floating point">
-     <td>|e|: vec|N|&lt;u32&gt;
+  <tr algorithm="vector conversion from unsigned integer to binary32 floating point">
+     <td>|e|: vec|N|&lt;f32&gt;
      <td>`vec`|N|&lt;`f32`&gt;`(`|e|`)`: vec|N|&lt;f32&gt;
-     <td>[=Component-wise=] value conversion to floating point, including invalid cases.
+     <td>[=Component-wise=] value conversion to binary32 floating point, including invalid cases.
+
+  <tr algorithm="vector conversion from binary16 floating point to binary32 floating point">
+     <td>|e|: vec|N|&lt;f16&gt;
+     <td>`vec`|N|&lt;`f32`&gt;`(`|e|`)`: vec|N|&lt;f32&gt;
+     <td>[=Component-wise=] exact value conversion to binary32 floating point.
+
+  <tr algorithm="vector conversion from bool to binary16 floating point">
+     <td>|e|: vec|N|&lt;bool&gt;
+     <td>`vec`|N|&lt;`f16`&gt;`(`|e|`)`: vec|N|&lt;f16&gt
+     <td>[=Component-wise=] conversion of a boolean vector to binary16 floating point.<br>
+         Component |i| of the result is `f16(`|e|`[`|i|`])`
+
+  <tr algorithm="vector conversion from signed integer to binary16 floating point">
+     <td>|e|: vec|N|&lt;i32&gt;
+     <td>`vec`|N|&lt;`f16`&gt;`(`|e|`)`: vec|N|&lt;f16&gt;
+     <td>[=Component-wise=] value conversion to binary16 floating point, including invalid cases.
+
+  <tr algorithm="vector conversion from unsigned integer to binary32 floating point">
+     <td>|e|: vec|N|&lt;u32&gt;
+     <td>`vec`|N|&lt;`f16`&gt;`(`|e|`)`: vec|N|&lt;f&gt;
+     <td>[=Component-wise=] value conversion to binary16 floating point, including invalid cases.
+
+  <tr algorithm="vector conversion from binary16 floating point to binary32 floating point">
+     <td>|e|: vec|N|&lt;f32&gt;
+     <td>`vec`|N|&lt;`f16`&gt;`(`|e|`)`: vec|N|&lt;f16&gt;
+     <td>[=Component-wise=] loosy value conversion to binary16 floating point.
+
+</table>
+
+<table class='data'>
+  <caption>Matrix conversion type rules</caption>
+  <thead>
+    <tr><th>Precondition<th>Conclusion<th>Notes
+  </thead>
+  <tr algorithm="matrix coercion of binary16 floating point to binary32 floating point">
+     <td>|e|: mat|N|x|M|&lt;f16&gt;
+     <td>`mat`|N|`x`|M|&lt;`f32`&gt;`(`|e|`)`: mat|N|x|M|&lt;f32&gt
+     <td>[=Component-wise=] exact value conversion to binary32 floating point.
+
+  <tr algorithm="vector coercion of binary32 floating point to binary16 floating point">
+     <td>|e|: mat|N|x|M|&lt;f32&gt;
+     <td>`mat`|N|`x`|M|&lt;`f16`&gt;`(`|e|`)`: mat|N|x|M|&lt;f16&gt
+     <td>[=Component-wise=] loosy value conversion to binary16 floating point.
 
 </table>
 
@@ -3865,15 +4009,53 @@ value in one type as a value in another type.
     <td>Identity transform. [=Component-wise=] when |T| is a vector.<br>
     The result is |e|.
 
-  <tr algorithm="general reinterpretation">
+  <tr algorithm="32-bit scalar reinterpretation">
     <td>|e|: |T1|<br>
-    |T1| is a [=numeric scalar=] or [=numeric vector=] type<br>
-    |T2| is not |T1| and is a numeric scalar type if |T1| is a scalar, or<br>
-    a numeric vector type if |T1| is a vector
+    |T1| is i32, u32, or f32<br>
+    |T2| is not |T1| and is i32, u32, or f32
     <td class="nowrap">bitcast&lt;|T2|&gt;(|e|): |T2|
-    <td>Reinterpretation of bits as |T2|. [=Component-wise=] when |T1| is a vector.<br>
+    <td>Reinterpretation of bits as |T2|. <br>
     The result is the reinterpretation of the bits in |e| as a |T2| value.
+
+  <tr algorithm="32-bit elements vector reinterpretation">
+    <td>|e|: vec|N|&lt;|T1|&gt;<br>
+    |T1| is i32, u32, or f32<br>
+    |T2| is not |T1| and is i32, u32, or f32
+    <td class="nowrap">bitcast&lt;vec|N|&lt;|T2|&gt;&gt;(|e|): vec|N|&lt;|T2|&gt;
+    <td>[=Component-wise=] reinterpretation of bits as |T2|.<br>
+    The result is the reinterpretation of the bits in |e| as a vec|N|&lt;|T2|&gt; value.
+
+  <tr algorithm="binary16x2 to 32-bit scalar reinterpretation">
+    <td>|e|: vec2&lt;f16&gt;<br>
+    |T| is i32, u32, or f32
+    <td class="nowrap">bitcast&lt;|T|&gt;(|e|): |T|
+    <td>Reinterpretation of bits as |T|.<br>
+    The result is the reinterpretation of the 32 bits in |e| as a |T| value, following the internal layout rules.
+
+  <tr algorithm="32-bit scalar to binary16x2 reinterpretation">
+    <td>|e|: |T|<br>
+    |T| is i32, u32, or f32
+    <td class="nowrap">bitcast&lt;vec2&lt;f16&gt;&gt;(|e|): vec2&lt;f16&gt;
+    <td>Reinterpretation of bits as vec2&lt;f16&gt;.<br>
+    The result is the reinterpretation of the 32 bits in |e| as a vec2&lt;f16&gt; value, following the internal layout rules.
+
+  <tr algorithm="binary16x4 to vec2 of 32-bit scalar reinterpretation">
+    <td>|e|: vec4&lt;f16&gt;<br>
+    |T| is i32, u32, or f32
+    <td class="nowrap">bitcast&lt;vec2&lt;|T|&gt;&gt;(|e|): vec2&lt;|T|&gt;
+    <td>Reinterpretation of bits as vec2&lt;|T|&gt;.<br>
+    The result is the reinterpretation of the 64 bits in |e| as a vec2&lt;|T|&gt; value, following the internal layout rules.
+
+  <tr algorithm="vec2 of 32-bit scalar to binary16x4 reinterpretation">
+    <td>|e|: vec2&lt;|T|&gt;<br>
+    |T| is i32, u32, or f32
+    <td class="nowrap">bitcast&lt;vec4&lt;f16&gt;&gt;(|e|): vec4&lt;f16&gt;
+    <td>Reinterpretation of bits as vec4&lt;f16&gt;.<br>
+    The result is the reinterpretation of the 64 bits in |e| as a vec4&lt;f16&gt; value, following the internal layout rules.
+
 </table>
+
+The internal layout rules are described in [[#internal-value-layout]].
 
 ## Composite Value Decomposition Expressions ## {#composite-value-decomposition-expr}
 
@@ -4264,7 +4446,7 @@ See [[#sync-builtin-functions]].
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr algorithm="negation"><td>|e|: |T|<br>
-  |T| is i32, f32, vec|N|&lt;i32&gt;, or vec|N|&lt;f32&gt;
+  |T| is i32, f32, f16, vec|N|&lt;i32&gt;, vec|N|&lt;f32&gt;, or vec|N|&lt;f16&gt;
   <td>`-`|e|`:` |T|
   <td>Negation. [=Component-wise=] when |T| is a vector.
   If |T| is an integral type and |e| evaluates to the largest negative value, then the result is |e|.
@@ -4362,7 +4544,7 @@ See [[#sync-builtin-functions]].
     <th>Preconditions<th>Conclusions<th>Semantics
   </thead>
   <tr algorithm="vector-scalar arithmetic, any scalar type">
-    <td rowspan="10">|S| is one of f32, i32, u32<br>
+    <td rowspan="10">|S| is one of i32, u32, f32, f16<br>
         |V| is vec|N|&lt;|S|&gt<br>
         |es|: |S|<br>
         |ev|: |V|
@@ -4403,37 +4585,42 @@ See [[#sync-builtin-functions]].
     <th>Preconditions<th>Conclusions<th>Semantics
   </thead>
   <tr algorithm="matrix addition">
-    <td rowspan=2>|e1|, |e2|: mat|M|x|N|&lt;f32&gt
-    <td>|e1| `+` |e2|: mat|M|x|N|&lt;f32&gt<br>
+    <td rowspan=2>|e1|, |e2|: mat|M|x|N|&lt;|T|&gt<br>
+        |T| is f32 or f16
+    <td>|e1| `+` |e2|: mat|M|x|N|&lt;|T|&gt<br>
     <td>Matrix addition: column |i| of the result is |e1|[i] + |e2|[i]
   <tr algorithm="matrix subtraction">
-    <td>|e1| `-` |e2|: mat|M|x|N|&lt;f32&gt
+    <td>|e1| `-` |e2|: mat|M|x|N|&lt;|T|&gt
     <td>Matrix subtraction: column |i| of the result is |e1|[|i|] - |e2|[|i|]
   <tr algorithm="matrix-scalar multiply">
-    <td rowspan=2>|m|: mat|M|x|N|&lt;f32&gt<br>
-        |s|: f32
-    <td>|m| `*` |s|:  mat|M|x|N|&lt;f32&gt<br>
+    <td rowspan=2>|m|: mat|M|x|N|&lt;|T|&gt<br>
+        |s|: |T|<br>
+        |T| is f32 or f16
+    <td>|m| `*` |s|:  mat|M|x|N|&lt;|T|&gt<br>
     <td>Component-wise scaling: (|m| `*` |s|)[i][j] is |m|[i][j] `*` |s|
   <tr algorithm="scalar-matrix multiply">
-    <td>|s| `*` |m|:  mat|M|x|N|&lt;f32&gt<br>
+    <td>|s| `*` |m|:  mat|M|x|N|&lt;|T|&gt<br>
     <td>Component-wise scaling: (|s| `*` |m|)[i][j] is |m|[i][j] `*` |s|
   <tr algorithm="matrix-column-vector multiply">
-    <td>|m|: mat|M|x|N|&lt;f32&gt<br>
-        |v|: vec|M|&lt;f32&gt
-    <td>|m| `*` |v|:  vec|N|&lt;f32&gt<br>
+    <td>|m|: mat|M|x|N|&lt;|T|&gt<br>
+        |v|: vec|M|&lt;|T|&gt<br>
+        |T| is f32 or f16
+    <td>|m| `*` |v|:  vec|N|&lt;|T|&gt<br>
     <td>Linear algebra matrix-column-vector product:
         Component |i| of the result is `dot`(|m|[|i|],|v|)
   <tr algorithm="matrix-row-vector multiply">
     <td>
-        |m|: mat|M|x|N|&lt;f32&gt<br>
-        |v|: vec|N|&lt;f32&gt
-    <td>|v| `*` |m|:  vec|M|&lt;f32&gt<br>
+        |m|: mat|M|x|N|&lt;|T|&gt<br>
+        |v|: vec|N|&lt;|T|&gt<br>
+        |T| is f32 or f16
+    <td>|v| `*` |m|:  vec|M|&lt;|T|&gt<br>
     <td>Linear algebra row-vector-matrix product:<br>
         [=transpose=](transpose(|m|) `*` transpose(|v|))
   <tr algorithm="matrix-matrix multiply">
-    <td>|e1|: mat|K|x|N|&lt;f32&gt<br>
-        |e2|: mat|M|x|K|&lt;f32&gt
-    <td>|e1| `*` |e2|:  mat|M|x|N|&lt;f32&gt<br>
+    <td>|e1|: mat|K|x|N|&lt;|T|&gt<br>
+        |e2|: mat|M|x|K|&lt;|T|&gt<br>
+        |T| is f32 or f16
+    <td>|e1| `*` |e2|:  mat|M|x|N|&lt;|T|&gt<br>
     <td>Linear algebra matrix product.
 
 </table>
@@ -4448,7 +4635,7 @@ See [[#sync-builtin-functions]].
 
   <tr algorithm="equality">
     <td>|e1|: |T|<br>|e2|: |T|<br>
-    |T| is bool, i32, u32, f32, vec|N|&lt;bool&gt;, vec|N|&lt;i32&gt;, vec|N|&lt;u32&gt;, or vec|N|&lt;f32&gt;<br>
+    |T| is bool, i32, u32, f32, f16, vec|N|&lt;bool&gt;, vec|N|&lt;i32&gt;, vec|N|&lt;u32&gt;, vec|N|&lt;f32&gt;, or vec|N|&lt;f16&gt;<br>
     |TB| is bool if |T| is scalar, or<br>
     vec|N|&lt;bool&gt; if |T| is a vector
     <td class="nowrap">|e1| `==` |e2|`:` |TB|
@@ -6894,6 +7081,19 @@ the implementation can issue a clear diagnostic.
   </xmp>
 </div>
 
+## Extensions list
+
+<table class='data'>
+  <caption>Extension identifier</caption>
+  <thead>
+    <tr><th>Identifier
+        <th>WebGPU extension name
+        <th>Description
+  </thead>
+  <tr><td>`f16`
+      <td>`"fp16-in-shader-and-buffer"`
+      <td>Keyword `f16` is valid if and only if this extension is enabled. Otherwise, using `f16` keyword will result in shader-creation error.
+</table>
 
 # WGSL Program # {#wgsl-program}
 
@@ -7520,76 +7720,76 @@ value with the same sign.
 <table class='data'>
   <caption>Accuracy of expressions</caption>
   <thead>
-    <tr><th>Expression<th>Accuracy<th>
+    <tr><th>Expression<th>Accuracy for f32<th>Accuracy for f16
   </thead>
 
-  <tr><td>`x + y`<td>Correctly rounded
-  <tr><td>`x - y`<td>Correctly rounded
-  <tr><td>`x * y`<td>Correctly rounded
-  <tr><td>`x / y`<td>2.5 ULP for `|y|` in the range [2<sup>-126</sup>, 2<sup>126</sup>]
-  <tr><td>`x % y`<td>Derived from `x - y * trunc(x/y)`
-  <tr><td>`-x`<td>Correctly rounded
+  <tr><td>`x + y`<td colspan=2>Correctly rounded
+  <tr><td>`x - y`<td colspan=2>Correctly rounded
+  <tr><td>`x * y`<td colspan=2>Correctly rounded
+  <tr><td>`x / y`<td>2.5 ULP for `|y|` in the range [2<sup>-126</sup>, 2<sup>126</sup>]<td>2.5 ULP for `|y|` in the range [2<sup>-14</sup>, 2<sup>14</sup>]
+  <tr><td>`x % y`<td colspan=2>Derived from `x - y * trunc(x/y)`
+  <tr><td>`-x`<td colspan=2>Correctly rounded
 
-  <tr><td>`x == y`<td>Correct result
-  <tr><td>`x != y`<td>Correct result
-  <tr><td>`x < y`<td>Correct result
-  <tr><td>`x <= y`<td>Correct result
-  <tr><td>`x > y`<td>Correct result
-  <tr><td>`x >= y`<td>Correct result
+  <tr><td>`x == y`<td colspan=2>Correct result
+  <tr><td>`x != y`<td colspan=2>Correct result
+  <tr><td>`x < y`<td colspan=2>Correct result
+  <tr><td>`x <= y`<td colspan=2>Correct result
+  <tr><td>`x > y`<td colspan=2>Correct result
+  <tr><td>`x >= y`<td colspan=2>Correct result
 </table>
 
 <table class='data'>
   <caption>Accuracy of built-in functions</caption>
   <thead>
-    <tr><th>Built-in Function<th>Accuracy
+    <tr><th>Built-in Function<th>Accuracy for f32<th>Accuracy for f16
   </thead>
 
-  <tr><td>`abs(x)`<td>Correctly rounded
-  <tr><td>`acos(x)`<td>Inherited from `atan2(sqrt(1.0 - x * x), x)`
-  <tr><td>`acosh(x)`<td>Inherited from `log(x + sqrt(x * x - 1.0))`
-  <tr><td>`asin(x)`<td>Inherited from `atan2(x, sqrt(1.0 - x * x))`
-  <tr><td>`asinh(x)`<td>Inherited from `log(x + sqrt(x * x + 1.0))`
-  <tr><td>`atan(x)`<td>4096 ULP
-  <tr><td>`atan2(y, x)`<td>4096 ULP
-  <tr><td>`atanh(x)`<td>Inherited from `log( (1.0 + x) / (1.0 - x) ) * 0.5`
-  <tr><td>`ceil(x)`<td>Correctly rounded
-  <tr><td>`clamp(x,low,high)`<td>Correctly rounded
-  <tr><td>`cos(x)`<td>Absolute error &le; 2<sup>-11</sup> inside the range of [-&pi;, &pi;]
-  <tr><td>`cosh(x)`<td>Inherited from `(exp(x) - exp(-x)) * 0.5`
-  <tr><td>`cross(x, y)`<td>Inherited from `(x[i] * y[j] - x[j] * y[i])`
-  <tr><td>`degrees(x)`<td>Inherited from `x * 57.295779513082322865`
-  <tr><td>`distance(x, y)`<td>Inherited from `length(x - y)`
-  <tr><td>`exp(x)`<td>`3 + 2 * |x|` ULP
-  <tr><td>`exp2(x)`<td>`3 + 2 * |x|` ULP
-  <tr><td class="nowrap">`faceForward(x, y, z)`<td>Inherited from `select(-x, x, dot(z, y) < 0.0)`
-  <tr><td>`floor(x)`<td>Correctly rounded
-  <tr><td>`fma(x, y, z)`<td>Inherited from `x * y + z`
-  <tr><td>`fract(x)`<td>Correctly rounded
-  <tr><td>`frexp(x)`<td>Correctly rounded
-  <tr><td>`inverseSqrt(x)`<td>2 ULP
-  <tr><td>`ldexp(x, y)`<td>Correctly rounded
-  <tr><td>`length(x)`<td>Inherited from `sqrt(dot(x, x))`
-  <tr><td>`log(x)`<td>3 ULP outside the range [0.5, 2.0].<br>Absolute error &lt; 2<sup>-21</sup> inside the range [0.5, 2.0]
-  <tr><td>`log2(x)`<td>3 ULP outside the range [0.5, 2.0].<br>Absolute error &lt; 2<sup>-21</sup> inside the range [0.5, 2.0]
-  <tr><td>`max(x, y)`<td>Correctly rounded
-  <tr><td>`min(x, y)`<td>Correctly rounded
-  <tr><td>`mix(x, y, z)`<td>Inherited from `x * (1.0 - z) + y * z`
-  <tr><td>`modf(x)`<td>Correctly rounded
-  <tr><td>`normalize(x)`<td>Inherited from `x / length(x)`
-  <tr><td>`pow(x, y)`<td>Inherited from `exp2(y * log2(x))`
-  <tr><td>`radians(x)`<td>Inherited from `x * 0.017453292519943295474`
-  <tr><td>`reflect(x, y)`<td>Inherited from `x - 2.0 * dot(x, y) * y`
-  <tr><td>`refract(x, y, z)`<td>Inherited from `z * x - (z * dot(y, x) + sqrt(k)) * y`,<br>where `k = 1.0 - z * z * (1.0 - dot(y, x) * dot(y, x))`<br>If `k < 0.0` the result is precisely 0.0
-  <tr><td>`round(x)`<td>Correctly rounded
-  <tr><td>`sign(x)`<td>Correctly rounded
-  <tr><td>`sin(x)`<td>Absolute error &le; 2<sup>-11</sup> inside the range [-&pi;, &pi;]
-  <tr><td>`sinh(x)`<td>Inherited from `(exp(x) - exp(-x)) * 0.5`
-  <tr><td>`smoothStep(low, high, x)`<td>Inherited from `t * t * (3.0 - 2.0 * t)`,<br>where `t = clamp((x - low) / (high - low), 0.0, 1.0)`
-  <tr><td>`sqrt(x)`<td>Inherited from `1.0 / inverseSqrt(x)`
-  <tr><td>`step(edge, x)`<td>Correctly rounded
-  <tr><td>`tan(x)`<td>Inherited from `sin(x) / cos(x)`
-  <tr><td>`tanh(x)`<td>Inherited from `sinh(x) / cosh(x)`
-  <tr><td>`trunc(x)`<td>Correctly rounded
+  <tr><td>`abs(x)`<td colspan=2>Correctly rounded
+  <tr><td>`acos(x)`<td colspan=2>Inherited from `atan2(sqrt(1.0 - x * x), x)`
+  <tr><td>`acosh(x)`<td colspan=2>Inherited from `log(x + sqrt(x * x - 1.0))`
+  <tr><td>`asin(x)`<td colspan=2>Inherited from `atan2(x, sqrt(1.0 - x * x))`
+  <tr><td>`asinh(x)`<td colspan=2>Inherited from `log(x + sqrt(x * x + 1.0))`
+  <tr><td>`atan(x)`<td>4096 ULP<td>5 ULP
+  <tr><td>`atan2(y, x)`<td>4096 ULP<td>5 ULP
+  <tr><td>`atanh(x)`<td colspan=2>Inherited from `log( (1.0 + x) / (1.0 - x) ) * 0.5`
+  <tr><td>`ceil(x)`<td colspan=2>Correctly rounded
+  <tr><td>`clamp(x,low,high)`<td colspan=2>Correctly rounded
+  <tr><td>`cos(x)`<td>Absolute error &le; 2<sup>-11</sup> inside the range of [-&pi;, &pi;]<td>Absolute error &le; 2<sup>-7</sup> inside the range of [-&pi;, &pi;]
+  <tr><td>`cosh(x)`<td colspan=2>Inherited from `(exp(x) - exp(-x)) * 0.5`
+  <tr><td>`cross(x, y)`<td colspan=2>Inherited from `(x[i] * y[j] - x[j] * y[i])`
+  <tr><td>`degrees(x)`<td colspan=2>Inherited from `x * 57.295779513082322865`
+  <tr><td>`distance(x, y)`<td colspan=2>Inherited from `length(x - y)`
+  <tr><td>`exp(x)`<td>`3 + 2 * |x|` ULP<td>`1 + 2 * |x|` ULP
+  <tr><td>`exp2(x)`<td>`3 + 2 * |x|` ULP<td>`1 + 2 * |x|` ULP
+  <tr><td class="nowrap">`faceForward(x, y, z)`<td colspan=2>Inherited from `select(-x, x, dot(z, y) < 0.0)`
+  <tr><td>`floor(x)`<td colspan=2>Correctly rounded
+  <tr><td>`fma(x, y, z)`<td colspan=2>Inherited from `x * y + z`
+  <tr><td>`fract(x)`<td colspan=2>Correctly rounded
+  <tr><td>`frexp(x)`<td colspan=2>Correctly rounded
+  <tr><td>`inverseSqrt(x)`<td colspan=2>2 ULP
+  <tr><td>`ldexp(x, y)`<td colspan=2>Correctly rounded
+  <tr><td>`length(x)`<td colspan=2>Inherited from `sqrt(dot(x, x))`
+  <tr><td>`log(x)`<td colspan=2>3 ULP outside the range [0.5, 2.0].<br>Absolute error &lt; 2<sup>-21</sup> inside the range [0.5, 2.0]
+  <tr><td>`log2(x)`<td colspan=2>3 ULP outside the range [0.5, 2.0].<br>Absolute error &lt; 2<sup>-21</sup> inside the range [0.5, 2.0]
+  <tr><td>`max(x, y)`<td colspan=2>Correctly rounded
+  <tr><td>`min(x, y)`<td colspan=2>Correctly rounded
+  <tr><td>`mix(x, y, z)`<td colspan=2>Inherited from `x * (1.0 - z) + y * z`
+  <tr><td>`modf(x)`<td colspan=2>Correctly rounded
+  <tr><td>`normalize(x)`<td colspan=2>Inherited from `x / length(x)`
+  <tr><td>`pow(x, y)`<td colspan=2>Inherited from `exp2(y * log2(x))`
+  <tr><td>`radians(x)`<td colspan=2>Inherited from `x * 0.017453292519943295474`
+  <tr><td>`reflect(x, y)`<td colspan=2>Inherited from `x - 2.0 * dot(x, y) * y`
+  <tr><td>`refract(x, y, z)`<td colspan=2>Inherited from `z * x - (z * dot(y, x) + sqrt(k)) * y`,<br>where `k = 1.0 - z * z * (1.0 - dot(y, x) * dot(y, x))`<br>If `k < 0.0` the result is precisely 0.0
+  <tr><td>`round(x)`<td colspan=2>Correctly rounded
+  <tr><td>`sign(x)`<td colspan=2>Correctly rounded
+  <tr><td>`sin(x)`<td>Absolute error &le; 2<sup>-11</sup> inside the range [-&pi;, &pi;]<td>Absolute error &le; 2<sup>-7</sup> inside the range [-&pi;, &pi;]
+  <tr><td>`sinh(x)`<td colspan=2>Inherited from `(exp(x) - exp(-x)) * 0.5`
+  <tr><td>`smoothStep(low, high, x)`<td colspan=2>Inherited from `t * t * (3.0 - 2.0 * t)`,<br>where `t = clamp((x - low) / (high - low), 0.0, 1.0)`
+  <tr><td>`sqrt(x)`<td colspan=2>Inherited from `1.0 / inverseSqrt(x)`
+  <tr><td>`step(edge, x)`<td colspan=2>Correctly rounded
+  <tr><td>`tan(x)`<td colspan=2>Inherited from `sin(x) / cos(x)`
+  <tr><td>`tanh(x)`<td colspan=2>Inherited from `sinh(x) / cosh(x)`
+  <tr><td>`trunc(x)`<td colspan=2>Correctly rounded
 
 </table>
 
@@ -7613,13 +7813,11 @@ than performing a multiply followed by an addition.
 ### Floating Point Conversion ### {#floating-point-conversion}
 
 In this section, a floating point type may be any of:
-* The [=f32=] type in WGSL.
+* The [=f32=] and [=f16=] type in WGSL.
 * A hypothetical type corresponding to a binary format defined by the [[!IEEE-754|IEEE-754]]
     floating point standard.
 
-    Note: The binary16 format is referenced in this way.
-
-Note: Recall that the [=f32=] WGSL type corresponds to the IEEE-754 binary32 format.
+Note: Recall that the [=f32=] WGSL type corresponds to the IEEE-754 binary32 format, and the [=f16=] WGSL type corresponds to the IEEE-754 binary16 format.
 
 When converting a floating point scalar value to an integral type:
 * If the original value is exactly representable in the destination type, then the result is that value.
@@ -7822,6 +8020,11 @@ Issue: https://github.com/gpuweb/gpuweb/issues/1621
   <dfn for=syntax>float32</dfn> :
 
     | `'f32'`
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>float16</dfn> :
+
+    | `'f16'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>int32</dfn> :
@@ -8418,8 +8621,6 @@ The following are reserved words:
     | `'extern'`   <!-- C++ Rust HLSL GLSL(reserved) -->
 
     | `'external'`   <!-- GLSL(reserved) -->
-
-    | `'f16'`   <!-- WGSL -->
 
     | `'f64'`   <!-- WGSL -->
 
@@ -9874,7 +10075,7 @@ See [[#function-calls]].
     [=Component-wise=] when |T| is a vector
 
   <tr algorithm="vector case, cross">
-    <td>|T| is f32
+    <td>|T| is f32 or f16
     <td class="nowrap">`cross(`|e1|`:` vec3<|T|> `, `|e2|`:` vec3<|T|>`) -> ` vec3<|T|>
     <td>Returns the cross product of |e1| and |e2|.
 
@@ -9902,7 +10103,7 @@ See [[#function-calls]].
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="faceForward">
-    <td>|T| is vec|N|&lt;f32&gt;
+    <td>|T| is vec|N|&lt;f32&gt; or vec|N|&lt;f16&gt;
     <td class="nowrap">`faceForward(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T| `) -> ` |T|
     <td>Returns |e1| if `dot(`|e2|`,`|e3|`)` is negative, and `-`|e1| otherwise.
 
@@ -9924,7 +10125,7 @@ See [[#function-calls]].
     <td>Returns the fractional part of |e|, computed as |e| `- floor(`|e|`)`.<br>
     [=Component-wise=] when |T| is a vector.
 
-  <tr algorithm="scalar case, frexp">
+  <tr algorithm="scalar case, binary32, frexp">
     <td>|T| is f32
     <td class="nowrap">`frexp(`|e|`: `|T|`) -> __frexp_result`<br>
     <td>Splits |e| into a significand and exponent of the form `significand * 2`<sup>`exponent`</sup>.
@@ -9948,7 +10149,22 @@ struct __frexp_result {
     </xmp>
     </div>
 
-  <tr algorithm="vector case, frexp">
+  <tr algorithm="scalar case, binary16, frexp">
+    <td>|T| is f16
+    <td class="nowrap">`frexp(`|e|`: `|T|`) -> __frexp_result_f16`<br>
+    <td>Splits |e| into a significand and exponent of the form `significand * 2`<sup>`exponent`</sup>.
+    Returns the `__frexp_result_f16` built-in structure, defined as if as follows:
+    ```rust
+struct __frexp_result_f16 {
+  sig : f16, // significand part
+  exp : i32  // exponent part
+}
+    ```
+    The magnitude of the significand is in the range of [0.5, 1.0) or 0.
+
+    Note: A value cannot be explicitly declared with the type `__frexp_result_f16`, but a value may infer the type.
+
+  <tr algorithm="vector case, binary32, frexp">
     <td>|T| is vec|N|&lt;f32&gt;
     <td class="nowrap">`frexp(`|e|`: `|T|`) -> __frexp_result_vec`|N|<br>
     <td>Splits the components of |e| into a significand and exponent of the form `significand * 2`<sup>`exponent`</sup>.
@@ -9962,6 +10178,21 @@ struct __frexp_result_vecN {
     The magnitude of each component of the significand is in the range of [0.5, 1.0) or 0.
 
     Note: A value cannot be explicitly declared with the type `__frexp_result_vec`|N|, but a value may infer the type.
+
+  <tr algorithm="vector case, binary16, frexp">
+    <td>|T| is vec|N|&lt;f16&gt;
+    <td class="nowrap">`frexp(`|e|`: `|T|`) -> __frexp_result_vec`|N|`_f16`<br>
+    <td>Splits the components of |e| into a significand and exponent of the form `significand * 2`<sup>`exponent`</sup>.
+    Returns the `__frexp_result_vec`|N| built-in structure, defined as if as follows:
+    ```rust
+struct __frexp_result_vecN_f16 {
+  sig : vecN<f16>, // significand part
+  exp : vecN<i32>  // exponent part
+}
+    ```
+    The magnitude of each component of the significand is in the range of [0.5, 1.0) or 0.
+
+    Note: A value cannot be explicitly declared with the type `__frexp_result_vec`|N|`_f16`, but a value may infer the type.
 
   <tr algorithm="inverseSqrt">
     <td>|T| is [FLOATING]
@@ -10019,13 +10250,13 @@ struct __frexp_result_vecN {
     <br>
 
   <tr algorithm="vector mix with scalar blending factor">
-    <td>|T| is vec|N|&lt;f32&gt;
-    <td class="nowrap">`mix(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` f32 `) -> ` |T|
+    <td>|T1| is f32 or f16<br>|T2| is vec|N|&lt;|T|&gt;
+    <td class="nowrap">`mix(`|e1|`:` |T2| `, `|e2|`:` |T2| `, `|e3|`:` |T1| `) -> ` |T2|
     <td>Returns the component-wise linear blend of |e1| and |e2|,
         using scalar blending factor |e3| for each component.<br>
-        Same as `mix(`|e1|`, `|e2|`, `|T|`(`|e3|`))`.
+        Same as `mix(`|e1|`, `|e2|`, `|T2|`(`|e3|`))`.
 
-  <tr algorithm="scalar case, modf">
+  <tr algorithm="scalar case, binary32, modf">
     <td>|T| is f32
     <td class="nowrap">`modf(`|e|`: `|T|`) -> __modf_result`<br>
     <td>Splits |e| into fractional and whole number parts.
@@ -10048,7 +10279,21 @@ struct __modf_result {
     </xmp>
     </div>
 
-  <tr algorithm="vector case, modf">
+  <tr algorithm="scalar case, binary16, modf">
+    <td>|T| is f16
+    <td class="nowrap">`modf(`|e|`: `|T|`) -> __modf_result_f16`<br>
+    <td>Splits |e| into fractional and whole number parts.
+    Returns the `__modf_result_f16` built-in structure, defined as if as follows:
+    ```rust
+struct __modf_result_f16 {
+  fract : f16, // fractional part
+  whole : f16  // whole part
+}
+    ```
+
+    Note: A value cannot be explicitly declared with the type `__modf_result_f16`, but a value may infer the type.
+
+  <tr algorithm="vector case, binary32, modf">
     <td>|T| is vec|N|&lt;f32&gt;
     <td class="nowrap">`modf(`|e|`: `|T|`) -> __modf_result_vec`|N|<br>
     <td>Splits the components of |e| into fractional and whole number parts.
@@ -10062,8 +10307,22 @@ struct __modf_result_vecN {
 
     Note: A value cannot be explicitly declared with the type `__modf_result_vec`|N|, but a value may infer the type.
 
+  <tr algorithm="vector case, binary16, modf">
+    <td>|T| is vec|N|&lt;f16&gt;
+    <td class="nowrap">`modf(`|e|`: `|T|`) -> __modf_result_vec`|N|`_f16`<br>
+    <td>Splits the components of |e| into fractional and whole number parts.
+    Returns the `__modf_result_vec`|N|`_f16` built-in structure, defined as if as follows:
+    ```rust
+struct __modf_result_vecN_f16 {
+  fract : vecN<f16>, // fractional part
+  whole : vecN<f16>  // whole part
+}
+    ```
+
+    Note: A value cannot be explicitly declared with the type `__modf_result_vec`|N|`_f16`, but a value may infer the type.
+
   <tr algorithm="vector case, normalize">
-    <td>|T| is f32
+    <td>|T| is f32 or f16
     <td class="nowrap">`normalize(`|e|`:` vec|N|<|T|> `) -> ` vec|N|<|T|>
     <td>Returns a unit vector in the same direction as |e|.
 
@@ -10074,7 +10333,7 @@ struct __modf_result_vecN {
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="quantize to f16">
-    <td>|T| is [FLOATING]
+    <td>|T| is f32 or vec|N|&lt;f32&gt;
     <td class="nowrap">`quantizeToF16(`|e|`:` |T| `) -> ` |T|
     <td>Quantizes a 32-bit floating point value |e| as if |e| were converted to a [[!IEEE-754|IEEE 754]] binary16 value,
         and then converted back to a IEEE 754 binary32 value.<br>
@@ -10090,14 +10349,14 @@ struct __modf_result_vecN {
     [=Component-wise=] when |T| is a vector<br>
 
   <tr algorithm="reflect">
-    <td>|T| is vec|N|&lt;f32&gt;
+    <td>|T| is vec|N|&lt;f32&gt; or vec|N|&lt;f16&gt;
     <td class="nowrap">`reflect(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>For the incident vector |e1| and surface orientation |e2|, returns the reflection direction
     |e1|`-2*dot(`|e2|`,`|e1|`)*`|e2|.
 
   <tr algorithm="refract">
-    <td>|T| is vec|N|&lt;f32&gt;<br>I is f32
-    <td class="nowrap">`refract(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |I| `) -> ` |T|
+    <td>|T1| is f32 or f16<br>|T2| is vec|N|&lt;|T1|&gt;
+    <td class="nowrap">`refract(`|e1|`:` |T2| `, `|e2|`:` |T2| `, `|e3|`:` |T1| `) -> ` |T2|
     <td>For the incident vector |e1| and surface normal |e2|, and the ratio of indices of refraction |e3|,
     let `k = 1.0 - `|e3|` * `|e3|` * (1.0 - dot(`|e2|`, `|e1|`) * dot(`|e2|`, `|e1|`))`. If `k < 0.0`, returns the
     refraction vector 0.0, otherwise return the refraction vector
@@ -10350,11 +10609,11 @@ struct __modf_result_vecN {
     <tr><th>Parameterization<th>Overload<th>Description
   </thead>
   <tr algorithm="determinant">
-    <td>|T| is f32
+    <td>|T| is f32 or f16
     <td class="nowrap">`determinant(`|e|`:` mat|N|x|N|<|T|> `) -> ` |T|
     <td>Returns the determinant of |e|.
   <tr algorithm="transpose">
-    <td>|T| is f32
+    <td>|T| is f32 or f16
     <td class="nowrap">`transpose(`|e|`:` mat|M|x|N|<|T|> `) -> ` mat|N|x|M|<|T|>
     <td>Returns the transpose of |e|.
 </table>
@@ -10365,7 +10624,7 @@ struct __modf_result_vecN {
   <thead>
     <tr><th>Parameterization<td>Overload<td>Description
   </thead>
-  <tr algorithm="float dot"><td>|T| is f32
+  <tr algorithm="float dot"><td>|T| is f32 or f16
     <td>`dot(`|e1|`: vecN<`|T|`>, `|e2|`: vecN<`|T|`>) ->` |T|
     <td>Returns the dot product of |e1| and |e2|.
   <tr algorithm="signed dot"><td>|T| is i32
@@ -11200,10 +11459,11 @@ reduce a shader's memory bandwidth demand.
 
 <table class='data'>
   <thead>
-    <tr><td>Overload<td>Description
+    <tr><td>Parameterization<td>Overload<td>Description
   </thead>
   <tr algorithm="packing 4x8snorm">
-    <td class="nowrap">`pack4x8snorm`(|e|: vec4&lt;f32&gt;) -> u32
+    <td>|T| is f32 or f16
+    <td class="nowrap">`pack4x8snorm`(|e|: vec4&lt;|T|&gt;) -> u32
     <td>Converts four normalized floating point values to 8-bit signed integers, and then combines them
         into one `u32` value.<br>
         Component |e|[|i|] of the input is converted to an 8-bit twos complement integer value
@@ -11212,7 +11472,8 @@ reduce a shader's memory bandwidth demand.
         8 &times; |i| + 7 of the result.
 
   <tr algorithm="packing 4x8unorm">
-    <td class="nowrap">`pack4x8unorm`(|e|: vec4&lt;f32&gt;) -> u32
+    <td>|T| is f32 or f16
+    <td class="nowrap">`pack4x8unorm`(|e|: vec4&lt;|T|&gt;) -> u32
     <td>Converts four normalized floating point values to 8-bit unsigned integers, and then combines them
         into one `u32` value.<br>
         Component |e|[|i|] of the input is converted to an 8-bit unsigned integer value
@@ -11221,7 +11482,8 @@ reduce a shader's memory bandwidth demand.
         8 &times; |i| + 7 of the result.
 
   <tr algorithm="packing 2x16snorm">
-    <td class="nowrap">`pack2x16snorm`(|e|: vec2&lt;f32&gt;) -> u32
+    <td>|T| is f32 or f16
+    <td class="nowrap">`pack2x16snorm`(|e|: vec2&lt;|T|&gt;) -> u32
     <td>Converts two normalized floating point values to 16-bit signed integers, and then combines them
         into one `u32` value.<br>
         Component |e|[|i|] of the input is converted to a 16-bit twos complement integer value
@@ -11230,7 +11492,8 @@ reduce a shader's memory bandwidth demand.
         16 &times; |i| + 15 of the result.
 
   <tr algorithm="packing 2x16unorm">
-    <td class="nowrap">`pack2x16unorm`(|e|: vec2&lt;f32&gt;) -> u32
+    <td>|T| is f32 or f16
+    <td class="nowrap">`pack2x16unorm`(|e|: vec2&lt;|T|&gt;) -> u32
     <td>Converts two normalized floating point values to 16-bit unsigned integers, and then combines them
         into one `u32` value.<br>
         Component |e|[|i|] of the input is converted to a 16-bit unsigned integer value
@@ -11238,15 +11501,24 @@ reduce a shader's memory bandwidth demand.
         16 &times; |i| through
         16 &times; |i| + 15 of the result.
 
-  <tr algorithm="packing 2x16float">
+  <tr algorithm="binary32, packing 2x16float">
+    <td>
     <td class="nowrap">`pack2x16float`(|e|: vec2&lt;f32&gt;) -> u32
-    <td>Converts two floating point values to half-precision floating point numbers, and then combines
+    <td>Converts two f32 floating point values to half-precision floating point numbers, and then combines
         them into one `u32` value.<br>
         Component |e|[|i|] of the input is converted to a [[!IEEE-754|IEEE-754]] binary16 value, which is then
         placed in bits
         16 &times; |i| through
         16 &times; |i| + 15 of the result.
         See [[#floating-point-conversion]].
+
+  <tr algorithm="binary16, packing 2x16float">
+    <td>
+    <td class="nowrap">`pack2x16float`(|e|: vec2&lt;f16&gt;) -> u32
+    <td>Combines two f16 floating point numbers into one u32 value.<br>
+        Component |e|[|i|] of the input is placed in bits
+        16 &times; |i| through
+        16 &times; |i| + 15 of the result.
 </table>
 
 ## Data Unpacking Built-in Functions ## {#unpack-builtin-functions}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7135,7 +7135,7 @@ the implementation can issue a clear diagnostic.
   </xmp>
 </div>
 
-## Extensions list # {#extension-list}
+## Extensions list ## {#extension-list}
 
 <table class='data'>
   <caption>Extension identifier</caption>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4016,12 +4016,12 @@ Details of conversion to and from floating point are explained in [[#floating-po
      <td>`vec`|N|&lt;`f16`&gt;`(`|e|`)`: vec|N|&lt;f16&gt;
      <td>[=Component-wise=] value conversion to binary16 floating point, including invalid cases.
 
-  <tr algorithm="vector conversion from unsigned integer to binary32 floating point">
+  <tr algorithm="vector conversion from unsigned integer to binary16 floating point">
      <td>|e|: vec|N|&lt;u32&gt;
      <td>`vec`|N|&lt;`f16`&gt;`(`|e|`)`: vec|N|&lt;f&gt;
      <td>[=Component-wise=] value conversion to binary16 floating point, including invalid cases.
 
-  <tr algorithm="vector conversion from binary16 floating point to binary32 floating point">
+  <tr algorithm="vector conversion from binary32 floating point to binary16 floating point">
      <td>|e|: vec|N|&lt;f32&gt;
      <td>`vec`|N|&lt;`f16`&gt;`(`|e|`)`: vec|N|&lt;f16&gt;
      <td>[=Component-wise=] loosy value conversion to binary16 floating point.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -11989,11 +11989,10 @@ reduce a shader's memory bandwidth demand.
 
 <table class='data'>
   <thead>
-    <tr><td>Parameterization<td>Overload<td>Description
+    <tr><td>Overload<td>Description
   </thead>
   <tr algorithm="packing 4x8snorm">
-    <td>|T| is f32 or f16
-    <td class="nowrap">`pack4x8snorm`(|e|: vec4&lt;|T|&gt;) -> u32
+    <td class="nowrap">`pack4x8snorm`(|e|: vec4&lt;f32&gt;) -> u32
     <td>Converts four normalized floating point values to 8-bit signed integers, and then combines them
         into one `u32` value.<br>
         Component |e|[|i|] of the input is converted to an 8-bit twos complement integer value
@@ -12002,8 +12001,7 @@ reduce a shader's memory bandwidth demand.
         8 &times; |i| + 7 of the result.
 
   <tr algorithm="packing 4x8unorm">
-    <td>|T| is f32 or f16
-    <td class="nowrap">`pack4x8unorm`(|e|: vec4&lt;|T|&gt;) -> u32
+    <td class="nowrap">`pack4x8unorm`(|e|: vec4&lt;f32&gt;) -> u32
     <td>Converts four normalized floating point values to 8-bit unsigned integers, and then combines them
         into one `u32` value.<br>
         Component |e|[|i|] of the input is converted to an 8-bit unsigned integer value
@@ -12012,8 +12010,7 @@ reduce a shader's memory bandwidth demand.
         8 &times; |i| + 7 of the result.
 
   <tr algorithm="packing 2x16snorm">
-    <td>|T| is f32 or f16
-    <td class="nowrap">`pack2x16snorm`(|e|: vec2&lt;|T|&gt;) -> u32
+    <td class="nowrap">`pack2x16snorm`(|e|: vec2&lt;f32&gt;) -> u32
     <td>Converts two normalized floating point values to 16-bit signed integers, and then combines them
         into one `u32` value.<br>
         Component |e|[|i|] of the input is converted to a 16-bit twos complement integer value
@@ -12022,8 +12019,7 @@ reduce a shader's memory bandwidth demand.
         16 &times; |i| + 15 of the result.
 
   <tr algorithm="packing 2x16unorm">
-    <td>|T| is f32 or f16
-    <td class="nowrap">`pack2x16unorm`(|e|: vec2&lt;|T|&gt;) -> u32
+    <td class="nowrap">`pack2x16unorm`(|e|: vec2&lt;f32&gt;) -> u32
     <td>Converts two normalized floating point values to 16-bit unsigned integers, and then combines them
         into one `u32` value.<br>
         Component |e|[|i|] of the input is converted to a 16-bit unsigned integer value
@@ -12031,24 +12027,15 @@ reduce a shader's memory bandwidth demand.
         16 &times; |i| through
         16 &times; |i| + 15 of the result.
 
-  <tr algorithm="binary32, packing 2x16float">
-    <td>
+  <tr algorithm="packing 2x16float">
     <td class="nowrap">`pack2x16float`(|e|: vec2&lt;f32&gt;) -> u32
-    <td>Converts two f32 floating point values to half-precision floating point numbers, and then combines
+    <td>Converts two floating point values to half-precision floating point numbers, and then combines
         them into one `u32` value.<br>
         Component |e|[|i|] of the input is converted to a [[!IEEE-754|IEEE-754]] binary16 value, which is then
         placed in bits
         16 &times; |i| through
         16 &times; |i| + 15 of the result.
         See [[#floating-point-conversion]].
-
-  <tr algorithm="binary16, packing 2x16float">
-    <td>
-    <td class="nowrap">`pack2x16float`(|e|: vec2&lt;f16&gt;) -> u32
-    <td>Combines two f16 floating point numbers into one u32 value.<br>
-        Component |e|[|i|] of the input is placed in bits
-        16 &times; |i| through
-        16 &times; |i| + 15 of the result.
 </table>
 
 ## Data Unpacking Built-in Functions ## {#unpack-builtin-functions}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7090,7 +7090,7 @@ described by a particular named
 [=extension=] may be used.
 The grammar rules imply that all enable directives must appear before any [=declarations=].
 
-The directive uses an [=identifier=], [=keyword=], or [=reserved word=] to name the extension.
+The directive uses an [=identifier=], [=keyword=], or [=reserved word=] to name the extension. The valid extension name are listed in [[#extension-list]].
 
 If the name is an identifier, the directive does not
 create a [=scope=] for the identifier.
@@ -7135,7 +7135,7 @@ the implementation can issue a clear diagnostic.
   </xmp>
 </div>
 
-## Extensions list
+## Extensions list # {#extension-list}
 
 <table class='data'>
   <caption>Extension identifier</caption>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2394,8 +2394,8 @@ A value |V| of type [=f16=] is represented in [[!IEEE-754|IEEE-754]] binary16 fo
 It has one sign bit, 5 exponent bits, and 10 fraction bits.
 When |V| is placed at byte offset |k| of host-shared buffer, then:
    * Byte |k| contains bits 0 through 7 of the fraction.
-   * Bits 0 through 1 of byte |k|+1 contains bits 8 through 9 of the fraction.
-   * Bits 2 through 6 of byte |k|+1 contains bits 0 through 4 of the exponent.
+   * Bits 0 through 1 of byte |k|+1 contain bits 8 through 9 of the fraction.
+   * Bits 2 through 6 of byte |k|+1 contain bits 0 through 4 of the exponent.
    * Bit 7 of byte |k|+1 contains the sign bit.
 
 Note: The above rules imply that numeric values in host-shared buffers

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -489,8 +489,8 @@ or a hexadecimal floating point literal.
     * Then an optional exponent suffix consisting of:
         * `e` or `E`.
         * Then an exponent specified as an decimal number with an optional leading sign (`+` or `-`).
-        * Then an optional `f` suffix.
-    * At least one of the decimal point, or the exponent, or the `f` suffix must be present.
+        * Then an optional `f` or `h` suffix.
+    * At least one of the decimal point, or the exponent, or the `f` or `h` suffix must be present.
          If none are, then the token is instead an [=integer literal=].
     * The value of the literal is the value of the mantissa multiplied by 10 to the power of the exponent.
          When no exponent is specified, an exponent of 0 is assumed.
@@ -501,7 +501,7 @@ or a hexadecimal floating point literal.
     * Then an optional exponent suffix consisting of:
         * `p` or `P`
         * Then an exponent specified as an decimal number with an optional leading sign (`+` or `-`).
-        * Then an optional `f` suffix.
+        * Then an optional `f` or `h` suffix.
     * At least one of the hexadecimal point, or the exponent must be present.
          If neither are, then the token is instead an [=integer literal=].
     * The value of the literal is the value of the mantissa multiplied by 2 to the power of the exponent.
@@ -518,7 +518,7 @@ or a hexadecimal floating point literal.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>decimal_float_literal</dfn> :
 
-    | `/((([0-9]*\.[0-9]+|[0-9]+\.[0-9]*)([eE](\+|-)?[0-9]+)?)|([0-9]+[eE](\+|-)?[0-9]+))f?|0f|[1-9][0-9]*f/`
+    | `/((([0-9]*\.[0-9]+|[0-9]+\.[0-9]*)([eE](\+|-)?[0-9]+)?)|([0-9]+[eE](\+|-)?[0-9]+))[fh]?|0[fh]|[1-9][0-9]*[fh]/`
 </div>
 
 <div class='syntax' noexport='true'>
@@ -550,13 +550,14 @@ Otherwise, the literal denotes a value one of the [=abstract numeric types=] def
   <tr><td>[=integer literal=]<td>`u`<td>[=u32=]<td>42u
   <tr><td>[=integer literal=]<td><td>[=AbstractInt=]<td>124
   <tr><td>[=floating point literal=]<td>`f`<td>[=f32=]<td>42f 1e5f 1.2f 0x1.0p10f
+  <tr><td>[=floating point literal=]<td>`h`<td>[=f16=]<td>42h 1e5h 1.2h 0x1.0p10h
   <tr><td>[=floating point literal=]<td><td>[=AbstractFloat=]<td>1e5 1.2 0x1.0p10
 </table>
 
 A [=shader-creation error=] results if:
 * An [=integer literal=] with a `i` or `u` suffix cannot be represented by the target type.
-* A [=hexadecimal floating point literal=] with a `f` suffix overflows or cannot be exactly represented by the target type.
-* A [=decimal floating point literal=] with a `f` suffix overflows the target type.
+* A [=hexadecimal floating point literal=] with a `f` or `h` suffix overflows or cannot be exactly represented by the target type.
+* A [=decimal floating point literal=] with a `f` or `h` suffix overflows the target type.
 
 Note: The hexadecimal float value 0x1.00000001p0 requires 33 mantissa bits to be represented exactly,
 but [=f32=] only has 23 explicit mantissa bits.
@@ -1134,26 +1135,36 @@ Note: When no conversion is performed, the conversion rank is zero.
       <td>f32
       <td>1
       <td>
+  <tr algorithm="conversion rank abstract float to f16">
+      <td>[=AbstractFloat=]
+      <td>f16
+      <td>2
+      <td>
   <tr algorithm="conversion rank abstract int to i32">
       <td>[=AbstractInt=]
       <td>i32
-      <td>2
+      <td>3
       <td>
   <tr algorithm="conversion rank abstract int to u32">
       <td>[=AbstractInt=]
       <td>u32
-      <td>3
+      <td>4
       <td>
   <tr algorithm="conversion rank abstract int to abstract float">
       <td>[=AbstractInt=]
       <td>[=AbstractFloat=]
-      <td>4
+      <td>5
       <td>
   <tr algorithm="conversion rank abstract int to f32">
       <td>[=AbstractInt=]
       <td>f32
-      <td>5
+      <td>6
       <td>Behaves as [=AbstractInt=] to [=AbstractFloat=], and then [=AbstractFloat=] to f32
+  <tr algorithm="conversion rank abstract int to f16">
+      <td>[=AbstractInt=]
+      <td>f16
+      <td>7
+      <td>Behaves as [=AbstractInt=] to [=AbstractFloat=], and then [=AbstractFloat=] to f16
   <tr algorithm="conversion rank for non-convertible cases">
       <td>|S|
       <td>|T|<br>where above cases don't apply
@@ -7557,7 +7568,7 @@ the implementation can issue a clear diagnostic.
         <th>Description
   </thead>
   <tr><td>`f16`
-      <td>`"fp16-in-shader-and-buffer"`
+      <td>`"shader-f16"`
       <td>Keyword `f16` is valid if and only if this extension is enabled. Otherwise, using `f16` keyword will result in shader-creation error.
 </table>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -558,6 +558,7 @@ A [=shader-creation error=] results if:
 * An [=integer literal=] with a `i` or `u` suffix cannot be represented by the target type.
 * A [=hexadecimal floating point literal=] with a `f` or `h` suffix overflows or cannot be exactly represented by the target type.
 * A [=decimal floating point literal=] with a `f` or `h` suffix overflows the target type.
+* A [=floating point literal=] with a `h` suffix is used while the [=extension/f16|f16 extension=] is not enabled.
 
 Note: The hexadecimal float value 0x1.00000001p0 requires 33 mantissa bits to be represented exactly,
 but [=f32=] only has 23 explicit mantissa bits.
@@ -935,7 +936,7 @@ For example, the mathematical number 1 corresponds to these distinct values in [
 * the 32-bit signed integer value `1i`,
 * the 32-bit unsigned integer value `1u`,
 * the 32-bit floating point value `1.0f`,
-* the 16-bit floating point value `1.0h` if `f16` extension is enabled,
+* the 16-bit floating point value `1.0h` if the [=extension/f16|f16 extension=] is enabled,
 * the [=AbstractInt=] value 1, and
 * the [=AbstractFloat=] value 1.0
 
@@ -1449,7 +1450,7 @@ It uses a two's complementation representation, with the sign bit in the most si
 The <dfn noexport>f32</dfn> type is the set of 32-bit floating point values of the [[!IEEE-754|IEEE-754]] binary32 (single precision) format.
 See [[#floating-point-evaluation]] for details.
 
-The <dfn noexport>f16</dfn> type is the set of 16-bit floating point values of the [[!IEEE-754|IEEE-754]] binary16 (half precision) format. Using [=f16=] type is allowed if and only if the program has an "enable f16;" directive, otherwise there is a shader-creation error. The support for "enable f16;" directive is optional. See [[#floating-point-evaluation]] for details.
+The <dfn noexport>f16</dfn> type is the set of 16-bit floating point values of the [[!IEEE-754|IEEE-754]] binary16 (half precision) format. It is a [=shader-creation error=] if the [=f16=] type is used unless the program contains the "enable f16;" directive to enable the [=extension/f16|f16 extension=]. See [[#floating-point-evaluation]] for details.
 
 ### Scalar Types ### {#scalar-types}
 
@@ -4053,47 +4054,47 @@ specify the component type; the component type is inferred from the constructor 
         `mat3x4(e1,...,e12)`: mat3x4&lt;|T|&gt;<br>
         `mat4x4(e1,...,e16)`: mat4x4&lt;|T|&gt;
   <tr>
-    <td rowspan=2>*e1*: vec2&lt;*T*&gt;<br>
-        *e2*: vec2&lt;*T*&gt;<br>
-        *e3*: vec2&lt;*T*&gt;<br>
-        *e4*: vec2&lt;*T*&gt;<br>
-        *T* is f32 or f16
-    <td>`mat2x2<T>(e1,e2)`: mat2x2&lt;*T*&gt;<br>
-        `mat3x2<T>(e1,e2,e3)`: mat3x2&lt;*T*&gt;<br>
-        `mat4x2<T>(e1,e2,e3,e4)`: mat4x2&lt;*T*&gt;
+    <td rowspan=2>*e1*: vec2&lt;|T|&gt;<br>
+        *e2*: vec2&lt;|T|&gt;<br>
+        *e3*: vec2&lt;|T|&gt;<br>
+        *e4*: vec2&lt;|T|&gt;<br>
+        |T| is f32 or f16
+    <td>`mat2x2<T>(e1,e2)`: mat2x2&lt;|T|&gt;<br>
+        `mat3x2<T>(e1,e2,e3)`: mat3x2&lt;|T|&gt;<br>
+        `mat4x2<T>(e1,e2,e3,e4)`: mat4x2&lt;|T|&gt;
     <td rowspan=2>Column by column construction.<br>
   <tr>
-    <td>`mat2x2(e1,e2)`: mat2x2&lt;*T*&gt;<br>
-        `mat3x2(e1,e2,e3)`: mat3x2&lt;*T*&gt;<br>
-        `mat4x2(e1,e2,e3,e4)`: mat4x2&lt;*T*&gt;
+    <td>`mat2x2(e1,e2)`: mat2x2&lt;|T|&gt;<br>
+        `mat3x2(e1,e2,e3)`: mat3x2&lt;|T|&gt;<br>
+        `mat4x2(e1,e2,e3,e4)`: mat4x2&lt;|T|&gt;
   <tr>
-    <td rowspan=2>*e1*: vec3&lt;*T*&gt;<br>
-        *e2*: vec3&lt;*T*&gt;<br>
-        *e3*: vec3&lt;*T*&gt;<br>
-        *e4*: vec3&lt;*T*&gt;<br>
-        *T* is f32 or f16
-    <td>`mat2x3<T>(e1,e2)`: mat2x3&lt;*T*&gt;<br>
-        `mat3x3<T>(e1,e2,e3)`: mat3x3&lt;*T*&gt;<br>
-        `mat4x3<T>(e1,e2,e3,e4)`: mat4x3&lt;*T*&gt;
+    <td rowspan=2>*e1*: vec3&lt;|T|&gt;<br>
+        *e2*: vec3&lt;|T|&gt;<br>
+        *e3*: vec3&lt;|T|&gt;<br>
+        *e4*: vec3&lt;|T|&gt;<br>
+        |T| is f32 or f16
+    <td>`mat2x3<T>(e1,e2)`: mat2x3&lt;|T|&gt;<br>
+        `mat3x3<T>(e1,e2,e3)`: mat3x3&lt;|T|&gt;<br>
+        `mat4x3<T>(e1,e2,e3,e4)`: mat4x3&lt;|T|&gt;
     <td rowspan=2>Column by column construction.<br>
   <tr>
-    <td>`mat2x3(e1,e2)`: mat2x3&lt;*T*&gt;<br>
-        `mat3x3(e1,e2,e3)`: mat3x3&lt;*T*&gt;<br>
-        `mat4x3(e1,e2,e3,e4)`: mat4x3&lt;*T*&gt;
+    <td>`mat2x3(e1,e2)`: mat2x3&lt;|T|&gt;<br>
+        `mat3x3(e1,e2,e3)`: mat3x3&lt;|T|&gt;<br>
+        `mat4x3(e1,e2,e3,e4)`: mat4x3&lt;|T|&gt;
   <tr>
-    <td rowspan=2>*e1*: vec4&lt;*T*&gt;<br>
-        *e2*: vec4&lt;*T*&gt;<br>
-        *e3*: vec4&lt;*T*&gt;<br>
-        *e4*: vec4&lt;*T*&gt;<br>
-        *T* is f32 or f16
-    <td>`mat2x4<T>(e1,e2)`: mat2x4&lt;*T*&gt;<br>
-        `mat3x4<T>(e1,e2,e3)`: mat3x4&lt;*T*&gt;<br>
-        `mat4x4<T>(e1,e2,e3,e4)`: mat4x4&lt;*T*&gt;
+    <td rowspan=2>*e1*: vec4&lt;|T|&gt;<br>
+        *e2*: vec4&lt;|T|&gt;<br>
+        *e3*: vec4&lt;|T|&gt;<br>
+        *e4*: vec4&lt;|T|&gt;<br>
+        |T| is f32 or f16
+    <td>`mat2x4<T>(e1,e2)`: mat2x4&lt;|T|&gt;<br>
+        `mat3x4<T>(e1,e2,e3)`: mat3x4&lt;|T|&gt;<br>
+        `mat4x4<T>(e1,e2,e3,e4)`: mat4x4&lt;|T|&gt;
     <td rowspan=2>Column by column construction.<br>
   <tr>
-    <td>`mat2x4(e1,e2)`: mat2x4&lt;*T*&gt;<br>
-        `mat3x4(e1,e2,e3)`: mat3x4&lt;*T*&gt;<br>
-        `mat4x4(e1,e2,e3,e4)`: mat4x4&lt;*T*&gt;
+    <td>`mat2x4(e1,e2)`: mat2x4&lt;|T|&gt;<br>
+        `mat3x4(e1,e2,e3)`: mat3x4&lt;|T|&gt;<br>
+        `mat4x4(e1,e2,e3,e4)`: mat4x4&lt;|T|&gt;
 </table>
 
 <table class='data'>
@@ -4142,7 +4143,7 @@ The zero values are as follows:
 * `f32()` is 0.0
 * `f16()` is 0.0
 * The zero value for an *N*-component vector of type *T* is the *N*-component vector of the zero value for *T*.
-* The zero value for an *N*-column *M*-row matrix of `f32` or `f16` is the matrix of those dimensions filled with 0.0 entries.
+* The zero value for an *N*-column *M*-row matrix of type *T* is the matrix of those dimensions filled with the zero value for *T*.
 * The zero value for a [=constructible=] *N*-element array with element type *E* is an array of *N* elements of the zero value for *E*.
 * The zero value for a [=constructible=] structure type *S* is the structure value *S* with zero-valued members.
 
@@ -4162,21 +4163,21 @@ Note: WGSL does not have zero expression for [=atomic types=],
 </table>
 
 <table class='data'>
-  <caption>Vector zero type rules, where *T* is a scalar type</caption>
+  <caption>Vector zero type rules, where |T| is a scalar type</caption>
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr>
     <td>
-    <td>`vec2<T>()`: vec2<*T*>
+    <td>`vec2<T>()`: vec2<|T|>
     <td>Zero value
   <tr>
     <td>
-    <td>`vec3<T>()`: vec3<*T*>
+    <td>`vec3<T>()`: vec3<|T|>
     <td>Zero value
   <tr>
     <td>
-    <td>`vec4<T>()`: vec4<*T*>
+    <td>`vec4<T>()`: vec4<|T|>
     <td>Zero value
 </table>
 
@@ -4197,22 +4198,22 @@ Note: WGSL does not have zero expression for [=atomic types=],
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr>
-    <td>*T* is f32 or f16
-    <td>`mat2x2<T>()`: mat2x2&lt;*T*&gt;<br>
-        `mat3x2<T>()`: mat3x2&lt;*T*&gt;<br>
-        `mat4x2<T>()`: mat4x2&lt;*T*&gt;
+    <td>|T| is f32 or f16
+    <td>`mat2x2<T>()`: mat2x2&lt;|T|&gt;<br>
+        `mat3x2<T>()`: mat3x2&lt;|T|&gt;<br>
+        `mat4x2<T>()`: mat4x2&lt;|T|&gt;
     <td>Zero value
   <tr>
     <td>
-    <td>`mat2x3<T>()`: mat2x3&lt;*T*&gt;<br>
-        `mat3x3<T>()`: mat3x3&lt;*T*&gt;<br>
-        `mat4x3<T>()`: mat4x3&lt;*T*&gt;
+    <td>`mat2x3<T>()`: mat2x3&lt;|T|&gt;<br>
+        `mat3x3<T>()`: mat3x3&lt;|T|&gt;<br>
+        `mat4x3<T>()`: mat4x3&lt;|T|&gt;
     <td>Zero value
   <tr>
     <td>
-    <td>`mat2x4<T>()`: mat2x4&lt;*T*&gt;<br>
-        `mat3x4<T>()`: mat3x4&lt;*T*&gt;<br>
-        `mat4x4<T>()`: mat4x4&lt;*T*&gt;
+    <td>`mat2x4<T>()`: mat2x4&lt;|T|&gt;<br>
+        `mat3x4<T>()`: mat3x4&lt;|T|&gt;<br>
+        `mat4x4<T>()`: mat4x4&lt;|T|&gt;
     <td>Zero value
 </table>
 
@@ -4460,7 +4461,7 @@ Details of conversion to and from floating point are explained in [[#floating-po
   <tr algorithm="vector conversion from binary32 floating point to binary16 floating point">
      <td>|e|: vec|N|&lt;f32&gt;
      <td>`vec`|N|&lt;`f16`&gt;`(`|e|`)`: vec|N|&lt;f16&gt;
-     <td>[=Component-wise=] loosy value conversion to binary16 floating point.
+     <td>[=Component-wise=] lossy value conversion to binary16 floating point.
 
 </table>
 
@@ -4477,7 +4478,7 @@ Details of conversion to and from floating point are explained in [[#floating-po
   <tr algorithm="vector coercion of binary32 floating point to binary16 floating point">
      <td>|e|: mat|N|x|M|&lt;f32&gt;
      <td>`mat`|N|`x`|M|&lt;`f16`&gt;`(`|e|`)`: mat|N|x|M|&lt;f16&gt
-     <td>[=Component-wise=] loosy value conversion to binary16 floating point.
+     <td>[=Component-wise=] lossy value conversion to binary16 floating point.
 
 </table>
 
@@ -7567,9 +7568,9 @@ the implementation can issue a clear diagnostic.
         <th>WebGPU extension name
         <th>Description
   </thead>
-  <tr><td>`f16`
+  <tr><td><dfn noexport dfn-for="extension">`f16`</dfn>
       <td>`"shader-f16"`
-      <td>Keyword `f16` is valid if and only if this extension is enabled. Otherwise, using `f16` keyword will result in shader-creation error.
+      <td>Keyword `f16` and any [=floating point literal=] with a `h` suffix is valid if and only if this extension is enabled. Otherwise, using `f16` keyword or any [=floating point literal=] with a `h` suffix will result in a [=shader-creation error=].
 </table>
 
 # WGSL Program # {#wgsl-program}
@@ -8241,19 +8242,19 @@ value with the same sign.
     <tr><th>Expression<th>Accuracy for f32<th>Accuracy for f16
   </thead>
 
-  <tr><td>`x + y`<td colspan=2>Correctly rounded
-  <tr><td>`x - y`<td colspan=2>Correctly rounded
-  <tr><td>`x * y`<td colspan=2>Correctly rounded
+  <tr><td>`x + y`<td colspan=2 style="text-align:left;">Correctly rounded
+  <tr><td>`x - y`<td colspan=2 style="text-align:left;">Correctly rounded
+  <tr><td>`x * y`<td colspan=2 style="text-align:left;">Correctly rounded
   <tr><td>`x / y`<td>2.5 ULP for `|y|` in the range [2<sup>-126</sup>, 2<sup>126</sup>]<td>2.5 ULP for `|y|` in the range [2<sup>-14</sup>, 2<sup>14</sup>]
-  <tr><td>`x % y`<td colspan=2>Derived from `x - y * trunc(x/y)`
-  <tr><td>`-x`<td colspan=2>Correctly rounded
+  <tr><td>`x % y`<td colspan=2 style="text-align:left;">Derived from `x - y * trunc(x/y)`
+  <tr><td>`-x`<td colspan=2 style="text-align:left;">Correctly rounded
 
-  <tr><td>`x == y`<td colspan=2>Correct result
-  <tr><td>`x != y`<td colspan=2>Correct result
-  <tr><td>`x < y`<td colspan=2>Correct result
-  <tr><td>`x <= y`<td colspan=2>Correct result
-  <tr><td>`x > y`<td colspan=2>Correct result
-  <tr><td>`x >= y`<td colspan=2>Correct result
+  <tr><td>`x == y`<td colspan=2 style="text-align:left;">Correct result
+  <tr><td>`x != y`<td colspan=2 style="text-align:left;">Correct result
+  <tr><td>`x < y`<td colspan=2 style="text-align:left;">Correct result
+  <tr><td>`x <= y`<td colspan=2 style="text-align:left;">Correct result
+  <tr><td>`x > y`<td colspan=2 style="text-align:left;">Correct result
+  <tr><td>`x >= y`<td colspan=2 style="text-align:left;">Correct result
 </table>
 
 <table class='data'>
@@ -8262,52 +8263,52 @@ value with the same sign.
     <tr><th>Built-in Function<th>Accuracy for f32<th>Accuracy for f16
   </thead>
 
-  <tr><td>`abs(x)`<td colspan=2>Correctly rounded
-  <tr><td>`acos(x)`<td colspan=2>Inherited from `atan2(sqrt(1.0 - x * x), x)`
-  <tr><td>`acosh(x)`<td colspan=2>Inherited from `log(x + sqrt(x * x - 1.0))`
-  <tr><td>`asin(x)`<td colspan=2>Inherited from `atan2(x, sqrt(1.0 - x * x))`
-  <tr><td>`asinh(x)`<td colspan=2>Inherited from `log(x + sqrt(x * x + 1.0))`
+  <tr><td>`abs(x)`<td colspan=2 style="text-align:left;">Correctly rounded
+  <tr><td>`acos(x)`<td colspan=2 style="text-align:left;">Inherited from `atan2(sqrt(1.0 - x * x), x)`
+  <tr><td>`acosh(x)`<td colspan=2 style="text-align:left;">Inherited from `log(x + sqrt(x * x - 1.0))`
+  <tr><td>`asin(x)`<td colspan=2 style="text-align:left;">Inherited from `atan2(x, sqrt(1.0 - x * x))`
+  <tr><td>`asinh(x)`<td colspan=2 style="text-align:left;">Inherited from `log(x + sqrt(x * x + 1.0))`
   <tr><td>`atan(x)`<td>4096 ULP<td>5 ULP
   <tr><td>`atan2(y, x)`<td>4096 ULP<td>5 ULP
-  <tr><td>`atanh(x)`<td colspan=2>Inherited from `log( (1.0 + x) / (1.0 - x) ) * 0.5`
-  <tr><td>`ceil(x)`<td colspan=2>Correctly rounded
-  <tr><td>`clamp(x,low,high)`<td colspan=2>Correctly rounded
+  <tr><td>`atanh(x)`<td colspan=2 style="text-align:left;">Inherited from `log( (1.0 + x) / (1.0 - x) ) * 0.5`
+  <tr><td>`ceil(x)`<td colspan=2 style="text-align:left;">Correctly rounded
+  <tr><td>`clamp(x,low,high)`<td colspan=2 style="text-align:left;">Correctly rounded
   <tr><td>`cos(x)`<td>Absolute error &le; 2<sup>-11</sup> inside the range of [-&pi;, &pi;]<td>Absolute error &le; 2<sup>-7</sup> inside the range of [-&pi;, &pi;]
-  <tr><td>`cosh(x)`<td colspan=2>Inherited from `(exp(x) - exp(-x)) * 0.5`
-  <tr><td>`cross(x, y)`<td colspan=2>Inherited from `(x[i] * y[j] - x[j] * y[i])`
-  <tr><td>`degrees(x)`<td colspan=2>Inherited from `x * 57.295779513082322865`
-  <tr><td>`distance(x, y)`<td colspan=2>Inherited from `length(x - y)`
+  <tr><td>`cosh(x)`<td colspan=2 style="text-align:left;">Inherited from `(exp(x) - exp(-x)) * 0.5`
+  <tr><td>`cross(x, y)`<td colspan=2 style="text-align:left;">Inherited from `(x[i] * y[j] - x[j] * y[i])`
+  <tr><td>`degrees(x)`<td colspan=2 style="text-align:left;">Inherited from `x * 57.295779513082322865`
+  <tr><td>`distance(x, y)`<td colspan=2 style="text-align:left;">Inherited from `length(x - y)`
   <tr><td>`exp(x)`<td>`3 + 2 * |x|` ULP<td>`1 + 2 * |x|` ULP
   <tr><td>`exp2(x)`<td>`3 + 2 * |x|` ULP<td>`1 + 2 * |x|` ULP
-  <tr><td class="nowrap">`faceForward(x, y, z)`<td colspan=2>Inherited from `select(-x, x, dot(z, y) < 0.0)`
-  <tr><td>`floor(x)`<td colspan=2>Correctly rounded
-  <tr><td>`fma(x, y, z)`<td colspan=2>Inherited from `x * y + z`
-  <tr><td>`fract(x)`<td colspan=2>Correctly rounded
-  <tr><td>`frexp(x)`<td colspan=2>Correctly rounded
-  <tr><td>`inverseSqrt(x)`<td colspan=2>2 ULP
-  <tr><td>`ldexp(x, y)`<td colspan=2>Correctly rounded
-  <tr><td>`length(x)`<td colspan=2>Inherited from `sqrt(dot(x, x))`
+  <tr><td class="nowrap">`faceForward(x, y, z)`<td colspan=2 style="text-align:left;">Inherited from `select(-x, x, dot(z, y) < 0.0)`
+  <tr><td>`floor(x)`<td colspan=2 style="text-align:left;">Correctly rounded
+  <tr><td>`fma(x, y, z)`<td colspan=2 style="text-align:left;">Inherited from `x * y + z`
+  <tr><td>`fract(x)`<td colspan=2 style="text-align:left;">Correctly rounded
+  <tr><td>`frexp(x)`<td colspan=2 style="text-align:left;">Correctly rounded
+  <tr><td>`inverseSqrt(x)`<td colspan=2 style="text-align:left;">2 ULP
+  <tr><td>`ldexp(x, y)`<td colspan=2 style="text-align:left;">Correctly rounded
+  <tr><td>`length(x)`<td colspan=2 style="text-align:left;">Inherited from `sqrt(dot(x, x))`
   <tr><td>`log(x)`<td>3 ULP outside the range [0.5, 2.0].<br>Absolute error &lt; 2<sup>-21</sup> inside the range [0.5, 2.0]<td>3 ULP outside the range [0.5, 2.0].<br>Absolute error &lt; 2<sup>-7</sup> inside the range [0.5, 2.0]
   <tr><td>`log2(x)`<td>3 ULP outside the range [0.5, 2.0].<br>Absolute error &lt; 2<sup>-21</sup> inside the range [0.5, 2.0]<td>3 ULP outside the range [0.5, 2.0].<br>Absolute error &lt; 2<sup>-7</sup> inside the range [0.5, 2.0]
-  <tr><td>`max(x, y)`<td colspan=2>Correctly rounded
-  <tr><td>`min(x, y)`<td colspan=2>Correctly rounded
-  <tr><td>`mix(x, y, z)`<td colspan=2>Inherited from `x * (1.0 - z) + y * z`
-  <tr><td>`modf(x)`<td colspan=2>Correctly rounded
-  <tr><td>`normalize(x)`<td colspan=2>Inherited from `x / length(x)`
-  <tr><td>`pow(x, y)`<td colspan=2>Inherited from `exp2(y * log2(x))`
-  <tr><td>`radians(x)`<td colspan=2>Inherited from `x * 0.017453292519943295474`
-  <tr><td>`reflect(x, y)`<td colspan=2>Inherited from `x - 2.0 * dot(x, y) * y`
-  <tr><td>`refract(x, y, z)`<td colspan=2>Inherited from `z * x - (z * dot(y, x) + sqrt(k)) * y`,<br>where `k = 1.0 - z * z * (1.0 - dot(y, x) * dot(y, x))`<br>If `k < 0.0` the result is precisely 0.0
-  <tr><td>`round(x)`<td colspan=2>Correctly rounded
-  <tr><td>`sign(x)`<td colspan=2>Correctly rounded
+  <tr><td>`max(x, y)`<td colspan=2 style="text-align:left;">Correctly rounded
+  <tr><td>`min(x, y)`<td colspan=2 style="text-align:left;">Correctly rounded
+  <tr><td>`mix(x, y, z)`<td colspan=2 style="text-align:left;">Inherited from `x * (1.0 - z) + y * z`
+  <tr><td>`modf(x)`<td colspan=2 style="text-align:left;">Correctly rounded
+  <tr><td>`normalize(x)`<td colspan=2 style="text-align:left;">Inherited from `x / length(x)`
+  <tr><td>`pow(x, y)`<td colspan=2 style="text-align:left;">Inherited from `exp2(y * log2(x))`
+  <tr><td>`radians(x)`<td colspan=2 style="text-align:left;">Inherited from `x * 0.017453292519943295474`
+  <tr><td>`reflect(x, y)`<td colspan=2 style="text-align:left;">Inherited from `x - 2.0 * dot(x, y) * y`
+  <tr><td>`refract(x, y, z)`<td colspan=2 style="text-align:left;">Inherited from `z * x - (z * dot(y, x) + sqrt(k)) * y`,<br>where `k = 1.0 - z * z * (1.0 - dot(y, x) * dot(y, x))`<br>If `k < 0.0` the result is precisely 0.0
+  <tr><td>`round(x)`<td colspan=2 style="text-align:left;">Correctly rounded
+  <tr><td>`sign(x)`<td colspan=2 style="text-align:left;">Correctly rounded
   <tr><td>`sin(x)`<td>Absolute error &le; 2<sup>-11</sup> inside the range [-&pi;, &pi;]<td>Absolute error &le; 2<sup>-7</sup> inside the range [-&pi;, &pi;]
-  <tr><td>`sinh(x)`<td colspan=2>Inherited from `(exp(x) - exp(-x)) * 0.5`
-  <tr><td>`smoothstep(low, high, x)`<td colspan=2>Inherited from `t * t * (3.0 - 2.0 * t)`,<br>where `t = clamp((x - low) / (high - low), 0.0, 1.0)`
-  <tr><td>`sqrt(x)`<td colspan=2>Inherited from `1.0 / inverseSqrt(x)`
-  <tr><td>`step(edge, x)`<td colspan=2>Correctly rounded
-  <tr><td>`tan(x)`<td colspan=2>Inherited from `sin(x) / cos(x)`
-  <tr><td>`tanh(x)`<td colspan=2>Inherited from `sinh(x) / cosh(x)`
-  <tr><td>`trunc(x)`<td colspan=2>Correctly rounded
+  <tr><td>`sinh(x)`<td colspan=2 style="text-align:left;">Inherited from `(exp(x) - exp(-x)) * 0.5`
+  <tr><td>`smoothstep(low, high, x)`<td colspan=2 style="text-align:left;">Inherited from `t * t * (3.0 - 2.0 * t)`,<br>where `t = clamp((x - low) / (high - low), 0.0, 1.0)`
+  <tr><td>`sqrt(x)`<td colspan=2 style="text-align:left;">Inherited from `1.0 / inverseSqrt(x)`
+  <tr><td>`step(edge, x)`<td colspan=2 style="text-align:left;">Correctly rounded
+  <tr><td>`tan(x)`<td colspan=2 style="text-align:left;">Inherited from `sin(x) / cos(x)`
+  <tr><td>`tanh(x)`<td colspan=2 style="text-align:left;">Inherited from `sinh(x) / cosh(x)`
+  <tr><td>`trunc(x)`<td colspan=2 style="text-align:left;">Correctly rounded
 
 </table>
 


### PR DESCRIPTION
FP16 extension against the whole spec, merging the proposed changes into WebGPU and WGSL spec.
The related issue is #2512.
The FP16 extension document (PR #2647) is intend to be aligned with this PR.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jzm-intel/gpuweb/pull/2696.html" title="Last updated on Apr 11, 2022, 7:18 AM UTC (8da687b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2696/a8e20cf...jzm-intel:8da687b.html" title="Last updated on Apr 11, 2022, 7:18 AM UTC (8da687b)">Diff</a>