### PR TITLE
[editorial] Add definitions for uniformity tags

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7325,7 +7325,7 @@ The most complex rule is for function calls:
 - Add an edge from Result to CF_after
 - For each argument *i*:
     - If the corresponding [=parameter tag=] is [=ParameterRequiredToBeUniform=], then add an edge from RequiredToBeUniform to arg_i
-    - Otherwise if the [=parameter tag=] is [=ParameterNoRestriction=], then add an edge from CF_after to arg_i
+    - Otherwise if the [=parameter tag=] is [=ParameterRequiredToBeUniformForSubsequentControlFlow=], then add an edge from CF_after to arg_i
     - Otherwise if the [=parameter tag=] is [=ParameterRequiredToBeUniformForReturnValue=], then add an edge from Result to arg_i
 
 Note: Notice that this rule only requires adding a number of edges bounded by 3 + the number of parameters of the functions, independently of how complex the implementation of the function might be. This is key to the linear complexity of the overall algorithm.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7103,32 +7103,73 @@ The second phase explores that graph, resulting in either rejecting the program,
         A consequence of this interpretation is that every node reachable from RequiredToBeUniform corresponds to something which must be uniform for the program to be valid, and every node from which cannotBeUniform is reachable corresponds to something whose uniformity we cannot guarantee. It follows that we have a uniformity violation (and thus reject the program) if there is any path from RequiredToBeUniform to MayBeNonUniform.
 </div>
 
-In more detail, here is what we compute for each function:
+For each function, two tags are computed:
+  * A <dfn noexport>call site tag</dfn> describing the control flow uniformity requirements on the [=call sites=] of the function, and
+  * A <dfn noexport>function tag</dfn> describing the function's effects on uniformity.
 
-* A tag about the control-flow in which the function can be called: one of {AlwaysRequiredToBeUniform, RequiredToBeUniformForControlFlowAfter}
-* A tag for each parameter of the function: one of {AlwaysRequiredToBeUniform, RequiredToBeUniformForControlFlowAfter, RequiredToBeUniformForReturnValue, NoRestriction}
-* A tag for the function as a whole: one of {ControlFlowMayBeNonUniformAfter, ReturnValueMayBeNonUniform, NoRestriction}
+Additionally, for each [=formal parameter=] of a function, a <dfn
+noexport>parameter tag</dfn> is computed that describes the uniformity
+requirement of the parameter value.
 
-Here is the algorithm for computing this data for a given function:
+<table class='data'>
+  <caption>[=Call site tag=] values</caption>
+  <thead>
+    <tr><th>Call Site Tag<th>Description
+  </thead>
+  <tr><td><dfn noexport>CallSiteRequiredToBeUniform</dfn>
+      <td>The function must only be called from [=uniform control flow=].
+  <tr><td><dfn noexport>CallSiteNoRestriction</dfn>
+      <td>The function may be called from [=uniform control flow|non-uniform control flow=].
+</table>
 
-* Create nodes called "RequiredToBeUniform", "MayBeNonUniform", "CF_start", "CF_return", and if the function is non-void a node called "Value_return"
-* Create one node for each parameter of the function which we'll call "arg_i"
+<table class='data'>
+  <caption>[=Function tag=] values</caption>
+  <thead>
+    <tr><th>Function Tag<th>Description
+  </thead>
+  <tr><td><dfn noexport>SubsequentControlFlowMayBeNonUniform</dfn>
+      <td>The control flow after the function call may be non-uniform.
+  <tr><td><dfn noexport>ReturnValueMayBeNonUniform</dfn>
+      <td>The [=return value=] of the function may be non-uniform.
+  <tr><td><dfn noexport>NoRestriction</dfn>
+      <td>The function does not introduce non-uniformity.
+</table>
+
+<table class='data'>
+  <caption>[=Parameter tag=] values</caption>
+  <thead>
+    <tr><th>Parameter Tag<th>Description
+  </thead>
+  <tr><td><dfn noexport>ParameterRequiredToBeUniform</dfn>
+      <td>The parameter must be a [=uniform value=].
+  <tr><td><dfn noexport>ParameterRequiredToBeUniformForSubsequentControlFlow</dfn>
+      <td>The parameter must be a [=uniform value=] for control flow after the function call to be [=uniform control flow|uniform=].
+  <tr><td><dfn noexport>ParameterRequiredToBeUniformForReturnValue</dfn>
+      <td>The parameter must be a [=uniform value=] in order for the [=return value=] to be a uniform value.
+  <tr><td><dfn noexport>ParameterNoRestriction</dfn>
+      <td>The parameter value has no uniformity requirement.
+</table>
+
+The following algorithm describes how to compute these tags for a given function:
+
+* Create nodes called "RequiredToBeUniform", "MayBeNonUniform", "CF_start", "CF_return", and if the function is non-void a node called "Value_return".
+* Create one node for each parameter of the function which we'll call "arg_i".
 * Walk over the syntax of the function, adding nodes and edges to the graph following the rules of the next sections ([[#uniformity-statements]], [[#uniformity-function-calls]], [[#uniformity-expressions]]), using CF_start as the starting control-flow for the function's body.
-* Look at which nodes are reachable from "RequiredToBeUniform"
+* Look at which nodes are reachable from "RequiredToBeUniform".
     * If this set includes the node "MayBeNonUniform", then reject the program.
-    * If this set includes "CF_start", then the control-flow in which the function can be called is AlwaysRequiredToBeUniform.
-    * Otherwise it is RequiredToBeUniformForControlFlowAfter
-    * For each "arg_i" in this set, the corresponding parameter is AlwaysRequiredToBeUniform
-    * Remove from the graph all nodes that have been visited
+    * If this set includes "CF_start", then the [=call site tag=] for the function is [=CallSiteRequiredToBeuniform=].
+    * Otherwise, the [=call site tag=] is [=CallSiteNoRestriction=].
+    * For each "arg_i" in this set, the corresponding [=parameter tag=] is [=ParameterRequiredToBeUniform=].
+    * Remove from the graph all nodes that have been visited.
 * Look at which nodes are reachable from "CF_return"
-    * If this set includes "MayBeNonUniform", then the function is ControlFlowMayBeNonUniformAfter
-    * For each "arg_i" in this set, the corresponding parameter is RequiredToBeUniformForControlFlowAfter
-    * Remove from the graph all nodes that have been visited
+    * If this set includes "MayBeNonUniform", then [=function tag=] for the function is [=SubsequentControlFlowMayBeNonUniform=].
+    * For each "arg_i" in this set, the corresponding [=parameter tag=] is [=ParameterRequiredToBeUniformForSubsequentControlFlow=].
+    * Remove from the graph all nodes that have been visited.
 * If "Value_return" exists, look at which nodes are reachable from it
-    * If this set includes "MayBeNonUniform", then the function is ReturnValueMayBeNonUniform
-    * For each "arg_i" in this set, the corresponding parameter is RequiredToBeUniformForReturnValue
-* If the function has not been assigned a tag, then it is NoRestriction.
-* For each parameter, if it has not been assigned a tag, then it is NoRestriction.
+    * If this set includes "MayBeNonUniform", then the [=function tag=] is [=ReturnValueMayBeNonUniform=].
+    * For each "arg_i" in this set, the corresponding [=parameter tag=] is [=ParameterRequiredToBeUniformForReturnValue=].
+* If the [=function tag=] has not been assigned, then it is [=NoRestriction=].
+* For each parameter, if it has not been assigned a [=parameter tag=], then it is [=ParameterNoRestriction=].
 
 Note: The entire graph can be destroyed at this point. The tags listed above are all that we need to remember to analyze callers of this function.
 
@@ -7277,26 +7318,26 @@ Note: If the set of behaviors (see [[#behaviors]]) for an if, switch, or loop st
 The most complex rule is for function calls:
 - For each argument, apply the corresponding expression rule, with the control flow at the exit of the previous argument (using the control flow at the beginning of the function call for the first argument). Name the corresponding value nodes "arg_i" and the corresponding control flow nodes "CF_i"
 - Create two new nodes, named "Result" and "CF_after"
-- If the control-flow at the start of the function was tagged AlwaysRequiredToBeUniform, then add an edge from RequiredToBeUniform to the last CF_i
+- If the [=call site tag=] of the function is [=CallSiteRequiredToBeuniform=], then add an edge from RequiredToBeUniform to the last CF_i
 - Otherwise add an edge from CF_after to the last CF_i
-- If the function was tagged ControlFlowMayBeNonUniformAfter, then add an edge from CF_after to MayBeNonUniform
-- Else if it was tagged ReturnValueMayBeNonUniform, then add an edge from Result to MayBeNonUniform
+- If the [=function tag=] is [=SubsequentControlFlowMayBeNonUniform=], then add an edge from CF_after to MayBeNonUniform
+- Otherwise if the [=function tag=] is [=ReturnValueMayBeNonUniform=], then add an edge from Result to MayBeNonUniform
 - Add an edge from Result to CF_after
 - For each argument *i*:
-    - If the corresponding parameter was tagged AlwaysRequiredToBeUniform, then add an edge from RequiredToBeUniform to arg_i
-    - Else if it was tagged RequiredToBeUniformForControlFlowAfter, then add an edge from CF_after to arg_i
-    - Else if it was tagged RequiredToBeUniformForReturnValue, then add an edge from Result to arg_i
+    - If the corresponding [=parameter tag=] is [=ParameterRequiredToBeUniform=], then add an edge from RequiredToBeUniform to arg_i
+    - Otherwise if the [=parameter tag=] is [=ParameterNoRestriction=], then add an edge from CF_after to arg_i
+    - Otherwise if the [=parameter tag=] is [=ParameterRequiredToBeUniformForReturnValue=], then add an edge from Result to arg_i
 
 Note: Notice that this rule only requires adding a number of edges bounded by 3 + the number of parameters of the functions, independently of how complex the implementation of the function might be. This is key to the linear complexity of the overall algorithm.
 
 Most built-in functions have tags of:
-- for the control-flow in which they can be called: RequiredToBeUniformForControlFlowAfter
-- for the function as a whole: NoRestriction
-- for each parameter: RequiredToBeUniformForReturnValue
+- A [=call site tag=] of [=CallSiteNoRestriction=].
+- A [=function tag=] of [=NoRestriction=].
+- For each parameter, a [=parameter tag|tag=] of [=ParameterRequiredToBeUniformForReturnValue=].
 
 Here is the list of exceptions:
-- All functions in [[#sync-builtin-functions]] are AlwaysRequiredToBeUniform
-- All functions in [[#derivative-builtin-functions]], [[#texturesample]], [[#texturesamplebias]], and [[#texturesamplecompare]] are AlwaysRequiredToBeUniform and ReturnValueMayBeNonUniform
+- All functions in [[#sync-builtin-functions]] have a [=call site tag=] of  [=CallSiteRequiredToBeuniform=].
+- All functions in [[#derivative-builtin-functions]], [[#texturesample]], [[#texturesamplebias]], and [[#texturesamplecompare]] have a [=call site tag=] of [=CallSiteRequiredToBeUniform=] and a [=function tag=] of [=ReturnValueMayBeNonUniform=].
 
 ### Uniformity rules for expressions ### {#uniformity-expressions}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7128,7 +7128,7 @@ requirement of the parameter value.
     <tr><th>Function Tag<th>Description
   </thead>
   <tr><td><dfn noexport>SubsequentControlFlowMayBeNonUniform</dfn>
-      <td>The control flow after the function call may be non-uniform.
+      <td>Calling this function may cause control flow to be non-uniform immediately after the [=call site=].
   <tr><td><dfn noexport>ReturnValueMayBeNonUniform</dfn>
       <td>The [=return value=] of the function may be non-uniform.
   <tr><td><dfn noexport>NoRestriction</dfn>
@@ -7152,7 +7152,7 @@ requirement of the parameter value.
 
 The following algorithm describes how to compute these tags for a given function:
 
-* Create nodes called "RequiredToBeUniform", "MayBeNonUniform", "CF_start", "CF_return", and if the function is non-void a node called "Value_return".
+* Create nodes called "RequiredToBeUniform", "MayBeNonUniform", "CF_start", "CF_return", and if the function has a [=return type=] a node called "Value_return".
 * Create one node for each parameter of the function which we'll call "arg_i".
 * Walk over the syntax of the function, adding nodes and edges to the graph following the rules of the next sections ([[#uniformity-statements]], [[#uniformity-function-calls]], [[#uniformity-expressions]]), using CF_start as the starting control-flow for the function's body.
 * Look at which nodes are reachable from "RequiredToBeUniform".


### PR DESCRIPTION
* A definitions for each tag type: call site, function and parameter
* Add tables for the possible values of each tag and the meaning
* Renames some of the tag values for clarity
* Update subsequent uses to link to the new defintions