### PR TITLE
Removing links to closed issues

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6767,11 +6767,6 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
 
 </div>
 
-Issue(gpuweb/gpuweb#537): Additional restrictions on rowsPerImage if needed.
-
-Issue(gpuweb/gpuweb#652): Define the copies with {{GPUTextureFormat/"depth24plus"}},
-{{GPUTextureFormat/"depth24plus-stencil8"}}, and {{GPUTextureFormat/"stencil8"}}.
-
 <dl dfn-type=method dfn-for=GPUCommandEncoder>
     : <dfn>copyBufferToTexture(source, destination, copySize)</dfn>
     ::


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/litherum/gpuweb/pull/2700.html" title="Last updated on Mar 26, 2022, 1:02 AM UTC (9cf19c8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2700/bb3b4ca...litherum:9cf19c8.html" title="Last updated on Mar 26, 2022, 1:02 AM UTC (9cf19c8)">Diff</a>