### PR TITLE
Add rigorous definition of physical texture subresource size

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -935,8 +935,9 @@ to form complete [=texel blocks=] in the [=texture=]. It is calculated by this p
     <dfn abstract-op>Physical miplevel-specific texture extent</dfn>(descriptor, mipLevel)
 
     **Arguments:**
-        - {{GPUTextureDescriptor}} |descriptor|
-        - {{GPUSize32}} |mipLevel|
+
+    - {{GPUTextureDescriptor}} |descriptor|
+    - {{GPUSize32}} |mipLevel|
 
     **Returns:** {{GPUExtent3DDict}}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -891,8 +891,9 @@ The <dfn dfn>logical miplevel-specific texture extent</dfn> of a [=texture=] is 
     <dfn abstract-op>Logical miplevel-specific texture extent</dfn>(descriptor, mipLevel)
 
     **Arguments:**
-        - {{GPUTextureDescriptor}} |descriptor|
-        - {{GPUSize32}} |mipLevel|
+
+    - {{GPUTextureDescriptor}} |descriptor|
+    - {{GPUSize32}} |mipLevel|
 
     **Returns:** {{GPUExtent3DDict}}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -965,7 +965,7 @@ to form complete [=texel blocks=] in the [=subresource=]. It is calculated by th
 
                 Set |extent|.{{GPUExtent3DDict/height}} to |logicalExtent|.[=Extent3D/height=] rounded up to the nearest multiple of |descriptor|'s [=texel block height=].
 
-                Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |logicalExtent|.[=Extent3D/height=].
+                Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |logicalExtent|.[=Extent3D/depthOrArrayLayers=].
         </dl>
     1. Return |extent|.
 </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -884,11 +884,11 @@ The [=subresources=] of textures included in the views provided to
 {{GPURenderPassColorAttachment/resolveTarget|GPURenderPassColorAttachment.resolveTarget}}
 are considered to be used as [=internal usage/attachment=] for the [=usage scope=] of this render pass.
 
-The <dfn dfn>logical texture subresource extent</dfn> of a [=texture subresource=] is the size of the
-[=texture subresource=] in texels which are visible by shaders. It is calculated by this procedure:
+The <dfn dfn>logical miplevel-specific texture extent</dfn> of a [=texture=] is the size of the
+[=texture=] in texels at a specific miplevel. It is calculated by this procedure:
 
 <div algorithm>
-    <dfn abstract-op>Logical texture subresource extent</dfn>(descriptor, mipLevel)
+    <dfn abstract-op>Logical miplevel-specific texture extent</dfn>(descriptor, mipLevel)
 
     **Arguments:**
         - {{GPUTextureDescriptor}} |descriptor|
@@ -905,7 +905,7 @@ The <dfn dfn>logical texture subresource extent</dfn> of a [=texture subresource
 
                 Set |extent|.{{GPUExtent3DDict/height}} to 1.
 
-                Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to 1.
+                Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=].
 
             : {{GPUTextureDimension/"2d"}}
             ::
@@ -913,7 +913,7 @@ The <dfn dfn>logical texture subresource extent</dfn> of a [=texture subresource
 
                 Set |extent|.{{GPUExtent3DDict/height}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] &Gt; |mipLevel|).
 
-                Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to 1.
+                Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=].
 
             : {{GPUTextureDimension/"3d"}}
             ::
@@ -926,12 +926,12 @@ The <dfn dfn>logical texture subresource extent</dfn> of a [=texture subresource
     1. Return |extent|.
 </div>
 
-The <dfn dfn>physical size</dfn> of a [=texture subresource=] is the dimension of the
-[=texture subresource=] in texels that includes the possible extra padding
-to form complete [=texel blocks=] in the [=subresource=]. It is calculated by this procedure:
+The <dfn dfn>physical miplevel-specific texture extent</dfn> of a [=texture=] is the size of the
+[=texture=] in texels at a specific miplevel that includes the possible extra padding
+to form complete [=texel blocks=] in the [=texture=]. It is calculated by this procedure:
 
 <div algorithm>
-    <dfn abstract-op>Physical texture subresource extent</dfn>(descriptor, mipLevel)
+    <dfn abstract-op>Physical miplevel-specific texture extent</dfn>(descriptor, mipLevel)
 
     **Arguments:**
         - {{GPUTextureDescriptor}} |descriptor|
@@ -940,7 +940,7 @@ to form complete [=texel blocks=] in the [=subresource=]. It is calculated by th
     **Returns:** {{GPUExtent3DDict}}
 
     1. Let |extent| be a new {{GPUExtent3DDict}} object.
-    1. Let |logicalExtent| be [=Logical texture subresource extent=](|descriptor|, |mipLevel|).
+    1. Let |logicalExtent| be [=logical miplevel-specific texture extent=](|descriptor|, |mipLevel|).
     1. If |descriptor|.{{GPUTextureDescriptor/dimension}} is:
         <dl class="switch">
             : {{GPUTextureDimension/"1d"}}
@@ -949,7 +949,7 @@ to form complete [=texel blocks=] in the [=subresource=]. It is calculated by th
 
                 Set |extent|.{{GPUExtent3DDict/height}} to 1.
 
-                Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to 1.
+                Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |logicalExtent|.[=Extent3D/depthOrArrayLayers=].
 
             : {{GPUTextureDimension/"2d"}}
             ::
@@ -957,7 +957,7 @@ to form complete [=texel blocks=] in the [=subresource=]. It is calculated by th
 
                 Set |extent|.{{GPUExtent3DDict/height}} to |logicalExtent|.[=Extent3D/height=] rounded up to the nearest multiple of |descriptor|'s [=texel block height=].
 
-                Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to 1.
+                Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |logicalExtent|.[=Extent3D/depthOrArrayLayers=].
 
             : {{GPUTextureDimension/"3d"}}
             ::
@@ -6746,7 +6746,7 @@ Issue: Does the term "image copy" include copyTextureToTexture?
   The [=imageCopyTexture subresource size=] of |imageCopyTexture| is calculated as follows:
 
   Its [=Extent3D/width=], [=Extent3D/height=] and [=Extent3D/depthOrArrayLayers=] are the width, height, and depth, respectively,
-  of the [=physical size=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}} [=subresource=] at [=mipmap level=]
+  of the [=physical miplevel-specific texture extent=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}} [=subresource=] at [=mipmap level=]
   |imageCopyTexture|.{{GPUImageCopyTexture/mipLevel}}.
 
 </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -884,20 +884,90 @@ The [=subresources=] of textures included in the views provided to
 {{GPURenderPassColorAttachment/resolveTarget|GPURenderPassColorAttachment.resolveTarget}}
 are considered to be used as [=internal usage/attachment=] for the [=usage scope=] of this render pass.
 
+The <dfn dfn>logical texture subresource extent</dfn> of a [=texture subresource=] is the size of the
+[=texture subresource=] in texels which are visible by shaders. It is calculated by this procedure:
+
+<div algorithm>
+    <dfn abstract-op>Logical texture subresource extent</dfn>(descriptor, mipLevel)
+
+    **Arguments:**
+        - {{GPUTextureDescriptor}} |descriptor|
+        - {{GPUSize32}} |mipLevel|
+
+    **Returns:** {{GPUExtent3DDict}}
+
+    1. Let |extent| be a new {{GPUExtent3DDict}} object.
+    1. If |descriptor|.{{GPUTextureDescriptor/dimension}} is:
+        <dl class="switch">
+            : {{GPUTextureDimension/"1d"}}
+            ::
+                Set |extent|.{{GPUExtent3DDict/width}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] &Gt; |mipLevel|).
+
+                Set |extent|.{{GPUExtent3DDict/height}} to 1.
+
+                Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to 1.
+
+            : {{GPUTextureDimension/"2d"}}
+            ::
+                Set |extent|.{{GPUExtent3DDict/width}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] &Gt; |mipLevel|).
+
+                Set |extent|.{{GPUExtent3DDict/height}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] &Gt; |mipLevel|).
+
+                Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to 1.
+
+            : {{GPUTextureDimension/"3d"}}
+            ::
+                Set |extent|.{{GPUExtent3DDict/width}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] &Gt; |mipLevel|).
+
+                Set |extent|.{{GPUExtent3DDict/height}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] &Gt; |mipLevel|).
+
+                Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] &Gt; |mipLevel|).
+        </dl>
+    1. Return |extent|.
+</div>
+
 The <dfn dfn>physical size</dfn> of a [=texture subresource=] is the dimension of the
-[=texture subresource=] in texels that includes the possible extra paddings
-to form complete [=texel blocks=] in the [=subresource=].
+[=texture subresource=] in texels that includes the possible extra padding
+to form complete [=texel blocks=] in the [=subresource=]. It is calculated by this procedure:
 
-  - For pixel-based {{GPUTextureFormat|GPUTextureFormats}}, the [=physical size=] is always equal to the size of the [=texture subresource=]
-    used in the sampling hardware.
-  - [=Textures=] in block-based compressed {{GPUTextureFormat|GPUTextureFormats}} always have a [=mipmap level=] 0 whose {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}
-    is a multiple of the [=texel block size=], but the lower mipmap levels might not be
-    multiples of the [=texel block size=] and can have paddings.
+<div algorithm>
+    <dfn abstract-op>Physical texture subresource extent</dfn>(descriptor, mipLevel)
 
-<div class="example">
-Considering a {{GPUTexture}} in BC format whose {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}} is {60, 60, 1}, when sampling
-the {{GPUTexture}} at [=mipmap level=] 2, the sampling hardware uses {15, 15, 1} as the size of the [=texture subresource=],
-while its [=physical size=] is {16, 16, 1} as the block-compression algorithm can only operate on 4x4 [=texel blocks=].
+    **Arguments:**
+        - {{GPUTextureDescriptor}} |descriptor|
+        - {{GPUSize32}} |mipLevel|
+
+    **Returns:** {{GPUExtent3DDict}}
+
+    1. Let |extent| be a new {{GPUExtent3DDict}} object.
+    1. Let |logicalExtent| be [=Logical texture subresource extent=](|descriptor|, |mipLevel|).
+    1. If |descriptor|.{{GPUTextureDescriptor/dimension}} is:
+        <dl class="switch">
+            : {{GPUTextureDimension/"1d"}}
+            ::
+                Set |extent|.{{GPUExtent3DDict/width}} to |logicalExtent|.[=Extent3D/width=] rounded up to the nearest multiple of |descriptor|'s [=texel block width=].
+
+                Set |extent|.{{GPUExtent3DDict/height}} to 1.
+
+                Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to 1.
+
+            : {{GPUTextureDimension/"2d"}}
+            ::
+                Set |extent|.{{GPUExtent3DDict/width}} to |logicalExtent|.[=Extent3D/width=] rounded up to the nearest multiple of |descriptor|'s [=texel block width=].
+
+                Set |extent|.{{GPUExtent3DDict/height}} to |logicalExtent|.[=Extent3D/height=] rounded up to the nearest multiple of |descriptor|'s [=texel block height=].
+
+                Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to 1.
+
+            : {{GPUTextureDimension/"3d"}}
+            ::
+                Set |extent|.{{GPUExtent3DDict/width}} to |logicalExtent|.[=Extent3D/width=] rounded up to the nearest multiple of |descriptor|'s [=texel block width=].
+
+                Set |extent|.{{GPUExtent3DDict/height}} to |logicalExtent|.[=Extent3D/height=] rounded up to the nearest multiple of |descriptor|'s [=texel block height=].
+
+                Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |logicalExtent|.[=Extent3D/height=].
+        </dl>
+    1. Return |extent|.
 </div>
 
 ### Synchronization ### {#programming-model-synchronization}
@@ -3071,7 +3141,8 @@ and a single compressed block of the textures in block-based compressed {{GPUTex
 The <dfn dfn>texel block width</dfn> and <dfn dfn>texel block height</dfn> specifies the dimension of one [=texel block=].
   - For pixel-based {{GPUTextureFormat}}s, the [=texel block width=] and [=texel block height=] are always 1.
   - For block-based compressed {{GPUTextureFormat}}s, the [=texel block width=] is the number of texels in each row of one [=texel block=],
-    and the [=texel block height=] is the number of texel rows in one [=texel block=].
+    and the [=texel block height=] is the number of texel rows in one [=texel block=]. See [[#texture-format-caps]] for an exhaustive list
+    of values for every texture format.
 
 The <dfn dfn>texel block size</dfn> of a {{GPUTextureFormat}} is the number of bytes to store one [=texel block=].
 The [=texel block size=] of each {{GPUTextureFormat}} is constant except for {{GPUTextureFormat/"stencil8"}}, {{GPUTextureFormat/"depth24plus"}}, and {{GPUTextureFormat/"depth24plus-stencil8"}}.


### PR DESCRIPTION
Fixes https://github.com/gpuweb/gpuweb/issues/2698


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/litherum/gpuweb/pull/2701.html" title="Last updated on Mar 31, 2022, 9:22 AM UTC (f2d6d77)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2701/bb3b4ca...litherum:f2d6d77.html" title="Last updated on Mar 31, 2022, 9:22 AM UTC (f2d6d77)">Diff</a>