### PR TITLE
Add the concept of an "aspect-specific format"

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6796,10 +6796,12 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
                         - [$validating GPUImageCopyTexture$](|destination|, |copySize|) returns `true`.
                         - |dstTextureDesc|.{{GPUTextureDescriptor/usage}} contains {{GPUTextureUsage/COPY_DST}}.
                         - |dstTextureDesc|.{{GPUTextureDescriptor/sampleCount}} is 1.
+                        - Let |aspectSpecificFormat| = |dstTextureDesc|.{{GPUTextureDescriptor/format}}.
                         - If |dstTextureDesc|.{{GPUTextureDescriptor/format}} is a [=depth-or-stencil format=]:
                             - |destination|.{{GPUImageCopyTexture/aspect}} must refer to a single aspect of
-                                |dstTextureDesc|.{{GPUTextureDescriptor/format}}, and that aspect must be
-                                a valid image copy destination according to [[#depth-formats]].
+                                |dstTextureDesc|.{{GPUTextureDescriptor/format}}.
+                            - That aspect must be a valid image copy destination according to [[#depth-formats]].
+                            - Set |aspectSpecificFormat| to the [=aspect-specific format=] according to [[#depth-formats]].
                         - [=validating texture copy range=](|destination|, |copySize|) return `true`.
                         - If |dstTextureDesc|.{{GPUTextureDescriptor/format}} is not a [=depth-or-stencil format=]:
                             - |source|.{{GPUImageDataLayout/offset}} is a multiple of the [=texel block size=] of
@@ -6808,7 +6810,7 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
                             - |source|.{{GPUImageDataLayout/offset}} is a multiple of 4.
                         - [$validating linear texture data$](|source|,
                             |source|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[size]]}},
-                            |dstTextureDesc|.{{GPUTextureDescriptor/format}},
+                            |aspectSpecificFormat|,
                             |copySize|) succeeds.
                     </div>
             </div>
@@ -6840,10 +6842,12 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
                         - [$validating GPUImageCopyTexture$](|source|, |copySize|) returns `true`.
                         - |srcTextureDesc|.{{GPUTextureDescriptor/usage}} contains {{GPUTextureUsage/COPY_SRC}}.
                         - |srcTextureDesc|.{{GPUTextureDescriptor/sampleCount}} is 1.
-                        - If |srcTextureDesc|.{{GPUTextureDescriptor/format}} is a depth-stencil format:
+                        - Let |aspectSpecificFormat| = |srcTextureDesc|.{{GPUTextureDescriptor/format}}.
+                        - If |srcTextureDesc|.{{GPUTextureDescriptor/format}} is a [=depth-or-stencil format=] format:
                             - |source|.{{GPUImageCopyTexture/aspect}} must refer to a single aspect of
-                                |srcTextureDesc|.{{GPUTextureDescriptor/format}}, and that aspect must be
-                                a valid image copy source according to [[#depth-formats]].
+                                |srcTextureDesc|.{{GPUTextureDescriptor/format}}.
+                            - That aspect must be a valid image copy source according to [[#depth-formats]].
+                            - Set |aspectSpecificFormat| to the [=aspect-specific format=] according to [[#depth-formats]].
                         - [$validating GPUImageCopyBuffer$](|destination|) returns `true`.
                         - |destination|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[usage]]}} contains
                             {{GPUBufferUsage/COPY_DST}}.
@@ -6855,7 +6859,7 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
                             - |destination|.{{GPUImageDataLayout/offset}} is a multiple of 4.
                         - [$validating linear texture data$](|destination|,
                             |destination|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[size]]}},
-                            |srcTextureDesc|.{{GPUTextureDescriptor/format}},
+                            |aspectSpecificFormat|,
                             |copySize|) succeeds.
                     </div>
             </div>
@@ -8952,14 +8956,6 @@ GPUQueue includes GPUObjectBase;
             1. Let |dataBytes| be [=get a copy of the buffer source|a copy of the bytes held by the buffer source=] |data|.
             1. Let |dataByteSize| be the number of bytes in |dataBytes|.
             1. Let |textureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
-            1. If any of the following conditions are unsatisfied,
-                throw {{OperationError}} and stop.
-                <div class=validusage>
-                    - [$validating linear texture data$](|dataLayout|,
-                        |dataByteSize|,
-                        |textureDesc|.{{GPUTextureDescriptor/format}},
-                        |size|) succeeds.
-                </div>
             1. Let |contents| be the contents of the [=images=] seen by
                 viewing |dataBytes| with |dataLayout| and |size|.
 
@@ -8974,8 +8970,15 @@ GPUQueue includes GPUObjectBase;
                             - |textureDesc|.{{GPUTextureDescriptor/sampleCount}} is 1.
                             - [=validating texture copy range=](|destination|, |size|) return `true`.
                             - |destination|.{{GPUImageCopyTexture/aspect}} must refer to a single aspect of
-                                |textureDesc|.{{GPUTextureDescriptor/format}}, and that aspect must be
-                                a valid image copy destination according to [[#depth-formats]].
+                                |textureDesc|.{{GPUTextureDescriptor/format}}.
+                            - That aspect must be a valid image copy destination according to [[#depth-formats]].
+                            - Let |aspectSpecificFormat| = |textureDesc|.{{GPUTextureDescriptor/format}}.
+                            - If |textureDesc|.{{GPUTextureDescriptor/format}} is a [=depth-or-stencil format=]:
+                                - Set |aspectSpecificFormat| to the [=aspect-specific format=] of |textureDesc|.{{GPUTextureDescriptor/format}} according to [[#depth-formats]].
+                            - [$validating linear texture data$](|dataLayout|,
+                                |dataByteSize|,
+                                |aspectSpecificFormat|,
+                                |size|) succeeds.
 
                             Note: unlike
                             {{GPUCommandEncoder}}.{{GPUCommandEncoder/copyBufferToTexture()}},
@@ -11260,6 +11263,7 @@ None of the depth formats can be filtered.
             <th>{{GPUTextureSampleType}}
             <th>Valid [=image copy=] source
             <th>Valid [=image copy=] destination
+            <th><dfn dfn>Aspect-specific format</dfn>
     </thead>
     <tr>
         <td>{{GPUTextureFormat/stencil8}}
@@ -11268,6 +11272,7 @@ None of the depth formats can be filtered.
         <td>1
         <td>{{GPUTextureSampleType/"uint"}}
         <td colspan=2>&checkmark;
+        <td>{{GPUTextureFormat/stencil8}}
     <tr>
         <td>{{GPUTextureFormat/depth16unorm}}
         <td>2
@@ -11275,6 +11280,7 @@ None of the depth formats can be filtered.
         <td>2
         <td>{{GPUTextureSampleType/"depth"}}
         <td colspan=2>&checkmark;
+        <td>{{GPUTextureFormat/depth16unorm}}
     <tr>
         <td>{{GPUTextureFormat/depth24plus}}
         <td>4
@@ -11282,6 +11288,7 @@ None of the depth formats can be filtered.
         <td>- (<a href="#depthPlus">See prose</a>)
         <td>{{GPUTextureSampleType/"depth"}}
         <td colspan=2>&cross;
+        <td>- (Not a valid image copy source nor a valid image copy destination)
     <tr>
         <td rowspan=2 style='white-space:nowrap'>{{GPUTextureFormat/depth24plus-stencil8}}
         <td rowspan=2>4 &minus; 8
@@ -11289,11 +11296,13 @@ None of the depth formats can be filtered.
         <td>- (<a href="#depthPlus">See prose</a>)
         <td>{{GPUTextureSampleType/"depth"}}
         <td colspan=2>&cross;
+        <td>- (Not a valid image copy source nor a valid image copy destination)
     <tr>
         <td>stencil
         <td>1
         <td>{{GPUTextureSampleType/"uint"}}
         <td colspan=2>&checkmark;
+        <td>{{GPUTextureFormat/stencil8}}
     <tr>
         <td>{{GPUTextureFormat/depth32float}}
         <td>4
@@ -11302,6 +11311,7 @@ None of the depth formats can be filtered.
         <td>{{GPUTextureSampleType/"depth"}}
         <td colspan=1>&checkmark;
         <td colspan=1>&cross;
+        <td>{{GPUTextureFormat/depth32float}}
     <tr>
         <td rowspan=2 style='white-space:nowrap'>{{GPUTextureFormat/depth24unorm-stencil8}}
         <td rowspan=2>4
@@ -11309,11 +11319,13 @@ None of the depth formats can be filtered.
         <td>3
         <td>{{GPUTextureSampleType/"depth"}}
         <td colspan=2>&cross;
+        <td>- (Not a valid image copy source nor a valid image copy destination)
     <tr>
         <td>stencil
         <td>1
         <td>{{GPUTextureSampleType/"uint"}}
         <td colspan=2>&checkmark;
+        <td>{{GPUTextureFormat/stencil8}}
     <tr>
         <td rowspan=2 style='white-space:nowrap'>{{GPUTextureFormat/depth32float-stencil8}}
         <td rowspan=2>5 &minus; 8
@@ -11322,11 +11334,13 @@ None of the depth formats can be filtered.
         <td>{{GPUTextureSampleType/"depth"}}
         <td colspan=1>&checkmark;
         <td colspan=1>&cross;
+        <td>{{GPUTextureFormat/depth32float}}
     <tr>
         <td>stencil
         <td>1
         <td>{{GPUTextureSampleType/"uint"}}
         <td colspan=2>&checkmark;
+        <td>{{GPUTextureFormat/stencil8}}
 </table>
 
 #### Reading and Sampling Depth/Stencil Textures #### {#reading-depth-stencil}


### PR DESCRIPTION
For example, if the app is populating a depth32float-stencil8 texture from a buffer, but is specifying
just the stencil aspect for the copy, then the data in the buffer should be packed uint8s (one for each
stencil value) without 4-byte holes between them. This is particularly important because it's legal to
copy to the stencil aspect of a depth24plus-stencil8 texture - so there can't be any holes because the
caller wouldn't know how big to make their holes.

This ends up interacting with validation. In [$validating linear texture data$], we make sure that
there's enough space for blockSize × widthInBlocks, so that blockSize needs to be 1 in the above case,
not 5. So, this PR modifies every call to [$validating linear texture data$] to pass the "aspect-
specific format" (which, in this example, turns the depth32float-stencil8 into just stencil8). That
way, the correct [=texel block size=] gets validated.

I believe this is almost entirely just editorial - there's one tiny non-editorial change in
writeTexture() that changes error handling. One of the prerequisites for calculating the aspect-specific
format is that you have to know the format is a valid image copy source or a valid image copy
destination, so this patch delays calling [$validating linear texture data$] until that validity
check has occurred.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/litherum/gpuweb/pull/2702.html" title="Last updated on Mar 27, 2022, 9:40 PM UTC (9dd1ad1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2702/bc69067...litherum:9dd1ad1.html" title="Last updated on Mar 27, 2022, 9:40 PM UTC (9dd1ad1)">Diff</a>