### PR TITLE
Align Python across repository

### DIFF
--- a/spec/Makefile
+++ b/spec/Makefile
@@ -9,9 +9,9 @@ index.pre.html: index.bs
 	bikeshed --die-on=everything spec index.bs index.pre.html
 
 webgpu.idl: index.bs extract-idl.py
-	python extract-idl.py index.bs > webgpu.idl
+	python3 extract-idl.py index.bs > webgpu.idl
 
 online:
 	curl https://api.csswg.org/bikeshed/ -F file=@index.bs -F output=err
 	curl https://api.csswg.org/bikeshed/ -F file=@index.bs -F die-on=everything > index.html
-	python extract-idl.py index.bs > webgpu.idl
+	python3 extract-idl.py index.bs > webgpu.idl

--- a/spec/extract-idl.py
+++ b/spec/extract-idl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from datetime import date
 from string import Template


### PR DESCRIPTION
This aligns these last instances to be the same with others in the repository. Depending on the environment, these can remove the need for an alias.