### PR TITLE
Better specify the order of dynamicOffsets in setBindGroup

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7096,7 +7096,7 @@ interface mixin GPUProgrammablePassEncoder {
                 define the arguments for the 5-arg variant of the method, despite the "for"
                 explicitly pointing at the 3-arg variant. See
                 https://github.com/plinss/widlparser/issues/56 and
-                ihttps://github.com/tabatkins/bikeshed/issues/1740 -->
+                https://github.com/tabatkins/bikeshed/issues/1740 -->
                 <!--|dynamicOffsets|: Array containing buffer offsets in bytes for each entry in
                     |bindGroup| marked as {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}}.-->
             </pre>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7071,6 +7071,10 @@ interface mixin GPUProgrammablePassEncoder {
     : <dfn>\[[bind_groups]]</dfn>, of type [=ordered map=]&lt;{{GPUIndex32}}, {{GPUBindGroup}}&gt;
     ::
         The current {{GPUBindGroup}} for each index, initially empty.
+
+    : <dfn>\[[dynamic_offsets]]</dfn>, of type [=ordered map=]&lt;{{GPUIndex32}}, sequence<{{GPUBufferDynamicOffset}}>&gt;
+    ::
+        The current dynamic offsets for each {{GPUProgrammablePassEncoder/[[bind_groups]]}} entry, initially empty.
 </dl>
 
 ## Bind Groups ## {#programmable-passes-bind-groups}
@@ -7090,7 +7094,9 @@ interface mixin GPUProgrammablePassEncoder {
 
                 <!--The overload appears to be confusing bikeshed, and it ends up expecting this to
                 define the arguments for the 5-arg variant of the method, despite the "for"
-                explicitly pointing at the 3-arg variant.-->
+                explicitly pointing at the 3-arg variant. See
+                https://github.com/plinss/widlparser/issues/56 and
+                ihttps://github.com/tabatkins/bikeshed/issues/1740 -->
                 <!--|dynamicOffsets|: Array containing buffer offsets in bytes for each entry in
                     |bindGroup| marked as {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}}.-->
             </pre>
@@ -7099,6 +7105,12 @@ interface mixin GPUProgrammablePassEncoder {
                 defining |dynamicOffsets|.
 
             **Returns:** {{undefined}}
+
+            Note:
+            |dynamicOffsets|[|i|] is used for the |i|-th dynamic buffer binding in the bind group,
+            when bindings are ordered by {{GPUBindGroupLayoutEntry}}.{{GPUBindGroupLayoutEntry/binding}}.
+            Said differently |dynamicOffsets| are in the same order as dynamic buffer binding's
+            {{GPUBindGroupLayoutEntry}}.{{GPUBindGroupLayoutEntry/binding}}.
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
@@ -7128,6 +7140,7 @@ interface mixin GPUProgrammablePassEncoder {
 
                     </div>
                 1. Set |this|.{{GPUProgrammablePassEncoder/[[bind_groups]]}}[|index|] to be |bindGroup|.
+                1. Set |this|.{{GPUProgrammablePassEncoder/[[dynamic_offsets]]}}[|index|] to be a copy of |dynamicOffsets|.
             </div>
         </div>
 
@@ -7171,7 +7184,7 @@ interface mixin GPUProgrammablePassEncoder {
 
     1. Let |dynamicOffsetIndex| be `0`.
     1. Let |layout| be |bindGroup|.{{GPUBindGroup/[[layout]]}}.
-    1. For each {{GPUBindGroupEntry}} |entry| in |bindGroup|.{{GPUBindGroup/[[entries]]}}:
+    1. For each {{GPUBindGroupEntry}} |entry| in |bindGroup|.{{GPUBindGroup/[[entries]]}} ordered in increasing values of |entry|.{{GPUBindGroupEntry/binding}}:
         1. Let |bindingDescriptor| be the {{GPUBindGroupLayoutEntry}} at
             |layout|.{{GPUBindGroupLayout/[[entryMap]]}}[|entry|.{{GPUBindGroupEntry/binding}}]:
         1. If |bindingDescriptor|.{{GPUBindGroupLayoutEntry/buffer}} is not `undefined` and


### PR DESCRIPTION
But to really specify this correclty we should define how work on the
GPU is scheduled and resources are bound to shaders.

Fixes #2392


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/2710.html" title="Last updated on Apr 4, 2022, 7:57 AM UTC (74d4907)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2710/d25cd48...Kangz:74d4907.html" title="Last updated on Apr 4, 2022, 7:57 AM UTC (74d4907)">Diff</a>