### PR TITLE
Make colon in case optional

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5742,9 +5742,9 @@ An `if` statement is executed as follows:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>switch_body</dfn> :
 
-    | [=syntax/case=] [=syntax/case_selectors=] [=syntax/colon=] [=syntax/case_compound_statement=]
+    | [=syntax/case=] [=syntax/case_selectors=] [=syntax/colon=] ? [=syntax/case_compound_statement=]
 
-    | [=syntax/default=] [=syntax/colon=] [=syntax/case_compound_statement=]
+    | [=syntax/default=] [=syntax/colon=] ? [=syntax/case_compound_statement=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>case_selectors</dfn> :
@@ -5797,17 +5797,17 @@ which are reachable via a `fallthrough` statement.
     var a : i32;
     let x : i32 = generateValue();
     switch x {
-      case 0: {
+      case 0: {      // the colon is optional
         a = 1;
       }
-      default: {     // the default needn't appear last
+      default {      // the default needn't appear last
         a = 2;
       }
-      case 1, 2: {   // multiple selector values can be used
+      case 1, 2 {    // multiple selector values can be used
         a = 3;       // a will be overridden in the next case
         fallthrough;
       }
-      case 3: {
+      case 3 {
         a = 4;
       }
     }


### PR DESCRIPTION
Fixes #2678

* Make colon token optional in specifying a case of a switch statement