### PR TITLE
Remove shift tokens and add shift built-in functions

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5007,51 +5007,6 @@ See [[#sync-builtin-functions]].
     <td>Bitwise-exclusive-or. [=Component-wise=] when |T| is a vector.
 </table>
 
-
-<table class='data'>
-  <caption>Bit shift expressions</caption>
-  <thead>
-    <tr><th>Precondition<th>Conclusion<th>Notes
-  </thead>
-
-  <tr algorithm="logical shift left">
-    <td>|e1|: |T|<br>
-    |e2|: |TS|<br>
-    |T| is [INTEGRAL]<br>
-    |TS| is u32 if |e1| is a scalar, or<br>
-    vec|N|&lt;u32&gt;.
-    <td class="nowrap">|e1| `<<` |e2|: |T|
-    <td>Logical shift left:<br>
-        Shift |e1| left, inserting zero bits at the least significant positions,
-        and discarding the most significant bits.
-        The number of bits to shift is the value of |e2| modulo the bit width of |e1|.<br>
-        [=Component-wise=] when |T| is a vector.
-
-  <tr algorithm="logical shift right">
-    <td>|e1|: |T|<br>
-    |e2|: |T|<br>
-    |T| is [UNSIGNEDINTEGRAL]
-    <td class="nowrap">|e1| >> |e2|: |T|
-    <td>Logical shift right:<br>
-        Shift |e1| right, inserting zero bits at the most significant positions,
-        and discarding the least significant bits.
-        The number of bits to shift is the value of |e2| modulo the bit width of |e1|.
-        [=Component-wise=] when |T| is a vector.
-
-  <tr algorithm="arithmetic shift right">
-    <td>|e1|: |T|<br>
-    |e2|: |TS|<br>
-    |T| is [SIGNEDINTEGRAL]<br>
-    |TS| is u32 if |e1| is a scalar, or<br>
-    vec|N|&lt;u32&gt;.
-    <td class="nowrap">|e1| >> |e2|: |T|
-    <td>Arithmetic shift right:<br>
-        Shift |e1| right, copying the sign bit of |e1| into the most significant positions,
-        and discarding the least significant bits.
-        The number of bits to shift is the value of |e2| modulo the bit width of |e1|.
-        [=Component-wise=] when |T| is a vector.
-</table>
-
 ## Function Call Expression ## {#function-call-expr}
 
 A function call expression executes a [=function call=] where the called
@@ -5284,30 +5239,21 @@ However, [[#declaration-and-scope|declaration and scope]] rules ensure those nam
     | [=syntax/additive_expression=] [=syntax/minus=] [=syntax/multiplicative_expression=]
 </div>
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>shift_expression</dfn> :
+  <dfn for=syntax>relational_expression</dfn> :
 
     | [=syntax/additive_expression=]
 
-    | [=syntax/unary_expression=] [=syntax/shift_left=] [=syntax/unary_expression=]
+    | [=syntax/additive_expression=] [=syntax/less_than=] [=syntax/additive_expression=]
 
-    | [=syntax/unary_expression=] [=syntax/shift_right=] [=syntax/unary_expression=]
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>relational_expression</dfn> :
+    | [=syntax/additive_expression=] [=syntax/greater_than=] [=syntax/additive_expression=]
 
-    | [=syntax/shift_expression=]
+    | [=syntax/additive_expression=] [=syntax/less_than_equal=] [=syntax/additive_expression=]
 
-    | [=syntax/shift_expression=] [=syntax/less_than=] [=syntax/shift_expression=]
+    | [=syntax/additive_expression=] [=syntax/greater_than_equal=] [=syntax/additive_expression=]
 
-    | [=syntax/shift_expression=] [=syntax/greater_than=] [=syntax/shift_expression=]
+    | [=syntax/additive_expression=] [=syntax/equal_equal=] [=syntax/additive_expression=]
 
-    | [=syntax/shift_expression=] [=syntax/less_than_equal=] [=syntax/shift_expression=]
-
-    | [=syntax/shift_expression=] [=syntax/greater_than_equal=] [=syntax/shift_expression=]
-
-    | [=syntax/shift_expression=] [=syntax/equal_equal=] [=syntax/shift_expression=]
-
-    | [=syntax/shift_expression=] [=syntax/not_equal=] [=syntax/shift_expression=]
+    | [=syntax/additive_expression=] [=syntax/not_equal=] [=syntax/additive_expression=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>short_circuit_and_expression</dfn> :
@@ -5551,10 +5497,6 @@ An [=statement/assignment=] is a <dfn noexport>compound assignment</dfn> when th
     | [=syntax/or_equal=]
 
     | [=syntax/xor_equal=]
-
-    | [=syntax/shift_right_equal=]
-
-    | [=syntax/shift_left_equal=]
 </div>
 
 The type requirements, semantics, and behavior of each statement is defined as if
@@ -5588,12 +5530,6 @@ the compound assignment expands as in the following table, except that the refer
 <tr algorithm="bitwise-xor-assign">
     <td class="nowrap">|e1| ^= |e2|
     <td>|e1| = |e1| ^ (|e2|)
-<tr algorithm="bitwise-shiftright-assign">
-    <td class="nowrap">|e1| >>= |e2|
-    <td>|e1| = |e1| >> (|e2|)
-<tr algorithm="bitwise-shiftleft-assign">
-    <td class="nowrap">|e1| <<= |e2|
-    <td>|e1| = |e1| << (|e2|)
 </table>
 
 Note: The syntax does not allow a [=compound assignment=] to also be a [=phony assignment=].
@@ -9968,11 +9904,6 @@ A <dfn>syntactic token</dfn> is a sequence of special characters, used:
     | `'>='`
 </div>
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>shift_right</dfn> :
-
-    | `'>>'`
-</div>
-<div class='syntax' noexport='true'>
   <dfn for=syntax>less_than</dfn> :
 
     | `'<'`
@@ -9981,11 +9912,6 @@ A <dfn>syntactic token</dfn> is a sequence of special characters, used:
   <dfn for=syntax>less_than_equal</dfn> :
 
     | `'<='`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>shift_left</dfn> :
-
-    | `'<<'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>modulo</dfn> :
@@ -10101,16 +10027,6 @@ A <dfn>syntactic token</dfn> is a sequence of special characters, used:
   <dfn for=syntax>xor_equal</dfn> :
 
     | `'^='`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>shift_right_equal</dfn> :
-
-    | `'>>='`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>shift_left_equal</dfn> :
-
-    | `'<<='`
 </div>
 
 # Built-in Values # {#builtin-values}
@@ -10913,6 +10829,37 @@ struct __modf_result_vecN {
     <td>Reverses the bits in |e|:  The bit at position |k| of the result equals the
         bit at position 31-|k| of |e|.<br>
         [=Component-wise=] when |T| is a vector.
+
+  <tr algorithm="shift left">
+    <td>|T| is [INTEGRAL]<br>
+    |TS| is u32 if |T| is scalar, or<br>
+    vec|N|&lt;u32&gt; otherwise
+    <td class="nowrap">`shiftLeft(`|e1|`:` |T|`,` |e2|`:` |TS|`) ->` |T|
+    <td>Logical shift left.<br>
+    Shift |e1| left, inserting zero bits at the least significant positions,
+    and discarding the most significant bits.
+    The number of bits to shift is the value of |e2| modulo the bit width of |e1|.<br>
+    [=Component-wise=] when |T| is a vector.
+
+  <tr algorithm="logical shift right">
+    <td>|T| is [UNSIGNEDINTEGRAL]
+    <td class="nowrap">`shiftRight(`|e1|`:` |T|`,` |e2|`:` |T|`) ->` |T|
+    <td>Logical shift right.<br>
+    Shift |e1| right, inserting zero bits at the most significant positions,
+    and discarding the least significant bits.
+    The number of bits to shift is the value of |e2| modulo the bit width of |e1|.
+    [=Component-wise=] when |T| is a vector.
+
+  <tr algorithm="arithmetic shift right">
+    <td>|T| is [SIGNEDINTEGRAL]<br>
+    |TS| is u32 if |T| is scalar, or<br>
+    vec|N|&lt;u32&gt; otherwise
+    <td class="nowrap">`shiftRight(`|e1|`:` |T|`,` |e2|`:` |TS|`) ->` |T|
+    <td>Arithmetic shift right.<br>
+    Shift |e1| right, copying the sign bit of |e1| into the most significant positions,
+    and discarding the least significant bits.
+    The number of bits to shift is the value of |e2| modulo the bit width of |e1|.
+    [=Component-wise=] when |T| is a vector.
 </table>
 
 ## Matrix Built-in Functions ## {#matrix-builtin-functions}


### PR DESCRIPTION
Fixes #2092

* Remove the `>>`, `<<`, `>>=` and `<<=` tokens
* Remove shift expressions and compound shift assignments
* Add shiftLeft and shiftRight integer built-in functions