### PR TITLE
Add identity constructors for matrix types

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3854,7 +3854,7 @@ specify the component type; the component type is inferred from the constructor 
 <table class='data'>
   <caption>Scalar constructor type rules</caption>
   <thead>
-    <tr><th>Precondition<th>Conclusion
+    <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
   <tr><td>*e*: bool<td>`bool(e)`: bool<td>Identity.
   <tr><td>*e*: i32<td>`i32(e)`: i32<td>Identity.
@@ -3959,6 +3959,43 @@ specify the component type; the component type is inferred from the constructor 
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
+  <tr>
+    <td>|e|: mat2x2&lt;f32&gt;<br>
+    <td>`mat2x2<f32>(`|e|`)`: mat2x2&lt;f32&gt;<br>
+        `mat2x2(`|e|`)`: mat2x2&lt;f32&gt;<br>
+    <td rowspan=9>Identity. The result is |e|.
+  <tr>
+    <td>|e|: mat2x3&lt;f32&gt;<br>
+    <td>`mat2x3<f32>(`|e|`)`: mat2x3&lt;f32&gt;<br>
+        `mat2x3(`|e|`)`: mat2x3&lt;f32&gt;
+  <tr>
+    <td>|e|: mat2x4&lt;f32&gt;<br>
+    <td>`mat2x4<f32>(`|e|`)`: mat2x4&lt;f32&gt;<br>
+        `mat2x4(`|e|`)`: mat2x4&lt;f32&gt;
+  <tr>
+    <td>|e|: mat3x2&lt;f32&gt;<br>
+    <td>`mat3x2<f32>(`|e|`)`: mat3x2&lt;f32&gt;<br>
+        `mat3x2(`|e|`)`: mat3x2&lt;f32&gt;
+  <tr>
+    <td>|e|: mat3x3&lt;f32&gt;<br>
+    <td>`mat3x3<f32>(`|e|`)`: mat3x3&lt;f32&gt;<br>
+        `mat3x3(`|e|`)`: mat3x3&lt;f32&gt;
+  <tr>
+    <td>|e|: mat3x4&lt;f32&gt;<br>
+    <td>`mat3x4<f32>(`|e|`)`: mat3x4&lt;f32&gt;<br>
+        `mat3x4(`|e|`)`: mat3x4&lt;f32&gt;
+  <tr>
+    <td>|e|: mat4x2&lt;f32&gt;<br>
+    <td>`mat4x2<f32>(`|e|`)`: mat4x2&lt;f32&gt;<br>
+        `mat4x2(`|e|`)`: mat4x2&lt;f32&gt;
+  <tr>
+    <td>|e|: mat4x3&lt;f32&gt;<br>
+    <td>`mat4x3<f32>(`|e|`)`: mat4x3&lt;f32&gt;<br>
+        `mat4x3(`|e|`)`: mat4x3&lt;f32&gt;
+  <tr>
+    <td>|e|: mat4x4&lt;f32&gt;<br>
+    <td>`mat4x4<f32>(`|e|`)`: mat4x4&lt;f32&gt;<br>
+        `mat4x4(`|e|`)`: mat4x4&lt;f32&gt;
   <tr>
     <td rowspan=2>|e1|: |f32|<br>
         ...<br>


### PR DESCRIPTION
Example:
    mat2x3<f32>(e)
    mat2x3(e)

These are identity constructors when e is already has type mat2x3<f32>

Fixes: #2704