### PR TITLE
Require views on 2d multisampled textures to be 2d

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3014,6 +3014,8 @@ enum GPUTextureAspect {
                             - |descriptor|.{{GPUTextureViewDescriptor/baseArrayLayer}} +
                                 |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be &le;
                                 the [$array layer count$] of |this|.
+                            - If |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}} is &gt; 1,
+                                |descriptor|.{{GPUTextureViewDescriptor/dimension}} must be {{GPUTextureViewDimension/"2d"}}.
                             - If |descriptor|.{{GPUTextureViewDescriptor/dimension}} is:
                                 <dl class="switch">
                                     : {{GPUTextureViewDimension/"1d"}}


### PR DESCRIPTION
Fixes #2715.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/austinEng/gpuweb/pull/2716.html" title="Last updated on Apr 4, 2022, 10:49 PM UTC (36aae40)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2716/e95305c...austinEng:36aae40.html" title="Last updated on Apr 4, 2022, 10:49 PM UTC (36aae40)">Diff</a>