### PR TITLE
Fix deprecation warnings in workload simulator

### DIFF
--- a/samples/workload-simulator.html
+++ b/samples/workload-simulator.html
@@ -408,7 +408,7 @@ let device;
 let gpuPresent;
 let canvasContext;
 let multisampleRenderAttachment;
-let sampleCount = 4;
+let sampleCount = multisampling.checked ? 4 : 1;
 let pipeline;
 let sampler;
 let bindGroup;
@@ -679,7 +679,7 @@ async function render(fromRaf, fromPostMessage) {
         pipeline = device.createRenderPipeline({
           primitive: { topology: 'triangle-list' },
           layout: pipelineLayout,
-          multisample: { count: multisampling.checked ? sampleCount : 1, },
+          multisample: { count: sampleCount },
           vertex: {
             entryPoint: 'vs',
             module: shaderModule,

--- a/samples/workload-simulator.html
+++ b/samples/workload-simulator.html
@@ -73,8 +73,8 @@ input[type="range"] {
 .bad { color: red; user-select: text; }
 .light { color: #CCCCCC; }
 </style>
-<canvas id=webglCanvas class=square></canvas>
-<canvas id=webGPUCanvas class=square></canvas>
+<canvas id=webglCanvas width=512 height=512 class=square></canvas>
+<canvas id=webGPUCanvas width=512 height=512 class=square style=display:none;></canvas>
 <canvas id=canvas class=square style=display:none;></canvas>
 <div id=dom class=square style=display:none;background:white>
   <img id=img style=width:256px;height:256px;background:black></img>
@@ -82,7 +82,7 @@ input[type="range"] {
 <div style="margin:0 2em; padding-top:2em">
 <h2 style=margin-top:0>Drag the logo, or choose "Animate".</h2>
 <label for=animate><input type=checkbox name=animate id=animate>Animate</label>
-<span id=continuousOptions>
+<span id=continuousOptions style=display:none;>
   <label for=useRaf><input type=radio name=loop id=useRaf checked>requestAnimationFrame</label>
   <label for=usePostMessage><input type=radio name=loop id=usePostMessage>postMessage</label>
   <label for=useSetTimeout><input type=radio name=loop id=useSetTimeout>setTimeout</label>

--- a/samples/workload-simulator.html
+++ b/samples/workload-simulator.html
@@ -657,8 +657,8 @@ async function render(fromRaf, fromPostMessage) {
           @binding(2) @group(0) var texture1: texture_2d<f32>;
 
           struct Output {
-            @builtin(position) Position : vec4<f32>;
-            @location(0) uv : vec2<f32>;
+            @builtin(position) Position : vec4<f32>,
+            @location(0) uv : vec2<f32>,
           };
           
           @stage(vertex)
@@ -820,7 +820,8 @@ async function render(fromRaf, fromPostMessage) {
         colorAttachments: [ {
           view: renderAttachment,
           resolveTarget: multisampling.checked ? canvasView : undefined,
-          loadValue: { r: 1, g: 1, b: 1, a: 1 },
+          loadOp: 'clear',
+          clearValue: { r: 1, g: 1, b: 1, a: 1 },
           storeOp: multisampling.checked ? 'discard' : 'store',
         }, ],
       });

--- a/samples/workload-simulator.html
+++ b/samples/workload-simulator.html
@@ -173,6 +173,7 @@ input[type="range"] {
   <details id=webgpuCanvasOptions>
     <summary>WebGPU canvas context options</summary>
       <label for=multisampling><input type=checkbox name=multisampling id=multisampling checked>4x Multisampling</label>
+      <label for=opaque><input type=checkbox name=opaque id=opaque checked>Opaque</label>
   </details>
   <details id=contextAttributes>
     <summary>WebGL Context attributes</summary>
@@ -234,7 +235,7 @@ for (const control of controls) {
 }
 // Some controls require a page reload when changed.
 let reloadingPage = false;
-const reloadControls = ['useWebGL2', 'antialias', 'alpha', 'depth', 'stencil', 'premultipliedAlpha', 'preserveDrawingBuffer', 'desynchronized', 'ppDefault', 'lowPower', 'highPerformance', 'canvasSize', 'onscreen', 'offscreen', 'transferControlToOffscreen', 'multisampling'].map(x=>window[x]);
+const reloadControls = ['useWebGL2', 'antialias', 'alpha', 'depth', 'stencil', 'premultipliedAlpha', 'preserveDrawingBuffer', 'desynchronized', 'ppDefault', 'lowPower', 'highPerformance', 'canvasSize', 'onscreen', 'offscreen', 'transferControlToOffscreen', 'multisampling', 'opaque'].map(x=>window[x]);
 for (let control of reloadControls) {
   control.oninput = null;
   control.onchange = ()=>{
@@ -605,7 +606,11 @@ async function render(fromRaf, fromPostMessage) {
           if (!errorMessage.textContent) errorMessage.textContent = 'Uncaptured error: ' + e.error.message;
         });
         canvasContext = webGPUCanvas.getContext('webgpu');
-        canvasContext.configure({device, format: canvasFormat});
+        canvasContext.configure({
+          device,
+          format: canvasFormat,
+          compositingAlphaMode: opaque.checked ? 'opaque' : 'premultiplied'
+        });
         const bindGroupLayout = device.createBindGroupLayout({
           entries: [
             {


### PR DESCRIPTION
Along with a couple of other miscellaneous things: an issue with RenderBundles when multisampling is disabled, and flickering when the page reloads after some checkboxes are used.