### PR TITLE
wgsl: Allow increment/decrement statements in for_init

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5872,6 +5872,10 @@ allows them to naturally use values defined in the loop body.
 
     | [=syntax/variable_statement=]
 
+    | [=syntax/increment_statement=]
+
+    | [=syntax/decrement_statement=]
+
     | [=syntax/assignment_statement=]
 
     | [=syntax/func_call_statement=]


### PR DESCRIPTION
These statements are supported in for-loop initializers in GLSL, HLSL,
and MSL too.

With this change, the increment_statement and decrement_statement
rules are supported everywhere that assignment_statement is supported,
which is useful for parsing since their grammar rules overlap.