### PR TITLE
Change integer texture parameters to unsigned

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -11000,33 +11000,33 @@ Parameter values must be valid for the respective texture types.
 Returns the dimensions of a texture, or texture's mip level in texels.
 
 ```rust
-fn textureDimensions(t: texture_1d<T>) -> i32
-fn textureDimensions(t: texture_1d<T>, level: i32) -> i32
-fn textureDimensions(t: texture_2d<T>) -> vec2<i32>
-fn textureDimensions(t: texture_2d<T>, level: i32) -> vec2<i32>
-fn textureDimensions(t: texture_2d_array<T>) -> vec2<i32>
-fn textureDimensions(t: texture_2d_array<T>, level: i32) -> vec2<i32>
-fn textureDimensions(t: texture_3d<T>) -> vec3<i32>
-fn textureDimensions(t: texture_3d<T>, level: i32) -> vec3<i32>
-fn textureDimensions(t: texture_cube<T>) -> vec2<i32>
-fn textureDimensions(t: texture_cube<T>, level: i32) -> vec2<i32>
-fn textureDimensions(t: texture_cube_array<T>) -> vec2<i32>
-fn textureDimensions(t: texture_cube_array<T>, level: i32) -> vec2<i32>
-fn textureDimensions(t: texture_multisampled_2d<T>)-> vec2<i32>
-fn textureDimensions(t: texture_depth_2d) -> vec2<i32>
-fn textureDimensions(t: texture_depth_2d, level: i32) -> vec2<i32>
-fn textureDimensions(t: texture_depth_2d_array) -> vec2<i32>
-fn textureDimensions(t: texture_depth_2d_array, level: i32) -> vec2<i32>
-fn textureDimensions(t: texture_depth_cube) -> vec2<i32>
-fn textureDimensions(t: texture_depth_cube, level: i32) -> vec2<i32>
-fn textureDimensions(t: texture_depth_cube_array) -> vec2<i32>
-fn textureDimensions(t: texture_depth_cube_array, level: i32) -> vec2<i32>
-fn textureDimensions(t: texture_depth_multisampled_2d)-> vec2<i32>
-fn textureDimensions(t: texture_storage_1d<F,A>) -> i32
-fn textureDimensions(t: texture_storage_2d<F,A>) -> vec2<i32>
-fn textureDimensions(t: texture_storage_2d_array<F,A>) -> vec2<i32>
-fn textureDimensions(t: texture_storage_3d<F,A>) -> vec3<i32>
-fn textureDimensions(t: texture_external) -> vec2<i32>
+fn textureDimensions(t: texture_1d<T>) -> u32
+fn textureDimensions(t: texture_1d<T>, level: u32) -> u32
+fn textureDimensions(t: texture_2d<T>) -> vec2<u32>
+fn textureDimensions(t: texture_2d<T>, level: u32) -> vec2<u32>
+fn textureDimensions(t: texture_2d_array<T>) -> vec2<u32>
+fn textureDimensions(t: texture_2d_array<T>, level: u32) -> vec2<u32>
+fn textureDimensions(t: texture_3d<T>) -> vec3<u32>
+fn textureDimensions(t: texture_3d<T>, level: u32) -> vec3<u32>
+fn textureDimensions(t: texture_cube<T>) -> vec2<u32>
+fn textureDimensions(t: texture_cube<T>, level: u32) -> vec2<u32>
+fn textureDimensions(t: texture_cube_array<T>) -> vec2<u32>
+fn textureDimensions(t: texture_cube_array<T>, level: u32) -> vec2<u32>
+fn textureDimensions(t: texture_multisampled_2d<T>)-> vec2<u32>
+fn textureDimensions(t: texture_depth_2d) -> vec2<u32>
+fn textureDimensions(t: texture_depth_2d, level: u32) -> vec2<u32>
+fn textureDimensions(t: texture_depth_2d_array) -> vec2<u32>
+fn textureDimensions(t: texture_depth_2d_array, level: u32) -> vec2<u32>
+fn textureDimensions(t: texture_depth_cube) -> vec2<u32>
+fn textureDimensions(t: texture_depth_cube, level: u32) -> vec2<u32>
+fn textureDimensions(t: texture_depth_cube_array) -> vec2<u32>
+fn textureDimensions(t: texture_depth_cube_array, level: u32) -> vec2<u32>
+fn textureDimensions(t: texture_depth_multisampled_2d)-> vec2<u32>
+fn textureDimensions(t: texture_storage_1d<F,A>) -> u32
+fn textureDimensions(t: texture_storage_2d<F,A>) -> vec2<u32>
+fn textureDimensions(t: texture_storage_2d_array<F,A>) -> vec2<u32>
+fn textureDimensions(t: texture_storage_3d<F,A>) -> vec3<u32>
+fn textureDimensions(t: texture_external) -> vec2<u32>
 ```
 
 **Parameters:**
@@ -11095,6 +11095,15 @@ fn textureGather(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array
 fn textureGather(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: i32, offset: vec2<i32>) -> vec4<f32>
 fn textureGather(t: texture_depth_cube, s: sampler, coords: vec3<f32>) -> vec4<f32>
 fn textureGather(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, array_index: i32) -> vec4<f32>
+fn textureGather(component: u32, t: texture_2d<T>, s: sampler, coords: vec2<f32>) -> vec4<T>
+fn textureGather(component: u32, t: texture_2d<T>, s: sampler, coords: vec2<f32>, offset: vec2<i32>) -> vec4<T>
+fn textureGather(component: u32, t: texture_2d_array<T>, s: sampler, coords: vec2<f32>, array_index: u32) -> vec4<T>
+fn textureGather(component: u32, t: texture_2d_array<T>, s: sampler, coords: vec2<f32>, array_index: u32, offset: vec2<i32>) -> vec4<T>
+fn textureGather(component: u32, t: texture_cube<T>, s: sampler, coords: vec3<f32>) -> vec4<T>
+fn textureGather(component: u32, t: texture_cube_array<T>, s: sampler, coords: vec3<f32>, array_index: u32) -> vec4<T>
+fn textureGather(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: u32) -> vec4<f32>
+fn textureGather(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: u32, offset: vec2<i32>) -> vec4<f32>
+fn textureGather(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, array_index: u32) -> vec4<f32>
 ```
 
 **Parameters:**
@@ -11178,6 +11187,9 @@ fn textureGatherCompare(t: texture_depth_2d_array, s: sampler_comparison, coords
 fn textureGatherCompare(t: texture_depth_2d_array, s: sampler_comparison, coords: vec2<f32>, array_index: i32, depth_ref: f32, offset: vec2<i32>) -> vec4<f32>
 fn textureGatherCompare(t: texture_depth_cube, s: sampler_comparison, coords: vec3<f32>, depth_ref: f32) -> vec4<f32>
 fn textureGatherCompare(t: texture_depth_cube_array, s: sampler_comparison, coords: vec3<f32>, array_index: i32, depth_ref: f32) -> vec4<f32>
+fn textureGatherCompare(t: texture_depth_2d_array, s: sampler_comparison, coords: vec2<f32>, array_index: u32, depth_ref: f32) -> vec4<f32>
+fn textureGatherCompare(t: texture_depth_2d_array, s: sampler_comparison, coords: vec2<f32>, array_index: u32, depth_ref: f32, offset: vec2<i32>) -> vec4<f32>
+fn textureGatherCompare(t: texture_depth_cube_array, s: sampler_comparison, coords: vec3<f32>, array_index: u32, depth_ref: f32) -> vec4<f32>
 ```
 **Parameters:**
 
@@ -11230,6 +11242,15 @@ fn textureLoad(t: texture_depth_2d, coords: vec2<i32>, level: i32) -> f32
 fn textureLoad(t: texture_depth_2d_array, coords: vec2<i32>, array_index: i32, level: i32) -> f32
 fn textureLoad(t: texture_depth_multisampled_2d, coords: vec2<i32>, sample_index: i32)-> f32
 fn textureLoad(t: texture_external, coords: vec2<i32>) -> vec4<f32>
+fn textureLoad(t: texture_1d<T>, coords: u32, level: u32) -> vec4<T>
+fn textureLoad(t: texture_2d<T>, coords: vec2<u32>, level: u32) -> vec4<T>
+fn textureLoad(t: texture_2d_array<T>, coords: vec2<u32>, array_index: u32, level: u32) -> vec4<T>
+fn textureLoad(t: texture_3d<T>, coords: vec3<u32>, level: u32) -> vec4<T>
+fn textureLoad(t: texture_multisampled_2d<T>, coords: vec2<u32>, sample_index: u32)-> vec4<T>
+fn textureLoad(t: texture_depth_2d, coords: vec2<u32>, level: u32) -> f32
+fn textureLoad(t: texture_depth_2d_array, coords: vec2<u32>, array_index: u32, level: u32) -> f32
+fn textureLoad(t: texture_depth_multisampled_2d, coords: vec2<u32>, sample_index: u32)-> f32
+fn textureLoad(t: texture_external, coords: vec2<u32>) -> vec4<f32>
 ```
 
 **Parameters:**
@@ -11269,11 +11290,11 @@ If an out of bounds access occurs, the built-in function returns one of:
 Returns the number of layers (elements) of an array texture.
 
 ```rust
-fn textureNumLayers(t: texture_2d_array<T>) -> i32
-fn textureNumLayers(t: texture_cube_array<T>) -> i32
-fn textureNumLayers(t: texture_depth_2d_array) -> i32
-fn textureNumLayers(t: texture_depth_cube_array) -> i32
-fn textureNumLayers(t: texture_storage_2d_array<F,A>) -> i32
+fn textureNumLayers(t: texture_2d_array<T>) -> u32
+fn textureNumLayers(t: texture_cube_array<T>) -> u32
+fn textureNumLayers(t: texture_depth_2d_array) -> u32
+fn textureNumLayers(t: texture_depth_cube_array) -> u32
+fn textureNumLayers(t: texture_storage_2d_array<F,A>) -> u32
 ```
 
 **Parameters:**
@@ -11295,16 +11316,16 @@ The number of layers (elements) of the array texture.
 Returns the number of mip levels of a texture.
 
 ```rust
-fn textureNumLevels(t: texture_1d<T>) -> i32
-fn textureNumLevels(t: texture_2d<T>) -> i32
-fn textureNumLevels(t: texture_2d_array<T>) -> i32
-fn textureNumLevels(t: texture_3d<T>) -> i32
-fn textureNumLevels(t: texture_cube<T>) -> i32
-fn textureNumLevels(t: texture_cube_array<T>) -> i32
-fn textureNumLevels(t: texture_depth_2d) -> i32
-fn textureNumLevels(t: texture_depth_2d_array) -> i32
-fn textureNumLevels(t: texture_depth_cube) -> i32
-fn textureNumLevels(t: texture_depth_cube_array) -> i32
+fn textureNumLevels(t: texture_1d<T>) -> u32
+fn textureNumLevels(t: texture_2d<T>) -> u32
+fn textureNumLevels(t: texture_2d_array<T>) -> u32
+fn textureNumLevels(t: texture_3d<T>) -> u32
+fn textureNumLevels(t: texture_cube<T>) -> u32
+fn textureNumLevels(t: texture_cube_array<T>) -> u32
+fn textureNumLevels(t: texture_depth_2d) -> u32
+fn textureNumLevels(t: texture_depth_2d_array) -> u32
+fn textureNumLevels(t: texture_depth_cube) -> u32
+fn textureNumLevels(t: texture_depth_cube_array) -> u32
 ```
 
 **Parameters:**
@@ -11324,8 +11345,8 @@ The number of mip levels for the texture.
 Returns the number samples per texel in a multisampled texture.
 
 ```rust
-textureNumSamples(t: texture_multisampled_2d<T>) -> i32
-textureNumSamples(t: texture_depth_multisampled_2d) -> i32
+fn textureNumSamples(t: texture_multisampled_2d<T>) -> u32
+fn textureNumSamples(t: texture_depth_multisampled_2d) -> u32
 ```
 
 **Parameters:**
@@ -11363,6 +11384,12 @@ fn textureSample(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array
 fn textureSample(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: i32, offset: vec2<i32>) -> f32
 fn textureSample(t: texture_depth_cube, s: sampler, coords: vec3<f32>) -> f32
 fn textureSample(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, array_index: i32) -> f32
+fn textureSample(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: u32) -> vec4<f32>
+fn textureSample(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: u32, offset: vec2<i32>) -> vec4<f32>
+fn textureSample(t: texture_cube_array<f32>, s: sampler, coords: vec3<f32>, array_index: u32) -> vec4<f32>
+fn textureSample(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: u32) -> f32
+fn textureSample(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: u32, offset: vec2<i32>) -> f32
+fn textureSample(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, array_index: u32) -> f32
 ```
 
 **Parameters:**
@@ -11407,6 +11434,9 @@ fn textureSampleBias(t: texture_3d<f32>, s: sampler, coords: vec3<f32>, bias: f3
 fn textureSampleBias(t: texture_3d<f32>, s: sampler, coords: vec3<f32>, bias: f32, offset: vec3<i32>) -> vec4<f32>
 fn textureSampleBias(t: texture_cube<f32>, s: sampler, coords: vec3<f32>, bias: f32) -> vec4<f32>
 fn textureSampleBias(t: texture_cube_array<f32>, s: sampler, coords: vec3<f32>, array_index: i32, bias: f32) -> vec4<f32>
+fn textureSampleBias(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: u32, bias: f32) -> vec4<f32>
+fn textureSampleBias(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: u32, bias: f32, offset: vec2<i32>) -> vec4<f32>
+fn textureSampleBias(t: texture_cube_array<f32>, s: sampler, coords: vec3<f32>, array_index: u32, bias: f32) -> vec4<f32>
 ```
 
 **Parameters:**
@@ -11451,6 +11481,9 @@ fn textureSampleCompare(t: texture_depth_2d_array, s: sampler_comparison, coords
 fn textureSampleCompare(t: texture_depth_2d_array, s: sampler_comparison, coords: vec2<f32>, array_index: i32, depth_ref: f32, offset: vec2<i32>) -> f32
 fn textureSampleCompare(t: texture_depth_cube, s: sampler_comparison, coords: vec3<f32>, depth_ref: f32) -> f32
 fn textureSampleCompare(t: texture_depth_cube_array, s: sampler_comparison, coords: vec3<f32>, array_index: i32, depth_ref: f32) -> f32
+fn textureSampleCompare(t: texture_depth_2d_array, s: sampler_comparison, coords: vec2<f32>, array_index: u32, depth_ref: f32) -> f32
+fn textureSampleCompare(t: texture_depth_2d_array, s: sampler_comparison, coords: vec2<f32>, array_index: u32, depth_ref: f32, offset: vec2<i32>) -> f32
+fn textureSampleCompare(t: texture_depth_cube_array, s: sampler_comparison, coords: vec3<f32>, array_index: u32, depth_ref: f32) -> f32
 ```
 
 **Parameters:**
@@ -11499,6 +11532,9 @@ fn textureSampleCompareLevel(t: texture_depth_2d_array, s: sampler_comparison, c
 fn textureSampleCompareLevel(t: texture_depth_2d_array, s: sampler_comparison, coords: vec2<f32>, array_index: i32, depth_ref: f32, offset: vec2<i32>) -> f32
 fn textureSampleCompareLevel(t: texture_depth_cube, s: sampler_comparison, coords: vec3<f32>, depth_ref: f32) -> f32
 fn textureSampleCompareLevel(t: texture_depth_cube_array, s: sampler_comparison, coords: vec3<f32>, array_index: i32, depth_ref: f32) -> f32
+fn textureSampleCompareLevel(t: texture_depth_2d_array, s: sampler_comparison, coords: vec2<f32>, array_index: u32, depth_ref: f32) -> f32
+fn textureSampleCompareLevel(t: texture_depth_2d_array, s: sampler_comparison, coords: vec2<f32>, array_index: u32, depth_ref: f32, offset: vec2<i32>) -> f32
+fn textureSampleCompareLevel(t: texture_depth_cube_array, s: sampler_comparison, coords: vec3<f32>, array_index: u32, depth_ref: f32) -> f32
 ```
 
 The `textureSampleCompareLevel` function is the same as `textureSampleCompare`, except that:
@@ -11521,6 +11557,9 @@ fn textureSampleGrad(t: texture_3d<f32>, s: sampler, coords: vec3<f32>, ddx: vec
 fn textureSampleGrad(t: texture_3d<f32>, s: sampler, coords: vec3<f32>, ddx: vec3<f32>, ddy: vec3<f32>, offset: vec3<i32>) -> vec4<f32>
 fn textureSampleGrad(t: texture_cube<f32>, s: sampler, coords: vec3<f32>, ddx: vec3<f32>, ddy: vec3<f32>) -> vec4<f32>
 fn textureSampleGrad(t: texture_cube_array<f32>, s: sampler, coords: vec3<f32>, array_index: i32, ddx: vec3<f32>, ddy: vec3<f32>) -> vec4<f32>
+fn textureSampleGrad(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: u32, ddx: vec2<f32>, ddy: vec2<f32>) -> vec4<f32>
+fn textureSampleGrad(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: u32, ddx: vec2<f32>, ddy: vec2<f32>, offset: vec2<i32>) -> vec4<f32>
+fn textureSampleGrad(t: texture_cube_array<f32>, s: sampler, coords: vec3<f32>, array_index: u32, ddx: vec3<f32>, ddy: vec3<f32>) -> vec4<f32>
 ```
 
 **Parameters:**
@@ -11572,6 +11611,15 @@ fn textureSampleLevel(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, 
 fn textureSampleLevel(t: texture_depth_cube, s: sampler, coords: vec3<f32>, level: i32) -> f32
 fn textureSampleLevel(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, array_index: i32, level: i32) -> f32
 fn textureSampleLevel(t: texture_external, s: sampler, coords: vec2<f32>) -> vec4<f32>
+fn textureSampleLevel(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: u32, level: f32) -> vec4<f32>
+fn textureSampleLevel(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: u32, level: f32, offset: vec2<i32>) -> vec4<f32>
+fn textureSampleLevel(t: texture_cube_array<f32>, s: sampler, coords: vec3<f32>, array_index: u32, level: f32) -> vec4<f32>
+fn textureSampleLevel(t: texture_depth_2d, s: sampler, coords: vec2<f32>, level: u32) -> f32
+fn textureSampleLevel(t: texture_depth_2d, s: sampler, coords: vec2<f32>, level: u32, offset: vec2<i32>) -> f32
+fn textureSampleLevel(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: u32, level: u32) -> f32
+fn textureSampleLevel(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: u32, level: u32, offset: vec2<i32>) -> f32
+fn textureSampleLevel(t: texture_depth_cube, s: sampler, coords: vec3<f32>, level: u32) -> f32
+fn textureSampleLevel(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, array_index: u32, level: u32) -> f32
 ```
 
 **Parameters:**
@@ -11615,6 +11663,10 @@ fn textureStore(t: texture_storage_1d<F,write>, coords: i32, value: vec4<T>)
 fn textureStore(t: texture_storage_2d<F,write>, coords: vec2<i32>, value: vec4<T>)
 fn textureStore(t: texture_storage_2d_array<F,write>, coords: vec2<i32>, array_index: i32, value: vec4<T>)
 fn textureStore(t: texture_storage_3d<F,write>, coords: vec3<i32>, value: vec4<T>)
+fn textureStore(t: texture_storage_1d<F,write>, coords: u32, value: vec4<T>)
+fn textureStore(t: texture_storage_2d<F,write>, coords: vec2<u32>, value: vec4<T>)
+fn textureStore(t: texture_storage_2d_array<F,write>, coords: vec2<u32>, array_index: u32, value: vec4<T>)
+fn textureStore(t: texture_storage_3d<F,write>, coords: vec3<u32>, value: vec4<T>)
 ```
 
 The channel format `T` depends on the storage texel format `F`.


### PR DESCRIPTION
Fixes #2570

* Change all the integer parameters for texture built-in functions from
  signed to unsigned
* With literal unification, unsuffixed literals will continue to be
  accepted in these functions

I plan to leave #2588 open for now, but this is a more reasonable state than the current one and likely easier to get consensus on.