### PR TITLE
[wgsl] Allow continue to be called within a while loop.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6051,7 +6051,7 @@ A <dfn noexport dfn-for="statement">continue</dfn> statement transfers control i
 *  forward to the [=statement/continuing=] statement at the end of the body of that loop, if it exists.
 *  otherwise backward to the first statement in the loop body, starting the next [=iteration=].
 
-A `continue` statement must only be used in a [=statement/loop=] or [=statement/for=] statement.
+A `continue` statement must only be used in a [=statement/loop=], [=statement/for=] or [=statement/while=] statement.
 A `continue` statement must not be placed such that it would transfer
 control to an enclosing [=statement/continuing=] statement.
 (It is a *forward* branch when branching to a `continuing` statement.)
@@ -11842,4 +11842,3 @@ stage.
 storageBarrier affects memory and atomic operations in the [=address spaces/storage=] address space.
 
 workgroupBarrier affects memory and atomic operations in the [=address spaces/workgroup=] address space.
-


### PR DESCRIPTION
Currently the `continue` text says it may only be used in a `loop` or
`for`. This PR extends to also allow within a `while` loop.