### PR TITLE
[wgsl] Match any and all formatting in logical built-in table.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -10237,8 +10237,8 @@ See [[#function-calls]].
     <td>Returns true if each component of |e| is true.
 
   <tr algorithm="scalar all">
-    <td>|e|: bool
-    <td>`all(`|e|`)`: bool
+    <td>
+    <td>`all`(|e|: bool) -> bool
     <td>Returns |e|.
 
   <tr algorithm="vector any">
@@ -10247,8 +10247,8 @@ See [[#function-calls]].
     <td>Returns true if any component of |e| is true.
 
   <tr algorithm="scalar any">
-    <td>|e|: bool
-    <td>`any(`|e|`)`: bool
+    <td>
+    <td>`any`(|e|: bool) -> bool
     <td>Returns |e|.
 
   <tr algorithm="scalar select">
@@ -11842,4 +11842,3 @@ stage.
 storageBarrier affects memory and atomic operations in the [=address spaces/storage=] address space.
 
 workgroupBarrier affects memory and atomic operations in the [=address spaces/workgroup=] address space.
-


### PR DESCRIPTION
This PR updates the `any` and `all` documentation for a single `bool`
parameter to have formatting consistent with the other entries in the
table.