### PR TITLE
[wgsl] Link CTS from spec.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -16,6 +16,7 @@ Text Macro: NUMERIC i32, u32, f32, vec|N|&lt;i32&gt;, vec|N|&lt;u32&gt;, or vec|
 Ignored Vars: i, c0, e, e1, e2, e3, eN, p, s1, s2, sn, N, M, v, Stride, Offset, Align, Extent, S, T, T1
 
 !Participate: <a href="https://github.com/gpuweb/gpuweb/issues/new?labels=wgsl">File an issue</a> (<a href="https://github.com/gpuweb/gpuweb/issues?q=is%3Aissue+is%3Aopen+label%3Awgsl">open issues</a>)
+!Tests: <a href=https://github.com/gpuweb/cts/tree/main/src/webgpu/shader/>WebGPU CTS shader/</a>
 
 Editor: David Neto, Google https://www.google.com, dneto@google.com, w3cid 99785
 Editor: Myles C. Maxfield, Apple Inc., mmaxfield@apple.com, w3cid 77180


### PR DESCRIPTION
This PR adds a link to the CTS shader folder to the metadata of the
spec.