### PR TITLE
WGSL Internationalization Adjustment for Code Points

### DIFF
--- a/wgsl/extract-grammar.py
+++ b/wgsl/extract-grammar.py
@@ -324,7 +324,7 @@ module.exports = grammar({
     extras: $ => [
         $._comment,
         $._block_comment,
-        $.blankspace,
+        $._blankspace,
     ],
 
     inline: $ => [
@@ -467,7 +467,7 @@ for key, value in scanner_components[scanner_rule.name()].items():
 
 
 for key, value in scanner_components[scanner_rule.name()].items():
-    if key.startswith("_") and key != "_comment" and key != "blankspace" and key not in rule_skip:
+    if key.startswith("_") and key != "_comment" and key != "_blankspace" and key not in rule_skip:
         grammar_source += grammar_from_rule(key, value) + ",\n"
         rule_skip.add(key)
 
@@ -492,8 +492,8 @@ rule_skip.add("_comment")
 
 
 grammar_source += grammar_from_rule(
-    "blankspace", scanner_components[scanner_rule.name()]["blankspace"])
-rule_skip.add("blankspace")
+    "_blankspace", scanner_components[scanner_rule.name()]["_blankspace"])
+rule_skip.add("_blankspace")
 
 
 grammar_source += "\n"

--- a/wgsl/extract-grammar.py
+++ b/wgsl/extract-grammar.py
@@ -146,7 +146,9 @@ class scanner_rule(Scanner):
 
     @staticmethod
     def parse(lines, i):
-        line = lines[i].rstrip()
+        # Exclude code point comments
+        # Supports both "Code point" and "Code points"
+        line = lines[i].split("(Code point")[0].rstrip()
         if line[2:].startswith("<dfn for=syntax>"):
             # When the line is
             #    <dfn for=syntax>access_mode</dfn>
@@ -322,7 +324,7 @@ module.exports = grammar({
     extras: $ => [
         $._comment,
         $._block_comment,
-        $._space,
+        $.blankspace,
     ],
 
     inline: $ => [
@@ -465,7 +467,7 @@ for key, value in scanner_components[scanner_rule.name()].items():
 
 
 for key, value in scanner_components[scanner_rule.name()].items():
-    if key.startswith("_") and key != "_comment" and key != "_space" and key not in rule_skip:
+    if key.startswith("_") and key != "_comment" and key != "blankspace" and key not in rule_skip:
         grammar_source += grammar_from_rule(key, value) + ",\n"
         rule_skip.add(key)
 
@@ -490,8 +492,8 @@ rule_skip.add("_comment")
 
 
 grammar_source += grammar_from_rule(
-    "_space", scanner_components[scanner_rule.name()]["_space"])
-rule_skip.add("_space")
+    "blankspace", scanner_components[scanner_rule.name()]["blankspace"])
+rule_skip.add("blankspace")
 
 
 grammar_source += "\n"

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -375,7 +375,9 @@ WGSL program text consists of a sequence of code points, grouped into contiguous
 
 The program text must not include a null code point (`U+0000`).
 
-<dfn>Blankspace</dfn> is any combination of one or more of the following code points:
+<dfn>Blankspace</dfn> is any combination of one or more of code points from
+[=Unicode Standard Annex #31 for Unicode Version 14.0.0|Pattern_White_Space=] property.
+Following is the set of code points in [=Unicode Standard Annex #31 for Unicode Version 14.0.0|Pattern_White_Space=]:
 * space (`U+0020`)
 * horizontal tab (`U+0009`)
 * line feed (`U+000A`)

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -368,38 +368,43 @@ However, UTF-8 is always a valid encoding for a WGSL program.
 Note: The intent of promoting UTF-8 like this is to simplify interchange of WGSL programs
 and to encourage interoperability among tools.
 
-WGSL program text consists of a sequence of characters, grouped into contiguous non-empty sets forming:
+WGSL program text consists of a sequence of code points, grouped into contiguous non-empty sets forming:
 * [=comments=]
 * [=tokens=]
 * [=blankspace=]
 
-The program text must not include a null character.
+The program text must not include a null code point (`U+0000`).
 
-<dfn>Blankspace</dfn> is any combination of one or more of the following characters:
-* space
-* horizontal tab
-* linefeed
-* vertical tab
-* formfeed
-* carriage return
+<dfn>Blankspace</dfn> is any combination of one or more of the following code points:
+* space (`U+0020`)
+* horizontal tab (`U+0009`)
+* line feed (`U+000A`)
+* vertical tab (`U+000B`)
+* form feed (`U+000C`)
+* carriage return (`U+000D`)
+* next line (`U+0085`)
+* left-to-right mark (`U+200E`)
+* right-to-left mark (`U+200F`)
+* line separator (`U+2028`)
+* paragraph separator (`U+2029`)
 
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>_space</dfn> :
+  <dfn for=syntax>blankspace</dfn> :
 
-    | `/\s/`
+    | `/[\u0020\u0009\u000a\u000b\u000c\u000d\u0085\u200e\u200f\u2028\u2029]/uy`
 </div>
 
 To parse a WGSL program:
 1. Remove comments:
-    * Replace the first comment with a space character.
+    * Replace the first comment with a space code point.
     * Repeat until no comments remain.
-2. Scanning from beginning to end, group the remaining characters into tokens and blankspace
+2. Scanning from beginning to end, group the remaining code points into tokens and blankspace
     in greedy fashion:
     * The next group is formed from the longest
-        non-empty prefix of the remaining ungrouped characters, that is either:
+        non-empty prefix of the remaining ungrouped code points, that is either:
         * a valid token, or
         * blankspace
-    * Repeat until no ungrouped characters remain.
+    * Repeat until no ungrouped code points remain.
 3. Discard the blankspace, leaving only tokens.
 4. Parse the token sequence, attempting to match the [=syntax/translation_unit=] grammar rule.
 
@@ -414,17 +419,18 @@ program, except that a comment can separate [=tokens=].
 Shader authors can use comments to document their programs.
 
 A <dfn noexport>line-ending comment</dfn> is a kind of [=comment=] consisting
-of the two characters `//` and the characters that follow,
+of the two code points `//` and the code points that follow,
 up until but not including:
-* the next [=blankspace=] character other than a space or a horizontal tab, or
+* the next [=blankspace=] code point other than a space or a horizontal tab, or
 * the end of the program.
 
 A <dfn noexport>block comment</dfn> is a kind of [=comment=] consisting of:
-* The two characters `/*`
+* The two code points `/*` (`U+002F` followed by `U+002A`)
 * Then any sequence of:
     * A [=block comment=], or
-    * Text that does not contain either `*/` or `/*`
-* Then the two characters `*/`
+    * Text that does not contain either `*/` (`U+002A` followed by `U+002F`)
+        or `/*` (`U+002F` followed by `U+002A`)
+* Then the two code points `*/` (`U+002A` followed by `U+002F`)
 
 Note: Block comments can be nested.
 Since a block comment requires matching start and end text sequences, and allows arbitrary nesting,
@@ -445,7 +451,7 @@ This is a consequence of the Pumping Lemma for Regular Languages.
 
 ## Tokens ## {#tokens}
 
-A <dfn>token</dfn> is a contiguous sequence of characters forming one of:
+A <dfn>token</dfn> is a contiguous sequence of code points forming one of:
 * a [=literal=].
 * a [=keyword=].
 * a [=reserved word=].
@@ -579,7 +585,7 @@ The form of an identifier is based on the
 [[!UnicodeVersion14|Unicode Version 14.0.0]],
 with the following elaborations. Identifiers do not compare under canonical equivalence
 and they are not normalized otherwise,
-meaning that single accented code points are distinct from the same characters constructed
+meaning that single accented code points are distinct from the same code points constructed
 by an accent and a letter, and Unicode code points that look similar are not
 treated as the same and they compare by their code points.
 
@@ -593,7 +599,7 @@ Identifiers use the following profile described in terms of [=UAX31 Grammar=]:
 <Medial> :=
 ```
 
-This means identifiers with non-ASCII characters like these are
+This means identifiers with non-ASCII code points like these are
 valid: `Δέλτα`, `réflexion`, `Кызыл`, `𐰓𐰏𐰇`, `朝焼け`, `سلام`, `검정`, `שָׁלוֹם`, `गुलाबी`, `փիրուզ`.
 
 With the following exceptions:
@@ -608,7 +614,7 @@ With the following exceptions:
 </div>
 
 [=Unicode Character Database for Unicode Version 14.0.0=] includes non-normative listing
-with all valid characters
+with all valid code points
 of both [=UAX31 Lexical Classes|XID_Start=] and
 [=UAX31 Lexical Classes|XID_Continue=].
 
@@ -9814,219 +9820,219 @@ The following are reserved words:
 
 ## Syntactic Tokens ## {#syntactic-tokens}
 
-A <dfn>syntactic token</dfn> is a sequence of special characters, used:
+A <dfn>syntactic token</dfn> is a sequence of special code points, used:
 * to spell an expression operator, or
 * as punctuation: to group, sequence, or separate other grammar elements.
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>and</dfn> :
 
-    | `'&'`
+    | `'&'` (Code point: `U+0026`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>and_and</dfn> :
 
-    | `'&&'`
+    | `'&&'` (Code points: `U+0026` `U+0026`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>arrow</dfn> :
 
-    | `'->'`
+    | `'->'` (Code points: `U+002D` `U+003E`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>attr</dfn> :
 
-    | `'@'`
+    | `'@'` (Code point: `U+0040`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>forward_slash</dfn> :
 
-    | `'/'`
+    | `'/'` (Code point: `U+002F`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>bang</dfn> :
 
-    | `'!'`
+    | `'!'` (Code point: `U+0021`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>bracket_left</dfn> :
 
-    | `'['`
+    | `'['` (Code point: `U+005B`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>bracket_right</dfn> :
 
-    | `']'`
+    | `']'` (Code point: `U+005D`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>brace_left</dfn> :
 
-    | `'{'`
+    | `'{'` (Code point: `U+007B`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>brace_right</dfn> :
 
-    | `'}'`
+    | `'}'` (Code point: `U+007D`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>colon</dfn> :
 
-    | `':'`
+    | `':'` (Code point: `U+003A`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>comma</dfn> :
 
-    | `','`
+    | `','` (Code point: `U+002C`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>equal</dfn> :
 
-    | `'='`
+    | `'='` (Code point: `U+003D`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>equal_equal</dfn> :
 
-    | `'=='`
+    | `'=='` (Code points: `U+003D` `U+003D`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>not_equal</dfn> :
 
-    | `'!='`
+    | `'!='` (Code points: `U+0021` `U+003D`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>greater_than</dfn> :
 
-    | `'>'`
+    | `'>'` (Code point: `U+003E`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>greater_than_equal</dfn> :
 
-    | `'>='`
+    | `'>='` (Code points: `U+003E` `U+003D`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>less_than</dfn> :
 
-    | `'<'`
+    | `'<'` (Code point: `U+003C`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>less_than_equal</dfn> :
 
-    | `'<='`
+    | `'<='` (Code points: `U+003C` `U+003D`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>modulo</dfn> :
 
-    | `'%'`
+    | `'%'` (Code point: `U+0025`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>minus</dfn> :
 
-    | `'-'`
+    | `'-'` (Code point: `U+002D`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>minus_minus</dfn> :
 
-    | `'--'`
+    | `'--'` (Code points: `U+002D` `U+002D`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>period</dfn> :
 
-    | `'.'`
+    | `'.'` (Code point: `U+002E`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>plus</dfn> :
 
-    | `'+'`
+    | `'+'` (Code point: `U+002B`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>plus_plus</dfn> :
 
-    | `'++'`
+    | `'++'` (Code points: `U+002B` `U+002B`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>or</dfn> :
 
-    | `'|'`
+    | `'|'` (Code point: `U+007C`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>or_or</dfn> :
 
-    | `'||'`
+    | `'||'` (Code points: `U+007C` `U+007C`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>paren_left</dfn> :
 
-    | `'('`
+    | `'('` (Code point: `U+0028`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>paren_right</dfn> :
 
-    | `')'`
+    | `')'` (Code point: `U+0029`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>semicolon</dfn> :
 
-    | `';'`
+    | `';'` (Code point: `U+003B`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>star</dfn> :
 
-    | `'*'`
+    | `'*'` (Code point: `U+002A`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>tilde</dfn> :
 
-    | `'~'`
+    | `'~'` (Code point: `U+007E`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>underscore</dfn> :
 
-    | `'_'`
+    | `'_'` (Code point: `U+005F`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>xor</dfn> :
 
-    | `'^'`
+    | `'^'` (Code point: `U+005E`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>plus_equal</dfn> :
 
-    | `'+='`
+    | `'+='` (Code points: `U+002B` `U+003D`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>minus_equal</dfn> :
 
-    | `'-='`
+    | `'-='` (Code points: `U+002D` `U+003D`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>times_equal</dfn> :
 
-    | `'*='`
+    | `'*='` (Code points: `U+002A` `U+003D`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>division_equal</dfn> :
 
-    | `'/='`
+    | `'/='` (Code points: `U+002F` `U+003D`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>modulo_equal</dfn> :
 
-    | `'%='`
+    | `'%='` (Code points: `U+0025` `U+003D`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>and_equal</dfn> :
 
-    | `'&='`
+    | `'&='` (Code points: `U+0026` `U+003D`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>or_equal</dfn> :
 
-    | `'|='`
+    | `'|='` (Code points: `U+007C` `U+003D`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>xor_equal</dfn> :
 
-    | `'^='`
+    | `'^='` (Code points: `U+005E` `U+003D`)
 </div>
 
 # Built-in Values # {#builtin-values}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -396,7 +396,7 @@ The program text must not include a null code point (`U+0000`).
 
 To parse a WGSL program:
 1. Remove comments:
-    * Replace the first comment with a space code point.
+    * Replace the first comment with a space code point (`U+0020`).
     * Repeat until no comments remain.
 2. Scanning from beginning to end, group the remaining code points into tokens and blankspace
     in greedy fashion:
@@ -421,8 +421,8 @@ Shader authors can use comments to document their programs.
 A <dfn noexport>line-ending comment</dfn> is a kind of [=comment=] consisting
 of the two code points `//` (`U+002F` followed by `U+002F`) and the code points that follow,
 up until but not including:
-* the next [=blankspace=] code point other than a space, a horizontal tab,
-    a left-to-right mark or a right-to-left mark, or
+* the next [=blankspace=] code point other than a space (`U+0020`), a horizontal tab (`U+0009`),
+    a left-to-right mark (`U+200E`) or a right-to-left mark (`U+200F`), or
 * the end of the program.
 
 A <dfn noexport>block comment</dfn> is a kind of [=comment=] consisting of:

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -419,9 +419,10 @@ program, except that a comment can separate [=tokens=].
 Shader authors can use comments to document their programs.
 
 A <dfn noexport>line-ending comment</dfn> is a kind of [=comment=] consisting
-of the two code points `//` and the code points that follow,
+of the two code points `//` (`U+002F` followed by `U+002F`) and the code points that follow,
 up until but not including:
-* the next [=blankspace=] code point other than a space or a horizontal tab, or
+* the next [=blankspace=] code point other than a space, a horizontal tab,
+    a left-to-right mark or a right-to-left mark, or
 * the end of the program.
 
 A <dfn noexport>block comment</dfn> is a kind of [=comment=] consisting of:

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -389,7 +389,7 @@ The program text must not include a null code point (`U+0000`).
 * paragraph separator (`U+2029`)
 
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>blankspace</dfn> :
+  <dfn for=syntax>_blankspace</dfn> :
 
     | `/[\u0020\u0009\u000a\u000b\u000c\u000d\u0085\u200e\u200f\u2028\u2029]/uy`
 </div>


### PR DESCRIPTION
This WGSL PR improves the specification of code point-related elements in anticipation of upcoming internationalization feedback (see https://github.com/w3c/i18n-activity/issues/1501 and https://github.com/w3c/i18n-activity/issues/1502 threads). It is primarily mechanical, and in most places, it uses the term "code point" instead of "character" to improve and provide the exact Unicode code point in `U+....` format. In addition, PR includes updating the grammar extractor to support code point comments for syntax rules.

For blank space, this PR renames the `_space` rule to `_blankspace` to match the discussion as space of blank space in the rest of the spec.

There is only one contentious change: this PR, while improving blank space, adds a few code points to cover `Pattern_White_Space` (see https://util.unicode.org/UnicodeJsps/list-unicodeset.jsp?a=%5B%3APattern_White_Space%3DYes%3A%5D&g=&i= listing) completely, which is an immutable, stable property https://www.unicode.org/policies/stability_policy.html as seen here. Rust also adopts https://doc.rust-lang.org/reference/whitespace.html this approach. (ECMAScript includes more characters as seen here (check line terminators section too) https://tc39.es/ecma262/#sec-white-space but these properties lack stability guarantees)