### PR TITLE
[editorial] Change vast majority of must language to link to shader-creation error

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -355,12 +355,14 @@ A processing error may occur during three phases in the shader lifecycle:
 
 * A <dfn export>shader-creation error</dfn>
     is an error feasibly detectable at [=shader module creation=] time.
-    Detection must rely only on the WGSL program source text
+    Detection relies only on the WGSL program source text
     and other information available to the `createShaderModule` API method.
+    Statements in this specification that describe something the program *must*
+    do generally produce a shader-creation error if those assertions are violated.
 
 * A <dfn export>pipeline-creation error</dfn>
     is an error detectable at [=pipeline creation=] time.
-    Detection must rely only on the WGSL program source text
+    Detection relies on the WGSL program source text
     and other information available to the particular pipeline creation API method.
 
 * A <dfn export>dynamic error</dfn> is an error occurring during shader execution.
@@ -394,7 +396,7 @@ WGSL program text consists of a sequence of Unicode [=code points=], grouped int
 * [=tokens=]
 * [=blankspaces=]
 
-The program text must not include a null code point (`U+0000`).
+The program text [=shader-creation error|must not=] include a null code point (`U+0000`).
 
 ## Parsing ## {#parsing}
 
@@ -562,7 +564,8 @@ or a [=hexadecimal floating point literal=].
         * `e` or `E`.
         * Then an exponent specified as an decimal number with an optional leading sign (`+` or `-`).
         * Then an optional `f` or `h` suffix.
-    * At least one of the decimal point, or the exponent, or the `f` or `h` suffix must be present.
+    * At least one of the decimal point, or the exponent, or the `f` or `h` suffix
+         [=shader-creation error|must=] be present.
          If none are, then the token is instead an [=integer literal=].
     * The value of the literal is the value of the mantissa multiplied by 10 to the power of the exponent.
          When no exponent is specified, an exponent of 0 is assumed.
@@ -574,7 +577,7 @@ or a [=hexadecimal floating point literal=].
         * `p` or `P`
         * Then an exponent specified as an decimal number with an optional leading sign (`+` or `-`).
         * Then an optional `f` or `h` suffix.
-    * At least one of the hexadecimal point, or the exponent must be present.
+    * At least one of the hexadecimal point, or the exponent [=shader-creation error|must=] be present.
          If neither are, then the token is instead an [=integer literal=].
     * The value of the literal is the value of the mantissa multiplied by 2 to the power of the exponent.
          When no exponent is specified, an exponent of 0 is assumed.
@@ -697,9 +700,9 @@ This means identifiers with non-ASCII code points like these are
 valid: `Δέλτα`, `réflexion`, `Кызыл`, `𐰓𐰏𐰇`, `朝焼け`, `سلام`, `검정`, `שָׁלוֹם`, `गुलाबी`, `փիրուզ`.
 
 With the following exceptions:
-* An identifier must not have the same spelling as a [=keyword=] or as a [=reserved word=].
-* An identifier must not be `_` (a single underscore, `U+005F`).
-* An identifier must not start with `__` (two underscores, `U+005F` followed by `U+005F`).
+* An identifier [=shader-creation error|must not=] have the same spelling as a [=keyword=] or as a [=reserved word=].
+* An identifier [=shader-creation error|must not=] be `_` (a single underscore, `U+005F`).
+* An identifier [=shader-creation error|must not=] start with `__` (two underscores, `U+005F` followed by `U+005F`).
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>ident</dfn> :
@@ -745,7 +748,7 @@ Attributes are used for a variety of purposes such as specifying the interface w
 Generally speaking, from the language's point-of-view, attributes can be
 ignored for the purposes of type and semantic checking.
 
-An attribute must not be specified more than once per object or type.
+An attribute [=shader-creation error|must not=] be specified more than once per object or type.
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>attribute</dfn> :
@@ -772,15 +775,15 @@ An attribute must not be specified more than once per object or type.
 
   <tr><td><dfn noexport dfn-for="attribute">`align`</dfn>
     <td>positive i32 literal
-    <td>Must only be applied to a member of a [=structure=] type.
+    <td>[=shader-creation error|Must=] only be applied to a member of a [=structure=] type.
 
-    Must be a power of 2, and must satisfy the required-alignment for the member type:
+    [=shader-creation error|Must=] be a power of 2, and [=shader-creation error|must=] satisfy the required-alignment for the member type:
 
     <p algorithm="align constraint">
     If `align(`|n|`)` is applied to a member of |S|
     with type |T|, and |S| is the [=store type=]
     or contained in the store type for a variable in address space |C|,
-    then |n| must satisfy:
+    then |n| [=shader-creation error|must=] satisfy:
     |n|&nbsp;=&nbsp;|k|&nbsp;&times;&nbsp;[=RequiredAlignOf=](|T|,|C|)
     for some positive integer |k|.
     </p>
@@ -789,15 +792,15 @@ An attribute must not be specified more than once per object or type.
 
   <tr><td><dfn noexport dfn-for="attribute">`binding`
     <td>non-negative i32 literal
-    <td>Must only be applied to a [=resource=] variable.
+    <td>[=shader-creation error|Must=] only be applied to a [=resource=] variable.
 
     Specifies the binding number of the resource in a bind [=attribute/group=].
     See [[#resource-interface]].
 
   <tr><td><dfn noexport dfn-for="attribute">`builtin`
     <td>identifier name for a built-in value
-    <td>Must only be applied to an entry point function parameter, entry point
-    return type, or member of a [=structure=].
+    <td>[=shader-creation error|Must=] only be applied to an entry point
+    function parameter, entry point return type, or member of a [=structure=].
 
     Declares a built-in value.
     See [[#builtin-values]].
@@ -815,14 +818,14 @@ An attribute must not be specified more than once per object or type.
 
   <tr><td><dfn noexport dfn-for="attribute">`group`
     <td>non-negative i32 literal
-    <td>Must only be applied to a [=resource=] variable.
+    <td>[=shader-creation error|Must=] only be applied to a [=resource=] variable.
 
     Specifies the binding group of the resource.
     See [[#resource-interface]].
 
   <tr><td><dfn noexport dfn-for="attribute">`id`
     <td>non-negative i32 literal
-    <td>Must only be applied to an [=override declaration=] of [=scalar=] type.
+    <td>[=shader-creation error|Must=] only be applied to an [=override declaration=] of [=scalar=] type.
 
     Specifies a numeric identifier as an alternate name for a
     [=pipeline-overridable=] constant.
@@ -830,19 +833,19 @@ An attribute must not be specified more than once per object or type.
   <tr><td><dfn noexport dfn-for="attribute">`interpolate`
     <td>One or two parameters.
 
-    The first parameter must be an [=interpolation type=].
-    The second parameter, if present, must specify the [=interpolation sampling=].
-    <td>Must only be applied to a declaration that is decorated with a
+    The first parameter [=shader-creation error|must=] be an [=interpolation type=].
+    The second parameter, if present, [=shader-creation error|must=] specify the [=interpolation sampling=].
+    <td>[=shader-creation error|Must=] only be applied to a declaration that is decorated with a
     [=attribute/location=] attribute.
 
-    Specifies how the user-defined IO must be interpolated.
+    Specifies how the user-defined IO [=shader-creation error|must=] be interpolated.
     The attribute is only significant on user-defined [=vertex=] outputs
     and [=fragment=] inputs.
     See [[#interpolation]].
 
   <tr><td><dfn noexport dfn-for="attribute">`invariant`
     <td>*None*
-    <td>Must only be applied to the `position` built-in value.
+    <td>[=shader-creation error|Must=] only be applied to the `position` built-in value.
 
     When applied to the `position` [=built-in output value=] of a vertex
     shader, the computation of the result is invariant across different
@@ -857,22 +860,22 @@ An attribute must not be specified more than once per object or type.
 
   <tr><td><dfn noexport dfn-for="attribute">`location`
     <td>non-negative i32 literal
-    <td>Must only be applied to an entry point function parameter, entry point
+    <td>[=shader-creation error|Must=] only be applied to an entry point function parameter, entry point
     return type, or member of a [=structure=] type.
-    Must only be applied to declarations of [=numeric scalar=] or [=numeric
+    [=shader-creation error|Must=] only be applied to declarations of [=numeric scalar=] or [=numeric
     vector=] type.
-    Must not be used with the [=compute=] shader stage.
+    [=shader-creation error|Must not=] be used with the [=compute=] shader stage.
 
     Specifies a part of the user-defined IO of an entry point.
     See [[#input-output-locations]].
 
   <tr><td><dfn noexport dfn-for="attribute">`size`</dfn>
     <td>positive i32 literal
-    <td>Must only be applied to a member of a [=structure=] type.
+    <td>[=shader-creation error|Must=] only be applied to a member of a [=structure=] type.
 
     The number of bytes reserved in the struct for this member.
 
-    This number must be at least the [=byte-size=] of the type of the member:
+    This number [=shader-creation error|must=] be at least the [=byte-size=] of the type of the member:
     <p algorithm="byte-size constraint">
     If `size(`|n|`)` is applied to a member with type |T|, then [=SizeOf=](|T|)&nbsp;&leq;&nbsp;|n|.
     </p>
@@ -883,22 +886,22 @@ An attribute must not be specified more than once per object or type.
     <td>One, two or three parameters.
 
     Each parameter is either a literal or [[#module-constants|module-scope constant]].
-    All parameters must be of the same type, either [INT].
-    <td>Must be applied to a [=compute shader stage|compute shader=] entry point function.
-    Must not be applied to any other object.
+    All parameters [=shader-creation error|must=] be of the same type, either i32 or u32.
+    <td>[=shader-creation error|Must=] be applied to a [=compute shader stage|compute shader=] entry point function.
+    [=shader-creation error|Must not=] be applied to any other object.
 
     Specifies the x, y, and z dimensions of the [=workgroup grid=] for the compute shader.
 
     The first parameter specifies the x dimension.
     The second parameter, if provided, specifies the y dimension, otherwise is assumed to be 1.
     The third parameter, if provided, specifies the z dimension, otherwise is assumed to be 1.
-    Each dimension must be at least 1 and at most an upper bound specified by the WebGPU API.
+    Each dimension [=shader-creati be at least 1 and at most an upper bound specified by the WebGPU API.
 
 </table>
 
 The <dfn noexport>pipeline stage attributes</dfn> below
 designate a function as an [=entry point=] for a particular [=shader stage=].
-These attributes may only be applied to [=function declarations=],
+These attributes [=shader-creation error|must=] only be applied to [=function declarations=],
 and at most one may be present on a given function.
 They take no parameters.
 
@@ -928,7 +931,7 @@ A <dfn noexport>directive</dfn> is a [=token=] sequence which modifies how a WGS
 program is processed by a WebGPU implementation.
 
 Directives are optional.
-If present, all directives must appear before any declarations.
+If present, all directives [=shader-creation error|must=] appear before any declarations.
 
 See [[#enable-directive-section]].
 
@@ -956,7 +959,8 @@ its associated object.
 We say the identifier is <dfn noexport>in scope</dfn>
 (of the declaration) at those source locations.
 
-When an identifier is used, it must be [=in scope=] for some declaration, or as part of a directive.
+When an identifier is used, it [=shader-creation error|must=] be [=in scope=]
+for some declaration, or as part of a directive.
 When an identifier is used in scope of one or more declarations for that name,
 the identifier will denote the object of the non-[=module scope|module-scope=] declaration appearing closest to
 that use, or the [=module scope|module-scope=] declaration if no other declaration is in scope.
@@ -967,7 +971,7 @@ Generally, the scope is a span of text beginning immediately after the end of
 the declaration.
 Declarations at [=module scope=] are the exception, described below.
 
-A declaration must not introduce a name when that identifier is
+A declaration [=shader-creation error|must not=] introduce a name when that identifier is
 already in scope with the same end of scope as another instance of that name.
 
 Certain objects are provided by the WebGPU implementation, and are treated as
@@ -985,7 +989,7 @@ That is, a declaration at module scope may be referenced by source text
 that follows *or precedes* that declaration.
 
 It is a [=shader-creation error=] if any module scope declaration is recursive.
-That is, there must be no cycles among the declarations:
+That is, there can be no cycles among the declarations:
 
 > Consider the directed graph where:
 > * Each node corresponds to a declaration |D|.
@@ -1130,8 +1134,9 @@ It is not a runtime check.
 
 Statements often use expressions, and may place requirements on the static types of those expressions.
 For example:
-* The condition expression of an `if` statement must be of type [=bool=].
-* In a `let` declaration with an explicit type specified, the initializer expression must evaluate to that type.
+* The condition expression of an `if` statement [=shader-creation error|must=] be of type [=bool=].
+* In a `let` declaration with an explicit type specified, the initializer
+      expression [=shader-creation error|must=] evaluate to that type.
 
 <dfn noexport>Type checking</dfn> a successfully parsed WGSL program is the process of mapping
 each expression to its static type,
@@ -1363,8 +1368,8 @@ and with a numeric range and precision that may be larger than directly implemen
 * The <dfn noexport>AbstractFloat</dfn> type is the set of finite floating point numbers representable
     in the [[!IEEE-754|IEEE-754]] binary64 (double precision) format.
 
-An evaluation of an expression in one of these types must not overflow or produce undefined results.
-Otherwise, the result is a [=shader-creation error=].
+An evaluation of an expression in one of these types [=shader-creation
+error|must not=] overflow or produce undefined results.
 
 These types cannot be spelled in WGSL source. They are only used by [=type checking=].
 
@@ -1566,9 +1571,9 @@ A <dfn noexport>vector</dfn> is a grouped sequence of 2, 3, or 4 [=scalar=] or
     <tr><th>Type<th>Description
   </thead>
   <tr><td>vec*N*<*T*><td>Vector of *N* components of type *T*.
-                          *N* must be in {2, 3, 4} and *T*
-                          must be one of the [=scalar=] or [=abstract numeric
-                          type|abstract numeric=] types.
+                          *N* must be in {2, 3, 4} and *T* [=shader-creation
+                          error|must=] be one of the [=scalar=] or [=abstract
+                          numeric type|abstract numeric=] types.
                           We say *T* is the <dfn noexport>component type</dfn> of the vector.
 </table>
 
@@ -1645,10 +1650,10 @@ An <dfn noexport>atomic type</dfn> encapsulates an [=integer scalar=] type such 
     <tr><th>Type<th>Description
   </thead>
   <tr algorithm="atomic type"><td>atomic&lt;|T|&gt;
-    <td>Atomic of type |T|. |T| must be either [=u32=] or [=i32=].
+    <td>Atomic of type |T|. |T| [=shader-creation error|must=] be either [=u32=] or [=i32=].
 </table>
 
-An expression must not evaluate to an atomic type.
+An expression [=shader-creation error|must not=] evaluate to an atomic type.
 
 Atomic types may only be instantiated by variables in the [=address spaces/workgroup=]
 address space or by [=storage buffer=] variables with a [=access/read_write=] access mode.
@@ -1693,15 +1698,16 @@ An <dfn noexport>array</dfn> is an indexable grouping of element values.
 The first element in an array is at index 0, and each successive element is at the next integer index.
 See [[#array-access-expr]].
 
-An expression must not evaluate to a runtime-sized array type.
+An expression [=shader-creation error|must not=] evaluate to a runtime-sized array type.
 
-The element count expression |N| of a fixed-size array must:
-* be an [=override expression=], and
-* evaluate to an [=integer scalar=] with value greater than zero.
+The element count expression |N| of a fixed-size array is subject to the following constraints:
+* It [=shader-creation error|must=] be an [=override expression=].
+* It [=shader-creation error|must=] evalute to an [=integer scalar=].
+* It is a [=pipeline-creation error=] if expression is not greater than zero.
 
 Note:  The element count value is fully determined at [=pipeline creation=] time.
 
-An array element type must be one of:
+An array element type [=shader-creation error|must=] be one of:
 * a [=scalar=] type
 * a [=vector=] type with [=concrete=] components
 * a [=matrix=] type with [=concrete=] components
@@ -1717,8 +1723,8 @@ Two array types are the same if and only if all of the following are true:
     * They are both runtime-sized.
     * They are both fixed-sized with [=creation-fixed footprint=], and
         equal-valued element counts, even if one is signed and the other is unsigned.
-        (Signed and unsigned values are comparable in this case because element counts must
-        be greater than zero.)
+        (Signed and unsigned values are comparable in this case because element counts
+        are always positive.)
     * They are both fixed-sized with element count specified as the same
         [=pipeline-overridable=] constant.
 
@@ -1790,10 +1796,10 @@ A <dfn noexport>structure</dfn> is a grouping of named member values.
       <td>An ordered tuple of *N* members of types
           |T|<sub>1</sub> through |T|<sub>N</sub>, with |N| being an integer greater than 0.
           A structure type declaration specifies an [=identifier=] name for each member.
-          Two members of the same structure type must not have the same name.
+          Two members of the same structure type [=shader-creation error|must not=] have the same name.
 </table>
 
-A structure member type must be one of:
+A structure member type [=shader-creation error|must=] be one of:
 * a [=scalar=] type
 * a [=vector=] type
 * a [=matrix=] type
@@ -1804,8 +1810,8 @@ A structure member type must be one of:
 
 Note: Each member type must be a [=plain type=].
 
-Some consequences of the restrictions on structure member and array element types are:
-* A pointer, texture, or sampler must not appear in any level of nesting within an array or structure.
+Some consequences of the restrictions structure member and array element types are:
+* A pointer, texture, or sampler [=shader-creation error|must not=] appear in any level of nesting within an array or structure.
 * When a [=runtime-sized=] array is part of a larger type, it may only appear
     as the last element of a structure, which itself cannot be part of an enclosing array or structure.
 
@@ -1968,8 +1974,8 @@ Two sets of memory locations <dfn noexport>overlap</dfn> if the intersection of
 their sets of memory locations is non-empty. Each variable declaration has a
 set of memory locations that does not overlap with the sets of memory locations of
 any other variable declaration. Memory operations on structures and arrays may
-access padding between elements, but must not access padding at the end of the
-structure or array.
+access padding between elements, but it is a [=dynamic error=] to access
+padding at the end of the structure or array.
 
 ### Memory Access Mode ### {#memory-access-mode}
 
@@ -2002,7 +2008,7 @@ as the memory's <dfn noexport>access mode</dfn>:
 
 ### Storable Types ### {#storable-types}
 
-The value contained in a [=variable=] must be of a [=storable=] type.
+The value contained in a [=variable=] [=shader-creation error|must=] be of a [=storable=] type.
 A storable type may have an explicit representation defined by WGSL,
 as described in [[#internal-value-layout]],
 or it may be opaque, such as for textures and samplers.
@@ -2023,7 +2029,7 @@ Note: That is, the storable types are the [=plain types=], texture types, and sa
 ### IO-shareable Types ### {#io-shareable-types}
 
 [[#user-defined-inputs-outputs|User-defined pipeline input and output values]]
-must be of IO-shareable type.
+[=shader-creation error|must=] be of IO-shareable type.
 
 A type is <dfn noexport>IO-shareable</dfn> if it is one of:
 
@@ -2031,7 +2037,7 @@ A type is <dfn noexport>IO-shareable</dfn> if it is one of:
 * a [=numeric vector=] type
 * a [=structure=] type, if all its members are [=numeric scalars=] or [=numeric vectors=]
 
-The following kinds of values must be of IO-shareable type:
+The following kinds of values [=shader-creation error|must=] be of IO-shareable type:
 
 * Values accepted as user-defined inputs from an upstream pipeline stage.
 * Values written as user-defined output for downstream processing in the pipeline, or to an output attachment.
@@ -2046,10 +2052,10 @@ IO-shareable.
 
 Host-shareable types are used to describe the contents of buffers which are shared between
 the host and the GPU, or copied between host and GPU without format translation.
-When used for this purpose, the type must be additionally decorated with layout attributes
+When used for this purpose, the type may be additionally decorated with layout attributes
 as described in [[#memory-layouts]].
 We will see in [[#module-scope-variables]] that the [=store type=] of [=uniform buffer=] and [=storage buffer=]
-variables must be host-shareable.
+variables [=shader-creation error|must=] be host-shareable.
 
 A type is <dfn noexport>host-shareable</dfn> if it is one of:
 
@@ -2156,13 +2162,16 @@ bulk data organized as a sequence of bytes in memory.
 Buffers are shared between the CPU and the GPU, or between different shader stages
 in a pipeline, or between different pipelines.
 
-Because buffer data are shared without reformatting or translation,
-buffer producers and consumers must agree on the <dfn noexport>memory layout</dfn>,
-which is the description of how the bytes in a buffer are organized into typed WGSL values.
+Because buffer data are shared without reformatting or translation, it is a
+[=dynamic error=] if buffer producers and consumers do not agree on the <dfn
+noexport>memory layout</dfn>, which is the description of how the bytes in a
+buffer are organized into typed WGSL values.
 
-The [=store type=] of a buffer variable must be [=host-shareable=], with fully elaborated memory layout, as described below.
+The [=store type=] of a buffer variable [=shader-creation error|must=] be
+[=host-shareable=], with fully elaborated memory layout, as described below.
 
-Each buffer variable must be declared in either the [=address spaces/uniform=] or [=address spaces/storage=] address spaces.
+Each buffer variable [=shader-creation error|must=] be declared in either the
+[=address spaces/uniform=] or [=address spaces/storage=] address spaces.
 
 The memory layout of a type is significant only when evaluating an expression with:
 * a variable in the [=address spaces/uniform=] or [=address spaces/storage=] address space, or
@@ -2192,7 +2201,7 @@ Each [=host-shareable=] data type |T| has an alignment and size.
 
 The <dfn>alignment</dfn> of a type is a constraint on where values of that type may be placed in memory, expressed
 as an integer:
-a type's alignment must evenly divide
+a type's alignment [=shader-creation error|must=] evenly divide
 the byte address of the starting [=memory location=] of a value of that type.
 Alignments enable use of more efficient hardware instructions for accessing the values,
 or satisfy more restrictive hardware requirements on certain
@@ -2335,9 +2344,9 @@ as described in [[#internal-value-layout]].
   Otherwise, it is [=AlignOf=](|T|) where |T| is the type of the member.
 </p>
 
-If a structure member is decorated with the
-[=attribute/size=] attribute, the value must be at least as large as the
-size of the member's type:
+If a structure member is decorated with the [=attribute/size=] attribute, the
+value [=shader-creation error|must=] be at least as large as the size of the
+member's type:
 
 <p algorithm="member size constraint">
   [=SizeOfMember=](|S|, |i|) &ge; [=SizeOf=](T)<br>
@@ -2464,9 +2473,10 @@ of a buffer, given an assumed placement of the overall value.
 These layouts depend on the value's type,
 and the [=attribute/align=] and [=attribute/size=] attributes on structure members.
 
-The buffer byte offset at which a value is placed must satisfy the type alignment requirement:
-If a value of type |T| is placed
-at buffer offset |k|, then |k| = |c| &times; [=AlignOf=](|T|), for some non-negative integer |c|.
+The buffer byte offset at which a value is placed [=shader-creation
+error|must=] satisfy the type alignment requirement: If a value of type |T| is
+placed at buffer offset |k|, then |k| = |c| &times; [=AlignOf=](|T|), for some
+non-negative integer |c|.
 
 The data will appear identically regardless of the address space.
 
@@ -2530,7 +2540,7 @@ The [=address spaces/storage=] and [=address spaces/uniform=] address spaces
 have different buffer layout constraints which are described in this section.
 
 All structure and array types directly or indirectly referenced by a variable
-must obey the constraints of the variable's address space.
+[=shader-creation error|must=] obey the constraints of the variable's address space.
 Violations of an address space constraint results in a [=shader-creation error=].
 
 In this section we define <dfn noexport>RequiredAlignOf</dfn>(|S|, |C|) as the
@@ -2574,7 +2584,7 @@ used in address space |C|.
       <td>[=roundUp=](16, [=AlignOf=](|S|))<br>
 </table>
 
-Structure members of type |T| must have a byte offset
+Structure members of type |T| [=shader-creation error|must=] have a byte offset
 from the start of the structure that is a multiple of the [=RequiredAlignOf=](|T|, |C|)
 for the address space |C|:
 
@@ -2583,7 +2593,7 @@ for the address space |C|:
     Where |k| is a positive integer and |M| is a member of structure |S| with type |T|
 </p>
 
-Arrays of element type |T| must have an [=element stride=] that is a
+Arrays of element type |T| [=shader-creation error|must=] have an [=element stride=] that is a
 multiple of the [=RequiredAlignOf=](|T|, |C|) for the address space |C|:
 
 <p algorithm="array element minimum alignment">
@@ -2603,7 +2613,7 @@ The [=address spaces/uniform=] address space also requires that:
     That is, [=StrideOf=](array&lt;|T|,|N|&gt;) = 16 &times; |k|' for some positive integer |k|'.
 * If a structure member itself has a structure type `S`, then the number of
     bytes between the start of that member and the start of any following member
-    must be at least [=roundUp=](16, [=SizeOf=](S)).
+    [=shader-creation error|must=] be at least [=roundUp=](16, [=SizeOf=](S)).
 
 Note: The following examples show how to use [=attribute/align=] and [=attribute/size=] attributes
 on structure members to satisfy layout requirements for uniform buffers.
@@ -2658,7 +2668,7 @@ A <dfn noexport>memory view</dfn> comprises:
 * an interpretation of the contents of those locations as a WGSL [=type=], and
 * an [=access mode=].
 
-The access mode of a memory view must be supported by the address space. See [[#address-space]].
+The access mode of a memory view [=shader-creation error|must=] be supported by the address space. See [[#address-space]].
 
 WGSL has two kinds of types for representing memory views:
 [=reference types=] and [=pointer types=].
@@ -2691,7 +2701,7 @@ an address space, a storable type, and an access mode.
 In code examples in this specification, the comments show this fully parameterized form.
 
 However, in WGSL *source* text:
-* Reference types must not appear.
+* Reference types [=shader-creation error|must not=] appear.
 * Pointer types may appear.  A pointer type is spelled with parameterization by:
     * [=address space=],
     * [=store type=], and
@@ -2734,7 +2744,7 @@ The access mode for a memory view is often determined by context:
 
 When writing a [=variable declaration=] or a [=pointer type=] in WGSL source:
 * For the [=address spaces/storage=] address space, the access mode is optional, and defaults to [=access/read=].
-* For other address spaces, the access mode must not be written.
+* For other address spaces, the access mode [=shader-creation error|must not=] be written.
 
 ### Originating Variable ### {#originating-variable-section}
 
@@ -2763,9 +2773,9 @@ memory reference</dfn> is produced.
     * store the value to any [=memory locations|memory location(s)=] of the
         [[WebGPU#buffers|WebGPU buffer]] bound to the [=originating variable=]
     * not be executed
-[[#atomic-rmw|Read-modify-write atomics]] that operate on an invalid memory
-reference must load and store from the same [=memory locations|memory
-locations=] if they access memory.
+It is a [=dynamic error=] if [[#atomic-rmw|Read-modify-write atomics]] that
+operate on an invalid memory reference load and store from different [=memory
+locations|memory locations=] if they access memory.
 
 ### Use Cases for References and Pointers ### {#ref-ptr-use-cases}
 
@@ -2777,8 +2787,8 @@ References and pointers are distinguished by how they are used:
 * A [=let declaration=] can be of pointer type, but not of reference type.
 * A [=formal parameter=] can be of pointer type, but not of reference type.
 * A [=simple assignment=] statement performs a [=write access=] to update the contents of memory via a reference, where:
-    * The [=left-hand side=] of the assignment statement must be of reference type, with access mode [=access/write=] or [=access/read_write=].
-    * The [=right-hand side=] of the assignment statement must evaluate to the store type of the left-hand side.
+    * The [=left-hand side=] of the assignment statement [=shader-creation error|must=] be of reference type, with access mode [=access/write=] or [=access/read_write=].
+    * The [=right-hand side=] of the assignment statement [=shader-creation error|must=] evaluate to the store type of the left-hand side.
 * The <dfn noexport>Load Rule</dfn>: Inside a function, a reference is automatically dereferenced (read from) to satisfy type rules:
     * In a function, when a reference expression |r| with store type |T| is used in a statement or an expression, where
     * |r| has an access mode of [=access/read=] or [=access/read_write=], and
@@ -2841,7 +2851,7 @@ Defining pointers in this way enables two key use cases:
 
 * Using a let declaration with pointer type, to form a short name for part of the contents of a variable.
 * Using a formal parameter of a function to refer to the memory of a variable that is accessible to the [=calling function=].
-    * The call to such a function must supply a pointer value for that operand.
+    * The call to such a function [=shader-creation error|must=] supply a pointer value for that operand.
         This often requires using an [=address-of=] operation (unary `&`) to get a pointer to the variable's contents.
 
 Note: The following examples use WGSL features explained later in this specification.
@@ -3080,7 +3090,7 @@ In particular:
     either as a variable or as a formal parameter.
 * In WGSL pointers and references are not [=storable=].
     That is, the content of a WGSL variable may not contain a pointer or a reference.
-* In WGSL a function must not return a pointer or reference.
+* In WGSL a function [=shader-creation error|must not=] return a pointer or reference.
 * In WGSL there is no way to convert between integer values and pointer values.
 * In WGSL there is no way to forcibly change the type of a pointer value into another pointer type.
     * A composite component reference expression is different:
@@ -3159,7 +3169,7 @@ Instead, access is mediated through an opaque handle:
         the texture variable or function parameter as the builtin function's
         first parameter.
 * When constructing the WebGPU pipeline, the texture variable's store type and binding
-    must be compatible with the corresponding bind group layout entry.
+    [=shader-creation error|must=] be compatible with the corresponding bind group layout entry.
 
 In this way, the set of supported operations for a texture type
 is determined by the availability of texture builtin functions accepting that texture type
@@ -3302,7 +3312,7 @@ The last column in the table below uses the format-specific
 `texture_cube<type>`
 `texture_cube_array<type>`
 </pre>
-* type must be `f32`, `i32` or `u32`
+* type [=shader-creation error|must=] be `f32`, `i32` or `u32`
 * The parameterized type for the images is the type after conversion from sampling.
     E.g. you can have an image with texels with 8bit unorm components, but when you sample
     them you get a 32-bit float result (or vec-of-f32).
@@ -3312,7 +3322,7 @@ The last column in the table below uses the format-specific
 <pre class='def'>
 `texture_multisampled_2d<type>`
 </pre>
-* type must be `f32`, `i32` or `u32`
+* type [=shader-creation error|must=] be `f32`, `i32` or `u32`
 
 ### External Sampled Texture Types ### {#external-texture-type}
 
@@ -3335,7 +3345,7 @@ A <dfn noexport>storage texture</dfn> supports accessing a single texel without 
      supports writing a single texel, with automatic conversion of the shader value to a
      stored texel value.
 
-A storage texture type must be parameterized by one of the
+A storage texture type [=shader-creation error|must=] be parameterized by one of the
 [=storage-texel-format|texel formats for storage textures=].
 The texel format determines the conversion function as specified in [[#texel-formats]].
 
@@ -3353,8 +3363,8 @@ TODO(dneto): Move description of the conversion to the builtin function that act
 `texture_storage_3d<texel_format,access>`
 </pre>
 
-* `texel_format` must be one of the texel types specified in [=storage-texel-formats=]
-* `access` must be [=access/write=].
+* `texel_format` [=shader-creation error|must=] be one of the texel types specified in [=storage-texel-formats=]
+* `access` [=shader-creation error|must=] be [=access/write=].
 
 ### Depth Texture Types ### {#texture-depth}
 <pre class='def'>
@@ -3501,7 +3511,7 @@ sampler_comparison
 ## Type Aliases ## {#type-aliases}
 
 A <dfn noexport>type alias</dfn> declares a new name for an existing type.
-The declaration must appear at [=module scope=], and its [=scope=] is the entire program.
+The declaration [=shader-creation error|must=] appear at [=module scope=], and its [=scope=] is the entire program.
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>type_alias_decl</dfn> :
@@ -3589,7 +3599,7 @@ The declaration must appear at [=module scope=], and its [=scope=] is the entire
     | [=syntax/mat4x4=]
 </div>
 
-When the type declaration is an [=identifier=], then the expression must be in scope of a
+When the type declaration is an [=identifier=], then the expression [=shader-creation error|must=] be in scope of a
 [=declaration=] of the identifier as a type alias or structure type.
 
 <div class='example' heading="Type Declarations">
@@ -3644,11 +3654,9 @@ A <dfn noexport>let declaration</dfn> specifies a name for a value.
 Once the value for a let-declaration is computed, it is immutable.
 When an [=identifier=] use [=resolves=] to a let-declaration, the identifier denotes that value.
 
-When a `let` identifier is declared without an explicitly specified type, e.g.
-`let foo = 4`, the type is automatically inferred from the expression to the
-right of the [=syntax/equals=] token.
-The type of a `let` declaration is always [=concrete=].
-When the type is specified, e.g `let foo: i32 = 4`, the initializer expression must evaluate to that type.
+When a `let` identifier is declared without an explicitly specified type,
+e.g. `let foo = 4`, the type is automatically inferred from the expression to the right of the equals token (`=`).
+When the type is specified, e.g `let foo: i32 = 4`, the initializer expression [=shader-creation error|must=] evaluate to that type.
 
 `let`-declarations can only appear within a function definition.
 
@@ -3671,13 +3679,13 @@ pipeline-creation time.
 The value is the one specified by the WebGPU pipeline-creation method, if
 specified, and otherwise is the value of its initializer expression.
 When an [=identifier=] use [=resolves=] to a override-declaration, the identifier denotes that value.
-`override`-declarations must meet the following restrictions:
+`override`-declarations [=shader-creation error|must=] meet the following restrictions:
 
-  * The declaration must only occur at [=module scope=].
-  * The declaration must have at least one of a declared type, an initializer
+  * The declaration [=shader-creation error|must=] only occur at [=module scope=].
+  * The declaration [=shader-creation error|must=] have at least one of a declared type, an initializer
       expression, or both.
-  * The declared type, if present, must be a [=scalar=].
-  * The initializer expression, if present, must:
+  * The declared type, if present, [=shader-creation error|must=] be a [=scalar=].
+  * The initializer expression, if present, [=shader-creation error|must=]:
       * evaluate to a [=scalar=] type.
       * evaluate to the declared type if it is present.
       * be composed only [=creation-time expressions=] or expressions where all
@@ -3685,10 +3693,10 @@ When an [=identifier=] use [=resolves=] to a override-declaration, the identifie
           constants=], or [=creation-time functions=].
           Such an expression is called an <dfn noexport>override expression</dfn>.
   * If the declaration has the [=attribute/id=] applied, the literal operand is
-      known as the <dfn noexport>pipeline constant ID</dfn>, and must be an
+      known as the <dfn noexport>pipeline constant ID</dfn>, and [=shader-creation error|must=] be an
       integer value between 0 and 65535.
-  * Pipeline constant IDs must be unique within the WGSL program: Two `override`-declarations
-    must not use the same pipeline constant ID.
+  * Pipeline constant IDs [=shader-creation error|must=] be unique within the WGSL program: Two `override`-declarations
+    [=shader-creation error|must not=] use the same pipeline constant ID.
   * The application can specify its own value for the constant at pipeline-creation time.
     The pipeline creation API accepts a mapping from overridable constant to a
     value of the constant's type.
@@ -3697,7 +3705,7 @@ When an [=identifier=] use [=resolves=] to a override-declaration, the identifie
     the declared [=name=] of the constant.
   * The <dfn export>pipeline-overridable constant has a default value</dfn> if
     its declaration has an initializer expression.
-    If it doesn't, a value must be provided at pipeline-creation time.
+    If it doesn't, it is a [=pipeline-creation error=] if a value is not provided at pipeline-creation time.
 
 Note: Override expressions are a superset of [=creation-time expressions=].
 
@@ -3778,7 +3786,7 @@ A <dfn noexport>variable declaration</dfn>:
 * Ensures the execution environment allocates memory for a value of the store type, in the specified address space,
     supporting the given access mode, for the [=lifetime=] of the variable.
 * Optionally has an *initializer* expression, if the variable is in the [=address spaces/private=] or [=address spaces/function=] address spaces.
-    If present, the initializer expression must evaluate to the variable's store type.
+    If present, the initializer expression [=shader-creation error|must=] evaluate to the variable's store type.
 
 When an [=identifier=] use [=resolves=] to a variable declaration,
 the identifier is an expression denoting the reference [=memory view=] for the variable's memory,
@@ -3790,7 +3798,7 @@ a variable in a particular address space can be declared,
 and when the address space decoration is required, optional, or forbidden.
 
 The access mode always has a default, and except for variables in the [=address spaces/storage=] address space,
-must not be written in WGSL source text. See [[#access-mode-defaults]].
+[=shader-creation error|must not=] be written in WGSL source text. See [[#access-mode-defaults]].
 
 The <dfn noexport>lifetime</dfn> of a variable is the period during shader
 execution for which the variable exists.
@@ -3851,20 +3859,20 @@ The variable name is [=in scope=] for the entire program.
 
 Variables at [=module scope=] are restricted as follows:
 
-* The variable must not be in the [=address spaces/function=] address space.
+* The variable [=shader-creation error|must not=] be in the [=address spaces/function=] address space.
 * A variable in the [=address spaces/private=], [=address spaces/workgroup=], [=address spaces/uniform=], or [=address spaces/storage=] address spaces:
-    * Must be declared with an explicit address space decoration.
-    * Must use a [=store type=] as described in [[#address-space]].
-* If the [=store type=] is a texture type or a sampler type, then the variable declaration must not
+    * [=shader-creation error|Must=] be declared with an explicit address space decoration.
+    * [=shader-creation error|Must=] use a [=store type=] as described in [[#address-space]].
+* If the [=store type=] is a texture type or a sampler type, then the variable declaration [=shader-creation error|must not=]
     have an address space decoration.  The address space will always be [=address spaces/handle=].
 
 A variable in the [=address spaces/uniform=] address space is a <dfn noexport>uniform buffer</dfn> variable.
-Its [=store type=] must be a [=host-shareable=] [=constructible=] type,
-and must satisfy [address space layout constraints](#address-space-layout-constraints).
+Its [=store type=] [=shader-creation error|must=] be a [=host-shareable=] [=constructible=] type,
+and [=shader-creation error|must=] satisfy [address space layout constraints](#address-space-layout-constraints).
 
 A variable in the [=address spaces/storage=] address space is a <dfn noexport>storage buffer</dfn> variable.
-Its [=store type=] must be a [=host-shareable=] type
-and must satisfy [address space layout constraints](#address-space-layout-constraints).
+Its [=store type=] [=shader-creation error|must=] be a [=host-shareable=] type
+and [=shader-creation error|must=] satisfy [address space layout constraints](#address-space-layout-constraints).
 The variable may be declared with a [=access/read=] or [=access/read_write=] access mode; the default is [=access/read=].
 
 As described in [[#resource-interface]],
@@ -3931,13 +3939,13 @@ The name is available for use immediately after its declaration statement, and
 until the end of the brace-delimited list of statements immediately enclosing
 the declaration.
 
-A [=let declaration|let-declared=] constant must be of [=constructible=] type,
-or of [=pointer type=].
+A function-scope [=let declaration|let-declared=] constant [=shader-creation error|must=] be of
+[=constructible=] type, or of [=pointer type=].
 
 For a variable declared in function scope:
 * The variable is always in the [=address spaces/function=] address space.
-* The [=address space=] attribute is optional.
-* The [=store type=] must be a [=constructible=] type.
+* The address space decoration is optional.
+* The [=store type=] [=shader-creation error|must=] be a [=constructible=] type.
 * When an initializer is specified, the store type may be omitted from the declaration.
     In this case the store type is the type of the result of evaluating the initializer.
 
@@ -6037,7 +6045,7 @@ A <dfn noexport>decrement statement</dfn> subtracts 1 from the contents of a var
     | [=syntax/lhs_expression=] [=syntax/minus_minus=]
 </div>
 
-The expression must evaluate to a reference with an [=integer scalar=] [=store type=] and [=access/read_write=] [=access mode=].
+The expression [=shader-creation error|must=] evaluate to a reference with an [=integer scalar=] [=store type=] and [=access/read_write=] [=access mode=].
 
 <table class='data'>
   <thead>
@@ -6095,7 +6103,7 @@ The `if` statements in WGSL use an if/else if/else structure, that contains a si
 `if` clause, zero or more `else if` clauses and a single optional `else` clause.
 
 [=Type rule precondition=]:
-Each of the expressions for the `if` and `else if` clause conditions must be scalar boolean expressions.
+Each of the expressions for the `if` and `else if` clause conditions [=shader-creation error|must=] be scalar boolean expressions.
 
 An `if` statement is executed as follows:
 * The condition associated with the `if` clause is evaluated.
@@ -6147,12 +6155,12 @@ be [=creation-time expressions=].
 If the selector value does not equal any of the case selector values, then control is
 transferred to the `default` clause.
 
-Each switch statement must have exactly one default clause.
+Each switch statement [=shader-creation error|must=] have exactly one default clause.
 
 [=Type rule precondition=]:
-For a single switch statement, the selector expression and all case selector expressions must be of the same [=integer scalar=] type.
+For a single switch statement, the selector expression and all case selector expressions [=shader-creation error|must=] be of the same [=integer scalar=] type.
 
-A literal value must not appear more than once in the case selectors for a switch statement.
+A literal value [=shader-creation error|must not=] appear more than once in the case selectors for a switch statement.
 
 Note: The value of the literal is what matters, not the spelling.
 For example `0` and `0x0000` both denote the zero value.
@@ -6162,7 +6170,7 @@ after the switch statement.
 Alternately, executing a <dfn noexport dfn-for="statement">fallthrough</dfn> statement
 transfers control to the body of the next case clause or
 default clause, whichever appears next in the switch body.
-A `fallthrough` statement must not appear as the last statement in the last clause of a switch.
+A `fallthrough` statement [=shader-creation error|must not=] appear as the last statement in the last clause of a switch.
 When a [=declaration=] appears in a case body, its [=identifier=] is [=in scope=] from
 the start of the next statement until the end of the case body.
 
@@ -6341,7 +6349,7 @@ Additionally:
 * If `condition` is non-empty, it is checked at the beginning of the loop body and if unsatisfied then a [[#break-statement]] is executed.
 * If `update_part` is non-empty, it becomes a [=statement/continuing=] statement at the end of the loop body.
 
-[=Type rule precondition=]: The condition must be of [=bool=] type.
+[=Type rule precondition=]: The condition [=shader-creation error|must=] be of [=bool=] type.
 
 The `initializer` of a for loop is executed once prior to executing the loop.
 When a [=declaration=] appears in the initializer, its [=identifier=] is [=in scope=] until the end of the `body`.
@@ -6403,7 +6411,7 @@ At the start of each loop [=iteration=], a boolean condition is evaluated.
 If the condition is false, the while loop ends execution.
 Otherwise, the rest of the iteration is executed.
 
-[=Type rule precondition=]: The condition must be of [=bool=] type.
+[=Type rule precondition=]: The condition [=shader-creation error|must=] be of [=bool=] type.
 
 A while loop can be viewed as syntactic sugar over either a [=statement/loop=] or [=statement/for=] statement.
 The following statement forms are equivalent:
@@ -6423,9 +6431,9 @@ A <dfn noexport dfn-for="statement">break</dfn> statement transfers control to i
 after the body of the nearest-enclosing loop
 or [=statement/switch=] statement, thus ending execution of the loop or switch statement.
 
-A `break` statement must only be used within [=statement/loop=], [=statement/for=], [=statement/while=], and [=statement/switch=] statements.
+A `break` statement [=shader-creation error|must=] only be used within [=statement/loop=], [=statement/for=], [=statement/while=], and [=statement/switch=] statements.
 
-A `break` statement must not be placed such that it would exit from a loop's [[#continuing-statement|continuing]] statement.
+A `break` statement [=shader-creation error|must not=] placed such that it would exit from a loop's [[#continuing-statement|continuing]] statement.
 Use a [[#break-if-statement|break-if]] statement instead.
 
 <div class='example wgsl function-scope' heading="WGSL Invalid loop break from a continuing clause">
@@ -6459,7 +6467,7 @@ A <dfn noexport dfn-for="statement">break-if</dfn> statement evaluates a boolean
 If the condition is true, control is transferred to immediately after the body of the nearest-enclosing [=statement/loop=]
 statement, ending execution of that loop.
 
-[=Type rule precondition=]: The condition must be of [=bool=] type.
+[=Type rule precondition=]: The condition [=shader-creation error|must=] be of [=bool=] type.
 
 Note: A break-if statement may only appear as the last statement in the body of a [[#continuing-statement|continuing]]
 statement.
@@ -6496,12 +6504,12 @@ A <dfn noexport dfn-for="statement">continue</dfn> statement transfers control i
 *  forward to the [=statement/continuing=] statement at the end of the body of that loop, if it exists.
 *  otherwise backward to the first statement in the loop body, starting the next [=iteration=].
 
-A `continue` statement must only be used in a [=statement/loop=], [=statement/for=] or [=statement/while=] statement.
-A `continue` statement must not be placed such that it would transfer
+A `continue` statement [=shader-creation error|must=] only be used in a [=statement/loop=], [=statement/for=] or [=statement/while=] statement.
+A `continue` statement [=shader-creation error|must not=] be placed such that it would transfer
 control to an enclosing [=statement/continuing=] statement.
 (It is a *forward* branch when branching to a `continuing` statement.)
 
-A `continue` statement must not be placed such that it would transfer
+A `continue` statement [=shader-creation error|must not=] be placed such that it would transfer
 control past a declaration used in the targeted [=statement/continuing=] statement.
 
 Note: A `continue` can only be used in a `continuing` statement if it is used for transferring control
@@ -6542,9 +6550,9 @@ cannot be used to transfer control to the start of the currently executing `cont
 A <dfn dfn-for="statement">continuing</dfn> statement specifies a [=compound statement=] to be executed at the end of a loop [=iteration=].
 The construct is optional.
 
-The compound statement must not contain a [=statement/return=] at any compound statement nesting level.
+The compound statement [=shader-creation error|must not=] contain a [=statement/return=] at any compound statement nesting level.
 
-The compound statement must not contain a [=statement/discard=] at any compound statement nesting level nor through function calls.
+The compound statement [=shader-creation error|must not=] contain a [=statement/discard=] at any compound statement nesting level nor through function calls.
 See [[#behaviors]] for a more formal description of this rule.
 
 ### Return Statement ### {#return-statement}
@@ -6562,16 +6570,16 @@ Otherwise, evaluation continues with the next expression or statement after
 the evaluation of the [=call site=] of the current function invocation.
 
 If the function does not have a [=return type=], then the [=statement/return=] statement is
-optional. If the return statement is provided for such a function, it must not
+optional. If the return statement is provided for such a function, it [=shader-creation error|must not=]
 supply a value.
-Otherwise the expression must be present, and is called the <dfn>return value</dfn>.
+Otherwise the expression [=shader-creation error|must=] be present, and is called the <dfn>return value</dfn>.
 In this case the call site of this function invocation evaluates to the return value.
-The type of the return value must match the return type of the function.
+The type of the return value [=shader-creation error|must=] match the return type of the function.
 
 ### Discard Statement ### {#discard-statement}
 
 A <dfn dfn-for="statement">discard</dfn> statement immediately ends execution of a fragment shader invocation and throws away the fragment.
-The `discard` statement must only be used in a [=fragment=] shader stage.
+The `discard` statement [=shader-creation error|must=] only be used in a [=fragment=] shader stage.
 
 More precisely, executing a `discard` statement will:
 
@@ -6732,9 +6740,9 @@ Each of those correspond to a way to exit a compound statement: either through a
 We note "*s*: *B*" to say that *s* respects the rules regarding behaviors, and has [=behavior=] *B*.
 
 For each function:
-- Its body must be a valid statement by these rules.
-- If the function has a return type, the [=behavior=] of its body must be one of {Return} or {Return, Discard}.
-- Otherwise, the [=behavior=] of its body must be a subset of {Next, Return, Discard}.
+- Its body [=shader-creation error|must=] be a valid statement by these rules.
+- If the function has a return type, the [=behavior=] of its body [=shader-creation error|must=] be one of {Return} or {Return, Discard}.
+- Otherwise, the [=behavior=] of its body [=shader-creation error|must=] be a subset of {Next, Return, Discard}.
 
 We assign a [=behavior=] to each function: it is its body's [=behavior=] (treating the body as a regular statement), with any "Return" replaced by "Next".
 As a consequence of the rules above, a function behavior is always one of {}, {Next}, {Discard}, or {Next, Discard}.
@@ -6922,9 +6930,9 @@ Each [=built-in function=] has a [=behavior=] of {Next}.
 And each operator application not listed in the table above has the same [=behavior=] as if it were a function call with the same operands and with a function's [=behavior=] of {Next}.
 
 A [=shader-creation error=] results if behavior analysis fails:
-- Behavior analysis must be able to determine a non-empty [=behavior=] for each statement, expression, and function.
-- The function behaviors must satisfy the rules given above.
-- The behaviors of compute and vertex entry points must not contain Discard.
+- Behavior analysis [=shader-creation error|must=] be able to determine a non-empty [=behavior=] for each statement, expression, and function.
+- The function behaviors [=shader-creation error|must=] satisfy the rules given above.
+- The behaviors of compute and vertex entry points [=shader-creation error|must not=] contain Discard.
 
 ### Notes ### {#behaviors-notes}
 
@@ -7183,21 +7191,21 @@ A <dfn noexport>function declaration</dfn> creates a user-defined function, by s
 * The <dfn noexport>function body</dfn>.
     This is the set of statements to be executed when the function is [=function call|called=].
 
-A function declaration must only occur at [=module scope=].
+A function declaration [=shader-creation error|must=] only occur at [=module scope=].
 A function name is [=in scope=] for the entire program.
 
-A <dfn noexport>formal parameter</dfn> [=declaration=] specifies an [=identifier=] name and a type for a value that must be
+A <dfn noexport>formal parameter</dfn> [=declaration=] specifies an [=identifier=] name and a type for a value that [=shader-creation error|must=] be
 provided when invoking the function.
 A formal parameter may have attributes.
 See [[#function-calls]].
 The identifier is [=in scope=] until the end of the function.
-Two formal parameters for a given function must not have the same name.
+Two formal parameters for a given function [=shader-creation error|must not=] have the same name.
 
 Note: Some built-in functions may allow parameters to be [=abstract numeric types=];
 however, this functionality is not currently supported for user-declared
 functions.
 
-The [=return type=], if specified, must be [=constructible=].
+The [=return type=], if specified, [=shader-creation error|must=] be [=constructible=].
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>function_decl</dfn> :
@@ -7260,9 +7268,9 @@ The function call:
 * Names the [=called function=], and
 * Provides a parenthesized, comma-separated list of argument value expressions.
 
-The function call must supply the same number of argument values as there are
+The function call [=shader-creation error|must=] supply the same number of argument values as there are
 [=formal parameter|formal parameters=] in the [=called function=].
-Each argument value must evaluate to the same type as the corresponding formal
+Each argument value [=shader-creation error|must=] evaluate to the same type as the corresponding formal
 parameter, by position.
 
 In summary, when calling a function:
@@ -7339,31 +7347,31 @@ Note: The [=attribute/const=] attribute cannot be applied to user-declared funct
 
 ## Restrictions on Functions ## {#function-restriction}
 
-* A [=vertex=] shader must return the `position` [=built-in output value=].
+* A [=vertex=] shader [=shader-creation error|must=] return the `position` [=built-in output value=].
     See [[#builtin-values]].
-* An [=entry point=] must never be the target of a [=function call=].
-* If a function has a return type, it must be a [=constructible=] type.
-* A [=formal parameter|function parameter=] must one the following types:
-    * a [=constructible=] type
-    * a [=pointer type|pointer=] type
-    * a [=texture=] type
-    * a [=sampler=] type
-* Each function call argument must evaluate to the type of the corresponding
+* An entry point [=shader-creation error|must=] never be the target of a [=function call=].
+* If a function has a return type, it [=shader-creation error|must=] be a [=constructible=] type.
+* A [=formal parameter|function parameter=] [=shader-creation error|must=] one the following types:
+    * a constructible type
+    * a pointer type
+    * a texture type
+    * a sampler type
+* Each function call argument [=shader-creation error|must=] evaluate to the type of the corresponding
     function parameter.
-    * In particular, an argument that is a pointer must agree with the formal parameter
+    * In particular, an argument that is a pointer [=shader-creation error|must=] agree with the formal parameter
         on address space, pointee type, and access mode.
-* For [=user-defined functions=], a parameter of pointer type must be in one of
+* For [=user-defined functions=], a parameter of pointer type [=shader-creation error|must=] be in one of
     the following address spaces:
     * [=address spaces/function=]
     * [=address spaces/private=]
     * [=address spaces/workgroup=]
-* For [=built-in functions=], a parameter of pointer type must be in one of
+* For [=built-in functions=], a parameter of pointer type [=shader-creation error|must=] be in one of
     the following address spaces:
     * [=address spaces/function=]
     * [=address spaces/private=]
     * [=address spaces/workgroup=]
     * [=address spaces/storage=]
-* Each argument of pointer type to a [=user-defined function=] must be one of:
+* Each argument of pointer type to a [=user-defined function=] [=shader-creation error|must=] be one of:
     * An [[#address-of-expr|address-of expression]] of a
         [[#var-identifier-expr|variable identifier expression]]
     * A [=formal parameter|function parameter=]
@@ -7496,7 +7504,7 @@ the entry point's function name maps to the `entryPoint` attribute of the
 
 The entry point's [=formal parameters=] form the stage's [=pipeline inputs=].
 The entry point's [=return type=], if specified, forms the stage's [=pipeline output=].
-Each input and output must be an [=entry point IO type=].
+Each input and output [=shader-creation error|must=] be an [=entry point IO type=].
 
 Note: [=Compute=] entry points never have a return type.
 
@@ -7587,7 +7595,7 @@ The <dfn dfn>entry point IO type</dfn>s include the following:
   - Built-in values. See [[#builtin-inputs-outputs]].
   - User-defined IO. See [[#user-defined-inputs-outputs]]
   - Structures containing only built-in values and user-defined IO.
-    The structure must not contain a nested structure.
+    The structure [=shader-creation error|must not=] contain a nested structure.
 
 A <dfn noexport>pipeline input</dfn> is data provided to the shader stage from upstream in the pipeline.
 A pipeline input is denoted by the arguments of the entry point.
@@ -7612,7 +7620,7 @@ A built-in input for stage *S* with name *X* and type *T*<sub>*X*</sub> is acces
 2. The parameter has structure type, where one of the structure members has attribute `builtin(`*X*`)` and is of type *T*<sub>*X*</sub>.
 
 Conversely, when a parameter or member of a parameter for an entry point has a `builtin` attribute,
-the corresponding builtin must be an input for the entry point's shader stage.
+the corresponding builtin [=shader-creation error|must=] be an input for the entry point's shader stage.
 
 A <dfn noexport>built-in output value</dfn> is used by the shader to convey
 control information to later processing steps in the pipeline.
@@ -7625,7 +7633,7 @@ A built-in output for stage *S* with name *Y* and type *T*<sub>*Y*</sub> is set 
 2. The entry point [=return type=] has structure type, where one of the structure members has attribute `builtin(`*Y*`)` and is of type *T*<sub>*Y*</sub>.
 
 Conversely, when the return type or member of a return type for an entry point has a `builtin` attribute,
-the corresponding builtin must be an output for the entry point's shader stage.
+the corresponding builtin [=shader-creation error|must=] be an output for the entry point's shader stage.
 
 Note: The `position` built-in is both an output of a vertex shader, and an input to the fragement shader.
 
@@ -7633,9 +7641,9 @@ Note: The `position` built-in is both an output of a vertex shader, and an input
 
 User-defined data can be passed as input to the start of a pipeline, passed
 between stages of a pipeline or output from the end of a pipeline.
-User-defined IO must not be passed to [=compute=] shader entry points.
-User-defined IO must be of [=IO-shareable=] type.
-All user-defined IO must be assigned locations (See [[#input-output-locations]]).
+User-defined IO [=shader-creation error|must not=] be passed to [=compute=] shader entry points.
+User-defined IO [=shader-creation error|must=] be of [=IO-shareable=] type.
+All user-defined IO [=shader-creation error|must=] be assigned locations (See [[#input-output-locations]]).
 
 #### Interpolation #### {#interpolation}
 
@@ -7644,13 +7652,13 @@ the [=attribute/interpolate=] attribute.
 WGSL offers two aspects of interpolation to control: the type of
 interpolation, and the sampling of the interpolation.
 
-The <dfn noexport>interpolation type</dfn> must be one of:
+The <dfn noexport>interpolation type</dfn> [=shader-creation error|must=] be one of:
 * `perspective` - Values are interpolated in a perspective correct manner.
 * `linear` - Values are interpolated in a linear, non-perspective correct manner.
 * `flat` - Values are not interpolated.
     Interpolation sampling is not used with `flat` interpolation.
 
-The <dfn noexport>interpolation sampling</dfn> must be one of:
+The <dfn noexport>interpolation sampling</dfn> [=shader-creation error|must=] be one of:
 * `center` - Interpolation is performed at the center of the pixel.
 * `centroid` - Interpolation is performed at a point that lies within all the
     samples covered by the fragment within the current primitive.
@@ -7662,15 +7670,15 @@ The <dfn noexport>interpolation sampling</dfn> must be one of:
 For user-defined IO of scalar or vector floating-point type:
 * If the interpolation attribute is not specified, then `@interpolate(perspective, center)` is assumed.
 * If the interpolation attribute is specified with an interpolation type:
-    * If the interpolation type is `flat`, then interpolation sampling must not be specified.
+    * If the interpolation type is `flat`, then interpolation sampling [=shader-creation error|must not=] be specified.
     * If the interpolation type is `perspective` or `linear`, then:
          * Any interpolation sampling is valid.
          * If interpolation sampling is not specified, `center` is assumed.
 
-User-defined IO of scalar or vector integer type must always be specified as
+User-defined IO of scalar or vector integer type [=shader-creation error|must=] always be specified as
 `@interpolate(flat)`.
 
-Interpolation attributes must match between [=vertex=] outputs and [=fragment=]
+Interpolation attributes [=shader-creation error|must=] match between [=vertex=] outputs and [=fragment=]
 inputs with the same [=attribute/location=] assignment within the same [=pipeline=].
 
 #### Input-output Locations #### {#input-output-locations}
@@ -7681,12 +7689,12 @@ For example, a four-component vector of floating-point values occupies a single 
 
 Locations are specified via the [=attribute/location=] attribute.
 
-Every user-defined input and output must have a fully specified set of
+Every user-defined input and output [=shader-creation error|must=] have a fully specified set of
 locations.
-Each structure member in the entry point IO must be one of either a built-in value
+Each structure member in the entry point IO [=shader-creation error|must=] be one of either a built-in value
 (see [[#builtin-inputs-outputs]]), or assigned a location.
 
-Locations must not overlap within each of the following sets:
+Locations [=shader-creation error|must not=] overlap within each of the following sets:
 * Members within a structure type.
     This applies to any structure, not just those used in pipeline inputs or outputs.
 * An entry point's pipeline inputs,
@@ -7801,24 +7809,23 @@ The <dfn noexport>resource interface of a shader</dfn> is the set of module-scop
 resource variables [=statically accessed=] by
 [=functions in a shader stage|functions in the shader stage=].
 
-Each resource variable must be declared with both [=attribute/group=] and [=attribute/binding=]
+Each resource variable [=shader-creation error|must=] be declared with both [=attribute/group=] and [=attribute/binding=]
 attributes.
 Together with the shader's stage, these identify the binding address
 of the resource on the shader's pipeline.
 See [[WebGPU#pipeline-layout|WebGPU &sect; GPUPipelineLayout]].
 
-Bindings must not alias within a shader stage:
+Bindings [=shader-creation error|must not=] alias within a shader stage:
 two different variables in the resource interface of a given
-shader must not have the same group and binding values, when considered as a pair of values.
+shader [=shader-creation error|must not=] have the same group and binding values, when considered as a pair of values.
 
 ### Resource Layout Compatibility ### {#resource-layout-compatibility}
 
 WebGPU requires that a shader's resource interface match the [[WebGPU#pipeline-layout|layout of the pipeline]]
 using the shader.
 
-Each WGSL variable in a resource interface must be bound to a WebGPU resource with
-a compatible
-[[WebGPU#binding-resource-type|resource type]] and
+It is a [=pipeline-creation error=] if a WGSL variable in a resource interface is bound to an incompatible WebGPU 
+[[WebGPU#binding-resource-type|resource type]] or
 [[WebGPU#binding-type|binding type]],
 where compatibility is defined by the following table.
 <table class='data'>
@@ -7892,7 +7899,7 @@ Hypothetically, extensions could be used to:
 An <dfn noexport>enable directive</dfn> indicates that the functionality
 described by a particular named
 [=extension=] may be used.
-The grammar rules imply that all enable directives must appear before any [=declarations=].
+The grammar rules imply that all enable directives [=shader-creation error|must=] appear before any [=declarations=].
 
 The directive uses an [=identifier=], [=keyword=], or [=reserved word=] to name the extension. The valid extension name are listed in [[#extension-list]].
 
@@ -7980,7 +7987,7 @@ A WGSL program is a sequence of optional [=directives=] followed by [=module sco
 
 ## Limits ## {#limits}
 
-A program must satisfy the following limits:
+A program [=shader-creation error|must=] satisfy the following limits:
 
 <table class='data'>
   <caption>Quantifiable shader complexity limits</caption>
@@ -8070,19 +8077,19 @@ The first phase walks over the syntax of the function, building a directed graph
 The second phase explores that graph, resulting in either rejecting the program, or computing the constraints on calling this function.
 
 <div class="note">Note: apart from two special nodes RequiredToBeUniform and MayBeNonUniform, all nodes can be understood as having one of the following meanings:
-        - A specific point of the program must be executed in [=uniform control flow=]
-        - An expression must be a [=uniform value=]
-        - A variable must be a [=uniform variable=]
+        - A specific point of the program [=shader-creation error|must=] be executed in [=uniform control flow=]
+        - An expression [=shader-creation error|must=] be a [=uniform value=]
+        - A variable [=shader-creation error|must=] be a [=uniform variable=]
 
         An edge can be understood as an implication from the statement corresponding to its source node to the statement corresponding to its target node.
 
-        To express that something must always be uniform (e.g. the control flow at the call site of a derivative), we add an edge from RequiredToBeUniform to the corresponding node.
+        To express that uniformity requirement (e.g. the control flow at the call site of a derivative), we add an edge from RequiredToBeUniform to the corresponding node.
         One way to understand this, is that RequiredToBeUniform corresponds to the proposition True, so that RequiredToBeUniform -> X is the same as saying that X is true.
 
         Reciprocally, to express that we cannot ensure the uniformity of something (e.g. a variable which holds the thread id), we add an edge from the corresponding node to MayBeNonUniform.
         One way to understand this, is that MayBeNonUniform corresponds to the proposition False, so that X -> MayBeNonUniform is the same as saying that X is false.
 
-        A consequence of this interpretation is that every node reachable from RequiredToBeUniform corresponds to something which must be uniform for the program to be valid, and every node from which MayBeNonUniform is reachable corresponds to something whose uniformity we cannot guarantee. It follows that we have a uniformity violation (and thus reject the program) if there is any path from RequiredToBeUniform to MayBeNonUniform.
+        A consequence of this interpretation is that every node reachable from RequiredToBeUniform corresponds to something which is required to be uniform for the program to be valid, and every node from which MayBeNonUniform is reachable corresponds to something whose uniformity we cannot guarantee. It follows that we have a uniformity violation (and thus reject the program) if there is any path from RequiredToBeUniform to MayBeNonUniform.
 </div>
 
 For each function, two tags are computed:
@@ -8099,7 +8106,7 @@ requirement of the parameter value.
     <tr><th>Call Site Tag<th>Description
   </thead>
   <tr><td><dfn noexport>CallSiteRequiredToBeUniform</dfn>
-      <td>The function must only be called from [=uniform control flow=].
+      <td>The function [=shader-creation error|must=] only be called from [=uniform control flow=].
   <tr><td><dfn noexport>CallSiteNoRestriction</dfn>
       <td>The function may be called from [=uniform control flow|non-uniform control flow=].
 </table>
@@ -8123,11 +8130,11 @@ requirement of the parameter value.
     <tr><th>Parameter Tag<th>Description
   </thead>
   <tr><td><dfn noexport>ParameterRequiredToBeUniform</dfn>
-      <td>The parameter must be a [=uniform value=].
+      <td>The parameter [=shader-creation error|must=] be a [=uniform value=].
   <tr><td><dfn noexport>ParameterRequiredToBeUniformForSubsequentControlFlow</dfn>
-      <td>The parameter must be a [=uniform value=] for control flow after the function call to be [=uniform control flow|uniform=].
+      <td>The parameter [=shader-creation error|must=] be a [=uniform value=] for control flow after the function call to be [=uniform control flow|uniform=].
   <tr><td><dfn noexport>ParameterRequiredToBeUniformForReturnValue</dfn>
-      <td>The parameter must be a [=uniform value=] in order for the [=return value=] to be a uniform value.
+      <td>The parameter [=shader-creation error|must=] be a [=uniform value=] in order for the [=return value=] to be a uniform value.
   <tr><td><dfn noexport>ParameterNoRestriction</dfn>
       <td>The parameter value has no uniformity requirement.
 </table>
@@ -8528,7 +8535,7 @@ A barrier is a [[#sync-builtin-functions|synchronization built-in function]]
 that orders memory operations in a program.
 A <dfn noexport>control barrier</dfn> is executed by all invocations in the
 same [=compute shader stage/workgroup=] as if it were executed concurrently.
-As such, control barriers must only be executed in [=uniform control flow=] in a
+As such, control barriers [=shader-creation error|must=] only be executed in [=uniform control flow=] in a
 [=compute shader stage|compute=] shader.
 
 ### Derivatives ### {#derivatives}
@@ -8554,8 +8561,9 @@ built-in functions described in [[#derivative-builtin-functions]]:
 * `dpdy`, `dpdyCoarse`, and `dpdyFine` compute partial derivatives along the y axis.
 * `fwidth`, `fwidthCoarse`, and `fwidthFine` compute the Manhattan metric over the associated x and y partial derivatives.
 
-Because neighbouring invocations must collaborate to compute derivatives,
-these functions must only be invoked in [=uniform control flow=] in a fragment shader.
+Because neighbouring invocations collaborate to compute derivatives, these
+functions [=shader-creation error|must=] only be invoked in [=uniform control
+flow=] in a fragment shader.
 
 ## Floating Point Evaluation ## {#floating-point-evaluation}
 
@@ -9252,7 +9260,7 @@ Issue: https://github.com/gpuweb/gpuweb/issues/1621
 ## Reserved Words ## {#reserved-words}
 
 A <dfn>reserved word</dfn> is a [=token=] which is reserved for future use.
-A WGSL program must not contain a reserved word.
+A WGSL program [=shader-creation error|must not=] contain a reserved word.
 
 The following are reserved words:
 
@@ -11092,8 +11100,8 @@ struct __modf_result_vecN_f16 {
 See [[#derivatives]].
 
 These functions:
-* Must only be used in a [=fragment=] shader stage.
-* Must only be invoked in [=uniform control flow=].
+* [=shader-creation error|Must=] only be used in a [=fragment=] shader stage.
+* [=shader-creation error|Must=] only be invoked in [=uniform control flow=].
 
 <table class='data'>
   <thead>
@@ -11140,7 +11148,7 @@ In this section, texture types are shown with the following parameters:
 * <var ignore>F</var>, a [=texel format=].
 * <var ignore>A</var>, an [=access mode=].
 
-Parameter values must be valid for the respective texture types.
+Parameter values [=shader-creation error|must=] be valid for the respective texture types.
 
 ### `textureDimensions` ### {#texturedimensions}
 
@@ -11259,7 +11267,7 @@ fn textureGather(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, arr
   <tr><td>`component`<td>
   Only applies to non-depth textures.
   <br>The index of the channel to read from the selected texels.
-  <br>When provided, the `component` expression must a [=creation-time expression=] (e.g. `1`).<br>
+  <br>When provided, the `component` expression [=shader-creation error|must=] be a [=creation-time expression=] (e.g. `1`).<br>
   Its value must be at least 0 and at most 3.
   Values outside of this range will result in a [=shader-creation error=].
   <tr><td>`t`<td>
@@ -11274,8 +11282,8 @@ fn textureGather(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, arr
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  The `offset` expression must be a [=creation-time expression=] (e.g. `vec2<i32>(1, 2)`).<br>
-  Each `offset` component must be at least `-8` and at most `7`. Values outside
+  The `offset` expression [=shader-creation error|must=] be a [=creation-time expression=] (e.g. `vec2<i32>(1, 2)`).<br>
+  Each `offset` component [=shader-creation error|must=] be at least `-8` and at most `7`. Values outside
   of this range will result in a [=shader-creation error=].
 </table>
 
@@ -11355,8 +11363,8 @@ fn textureGatherCompare(t: texture_depth_cube_array, s: sampler_comparison, coor
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  The `offset` expression must be a [=creation-time expression=] (e.g. `vec2<i32>(1, 2)`).<br>
-  Each `offset` component must be at least `-8` and at most `7`. Values outside
+  The `offset` expression [=shader-creation error|must=] be a [=creation-time expression=] (e.g. `vec2<i32>(1, 2)`).<br>
+  Each `offset` component [=shader-creation error|must=] be at least `-8` and at most `7`. Values outside
   of this range will result in a [=shader-creation error=].
 </table>
 
@@ -11512,8 +11520,8 @@ The number of samples per texel in the multisampled texture.
 
 Samples a texture.
 
-Must only be used in a [=fragment=] shader stage.
-Must only be invoked in [=uniform control flow=].
+[=shader-creation error|Must=] only be used in a [=fragment=] shader stage.
+[=shader-creation error|Must=] only be invoked in [=uniform control flow=].
 
 ```rust
 fn textureSample(t: texture_1d<f32>, s: sampler, coords: f32) -> vec4<f32>
@@ -11556,8 +11564,8 @@ fn textureSample(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, arr
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  The `offset` expression must be a [=creation-time expression=] (e.g. `vec2<i32>(1, 2)`).<br>
-  Each `offset` component must be at least `-8` and at most `7`. Values outside
+  The `offset` expression [=shader-creation error|must=] be a [=creation-time expression=] (e.g. `vec2<i32>(1, 2)`).<br>
+  Each `offset` component [=shader-creation error|must=] be at least `-8` and at most `7`. Values outside
   of this range will result in a [=shader-creation error=].
 </table>
 
@@ -11569,8 +11577,8 @@ The sampled value.
 
 Samples a texture with a bias to the mip level.
 
-Must only be used in a [=fragment=] shader stage.
-Must only be invoked in [=uniform control flow=].
+[=shader-creation error|Must=] only be used in a [=fragment=] shader stage.
+[=shader-creation error|Must=] only be invoked in [=uniform control flow=].
 
 ```rust
 fn textureSampleBias(t: texture_2d<f32>, s: sampler, coords: vec2<f32>, bias: f32) -> vec4<f32>
@@ -11599,13 +11607,13 @@ fn textureSampleBias(t: texture_cube_array<f32>, s: sampler, coords: vec3<f32>, 
   The 0-based texture array index to sample.
   <tr><td>`bias`<td>
   The bias to apply to the mip level before sampling.
-  `bias` must be between `-16.0` and `15.99`.
+  `bias` [=shader-creation error|must=] be between `-16.0` and `15.99`.
   <tr><td>`offset`<td>
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  The `offset` expression must be a [=creation-time expression=] (e.g. `vec2<i32>(1, 2)`).<br>
-  Each `offset` component must be at least `-8` and at most `7`. Values outside
+  The `offset` expression [=shader-creation error|must=] be a [=creation-time expression=] (e.g. `vec2<i32>(1, 2)`).<br>
+  Each `offset` component [=shader-creation error|must=] be at least `-8` and at most `7`. Values outside
   of this range will result in a [=shader-creation error=].
 </table>
 
@@ -11618,8 +11626,8 @@ The sampled value.
 
 Samples a depth texture and compares the sampled depth values against a reference value.
 
-Must only be used in a [=fragment=] shader stage.
-Must only be invoked in [=uniform control flow=].
+[=shader-creation error|Must=] only be used in a [=fragment=] shader stage.
+[=shader-creation error|Must=] only be invoked in [=uniform control flow=].
 
 ```rust
 fn textureSampleCompare(t: texture_depth_2d, s: sampler_comparison, coords: vec2<f32>, depth_ref: f32) -> f32
@@ -11650,8 +11658,8 @@ fn textureSampleCompare(t: texture_depth_cube_array, s: sampler_comparison, coor
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  The `offset` expression must be a [=creation-time expression=] (e.g. `vec2<i32>(1, 2)`).<br>
-  Each `offset` component must be at least `-8` and at most `7`. Values outside
+  The `offset` expression [=shader-creation error|must=] be a [=creation-time expression=] (e.g. `vec2<i32>(1, 2)`).<br>
+  Each `offset` component [=shader-creation error|must=] be at least `-8` and at most `7`. Values outside
   of this range will result in a [=shader-creation error=].
 </table>
 
@@ -11728,8 +11736,8 @@ fn textureSampleGrad(t: texture_cube_array<f32>, s: sampler, coords: vec3<f32>, 
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  The `offset` expression must be a [=creation-time expression=] (e.g. `vec2<i32>(1, 2)`).<br>
-  Each `offset` component must be at least `-8` and at most `7`. Values outside
+  The `offset` expression [=shader-creation error|must=] be a [=creation-time expression=] (e.g. `vec2<i32>(1, 2)`).<br>
+  Each `offset` component [=shader-creation error|must=] be at least `-8` and at most `7`. Values outside
   of this range will result in a [=shader-creation error=].
 </table>
 
@@ -11791,8 +11799,8 @@ fn textureSampleLevel(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  The `offset` expression must be a [=creation-time expression=] (e.g. `vec2<i32>(1, 2)`).<br>
-  Each `offset` component must be at least `-8` and at most `7`. Values outside
+  The `offset` expression [=shader-creation error|must=] be a [=creation-time expression=] (e.g. `vec2<i32>(1, 2)`).<br>
+  Each `offset` component [=shader-creation error|must=] be at least `-8` and at most `7`. Values outside
   of this range will result in a [=shader-creation error=].
 </table>
 
@@ -11855,12 +11863,12 @@ atomic operations acting on the same [=memory locations=].  No synchronization
 or ordering guarantees apply between atomic and non-atomic memory accesses, or
 between atomic accesses acting on different memory locations.
 
-Atomic built-in functions `must` not be used in a [=vertex=] shader stage.
+Atomic built-in functions `[=shader-creation error=]` not be used in a [=vertex=] shader stage.
 
 The address space `SC` of the `atomic_ptr` parameter in all atomic built-in
-functions `must` be either [=address spaces/storage=] or [=address spaces/workgroup=].
+functions [=shader-creation error=] be either [=address spaces/storage=] or [=address spaces/workgroup=].
 
-The access mode `A` in all atomic built-in functions must be [=access/read_write=].
+The access mode `A` in all atomic built-in functions [=shader-creation error|must=] be [=access/read_write=].
 
 ### Atomic Load ### {#atomic-load}
 
@@ -12059,7 +12067,7 @@ workgroup before any affected memory or atomic operation program-ordered after
 the synchronization function is executed by a member of the workgroup.
 All synchronization functions use the `Workgroup` [=memory scope=].
 All synchronization functions have a `Workgroup` [=execution scope=].
-All synchronization functions must only be used in the [=compute=] shader
+All synchronization functions [=shader-creation error|must=] only be used in the [=compute=] shader
 stage.
 
 `storageBarrier` affects memory and atomic operations in the [=address spaces/storage=] address space.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -895,7 +895,8 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     The first parameter specifies the x dimension.
     The second parameter, if provided, specifies the y dimension, otherwise is assumed to be 1.
     The third parameter, if provided, specifies the z dimension, otherwise is assumed to be 1.
-    Each dimension [=shader-creati be at least 1 and at most an upper bound specified by the WebGPU API.
+    Each dimension [=shader-creation error|must=] be at least 1 and at most an
+    upper bound specified by the WebGPU API.
 
 </table>
 
@@ -989,7 +990,7 @@ That is, a declaration at module scope may be referenced by source text
 that follows *or precedes* that declaration.
 
 It is a [=shader-creation error=] if any module scope declaration is recursive.
-That is, there can be no cycles among the declarations:
+That is, no cycles can exist among the declarations:
 
 > Consider the directed graph where:
 > * Each node corresponds to a declaration |D|.
@@ -2773,7 +2774,7 @@ memory reference</dfn> is produced.
     * store the value to any [=memory locations|memory location(s)=] of the
         [[WebGPU#buffers|WebGPU buffer]] bound to the [=originating variable=]
     * not be executed
-It is a [=dynamic error=] if [[#atomic-rmw|Read-modify-write atomics]] that
+It is a [=dynamic error=] if [[#atomic-rmw|read-modify-write atomics]] that
 operate on an invalid memory reference load and store from different [=memory
 locations|memory locations=] if they access memory.
 
@@ -6433,7 +6434,7 @@ or [=statement/switch=] statement, thus ending execution of the loop or switch s
 
 A `break` statement [=shader-creation error|must=] only be used within [=statement/loop=], [=statement/for=], [=statement/while=], and [=statement/switch=] statements.
 
-A `break` statement [=shader-creation error|must not=] placed such that it would exit from a loop's [[#continuing-statement|continuing]] statement.
+A `break` statement [=shader-creation error|must not=] be placed such that it would exit from a loop's [[#continuing-statement|continuing]] statement.
 Use a [[#break-if-statement|break-if]] statement instead.
 
 <div class='example wgsl function-scope' heading="WGSL Invalid loop break from a continuing clause">
@@ -11863,10 +11864,10 @@ atomic operations acting on the same [=memory locations=].  No synchronization
 or ordering guarantees apply between atomic and non-atomic memory accesses, or
 between atomic accesses acting on different memory locations.
 
-Atomic built-in functions `[=shader-creation error=]` not be used in a [=vertex=] shader stage.
+Atomic built-in functions [=shader-creation error|must not=] be used in a [=vertex=] shader stage.
 
 The address space `SC` of the `atomic_ptr` parameter in all atomic built-in
-functions [=shader-creation error=] be either [=address spaces/storage=] or [=address spaces/workgroup=].
+functions [=shader-creation error|must=] be either [=address spaces/storage=] or [=address spaces/workgroup=].
 
 The access mode `A` in all atomic built-in functions [=shader-creation error|must=] be [=access/read_write=].
 


### PR DESCRIPTION
* Clarify must language that would produce a pipeline-creation or
  dyanmic error
* Only a few bare instances of must remain that describe incorrect
  implementations
* Side-effect is that every shader-creation error is now directly linked
  from the shader-creation error definition
* left all must language in notes and examples alone