### PR TITLE
Expose different error types directly instead of via polymorphism

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9876,6 +9876,19 @@ interface GPUError {
 };
 </script>
 
+<dl dfn-type=attribute dfn-for=GPUError>
+    : <dfn>message</dfn>
+    ::
+        A human-readable message providing information about the error that occurred.
+
+        Note: This message is generally intended for application developers to debug their
+        applications and capture information for debug reports, not to be surfaced to end-users.
+
+        Note: User agents should not include potentially machine-parsable details in this message,
+        such as free system memory on {{GPUErrorType/"out-of-memory"}} errors, or other details
+        about the conditions under which memory was exhausted.
+</dl>
+
 <script type=idl>
 partial interface GPUDevice {
     undefined pushErrorScope(GPUErrorType filter);

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1059,7 +1059,7 @@ For each [=usage scope=], the implementation performs
 [=internal usage=] flags of each [=subresource=] used in the [=usage scope=].
 If any of those lists is not a [=compatible usage list=],
 {{GPUCommandEncoder/finish()|GPUCommandEncoder.finish()}}
-generates a {{GPUValidationError}} in the current error scope.
+[$generates a validation error$].
 
 
 ## Core Internal Objects ## {#core-internal-objects}
@@ -6262,7 +6262,7 @@ The <dfn dfn>encoder state</dfn> may be one of the following:
     ::
         The encoder has been ended and new commands can no longer be encoded.
 
-        Any command issued in this state generates a {{GPUValidationError}}.
+        Any command issued in this state [$generates a validation error$].
 </dl>
 
 <div algorithm>
@@ -9856,36 +9856,29 @@ of WebGPU calls, typically for debugging purposes or to make an operation more f
     ::
         The first {{GPUError}}, if any, observed while the [=GPU error scope=] was current.
 
-    : <dfn>\[[filter]]</dfn> of type {{GPUErrorFilter}}.
+    : <dfn>\[[filter]]</dfn> of type {{GPUErrorType}}.
     ::
         Determines what type of {{GPUError}} this [=GPU error scope=] observes.
 </dl>
 
 <script type=idl>
-enum GPUErrorFilter {
+enum GPUErrorType {
     "out-of-memory",
     "validation",
 };
-</script>
-
-<script type=idl>
-[Exposed=(Window, DedicatedWorker), SecureContext]
-interface GPUOutOfMemoryError {
-    constructor();
-};
 
 [Exposed=(Window, DedicatedWorker), SecureContext]
-interface GPUValidationError {
-    constructor(DOMString message);
+interface GPUError {
+    constructor(GPUErrorType type, DOMString message);
+
+    readonly attribute GPUErrorType type;
     readonly attribute DOMString message;
 };
-
-typedef (GPUOutOfMemoryError or GPUValidationError) GPUError;
 </script>
 
 <script type=idl>
 partial interface GPUDevice {
-    undefined pushErrorScope(GPUErrorFilter filter);
+    undefined pushErrorScope(GPUErrorType filter);
     Promise<GPUError?> popErrorScope();
 };
 </script>
@@ -9903,16 +9896,9 @@ partial interface GPUDevice {
     |device| is determined by issuing the following steps to the [=Device timeline=]:
 
     <div class=device-timeline>
-        1. If |error| is an instance of:
-            <dl class="switch">
-                : {{GPUValidationError}}
-                :: Let |type| be "validation".
-                : {{GPUOutOfMemoryError}}
-                :: Let |type| be "out-of-memory".
-            </dl>
         1. Let |scope| be the last [=list/item=] of |device|.{{GPUDevice/[[errorScopeStack]]}}.
         1. While |scope| is not `undefined`:
-            1. If |scope|.{{GPU error scope/[[filter]]}} is |type|, return |scope|.
+            1. If |scope|.{{GPU error scope/[[filter]]}} is |error|.{{GPUError/type}}, return |scope|.
             1. Set |scope| to the previous [=list/item=] of
                 |device|.{{GPUDevice/[[errorScopeStack]]}}.
         1. Return `undefined`.
@@ -9920,10 +9906,11 @@ partial interface GPUDevice {
 </div>
 
 <div algorithm>
-    To <dfn abstract-op lt="Generate a validation error|generate a validation error">generate a
-    validation error</dfn> for {{GPUDevice}} |device|, run the following steps:
+    To <dfn abstract-op lt="Generate a validation error|generate a validation error|generates a validation error">
+    generate a validation error</dfn> for {{GPUDevice}} |device|, run the following steps:
 
-    1. Let |error| be a new {{GPUValidationError}} with an appropriate error message.
+    1. Let |error| be a new {{GPUError}} with {{GPUError/type}} {{GPUErrorType/"validation"}} and
+        an appropriate {{GPUError/message}}.
     1. Issue the following steps to the [=Device timeline=]:
         <div class=device-timeline>
             1. Let |scope| be the [$current error scope$] for |error| and |device|.
@@ -10074,7 +10061,7 @@ partial interface GPUDevice {
     Listening for uncaptured errors from a {{GPUDevice}}:
     <pre highlight="js">
         gpuDevice.addEventListener('uncapturederror', (event) => {
-            if (event.error instanceof GPUValidationError) {
+            if (event.error.type === 'validation') {
                 console.error(\`An uncaught WebGPU validation error was raised: ${event.error.message}\`);
             }
         });

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9856,27 +9856,34 @@ of WebGPU calls, typically for debugging purposes or to make an operation more f
     ::
         The first {{GPUError}}, if any, observed while the [=GPU error scope=] was current.
 
-    : <dfn>\[[filter]]</dfn> of type {{GPUErrorType}}.
+    : <dfn>\[[filter]]</dfn> of type {{GPUErrorFilter}}.
     ::
         Determines what type of {{GPUError}} this [=GPU error scope=] observes.
 </dl>
 
 <script type=idl>
-enum GPUErrorType {
+enum GPUErrorFilter {
     "out-of-memory",
     "validation",
 };
 
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUError {
-    constructor(GPUErrorType type, DOMString message);
+    constructor(DOMString type, DOMString message);
 
-    readonly attribute GPUErrorType type;
+    readonly attribute DOMString type;
     readonly attribute DOMString message;
 };
 </script>
 
 <dl dfn-type=attribute dfn-for=GPUError>
+    : <dfn>type</dfn>
+    ::
+        The type of the error, currently either `"out-of-memory"` or `"validation"`.
+
+        New values may be returned here in the future.
+        Applications **must not** assume a fixed set of possible `type` values.
+
     : <dfn>message</dfn>
     ::
         A human-readable message providing information about the error that occurred.
@@ -9885,13 +9892,13 @@ interface GPUError {
         applications and capture information for debug reports, not to be surfaced to end-users.
 
         Note: User agents should not include potentially machine-parsable details in this message,
-        such as free system memory on {{GPUErrorType/"out-of-memory"}} errors, or other details
+        such as free system memory on "out-of-memory" errors, or other details
         about the conditions under which memory was exhausted.
 </dl>
 
 <script type=idl>
 partial interface GPUDevice {
-    undefined pushErrorScope(GPUErrorType filter);
+    undefined pushErrorScope(GPUErrorFilter filter);
     Promise<GPUError?> popErrorScope();
 };
 </script>
@@ -9922,7 +9929,7 @@ partial interface GPUDevice {
     To <dfn abstract-op lt="Generate a validation error|generate a validation error|generates a validation error">
     generate a validation error</dfn> for {{GPUDevice}} |device|, run the following steps:
 
-    1. Let |error| be a new {{GPUError}} with {{GPUError/type}} {{GPUErrorType/"validation"}} and
+    1. Let |error| be a new {{GPUError}} with {{GPUError/type}} `"validation"` and
         an appropriate {{GPUError/message}}.
     1. Issue the following steps to the [=Device timeline=]:
         <div class=device-timeline>


### PR DESCRIPTION
This makes it easier to programmatically handle possible future error
types, especially for marshalling into other languages (like C).

Fixes #1884


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2750.html" title="Last updated on May 6, 2022, 9:49 PM UTC (3857a5f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2750/4238070...kainino0x:3857a5f.html" title="Last updated on May 6, 2022, 9:49 PM UTC (3857a5f)">Diff</a>