### PR TITLE
docs: add the WebGPU logo to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # W3C _GPU for the Web_ Community Group
 
+<img alt="WebGPU logo" src="logo/webgpu.png" width="400">
+
 This is the repository for the W3C's [GPU for the Web](https://www.w3.org/community/gpu/)
 Community Group.
 


### PR DESCRIPTION
Hello, this PR just adds the WebGPU logo to the top of README.

Before reading this comment https://github.com/gpuweb/admin/issues/14#issuecomment-801444493 today, I had the same misunderstanding on the WebGPU logo. Adding the logo on the top of README would help improve the visibility of the nice logo.

**Screenshots:**

<img width="1275" alt="Screen Shot 2022-04-13 at 17 15 28" src="https://user-images.githubusercontent.com/1425259/163132670-505d2e04-96c8-4950-8495-6ce348440b17.png">
<img width="506" alt="Screen Shot 2022-04-13 at 17 15 44" src="https://user-images.githubusercontent.com/1425259/163132689-34e7a652-c7a5-4854-9402-045cdfb3fa06.png">

You can also see the live preview on this branch: https://github.com/shuuji3/gpuweb/tree/add-logo-to-readme.
