### PR TITLE
Update logic for default TextureView dimension

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2979,6 +2979,19 @@ enum GPUTextureAspect {
     ::
         Creates a {{GPUTextureView}}.
 
+        <div class="note">
+        By default {{GPUTexture/createView()}} will create a view with a dimension that can
+        represent the entire texture. For example, calling {{GPUTexture/createView()}} without
+        specifying a {{GPUTextureViewDescriptor/dimension}} on a {{GPUTextureDimension/"2d"}}
+        texture with more than one layer will create a {{GPUTextureViewDimension/"2d-array"}}
+        {{GPUTextureView}}, even if an {{GPUTextureViewDescriptor/arrayLayerCount}} of 1 is
+        specified.
+
+        For textures created from sources where the layer count is unknown at the
+        time of development it is recommended that calls to {{GPUTexture/createView()}} are provided
+        an explicit {{GPUTextureViewDescriptor/dimension}} to ensure shader compatibility.
+        </div>
+
         <div algorithm=GPUTexture.createView>
             **Called on:** {{GPUTexture}} |this|.
 
@@ -2989,7 +3002,7 @@ enum GPUTextureAspect {
 
             **Returns:** |view|, of type {{GPUTextureView}}.
 
-            1. Set |descriptor| to the result of [$resolving GPUTextureViewDescriptor defaults$] with |descriptor|.
+            1. Set |descriptor| to the result of [$resolving GPUTextureViewDescriptor defaults$] for |this| with |descriptor|.
             1. Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
                     1. If any of the following requirements are unmet:
@@ -3065,8 +3078,8 @@ enum GPUTextureAspect {
 </dl>
 
 <div algorithm>
-    When <dfn abstract-op>resolving GPUTextureViewDescriptor defaults</dfn> for {{GPUTextureViewDescriptor}}
-    |descriptor| run the following steps:
+    When <dfn abstract-op>resolving GPUTextureViewDescriptor defaults</dfn> for {{GPUTextureView}}
+    |texture| with a {{GPUTextureViewDescriptor}} |descriptor| run the following steps:
 
     1. Let |resolved| be a copy of |descriptor|.
     1. If |resolved|.{{GPUTextureViewDescriptor/format}} is `undefined`,
@@ -3089,7 +3102,10 @@ enum GPUTextureAspect {
             :: Set |resolved|.{{GPUTextureViewDescriptor/dimension}} to {{GPUTextureViewDimension/"1d"}}.
 
             : {{GPUTextureDimension/"2d"}}
-            :: Set |resolved|.{{GPUTextureViewDescriptor/dimension}} to {{GPUTextureViewDimension/"2d"}}.
+            :: If the [$array layer count$] of |texture| is 1:
+                    - Set |resolved|.{{GPUTextureViewDescriptor/dimension}} to {{GPUTextureViewDimension/"2d"}}.
+                Otherwise:
+                    - Set |resolved|.{{GPUTextureViewDescriptor/dimension}} to {{GPUTextureViewDimension/"2d-array"}}.
 
             : {{GPUTextureDimension/"3d"}}
             :: Set |resolved|.{{GPUTextureViewDescriptor/dimension}} to {{GPUTextureViewDimension/"3d"}}.
@@ -3105,9 +3121,8 @@ enum GPUTextureAspect {
             :: Set |resolved|.{{GPUTextureViewDescriptor/arrayLayerCount}} to `6`.
 
             : {{GPUTextureViewDimension/"2d-array"}} or {{GPUTextureViewDimension/"cube-array"}}
-            :: Set |resolved|.{{GPUTextureViewDescriptor/arrayLayerCount}} to
-                |texture|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] &minus;
-                |resolved|.{{GPUTextureViewDescriptor/baseArrayLayer}}.
+            :: Set |resolved|.{{GPUTextureViewDescriptor/arrayLayerCount}} to the [$array layer count$] of |texture|
+                &minus; |resolved|.{{GPUTextureViewDescriptor/baseArrayLayer}}.
         </dl>
 
     1. Return |resolved|.


### PR DESCRIPTION
Fixes #2684

Changed to consider the array layer count of the texture and
default to `2d-array` if the dimension is `2d` and the layer count
is greater than 1. Added a note to the `createView()` algorithm
pointing out that this may have unexpected results in data-driven
scenarios, so an specifying a dimension should be preferred.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/2755.html" title="Last updated on Apr 13, 2022, 10:52 PM UTC (8f3044b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2755/cbfa42b...8f3044b.html" title="Last updated on Apr 13, 2022, 10:52 PM UTC (8f3044b)">Diff</a>