### PR TITLE
[wgsl] Convert literal regex to grammar.

### DIFF
--- a/wgsl/extract-grammar.py
+++ b/wgsl/extract-grammar.py
@@ -342,7 +342,7 @@ module.exports = grammar({
 grammar_source += "\n"
 
 
-def grammar_from_rule_item(rule_item):
+def grammar_from_rule_item(rule_item, prec=0):
     result = ""
     item_choice = False
     items = []
@@ -401,16 +401,20 @@ def grammar_from_rule_item(rule_item):
             result = items[0]
         else:
             result = f"seq({', '.join(items)})"
+
+    if prec > 0:
+        result = f"prec({prec}, {result})"
+
     return result
 
 
-def grammar_from_rule(key, value):
+def grammar_from_rule(key, value, prec=0):
     result = f"        {key}: $ =>"
     if len(value) == 1:
-        result += f" {grammar_from_rule_item(value[0])}"
+        result += f" {grammar_from_rule_item(value[0], prec)}"
     else:
         result += " choice(\n            {}\n        )".format(
-            ',\n            '.join([grammar_from_rule_item(i) for i in value]))
+            ',\n            '.join([grammar_from_rule_item(i, prec) for i in value]))
     return result
 
 
@@ -430,9 +434,11 @@ for rule in ["translation_unit", "global_directive", "global_decl"]:
 # Extract literals
 
 
+prec = 0
 for key, value in scanner_components[scanner_rule.name()].items():
     if key.endswith("_literal") and key not in rule_skip:
-        grammar_source += grammar_from_rule(key, value) + ",\n"
+        grammar_source += grammar_from_rule(key, value, prec) + ",\n"
+        prec += 1
         rule_skip.add(key)
 
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -494,7 +494,43 @@ An <dfn>integer literal</dfn> is:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>int_literal</dfn> :
 
-    | `/(0[xX][0-9a-fA-F]+|0|[1-9][0-9]*)[iu]?/`
+    | [=syntax/hex_int_segment=] [=syntax/int_suffix=] ?
+
+    | [=syntax/non_zero_decimal_digit=] [=syntax/decimal_digit=] * [=syntax/int_suffix=] ?
+
+    | `'0'` [=syntax/int_suffix=] ?
+</div>
+
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>hex_int_segment</dfn> :
+
+    | `'0'` `/[xX]/` [=syntax/hex_digit=] +
+</div>
+
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>non_zero_decimal_digit</dfn> :
+
+    | `/[1-9]/`
+</div>
+
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>decimal_digit</dfn> :
+
+    | `/[0-9]/`
+</div>
+
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>hex_digit</dfn> :
+
+    | `/[0-9a-fA-F]/`
+</div>
+
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>int_suffix</dfn> :
+
+    | `'i'`
+
+    | `'u'`
 </div>
 
 A <dfn>floating point literal</dfn> is either a [=decimal floating point literal=]
@@ -533,7 +569,29 @@ or a [=hexadecimal floating point literal=].
 <div class='syntax' noexport='true'>
   <dfn for=syntax>decimal_float_literal</dfn> :
 
-    | `/((([0-9]*\.[0-9]+|[0-9]+\.[0-9]*)([eE](\+|-)?[0-9]+)?)|([0-9]+[eE](\+|-)?[0-9]+))[fh]?|0[fh]|[1-9][0-9]*[fh]/`
+    | [=syntax/decimal_digit=] * `'.'` [=syntax/decimal_digit=] + [=syntax/float_exponent=] ? [=syntax/float_suffix=] ?
+
+    | [=syntax/decimal_digit=] + `'.'` [=syntax/decimal_digit=] * [=syntax/float_exponent=] ? [=syntax/float_suffix=] ?
+
+    | [=syntax/decimal_digit=] + [=syntax/float_exponent=] [=syntax/float_suffix=] ?
+
+    | [=syntax/non_zero_decimal_digit=] [=syntax/decimal_digit=] * [=syntax/float_suffix=]
+
+    | `'0'` [=syntax/float_suffix=]
+</div>
+
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>float_exponent</dfn> :
+
+    | `/[eE]/` [=syntax/float_exp_sign=] ? [=syntax/decimal_digit=] +
+</div>
+
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>float_exp_sign</dfn> :
+
+    | `'+'`
+
+    | `'-'`
 </div>
 
 <div class='syntax' noexport='true'>
@@ -542,12 +600,21 @@ or a [=hexadecimal floating point literal=].
     | `/0[xX]((([0-9a-fA-F]*\.[0-9a-fA-F]+|[0-9a-fA-F]+\.[0-9a-fA-F]*)([pP](\+|-)?[0-9]+f?)?)|([0-9a-fA-F]+[pP](\+|-)?[0-9]+f?))/`
 </div>
 
+
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>float_suffix</dfn> :
+
+    | `'f'`
+
+    | `'h'`
+</div>
+
 <div class='syntax' noexport='true'>
   <dfn for=syntax>const_literal</dfn> :
 
-    | [=syntax/int_literal=]
-
     | [=syntax/float_literal=]
+
+    | [=syntax/int_literal=]
 
     | [=syntax/bool_literal=]
 </div>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -158,7 +158,7 @@ that run on the GPU.
   <xmp highlight='rust'>
     @fragment
     fn main() -> @location(0) vec4<f32> {
-        return vec4<f32>(0.4, 0.4, 0.8, 1.0);
+        return vec4<f32>(0.4f, 0.4, 0.8, 1.0);
     }
   </xmp>
 </div>
@@ -474,6 +474,13 @@ A <dfn>literal</dfn> is one of:
 * A <dfn>numeric literal</dfn>: either an [=integer literal=] or a [=floating point literal=],
     and is used to represent a number.
 
+<div class='example wgsl bool-literals'>
+  <xmp highlight='rust'>
+    const a = true;
+    const b = false;
+  </xmp>
+</div>
+
 <div class='syntax' noexport='true'>
   <dfn for=syntax>bool_literal</dfn> :
 
@@ -491,38 +498,31 @@ An <dfn>integer literal</dfn> is:
     * `0x` or `0X` followed by a sequence of hexadecimal digits.
 * Then an optional `i` or `u` suffix.
 
+<div class='example wgsl int-literals'>
+  <xmp highlight='rust'>
+    const a = 0x123;
+    const b = 0X123u;
+    const c = 1u;
+    const d = 123;
+    const f = 0;
+    const f = 0i;
+  </xmp>
+</div>
+
 <div class='syntax' noexport='true'>
   <dfn for=syntax>int_literal</dfn> :
 
-    | [=syntax/hex_int_segment=] [=syntax/int_suffix=] ?
+    | `/0[xX]/` [=syntax/hex_digit=] + [=syntax/int_suffix=] ?
 
-    | [=syntax/non_zero_decimal_digit=] [=syntax/decimal_digit=] * [=syntax/int_suffix=] ?
+    | [=syntax/non_zero_int_literal=] [=syntax/int_suffix=] ?
 
     | `'0'` [=syntax/int_suffix=] ?
 </div>
 
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>hex_int_segment</dfn> :
+  <dfn for=syntax>non_zero_int_literal</dfn> :
 
-    | `'0'` `/[xX]/` [=syntax/hex_digit=] +
-</div>
-
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>non_zero_decimal_digit</dfn> :
-
-    | `/[1-9]/`
-</div>
-
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>decimal_digit</dfn> :
-
-    | `/[0-9]/`
-</div>
-
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>hex_digit</dfn> :
-
-    | `/[0-9a-fA-F]/`
+    | [=syntax/non_zero_digit=] [=syntax/digit=] *
 </div>
 
 <div class='syntax' noexport='true'>
@@ -558,6 +558,23 @@ or a [=hexadecimal floating point literal=].
     * The value of the literal is the value of the mantissa multiplied by 2 to the power of the exponent.
          When no exponent is specified, an exponent of 0 is assumed.
 
+<div class='example wgsl float-literals'>
+  <xmp highlight='rust'>
+    const a = 0.e+4f;
+    const b = 01.;
+    const c = .01;
+    const d = 12.34;
+    const f = .0f;
+    const g = 0h;
+    const h = 1e-3;
+    const i = 0xa.fp+2;
+    const j = 0x1P+4f;
+    const k = 0X.3;
+    const l = 0x3f;
+    const m = 0X1.fp-4;
+  </xmp>
+</div>
+
 <div class='syntax' noexport='true'>
   <dfn for=syntax>float_literal</dfn> :
 
@@ -569,21 +586,53 @@ or a [=hexadecimal floating point literal=].
 <div class='syntax' noexport='true'>
   <dfn for=syntax>decimal_float_literal</dfn> :
 
-    | [=syntax/decimal_digit=] * `'.'` [=syntax/decimal_digit=] + [=syntax/float_exponent=] ? [=syntax/float_suffix=] ?
+    | [=syntax/float_fractional=] [=syntax/float_exponent=] ? [=syntax/float_suffix=] ?
 
-    | [=syntax/decimal_digit=] + `'.'` [=syntax/decimal_digit=] * [=syntax/float_exponent=] ? [=syntax/float_suffix=] ?
+    | [=syntax/digit=] + [=syntax/float_exponent=] [=syntax/float_suffix=] ?
 
-    | [=syntax/decimal_digit=] + [=syntax/float_exponent=] [=syntax/float_suffix=] ?
-
-    | [=syntax/non_zero_decimal_digit=] [=syntax/decimal_digit=] * [=syntax/float_suffix=]
+    | [=syntax/non_zero_digit=] [=syntax/digit=] * [=syntax/float_suffix=]
 
     | `'0'` [=syntax/float_suffix=]
 </div>
 
 <div class='syntax' noexport='true'>
+  <dfn for=syntax>float_fractional</dfn> :
+
+    | [=syntax/digit=] + [=syntax/period=] [=syntax/digit=] *
+
+    | [=syntax/non_zero_int_literal=] [=syntax/period=] [=syntax/digit=] *
+
+    | [=syntax/period=] [=syntax/digit=] +
+</div>
+
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>hex_float_literal</dfn> :
+
+    | `/0[xX]/` [=syntax/hex_digit=] + [=syntax/period=] [=syntax/hex_digit=] * [=syntax/hex_float_exponent=] ?
+
+    | `/0[xX]/` [=syntax/hex_digit=] * [=syntax/period=] [=syntax/hex_digit=] + [=syntax/hex_float_exponent=] ?
+
+    | `/0[xX]/` [=syntax/hex_digit=] + [=syntax/hex_float_exponent=]
+</div>
+
+<div class='syntax' noexport='true'>
   <dfn for=syntax>float_exponent</dfn> :
 
-    | `/[eE]/` [=syntax/float_exp_sign=] ? [=syntax/decimal_digit=] +
+    | `/[eE]/` [=syntax/float_exp_sign=] ? [=syntax/digit=] +
+</div>
+
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>hex_float_exponent</dfn> :
+
+    | `/[pP]/` [=syntax/float_exp_sign=] ? [=syntax/digit=] + `'f'` ?
+</div>
+
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>float_suffix</dfn> :
+
+    | `'f'`
+
+    | `'h'`
 </div>
 
 <div class='syntax' noexport='true'>
@@ -595,18 +644,39 @@ or a [=hexadecimal floating point literal=].
 </div>
 
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>hex_float_literal</dfn> :
+  <dfn for=syntax>hex_digit</dfn> :
 
-    | `/0[xX]((([0-9a-fA-F]*\.[0-9a-fA-F]+|[0-9a-fA-F]+\.[0-9a-fA-F]*)([pP](\+|-)?[0-9]+f?)?)|([0-9a-fA-F]+[pP](\+|-)?[0-9]+f?))/`
+    | `/[0-9a-fA-F]/`
 </div>
 
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>digit</dfn> :
+
+    | `'0'`
+
+    | [=syntax/non_zero_digit=]
+</div>
 
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>float_suffix</dfn> :
+  <dfn for=syntax>non_zero_digit</dfn> :
 
-    | `'f'`
+    | `'1'`
 
-    | `'h'`
+    | `'2'`
+
+    | `'3'`
+
+    | `'4'`
+
+    | `'5'`
+
+    | `'6'`
+
+    | `'7'`
+
+    | `'8'`
+
+    | `'9'`
 </div>
 
 <div class='syntax' noexport='true'>
@@ -5551,8 +5621,6 @@ When an identifier is used as a [=syntax/callable=] item, it is one of:
 
     | [=syntax/callable=] [=syntax/argument_expression_list=]
 
-    | [=syntax/const_literal=]
-
     | [=syntax/paren_expression=]
 
     | [=syntax/bitcast=] [=syntax/less_than=] [=syntax/type_decl=] [=syntax/greater_than=] [=syntax/paren_expression=]
@@ -5604,6 +5672,8 @@ When an identifier is used as a [=syntax/callable=] item, it is one of:
   <dfn for=syntax>singular_expression</dfn> :
 
     | [=syntax/primary_expression=] [=syntax/postfix_expression=] ?
+
+    | [=syntax/const_literal=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>lhs_expression</dfn> :

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -571,7 +571,8 @@ or a [=hexadecimal floating point literal=].
     const j = 0x1P+4f;
     const k = 0X.3;
     const l = 0x3f;
-    const m = 0X1.fp-4;
+    const m = 0x3p+2h;
+    const n = 0X1.fp-4;
   </xmp>
 </div>
 
@@ -590,7 +591,7 @@ or a [=hexadecimal floating point literal=].
 
     | [=syntax/digit=] + [=syntax/float_exponent=] [=syntax/float_suffix=] ?
 
-    | [=syntax/non_zero_digit=] [=syntax/digit=] * [=syntax/float_suffix=]
+    | [=syntax/non_zero_int_literal=] [=syntax/float_suffix=]
 
     | `'0'` [=syntax/float_suffix=]
 </div>
@@ -624,7 +625,7 @@ or a [=hexadecimal floating point literal=].
 <div class='syntax' noexport='true'>
   <dfn for=syntax>hex_float_exponent</dfn> :
 
-    | `/[pP]/` [=syntax/float_exp_sign=] ? [=syntax/digit=] + `'f'` ?
+    | `/[pP]/` [=syntax/float_exp_sign=] ? [=syntax/digit=] + [=syntax/float_suffix=] ?
 </div>
 
 <div class='syntax' noexport='true'>


### PR DESCRIPTION
This PR re-writes the literal regexes as grammar rules in order to make them easier to understand.

In order to fixup a precedence issue between integers and floats, the `extract_grammar.py` will inject precedence values for the `_literals`. Essentially, the later a literal appears in the spec, the higher the precedence. This means `float` will take precedence over `int` for tree-sitter. Without this change to extract grammar tree-sitter has a conflict between `non_zero_int_literal` and `digit`.