### PR TITLE
[wgsl] Add literal examples; fixup f16 hex floats regex.

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -32,7 +32,6 @@ jobs:
           rm spec/index.bs wgsl/index.bs explainer/index.bs
           wget -O spec/index.bs https://raw.githubusercontent.com/${{ github.event.workflow_run.head_repository.full_name }}/${{ github.event.workflow_run.head_sha }}/spec/index.bs
           wget -O wgsl/index.bs https://raw.githubusercontent.com/${{ github.event.workflow_run.head_repository.full_name }}/${{ github.event.workflow_run.head_sha }}/wgsl/index.bs
-          wget -O wgsl/extract-grammar.py https://raw.githubusercontent.com/${{ github.event.workflow_run.head_repository.full_name }}/${{ github.event.workflow_run.head_sha }}/wgsl/extract-grammar.py
           wget -O explainer/index.bs https://raw.githubusercontent.com/${{ github.event.workflow_run.head_repository.full_name }}/${{ github.event.workflow_run.head_sha }}/explainer/index.bs
 
       # Adds Firebase config files to directory

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -32,6 +32,7 @@ jobs:
           rm spec/index.bs wgsl/index.bs explainer/index.bs
           wget -O spec/index.bs https://raw.githubusercontent.com/${{ github.event.workflow_run.head_repository.full_name }}/${{ github.event.workflow_run.head_sha }}/spec/index.bs
           wget -O wgsl/index.bs https://raw.githubusercontent.com/${{ github.event.workflow_run.head_repository.full_name }}/${{ github.event.workflow_run.head_sha }}/wgsl/index.bs
+          wget -O wgsl/extract-grammar.py https://raw.githubusercontent.com/${{ github.event.workflow_run.head_repository.full_name }}/${{ github.event.workflow_run.head_sha }}/wgsl/extract-grammar.py
           wget -O explainer/index.bs https://raw.githubusercontent.com/${{ github.event.workflow_run.head_repository.full_name }}/${{ github.event.workflow_run.head_sha }}/explainer/index.bs
 
       # Adds Firebase config files to directory

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -504,7 +504,7 @@ An <dfn>integer literal</dfn> is:
     const b = 0X123u;
     const c = 1u;
     const d = 123;
-    const f = 0;
+    const e = 0;
     const f = 0i;
     const g = 0x3f;
   </xmp>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -506,6 +506,7 @@ An <dfn>integer literal</dfn> is:
     const d = 123;
     const f = 0;
     const f = 0i;
+    const g = 0x3f;
   </xmp>
 </div>
 
@@ -552,10 +553,9 @@ or a [=hexadecimal floating point literal=].
     const i = 0xa.fp+2;
     const j = 0x1P+4f;
     const k = 0X.3;
-    const l = 0x3f;
-    const m = 0x3p+2h;
-    const n = 0X1.fp-4;
-    const o = 0x3.2p+2h;
+    const l = 0x3p+2h;
+    const m = 0X1.fp-4;
+    const n = 0x3.2p+2h;
   </xmp>
 </div>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -474,6 +474,13 @@ A <dfn>literal</dfn> is one of:
 * A <dfn>numeric literal</dfn>: either an [=integer literal=] or a [=floating point literal=],
     and is used to represent a number.
 
+<div class='example wgsl bool-literals' heading='boolean literals'>
+  <xmp highlight='rust'>
+    const a = true;
+    const b = false;
+  </xmp>
+</div>
+
 <div class='syntax' noexport='true'>
   <dfn for=syntax>bool_literal</dfn> :
 
@@ -490,6 +497,17 @@ An <dfn>integer literal</dfn> is:
     * A sequence of decimal digits, where the first digit is not `0`.
     * `0x` or `0X` followed by a sequence of hexadecimal digits.
 * Then an optional `i` or `u` suffix.
+
+<div class='example wgsl int-literals' heading='integer literals'>
+  <xmp highlight='rust'>
+    const a = 0x123;
+    const b = 0X123u;
+    const c = 1u;
+    const d = 123;
+    const f = 0;
+    const f = 0i;
+  </xmp>
+</div>
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>int_literal</dfn> :
@@ -522,6 +540,25 @@ or a [=hexadecimal floating point literal=].
     * The value of the literal is the value of the mantissa multiplied by 2 to the power of the exponent.
          When no exponent is specified, an exponent of 0 is assumed.
 
+<div class='example wgsl float-literals' heading='floating point literals'>
+  <xmp highlight='rust'>
+    const a = 0.e+4f;
+    const b = 01.;
+    const c = .01;
+    const d = 12.34;
+    const f = .0f;
+    const g = 0h;
+    const h = 1e-3;
+    const i = 0xa.fp+2;
+    const j = 0x1P+4f;
+    const k = 0X.3;
+    const l = 0x3f;
+    const m = 0x3p+2h;
+    const n = 0X1.fp-4;
+    const o = 0x3.2p+2h;
+  </xmp>
+</div>
+
 <div class='syntax' noexport='true'>
   <dfn for=syntax>float_literal</dfn> :
 
@@ -539,7 +576,7 @@ or a [=hexadecimal floating point literal=].
 <div class='syntax' noexport='true'>
   <dfn for=syntax>hex_float_literal</dfn> :
 
-    | `/0[xX]((([0-9a-fA-F]*\.[0-9a-fA-F]+|[0-9a-fA-F]+\.[0-9a-fA-F]*)([pP](\+|-)?[0-9]+f?)?)|([0-9a-fA-F]+[pP](\+|-)?[0-9]+f?))/`
+    | `/0[xX]((([0-9a-fA-F]*\.[0-9a-fA-F]+|[0-9a-fA-F]+\.[0-9a-fA-F]*)([pP](\+|-)?[0-9]+[fh]?)?)|([0-9a-fA-F]+[pP](\+|-)?[0-9]+[fh]?))/`
 </div>
 
 <div class='syntax' noexport='true'>


### PR DESCRIPTION
This PR adds examples for various cases of literal. The regex for
hex floats is corrected to allow the h suffix in order to pass
the float examples.

Fixes #2756