### PR TITLE
[wgsl] Split regex apart by segment. 

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -28,11 +28,11 @@ jobs:
       # Replaces base specs with head specs
       - name: Pull PR
         if: ${{ github.event.workflow_run.event == 'pull_request' && env.PR }}
+        # Note, do not add python scripts here due to easy private key access.
         run: |
           rm spec/index.bs wgsl/index.bs explainer/index.bs
           wget -O spec/index.bs https://raw.githubusercontent.com/${{ github.event.workflow_run.head_repository.full_name }}/${{ github.event.workflow_run.head_sha }}/spec/index.bs
           wget -O wgsl/index.bs https://raw.githubusercontent.com/${{ github.event.workflow_run.head_repository.full_name }}/${{ github.event.workflow_run.head_sha }}/wgsl/index.bs
-          wget -O wgsl/extract-grammar.py https://raw.githubusercontent.com/${{ github.event.workflow_run.head_repository.full_name }}/${{ github.event.workflow_run.head_sha }}/wgsl/extract-grammar.py
           wget -O explainer/index.bs https://raw.githubusercontent.com/${{ github.event.workflow_run.head_repository.full_name }}/${{ github.event.workflow_run.head_sha }}/explainer/index.bs
 
       # Adds Firebase config files to directory

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -32,7 +32,6 @@ jobs:
           rm spec/index.bs wgsl/index.bs explainer/index.bs
           wget -O spec/index.bs https://raw.githubusercontent.com/${{ github.event.workflow_run.head_repository.full_name }}/${{ github.event.workflow_run.head_sha }}/spec/index.bs
           wget -O wgsl/index.bs https://raw.githubusercontent.com/${{ github.event.workflow_run.head_repository.full_name }}/${{ github.event.workflow_run.head_sha }}/wgsl/index.bs
-          wget -O wgsl/extract-grammar.py https://raw.githubusercontent.com/${{ github.event.workflow_run.head_repository.full_name }}/${{ github.event.workflow_run.head_sha }}/wgsl/extract-grammar.py
           wget -O explainer/index.bs https://raw.githubusercontent.com/${{ github.event.workflow_run.head_repository.full_name }}/${{ github.event.workflow_run.head_sha }}/explainer/index.bs
 
       # Adds Firebase config files to directory

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -32,6 +32,7 @@ jobs:
           rm spec/index.bs wgsl/index.bs explainer/index.bs
           wget -O spec/index.bs https://raw.githubusercontent.com/${{ github.event.workflow_run.head_repository.full_name }}/${{ github.event.workflow_run.head_sha }}/spec/index.bs
           wget -O wgsl/index.bs https://raw.githubusercontent.com/${{ github.event.workflow_run.head_repository.full_name }}/${{ github.event.workflow_run.head_sha }}/wgsl/index.bs
+          wget -O wgsl/extract-grammar.py https://raw.githubusercontent.com/${{ github.event.workflow_run.head_repository.full_name }}/${{ github.event.workflow_run.head_sha }}/wgsl/extract-grammar.py
           wget -O explainer/index.bs https://raw.githubusercontent.com/${{ github.event.workflow_run.head_repository.full_name }}/${{ github.event.workflow_run.head_sha }}/explainer/index.bs
 
       # Adds Firebase config files to directory

--- a/wgsl/extract-grammar.py
+++ b/wgsl/extract-grammar.py
@@ -156,22 +156,6 @@ class scanner_rule(Scanner):
             rule_name = line[2:].split("<dfn for=syntax>")[1]
             rule_name = rule_name.split("</dfn>")[0].strip()
             return (rule_name, None, 0)
-        elif line[4:].startswith("<xmp> |"):
-            # When the line is
-            #    <xmp> |
-            #       / <regex
-            #       over multiple
-            #       lines/
-            #     </xmp>
-            # returns (None, '<regex with space collapsed>', num_lines)
-            count = 1
-            rule_value = ''
-            line = lines[i + count]
-            while not line[4:].startswith("</xmp>"):
-                rule_value += line.strip()
-                count += 1
-                line = lines[i + count]
-            return (None, ["`" + rule_value.replace(' ', '') + "`"], count)
         elif line[4:].startswith("| "):
             # When the line is
             #    | [=syntax/variable_decl=] [=syntax/equal=] [=syntax/expression=]

--- a/wgsl/extract-grammar.py
+++ b/wgsl/extract-grammar.py
@@ -156,6 +156,22 @@ class scanner_rule(Scanner):
             rule_name = line[2:].split("<dfn for=syntax>")[1]
             rule_name = rule_name.split("</dfn>")[0].strip()
             return (rule_name, None, 0)
+        elif line[4:].startswith("<xmp> |"):
+            # When the line is
+            #    <xmp> |
+            #       / <regex
+            #       over multiple
+            #       lines/
+            #     </xmp>
+            # returns (None, '<regex with space collapsed>', num_lines)
+            count = 1
+            rule_value = ''
+            line = lines[i + count]
+            while not line[4:].startswith("</xmp>"):
+                rule_value += line.strip()
+                count += 1
+                line = lines[i + count]
+            return (None, ["`" + rule_value.replace(' ', '') + "`"], count)
         elif line[4:].startswith("| "):
             # When the line is
             #    | [=syntax/variable_decl=] [=syntax/equal=] [=syntax/expression=]

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -506,6 +506,7 @@ An <dfn>integer literal</dfn> is:
     const d = 123;
     const f = 0;
     const f = 0i;
+    const g = 0x3f;
   </xmp>
 </div>
 
@@ -552,10 +553,9 @@ or a [=hexadecimal floating point literal=].
     const i = 0xa.fp+2;
     const j = 0x1P+4f;
     const k = 0X.3;
-    const l = 0x3f;
-    const m = 0x3p+2h;
-    const n = 0X1.fp-4;
-    const o = 0x3.2p+2h;
+    const l = 0x3p+2h;
+    const m = 0X1.fp-4;
+    const n = 0x3.2p+2h;
   </xmp>
 </div>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -512,8 +512,11 @@ An <dfn>integer literal</dfn> is:
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>int_literal</dfn> :
-
-    | `/(0[xX][0-9a-fA-F]+|0|[1-9][0-9]*)[iu]?/`
+    <xmp> |
+      /   0[xX][0-9a-fA-F]+[iu]?
+          | 0[iu]?
+          | [1-9][0-9]*[iu]?/
+    </xmp>
 </div>
 
 A <dfn>floating point literal</dfn> is either a [=decimal floating point literal=]
@@ -569,14 +572,22 @@ or a [=hexadecimal floating point literal=].
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>decimal_float_literal</dfn> :
-
-    | `/((([0-9]*\.[0-9]+|[0-9]+\.[0-9]*)([eE](\+|-)?[0-9]+)?)|([0-9]+[eE](\+|-)?[0-9]+))[fh]?|0[fh]|[1-9][0-9]*[fh]/`
+    <xmp> |
+      /   [0-9]*\.[0-9]+([eE](\+|-)?[0-9]+)?[fh]?
+          | [0-9]+\.[0-9]*([eE](\+|-)?[0-9]+)?[fh]?
+          | [0-9]+[eE](\+|-)?[0-9]+[fh]?
+          | 0[fh]
+          | [1-9][0-9]*[fh]/
+    </xmp>
 </div>
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>hex_float_literal</dfn> :
-
-    | `/0[xX]((([0-9a-fA-F]*\.[0-9a-fA-F]+|[0-9a-fA-F]+\.[0-9a-fA-F]*)([pP](\+|-)?[0-9]+[fh]?)?)|([0-9a-fA-F]+[pP](\+|-)?[0-9]+[fh]?))/`
+    <xmp> |
+      /   0[xX][0-9a-fA-F]*\.[0-9a-fA-F]+([pP](\+|-)?[0-9]+[fh]?)?
+          | 0[xX][0-9a-fA-F]+\.[0-9a-fA-F]*([pP](\+|-)?[0-9]+[fh]?)?
+          | 0[xX]([0-9a-fA-F]+[pP](\+|-)?[0-9]+[fh]?)/
+    </xmp>
 </div>
 
 <div class='syntax' noexport='true'>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -474,6 +474,13 @@ A <dfn>literal</dfn> is one of:
 * A <dfn>numeric literal</dfn>: either an [=integer literal=] or a [=floating point literal=],
     and is used to represent a number.
 
+<div class='example wgsl bool-literals' heading='boolean literals'>
+  <xmp highlight='rust'>
+    const a = true;
+    const b = false;
+  </xmp>
+</div>
+
 <div class='syntax' noexport='true'>
   <dfn for=syntax>bool_literal</dfn> :
 
@@ -490,6 +497,17 @@ An <dfn>integer literal</dfn> is:
     * A sequence of decimal digits, where the first digit is not `0`.
     * `0x` or `0X` followed by a sequence of hexadecimal digits.
 * Then an optional `i` or `u` suffix.
+
+<div class='example wgsl int-literals' heading='integer literals'>
+  <xmp highlight='rust'>
+    const a = 0x123;
+    const b = 0X123u;
+    const c = 1u;
+    const d = 123;
+    const f = 0;
+    const f = 0i;
+  </xmp>
+</div>
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>int_literal</dfn> :
@@ -522,6 +540,25 @@ or a [=hexadecimal floating point literal=].
     * The value of the literal is the value of the mantissa multiplied by 2 to the power of the exponent.
          When no exponent is specified, an exponent of 0 is assumed.
 
+<div class='example wgsl float-literals' heading='floating point literals'>
+  <xmp highlight='rust'>
+    const a = 0.e+4f;
+    const b = 01.;
+    const c = .01;
+    const d = 12.34;
+    const f = .0f;
+    const g = 0h;
+    const h = 1e-3;
+    const i = 0xa.fp+2;
+    const j = 0x1P+4f;
+    const k = 0X.3;
+    const l = 0x3f;
+    const m = 0x3p+2h;
+    const n = 0X1.fp-4;
+    const o = 0x3.2p+2h;
+  </xmp>
+</div>
+
 <div class='syntax' noexport='true'>
   <dfn for=syntax>float_literal</dfn> :
 
@@ -539,7 +576,7 @@ or a [=hexadecimal floating point literal=].
 <div class='syntax' noexport='true'>
   <dfn for=syntax>hex_float_literal</dfn> :
 
-    | `/0[xX]((([0-9a-fA-F]*\.[0-9a-fA-F]+|[0-9a-fA-F]+\.[0-9a-fA-F]*)([pP](\+|-)?[0-9]+f?)?)|([0-9a-fA-F]+[pP](\+|-)?[0-9]+f?))/`
+    | `/0[xX]((([0-9a-fA-F]*\.[0-9a-fA-F]+|[0-9a-fA-F]+\.[0-9a-fA-F]*)([pP](\+|-)?[0-9]+[fh]?)?)|([0-9a-fA-F]+[pP](\+|-)?[0-9]+[fh]?))/`
 </div>
 
 <div class='syntax' noexport='true'>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -512,11 +512,12 @@ An <dfn>integer literal</dfn> is:
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>int_literal</dfn> :
-    <xmp> |
-      /   0[xX][0-9a-fA-F]+[iu]?
-          | 0[iu]?
-          | [1-9][0-9]*[iu]?/
-    </xmp>
+
+    | `/0[xX][0-9a-fA-F]+[iu]?/`
+
+    | `/0[iu]?/`
+
+    | `/[1-9][0-9]*[iu]?/`
 </div>
 
 A <dfn>floating point literal</dfn> is either a [=decimal floating point literal=]
@@ -572,22 +573,26 @@ or a [=hexadecimal floating point literal=].
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>decimal_float_literal</dfn> :
-    <xmp> |
-      /   [0-9]*\.[0-9]+([eE](\+|-)?[0-9]+)?[fh]?
-          | [0-9]+\.[0-9]*([eE](\+|-)?[0-9]+)?[fh]?
-          | [0-9]+[eE](\+|-)?[0-9]+[fh]?
-          | 0[fh]
-          | [1-9][0-9]*[fh]/
-    </xmp>
+
+    | `/[0-9]*\.[0-9]+([eE](\+|-)?[0-9]+)?[fh]?/`
+
+    | `/[0-9]+\.[0-9]*([eE](\+|-)?[0-9]+)?[fh]?/`
+
+    | `/[0-9]+[eE](\+|-)?[0-9]+[fh]?/`
+
+    | `/0[fh]/`
+
+    | `/[1-9][0-9]*[fh]/`
 </div>
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>hex_float_literal</dfn> :
-    <xmp> |
-      /   0[xX][0-9a-fA-F]*\.[0-9a-fA-F]+([pP](\+|-)?[0-9]+[fh]?)?
-          | 0[xX][0-9a-fA-F]+\.[0-9a-fA-F]*([pP](\+|-)?[0-9]+[fh]?)?
-          | 0[xX]([0-9a-fA-F]+[pP](\+|-)?[0-9]+[fh]?)/
-    </xmp>
+
+    | `/0[xX][0-9a-fA-F]*\.[0-9a-fA-F]+([pP](\+|-)?[0-9]+[fh]?)?/`
+
+    | `/0[xX][0-9a-fA-F]+\.[0-9a-fA-F]*([pP](\+|-)?[0-9]+[fh]?)?/`
+
+    | `/0[xX]([0-9a-fA-F]+[pP](\+|-)?[0-9]+[fh]?)/`
 </div>
 
 <div class='syntax' noexport='true'>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -592,7 +592,7 @@ or a [=hexadecimal floating point literal=].
 
     | `/0[xX][0-9a-fA-F]+\.[0-9a-fA-F]*([pP](\+|-)?[0-9]+[fh]?)?/`
 
-    | `/0[xX]([0-9a-fA-F]+[pP](\+|-)?[0-9]+[fh]?)/`
+    | `/0[xX][0-9a-fA-F]+[pP](\+|-)?[0-9]+[fh]?/`
 </div>
 
 <div class='syntax' noexport='true'>


### PR DESCRIPTION
This PR displays the regex values by segment instead of as a continuous
string. The extract_grammar script is updated to rebuild the
non-separated regex before providing to tree-sitter.

The regex's are also exploded slight so there is more duplication
in them, but it means each segment stands alone to increase readability.

Builds on top of #2761 