### PR TITLE
Set the default value of maxInterStageShaderComponents to 32

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1397,7 +1397,7 @@ applications should generally request the "worst" limits that work for their con
         when creating a {{GPURenderPipeline}}.
 
     <tr><td><dfn>maxInterStageShaderComponents</dfn>
-        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>60
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>32
     <tr class=row-continuation><td colspan=4>
         The maximum allowed number of components of input or output variables
         for inter-stage communication (like vertex outputs or fragment inputs).


### PR DESCRIPTION
This is a stop-gap measure until https://github.com/gpuweb/gpuweb/issues/2749
is resolved. According to the Metal feature set tables, Macs limit the number
of inter-stage inputs to 32 and the number of inter-stage components to 124
If we limit the number of components to anything higher than 32, then a program
which uses single-component values will be able to exceed the limit on Macs.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/litherum/gpuweb/pull/2763.html" title="Last updated on Apr 15, 2022, 9:10 AM UTC (276dcdd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2763/cbfa42b...litherum:276dcdd.html" title="Last updated on Apr 15, 2022, 9:10 AM UTC (276dcdd)">Diff</a>