### PR TITLE
Adopt identical-to and further clarifications for both WGSL and WebGPU

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -43,13 +43,6 @@ Assume Explicit For: yes
     ],
     "href": "https://sourcemaps.info/spec.html",
     "title": "Source Map Revision 3 Proposal"
-  },
-  "UnicodeVersion14": {
-    "href":"http://www.unicode.org/versions/Unicode14.0.0/",
-    "author":"The Unicode Consortium",
-    "title":"The Unicode Standard, Version 14.0.0",
-    "isbn":"978-1-936213-29-0",
-    "id":"UnicodeVersion14"
   }
 }
 </pre>
@@ -102,17 +95,7 @@ spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
         text: runtime-sized; url: runtime-sized
         text: SizeOf; url: sizeof
         text: WGSL floating point conversion; url: floating-point-conversion
-spec: UAX15; urlPrefix: https://www.unicode.org/reports/tr15/tr15-51.html
-    type: dfn
-        text: Unicode Standard Annex #15 for Unicode Version 14.0.0
-        text: UAX15 Normalization Forms; url: Normalization_Forms_Table
-        text: UAX15 Equivalences; url: Canon_Compat_Equivalence
-spec: UTS46; urlPrefix: https://www.unicode.org/reports/tr46/tr46-27.html
-    type: dfn
-        text: UTS46 Mapping; url: IDNA_Mapping_Table
-spec: charmod-norm; urlPrefix: https://www.w3.org/TR/charmod-norm/
-    type: dfn
-        text: charmod-norm Matching; url: identityMatching
+        text: WGSL identifier comparison; url: identifier-comparison
 </pre>
 
 <style>
@@ -4692,31 +4675,14 @@ dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
 source-map-v3 format.
 Source maps are optional, but serve as a standardized way to support dev-tool
 integration such as source-language debugging [[SourceMap]].
-WGSL names (identifiers) in source maps [=string/is|identical to=] each other are the same. As such, they do not compare
-through normalizations such as [=UAX15 Normalization Forms|Normalization Form C (NFC)=],
-[=UAX15 Normalization Forms|Normalization Form D (NFD)=], [=UAX15 Normalization Forms|Normalization Form KC (NFKC)=],
-[=UAX15 Normalization Forms|Normalization Form KD (NFKD)=],
-and further matching such as [=UTS46 Mapping=], and [=charmod-norm Matching=].
-
-Note: A user agent should issue developer-visible warnings when WGSL identifiers contain
-code points or code point sequences with homoglyphs since underlying code point sequences
-would cause the homographs to resolve to different WGSL identifiers despite looking
-the same to the reader. Examples of mappings to detect such display include
-normalizations such as [=UAX15 Normalization Forms|Normalization Form C (NFC)=],
-[=UAX15 Normalization Forms|Normalization Form D (NFD)=], [=UAX15 Normalization Forms|Normalization Form KC (NFKC)=],
-[=UAX15 Normalization Forms|Normalization Form KD (NFKD)=],
-and further matching such as [=UTS46 Mapping=], and [=charmod-norm Matching=].
+WGSL names (identifiers) in source maps follow the rules defined in [=WGSL identifier comparison=].
 
 {{GPUShaderModuleDescriptor/hints}}, if defined, maps an entry point name from
 the shader to a {{GPUShaderModuleCompilationHint}}. No validation is performed with
 any of these {{GPUShaderModuleCompilationHint}}. Implementations should use any
 information present in the {{GPUShaderModuleCompilationHint}} to perform as much
 compilation as is possible within {{GPUDevice/createShaderModule()}}.
-Entry point names [=string/is|identical to=] each other are the same. As such, they do not compare
-through normalizations such as [=UAX15 Normalization Forms|Normalization Form C (NFC)=],
-[=UAX15 Normalization Forms|Normalization Form D (NFD)=], [=UAX15 Normalization Forms|Normalization Form KC (NFKC)=],
-[=UAX15 Normalization Forms|Normalization Form KD (NFKD)=],
-and further matching such as [=UTS46 Mapping=], and [=charmod-norm Matching=].
+Entry point names follow the rules defined in [=WGSL identifier comparison=].
 
 Note: Supplying information in {{GPUShaderModuleDescriptor/hints}} does not have any
 observable effect, other than performance. Because a single shader module can hold
@@ -5125,11 +5091,7 @@ run the following steps:
 
 A {{GPUProgrammableStage}} describes the entry point in the user-provided
 {{GPUShaderModule}} that controls one of the programmable stages of a [=pipeline=].
-Entry point names [=string/is|identical to=] each other are the same. As such, they do not compare
-through normalizations such as [=UAX15 Normalization Forms|Normalization Form C (NFC)=],
-[=UAX15 Normalization Forms|Normalization Form D (NFD)=], [=UAX15 Normalization Forms|Normalization Form KC (NFKC)=],
-[=UAX15 Normalization Forms|Normalization Form KD (NFKD)=],
-and further matching such as [=UTS46 Mapping=], and [=charmod-norm Matching=].
+Entry point names follow the rules defined in [=WGSL identifier comparison=].
 
 <script type=idl>
 dictionary GPUProgrammableStage {
@@ -5150,19 +5112,10 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         Each such [=pipeline-overridable=] constant is uniquely identified by a single
         [=pipeline-overridable constant identifier string=] (representing the numeric ID of the
         constant, if one is specified, and otherwise the constant's identifier name).
-        WGSL names (identifiers) in source maps [=string/is|identical to=] each other are the same. As such, they do not compare
-        through normalizations such as [=UAX15 Normalization Forms|Normalization Form C (NFC)=],
-        [=UAX15 Normalization Forms|Normalization Form D (NFD)=], [=UAX15 Normalization Forms|Normalization Form KC (NFKC)=],
-        [=UAX15 Normalization Forms|Normalization Form KD (NFKD)=],
-        and further matching such as [=UTS46 Mapping=], and [=charmod-norm Matching=].
+        WGSL names (identifiers) in source maps follow the rules defined in [=WGSL identifier comparison=].
 
         The key of each key-value pair must equal the identifier string of one such constant.
         When the pipeline is executed, that constant will have the specified value.
-
-        Note: A user agent or should issue developer-visible warnings when the meaning of a
-        WGSL program would change if all instances of an identifier spelled with a specific
-        code point sequence are replaced by another code point sequence
-        that would appear the same to a reader.
 
         Values are specified as <dfn typedef for=>GPUPipelineConstantValue</dfn>, which is a
         `double` which is converted to the WGSL data type of the corresponding pipeline-overridable
@@ -5249,17 +5202,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         |descriptor|.{{GPUProgrammableStage/constants}}:
         - |key| must equal the [=pipeline-overridable constant identifier string=] of
             some [=pipeline-overridable=] constant defined in the shader module
-            |descriptor|.{{GPUProgrammableStage/module}} by code points and
-            not by [=UAX15 Equivalences=] for [[!UnicodeVersion14|Unicode Version 14.0.0]].
-
-            Note: A user agent should issue developer-visible warnings when WGSL identifiers contain
-            code points or code point sequences with homoglyphs since underlying code point sequences
-            would cause the homographs to resolve to different WGSL identifiers despite looking
-            the same to the reader. Examples of mappings to detect such display include
-            normalizations such as [=UAX15 Normalization Forms|Normalization Form C (NFC)=],
-            [=UAX15 Normalization Forms|Normalization Form D (NFD)=], [=UAX15 Normalization Forms|Normalization Form KC (NFKC)=],
-            [=UAX15 Normalization Forms|Normalization Form KD (NFKD)=],
-            and further matching such as [=UTS46 Mapping=], and [=charmod-norm Matching=].
+            |descriptor|.{{GPUProgrammableStage/module}} by the rules defined in [=WGSL identifier comparison=].
     - For each [=pipeline-overridable constant identifier string=] |key| which is
         [=statically accessed=] by the shader entry point:
         - If the pipeline-overridable constant identified by |key|

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5150,8 +5150,11 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         Each such [=pipeline-overridable=] constant is uniquely identified by a single
         [=pipeline-overridable constant identifier string=] (representing the numeric ID of the
         constant, if one is specified, and otherwise the constant's identifier name).
-        The names compare by their code points and
-        do not follow [=UAX15 Equivalences=] for [[!UnicodeVersion14|Unicode Version 14.0.0]].
+        WGSL names (identifiers) in source maps [=string/is|identical to=] each other are the same. As such, they do not compare
+        through normalizations such as [=UAX15 Normalization Forms|Normalization Form C (NFC)=],
+        [=UAX15 Normalization Forms|Normalization Form D (NFD)=], [=UAX15 Normalization Forms|Normalization Form KC (NFKC)=],
+        [=UAX15 Normalization Forms|Normalization Form KD (NFKD)=],
+        and further matching such as [=UTS46 Mapping=], and [=charmod-norm Matching=].
 
         The key of each key-value pair must equal the identifier string of one such constant.
         When the pipeline is executed, that constant will have the specified value.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -107,6 +107,12 @@ spec: UAX15; urlPrefix: https://www.unicode.org/reports/tr15/tr15-51.html
         text: Unicode Standard Annex #15 for Unicode Version 14.0.0
         text: UAX15 Normalization Forms; url: Normalization_Forms_Table
         text: UAX15 Equivalences; url: Canon_Compat_Equivalence
+spec: UTS46; urlPrefix: https://www.unicode.org/reports/tr46/tr46-27.html
+    type: dfn
+        text: UTS46 Mapping; url: IDNA_Mapping_Table
+spec: charmod-norm; urlPrefix: https://www.w3.org/TR/charmod-norm/
+    type: dfn
+        text: charmod-norm Matching; url: identityMatching
 </pre>
 
 <style>
@@ -4686,21 +4692,31 @@ dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
 source-map-v3 format.
 Source maps are optional, but serve as a standardized way to support dev-tool
 integration such as source-language debugging [[SourceMap]].
-WGSL names in source maps compare by their code points and
-do not follow [=UAX15 Equivalences=] for [[!UnicodeVersion14|Unicode Version 14.0.0]].
+WGSL names (identifiers) in source maps [=string/is|identical to=] each other are the same. As such, they do not compare
+through normalizations such as [=UAX15 Normalization Forms|Normalization Form C (NFC)=],
+[=UAX15 Normalization Forms|Normalization Form D (NFD)=], [=UAX15 Normalization Forms|Normalization Form KC (NFKC)=],
+[=UAX15 Normalization Forms|Normalization Form KD (NFKD)=],
+and further matching such as [=UTS46 Mapping=], and [=charmod-norm Matching=].
 
-Note: User agents should consider issuing developer-visible warnings in most or all
-situations where display of two names with different code point sequences
-look the same to the reader, such as ones same under canonical equivalence with
-[=UAX15 Normalization Forms|Normalization Form C (NFC)=] or characters that look similarly.
+Note: A user agent should issue developer-visible warnings when WGSL identifiers contain
+code points or code point sequences with homoglyphs since underlying code point sequences
+would cause the homographs to resolve to different WGSL identifiers despite looking
+the same to the reader. Examples of mappings to detect such display include
+normalizations such as [=UAX15 Normalization Forms|Normalization Form C (NFC)=],
+[=UAX15 Normalization Forms|Normalization Form D (NFD)=], [=UAX15 Normalization Forms|Normalization Form KC (NFKC)=],
+[=UAX15 Normalization Forms|Normalization Form KD (NFKD)=],
+and further matching such as [=UTS46 Mapping=], and [=charmod-norm Matching=].
 
 {{GPUShaderModuleDescriptor/hints}}, if defined, maps an entry point name from
 the shader to a {{GPUShaderModuleCompilationHint}}. No validation is performed with
 any of these {{GPUShaderModuleCompilationHint}}. Implementations should use any
 information present in the {{GPUShaderModuleCompilationHint}} to perform as much
 compilation as is possible within {{GPUDevice/createShaderModule()}}.
-Entry point names compare by their code points and
-do not follow [=UAX15 Equivalences=] for [[!UnicodeVersion14|Unicode Version 14.0.0]].
+Entry point names [=string/is|identical to=] each other are the same. As such, they do not compare
+through normalizations such as [=UAX15 Normalization Forms|Normalization Form C (NFC)=],
+[=UAX15 Normalization Forms|Normalization Form D (NFD)=], [=UAX15 Normalization Forms|Normalization Form KC (NFKC)=],
+[=UAX15 Normalization Forms|Normalization Form KD (NFKD)=],
+and further matching such as [=UTS46 Mapping=], and [=charmod-norm Matching=].
 
 Note: Supplying information in {{GPUShaderModuleDescriptor/hints}} does not have any
 observable effect, other than performance. Because a single shader module can hold
@@ -4835,7 +4851,7 @@ any specific point in the code at all.
         The offset, in UTF-16 code units, from the beginning of line {{GPUCompilationMessage/lineNum}}
         of the shader {{GPUShaderModuleDescriptor/code}} to the point or beginning of the substring
         that the {{GPUCompilationMessage/message}} corresponds to. Value is one-based, such that a
-        {{GPUCompilationMessage/linePos}} of `1` indicates the first character of the line.
+        {{GPUCompilationMessage/linePos}} of `1` indicates the first code unit of the line.
 
         If {{GPUCompilationMessage/message}} corresponds to a substring this points to the
         first UTF-16 code unit of the substring. Must be `0` if the {{GPUCompilationMessage/message}}
@@ -5109,8 +5125,11 @@ run the following steps:
 
 A {{GPUProgrammableStage}} describes the entry point in the user-provided
 {{GPUShaderModule}} that controls one of the programmable stages of a [=pipeline=].
-Entry point names compare by their code points and
-do not follow [=UAX15 Equivalences=] for [[!UnicodeVersion14|Unicode Version 14.0.0]].
+Entry point names [=string/is|identical to=] each other are the same. As such, they do not compare
+through normalizations such as [=UAX15 Normalization Forms|Normalization Form C (NFC)=],
+[=UAX15 Normalization Forms|Normalization Form D (NFD)=], [=UAX15 Normalization Forms|Normalization Form KC (NFKC)=],
+[=UAX15 Normalization Forms|Normalization Form KD (NFKD)=],
+and further matching such as [=UTS46 Mapping=], and [=charmod-norm Matching=].
 
 <script type=idl>
 dictionary GPUProgrammableStage {
@@ -5230,10 +5249,14 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
             |descriptor|.{{GPUProgrammableStage/module}} by code points and
             not by [=UAX15 Equivalences=] for [[!UnicodeVersion14|Unicode Version 14.0.0]].
 
-            Note: User agents should consider issuing developer-visible warnings in most or all
-            situations where display of two names with different code point sequences
-            look the same to the reader, such as ones same under canonical equivalence with
-            [=UAX15 Normalization Forms|Normalization Form C (NFC)=] or characters that look similarly.
+            Note: A user agent should issue developer-visible warnings when WGSL identifiers contain
+            code points or code point sequences with homoglyphs since underlying code point sequences
+            would cause the homographs to resolve to different WGSL identifiers despite looking
+            the same to the reader. Examples of mappings to detect such display include
+            normalizations such as [=UAX15 Normalization Forms|Normalization Form C (NFC)=],
+            [=UAX15 Normalization Forms|Normalization Form D (NFD)=], [=UAX15 Normalization Forms|Normalization Form KC (NFKC)=],
+            [=UAX15 Normalization Forms|Normalization Form KD (NFKD)=],
+            and further matching such as [=UTS46 Mapping=], and [=charmod-norm Matching=].
     - For each [=pipeline-overridable constant identifier string=] |key| which is
         [=statically accessed=] by the shader entry point:
         - If the pipeline-overridable constant identified by |key|

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -143,6 +143,12 @@ spec: UAX31; urlPrefix: https://www.unicode.org/reports/tr31/tr31-35.html
         text: Unicode Standard Annex #31 for Unicode Version 14.0.0
         text: UAX31 Lexical Classes; url: Table_Lexical_Classes_for_Identifiers
         text: UAX31 Grammar; url: D1
+spec: UTS46; urlPrefix: https://www.unicode.org/reports/tr46/tr46-27.html
+    type: dfn
+        text: UTS46 Mapping; url: IDNA_Mapping_Table
+spec: charmod-norm; urlPrefix: https://www.w3.org/TR/charmod-norm/
+    type: dfn
+        text: charmod-norm Matching; url: identityMatching
 spec: Unicode Character Database for Unicode Version 14.0.0; urlPrefix: https://www.unicode.org/Public/14.0.0/ucd/DerivedCoreProperties.txt
     type: dfn
         text: Unicode Character Database for Unicode Version 14.0.0
@@ -594,11 +600,12 @@ See [[#declaration-and-scope]] and [[#directives]].
 The form of an identifier is based on the
 [=Unicode Standard Annex #31 for Unicode Version 14.0.0|Unicode Standard Annex #31=] for
 [[!UnicodeVersion14|Unicode Version 14.0.0]],
-with the following elaborations. Identifiers do not compare under canonical equivalence
-and they are not normalized otherwise,
-meaning that single accented code points are distinct from the same code points constructed
-by an accent and a letter, and Unicode code points that look similar are not
-treated as the same and they compare by their code points.
+with the following elaborations.
+WGSL identifiers [=string/is|identical to=] each other are the same. As such, they do not compare
+through normalizations such as [=UAX15 Normalization Forms|Normalization Form C (NFC)=],
+[=UAX15 Normalization Forms|Normalization Form D (NFD)=], [=UAX15 Normalization Forms|Normalization Form KC (NFKC)=],
+[=UAX15 Normalization Forms|Normalization Form KD (NFKD)=],
+and further matching such as [=UTS46 Mapping=], and [=charmod-norm Matching=].
 
 Identifiers use the following profile described in terms of [=UAX31 Grammar=]:
 
@@ -629,14 +636,14 @@ with all valid code points
 of both [=UAX31 Lexical Classes|XID_Start=] and
 [=UAX31 Lexical Classes|XID_Continue=].
 
-Note: A user agent or should issue developer-visible warnings when
-the meaning of a WGSL program would change if all instances of an
-identifier spelled with a specific code point sequence are replaced
-by another code point sequence that would appear the same to a reader.
-For example, remapping each identifier to its canonical equivalent
-spelling under [=UAX15 Normalization Forms|Normalization Form C (NFC)=]
-must permit the same set of declarations (avoiding new identifier collisions),
-and must not change how identifier uses [=resolve=] to their declarations.
+Note: A user agent should issue developer-visible warnings when WGSL identifiers contain
+code points or code point sequences with homoglyphs since underlying code point sequences
+would cause the homographs to resolve to different WGSL identifiers despite looking
+the same to the reader. Examples of mappings to detect such display include
+normalizations such as [=UAX15 Normalization Forms|Normalization Form C (NFC)=],
+[=UAX15 Normalization Forms|Normalization Form D (NFD)=], [=UAX15 Normalization Forms|Normalization Form KC (NFKC)=],
+[=UAX15 Normalization Forms|Normalization Form KD (NFKD)=],
+and further matching such as [=UTS46 Mapping=], and [=charmod-norm Matching=].
 
 Note: The [=return type=] for some [=built-in functions=] are structure types whose name cannot be used WGSL source.
 Those structure types are described as if they were [=predeclared=] with a name starting with two underscores.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -622,8 +622,8 @@ valid: `Δέλτα`, `réflexion`, `Кызыл`, `𐰓𐰏𐰇`, `朝焼け`, `�
 
 With the following exceptions:
 * An identifier must not have the same spelling as a [=keyword=] or as a [=reserved word=].
-* An identifier must not be `_` (a single underscore)
-* An identifier must not start with two underscores.
+* An identifier must not be `_` (a single underscore, `U+005F`).
+* An identifier must not start with `__` (two underscores, `U+005F` followed by `U+005F`).
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>ident</dfn> :

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -601,11 +601,6 @@ The form of an identifier is based on the
 [=Unicode Standard Annex #31 for Unicode Version 14.0.0|Unicode Standard Annex #31=] for
 [[!UnicodeVersion14|Unicode Version 14.0.0]],
 with the following elaborations.
-WGSL identifiers [=string/is|identical to=] each other are the same. As such, they do not compare
-through normalizations such as [=UAX15 Normalization Forms|Normalization Form C (NFC)=],
-[=UAX15 Normalization Forms|Normalization Form D (NFD)=], [=UAX15 Normalization Forms|Normalization Form KC (NFKC)=],
-[=UAX15 Normalization Forms|Normalization Form KD (NFKD)=],
-and further matching such as [=UTS46 Mapping=], and [=charmod-norm Matching=].
 
 Identifiers use the following profile described in terms of [=UAX31 Grammar=]:
 
@@ -636,6 +631,19 @@ with all valid code points
 of both [=UAX31 Lexical Classes|XID_Start=] and
 [=UAX31 Lexical Classes|XID_Continue=].
 
+Note: The [=return type=] for some [=built-in functions=] are structure types whose name cannot be used WGSL source.
+Those structure types are described as if they were [=predeclared=] with a name starting with two underscores.
+The result value can be saved into newly declared `let` or `var` using type inferencing, or immediately have one of its members
+immediately extracted by name.  See example usages in the description of `frexp` and `modf`.
+
+### Identifier Comparison ### {#identifier-comparison}
+
+WGSL identifiers [=string/is|identical to=] each other are the same. As such, they do not compare
+assuming normalizations such as [=UAX15 Normalization Forms|Normalization Form C (NFC)=],
+[=UAX15 Normalization Forms|Normalization Form D (NFD)=], [=UAX15 Normalization Forms|Normalization Form KC (NFKC)=],
+[=UAX15 Normalization Forms|Normalization Form KD (NFKD)=],
+and further matching such as [=UTS46 Mapping=], and [=charmod-norm Matching=].
+
 Note: A user agent should issue developer-visible warnings when WGSL identifiers contain
 code points or code point sequences with homoglyphs since underlying code point sequences
 would cause the homographs to resolve to different WGSL identifiers despite looking
@@ -644,11 +652,6 @@ normalizations such as [=UAX15 Normalization Forms|Normalization Form C (NFC)=],
 [=UAX15 Normalization Forms|Normalization Form D (NFD)=], [=UAX15 Normalization Forms|Normalization Form KC (NFKC)=],
 [=UAX15 Normalization Forms|Normalization Form KD (NFKD)=],
 and further matching such as [=UTS46 Mapping=], and [=charmod-norm Matching=].
-
-Note: The [=return type=] for some [=built-in functions=] are structure types whose name cannot be used WGSL source.
-Those structure types are described as if they were [=predeclared=] with a name starting with two underscores.
-The result value can be saved into newly declared `let` or `var` using type inferencing, or immediately have one of its members
-immediately extracted by name.  See example usages in the description of `frexp` and `modf`.
 
 ## Attributes ## {#attributes}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -638,11 +638,7 @@ immediately extracted by name.  See example usages in the description of `frexp`
 
 ### Identifier Comparison ### {#identifier-comparison}
 
-WGSL identifiers [=string/is|identical to=] each other are the same. As such, they do not compare
-assuming normalizations such as [=UAX15 Normalization Forms|Normalization Form C (NFC)=],
-[=UAX15 Normalization Forms|Normalization Form D (NFD)=], [=UAX15 Normalization Forms|Normalization Form KC (NFKC)=],
-[=UAX15 Normalization Forms|Normalization Form KD (NFKD)=],
-and further matching such as [=UTS46 Mapping=], and [=charmod-norm Matching=].
+Two WGSL identifiers are the same if and only if they consist of the same sequence of code points.
 
 In particular, two identifiers may be distinct in WGSL, but considered the same under conventional normalization,
 mapping, and matching algorithms such as:

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -644,14 +644,21 @@ assuming normalizations such as [=UAX15 Normalization Forms|Normalization Form C
 [=UAX15 Normalization Forms|Normalization Form KD (NFKD)=],
 and further matching such as [=UTS46 Mapping=], and [=charmod-norm Matching=].
 
-Note: A user agent should issue developer-visible warnings when WGSL identifiers contain
-code points or code point sequences with homoglyphs since underlying code point sequences
-would cause the homographs to resolve to different WGSL identifiers despite looking
-the same to the reader. Examples of mappings to detect such display include
-normalizations such as [=UAX15 Normalization Forms|Normalization Form C (NFC)=],
-[=UAX15 Normalization Forms|Normalization Form D (NFD)=], [=UAX15 Normalization Forms|Normalization Form KC (NFKC)=],
-[=UAX15 Normalization Forms|Normalization Form KD (NFKD)=],
-and further matching such as [=UTS46 Mapping=], and [=charmod-norm Matching=].
+In particular, two identifiers may be distinct in WGSL, but considered the same under conventional normalization,
+mapping, and matching algorithms such as:
+- [=UAX15 Normalization Forms|Normalization Form C (NFC)=],
+- [=UAX15 Normalization Forms|Normalization Form D (NFD)=],
+- [=UAX15 Normalization Forms|Normalization Form KC (NFKC)=],
+- [=UAX15 Normalization Forms|Normalization Form KD (NFKD)=],
+- [=UTS46 Mapping=], and
+- [=charmod-norm Matching=].
+
+Note: A user agent should issue developer-visible warnings when the meaning of a WGSL program would change if
+all instances of an identifier are replaced with one of that identifier's homographs.
+(A homoglyph is a sequence of code points that may appear the same to a reader as another sequence of code points. 
+Examples of mappings to detect homoglyphs are the transformations, mappings, and matching algorithms mentioned in
+the previous paragraph. Two sequences of code points are homographs if the identifier can transform one into the other by
+repeatedly replacing a subsequence with its homoglyph.)
 
 ## Attributes ## {#attributes}
 


### PR DESCRIPTION
This PR does not alter any behavior and introduces (beneficially) verbose wording and Infra reuse to help anticipated i18n https://github.com/w3c/i18n-activity/issues/1501 and https://github.com/w3c/i18n-activity/issues/1508 and https://github.com/w3c/i18n-activity/issues/1509 and https://github.com/w3c/i18n-activity/issues/1510 feedback.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mehmetoguzderin/gpuweb/pull/2767.html" title="Last updated on Apr 20, 2022, 7:54 PM UTC (4c4c20a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2767/cbfa42b...mehmetoguzderin:4c4c20a.html" title="Last updated on Apr 20, 2022, 7:54 PM UTC (4c4c20a)">Diff</a>