### PR TITLE
Move preferred format queries to navigator.gpu

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1640,7 +1640,13 @@ interface GPU {
 
     : <dfn>getPreferredCanvasFormat()</dfn>
     ::
-        Returns an optimal {{GPUTextureFormat}} to use for {{GPUCanvasContext}}s on this system.
+        Returns an optimal {{GPUTextureFormat}} to use when calling
+        {{GPUCanvasContext/configure()}} on a {{GPUCanvasContext}}, for displaying
+        8-bit depth, standard dynamic range content to the screen: either
+        {{GPUTextureFormat/"rgba8unorm"}} or {{GPUTextureFormat/"bgra8unorm"}}.
+
+        Canvases which are not displayed to the screen may or may not benefit from
+        using this format.
 
         <div algorithm="GPU.getPreferredCanvasFormat">
             **Called on:** {{GPU}} this.
@@ -1648,9 +1654,8 @@ interface GPU {
             **Returns:** {{GPUTextureFormat}}
 
             <div class=content-timeline>
-                1. Return an optimal {{GPUTextureFormat}} to use when calling
-                    {{GPUCanvasContext/configure()}} on a {{GPUCanvasContext}} on this system. Must
-                    be one of the [=supported context formats=].
+                1. Out of {{GPUTextureFormat/"rgba8unorm"}} and {{GPUTextureFormat/"bgra8unorm"}},
+                    return the format which is optimal for displaying WebGPU canvases on this system.
             </div>
         </div>
 </dl>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1596,6 +1596,7 @@ WorkerNavigator includes NavigatorGPU;
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPU {
     Promise<GPUAdapter?> requestAdapter(optional GPURequestAdapterOptions options = {});
+    GPUTextureFormat getPreferredCanvasFormat();
 };
 </script>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1640,13 +1640,16 @@ interface GPU {
 
     : <dfn>getPreferredCanvasFormat()</dfn>
     ::
-        Returns an optimal {{GPUTextureFormat}} to use when calling
-        {{GPUCanvasContext/configure()}} on a {{GPUCanvasContext}}, for displaying
-        8-bit depth, standard dynamic range content to the screen: either
-        {{GPUTextureFormat/"rgba8unorm"}} or {{GPUTextureFormat/"bgra8unorm"}}.
+        Returns an optimal {{GPUTextureFormat}} for displaying 8-bit depth, standard dynamic range
+        content on this system. Must only return {{GPUTextureFormat/"rgba8unorm"}} or
+        {{GPUTextureFormat/"bgra8unorm"}}.
 
-        Canvases which are not displayed to the screen may or may not benefit from
-        using this format.
+        The returned value can be passed as the {{GPUCanvasConfiguration/format}} to
+        {{GPUCanvasContext/configure()}} calls on a {{GPUCanvasContext}} to ensure the associated
+        canvas is able to display its contents efficiently.
+
+        Note: Canvases which are not displayed to the screen may or may not benefit from using this
+        format.
 
         <div algorithm="GPU.getPreferredCanvasFormat">
             **Called on:** {{GPU}} this.
@@ -1654,8 +1657,9 @@ interface GPU {
             **Returns:** {{GPUTextureFormat}}
 
             <div class=content-timeline>
-                1. Out of {{GPUTextureFormat/"rgba8unorm"}} and {{GPUTextureFormat/"bgra8unorm"}},
-                    return the format which is optimal for displaying WebGPU canvases on this system.
+                1. Return either {{GPUTextureFormat/"rgba8unorm"}} or
+                    {{GPUTextureFormat/"bgra8unorm"}}, depending on which format is optimal for
+                    displaying WebGPU canvases on this system.
             </div>
         </div>
 </dl>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1791,6 +1791,7 @@ interface GPUAdapter {
     readonly attribute boolean isFallbackAdapter;
 
     Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor = {});
+    GPUTextureFormat getPreferredContextFormat();
 };
 </script>
 
@@ -1894,6 +1895,23 @@ interface GPUAdapter {
                 </div>
             1. Return |promise|.
 
+        </div>
+
+    : <dfn>getPreferredContextFormat()</dfn>
+    ::
+        Returns an optimal {{GPUTextureFormat}} to use for {{GPUCanvasContext}}s with devices
+        created from this adapter.
+
+        <div algorithm="GPUCanvasContext.getPreferredContextFormat">
+            **Called on:** {{GPUAdapter}} |this|.
+
+            **Returns:** {{GPUTextureFormat}}
+
+            <div class=content-timeline>
+                1. Return an optimal {{GPUTextureFormat}} to use when calling
+                    {{GPUCanvasContext/configure()}} on a {{GPUCanvasContext}} with a {{GPUDevice}}
+                    created by |this|. Must be one of the [=supported context formats=].
+            </div>
         </div>
 </dl>
 
@@ -9482,7 +9500,6 @@ interface GPUCanvasContext {
     undefined configure(GPUCanvasConfiguration configuration);
     undefined unconfigure();
 
-    GPUTextureFormat getPreferredFormat(GPUAdapter adapter);
     GPUTexture getCurrentTexture();
 };
 </script>
@@ -9588,27 +9605,6 @@ interface GPUCanvasContext {
             1. If |this|.{{GPUCanvasContext/[[currentTexture]]}} is not `null` call
                 {{GPUTexture/destroy()}} on |this|.{{GPUCanvasContext/[[currentTexture]]}}.
             1. Set |this|.{{GPUCanvasContext/[[currentTexture]]}} to `null`.
-        </div>
-
-    : <dfn>getPreferredFormat(adapter)</dfn>
-    ::
-        Returns an optimal {{GPUTextureFormat}} to use with this context and devices created from
-        the given adapter.
-
-        <div algorithm="GPUCanvasContext.getPreferredFormat">
-            **Called on:** {{GPUCanvasContext}} this.
-
-            **Arguments:**
-            <pre class=argumentdef for="GPUCanvasContext/getPreferredFormat(adapter)">
-                |adapter|: Adapter the format should be queried for.
-            </pre>
-
-            **Returns:** {{GPUTextureFormat}}
-
-            <div class=content-timeline>
-                1. Return an optimal {{GPUTextureFormat}} to use when calling {{GPUCanvasContext/configure()}}
-                    with the given |adapter|. Must be one of the [=supported context formats=].
-            </div>
         </div>
 
     : <dfn>getCurrentTexture()</dfn>
@@ -9755,7 +9751,7 @@ dictionary GPUCanvasConfiguration {
 
         context.configure({
             device: gpuDevice,
-            format: context.getPreferredFormat(gpuAdapter),
+            format: gpuAdapter.getPreferredContextFormat(),
         });
     </pre>
 </div>
@@ -9808,7 +9804,7 @@ must be reconfigured by calling {{GPUCanvasContext/configure()}} again with the 
                 if (entry.target != canvas) { continue; }
                 context.configure({
                     device: gpuDevice,
-                    format: context.getPreferredFormat(gpuAdapter),
+                    format: gpuAdapter.getPreferredContextFormat(),
                     size: {
                         // This reports the size of the canvas element in pixels
                         width: entry.devicePixelContentBoxSize[0].inlineSize,

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1637,6 +1637,22 @@ interface GPU {
             <!-- If we add ways to make invalid adapter requests (aside from those
                  that violate IDL rules), specify that they reject the promise. -->
         </div>
+
+    : <dfn>getPreferredCanvasFormat()</dfn>
+    ::
+        Returns an optimal {{GPUTextureFormat}} to use for {{GPUCanvasContext}}s on this system.
+
+        <div algorithm="GPU.getPreferredCanvasFormat">
+            **Called on:** {{GPU}} this.
+
+            **Returns:** {{GPUTextureFormat}}
+
+            <div class=content-timeline>
+                1. Return an optimal {{GPUTextureFormat}} to use when calling
+                    {{GPUCanvasContext/configure()}} on a {{GPUCanvasContext}} on this system. Must
+                    be one of the [=supported context formats=].
+            </div>
+        </div>
 </dl>
 
 {{GPU}} has the following internal slots:
@@ -1791,7 +1807,6 @@ interface GPUAdapter {
     readonly attribute boolean isFallbackAdapter;
 
     Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor = {});
-    GPUTextureFormat getPreferredContextFormat();
 };
 </script>
 
@@ -1895,23 +1910,6 @@ interface GPUAdapter {
                 </div>
             1. Return |promise|.
 
-        </div>
-
-    : <dfn>getPreferredContextFormat()</dfn>
-    ::
-        Returns an optimal {{GPUTextureFormat}} to use for {{GPUCanvasContext}}s with devices
-        created from this adapter.
-
-        <div algorithm="GPUCanvasContext.getPreferredContextFormat">
-            **Called on:** {{GPUAdapter}} |this|.
-
-            **Returns:** {{GPUTextureFormat}}
-
-            <div class=content-timeline>
-                1. Return an optimal {{GPUTextureFormat}} to use when calling
-                    {{GPUCanvasContext/configure()}} on a {{GPUCanvasContext}} with a {{GPUDevice}}
-                    created by |this|. Must be one of the [=supported context formats=].
-            </div>
         </div>
 </dl>
 
@@ -9747,11 +9745,11 @@ dictionary GPUCanvasConfiguration {
     format for this context:
     <pre highlight="js">
         const canvas = document.createElement('canvas');
-        const context =  canvas.getContext('webgpu');
+        const context = canvas.getContext('webgpu');
 
         context.configure({
             device: gpuDevice,
-            format: gpuAdapter.getPreferredContextFormat(),
+            format: navigator.gpu.getPreferredCanvasFormat(),
         });
     </pre>
 </div>
@@ -9804,7 +9802,7 @@ must be reconfigured by calling {{GPUCanvasContext/configure()}} again with the 
                 if (entry.target != canvas) { continue; }
                 context.configure({
                     device: gpuDevice,
-                    format: gpuAdapter.getPreferredContextFormat(),
+                    format: navigator.gpu.getPreferredCanvasFormat(),
                     size: {
                         // This reports the size of the canvas element in pixels
                         width: entry.devicePixelContentBoxSize[0].inlineSize,


### PR DESCRIPTION
Fixes #2747
(Assumes that the resolution proposed in #2747 is adopted by the group.)

Removes the need to have a canvas context in order to query a
preferred format. This should help put developers at ease that they
don't need to rebuild all their pipelines when rendering to
multiple canvases.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/2771.html" title="Last updated on May 16, 2022, 9:00 PM UTC (f36a1f0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2771/cbfa42b...f36a1f0.html" title="Last updated on May 16, 2022, 9:00 PM UTC (f36a1f0)">Diff</a>