### PR TITLE
Clarify conversions: floating, and out-of-range AbstractInt

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8638,7 +8638,7 @@ When converting a value to a floating point type:
 * If the original value is exactly representable in the destination type, then the result is that value.
     * Additionally, if the original value is zero and of integral type, then the resulting value has a zero sign bit.
 * Otherwise, the original value is not exactly representable.
-    * If the original value is different from but lies between two adjacent values representable in the destination type,
+    * If the original value is different from but lies between two adjacent finite values representable in the destination type,
          then the result is one of those two values.
          WGSL does not specify whether the larger or smaller representable
          value is chosen, and different instances of such a conversion may choose differently.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1201,7 +1201,7 @@ Note: When no conversion is performed, the conversion rank is zero.
     <tr><th>Src
         <th>Dest
         <th>ConversionRank(Src,Dest)
-        <th>Notes
+        <th>Description
   </thead>
   <tr algorithm="conversion rank identity">
       <td>|T|
@@ -1217,27 +1217,29 @@ Note: When no conversion is performed, the conversion rank is zero.
       <td>[=AbstractFloat=]
       <td>f32
       <td>1
-      <td>
+      <td>See [[#floating-point-conversion]]
   <tr algorithm="conversion rank abstract float to f16">
       <td>[=AbstractFloat=]
       <td>f16
       <td>2
-      <td>
+      <td>See [[#floating-point-conversion]]
   <tr algorithm="conversion rank abstract int to i32">
       <td>[=AbstractInt=]
       <td>i32
       <td>3
-      <td>
+      <td>Identity if the value is in [=i32=].
+          Produces a [=shader-creation error=] otherwise.
   <tr algorithm="conversion rank abstract int to u32">
       <td>[=AbstractInt=]
       <td>u32
       <td>4
-      <td>
+      <td>Identity if the value is in [=u32=].
+          Produces a [=shader-creation error=] otherwise.
   <tr algorithm="conversion rank abstract int to abstract float">
       <td>[=AbstractInt=]
       <td>[=AbstractFloat=]
       <td>5
-      <td>
+      <td>See [[#floating-point-conversion]]
   <tr algorithm="conversion rank abstract int to f32">
       <td>[=AbstractInt=]
       <td>f32
@@ -8634,19 +8636,19 @@ Therefore the maximum u32 value resulting from a floating point conversion is 42
 
 When converting a value to a floating point type:
 * If the original value is exactly representable in the destination type, then the result is that value.
-    * If the original value is zero and of integral type, then the resulting value has a zero sign bit.
+    * Additionally, if the original value is zero and of integral type, then the resulting value has a zero sign bit.
 * Otherwise, the original value is not exactly representable.
     * If the original value is different from but lies between two adjacent values representable in the destination type,
          then the result is one of those two values.
          WGSL does not specify whether the larger or smaller representable
          value is chosen, and different instances of such a conversion may choose differently.
-    * Otherwise, if the original value lies outside the range of the destination type.
-         * This does not occur when the original types is one of [=i32=] or [=u32=] and the destination type is [=f32=].
-         * This does not occur when the source type is a floating point type with fewer exponent and mantissa bits.
-         * If the source type is a floating point type with more mantissa bits than the destination type, then:
-             * The extra mantissa bits of the source value may be discarded (treated as if they are 0).
-                 * If the resulting value is the maximum normal value of the destination type, then that is the result.
-             * Otherwise the result is the infinity value with the same sign as the source value.
+    * Otherwise, the original value lies outside the finite range of the destination type. The conversion proceeds as follows:
+         1. Set |X| to the original value.
+         2. If the source type is a floating point type with more mantissa bits than the destination type,
+             the extra mantissa bits of the source value *may* be discarded (i.e. treated as if they are 0).
+             Update |X| accordingly.
+         3. If |X| is the most-positive or most-negative normal value of the destination type, then the result is |X|.
+         4. Otherwise, the result is the infinity value of the destination type, with the same sign as |X|.
     * Otherwise, if the original value is a NaN for the source type, then the result is a NaN in the destination type.
 
 NOTE: An integer value may lie between two adjacent representable floating point values.
@@ -8656,6 +8658,12 @@ the set of fractional bits together with an extra 1-bit at the most significant 
 Then, for example, integers 2<sup>28</sup> and 1+2<sup>28</sup> both map to the same floating point value: the difference in the
 least significant 1 bit is not representable by the floating point format.
 This kind of collision occurs for pairs of adjacent integers with a magnitude of at least 2<sup>25</sup>.
+
+Note: The original value is always within range of the destination type when
+the original type is one of [=i32=] or [=u32=] and the destination type is [=f32=].
+
+Note: The original value is always within range of the destination type when
+the source type is a floating point type with fewer exponent and mantissa bits than the target floating point type.
 
 Issue: Check behaviour of the f32 to f16 conversion for numbers just beyond the max normal f16 values.
 I've written what an NVIDIA GPU does.  See https://github.com/google/amber/pull/918 for an executable test case.


### PR DESCRIPTION
Conversion Rank table:
* Last column is now "Description", not "Notes". So it's more clearly normative.
* AbstractInt to scalar integral conversions says it's identity when value is in
  range of the target type, and shader-creation error otherwise.
* Reference floating point conversion section where needed.

Floating point conversion
* Rewrite the "out of taget range" clauses as a procedure.
  This allows us to cleanly handle:
    - optional truncation of mantissa bits
    - the case where the source type is integral. This can occur now
      with i32 or u32 as source type and f16 as target type (whose max
      normal value is 65504).

Fixes: #2769