### PR TITLE
Adjust pipeline fragment output validation rules

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5852,8 +5852,8 @@ dictionary GPUFragmentState : GPUProgrammableStage {
                 in the |descriptor|.{{GPUFragmentState/targets}} list:
                 - The [=pipeline output=] type must be compatible with |colorState|.{{GPUColorTargetState/format}}.
 
-                Otherwise:
-                - |colorState|.{{GPUColorTargetState/writeMask}} must be 0.
+                Otherwise, if |colorState|.{{GPUColorTargetState/writeMask}} is 0:
+                - |colorState|.{{GPUColorTargetState/format}} can be `null` instead.
 </div>
 
 Note:


### PR DESCRIPTION
context:
https://github.com/gpuweb/gpuweb/pull/1918#issuecomment-1102940792

The original intent of the PR was to make it valid for the fragment stage have extra outputs, thus we can narrow down the validation rule to only allow color state format to be `null`, when the writeMask is 0.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shrekshao/gpuweb/pull/2775.html" title="Last updated on Apr 19, 2022, 8:58 PM UTC (bfb432d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2775/468a957...shrekshao:bfb432d.html" title="Last updated on Apr 19, 2022, 8:58 PM UTC (bfb432d)">Diff</a>