### PR TITLE
Make blankspaces a section

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -386,11 +386,31 @@ and to encourage interoperability among tools.
 WGSL program text consists of a sequence of Unicode [=code points=], grouped into contiguous non-empty sets forming:
 * [=comments=]
 * [=tokens=]
-* [=blankspace=]
+* [=blankspaces=]
 
 The program text must not include a null code point (`U+0000`).
 
-<dfn>Blankspace</dfn> is any combination of one or more of code points from
+To parse a WGSL program:
+1. Remove comments:
+    * Replace the first comment with a space code point (`U+0020`).
+    * Repeat until no comments remain.
+2. Scanning from beginning to end, group the remaining code points into tokens and blankspace
+    in greedy fashion:
+    * The next group is formed from the longest
+        non-empty prefix of the remaining ungrouped code points, that is either:
+        * a valid token, or
+        * blankspace
+    * Repeat until no ungrouped code points remain.
+3. Discard the blankspace, leaving only tokens.
+4. Parse the token sequence, attempting to match the [=syntax/translation_unit=] grammar rule.
+
+A [=shader-creation error=] results if:
+* the entire source text cannot be converted into a finite sequence of valid tokens, or
+* the [=syntax/translation_unit=] grammar rule does not match the entire token sequence.
+
+## Blankspaces ## {#blankspaces}
+
+A <dfn>blankspace</dfn> is any combination of one or more of code points from
 [=Unicode Standard Annex #31 for Unicode Version 14.0.0|Pattern_White_Space=] property.
 Following is the set of code points in [=Unicode Standard Annex #31 for Unicode Version 14.0.0|Pattern_White_Space=]:
 * space (`U+0020`)
@@ -410,24 +430,6 @@ Following is the set of code points in [=Unicode Standard Annex #31 for Unicode 
 
     | `/[\u0020\u0009\u000a\u000b\u000c\u000d\u0085\u200e\u200f\u2028\u2029]/uy`
 </div>
-
-To parse a WGSL program:
-1. Remove comments:
-    * Replace the first comment with a space code point (`U+0020`).
-    * Repeat until no comments remain.
-2. Scanning from beginning to end, group the remaining code points into tokens and blankspace
-    in greedy fashion:
-    * The next group is formed from the longest
-        non-empty prefix of the remaining ungrouped code points, that is either:
-        * a valid token, or
-        * blankspace
-    * Repeat until no ungrouped code points remain.
-3. Discard the blankspace, leaving only tokens.
-4. Parse the token sequence, attempting to match the [=syntax/translation_unit=] grammar rule.
-
-A [=shader-creation error=] results if:
-* the entire source text cannot be converted into a finite sequence of valid tokens, or
-* the [=syntax/translation_unit=] grammar rule does not match the entire token sequence.
 
 ## Comments ## {#comments}
 


### PR DESCRIPTION
With recent changes, blankspaces in WGSL contain more prose to them. This growth makes the reading experience at the start of Textual Structure a bit interrupted by the exact definition of blankspaces, where other items are in their sections, and when scrolling, blankspaces are harder to catch this way. At the same time, most language specs we mention during our discussions do have a dedicated blankspace section, making the sectioning of the spec more comparable.