### PR TITLE
Adjust line-ending comment for unicode line break recommendations

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -134,6 +134,11 @@ spec: Vulkan ; urlPrefix: https://www.khronos.org/registry/vulkan/specs/1.2-exte
         text: memory model scope; url:memory-model-scope
         text: memory model memory semantics; url:memory-model-memory-semantics
         text: memory model non-private; url: memory-model-non-private
+spec: UAX14; urlPrefix: https://www.unicode.org/reports/tr14
+    type: dfn
+        text: UAX14 Section 6.1 Non-tailorable Line Breaking Rules; url: BreakingRules
+        text: UAX14 LB4; url: LB4
+        text: UAX14 LB5; url: LB5
 spec: UAX15; urlPrefix: https://www.unicode.org/reports/tr15/tr15-51.html
     type: dfn
         text: Unicode Standard Annex #15 for Unicode Version 14.0.0
@@ -390,11 +395,13 @@ WGSL program text consists of a sequence of Unicode [=code points=], grouped int
 
 The program text must not include a null code point (`U+0000`).
 
+## Parsing ## {#parsing}
+
 To parse a WGSL program:
-1. Remove comments:
+1. Remove [=comments=]:
     * Replace the first comment with a space code point (`U+0020`).
     * Repeat until no comments remain.
-2. Scanning from beginning to end, group the remaining code points into tokens and blankspace
+2. Scanning from beginning to end, group the remaining code points into [=tokens=] and [=blankspace=]
     in greedy fashion:
     * The next group is formed from the longest
         non-empty prefix of the remaining ungrouped code points, that is either:
@@ -408,11 +415,11 @@ A [=shader-creation error=] results if:
 * the entire source text cannot be converted into a finite sequence of valid tokens, or
 * the [=syntax/translation_unit=] grammar rule does not match the entire token sequence.
 
-## Blankspaces ## {#blankspaces}
+## Blankspace and line breaks ## {#blankspace-and-line-breaks}
 
-A <dfn>blankspace</dfn> is any combination of one or more of code points from
+<dfn>Blankspace</dfn> is any combination of one or more of code points from the Unicode
 [=Unicode Standard Annex #31 for Unicode Version 14.0.0|Pattern_White_Space=] property.
-Following is the set of code points in [=Unicode Standard Annex #31 for Unicode Version 14.0.0|Pattern_White_Space=]:
+The following is the set of code points in [=Unicode Standard Annex #31 for Unicode Version 14.0.0|Pattern_White_Space=]:
 * space (`U+0020`)
 * horizontal tab (`U+0009`)
 * line feed (`U+000A`)
@@ -431,6 +438,22 @@ Following is the set of code points in [=Unicode Standard Annex #31 for Unicode 
     | `/[\u0020\u0009\u000a\u000b\u000c\u000d\u0085\u200e\u200f\u2028\u2029]/uy`
 </div>
 
+A <dfn>line break</dfn> is a contiguous sequence of [=blankspace=] code points indicating the end of a line.
+It is defined as the blankspace signalling a "mandatory break" as defined by
+[=UAX14 Section 6.1 Non-tailorable Line Breaking Rules=] [=UAX14 LB4|LB4=] and [=UAX14 LB5|LB5=].
+That is, a line break is any of:
+* line feed (`U+000A`)
+* vertical tab (`U+000B`)
+* form feed (`U+000C`)
+* carriage return (`U+000D`) when not also followed by line feed (`U+000A`)
+* carriage return (`U+000D`) followed by line feed (`U+000A`)
+* next line (`U+0085`)
+* line separator (`U+2028`)
+* paragraph separator (`U+2029`)
+
+Note: Diagnostics that report source text locations in terms of line numbers should use [=line breaks=] to
+count lines.
+
 ## Comments ## {#comments}
 
 A <dfn>comment</dfn> is a span of text that does not influence the validity or meaning of a WGSL
@@ -440,8 +463,7 @@ Shader authors can use comments to document their programs.
 A <dfn noexport>line-ending comment</dfn> is a kind of [=comment=] consisting
 of the two code points `//` (`U+002F` followed by `U+002F`) and the code points that follow,
 up until but not including:
-* the next [=blankspace=] code point other than a space (`U+0020`), a horizontal tab (`U+0009`),
-    a left-to-right mark (`U+200E`) or a right-to-left mark (`U+200F`), or
+* the next [=line break=], or
 * the end of the program.
 
 A <dfn noexport>block comment</dfn> is a kind of [=comment=] consisting of:


### PR DESCRIPTION
Define "line break" as the blankspace that signals a mandatory line
break as in UAX14 Line Breaking Algorithm.

Also, make "Parsing" its own section and add links to forward concepts
"comments" and "tokens"

Fixes: #2758