### PR TITLE
[wgsl] Add some assert tags to the spec

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -388,7 +388,7 @@ WGSL program text consists of a sequence of Unicode [=code points=], grouped int
 * [=tokens=]
 * [=blankspaces=]
 
-The program text must not include a null code point (`U+0000`).
+<assert>The program text must not include a null code point (`U+0000`).</assert>
 
 To parse a WGSL program:
 1. Remove comments:
@@ -405,13 +405,15 @@ To parse a WGSL program:
 4. Parse the token sequence, attempting to match the [=syntax/translation_unit=] grammar rule.
 
 A [=shader-creation error=] results if:
-* the entire source text cannot be converted into a finite sequence of valid tokens, or
-* the [=syntax/translation_unit=] grammar rule does not match the entire token sequence.
+* <assert>the entire source text cannot be converted into a finite sequence of valid tokens</assert>, or
+* <assert>the [=syntax/translation_unit=] grammar rule does not match the entire token sequence.</assert>
 
 ## Blankspaces ## {#blankspaces}
 
 A <dfn>blankspace</dfn> is any combination of one or more of code points from
 [=Unicode Standard Annex #31 for Unicode Version 14.0.0|Pattern_White_Space=] property.
+
+<assert>
 Following is the set of code points in [=Unicode Standard Annex #31 for Unicode Version 14.0.0|Pattern_White_Space=]:
 * space (`U+0020`)
 * horizontal tab (`U+0009`)
@@ -425,11 +427,15 @@ Following is the set of code points in [=Unicode Standard Annex #31 for Unicode 
 * line separator (`U+2028`)
 * paragraph separator (`U+2029`)
 
+</assert>
+
+<assert>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>_blankspace</dfn> :
 
     | `/[\u0020\u0009\u000a\u000b\u000c\u000d\u0085\u200e\u200f\u2028\u2029]/uy`
 </div>
+</assert>
 
 ## Comments ## {#comments}
 
@@ -437,6 +443,7 @@ A <dfn>comment</dfn> is a span of text that does not influence the validity or m
 program, except that a comment can separate [=tokens=].
 Shader authors can use comments to document their programs.
 
+<assert>
 A <dfn noexport>line-ending comment</dfn> is a kind of [=comment=] consisting
 of the two code points `//` (`U+002F` followed by `U+002F`) and the code points that follow,
 up until but not including:
@@ -444,6 +451,9 @@ up until but not including:
     a left-to-right mark (`U+200E`) or a right-to-left mark (`U+200F`), or
 * the end of the program.
 
+</assert>
+
+<assert>
 A <dfn noexport>block comment</dfn> is a kind of [=comment=] consisting of:
 * The two code points `/*` (`U+002F` followed by `U+002A`)
 * Then any sequence of:
@@ -452,7 +462,9 @@ A <dfn noexport>block comment</dfn> is a kind of [=comment=] consisting of:
         or `/*` (`U+002F` followed by `U+002A`)
 * Then the two code points `*/` (`U+002A` followed by `U+002F`)
 
-Note: Block comments can be nested.
+</assert>
+
+Note: <assert>Block comments can be nested.</assert>
 Since a block comment requires matching start and end text sequences, and allows arbitrary nesting,
 a block comment cannot be recognized with a regular expression.
 This is a consequence of the Pumping Lemma for Regular Languages.
@@ -481,7 +493,7 @@ A <dfn>token</dfn> is a contiguous sequence of code points forming one of:
 ## Literals ## {#literals}
 
 A <dfn>literal</dfn> is one of:
-* A <dfn noexport>boolean literal</dfn>: either `true` or `false`.
+* <assert>A <dfn noexport>boolean literal</dfn>: either `true` or `false`.</assert>
 * A <dfn>numeric literal</dfn>: either an [=integer literal=] or a [=floating point literal=],
     and is used to represent a number.
 
@@ -502,12 +514,15 @@ A <dfn>literal</dfn> is one of:
 
 The form of a [=numeric literal=] is defined via pattern-matching.
 
+<assert>
 An <dfn>integer literal</dfn> is:
 * An integer specified as any of:
     * `0`
     * A sequence of decimal digits, where the first digit is not `0`.
     * `0x` or `0X` followed by a sequence of hexadecimal digits.
 * Then an optional `i` or `u` suffix.
+
+</assert>
 
 <div class='example wgsl int-literals' heading='integer literals'>
   <xmp highlight='rust'>
@@ -529,6 +544,8 @@ An <dfn>integer literal</dfn> is:
 
 A <dfn>floating point literal</dfn> is either a [=decimal floating point literal=]
 or a [=hexadecimal floating point literal=].
+
+<assert>
 * A <dfn noexport>decimal floating point literal</dfn> is:
     * A mantissa, specified as a sequence of digits, with an optional decimal point (`.`) somewhere among them.
     * Then an optional exponent suffix consisting of:
@@ -540,6 +557,9 @@ or a [=hexadecimal floating point literal=].
     * The value of the literal is the value of the mantissa multiplied by 10 to the power of the exponent.
          When no exponent is specified, an exponent of 0 is assumed.
 
+</assert>
+
+<assert>
 * A <dfn noexport>hexadecimal floating point literal</dfn> is:
     * A `0x` or `0X` prefix
     * Then a mantissa, specified as a sequence of hexadecimal digits, with an optional hexadecimal point (`.`) somewhere among them.
@@ -551,6 +571,8 @@ or a [=hexadecimal floating point literal=].
          If neither are, then the token is instead an [=integer literal=].
     * The value of the literal is the value of the mantissa multiplied by 2 to the power of the exponent.
          When no exponent is specified, an exponent of 0 is assumed.
+
+</assert>
 
 <div class='example wgsl float-literals' heading='floating point literals'>
   <xmp highlight='rust'>
@@ -618,10 +640,10 @@ Otherwise, the literal denotes a value one of the [=abstract numeric types=] def
 </table>
 
 A [=shader-creation error=] results if:
-* An [=integer literal=] with a `i` or `u` suffix cannot be represented by the target type.
-* A [=hexadecimal floating point literal=] with a `f` or `h` suffix overflows or cannot be exactly represented by the target type.
-* A [=decimal floating point literal=] with a `f` or `h` suffix overflows the target type.
-* A [=floating point literal=] with a `h` suffix is used while the [=extension/f16|f16 extension=] is not enabled.
+* <assert>An [=integer literal=] with a `i` or `u` suffix cannot be represented by the target type.</assert>
+* <assert>A [=hexadecimal floating point literal=] with a `f` or `h` suffix overflows or cannot be exactly represented by the target type.</assert>
+* <assert>A [=decimal floating point literal=] with a `f` or `h` suffix overflows the target type.</assert>
+* <assert>A [=floating point literal=] with a `h` suffix is used while the [=extension/f16|f16 extension=] is not enabled.</assert>
 
 Note: The hexadecimal float value 0x1.00000001p0 requires 33 mantissa bits to be represented exactly,
 but [=f32=] only has 23 explicit mantissa bits.


### PR DESCRIPTION
This PR starts adding `assert` tags into the WGSL spec. The `assert` tag
is process by bikeshed which takes the text inside the `assert` and
generates a unique hash. The `assert` is then replaced by `span
id=assert-<hash>`. The hash will only change if the text inside the
`assert` tag changes.

This then allows tools to identify assertions in the text, and link to
them if desired.