### PR TITLE
Clarify type and use case for object labels

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -626,7 +626,7 @@ Any interface which includes {{GPUObjectBase}} is a [=WebGPU interface=].
 
 <script type=idl>
 interface mixin GPUObjectBase {
-    attribute (USVString or undefined) label;
+    attribute USVString label;
 };
 </script>
 
@@ -635,12 +635,15 @@ interface mixin GPUObjectBase {
 <dl dfn-type=attribute dfn-for=GPUObjectBase>
     : <dfn>label</dfn>
     ::
-        A label which can be used by development tools (such as error/warning messages,
-        browser developer tools, or platform debugging utilities) to identify the underlying
-        [=internal object=] to the developer.
-        It has no specified format, and therefore cannot be reliably machine-parsed.
+        Initially the empty string.
 
-        In any given situation, the user agent may or may not choose to use this label.
+        A developer-provided label which can be used by the browser, OS, or other tools to help
+        identify the underlying [=internal object=] to the developer. Examples include displaying
+        the label in error/warning messages, browser developer tools, and platform debugging
+        utilities. The user agent is free to choose if and how it will use this label.
+
+        Note: {{GPUObjectBase/label}} is defined as a {{USVString}} because some user agents may
+        supply it to the debug facilities of the underlying native APIs.
 </dl>
 
 {{GPUObjectBase}} has the following internal slots:


### PR DESCRIPTION
Addresses part of #2633.

There were some concerns about the type (USVString or undefined) being
unusual for the web platform, so replaced it with simply USVString and
indicate that it defaults to empty string. Also added a note to explain
why USVString was used in favor of DOMString.

Additionally, there was some confusion about whether or not the label
was supplied by the browser or the developer and how it was used. Tried
to clarify the text to indicate that the label is developer-provided and
emphasize some possible use cases.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/2784.html" title="Last updated on Apr 21, 2022, 3:07 AM UTC (584e3b5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2784/7863716...584e3b5.html" title="Last updated on Apr 21, 2022, 3:07 AM UTC (584e3b5)">Diff</a>