### PR TITLE
Require RENDER_ATTACHMENT usage when creating multisampled textures

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2776,7 +2776,8 @@ namespace GPUTextureUsage {
                                 - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be 1.
                                 - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be 1.
                                 - |descriptor|.{{GPUTextureDescriptor/usage}} must not include the {{GPUTextureUsage/STORAGE_BINDING}} bit.
-                                - |descriptor|.{{GPUTextureDescriptor/format}} must be a [=renderable format=] and support multisampling according to [[#texture-format-caps]].
+                                - |descriptor|.{{GPUTextureDescriptor/usage}} must include the {{GPUTextureUsage/RENDER_ATTACHMENT}} bit.
+                                - |descriptor|.{{GPUTextureDescriptor/format}} must support multisampling according to [[#texture-format-caps]].
 
                             - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be less than or equal to
                                 [$maximum mipLevel count$](|descriptor|.{{GPUTextureDescriptor/dimension}}, |descriptor|.{{GPUTextureDescriptor/size}}).


### PR DESCRIPTION
This patch requires the RENDER_ATTACHMENT usage when creating a
texture with sampleCount > 1 because
1. Such textures are useless.
2. Such textures cannot be initialized to 0.

fixes: #2465


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Jiawei-Shao/gpuweb/pull/2786.html" title="Last updated on Apr 25, 2022, 8:11 AM UTC (66e57c3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2786/e303907...Jiawei-Shao:66e57c3.html" title="Last updated on Apr 25, 2022, 8:11 AM UTC (66e57c3)">Diff</a>