### PR TITLE
Allow creation-time expression in case seletors; Add missings `@const`s

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -11004,7 +11004,7 @@ struct __modf_result_vecN_f16 {
     <td>Returns the determinant of |e|.
   <tr algorithm="transpose">
     <td>|T| is AbstractFloat, f32, or f16
-    <td class="nowrap"`@const fn`<br>>`transpose(`|e|`:` mat|R|x|C|<|T|> `) -> ` mat|C|x|R|<|T|>
+    <td class="nowrap"`@const fn`<br>`transpose(`|e|`:` mat|R|x|C|<|T|> `) -> ` mat|C|x|R|<|T|>
     <td>Returns the transpose of |e|.
 </table>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6099,7 +6099,7 @@ An `if` statement is executed as follows:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>case_selectors</dfn> :
 
-    | [=syntax/const_literal=] ( [=syntax/comma=] [=syntax/const_literal=] ) * [=syntax/comma=] ?
+    | [=syntax/expression=] ( [=syntax/comma=] [=syntax/expression=] ) * [=syntax/comma=] ?
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>case_compound_statement</dfn> :
@@ -6117,6 +6117,8 @@ depending on the evaluation of a selector expression.
 
 If the selector value equals a value in a case selector list, then control is transferred to
 the body of that case clause.
+The expressions in the [=syntax/case_selectors=] [=shader-creation error|must=]
+be [=creation-time expressions=].
 If the selector value does not equal any of the case selector values, then control is
 transferred to the `default` clause.
 
@@ -10432,7 +10434,7 @@ See [[#function-calls]].
 
   <tr algorithm="clamp">
     <td>|T| is [ALLFLOATING]
-    <td class="nowrap">`clamp(`|e|`:` |T| `,` |low|`:` |T| `,` |high|`:` |T|`) -> ` |T|
+    <td class="nowrap">`@const fn`<br>`clamp(`|e|`:` |T| `,` |low|`:` |T| `,` |high|`:` |T|`) -> ` |T|
     <td>Returns either `min(max(`|e|`,`|low|`),`|high|`)`, or the median of the three values |e|, |low|, |high|.
     [=Component-wise=] when |T| is a vector.
 
@@ -10998,11 +11000,11 @@ struct __modf_result_vecN_f16 {
   </thead>
   <tr algorithm="determinant">
     <td>|T| is AbstractFloat, f32, or f16
-    <td class="nowrap">`determinant(`|e|`:` mat|C|x|C|<|T|> `) -> ` |T|
+    <td class="nowrap">`@const fn`<br>`determinant(`|e|`:` mat|C|x|C|<|T|> `) -> ` |T|
     <td>Returns the determinant of |e|.
   <tr algorithm="transpose">
     <td>|T| is AbstractFloat, f32, or f16
-    <td class="nowrap">`transpose(`|e|`:` mat|R|x|C|<|T|> `) -> ` mat|C|x|R|<|T|>
+    <td class="nowrap"`@const fn`<br>>`transpose(`|e|`:` mat|R|x|C|<|T|> `) -> ` mat|C|x|R|<|T|>
     <td>Returns the transpose of |e|.
 </table>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -11004,7 +11004,7 @@ struct __modf_result_vecN_f16 {
     <td>Returns the determinant of |e|.
   <tr algorithm="transpose">
     <td>|T| is AbstractFloat, f32, or f16
-    <td class="nowrap"`@const fn`<br>`transpose(`|e|`:` mat|R|x|C|<|T|> `) -> ` mat|C|x|R|<|T|>
+    <td class="nowrap">`@const fn`<br>`transpose(`|e|`:` mat|R|x|C|<|T|> `) -> ` mat|C|x|R|<|T|>
     <td>Returns the transpose of |e|.
 </table>
 


### PR DESCRIPTION
Fixes #2764
Fixes #2787

* Allow switch statement case selectors to be creation-time expressions
* Add missing `@const` qualification to clamp, determinant and transpose
  builtin functions