### PR TITLE
Clarity how to interpret GPURenderPassColorAttachment/clearValue

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7960,6 +7960,27 @@ dictionary GPURenderPassColorAttachment {
         render pass. If not [=map/exist|provided=] defaults to `{r: 0, g: 0, b: 0, a: 0}`. Ignored
         if {{GPURenderPassColorAttachment/loadOp}} is not {{GPULoadOp/"clear"}}.
 
+        <div class=note>
+            The members of {{GPURenderPassColorAttachment/clearValue}} are all double values, so
+            they will be converted to the fully qualified format type of
+            {{GPURenderPassColorAttachment/view}} before being set as the clear value of
+            {{{GPURenderPassColorAttachment/view}}.
+
+            Let |colorAttachmentFormat| be
+            {{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
+            - If the components of |colorAttachmentFormat| are floating point values, the members of
+              of {{GPURenderPassColorAttachment/clearValue}} will be converted into floating point
+              values.
+            - If the components of |colorAttachmentFormat| are signed or unsigned normalized values,
+              the members of {{GPURenderPassColorAttachment/clearValue}} will be first clamped into
+              the range [0, 1], then converted into floating point values, and finally converted
+              into the signed or unsigned normalized values.
+            - If the components of |colorAttachmentFormat| are signed or unsigned integer values,
+              the members of {{GPURenderPassColorAttachment/clearValue}} will be first clamped into
+              the range of signed or unsigned integer values with same bit length, and then rounded
+              into the nearest signed or unsigned integer values.
+        </div>
+
     : <dfn>loadOp</dfn>
     ::
         Indicates the load operation to perform on {{GPURenderPassColorAttachment/view}} prior to

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7962,7 +7962,7 @@ dictionary GPURenderPassColorAttachment {
 
         <div class=note>
             The members of {{GPURenderPassColorAttachment/clearValue}} are all double values, so
-            they will be converted to the fully qualified format type of
+            they will first be converted to the fully qualified format type of
             {{GPURenderPassColorAttachment/view}} before being set as the clear value of
             {{{GPURenderPassColorAttachment/view}}.
 
@@ -7972,11 +7972,11 @@ dictionary GPURenderPassColorAttachment {
               of {{GPURenderPassColorAttachment/clearValue}} will be converted into floating point
               values.
             - If the components of |colorAttachmentFormat| are signed or unsigned normalized values,
-              the members of {{GPURenderPassColorAttachment/clearValue}} will be first clamped into
+              the members of {{GPURenderPassColorAttachment/clearValue}} will first be clamped into
               the range [0, 1], then converted into floating point values, and finally converted
               into the signed or unsigned normalized values.
             - If the components of |colorAttachmentFormat| are signed or unsigned integer values,
-              the members of {{GPURenderPassColorAttachment/clearValue}} will be first clamped into
+              the members of {{GPURenderPassColorAttachment/clearValue}} will first be clamped into
               the range of signed or unsigned integer values with same bit length, and then rounded
               into the nearest signed or unsigned integer values.
         </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7972,19 +7972,15 @@ dictionary GPURenderPassColorAttachment {
         channels of {{GPURenderPassColorAttachment/clearValue}}.
 
         For each |channel| of |colorAttachmentFormat|:
-        - If the |channel| contains a {{float}} value, the corresponding member of
-            {{GPURenderPassColorAttachment/clearValue}} will be converted into {{float}} via
-            [=converted to an IDL value|an IDL value=].
-        - If the |channel| contains a signed or unsigned normalized value, the corresponding member of
-            {{GPURenderPassColorAttachment/clearValue}} will first be clamped
-            into the range [0, 1], then converted into {{float}} via
-            [=converted to an IDL value|an IDL value=], and finally converted into the signed or
-            unsigned normalized values with the same bit length as the |channel|.
+        - If the |channel| contains a {{float}}, signed or unsigned normalized value, the
+          corresponding member of {{GPURenderPassColorAttachment/clearValue}} will be converted
+          into the format type of |channel|.
         - If the |channel| contains signed or unsigned integer values, the corresponding member of
             {{GPURenderPassColorAttachment/clearValue}} will first be clamped
             into the range of signed or unsigned integer values with same bit length as the
-            |channel|, and then rounded into the nearest signed or unsigned integer values, choosing
-            the even integer if it lies halfway between two.
+            |channel|, and then rounded into the nearest signed or unsigned integer values. The even
+            integer is chosen if the value before being rounded lies halfway between two signed or
+            unsigned integer values.
 
     : <dfn>loadOp</dfn>
     ::

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7979,15 +7979,21 @@ dictionary GPURenderPassColorAttachment {
         channels of {{GPURenderPassColorAttachment/clearValue}}.
 
         For each |channel| of |colorAttachmentFormat|:
-        - If the |channel| contains a {{float}}, signed or unsigned normalized value, the
-            corresponding member of {{GPURenderPassColorAttachment/clearValue}} will be converted
-            into the format type of |channel|.
+
+        - If the |channel| contains a {{unrestricted float}} value, the corresponding member of
+            {{GPURenderPassColorAttachment/clearValue}} will first be converted into a {{float}}
+            value, then converted into the format type of |channel|.
+        - If the |channel| contains a signed or unsigned normalized value, the corresponding member
+            of {{GPURenderPassColorAttachment/clearValue}} will first be clamped into the range
+            [0, 1], then converted into the format type of |channel|.
         - If the |channel| contains signed or unsigned integer values, the corresponding member of
-            {{GPURenderPassColorAttachment/clearValue}} will first be clamped
-            into the range of signed or unsigned integer values with same bit length as the
-            |channel|, and then rounded into the nearest signed or unsigned integer values. The even
-            integer is chosen if the value before being rounded lies halfway between two signed or
-            unsigned integer values.
+            {{GPURenderPassColorAttachment/clearValue}} will first be clamped into the range of
+            signed or unsigned integer values with same bit length as the |channel|, and then
+            rounded into the nearest signed or unsigned integer values. The even integer is chosen
+            if the value before being rounded lies halfway between two signed or unsigned integer
+            values.
+
+        Issue: Define our own conversions for float16/ufloat10/ufloat11 following the same pattern as {{unrestricted float}}.
 
     : <dfn>loadOp</dfn>
     ::

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7967,17 +7967,24 @@ dictionary GPURenderPassColorAttachment {
 
         Let |colorAttachmentFormat| be
         {{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
-        - If the components of |colorAttachmentFormat| are floating point values, the members of
-            {{GPURenderPassColorAttachment/clearValue}} will be converted into floating point
-            values.
-        - If the components of |colorAttachmentFormat| are signed or unsigned normalized values,
-            the members of {{GPURenderPassColorAttachment/clearValue}} will first be clamped
-            into the range [0, 1], then converted into floating point values, and finally
-            converted into the signed or unsigned normalized values.
-        - If the components of |colorAttachmentFormat| are signed or unsigned integer values,
-            the members of {{GPURenderPassColorAttachment/clearValue}} will first be clamped
-            into the range of signed or unsigned integer values with same bit length, and then
-            rounded into the nearest signed or unsigned integer values.
+        A |colorAttachmentFormat| has up to four |channel|s: `r`, `g`, `b`, and `a` (each |channel|
+        contains one scalar), normally corresponding to the concepts of red, green, blue, and alpha
+        channels of {{GPURenderPassColorAttachment/clearValue}}.
+
+        For each |channel| of |colorAttachmentFormat|:
+        - If the |channel| contains a {{float}} value, the corresponding member of
+            {{GPURenderPassColorAttachment/clearValue}} will be converted into {{float}} via
+            [=converted to an IDL value|an IDL value=].
+        - If the |channel| contains a signed or unsigned normalized value, the corresponding member of
+            {{GPURenderPassColorAttachment/clearValue}} will first be clamped
+            into the range [0, 1], then converted into {{float}} via
+            [=converted to an IDL value|an IDL value=], and finally converted into the signed or
+            unsigned normalized values with the same bit length as the |channel|.
+        - If the |channel| contains signed or unsigned integer values, the corresponding member of
+            {{GPURenderPassColorAttachment/clearValue}} will first be clamped
+            into the range of signed or unsigned integer values with same bit length as the
+            |channel|, and then rounded into the nearest signed or unsigned integer values, choosing
+            the even integer if it lies halfway between two.
 
     : <dfn>loadOp</dfn>
     ::

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7969,16 +7969,16 @@ dictionary GPURenderPassColorAttachment {
             Let |colorAttachmentFormat| be
             {{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
             - If the components of |colorAttachmentFormat| are floating point values, the members of
-              of {{GPURenderPassColorAttachment/clearValue}} will be converted into floating point
-              values.
+                {{GPURenderPassColorAttachment/clearValue}} will be converted into floating point
+                values.
             - If the components of |colorAttachmentFormat| are signed or unsigned normalized values,
-              the members of {{GPURenderPassColorAttachment/clearValue}} will first be clamped into
-              the range [0, 1], then converted into floating point values, and finally converted
-              into the signed or unsigned normalized values.
+                the members of {{GPURenderPassColorAttachment/clearValue}} will first be clamped
+                into the range [0, 1], then converted into floating point values, and finally
+                converted into the signed or unsigned normalized values.
             - If the components of |colorAttachmentFormat| are signed or unsigned integer values,
-              the members of {{GPURenderPassColorAttachment/clearValue}} will first be clamped into
-              the range of signed or unsigned integer values with same bit length, and then rounded
-              into the nearest signed or unsigned integer values.
+                the members of {{GPURenderPassColorAttachment/clearValue}} will first be clamped
+                into the range of signed or unsigned integer values with same bit length, and then
+                rounded into the nearest signed or unsigned integer values.
         </div>
 
     : <dfn>loadOp</dfn>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7989,7 +7989,7 @@ dictionary GPURenderPassColorAttachment {
                     :: Convert |value| [=converted to an IDL value|to an IDL value=] of type {{unrestricted float}} (`f32`).
                     : signed integer type
                     :: Convert |value| [=converted to an IDL value|to an IDL value=] of type {{long long}} (`i32`).
-                    : signed integer type
+                    : unsigned integer type
                     :: Convert |value| [=converted to an IDL value|to an IDL value=] of type {{unsigned long long}} (`u32`).
                 </dl>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7964,7 +7964,7 @@ dictionary GPURenderPassColorAttachment {
             The members of {{GPURenderPassColorAttachment/clearValue}} are all double values, so
             they will first be converted to the fully qualified format type of
             {{GPURenderPassColorAttachment/view}} before being set as the clear value of
-            {{{GPURenderPassColorAttachment/view}}.
+            {{GPURenderPassColorAttachment/view}}.
 
             Let |colorAttachmentFormat| be
             {{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7960,26 +7960,24 @@ dictionary GPURenderPassColorAttachment {
         render pass. If not [=map/exist|provided=] defaults to `{r: 0, g: 0, b: 0, a: 0}`. Ignored
         if {{GPURenderPassColorAttachment/loadOp}} is not {{GPULoadOp/"clear"}}.
 
-        <div class=note>
-            The members of {{GPURenderPassColorAttachment/clearValue}} are all double values, so
-            they will first be converted to the fully qualified format type of
-            {{GPURenderPassColorAttachment/view}} before being set as the clear value of
-            {{GPURenderPassColorAttachment/view}}.
+        The members of {{GPURenderPassColorAttachment/clearValue}} are all double values, so
+        they will first be converted to the fully qualified format type of
+        {{GPURenderPassColorAttachment/view}} before being set as the clear value of
+        {{GPURenderPassColorAttachment/view}}.
 
-            Let |colorAttachmentFormat| be
-            {{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
-            - If the components of |colorAttachmentFormat| are floating point values, the members of
-                {{GPURenderPassColorAttachment/clearValue}} will be converted into floating point
-                values.
-            - If the components of |colorAttachmentFormat| are signed or unsigned normalized values,
-                the members of {{GPURenderPassColorAttachment/clearValue}} will first be clamped
-                into the range [0, 1], then converted into floating point values, and finally
-                converted into the signed or unsigned normalized values.
-            - If the components of |colorAttachmentFormat| are signed or unsigned integer values,
-                the members of {{GPURenderPassColorAttachment/clearValue}} will first be clamped
-                into the range of signed or unsigned integer values with same bit length, and then
-                rounded into the nearest signed or unsigned integer values.
-        </div>
+        Let |colorAttachmentFormat| be
+        {{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
+        - If the components of |colorAttachmentFormat| are floating point values, the members of
+            {{GPURenderPassColorAttachment/clearValue}} will be converted into floating point
+            values.
+        - If the components of |colorAttachmentFormat| are signed or unsigned normalized values,
+            the members of {{GPURenderPassColorAttachment/clearValue}} will first be clamped
+            into the range [0, 1], then converted into floating point values, and finally
+            converted into the signed or unsigned normalized values.
+        - If the components of |colorAttachmentFormat| are signed or unsigned integer values,
+            the members of {{GPURenderPassColorAttachment/clearValue}} will first be clamped
+            into the range of signed or unsigned integer values with same bit length, and then
+            rounded into the nearest signed or unsigned integer values.
 
     : <dfn>loadOp</dfn>
     ::

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7981,32 +7981,29 @@ dictionary GPURenderPassColorAttachment {
 
             For each |componentType| of |colorAttachmentFormat| and corresponding component scalar
             value |value| in {{GPURenderPassColorAttachment/clearValue}}:
-            If |componentType| is a:
 
-            <dl class=switch>
-                : floating-point type or normalized type
-                ::
-                    1. Convert |value| [=converted to an IDL value|to an IDL value=] of type
-                        {{unrestricted float}}.
-                    1. Convert to |componentType| using the same conversion rules as the [#Output
-                        Merging] step and return the result.
+            1. If |componentType| is a:
 
-                        The exact choice of value is implementation-defined.
-                        If the |componentType| has a limited range, this results in
-                        clamping to that range.
+                <dl class=switch>
+                    : floating-point type or normalized type
+                    :: Convert |value| [=converted to an IDL value|to an IDL value=] of type {{unrestricted float}} (`f32`).
+                    : signed integer type
+                    :: Convert |value| [=converted to an IDL value|to an IDL value=] of type {{long long}} (`i32`).
+                    : signed integer type
+                    :: Convert |value| [=converted to an IDL value|to an IDL value=] of type {{unsigned long long}} (`u32`).
+                </dl>
 
-                    Note: In other words, the value written will be as if it was written by a WGSL
-                    shader that outputs the |value| as an `f32`.
+            1. Convert |value| to |componentType| using the same conversion rules as the [#Output Merging]
+                step, and return the result.
 
-                : integer type
-                ::
-                    Return [$ConvertToInt$](|value|, bit length of |componentType|,
-                    signedness of |componentType|).
+            <div class=note>
+                In other words, the value written will be as if it was written by a WGSL shader that
+                outputs the |value| represented as WGSL's `f32`, `i32`, or `u32`, according to its type.
 
-                    Issue: Once the details in [#Output Merging] are defined, determine if this is
-                    the same as writing an `i32` or `u32` from WGSL. If so, make a note of it like
-                    the one above.
-            </dl>
+                For non-integer types, the exact choice of value is implementation-defined.
+                For normalized types, this results in clamping to the range of the type.
+            </div>
+
         </div>
 
     : <dfn>loadOp</dfn>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7972,28 +7972,42 @@ dictionary GPURenderPassColorAttachment {
         {{GPURenderPassColorAttachment/view}} before being set as the clear value of
         {{GPURenderPassColorAttachment/view}}.
 
-        Let |colorAttachmentFormat| be
-        {{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
-        A |colorAttachmentFormat| has up to four |channel|s: `r`, `g`, `b`, and `a` (each |channel|
-        contains one scalar), normally corresponding to the concepts of red, green, blue, and alpha
-        channels of {{GPURenderPassColorAttachment/clearValue}}.
+        <div algorithm="clearValue to texture value">
+            Let |colorAttachmentFormat| be
+            {{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
 
-        For each |channel| of |colorAttachmentFormat|:
+            |colorAttachmentFormat| has up to four components: `r`, `g`, `b`, and `a`, each
+            component containing one scalar value.
 
-        - If the |channel| contains a {{unrestricted float}} value, the corresponding member of
-            {{GPURenderPassColorAttachment/clearValue}} will first be converted into a {{float}}
-            value, then converted into the format type of |channel|.
-        - If the |channel| contains a signed or unsigned normalized value, the corresponding member
-            of {{GPURenderPassColorAttachment/clearValue}} will first be clamped into the range
-            [0, 1], then converted into the format type of |channel|.
-        - If the |channel| contains signed or unsigned integer values, the corresponding member of
-            {{GPURenderPassColorAttachment/clearValue}} will first be clamped into the range of
-            signed or unsigned integer values with same bit length as the |channel|, and then
-            rounded into the nearest signed or unsigned integer values. The even integer is chosen
-            if the value before being rounded lies halfway between two signed or unsigned integer
-            values.
+            For each |componentType| of |colorAttachmentFormat| and corresponding component scalar
+            value |value| in {{GPURenderPassColorAttachment/clearValue}}:
+            If |componentType| is a:
 
-        Issue: Define our own conversions for float16/ufloat10/ufloat11 following the same pattern as {{unrestricted float}}.
+            <dl class=switch>
+                : floating-point type or normalized type
+                ::
+                    1. Convert |value| [=converted to an IDL value|to an IDL value=] of type
+                        {{unrestricted float}}.
+                    1. Convert to |componentType| using the same conversion rules as the [#Output
+                        Merging] step and return the result.
+
+                        The exact choice of value is implementation-defined.
+                        If the |componentType| has a limited range, this results in
+                        clamping to that range.
+
+                    Note: In other words, the value written will be as if it was written by a WGSL
+                    shader that outputs the |value| as an `f32`.
+
+                : integer type
+                ::
+                    Return [$ConvertToInt$](|value|, bit length of |componentType|,
+                    signedness of |componentType|).
+
+                    Issue: Once the details in [#Output Merging] are defined, determine if this is
+                    the same as writing an `i32` or `u32` from WGSL. If so, make a note of it like
+                    the one above.
+            </dl>
+        </div>
 
     : <dfn>loadOp</dfn>
     ::

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7973,8 +7973,8 @@ dictionary GPURenderPassColorAttachment {
 
         For each |channel| of |colorAttachmentFormat|:
         - If the |channel| contains a {{float}}, signed or unsigned normalized value, the
-          corresponding member of {{GPURenderPassColorAttachment/clearValue}} will be converted
-          into the format type of |channel|.
+            corresponding member of {{GPURenderPassColorAttachment/clearValue}} will be converted
+            into the format type of |channel|.
         - If the |channel| contains signed or unsigned integer values, the corresponding member of
             {{GPURenderPassColorAttachment/clearValue}} will first be clamped
             into the range of signed or unsigned integer values with same bit length as the


### PR DESCRIPTION
fixes: https://github.com/gpuweb/gpuweb/issues/965


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Jiawei-Shao/gpuweb/pull/2795.html" title="Last updated on May 12, 2022, 6:02 AM UTC (377833f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2795/498a37e...Jiawei-Shao:377833f.html" title="Last updated on May 12, 2022, 6:02 AM UTC (377833f)">Diff</a>