### PR TITLE
Make GPUExternalTexture sampling always use clamping address mode.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3395,6 +3395,10 @@ External textures use several binding slots: see [=Exceeds the binding slot limi
     - one sampled texture binding for a 3D LUT,
     - one sampler binding to sample the 3D LUT, and
     - one uniform buffer binding for metadata.
+
+    Because of the cropping and rotation that may happen for external textures, sampling
+    coordinates outside of [0, 1] might read pixels outside of the transformed rectangle. For that
+    reason `textureSampleLevel` of an external texture clamps the coordinates to [0, 1].
 </div>
 
 <script type=idl>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -11631,7 +11631,8 @@ The sampled value.
 
 ### `textureSampleLevel` ### {#texturesamplelevel}
 
-Samples a texture using an explicit mip level, or at mip level 0.
+Samples a texture using an explicit mip level, or at mip level 0. Sampling of a `texture_external`
+texture clamps the `coords` to [0, 1] before any further operations.
 
 ```rust
 fn textureSampleLevel(t: texture_2d<f32>, s: sampler, coords: vec2<f32>, level: f32) -> vec4<f32>


### PR DESCRIPTION
Fixes #2766


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/2796.html" title="Last updated on Apr 26, 2022, 3:54 PM UTC (01b21f0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2796/819184c...Kangz:01b21f0.html" title="Last updated on Apr 26, 2022, 3:54 PM UTC (01b21f0)">Diff</a>