### PR TITLE
In type rule for boolean negation (`!`), use `T` in precondition.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5108,7 +5108,7 @@ See [[#sync-builtin-functions]].
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>
-  <tr algorithm="boolean negation"><td>|e|: bool<br>|T| is bool or vec|N|&lt;bool&gt;
+  <tr algorithm="boolean negation"><td>|e|: T<br>|T| is bool or vec|N|&lt;bool&gt;
   <td>`!`|e|: |T|
   <td>Logical negation.
   The result is `true` when |e| is `false` and `false` when |e| is `true`.


### PR DESCRIPTION
The rule as written doesn't permit `!` on `vecN<bool>`.
