### PR TITLE
Encoder mixin followups

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6257,7 +6257,7 @@ The <dfn dfn>encoder state</dfn> may be one of the following:
 </dl>
 
 <div algorithm>
-    To <dfn abstract-op>Prepare the encoder state</dfn> of {{GPUCommandsMixin}} |encoder|:
+    To <dfn abstract-op>Validate the encoder state</dfn> of {{GPUCommandsMixin}} |encoder|:
 
     If |encoder|.{{GPUCommandsMixin/[[state]]}} is:
     <dl class=switch>
@@ -6711,7 +6711,7 @@ dictionary GPUImageCopyExternalImage {
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |source| is [$valid to use with$] |this|.
@@ -6756,7 +6756,7 @@ dictionary GPUImageCopyExternalImage {
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If |size| is missing, set |size| to `max(0, |buffer|.{{GPUBuffer/[[size]]}} - |offset|)`.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
@@ -6908,7 +6908,7 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - Let |dstTextureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
@@ -6956,7 +6956,7 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - Let |srcTextureDesc| be |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
@@ -7006,7 +7006,7 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - Let |srcTextureDesc| be |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
@@ -7079,7 +7079,7 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
                 {{GPUFeatureName/"timestamp-query"}}, throw a {{TypeError}}.
             1. Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
                 <div class=device-timeline>
-                    1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
+                    1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                     1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                         <div class=validusage>
                             - |querySet| is [$valid to use with$] |this|.
@@ -7111,7 +7111,7 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |querySet| is [$valid to use with$] |this|.
@@ -7238,7 +7238,7 @@ It must only be included by interfaces which also include those mixins.
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |bindGroup| is [$valid to use with$] |this|.
@@ -7456,7 +7456,7 @@ It must only be included by interfaces which also include those mixins.
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. [=stack/Push=] |groupLabel| onto |this|.{{GPUDebugCommandsMixin/[[debug_group_stack]]}}.
             </div>
         </div>
@@ -7472,7 +7472,7 @@ It must only be included by interfaces which also include those mixins.
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following requirements are unmet, make |this| [=invalid=], and stop.
                     <div class=validusage>
                         - |this|.{{GPUDebugCommandsMixin/[[debug_group_stack]]}} must not [=list/is empty|be empty=].
@@ -7497,7 +7497,7 @@ It must only be included by interfaces which also include those mixins.
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
             </div>
         </div>
 </dl>
@@ -7595,7 +7595,7 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |pipeline| is [$valid to use with$] |this|.
@@ -7637,7 +7637,7 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - [$Validate encoder bind groups$](|this|, |this|.{{GPUComputePassEncoder/[[pipeline]]}})
@@ -7689,7 +7689,7 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - [$Validate encoder bind groups$](|this|, |this|.{{GPUComputePassEncoder/[[pipeline]]}})
@@ -8350,7 +8350,7 @@ It must only be included by interfaces which also include those mixins.
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. Let |pipelineTargetsLayout| be [$derive render targets layout from pipeline$](|pipeline|.{{GPURenderPipeline/[[descriptor]]}}).
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
@@ -8387,7 +8387,7 @@ It must only be included by interfaces which also include those mixins.
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If |size| is missing, set |size| to max(0, |buffer|.{{GPUBuffer/[[size]]}} - |offset|).
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
@@ -8423,7 +8423,7 @@ It must only be included by interfaces which also include those mixins.
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If |size| is missing, set |size| to max(0, |buffer|.{{GPUBuffer/[[size]]}} - |offset|).
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
@@ -8459,7 +8459,7 @@ It must only be included by interfaces which also include those mixins.
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - It is [$valid to draw$] with |this|.
@@ -8503,7 +8503,7 @@ It must only be included by interfaces which also include those mixins.
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - It is [$valid to draw indexed$] with |this|.
@@ -8563,7 +8563,7 @@ It must only be included by interfaces which also include those mixins.
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - It is [$valid to draw$] with |this|.
@@ -8612,7 +8612,7 @@ It must only be included by interfaces which also include those mixins.
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - It is [$valid to draw indexed$] with |this|.
@@ -8691,7 +8691,7 @@ attachments used by this encoder.
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
-                1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=]
                     and stop.
                     <div class=validusage>
@@ -8734,7 +8734,7 @@ attachments used by this encoder.
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
-                1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=]
                     and stop.
                     <div class=validusage>
@@ -8794,7 +8794,7 @@ attachments used by this encoder.
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |this|.{{GPURenderPassEncoder/[[occlusion_query_set]]}} is not `null`.
@@ -8816,7 +8816,7 @@ attachments used by this encoder.
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
-                1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |this|.{{GPURenderPassEncoder/[[occlusion_query_active]]}} is `true`.
@@ -8854,7 +8854,7 @@ attachments used by this encoder.
 
             Issue the following steps on the [=Device timeline=] of |this|:
             <div class=device-timeline>
-                1. [$Prepare the encoder state$] of |this|. If it returns false, stop.
+                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=]
                     and stop.
                     <div class=validusage>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7185,8 +7185,9 @@ interface mixin GPUBindingCommandsMixin {
 };
 </script>
 
-{{GPUBindingCommandsMixin}} is only included by interfaces which include
-{{GPUObjectBase}} and {{GPUCommandsMixin}}.
+{{GPUBindingCommandsMixin}} assumes the presence of
+{{GPUObjectBase}} and {{GPUCommandsMixin}} members on the same object.
+It must only be included by interfaces which also include those mixins.
 
 {{GPUBindingCommandsMixin}} has the following internal slots:
 
@@ -7424,8 +7425,9 @@ interface mixin GPUDebugCommandsMixin {
 };
 </script>
 
-{{GPUDebugCommandsMixin}} is only included by interfaces which include
-{{GPUObjectBase}} and {{GPUCommandsMixin}}.
+{{GPUDebugCommandsMixin}} assumes the presence of
+{{GPUObjectBase}} and {{GPUCommandsMixin}} members on the same object.
+It must only be included by interfaces which also include those mixins.
 
 {{GPUDebugCommandsMixin}} adds the following internal slots to interfaces which include it:
 
@@ -8283,8 +8285,9 @@ interface mixin GPURenderCommandsMixin {
 };
 </script>
 
-{{GPURenderCommandsMixin}} is only included by interfaces which include
-{{GPUObjectBase}} and {{GPUCommandsMixin}}.
+{{GPURenderCommandsMixin}} assumes the presence of
+{{GPUObjectBase}} and {{GPUCommandsMixin}} members on the same object.
+It must only be included by interfaces which also include those mixins.
 
 {{GPURenderCommandsMixin}} has the following internal slots:
 


### PR DESCRIPTION
Followup to #2751
- Clarify the dependency between mixins
- Rename "Prepare the encoder state" back to "Validate the encoder state" because it never modifies the encoder state (only the encoder validity)