### PR TITLE
Specify how `getBindGroupLayout` handles out-of-bounds indices.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4947,6 +4947,10 @@ interface mixin GPUPipelineBase {
             1. If |this| is not [=valid=]:
                 1. Return a new error {{GPUBindGroupLayout}}.
 
+            1. If |index| &ge; the [=list/size=] of
+                |this|.{{GPUPipelineBase/[[layout]]}}.{{GPUPipelineLayout/[[bindGroupLayouts]]}}:
+                1. Return a new error {{GPUBindGroupLayout}}.
+
             1. Return a new {{GPUBindGroupLayout}} object that references the same internal object as
                 |this|.{{GPUPipelineBase/[[layout]]}}.{{GPUPipelineLayout/[[bindGroupLayouts]]}}[|index|].
 


### PR DESCRIPTION
Fixes #2801.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jimblandy/gpuweb/pull/2803.html" title="Last updated on Apr 28, 2022, 2:19 AM UTC (8913b5e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2803/819184c...jimblandy:8913b5e.html" title="Last updated on Apr 28, 2022, 2:19 AM UTC (8913b5e)">Diff</a>