### PR TITLE
Remove restrictions on the canvas type for CopyExternalImageToTexture()

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9198,10 +9198,6 @@ GPUQueue includes GPUObjectBase;
                 throw a {{SecurityError}} and stop.
             1. If any of the following requirements are unmet, throw an {{OperationError}} and stop.
                 <div class=validusage>
-                    - If |source|.{{GPUImageCopyExternalImage/source}} is an {{HTMLCanvasElement}}:
-                        Its [=canvas context mode=] must be `"2d"`, `"webgl"`, `"webgl2"`, or `"webgpu"`.
-                    - If |source|.{{GPUImageCopyExternalImage/source}} is an {{OffscreenCanvas}}:
-                        Its [=OffscreenCanvas context mode=] must be `"2d"`, `"webgl"`, `"webgl2"`, or `"webgpu"`.
                     - |source|.|origin|.[=Origin3D/x=] + |copySize|.[=Extent3D/width=]
                         must be &le; the width of |sourceImage|.
                     - |source|.|origin|.[=Origin3D/y=] + |copySize|.[=Extent3D/height=]


### PR DESCRIPTION
fixes:#2373


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shaoboyan/gpuweb/pull/2804.html" title="Last updated on Apr 28, 2022, 6:05 AM UTC (d7987fa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2804/8321180...shaoboyan:d7987fa.html" title="Last updated on Apr 28, 2022, 6:05 AM UTC (d7987fa)">Diff</a>