### PR TITLE
Add validation for GPURender/ComputePassTimestampLocation

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7582,6 +7582,8 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
         1. |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/"timestamp"}}.
 
         1. |timestampWrite|.{{GPUComputePassTimestampWrite/queryIndex}} &lt; |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}}.
+
+        1. |timestampWrite|.{{GPUComputePassTimestampWrite/location}} is written at most once for each value in {{GPUComputePassTimestampLocation}} in this compute pass.
 </div>
 
 ### Dispatch ### {#compute-pass-encoder-dispatch}
@@ -7918,6 +7920,8 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
         1. |timestampWrite|.{{GPURenderPassTimestampWrite/queryIndex}} &lt; |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}}.
 
         1. |timestampWrite|.{{GPURenderPassTimestampWrite/queryIndex}} is written at most once in the same |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}} in this render pass.
+
+        1. |timestampWrite|.{{GPURenderPassTimestampWrite/location}} is written at most once for each value in {{GPURenderPassTimestampLocation}} in this render pass.
 
     Issue(gpuweb/gpuweb#503): support for no attachments
 </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7577,13 +7577,13 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
 
     Given a {{GPUComputePassDescriptor}} |this| the following validation rules apply:
 
+    1. No two entries in |this|.{{GPUComputePassDescriptor/timestampWrites}} have the same {{GPUComputePassTimestampWrite/location}}.
+
     1. For each |timestampWrite| in |this|.{{GPUComputePassDescriptor/timestampWrites}}:
 
         1. |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/"timestamp"}}.
 
         1. |timestampWrite|.{{GPUComputePassTimestampWrite/queryIndex}} &lt; |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}}.
-
-        1. No two entries in |this|.{{GPUComputePassDescriptor/timestampWrites}} have the same {{GPUComputePassTimestampWrite/location}}.
 </div>
 
 ### Dispatch ### {#compute-pass-encoder-dispatch}
@@ -7913,6 +7913,8 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
         1. |this|.{{GPURenderPassDescriptor/occlusionQuerySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/type}}
             must be {{GPUQueryType/occlusion}}.
 
+    1. No two entries in |this|.{{GPURenderPassDescriptor/timestampWrites}} have the same {{GPURenderPassTimestampWrite/location}}.
+
     1. For each |timestampWrite| in |this|.{{GPURenderPassDescriptor/timestampWrites}}:
 
         1. |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/"timestamp"}}.
@@ -7920,8 +7922,6 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
         1. |timestampWrite|.{{GPURenderPassTimestampWrite/queryIndex}} &lt; |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}}.
 
         1. |timestampWrite|.{{GPURenderPassTimestampWrite/queryIndex}} is written at most once in the same |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}} in this render pass.
-
-        1. No two entries in |this|.{{GPURenderPassDescriptor/timestampWrites}} have the same {{GPURenderPassTimestampWrite/location}}.
 
     Issue(gpuweb/gpuweb#503): support for no attachments
 </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7583,7 +7583,7 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
 
         1. |timestampWrite|.{{GPUComputePassTimestampWrite/queryIndex}} &lt; |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}}.
 
-        1. |timestampWrite|.{{GPUComputePassTimestampWrite/location}} is written at most once for each value in {{GPUComputePassTimestampLocation}} in this compute pass.
+        1. No two entries in |this|.{{GPUComputePassDescriptor/timestampWrites}} have the same {{GPUComputePassTimestampWrite/location}}.
 </div>
 
 ### Dispatch ### {#compute-pass-encoder-dispatch}
@@ -7921,7 +7921,7 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
 
         1. |timestampWrite|.{{GPURenderPassTimestampWrite/queryIndex}} is written at most once in the same |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}} in this render pass.
 
-        1. |timestampWrite|.{{GPURenderPassTimestampWrite/location}} is written at most once for each value in {{GPURenderPassTimestampLocation}} in this render pass.
+        1. No two entries in |this|.{{GPURenderPassDescriptor/timestampWrites}} have the same {{GPURenderPassTimestampWrite/location}}.
 
     Issue(gpuweb/gpuweb#503): support for no attachments
 </div>


### PR DESCRIPTION
Fixed #2662


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/haoxli/gpuweb/pull/2812.html" title="Last updated on May 6, 2022, 10:10 PM UTC (1f7cd8c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2812/498a37e...haoxli:1f7cd8c.html" title="Last updated on May 6, 2022, 10:10 PM UTC (1f7cd8c)">Diff</a>