### PR TITLE
Make IO-shareable types apply to user-defined IO only.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1998,23 +1998,25 @@ Note: That is, the storable types are the [=plain types=], texture types, and sa
 
 ### IO-shareable Types ### {#io-shareable-types}
 
-Pipeline input and output values must be of IO-shareable type.
+[[#user-defined-inputs-outputs|User-defined pipeline input and output values]]
+must be of IO-shareable type.
 
 A type is <dfn noexport>IO-shareable</dfn> if it is one of:
 
-* a [=scalar=] type
+* a [=numeric scalar=] type
 * a [=numeric vector=] type
-* a [=structure=] type, if all its members are [=scalars=] or [=numeric vectors=]
+* a [=structure=] type, if all its members are [=numeric scalars=] or [=numeric vectors=]
 
 The following kinds of values must be of IO-shareable type:
 
-* Values read from or written to built-in values.
-* Values accepted as inputs from an upstream pipeline stage.
-* Values written as output for downstream processing in the pipeline, or to an output attachment.
+* Values accepted as user-defined inputs from an upstream pipeline stage.
+* Values written as user-defined output for downstream processing in the pipeline, or to an output attachment.
 
-Note: Only built-in pipeline inputs may have a boolean type.
-A user input or output data attribute must not be of [=bool=] type or contain a [=bool=] type.
-See [[#pipeline-inputs-outputs]].
+Note: Only user-defined pipeline input and output values must be
+IO-shareable. Built-in pipeline inputs and outputs have the types specified in
+[[#builtin-values]], which are not necessarily in this category. For example, the
+`front_facing` built-in input for fragment shaders has type `bool`, which is not
+IO-shareable.
 
 ### Host-shareable Types ### {#host-shareable-types}
 
@@ -2039,8 +2041,7 @@ WGSL defines the following attributes that affect memory layouts:
  * [=attribute/align=]
  * [=attribute/size=]
 
-Note: An [=IO-shareable=] type *T* is host-shareable if *T* is not [=bool=] and does not contain [=bool=].
-Many types are host-shareable, but not IO-shareable, including [=atomic types=],
+Note: Many types are host-shareable, but not IO-shareable, including [=atomic types=],
 [=runtime-sized=] arrays, and any composite types containing them.
 
 Note: Both IO-shareable and host-shareable types have specified sizes, but counted differently.
@@ -7574,8 +7575,7 @@ Note: The `position` built-in is both an output of a vertex shader, and an input
 User-defined data can be passed as input to the start of a pipeline, passed
 between stages of a pipeline or output from the end of a pipeline.
 User-defined IO must not be passed to [=compute=] shader entry points.
-User-defined IO must be of [=numeric scalar=] or [=numeric vector=] type,
-or of a structure type whose members are numeric scalars or vectors.
+User-defined IO must be of [=IO-shareable=] type.
 All user-defined IO must be assigned locations (See [[#input-output-locations]]).
 
 #### Interpolation #### {#interpolation}


### PR DESCRIPTION
The types of built-in pipeline IO values are fixed by the definition of each particular built-in, so there's no need to have a category that covers them. Restricting the definition of IO-shareable types to exclude `bool` and `vec<bool>` makes the definition usable in the description of user-defined IO.

Trade a Note about the special case of `bool` for a Note about built-in types being independent of the IO-shareable category.