### PR TITLE
Fix second form of mix

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -10614,7 +10614,7 @@ struct __frexp_result_vecN_f16 {
   <tr algorithm="vector mix with scalar blending factor">
     <td>|T| is AbstractFloat, f32, or f16<br>
         |T2| is vec|N|&lt;|T|&gt;
-    <td class="nowrap">`@const fn`<br>`mix(`|e1|`:` |T2| `, `|e2|`:` |T2| `, `|e3|`:` f32 `) -> ` |T|
+    <td class="nowrap">`@const fn`<br>`mix(`|e1|`:` |T2| `, `|e2|`:` |T2| `, `|e3|`:` |T| `) -> ` |T2|
     <td>Returns the component-wise linear blend of |e1| and |e2|,
         using scalar blending factor |e3| for each component.<br>
         Same as `mix(`|e1|`, `|e2|`, `|T2|`(`|e3|`))`.


### PR DESCRIPTION
Fixes #2806
Fixes #2807

* Third parameter in the splat version of mix should be T
* Return type of splat version of mix should be T2