### PR TITLE
Clarify workgroup variable initialization value description

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3789,8 +3789,11 @@ When a variable is created, its memory contains an initial value as follows:
     * Otherwise, it is the result of evaluating the initializer expression at that point in the program execution.
 * For variables in the [=address spaces/workgroup=] address space:
     * When the store type is [=constructible=], the [=zero value=] for the store type.
-    * Otherwise, the store type is an array of construcible elements, and each element
-        is initialized to its zero value.
+    * If the store type is an [=atomic type=], the [=zero value=] is that of the underlying [=integer scalar=] type.
+    * Otherwise, if the store type is not constructible, the [=zero value=] is determined by recursively applying these
+        rules to each component of the [=composite=] until a [=constructible=] type is encountered.
+        * Note: This commonly occurs when using an array with a [=pipeline-overridable=] element count or
+            a composite that contains an atomic type.
 * Variables in other address spaces are [=resources=]
     set by bindings in the [=draw command=] or [=dispatch command=].
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3789,7 +3789,7 @@ When a variable is created, its memory contains an initial value as follows:
     * Otherwise, it is the result of evaluating the initializer expression at that point in the program execution.
 * For variables in the [=address spaces/workgroup=] address space:
     * When the store type is [=constructible=], the [=zero value=] for the store type.
-    * If the store type is an [=atomic type=], the [=zero value=] is that of the underlying [=integer scalar=] type.
+    * If the store type is an [=atomic type=], the [=zero value=] is that of the underlying type ([=integer scalar=]).
     * Otherwise, if the store type is not constructible, the [=zero value=] is determined by recursively applying these
         rules to each component of the [=composite=] until a [=constructible=] type is encountered.
         * Note: This commonly occurs when using an array with a [=pipeline-overridable=] element count or


### PR DESCRIPTION
Fixes #2811

* Clarify initialization values for workgroup variables to cover
  non-constructible types (due to atomics)