### PR TITLE
Add definitions to all Depth/Stencil State members

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5960,7 +5960,7 @@ enum GPUStencilOperation {
 </script>
 
 {{GPUDepthStencilState}} has the following members, which describe how a {{GPURenderPipeline}}
-will affect a render pass' {{GPURenderPassDescriptor/depthStencilAttachment}}:
+will affect a render pass's {{GPURenderPassDescriptor/depthStencilAttachment}}:
 
 <dl dfn-type=dict-member dfn-for=GPUDepthStencilState>
     : <dfn>format</dfn>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5959,6 +5959,142 @@ enum GPUStencilOperation {
 };
 </script>
 
+{{GPUDepthStencilState}} has the following members, which describe how a {{GPURenderPipeline}}
+will affect a render pass' {{GPURenderPassDescriptor/depthStencilAttachment}}:
+
+<dl dfn-type=dict-member dfn-for=GPUDepthStencilState>
+    : <dfn>format</dfn>
+    ::
+        The {{GPUTextureViewDescriptor/format}} of {{GPURenderPassDescriptor/depthStencilAttachment}}
+        this {{GPURenderPipeline}} will be compatible with.
+
+    : <dfn>depthWriteEnabled</dfn>
+    ::
+        Indicates if this {{GPURenderPipeline}} can modify
+        {{GPURenderPassDescriptor/depthStencilAttachment}} depth values.
+
+    : <dfn>depthCompare</dfn>
+    ::
+        The comparison operation used to test fragment depths against
+        {{GPURenderPassDescriptor/depthStencilAttachment}} depth values.
+
+    : <dfn>stencilFront</dfn>
+    ::
+        Defines how stencil comparisons and operations are performed for front-facing primitives.
+
+    : <dfn>stencilBack</dfn>
+    ::
+        Defines how stencil comparisons and operations are performed for back-facing primitives.
+
+    : <dfn>stencilReadMask</dfn>
+    ::
+        Bitmask controlling which {{GPURenderPassDescriptor/depthStencilAttachment}} stencil value
+        bits are read when performing stencil comparison tests.
+
+    : <dfn>stencilWriteMask</dfn>
+    ::
+        Bitmask controlling which {{GPURenderPassDescriptor/depthStencilAttachment}} stencil value
+        bits are written to when performing stencil operations.
+
+    : <dfn>depthBias</dfn>
+    ::
+        Constant depth bias added to each fragment. See [$biased fragment depth$] for details.
+
+    : <dfn>depthBiasSlopeScale</dfn>
+    ::
+        Depth bias that scales with the fragment’s slope. See [$biased fragment depth$] for details.
+
+    : <dfn>depthBiasClamp</dfn>
+    ::
+        The maximum depth bias of a fragment. See [$biased fragment depth$] for details.
+</dl>
+
+<div algorithm>
+    The <dfn abstract-op>biased fragment depth</dfn> for a fragment being written to
+    {{GPURenderPassDescriptor/depthStencilAttachment}} |attachment| when drawing using
+    {{GPUDepthStencilState}} |state| is calculated by running the following steps:
+
+    1. Let |format| be |attachment|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTextureViewDescriptor/format}}.
+    1. Let |r| be the minimum positive representable value &gt; `0` in the |format| converted to a 32-bit float.
+    1. Let |maxDepthSlope| be the maximum of the horizontal and vertical slopes of the fragment's depth value.
+    1. If |format| is a **unorm** format:
+        1. Let |bias| be <code>(float)|state|.{{GPUDepthStencilState/depthBias}} * |r| + |state|.{{GPUDepthStencilState/depthBiasSlopeScale}} * |maxDepthSlope|</code>.
+    1. Otherwise, if |format| is a **float** format:
+        1. Let |bias| be <code>(float)|state|.{{GPUDepthStencilState/depthBias}} * 2^(exp(max depth in primitive) - |r|) + |state|.{{GPUDepthStencilState/depthBiasSlopeScale}} * |maxDepthSlope|</code>.
+    1. If |state|.{{GPUDepthStencilState/depthBiasClamp}} &gt; `0`:
+        1. Set |bias| to <code>min(|state|.{{GPUDepthStencilState/depthBiasClamp}}, |bias|)</code>.
+    1. Otherwise if |state|.{{GPUDepthStencilState/depthBiasClamp}} &lt; `0`:
+        1. Set |bias| to <code>max(|state|.{{GPUDepthStencilState/depthBiasClamp}}, |bias|)</code>.
+    1. If |state|.{{GPUDepthStencilState/depthBias}} &ne; `0` or |state|.{{GPUDepthStencilState/depthBiasSlopeScale}} &ne; `0`:
+        1. Set the fragment depth value to <code>fragment depth value + |bias|</code>
+</div>
+
+{{GPUStencilFaceState}} has the following members, which describe how stencil comparisons and
+operations are performed:
+
+<dl dfn-type=dict-member dfn-for=GPUStencilFaceState>
+    : <dfn>compare</dfn>
+    ::
+        The {{GPUCompareFunction}} used when testing fragments against
+        {{GPURenderPassDescriptor/depthStencilAttachment}} stencil values.
+
+    : <dfn>failOp</dfn>
+    ::
+        The {{GPUStencilOperation}} performed if the fragment stencil comparison test described by
+        {{GPUStencilFaceState/compare}} fails.
+
+    : <dfn>depthFailOp</dfn>
+    ::
+        The {{GPUStencilOperation}} performed if the fragment depth comparison described by
+        {{GPUDepthStencilState/depthCompare}} fails.
+
+    : <dfn>passOp</dfn>
+    ::
+        The {{GPUStencilOperation}} performed if the fragment stencil comparison test described by
+        {{GPUStencilFaceState/compare}} passes.
+</dl>
+
+{{GPUStencilOperation}} defines the following operations:
+
+<dl dfn-type="enum-value" dfn-for=GPUStencilOperation>
+    : <dfn>"keep"</dfn>
+    ::
+        Keep the current stencil value.
+
+    : <dfn>"zero"</dfn>
+    ::
+        Set the stencil value to `0`.
+
+    : <dfn>"replace"</dfn>
+    ::
+        Set the stencil value to {{GPURenderPassEncoder/[[stencil_reference]]}}.
+
+    : <dfn>"invert"</dfn>
+    ::
+        Bitwise-invert the current stencil value.
+
+    : <dfn>"increment-clamp"</dfn>
+    ::
+        Increments the current stencil value, clamping to the maximum representable value of the
+        {{GPURenderPassDescriptor/depthStencilAttachment}}'s stencil aspect.
+
+    : <dfn>"decrement-clamp"</dfn>
+    ::
+        Decrement the current stencil value, clamping to `0`.
+
+    : <dfn>"increment-wrap"</dfn>
+    ::
+        Increments the current stencil value, wrapping to zero if the value exceeds the maximum
+        representable value of the {{GPURenderPassDescriptor/depthStencilAttachment}}'s stencil
+        aspect.
+
+    : <dfn>"decrement-wrap"</dfn>
+    ::
+        Decrement the current stencil value, wrapping to the maximum representable value of the
+        {{GPURenderPassDescriptor/depthStencilAttachment}}'s stencil aspect if the value goes below
+        `0`.
+</dl>
+
 <div algorithm>
     <dfn abstract-op>validating GPUDepthStencilState</dfn>(descriptor)
     **Arguments:**
@@ -7816,6 +7952,9 @@ GPURenderPassEncoder includes GPURenderCommandsMixin;
     : <dfn>\[[viewport]]</dfn>
     ::  Current viewport rectangle and depth range.
 
+    : <dfn>\[[stencil_reference]]</dfn>
+    ::  Current stencil reference value, initially `0`.
+
     : <dfn>\[[endTimestampWrites]]</dfn>, of type {{GPURenderPassTimestampWrites}}
     ::
         The timestamp attachments which need to be executed when the pass ends.
@@ -8771,16 +8910,22 @@ attachments used by this encoder.
 
     : <dfn>setStencilReference(reference)</dfn>
     ::
-        Sets the stencil reference value used during stencil tests with the
-        {{GPUStencilOperation/"replace"}} {{GPUStencilOperation}}.
+        Sets the {{GPURenderPassEncoder/[[stencil_reference]]}} value used during stencil tests with
+        the {{GPUStencilOperation/"replace"}} {{GPUStencilOperation}}.
 
         <div algorithm="GPURenderPassEncoder.setStencilReference">
             **Called on:** {{GPURenderPassEncoder}} this.
 
             **Arguments:**
             <pre class=argumentdef for="GPURenderPassEncoder/setStencilReference(reference)">
-                reference: The stencil reference value.
+                |reference|: The new stencil reference value.
             </pre>
+
+            Issue the following steps on the [=Device timeline=] of |this|:
+            <div class=device-timeline>
+                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
+                1. Set {{GPURenderPassEncoder/[[stencil_reference]]}} to |reference|.
+            </div>
         </div>
 </dl>
 


### PR DESCRIPTION
Starting on #2815. Most text is based on looking through the three native API equivalents and trying to normalize their descriptions of the same functionality into something that feels appropriate for WebGPU's verbiage and structure.

Hoping to use this PR as a place to feel out how detailed we want these to be. For example: Including the depth bias algorithm in this spec may be overkill? But if we want the spec to stand on it's own without implicitly hand-waving at the corresponding native APIs and saying "go see what they do if you want to know how this works" then it seems necessary.

Happy to take any and all suggestions!


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/2817.html" title="Last updated on May 3, 2022, 9:15 PM UTC (8bafdd9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2817/5a0b3e4...8bafdd9.html" title="Last updated on May 3, 2022, 9:15 PM UTC (8bafdd9)">Diff</a>