### PR TITLE
Add a limit for maxColorAttachments

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1394,6 +1394,14 @@ applications should generally request the "worst" limits that work for their con
         The maximum allowed number of components of input or output variables
         for inter-stage communication (like vertex outputs or fragment inputs).
 
+    <tr><td><dfn>maxColorAttachments</dfn>
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>8
+    <tr class=row-continuation><td colspan=4>
+        The maximum allowed number of color attachments in
+        {{GPURenderPipelineDescriptor}}.{{GPURenderPipelineDescriptor/fragment}}.{{GPUFragmentState/targets}},
+        {{GPURenderPassDescriptor}}.{{GPURenderPassDescriptor/colorAttachments}},
+        and {{GPURenderPassLayout}}.{{GPURenderPassLayout/colorFormats}}.
+
     <tr><td><dfn>maxComputeWorkgroupStorageSize</dfn>
         <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>16352
     <tr class=row-continuation><td colspan=4>
@@ -5671,7 +5679,7 @@ details.
                 - [$validating GPUProgrammableStage$]({{GPUShaderStage/FRAGMENT}},
                     |descriptor|.{{GPURenderPipelineDescriptor/fragment}},
                     |descriptor|.{{GPUPipelineDescriptorBase/layout}}) succeeds.
-                - [$validating GPUFragmentState$](|descriptor|.{{GPURenderPipelineDescriptor/fragment}}) succeeds.
+                - [$validating GPUFragmentState$](|device|, |descriptor|.{{GPURenderPipelineDescriptor/fragment}}) succeeds.
                 - If the "sample_mask" [=builtin=] is a [=pipeline output=] of |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
                     - |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/alphaToCoverageEnabled}} is `false`.
             - [$validating GPUPrimitiveState$](|descriptor|.{{GPURenderPipelineDescriptor/primitive}}, |device|.{{device/[[features]]}}) succeeds.
@@ -5809,28 +5817,30 @@ dictionary GPUFragmentState : GPUProgrammableStage {
 </script>
 
 <div algorithm>
-    <dfn abstract-op>validating GPUFragmentState</dfn>(|descriptor|)
-        Return `true` if all of the following requirements are met:
+    <dfn abstract-op>validating GPUFragmentState</dfn>({{GPUDevice}} |device|, {{GPUFragmentState}} |descriptor|)
 
-        - |descriptor|.{{GPUFragmentState/targets}}.length must be &le; 8.
-        - For each non-`null` |colorState| layout descriptor in the list |descriptor|.{{GPUFragmentState/targets}}:
-            - |colorState|.{{GPUColorTargetState/format}} must be listed in [[#plain-color-formats]]
-                with {{GPUTextureUsage/RENDER_ATTACHMENT}} capability.
-            - If |colorState|.{{GPUColorTargetState/blend}} is not `undefined`:
-                - The |colorState|.{{GPUColorTargetState/format}} must be filterable
-                    according to the [[#plain-color-formats]] table.
-                - |colorState|.{{GPUColorTargetState/blend}}.{{GPUBlendState/color}}
-                    must be a [=valid GPUBlendComponent=].
-                - |colorState|.{{GPUColorTargetState/blend}}.{{GPUBlendState/alpha}}
-                    must be a [=valid GPUBlendComponent=].
-            - |colorState|.{{GPUColorTargetState/writeMask}} must be &lt; 16.
-            - If |descriptor|.{{GPUProgrammableStage/entryPoint}} has a [=pipeline output=] value
-                with [=location=] attribute equal to the index of the |colorState|
-                in the |descriptor|.{{GPUFragmentState/targets}} list:
-                - The [=pipeline output=] type must be compatible with |colorState|.{{GPUColorTargetState/format}}.
+    Return `true` if all of the following requirements are met:
 
-                Otherwise:
-                - |colorState|.{{GPUColorTargetState/writeMask}} must be 0.
+    - |descriptor|.{{GPUFragmentState/targets}}.length must be &le;
+        |device|.{{device/[[limits]]}}.{{supported limits/maxColorAttachments}}.
+    - For each non-`null` |colorState| layout descriptor in the list |descriptor|.{{GPUFragmentState/targets}}:
+        - |colorState|.{{GPUColorTargetState/format}} must be listed in [[#plain-color-formats]]
+            with {{GPUTextureUsage/RENDER_ATTACHMENT}} capability.
+        - If |colorState|.{{GPUColorTargetState/blend}} is not `undefined`:
+            - The |colorState|.{{GPUColorTargetState/format}} must be filterable
+                according to the [[#plain-color-formats]] table.
+            - |colorState|.{{GPUColorTargetState/blend}}.{{GPUBlendState/color}}
+                must be a [=valid GPUBlendComponent=].
+            - |colorState|.{{GPUColorTargetState/blend}}.{{GPUBlendState/alpha}}
+                must be a [=valid GPUBlendComponent=].
+        - |colorState|.{{GPUColorTargetState/writeMask}} must be &lt; 16.
+        - If |descriptor|.{{GPUProgrammableStage/entryPoint}} has a [=pipeline output=] value
+            with [=location=] attribute equal to the index of the |colorState|
+            in the |descriptor|.{{GPUFragmentState/targets}} list:
+            - The [=pipeline output=] type must be compatible with |colorState|.{{GPUColorTargetState/format}}.
+
+            Otherwise:
+            - |colorState|.{{GPUColorTargetState/writeMask}} must be 0.
 </div>
 
 Note:
@@ -8022,9 +8032,11 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
 <div class=validusage dfn-for=GPURenderPassDescriptor>
     <dfn abstract-op>Valid Usage</dfn>
 
-    Given a {{GPURenderPassDescriptor}} |this| the following validation rules apply:
+    Given a {{GPUDevice}} |device| and {{GPURenderPassDescriptor}} |this|, the following validation rules apply:
 
-    1. |this|.{{GPURenderPassDescriptor/colorAttachments}}.length must be less than or equal to 8.
+    1. |this|.{{GPURenderPassDescriptor/colorAttachments}}.length must be less than or equal to
+        |device|.{{device/[[limits]]}}.{{supported limits/maxColorAttachments}}.
+
     1. If |this|.{{GPURenderPassDescriptor/colorAttachments}} has all values be `null` (or the sequence is empty):
 
         1. |this|.{{GPURenderPassDescriptor/depthStencilAttachment}} must not be `null`.
@@ -9091,7 +9103,8 @@ GPURenderBundleEncoder includes GPURenderCommandsMixin;
             <div class=device-timeline>
                 1. If any of the following conditions are unsatisfied, [$generate a validation error$] and stop.
                     <div class=validusage>
-                        - |descriptor|.{{GPURenderPassLayout/colorFormats}}.length must be less than or equal to 8.
+                        - |descriptor|.{{GPURenderPassLayout/colorFormats}}.length must be less than or equal to
+                            |this|.{{device/[[limits]]}}.{{supported limits/maxColorAttachments}}.
                         - If |descriptor|.{{GPURenderPassLayout/colorFormats}} only contains `null` members:
                             - |descriptor|.{{GPURenderPassLayout/depthStencilFormat}} must not be `null`.
                         - For each |colorFormat| in |descriptor|.{{GPURenderPassLayout/colorFormats}}:


### PR DESCRIPTION
TBD whether it's configurable - see #1865 - but I'm guessing it will be.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2820.html" title="Last updated on May 4, 2022, 12:09 AM UTC (ba5caae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2820/f7f5a0a...kainino0x:ba5caae.html" title="Last updated on May 4, 2022, 12:09 AM UTC (ba5caae)">Diff</a>