### PR TITLE
Validate canvas configuration in configure()

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9918,9 +9918,10 @@ dictionary GPUCanvasConfiguration {
 </div>
 
 <div algorithm>
-    The <dfn abstract-op>GPUTextureDescriptor for the canvas and configuration</dfn>({{HTMLCanvasElement}}
-    |canvas|, {{GPUCanvasConfiguration}} |configuration|) is a {{GPUTextureDescriptor}} with the
-    following members:
+    The <dfn abstract-op>GPUTextureDescriptor for the canvas and configuration</dfn>(
+    ({{HTMLCanvasElement}} or {{OffscreenCanvas}}) |canvas|,
+    {{GPUCanvasConfiguration}} |configuration|)
+    is a {{GPUTextureDescriptor}} with the following members:
 
     - {{GPUTextureDescriptor/size}}: |configuration|.{{GPUCanvasConfiguration/size}} if it
         [=map/exists=], and [|canvas|.width, |canvas|.height, 1] otherwise.
@@ -9929,6 +9930,9 @@ dictionary GPUCanvasConfiguration {
     - {{GPUTextureDescriptor/viewFormats}}: |configuration|.{{GPUCanvasConfiguration/viewFormats}}.
 
     and other members set to their defaults.
+
+    |canvas|.width refers to {{HTMLCanvasElement}}.{{HTMLCanvasElement/width}} or {{OffscreenCanvas}}.{{OffscreenCanvas/width}}.
+    |canvas|.height refers to {{HTMLCanvasElement}}.{{HTMLCanvasElement/height}} or {{OffscreenCanvas}}.{{OffscreenCanvas/height}}.
 </div>
 
 ### Canvas Color Space ### {#canvas-color-space}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9790,8 +9790,8 @@ interface GPUCanvasContext {
                     <div class=note>
                         If the texture can't be created (e.g. due to validation failure or out-of-memory),
                         this generates and error and returns an [=invalid=] {{GPUTexture}}.
-                        This is true even if the same validation already failed in {{GPUCanvasContext/configure()}}.
-                        Implementations may deduplicate this validation, but **must** still resurface the validation error here.
+                        Some validation here is redundant with that done in {{GPUCanvasContext/configure()}}.
+                        Implementations must not skip this redundant validation.
 
                         {{GPUCanvasContext/getCurrentTexture()}} will continue returning the same
                         invalid texture until it is [$Invalidate the current texture|invalidated$]

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2644,6 +2644,11 @@ GPUTexture includes GPUObjectBase;
     ::
         If the texture is destroyed, it can no longer be used in any operation,
         and its underlying memory can be freed.
+
+        Issue: Like many pieces of state, this should move to the device-timeline. But it needs to
+        be mirrored on the shared-content-timeline as well (for canvas textures) for use in
+        {{GPUCanvasContext/getCurrentTexture()}}. Alternatively, destroy() could be overridden to
+        clear the {{GPUCanvasContext/[[currentTexture]]}} slot.
 </dl>
 
 <div algorithm>
@@ -9670,19 +9675,20 @@ interface GPUCanvasContext {
 {{GPUCanvasContext}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUCanvasContext">
-    : <dfn>\[[validConfiguration]]</dfn> of type boolean, initially `false`.
+    : <dfn>\[[configuration]]</dfn> of type {{GPUCanvasConfiguration}}?, initially `null`.
     ::
-        Indicates if the context currently has a valid configuration.
+        The options this context is currently configured with.
 
-    : <dfn>\[[configuration]]</dfn> of type {{GPUCanvasConfiguration}}, initially `null`.
-    ::
-        The options this context is configured with. `null` if the context has not been configured
-        or the configuration has been removed.
+        `null` if the context has not been configured or has been
+        {{GPUCanvasContext/unconfigure()|unconfigured}}.
 
-    : <dfn>\[[size]]</dfn> of type {{GPUExtent3D}}
+    : <dfn>\[[textureDescriptor]]</dfn> of type {{GPUTextureDescriptor}}?, initially `null`.
     ::
-        The size of {{GPUTexture}}s returned from this context.
-        [=Extent3D/depthOrArrayLayers=] is always `1`.
+        The currently configured texture descriptor, derived from the
+        {{GPUCanvasContext/[[configuration]]}} and canvas.
+
+        `null` if the context has not been configured or has been
+        {{GPUCanvasContext/unconfigure()|unconfigured}}.
 
     : <dfn>\[[currentTexture]]</dfn> of type {{GPUTexture}}?, initially `null`
     ::
@@ -9714,37 +9720,17 @@ interface GPUCanvasContext {
             **Returns:** undefined
 
             1. [$Invalidate the current texture$] of |this|.
-            1. Set |this|.{{GPUCanvasContext/[[validConfiguration]]}} to `false`.
-            1. Set |this|.{{GPUCanvasContext/[[configuration]]}} to |configuration|.
             1. Let |device| be |configuration|.{{GPUCanvasConfiguration/device}}.
-            1. Let |canvas| be |this|.{{GPUCanvasContext/canvas}}.
-            1. If |configuration|.{{GPUCanvasConfiguration/size}} is `undefined` set
-                |this|.{{GPUCanvasContext/[[size]]}} to [|canvas|.width, |canvas|.height, 1],
-                otherwise set |this|.{{GPUCanvasContext/[[size]]}} to
-                |configuration|.{{GPUCanvasConfiguration/size}}.
+            1. Let |descriptor| be the
+                {$GPUTextureDescriptor for the canvas and configuration$}(|this|.{{GPUCanvasContext/canvas}}, |configuration|).
+            1. Set |this|.{{GPUCanvasContext/[[configuration]]}} to |configuration|.
+            1. Set |this|.{{GPUCanvasContext/[[textureDescriptor]]}} to |descriptor|.
 
             1. Issue the following steps on the [=Device timeline=] of |device|:
                 <div class=device-timeline>
-                    1. If any of the following conditions are unsatisfied:
-                        <div class=validusage>
-                            - |device| is a [=valid=] {{GPUDevice}}.
-                            - [=Supported context formats=] [=set/contains=]
-                                |configuration|.{{GPUCanvasConfiguration/format}}.
-                            - |this|.{{GPUCanvasContext/[[size]]}}.[=Extent3D/width=] &gt; 0.
-                            - |this|.{{GPUCanvasContext/[[size]]}}.[=Extent3D/width=] &le;
-                                |device|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
-                            - |this|.{{GPUCanvasContext/[[size]]}}.[=Extent3D/height=] &gt; 0.
-                            - |this|.{{GPUCanvasContext/[[size]]}}.[=Extent3D/height=] &le;
-                                |device|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
-                            - |this|.{{GPUCanvasContext/[[size]]}}.[=Extent3D/depthOrArrayLayers=]
-                                is 1;
-                        </div>
-
-                        Then:
-                            1. [$Generate a validation error$].
-                            1. Return.
+                    1. If [$validating GPUTextureDescriptor$](|device|, |descriptor|) returns false,
+                        [$generate a validation error$] and stop.
                 </div>
-            1. Set |this|.{{GPUCanvasContext/[[validConfiguration]]}} to `true`.
         </div>
 
     : <dfn>unconfigure()</dfn>
@@ -9757,8 +9743,8 @@ interface GPUCanvasContext {
             **Returns:** undefined
 
             1. [$Invalidate the current texture$] of |this|.
-            1. Set |this|.{{GPUCanvasContext/[[validConfiguration]]}} to `false`.
             1. Set |this|.{{GPUCanvasContext/[[configuration]]}} to `null`.
+            1. Set |this|.{{GPUCanvasContext/[[textureDescriptor]]}} to `null`.
         </div>
 
     : <dfn>getPreferredFormat(adapter)</dfn>
@@ -9793,11 +9779,24 @@ interface GPUCanvasContext {
             **Returns:** {{GPUTexture}}
 
             1. If |this|.{{GPUCanvasContext/[[configuration]]}} is `null`:
-                1. Throw an {{OperationError}} and stop.
+                1. Throw an {{InvalidStateError}} and stop.
+            1. [=Assert=] |this|.{{GPUCanvasContext/[[textureDescriptor]]}} is not `null`.
+            1. Let |device| be |this|.{{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/device}}.
             1. If |this|.{{GPUCanvasContext/[[currentTexture]]}} is `null` or
                 |this|.{{GPUCanvasContext/[[currentTexture]]}}.{{GPUTexture/[[destroyed]]}} is true:
-                1. Set |this|.{{GPUCanvasContext/[[currentTexture]]}} to the result of [$allocating
-                    a new context texture$] for |this|.
+                1. Set |this|.{{GPUCanvasContext/[[currentTexture]]}} to the result of calling
+                    |device|.{{GPUDevice/createTexture()}} with |this|.{{GPUCanvasContext/[[textureDescriptor]]}}.
+
+                    <div class=note>
+                        If the texture can't be created (e.g. due to validation failure or out-of-memory),
+                        this generates and error and returns an [=invalid=] {{GPUTexture}}.
+                        This is true even if the same validation already failed in {{GPUCanvasContext/configure()}}.
+                        Implementations may deduplicate this validation, but **must** still resurface the validation error here.
+
+                        {{GPUCanvasContext/getCurrentTexture()}} will continue returning the same
+                        invalid texture until it is [$Invalidate the current texture|invalidated$]
+                        or explicitly {{GPUTexture/destroy()|destroyed}}.
+                    </div>
             1. Return |this|.{{GPUCanvasContext/[[currentTexture]]}}.
         </div>
 
@@ -9849,7 +9848,7 @@ interface GPUCanvasContext {
 
     1. Let |texture| be |context|.{{GPUCanvasContext/[[currentTexture]]}}.
     1. If any of the following requirements is unmet, return a transparent black image of size
-        |context|.{{GPUCanvasContext/[[size]]}} and stop.
+        |context|.{{GPUCanvasContext/[[textureDescriptor]]}}.{{GPUTextureDescriptor/size}} and stop.
         <div class=validusage>
             - |texture| must not be `null`.
             - |texture|.{{GPUTexture/[[destroyed]]}} must be false.
@@ -9864,32 +9863,6 @@ interface GPUCanvasContext {
         |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/colorSpace}}.
 
         Issue(gpuweb/gpuweb#1847): Does compositingAlphaMode=opaque make this return opaque contents?
-</div>
-
-<div algorithm>
-    To <dfn abstract-op lt='allocating a new context texture'>allocate a new context texture</dfn>
-    for {{GPUCanvasContext}} |context| run the following steps:
-
-    1. Let |device| be |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/device}}.
-    1. If |context|.{{GPUCanvasContext/[[validConfiguration]]}} is `false`:
-        1. [$Generate a validation error$].
-        1. Return a new [=invalid=] {{GPUTexture}}.
-    1. Let |textureDescriptor| be a new {{GPUTextureDescriptor}}.
-    1. Set |textureDescriptor|.{{GPUTextureDescriptor/size}} to |context|.{{GPUCanvasContext/[[size]]}}.
-    1. Set |textureDescriptor|.{{GPUTextureDescriptor/format}} to
-        |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/format}}.
-    1. Set |textureDescriptor|.{{GPUTextureDescriptor/usage}} to
-        |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/usage}}.
-    1. Let |texture| be a new {{GPUTexture}} created as if |device|.{{GPUDevice/createTexture()}}
-        were called with |textureDescriptor|.
-
-        Note: This results in an [=invalid=] {{GPUTexture}} and generates an error if the
-        texture can't be created (e.g. due to out-of-memory).
-
-        Note: If a previously presented texture from |context| matches the required criteria,
-        its GPU memory may be re-used. This optimization is unobservable.
-    1. Ensure |texture| is cleared to `(0, 0, 0, 0)`.
-    1. Return |texture|.
 </div>
 
 <div algorithm>
@@ -9944,6 +9917,20 @@ dictionary GPUCanvasConfiguration {
     </pre>
 </div>
 
+<div algorithm>
+    The <dfn abstract-op>GPUTextureDescriptor for the canvas and configuration</dfn>({{HTMLCanvasElement}}
+    |canvas|, {{GPUCanvasConfiguration}} |configuration|) is a {{GPUTextureDescriptor}} with the
+    following members:
+
+    - {{GPUTextureDescriptor/size}}: |configuration|.{{GPUCanvasConfiguration/size}} if it
+        [=map/exists=], and [|canvas|.width, |canvas|.height, 1] otherwise.
+    - {{GPUTextureDescriptor/format}}: |configuration|.{{GPUCanvasConfiguration/format}}.
+    - {{GPUTextureDescriptor/usage}}: |configuration|.{{GPUCanvasConfiguration/usage}}.
+    - {{GPUTextureDescriptor/viewFormats}}: |configuration|.{{GPUCanvasConfiguration/viewFormats}}.
+
+    and other members set to their defaults.
+</div>
+
 ### Canvas Color Space ### {#canvas-color-space}
 
 During presentation, the chrominance of color values outside of the [0, 1] range is not to be
@@ -9959,13 +9946,12 @@ high dynamic range is explicitly enabled for the canvas element.
 
 ### Canvas Context sizing ### {#context-sizing}
 
-A {{GPUCanvasContext}}'s {{GPUCanvasContext/[[size]]}} is set by the {{GPUCanvasConfiguration}}
+The size of the image used to present a WebGPU canvas is set by the {{GPUCanvasConfiguration}}
 passed to {{GPUCanvasContext/configure()}}, and remains the same until {{GPUCanvasContext/configure()}}
 is called again with a new size. If a {{GPUCanvasConfiguration/size}} is not specified then the
 width and height attributes of the {{GPUCanvasContext}}.{{GPUCanvasContext/canvas}}
-at the time {{GPUCanvasContext/configure()}} is called will be used. If
-{{GPUCanvasContext}}.{{GPUCanvasContext/[[size]]}} does not match the dimensions of the canvas
-the textures produced by the {{GPUCanvasContext}} will be scaled to fit the canvas element.
+at the time {{GPUCanvasContext/configure()}} is called will be used.
+The image will be scaled to fit the displayed size of the canvas element.
 
 <div class="note">
     Note: Unlike `'webgl'` or `'2d'` contexts, `width` and `height` attributes of canvases with a

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2731,82 +2731,85 @@ namespace GPUTextureUsage {
                     1. If |descriptor|.{{GPUTextureDescriptor/format}} is a {{GPUTextureFormat}} that requires a feature (see
                         [[#texture-format-caps]]), but |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} does not
                         [=list/contain=] the feature, throw a {{TypeError}}.
-                    1. If any of the following requirements are unmet:
-                        <div class=validusage>
-                            - |this| must be a [=valid=] {{GPUDevice}}.
-                            - |descriptor|.{{GPUTextureDescriptor/usage}} must not be 0.
-                            - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=],
-                                |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=],
-                                and |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be greater than zero.
-                            - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be greater than zero.
-                            - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be either 1 or 4.
-
-                            - If |descriptor|.{{GPUTextureDescriptor/dimension}} is:
-                                <dl class="switch">
-                                    : {{GPUTextureDimension/"1d"}}
-                                    ::
-                                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be less than or equal to
-                                            |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension1D}}.
-                                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be 1.
-                                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be 1.
-                                        - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
-                                        - |descriptor|.{{GPUTextureDescriptor/format}} must not be a [=compressed format=] or [=depth-or-stencil format=].
-
-                                    : {{GPUTextureDimension/"2d"}}
-                                    ::
-                                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be less than or equal to
-                                            |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
-                                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be less than or equal to
-                                            |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
-                                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be less than
-                                            or equal to |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureArrayLayers}}.
-
-                                    : {{GPUTextureDimension/"3d"}}
-                                    ::
-                                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be less than or equal to
-                                            |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension3D}}.
-                                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be less than or equal to
-                                            |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension3D}}.
-                                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be less than
-                                            or equal to |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension3D}}.
-                                        - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
-                                        - |descriptor|.{{GPUTextureDescriptor/format}} must not be a [=compressed format=] or [=depth-or-stencil format=].
-                                </dl>
-                            - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be multiple of [=texel block width=].
-                            - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be multiple of [=texel block height=].
-
-                            - If |descriptor|.{{GPUTextureDescriptor/sampleCount}} > 1:
-                                - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be 1.
-                                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be 1.
-                                - |descriptor|.{{GPUTextureDescriptor/usage}} must not include the {{GPUTextureUsage/STORAGE_BINDING}} bit.
-                                - |descriptor|.{{GPUTextureDescriptor/usage}} must include the {{GPUTextureUsage/RENDER_ATTACHMENT}} bit.
-                                - |descriptor|.{{GPUTextureDescriptor/format}} must support multisampling according to [[#texture-format-caps]].
-
-                            - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be less than or equal to
-                                [$maximum mipLevel count$](|descriptor|.{{GPUTextureDescriptor/dimension}}, |descriptor|.{{GPUTextureDescriptor/size}}).
-
-                            - |descriptor|.{{GPUTextureDescriptor/usage}} must be a combination of {{GPUTextureUsage}} values.
-                            - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/RENDER_ATTACHMENT}} bit:
-                                - |descriptor|.{{GPUTextureDescriptor/format}} must be a [=renderable format=].
-                                - |descriptor|.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"2d"}}.
-                            - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/STORAGE_BINDING}} bit:
-                                - |descriptor|.{{GPUTextureDescriptor/format}} must be listed in [[#plain-color-formats]] table
-                                    with {{GPUTextureUsage/STORAGE_BINDING}} capability.
-                            - For each |viewFormat| in |descriptor|.{{GPUTextureDescriptor/viewFormats}},
-                                |descriptor|.{{GPUTextureDescriptor/format}} and |viewFormat| must be
-                                [=texture view format compatible=].
-                        </div>
-
-                        Then:
-                            1. [$Generate a validation error$].
-                            1. Return a new [=invalid=] {{GPUTexture}}.
-
+                    1. If [$validating GPUTextureDescriptor$](|this|, |descriptor|) returns false:
+                        1. [$Generate a validation error$].
+                        1. Return a new [=invalid=] {{GPUTexture}}.
                     1. Let |t| be a new {{GPUTexture}} object.
                     1. Set |t|.{{GPUTexture/[[descriptor]]}} to |descriptor|.
                     1. Return |t|.
                 </div>
         </div>
 </dl>
+
+<div algorithm class=validusage>
+    <dfn abstract-op>validating GPUTextureDescriptor</dfn>({{GPUDevice}} |this|, {{GPUTextureDescriptor}} |descriptor|):
+
+    Return true if all of the following requirements are met, and false otherwise:
+
+    - |this| must be a [=valid=] {{GPUDevice}}.
+    - |descriptor|.{{GPUTextureDescriptor/usage}} must not be 0.
+    - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=],
+        |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=],
+        and |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be greater than zero.
+    - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be greater than zero.
+    - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be either 1 or 4.
+
+    - If |descriptor|.{{GPUTextureDescriptor/dimension}} is:
+        <dl class="switch">
+            : {{GPUTextureDimension/"1d"}}
+            ::
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be less than or equal to
+                    |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension1D}}.
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be 1.
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be 1.
+                - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
+                - |descriptor|.{{GPUTextureDescriptor/format}} must not be a [=compressed format=] or [=depth-or-stencil format=].
+
+            : {{GPUTextureDimension/"2d"}}
+            ::
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be less than or equal to
+                    |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be less than or equal to
+                    |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be less than
+                    or equal to |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureArrayLayers}}.
+
+            : {{GPUTextureDimension/"3d"}}
+            ::
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be less than or equal to
+                    |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension3D}}.
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be less than or equal to
+                    |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension3D}}.
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be less than
+                    or equal to |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension3D}}.
+                - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
+                - |descriptor|.{{GPUTextureDescriptor/format}} must not be a [=compressed format=] or [=depth-or-stencil format=].
+        </dl>
+    - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be multiple of [=texel block width=].
+    - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be multiple of [=texel block height=].
+
+    - If |descriptor|.{{GPUTextureDescriptor/sampleCount}} > 1:
+        - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be 1.
+        - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be 1.
+        - |descriptor|.{{GPUTextureDescriptor/usage}} must not include the {{GPUTextureUsage/STORAGE_BINDING}} bit.
+        - |descriptor|.{{GPUTextureDescriptor/usage}} must include the {{GPUTextureUsage/RENDER_ATTACHMENT}} bit.
+        - |descriptor|.{{GPUTextureDescriptor/format}} must support multisampling according to [[#texture-format-caps]].
+
+    - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be less than or equal to
+        [$maximum mipLevel count$](|descriptor|.{{GPUTextureDescriptor/dimension}}, |descriptor|.{{GPUTextureDescriptor/size}}).
+
+    - |descriptor|.{{GPUTextureDescriptor/usage}} must be a combination of {{GPUTextureUsage}} values.
+    - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/RENDER_ATTACHMENT}} bit:
+        - |descriptor|.{{GPUTextureDescriptor/format}} must be a [=renderable format=].
+        - |descriptor|.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"2d"}}.
+    - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/STORAGE_BINDING}} bit:
+        - |descriptor|.{{GPUTextureDescriptor/format}} must be listed in [[#plain-color-formats]] table
+            with {{GPUTextureUsage/STORAGE_BINDING}} capability.
+    - For each |viewFormat| in |descriptor|.{{GPUTextureDescriptor/viewFormats}},
+        |descriptor|.{{GPUTextureDescriptor/format}} and |viewFormat| must be
+        [=texture view format compatible=].
+</div>
+
 
 <div class="example">
     Creating a 16x16, RGBA, 2D texture with one array layer and one mip level:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2058,6 +2058,37 @@ Those not defined here are defined elsewhere in this document.
         allocations and abort outstanding asynchronous operations immediately.
 </dl>
 
+<div algorithm>
+    A {{GPUDevice}}'s <dfn dfn>allowed buffer usages</dfn> are:
+
+    - Always allowed:
+        {{GPUBufferUsage/MAP_READ}},
+        {{GPUBufferUsage/MAP_WRITE}},
+        {{GPUBufferUsage/COPY_SRC}},
+        {{GPUBufferUsage/COPY_DST}},
+        {{GPUBufferUsage/INDEX}},
+        {{GPUBufferUsage/VERTEX}},
+        {{GPUBufferUsage/UNIFORM}},
+        {{GPUBufferUsage/STORAGE}},
+        {{GPUBufferUsage/INDIRECT}},
+        {{GPUBufferUsage/QUERY_RESOLVE}}
+
+    <!-- As needed, compute more allowed usages based on the features enabled on the device. -->
+</div>
+
+<div algorithm>
+    A {{GPUDevice}}'s <dfn dfn>allowed texture usages</dfn> are:
+
+    - Always allowed:
+        {{GPUTextureUsage/COPY_SRC}},
+        {{GPUTextureUsage/COPY_DST}},
+        {{GPUTextureUsage/TEXTURE_BINDING}},
+        {{GPUTextureUsage/STORAGE_BINDING}},
+        {{GPUTextureUsage/RENDER_ATTACHMENT}}
+
+    <!-- As needed, compute more allowed usages based on the features enabled on the device. -->
+</div>
+
 {{GPUDevice}} objects are [=serializable objects=].
 
 Issue(gpuweb/gpuweb#354): Finish defining multithreading API and add `[Serializable]` back to the interface.
@@ -2267,10 +2298,12 @@ dictionary GPUBufferDescriptor : GPUObjectDescriptorBase {
     it will still appear as if the mapped range can be written/read to until it is unmapped.
 
 <div algorithm>
-    <dfn abstract-op>validating GPUBufferDescriptor</dfn>(device, descriptor)
-        1. If device is lost return `false`.
-        1. If any of the bits of |descriptor|'s {{GPUBufferDescriptor/usage}} aren't present in this device's [[allowed buffer usages]] return `false`.
-        1. If both the {{GPUBufferUsage/MAP_READ}} and {{GPUBufferUsage/MAP_WRITE}} bits of |descriptor|'s {{GPUBufferDescriptor/usage}} attribute are set, return `false`.
+    <dfn abstract-op>validating GPUBufferDescriptor</dfn>(|device|, |descriptor|)
+        1. If |device| is lost return `false`.
+        1. If any of the bits of |descriptor|'s {{GPUBufferDescriptor/usage}} aren't present in
+            |device|'s [=allowed buffer usages=], return `false`.
+        1. If both the {{GPUBufferUsage/MAP_READ}} and {{GPUBufferUsage/MAP_WRITE}} bits of
+            |descriptor|'s {{GPUBufferDescriptor/usage}} attribute are set, return `false`.
         1. Return `true`.
 </div>
 
@@ -2313,7 +2346,7 @@ namespace GPUBufferUsage {
                     - |this| is a [=valid=] {{GPUDevice}}.
                     - [$validating GPUBufferDescriptor$](|this|, |descriptor|) returns true.
                     - |descriptor|.{{GPUBufferDescriptor/usage}} must not be 0.
-                    - |descriptor|.{{GPUBufferDescriptor/usage}} is a subset of |this|.[[allowed buffer usages]].
+                    - |descriptor|.{{GPUBufferDescriptor/usage}} is a subset of |this|'s [=allowed buffer usages=].
                     - If |descriptor|.{{GPUBufferDescriptor/usage}} contains {{GPUBufferUsage/MAP_READ}}:
                         - |descriptor|.{{GPUBufferDescriptor/usage}} contains no other flags
                             except {{GPUBufferUsage/COPY_DST}}.
@@ -2322,8 +2355,6 @@ namespace GPUBufferUsage {
                             except {{GPUBufferUsage/COPY_SRC}}.
                     - If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`:
                         - |descriptor|.{{GPUBufferDescriptor/size}} is a multiple of 4.
-
-                    Issue(gpuweb/gpuweb#605): Explain what are a {{GPUDevice}}'s `[[allowed buffer usages]]`.
                 </div>
 
             Note: If buffer creation fails, and |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `false`,
@@ -2748,6 +2779,7 @@ namespace GPUTextureUsage {
 
     - |this| must be a [=valid=] {{GPUDevice}}.
     - |descriptor|.{{GPUTextureDescriptor/usage}} must not be 0.
+    - |descriptor|.{{GPUTextureDescriptor/usage}} must contain only bits present in |this|'s [=allowed texture usages=].
     - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=],
         |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=],
         and |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be greater than zero.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -10462,8 +10462,13 @@ interface GPUCanvasContext {
 
             1. Issue the following steps on the [=Device timeline=] of |device|:
                 <div class=device-timeline>
-                    1. If [$validating GPUTextureDescriptor$](|device|, |descriptor|) returns false,
-                        [$generate a validation error$] and stop.
+                    1. If any of the following requirements are unmet, [$generate a validation error$] and stop.
+                        <div class=validusage>
+                            - [$validating GPUTextureDescriptor$](|device|, |descriptor|)
+                                must return true.
+                            - [=Supported context formats=] must [=set/contain=]
+                                |configuration|.{{GPUCanvasConfiguration/format}}.
+                        </div>
                 </div>
         </div>
 


### PR DESCRIPTION
~**Dependent on #2823**~

Moves the validation of the GPUCanvasConfiguration to configure(), instead of doing it implicitly later in getCurrentTexture().


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 16, 2022, 10:29 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fkainino0x%2Fgpuweb%2F25fa086307e93dffc9cf1b1b34caeb7ce4e48c60%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%232821.)._
</details>
