### PR TITLE
Validate unknown texture usage bits

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2731,82 +2731,85 @@ namespace GPUTextureUsage {
                     1. If |descriptor|.{{GPUTextureDescriptor/format}} is a {{GPUTextureFormat}} that requires a feature (see
                         [[#texture-format-caps]]), but |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} does not
                         [=list/contain=] the feature, throw a {{TypeError}}.
-                    1. If any of the following requirements are unmet:
-                        <div class=validusage>
-                            - |this| must be a [=valid=] {{GPUDevice}}.
-                            - |descriptor|.{{GPUTextureDescriptor/usage}} must not be 0.
-                            - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=],
-                                |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=],
-                                and |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be greater than zero.
-                            - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be greater than zero.
-                            - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be either 1 or 4.
-
-                            - If |descriptor|.{{GPUTextureDescriptor/dimension}} is:
-                                <dl class="switch">
-                                    : {{GPUTextureDimension/"1d"}}
-                                    ::
-                                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be less than or equal to
-                                            |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension1D}}.
-                                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be 1.
-                                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be 1.
-                                        - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
-                                        - |descriptor|.{{GPUTextureDescriptor/format}} must not be a [=compressed format=] or [=depth-or-stencil format=].
-
-                                    : {{GPUTextureDimension/"2d"}}
-                                    ::
-                                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be less than or equal to
-                                            |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
-                                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be less than or equal to
-                                            |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
-                                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be less than
-                                            or equal to |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureArrayLayers}}.
-
-                                    : {{GPUTextureDimension/"3d"}}
-                                    ::
-                                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be less than or equal to
-                                            |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension3D}}.
-                                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be less than or equal to
-                                            |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension3D}}.
-                                        - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be less than
-                                            or equal to |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension3D}}.
-                                        - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
-                                        - |descriptor|.{{GPUTextureDescriptor/format}} must not be a [=compressed format=] or [=depth-or-stencil format=].
-                                </dl>
-                            - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be multiple of [=texel block width=].
-                            - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be multiple of [=texel block height=].
-
-                            - If |descriptor|.{{GPUTextureDescriptor/sampleCount}} > 1:
-                                - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be 1.
-                                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be 1.
-                                - |descriptor|.{{GPUTextureDescriptor/usage}} must not include the {{GPUTextureUsage/STORAGE_BINDING}} bit.
-                                - |descriptor|.{{GPUTextureDescriptor/usage}} must include the {{GPUTextureUsage/RENDER_ATTACHMENT}} bit.
-                                - |descriptor|.{{GPUTextureDescriptor/format}} must support multisampling according to [[#texture-format-caps]].
-
-                            - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be less than or equal to
-                                [$maximum mipLevel count$](|descriptor|.{{GPUTextureDescriptor/dimension}}, |descriptor|.{{GPUTextureDescriptor/size}}).
-
-                            - |descriptor|.{{GPUTextureDescriptor/usage}} must be a combination of {{GPUTextureUsage}} values.
-                            - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/RENDER_ATTACHMENT}} bit:
-                                - |descriptor|.{{GPUTextureDescriptor/format}} must be a [=renderable format=].
-                                - |descriptor|.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"2d"}}.
-                            - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/STORAGE_BINDING}} bit:
-                                - |descriptor|.{{GPUTextureDescriptor/format}} must be listed in [[#plain-color-formats]] table
-                                    with {{GPUTextureUsage/STORAGE_BINDING}} capability.
-                            - For each |viewFormat| in |descriptor|.{{GPUTextureDescriptor/viewFormats}},
-                                |descriptor|.{{GPUTextureDescriptor/format}} and |viewFormat| must be
-                                [=texture view format compatible=].
-                        </div>
-
-                        Then:
-                            1. [$Generate a validation error$].
-                            1. Return a new [=invalid=] {{GPUTexture}}.
-
+                    1. If [$validating GPUTextureDescriptor$](|this|, |descriptor|) returns false:
+                        1. [$Generate a validation error$].
+                        1. Return a new [=invalid=] {{GPUTexture}}.
                     1. Let |t| be a new {{GPUTexture}} object.
                     1. Set |t|.{{GPUTexture/[[descriptor]]}} to |descriptor|.
                     1. Return |t|.
                 </div>
         </div>
 </dl>
+
+<div algorithm class=validusage>
+    <dfn abstract-op>validating GPUTextureDescriptor</dfn>({{GPUDevice}} |this|, {{GPUTextureDescriptor}} |descriptor|):
+
+    Return true if all of the following requirements are met, and false otherwise:
+
+    - |this| must be a [=valid=] {{GPUDevice}}.
+    - |descriptor|.{{GPUTextureDescriptor/usage}} must not be 0.
+    - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=],
+        |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=],
+        and |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be greater than zero.
+    - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be greater than zero.
+    - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be either 1 or 4.
+
+    - If |descriptor|.{{GPUTextureDescriptor/dimension}} is:
+        <dl class="switch">
+            : {{GPUTextureDimension/"1d"}}
+            ::
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be less than or equal to
+                    |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension1D}}.
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be 1.
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be 1.
+                - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
+                - |descriptor|.{{GPUTextureDescriptor/format}} must not be a [=compressed format=] or [=depth-or-stencil format=].
+
+            : {{GPUTextureDimension/"2d"}}
+            ::
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be less than or equal to
+                    |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be less than or equal to
+                    |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be less than
+                    or equal to |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureArrayLayers}}.
+
+            : {{GPUTextureDimension/"3d"}}
+            ::
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be less than or equal to
+                    |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension3D}}.
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be less than or equal to
+                    |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension3D}}.
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be less than
+                    or equal to |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension3D}}.
+                - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
+                - |descriptor|.{{GPUTextureDescriptor/format}} must not be a [=compressed format=] or [=depth-or-stencil format=].
+        </dl>
+    - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be multiple of [=texel block width=].
+    - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be multiple of [=texel block height=].
+
+    - If |descriptor|.{{GPUTextureDescriptor/sampleCount}} > 1:
+        - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be 1.
+        - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be 1.
+        - |descriptor|.{{GPUTextureDescriptor/usage}} must not include the {{GPUTextureUsage/STORAGE_BINDING}} bit.
+        - |descriptor|.{{GPUTextureDescriptor/usage}} must include the {{GPUTextureUsage/RENDER_ATTACHMENT}} bit.
+        - |descriptor|.{{GPUTextureDescriptor/format}} must support multisampling according to [[#texture-format-caps]].
+
+    - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be less than or equal to
+        [$maximum mipLevel count$](|descriptor|.{{GPUTextureDescriptor/dimension}}, |descriptor|.{{GPUTextureDescriptor/size}}).
+
+    - |descriptor|.{{GPUTextureDescriptor/usage}} must be a combination of {{GPUTextureUsage}} values.
+    - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/RENDER_ATTACHMENT}} bit:
+        - |descriptor|.{{GPUTextureDescriptor/format}} must be a [=renderable format=].
+        - |descriptor|.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"2d"}}.
+    - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/STORAGE_BINDING}} bit:
+        - |descriptor|.{{GPUTextureDescriptor/format}} must be listed in [[#plain-color-formats]] table
+            with {{GPUTextureUsage/STORAGE_BINDING}} capability.
+    - For each |viewFormat| in |descriptor|.{{GPUTextureDescriptor/viewFormats}},
+        |descriptor|.{{GPUTextureDescriptor/format}} and |viewFormat| must be
+        [=texture view format compatible=].
+</div>
+
 
 <div class="example">
     Creating a 16x16, RGBA, 2D texture with one array layer and one mip level:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2058,6 +2058,37 @@ Those not defined here are defined elsewhere in this document.
         allocations and abort outstanding asynchronous operations immediately.
 </dl>
 
+<div algorithm>
+    A {{GPUDevice}}'s <dfn dfn>allowed buffer usages</dfn> are:
+
+    - Always allowed:
+        {{GPUBufferUsage/MAP_READ}},
+        {{GPUBufferUsage/MAP_WRITE}},
+        {{GPUBufferUsage/COPY_SRC}},
+        {{GPUBufferUsage/COPY_DST}},
+        {{GPUBufferUsage/INDEX}},
+        {{GPUBufferUsage/VERTEX}},
+        {{GPUBufferUsage/UNIFORM}},
+        {{GPUBufferUsage/STORAGE}},
+        {{GPUBufferUsage/INDIRECT}},
+        {{GPUBufferUsage/QUERY_RESOLVE}}
+
+    <!-- As needed, compute more allowed usages based on the features enabled on the device. -->
+</div>
+
+<div algorithm>
+    A {{GPUDevice}}'s <dfn dfn>allowed texture usages</dfn> are:
+
+    - Always allowed:
+        {{GPUTextureUsage/COPY_SRC}},
+        {{GPUTextureUsage/COPY_DST}},
+        {{GPUTextureUsage/TEXTURE_BINDING}},
+        {{GPUTextureUsage/STORAGE_BINDING}},
+        {{GPUTextureUsage/RENDER_ATTACHMENT}}
+
+    <!-- As needed, compute more allowed usages based on the features enabled on the device. -->
+</div>
+
 {{GPUDevice}} objects are [=serializable objects=].
 
 Issue(gpuweb/gpuweb#354): Finish defining multithreading API and add `[Serializable]` back to the interface.
@@ -2267,10 +2298,12 @@ dictionary GPUBufferDescriptor : GPUObjectDescriptorBase {
     it will still appear as if the mapped range can be written/read to until it is unmapped.
 
 <div algorithm>
-    <dfn abstract-op>validating GPUBufferDescriptor</dfn>(device, descriptor)
-        1. If device is lost return `false`.
-        1. If any of the bits of |descriptor|'s {{GPUBufferDescriptor/usage}} aren't present in this device's [[allowed buffer usages]] return `false`.
-        1. If both the {{GPUBufferUsage/MAP_READ}} and {{GPUBufferUsage/MAP_WRITE}} bits of |descriptor|'s {{GPUBufferDescriptor/usage}} attribute are set, return `false`.
+    <dfn abstract-op>validating GPUBufferDescriptor</dfn>(|device|, |descriptor|)
+        1. If |device| is lost return `false`.
+        1. If any of the bits of |descriptor|'s {{GPUBufferDescriptor/usage}} aren't present in
+            |device|'s [=allowed buffer usages=], return `false`.
+        1. If both the {{GPUBufferUsage/MAP_READ}} and {{GPUBufferUsage/MAP_WRITE}} bits of
+            |descriptor|'s {{GPUBufferDescriptor/usage}} attribute are set, return `false`.
         1. Return `true`.
 </div>
 
@@ -2313,7 +2346,7 @@ namespace GPUBufferUsage {
                     - |this| is a [=valid=] {{GPUDevice}}.
                     - [$validating GPUBufferDescriptor$](|this|, |descriptor|) returns true.
                     - |descriptor|.{{GPUBufferDescriptor/usage}} must not be 0.
-                    - |descriptor|.{{GPUBufferDescriptor/usage}} is a subset of |this|.[[allowed buffer usages]].
+                    - |descriptor|.{{GPUBufferDescriptor/usage}} is a subset of |this|'s [=allowed buffer usages=].
                     - If |descriptor|.{{GPUBufferDescriptor/usage}} contains {{GPUBufferUsage/MAP_READ}}:
                         - |descriptor|.{{GPUBufferDescriptor/usage}} contains no other flags
                             except {{GPUBufferUsage/COPY_DST}}.
@@ -2322,8 +2355,6 @@ namespace GPUBufferUsage {
                             except {{GPUBufferUsage/COPY_SRC}}.
                     - If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`:
                         - |descriptor|.{{GPUBufferDescriptor/size}} is a multiple of 4.
-
-                    Issue(gpuweb/gpuweb#605): Explain what are a {{GPUDevice}}'s `[[allowed buffer usages]]`.
                 </div>
 
             Note: If buffer creation fails, and |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `false`,
@@ -2748,6 +2779,7 @@ namespace GPUTextureUsage {
 
     - |this| must be a [=valid=] {{GPUDevice}}.
     - |descriptor|.{{GPUTextureDescriptor/usage}} must not be 0.
+    - |descriptor|.{{GPUTextureDescriptor/usage}} must contain only bits present in |this|'s [=allowed texture usages=].
     - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=],
         |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=],
         and |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be greater than zero.


### PR DESCRIPTION
- Validate unknown texture usage bits
- Add definition of "allowed buffer usages" too
- Factor GPUTextureDescriptor validation into a separate algorithm (for #2821)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 6, 2022, 12:59 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fgpuweb%2Fgpuweb%2F8110dbbf672b8ebf02d864de73eaffd7b3d72e9a%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%232823.)._
</details>
