### PR TITLE
Add definitions to more render pipeline descriptors

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6071,43 +6071,43 @@ enum GPUBlendFactor {
   <tbody dfn-type=enum-value dfn-for=GPUBlendFactor>
     <tr>
       <td><dfn>"zero"
-      <td><code>(0,0,0,0)
+      <td><code>(0, 0, 0, 0)
     <tr>
       <td><dfn>"one"
-      <td><code>(1,1,1,1)
+      <td><code>(1, 1, 1, 1)
     <tr>
       <td><dfn>"src"
-      <td><code>(R<sub>src</sub>,G<sub>src</sub>,B<sub>src</sub>,A<sub>src</sub>)
+      <td><code>(R<sub>src</sub>, G<sub>src</sub>, B<sub>src</sub>, A<sub>src</sub>)
     <tr>
       <td><dfn>"one-minus-src"
-      <td><code>(1-R<sub>src</sub>,1-G<sub>src</sub>,1-B<sub>src</sub>,1-A<sub>src</sub>)
+      <td><code>(1 - R<sub>src</sub>, 1 - G<sub>src</sub>, 1 - B<sub>src</sub>, 1 - A<sub>src</sub>)
     <tr>
       <td><dfn>"src-alpha"
-      <td><code>(A<sub>src</sub>,A<sub>src</sub>,A<sub>src</sub>,A<sub>src</sub>)
+      <td><code>(A<sub>src</sub>, A<sub>src</sub>, A<sub>src</sub>, A<sub>src</sub>)
     <tr>
       <td><dfn>"one-minus-src-alpha"
-      <td><code>(1-A<sub>src</sub>,1-A<sub>src</sub>,1-A<sub>src</sub>,1-A<sub>src</sub>)
+      <td><code>(1 - A<sub>src</sub>, 1 - A<sub>src</sub>, 1 - A<sub>src</sub>, 1 - A<sub>src</sub>)
     <tr>
       <td><dfn>"dst"
-      <td><code>(R<sub>dst</sub>,G<sub>dst</sub>,B<sub>dst</sub>,A<sub>dst</sub>)
+      <td><code>(R<sub>dst</sub>, G<sub>dst</sub>, B<sub>dst</sub>, A<sub>dst</sub>)
     <tr>
       <td><dfn>"one-minus-dst"
-      <td><code>(1-R<sub>dst</sub>,1-G<sub>dst</sub>,1-B<sub>dst</sub>,1-A<sub>dst</sub>)
+      <td><code>(1 - R<sub>dst</sub>, 1 - G<sub>dst</sub>, 1 - B<sub>dst</sub>, 1 - A<sub>dst</sub>)
     <tr>
       <td><dfn>"dst-alpha"
-      <td><code>(A<sub>dst</sub>,A<sub>dst</sub>,A<sub>dst</sub>,A<sub>dst</sub>)
+      <td><code>(A<sub>dst</sub>, A<sub>dst</sub>, A<sub>dst</sub>, A<sub>dst</sub>)
     <tr>
       <td><dfn>"one-minus-dst-alpha"
-      <td><code>(1-A<sub>dst</sub>,1-A<sub>dst</sub>,1-A<sub>dst</sub>,1-A<sub>dst</sub>)
+      <td><code>(1 - A<sub>dst</sub>, 1 - A<sub>dst</sub>, 1 - A<sub>dst</sub>, 1 - A<sub>dst</sub>)
     <tr>
       <td><dfn>"src-alpha-saturated"
-      <td><code>(A<sub>src</sub>,A<sub>src</sub>,A<sub>src</sub>,A<sub>src</sub>)
+      <td><code>(A<sub>src</sub>, A<sub>src</sub>, A<sub>src</sub>, A<sub>src</sub>)
     <tr>
       <td><dfn>"constant"
-      <td><code>(R<sub>const</sub>,G<sub>const</sub>,B<sub>const</sub>,A<sub>const</sub>)
+      <td><code>(R<sub>const</sub>, G<sub>const</sub>, B<sub>const</sub>, A<sub>const</sub>)
     <tr>
       <td><dfn>"one-minus-constant"
-      <td><code>(1-R<sub>const</sub>,1-G<sub>const</sub>,1-B<sub>const</sub>,A<sub>const</sub>)
+      <td><code>(1 - R<sub>const</sub>, 1 - G<sub>const</sub>, 1 - B<sub>const</sub>, 1 - A<sub>const</sub>)
   </tbody>
 </table>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5888,9 +5888,10 @@ interacts with a render pass's multisampled attachments.
 <dl dfn-type=dict-member dfn-for=GPUMultisampleState>
     : <dfn>count</dfn>
     ::
-        The {{GPUTextureDescriptor/sampleCount}} of any {{GPURenderPassDescriptor/colorAttachments}}
-        and {{GPURenderPassDescriptor/depthStencilAttachment}} this {{GPURenderPipeline}} will be
-        compatible with.
+        Number of samples per pixel. This {{GPURenderPipeline}} will be compatible only
+        with attachment textures ({{GPURenderPassDescriptor/colorAttachments}}
+        and {{GPURenderPassDescriptor/depthStencilAttachment}}) 
+        with matching {{GPUTextureDescriptor/sampleCount}}s.
 
     : <dfn>mask</dfn>
     ::

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5731,16 +5731,6 @@ Issue: need a proper limit for the maximum number of color targets.
 ### Primitive State ### {#primitive-state}
 
 <script type=idl>
-enum GPUPrimitiveTopology {
-    "point-list",
-    "line-list",
-    "line-strip",
-    "triangle-list",
-    "triangle-strip",
-};
-</script>
-
-<script type=idl>
 dictionary GPUPrimitiveState {
     GPUPrimitiveTopology topology = "triangle-list";
     GPUIndexFormat stripIndexFormat;
@@ -5751,6 +5741,35 @@ dictionary GPUPrimitiveState {
     boolean unclippedDepth = false;
 };
 </script>
+
+{{GPUPrimitiveState}} has the following members, which describe how a {{GPURenderPipeline}}
+constructs and rasterizes primitives from it's vertex inputs:
+
+<dl dfn-type=dict-member dfn-for=GPUPrimitiveState>
+    : <dfn>topology</dfn>
+    ::
+        The type of primitive to be constructed from the vertex inptus.
+
+    : <dfn>stripIndexFormat</dfn>
+    ::
+        For strip topologies ({{GPUPrimitiveTopology/"line-strip"}} or
+        {{GPUPrimitiveTopology/"triangle-strip"}}), defines the format of indices that may be used
+        with this {{GPURenderPipeline}}. This determines the strip's primitive restart value. See
+        [[#primitive-assembly]] for additional details.
+
+    : <dfn>frontFace</dfn>
+    ::
+        Defines which polygons are considered [=front-facing=].
+
+    : <dfn>cullMode</dfn>
+    ::
+        Defines which polygon orientation will be culled.
+
+    : <dfn>unclippedDepth</dfn>
+    ::
+        If the {{GPUFeatureName/"depth-clip-control"}} feature is enabled, indicates that depth
+        clipping is disabled when set to `true`. See [[#depth-clip-control]] for additional details.
+</dl>
 
 <div algorithm>
     <dfn abstract-op>validating GPUPrimitiveState</dfn>(|descriptor|, |features|)
@@ -5767,11 +5786,62 @@ dictionary GPUPrimitiveState {
 </div>
 
 <script type=idl>
+enum GPUPrimitiveTopology {
+    "point-list",
+    "line-list",
+    "line-strip",
+    "triangle-list",
+    "triangle-strip",
+};
+</script>
+
+{{GPUPrimitiveTopology}} defines the primitive type draw calls made with a {{GPURenderPipeline}}
+will use. See [[#rasterization]] for additional details:
+
+<dl dfn-type=enum-value dfn-for=GPUPrimitiveTopology>
+    : <dfn>"point-list"</dfn>
+    ::
+        Each vertex defines a point primitive.
+
+    : <dfn>"line-list"</dfn>
+    ::
+        Each separate set of two vertices defines a line primitive.
+
+    : <dfn>"line-strip"</dfn>
+    ::
+        Each vertex after the first defines a line primitive between it and the previous vertex.
+
+    : <dfn>"triangle-list"</dfn>
+    ::
+        Each separate set of three vertices defines a triangle primitive.
+
+    : <dfn>"triangle-strip"</dfn>
+    ::
+        Each vertex after the first two defines a triangle primitive between it and the previous
+        two vertices.
+</dl>
+
+<script type=idl>
 enum GPUFrontFace {
     "ccw",
     "cw",
 };
 </script>
+
+{{GPUFrontFace}} defines which polygons are considered [=front-facing=] by a {{GPURenderPipeline}}.
+See [[#polygon-rasterization]] for additional details:
+
+<dl dfn-type=enum-value dfn-for=GPUFrontFace>
+    : <dfn>"ccw"</dfn>
+    ::
+        Polygons with vertices who's framebuffer coordinates are given in counter-clockwise order
+        are considered [=front-facing=].
+
+    : <dfn>"cw"</dfn>
+    ::
+        Polygons with vertices who's framebuffer coordinates are given in clockwise order are
+        considered [=front-facing=].
+</dl>
 
 <script type=idl>
 enum GPUCullMode {
@@ -5780,6 +5850,23 @@ enum GPUCullMode {
     "back",
 };
 </script>
+
+{{GPUPrimitiveTopology}} defines which polygons will be culled by draw calls made with a
+{{GPURenderPipeline}}. See [[#polygon-rasterization]] for additional details:
+
+<dl dfn-type=enum-value dfn-for=GPUCullMode>
+    : <dfn>"none"</dfn>
+    ::
+        No polygons are discarded.
+
+    : <dfn>"front"</dfn>
+    ::
+        [=Front-facing=] polygons are discarded.
+
+    : <dfn>"back"</dfn>
+    ::
+        [=Back-facing=] polygons are discarded.
+</dl>
 
 ### Multisample State ### {#multisample-state}
 
@@ -5790,6 +5877,26 @@ dictionary GPUMultisampleState {
     boolean alphaToCoverageEnabled = false;
 };
 </script>
+
+{{GPUMultisampleState}} has the following members, which describe how a {{GPURenderPipeline}}
+interacts with a render pass's multisampled attachments.
+
+<dl dfn-type=dict-member dfn-for=GPUMultisampleState>
+    : <dfn>count</dfn>
+    ::
+        The {{GPUTextureDescriptor/sampleCount}} of any {{GPURenderPassDescriptor/colorAttachments}}
+        and {{GPURenderPassDescriptor/depthStencilAttachment}} this {{GPURenderPipeline}} will be
+        compatible with.
+
+    : <dfn>mask</dfn>
+    ::
+        Mask determining which samples are written to.
+
+    : <dfn>alphaToCoverageEnabled</dfn>
+    ::
+        When `true` indicates that a fragment's alpha channel should be used to generate a sample
+        covarge mask.
+</dl>
 
 <div algorithm>
     <dfn abstract-op>validating GPUMultisampleState</dfn>(|descriptor|)
@@ -5889,6 +5996,46 @@ dictionary GPUBlendComponent {
 };
 </script>
 
+{{GPUBlendComponent}} has the following members, which describe how the color or alpha components
+of a fragment are blended:
+
+<dl dfn-type=dict-member dfn-for=GPUBlendComponent>
+    : <dfn>operation</dfn>
+    ::
+        Defines the {{GPUBlendOperation}} used to calculate the values written to the target
+        attachment components.
+
+    : <dfn>srcFactor</dfn>
+    ::
+        Defines the {{GPUBlendFactor}} operation to be performed on values from the fragment shader.
+
+    : <dfn>dstFactor</dfn>
+    ::
+        Defines the {{GPUBlendFactor}} operation to be performed on values from the target attachment.
+</dl>
+
+The following tables use this notation to describe color components for a given fragment
+location:
+<table class="data">
+  <tbody>
+    <tr>
+      <td><b><code>RGBA<sub>src</src></code></b>
+      <td>Color output by the fragment shader for the color attachment.
+    <tr>
+      <td><b><code>RGBA<sub>dst</src></code></b>
+      <td>Color currently in the color attachment.
+    <tr>
+      <td><b><code>RGBA<sub>const</src></code></b>
+      <td>The current {{GPURenderPassEncoder/[[blend_constant]]}}.
+    <tr>
+      <td><b><code>RGBA<sub>srcFactor</src></code></b>
+      <td>The source blend factor components, as defined by {{GPUBlendComponent/srcFactor}}.
+    <tr>
+      <td><b><code>RGBA<sub>dstFactor</src></code></b>
+      <td>The destination blend factor components, as defined by {{GPUBlendComponent/dstFactor}}.
+  </tbody>
+</table>
+
 <script type=idl>
 enum GPUBlendFactor {
     "zero",
@@ -5907,6 +6054,58 @@ enum GPUBlendFactor {
 };
 </script>
 
+{{GPUBlendFactor}} defines how either a source or destination blend factors is calculated:
+
+<table class="data">
+  <thead>
+    <tr>
+      <th>GPUBlendFactor
+      <th>Blend factor RGBA components
+    </tr>
+  </thead>
+  <tbody dfn-type=enum-value dfn-for=GPUBlendFactor>
+    <tr>
+      <td><dfn>"zero"
+      <td><code>(0,0,0,0)
+    <tr>
+      <td><dfn>"one"
+      <td><code>(1,1,1,1)
+    <tr>
+      <td><dfn>"src"
+      <td><code>(R<sub>src</sub>,G<sub>src</sub>,B<sub>src</sub>,A<sub>src</sub>)
+    <tr>
+      <td><dfn>"one-minus-src"
+      <td><code>(1-R<sub>src</sub>,1-G<sub>src</sub>,1-B<sub>src</sub>,1-A<sub>src</sub>)
+    <tr>
+      <td><dfn>"src-alpha"
+      <td><code>(A<sub>src</sub>,A<sub>src</sub>,A<sub>src</sub>,A<sub>src</sub>)
+    <tr>
+      <td><dfn>"one-minus-src-alpha"
+      <td><code>(1-A<sub>src</sub>,1-A<sub>src</sub>,1-A<sub>src</sub>,1-A<sub>src</sub>)
+    <tr>
+      <td><dfn>"dst"
+      <td><code>(R<sub>dst</sub>,G<sub>dst</sub>,B<sub>dst</sub>,A<sub>dst</sub>)
+    <tr>
+      <td><dfn>"one-minus-dst"
+      <td><code>(1-R<sub>dst</sub>,1-G<sub>dst</sub>,1-B<sub>dst</sub>,1-A<sub>dst</sub>)
+    <tr>
+      <td><dfn>"dst-alpha"
+      <td><code>(A<sub>dst</sub>,A<sub>dst</sub>,A<sub>dst</sub>,A<sub>dst</sub>)
+    <tr>
+      <td><dfn>"one-minus-dst-alpha"
+      <td><code>(1-A<sub>dst</sub>,1-A<sub>dst</sub>,1-A<sub>dst</sub>,1-A<sub>dst</sub>)
+    <tr>
+      <td><dfn>"src-alpha-saturated"
+      <td><code>(A<sub>src</sub>,A<sub>src</sub>,A<sub>src</sub>,A<sub>src</sub>)
+    <tr>
+      <td><dfn>"constant"
+      <td><code>(R<sub>const</sub>,G<sub>const</sub>,B<sub>const</sub>,A<sub>const</sub>)
+    <tr>
+      <td><dfn>"one-minus-constant"
+      <td><code>(1-R<sub>const</sub>,1-G<sub>const</sub>,1-B<sub>const</sub>,A<sub>const</sub>)
+  </tbody>
+</table>
+
 <script type=idl>
 enum GPUBlendOperation {
     "add",
@@ -5916,6 +6115,39 @@ enum GPUBlendOperation {
     "max",
 };
 </script>
+
+{{GPUBlendOperation}} defines the algorithm used to combine source and destination blend factors:
+
+<table class="data">
+  <thead>
+    <tr>
+      <th>GPUBlendOperation
+      <th>RGBA Components
+    </tr>
+  </thead>
+  <tbody dfn-type=enum-value dfn-for=GPUBlendOperation>
+    <tr>
+      <td><dfn>"add"
+      <td>
+        <code>RGBA<sub>src</sub> × RGBA<sub>srcFactor</sub> + RGBA<sub>dst</sub> × RGBA<sub>dstFactor</sub>
+    <tr>
+      <td><dfn>"subtract"
+      <td>
+        <code>RGBA<sub>src</sub> × RGBA<sub>srcFactor</sub> - RGBA<sub>dst</sub> × RGBA<sub>dstFactor</sub>
+    <tr>
+      <td><dfn>"reverse-subtract"
+      <td>
+        <code>RGBA<sub>dst</sub> × RGBA<sub>dstFactor</sub> - RGBA<sub>src</sub> × RGBA<sub>srcFactor</sub>
+    <tr>
+      <td><dfn>"min"
+      <td>
+        <code>min(RGBA<sub>src</sub>, RGBA<sub>dst</sub>)
+    <tr>
+      <td><dfn>"max"
+      <td>
+        <code>max(RGBA<sub>src</sub>, RGBA<sub>dst</sub>)
+  </tbody>
+</table>
 
 ### Depth/Stencil State ### {#depth-stencil-state}
 
@@ -5935,28 +6167,6 @@ dictionary GPUDepthStencilState {
     GPUDepthBias depthBias = 0;
     float depthBiasSlopeScale = 0;
     float depthBiasClamp = 0;
-};
-</script>
-
-<script type=idl>
-dictionary GPUStencilFaceState {
-    GPUCompareFunction compare = "always";
-    GPUStencilOperation failOp = "keep";
-    GPUStencilOperation depthFailOp = "keep";
-    GPUStencilOperation passOp = "keep";
-};
-</script>
-
-<script type=idl>
-enum GPUStencilOperation {
-    "keep",
-    "zero",
-    "replace",
-    "invert",
-    "increment-clamp",
-    "decrement-clamp",
-    "increment-wrap",
-    "decrement-wrap",
 };
 </script>
 
@@ -6030,6 +6240,33 @@ will affect a render pass's {{GPURenderPassDescriptor/depthStencilAttachment}}:
         1. Set the fragment depth value to <code>fragment depth value + |bias|</code>
 </div>
 
+<div algorithm>
+    <dfn abstract-op>validating GPUDepthStencilState</dfn>(descriptor)
+    **Arguments:**
+        - {{GPUDepthStencilState}} |descriptor|
+
+    Return `true`, if and only if, all of the following conditions are satisfied:
+
+        - |descriptor|.{{GPUDepthStencilState/format}} is a [=depth-or-stencil format=].
+        - if |descriptor|.{{GPUDepthStencilState/depthWriteEnabled}} is `true` or
+            |descriptor|.{{GPUDepthStencilState/depthCompare}} is not {{GPUCompareFunction/"always"}}:
+            - |descriptor|.{{GPUDepthStencilState/format}} must have a depth component.
+        - if |descriptor|.{{GPUDepthStencilState/stencilFront}} or
+            |descriptor|.{{GPUDepthStencilState/stencilBack}} are not default values:
+            - |descriptor|.{{GPUDepthStencilState/format}} must have a stencil component.
+
+    Issue: how can this algorithm support depth/stencil formats that are added in extensions?
+</div>
+
+<script type=idl>
+dictionary GPUStencilFaceState {
+    GPUCompareFunction compare = "always";
+    GPUStencilOperation failOp = "keep";
+    GPUStencilOperation depthFailOp = "keep";
+    GPUStencilOperation passOp = "keep";
+};
+</script>
+
 {{GPUStencilFaceState}} has the following members, which describe how stencil comparisons and
 operations are performed:
 
@@ -6055,9 +6292,22 @@ operations are performed:
         {{GPUStencilFaceState/compare}} passes.
 </dl>
 
+<script type=idl>
+enum GPUStencilOperation {
+    "keep",
+    "zero",
+    "replace",
+    "invert",
+    "increment-clamp",
+    "decrement-clamp",
+    "increment-wrap",
+    "decrement-wrap",
+};
+</script>
+
 {{GPUStencilOperation}} defines the following operations:
 
-<dl dfn-type="enum-value" dfn-for=GPUStencilOperation>
+<dl dfn-type=enum-value dfn-for=GPUStencilOperation>
     : <dfn>"keep"</dfn>
     ::
         Keep the current stencil value.
@@ -6095,24 +6345,6 @@ operations are performed:
         {{GPURenderPassDescriptor/depthStencilAttachment}}'s stencil aspect if the value goes below
         `0`.
 </dl>
-
-<div algorithm>
-    <dfn abstract-op>validating GPUDepthStencilState</dfn>(descriptor)
-    **Arguments:**
-        - {{GPUDepthStencilState}} |descriptor|
-
-    Return `true`, if and only if, all of the following conditions are satisfied:
-
-        - |descriptor|.{{GPUDepthStencilState/format}} is a [=depth-or-stencil format=].
-        - if |descriptor|.{{GPUDepthStencilState/depthWriteEnabled}} is `true` or
-            |descriptor|.{{GPUDepthStencilState/depthCompare}} is not {{GPUCompareFunction/"always"}}:
-            - |descriptor|.{{GPUDepthStencilState/format}} must have a depth component.
-        - if |descriptor|.{{GPUDepthStencilState/stencilFront}} or
-            |descriptor|.{{GPUDepthStencilState/stencilBack}} are not default values:
-            - |descriptor|.{{GPUDepthStencilState/format}} must have a stencil component.
-
-    Issue: how can this algorithm support depth/stencil formats that are added in extensions?
-</div>
 
 ### Vertex State ### {#vertex-state}
 
@@ -7953,6 +8185,9 @@ GPURenderPassEncoder includes GPURenderCommandsMixin;
     : <dfn>\[[viewport]]</dfn>
     ::  Current viewport rectangle and depth range.
 
+    : <dfn>\[[blend_constant]]</dfn>
+    ::  Current blend constant value, initially `[0, 0, 0, 0]`.
+
     : <dfn>\[[stencil_reference]]</dfn>
     ::  Current stencil reference value, initially `0`.
 
@@ -8905,8 +9140,14 @@ attachments used by this encoder.
 
             **Arguments:**
             <pre class=argumentdef for="GPURenderPassEncoder/setBlendConstant(color)">
-                color: The color to use when blending.
+                |color|: The color to use when blending.
             </pre>
+
+            Issue the following steps on the [=Device timeline=] of |this|:
+            <div class=device-timeline>
+                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
+                1. Set {{GPURenderPassEncoder/[[blend_constant]]}} to |color|.
+            </div>
         </div>
 
     : <dfn>setStencilReference(reference)</dfn>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5743,7 +5743,7 @@ dictionary GPUPrimitiveState {
 </script>
 
 {{GPUPrimitiveState}} has the following members, which describe how a {{GPURenderPipeline}}
-constructs and rasterizes primitives from it's vertex inputs:
+constructs and rasterizes primitives from its vertex inputs:
 
 <dl dfn-type=dict-member dfn-for=GPUPrimitiveState>
     : <dfn>topology</dfn>
@@ -5757,18 +5757,22 @@ constructs and rasterizes primitives from it's vertex inputs:
         with this {{GPURenderPipeline}}. This determines the strip's primitive restart value. See
         [[#primitive-assembly]] for additional details.
 
+        Required only if the pipeline is used with indexed draw calls.
+        Not allowed with non-strip topologies.
+
     : <dfn>frontFace</dfn>
     ::
         Defines which polygons are considered [=front-facing=].
 
     : <dfn>cullMode</dfn>
     ::
-        Defines which polygon orientation will be culled.
+        Defines which polygon orientation will be culled, if any.
 
     : <dfn>unclippedDepth</dfn>
     ::
-        If the {{GPUFeatureName/"depth-clip-control"}} feature is enabled, indicates that depth
-        clipping is disabled when set to `true`. See [[#depth-clip-control]] for additional details.
+        If true, indicates that depth clipping is disabled. See [[#depth-clip-control]] for additional details.
+        
+        Requires the {{GPUFeatureName/"depth-clip-control"}} feature to be enabled.
 </dl>
 
 <div algorithm>
@@ -5805,7 +5809,7 @@ will use. See [[#rasterization]] for additional details:
 
     : <dfn>"line-list"</dfn>
     ::
-        Each separate set of two vertices defines a line primitive.
+        Each consecutive pair of two vertices defines a line primitive.
 
     : <dfn>"line-strip"</dfn>
     ::
@@ -5813,7 +5817,7 @@ will use. See [[#rasterization]] for additional details:
 
     : <dfn>"triangle-list"</dfn>
     ::
-        Each separate set of three vertices defines a triangle primitive.
+        Each consecutive triplet of three vertices defines a triangle primitive.
 
     : <dfn>"triangle-strip"</dfn>
     ::
@@ -5834,12 +5838,12 @@ See [[#polygon-rasterization]] for additional details:
 <dl dfn-type=enum-value dfn-for=GPUFrontFace>
     : <dfn>"ccw"</dfn>
     ::
-        Polygons with vertices who's framebuffer coordinates are given in counter-clockwise order
+        Polygons with vertices whose framebuffer coordinates are given in counter-clockwise order
         are considered [=front-facing=].
 
     : <dfn>"cw"</dfn>
     ::
-        Polygons with vertices who's framebuffer coordinates are given in clockwise order are
+        Polygons with vertices whose framebuffer coordinates are given in clockwise order are
         considered [=front-facing=].
 </dl>
 
@@ -6241,18 +6245,20 @@ will affect a render pass's {{GPURenderPassDescriptor/depthStencilAttachment}}:
 </div>
 
 <div algorithm>
-    <dfn abstract-op>validating GPUDepthStencilState</dfn>(descriptor)
+    <dfn abstract-op>validating GPUDepthStencilState</dfn>(|descriptor|)
+
     **Arguments:**
-        - {{GPUDepthStencilState}} |descriptor|
 
-    Return `true`, if and only if, all of the following conditions are satisfied:
+    - {{GPUDepthStencilState}} |descriptor|
 
-        - |descriptor|.{{GPUDepthStencilState/format}} is a [=depth-or-stencil format=].
-        - if |descriptor|.{{GPUDepthStencilState/depthWriteEnabled}} is `true` or
-            |descriptor|.{{GPUDepthStencilState/depthCompare}} is not {{GPUCompareFunction/"always"}}:
-            - |descriptor|.{{GPUDepthStencilState/format}} must have a depth component.
-        - if |descriptor|.{{GPUDepthStencilState/stencilFront}} or
-            |descriptor|.{{GPUDepthStencilState/stencilBack}} are not default values:
+    Return `true` if, and only if, all of the following conditions are satisfied:
+
+    - |descriptor|.{{GPUDepthStencilState/format}} is a [=depth-or-stencil format=].
+    - If |descriptor|.{{GPUDepthStencilState/depthWriteEnabled}} is `true` or
+        |descriptor|.{{GPUDepthStencilState/depthCompare}} is not {{GPUCompareFunction/"always"}}:
+        - |descriptor|.{{GPUDepthStencilState/format}} must have a depth component.
+    - If |descriptor|.{{GPUDepthStencilState/stencilFront}} or
+            |descriptor|.{{GPUDepthStencilState/stencilBack}} are not the default values:
             - |descriptor|.{{GPUDepthStencilState/format}} must have a stencil component.
 
     Issue: how can this algorithm support depth/stencil formats that are added in extensions?


### PR DESCRIPTION
Part of #2815

Adds descriptor definitions for BlendComponent, MultisampleState,
PrimitiveState, and related descriptors and enums.

Also does a tiny bit of restructuring of the previous descriptor CL for
consistency. (Moves definition blocks directly under the associated IDL.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/2825.html" title="Last updated on May 12, 2022, 4:25 PM UTC (5efeeb0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2825/371e040...5efeeb0.html" title="Last updated on May 12, 2022, 4:25 PM UTC (5efeeb0)">Diff</a>