### PR TITLE
Add descriptions for buffer and texture creation options

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2264,8 +2264,6 @@ Note:
 
 ### {{GPUBufferDescriptor}} ### {#GPUBufferDescriptor}
 
-This specifies the options to use in creating a {{GPUBuffer}}.
-
 <script type=idl>
 dictionary GPUBufferDescriptor : GPUObjectDescriptorBase {
     required GPUSize64 size;
@@ -2274,8 +2272,28 @@ dictionary GPUBufferDescriptor : GPUObjectDescriptorBase {
 };
 </script>
 
-- {{GPUBufferDescriptor/mappedAtCreation}} guarantees that even if the buffer eventually fails creation,
-    it will still appear as if the mapped range can be written/read to until it is unmapped.
+{{GPUBufferDescriptor}} has the following members:
+
+<dl dfn-type=dict-member dfn-for=GPUBufferDescriptor>
+    : <dfn>size</dfn>
+    ::
+        The size of the buffer in bytes.
+
+    : <dfn>usage</dfn>
+    ::
+        The allowed usages for the buffer.
+
+    : <dfn>mappedAtCreation</dfn>
+    ::
+        If `true` creates the buffer in an already mapped state, allowing
+        {{GPUBuffer/getMappedRange()}} to be called immediately. It is valid to set
+        {{GPUBufferDescriptor/mappedAtCreation}} to `true` even if {{GPUBufferDescriptor/usage}}
+        does not contain {{GPUBufferUsage/MAP_READ}} or {{GPUBufferUsage/MAP_WRITE}}. This can be
+        used to set the buffer's initial data.
+
+        Guarantees that even if the buffer creation eventually fails, it will still appear as if the
+        mapped range can be written/read to until it is unmapped.
+</dl>
 
 <div algorithm>
     <dfn abstract-op>validating GPUBufferDescriptor</dfn>(|device|, |descriptor|)
@@ -2305,6 +2323,71 @@ namespace GPUBufferUsage {
     const GPUFlagsConstant QUERY_RESOLVE = 0x0200;
 };
 </script>
+
+The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after it's creation:
+
+<dl dfn-type="const" dfn-for=GPUBufferUsage>
+    : <dfn>MAP_READ</dfn>
+    ::
+        The buffer can be mapped for reading. (Example: calling {{GPUBuffer/mapAsync()}} with
+        {{GPUMapMode/READ|GPUMapMode.READ}})
+
+        May only be combined with {{GPUBufferUsage/COPY_DST}}.
+
+    : <dfn>MAP_WRITE</dfn>
+    ::
+        The buffer can be mapped for writing. (Example: calling {{GPUBuffer/mapAsync()}} with
+        {{GPUMapMode/WRITE|GPUMapMode.WRITE}})
+
+        May only be combined with {{GPUBufferUsage/COPY_SRC}}.
+
+    : <dfn>COPY_SRC</dfn>
+    ::
+        The buffer can be used as the source of a copy operation. (Examples: as the `source`
+        argument of a {{GPUCommandEncoder/copyBufferToBuffer()}} or
+        {{GPUCommandEncoder/copyBufferToTexture()}} call.)
+
+    : <dfn>COPY_DST</dfn>
+    ::
+        The buffer can be used as the destination of a copy or write operation. (Examples: as the
+        `destination` argument of a {{GPUCommandEncoder/copyBufferToBuffer()}} or
+        {{GPUCommandEncoder/copyTextureToBuffer()}} call, or as the target of a
+        {{GPUQueue/writeBuffer()}} call.)
+
+    : <dfn>INDEX</dfn>
+    ::
+        The buffer can be used as an index buffer. (Example: passed to
+        {{GPURenderCommandsMixin/setIndexBuffer()}}.)
+
+    : <dfn>VERTEX</dfn>
+    ::
+        The buffer can be used as a vertex buffer. (Example: passed to
+        {{GPURenderCommandsMixin/setVertexBuffer()}}.)
+
+    : <dfn>UNIFORM</dfn>
+    ::
+        The buffer can be used as a uniform buffer. (Example: as a bind group entry for a
+        {{GPUBufferBindingLayout}} with a
+        {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/type}} of
+        {{GPUBufferBindingType/"uniform"}}.)
+
+    : <dfn>STORAGE</dfn>
+    ::
+        The buffer can be used as a storage buffer. (Example: as a bind group entry for a
+        {{GPUBufferBindingLayout}} with a
+        {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/type}} of
+        {{GPUBufferBindingType/"storage"}} or {{GPUBufferBindingType/"read-only-storage"}}.)
+
+    : <dfn>INDIRECT</dfn>
+    ::
+        The buffer can be used as to store indirect command arguments. (Examples: as the
+        `indirectBuffer` argument of a {{GPURenderCommandsMixin/drawIndirect()}} or
+        {{GPUComputePassEncoder/dispatchWorkgroupsIndirect()}} call.)
+
+    : <dfn>QUERY_RESOLVE</dfn>
+    ::
+        The buffer can be used to capture query results.
+</dl>
 
 <dl dfn-type=method dfn-for=GPUDevice>
     : <dfn>createBuffer(descriptor)</dfn>
@@ -2360,11 +2443,6 @@ namespace GPUBufferUsage {
 
             1. Set each byte of |b|'s allocation to zero.
             1. Return |b|.
-
-            Note: it is valid to set {{GPUBufferDescriptor/mappedAtCreation}} to `true` without {{GPUBufferUsage/MAP_READ}}
-            or {{GPUBufferUsage/MAP_WRITE}} in {{GPUBufferDescriptor/usage}}. This can be used to set the buffer's
-            initial data.
-
         </div>
 
 </dl>
@@ -2658,7 +2736,34 @@ dictionary GPUTextureDescriptor : GPUObjectDescriptorBase {
 };
 </script>
 
+{{GPUTextureDescriptor}} has the following members:
+
 <dl dfn-type=dict-member dfn-for=GPUTextureDescriptor>
+    : <dfn>size</dfn>
+    ::
+        The width, height, and depth or layer count of the texture.
+
+    : <dfn>mipLevelCount</dfn>
+    ::
+        The number of mip levels the texture will contain.
+
+    : <dfn>sampleCount</dfn>
+    ::
+        The sample count of the texture. A {{GPUTextureDescriptor/sampleCount}} &gt; `1` indicates
+        a multisampled texture.
+
+    : <dfn>dimension</dfn>
+    ::
+        Whether the texture is one, two, or three dimensional.
+
+    : <dfn>format</dfn>
+    ::
+        The format of the texture.
+
+    : <dfn>usage</dfn>
+    ::
+        The allowed usages for the texture.
+
     : <dfn>viewFormats</dfn>
     ::
         Specifies what view {{GPUTextureViewDescriptor/format}} values will be allowed when calling
@@ -2689,6 +2794,22 @@ enum GPUTextureDimension {
 };
 </script>
 
+<dl dfn-type="enum-value" dfn-for=GPUTextureDimension>
+    : <dfn>"1d"</dfn>
+    ::
+        Specifies a texture that has one dimension, width.
+
+    : <dfn>"2d"</dfn>
+    ::
+        Specifies a texture that has a width and height, and may have layers. Only
+        {{GPUTextureDimension/"2d"}} textures may have mipmaps, be multisampled, use a compressed or
+        depth/stencil format, and be used as a render attachment.
+
+    : <dfn>"3d"</dfn>
+    ::
+        Specifies a texture that has a width, height, and depth.
+</dl>
+
 <script type=idl>
 typedef [EnforceRange] unsigned long GPUTextureUsageFlags;
 [Exposed=(Window, DedicatedWorker)]
@@ -2700,6 +2821,39 @@ namespace GPUTextureUsage {
     const GPUFlagsConstant RENDER_ATTACHMENT = 0x10;
 };
 </script>
+
+The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after it's creation:
+
+<dl dfn-type="const" dfn-for=GPUTextureUsage>
+    : <dfn>COPY_SRC</dfn>
+    ::
+        The texture can be used as the source of a copy operation. (Examples: as the `source`
+        argument of a {{GPUCommandEncoder/copyTextureToTexture()}} or
+        {{GPUCommandEncoder/copyTextureToBuffer()}} call.)
+
+    : <dfn>COPY_DST</dfn>
+    ::
+        The texture can be used as the destination of a copy or write operation. (Examples: as the
+        `destination` argument of a {{GPUCommandEncoder/copyTextureToTexture()}} or
+        {{GPUCommandEncoder/copyBufferToTexture()}} call, or as the target of a
+        {{GPUQueue/writeTexture()}} call.)
+
+    : <dfn>TEXTURE_BINDING</dfn>
+    ::
+        The texture can be used as a sampled texture in a shader (Example: as a bind group entry for
+        a {{GPUTextureBindingLayout}}.)
+
+    : <dfn>STORAGE_BINDING</dfn>
+    ::
+        The texture can be used as a storage texture in a shader (Example: as a bind group entry for
+        a {{GPUStorageTextureBindingLayout}}.)
+
+    : <dfn>RENDER_ATTACHMENT</dfn>
+    ::
+        The texture can be used as a color or depth/stencil attachment in a render pass.
+        (Example: provide the {{GPURenderPassColorAttachment/view}} for a
+        {{GPURenderPassColorAttachment}} or {{GPURenderPassDepthStencilAttachment}}.)
+</dl>
 
 <div algorithm>
     <dfn abstract-op>maximum mipLevel count</dfn>(dimension, size)

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2386,7 +2386,8 @@ The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its
 
     : <dfn>QUERY_RESOLVE</dfn>
     ::
-        The buffer can be used to capture query results.
+        The buffer can be used to capture query results. (Example: as the `destination` argument of
+        a {{GPUCommandEncoder/resolveQuerySet()}} call.)
 </dl>
 
 <dl dfn-type=method dfn-for=GPUDevice>
@@ -2840,20 +2841,19 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
 
     : <dfn>TEXTURE_BINDING</dfn>
     ::
-        The texture can be bound for use as a sampled texture in a shader (Example: as a bind group entry for
-        a {{GPUTextureBindingLayout}}.)
+        The texture can be bound for use as a sampled texture in a shader (Example: as a bind group
+        entry for a {{GPUTextureBindingLayout}}.)
 
     : <dfn>STORAGE_BINDING</dfn>
     ::
-        The texture can be bound for use as a storage texture in a shader (Example: as a bind group entry for
-        a {{GPUStorageTextureBindingLayout}}.)
+        The texture can be bound for use as a storage texture in a shader (Example: as a bind group
+        entry for a {{GPUStorageTextureBindingLayout}}.)
 
     : <dfn>RENDER_ATTACHMENT</dfn>
     ::
         The texture can be used as a color or depth/stencil attachment in a render pass.
-        (Example: provide the {{GPURenderPassColorAttachment/view}} for a
-        {{GPURenderPassColorAttachment}} or {{GPURenderPassDepthStencilAttachment/view}}
-        for a {{GPURenderPassDepthStencilAttachment}}.)
+        (Example: as a {{GPURenderPassColorAttachment}}.{{GPURenderPassColorAttachment/view}} or
+        {{GPURenderPassDepthStencilAttachment}}.{{GPURenderPassDepthStencilAttachment/view}}.)
 </dl>
 
 <div algorithm>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2324,7 +2324,7 @@ namespace GPUBufferUsage {
 };
 </script>
 
-The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after it's creation:
+The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its creation:
 
 <dl dfn-type="const" dfn-for=GPUBufferUsage>
     : <dfn>MAP_READ</dfn>
@@ -2754,7 +2754,7 @@ dictionary GPUTextureDescriptor : GPUObjectDescriptorBase {
 
     : <dfn>dimension</dfn>
     ::
-        Whether the texture is one, two, or three dimensional.
+        Whether the texture is one-dimensional, an array of two-dimensional layers, or three-dimensional.
 
     : <dfn>format</dfn>
     ::
@@ -2822,7 +2822,7 @@ namespace GPUTextureUsage {
 };
 </script>
 
-The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after it's creation:
+The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after its creation:
 
 <dl dfn-type="const" dfn-for=GPUTextureUsage>
     : <dfn>COPY_SRC</dfn>
@@ -2840,19 +2840,20 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
 
     : <dfn>TEXTURE_BINDING</dfn>
     ::
-        The texture can be used as a sampled texture in a shader (Example: as a bind group entry for
+        The texture can be bound for use as a sampled texture in a shader (Example: as a bind group entry for
         a {{GPUTextureBindingLayout}}.)
 
     : <dfn>STORAGE_BINDING</dfn>
     ::
-        The texture can be used as a storage texture in a shader (Example: as a bind group entry for
+        The texture can be bound for use as a storage texture in a shader (Example: as a bind group entry for
         a {{GPUStorageTextureBindingLayout}}.)
 
     : <dfn>RENDER_ATTACHMENT</dfn>
     ::
         The texture can be used as a color or depth/stencil attachment in a render pass.
         (Example: provide the {{GPURenderPassColorAttachment/view}} for a
-        {{GPURenderPassColorAttachment}} or {{GPURenderPassDepthStencilAttachment}}.)
+        {{GPURenderPassColorAttachment}} or {{GPURenderPassDepthStencilAttachment/view}}
+        for a {{GPURenderPassDepthStencilAttachment}}.)
 </dl>
 
 <div algorithm>


### PR DESCRIPTION
Fixes #2663.

Part of #2815, adds descriptions to buffer and texture descriptors
and usages.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/2831.html" title="Last updated on May 6, 2022, 8:50 PM UTC (295c80b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2831/9a88749...295c80b.html" title="Last updated on May 6, 2022, 8:50 PM UTC (295c80b)">Diff</a>