### PR TITLE
Raise maxComputeWorkgroupStorageSize from 16352 to 16384

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1401,7 +1401,7 @@ applications should generally request the "worst" limits that work for their con
         and {{GPURenderPassLayout}}.{{GPURenderPassLayout/colorFormats}}.
 
     <tr><td><dfn>maxComputeWorkgroupStorageSize</dfn>
-        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>16352
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>16384
     <tr class=row-continuation><td colspan=4>
         The maximum number of bytes used for a compute stage
         {{GPUShaderModule}} entry-point.


### PR DESCRIPTION
16352 was only required for Metal families Apple1/Apple2 which we don't support anymore anyway.

Issue: #2832


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2834.html" title="Last updated on May 6, 2022, 8:56 PM UTC (738acce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2834/bd3f2fe...kainino0x:738acce.html" title="Last updated on May 6, 2022, 8:56 PM UTC (738acce)">Diff</a>