### PR TITLE
Specify computed values for modf

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -10681,6 +10681,9 @@ struct __frexp_result_vecN_f16 {
     <td>|T| is f32
     <td class="nowrap">`@const fn`<br>`modf(`|e|`: `|T|`) -> __modf_result`<br>
     <td>Splits |e| into fractional and whole number parts.
+
+    The whole part is (|e| % 1.0), and the fractional part is |e| minus the whole part.
+
     Returns the `__modf_result` built-in structure, defined as follows:
     ```rust
 struct __modf_result {
@@ -10704,6 +10707,9 @@ struct __modf_result {
     <td>|T| is f16
     <td class="nowrap">`@const fn modf(`|e|`: `|T|`) -> __modf_result_f16`<br>
     <td>Splits |e| into fractional and whole number parts.
+
+    The whole part is (|e| % 1.0), and the fractional part is |e| minus the whole part.
+
     Returns the `__modf_result_f16` built-in structure, defined as if as follows:
     ```rust
 struct __modf_result_f16 {
@@ -10718,6 +10724,10 @@ struct __modf_result_f16 {
     <td>|T| is vec|N|&lt;f32&gt;
     <td class="nowrap">`@const fn`<br>`modf(`|e|`: `|T|`) -> __modf_result_vec`|N|<br>
     <td>Splits the components of |e| into fractional and whole number parts.
+
+    The |i|'th component of the whole and fractional parts equal the whole and fractional parts
+    of `modf`(|e|[|i|]).
+
     Returns the `__modf_result_vec`|N| built-in structure, defined as follows:
     ```rust
 struct __modf_result_vecN {
@@ -10732,6 +10742,10 @@ struct __modf_result_vecN {
     <td>|T| is vec|N|&lt;f16&gt;
     <td class="nowrap">`@const fn modf(`|e|`: `|T|`) -> __modf_result_vec`|N|`_f16`<br>
     <td>Splits the components of |e| into fractional and whole number parts.
+
+    The |i|'th component of the whole and fractional parts equal the whole and fractional parts
+    of `modf`(|e|[|i|]).
+
     Returns the `__modf_result_vec`|N|`_f16` built-in structure, defined as if as follows:
     ```rust
 struct __modf_result_vecN_f16 {


### PR DESCRIPTION
The whole part of modf(x) is (x % 1.0), and x is the sume of its
whole and fractional parts.
The floating point % operator specifies the rest.

Fixes: #2468