### PR TITLE
editorial: Define trunc in terms of truncate

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -283,7 +283,8 @@ The <dfn noexport>ceiling expression</dfn> is defined over real numbers |x|:
 
 * &lceil;|x|&rceil; = |k|, where |k| is the unique integer such that |k|-1 &lt; |x| &le; |k|
 
-The <dfn noexport>truncate</dfn> function is defined over real numbers |x|:
+The <dfn noexport>truncate</dfn> function is defined over real numbers |x|,
+and computes the nearest whole number whose absolute value is less than or equal to |x|:
 
 * truncate(|x|) = &lfloor;|x|&rfloor; if |x| &ge; 0, and &lceil;|x|&rceil; if |x| &lt; 0.
 
@@ -10846,7 +10847,7 @@ struct __modf_result_vecN_f16 {
   <tr algorithm="trunc">
     <td>|T| is [ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`trunc(`|e|`:` |T| `) -> ` |T|
-    <td>Returns the nearest whole number whose absolute value is less than or equal to |e|.
+    <td>Returns [=truncate=](|e|), the nearest whole number whose absolute value is less than or equal to |e|.
     [=Component-wise=] when |T| is a vector.
 </table>
 


### PR DESCRIPTION
And copy the prose explanation of 'trunc' to the definition of truncate.

It was weird that 'trunc' didn't link to the 'truncate' definintion.