### PR TITLE
buffer/device.destroy() unmaps buffer on current thread

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2052,16 +2052,25 @@ Those not defined here are defined elsewhere in this document.
         Destroys the [=device=], preventing further operations on it.
         Outstanding asynchronous operations will fail.
 
+        Note: It is valid to destroy a device multiple times.
+
         <div algorithm=GPUDevice.destroy()>
             **Called on:** {{GPUDevice}} |this|.
 
             1. [=Lose the device=](|this|.{{GPUObjectBase/[[device]]}},
                 {{GPUDeviceLostReason/"destroyed"}}).
+
+            1. {{GPUBuffer/unmap()}} all {{GPUBuffer}}s from this device which are mapped in this [=agent=] (thread).
+
+                Note: Any buffers which are mapped in a different thread are not unmapped.
+                They can be unmapped only from the thread on which they are mapped, either by
+                another call to {{GPUDevice/destroy()|GPUDevice.destroy()}}, or by
+                {{GPUBuffer/destroy()|GPUBuffer.destroy()}} or {{GPUBuffer/unmap()|GPUBuffer.unmap()}}.
         </div>
 
-        Note:
-        Since no further operations can occur on this device, implementations can free resource
-        allocations and abort outstanding asynchronous operations immediately.
+        Note: Since no further operations can be enqueued on this device, implementations can abort
+        outstanding asynchronous operations immediately and free resource allocations (except for
+        those used for still-live mappings on other threads).
 </dl>
 
 <div algorithm>
@@ -2472,17 +2481,27 @@ once all previously submitted operations using it are complete.
     ::
         Destroys the {{GPUBuffer}}.
 
+        Note: It is valid to destroy a buffer multiple times.
+
         <div algorithm=GPUBuffer.destroy>
             **Called on:** {{GPUBuffer}} |this|.
 
             **Returns:** {{undefined}}
 
-            1. If the |this|.{{GPUBuffer/[[state]]}} is not either of [=buffer state/unmapped=] or [=buffer state/destroyed=]
+            1. If |this| is mapped in this [=agent=] (thread):
 
                 1. Run the steps to unmap |this|.
 
+                Note: If the buffer is mapped in a different thread, it is not unmapped.
+                It can be unmapped only from the thread on which it is mapped, either by
+                another call to {{GPUBuffer/destroy()|GPUBuffer.destroy()}},
+                or by {{GPUBuffer/unmap()|GPUBuffer.unmap()}}.
+
             1. Set |this|.{{GPUBuffer/[[state]]}} to [=buffer state/destroyed=].
         </div>
+
+        Note: Since no further operations can be enqueued using this buffer, implementations can
+        free resource allocations (except for those used for still-live mappings on other threads).
 </dl>
 
 ## Buffer Mapping ## {#buffer-mapping}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2060,17 +2060,21 @@ Those not defined here are defined elsewhere in this document.
             1. [=Lose the device=](|this|.{{GPUObjectBase/[[device]]}},
                 {{GPUDeviceLostReason/"destroyed"}}).
 
-            1. {{GPUBuffer/unmap()}} all {{GPUBuffer}}s from this device which are mapped in this [=agent=] (thread).
+            1. {{GPUBuffer/unmap()}} all {{GPUBuffer}}s from this device.
+
+                <!-- [tentative text for multithreading:]
+                ... which are mapped in this [=agent=] (thread).
 
                 Note: Any buffers which are mapped in a different thread are not unmapped.
                 They can be unmapped only from the thread on which they are mapped, either by
                 another call to {{GPUDevice/destroy()|GPUDevice.destroy()}}, or by
                 {{GPUBuffer/destroy()|GPUBuffer.destroy()}} or {{GPUBuffer/unmap()|GPUBuffer.unmap()}}.
+                -->
         </div>
 
         Note: Since no further operations can be enqueued on this device, implementations can abort
-        outstanding asynchronous operations immediately and free resource allocations (except for
-        those used for still-live mappings on other threads).
+        outstanding asynchronous operations immediately and free resource allocations, including
+        mapped memory that was just unmapped.
 </dl>
 
 <div algorithm>
@@ -2488,20 +2492,22 @@ once all previously submitted operations using it are complete.
 
             **Returns:** {{undefined}}
 
-            1. If |this| is mapped in this [=agent=] (thread):
+            1. If |this| is mapped, call |this|.{{GPUBuffer/unmap()}}.
 
-                1. Run the steps to unmap |this|.
+            <!-- [tentative text for multithreading:]
+            1. If |this| is mapped in this [=agent=] (thread), call |this|.{{GPUBuffer/unmap()}}.
 
                 Note: If the buffer is mapped in a different thread, it is not unmapped.
                 It can be unmapped only from the thread on which it is mapped, either by
                 another call to {{GPUBuffer/destroy()|GPUBuffer.destroy()}},
                 or by {{GPUBuffer/unmap()|GPUBuffer.unmap()}}.
+            -->
 
             1. Set |this|.{{GPUBuffer/[[state]]}} to [=buffer state/destroyed=].
         </div>
 
         Note: Since no further operations can be enqueued using this buffer, implementations can
-        free resource allocations (except for those used for still-live mappings on other threads).
+        free resource allocations, including mapped memory that was just unmapped.
 </dl>
 
 ## Buffer Mapping ## {#buffer-mapping}


### PR DESCRIPTION
Adds some language that assumes multiple threads, which we don't have,
but I think it's fine. Better to have this codified now.

Unfortunately the language is hand-wavy, but this isn't going to get
fixed until we have a clean client-vs-shared-vs-server state split.

Fixes #2545


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2837.html" title="Last updated on May 11, 2022, 10:42 PM UTC (854c8cf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2837/e9f8cd3...kainino0x:854c8cf.html" title="Last updated on May 11, 2022, 10:42 PM UTC (854c8cf)">Diff</a>