### PR TITLE
Add "bgra8unorm-storage" feature flag

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1977,6 +1977,7 @@ enum GPUFeatureName {
     "timestamp-query",
     "indirect-first-instance",
     "shader-f16",
+    "bgra8unorm-storage",
 };
 </script>
 
@@ -11443,6 +11444,10 @@ Removes the zero value restriction on `firstInstance` in [=indirect draw paramet
 
 Using "`enable f16;`" directive in WGSL code for a shader module is allowed if and only if the {{GPUFeatureName/"shader-f16"}} [=feature=] is enabled; otherwise using it must result in a compilation error when creating shader module.
 
+## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>"bgra8unorm-storage"</dfn> ## {#bgra8unorm-storage}
+
+Allows the {{GPUTextureUsage/STORAGE_BINDING}} usage on textures with format {{GPUTextureFormat/"bgra8unorm"}}.
+
 # Appendices # {#appendices}
 
 ## Texture Format Capabilities ## {#texture-format-caps}
@@ -11579,7 +11584,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
-        <td>
+        <td>If {{GPUFeatureName/"bgra8unorm-storage"}} is enabled
         <td>4
     <tr>
         <td>{{GPUTextureFormat/bgra8unorm-srgb}}


### PR DESCRIPTION
Agreed upon in #2748.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 6, 2022, 10:16 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fkainino0x%2Fgpuweb%2F66cb1f20f913d622fb2c0f450921b3a510d51c55%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%232838.)._
</details>
