### PR TITLE
Add guidance on what browsers "should" put in error messages/console

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4914,12 +4914,22 @@ same module, they should avoid passing that information to
 
             Issue: Describe {{GPUDevice/createShaderModule()}} algorithm steps.
 
-            Note: User agents **should not** include error messages or shader text in
-            the {{GPUValidationError/message}} text of validation errors arising here:
-            these details are accessible via {{GPUShaderModule/compilationInfo()}}.
-            User agents **should** surface human-readable, formatted error details to
-            developers for easier debugging (for example as a warning in the browser developer
-            console, expandable to show full shader source).
+            <div class=note>
+                User agents **should not** include error messages or shader text in
+                the {{GPUValidationError/message}} text of validation errors arising here:
+                these details are accessible via {{GPUShaderModule/compilationInfo()}}.
+                User agents **should** surface human-readable, formatted error details to
+                developers for easier debugging (for example as a warning in the browser developer
+                console, expandable to show full shader source).
+
+                As shader compilation errors should be rare in production applications, user agents
+                could choose to surface them regardless of error handling ([=GPU error scopes=] or
+                {{GPUDevice/unhandlederror}} event handlers), e.g. as an expandable warning.
+                If not, they should provide and document another way for developers to access
+                human-readable error details, for example by adding a checkbox to show errors
+                unconditionally, or by showing human-readable details when logging a
+                {{GPUCompilationInfo}} object to the console.
+            </div>
         </div>
 </dl>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4924,7 +4924,7 @@ same module, they should avoid passing that information to
 
                 As shader compilation errors should be rare in production applications, user agents
                 could choose to surface them regardless of error handling ([=GPU error scopes=] or
-                {{GPUDevice/unhandlederror}} event handlers), e.g. as an expandable warning.
+                {{GPUDevice/uncapturederror}} event handlers), e.g. as an expandable warning.
                 If not, they should provide and document another way for developers to access
                 human-readable error details, for example by adding a checkbox to show errors
                 unconditionally, or by showing human-readable details when logging a

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4913,6 +4913,13 @@ same module, they should avoid passing that information to
             **Returns:** {{GPUShaderModule}}
 
             Issue: Describe {{GPUDevice/createShaderModule()}} algorithm steps.
+
+            Note: User agents **should not** include error messages or shader text in
+            the {{GPUValidationError/message}} text of validation errors arising here:
+            these details are accessible via {{GPUShaderModule/compilationInfo()}}.
+            User agents **should** surface human-readable, formatted error details to
+            developers for easier debugging (for example as a warning in the browser developer
+            console, expandable to show full shader source).
         </div>
 </dl>
 
@@ -10300,6 +10307,10 @@ partial interface GPUDevice {
                     1. If the user agent chooses, [=queue a task=] to fire a
                         {{GPUUncapturedErrorEvent}} named "{{GPUDevice/uncapturederror}}" on
                         |device| with an {{GPUUncapturedErrorEvent/error}} of |error|.
+
+                    Note: If (and only if) there are no {{GPUDevice/uncapturederror}} handlers are
+                    registered, user agents **should** surface uncaptured errors to developers,
+                    for example as warnings in the browser's developer console.
                 </div>
         </div>
 


### PR DESCRIPTION
Fixes #2516


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2840.html" title="Last updated on May 10, 2022, 11:52 PM UTC (695a7f2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2840/e9f8cd3...kainino0x:695a7f2.html" title="Last updated on May 10, 2022, 11:52 PM UTC (695a7f2)">Diff</a>