### PR TITLE
Explicitly specify precision for color space conversions

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1570,6 +1570,10 @@ Colors are not lossily clamped during conversion: converting from one color spac
 will result in values outside the range [0, 1] if the source color values were outside the range
 of the destination color space's gamut (e.g. if a Display P3 image is converted to sRGB).
 
+Similarly, if the source value has a high bit depth (e.g. PNG with 16 bits per component) or
+extended range (e.g. canvas with `float16` storage), these colors are preserved through color space
+conversion, with intermediate computations having at least the precision of the source.
+
 
 # Initialization # {#initialization}
 


### PR DESCRIPTION
The precision requirement is not actually very high; I considered
requiring single-precision float precision, but that may be excessive in
many cases (especially unorm8->unorm8). And float16 has lower precision
than unorm16 for some ranges, so would be insufficiently precise.

Fixes #1482


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2841.html" title="Last updated on May 6, 2022, 10:55 PM UTC (3a1225d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2841/e9f8cd3...kainino0x:3a1225d.html" title="Last updated on May 6, 2022, 10:55 PM UTC (3a1225d)">Diff</a>