### PR TITLE
Validation for copyExternalImageToTexture should be at queue timeline

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9381,8 +9381,8 @@ GPUQueue includes GPUObjectBase;
                     - |source|.|origin|.[=Origin3D/z=] + |copySize|.[=Extent3D/depthOrArrayLayers=]
                         must be &le; 1.
                 </div>
-            1. Issue the following steps on the [=Device timeline=] of |this|:
-                <div class=device-timeline>
+            1. Issue the following steps on the [=Queue timeline=] of |this|:
+                <div class=queue-timeline>
                     1. Let |textureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
                     1. If any of the following requirements are unmet, [$generate a validation error$] and stop.
                         <div class=validusage>


### PR DESCRIPTION
Is this a typo? I am not very sure about this tiny change, but validation steps for writeBuffer and writeTexture are both at queue timeline, while validation steps for copyExternalImageToTexture are at device timeline.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Richard-Yunchao/gpuweb/pull/2842.html" title="Last updated on May 6, 2022, 11:45 PM UTC (3b63eaa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2842/8a7cd05...Richard-Yunchao:3b63eaa.html" title="Last updated on May 6, 2022, 11:45 PM UTC (3b63eaa)">Diff</a>