### PR TITLE
Handle discontinous vertex buffer slots in validation

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8983,8 +8983,8 @@ It must only be included by interfaces which also include those mixins.
             - Let |pipelineDescriptor| be |encoder|.{{GPURenderCommandsMixin/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.
             - For each {{GPUIndex32}} |slot| `0` to
                 |pipelineDescriptor|.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}.length:
-                - If |pipelineDescriptor|.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}[|slot|] is not {{undefined}}, 
-                    |encoder|.{{GPURenderCommandsMixin/[[vertex_buffers]]}}[|slot|] must not be `null`.
+                - If |pipelineDescriptor|.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}[|slot|] is not `null`,
+                    |encoder|.{{GPURenderCommandsMixin/[[vertex_buffers]]}}[|slot|] must [=map/exist=].
         </div>
 
     Otherwise return `true`.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8983,7 +8983,8 @@ It must only be included by interfaces which also include those mixins.
             - Let |pipelineDescriptor| be |encoder|.{{GPURenderCommandsMixin/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.
             - For each {{GPUIndex32}} |slot| `0` to
                 |pipelineDescriptor|.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}.length:
-                - |encoder|.{{GPURenderCommandsMixin/[[vertex_buffers]]}}[|slot|] must not be `null`.
+                - If |pipelineDescriptor|.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}[|slot|] is not {{undefined}}, 
+                    |encoder|.{{GPURenderCommandsMixin/[[vertex_buffers]]}}[|slot|] must not be `null`.
         </div>
 
     Otherwise return `true`.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8984,7 +8984,7 @@ It must only be included by interfaces which also include those mixins.
             - For each {{GPUIndex32}} |slot| `0` to
                 |pipelineDescriptor|.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}.length:
                 - If |pipelineDescriptor|.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}[|slot|] is not `null`,
-                    |encoder|.{{GPURenderCommandsMixin/[[vertex_buffers]]}}[|slot|] must [=map/exist=].
+                    |encoder|.{{GPURenderCommandsMixin/[[vertex_buffers]]}} must [=map/contain=] |slot|.
         </div>
 
     Otherwise return `true`.


### PR DESCRIPTION
Clarify the "valid to draw" validation rules of drawing with GPURenderCommandsMixin encoder to make using discontinuous buffer slots in vertex buffer layout in GPURenderPipelineDescriptor valid.

Fix #2843


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jzm-intel/gpuweb/pull/2844.html" title="Last updated on May 11, 2022, 11:02 PM UTC (b52f6a9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2844/0ce2c2f...jzm-intel:b52f6a9.html" title="Last updated on May 11, 2022, 11:02 PM UTC (b52f6a9)">Diff</a>