### PR TITLE
Special case uniformity of arrayLength

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8313,8 +8313,9 @@ Most built-in functions have tags of:
 Here is the list of exceptions:
 - All functions in [[#sync-builtin-functions]] have a [=call site tag=] of  [=CallSiteRequiredToBeuniform=].
 - All functions in [[#derivative-builtin-functions]], [[#texturesample]], [[#texturesamplebias]], and [[#texturesamplecompare]] have a [=call site tag=] of [=CallSiteRequiredToBeUniform=] and a [=function tag=] of [=ReturnValueMayBeNonUniform=].
-- All functions in [[#array-builtin-functions]] have [=parameter tags=] of
-    [=ParameterNoRestriction=] for each parameter.
+- `arrayLength` (see [[#array-builtin-functions]]) has a [=call site tag=] of
+    [=CallSiteNoRestriction=], a [=function tag=] of [=NoRestriction=] and
+    the input parameter `p` has a [=parameter tag=] of [=ParameterNoRestriction=]
 
 ### Uniformity rules for expressions ### {#uniformity-expressions}
 
@@ -10409,7 +10410,7 @@ See [[#function-calls]].
   </thead>
   <tr algorithm="runtime-sized array length">
     <td>
-    <td>`fn arrayLength`(|e|: ptr&lt;storage,array&lt;|T|&gt;&gt; ) -> u32
+    <td>`fn arrayLength`(|p|: ptr&lt;storage,array&lt;|T|&gt;&gt; ) -> u32
         <td>Returns the number of elements in the [=runtime-sized=] array.
 </table>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8313,6 +8313,8 @@ Most built-in functions have tags of:
 Here is the list of exceptions:
 - All functions in [[#sync-builtin-functions]] have a [=call site tag=] of  [=CallSiteRequiredToBeuniform=].
 - All functions in [[#derivative-builtin-functions]], [[#texturesample]], [[#texturesamplebias]], and [[#texturesamplecompare]] have a [=call site tag=] of [=CallSiteRequiredToBeUniform=] and a [=function tag=] of [=ReturnValueMayBeNonUniform=].
+- All functions in [[#array-builtin-functions]] have [=parameter tags=] of
+    [=ParameterNoRestriction=] for each parameter.
 
 ### Uniformity rules for expressions ### {#uniformity-expressions}
 


### PR DESCRIPTION
* The return value of arrayLength is always a uniform value since there
  is no way to have a non-uniform pointer currently; however, since
  runtime-sized arrays are often used in read_write storage buffers they
  would otherwise be automatically considered non-uniform

Note: this came up during tint's implementation of the uniformity analysis.