### PR TITLE
Validations for writeBuffer and writeTexture should be at device timeline

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9269,8 +9269,8 @@ GPUQueue includes GPUObjectBase;
             1. Let |dataContents| be [=get a copy of the buffer source|a copy of the bytes held by the buffer source=].
             1. Let |contents| be the |contentsSize| elements of |dataContents| starting at
                 an offset of |dataOffset| elements.
-            1. Issue the following steps on the [=Queue timeline=] of |this|:
-                <div class=queue-timeline>
+            1. Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
                     1. If any of the following conditions are unsatisfied,
                         [$generate a validation error$] and stop.
                         <div class=validusage>
@@ -9308,8 +9308,8 @@ GPUQueue includes GPUObjectBase;
                 viewing |dataBytes| with |dataLayout| and |size|.
 
                 Issue: Specify more formally.
-            1. Issue the following steps on the [=Queue timeline=] of |this|:
-                <div class=queue-timeline>
+            1. Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
                     1. If any of the following conditions are unsatisfied,
                         [$generate a validation error$] and stop.
                         <div class=validusage>


### PR DESCRIPTION
@kainino0x , PATL. I renamed the git branch name on my local machine and uploaded the feedback from you for https://github.com/gpuweb/gpuweb/pull/2842, then it is a new PR.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Richard-Yunchao/gpuweb/pull/2847.html" title="Last updated on May 9, 2022, 5:21 PM UTC (e3f36f9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2847/8a7cd05...Richard-Yunchao:e3f36f9.html" title="Last updated on May 9, 2022, 5:21 PM UTC (e3f36f9)">Diff</a>