### PR TITLE
Clarify conversion rank for composites of abstract types

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1312,6 +1312,13 @@ Note: When no conversion is performed, the conversion rank is zero.
       <td>There are no automatic conversions between other types.
 </table>
 
+[=Vectors=] and [=matrix|matrices=] of [=abstract numeric types=] use the same
+[=ConversionRank=] as the scalar [=component=] type of the [=composite=] when
+converting to a vector or matrix of a different type.
+For example, a vector of [=AbstractInt=] uses the same conversion ranking as a
+scalar of [=AbstractInt=] listed above when converting to a different vector
+type.
+
 ### Overload Resolution ### {#overload-resolution-section}
 
 When more than one [=type rule applies to a syntactic phrase=], a tie-breaking procedure is used
@@ -4127,7 +4134,7 @@ specify the component type; the component type is inferred from the constructor 
 </table>
 
 <table class='data'>
-  <caption>Vector constructor type rules, where *T* is a scalar type</caption>
+  <caption>Vector constructor type rules</caption>
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Notes
   </thead>


### PR DESCRIPTION
* Remove reference to scalar type T in vector constructor rules
* Add paragraph to cover conversion rank for abstract numeric composites
  * uses the same rank as the scalar component type