### PR TITLE
ConversionRank table gets vector, matrix rows

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1322,13 +1322,6 @@ Note: When no conversion is performed, the conversion rank is zero.
       <td>There are no automatic conversions between other types.
 </table>
 
-[=Vectors=] and [=matrix|matrices=] of [=abstract numeric types=] use the same
-[=ConversionRank=] as the scalar [=component=] type of the [=composite=] when
-converting to a vector or matrix of a different type.
-For example, a vector of [=AbstractInt=] uses the same conversion ranking as a
-scalar of [=AbstractInt=] listed above when converting to a different vector
-type.
-
 ### Overload Resolution ### {#overload-resolution-section}
 
 When more than one [=type rule applies to a syntactic phrase=], a tie-breaking procedure is used

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1305,6 +1305,16 @@ Note: When no conversion is performed, the conversion rank is zero.
       <td>f16
       <td>7
       <td>Behaves as [=AbstractInt=] to [=AbstractFloat=], and then [=AbstractFloat=] to f16
+  <tr algorithm="conversion rank abstract vector">
+      <td>vec|N|&lt;|S|&gt;
+      <td>vec|N|&lt;|T|&gt;
+      <td>ConversionRank(|S|,|T|)
+      <td>Inherit conversion rank from component types.
+  <tr algorithm="conversion rank abstract matrix">
+      <td>mat|C|x|R|&lt;|S|&gt;
+      <td>mat|C|x|R|&lt;|T|&gt;
+      <td>ConversionRank(|S|,|T|)
+      <td>Inherit conversion rank from component types.
   <tr algorithm="conversion rank for non-convertible cases">
       <td>|S|
       <td>|T|<br>where above cases don't apply


### PR DESCRIPTION
Codifies #2848 in the table.