### PR TITLE
Move "expire stale external textures" slightly earlier

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3852,9 +3852,8 @@ dictionary GPUExternalTextureDescriptor : GPUObjectDescriptorBase {
 </dl>
 
 <div algorithm="expire stale external textures">
-    Immediately before the "run the animation frame callbacks" step of the "[=Update the rendering=]"
-    step of the HTML processing model, run the following steps to
-    <dfn abstract-op>expire stale external textures</dfn>:
+    Immediately before the "[=Update the rendering=]" step of the HTML processing model,
+    run the following steps to <dfn abstract-op>expire stale external textures</dfn>:
 
     1. For each |texture| in {{GPUExternalTexture}}.{{GPUExternalTexture/[[active_imports]]}}:
         1. Let |video| be |texture|.{{GPUExternalTexture/[[descriptor]]}}.{{GPUExternalTextureDescriptor/source}}.
@@ -3863,12 +3862,6 @@ dictionary GPUExternalTextureDescriptor : GPUObjectDescriptorBase {
             1. Remove |texture| from {{GPUExternalTexture}}.{{GPUExternalTexture/[[active_imports]]}}.
             1. Set |texture|.{{GPUExternalTexture/[[destroyed]]}} to `true`, releasing ownership of
                 the underlying resource.
-
-    Note:
-    The steps above occur before `requestVideoFrameCallback` callbacks, if any.
-    If `requestVideoFrameCallback` is implemented, stale {{GPUExternalTexture}}s could equivalently
-    be said to be destroyed in a "priority" `requestVideoFrameCallback` callback that occurs just
-    before user-specified callbacks.
 
     Note:
     An external video texture should be imported in the same task that samples the texture


### PR DESCRIPTION
**DRAFT**, depends on #2854

It was pointed out to me that, as written, a texture would be unexpired in any event handlers called by the focus, resize, scroll, media query, animation, fullscreen, and 2d context loss steps inside "[Update the rendering](https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering)", but then expire for rVFC and rAF.

I originally put it here because it lines up with requestVideoFrameCallback (see the deleted "Note:").
There's nothing fundamentally wrong with that, but this PR proposes moving it earlier, so it runs before "Update the rendering":

- It still runs after all user tasks.
- Avoids developers needing to understand the ordering of callbacks for different types of events (focus/resize/etc. vs rAF callbacks).
- No harm in it being earlier: the behavior is still tightly specified, and it lets us free the import earlier.

It's also perhaps a bit more future-proof: "Update the rendering" only occurs in windows, not workers. It doesn't matter now, because only HTMLVideoElement imports auto-expire. But if we added another auto-expiring import in the future, this would be better.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2855.html" title="Last updated on May 19, 2022, 11:18 PM UTC (048b065)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2855/d72a6db...kainino0x:048b065.html" title="Last updated on May 19, 2022, 11:18 PM UTC (048b065)">Diff</a>