### PR TITLE
Add maxInterStageShaderVariables and inter-stage limit validation

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5884,18 +5884,33 @@ details.
                 type, and
                 [=interpolation=]
                 of the input.
-            - There is less than |device|.limits.{{supported limits/maxInterStageShaderComponents}}
-                components of user-defined and built-in outputs for |descriptor|.{{GPURenderPipelineDescriptor/vertex}}.
-              - If |descriptor|.{{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/topology}} is
-                  {{GPUPrimitiveTopology/"point-list"}}:
-                - There is less than (|device|.limits.{{supported limits/maxInterStageShaderComponents}} - 1)
-                    components of user-defined and built-in outputs for |descriptor|.{{GPURenderPipelineDescriptor/vertex}}.
-            - There is less than |device|.limits.{{supported limits/maxInterStageShaderComponents}}
-                components of user-defined and built-in inputs for |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.
-            - The [=location=] of each user-defined output of |descriptor|.{{GPURenderPipelineDescriptor/vertex}} must
-                be less than (|device|.limits.{{supported limits/maxInterStageShaderComponents}} / 4 - 1).
-            - The [=location=] of each user-defined input of |descriptor|.{{GPURenderPipelineDescriptor/fragment}} must
-                be less than (|device|.limits.{{supported limits/maxInterStageShaderComponents}} / 4 - 1).
+            - [$validating inter-stage interfaces$](|device|, |descriptor|) succeeds.
+</div>
+
+<div algorithm>
+    <dfn abstract-op>validating inter-stage interfaces</dfn>(device, descriptor)
+
+    **Arguments:**
+        - {{GPUDevice}} |device|
+        - {{GPURenderPipelineDescriptor}} |descriptor|
+
+    **Returns:** {{boolean}}
+
+    let |maxVertexShaderOutputComponents| be |device|.limits.{{supported limits/maxInterStageShaderComponents}}.
+    - If |descriptor|.{{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/topology}} is
+        {{GPUPrimitiveTopology/"point-list"}}:
+        - |maxVertexShaderOutputComponents| = |maxVertexShaderOutputComponents| - 1
+
+    Return `true` if and only if all of the following conditions are satisfied:
+        - |device| is valid.
+        - There are less than |maxVertexShaderOutputComponents| components of user-defined and built-in outputs for
+            |descriptor|.{{GPURenderPipelineDescriptor/vertex}}.
+        - There are less than |device|.limits.{{supported limits/maxInterStageShaderComponents}}
+            components of user-defined and built-in inputs for |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.
+        - The [=location=] of each user-defined output of |descriptor|.{{GPURenderPipelineDescriptor/vertex}} is less
+            than (|device|.limits.{{supported limits/maxInterStageShaderComponents}} / 4 - 1).
+        - The [=location=] of each user-defined input of |descriptor|.{{GPURenderPipelineDescriptor/fragment}} is less
+            than (|device|.limits.{{supported limits/maxInterStageShaderComponents}} / 4 - 1).
 </div>
 
 Issue: should we validate that `cullMode` is none for points and lines?

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1387,7 +1387,7 @@ applications should generally request the "worst" limits that work for their con
         when creating a {{GPURenderPipeline}}.
 
     <tr><td><dfn>maxInterStageShaderComponents</dfn>
-        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>60
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>64
     <tr class=row-continuation><td colspan=4>
         The maximum allowed number of components of input or output variables
         for inter-stage communication (like vertex outputs or fragment inputs).
@@ -5885,9 +5885,17 @@ details.
                 [=interpolation=]
                 of the input.
             - There is less than |device|.limits.{{supported limits/maxInterStageShaderComponents}}
-                components of user-defined outputs for |descriptor|.{{GPURenderPipelineDescriptor/vertex}}.
+                components of user-defined and built-in outputs for |descriptor|.{{GPURenderPipelineDescriptor/vertex}}.
+              - If |descriptor|.{{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/topology}} is
+                  {{GPUPrimitiveTopology/"point-list"}}:
+                - There is less than (|device|.limits.{{supported limits/maxInterStageShaderComponents}} - 1)
+                    components of user-defined and built-in outputs for |descriptor|.{{GPURenderPipelineDescriptor/vertex}}.
             - There is less than |device|.limits.{{supported limits/maxInterStageShaderComponents}}
-                components of user-defined inputs for |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.
+                components of user-defined and built-in inputs for |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.
+            - The [=location=] of each user-defined output of |descriptor|.{{GPURenderPipelineDescriptor/vertex}} must
+                be less than (|device|.limits.{{supported limits/maxInterStageShaderComponents}} / 4).
+            - The [=location=] of each user-defined input of |descriptor|.{{GPURenderPipelineDescriptor/fragment}} must
+                be less than (|device|.limits.{{supported limits/maxInterStageShaderComponents}} / 4).
 </div>
 
 Issue: should we validate that `cullMode` is none for points and lines?

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5893,9 +5893,9 @@ details.
             - There is less than |device|.limits.{{supported limits/maxInterStageShaderComponents}}
                 components of user-defined and built-in inputs for |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.
             - The [=location=] of each user-defined output of |descriptor|.{{GPURenderPipelineDescriptor/vertex}} must
-                be less than (|device|.limits.{{supported limits/maxInterStageShaderComponents}} / 4).
+                be less than (|device|.limits.{{supported limits/maxInterStageShaderComponents}} / 4 - 1).
             - The [=location=] of each user-defined input of |descriptor|.{{GPURenderPipelineDescriptor/fragment}} must
-                be less than (|device|.limits.{{supported limits/maxInterStageShaderComponents}} / 4).
+                be less than (|device|.limits.{{supported limits/maxInterStageShaderComponents}} / 4 - 1).
 </div>
 
 Issue: should we validate that `cullMode` is none for points and lines?

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6390,7 +6390,7 @@ details.
                 type, and
                 [=interpolation=]
                 of the input.
-            - [$validating inter-stage interfaces$](|device|, |descriptor|) succeeds.
+            - [$validating inter-stage interfaces$](|device|, |descriptor|) returns `true`.
 </div>
 
 <div algorithm>
@@ -6406,24 +6406,26 @@ details.
     1. Let |maxVertexShaderOutputComponents| be |device|.limits.{{supported limits/maxInterStageShaderComponents}}.
         1. If |descriptor|.{{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/topology}} is
             {{GPUPrimitiveTopology/"point-list"}}:
-            1. Set |maxVertexShaderOutputComponents| to (|maxVertexShaderOutputComponents| - 1)
+            1. Decrement |maxVertexShaderOutputComponents| by 1.
     1. Let |maxFragmentShaderInputComponents| be |device|.limits.{{supported limits/maxInterStageShaderComponents}}.
         1. If the `front_facing` [=builtin=] is an input of |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
-            1. Set |maxFragmentShaderInputComponents| to (|maxFragmentShaderInputComponents| - 1)
+            1. Decrement |maxFragmentShaderInputComponents| by 1.
         1. If the `sample_index` [=builtin=] is an input of |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
-            1. Set |maxFragmentShaderInputComponents| to (|maxFragmentShaderInputComponents| - 1)
+            1. Decrement |maxFragmentShaderInputComponents| by 1.
         1. If the `sample_mask` [=builtin=] is an input of |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
-            1. Set |maxFragmentShaderInputComponents| to (|maxFragmentShaderInputComponents| - 1)
+            1. Decrement |maxFragmentShaderInputComponents| by 1.
     1. Return `true` if and only if all of the following conditions are satisfied:
         - The [=location=] of each user-defined output of |descriptor|.{{GPURenderPipelineDescriptor/vertex}} is less
             than (|device|.limits.{{supported limits/maxInterStageShaderVariables}}).
         - The [=location=] of each user-defined input of |descriptor|.{{GPURenderPipelineDescriptor/fragment}} is less
             than (|device|.limits.{{supported limits/maxInterStageShaderVariables}}).
-        - There are no more than |maxVertexShaderOutputComponents| components of user-defined outputs for
+        - There are no more than |maxVertexShaderOutputComponents| scalar
+            components across all user-defined outputs for
             |descriptor|.{{GPURenderPipelineDescriptor/vertex}}.
-        - There are no more than |maxFragmentShaderInputComponents| components of user-defined inputs for
+            (For example, a `f32` output uses 1 component, and a `vec3<f32>` output uses 3 components.)
+        - There are no more than |maxFragmentShaderInputComponents| scalar
+            components across all user-defined inputs for
             |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.
-
 </div>
 
 Issue: define what "compatible" means for render target formats.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5888,11 +5888,12 @@ details.
 </div>
 
 <div algorithm>
-    <dfn abstract-op>validating inter-stage interfaces</dfn>(device, descriptor)
+    <dfn abstract-op>validating inter-stage interfaces</dfn>(|device|, |descriptor|)
 
     **Arguments:**
-        - {{GPUDevice}} |device|
-        - {{GPURenderPipelineDescriptor}} |descriptor|
+
+    - {{GPUDevice}} |device|
+    - {{GPURenderPipelineDescriptor}} |descriptor|
 
     **Returns:** {{boolean}}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1412,6 +1412,12 @@ applications should generally request the "worst" limits that work for their con
         The maximum allowed number of components of input or output variables
         for inter-stage communication (like vertex outputs or fragment inputs).
 
+    <tr><td><dfn>maxInterStageShaderVariables</dfn>
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>16
+    <tr class=row-continuation><td colspan=4>
+        The maximum allowed number of input or output variables for inter-stage
+        communication (like vertex outputs or fragment inputs).
+
     <tr><td><dfn>maxColorAttachments</dfn>
         <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>8
     <tr class=row-continuation><td colspan=4>
@@ -1488,6 +1494,7 @@ interface GPUSupportedLimits {
     readonly attribute unsigned long maxVertexAttributes;
     readonly attribute unsigned long maxVertexBufferArrayStride;
     readonly attribute unsigned long maxInterStageShaderComponents;
+    readonly attribute unsigned long maxInterStageShaderVariables;
     readonly attribute unsigned long maxComputeWorkgroupStorageSize;
     readonly attribute unsigned long maxComputeInvocationsPerWorkgroup;
     readonly attribute unsigned long maxComputeWorkgroupSizeX;
@@ -6397,18 +6404,26 @@ details.
     **Returns:** {{boolean}}
 
     1. Let |maxVertexShaderOutputComponents| be |device|.limits.{{supported limits/maxInterStageShaderComponents}}.
-    1. If |descriptor|.{{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/topology}} is
-        {{GPUPrimitiveTopology/"point-list"}}:
-        1. Set |maxVertexShaderOutputComponents| to |maxVertexShaderOutputComponents| - 1
+        1. If |descriptor|.{{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/topology}} is
+            {{GPUPrimitiveTopology/"point-list"}}:
+            1. Set |maxVertexShaderOutputComponents| to (|maxVertexShaderOutputComponents| - 1)
+    1. Let |maxFragmentShaderInputComponents| be |device|.limits.{{supported limits/maxInterStageShaderComponents}}.
+        1. If the `front_facing` [=builtin=] is an input of |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
+            1. Set |maxFragmentShaderInputComponents| to (|maxFragmentShaderInputComponents| - 1)
+        1. If the `sample_index` [=builtin=] is an input of |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
+            1. Set |maxFragmentShaderInputComponents| to (|maxFragmentShaderInputComponents| - 1)
+        1. If the `sample_mask` [=builtin=] is an input of |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
+            1. Set |maxFragmentShaderInputComponents| to (|maxFragmentShaderInputComponents| - 1)
     1. Return `true` if and only if all of the following conditions are satisfied:
-        - There are less than |maxVertexShaderOutputComponents| components of user-defined and built-in outputs for
-            |descriptor|.{{GPURenderPipelineDescriptor/vertex}}.
-        - There are less than |device|.limits.{{supported limits/maxInterStageShaderComponents}}
-            components of user-defined and built-in inputs for |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.
         - The [=location=] of each user-defined output of |descriptor|.{{GPURenderPipelineDescriptor/vertex}} is less
-            than (|device|.limits.{{supported limits/maxInterStageShaderComponents}} / 4 - 1).
+            than (|device|.limits.{{supported limits/maxInterStageShaderVariables}}).
         - The [=location=] of each user-defined input of |descriptor|.{{GPURenderPipelineDescriptor/fragment}} is less
-            than (|device|.limits.{{supported limits/maxInterStageShaderComponents}} / 4 - 1).
+            than (|device|.limits.{{supported limits/maxInterStageShaderVariables}}).
+        - There are no more than |maxVertexShaderOutputComponents| components of user-defined outputs for
+            |descriptor|.{{GPURenderPipelineDescriptor/vertex}}.
+        - There are no more than |maxFragmentShaderInputComponents| components of user-defined inputs for
+            |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.
+
 </div>
 
 Issue: define what "compatible" means for render target formats.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1387,7 +1387,7 @@ applications should generally request the "worst" limits that work for their con
         when creating a {{GPURenderPipeline}}.
 
     <tr><td><dfn>maxInterStageShaderComponents</dfn>
-        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>64
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>60
     <tr class=row-continuation><td colspan=4>
         The maximum allowed number of components of input or output variables
         for inter-stage communication (like vertex outputs or fragment inputs).
@@ -5902,7 +5902,6 @@ details.
         {{GPUPrimitiveTopology/"point-list"}}:
         1. Set |maxVertexShaderOutputComponents| to |maxVertexShaderOutputComponents| - 1
     1. Return `true` if and only if all of the following conditions are satisfied:
-        - |device| is valid.
         - There are less than |maxVertexShaderOutputComponents| components of user-defined and built-in outputs for
             |descriptor|.{{GPURenderPipelineDescriptor/vertex}}.
         - There are less than |device|.limits.{{supported limits/maxInterStageShaderComponents}}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5896,12 +5896,11 @@ details.
 
     **Returns:** {{boolean}}
 
-    let |maxVertexShaderOutputComponents| be |device|.limits.{{supported limits/maxInterStageShaderComponents}}.
-    - If |descriptor|.{{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/topology}} is
+    1. Let |maxVertexShaderOutputComponents| be |device|.limits.{{supported limits/maxInterStageShaderComponents}}.
+    1. If |descriptor|.{{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/topology}} is
         {{GPUPrimitiveTopology/"point-list"}}:
-        - |maxVertexShaderOutputComponents| = |maxVertexShaderOutputComponents| - 1
-
-    Return `true` if and only if all of the following conditions are satisfied:
+        1. Set |maxVertexShaderOutputComponents| to |maxVertexShaderOutputComponents| - 1
+    1. Return `true` if and only if all of the following conditions are satisfied:
         - |device| is valid.
         - There are less than |maxVertexShaderOutputComponents| components of user-defined and built-in outputs for
             |descriptor|.{{GPURenderPipelineDescriptor/vertex}}.


### PR DESCRIPTION
This patch intends to clarify all the validations with
maxInterStageShaderComponents in WebGPU SPEC.
- The total number of user-defined and built-in vertex output
  components should be no more than `maxInterStageShaderComponents`.
  - If the primitive type is `point-list`, the The total amount of
    both user-defined and built-in vertex output components should
    be no more than (`maxInterStageShaderComponents - 1`) as on
    Vulkan `PointSize` should always be declared and consume 1
    vertex output component.
- The total amount of user-defined and built-in fragment input
  components should be no more than `maxInterStageShaderComponents`.
- The `location` of each vertex output and fragment input variables
  must be less than `maxInterStageShaderComponents / 4` as is required
  by Vulkan SPEC.

You can read the discussions in #1962 for more details.

Fixes #1962
Fixes #2400
Closes #2763


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Jiawei-Shao/gpuweb/pull/2857.html" title="Last updated on Jun 2, 2022, 3:45 AM UTC (c836ff1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2857/50b468a...Jiawei-Shao:c836ff1.html" title="Last updated on Jun 2, 2022, 3:45 AM UTC (c836ff1)">Diff</a>