### PR TITLE
Even more descriptions for dictionary and enum members

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2515,6 +2515,32 @@ namespace GPUMapMode {
 };
 </script>
 
+The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
+{{GPUBuffer/mapAsync()}}:
+
+<dl dfn-type="const" dfn-for=GPUMapMode>
+    : <dfn>READ</dfn>
+    ::
+        Only valid with buffers created with the {{GPUBufferUsage/MAP_READ}} usage.
+
+        Once the buffer is mapped, calls to {{GPUBuffer/getMappedRange()}} will return an
+        {{ArrayBuffer}} containing the buffer's current values. Changes to the returned
+        {{ArrayBuffer}} will be discarded after {{GPUBuffer/unmap()}} is called.
+
+    : <dfn>WRITE</dfn>
+    ::
+        Only valid with buffers created with the {{GPUBufferUsage/MAP_WRITE}} usage.
+
+        Once the buffer is mapped, calls to {{GPUBuffer/getMappedRange()}} will return an
+        {{ArrayBuffer}} containing the buffer's current values. Changes to the returned
+        {{ArrayBuffer}} will be stored in the {{GPUBuffer}} after {{GPUBuffer/unmap()}} is called.
+
+        Note: Since the {{GPUBufferUsage/MAP_WRITE}} buffer usage may only be combined with the
+        {{GPUBufferUsage/COPY_SRC}} buffer usage, mapping for writing can never return values
+        produced by the GPU, and the returned {{ArrayBuffer}} will only ever contain the default
+        initialized data (zeros) or data written by the page during a previous mapping.
+</dl>
+
 <dl dfn-type=method dfn-for=GPUBuffer>
     : <dfn>mapAsync(mode, offset, size)</dfn>
     ::
@@ -3069,6 +3095,41 @@ dictionary GPUTextureViewDescriptor : GPUObjectDescriptorBase {
 };
 </script>
 
+{{GPUTextureDescriptor}} has the following members:
+
+<dl dfn-type=dict-member dfn-for=GPUTextureViewDescriptor>
+    : <dfn>format</dfn>
+    ::
+        The format of the texture view. Must be either the {{GPUTextureDescriptor/format}} of the
+        texture or one of the {{GPUTextureDescriptor/viewFormats}} specified during its creation.
+
+    : <dfn>dimension</dfn>
+    ::
+        The dimension to view the texture as.
+
+    : <dfn>aspect</dfn>
+    ::
+        Which {{GPUTextureAspect|aspect(s)}} of the texture are accessible to the texture view.
+
+    : <dfn>baseMipLevel</dfn>
+    ::
+        The first (most detailed) mipmap level accessible to the texture view.
+
+    : <dfn>mipLevelCount</dfn>
+    ::
+        How many mipmap levels after the {{GPUTextureViewDescriptor/baseMipLevel}} are accessible to
+        the texture view.
+
+    : <dfn>baseArrayLayer</dfn>
+    ::
+        The index of the first array layer accessible to the texture view.
+
+    : <dfn>arrayLayerCount</dfn>
+    ::
+        How many array layers after the {{GPUTextureViewDescriptor/baseArrayLayer}} are accessible
+        to the texture view.
+</dl>
+
 <script type=idl>
 enum GPUTextureViewDimension {
     "1d",
@@ -3151,6 +3212,25 @@ enum GPUTextureAspect {
     "depth-only",
 };
 </script>
+
+<dl dfn-type=enum-value dfn-for=GPUTextureAspect>
+    : <dfn>"all"</dfn>
+    ::
+        All available aspects of the texture format will be accessible to the texture view. For
+        color formats the color aspect accessible will be accessible. For
+        [=combined depth-stencil format=]s both the depth and stencil aspects will be accessible.
+        [=Depth-or-stencil format=]s with a single aspect will only make that aspect accessible.
+
+    : <dfn>"stencil-only"</dfn>
+    ::
+        Only the stencil aspect of a [=depth-or-stencil format=] format will be accessible to the
+        texture view.
+
+    : <dfn>"depth-only"</dfn>
+    ::
+        Only the depth aspect of a [=depth-or-stencil format=] format will be accessible to the
+        texture view.
+</dl>
 
 <dl dfn-type=method dfn-for=GPUTexture>
     : <dfn>createView(descriptor)</dfn>
@@ -3829,24 +3909,49 @@ dictionary GPUSamplerDescriptor : GPUObjectDescriptorBase {
 };
 </script>
 
-- {{GPUSamplerDescriptor/addressModeU}}, {{GPUSamplerDescriptor/addressModeV}},
-    and {{GPUSamplerDescriptor/addressModeW}} specify the address modes for the texture width,
-    height, and depth coordinates, respectively.
-- {{GPUSamplerDescriptor/magFilter}} specifies the sampling behavior when the sample footprint
-    is smaller than or equal to one texel.
-- {{GPUSamplerDescriptor/minFilter}} specifies the sampling behavior when the sample footprint
-    is larger than one texel.
-- {{GPUSamplerDescriptor/mipmapFilter}} specifies behavior for sampling between two mipmap levels.
-- {{GPUSamplerDescriptor/lodMinClamp}} and {{GPUSamplerDescriptor/lodMaxClamp}} specify the minimum and
-    maximum levels of detail, respectively, used internally when sampling a texture.
-- If {{GPUSamplerDescriptor/compare}} is provided, the sampler will be a comparison sampler with the specified
-    {{GPUCompareFunction}}. Comparison samplers may use filtering, but the sampling results will be
-    implementation-dependent and may differ from the normal filtering rules.
-- {{GPUSamplerDescriptor/maxAnisotropy}} specifies the maximum anisotropy value clamp used by the sampler.
+<dl dfn-type=dict-member dfn-for=GPUSamplerDescriptor>
+    : <dfn>addressModeU</dfn>
+    : <dfn>addressModeV</dfn>
+    : <dfn>addressModeW</dfn>
+    ::
+        Specifies the {{GPUAddressMode|address modes}} for the texture width, height, and depth
+        coordinates, respectively.
 
-    Note: Most implementations support {{GPUSamplerDescriptor/maxAnisotropy}} values in range between 1 and 16, inclusive.
-    The used value of {{GPUSamplerDescriptor/maxAnisotropy}} will be clamped to the maximum value that the platform
-    supports.
+    : <dfn>magFilter</dfn>
+    ::
+        Specifies the sampling behavior when the sample footprint is smaller than or equal to one
+        texel.
+
+    : <dfn>minFilter</dfn>
+    ::
+        Specifies the sampling behavior when the sample footprint is larger than one texel.
+
+    : <dfn>mipmapFilter</dfn>
+    ::
+        Specifies behavior for sampling between mipmap levels.
+
+    : <dfn>lodMinClamp</dfn>
+    : <dfn>lodMaxClamp</dfn>
+    ::
+        Specifies the minimum and maximum levels of detail, respectively, used internally when
+        sampling a texture.
+
+    : <dfn>compare</dfn>
+    ::
+        When provided the sampler will be a comparison sampler with the specified
+        {{GPUCompareFunction}}.
+
+        Note: Comparison samplers may use filtering, but the sampling results will be
+        implementation-dependent and may differ from the normal filtering rules.
+
+    : <dfn>maxAnisotropy</dfn>
+    ::
+        Specifies the maximum anisotropy value clamp used by the sampler.
+
+        Note: Most implementations support {{GPUSamplerDescriptor/maxAnisotropy}} values in range
+        between 1 and 16, inclusive. The used value of {{GPUSamplerDescriptor/maxAnisotropy}} will
+        be clamped to the maximum value that the platform supports.
+</dl>
 
 Issue: explain how LOD is calculated and if there are differences here between platforms.
 
@@ -4063,14 +4168,6 @@ dictionary GPUBindGroupLayoutDescriptor : GPUObjectDescriptorBase {
 A {{GPUBindGroupLayoutEntry}} describes a single shader resource binding to be included in a {{GPUBindGroupLayout}}.
 
 <script type=idl>
-typedef [EnforceRange] unsigned long GPUShaderStageFlags;
-[Exposed=(Window, DedicatedWorker)]
-namespace GPUShaderStage {
-    const GPUFlagsConstant VERTEX   = 0x1;
-    const GPUFlagsConstant FRAGMENT = 0x2;
-    const GPUFlagsConstant COMPUTE  = 0x4;
-};
-
 dictionary GPUBindGroupLayoutEntry {
     required GPUIndex32 binding;
     required GPUShaderStageFlags visibility;
@@ -4122,6 +4219,33 @@ dictionary GPUBindGroupLayoutEntry {
     ::
         When not `undefined`, indicates the [=binding resource type=] for this {{GPUBindGroupLayoutEntry}}
         is {{GPUExternalTexture}}.
+</dl>
+
+<script type=idl>
+typedef [EnforceRange] unsigned long GPUShaderStageFlags;
+[Exposed=(Window, DedicatedWorker)]
+namespace GPUShaderStage {
+    const GPUFlagsConstant VERTEX   = 0x1;
+    const GPUFlagsConstant FRAGMENT = 0x2;
+    const GPUFlagsConstant COMPUTE  = 0x4;
+};
+</script>
+
+{{GPUShaderStage}} contains the following flags, which describe which shader stages a
+corresponding {{GPUBindGroupEntry}} for this {{GPUBindGroupLayoutEntry}} will be visible to:
+
+<dl dfn-type=const dfn-for=GPUShaderStage>
+    : <dfn>VERTEX</dfn>
+    ::
+        The bind group entry will be accessible to vertex shaders.
+
+    : <dfn>FRAGMENT</dfn>
+    ::
+        The bind group entry will be accessible to fragment shaders.
+
+    : <dfn>COMPUTE</dfn>
+    ::
+        The bind group entry will be accessible to compute shaders.
 </dl>
 
 The [=binding member=] of a {{GPUBindGroupLayoutEntry}} is determined by which member of the
@@ -4861,10 +4985,6 @@ GPUShaderModule includes GPUObjectBase;
 ### Shader Module Creation ### {#shader-module-creation}
 
 <script type=idl>
-dictionary GPUShaderModuleCompilationHint {
-    required (GPUPipelineLayout or GPUAutoLayoutMode) layout;
-};
-
 dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
     required USVString code;
     object sourceMap;
@@ -4872,45 +4992,37 @@ dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
 };
 </script>
 
-{{GPUShaderModuleDescriptor/sourceMap}}, if defined, MAY be interpreted as a
-source-map-v3 format.
-Source maps are optional, but serve as a standardized way to support dev-tool
-integration such as source-language debugging [[SourceMap]].
-WGSL names (identifiers) in source maps follow the rules defined in [=WGSL identifier comparison=].
+<dl dfn-type=dict-member dfn-for=GPUShaderModuleDescriptor>
+    : <dfn>code</dfn>
+    ::
+        The <a href="https://gpuweb.github.io/gpuweb/wgsl/">WGSL</a> source code for the shader
+        module.
 
-{{GPUShaderModuleDescriptor/hints}}, if defined, maps an entry point name from
-the shader to a {{GPUShaderModuleCompilationHint}}. No validation is performed with
-any of these {{GPUShaderModuleCompilationHint}}. Implementations should use any
-information present in the {{GPUShaderModuleCompilationHint}} to perform as much
-compilation as is possible within {{GPUDevice/createShaderModule()}}.
-Entry point names follow the rules defined in [=WGSL identifier comparison=].
+    : <dfn>sourceMap</dfn>
+    ::
+        If defined MAY be interpreted as a source-map-v3 format.
 
-Note: Supplying information in {{GPUShaderModuleDescriptor/hints}} does not have any
-observable effect, other than performance. Because a single shader module can hold
-multiple entry points, and multiple pipelines can be created from a single shader
-module, it can be more performant for an implementation to do as much compilation as
-possible once in {{GPUDevice/createShaderModule()}} rather than multiple times in
-the multiple calls to {{GPUDevice/createComputePipeline()}} /
-{{GPUDevice/createRenderPipeline()}}.
+        Source maps are optional, but serve as a standardized way to support dev-tool
+        integration such as source-language debugging [[SourceMap]].
+        WGSL names (identifiers) in source maps follow the rules defined in [=WGSL identifier
+        comparison=].
 
-Note: If possible, authors should be supplying the same information to
-{{GPUDevice/createShaderModule()}} and {{GPUDevice/createComputePipeline()}} /
-{{GPUDevice/createRenderPipeline()}}.
+    : <dfn>hints</dfn>
+    ::
+        If defined maps an entry point name from the shader to a {{GPUShaderModuleCompilationHint}}.
+        No validation is performed with any of these {{GPUShaderModuleCompilationHint}}.
+        Implementations should use any information present in the {{GPUShaderModuleCompilationHint}}
+        to perform as much compilation as is possible within {{GPUDevice/createShaderModule()}}.
+        Entry point names follow the rules defined in [=WGSL identifier comparison=].
 
-Note: If an author is unable to provide this {{GPUShaderModuleDescriptor/hints}}
-information at the time of calling {{GPUDevice/createShaderModule()}}, they should
-usually not delay calling {{GPUDevice/createShaderModule()}}; but should instead just
-omit the unknown information from {{GPUShaderModuleDescriptor/hints}} or
-{{GPUShaderModuleCompilationHint}}. Omitting this information may cause compilation
-to be deferred to {{GPUDevice/createComputePipeline()}} /
-{{GPUDevice/createRenderPipeline()}}.
-
-Note: If an author is not confident that the information passed to
-{{GPUDevice/createShaderModule()}} will match the information later passed to
-{{GPUDevice/createComputePipeline()}} / {{GPUDevice/createRenderPipeline()}} with that
-same module, they should avoid passing that information to
-{{GPUDevice/createShaderModule()}}, as passing mismatched information to
-{{GPUDevice/createShaderModule()}} may cause unnecessary compilations to occur.
+        Note: Supplying information in {{GPUShaderModuleDescriptor/hints}} does not have any
+        observable effect, other than performance. Because a single shader module can hold
+        multiple entry points, and multiple pipelines can be created from a single shader
+        module, it can be more performant for an implementation to do as much compilation as
+        possible once in {{GPUDevice/createShaderModule()}} rather than multiple times in
+        the multiple calls to {{GPUDevice/createComputePipeline()}} /
+        {{GPUDevice/createRenderPipeline()}}.
+</dl>
 
 <dl dfn-type=method dfn-for=GPUDevice>
     : <dfn>createShaderModule(descriptor)</dfn>
@@ -4954,6 +5066,46 @@ same module, they should avoid passing that information to
             code: shaderSource,
         });
     </pre>
+</div>
+
+#### Shader Module Compilation Hints #### {#shader-module-compilation-hints}
+
+Shader module compilation hints are optional, additional information indicating how a given
+{{GPUShaderModule}} entry point is intended to be used in the future. For some implmentations this
+information may aid in compiling the shader module earlier, potentially increasing performance.
+
+<script type=idl>
+dictionary GPUShaderModuleCompilationHint {
+    required (GPUPipelineLayout or GPUAutoLayoutMode) layout;
+};
+</script>
+
+<dl dfn-type=dict-member dfn-for=GPUShaderModuleCompilationHint>
+    : <dfn>layout</dfn>
+    ::
+        A {{GPUPipelineLayout}} that the {{GPUShaderModule}} may be used with in a future
+        {{GPUDevice/createComputePipeline()}} or {{GPUDevice/createRenderPipeline()}} call.
+        If set to {{GPUAutoLayoutMode/"auto"}} the layout will be the [$default pipeline layout$]
+        for the entry point associated with this hint will be used.
+</dl>
+
+<div class=note>
+If possible, authors should be supplying the same information to
+{{GPUDevice/createShaderModule()}} and {{GPUDevice/createComputePipeline()}} /
+{{GPUDevice/createRenderPipeline()}}.
+
+If an author is unable to provide hint information at the time of calling
+{{GPUDevice/createShaderModule()}}, they should usually not delay calling
+{{GPUDevice/createShaderModule()}}; but should instead just omit the unknown information from
+{{GPUShaderModuleDescriptor/hints}} or {{GPUShaderModuleCompilationHint}}. Omitting this information
+may cause compilation to be deferred to {{GPUDevice/createComputePipeline()}} /
+{{GPUDevice/createRenderPipeline()}}.
+
+If an author is not confident that the hint information passed to {{GPUDevice/createShaderModule()}}
+will match the information later passed to {{GPUDevice/createComputePipeline()}} /
+{{GPUDevice/createRenderPipeline()}} with that same module, they should avoid passing that
+information to {{GPUDevice/createShaderModule()}}, as passing mismatched information to
+{{GPUDevice/createShaderModule()}} may cause unnecessary compilations to occur.
 </div>
 
 ### Shader Module Compilation Information ### {#shader-module-compilation-information}
@@ -6330,22 +6482,19 @@ when doing indexed rendering.
 <table class="data">
   <thead>
     <tr>
-      <th>Index format</th>
-      <th>Byte size</th>
-      <th>Primitive restart value</th>
-    </tr>
+      <th>Index format
+      <th>Byte size
+      <th>Primitive restart value
   </thead>
-  <tbody>
+  <tbody dfn-type=enum-value dfn-for=GPUIndexFormat>
     <tr>
-      <td>{{GPUIndexFormat/"uint16"}}</td>
-      <td>2</td>
-      <td>0xFFFF</td>
-    </tr>
+      <td><dfn>"uint16"
+      <td>2
+      <td>0xFFFF
     <tr>
-      <td>{{GPUIndexFormat/"uint32"}}</td>
-      <td>4</td>
-      <td>0xFFFFFFFF</td>
-    </tr>
+      <td><dfn>"uint32"
+      <td>4
+      <td>0xFFFFFFFF
   </tbody>
 </table>
 
@@ -6407,12 +6556,16 @@ enum GPUVertexStepMode {
 
 The step mode configures how an address for vertex buffer data is computed, based on the
 current vertex or instance index:
-<dl class="switch">
-    : {{GPUVertexStepMode/"vertex"}}
-    :: The address is advanced by {{GPUVertexBufferLayout/arrayStride}} for each vertex,
+
+<dl dfn-type=enum-value dfn-for=GPUVertexStepMode>
+    : <dfn>"vertex"</dfn>
+    ::
+        The address is advanced by {{GPUVertexBufferLayout/arrayStride}} for each vertex,
         and reset between instances.
-    : {{GPUVertexStepMode/"instance"}}
-    :: The address is advanced by {{GPUVertexBufferLayout/arrayStride}} for each instance.
+
+    : <dfn>"instance"</dfn>
+    ::
+        The address is advanced by {{GPUVertexBufferLayout/arrayStride}} for each instance.
 </dl>
 
 <script type=idl>
@@ -6442,6 +6595,20 @@ dictionary GPUVertexBufferLayout {
 };
 </script>
 
+<dl dfn-type=dict-member dfn-for=GPUVertexBufferLayout>
+    : <dfn>arrayStride</dfn>
+    ::
+        The stride, in bytes, between elements of this array.
+
+    : <dfn>stepMode</dfn>
+    ::
+        Whether each element of this array represents per-vertex data or per-instance data
+
+    : <dfn>attributes</dfn>
+    ::
+        An array defining the layout of the vertex attributes within each element.
+</dl>
+
 <script type=idl>
 dictionary GPUVertexAttribute {
     required GPUVertexFormat format;
@@ -6450,6 +6617,22 @@ dictionary GPUVertexAttribute {
     required GPUIndex32 shaderLocation;
 };
 </script>
+
+<dl dfn-type=dict-member dfn-for=GPUVertexAttribute>
+    : <dfn>format</dfn>
+    ::
+        The {{GPUVertexFormat}} of the attribute.
+
+    : <dfn>offset</dfn>
+    ::
+        The offset, in bytes, from the beginning of the element to the data for the attribute.
+
+    : <dfn>shaderLocation</dfn>
+    ::
+        The numeric location associated with this attribute, which will correspond with a
+        <a href="https://gpuweb.github.io/gpuweb/wgsl/#input-output-locations">"@location" attribute</a>
+        declared in the {{GPURenderPipelineDescriptor/vertex}}.{{GPUProgrammableStage/module|module}}.
+</dl>
 
 <div algorithm>
     <dfn abstract-op>validating GPUVertexBufferLayout</dfn>(device, descriptor, vertexStage)
@@ -6837,6 +7020,12 @@ depth values are tightly packed in an array of the appropriate type ("depth16uno
 Issue: Define the exact copy semantics, by reference to common algorithms shared by the copy methods.
 
 <dl dfn-type=dict-member dfn-for=GPUImageDataLayout>
+    : <dfn>offset</dfn>
+    ::
+        The offset, in bytes, from the beginning of the image data source (such as a
+        {{GPUImageCopyBuffer/buffer|GPUImageCopyBuffer.buffer}}) to the start of the image data
+        within that source.
+
     : <dfn>bytesPerRow</dfn>
     ::
         The stride, in bytes, between the beginning of each [=block row=] and the subsequent [=block row=].
@@ -6862,6 +7051,13 @@ dictionary GPUImageCopyBuffer : GPUImageDataLayout {
     required GPUBuffer buffer;
 };
 </script>
+
+<dl dfn-type=dict-member dfn-for=GPUImageCopyBuffer>
+    : <dfn>buffer</dfn>
+    ::
+        A buffer which either contains image data to be copied or will store the image data being
+        copied, depending on the method it is being passed to.
+</dl>
 
 <div algorithm class=validusage>
 <dfn abstract-op>validating GPUImageCopyBuffer</dfn>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2538,7 +2538,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
         Note: Since the {{GPUBufferUsage/MAP_WRITE}} buffer usage may only be combined with the
         {{GPUBufferUsage/COPY_SRC}} buffer usage, mapping for writing can never return values
         produced by the GPU, and the returned {{ArrayBuffer}} will only ever contain the default
-        initialized data (zeros) or data written by the page during a previous mapping.
+        initialized data (zeros) or data written by the webpage during a previous mapping.
 </dl>
 
 <dl dfn-type=method dfn-for=GPUBuffer>
@@ -3117,7 +3117,7 @@ dictionary GPUTextureViewDescriptor : GPUObjectDescriptorBase {
 
     : <dfn>mipLevelCount</dfn>
     ::
-        How many mipmap levels after the {{GPUTextureViewDescriptor/baseMipLevel}} are accessible to
+        How many mipmap levels, starting with {{GPUTextureViewDescriptor/baseMipLevel}}, are accessible to
         the texture view.
 
     : <dfn>baseArrayLayer</dfn>
@@ -3126,7 +3126,7 @@ dictionary GPUTextureViewDescriptor : GPUObjectDescriptorBase {
 
     : <dfn>arrayLayerCount</dfn>
     ::
-        How many array layers after the {{GPUTextureViewDescriptor/baseArrayLayer}} are accessible
+        How many array layers, starting with {{GPUTextureViewDescriptor/baseArrayLayer}}, are accessible
         to the texture view.
 </dl>
 
@@ -3217,7 +3217,7 @@ enum GPUTextureAspect {
     : <dfn>"all"</dfn>
     ::
         All available aspects of the texture format will be accessible to the texture view. For
-        color formats the color aspect accessible will be accessible. For
+        color formats the color aspect will be accessible. For
         [=combined depth-stencil format=]s both the depth and stencil aspects will be accessible.
         [=Depth-or-stencil format=]s with a single aspect will only make that aspect accessible.
 


### PR DESCRIPTION
Part of #2815

Adds or improves descriptions for the following dictionaries and
enums:
 - GPUMapMode
 - GPUTextureViewDescriptor
 - GPUTextureAspect
 - GPUSamplerDescriptor
 - GPUShaderStageFlags
 - GPUShaderStage
 - GPUShaderModuleDescriptor
 - GPUShaderModuleCompilationHint
 - GPUIndexFormat
 - GPUVertexStepMode
 - GPUVertexBufferLayout
 - GPUVertexAttribute
 - GPUImageDataLayout
 - GPUImageCopyBuffer

No particular rhyme or reason to which ones I updated. Just whatever I happened to notice, and at some point I forced myself to stop for the sanity of the reviewer. :)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/2858.html" title="Last updated on May 12, 2022, 5:02 AM UTC (3efd67c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2858/91b8b35...3efd67c.html" title="Last updated on May 12, 2022, 5:02 AM UTC (3efd67c)">Diff</a>