### PR TITLE
Add table detailing vertex formats

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -96,6 +96,7 @@ spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
         text: SizeOf; url: sizeof
         text: WGSL floating point conversion; url: floating-point-conversion
         text: WGSL identifier comparison; url: identifier-comparison
+        text: WGSL scalar type; url: scalar-types
 </pre>
 
 <style>
@@ -6785,14 +6786,86 @@ when doing indexed rendering.
 
 #### Vertex Formats #### {#vertex-formats}
 
-The name of the format specifies the order of components, bits per component,
-and <dfn dfn>vertex data type</dfn> for the component.
+The {{GPUVertexFormat}} of a vertex attribute indicate the how data from a vertex buffer will
+be interpreted and exposed to the shader. The name of the format specifies the order of components,
+bits per component, and [=vertex data type=] for the component.
 
-  * `unorm` = unsigned normalized
-  * `snorm` = signed normalized
-  * `uint` = unsigned int
-  * `sint` = signed int
-  * `float` = floating point
+Each <dfn dfn>vertex data type</dfn> can map to any [=WGSL scalar type=] of the same base type,
+regardless of the bits per component:
+
+<table class="data">
+  <thead>
+    <tr>
+      <th>Vertex format prefix
+      <th>Vertex data type
+      <th>Compatible WGSL types
+  </thead>
+  <tbody>
+    <tr>
+      <td>`uint`
+      <td>unsigned int
+      <td>`u32`
+    <tr>
+      <td>`sint`
+      <td>signed int
+      <td>`i32`
+    <tr>
+      <td>`unorm`
+      <td>unsigned normalized
+      <td rowspan=3>`f16`, `f32`
+    <tr>
+      <td>`snorm`
+      <td>signed normalized
+    <tr>
+      <td>`float`
+      <td>floating point
+  </tbody>
+</table>
+
+The multi-component formats specify the number of components after "x". Mismatches in the number of
+components between the vertex format and shader type are allowed, with components being either
+dropped or filled with default values to compensate.
+
+<div class="example">
+  A vertex attribute with a format of {{GPUVertexFormat/"uint8x2"}} and byte values `[0x7F, 0xFF]`
+  can be accessed in the shader with the following types:
+
+  <table class="data">
+    <thead>
+      <tr>
+        <th>Shader type
+        <th>Shader value
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>f16
+        <td><code>0.5h
+      <tr>
+        <td><code>f32
+        <td><code>0.5f
+      <tr>
+        <td><code>vec2&lt;f16&gt;
+        <td><code>vec2(0.5h, 1.0h)
+      <tr>
+        <td><code>vec2&lt;f32&gt;
+        <td><code>vec2(0.5f, 1.0f)
+      <tr>
+        <td><code>vec3&lt;f16&gt;
+        <td><code>vec2(0.5h, 1.0h, 0.0h)
+      <tr>
+        <td><code>vec3&lt;f32&gt;
+        <td><code>vec2(0.5f, 1.0f, 0.0f)
+      <tr>
+        <td><code>vec4&lt;f16&gt;
+        <td><code>vec2(0.5h, 1.0h, 0.0h, 1.0h)
+      <tr>
+        <td><code>vec4&lt;f32&gt;
+        <td><code>vec2(0.5f, 1.0f, 0.0f, 1.0f)
+  </table>
+</div>
+
+See [[#vertex-processing]] for additional information about how vertex formats are exposed in the
+shader.
 
 <script type=idl>
 enum GPUVertexFormat {
@@ -6829,8 +6902,198 @@ enum GPUVertexFormat {
 };
 </script>
 
-The multi-component formats specify the number of components after "x".
-As such, {{GPUVertexFormat/"sint32x3"}} denotes a 3-component vector of `i32` values in the shader.
+<table class="data">
+  <thead>
+    <tr>
+      <th>Vertex format
+      <th>Data type
+      <th>Components
+      <th>Byte size
+      <th>Example WGSL type
+  </thead>
+  <tbody dfn-type=enum-value dfn-for=GPUVertexFormat>
+    <tr>
+      <td><dfn>"uint8x2"
+      <td>unsigned int
+      <td>2
+      <td>2
+      <td><code>vec2&lt;u32&gt;
+    <tr>
+      <td><dfn>"uint8x4"
+      <td>unsigned int
+      <td>4
+      <td>4
+      <td><code>vec4&lt;u32&gt;
+    <tr>
+      <td><dfn>"sint8x2"
+      <td>signed int
+      <td>2
+      <td>2
+      <td><code>vec2&lt;i32&gt;
+    <tr>
+      <td><dfn>"sint8x4"
+      <td>signed int
+      <td>4
+      <td>4
+      <td><code>vec4&lt;i32&gt;
+    <tr>
+      <td><dfn>"unorm8x2"
+      <td>unsigned normalized
+      <td>2
+      <td>2
+      <td><code>vec2&lt;f32&gt;
+    <tr>
+      <td><dfn>"unorm8x4"
+      <td>unsigned normalized
+      <td>4
+      <td>4
+      <td><code>vec4&lt;f32&gt;
+    <tr>
+      <td><dfn>"snorm8x2"
+      <td>signed normalized
+      <td>2
+      <td>2
+      <td><code>vec2&lt;f32&gt;
+    <tr>
+      <td><dfn>"snorm8x4"
+      <td>signed normalized
+      <td>4
+      <td>4
+      <td><code>vec4&lt;f32&gt;
+    <tr>
+      <td><dfn>"uint16x2"
+      <td>unsigned int
+      <td>2
+      <td>4
+      <td><code>vec2&lt;u32&gt;
+    <tr>
+      <td><dfn>"uint16x4"
+      <td>unsigned int
+      <td>4
+      <td>8
+      <td><code>vec4&lt;u32&gt;
+    <tr>
+      <td><dfn>"sint16x2"
+      <td>signed int
+      <td>2
+      <td>4
+      <td><code>vec2&lt;i32&gt;
+    <tr>
+      <td><dfn>"sint16x4"
+      <td>signed int
+      <td>4
+      <td>8
+      <td><code>vec4&lt;i32&gt;
+    <tr>
+      <td><dfn>"unorm16x2"
+      <td>unsigned normalized
+      <td>2
+      <td>4
+      <td><code>vec2&lt;f32&gt;
+    <tr>
+      <td><dfn>"unorm16x4"
+      <td>unsigned normalized
+      <td>4
+      <td>8
+      <td><code>vec4&lt;f32&gt;
+    <tr>
+      <td><dfn>"snorm16x2"
+      <td>signed normalized
+      <td>2
+      <td>4
+      <td><code>vec2&lt;f32&gt;
+    <tr>
+      <td><dfn>"snorm16x4"
+      <td>signed normalized
+      <td>4
+      <td>8
+      <td><code>vec4&lt;f32&gt;
+    <tr>
+      <td><dfn>"float16x2"
+      <td>float
+      <td>2
+      <td>4
+      <td><code>vec2&lt;f16&gt;
+    <tr>
+      <td><dfn>"float16x4"
+      <td>float
+      <td>4
+      <td>8
+      <td><code>vec4&lt;f16&gt;
+    <tr>
+      <td><dfn>"float32"
+      <td>float
+      <td>1
+      <td>4
+      <td><code>f32
+    <tr>
+      <td><dfn>"float32x2"
+      <td>float
+      <td>2
+      <td>8
+      <td><code>vec2&lt;f32&gt;
+    <tr>
+      <td><dfn>"float32x3"
+      <td>float
+      <td>3
+      <td>12
+      <td><code>vec3&lt;f32&gt;
+    <tr>
+      <td><dfn>"float32x4"
+      <td>float
+      <td>4
+      <td>16
+      <td><code>vec4&lt;f32&gt;
+    <tr>
+      <td><dfn>"uint32"
+      <td>unsigned int
+      <td>1
+      <td>4
+      <td><code>u32
+    <tr>
+      <td><dfn>"uint32x2"
+      <td>unsigned int
+      <td>2
+      <td>8
+      <td><code>vec2&lt;u32&gt;
+    <tr>
+      <td><dfn>"uint32x3"
+      <td>unsigned int
+      <td>3
+      <td>12
+      <td><code>vec3&lt;u32&gt;
+    <tr>
+      <td><dfn>"uint32x4"
+      <td>unsigned int
+      <td>4
+      <td>16
+      <td><code>vec4&lt;u32&gt;
+    <tr>
+      <td><dfn>"sint32"
+      <td>signed int
+      <td>1
+      <td>4
+      <td><code>i32
+    <tr>
+      <td><dfn>"sint32x2"
+      <td>signed int
+      <td>2
+      <td>8
+      <td><code>vec2&lt;i32&gt;
+    <tr>
+      <td><dfn>"sint32x3"
+      <td>signed int
+      <td>3
+      <td>12
+      <td><code>vec3&lt;i32&gt;
+    <tr>
+      <td><dfn>"sint32x4"
+      <td>signed int
+      <td>4
+      <td>16
+      <td><code>vec4&lt;i32&gt;
+  </tbody>
+</table>
 
 <script type=idl>
 enum GPUVertexStepMode {


### PR DESCRIPTION
Part of #2815.

This is kind of an odd one, because the formats are largely self-explanatory, but I'd still like to have something in here that defines them and provides additional details. I think the size in bytes and WGSL format are useful to list (though the WGSL format is actually the "ideal" format, since they can map to types with more or less components.) but listing the data type and component count feels kind of redundant.

Anyway, happy to discuss ways to make this more useful or less verbose!


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/2860.html" title="Last updated on May 16, 2022, 5:21 PM UTC (cc7116a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2860/e10f3e1...cc7116a.html" title="Last updated on May 16, 2022, 5:21 PM UTC (cc7116a)">Diff</a>