### PR TITLE
Add algorithm for onSubmittedWorkDone()

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9630,15 +9630,16 @@ GPUQueue includes GPUObjectBase;
         up to this moment.
 
         <div algorithm="GPUQueue.onSubmittedWorkDone">
-            **Called on:** {{GPUQueue}} this.
-
-            **Arguments:**
-            <pre class=argumentdef for="GPUQueue/onSubmittedWorkDone()">
-            </pre>
+            **Called on:** {{GPUQueue}} |this|.
 
             **Returns:** {{Promise}}&lt;{{undefined}}&gt;
 
-            Issue: Describe {{GPUQueue/onSubmittedWorkDone()}} algorithm steps.
+            1. Let |promise| be [=a new promise=].
+            1. Enqueue an operation on the [=Queue timeline=] of |this| that will execute the following:
+                <div class=queue-timeline>
+                    1. [=Resolve=] |promise|.
+                </div>
+            1. Return |promise|.
         </div>
 </dl>
 


### PR DESCRIPTION
Resolves an issue within the spec.

The algorithm for this seems pretty simple, given that we've been pretty loose about the concept of resolving promises across timelines.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/2861.html" title="Last updated on May 11, 2022, 8:56 PM UTC (133dc63)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2861/86a23b8...133dc63.html" title="Last updated on May 11, 2022, 8:56 PM UTC (133dc63)">Diff</a>