### PR TITLE
Clarify convertability of constant-time expressions

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1232,7 +1232,7 @@ TODO: example: non-result-value effect is any side effect of a function call sub
 
 When a type assertion |e|:|T| is used as a [=type rule precondition=], it is satisfied when:
 * |e| is already of type |T|, or
-* |e| is of type |S|, and type |S| is [=feasible automatic conversion|automatically convertable=] to type |T|, as defined below.
+* |e| is of type |S|, and type |S| is [=feasible automatic conversion|automatically convertible=] to type |T|, as defined below.
 
 The rule is codified by the <dfn>ConversionRank</dfn> function over pairs of types, defined in the table below.
 The [=ConversionRank=] function expresses the preference and feasibility of automatically converting a value of one type (*Src*) to

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1232,7 +1232,7 @@ TODO: example: non-result-value effect is any side effect of a function call sub
 
 When a type assertion |e|:|T| is used as a [=type rule precondition=], it is satisfied when:
 * |e| is already of type |T|, or
-* the value of |e| can be automatically converted to a value of type |T|.
+* |e| is of type |S|, and type |S| is [=feasible automatic conversion|automatically convertable=] to type |T|, as defined below.
 
 The rule is codified by the <dfn>ConversionRank</dfn> function over pairs of types, defined in the table below.
 The [=ConversionRank=] function expresses the preference and feasibility of automatically converting a value of one type (*Src*) to


### PR DESCRIPTION
The inferred concrete type for an abstract type depends only
on the type of the constant-time expression, not on its value.

There is already an example illustrating the principle:

      let i32_too_large_2 = 2147483648; // Invalid.