### PR TITLE
editorial:  Change 'pointee type' to 'store type'

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2652,7 +2652,7 @@ Each memory access is performed via a [=memory view=].
 
 A <dfn noexport>memory view</dfn> comprises:
 * a set of [=memory locations=] in a particular [=address space=],
-* an interpretation of the contents of those locations as a WGSL [=type=], and
+* an interpretation of the contents of those locations as a WGSL [=type=], known as the <dfn>store type</dfn>, and
 * an [=access mode=].
 
 The access mode of a memory view [=shader-creation error|must=] be supported by the address space. See [[#address-space]].
@@ -2670,7 +2670,7 @@ WGSL has two kinds of types for representing memory views:
     <td>The <dfn noexport>reference type</dfn>
         identified with the set of [=memory views=] for memory locations in |S| holding values of type |T|,
         supporting memory accesses described by mode |A|.<br>
-        In this context |T| is known as the <dfn noexport>store type</dfn>.<br>
+        Here, |T| is the [=store type=].<br>
         Reference types are not written in WGSL program source;
         instead they are used to analyze a WGSL program.
   <tr algorithm="pointer type">
@@ -2679,7 +2679,7 @@ WGSL has two kinds of types for representing memory views:
     <td>The <dfn noexport>pointer type</dfn>
         identified with the set of [=memory views=] for memory locations in |S| holding values of type |T|,
         supporting memory accesses described by mode |A|.<br>
-        In this context |T| is known as the <dfn noexport>pointee type</dfn>.<br>
+        Here, |T| is the [=store type=].<br>
         Pointer types may appear in WGSL program source.
 </table>
 
@@ -2699,14 +2699,14 @@ However, in WGSL *source* text:
     fn my_function(
       /* 'ptr<function,i32,read_write>' is the type of a pointer value that references
          memory for keeping an 'i32' value, using memory locations in the 'function'
-         address space.  Here 'i32' is the pointee type.
+         address space.  Here 'i32' is the store type.
          The implied access mode is 'read_write'. See below for access mode defaults. */
       ptr_int: ptr<function,i32>,
 
       // 'ptr<private,array<f32,50>,read_write>' is the type of a pointer value that
       // refers to memory for keeping an array of 50 elements of type 'f32', using
       // memory locations in the 'private' address space.
-      // Here the pointee type is 'array<f32,50>'.
+      // Here the store type is 'array<f32,50>'.
       // The implied access mode is 'read_write'. See below for access mode defaults.
       ptr_array: ptr<private, array<f32, 50>>
     ) { }
@@ -7345,14 +7345,13 @@ Note: The [=attribute/const=] attribute cannot be applied to user-declared funct
     * a constructible type
     * a pointer type
         * It [=shader-creation error|must=] be valid to [=variable declaration|declare a variable=]
-             with the pointer type's [=address space=] and [=access mode=],
-             and where the variable's [=store type=] is the same as the pointer's [=pointee type=].
+             with the pointer type's [=address space=], [=store type=], and [=access mode=].
     * a texture type
     * a sampler type
 * Each function call argument [=shader-creation error|must=] evaluate to the type of the corresponding
     function parameter.
     * In particular, an argument that is a pointer [=shader-creation error|must=] agree with the formal parameter
-        on address space, [=pointee type=], and access mode.
+        on [=address space=], [=store type=], and [=access mode=].
 * For [=user-defined functions=], a parameter of pointer type [=shader-creation error|must=] be in one of
     the following address spaces:
     * [=address spaces/function=]

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2652,7 +2652,7 @@ Each memory access is performed via a [=memory view=].
 
 A <dfn noexport>memory view</dfn> comprises:
 * a set of [=memory locations=] in a particular [=address space=],
-* an interpretation of the contents of those locations as a WGSL [=type=], known as the <dfn>store type</dfn>, and
+* an interpretation of the contents of those locations as a WGSL [=type=], known as the <dfn noexport>store type</dfn>, and
 * an [=access mode=].
 
 The access mode of a memory view [=shader-creation error|must=] be supported by the address space. See [[#address-space]].


### PR DESCRIPTION
This unifies the language for the parameterizations of reference and pointer types, which
makes certain things easier to say.