### PR TITLE
wgsl: Make float builtin preconditions similar to integer builtins.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -15,7 +15,7 @@ Text Macro: INTEGRAL i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;
 Text Macro: FLOATING f32, f16, vec|N|&lt;f32&gt;, or vec|N|&lt;f16&gt;
 Text Macro: NUMERIC i32, u32, f32, f16, vec|N|&lt;i32&gt;, vec|N|&lt;u32&gt;, vec|N|&lt;f32&gt;, or vec|N|&lt;f16&gt;
 Text Macro: ALLINTEGRALDECL |S| is AbstractInt, i32, or u32<br>|T| is |S| or vec|N|&lt;|S|&gt;
-Text Macro: ALLFLOATING |S| is AbstractFloat, f32, or f16<br>|T| is |S| or vec|N|&lt;|S|&gt;
+Text Macro: ALLFLOATINGDECL |S| is AbstractFloat, f32, or f16<br>|T| is |S| or vec|N|&lt;|S|&gt;
 Text Macro: ALLNUMERICDECL |S| is AbstractInt, AbstractFloat, i32, u32, f32, or f16<br>|T| is |S|, or vec|N|&lt;|S|&gt;
 Text Macro: ALLINTEGRALDECL |S| is AbstractInt, i32, or u32<br>|T| is |S| or vec|N|&lt;|S|&gt;
 Ignored Vars: i, c0, e, e1, e2, e3, eN, p, s1, s2, sn, N, M, C, R, v, Stride, Offset, Align, Extent, S, T, T1
@@ -721,7 +721,7 @@ characters when choosing values. For more information, see [[CHARMOD-NORM]].
 
 Note: A user agent should issue developer-visible warnings when the meaning of a WGSL program would change if
 all instances of an identifier are replaced with one of that identifier's homographs.
-(A homoglyph is a sequence of code points that may appear the same to a reader as another sequence of code points. 
+(A homoglyph is a sequence of code points that may appear the same to a reader as another sequence of code points.
 Examples of mappings to detect homoglyphs are the transformations, mappings, and matching algorithms mentioned in
 the previous paragraph. Two sequences of code points are homographs if the identifier can transform one into the other by
 repeatedly replacing a subsequence with its homoglyph.)
@@ -7817,7 +7817,7 @@ shader [=shader-creation error|must not=] have the same group and binding values
 WebGPU requires that a shader's resource interface match the [[WebGPU#pipeline-layout|layout of the pipeline]]
 using the shader.
 
-It is a [=pipeline-creation error=] if a WGSL variable in a resource interface is bound to an incompatible WebGPU 
+It is a [=pipeline-creation error=] if a WGSL variable in a resource interface is bound to an incompatible WebGPU
 [[WebGPU#binding-resource-type|resource type]] or
 [[WebGPU#binding-type|binding type]],
 where compatibility is defined by the following table.
@@ -10426,19 +10426,19 @@ See [[#function-calls]].
     <tr><th>Parameterization<th>Overload<th>Description
   </thead>
   <tr algorithm="float abs">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`abs(`|e|`:` |T| `) -> ` |T|
     <td>Returns the absolute value of |e| (e.g. |e| with a positive sign bit).
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="acos">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`acos(`|e|`:` |T| `) -> ` |T|
     <td>Returns the arc cosine of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="acosh">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`acosh(`|e|`:` |T| `) -> ` |T|
     <td>Returns the hyperbolic arc cosine of |e|.
     The result is 0 when |e| &lt; 1.<br>
@@ -10447,26 +10447,26 @@ See [[#function-calls]].
 
     Note: The result is not mathematically meaningful when |e| &lt; 1.
   <tr algorithm="asin">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`asin(`|e|`:` |T| `) -> ` |T|
     <td>Returns the arc sine of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="asinh">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`asinh(`|e|`:` |T| `) -> ` |T|
     <td>Returns the hyperbolic arc sine of |e|.<br>
     Computes the functional inverse of `sinh`.<br>
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="atan">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`atan(`|e|`:` |T| `) -> ` |T|
     <td>Returns the arc tangent of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="atanh">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`atanh(`|e|`:` |T| `) -> ` |T|
     <td>Returns the hyperbolic arc tangent of |e|.
     The result is 0 when `abs`(|e|) &ge; 1.<br>
@@ -10476,31 +10476,31 @@ See [[#function-calls]].
     Note: The result is not mathematically meaningful when `abs`(|e|) &ge; 1.<br>
 
   <tr algorithm="atan2">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`atan2(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>Returns the arc tangent of |e1| over |e2|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="ceil">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`ceil(`|e|`:` |T| `) -> ` |T|
     <td>Returns the [=ceiling expression|ceiling=] of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="clamp">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`clamp(`|e|`:` |T| `,` |low|`:` |T| `,` |high|`:` |T|`) -> ` |T|
     <td>Returns either `min(max(`|e|`,`|low|`),`|high|`)`, or the median of the three values |e|, |low|, |high|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="cos">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`cos(`|e|`:` |T| `) -> ` |T|
     <td>Returns the cosine of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="cosh">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`cosh(`|e|`:` |T| `) -> ` |T|
     <td>Returns the hyperbolic cosine of |e|.
     [=Component-wise=] when |T| is a vector
@@ -10511,24 +10511,24 @@ See [[#function-calls]].
     <td>Returns the cross product of |e1| and |e2|.
 
   <tr algorithm="degrees">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`degrees(`|e1|`:` |T| `) -> ` |T|
     <td>Converts radians to degrees, approximating |e1|&nbsp;&times;&nbsp;180&nbsp;&div;&nbsp;&pi;.
     [=Component-wise=] when |T| is a vector<br>
 
   <tr algorithm="distance">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`distance(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` f32
     <td>Returns the distance between |e1| and |e2| (e.g. `length(`|e1|` - `|e2|`)`).
 
   <tr algorithm="exp">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`exp(`|e1|`:` |T| `) -> ` |T|
     <td>Returns the natural exponentiation of |e1| (e.g. `e`<sup>|e1|</sup>).
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="exp2">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`exp2(`|e|`:` |T| `) -> ` |T|
     <td>Returns 2 raised to the power |e| (e.g. `2`<sup>|e|</sup>).
     [=Component-wise=] when |T| is a vector.
@@ -10539,19 +10539,19 @@ See [[#function-calls]].
     <td>Returns |e1| if `dot(`|e2|`,`|e3|`)` is negative, and `-`|e1| otherwise.
 
   <tr algorithm="floor">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`floor(`|e|`:` |T| `) -> ` |T|
     <td>Returns the [=floor expression|floor=] of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="fma">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`fma(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T| `) -> ` |T|
     <td>Returns |e1| `*` |e2| `+` |e3|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="fract">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`fract(`|e|`:` |T| `) -> ` |T|
     <td>Returns the fractional part of |e|, computed as |e| `- floor(`|e|`)`.<br>
     [=Component-wise=] when |T| is a vector.
@@ -10626,13 +10626,13 @@ struct __frexp_result_vecN_f16 {
     Note: A value cannot be explicitly declared with the type `__frexp_result_vec`|N|`_f16`, but a value may infer the type.
 
   <tr algorithm="inverseSqrt">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`inverseSqrt(`|e|`:` |T| `) -> ` |T|
     <td>Returns the reciprocal of `sqrt(`|e|`)`.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="ldexp">
-    <td>[ALLFLOATING]<br>
+    <td>[ALLFLOATINGDECL]<br>
         |I| is [ALLSIGNEDINTEGRAL], where<br>
         |I| is a scalar if |T| is a scalar, or<br>
         a vector when |T| is a vector
@@ -10641,24 +10641,24 @@ struct __frexp_result_vecN_f16 {
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="length">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`length(`|e|`:` |T| `) -> ` f32
     <td>Returns the length of |e| (e.g. `abs(`|e|`)` if |T| is a scalar, or `sqrt(`|e|`[0]`<sup>`2`</sup> `+` |e|`[1]`<sup>`2`</sup> `+ ...)` if |T| is a vector).
 
   <tr algorithm="log">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`log(`|e|`:` |T| `) -> ` |T|
     <td>Returns the natural logarithm of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="log2">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`log2(`|e|`:` |T| `) -> ` |T|
     <td>Returns the base-2 logarithm of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="max">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`max(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>Returns |e2| if |e1| is less than |e2|, and |e1| otherwise.
     If one operand is a NaN, the other is returned.
@@ -10666,7 +10666,7 @@ struct __frexp_result_vecN_f16 {
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="min">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`min(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>Returns |e2| if |e2| is less than |e1|, and |e1| otherwise.
     If one operand is a NaN, the other is returned.
@@ -10674,7 +10674,7 @@ struct __frexp_result_vecN_f16 {
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="mix all same type operands">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`mix(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T|`) -> ` |T|
     <td>Returns the linear blend of |e1| and |e2| (e.g. |e1|`*(1-`|e3|`)+`|e2|`*`|e3|).
     [=Component-wise=] when |T| is a vector.
@@ -10773,7 +10773,7 @@ struct __modf_result_vecN_f16 {
     <td>Returns a unit vector in the same direction as |e|.
 
   <tr algorithm="pow">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`pow(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>Returns |e1| raised to the power |e2|.
     [=Component-wise=] when |T| is a vector.
@@ -10789,7 +10789,7 @@ struct __modf_result_vecN_f16 {
         Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(`|e|`))`.
 
   <tr algorithm="radians">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`radians(`|e1|`:` |T| `) -> ` |T|
     <td>Converts degrees to radians, approximating |e1|&nbsp;&times;&nbsp;&pi;&nbsp;&div;&nbsp;180.
     [=Component-wise=] when |T| is a vector<br>
@@ -10809,7 +10809,7 @@ struct __modf_result_vecN_f16 {
     |e3|` * `|e1|` - (`|e3|` * dot(`|e2|`, `|e1|`) + sqrt(k)) * `|e2|.
 
   <tr algorithm="round">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`round(`|e|`:` |T| `) -> ` |T|
     <td>Result is the integer |k| nearest to |e|, as a floating point value.<br>
         When |e| lies halfway between integers |k| and |k|+1,
@@ -10817,25 +10817,25 @@ struct __modf_result_vecN_f16 {
         [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="float sign">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`sign(`|e|`:` |T| `) -> ` |T|
     <td>Returns the sign of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="sin">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`sin(`|e|`:` |T| `) -> ` |T|
     <td>Returns the sine of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="sinh">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`sinh(`|e|`:` |T| `) -> ` |T|
     <td>Returns the hyperbolic sine of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="smoothstep">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`smoothstep(`|low|`:` |T| `,` |high|`:` |T| `,` |x|`:` |T| `) -> ` |T|
     <td>Returns the smooth Hermite interpolation between 0 and 1.
     [=Component-wise=] when |T| is a vector.
@@ -10845,31 +10845,31 @@ struct __modf_result_vecN_f16 {
     where |t| = clamp((|x| - |low|) / (|high| - |low|), 0.0, 1.0).
 
   <tr algorithm="sqrt">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`sqrt(`|e|`:` |T| `) -> ` |T|
     <td>Returns the square root of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="step">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`step(`|edge|`:` |T| `, `|x|`:` |T| `) -> ` |T|
     <td>Returns 1.0 if |edge| &le; |x|, and 0.0 otherwise.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="tan">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`tan(`|e|`:` |T| `) -> ` |T|
     <td>Returns the tangent of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="tanh">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`tanh(`|e|`:` |T| `) -> ` |T|
     <td>Returns the hyperbolic tangent of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="trunc">
-    <td>[ALLFLOATING]
+    <td>[ALLFLOATINGDECL]
     <td class="nowrap">`@const fn`<br>`trunc(`|e|`:` |T| `) -> ` |T|
     <td>Returns [=truncate=](|e|), the nearest whole number whose absolute value is less than or equal to |e|.
     [=Component-wise=] when |T| is a vector.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -14,8 +14,8 @@ Text Macro: ALLSIGNEDINTEGRAL AbstractInt, i32, vec|N|&lt;AbstractInt&gt;, or ve
 Text Macro: INTEGRAL i32, u32, vec|N|&lt;i32&gt;, or vec|N|&lt;u32&gt;
 Text Macro: FLOATING f32, f16, vec|N|&lt;f32&gt;, or vec|N|&lt;f16&gt;
 Text Macro: NUMERIC i32, u32, f32, f16, vec|N|&lt;i32&gt;, vec|N|&lt;u32&gt;, vec|N|&lt;f32&gt;, or vec|N|&lt;f16&gt;
-Text Macro: ALLINTEGRALDECL |S| is AbstractInt, i32, u32<br>|T| is |S| or vec|N|&lt;|S|&gt;
-Text Macro: ALLFLOATING AbstractFloat, f32, f16, vec|N|&lt;AbstractFloat&gt;, vec|N|&lt;f32&gt;, or vec|N|&lt;f16&gt;
+Text Macro: ALLINTEGRALDECL |S| is AbstractInt, i32, or u32<br>|T| is |S| or vec|N|&lt;|S|&gt;
+Text Macro: ALLFLOATING |S| is AbstractFloat, f32, or f16<br>|T| is |S| or vec|N|&lt;|S|&gt;
 Text Macro: ALLNUMERICDECL |S| is AbstractInt, AbstractFloat, i32, u32, f32, or f16<br>|T| is |S|, or vec|N|&lt;|S|&gt;
 Text Macro: ALLINTEGRALDECL |S| is AbstractInt, i32, or u32<br>|T| is |S| or vec|N|&lt;|S|&gt;
 Ignored Vars: i, c0, e, e1, e2, e3, eN, p, s1, s2, sn, N, M, C, R, v, Stride, Offset, Align, Extent, S, T, T1
@@ -10426,19 +10426,19 @@ See [[#function-calls]].
     <tr><th>Parameterization<th>Overload<th>Description
   </thead>
   <tr algorithm="float abs">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`abs(`|e|`:` |T| `) -> ` |T|
     <td>Returns the absolute value of |e| (e.g. |e| with a positive sign bit).
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="acos">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`acos(`|e|`:` |T| `) -> ` |T|
     <td>Returns the arc cosine of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="acosh">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`acosh(`|e|`:` |T| `) -> ` |T|
     <td>Returns the hyperbolic arc cosine of |e|.
     The result is 0 when |e| &lt; 1.<br>
@@ -10447,26 +10447,26 @@ See [[#function-calls]].
 
     Note: The result is not mathematically meaningful when |e| &lt; 1.
   <tr algorithm="asin">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`asin(`|e|`:` |T| `) -> ` |T|
     <td>Returns the arc sine of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="asinh">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`asinh(`|e|`:` |T| `) -> ` |T|
     <td>Returns the hyperbolic arc sine of |e|.<br>
     Computes the functional inverse of `sinh`.<br>
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="atan">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`atan(`|e|`:` |T| `) -> ` |T|
     <td>Returns the arc tangent of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="atanh">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`atanh(`|e|`:` |T| `) -> ` |T|
     <td>Returns the hyperbolic arc tangent of |e|.
     The result is 0 when `abs`(|e|) &ge; 1.<br>
@@ -10476,31 +10476,31 @@ See [[#function-calls]].
     Note: The result is not mathematically meaningful when `abs`(|e|) &ge; 1.<br>
 
   <tr algorithm="atan2">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`atan2(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>Returns the arc tangent of |e1| over |e2|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="ceil">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`ceil(`|e|`:` |T| `) -> ` |T|
     <td>Returns the [=ceiling expression|ceiling=] of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="clamp">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`clamp(`|e|`:` |T| `,` |low|`:` |T| `,` |high|`:` |T|`) -> ` |T|
     <td>Returns either `min(max(`|e|`,`|low|`),`|high|`)`, or the median of the three values |e|, |low|, |high|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="cos">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`cos(`|e|`:` |T| `) -> ` |T|
     <td>Returns the cosine of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="cosh">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`cosh(`|e|`:` |T| `) -> ` |T|
     <td>Returns the hyperbolic cosine of |e|.
     [=Component-wise=] when |T| is a vector
@@ -10511,24 +10511,24 @@ See [[#function-calls]].
     <td>Returns the cross product of |e1| and |e2|.
 
   <tr algorithm="degrees">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`degrees(`|e1|`:` |T| `) -> ` |T|
     <td>Converts radians to degrees, approximating |e1|&nbsp;&times;&nbsp;180&nbsp;&div;&nbsp;&pi;.
     [=Component-wise=] when |T| is a vector<br>
 
   <tr algorithm="distance">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`distance(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` f32
     <td>Returns the distance between |e1| and |e2| (e.g. `length(`|e1|` - `|e2|`)`).
 
   <tr algorithm="exp">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`exp(`|e1|`:` |T| `) -> ` |T|
     <td>Returns the natural exponentiation of |e1| (e.g. `e`<sup>|e1|</sup>).
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="exp2">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`exp2(`|e|`:` |T| `) -> ` |T|
     <td>Returns 2 raised to the power |e| (e.g. `2`<sup>|e|</sup>).
     [=Component-wise=] when |T| is a vector.
@@ -10539,19 +10539,19 @@ See [[#function-calls]].
     <td>Returns |e1| if `dot(`|e2|`,`|e3|`)` is negative, and `-`|e1| otherwise.
 
   <tr algorithm="floor">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`floor(`|e|`:` |T| `) -> ` |T|
     <td>Returns the [=floor expression|floor=] of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="fma">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`fma(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T| `) -> ` |T|
     <td>Returns |e1| `*` |e2| `+` |e3|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="fract">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`fract(`|e|`:` |T| `) -> ` |T|
     <td>Returns the fractional part of |e|, computed as |e| `- floor(`|e|`)`.<br>
     [=Component-wise=] when |T| is a vector.
@@ -10626,13 +10626,13 @@ struct __frexp_result_vecN_f16 {
     Note: A value cannot be explicitly declared with the type `__frexp_result_vec`|N|`_f16`, but a value may infer the type.
 
   <tr algorithm="inverseSqrt">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`inverseSqrt(`|e|`:` |T| `) -> ` |T|
     <td>Returns the reciprocal of `sqrt(`|e|`)`.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="ldexp">
-    <td>|T| is [ALLFLOATING]<br>
+    <td>[ALLFLOATING]<br>
         |I| is [ALLSIGNEDINTEGRAL], where<br>
         |I| is a scalar if |T| is a scalar, or<br>
         a vector when |T| is a vector
@@ -10641,24 +10641,24 @@ struct __frexp_result_vecN_f16 {
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="length">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`length(`|e|`:` |T| `) -> ` f32
     <td>Returns the length of |e| (e.g. `abs(`|e|`)` if |T| is a scalar, or `sqrt(`|e|`[0]`<sup>`2`</sup> `+` |e|`[1]`<sup>`2`</sup> `+ ...)` if |T| is a vector).
 
   <tr algorithm="log">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`log(`|e|`:` |T| `) -> ` |T|
     <td>Returns the natural logarithm of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="log2">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`log2(`|e|`:` |T| `) -> ` |T|
     <td>Returns the base-2 logarithm of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="max">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`max(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>Returns |e2| if |e1| is less than |e2|, and |e1| otherwise.
     If one operand is a NaN, the other is returned.
@@ -10666,7 +10666,7 @@ struct __frexp_result_vecN_f16 {
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="min">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`min(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>Returns |e2| if |e2| is less than |e1|, and |e1| otherwise.
     If one operand is a NaN, the other is returned.
@@ -10674,7 +10674,7 @@ struct __frexp_result_vecN_f16 {
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="mix all same type operands">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`mix(`|e1|`:` |T| `, `|e2|`:` |T| `, `|e3|`:` |T|`) -> ` |T|
     <td>Returns the linear blend of |e1| and |e2| (e.g. |e1|`*(1-`|e3|`)+`|e2|`*`|e3|).
     [=Component-wise=] when |T| is a vector.
@@ -10773,7 +10773,7 @@ struct __modf_result_vecN_f16 {
     <td>Returns a unit vector in the same direction as |e|.
 
   <tr algorithm="pow">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`pow(`|e1|`:` |T| `, `|e2|`:` |T| `) -> ` |T|
     <td>Returns |e1| raised to the power |e2|.
     [=Component-wise=] when |T| is a vector.
@@ -10789,7 +10789,7 @@ struct __modf_result_vecN_f16 {
         Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(`|e|`))`.
 
   <tr algorithm="radians">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`radians(`|e1|`:` |T| `) -> ` |T|
     <td>Converts degrees to radians, approximating |e1|&nbsp;&times;&nbsp;&pi;&nbsp;&div;&nbsp;180.
     [=Component-wise=] when |T| is a vector<br>
@@ -10809,7 +10809,7 @@ struct __modf_result_vecN_f16 {
     |e3|` * `|e1|` - (`|e3|` * dot(`|e2|`, `|e1|`) + sqrt(k)) * `|e2|.
 
   <tr algorithm="round">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`round(`|e|`:` |T| `) -> ` |T|
     <td>Result is the integer |k| nearest to |e|, as a floating point value.<br>
         When |e| lies halfway between integers |k| and |k|+1,
@@ -10817,25 +10817,25 @@ struct __modf_result_vecN_f16 {
         [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="float sign">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`sign(`|e|`:` |T| `) -> ` |T|
     <td>Returns the sign of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="sin">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`sin(`|e|`:` |T| `) -> ` |T|
     <td>Returns the sine of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="sinh">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`sinh(`|e|`:` |T| `) -> ` |T|
     <td>Returns the hyperbolic sine of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="smoothstep">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`smoothstep(`|low|`:` |T| `,` |high|`:` |T| `,` |x|`:` |T| `) -> ` |T|
     <td>Returns the smooth Hermite interpolation between 0 and 1.
     [=Component-wise=] when |T| is a vector.
@@ -10845,31 +10845,31 @@ struct __modf_result_vecN_f16 {
     where |t| = clamp((|x| - |low|) / (|high| - |low|), 0.0, 1.0).
 
   <tr algorithm="sqrt">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`sqrt(`|e|`:` |T| `) -> ` |T|
     <td>Returns the square root of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="step">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`step(`|edge|`:` |T| `, `|x|`:` |T| `) -> ` |T|
     <td>Returns 1.0 if |edge| &le; |x|, and 0.0 otherwise.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="tan">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`tan(`|e|`:` |T| `) -> ` |T|
     <td>Returns the tangent of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="tanh">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`tanh(`|e|`:` |T| `) -> ` |T|
     <td>Returns the hyperbolic tangent of |e|.
     [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="trunc">
-    <td>|T| is [ALLFLOATING]
+    <td>[ALLFLOATING]
     <td class="nowrap">`@const fn`<br>`trunc(`|e|`:` |T| `) -> ` |T|
     <td>Returns [=truncate=](|e|), the nearest whole number whose absolute value is less than or equal to |e|.
     [=Component-wise=] when |T| is a vector.


### PR DESCRIPTION
This PR changes the float builtins to use a structure like:

```
|S| is AbstractFloat, f32, or f16
|T| is S or vecN<S>
```

which matches how the integer builtins are specified.