### PR TITLE
Normalizing object creation and invalidation

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2410,44 +2410,48 @@ The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its
 
             **Returns:** {{GPUBuffer}}
 
-            1. If any of the following conditions are unsatisfied, return an error buffer and stop.
-                <div class=validusage>
-                    - |this| is a [=valid=] {{GPUDevice}}.
-                    - [$validating GPUBufferDescriptor$](|this|, |descriptor|) returns true.
-                    - |descriptor|.{{GPUBufferDescriptor/usage}} must not be 0.
-                    - |descriptor|.{{GPUBufferDescriptor/usage}} is a subset of |this|'s [=allowed buffer usages=].
-                    - If |descriptor|.{{GPUBufferDescriptor/usage}} contains {{GPUBufferUsage/MAP_READ}}:
-                        - |descriptor|.{{GPUBufferDescriptor/usage}} contains no other flags
-                            except {{GPUBufferUsage/COPY_DST}}.
-                    - If |descriptor|.{{GPUBufferDescriptor/usage}} contains {{GPUBufferUsage/MAP_WRITE}}:
-                        - |descriptor|.{{GPUBufferDescriptor/usage}} contains no other flags
-                            except {{GPUBufferUsage/COPY_SRC}}.
-                    - If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`:
-                        - |descriptor|.{{GPUBufferDescriptor/size}} is a multiple of 4.
-                </div>
-
-            Note: If buffer creation fails, and |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `false`,
-            any calls to {{GPUBuffer/mapAsync()}} will reject, so any resources allocated to enable mapping can
-            and may be discarded or recycled.
-
             1. Let |b| be a new {{GPUBuffer}} object.
-            1. Set |b|.{{GPUBuffer/[[size]]}} to |descriptor|.{{GPUBufferDescriptor/size}}.
-            1. Set |b|.{{GPUBuffer/[[usage]]}} to |descriptor|.{{GPUBufferDescriptor/usage}}.
-            1. If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`:
+            1. Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
+                    1. If any of the following conditions are unsatisfied
+                        [$generate a validation error$], make |b| [=invalid=], and stop.
+                        <div class=validusage>
+                            - |this| is [=valid=].
+                            - [$validating GPUBufferDescriptor$](|this|, |descriptor|) returns true.
+                            - |descriptor|.{{GPUBufferDescriptor/usage}} must not be 0.
+                            - |descriptor|.{{GPUBufferDescriptor/usage}} is a subset of |this|'s [=allowed buffer usages=].
+                            - If |descriptor|.{{GPUBufferDescriptor/usage}} contains {{GPUBufferUsage/MAP_READ}}:
+                                - |descriptor|.{{GPUBufferDescriptor/usage}} contains no other flags
+                                    except {{GPUBufferUsage/COPY_DST}}.
+                            - If |descriptor|.{{GPUBufferDescriptor/usage}} contains {{GPUBufferUsage/MAP_WRITE}}:
+                                - |descriptor|.{{GPUBufferDescriptor/usage}} contains no other flags
+                                    except {{GPUBufferUsage/COPY_SRC}}.
+                            - If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`:
+                                - |descriptor|.{{GPUBufferDescriptor/size}} is a multiple of 4.
+                        </div>
 
-                1. Set |b|.{{GPUBuffer/[[mapping]]}} to a new {{ArrayBuffer}} of size |b|.{{GPUBuffer/[[size]]}}.
-                1. Set |b|.{{GPUBuffer/[[mapping_range]]}} to `[0, descriptor.size]`.
-                1. Set |b|.{{GPUBuffer/[[mapped_ranges]]}} to `[]`.
-                1. Set |b|.{{GPUBuffer/[[state]]}} to [=buffer state/mapped at creation=].
+                    Note: If buffer creation fails, and |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `false`,
+                    any calls to {{GPUBuffer/mapAsync()}} will reject, so any resources allocated to enable mapping can
+                    and may be discarded or recycled.
 
-                Else:
+                    1. Set |b|.{{GPUBuffer/[[size]]}} to |descriptor|.{{GPUBufferDescriptor/size}}.
+                    1. Set |b|.{{GPUBuffer/[[usage]]}} to |descriptor|.{{GPUBufferDescriptor/usage}}.
+                    1. If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`:
 
-                1. Set |b|.{{GPUBuffer/[[mapping]]}} to `null`.
-                1. Set |b|.{{GPUBuffer/[[mapping_range]]}} to `null`.
-                1. Set |b|.{{GPUBuffer/[[mapped_ranges]]}} to `null`.
-                1. Set |b|.{{GPUBuffer/[[state]]}} to [=buffer state/unmapped=].
+                        1. Set |b|.{{GPUBuffer/[[mapping]]}} to a new {{ArrayBuffer}} of size |b|.{{GPUBuffer/[[size]]}}.
+                        1. Set |b|.{{GPUBuffer/[[mapping_range]]}} to `[0, descriptor.size]`.
+                        1. Set |b|.{{GPUBuffer/[[mapped_ranges]]}} to `[]`.
+                        1. Set |b|.{{GPUBuffer/[[state]]}} to [=buffer state/mapped at creation=].
 
-            1. Set each byte of |b|'s allocation to zero.
+                        Else:
+
+                        1. Set |b|.{{GPUBuffer/[[mapping]]}} to `null`.
+                        1. Set |b|.{{GPUBuffer/[[mapping_range]]}} to `null`.
+                        1. Set |b|.{{GPUBuffer/[[mapped_ranges]]}} to `null`.
+                        1. Set |b|.{{GPUBuffer/[[state]]}} to [=buffer state/unmapped=].
+
+                    1. Set each byte of |b|'s allocation to zero.
+                </div>
             1. Return |b|.
         </div>
 
@@ -2907,25 +2911,27 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
 
             **Returns:** {{GPUTexture}}
 
+            1. If |descriptor|.{{GPUTextureDescriptor/format}} is a {{GPUTextureFormat}} that requires a feature (see
+                [[#texture-format-caps]]), but |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} does not
+                [=list/contain=] the feature, throw a {{TypeError}}.
+            1. Let |t| be a new {{GPUTexture}} object.
             1. Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
-                    1. If |descriptor|.{{GPUTextureDescriptor/format}} is a {{GPUTextureFormat}} that requires a feature (see
-                        [[#texture-format-caps]]), but |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} does not
-                        [=list/contain=] the feature, throw a {{TypeError}}.
-                    1. If [$validating GPUTextureDescriptor$](|this|, |descriptor|) returns false:
-                        1. [$Generate a validation error$].
-                        1. Return a new [=invalid=] {{GPUTexture}}.
-                    1. Let |t| be a new {{GPUTexture}} object.
+                    1. If any of the following conditions are unsatisfied
+                        [$generate a validation error$], make |t| [=invalid=], and stop.
+                        <div class=validusage>
+                            - [$validating GPUTextureDescriptor$](|this|, |descriptor|) returns `true`.
+                        </div>
                     1. Set |t|.{{GPUTexture/[[descriptor]]}} to |descriptor|.
-                    1. Return |t|.
                 </div>
+            1. Return |t|.
         </div>
 </dl>
 
 <div algorithm class=validusage>
     <dfn abstract-op>validating GPUTextureDescriptor</dfn>({{GPUDevice}} |this|, {{GPUTextureDescriptor}} |descriptor|):
 
-    Return true if all of the following requirements are met, and false otherwise:
+    Return `true` if all of the following requirements are met, and `false` otherwise:
 
     - |this| must be a [=valid=] {{GPUDevice}}.
     - |descriptor|.{{GPUTextureDescriptor/usage}} must not be 0.
@@ -3180,12 +3186,15 @@ enum GPUTextureAspect {
 
             **Returns:** |view|, of type {{GPUTextureView}}.
 
-            1. Set |descriptor| to the result of [$resolving GPUTextureViewDescriptor defaults$] for |this| with |descriptor|.
+            1. Let |view| be a new {{GPUTextureView}} object.
             1. Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
-                    1. If any of the following requirements are unmet:
+                    1. Set |descriptor| to the result of [$resolving GPUTextureViewDescriptor defaults$]
+                        for |this| with |descriptor|.
+                    1. If any of the following conditions are unsatisfied
+                        [$generate a validation error$], make |view| [=invalid=], and stop.
                         <div class=validusage>
-                            - |this| is [=valid=]
+                            - |this| is [=valid=].
                             - |descriptor|.{{GPUTextureViewDescriptor/aspect}} must be present in
                                 |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
                             - If the |descriptor|.{{GPUTextureViewDescriptor/aspect}} is {{GPUTextureAspect/"all"}}:
@@ -3240,18 +3249,14 @@ enum GPUTextureAspect {
                                 </dl>
                         </div>
 
-                        Then:
-                            1. [$Generate a validation error$].
-                            1. Return a new [=invalid=] {{GPUTextureView}}.
-
                     1. Let |view| be a new {{GPUTextureView}} object.
                     1. Set |view|.{{GPUTextureView/[[texture]]}} to |this|.
                     1. Set |view|.{{GPUTextureView/[[descriptor]]}} to |descriptor|.
                     1. If |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}} contains {{GPUTextureUsage/RENDER_ATTACHMENT}}:
                         1. Let |renderExtent| be [$compute render extent$](|this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}, |descriptor|.{{GPUTextureViewDescriptor/baseMipLevel}}).
                         1. Set |view|.{{GPUTextureView/[[renderExtent]]}} to |renderExtent|.
-                    1. Return |view|.
                 </div>
+            1. Return |view|.
         </div>
 </dl>
 
@@ -3959,31 +3964,6 @@ enum GPUCompareFunction {
         Comparison tests always pass.
 </dl>
 
-<div algorithm>
-    <dfn abstract-op>validating GPUSamplerDescriptor</dfn>(device, descriptor)
-
-    **Arguments:**
-        - {{GPUDevice}} |device|
-        - {{GPUSamplerDescriptor}} |descriptor|
-
-    **Returns:** {{boolean}}
-
-    Return `true` if and only if all of the following conditions are satisfied:
-        - |device| is valid.
-        - |descriptor|.{{GPUSamplerDescriptor/lodMinClamp}} is greater than or equal to 0.
-        - |descriptor|.{{GPUSamplerDescriptor/lodMaxClamp}} is greater than or equal to
-            |descriptor|.{{GPUSamplerDescriptor/lodMinClamp}}.
-        - |descriptor|.{{GPUSamplerDescriptor/maxAnisotropy}} is greater than or equal to 1.
-
-            Note: Most implementations support {{GPUSamplerDescriptor/maxAnisotropy}} values in range between 1 and 16, inclusive.
-            The provided {{GPUSamplerDescriptor/maxAnisotropy}} value will be clamped to the maximum value that the platform
-            supports.
-
-        - When |descriptor|.{{GPUSamplerDescriptor/maxAnisotropy}} is greater than 1,
-            |descriptor|.{{GPUSamplerDescriptor/magFilter}}, |descriptor|.{{GPUSamplerDescriptor/minFilter}},
-            and |descriptor|.{{GPUSamplerDescriptor/mipmapFilter}} must be equal to {{GPUMipmapFilterMode/"linear"}}.
-</div>
-
 <dl dfn-type=method dfn-for=GPUDevice>
     : <dfn>createSampler(descriptor)</dfn>
     ::
@@ -4000,21 +3980,36 @@ enum GPUCompareFunction {
             **Returns:** {{GPUSampler}}
 
             1. Let |s| be a new {{GPUSampler}} object.
-            1. Set |s|.{{GPUSampler/[[descriptor]]}} to |descriptor|.
-            1. Set |s|.{{GPUSampler/[[isComparison]]}} to `false` if the {{GPUSamplerDescriptor/compare}} attribute
-                    of |s|.{{GPUSampler/[[descriptor]]}} is `null` or undefined. Otherwise, set it to `true`.
-            1. Set |s|.{{GPUSampler/[[isFiltering]]}} to `false` if none of {{GPUSamplerDescriptor/minFilter}},
-                {{GPUSamplerDescriptor/magFilter}}, or {{GPUSamplerDescriptor/mipmapFilter}} has the value of
-                {{GPUFilterMode/"linear"}}. Otherwise, set it to `true`.
-            1. Return |s|.
+            1. Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
+                    1. If any of the following conditions are unsatisfied
+                        [$generate a validation error$], make |s| [=invalid=], and stop.
+                        <div class=validusage>
+                            - |this| is [=valid=].
+                            - |descriptor|.{{GPUSamplerDescriptor/lodMinClamp}} &ge; 0.
+                            - |descriptor|.{{GPUSamplerDescriptor/lodMaxClamp}} &ge;
+                                |descriptor|.{{GPUSamplerDescriptor/lodMinClamp}}.
+                            - |descriptor|.{{GPUSamplerDescriptor/maxAnisotropy}} &ge; 1.
 
-            <div class=validusage dfn-for=GPUDevice.createSampler>
-                <dfn abstract-op>Valid Usage</dfn>
-                - If |descriptor| is not `null` or undefined:
-                    - If [$validating GPUSamplerDescriptor$](this, |descriptor|) returns `false`:
-                        1. [$Generate a validation error$].
-                        1. Create a new [=invalid=] {{GPUSampler}} and return the result.
-            </div>
+                                Note: Most implementations support {{GPUSamplerDescriptor/maxAnisotropy}}
+                                values in range between 1 and 16, inclusive. The provided
+                                {{GPUSamplerDescriptor/maxAnisotropy}} value will be clamped to the
+                                maximum value that the platform supports.
+
+                            - If |descriptor|.{{GPUSamplerDescriptor/maxAnisotropy}} &gt; 1:
+                                - |descriptor|.{{GPUSamplerDescriptor/magFilter}},
+                                    |descriptor|.{{GPUSamplerDescriptor/minFilter}},
+                                    and |descriptor|.{{GPUSamplerDescriptor/mipmapFilter}} must be
+                                    {{GPUMipmapFilterMode/"linear"}}.
+                        </div>
+                    1. Set |s|.{{GPUSampler/[[descriptor]]}} to |descriptor|.
+                    1. Set |s|.{{GPUSampler/[[isComparison]]}} to `false` if the {{GPUSamplerDescriptor/compare}} attribute
+                            of |s|.{{GPUSampler/[[descriptor]]}} is `null` or undefined. Otherwise, set it to `true`.
+                    1. Set |s|.{{GPUSampler/[[isFiltering]]}} to `false` if none of {{GPUSamplerDescriptor/minFilter}},
+                        {{GPUSamplerDescriptor/magFilter}}, or {{GPUSamplerDescriptor/mipmapFilter}} has the value of
+                        {{GPUFilterMode/"linear"}}. Otherwise, set it to `true`.
+                </div>
+            1. Return |s|.
         </div>
 </dl>
 
@@ -4412,13 +4407,13 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
 
             **Returns:** {{GPUBindGroupLayout}}
 
-            1. Let |layout| be a new valid {{GPUBindGroupLayout}} object.
-            1. Set |layout|.{{GPUBindGroupLayout/[[descriptor]]}} to |descriptor|.
+            1. Let |layout| be a new {{GPUBindGroupLayout}} object.
             1. Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
-                    1. If any of the following conditions are unsatisfied:
+                    1. If any of the following conditions are unsatisfied
+                        [$generate a validation error$], make |layout| [=invalid=], and stop.
                         <div class=validusage>
-                            - |this| is a [=valid=] {{GPUDevice}}.
+                            - |this| is [=valid=].
                             - The {{GPUBindGroupLayoutEntry/binding}} of each entry in |descriptor| is unique.
                             - The {{GPUBindGroupLayoutEntry/binding}} of each entry in |descriptor| must be &lt; 65536.
                             - |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}} must not
@@ -4454,10 +4449,7 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                                         which can support storage usage.
                         </div>
 
-                        Then:
-                            1. [$Generate a validation error$].
-                            1. Make |layout| [=invalid=] and return |layout|.
-
+                    1. Set |layout|.{{GPUBindGroupLayout/[[descriptor]]}} to |descriptor|.
                     1. Set |layout|.{{GPUBindGroupLayout/[[dynamicOffsetCount]]}} to the number of
                         entries in |descriptor| where {{GPUBindGroupLayoutEntry/buffer}} is not `undefined` and
                         {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}} is `true`.
@@ -4561,11 +4553,12 @@ A {{GPUBindGroup}} object has the following internal slots:
 
             **Returns:** {{GPUBindGroup}}
 
-            1. Let |bindGroup| be a new valid {{GPUBindGroup}} object.
-            1. Let |limits| be |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.
+            1. Let |bindGroup| be a new {{GPUBindGroup}} object.
             1. Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
-                    1. If any of the following conditions are unsatisfied:
+                    1. Let |limits| be |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.
+                    1. If any of the following conditions are unsatisfied
+                        [$generate a validation error$], make |bindGroup| [=invalid=], and stop.
                         <div class=validusage>
                             - |descriptor|.{{GPUBindGroupDescriptor/layout}} is [$valid to use with$] |this|.
                             - The number of {{GPUBindGroupLayoutDescriptor/entries}} of
@@ -4662,10 +4655,6 @@ A {{GPUBindGroup}} object has the following internal slots:
                                             - |resource| is [$valid to use with$] |this|.
                                     </dl>
                         </div>
-
-                        Then:
-                            1. [$Generate a validation error$].
-                            1. Make |bindGroup| [=invalid=] and return |bindGroup|.
 
                     1. Let |bindGroup|.{{GPUBindGroup/[[layout]]}} =
                         |descriptor|.{{GPUBindGroupDescriptor/layout}}.
@@ -4772,29 +4761,27 @@ dictionary GPUPipelineLayoutDescriptor : GPUObjectDescriptorBase {
 
             **Returns:** {{GPUPipelineLayout}}
 
-            1. If any of the following requirements are unmet:
-                <div class=validusage>
-                    Let |limits| be |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.
-
-                    Let |allEntries| be the result of concatenating
+            1. Let |pl| be a new {{GPUPipelineLayout}} object.
+            1. Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
+                    1. Let |limits| be |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.
+                    1. Let |allEntries| be the result of concatenating
                         |bgl|.{{GPUBindGroupLayout/[[descriptor]]}}.{{GPUBindGroupLayoutDescriptor/entries}}
                         for all |bgl| in |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}.
+                    1. If any of the following conditions are unsatisfied
+                        [$generate a validation error$], make |pl| [=invalid=], and stop.
+                        <div class=validusage>
+                            - Every {{GPUBindGroupLayout}} in |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
+                                must be [$valid to use with$] |this| and have a {{GPUBindGroupLayout/[[exclusivePipeline]]}}
+                                of `null`.
+                            - The [=list/size=] of |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
+                                must be &le; |limits|.{{supported limits/maxBindGroups}}.
+                            - |allEntries| must not [=exceeds the binding slot limits|exceed the binding slot limits=] of |limits|.
+                        </div>
 
-                    - Every {{GPUBindGroupLayout}} in |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
-                        must be [$valid to use with$] |this| and have a {{GPUBindGroupLayout/[[exclusivePipeline]]}}
-                        of `null`.
-                    - The [=list/size=] of |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
-                        must be &le; |limits|.{{supported limits/maxBindGroups}}.
-                    - |allEntries| must not [=exceeds the binding slot limits|exceed the binding slot limits=] of |limits|.
+                    1. Set the |pl|.{{GPUPipelineLayout/[[bindGroupLayouts]]}} to
+                        |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}.
                 </div>
-
-                Then:
-                    1. [$Generate a validation error$].
-                    1. Create a new [=invalid=] {{GPUPipelineLayout}} and return the result.
-
-            1. Let |pl| be a new {{GPUPipelineLayout}} object.
-            1. Set the |pl|.{{GPUPipelineLayout/[[bindGroupLayouts]]}} to
-                |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}.
             1. Return |pl|.
         </div>
 </dl>
@@ -4928,7 +4915,19 @@ same module, they should avoid passing that information to
 
             **Returns:** {{GPUShaderModule}}
 
-            Issue: Describe {{GPUDevice/createShaderModule()}} algorithm steps.
+            1. Let |sm| be a new {{GPUShaderModule}} object.
+            1. Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
+                    1. If any of the following conditions are unsatisfied
+                        [$generate a validation error$], make |sm| [=invalid=], and stop.
+                        <div class=validusage>
+                            - |this| is [=valid=].
+                        </div>
+
+                    Issue: Describe remaining {{GPUDevice/createShaderModule()}} validation and
+                    algorithm steps.
+                </div>
+            1. Return |sm|.
 
             <div class=note>
                 User agents **should not** include error messages or shader text in
@@ -5611,14 +5610,15 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
 
             **Returns:** {{GPUComputePipeline}}
 
-            1. Let |pipeline| be a new valid {{GPUComputePipeline}} object.
+            1. Let |pipeline| be a new {{GPUComputePipeline}} object.
             1. Issue the following steps on the [=Device timeline=] of |this|:
                 1. Let |layout| be a new [$default pipeline layout$] for |pipeline| if
                     |descriptor|.{{GPUPipelineDescriptorBase/layout}} is {{GPUAutoLayoutMode/"auto"}},
                     and |descriptor|.{{GPUPipelineDescriptorBase/layout}} otherwise.
 
                 <div class=device-timeline>
-                    1. If any of the following conditions are unsatisfied:
+                    1. If any of the following conditions are unsatisfied
+                        [$generate a validation error$], make |pipeline| [=invalid=], and stop.
                         <div class=validusage>
                             - |layout| is [$valid to use with$] |this|.
                             - [$validating GPUProgrammableStage$]({{GPUShaderStage/COMPUTE}},
@@ -5638,10 +5638,6 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
                                 |device|.limits.{{supported limits/maxComputeWorkgroupSizeY}},
                                 |device|.limits.{{supported limits/maxComputeWorkgroupSizeZ}}].
                         </div>
-
-                        Then:
-                            1. [$Generate a validation error$]
-                            1. Make |pipeline| [=invalid=].
 
                     1. Set |pipeline|.{{GPUPipelineBase/[[layout]]}} to |layout|.
                 </div>
@@ -5675,7 +5671,8 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
                     1. Let |pipeline| be a new {{GPUComputePipeline}} created as if
                         |this|.{{GPUDevice/createComputePipeline()}} was called with |descriptor|;
 
-                    1. When |pipeline| is ready to be used, [=resolve=] |promise| with |pipeline|.
+                    1. When |pipeline| is ready to be used or has been made [=invalid=], [=resolve=]
+                        |promise| with |pipeline|.
                 </div>
             1. Return |promise|.
         </div>
@@ -5788,7 +5785,7 @@ details.
 
             **Returns:** {{GPURenderPipeline}}
 
-            1. Let |pipeline| be a new valid {{GPURenderPipeline}} object.
+            1. Let |pipeline| be a new {{GPURenderPipeline}} object.
             1. Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
                     1. Let |layout| be a new [$default pipeline layout$] for |pipeline| if
@@ -5796,14 +5793,11 @@ details.
                         and |descriptor|.{{GPUPipelineDescriptorBase/layout}} otherwise.
 
                     1. If any of the following conditions are unsatisfied:
+                        [$generate a validation error$], make |pipeline| [=invalid=], and stop.
                         <div class=validusage>
                             - |layout| is [$valid to use with$] |this|.
                             - [$validating GPURenderPipelineDescriptor$](|descriptor|, |layout|, |this|) succeeds.
                         </div>
-
-                        Then:
-                            1. [$Generate a validation error$].
-                            1. Make |pipeline| [=invalid=].
 
                     1. Set |pipeline|.{{GPURenderPipeline/[[descriptor]]}} to |descriptor|.
                     1. Set |pipeline|.{{GPURenderPipeline/[[writesDepth]]}} to false.
@@ -5856,7 +5850,8 @@ details.
                     1. Let |pipeline| be a new {{GPURenderPipeline}} created as if
                         |this|.{{GPUDevice/createRenderPipeline()}} was called with |descriptor|;
 
-                    1. When |pipeline| is ready to be used, [=resolve=] |promise| with |pipeline|.
+                    1. When |pipeline| is ready to be used or has been made [=invalid=], [=resolve=]
+                        |promise| with |pipeline|.
                 </div>
             1. Return |promise|.
         </div>
@@ -6698,7 +6693,19 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 
             **Returns:** {{GPUCommandEncoder}}
 
-            Issue: Describe {{GPUDevice/createCommandEncoder()}} algorithm steps.
+            1. Let |e| be a new {{GPUCommandEncoder}} object.
+            1. Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
+                    1. If any of the following conditions are unsatisfied
+                        [$generate a validation error$], make |e| [=invalid=], and stop.
+                        <div class=validusage>
+                            - |this| is [=valid=].
+                        </div>
+
+                    Issue: Describe remaining {{GPUDevice/createCommandEncoder()}} validation and
+                    algorithm steps.
+                </div>
+            1. Return |e|.
         </div>
 </dl>
 
@@ -6730,50 +6737,52 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 
             **Returns:** {{GPURenderPassEncoder}}
 
-            Issue the following steps on the [=Device timeline=] of |this|:
-            <div class=device-timeline>
-                1. Let |pass| be a new {{GPURenderPassEncoder}} object.
-                1. If any of the following conditions are unsatisfied, [$generate a validation error$]
-                    and stop.
-                    <div class=validusage>
-                        - |this|.{{GPUCommandsMixin/[[state]]}} is "[=encoder state/open=]".
-                        - |descriptor| meets the
-                            [$GPURenderPassDescriptor/Valid Usage$] rules.
-                        - |descriptor|.{{GPURenderPassDescriptor/timestampWrites}} is empty, or
-                            |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} [=list/contain=]s
-                            {{GPUFeatureName/"timestamp-query"}}.
-                        - For each |timestampWrite| in |descriptor|.{{GPURenderPassDescriptor/timestampWrites}},
-                            - |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}} is [$valid to use with$] |this|.
-                    </div>
-                1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/locked=]".
-                1. For each non-`null` |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
-                    1. The [=texture subresource=] seen by |colorAttachment|.{{GPURenderPassColorAttachment/view}}
-                        is considered to be used as [=internal usage/attachment=] for the
-                        duration of the render pass.
-                1. Let |depthStencilAttachment| be |descriptor|.{{GPURenderPassDescriptor/depthStencilAttachment}}.
-                1. If |depthStencilAttachment| is not `null`:
-                    1. Let |depthStencilView| be |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/view}}.
-                    1. If |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} and
-                        {{GPURenderPassDepthStencilAttachment/stencilReadOnly}} are `true`:
-                        1. The [=texture subresources=] seen by |depthStencilView|
-                            are considered to be used as [=internal usage/attachment-read=] for the duration of the render pass.
+            1. Let |pass| be a new {{GPURenderPassEncoder}} object.
+            1. Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
+                    1. If any of the following conditions are unsatisfied
+                        [$generate a validation error$], make |pass| [=invalid=], and stop.
+                        <div class=validusage>
+                            - |this|.{{GPUCommandsMixin/[[state]]}} is "[=encoder state/open=]".
+                            - |descriptor| meets the
+                                [$GPURenderPassDescriptor/Valid Usage$] rules.
+                            - |descriptor|.{{GPURenderPassDescriptor/timestampWrites}} is empty, or
+                                |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} [=list/contain=]s
+                                {{GPUFeatureName/"timestamp-query"}}.
+                            - For each |timestampWrite| in |descriptor|.{{GPURenderPassDescriptor/timestampWrites}},
+                                - |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}} is [$valid to use with$] |this|.
+                        </div>
 
-                            Issue: Describe this in terms of a "set of subresources of" algorithm.
-                    1. Else, the [=texture subresource=] seen by |depthStencilView|
-                        is considered to be used as [=internal usage/attachment=] for the duration of the render pass.
-                    1. Set |pass|.{{GPURenderCommandsMixin/[[depthReadOnly]]}} to |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}}.
-                    1. Set |pass|.{{GPURenderCommandsMixin/[[stencilReadOnly]]}} to |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}}.
-                1. Set |pass|.{{GPURenderCommandsMixin/[[layout]]}} to [$derive render targets layout from pass$](|descriptor|).
-                1. For each |timestampWrite| in |descriptor|.{{GPURenderPassDescriptor/timestampWrites}},
-                    1. If |timestampWrite|.{{GPURenderPassTimestampWrite/location}} is {{GPURenderPassTimestampLocation/"beginning"}},
-                        [=list/append=] a [=GPU command=] to |this|.{{GPUCommandsMixin/[[commands]]}}
-                        that writes the GPU's timestamp value into the |timestampWrite|.{{GPURenderPassTimestampWrite/queryIndex}}th
-                        index in |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}}.
-                    1. Otherwise, if |timestampWrite|.{{GPURenderPassTimestampWrite/location}} is {{GPURenderPassTimestampLocation/"end"}},
-                        [=list/Append=] |timestampWrite| to |pass|.{{GPURenderPassEncoder/[[endTimestampWrites]]}}.
-                1. Issue: Enqueue attachment loads/clears.
-                1. Return |pass|.
-            </div>
+                    1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/locked=]".
+                    1. For each non-`null` |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
+                        1. The [=texture subresource=] seen by |colorAttachment|.{{GPURenderPassColorAttachment/view}}
+                            is considered to be used as [=internal usage/attachment=] for the
+                            duration of the render pass.
+                    1. Let |depthStencilAttachment| be |descriptor|.{{GPURenderPassDescriptor/depthStencilAttachment}}.
+                    1. If |depthStencilAttachment| is not `null`:
+                        1. Let |depthStencilView| be |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/view}}.
+                        1. If |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} and
+                            {{GPURenderPassDepthStencilAttachment/stencilReadOnly}} are `true`:
+                            1. The [=texture subresources=] seen by |depthStencilView|
+                                are considered to be used as [=internal usage/attachment-read=] for the duration of the render pass.
+
+                                Issue: Describe this in terms of a "set of subresources of" algorithm.
+                        1. Else, the [=texture subresource=] seen by |depthStencilView|
+                            is considered to be used as [=internal usage/attachment=] for the duration of the render pass.
+                        1. Set |pass|.{{GPURenderCommandsMixin/[[depthReadOnly]]}} to |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}}.
+                        1. Set |pass|.{{GPURenderCommandsMixin/[[stencilReadOnly]]}} to |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}}.
+                    1. Set |pass|.{{GPURenderCommandsMixin/[[layout]]}} to [$derive render targets layout from pass$](|descriptor|).
+                    1. For each |timestampWrite| in |descriptor|.{{GPURenderPassDescriptor/timestampWrites}},
+                        1. If |timestampWrite|.{{GPURenderPassTimestampWrite/location}} is {{GPURenderPassTimestampLocation/"beginning"}},
+                            [=list/append=] a [=GPU command=] to |this|.{{GPUCommandsMixin/[[commands]]}}
+                            that writes the GPU's timestamp value into the |timestampWrite|.{{GPURenderPassTimestampWrite/queryIndex}}th
+                            index in |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}}.
+                        1. Otherwise, if |timestampWrite|.{{GPURenderPassTimestampWrite/location}} is {{GPURenderPassTimestampLocation/"end"}},
+                            [=list/Append=] |timestampWrite| to |pass|.{{GPURenderPassEncoder/[[endTimestampWrites]]}}.
+                    1. Issue: Enqueue attachment loads/clears.
+
+                </div>
+            1. Return |pass|.
 
             Issue: specify the behavior of read-only depth/stencil
         </div>
@@ -6792,30 +6801,31 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 
             **Returns:** {{GPUComputePassEncoder}}
 
-            Issue the following steps on the [=Device timeline=] of |this|:
-            <div class=device-timeline>
-                1. If any of the following conditions are unsatisfied, [$generate a validation error$]
-                    and stop.
-                    <div class=validusage>
-                        - |this|.{{GPUCommandsMixin/[[state]]}} is "[=encoder state/open=]".
-                        - |descriptor|.{{GPUComputePassDescriptor/timestampWrites}} is empty, or
-                            |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} [=list/contain=]s
-                            {{GPUFeatureName/"timestamp-query"}}.
-                        - For each |timestampWrite| in |descriptor|.{{GPUComputePassDescriptor/timestampWrites}},
-                            - |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}} is [$valid to use with$] |this|.
-                    </div>
-                1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/locked=]".
-                1. Let |pass| be a new {{GPUComputePassEncoder}} object.
-                1. For each |timestampWrite| in |descriptor|.{{GPUComputePassDescriptor/timestampWrites}},
-                    1. If |timestampWrite|.{{GPUComputePassTimestampWrite/location}} is {{GPUComputePassTimestampLocation/"beginning"}},
-                        [=list/append=] a [=GPU command=] to
-                        |this|.{{GPUCommandsMixin/[[commands]]}}
-                        that writes the GPU's timestamp value into the |timestampWrite|.{{GPUComputePassTimestampWrite/queryIndex}}th
-                        index in |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}}.
-                    1. Otherwise, if |timestampWrite|.{{GPUComputePassTimestampWrite/location}} is {{GPUComputePassTimestampLocation/"end"}},
-                        [=list/Append=] |timestampWrite| to |pass|.{{GPUComputePassEncoder/[[endTimestampWrites]]}}.
-                1. Return |pass|.
-            </div>
+            1. Let |pass| be a new {{GPUComputePassEncoder}} object.
+            1. Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
+                    1. If any of the following conditions are unsatisfied
+                        [$generate a validation error$], make |pass| [=invalid=], and stop.
+                        <div class=validusage>
+                            - |this|.{{GPUCommandsMixin/[[state]]}} is "[=encoder state/open=]".
+                            - |descriptor|.{{GPUComputePassDescriptor/timestampWrites}} is empty, or
+                                |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} [=list/contain=]s
+                                {{GPUFeatureName/"timestamp-query"}}.
+                            - For each |timestampWrite| in |descriptor|.{{GPUComputePassDescriptor/timestampWrites}},
+                                - |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}} is [$valid to use with$] |this|.
+                        </div>
+                    1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/locked=]".
+
+                    1. For each |timestampWrite| in |descriptor|.{{GPUComputePassDescriptor/timestampWrites}},
+                        1. If |timestampWrite|.{{GPUComputePassTimestampWrite/location}} is {{GPUComputePassTimestampLocation/"beginning"}},
+                            [=list/append=] a [=GPU command=] to
+                            |this|.{{GPUCommandsMixin/[[commands]]}}
+                            that writes the GPU's timestamp value into the |timestampWrite|.{{GPUComputePassTimestampWrite/queryIndex}}th
+                            index in |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}}.
+                        1. Otherwise, if |timestampWrite|.{{GPUComputePassTimestampWrite/location}} is {{GPUComputePassTimestampLocation/"end"}},
+                            [=list/Append=] |timestampWrite| to |pass|.{{GPUComputePassEncoder/[[endTimestampWrites]]}}.
+                </div>
+            1. Return |pass|.
         </div>
 </dl>
 
@@ -9302,32 +9312,34 @@ GPURenderBundleEncoder includes GPURenderCommandsMixin;
 
             **Returns:** {{GPURenderBundleEncoder}}
 
-            Issue the following steps on the [=Device timeline=] of |this|:
-            <div class=device-timeline>
-                1. If any of the following conditions are unsatisfied, [$generate a validation error$] and stop.
-                    <div class=validusage>
-                        - |descriptor|.{{GPURenderPassLayout/colorFormats}}.length must be less than or equal to
-                            |this|.{{device/[[limits]]}}.{{supported limits/maxColorAttachments}}.
-                        - If |descriptor|.{{GPURenderPassLayout/colorFormats}} only contains `null` members:
-                            - |descriptor|.{{GPURenderPassLayout/depthStencilFormat}} must not be `null`.
-                        - For each |colorFormat| in |descriptor|.{{GPURenderPassLayout/colorFormats}}:
-                            - |colorFormat| is `null`, or it must be a [=color renderable format=].
-                        - Let |depthStencilFormat| be |descriptor|.{{GPURenderPassLayout/depthStencilFormat}}.
-                        - If |depthStencilFormat| is not `null`:
-                            - |depthStencilFormat| must be a [=depth-or-stencil format=].
-                            - If |depthStencilFormat| is a [=combined depth-stencil format=]:
-                                - |descriptor|.{{GPURenderBundleEncoderDescriptor/depthReadOnly}} must be equal to
-                                    |descriptor|.{{GPURenderBundleEncoderDescriptor/stencilReadOnly}}
-                    </div>
-                1. Let |e| be a new {{GPURenderBundleEncoder}} object.
-                1. Set |e|.{{GPURenderCommandsMixin/[[layout]]}} to |descriptor|.{{GPURenderPassLayout}}.
-                1. Set |e|.{{GPURenderCommandsMixin/[[depthReadOnly]]}} to |descriptor|.{{GPURenderBundleEncoderDescriptor/depthReadOnly}}.
-                1. Set |e|.{{GPURenderCommandsMixin/[[stencilReadOnly]]}} to |descriptor|.{{GPURenderBundleEncoderDescriptor/stencilReadOnly}}.
-                1. Set |e|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/open=]".
-                1. Return |e|.
+            1. Let |e| be a new {{GPURenderBundleEncoder}} object.
+            1. Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
+                    1. If any of the following conditions are unsatisfied
+                        [$generate a validation error$], make |e| [=invalid=], and stop.
+                        <div class=validusage>
+                            - |this| is [=valid=].
+                            - |descriptor|.{{GPURenderPassLayout/colorFormats}}.length must be less than or equal to
+                                |this|.{{device/[[limits]]}}.{{supported limits/maxColorAttachments}}.
+                            - If |descriptor|.{{GPURenderPassLayout/colorFormats}} only contains `null` members:
+                                - |descriptor|.{{GPURenderPassLayout/depthStencilFormat}} must not be `null`.
+                            - For each |colorFormat| in |descriptor|.{{GPURenderPassLayout/colorFormats}}:
+                                - |colorFormat| is `null`, or it must be a [=color renderable format=].
+                            - Let |depthStencilFormat| be |descriptor|.{{GPURenderPassLayout/depthStencilFormat}}.
+                            - If |depthStencilFormat| is not `null`:
+                                - |depthStencilFormat| must be a [=depth-or-stencil format=].
+                                - If |depthStencilFormat| is a [=combined depth-stencil format=]:
+                                    - |descriptor|.{{GPURenderBundleEncoderDescriptor/depthReadOnly}} must be equal to
+                                        |descriptor|.{{GPURenderBundleEncoderDescriptor/stencilReadOnly}}
+                        </div>
+                    1. Set |e|.{{GPURenderCommandsMixin/[[layout]]}} to |descriptor|.{{GPURenderPassLayout}}.
+                    1. Set |e|.{{GPURenderCommandsMixin/[[depthReadOnly]]}} to |descriptor|.{{GPURenderBundleEncoderDescriptor/depthReadOnly}}.
+                    1. Set |e|.{{GPURenderCommandsMixin/[[stencilReadOnly]]}} to |descriptor|.{{GPURenderBundleEncoderDescriptor/stencilReadOnly}}.
+                    1. Set |e|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/open=]".
 
-                Issue: Describe the reset of the steps for {{GPUDevice/createRenderBundleEncoder()}}.
-            </div>
+                    Issue: Describe the reset of the steps for {{GPUDevice/createRenderBundleEncoder()}}.
+                </div>
+            1. Return |e|.
         </div>
 </dl>
 
@@ -9733,14 +9745,19 @@ dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
             1. If |descriptor|.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/"timestamp"}},
                 but |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} does not [=list/contain=]
                 {{GPUFeatureName/"timestamp-query"}}, throw a {{TypeError}}.
-            1. If any of the following requirements are unmet, return an error query set and stop.
-                <div class=validusage>
-                    - |this| must be a [=valid=] {{GPUDevice}}.
-                    - |descriptor|.{{GPUQuerySetDescriptor/count}} must be &le; 8192.
-                </div>
             1. Let |q| be a new {{GPUQuerySet}} object.
-            1. Set |q|.{{GPUQuerySet/[[descriptor]]}} to |descriptor|.
-            1. Set |q|.{{GPUQuerySet/[[state]]}} to [=query set state/available=].
+            1. Issue the following steps on the [=Device timeline=] of |this|:
+                <div class=device-timeline>
+                    1. If any of the following requirements are unmet, [$generate a validation error$],
+                        make |q| [=invalid=], and stop.
+                        <div class=validusage>
+                            - |this| is [=valid=].
+                            - |descriptor|.{{GPUQuerySetDescriptor/count}} must be &le; 8192.
+                        </div>
+                    1. Let |q| be a new {{GPUQuerySet}} object.
+                    1. Set |q|.{{GPUQuerySet/[[descriptor]]}} to |descriptor|.
+                    1. Set |q|.{{GPUQuerySet/[[state]]}} to [=query set state/available=].
+                </div>
             1. Return |q|.
         </div>
 </dl>


### PR DESCRIPTION
Several create or begin algorithms weren't clear about exactly what
should happen when validation errors occured, occasionally instructing
the algorithm to stop without returning anything.

This PR normalizes the various create/begin methods in the spec so that:
 - An object is always created and returned immediately on the content
   timeline.
 - Validation always happens on the device timeline.
 - Failed validation marks the previously returned object invalid.
 - The same language and structure is used for all of the creation
   methods for clarity. For example, the "make invalid and stop" step is
   now always shown prior to the validation steps, because otherwise
   they would frequently be pushed below a long list of steps and it
   could make it mroe difficult to follow the logic.

There's also a few misc cleanups scattered in here that I noticed while
making this change.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/2873.html" title="Last updated on May 11, 2022, 11:36 PM UTC (6db8cac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2873/c38e7a6...6db8cac.html" title="Last updated on May 11, 2022, 11:36 PM UTC (6db8cac)">Diff</a>