### PR TITLE
Address out-of-bounds sample index in textureLoad

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -11426,7 +11426,8 @@ An out of bounds access occurs if:
 * any element of `coords` is outside the range `[0, textureDimensions(t, level))`
     for the corresponding element, or
 * `array_index` is outside the range `[0, textureNumLayers(t))`, or
-* `level` is outside the range `[0, textureNumLevels(t))`
+* `level` is outside the range `[0, textureNumLevels(t))`, or
+* `sample_index` is outside the range `[0, textureNumSamples(s))`
 
 If an out of bounds access occurs, the built-in function returns one of:
 * The data for some texel within bounds of the texture


### PR DESCRIPTION
Fixes #2879

* Add a bullet that sample_index must be in the correct range