### PR TITLE
Remove multisampled text from textureNumLayers

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -11451,7 +11451,7 @@ fn textureNumLayers(t: texture_storage_2d_array<F,A>) -> u32
 <table class='data'>
   <tr><td>`t`<td>
   The [sampled](#sampled-texture-type),
-  [multisampled](#multisampled-texture-type), [depth](#texture-depth) or
+  [depth](#texture-depth) or
   [storage](#texture-storage) array texture.
 </table>
 


### PR DESCRIPTION
Fixes #2881

* There are no multisampled array textures in WGSL