### PR TITLE
Clarify flat interpoation requirements

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7667,7 +7667,8 @@ For user-defined IO of scalar or vector floating-point type:
          * Any interpolation sampling is valid.
          * If interpolation sampling is not specified, `center` is assumed.
 
-User-defined IO of scalar or vector integer type [=shader-creation error|must=] always be specified as
+User-defined [=vertex=] outputs and [=fragment=] inputs of scalar or vector
+integer type [=shader-creation error|must=] always be specified as
 `@interpolate(flat)`.
 
 Interpolation attributes [=shader-creation error|must=] match between [=vertex=] outputs and [=fragment=]


### PR DESCRIPTION
Fixes #2760

* Clarify flat interpolate attribute is only required on vertex outputs
  and fragment inputs of integral type