### PR TITLE
Throw when using formats without required feature

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2937,9 +2937,9 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
 
             **Returns:** {{GPUTexture}}
 
-            1. [$Validate feature texture format usage$] of
+            1. [$Validate texture format required features$] of
                 |descriptor|.{{GPUTextureDescriptor/format}} with |this|.{{GPUObjectBase/[[device]]}}.
-            1. [$Validate feature texture format usage$] of each element of
+            1. [$Validate texture format required features$] of each element of
                 |descriptor|.{{GPUTextureDescriptor/viewFormats}} with |this|.{{GPUObjectBase/[[device]]}}.
             1. Let |t| be a new {{GPUTexture}} object.
             1. Issue the following steps on the [=Device timeline=] of |this|:
@@ -3267,7 +3267,7 @@ enum GPUTextureAspect {
 
             **Returns:** |view|, of type {{GPUTextureView}}.
 
-            1. [$Validate feature texture format usage$] of
+            1. [$Validate texture format required features$] of
                 |descriptor|.{{GPUTextureViewDescriptor/format}} with |this|.{{GPUObjectBase/[[device]]}}.
             1. Let |view| be a new {{GPUTextureView}} object.
             1. Issue the following steps on the [=Device timeline=] of |this|:
@@ -3637,17 +3637,17 @@ All [=depth-or-stencil formats=] are renderable.
     1. Return `null`.
 </div>
 
-Use of some texture formats require a feature to be enabled on the {{GPUDevice}}. Because support
-for these formats may not be implemented on all systems, the associated enums may not be present.
-In order to normalize behavior across implementations attempting to use a format that requires a
-feature when the associated feature is not enabled on the device will throw an exception, making the
-behavior the same as if an undefined enum was used.
+Use of some texture formats require a feature to be enabled on the {{GPUDevice}}. Because new
+formats can be added to the specification, those enum values may not be known by the implementation.
+In order to normalize behavior across implementations, attempting to use a format that requires a
+feature will throw an exception if the associated feature is not enabled on the device. This makes
+the behavior the same as when the format is unknown to the implementation.
 
 See [[#texture-format-caps]] for information about which {{GPUTextureFormat}}s require features.
 
 <div algorithm>
-    <dfn abstract-op>Validate feature texture format usage</dfn> of a {{GPUTextureFormat}} |format|
-    with logical [=device=] |device| by running the following steps:
+    <dfn abstract-op>Validate texture format required features</dfn> of a {{GPUTextureFormat}}
+    |format| with logical [=device=] |device| by running the following steps:
 
     1. If |format| requires a feature and |device|.{{device/[[features]]}} does not [=list/contain=]
         the feature:
@@ -4553,9 +4553,9 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
 
             1. For each {{GPUBindGroupLayoutEntry}} |entry| in |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
                 1. If |entry|.{{GPUBindGroupLayoutEntry/storageTexture}} is not `undefined`:
-                    1. [$Validate feature texture format usage$] for
+                    1. [$Validate texture format required features$] for
                         |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/format}}
-                        with |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}}.
+                        with |this|.{{GPUObjectBase/[[device]]}}.
             1. Let |layout| be a new {{GPUBindGroupLayout}} object.
             1. Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
@@ -5965,10 +5965,10 @@ details.
             1. If |descriptor|.{{GPURenderPipelineDescriptor/fragment}} is not `undefined`:
                 1. For each non-`null` |colorState| layout descriptor in the list
                     |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.{{GPUFragmentState/targets}}:
-                    1. [$Validate feature texture format usage$] of
+                    1. [$Validate texture format required features$] of
                         |colorState|.{{GPUColorTargetState/format}} with |this|.{{GPUObjectBase/[[device]]}}.
             1. If |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}} is not `null`:
-                1. [$Validate feature texture format usage$] of
+                1. [$Validate texture format required features$] of
                     |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}.{{GPUDepthStencilState/format}}
                     with |this|.{{GPUObjectBase/[[device]]}}.
             1. Let |pipeline| be a new {{GPURenderPipeline}} object.
@@ -9790,9 +9790,9 @@ GPURenderBundleEncoder includes GPURenderCommandsMixin;
 
             **Returns:** {{GPURenderBundleEncoder}}
 
-            1. [$Validate feature texture format usage$] of each element of
+            1. [$Validate texture format required features$] of each element of
                 |descriptor|.{{GPURenderPassLayout/colorFormats}} with |this|.{{GPUObjectBase/[[device]]}}.
-            1. [$Validate feature texture format usage$] of
+            1. [$Validate texture format required features$] of
                 |descriptor|.{{GPURenderPassLayout/depthStencilFormat}} with |this|.{{GPUObjectBase/[[device]]}}.
             1. Let |e| be a new {{GPURenderBundleEncoder}} object.
             1. Issue the following steps on the [=Device timeline=] of |this|:
@@ -10394,9 +10394,9 @@ interface GPUCanvasContext {
             **Returns:** undefined
 
             1. Let |device| be |configuration|.{{GPUCanvasConfiguration/device}}.
-            1. [$Validate feature texture format usage$] of
+            1. [$Validate texture format required features$] of
                 |configuration|.{{GPUCanvasConfiguration/format}} with |device|.{{GPUObjectBase/[[device]]}}.
-            1. [$Validate feature texture format usage$] of each element of
+            1. [$Validate texture format required features$] of each element of
                 |configuration|.{{GPUTextureDescriptor/viewFormats}} with |device|.{{GPUObjectBase/[[device]]}}.
             1. [$Invalidate the current texture$] of |this|.
             1. Set |this|.{{GPUCanvasContext/[[validConfiguration]]}} to `false`.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2937,9 +2937,10 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
 
             **Returns:** {{GPUTexture}}
 
-            1. If |descriptor|.{{GPUTextureDescriptor/format}} is a {{GPUTextureFormat}} that requires a feature (see
-                [[#texture-format-caps]]), but |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} does not
-                [=list/contain=] the feature, throw a {{TypeError}}.
+            1. [$Validate feature texture format usage$] of
+                |descriptor|.{{GPUTextureDescriptor/format}} with |this|.{{GPUObjectBase/[[device]]}}.
+            1. [$Validate feature texture format usage$] of each element of
+                |descriptor|.{{GPUTextureDescriptor/viewFormats}} with |this|.{{GPUObjectBase/[[device]]}}.
             1. Let |t| be a new {{GPUTexture}} object.
             1. Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
@@ -3266,6 +3267,8 @@ enum GPUTextureAspect {
 
             **Returns:** |view|, of type {{GPUTextureView}}.
 
+            1. [$Validate feature texture format usage$] of
+                |descriptor|.{{GPUTextureViewDescriptor/format}} with |this|.{{GPUObjectBase/[[device]]}}.
             1. Let |view| be a new {{GPUTextureView}} object.
             1. Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
@@ -3632,6 +3635,23 @@ All [=depth-or-stencil formats=] are renderable.
                     the aspect is not present in |format|.
         </dl>
     1. Return `null`.
+</div>
+
+Use of some texture formats require a feature to be enabled on the {{GPUDevice}}. Because support
+for these formats may not be implemented on all systems, the associated enums may not be present.
+In order to normalize behavior across implementations attempting to use a format that requires a
+feature when the associated feature is not enabled on the device will throw an exception, making the
+behavior the same as if an undefined enum was used.
+
+See [[#texture-format-caps]] for information about which {{GPUTextureFormat}}s require features.
+
+<div algorithm>
+    <dfn abstract-op>Validate feature texture format usage</dfn> of a {{GPUTextureFormat}} |format|
+    with logical [=device=] |device| by running the following steps:
+
+    1. If |format| requires a feature and |device|.{{device/[[features]]}} does not [=list/contain=]
+        the feature:
+        1. Throw a {{TypeError}}.
 </div>
 
 ## <dfn interface>GPUExternalTexture</dfn> ## {#gpu-external-texture}
@@ -4531,6 +4551,11 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
 
             **Returns:** {{GPUBindGroupLayout}}
 
+            1. For each {{GPUBindGroupLayoutEntry}} |entry| in |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
+                1. If |entry|.{{GPUBindGroupLayoutEntry/storageTexture}} is not `undefined`:
+                    1. [$Validate feature texture format usage$] for
+                        |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/format}}
+                        with |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}}.
             1. Let |layout| be a new {{GPUBindGroupLayout}} object.
             1. Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
@@ -5937,6 +5962,15 @@ details.
 
             **Returns:** {{GPURenderPipeline}}
 
+            1. If |descriptor|.{{GPURenderPipelineDescriptor/fragment}} is not `undefined`:
+                1. For each non-`null` |colorState| layout descriptor in the list
+                    |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.{{GPUFragmentState/targets}}:
+                    1. [$Validate feature texture format usage$] of
+                        |colorState|.{{GPUColorTargetState/format}} with |this|.{{GPUObjectBase/[[device]]}}.
+            1. If |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}} is not `null`:
+                1. [$Validate feature texture format usage$] of
+                    |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}.{{GPUDepthStencilState/format}}
+                    with |this|.{{GPUObjectBase/[[device]]}}.
             1. Let |pipeline| be a new {{GPURenderPipeline}} object.
             1. Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
@@ -9756,6 +9790,10 @@ GPURenderBundleEncoder includes GPURenderCommandsMixin;
 
             **Returns:** {{GPURenderBundleEncoder}}
 
+            1. [$Validate feature texture format usage$] of each element of
+                |descriptor|.{{GPURenderPassLayout/colorFormats}} with |this|.{{GPUObjectBase/[[device]]}}.
+            1. [$Validate feature texture format usage$] of
+                |descriptor|.{{GPURenderPassLayout/depthStencilFormat}} with |this|.{{GPUObjectBase/[[device]]}}.
             1. Let |e| be a new {{GPURenderBundleEncoder}} object.
             1. Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
@@ -10355,10 +10393,14 @@ interface GPUCanvasContext {
 
             **Returns:** undefined
 
+            1. Let |device| be |configuration|.{{GPUCanvasConfiguration/device}}.
+            1. [$Validate feature texture format usage$] of
+                |configuration|.{{GPUCanvasConfiguration/format}} with |device|.{{GPUObjectBase/[[device]]}}.
+            1. [$Validate feature texture format usage$] of each element of
+                |configuration|.{{GPUTextureDescriptor/viewFormats}} with |device|.{{GPUObjectBase/[[device]]}}.
             1. [$Invalidate the current texture$] of |this|.
             1. Set |this|.{{GPUCanvasContext/[[validConfiguration]]}} to `false`.
             1. Set |this|.{{GPUCanvasContext/[[configuration]]}} to |configuration|.
-            1. Let |device| be |configuration|.{{GPUCanvasConfiguration/device}}.
             1. Let |canvas| be |this|.{{GPUCanvasContext/canvas}}.
             1. If |configuration|.{{GPUCanvasConfiguration/size}} is `undefined` set
                 |this|.{{GPUCanvasContext/[[size]]}} to [|canvas|.width, |canvas|.height, 1],


### PR DESCRIPTION
As pointed out in https://github.com/gpuweb/gpuweb/pull/2873#discussion_r870969925

Adds algorithm steps to every method in the spec that accepts a
`GPUTextureFormat` causing them to throw a TypeError if the format
requires a feature which isn't enabled on the device. This is to
normalize behavior with implementations that don't implement the feature
at all, and will throw a type error at the IDL level.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/2887.html" title="Last updated on May 13, 2022, 10:14 PM UTC (02ccf5d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2887/e02dbb7...02ccf5d.html" title="Last updated on May 13, 2022, 10:14 PM UTC (02ccf5d)">Diff</a>