### PR TITLE
Typo L10578 fixed

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -10575,7 +10575,7 @@ struct __frexp_result {
   exp : i32  // exponent part
 }
     ```
-    The magnitude of the significand is in the range of [0.5, 1.0) or 0.
+    The magnitude of the significand is in the range of [0.5, 1.0] or 0.
 
     Note: A value cannot be explicitly declared with the type `__frexp_result`, but a value may infer the type.
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -10575,7 +10575,7 @@ struct __frexp_result {
   exp : i32  // exponent part
 }
     ```
-    The magnitude of the significand is in the range of [0.5, 1.0] or 0.
+    The magnitude of the significand is in the range of [0.5, 1.0) or 0.
 
     Note: A value cannot be explicitly declared with the type `__frexp_result`, but a value may infer the type.
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -10599,7 +10599,7 @@ struct __frexp_result_f16 {
   exp : i32  // exponent part
 }
     ```
-    The magnitude of the significand is in the range of [0.5, 1.0) or 0.
+    The magnitude of the significand is in the range of [0.5, 1.0] or 0.
 
     Note: A value cannot be explicitly declared with the type `__frexp_result_f16`, but a value may infer the type.
 
@@ -10614,7 +10614,7 @@ struct __frexp_result_vecN {
   exp : vecN<i32>  // exponent part
 }
     ```
-    The magnitude of each component of the significand is in the range of [0.5, 1.0) or 0.
+    The magnitude of each component of the significand is in the range of [0.5, 1.0] or 0.
 
     Note: A value cannot be explicitly declared with the type `__frexp_result_vec`|N|, but a value may infer the type.
 
@@ -10629,7 +10629,7 @@ struct __frexp_result_vecN_f16 {
   exp : vecN<i32>  // exponent part
 }
     ```
-    The magnitude of each component of the significand is in the range of [0.5, 1.0) or 0.
+    The magnitude of each component of the significand is in the range of [0.5, 1.0] or 0.
 
     Note: A value cannot be explicitly declared with the type `__frexp_result_vec`|N|`_f16`, but a value may infer the type.
 


### PR DESCRIPTION
I found the typo while reading the docs on line 10578.