### PR TITLE
Add definitions for bind group descriptors

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4261,7 +4261,7 @@ dictionary GPUBindGroupLayoutEntry {
     : <dfn>binding</dfn>
     ::
         A unique identifier for a resource binding within the {{GPUBindGroupLayout}}, corresponding
-        to a {{GPUBindGroupLayoutEntry/binding|GPUBindGroupLayoutEntry.binding}} and a [=@binding=]
+        to a {{GPUBindGroupEntry/binding|GPUBindGroupEntry.binding}} and a [=@binding=]
         attribute in the {{GPUShaderModule}}.
 
     : <dfn>visibility</dfn>
@@ -4699,15 +4699,15 @@ GPUBindGroup includes GPUObjectBase;
 A {{GPUBindGroup}} object has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUBindGroup">
-    : <dfn>\[[layout]]</dfn> of type {{GPUBindGroupLayout}}.
+    : <dfn>\[[layout]]</dfn>, of type {{GPUBindGroupLayout}}, readonly
     ::
         The {{GPUBindGroupLayout}} associated with this {{GPUBindGroup}}.
 
-    : <dfn>\[[entries]]</dfn> of type sequence<{{GPUBindGroupEntry}}>.
+    : <dfn>\[[entries]]</dfn>, of type sequence&lt;{{GPUBindGroupEntry}}&gt;, readonly
     ::
         The set of {{GPUBindGroupEntry}}s this {{GPUBindGroup}} describes.
 
-    : <dfn>\[[usedResources]]</dfn> of type [=ordered map=]&lt;[=subresource=], [=list=]&lt;[=internal usage=]&gt;&gt;.
+    : <dfn>\[[usedResources]]</dfn>, of type [=ordered map=]&lt;[=subresource=], [=list=]&lt;[=internal usage=]&gt;&gt;, readonly
     ::
         The set of buffer and texture [=subresource=]s used by this bind group,
         associated with lists of the [=internal usage=] flags.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -97,6 +97,8 @@ spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
         text: WGSL floating point conversion; url: floating-point-conversion
         text: WGSL identifier comparison; url: identifier-comparison
         text: WGSL scalar type; url: scalar-types
+        text: @binding; url: attribute-binding
+        text: @group; url: attribute-group
 </pre>
 
 <style>
@@ -4258,9 +4260,9 @@ dictionary GPUBindGroupLayoutEntry {
 <dl dfn-type=dict-member dfn-for=GPUBindGroupLayoutEntry>
     : <dfn>binding</dfn>
     ::
-        A unique identifier for a resource binding within a
-        {{GPUBindGroupLayoutEntry}}, a corresponding {{GPUBindGroupEntry}},
-        and the {{GPUShaderModule}}s.
+        A unique identifier for a resource binding within the {{GPUBindGroupLayout}}, corresponding
+        to a {{GPUBindGroupLayoutEntry/binding|GPUBindGroupLayoutEntry.binding}} and a [=@binding=]
+        attribute in the {{GPUShaderModule}}.
 
     : <dfn>visibility</dfn>
     ::
@@ -4694,39 +4696,6 @@ interface GPUBindGroup {
 GPUBindGroup includes GPUObjectBase;
 </script>
 
-### Bind Group Creation ### {#bind-group-creation}
-
-A {{GPUBindGroup}} is created via {{GPUDevice/createBindGroup()|GPUDevice.createBindGroup()}}.
-
-<script type=idl>
-dictionary GPUBindGroupDescriptor : GPUObjectDescriptorBase {
-    required GPUBindGroupLayout layout;
-    required sequence<GPUBindGroupEntry> entries;
-};
-</script>
-
-A {{GPUBindGroupEntry}} describes a single resource to be bound in a {{GPUBindGroup}}.
-
-<script type=idl>
-typedef (GPUSampler or GPUTextureView or GPUBufferBinding or GPUExternalTexture) GPUBindingResource;
-
-dictionary GPUBindGroupEntry {
-    required GPUIndex32 binding;
-    required GPUBindingResource resource;
-};
-</script>
-
-<script type=idl>
-dictionary GPUBufferBinding {
-    required GPUBuffer buffer;
-    GPUSize64 offset = 0;
-    GPUSize64 size;
-};
-</script>
-
-  * {{GPUBufferBinding/size}}: If undefined, specifies the range starting at
-      {{GPUBufferBinding/offset}} and ending at the end of the buffer.
-
 A {{GPUBindGroup}} object has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUBindGroup">
@@ -4742,6 +4711,82 @@ A {{GPUBindGroup}} object has the following internal slots:
     ::
         The set of buffer and texture [=subresource=]s used by this bind group,
         associated with lists of the [=internal usage=] flags.
+</dl>
+
+### Bind Group Creation ### {#bind-group-creation}
+
+A {{GPUBindGroup}} is created via {{GPUDevice/createBindGroup()|GPUDevice.createBindGroup()}}.
+
+<script type=idl>
+dictionary GPUBindGroupDescriptor : GPUObjectDescriptorBase {
+    required GPUBindGroupLayout layout;
+    required sequence<GPUBindGroupEntry> entries;
+};
+</script>
+
+{{GPUBindGroupDescriptor}} dictionaries have the following members:
+
+<dl dfn-type=dict-member dfn-for=GPUBindGroupDescriptor>
+    : <dfn>layout</dfn>
+    ::
+        The {{GPUBindGroupLayout}} the entries of this bind group will conform to.
+
+    : <dfn>entries</dfn>
+    ::
+        A list of entries describing the resources to expose to the shader for each binding
+        described by the {{GPUBindGroupDescriptor/layout}}.
+</dl>
+
+<script type=idl>
+typedef (GPUSampler or GPUTextureView or GPUBufferBinding or GPUExternalTexture) GPUBindingResource;
+
+dictionary GPUBindGroupEntry {
+    required GPUIndex32 binding;
+    required GPUBindingResource resource;
+};
+</script>
+
+A {{GPUBindGroupEntry}} describes a single resource to be bound in a {{GPUBindGroup}}, and has the
+following members:
+
+<dl dfn-type=dict-member dfn-for=GPUBindGroupEntry>
+    : <dfn>binding</dfn>
+    ::
+        A unique identifier for a resource binding within the {{GPUBindGroup}}, corresponding to a
+        {{GPUBindGroupLayoutEntry/binding|GPUBindGroupLayoutEntry.binding}} and a [=@binding=]
+        attribute in the {{GPUShaderModule}}.
+
+    : <dfn>resource</dfn>
+    ::
+        The resource to bind, which may be a {{GPUSampler}}, {{GPUTextureView}},
+        {{GPUExternalTexture}}, or {{GPUBufferBinding}}.
+</dl>
+
+<script type=idl>
+dictionary GPUBufferBinding {
+    required GPUBuffer buffer;
+    GPUSize64 offset = 0;
+    GPUSize64 size;
+};
+</script>
+
+A {{GPUBufferBinding}} describes a buffer and optional range to bind as a resource, and has the
+following members:
+
+<dl dfn-type=dict-member dfn-for=GPUBufferBinding>
+    : <dfn>buffer</dfn>
+    ::
+        The {{GPUBuffer}} to bind.
+
+    : <dfn>offset</dfn>
+    ::
+        The offset, in bytes, from the beginning of {{GPUBufferBinding/buffer}} to the
+        beginning of the range exposed to the shader by the buffer binding.
+
+    : <dfn>size</dfn>
+    ::
+        The size, in bytes, of the buffer binding. If `undefined`, specifies the range starting at
+        {{GPUBufferBinding/offset}} and ending at the end of {{GPUBufferBinding/buffer}}.
 </dl>
 
 <dl dfn-type=method dfn-for=GPUDevice>
@@ -4951,6 +4996,17 @@ dictionary GPUPipelineLayoutDescriptor : GPUObjectDescriptorBase {
     required sequence<GPUBindGroupLayout> bindGroupLayouts;
 };
 </script>
+
+{{GPUPipelineLayoutDescriptor}} dictionaries define all the {{GPUBindGroupLayout}}s used by a
+pipeline, and have the following members:
+
+<dl dfn-type=dict-member dfn-for=GPUPipelineLayoutDescriptor>
+    : <dfn>bindGroupLayouts</dfn>
+    ::
+        A list of {{GPUBindGroupLayout}}s the pipline will use. Each element corresponds to a
+        [=@group=] attribute in the {{GPUShaderModule}}, with the `N`th element corresponding with
+        `@group(N)`.
+</dl>
 
 <dl dfn-type=method dfn-for=GPUDevice>
     : <dfn>createPipelineLayout(descriptor)</dfn>


### PR DESCRIPTION
Part of #2815

Adds or improves descriptions for the following dictionaries:

 - GPUBindGroupLayoutEntry
 - GPUBindGroupDescriptor
 - GPUBindGroupEntry
 - GPUBufferBinding
 - GPUPipelineLayoutDescriptor


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 17, 2022, 4:03 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fgpuweb%2Fgpuweb%2F16044841002bf5e86ba09da1ca59c58efb0d7f21%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%232893.)._
</details>
