### PR TITLE
Minor atomic method editorial changes.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -11870,12 +11870,12 @@ Atomic built-in functions [=shader-creation error|must not=] be used in a [=vert
 The address space `SC` of the `atomic_ptr` parameter in all atomic built-in
 functions [=shader-creation error|must=] be either [=address spaces/storage=] or [=address spaces/workgroup=].
 
-The access mode `A` in all atomic built-in functions [=shader-creation error|must=] be [=access/read_write=].
+|T| [=shader-creation error|must=] be either [=u32=] or [=i32=]
 
 ### Atomic Load ### {#atomic-load}
 
 ```rust
-fn atomicLoad(atomic_ptr: ptr<SC, atomic<T>, A>) -> T
+fn atomicLoad(atomic_ptr: ptr<SC, atomic<T>, read_write>) -> T
 ```
 
 Returns the atomically loaded the value pointed to by `atomic_ptr`.
@@ -11884,7 +11884,7 @@ It does not [=atomic modification|modify=] the object.
 ### Atomic Store ### {#atomic-store}
 
 ```rust
-fn atomicStore(atomic_ptr: ptr<SC, atomic<T>, A>, v: T)
+fn atomicStore(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T)
 ```
 
 Atomically stores the value `v` in the atomic object pointed to by `atomic_ptr`.
@@ -11892,13 +11892,13 @@ Atomically stores the value `v` in the atomic object pointed to by `atomic_ptr`.
 ### Atomic Read-modify-write ### {#atomic-rmw}
 
 ```rust
-fn atomicAdd(atomic_ptr: ptr<SC, atomic<T>, A>, v: T) -> T
-fn atomicSub(atomic_ptr: ptr<SC, atomic<T>, A>, v: T) -> T
-fn atomicMax(atomic_ptr: ptr<SC, atomic<T>, A>, v: T) -> T
-fn atomicMin(atomic_ptr: ptr<SC, atomic<T>, A>, v: T) -> T
-fn atomicAnd(atomic_ptr: ptr<SC, atomic<T>, A>, v: T) -> T
-fn atomicOr(atomic_ptr: ptr<SC, atomic<T>, A>, v: T) -> T
-fn atomicXor(atomic_ptr: ptr<SC, atomic<T>, A>, v: T) -> T
+fn atomicAdd(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T) -> T
+fn atomicSub(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T) -> T
+fn atomicMax(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T) -> T
+fn atomicMin(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T) -> T
+fn atomicAnd(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T) -> T
+fn atomicOr(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T) -> T
+fn atomicXor(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T) -> T
 ```
 Each function performs the following steps atomically:
 
@@ -11910,14 +11910,14 @@ Each function performs the following steps atomically:
 Each function returns the original value stored in the atomic object.
 
 ```rust
-fn atomicExchange(atomic_ptr: ptr<SC, atomic<T>, A>, v: T) -> T
+fn atomicExchange(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T) -> T
 ```
 
 Atomically stores the value `v` in the atomic object pointed to
 `atomic_ptr` and returns the original value stored in the atomic object.
 
 ```rust
-fn atomicCompareExchangeWeak(atomic_ptr: ptr<SC, atomic<T>, A>, cmp: T, v: T) -> __atomic_compare_exchange_result<T>
+fn atomicCompareExchangeWeak(atomic_ptr: ptr<SC, atomic<T>, read_write>, cmp: T, v: T) -> __atomic_compare_exchange_result<T>
 
 struct __atomic_compare_exchange_result<T> {
   old_value : T; // old value stored in the atomic


### PR DESCRIPTION
This PR inlines the `A` variable as it is always `read_write` directly into
the function definitions.

The `T` definition is copied from the `Atomic Types` section to make it
easier to find when reading the builtins.