### PR TITLE
Clairfy attribute numeric params

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -760,7 +760,7 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
   </thead>
 
   <tr><td><dfn noexport dfn-for="attribute">`align`</dfn>
-    <td>[=integer literal=], yielding positive i32
+    <td>[=integer literal=], yielding a positive i32
     <td>[=shader-creation error|Must=] only be applied to a member of a [=structure=] type.
 
     [=shader-creation error|Must=] be a power of 2, and [=shader-creation error|must=] satisfy the required-alignment for the member type:
@@ -777,7 +777,7 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     See [[#memory-layouts]]
 
   <tr><td><dfn noexport dfn-for="attribute">`binding`
-    <td>[=integer literal=], yielding non-negative i32
+    <td>[=integer literal=], yielding a non-negative i32
     <td>[=shader-creation error|Must=] only be applied to a [=resource=] variable.
 
     Specifies the binding number of the resource in a bind [=attribute/group=].
@@ -803,14 +803,14 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     built-in functions can be used in [=creation-time expressions=].
 
   <tr><td><dfn noexport dfn-for="attribute">`group`
-    <td>[=integer literal=], yielding non-negative i32
+    <td>[=integer literal=], yielding a non-negative i32
     <td>[=shader-creation error|Must=] only be applied to a [=resource=] variable.
 
     Specifies the binding group of the resource.
     See [[#resource-interface]].
 
   <tr><td><dfn noexport dfn-for="attribute">`id`
-    <td>[=integer literal=], yielding non-negative i32
+    <td>[=integer literal=], yielding a non-negative i32
     <td>[=shader-creation error|Must=] only be applied to an [=override declaration=] of [=scalar=] type.
 
     Specifies a numeric identifier as an alternate name for a
@@ -845,7 +845,7 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     `invariant` qualifier in GLSL.
 
   <tr><td><dfn noexport dfn-for="attribute">`location`
-    <td>[=integer literal=], yielding non-negative i32
+    <td>[=integer literal=], yielding a non-negative i32
     <td>[=shader-creation error|Must=] only be applied to an entry point function parameter, entry point
     return type, or member of a [=structure=] type.
     [=shader-creation error|Must=] only be applied to declarations of [=numeric scalar=] or [=numeric
@@ -856,7 +856,7 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     See [[#input-output-locations]].
 
   <tr><td><dfn noexport dfn-for="attribute">`size`</dfn>
-    <td>[=integer literal=], yielding positive i32
+    <td>[=integer literal=], yielding a positive i32
     <td>[=shader-creation error|Must=] only be applied to a member of a [=structure=] type.
 
     The number of bytes reserved in the struct for this member.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -760,7 +760,7 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
   </thead>
 
   <tr><td><dfn noexport dfn-for="attribute">`align`</dfn>
-    <td>positive i32 literal
+    <td>[=integer literal=], yielding positive i32
     <td>[=shader-creation error|Must=] only be applied to a member of a [=structure=] type.
 
     [=shader-creation error|Must=] be a power of 2, and [=shader-creation error|must=] satisfy the required-alignment for the member type:
@@ -777,7 +777,7 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     See [[#memory-layouts]]
 
   <tr><td><dfn noexport dfn-for="attribute">`binding`
-    <td>non-negative i32 literal
+    <td>[=integer literal=], yielding non-negative i32
     <td>[=shader-creation error|Must=] only be applied to a [=resource=] variable.
 
     Specifies the binding number of the resource in a bind [=attribute/group=].
@@ -803,14 +803,14 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     built-in functions can be used in [=creation-time expressions=].
 
   <tr><td><dfn noexport dfn-for="attribute">`group`
-    <td>non-negative i32 literal
+    <td>[=integer literal=], yielding non-negative i32
     <td>[=shader-creation error|Must=] only be applied to a [=resource=] variable.
 
     Specifies the binding group of the resource.
     See [[#resource-interface]].
 
   <tr><td><dfn noexport dfn-for="attribute">`id`
-    <td>non-negative i32 literal
+    <td>[=integer literal=], yielding non-negative i32
     <td>[=shader-creation error|Must=] only be applied to an [=override declaration=] of [=scalar=] type.
 
     Specifies a numeric identifier as an alternate name for a
@@ -845,7 +845,7 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     `invariant` qualifier in GLSL.
 
   <tr><td><dfn noexport dfn-for="attribute">`location`
-    <td>non-negative i32 literal
+    <td>[=integer literal=], yielding non-negative i32
     <td>[=shader-creation error|Must=] only be applied to an entry point function parameter, entry point
     return type, or member of a [=structure=] type.
     [=shader-creation error|Must=] only be applied to declarations of [=numeric scalar=] or [=numeric
@@ -856,7 +856,7 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     See [[#input-output-locations]].
 
   <tr><td><dfn noexport dfn-for="attribute">`size`</dfn>
-    <td>positive i32 literal
+    <td>[=integer literal=], yielding positive i32
     <td>[=shader-creation error|Must=] only be applied to a member of a [=structure=] type.
 
     The number of bytes reserved in the struct for this member.


### PR DESCRIPTION
Change "positive i32 literal" to "integer literal, yielding positive i32"
Similar for non-negative

Fixes: #2809