### PR TITLE
Clarify some error types

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4814,9 +4814,11 @@ The convenience names are accessed using the `.` notation. (e.g. `color.bgra`).
 
 NOTE: the convenience letterings can not be mixed. (i.e. you can not use `rybw`).
 
-Using a convenience letter, or array subscript, which accesses a component past the end of the vector is an error.
+A convenience letter [=shader-creation error|must not=] access a component past the end of the vector.
 
-The convenience letterings can be applied in any order, including duplicating letters as needed. You can provide 1 to 4 letters when extracting components from a vector. Providing more then 4 letters is an error.
+The convenience letterings can be applied in any order, including duplicating letters as needed.
+The provided number of letters [=shader-creation error|must=] be less than or equal to the number of components of the source vector.
+That is, using convenience letters can only produce a vector of smaller or equal size to the source vector.
 
 The result type depends on the number of letters provided. Assuming a `vec4<f32>`
 <table>
@@ -10385,9 +10387,9 @@ Each [=overload=] is described below via:
 * The built-in function name, a parenthesized list of [=formal parameters=], and optionally a [=return type=].
 * The behaviour of this overload of the function.
 
-Since a built-in function is always in scope, it is an error to attempt to redefine
-one or to use the name of a built-in function as an [=identifier=] for any other
-[=module scope|module-scope=] declaration.
+Since a built-in function is always in scope, it is a [=shader-creation error=]
+to attempt to redefine one or to use the name of a built-in function as an
+[=identifier=] for any other [=module scope|module-scope=] declaration.
 
 When calling a built-in function, all arguments to the function are evaluated
 before function evaluation begins.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4817,8 +4817,8 @@ NOTE: the convenience letterings can not be mixed. (i.e. you can not use `rybw`)
 A convenience letter [=shader-creation error|must not=] access a component past the end of the vector.
 
 The convenience letterings can be applied in any order, including duplicating letters as needed.
-The provided number of letters [=shader-creation error|must=] be less than or equal to the number of components of the source vector.
-That is, using convenience letters can only produce a vector of smaller or equal size to the source vector.
+The provided number of letters [=shader-creation error|must=] be between 1 and 4.
+That is, using convenience letters can only produce a valid vector type.
 
 The result type depends on the number of letters provided. Assuming a `vec4<f32>`
 <table>


### PR DESCRIPTION
Fixes #2730

* For vector accesses, it is a shader-creation error if there are more
  letters than the ordinality of the vector
* For vector accesses, it is a shader-creation error if the letter
  access is out-of-bounds
* Remove statement about error for array indexing out-of-bounds in
  vector accesses
* Clarify it is a shader-creation error to reuse a built-in function
  identifier at module scope