### PR TITLE
Update constructors in GPUError IDL

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -11161,16 +11161,17 @@ enum GPUErrorFilter {
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUError {
-    constructor(DOMString message);
     readonly attribute DOMString message;
 };
 
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUOutOfMemoryError : GPUError {
+    constructor(DOMString message);
 };
 
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUValidationError : GPUError {
+    constructor(DOMString message);
 };
 </script>
 


### PR DESCRIPTION
The previous IDL left OOM and Validation errors without a constructor, because constructors aren't inherited.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/2911.html" title="Last updated on May 18, 2022, 4:52 PM UTC (f73e719)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2911/4addcf0...f73e719.html" title="Last updated on May 18, 2022, 4:52 PM UTC (f73e719)">Diff</a>