### PR TITLE
Add reflection for container objects.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2433,6 +2433,9 @@ interface GPUBuffer {
     undefined unmap();
 
     undefined destroy();
+
+    readonly attribute GPUSize64 size;
+    readonly attribute GPUBufferUsageFlags usage;
 };
 GPUBuffer includes GPUObjectBase;
 </script>
@@ -2440,11 +2443,11 @@ GPUBuffer includes GPUObjectBase;
 {{GPUBuffer}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUBuffer">
-    : <dfn>\[[size]]</dfn> of type {{GPUSize64}}.
+    : <dfn>size</dfn> of type {{GPUSize64}}.
     ::
         The length of the {{GPUBuffer}} allocation in bytes.
 
-    : <dfn>\[[usage]]</dfn> of type {{GPUBufferUsageFlags}}.
+    : <dfn>usage</dfn> of type {{GPUBufferUsageFlags}}.
     ::
         The allowed usages for this {{GPUBuffer}}.
 
@@ -2475,7 +2478,7 @@ GPUBuffer includes GPUObjectBase;
         The {{GPUMapModeFlags}} of the last call to {{GPUBuffer/mapAsync()}} (if any).
 </dl>
 
-Issue: {{GPUBuffer/[[usage]]}} is differently named from {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}}.
+Issue: {{GPUBuffer/usage}} is differently named from {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}}.
 We should make it consistent.
 
 Each {{GPUBuffer}} has a current <dfn dfn>buffer state</dfn> on the [=Content timeline=]
@@ -2493,7 +2496,7 @@ which is one of the following:
      no longer available for any operations except {{GPUBuffer/destroy}}.
 
 Note:
-{{GPUBuffer/[[size]]}} and {{GPUBuffer/[[usage]]}} are immutable once the
+{{GPUBuffer/size}} and {{GPUBuffer/usage}} are immutable once the
 {{GPUBuffer}} has been created.
 
 <div class=note>
@@ -2680,11 +2683,11 @@ The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its
                     any calls to {{GPUBuffer/mapAsync()}} will reject, so any resources allocated to enable mapping can
                     and may be discarded or recycled.
 
-                    1. Set |b|.{{GPUBuffer/[[size]]}} to |descriptor|.{{GPUBufferDescriptor/size}}.
-                    1. Set |b|.{{GPUBuffer/[[usage]]}} to |descriptor|.{{GPUBufferDescriptor/usage}}.
+                    1. Set |b|.{{GPUBuffer/size}} to |descriptor|.{{GPUBufferDescriptor/size}}.
+                    1. Set |b|.{{GPUBuffer/usage}} to |descriptor|.{{GPUBufferDescriptor/usage}}.
                     1. If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`:
 
-                        1. Set |b|.{{GPUBuffer/[[mapping]]}} to a new {{ArrayBuffer}} of size |b|.{{GPUBuffer/[[size]]}}.
+                        1. Set |b|.{{GPUBuffer/[[mapping]]}} to a new {{ArrayBuffer}} of size |b|.{{GPUBuffer/size}}.
                         1. Set |b|.{{GPUBuffer/[[mapping_range]]}} to `[0, descriptor.size]`.
                         1. Set |b|.{{GPUBuffer/[[mapped_ranges]]}} to `[]`.
                         1. Set |b|.{{GPUBuffer/[[state]]}} to [=buffer state/mapped at creation=].
@@ -2824,7 +2827,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
             Issue(gpuweb/gpuweb#605): Handle error buffers once we have a description of the error monad.
 
             1. If |size| is missing:
-                1. Let |rangeSize| be max(0, |this|.{{GPUBuffer/[[size]]}} - |offset|).
+                1. Let |rangeSize| be max(0, |this|.{{GPUBuffer/size}} - |offset|).
 
                 Otherwise, let |rangeSize| be |size|.
 
@@ -2834,11 +2837,11 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                         TODO: check destroyed state?
                     - |offset| is a multiple of 8.
                     - |rangeSize| is a multiple of 4.
-                    - |offset| + |rangeSize| is less or equal to |this|.{{GPUBuffer/[[size]]}}
+                    - |offset| + |rangeSize| is less or equal to |this|.{{GPUBuffer/size}}
                     - |this|.{{GPUBuffer/[[state]]}} is [=buffer state/unmapped=]
                     - |mode| contains exactly one of {{GPUMapMode/READ}} or {{GPUMapMode/WRITE}}.
-                    - If |mode| contains {{GPUMapMode/READ}} then |this|.{{GPUBuffer/[[usage]]}} must contain {{GPUBufferUsage/MAP_READ}}.
-                    - If |mode| contains {{GPUMapMode/WRITE}} then |this|.{{GPUBuffer/[[usage]]}} must contain {{GPUBufferUsage/MAP_WRITE}}.
+                    - If |mode| contains {{GPUMapMode/READ}} then |this|.{{GPUBuffer/usage}} must contain {{GPUBufferUsage/MAP_READ}}.
+                    - If |mode| contains {{GPUMapMode/WRITE}} then |this|.{{GPUBuffer/usage}} must contain {{GPUBufferUsage/MAP_WRITE}}.
 
                     Issue: Do we validate that |mode| contains only valid flags?
                 </div>
@@ -2883,7 +2886,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
             **Returns:** {{ArrayBuffer}}
 
             1. If |size| is missing:
-                1. Let |rangeSize| be max(0, |this|.{{GPUBuffer/[[size]]}} - |offset|).
+                1. Let |rangeSize| be max(0, |this|.{{GPUBuffer/size}} - |offset|).
 
                 Otherwise, let |rangeSize| be |size|.
 
@@ -5120,7 +5123,7 @@ following members:
 <div algorithm>
     <dfn abstract-op>effective buffer binding size</dfn>(binding)
         1. If |binding|.{{GPUBufferBinding/size}} is `undefined`:
-            1. Return max(0, |binding|.{{GPUBufferBinding/buffer}}.{{GPUBuffer/[[size]]}} - |binding|.{{GPUBufferBinding/offset}});
+            1. Return max(0, |binding|.{{GPUBufferBinding/buffer}}.{{GPUBuffer/size}} - |binding|.{{GPUBufferBinding/offset}});
         1. Return |binding|.{{GPUBufferBinding/size}}.
 </div>
 
@@ -8146,15 +8149,15 @@ dictionary GPUImageCopyExternalImage {
                     <div class=validusage>
                         - |source| is [$valid to use with$] |this|.
                         - |destination| is [$valid to use with$] |this|.
-                        - |source|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/COPY_SRC}}.
-                        - |destination|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/COPY_DST}}.
+                        - |source|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/COPY_SRC}}.
+                        - |destination|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/COPY_DST}}.
                         - |size| is a multiple of 4.
                         - |sourceOffset| is a multiple of 4.
                         - |destinationOffset| is a multiple of 4.
                         - (|sourceOffset| + |size|) does not overflow a {{GPUSize64}}.
                         - (|destinationOffset| + |size|) does not overflow a {{GPUSize64}}.
-                        - |source|.{{GPUBuffer/[[size]]}} is greater than or equal to (|sourceOffset| + |size|).
-                        - |destination|.{{GPUBuffer/[[size]]}} is greater than or equal to (|destinationOffset| + |size|).
+                        - |source|.{{GPUBuffer/size}} is greater than or equal to (|sourceOffset| + |size|).
+                        - |destination|.{{GPUBuffer/size}} is greater than or equal to (|destinationOffset| + |size|).
                         - |source| and |destination| are not the same {{GPUBuffer}}.
 
                         Issue(gpuweb/gpuweb#69): figure out how to handle overflows in the spec.
@@ -8187,14 +8190,14 @@ dictionary GPUImageCopyExternalImage {
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If |size| is missing, set |size| to `max(0, |buffer|.{{GPUBuffer/[[size]]}} - |offset|)`.
+                1. If |size| is missing, set |size| to `max(0, |buffer|.{{GPUBuffer/size}} - |offset|)`.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |buffer| is [$valid to use with$] |this|.
-                        - |buffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/COPY_DST}}.
+                        - |buffer|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/COPY_DST}}.
                         - |size| is a multiple of 4.
                         - |offset| is a multiple of 4.
-                        - |buffer|.{{GPUBuffer/[[size]]}} is greater than or equal to (|offset| + |size|).
+                        - |buffer|.{{GPUBuffer/size}} is greater than or equal to (|offset| + |size|).
                     </div>
             </div>
         </div>
@@ -8343,7 +8346,7 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
                     <div class=validusage>
                         - Let |dstTextureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
                         - [$validating GPUImageCopyBuffer$](|source|) returns `true`.
-                        - |source|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/COPY_SRC}}.
+                        - |source|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/usage}} contains {{GPUBufferUsage/COPY_SRC}}.
                         - [$validating GPUImageCopyTexture$](|destination|, |copySize|) returns `true`.
                         - |dstTextureDesc|.{{GPUTextureDescriptor/usage}} contains {{GPUTextureUsage/COPY_DST}}.
                         - |dstTextureDesc|.{{GPUTextureDescriptor/sampleCount}} is 1.
@@ -8360,7 +8363,7 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
                         - If |dstTextureDesc|.{{GPUTextureDescriptor/format}} is a [=depth-or-stencil format=]:
                             - |source|.{{GPUImageDataLayout/offset}} is a multiple of 4.
                         - [$validating linear texture data$](|source|,
-                            |source|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[size]]}},
+                            |source|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/size}},
                             |aspectSpecificFormat|,
                             |copySize|) succeeds.
                     </div>
@@ -8400,7 +8403,7 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
                             - That aspect must be a valid image copy source according to [[#depth-formats]].
                             - Set |aspectSpecificFormat| to the [=aspect-specific format=] according to [[#depth-formats]].
                         - [$validating GPUImageCopyBuffer$](|destination|) returns `true`.
-                        - |destination|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[usage]]}} contains
+                        - |destination|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/usage}} contains
                             {{GPUBufferUsage/COPY_DST}}.
                         - [=validating texture copy range=](|source|, |copySize|) returns `true`.
                         - If |srcTextureDesc|.{{GPUTextureDescriptor/format}} is not a [=depth-or-stencil format=]:
@@ -8409,7 +8412,7 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
                         - If |srcTextureDesc|.{{GPUTextureDescriptor/format}} is a [=depth-or-stencil format=]:
                             - |destination|.{{GPUImageDataLayout/offset}} is a multiple of 4.
                         - [$validating linear texture data$](|destination|,
-                            |destination|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/[[size]]}},
+                            |destination|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/size}},
                             |aspectSpecificFormat|,
                             |copySize|) succeeds.
                     </div>
@@ -8546,11 +8549,11 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
                     <div class=validusage>
                         - |querySet| is [$valid to use with$] |this|.
                         - |destination| is [$valid to use with$] |this|.
-                        - |destination|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/QUERY_RESOLVE}}.
+                        - |destination|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/QUERY_RESOLVE}}.
                         - |firstQuery| is less than the number of queries in |querySet|.
                         - (|firstQuery| + |queryCount|) is less than or equal to the number of queries in |querySet|.
                         - |destinationOffset| is a multiple of 256.
-                        - |destinationOffset| + 8 &times; |queryCount| &le; |destination|.{{GPUBuffer/[[size]]}}.
+                        - |destinationOffset| + 8 &times; |queryCount| &le; |destination|.{{GPUBuffer/size}}.
                     </div>
 
                 Issue: Describe {{GPUCommandEncoder/resolveQuerySet()}} algorithm steps.
@@ -8683,7 +8686,7 @@ It must only be included by interfaces which also include those mixins.
                             - Let |bufferDynamicOffset| be |dynamicOffsets|[|dynamicOffsetIndex|].
                             - |bufferBinding|.{{GPUBufferBinding/offset}} + |bufferDynamicOffset| +
                                 |bufferLayout|.{{GPUBufferBindingLayout/minBindingSize}} &le;
-                                |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBuffer/[[size]]}}.
+                                |bufferBinding|.{{GPUBufferBinding/buffer}}.{{GPUBuffer/size}}.
                             - if |bufferLayout|.{{GPUBufferBindingLayout/type}} is {{GPUBufferBindingType/"uniform"}}:
 
                                 - |dynamicOffset| is a multiple of {{supported limits/minUniformBufferOffsetAlignment}}.
@@ -9127,9 +9130,9 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
                         - [$Validate encoder bind groups$](|this|, |this|.{{GPUComputePassEncoder/[[pipeline]]}})
                             is `true`.
                         - |indirectBuffer| is [$valid to use with$] |this|.
-                        - |indirectBuffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDIRECT}}.
+                        - |indirectBuffer|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/INDIRECT}}.
                         - |indirectOffset| + sizeof([=indirect dispatch parameters=]) &le;
-                            |indirectBuffer|.{{GPUBuffer/[[size]]}}.
+                            |indirectBuffer|.{{GPUBuffer/size}}.
                         - |indirectOffset| is a multiple of 4.
                     </div>
                 1. Add |indirectBuffer| to the [=usage scope=] as {{GPUBufferUsage/INDIRECT}}.
@@ -9869,13 +9872,13 @@ It must only be included by interfaces which also include those mixins.
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If |size| is missing, set |size| to max(0, |buffer|.{{GPUBuffer/[[size]]}} - |offset|).
+                1. If |size| is missing, set |size| to max(0, |buffer|.{{GPUBuffer/size}} - |offset|).
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |buffer| is [$valid to use with$] |this|.
-                        - |buffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDEX}}.
+                        - |buffer|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/INDEX}}.
                         - |offset| is a multiple of |indexFormat|'s byte size.
-                        - |offset| + |size| &le; |buffer|.{{GPUBuffer/[[size]]}}.
+                        - |offset| + |size| &le; |buffer|.{{GPUBuffer/size}}.
                     </div>
                 1. Add |buffer| to the [=usage scope=] as [=internal usage/input=].
                 1. Set |this|.{{GPURenderCommandsMixin/[[index_buffer]]}} to be |buffer|.
@@ -9905,14 +9908,14 @@ It must only be included by interfaces which also include those mixins.
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If |size| is missing, set |size| to max(0, |buffer|.{{GPUBuffer/[[size]]}} - |offset|).
+                1. If |size| is missing, set |size| to max(0, |buffer|.{{GPUBuffer/size}} - |offset|).
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |buffer| is [$valid to use with$] |this|.
-                        - |buffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/VERTEX}}.
+                        - |buffer|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/VERTEX}}.
                         - |slot| &lt; |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBuffers}}.
                         - |offset| is a multiple of 4.
-                        - |offset| + |size| &le; |buffer|.{{GPUBuffer/[[size]]}}.
+                        - |offset| + |size| &le; |buffer|.{{GPUBuffer/size}}.
                     </div>
                 1. Add |buffer| to the [=usage scope=] as [=internal usage/input=].
                 1. Set |this|.{{GPURenderCommandsMixin/[[vertex_buffers]]}}[|slot|] to be |buffer|.
@@ -10051,9 +10054,9 @@ It must only be included by interfaces which also include those mixins.
                     <div class=validusage>
                         - It is [$valid to draw$] with |this|.
                         - |indirectBuffer| is [$valid to use with$] |this|.
-                        - |indirectBuffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDIRECT}}.
+                        - |indirectBuffer|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/INDIRECT}}.
                         - |indirectOffset| + sizeof([=indirect draw parameters=]) &le;
-                            |indirectBuffer|.{{GPUBuffer/[[size]]}}.
+                            |indirectBuffer|.{{GPUBuffer/size}}.
                         - |indirectOffset| is a multiple of 4.
                     </div>
                 1. Add |indirectBuffer| to the [=usage scope=] as [=internal usage/input=].
@@ -10100,9 +10103,9 @@ It must only be included by interfaces which also include those mixins.
                     <div class=validusage>
                         - It is [$valid to draw indexed$] with |this|.
                         - |indirectBuffer| is [$valid to use with$] |this|.
-                        - |indirectBuffer|.{{GPUBuffer/[[usage]]}} contains {{GPUBufferUsage/INDIRECT}}.
+                        - |indirectBuffer|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/INDIRECT}}.
                         - |indirectOffset| + sizeof([=indirect drawIndexed parameters=]) &le;
-                            |indirectBuffer|.{{GPUBuffer/[[size]]}}.
+                            |indirectBuffer|.{{GPUBuffer/size}}.
                         - |indirectOffset| is a multiple of 4.
                     </div>
                 1. Add |indirectBuffer| to the [=usage scope=] as [=internal usage/input=].
@@ -10602,9 +10605,9 @@ GPUQueue includes GPUObjectBase;
                         <div class=validusage>
                             - |buffer| is [$valid to use with$] |this|.
                             - |buffer|.{{GPUBuffer/[[state]]}} is [=buffer state/unmapped=].
-                            - |buffer|.{{GPUBuffer/[[usage]]}} includes {{GPUBufferUsage/COPY_DST}}.
+                            - |buffer|.{{GPUBuffer/usage}} includes {{GPUBufferUsage/COPY_DST}}.
                             - |bufferOffset|, converted to bytes, is a multiple of 4 bytes.
-                            - |bufferOffset| + |contentsSize|, converted to bytes, &le; |buffer|.{{GPUBuffer/[[size]]}} bytes.
+                            - |bufferOffset| + |contentsSize|, converted to bytes, &le; |buffer|.{{GPUBuffer/size}} bytes.
                         </div>
                     1. Write |contents| into |buffer| starting at |bufferOffset|.
                 </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2980,7 +2980,7 @@ interface GPUTexture {
 
     undefined destroy();
 
-    [SameObject] readonly attribute GPUExtent3DDict size;
+    [SameObject] readonly attribute GPUExtent3DReadOnly size;
     readonly attribute GPUIntegerCoordinate mipLevelCount;
     readonly attribute GPUSize32 sampleCount;
     readonly attribute GPUTextureDimension dimension;
@@ -2993,7 +2993,7 @@ GPUTexture includes GPUObjectBase;
 {{GPUTexture}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUTexture">
-    : <dfn>size</dfn>, of type {{GPUExtent3DDict}}
+    : <dfn>size</dfn>, of type {{GPUExtent3DReadOnly}}
     ::
         The width, height, and depth or layer count of this {{GPUTexture}}.
 
@@ -3034,14 +3034,14 @@ GPUTexture includes GPUObjectBase;
     <dfn abstract-op>compute render extent</dfn>(baseSize, mipLevel)
 
     **Arguments:**
-        - {{GPUExtent3D}} |baseSize|
+        - {{GPUExtent3DReadOnly}} |baseSize|
         - {{GPUSize32}} |mipLevel|
 
     **Returns:** {{GPUExtent3DDict}}
 
     1. Let |extent| be a new {{GPUExtent3DDict}} object.
-    1. Set |extent|.{{GPUExtent3DDict/width}} to max(1, |baseSize|.[=Extent3D/width=] &Gt; |mipLevel|).
-    1. Set |extent|.{{GPUExtent3DDict/height}} to max(1, |baseSize|.[=Extent3D/height=] &Gt; |mipLevel|).
+    1. Set |extent|.{{GPUExtent3DDict/width}} to max(1, |baseSize|.{{GPUExtent3DReadOnly/width}} &Gt; |mipLevel|).
+    1. Set |extent|.{{GPUExtent3DDict/height}} to max(1, |baseSize|.{{GPUExtent3DReadOnly/height}} &Gt; |mipLevel|).
     1. Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to 1.
     1. Return |extent|.
 </div>
@@ -3239,10 +3239,10 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
                         <div class=validusage>
                             - [$validating GPUTextureDescriptor$](|this|, |descriptor|) returns `true`.
                         </div>
-                    1. Set |t|.{{GPUTexture/size}} to a new {{GPUExtent3DDict}} with the following fields set:
-                        1. {{GPUExtent3DDict/width}} set to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=].
-                        1. {{GPUExtent3DDict/height}} set to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=].
-                        1. {{GPUExtent3DDict/depthOrArrayLayers}} set to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=].
+                    1. Set |t|.{{GPUTexture/size}} to a new {{GPUExtent3DReadOnly}} with the following fields set:
+                        1. {{GPUExtent3DReadOnly/width}} set to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=].
+                        1. {{GPUExtent3DReadOnly/height}} set to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=].
+                        1. {{GPUExtent3DReadOnly/depthOrArrayLayers}} set to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=].
                     1. Set |t|.{{GPUTexture/mipLevelCount}} to |descriptor|.{{GPUTextureDescriptor/mipLevelCount}}.
                     1. Set |t|.{{GPUTexture/sampleCount}} to |descriptor|.{{GPUTextureDescriptor/sampleCount}}.
                     1. Set |t|.{{GPUTexture/dimension}} to |descriptor|.{{GPUTextureDescriptor/dimension}}.
@@ -3615,14 +3615,14 @@ enum GPUTextureAspect {
                                     : {{GPUTextureViewDimension/"cube"}}
                                     :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
                                     :: |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `6`.
-                                    :: |this|.{{GPUTexture/size}}.[=Extent3D/width=] must be
-                                        |this|.{{GPUTexture/size}}.[=Extent3D/height=].
+                                    :: |this|.{{GPUTexture/size}}.{{GPUExtent3DReadOnly/width}} must be equal to
+                                        |this|.{{GPUTexture/size}}.{{GPUExtent3DReadOnly/height}}.
 
                                     : {{GPUTextureViewDimension/"cube-array"}}
                                     :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
                                     :: |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be a multiple of `6`.
-                                    :: |this|.{{GPUTexture/size}}.[=Extent3D/width=] must be
-                                        |this|.{{GPUTexture/size}}.[=Extent3D/height=].
+                                    :: |this|.{{GPUTexture/size}}.{{GPUExtent3DReadOnly/width}} must be equal to
+                                        |this|.{{GPUTexture/size}}.{{GPUExtent3DReadOnly/height}}.
 
                                     : {{GPUTextureViewDimension/"3d"}}
                                     :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"3d"}}.
@@ -3702,7 +3702,7 @@ enum GPUTextureAspect {
                 :: Return `1`.
 
                 : {{GPUTextureDimension/"2d"}}
-                :: Return |texture|.{{GPUTexture/size}}.[=Extent3D/depthOrArrayLayers=].
+                :: Return |texture|.{{GPUTexture/size}}.{{GPUExtent3DReadOnly/depthOrArrayLayers}}.
             </dl>
 </div>
 
@@ -12584,6 +12584,19 @@ An <dfn dfn>Extent3D</dfn> is a {{GPUExtent3D}}.
         either {{GPUExtent3DDict}}.{{GPUExtent3DDict/depthOrArrayLayers}}
         or the third item of the sequence (1 if not present).
 </div>
+
+<script type=idl>
+[Exposed=(Window, DedicatedWorker), SecureContext]
+interface GPUExtent3DReadOnly {
+    readonly attribute GPUIntegerCoordinate width;
+    readonly attribute GPUIntegerCoordinate height;
+    readonly attribute GPUIntegerCoordinate depthOrArrayLayers;
+};
+</script>
+
+A <dfn interface>GPUExtent3DReadOnly</dfn> is an equivalent to [=Extent3D=]
+that's an interface with all members required. It is used for interface attributes in lieu
+of the dictionary {{GPUExtent3DDict}} as WebIDL forbids dictionary attributes.
 
 # Feature Index # {#feature-index}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2478,9 +2478,6 @@ GPUBuffer includes GPUObjectBase;
         The {{GPUMapModeFlags}} of the last call to {{GPUBuffer/mapAsync()}} (if any).
 </dl>
 
-Issue: {{GPUBuffer/usage}} is differently named from {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}}.
-We should make it consistent.
-
 Each {{GPUBuffer}} has a current <dfn dfn>buffer state</dfn> on the [=Content timeline=]
 which is one of the following:
 
@@ -2982,6 +2979,13 @@ interface GPUTexture {
     GPUTextureView createView(optional GPUTextureViewDescriptor descriptor = {});
 
     undefined destroy();
+
+    [SameObject] readonly attribute GPUExtent3DDict size;
+    readonly attribute GPUIntegerCoordinate mipLevelCount;
+    readonly attribute GPUSize32 sampleCount;
+    readonly attribute GPUTextureDimension dimension;
+    readonly attribute GPUTextureFormat format;
+    readonly attribute GPUTextureUsageFlags usage;
 };
 GPUTexture includes GPUObjectBase;
 </script>
@@ -2989,11 +2993,36 @@ GPUTexture includes GPUObjectBase;
 {{GPUTexture}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUTexture">
-    : <dfn>\[[descriptor]]</dfn>, of type {{GPUTextureDescriptor}}
+    : <dfn>size</dfn>, of type {{GPUExtent3DDict}}
     ::
-        The {{GPUTextureDescriptor}} describing this texture.
+        The width, height, and depth or layer count of this {{GPUTexture}}.
 
-        All optional fields of {{GPUTextureDescriptor}} are defined.
+        Note: It is a {{GPUExtent3DDict}} with all fields set instead of a {{GPUExtent3D}} union type.
+
+    : <dfn>mipLevelCount</dfn>, of type {{GPUIntegerCoordinate}}
+    ::
+        The number of mip levels of this {{GPUTexture}}.
+
+    : <dfn>sampleCount</dfn>, of type {{GPUSize32}}
+    ::
+        The number of sample count of this {{GPUTexture}}.
+
+    : <dfn>dimension</dfn>, of type {{GPUTextureDimension}}
+    ::
+        The dimension of the set of texel for each of this {{GPUTexture}}'s subresources.
+
+    : <dfn>format</dfn>, of type {{GPUTextureFormat}}
+    ::
+        The format of this {{GPUTexture}}.
+
+    : <dfn>usage</dfn>, of type {{GPUTextureUsage}}
+    ::
+        The allowed usages for this {{GPUTexture}}.
+
+    : <dfn>\[[viewFormats]]</dfn>, of type sequence&lt;{{GPUTextureFormat}}&gt;
+    ::
+        The set of {{GPUTextureFormat}}s that can be used {{GPUTextureViewDescriptor}}.{{GPUTextureViewDescriptor/format}}
+        when creating views on this {{GPUTexture}}.
 
     : <dfn>\[[destroyed]]</dfn>, of type `boolean`, initially false
     ::
@@ -3210,7 +3239,16 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
                         <div class=validusage>
                             - [$validating GPUTextureDescriptor$](|this|, |descriptor|) returns `true`.
                         </div>
-                    1. Set |t|.{{GPUTexture/[[descriptor]]}} to |descriptor|.
+                    1. Set |t|.{{GPUTexture/size}} to a new {{GPUExtent3DDict}} with the following fields set:
+                        1. {{GPUExtent3DDict/width}} set to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=].
+                        1. {{GPUExtent3DDict/height}} set to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=].
+                        1. {{GPUExtent3DDict/depthOrArrayLayers}} set to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=].
+                    1. Set |t|.{{GPUTexture/mipLevelCount}} to |descriptor|.{{GPUTextureDescriptor/mipLevelCount}}.
+                    1. Set |t|.{{GPUTexture/sampleCount}} to |descriptor|.{{GPUTextureDescriptor/sampleCount}}.
+                    1. Set |t|.{{GPUTexture/dimension}} to |descriptor|.{{GPUTextureDescriptor/dimension}}.
+                    1. Set |t|.{{GPUTexture/format}} to |descriptor|.{{GPUTextureDescriptor/format}}.
+                    1. Set |t|.{{GPUTexture/usage}} to |descriptor|.{{GPUTextureDescriptor/usage}}.
+                    1. Set |t|.{{GPUTexture/[[viewFormats]]}} to |descriptor|.{{GPUTextureDescriptor/viewFormats}}.
                 </div>
             1. Return |t|.
         </div>
@@ -3539,56 +3577,55 @@ enum GPUTextureAspect {
                         [$generate a validation error$], make |view| [=invalid=], and stop.
                         <div class=validusage>
                             - |this| is [=valid=].
-                            - |descriptor|.{{GPUTextureViewDescriptor/aspect}} must be present in
-                                |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
+                            - |descriptor|.{{GPUTextureViewDescriptor/aspect}} must be present in |this|.{{GPUTexture/format}}.
                             - If the |descriptor|.{{GPUTextureViewDescriptor/aspect}} is {{GPUTextureAspect/"all"}}:
                                 - |descriptor|.{{GPUTextureViewDescriptor/format}} must be equal to either
-                                        |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}} or one
-                                        of the formats in |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/viewFormats}}.
+                                        |this|.{{GPUTexture/format}} or one
+                                        of the formats in |this|.{{GPUTexture/[[viewFormats]]}}.
 
                                 Otherwise:
 
                                 - |descriptor|.{{GPUTextureViewDescriptor/format}} must be equal to the result of [$resolving GPUTextureAspect$](
-                                    |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}},
+                                    |this|.{{GPUTexture/format}},
                                     |descriptor|.{{GPUTextureViewDescriptor/aspect}}).
 
                             - |descriptor|.{{GPUTextureViewDescriptor/mipLevelCount}} must be &gt; 0.
                             - |descriptor|.{{GPUTextureViewDescriptor/baseMipLevel}} +
                                 |descriptor|.{{GPUTextureViewDescriptor/mipLevelCount}} must be &le;
-                                |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/mipLevelCount}}.
+                                |this|.{{GPUTexture/mipLevelCount}}.
                             - |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be &gt; 0.
                             - |descriptor|.{{GPUTextureViewDescriptor/baseArrayLayer}} +
                                 |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be &le;
                                 the [$array layer count$] of |this|.
-                            - If |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}} is &gt; 1,
+                            - If |this|.{{GPUTexture/sampleCount}} is &gt; 1,
                                 |descriptor|.{{GPUTextureViewDescriptor/dimension}} must be {{GPUTextureViewDimension/"2d"}}.
                             - If |descriptor|.{{GPUTextureViewDescriptor/dimension}} is:
                                 <dl class="switch">
                                     : {{GPUTextureViewDimension/"1d"}}
-                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"1d"}}.
+                                    :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"1d"}}.
                                     :: |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `1`.
 
                                     : {{GPUTextureViewDimension/"2d"}}
-                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"2d"}}.
+                                    :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
                                     :: |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `1`.
 
                                     : {{GPUTextureViewDimension/"2d-array"}}
-                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"2d"}}.
+                                    :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
 
                                     : {{GPUTextureViewDimension/"cube"}}
-                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"2d"}}.
+                                    :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
                                     :: |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `6`.
-                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be
-                                        |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}.[=Extent3D/height=].
+                                    :: |this|.{{GPUTexture/size}}.[=Extent3D/width=] must be
+                                        |this|.{{GPUTexture/size}}.[=Extent3D/height=].
 
                                     : {{GPUTextureViewDimension/"cube-array"}}
-                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"2d"}}.
+                                    :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
                                     :: |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be a multiple of `6`.
-                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be
-                                        |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}.[=Extent3D/height=].
+                                    :: |this|.{{GPUTexture/size}}.[=Extent3D/width=] must be
+                                        |this|.{{GPUTexture/size}}.[=Extent3D/height=].
 
                                     : {{GPUTextureViewDimension/"3d"}}
-                                    :: |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"3d"}}.
+                                    :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"3d"}}.
                                     :: |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `1`.
                                 </dl>
                         </div>
@@ -3596,8 +3633,8 @@ enum GPUTextureAspect {
                     1. Let |view| be a new {{GPUTextureView}} object.
                     1. Set |view|.{{GPUTextureView/[[texture]]}} to |this|.
                     1. Set |view|.{{GPUTextureView/[[descriptor]]}} to |descriptor|.
-                    1. If |this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}} contains {{GPUTextureUsage/RENDER_ATTACHMENT}}:
-                        1. Let |renderExtent| be [$compute render extent$](|this|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}, |descriptor|.{{GPUTextureViewDescriptor/baseMipLevel}}).
+                    1. If |this|.{{GPUTexture/usage}} contains {{GPUTextureUsage/RENDER_ATTACHMENT}}:
+                        1. Let |renderExtent| be [$compute render extent$](|this|.{{GPUTexture/size}}, |descriptor|.{{GPUTextureViewDescriptor/baseMipLevel}}).
                         1. Set |view|.{{GPUTextureView/[[renderExtent]]}} to |renderExtent|.
                 </div>
             1. Return |view|.
@@ -3611,19 +3648,19 @@ enum GPUTextureAspect {
     1. Let |resolved| be a copy of |descriptor|.
     1. If |resolved|.{{GPUTextureViewDescriptor/format}} is `undefined`,
         1. Let |format| be the result of [$resolving GPUTextureAspect$](
-                {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}},
+                {{GPUTexture/format}},
                 |descriptor|.{{GPUTextureViewDescriptor/aspect}}).
         1. If |format| is `null`:
-            - Set |resolved|.{{GPUTextureViewDescriptor/format}} to |texture|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
+            - Set |resolved|.{{GPUTextureViewDescriptor/format}} to |texture|.{{GPUTexture/format}}.
 
             Otherwise:
 
             - Set |resolved|.{{GPUTextureViewDescriptor/format}} to |format|.
     1. If |resolved|.{{GPUTextureViewDescriptor/mipLevelCount}} is `undefined`,
-        set |resolved|.{{GPUTextureViewDescriptor/mipLevelCount}} to |texture|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/mipLevelCount}}
+        set |resolved|.{{GPUTextureViewDescriptor/mipLevelCount}} to |texture|.{{GPUTexture/mipLevelCount}}
         &minus; |resolved|.{{GPUTextureViewDescriptor/baseMipLevel}}.
     1. If |resolved|.{{GPUTextureViewDescriptor/dimension}} is `undefined` and
-        |texture|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} is:
+        |texture|.{{GPUTexture/dimension}} is:
         <dl class="switch">
             : {{GPUTextureDimension/"1d"}}
             :: Set |resolved|.{{GPUTextureViewDescriptor/dimension}} to {{GPUTextureViewDimension/"1d"}}.
@@ -3659,13 +3696,13 @@ enum GPUTextureAspect {
     To determine the <dfn abstract-op>array layer count</dfn> of {{GPUTexture}} |texture|, run the
     following steps:
 
-        1. If |texture|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}} is:
+        1. If |texture|.{{GPUTexture/dimension}} is:
             <dl class="switch">
                 : {{GPUTextureDimension/"1d"}} or {{GPUTextureDimension/"3d"}}
                 :: Return `1`.
 
                 : {{GPUTextureDimension/"2d"}}
-                :: Return |texture|.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=].
+                :: Return |texture|.{{GPUTexture/size}}.[=Extent3D/depthOrArrayLayers=].
             </dl>
 </div>
 
@@ -8021,19 +8058,19 @@ dictionary GPUImageCopyTexture {
   **Returns:** {{boolean}}
 
   Let:
-  - |blockWidth| be the [=texel block width=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
-  - |blockHeight| be the [=texel block height=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
+  - |blockWidth| be the [=texel block width=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}}.
+  - |blockHeight| be the [=texel block height=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}}.
 
   Return `true` if and only if all of the following conditions apply:
   - |imageCopyTexture|.{{GPUImageCopyTexture/texture}} must be a [=valid=] {{GPUTexture}}.
-  - |imageCopyTexture|.{{GPUImageCopyTexture/mipLevel}} must be less than the {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/mipLevelCount}} of
+  - |imageCopyTexture|.{{GPUImageCopyTexture/mipLevel}} must be less than the {{GPUTexture/mipLevelCount}} of
     |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.
   - |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/x=] must be a multiple of |blockWidth|.
   - |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/y=] must be a multiple of |blockHeight|.
   - The [=imageCopyTexture subresource size=] of |imageCopyTexture| is equal to |copySize| if either of
       the following conditions is true:
-        - |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}} is a depth-stencil format.
-        - |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}} is greater than 1.
+        - |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}} is a depth-stencil format.
+        - |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/sampleCount}} is greater than 1.
 
 </div>
 
@@ -8307,8 +8344,8 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
     : {{GPUExtent3D}} |copySize|
     :: The size of the texture.
 
-    1. Let |blockWidth| be the [=texel block width=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
-    1. Let |blockHeight| be the [=texel block height=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/format}}.
+    1. Let |blockWidth| be the [=texel block width=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}}.
+    1. Let |blockHeight| be the [=texel block height=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}}.
     1. Let |subresourceSize| be the [=imageCopyTexture subresource size=] of |imageCopyTexture|.
 
     1. Return whether all the conditions below are satisfied:
@@ -8344,23 +8381,23 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
-                        - Let |dstTextureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
+                        - Let |dstTexture| be |destination|.{{GPUImageCopyTexture/texture}}.
                         - [$validating GPUImageCopyBuffer$](|source|) returns `true`.
                         - |source|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/usage}} contains {{GPUBufferUsage/COPY_SRC}}.
                         - [$validating GPUImageCopyTexture$](|destination|, |copySize|) returns `true`.
-                        - |dstTextureDesc|.{{GPUTextureDescriptor/usage}} contains {{GPUTextureUsage/COPY_DST}}.
-                        - |dstTextureDesc|.{{GPUTextureDescriptor/sampleCount}} is 1.
-                        - Let |aspectSpecificFormat| = |dstTextureDesc|.{{GPUTextureDescriptor/format}}.
-                        - If |dstTextureDesc|.{{GPUTextureDescriptor/format}} is a [=depth-or-stencil format=]:
+                        - |dstTexture|.{{GPUTexture/usage}} contains {{GPUTextureUsage/COPY_DST}}.
+                        - |dstTexture|.{{GPUTexture/sampleCount}} is 1.
+                        - Let |aspectSpecificFormat| = |dstTexture|.{{GPUTexture/format}}.
+                        - If |dstTexture|.{{GPUTexture/format}} is a [=depth-or-stencil format=]:
                             - |destination|.{{GPUImageCopyTexture/aspect}} must refer to a single aspect of
-                                |dstTextureDesc|.{{GPUTextureDescriptor/format}}.
+                                |dstTexture|.{{GPUTexture/format}}.
                             - That aspect must be a valid image copy destination according to [[#depth-formats]].
                             - Set |aspectSpecificFormat| to the [=aspect-specific format=] according to [[#depth-formats]].
                         - [=validating texture copy range=](|destination|, |copySize|) return `true`.
-                        - If |dstTextureDesc|.{{GPUTextureDescriptor/format}} is not a [=depth-or-stencil format=]:
+                        - If |dstTexture|.{{GPUTexture/format}} is not a [=depth-or-stencil format=]:
                             - |source|.{{GPUImageDataLayout/offset}} is a multiple of the [=texel block size=] of
-                                |dstTextureDesc|.{{GPUTextureDescriptor/format}}.
-                        - If |dstTextureDesc|.{{GPUTextureDescriptor/format}} is a [=depth-or-stencil format=]:
+                                |dstTexture|.{{GPUTexture/format}}.
+                        - If |dstTexture|.{{GPUTexture/format}} is a [=depth-or-stencil format=]:
                             - |source|.{{GPUImageDataLayout/offset}} is a multiple of 4.
                         - [$validating linear texture data$](|source|,
                             |source|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/size}},
@@ -8392,24 +8429,24 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
-                        - Let |srcTextureDesc| be |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
+                        - Let |srcTexture| be |source|.{{GPUImageCopyTexture/texture}}.
                         - [$validating GPUImageCopyTexture$](|source|, |copySize|) returns `true`.
-                        - |srcTextureDesc|.{{GPUTextureDescriptor/usage}} contains {{GPUTextureUsage/COPY_SRC}}.
-                        - |srcTextureDesc|.{{GPUTextureDescriptor/sampleCount}} is 1.
-                        - Let |aspectSpecificFormat| = |srcTextureDesc|.{{GPUTextureDescriptor/format}}.
-                        - If |srcTextureDesc|.{{GPUTextureDescriptor/format}} is a [=depth-or-stencil format=] format:
+                        - |srcTexture|.{{GPUTexture/usage}} contains {{GPUTextureUsage/COPY_SRC}}.
+                        - |srcTexture|.{{GPUTexture/sampleCount}} is 1.
+                        - Let |aspectSpecificFormat| = |srcTexture|.{{GPUTexture/format}}.
+                        - If |srcTexture|.{{GPUTexture/format}} is a [=depth-or-stencil format=] format:
                             - |source|.{{GPUImageCopyTexture/aspect}} must refer to a single aspect of
-                                |srcTextureDesc|.{{GPUTextureDescriptor/format}}.
+                                |srcTexture|.{{GPUTexture/format}}.
                             - That aspect must be a valid image copy source according to [[#depth-formats]].
                             - Set |aspectSpecificFormat| to the [=aspect-specific format=] according to [[#depth-formats]].
                         - [$validating GPUImageCopyBuffer$](|destination|) returns `true`.
                         - |destination|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/usage}} contains
                             {{GPUBufferUsage/COPY_DST}}.
                         - [=validating texture copy range=](|source|, |copySize|) returns `true`.
-                        - If |srcTextureDesc|.{{GPUTextureDescriptor/format}} is not a [=depth-or-stencil format=]:
+                        - If |srcTexture|.{{GPUTexture/format}} is not a [=depth-or-stencil format=]:
                             - |destination|.{{GPUImageDataLayout/offset}} is a multiple of the [=texel block size=] of
-                                |srcTextureDesc|.{{GPUTextureDescriptor/format}}.
-                        - If |srcTextureDesc|.{{GPUTextureDescriptor/format}} is a [=depth-or-stencil format=]:
+                                |srcTexture|.{{GPUTexture/format}}.
+                        - If |srcTexture|.{{GPUTexture/format}} is a [=depth-or-stencil format=]:
                             - |destination|.{{GPUImageDataLayout/offset}} is a multiple of 4.
                         - [$validating linear texture data$](|destination|,
                             |destination|.{{GPUImageCopyBuffer/buffer}}.{{GPUBuffer/size}},
@@ -8442,19 +8479,19 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
-                        - Let |srcTextureDesc| be |source|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
-                        - Let |dstTextureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
+                        - Let |srcTexture| be |source|.{{GPUImageCopyTexture/texture}}.
+                        - Let |dstTexture| be |destination|.{{GPUImageCopyTexture/texture}}.
                         - [$validating GPUImageCopyTexture$](|source|, |copySize|) returns `true`.
-                        - |srcTextureDesc|.{{GPUTextureDescriptor/usage}} contains {{GPUTextureUsage/COPY_SRC}}.
+                        - |srcTexture|.{{GPUTexture/usage}} contains {{GPUTextureUsage/COPY_SRC}}.
                         - [$validating GPUImageCopyTexture$](|destination|, |copySize|) returns `true`.
-                        - |dstTextureDesc|.{{GPUTextureDescriptor/usage}} contains {{GPUTextureUsage/COPY_DST}}.
-                        - |srcTextureDesc|.{{GPUTextureDescriptor/sampleCount}} is equal to |dstTextureDesc|.{{GPUTextureDescriptor/sampleCount}}.
-                        - |srcTextureDesc|.{{GPUTextureDescriptor/format}} and |dstTextureDesc|.{{GPUTextureDescriptor/format}}
+                        - |dstTexture|.{{GPUTexture/usage}} contains {{GPUTextureUsage/COPY_DST}}.
+                        - |srcTexture|.{{GPUTexture/sampleCount}} is equal to |dstTexture|.{{GPUTexture/sampleCount}}.
+                        - |srcTexture|.{{GPUTexture/format}} and |dstTexture|.{{GPUTexture/format}}
                             must be [=copy-compatible=].
-                        - If |srcTextureDesc|.{{GPUTextureDescriptor/format}} is a depth-stencil format:
+                        - If |srcTexture|.{{GPUTexture/format}} is a depth-stencil format:
                             - |source|.{{GPUImageCopyTexture/aspect}} and |destination|.{{GPUImageCopyTexture/aspect}}
-                                must both refer to all aspects of |srcTextureDesc|.{{GPUTextureDescriptor/format}}
-                                and |dstTextureDesc|.{{GPUTextureDescriptor/format}}, respectively.
+                                must both refer to all aspects of |srcTexture|.{{GPUTexture/format}}
+                                and |dstTexture|.{{GPUTexture/format}}, respectively.
                         - [=validating texture copy range=](|source|, |copySize|) returns `true`.
                         - [=validating texture copy range=](|destination|, |copySize|) returns `true`.
                         - The [$set of subresources for texture copy$](|source|, |copySize|) and
@@ -8478,7 +8515,7 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
     The <dfn abstract-op>set of subresources for texture copy</dfn>(|imageCopyTexture|, |copySize|)
     is the set containing:
 
-      - If |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/dimension}}
+      - If |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/dimension}}
         is {{GPUTextureDimension/"2d"}}:
           - For each |arrayLayer| of the |copySize|.[=Extent3D/depthOrArrayLayers=] [=array layers=]
             starting at |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/z=]:
@@ -9335,7 +9372,7 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
 
     1. All {{GPURenderPassColorAttachment/view}}s in non-`null` members of |this|.{{GPURenderPassDescriptor/colorAttachments}},
         and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachment/view}}
-        if present, must have equal {{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}}s.
+        if present, must have equal {{GPUTexture/sampleCount}}s.
 
     1. For each {{GPURenderPassColorAttachment/view}} in non-`null` members of |this|.{{GPURenderPassDescriptor/colorAttachments}}
         and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachment/view}},
@@ -9463,16 +9500,16 @@ dictionary GPURenderPassColorAttachment {
 
     1. Let |renderViewDescriptor| be |this|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.
     1. Let |resolveViewDescriptor| be |this|.{{GPURenderPassColorAttachment/resolveTarget}}.{{GPUTextureView/[[descriptor]]}}.
-    1. Let |renderTextureDescriptor| be |this|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.
-    1. Let |resolveTextureDescriptor| be |this|.{{GPURenderPassColorAttachment/resolveTarget}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.
+    1. Let |renderTexture| be |this|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.
+    1. Let |resolveTexture| be |this|.{{GPURenderPassColorAttachment/resolveTarget}}.{{GPUTextureView/[[texture]]}}.
 
     The following validation rules apply:
 
     - |renderViewDescriptor|.{{GPUTextureViewDescriptor/format}} must be a [=color renderable format=].
     - |this|.{{GPURenderPassColorAttachment/view}} must be a [$renderable texture view$].
     - If |this|.{{GPURenderPassColorAttachment/resolveTarget}} is not `null`:
-        - |renderTextureDescriptor|.{{GPUTextureDescriptor/sampleCount}} must be greater than 1.
-        - |resolveTextureDescriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
+        - |renderTexture|.{{GPUTexture/sampleCount}} must be greater than 1.
+        - |resolveTexture|.{{GPUTexture/sampleCount}} must be 1.
         - |this|.{{GPURenderPassColorAttachment/resolveTarget}} must be a [$renderable texture view$].
         - The sizes of the [=subresource=]s seen by |this|.{{GPURenderPassColorAttachment/resolveTarget}}
             and |this|.{{GPURenderPassColorAttachment/view}} must match.
@@ -9485,7 +9522,7 @@ dictionary GPURenderPassColorAttachment {
     A {{GPUTextureView}} |view| is a <dfn abstract-op>renderable texture view</dfn>
     if the following requirements are met:
 
-    - |view|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/usage}}
+    - |view|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/usage}}
         must contain {{GPUTextureUsage/RENDER_ATTACHMENT}}.
     - |descriptor|.{{GPUTextureViewDescriptor/dimension}} must be {{GPUTextureViewDimension/"2d"}}.
     - |descriptor|.{{GPUTextureViewDescriptor/mipLevelCount}} must be 1.
@@ -9666,14 +9703,14 @@ dictionary GPURenderPassLayout: GPUObjectDescriptorBase {
     1. Let |layout| be a new {{GPURenderPassLayout}} object.
     1. For each |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
         1. If |colorAttachment| is not `null`:
-            1. Set |layout|.{{GPURenderPassLayout/sampleCount}} to |colorAttachment|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}}.
+            1. Set |layout|.{{GPURenderPassLayout/sampleCount}} to |colorAttachment|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/sampleCount}}.
             1. Append |colorAttachment|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}} to |layout|.{{GPURenderPassLayout/colorFormats}}.
         1. Otherwise:
             1. Append `null` to |layout|.{{GPURenderPassLayout/colorFormats}}.
     1. Let |depthStencilAttachment| be |descriptor|.{{GPURenderPassDescriptor/depthStencilAttachment}}.
     1. If |depthStencilAttachment| is not `null`:
         1. Let |view| be |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/view}}.
-        1. Set |layout|.{{GPURenderPassLayout/sampleCount}} to |view|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/[[descriptor]]}}.{{GPUTextureDescriptor/sampleCount}}.
+        1. Set |layout|.{{GPURenderPassLayout/sampleCount}} to |view|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/sampleCount}}.
         1. Set |layout|.{{GPURenderPassLayout/depthStencilFormat}} to |view|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
     1. Return |layout|.
 
@@ -10632,7 +10669,7 @@ GPUQueue includes GPUObjectBase;
 
             1. Let |dataBytes| be [=get a copy of the buffer source|a copy of the bytes held by the buffer source=] |data|.
             1. Let |dataByteSize| be the number of bytes in |dataBytes|.
-            1. Let |textureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
+            1. Let |texture| be |destination|.{{GPUImageCopyTexture/texture}}.
             1. Let |contents| be the contents of the [=images=] seen by
                 viewing |dataBytes| with |dataLayout| and |size|.
 
@@ -10643,15 +10680,15 @@ GPUQueue includes GPUObjectBase;
                         [$generate a validation error$] and stop.
                         <div class=validusage>
                             - [$validating GPUImageCopyTexture$](|destination|, |size|) returns `true`.
-                            - |textureDesc|.{{GPUTextureDescriptor/usage}} includes {{GPUTextureUsage/COPY_DST}}.
-                            - |textureDesc|.{{GPUTextureDescriptor/sampleCount}} is 1.
+                            - |texture|.{{GPUTexture/usage}} includes {{GPUTextureUsage/COPY_DST}}.
+                            - |texture|.{{GPUTexture/sampleCount}} is 1.
                             - [=validating texture copy range=](|destination|, |size|) return `true`.
                             - |destination|.{{GPUImageCopyTexture/aspect}} must refer to a single aspect of
-                                |textureDesc|.{{GPUTextureDescriptor/format}}.
+                                |texture|.{{GPUTexture/format}}.
                             - That aspect must be a valid image copy destination according to [[#depth-formats]].
-                            - Let |aspectSpecificFormat| = |textureDesc|.{{GPUTextureDescriptor/format}}.
-                            - If |textureDesc|.{{GPUTextureDescriptor/format}} is a [=depth-or-stencil format=]:
-                                - Set |aspectSpecificFormat| to the [=aspect-specific format=] of |textureDesc|.{{GPUTextureDescriptor/format}} according to [[#depth-formats]].
+                            - Let |aspectSpecificFormat| = |texture|.{{GPUTexture/format}}.
+                            - If |texture|.{{GPUTexture/format}} is a [=depth-or-stencil format=]:
+                                - Set |aspectSpecificFormat| to the [=aspect-specific format=] of |texture|.{{GPUTexture/format}} according to [[#depth-formats]].
                             - [$validating linear texture data$](|dataLayout|,
                                 |dataByteSize|,
                                 |aspectSpecificFormat|,
@@ -10712,17 +10749,17 @@ GPUQueue includes GPUObjectBase;
                 </div>
             1. Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
-                    1. Let |textureDesc| be |destination|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/[[descriptor]]}}.
+                    1. Let |texture| be |destination|.{{GPUImageCopyTexture/texture}}.
                     1. If any of the following requirements are unmet, [$generate a validation error$] and stop.
                         <div class=validusage>
                             - |destination|.{{GPUImageCopyTexture/texture}} must be [$valid to use with$] |this|.
                             - [$validating GPUImageCopyTexture$](destination, copySize) must return `true`.
                             - [=validating texture copy range=](destination, copySize) must return `true`.
-                            - |textureDesc|.{{GPUTextureDescriptor/usage}} must include both
+                            - |texture|.{{GPUTexture/usage}} must include both
                                 {{GPUTextureUsage/RENDER_ATTACHMENT}} and {{GPUTextureUsage/COPY_DST}}.
-                            - |textureDesc|.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"2d"}}.
-                            - |textureDesc|.{{GPUTextureDescriptor/sampleCount}} must be 1.
-                            - |textureDesc|.{{GPUTextureDescriptor/format}} must be one of the following
+                            - |texture|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
+                            - |texture|.{{GPUTexture/sampleCount}} must be 1.
+                            - |texture|.{{GPUTexture/format}} must be one of the following
                                 formats (which all support {{GPUTextureUsage/RENDER_ATTACHMENT}} usage):
                                 - {{GPUTextureFormat/"r8unorm"}}
                                 - {{GPUTextureFormat/"r16float"}}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2440,17 +2440,21 @@ interface GPUBuffer {
 GPUBuffer includes GPUObjectBase;
 </script>
 
-{{GPUBuffer}} has the following internal slots:
+{{GPUBuffer}} has the following attributes:
 
 <dl dfn-type=attribute dfn-for="GPUBuffer">
-    : <dfn>size</dfn> of type {{GPUSize64}}.
+    : <dfn>size</dfn>
     ::
         The length of the {{GPUBuffer}} allocation in bytes.
 
-    : <dfn>usage</dfn> of type {{GPUBufferUsageFlags}}.
+    : <dfn>usage</dfn>
     ::
         The allowed usages for this {{GPUBuffer}}.
+</dl>
 
+{{GPUBuffer}} has the following internal slots:
+
+<dl dfn-type=attribute dfn-for="GPUBuffer">
     : <dfn>\[[state]]</dfn> of type [=buffer state=].
     ::
         The current state of the {{GPUBuffer}}.
@@ -2980,7 +2984,9 @@ interface GPUTexture {
 
     undefined destroy();
 
-    [SameObject] readonly attribute GPUExtent3DReadOnly size;
+    readonly attribute GPUIntegerCoordinate width;
+    readonly attribute GPUIntegerCoordinate height;
+    readonly attribute GPUIntegerCoordinate depthOrArrayLayers;
     readonly attribute GPUIntegerCoordinate mipLevelCount;
     readonly attribute GPUSize32 sampleCount;
     readonly attribute GPUTextureDimension dimension;
@@ -2990,34 +2996,48 @@ interface GPUTexture {
 GPUTexture includes GPUObjectBase;
 </script>
 
-{{GPUTexture}} has the following internal slots:
+{{GPUTexture}} has the following attributes:
 
 <dl dfn-type=attribute dfn-for="GPUTexture">
-    : <dfn>size</dfn>, of type {{GPUExtent3DReadOnly}}
+    : <dfn>width</dfn>
     ::
-        The width, height, and depth or layer count of this {{GPUTexture}}.
+        The width of this {{GPUTexture}}.
 
-        Note: It is a {{GPUExtent3DDict}} with all fields set instead of a {{GPUExtent3D}} union type.
+    : <dfn>height</dfn>
+    ::
+        The height of this {{GPUTexture}}.
 
-    : <dfn>mipLevelCount</dfn>, of type {{GPUIntegerCoordinate}}
+    : <dfn>depthOrArrayLayers</dfn>
+    ::
+        The depth or layer count of this {{GPUTexture}}.
+
+    : <dfn>mipLevelCount</dfn>
     ::
         The number of mip levels of this {{GPUTexture}}.
 
-    : <dfn>sampleCount</dfn>, of type {{GPUSize32}}
+    : <dfn>sampleCount</dfn>
     ::
         The number of sample count of this {{GPUTexture}}.
 
-    : <dfn>dimension</dfn>, of type {{GPUTextureDimension}}
+    : <dfn>dimension</dfn>
     ::
         The dimension of the set of texel for each of this {{GPUTexture}}'s subresources.
 
-    : <dfn>format</dfn>, of type {{GPUTextureFormat}}
+    : <dfn>format</dfn>
     ::
         The format of this {{GPUTexture}}.
 
-    : <dfn>usage</dfn>, of type {{GPUTextureUsage}}
+    : <dfn>usage</dfn>
     ::
         The allowed usages for this {{GPUTexture}}.
+</dl>
+
+{{GPUTexture}} has the following internal slots:
+
+<dl dfn-type=attribute dfn-for="GPUTexture">
+    : <dfn>\[[size]]</dfn>, of type {{GPUExtent3D}}
+    ::
+        The size of the texture (same as {{GPUTexture/width}}, {{GPUTexture/height}}, {{GPUTexture/depthOrArrayLayers}}).
 
     : <dfn>\[[viewFormats]]</dfn>, of type sequence&lt;{{GPUTextureFormat}}&gt;
     ::
@@ -3034,14 +3054,14 @@ GPUTexture includes GPUObjectBase;
     <dfn abstract-op>compute render extent</dfn>(baseSize, mipLevel)
 
     **Arguments:**
-        - {{GPUExtent3DReadOnly}} |baseSize|
+        - {{GPUExtent3D}} |baseSize|
         - {{GPUSize32}} |mipLevel|
 
     **Returns:** {{GPUExtent3DDict}}
 
     1. Let |extent| be a new {{GPUExtent3DDict}} object.
-    1. Set |extent|.{{GPUExtent3DDict/width}} to max(1, |baseSize|.{{GPUExtent3DReadOnly/width}} &Gt; |mipLevel|).
-    1. Set |extent|.{{GPUExtent3DDict/height}} to max(1, |baseSize|.{{GPUExtent3DReadOnly/height}} &Gt; |mipLevel|).
+    1. Set |extent|.{{GPUExtent3DDict/width}} to max(1, |baseSize|.[=Extent3D/width=] &Gt; |mipLevel|).
+    1. Set |extent|.{{GPUExtent3DDict/height}} to max(1, |baseSize|.[=Extent3D/height=] &Gt; |mipLevel|).
     1. Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to 1.
     1. Return |extent|.
 </div>
@@ -3239,15 +3259,15 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
                         <div class=validusage>
                             - [$validating GPUTextureDescriptor$](|this|, |descriptor|) returns `true`.
                         </div>
-                    1. Set |t|.{{GPUTexture/size}} to a new {{GPUExtent3DReadOnly}} with the following fields set:
-                        1. {{GPUExtent3DReadOnly/width}} set to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=].
-                        1. {{GPUExtent3DReadOnly/height}} set to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=].
-                        1. {{GPUExtent3DReadOnly/depthOrArrayLayers}} set to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=].
+                    1. Set |t|.{{GPUTexture/width}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=].
+                    1. Set |t|.{{GPUTexture/height}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=].
+                    1. Set |t|.{{GPUTexture/depthOrArrayLayers}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=].
                     1. Set |t|.{{GPUTexture/mipLevelCount}} to |descriptor|.{{GPUTextureDescriptor/mipLevelCount}}.
                     1. Set |t|.{{GPUTexture/sampleCount}} to |descriptor|.{{GPUTextureDescriptor/sampleCount}}.
                     1. Set |t|.{{GPUTexture/dimension}} to |descriptor|.{{GPUTextureDescriptor/dimension}}.
                     1. Set |t|.{{GPUTexture/format}} to |descriptor|.{{GPUTextureDescriptor/format}}.
                     1. Set |t|.{{GPUTexture/usage}} to |descriptor|.{{GPUTextureDescriptor/usage}}.
+                    1. Set |t|.{{GPUTexture/[[size]]}} to |descriptor|.{{GPUTextureDescriptor/size}}.
                     1. Set |t|.{{GPUTexture/[[viewFormats]]}} to |descriptor|.{{GPUTextureDescriptor/viewFormats}}.
                 </div>
             1. Return |t|.
@@ -3615,14 +3635,12 @@ enum GPUTextureAspect {
                                     : {{GPUTextureViewDimension/"cube"}}
                                     :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
                                     :: |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `6`.
-                                    :: |this|.{{GPUTexture/size}}.{{GPUExtent3DReadOnly/width}} must be equal to
-                                        |this|.{{GPUTexture/size}}.{{GPUExtent3DReadOnly/height}}.
+                                    :: |this|.{{GPUTexture/width}} must be equal to |this|.{{GPUTexture/height}}.
 
                                     : {{GPUTextureViewDimension/"cube-array"}}
                                     :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
                                     :: |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be a multiple of `6`.
-                                    :: |this|.{{GPUTexture/size}}.{{GPUExtent3DReadOnly/width}} must be equal to
-                                        |this|.{{GPUTexture/size}}.{{GPUExtent3DReadOnly/height}}.
+                                    :: |this|.{{GPUTexture/width}} must be equal to |this|.{{GPUTexture/height}}.
 
                                     : {{GPUTextureViewDimension/"3d"}}
                                     :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"3d"}}.
@@ -3634,7 +3652,7 @@ enum GPUTextureAspect {
                     1. Set |view|.{{GPUTextureView/[[texture]]}} to |this|.
                     1. Set |view|.{{GPUTextureView/[[descriptor]]}} to |descriptor|.
                     1. If |this|.{{GPUTexture/usage}} contains {{GPUTextureUsage/RENDER_ATTACHMENT}}:
-                        1. Let |renderExtent| be [$compute render extent$](|this|.{{GPUTexture/size}}, |descriptor|.{{GPUTextureViewDescriptor/baseMipLevel}}).
+                        1. Let |renderExtent| be [$compute render extent$](|this|.{{GPUTexture/[[size]]}}, |descriptor|.{{GPUTextureViewDescriptor/baseMipLevel}}).
                         1. Set |view|.{{GPUTextureView/[[renderExtent]]}} to |renderExtent|.
                 </div>
             1. Return |view|.
@@ -3702,7 +3720,7 @@ enum GPUTextureAspect {
                 :: Return `1`.
 
                 : {{GPUTextureDimension/"2d"}}
-                :: Return |texture|.{{GPUTexture/size}}.{{GPUExtent3DReadOnly/depthOrArrayLayers}}.
+                :: Return |texture|.{{GPUTexture/depthOrArrayLayers}}.
             </dl>
 </div>
 
@@ -10850,17 +10868,21 @@ interface GPUQuerySet {
 GPUQuerySet includes GPUObjectBase;
 </script>
 
-{{GPUQuerySet}} has the following internal slots:
+{{GPUQuerySet}} has the following attributes:
 
 <dl dfn-type=attribute dfn-for="GPUQuerySet">
-    : <dfn>type</dfn> of type {{GPUQueryType}}.
+    : <dfn>type</dfn>
     ::
         The type of the queries managed by this {{GPUQuerySet}}.
 
-    : <dfn>count</dfn> of type {{GPUSize32}}.
+    : <dfn>count</dfn>
     ::
         The number of queries managed by this {{GPUQuerySet}}.
+</dl>
 
+{{GPUQuerySet}} has the following internal slots:
+
+<dl dfn-type=attribute dfn-for="GPUQuerySet">
     : <dfn>\[[state]]</dfn> of type [=query set state=].
     ::
         The current state of the {{GPUQuerySet}}.
@@ -12584,19 +12606,6 @@ An <dfn dfn>Extent3D</dfn> is a {{GPUExtent3D}}.
         either {{GPUExtent3DDict}}.{{GPUExtent3DDict/depthOrArrayLayers}}
         or the third item of the sequence (1 if not present).
 </div>
-
-<script type=idl>
-[Exposed=(Window, DedicatedWorker), SecureContext]
-interface GPUExtent3DReadOnly {
-    readonly attribute GPUIntegerCoordinate width;
-    readonly attribute GPUIntegerCoordinate height;
-    readonly attribute GPUIntegerCoordinate depthOrArrayLayers;
-};
-</script>
-
-A <dfn interface>GPUExtent3DReadOnly</dfn> is like a read-only {{GPUExtent3D}}.
-It is used to output values from the API back to the application, such as for reflection
-of a texture's size, where a {{GPUExtent3DDict}} (an "input" type) isn't appropriate.
 
 # Feature Index # {#feature-index}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3037,7 +3037,8 @@ GPUTexture includes GPUObjectBase;
 <dl dfn-type=attribute dfn-for="GPUTexture">
     : <dfn>\[[size]]</dfn>, of type {{GPUExtent3D}}
     ::
-        The size of the texture (same as {{GPUTexture/width}}, {{GPUTexture/height}}, {{GPUTexture/depthOrArrayLayers}}).
+        The size of the texture (same as the {{GPUTexture/width}}, {{GPUTexture/height}}, and
+        {{GPUTexture/depthOrArrayLayers}} attributes).
 
     : <dfn>\[[viewFormats]]</dfn>, of type sequence&lt;{{GPUTextureFormat}}&gt;
     ::

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12594,9 +12594,9 @@ interface GPUExtent3DReadOnly {
 };
 </script>
 
-A <dfn interface>GPUExtent3DReadOnly</dfn> is an equivalent to [=Extent3D=]
-that's an interface with all members required. It is used for interface attributes in lieu
-of the dictionary {{GPUExtent3DDict}} as WebIDL forbids dictionary attributes.
+A <dfn interface>GPUExtent3DReadOnly</dfn> is like a read-only {{GPUExtent3D}}.
+It is used to output values from the API back to the application, such as for reflection
+of a texture's size, where a {{GPUExtent3DDict}} (an "input" type) isn't appropriate.
 
 # Feature Index # {#feature-index}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8553,8 +8553,8 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
                     1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                         <div class=validusage>
                             - |querySet| is [$valid to use with$] |this|.
-                            - |querySet|.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/"timestamp"}}.
-                            - |queryIndex| &lt; |querySet|.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}}.
+                            - |querySet|.{{GPUQuerySet/type}} is {{GPUQueryType/"timestamp"}}.
+                            - |queryIndex| &lt; |querySet|{{GPUQuerySet/count}}.
                         </div>
 
                     Issue: Describe {{GPUCommandEncoder/writeTimestamp()}} algorithm steps.
@@ -9043,9 +9043,9 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
 
     1. For each |timestampWrite| in |this|.{{GPUComputePassDescriptor/timestampWrites}}:
 
-        1. |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/"timestamp"}}.
+        1. |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}}.{{GPUQuerySet/type}} is {{GPUQueryType/"timestamp"}}.
 
-        1. |timestampWrite|.{{GPUComputePassTimestampWrite/queryIndex}} &lt; |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}}.
+        1. |timestampWrite|.{{GPUComputePassTimestampWrite/queryIndex}} &lt; |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}}.{{GPUQuerySet/count}}.
 </div>
 
 ### Dispatch ### {#compute-pass-encoder-dispatch}
@@ -9380,16 +9380,16 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
 
     1. If |this|.{{GPURenderPassDescriptor/occlusionQuerySet}} is not `null`:
 
-        1. |this|.{{GPURenderPassDescriptor/occlusionQuerySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/type}}
+        1. |this|.{{GPURenderPassDescriptor/occlusionQuerySet}}.{{GPUQuerySet/type}}
             must be {{GPUQueryType/occlusion}}.
 
     1. No two entries in |this|.{{GPURenderPassDescriptor/timestampWrites}} have the same {{GPURenderPassTimestampWrite/location}}.
 
     1. For each |timestampWrite| in |this|.{{GPURenderPassDescriptor/timestampWrites}}:
 
-        1. |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/"timestamp"}}.
+        1. |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}}.{{GPUQuerySet/type}} is {{GPUQueryType/"timestamp"}}.
 
-        1. |timestampWrite|.{{GPURenderPassTimestampWrite/queryIndex}} &lt; |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}}.
+        1. |timestampWrite|.{{GPURenderPassTimestampWrite/queryIndex}} &lt; |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}}.{{GPUQuerySet/count}}.
 
         1. |timestampWrite|.{{GPURenderPassTimestampWrite/queryIndex}} is written at most once in the same |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}} in this render pass.
 
@@ -10334,7 +10334,7 @@ attachments used by this encoder.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
                     <div class=validusage>
                         - |this|.{{GPURenderPassEncoder/[[occlusion_query_set]]}} is not `null`.
-                        - |queryIndex| &lt; |this|.{{GPURenderPassEncoder/[[occlusion_query_set]]}}.{{GPUQuerySet/[[descriptor]]}}.{{GPUQuerySetDescriptor/count}}.
+                        - |queryIndex| &lt; |this|.{{GPURenderPassEncoder/[[occlusion_query_set]]}}.{{GPUQuerySet/count}}.
                         - The query at same |queryIndex| must not have been previously written to in this pass.
                         - |this|.{{GPURenderPassEncoder/[[occlusion_query_active]]}} is `false`.
                     </div>
@@ -10843,6 +10843,9 @@ Queries {#queries}
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUQuerySet {
     undefined destroy();
+
+    readonly attribute GPUQueryType type;
+    readonly attribute GPUSize32 count;
 };
 GPUQuerySet includes GPUObjectBase;
 </script>
@@ -10850,11 +10853,13 @@ GPUQuerySet includes GPUObjectBase;
 {{GPUQuerySet}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUQuerySet">
-    : <dfn>\[[descriptor]]</dfn>, of type {{GPUQuerySetDescriptor}}
+    : <dfn>type</dfn> of type {{GPUQueryType}}.
     ::
-        The {{GPUQuerySetDescriptor}} describing this query set.
+        The type of the queries managed by this {{GPUQuerySet}}.
 
-        All optional fields of {{GPUTextureViewDescriptor}} are defined.
+    : <dfn>count</dfn> of type {{GPUSize32}}.
+    ::
+        The number of queries managed by this {{GPUQuerySet}}.
 
     : <dfn>\[[state]]</dfn> of type [=query set state=].
     ::
@@ -10918,7 +10923,8 @@ dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
                             - |descriptor|.{{GPUQuerySetDescriptor/count}} must be &le; 8192.
                         </div>
                     1. Let |q| be a new {{GPUQuerySet}} object.
-                    1. Set |q|.{{GPUQuerySet/[[descriptor]]}} to |descriptor|.
+                    1. Set |q|.{{GPUQuerySet/type}} to |descriptor|.{{GPUQuerySetDescriptor/type}}.
+                    1. Set |q|.{{GPUQuerySet/count}} to |descriptor|.{{GPUQuerySetDescriptor/count}}.
                     1. Set |q|.{{GPUQuerySet/[[state]]}} to [=query set state/available=].
                 </div>
             1. Return |q|.


### PR DESCRIPTION
This PR adds reflection, but only for container objects: `GPUBuffer`, `GPUTexture` and `GPUQuerySet`. The intent is to expose information that's the most useful, but also doesn't add a lot of implementation cost. (exposing all descrriptors of all objects would be non-trivial and expensive at runtime).

Issue: #1498


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Kangz/gpuweb/pull/2919.html" title="Last updated on Jun 3, 2022, 10:30 PM UTC (be548cb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2919/b487c44...Kangz:be548cb.html" title="Last updated on Jun 3, 2022, 10:30 PM UTC (be548cb)">Diff</a>