### PR TITLE
[wgsl]: Remove interpolation tokens from reserved words

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9395,8 +9395,6 @@ The following are reserved words:
 
     | `'cbuffer'`   <!-- HLSL -->
 
-    | `'centroid'`   <!-- HLSL GLSL -->
-
     | `'char'`   <!-- C++ -->
 
     | `'class'`   <!-- C++ ECMAScript2022 HLSL GLSL(reserved) -->
@@ -9466,8 +9464,6 @@ The following are reserved words:
     | `'finally'`   <!-- ECMAScript2022 -->
 
     | `'fixed'`   <!-- GLSL(reserved) -->
-
-    | `'flat'`   <!-- GLSL -->
 
     | `'friend'`   <!-- C++ -->
 
@@ -9617,8 +9613,6 @@ The following are reserved words:
 
     | `'lineadj'`   <!-- HLSL -->
 
-    | `'linear'`   <!-- HLSL -->
-
     | `'lowp'`   <!-- GLSL -->
 
     | `'macro'`   <!-- Rust -->
@@ -9714,8 +9708,6 @@ The following are reserved words:
     | `'row_major'`   <!-- HLSL -->
 
     | `'samper'`   <!-- HLSL -->
-
-    | `'sample'`   <!-- HLSL GLSL -->
 
     | `'sampler1D'`   <!-- GLSL -->
 

--- a/wgsl/keywords
+++ b/wgsl/keywords
@@ -416,6 +416,7 @@ bitcast
 bool
 break
 case
+centroid
 const
 continue
 continuing
@@ -427,12 +428,14 @@ f16
 f32
 fallthrough
 false
+flat
 fn
 for
 function
 i32
 if
 let
+linear
 loop
 mat2x2
 mat2x3
@@ -447,6 +450,7 @@ override
 private
 ptr
 return
+sample
 sampler
 sampler_comparison
 storage


### PR DESCRIPTION
This PR removes some reserved words which are used in the interpolation
attribute.

Issue #2913