### PR TITLE
mapAsync(WRITE) and zero-filling

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2837,6 +2837,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                 <div class=queue-timeline>
                     1. If |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapping pending=]:
 
+                        1. If |mode| contains {{GPUMapMode/WRITE}}, fill |this|'s allocation with 0s starting at offset |offset| and for |rangeSize| bytes.
                         1. Let |m| be a new {{ArrayBuffer}} of size |rangeSize|.
                         1. Set the content of |m| to the content of |this|'s allocation starting at offset |offset| and for |rangeSize| bytes.
                         1. Set |this|.{{GPUBuffer/[[mapping]]}} to |m|.


### PR DESCRIPTION
This is required to make UMA and non-UMA devices behave portably.

It would be unfortunate if we had to run `memset()` on the CPU for triply-mapped buffers on UMA (GPU Process, web process, and GPU). The only way to offload the zero-filling work to the GPU is to do it in `mapAsync()`, and if we do it in `mapAsync()` then it has to clear the whole mapped region (not just the regions `getMappedRange()` is called on).

(I also didn't see anything in the definition of `getMappedRange()` about zero-filling so I'm assuming this is just an oversight.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/litherum/gpuweb/pull/2926.html" title="Last updated on May 22, 2022, 3:07 AM UTC (ae7350e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2926/2e1999f...litherum:ae7350e.html" title="Last updated on May 22, 2022, 3:07 AM UTC (ae7350e)">Diff</a>