### PR TITLE
Specify the meaning of `Foo.Interface`.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -10407,7 +10407,7 @@ GPURenderBundleEncoder includes GPURenderCommandsMixin;
                                     - |descriptor|.{{GPURenderBundleEncoderDescriptor/depthReadOnly}} must be equal to
                                         |descriptor|.{{GPURenderBundleEncoderDescriptor/stencilReadOnly}}
                         </div>
-                    1. Set |e|.{{GPURenderCommandsMixin/[[layout]]}} to |descriptor|.{{GPURenderPassLayout}}.
+                    1. Set |e|.{{GPURenderCommandsMixin/[[layout]]}} to a copy of |descriptor|'s included {{GPURenderPassLayout}} interface.
                     1. Set |e|.{{GPURenderCommandsMixin/[[depthReadOnly]]}} to |descriptor|.{{GPURenderBundleEncoderDescriptor/depthReadOnly}}.
                     1. Set |e|.{{GPURenderCommandsMixin/[[stencilReadOnly]]}} to |descriptor|.{{GPURenderBundleEncoderDescriptor/stencilReadOnly}}.
                     1. Set |e|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/open=]".
@@ -11816,7 +11816,7 @@ clip space positions for [[#primitive-clipping]], as well as other data for the
     1. For each {{GPUBindGroup}} group at |index| in |state|.[=RenderState/bindGroups=]:
         1. For each resource {{GPUBindingResource}} in the bind group:
             1. Let |entry| be the corresponding {{GPUBindGroupLayoutEntry}} for this resource.
-            1. If |entry|.{{GPUBindGroupLayoutEntry}}.visibility includes {{GPUShaderStage/VERTEX}}:
+            1. If |entry|.{{GPUBindGroupLayoutEntry/visibility}} includes {{GPUShaderStage/VERTEX}}:
                 - Bind the resource to the shader under group |index| and binding {{GPUBindGroupLayoutEntry/binding|GPUBindGroupLayoutEntry.binding}}.
     1. Set the shader [=builtins=]:
         - Set the `vertex_index` builtin, if any, to |vertexIndex|.


### PR DESCRIPTION
This syntax is used in, for example, the specification of
**createRenderBundleEncoder**, which includes the step:

> Set `e.[[layout]]` to `descriptor.GPURenderPassLayout`.

In this case, `descriptor` implements
`GPURenderBundleEncoderDescriptor`, which includes
`GPURenderPassLayout`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jimblandy/gpuweb/pull/2928.html" title="Last updated on May 31, 2022, 10:26 PM UTC (fdaa16e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2928/c384f79...jimblandy:fdaa16e.html" title="Last updated on May 31, 2022, 10:26 PM UTC (fdaa16e)">Diff</a>