### PR TITLE
OOB check in draw calls should ignore empty vertex buffer slots

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9901,6 +9901,7 @@ It must only be included by interfaces which also include those mixins.
                         - It is [$valid to draw$] with |this|.
                         - Let |buffers| be |this|.{{GPURenderCommandsMixin/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}.
                         - For each {{GPUIndex32}} |slot| from `0` to |buffers|.length (non-inclusive):
+                            - Continue if |buffers|[|slot|] is `null`
                             - Let |bufferSize| be |this|.{{GPURenderCommandsMixin/[[vertex_buffer_sizes]]}}[|slot|].
                             - Let |stride| be |buffers|[|slot|].{{GPUVertexBufferLayout/arrayStride}}.
                             - Let |lastStride| be max(|attribute|.{{GPUVertexAttribute/offset}} &plus; sizeof(|attribute|.{{GPUVertexAttribute/format}}))
@@ -9947,6 +9948,7 @@ It must only be included by interfaces which also include those mixins.
                             &div; |this|.{{GPURenderCommandsMixin/[[index_format]]}}'s byte size;
                         - Let |buffers| be |this|.{{GPURenderCommandsMixin/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}.
                         - For each {{GPUIndex32}} |slot| from `0` to |buffers|.length (non-inclusive):
+                            - Continue if |buffers|[|slot|] is `null`
                             - Let |bufferSize| be |this|.{{GPURenderCommandsMixin/[[vertex_buffer_sizes]]}}[|slot|].
                             - Let |stride| be |buffers|[|slot|].{{GPUVertexBufferLayout/arrayStride}}.
                             - Let |lastStride| be max(|attribute|.{{GPUVertexAttribute/offset}} &plus; sizeof(|attribute|.{{GPUVertexAttribute/format}}))

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9901,7 +9901,7 @@ It must only be included by interfaces which also include those mixins.
                         - It is [$valid to draw$] with |this|.
                         - Let |buffers| be |this|.{{GPURenderCommandsMixin/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}.
                         - For each {{GPUIndex32}} |slot| from `0` to |buffers|.length (non-inclusive):
-                            - Continue if |buffers|[|slot|] is `null`
+                            - If |buffers|[|slot|] is `null`, [=iteration/continue=].
                             - Let |bufferSize| be |this|.{{GPURenderCommandsMixin/[[vertex_buffer_sizes]]}}[|slot|].
                             - Let |stride| be |buffers|[|slot|].{{GPUVertexBufferLayout/arrayStride}}.
                             - Let |lastStride| be max(|attribute|.{{GPUVertexAttribute/offset}} &plus; sizeof(|attribute|.{{GPUVertexAttribute/format}}))
@@ -9948,7 +9948,7 @@ It must only be included by interfaces which also include those mixins.
                             &div; |this|.{{GPURenderCommandsMixin/[[index_format]]}}'s byte size;
                         - Let |buffers| be |this|.{{GPURenderCommandsMixin/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}.
                         - For each {{GPUIndex32}} |slot| from `0` to |buffers|.length (non-inclusive):
-                            - Continue if |buffers|[|slot|] is `null`
+                            - If |buffers|[|slot|] is `null`, [=iteration/continue=].
                             - Let |bufferSize| be |this|.{{GPURenderCommandsMixin/[[vertex_buffer_sizes]]}}[|slot|].
                             - Let |stride| be |buffers|[|slot|].{{GPUVertexBufferLayout/arrayStride}}.
                             - Let |lastStride| be max(|attribute|.{{GPUVertexAttribute/offset}} &plus; sizeof(|attribute|.{{GPUVertexAttribute/format}}))


### PR DESCRIPTION
Fixes: #2929

OOB check in draw calls should ignore empty vertex buffer slots but currently the spec doesn't care empty slots in draw call validations.

I would like to suggest to add

> - Continue if |buffers|[|slot|] is `null`

in the OOB validation steps in draw calls.

Another edit idea would be

> For each [GPUIndex32](https://www.w3.org/TR/webgpu/#typedefdef-gpuindex32) slot, where buffers[slot] is non-null, from 0 to buffers.length (non-inclusive):


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/takahirox/gpuweb/pull/2935.html" title="Last updated on May 26, 2022, 12:33 AM UTC (bbbbbf1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2935/f874e0a...takahirox:bbbbbf1.html" title="Last updated on May 26, 2022, 12:33 AM UTC (bbbbbf1)">Diff</a>