### PR TITLE
Clarify 'S' in the ref<S,T,A> row of the ConversionRank

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1258,7 +1258,8 @@ Note: When no conversion is performed, the conversion rank is zero.
       <td>0
       <td>Identity. No conversion performed.
   <tr algorithm="conversion rank from reference via load rule">
-      <td>ref&lt;|S|,|T|,|A|&gt;<br>where |A| is [=access/read=] or [=access/read_write=]
+      <td>ref&lt;|S|,|T|,|A|&gt;<br>for address space |S|,
+          and where access mode |A| is [=access/read=] or [=access/read_write=].
       <td>|T|
       <td>0
       <td>Apply the [=Load Rule=] to load a value from a memory reference.


### PR DESCRIPTION
Fixes: #2940