### PR TITLE
Change ref<S,T,A>  to ref<AS,T,AM>

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -18,7 +18,7 @@ Text Macro: ALLINTEGRALDECL |S| is AbstractInt, i32, or u32<br>|T| is |S| or vec
 Text Macro: ALLFLOATINGDECL |S| is AbstractFloat, f32, or f16<br>|T| is |S| or vec|N|&lt;|S|&gt;
 Text Macro: ALLNUMERICDECL |S| is AbstractInt, AbstractFloat, i32, u32, f32, or f16<br>|T| is |S|, or vec|N|&lt;|S|&gt;
 Text Macro: ALLINTEGRALDECL |S| is AbstractInt, i32, or u32<br>|T| is |S| or vec|N|&lt;|S|&gt;
-Ignored Vars: i, c0, e, e1, e2, e3, eN, p, s1, s2, sn, N, M, C, R, v, Stride, Offset, Align, Extent, S, T, T1
+Ignored Vars: i, c0, e, e1, e2, e3, eN, p, s1, s2, sn, AS, AM, N, M, C, R, v, Stride, Offset, Align, Extent, T, T1
 
 !Participate: <a href="https://github.com/gpuweb/gpuweb/issues/new?labels=wgsl">File an issue</a> (<a href="https://github.com/gpuweb/gpuweb/issues?q=is%3Aissue+is%3Aopen+label%3Awgsl">open issues</a>)
 !Tests: <a href=https://github.com/gpuweb/cts/tree/main/src/webgpu/shader/>WebGPU CTS shader/</a>
@@ -1260,8 +1260,8 @@ Note: When no conversion is performed, the conversion rank is zero.
       <td>0
       <td>Identity. No conversion performed.
   <tr algorithm="conversion rank from reference via load rule">
-      <td>ref&lt;|S|,|T|,|A|&gt;<br>for address space |S|,
-          and where access mode |A| is [=access/read=] or [=access/read_write=].
+      <td>ref&lt;|AS|,|T|,|AM|&gt;<br>for [=address space=] |AS|,
+          and where [=access mode=] |AM| is [=access/read=] or [=access/read_write=].
       <td>|T|
       <td>0
       <td>Apply the [=Load Rule=] to load a value from a memory reference.
@@ -1313,8 +1313,8 @@ Note: When no conversion is performed, the conversion rank is zero.
       <td>ConversionRank(|S|,|T|)
       <td>Inherit conversion rank from component types.
   <tr algorithm="conversion rank for non-convertible cases">
-      <td>|S|
-      <td>|T|<br>where above cases don't apply
+      <td><var ignore>S</var>
+      <td><var ignore>T</var><br>where above cases don't apply
       <td>infinity
       <td>There are no automatic conversions between other types.
 </table>
@@ -2325,7 +2325,7 @@ following table:
 
 #### Structure Member Layout ####  {#structure-member-layout}
 
-The |i|'th member of structure |S| has a size and alignment, denoted
+The |i|'th member of structure type |S| has a size and alignment, denoted
 by [=SizeOfMember=](|S|, |i|) and [=AlignOfMember=](|S|, |i|), respectively.
 The member sizes and alignments are used to calculate each member's byte offset from the start of the structure,
 as described in [[#internal-value-layout]].
@@ -2336,7 +2336,7 @@ as described in [[#internal-value-layout]].
 </p>
 
 <p algorithm="structure member alignment">
-  [=AlignOfMember=](|S|, |i|) is |k| if the |i|'th member has attribute [=attribute/align=](|k|).
+  [=AlignOfMember=](|S|, |i|) is |k| if the |i|'th member of |S| has attribute [=attribute/align=](|k|).
   Otherwise, it is [=AlignOf=](|T|) where |T| is the type of the member.
 </p>
 
@@ -2352,7 +2352,7 @@ member's type:
 The first structure member always has a zero byte offset from the start of the
 structure:
 <p algorithm="offset of first structure member">
-  [=OffsetOfMember=](|S|, 1) = 0
+  [=OffsetOfMember=](<var ignore>S</var>, 1) = 0
 </p>
 
 Each subsequent member is placed at the lowest offset that satisfies the member type alignment,
@@ -2674,20 +2674,20 @@ WGSL has two kinds of types for representing memory views:
     <tr><th>Constraint<th>Type<th>Description
   </thead>
   <tr algorithm="memory reference type">
-    <td style="width:25%">|S| is a [=address space=],<br>|T| is a [=storable=] type,<br>|A| is an [=access mode=]
-    <td>ref&lt;|S|,|T|,|A|&gt;
+    <td style="width:25%">|AS| is an [=address space=],<br>|T| is a [=storable=] type,<br>|AM| is an [=access mode=]
+    <td>ref&lt;|AS|,|T|,|AM|&gt;
     <td>The <dfn noexport>reference type</dfn>
-        identified with the set of [=memory views=] for memory locations in |S| holding values of type |T|,
-        supporting memory accesses described by mode |A|.<br>
+        identified with the set of [=memory views=] for memory locations in |AS| holding values of type |T|,
+        supporting memory accesses described by mode |AM|.<br>
         Here, |T| is the [=store type=].<br>
         Reference types are not written in WGSL program source;
         instead they are used to analyze a WGSL program.
   <tr algorithm="pointer type">
-    <td>|S| is a [=address space=],<br>|T| is a [=storable=] type,<br>|A| is an [=access mode=]
-    <td>ptr&lt;|S|,|T|,|A|&gt;
+    <td>|AS| is an [=address space=],<br>|T| is a [=storable=] type,<br>|AM| is an [=access mode=]
+    <td>ptr&lt;|AS|,|T|,|AM|&gt;
     <td>The <dfn noexport>pointer type</dfn>
-        identified with the set of [=memory views=] for memory locations in |S| holding values of type |T|,
-        supporting memory accesses described by mode |A|.<br>
+        identified with the set of [=memory views=] for memory locations in |AS| holding values of type |T|,
+        supporting memory accesses described by mode |AM|.<br>
         Here, |T| is the [=store type=].<br>
         Pointer types may appear in WGSL program source.
 </table>
@@ -2738,7 +2738,7 @@ Reference types and pointer types are both sets of memory views:
 a particular memory view is associated with a unique reference value and also a unique pointer value:
 
 <blockquote algorithm="pointer reference correspondence">
-Each pointer value |p| of type ptr&lt;|S|,|T|,|A|&gt; corresponds to a unique reference value |r| of type ref&lt;|S|,|T|,|A|&gt;,
+Each pointer value |p| of type ptr&lt;|AS|,|T|,|AM|&gt; corresponds to a unique reference value |r| of type ref&lt;|AS|,|T|,|AM|&gt;,
 and vice versa,
 where |p| and |r| describe the same memory view.
 </blockquote>
@@ -3782,8 +3782,8 @@ particular [=storable=] type.
 Two types are associated with a variable: its [=store type=] (the type of value
 that may be placed in the referenced memory) and its [=reference type=] (the type
 of the variable itself).
-If a variable has store type *T*, [=address space=] *S*, and [=access mode=] *A*,
-then its reference type is ref&lt;*S*,*T*,*A*&gt;.
+If a variable has store type |T|, [=address space=] |AS|, and [=access mode=] |AM|,
+then its reference type is ref&lt;|AS|,|T|,|AM|&gt;.
 The [=store type=] of a variable is always [=concrete=].
 
 A <dfn noexport>variable declaration</dfn>:
@@ -4972,43 +4972,43 @@ See [[#sync-builtin-functions]].
     <tr><th>Precondition<th>Conclusion<th>Description
   </thead>
   <tr algorithm="first vector component reference selection">
-       <td>|r|: ref&lt;|S|,vec|N|&lt;|T|&gt;&gt;<br>
+       <td>|r|: ref&lt;|AS|,vec|N|&lt;|T|&gt;,|AM|&gt;<br>
        <td class="nowrap">
-           |r|`.x`: ref&lt;|S|,|T|&gt;<br>
-           |r|`.r`: ref&lt;|S|,|T|&gt;<br>
+           |r|`.x`: ref&lt;|AS|,|T|,|AM|&gt;<br>
+           |r|`.r`: ref&lt;|AS|,|T|,|AM|&gt;<br>
        <td>Compute a reference to the first component of the vector referenced by the reference |r|.<br>
            The [=originating variable=] of the resulting reference is
            the same as the originating variable of |r|.
   <tr algorithm="second vector component reference selection">
-       <td>|r|: ref&lt;|S|,vec|N|&lt;|T|&gt;&gt;<br>
+       <td>|r|: ref&lt;|AS|,vec|N|&lt;|T|&gt;,|AM|&gt;<br>
        <td class="nowrap">
-           |r|`.y`: ref&lt;|S|,|T|&gt;<br>
-           |r|`.g`: ref&lt;|S|,|T|&gt;<br>
+           |r|`.y`: ref&lt;|AS|,|T|,|AM|&gt;<br>
+           |r|`.g`: ref&lt;|AS|,|T|,|AM|&gt;<br>
        <td>Compute a reference to the second component of the vector referenced by the reference |r|.<br>
            The [=originating variable=] of the resulting reference is
            the same as the originating variable of |r|.
   <tr algorithm="third vector component reference selection">
-       <td>|r|: ref&lt;|S|,vec|N|&lt;|T|&gt;&gt;<br>
+       <td>|r|: ref&lt;|AS|,vec|N|&lt;|T|&gt;,|AM|&gt;<br>
            |N| is 3 or 4
        <td class="nowrap">
-           |r|`.z`: ref&lt;|S|,|T|&gt;<br>
-           |r|`.b`: ref&lt;|S|,|T|&gt;<br>
+           |r|`.z`: ref&lt;|AS|,|T|,|AM|&gt;<br>
+           |r|`.b`: ref&lt;|AS|,|T|,|AM|&gt;<br>
        <td>Compute a reference to the third component of the vector referenced by the reference |r|.<br>
            The [=originating variable=] of the resulting reference is
            the same as the originating variable of |r|.
   <tr algorithm="fourth vector component reference selection">
-       <td>|r|: ref&lt;|S|,vec4&lt;|T|&gt;&gt;<br>
+       <td>|r|: ref&lt;|AS|,vec4&lt;|T|&gt;,|AM|&gt;<br>
        <td class="nowrap">
-           |r|`.w`: ref&lt;|S|,|T|&gt;<br>
-           |r|`.a`: ref&lt;|S|,|T|&gt;<br>
+           |r|`.w`: ref&lt;|AS|,|T|,|AM|&gt;<br>
+           |r|`.a`: ref&lt;|AS|,|T|,|AM|&gt;<br>
        <td>Compute a reference to the fourth component of the vector referenced by the reference |r|.<br>
            The [=originating variable=] of the resulting reference is
            the same as the originating variable of |r|.
   <tr algorithm="vector indexed component reference selection">
-       <td>|r|: ref&lt;|S|,vec|N|&lt;|T|&gt;&gt;<br>
+       <td>|r|: ref&lt;|AS|,vec|N|&lt;|T|&gt;,|AM|&gt;<br>
           |i|: [INT]
        <td class="nowrap">
-           |r|[|i|] : ref&lt;|S|,|T|&gt;
+           |r|[|i|] : ref&lt;|AS|,|T|,|AM|&gt;
        <td>Compute a reference to the |i|'<sup>th</sup> component of the vector
            referenced by the reference |r|.
 
@@ -5045,10 +5045,10 @@ See [[#sync-builtin-functions]].
   </thead>
   <tr algorithm="matrix indexed column vector reference selection">
        <td class="nowrap">
-          |r|: ref&lt;|S|,mat|C|x|R|&lt;|T|&gt;&gt;<br>
+          |r|: ref&lt;|AS|,mat|C|x|R|&lt;|T|&gt;,|AM|&gt;<br>
           |i|: [INT]
        <td class="nowrap">
-           |r|[|i|] : ref&lt;vec|R|&lt;|S|,|T|&gt;&gt;
+           |r|[|i|] : ref&lt;|AS|,vec|R|&lt;|T|&gt;,|AM|&gt;
        <td>Compute a reference to the |i|'<sup>th</sup> column vector of the
            matrix referenced by the reference |r|.
 
@@ -5085,10 +5085,10 @@ See [[#sync-builtin-functions]].
   </thead>
   <tr algorithm="fixed-size array indexed reference selection">
        <td class="nowrap">
-          |r|: ref&lt;|S|,array&lt;|T|,|N|&gt;&gt;<br>
+          |r|: ref&lt;|AS|,array&lt;|T|,|N|&gt;,|AM|&gt;<br>
           |i|: [INT]
        <td class="nowrap">
-           |r|[|i|] : ref&lt;|S|,|T|&gt;
+           |r|[|i|] : ref&lt;|AS|,|T|,|AM|&gt;
        <td>Compute a reference to the |i|'<sup>th</sup> element of the array
            referenced by the reference |r|.
 
@@ -5098,10 +5098,10 @@ See [[#sync-builtin-functions]].
            The [=originating variable=] of the resulting reference is
            the same as the originating variable of |r|.
   <tr algorithm="array indexed reference selection">
-       <td>|r|: ref&lt;|S|,array&lt;|T|&gt;&gt;<br>
+       <td>|r|: ref&lt;|AS|,array&lt;|T|&gt;,|AM|&gt;<br>
           |i|: [INT]
        <td class="nowrap">
-           |r|[|i|] : ref&lt;|S|,|T|&gt;
+           |r|[|i|] : ref&lt;|AS|,|T|,|AM|&gt;
        <td>Compute a reference to the |i|'<sup>th</sup> element of the
            runtime-sized array referenced by the reference |r|.
 
@@ -5140,9 +5140,9 @@ See [[#sync-builtin-functions]].
        <td class="nowrap">
           |S| is a structure type<br>
           |M| is the name of a member of |S|, having type |T|<br>
-          |r|: ref&lt;|S|,|S|&gt;<br>
+          |r|: ref&lt;|AS|,|S|,|AM|&gt;<br>
        <td class="nowrap">
-           |r|.|M|: ref&lt;|S|,|T|&gt;
+           |r|.|M|: ref&lt;|AS|,|T|,|AM|&gt;
        <td>Given a reference to a structure, the result is a reference to the structure member with identifier name |M|.<br>
            The [=originating variable=] of the resulting reference is
            the same as the originating variable of |r|.
@@ -5483,10 +5483,10 @@ See [[#function-call-statement]].
   <tr algorithm="variable reference">
        <td>
           |v| is an [=identifier=] [=resolves|resolving=] to
-          an [=in scope|in-scope=] variable declared in [=address space=] |S|
-          with [=store type=] |T|
+          an [=in scope|in-scope=] variable declared in [=address space=] |AS|
+          with [=store type=] |T| and address mode |AM|
        <td class="nowrap">
-          |v|: ref&lt;|S|,|T|&gt;
+          |v|: ref&lt;|AS|,|T|,|AM|&gt;
        <td>Result is a reference to the memory for the named variable |v|.
 </table>
 
@@ -5518,16 +5518,16 @@ The <dfn noexport>address-of</dfn> operator converts a reference to its correspo
   </thead>
   <tr algorithm="address-of expression">
        <td>
-          |r|: ref&lt;|S|,|T|,|A|&gt;
+          |r|: ref&lt;|AS|,|T|,|AM|&gt;
        <td class="nowrap">
-          `&`|r|: ptr&lt;|S|,|T|,|A|&gt;
+          `&`|r|: ptr&lt;|AS|,|T|,|AM|&gt;
        <td>Result is the pointer value corresponding to the
            same [=memory view=] as the reference value |r|.
 
            If |r| is an [=invalid memory reference=], then the resulting
            pointer is also an invalid memory reference.
 
-           It is a [=shader-creation error=] if |S| is the [=address spaces/handle=] address space.
+           It is a [=shader-creation error=] if |AS| is the [=address spaces/handle=] address space.
 
            It is a [=shader-creation error=] if |r| is a
            [[#component-reference-from-vector-reference|reference to a vector component]].
@@ -5545,9 +5545,9 @@ The <dfn noexport>indirection</dfn> operator converts a pointer to its correspon
   </thead>
   <tr algorithm="indirection expression">
        <td>
-          |p|: ptr&lt;|S|,|T|,|A|&gt;
+          |p|: ptr&lt;|AS|,|T|,|AM|&gt;
        <td class="nowrap">
-          `*`|p|: ref&lt;|S|,|T|,|A|&gt;
+          `*`|p|: ref&lt;|AS|,|T|,|AM|&gt;
        <td>Result is the reference value corresponding to the
            same [=memory view=] as the pointer value |p|.
 
@@ -5823,7 +5823,7 @@ In this case the value of the [=right-hand side=] is written to the memory refer
   </thead>
   <tr algorithm="updating assignment">
     <td>|r|: ref<|S|,|T|,|A|>,<br>
-        |A| is [=access/write=] or [=access/read_write=]<br>
+        [=access mode=] |A| is [=access/write=] or [=access/read_write=]<br>
         |e|: |T|,<br>
         |T| is a [=constructible=] type,<br>
         |S| is a writable [=address space=]
@@ -6065,13 +6065,13 @@ The expression [=shader-creation error|must=] evaluate to a reference with an [=
     <tr><th>Precondition<th>Statement<th>Description
   </thead>
   <tr algorithm="increment statement">
-    <td class="nowrap">|r| : ref&lt;<var ignore>SC</var>,|T|,[=access/read_write=]&gt;,<br>
+    <td class="nowrap">|r| : ref&lt;|AS|,|T|,[=access/read_write=]&gt;,<br>
         |T| is [=integer scalar=]<br>
     <td class="nowrap">|r|`++`
     <td>Adds 1 to the contents of memory referenced by |r|.
         <br>Same as |r| += |T|(1)
   <tr algorithm="decrement statement">
-    <td class="nowrap">|r| : ref&lt;<var ignore>SC</var>,|T|,[=access/read_write=]&gt;,<br>
+    <td class="nowrap">|r| : ref&lt;|AS|,|T|,[=access/read_write=]&gt;,<br>
         |T| is [=integer scalar=]<br>
     <td class="nowrap">|r|`--`
     <td>Subtracts 1 from the contents of memory referenced by |r|.
@@ -10452,8 +10452,9 @@ See [[#function-calls]].
     <tr><th>Parameterization<th>Overload<th>Description
   </thead>
   <tr algorithm="runtime-sized array length">
-    <td>
-    <td>`fn arrayLength`(|p|: ptr&lt;storage,array&lt;|T|&gt;&gt; ) -> u32
+    <td>|E| is an element type for a [=runtime-sized=] array,<br>
+        [=access mode=] |AM| is [=access/read=] or [=access/read_write=]
+    <td>`fn arrayLength`(|p|: ptr&lt;storage,array&lt;|E|&gt;,|AM|&gt; ) -> u32
         <td>Returns the number of elements in the [=runtime-sized=] array.
 </table>
 
@@ -11900,7 +11901,7 @@ between atomic accesses acting on different memory locations.
 
 Atomic built-in functions [=shader-creation error|must not=] be used in a [=vertex=] shader stage.
 
-The address space `SC` of the `atomic_ptr` parameter in all atomic built-in
+The address space `AS` of the `atomic_ptr` parameter in all atomic built-in
 functions [=shader-creation error|must=] be either [=address spaces/storage=] or [=address spaces/workgroup=].
 
 |T| [=shader-creation error|must=] be either [=u32=] or [=i32=]
@@ -11908,7 +11909,7 @@ functions [=shader-creation error|must=] be either [=address spaces/storage=] or
 ### Atomic Load ### {#atomic-load}
 
 ```rust
-fn atomicLoad(atomic_ptr: ptr<SC, atomic<T>, read_write>) -> T
+fn atomicLoad(atomic_ptr: ptr<AS, atomic<T>, read_write>) -> T
 ```
 
 Returns the atomically loaded the value pointed to by `atomic_ptr`.
@@ -11917,7 +11918,7 @@ It does not [=atomic modification|modify=] the object.
 ### Atomic Store ### {#atomic-store}
 
 ```rust
-fn atomicStore(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T)
+fn atomicStore(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T)
 ```
 
 Atomically stores the value `v` in the atomic object pointed to by `atomic_ptr`.
@@ -11925,13 +11926,13 @@ Atomically stores the value `v` in the atomic object pointed to by `atomic_ptr`.
 ### Atomic Read-modify-write ### {#atomic-rmw}
 
 ```rust
-fn atomicAdd(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T) -> T
-fn atomicSub(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T) -> T
-fn atomicMax(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T) -> T
-fn atomicMin(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T) -> T
-fn atomicAnd(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T) -> T
-fn atomicOr(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T) -> T
-fn atomicXor(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T) -> T
+fn atomicAdd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
+fn atomicSub(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
+fn atomicMax(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
+fn atomicMin(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
+fn atomicAnd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
+fn atomicOr(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
+fn atomicXor(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 ```
 Each function performs the following steps atomically:
 
@@ -11943,14 +11944,14 @@ Each function performs the following steps atomically:
 Each function returns the original value stored in the atomic object.
 
 ```rust
-fn atomicExchange(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T) -> T
+fn atomicExchange(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 ```
 
 Atomically stores the value `v` in the atomic object pointed to
 `atomic_ptr` and returns the original value stored in the atomic object.
 
 ```rust
-fn atomicCompareExchangeWeak(atomic_ptr: ptr<SC, atomic<T>, read_write>, cmp: T, v: T) -> __atomic_compare_exchange_result<T>
+fn atomicCompareExchangeWeak(atomic_ptr: ptr<AS, atomic<T>, read_write>, cmp: T, v: T) -> __atomic_compare_exchange_result<T>
 
 struct __atomic_compare_exchange_result<T> {
   old_value : T; // old value stored in the atomic

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5484,7 +5484,7 @@ See [[#function-call-statement]].
        <td>
           |v| is an [=identifier=] [=resolves|resolving=] to
           an [=in scope|in-scope=] variable declared in [=address space=] |AS|
-          with [=store type=] |T| and address mode |AM|
+          with [=store type=] |T| and [=access mode=] |AM|
        <td class="nowrap">
           |v|: ref&lt;|AS|,|T|,|AM|&gt;
        <td>Result is a reference to the memory for the named variable |v|.
@@ -5822,11 +5822,11 @@ In this case the value of the [=right-hand side=] is written to the memory refer
     <tr><th style="width:40%">Precondition<th>Statement<th>Description
   </thead>
   <tr algorithm="updating assignment">
-    <td>|r|: ref<|S|,|T|,|A|>,<br>
-        [=access mode=] |A| is [=access/write=] or [=access/read_write=]<br>
-        |e|: |T|,<br>
+    <td>|e|: |T|,<br>
         |T| is a [=constructible=] type,<br>
-        |S| is a writable [=address space=]
+        |r|: ref<|AS|,|T|,|AM|>,<br>
+        |AS| is a writable [=address space=],<br>
+        [=access mode=] |AM| is [=access/write=] or [=access/read_write=]<br>
     <td class="nowrap">|r| = |e|
     <td>Evaluates |e|, evaluates |r|, then writes the value computed for |e| into
         the [=memory locations=] referenced by |r|.


### PR DESCRIPTION
- Fix cases where the access mode was missing
- Remove |S| as a defaulted variable, so Bikeshed will tell us when
  we used it only once in an "algorithm".
   Changed three single-use instances to <var ignore>S</var>
- Fixed description of arrayLength to be explicit that the pointer
  parameter could use 'read' or 'read_write' access modes.

Fixes: #2943