### PR TITLE
Rename `discard` to `terminate`.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -218,7 +218,7 @@ Statements:
     * Repetition: loop, while, for.
     * Escaping a nested execution construct: break, continue.
     * Refactoring: function call and return.
-    * Discard (fragment shaders only): terminating the invocation and throwing away the output.
+    * Terminate (fragment shaders only): terminating the invocation and discarding the output.
 * Evaluate expressions to compute values as part of the above behaviours.
 
 WGSL is statically typed: each value computed by a particular expression is in a specific type,
@@ -6230,7 +6230,7 @@ The declaration is executed each time it is reached, so each new iteration
 creates a new instance of the variable or constant, and re-initializes it.
 
 This repetition can be interrupted by a [=statement/break=], [=statement/return=], or
-[=statement/discard=] statement.
+[=statement/terminate=] statement.
 
 Optionally, the last statement in the loop body may be a
 [=statement/continuing=] statement.
@@ -6565,7 +6565,7 @@ The construct is optional.
 
 The compound statement [=shader-creation error|must not=] contain a [=statement/return=] at any compound statement nesting level.
 
-The compound statement [=shader-creation error|must not=] contain a [=statement/discard=] at any compound statement nesting level nor through function calls.
+The compound statement [=shader-creation error|must not=] contain a [=statement/terminate=] at any compound statement nesting level nor through function calls.
 See [[#behaviors]] for a more formal description of this rule.
 
 ### Return Statement ### {#return-statement}
@@ -6589,36 +6589,36 @@ Otherwise the expression [=shader-creation error|must=] be present, and is calle
 In this case the call site of this function invocation evaluates to the return value.
 The type of the return value [=shader-creation error|must=] match the return type of the function.
 
-### Discard Statement ### {#discard-statement}
+### Terminate Statement ### {#terminate-statement}
 
-A <dfn dfn-for="statement">discard</dfn> statement immediately ends execution of a fragment shader invocation and throws away the fragment.
-The `discard` statement [=shader-creation error|must=] only be used in a [=fragment=] shader stage.
+A <dfn dfn-for="statement">terminate</dfn> statement immediately ends execution of a fragment shader invocation and throws away the fragment.
+The `terminate` statement [=shader-creation error|must=] only be used in a [=fragment=] shader stage.
 
-More precisely, executing a `discard` statement will:
+More precisely, executing a `terminate` statement will:
 
-* immediately terminate the current invocation, and
+* (behave as-if it will) immediately terminate the current invocation, and
 * prevent evaluation and generation of a [=return value=] for the [=entry point=], and
 * prevent the current fragment from being processed downstream in the [=GPURenderPipeline=].
 
 Only statements
-executed prior to the `discard` statement will have observable effects.
+executed prior to the `terminate` statement will have observable effects.
 
-Note: A `discard` statement may be executed by any
+Note: A `terminate` statement may be executed by any
 [=functions in a shader stage|function in a fragment stage=] and the effect is the same:
 immediate termination of the invocation.
 
-After a `discard` statement is executed, control flow is [[=uniform control flow|non-uniform=]] for the
-duration of the entry point.
+After a `terminate` statement is executed, control flow is [[=uniform control flow|non-uniform=]] for the
+duration of the entry point. (Control flow uniformity does not reconverge after a branch or call containing a `terminate`)
 
-<div class='example wgsl' heading='Using the discard statement to throw away a fragment'>
+<div class='example wgsl' heading='Using the terminate statement to throw away a fragment'>
   <xmp highlight='rust'>
   var<private> will_emit_color: bool = false;
 
-  fn discard_if_shallow(pos: vec4<f32>) {
+  fn terminate_if_shallow(pos: vec4<f32>) {
     if pos.z < 0.001 {
       // If this is executed, then the will_emit_color flag will
       // never be set to true.
-      discard;
+      terminate;
     }
     will_emit_color = true;
   }
@@ -6627,10 +6627,10 @@ duration of the entry point.
   fn main(@builtin(position) coord_in: vec4<f32>)
     -> @location(0) vec4<f32>
   {
-    discard_if_shallow(coord_in);
+    terminate_if_shallow(coord_in);
 
     // Set the flag and emit red, but only if the helper function
-    // did not execute the discard statement.
+    // did not execute the terminate statement.
     will_emit_color = true;
     return vec4<f32>(1.0, 0.0, 0.0, 1.0);
   }
@@ -6709,7 +6709,7 @@ The [=syntax/statement=] rule matches statements that can be used in most places
 
     | [=syntax/continue_statement=] [=syntax/semicolon=]
 
-    | [=syntax/discard=] [=syntax/semicolon=]
+    | [=syntax/terminate=] [=syntax/semicolon=]
 
     | [=syntax/assignment_statement=] [=syntax/semicolon=]
 
@@ -6742,7 +6742,7 @@ As with type analysis for values and expressions, behavior analysis proceeds bot
 
 A <dfn export>behavior</dfn> is a set, whose elements may be:
 - Return
-- Discard
+- Terminate
 - Break
 - Continue
 - Fallthrough
@@ -6754,14 +6754,14 @@ We note "*s*: *B*" to say that *s* respects the rules regarding behaviors, and h
 
 For each function:
 - Its body [=shader-creation error|must=] be a valid statement by these rules.
-- If the function has a return type, the [=behavior=] of its body [=shader-creation error|must=] be one of {Return} or {Return, Discard}.
-- Otherwise, the [=behavior=] of its body [=shader-creation error|must=] be a subset of {Next, Return, Discard}.
+- If the function has a return type, the [=behavior=] of its body [=shader-creation error|must=] be one of {Return} or {Return, Terminate}.
+- Otherwise, the [=behavior=] of its body [=shader-creation error|must=] be a subset of {Next, Return, Terminate}.
 
 We assign a [=behavior=] to each function: it is its body's [=behavior=] (treating the body as a regular statement), with any "Return" replaced by "Next".
-As a consequence of the rules above, a function behavior is always one of {}, {Next}, {Discard}, or {Next, Discard}.
+As a consequence of the rules above, a function behavior is always one of {}, {Next}, {Terminate}, or {Next, Terminate}.
 
-Similarly, we assign a [=behavior=] to each expression, since expressions can include function calls, which can discard.
-Like functions, expression behaviors are always one of {}, {Next}, {Discard}, or {Next, Discard}.
+Similarly, we assign a [=behavior=] to each expression, since expressions can include function calls, which can `terminate`.
+Like functions, expression behaviors are always one of {}, {Next}, {Terminate}, or {Next, Terminate}.
 
 Note: There is currently no valid program with an expression that does not have Next in its [=behavior=].
 The reason is that only functions without a return type can have such a [=behavior=], and there is no compound expression in which such a function can be called.
@@ -6830,10 +6830,10 @@ The reason is that only functions without a return type can have such a [=behavi
     <td class="nowrap">return |e|;
     <td class="nowrap">|e|: |B|<br>
     <td class="nowrap">(|B|&#x2216;{Next}) &cup; {Return}
-  <tr algorithm="discard behaviour">
-    <td>discard;
+  <tr algorithm="terminate behaviour">
+    <td>terminate;
     <td>
-    <td>{Discard}
+    <td>{Terminate}
   <tr algorithm="break behavior">
     <td>break;
     <td>
@@ -6860,13 +6860,13 @@ The reason is that only functions without a return type can have such a [=behavi
     <td class="nowrap" rowspan=2>loop {|s1| continuing {|s2|}}
     <td class="nowrap">|s1|: |B1|<br>
         |s2|: |B2|<br>
-        None of {Continue, Return, Discard} are in |B2|<br>
+        None of {Continue, Return, Terminate} are in |B2|<br>
         Break is not in (|B1| &cup; |B2|)
     <td class="nowrap">(|B1| &cup; |B2|)&#x2216;{Continue, Next}
   <tr algorithm="loop with continuing with break behavior">
     <td class="nowrap">|s1|: |B1|<br>
         |s2|: |B2|<br>
-        None of {Continue, Return, Discard} are in |B2|<br/>
+        None of {Continue, Return, Terminate} are in |B2|<br/>
         Break is in (|B1| &cup; |B2|)
     <td class="nowrap">(|B1| &cup; |B2| &cup; {Next})&#x2216;{Break, Continue}
   <tr algorithm="switch behavior">
@@ -6945,18 +6945,18 @@ And each operator application not listed in the table above has the same [=behav
 A [=shader-creation error=] results if behavior analysis fails:
 - Behavior analysis [=shader-creation error|must=] be able to determine a non-empty [=behavior=] for each statement, expression, and function.
 - The function behaviors [=shader-creation error|must=] satisfy the rules given above.
-- The behaviors of compute and vertex entry points [=shader-creation error|must not=] contain Discard.
+- The behaviors of compute and vertex entry points [=shader-creation error|must not=] contain Terminate.
 
 ### Notes ### {#behaviors-notes}
 
 This section is informative, non-normative.
 
 Here is the full list of ways that these rules can cause a program to be rejected (this is just restating information already listed above):
-- The body of a function (treated as a regular statement) has a behavior not included in {Next, Return, Discard}.
-- The body of a function with a return type has a behavior which is neither {Return} nor {Return, Discard}.
-- The behavior of a continuing block contains any of Continue, Return, or Discard.
+- The body of a function (treated as a regular statement) has a behavior not included in {Next, Return, Terminate}.
+- The body of a function with a return type has a behavior which is neither {Return} nor {Return, Terminate}.
+- The behavior of a continuing block contains any of Continue, Return, or Terminate.
 - The behavior of the last case of a switch contains Fallthrough.
-- The behavior of a compute or vertex entry point function contains Discard.
+- The behavior of a compute or vertex entry point function contains Terminate.
 - Some obviously infinite loops have an empty behaviour set, and are therefore invalid.
 
 This analysis can be run in linear time, by analyzing the call-graph bottom-up (since the behavior of a function call can depend on the function's code).
@@ -7081,7 +7081,7 @@ Here are some examples showing this analysis in action:
         a = a * 2;           // Valid, as the previous statement has Next in its behavior
         continuing {         // Valid as the continuing statement has behavior {Next}
                              //  which does not include any of:
-                             //  {Break, Continue, Discard, Return}
+                             //  {Break, Continue, Terminate, Return}
           a = a + 1;
         }
       }                      // The loop as a whole has behavior {Next},
@@ -7120,34 +7120,34 @@ Here are some examples showing this analysis in action:
 </div>
 `for` loops desugar to `loop` with a conditional break. As shown in a previous example, the conditional break has [=behavior=] {Break, Next}, which leads to adding "Next" to the loop's [=behavior=].
 
-<div class='example wgsl expect-error' heading='Effect of a function that discards unconditionally'>
+<div class='example wgsl expect-error' heading='Effect of a function that terminates unconditionally'>
    <xmp highlight='rust'>
-    fn always_discard() {
-      discard;
-    }                   // The whole function has behavior {Discard}
-    fn code_after_discard() {
+    fn always_terminate() {
+      terminate;
+    }                   // The whole function has behavior {Terminate}
+    fn code_after_terminate() {
       var a: i32;
-      always_discard(); // Behavior: {Discard}
-      a = a + 1;        // Valid, statically unreachable code.
-                        //   Statement behavior: {Next}
-                        //   Overall behavior: {Discard}
+      always_terminate(); // Behavior: {Terminate}
+      a = a + 1;     // Valid, statically unreachable code.
+                     //   Statement behavior: {Next}
+                     //   Overall behavior: {Terminate}
     }
    </xmp>
 </div>
 
-<div class='example wgsl' heading='Effect of a function that discards conditionally'>
+<div class='example wgsl' heading='Effect of a function that terminates conditionally'>
    <xmp highlight='rust'>
-    fn sometimes_discard(a: i32) {
+    fn sometimes_terminate(a: i32) {
       if a {
-        discard;        // Behavior: {Discard}
-      }                 // Behavior: {Next, Discard}
-    }                   // The whole function has behavior {Next, Discard}
-    fn code_after_discard() {
+        terminate;      // Behavior: {Terminate}
+      }                 // Behavior: {Next, Terminate}
+    }                   // The whole function has behavior {Next, Terminate}
+    fn code_after_terminate() {
       var a: i32;
       a = 42;
-      sometimes_discard(a);  // Behavior: {Next, Discard}
-      a = a + 1;             // Valid
-    }                        // The whole function has behavior {Next, Discard}
+      sometimes_terminate(a); // Behavior: {Next, Terminate}
+      a = a + 1;              // Valid
+    }                         // The whole function has behavior {Next, Terminate}
    </xmp>
 </div>
 
@@ -7318,7 +7318,7 @@ In detail, when a function call is executed the following steps occur:
     value of the function call expression.
 
 Note: The current function will not resume execution if the called function or
-any descendent called function executes a [=statement/discard=] statement.
+any descendent called function executes a [=statement/terminate=] statement.
 
 The location of a function call is referred to as a <dfn noexport>call site</dfn>.
 Call sites are a [=dynamic context=].
@@ -8278,7 +8278,7 @@ When several edges have to be created we use `X -> {Y, Z}` as a short-hand for `
       <td rowspan=3>*CF*
       <td rowspan=3>
   <tr><td class="nowrap">fallthrough;
-  <tr><td class="nowrap">discard;
+  <tr><td class="nowrap">terminate;
   <tr><td class="nowrap">return;
       <td>
       <td>
@@ -9183,9 +9183,9 @@ Issue: https://github.com/gpuweb/gpuweb/issues/1621
     | `'default'`
 </div>
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>discard</dfn> :
+  <dfn for=syntax>terminate</dfn> :
 
-    | `'discard'`
+    | `'terminate'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>else</dfn> :
@@ -9464,6 +9464,8 @@ The following are reserved words:
 
     | `'demote_to_helper'`   <!-- WGSL -->
 
+    | `'discard'`   <!-- GLSL, HLSL -->
+
     | `'do'`   <!-- C++ ECMAScript2022 Rust HLSL GLSL WGSL -->
 
     | `'dword'`   <!-- HLSL -->
@@ -9635,6 +9637,8 @@ The following are reserved words:
     | `'itextureCube'`   <!-- GLSL -->
 
     | `'itextureCubeArray'`   <!-- GLSL -->
+
+    | `'kill'`   <!-- SPIR-V -->
 
     | `'layout'`   <!-- GLSL -->
 


### PR DESCRIPTION
HLSL has "demote (to helper)" behavior for `discard`, but GLSL has
"kill" behavior.
`kill` is less ambiguous. "Kill" is the verb used by e.g. SPIR-V, and it
more clearly contrasts with "demote" as a verb for the HLSL `discard`
behavior.

This effectively reverts #918.