### PR TITLE
Editorial nits in depth24plus section

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3836,11 +3836,13 @@ enum GPUTextureFormat {
 };
 </script>
 
-<span id="depthPlus">The depth component of the {{GPUTextureFormat/"depth24plus"}}) and {{GPUTextureFormat/"depth24plus-stencil8"}})
+<p id=depthPlus>
+The depth component of the {{GPUTextureFormat/"depth24plus"}} and {{GPUTextureFormat/"depth24plus-stencil8"}}
 formats may be implemented as either a 24-bit unsigned normalized value (like "depth24unorm" in {{GPUTextureFormat/"depth24unorm-stencil8"}})
-or a 32-bit IEEE 754 floating point value (like {{GPUTextureFormat/"depth32float"}}).</span>
+or a 32-bit IEEE 754 floating point value (like {{GPUTextureFormat/"depth32float"}}).
+</p>
 
-Issue: add something on GPUAdapter(?) that gives an estimate of the bytes per texel of
+Issue(gpuweb/gpuweb#1887): add something on GPUAdapter(?) that gives an estimate of the bytes per texel of
 {{GPUTextureFormat/"stencil8"}}, {{GPUTextureFormat/"depth24plus-stencil8"}}, and {{GPUTextureFormat/"depth32float-stencil8"}}.
 
 The {{GPUTextureFormat/stencil8}} format may be implemented as


### PR DESCRIPTION
TBR @toji


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 26, 2022, 1:32 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fgpuweb%2Fgpuweb%2F52ec46c677bf936235478d9da460f1e8e724ee86%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%232949.)._
</details>
