### PR TITLE
Remove depth24unorm-stencil8

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2195,7 +2195,6 @@ allows additional usages of WebGPU that would have otherwise been invalid.
 <script type=idl>
 enum GPUFeatureName {
     "depth-clip-control",
-    "depth24unorm-stencil8",
     "depth32float-stencil8",
     "texture-compression-bc",
     "texture-compression-etc2",
@@ -3769,9 +3768,6 @@ enum GPUTextureFormat {
     "depth24plus-stencil8",
     "depth32float",
 
-    // "depth24unorm-stencil8" feature
-    "depth24unorm-stencil8",
-
     // "depth32float-stencil8" feature
     "depth32float-stencil8",
 
@@ -3840,7 +3836,7 @@ enum GPUTextureFormat {
 
 <p id=depthPlus>
 The depth component of the {{GPUTextureFormat/"depth24plus"}} and {{GPUTextureFormat/"depth24plus-stencil8"}}
-formats may be implemented as either a 24-bit unsigned normalized value (like "depth24unorm" in {{GPUTextureFormat/"depth24unorm-stencil8"}})
+formats may be implemented as either a 24-bit unsigned normalized value (like "depth24unorm")
 or a 32-bit IEEE 754 floating point value (like {{GPUTextureFormat/"depth32float"}}).
 </p>
 
@@ -12513,21 +12509,6 @@ The following dictionary values are supported if and only if the {{GPUFeatureNam
         * {{GPUPrimitiveState/unclippedDepth}}
 </dl>
 
-## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>"depth24unorm-stencil8"</dfn> ## {#depth24unorm-stencil8}
-
-Allows for explicit creation of textures of format {{GPUTextureFormat/"depth24unorm-stencil8"}}.
-
-**Feature Enums**
-
-The following enums are supported if and only if the {{GPUFeatureName/"depth24unorm-stencil8"}}
-[=feature=] is enabled:
-
-<dl>
-    : {{GPUTextureFormat}}
-    ::
-        * {{GPUTextureFormat/"depth24unorm-stencil8"}}
-</dl>
-
 ## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>"depth32float-stencil8"</dfn> ## {#depth32float-stencil8}
 
 Allows for explicit creation of textures of format {{GPUTextureFormat/"depth32float-stencil8"}}.
@@ -13051,20 +13032,6 @@ be used with {{GPUSamplerBindingType/"comparison"}} samplers (which may use filt
         <td colspan=1>&cross;
         <td>{{GPUTextureFormat/depth32float}}
     <tr>
-        <td rowspan=2 style='white-space:nowrap'>{{GPUTextureFormat/depth24unorm-stencil8}}
-        <td rowspan=2>4
-        <td>depth
-        <td>3
-        <td>{{GPUTextureSampleType/"depth"}}
-        <td colspan=2>&cross;
-        <td>{{GPUTextureFormat/depth24plus}}
-    <tr>
-        <td>stencil
-        <td>1
-        <td>{{GPUTextureSampleType/"uint"}}
-        <td colspan=2>&checkmark;
-        <td>{{GPUTextureFormat/stencil8}}
-    <tr>
         <td rowspan=2 style='white-space:nowrap'>{{GPUTextureFormat/depth32float-stencil8}}
         <td rowspan=2>5 &minus; 8
         <td>depth
@@ -13111,8 +13078,6 @@ As a result, copies into such textures are only valid from other textures of the
 The depth aspects of depth24plus formats
 ({{GPUTextureFormat/"depth24plus"}} and {{GPUTextureFormat/"depth24plus-stencil8"}})
 have opaque representations (implemented as either "depth24unorm" or "depth32float").
-The depth aspect of {{GPUTextureFormat/"depth24unorm-stencil8"}}
-doesn't have an aligned tightly-packed representation (because its size is 3 bytes).
 As a result, depth-aspect [=image copies=] are not allowed with these formats.
 
 <div class=note>
@@ -13120,7 +13085,7 @@ As a result, depth-aspect [=image copies=] are not allowed with these formats.
 
     - All of these formats can be written in a render pass using a fragment shader that outputs
         depth values via the `frag_depth` output.
-    - Textures with "depth24plus"/"depth24unorm" formats can be read as shader textures, and
+    - Textures with "depth24plus" formats can be read as shader textures, and
         written to a texture (as a render pass attachment) or
         buffer (via a storage buffer binding in a compute shader).
 </div>


### PR DESCRIPTION
Proposal for #2732.
Rationale: https://github.com/gpuweb/gpuweb/issues/2732#issuecomment-1137807847


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 31, 2022, 7:06 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fkainino0x%2Fgpuweb%2F1346ff402a323f9ffe9ddb8c3c0671a3a24f32c8%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%232950.)._
</details>
