### PR TITLE
Fix and clean biblio references

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -47,16 +47,10 @@ spec: ECMA-262; urlPrefix: https://tc39.es/ecma262/#
         text: agent; url: agent
         text: surrounding agent; url: surrounding-agent
         text: agent cluster; url: sec-agent-clusters
-spec: web-apis; urlPrefix: https://html.spec.whatwg.org/multipage/webappapis.html#
+spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
     type: dfn
-        text: cross-origin isolated capability; url: concept-settings-object-cross-origin-isolated-capability
-spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/canvas.html#
-    type: dfn
-        text: origin-clean; url: concept-canvas-origin-clean
-        text: placeholder canvas element; url: offscreencanvas-placeholder
-        text: canvas context mode; url: concept-canvas-context-mode
-        text: OffscreenCanvas context mode; url: offscreencanvas-context-mode
-        text: check the usability of the image argument; url: check-the-usability-of-the-image-argument
+        text: origin-clean; url: canvas.html#concept-canvas-origin-clean
+        text: check the usability of the image argument; url: canvas.html#check-the-usability-of-the-image-argument
 spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
     type: dfn
         text: location; url: input-output-locations
@@ -66,8 +60,6 @@ spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
         text: pipeline-overridable constant identifier string; url: pipeline-overridable-constant-identifier-string
         text: pipeline-overridable constant has a default value; url: pipeline-overridable-constant-has-a-default-value
         text: statically accessed; url: statically-accessed
-        text: wgsl-declaration; url: declaration
-        text: wgsl-type; url: type
         text: pipeline output; url: pipeline-output
         text: pipeline input; url: pipeline-input
         text: builtin; url: builtin-variables

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -23,19 +23,6 @@ Assume Explicit For: yes
 
 <pre class=biblio>
 {
-  "WGSL": {
-    "authors": [
-      "David Neto",
-      "Myles C. Maxfield"
-    ],
-    "href": "https://gpuweb.github.io/gpuweb/wgsl/",
-    "title": "WebGPU Shading Language",
-    "status": "Editor's Draft",
-    "publisher": "W3C",
-    "deliveredBy": [
-      "https://github.com/gpuweb/gpuweb"
-    ]
-  },
   "SourceMap": {
     "authors": [
       "John Lenz",
@@ -60,13 +47,10 @@ spec: ECMA-262; urlPrefix: https://tc39.es/ecma262/#
         text: agent; url: agent
         text: surrounding agent; url: surrounding-agent
         text: agent cluster; url: sec-agent-clusters
-spec: webidl; urlPrefix: https://heycam.github.io/webidl/#
-    type: dfn
-        text: resolve; url: resolve
 spec: web-apis; urlPrefix: https://html.spec.whatwg.org/multipage/webappapis.html#
     type: dfn
         text: cross-origin isolated capability; url: concept-settings-object-cross-origin-isolated-capability
-spec: canvas; urlPrefix: https://html.spec.whatwg.org/multipage/canvas.html#
+spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/canvas.html#
     type: dfn
         text: origin-clean; url: concept-canvas-origin-clean
         text: placeholder canvas element; url: offscreencanvas-placeholder
@@ -1675,9 +1659,9 @@ canvas rendered using WebGPU will never be set to `false`.
 
 For more information on issuing CORS requests for image and video elements, consult:
 
-- [[html#cors-settings-attributes]]
-- [[html#the-img-element]] <{img}>
-- [[html#media-elements]] {{HTMLMediaElement}}
+- [[!html#cors-settings-attributes]]
+- [[!html#the-img-element]] <{img}>
+- [[!html#media-elements]] {{HTMLMediaElement}}
 
 ## Color Spaces and Encoding ## {#color-spaces}
 
@@ -8035,7 +8019,7 @@ dictionary GPUImageCopyTextureTagged : GPUImageCopyTexture {
 
         Note:
         If {{GPUImageCopyTextureTagged/premultipliedAlpha}} matches the source image, no conversion occurs.
-        2d canvases are [[html#premultiplied-alpha-and-the-2d-rendering-context|always premultiplied]],
+        2d canvases are [[!html#premultiplied-alpha-and-the-2d-rendering-context|always premultiplied]],
         while WebGL canvases can be controlled via <l spec=html>[=WebGLContextAttributes=]</l>.
         {{ImageBitmap}} premultiplication can be controlled via {{ImageBitmapOptions}}.
 </dl>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1659,9 +1659,9 @@ canvas rendered using WebGPU will never be set to `false`.
 
 For more information on issuing CORS requests for image and video elements, consult:
 
-- [[!html#cors-settings-attributes]]
-- [[!html#the-img-element]] <{img}>
-- [[!html#media-elements]] {{HTMLMediaElement}}
+- [[html#cors-settings-attributes]]
+- [[html#the-img-element]] <{img}>
+- [[html#media-elements]] {{HTMLMediaElement}}
 
 ## Color Spaces and Encoding ## {#color-spaces}
 
@@ -8019,7 +8019,7 @@ dictionary GPUImageCopyTextureTagged : GPUImageCopyTexture {
 
         Note:
         If {{GPUImageCopyTextureTagged/premultipliedAlpha}} matches the source image, no conversion occurs.
-        2d canvases are [[!html#premultiplied-alpha-and-the-2d-rendering-context|always premultiplied]],
+        2d canvases are <a href="https://html.spec.whatwg.org/multipage/canvas.html#premultiplied-alpha-and-the-2d-rendering-context">always premultiplied</a>,
         while WebGL canvases can be controlled via <l spec=html>[=WebGLContextAttributes=]</l>.
         {{ImageBitmap}} premultiplication can be controlled via {{ImageBitmapOptions}}.
 </dl>


### PR DESCRIPTION
Main fix prompted by recent updates in Bikeshed, which now fails to fix inconsistent informative/normative references to a spec, see #2951.

Problem appeared because of the one reference to "always premultiplied" in an informative note. This now seems to confuse Bikeshed, and the HTML biblio entry appeared both under normative and informative references as a result, with the same ID, which in turn made Bikeshed issue a warning, preventing build (build is configured to fail on warnings). I filed https://github.com/tabatkins/bikeshed/issues/2284 to report the issue on Bikeshed.

While this gets fixed, the only real workaround is to use an explicit URL for that link (I thought `[[!FOO#bar]]` would work, but Bikeshed does not recognize that pattern and, conceptually speaking, the link in the Note should remain an informative one.

The other updates in this pull request are not needed to fix spec generation with Bikeshed but further clean up biblio references:
- The term "resolve" in Web IDL can be referenced directly, no need to define it locally (plus the spec URL was no longer current, as spec migrated to WHATWG)
- Canvas related terms needed to be associated with HTML no to create a `[CANVAS]` entry in the index section that does not map to any `[CANVAS]` biblio entry.
- WGSL now exists in Specref, no need to have it in local biblio anymore (this also allows to use the right "Working Draft" status for the spec, which is no longer only an Editor's Draft)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/gpuweb/pull/2952.html" title="Last updated on May 27, 2022, 12:42 PM UTC (0894326)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2952/698c1d2...tidoust:0894326.html" title="Last updated on May 27, 2022, 12:42 PM UTC (0894326)">Diff</a>