### PR TITLE
Better specify color space conversion elision

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -73,6 +73,13 @@ spec: canvas; urlPrefix: https://html.spec.whatwg.org/multipage/canvas.html#
         text: canvas context mode; url: concept-canvas-context-mode
         text: OffscreenCanvas context mode; url: offscreencanvas-context-mode
         text: check the usability of the image argument; url: check-the-usability-of-the-image-argument
+spec: WEBGL-1; urlPrefix: https://www.khronos.org/registry/webgl/specs/latest/1.0/#
+    type: interface
+        text: WebGLRenderingContext; url: WEBGLRENDERINGCONTEXT
+    type: attribute; for: WebGLRenderingContext
+        text: drawingBufferColorSpace; url: DOM-WebGLRenderingContext-drawingBufferColorSpace
+    type: dictionary
+        text: WebGLContextAttributes; url: WEBGLCONTEXTATTRIBUTES
 spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
     type: dfn
         text: location; url: input-output-locations
@@ -1737,8 +1744,25 @@ conversion, with intermediate computations having at least the precision of the 
 
 ### Color Space Conversion Elision ### {#color-space-conversion-elision}
 
-Issue: Write this section.
+If the source and destination of a color space/encoding conversion are the same, then conversion
+is not necessary. In general, if any given step of the conversion is an identity function (no-op),
+implementations **should** elide it, for performance.
 
+For optimal performance, applications **should** set their color space and encoding
+options so that the number of necessary conversions is minimized throughout the process.
+For various image sources of {{GPUImageCopyExternalImage}}:
+
+- {{ImageBitmap}}:
+    - Premultiplication is controlled via {{ImageBitmapOptions/premultiplyAlpha}}.
+    - Color space is controlled via {{ImageBitmapOptions/colorSpaceConversion}}.
+- 2d canvas:
+    - [[html#premultiplied-alpha-and-the-2d-rendering-context|Always premultiplied]].
+    - Color space is controlled via the {{CanvasRenderingContext2DSettings/colorSpace}} context creation attribute.
+- WebGL canvas:
+    - Premultiplication is controlled via the `premultipliedAlpha` option in {{WebGLContextAttributes}}.
+    - Color space is controlled via the {{WebGLRenderingContext}}'s {{WebGLRenderingContext/drawingBufferColorSpace}} state.
+
+Note: Check browser implementation support for these features before relying on them.
 
 # Initialization # {#initialization}
 


### PR DESCRIPTION
With more complete links to other specs.

Restores and improves on what I removed in 7c2fa513155040ff8943c752ad9b901c6eb1c85a to fix #2951.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/2956.html" title="Last updated on May 26, 2022, 6:36 PM UTC (276c117)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2956/7c2fa51...kainino0x:276c117.html" title="Last updated on May 26, 2022, 6:36 PM UTC (276c117)">Diff</a>