### PR TITLE
Clarify to interpret stencilClearValue as masked

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9534,6 +9534,9 @@ dictionary GPURenderPassDepthStencilAttachment {
         to prior to executing the render pass. Ignored if {{GPURenderPassDepthStencilAttachment/stencilLoadOp}}
         is not {{GPULoadOp/"clear"}}.
 
+        Note: The value will always be converted to the type of the stencil aspect of |view| by taking the same
+        number of LSBs as the number of bits in the stencil aspect of one texel block of |view|.
+
     : <dfn>stencilLoadOp</dfn>
     ::
         Indicates the load operation to perform on {{GPURenderPassDepthStencilAttachment/view}}'s

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9534,7 +9534,7 @@ dictionary GPURenderPassDepthStencilAttachment {
         to prior to executing the render pass. Ignored if {{GPURenderPassDepthStencilAttachment/stencilLoadOp}}
         is not {{GPULoadOp/"clear"}}.
 
-        Note: The value will always be converted to the type of the stencil aspect of |view| by taking the same
+        The value will be converted to the type of the stencil aspect of |view| by taking the same
         number of LSBs as the number of bits in the stencil aspect of one texel block of |view|.
 
     : <dfn>stencilLoadOp</dfn>


### PR DESCRIPTION
Current WebGPU SPEC only supports 8-bit stencil formats, while the
type of stencilClearValue is unsigned long. This patch clarifies
that stencilClearValue will always be converted to the attachment's
stencil format by taking the appropriate number of LSBs.

fixes: #2921


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Jiawei-Shao/gpuweb/pull/2964.html" title="Last updated on Jun 6, 2022, 5:18 AM UTC (cd59dab)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2964/698c1d2...Jiawei-Shao:cd59dab.html" title="Last updated on Jun 6, 2022, 5:18 AM UTC (cd59dab)">Diff</a>