### PR TITLE
Remove commas after final member of a WebIDL enum.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1702,7 +1702,7 @@ to represent color values outside of its space (in both chrominance and luminanc
 
 <script type=idl>
 enum GPUPredefinedColorSpace {
-    "srgb",
+    "srgb"
 };
 </script>
 
@@ -1911,7 +1911,7 @@ dictionary GPURequestAdapterOptions {
 <script type=idl>
 enum GPUPowerPreference {
     "low-power",
-    "high-performance",
+    "high-performance"
 };
 </script>
 
@@ -2231,7 +2231,7 @@ enum GPUFeatureName {
     "timestamp-query",
     "indirect-first-instance",
     "shader-f16",
-    "bgra8unorm-storage",
+    "bgra8unorm-storage"
 };
 </script>
 
@@ -3111,7 +3111,7 @@ dictionary GPUTextureDescriptor : GPUObjectDescriptorBase {
 enum GPUTextureDimension {
     "1d",
     "2d",
-    "3d",
+    "3d"
 };
 </script>
 
@@ -3419,7 +3419,7 @@ enum GPUTextureViewDimension {
     "2d-array",
     "cube",
     "cube-array",
-    "3d",
+    "3d"
 };
 </script>
 
@@ -3491,7 +3491,7 @@ enum GPUTextureViewDimension {
 enum GPUTextureAspect {
     "all",
     "stencil-only",
-    "depth-only",
+    "depth-only"
 };
 </script>
 
@@ -3862,7 +3862,7 @@ enum GPUTextureFormat {
     "astc-12x10-unorm",
     "astc-12x10-unorm-srgb",
     "astc-12x12-unorm",
-    "astc-12x12-unorm-srgb",
+    "astc-12x12-unorm-srgb"
 };
 </script>
 
@@ -4262,7 +4262,7 @@ Issue: Describe a "sample footprint" in greater detail.
 enum GPUAddressMode {
     "clamp-to-edge",
     "repeat",
-    "mirror-repeat",
+    "mirror-repeat"
 };
 </script>
 
@@ -4287,12 +4287,12 @@ match one texel.
 <script type=idl>
 enum GPUFilterMode {
     "nearest",
-    "linear",
+    "linear"
 };
 
 enum GPUMipmapFilterMode {
     "nearest",
-    "linear",
+    "linear"
 };
 </script>
 
@@ -4321,7 +4321,7 @@ enum GPUCompareFunction {
     "greater",
     "not-equal",
     "greater-equal",
-    "always",
+    "always"
 };
 </script>
 
@@ -4647,7 +4647,7 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
 enum GPUBufferBindingType {
     "uniform",
     "storage",
-    "read-only-storage",
+    "read-only-storage"
 };
 
 dictionary GPUBufferBindingLayout {
@@ -4694,7 +4694,7 @@ dictionary GPUBufferBindingLayout {
 enum GPUSamplerBindingType {
     "filtering",
     "non-filtering",
-    "comparison",
+    "comparison"
 };
 
 dictionary GPUSamplerBindingLayout {
@@ -4716,7 +4716,7 @@ enum GPUTextureSampleType {
     "unfilterable-float",
     "depth",
     "sint",
-    "uint",
+    "uint"
 };
 
 dictionary GPUTextureBindingLayout {
@@ -4749,7 +4749,7 @@ truly optional.
 
 <script type=idl>
 enum GPUStorageTextureAccess {
-    "write-only",
+    "write-only"
 };
 
 dictionary GPUStorageTextureBindingLayout {
@@ -5480,7 +5480,7 @@ information to {{GPUDevice/createShaderModule()}}, as passing mismatched informa
 enum GPUCompilationMessageType {
     "error",
     "warning",
-    "info",
+    "info"
 };
 
 [Exposed=(Window, DedicatedWorker), Serializable, SecureContext]
@@ -5608,7 +5608,7 @@ and switched as one
 
 <script type=idl>
 enum GPUAutoLayoutMode {
-    "auto",
+    "auto"
 };
 
 dictionary GPUPipelineDescriptorBase : GPUObjectDescriptorBase {
@@ -6502,7 +6502,7 @@ enum GPUPrimitiveTopology {
     "line-list",
     "line-strip",
     "triangle-list",
-    "triangle-strip",
+    "triangle-strip"
 };
 </script>
 
@@ -6535,7 +6535,7 @@ will use. See [[#rasterization]] for additional details:
 <script type=idl>
 enum GPUFrontFace {
     "ccw",
-    "cw",
+    "cw"
 };
 </script>
 
@@ -6558,7 +6558,7 @@ See [[#polygon-rasterization]] for additional details:
 enum GPUCullMode {
     "none",
     "front",
-    "back",
+    "back"
 };
 </script>
 
@@ -6767,7 +6767,7 @@ enum GPUBlendFactor {
     "one-minus-dst-alpha",
     "src-alpha-saturated",
     "constant",
-    "one-minus-constant",
+    "one-minus-constant"
 };
 </script>
 
@@ -6829,7 +6829,7 @@ enum GPUBlendOperation {
     "subtract",
     "reverse-subtract",
     "min",
-    "max",
+    "max"
 };
 </script>
 
@@ -7020,7 +7020,7 @@ enum GPUStencilOperation {
     "increment-clamp",
     "decrement-clamp",
     "increment-wrap",
-    "decrement-wrap",
+    "decrement-wrap"
 };
 </script>
 
@@ -7070,7 +7070,7 @@ enum GPUStencilOperation {
 <script type=idl>
 enum GPUIndexFormat {
     "uint16",
-    "uint32",
+    "uint32"
 };
 </script>
 
@@ -7221,7 +7221,7 @@ enum GPUVertexFormat {
     "sint32",
     "sint32x2",
     "sint32x3",
-    "sint32x4",
+    "sint32x4"
 };
 </script>
 
@@ -7421,7 +7421,7 @@ enum GPUVertexFormat {
 <script type=idl>
 enum GPUVertexStepMode {
     "vertex",
-    "instance",
+    "instance"
 };
 </script>
 
@@ -8957,7 +8957,7 @@ GPUComputePassEncoder includes GPUBindingCommandsMixin;
 <script type=idl>
 enum GPUComputePassTimestampLocation {
     "beginning",
-    "end",
+    "end"
 };
 
 dictionary GPUComputePassTimestampWrite {
@@ -9250,7 +9250,7 @@ When a {{GPURenderPassEncoder}} is created, it has the following default state:
 <script type=idl>
 enum GPURenderPassTimestampLocation {
     "beginning",
-    "end",
+    "end"
 };
 
 dictionary GPURenderPassTimestampWrite {
@@ -9585,7 +9585,7 @@ dictionary GPURenderPassDepthStencilAttachment {
 <script type=idl>
 enum GPULoadOp {
     "load",
-    "clear",
+    "clear"
 };
 </script>
 
@@ -9609,7 +9609,7 @@ enum GPULoadOp {
 <script type=idl>
 enum GPUStoreOp {
     "store",
-    "discard",
+    "discard"
 };
 </script>
 
@@ -10904,7 +10904,7 @@ garbage collection by calling {{GPUQuerySet/destroy()}}.
 <script type=idl>
 enum GPUQueryType {
     "occlusion",
-    "timestamp",
+    "timestamp"
 };
 </script>
 
@@ -11247,7 +11247,7 @@ a view with an `srgb` format.
 <script type=idl>
 enum GPUCanvasAlphaMode {
     "opaque",
-    "premultiplied",
+    "premultiplied"
 };
 
 dictionary GPUCanvasConfiguration {
@@ -11394,7 +11394,7 @@ This enum selects how the contents of the canvas will be interpreted when read, 
 
 <script type=idl>
 enum GPUDeviceLostReason {
-    "destroyed",
+    "destroyed"
 };
 
 [Exposed=(Window, DedicatedWorker), SecureContext]
@@ -11440,7 +11440,7 @@ of WebGPU calls, typically for debugging purposes or to make an operation more f
 <script type=idl>
 enum GPUErrorFilter {
     "out-of-memory",
-    "validation",
+    "validation"
 };
 </script>
 


### PR DESCRIPTION
bikeshed 3.7.0 uses widlparser 1.0.12, which prints the warning:

      WARNING: IGNORED LEGACY IDL LINE: 4 - ","
       ✘  Did not generate, due to fatal errors

if there is a comma after the last string in a WebIDL enum.

I don't know if it's better to change the WebGPU spec, like this, or to fix bikeshed / widlparser - trailing commas are arguably a feature, not a bug. But anyway, this will let the spec build again.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jimblandy/gpuweb/pull/2966.html" title="Last updated on May 28, 2022, 8:14 AM UTC (90be33f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/2966/5fffd58...jimblandy:90be33f.html" title="Last updated on May 28, 2022, 8:14 AM UTC (90be33f)">Diff</a>