### PR TITLE
Use PredefinedColorSpace instead of GPUPredefinedColorSpace

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1700,22 +1700,8 @@ premultiplication) in which the WebGPU numeric values are to be interpreted.
 Each color space is defined over an extended range, if defined by the referenced CSS definitions,
 to represent color values outside of its space (in both chrominance and luminance).
 
-<script type=idl>
-enum GPUPredefinedColorSpace {
-    "srgb",
-};
-</script>
-
-Issue: Possibly replace this with {{PredefinedColorSpace}}, but note that doing so would mean new
-WebGPU functionality gets added automatically when items are added to that enum in the upstream spec.
-
 Issue(gpuweb/gpuweb#1715):
 Consider a path for uploading srgb-encoded images into linearly-encoded textures.
-
-<dl dfn-type=enum-value dfn-for=GPUPredefinedColorSpace>
-    : <dfn>"srgb"</dfn>
-    :: The CSS predefined color space <a value for=color()>srgb</a>.
-</dl>
 
 A premultiplied RGBA value is <dfn dfn>super-luminant</dfn> if any of the R/G/B channel values
 exceeds the alpha channel value. For example, the premultiplied sRGB RGBA value [1.0, 0, 0, 0.5]
@@ -4021,7 +4007,7 @@ already scheduled to match the video's frame rate.
 <script type=idl>
 dictionary GPUExternalTextureDescriptor : GPUObjectDescriptorBase {
     required HTMLVideoElement source;
-    GPUPredefinedColorSpace colorSpace = "srgb";
+    PredefinedColorSpace colorSpace = "srgb";
 };
 </script>
 
@@ -8034,7 +8020,7 @@ operation, not the semantics of the destination texture.
 
 <script type=idl>
 dictionary GPUImageCopyTextureTagged : GPUImageCopyTexture {
-    GPUPredefinedColorSpace colorSpace = "srgb";
+    PredefinedColorSpace colorSpace = "srgb";
     boolean premultipliedAlpha = false;
 };
 </script>
@@ -11221,7 +11207,7 @@ this incurs a clear of the alpha channel. If a canvas is only needed for interop
         size as |context|.{{GPUCanvasContext/canvas}}.
 
         - If |configuration| is null, the drawing buffer is tagged with the color space
-            {{GPUPredefinedColorSpace/"srgb"}}.
+            {{PredefinedColorSpace/"srgb"}}.
             In this case, the drawing buffer will remain blank until the context is configured.
         - If not, the drawing buffer has the specified
             |configuration|.{{GPUCanvasConfiguration/format}} and is tagged with the specified
@@ -11255,7 +11241,7 @@ dictionary GPUCanvasConfiguration {
     required GPUTextureFormat format;
     GPUTextureUsageFlags usage = 0x10;  // GPUTextureUsage.RENDER_ATTACHMENT
     sequence<GPUTextureFormat> viewFormats = [];
-    GPUPredefinedColorSpace colorSpace = "srgb";
+    PredefinedColorSpace colorSpace = "srgb";
     GPUCanvasAlphaMode alphaMode = "opaque";
 };
 </script>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1697,7 +1697,8 @@ Thus, color conversion must be performed between the WebGPU numeric values and t
 Each such interface point locally defines an encoding (color space, transfer function, and alpha
 premultiplication) in which the WebGPU numeric values are to be interpreted.
 
-Each color space is defined over an extended range, if defined by the referenced CSS definitions,
+WebGPU allows all of the color spaces in the {{PredefinedColorSpace}} enum.
+Note, each color space is defined over an extended range, as defined by the referenced CSS definitions,
 to represent color values outside of its space (in both chrominance and luminance).
 
 Issue(gpuweb/gpuweb#1715):


### PR DESCRIPTION
An issue indicates that doing this would mean that WebGPU automatically
gets support for new color spaces when additional entries are added to
PredefinedColorSpace. This seems like a good thing for the consistency
of the Web platform given WebGL and 2D canvas already do that. If a
future PredefinedColorSpace value is impossible to support in WebGPU
(which is unlikely), then additional validation can be added to the
spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 1, 2022, 8:20 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FKangz%2Fgpuweb%2F93889a304e853350148093e20d4216577abbe006%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%232967.)._
</details>
