### PR TITLE
wgsl: Allow phony assignment of abstract numeric type

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5993,7 +5993,7 @@ In this case the [=right-hand side=] is evaluated, and then ignored.
   </thead>
   <tr algorithm="phony-assignment">
     <td>|e|: |T|,<br>
-        |T| is [=constructible=], a [=pointer type=], a [=texture=] type, or a [=sampler=] type
+        |T| is [=constructible=], an [=abstract numeric type=], a [=pointer type=], a [=texture=] type, or a [=sampler=] type
     <td class="nowrap">_ = |e|
     <td>Evaluates |e|.
 


### PR DESCRIPTION
Without this, a statement such as `_ = 1e300;` would be an error, but would be valid if the LHS were a named `const`.

This might also be useful for code generators, or for developers wanting to validate an expression, but not use the expression (e.g. WIP code).