### PR TITLE
wgsl: Use code tags for enable f16 code snippet.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1544,10 +1544,14 @@ It uses a two's complementation representation, with the sign bit in the most si
 
 ### Floating Point Type ### {#floating-point-types}
 
-The <dfn noexport>f32</dfn> type is the set of 32-bit floating point values of the [[!IEEE-754|IEEE-754]] binary32 (single precision) format.
+The <dfn noexport>f32</dfn> type is the set of 32-bit floating point values of the
+[[!IEEE-754|IEEE-754]] binary32 (single precision) format.
 See [[#floating-point-evaluation]] for details.
 
-The <dfn noexport>f16</dfn> type is the set of 16-bit floating point values of the [[!IEEE-754|IEEE-754]] binary16 (half precision) format. It is a [=shader-creation error=] if the [=f16=] type is used unless the program contains the "enable f16;" directive to enable the [=extension/f16|f16 extension=]. See [[#floating-point-evaluation]] for details.
+The <dfn noexport>f16</dfn> type is the set of 16-bit floating point values of the
+[[!IEEE-754|IEEE-754]] binary16 (half precision) format. It is a [=shader-creation error=]
+if the [=f16=] type is used unless the program contains the `enable f16;` directive to enable
+the [=extension/f16|f16 extension=]. See [[#floating-point-evaluation]] for details.
 
 ### Scalar Types ### {#scalar-types}
 


### PR DESCRIPTION
This converts a "enable f16;" into `enable f16;` as it is a code
snippet.