### PR TITLE
Disallow accessing padding

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1985,8 +1985,8 @@ memory locations.
 Two sets of memory locations <dfn noexport>overlap</dfn> if the intersection of
 their sets of memory locations is non-empty. Each variable declaration has a
 set of memory locations that does not overlap with the sets of memory locations of
-any other variable declaration. Memory operations on structures and arrays
-must not access padding memory locations.
+any other variable declaration. Memory operations on structures and arrays will
+not access padding memory locations.
 
 ### Memory Access Mode ### {#memory-access-mode}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1985,9 +1985,8 @@ memory locations.
 Two sets of memory locations <dfn noexport>overlap</dfn> if the intersection of
 their sets of memory locations is non-empty. Each variable declaration has a
 set of memory locations that does not overlap with the sets of memory locations of
-any other variable declaration. Memory operations on structures and arrays may
-access padding between elements, but it is a [=dynamic error=] to access
-padding at the end of the structure or array.
+any other variable declaration. Memory operations on structures and arrays
+must not access padding memory locations.
 
 ### Memory Access Mode ### {#memory-access-mode}
 


### PR DESCRIPTION
Fixes #1747

* Implementations must not access padding memory locations in structures
  and arrays
  * intentionally not a shader-creation error as it is not expressible
    in WGSL, but is an implementation requirement