### PR TITLE
Add shift operators, remove shiftLeft, shiftRight builtins

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -17,7 +17,6 @@ Text Macro: NUMERIC i32, u32, f32, f16, vec|N|&lt;i32&gt;, vec|N|&lt;u32&gt;, ve
 Text Macro: ALLINTEGRALDECL |S| is AbstractInt, i32, or u32<br>|T| is |S| or vec|N|&lt;|S|&gt;
 Text Macro: ALLFLOATINGDECL |S| is AbstractFloat, f32, or f16<br>|T| is |S| or vec|N|&lt;|S|&gt;
 Text Macro: ALLNUMERICDECL |S| is AbstractInt, AbstractFloat, i32, u32, f32, or f16<br>|T| is |S|, or vec|N|&lt;|S|&gt;
-Text Macro: ALLINTEGRALDECL |S| is AbstractInt, i32, or u32<br>|T| is |S| or vec|N|&lt;|S|&gt;
 Ignored Vars: i, c0, e, e1, e2, e3, eN, p, s1, s2, sn, AS, AM, N, M, C, R, v, Stride, Offset, Align, Extent, T, T1
 
 !Participate: <a href="https://github.com/gpuweb/gpuweb/issues/new?labels=wgsl">File an issue</a> (<a href="https://github.com/gpuweb/gpuweb/issues?q=is%3Aissue+is%3Aopen+label%3Awgsl">open issues</a>)
@@ -5480,6 +5479,74 @@ See [[#sync-builtin-functions]].
     <td>Bitwise-exclusive-or. [=Component-wise=] when |T| is a vector.
 </table>
 
+
+<table class='data'>
+  <caption>Bit shift expressions</caption>
+  <thead>
+    <tr><th>Precondition<th>Conclusion<th>Notes
+  </thead>
+
+  <tr algorithm="concrete shift left">
+    <td>|e1|: |T|<br>
+    |e2|: |TS|<br>
+    |S| is [INT]<br>
+    |T| is |S| or vec|N|&lt;|S|&gt;<br>
+    |TS| is u32 when |T| is |S|, otherwise |TS| is vec|N|&lt;u32&gt;
+    <td class="nowrap">|e1| `<<` |e2|: |T|
+    <td>Shift left (concrete):
+
+        Shift |e1| left, inserting zero bits at the least significant positions,
+        and discarding the most significant bits.
+
+        The number of bits to shift is the value of |e2|, modulo the bit width of |e1|.<br>
+
+        [=Component-wise=] when |T| is a vector.
+
+  <tr algorithm="abstract shift left">
+    <td>|e1|: |T|<br>
+    |e2|: |T|<br>
+    |T| is AbstractInt or vec|N|&lt;AbstractInt&gt;
+    <td class="nowrap">|e1| `<<` |e2|: |T|
+    <td>Shift left (abstract):
+
+        Shift |e1| left, inserting zero bits at the least significant positions,
+        and discarding the most significant bits.
+
+        The number of bits to shift is the value of |e2|.
+
+        [=Component-wise=] when |T| is a vector.
+
+        It is a [=shader-creation error=] if the calculation would overflow the AbstractInt type.
+        Overflow occurs when both 0 and 1 bits would be discarded,
+        or when the most significant bit of |e1| would differ from the most
+        significant bit of the result.
+
+        It is a [=shader-creation error=] if any of the |e2| values are less than 0.
+
+  <tr algorithm="shift right">
+    <td>|e1|: |T|<br>
+    |e2|: |TS|<br>
+    [ALLINTEGRALDECL]<br>
+    |TS| is vec|N|&lt;AbstractInt&gt; or vec|N|&lt;u32&gt; when |T| is vec|N|&lt;S&gt;,
+    otherwise |TS| is AbstractInt or u32
+    <td class="nowrap">|e1| >> |e2|: |T|
+    <td>Shift right.
+
+        If |e1| is unsigned [=concrete=], shift |e1| right, inserting zero bits at the most significant positions,
+        and discarding the least significant bits.
+
+        If |e1| is AbstractInt or signed [=concrete=], shift |e1| right, copying the sign bit of |e1| into the most significant positions,
+        and discarding the least significant bits.
+
+        The number of bits to shift is the value of |e2|.
+        If |e1| has a [=concrete=] type, the shift value is modulo the bit width of |e1|.<br>
+
+        [=Component-wise=] when |T| is a vector.
+
+        If |e2| is an [=AbstractInt=] or vec|N|&lt;AbstractInt&gt;, it is a
+        [=shader-creation error=] if any of the values are less than 0.
+</table>
+
 ## Function Call Expression ## {#function-call-expr}
 
 A function call expression executes a [=function call=] where the called
@@ -5709,21 +5776,30 @@ When an identifier is used as a [=syntax/callable=] item, it is one of:
     | [=syntax/additive_expression=] [=syntax/minus=] [=syntax/multiplicative_expression=]
 </div>
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>relational_expression</dfn> :
+  <dfn for=syntax>shift_expression</dfn> :
 
     | [=syntax/additive_expression=]
 
-    | [=syntax/additive_expression=] [=syntax/less_than=] [=syntax/additive_expression=]
+    | [=syntax/unary_expression=] [=syntax/shift_left=] [=syntax/unary_expression=]
 
-    | [=syntax/additive_expression=] [=syntax/greater_than=] [=syntax/additive_expression=]
+    | [=syntax/unary_expression=] [=syntax/shift_right=] [=syntax/unary_expression=]
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>relational_expression</dfn> :
 
-    | [=syntax/additive_expression=] [=syntax/less_than_equal=] [=syntax/additive_expression=]
+    | [=syntax/shift_expression=]
 
-    | [=syntax/additive_expression=] [=syntax/greater_than_equal=] [=syntax/additive_expression=]
+    | [=syntax/shift_expression=] [=syntax/less_than=] [=syntax/shift_expression=]
 
-    | [=syntax/additive_expression=] [=syntax/equal_equal=] [=syntax/additive_expression=]
+    | [=syntax/shift_expression=] [=syntax/greater_than=] [=syntax/shift_expression=]
 
-    | [=syntax/additive_expression=] [=syntax/not_equal=] [=syntax/additive_expression=]
+    | [=syntax/shift_expression=] [=syntax/less_than_equal=] [=syntax/shift_expression=]
+
+    | [=syntax/shift_expression=] [=syntax/greater_than_equal=] [=syntax/shift_expression=]
+
+    | [=syntax/shift_expression=] [=syntax/equal_equal=] [=syntax/shift_expression=]
+
+    | [=syntax/shift_expression=] [=syntax/not_equal=] [=syntax/shift_expression=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>short_circuit_and_expression</dfn> :
@@ -5972,6 +6048,10 @@ An [=statement/assignment=] is a <dfn noexport>compound assignment</dfn> when th
     | [=syntax/or_equal=]
 
     | [=syntax/xor_equal=]
+
+    | [=syntax/shift_right_equal=]
+
+    | [=syntax/shift_left_equal=]
 </div>
 
 The type requirements, semantics, and behavior of each statement is defined as if
@@ -6005,6 +6085,12 @@ the compound assignment expands as in the following table, except that the refer
 <tr algorithm="bitwise-xor-assign">
     <td class="nowrap">|e1| ^= |e2|
     <td>|e1| = |e1| ^ (|e2|)
+<tr algorithm="bitwise-shiftright-assign">
+    <td class="nowrap">|e1| >>= |e2|
+    <td>|e1| = |e1| >> (|e2|)
+<tr algorithm="bitwise-shiftleft-assign">
+    <td class="nowrap">|e1| <<= |e2|
+    <td>|e1| = |e1| << (|e2|)
 </table>
 
 Note: The syntax does not allow a [=compound assignment=] to also be a [=phony assignment=].
@@ -10099,6 +10185,11 @@ A <dfn>syntactic token</dfn> is a sequence of special code points, used:
     | `'>='` (Code points: `U+003E` `U+003D`)
 </div>
 <div class='syntax' noexport='true'>
+  <dfn for=syntax>shift_right</dfn> :
+
+    | `'>>'`
+</div>
+<div class='syntax' noexport='true'>
   <dfn for=syntax>less_than</dfn> :
 
     | `'<'` (Code point: `U+003C`)
@@ -10107,6 +10198,11 @@ A <dfn>syntactic token</dfn> is a sequence of special code points, used:
   <dfn for=syntax>less_than_equal</dfn> :
 
     | `'<='` (Code points: `U+003C` `U+003D`)
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>shift_left</dfn> :
+
+    | `'<<'` (Code points: `U+003C` `U+003C`)
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>modulo</dfn> :
@@ -10222,6 +10318,16 @@ A <dfn>syntactic token</dfn> is a sequence of special code points, used:
   <dfn for=syntax>xor_equal</dfn> :
 
     | `'^='` (Code points: `U+005E` `U+003D`)
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>shift_right_equal</dfn> :
+
+    | `'>>='` (Code points: `U+005E` `U+005E` `U+003D`)
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>shift_left_equal</dfn> :
+
+    | `'<<='` (Code points: `U+003C` `U+003C` `U+003D`)
 </div>
 
 # Built-in Values # {#builtin-values}
@@ -11078,40 +11184,6 @@ struct __modf_result_vecN_f16 {
     <td>Reverses the bits in |e|:  The bit at position |k| of the result equals the
         bit at position 31-|k| of |e|.<br>
         [=Component-wise=] when |T| is a vector.
-
-  <tr algorithm="shift left">
-    <td>[ALLINTEGRALDECL]<br>
-    |TS| is AbstractInt or u32 if |T| is scalar, or<br>
-    vec|N|&lt;AbstractInt&gt;, or vec|N|&lt;u32&gt; otherwise
-    <td class="nowrap">`@const fn shiftLeft(`|e1|`:` |T|`,` |e2|`:` |TS|`) ->` |T|
-    <td>Logical shift left.<br>
-    Shift |e1| left, inserting zero bits at the least significant positions,
-    and discarding the most significant bits.
-
-    The number of bits to shift is the value of |e2|.
-    If |e1| has a [=concrete=] type, the shift value is modulo the bit width of |e1|.<br>
-    [=Component-wise=] when |T| is a vector.
-
-    If |e2| is an [=AbstractInt=] or vec|N|&lt;AbstractInt&gt;, it is a
-    [=shader-creation error=] if any of the values are less than 0.
-
-  <tr algorithm="shift right">
-    <td>[ALLINTEGRALDECL]>br>
-    |TS| is AbstractInt or u32 if |T| is scalar, or<br>
-    vec|N|&lt;AbstractInt&gt;, or vec|N|&lt;u32&gt; otherwise
-    <td class="nowrap">`@const fn shiftRight(`|e1|`:` |T|`,` |e2|`:` |TS|`) ->` |T|
-    <td>Logical shift right.<br>
-    If |e1| is signed, shift |e1| right, inserting zero bits at the most
-    significant positions, and discarding the least significant bits.
-    If |e1| is unsigned, shift |e1| right, copying the sign bit of |e1| into
-    the most significant positions, and discarding the least significant bits.
-
-    The number of bits to shift is the value of |e2|.
-    If |e1| has a [=concrete=] type, the shift value is modulo the bit width of |e1|.<br>
-    [=Component-wise=] when |T| is a vector.
-
-    If |e2| is an [=AbstractInt=] or vec|N|&lt;AbstractInt&gt;, it is a
-    [=shader-creation error=] if any of the values are less than 0.
 
 </table>
 


### PR DESCRIPTION
Part 1:

  Revert "Remove shift tokens and add shift built-in functions (#2713)"
  This reverts commit 48efd979a020562177715416de4a124bf8126f03.

Part 2:

  Since the removal of shift operators, the shiftLeft and shiftRight
  builtins added the ability to take operands that were AbstractInt
  or vectors of AbstractInt.

  We already have a rule that creation-time expressions must not
  overflow. For shift-left, that can only be determined if both its
  operands are abstract.  So split the description of shift-left
  into all-concrete operands, and all-abstract operands.

  Additionally, spell out the overflow condition for the all-abstract
  form of shift-left.

Fixes: #2092