### PR TITLE
Fix typos

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -508,7 +508,7 @@ The privacy considerations for WebGPU are similar to those of WebGL. GPU APIs ar
 expose various aspects of a device's capabilities out of necessity in order to enable developers to
 take advantage of those capabilities effectively. The general mitigation approach involves
 normalizing or binning potentially identifying information and enforcing uniform behavior where
-possble.
+possible.
 
 ### Machine-specific limits ### {#privacy-machine-limits}
 
@@ -1203,7 +1203,7 @@ on all implementations, typically due to hardware or system software constraints
 Each {{GPUAdapter}} exposes a set of available features.
 Only those features may be requested in {{GPUAdapter/requestDevice()}}.
 
-Functionality that is part of an feature may only be used if the feature was requested at device
+Functionality that is part of a feature may only be used if the feature was requested at device
 creation.
 Dictionary members added to existing dictionaries by optional features are always optional at the
 WebIDL level; if the feature is not enabled, such members must not be set to non-default values.
@@ -1552,11 +1552,11 @@ interface GPUAdapterInfo {
 <dl dfn-type=attribute dfn-for=GPUAdapterInfo>
     : <dfn>vendor</dfn>
     ::
-        The name of the vendor of the [=adapter=], if avaliable. Empty string otherwise.
+        The name of the vendor of the [=adapter=], if available. Empty string otherwise.
 
     : <dfn>architecture</dfn>
     ::
-        The name of the family or class of GPUs the [=adapter=] belongs to, if avaliable. Empty
+        The name of the family or class of GPUs the [=adapter=] belongs to, if available. Empty
         string otherwise.
 
     : <dfn>device</dfn>
@@ -1569,7 +1569,7 @@ interface GPUAdapterInfo {
 
     : <dfn>description</dfn>
     ::
-        A human readable string describing the [=adapter=] as reported by the driver, if avaliable.
+        A human readable string describing the [=adapter=] as reported by the driver, if available.
         Empty string otherwise.
 
         Note: Because no formatting is applied to {{GPUAdapterInfo/description}} attempting to parse
@@ -1604,13 +1604,13 @@ interface GPUAdapterInfo {
             reasonable approximation of the architecture as a [=normalized identifier string=].
 
     1. If |unmaskedValues| [=set/contains=] `"device"` and the device is known:
-        1. Set |adapterInfo|.{{GPUAdapterInfo/device}} to a to a [=normalized identifier string=]
-             reprenting a vendor-specific indetifier for |adapter|.
+        1. Set |adapterInfo|.{{GPUAdapterInfo/device}} to a [=normalized identifier string=]
+             representing a vendor-specific identifier for |adapter|.
 
         Otherwise:
 
         1. Set |adapterInfo|.{{GPUAdapterInfo/device}} to to the empty string or a
-            reasonable approximation of a vendor-specific indetifier as a [=normalized identifier
+            reasonable approximation of a vendor-specific identifier as a [=normalized identifier
             string=].
 
     1. If |unmaskedValues| [=set/contains=] `"description"` and a description is known:
@@ -3505,7 +3505,7 @@ enum GPUTextureAspect {
 
         For textures created from sources where the layer count is unknown at the
         time of development it is recommended that calls to {{GPUTexture/createView()}} are provided
-        an explicit {{GPUTextureViewDescriptor/dimension}} to ensure shader compatibility.
+        with an explicit {{GPUTextureViewDescriptor/dimension}} to ensure shader compatibility.
         </div>
 
         <div algorithm=GPUTexture.createView>
@@ -5413,7 +5413,7 @@ dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
 #### Shader Module Compilation Hints #### {#shader-module-compilation-hints}
 
 Shader module compilation hints are optional, additional information indicating how a given
-{{GPUShaderModule}} entry point is intended to be used in the future. For some implmentations this
+{{GPUShaderModule}} entry point is intended to be used in the future. For some implementations this
 information may aid in compiling the shader module earlier, potentially increasing performance.
 
 <script type=idl>
@@ -6431,7 +6431,7 @@ constructs and rasterizes primitives from its vertex inputs:
 <dl dfn-type=dict-member dfn-for=GPUPrimitiveState>
     : <dfn>topology</dfn>
     ::
-        The type of primitive to be constructed from the vertex inptus.
+        The type of primitive to be constructed from the vertex inputs.
 
     : <dfn>stripIndexFormat</dfn>
     ::
@@ -6586,7 +6586,7 @@ interacts with a render pass's multisampled attachments.
     : <dfn>alphaToCoverageEnabled</dfn>
     ::
         When `true` indicates that a fragment's alpha channel should be used to generate a sample
-        covarge mask.
+        coverage mask.
 </dl>
 
 <div algorithm>
@@ -7085,7 +7085,7 @@ when doing indexed rendering.
 
 #### Vertex Formats #### {#vertex-formats}
 
-The {{GPUVertexFormat}} of a vertex attribute indicate the how data from a vertex buffer will
+The {{GPUVertexFormat}} of a vertex attribute indicates how data from a vertex buffer will
 be interpreted and exposed to the shader. The name of the format specifies the order of components,
 bits per component, and [=vertex data type=] for the component.
 
@@ -8030,7 +8030,7 @@ dictionary GPUImageCopyTextureTagged : GPUImageCopyTexture {
 
     : <dfn>premultipliedAlpha</dfn>
     ::
-        Describes whether the data written into the texture should be have its RGB channels
+        Describes whether the data written into the texture should have its RGB channels
         premultiplied by the alpha channel, or not.
 
         If this option is set to `true` and the {{GPUImageCopyExternalImage/source}} is also


### PR DESCRIPTION
This PR fixes some typos found in the spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 1, 2022, 8:07 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fgpuweb%2Fgpuweb%2F50b468a4e94f9231c5f36ab9c952aeb64a38d245%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%232992.)._
</details>
