### PR TITLE
Alignment limits must not go below 16

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1377,6 +1377,9 @@ applications should generally request the "worst" limits that work for their con
         |entry|.{{GPUBindGroupLayoutEntry/buffer}}?.{{GPUBufferBindingLayout/type}}
         is {{GPUBufferBindingType/"uniform"}}.
 
+        Implementations **must not** support values less than the largest alignment of a
+        built-in host-shareable type in WGSL, which is 16 bytes. See [[WGSL#alignment-and-size]].
+
     <tr><td><dfn>minStorageBufferOffsetAlignment</dfn>
         <td>{{GPUSize32}} <td>[=limit class/alignment=] <td>256
     <tr class=row-continuation><td colspan=4>
@@ -1386,6 +1389,9 @@ applications should generally request the "worst" limits that work for their con
         |entry|.{{GPUBindGroupLayoutEntry/buffer}}?.{{GPUBufferBindingLayout/type}}
         is {{GPUBufferBindingType/"storage"}}
         or {{GPUBufferBindingType/"read-only-storage"}}.
+
+        Implementations **must not** support values less than the largest alignment of a
+        built-in host-shareable type in WGSL, which is 16 bytes. See [[WGSL#alignment-and-size]].
 
     <tr><td><dfn>maxVertexBuffers</dfn>
         <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>8


### PR DESCRIPTION
I postulate this is future-proof because `vec4<f64>` only requires 8-byte alignment and not 32-byte alignment. But I don't know for sure.

Fixes #2505