### PR TITLE
Add GPURenderPassDescriptor.maxDrawCount

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7835,6 +7835,8 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                             index in |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}}.
                         1. Otherwise, if |timestampWrite|.{{GPURenderPassTimestampWrite/location}} is {{GPURenderPassTimestampLocation/"end"}},
                             [=list/Append=] |timestampWrite| to |pass|.{{GPURenderPassEncoder/[[endTimestampWrites]]}}.
+                    1. Set |pass|.{{GPURenderCommandsMixin/[[drawCount]]}} to 0.
+                    1. Set |pass|.{{GPURenderPassEncoder/[[maxDrawCount]]}} to |descriptor|.{{GPURenderPassDescriptor/maxDrawCount}}.
                     1. Issue: Enqueue attachment loads/clears.
 
                 </div>
@@ -9249,6 +9251,10 @@ GPURenderPassEncoder includes GPURenderCommandsMixin;
     : <dfn>\[[endTimestampWrites]]</dfn>, of type {{GPURenderPassTimestampWrites}}
     ::
         The timestamp attachments which need to be executed when the pass ends.
+
+    : <dfn>\[[maxDrawCount]]</dfn> of type {{GPUSize64}}.
+    ::
+        The maximum number of draws allowed in this pass.
 </dl>
 
 When a {{GPURenderPassEncoder}} is created, it has the following default state:
@@ -9281,6 +9287,7 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
     GPURenderPassDepthStencilAttachment depthStencilAttachment;
     GPUQuerySet occlusionQuerySet;
     GPURenderPassTimestampWrites timestampWrites = [];
+    GPUSize64 maxDrawCount = 50000000;
 };
 </script>
 
@@ -9308,6 +9315,12 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
     : <dfn>timestampWrites</dfn>
     ::
         A sequence of {{GPURenderPassTimestampWrite}} values defines where and when timestamp values will be written for this pass.
+
+    : <dfn>maxDrawCount</dfn>
+    ::
+        The maximum number of draw calls that will be done in the render pass. Used by some
+        implementations to size work injected before the render pass. Keeping the default value
+        is a good default, unless it is known that more draw calls will be done.
 </dl>
 
 <div class=validusage dfn-for=GPURenderPassDescriptor>
@@ -9728,6 +9741,7 @@ called the render pass encoder can no longer be used.
                         - |this| must be [=valid=].
                         - |this|.{{GPUDebugCommandsMixin/[[debug_group_stack]]}} must [=list/is empty|be empty=].
                         - |this|.{{GPURenderPassEncoder/[[occlusion_query_active]]}} must be `false`.
+                        - |this|.{{GPURenderCommandsMixin/[[drawCount]]}} must be less than |this|.{{GPURenderPassEncoder/[[maxDrawCount]]}}.
                     </div>
                 1. [=list/Extend=] |parentEncoder|.{{GPUCommandsMixin/[[commands]]}}
                     with |this|.{{GPUCommandsMixin/[[commands]]}}.
@@ -9810,6 +9824,10 @@ It must only be included by interfaces which also include those mixins.
     ::
         The size in bytes of the section of {{GPUBuffer}} currently set for each slot, initially
         empty.
+
+    : <dfn>\[[drawCount]]</dfn>, of type {{GPUSize64}}
+    ::
+        The number of draw commands recorded in this encoder.
 </dl>
 
 ### Drawing ### {#render-pass-encoder-drawing}
@@ -9961,6 +9979,7 @@ It must only be included by interfaces which also include those mixins.
                             - If |strideCount| &ne; `0`
                                 - Ensure (|strideCount| &minus; `1`) &times; |stride| &plus; |lastStride| &le; |bufferSize|.
                     </div>
+                1. Increment |this|.{{GPURenderCommandsMixin/[[drawCount]]}} by 1.
             </div>
         </div>
 
@@ -10002,6 +10021,7 @@ It must only be included by interfaces which also include those mixins.
                             - If |buffers|[|slot|].{{GPUVertexBufferLayout/stepMode}} is {{GPUVertexStepMode/"instance"}} and |strideCount| &ne; `0`:
                                 - Ensure (|strideCount| &minus; `1`) &times; |stride| &plus; |lastStride| &le; |bufferSize|.
                     </div>
+                1. Increment |this|.{{GPURenderCommandsMixin/[[drawCount]]}} by 1.
             </div>
 
             Note: a valid program should also never use vertex indices with
@@ -10057,6 +10077,7 @@ It must only be included by interfaces which also include those mixins.
                         - |indirectOffset| is a multiple of 4.
                     </div>
                 1. Add |indirectBuffer| to the [=usage scope=] as [=internal usage/input=].
+                1. Increment |this|.{{GPURenderCommandsMixin/[[drawCount]]}} by 1.
             </div>
         </div>
 
@@ -10106,6 +10127,7 @@ It must only be included by interfaces which also include those mixins.
                         - |indirectOffset| is a multiple of 4.
                     </div>
                 1. Add |indirectBuffer| to the [=usage scope=] as [=internal usage/input=].
+                1. Increment |this|.{{GPURenderCommandsMixin/[[drawCount]]}} by 1.
             </div>
         </div>
 </dl>
@@ -10360,7 +10382,11 @@ attachments used by this encoder.
                             - If |this|.{{GPURenderCommandsMixin/[[depthReadOnly]]}} is true, |bundle|.{{GPURenderBundle/[[depthReadOnly]]}} must be true.
                             - If |this|.{{GPURenderCommandsMixin/[[stencilReadOnly]]}} is true, |bundle|.{{GPURenderBundle/[[stencilReadOnly]]}} must be true.
                     </div>
-                1. Issue: Describe steps
+
+                - For each |bundle| in |bundles|:
+                    - Increment |this|.{{GPURenderCommandsMixin/[[drawCount]]}} by |bundle|.{{GPURenderBundle/[[drawCount]]}}.
+
+                1. Issue: Describe the rest of the steps
             </div>
 
         </div>
@@ -10394,6 +10420,10 @@ GPURenderBundle includes GPUObjectBase;
     : <dfn>\[[stencilReadOnly]]</dfn>, of type boolean
     ::
         If `true`, indicates that the stencil component is not modified by executing this render bundle.
+
+    : <dfn>\[[drawCount]]</dfn>, of type {{GPUSize64}}
+    ::
+        The number of draw commands in this {{GPURenderBundle}}.
 </dl>
 
 ### Creation ### {#render-bundle-creation}
@@ -10458,6 +10488,7 @@ GPURenderBundleEncoder includes GPURenderCommandsMixin;
                     1. Set |e|.{{GPURenderCommandsMixin/[[depthReadOnly]]}} to |descriptor|.{{GPURenderBundleEncoderDescriptor/depthReadOnly}}.
                     1. Set |e|.{{GPURenderCommandsMixin/[[stencilReadOnly]]}} to |descriptor|.{{GPURenderBundleEncoderDescriptor/stencilReadOnly}}.
                     1. Set |e|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/open=]".
+                    1. Set |e|.{{GPURenderCommandsMixin/[[drawCount]]}} to 0.
 
                     Issue: Describe the reset of the steps for {{GPUDevice/createRenderBundleEncoder()}}.
                 </div>
@@ -10507,6 +10538,8 @@ dictionary GPURenderBundleEncoderDescriptor : GPURenderPassLayout {
                         1. Return a new [=invalid=] {{GPURenderBundle}}.
                     1. Set |renderBundle|.{{GPURenderBundle/[[command_list]]}} to
                         |this|.{{GPUCommandsMixin/[[commands]]}}.
+                    1. Set |renderBundle|.{{GPURenderBundle/[[drawCount]]}} to
+                        |this|.{{GPURenderCommandsMixin/[[drawCount]]}}.
                 </div>
 
             1. Return |renderBundle|.


### PR DESCRIPTION
Fixes #2189


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 2, 2022, 3:34 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FKangz%2Fgpuweb%2F1e32635b49903e9d988f624f55e36e1ac81b1b9f%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%233005.)._
</details>
