### PR TITLE
Update WGSL stage syntax in example code

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1595,9 +1595,9 @@ interface GPUAdapterInfo {
     1. If |unmaskedValues| [=set/contains=] `"vendor"` and the vendor is known:
         1. Set |adapterInfo|.{{GPUAdapterInfo/vendor}} to the name of |adapter|'s vendor as a
             [=normalized identifier string=].
-        
+
         Otherwise:
-        
+
         1. Set |adapterInfo|.{{GPUAdapterInfo/vendor}} to the empty string or a
             reasonable approximation of the vendor as a [=normalized identifier string=].
 
@@ -5400,12 +5400,12 @@ dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
             var&lt;private&gt; pos : array&lt;vec2&lt;f32&gt;, 3&gt; = array&lt;vec2&lt;f32&gt;, 3&gt;(
                 vec2(-1.0, -1.0), vec2(-1.0, 3.0), vec2(3.0, -1.0));
 
-            @stage(vertex)
+            @vertex
             fn vertexMain(@builtin(vertex_index) vertexIndex : u32) -&gt; @builtin(position) vec4&lt;f32&gt; {
                 return vec4(pos[input.vertexIndex], 1.0, 1.0);
             }
 
-            @stage(fragment)
+            @fragment
             fn fragmentMain() -&gt; @location(0) vec4&lt;f32&gt; {
                 return vec4(1.0, 0.0, 0.0, 1.0);
             }


### PR DESCRIPTION
Flagged by @magcius on the WebGPU matrix chat, the WGSL spec has already
changed over to using `@vertex`, `@compute`, and `@fragment` rather than
`@stage(...)`.