### PR TITLE
Even more descriptor definitions

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5818,7 +5818,18 @@ dictionary GPUProgrammableStage {
 typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32, u32, and f16 if enabled.
 </script>
 
+{{GPUProgrammableStage}} has the following members:
+
 <dl dfn-for=GPUProgrammableStage dfn-type=dict-member>
+    : <dfn>module</dfn>
+    ::
+        The {{GPUShaderModule}} containing the code that this programmable stage will execute.
+
+    : <dfn>entryPoint</dfn>
+    ::
+        The name of the function in {{GPUProgrammableStage/module}} that this stage will use to
+        perform its work.
+
     : <dfn>constants</dfn>
     ::
         Specifies the values of [=pipeline-overridable=] constants in the shader module
@@ -6073,11 +6084,22 @@ GPUComputePipeline includes GPUPipelineBase;
 
 ### Creation ### {#compute-pipeline-creation}
 
+A {{GPURenderPipelineDescriptor}} describes the state of a compute [=pipeline=]. See
+[[#computing-operations]] for additional details.
+
 <script type=idl>
 dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
     required GPUProgrammableStage compute;
 };
 </script>
+
+{{GPUComputePipelineDescriptor}} has the following members:
+
+<dl dfn-type=dict-member dfn-for=GPUComputePipelineDescriptor>
+    : <dfn>compute</dfn>
+    ::
+        Describes the compute shader entry point of the [=pipeline=].
+</dl>
 
 <dl dfn-type=method dfn-for=GPUDevice>
     : <dfn>createComputePipeline(descriptor)</dfn>
@@ -6228,6 +6250,9 @@ GPURenderPipeline includes GPUPipelineBase;
 
 ### Creation ### {#render-pipeline-creation}
 
+A {{GPURenderPipelineDescriptor}} describes the state of a render [=pipeline=] by configuring each
+of the [=render stages=]. See [[#rendering-operations]] for additional details.
+
 <script type=idl>
 dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
     required GPUVertexState vertex;
@@ -6238,21 +6263,30 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
 };
 </script>
 
-A {{GPURenderPipelineDescriptor}} describes the state of a render [=pipeline=] by
-configuring each of the [=render stages=]. See [[#rendering-operations]] for the
-details.
+{{GPURenderPipelineDescriptor}} has the following members:
 
-- {{GPURenderPipelineDescriptor/vertex}} describes
-    the vertex shader entry point of the [=pipeline=] and its input buffer layouts.
-- {{GPURenderPipelineDescriptor/primitive}} describes
-    the primitive-related properties of the [=pipeline=].
-- {{GPURenderPipelineDescriptor/depthStencil}} describes
-    the optional depth-stencil properties, including the testing, operations, and bias.
-- {{GPURenderPipelineDescriptor/multisample}} describes
-    the multi-sampling properties of the [=pipeline=].
-- {{GPURenderPipelineDescriptor/fragment}} describes
-    the fragment shader entry point of the [=pipeline=] and its output colors.
-    If it's `null`, the [[#no-color-output]] mode is enabled.
+<dl dfn-type=dict-member dfn-for=GPURenderPipelineDescriptor>
+    : <dfn>vertex</dfn>
+    ::
+        Describes the vertex shader entry point of the [=pipeline=] and its input buffer layouts.
+
+    : <dfn>primitive</dfn>
+    ::
+        Describes the primitive-related properties of the [=pipeline=].
+
+    : <dfn>depthStencil</dfn>
+    ::
+        Describes the optional depth-stencil properties, including the testing, operations, and bias.
+
+    : <dfn>multisample</dfn>
+    ::
+        Describes the multi-sampling properties of the [=pipeline=].
+
+    : <dfn>fragment</dfn>
+    ::
+        Describes the fragment shader entry point of the [=pipeline=] and its output colors. If
+        `undefined`, the [[#no-color-output]] mode is enabled.
+</dl>
 
 <dl dfn-type=method dfn-for=GPUDevice>
     : <dfn>createRenderPipeline(descriptor)</dfn>
@@ -11274,6 +11308,43 @@ dictionary GPUCanvasConfiguration {
     GPUCanvasAlphaMode alphaMode = "opaque";
 };
 </script>
+
+{{GPUCanvasConfiguration}} has the following members:
+
+<dl dfn-type=dict-member dfn-for=GPUCanvasConfiguration>
+    : <dfn>device</dfn>
+    ::
+        The {{GPUDevice}} that textures returned by {{GPUCanvasContext/getCurrentTexture()}} will be
+        compatible with.
+
+    : <dfn>format</dfn>
+    ::
+        The format that textures returned by {{GPUCanvasContext/getCurrentTexture()}} will have.
+        Must be one of the [=Supported context formats=].
+
+    : <dfn>usage</dfn>
+    ::
+        The usage that textures returned by {{GPUCanvasContext/getCurrentTexture()}} will have.
+        {{GPUTextureUsage/RENDER_ATTACHMENT}} is the default, but is not automatically included
+        if the usage is explicitly set. Be sure to include {{GPUTextureUsage/RENDER_ATTACHMENT}}
+        when setting a custom usage if you wish to use textures returned by
+        {{GPUCanvasContext/getCurrentTexture()}} as color targets for a render pass.
+
+    : <dfn>viewFormats</dfn>
+    ::
+        The formats that views created from textures returned by
+        {{GPUCanvasContext/getCurrentTexture()}} may use.
+
+    : <dfn>colorSpace</dfn>
+    ::
+        The color space that values written into textures returned by
+        {{GPUCanvasContext/getCurrentTexture()}} should be displayed with.
+
+    : <dfn>alphaMode</dfn>
+    ::
+        Determines the effect that alpha values will have on the content of textures returned by
+        {{GPUCanvasContext/getCurrentTexture()}} when read, displayed, or used as an image source.
+</dl>
 
 <div class="example">
     Configure a {{GPUCanvasContext}} to be used with a specific {{GPUDevice}}, using the preferred

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6084,7 +6084,7 @@ GPUComputePipeline includes GPUPipelineBase;
 
 ### Creation ### {#compute-pipeline-creation}
 
-A {{GPURenderPipelineDescriptor}} describes the state of a compute [=pipeline=]. See
+A {{GPURenderPipelineDescriptor}} describes a compute [=pipeline=]. See
 [[#computing-operations]] for additional details.
 
 <script type=idl>
@@ -6250,7 +6250,7 @@ GPURenderPipeline includes GPUPipelineBase;
 
 ### Creation ### {#render-pipeline-creation}
 
-A {{GPURenderPipelineDescriptor}} describes the state of a render [=pipeline=] by configuring each
+A {{GPURenderPipelineDescriptor}} describes a render [=pipeline=] by configuring each
 of the [=render stages=]. See [[#rendering-operations]] for additional details.
 
 <script type=idl>


### PR DESCRIPTION
Adds or improves member definitions for the following dictionaries
 - GPUCanvasConfiguration
 - GPUProgrammableStage
 - GPUComputePipelineDescriptor
 - GPURenderPipelineDescriptor


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/pull/3009.html" title="Last updated on Jun 2, 2022, 11:52 PM UTC (1c67a70)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/3009/fa141f1...1c67a70.html" title="Last updated on Jun 2, 2022, 11:52 PM UTC (1c67a70)">Diff</a>