### PR TITLE
Return null from getMappedRange if mapping is pending

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2429,7 +2429,7 @@ that returns a new buffer in the [=buffer state/mapped=] or [=buffer state/unmap
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUBuffer {
     Promise<undefined> mapAsync(GPUMapModeFlags mode, optional GPUSize64 offset = 0, optional GPUSize64 size);
-    ArrayBuffer getMappedRange(optional GPUSize64 offset = 0, optional GPUSize64 size);
+    ArrayBuffer? getMappedRange(optional GPUSize64 offset = 0, optional GPUSize64 size);
     undefined unmap();
 
     undefined destroy();
@@ -2889,7 +2889,8 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
 
             1. If any of the following conditions are unsatisfied, throw an {{OperationError}} and stop.
                 <div class=validusage>
-                    - |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapped=] or [=buffer state/mapped at creation=].
+                    - |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapped=],
+                        [=buffer state/mapped at creation=], or [=buffer state/mapping pending=].
                     - |offset| is a multiple of 8.
                     - |rangeSize| is a multiple of 4.
                     - |offset| is greater than or equal to |this|.{{GPUBuffer/[[mapping_range]]}}[0].
@@ -2902,6 +2903,8 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
 
                     Issue: Consider aligning mapAsync offset to 8 to match this.
                 </div>
+
+            1. If |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapping pending=], return `null`.
 
             1. Let |m| be a new {{ArrayBuffer}} of size |rangeSize| pointing at the content
                 of |this|.{{GPUBuffer/[[mapping]]}} at offset |offset| - |this|.{{GPUBuffer/[[mapping_range]]}}[0].


### PR DESCRIPTION
getMappedRange can be used to detect whether a map has completed (even
before this change, using try/catch). This is a valid way of knowing
when a map is available - it's pretty much equivalent to
`mapAsync().then(() => { is_mapped = true; })`; the
state can only change when mapAsync's resolution happens anyway so the
state can't change inside a task.

This change makes this explicit by returning null instead of throwing an
exception in this case. This makes it distinguishable from real errors
which are still thrown as exceptions

Open questions:
- Should there be a way to query this without actually getting a mapped
  range? I think maybe, but you can always do the promise thing above.
- Should getMappedRange also return null when the buffer is in the
  unmapped state? I think no, it should still throw an exception.
- How does this get exposed in webgpu.h? (I'll open an issue there if we
  do this.)

Fixes #3013


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 6, 2022, 10:30 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fgpuweb%2Fgpuweb%2F4660d839c35e7b6cb6cf66c5ee2a62fa3ed09f49%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%233010.)._
</details>
