### PR TITLE
Format internal slots consistently with IDL attributes

### DIFF
--- a/explainer/index.bs
+++ b/explainer/index.bs
@@ -1078,8 +1078,8 @@ The exact format cannot be hidden, because the format is observable - e.g.,
 in the behavior of a `copyBufferToTexture` call and in compatibility rules with render pipelines
 (which specify a format, see `GPUColorTargetState.format`).
 
-Desktop-lineage hardware usually prefers `bgra8unorm` (4 bytes in BGRA order),
-while mobile-lineage hardware usually prefers `rgba8unorm` (4 bytes in RGBA order).
+Most hardware prefers `bgra8unorm` (4 bytes in BGRA order) or is agnostic, while some mobile and
+embedded devices (like Android phones) prefer `rgba8unorm` (4 bytes in RGBA order).
 
 For high-bit-depth, different systems may also prefer different formats,
 like `rgba16float` or `rgb10a2unorm`.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2455,11 +2455,11 @@ GPUBuffer includes GPUObjectBase;
 {{GPUBuffer}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUBuffer">
-    : <dfn>\[[state]]</dfn> of type [=buffer state=].
+    : <dfn>\[[state]]</dfn>, of type [=buffer state=]
     ::
         The current state of the {{GPUBuffer}}.
 
-    : <dfn>\[[mapping]]</dfn> of type {{ArrayBuffer}} or {{Promise}} or `null`.
+    : <dfn>\[[mapping]]</dfn>, of type {{ArrayBuffer}} or {{Promise}} or `null`
     ::
         The mapping for this {{GPUBuffer}}. The {{ArrayBuffer}} isn't directly accessible
         and is instead accessed through views into it, called the mapped ranges, that are
@@ -2468,16 +2468,16 @@ GPUBuffer includes GPUObjectBase;
         Issue(gpuweb/gpuweb#605): Specify {{GPUBuffer/[[mapping]]}} in term of `DataBlock` similarly
         to `AllocateArrayBuffer`?
 
-    : <dfn>\[[mapping_range]]</dfn> of type [=list=]&lt;{{unsigned long long}}&gt; or `null`.
+    : <dfn>\[[mapping_range]]</dfn>, of type [=list=]&lt;{{unsigned long long}}&gt; or `null`
     ::
         The range of this {{GPUBuffer}} that is mapped.
 
-    : <dfn>\[[mapped_ranges]]</dfn> of type [=list=]&lt;{{ArrayBuffer}}&gt; or `null`.
+    : <dfn>\[[mapped_ranges]]</dfn>, of type [=list=]&lt;{{ArrayBuffer}}&gt; or `null`
     ::
         The {{ArrayBuffer}}s returned via {{GPUBuffer/getMappedRange}} to the application. They are tracked
         so they can be detached when {{GPUBuffer/unmap}} is called.
 
-    : <dfn>\[[map_mode]]</dfn> of type {{GPUMapModeFlags}}.
+    : <dfn>\[[map_mode]]</dfn>, of type {{GPUMapModeFlags}}
     ::
         The {{GPUMapModeFlags}} of the last call to {{GPUBuffer/mapAsync()}} (if any).
 </dl>
@@ -4217,11 +4217,11 @@ GPUSampler includes GPUObjectBase;
     ::
         The {{GPUSamplerDescriptor}} with which the {{GPUSampler}} was created.
 
-    : <dfn>\[[isComparison]]</dfn> of type {{boolean}}.
+    : <dfn>\[[isComparison]]</dfn>, of type {{boolean}}
     ::
         Whether the {{GPUSampler}} is used as a comparison sampler.
 
-    : <dfn>\[[isFiltering]]</dfn> of type {{boolean}}.
+    : <dfn>\[[isFiltering]]</dfn>, of type {{boolean}}
     ::
         Whether the {{GPUSampler}} weights multiple samples of a texture.
 </dl>
@@ -4831,16 +4831,16 @@ dictionary GPUExternalTextureBindingLayout {
 A {{GPUBindGroupLayout}} object has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUBindGroupLayout">
-    : <dfn>\[[entryMap]]</dfn> of type [=ordered map=]&lt;{{GPUSize32}}, {{GPUBindGroupLayoutEntry}}&gt.
+    : <dfn>\[[entryMap]]</dfn>, of type [=ordered map=]&lt;{{GPUSize32}}, {{GPUBindGroupLayoutEntry}}&gt
     ::
         The map of binding indices pointing to the {{GPUBindGroupLayoutEntry}}s,
         which this {{GPUBindGroupLayout}} describes.
 
-    : <dfn>\[[dynamicOffsetCount]]</dfn> of type {{GPUSize32}}.
+    : <dfn>\[[dynamicOffsetCount]]</dfn>, of type {{GPUSize32}}
     ::
         The number of buffer bindings with dynamic offsets in this {{GPUBindGroupLayout}}.
 
-    : <dfn>\[[exclusivePipeline]]</dfn> of type {{GPUPipelineBase}}?, initially `null`.
+    : <dfn>\[[exclusivePipeline]]</dfn>, of type {{GPUPipelineBase}}?, initially `null`
     ::
         The pipeline that created this {{GPUBindGroupLayout}}, if it was created as part of a
         [[#default-pipeline-layout|default pipeline layout]]. If not `null`, {{GPUBindGroup}}s
@@ -5214,7 +5214,7 @@ GPUPipelineLayout includes GPUObjectBase;
 {{GPUPipelineLayout}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUPipelineLayout">
-    : <dfn>\[[bindGroupLayouts]]</dfn> of type [=list=]&lt;{{GPUBindGroupLayout}}&gt;.
+    : <dfn>\[[bindGroupLayouts]]</dfn>, of type [=list=]&lt;{{GPUBindGroupLayout}}&gt;
     ::
         The {{GPUBindGroupLayout}} objects provided at creation in {{GPUPipelineLayoutDescriptor/bindGroupLayouts|GPUPipelineLayoutDescriptor.bindGroupLayouts}}.
 </dl>
@@ -5665,7 +5665,7 @@ interface mixin GPUPipelineBase {
 {{GPUPipelineBase}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUPipelineBase">
-    : <dfn>\[[layout]]</dfn> of type `GPUPipelineLayout`.
+    : <dfn>\[[layout]]</dfn>, of type `GPUPipelineLayout`
     ::
         The definition of the layout of resources which can be used with `this`.
 </dl>
@@ -6300,6 +6300,7 @@ GPURenderPipeline includes GPUPipelineBase;
         The {{GPURenderPipelineDescriptor}} describing this pipeline.
 
         All optional fields of {{GPURenderPipelineDescriptor}} are defined.
+
     : <dfn>\[[writesDepth]]</dfn>, of type boolean
     :: True if the pipeline writes to the depth component of the depth/stencil attachment
 
@@ -7692,7 +7693,7 @@ GPUCommandBuffer includes GPUObjectBase;
 {{GPUCommandBuffer}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUCommandBuffer">
-    : <dfn>\[[command_list]]</dfn> of type [=list=]&lt;[=GPU command=]&gt;.
+    : <dfn>\[[command_list]]</dfn>, of type [=list=]&lt;[=GPU command=]&gt;
     ::
         A [=list=] of [=GPU commands=] to be executed on the [=Queue timeline=] when this command
         buffer is submitted.
@@ -8955,7 +8956,7 @@ It must only be included by interfaces which also include those mixins.
 {{GPUDebugCommandsMixin}} adds the following internal slots to interfaces which include it:
 
 <dl dfn-type=attribute dfn-for=GPUDebugCommandsMixin>
-    : <dfn>\[[debug_group_stack]]</dfn> of type [=stack=]&lt;{{USVString}}&gt;.
+    : <dfn>\[[debug_group_stack]]</dfn>, of type [=stack=]&lt;{{USVString}}&gt;
     ::
         A stack of active debug group labels.
 </dl>
@@ -9047,7 +9048,7 @@ GPUComputePassEncoder includes GPUBindingCommandsMixin;
 {{GPUComputePassEncoder}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUComputePassEncoder">
-    : <dfn>\[[command_encoder]]</dfn> of type {{GPUCommandEncoder}}, readonly
+    : <dfn>\[[command_encoder]]</dfn>, of type {{GPUCommandEncoder}}, readonly
     ::
         The {{GPUCommandEncoder}} that created this compute pass encoder.
 
@@ -9312,7 +9313,7 @@ GPURenderPassEncoder includes GPURenderCommandsMixin;
 {{GPURenderPassEncoder}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPURenderPassEncoder">
-    : <dfn>\[[command_encoder]]</dfn> of type {{GPUCommandEncoder}}, readonly
+    : <dfn>\[[command_encoder]]</dfn>, of type {{GPUCommandEncoder}}, readonly
     ::
         The {{GPUCommandEncoder}} that created this render pass encoder.
 
@@ -10474,7 +10475,7 @@ GPURenderBundle includes GPUObjectBase;
 </script>
 
 <dl dfn-type=attribute dfn-for="GPURenderBundle">
-    : <dfn>\[[command_list]]</dfn> of type [=list=]&lt;[=GPU command=]&gt;.
+    : <dfn>\[[command_list]]</dfn>, of type [=list=]&lt;[=GPU command=]&gt;
     ::
         A [=list=] of [=GPU commands=] to be submitted to the {{GPURenderPassEncoder}} when the
         {{GPURenderBundle}} is executed.
@@ -10921,7 +10922,7 @@ GPUQuerySet includes GPUObjectBase;
 {{GPUQuerySet}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUQuerySet">
-    : <dfn>\[[state]]</dfn> of type [=query set state=].
+    : <dfn>\[[state]]</dfn>, of type [=query set state=]
     ::
         The current state of the {{GPUQuerySet}}.
 </dl>
@@ -11106,14 +11107,14 @@ interface GPUCanvasContext {
 {{GPUCanvasContext}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUCanvasContext">
-    : <dfn>\[[configuration]]</dfn>, of type {{GPUCanvasConfiguration}}?, initially `null`.
+    : <dfn>\[[configuration]]</dfn>, of type {{GPUCanvasConfiguration}}?, initially `null`
     ::
         The options this context is currently configured with.
 
         `null` if the context has not been configured or has been
         {{GPUCanvasContext/unconfigure()|unconfigured}}.
 
-    : <dfn>\[[textureDescriptor]]</dfn>, of type {{GPUTextureDescriptor}}?, initially `null`.
+    : <dfn>\[[textureDescriptor]]</dfn>, of type {{GPUTextureDescriptor}}?, initially `null`
     ::
         The currently configured texture descriptor, derived from the
         {{GPUCanvasContext/[[configuration]]}} and canvas.
@@ -11586,11 +11587,11 @@ of WebGPU calls, typically for debugging purposes or to make an operation more f
 
 [=GPU error scope=] has the following internal slots:
 <dl dfn-type=attribute dfn-for="GPU error scope">
-    : <dfn>\[[error]]</dfn> of type {{GPUError}}?, initially `null`.
+    : <dfn>\[[error]]</dfn>, of type {{GPUError}}?, initially `null`
     ::
         The first {{GPUError}}, if any, observed while the [=GPU error scope=] was current.
 
-    : <dfn>\[[filter]]</dfn> of type {{GPUErrorFilter}}.
+    : <dfn>\[[filter]]</dfn>, of type {{GPUErrorFilter}}
     ::
         Determines what type of {{GPUError}} this [=GPU error scope=] observes.
 </dl>
@@ -11652,7 +11653,7 @@ partial interface GPUDevice {
 {{GPUDevice}} has the following internal slots:
 
 <dl dfn-type=attribute dfn-for="GPUDevice">
-    : <dfn>\[[errorScopeStack]]</dfn> of type [=stack=]&lt;[=GPU error scope=]&gt;.
+    : <dfn>\[[errorScopeStack]]</dfn>, of type [=stack=]&lt;[=GPU error scope=]&gt;
     ::
         A [=stack=] of [=GPU error scopes=] that have been pushed to the {{GPUDevice}}.
 </dl>


### PR DESCRIPTION
Unrelatedly, correct some language in the explainer for my more recent understanding. https://github.com/gpuweb/gpuweb/issues/2748#issuecomment-1111507965


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 7, 2022, 1:32 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fkainino0x%2Fgpuweb%2F6cfbe56c070e1627897a5c087dacb05f73b00bcb%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%233011.)._
</details>
