### PR TITLE
Expose the buffer state as an attribute

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2589,16 +2589,24 @@ that returns a new buffer (which may be {{GPUBufferDescriptor/mappedAtCreation}}
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUBuffer {
+    readonly attribute GPUSize64 size;
+    readonly attribute GPUBufferUsageFlags usage;
+
+    readonly attribute GPUBufferMapState mapState;
+
     Promise<undefined> mapAsync(GPUMapModeFlags mode, optional GPUSize64 offset = 0, optional GPUSize64 size);
     ArrayBuffer getMappedRange(optional GPUSize64 offset = 0, optional GPUSize64 size);
     undefined unmap();
 
     undefined destroy();
-
-    readonly attribute GPUSize64 size;
-    readonly attribute GPUBufferUsageFlags usage;
 };
 GPUBuffer includes GPUObjectBase;
+
+enum GPUBufferMapState {
+    "unmapped",
+    "pending",
+    "mapped"
+};
 </script>
 
 {{GPUBuffer}} has the following attributes:
@@ -2617,6 +2625,39 @@ GPUBuffer includes GPUObjectBase;
 
         This attribute is backed by an immutable internal slot of the same name, and
         always returns its value.
+
+    : <dfn>mapState</dfn>
+    ::
+        The current <dfn enum for=>GPUBufferMapState</dfn> of the buffer:
+
+        <dl dfn-type=enum-value dfn-for=GPUBufferMapState>
+            : <dfn>"unmapped"</dfn>
+            ::
+                The buffer is not mapped for use by `this`.{{GPUBuffer/getMappedRange()}}.
+
+            : <dfn>"pending"</dfn>
+            ::
+                A mapping of the buffer has been requested, but is pending.
+                It may succeed, or fail validation in {{GPUBuffer/mapAsync()}}.
+
+            : <dfn>"mapped"</dfn>
+            ::
+                The buffer is mapped and `this`.{{GPUBuffer/getMappedRange()}} may be used.
+        </dl>
+
+        The [=getter steps=] are:
+
+        <div algorithm=mapState>
+            <div data-timeline=content>
+                [=Content timeline=] steps:
+
+                1. If |this|.{{GPUBuffer/[[mapping]]}} is not `null`,
+                    return {{GPUBufferMapState/"mapped"}}.
+                1. If |this|.{{GPUBuffer/[[map_requests]]}} is not empty,
+                    return {{GPUBufferMapState/"pending"}}.
+                1. Return {{GPUBufferMapState/"unmapped"}}.
+            </div>
+        </div>
 </dl>
 
 {{GPUBuffer}} has the following internal slots:


### PR DESCRIPTION
Fixes #3013


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/3014.html" title="Last updated on Jun 7, 2022, 9:10 PM UTC (062591b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/3014/f198c8d...kainino0x:062591b.html" title="Last updated on Jun 7, 2022, 9:10 PM UTC (062591b)">Diff</a>