### PR TITLE
Move builtin names to section headers.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -10552,9 +10552,8 @@ See [[#function-calls]].
 
 ## Logical Built-in Functions ## {#logical-builtin-functions}
 
+### `all` (vector) ### {#all-vector-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**all**
   <tr>
     <td>Description
     <td>Returns true if each component of `e` is true.
@@ -10563,9 +10562,8 @@ See [[#function-calls]].
     <td><xmp highlight=rust>@const fn all(e: vecN<bool>) -> bool</xmp>
 </table>
 
+### `all` (scalar) ### {#all-scalar-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**all**
   <tr>
     <td>Description
     <td>Returns `e`.
@@ -10574,9 +10572,8 @@ See [[#function-calls]].
     <td class="nowrap"><xmp highlight=rust>@const fn all(e: bool) -> bool</xmp>
 </table>
 
+### `any` (vector) ### {#any-vector-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**any**
   <tr>
     <td style="width:10%">Description
     <td>Returns true if any component of `e` is true.
@@ -10587,9 +10584,8 @@ See [[#function-calls]].
 </xmp>
 </table>
 
+### `any` (scalar) ### {#any-scalar-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**any**
   <tr>
     <td>Description
     <td>Returns `e`.
@@ -10598,9 +10594,8 @@ See [[#function-calls]].
     <td class="nowrap"><xmp highlight=rust>@const fn any(e: bool) -> bool</xmp>
 </table>
 
+### `select` (scalar) ### {#select-scalar-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**select**
   <tr>
     <td>Description
     <td>Returns `t` when `cond` is true, and `f` otherwise.
@@ -10616,9 +10611,8 @@ See [[#function-calls]].
     <td>`T` is [=scalar=], [=abstract numeric type=], or [=vector=]
 </table>
 
+### `select` (vector) ### {#select-vector-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**select**
   <tr>
     <td>Description
     <td>[=Component-wise=] selection. Result component `i` is evaluated
@@ -10636,9 +10630,9 @@ See [[#function-calls]].
 </table>
 
 ## Array Built-in Functions ## {#array-builtin-functions}
+
+### `arrayLength` ### {#arrayLength-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**arrayLength**
   <tr>
     <td>Description
     <td>Returns the number of elements in the [=runtime-sized=] array.
@@ -10655,10 +10649,8 @@ fn arrayLength(p: ptr<storage, array<E>, AM>) -> u32
 
 ## Float Built-in Functions ## {#float-builtin-functions}
 
-
+### `abs` ### {#abs-float-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**abs**
   <tr>
     <td>Description
     <td>Returns the absolute value of `e` (e.g. `e` with a positive sign bit).
@@ -10673,9 +10665,8 @@ fn arrayLength(p: ptr<storage, array<E>, AM>) -> u32
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `acos` ### {#acos-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**acos**
   <tr>
     <td>Description
     <td>Returns the arc cosine of `e`.
@@ -10690,9 +10681,8 @@ fn arrayLength(p: ptr<storage, array<E>, AM>) -> u32
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `acosh` ### {#acosh-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**acosh**
   <tr>
     <td>Description
     <td>Returns the hyperbolic arc cosine of `e`.
@@ -10715,9 +10705,8 @@ Note: The result is not mathematically meaningful when `e` &lt; 1.
 
 </table>
 
+### `asin` ### {#asin-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**asin**
   <tr>
     <td>Description
     <td>Returns the arc sine of `e`.
@@ -10732,9 +10721,8 @@ Note: The result is not mathematically meaningful when `e` &lt; 1.
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `asinh` ### {#asinh-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**asinh**
   <tr>
     <td>Description
     <td>Returns the hyperbolic arc sine of `e`.<br>
@@ -10750,9 +10738,8 @@ Note: The result is not mathematically meaningful when `e` &lt; 1.
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `atan` ### {#atan-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**atan**
   <tr>
     <td>Description
     <td>Returns the arc tangent of `e`.
@@ -10767,9 +10754,8 @@ Note: The result is not mathematically meaningful when `e` &lt; 1.
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `atanh` ### {#atanh-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**atanh**
   <tr>
     <td>Description
     <td>Returns the hyperbolic arc tangent of `e`.
@@ -10792,9 +10778,8 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
 
 </table>
 
+### `atan2` ### {#atan2-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**atan2**
   <tr>
     <td>Description
     <td>Returns the arc tangent of `e1` over `e2`.
@@ -10810,9 +10795,8 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `ceil` ### {#ceil-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**ceil**
   <tr>
     <td>Description
     <td>Returns the [=ceiling expression|ceiling=] of `e`.
@@ -10827,9 +10811,8 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `clamp` ### {#clamp-float-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**clamp**
   <tr>
     <td>Description
     <td>Returns either `min(max(e, low), high)`, or the median of
@@ -10847,9 +10830,8 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `cos` ### {#cos-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**cos**
   <tr>
     <td>Description
     <td>Returns the cosine of `e`.
@@ -10864,9 +10846,8 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `cosh` ### {#cosh-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**cosh**
   <tr>
     <td>Description
     <td>Returns the hyperbolic cosine of `e`.
@@ -10881,9 +10862,8 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `cross` ### {#cross-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**cross**
   <tr>
     <td>Description
     <td>Returns the cross product of `e1` and `e2`.
@@ -10898,9 +10878,8 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
     <td>`T` is AbstractFloat, f32, or f16
 </table>
 
+### `degrees` ### {#degrees-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**degrees**
   <tr>
     <td>Description
     <td>Converts radians to degrees, approximating `e1`&nbsp;&times;&nbsp;180&nbsp;&div;&nbsp;&pi;.
@@ -10915,9 +10894,8 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `distance` ### {#distance-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**distance**
   <tr>
     <td>Description
     <td>Returns the distance between `e1` and `e2` (e.g. `length(e1 - e2)`).
@@ -10932,9 +10910,8 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `exp` ### {#exp-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**exp**
   <tr>
     <td>Description
     <td>Returns the natural exponentiation of `e1` (e.g. `e`<sup>`e1`</sup>).
@@ -10949,9 +10926,8 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `exp2` ### {#exp2-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**exp2**
   <tr>
     <td>Description
     <td>Returns 2 raised to the power `e` (e.g. `2`<sup>`e`</sup>).
@@ -10966,9 +10942,8 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `faceForward` ### {#faceForward-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**faceForward**
   <tr>
     <td>Description
     <td>Returns `e1` if `dot(e2, e3)` is negative, and `-e1` otherwise.
@@ -10984,9 +10959,8 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
     <td>`T` is vecN&lt;AbstractFloat&gt;, vecN&lt;f32&gt;, or vecN&lt;f16&gt;
 </table>
 
+### `floor` ### {#floor-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**floor**
   <tr>
     <td>Description
     <td>Returns the [=floor expression|floor=] of `e`.
@@ -11001,9 +10975,8 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `fma` ### {#fma-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**fma**
   <tr>
     <td>Description
     <td>Returns `e1 * e2 + e3`.
@@ -11020,9 +10993,8 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `fract` ### {#fract-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**fract**
   <tr>
     <td>Description
     <td>Returns the fractional part of `e`, computed as `e - floor(e)`.<br>
@@ -11044,9 +11016,8 @@ For example, if `e` is a very small negative number, then `fract(e)` may be 1.0.
 
 </table>
 
+### `frexp` (scalar f32) ### {#frexp-scalar-f32-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**frexp**
   <tr>
     <td>Description
     <td>Splits `e` into a significand and exponent of the form `significand * 2`<sup>`exponent`</sup>.
@@ -11086,9 +11057,8 @@ but a value may infer the type.
 
 </table>
 
+### `frexp` (scalar f16) ### {#frexp-scalar-f16-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**frexp**
   <tr>
     <td>Description
     <td>Splits `e` into a significand and exponent of the form `significand * 2`<sup>`exponent`</sup>.
@@ -11117,9 +11087,8 @@ but a value may infer the type.
 
 </table>
 
+### `frexp` (vector f32) ### {#frexp-vector-f32-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**frexp**
   <tr>
     <td>Description
     <td>Splits the components of `e` into a significand and exponent of the form
@@ -11150,9 +11119,8 @@ but a value may infer the type.
 
 </table>
 
+### `frexp` (vector f16) ### {#frexp-vector-f16-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**frexp**
   <tr>
     <td>Description
     <td>Splits the components of `e` into a significand and exponent of the form
@@ -11183,9 +11151,8 @@ but a value may infer the type.
 
 </table>
 
+### `inverseSqrt` ### {#inverseSqrt-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**inverseSqrt**
   <tr>
     <td>Description
     <td>Returns the reciprocal of `sqrt(e)`.
@@ -11200,9 +11167,8 @@ but a value may infer the type.
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `ldexp` ### {#ldexp-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**ldexp**
   <tr>
     <td>Description
     <td>Returns `e1 * 2`<sup>`e2`</sup>.
@@ -11221,9 +11187,8 @@ but a value may infer the type.
         `I` is [=concrete=] if and only if `T` is a [=concrete=]
 </table>
 
+### `length` ### {#length-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**length**
   <tr>
     <td>Description
     <td>Returns the length of `e` (e.g. `abs(e)` if `T` is a scalar, or
@@ -11238,9 +11203,8 @@ but a value may infer the type.
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `log` ### {#log-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**log**
   <tr>
     <td>Description
     <td>Returns the natural logarithm of `e`.
@@ -11255,9 +11219,8 @@ but a value may infer the type.
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `log2` ### {#log2-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**log2**
   <tr>
     <td>Description
     <td>Returns the base-2 logarithm of `e`.
@@ -11272,9 +11235,8 @@ but a value may infer the type.
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `max` ### {#max-float-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**max**
   <tr>
     <td>Description
     <td>Returns `e2` if `e1` is less than `e2`, and `e1` otherwise.
@@ -11292,9 +11254,8 @@ but a value may infer the type.
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `min` ### {#min-float-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**min**
   <tr>
     <td>Description
     <td>Returns `e2` if `e2` is less than `e1`, and `e1` otherwise.
@@ -11312,9 +11273,8 @@ but a value may infer the type.
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `mix` (scalar) ### {#mix-scalar-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**mix**
   <tr>
     <td>Description
     <td>Returns the linear blend of `e1` and `e2` (e.g. `e1 * (1 - e3) + e2 * e3`).
@@ -11331,9 +11291,8 @@ but a value may infer the type.
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `mix` (vector) ### {#mix-vector-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**mix**
   <tr>
     <td>Description
     <td>Returns the component-wise linear blend of `e1` and `e2`,
@@ -11352,9 +11311,8 @@ but a value may infer the type.
         `T2` is vecN&lt;T&gt;
 </table>
 
+### `modf` (scalar f32) ### {#modf-scalar-f32-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**modf**
   <tr>
     <td>Description
     <td>Splits `e` into fractional and whole number parts.
@@ -11396,9 +11354,8 @@ but a value may infer the type.
 
 </table>
 
+### `modf` (scalar f16) ### {#modf-scalar-f16-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**modf**
   <tr>
     <td>Description
     <td>Splits `e` into fractional and whole number parts.
@@ -11429,9 +11386,8 @@ but a value may infer the type.
 
 </table>
 
+### `modf` (vector f32) ### {#modf-vector-f32-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**modf**
   <tr>
     <td>Description
     <td>Splits the components of `e` into fractional and whole number parts.
@@ -11463,9 +11419,8 @@ but a value may infer the type.
 
 </table>
 
+### `modf` (vector f16) ### {#modf-vector-f16-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**modf**
   <tr>
     <td>Description
     <td>Splits the components of `e` into fractional and whole number parts.
@@ -11497,9 +11452,8 @@ but a value may infer the type.
 
 </table>
 
+### `normalize` ### {#normalize-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**normalize**
   <tr>
     <td>Description
     <td>Returns a unit vector in the same direction as `e`.
@@ -11513,9 +11467,8 @@ but a value may infer the type.
     <td>`T` is AbstractFloat, f32, or f16
 </table>
 
+### `pow` ### {#pow-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**pow**
   <tr>
     <td>Description
     <td>Returns `e1` raised to the power `e2`.
@@ -11531,9 +11484,8 @@ but a value may infer the type.
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `quantizeToF16` ### {#quantizeToF16-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**quantizeToF16**
   <tr>
     <td>Description
     <td>Quantizes a 32-bit floating point value `e` as if `e` were converted to
@@ -11557,9 +11509,8 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
 
 </table>
 
+### `radians` ### {#radians-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**radians**
   <tr>
     <td>Description
     <td>Converts degrees to radians, approximating `e1`&nbsp;&times;&nbsp;&pi;&nbsp;&div;&nbsp;180.
@@ -11574,9 +11525,8 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `reflect` ### {#reflect-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**reflect**
   <tr>
     <td>Description
     <td>For the incident vector `e1` and surface orientation `e2`, returns the reflection direction
@@ -11592,9 +11542,8 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
     <td>`T` is vecN&lt;AbstractFloat&gt;, vecN&lt;f32&gt;, or vecN&lt;f16&gt;
 </table>
 
+### `refract` ### {#refract-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**refract**
   <tr>
     <td>Description
     <td>For the incident vector `e1` and surface normal `e2`, and the ratio of
@@ -11615,9 +11564,8 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
         `I` is AbstractFloat, f32, or f16
 </table>
 
+### `round` ### {#round-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**round**
   <tr>
     <td>Description
     <td>Result is the integer `k` nearest to `e`, as a floating point value.<br>
@@ -11634,9 +11582,8 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `sign` ### {#sign-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**sign**
   <tr>
     <td>Description
     <td>Returns the sign of `e`.
@@ -11651,9 +11598,8 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `sin` ### {#sin-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**sin**
   <tr>
     <td>Description
     <td>Returns the sine of `e`.
@@ -11668,9 +11614,8 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `sinh` ### {#sinh-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**sinh**
   <tr>
     <td>Description
     <td>Returns the hyperbolic sine of `e`.
@@ -11685,9 +11630,8 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `smoothstep` ### {#smoothstep-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**smoothstep**
   <tr>
     <td>Description
     <td>Returns the smooth Hermite interpolation between 0 and 1.
@@ -11708,9 +11652,8 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `sqrt` ### {#sqrt-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**sqrt**
   <tr>
     <td>Description
     <td>Returns the square root of `e`.
@@ -11725,9 +11668,8 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `step` ### {#step-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**step**
   <tr>
     <td>Description
     <td>Returns 1.0 if `edge` &le; `x`, and 0.0 otherwise.
@@ -11743,9 +11685,8 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `tan` ### {#tan-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**tan**
   <tr>
     <td>Description
     <td>Returns the tangent of `e`.
@@ -11760,9 +11701,8 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `tanh` ### {#tanh-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**tanh**
   <tr>
     <td>Description
     <td>Returns the hyperbolic tangent of `e`.
@@ -11777,9 +11717,8 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
     <td>[ALLFLOATINGDECL]
 </table>
 
+### `trunc` ### {#trunc-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**trunc**
   <tr>
     <td>Description
     <td>Returns [=truncate=](`e`), the nearest whole number whose absolute value
@@ -11797,9 +11736,8 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
 
 ## Integer Built-in Functions ## {#integer-builtin-functions}
 
+### `abs` ### {#abs-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**abs**
   <tr>
     <td>Description
     <td>The absolute value of `e`.
@@ -11817,9 +11755,8 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
     <td>[ALLINTEGRALDECL]
 </table>
 
+### `clamp` ### {#clamp-integral-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**clamp**
   <tr>
     <td>Description
     <td>Returns `min(max(e, low), high)`.
@@ -11836,9 +11773,8 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
     <td>[ALLINTEGRALDECL]
 </table>
 
+### `countLeadingZeros` ### {#countLeadingZeros-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**countLeadingZeros**
   <tr>
     <td>Description
     <td>The number of consecutive 0 bits starting from the most significant bit
@@ -11855,9 +11791,8 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
     <td>`T` is [INTEGRAL]
 </table>
 
+### `countOneBits` ### {#countOneBits-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**countOneBits**
   <tr>
     <td>Description
     <td>The number of 1 bits in the representation of `e`.<br>
@@ -11873,9 +11808,8 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
     <td>`T` is [INTEGRAL]
 </table>
 
+### `countTrailingZeros` ### {#countTrailingZeros-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**countTrailingZeros**
   <tr>
     <td>Description
     <td>The number of consecutive 0 bits starting from the least significant bit
@@ -11892,9 +11826,8 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
     <td>`T` is [INTEGRAL]
 </table>
 
+### `firstLeadingBit` (signed) ### {#firstLeadingBit-signed-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**firstLeadingBit**
   <tr>
     <td>Description
     <td>For scalar `T`, the result is:
@@ -11922,9 +11855,8 @@ the sign bit appears in the most significant bit position.
 
 </table>
 
+### `firstLeadingBit` (unsigned) ### {#firstLeadingBit-unsigned-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**firstLeadingBit**
   <tr>
     <td>Description
     <td>For scalar `T`, the result is:
@@ -11944,9 +11876,8 @@ the sign bit appears in the most significant bit position.
     <td>`T` is [UNSIGNEDINTEGRAL]
 </table>
 
+### `firstTrailingBit` ### {#firstTrailingBit-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**firstTrailingBit**
   <tr>
     <td>Description
     <td>For scalar `T`, the result is:
@@ -11966,9 +11897,8 @@ the sign bit appears in the most significant bit position.
     <td>`T` is [INTEGRAL]
 </table>
 
+### `extractBits` (signed) ### {#extractBits-signed-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**extractBits**
   <tr>
     <td>Description
     <td>Reads bits from an integer, with sign extension.
@@ -11996,9 +11926,8 @@ the sign bit appears in the most significant bit position.
     <td>`T` is [SIGNEDINTEGRAL]
 </table>
 
+### `extractBits` (unsigned) ### {#extractBits-unsigned-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**extractBits**
   <tr>
     <td>Description
     <td>Reads bits from an integer, without sign extension.
@@ -12026,9 +11955,8 @@ the sign bit appears in the most significant bit position.
     <td>`T` is [UNSIGNEDINTEGRAL]
 </table>
 
+### `insertBits` ### {#insertBits-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**insertBits**
   <tr>
     <td>Description
     <td>Sets bits in an integer.
@@ -12057,9 +11985,8 @@ the sign bit appears in the most significant bit position.
     <td>`T` is [INTEGRAL]
 </table>
 
+### `max` ### {#max-integral-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**max**
   <tr>
     <td>Description
     <td>Returns `e2` if `e1` is less than `e2`, and `e1` otherwise.
@@ -12075,9 +12002,8 @@ the sign bit appears in the most significant bit position.
     <td>[ALLINTEGRALDECL]
 </table>
 
+### `min` ### {#min-integral-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**min**
   <tr>
     <td>Description
     <td>Returns `e1` if `e1` is less than `e2`, and `e2` otherwise.
@@ -12093,9 +12019,8 @@ the sign bit appears in the most significant bit position.
     <td>[ALLINTEGRALDECL]
 </table>
 
+### `reverseBits` ### {#reverseBits-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**reverseBits**
   <tr>
     <td>Description
     <td>Reverses the bits in `e`:  The bit at position `k` of the result equals the
@@ -12112,9 +12037,9 @@ the sign bit appears in the most significant bit position.
 </table>
 
 ## Matrix Built-in Functions ## {#matrix-builtin-functions}
+
+### `determinant` ### {#determinant-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**determinant**
   <tr>
     <td>Description
     <td>Returns the determinant of `e`.
@@ -12128,9 +12053,8 @@ the sign bit appears in the most significant bit position.
     <td>`T` is AbstractFloat, f32, or f16
 </table>
 
+### `transpose` ### {#transpose-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**transpose**
   <tr>
     <td>Description
     <td>Returns the transpose of `e`.
@@ -12146,9 +12070,8 @@ the sign bit appears in the most significant bit position.
 
 ## Vector Built-in Functions ## {#vector-builtin-functions}
 
+### `dot` ### {#dot-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**dot**
   <tr>
     <td>Description
     <td>Returns the dot product of `e1` and `e2`.
@@ -12171,9 +12094,8 @@ These functions:
 * [=shader-creation error|Must=] only be used in a [=fragment=] shader stage.
 * [=shader-creation error|Must=] only be invoked in [=uniform control flow=].
 
+### `dpdx` ### {#dpdx-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**dpdx**
   <tr>
     <td>Description
     <td>Partial derivative of `e` with respect to window x coordinates.
@@ -12188,9 +12110,8 @@ fn dpdx(e: T) -> T
     <td>`T` is f32 or vecN&lt;f32&gt;
 </table>
 
+### `dpdxCoarse` ### {#dpdxCoarse-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**dpdxCoarse**
   <tr>
     <td>Description
     <td>Returns the partial derivative of `e` with respect to window x coordinates using local differences.
@@ -12205,9 +12126,8 @@ fn dpdxCoarse(e: T) -> T
     <td>`T` is f32 or vecN&lt;f32&gt;
 </table>
 
+### `dpdxFine` ### {#dpdxFine-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**dpdxFine**
   <tr>
     <td>Description
     <td>Returns the partial derivative of `e` with respect to window x coordinates.
@@ -12221,9 +12141,8 @@ fn dpdxFine(e: T) -> T
     <td>`T` is f32 or vecN&lt;f32&gt;
 </table>
 
+### `dpdy` ### {#dpdy-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**dpdy**
   <tr>
     <td>Description
     <td>Partial derivative of `e` with respect to window y coordinates.
@@ -12238,9 +12157,8 @@ fn dpdy(e: T) -> T
     <td>`T` is f32 or vecN&lt;f32&gt;
 </table>
 
+### `dpdyCoarse` ### {#dpdyCoarse-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**dpdyCoarse**
   <tr>
     <td>Description
     <td>Returns the partial derivative of `e` with respect to window y coordinates using local differences.
@@ -12255,9 +12173,8 @@ fn dpdyCoarse(e: T) -> T
     <td>`T` is f32 or vecN&lt;f32&gt;
 </table>
 
+### `dpdyFine` ### {#dpdyFine-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**dpdyFine**
   <tr>
     <td>Description
     <td>Returns the partial derivative of `e` with respect to window y coordinates.
@@ -12271,9 +12188,8 @@ fn dpdyFine(e: T) -> T
     <td>`T` is f32 or vecN&lt;f32&gt;
 </table>
 
+### `fwidth` ### {#fwidth-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**fwidth**
   <tr>
     <td>Description
     <td>Returns `abs(dpdx(e)) + abs(dpdy(e))`.
@@ -12287,9 +12203,8 @@ fn fwidth(e: T) -> T
     <td>`T` is f32 or vecN&lt;f32&gt;
 </table>
 
+### `fwidthCoarse` ### {#fwidthCoarse-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**fwidthCoarse**
   <tr>
     <td>Description
     <td>Returns `abs(dpdxCoarse(e)) + abs(dpdyCoarse(e))`.
@@ -12303,9 +12218,8 @@ fn fwidthCoarse(e: T) -> T
     <td>`T` is f32 or vecN&lt;f32&gt;
 </table>
 
+### `fwidthFine` ### {#fwidthFine-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**fwidthFine**
   <tr>
     <td>Description
     <td>Returns `abs(dpdxFine(e)) + abs(dpdyFine(e))`.
@@ -12326,7 +12240,6 @@ Parameter values [=shader-creation error|must=] be valid for the respective text
 ### `textureDimensions` ### {#texturedimensions}
 
 Returns the dimensions of a texture, or texture's mip level in texels.
-
 
 <table class='data'>
   <thead>
@@ -13791,9 +13704,8 @@ do not correspond directly to types in WGSL.
 This enables a program to write many densely packed values to memory, which can
 reduce a shader's memory bandwidth demand.
 
+### `pack4x8snorm` ### {#pack4x8snorm-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**pack4x8snorm**
   <tr>
     <td>Description
     <td>Converts four normalized floating point values to 8-bit signed integers, and then combines them
@@ -13809,9 +13721,8 @@ reduce a shader's memory bandwidth demand.
 </xmp>
 </table>
 
+### `pack4x8unorm` ### {#pack4x8unorm-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**pack4x8unorm**
   <tr>
     <td>Description
     <td>Converts four normalized floating point values to 8-bit unsigned integers, and then combines them
@@ -13827,9 +13738,8 @@ reduce a shader's memory bandwidth demand.
 </xmp>
 </table>
 
+### `pack2x16snorm` ### {#pack2x16snorm-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**pack2x16snorm**
   <tr>
     <td>Description
     <td>Converts two normalized floating point values to 16-bit signed integers, and then combines them
@@ -13845,9 +13755,8 @@ reduce a shader's memory bandwidth demand.
 </xmp>
 </table>
 
+### `pack2x16unorm` ### {#pack2x16unorm-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**pack2x16unorm**
   <tr>
     <td>Description
     <td>Converts two normalized floating point values to 16-bit unsigned integers, and then combines them
@@ -13863,9 +13772,8 @@ reduce a shader's memory bandwidth demand.
 </xmp>
 </table>
 
+### `pack2x16float` ### {#pack2x16float-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**pack2x16float**
   <tr>
     <td>Description
     <td>Converts two floating point values to half-precision floating point numbers, and then combines
@@ -13889,9 +13797,8 @@ data formats that do not correspond directly to types in WGSL.
 This enables a program to read many densely packed values from memory, which can
 reduce a shader's memory bandwidth demand.
 
+### `unpack4x8snorm` ### {#unpack4x8snorm-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**unpack4x8snorm**
   <tr>
     <td>Description
     <td>Decomposes a 32-bit value into four 8-bit chunks, then reinterprets
@@ -13905,9 +13812,8 @@ reduce a shader's memory bandwidth demand.
 </xmp>
 </table>
 
+### `unpack4x8unorm` ### {#unpack4x8unorm-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**unpack4x8unorm**
   <tr>
     <td>Description
     <td>Decomposes a 32-bit value into four 8-bit chunks, then reinterprets
@@ -13921,9 +13827,8 @@ reduce a shader's memory bandwidth demand.
 </xmp>
 </table>
 
+### `unpack2x16snorm` ### {#unpack2x16snorm-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**unpack2x16snorm**
   <tr>
     <td>Description
     <td>Decomposes a 32-bit value into two 16-bit chunks, then reinterprets
@@ -13937,9 +13842,8 @@ reduce a shader's memory bandwidth demand.
 </xmp>
 </table>
 
+### `unpack2x16unorm` ### {#unpack2x16unorm-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**unpack2x16unorm**
   <tr>
     <td>Description
     <td>Decomposes a 32-bit value into two 16-bit chunks, then reinterprets
@@ -13953,9 +13857,8 @@ reduce a shader's memory bandwidth demand.
 </xmp>
 </table>
 
+### `unpack2x16float` ### {#unpack2x16float-builtin}
 <table class='data builtin'>
-  <tr>
-    <td colspan=2 style="text-align:left;">**unpack2x16float**
   <tr>
     <td>Description
     <td>Decomposes a 32-bit value into two 16-bit chunks, and reinterpets each chunk


### PR DESCRIPTION
This CL moves the builtin names to be section headers instead of
entries in the table. This makes them findable in side bar and makes
them better matchup to how textures are done already.