### PR TITLE
Ensure the formats supporting multisampling must support rendering

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12859,7 +12859,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>{{GPUTextureFormat/r8snorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td><!-- Vulkan -->
-        <td>
+        <td><!-- no multisampling without RENDER_ATTACHMENT (gpuweb/gpuweb#2465) -->
         <td>
         <td><!-- Vulkan -->
         <td>1
@@ -12891,7 +12891,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>{{GPUTextureFormat/rg8snorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td><!-- Vulkan -->
-        <td>
+        <td><!-- no multisampling without RENDER_ATTACHMENT (gpuweb/gpuweb#2465) -->
         <td>
         <td><!-- Vulkan -->
         <td>2
@@ -12931,7 +12931,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>{{GPUTextureFormat/rgba8snorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td><!-- Vulkan -->
-        <td>
+        <td><!-- no multisampling without RENDER_ATTACHMENT (gpuweb/gpuweb#2465) -->
         <td>
         <td>&checkmark;
         <td>4
@@ -13126,7 +13126,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>{{GPUTextureFormat/rg11b10ufloat}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td><!-- Vulkan -->
-        <td>
+        <td><!-- no multisampling without RENDER_ATTACHMENT (gpuweb/gpuweb#2465) -->
         <td>
         <td><!-- Vulkan -->
         <td>4

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12859,7 +12859,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>{{GPUTextureFormat/r8snorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td><!-- Vulkan -->
-        <td>&checkmark;
+        <td>
         <td>
         <td><!-- Vulkan -->
         <td>1
@@ -12891,7 +12891,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>{{GPUTextureFormat/rg8snorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td><!-- Vulkan -->
-        <td>&checkmark;
+        <td>
         <td>
         <td><!-- Vulkan -->
         <td>2
@@ -12931,7 +12931,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>{{GPUTextureFormat/rgba8snorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td><!-- Vulkan -->
-        <td>&checkmark;
+        <td>
         <td>
         <td>&checkmark;
         <td>4
@@ -13126,7 +13126,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>{{GPUTextureFormat/rg11b10ufloat}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td><!-- Vulkan -->
-        <td>&checkmark;
+        <td>
         <td>
         <td><!-- Vulkan -->
         <td>4


### PR DESCRIPTION
This patch removes the 'multisampling' capability on the formats
that don't support 'RENDER_ATTACHMEMT' as current SPEC requires
the 'RENDER_ATTACHMENT' usage must be specified when we create a
multisampled texture.

The affected formats are:
- r8snorm
- rg8snorm
- rgba8snorm
- rg11b10ufloat

issue: #2465


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Jiawei-Shao/gpuweb/pull/3018.html" title="Last updated on Jun 8, 2022, 10:07 PM UTC (3bc1ca8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/3018/1cfd17e...Jiawei-Shao:3bc1ca8.html" title="Last updated on Jun 8, 2022, 10:07 PM UTC (3bc1ca8)">Diff</a>