### PR TITLE
Combine section headers which define the same function

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -10552,7 +10552,7 @@ See [[#function-calls]].
 
 ## Logical Built-in Functions ## {#logical-builtin-functions}
 
-### `all` (vector) ### {#all-vector-builtin}
+### `all` ### {#all-builtin}
 <table class='data builtin'>
   <tr>
     <td>Description
@@ -10562,7 +10562,6 @@ See [[#function-calls]].
     <td><xmp highlight=rust>@const fn all(e: vecN<bool>) -> bool</xmp>
 </table>
 
-### `all` (scalar) ### {#all-scalar-builtin}
 <table class='data builtin'>
   <tr>
     <td>Description
@@ -10572,7 +10571,7 @@ See [[#function-calls]].
     <td class="nowrap"><xmp highlight=rust>@const fn all(e: bool) -> bool</xmp>
 </table>
 
-### `any` (vector) ### {#any-vector-builtin}
+### `any` ### {#any-builtin}
 <table class='data builtin'>
   <tr>
     <td style="width:10%">Description
@@ -10584,7 +10583,6 @@ See [[#function-calls]].
 </xmp>
 </table>
 
-### `any` (scalar) ### {#any-scalar-builtin}
 <table class='data builtin'>
   <tr>
     <td>Description
@@ -10594,7 +10592,7 @@ See [[#function-calls]].
     <td class="nowrap"><xmp highlight=rust>@const fn any(e: bool) -> bool</xmp>
 </table>
 
-### `select` (scalar) ### {#select-scalar-builtin}
+### `select` ### {#select-builtin}
 <table class='data builtin'>
   <tr>
     <td>Description
@@ -10611,7 +10609,6 @@ See [[#function-calls]].
     <td>`T` is [=scalar=], [=abstract numeric type=], or [=vector=]
 </table>
 
-### `select` (vector) ### {#select-vector-builtin}
 <table class='data builtin'>
   <tr>
     <td>Description
@@ -11016,7 +11013,7 @@ For example, if `e` is a very small negative number, then `fract(e)` may be 1.0.
 
 </table>
 
-### `frexp` (scalar f32) ### {#frexp-scalar-f32-builtin}
+### `frexp` ### {#frexp-builtin}
 <table class='data builtin'>
   <tr>
     <td>Description
@@ -11057,7 +11054,6 @@ but a value may infer the type.
 
 </table>
 
-### `frexp` (scalar f16) ### {#frexp-scalar-f16-builtin}
 <table class='data builtin'>
   <tr>
     <td>Description
@@ -11087,7 +11083,6 @@ but a value may infer the type.
 
 </table>
 
-### `frexp` (vector f32) ### {#frexp-vector-f32-builtin}
 <table class='data builtin'>
   <tr>
     <td>Description
@@ -11119,7 +11114,6 @@ but a value may infer the type.
 
 </table>
 
-### `frexp` (vector f16) ### {#frexp-vector-f16-builtin}
 <table class='data builtin'>
   <tr>
     <td>Description
@@ -11273,7 +11267,7 @@ but a value may infer the type.
     <td>[ALLFLOATINGDECL]
 </table>
 
-### `mix` (scalar) ### {#mix-scalar-builtin}
+### `mix` ### {#mix-builtin}
 <table class='data builtin'>
   <tr>
     <td>Description
@@ -11291,7 +11285,6 @@ but a value may infer the type.
     <td>[ALLFLOATINGDECL]
 </table>
 
-### `mix` (vector) ### {#mix-vector-builtin}
 <table class='data builtin'>
   <tr>
     <td>Description
@@ -11311,7 +11304,7 @@ but a value may infer the type.
         `T2` is vecN&lt;T&gt;
 </table>
 
-### `modf` (scalar f32) ### {#modf-scalar-f32-builtin}
+### `modf` ### {#modf-builtin}
 <table class='data builtin'>
   <tr>
     <td>Description
@@ -11354,7 +11347,6 @@ but a value may infer the type.
 
 </table>
 
-### `modf` (scalar f16) ### {#modf-scalar-f16-builtin}
 <table class='data builtin'>
   <tr>
     <td>Description
@@ -11386,7 +11378,6 @@ but a value may infer the type.
 
 </table>
 
-### `modf` (vector f32) ### {#modf-vector-f32-builtin}
 <table class='data builtin'>
   <tr>
     <td>Description
@@ -11419,7 +11410,6 @@ but a value may infer the type.
 
 </table>
 
-### `modf` (vector f16) ### {#modf-vector-f16-builtin}
 <table class='data builtin'>
   <tr>
     <td>Description


### PR DESCRIPTION
This CL recombines sections which define the same builtin with different
arguments (scalar, vector, f32, f16, etc).