### PR TITLE
Add limit for max total render target size per pixel

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1426,6 +1426,16 @@ applications should generally request the "worst" limits that work for their con
         {{GPURenderPassDescriptor}}.{{GPURenderPassDescriptor/colorAttachments}},
         and {{GPURenderPassLayout}}.{{GPURenderPassLayout/colorFormats}}.
 
+    <tr><td><dfn>maxColorAttachmentBytesPerPixel</dfn>
+        <dn>{{GPUSize32}} <td>[=limit class/maximum=] <td>32 bytes
+    <tr class=row-continuation><td colspan=4>
+        The maximum number of bytes used for color attachments in
+        {{GPURenderPipelineDescriptor}}.{{GPURenderPipelineDescriptor/fragment}}.{{GPUFragmentState/targets}},
+        {{GPURenderPassDescriptor}}.{{GPURenderPassDescriptor/colorAttachments}},
+        and {{GPURenderPassLayout}}.{{GPURenderPassLayout/colorFormats}}.
+        The number of bytes used is the sum of the [=texel block sizes=] of the outputs,
+        times the sample count (note all renderable formats have 1x1 [=texel blocks=]).
+
     <tr><td><dfn>maxComputeWorkgroupStorageSize</dfn>
         <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>16384 bytes
     <tr class=row-continuation><td colspan=4>
@@ -1496,6 +1506,7 @@ interface GPUSupportedLimits {
     readonly attribute unsigned long maxInterStageShaderComponents;
     readonly attribute unsigned long maxInterStageShaderVariables;
     readonly attribute unsigned long maxColorAttachments;
+    readonly attribute unsigned long maxColorAttachmentBytesPerPixel;
     readonly attribute unsigned long maxComputeWorkgroupStorageSize;
     readonly attribute unsigned long maxComputeInvocationsPerWorkgroup;
     readonly attribute unsigned long maxComputeWorkgroupSizeX;
@@ -6429,6 +6440,26 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
 </dl>
 
 <div algorithm>
+    <dfn abstract-op>validating attachment layout</dfn>(|device|, |sampleCount|, |formats|)
+
+    **Arguments:**
+
+    - {{GPUDevice}} |device|
+    - {{GPUSize32}} |sampleCount|
+    - [=list=]&lt;{{GPUTextureFormat}}?&gt; |formats|
+
+    **Returns:** boolean
+
+    1. If |formats|.length &gt; |device|.{{device/[[limits]]}}.{{supported limits/maxColorAttachments}},
+        return false.
+    1. Let |bytesPerSample| be the sum of the [=texel block sizes=] of the non-null formats in |formats|.
+    1. Let |bytesPerPixel| be |bytesPerSample| &times; |sampleCount|.
+    1. If |bytesPerPixel| &gt; |device|.{{device/[[limits]]}}.{{supported limits/maxColorAttachmentBytesPerPixel}},
+        return false.
+    1. Return true.
+</div>
+
+<div algorithm>
     <dfn abstract-op>validating GPURenderPipelineDescriptor</dfn>(descriptor, layout, device)
         **Arguments:**
             - {{GPURenderPipelineDescriptor}} |descriptor|
@@ -6444,7 +6475,8 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
             - If |descriptor|.{{GPURenderPipelineDescriptor/fragment}} is not `null`:
                 - [$validating GPUProgrammableStage$]({{GPUShaderStage/FRAGMENT}},
                     |descriptor|.{{GPURenderPipelineDescriptor/fragment}}, |layout|) succeeds.
-                - [$validating GPUFragmentState$](|device|, |descriptor|.{{GPURenderPipelineDescriptor/fragment}}) succeeds.
+                - [$validating GPUFragmentState$](|device|, |descriptor|.{{GPURenderPipelineDescriptor/fragment}},
+                    |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/count}}) succeeds.
                 - If the "sample_mask" [=builtin=] is a [=pipeline output=] of |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
                     - |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/alphaToCoverageEnabled}} is `false`.
             - [$validating GPUPrimitiveState$](|descriptor|.{{GPURenderPipelineDescriptor/primitive}}, |device|.{{device/[[features]]}}) succeeds.
@@ -6725,12 +6757,15 @@ dictionary GPUFragmentState : GPUProgrammableStage {
 </script>
 
 <div algorithm>
-    <dfn abstract-op>validating GPUFragmentState</dfn>({{GPUDevice}} |device|, {{GPUFragmentState}} |descriptor|)
+    <dfn abstract-op>validating GPUFragmentState</dfn>({{GPUDevice}} |device|,
+    {{GPUFragmentState}} |descriptor|, {{GPUSize32}} |sampleCount|)
 
     Return `true` if all of the following requirements are met:
 
-    - |descriptor|.{{GPUFragmentState/targets}}.length must be &le;
-        |device|.{{device/[[limits]]}}.{{supported limits/maxColorAttachments}}.
+    - [$validating attachment layout$](|device|, |sampleCount|, [
+        |target|?.{{GPUColorTargetState/format}} for each |target| in
+        |descriptor|.{{GPUFragmentState/targets}}
+        ]) returns true.
     - For each non-`null` |colorState| layout descriptor in the list |descriptor|.{{GPUFragmentState/targets}}:
         - |colorState|.{{GPUColorTargetState/format}} must be listed in [[#plain-color-formats]]
             with {{GPUTextureUsage/RENDER_ATTACHMENT}} capability.
@@ -9410,7 +9445,12 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
 
     1. All {{GPURenderPassColorAttachment/view}}s in non-`null` members of |this|.{{GPURenderPassDescriptor/colorAttachments}},
         and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachment/view}}
-        if present, must have equal {{GPUTexture/sampleCount}}s.
+        if present, must have equal {{GPUTexture/sampleCount}}s. Let |sampleCount| be that value.
+
+    1. [$validating attachment layout$](|device|, |sampleCount|, [
+        |attachment|?.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/format}}
+        for each |attachment| in |this|.{{GPURenderPassDescriptor/colorAttachments}}
+        ]) must return true.
 
     1. For each {{GPURenderPassColorAttachment/view}} in non-`null` members of |this|.{{GPURenderPassDescriptor/colorAttachments}}
         and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachment/view}},
@@ -9726,7 +9766,7 @@ enum GPUStoreOp {
 which determines the compatibility of the pass with render pipelines.
 
 <script type=idl>
-dictionary GPURenderPassLayout: GPUObjectDescriptorBase {
+dictionary GPURenderPassLayout : GPUObjectDescriptorBase {
     required sequence<GPUTextureFormat?> colorFormats;
     GPUTextureFormat depthStencilFormat;
     GPUSize32 sampleCount = 1;
@@ -10522,8 +10562,8 @@ GPURenderBundleEncoder includes GPURenderCommandsMixin;
                         [$generate a validation error$], make |e| [=invalid=], and stop.
                         <div class=validusage>
                             - |this| is [=valid=].
-                            - |descriptor|.{{GPURenderPassLayout/colorFormats}}.length must be less than or equal to
-                                |this|.{{device/[[limits]]}}.{{supported limits/maxColorAttachments}}.
+                            - [$validating attachment layout$](|this|, |descriptor|.{{GPURenderPassLayout/sampleCount}},
+                                |descriptor|.{{GPURenderPassLayout/colorFormats}}]) must return true.
                             - If |descriptor|.{{GPURenderPassLayout/colorFormats}} only contains `null` members:
                                 - |descriptor|.{{GPURenderPassLayout/depthStencilFormat}} must not be `null`.
                             - For each |colorFormat| in |descriptor|.{{GPURenderPassLayout/colorFormats}}:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1426,7 +1426,7 @@ applications should generally request the "worst" limits that work for their con
         {{GPURenderPassDescriptor}}.{{GPURenderPassDescriptor/colorAttachments}},
         and {{GPURenderPassLayout}}.{{GPURenderPassLayout/colorFormats}}.
 
-    <tr><td><dfn>maxColorAttachmentBytesPerPixel</dfn>
+    <tr><td><dfn>maxAttachmentBytesPerPixel</dfn>
         <dn>{{GPUSize32}} <td>[=limit class/maximum=] <td>32 bytes
     <tr class=row-continuation><td colspan=4>
         The maximum number of bytes used for color attachments in
@@ -1506,7 +1506,7 @@ interface GPUSupportedLimits {
     readonly attribute unsigned long maxInterStageShaderComponents;
     readonly attribute unsigned long maxInterStageShaderVariables;
     readonly attribute unsigned long maxColorAttachments;
-    readonly attribute unsigned long maxColorAttachmentBytesPerPixel;
+    readonly attribute unsigned long maxAttachmentBytesPerPixel;
     readonly attribute unsigned long maxComputeWorkgroupStorageSize;
     readonly attribute unsigned long maxComputeInvocationsPerWorkgroup;
     readonly attribute unsigned long maxComputeWorkgroupSizeX;
@@ -2896,7 +2896,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                     - |rangeSize| is a multiple of 4.
                     - |offset| is greater than or equal to |this|.{{GPUBuffer/[[mapping_range]]}}[0].
                     - |offset| + |rangeSize| is less than or equal to |this|.{{GPUBuffer/[[mapping_range]]}}[1].
-                    - [|offset|, |offset| + |rangeSize|) does not overlap another range in |this|.{{GPUBuffer/[[mapped_ranges]]}}.
+                    - [|offset|, |offset| + |rangeSize|] does not overlap another range in |this|.{{GPUBuffer/[[mapped_ranges]]}}.
 
                     Note: It is always valid to get mapped ranges of a {{GPUBuffer}} that is
                     [=buffer state/mapped at creation=], even if it is [=invalid=], because
@@ -3136,7 +3136,11 @@ dictionary GPUTextureDescriptor : GPUObjectDescriptorBase {
             - |format| equals |viewFormat|, or
             - |format| and |viewFormat| differ only in whether they are `srgb` formats (have the `-srgb` suffix).
 
-            Issue(gpuweb/gpuweb#168): Define larger compatibility classes.
+            <!--
+            Issue(gpuweb/gpuweb#168): Define larger compatibility classes. When doing so, make sure
+            the validation of the [=supported limits/maxAttachmentBytesPerPixel=] limit is correct
+            (should it count the texture format or the texture view format?).
+            -->
         </div>
 
 </dl>
@@ -6440,21 +6444,24 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
 </dl>
 
 <div algorithm>
-    <dfn abstract-op>validating attachment layout</dfn>(|device|, |sampleCount|, |formats|)
+    <dfn abstract-op>validating attachment layout</dfn>(|device|, |sampleCount|, |formats|, |depthStencilFormat|)
 
     **Arguments:**
 
     - {{GPUDevice}} |device|
     - {{GPUSize32}} |sampleCount|
     - [=list=]&lt;{{GPUTextureFormat}}?&gt; |formats|
+    - {{GPUTextureFormat}}? |depthStencilFormat|
 
     **Returns:** boolean
 
     1. If |formats|.length &gt; |device|.{{device/[[limits]]}}.{{supported limits/maxColorAttachments}},
         return false.
-    1. Let |bytesPerSample| be the sum of the [=texel block sizes=] of the non-null formats in |formats|.
+    1. Let |bytesPerSample| be the sum of the [=texel block sizes=] of the non-null {{GPUTextureFormat}}s in
+        |formats| + [ |depthStencilFormat| ].
+        - [=Assert=]: All of these formats have 1x1 texel blocks.
     1. Let |bytesPerPixel| be |bytesPerSample| &times; |sampleCount|.
-    1. If |bytesPerPixel| &gt; |device|.{{device/[[limits]]}}.{{supported limits/maxColorAttachmentBytesPerPixel}},
+    1. If |bytesPerPixel| &gt; |device|.{{device/[[limits]]}}.{{supported limits/maxAttachmentBytesPerPixel}},
         return false.
     1. Return true.
 </div>
@@ -6475,10 +6482,16 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
             - If |descriptor|.{{GPURenderPipelineDescriptor/fragment}} is not `null`:
                 - [$validating GPUProgrammableStage$]({{GPUShaderStage/FRAGMENT}},
                     |descriptor|.{{GPURenderPipelineDescriptor/fragment}}, |layout|) succeeds.
-                - [$validating GPUFragmentState$](|device|, |descriptor|.{{GPURenderPipelineDescriptor/fragment}},
-                    |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/count}}) succeeds.
+                - [$validating GPUFragmentState$](|descriptor|.{{GPURenderPipelineDescriptor/fragment}}) succeeds.
                 - If the "sample_mask" [=builtin=] is a [=pipeline output=] of |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
                     - |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/alphaToCoverageEnabled}} is `false`.
+                - [$validating attachment layout$](|device|,
+                    |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/count}}, [
+                        |target|?.{{GPUColorTargetState/format}} for each |target| in
+                        |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.{{GPUFragmentState/targets}}
+                    ],
+                    |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}?.{{GPUDepthStencilState/format}})
+                    returns true.
             - [$validating GPUPrimitiveState$](|descriptor|.{{GPURenderPipelineDescriptor/primitive}}, |device|.{{device/[[features]]}}) succeeds.
             - if |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}} is not `null`:
                 - [$validating GPUDepthStencilState$](|descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}) succeeds.
@@ -6757,15 +6770,10 @@ dictionary GPUFragmentState : GPUProgrammableStage {
 </script>
 
 <div algorithm>
-    <dfn abstract-op>validating GPUFragmentState</dfn>({{GPUDevice}} |device|,
-    {{GPUFragmentState}} |descriptor|, {{GPUSize32}} |sampleCount|)
+    <dfn abstract-op>validating GPUFragmentState</dfn>({{GPUFragmentState}} |descriptor|)
 
     Return `true` if all of the following requirements are met:
 
-    - [$validating attachment layout$](|device|, |sampleCount|, [
-        |target|?.{{GPUColorTargetState/format}} for each |target| in
-        |descriptor|.{{GPUFragmentState/targets}}
-        ]) returns true.
     - For each non-`null` |colorState| layout descriptor in the list |descriptor|.{{GPUFragmentState/targets}}:
         - |colorState|.{{GPUColorTargetState/format}} must be listed in [[#plain-color-formats]]
             with {{GPUTextureUsage/RENDER_ATTACHMENT}} capability.
@@ -9448,9 +9456,11 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
         if present, must have equal {{GPUTexture/sampleCount}}s. Let |sampleCount| be that value.
 
     1. [$validating attachment layout$](|device|, |sampleCount|, [
-        |attachment|?.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[texture]]}}.{{GPUTexture/format}}
-        for each |attachment| in |this|.{{GPURenderPassDescriptor/colorAttachments}}
-        ]) must return true.
+            |attachment|?.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}
+            for each |attachment| in |this|.{{GPURenderPassDescriptor/colorAttachments}}
+        ],
+        |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}?.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}})
+        must return true.
 
     1. For each {{GPURenderPassColorAttachment/view}} in non-`null` members of |this|.{{GPURenderPassDescriptor/colorAttachments}}
         and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachment/view}},
@@ -10563,7 +10573,9 @@ GPURenderBundleEncoder includes GPURenderCommandsMixin;
                         <div class=validusage>
                             - |this| is [=valid=].
                             - [$validating attachment layout$](|this|, |descriptor|.{{GPURenderPassLayout/sampleCount}},
-                                |descriptor|.{{GPURenderPassLayout/colorFormats}}]) must return true.
+                                |descriptor|.{{GPURenderPassLayout/colorFormats}},
+                                |descriptor|.{{GPURenderPassLayout/depthStencilFormat}})
+                                must return true.
                             - If |descriptor|.{{GPURenderPassLayout/colorFormats}} only contains `null` members:
                                 - |descriptor|.{{GPURenderPassLayout/depthStencilFormat}} must not be `null`.
                             - For each |colorFormat| in |descriptor|.{{GPURenderPassLayout/colorFormats}}:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1427,7 +1427,7 @@ applications should generally request the "worst" limits that work for their con
         and {{GPURenderPassLayout}}.{{GPURenderPassLayout/colorFormats}}.
 
     <tr><td><dfn>maxAttachmentBytesPerPixel</dfn>
-        <dn>{{GPUSize32}} <td>[=limit class/maximum=] <td>32 bytes
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>32 bytes
     <tr class=row-continuation><td colspan=4>
         The maximum number of bytes used for color attachments in
         {{GPURenderPipelineDescriptor}}.{{GPURenderPipelineDescriptor/fragment}}.{{GPUFragmentState/targets}},

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1474,8 +1474,6 @@ applications should generally request the "worst" limits that work for their con
 
 </table>
 
-Issue: Do we need to have a max per-pixel render target size?
-
 #### <dfn interface>GPUSupportedLimits</dfn> #### {#gpu-supportedlimits}
 
 {{GPUSupportedLimits}} exposes the [=limits=] supported by an adapter or device.


### PR DESCRIPTION
**Draft** because I don't know that this is the correct computation of this limit. See issue.

Fixes #2965


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/3028.html" title="Last updated on Jun 14, 2022, 6:55 PM UTC (57982a9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/3028/edca800...kainino0x:57982a9.html" title="Last updated on Jun 14, 2022, 6:55 PM UTC (57982a9)">Diff</a>