### PR TITLE
editorial: specify units for limits where relevant

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1352,7 +1352,7 @@ applications should generally request the "worst" limits that work for their con
         See [=Exceeds the binding slot limits=].
 
     <tr><td><dfn>maxUniformBufferBindingSize</dfn>
-        <td>{{GPUSize64}} <td>[=limit class/maximum=] <td>65536
+        <td>{{GPUSize64}} <td>[=limit class/maximum=] <td>65536 bytes
     <tr class=row-continuation><td colspan=4>
         The maximum {{GPUBufferBinding}}.{{GPUBufferBinding/size}} for bindings with a
         {{GPUBindGroupLayoutEntry}} |entry| for which
@@ -1360,7 +1360,7 @@ applications should generally request the "worst" limits that work for their con
         is {{GPUBufferBindingType/"uniform"}}.
 
     <tr><td><dfn>maxStorageBufferBindingSize</dfn>
-        <td>{{GPUSize64}} <td>[=limit class/maximum=] <td> 134217728 (128 MiB)
+        <td>{{GPUSize64}} <td>[=limit class/maximum=] <td> 134217728 bytes (128 MiB)
     <tr class=row-continuation><td colspan=4>
         The maximum {{GPUBufferBinding}}.{{GPUBufferBinding/size}} for bindings with a
         {{GPUBindGroupLayoutEntry}} |entry| for which
@@ -1369,7 +1369,7 @@ applications should generally request the "worst" limits that work for their con
         or {{GPUBufferBindingType/"read-only-storage"}}.
 
     <tr><td><dfn>minUniformBufferOffsetAlignment</dfn>
-        <td>{{GPUSize32}} <td>[=limit class/alignment=] <td>256
+        <td>{{GPUSize32}} <td>[=limit class/alignment=] <td>256 bytes
     <tr class=row-continuation><td colspan=4>
         The required alignment for {{GPUBufferBinding}}.{{GPUBufferBinding/offset}} and
         {{GPUBindingCommandsMixin/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup}}
@@ -1378,7 +1378,7 @@ applications should generally request the "worst" limits that work for their con
         is {{GPUBufferBindingType/"uniform"}}.
 
     <tr><td><dfn>minStorageBufferOffsetAlignment</dfn>
-        <td>{{GPUSize32}} <td>[=limit class/alignment=] <td>256
+        <td>{{GPUSize32}} <td>[=limit class/alignment=] <td>256 bytes
     <tr class=row-continuation><td colspan=4>
         The required alignment for {{GPUBufferBinding}}.{{GPUBufferBinding/offset}} and
         {{GPUBindingCommandsMixin/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup}}
@@ -1401,7 +1401,7 @@ applications should generally request the "worst" limits that work for their con
         when creating a {{GPURenderPipeline}}.
 
     <tr><td><dfn>maxVertexBufferArrayStride</dfn>
-        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>2048
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>2048 bytes
     <tr class=row-continuation><td colspan=4>
         The maximum allowed {{GPUVertexBufferLayout/arrayStride}}
         when creating a {{GPURenderPipeline}}.
@@ -1427,7 +1427,7 @@ applications should generally request the "worst" limits that work for their con
         and {{GPURenderPassLayout}}.{{GPURenderPassLayout/colorFormats}}.
 
     <tr><td><dfn>maxComputeWorkgroupStorageSize</dfn>
-        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>16384
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>16384 bytes
     <tr class=row-continuation><td colspan=4>
         The maximum number of bytes used for a compute stage
         {{GPUShaderModule}} entry-point.


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/gpuweb/pull/3039.html" title="Last updated on Jun 11, 2022, 2:01 AM UTC (08315fd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/3039/29618da...kainino0x:08315fd.html" title="Last updated on Jun 11, 2022, 2:01 AM UTC (08315fd)">Diff</a>