### PR TITLE
Clean methods, separate build, and apply suggestion for WGSL grammar

### DIFF
--- a/.github/workflows/publish-specs.yml
+++ b/.github/workflows/publish-specs.yml
@@ -78,4 +78,5 @@ jobs:
           export PATH="$(python3 -m site --user-base)/bin:${PATH}"
           bikeshed update
           mkdir out
+          cd wgsl
           make

--- a/.github/workflows/publish-specs.yml
+++ b/.github/workflows/publish-specs.yml
@@ -78,5 +78,4 @@ jobs:
           export PATH="$(python3 -m site --user-base)/bin:${PATH}"
           bikeshed update
           mkdir out
-          cd wgsl
-          make
+          make -C wgsl

--- a/.github/workflows/publish-specs.yml
+++ b/.github/workflows/publish-specs.yml
@@ -65,7 +65,6 @@ jobs:
             group: gpuwg
             status: ${{ matrix.w3c_build_override_status }}
 
-  # TODO: Is this step checking anything that the other steps/workflows aren't checking?
   wgsl-grammar:
     runs-on: ubuntu-20.04
 
@@ -79,4 +78,4 @@ jobs:
           export PATH="$(python3 -m site --user-base)/bin:${PATH}"
           bikeshed update
           mkdir out
-          ./compile.sh
+          make

--- a/compile.sh
+++ b/compile.sh
@@ -9,11 +9,11 @@ if [ "$1" == 'static' ]; then
   make -C spec webgpu.idl
 else
   echo 'Building spec'
-  make -C spec
+  make -C spec index.html webgpu.idl
   echo 'Building wgsl'
   make -C wgsl index.html
   echo 'Building explainer'
-  make -C explainer
+  make -C explainer index.html
 fi
 
 if [ -d out ]; then

--- a/compile.sh
+++ b/compile.sh
@@ -11,7 +11,7 @@ else
   echo 'Building spec'
   make -C spec
   echo 'Building wgsl'
-  make -C wgsl
+  make -C wgsl index.html
   echo 'Building explainer'
   make -C explainer
 fi

--- a/wgsl/extract-grammar.py
+++ b/wgsl/extract-grammar.py
@@ -39,15 +39,6 @@ grammar_path = os.path.dirname(grammar_filename)
 os.makedirs(grammar_path, exist_ok=True)
 grammar_file = open(grammar_filename, "w")
 
-
-def scanner_escape_name(name):
-    return name.strip().replace("`", "").replace('-', '_').lower().strip()
-
-
-def scanner_escape_regex(regex):
-    return re.escape(regex.strip()).strip().replace("/", "\\/").replace("\\_", "_").replace("\\%", "%").replace("\\;", ";").replace("\\<", "<").replace("\\>", ">").replace("\\=", "=").replace("\\,", ",").replace("\\:", ":").replace("\\!", "!")
-
-
 # Global variable holding the current line text.
 line = ""
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -628,11 +628,11 @@ or a [=hexadecimal floating point literal=].
 <div class='syntax' noexport='true'>
   <dfn for=syntax>decimal_float_literal</dfn> :
 
-    | `/[0-9]*\.[0-9]+([eE](\+|-)?[0-9]+)?[fh]?/`
+    | `/[0-9]*\.[0-9]+([eE][+-]?[0-9]+)?[fh]?/`
 
-    | `/[0-9]+\.[0-9]*([eE](\+|-)?[0-9]+)?[fh]?/`
+    | `/[0-9]+\.[0-9]*([eE][+-]?[0-9]+)?[fh]?/`
 
-    | `/[0-9]+[eE](\+|-)?[0-9]+[fh]?/`
+    | `/[0-9]+[eE][+-]?[0-9]+[fh]?/`
 
     | `/0[fh]/`
 
@@ -642,11 +642,11 @@ or a [=hexadecimal floating point literal=].
 <div class='syntax' noexport='true'>
   <dfn for=syntax>hex_float_literal</dfn> :
 
-    | `/0[xX][0-9a-fA-F]*\.[0-9a-fA-F]+([pP](\+|-)?[0-9]+[fh]?)?/`
+    | `/0[xX][0-9a-fA-F]*\.[0-9a-fA-F]+([pP][+-]?[0-9]+[fh]?)?/`
 
-    | `/0[xX][0-9a-fA-F]+\.[0-9a-fA-F]*([pP](\+|-)?[0-9]+[fh]?)?/`
+    | `/0[xX][0-9a-fA-F]+\.[0-9a-fA-F]*([pP][+-]?[0-9]+[fh]?)?/`
 
-    | `/0[xX][0-9a-fA-F]+[pP](\+|-)?[0-9]+[fh]?/`
+    | `/0[xX][0-9a-fA-F]+[pP][+-]?[0-9]+[fh]?/`
 </div>
 
 <div class='syntax' noexport='true'>


### PR DESCRIPTION
This PR:
1. Removes some unused methods from grammar extractor
2. Separates build process so that main compile.sh only builds index.html for WGSL and grammar validation step builds all targets
3. Apply suggestion to RegEx by @teoxoy https://github.com/gpuweb/gpuweb/pull/2762#issuecomment-1101257471 which I thought was already in with the last commit but apparently not, improves reading.

I suggest this PR to not occupy weekly meeting space.