### PR TITLE
Correct '/' to '.' in 'derive render targets layout from pipeline'.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9768,7 +9768,7 @@ dictionary GPURenderPassLayout: GPUObjectDescriptorBase {
     1. Let |layout| be a new {{GPURenderPassLayout}} object.
     1. Set |layout|.{{GPURenderPassLayout/sampleCount}} to |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/count}}.
     1. If |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}} is not `null`:
-        1. Set |layout|.{{GPURenderPassLayout/depthStencilFormat}} to |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}/{{GPUDepthStencilState/format}}.
+        1. Set |layout|.{{GPURenderPassLayout/depthStencilFormat}} to |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}.{{GPUDepthStencilState/format}}.
     1. If |descriptor|.{{GPURenderPipelineDescriptor/fragment}} is not `null`:
         1. For each |colorTarget| in |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.{{GPUFragmentState/targets}}:
             1. Append |colorTarget|.{{GPUColorTargetState/format}} to |layout|.{{GPURenderPassLayout/colorFormats}}


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jimblandy/gpuweb/pull/3041.html" title="Last updated on Jun 14, 2022, 3:39 AM UTC (75f34e8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/gpuweb/gpuweb/3041/170f891...jimblandy:75f34e8.html" title="Last updated on Jun 14, 2022, 3:39 AM UTC (75f34e8)">Diff</a>