### PR TITLE
wgsl: Fix description of atomicCompareExchangeWeak

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -13677,7 +13677,7 @@ Note: A value cannot be explicitly declared with the type
 Performs the following steps atomically:
 
 1. Load the original value pointed to by `atomic_ptr`.
-2. Compare the original value to the value `v` using an equality operation.
+2. Compare the original value to the value `cmp` using an equality operation.
 3. Store the value `v` `only if` the result of the equality comparison was `true`.
 
 Returns a two member structure, where the first member, `old_value`, is the


### PR DESCRIPTION
The original value is compared to `cmp`, not `v`.