### PR TITLE
Ensure that reflection attributes are initialized

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2648,6 +2648,8 @@ The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its
             **Returns:** {{GPUBuffer}}
 
             1. Let |b| be a new {{GPUBuffer}} object.
+            1. Set |b|.{{GPUBuffer/size}} to |descriptor|.{{GPUBufferDescriptor/size}}.
+            1. Set |b|.{{GPUBuffer/usage}} to |descriptor|.{{GPUBufferDescriptor/usage}}.
             1. Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
                     1. If any of the following conditions are unsatisfied
@@ -2671,8 +2673,6 @@ The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its
                     any calls to {{GPUBuffer/mapAsync()}} will reject, so any resources allocated to enable mapping can
                     and may be discarded or recycled.
 
-                    1. Set |b|.{{GPUBuffer/size}} to |descriptor|.{{GPUBufferDescriptor/size}}.
-                    1. Set |b|.{{GPUBuffer/usage}} to |descriptor|.{{GPUBufferDescriptor/usage}}.
                     1. If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`:
 
                         1. Set |b|.{{GPUBuffer/[[mapping]]}} to a new {{ArrayBuffer}} of size |b|.{{GPUBuffer/size}}.
@@ -3240,6 +3240,14 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
             1. [$Validate texture format required features$] of each element of
                 |descriptor|.{{GPUTextureDescriptor/viewFormats}} with |this|.{{GPUObjectBase/[[device]]}}.
             1. Let |t| be a new {{GPUTexture}} object.
+            1. Set |t|.{{GPUTexture/width}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=].
+            1. Set |t|.{{GPUTexture/height}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=].
+            1. Set |t|.{{GPUTexture/depthOrArrayLayers}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=].
+            1. Set |t|.{{GPUTexture/mipLevelCount}} to |descriptor|.{{GPUTextureDescriptor/mipLevelCount}}.
+            1. Set |t|.{{GPUTexture/sampleCount}} to |descriptor|.{{GPUTextureDescriptor/sampleCount}}.
+            1. Set |t|.{{GPUTexture/dimension}} to |descriptor|.{{GPUTextureDescriptor/dimension}}.
+            1. Set |t|.{{GPUTexture/format}} to |descriptor|.{{GPUTextureDescriptor/format}}.
+            1. Set |t|.{{GPUTexture/usage}} to |descriptor|.{{GPUTextureDescriptor/usage}}.
             1. Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
                     1. If any of the following conditions are unsatisfied
@@ -3247,14 +3255,7 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
                         <div class=validusage>
                             - [$validating GPUTextureDescriptor$](|this|, |descriptor|) returns `true`.
                         </div>
-                    1. Set |t|.{{GPUTexture/width}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=].
-                    1. Set |t|.{{GPUTexture/height}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=].
-                    1. Set |t|.{{GPUTexture/depthOrArrayLayers}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=].
-                    1. Set |t|.{{GPUTexture/mipLevelCount}} to |descriptor|.{{GPUTextureDescriptor/mipLevelCount}}.
-                    1. Set |t|.{{GPUTexture/sampleCount}} to |descriptor|.{{GPUTextureDescriptor/sampleCount}}.
-                    1. Set |t|.{{GPUTexture/dimension}} to |descriptor|.{{GPUTextureDescriptor/dimension}}.
-                    1. Set |t|.{{GPUTexture/format}} to |descriptor|.{{GPUTextureDescriptor/format}}.
-                    1. Set |t|.{{GPUTexture/usage}} to |descriptor|.{{GPUTextureDescriptor/usage}}.
+
                     1. Set |t|.{{GPUTexture/[[size]]}} to |descriptor|.{{GPUTextureDescriptor/size}}.
                     1. Set |t|.{{GPUTexture/[[viewFormats]]}} to |descriptor|.{{GPUTextureDescriptor/viewFormats}}.
                 </div>
@@ -10992,6 +10993,8 @@ dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
                 but |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} does not [=list/contain=]
                 {{GPUFeatureName/"timestamp-query"}}, throw a {{TypeError}}.
             1. Let |q| be a new {{GPUQuerySet}} object.
+            1. Set |q|.{{GPUQuerySet/type}} to |descriptor|.{{GPUQuerySetDescriptor/type}}.
+            1. Set |q|.{{GPUQuerySet/count}} to |descriptor|.{{GPUQuerySetDescriptor/count}}.
             1. Issue the following steps on the [=Device timeline=] of |this|:
                 <div class=device-timeline>
                     1. If any of the following requirements are unmet, [$generate a validation error$],
@@ -11000,9 +11003,7 @@ dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
                             - |this| is [=valid=].
                             - |descriptor|.{{GPUQuerySetDescriptor/count}} must be &le; 8192.
                         </div>
-                    1. Let |q| be a new {{GPUQuerySet}} object.
-                    1. Set |q|.{{GPUQuerySet/type}} to |descriptor|.{{GPUQuerySetDescriptor/type}}.
-                    1. Set |q|.{{GPUQuerySet/count}} to |descriptor|.{{GPUQuerySetDescriptor/count}}.
+
                     1. Set |q|.{{GPUQuerySet/[[state]]}} to [=query set state/available=].
                 </div>
             1. Return |q|.


### PR DESCRIPTION
Fixes #3064 (The more I think about this, the more it seems like clearly the right thing to do.)

This change ensures that even when object creation fails due to a validation
error the reflection attributes for that object are initialized to the values
from the descriptor for consistency. This happens to remove the need to
synchronize with the object creation on the device timeline before reporting
any of these values, which also seems like a good thing.