### PR TITLE
fix bikeshed syntax typo

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -11212,7 +11212,7 @@ interface GPUCanvasContext {
             1. [$Validate texture format required features$] of each element of
                 |configuration|.{{GPUTextureDescriptor/viewFormats}} with |device|.{{GPUObjectBase/[[device]]}}.
             1. Let |descriptor| be the
-                {$GPUTextureDescriptor for the canvas and configuration$}(|this|.{{GPUCanvasContext/canvas}}, |configuration|).
+                [$GPUTextureDescriptor for the canvas and configuration$](|this|.{{GPUCanvasContext/canvas}}, |configuration|).
             1. Set |this|.{{GPUCanvasContext/[[configuration]]}} to |configuration|.
             1. Set |this|.{{GPUCanvasContext/[[textureDescriptor]]}} to |descriptor|.
             1. [$Replace the drawing buffer$] of |this|, which resets
@@ -11507,7 +11507,7 @@ In WebGPU, it does so by [$Replace the drawing buffer|replacing the drawing buff
     1. Let |configuration| be |context|.{{GPUCanvasContext/[[configuration]]}}
     1. If |configuration| is not `null`:
         1. Set |context|.{{GPUCanvasContext/[[textureDescriptor]]}} to the
-            {$GPUTextureDescriptor for the canvas and configuration$}(|canvas|, |configuration|).
+            [$GPUTextureDescriptor for the canvas and configuration$](|canvas|, |configuration|).
 
     Note: This may result a {{GPUTextureDescriptor}} which exceeds the
     {{supported limits/maxTextureDimension2D}} of the device. In this case,


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 17, 2022, 12:24 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fgpuweb%2Fgpuweb%2F1c889b5d0597ac063191305742c0737735a87a7f%2Fspec%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%233066.)._
</details>
