### PR TITLE
[editorial] Generalize language of reading-depth-stencil section

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4896,6 +4896,9 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                                     - |textureLayout|.{{GPUTextureBindingLayout/sampleType}} is not
                                         {{GPUTextureSampleType/"float"}} or {{GPUTextureSampleType/"depth"}}.
 
+                                        Issue(gpuweb/gpuweb#1924):
+                                        This seems to prevent the use of `texture_depth_multisampled_2d`.
+
                                 - If |storageTextureLayout| is not `undefined`:
                                     - |storageTextureLayout|.{{GPUStorageTextureBindingLayout/viewDimension}} is not
                                         {{GPUTextureViewDimension/"cube"}} or {{GPUTextureViewDimension/"cube-array"}}.
@@ -13265,18 +13268,21 @@ be used with {{GPUSamplerBindingType/"comparison"}} samplers (which may use filt
 
 #### Reading and Sampling Depth/Stencil Textures #### {#reading-depth-stencil}
 
-It is possible to bind a depth-aspect {{GPUTextureView}} to either a `texture_depth_*` binding
-or a `texture_2d<f32>` binding. In both cases, the {{GPUTextureBindingLayout/sampleType}} must
-be {{GPUTextureSampleType/"depth"}}.
+It is [$validating shader binding|possible$] to bind a depth-aspect {{GPUTextureView}}
+to either a `texture_depth_*` binding or a binding with other non-depth 2d/cube texture types.
+In both cases, the {{GPUTextureBindingLayout/sampleType}} in the {{GPUBindGroupLayout}}
+must be {{GPUTextureSampleType/"depth"}}.
 
-When reading or sampling a depth aspect via a binding with type `texture_2d<f32>`,
-it behaves as if the texture contains the values `(D, X, X, X)`, where D is the depth value
+A stencil-aspect {{GPUTextureView}} must be bound to a normal texture binding type.
+The {{GPUTextureBindingLayout/sampleType}} in the {{GPUBindGroupLayout}}
+must be {{GPUTextureSampleType/"uint"}}.
+
+Reading or sampling the depth or stencil aspect of a texture behaves as if the texture contains
+the values `(V, X, X, X)`, where V is the actual depth or stencil value,
 and each X is an implementation-defined unspecified value.
 
-Reading or sampling a stencil aspect must be done via a normal texture binding
-(`texture_2d`, `texture_2d_array`, `texture_cube`, or `texture_cube_array`). When doing so,
-it behaves as if the texture contains the values `(S, X, X, X)`, where S is the stencil value
-and each X is an implementation-defined unspecified value.
+For depth-aspect bindings, the unspecified values are not visible through bindings with
+`texture_depth_*` types.
 
 <div class=example>
     If a depth texture is bound to `tex` with type `texture_2d<f32>`:


### PR DESCRIPTION
Makes this language agnostic to exactly which types depth can be bound to, because we need to change that (#3070).

Also add a spec issue for #1924.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 17, 2022, 10:56 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fgpuweb%2Fgpuweb%2Fpull%2F3069%2F293a343.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fkainino0x%2Fgpuweb%2Fpull%2F3069.html)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 sysreq@w3.org to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20gpuweb/gpuweb%233069.)._
</details>
