### PR TITLE
Define inter-stage variable subsetting rules

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6460,26 +6460,9 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
                 - If the "sample_mask" [=builtin=] is a [=pipeline output=] of |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
                     - |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/alphaToCoverageEnabled}} is `false`.
             - [$validating GPUPrimitiveState$](|descriptor|.{{GPURenderPipelineDescriptor/primitive}}, |device|.{{device/[[features]]}}) succeeds.
-            - if |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}} is not `null`:
+            - If |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}} is not `null`:
                 - [$validating GPUDepthStencilState$](|descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}) succeeds.
             - [$validating GPUMultisampleState$](|descriptor|.{{GPURenderPipelineDescriptor/multisample}}) succeeds.
-            - For each user-defined output of
-                |descriptor|.{{GPURenderPipelineDescriptor/vertex}} there must
-                be a user-defined input of
-                |descriptor|.{{GPURenderPipelineDescriptor/fragment}} that
-                matches the
-                [=location=],
-                type, and
-                [=interpolation=]
-                of the output.
-            - For each user-defined input of
-                |descriptor|.{{GPURenderPipelineDescriptor/fragment}} there
-                must be a user-defined output of
-                |descriptor|.{{GPURenderPipelineDescriptor/vertex}} that
-                [=location=],
-                type, and
-                [=interpolation=]
-                of the input.
             - [$validating inter-stage interfaces$](|device|, |descriptor|) returns `true`.
 </div>
 
@@ -6493,29 +6476,38 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
 
     **Returns:** {{boolean}}
 
+    1. Let |vertex| be the entry point described by |descriptor|.{{GPURenderPipelineDescriptor/vertex}}.
+    1. Let |fragment| be the entry point described by |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.
     1. Let |maxVertexShaderOutputComponents| be |device|.limits.{{supported limits/maxInterStageShaderComponents}}.
         1. If |descriptor|.{{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/topology}} is
             {{GPUPrimitiveTopology/"point-list"}}:
             1. Decrement |maxVertexShaderOutputComponents| by 1.
     1. Let |maxFragmentShaderInputComponents| be |device|.limits.{{supported limits/maxInterStageShaderComponents}}.
-        1. If the `front_facing` [=builtin=] is an input of |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
+        1. If the `front_facing` [=builtin=] is an input of |fragment|:
             1. Decrement |maxFragmentShaderInputComponents| by 1.
-        1. If the `sample_index` [=builtin=] is an input of |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
+        1. If the `sample_index` [=builtin=] is an input of |fragment|:
             1. Decrement |maxFragmentShaderInputComponents| by 1.
-        1. If the `sample_mask` [=builtin=] is an input of |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
+        1. If the `sample_mask` [=builtin=] is an input of |fragment|:
             1. Decrement |maxFragmentShaderInputComponents| by 1.
-    1. Return `true` if and only if all of the following conditions are satisfied:
-        - The [=location=] of each user-defined output of |descriptor|.{{GPURenderPipelineDescriptor/vertex}} is less
+    1. Return `true` if and only if all of the following requirements are met:
+        - The [=location=] of each user-defined output of |vertex| must be less
             than (|device|.limits.{{supported limits/maxInterStageShaderVariables}}).
-        - The [=location=] of each user-defined input of |descriptor|.{{GPURenderPipelineDescriptor/fragment}} is less
+        - The [=location=] of each user-defined input of |fragment| must be less
             than (|device|.limits.{{supported limits/maxInterStageShaderVariables}}).
-        - There are no more than |maxVertexShaderOutputComponents| scalar
-            components across all user-defined outputs for
-            |descriptor|.{{GPURenderPipelineDescriptor/vertex}}.
+        - There must be no more than |maxVertexShaderOutputComponents| scalar
+            components across all user-defined outputs for |vertex|.
             (For example, a `f32` output uses 1 component, and a `vec3<f32>` output uses 3 components.)
-        - There are no more than |maxFragmentShaderInputComponents| scalar
-            components across all user-defined inputs for
-            |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.
+        - There must be no more than |maxFragmentShaderInputComponents| scalar
+            components across all user-defined inputs for |fragment|.
+        - In order by [=location=], the user-defined inputs of |fragment| must be an exact prefix of
+            the user-defined outputs of |vertex|:
+            1. Let |maxFragmentInputLocation| be the greatest [=location=] value of all of the
+                user-defined inputs of |fragment|.
+            1. For each |location| from 0 to |maxFragmentInputLocation|:
+                1. If |vertex| does not define an output at |location|,
+                    |fragment| must not define an input at |location|.
+                1. If |vertex| does define an output at |location|,
+                    |fragment| must define an input at |location| with the same type and [=interpolation=].
 </div>
 
 Issue: define what "compatible" means for render target formats.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6508,6 +6508,8 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
                     |fragment| must not define an input at |location|.
                 1. If |vertex| does define an output at |location|,
                     |fragment| must define an input at |location| with the same type and [=interpolation=].
+        - If the `position` [=builtin=] is an input of |fragment|,
+            the number of user-defined |vertex| inputs must equal the number of user-defined |fragment| inputs.
 </div>
 
 Issue: define what "compatible" means for render target formats.


### PR DESCRIPTION
I think these are the rules described in #2038, but I can't find the actual rules for D3D in the D3D11 Functional Spec, so I need someone to help me verify these are correct (or just point me to the right docs/spec).

Here's what I do know, from [the minutes](https://github.com/gpuweb/gpuweb/wiki/Minutes-2022-04-20#shader-stage-input-output-subsetting-rules-2038):

> JN: any inputs to later stage that are not system values needs to match in ordering the same subset from the previous stage. Inputting 3 attribs in PS coming from VS - need to be the first 3 attribs in the same order from VS>
MM: makes sense.
CW: all need to be present in FS?
JN: no. Can have outputs from earlier stage not in later stage.
MM: if consumer consumes 3rd attribute - it needs to consume the first 2 attribs too?
JN: yes. You can't skip attribs.
CW: assume float4 output 0, 1, 2. Want to use input 3 as float4 in frag shader - I need to declare 1, 2? Or want to use 2, don't need to declare 3?
JN: correct.
MM: think that makes sense.
CW: builtin values FS uses? SV_Position for example? Does position of SV_Position in input structure need to match its location in VS output structure?
JN: yes, if written by previous stage like SV_Position - assumed same order between stages. Is_FrontFace, for example, can be at the end.
MM: that's the trick - if producer produces 5 outputs and an SV_ value, and consumer wants middle output and SV_ value, consumer needs all values in their struct.
JN: correct. Well - doesn't need to be last - needs to be in same position on consumer side.
CW: ah we want to put it last because otherwise we have to declare it in FS.

In this PR, variables are ordered by location, and `position` is put at the end (not how the spec is written exactly, but it's the effect). That's based on this:

> MM: Seems like we have a resolution, up to editors to spec this. Not dealing with resources, not dealing with bindgroups. Attribs are one-dimensional; shader interfaces strictly ordered, etc., so not intractable.
CW: problem - in D3D you can put SV_Position wherever you want. If you use it in frag shader you still need to spec everything before/after it. Have to decide how this'll work in WGSL. Does it always go in the end? Have to specify everything in FS then.
MM: makes sense. We also have static use rules. Shouldn't rely on source order.
CW: also entry points take things as arguments.
JN: how it is in HLSL too.
CW: ordering between structures-in-structures, parameters, etc.?
JN: also packing rules where vectors can combine. Here, concerned about packing WGSL args to match lower-level D3D linkages - vec4s.

- [ ] Are there any other builtins which need to be placed at the end like this?

Fixes #2038