### PR TITLE
Set a limit for maximum array size

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8443,18 +8443,29 @@ A WGSL program is a sequence of optional [=directives=] followed by [=module sco
 
 ## Limits ## {#limits}
 
-A program [=shader-creation error|must=] satisfy the following limits:
+A WGSL implementation will support shaders that satisfy the following limits.
+A WGSL implementation may support shaders that go beyond the specified limits.
+
+Note: A WGSL implementation should issue an error if it does not support a
+shader that goes beyond the specified limits.
 
 <table class='data'>
   <caption>Quantifiable shader complexity limits</caption>
   <thead>
-    <tr><th>Limit<th>Maximum value
+    <tr><th>Limit<th>Minimum supported value
   </thead>
-    <tr><td>Number of members in a [=structure=] type<td>16383
-    <tr><td>[=Nesting depth=] of a [=composite=] type<td>255
-    <tr><td>Number of [=formal parameter|parameters=] for a function<td>255
-    <tr><td>Number of case selector values in a [=statement/switch=] statement<td>16383
-    <tr><td>[=Byte-size=] of an [=array=] type<td>65535
+    <tr><td>Maximum number of members in a [=structure=] type<td>16383
+    <tr><td>Maximum [=nesting depth=] of a [=composite=] type<td>255
+    <tr><td>Maximum umber of [=formal parameter|parameters=] for a function<td>255
+    <tr><td>Maximum umber of case selector values in a [=statement/switch=] statement<td>16383
+    <tr><td>Maximum [=byte-size=] of an [=array=] type instantiated in the following [=address spaces=]:
+            * [=address spaces/function=]
+            * [=address spaces/private=]
+            * [=address spaces/workgroup=]
+
+            For the purposes of this limit, [=bool=] has size of 1 byte.
+        <td>65535
+    <tr><td>Maximum number of elements in [=creation-time expression=] of [=array=] type<td>65535
 </table>
 
 # Execution # {#execution}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8463,7 +8463,7 @@ shader that goes beyond the specified limits.
             * [=address spaces/private=]
             * [=address spaces/workgroup=]
 
-            For the purposes of this limit, [=bool=] has size of 1 byte.
+            For the purposes of this limit, [=bool=] has a size of 1 byte.
         <td>65535
     <tr><td>Maximum number of elements in [=creation-time expression=] of [=array=] type<td>65535
 </table>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8458,13 +8458,16 @@ shader that goes beyond the specified limits.
     <tr><td>Maximum [=nesting depth=] of a [=composite=] type<td>255
     <tr><td>Maximum number of [=formal parameter|parameters=] for a function<td>255
     <tr><td>Maximum number of case selector values in a [=statement/switch=] statement<td>16383
-    <tr><td>Maximum [=byte-size=] of an [=array=] type instantiated in the following [=address spaces=]:
-            * [=address spaces/function=]
-            * [=address spaces/private=]
-            * [=address spaces/workgroup=]
+    <tr><td>Maximum [=byte-size=] of an [=array=] type instantiated in the
+            [=address spaces/function=] or [=address spaces/private=] address spaces
 
             For the purposes of this limit, [=bool=] has a size of 1 byte.
         <td>65535
+    <tr><td>Maximum [=byte-size=] of an [=array=] type instantiated in the
+            [=address spaces/workgroup=] address space
+
+            For the purposes of this limit, [=bool=] has a size of 1 byte.
+        <td>[[WebGPU#dom-supported-limits-maxcomputeworkgroupstoragesize|16384]]
     <tr><td>Maximum number of elements in [=creation-time expression=] of [=array=] type<td>65535
 </table>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8456,8 +8456,8 @@ shader that goes beyond the specified limits.
   </thead>
     <tr><td>Maximum number of members in a [=structure=] type<td>16383
     <tr><td>Maximum [=nesting depth=] of a [=composite=] type<td>255
-    <tr><td>Maximum umber of [=formal parameter|parameters=] for a function<td>255
-    <tr><td>Maximum umber of case selector values in a [=statement/switch=] statement<td>16383
+    <tr><td>Maximum number of [=formal parameter|parameters=] for a function<td>255
+    <tr><td>Maximum number of case selector values in a [=statement/switch=] statement<td>16383
     <tr><td>Maximum [=byte-size=] of an [=array=] type instantiated in the following [=address spaces=]:
             * [=address spaces/function=]
             * [=address spaces/private=]

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8468,7 +8468,7 @@ shader that goes beyond the specified limits.
 
             For the purposes of this limit, [=bool=] has a size of 1 byte.
         <td>[[WebGPU#dom-supported-limits-maxcomputeworkgroupstoragesize|16384]]
-    <tr><td>Maximum number of elements in [=creation-time expression=] of [=array=] type<td>65535
+    <tr><td>Maximum number of elements in [=const-expression=] of [=array=] type<td>65535
 </table>
 
 # Execution # {#execution}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8454,6 +8454,7 @@ A program [=shader-creation error|must=] satisfy the following limits:
     <tr><td>[=Nesting depth=] of a [=composite=] type<td>255
     <tr><td>Number of [=formal parameter|parameters=] for a function<td>255
     <tr><td>Number of case selector values in a [=statement/switch=] statement<td>16383
+    <tr><td>[=Byte-size=] of an [=array=] type<td>655in35
 </table>
 
 # Execution # {#execution}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8454,7 +8454,7 @@ A program [=shader-creation error|must=] satisfy the following limits:
     <tr><td>[=Nesting depth=] of a [=composite=] type<td>255
     <tr><td>Number of [=formal parameter|parameters=] for a function<td>255
     <tr><td>Number of case selector values in a [=statement/switch=] statement<td>16383
-    <tr><td>[=Byte-size=] of an [=array=] type<td>655in35
+    <tr><td>[=Byte-size=] of an [=array=] type<td>65535
 </table>
 
 # Execution # {#execution}


### PR DESCRIPTION
Fixes #2118

* Set a limit of 64k bytes for an array size