### PR TITLE
Stop using spec-prod for gh-pages builds

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,14 +1,21 @@
-name: Publish static files to GitHub Pages
+name: Build and publish to GitHub Pages
 
-# Workflow runs on pushes to the main branch. It publishes statics files to
-# GitHub Pages. The specs themselves (WebGPU, WGSL, the explainer) are handled
-# separately in a different workflow.
+# Workflow runs on pushes to the main branch. It builds all Bikeshed documents
+# (specs and explainers/references) and some supplemental materials (IDL and
+# grammar) and pushes them to GitHub Pages.
+#
 # The "workflow_dispatch" hook allows admins to trigger the workflow manually
 # from GitHub's UI.
 
 on:
   push:
     branches: [main]
+    paths:
+      - '.github/**'
+      - 'tools/**'
+      - 'spec/**'
+      - 'wgsl/**'
+      - 'explainer/**'
   workflow_dispatch:
 
 jobs:
@@ -19,12 +26,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Copy static files to the "out" folder
+      - name: Populate out/
         run: |
           export PATH="$(python3 -m site --user-base)/bin:${PATH}"
-          pip3 install bikeshed==3.7.0 tree_sitter==0.19.0
+          pip3 install bikeshed==3.7.0
           mkdir ./out
-          ./compile.sh static
+          ./compile.sh
 
       - name: Deploy to GitHub Pages
         if: ${{ success() && github.ref == 'refs/heads/main' }}
@@ -32,7 +39,3 @@ jobs:
         with:
           BRANCH: gh-pages
           FOLDER: out
-          CLEAN-EXCLUDE: |
-            index.html
-            wgsl/index.html
-            explainer/index.html

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -92,9 +92,8 @@ jobs:
           issue-number: ${{ env.PR }}
           body: |
             Previews, as seen when this [build job](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}) started (${{ github.event.workflow_run.head_sha }}):
-            [**WebGPU**](${{ steps.deployment.outputs.details_url }}/) | [**IDL**](${{ steps.deployment.outputs.details_url }}/webgpu.idl)
-            [**WGSL**](${{ steps.deployment.outputs.details_url }}/wgsl/)
-            [**Explainer**](${{ steps.deployment.outputs.details_url }}/explainer/)
+            [**WebGPU**](${{ steps.deployment.outputs.details_url }}/) | [**IDL**](${{ steps.deployment.outputs.details_url }}/webgpu.idl) | [**Explainer**](${{ steps.deployment.outputs.details_url }}/explainer/)
+            [**WGSL**](${{ steps.deployment.outputs.details_url }}/wgsl/) | [**`wgsl.lalr.txt`**](${{ steps.deployment.outputs.details_url }}/wgsl/wgsl.lalr.txt)
             <!--
             pr;head;sha
             ${{ env.PR }};${{ github.event.workflow_run.head_repository.full_name }};${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/publish-specs.yml
+++ b/.github/workflows/publish-specs.yml
@@ -1,14 +1,18 @@
-name: Build, validate and publish spec to GitHub Pages and /TR
+name: Build, validate and publish specs to /TR
 
-# Workflow runs once per spec (WebGPU, WGSL and explainer) on pull requests and
+# Workflow runs once per published spec (WebGPU, WGSL) on pull requests and
 # on pushes to the main branch that touch the spec. For pull requests, it makes
 # sure that the spec can be generated and that markup is valid. For pushes, it
-# also deploys the generate spec to GitHub Pages and to /TR for WebGPU and WGSL.
+# also deploys the generated spec to /TR for WebGPU and WGSL.
+#
 # The "workflow_dispatch" hook allows admins to trigger the workflow manually
 # from GitHub's UI.
 #
 # Workflow uses the w3c/spec-prod action, see base multi-spec repo example at:
 # https://github.com/w3c/spec-prod/blob/main/docs/examples.md#multiple-specs-in-same-repository
+# Note, spec-prod can publish to gh-pages as well, but we need a custom publish
+# step to publish additional files as well, so we use that instead of making
+# many separate gh-pages commits (one per bikeshed file + one for extra files).
 
 on:
   pull_request:
@@ -16,9 +20,9 @@ on:
     branches: [main]
     paths:
       - '.github/**'
+      - 'tools/**'
       - 'spec/**'
       - 'wgsl/**'
-      - 'explainer/**'
   workflow_dispatch:
 
 jobs:
@@ -31,34 +35,23 @@ jobs:
       matrix:
         include:
           - source: spec/index.bs
-            destination: index.html
             echidna_token: ECHIDNA_TOKEN_WEBGPU
             w3c_build_override_status: WD
           - source: wgsl/index.bs
-            destination: wgsl/index.html
             echidna_token: ECHIDNA_TOKEN_WGSL
             w3c_build_override_status: WD
-          - source: explainer/index.bs
-            destination: explainer/index.html
-            # Explainer is not published to /TR, no echidna_token
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        
-      - name: Update dependencies
-        # TODO: spec-prod seems to use the latest bikeshed instead of this one
-        run: |
-          pip3 install bikeshed==3.7.0 tree_sitter==0.19.0
 
-      - name: Build and validate spec, publish to GitHub Pages and /TR
+      # TODO: spec-prod seems to use the latest bikeshed instead of our pinned version
+      - name: Build and validate spec, publish to /TR
         uses: w3c/spec-prod@v2
         with:
           TOOLCHAIN: bikeshed
           SOURCE: ${{ matrix.source }}
-          DESTINATION: ${{ matrix.destination }}
           BUILD_FAIL_ON: warning
-          GH_PAGES_BRANCH: gh-pages
           W3C_ECHIDNA_TOKEN: ${{ secrets[matrix.echidna_token] }}
           W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-gpu/2021Apr/0004.html
           W3C_BUILD_OVERRIDE: |
@@ -74,8 +67,5 @@ jobs:
 
       - name: Validate WGSL grammar
         run: |
-          pip3 install bikeshed==3.7.0 tree_sitter==0.19.0
-          export PATH="$(python3 -m site --user-base)/bin:${PATH}"
-          bikeshed update
-          mkdir out
-          make -C wgsl
+          pip3 install tree_sitter==0.19.0
+          make -C wgsl validate

--- a/compile.sh
+++ b/compile.sh
@@ -3,36 +3,25 @@ set -e # Exit with nonzero exit code if anything fails
 
 export BIKESHED_DISALLOW_ONLINE=1
 
-# Compile specs by default, unless told to only copy static files
-if [ "$1" == 'static' ]; then
-  echo 'Extracting IDL from WebGPU spec'
-  make -C spec webgpu.idl
-else
-  echo 'Building spec'
-  make -C spec index.html webgpu.idl
-  echo 'Building wgsl'
-  make -C wgsl index.html
-  echo 'Building explainer'
-  make -C explainer index.html
-fi
+echo 'Building spec and webgpu.idl'
+make -C spec index.html webgpu.idl
+echo 'Building wgsl'
+make -C wgsl index.html wgsl.lalr.txt
+echo 'Building explainer'
+make -C explainer index.html
+echo 'Building correspondence'
+make -C correspondence index.html
 
 if [ -d out ]; then
-  mkdir -p out/wgsl out/explainer out/samples
+  echo 'Populating out/'
 
-  echo 'Copying wgsl/* -> out/wgsl/'
-  cp -r wgsl/* out/wgsl/
-  rm out/wgsl/{Makefile,*.bs}
+  mkdir -p out/wgsl out/explainer out/correspondence out/samples
+  cp -r spec/{index.html,webgpu.idl} out/
+  cp -r wgsl/index.html out/wgsl/
+  cp -r explainer/{index.html,img} out/explainer/
+  cp -r correspondence/index.html out/correspondence/
+  cp -r samples/* out/samples/
 
-  echo 'Copying explainer/* -> out/explainer/'
-  cp -r explainer/* out/explainer/
-  rm out/explainer/{Makefile,*.bs}
-
-  echo 'Copying spec/* -> out/'
-  cp spec/* out/
-  rm out/{README.md,Makefile,*.bs}
-
-  echo 'Copying samples/* -> out/samples/'
-  cp samples/* out/samples/
-
+  # Redirect wgsl.html to wgsl/
   echo '<meta http-equiv="refresh" content="0;url=wgsl/" />' > out/wgsl.html
 fi

--- a/compile.sh
+++ b/compile.sh
@@ -9,17 +9,14 @@ echo 'Building wgsl'
 make -C wgsl index.html wgsl.lalr.txt
 echo 'Building explainer'
 make -C explainer index.html
-echo 'Building correspondence'
-make -C correspondence index.html
 
 if [ -d out ]; then
   echo 'Populating out/'
 
-  mkdir -p out/wgsl out/explainer out/correspondence out/samples
+  mkdir -p out/wgsl out/explainer out/samples
   cp -r spec/{index.html,webgpu.idl} out/
   cp -r wgsl/index.html out/wgsl/
   cp -r explainer/{index.html,img} out/explainer/
-  cp -r correspondence/index.html out/correspondence/
   cp -r samples/* out/samples/
 
   # Redirect wgsl.html to wgsl/

--- a/explainer/index.bs
+++ b/explainer/index.bs
@@ -1,7 +1,7 @@
 <pre class='metadata'>
 Title: WebGPU Explainer
 Shortname: webgpu-explainer
-Level: 1
+Level: None
 Status: LS
 Group: webgpu
 URL: https://gpuweb.github.io/gpuweb/explainer/

--- a/wgsl/Makefile
+++ b/wgsl/Makefile
@@ -1,6 +1,7 @@
-.PHONY: all clean
+.PHONY: all validate clean
 
-all: index.html grammar/grammar.js test wgsl.lalr.txt
+all: index.html grammar/grammar.js test lalr
+validate: lalr
 
 clean:
 	rm -f index.html index.pre.html grammar/grammar.js wgsl.lalr.txt
@@ -17,17 +18,13 @@ index.html: index.pre.html
 grammar/grammar.js: index.bs extract-grammar.py
 	python3 ./extract-grammar.py index.bs grammar/grammar.js
 
-online:
-	curl https://api.csswg.org/bikeshed/ -F file=@index.bs -F output=err
-	curl https://api.csswg.org/bikeshed/ -F file=@index.bs -F force=1 > index.html
-
 # The grammar in JSON form, emitted by Treesitter.
 WGSL_GRAMMAR=grammar/src/grammar.json
 $(WGSL_GRAMMAR) : grammar/grammar.js
 
 
 #### Grammar analyzer materials below here.
-#### You probably only want 'make lalr'
+#### You probably only want 'make validate'
 
 .PHONY: test
 test: analyze_test


### PR DESCRIPTION
Using spec-prod for gh-pages builds means we push one commit to gh-pages
for each document being built in this repo. And each of these commits
@ mentions the person who clicked the merge button, sending them 3 emails.

We already have a workflow for publishing docs to gh-pages because we
also want to publish webgpu.idl, and used to publish the specs that way.

I think the only thing this changes about our gh-pages output is that it
will have the "This version" line with the git hash in it like local
builds have now.

**It's entirely possible that landing this will break the build and we'll need to revert or fix it afterward.**