### PR TITLE
Allow drawCount == maxDrawCount

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9834,7 +9834,7 @@ called the render pass encoder can no longer be used.
                         - |this| must be [=valid=].
                         - |this|.{{GPUDebugCommandsMixin/[[debug_group_stack]]}} must [=list/is empty|be empty=].
                         - |this|.{{GPURenderPassEncoder/[[occlusion_query_active]]}} must be `false`.
-                        - |this|.{{GPURenderCommandsMixin/[[drawCount]]}} must be less than or equal to |this|.{{GPURenderPassEncoder/[[maxDrawCount]]}}.
+                        - |this|.{{GPURenderCommandsMixin/[[drawCount]]}} must be &le; |this|.{{GPURenderPassEncoder/[[maxDrawCount]]}}.
                     </div>
                 1. [=list/Extend=] |parentEncoder|.{{GPUCommandsMixin/[[commands]]}}
                     with |this|.{{GPUCommandsMixin/[[commands]]}}.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -9834,7 +9834,7 @@ called the render pass encoder can no longer be used.
                         - |this| must be [=valid=].
                         - |this|.{{GPUDebugCommandsMixin/[[debug_group_stack]]}} must [=list/is empty|be empty=].
                         - |this|.{{GPURenderPassEncoder/[[occlusion_query_active]]}} must be `false`.
-                        - |this|.{{GPURenderCommandsMixin/[[drawCount]]}} must be less than |this|.{{GPURenderPassEncoder/[[maxDrawCount]]}}.
+                        - |this|.{{GPURenderCommandsMixin/[[drawCount]]}} must be less than or equal to |this|.{{GPURenderPassEncoder/[[maxDrawCount]]}}.
                     </div>
                 1. [=list/Extend=] |parentEncoder|.{{GPUCommandsMixin/[[commands]]}}
                     with |this|.{{GPUCommandsMixin/[[commands]]}}.


### PR DESCRIPTION
From https://github.com/gpuweb/gpuweb/pull/3005#discussion_r903447104

Currently the specification describes that `drawCount` must be less
than `maxDrawCount` but `drawCount == maxDrawCount` must also be
valid.

So I would like to suggest to replace

> - this.[[drawCount]] must be less than this.[[maxDrawCount]].

with

> - this.[[drawCount]] must be less than or equal to this.[[maxDrawCount]].
 