### PR TITLE
Fix definition of matrix-column-vector product.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5387,7 +5387,7 @@ See [[#sync-builtin-functions]].
         |T| is AbstractFloat, f32, or f16
     <td>|m| `*` |v|:  vec|R|&lt;|T|&gt<br>
     <td>Linear algebra matrix-column-vector product:
-        Component |i| of the result is `dot`(|m|[|i|],|v|)
+        Component |i| of the result is `dot`(transpose(|m|)[|i|],|v|)
   <tr algorithm="matrix-row-vector multiply">
     <td>
         |m|: mat|C|x|R|&lt;|T|&gt<br>


### PR DESCRIPTION
A matrix-column-vector product `m * v` produces a vector whose `i`'th
element is the dot product of `v` with the i'th row of `m`, but the
current text tries to take the dot product with `m[i]`, which is the
`i`'th column of `m`. `transpose(m)[i]` is the correct way to refer to
the `i`'th row.