### PR TITLE
nit: remove a redundant validation step

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3334,7 +3334,6 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
     - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be less than or equal to
         [$maximum mipLevel count$](|descriptor|.{{GPUTextureDescriptor/dimension}}, |descriptor|.{{GPUTextureDescriptor/size}}).
 
-    - |descriptor|.{{GPUTextureDescriptor/usage}} must be a combination of {{GPUTextureUsage}} values.
     - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/RENDER_ATTACHMENT}} bit:
         - |descriptor|.{{GPUTextureDescriptor/format}} must be a [=renderable format=].
         - |descriptor|.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"2d"}}.


### PR DESCRIPTION
we also have `|descriptor|.{{GPUTextureDescriptor/usage}} must contain only bits present in |this|'s [=allowed texture usages=]` which is a stricter rule