### PR TITLE
Add a note that WebGPU should be included in any high-power warnings

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -497,6 +497,11 @@ To mitigate this form of abuse, browsers can throttle operations on background
 tabs, could warn that a tab is using a lot of resource, and restrict which
 contexts are allowed to use WebGPU.
 
+User agents can heuristically issue warnings to users about high power use,
+especially due to potentially malicious usage.
+If a user agent implements such a warning, it should include WebGPU usage in
+its heuristics, in addition to JavaScript, WebAssembly, WebGL, and so on.
+
 Issue: Update this section with iframe-control defaulting to "self" being a
 mitigation against this issue since only the top level origin (that is a bit
 more trusted since the user navigated to it, or is staying on it).


### PR DESCRIPTION
I don't think such warnings exist in any browser today so this is very
theoretical, and should be enough to fix #2947.