### PR TITLE
Fix phrasing of accuracy of cos, sin, log, log2

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8850,7 +8850,9 @@ value with the same sign.
   <tr><td>`atanh(x)`<td colspan=2 style="text-align:left;">Inherited from `log( (1.0 + x) / (1.0 - x) ) * 0.5`
   <tr><td>`ceil(x)`<td colspan=2 style="text-align:left;">Correctly rounded
   <tr><td>`clamp(x,low,high)`<td colspan=2 style="text-align:left;">Inherited from `min(max(x, low), high)` and median of `[x, low, high]`
-  <tr><td>`cos(x)`<td>Absolute error &le; 2<sup>-11</sup> inside the range of [-&pi;, &pi;]<td>Absolute error &le; 2<sup>-7</sup> inside the range of [-&pi;, &pi;]
+  <tr><td>`cos(x)`
+      <td>Absolute error at most 2<sup>-11</sup> when `x` is in the interval [-&pi;, &pi;]
+      <td>Absolute error at most 2<sup>-7</sup> when `x` is in the interval [-&pi;, &pi;]
   <tr><td>`cosh(x)`<td colspan=2 style="text-align:left;">Inherited from `(exp(x) - exp(-x)) * 0.5`
   <tr><td>`cross(x, y)`<td colspan=2 style="text-align:left;">Inherited from `(x[i] * y[j] - x[j] * y[i])`
   <tr><td>`degrees(x)`<td colspan=2 style="text-align:left;">Inherited from `x * 57.295779513082322865`
@@ -8866,8 +8868,16 @@ value with the same sign.
   <tr><td>`inverseSqrt(x)`<td colspan=2 style="text-align:left;">2 ULP
   <tr><td>`ldexp(x, y)`<td colspan=2 style="text-align:left;">Correctly rounded
   <tr><td>`length(x)`<td colspan=2 style="text-align:left;">Inherited from `sqrt(dot(x, x))`
-  <tr><td>`log(x)`<td>3 ULP outside the range [0.5, 2.0].<br>Absolute error &lt; 2<sup>-21</sup> inside the range [0.5, 2.0]<td>3 ULP outside the range [0.5, 2.0].<br>Absolute error &lt; 2<sup>-7</sup> inside the range [0.5, 2.0]
-  <tr><td>`log2(x)`<td>3 ULP outside the range [0.5, 2.0].<br>Absolute error &lt; 2<sup>-21</sup> inside the range [0.5, 2.0]<td>3 ULP outside the range [0.5, 2.0].<br>Absolute error &lt; 2<sup>-7</sup> inside the range [0.5, 2.0]
+  <tr><td>`log(x)`
+      <td>Absolute error at most 2<sup>-21</sup> when `x` is in the interval [0.5, 2.0].<br>
+          3 ULP when `x` is outside the interval [0.5, 2.0].<br>
+      <td>Absolute error at most 2<sup>-7</sup> when `x` is in the interval [0.5, 2.0].<br>
+          3 ULP when `x` is outside the interval [0.5, 2.0].<br>
+  <tr><td>`log2(x)`
+      <td>Absolute error at most 2<sup>-21</sup> when `x` is in the interval [0.5, 2.0].<br>
+          3 ULP when `x` is outside the interval [0.5, 2.0].<br>
+      <td>Absolute error at most 2<sup>-7</sup> when `x` is in the interval [0.5, 2.0].<br>
+          3 ULP when `x` is outside the interval [0.5, 2.0].<br>
   <tr><td>`max(x, y)`<td colspan=2 style="text-align:left;">Correctly rounded
   <tr><td>`min(x, y)`<td colspan=2 style="text-align:left;">Correctly rounded
   <tr><td>`mix(x, y, z)`<td colspan=2 style="text-align:left;">Inherited from `x * (1.0 - z) + y * z`
@@ -8879,7 +8889,9 @@ value with the same sign.
   <tr><td>`refract(x, y, z)`<td colspan=2 style="text-align:left;">Inherited from `z * x - (z * dot(y, x) + sqrt(k)) * y`,<br>where `k = 1.0 - z * z * (1.0 - dot(y, x) * dot(y, x))`<br>If `k < 0.0` the result is precisely 0.0
   <tr><td>`round(x)`<td colspan=2 style="text-align:left;">Correctly rounded
   <tr><td>`sign(x)`<td colspan=2 style="text-align:left;">Correctly rounded
-  <tr><td>`sin(x)`<td>Absolute error &le; 2<sup>-11</sup> inside the range [-&pi;, &pi;]<td>Absolute error &le; 2<sup>-7</sup> inside the range [-&pi;, &pi;]
+  <tr><td>`sin(x)`
+      <td>Absolute error at most 2<sup>-11</sup> when `x` is in the interval [-&pi;, &pi;]
+      <td>Absolute error at most 2<sup>-7</sup> when `x` is in the interval [-&pi;, &pi;]
   <tr><td>`sinh(x)`<td colspan=2 style="text-align:left;">Inherited from `(exp(x) - exp(-x)) * 0.5`
   <tr><td>`smoothstep(low, high, x)`<td colspan=2 style="text-align:left;">Inherited from `t * t * (3.0 - 2.0 * t)`,<br>where `t = clamp((x - low) / (high - low), 0.0, 1.0)`
   <tr><td>`sqrt(x)`<td colspan=2 style="text-align:left;">Inherited from `1.0 / inverseSqrt(x)`


### PR DESCRIPTION
When they were saying "range" they meant to bound the argument x,
not the answer y = f(x).

Fixes: #3104