### PR TITLE
Forbid pointer-to-workgroup param on user functions, when store type …

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7541,6 +7541,8 @@ Note: The [=attribute/const=] attribute cannot be applied to user-declared funct
     * [=address spaces/function=]
     * [=address spaces/private=]
     * [=address spaces/workgroup=]
+         * In this case, the pointer's [=store type=] [=shader-creation error|must not=] not be an [=atomic type=],
+            nor contain an atomic type at any [=nesting depth=].
 * For [=built-in functions=], a parameter of pointer type [=shader-creation error|must=] be in one of
     the following address spaces:
     * [=address spaces/function=]


### PR DESCRIPTION
…contains an atomic

Fixes: #3067