### PR TITLE
Restore commas after final members of enums

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2418,7 +2418,7 @@ dictionary GPURequestAdapterOptions {
 <script type=idl>
 enum GPUPowerPreference {
     "low-power",
-    "high-performance"
+    "high-performance",
 };
 </script>
 
@@ -2790,7 +2790,7 @@ enum GPUFeatureName {
     "shader-f16",
     "rg11b10ufloat-renderable",
     "bgra8unorm-storage",
-    "float32-filterable"
+    "float32-filterable",
 };
 </script>
 
@@ -3034,7 +3034,7 @@ GPUBuffer includes GPUObjectBase;
 enum GPUBufferMapState {
     "unmapped",
     "pending",
-    "mapped"
+    "mapped",
 };
 </script>
 
@@ -4058,7 +4058,7 @@ dictionary GPUTextureDescriptor
 enum GPUTextureDimension {
     "1d",
     "2d",
-    "3d"
+    "3d",
 };
 </script>
 
@@ -4420,7 +4420,7 @@ enum GPUTextureViewDimension {
     "2d-array",
     "cube",
     "cube-array",
-    "3d"
+    "3d",
 };
 </script>
 
@@ -4495,7 +4495,7 @@ The <dfn dfn for=GPUTextureAspect>set of aspects</dfn> are defined for each valu
 enum GPUTextureAspect {
     "all",
     "stencil-only",
-    "depth-only"
+    "depth-only",
 };
 </script>
 
@@ -4868,7 +4868,7 @@ enum GPUTextureFormat {
     "astc-12x10-unorm",
     "astc-12x10-unorm-srgb",
     "astc-12x12-unorm",
-    "astc-12x12-unorm-srgb"
+    "astc-12x12-unorm-srgb",
 };
 </script>
 
@@ -5290,7 +5290,7 @@ Issue: Describe a "sample footprint" in greater detail.
 enum GPUAddressMode {
     "clamp-to-edge",
     "repeat",
-    "mirror-repeat"
+    "mirror-repeat",
 };
 </script>
 
@@ -5315,12 +5315,12 @@ match one texel.
 <script type=idl>
 enum GPUFilterMode {
     "nearest",
-    "linear"
+    "linear",
 };
 
 enum GPUMipmapFilterMode {
     "nearest",
-    "linear"
+    "linear",
 };
 </script>
 
@@ -5349,7 +5349,7 @@ enum GPUCompareFunction {
     "greater",
     "not-equal",
     "greater-equal",
-    "always"
+    "always",
 };
 </script>
 
@@ -5691,7 +5691,7 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
 enum GPUBufferBindingType {
     "uniform",
     "storage",
-    "read-only-storage"
+    "read-only-storage",
 };
 
 dictionary GPUBufferBindingLayout {
@@ -5739,7 +5739,7 @@ dictionary GPUBufferBindingLayout {
 enum GPUSamplerBindingType {
     "filtering",
     "non-filtering",
-    "comparison"
+    "comparison",
 };
 
 dictionary GPUSamplerBindingLayout {
@@ -5761,7 +5761,7 @@ enum GPUTextureSampleType {
     "unfilterable-float",
     "depth",
     "sint",
-    "uint"
+    "uint",
 };
 
 dictionary GPUTextureBindingLayout {
@@ -5790,7 +5790,7 @@ dictionary GPUTextureBindingLayout {
 
 <script type=idl>
 enum GPUStorageTextureAccess {
-    "write-only"
+    "write-only",
 };
 
 dictionary GPUStorageTextureBindingLayout {
@@ -6576,7 +6576,7 @@ dictionary GPUShaderModuleCompilationHint {
 enum GPUCompilationMessageType {
     "error",
     "warning",
-    "info"
+    "info",
 };
 
 [Exposed=(Window, DedicatedWorker), Serializable, SecureContext]
@@ -6813,7 +6813,7 @@ dictionary GPUPipelineErrorInit {
 
 enum GPUPipelineErrorReason {
     "validation",
-    "internal"
+    "internal",
 };
 </script>
 
@@ -6866,7 +6866,7 @@ enum GPUPipelineErrorReason {
 
 <script type=idl>
 enum GPUAutoLayoutMode {
-    "auto"
+    "auto",
 };
 
 dictionary GPUPipelineDescriptorBase
@@ -7977,7 +7977,7 @@ enum GPUPrimitiveTopology {
     "line-list",
     "line-strip",
     "triangle-list",
-    "triangle-strip"
+    "triangle-strip",
 };
 </script>
 
@@ -8010,7 +8010,7 @@ will use. See [[#rasterization]] for additional details:
 <script type=idl>
 enum GPUFrontFace {
     "ccw",
-    "cw"
+    "cw",
 };
 </script>
 
@@ -8033,7 +8033,7 @@ See [[#polygon-rasterization]] for additional details:
 enum GPUCullMode {
     "none",
     "front",
-    "back"
+    "back",
 };
 </script>
 
@@ -8264,7 +8264,7 @@ enum GPUBlendFactor {
     "one-minus-dst-alpha",
     "src-alpha-saturated",
     "constant",
-    "one-minus-constant"
+    "one-minus-constant",
 };
 </script>
 
@@ -8326,7 +8326,7 @@ enum GPUBlendOperation {
     "subtract",
     "reverse-subtract",
     "min",
-    "max"
+    "max",
 };
 </script>
 
@@ -8512,7 +8512,7 @@ enum GPUStencilOperation {
     "increment-clamp",
     "decrement-clamp",
     "increment-wrap",
-    "decrement-wrap"
+    "decrement-wrap",
 };
 </script>
 
@@ -8562,7 +8562,7 @@ enum GPUStencilOperation {
 <script type=idl>
 enum GPUIndexFormat {
     "uint16",
-    "uint32"
+    "uint32",
 };
 </script>
 
@@ -8714,7 +8714,7 @@ enum GPUVertexFormat {
     "sint32",
     "sint32x2",
     "sint32x3",
-    "sint32x4"
+    "sint32x4",
 };
 </script>
 
@@ -8914,7 +8914,7 @@ enum GPUVertexFormat {
 <script type=idl>
 enum GPUVertexStepMode {
     "vertex",
-    "instance"
+    "instance",
 };
 </script>
 
@@ -10320,7 +10320,7 @@ GPUComputePassEncoder includes GPUBindingCommandsMixin;
 <script type=idl>
 enum GPUComputePassTimestampLocation {
     "beginning",
-    "end"
+    "end",
 };
 
 dictionary GPUComputePassTimestampWrite {
@@ -10672,7 +10672,7 @@ When executing encoded render pass commands as part of a {{GPUCommandBuffer}}, a
 <script type=idl>
 enum GPURenderPassTimestampLocation {
     "beginning",
-    "end"
+    "end",
 };
 
 dictionary GPURenderPassTimestampWrite {
@@ -11007,7 +11007,7 @@ dictionary GPURenderPassDepthStencilAttachment {
 <script type=idl>
 enum GPULoadOp {
     "load",
-    "clear"
+    "clear",
 };
 </script>
 
@@ -11031,7 +11031,7 @@ enum GPULoadOp {
 <script type=idl>
 enum GPUStoreOp {
     "store",
-    "discard"
+    "discard",
 };
 </script>
 
@@ -12762,7 +12762,7 @@ garbage collection by calling {{GPUQuerySet/destroy()}}.
 <script type=idl>
 enum GPUQueryType {
     "occlusion",
-    "timestamp"
+    "timestamp",
 };
 </script>
 
@@ -13212,7 +13212,7 @@ a view with an `srgb` format.
 <script type=idl>
 enum GPUCanvasAlphaMode {
     "opaque",
-    "premultiplied"
+    "premultiplied",
 };
 
 dictionary GPUCanvasConfiguration {
@@ -13403,7 +13403,7 @@ Instead, the {{GPUDevice}}.{{GPUDevice/lost}} promise resolves to indicate the d
 <script type=idl>
 enum GPUDeviceLostReason {
     "unknown",
-    "destroyed"
+    "destroyed",
 };
 
 [Exposed=(Window, DedicatedWorker), SecureContext]
@@ -13573,7 +13573,7 @@ of WebGPU calls, typically for debugging purposes or to make an operation more f
 enum GPUErrorFilter {
     "validation",
     "out-of-memory",
-    "internal"
+    "internal",
 };
 
 partial interface GPUDevice {


### PR DESCRIPTION
See #2966 which removed them.

- [x] ~Blocked on having a Bikeshed release that uses widlparser 1.1.1 (for https://github.com/plinss/widlparser/commit/048fcc351f0a35a5700617d1414653c077a8a338)~