### PR TITLE
[editorial] Make GPUCommandBuffer one-time-use

### DIFF
--- a/design/CommandSubmission.md
+++ b/design/CommandSubmission.md
@@ -1,5 +1,7 @@
 # Command Submission
 
+**THIS DOCUMENT IS OUTDATED**
+
 Command buffers carry sequences of user commands on the CPU side.
 They can be recorded independently of the work done on GPU, or each other.
 They go through the following stages:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -711,7 +711,7 @@ may become unusable, e.g. if the owning device is [=lose the device|lost=] or
 like buffer state [=buffer state/destroyed=].
 
 [=Internal objects=] of some types *can* become [=invalid=] after they are created; specifically,
-[=devices=], [=adapters=], and command/pass/bundle encoders.
+[=devices=], [=adapters=], {{GPUCommandBuffer}}s, and command/pass/bundle encoders.
 
 <div algorithm>
     A given {{GPUObjectBase}} |object| is <dfn abstract-op>valid to use with</dfn>
@@ -7702,6 +7702,9 @@ Command buffers are pre-recorded lists of [=GPU commands=] that can be submitted
 for execution. Each <dfn dfn>GPU command</dfn> represents a task to be performed on the GPU, such as
 setting state, drawing, copying resources, etc.
 
+A {{GPUCommandBuffer}} can only be submitted once, at which point it becomes [=invalid=].
+To reuse rendering commands across multiple submissions, use {{GPURenderBundle}}.
+
 ## <dfn interface>GPUCommandBuffer</dfn> ## {#command-buffer}
 
 <script type=idl>
@@ -10894,6 +10897,8 @@ GPUQueue includes GPUObjectBase;
     ::
         Schedules the execution of the command buffers by the GPU on this queue.
 
+        Submitted command buffers cannot be used again.
+
         <div algorithm=GPUQueue.submit>
             **Called on:** {{GPUQueue}} this.
 
@@ -10917,6 +10922,9 @@ GPUQueue includes GPUObjectBase;
                             does not constitute a reference, while {{GPURenderPassEncoder/beginOcclusionQuery()}}
                             does.
                     </div>
+
+                1. For each |commandBuffer| in |commandBuffers|:
+                    1. Make |commandBuffer| [=invalid=].
 
                 1. Issue the following steps on the [=Queue timeline=] of |this|:
                     <div class=queue-timeline>


### PR DESCRIPTION
This has always been true, but it turns out we were missing an actual description of this from the validation in the spec.

Fixes #1294