### PR TITLE
In certain places, identifiers don't resolve to declarations

### DIFF
--- a/wgsl/extract-grammar.py
+++ b/wgsl/extract-grammar.py
@@ -326,7 +326,7 @@ module.exports = grammar({
     // WGSL has no parsing conflicts.
     conflicts: $ => [],
 
-    word: $ => $.ident,
+    word: $ => $.ident_pattern_token,
 
     rules: {
 """[1:-1]

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -967,11 +967,35 @@ the following kinds of objects:
 
 In other words, a declaration introduces a <dfn noexport>name</dfn> for an object.
 
+A declaration is at <dfn noexport>module scope</dfn> if the declaration appears outside
+the text of any other declaration.
+
+A [=function/function=] declaration appears at module-scope. But a function declaration
+contains declarations for formal parameters, if it has any,
+and it may contain variable and value declarations inside its [=function body|body=].
+Those contained declarations are therefore not at module-scope.
+
+Note: Only a [=function declaration=] can contain other declarations.
+
+Certain objects are provided by the WebGPU implementation, and are treated as
+if they have been declared before the start of the WGSL program source.
+We say such objects are <dfn noexport>predeclared</dfn>.
+For example, WGSL predeclares [=built-in functions=], and built-in types such as [=i32=] and [=f32=].
+
 The <dfn noexport>scope</dfn> of a declaration is the set of
 program locations where a use of the declared identifier potentially denotes
 its associated object.
 We say the identifier is <dfn noexport>in scope</dfn>
 (of the declaration) at those source locations.
+
+Where a declaration appears determines its scope:
+* Predeclared objects, and objects declared at module-scope, are [=in scope=] across the entire program source.
+* Otherwise, the scope is a span of text beginning immediately after the end of the declaration.
+    For details, see [[#function-scope-variables]].
+
+A declaration [=shader-creation error|must not=] introduce a name when that identifier is
+already in scope with the same end-of-scope as another instance of that name.
+
 
 When an identifier is used, it [=shader-creation error|must=] be [=in scope=]
 for some declaration, or as part of a directive.
@@ -980,29 +1004,11 @@ the identifier will denote the object of the non-[=module scope|module-scope=] d
 that use, or the [=module scope|module-scope=] declaration if no other declaration is in scope.
 We say the identifier use <dfn noexport>resolves</dfn> to that declaration.
 
-Where a declaration appears determines its scope.
-Generally, the scope is a span of text beginning immediately after the end of
-the declaration.
-Declarations at [=module scope=] are the exception, described below.
 
-A declaration [=shader-creation error|must not=] introduce a name when that identifier is
-already in scope with the same end of scope as another instance of that name.
-
-Certain objects are provided by the WebGPU implementation, and are treated as
-if they have been declared by every WGSL program.
-We say such objects are <dfn noexport>predeclared</dfn>.
-Their scope is the entire WGSL program.
-Examples of predeclared objects are:
-* [=built-in functions=], and
-* built-in types.
-
-A declaration is at <dfn noexport>module scope</dfn> if the declaration appears outside
-the text of any other declaration.
-Module scope declarations are [=in scope=] for the entire program.
-That is, a declaration at module scope may be referenced by source text
+Note: An object declared at [=module scope=] may be referenced by source text
 that follows *or precedes* that declaration.
 
-It is a [=shader-creation error=] if any module scope declaration is recursive.
+It is a [=shader-creation error=] if any [=module scope=] declaration is recursive.
 That is, no cycles can exist among the declarations:
 
 > Consider the directed graph where:
@@ -1017,10 +1023,6 @@ functions must not be recursive, either directly or indirectly.
 
 Note: Use of a non-[=module scope=] identifier must follow the declaration of
 that identifier in the text.
-This is not true, however, for [=module scope=] declarations, which may be
-referenced out of order in the text.
-
-Note: Only a [=function declaration=] can contain other declarations.
 
 <div class='example wgsl' heading='Valid and invalid declarations'>
   <xmp highlight='rust'>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -519,6 +519,7 @@ A <dfn>token</dfn> is a contiguous sequence of code points forming one of:
 * a [=reserved word=].
 * a [=syntactic token=].
 * an [=identifier=].
+* a [=context-dependent name=].
 
 ## Literals ## {#literals}
 
@@ -690,20 +691,28 @@ use a binary exponent.  For example, write `0x1p0f`.  In comparison, `0x1f` is a
 
 ## Keywords ## {#keywords}
 
-A <dfn>keyword</dfn> is a [=token=] which always refers to a predefined language concept.
+A <dfn>keyword</dfn> is a [=token=] which refers to a predefined language concept.
 See [[#keyword-summary]] for the list of WGSL keywords.
 
 ## Identifiers ## {#identifiers}
 
 An <dfn>identifier</dfn> is a kind of [=token=] used as a name.
+See [[#declaration-and-scope]].
 
-There are three kinds of uses for identifiers:
-* In a [=declaration=], as the name for the object being declared.
-* As a name, denoting an object declared elsewhere.
-* Otherwise, as a name for a concept specific to a grammar-determined context.
-    We say these contexts are <dfn noexport>non-declaration-resolving</dfn>,
-    because an identifer appearing there never [=resolves=] to a declared object.
-    Such contexts are defined throughout the rest of this specification.
+WGSL uses two grammar nonterminals to separate use cases:
+* An [=syntax/ident=] is used to name a declared object.
+* A [=syntax/member_ident=] is used to name a [=member=] of a [=structure=] type.
+
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>ident</dfn> :
+
+    | [=syntax/ident_pattern_token=]
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>member_ident</dfn> :
+
+    | [=syntax/ident_pattern_token=]
+</div>
 
 The form of an identifier is based on the
 [=Unicode Standard Annex #31 for Unicode Version 14.0.0|Unicode Standard Annex #31=] for
@@ -729,7 +738,7 @@ With the following exceptions:
 * An identifier [=shader-creation error|must not=] start with `__` (two underscores, `U+005F` followed by `U+005F`).
 
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>ident</dfn> :
+  <dfn for=syntax>ident_pattern_token</dfn> :
 
     | `/([_\p{XID_Start}][\p{XID_Continue}]+)|([\p{XID_Start}])/uy`
 </div>
@@ -760,35 +769,25 @@ Examples of mappings to detect homoglyphs are the transformations, mappings, and
 the previous paragraph. Two sequences of code points are homographs if the identifier can transform one into the other by
 repeatedly replacing a subsequence with its homoglyph.)
 
+## Context-Dependent Names ## {#context-dependent-names}
+
+A <dfn>context-dependent name</dfn> is a [=token=] used to name a concept, but only in specific grammatical contexts.
+The spelling of the token may be the same as an [=identifier=], but the token does not [=resolve=] to a declared object.
+
+Section [[#context-dependent-name-tokens]] lists all such tokens.
+
 ## Attributes ## {#attributes}
 
 An <dfn noexport>attribute</dfn> modifies an object or type.
 WGSL provides a unified syntax for applying attributes.
 Attributes are used for a variety of purposes such as specifying the interface with the API.
+
 Generally speaking, from the language's point-of-view, attributes can be
 ignored for the purposes of type and semantic checking.
-
-The token position naming the attribute, i.e. immediately after the `@` (Code point: `U+0040`),
-is a [=non-declaration-resolving=] context.
+Additionally, the attribute name is a [=context-dependent name=], and
+some attribute parameters are also context-dependent names.
 
 An attribute [=shader-creation error|must not=] be specified more than once per object or type.
-
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>attribute</dfn> :
-
-    | [=syntax/attr=] [=syntax/ident=] [=syntax/paren_left=] ( [=syntax/literal_or_ident=] [=syntax/comma=] ) * [=syntax/literal_or_ident=] [=syntax/comma=] ? [=syntax/paren_right=]
-
-    | [=syntax/attr=] [=syntax/ident=]
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>literal_or_ident</dfn> :
-
-    | [=syntax/float_literal=]
-
-    | [=syntax/int_literal=]
-
-    | [=syntax/ident=]
-</div>
 
 <table class='data'>
   <caption>Attributes defined in WGSL</caption>
@@ -825,10 +824,8 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     <td>[=shader-creation error|Must=] only be applied to an entry point
     function parameter, entry point return type, or member of a [=structure=].
 
-    Declares a built-in value.
+    Declares a built-in value with the given [=context-dependent name=].
     See [[#builtin-values]].
-
-    The identifier name token position is a [=non-declaration-resolving=] context.
 
   <tr><td><dfn noexport dfn-for="attribute">`const`</dfn>
     <td>*None*
@@ -859,6 +856,7 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     <td>One or two parameters.
 
     The first parameter [=shader-creation error|must=] be an [=interpolation type=].
+
     The second parameter, if present, [=shader-creation error|must=] specify the [=interpolation sampling=].
 
     <td>[=shader-creation error|Must=] only be applied to a declaration that is decorated with a
@@ -869,7 +867,7 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     and [=fragment=] inputs.
     See [[#interpolation]].
 
-    The parameter token positions are [=non-declaration-resolving=] contexts.
+    Both parameters are [=context-dependent names=].
 
   <tr><td><dfn noexport dfn-for="attribute">`invariant`</dfn>
     <td>*None*
@@ -954,6 +952,56 @@ They take no parameters.
 
 </table>
 
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>attribute</dfn> :
+
+    | [=syntax/attr=] `'align'` [=syntax/paren_left=] [=syntax/int_literal=] [=syntax/attrib_end=]
+
+    | [=syntax/attr=] `'binding'` [=syntax/paren_left=] [=syntax/int_literal=] [=syntax/attrib_end=]
+
+    | [=syntax/attr=] `'builtin'` [=syntax/paren_left=] [=syntax/builtin_value_name=] [=syntax/attrib_end=]
+
+    | [=syntax/attr=] `'const'`
+
+    | [=syntax/attr=] `'group'` [=syntax/paren_left=] [=syntax/int_literal=] [=syntax/attrib_end=]
+
+    | [=syntax/attr=] `'id'` [=syntax/paren_left=] [=syntax/int_literal=] [=syntax/attrib_end=]
+
+    | [=syntax/attr=] `'interpolate'` [=syntax/paren_left=] [=syntax/interpolation_type_name=] [=syntax/attrib_end=]
+
+    | [=syntax/attr=] `'interpolate'` [=syntax/paren_left=] [=syntax/interpolation_type_name=] [=syntax/comma=] [=syntax/interpolation_sample_name=] [=syntax/attrib_end=]
+
+    | [=syntax/attr=] `'invariant'`
+
+    | [=syntax/attr=] `'location'` [=syntax/paren_left=] [=syntax/int_literal=] [=syntax/attrib_end=]
+
+    | [=syntax/attr=] `'size'` [=syntax/paren_left=] [=syntax/int_literal=] [=syntax/attrib_end=]
+
+    | [=syntax/attr=] `'workgroup_size'` [=syntax/paren_left=] [=syntax/ident_or_int_literal=] [=syntax/attrib_end=]
+
+    | [=syntax/attr=] `'workgroup_size'` [=syntax/paren_left=] [=syntax/ident_or_int_literal=] [=syntax/comma=] [=syntax/ident_or_int_literal=] [=syntax/attrib_end=]
+
+    | [=syntax/attr=] `'workgroup_size'` [=syntax/paren_left=] [=syntax/ident_or_int_literal=] [=syntax/comma=] [=syntax/ident_or_int_literal=] [=syntax/comma=] [=syntax/ident_or_int_literal=] [=syntax/attrib_end=]
+
+    | [=syntax/attr=] `'vertex'`
+
+    | [=syntax/attr=] `'fragment'`
+
+    | [=syntax/attr=] `'compute'`
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>ident_or_int_literal</dfn> :
+
+    | [=syntax/int_literal=]
+
+    | [=syntax/ident=]
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>attrib_end</dfn> :
+
+    | [=syntax/comma=] ? [=syntax/paren_right=]
+</div>
+
 ## Directives ## {#directives}
 
 A <dfn noexport>directive</dfn> is a [=token=] sequence which modifies how a WGSL
@@ -982,14 +1030,12 @@ the following kinds of objects:
 
 In other words, a declaration introduces a <dfn noexport>name</dfn> for an object.
 
-The token position of the identifier (being associated to the object) is a [=non-declaration-resolving=] context.
-
 A declaration is at <dfn noexport>module scope</dfn> if the declaration appears outside
 the text of any other declaration.
 
-A [=function/function=] declaration appears at module-scope. But a function declaration
-contains declarations for formal parameters, if it has any,
-and it may contain variable and value declarations inside its [=function body|body=].
+A [=function/function=] declaration appears at module-scope.
+A function declaration contains declarations for formal parameters, if it has any,
+and it may contain [[#var-and-value|variable and value declarations]] inside its [=function body|body=].
 Those contained declarations are therefore not at module-scope.
 
 Note: Only a [=function declaration=] can contain other declarations.
@@ -1013,14 +1059,20 @@ Where a declaration appears determines its scope:
 A declaration [=shader-creation error|must not=] introduce a name when that identifier is
 already in scope with the same end-of-scope as another instance of that name.
 
+Identifiers are used as follows, distinguished by grammatical context:
+* A token matching the [=syntax/ident=] grammar element is:
+    * Used in a [=declaration=], as the name of the object being declared, or
+    * Used as a name, denoting an object declared elsewhere.  This is the common case.
+* A token matching the [=syntax/member_ident=] grammar element is:
+    * Used in a [=structure=] type [=declaration=], as the name of a [=member=], or
+    * Used as a name, denoting a member of a structure value, or denoting a reference to a member of a structure. See [[#struct-access-expr]].
 
-When an identifier appears outside of a [=non-declaration-resolving=] context,
+When an [=syntax/ident=] appears as a name denoting an object declared elsewhere,
 it [=shader-creation error|must=] be [=in scope=] for some declaration.
-When an identifier is used in scope of one or more declarations for that name,
+When such a use is in scope of one or more declarations for that name,
 the identifier will denote the object of the non-[=module scope|module-scope=] declaration appearing closest to
 that use, or the [=module scope|module-scope=] declaration if no other declaration is in scope.
 We say the identifier use <dfn noexport>resolves</dfn> to that declaration.
-
 
 Note: An object declared at [=module scope=] may be referenced by source text
 that follows *or precedes* that declaration.
@@ -1868,7 +1920,7 @@ of a variable in [=address spaces/workgroup=] space.
 
 ### Structure Types ### {#struct-types}
 
-A <dfn noexport>structure</dfn> is a grouping of named member values.
+A <dfn noexport>structure</dfn> is a grouping of named <dfn noexport>member</dfn> values.
 
 <table class='data'>
   <thead>
@@ -1923,7 +1975,7 @@ Some consequences of the restrictions structure member and array element types a
 <div class='syntax' noexport='true'>
   <dfn for=syntax>struct_member</dfn> :
 
-    | [=syntax/attribute=] * [=syntax/variable_ident_decl=]
+    | [=syntax/attribute=] * [=syntax/member_ident=] [=syntax/colon=] [=syntax/type_decl=]
 </div>
 
 WGSL defines the following attributes that can be applied to structure members:
@@ -2080,15 +2132,8 @@ as the memory's <dfn noexport>access mode</dfn>:
 : <dfn noexport dfn-for="access">read_write</dfn>
 :: Supports both read and write accesses.
 
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>access_mode</dfn> :
-
-    | `'read'`
-
-    | `'write'`
-
-    | `'read_write'`
-</div>
+When a [=token=] matches the [=syntax/access_mode=] grammar nonterminal, it is considered a [=context-dependent name=].
+In particular, the token does not [=resolve=] to any declared object.
 
 ### Storable Types ### {#storable-types}
 
@@ -2217,6 +2262,9 @@ and how to use variables with it.
       <td>For [=sampler=] and texture variables.<br>
 </table>
 
+When a [=token=] matches the [=syntax/address_space=] grammar nonterminal, it is considered a [=context-dependent name=].
+In particular, the token does not [=resolve=] to any declared object.
+
 Note: The token `handle` is reserved: it is never used in a WGSL program.
 
 Note: A texture variable holds an opaque handle which is used to access the underlying
@@ -2224,20 +2272,6 @@ grid of texels.
 The handle itself is always read-only.
 In most cases the underlying texels are read-only.
 For a write-only storage texture, the underlying texels are write-only.
-
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>address_space</dfn> :
-
-    | [=syntax/function=]
-
-    | [=syntax/private=]
-
-    | [=syntax/workgroup=]
-
-    | [=syntax/uniform=]
-
-    | [=syntax/storage=]
-</div>
 
 ### Memory Layout ### {#memory-layouts}
 
@@ -2802,7 +2836,6 @@ However, in WGSL *source* text:
         but never be able to create a pointer value of that type.
         Similarly, it would be valid to declare a function with a pointer formal parameter,
         but never be able to call that function.
-    * When spelling a pointer type, the [=address space=] and [=access mode=] token positions are [=non-declaration-resolving=] contexts.
 
 <div class='example wgsl' heading='Pointer type'>
   <xmp highlight='rust'>
@@ -3460,10 +3493,8 @@ TODO(dneto): Move description of the conversion to the builtin function that act
 `texture_storage_3d<texel_format,access>`
 </pre>
 
-* `texel_format` [=shader-creation error|must=] be one of the texel types specified in [=storage-texel-formats=]
-* `access` [=shader-creation error|must=] be [=access/write=].
-
-When spelling a storage texture type, the texel format and access token positions are [=non-declaration-resolving=] contexts.
+* `texel_format` is a [=context-dependent name=] and [=shader-creation error|must=] be one of the texel types specified in [=storage-texel-formats=]
+* `access` is a [=context-dependent name=] and [=shader-creation error|must=] be [=access/write=].
 
 ### Depth Texture Types ### {#texture-depth}
 <pre class='def'>
@@ -3570,41 +3601,6 @@ sampler_comparison
     | [=syntax/texture_depth_cube_array=]
 
     | [=syntax/texture_depth_multisampled_2d=]
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texel_format</dfn> :
-
-    | `'rgba8unorm'`
-
-    | `'rgba8snorm'`
-
-    | `'rgba8uint'`
-
-    | `'rgba8sint'`
-
-    | `'rgba16uint'`
-
-    | `'rgba16sint'`
-
-    | `'rgba16float'`
-
-    | `'r32uint'`
-
-    | `'r32sint'`
-
-    | `'r32float'`
-
-    | `'rg32uint'`
-
-    | `'rg32sint'`
-
-    | `'rg32float'`
-
-    | `'rgba32uint'`
-
-    | `'rgba32sint'`
-
-    | `'rgba32float'`
 </div>
 
 ## Type Aliases ## {#type-aliases}
@@ -3886,8 +3882,6 @@ A <dfn noexport>variable declaration</dfn>:
     supporting the given access mode, for the [=lifetime=] of the variable.
 * Optionally has an *initializer* expression, if the variable is in the [=address spaces/private=] or [=address spaces/function=] address spaces.
     If present, the initializer expression [=shader-creation error|must=] evaluate to the variable's store type.
-
-The [=address space=] and [=access mode=] token positions are [=non-declaration-resolving=] contexts.
 
 When an [=identifier=] use [=resolves=] to a variable declaration,
 the identifier is an expression denoting the reference [=memory view=] for the variable's memory,
@@ -4899,16 +4893,15 @@ The internal layout rules are described in [[#internal-value-layout]].
 
 ### Vector Access Expression ### {#vector-access-expr}
 
-Accessing components of a vector can be done either using array subscripting (e.g. `a[2]`) or using a sequence of convenience names, each mapping to a component of the source vector.
-
-<ul>
-  <li>The colour set of convenience names: `r`, `g`, `b`, `a` for vector components 0, 1, 2, and 3 respectively.
-  <li>The dimensional set of convenience names: `x`, `y`, `z`, `w` for vector components 0, 1, 2, and 3, respectively.
-</ul>
+Accessing components of a vector can be done either:
+* Using array subscripting (e.g. `v[2]`), or 
+* Using a <dfn noexport>swizzle</dfn> name, a [=context-dependent name=] written as a sequence of convenience names, each mapping to a component of the source vector.
+    * The colour set of convenience names: `r`, `g`, `b`, `a` for vector components 0, 1, 2, and 3 respectively.
+    * The dimensional set of convenience names: `x`, `y`, `z`, `w` for vector components 0, 1, 2, and 3, respectively.
 
 The convenience names are accessed using the `.` notation. (e.g. `color.bgra`).
 
-NOTE: the convenience letterings can not be mixed. (i.e. you can not use `rybw`).
+The convenience letterings [=shader-creation error|must not=] be mixed. For example, you can not use `.rybw`.
 
 A convenience letter [=shader-creation error|must not=] access a component past the end of the vector.
 
@@ -5807,7 +5800,9 @@ When an identifier is used as a [=syntax/callable=] item, it is one of:
 
     | [=syntax/bracket_left=] [=syntax/expression=] [=syntax/bracket_right=] [=syntax/postfix_expression=] ?
 
-    | [=syntax/period=] [=syntax/ident=] [=syntax/postfix_expression=] ?
+    | [=syntax/period=] [=syntax/member_ident=] [=syntax/postfix_expression=] ?
+
+    | [=syntax/period=] [=syntax/swizzle_name=] [=syntax/postfix_expression=] ?
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>unary_expression</dfn> :
@@ -8102,14 +8097,17 @@ described by a particular named
 [=extension=] may be used.
 The grammar rules imply that all enable directives [=shader-creation error|must=] appear before any [=declarations=].
 
-The directive uses an [=identifier=], [=keyword=], or [=reserved word=] to name the extension. The valid extension name are listed in [[#extension-list]].
+The directive uses a [=context-dependent name=] to name the extension.
 
-The identifier token position in the directive is a [=non-declaration-resolving=] context.
+In particular, an extension name may be spelled the same as a [=keyword=], [=reserved word=], or [=keyword=],
+but is not interpeted as any of those.
+
+The valid extensions are listed in [[#extension-list]].
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>enable_directive</dfn> :
 
-    | [=syntax/enable=] [=syntax/ident=] [=syntax/semicolon=]
+    | [=syntax/enable=] [=syntax/extension_name=] [=syntax/semicolon=]
 </div>
 
 Note: The grammar rule includes the terminating semicolon token,
@@ -8146,7 +8144,7 @@ the implementation can issue a clear diagnostic.
 <table class='data'>
   <caption>Extension identifier</caption>
   <thead>
-    <tr><th>Identifier
+    <tr><th>WGSL extension name
         <th>WebGPU extension name
         <th>Description
   </thead>
@@ -10424,6 +10422,200 @@ A <dfn>syntactic token</dfn> is a sequence of special code points, used:
 
     | `'<<='` (Code points: `U+003C` `U+003C` `U+003D`)
 </div>
+
+## Context-Dependent Name Tokens ## {#context-dependent-name-tokens}
+
+This section lists the tokens used as [=context-dependent names=].
+
+The [=syntax/attribute=] names are:
+
+* `'align'`
+* `'binding'`
+* `'builtin'`
+* `'compute'`
+* `'const'`
+* `'fragment'`
+* `'group'`
+* `'id'`
+* `'interpolate'`
+* `'invariant'`
+* `'location'`
+* `'size'`
+* `'vertex'`
+* `'workgroup_size'`
+
+The [=interpolation type=] names are:
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>interpolation_type_name</dfn> :
+
+    | `'perspective'`
+
+    | `'linear'`
+
+    | `'flat'`
+</div>
+
+The [=interpolation sampling=] names are:
+
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>interpolation_sample_name</dfn> :
+
+    | `'center'`
+
+    | `'centroid'`
+
+    | `'sample'`
+</div>
+
+The [[#builtin-values|built-in value]] names are:
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>builtin_value_name</dfn> :
+
+    | `'vertex_index'`
+
+    | `'instance_index'`
+
+    | `'position'`
+
+    | `'front_facing'`
+
+    | `'frag_depth'`
+
+    | `'local_invocation_id'`
+
+    | `'local_invocation_index'`
+
+    | `'global_invocation_id'`
+
+    | `'workgroup_id'`
+
+    | `'num_workgroups'`
+
+    | `'sample_index'`
+
+    | `'sample_mask'`
+</div>
+
+The [=Access mode|access mode=] names are:
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>access_mode</dfn> :
+
+    | `'read'`
+
+    | `'write'`
+
+    | `'read_write'`
+</div>
+
+
+The [=address space=] names are:
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>address_space</dfn> :
+
+    | [=syntax/function=]
+
+    | [=syntax/private=]
+
+    | [=syntax/workgroup=]
+
+    | [=syntax/uniform=]
+
+    | [=syntax/storage=]
+</div>
+
+TODO: address space names don't have to be keywords.
+
+The [=texel format=] names are:
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>texel_format</dfn> :
+
+    | `'rgba8unorm'`
+
+    | `'rgba8snorm'`
+
+    | `'rgba8uint'`
+
+    | `'rgba8sint'`
+
+    | `'rgba16uint'`
+
+    | `'rgba16sint'`
+
+    | `'rgba16float'`
+
+    | `'r32uint'`
+
+    | `'r32sint'`
+
+    | `'r32float'`
+
+    | `'rg32uint'`
+
+    | `'rg32sint'`
+
+    | `'rg32float'`
+
+    | `'rgba32uint'`
+
+    | `'rgba32sint'`
+
+    | `'rgba32float'`
+</div>
+
+The [=extension=] names are:
+
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>extension_name</dfn> :
+
+    | `'f16'`
+</div>
+
+The [=swizzle=] names are used in [[#vector-access-expr|vector access expressions]]:
+
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>swizzle_name</dfn> :
+
+    | [=syntax/rgba_letter=]
+
+    | [=syntax/rgba_letter=] [=syntax/rgba_letter=]
+
+    | [=syntax/rgba_letter=] [=syntax/rgba_letter=] [=syntax/rgba_letter=]
+
+    | [=syntax/rgba_letter=] [=syntax/rgba_letter=] [=syntax/rgba_letter=] [=syntax/rgba_letter=]
+
+    | [=syntax/xyzw_letter=]
+
+    | [=syntax/xyzw_letter=] [=syntax/xyzw_letter=]
+
+    | [=syntax/xyzw_letter=] [=syntax/xyzw_letter=] [=syntax/xyzw_letter=]
+
+    | [=syntax/xyzw_letter=] [=syntax/xyzw_letter=] [=syntax/xyzw_letter=] [=syntax/xyzw_letter=]
+</div>
+
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>rgba_letter</dfn> :
+
+    | `'r'`
+
+    | `'g'`
+
+    | `'b'`
+
+    | `'a'`
+</div>
+
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>xyzw_letter</dfn> :
+
+    | `'x'`
+
+    | `'y'`
+
+    | `'z'`
+
+    | `'w'`
+</div>
+
 
 # Built-in Values # {#builtin-values}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -701,7 +701,7 @@ There are three kinds of uses for identifiers:
 * In a [=declaration=], as the name for the object being declared.
 * As a name, denoting an object declared elsewhere.
 * Otherwise, as a name for a concept specific to a grammar-determined context.
-    We say these contexts are <dfn noexport>non-resolving</dfn>,
+    We say these contexts are <dfn noexport>non-declaration-resolving</dfn>,
     because an identifer appearing there never [=resolves=] to a declared object.
     Such contexts are defined throughout the rest of this specification.
 
@@ -769,7 +769,7 @@ Generally speaking, from the language's point-of-view, attributes can be
 ignored for the purposes of type and semantic checking.
 
 The token position naming the attribute, i.e. immediately after the `@` (Code point: `U+0040`),
-is a [=non-resolving=] context.
+is a [=non-declaration-resolving=] context.
 
 An attribute [=shader-creation error|must not=] be specified more than once per object or type.
 
@@ -828,7 +828,7 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     Declares a built-in value.
     See [[#builtin-values]].
 
-    The identifier name token position is a [=non-resolving=] context.
+    The identifier name token position is a [=non-declaration-resolving=] context.
 
   <tr><td><dfn noexport dfn-for="attribute">`const`</dfn>
     <td>*None*
@@ -869,7 +869,7 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     and [=fragment=] inputs.
     See [[#interpolation]].
 
-    The parameter token positions are [=non-resolving=] contexts.
+    The parameter token positions are [=non-declaration-resolving=] contexts.
 
   <tr><td><dfn noexport dfn-for="attribute">`invariant`</dfn>
     <td>*None*
@@ -982,7 +982,7 @@ the following kinds of objects:
 
 In other words, a declaration introduces a <dfn noexport>name</dfn> for an object.
 
-The token position of the identifier (being associated to the object) is a [=non-resolving=] context.
+The token position of the identifier (being associated to the object) is a [=non-declaration-resolving=] context.
 
 A declaration is at <dfn noexport>module scope</dfn> if the declaration appears outside
 the text of any other declaration.
@@ -1014,7 +1014,7 @@ A declaration [=shader-creation error|must not=] introduce a name when that iden
 already in scope with the same end-of-scope as another instance of that name.
 
 
-When an identifier appears outside of a [=non-resolving=] context,
+When an identifier appears outside of a [=non-declaration-resolving=] context,
 it [=shader-creation error|must=] be [=in scope=] for some declaration.
 When an identifier is used in scope of one or more declarations for that name,
 the identifier will denote the object of the non-[=module scope|module-scope=] declaration appearing closest to
@@ -2802,7 +2802,7 @@ However, in WGSL *source* text:
         but never be able to create a pointer value of that type.
         Similarly, it would be valid to declare a function with a pointer formal parameter,
         but never be able to call that function.
-    * When spelling a pointer type, the [=address space=] and [=access mode=] token positions are [=non-resolving=] contexts.
+    * When spelling a pointer type, the [=address space=] and [=access mode=] token positions are [=non-declaration-resolving=] contexts.
 
 <div class='example wgsl' heading='Pointer type'>
   <xmp highlight='rust'>
@@ -3463,7 +3463,7 @@ TODO(dneto): Move description of the conversion to the builtin function that act
 * `texel_format` [=shader-creation error|must=] be one of the texel types specified in [=storage-texel-formats=]
 * `access` [=shader-creation error|must=] be [=access/write=].
 
-When spelling a storage texture type, the texel format and access token positions are [=non-resolving=] contexts.
+When spelling a storage texture type, the texel format and access token positions are [=non-declaration-resolving=] contexts.
 
 ### Depth Texture Types ### {#texture-depth}
 <pre class='def'>
@@ -3887,7 +3887,7 @@ A <dfn noexport>variable declaration</dfn>:
 * Optionally has an *initializer* expression, if the variable is in the [=address spaces/private=] or [=address spaces/function=] address spaces.
     If present, the initializer expression [=shader-creation error|must=] evaluate to the variable's store type.
 
-The [=address space=] and [=access mode=] token positions are [=non-resolving=] contexts.
+The [=address space=] and [=access mode=] token positions are [=non-declaration-resolving=] contexts.
 
 When an [=identifier=] use [=resolves=] to a variable declaration,
 the identifier is an expression denoting the reference [=memory view=] for the variable's memory,
@@ -8104,7 +8104,7 @@ The grammar rules imply that all enable directives [=shader-creation error|must=
 
 The directive uses an [=identifier=], [=keyword=], or [=reserved word=] to name the extension. The valid extension name are listed in [[#extension-list]].
 
-The identifier token position in the directive is a [=non-resolving=] context.
+The identifier token position in the directive is a [=non-declaration-resolving=] context.
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>enable_directive</dfn> :

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -696,7 +696,14 @@ See [[#keyword-summary]] for the list of WGSL keywords.
 ## Identifiers ## {#identifiers}
 
 An <dfn>identifier</dfn> is a kind of [=token=] used as a name.
-See [[#declaration-and-scope]] and [[#directives]].
+
+There are three kinds of uses for identifiers:
+* In a [=declaration=], as the name for the object being declared.
+* As a name, denoting an object declared elsewhere.
+* Otherwise, as a name for a concept specific to a grammar-determined context.
+    We say these contexts are <dfn noexport>non-resolving</dfn>,
+    because an identifer appearing there never [=resolves=] to a declared object.
+    Such contexts are defined throughout the rest of this specification.
 
 The form of an identifier is based on the
 [=Unicode Standard Annex #31 for Unicode Version 14.0.0|Unicode Standard Annex #31=] for
@@ -761,6 +768,9 @@ Attributes are used for a variety of purposes such as specifying the interface w
 Generally speaking, from the language's point-of-view, attributes can be
 ignored for the purposes of type and semantic checking.
 
+The token position naming the attribute, i.e. immediately after the `@` (Code point: `U+0040`),
+is a [=non-resolving=] context.
+
 An attribute [=shader-creation error|must not=] be specified more than once per object or type.
 
 <div class='syntax' noexport='true'>
@@ -818,6 +828,8 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     Declares a built-in value.
     See [[#builtin-values]].
 
+    The identifier name token position is a [=non-resolving=] context.
+
   <tr><td><dfn noexport dfn-for="attribute">`const`</dfn>
     <td>*None*
     <td>Must only be applied to function declarations.
@@ -848,6 +860,7 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
 
     The first parameter [=shader-creation error|must=] be an [=interpolation type=].
     The second parameter, if present, [=shader-creation error|must=] specify the [=interpolation sampling=].
+
     <td>[=shader-creation error|Must=] only be applied to a declaration that is decorated with a
     [=attribute/location=] attribute.
 
@@ -855,6 +868,8 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     The attribute is only significant on user-defined [=vertex=] outputs
     and [=fragment=] inputs.
     See [[#interpolation]].
+
+    The parameter token positions are [=non-resolving=] contexts.
 
   <tr><td><dfn noexport dfn-for="attribute">`invariant`</dfn>
     <td>*None*
@@ -967,6 +982,8 @@ the following kinds of objects:
 
 In other words, a declaration introduces a <dfn noexport>name</dfn> for an object.
 
+The token position of the identifier (being associated to the object) is a [=non-resolving=] context.
+
 A declaration is at <dfn noexport>module scope</dfn> if the declaration appears outside
 the text of any other declaration.
 
@@ -997,8 +1014,8 @@ A declaration [=shader-creation error|must not=] introduce a name when that iden
 already in scope with the same end-of-scope as another instance of that name.
 
 
-When an identifier is used, it [=shader-creation error|must=] be [=in scope=]
-for some declaration, or as part of a directive.
+When an identifier appears outside of a [=non-resolving=] context,
+it [=shader-creation error|must=] be [=in scope=] for some declaration.
 When an identifier is used in scope of one or more declarations for that name,
 the identifier will denote the object of the non-[=module scope|module-scope=] declaration appearing closest to
 that use, or the [=module scope|module-scope=] declaration if no other declaration is in scope.
@@ -2760,7 +2777,7 @@ WGSL has two kinds of types for representing memory views:
         identified with the set of [=memory views=] for memory locations in |AS| holding values of type |T|,
         supporting memory accesses described by mode |AM|.<br>
         Here, |T| is the [=store type=].<br>
-        Pointer types may appear in WGSL program source.
+        Pointer types may appear in WGSL program source.<br>
 </table>
 
 When *analyzing* a WGSL program, reference and pointer types are fully parameterized by
@@ -2785,6 +2802,7 @@ However, in WGSL *source* text:
         but never be able to create a pointer value of that type.
         Similarly, it would be valid to declare a function with a pointer formal parameter,
         but never be able to call that function.
+    * When spelling a pointer type, the [=address space=] and [=access mode=] token positions are [=non-resolving=] contexts.
 
 <div class='example wgsl' heading='Pointer type'>
   <xmp highlight='rust'>
@@ -3445,6 +3463,8 @@ TODO(dneto): Move description of the conversion to the builtin function that act
 * `texel_format` [=shader-creation error|must=] be one of the texel types specified in [=storage-texel-formats=]
 * `access` [=shader-creation error|must=] be [=access/write=].
 
+When spelling a storage texture type, the texel format and access token positions are [=non-resolving=] contexts.
+
 ### Depth Texture Types ### {#texture-depth}
 <pre class='def'>
 `texture_depth_2d`
@@ -3866,6 +3886,8 @@ A <dfn noexport>variable declaration</dfn>:
     supporting the given access mode, for the [=lifetime=] of the variable.
 * Optionally has an *initializer* expression, if the variable is in the [=address spaces/private=] or [=address spaces/function=] address spaces.
     If present, the initializer expression [=shader-creation error|must=] evaluate to the variable's store type.
+
+The [=address space=] and [=access mode=] token positions are [=non-resolving=] contexts.
 
 When an [=identifier=] use [=resolves=] to a variable declaration,
 the identifier is an expression denoting the reference [=memory view=] for the variable's memory,
@@ -8082,10 +8104,7 @@ The grammar rules imply that all enable directives [=shader-creation error|must=
 
 The directive uses an [=identifier=], [=keyword=], or [=reserved word=] to name the extension. The valid extension name are listed in [[#extension-list]].
 
-If the name is an identifier, the directive does not
-create a [=scope=] for the identifier.
-Use of the identifier by the directive does not conflict with the
-use of that identifier as the name in any [=declaration=].
+The identifier token position in the directive is a [=non-resolving=] context.
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>enable_directive</dfn> :

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -10575,47 +10575,23 @@ The [=swizzle=] names are used in [[#vector-access-expr|vector access expression
 <div class='syntax' noexport='true'>
   <dfn for=syntax>swizzle_name</dfn> :
 
-    | [=syntax/rgba_letter=]
+    | `'/[rgba]/'`
 
-    | [=syntax/rgba_letter=] [=syntax/rgba_letter=]
+    | `'/[rgba][rgba]/'`
 
-    | [=syntax/rgba_letter=] [=syntax/rgba_letter=] [=syntax/rgba_letter=]
+    | `'/[rgba][rgba][rgba]/'`
 
-    | [=syntax/rgba_letter=] [=syntax/rgba_letter=] [=syntax/rgba_letter=] [=syntax/rgba_letter=]
+    | `'/[rgba][rgba][rgba][rgba]/'`
 
-    | [=syntax/xyzw_letter=]
+    | `'/[xyzw]/'`
 
-    | [=syntax/xyzw_letter=] [=syntax/xyzw_letter=]
+    | `'/[xyzw][xyzw]/'`
 
-    | [=syntax/xyzw_letter=] [=syntax/xyzw_letter=] [=syntax/xyzw_letter=]
+    | `'/[xyzw][xyzw][xyzw]/'`
 
-    | [=syntax/xyzw_letter=] [=syntax/xyzw_letter=] [=syntax/xyzw_letter=] [=syntax/xyzw_letter=]
+    | `'/[xyzw][xyzw][xyzw][xyzw]/'`
+
 </div>
-
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>rgba_letter</dfn> :
-
-    | `'r'`
-
-    | `'g'`
-
-    | `'b'`
-
-    | `'a'`
-</div>
-
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>xyzw_letter</dfn> :
-
-    | `'x'`
-
-    | `'y'`
-
-    | `'z'`
-
-    | `'w'`
-</div>
-
 
 # Built-in Values # {#builtin-values}
 


### PR DESCRIPTION
Define non-resolving context, and specify where they are
    
Fixes: #3113

Reorg declaration and scope
    
    Reorder so we talk about all the kinds of declarations and their
    scopes before talking about resolving an identifier.
