### PR TITLE
Normalize bikeshed formatting somewhat

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1,4 +1,4 @@
-<pre class='metadata'>
+<pre class=metadata>
 Title: WebGPU
 Shortname: webgpu
 Level: None
@@ -23,25 +23,25 @@ Assume Explicit For: yes
 
 <pre class=biblio>
 {
-  "SourceMap": {
-    "authors": [
-      "John Lenz",
-      "Nick Fitzgerald"
-    ],
-    "href": "https://sourcemaps.info/spec.html",
-    "title": "Source Map Revision 3 Proposal"
-  }
+    "SourceMap": {
+        "authors": [
+            "John Lenz",
+            "Nick Fitzgerald"
+        ],
+        "href": "https://sourcemaps.info/spec.html",
+        "title": "Source Map Revision 3 Proposal"
+    }
 }
 </pre>
 
-<pre class="link-defaults">
+<pre class=link-defaults>
 spec:html;
     type:interface; text:Navigator
 spec:webidl;
     type:interface; text:Promise
 </pre>
 
-<pre class='anchors'>
+<pre class=anchors>
 spec: ECMA-262; urlPrefix: https://tc39.es/ecma262/#
     type: dfn
         text: agent; url: agent
@@ -266,7 +266,6 @@ thead.stickyheader th, th.stickyheader {
         --tint-purple: rgba(255, 0, 255, 22%);
     }
 }
-
 </style>
 
 
@@ -346,6 +345,7 @@ If the native API does not provide facilities to clear it, the WebGPU implementa
 shader to first do a clear across all invocations, synchronize them, and continue executing developer's code.
 
 <div class=note>
+    Note:
     The initialization status of a resource used in a queue operation can only be known when the
     operation is enqueued (not when it is encoded into a command buffer, for example). Therefore,
     some implementations will require an unoptimized late-clear at enqueue time (e.g. clearing a
@@ -378,15 +378,17 @@ validation on the host side.
 
 If the shader attempts to load data outside of [=physical resource=] bounds,
 the implementation is allowed to:
-  1. return a value at a different location within the resource bounds
-  2. return a value vector of "(0, 0, 0, X)" with any "X"
-  3. partially discard the draw or dispatch call
+
+1. return a value at a different location within the resource bounds
+1. return a value vector of "(0, 0, 0, X)" with any "X"
+1. partially discard the draw or dispatch call
 
 If the shader attempts to write data outside of [=physical resource=] bounds,
 the implementation is allowed to:
-  1. write the value to a different location within the resource bounds
-  2. discard the write operation
-  3. partially discard the draw or dispatch call
+
+1. write the value to a different location within the resource bounds
+1. discard the write operation
+1. partially discard the draw or dispatch call
 
 ### Invalid data ### {#security-invalid-data}
 
@@ -726,13 +728,13 @@ like buffer state [=buffer state/destroyed=].
 
 ## Coordinate Systems ## {#coordinate-systems}
 
-  - Y-axis is up in normalized device coordinate (NDC): point(-1.0, -1.0) in NDC is located at the bottom-left corner of NDC.
+- Y-axis is up in normalized device coordinate (NDC): point(-1.0, -1.0) in NDC is located at the bottom-left corner of NDC.
     In addition, x and y in NDC should be between -1.0 and 1.0 inclusive, while z in NDC should be between 0.0 and 1.0 inclusive.
     Vertices out of this range in NDC will not introduce any errors, but they will be clipped.
-  - Y-axis is down in [=framebuffer=] coordinate, viewport coordinate and fragment/pixel coordinate:
+- Y-axis is down in [=framebuffer=] coordinate, viewport coordinate and fragment/pixel coordinate:
     origin(0, 0) is located at the top-left corner in these coordinate systems.
-  - Window/present coordinate matches [=framebuffer=] coordinate.
-  - UV of origin(0, 0) in texture coordinate represents the first texel (the lowest byte) in texture memory.
+- Window/present coordinate matches [=framebuffer=] coordinate.
+- UV of origin(0, 0) in texture coordinate represents the first texel (the lowest byte) in texture memory.
 
 Note: WebGPU's coordinate systems match DirectX's coordinate systems in a graphics pipeline.
 
@@ -778,36 +780,35 @@ In this specification, asynchronous operations are used when the result value
 depends on work that happens on any timeline other than the [=Content timeline=].
 They are represented by callbacks and promises in JavaScript.
 
-<div class="example">
-{{GPUComputePassEncoder/dispatchWorkgroups()|GPUComputePassEncoder.dispatchWorkgroups()}}:
+<div class=example>
+    {{GPUComputePassEncoder/dispatchWorkgroups()|GPUComputePassEncoder.dispatchWorkgroups()}}:
 
-  1. User encodes a `dispatchWorkgroups` command by calling a method of the
-    {{GPUComputePassEncoder}} which happens on the [=Content timeline=].
-  2. User issues {{GPUQueue/submit(commandBuffers)|GPUQueue.submit()}} that hands over
-    the {{GPUCommandBuffer}} to the user agent, which processes it
-    on the [=Device timeline=] by calling the OS driver to do a low-level submission.
-  3. The submit gets dispatched by the GPU invocation scheduler onto the
-    actual compute units for execution, which happens on the [=Queue timeline=].
-
+    1. User encodes a `dispatchWorkgroups` command by calling a method of the
+        {{GPUComputePassEncoder}} which happens on the [=Content timeline=].
+    1. User issues {{GPUQueue/submit(commandBuffers)|GPUQueue.submit()}} that hands over
+        the {{GPUCommandBuffer}} to the user agent, which processes it
+        on the [=Device timeline=] by calling the OS driver to do a low-level submission.
+    1. The submit gets dispatched by the GPU invocation scheduler onto the
+        actual compute units for execution, which happens on the [=Queue timeline=].
 </div>
-<div class="example">
-{{GPUDevice/createBuffer(descriptor)|GPUDevice.createBuffer()}}:
 
-  1. User fills out a {{GPUBufferDescriptor}} and creates a {{GPUBuffer}} with it,
-    which happens on the [=Content timeline=].
-  2. User agent creates a low-level buffer on the [=Device timeline=].
+<div class=example>
+    {{GPUDevice/createBuffer(descriptor)|GPUDevice.createBuffer()}}:
 
+    1. User fills out a {{GPUBufferDescriptor}} and creates a {{GPUBuffer}} with it,
+        which happens on the [=Content timeline=].
+    2. User agent creates a low-level buffer on the [=Device timeline=].
 </div>
-<div class="example">
-{{GPUBuffer/mapAsync()|GPUBuffer.mapAsync()}}:
 
-  1. User requests to map a {{GPUBuffer}} on the [=Content timeline=] and
-    gets a promise in return.
-  2. User agent checks if the buffer is currently used by the GPU
-    and makes a reminder to itself to check back when this usage is over.
-  3. After the GPU operating on [=Queue timeline=] is done using the buffer,
-    the user agent maps it to memory and [=resolves=] the promise.
+<div class=example>
+    {{GPUBuffer/mapAsync()|GPUBuffer.mapAsync()}}:
 
+    1. User requests to map a {{GPUBuffer}} on the [=Content timeline=] and
+        gets a promise in return.
+    2. User agent checks if the buffer is currently used by the GPU
+        and makes a reminder to itself to check back when this usage is over.
+    3. After the GPU operating on [=Queue timeline=] is done using the buffer,
+        the user agent maps it to memory and [=resolves=] the promise.
 </div>
 
 ### Memory Model ### {#programming-model-memory}
@@ -816,18 +817,20 @@ They are represented by callbacks and promises in JavaScript.
 
 Once a {{GPUDevice}} has been obtained during an application initialization routine,
 we can describe the <dfn dfn>WebGPU platform</dfn> as consisting of the following layers:
-  1. User agent implementing the specification.
-  2. Operating system with low-level native API drivers for this device.
-  3. Actual CPU and GPU hardware.
+
+1. User agent implementing the specification.
+1. Operating system with low-level native API drivers for this device.
+1. Actual CPU and GPU hardware.
 
 Each layer of the [=WebGPU platform=] may have different memory types
 that the user agent needs to consider when implementing the specification:
-  - The script-owned memory, such as an {{ArrayBuffer}} created by the script,
+
+- The script-owned memory, such as an {{ArrayBuffer}} created by the script,
     is generally not accessible by a GPU driver.
-  - A user agent may have different processes responsible for running
+- A user agent may have different processes responsible for running
     the content and communication to the GPU driver.
     In this case, it uses inter-process shared memory to transfer data.
-  - Dedicated GPUs have their own memory with high bandwidth,
+- Dedicated GPUs have their own memory with high bandwidth,
     while integrated GPUs typically share memory with the system.
 
 Most [=physical resources=] are allocated in the memory of type
@@ -851,6 +854,7 @@ the user behind an `ArrayBuffer`, thus avoiding any data copies.
 ### Resource Usages ### {#programming-model-resource-usages}
 
 A [=physical resource=] can be used on GPU with an <dfn dfn>internal usage</dfn>:
+
 <dl dfn-type=dfn dfn-for="internal usage">
     : <dfn>input</dfn>
     :: Buffer with input data for draw or dispatch calls. Preserves the contents.
@@ -882,9 +886,10 @@ and [=aspect=].
 We define <dfn dfn>subresource</dfn> to be either a whole buffer, or a [=texture subresource=].
 
 <div algorithm="compatible usage list">
-Some [=internal usages=] are compatible with others. A [=subresource=] can be in a state
-that combines multiple usages together. We consider a list |U| to be
-a <dfn dfn>compatible usage list</dfn> if (and only if) it satisfies any of the following rules:
+    Some [=internal usages=] are compatible with others. A [=subresource=] can be in a state
+    that combines multiple usages together. We consider a list |U| to be
+    a <dfn dfn>compatible usage list</dfn> if (and only if) it satisfies any of the following rules:
+
     - Each usage in |U| is [=internal usage/input=], [=internal usage/constant=], [=internal usage/storage-read=], or [=internal usage/attachment-read=].
     - Each usage in |U| is [=internal usage/storage=].
     - |U| contains exactly one element: [=internal usage/attachment=].
@@ -931,30 +936,25 @@ The <dfn dfn>logical miplevel-specific texture extent</dfn> of a [=texture=] is 
 
     1. Let |extent| be a new {{GPUExtent3DDict}} object.
     1. If |descriptor|.{{GPUTextureDescriptor/dimension}} is:
-        <dl class="switch">
+
+        <dl class=switch>
             : {{GPUTextureDimension/"1d"}}
             ::
-                Set |extent|.{{GPUExtent3DDict/width}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] &Gt; |mipLevel|).
-
-                Set |extent|.{{GPUExtent3DDict/height}} to 1.
-
-                Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=].
+                - Set |extent|.{{GPUExtent3DDict/width}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] &Gt; |mipLevel|).
+                - Set |extent|.{{GPUExtent3DDict/height}} to 1.
+                - Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=].
 
             : {{GPUTextureDimension/"2d"}}
             ::
-                Set |extent|.{{GPUExtent3DDict/width}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] &Gt; |mipLevel|).
-
-                Set |extent|.{{GPUExtent3DDict/height}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] &Gt; |mipLevel|).
-
-                Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=].
+                - Set |extent|.{{GPUExtent3DDict/width}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] &Gt; |mipLevel|).
+                - Set |extent|.{{GPUExtent3DDict/height}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] &Gt; |mipLevel|).
+                - Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=].
 
             : {{GPUTextureDimension/"3d"}}
             ::
-                Set |extent|.{{GPUExtent3DDict/width}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] &Gt; |mipLevel|).
-
-                Set |extent|.{{GPUExtent3DDict/height}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] &Gt; |mipLevel|).
-
-                Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] &Gt; |mipLevel|).
+                - Set |extent|.{{GPUExtent3DDict/width}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] &Gt; |mipLevel|).
+                - Set |extent|.{{GPUExtent3DDict/height}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] &Gt; |mipLevel|).
+                - Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] &Gt; |mipLevel|).
         </dl>
     1. Return |extent|.
 </div>
@@ -976,30 +976,25 @@ to form complete [=texel blocks=] in the [=texture=]. It is calculated by this p
     1. Let |extent| be a new {{GPUExtent3DDict}} object.
     1. Let |logicalExtent| be [=logical miplevel-specific texture extent=](|descriptor|, |mipLevel|).
     1. If |descriptor|.{{GPUTextureDescriptor/dimension}} is:
-        <dl class="switch">
+
+        <dl class=switch>
             : {{GPUTextureDimension/"1d"}}
             ::
-                Set |extent|.{{GPUExtent3DDict/width}} to |logicalExtent|.[=Extent3D/width=] rounded up to the nearest multiple of |descriptor|'s [=texel block width=].
-
-                Set |extent|.{{GPUExtent3DDict/height}} to 1.
-
-                Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |logicalExtent|.[=Extent3D/depthOrArrayLayers=].
+                - Set |extent|.{{GPUExtent3DDict/width}} to |logicalExtent|.[=Extent3D/width=] rounded up to the nearest multiple of |descriptor|'s [=texel block width=].
+                - Set |extent|.{{GPUExtent3DDict/height}} to 1.
+                - Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |logicalExtent|.[=Extent3D/depthOrArrayLayers=].
 
             : {{GPUTextureDimension/"2d"}}
             ::
-                Set |extent|.{{GPUExtent3DDict/width}} to |logicalExtent|.[=Extent3D/width=] rounded up to the nearest multiple of |descriptor|'s [=texel block width=].
-
-                Set |extent|.{{GPUExtent3DDict/height}} to |logicalExtent|.[=Extent3D/height=] rounded up to the nearest multiple of |descriptor|'s [=texel block height=].
-
-                Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |logicalExtent|.[=Extent3D/depthOrArrayLayers=].
+                - Set |extent|.{{GPUExtent3DDict/width}} to |logicalExtent|.[=Extent3D/width=] rounded up to the nearest multiple of |descriptor|'s [=texel block width=].
+                - Set |extent|.{{GPUExtent3DDict/height}} to |logicalExtent|.[=Extent3D/height=] rounded up to the nearest multiple of |descriptor|'s [=texel block height=].
+                - Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |logicalExtent|.[=Extent3D/depthOrArrayLayers=].
 
             : {{GPUTextureDimension/"3d"}}
             ::
-                Set |extent|.{{GPUExtent3DDict/width}} to |logicalExtent|.[=Extent3D/width=] rounded up to the nearest multiple of |descriptor|'s [=texel block width=].
-
-                Set |extent|.{{GPUExtent3DDict/height}} to |logicalExtent|.[=Extent3D/height=] rounded up to the nearest multiple of |descriptor|'s [=texel block height=].
-
-                Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |logicalExtent|.[=Extent3D/depthOrArrayLayers=].
+                - Set |extent|.{{GPUExtent3DDict/width}} to |logicalExtent|.[=Extent3D/width=] rounded up to the nearest multiple of |descriptor|'s [=texel block width=].
+                - Set |extent|.{{GPUExtent3DDict/height}} to |logicalExtent|.[=Extent3D/height=] rounded up to the nearest multiple of |descriptor|'s [=texel block height=].
+                - Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |logicalExtent|.[=Extent3D/depthOrArrayLayers=].
         </dl>
     1. Return |extent|.
 </div>
@@ -1040,6 +1035,7 @@ Issue: The above should probably talk about [=GPU commands=]. But we don't have 
 reference specific GPU commands (like dispatch) yet.
 
 <div class=note>
+    Note:
     The above rules mean the following example resource usages **are**
     included in [=usage scope validation=]:
 
@@ -1474,7 +1470,6 @@ applications should generally request the "worst" limits that work for their con
     <tr class=row-continuation><td colspan=4>
         The maximum value for the arguments of
         {{GPUComputePassEncoder/dispatchWorkgroups(workgroupCountX, workgroupCountY, workgroupCountZ)}}.
-
 </table>
 
 Issue: Do we need to have a max per-pixel render target size?
@@ -1531,22 +1526,24 @@ interface GPUSupportedFeatures {
 };
 </script>
 
-<div class="note">
-Note: The type of the {{GPUSupportedFeatures}} [=set entries=] is {{DOMString}} to allow user
-agents to gracefully handle valid {{GPUFeatureName}}s which are added in later revisions of the spec
-but which the user agent has not been updated to recognize yet. If the [=set entries=] type was
-{{GPUFeatureName}} the following code would throw an {{TypeError}} rather than reporting `false`:
+<div class=note>
+    Note:
+    The type of the {{GPUSupportedFeatures}} [=set entries=] is {{DOMString}} to allow user
+    agents to gracefully handle valid {{GPUFeatureName}}s which are added in later revisions of the spec
+    but which the user agent has not been updated to recognize yet. If the [=set entries=] type was
+    {{GPUFeatureName}} the following code would throw an {{TypeError}} rather than reporting `false`:
 
-<div class="example">
-    Check for support of an unrecognized feature:
-    <pre highlight="js">
-        if (adapter.features.has('unknown-feature')) {
-            // Use unknown-feature
-        } else {
-            console.warn('unknown-feature is not supported by this adapter.');
-        }
-    </pre>
-</div>
+    <div class=example>
+        Check for support of an unrecognized feature:
+
+        <pre highlight=js>
+            if (adapter.features.has('unknown-feature')) {
+                // Use unknown-feature
+            } else {
+                console.warn('unknown-feature is not supported by this adapter.');
+            }
+        </pre>
+    </div>
 </div>
 
 #### <dfn interface>GPUAdapterInfo</dfn> #### {#gpu-adapterinfo}
@@ -1561,10 +1558,10 @@ including the absence of those values.
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUAdapterInfo {
-  readonly attribute DOMString vendor;
-  readonly attribute DOMString architecture;
-  readonly attribute DOMString device;
-  readonly attribute DOMString description;
+    readonly attribute DOMString vendor;
+    readonly attribute DOMString architecture;
+    readonly attribute DOMString device;
+    readonly attribute DOMString description;
 };
 </script>
 
@@ -1597,7 +1594,6 @@ interface GPUAdapterInfo {
         this value is not recommended. Applications which change their behavior based on the
         {{GPUAdapterInfo}}, such as applying workarounds for known driver issues, should rely on the
         other fields when possible.
-
 </dl>
 
 <div algorithm>
@@ -1626,7 +1622,7 @@ interface GPUAdapterInfo {
 
     1. If |unmaskedValues| [=set/contains=] `"device"` and the device is known:
         1. Set |adapterInfo|.{{GPUAdapterInfo/device}} to a [=normalized identifier string=]
-             representing a vendor-specific identifier for |adapter|.
+            representing a vendor-specific identifier for |adapter|.
 
         Otherwise:
 
@@ -1649,15 +1645,16 @@ interface GPUAdapterInfo {
 <div algorithm>
     A <dfn>normalized identifier string</dfn> is one that follows the following pattern:
 
-    <pre class='railroad'>
-    OneOrMore:
+    <pre class=railroad>
         OneOrMore:
-            T: a-z 0-9
-        T: -
+            OneOrMore:
+                T: a-z 0-9
+            T: -
     </pre>
 
-    <div class="example">
-    Examples of valid normalized identifier strings include:
+    <div class=example>
+        Examples of valid normalized identifier strings include:
+
         - `gpu`
         - `3d`
         - `0x3b2f`
@@ -1793,6 +1790,7 @@ interface GPU {
             **Called on:** {{GPU}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPU/requestAdapter(options)">
                 |options|: Criteria used to select the adapter.
             </pre>
@@ -1801,6 +1799,7 @@ interface GPU {
 
             1. Let |promise| be [=a new promise=].
             1. Issue the following steps on the [=Device timeline=] of |this|:
+
                 <div class=device-timeline>
                     1. If the user agent chooses to return an adapter, it should:
                         1. Create a [=valid=] [=adapter=] |adapter|, chosen according to
@@ -1816,7 +1815,7 @@ interface GPU {
             1. Return |promise|.
 
             <!-- If we add ways to make invalid adapter requests (aside from those
-                 that violate IDL rules), specify that they reject the promise. -->
+                that violate IDL rules), specify that they reject the promise. -->
         </div>
 
     : <dfn>getPreferredCanvasFormat()</dfn>
@@ -1832,7 +1831,7 @@ interface GPU {
         Note: Canvases which are not displayed to the screen may or may not benefit from using this
         format.
 
-        <div algorithm="GPU.getPreferredCanvasFormat">
+        <div algorithm=GPU.getPreferredCanvasFormat>
             **Called on:** {{GPU}} this.
 
             **Returns:** {{GPUTextureFormat}}
@@ -1877,9 +1876,10 @@ calling {{GPUAdapter/requestDevice()}}.
     Issue: Update here if an `adaptersadded`/`adapterschanged` event is introduced.
 </div>
 
-<div class="example">
+<div class=example>
     Requesting a {{GPUAdapter}} with no hints:
-    <pre highlight="js">
+
+    <pre highlight=js>
         const gpuAdapter = await navigator.gpu.requestAdapter();
     </pre>
 </div>
@@ -1972,9 +1972,10 @@ enum GPUPowerPreference {
         attribute prior to requesting a {{GPUDevice}}.
 </dl>
 
-<div class="example">
+<div class=example>
     Requesting a {{GPUPowerPreference/"high-performance"}} {{GPUAdapter}}:
-    <pre highlight="js">
+
+    <pre highlight=js>
         const gpuAdapter = await navigator.gpu.requestAdapter({
             powerPreference: 'high-performance'
         });
@@ -2035,6 +2036,7 @@ interface GPUAdapter {
             **Called on:** {{GPUAdapter}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUAdapter/requestDevice(descriptor)">
                 |descriptor|: Description of the {{GPUDevice}} to request.
             </pre>
@@ -2044,6 +2046,7 @@ interface GPUAdapter {
             1. Let |promise| be [=a new promise=].
             1. Let |adapter| be |this|.{{GPUAdapter/[[adapter]]}}.
             1. Issue the following steps to the [=Device timeline=]:
+
                 <div class=device-timeline>
                     1. If any of the following requirements are unmet,
                         [=reject=] |promise| with a {{TypeError}} and stop.
@@ -2094,7 +2097,6 @@ interface GPUAdapter {
                         [=a new device=] with the capabilities described by |descriptor|.
                 </div>
             1. Return |promise|.
-
         </div>
 
     : <dfn>requestAdapterInfo()</dfn>
@@ -2110,6 +2112,7 @@ interface GPUAdapter {
             **Called on:** {{GPUAdapter}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUAdapter/requestAdapterInfo()">
                 |unmaskHints|: A list of {{GPUAdapterInfo}} attribute names for which unmasked
                     values are desired if available.
@@ -2138,9 +2141,10 @@ interface GPUAdapter {
         </div>
 </dl>
 
-<div class="example">
+<div class=example>
     Requesting a {{GPUDevice}} with default features and limits:
-    <pre highlight="js">
+
+    <pre highlight=js>
         const gpuAdapter = await navigator.gpu.requestAdapter();
         const gpuDevice = await gpuAdapter.requestDevice();
     </pre>
@@ -2188,9 +2192,10 @@ dictionary GPUDeviceDescriptor : GPUObjectDescriptorBase {
         The descriptor for the default {{GPUQueue}}.
 </dl>
 
-<div class="example">
+<div class=example>
     Requesting a {{GPUDevice}} with the {{GPUFeatureName/"texture-compression-astc"}} feature if supported:
-    <pre highlight="js">
+
+    <pre highlight=js>
         const gpuAdapter = await navigator.gpu.requestAdapter();
 
         const requiredFeatures = [];
@@ -2353,9 +2358,10 @@ Those not defined here are defined elsewhere in this document.
 
 ## Example ## {#initialization-examples}
 
-<div class="example">
+<div class=example>
     A more robust example of requesting a {{GPUAdapter}} and {{GPUDevice}} with error handling:
-    <pre highlight="js">
+
+    <pre highlight=js>
         let gpuDevice = null;
 
         async function initializeWebGPU() {
@@ -2447,7 +2453,7 @@ GPUBuffer includes GPUObjectBase;
 
 {{GPUBuffer}} has the following attributes:
 
-<dl dfn-type=attribute dfn-for="GPUBuffer">
+<dl dfn-type=attribute dfn-for=GPUBuffer>
     : <dfn>size</dfn>
     ::
         The length of the {{GPUBuffer}} allocation in bytes.
@@ -2459,7 +2465,7 @@ GPUBuffer includes GPUObjectBase;
 
 {{GPUBuffer}} has the following internal slots:
 
-<dl dfn-type=attribute dfn-for="GPUBuffer">
+<dl dfn-type=attribute dfn-for=GPUBuffer>
     : <dfn>\[[state]]</dfn>, of type [=buffer state=]
     ::
         The current state of the {{GPUBuffer}}.
@@ -2490,32 +2496,35 @@ GPUBuffer includes GPUObjectBase;
 Each {{GPUBuffer}} has a current <dfn dfn>buffer state</dfn> on the [=Content timeline=]
 which is one of the following:
 
- - "<dfn dfn for="buffer state">mapped</dfn>" where the {{GPUBuffer}} is
-     available for CPU operations on its content.
- - "<dfn dfn for="buffer state">mapped at creation</dfn>" where the {{GPUBuffer}} was
-     just created and is available for CPU operations on its content.
- - "<dfn dfn for="buffer state">mapping pending</dfn>" where the {{GPUBuffer}} is
-     being made available for CPU operations on its content.
- - "<dfn dfn for="buffer state">unmapped</dfn>" where the {{GPUBuffer}} is
-     available for GPU operations.
- - "<dfn dfn for="buffer state">destroyed</dfn>" where the {{GPUBuffer}} is
-     no longer available for any operations except {{GPUBuffer/destroy}}.
+<dl dfn-type=dfn dfn-for="buffer state">
+    : "<dfn>mapped</dfn>"
+    :: The {{GPUBuffer}} is available for CPU operations on its content.
+    : "<dfn>mapped at creation</dfn>"
+    :: The {{GPUBuffer}} was just created and is available for CPU operations on its content.
+    : "<dfn>mapping pending</dfn>"
+    :: The {{GPUBuffer}} is being made available for CPU operations on its content.
+    : "<dfn>unmapped</dfn>"
+    :: The {{GPUBuffer}} is available for GPU operations.
+    : "<dfn>destroyed</dfn>"
+    :: The {{GPUBuffer}} is no longer available for any operations except {{GPUBuffer/destroy}}.
+</dl>
 
 Note:
 {{GPUBuffer/size}} and {{GPUBuffer/usage}} are immutable once the
 {{GPUBuffer}} has been created.
 
 <div class=note>
-   Note: {{GPUBuffer}} has a state machine with the following states.
+    Note:
+    {{GPUBuffer}} has a state machine with the following states.
     ({{GPUBuffer/[[mapping]]}}, {{GPUBuffer/[[mapping_range]]}},
     and {{GPUBuffer/[[mapped_ranges]]}} are `null` when not specified.)
 
-     - [=buffer state/unmapped=] and [=buffer state/destroyed=].
-     - [=buffer state/mapped=] or [=buffer state/mapped at creation=] with an
+    - [=buffer state/unmapped=] and [=buffer state/destroyed=].
+    - [=buffer state/mapped=] or [=buffer state/mapped at creation=] with an
         {{ArrayBuffer}} typed {{GPUBuffer/[[mapping]]}}, a sequence of two
         numbers in {{GPUBuffer/[[mapping_range]]}} and a sequence of {{ArrayBuffer}}
         in {{GPUBuffer/[[mapped_ranges]]}}
-     - [=buffer state/mapping pending=] with a {{Promise}} typed {{GPUBuffer/[[mapping]]}}.
+    - [=buffer state/mapping pending=] with a {{Promise}} typed {{GPUBuffer/[[mapping]]}}.
 </div>
 
 {{GPUBuffer}} is a reference to an internal buffer object.
@@ -2586,7 +2595,7 @@ namespace GPUBufferUsage {
 
 The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its creation:
 
-<dl dfn-type="const" dfn-for=GPUBufferUsage>
+<dl dfn-type=const dfn-for=GPUBufferUsage>
     : <dfn>MAP_READ</dfn>
     ::
         The buffer can be mapped for reading. (Example: calling {{GPUBuffer/mapAsync()}} with
@@ -2659,6 +2668,7 @@ The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its
             **Called on:** {{GPUDevice}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUDevice/createBuffer(descriptor)">
                 |descriptor|: Description of the {{GPUBuffer}} to create.
             </pre>
@@ -2669,9 +2679,11 @@ The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its
             1. Set |b|.{{GPUBuffer/size}} to |descriptor|.{{GPUBufferDescriptor/size}}.
             1. Set |b|.{{GPUBuffer/usage}} to |descriptor|.{{GPUBufferDescriptor/usage}}.
             1. Issue the following steps on the [=Device timeline=] of |this|:
+
                 <div class=device-timeline>
                     1. If any of the following conditions are unsatisfied
                         [$generate a validation error$], make |b| [=invalid=], and stop.
+
                         <div class=validusage>
                             - |this| is [=valid=].
                             - [$validating GPUBufferDescriptor$](|this|, |descriptor|) returns true.
@@ -2692,7 +2704,6 @@ The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its
                     and may be discarded or recycled.
 
                     1. If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`:
-
                         1. Set |b|.{{GPUBuffer/[[mapping]]}} to a new {{ArrayBuffer}} of size |b|.{{GPUBuffer/size}}.
                         1. Set |b|.{{GPUBuffer/[[mapping_range]]}} to `[0, descriptor.size]`.
                         1. Set |b|.{{GPUBuffer/[[mapped_ranges]]}} to `[]`.
@@ -2709,12 +2720,12 @@ The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its
                 </div>
             1. Return |b|.
         </div>
-
 </dl>
 
-<div class="example">
+<div class=example>
     Creating a 128 byte uniform buffer that can be written into:
-    <pre highlight="js">
+
+    <pre highlight=js>
         const buffer = gpuDevice.createBuffer({
             size: 128,
             usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
@@ -2774,8 +2785,8 @@ cannot be used by the GPU and must be unmapped using {{GPUBuffer/unmap}} before
 work using it can be submitted to the [=Queue timeline=].
 
 Issue(gpuweb/gpuweb#605): Add client-side validation that a mapped buffer can
-  only be unmapped and destroyed on the worker on which it was mapped. Likewise
-  {{GPUBuffer/getMappedRange()}} can only be called on that worker.
+only be unmapped and destroyed on the worker on which it was mapped. Likewise
+{{GPUBuffer/getMappedRange()}} can only be called on that worker.
 
 <div algorithm>
     A <dfn dfn>mapped range ArrayBuffer</dfn> is a special type of {{ArrayBuffer}}, returned by
@@ -2803,7 +2814,7 @@ namespace GPUMapMode {
 The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
 {{GPUBuffer/mapAsync()}}:
 
-<dl dfn-type="const" dfn-for=GPUMapMode>
+<dl dfn-type=const dfn-for=GPUMapMode>
     : <dfn>READ</dfn>
     ::
         Only valid with buffers created with the {{GPUBufferUsage/MAP_READ}} usage.
@@ -2836,6 +2847,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
             **Called on:** {{GPUBuffer}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUBuffer/mapAsync(mode, offset, size)">
                 |mode|: Whether the buffer should be mapped for reading or writing.
                 |offset|: Offset in bytes into the buffer to the start of the range to map.
@@ -2849,9 +2861,12 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
             1. If |size| is missing:
                 1. Let |rangeSize| be max(0, |this|.{{GPUBuffer/size}} - |offset|).
 
-                Otherwise, let |rangeSize| be |size|.
+                Otherwise:
+                
+                1. Let |rangeSize| be |size|.
 
             1. If any of the following conditions are unsatisfied:
+
                 <div class=validusage>
                     - |this| is a [=valid=] {{GPUBuffer}}.
                         TODO: check destroyed state?
@@ -2867,6 +2882,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                 </div>
 
                 Then:
+
                 1. Record a validation error on the current scope.
                 1. Return [=a promise rejected with=] an {{OperationError}} on the [=Device timeline=].
 
@@ -2875,6 +2891,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
             1. Set |this|.{{GPUBuffer/[[state]]}} to [=buffer state/mapping pending=].
             1. Set |this|.{{GPUBuffer/[[map_mode]]}} to |mode|.
             1. Enqueue an operation on the default queue's [=Queue timeline=] that will execute the following:
+
                 <div class=queue-timeline>
                     1. If |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapping pending=]:
 
@@ -2900,6 +2917,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
             **Called on:** {{GPUBuffer}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUBuffer/getMappedRange(offset, size)">
                 |offset|: Offset in bytes into the buffer to return buffer contents from.
                 |size|: Size in bytes of the {{ArrayBuffer}} to return.
@@ -2913,6 +2931,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                 Otherwise, let |rangeSize| be |size|.
 
             1. If any of the following conditions are unsatisfied, throw an {{OperationError}} and stop.
+
                 <div class=validusage>
                     - |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapped=] or [=buffer state/mapped at creation=].
                     - |offset| is a multiple of 8.
@@ -2947,6 +2966,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
             **Returns:** {{undefined}}
 
             1. If any of the following requirements are unmet, [$generate a validation error$] and stop.
+
                 <div class=validusage>
                     - |this|.{{GPUBuffer/[[state]]}} must be [=buffer state/mapped at creation=],
                         [=buffer state/mapping pending=], or [=buffer state/mapped=].
@@ -2981,8 +3001,8 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
             1. Set |this|.{{GPUBuffer/[[state]]}} to [=buffer state/unmapped=].
 
             Note: When a {{GPUBufferUsage/MAP_READ}} buffer (not currently mapped at creation) is
-                unmapped, any local modifications done by the application to the mapped ranges
-                {{ArrayBuffer}} are discarded and will not affect the content of follow-up mappings.
+            unmapped, any local modifications done by the application to the mapped ranges
+            {{ArrayBuffer}} are discarded and will not affect the content of follow-up mappings.
         </div>
 </dl>
 
@@ -3019,7 +3039,7 @@ GPUTexture includes GPUObjectBase;
 
 {{GPUTexture}} has the following attributes:
 
-<dl dfn-type=attribute dfn-for="GPUTexture">
+<dl dfn-type=attribute dfn-for=GPUTexture>
     : <dfn>width</dfn>
     ::
         The width of this {{GPUTexture}}.
@@ -3055,7 +3075,7 @@ GPUTexture includes GPUObjectBase;
 
 {{GPUTexture}} has the following internal slots:
 
-<dl dfn-type=attribute dfn-for="GPUTexture">
+<dl dfn-type=attribute dfn-for=GPUTexture>
     : <dfn>\[[size]]</dfn>, of type {{GPUExtent3D}}
     ::
         The size of the texture (same as the {{GPUTexture/width}}, {{GPUTexture/height}}, and
@@ -3076,8 +3096,9 @@ GPUTexture includes GPUObjectBase;
     <dfn abstract-op>compute render extent</dfn>(baseSize, mipLevel)
 
     **Arguments:**
-        - {{GPUExtent3D}} |baseSize|
-        - {{GPUSize32}} |mipLevel|
+
+    - {{GPUExtent3D}} |baseSize|
+    - {{GPUSize32}} |mipLevel|
 
     **Returns:** {{GPUExtent3DDict}}
 
@@ -3139,6 +3160,7 @@ dictionary GPUTextureDescriptor : GPUObjectDescriptorBase {
         {{GPUTextureDescriptor/format}}).
 
         <div class=note>
+            Note:
             Adding a format to this list may have a significant performance impact, so it is best
             to avoid adding formats unnecessarily.
 
@@ -3161,7 +3183,6 @@ dictionary GPUTextureDescriptor : GPUObjectDescriptorBase {
 
             Issue(gpuweb/gpuweb#168): Define larger compatibility classes.
         </div>
-
 </dl>
 
 <script type=idl>
@@ -3172,7 +3193,7 @@ enum GPUTextureDimension {
 };
 </script>
 
-<dl dfn-type="enum-value" dfn-for=GPUTextureDimension>
+<dl dfn-type=enum-value dfn-for=GPUTextureDimension>
     : <dfn>"1d"</dfn>
     ::
         Specifies a texture that has one dimension, width.
@@ -3202,7 +3223,7 @@ namespace GPUTextureUsage {
 
 The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after its creation:
 
-<dl dfn-type="const" dfn-for=GPUTextureUsage>
+<dl dfn-type=const dfn-for=GPUTextureUsage>
     : <dfn>COPY_SRC</dfn>
     ::
         The texture can be used as the source of a copy operation. (Examples: as the `source`
@@ -3235,13 +3256,16 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
 
 <div algorithm>
     <dfn abstract-op>maximum mipLevel count</dfn>(dimension, size)
+
     **Arguments:**
-        - {{GPUTextureDescriptor/dimension}} |dimension|
-        - {{GPUTextureDescriptor/size}} |size|
+
+    - {{GPUTextureDescriptor/dimension}} |dimension|
+    - {{GPUTextureDescriptor/size}} |size|
 
     1. Calculate the max dimension value |m|:
         - If |dimension| is:
-            <dl class="switch">
+
+            <dl class=switch>
                 : {{GPUTextureDimension/"1d"}}
                 :: Return 1.
 
@@ -3263,6 +3287,7 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
             **Called on:** {{GPUDevice}} this.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUDevice/createTexture(descriptor)">
                 |descriptor|: Description of the {{GPUTexture}} to create.
             </pre>
@@ -3283,9 +3308,11 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
             1. Set |t|.{{GPUTexture/format}} to |descriptor|.{{GPUTextureDescriptor/format}}.
             1. Set |t|.{{GPUTexture/usage}} to |descriptor|.{{GPUTextureDescriptor/usage}}.
             1. Issue the following steps on the [=Device timeline=] of |this|:
+
                 <div class=device-timeline>
                     1. If any of the following conditions are unsatisfied
                         [$generate a validation error$], make |t| [=invalid=], and stop.
+
                         <div class=validusage>
                             - [$validating GPUTextureDescriptor$](|this|, |descriptor|) returns `true`.
                         </div>
@@ -3310,9 +3337,9 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
         and |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be greater than zero.
     - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be greater than zero.
     - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be either 1 or 4.
-
     - If |descriptor|.{{GPUTextureDescriptor/dimension}} is:
-        <dl class="switch">
+
+        <dl class=switch>
             : {{GPUTextureDimension/"1d"}}
             ::
                 - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be less than or equal to
@@ -3344,17 +3371,14 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
         </dl>
     - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be multiple of [=texel block width=].
     - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be multiple of [=texel block height=].
-
     - If |descriptor|.{{GPUTextureDescriptor/sampleCount}} > 1:
         - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be 1.
         - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be 1.
         - |descriptor|.{{GPUTextureDescriptor/usage}} must not include the {{GPUTextureUsage/STORAGE_BINDING}} bit.
         - |descriptor|.{{GPUTextureDescriptor/usage}} must include the {{GPUTextureUsage/RENDER_ATTACHMENT}} bit.
         - |descriptor|.{{GPUTextureDescriptor/format}} must support multisampling according to [[#texture-format-caps]].
-
     - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be less than or equal to
         [$maximum mipLevel count$](|descriptor|.{{GPUTextureDescriptor/dimension}}, |descriptor|.{{GPUTextureDescriptor/size}}).
-
     - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/RENDER_ATTACHMENT}} bit:
         - |descriptor|.{{GPUTextureDescriptor/format}} must be a [=renderable format=].
         - |descriptor|.{{GPUTextureDescriptor/dimension}} must be {{GPUTextureDimension/"2d"}}.
@@ -3367,9 +3391,10 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
 </div>
 
 
-<div class="example">
+<div class=example>
     Creating a 16x16, RGBA, 2D texture with one array layer and one mip level:
-    <pre highlight="js">
+
+    <pre highlight=js>
         const texture = gpuDevice.createTexture({
             size: { width: 16, height: 16 },
             format: 'rgba8unorm',
@@ -3411,7 +3436,7 @@ GPUTextureView includes GPUObjectBase;
 
 {{GPUTextureView}} has the following internal slots:
 
-<dl dfn-type=attribute dfn-for="GPUTextureView">
+<dl dfn-type=attribute dfn-for=GPUTextureView>
     : <dfn>\[[texture]]</dfn>
     ::
         The {{GPUTexture}} into which this is a view.
@@ -3426,7 +3451,6 @@ GPUTextureView includes GPUObjectBase;
         For renderable views, this is the effective {{GPUExtent3DDict}} for rendering.
 
         Note: this extent depends on the {{GPUTextureViewDescriptor/baseMipLevel}}.
-
 </dl>
 
 ### Texture View Creation ### {#texture-view-creation}
@@ -3585,23 +3609,25 @@ enum GPUTextureAspect {
     ::
         Creates a {{GPUTextureView}}.
 
-        <div class="note">
-        By default {{GPUTexture/createView()}} will create a view with a dimension that can
-        represent the entire texture. For example, calling {{GPUTexture/createView()}} without
-        specifying a {{GPUTextureViewDescriptor/dimension}} on a {{GPUTextureDimension/"2d"}}
-        texture with more than one layer will create a {{GPUTextureViewDimension/"2d-array"}}
-        {{GPUTextureView}}, even if an {{GPUTextureViewDescriptor/arrayLayerCount}} of 1 is
-        specified.
+        <div class=note>
+            Note:
+            By default {{GPUTexture/createView()}} will create a view with a dimension that can
+            represent the entire texture. For example, calling {{GPUTexture/createView()}} without
+            specifying a {{GPUTextureViewDescriptor/dimension}} on a {{GPUTextureDimension/"2d"}}
+            texture with more than one layer will create a {{GPUTextureViewDimension/"2d-array"}}
+            {{GPUTextureView}}, even if an {{GPUTextureViewDescriptor/arrayLayerCount}} of 1 is
+            specified.
 
-        For textures created from sources where the layer count is unknown at the
-        time of development it is recommended that calls to {{GPUTexture/createView()}} are provided
-        with an explicit {{GPUTextureViewDescriptor/dimension}} to ensure shader compatibility.
+            For textures created from sources where the layer count is unknown at the
+            time of development it is recommended that calls to {{GPUTexture/createView()}} are provided
+            with an explicit {{GPUTextureViewDescriptor/dimension}} to ensure shader compatibility.
         </div>
 
         <div algorithm=GPUTexture.createView>
             **Called on:** {{GPUTexture}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUTexture/createView(descriptor)">
                 |descriptor|: Description of the {{GPUTextureView}} to create.
             </pre>
@@ -3612,11 +3638,13 @@ enum GPUTextureAspect {
                 |descriptor|.{{GPUTextureViewDescriptor/format}} with |this|.{{GPUObjectBase/[[device]]}}.
             1. Let |view| be a new {{GPUTextureView}} object.
             1. Issue the following steps on the [=Device timeline=] of |this|:
+
                 <div class=device-timeline>
                     1. Set |descriptor| to the result of [$resolving GPUTextureViewDescriptor defaults$]
                         for |this| with |descriptor|.
                     1. If any of the following conditions are unsatisfied
                         [$generate a validation error$], make |view| [=invalid=], and stop.
+
                         <div class=validusage>
                             - |this| is [=valid=].
                             - |descriptor|.{{GPUTextureViewDescriptor/aspect}} must be present in |this|.{{GPUTexture/format}}.
@@ -3642,7 +3670,8 @@ enum GPUTextureAspect {
                             - If |this|.{{GPUTexture/sampleCount}} is &gt; 1,
                                 |descriptor|.{{GPUTextureViewDescriptor/dimension}} must be {{GPUTextureViewDimension/"2d"}}.
                             - If |descriptor|.{{GPUTextureViewDescriptor/dimension}} is:
-                                <dl class="switch">
+
+                                <dl class=switch>
                                     : {{GPUTextureViewDimension/"1d"}}
                                     :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"1d"}}.
                                     :: |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `1`.
@@ -3691,6 +3720,7 @@ enum GPUTextureAspect {
                 {{GPUTexture/format}},
                 |descriptor|.{{GPUTextureViewDescriptor/aspect}}).
         1. If |format| is `null`:
+
             - Set |resolved|.{{GPUTextureViewDescriptor/format}} to |texture|.{{GPUTexture/format}}.
 
             Otherwise:
@@ -3701,22 +3731,27 @@ enum GPUTextureAspect {
         &minus; |resolved|.{{GPUTextureViewDescriptor/baseMipLevel}}.
     1. If |resolved|.{{GPUTextureViewDescriptor/dimension}} is `undefined` and
         |texture|.{{GPUTexture/dimension}} is:
-        <dl class="switch">
+
+        <dl class=switch>
             : {{GPUTextureDimension/"1d"}}
             :: Set |resolved|.{{GPUTextureViewDescriptor/dimension}} to {{GPUTextureViewDimension/"1d"}}.
 
             : {{GPUTextureDimension/"2d"}}
             :: If the [$array layer count$] of |texture| is 1:
-                    - Set |resolved|.{{GPUTextureViewDescriptor/dimension}} to {{GPUTextureViewDimension/"2d"}}.
+
+                - Set |resolved|.{{GPUTextureViewDescriptor/dimension}} to {{GPUTextureViewDimension/"2d"}}.
+
                 Otherwise:
-                    - Set |resolved|.{{GPUTextureViewDescriptor/dimension}} to {{GPUTextureViewDimension/"2d-array"}}.
+
+                - Set |resolved|.{{GPUTextureViewDescriptor/dimension}} to {{GPUTextureViewDimension/"2d-array"}}.
 
             : {{GPUTextureDimension/"3d"}}
             :: Set |resolved|.{{GPUTextureViewDescriptor/dimension}} to {{GPUTextureViewDimension/"3d"}}.
         </dl>
     1. If |resolved|.{{GPUTextureViewDescriptor/arrayLayerCount}} is `undefined` and
         |resolved|.{{GPUTextureViewDescriptor/dimension}} is:
-        <dl class="switch">
+
+        <dl class=switch>
             : {{GPUTextureViewDimension/"1d"}}, {{GPUTextureViewDimension/"2d"}}, or
                 {{GPUTextureViewDimension/"3d"}}
             :: Set |resolved|.{{GPUTextureViewDescriptor/arrayLayerCount}} to `1`.
@@ -3737,7 +3772,8 @@ enum GPUTextureAspect {
     following steps:
 
         1. If |texture|.{{GPUTexture/dimension}} is:
-            <dl class="switch">
+
+            <dl class=switch>
                 : {{GPUTextureDimension/"1d"}} or {{GPUTextureDimension/"3d"}}
                 :: Return `1`.
 
@@ -3779,12 +3815,12 @@ enum GPUTextureAspect {
 The name of the format specifies the order of components, bits per component,
 and data type for the component.
 
-  * `r`, `g`, `b`, `a` = red, green, blue, alpha
-  * `unorm` = unsigned normalized
-  * `snorm` = signed normalized
-  * `uint` = unsigned int
-  * `sint` = signed int
-  * `float` = floating point
+- `r`, `g`, `b`, `a` = red, green, blue, alpha
+- `unorm` = unsigned normalized
+- `snorm` = signed normalized
+- `uint` = unsigned int
+- `sint` = signed int
+- `float` = floating point
 
 If the format has the `-srgb` suffix, then sRGB conversions from gamma to linear
 and vice versa are applied during the reading and writing of color values in the
@@ -3796,8 +3832,9 @@ The <dfn dfn>texel block</dfn> is a single addressable element of the textures i
 and a single compressed block of the textures in block-based compressed {{GPUTextureFormat}}s.
 
 The <dfn dfn>texel block width</dfn> and <dfn dfn>texel block height</dfn> specifies the dimension of one [=texel block=].
-  - For pixel-based {{GPUTextureFormat}}s, the [=texel block width=] and [=texel block height=] are always 1.
-  - For block-based compressed {{GPUTextureFormat}}s, the [=texel block width=] is the number of texels in each row of one [=texel block=],
+
+- For pixel-based {{GPUTextureFormat}}s, the [=texel block width=] and [=texel block height=] are always 1.
+- For block-based compressed {{GPUTextureFormat}}s, the [=texel block width=] is the number of texels in each row of one [=texel block=],
     and the [=texel block height=] is the number of texel rows in one [=texel block=]. See [[#texture-format-caps]] for an exhaustive list
     of values for every texture format.
 
@@ -3955,13 +3992,15 @@ All [=depth-or-stencil formats=] are renderable.
     <dfn abstract-op>resolving GPUTextureAspect</dfn>(format, aspect)
 
     **Arguments:**
-        - {{GPUTextureFormat}} |format|
-        - {{GPUTextureAspect}} |aspect|
+
+    - {{GPUTextureFormat}} |format|
+    - {{GPUTextureAspect}} |aspect|
 
     **Returns:** {{GPUTextureFormat}} or `null`
 
     1. If |aspect| is:
-        <dl class="switch">
+
+        <dl class=switch>
             : {{GPUTextureAspect/"all"}}
             :: Return |format|.
 
@@ -4004,6 +4043,7 @@ bind group layout entry member.
 External textures use several binding slots: see [=Exceeds the binding slot limits=].
 
 <div class=note>
+    Note:
     External textures *can* be implemented without creating a copy of the imported source,
     but this depends implementation-defined factors.
     Ownership of the underlying representation may either be exclusive or shared with other
@@ -4094,6 +4134,7 @@ dictionary GPUExternalTextureDescriptor : GPUObjectDescriptorBase {
             **Called on:** {{GPUDevice}} this.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUDevice/importExternalTexture(descriptor)">
                 |descriptor|: Provides the external image source object (and any creation options).
             </pre>
@@ -4148,10 +4189,10 @@ dictionary GPUExternalTextureDescriptor : GPUObjectDescriptorBase {
     Otherwise, a texture could get destroyed by these steps before it is used.
 </div>
 
-<div class="example">
+<div class=example>
     Rendering using an video element external texture at the page animation frame rate:
 
-    <pre highlight="js">
+    <pre highlight=js>
         const videoElement = document.createElement('video');
         // ... set up videoElement, wait for it to be ready...
 
@@ -4173,11 +4214,11 @@ dictionary GPUExternalTextureDescriptor : GPUObjectDescriptorBase {
     </pre>
 </div>
 
-<div class="example">
+<div class=example>
     Rendering using an video element external texture at the video's frame rate, if
     `requestVideoFrameCallback` is available:
 
-    <pre highlight="js">
+    <pre highlight=js>
         const videoElement = document.createElement('video');
         // ... set up videoElement...
 
@@ -4230,7 +4271,7 @@ GPUSampler includes GPUObjectBase;
 
 {{GPUSampler}} has the following internal slots:
 
-<dl dfn-type=attribute dfn-for="GPUSampler">
+<dl dfn-type=attribute dfn-for=GPUSampler>
     : <dfn>\[[descriptor]]</dfn>, of type {{GPUSamplerDescriptor}}, readonly
     ::
         The {{GPUSamplerDescriptor}} with which the {{GPUSampler}} was created.
@@ -4326,7 +4367,7 @@ enum GPUAddressMode {
 };
 </script>
 
-<dl dfn-type="enum-value" dfn-for=GPUAddressMode>
+<dl dfn-type=enum-value dfn-for=GPUAddressMode>
     : <dfn>"clamp-to-edge"</dfn>
     ::
         Texture coordinates are clamped between 0.0 and 1.0, inclusive.
@@ -4356,7 +4397,7 @@ enum GPUMipmapFilterMode {
 };
 </script>
 
-<dl dfn-type="enum-value" dfn-for=GPUFilterMode>
+<dl dfn-type=enum-value dfn-for=GPUFilterMode>
     : <dfn>"nearest"</dfn>
     ::
         Return the value of the texel nearest to the texture coordinates.
@@ -4385,7 +4426,7 @@ enum GPUCompareFunction {
 };
 </script>
 
-<dl dfn-type="enum-value" dfn-for=GPUCompareFunction>
+<dl dfn-type=enum-value dfn-for=GPUCompareFunction>
     : <dfn>"never"</dfn>
     ::
         Comparison tests never pass.
@@ -4428,6 +4469,7 @@ enum GPUCompareFunction {
             **Called on:** {{GPUDevice}} this.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUDevice/createSampler(descriptor)">
                 |descriptor|: Description of the {{GPUSampler}} to create.
             </pre>
@@ -4436,9 +4478,11 @@ enum GPUCompareFunction {
 
             1. Let |s| be a new {{GPUSampler}} object.
             1. Issue the following steps on the [=Device timeline=] of |this|:
+
                 <div class=device-timeline>
                     1. If any of the following conditions are unsatisfied
                         [$generate a validation error$], make |s| [=invalid=], and stop.
+
                         <div class=validusage>
                             - |this| is [=valid=].
                             - |descriptor|.{{GPUSamplerDescriptor/lodMinClamp}} &ge; 0.
@@ -4468,9 +4512,10 @@ enum GPUCompareFunction {
         </div>
 </dl>
 
-<div class="example">
+<div class=example>
     Creating a {{GPUSampler}} that does trilinear filtering and repeats texture coordinates:
-    <pre highlight="js">
+
+    <pre highlight=js>
         const sampler = gpuDevice.createSampler({
             addressModeU: 'repeat',
             addressModeV: 'repeat',
@@ -4603,7 +4648,7 @@ Only one may be defined for any given {{GPUBindGroupLayoutEntry}}.
 Each member has an associated {{GPUBindingResource}}
 type and each [=binding type=] has an associated [=internal usage=], given by this table:
 
-<table class="data" style="white-space: nowrap">
+<table class=data style="white-space: nowrap">
     <thead>
         <tr>
             <th><dfn dfn>Binding member</dfn>
@@ -4667,6 +4712,7 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
     Each entry may use multiple slots toward multiple limits.
 
     1. For each |entry| in |entries|, if:
+
         <dl class=switch>
             : |entry|.{{GPUBindGroupLayoutEntry/buffer}}?.{{GPUBufferBindingLayout/type}}
                 is {{GPUBufferBindingType/"uniform"}} and
@@ -4681,6 +4727,7 @@ type and each [=binding type=] has an associated [=internal usage=], given by th
         &laquo; {{GPUShaderStage/VERTEX}}, {{GPUShaderStage/FRAGMENT}}, {{GPUShaderStage/COMPUTE}} &raquo;:
         1. For each |entry| in |entries|  for which
             |entry|.{{GPUBindGroupLayoutEntry/visibility}} contains |stage|, if:
+
             <dl class=switch>
                 : |entry|.{{GPUBindGroupLayoutEntry/buffer}}?.{{GPUBufferBindingLayout/type}}
                     is {{GPUBufferBindingType/"uniform"}}
@@ -4800,7 +4847,6 @@ truly optional.
     ::
         Indicates the required {{GPUTextureViewDescriptor/dimension}} for texture views bound to
         this binding.
-        <!-- https://github.com/gpuweb/gpuweb/pull/339 -->
 
     : <dfn>multisampled</dfn>
     ::
@@ -4838,7 +4884,6 @@ truly optional.
     ::
         Indicates the required {{GPUTextureViewDescriptor/dimension}} for texture views bound to
         this binding.
-        <!-- https://github.com/gpuweb/gpuweb/pull/339 -->
 </dl>
 
 <script type=idl>
@@ -4848,7 +4893,7 @@ dictionary GPUExternalTextureBindingLayout {
 
 A {{GPUBindGroupLayout}} object has the following internal slots:
 
-<dl dfn-type=attribute dfn-for="GPUBindGroupLayout">
+<dl dfn-type=attribute dfn-for=GPUBindGroupLayout>
     : <dfn>\[[entryMap]]</dfn>, of type [=ordered map=]&lt;{{GPUSize32}}, {{GPUBindGroupLayoutEntry}}&gt
     ::
         The map of binding indices pointing to the {{GPUBindGroupLayoutEntry}}s,
@@ -4875,6 +4920,7 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
             **Called on:** {{GPUDevice}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUDevice/createBindGroupLayout(descriptor)">
                 |descriptor|: Description of the {{GPUBindGroupLayout}} to create.
             </pre>
@@ -4888,9 +4934,11 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                         with |this|.{{GPUObjectBase/[[device]]}}.
             1. Let |layout| be a new {{GPUBindGroupLayout}} object.
             1. Issue the following steps on the [=Device timeline=] of |this|:
+
                 <div class=device-timeline>
                     1. If any of the following conditions are unsatisfied
                         [$generate a validation error$], make |layout| [=invalid=], and stop.
+
                         <div class=validusage>
                             - |this| is [=valid=].
                             - The {{GPUBindGroupLayoutEntry/binding}} of each entry in |descriptor| is unique.
@@ -4972,7 +5020,7 @@ GPUBindGroup includes GPUObjectBase;
 
 A {{GPUBindGroup}} object has the following internal slots:
 
-<dl dfn-type=attribute dfn-for="GPUBindGroup">
+<dl dfn-type=attribute dfn-for=GPUBindGroup>
     : <dfn>\[[layout]]</dfn>, of type {{GPUBindGroupLayout}}, readonly
     ::
         The {{GPUBindGroupLayout}} associated with this {{GPUBindGroup}}.
@@ -5072,6 +5120,7 @@ following members:
             **Called on:** {{GPUDevice}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUDevice/createBindGroup(descriptor)">
                 |descriptor|: Description of the {{GPUBindGroup}} to create.
             </pre>
@@ -5080,10 +5129,12 @@ following members:
 
             1. Let |bindGroup| be a new {{GPUBindGroup}} object.
             1. Issue the following steps on the [=Device timeline=] of |this|:
+
                 <div class=device-timeline>
                     1. Let |limits| be |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.
                     1. If any of the following conditions are unsatisfied
                         [$generate a validation error$], make |bindGroup| [=invalid=], and stop.
+
                         <div class=validusage>
                             - |descriptor|.{{GPUBindGroupDescriptor/layout}} is [$valid to use with$] |this|.
                             - The number of {{GPUBindGroupLayoutDescriptor/entries}} of
@@ -5099,13 +5150,15 @@ following members:
                                     |bindingDescriptor|.{{GPUBindGroupEntry/binding}}.
 
                                 - If the defined [=binding member=] for |layoutBinding| is
-                                    <dl class="switch">
+
+                                    <dl class=switch>
                                         : {{GPUBindGroupLayoutEntry/sampler}}
                                         ::
                                             - |resource| is a {{GPUSampler}}.
                                             - |resource| is [$valid to use with$] |this|.
                                             - If |layoutBinding|.{{GPUBindGroupLayoutEntry/sampler}}.{{GPUSamplerBindingLayout/type}} is:
-                                                <dl class="switch">
+
+                                                <dl class=switch>
                                                     : {{GPUSamplerBindingType/"filtering"}}
                                                     :: |resource|.{{GPUSampler/[[isComparison]]}} is `false`.
 
@@ -5155,7 +5208,8 @@ following members:
                                                 |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}}.
 
                                             - If |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/type}} is
-                                                <dl class="switch">
+
+                                                <dl class=switch>
                                                     : {{GPUBufferBindingType/"uniform"}}
                                                     :: |resource|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
                                                         includes {{GPUBufferUsage/UNIFORM}}.
@@ -5219,9 +5273,10 @@ following members:
 A {{GPUPipelineLayout}} defines the mapping between resources of all {{GPUBindGroup}} objects set up during command encoding in {{GPUBindingCommandsMixin/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup}}, and the shaders of the pipeline set by {{GPURenderCommandsMixin/setPipeline(pipeline)|GPURenderCommandsMixin.setPipeline}} or {{GPUComputePassEncoder/setPipeline(pipeline)|GPUComputePassEncoder.setPipeline}}.
 
 The full binding address of a resource can be defined as a trio of:
-  1. shader stage mask, to which the resource is visible
-  2. bind group index
-  3. binding number
+
+1. shader stage mask, to which the resource is visible
+1. bind group index
+1. binding number
 
 The components of this address can also be seen as the binding space of a pipeline. A {{GPUBindGroup}} (with the corresponding {{GPUBindGroupLayout}}) covers that space for a fixed bind group index. The contained bindings need to be a superset of the resources used by the shader at this bind group index.
 
@@ -5234,7 +5289,7 @@ GPUPipelineLayout includes GPUObjectBase;
 
 {{GPUPipelineLayout}} has the following internal slots:
 
-<dl dfn-type=attribute dfn-for="GPUPipelineLayout">
+<dl dfn-type=attribute dfn-for=GPUPipelineLayout>
     : <dfn>\[[bindGroupLayouts]]</dfn>, of type [=list=]&lt;{{GPUBindGroupLayout}}&gt;
     ::
         The {{GPUBindGroupLayout}} objects provided at creation in {{GPUPipelineLayoutDescriptor/bindGroupLayouts|GPUPipelineLayoutDescriptor.bindGroupLayouts}}.
@@ -5242,19 +5297,19 @@ GPUPipelineLayout includes GPUObjectBase;
 
 Note: using the same {{GPUPipelineLayout}} for many {{GPURenderPipeline}} or {{GPUComputePipeline}} pipelines guarantees that the user agent doesn't need to rebind any resources internally when there is a switch between these pipelines.
 
-<div class="example">
-{{GPUComputePipeline}} object X was created with {{GPUPipelineLayout/[[bindGroupLayouts]]|GPUPipelineLayout.bindGroupLayouts}} A, B, C. {{GPUComputePipeline}} object Y was created with {{GPUPipelineLayout/[[bindGroupLayouts]]|GPUPipelineLayout.bindGroupLayouts}} A, D, C. Supposing the command encoding sequence has two dispatches:
+<div class=example>
+    {{GPUComputePipeline}} object X was created with {{GPUPipelineLayout/[[bindGroupLayouts]]|GPUPipelineLayout.bindGroupLayouts}} A, B, C. {{GPUComputePipeline}} object Y was created with {{GPUPipelineLayout/[[bindGroupLayouts]]|GPUPipelineLayout.bindGroupLayouts}} A, D, C. Supposing the command encoding sequence has two dispatches:
 
-  1. {{GPUBindingCommandsMixin/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup(0, ...)}}
-  1. {{GPUBindingCommandsMixin/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup(1, ...)}}
-  1. {{GPUBindingCommandsMixin/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup(2, ...)}}
-  1. {{GPUComputePassEncoder/setPipeline(pipeline)|setPipeline(X)}}
-  1. {{GPUComputePassEncoder/dispatchWorkgroups()|dispatchWorkgroups()}}
-  1. {{GPUBindingCommandsMixin/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup(1, ...)}}
-  1. {{GPUComputePassEncoder/setPipeline(pipeline)|setPipeline(Y)}}
-  1. {{GPUComputePassEncoder/dispatchWorkgroups()|dispatchWorkgroups()}}
+    1. {{GPUBindingCommandsMixin/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup(0, ...)}}
+    1. {{GPUBindingCommandsMixin/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup(1, ...)}}
+    1. {{GPUBindingCommandsMixin/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup(2, ...)}}
+    1. {{GPUComputePassEncoder/setPipeline(pipeline)|setPipeline(X)}}
+    1. {{GPUComputePassEncoder/dispatchWorkgroups()|dispatchWorkgroups()}}
+    1. {{GPUBindingCommandsMixin/setBindGroup(index, bindGroup, dynamicOffsets)|setBindGroup(1, ...)}}
+    1. {{GPUComputePassEncoder/setPipeline(pipeline)|setPipeline(Y)}}
+    1. {{GPUComputePassEncoder/dispatchWorkgroups()|dispatchWorkgroups()}}
 
-In this scenario, the user agent would have to re-bind the group slot 2 for the second dispatch, even though neither the {{GPUBindGroupLayout}} at index 2 of {{GPUPipelineLayout/[[bindGroupLayouts]]|GPUPipelineLayout.bindGrouplayouts}}, or the {{GPUBindGroup}} at slot 2, change.
+    In this scenario, the user agent would have to re-bind the group slot 2 for the second dispatch, even though neither the {{GPUBindGroupLayout}} at index 2 of {{GPUPipelineLayout/[[bindGroupLayouts]]|GPUPipelineLayout.bindGrouplayouts}}, or the {{GPUBindGroup}} at slot 2, change.
 </div>
 
 Issue: should this example and the note be moved to some "best practices" document?
@@ -5291,6 +5346,7 @@ pipeline, and have the following members:
             **Called on:** {{GPUDevice}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUDevice/createPipelineLayout(descriptor)">
                 |descriptor|: Description of the {{GPUPipelineLayout}} to create.
             </pre>
@@ -5299,6 +5355,7 @@ pipeline, and have the following members:
 
             1. Let |pl| be a new {{GPUPipelineLayout}} object.
             1. Issue the following steps on the [=Device timeline=] of |this|:
+
                 <div class=device-timeline>
                     1. Let |limits| be |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.
                     1. Let |allEntries| be the result of concatenating
@@ -5306,6 +5363,7 @@ pipeline, and have the following members:
                         for all |bgl| in |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}.
                     1. If any of the following conditions are unsatisfied
                         [$generate a validation error$], make |pl| [=invalid=], and stop.
+
                         <div class=validusage>
                             - Every {{GPUBindGroupLayout}} in |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
                                 must be [$valid to use with$] |this| and have a {{GPUBindGroupLayout/[[exclusivePipeline]]}}
@@ -5328,10 +5386,11 @@ if their internal {{GPUPipelineLayout/[[bindGroupLayouts]]}} sequences contain
 
 ## Example ## {#bindgroup-examples}
 
-<div class="example">
+<div class=example>
     Create a {{GPUBindGroupLayout}} that describes a binding with a uniform buffer, a texture, and a sampler.
     Then create a {{GPUBindGroup}} and a {{GPUPipelineLayout}} using the {{GPUBindGroupLayout}}.
-    <pre highlight="js">
+
+    <pre highlight=js>
         const bindGroupLayout = gpuDevice.createBindGroupLayout({
             entries: [{
                 binding: 0,
@@ -5433,6 +5492,7 @@ dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
             **Called on:** {{GPUDevice}} this.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUDevice/createShaderModule(descriptor)">
                 descriptor: Description of the {{GPUShaderModule}} to create.
             </pre>
@@ -5441,9 +5501,11 @@ dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
 
             1. Let |sm| be a new {{GPUShaderModule}} object.
             1. Issue the following steps on the [=Device timeline=] of |this|:
+
                 <div class=device-timeline>
                     1. If any of the following conditions are unsatisfied
                         [$generate a validation error$], make |sm| [=invalid=], and stop.
+
                         <div class=validusage>
                             - |this| is [=valid=].
                         </div>
@@ -5454,6 +5516,7 @@ dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
             1. Return |sm|.
 
             <div class=note>
+                Note:
                 User agents **should not** include error messages or shader text in
                 the {{GPUError/message}} text of validation errors arising here:
                 these details are accessible via {{GPUShaderModule/compilationInfo()}}.
@@ -5472,9 +5535,10 @@ dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
         </div>
 </dl>
 
-<div class="example">
+<div class=example>
     Create a {{GPUShaderModule}} from WGSL code:
-    <pre highlight="js">
+
+    <pre highlight=js>
         // A simple vertex and fragment shader pair that will fill the viewport with red.
         const shaderSource = \`
             var&lt;private&gt; pos : array&lt;vec2&lt;f32&gt;, 3&gt; = array&lt;vec2&lt;f32&gt;, 3&gt;(
@@ -5519,22 +5583,23 @@ dictionary GPUShaderModuleCompilationHint {
 </dl>
 
 <div class=note>
-If possible, authors should be supplying the same information to
-{{GPUDevice/createShaderModule()}} and {{GPUDevice/createComputePipeline()}} /
-{{GPUDevice/createRenderPipeline()}}.
+    Note:
+    If possible, authors should be supplying the same information to
+    {{GPUDevice/createShaderModule()}} and {{GPUDevice/createComputePipeline()}} /
+    {{GPUDevice/createRenderPipeline()}}.
 
-If an author is unable to provide hint information at the time of calling
-{{GPUDevice/createShaderModule()}}, they should usually not delay calling
-{{GPUDevice/createShaderModule()}}; but should instead just omit the unknown information from
-{{GPUShaderModuleDescriptor/hints}} or {{GPUShaderModuleCompilationHint}}. Omitting this information
-may cause compilation to be deferred to {{GPUDevice/createComputePipeline()}} /
-{{GPUDevice/createRenderPipeline()}}.
+    If an author is unable to provide hint information at the time of calling
+    {{GPUDevice/createShaderModule()}}, they should usually not delay calling
+    {{GPUDevice/createShaderModule()}}; but should instead just omit the unknown information from
+    {{GPUShaderModuleDescriptor/hints}} or {{GPUShaderModuleCompilationHint}}. Omitting this information
+    may cause compilation to be deferred to {{GPUDevice/createComputePipeline()}} /
+    {{GPUDevice/createRenderPipeline()}}.
 
-If an author is not confident that the hint information passed to {{GPUDevice/createShaderModule()}}
-will match the information later passed to {{GPUDevice/createComputePipeline()}} /
-{{GPUDevice/createRenderPipeline()}} with that same module, they should avoid passing that
-information to {{GPUDevice/createShaderModule()}}, as passing mismatched information to
-{{GPUDevice/createShaderModule()}} may cause unnecessary compilations to occur.
+    If an author is not confident that the hint information passed to {{GPUDevice/createShaderModule()}}
+    will match the information later passed to {{GPUDevice/createComputePipeline()}} /
+    {{GPUDevice/createRenderPipeline()}} with that same module, they should avoid passing that
+    information to {{GPUDevice/createShaderModule()}}, as passing mismatched information to
+    {{GPUDevice/createShaderModule()}} may cause unnecessary compilations to occur.
 </div>
 
 ### Shader Module Compilation Information ### {#shader-module-compilation-information}
@@ -5639,7 +5704,7 @@ Note: {{GPUCompilationMessage}}.{{GPUCompilationMessage/offset}} and
         In particular, messages may not be ordered by {{GPUCompilationMessage/lineNum}}.
 
         <div algorithm=GPUShaderModule.compilationInfo>
-            **Called on:** {{GPUShaderModule}} this.
+            **Called on:** {{GPUShaderModule}} this
 
             **Returns:** {{Promise}}&lt;{{GPUCompilationInfo}}&gt;
 
@@ -5685,7 +5750,7 @@ interface mixin GPUPipelineBase {
 
 {{GPUPipelineBase}} has the following internal slots:
 
-<dl dfn-type=attribute dfn-for="GPUPipelineBase">
+<dl dfn-type=attribute dfn-for=GPUPipelineBase>
     : <dfn>\[[layout]]</dfn>, of type `GPUPipelineLayout`
     ::
         The definition of the layout of resources which can be used with `this`.
@@ -5700,9 +5765,10 @@ interface mixin GPUPipelineBase {
         {{GPUBindGroupLayout}} at `index`.
 
         <div algorithm=GPUPipelineBase.getBindGroupLayout>
-            **Called on:** {{GPUPipelineBase}} |this|.
+            **Called on:** {{GPUPipelineBase}} |this|
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUPipelineBase/getBindGroupLayout(index)">
                 |index|: Index into the pipeline layout's {{GPUPipelineLayout/[[bindGroupLayouts]]}}
                     sequence.
@@ -5804,21 +5870,21 @@ run the following steps:
                 1. Let |textureLayout| be a new {{GPUTextureBindingLayout}}.
 
                 1. If |resource| is a depth texture binding:
+
                     - Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"depth"}}
 
                     Else if the sampled type of |resource| is:
 
-                    -
-                        <dl class=switch>
-                            : `f32` and |resource| is statically used with a textureSample* builtin in the shader
-                            :: Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"float"}}
-                            : `f32` otherwise
-                            :: Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"unfilterable-float"}}
-                            : `i32`
-                            :: Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"sint"}}
-                            : `u32`
-                            :: Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"uint"}}
-                        </dl>
+                    <dl class=switch>
+                        : `f32` and |resource| is statically used with a textureSample* builtin in the shader
+                        :: Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"float"}}
+                        : `f32` otherwise
+                        :: Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"unfilterable-float"}}
+                        : `i32`
+                        :: Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"sint"}}
+                        : `u32`
+                        :: Set |textureLayout|.{{GPUTextureBindingLayout/sampleType}} to {{GPUTextureSampleType/"uint"}}
+                    </dl>
 
                 1. Set |textureLayout|.{{GPUTextureBindingLayout/viewDimension}} to |resource|'s dimension.
                 1. If |resource| is for a multisampled texture:
@@ -5879,7 +5945,6 @@ run the following steps:
     1. Return |device|.{{GPUDevice/createPipelineLayout()}}(|desc|).
 
     Issue: This fills the pipeline layout with empty bindgroups. Revisit once the behavior of empty bindgroups is specified.
-
 </div>
 
 ### <dfn dictionary>GPUProgrammableStage</dfn> ### {#GPUProgrammableStage}
@@ -5937,18 +6002,18 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
             Pipeline-overridable constants defined in WGSL:
 
             <pre highlight=rust>
-                @id(0)    override has_point_light: bool = true; // Algorithmic control.
-                @id(1200) override specular_param: f32 = 2.3;    // Numeric control.
-                @id(1300) override gain: f32;                    // Must be overridden.
-                          override width: f32 = 0.0;             // Specifed at the API level
-                                                                 //   using the name "width".
-                          override depth: f32;                   // Specifed at the API level
-                                                                 //   using the name "depth".
-                                                                 //   Must be overridden.
-                          override height = 2 * depth;           // The default value
-                                                                 // (if not set at the API level),
-                                                                 // depends on another
-                                                                 // overridable constant.
+                @id(0)      override has_point_light: bool = true;  // Algorithmic control.
+                @id(1200)   override specular_param: f32 = 2.3;     // Numeric control.
+                @id(1300)   override gain: f32;                     // Must be overridden.
+                            override width: f32 = 0.0;              // Specifed at the API level
+                                                                    //   using the name "width".
+                            override depth: f32;                    // Specifed at the API level
+                                                                    //   using the name "depth".
+                                                                    //   Must be overridden.
+                            override height = 2 * depth;            // The default value
+                                                                    // (if not set at the API level),
+                                                                    // depends on another
+                                                                    // overridable constant.
             </pre>
 
             Corresponding JavaScript code, providing only the overrides which are required
@@ -5986,6 +6051,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
     <dfn abstract-op>validating GPUProgrammableStage</dfn>(stage, descriptor, layout)
 
     **Arguments:**
+
     - {{GPUShaderStage}} |stage|
     - {{GPUProgrammableStage}} |descriptor|
     - {{GPUPipelineLayout}} |layout|
@@ -6022,8 +6088,9 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
     <dfn abstract-op>validating shader binding</dfn>(binding, layout)
 
     **Arguments:**
-        - shader binding declaration |variable|, a module-scope variable declaration reflected from a shader module
-        - {{GPUPipelineLayout}} |layout|
+
+    - shader binding declaration |variable|, a module-scope variable declaration reflected from a shader module
+    - {{GPUPipelineLayout}} |layout|
 
     Let |bindGroup| be the bind group index, and |bindIndex| be the binding index,
     of the shader binding declaration |variable|.
@@ -6033,10 +6100,12 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         - |layout|.{{GPUPipelineLayout/[[bindGroupLayouts]]}}[|bindGroup|] contains
             a {{GPUBindGroupLayoutEntry}} |entry| whose |entry|.{{GPUBindGroupLayoutEntry/binding}} == |bindIndex|.
         - If the defined [=binding member=] for |entry| is:
+
             <dl class=switch>
                 : {{GPUBindGroupLayoutEntry/buffer}}
                 ::
                     If |entry|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/type}} is:
+
                     <dl class=switch>
                         : {{GPUBufferBindingType/"uniform"}}
                         :: |variable| is declared with address space `uniform`.
@@ -6058,6 +6127,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
                 : {{GPUBindGroupLayoutEntry/sampler}}
                 ::
                     If |entry|.{{GPUBindGroupLayoutEntry/sampler}}.{{GPUSamplerBindingLayout/type}} is:
+
                     <dl class=switch>
                         : {{GPUSamplerBindingType/"filtering"}} or {{GPUSamplerBindingType/"non-filtering"}}
                         :: |variable| has type `sampler`.
@@ -6072,6 +6142,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
                     is `true`, |variable| has type `texture_multisampled_2d<T>` or `texture_depth_multisampled_2d<T>`.
                 ::
                     If |entry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/sampleType}} is:
+
                     <dl class=switch>
                         : {{GPUTextureSampleType/"float"}}, {{GPUTextureSampleType/"unfilterable-float"}},
                             {{GPUTextureSampleType/"sint"}} or {{GPUTextureSampleType/"uint"}}
@@ -6081,6 +6152,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
                             `texture_multisampled_2d<T>`.
                         ::
                             If |entry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/sampleType}} is:
+
                             <dl class=switch>
                                 : {{GPUTextureSampleType/"float"}} or {{GPUTextureSampleType/"unfilterable-float"}}
                                 :: The sampled type `T` is `f32`.
@@ -6097,6 +6169,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
                     </dl>
                 ::
                     If |entry|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/viewDimension}} is:
+
                     <dl class=switch>
                         : {{GPUTextureViewDimension/"1d"}}
                         :: |variable| has type `texture_1d<T>`.
@@ -6115,6 +6188,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
                 : {{GPUBindGroupLayoutEntry/storageTexture}}
                 ::
                     If |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/viewDimension}} is:
+
                     <dl class=switch>
                         : {{GPUTextureViewDimension/"1d"}}
                         :: |variable| has type `texture_storage_1d<T, A>`.
@@ -6127,6 +6201,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
                     </dl>
                 ::
                     If |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/access}} is:
+
                     <dl class=switch>
                         : {{GPUStorageTextureAccess/"write-only"}}
                         :: The access mode `A` is `write`.
@@ -6152,7 +6227,8 @@ The outputs correspond to {{GPUBindGroupLayoutEntry/buffer}} bindings with a typ
 and {{GPUBindGroupLayoutEntry/storageTexture}} bindings with a type of {{GPUStorageTextureAccess/"write-only"}}.
 
 Stages of a compute [=pipeline=]:
-  1. Compute shader
+
+1. Compute shader
 
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
@@ -6190,6 +6266,7 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
             **Called on:** {{GPUDevice}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUDevice/createComputePipeline(descriptor)">
                 |descriptor|: Description of the {{GPUComputePipeline}} to create.
             </pre>
@@ -6198,13 +6275,15 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
 
             1. Let |pipeline| be a new {{GPUComputePipeline}} object.
             1. Issue the following steps on the [=Device timeline=] of |this|:
-                1. Let |layout| be a new [$default pipeline layout$] for |pipeline| if
-                    |descriptor|.{{GPUPipelineDescriptorBase/layout}} is {{GPUAutoLayoutMode/"auto"}},
-                    and |descriptor|.{{GPUPipelineDescriptorBase/layout}} otherwise.
 
                 <div class=device-timeline>
+                    1. Let |layout| be a new [$default pipeline layout$] for |pipeline| if
+                        |descriptor|.{{GPUPipelineDescriptorBase/layout}} is {{GPUAutoLayoutMode/"auto"}},
+                        and |descriptor|.{{GPUPipelineDescriptorBase/layout}} otherwise.
+
                     1. If any of the following conditions are unsatisfied
                         [$generate a validation error$], make |pipeline| [=invalid=], and stop.
+
                         <div class=validusage>
                             - |layout| is [$valid to use with$] |this|.
                             - [$validating GPUProgrammableStage$]({{GPUShaderStage/COMPUTE}},
@@ -6245,6 +6324,7 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
             **Called on:** {{GPUDevice}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUDevice/createComputePipelineAsync(descriptor)">
                 |descriptor|: Description of the {{GPUComputePipeline}} to create.
             </pre>
@@ -6253,6 +6333,7 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
 
             1. Let |promise| be [=a new promise=].
             1. Issue the following steps on the [=Device timeline=] of |this|:
+
                 <div class=device-timeline>
                     1. Let |pipeline| be a new {{GPUComputePipeline}} created as if
                         |this|.{{GPUDevice/createComputePipeline()}} was called with |descriptor|;
@@ -6264,9 +6345,10 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
         </div>
 </dl>
 
-<div class="example">
+<div class=example>
     Creating a simple {{GPUComputePipeline}}:
-    <pre highlight="js">
+
+    <pre highlight=js>
         const computePipeline = gpuDevice.createComputePipeline({
             layout: pipelineLayout,
             compute: {
@@ -6284,26 +6366,29 @@ and fragment shader stages, and can be used in {{GPURenderPassEncoder}}
 as well as {{GPURenderBundleEncoder}}.
 
 Render [=pipeline=] inputs are:
-  - bindings, according to the given {{GPUPipelineLayout}}
-  - vertex and index buffers, described by {{GPUVertexState}}
-  - the color attachments, described by {{GPUColorTargetState}}
-  - optionally, the depth-stencil attachment, described by {{GPUDepthStencilState}}
+
+- bindings, according to the given {{GPUPipelineLayout}}
+- vertex and index buffers, described by {{GPUVertexState}}
+- the color attachments, described by {{GPUColorTargetState}}
+- optionally, the depth-stencil attachment, described by {{GPUDepthStencilState}}
 
 Render [=pipeline=] outputs are:
-  - {{GPUBindGroupLayoutEntry/buffer}} bindings with a {{GPUBufferBindingLayout/type}} of {{GPUBufferBindingType/"storage"}}
-  - {{GPUBindGroupLayoutEntry/storageTexture}} bindings with a {{GPUStorageTextureBindingLayout/access}} of {{GPUStorageTextureAccess/"write-only"}}
-  - the color attachments, described by {{GPUColorTargetState}}
-  - optionally, depth-stencil attachment, described by {{GPUDepthStencilState}}
+
+- {{GPUBindGroupLayoutEntry/buffer}} bindings with a {{GPUBufferBindingLayout/type}} of {{GPUBufferBindingType/"storage"}}
+- {{GPUBindGroupLayoutEntry/storageTexture}} bindings with a {{GPUStorageTextureBindingLayout/access}} of {{GPUStorageTextureAccess/"write-only"}}
+- the color attachments, described by {{GPUColorTargetState}}
+- optionally, depth-stencil attachment, described by {{GPUDepthStencilState}}
 
 A render [=pipeline=] is comprised of the following <dfn dfn>render stages</dfn>:
-  1. Vertex fetch, controlled by {{GPUVertexState/buffers|GPUVertexState.buffers}}
-  2. Vertex shader, controlled by {{GPUVertexState}}
-  3. Primitive assembly, controlled by {{GPUPrimitiveState}}
-  4. Rasterization, controlled by {{GPUPrimitiveState}}, {{GPUDepthStencilState}}, and {{GPUMultisampleState}}
-  5. Fragment shader, controlled by {{GPUFragmentState}}
-  6. Stencil test and operation, controlled by {{GPUDepthStencilState}}
-  7. Depth test and write, controlled by {{GPUDepthStencilState}}
-  8. Output merging, controlled by {{GPUFragmentState/targets|GPUFragmentState.targets}}
+
+1. Vertex fetch, controlled by {{GPUVertexState/buffers|GPUVertexState.buffers}}
+1. Vertex shader, controlled by {{GPUVertexState}}
+1. Primitive assembly, controlled by {{GPUPrimitiveState}}
+1. Rasterization, controlled by {{GPUPrimitiveState}}, {{GPUDepthStencilState}}, and {{GPUMultisampleState}}
+1. Fragment shader, controlled by {{GPUFragmentState}}
+1. Stencil test and operation, controlled by {{GPUDepthStencilState}}
+1. Depth test and write, controlled by {{GPUDepthStencilState}}
+1. Output merging, controlled by {{GPUFragmentState/targets|GPUFragmentState.targets}}
 
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
@@ -6378,6 +6463,7 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
             **Called on:** {{GPUDevice}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUDevice/createRenderPipeline(descriptor)">
                 |descriptor|: Description of the {{GPURenderPipeline}} to create.
             </pre>
@@ -6395,18 +6481,18 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
                     with |this|.{{GPUObjectBase/[[device]]}}.
             1. Let |pipeline| be a new {{GPURenderPipeline}} object.
             1. Issue the following steps on the [=Device timeline=] of |this|:
+
                 <div class=device-timeline>
                     1. Let |layout| be a new [$default pipeline layout$] for |pipeline| if
                         |descriptor|.{{GPUPipelineDescriptorBase/layout}} is {{GPUAutoLayoutMode/"auto"}},
                         and |descriptor|.{{GPUPipelineDescriptorBase/layout}} otherwise.
-
                     1. If any of the following conditions are unsatisfied:
                         [$generate a validation error$], make |pipeline| [=invalid=], and stop.
+
                         <div class=validusage>
                             - |layout| is [$valid to use with$] |this|.
                             - [$validating GPURenderPipelineDescriptor$](|descriptor|, |layout|, |this|) succeeds.
                         </div>
-
                     1. Set |pipeline|.{{GPURenderPipeline/[[descriptor]]}} to |descriptor|.
                     1. Set |pipeline|.{{GPURenderPipeline/[[writesDepth]]}} to false.
                     1. Set |pipeline|.{{GPURenderPipeline/[[writesStencil]]}} to false.
@@ -6446,6 +6532,7 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
             **Called on:** {{GPUDevice}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUDevice/createRenderPipelineAsync(descriptor)">
                 |descriptor|: Description of the {{GPURenderPipeline}} to create.
             </pre>
@@ -6454,6 +6541,7 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
 
             1. Let |promise| be [=a new promise=].
             1. Issue the following steps on the [=Device timeline=] of |this|:
+
                 <div class=device-timeline>
                     1. Let |pipeline| be a new {{GPURenderPipeline}} created as if
                         |this|.{{GPUDevice/createRenderPipeline()}} was called with |descriptor|;
@@ -6467,45 +6555,47 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
 
 <div algorithm>
     <dfn abstract-op>validating GPURenderPipelineDescriptor</dfn>(descriptor, layout, device)
-        **Arguments:**
-            - {{GPURenderPipelineDescriptor}} |descriptor|
-            - {{GPUPipelineLayout}} |layout|
-            - {{GPUDevice}} |device|
 
-        Return `true` if all of the following conditions are satisfied:
+    **Arguments:**
 
-            - [$validating GPUProgrammableStage$]({{GPUShaderStage/VERTEX}},
-                |descriptor|.{{GPURenderPipelineDescriptor/vertex}}, |layout|) succeeds.
-            - [$validating GPUVertexState$](|device|, |descriptor|.{{GPURenderPipelineDescriptor/vertex}},
-                |descriptor|.{{GPURenderPipelineDescriptor/vertex}}) succeeds.
-            - If |descriptor|.{{GPURenderPipelineDescriptor/fragment}} is not `null`:
-                - [$validating GPUProgrammableStage$]({{GPUShaderStage/FRAGMENT}},
-                    |descriptor|.{{GPURenderPipelineDescriptor/fragment}}, |layout|) succeeds.
-                - [$validating GPUFragmentState$](|device|, |descriptor|.{{GPURenderPipelineDescriptor/fragment}}) succeeds.
-                - If the "sample_mask" [=builtin=] is a [=pipeline output=] of |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
-                    - |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/alphaToCoverageEnabled}} is `false`.
-            - [$validating GPUPrimitiveState$](|descriptor|.{{GPURenderPipelineDescriptor/primitive}}, |device|.{{device/[[features]]}}) succeeds.
-            - if |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}} is not `null`:
-                - [$validating GPUDepthStencilState$](|descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}) succeeds.
-            - [$validating GPUMultisampleState$](|descriptor|.{{GPURenderPipelineDescriptor/multisample}}) succeeds.
-            - For each user-defined output of
-                |descriptor|.{{GPURenderPipelineDescriptor/vertex}} there must
-                be a user-defined input of
-                |descriptor|.{{GPURenderPipelineDescriptor/fragment}} that
-                matches the
-                [=location=],
-                type, and
-                [=interpolation=]
-                of the output.
-            - For each user-defined input of
-                |descriptor|.{{GPURenderPipelineDescriptor/fragment}} there
-                must be a user-defined output of
-                |descriptor|.{{GPURenderPipelineDescriptor/vertex}} that
-                [=location=],
-                type, and
-                [=interpolation=]
-                of the input.
-            - [$validating inter-stage interfaces$](|device|, |descriptor|) returns `true`.
+    - {{GPURenderPipelineDescriptor}} |descriptor|
+    - {{GPUPipelineLayout}} |layout|
+    - {{GPUDevice}} |device|
+
+    Return `true` if all of the following conditions are satisfied:
+
+    - [$validating GPUProgrammableStage$]({{GPUShaderStage/VERTEX}},
+        |descriptor|.{{GPURenderPipelineDescriptor/vertex}}, |layout|) succeeds.
+    - [$validating GPUVertexState$](|device|, |descriptor|.{{GPURenderPipelineDescriptor/vertex}},
+        |descriptor|.{{GPURenderPipelineDescriptor/vertex}}) succeeds.
+    - If |descriptor|.{{GPURenderPipelineDescriptor/fragment}} is not `null`:
+        - [$validating GPUProgrammableStage$]({{GPUShaderStage/FRAGMENT}},
+            |descriptor|.{{GPURenderPipelineDescriptor/fragment}}, |layout|) succeeds.
+        - [$validating GPUFragmentState$](|device|, |descriptor|.{{GPURenderPipelineDescriptor/fragment}}) succeeds.
+        - If the "sample_mask" [=builtin=] is a [=pipeline output=] of |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
+            - |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/alphaToCoverageEnabled}} is `false`.
+    - [$validating GPUPrimitiveState$](|descriptor|.{{GPURenderPipelineDescriptor/primitive}}, |device|.{{device/[[features]]}}) succeeds.
+    - if |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}} is not `null`:
+        - [$validating GPUDepthStencilState$](|descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}) succeeds.
+    - [$validating GPUMultisampleState$](|descriptor|.{{GPURenderPipelineDescriptor/multisample}}) succeeds.
+    - For each user-defined output of
+        |descriptor|.{{GPURenderPipelineDescriptor/vertex}} there must
+        be a user-defined input of
+        |descriptor|.{{GPURenderPipelineDescriptor/fragment}} that
+        matches the
+        [=location=],
+        type, and
+        [=interpolation=]
+        of the output.
+    - For each user-defined input of
+        |descriptor|.{{GPURenderPipelineDescriptor/fragment}} there
+        must be a user-defined output of
+        |descriptor|.{{GPURenderPipelineDescriptor/vertex}} that
+        [=location=],
+        type, and
+        [=interpolation=]
+        of the input.
+    - [$validating inter-stage interfaces$](|device|, |descriptor|) returns `true`.
 </div>
 
 <div algorithm>
@@ -6545,9 +6635,10 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
 
 Issue: define what "compatible" means for render target formats.
 
-<div class="example">
+<div class=example>
     Creating a simple {{GPURenderPipeline}}:
-    <pre highlight="js">
+
+    <pre highlight=js>
         const renderPipeline = gpuDevice.createRenderPipeline({
             layout: pipelineLayout,
             vertex: {
@@ -6615,15 +6706,17 @@ constructs and rasterizes primitives from its vertex inputs:
 <div algorithm>
     <dfn abstract-op>validating GPUPrimitiveState</dfn>(|descriptor|, |features|)
         **Arguments:**
-            - {{GPUPrimitiveState}} |descriptor|
-            - [=list=]&lt;{{GPUFeatureName}}&gt; |features|
+
+        - {{GPUPrimitiveState}} |descriptor|
+        - [=list=]&lt;{{GPUFeatureName}}&gt; |features|
 
         Return `true` if all of the following conditions are satisfied:
-            - If |descriptor|.{{GPUPrimitiveState/topology}} is not
-                {{GPUPrimitiveTopology/"line-strip"}} or {{GPUPrimitiveTopology/"triangle-strip"}}:
-                - |descriptor|.{{GPUPrimitiveState/stripIndexFormat}} is `undefined`
-            - If |descriptor|.{{GPUPrimitiveState/unclippedDepth}} is `true`:
-                - |features| must [=list/contain=] {{GPUFeatureName/"depth-clip-control"}}.
+
+        - If |descriptor|.{{GPUPrimitiveState/topology}} is not
+            {{GPUPrimitiveTopology/"line-strip"}} or {{GPUPrimitiveTopology/"triangle-strip"}}:
+            - |descriptor|.{{GPUPrimitiveState/stripIndexFormat}} is `undefined`
+        - If |descriptor|.{{GPUPrimitiveState/unclippedDepth}} is `true`:
+            - |features| must [=list/contain=] {{GPUFeatureName/"depth-clip-control"}}.
 </div>
 
 <script type=idl>
@@ -6746,7 +6839,8 @@ interacts with a render pass's multisampled attachments.
 <div algorithm>
     <dfn abstract-op>validating GPUMultisampleState</dfn>(|descriptor|)
         **Arguments:**
-            - {{GPUMultisampleState}} |descriptor|
+
+        - {{GPUMultisampleState}} |descriptor|
 
         Return `true` if all of the following conditions are satisfied:
             - If |descriptor|.{{GPUMultisampleState/alphaToCoverageEnabled}} is `true`:
@@ -6863,24 +6957,24 @@ of a fragment are blended:
 
 The following tables use this notation to describe color components for a given fragment
 location:
-<table class="data">
-  <tbody>
-    <tr>
-      <td><b><code>RGBA<sub>src</src></code></b>
-      <td>Color output by the fragment shader for the color attachment.
-    <tr>
-      <td><b><code>RGBA<sub>dst</src></code></b>
-      <td>Color currently in the color attachment.
-    <tr>
-      <td><b><code>RGBA<sub>const</src></code></b>
-      <td>The current {{GPURenderPassEncoder/[[blend_constant]]}}.
-    <tr>
-      <td><b><code>RGBA<sub>srcFactor</src></code></b>
-      <td>The source blend factor components, as defined by {{GPUBlendComponent/srcFactor}}.
-    <tr>
-      <td><b><code>RGBA<sub>dstFactor</src></code></b>
-      <td>The destination blend factor components, as defined by {{GPUBlendComponent/dstFactor}}.
-  </tbody>
+<table class=data>
+    <tbody>
+        <tr>
+            <td><b><code>RGBA<sub>src</src></code></b>
+            <td>Color output by the fragment shader for the color attachment.
+        <tr>
+            <td><b><code>RGBA<sub>dst</src></code></b>
+            <td>Color currently in the color attachment.
+        <tr>
+            <td><b><code>RGBA<sub>const</src></code></b>
+            <td>The current {{GPURenderPassEncoder/[[blend_constant]]}}.
+        <tr>
+            <td><b><code>RGBA<sub>srcFactor</src></code></b>
+            <td>The source blend factor components, as defined by {{GPUBlendComponent/srcFactor}}.
+        <tr>
+            <td><b><code>RGBA<sub>dstFactor</src></code></b>
+            <td>The destination blend factor components, as defined by {{GPUBlendComponent/dstFactor}}.
+    </tbody>
 </table>
 
 <script type=idl>
@@ -6903,54 +6997,54 @@ enum GPUBlendFactor {
 
 {{GPUBlendFactor}} defines how either a source or destination blend factors is calculated:
 
-<table class="data">
-  <thead>
-    <tr>
-      <th>GPUBlendFactor
-      <th>Blend factor RGBA components
-    </tr>
-  </thead>
-  <tbody dfn-type=enum-value dfn-for=GPUBlendFactor>
-    <tr>
-      <td><dfn>"zero"
-      <td><code>(0, 0, 0, 0)
-    <tr>
-      <td><dfn>"one"
-      <td><code>(1, 1, 1, 1)
-    <tr>
-      <td><dfn>"src"
-      <td><code>(R<sub>src</sub>, G<sub>src</sub>, B<sub>src</sub>, A<sub>src</sub>)
-    <tr>
-      <td><dfn>"one-minus-src"
-      <td><code>(1 - R<sub>src</sub>, 1 - G<sub>src</sub>, 1 - B<sub>src</sub>, 1 - A<sub>src</sub>)
-    <tr>
-      <td><dfn>"src-alpha"
-      <td><code>(A<sub>src</sub>, A<sub>src</sub>, A<sub>src</sub>, A<sub>src</sub>)
-    <tr>
-      <td><dfn>"one-minus-src-alpha"
-      <td><code>(1 - A<sub>src</sub>, 1 - A<sub>src</sub>, 1 - A<sub>src</sub>, 1 - A<sub>src</sub>)
-    <tr>
-      <td><dfn>"dst"
-      <td><code>(R<sub>dst</sub>, G<sub>dst</sub>, B<sub>dst</sub>, A<sub>dst</sub>)
-    <tr>
-      <td><dfn>"one-minus-dst"
-      <td><code>(1 - R<sub>dst</sub>, 1 - G<sub>dst</sub>, 1 - B<sub>dst</sub>, 1 - A<sub>dst</sub>)
-    <tr>
-      <td><dfn>"dst-alpha"
-      <td><code>(A<sub>dst</sub>, A<sub>dst</sub>, A<sub>dst</sub>, A<sub>dst</sub>)
-    <tr>
-      <td><dfn>"one-minus-dst-alpha"
-      <td><code>(1 - A<sub>dst</sub>, 1 - A<sub>dst</sub>, 1 - A<sub>dst</sub>, 1 - A<sub>dst</sub>)
-    <tr>
-      <td><dfn>"src-alpha-saturated"
-      <td><code>(A<sub>src</sub>, A<sub>src</sub>, A<sub>src</sub>, A<sub>src</sub>)
-    <tr>
-      <td><dfn>"constant"
-      <td><code>(R<sub>const</sub>, G<sub>const</sub>, B<sub>const</sub>, A<sub>const</sub>)
-    <tr>
-      <td><dfn>"one-minus-constant"
-      <td><code>(1 - R<sub>const</sub>, 1 - G<sub>const</sub>, 1 - B<sub>const</sub>, 1 - A<sub>const</sub>)
-  </tbody>
+<table class=data>
+    <thead>
+        <tr>
+            <th>GPUBlendFactor
+            <th>Blend factor RGBA components
+        </tr>
+    </thead>
+    <tbody dfn-type=enum-value dfn-for=GPUBlendFactor>
+        <tr>
+            <td><dfn>"zero"</dfn>
+            <td><code>(0, 0, 0, 0)</code>
+        <tr>
+            <td><dfn>"one"</dfn>
+            <td><code>(1, 1, 1, 1)</code>
+        <tr>
+            <td><dfn>"src"</dfn>
+            <td><code>(R<sub>src</sub>, G<sub>src</sub>, B<sub>src</sub>, A<sub>src</sub>)</code>
+        <tr>
+            <td><dfn>"one-minus-src"</dfn>
+            <td><code>(1 - R<sub>src</sub>, 1 - G<sub>src</sub>, 1 - B<sub>src</sub>, 1 - A<sub>src</sub>)</code>
+        <tr>
+            <td><dfn>"src-alpha"</dfn>
+            <td><code>(A<sub>src</sub>, A<sub>src</sub>, A<sub>src</sub>, A<sub>src</sub>)</code>
+        <tr>
+            <td><dfn>"one-minus-src-alpha"</dfn>
+            <td><code>(1 - A<sub>src</sub>, 1 - A<sub>src</sub>, 1 - A<sub>src</sub>, 1 - A<sub>src</sub>)</code>
+        <tr>
+            <td><dfn>"dst"</dfn>
+            <td><code>(R<sub>dst</sub>, G<sub>dst</sub>, B<sub>dst</sub>, A<sub>dst</sub>)</code>
+        <tr>
+            <td><dfn>"one-minus-dst"</dfn>
+            <td><code>(1 - R<sub>dst</sub>, 1 - G<sub>dst</sub>, 1 - B<sub>dst</sub>, 1 - A<sub>dst</sub>)</code>
+        <tr>
+            <td><dfn>"dst-alpha"</dfn>
+            <td><code>(A<sub>dst</sub>, A<sub>dst</sub>, A<sub>dst</sub>, A<sub>dst</sub>)</code>
+        <tr>
+            <td><dfn>"one-minus-dst-alpha"</dfn>
+            <td><code>(1 - A<sub>dst</sub>, 1 - A<sub>dst</sub>, 1 - A<sub>dst</sub>, 1 - A<sub>dst</sub>)</code>
+        <tr>
+            <td><dfn>"src-alpha-saturated"</dfn>
+            <td><code>(A<sub>src</sub>, A<sub>src</sub>, A<sub>src</sub>, A<sub>src</sub>)</code>
+        <tr>
+            <td><dfn>"constant"</dfn>
+            <td><code>(R<sub>const</sub>, G<sub>const</sub>, B<sub>const</sub>, A<sub>const</sub>)</code>
+        <tr>
+            <td><dfn>"one-minus-constant"</dfn>
+            <td><code>(1 - R<sub>const</sub>, 1 - G<sub>const</sub>, 1 - B<sub>const</sub>, 1 - A<sub>const</sub>)</code>
+    </tbody>
 </table>
 
 <script type=idl>
@@ -6965,35 +7059,30 @@ enum GPUBlendOperation {
 
 {{GPUBlendOperation}} defines the algorithm used to combine source and destination blend factors:
 
-<table class="data">
-  <thead>
-    <tr>
-      <th>GPUBlendOperation
-      <th>RGBA Components
-    </tr>
-  </thead>
-  <tbody dfn-type=enum-value dfn-for=GPUBlendOperation>
-    <tr>
-      <td><dfn>"add"
-      <td>
-        <code>RGBA<sub>src</sub> × RGBA<sub>srcFactor</sub> + RGBA<sub>dst</sub> × RGBA<sub>dstFactor</sub>
-    <tr>
-      <td><dfn>"subtract"
-      <td>
-        <code>RGBA<sub>src</sub> × RGBA<sub>srcFactor</sub> - RGBA<sub>dst</sub> × RGBA<sub>dstFactor</sub>
-    <tr>
-      <td><dfn>"reverse-subtract"
-      <td>
-        <code>RGBA<sub>dst</sub> × RGBA<sub>dstFactor</sub> - RGBA<sub>src</sub> × RGBA<sub>srcFactor</sub>
-    <tr>
-      <td><dfn>"min"
-      <td>
-        <code>min(RGBA<sub>src</sub>, RGBA<sub>dst</sub>)
-    <tr>
-      <td><dfn>"max"
-      <td>
-        <code>max(RGBA<sub>src</sub>, RGBA<sub>dst</sub>)
-  </tbody>
+<table class=data>
+    <thead>
+        <tr>
+            <th>GPUBlendOperation
+            <th>RGBA Components
+        </tr>
+    </thead>
+    <tbody dfn-type=enum-value dfn-for=GPUBlendOperation>
+        <tr>
+            <td><dfn>"add"</dfn>
+            <td><code>RGBA<sub>src</sub> &times; RGBA<sub>srcFactor</sub> + RGBA<sub>dst</sub> &times; RGBA<sub>dstFactor</sub></code>
+        <tr>
+            <td><dfn>"subtract"</dfn>
+            <td><code>RGBA<sub>src</sub> &times; RGBA<sub>srcFactor</sub> - RGBA<sub>dst</sub> &times; RGBA<sub>dstFactor</sub></code>
+        <tr>
+            <td><dfn>"reverse-subtract"</dfn>
+            <td><code>RGBA<sub>dst</sub> &times; RGBA<sub>dstFactor</sub> - RGBA<sub>src</sub> &times; RGBA<sub>srcFactor</sub></code>
+        <tr>
+            <td><dfn>"min"</dfn>
+            <td><code>min(RGBA<sub>src</sub>, RGBA<sub>dst</sub>)</code>
+        <tr>
+            <td><dfn>"max"</dfn>
+            <td><code>max(RGBA<sub>src</sub>, RGBA<sub>dst</sub>)</code>
+    </tbody>
 </table>
 
 ### Depth/Stencil State ### {#depth-stencil-state}
@@ -7218,23 +7307,23 @@ creation time. {{GPUPrimitiveState}}s that specify a list primitive
 topology will use the index format passed to {{GPURenderCommandsMixin/setIndexBuffer()}}
 when doing indexed rendering.
 
-<table class="data">
-  <thead>
-    <tr>
-      <th>Index format
-      <th>Byte size
-      <th>Primitive restart value
-  </thead>
-  <tbody dfn-type=enum-value dfn-for=GPUIndexFormat>
-    <tr>
-      <td><dfn>"uint16"
-      <td>2
-      <td>0xFFFF
-    <tr>
-      <td><dfn>"uint32"
-      <td>4
-      <td>0xFFFFFFFF
-  </tbody>
+<table class=data>
+    <thead>
+        <tr>
+            <th>Index format
+            <th>Byte size
+            <th>Primitive restart value
+    </thead>
+    <tbody dfn-type=enum-value dfn-for=GPUIndexFormat>
+        <tr>
+            <td><dfn>"uint16"</dfn>
+            <td>2
+            <td>0xFFFF
+        <tr>
+            <td><dfn>"uint32"</dfn>
+            <td>4
+            <td>0xFFFFFFFF
+    </tbody>
 </table>
 
 #### Vertex Formats #### {#vertex-formats}
@@ -7246,75 +7335,76 @@ bits per component, and [=vertex data type=] for the component.
 Each <dfn dfn>vertex data type</dfn> can map to any [=WGSL scalar type=] of the same base type,
 regardless of the bits per component:
 
-<table class="data">
-  <thead>
-    <tr>
-      <th>Vertex format prefix
-      <th>Vertex data type
-      <th>Compatible WGSL types
-  </thead>
-  <tbody>
-    <tr>
-      <td>`uint`
-      <td>unsigned int
-      <td>`u32`
-    <tr>
-      <td>`sint`
-      <td>signed int
-      <td>`i32`
-    <tr>
-      <td>`unorm`
-      <td>unsigned normalized
-      <td rowspan=3>`f16`, `f32`
-    <tr>
-      <td>`snorm`
-      <td>signed normalized
-    <tr>
-      <td>`float`
-      <td>floating point
-  </tbody>
+<table class=data>
+    <thead>
+        <tr>
+            <th>Vertex format prefix
+            <th>Vertex data type
+            <th>Compatible WGSL types
+    </thead>
+    <tbody>
+        <tr>
+            <td>`uint`
+            <td>unsigned int
+            <td>`u32`
+        <tr>
+            <td>`sint`
+            <td>signed int
+            <td>`i32`
+        <tr>
+            <td>`unorm`
+            <td>unsigned normalized
+            <td rowspan=3>`f16`, `f32`
+        <tr>
+            <td>`snorm`
+            <td>signed normalized
+        <tr>
+            <td>`float`
+            <td>floating point
+    </tbody>
 </table>
 
 The multi-component formats specify the number of components after "x". Mismatches in the number of
 components between the vertex format and shader type are allowed, with components being either
 dropped or filled with default values to compensate.
 
-<div class="example">
-  A vertex attribute with a format of {{GPUVertexFormat/"unorm8x2"}} and byte values `[0x7F, 0xFF]`
-  can be accessed in the shader with the following types:
+<div class=example>
+    A vertex attribute with a format of {{GPUVertexFormat/"unorm8x2"}} and byte values `[0x7F, 0xFF]`
+    can be accessed in the shader with the following types:
 
-  <table class="data">
-    <thead>
-      <tr>
-        <th>Shader type
-        <th>Shader value
-    </thead>
-    <tbody>
-      <tr>
-        <td><code>f16
-        <td><code>0.5h
-      <tr>
-        <td><code>f32
-        <td><code>0.5f
-      <tr>
-        <td><code>vec2&lt;f16&gt;
-        <td><code>vec2(0.5h, 1.0h)
-      <tr>
-        <td><code>vec2&lt;f32&gt;
-        <td><code>vec2(0.5f, 1.0f)
-      <tr>
-        <td><code>vec3&lt;f16&gt;
-        <td><code>vec2(0.5h, 1.0h, 0.0h)
-      <tr>
-        <td><code>vec3&lt;f32&gt;
-        <td><code>vec2(0.5f, 1.0f, 0.0f)
-      <tr>
-        <td><code>vec4&lt;f16&gt;
-        <td><code>vec2(0.5h, 1.0h, 0.0h, 1.0h)
-      <tr>
-        <td><code>vec4&lt;f32&gt;
-        <td><code>vec2(0.5f, 1.0f, 0.0f, 1.0f)
-  </table>
+    <table class=data>
+        <thead>
+            <tr>
+                <th>Shader type
+                <th>Shader value
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>f16</code>
+                <td><code>0.5h</code>
+            <tr>
+                <td><code>f32</code>
+                <td><code>0.5f</code>
+            <tr>
+                <td><code>vec2&lt;f16&gt;</code>
+                <td><code>vec2(0.5h, 1.0h)</code>
+            <tr>
+                <td><code>vec2&lt;f32&gt;</code>
+                <td><code>vec2(0.5f, 1.0f)</code>
+            <tr>
+                <td><code>vec3&lt;f16&gt;</code>
+                <td><code>vec2(0.5h, 1.0h, 0.0h)</code>
+            <tr>
+                <td><code>vec3&lt;f32&gt;</code>
+                <td><code>vec2(0.5f, 1.0f, 0.0f)</code>
+            <tr>
+                <td><code>vec4&lt;f16&gt;</code>
+                <td><code>vec2(0.5h, 1.0h, 0.0h, 1.0h)</code>
+            <tr>
+                <td><code>vec4&lt;f32&gt;</code>
+                <td><code>vec2(0.5f, 1.0f, 0.0f, 1.0f)</code>
+        </tbody>
+    </table>
 </div>
 
 See [[#vertex-processing]] for additional information about how vertex formats are exposed in the
@@ -7355,197 +7445,197 @@ enum GPUVertexFormat {
 };
 </script>
 
-<table class="data">
-  <thead>
-    <tr>
-      <th>Vertex format
-      <th>Data type
-      <th>Components
-      <th>Byte size
-      <th>Example WGSL type
-  </thead>
-  <tbody dfn-type=enum-value dfn-for=GPUVertexFormat>
-    <tr>
-      <td><dfn>"uint8x2"
-      <td>unsigned int
-      <td>2
-      <td>2
-      <td><code>vec2&lt;u32&gt;
-    <tr>
-      <td><dfn>"uint8x4"
-      <td>unsigned int
-      <td>4
-      <td>4
-      <td><code>vec4&lt;u32&gt;
-    <tr>
-      <td><dfn>"sint8x2"
-      <td>signed int
-      <td>2
-      <td>2
-      <td><code>vec2&lt;i32&gt;
-    <tr>
-      <td><dfn>"sint8x4"
-      <td>signed int
-      <td>4
-      <td>4
-      <td><code>vec4&lt;i32&gt;
-    <tr>
-      <td><dfn>"unorm8x2"
-      <td>unsigned normalized
-      <td>2
-      <td>2
-      <td><code>vec2&lt;f32&gt;
-    <tr>
-      <td><dfn>"unorm8x4"
-      <td>unsigned normalized
-      <td>4
-      <td>4
-      <td><code>vec4&lt;f32&gt;
-    <tr>
-      <td><dfn>"snorm8x2"
-      <td>signed normalized
-      <td>2
-      <td>2
-      <td><code>vec2&lt;f32&gt;
-    <tr>
-      <td><dfn>"snorm8x4"
-      <td>signed normalized
-      <td>4
-      <td>4
-      <td><code>vec4&lt;f32&gt;
-    <tr>
-      <td><dfn>"uint16x2"
-      <td>unsigned int
-      <td>2
-      <td>4
-      <td><code>vec2&lt;u32&gt;
-    <tr>
-      <td><dfn>"uint16x4"
-      <td>unsigned int
-      <td>4
-      <td>8
-      <td><code>vec4&lt;u32&gt;
-    <tr>
-      <td><dfn>"sint16x2"
-      <td>signed int
-      <td>2
-      <td>4
-      <td><code>vec2&lt;i32&gt;
-    <tr>
-      <td><dfn>"sint16x4"
-      <td>signed int
-      <td>4
-      <td>8
-      <td><code>vec4&lt;i32&gt;
-    <tr>
-      <td><dfn>"unorm16x2"
-      <td>unsigned normalized
-      <td>2
-      <td>4
-      <td><code>vec2&lt;f32&gt;
-    <tr>
-      <td><dfn>"unorm16x4"
-      <td>unsigned normalized
-      <td>4
-      <td>8
-      <td><code>vec4&lt;f32&gt;
-    <tr>
-      <td><dfn>"snorm16x2"
-      <td>signed normalized
-      <td>2
-      <td>4
-      <td><code>vec2&lt;f32&gt;
-    <tr>
-      <td><dfn>"snorm16x4"
-      <td>signed normalized
-      <td>4
-      <td>8
-      <td><code>vec4&lt;f32&gt;
-    <tr>
-      <td><dfn>"float16x2"
-      <td>float
-      <td>2
-      <td>4
-      <td><code>vec2&lt;f16&gt;
-    <tr>
-      <td><dfn>"float16x4"
-      <td>float
-      <td>4
-      <td>8
-      <td><code>vec4&lt;f16&gt;
-    <tr>
-      <td><dfn>"float32"
-      <td>float
-      <td>1
-      <td>4
-      <td><code>f32
-    <tr>
-      <td><dfn>"float32x2"
-      <td>float
-      <td>2
-      <td>8
-      <td><code>vec2&lt;f32&gt;
-    <tr>
-      <td><dfn>"float32x3"
-      <td>float
-      <td>3
-      <td>12
-      <td><code>vec3&lt;f32&gt;
-    <tr>
-      <td><dfn>"float32x4"
-      <td>float
-      <td>4
-      <td>16
-      <td><code>vec4&lt;f32&gt;
-    <tr>
-      <td><dfn>"uint32"
-      <td>unsigned int
-      <td>1
-      <td>4
-      <td><code>u32
-    <tr>
-      <td><dfn>"uint32x2"
-      <td>unsigned int
-      <td>2
-      <td>8
-      <td><code>vec2&lt;u32&gt;
-    <tr>
-      <td><dfn>"uint32x3"
-      <td>unsigned int
-      <td>3
-      <td>12
-      <td><code>vec3&lt;u32&gt;
-    <tr>
-      <td><dfn>"uint32x4"
-      <td>unsigned int
-      <td>4
-      <td>16
-      <td><code>vec4&lt;u32&gt;
-    <tr>
-      <td><dfn>"sint32"
-      <td>signed int
-      <td>1
-      <td>4
-      <td><code>i32
-    <tr>
-      <td><dfn>"sint32x2"
-      <td>signed int
-      <td>2
-      <td>8
-      <td><code>vec2&lt;i32&gt;
-    <tr>
-      <td><dfn>"sint32x3"
-      <td>signed int
-      <td>3
-      <td>12
-      <td><code>vec3&lt;i32&gt;
-    <tr>
-      <td><dfn>"sint32x4"
-      <td>signed int
-      <td>4
-      <td>16
-      <td><code>vec4&lt;i32&gt;
-  </tbody>
+<table class=data>
+    <thead>
+        <tr>
+            <th>Vertex format
+            <th>Data type
+            <th>Components
+            <th>Byte size
+            <th>Example WGSL type
+    </thead>
+    <tbody dfn-type=enum-value dfn-for=GPUVertexFormat>
+        <tr>
+            <td><dfn>"uint8x2"</dfn>
+            <td>unsigned int
+            <td>2
+            <td>2
+            <td><code>vec2&lt;u32&gt;</code>
+        <tr>
+            <td><dfn>"uint8x4"</dfn>
+            <td>unsigned int
+            <td>4
+            <td>4
+            <td><code>vec4&lt;u32&gt;</code>
+        <tr>
+            <td><dfn>"sint8x2"</dfn>
+            <td>signed int
+            <td>2
+            <td>2
+            <td><code>vec2&lt;i32&gt;</code>
+        <tr>
+            <td><dfn>"sint8x4"</dfn>
+            <td>signed int
+            <td>4
+            <td>4
+            <td><code>vec4&lt;i32&gt;</code>
+        <tr>
+            <td><dfn>"unorm8x2"</dfn>
+            <td>unsigned normalized
+            <td>2
+            <td>2
+            <td><code>vec2&lt;f32&gt;</code>
+        <tr>
+            <td><dfn>"unorm8x4"</dfn>
+            <td>unsigned normalized
+            <td>4
+            <td>4
+            <td><code>vec4&lt;f32&gt;</code>
+        <tr>
+            <td><dfn>"snorm8x2"</dfn>
+            <td>signed normalized
+            <td>2
+            <td>2
+            <td><code>vec2&lt;f32&gt;</code>
+        <tr>
+            <td><dfn>"snorm8x4"</dfn>
+            <td>signed normalized
+            <td>4
+            <td>4
+            <td><code>vec4&lt;f32&gt;</code>
+        <tr>
+            <td><dfn>"uint16x2"</dfn>
+            <td>unsigned int
+            <td>2
+            <td>4
+            <td><code>vec2&lt;u32&gt;</code>
+        <tr>
+            <td><dfn>"uint16x4"</dfn>
+            <td>unsigned int
+            <td>4
+            <td>8
+            <td><code>vec4&lt;u32&gt;</code>
+        <tr>
+            <td><dfn>"sint16x2"</dfn>
+            <td>signed int
+            <td>2
+            <td>4
+            <td><code>vec2&lt;i32&gt;</code>
+        <tr>
+            <td><dfn>"sint16x4"</dfn>
+            <td>signed int
+            <td>4
+            <td>8
+            <td><code>vec4&lt;i32&gt;</code>
+        <tr>
+            <td><dfn>"unorm16x2"</dfn>
+            <td>unsigned normalized
+            <td>2
+            <td>4
+            <td><code>vec2&lt;f32&gt;</code>
+        <tr>
+            <td><dfn>"unorm16x4"</dfn>
+            <td>unsigned normalized
+            <td>4
+            <td>8
+            <td><code>vec4&lt;f32&gt;</code>
+        <tr>
+            <td><dfn>"snorm16x2"</dfn>
+            <td>signed normalized
+            <td>2
+            <td>4
+            <td><code>vec2&lt;f32&gt;</code>
+        <tr>
+            <td><dfn>"snorm16x4"</dfn>
+            <td>signed normalized
+            <td>4
+            <td>8
+            <td><code>vec4&lt;f32&gt;</code>
+        <tr>
+            <td><dfn>"float16x2"</dfn>
+            <td>float
+            <td>2
+            <td>4
+            <td><code>vec2&lt;f16&gt;</code>
+        <tr>
+            <td><dfn>"float16x4"</dfn>
+            <td>float
+            <td>4
+            <td>8
+            <td><code>vec4&lt;f16&gt;</code>
+        <tr>
+            <td><dfn>"float32"</dfn>
+            <td>float
+            <td>1
+            <td>4
+            <td><code>f32</code>
+        <tr>
+            <td><dfn>"float32x2"</dfn>
+            <td>float
+            <td>2
+            <td>8
+            <td><code>vec2&lt;f32&gt;</code>
+        <tr>
+            <td><dfn>"float32x3"</dfn>
+            <td>float
+            <td>3
+            <td>12
+            <td><code>vec3&lt;f32&gt;</code>
+        <tr>
+            <td><dfn>"float32x4"</dfn>
+            <td>float
+            <td>4
+            <td>16
+            <td><code>vec4&lt;f32&gt;</code>
+        <tr>
+            <td><dfn>"uint32"</dfn>
+            <td>unsigned int
+            <td>1
+            <td>4
+            <td><code>u32</code>
+        <tr>
+            <td><dfn>"uint32x2"</dfn>
+            <td>unsigned int
+            <td>2
+            <td>8
+            <td><code>vec2&lt;u32&gt;</code>
+        <tr>
+            <td><dfn>"uint32x3"</dfn>
+            <td>unsigned int
+            <td>3
+            <td>12
+            <td><code>vec3&lt;u32&gt;</code>
+        <tr>
+            <td><dfn>"uint32x4"</dfn>
+            <td>unsigned int
+            <td>4
+            <td>16
+            <td><code>vec4&lt;u32&gt;</code>
+        <tr>
+            <td><dfn>"sint32"</dfn>
+            <td>signed int
+            <td>1
+            <td>4
+            <td><code>i32</code>
+        <tr>
+            <td><dfn>"sint32x2"</dfn>
+            <td>signed int
+            <td>2
+            <td>8
+            <td><code>vec2&lt;i32&gt;</code>
+        <tr>
+            <td><dfn>"sint32x3"</dfn>
+            <td>signed int
+            <td>3
+            <td>12
+            <td><code>vec3&lt;i32&gt;</code>
+        <tr>
+            <td><dfn>"sint32x4"</dfn>
+            <td>signed int
+            <td>4
+            <td>16
+            <td><code>vec4&lt;i32&gt;</code>
+    </tbody>
 </table>
 
 <script type=idl>
@@ -7637,63 +7727,69 @@ dictionary GPUVertexAttribute {
 
 <div algorithm>
     <dfn abstract-op>validating GPUVertexBufferLayout</dfn>(device, descriptor, vertexStage)
+
     **Arguments:**
-        - {{GPUDevice}} |device|
-        - {{GPUVertexBufferLayout}} |descriptor|
-        - {{GPUProgrammableStage}} |vertexStage|
+
+    - {{GPUDevice}} |device|
+    - {{GPUVertexBufferLayout}} |descriptor|
+    - {{GPUProgrammableStage}} |vertexStage|
 
     Return `true`, if and only if, all of the following conditions are satisfied:
 
-        - |descriptor|.{{GPUVertexBufferLayout/arrayStride}} &le;
-            |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBufferArrayStride}}.
-        - |descriptor|.{{GPUVertexBufferLayout/arrayStride}} is a multiple of 4.
-        - For each attribute |attrib| in the list |descriptor|.{{GPUVertexBufferLayout/attributes}}:
-            - If |descriptor|.{{GPUVertexBufferLayout/arrayStride}} is zero:
-                - |attrib|.{{GPUVertexAttribute/offset}} + sizeof(|attrib|.{{GPUVertexAttribute/format}}) &le;
-                    |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBufferArrayStride}}.
+    - |descriptor|.{{GPUVertexBufferLayout/arrayStride}} &le;
+        |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBufferArrayStride}}.
+    - |descriptor|.{{GPUVertexBufferLayout/arrayStride}} is a multiple of 4.
+    - For each attribute |attrib| in the list |descriptor|.{{GPUVertexBufferLayout/attributes}}:
+        - If |descriptor|.{{GPUVertexBufferLayout/arrayStride}} is zero:
+            - |attrib|.{{GPUVertexAttribute/offset}} + sizeof(|attrib|.{{GPUVertexAttribute/format}}) &le;
+                |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBufferArrayStride}}.
 
-                Otherwise:
-                - |attrib|.{{GPUVertexAttribute/offset}} + sizeof(|attrib|.{{GPUVertexAttribute/format}}) &le;
-                    |descriptor|.{{GPUVertexBufferLayout/arrayStride}}.
-            - |attrib|.{{GPUVertexAttribute/offset}} is a multiple of the minimum of 4 and
-                sizeof(|attrib|.{{GPUVertexAttribute/format}}).
-            - |attrib|.{{GPUVertexAttribute/shaderLocation}} is less than
-                |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexAttributes}}.
-        - For every vertex attribute in the shader reflection of |vertexStage|.{{GPUProgrammableStage/module}}
-            that is a [=pipeline input=] of |vertexStage|.{{GPUProgrammableStage/entryPoint}},
-            there is a corresponding |attrib| element of |descriptor|.{{GPUVertexBufferLayout/attributes}} for which
-            all of the following are true:
-            - The shader format is compatible with |attrib|.{{GPUVertexAttribute/format}}'s [=vertex data type=]:
-                <dl class="switch">
-                    : "unorm", "snorm", or "float"
-                    :: shader format must be `f32` or `vecN<f32>`.
-                    : "uint"
-                    :: shader format must be `u32` or `vecN<u32>`.
-                    : "sint"
-                    :: shader format must be `i32` or `vecN<i32>`.
-                </dl>
-            - The shader location is |attrib|.{{GPUVertexAttribute/shaderLocation}}.
+            Otherwise:
+
+            - |attrib|.{{GPUVertexAttribute/offset}} + sizeof(|attrib|.{{GPUVertexAttribute/format}}) &le;
+                |descriptor|.{{GPUVertexBufferLayout/arrayStride}}.
+        - |attrib|.{{GPUVertexAttribute/offset}} is a multiple of the minimum of 4 and
+            sizeof(|attrib|.{{GPUVertexAttribute/format}}).
+        - |attrib|.{{GPUVertexAttribute/shaderLocation}} is less than
+            |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexAttributes}}.
+    - For every vertex attribute in the shader reflection of |vertexStage|.{{GPUProgrammableStage/module}}
+        that is a [=pipeline input=] of |vertexStage|.{{GPUProgrammableStage/entryPoint}},
+        there is a corresponding |attrib| element of |descriptor|.{{GPUVertexBufferLayout/attributes}} for which
+        all of the following are true:
+        - The shader format is compatible with |attrib|.{{GPUVertexAttribute/format}}'s [=vertex data type=]:
+
+            <dl class=switch>
+                : "unorm", "snorm", or "float"
+                :: shader format must be `f32` or `vecN<f32>`.
+                : "uint"
+                :: shader format must be `u32` or `vecN<u32>`.
+                : "sint"
+                :: shader format must be `i32` or `vecN<i32>`.
+            </dl>
+        - The shader location is |attrib|.{{GPUVertexAttribute/shaderLocation}}.
 </div>
 
 <div algorithm>
     <dfn abstract-op>validating GPUVertexState</dfn>(device, descriptor)
+
     **Arguments:**
-        - {{GPUDevice}} |device|
-        - {{GPUVertexState}} |descriptor|
+
+    - {{GPUDevice}} |device|
+    - {{GPUVertexState}} |descriptor|
 
     Return `true`, if and only if, all of the following conditions are satisfied:
 
-        - |descriptor|.{{GPUVertexState/buffers}}.length is less than or equal to
-            |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBuffers}}.
-        - Each |vertexBuffer| layout descriptor in the list |descriptor|.{{GPUVertexState/buffers}}
-            passes [$validating GPUVertexBufferLayout$](|device|, |vertexBuffer|, |descriptor|)
-        - The sum of |vertexBuffer|.{{GPUVertexBufferLayout/attributes}}.length,
-            over every |vertexBuffer| in |descriptor|.{{GPUVertexState/buffers}},
-            is less than or equal to
-            |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexAttributes}}.
-        - Each |attrib| in the union of all {{GPUVertexAttribute}}
-            across |descriptor|.{{GPUVertexState/buffers}} has a distinct
-            |attrib|.{{GPUVertexAttribute/shaderLocation}} value.
+    - |descriptor|.{{GPUVertexState/buffers}}.length is less than or equal to
+        |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBuffers}}.
+    - Each |vertexBuffer| layout descriptor in the list |descriptor|.{{GPUVertexState/buffers}}
+        passes [$validating GPUVertexBufferLayout$](|device|, |vertexBuffer|, |descriptor|)
+    - The sum of |vertexBuffer|.{{GPUVertexBufferLayout/attributes}}.length,
+        over every |vertexBuffer| in |descriptor|.{{GPUVertexState/buffers}},
+        is less than or equal to
+        |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexAttributes}}.
+    - Each |attrib| in the union of all {{GPUVertexAttribute}}
+        across |descriptor|.{{GPUVertexState/buffers}} has a distinct
+        |attrib|.{{GPUVertexAttribute/shaderLocation}} value.
 </div>
 
 # Command Buffers # {#command-buffers}
@@ -7713,7 +7809,7 @@ GPUCommandBuffer includes GPUObjectBase;
 
 {{GPUCommandBuffer}} has the following internal slots:
 
-<dl dfn-type=attribute dfn-for="GPUCommandBuffer">
+<dl dfn-type=attribute dfn-for=GPUCommandBuffer>
     : <dfn>\[[command_list]]</dfn>, of type [=list=]&lt;[=GPU command=]&gt;
     ::
         A [=list=] of [=GPU commands=] to be executed on the [=Queue timeline=] when this command
@@ -7779,6 +7875,7 @@ The <dfn dfn>encoder state</dfn> may be one of the following:
     To <dfn abstract-op>Validate the encoder state</dfn> of {{GPUCommandsMixin}} |encoder|:
 
     If |encoder|.{{GPUCommandsMixin/[[state]]}} is:
+
     <dl class=switch>
         : "[=encoder state/open=]"
         :: Return `true`.
@@ -7858,6 +7955,7 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
             **Called on:** {{GPUDevice}} this.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUDevice/createCommandEncoder(descriptor)">
                 descriptor: Description of the {{GPUCommandEncoder}} to create.
             </pre>
@@ -7866,9 +7964,11 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 
             1. Let |e| be a new {{GPUCommandEncoder}} object.
             1. Issue the following steps on the [=Device timeline=] of |this|:
+
                 <div class=device-timeline>
                     1. If any of the following conditions are unsatisfied
                         [$generate a validation error$], make |e| [=invalid=], and stop.
+
                         <div class=validusage>
                             - |this| is [=valid=].
                         </div>
@@ -7880,10 +7980,11 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
         </div>
 </dl>
 
-<div class="example">
+<div class=example>
     Creating a {{GPUCommandEncoder}}, encoding a command to clear a buffer, finishing the
     encoder to get a {{GPUCommandBuffer}}, then submitting it to the {{GPUQueue}}.
-    <pre highlight="js">
+
+    <pre highlight=js>
         const commandEncoder = gpuDevice.createCommandEncoder();
         commandEncoder.clearBuffer(buffer);
         const commandBuffer = commandEncoder.finish();
@@ -7902,6 +8003,7 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
             **Called on:** {{GPUCommandEncoder}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUCommandEncoder/beginRenderPass(descriptor)">
                 |descriptor|: Description of the {{GPURenderPassEncoder}} to create.
             </pre>
@@ -7910,9 +8012,11 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 
             1. Let |pass| be a new {{GPURenderPassEncoder}} object.
             1. Issue the following steps on the [=Device timeline=] of |this|:
+
                 <div class=device-timeline>
                     1. If any of the following conditions are unsatisfied
                         [$generate a validation error$], make |pass| [=invalid=], and stop.
+
                         <div class=validusage>
                             - |this|.{{GPUCommandsMixin/[[state]]}} is "[=encoder state/open=]".
                             - |descriptor| meets the
@@ -7968,6 +8072,7 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
             **Called on:** {{GPUCommandEncoder}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUCommandEncoder/beginComputePass(descriptor)">
                 descriptor:
             </pre>
@@ -7976,9 +8081,11 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 
             1. Let |pass| be a new {{GPUComputePassEncoder}} object.
             1. Issue the following steps on the [=Device timeline=] of |this|:
+
                 <div class=device-timeline>
                     1. If any of the following conditions are unsatisfied
                         [$generate a validation error$], make |pass| [=invalid=], and stop.
+
                         <div class=validusage>
                             - |this|.{{GPUCommandsMixin/[[state]]}} is "[=encoder state/open=]".
                             - |descriptor|.{{GPUComputePassDescriptor/timestampWrites}} is empty, or
@@ -8020,8 +8127,8 @@ A {{GPUImageDataLayout}} is a layout of <dfn dfn>images</dfn> within some linear
 It's used when copying data between a [=texture=] and a [=buffer=], or when scheduling a
 write into a [=texture=] from the {{GPUQueue}}.
 
-  - For {{GPUTextureDimension/2d}} textures, data is copied between one or multiple contiguous [=images=] and [=array layers=].
-  - For {{GPUTextureDimension/3d}} textures, data is copied between one or multiple contiguous [=images=] and depth [=slices=].
+- For {{GPUTextureDimension/2d}} textures, data is copied between one or multiple contiguous [=images=] and [=array layers=].
+- For {{GPUTextureDimension/3d}} textures, data is copied between one or multiple contiguous [=images=] and depth [=slices=].
 
 Issue: Define images more precisely. In particular, define them as being comprised of [=texel blocks=].
 
@@ -8078,17 +8185,17 @@ dictionary GPUImageCopyBuffer : GPUImageDataLayout {
 </dl>
 
 <div algorithm class=validusage>
-<dfn abstract-op>validating GPUImageCopyBuffer</dfn>
+    <dfn abstract-op>validating GPUImageCopyBuffer</dfn>
 
-  **Arguments:**
+    **Arguments:**
+
     - {{GPUImageCopyBuffer}} |imageCopyBuffer|
 
-  **Returns:** {{boolean}}
+    **Returns:** {{boolean}}
 
-  Return `true` if and only if all of the following conditions are satisfied:
-    - |imageCopyBuffer|.{{GPUImageCopyBuffer/buffer}} must be a [=valid=] {{GPUBuffer}}.
-    - |imageCopyBuffer|.{{GPUImageDataLayout/bytesPerRow}} must be a multiple of 256.
-
+    1. Return `true` if and only if all of the following conditions are satisfied:
+        - |imageCopyBuffer|.{{GPUImageCopyBuffer/buffer}} must be a [=valid=] {{GPUBuffer}}.
+        - |imageCopyBuffer|.{{GPUImageDataLayout/bytesPerRow}} must be a multiple of 256.
 </div>
 
 ### <dfn dictionary>GPUImageCopyTexture</dfn> ### {#gpu-image-copy-texture}
@@ -8126,29 +8233,28 @@ dictionary GPUImageCopyTexture {
 </dl>
 
 <div algorithm class=validusage>
-<dfn abstract-op>validating GPUImageCopyTexture</dfn>
+    <dfn abstract-op>validating GPUImageCopyTexture</dfn>
 
-  **Arguments:**
+    **Arguments:**
+
     - {{GPUImageCopyTexture}} |imageCopyTexture|
     - {{GPUExtent3D}} |copySize|
 
-  **Returns:** {{boolean}}
+    **Returns:** {{boolean}}
 
-  Let:
-  - |blockWidth| be the [=texel block width=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}}.
-  - |blockHeight| be the [=texel block height=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}}.
+    1. Let |blockWidth| be the [=texel block width=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}}.
+    1. Let |blockHeight| be the [=texel block height=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}}.
 
-  Return `true` if and only if all of the following conditions apply:
-  - |imageCopyTexture|.{{GPUImageCopyTexture/texture}} must be a [=valid=] {{GPUTexture}}.
-  - |imageCopyTexture|.{{GPUImageCopyTexture/mipLevel}} must be less than the {{GPUTexture/mipLevelCount}} of
-    |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.
-  - |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/x=] must be a multiple of |blockWidth|.
-  - |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/y=] must be a multiple of |blockHeight|.
-  - The [=imageCopyTexture subresource size=] of |imageCopyTexture| is equal to |copySize| if either of
-      the following conditions is true:
-        - |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}} is a depth-stencil format.
-        - |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/sampleCount}} is greater than 1.
-
+    1. Return `true` if and only if all of the following conditions apply:
+        - |imageCopyTexture|.{{GPUImageCopyTexture/texture}} must be a [=valid=] {{GPUTexture}}.
+        - |imageCopyTexture|.{{GPUImageCopyTexture/mipLevel}} must be less than the {{GPUTexture/mipLevelCount}} of
+            |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.
+        - |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/x=] must be a multiple of |blockWidth|.
+        - |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/y=] must be a multiple of |blockHeight|.
+        - The [=imageCopyTexture subresource size=] of |imageCopyTexture| is equal to |copySize| if either of
+            the following conditions is true:
+            - |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}} is a depth-stencil format.
+            - |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/sampleCount}} is greater than 1.
 </div>
 
 Issue(gpuweb/gpuweb#69): Define the copies with {{GPUTextureDimension/1d}} and {{GPUTextureDimension/3d}} textures.
@@ -8246,6 +8352,7 @@ dictionary GPUImageCopyExternalImage {
             **Called on:** {{GPUCommandEncoder}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUCommandEncoder/copyBufferToBuffer(source, sourceOffset, destination, destinationOffset, size)">
                 |source|: The {{GPUBuffer}} to copy from.
                 |sourceOffset|: Offset in bytes into |source| to begin copying from.
@@ -8257,9 +8364,11 @@ dictionary GPUImageCopyExternalImage {
             **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+
                     <div class=validusage>
                         - |source| is [$valid to use with$] |this|.
                         - |destination| is [$valid to use with$] |this|.
@@ -8293,6 +8402,7 @@ dictionary GPUImageCopyExternalImage {
             **Called on:** {{GPUCommandEncoder}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUCommandEncoder/clearBuffer(buffer, offset, size)">
                 |buffer|: The {{GPUBuffer}} to clear.
                 |offset|: Offset in bytes into |buffer| where the sub-region to clear begins.
@@ -8302,10 +8412,12 @@ dictionary GPUImageCopyExternalImage {
             **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If |size| is missing, set |size| to `max(0, |buffer|.{{GPUBuffer/size}} - |offset|)`.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+
                     <div class=validusage>
                         - |buffer| is [$valid to use with$] |this|.
                         - |buffer|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/COPY_DST}}.
@@ -8332,20 +8444,19 @@ Issue: Does the term "image copy" include copyTextureToTexture?
 {{GPUCommandEncoder/copyTextureToTexture()}}.
 
 <div algorithm="imageCopyTexture subresource size">
+    <dfn dfn>imageCopyTexture subresource size</dfn>
 
-<dfn dfn>imageCopyTexture subresource size</dfn>
+    **Arguments:**
 
-  **Arguments:**
     - {{GPUImageCopyTexture}} |imageCopyTexture|
 
-  **Returns:** {{GPUExtent3D}}
+    **Returns:** {{GPUExtent3D}}
 
-  The [=imageCopyTexture subresource size=] of |imageCopyTexture| is calculated as follows:
+    The [=imageCopyTexture subresource size=] of |imageCopyTexture| is calculated as follows:
 
-  Its [=Extent3D/width=], [=Extent3D/height=] and [=Extent3D/depthOrArrayLayers=] are the width, height, and depth, respectively,
-  of the [=physical miplevel-specific texture extent=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}} [=subresource=] at [=mipmap level=]
-  |imageCopyTexture|.{{GPUImageCopyTexture/mipLevel}}.
-
+    Its [=Extent3D/width=], [=Extent3D/height=] and [=Extent3D/depthOrArrayLayers=] are the width, height, and depth, respectively,
+    of the [=physical miplevel-specific texture extent=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}} [=subresource=] at [=mipmap level=]
+    |imageCopyTexture|.{{GPUImageCopyTexture/mipLevel}}.
 </div>
 
 Issue: define this as an algorithm with (texture, mipmapLevel) parameters and use the call syntax instead of referring to the definition by label.
@@ -8354,6 +8465,7 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
     <dfn abstract-op>validating linear texture data</dfn>(layout, byteSize, format, copyExtent)
 
     **Arguments:**
+
     : {{GPUImageDataLayout}} |layout|
     :: Layout of the linear texture data.
     : {{GPUSize64}} |byteSize|
@@ -8407,6 +8519,7 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
             |bytesInLastRow| to |requiredBytesInCopy|.
 
     1. Fail if the following conditions are not satisfied:
+
         <div class=validusage>
             - |layout|.{{GPUImageDataLayout/offset}} + |requiredBytesInCopy| &le; |byteSize|.
         </div>
@@ -8416,6 +8529,7 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
     <dfn dfn>validating texture copy range</dfn>
 
     **Arguments:**
+
     : {{GPUImageCopyTexture}} |imageCopyTexture|
     :: The texture subresource being copied into and copy origin.
     : {{GPUExtent3D}} |copySize|
@@ -8424,15 +8538,13 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
     1. Let |blockWidth| be the [=texel block width=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}}.
     1. Let |blockHeight| be the [=texel block height=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}}.
     1. Let |subresourceSize| be the [=imageCopyTexture subresource size=] of |imageCopyTexture|.
-
     1. Return whether all the conditions below are satisfied:
 
-      - (|imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/x=] + |copySize|.[=Extent3D/width=]) &le; |subresourceSize|.[=Extent3D/width=]
-      - (|imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/y=] + |copySize|.[=Extent3D/height=]) &le; |subresourceSize|.[=Extent3D/height=]
-      - (|imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/z=] + |copySize|.[=Extent3D/depthOrArrayLayers=]) &le; |subresourceSize|.[=Extent3D/depthOrArrayLayers=]
-      - |copySize|.[=Extent3D/width=] must be a multiple of |blockWidth|.
-      - |copySize|.[=Extent3D/height=] must be a multiple of |blockHeight|.
-
+        - (|imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/x=] + |copySize|.[=Extent3D/width=]) &le; |subresourceSize|.[=Extent3D/width=]
+        - (|imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/y=] + |copySize|.[=Extent3D/height=]) &le; |subresourceSize|.[=Extent3D/height=]
+        - (|imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/z=] + |copySize|.[=Extent3D/depthOrArrayLayers=]) &le; |subresourceSize|.[=Extent3D/depthOrArrayLayers=]
+        - |copySize|.[=Extent3D/width=] must be a multiple of |blockWidth|.
+        - |copySize|.[=Extent3D/height=] must be a multiple of |blockHeight|.
 </div>
 
 <dl dfn-type=method dfn-for=GPUCommandEncoder>
@@ -8445,6 +8557,7 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
             **Called on:** {{GPUCommandEncoder}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUCommandEncoder/copyBufferToTexture(source, destination, copySize)">
                 |source|: Combined with |copySize|, defines the region of the source buffer.
                 |destination|: Combined with |copySize|, defines the region of the destination [=texture subresource=].
@@ -8454,9 +8567,11 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
             **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+
                     <div class=validusage>
                         - Let |dstTexture| be |destination|.{{GPUImageCopyTexture/texture}}.
                         - [$validating GPUImageCopyBuffer$](|source|) returns `true`.
@@ -8493,6 +8608,7 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
             **Called on:** {{GPUCommandEncoder}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUCommandEncoder/copyTextureToBuffer(source, destination, copySize)">
                 |source|: Combined with |copySize|, defines the region of the source [=texture subresources=].
                 |destination|: Combined with |copySize|, defines the region of the destination buffer.
@@ -8502,9 +8618,11 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
             **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+
                     <div class=validusage>
                         - Let |srcTexture| be |source|.{{GPUImageCopyTexture/texture}}.
                         - [$validating GPUImageCopyTexture$](|source|, |copySize|) returns `true`.
@@ -8543,6 +8661,7 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
             **Called on:** {{GPUCommandEncoder}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUCommandEncoder/copyTextureToTexture(source, destination, copySize)">
                 |source|: Combined with |copySize|, defines the region of the source [=texture subresources=].
                 |destination|: Combined with |copySize|, defines the region of the destination [=texture subresources=].
@@ -8552,9 +8671,11 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
             **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+
                     <div class=validusage>
                         - Let |srcTexture| be |source|.{{GPUImageCopyTexture/texture}}.
                         - Let |dstTexture| be |destination|.{{GPUImageCopyTexture/texture}}.
@@ -8592,15 +8713,18 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
     The <dfn abstract-op>set of subresources for texture copy</dfn>(|imageCopyTexture|, |copySize|)
     is the set containing:
 
-      - If |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/dimension}}
+    - If |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/dimension}}
         is {{GPUTextureDimension/"2d"}}:
-          - For each |arrayLayer| of the |copySize|.[=Extent3D/depthOrArrayLayers=] [=array layers=]
+
+        - For each |arrayLayer| of the |copySize|.[=Extent3D/depthOrArrayLayers=] [=array layers=]
             starting at |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/z=]:
-              - The [=subresource=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}} at
+            - The [=subresource=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}} at
                 [=mipmap level=] |imageCopyTexture|.{{GPUImageCopyTexture/mipLevel}} and
                 [=array layer=] |arrayLayer|.
-      - Otherwise:
-          - The [=subresource=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}} at
+
+        Otherwise:
+
+        - The [=subresource=] of |imageCopyTexture|.{{GPUImageCopyTexture/texture}} at
             [=mipmap level=] |imageCopyTexture|.{{GPUImageCopyTexture/mipLevel}}.
 </div>
 
@@ -8615,6 +8739,7 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
             **Called on:** {{GPUCommandEncoder}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUCommandEncoder/writeTimestamp(querySet, queryIndex)">
                 |querySet|: The query set that will store the timestamp values.
                 |queryIndex|: The index of the query in the query set.
@@ -8625,9 +8750,11 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
             1. If |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} does not [=list/contain=]
                 {{GPUFeatureName/"timestamp-query"}}, throw a {{TypeError}}.
             1. Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+
                 <div class=device-timeline>
                     1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                     1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+
                         <div class=validusage>
                             - |querySet| is [$valid to use with$] |this|.
                             - |querySet|.{{GPUQuerySet/type}} is {{GPUQueryType/"timestamp"}}.
@@ -8646,6 +8773,7 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
             **Called on:** {{GPUCommandEncoder}} this.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUCommandEncoder/resolveQuerySet(querySet, firstQuery, queryCount, destination, destinationOffset)">
                 querySet:
                 firstQuery:
@@ -8657,9 +8785,11 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
             **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+
                     <div class=validusage>
                         - |querySet| is [$valid to use with$] |this|.
                         - |destination| is [$valid to use with$] |this|.
@@ -8690,6 +8820,7 @@ command encoder can no longer be used.
             **Called on:** {{GPUCommandEncoder}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUCommandEncoder/finish(descriptor)">
                 descriptor:
             </pre>
@@ -8698,8 +8829,10 @@ command encoder can no longer be used.
 
             1. Let |commandBuffer| be a new {{GPUCommandBuffer}}.
             1. Issue the following steps on the [=Device timeline=] of |this|:
+
                 <div class=device-timeline>
                     1. Let |validationSucceeded| be `true` if all of the following requirements are met, and `false` otherwise.
+
                         <div class=validusage>
                             - |this| must be [=valid=].
                             - |this|.{{GPUCommandsMixin/[[state]]}} must be "[=encoder state/open=]".
@@ -8723,12 +8856,12 @@ command encoder can no longer be used.
 <script type=idl>
 interface mixin GPUBindingCommandsMixin {
     undefined setBindGroup(GPUIndex32 index, GPUBindGroup bindGroup,
-                      optional sequence<GPUBufferDynamicOffset> dynamicOffsets = []);
+        optional sequence<GPUBufferDynamicOffset> dynamicOffsets = []);
 
     undefined setBindGroup(GPUIndex32 index, GPUBindGroup bindGroup,
-                      Uint32Array dynamicOffsetsData,
-                      GPUSize64 dynamicOffsetsDataStart,
-                      GPUSize32 dynamicOffsetsDataLength);
+        Uint32Array dynamicOffsetsData,
+        GPUSize64 dynamicOffsetsDataStart,
+        GPUSize32 dynamicOffsetsDataLength);
 };
 </script>
 
@@ -8738,7 +8871,7 @@ It must only be included by interfaces which also include those mixins.
 
 {{GPUBindingCommandsMixin}} has the following internal slots:
 
-<dl dfn-type=attribute dfn-for="GPUBindingCommandsMixin">
+<dl dfn-type=attribute dfn-for=GPUBindingCommandsMixin>
     : <dfn>\[[bind_groups]]</dfn>, of type [=ordered map=]&lt;{{GPUIndex32}}, {{GPUBindGroup}}&gt;
     ::
         The current {{GPUBindGroup}} for each index, initially empty.
@@ -8759,6 +8892,7 @@ It must only be included by interfaces which also include those mixins.
             **Called on:** {{GPUBindingCommandsMixin}} this.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUBindingCommandsMixin/setBindGroup(index, bindGroup, dynamicOffsets)">
                 |index|: The index to set the bind group at.
                 |bindGroup|: Bind group to use for subsequent render or compute commands.
@@ -8768,6 +8902,7 @@ It must only be included by interfaces which also include those mixins.
                 explicitly pointing at the 3-arg variant. See
                 https://github.com/plinss/widlparser/issues/56 and
                 https://github.com/tabatkins/bikeshed/issues/1740 -->
+
                 <!--|dynamicOffsets|: Array containing buffer offsets in bytes for each entry in
                     |bindGroup| marked as {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}}.-->
             </pre>
@@ -8784,9 +8919,11 @@ It must only be included by interfaces which also include those mixins.
             {{GPUBindGroupLayoutEntry}}.{{GPUBindGroupLayoutEntry/binding}}.
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+
                     <div class=validusage>
                         - |bindGroup| is [$valid to use with$] |this|.
                         - |index| &lt; |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroups}}.
@@ -8825,6 +8962,7 @@ It must only be included by interfaces which also include those mixins.
             **Called on:** {{GPUBindingCommandsMixin}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUBindingCommandsMixin/setBindGroup(index, bindGroup, dynamicOffsetsData, dynamicOffsetsDataStart, dynamicOffsetsDataLength)">
                 |index|: The index to set the bind group at.
                 |bindGroup|: Bind group to use for subsequent render or compute commands.
@@ -8838,6 +8976,7 @@ It must only be included by interfaces which also include those mixins.
             **Returns:** {{undefined}}
 
             1. If any of the following requirements are unmet, throw a {{RangeError}} and stop.
+
                 <div class=validusage>
                     - |dynamicOffsetsDataStart| must be &ge; 0.
                     - |dynamicOffsetsDataStart| + |dynamicOffsetsDataLength| must be &le;
@@ -8871,14 +9010,14 @@ It must only be included by interfaces which also include those mixins.
     <dfn abstract-op>Validate encoder bind groups</dfn>(encoder, pipeline)
 
     **Arguments:**
-    <dl>
-        : {{GPUBindingCommandsMixin}} |encoder|
-        :: Encoder whose bind groups are being validated.
-        : {{GPUPipelineBase}} |pipeline|
-        :: Pipeline to validate |encoder|s bind groups are compatible with.
-    </dl>
+
+    : {{GPUBindingCommandsMixin}} |encoder|
+    :: Encoder whose bind groups are being validated.
+    : {{GPUPipelineBase}} |pipeline|
+    :: Pipeline to validate |encoder|s bind groups are compatible with.
 
     1. If any of the following conditions are unsatisfied, return `false`:
+
         <div class=validusage>
             - |pipeline| must not be `null`.
             - All bind groups used by the pipeline must be set and compatible with the pipeline layout:
@@ -8908,12 +9047,11 @@ It must only be included by interfaces which also include those mixins.
     (which may use the same or a different {{GPUTextureView}} object).
 
     **Arguments:**
-    <dl>
-        : {{GPUBindingCommandsMixin}} |encoder|
-        :: Encoder whose bind groups are being validated.
-        : {{GPUPipelineBase}} |pipeline|
-        :: Pipeline to validate |encoder|s bind groups are compatible with.
-    </dl>
+
+    : {{GPUBindingCommandsMixin}} |encoder|
+    :: Encoder whose bind groups are being validated.
+    : {{GPUPipelineBase}} |pipeline|
+    :: Pipeline to validate |encoder|s bind groups are compatible with.
 
     1. For each |stage| in [{{GPUShaderStage/VERTEX}}, {{GPUShaderStage/FRAGMENT}}, {{GPUShaderStage/COMPUTE}}]:
         1. Let |bufferBindings| be a [=list=] of ({{GPUBufferBinding}}, `boolean`) pairs,
@@ -8995,6 +9133,7 @@ It must only be included by interfaces which also include those mixins.
             **Called on:** {{GPUDebugCommandsMixin}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUDebugCommandsMixin/pushDebugGroup(groupLabel)">
                 |groupLabel|: The label for the command group.
             </pre>
@@ -9002,6 +9141,7 @@ It must only be included by interfaces which also include those mixins.
             **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. [=stack/Push=] |groupLabel| onto |this|.{{GPUDebugCommandsMixin/[[debug_group_stack]]}}.
@@ -9018,9 +9158,11 @@ It must only be included by interfaces which also include those mixins.
             **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following requirements are unmet, make |this| [=invalid=], and stop.
+
                     <div class=validusage>
                         - |this|.{{GPUDebugCommandsMixin/[[debug_group_stack]]}} must not [=list/is empty|be empty=].
                     </div>
@@ -9036,6 +9178,7 @@ It must only be included by interfaces which also include those mixins.
             **Called on:** {{GPUDebugCommandsMixin}} this.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUDebugCommandsMixin/insertDebugMarker(markerLabel)">
                 markerLabel: The label to insert.
             </pre>
@@ -9043,6 +9186,7 @@ It must only be included by interfaces which also include those mixins.
             **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
             </div>
@@ -9070,7 +9214,7 @@ GPUComputePassEncoder includes GPUBindingCommandsMixin;
 
 {{GPUComputePassEncoder}} has the following internal slots:
 
-<dl dfn-type=attribute dfn-for="GPUComputePassEncoder">
+<dl dfn-type=attribute dfn-for=GPUComputePassEncoder>
     : <dfn>\[[command_encoder]]</dfn>, of type {{GPUCommandEncoder}}, readonly
     ::
         The {{GPUCommandEncoder}} that created this compute pass encoder.
@@ -9132,10 +9276,11 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
     ::
         Sets the current {{GPUComputePipeline}}.
 
-        <div algorithm="GPUComputePassEncoder.setPipeline">
+        <div algorithm=GPUComputePassEncoder.setPipeline>
             **Called on:** {{GPUComputePassEncoder}} this.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUComputePassEncoder/setPipeline(pipeline)">
                 |pipeline|: The compute pipeline to use for subsequent dispatch commands.
             </pre>
@@ -9143,9 +9288,11 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
             **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+
                     <div class=validusage>
                         - |pipeline| is [$valid to use with$] |this|.
                     </div>
@@ -9158,10 +9305,11 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
         Dispatch work to be performed with the current {{GPUComputePipeline}}.
         See [[#computing-operations]] for the detailed specification.
 
-        <div algorithm="GPUComputePassEncoder.dispatch">
+        <div algorithm=GPUComputePassEncoder.dispatch>
             **Called on:** {{GPUComputePassEncoder}} this.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUComputePassEncoder/dispatchWorkgroups(workgroupCountX, workgroupCountY, workgroupCountZ)">
                 |workgroupCountX|: X dimension of the grid of workgroups to dispatch.
                 |workgroupCountY|: Y dimension of the grid of workgroups to dispatch.
@@ -9169,7 +9317,8 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
             </pre>
 
             <div class=note>
-                Note: The `x`, `y`, and `z` values passed to {{GPUComputePassEncoder/dispatchWorkgroups()}}
+                Note:
+                The `x`, `y`, and `z` values passed to {{GPUComputePassEncoder/dispatchWorkgroups()}}
                 and {{GPUComputePassEncoder/dispatchWorkgroupsIndirect()}} are the number of
                 *workgroups* to dispatch for each dimension, *not* the number of shader invocations
                 to perform across each dimension. This matches the behavior of modern native GPU
@@ -9185,9 +9334,11 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
             **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+
                     <div class=validusage>
                         - [$Validate encoder bind groups$](|this|, |this|.{{GPUComputePassEncoder/[[pipeline]]}})
                             is `true`.
@@ -9198,6 +9349,7 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
                 1. Let |passState| be a snapshot of |this|'s current state.
                 1. [=list/Append=] a [=GPU command=] to |this|.{{GPUCommandsMixin/[[commands]]}}
                     executing the following [=queue timeline=] steps:
+
                     <div class=queue-timeline>
                         1. Dispatch a grid of workgroups with dimensions [|workgroupCountX|, |workgroupCountY|,
                             |workgroupCountZ|] with
@@ -9218,17 +9370,18 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
         given in the same order as the arguments for {{GPUComputePassEncoder/dispatchWorkgroups()}}.
         For example:
 
-        <pre highlight="js">
+        <pre highlight=js>
             let dispatchIndirectParameters = new Uint32Array(3);
             dispatchIndirectParameters[0] = workgroupCountX;
             dispatchIndirectParameters[1] = workgroupCountY;
             dispatchIndirectParameters[2] = workgroupCountZ;
         </pre>
 
-        <div algorithm="GPUComputePassEncoder.dispatchIndirect">
+        <div algorithm=GPUComputePassEncoder.dispatchIndirect>
             **Called on:** {{GPUComputePassEncoder}} this.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUComputePassEncoder/dispatchWorkgroupsIndirect(indirectBuffer, indirectOffset)">
                 |indirectBuffer|: Buffer containing the [=indirect dispatch parameters=].
                 |indirectOffset|: Offset in bytes into |indirectBuffer| where the dispatch data begins.
@@ -9237,9 +9390,11 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
             **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+
                     <div class=validusage>
                         - [$Validate encoder bind groups$](|this|, |this|.{{GPUComputePassEncoder/[[pipeline]]}})
                             is `true`.
@@ -9269,15 +9424,17 @@ called the compute pass encoder can no longer be used.
     ::
         Completes recording of the compute pass commands sequence.
 
-        <div algorithm="GPUComputePassEncoder.end">
+        <div algorithm=GPUComputePassEncoder.end>
             **Called on:** {{GPUComputePassEncoder}} |this|.
 
             **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|:
+
             <div class=device-timeline>
                 1. If any of the following requirements are unmet,
                     [$generate a validation error$] and stop.
+
                     <div class=validusage>
                         - |this|.{{GPUCommandsMixin/[[state]]}} must be "[=encoder state/open=]",
                     </div>
@@ -9287,6 +9444,7 @@ called the compute pass encoder can no longer be used.
                 1. Set |parentEncoder|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/open=]".
                 1. If any of the following requirements are unmet, make
                     |parentEncoder| [=invalid=] and stop.
+
                     <div class=validusage>
                         - |this| must be [=valid=].
                         - |this|.{{GPUDebugCommandsMixin/[[debug_group_stack]]}} must [=list/is empty|be empty=].
@@ -9311,8 +9469,8 @@ called the compute pass encoder can no longer be used.
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPURenderPassEncoder {
     undefined setViewport(float x, float y,
-                     float width, float height,
-                     float minDepth, float maxDepth);
+        float width, float height,
+        float minDepth, float maxDepth);
 
     undefined setScissorRect(GPUIntegerCoordinate x, GPUIntegerCoordinate y,
                         GPUIntegerCoordinate width, GPUIntegerCoordinate height);
@@ -9335,7 +9493,7 @@ GPURenderPassEncoder includes GPURenderCommandsMixin;
 
 {{GPURenderPassEncoder}} has the following internal slots:
 
-<dl dfn-type=attribute dfn-for="GPURenderPassEncoder">
+<dl dfn-type=attribute dfn-for=GPURenderPassEncoder>
     : <dfn>\[[command_encoder]]</dfn>, of type {{GPUCommandEncoder}}, readonly
     ::
         The {{GPUCommandEncoder}} that created this render pass encoder.
@@ -9373,13 +9531,14 @@ GPURenderPassEncoder includes GPURenderCommandsMixin;
 </dl>
 
 When a {{GPURenderPassEncoder}} is created, it has the following default state:
-  * {{GPURenderPassEncoder/[[viewport]]}}:
-      * `x, y` = `0.0, 0.0`
-      * `width, height` = the dimensions of the pass's render targets
-      * `minDepth, maxDepth` = `0.0, 1.0`
-  * Scissor rectangle:
-      * `x, y` = `0, 0`
-      * `width, height` = the dimensions of the pass's render targets
+
+- {{GPURenderPassEncoder/[[viewport]]}}:
+    - `x, y` = `0.0, 0.0`
+    - `width, height` = the dimensions of the pass's render targets
+    - `minDepth, maxDepth` = `0.0, 1.0`
+- Scissor rectangle:
+    - `x, y` = `0, 0`
+    - `width, height` = the dimensions of the pass's render targets
 
 ### Creation ### {#render-pass-encoder-creation}
 
@@ -9487,7 +9646,7 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
 <div algorithm="GPURenderPassDescriptor accessors" dfn-for=RenderPassDescriptor>
     For a given {{GPURenderPassDescriptor}} value |descriptor|, the syntax:
 
-      - |descriptor|.<dfn dfn>renderExtent</dfn> refers to
+    - |descriptor|.<dfn dfn>renderExtent</dfn> refers to
         {{GPUTextureView/[[renderExtent]]}} of any {{GPUTextureView/[[descriptor]]}}
         in either |descriptor|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachment/view}},
         or any of the {{GPURenderPassColorAttachment/view}} in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}.
@@ -9559,6 +9718,7 @@ dictionary GPURenderPassColorAttachment {
                 step, and return the result.
 
             <div class=note>
+                Note:
                 In other words, the value written will be as if it was written by a WGSL shader that
                 outputs the |value| represented as WGSL's `f32`, `i32`, or `u32`, according to its type.
 
@@ -9787,6 +9947,7 @@ dictionary GPURenderPassLayout: GPUObjectDescriptorBase {
     <dfn abstract-op>derive render targets layout from pass</dfn>
 
     **Arguments:**
+
     - {{GPURenderPassDescriptor}} |descriptor|
 
     **Returns:** {{GPURenderPassLayout}}
@@ -9804,13 +9965,13 @@ dictionary GPURenderPassLayout: GPUObjectDescriptorBase {
         1. Set |layout|.{{GPURenderPassLayout/sampleCount}} to |view|.{{GPUTextureView/[[texture]]}}.{{GPUTexture/sampleCount}}.
         1. Set |layout|.{{GPURenderPassLayout/depthStencilFormat}} to |view|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
     1. Return |layout|.
-
 </div>
 
 <div algorithm>
     <dfn abstract-op>derive render targets layout from pipeline</dfn>
 
     **Arguments:**
+
     - {{GPURenderPipelineDescriptor}} |descriptor|
 
     **Returns:** {{GPURenderPassLayout}}
@@ -9824,7 +9985,6 @@ dictionary GPURenderPassLayout: GPUObjectDescriptorBase {
             1. Append |colorTarget|.{{GPUColorTargetState/format}} to |layout|.{{GPURenderPassLayout/colorFormats}}
                 if |colorTarget| is not `null`, or append `null` otherwise.
     1. Return |layout|.
-
 </div>
 
 ### Finalization ### {#render-pass-encoder-finalization}
@@ -9838,15 +9998,17 @@ called the render pass encoder can no longer be used.
     ::
         Completes recording of the render pass commands sequence.
 
-        <div algorithm="GPURenderPassEncoder.end">
+        <div algorithm=GPURenderPassEncoder.end>
             **Called on:** {{GPURenderPassEncoder}} |this|.
 
             **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|:
+
             <div class=device-timeline>
                 1. If any of the following requirements are unmet,
                     [$generate a validation error$] and stop.
+
                     <div class=validusage>
                         - |this|.{{GPUCommandsMixin/[[state]]}} must be "[=encoder state/open=]",
                     </div>
@@ -9855,6 +10017,7 @@ called the render pass encoder can no longer be used.
                 1. [=Assert=]: |parentEncoder|.{{GPUCommandsMixin/[[state]]}} is "[=encoder state/locked=]".
                 1. Set |parentEncoder|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/open=]".
                 1. If any of the following requirements are unmet, make |this| [=invalid=] and stop.
+
                     <div class=validusage>
                         - |this| must be [=valid=].
                         - |this|.{{GPUDebugCommandsMixin/[[debug_group_stack]]}} must [=list/is empty|be empty=].
@@ -9887,11 +10050,11 @@ interface mixin GPURenderCommandsMixin {
     undefined setVertexBuffer(GPUIndex32 slot, GPUBuffer buffer, optional GPUSize64 offset = 0, optional GPUSize64 size);
 
     undefined draw(GPUSize32 vertexCount, optional GPUSize32 instanceCount = 1,
-              optional GPUSize32 firstVertex = 0, optional GPUSize32 firstInstance = 0);
+        optional GPUSize32 firstVertex = 0, optional GPUSize32 firstInstance = 0);
     undefined drawIndexed(GPUSize32 indexCount, optional GPUSize32 instanceCount = 1,
-                     optional GPUSize32 firstIndex = 0,
-                     optional GPUSignedOffset32 baseVertex = 0,
-                     optional GPUSize32 firstInstance = 0);
+        optional GPUSize32 firstIndex = 0,
+        optional GPUSignedOffset32 baseVertex = 0,
+        optional GPUSize32 firstInstance = 0);
 
     undefined drawIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
     undefined drawIndexedIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
@@ -9904,7 +10067,7 @@ It must only be included by interfaces which also include those mixins.
 
 {{GPURenderCommandsMixin}} has the following internal slots:
 
-<dl dfn-type=attribute dfn-for="GPURenderCommandsMixin">
+<dl dfn-type=attribute dfn-for=GPURenderCommandsMixin>
     : <dfn>\[[layout]]</dfn>, of type {{GPURenderPassLayout}}
     ::
         The layout of the render pass.
@@ -9955,10 +10118,11 @@ It must only be included by interfaces which also include those mixins.
     ::
         Sets the current {{GPURenderPipeline}}.
 
-        <div algorithm="GPURenderCommandsMixin.setPipeline">
+        <div algorithm=GPURenderCommandsMixin.setPipeline>
             **Called on:** {{GPURenderCommandsMixin}} this.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPURenderCommandsMixin/setPipeline(pipeline)">
                 |pipeline|: The render pipeline to use for subsequent drawing commands.
             </pre>
@@ -9966,10 +10130,12 @@ It must only be included by interfaces which also include those mixins.
             **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. Let |pipelineTargetsLayout| be [$derive render targets layout from pipeline$](|pipeline|.{{GPURenderPipeline/[[descriptor]]}}).
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+
                     <div class=validusage>
                         - |pipeline| is [$valid to use with$] |this|.
                         - |this|.{{GPURenderCommandsMixin/[[layout]]}} equals |pipelineTargetsLayout|.
@@ -9988,10 +10154,11 @@ It must only be included by interfaces which also include those mixins.
     ::
         Sets the current index buffer.
 
-        <div algorithm="GPURenderCommandsMixin.setIndexBuffer">
+        <div algorithm=GPURenderCommandsMixin.setIndexBuffer>
             **Called on:** {{GPURenderCommandsMixin}} this.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPURenderCommandsMixin/setIndexBuffer(buffer, indexFormat, offset, size)">
                 |buffer|: Buffer containing index data to use for subsequent drawing commands.
                 |indexFormat|: Format of the index data contained in |buffer|.
@@ -10003,10 +10170,12 @@ It must only be included by interfaces which also include those mixins.
             **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If |size| is missing, set |size| to max(0, |buffer|.{{GPUBuffer/size}} - |offset|).
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+
                     <div class=validusage>
                         - |buffer| is [$valid to use with$] |this|.
                         - |buffer|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/INDEX}}.
@@ -10024,10 +10193,11 @@ It must only be included by interfaces which also include those mixins.
     ::
         Sets the current vertex buffer for the given slot.
 
-        <div algorithm="GPURenderCommandsMixin.setVertexBuffer">
+        <div algorithm=GPURenderCommandsMixin.setVertexBuffer>
             **Called on:** {{GPURenderCommandsMixin}} this.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPURenderCommandsMixin/setVertexBuffer(slot, buffer, offset, size)">
                 |slot|: The vertex buffer slot to set the vertex buffer for.
                 |buffer|: Buffer containing vertex data to use for subsequent drawing commands.
@@ -10039,10 +10209,12 @@ It must only be included by interfaces which also include those mixins.
             **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If |size| is missing, set |size| to max(0, |buffer|.{{GPUBuffer/size}} - |offset|).
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+
                     <div class=validusage>
                         - |buffer| is [$valid to use with$] |this|.
                         - |buffer|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/VERTEX}}.
@@ -10061,10 +10233,11 @@ It must only be included by interfaces which also include those mixins.
         Draws primitives.
         See [[#rendering-operations]] for the detailed specification.
 
-        <div algorithm="GPURenderCommandsMixin.draw">
+        <div algorithm=GPURenderCommandsMixin.draw>
             **Called on:** {{GPURenderCommandsMixin}} this.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPURenderCommandsMixin/draw(vertexCount, instanceCount, firstVertex, firstInstance)">
                 |vertexCount|: The number of vertices to draw.
                 |instanceCount|: The number of instances to draw.
@@ -10075,9 +10248,11 @@ It must only be included by interfaces which also include those mixins.
             **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+
                     <div class=validusage>
                         - It is [$valid to draw$] with |this|.
                         - Let |buffers| be |this|.{{GPURenderCommandsMixin/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}.
@@ -10088,7 +10263,8 @@ It must only be included by interfaces which also include those mixins.
                             - Let |lastStride| be max(|attribute|.{{GPUVertexAttribute/offset}} &plus; sizeof(|attribute|.{{GPUVertexAttribute/format}}))
                                 for each |attribute| in |buffers|[|slot|].{{GPUVertexBufferLayout/attributes}}.
                             - Let |strideCount| be computed based on |buffers|[|slot|].{{GPUVertexBufferLayout/stepMode}}:
-                                <dl class="switch">
+
+                                <dl class=switch>
                                     : {{GPUVertexStepMode/"vertex"}}
                                     :: |firstVertex| &plus; |vertexCount|
                                     : {{GPUVertexStepMode/"instance"}}
@@ -10106,10 +10282,11 @@ It must only be included by interfaces which also include those mixins.
         Draws indexed primitives.
         See [[#rendering-operations]] for the detailed specification.
 
-        <div algorithm="GPURenderCommandsMixin.drawIndexed">
+        <div algorithm=GPURenderCommandsMixin.drawIndexed>
             **Called on:** {{GPURenderCommandsMixin}} this.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPURenderCommandsMixin/drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance)">
                 |indexCount|: The number of indices to draw.
                 |instanceCount|: The number of instances to draw.
@@ -10121,9 +10298,11 @@ It must only be included by interfaces which also include those mixins.
             **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+
                     <div class=validusage>
                         - It is [$valid to draw indexed$] with |this|.
                         - |firstIndex| + |indexCount| &le; |this|.{{GPURenderCommandsMixin/[[index_buffer_size]]}}
@@ -10159,7 +10338,7 @@ It must only be included by interfaces which also include those mixins.
         packed block of **four 32-bit unsigned integer values (16 bytes total)**, given in the same
         order as the arguments for {{GPURenderCommandsMixin/draw()}}. For example:
 
-        <pre highlight="js">
+        <pre highlight=js>
             let drawIndirectParameters = new Uint32Array(4);
             drawIndirectParameters[0] = vertexCount;
             drawIndirectParameters[1] = instanceCount;
@@ -10171,10 +10350,11 @@ It must only be included by interfaces which also include those mixins.
         [=feature=] is enabled.  If the {{GPUFeatureName/"indirect-first-instance"}} [=feature=] is not enabled and
         `firstInstance` is not zero the {{GPURenderCommandsMixin/drawIndirect()}} call will be treated as a no-op.
 
-        <div algorithm="GPURenderCommandsMixin.drawIndirect">
+        <div algorithm=GPURenderCommandsMixin.drawIndirect>
             **Called on:** {{GPURenderCommandsMixin}} this.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPURenderCommandsMixin/drawIndirect(indirectBuffer, indirectOffset)">
                 |indirectBuffer|: Buffer containing the [=indirect draw parameters=].
                 |indirectOffset|: Offset in bytes into |indirectBuffer| where the drawing data begins.
@@ -10183,9 +10363,11 @@ It must only be included by interfaces which also include those mixins.
             **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+
                     <div class=validusage>
                         - It is [$valid to draw$] with |this|.
                         - |indirectBuffer| is [$valid to use with$] |this|.
@@ -10208,7 +10390,7 @@ It must only be included by interfaces which also include those mixins.
         tightly packed block of **five 32-bit unsigned integer values (20 bytes total)**, given in
         the same order as the arguments for {{GPURenderCommandsMixin/drawIndexed()}}. For example:
 
-        <pre highlight="js">
+        <pre highlight=js>
             let drawIndexedIndirectParameters = new Uint32Array(5);
             drawIndexedIndirectParameters[0] = indexCount;
             drawIndexedIndirectParameters[1] = instanceCount;
@@ -10221,10 +10403,11 @@ It must only be included by interfaces which also include those mixins.
         [=feature=] is enabled.  If the {{GPUFeatureName/"indirect-first-instance"}} [=feature=] is not enabled and
         `firstInstance` is not zero the {{GPURenderCommandsMixin/drawIndexedIndirect()}} call will be treated as a no-op.
 
-        <div algorithm="GPURenderCommandsMixin.drawIndexedIndirect">
+        <div algorithm=GPURenderCommandsMixin.drawIndexedIndirect>
             **Called on:** {{GPURenderCommandsMixin}} this.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPURenderCommandsMixin/drawIndexedIndirect(indirectBuffer, indirectOffset)">
                 |indirectBuffer|: Buffer containing the [=indirect drawIndexed parameters=].
                 |indirectOffset|: Offset in bytes into |indirectBuffer| where the drawing data begins.
@@ -10233,9 +10416,11 @@ It must only be included by interfaces which also include those mixins.
             **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+
                     <div class=validusage>
                         - It is [$valid to draw indexed$] with |this|.
                         - |indirectBuffer| is [$valid to use with$] |this|.
@@ -10254,37 +10439,34 @@ It must only be included by interfaces which also include those mixins.
     To determine if it's <dfn abstract-op>valid to draw</dfn> with {{GPURenderCommandsMixin}} |encoder|
     run the following steps:
 
-    If any of the following conditions are unsatisfied, return `false`:
+    1. If any of the following conditions are unsatisfied, return `false`:
         <div class=validusage>
             - [$Validate encoder bind groups$](|encoder|, |encoder|.{{GPURenderCommandsMixin/[[pipeline]]}})
                 must be `true`.
-
             - Let |pipelineDescriptor| be |encoder|.{{GPURenderCommandsMixin/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.
             - For each {{GPUIndex32}} |slot| `0` to
                 |pipelineDescriptor|.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}.length:
                 - If |pipelineDescriptor|.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}}[|slot|] is not `null`,
                     |encoder|.{{GPURenderCommandsMixin/[[vertex_buffers]]}} must [=map/contain=] |slot|.
         </div>
-
-    Otherwise return `true`.
+    1. Otherwise return `true`.
 </div>
 
 <div algorithm>
     To determine if it's <dfn abstract-op>valid to draw indexed</dfn> with {{GPURenderCommandsMixin}} |encoder|
     run the following steps:
 
-    If any of the following conditions are unsatisfied, return `false`:
+    1. If any of the following conditions are unsatisfied, return `false`:
+
         <div class=validusage>
             - It must be [$valid to draw$] with |encoder|.
-
             - |encoder|.{{GPURenderCommandsMixin/[[index_buffer]]}} must not be `null`.
             - Let |topology| be |encoder|.{{GPURenderCommandsMixin/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.{{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/topology}}.
             - If |topology| is {{GPUPrimitiveTopology/"line-strip"}} or {{GPUPrimitiveTopology/"triangle-strip"}}:
                 - |encoder|.{{GPURenderCommandsMixin/[[index_format]]}} must equal
                     |encoder|.{{GPURenderCommandsMixin/[[pipeline]]}}.{{GPURenderPipeline/[[descriptor]]}}.{{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/stripIndexFormat}}.
         </div>
-
-    Otherwise return `true`.
+    1. Otherwise return `true`.
 </div>
 
 ### Rasterization state ### {#render-pass-encoder-rasterization-state}
@@ -10298,10 +10480,11 @@ attachments used by this encoder.
         Sets the viewport used during the rasterization stage to linearly map from normalized device
         coordinates to viewport coordinates.
 
-        <div algorithm="GPURenderPassEncoder.setViewport">
+        <div algorithm=GPURenderPassEncoder.setViewport>
             **Called on:** {{GPURenderPassEncoder}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPURenderPassEncoder/setViewport(x, y, width, height, minDepth, maxDepth)">
                 |x|: Minimum X value of the viewport in pixels.
                 |y|: Minimum Y value of the viewport in pixels.
@@ -10314,10 +10497,12 @@ attachments used by this encoder.
             **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|:
+
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=]
                     and stop.
+
                     <div class=validusage>
                         - |x| is greater than or equal to `0`.
                         - |y| is greater than or equal to `0`.
@@ -10343,10 +10528,11 @@ attachments used by this encoder.
         After transformation into viewport coordinates any fragments which fall outside the scissor
         rectangle will be discarded.
 
-        <div algorithm="GPURenderPassEncoder.setScissorRect">
+        <div algorithm=GPURenderPassEncoder.setScissorRect>
             **Called on:** {{GPURenderPassEncoder}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPURenderPassEncoder/setScissorRect(x, y, width, height)">
                 |x|: Minimum X value of the scissor rectangle in pixels.
                 |y|: Minimum Y value of the scissor rectangle in pixels.
@@ -10357,10 +10543,12 @@ attachments used by this encoder.
             **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|:
+
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=]
                     and stop.
+
                     <div class=validusage>
                         - |x|+|width| is less than or equal to
                             |this|.{{GPURenderPassEncoder/[[attachment_size]]}}.width.
@@ -10376,15 +10564,17 @@ attachments used by this encoder.
         Sets the constant blend color and alpha values used with {{GPUBlendFactor/"constant"}}
         and {{GPUBlendFactor/"one-minus-constant"}} {{GPUBlendFactor}}s.
 
-        <div algorithm="GPURenderPassEncoder.setBlendConstant">
+        <div algorithm=GPURenderPassEncoder.setBlendConstant>
             **Called on:** {{GPURenderPassEncoder}} this.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPURenderPassEncoder/setBlendConstant(color)">
                 |color|: The color to use when blending.
             </pre>
 
             Issue the following steps on the [=Device timeline=] of |this|:
+
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. Set {{GPURenderPassEncoder/[[blend_constant]]}} to |color|.
@@ -10396,15 +10586,17 @@ attachments used by this encoder.
         Sets the {{GPURenderPassEncoder/[[stencil_reference]]}} value used during stencil tests with
         the {{GPUStencilOperation/"replace"}} {{GPUStencilOperation}}.
 
-        <div algorithm="GPURenderPassEncoder.setStencilReference">
+        <div algorithm=GPURenderPassEncoder.setStencilReference>
             **Called on:** {{GPURenderPassEncoder}} this.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPURenderPassEncoder/setStencilReference(reference)">
                 |reference|: The new stencil reference value.
             </pre>
 
             Issue the following steps on the [=Device timeline=] of |this|:
+
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. Set {{GPURenderPassEncoder/[[stencil_reference]]}} to |reference|.
@@ -10417,11 +10609,11 @@ attachments used by this encoder.
 <dl dfn-type=method dfn-for=GPURenderPassEncoder>
     : <dfn>beginOcclusionQuery(queryIndex)</dfn>
     ::
-
-        <div algorithm="GPURenderPassEncoder.beginOcclusionQuery">
+        <div algorithm=GPURenderPassEncoder.beginOcclusionQuery>
             **Called on:** {{GPURenderPassEncoder}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPURenderPassEncoder/beginOcclusionQuery(queryIndex)">
                 |queryIndex|: The index of the query in the query set.
             </pre>
@@ -10429,9 +10621,11 @@ attachments used by this encoder.
             **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+
                     <div class=validusage>
                         - |this|.{{GPURenderPassEncoder/[[occlusion_query_set]]}} is not `null`.
                         - |queryIndex| &lt; |this|.{{GPURenderPassEncoder/[[occlusion_query_set]]}}.{{GPUQuerySet/count}}.
@@ -10444,16 +10638,17 @@ attachments used by this encoder.
 
     : <dfn>endOcclusionQuery()</dfn>
     ::
-
-        <div algorithm="GPURenderPassEncoder.endOcclusionQuery">
+        <div algorithm=GPURenderPassEncoder.endOcclusionQuery>
             **Called on:** {{GPURenderPassEncoder}} this.
 
             **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+
                     <div class=validusage>
                         - |this|.{{GPURenderPassEncoder/[[occlusion_query_active]]}} is `true`.
                     </div>
@@ -10478,10 +10673,11 @@ attachments used by this encoder.
         Note: The state is cleared, not restored to the previous state.
         This occurs even if zero {{GPURenderBundle|GPURenderBundles}} are executed.
 
-        <div algorithm="GPURenderPassEncoder.executeBundles">
+        <div algorithm=GPURenderPassEncoder.executeBundles>
             **Called on:** {{GPURenderPassEncoder}} this.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPURenderPassEncoder/executeBundles(bundles)">
                 |bundles|: List of render bundles to execute.
             </pre>
@@ -10489,10 +10685,12 @@ attachments used by this encoder.
             **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|:
+
             <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=]
                     and stop.
+
                     <div class=validusage>
                         - For each |bundle| in |bundles|:
                             - |bundle| must be [$valid to use with$] |this|.
@@ -10521,7 +10719,7 @@ interface GPURenderBundle {
 GPURenderBundle includes GPUObjectBase;
 </script>
 
-<dl dfn-type=attribute dfn-for="GPURenderBundle">
+<dl dfn-type=attribute dfn-for=GPURenderBundle>
     : <dfn>\[[command_list]]</dfn>, of type [=list=]&lt;[=GPU command=]&gt;
     ::
         A [=list=] of [=GPU commands=] to be submitted to the {{GPURenderPassEncoder}} when the
@@ -10572,6 +10770,7 @@ GPURenderBundleEncoder includes GPURenderCommandsMixin;
             **Called on:** {{GPUDevice}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUDevice/createRenderBundleEncoder(descriptor)">
                 |descriptor|: Description of the {{GPURenderBundleEncoder}} to create.
             </pre>
@@ -10584,9 +10783,11 @@ GPURenderBundleEncoder includes GPURenderCommandsMixin;
                 |descriptor|.{{GPURenderPassLayout/depthStencilFormat}} with |this|.{{GPUObjectBase/[[device]]}}.
             1. Let |e| be a new {{GPURenderBundleEncoder}} object.
             1. Issue the following steps on the [=Device timeline=] of |this|:
+
                 <div class=device-timeline>
                     1. If any of the following conditions are unsatisfied
                         [$generate a validation error$], make |e| [=invalid=], and stop.
+
                         <div class=validusage>
                             - |this| is [=valid=].
                             - |descriptor|.{{GPURenderPassLayout/colorFormats}}.length must be less than or equal to
@@ -10630,10 +10831,11 @@ dictionary GPURenderBundleEncoderDescriptor : GPURenderPassLayout {
     ::
         Completes recording of the render bundle commands sequence.
 
-        <div algorithm="GPURenderBundleEncoder.finish">
+        <div algorithm=GPURenderBundleEncoder.finish>
             **Called on:** {{GPURenderBundleEncoder}} this.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPURenderBundleEncoder/finish(descriptor)">
                 descriptor:
             </pre>
@@ -10642,8 +10844,10 @@ dictionary GPURenderBundleEncoderDescriptor : GPURenderPassLayout {
 
             1. Let |renderBundle| be a new {{GPURenderBundle}}.
             1. Issue the following steps on the [=Device timeline=] of |this|:
+
                 <div class=device-timeline>
                     1. Let |validationSucceeded| be `true` if all of the following requirements are met, and `false` otherwise.
+
                         <div class=validusage>
                             - |this| must be [=valid=].
                             - |this|.{{GPUCommandsMixin/[[state]]}} must be "[=encoder state/open=]".
@@ -10716,6 +10920,7 @@ GPUQueue includes GPUObjectBase;
             **Called on:** {{GPUQueue}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUQueue/writeBuffer(buffer, bufferOffset, data, dataOffset, size)">
                 |buffer|: The buffer to write to.
                 |bufferOffset|: Offset in bytes into |buffer| to begin writing at.
@@ -10736,8 +10941,10 @@ GPUQueue includes GPUObjectBase;
                 Otherwise, let |contentsSize| be |size|.
             1. If any of the following conditions are unsatisfied,
                 throw {{OperationError}} and stop.
+
                 <!-- Note: it's easiest to write the valid usage rules inline
-                     here, because they depend on contentsSize above. -->
+                    here, because they depend on contentsSize above. -->
+
                 <div class=validusage>
                     - |contentsSize| &ge; 0.
                     - |dataOffset| + |contentsSize| &le; |dataSize|.
@@ -10747,9 +10954,11 @@ GPUQueue includes GPUObjectBase;
             1. Let |contents| be the |contentsSize| elements of |dataContents| starting at
                 an offset of |dataOffset| elements.
             1. Issue the following steps on the [=Device timeline=] of |this|:
+
                 <div class=device-timeline>
                     1. If any of the following conditions are unsatisfied,
                         [$generate a validation error$] and stop.
+
                         <div class=validusage>
                             - |buffer| is [$valid to use with$] |this|.
                             - |buffer|.{{GPUBuffer/[[state]]}} is [=buffer state/unmapped=].
@@ -10769,6 +10978,7 @@ GPUQueue includes GPUObjectBase;
             **Called on:** {{GPUQueue}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUQueue/writeTexture(destination, data, dataLayout, size)">
                 |destination|: The [=texture subresource=] and origin to write to.
                 |data|: Data to write into |destination|.
@@ -10786,9 +10996,11 @@ GPUQueue includes GPUObjectBase;
 
                 Issue: Specify more formally.
             1. Issue the following steps on the [=Device timeline=] of |this|:
+
                 <div class=device-timeline>
                     1. If any of the following conditions are unsatisfied,
                         [$generate a validation error$] and stop.
+
                         <div class=validusage>
                             - [$validating GPUImageCopyTexture$](|destination|, |size|) returns `true`.
                             - |texture|.{{GPUTexture/usage}} includes {{GPUTextureUsage/COPY_DST}}.
@@ -10835,6 +11047,7 @@ GPUQueue includes GPUObjectBase;
             **Called on:** {{GPUQueue}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUQueue/copyExternalImageToTexture(source, destination, copySize)">
                 |source|: source image and origin to copy to |destination|.
                 |destination|: The [=texture subresource=] and origin to write to, and its encoding metadata.
@@ -10850,6 +11063,7 @@ GPUQueue includes GPUObjectBase;
             1. If |sourceImage| <l spec=html>[=is not origin-clean=]</l>,
                 throw a {{SecurityError}} and stop.
             1. If any of the following requirements are unmet, throw an {{OperationError}} and stop.
+
                 <div class=validusage>
                     - |source|.|origin|.[=Origin3D/x=] + |copySize|.[=Extent3D/width=]
                         must be &le; the width of |sourceImage|.
@@ -10859,9 +11073,11 @@ GPUQueue includes GPUObjectBase;
                         must be &le; 1.
                 </div>
             1. Issue the following steps on the [=Device timeline=] of |this|:
+
                 <div class=device-timeline>
                     1. Let |texture| be |destination|.{{GPUImageCopyTexture/texture}}.
                     1. If any of the following requirements are unmet, [$generate a validation error$] and stop.
+
                         <div class=validusage>
                             - |destination|.{{GPUImageCopyTexture/texture}} must be [$valid to use with$] |this|.
                             - [$validating GPUImageCopyTexture$](destination, copySize) must return `true`.
@@ -10898,6 +11114,7 @@ GPUQueue includes GPUObjectBase;
             **Called on:** {{GPUQueue}} this.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUQueue/submit(commandBuffers)">
                 |commandBuffers|:
             </pre>
@@ -10905,8 +11122,10 @@ GPUQueue includes GPUObjectBase;
             **Returns:** {{undefined}}
 
             Issue the following steps on the [=Device timeline=] of |this|:
+
             <div class=device-timeline>
                 1. If any of the following conditions are unsatisfied, [$generate a validation error$] and stop.
+
                     <div class=validusage>
                         - Every {{GPUCommandBuffer}} in |commandBuffers| is [$valid to use with$] |this|.
                         - Every {{GPUBuffer}} referenced in any element of |commandBuffers| is in the
@@ -10919,6 +11138,7 @@ GPUQueue includes GPUObjectBase;
                     </div>
 
                 1. Issue the following steps on the [=Queue timeline=] of |this|:
+
                     <div class=queue-timeline>
                         1. For each |commandBuffer| in |commandBuffers|:
                             1. Execute each command in |commandBuffer|.{{GPUCommandBuffer/[[command_list]]}}.
@@ -10931,13 +11151,14 @@ GPUQueue includes GPUObjectBase;
         Returns a {{Promise}} that resolves once this queue finishes processing all the work submitted
         up to this moment.
 
-        <div algorithm="GPUQueue.onSubmittedWorkDone">
+        <div algorithm=GPUQueue.onSubmittedWorkDone>
             **Called on:** {{GPUQueue}} |this|.
 
             **Returns:** {{Promise}}&lt;{{undefined}}&gt;
 
             1. Let |promise| be [=a new promise=].
             1. Enqueue an operation on the [=Queue timeline=] of |this| that will execute the following:
+
                 <div class=queue-timeline>
                     1. [=Resolve=] |promise|.
                 </div>
@@ -10963,7 +11184,7 @@ GPUQuerySet includes GPUObjectBase;
 
 {{GPUQuerySet}} has the following attributes:
 
-<dl dfn-type=attribute dfn-for="GPUQuerySet">
+<dl dfn-type=attribute dfn-for=GPUQuerySet>
     : <dfn>type</dfn>
     ::
         The type of the queries managed by this {{GPUQuerySet}}.
@@ -10975,7 +11196,7 @@ GPUQuerySet includes GPUObjectBase;
 
 {{GPUQuerySet}} has the following internal slots:
 
-<dl dfn-type=attribute dfn-for="GPUQuerySet">
+<dl dfn-type=attribute dfn-for=GPUQuerySet>
     : <dfn>\[[state]]</dfn>, of type [=query set state=]
     ::
         The current state of the {{GPUQuerySet}}.
@@ -10984,10 +11205,12 @@ GPUQuerySet includes GPUObjectBase;
 Each {{GPUQuerySet}} has a current <dfn dfn>query set state</dfn> on the [=Device timeline=]
 which is one of the following:
 
- - "<dfn dfn for="query set state">available</dfn>" where the {{GPUQuerySet}} is
-     available for GPU operations on its content.
- - "<dfn dfn for="query set state">destroyed</dfn>" where the {{GPUQuerySet}} is
-     no longer available for any operations except {{GPUQuerySet/destroy}}.
+<dl dfn-type=dfn dfn-for="query set state">
+    : "<dfn>available</dfn>"
+    :: The {{GPUQuerySet}} is available for GPU operations on its content.
+    : "<dfn>destroyed</dfn>"
+    :: The {{GPUQuerySet}} is no longer available for any operations except {{GPUQuerySet/destroy}}.
+</dl>
 
 ### QuerySet Creation ### {#queryset-creation}
 
@@ -11019,6 +11242,7 @@ dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
             **Called on:** {{GPUDevice}} this.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUDevice/createQuerySet(descriptor)">
                 descriptor: Description of the {{GPUQuerySet}} to create.
             </pre>
@@ -11032,9 +11256,11 @@ dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
             1. Set |q|.{{GPUQuerySet/type}} to |descriptor|.{{GPUQuerySetDescriptor/type}}.
             1. Set |q|.{{GPUQuerySet/count}} to |descriptor|.{{GPUQuerySetDescriptor/count}}.
             1. Issue the following steps on the [=Device timeline=] of |this|:
+
                 <div class=device-timeline>
                     1. If any of the following requirements are unmet, [$generate a validation error$],
                         make |q| [=invalid=], and stop.
+
                         <div class=validusage>
                             - |this| is [=valid=].
                             - |descriptor|.{{GPUQuerySetDescriptor/count}} must be &le; 8192.
@@ -11046,9 +11272,10 @@ dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
         </div>
 </dl>
 
-<div class="example">
+<div class=example>
     Creating a {{GPUQuerySet}} which holds 32 occlusion query results.
-    <pre highlight="js">
+
+    <pre highlight=js>
         const querySet = gpuDevice.createQuerySet({
             type: 'occlusion',
             count: 32
@@ -11066,7 +11293,7 @@ garbage collection by calling {{GPUQuerySet/destroy()}}.
     ::
         Destroys the {{GPUQuerySet}}.
 
-        <div algorithm="GPUQuerySet.destroy">
+        <div algorithm=GPUQuerySet.destroy>
             **Called on:** {{GPUQuerySet}} |this|.
 
             **Returns:** {{undefined}}
@@ -11128,9 +11355,10 @@ instance by passing the string literal `'webgpu'` as its `contextType` argument.
     1. Return |context|.
 </div>
 
-<div class="example">
+<div class=example>
     Get a {{GPUCanvasContext}} from an offscreen {{HTMLCanvasElement}}:
-    <pre highlight="js">
+
+    <pre highlight=js>
         const canvas = document.createElement('canvas');
         const context = canvas.getContext('webgpu');
     </pre>
@@ -11160,7 +11388,7 @@ interface GPUCanvasContext {
 
 {{GPUCanvasContext}} has the following internal slots:
 
-<dl dfn-type=attribute dfn-for="GPUCanvasContext">
+<dl dfn-type=attribute dfn-for=GPUCanvasContext>
     : <dfn>\[[configuration]]</dfn>, of type {{GPUCanvasConfiguration}}?, initially `null`
     ::
         The options this context is currently configured with.
@@ -11224,10 +11452,11 @@ interface GPUCanvasContext {
         Configures the context for this canvas.
         This clears the drawing buffer to transparent black (in [$Replace the drawing buffer$]).
 
-        <div algorithm="GPUCanvasContext.configure">
+        <div algorithm=GPUCanvasContext.configure>
             **Called on:** {{GPUCanvasContext}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUCanvasContext/configure(configuration)">
                 |configuration|: Desired configuration for the context.
             </pre>
@@ -11247,8 +11476,10 @@ interface GPUCanvasContext {
                 |this|.{{GPUCanvasContext/[[drawingBuffer]]}} with a bitmap with the new format and tags.
 
             1. Issue the following steps on the [=Device timeline=] of |device|:
+
                 <div class=device-timeline>
                     1. If any of the following requirements are unmet, [$generate a validation error$] and stop.
+
                         <div class=validusage>
                             - [$validating GPUTextureDescriptor$](|device|, |descriptor|)
                                 must return true.
@@ -11267,7 +11498,7 @@ interface GPUCanvasContext {
     ::
         Removes the context configuration. Destroys any textures produced while configured.
 
-        <div algorithm="GPUCanvasContext.unconfigure">
+        <div algorithm=GPUCanvasContext.unconfigure>
             **Called on:** {{GPUCanvasContext}} |this|.
 
             **Returns:** undefined
@@ -11282,7 +11513,7 @@ interface GPUCanvasContext {
         Get the {{GPUTexture}} that will be composited to the document by the {{GPUCanvasContext}}
         next.
 
-        <div algorithm="GPUCanvasContext.getCurrentTexture">
+        <div algorithm=GPUCanvasContext.getCurrentTexture>
             **Called on:** {{GPUCanvasContext}} |this|.
 
             **Returns:** {{GPUTexture}}
@@ -11368,18 +11599,19 @@ this incurs a clear of the alpha channel. If a canvas is only needed for interop
     1. Let |alphaMode| be |context|.{{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/alphaMode}}.
     1.
         <dl class=switch>
-        : If |alphaMode| is {{GPUCanvasAlphaMode/"opaque"}}:
-        ::
-            1. Clear the alpha channel of |snapshot| to 1.0.
-            1. Tag |snapshot| as being opaque.
+            : If |alphaMode| is {{GPUCanvasAlphaMode/"opaque"}}:
+            ::
+                1. Clear the alpha channel of |snapshot| to 1.0.
+                1. Tag |snapshot| as being opaque.
 
-            Note:
-            If the {{GPUTexture}} exposing this {{GPUCanvasContext/[[currentTexture]]}} (if any) has
-            been [$Replace the drawing buffer|destroyed$], the alpha channel is unobservable, and
-            implementations may clear the alpha channel in-place.
+                Note:
+                If the {{GPUTexture}} exposing this {{GPUCanvasContext/[[currentTexture]]}} (if any) has
+                been [$Replace the drawing buffer|destroyed$], the alpha channel is unobservable, and
+                implementations may clear the alpha channel in-place.
 
-        : Otherwise:
-        :: Tag |snapshot| with |alphaMode|.
+            : Otherwise:
+            :: Tag |snapshot| with |alphaMode|.
+        </dl>
 
     1. Return |snapshot|.
 
@@ -11473,10 +11705,11 @@ dictionary GPUCanvasConfiguration {
         {{GPUCanvasContext/getCurrentTexture()}} when read, displayed, or used as an image source.
 </dl>
 
-<div class="example">
+<div class=example>
     Configure a {{GPUCanvasContext}} to be used with a specific {{GPUDevice}}, using the preferred
     format for this context:
-    <pre highlight="js">
+
+    <pre highlight=js>
         const canvas = document.createElement('canvas');
         const context = canvas.getContext('webgpu');
 
@@ -11542,12 +11775,12 @@ In WebGPU, it does so by [$Replace the drawing buffer|replacing the drawing buff
     validation will fail inside {{GPUCanvasContext/getCurrentTexture()}}.
 </div>
 
-<div class="example">
+<div class=example>
     Reconfigure a {{GPUCanvasContext}} in response to canvas resize, monitored using
     [ResizeObserver](https://www.w3.org/TR/resize-observer/) to get the exact pixel dimensions of
     the canvas:
 
-    <pre highlight="js">
+    <pre highlight=js>
         const canvas = document.createElement('canvas');
         const context = canvas.getContext('webgpu');
 
@@ -11569,7 +11802,7 @@ This enum selects how the contents of the canvas will be interpreted when read, 
 [$get a copy of the image contents of a context|used as an image source$]
 (in drawImage, toDataURL, etc.)
 
-<table class='data'>
+<table class=data>
     <thead>
         <tr>
             <th>GPUCanvasAlphaMode
@@ -11706,7 +11939,7 @@ partial interface GPUDevice {
 
 {{GPUDevice}} has the following internal slots:
 
-<dl dfn-type=attribute dfn-for="GPUDevice">
+<dl dfn-type=attribute dfn-for=GPUDevice>
     : <dfn>\[[errorScopeStack]]</dfn>, of type [=stack=]&lt;[=GPU error scope=]&gt;
     ::
         A [=stack=] of [=GPU error scopes=] that have been pushed to the {{GPUDevice}}.
@@ -11718,7 +11951,8 @@ partial interface GPUDevice {
 
     <div class=device-timeline>
         1. If |error| is an instance of:
-            <dl class="switch">
+
+            <dl class=switch>
                 : {{GPUValidationError}}
                 :: Let |type| be "validation".
                 : {{GPUOutOfMemoryError}}
@@ -11739,6 +11973,7 @@ partial interface GPUDevice {
 
     1. Let |error| be a new {{GPUValidationError}} with an appropriate error message.
     1. Issue the following steps to the [=Device timeline=]:
+
         <div class=device-timeline>
             1. Let |scope| be the [$current error scope$] for |error| and |device|.
             1. If |scope| is not `undefined`:
@@ -11746,6 +11981,7 @@ partial interface GPUDevice {
                     |scope|.{{GPU error scope/[[error]]}} to |error|.
                 1. Stop.
             1. Otherwise issue the following steps to the [=Content timeline=]:
+
                 <div class=content-timeline>
                     1. If the user agent chooses, [=queue a task=] to fire a
                         {{GPUUncapturedErrorEvent}} named "{{GPUDevice/uncapturederror}}" on
@@ -11771,11 +12007,13 @@ partial interface GPUDevice {
             **Called on:** {{GPUDevice}} |this|.
 
             **Arguments:**
+
             <pre class=argumentdef for="GPUDevice/pushErrorScope(filter)">
                 |filter|: Which class of errors this error scope observes.
             </pre>
 
             1. Issue the following steps to the [=Device timeline=]:
+
                 <div class=device-timeline>
                     1. Let |scope| be a new [=GPU error scope=].
                     1. Set |scope|.{{GPU error scope/[[filter]]}} to |filter|.
@@ -11795,6 +12033,7 @@ partial interface GPUDevice {
 
             1. Let |promise| be [=a new promise=].
             1. Issue the following steps to the [=Device timeline=]:
+
                 <div class=device-timeline>
                     1. If any of the following requirements are unmet,
                         [=reject=] |promise| with an {{OperationError}} and stop.
@@ -11812,9 +12051,10 @@ partial interface GPUDevice {
         </div>
 </dl>
 
-<div class="example">
+<div class=example>
     Using error scopes to capture validation errors from a {{GPUDevice}} operation that may fail:
-    <pre highlight="js">
+
+    <pre highlight=js>
         gpuDevice.pushErrorScope('validation');
 
         let sampler = gpuDevice.createSampler({
@@ -11833,7 +12073,7 @@ partial interface GPUDevice {
 
 ## Telemetry ## {#telemetry}
 
-When a {{GPUError}} is generated that is not observed by any [=GPU error scope=], the user agent **may** [=fire an event=] named <dfn event for="GPUDevice">uncapturederror</dfn> at a {{GPUDevice}} using {{GPUUncapturedErrorEvent}}.
+When a {{GPUError}} is generated that is not observed by any [=GPU error scope=], the user agent **may** [=fire an event=] named <dfn event for=GPUDevice>uncapturederror</dfn> at a {{GPUDevice}} using {{GPUUncapturedErrorEvent}}.
 
 Note: {{GPUDevice/uncapturederror}} events are intended to be used for telemetry and reporting
 unexpected errors. They may not be dispatched for all uncaptured errors (for example, there may be a limit on the number of errors surfaced), and should not be used for handling known error cases that may occur during
@@ -11880,16 +12120,16 @@ partial interface GPUDevice {
 
 {{GPUDevice}} has the following attributes:
 
-<dl dfn-type=attribute dfn-for="GPUDevice">
+<dl dfn-type=attribute dfn-for=GPUDevice>
     : <dfn>onuncapturederror</dfn>
     ::
         An [=event handler IDL attribute=] for the {{GPUDevice/uncapturederror}} event type.
 </dl>
 
-<div class="example">
+<div class=example>
     Listening for uncaptured errors from a {{GPUDevice}}:
 
-    <pre highlight="js">
+    <pre highlight=js>
         gpuDevice.addEventListener('uncapturederror', (event) => {
             // Re-surface the error, because adding an event listener may silence console logs.
             console.error('A WebGPU error was not captured:', event.error);
@@ -11917,8 +12157,9 @@ Compute shaders do not have pipeline inputs or outputs, their results are
 side effects from writing data into storage bindings bound as
 {{GPUBufferBindingType/"storage"|GPUBufferBindingType."storage"}} and {{GPUStorageTextureBindingLayout}}.
 These operations are encoded within {{GPUComputePassEncoder}} as:
-  - {{GPUComputePassEncoder/dispatchWorkgroups()}}
-  - {{GPUComputePassEncoder/dispatchWorkgroupsIndirect()}}
+
+- {{GPUComputePassEncoder/dispatchWorkgroups()}}
+- {{GPUComputePassEncoder/dispatchWorkgroupsIndirect()}}
 
 Issue: describe the computing algorithm
 
@@ -11927,10 +12168,11 @@ Issue: describe the computing algorithm
 Rendering is done by a set of GPU operations that are executed within {{GPURenderPassEncoder}},
 and result in modifications of the texture data, viewed by the render pass attachments.
 These operations are encoded with:
-  - {{GPURenderCommandsMixin/draw()}}
-  - {{GPURenderCommandsMixin/drawIndexed()}},
-  - {{GPURenderCommandsMixin/drawIndirect()}}
-  - {{GPURenderCommandsMixin/drawIndexedIndirect()}}.
+
+- {{GPURenderCommandsMixin/draw()}}
+- {{GPURenderCommandsMixin/drawIndexed()}},
+- {{GPURenderCommandsMixin/drawIndirect()}}
+- {{GPURenderCommandsMixin/drawIndexedIndirect()}}.
 
 Note: rendering is the traditional use of GPUs, and is supported by multiple fixed-function
 blocks in hardware.
@@ -11941,15 +12183,15 @@ of the current {{GPURenderPassEncoder}} during command encoding.
 <div algorithm="RenderState accessors" dfn-for=RenderState>
     For a given {{GPURenderPassEncoder}} |pass|, the syntax:
 
-      - |pass|.<dfn dfn>indexBuffer</dfn> refers to
+    - |pass|.<dfn dfn>indexBuffer</dfn> refers to
         the index buffer bound via {{GPURenderCommandsMixin/setIndexBuffer()}}, if any.
-      - |pass|.<dfn dfn>vertexBuffers</dfn> refers to
+    - |pass|.<dfn dfn>vertexBuffers</dfn> refers to
         [=list=]&lt;vertex buffer&gt; bound by {{GPURenderCommandsMixin/setVertexBuffer()}}.
-      - |pass|.<dfn dfn>bindGroups</dfn> refers to
+    - |pass|.<dfn dfn>bindGroups</dfn> refers to
         [=list=]&lt;{{GPUBindGroup}}&gt; bound by {{GPUBindingCommandsMixin/setBindGroup(index, bindGroup, dynamicOffsets)}}.
-      - |pass|.<dfn dfn>viewport</dfn> refers to an object containing {{GPURenderPassEncoder/setViewport()}} arguments.
+    - |pass|.<dfn dfn>viewport</dfn> refers to an object containing {{GPURenderPassEncoder/setViewport()}} arguments.
         At the start of a render pass, the state is equivalent to a call of setViewport(0, 0, |pass|.{{GPURenderPassEncoder/[[attachment_size]]}}.width, |pass|.{{GPURenderPassEncoder/[[attachment_size]]}}.height, 0.0, 1.0).
-      - |pass|.<dfn dfn>scissorRect</dfn> refers to an object containing {{GPURenderPassEncoder/setScissorRect()}} arguments.
+    - |pass|.<dfn dfn>scissorRect</dfn> refers to an object containing {{GPURenderPassEncoder/setScissorRect()}} arguments.
         At the start of a render pass, the state is equivalent to a call of setScissorRect(0, 0, |pass|.{{GPURenderPassEncoder/[[attachment_size]]}}.width, |pass|.{{GPURenderPassEncoder/[[attachment_size]]}}.height).
 </div>
 
@@ -11959,9 +12201,10 @@ The main rendering algorithm:
     <dfn abstract-op>render</dfn>(descriptor, drawCall, state)
 
         **Arguments:**
-            - |descriptor|: Description of the current {{GPURenderPipeline}}.
-            - |drawCall|: The draw call parameters.
-            - |state|: [=RenderState=] of the {{GPURenderCommandsMixin}} where the draw call is issued.
+
+        - |descriptor|: Description of the current {{GPURenderPipeline}}.
+        - |drawCall|: The draw call parameters.
+        - |state|: [=RenderState=] of the {{GPURenderCommandsMixin}} where the draw call is issued.
 
         1. **Resolve indices**. See [[#index-resolution]].
 
@@ -12007,6 +12250,7 @@ a list of vertices to process for each instance.
     <dfn abstract-op>resolve indices</dfn>(drawCall, state)
 
     **Arguments:**
+
     - |drawCall|: The draw call parameters.
     - |state|: The active [=RenderState=].
 
@@ -12040,13 +12284,15 @@ a list of vertices to process for each instance.
     <dfn abstract-op>fetch index</dfn>(i, buffer, offset, format)
 
     **Arguments:**
+
     - |i|: Index of a vertex index to fetch.
     - |indexBufferState|: A value of [=RenderState/indexBuffer=] (buffer, format, offset, and size).
 
     **Returns:** unsigned integer or `"out of bounds"`
 
     1. Let |indexSize| be defined by the |indexBufferState|.`format`:
-        <dl class="switch">
+
+        <dl class=switch>
             : {{GPUIndexFormat/"uint16"}}
             :: 2
             : {{GPUIndexFormat/"uint32"}}
@@ -12070,6 +12316,7 @@ clip space positions for [[#primitive-clipping]], as well as other data for the
     <dfn abstract-op>process vertices</dfn>(vertexIndexList, drawCall, desc, state)
 
     **Arguments:**
+
     - |vertexIndexList|: List of vertex indices to process (mutable, passed by reference).
     - |drawCall|: The draw call parameters.
     - |desc|: The descriptor of type {{GPUVertexState}}.
@@ -12081,13 +12328,15 @@ clip space positions for [[#primitive-clipping]], as well as other data for the
     This processing happens in parallel, and any side effects, such as
     writes into {{GPUBufferBindingType/"storage"|GPUBufferBindingType."storage"}} bindings,
     may happen in any order.
+
     1. Let |instanceIndex| be |rawInstanceIndex| + |drawCall|.firstInstance.
     1. For each non-`null` |vertexBufferLayout| in the list of |desc|.{{GPUVertexState/buffers}}:
         1. Let |i| be the index of the buffer layout in this list.
         1. Let |vertexBuffer|, |vertexBufferOffset|, and |vertexBufferBindingSize| be the
             buffer, offset, and size at slot |i| of |state|.[=RenderState/vertexBuffers=].
         1. Let |vertexElementIndex| be dependent on |vertexBufferLayout|.{{GPUVertexBufferLayout/stepMode}}:
-            <dl class="switch">
+
+            <dl class=switch>
                 : {{GPUVertexStepMode/"vertex"}}
                 :: |vertexIndex|
                 : {{GPUVertexStepMode/"instance"}}
@@ -12111,7 +12360,8 @@ clip space positions for [[#primitive-clipping]], as well as other data for the
                 Note: This allows implementations to detect out-of-bounds values in the index buffer
                 before issuing a draw call, instead of using [=invalid memory reference=] behavior.
             1. Convert the |data| into a shader-visible format, according to [=channel formats=] rules.
-                <div class="example">
+
+                <div class=example>
                     An attribute of type {{GPUVertexFormat/"snorm8x2"}} and byte values of `[0x70, 0xD0]`
                     will be converted to `vec2<f32>(0.88, -0.38)` in WGSL.
                 </div>
@@ -12119,13 +12369,15 @@ clip space positions for [[#primitive-clipping]], as well as other data for the
                 - if both are scalar, or both are vectors of the same dimensionality, no adjustment is needed.
                 - if |data| is vector but the shader type is scalar, then only the first component is extracted.
                 - if both are vectors, and |data| has a higher dimension, the extra components are dropped.
-                    <div class="example">
+
+                    <div class=example>
                         An attribute of type {{GPUVertexFormat/"float32x3"}} and value `vec3<f32>(1.0, 2.0, 3.0)`
                         will exposed to the shader as `vec2<f32>(1.0, 2.0)` if a 2-component vector is expected.
                     </div>
                 - if the shader type is a vector of higher dimensionality, or the |data| is a scalar,
                     then the missing components are filled from `vec4<*>(0, 0, 0, 1)` value.
-                    <div class="example">
+
+                    <div class=example>
                         An attribute of type {{GPUVertexFormat/"sint32"}} and value `5` will be exposed
                         to the shader as `vec4<i32>(5, 0, 0, 1)` if a 4-component vector is expected.
                     </div>
@@ -12155,9 +12407,10 @@ Primitives are assembled by a fixed-function stage of GPUs.
     <dfn abstract-op>assemble primitives</dfn>(vertexIndexList, drawCall, desc)
 
     **Arguments:**
-        - |vertexIndexList|: List of vertex indices to process.
-        - |drawCall|: The draw call parameters.
-        - |desc|: The descriptor of type {{GPUPrimitiveState}}.
+
+    - |vertexIndexList|: List of vertex indices to process.
+    - |drawCall|: The draw call parameters.
+    - |desc|: The descriptor of type {{GPUPrimitiveState}}.
 
     For each instance, the primitives get assembled from the vertices that have been
     processed by the shaders, based on the |vertexIndexList|.
@@ -12173,7 +12426,8 @@ Primitives are assembled by a fixed-function stage of GPUs.
 
     1. For each of the sub-lists |vl|, primitive generation is done according to the
         |desc|.{{GPUPrimitiveState/topology}}:
-        <dl class="switch">
+
+        <dl class=switch>
             : {{GPUPrimitiveTopology/"line-list"}}
             ::
                 Line primitives are composed from (|vl|.0, |vl|.1),
@@ -12203,7 +12457,6 @@ Primitives are assembled by a fixed-function stage of GPUs.
         Issue: should this be defined more formally?
 
         Any incomplete primitives are dropped.
-
 </div>
 
 ### Primitive Clipping ### {#primitive-clipping}
@@ -12215,9 +12468,10 @@ Issue: link to WGSL built-ins
 
 Primitives are clipped to the <dfn dfn>clip volume</dfn>, which, for any [=clip position=] |p|
 inside a primitive, is defined by the following inequalities:
-  - &minus;|p|.w &le; |p|.x &le; |p|.w
-  - &minus;|p|.w &le; |p|.y &le; |p|.w
-  - 0 &le; |p|.z &le; |p|.w (<dfn dfn>depth clipping</dfn>)
+
+- &minus;|p|.w &le; |p|.x &le; |p|.w
+- &minus;|p|.w &le; |p|.y &le; |p|.w
+- 0 &le; |p|.z &le; |p|.w (<dfn dfn>depth clipping</dfn>)
 
 If |descriptor|.{{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/unclippedDepth}} is `true`,
 [=depth clipping=] is not applied: the [=clip volume=] is not bounded in the z dimension.
@@ -12246,7 +12500,7 @@ where |x|.p is the output [=clip position=] of a vertex |x|.
 For each vertex output value "v" with a corresponding fragment input,
 |a|.v and |b|.v would be the outputs for |a| and |b| vertices respectively.
 The clipped shader output |c|.v is produced based on the interpolation qualifier:
-<dl class="switch">
+<dl class=switch>
     : "flat"
     ::
         Flat interpolation is unaffected, and is based on <dfn dfn>provoking vertex</dfn>,
@@ -12325,6 +12579,7 @@ Issue: define the depth computation algorithm
     <dfn abstract-op>rasterize</dfn>(primitiveList, state)
 
     **Arguments:**
+
     - |primitiveList|: List of primitives to rasterize.
     - |state|: The active [=RenderState=].
 
@@ -12344,18 +12599,19 @@ Issue: define the depth computation algorithm
         Then the [=NDC=] coordinates |n| are converted into [=framebuffer=] coordinates,
         based on the size of the render targets:
 
-       framebufferCoords(|n|) = vector(|vp|.`x` &plus; 0.5 &times; (|n|.x &plus; 1) &times; |vp|.`width`, |vp|.`y` &plus; .5 &times; (|n|.y &plus; 1) &times; |vp|.`height`)
+        framebufferCoords(|n|) = vector(|vp|.`x` &plus; 0.5 &times; (|n|.x &plus; 1) &times; |vp|.`width`, |vp|.`y` &plus; .5 &times; (|n|.y &plus; 1) &times; |vp|.`height`)
 
-       Issue: specify the depth translation into viewport as well
+        Issue: specify the depth translation into viewport as well
 
     1. Let |rasterizationPoints| be an empty list.
 
-      Issue: specify that each rasterization point gets assigned an interpolated `divisor(p)`
-      and `framebufferCoords(n)`, as well as the other attributes.
+        Issue: specify that each rasterization point gets assigned an interpolated `divisor(p)`
+        and `framebufferCoords(n)`, as well as the other attributes.
 
     1. Proceed with a specific rasterization algorithm,
         depending on {{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/topology}}:
-        <dl class="switch">
+
+        <dl class=switch>
             : {{GPUPrimitiveTopology/"point-list"}}
             :: The point, if not filtered by [[#primitive-clipping]], goes into [[#point-rasterization]].
             : {{GPUPrimitiveTopology/"line-list"}} or {{GPUPrimitiveTopology/"line-strip"}}
@@ -12371,7 +12627,6 @@ Issue: define the depth computation algorithm
         outside of |state|.[=RenderState/scissorRect=].
 
     1. Return |rasterizationPoints|.
-
 </div>
 
 #### Point Rasterization #### {#point-rasterization}
@@ -12380,7 +12635,7 @@ A single [=FragmentDestination=] is selected within the pixel containing the
 [=framebuffer=] coordinates of the point.
 
 The coverage mask depends on multi-sampling mode:
-<dl class="switch">
+<dl class=switch>
     : sample-frequency
     :: coverageMask = 1 &Lt; `sampleIndex`
     : pixel-frequency multi-sampling
@@ -12446,7 +12701,8 @@ Otherwise, the polygon is <dfn dfn>back-facing</dfn>.
         |area| = 0.5 &times; ((|v|<sub>1</sub>.x &times; |v|<sub>|n|</sub>.y &minus; |v|<sub>|n|</sub>.x &times; |v|<sub>1</sub>.y) &plus; &sum; (|v|<sub>|i|&plus;1</sub>.x &times; |v|<sub>|i|</sub>.y &minus; |v|<sub>|i|</sub>.x &times; |v|<sub>|i|&plus;1</sub>.y))
 
         The sign of |area| is interpreted based on the {{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/frontFace}}:
-        <dl class="switch">
+
+        <dl class=switch>
             : {{GPUFrontFace/"ccw"}}
             :: |area| &gt; 0 is considered [=front-facing=], otherwise [=back-facing=]
             : {{GPUFrontFace/"cw"}}
@@ -12454,7 +12710,8 @@ Otherwise, the polygon is <dfn dfn>back-facing</dfn>.
         </dl>
 
     1. Cull based on {{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/cullMode}}:
-        <dl class="switch">
+
+        <dl class=switch>
             : {{GPUCullMode/"none"}}
             :: All polygons pass this test.
             : {{GPUCullMode/"front"}}
@@ -12468,7 +12725,8 @@ Otherwise, the polygon is <dfn dfn>back-facing</dfn>.
         these are locations scheduled for the per-fragment operations.
         This operation is known as "point sampling".
         The logic is based on |descriptor|.{{GPURenderPipelineDescriptor/multisample}}:
-        <dl class="switch">
+
+        <dl class=switch>
             : disabled
             :: [=Fragment=]s are associated with pixel centers. That is, all the points with coordinates |C|, where
                 fract(|C|) = vector2(0.5, 0.5) in the [=framebuffer=] space, enclosed into the polygon, are included.
@@ -12499,7 +12757,6 @@ Otherwise, the polygon is <dfn dfn>back-facing</dfn>.
         1. Append |rp| to |rasterizationPoints|.
 
     1. Return |rasterizationPoints|.
-
 </div>
 
 ### Fragment Processing ### {#fragment-processing}
@@ -12520,6 +12777,7 @@ This stage produces a <dfn dfn>Fragment</dfn> for each [=RasterizationPoint=]:
     <dfn abstract-op>process fragment</dfn>(rp, desc, state)
 
     **Arguments:**
+
     - |rp|: The [=RasterizationPoint=], produced by [[#rasterization]].
     - |desc|: The descriptor of type {{GPUFragmentState}}.
     - |state|: The active [=RenderState=].
@@ -12533,7 +12791,8 @@ This stage produces a <dfn dfn>Fragment</dfn> for each [=RasterizationPoint=]:
     1. If |desc| is not `null`:
         1. Set the shader input [=builtins=]. For each non-composite argument of the entry point,
             annotated as a [=builtin=], set its value based on the annotation:
-            <dl class="switch">
+
+            <dl class=switch>
                 : `position`
                 :: `vec4<f32>`(|rp|.[=RasterizationPoint/destination=].[=FragmentDestination/position=], |rp|.[=RasterizationPoint/depth=], |rp|.[=RasterizationPoint/perspectiveDivisor=])
 
@@ -12594,9 +12853,10 @@ fragment shader output value of the {{GPURenderPipelineDescriptor/fragment}}.{{G
 
 The algorithm of producing the extra mask is platform-dependent and can vary for different pixels.
 It guarantees that:
-  - if |alpha| is 0.0 or less, the result is 0x0
-  - if |alpha| is 1.0 or greater, the result is 0xFFFFFFFF
-  - if |alpha| is greater than some other |alpha1|,
+
+- if |alpha| is 0.0 or less, the result is 0x0
+- if |alpha| is 1.0 or greater, the result is 0xFFFFFFFF
+- if |alpha| is greater than some other |alpha1|,
     then the produced sample mask has at least as many bits set to 1 as the mask for |alpha1|
 
 ### Sample frequency shading ### {#sample-frequency-shading}
@@ -12673,10 +12933,10 @@ An <dfn dfn>Origin2D</dfn> is a {{GPUOrigin2D}}.
 <div algorithm="GPUOrigin2D accessors" dfn-for=Origin2D>
     For a given {{GPUOrigin2D}} value |origin|, depending on its type, the syntax:
 
-      - |origin|.<dfn dfn>x</dfn> refers to
+    - |origin|.<dfn dfn>x</dfn> refers to
         either {{GPUOrigin2DDict}}.{{GPUOrigin2DDict/x}}
         or the first item of the sequence or 0 if it isn't present.
-      - |origin|.<dfn dfn>y</dfn> refers to
+    - |origin|.<dfn dfn>y</dfn> refers to
         either {{GPUOrigin2DDict}}.{{GPUOrigin2DDict/y}}
         or the second item of the sequence or 0 if it isn't present.
 </div>
@@ -12697,13 +12957,13 @@ An <dfn dfn>Origin3D</dfn> is a {{GPUOrigin3D}}.
 <div algorithm="GPUOrigin3D accessors" dfn-for=Origin3D>
     For a given {{GPUOrigin3D}} value |origin|, depending on its type, the syntax:
 
-      - |origin|.<dfn dfn>x</dfn> refers to
+    - |origin|.<dfn dfn>x</dfn> refers to
         either {{GPUOrigin3DDict}}.{{GPUOrigin3DDict/x}}
         or the first item of the sequence or 0 if it isn't present.
-      - |origin|.<dfn dfn>y</dfn> refers to
+    - |origin|.<dfn dfn>y</dfn> refers to
         either {{GPUOrigin3DDict}}.{{GPUOrigin3DDict/y}}
         or the second item of the sequence or 0 if it isn't present.
-      - |origin|.<dfn dfn>z</dfn> refers to
+    - |origin|.<dfn dfn>z</dfn> refers to
         either {{GPUOrigin3DDict}}.{{GPUOrigin3DDict/z}}
         or the third item of the sequence or 0 if it isn't present.
 </div>
@@ -12724,13 +12984,13 @@ An <dfn dfn>Extent3D</dfn> is a {{GPUExtent3D}}.
 <div algorithm="GPUExtent3D accessors" dfn-for=Extent3D>
     For a given {{GPUExtent3D}} value |extent|, depending on its type, the syntax:
 
-      - |extent|.<dfn dfn>width</dfn> refers to
+    - |extent|.<dfn dfn>width</dfn> refers to
         either {{GPUExtent3DDict}}.{{GPUExtent3DDict/width}}
         or the first item of the sequence (1 if not present).
-      - |extent|.<dfn dfn>height</dfn> refers to
+    - |extent|.<dfn dfn>height</dfn> refers to
         either {{GPUExtent3DDict}}.{{GPUExtent3DDict/height}}
         or the second item of the sequence (1 if not present).
-      - |extent|.<dfn dfn>depthOrArrayLayers</dfn> refers to
+    - |extent|.<dfn dfn>depthOrArrayLayers</dfn> refers to
         either {{GPUExtent3DDict}}.{{GPUExtent3DDict/depthOrArrayLayers}}
         or the third item of the sequence (1 if not present).
 </div>
@@ -12746,11 +13006,8 @@ Issue: Define functionality when the {{GPUFeatureName/"depth-clip-control"}} [=f
 The following dictionary values are supported if and only if the {{GPUFeatureName/"depth-clip-control"}}
 [=feature=] is enabled; otherwise, they must be set to their default values:
 
-<dl>
-    : {{GPUPrimitiveState}}
-    ::
-        * {{GPUPrimitiveState/unclippedDepth}}
-</dl>
+- {{GPUPrimitiveState}}
+    - {{GPUPrimitiveState/unclippedDepth}}
 
 ## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>"depth32float-stencil8"</dfn> ## {#depth32float-stencil8}
 
@@ -12761,11 +13018,8 @@ Allows for explicit creation of textures of format {{GPUTextureFormat/"depth32fl
 The following enums are supported if and only if the {{GPUFeatureName/"depth32float-stencil8"}}
 [=feature=] is enabled:
 
-<dl>
-    : {{GPUTextureFormat}}
-    ::
-        * {{GPUTextureFormat/"depth32float-stencil8"}}
-</dl>
+- {{GPUTextureFormat}}
+    - {{GPUTextureFormat/"depth32float-stencil8"}}
 
 ## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>"texture-compression-bc"</dfn> ## {#texture-compression-bc}
 
@@ -12776,24 +13030,21 @@ Allows for explicit creation of textures of BC compressed formats.
 The following enums are supported if and only if the {{GPUFeatureName/"texture-compression-bc"}}
 [=feature=] is enabled:
 
-<dl>
-    : {{GPUTextureFormat}}
-    ::
-        * {{GPUTextureFormat/"bc1-rgba-unorm"}}
-        * {{GPUTextureFormat/"bc1-rgba-unorm-srgb"}}
-        * {{GPUTextureFormat/"bc2-rgba-unorm"}}
-        * {{GPUTextureFormat/"bc2-rgba-unorm-srgb"}}
-        * {{GPUTextureFormat/"bc3-rgba-unorm"}}
-        * {{GPUTextureFormat/"bc3-rgba-unorm-srgb"}}
-        * {{GPUTextureFormat/"bc4-r-unorm"}}
-        * {{GPUTextureFormat/"bc4-r-snorm"}}
-        * {{GPUTextureFormat/"bc5-rg-unorm"}}
-        * {{GPUTextureFormat/"bc5-rg-snorm"}}
-        * {{GPUTextureFormat/"bc6h-rgb-ufloat"}}
-        * {{GPUTextureFormat/"bc6h-rgb-float"}}
-        * {{GPUTextureFormat/"bc7-rgba-unorm"}}
-        * {{GPUTextureFormat/"bc7-rgba-unorm-srgb"}}
-</dl>
+- {{GPUTextureFormat}}
+    - {{GPUTextureFormat/"bc1-rgba-unorm"}}
+    - {{GPUTextureFormat/"bc1-rgba-unorm-srgb"}}
+    - {{GPUTextureFormat/"bc2-rgba-unorm"}}
+    - {{GPUTextureFormat/"bc2-rgba-unorm-srgb"}}
+    - {{GPUTextureFormat/"bc3-rgba-unorm"}}
+    - {{GPUTextureFormat/"bc3-rgba-unorm-srgb"}}
+    - {{GPUTextureFormat/"bc4-r-unorm"}}
+    - {{GPUTextureFormat/"bc4-r-snorm"}}
+    - {{GPUTextureFormat/"bc5-rg-unorm"}}
+    - {{GPUTextureFormat/"bc5-rg-snorm"}}
+    - {{GPUTextureFormat/"bc6h-rgb-ufloat"}}
+    - {{GPUTextureFormat/"bc6h-rgb-float"}}
+    - {{GPUTextureFormat/"bc7-rgba-unorm"}}
+    - {{GPUTextureFormat/"bc7-rgba-unorm-srgb"}}
 
 ## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>"texture-compression-etc2"</dfn> ## {#texture-compression-etc}
 
@@ -12804,20 +13055,17 @@ Allows for explicit creation of textures of ETC2 compressed formats.
 The following enums are supported if and only if the {{GPUFeatureName/"texture-compression-etc2"}}
 [=feature=] is enabled:
 
-<dl>
-    : {{GPUTextureFormat}}
-    ::
-        * {{GPUTextureFormat/"etc2-rgb8unorm"}}
-        * {{GPUTextureFormat/"etc2-rgb8unorm-srgb"}}
-        * {{GPUTextureFormat/"etc2-rgb8a1unorm"}}
-        * {{GPUTextureFormat/"etc2-rgb8a1unorm-srgb"}}
-        * {{GPUTextureFormat/"etc2-rgba8unorm"}}
-        * {{GPUTextureFormat/"etc2-rgba8unorm-srgb"}}
-        * {{GPUTextureFormat/"eac-r11unorm"}}
-        * {{GPUTextureFormat/"eac-r11snorm"}}
-        * {{GPUTextureFormat/"eac-rg11unorm"}}
-        * {{GPUTextureFormat/"eac-rg11snorm"}}
-</dl>
+- {{GPUTextureFormat}}
+    - {{GPUTextureFormat/"etc2-rgb8unorm"}}
+    - {{GPUTextureFormat/"etc2-rgb8unorm-srgb"}}
+    - {{GPUTextureFormat/"etc2-rgb8a1unorm"}}
+    - {{GPUTextureFormat/"etc2-rgb8a1unorm-srgb"}}
+    - {{GPUTextureFormat/"etc2-rgba8unorm"}}
+    - {{GPUTextureFormat/"etc2-rgba8unorm-srgb"}}
+    - {{GPUTextureFormat/"eac-r11unorm"}}
+    - {{GPUTextureFormat/"eac-r11snorm"}}
+    - {{GPUTextureFormat/"eac-rg11unorm"}}
+    - {{GPUTextureFormat/"eac-rg11snorm"}}
 
 ## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>"texture-compression-astc"</dfn> ## {#texture-compression-astc}
 
@@ -12828,38 +13076,35 @@ Allows for explicit creation of textures of ASTC compressed formats.
 The following enums are supported if and only if the {{GPUFeatureName/"texture-compression-astc"}}
 [=feature=] is enabled:
 
-<dl>
-    : {{GPUTextureFormat}}
-    ::
-        * {{GPUTextureFormat/"astc-4x4-unorm"}}
-        * {{GPUTextureFormat/"astc-4x4-unorm-srgb"}}
-        * {{GPUTextureFormat/"astc-5x4-unorm"}}
-        * {{GPUTextureFormat/"astc-5x4-unorm-srgb"}}
-        * {{GPUTextureFormat/"astc-5x5-unorm"}}
-        * {{GPUTextureFormat/"astc-5x5-unorm-srgb"}}
-        * {{GPUTextureFormat/"astc-6x5-unorm"}}
-        * {{GPUTextureFormat/"astc-6x5-unorm-srgb"}}
-        * {{GPUTextureFormat/"astc-6x6-unorm"}}
-        * {{GPUTextureFormat/"astc-6x6-unorm-srgb"}}
-        * {{GPUTextureFormat/"astc-8x5-unorm"}}
-        * {{GPUTextureFormat/"astc-8x5-unorm-srgb"}}
-        * {{GPUTextureFormat/"astc-8x6-unorm"}}
-        * {{GPUTextureFormat/"astc-8x6-unorm-srgb"}}
-        * {{GPUTextureFormat/"astc-8x8-unorm"}}
-        * {{GPUTextureFormat/"astc-8x8-unorm-srgb"}}
-        * {{GPUTextureFormat/"astc-10x5-unorm"}}
-        * {{GPUTextureFormat/"astc-10x5-unorm-srgb"}}
-        * {{GPUTextureFormat/"astc-10x6-unorm"}}
-        * {{GPUTextureFormat/"astc-10x6-unorm-srgb"}}
-        * {{GPUTextureFormat/"astc-10x8-unorm"}}
-        * {{GPUTextureFormat/"astc-10x8-unorm-srgb"}}
-        * {{GPUTextureFormat/"astc-10x10-unorm"}}
-        * {{GPUTextureFormat/"astc-10x10-unorm-srgb"}}
-        * {{GPUTextureFormat/"astc-12x10-unorm"}}
-        * {{GPUTextureFormat/"astc-12x10-unorm-srgb"}}
-        * {{GPUTextureFormat/"astc-12x12-unorm"}}
-        * {{GPUTextureFormat/"astc-12x12-unorm-srgb"}}
-</dl>
+- {{GPUTextureFormat}}
+    - {{GPUTextureFormat/"astc-4x4-unorm"}}
+    - {{GPUTextureFormat/"astc-4x4-unorm-srgb"}}
+    - {{GPUTextureFormat/"astc-5x4-unorm"}}
+    - {{GPUTextureFormat/"astc-5x4-unorm-srgb"}}
+    - {{GPUTextureFormat/"astc-5x5-unorm"}}
+    - {{GPUTextureFormat/"astc-5x5-unorm-srgb"}}
+    - {{GPUTextureFormat/"astc-6x5-unorm"}}
+    - {{GPUTextureFormat/"astc-6x5-unorm-srgb"}}
+    - {{GPUTextureFormat/"astc-6x6-unorm"}}
+    - {{GPUTextureFormat/"astc-6x6-unorm-srgb"}}
+    - {{GPUTextureFormat/"astc-8x5-unorm"}}
+    - {{GPUTextureFormat/"astc-8x5-unorm-srgb"}}
+    - {{GPUTextureFormat/"astc-8x6-unorm"}}
+    - {{GPUTextureFormat/"astc-8x6-unorm-srgb"}}
+    - {{GPUTextureFormat/"astc-8x8-unorm"}}
+    - {{GPUTextureFormat/"astc-8x8-unorm-srgb"}}
+    - {{GPUTextureFormat/"astc-10x5-unorm"}}
+    - {{GPUTextureFormat/"astc-10x5-unorm-srgb"}}
+    - {{GPUTextureFormat/"astc-10x6-unorm"}}
+    - {{GPUTextureFormat/"astc-10x6-unorm-srgb"}}
+    - {{GPUTextureFormat/"astc-10x8-unorm"}}
+    - {{GPUTextureFormat/"astc-10x8-unorm-srgb"}}
+    - {{GPUTextureFormat/"astc-10x10-unorm"}}
+    - {{GPUTextureFormat/"astc-10x10-unorm-srgb"}}
+    - {{GPUTextureFormat/"astc-12x10-unorm"}}
+    - {{GPUTextureFormat/"astc-12x10-unorm-srgb"}}
+    - {{GPUTextureFormat/"astc-12x12-unorm"}}
+    - {{GPUTextureFormat/"astc-12x12-unorm-srgb"}}
 
 ## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>"timestamp-query"</dfn> ## {#timestamp-query}
 
@@ -12870,11 +13115,8 @@ Issue: Define functionality when the {{GPUFeatureName/"timestamp-query"}} [=feat
 The following enums are supported if and only if the {{GPUFeatureName/"timestamp-query"}}
 [=feature=] is enabled:
 
-<dl>
-    : {{GPUQueryType}}
-    ::
-        * {{GPUQueryType/"timestamp"}}
-</dl>
+- {{GPUQueryType}}
+    - {{GPUQueryType/"timestamp"}}
 
 ## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>"indirect-first-instance"</dfn> ## {#indirect-first-instance}
 
@@ -12903,7 +13145,7 @@ The {{GPUTextureUsage/RENDER_ATTACHMENT}} and {{GPUTextureUsage/STORAGE_BINDING}
 specify support for {{GPUTextureUsage/RENDER_ATTACHMENT|GPUTextureUsage.RENDER_ATTACHMENT}}
 and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage respectively.
 
-<table class='data'>
+<table class=data>
     <thead class=stickyheader>
         <tr>
             <th>Format
@@ -13198,7 +13440,6 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>
         <td><!-- Vulkan -->
         <td>4
-
 </table>
 
 ### Depth-stencil formats ### {#depth-formats}
@@ -13215,7 +13456,7 @@ However, certain copy operations also restrict the source and destination format
 Depth textures cannot be used with {{GPUSamplerBindingType/"filtering"}} samplers, but can always
 be used with {{GPUSamplerBindingType/"comparison"}} samplers (which may use filtering).
 
-<table class='data'>
+<table class=data>
     <thead>
         <tr>
             <th>Format
@@ -13252,7 +13493,7 @@ be used with {{GPUSamplerBindingType/"comparison"}} samplers (which may use filt
         <td colspan=2>&cross;
         <td>{{GPUTextureFormat/depth24plus}}
     <tr>
-        <td rowspan=2 style='white-space:nowrap'>{{GPUTextureFormat/depth24plus-stencil8}}
+        <td rowspan=2 style="white-space: nowrap">{{GPUTextureFormat/depth24plus-stencil8}}
         <td rowspan=2>4 &minus; 8
         <td>depth
         <td>- (<a href="#depthPlus">See prose</a>)
@@ -13275,7 +13516,7 @@ be used with {{GPUSamplerBindingType/"comparison"}} samplers (which may use filt
         <td colspan=1>&cross;
         <td>{{GPUTextureFormat/depth32float}}
     <tr>
-        <td rowspan=2 style='white-space:nowrap'>{{GPUTextureFormat/depth32float-stencil8}}
+        <td rowspan=2 style="white-space: nowrap">{{GPUTextureFormat/depth32float-stencil8}}
         <td rowspan=2>5 &minus; 8
         <td>depth
         <td>4
@@ -13338,6 +13579,7 @@ have opaque representations (implemented as either "depth24unorm" or "depth32flo
 As a result, depth-aspect [=image copies=] are not allowed with these formats.
 
 <div class=note>
+    Note:
     It is possible to imitate these disallowed copies:
 
     - All of these formats can be written in a render pass using a fragment shader that outputs
@@ -13357,7 +13599,7 @@ A <dfn dfn>compressed format</dfn> is any format with a block size greater than 
 
 The [=texel block size=] (in bytes) of a packed format is equal to the Bytes per block column below.
 
-<table class='data'>
+<table class=data>
     <thead class=stickyheader>
         <tr>
             <th>Format
@@ -13528,9 +13770,8 @@ The [=texel block size=] (in bytes) of a packed format is equal to the Bytes per
 
 ## Temporary usages of non-exported dfns ## {#temp-dfn-usages}
 
-[=Origin2D/x=] [=Origin2D/y=]
-[=RenderPassDescriptor/renderExtent=]
-
 Eventually all of these should disappear but they are useful to avoid warning while building the specification.
 
+[=Origin2D/x=] [=Origin2D/y=]
+[=RenderPassDescriptor/renderExtent=]
 [=vertex buffer=]


### PR DESCRIPTION
- Fix a bunch of indentation errors and inconsistencies (e.g. lists
  shouldn't be indented relative to surrounding text)
- Fix a bunch of blank-line error and style (blank lines between
  "paragraphs")
- Normalize a bunch of whitespace and HTML attribute style
- Add some closing tags for things other than tr/td/th
- Use more appropriate list types in a few places

I'm sure I missed some, but this should take care of the biggest
inconsistencies