### PR TITLE
Use inequality symbols instead of words in validation rules

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2872,7 +2872,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                         TODO: check destroyed state?
                     - |offset| is a multiple of 8.
                     - |rangeSize| is a multiple of 4.
-                    - |offset| + |rangeSize| is less or equal to |this|.{{GPUBuffer/size}}
+                    - |offset| + |rangeSize| &le; |this|.{{GPUBuffer/size}}
                     - |this|.{{GPUBuffer/[[state]]}} is [=buffer state/unmapped=]
                     - |mode| contains exactly one of {{GPUMapMode/READ}} or {{GPUMapMode/WRITE}}.
                     - If |mode| contains {{GPUMapMode/READ}} then |this|.{{GPUBuffer/usage}} must contain {{GPUBufferUsage/MAP_READ}}.
@@ -2936,8 +2936,8 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                     - |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapped=] or [=buffer state/mapped at creation=].
                     - |offset| is a multiple of 8.
                     - |rangeSize| is a multiple of 4.
-                    - |offset| is greater than or equal to |this|.{{GPUBuffer/[[mapping_range]]}}[0].
-                    - |offset| + |rangeSize| is less than or equal to |this|.{{GPUBuffer/[[mapping_range]]}}[1].
+                    - |offset| &ge; |this|.{{GPUBuffer/[[mapping_range]]}}[0].
+                    - |offset| + |rangeSize| &le; |this|.{{GPUBuffer/[[mapping_range]]}}[1].
                     - [|offset|, |offset| + |rangeSize|) does not overlap another range in |this|.{{GPUBuffer/[[mapped_ranges]]}}.
 
                     Note: It is always valid to get mapped ranges of a {{GPUBuffer}} that is
@@ -3334,15 +3334,15 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
     - |descriptor|.{{GPUTextureDescriptor/usage}} must contain only bits present in |this|'s [=allowed texture usages=].
     - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=],
         |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=],
-        and |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be greater than zero.
-    - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be greater than zero.
+        and |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be &gt; zero.
+    - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be &gt; zero.
     - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be either 1 or 4.
     - If |descriptor|.{{GPUTextureDescriptor/dimension}} is:
 
         <dl class=switch>
             : {{GPUTextureDimension/"1d"}}
             ::
-                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be less than or equal to
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be &le;
                     |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension1D}}.
                 - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be 1.
                 - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be 1.
@@ -3351,21 +3351,21 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
 
             : {{GPUTextureDimension/"2d"}}
             ::
-                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be less than or equal to
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be &le;
                     |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
-                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be less than or equal to
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be &le;
                     |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension2D}}.
-                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be less than
-                    or equal to |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureArrayLayers}}.
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be &le;
+                    |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureArrayLayers}}.
 
             : {{GPUTextureDimension/"3d"}}
             ::
-                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be less than or equal to
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] must be &le;
                     |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension3D}}.
-                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be less than or equal to
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] must be &le;
                     |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension3D}}.
-                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be less than
-                    or equal to |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension3D}}.
+                - |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] must be &le;
+                    |this|.{{GPUDevice/limits}}.{{GPUSupportedLimits/maxTextureDimension3D}}.
                 - |descriptor|.{{GPUTextureDescriptor/sampleCount}} must be 1.
                 - |descriptor|.{{GPUTextureDescriptor/format}} must not be a [=compressed format=] or [=depth-or-stencil format=].
         </dl>
@@ -3377,7 +3377,7 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
         - |descriptor|.{{GPUTextureDescriptor/usage}} must not include the {{GPUTextureUsage/STORAGE_BINDING}} bit.
         - |descriptor|.{{GPUTextureDescriptor/usage}} must include the {{GPUTextureUsage/RENDER_ATTACHMENT}} bit.
         - |descriptor|.{{GPUTextureDescriptor/format}} must support multisampling according to [[#texture-format-caps]].
-    - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be less than or equal to
+    - |descriptor|.{{GPUTextureDescriptor/mipLevelCount}} must be &le;
         [$maximum mipLevel count$](|descriptor|.{{GPUTextureDescriptor/dimension}}, |descriptor|.{{GPUTextureDescriptor/size}}).
     - If |descriptor|.{{GPUTextureDescriptor/usage}} includes the {{GPUTextureUsage/RENDER_ATTACHMENT}} bit:
         - |descriptor|.{{GPUTextureDescriptor/format}} must be a [=renderable format=].
@@ -3649,13 +3649,13 @@ enum GPUTextureAspect {
                             - |this| is [=valid=].
                             - |descriptor|.{{GPUTextureViewDescriptor/aspect}} must be present in |this|.{{GPUTexture/format}}.
                             - If the |descriptor|.{{GPUTextureViewDescriptor/aspect}} is {{GPUTextureAspect/"all"}}:
-                                - |descriptor|.{{GPUTextureViewDescriptor/format}} must be equal to either
+                                - |descriptor|.{{GPUTextureViewDescriptor/format}} must equal either
                                         |this|.{{GPUTexture/format}} or one
                                         of the formats in |this|.{{GPUTexture/[[viewFormats]]}}.
 
                                 Otherwise:
 
-                                - |descriptor|.{{GPUTextureViewDescriptor/format}} must be equal to the result of [$resolving GPUTextureAspect$](
+                                - |descriptor|.{{GPUTextureViewDescriptor/format}} must equal the result of [$resolving GPUTextureAspect$](
                                     |this|.{{GPUTexture/format}},
                                     |descriptor|.{{GPUTextureViewDescriptor/aspect}}).
 
@@ -3667,7 +3667,7 @@ enum GPUTextureAspect {
                             - |descriptor|.{{GPUTextureViewDescriptor/baseArrayLayer}} +
                                 |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be &le;
                                 the [$array layer count$] of |this|.
-                            - If |this|.{{GPUTexture/sampleCount}} is &gt; 1,
+                            - If |this|.{{GPUTexture/sampleCount}} &gt; 1,
                                 |descriptor|.{{GPUTextureViewDescriptor/dimension}} must be {{GPUTextureViewDimension/"2d"}}.
                             - If |descriptor|.{{GPUTextureViewDescriptor/dimension}} is:
 
@@ -3686,12 +3686,12 @@ enum GPUTextureAspect {
                                     : {{GPUTextureViewDimension/"cube"}}
                                     :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
                                     :: |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `6`.
-                                    :: |this|.{{GPUTexture/width}} must be equal to |this|.{{GPUTexture/height}}.
+                                    :: |this|.{{GPUTexture/width}} must equal |this|.{{GPUTexture/height}}.
 
                                     : {{GPUTextureViewDimension/"cube-array"}}
                                     :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
                                     :: |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be a multiple of `6`.
-                                    :: |this|.{{GPUTexture/width}} must be equal to |this|.{{GPUTexture/height}}.
+                                    :: |this|.{{GPUTexture/width}} must equal |this|.{{GPUTexture/height}}.
 
                                     : {{GPUTextureViewDimension/"3d"}}
                                     :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"3d"}}.
@@ -5204,7 +5204,7 @@ following members:
                                             - |resource|.{{GPUBufferBinding/buffer}} is [$valid to use with$] |this|.
                                             - The bound part designated by |resource|.{{GPUBufferBinding/offset}} and
                                                 |resource|.{{GPUBufferBinding/size}} resides inside the buffer and has non-zero size.
-                                            - [$effective buffer binding size$](|resource|), is greater than or equal to
+                                            - [$effective buffer binding size$](|resource|), &ge;
                                                 |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}}.
 
                                             - If |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/type}} is
@@ -6844,7 +6844,7 @@ interacts with a render pass's multisampled attachments.
 
         Return `true` if all of the following conditions are satisfied:
             - If |descriptor|.{{GPUMultisampleState/alphaToCoverageEnabled}} is `true`:
-                - |descriptor|.{{GPUMultisampleState/count}} is greater than 1.
+                - |descriptor|.{{GPUMultisampleState/count}} &gt; 1.
 </div>
 
 ### Fragment State ### {#fragment-state}
@@ -7750,7 +7750,7 @@ dictionary GPUVertexAttribute {
                 |descriptor|.{{GPUVertexBufferLayout/arrayStride}}.
         - |attrib|.{{GPUVertexAttribute/offset}} is a multiple of the minimum of 4 and
             sizeof(|attrib|.{{GPUVertexAttribute/format}}).
-        - |attrib|.{{GPUVertexAttribute/shaderLocation}} is less than
+        - |attrib|.{{GPUVertexAttribute/shaderLocation}} is &lt;
             |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexAttributes}}.
     - For every vertex attribute in the shader reflection of |vertexStage|.{{GPUProgrammableStage/module}}
         that is a [=pipeline input=] of |vertexStage|.{{GPUProgrammableStage/entryPoint}},
@@ -7779,13 +7779,13 @@ dictionary GPUVertexAttribute {
 
     Return `true`, if and only if, all of the following conditions are satisfied:
 
-    - |descriptor|.{{GPUVertexState/buffers}}.length is less than or equal to
+    - |descriptor|.{{GPUVertexState/buffers}}.length is &le;
         |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexBuffers}}.
     - Each |vertexBuffer| layout descriptor in the list |descriptor|.{{GPUVertexState/buffers}}
         passes [$validating GPUVertexBufferLayout$](|device|, |vertexBuffer|, |descriptor|)
     - The sum of |vertexBuffer|.{{GPUVertexBufferLayout/attributes}}.length,
         over every |vertexBuffer| in |descriptor|.{{GPUVertexState/buffers}},
-        is less than or equal to
+        is &le;
         |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxVertexAttributes}}.
     - Each |attrib| in the union of all {{GPUVertexAttribute}}
         across |descriptor|.{{GPUVertexState/buffers}} has a distinct
@@ -8250,14 +8250,14 @@ dictionary GPUImageCopyTexture {
 
     1. Return `true` if and only if all of the following conditions apply:
         - |imageCopyTexture|.{{GPUImageCopyTexture/texture}} must be a [=valid=] {{GPUTexture}}.
-        - |imageCopyTexture|.{{GPUImageCopyTexture/mipLevel}} must be less than the {{GPUTexture/mipLevelCount}} of
+        - |imageCopyTexture|.{{GPUImageCopyTexture/mipLevel}} must be &lt; {{GPUTexture/mipLevelCount}} of
             |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.
         - |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/x=] must be a multiple of |blockWidth|.
         - |imageCopyTexture|.{{GPUImageCopyTexture/origin}}.[=Origin3D/y=] must be a multiple of |blockHeight|.
         - The [=imageCopyTexture subresource size=] of |imageCopyTexture| is equal to |copySize| if either of
             the following conditions is true:
             - |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/format}} is a depth-stencil format.
-            - |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/sampleCount}} is greater than 1.
+            - |imageCopyTexture|.{{GPUImageCopyTexture/texture}}.{{GPUTexture/sampleCount}} &gt; 1.
 </div>
 
 Issue(gpuweb/gpuweb#69): Define the copies with {{GPUTextureDimension/1d}} and {{GPUTextureDimension/3d}} textures.
@@ -8382,8 +8382,8 @@ dictionary GPUImageCopyExternalImage {
                         - |destinationOffset| is a multiple of 4.
                         - (|sourceOffset| + |size|) does not overflow a {{GPUSize64}}.
                         - (|destinationOffset| + |size|) does not overflow a {{GPUSize64}}.
-                        - |source|.{{GPUBuffer/size}} is greater than or equal to (|sourceOffset| + |size|).
-                        - |destination|.{{GPUBuffer/size}} is greater than or equal to (|destinationOffset| + |size|).
+                        - |source|.{{GPUBuffer/size}} &ge; (|sourceOffset| + |size|).
+                        - |destination|.{{GPUBuffer/size}} &ge; (|destinationOffset| + |size|).
                         - |source| and |destination| are not the same {{GPUBuffer}}.
 
                         Issue(gpuweb/gpuweb#69): figure out how to handle overflows in the spec.
@@ -8426,7 +8426,7 @@ dictionary GPUImageCopyExternalImage {
                         - |buffer|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/COPY_DST}}.
                         - |size| is a multiple of 4.
                         - |offset| is a multiple of 4.
-                        - |buffer|.{{GPUBuffer/size}} is greater than or equal to (|offset| + |size|).
+                        - |buffer|.{{GPUBuffer/size}} &ge; (|offset| + |size|).
                     </div>
             </div>
         </div>
@@ -8484,11 +8484,12 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
 
     1. It is assumed that |copyExtent|.[=Extent3D/width=] is a multiple of |blockWidth|
         and |copyExtent|.[=Extent3D/height=] is a multiple of |blockHeight|. Let:
-            - |widthInBlocks| be |copyExtent|.[=Extent3D/width=] &divide; |blockWidth|.
-            - |heightInBlocks| be |copyExtent|.[=Extent3D/height=] &divide; |blockHeight|.
-            - |bytesInLastRow| be |blockSize| &times; |widthInBlocks|.
+        - |widthInBlocks| be |copyExtent|.[=Extent3D/width=] &divide; |blockWidth|.
+        - |heightInBlocks| be |copyExtent|.[=Extent3D/height=] &divide; |blockHeight|.
+        - |bytesInLastRow| be |blockSize| &times; |widthInBlocks|.
 
     1. Fail if the following conditions are not satisfied:
+
         <div class=validusage>
             - If |heightInBlocks| &gt; 1,
                 |layout|.{{GPUImageDataLayout/bytesPerRow}} must be specified.
@@ -8496,9 +8497,9 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
                 |layout|.{{GPUImageDataLayout/bytesPerRow}} and
                 |layout|.{{GPUImageDataLayout/rowsPerImage}} must be specified.
             - If specified, |layout|.{{GPUImageDataLayout/bytesPerRow}}
-                must be greater than or equal to |bytesInLastRow|.
+                must be &ge; |bytesInLastRow|.
             - If specified, |layout|.{{GPUImageDataLayout/rowsPerImage}}
-                must be greater than or equal to |heightInBlocks|.
+                must be &ge; |heightInBlocks|.
         </div>
 
     1. Let |requiredBytesInCopy| be 0.
@@ -8797,8 +8798,8 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
                         - |querySet| is [$valid to use with$] |this|.
                         - |destination| is [$valid to use with$] |this|.
                         - |destination|.{{GPUBuffer/usage}} contains {{GPUBufferUsage/QUERY_RESOLVE}}.
-                        - |firstQuery| is less than the number of queries in |querySet|.
-                        - (|firstQuery| + |queryCount|) is less than or equal to the number of queries in |querySet|.
+                        - |firstQuery| &lt; the number of queries in |querySet|.
+                        - (|firstQuery| + |queryCount|) &le; the number of queries in |querySet|.
                         - |destinationOffset| is a multiple of 256.
                         - |destinationOffset| + 8 &times; |queryCount| &le; |destination|.{{GPUBuffer/size}}.
                     </div>
@@ -9345,7 +9346,7 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
                     <div class=validusage>
                         - [$Validate encoder bind groups$](|this|, |this|.{{GPUComputePassEncoder/[[pipeline]]}})
                             is `true`.
-                        - all of |workgroupCountX|, |workgroupCountY| and |workgroupCountZ| are less than or equal to
+                        - all of |workgroupCountX|, |workgroupCountY| and |workgroupCountZ| are &le;
                             |this|.device.limits.{{supported limits/maxComputeWorkgroupsPerDimension}}.
                     </div>
 
@@ -9504,7 +9505,8 @@ GPURenderPassEncoder includes GPURenderCommandsMixin;
     : <dfn>\[[attachment_size]]</dfn>
     ::
         Set to the following extents:
-            - `width, height` = the dimensions of the pass's render attachments
+
+        - `width, height` = the dimensions of the pass's render attachments
 
     : <dfn>\[[occlusion_query_set]]</dfn>, of type {{GPUQuerySet}}.
     ::
@@ -9605,7 +9607,7 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
 
     Given a {{GPUDevice}} |device| and {{GPURenderPassDescriptor}} |this|, the following validation rules apply:
 
-    1. |this|.{{GPURenderPassDescriptor/colorAttachments}}.length must be less than or equal to
+    1. |this|.{{GPURenderPassDescriptor/colorAttachments}}.length must be &le;
         |device|.{{device/[[limits]]}}.{{supported limits/maxColorAttachments}}.
 
     1. If |this|.{{GPURenderPassDescriptor/colorAttachments}} has all values be `null` (or the sequence is empty):
@@ -9759,7 +9761,7 @@ dictionary GPURenderPassColorAttachment {
     - |renderViewDescriptor|.{{GPUTextureViewDescriptor/format}} must be a [=color renderable format=].
     - |this|.{{GPURenderPassColorAttachment/view}} must be a [$renderable texture view$].
     - If |this|.{{GPURenderPassColorAttachment/resolveTarget}} is not `null`:
-        - |renderTexture|.{{GPUTexture/sampleCount}} must be greater than 1.
+        - |renderTexture|.{{GPUTexture/sampleCount}} must be &gt; 1.
         - |resolveTexture|.{{GPUTexture/sampleCount}} must be 1.
         - |this|.{{GPURenderPassColorAttachment/resolveTarget}} must be a [$renderable texture view$].
         - The sizes of the [=subresource=]s seen by |this|.{{GPURenderPassColorAttachment/resolveTarget}}
@@ -10443,6 +10445,7 @@ It must only be included by interfaces which also include those mixins.
     run the following steps:
 
     1. If any of the following conditions are unsatisfied, return `false`:
+
         <div class=validusage>
             - [$Validate encoder bind groups$](|encoder|, |encoder|.{{GPURenderCommandsMixin/[[pipeline]]}})
                 must be `true`.
@@ -10507,17 +10510,15 @@ attachments used by this encoder.
                     and stop.
 
                     <div class=validusage>
-                        - |x| is greater than or equal to `0`.
-                        - |y| is greater than or equal to `0`.
-                        - |width| is greater than or equal to `0`.
-                        - |height| is greater than or equal to `0`.
-                        - |x| + |width| is less than or equal to
-                            |this|.{{GPURenderPassEncoder/[[attachment_size]]}}.width.
-                        - |y| + |height| is less than or equal to
-                            |this|.{{GPURenderPassEncoder/[[attachment_size]]}}.height.
-                        - |minDepth| is greater than or equal to `0.0` and less than or equal to `1.0`.
-                        - |maxDepth| is greater than or equal to `0.0` and less than or equal to `1.0`.
-                        - |maxDepth| is greater than |minDepth|.
+                        - |x| &ge; `0`
+                        - |y| &ge; `0`
+                        - |width| &ge; `0`
+                        - |height| &ge; `0`
+                        - |x| + |width| &le; |this|.{{GPURenderPassEncoder/[[attachment_size]]}}.width
+                        - |y| + |height| &le; |this|.{{GPURenderPassEncoder/[[attachment_size]]}}.height
+                        - 0.0 &le; |minDepth| &le; 1.0
+                        - 0.0 &le; |maxDepth| &le; 1.0
+                        - |minDepth| &lt; |maxDepth|
                     </div>
                 1. Set |this|.{{GPURenderPassEncoder/[[viewport]]}} to the extents |x|, |y|, |width|, |height|, |minDepth|, and |maxDepth|.
             </div>
@@ -10553,9 +10554,9 @@ attachments used by this encoder.
                     and stop.
 
                     <div class=validusage>
-                        - |x|+|width| is less than or equal to
+                        - |x|+|width| &le;
                             |this|.{{GPURenderPassEncoder/[[attachment_size]]}}.width.
-                        - |y|+|height| is less than or equal to
+                        - |y|+|height| &le;
                             |this|.{{GPURenderPassEncoder/[[attachment_size]]}}.height.
                     </div>
                 1. Set the scissor rectangle to the extents |x|, |y|, |width|, and |height|.
@@ -10793,7 +10794,7 @@ GPURenderBundleEncoder includes GPURenderCommandsMixin;
 
                         <div class=validusage>
                             - |this| is [=valid=].
-                            - |descriptor|.{{GPURenderPassLayout/colorFormats}}.length must be less than or equal to
+                            - |descriptor|.{{GPURenderPassLayout/colorFormats}}.length must be &le;
                                 |this|.{{device/[[limits]]}}.{{supported limits/maxColorAttachments}}.
                             - If |descriptor|.{{GPURenderPassLayout/colorFormats}} only contains `null` members:
                                 - |descriptor|.{{GPURenderPassLayout/depthStencilFormat}} must not be `null`.
@@ -12862,8 +12863,8 @@ fragment shader output value of the {{GPURenderPipelineDescriptor/fragment}}.{{G
 The algorithm of producing the extra mask is platform-dependent and can vary for different pixels.
 It guarantees that:
 
-- if |alpha| is 0.0 or less, the result is 0x0
-- if |alpha| is 1.0 or greater, the result is 0xFFFFFFFF
+- if |alpha| &le; 0.0, the result is 0x0
+- if |alpha| &ge; 1.0, the result is 0xFFFFFFFF
 - if |alpha| is greater than some other |alpha1|,
     then the produced sample mask has at least as many bits set to 1 as the mask for |alpha1|
 
@@ -13603,7 +13604,7 @@ All packed texture formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsa
 and {{GPUTextureUsage/TEXTURE_BINDING}} usages. All of these formats have {{GPUTextureSampleType/"float"}}
 type and can be filtered on sampling. None of these formats support multisampling.
 
-A <dfn dfn>compressed format</dfn> is any format with a block size greater than 1 &times; 1.
+A <dfn dfn>compressed format</dfn> is any format with a block size greater than 1&times;1.
 
 The [=texel block size=] (in bytes) of a packed format is equal to the Bytes per block column below.
 


### PR DESCRIPTION
and more spacing fixes.