### PR TITLE
Remove styling for multiple <dd>s in a <dl>

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -91,10 +91,9 @@ main dl:not(.switch) {
     padding-left: .5em;
 }
 
-/** In switches, make multiple consecutive <dd> entries distinguishable. */
-dl.switch > dd {
-    display: list-item;
-    list-style: square;
+/* Remove unnecessary extra margin on switch bodies */
+dl.switch dd {
+    margin-left: 0em;
 }
 
 /* <p> by default has these margins. Update ul/ol/dl to match,
@@ -3673,29 +3672,36 @@ enum GPUTextureAspect {
 
                                 <dl class=switch>
                                     : {{GPUTextureViewDimension/"1d"}}
-                                    :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"1d"}}.
-                                    :: |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `1`.
+                                    ::
+                                        - |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"1d"}}.
+                                        - |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `1`.
 
                                     : {{GPUTextureViewDimension/"2d"}}
-                                    :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
-                                    :: |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `1`.
+                                    ::
+
+                                        - |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
+                                        - |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `1`.
 
                                     : {{GPUTextureViewDimension/"2d-array"}}
-                                    :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
+                                    ::
+                                        - |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
 
                                     : {{GPUTextureViewDimension/"cube"}}
-                                    :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
-                                    :: |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `6`.
-                                    :: |this|.{{GPUTexture/width}} must equal |this|.{{GPUTexture/height}}.
+                                    ::
+                                        - |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
+                                        - |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `6`.
+                                        - |this|.{{GPUTexture/width}} must equal |this|.{{GPUTexture/height}}.
 
                                     : {{GPUTextureViewDimension/"cube-array"}}
-                                    :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
-                                    :: |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be a multiple of `6`.
-                                    :: |this|.{{GPUTexture/width}} must equal |this|.{{GPUTexture/height}}.
+                                    ::
+                                        - |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
+                                        - |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be a multiple of `6`.
+                                        - |this|.{{GPUTexture/width}} must equal |this|.{{GPUTexture/height}}.
 
                                     : {{GPUTextureViewDimension/"3d"}}
-                                    :: |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"3d"}}.
-                                    :: |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `1`.
+                                    ::
+                                        - |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"3d"}}.
+                                        - |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `1`.
                                 </dl>
                         </div>
 
@@ -5211,21 +5217,23 @@ following members:
 
                                                 <dl class=switch>
                                                     : {{GPUBufferBindingType/"uniform"}}
-                                                    :: |resource|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
-                                                        includes {{GPUBufferUsage/UNIFORM}}.
-                                                    :: [$effective buffer binding size$](|resource|) &le;
-                                                        |limits|.{{supported limits/maxUniformBufferBindingSize}}.
-                                                    :: |resource|.{{GPUBufferBinding/offset}} is a multiple of
-                                                        |limits|.{{supported limits/minUniformBufferOffsetAlignment}}.
+                                                    ::
+                                                        - |resource|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
+                                                            includes {{GPUBufferUsage/UNIFORM}}.
+                                                        - [$effective buffer binding size$](|resource|) &le;
+                                                            |limits|.{{supported limits/maxUniformBufferBindingSize}}.
+                                                        - |resource|.{{GPUBufferBinding/offset}} is a multiple of
+                                                            |limits|.{{supported limits/minUniformBufferOffsetAlignment}}.
 
                                                     : {{GPUBufferBindingType/"storage"}} or
                                                         {{GPUBufferBindingType/"read-only-storage"}}
-                                                    :: |resource|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
-                                                        includes {{GPUBufferUsage/STORAGE}}.
-                                                    :: [$effective buffer binding size$](|resource|) &le;
-                                                        |limits|.{{supported limits/maxStorageBufferBindingSize}}.
-                                                    :: |resource|.{{GPUBufferBinding/offset}} is a multiple of
-                                                        |limits|.{{supported limits/minStorageBufferOffsetAlignment}}.
+                                                    ::
+                                                        - |resource|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
+                                                            includes {{GPUBufferUsage/STORAGE}}.
+                                                        - [$effective buffer binding size$](|resource|) &le;
+                                                            |limits|.{{supported limits/maxStorageBufferBindingSize}}.
+                                                        - |resource|.{{GPUBufferBinding/offset}} is a multiple of
+                                                            |limits|.{{supported limits/minStorageBufferOffsetAlignment}}.
                                                 </dl>
 
                                         :  {{GPUBindGroupLayoutEntry/externalTexture}}


### PR DESCRIPTION
The `display: list-item` was messing up numbering of surrounding `<ol>`
blocks (each `<dd>` item would increment the numbering of the outer list!)

Replace usages of multiple `<dd>`s in a row with a `<dd><ul>` (a list
inside a `<dd>`. Set the style of switches such that that doesn't result
in way too much indentation.