### PR TITLE
Add the "internal" error type

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12959,7 +12959,7 @@ list is not exhaustive:
 
 <div algorithm>
     To <dfn abstract-op lt="Generate an internal error|generate an internal error">generate an
-    internal error</dfn> with ({{GPUInternalErrorReason}} or [=undefined=]) |reason| for {{GPUDevice}} |device|, run
+    internal error</dfn> with ({{GPUInternalErrorReason}} or undefined) |reason| for {{GPUDevice}} |device|, run
     the following steps:
 
     <div data-timeline=content>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12883,14 +12883,14 @@ enum GPUErrorFilter {
 };
 </script>
 
-{{GPUErrorFilter}} defines the type of errors that should be caught when calilng
+{{GPUErrorFilter}} defines the type of errors that should be caught when calling
 {{GPUDevice/pushErrorScope()}}:
 
 <dl dfn-type=enum-value dfn-for=GPUPrimitiveTopology>
     : <dfn>"validation"</dfn>
     ::
         Indicates that an operation did not satisfy all validation requirements. Validation errors
-        are always indicitive of an application error, and is expected to fail the same way across
+        are always indicative of an application error, and is expected to fail the same way across
         all devices assuming the same {{device/[[features]]}} and {{device/[[limits]]}} are in use.
 
     : <dfn>"internal"</dfn>
@@ -12919,7 +12919,7 @@ For example: An error scope that only contains the creation of a single resource
 or buffer, can be used to detect failures such as out of memory conditions, in which case the
 application may try freeing some resources and trying the allocation again.
 
-Error scopes do not indetify which command failed, however. So, for instance, wrapping all the
+Error scopes do not identify which command failed, however. So, for instance, wrapping all the
 commands executed while loading a model in a single error scope will not offer enough granularity to
 determine if the issue was due to memory constraints. As a result freeing resources would usually
 not be a productive response to a failure of that scope. A more appropriate response would be to

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12959,7 +12959,7 @@ list is not exhaustive:
 
 <div algorithm>
     To <dfn abstract-op lt="Generate an internal error|generate an internal error">generate an
-    internal error</dfn> with {{GPUInternalErrorReason}} |reason| for {{GPUDevice}} |device|, run
+    internal error</dfn> with ({{GPUInternalErrorReason}} or [=undefined=]) |reason| for {{GPUDevice}} |device|, run
     the following steps:
 
     <div data-timeline=content>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12859,6 +12859,89 @@ partial interface GPUDevice {
         Upon initialization, it is set to [=a new promise=].
 </dl>
 
+## <dfn interface>GPUError</dfn> ## {#error}
+
+<script type=idl>
+[Exposed=(Window, DedicatedWorker), SecureContext]
+interface GPUError {
+    readonly attribute DOMString message;
+};
+</script>
+
+{{GPUError}} is the base interface for all errors surfaced from {{GPUDevice/popErrorScope()}}
+and the {{GPUDevice/uncapturederror}} event.
+
+{{GPUError}} has the following attributes:
+
+<dl dfn-type=attribute dfn-for=GPUError>
+    : <dfn>message</dfn>
+    ::
+        A human-readable message providing information about the error that occurred.
+
+        Note: This message is generally intended for application developers to debug their
+        applications and capture information for debug reports, not to be surfaced to end-users.
+
+        Note: User agents should not include potentially machine-parsable details in this message,
+        such as free system memory on {{GPUErrorFilter/"internal"}} errors raised due to memory
+        constraints, or other details about the conditions under which memory was exhausted.
+</dl>
+
+<script type=idl>
+[Exposed=(Window, DedicatedWorker), SecureContext]
+interface GPUValidationError : GPUError {
+    constructor(DOMString message);
+};
+</script>
+
+{{GPUValidationError}} is a subtype of {{GPUError}} which indicates that an operation did not
+satisfy all validation requirements. Validation errors are always indicative of an application
+error, and is expected to fail the same way across all devices assuming the same
+{{device/[[features]]}} and {{device/[[limits]]}} are in use.
+
+<script type=idl>
+enum GPUInternalErrorReason {
+    "out-of-memory"
+};
+
+[Exposed=(Window, DedicatedWorker), SecureContext]
+interface GPUInternalError : GPUError {
+    constructor(DOMString message, optional GPUInternalErrorReason reason);
+
+    readonly attribute (GPUInternalErrorReason or undefined) reason;
+};
+</script>
+
+{{GPUInternalError}} is a subtype of {{GPUError}} which indicates than an operation failed for a
+system or implementation-specific reason even when all validation requirements have been satisfied.
+For example, the operation may exceede the capabilities of the implementation in a way not easily
+captured by the [=supported limits=]. The same operation may succeed on other devices or under
+difference circumstances.
+
+{{GPUInternalErrorReason}} defines possible reasons why a {{GPUInternalError}} occurred, though the
+list is not exhaustive:
+
+<dl dfn-type=enum-value dfn-for=GPUInternalErrorReason>
+    : <dfn>"out-of-memory"</dfn>
+    ::
+        Indicate there was not enough free memory to complete the requested operation. The operation
+        may succeed if attempted again with a lower memory requirement (like using smaller texture
+        dimensions), or if memory used by other resources is released first.
+</dl>
+
+{{GPUInternalError}} has the following attributes:
+
+<dl dfn-type=attribute dfn-for=GPUInternalError>
+    : <dfn>reason</dfn>
+    ::
+        The reason the internal error was generated, if known. If a reason is not known or not
+        one of the available {{GPUInternalErrorReason}} options, must be `undefined`.
+</dl>
+
+Note: {{GPUError}} may gain new subtypes in future versions of this spec. Applications should handle
+this possibility, using only the error's {{GPUError/message}} when possible, and specializing using
+`instanceof`. Use `error.constructor.name` when it's necessary to serialize an error (e.g. into
+JSON, for a debug report).
+
 ## Error Scopes ## {#error-scopes}
 
 A <dfn dfn>GPU error scope</dfn> captures {{GPUError}}s that were generated while the
@@ -12881,99 +12964,25 @@ enum GPUErrorFilter {
     "validation",
     "internal"
 };
-</script>
 
-{{GPUErrorFilter}} defines the type of errors that should be caught when calling
-{{GPUDevice/pushErrorScope()}}:
-
-<dl dfn-type=enum-value dfn-for=GPUPrimitiveTopology>
-    : <dfn>"validation"</dfn>
-    ::
-        Indicates that an operation did not satisfy all validation requirements. Validation errors
-        are always indicative of an application error, and is expected to fail the same way across
-        all devices assuming the same {{device/[[features]]}} and {{device/[[limits]]}} are in use.
-
-    : <dfn>"internal"</dfn>
-    ::
-        Indicates than an operation failed for a system or implementation-specific reason even
-        when all validation requirements have been satisfied. The same operation may succeed on
-        other devices or under difference circumstances.
-
-        This error may indicate there was not enough free memory to complete the requested operation
-        or may be due to the operation exceeding the capabilities of the implementation in a way not
-        easily captured by the [=supported limits=].
-
-        If the failed operation was a resources allocation, such as the creation of a texture or
-        buffer, it may succeed if attempted again with a lower memory requirement (like using
-        smaller texture dimensions), or if memory used by other resources is released first.
-        Otherwise the operation may succeed if attempted again with changes to lower the complexity,
-        such as using a simpler shader during pipeline creation.
-</dl>
-
-<div class=note>
-Note: Error scopes can encompass as many commands as needed. The number of commands an error scope covers
-will generally be correlated to what sort of action the application intends to take in response to
-an error occuring.
-
-For example: An error scope that only contains the creation of a single resource, such as a texture
-or buffer, can be used to detect failures such as out of memory conditions, in which case the
-application may try freeing some resources and trying the allocation again.
-
-Error scopes do not identify which command failed, however. So, for instance, wrapping all the
-commands executed while loading a model in a single error scope will not offer enough granularity to
-determine if the issue was due to memory constraints. As a result freeing resources would usually
-not be a productive response to a failure of that scope. A more appropriate response would be to
-allow the application to fall back to a different model or produce a warning that the model could
-not be loaded. If responding to memory constraints is desired, the operations allocating memory can
-always be wrapped in a smaller nested error scope.
-</div>
-
-<script type=idl>
-[Exposed=(Window, DedicatedWorker), SecureContext]
-interface GPUError {
-    readonly attribute DOMString message;
-};
-
-[Exposed=(Window, DedicatedWorker), SecureContext]
-interface GPUInternalError : GPUError {
-    constructor(DOMString message);
-};
-
-[Exposed=(Window, DedicatedWorker), SecureContext]
-interface GPUValidationError : GPUError {
-    constructor(DOMString message);
-};
-</script>
-
-{{GPUError}} is the base interface for all errors surfaced from {{GPUDevice/popErrorScope()}}
-and the {{GPUDevice/uncapturederror}} event.
-
-Note: {{GPUError}} may gain new subtypes in future versions of this spec. Applications should handle
-this possibility, using only the error's {{GPUError/message}} when possible, and specializing using
-`instanceof`. Use `error.constructor.name` when it's necessary to serialize an error (e.g. into
-JSON, for a debug report).
-
-{{GPUError}} has the following attributes:
-
-<dl dfn-type=attribute dfn-for=GPUError>
-    : <dfn>message</dfn>
-    ::
-        A human-readable message providing information about the error that occurred.
-
-        Note: This message is generally intended for application developers to debug their
-        applications and capture information for debug reports, not to be surfaced to end-users.
-
-        Note: User agents should not include potentially machine-parsable details in this message,
-        such as free system memory on {{GPUErrorFilter/"internal"}} errors raised due to memory
-        constraints, or other details about the conditions under which memory was exhausted.
-</dl>
-
-<script type=idl>
 partial interface GPUDevice {
     undefined pushErrorScope(GPUErrorFilter filter);
     Promise<GPUError?> popErrorScope();
 };
 </script>
+
+{{GPUErrorFilter}} defines the type of errors that should be caught when calling
+{{GPUDevice/pushErrorScope()}}:
+
+<dl dfn-type=enum-value dfn-for=GPUErrorFilter>
+    : <dfn>"validation"</dfn>
+    ::
+        Indicates that the error scope catches {{GPUValidationError}}s.
+
+    : <dfn>"internal"</dfn>
+    ::
+        Indicates that the error scope catches {{GPUInternalError}}s.
+</dl>
 
 {{GPUDevice}} has the following internal slots:
 
@@ -13158,6 +13167,24 @@ partial interface GPUDevice {
             }
         });
     </pre>
+</div>
+
+<div class=note>
+Note: Error scopes can encompass as many commands as needed. The number of commands an error scope covers
+will generally be correlated to what sort of action the application intends to take in response to
+an error occuring.
+
+For example: An error scope that only contains the creation of a single resource, such as a texture
+or buffer, can be used to detect failures such as out of memory conditions, in which case the
+application may try freeing some resources and trying the allocation again.
+
+Error scopes do not identify which command failed, however. So, for instance, wrapping all the
+commands executed while loading a model in a single error scope will not offer enough granularity to
+determine if the issue was due to memory constraints. As a result freeing resources would usually
+not be a productive response to a failure of that scope. A more appropriate response would be to
+allow the application to fall back to a different model or produce a warning that the model could
+not be loaded. If responding to memory constraints is desired, the operations allocating memory can
+always be wrapped in a smaller nested error scope.
 </div>
 
 ## Telemetry ## {#telemetry}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12878,10 +12878,40 @@ of WebGPU calls, typically for debugging purposes or to make an operation more f
 
 <script type=idl>
 enum GPUErrorFilter {
+    "validation",
+    "operation",
     "out-of-memory",
-    "validation"
 };
 </script>
+
+{{GPUErrorFilter}} defines the type of errors that should be caught when calilng
+{{GPUDevice/pushErrorScope()}}:
+
+<dl dfn-type=enum-value dfn-for=GPUPrimitiveTopology>
+    : <dfn>"validation"</dfn>
+    ::
+        Indicates that an operation did not satisfy all validation requirements. Validation errors
+        are always indicitive of an application error, and is expected to fail the same way across
+        all devices assuming the same {{device/[[features]]}} and {{device/[[limits]]}} are in use.
+
+    : <dfn>"operation"</dfn>
+    ::
+        Indicates than an operation failed for a system or implementation-specific reason even
+        when all validation requirements have been satisfied. The same operation may succeed on
+        other devices. This error may be due to the operation exceeding the capabilities of the
+        implementation in a way not easily captured by the [=supported limits=].
+        
+        The operation may succeed if attempted again with changes to lower the complexity, (such as
+        using a simpler shader during pipeline creation).
+
+    : <dfn>"out-of-memory"</dfn>
+    ::
+        Indicates that there was not enough free memory to complete the requested operation.
+        
+        The operation may succeed if attempted again with a lower memory requirement (such as using
+        smaller dimensions during texture creation), or if memory used by other resources is
+        released first.
+</dl>
 
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
@@ -12891,6 +12921,11 @@ interface GPUError {
 
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUOutOfMemoryError : GPUError {
+    constructor(DOMString message);
+};
+
+[Exposed=(Window, DedicatedWorker), SecureContext]
+interface GPUOperationError : GPUError {
     constructor(DOMString message);
 };
 
@@ -12948,6 +12983,8 @@ partial interface GPUDevice {
             <dl class=switch>
                 : {{GPUValidationError}}
                 :: Let |type| be "validation".
+                : {{GPUOperationError}}
+                :: Let |type| be "operation".
                 : {{GPUOutOfMemoryError}}
                 :: Let |type| be "out-of-memory".
             </dl>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12871,6 +12871,9 @@ interface GPUError {
 {{GPUError}} is the base interface for all errors surfaced from {{GPUDevice/popErrorScope()}}
 and the {{GPUDevice/uncapturederror}} event.
 
+Errors must only be generated for operations that explicitly state the conditions one may
+be generated under in their respective algorithms, and the subtype of error that is generated.
+
 Note: {{GPUError}} may gain new subtypes in future versions of this spec. Applications should handle
 this possibility, using only the error's {{GPUError/message}} when possible, and specializing using
 `instanceof`. Use `error.constructor.name` when it's necessary to serialize an error (e.g. into
@@ -12887,8 +12890,8 @@ JSON, for a debug report).
         applications and capture information for debug reports, not to be surfaced to end-users.
 
         Note: User agents should not include potentially machine-parsable details in this message,
-        such as free system memory on {{GPUErrorFilter/"internal"}} errors raised due to memory
-        constraints, or other details about the conditions under which memory was exhausted.
+        such as free system memory on {{GPUErrorFilter/"out-of-memory"}} or other details about the
+        conditions under which memory was exhausted.
 </dl>
 
 <script type=idl>
@@ -12916,57 +12919,50 @@ error, and is expected to fail the same way across all devices assuming the same
 </div>
 
 <script type=idl>
-enum GPUInternalErrorReason {
-    "out-of-memory"
+[Exposed=(Window, DedicatedWorker), SecureContext]
+interface GPUOutOfMemoryError : GPUError {
+    constructor(DOMString message);
 };
+</script>
 
+{{GPUOutOfMemoryError}} is a subtype of {{GPUError}} which indicates that there was not enough free
+memory to complete the requested operation. The operation may succeed if attempted again with a
+lower memory requirement (like using smaller texture dimensions), or if memory used by other
+resources is released first.
+
+<div algorithm>
+    To <dfn abstract-op lt="Generate an out-of-memory error|generate an out-of-memory error">
+    generate an out-of-memory error</dfn> for {{GPUDevice}} |device|, run the following steps:
+
+    <div data-timeline=content>
+        [=Content timeline=] steps:
+
+        1. Let |error| be a new {{GPUOutOfMemoryError}} with an appropriate error message.
+        1. [$Dispatch error$] |error| to |device|.
+    </div>
+</div>
+
+<script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUInternalError : GPUError {
-    constructor(DOMString message, optional GPUInternalErrorReason reason);
-
-    readonly attribute (GPUInternalErrorReason or undefined) reason;
+    constructor(DOMString message);
 };
 </script>
 
 {{GPUInternalError}} is a subtype of {{GPUError}} which indicates than an operation failed for a
 system or implementation-specific reason even when all validation requirements have been satisfied.
-For example, the operation may exceede the capabilities of the implementation in a way not easily
+For example, the operation may exceed the capabilities of the implementation in a way not easily
 captured by the [=supported limits=]. The same operation may succeed on other devices or under
 difference circumstances.
 
-Internal errors must only be generated for operations that explicitly state the conditions one may
-be generated under in their respective algorithms.
-
-{{GPUInternalErrorReason}} defines possible reasons why a {{GPUInternalError}} occurred, though the
-list is not exhaustive:
-
-<dl dfn-type=enum-value dfn-for=GPUInternalErrorReason>
-    : <dfn>"out-of-memory"</dfn>
-    ::
-        Indicate there was not enough free memory to complete the requested operation. The operation
-        may succeed if attempted again with a lower memory requirement (like using smaller texture
-        dimensions), or if memory used by other resources is released first.
-</dl>
-
-{{GPUInternalError}} has the following attributes:
-
-<dl dfn-type=attribute dfn-for=GPUInternalError>
-    : <dfn>reason</dfn>
-    ::
-        The reason the internal error was generated, if known. If a reason is not known or not
-        one of the available {{GPUInternalErrorReason}} options, must be `undefined`.
-</dl>
-
 <div algorithm>
     To <dfn abstract-op lt="Generate an internal error|generate an internal error">generate an
-    internal error</dfn> with ({{GPUInternalErrorReason}} or undefined) |reason| for {{GPUDevice}} |device|, run
-    the following steps:
+    internal error</dfn> for {{GPUDevice}} |device|, run the following steps:
 
     <div data-timeline=content>
         [=Content timeline=] steps:
 
         1. Let |error| be a new {{GPUInternalError}} with an appropriate error message.
-        1. Set |error|.{{GPUInternalError/reason}} to |reason|.
         1. [$Dispatch error$] |error| to |device|.
     </div>
 </div>
@@ -12991,6 +12987,7 @@ of WebGPU calls, typically for debugging purposes or to make an operation more f
 <script type=idl>
 enum GPUErrorFilter {
     "validation",
+    "out-of-memory",
     "internal"
 };
 
@@ -13006,11 +13003,15 @@ partial interface GPUDevice {
 <dl dfn-type=enum-value dfn-for=GPUErrorFilter>
     : <dfn>"validation"</dfn>
     ::
-        Indicates that the error scope catches {{GPUValidationError}}s.
+        Indicates that the error scope will catch a {{GPUValidationError}}.
+
+    : <dfn>"out-of-memory"</dfn>
+    ::
+        Indicates that the error scope will catch a {{GPUOutOfMemoryError}}.
 
     : <dfn>"internal"</dfn>
     ::
-        Indicates that the error scope catches {{GPUInternalError}}s.
+        Indicates that the error scope will catch a {{GPUInternalError}}.
 </dl>
 
 {{GPUDevice}} has the following internal slots:
@@ -13033,6 +13034,8 @@ partial interface GPUDevice {
             <dl class=switch>
                 : {{GPUValidationError}}
                 :: Let |type| be "validation".
+                : {{GPUOutOfMemoryError}}
+                :: Let |type| be "out-of-memory".
                 : {{GPUInternalError}}
                 :: Let |type| be "internal".
             </dl>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12879,8 +12879,7 @@ of WebGPU calls, typically for debugging purposes or to make an operation more f
 <script type=idl>
 enum GPUErrorFilter {
     "validation",
-    "operation",
-    "out-of-memory",
+    "internal"
 };
 </script>
 
@@ -12894,24 +12893,39 @@ enum GPUErrorFilter {
         are always indicitive of an application error, and is expected to fail the same way across
         all devices assuming the same {{device/[[features]]}} and {{device/[[limits]]}} are in use.
 
-    : <dfn>"operation"</dfn>
+    : <dfn>"internal"</dfn>
     ::
         Indicates than an operation failed for a system or implementation-specific reason even
         when all validation requirements have been satisfied. The same operation may succeed on
-        other devices. This error may be due to the operation exceeding the capabilities of the
-        implementation in a way not easily captured by the [=supported limits=].
-        
-        The operation may succeed if attempted again with changes to lower the complexity, (such as
-        using a simpler shader during pipeline creation).
+        other devices or under difference circumstances.
 
-    : <dfn>"out-of-memory"</dfn>
-    ::
-        Indicates that there was not enough free memory to complete the requested operation.
-        
-        The operation may succeed if attempted again with a lower memory requirement (such as using
-        smaller dimensions during texture creation), or if memory used by other resources is
-        released first.
+        This error may indicate there was not enough free memory to complete the requested operation
+        or may be due to the operation exceeding the capabilities of the implementation in a way not
+        easily captured by the [=supported limits=].
+
+        If the failed operation was a resources allocation, such as the creation of a texture or
+        buffer, it may succeed if attempted again with a lower memory requirement (like using
+        smaller texture dimensions), or if memory used by other resources is released first.
+        Otherwise the operation may succeed if attempted again with changes to lower the complexity,
+        such as using a simpler shader during pipeline creation.
 </dl>
+
+<div class=note>
+Note: Error scopes can encompass as many commands as needed. The number of commands an error scope covers
+will generally be correlated to what sort of action the application intends to take in response to
+an error occuring.
+
+For example: An error scope that only contains the creation of a single resource, such as a texture
+or buffer, can be used to detect failures such as out of memory conditions, in which case the
+application may try freeing some resources and trying the allocation again.
+
+Error scopes do not indetify which command failed, however. So, for instance, wrapping all the
+commands executed while loading a model in a single error scope will not offer enough granularity to
+determine if the issue was due to memory constraints. As a result freeing resources would usually
+not be a productive response to a failure of that scope. A more appropriate response would be to
+allow the application to fall back to a different model or produce a warning that the model could
+not be loaded.
+</div>
 
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
@@ -12920,12 +12934,7 @@ interface GPUError {
 };
 
 [Exposed=(Window, DedicatedWorker), SecureContext]
-interface GPUOutOfMemoryError : GPUError {
-    constructor(DOMString message);
-};
-
-[Exposed=(Window, DedicatedWorker), SecureContext]
-interface GPUOperationError : GPUError {
+interface GPUInternalError : GPUError {
     constructor(DOMString message);
 };
 
@@ -12954,8 +12963,8 @@ JSON, for a debug report).
         applications and capture information for debug reports, not to be surfaced to end-users.
 
         Note: User agents should not include potentially machine-parsable details in this message,
-        such as free system memory on "out-of-memory" errors, or other details
-        about the conditions under which memory was exhausted.
+        such as free system memory on {{GPUErrorFilter/"internal"}} errors raised due to memory
+        constraints, or other details about the conditions under which memory was exhausted.
 </dl>
 
 <script type=idl>
@@ -12983,10 +12992,8 @@ partial interface GPUDevice {
             <dl class=switch>
                 : {{GPUValidationError}}
                 :: Let |type| be "validation".
-                : {{GPUOperationError}}
-                :: Let |type| be "operation".
-                : {{GPUOutOfMemoryError}}
-                :: Let |type| be "out-of-memory".
+                : {{GPUInternalError}}
+                :: Let |type| be "internal".
             </dl>
         1. Let |scope| be the last [=list/item=] of |device|.{{GPUDevice/[[errorScopeStack]]}}.
         1. While |scope| is not `undefined`:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12871,6 +12871,11 @@ interface GPUError {
 {{GPUError}} is the base interface for all errors surfaced from {{GPUDevice/popErrorScope()}}
 and the {{GPUDevice/uncapturederror}} event.
 
+Note: {{GPUError}} may gain new subtypes in future versions of this spec. Applications should handle
+this possibility, using only the error's {{GPUError/message}} when possible, and specializing using
+`instanceof`. Use `error.constructor.name` when it's necessary to serialize an error (e.g. into
+JSON, for a debug report).
+
 {{GPUError}} has the following attributes:
 
 <dl dfn-type=attribute dfn-for=GPUError>
@@ -12898,6 +12903,18 @@ satisfy all validation requirements. Validation errors are always indicative of 
 error, and is expected to fail the same way across all devices assuming the same
 {{device/[[features]]}} and {{device/[[limits]]}} are in use.
 
+<div algorithm>
+    To <dfn abstract-op lt="Generate a validation error|generate a validation error">generate a
+    validation error</dfn> for {{GPUDevice}} |device|, run the following steps:
+
+    <div data-timeline=content>
+        [=Content timeline=] steps:
+
+        1. Let |error| be a new {{GPUValidationError}} with an appropriate error message.
+        1. [$Dispatch error$] |error| to |device|.
+    </div>
+</div>
+
 <script type=idl>
 enum GPUInternalErrorReason {
     "out-of-memory"
@@ -12916,6 +12933,9 @@ system or implementation-specific reason even when all validation requirements h
 For example, the operation may exceede the capabilities of the implementation in a way not easily
 captured by the [=supported limits=]. The same operation may succeed on other devices or under
 difference circumstances.
+
+Internal errors must only be generated for operations that explicitly state the conditions one may
+be generated under in their respective algorithms.
 
 {{GPUInternalErrorReason}} defines possible reasons why a {{GPUInternalError}} occurred, though the
 list is not exhaustive:
@@ -12937,10 +12957,19 @@ list is not exhaustive:
         one of the available {{GPUInternalErrorReason}} options, must be `undefined`.
 </dl>
 
-Note: {{GPUError}} may gain new subtypes in future versions of this spec. Applications should handle
-this possibility, using only the error's {{GPUError/message}} when possible, and specializing using
-`instanceof`. Use `error.constructor.name` when it's necessary to serialize an error (e.g. into
-JSON, for a debug report).
+<div algorithm>
+    To <dfn abstract-op lt="Generate an internal error|generate an internal error">generate an
+    internal error</dfn> with {{GPUInternalErrorReason}} |reason| for {{GPUDevice}} |device|, run
+    the following steps:
+
+    <div data-timeline=content>
+        [=Content timeline=] steps:
+
+        1. Let |error| be a new {{GPUInternalError}} with an appropriate error message.
+        1. Set |error|.{{GPUInternalError/reason}} to |reason|.
+        1. [$Dispatch error$] |error| to |device|.
+    </div>
+</div>
 
 ## Error Scopes ## {#error-scopes}
 
@@ -12994,9 +13023,11 @@ partial interface GPUDevice {
 
 <div algorithm>
     The <dfn abstract-op>current error scope</dfn> for a {{GPUError}} |error| and {{GPUDevice}}
-    |device| is determined by issuing the following steps to the [=Device timeline=]:
+    |device| is determined by issuing the following steps to the [=Device timeline=] of |device|:
 
-    <div class=device-timeline>
+    <div data-timeline=device>
+        [=Device timeline=] steps:
+
         1. If |error| is an instance of:
 
             <dl class=switch>
@@ -13015,29 +13046,30 @@ partial interface GPUDevice {
 </div>
 
 <div algorithm>
-    To <dfn abstract-op lt="Generate a validation error|generate a validation error">generate a
-    validation error</dfn> for {{GPUDevice}} |device|, run the following steps:
+    To <dfn abstract-op lt="Dispatch error|dispatch error">dispatch an error</dfn> {{GPUError}}
+    |error| on {{GPUDevice}} |device|, run the following steps on the [=Device timeline=]
+    of |device|:
 
-    1. Let |error| be a new {{GPUValidationError}} with an appropriate error message.
-    1. Issue the following steps to the [=Device timeline=]:
+    <div data-timeline=device>
+        [=Device timeline=] steps:
 
-        <div class=device-timeline>
-            1. Let |scope| be the [$current error scope$] for |error| and |device|.
-            1. If |scope| is not `undefined`:
-                1. [=list/Append=] |error| to |scope|.{{GPU error scope/[[errors]]}}.
-                1. Return.
-            1. Otherwise issue the following steps to the [=Content timeline=]:
+        1. Let |scope| be the [$current error scope$] for |error| and |device|.
+        1. If |scope| is not `undefined`:
+            1. [=list/Append=] |error| to |scope|.{{GPU error scope/[[errors]]}}.
+            1. Return.
+        1. Otherwise issue the following steps to the [=Content timeline=]:
+    </div>
+    <div data-timeline=content>
+        [=Content timeline=] steps:
 
-                <div class=content-timeline>
-                    1. If the user agent chooses, [=queue a task=] to fire a
-                        {{GPUUncapturedErrorEvent}} named "{{GPUDevice/uncapturederror}}" on
-                        |device| with an {{GPUUncapturedErrorEvent/error}} of |error|.
+        1. If the user agent chooses, [=queue a task=] to fire a
+            {{GPUUncapturedErrorEvent}} named "{{GPUDevice/uncapturederror}}" on
+            |device| with an {{GPUUncapturedErrorEvent/error}} of |error|.
 
-                    Note: If (and only if) there are no {{GPUDevice/uncapturederror}} handlers are
-                    registered, user agents **should** surface uncaptured errors to developers,
-                    for example as warnings in the browser's developer console.
-                </div>
-        </div>
+        Note: If (and only if) there are no {{GPUDevice/uncapturederror}} handlers are
+        registered, user agents **should** surface uncaptured errors to developers,
+        for example as warnings in the browser's developer console.
+    </div>
 
     Note: The user agent may choose to throttle or limit the number of {{GPUUncapturedErrorEvent}}s
     that a {{GPUDevice}} can raise to prevent an excessive amount of error handling or logging from

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12924,7 +12924,8 @@ commands executed while loading a model in a single error scope will not offer e
 determine if the issue was due to memory constraints. As a result freeing resources would usually
 not be a productive response to a failure of that scope. A more appropriate response would be to
 allow the application to fall back to a different model or produce a warning that the model could
-not be loaded.
+not be loaded. If responding to memory constraints is desired, the operations allocating memory can
+always be wrapped in a smaller nested error scope.
 </div>
 
 <script type=idl>


### PR DESCRIPTION
~Fixes~Issue: #2308 (EDIT(@kainino0x): still need to keep that issue open about exposing non-uncategorized errors)

This error type captures non-validation errors that occur at a system
or implementation level. (Such as shaders failing because they are
too complex.) Initially only pipeline creation may produce operation
errors.