### PR TITLE
Generalize invalid memory reference to any originating variable

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2890,10 +2890,10 @@ The originating variable for a formal parameter of a function depends on the
 [=call site|call sites=] for the function.
 Different call sites may supply pointers into different originating variables.
 
-If a reference or pointer access is out of bounds, an <dfn noexport>invalid
-memory reference</dfn> is produced.
+If a reference or pointer access is out of bounds, an
+<dfn noexport>invalid memory reference</dfn> is produced.
 [=Load Rule|Loads=] from an invalid reference return one of:
-    * a value from any [=memory locations|memory location(s)=] of the [[WebGPU#buffers|WebGPU buffer]]
+    * a value from any [=memory locations|memory location(s)=]
         bound to the [=originating variable=]
     * the [=zero value=] for store type of the reference
     * if the loaded value is a vector, the value (0, 0, 0, x), where x is:

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2893,8 +2893,11 @@ Different call sites may supply pointers into different originating variables.
 If a reference or pointer access is out of bounds, an
 <dfn noexport>invalid memory reference</dfn> is produced.
 [=Load Rule|Loads=] from an invalid reference return one of:
-    * a value from any [=memory locations|memory location(s)=]
-        bound to the [=originating variable=]
+    * when the [=originating variable=] is a [=uniform buffer=] or a [=storage buffer=],
+        the value from any [=memory locations|memory location(s)=]
+        of the [[WebGPU#buffers|WebGPU buffer]] bound to the originating variable
+    * when the originating variable is not a [=uniform buffer=] or [=storage buffer=],
+        a value from any [=memory locations|memory location(s)=] in the originating variable
     * the [=zero value=] for store type of the reference
     * if the loaded value is a vector, the value (0, 0, 0, x), where x is:
         * 0, 1, or the maximum positive value for integer components


### PR DESCRIPTION
Fixes: #3128