### PR TITLE
Clarify attribute integer paramters validity

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -796,7 +796,8 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
   </thead>
 
   <tr><td><dfn noexport dfn-for="attribute">`align`</dfn>
-    <td>[=shader-creation error|Must=] be a positive [=i32=] or [=AbstractInt=] [=integer literal|literal=]
+    <td>[=shader-creation error|Must=] be an [=i32=] or [=AbstractInt=] [=integer literal|literal=].<br>
+        [=shader-creation error|Must=] be positive.
     <td>[=shader-creation error|Must=] only be applied to a member of a [=structure=] type.
 
     [=shader-creation error|Must=] be a power of 2, and [=shader-creation error|must=] satisfy the required-alignment for the member type:
@@ -813,7 +814,8 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     See [[#memory-layouts]]
 
   <tr><td><dfn noexport dfn-for="attribute">`binding`</dfn>
-    <td>[=shader-creation error|Must=] be a non-negative [=i32=] or [=AbstractInt=] [=integer literal|literal=]
+    <td>[=shader-creation error|Must=] be an [=i32=] or [=AbstractInt=] [=integer literal|literal=].<br>
+        [=shader-creation error|Must=] be non-negative.
     <td>[=shader-creation error|Must=] only be applied to a [=resource=] variable.
 
     Specifies the binding number of the resource in a bind [=attribute/group=].
@@ -839,14 +841,16 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     built-in functions can be used in [=creation-time expressions=].
 
   <tr><td><dfn noexport dfn-for="attribute">`group`</dfn>
-    <td>[=shader-creation error|Must=] be a non-negative [=i32=] or [=AbstractInt=] [=integer literal|literal=]
+    <td>[=shader-creation error|Must=] be an [=i32=] or [=AbstractInt=] [=integer literal|literal=].<br>
+        [=shader-creation error|Must=] be non-negative.
     <td>[=shader-creation error|Must=] only be applied to a [=resource=] variable.
 
     Specifies the binding group of the resource.
     See [[#resource-interface]].
 
   <tr><td><dfn noexport dfn-for="attribute">`id`</dfn>
-    <td>[=shader-creation error|Must=] be a non-negative [=i32=] or [=AbstractInt=] [=integer literal|literal=]
+    <td>[=shader-creation error|Must=] be an [=i32=] or [=AbstractInt=] [=integer literal|literal=].<br>
+        [=shader-creation error|Must=] be non-negative.
     <td>[=shader-creation error|Must=] only be applied to an [=override declaration=] of [=scalar=] type.
 
     Specifies a numeric identifier as an alternate name for a
@@ -885,7 +889,8 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     `invariant` qualifier in GLSL.
 
   <tr><td><dfn noexport dfn-for="attribute">`location`</dfn>
-    <td>[=shader-creation error|Must=] be a non-negative [=i32=] or [=AbstractInt=] [=integer literal|literal=]
+    <td>[=shader-creation error|Must=] be an [=i32=] or [=AbstractInt=] [=integer literal|literal=].<br>
+        [=shader-creation error|Must=] be non-negative.
     <td>[=shader-creation error|Must=] only be applied to an entry point function parameter, entry point
     return type, or member of a [=structure=] type.
     [=shader-creation error|Must=] only be applied to declarations of [=numeric scalar=] or [=numeric
@@ -896,7 +901,8 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     See [[#input-output-locations]].
 
   <tr><td><dfn noexport dfn-for="attribute">`size`</dfn>
-    <td>[=shader-creation error|Must=] be a positive [=i32=] or [=AbstractInt=] [=integer literal|literal=]
+    <td>[=shader-creation error|Must=] be an [=i32=] or [=AbstractInt=] [=integer literal|literal=].<br>
+        [=shader-creation error|Must=] be positive.
     <td>[=shader-creation error|Must=] only be applied to a member of a [=structure=] type.
 
     The number of bytes reserved in the struct for this member.


### PR DESCRIPTION

    Clarify attribute integer paramters validity
    
    Split the consraint into two statements:
     - one is about the tyep
     - other is about the range of values
    
  Fixes: #2916

