### PR TITLE
Fixed-footprint types: add remark about fixed-sized arrays

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2105,7 +2105,7 @@ Note: A [=constructible=] type has [=creation-fixed footprint=].
 
 The plain types with [=fixed footprint=] are any of:
 * a type with [=creation-fixed footprint=]
-* a [=fixed-size array=] type
+* a [=fixed-size array=] type (without further constraining its [=element count=])
 
 Note: The only valid use of a fixed-size array with an element count that is an
 [=override expression=] that is not a [=creation-time expression=] is as the


### PR DESCRIPTION
The remark notes that the element count is not further restricted.

Fixes: #3022