### PR TITLE
Make 'reference' and 'pointer type' appear in table-of-contents

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1206,7 +1206,7 @@ Some WGSL types are only used for analyzing a source program and
 for determining the program's runtime behaviour.
 This specification will describe such types, but they do not appear in WGSL source text.
 
-Note: WGSL [=reference types=] are not written in WGSL programs. See [[#memory-view-types]].
+Note: WGSL [=reference types=] are not written in WGSL programs. See [[#ref-ptr-types]].
 
 ## Type Checking ## {#type-checking-section}
 
@@ -2798,7 +2798,7 @@ to WGSL.
   </xmp>
 </div>
 
-## Memory View Types ## {#memory-view-types}
+## Memory Views ## {#memory-views}
 
 In addition to calculating with [=plain types|plain=] values, a WGSL program will
 also often read values from memory or write values to memory, via [=memory access=] operations.
@@ -2811,7 +2811,9 @@ A <dfn noexport>memory view</dfn> comprises:
 
 The access mode of a memory view [=shader-creation error|must=] be supported by the address space. See [[#address-space]].
 
-WGSL has two kinds of types for representing memory views:
+### Reference and Pointer Types ### {#ref-ptr-types}
+
+WGSL has two kinds of types for representing [=memory views=]:
 [=reference types=] and [=pointer types=].
 
 <table class='data'>
@@ -2823,8 +2825,10 @@ WGSL has two kinds of types for representing memory views:
     <td>ref&lt;|AS|,|T|,|AM|&gt;
     <td>The <dfn noexport>reference type</dfn>
         identified with the set of [=memory views=] for memory locations in |AS| holding values of type |T|,
-        supporting memory accesses described by mode |AM|.<br>
-        Here, |T| is the [=store type=].<br>
+        supporting memory accesses described by mode |AM|.
+
+        Here, |T| is the [=store type=].
+
         Reference types are not written in WGSL program source;
         instead they are used to analyze a WGSL program.
   <tr algorithm="pointer type">
@@ -2832,9 +2836,11 @@ WGSL has two kinds of types for representing memory views:
     <td>ptr&lt;|AS|,|T|,|AM|&gt;
     <td>The <dfn noexport>pointer type</dfn>
         identified with the set of [=memory views=] for memory locations in |AS| holding values of type |T|,
-        supporting memory accesses described by mode |AM|.<br>
-        Here, |T| is the [=store type=].<br>
-        Pointer types may appear in WGSL program source.<br>
+        supporting memory accesses described by mode |AM|.
+
+        Here, |T| is the [=store type=].
+
+        Pointer types may appear in WGSL program source.
 </table>
 
 When *analyzing* a WGSL program, reference and pointer types are fully parameterized by


### PR DESCRIPTION
Fixes: #3025