### PR TITLE
Structure members of vector and matrix type must be concrete

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1959,8 +1959,8 @@ A <dfn noexport>structure</dfn> is a grouping of named <dfn noexport>member</dfn
 
 A structure member type [=shader-creation error|must=] be one of:
 * a [=scalar=] type
-* a [=vector=] type
-* a [=matrix=] type
+* a [=vector=] type with [=concrete=] components
+* a [=matrix=] type with [=concrete=] components
 * an [=atomic type|atomic=] type
 * a [=fixed-size array=] type with [=creation-fixed footprint=]
 * a [=runtime-sized=] array type, but only if it is the last member of the structure


### PR DESCRIPTION
Fixes: #3032