### PR TITLE
Note that objects may hold strong references to parents

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -682,6 +682,23 @@ interface mixin GPUObjectBase {
         An internal slot holding the [=device=] which owns the [=internal object=].
 </dl>
 
+<div class=note>
+    Note:
+    Ideally [=WebGPU interfaces=] should not prevent their parent objects, such as the
+    {{GPUObjectBase/[[device]]}} that owns them, from being garbage collected. This cannot be
+    guaranteed, however, as holding a strong reference to a parent object may be required on some
+    systems.
+
+    As a result, developers should assume that a [=WebGPU interface=] may not be garbage collected
+    until all child objects of that interface have also been garbage collected. This may cause some
+    resources to remain allocated longer than anticipated.
+
+    Calling the `destroy` method on a [=WebGPU interface=] (such as
+    {{GPUDevice}}.{{GPUDevice/destroy()}} or {{GPUBuffer}}.{{GPUBuffer/destroy()}}) should be
+    favored over relying on garbage collection if predictable release of allocated resources is
+    needed.
+</div>
+
 ### Object Descriptors ### {#object-descriptors}
 
 An <dfn dfn>object descriptor</dfn> holds the information needed to create an object,

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -686,8 +686,8 @@ interface mixin GPUObjectBase {
     Note:
     Ideally [=WebGPU interfaces=] should not prevent their parent objects, such as the
     {{GPUObjectBase/[[device]]}} that owns them, from being garbage collected. This cannot be
-    guaranteed, however, as holding a strong reference to a parent object may be required on some
-    systems.
+    guaranteed, however, as holding a strong reference to a parent object may be required in some
+    implementations.
 
     As a result, developers should assume that a [=WebGPU interface=] may not be garbage collected
     until all child objects of that interface have also been garbage collected. This may cause some


### PR DESCRIPTION
Fixes #1497

Tries to capture the conclusions from the last call in a way that
helps guide developers. Note is non-normative, so doesn't place
any restrictions on implementations, but lets developers know that
the only predictable way to release resources is to call
`destroy()`.