### PR TITLE
Add rg11b10ufloat-renderable feature

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2250,7 +2250,8 @@ enum GPUFeatureName {
     "timestamp-query",
     "indirect-first-instance",
     "shader-f16",
-    "bgra8unorm-storage"
+    "bgra8unorm-storage",
+    "rg11b10ufloat-renderable"
 };
 </script>
 
@@ -13181,6 +13182,11 @@ Using "`enable f16;`" directive in WGSL code for a shader module is allowed if a
 
 Allows the {{GPUTextureUsage/STORAGE_BINDING}} usage on textures with format {{GPUTextureFormat/"bgra8unorm"}}.
 
+## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>"rg11b10ufloat-renderable"</dfn> ## {#rg11b10ufloat-renderable}
+
+Allows the {{GPUTextureUsage/RENDER_ATTACHMENT}} usage on textures with format {{GPUTextureFormat/"rg11b10ufloat"}},
+and also allows textures of that format to be multisampled.
+
 # Appendices # {#appendices}
 
 ## Texture Format Capabilities ## {#texture-format-caps}
@@ -13485,8 +13491,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
     <tr>
         <td>{{GPUTextureFormat/rg11b10ufloat}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
-        <td><!-- Vulkan -->
-        <td><!-- no multisampling without RENDER_ATTACHMENT (gpuweb/gpuweb#2465) -->
+        <td colspan=2>If {{GPUFeatureName/"rg11b10ufloat-renderable"}} is enabled
         <td>
         <td><!-- Vulkan -->
         <td>4


### PR DESCRIPTION
Makes rg11b10ufloat support both rendering and multisampling.

Fixes #2648