### PR TITLE
Delete vague statement about @group and @binding

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3995,8 +3995,6 @@ The variable may be declared with a [=access/read=] or [=access/read_write=] acc
 As described in [[#resource-interface]],
 uniform buffers, storage buffers, textures, and samplers form the
 [=resource interface of a shader=].
-Such variables are declared with [=attribute/group=] and [=attribute/binding=] decorations.
-
 
 WGSL defines the following attributes that can be applied to global variables:
  * [=attribute/binding=]


### PR DESCRIPTION
The rule is already stated in 9.3.2 Resource Interface

Fixes: #3082