### PR TITLE
Simplify 'if' description

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6312,27 +6312,37 @@ Control flow statements may cause the program to execute in non-sequential order
 
 ### If Statement ### {#if-statement}
 
+An <dfn noexport dfn-for="statement">if</dfn> statement conditionally executes at most one [=compound statement=] based on
+the evaluation of condition expressions.
+
+An `if` statement has an `if` clause, followed by zero or more `else if` clauses, followed by an optional `else` clause.
+
 <div class='syntax' noexport='true'>
   <dfn for=syntax>if_statement</dfn> :
 
-    | [=syntax/if=] [=syntax/expression=] [=syntax/compound_statement=] ( [=syntax/else=] [=syntax/else_statement=] ) ?
+    | [=syntax/if_clause=] [=syntax/else_if_clause=] * [=syntax/else_clause=] ?
 </div>
+
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>else_statement</dfn> :
+  <dfn for=syntax>if_clause</dfn> :
 
-    | [=syntax/compound_statement=]
-
-    | [=syntax/if_statement=]
+    | [=syntax/if=] [=syntax/expression=] [=syntax/compound_statement=]
 </div>
 
-An <dfn noexport dfn-for="statement">if</dfn> statement conditionally executes at most one [=compound statement=] based on
-the evaluation of the condition expressions.
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>else_if_clause</dfn> :
 
-The `if` statements in WGSL use an if/else if/else structure, that contains a single required
-`if` clause, zero or more `else if` clauses and a single optional `else` clause.
+    | [=syntax/else=] [=syntax/if=] [=syntax/expression=] [=syntax/compound_statement=]
+</div>
+
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>else_clause</dfn> :
+
+    | [=syntax/else=] [=syntax/compound_statement=]
+</div>
 
 [=Type rule precondition=]:
-Each of the expressions for the `if` and `else if` clause conditions [=shader-creation error|must=] be scalar boolean expressions.
+The expression in each `if` and `else if` clause [=shader-creation error|must=] be of [=bool=] type.
 
 An `if` statement is executed as follows:
 * The condition associated with the `if` clause is evaluated.


### PR DESCRIPTION
Simplify type precondition for 'if'

Fixes: #3152

Simplify description of if-statement structure

Refactor the grammar to match the prose.
This relies on some LALR mechanics, in the sense that "else" leads
to a parse state (item set) which can later accept either else_if_clause
or else_clause. That's fine in LALR(1) but would need modification for
an LL or recursive descent parser.

Move the introduction sentences of if-statement to the top of the
section. That's better for readability (and the other statement kinds
should be updated that way too)