### PR TITLE
[editorial] Add definitions for built-in values

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -875,9 +875,9 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
 
   <tr><td><dfn noexport dfn-for="attribute">`invariant`</dfn>
     <td>*None*
-    <td>[=shader-creation error|Must=] only be applied to the `position` built-in value.
+    <td>[=shader-creation error|Must=] only be applied to the [=built-in values/position=] built-in value.
 
-    When applied to the `position` [=built-in output value=] of a vertex
+    When applied to the [=built-in values/position=] [=built-in output value=] of a vertex
     shader, the computation of the result is invariant across different
     programs and different invocations of the same entry point.
     That is, if the data and control flow match for two `position` outputs in
@@ -2214,8 +2214,8 @@ The following kinds of values [=shader-creation error|must=] be of IO-shareable 
 Note: Only user-defined pipeline input and output values must be
 IO-shareable. Built-in pipeline inputs and outputs have the types specified in
 [[#builtin-values]], which are not necessarily in this category. For example, the
-`front_facing` built-in input for fragment shaders has type `bool`, which is not
-IO-shareable.
+[=built-in values/front_facing=] [=built-in input value|built-in input=] for
+fragment shaders has type `bool`, which is not IO-shareable.
 
 ### Host-shareable Types ### {#host-shareable-types}
 
@@ -7588,8 +7588,7 @@ Note: The [=attribute/const=] attribute cannot be applied to user-declared funct
 
 ## Restrictions on Functions ## {#function-restriction}
 
-* A [=vertex=] shader [=shader-creation error|must=] return the `position` [=built-in output value=].
-    See [[#builtin-values]].
+* A [=vertex=] shader [=shader-creation error|must=] return the [=built-in values/position=] [=built-in output value=].
 * An entry point [=shader-creation error|must=] never be the target of a [=function call=].
 * If a function has a return type, it [=shader-creation error|must=] be a [=constructible=] type.
 * A [=formal parameter|function parameter=] [=shader-creation error|must=] one the following types:
@@ -7878,7 +7877,9 @@ A built-in output for stage *S* with name *Y* and type *T*<sub>*Y*</sub> is set 
 Conversely, when the return type or member of a return type for an entry point has a `builtin` attribute,
 the corresponding builtin [=shader-creation error|must=] be an output for the entry point's shader stage.
 
-Note: The `position` built-in is both an output of a vertex shader, and an input to the fragement shader.
+Note: The [=built-in values/position=] built-in is both an output of a vertex shader, and an input to the fragement shader.
+
+Collectively, built-in input and built-in output values are known as <dfn noexport>built-in values</dfn>.
 
 #### User-defined Inputs and Outputs #### {#user-defined-inputs-outputs}
 
@@ -8649,8 +8650,8 @@ The rules for analyzing expressions take as argument both the expression itself 
 </table>
 
 The following built-in input variables are considered uniform:
-- workgroup_id
-- num_workgroups
+- [=built-in values/workgroup_id=]
+- [=built-in values/num_workgroups=]
 
 All other ones (see [[#builtin-values]]) are considered non-uniform.
 
@@ -10646,7 +10647,7 @@ The [=swizzle=] names are used in [[#vector-access-expr|vector access expression
 
 # Built-in Values # {#builtin-values}
 
-The following table lists the available [=built-in input values=] and [=built-in output values=].
+The following table lists the available [=built-in values=].
 
 See [[#builtin-inputs-outputs]] for how to declare a built-in value.
 
@@ -10656,7 +10657,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in value.
     <tr><th>Name<th>Stage<th>Input or Output<th>Type<th>Description
   </thead>
 
-  <tr><td>`vertex_index`
+  <tr><td><dfn noexport dfn-for="built-in values">`vertex_index`</dfn>
       <td>vertex
       <td>input
       <td>u32
@@ -10670,7 +10671,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in value.
          For an indexed draw, the index is equal to the index buffer entry for the
          vertex, plus the `baseVertex` argument of the draw, whether provided directly or indirectly.
 
-  <tr><td>`instance_index`
+  <tr><td><dfn noexport dfn-for="built-in values">`instance_index`</dfn>
       <td>vertex
       <td>input
       <td>u32
@@ -10680,7 +10681,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in value.
          whether provided directly or indirectly.
          The index is incremented by one for each additional instance in the draw.
 
-  <tr><td>`position`
+  <tr><td rowspan=2><dfn noexport dfn-for="built-in values">`position`</dfn>
       <td>vertex
       <td>output
       <td>vec4&lt;f32&gt;
@@ -10690,7 +10691,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in value.
       coordinate space.
       See [[WebGPU#coordinate-systems|WebGPU &sect; Coordinate Systems]].
 
-  <tr><td>`position`
+  <tr>
       <td>fragment
       <td>input
       <td>vec4&lt;f32&gt;
@@ -10698,7 +10699,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in value.
       (The *x*, *y*, and *z* components have already been scaled such that *w* is now 1.)
       See [[WebGPU#coordinate-systems|WebGPU &sect; Coordinate Systems]].
 
-  <tr><td>`front_facing`
+  <tr><td><dfn noexport dfn-for="built-in values">`front_facing`</dfn>
       <td>fragment
       <td>input
       <td>bool
@@ -10706,42 +10707,42 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in value.
          False otherwise.
          See [[WebGPU#front-facing|WebGPU &sect; Front-facing]].
 
-  <tr><td>`frag_depth`
+  <tr><td><dfn noexport dfn-for="built-in values">`frag_depth`</dfn>
       <td>fragment
       <td>output
       <td>f32
       <td style="width:50%">Updated depth of the fragment, in the viewport depth range.
       See [[WebGPU#coordinate-systems|WebGPU &sect; Coordinate Systems]].
 
-  <tr><td>`local_invocation_id`
+  <tr><td><dfn noexport dfn-for="built-in values">`local_invocation_id`</dfn>
       <td>compute
       <td>input
       <td>vec3&lt;u32&gt;
       <td style="width:50%">The current invocation's [=local invocation ID=],
             i.e. its position in the [=workgroup grid=].
 
-  <tr><td>`local_invocation_index`
+  <tr><td><dfn noexport dfn-for="built-in values">`local_invocation_index`</dfn>
       <td>compute
       <td>input
       <td>u32
       <td style="width:50%">The current invocation's [=local invocation index=], a linearized index of
           the invocation's position within the [=workgroup grid=].
 
-  <tr><td>`global_invocation_id`
+  <tr><td><dfn noexport dfn-for="built-in values">`global_invocation_id`</dfn>
       <td>compute
       <td>input
       <td>vec3&lt;u32&gt;
       <td style="width:50%">The current invocation's [=global invocation ID=],
           i.e. its position in the [=compute shader grid=].
 
-  <tr><td>`workgroup_id`
+  <tr><td><dfn noexport dfn-for="built-in values">`workgroup_id`</dfn>
       <td>compute
       <td>input
       <td>vec3&lt;u32&gt;
       <td style="width:50%">The current invocation's [=workgroup ID=],
           i.e. the position of the workgroup in the [=workgroup grid=].
 
-  <tr><td>`num_workgroups`
+  <tr><td><dfn noexport dfn-for="built-in values">`num_workgroups`</dfn>
       <td>compute
       <td>input
       <td>vec3&lt;u32&gt;
@@ -10749,7 +10750,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in value.
       group_count_y, group_count_z)`, of the compute shader
       [[WebGPU#dom-gpucomputepassencoder-dispatch|dispatched]] by the API.
 
-  <tr><td>`sample_index`
+  <tr><td><dfn noexport dfn-for="built-in values">`sample_index`</dfn>
       <td>fragment
       <td>input
       <td>u32
@@ -10759,7 +10760,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in value.
          is the number of MSAA samples specified for the GPU render pipeline.
          <br>See [[WebGPU#render-pipeline|WebGPU &sect; GPURenderPipeline]].
 
-  <tr><td>`sample_mask`
+  <tr><td rowspan=2><dfn noexport dfn-for="built-in values">`sample_mask`</dfn>
       <td>fragment
       <td>input
       <td>u32
@@ -10768,7 +10769,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in value.
          by the primitive being rendered.
          <br>See [[WebGPU#sample-masking|WebGPU &sect; Sample Masking]].
 
-  <tr><td>`sample_mask`
+  <tr>
       <td>fragment
       <td>output
       <td>u32


### PR DESCRIPTION
Fixes #3177

* Add definitions for the entries in the built-in value table
* Change references to specific values into links