### PR TITLE
Describe writeTexture as copying the entire source to the device timeline

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -11041,12 +11041,7 @@ GPUQueue includes GPUObjectBase;
             **Returns:** {{undefined}}
 
             1. Let |dataBytes| be [=get a copy of the buffer source|a copy of the bytes held by the buffer source=] |data|.
-            1. Let |dataByteSize| be the number of bytes in |dataBytes|.
             1. Let |texture| be |destination|.{{GPUImageCopyTexture/texture}}.
-            1. Let |contents| be the contents of the [=images=] seen by
-                viewing |dataBytes| with |dataLayout| and |size|.
-
-                Issue: Specify more formally.
             1. Issue the following steps on the [=Device timeline=] of |this|:
 
                 <div class=device-timeline>
@@ -11065,7 +11060,7 @@ GPUQueue includes GPUObjectBase;
                             - If |texture|.{{GPUTexture/format}} is a [=depth-or-stencil format=]:
                                 - Set |aspectSpecificFormat| to the [=aspect-specific format=] of |texture|.{{GPUTexture/format}} according to [[#depth-formats]].
                             - [$validating linear texture data$](|dataLayout|,
-                                |dataByteSize|,
+                                |dataBytes|.[=byte sequence/length=],
                                 |aspectSpecificFormat|,
                                 |size|) succeeds.
 
@@ -11074,9 +11069,21 @@ GPUQueue includes GPUObjectBase;
                             there is no alignment requirement on either
                             |dataLayout|.{{GPUImageDataLayout/bytesPerRow}} or |dataLayout|.{{GPUImageDataLayout/offset}}.
                         </div>
-                    1. Write |contents| into |destination|.
+                    1. Let |contents| be the contents of the [=images=] seen by
+                        viewing |dataBytes| with |dataLayout| and |size|.
 
                         Issue: Specify more formally.
+
+                        Note: This is described as copying all of |data| to the device timeline,
+                        but in practice |data| could be much larger than necessary.
+                        Implementations should optimize by copying only the necessary bytes.
+                    1. Issue the following steps on the [=Queue timeline=] of |this|:
+
+                        <div class=queue-timeline>
+                            1. Write |contents| into |destination|.
+
+                                Issue: Specify more formally.
+                        </div>
                 </div>
         </div>
 


### PR DESCRIPTION
With a note to optimize by only copying the bytes that are needed.

Fixes a problem where "Let |contents|..." assumed the validation had already passed.

Followup for #2680