### PR TITLE
Un-nest timeline steps

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -153,13 +153,53 @@ div.content-timeline, div.device-timeline, div.queue-timeline {
     background: var(--tint-purple);
 }
 
+span[data-timeline],
+[href="#content-timeline"],
+[href="#device-timeline"],
+[href="#queue-timeline"] {
+    border-style: solid;
+    border-radius: .3em;
+    border-width: 0 0 .2em 0;
+    text-decoration: none;
+}
+div[data-timeline] {
+    border-style: solid;
+    border-width: 1px 0 0 .75em;
+    border-radius: 1em 0 0 1em;
+    padding: .5em;
+}
+div.algorithm > div[data-timeline] {
+    /* Remove unnecessary padding in this common case. Makes the border of the
+     * timeline box line up with the border of the surrounding algorithm box. */
+    margin-left: calc(-.5em - 1px);
+    margin-right: calc(-.5em - 1px);
+}
+
+/*
+ * Coloring for steps and other stuff on particular timelines.
+ */
+[data-timeline="content"],
+[href="#content-timeline"] {
+    border-color: #00cc00 !important;
+}
+[data-timeline="device"],
+[href="#device-timeline"] {
+    border-color: #880000 !important;
+}
+[data-timeline="queue"],
+[href="#queue-timeline"] {
+    border-color: #c900f1 !important;
+}
+
 /*
  * Stylistic labels, for clarity of presentation of these blocks.
  *
  * NOTE: This text is non-accessible and non-selectable; surrounding
  * text must also explain the context.
  */
-.validusage, .content-timeline, .device-timeline, .queue-timeline {
+.validusage,
+.content-timeline, .device-timeline, .queue-timeline,
+[data-timeline] {
     position: relative;
 }
 .validusage::before,
@@ -168,7 +208,7 @@ div.content-timeline, div.device-timeline, div.queue-timeline {
 .queue-timeline::before {
     font-weight: bold;
     font-style: italic;
-    font-size: 130%;
+    font-size: 1.3rem;
     color: rgba(0, 0, 0, 0.15);
     color: var(--watermark-text);
     position: absolute;
@@ -251,7 +291,7 @@ thead.stickyheader th, th.stickyheader {
 }
 
 /*
- * Darkmode colors
+ * Light-mode and dark-mode colors
  */
 :root {
     --watermark-text: rgba(0, 0, 0, 15%);
@@ -781,10 +821,6 @@ has components working on different timelines in parallel:
 :: Associated with the execution of the Web script.
     It includes calling all methods described by this specification.
 
-    <div class=content-timeline>
-        Steps executed on the content timeline look like this.
-    </div>
-
 : <dfn dfn>Device timeline</dfn>
 :: Associated with the GPU device operations
     that are issued by the user agent.
@@ -793,18 +829,24 @@ has components working on different timelines in parallel:
     of view of the user agent part that controls the GPU,
     but can live in a separate OS process.
 
-    <div class=device-timeline>
-        Steps executed on the device timeline look like this.
-    </div>
-
 : <dfn dfn>Queue timeline</dfn>
 :: Associated with the execution of operations
     on the compute units of the GPU. It includes actual draw, copy,
     and compute jobs that run on the GPU.
 
-    <div class=queue-timeline>
-        Steps executed on the queue timeline look like this.
+<div class=algorithm>
+    This is an example algorithm.
+
+    <div data-timeline=content>
+        Steps executed on the [=content timeline=] look like this.
     </div>
+    <div data-timeline=device>
+        Steps executed on the [=device timeline=] look like this.
+    </div>
+    <div data-timeline=queue>
+        Steps executed on the [=queue timeline=] look like this.
+    </div>
+</div>
 
 In this specification, asynchronous operations are used when the result value
 depends on work that happens on any timeline other than the [=Content timeline=].

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -11060,64 +11060,70 @@ GPUQueue includes GPUObjectBase;
         Issues a write operation of the provided data into a {{GPUTexture}}.
 
         <div algorithm=GPUQueue.writeTexture>
-            **Called on:** {{GPUQueue}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUQueue}} |this|.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUQueue/writeTexture(destination, data, dataLayout, size)">
-                |destination|: The [=texture subresource=] and origin to write to.
-                |data|: Data to write into |destination|.
-                |dataLayout|: Layout of the content in |data|.
-                |size|: Extents of the content to write from |data| to |destination|.
-            </pre>
+                <pre class=argumentdef for="GPUQueue/writeTexture(destination, data, dataLayout, size)">
+                    |destination|: The [=texture subresource=] and origin to write to.
+                    |data|: Data to write into |destination|.
+                    |dataLayout|: Layout of the content in |data|.
+                    |size|: Extents of the content to write from |data| to |destination|.
+                </pre>
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
 
-            1. Let |dataBytes| be [=get a copy of the buffer source|a copy of the bytes held by the buffer source=] |data|.
-            1. Let |texture| be |destination|.{{GPUImageCopyTexture/texture}}.
-            1. Issue the following steps on the [=Device timeline=] of |this|:
+                [=Content timeline=] steps:
 
-                <div class=device-timeline>
-                    1. If any of the following conditions are unsatisfied,
-                        [$generate a validation error$] and stop.
+                1. Let |dataBytes| be [=get a copy of the buffer source|a copy of the bytes held by the buffer source=] |data|.
+                1. Issue the subsequent steps on the [=Device timeline=] of |this|.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
 
-                        <div class=validusage>
-                            - [$validating GPUImageCopyTexture$](|destination|, |size|) returns `true`.
-                            - |texture|.{{GPUTexture/usage}} includes {{GPUTextureUsage/COPY_DST}}.
-                            - |texture|.{{GPUTexture/sampleCount}} is 1.
-                            - [=validating texture copy range=](|destination|, |size|) return `true`.
-                            - |destination|.{{GPUImageCopyTexture/aspect}} must refer to a single aspect of
-                                |texture|.{{GPUTexture/format}}.
-                            - That aspect must be a valid image copy destination according to [[#depth-formats]].
-                            - Let |aspectSpecificFormat| = |texture|.{{GPUTexture/format}}.
-                            - If |texture|.{{GPUTexture/format}} is a [=depth-or-stencil format=]:
-                                - Set |aspectSpecificFormat| to the [=aspect-specific format=] of |texture|.{{GPUTexture/format}} according to [[#depth-formats]].
-                            - [$validating linear texture data$](|dataLayout|,
-                                |dataBytes|.[=byte sequence/length=],
-                                |aspectSpecificFormat|,
-                                |size|) succeeds.
+                1. Let |texture| be |destination|.{{GPUImageCopyTexture/texture}}.
+                1. If any of the following conditions are unsatisfied,
+                    [$generate a validation error$] and stop.
 
-                            Note: unlike
-                            {{GPUCommandEncoder}}.{{GPUCommandEncoder/copyBufferToTexture()}},
-                            there is no alignment requirement on either
-                            |dataLayout|.{{GPUImageDataLayout/bytesPerRow}} or |dataLayout|.{{GPUImageDataLayout/offset}}.
-                        </div>
-                    1. Let |contents| be the contents of the [=images=] seen by
-                        viewing |dataBytes| with |dataLayout| and |size|.
+                    <div class=validusage>
+                        - [$validating GPUImageCopyTexture$](|destination|, |size|) returns `true`.
+                        - |texture|.{{GPUTexture/usage}} includes {{GPUTextureUsage/COPY_DST}}.
+                        - |texture|.{{GPUTexture/sampleCount}} is 1.
+                        - [=validating texture copy range=](|destination|, |size|) return `true`.
+                        - |destination|.{{GPUImageCopyTexture/aspect}} must refer to a single aspect of
+                            |texture|.{{GPUTexture/format}}.
+                        - That aspect must be a valid image copy destination according to [[#depth-formats]].
+                        - Let |aspectSpecificFormat| = |texture|.{{GPUTexture/format}}.
+                        - If |texture|.{{GPUTexture/format}} is a [=depth-or-stencil format=]:
+                            - Set |aspectSpecificFormat| to the [=aspect-specific format=] of |texture|.{{GPUTexture/format}} according to [[#depth-formats]].
+                        - [$validating linear texture data$](|dataLayout|,
+                            |dataBytes|.[=byte sequence/length=],
+                            |aspectSpecificFormat|,
+                            |size|) succeeds.
 
-                        Issue: Specify more formally.
+                        Note: unlike
+                        {{GPUCommandEncoder}}.{{GPUCommandEncoder/copyBufferToTexture()}},
+                        there is no alignment requirement on either
+                        |dataLayout|.{{GPUImageDataLayout/bytesPerRow}} or |dataLayout|.{{GPUImageDataLayout/offset}}.
+                    </div>
+                1. Let |contents| be the contents of the [=images=] seen by
+                    viewing |dataBytes| with |dataLayout| and |size|.
 
-                        Note: This is described as copying all of |data| to the device timeline,
-                        but in practice |data| could be much larger than necessary.
-                        Implementations should optimize by copying only the necessary bytes.
-                    1. Issue the following steps on the [=Queue timeline=] of |this|:
+                    Issue: Specify more formally.
 
-                        <div class=queue-timeline>
-                            1. Write |contents| into |destination|.
+                    Note: This is described as copying all of |data| to the device timeline,
+                    but in practice |data| could be much larger than necessary.
+                    Implementations should optimize by copying only the necessary bytes.
+                1. Issue the subsequent steps on the [=Queue timeline=] of |this|.
+            </div>
+            <div data-timeline=queue>
+                [=Queue timeline=] steps:
 
-                                Issue: Specify more formally.
-                        </div>
-                </div>
+                1. Write |contents| into |destination|.
+
+                    Issue: Specify more formally.
+            </div>
         </div>
 
     : <dfn>copyExternalImageToTexture(source, destination, copySize)</dfn>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -11269,8 +11269,8 @@ GPUQueue includes GPUObjectBase;
         </div>
 </dl>
 
-Queries {#queries}
-================
+
+# Queries # {#queries}
 
 ## <dfn interface>GPUQuerySet</dfn> ## {#queryset}
 


### PR DESCRIPTION
It's not really necessary in most cases for the timeline steps to be nested like they are today. This change lets us flattens things and reduce nesting a bunch. It starts by updating just `writeTexture()`.