### PR TITLE
Fix length overloads

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -11476,7 +11476,7 @@ but a value may infer the type.
   <tr algorithm="length">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn length(e: T) -> f32
+@const fn length(e: T) -> S
 </xmp>
   <tr>
     <td style="width:10%">Parameterization


### PR DESCRIPTION
Fixes #3111

* Fix the return type of length built-in function to allow f16 and
  AbstractFloat returns