### PR TITLE
Rename creation-time constant/expresion/function to const-

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -832,12 +832,12 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     <td>*None*
     <td>Must only be applied to function declarations.
 
-    Specifies that the function can be used as a [=creation-time function=].
+    Specifies that the function can be used as a [=const-function=].
     It is a [=shader-creation error=] if this attribute is a applied to a
     user-defined function.
 
     Note: This attribute is used as a notational convention to describe which
-    built-in functions can be used in [=creation-time expressions=].
+    built-in functions can be used in [=const-expressions=].
 
   <tr><td><dfn noexport dfn-for="attribute">`group`</dfn>
     <td>[=shader-creation error|Must=] be an [=i32=] or [=AbstractInt=] [=integer literal|literal=].<br>
@@ -850,7 +850,7 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
   <tr><td><dfn noexport dfn-for="attribute">`id`</dfn>
     <td>[=shader-creation error|Must=] be an [=i32=] or [=AbstractInt=] [=integer literal|literal=].<br>
         [=shader-creation error|Must=] be non-negative.
-    <td>[=shader-creation error|Must=] only be applied to an [=override declaration=] of [=scalar=] type.
+    <td>[=shader-creation error|Must=] only be applied to an [=override-declaration=] of [=scalar=] type.
 
     Specifies a numeric identifier as an alternate name for a
     [=pipeline-overridable=] constant.
@@ -1394,7 +1394,7 @@ A <dfn>feasible automatic conversion</dfn> converts a value from type *Src* to t
 Such conversions are value-preserving, subject to limitations described in [[#floating-point-evaluation]].
 
 Note: Automatic conversions only occur in two kinds of situations.
-First, when converting a [=creation-time constant=] to its corresponding typed numeric value that can be used on the GPU.
+First, when converting a [=const-declarations=] to its corresponding typed numeric value that can be used on the GPU.
 Second, when a load from a reference-to-memory occurs, yielding the value stored in that memory.
 
 Note: A conversion of infinite rank is infeasible, i.e. not allowed.
@@ -1510,7 +1510,7 @@ Overload resolution for |P| proceeds as follows, with the goal of finding a sing
 
 TODO: Examples
 
-## Types for Creation-Time Constants ## {#types-for-creation-time-constants}
+## Abstract Numeric Types ## {#abstract-types}
 
 Certain expressions are evaluated at [=shader module creation|shader-creation time=],
 and with a numeric range and precision that may be larger than directly implemented by the GPU.
@@ -1858,7 +1858,7 @@ See [[#array-access-expr]].
 An expression [=shader-creation error|must not=] evaluate to a runtime-sized array type.
 
 The element count expression |N| of a fixed-size array is subject to the following constraints:
-* It [=shader-creation error|must=] be an [=override expression=].
+* It [=shader-creation error|must=] be an [=override-expression=].
 * It [=shader-creation error|must=] evalute to an [=integer scalar=].
 * It is a [=pipeline-creation error=] if expression is not greater than zero.
 
@@ -2114,7 +2114,7 @@ The plain types with [=creation-fixed footprint=] are:
 * a [=matrix=] type with [=concrete=] components
 * an [=atomic type|atomic=] type
 * a [=fixed-size array=] type, when:
-     * its [=element count=] is a [=creation-time expression=].
+     * its [=element count=] is a [=const-expression=].
 * a [=structure=] type, if all its members have [=creation-fixed footprint=].
 
 Note: A [=constructible=] type has [=creation-fixed footprint=].
@@ -2124,7 +2124,7 @@ The plain types with [=fixed footprint=] are any of:
 * a [=fixed-size array=] type (without further constraining its [=element count=])
 
 Note: The only valid use of a fixed-size array with an element count that is an
-[=override expression=] that is not a [=creation-time expression=] is as the
+[=override-expression=] that is not a [=const-expression=] is as the
 [=store type=] for a [=address spaces/workgroup=] variable.
 
 Note: A fixed-footprint type may contain an [=atomic type|atomic=] type, either directly or
@@ -2964,7 +2964,7 @@ References and pointers are distinguished by how they are used:
 * The type of a [=variable=] is a reference type.
 * The [=address-of=] operation (unary `&`) converts a reference value to its corresponding pointer value.
 * The [=indirection=] operation (unary `*`) converts a pointer value to its corresponding reference value.
-* A [=let declaration=] can be of pointer type, but not of reference type.
+* A [=let-declaration=] can be of pointer type, but not of reference type.
 * A [=formal parameter=] can be of pointer type, but not of reference type.
 * A [=simple assignment=] statement performs a [=write access=] to update the contents of memory via a reference, where:
     * The [=left-hand side=] of the assignment statement [=shader-creation error|must=] be of reference type, with access mode [=access/write=] or [=access/read_write=].
@@ -3029,7 +3029,7 @@ Defining references in this way enables simple idiomatic use of variables:
 
 Defining pointers in this way enables two key use cases:
 
-* Using a let declaration with pointer type, to form a short name for part of the contents of a variable.
+* Using a let-declaration with pointer type, to form a short name for part of the contents of a variable.
 * Using a formal parameter of a function to refer to the memory of a variable that is accessible to the [=calling function=].
     * The call to such a function [=shader-creation error|must=] supply a pointer value for that operand.
         This often requires using an [=address-of=] operation (unary `&`) to get a pointer to the variable's contents.
@@ -3186,7 +3186,7 @@ In all cases, the [=access mode=] of the result is the same as the access mode o
         //    the memory for the fifth element of the array referenced by
         //    the reference value from the previous step.
         //    The result value has type ref<function,i32,read_write>.
-        // The let declaration requires the right-hand-side to be of type i32.
+        // The let-declaration requires the right-hand-side to be of type i32.
         // The Load Rule applies (because no other type rule can apply), and
         // the evaluation of the initializer yields the i32 value loaded from
         // the memory locations referenced by 'A[4]' at the time the declaration
@@ -3201,7 +3201,7 @@ In all cases, the [=access mode=] of the result is the same as the access mode o
         //    the memory for the second member of the memory referenced by
         //    the reference value from the previous step.
         //    The result has type ref<private,f32,read_write>.
-        // The let declaration requires the right-hand-side to be of type f32.
+        // The let-declaration requires the right-hand-side to be of type f32.
         // The Load Rule applies (because no other type rule can apply), and
         // the evaluation of the initializer yields the f32 value loaded from
         // the memory locations referenced by 'person.weight' at the time the
@@ -3754,16 +3754,16 @@ See [[#declaration-and-scope]].
 
 [SHORTNAME] authors can declare names for immutable values using a <dfn noexport>value declaration</dfn> which are either:
 
-  * a [=let declaration=], or
-  * an [=override declaration=], or
-  * a [=creation-time constant=].
+  * a [=let-declaration=], or
+  * an [=override-declaration=], or
+  * a [=const-declaration=].
 
 Value declarations do not have any associated storage.
 That is, there are no [=memory locations=] associated with the declaration.
 
 ### `let` Declarations ### {#let-decls}
 
-A <dfn noexport>let declaration</dfn> specifies a name for a value.
+A <dfn noexport>let-declaration</dfn> specifies a name for a value.
 Once the value for a let-declaration is computed, it is immutable.
 When an [=identifier=] use [=resolves=] to a let-declaration, the identifier denotes that value.
 
@@ -3773,7 +3773,7 @@ When the type is specified, e.g `let foo: i32 = 4`, the initializer expression [
 
 `let`-declarations can only appear within a function definition.
 
-<div class='example wgsl let declaration at function-scope' heading='let-declared constants at function scope'>
+<div class='example wgsl let-declaration at function-scope' heading='let-declared constants at function scope'>
   <xmp highlight='rust'>
     // 'blockSize' denotes the i32 value 1024.
     let blockSize: i32 = 1024;
@@ -3785,7 +3785,7 @@ When the type is specified, e.g `let foo: i32 = 4`, the initializer expression [
 
 ### `override` Declarations ### {#override-decls}
 
-An <dfn noexport>override declaration</dfn> specifies a name for a
+An <dfn noexport>override-declaration</dfn> specifies a name for a
 [=pipeline-overridable=] constant value.
 The value of a <dfn noexport>pipeline-overridable</dfn> constant is fixed at
 pipeline-creation time.
@@ -3801,10 +3801,10 @@ When an [=identifier=] use [=resolves=] to a override-declaration, the identifie
   * The initializer expression, if present, [=shader-creation error|must=]:
       * evaluate to a [=scalar=] type.
       * evaluate to the declared type if it is present.
-      * be composed only [=creation-time expressions=] or expressions where all
-          identifiers [=resolve=] to overridable constants, [=creation-time
-          constants=], or [=creation-time functions=].
-          Such an expression is called an <dfn noexport>override expression</dfn>.
+      * be composed only [=const-expressions=] or expressions where all
+          identifiers [=resolve=] to overridable constants,
+          [=const-declarations=], or [=const-functions=].
+          Such an expression is called an <dfn noexport>override-expression</dfn>.
   * If the declaration has the [=attribute/id=] applied, the literal operand is
       known as the <dfn noexport>pipeline constant ID</dfn>, and [=shader-creation error|must=] be an
       integer value between 0 and 65535.
@@ -3820,7 +3820,7 @@ When an [=identifier=] use [=resolves=] to a override-declaration, the identifie
     its declaration has an initializer expression.
     If it doesn't, it is a [=pipeline-creation error=] if a value is not provided at pipeline-creation time.
 
-Note: Override expressions are a superset of [=creation-time expressions=].
+Note: Override expressions are a superset of [=const-expressions=].
 
 <div class='example wgsl global-scope' heading='Module constants, pipeline-overrideable'>
   <xmp highlight='rust'>
@@ -3840,18 +3840,18 @@ Note: Override expressions are a superset of [=creation-time expressions=].
   </xmp>
 </div>
 
-### Creation-time Constants ### {#creation-time-consts}
+### `const` Declarations ### {#const-decls}
 
-A <dfn noexport>creation-time constant</dfn> specifies a name for value that is
+A <dfn noexport>const-declaration</dfn> specifies a name for value that is
 fixed at [=shader module creation|shader-creation time=].
 Once the constant is declared, its value is immutable.
-When an [=identifier=] use [=resolves=] to a creation-time constant, the
+When an [=identifier=] use [=resolves=] to a const-declaration, the
 identifier denotes that value.
 
-When a creation-time constant is declared without an explicitly specified type,
-e.g. `const foo = 4`, the type is automatically inferred from the expression to
-the right of the [=syntax/equals=] token.
-The type of a creation-time constant must be:
+When const-declaration does not explicitly specify a type, `e.g. const foo =
+4`, the type is automatically inferred from the expression to the right of the
+[=syntax/equals=] token.
+The type of a `const` declaration must be:
 * a [=constructible=] type, or
 * an [=abstract numeric type=], or
 * a [=vector=], or
@@ -3863,11 +3863,11 @@ expression must evaluate to that type.
 Note: Since [=AbstractInt=] and [=AbstractFloat=] cannot be spelled in
 WGSL source, named values can only use them through type inference.
 
-A creation-time constant can be declared at module-scope or function-scope.
-A creation-time constant must be declared with an initializer and be composed
-only of [=creation-time expressions=].
+A const-declaration can be declared at module-scope or function-scope.
+A const-declaration must be declared with an initializer and be composed
+only of [=const-expressions=].
 
-<div class='example wgsl global-scope' heading='Creation-time constants'>
+<div class='example wgsl global-scope' heading='const-declarations'>
   <xmp>
     const a = 4;                  // AbstractInt with a value of 4.
     const b : i32 = 4;            // i32 with a value of 4.
@@ -4042,8 +4042,8 @@ WGSL defines the following attributes that can be applied to global variables:
 
 A [[#value-decls|value declaration]] appearing outside all functions declares a
 [=module scope|module-scope=] constant.
-Module-scope constants must be either [=override declarations=] or
-[=creation-time constants=].
+Module-scope constants must be either [=override-declarations=] or
+[=const-declaration=].
 The name is [=in scope=] for the entire program.
 
 <div class='example wgsl global-scope' heading='Module constants'>
@@ -4070,7 +4070,7 @@ The name is available for use immediately after its declaration statement, and
 until the end of the brace-delimited list of statements immediately enclosing
 the declaration.
 
-A function-scope [=let declaration|let-declared=] constant [=shader-creation error|must=] be of
+A function-scope [=let-declaration|let-declared=] constant [=shader-creation error|must=] be of
 [=constructible=] type, or of [=pointer type=].
 
 For a variable declared in function scope:
@@ -4149,15 +4149,15 @@ use the same memory.
 
 Expressions specify how values are computed.
 
-## Creation-time Expressions ## {#creation-time-expr}
+## `const` Expressions ## {#const-expr}
 
 Expressions that are evaluated at [=shader module creation|shader-creation
-time=] are called <dfn noexport>creation-time expressions</dfn>.
+time=] are called <dfn noexport>const-expressions</dfn>.
 In order for an expression to be evaluated at shader-creation time all
-[=identifiers=] used by the expression must [=resolve=] to [=creation-time
-constants=] or [=creation-time functions=].
+[=identifiers=] used by the expression must [=resolve=] to
+[=const-declarations=] or [=const-functions=].
 
-The types of creation-time expressions can resolve to types that include
+The types of `const` expressions can resolve to types that include
 [=abstract numeric types=].
 
 Example:  `(42)` is analyzed as follows:
@@ -4178,13 +4178,13 @@ Example:  `-2147483648` is analyzed as follows:
 
 Example:  `const minint = -2147483648;` is analyzed as follows:
 * As above, `-2147483648` evaluates to a [=AbstractInt=] value -2147483648.
-* A [=creation-time constant=] allows the initializer to be an [=abstract numeric type=].
+* A [=const-declaration=] allows the initializer to be an [=abstract numeric type=].
 * The result is that `minint` is declared to be the [=AbstractInt=] value -2147483648.
 
 Example:  `let minint = -2147483648;` is analyzed as follows:
 * As above, `-2147483648` evaluates to a [=AbstractInt=] value -2147483648.
-* A [=let declaration=] requires the initializer to be [=constructible=].
-* The let declaration does not have an explicit type, so [=overload resolution=] is used.
+* A [=let-declaration=] requires the initializer to be [=constructible=].
+* The let-declaration does not have an explicit type, so [=overload resolution=] is used.
     The overload candidates that apply use [=feasible automatic conversions=] from [=AbstractInt=] to either [=i32=], [=u32=], or [=f32=].
     The one of lowest rank is to [=i32=], and so
     [=AbstractInt=] -2147483648 value is converted to the [=i32=] value -2147483648.
@@ -5760,7 +5760,7 @@ The <dfn noexport>indirection</dfn> operator converts a pointer to its correspon
   <tr algorithm="pipeline-overridable constant value">
        <td>
           |c| is an [=identifier=] [=resolves|resolving=] to
-          an [=in scope|in-scope=] [=override declaration=] with type |T|
+          an [=in scope|in-scope=] [=override-declaration=] with type |T|
        <td class="nowrap">
           |c|: |T|
        <td>If pipeline creation specified a value for the [=pipeline constant ID|constant ID=],
@@ -6391,7 +6391,7 @@ depending on the evaluation of a selector expression.
 If the selector value equals a value in a case selector list, then control is transferred to
 the body of that case clause.
 The expressions in the [=syntax/case_selectors=] [=shader-creation error|must=]
-be [=creation-time expressions=].
+be [=const-expressions=].
 If the selector value does not equal any of the case selector values, then control is
 transferred to the `default` clause.
 
@@ -6876,7 +6876,7 @@ Note: If the function [=return value|returns a value=], that value is ignored.
 
 A static assertion statement produces a [=shader-creation error=] if the
 expression evaluates to `false`.
-The expression [=shader-creation error|must=] be a [=creation-time expression=].
+The expression [=shader-creation error|must=] be a [=const-expression=].
 The statement can satisfy [=statically accessed|static access=] requirements in
 a shader, but otherwise has no effect on the compiled shader.
 This statement can be used at [=module scope=] and within [=function scope|functions=].
@@ -6898,7 +6898,7 @@ This statement can be used at [=module scope=] and within [=function scope|funct
       const z = x + y - 2;
       staticAssert z > 0; // valid in functions.
       let a  = 3;
-      staticAssert a != 0; // invalid, the expresion must be a creation-time expression.
+      staticAssert a != 0; // invalid, the expresion must be a const-expression.
     }
   </xmp>
 </div>
@@ -7016,7 +7016,7 @@ non-empty [=behavior=] for each statement, and function.
     <td class="nowrap">var x:T;
     <td>
     <td>{Next}
-  <tr algorithm="let declaration behavior">
+  <tr algorithm="let-declaration behavior">
     <td class="nowrap">let x = |e|;
     <td>
     <td>{Next}
@@ -7475,20 +7475,20 @@ The location of a function call is referred to as a <dfn noexport>call site</dfn
 Call sites are a [=dynamic context=].
 As such, the same textual location may represent multiple call sites.
 
-## Creation-time Functions ## {#creation-time-funcs}
+## `const` Functions ## {#const-funcs}
 
 A function declared with a [=attribute/const=] attribute can be
 evaluated at [=shader module creation|shader-creation time=].
-These functions are called <dfn noexport>creation-time functions</dfn>.
-Calls to these functions can part of [=creation-time expressions=].
+These functions are called <dfn noexport>const-functions</dfn>.
+Calls to these functions can part of [=const-expressions=].
 
 It is a [=shader-creation error=] if the function contains any expressions that
-are not [=creation-time expressions=], or any declarations that are not
-[=creation-time constants=].
+are not [=const-expressions=], or any declarations that are not
+[=const-declarations=].
 
 Note: The [=attribute/const=] attribute cannot be applied to user-declared functions.
 
-<div class='example wgsl' heading='Creation-time functions'>
+<div class='example wgsl' heading='const-functions'>
   <xmp>
     const first_one = firstLeadingBit(1234 + 4567); // Evaluates to 12
                                                     // first_one has the type i32, because
@@ -7496,15 +7496,15 @@ Note: The [=attribute/const=] attribute cannot be applied to user-declared funct
                                                     // AbstractInt
 
     @id(1) override x : i32;
-    override y = firstLeadingBit(x); // Creation-time expressions can be
-                                     // used in override expressions.
+    override y = firstLeadingBit(x); // const-expressions can be
+                                     // used in override-expressions.
                                      // firstLeadingBit(x) is not a
-                                     // creation-time expression in this context.
+                                     // const-expression in this context.
 
     fn foo() {
-      var a : array<i32, firstLeadingBit(257)>; // Creation-time functions can be used in
-                                                // creation-time expressions if all their
-                                                // parameters are creation-time expressions.
+      var a : array<i32, firstLeadingBit(257)>; // const-functions can be used in
+                                                // const-expressions if all their
+                                                // parameters are const-expressions.
     }
   </xmp>
 </div>
@@ -8531,8 +8531,8 @@ The rules for analyzing expressions take as argument both the expression itself 
       <td>
       <td class="nowrap">*CF*, *CF*
       <td>
-   <tr><td>reference to function-scope variable, creation-time constant,
-      let-declaration, or non-built-in parameter "x"
+   <tr><td>reference to function-scope variable, [=const-declaration=],
+      [=let-declaration=], or non-built-in parameter "x"
       <td>*Result*
       <td class="nowrap">*X* is the node corresponding to "x"
       <td class="nowrap">*CF*, *Result*
@@ -8583,7 +8583,7 @@ All other ones (see [[#builtin-values]]) are considered non-uniform.
   <thead>
     <tr><th>Expression<th>New nodes<th>Recursive analyses<th>Resulting control flow node, variable node<th>New edges
   </thead>
-  <tr><td>reference to function-scope variable, creation-time constant, let-declaration, or parameter "x"
+  <tr><td>reference to function-scope variable, [=const-declaration=], [=let-declaration=], or parameter "x"
       <td>
       <td class="nowrap">*X* is the node corresponding to "x"
       <td class="nowrap">*CF*, *X*
@@ -12723,7 +12723,7 @@ fn textureGather(t: texture_depth_cube_array,
   <tr><td>`component`<td>
   Only applies to non-depth textures.
   <br>The index of the channel to read from the selected texels.
-  <br>When provided, the `component` expression [=shader-creation error|must=] be a [=creation-time expression=] (e.g. `1`).<br>
+  <br>When provided, the `component` expression [=shader-creation error|must=] be a [=const-expression=] (e.g. `1`).<br>
   Its value must be at least 0 and at most 3.
   Values outside of this range will result in a [=shader-creation error=].
   <tr><td>`t`<td>
@@ -12738,7 +12738,7 @@ fn textureGather(t: texture_depth_cube_array,
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  The `offset` expression [=shader-creation error|must=] be a [=creation-time expression=] (e.g. `vec2<i32>(1, 2)`).<br>
+  The `offset` expression [=shader-creation error|must=] be a [=const-expression=] (e.g. `vec2<i32>(1, 2)`).<br>
   Each `offset` component [=shader-creation error|must=] be at least `-8` and at most `7`. Values outside
   of this range will result in a [=shader-creation error=].
 </table>
@@ -12867,7 +12867,7 @@ fn textureGatherCompare(t: texture_depth_cube_array,
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  The `offset` expression [=shader-creation error|must=] be a [=creation-time expression=] (e.g. `vec2<i32>(1, 2)`).<br>
+  The `offset` expression [=shader-creation error|must=] be a [=const-expression=] (e.g. `vec2<i32>(1, 2)`).<br>
   Each `offset` component [=shader-creation error|must=] be at least `-8` and at most `7`. Values outside
   of this range will result in a [=shader-creation error=].
 </table>
@@ -13233,7 +13233,7 @@ fn textureSample(t: texture_depth_cube_array,
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  The `offset` expression [=shader-creation error|must=] be a [=creation-time expression=] (e.g. `vec2<i32>(1, 2)`).<br>
+  The `offset` expression [=shader-creation error|must=] be a [=const-expression=] (e.g. `vec2<i32>(1, 2)`).<br>
   Each `offset` component [=shader-creation error|must=] be at least `-8` and at most `7`. Values outside
   of this range will result in a [=shader-creation error=].
 </table>
@@ -13335,7 +13335,7 @@ fn textureSampleBias(t: texture_cube_array<f32>,
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  The `offset` expression [=shader-creation error|must=] be a [=creation-time expression=] (e.g. `vec2<i32>(1, 2)`).<br>
+  The `offset` expression [=shader-creation error|must=] be a [=const-expression=] (e.g. `vec2<i32>(1, 2)`).<br>
   Each `offset` component [=shader-creation error|must=] be at least `-8` and at most `7`. Values outside
   of this range will result in a [=shader-creation error=].
 </table>
@@ -13428,7 +13428,7 @@ fn textureSampleCompare(t: texture_depth_cube_array,
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  The `offset` expression [=shader-creation error|must=] be a [=creation-time expression=] (e.g. `vec2<i32>(1, 2)`).<br>
+  The `offset` expression [=shader-creation error|must=] be a [=const-expression=] (e.g. `vec2<i32>(1, 2)`).<br>
   Each `offset` component [=shader-creation error|must=] be at least `-8` and at most `7`. Values outside
   of this range will result in a [=shader-creation error=].
 </table>
@@ -13526,7 +13526,7 @@ fn textureSampleCompareLevel(t: texture_depth_cube_array,
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  The `offset` expression [=shader-creation error|must=] be a [=creation-time expression=] (e.g. `vec2<i32>(1, 2)`).<br>
+  The `offset` expression [=shader-creation error|must=] be a [=const-expression=] (e.g. `vec2<i32>(1, 2)`).<br>
   Each `offset` component [=shader-creation error|must=] be at least `-8` and at most `7`. Values outside
   of this range will result in a [=shader-creation error=].
 </table>
@@ -13640,7 +13640,7 @@ fn textureSampleGrad(t: texture_cube_array<f32>,
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  The `offset` expression [=shader-creation error|must=] be a [=creation-time expression=] (e.g. `vec2<i32>(1, 2)`).<br>
+  The `offset` expression [=shader-creation error|must=] be a [=const-expression=] (e.g. `vec2<i32>(1, 2)`).<br>
   Each `offset` component [=shader-creation error|must=] be at least `-8` and at most `7`. Values outside
   of this range will result in a [=shader-creation error=].
 </table>
@@ -13804,7 +13804,7 @@ fn textureSampleLevel(t: texture_external,
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  The `offset` expression [=shader-creation error|must=] be a [=creation-time expression=] (e.g. `vec2<i32>(1, 2)`).<br>
+  The `offset` expression [=shader-creation error|must=] be a [=const-expression=] (e.g. `vec2<i32>(1, 2)`).<br>
   Each `offset` component [=shader-creation error|must=] be at least `-8` and at most `7`. Values outside
   of this range will result in a [=shader-creation error=].
 </table>


### PR DESCRIPTION
* Renames
  * creation-time constant -> const-declaration
  * creation-time expression -> const-expression
  * creation-time function -> const-function
  * Types for Creation-Time Constants -> Abstract Numeric Types
* unified spellings between let-declaration, override-declaration, and
  const-declaration