### PR TITLE
Move override-expression definition into its own section

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1525,10 +1525,9 @@ error|must not=] overflow or produce undefined results.
 
 These types cannot be spelled in WGSL source. They are only used by [=type checking=].
 
-A type that is not an abstract numeric type nor contains an abstract numeric
-type is called <dfn noexport>concrete</dfn>.
-Similarly, a type that is an abstract numeric type or contains an abstract
-numeric type is called an <dfn noexport>abstract type</dfn>.
+A type is <dfn dfn-for="type" noexport>abstract</dfn> if it is an abstract
+numeric type or contains an abstract numeric type.
+A type is <dfn dfn-for="type" noexport>concrete</dfn> if it is not abstract.
 
 A [=numeric literal=] without a suffix denotes a value in an [=abstract numeric type=]:
 * An [=integer literal=] without an `i` or `u` suffix denotes an [=AbstractInt=] value.
@@ -1868,8 +1867,8 @@ Note:  The element count value is fully determined at [=pipeline creation=] time
 
 An array element type [=shader-creation error|must=] be one of:
 * a [=scalar=] type
-* a [=vector=] type with [=concrete=] components
-* a [=matrix=] type with [=concrete=] components
+* a [=vector=] type
+* a [=matrix=] type
 * an [=atomic type|atomic=] type
 * an [=array=] type having a [=creation-fixed footprint=]
 * a [=structure=] type having a [=creation-fixed footprint=].
@@ -1975,12 +1974,14 @@ Two structure types are the same if and only if they have the same name.
 
 A structure member type [=shader-creation error|must=] be one of:
 * a [=scalar=] type
-* a [=vector=] type with [=concrete=] components
-* a [=matrix=] type with [=concrete=] components
+* a [=vector=] type
+* a [=matrix=] type
 * an [=atomic type|atomic=] type
 * a [=fixed-size array=] type with [=creation-fixed footprint=]
 * a [=runtime-sized=] array type, but only if it is the last member of the structure
 * a [=structure=] type that has a [=creation-fixed footprint=]
+
+All structure types [=shader-creation error|must=] be [=type/concrete|concrete=].
 
 Note: Each member type must be a [=plain type=].
 
@@ -2082,8 +2083,8 @@ We call these [=constructible=].
 A type is <dfn>constructible</dfn> if it is one of:
 
 * a [=scalar=] type
-* a [=vector=] type with [=concrete=] components
-* a [=matrix=] type with [=concrete=] components
+* a [=vector=] type
+* a [=matrix=] type
 * a [=fixed-size array=] type, if it has [=creation-fixed footprint=] and its element type is constructible.
 * a [=structure=] type, if all its members are constructible.
 
@@ -2102,22 +2103,24 @@ Most variables are sized very early, at [=Shader module creation|shader creation
 Some variables may be sized later, at [=pipeline creation=] time,
 and others as late as the [=shader execution start|start of shader execution=].
 
-A [=plain type=] has a <dfn>creation-fixed footprint</dfn> if its size is fully determined
-at [=shader module creation|shader creation=] time.
+A type has a <dfn>creation-fixed footprint</dfn> if its [=feasible automatic
+conversion|concretization=] has a size that is fully determined at [=shader
+module creation|shader creation=] time.
 
-A [=plain type=] has a <dfn>fixed footprint</dfn> if its size is fully determined
+A type has a <dfn>fixed footprint</dfn> if its size is fully determined
 at [=pipeline creation=] time.
 
 Note: Pipeline creation depends on shader creation, so a type with [=creation-fixed footprint=] also has [=fixed footprint=].
 
-The plain types with [=creation-fixed footprint=] are:
+The types with [=creation-fixed footprint=] are:
 * a [=scalar=] type
-* a [=vector=] type with [=concrete=] components
-* a [=matrix=] type with [=concrete=] components
+* a [=vector=] type
+* a [=matrix=] type
 * an [=atomic type|atomic=] type
 * a [=fixed-size array=] type, when:
      * its [=element count=] is a [=const-expression=].
 * a [=structure=] type, if all its members have [=creation-fixed footprint=].
+* an [=abstract numeric type=]
 
 Note: A [=constructible=] type has [=creation-fixed footprint=].
 
@@ -2186,13 +2189,15 @@ or it may be opaque, such as for textures and samplers.
 A type is <dfn noexport>storable</dfn> if it is one of:
 
 * a [=scalar=] type
-* a [=vector=] type with [=concrete=] components
-* a [=matrix=] type with [=concrete=] components
+* a [=vector=] type
+* a [=matrix=] type
 * an [=atomic type|atomic=] type
 * an [=array=] type
 * a [=structure=] type
 * a [=texture=] type
 * a [=sampler=] type
+
+Additionally, a type is only storable if it is [=type/concrete|concrete=].
 
 Note: That is, the storable types are the [=plain types=], texture types, and sampler types.
 
@@ -2281,7 +2286,7 @@ and how to use variables with it.
       <td>Invocations in the same [=compute shader stage|compute shader=] [=compute shader stage/workgroup=]
       <td>[=access/read_write=]
       <td>[=Module scope=]
-      <td>[=Plain type=] with [=fixed footprint=]
+      <td>Type with a [=type/concrete|concrete=] [=fixed footprint=]
       <td>The [=element count=] of an outermost array may be a [=pipeline-overridable=] constant.
   <tr><td><dfn noexport dfn-for="address spaces">uniform</dfn>
       <td>Invocations in the same [=shader stage=]
@@ -3888,7 +3893,7 @@ that may be placed in the referenced memory) and its [=reference type=] (the typ
 of the variable itself).
 If a variable has store type |T|, [=address space=] |AS|, and [=access mode=] |AM|,
 then its reference type is ref&lt;|AS|,|T|,|AM|&gt;.
-The [=store type=] of a variable is always [=concrete=].
+The [=store type=] of a variable is always [=type/concrete|concrete=].
 
 A <dfn noexport>variable declaration</dfn>:
 
@@ -4165,7 +4170,10 @@ In order for an expression to be evaluated at shader-creation time all
 * [=type aliases=], or 
 * [=structure=] names
 
-The types of `const` expressions can [=type rules|resolve=] to [=abstract types=].
+The type of a `const` expression must [=type rules|resolve=] to a type with a
+[=creation-fixed footprint=].
+
+Note: [=type/abstract|Abstract types=] can be the inferred type of a const-expression.
 
 Example:  `(42)` is analyzed as follows:
 * The term `42` is the [=AbstractInt=] value 42.
@@ -4209,16 +4217,15 @@ In order for an expression to be evaluated at pipeline creation time all
 * [=type aliases=], or 
 * [=structure=] names
 
-Override-expressions are a superset of [=const-expressions=], except that they
-cannot [=type rules|resolve=] to an [=abstract type=].
+Note: All [=const-expressions=] are also override-expressions.
 
-Note: Override-expressions may have a type that is not assignable to an
-[=override-declaration=] because they can resolve to [=scalar|non-scalar=]
-types.
+Note: An override-expression may not be usable as the initializer for an
+[=override-declaration=], because such initializers must [=type rules|resolve=]
+to a [=type/concrete|concrete=] [=scalar=] type.
 
 Example: `override x = 42;` is analyzed as follows:
 * The term `42` is the [=AbstractInt=] value 42.
-* An [=override-declaration=] requires a [=concrete=] [=scalar=] type.
+* An [=override-declaration=] requires a [=type/concrete|concrete=] [=scalar=] type.
 * `42` is converted to [=i32=] via a [=feasible automatic conversion=].
 
 Example: `let y = x + 1;` is analyzed as follows:
@@ -5376,19 +5383,19 @@ See [[#sync-builtin-functions]].
     <td>|e1| : |T|<br>|e2| : |T|<br>[ALLNUMERICDECL]
     <td>|e1| `+` |e2| : |T|
     <td>Addition. [=Component-wise=] when |T| is a vector.
-    If |T| is a [=concrete=] integral type, then the result is modulo 2<sup>32</sup>.
+    If |T| is a [=type/concrete|concrete=] integral type, then the result is modulo 2<sup>32</sup>.
 
   <tr algorithm="subtraction">
     <td>|e1| : |T|<br>|e2| : |T|<br>[ALLNUMERICDECL]
     <td>|e1| `-` |e2| : |T|
     <td>Subtraction [=Component-wise=] when |T| is a vector.
-    If |T| is a [=concrete=] integral type, then the result is modulo 2<sup>32</sup>.
+    If |T| is a [=type/concrete|concrete=] integral type, then the result is modulo 2<sup>32</sup>.
 
   <tr algorithm="multiplication">
     <td>|e1| : |T|<br>|e2| : |T|<br>[ALLNUMERICDECL]
     <td>|e1| `*` |e2| : |T|
     <td>Multiplication. [=Component-wise=] when |T| is a vector.
-    If |T| is a [=concrete=] integral type, then the result is modulo 2<sup>32</sup>.
+    If |T| is a [=type/concrete|concrete=] integral type, then the result is modulo 2<sup>32</sup>.
 
   <tr algorithm="division">
     <td>|e1| : |T|<br>|e2| : |T|<br>[ALLNUMERICDECL]
@@ -11466,7 +11473,7 @@ but a value may infer the type.
     <td>[ALLFLOATINGDECL]<br>
         `I` is [ALLSIGNEDINTEGRAL]<br>
         `I` is a vector if and only if `T` is a vector<br>
-        `I` is [=concrete=] if and only if `T` is a [=concrete=]
+        `I` is [=type/concrete|concrete=] if and only if `T` is a [=type/concrete|concrete=]
   <tr>
     <td>Description
     <td>Returns `e1 * 2`<sup>`e2`</sup>.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1527,6 +1527,8 @@ These types cannot be spelled in WGSL source. They are only used by [=type check
 
 A type that is not an abstract numeric type nor contains an abstract numeric
 type is called <dfn noexport>concrete</dfn>.
+Similarly, a type that is an abstract numeric type or contains an abstract
+numeric type is called an <dfn noexport>abstract type</dfn>.
 
 A [=numeric literal=] without a suffix denotes a value in an [=abstract numeric type=]:
 * An [=integer literal=] without an `i` or `u` suffix denotes an [=AbstractInt=] value.
@@ -3801,10 +3803,7 @@ When an [=identifier=] use [=resolves=] to a override-declaration, the identifie
   * The initializer expression, if present, [=shader-creation error|must=]:
       * evaluate to a [=scalar=] type.
       * evaluate to the declared type if it is present.
-      * be composed only [=const-expressions=] or expressions where all
-          identifiers [=resolve=] to overridable constants,
-          [=const-declarations=], or [=const-functions=].
-          Such an expression is called an <dfn noexport>override-expression</dfn>.
+      * be an [=override-expression=].
   * If the declaration has the [=attribute/id=] applied, the literal operand is
       known as the <dfn noexport>pipeline constant ID</dfn>, and [=shader-creation error|must=] be an
       integer value between 0 and 65535.
@@ -4149,16 +4148,24 @@ use the same memory.
 
 Expressions specify how values are computed.
 
-## `const` Expressions ## {#const-expr}
+## Early Evaluation Expressions ## {#early-eval-exprs}
+
+WGSL defines two types of expressions that can be evaluated before runtime:
+* [=const-expressions=], and
+* [=override-expressions=]
+
+### `const` Expressions ### {#const-expr}
 
 Expressions that are evaluated at [=shader module creation|shader-creation
 time=] are called <dfn noexport>const-expressions</dfn>.
 In order for an expression to be evaluated at shader-creation time all
-[=identifiers=] used by the expression must [=resolve=] to
-[=const-declarations=] or [=const-functions=].
+[=identifiers=] used by the expression must [=resolve=] to:
+* [=const-declarations=], or
+* [=const-functions=], or 
+* [=type aliases=], or 
+* [=structure=] names
 
-The types of `const` expressions can resolve to types that include
-[=abstract numeric types=].
+The types of `const` expressions can [=type rules|resolve=] to [=abstract types=].
 
 Example:  `(42)` is analyzed as follows:
 * The term `42` is the [=AbstractInt=] value 42.
@@ -4189,6 +4196,46 @@ Example:  `let minint = -2147483648;` is analyzed as follows:
     The one of lowest rank is to [=i32=], and so
     [=AbstractInt=] -2147483648 value is converted to the [=i32=] value -2147483648.
 * The result is that `minint` is declared to be the i32 value -2147483648.
+
+### `override` Expressions ### {#override-expr}
+
+Expressions that are evaluated at [=pipeline creation=] time are called <dfn
+noexport>override-expressions</dfn>.
+In order for an expression to be evaluated at pipeline creation time all
+[=identifiers=] used by the expression must [=resolve=] to:
+* [=override-declarations=], or
+* [=const-declarations=], or
+* [=const-functions=], or 
+* [=type aliases=], or 
+* [=structure=] names
+
+Override-expressions are a superset of [=const-expressions=], except that they
+cannot [=type rules|resolve=] to an [=abstract type=].
+
+Note: Override-expressions may have a type that is not assignable to an
+[=override-declaration=] because they can resolve to [=scalar|non-scalar=]
+types.
+
+Example: `override x = 42;` is analyzed as follows:
+* The term `42` is the [=AbstractInt=] value 42.
+* An [=override-declaration=] requires a [=concrete=] [=scalar=] type.
+* `42` is converted to [=i32=] via a [=feasible automatic conversion=].
+
+Example: `let y = x + 1;` is analyzed as follows:
+* From above, `x` has a type of [=i32=].
+* The expression `x + 1` is an override-expression because it is composed of an
+    [=override-declaration=] and an [=integer literal=].
+* The expression has a type of [=i32=] and is evaluated at [=pipeline
+    creation=] time.
+    Its value depends on whether or not `x` is overridden at pipeline creation
+    time.
+
+Example: `vec3(x,x,x)` is analyzed as follows:
+* From above, `x` is an [=override-declaration=] with the type [=i32=].
+* `vec3(x,x,x)` is an override-expression because the only identifiers
+    [=resolve=] to override-declarations.
+* The type of the expression is a [=vector=] of 3 components
+    of [=i32=] (`vec3<i32>`).
 
 ## Literal Value Expressions ## {#literal-expressions}
 


### PR DESCRIPTION
* Add new section for early evaluation expressions
  * move const-expression under it
  * add override-expression there
* Add type aliases and structure names as allowed in const-expressions
  and override-expressions
* Define abstract type and use it in override-expression and
  const-expression