### PR TITLE
Add abstract arrays

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1463,12 +1463,18 @@ Note: When no conversion is performed, the conversion rank is zero.
       <td>vec|N|&lt;|S|&gt;
       <td>vec|N|&lt;|T|&gt;
       <td>ConversionRank(|S|,|T|)
-      <td>Inherit conversion rank from component types.
+      <td>Inherit conversion rank from component type.
   <tr algorithm="conversion rank abstract matrix">
       <td>mat|C|x|R|&lt;|S|&gt;
       <td>mat|C|x|R|&lt;|T|&gt;
       <td>ConversionRank(|S|,|T|)
-      <td>Inherit conversion rank from component types.
+      <td>Inherit conversion rank from component type.
+  <tr algorithm="conversion rank abstract array">
+      <td>array&lt;|S|,|N|&gt;
+      <td>array&lt;|T|,|N|&gt;
+      <td>ConversionRank(|S|,|T|)
+      <td>Inherit conversion rank from component type.
+      Note: Only [=fixed-size arrays=] may have an [=type/abstract=] component type.
   <tr algorithm="conversion rank for non-convertible cases">
       <td><var ignore>S</var>
       <td><var ignore>T</var><br>where above cases don't apply
@@ -1981,7 +1987,7 @@ A structure member type [=shader-creation error|must=] be one of:
 * a [=runtime-sized=] array type, but only if it is the last member of the structure
 * a [=structure=] type that has a [=creation-fixed footprint=]
 
-All structure types [=shader-creation error|must=] be [=type/concrete|concrete=].
+Note: All structure types are [=type/concrete=].
 
 Note: Each member type must be a [=plain type=].
 
@@ -2082,13 +2088,14 @@ We call these [=constructible=].
 
 A type is <dfn>constructible</dfn> if it is one of:
 
+* an [=abstract numeric type=]
 * a [=scalar=] type
 * a [=vector=] type
 * a [=matrix=] type
 * a [=fixed-size array=] type, if it has [=creation-fixed footprint=] and its element type is constructible.
 * a [=structure=] type, if all its members are constructible.
 
-Note: All constructible types are [=plain types|plain=] and have [=creation-fixed footprint=].
+Note: All constructible types have a [=creation-fixed footprint=].
 
 Note: Atomic types and runtime-sized array types are not constructible.
 Composite types containing atomics and runtime-sized arrays are not constructible.
@@ -2122,7 +2129,7 @@ The types with [=creation-fixed footprint=] are:
 * a [=structure=] type, if all its members have [=creation-fixed footprint=].
 * an [=abstract numeric type=]
 
-Note: A [=constructible=] type has [=creation-fixed footprint=].
+Note: A [=constructible=] type has a [=creation-fixed footprint=].
 
 The plain types with [=fixed footprint=] are any of:
 * a type with [=creation-fixed footprint=]
@@ -2186,7 +2193,7 @@ A storable type may have an explicit representation defined by WGSL,
 as described in [[#internal-value-layout]],
 or it may be opaque, such as for textures and samplers.
 
-A type is <dfn noexport>storable</dfn> if it is one of:
+A type is <dfn noexport>storable</dfn> if it is both [=type/concrete=] and one of:
 
 * a [=scalar=] type
 * a [=vector=] type
@@ -2196,8 +2203,6 @@ A type is <dfn noexport>storable</dfn> if it is one of:
 * a [=structure=] type
 * a [=texture=] type
 * a [=sampler=] type
-
-Additionally, a type is only storable if it is [=type/concrete|concrete=].
 
 Note: That is, the storable types are the [=plain types=], texture types, and sampler types.
 
@@ -2286,7 +2291,7 @@ and how to use variables with it.
       <td>Invocations in the same [=compute shader stage|compute shader=] [=compute shader stage/workgroup=]
       <td>[=access/read_write=]
       <td>[=Module scope=]
-      <td>Type with a [=type/concrete|concrete=] [=fixed footprint=]
+      <td>Type with a [=type/concrete=] [=fixed footprint=]
       <td>The [=element count=] of an outermost array may be a [=pipeline-overridable=] constant.
   <tr><td><dfn noexport dfn-for="address spaces">uniform</dfn>
       <td>Invocations in the same [=shader stage=]
@@ -3878,8 +3883,9 @@ only of [=const-expressions=].
     const c : u32 = 4;            // u32 with a value of 4.
     const d : f32 = 4;            // f32 with a value of 4.
     const e = vec3(a, a, a);      // vec3 of AbstractInt with a value of (4, 4, 4).
-    const f = 4.0;                // AbstractFloat with a vaue of 4.
-    const g = mat2x2(a, f, a, f); // mat2x2 of AbstractFloat with a value of ((2, 4), (2, 4)).
+    const f = 2.0;                // AbstractFloat with a vaue of 4.
+    const g = mat2x2(a, f, a, f); // mat2x2 of AbstractFloat with a value of ((4.0, 2.0), (4.0, 2.0)).
+    const h = array(a, f, a, f);  // array of AbstractFloat with 4 components: (4.0, 2.0, 4.0, 2.0).
   </xmp>
 </div>
 
@@ -3893,7 +3899,7 @@ that may be placed in the referenced memory) and its [=reference type=] (the typ
 of the variable itself).
 If a variable has store type |T|, [=address space=] |AS|, and [=access mode=] |AM|,
 then its reference type is ref&lt;|AS|,|T|,|AM|&gt;.
-The [=store type=] of a variable is always [=type/concrete|concrete=].
+The [=store type=] of a variable is always [=type/concrete=].
 
 A <dfn noexport>variable declaration</dfn>:
 
@@ -4198,7 +4204,7 @@ Example:  `const minint = -2147483648;` is analyzed as follows:
 
 Example:  `let minint = -2147483648;` is analyzed as follows:
 * As above, `-2147483648` evaluates to a [=AbstractInt=] value -2147483648.
-* A [=let-declaration=] requires the initializer to be [=constructible=].
+* A [=let-declaration=] requires the initializer to be a [=type/concrete=] [=constructible=] type or a pointer type.
 * The let-declaration does not have an explicit type, so [=overload resolution=] is used.
     The overload candidates that apply use [=feasible automatic conversions=] from [=AbstractInt=] to either [=i32=], [=u32=], or [=f32=].
     The one of lowest rank is to [=i32=], and so
@@ -4221,11 +4227,11 @@ Note: All [=const-expressions=] are also override-expressions.
 
 Note: An override-expression may not be usable as the initializer for an
 [=override-declaration=], because such initializers must [=type rules|resolve=]
-to a [=type/concrete|concrete=] [=scalar=] type.
+to a [=type/concrete=] [=scalar=] type.
 
 Example: `override x = 42;` is analyzed as follows:
 * The term `42` is the [=AbstractInt=] value 42.
-* An [=override-declaration=] requires a [=type/concrete|concrete=] [=scalar=] type.
+* An [=override-declaration=] requires a [=type/concrete=] [=scalar=] type.
 * `42` is converted to [=i32=] via a [=feasible automatic conversion=].
 
 Example: `let y = x + 1;` is analyzed as follows:
@@ -4293,7 +4299,7 @@ Example: `vec3(x,x,x)` is analyzed as follows:
 
 ## Type Constructor Expressions ## {#type-constructor-expr}
 
-A type constructor expression explicitly creates a value of a given [=constructible=] type.
+A type constructor expression explicitly creates a value of a given [=type/concrete=] [=constructible=] type.
 
 There are three kinds of constructor expressions:
 * [[#construction-from-components]]
@@ -4534,13 +4540,21 @@ specify the component type; the component type is inferred from the constructor 
     <td>|e1|: |T|<br>
         ...<br>
         |eN|: |T|,<br>
-        |T| is [=constructible=]<br>
+        |T| is [=type/concrete=] and [=constructible=]<br>
     <td class="nowrap">`array<`|T|,|N|`>(`|e1|,...,|eN|`)` : array&lt;|T|,|N|&gt;
     <td>Construction of an array from elements.
 
         Note: array&lt;|T|,|N|&gt; is [=constructible=] because its [=element count=]
         is equal to the number of arguments to the constructor, and hence
         fully determined at [=shader module creation|shader-creation=] time.
+  <tr algorithm="array value construction with inferred components">
+    <td>|e1|: |T|<br>
+        ...<br>
+        |eN|: |T|,<br>
+        |T| is [=constructible=]<br>
+    <td class="nowrap">`array(`|e1|,...,|eN|`)` : array&lt;|T|,|N|&gt;
+    <td>Construction of an array from elements.
+        The component type is inferred from the elements' types.
 </table>
 
 <table class='data'>
@@ -4560,7 +4574,7 @@ specify the component type; the component type is inferred from the constructor 
 
 ### Zero Value Expressions ### {#zero-value-expr}
 
-Each [=constructible=] *T* has a unique <dfn noexport>zero value</dfn>
+Each [=type/concrete=], [=constructible=] *T* has a unique <dfn noexport>zero value</dfn>
 written in WGSL as the type followed by an empty pair of parentheses: *T* `()`.
 
 The zero values are as follows:
@@ -5383,19 +5397,19 @@ See [[#sync-builtin-functions]].
     <td>|e1| : |T|<br>|e2| : |T|<br>[ALLNUMERICDECL]
     <td>|e1| `+` |e2| : |T|
     <td>Addition. [=Component-wise=] when |T| is a vector.
-    If |T| is a [=type/concrete|concrete=] integral type, then the result is modulo 2<sup>32</sup>.
+    If |T| is a [=type/concrete=] integral type, then the result is modulo 2<sup>32</sup>.
 
   <tr algorithm="subtraction">
     <td>|e1| : |T|<br>|e2| : |T|<br>[ALLNUMERICDECL]
     <td>|e1| `-` |e2| : |T|
     <td>Subtraction [=Component-wise=] when |T| is a vector.
-    If |T| is a [=type/concrete|concrete=] integral type, then the result is modulo 2<sup>32</sup>.
+    If |T| is a [=type/concrete=] integral type, then the result is modulo 2<sup>32</sup>.
 
   <tr algorithm="multiplication">
     <td>|e1| : |T|<br>|e2| : |T|<br>[ALLNUMERICDECL]
     <td>|e1| `*` |e2| : |T|
     <td>Multiplication. [=Component-wise=] when |T| is a vector.
-    If |T| is a [=type/concrete|concrete=] integral type, then the result is modulo 2<sup>32</sup>.
+    If |T| is a [=type/concrete=] integral type, then the result is modulo 2<sup>32</sup>.
 
   <tr algorithm="division">
     <td>|e1| : |T|<br>|e2| : |T|<br>[ALLNUMERICDECL]
@@ -5871,6 +5885,8 @@ When an identifier is used as a [=syntax/callable=] item, it is one of:
     | [=syntax/vec_prefix=]
 
     | [=syntax/mat_prefix=]
+
+    | [=syntax/array=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>paren_expression</dfn> :
@@ -6082,7 +6098,7 @@ In this case the value of the [=right-hand side=] is written to the memory refer
   </thead>
   <tr algorithm="updating assignment">
     <td>|e|: |T|,<br>
-        |T| is a [=constructible=] type,<br>
+        |T| is a [=storable=] type,<br>
         |r|: ref<|AS|,|T|,|AM|>,<br>
         |AS| is a writable [=address space=],<br>
         [=access mode=] |AM| is [=access/write=] or [=access/read_write=]<br>
@@ -6136,7 +6152,7 @@ In this case the [=right-hand side=] is evaluated, and then ignored.
   </thead>
   <tr algorithm="phony-assignment">
     <td>|e|: |T|,<br>
-        |T| is [=constructible=], an [=abstract numeric type=], a [=pointer type=], a [=texture=] type, or a [=sampler=] type
+        |T| is [=constructible=], a [=pointer type=], a [=texture=] type, or a [=sampler=] type
     <td class="nowrap">_ = |e|
     <td>Evaluates |e|.
 
@@ -11473,7 +11489,7 @@ but a value may infer the type.
     <td>[ALLFLOATINGDECL]<br>
         `I` is [ALLSIGNEDINTEGRAL]<br>
         `I` is a vector if and only if `T` is a vector<br>
-        `I` is [=type/concrete|concrete=] if and only if `T` is a [=type/concrete|concrete=]
+        `I` is [=type/concrete=] if and only if `T` is a [=type/concrete=]
   <tr>
     <td>Description
     <td>Returns `e1 * 2`<sup>`e2`</sup>.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6098,7 +6098,7 @@ In this case the value of the [=right-hand side=] is written to the memory refer
   </thead>
   <tr algorithm="updating assignment">
     <td>|e|: |T|,<br>
-        |T| is a [=storable=] type,<br>
+        |T| is a [=type/concrete=] [=constructible=] type,<br>
         |r|: ref<|AS|,|T|,|AM|>,<br>
         |AS| is a writable [=address space=],<br>
         [=access mode=] |AM| is [=access/write=] or [=access/read_write=]<br>


### PR DESCRIPTION
* Adds conversion ranks for abstract component arrays
* Adds an array constructor with an inferred component type
* Editorial fixes
  * add abstract numerics to constructible types
  * simplify several definition links
  * change simple assignment to use storable type
  * clarify let types
  * clarify storable types