### PR TITLE
[editorial] Move abstract numeric types under plain types

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1516,7 +1516,18 @@ Overload resolution for |P| proceeds as follows, with the goal of finding a sing
 
 TODO: Examples
 
-## Abstract Numeric Types ## {#abstract-types}
+## Plain Types ## {#plain-types-section}
+
+[=Plain types=] are types for the machine representation of boolean values, numbers, vectors,
+matrices, or aggregations of such values.
+
+A <dfn>plain type</dfn> is either an [=abstract numeric type=], a [=scalar=]
+type, an [=atomic type|atomic=] type, or a [=composite=] type.
+
+Note: Plain types in WGSL are similar to Plain-Old-Data types in C++, but also
+include atomic types and abstract numeric types.
+
+### Abstract Numeric Types ### {#abstract-types}
 
 Certain expressions are evaluated at [=shader module creation|shader-creation time=],
 and with a numeric range and precision that may be larger than directly implemented by the GPU.
@@ -1676,15 +1687,6 @@ Example:  `1u + 2.5` results in a [=shader-creation error=]:
 
   </xmp>
 </div>
-
-## Plain Types ## {#plain-types-section}
-
-[=Plain types=] are types for the machine representation of boolean values, numbers, vectors,
-matrices, or aggregations of such values.
-
-A <dfn>plain type</dfn> is either a [=scalar=] type, an [=atomic type|atomic=] type, or a [=composite=] type.
-
-Note: Plain types in WGSL are similar to Plain-Old-Data types in C++, but also include atomic types.
 
 ### Boolean Type ### {#bool-type}
 
@@ -2204,7 +2206,7 @@ A type is <dfn noexport>storable</dfn> if it is both [=type/concrete=] and one o
 * a [=texture=] type
 * a [=sampler=] type
 
-Note: That is, the storable types are the [=plain types=], texture types, and sampler types.
+Note: That is, the storable types are the [=type/concrete=] [=plain types=], texture types, and sampler types.
 
 ### IO-shareable Types ### {#io-shareable-types}
 


### PR DESCRIPTION
* Plain types are described as booleans, numbers, vectors, etc and
  abstract numerics are numbers
* additionally constructible and fixed-footprint types are under plain
  types (as are arrays, vectors and matrices) and they all support
  abstract components