### PR TITLE
Set currentTexture to null on presentation

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -11537,7 +11537,7 @@ interface GPUCanvasContext {
         Any changes to the drawing buffer made through the currentTexture get presented at the end
         of the frame, in "[$update the rendering of the WebGPU canvas$]", which also destroys
         this texture and sets {{GPUCanvasContext/[[currentTexture]]}} to `null`, indicating
-        a new one needs to be created by {{GPUCanvasContext/getCurrentTexture()}}.
+        a new one will be created by {{GPUCanvasContext/getCurrentTexture()}}.
 
         {{GPUTexture/destroy()|Destroying}} the currentTexture has no effect on the drawing buffer
         contents; it only terminates write-access to the drawing buffer early.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -11453,8 +11453,7 @@ instance by passing the string literal `'webgpu'` as its `contextType` argument.
 
     1. Let |context| be a new {{GPUCanvasContext}}.
     1. Set |context|.{{GPUCanvasContext/canvas}} to |canvas|.
-    1. Set |context|.{{GPUCanvasContext/[[drawingBuffer]]}} to a transparent black
-        image with the same size as |canvas|.
+    1. [$Replace the drawing buffer$].
     1. Return |context|.
 </div>
 
@@ -11523,6 +11522,7 @@ interface GPUCanvasContext {
 
         The drawing buffer outlives the {{GPUCanvasContext/[[currentTexture]]}} and contains the
         previously-rendered contents even after the canvas has been presented.
+        It is only cleared in [$Replace the drawing buffer$].
 
         Any time the drawing buffer is read, implementations must ensure that all previously
         submitted work (e.g. queue submissions) have completed writing to it via
@@ -11532,19 +11532,20 @@ interface GPUCanvasContext {
     ::
         The {{GPUTexture}} to draw into for the current frame.
         It exposes a writable view onto the underlying {{GPUCanvasContext/[[drawingBuffer]]}}.
-        {{GPUCanvasContext/getCurrentTexture()}} populates this slot if null or destroyed,
-        then returns it.
+        {{GPUCanvasContext/getCurrentTexture()}} populates this slot if `null`, then returns it.
 
         Any changes to the drawing buffer made through the currentTexture get presented at the end
-        of the frame, in "[$update the rendering of the WebGPU canvas$]".
+        of the frame, in "[$update the rendering of the WebGPU canvas$]", which also destroys
+        this texture and sets {{GPUCanvasContext/[[currentTexture]]}} to `null`, indicating
+        a new one needs to be created by {{GPUCanvasContext/getCurrentTexture()}}.
 
         {{GPUTexture/destroy()|Destroying}} the currentTexture has no effect on the drawing buffer
         contents; it only terminates write-access to the drawing buffer early.
         During the same frame, {{GPUCanvasContext/getCurrentTexture()}} continues returning the
         same destroyed texture.
 
-        Calling {{GPUCanvasContext/configure()}} or resizing the canvas clears the drawing buffer
-        and sets the current texture to `null`, in "[$Replace the drawing buffer$]".
+        [$Replace the drawing buffer$] sets the currentTexture to `null`.
+        It is called by {{GPUCanvasContext/configure()}}, resizing the canvas, and others.
 </dl>
 
 {{GPUCanvasContext}} has the following methods:
@@ -11658,6 +11659,7 @@ interface GPUCanvasContext {
         1. Call |context|.{{GPUCanvasContext/[[currentTexture]]}}.{{GPUTexture/destroy()}}
             (without destroying |context|.{{GPUCanvasContext/[[drawingBuffer]]}})
             to terminate write access to the image.
+        1. Set |context|.{{GPUCanvasContext/[[currentTexture]]}} to `null`.
 
     Note: If {{GPUCanvasConfiguration/alphaMode}} is {{GPUCanvasAlphaMode/"opaque"}},
     the presented image has its alpha channel cleared. Implementations may skip this step if they


### PR DESCRIPTION
Without this, `getCurrentTexture()` doesn't know it's supposed to
allocate a new texture, it just keeps using the destroyed one.

And related language tweaks.

Issue introduced in #2905. This PR still implements the behavior
described and agreed upon there. Issue found in whatwg/html#8123.