### PR TITLE
Allow using depth textures with 'unfilterable-float' bindings

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -13638,7 +13638,7 @@ be used with {{GPUSamplerBindingType/"comparison"}} samplers (which may use filt
         <td>2
         <td>depth
         <td>2
-        <td>{{GPUTextureSampleType/"depth"}}
+        <td>{{GPUTextureSampleType/"depth"}}, {{GPUTextureSampleType/"unfilterable-float"}}
         <td colspan=2>&checkmark;
         <td>{{GPUTextureFormat/depth16unorm}}
     <tr>
@@ -13646,7 +13646,7 @@ be used with {{GPUSamplerBindingType/"comparison"}} samplers (which may use filt
         <td>4
         <td>depth
         <td>- (<a href="#depthPlus">See prose</a>)
-        <td>{{GPUTextureSampleType/"depth"}}
+        <td>{{GPUTextureSampleType/"depth"}}, {{GPUTextureSampleType/"unfilterable-float"}}
         <td colspan=2>&cross;
         <td>{{GPUTextureFormat/depth24plus}}
     <tr>
@@ -13654,7 +13654,7 @@ be used with {{GPUSamplerBindingType/"comparison"}} samplers (which may use filt
         <td rowspan=2>4 &minus; 8
         <td>depth
         <td>- (<a href="#depthPlus">See prose</a>)
-        <td>{{GPUTextureSampleType/"depth"}}
+        <td>{{GPUTextureSampleType/"depth"}}, {{GPUTextureSampleType/"unfilterable-float"}}
         <td colspan=2>&cross;
         <td>{{GPUTextureFormat/depth24plus}}
     <tr>
@@ -13668,7 +13668,7 @@ be used with {{GPUSamplerBindingType/"comparison"}} samplers (which may use filt
         <td>4
         <td>depth
         <td>4
-        <td>{{GPUTextureSampleType/"depth"}}
+        <td>{{GPUTextureSampleType/"depth"}}, {{GPUTextureSampleType/"unfilterable-float"}}
         <td colspan=1>&checkmark;
         <td colspan=1>&cross;
         <td>{{GPUTextureFormat/depth32float}}
@@ -13677,7 +13677,7 @@ be used with {{GPUSamplerBindingType/"comparison"}} samplers (which may use filt
         <td rowspan=2>5 &minus; 8
         <td>depth
         <td>4
-        <td>{{GPUTextureSampleType/"depth"}}
+        <td>{{GPUTextureSampleType/"depth"}}, {{GPUTextureSampleType/"unfilterable-float"}}
         <td colspan=1>&checkmark;
         <td colspan=1>&cross;
         <td>{{GPUTextureFormat/depth32float}}
@@ -13693,8 +13693,6 @@ be used with {{GPUSamplerBindingType/"comparison"}} samplers (which may use filt
 
 It is [$validating shader binding|possible$] to bind a depth-aspect {{GPUTextureView}}
 to either a `texture_depth_*` binding or a binding with other non-depth 2d/cube texture types.
-In both cases, the {{GPUTextureBindingLayout/sampleType}} in the {{GPUBindGroupLayout}}
-must be {{GPUTextureSampleType/"depth"}}.
 
 A stencil-aspect {{GPUTextureView}} must be bound to a normal texture binding type.
 The {{GPUTextureBindingLayout/sampleType}} in the {{GPUBindGroupLayout}}


### PR DESCRIPTION
Fixes #2094