### PR TITLE
Rename staticAssert to static_assert

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6956,21 +6956,21 @@ This statement can be used at [=module scope=] and within [=function scope|funct
 <div class='syntax' noexport='true'>
   <dfn for=syntax>static_assert_statement</dfn> :
 
-    | [=syntax/staticAssert=] [=syntax/expression=]
+    | [=syntax/static_assert=] [=syntax/expression=]
 </div>
 
 <div class='example wgsl global-scope' heading="Static assertion examples">
   <xmp highlight='rust'>
     const x = 1;
     const y = 2;
-    staticAssert x < y; // valid at module-scope.
-    staticAssert(y != 0); // parentheses are optional.
+    static_assert x < y; // valid at module-scope.
+    static_assert(y != 0); // parentheses are optional.
 
     fn foo() {
       const z = x + y - 2;
-      staticAssert z > 0; // valid in functions.
+      static_assert z > 0; // valid in functions.
       let a  = 3;
-      staticAssert a != 0; // invalid, the expresion must be a const-expression.
+      static_assert a != 0; // invalid, the expresion must be a const-expression.
     }
   </xmp>
 </div>
@@ -9311,9 +9311,9 @@ Issue: https://github.com/gpuweb/gpuweb/issues/1621
     | `'sampler_comparison'`
 </div>
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>staticAssert</dfn> :
+  <dfn for=syntax>static_assert</dfn> :
 
-    | `'staticAssert'`
+    | `'static_assert'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>struct</dfn> :


### PR DESCRIPTION
* Switch to snake case
  * When static assertions became statements the keyword was left camel
    case, but that doesn't match with other keywords as well (e.g. texture
    types)