### PR TITLE
Allow expressions in attribute parameters

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -795,7 +795,7 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
   </thead>
 
   <tr><td><dfn noexport dfn-for="attribute">`align`</dfn>
-    <td>[=shader-creation error|Must=] be an [=i32=] or [=AbstractInt=] [=integer literal|literal=].<br>
+    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=].<br>
         [=shader-creation error|Must=] be positive.
     <td>[=shader-creation error|Must=] only be applied to a member of a [=structure=] type.
 
@@ -813,7 +813,7 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     See [[#memory-layouts]]
 
   <tr><td><dfn noexport dfn-for="attribute">`binding`</dfn>
-    <td>[=shader-creation error|Must=] be an [=i32=] or [=AbstractInt=] [=integer literal|literal=].<br>
+    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=].<br>
         [=shader-creation error|Must=] be non-negative.
     <td>[=shader-creation error|Must=] only be applied to a [=resource=] variable.
 
@@ -840,7 +840,7 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     built-in functions can be used in [=const-expressions=].
 
   <tr><td><dfn noexport dfn-for="attribute">`group`</dfn>
-    <td>[=shader-creation error|Must=] be an [=i32=] or [=AbstractInt=] [=integer literal|literal=].<br>
+    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=].<br>
         [=shader-creation error|Must=] be non-negative.
     <td>[=shader-creation error|Must=] only be applied to a [=resource=] variable.
 
@@ -848,7 +848,7 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     See [[#resource-interface]].
 
   <tr><td><dfn noexport dfn-for="attribute">`id`</dfn>
-    <td>[=shader-creation error|Must=] be an [=i32=] or [=AbstractInt=] [=integer literal|literal=].<br>
+    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=].<br>
         [=shader-creation error|Must=] be non-negative.
     <td>[=shader-creation error|Must=] only be applied to an [=override-declaration=] of [=scalar=] type.
 
@@ -888,7 +888,7 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     `invariant` qualifier in GLSL.
 
   <tr><td><dfn noexport dfn-for="attribute">`location`</dfn>
-    <td>[=shader-creation error|Must=] be an [=i32=] or [=AbstractInt=] [=integer literal|literal=].<br>
+    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=].<br>
         [=shader-creation error|Must=] be non-negative.
     <td>[=shader-creation error|Must=] only be applied to an entry point function parameter, entry point
     return type, or member of a [=structure=] type.
@@ -900,7 +900,7 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     See [[#input-output-locations]].
 
   <tr><td><dfn noexport dfn-for="attribute">`size`</dfn>
-    <td>[=shader-creation error|Must=] be an [=i32=] or [=AbstractInt=] [=integer literal|literal=].<br>
+    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=].<br>
         [=shader-creation error|Must=] be positive.
     <td>[=shader-creation error|Must=] only be applied to a member of a [=structure=] type.
 
@@ -916,9 +916,8 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
   <tr><td><dfn noexport dfn-for="attribute">`workgroup_size`</dfn>
     <td>One, two or three parameters.
 
-    Each parameter is either a literal, [=module scope|module-scope=]
-    [=const-declaration=], or [=override-declaration=].
-    All parameters [=shader-creation error|must=] be of the same type, either i32 or u32.
+    Each parameter [=shader-creation error|must=] be a a[=const-expression=] or an [=override-expression=].
+    All parameters [=shader-creation error|must=] be the same type, either [=i32=] or [=u32=].
     <td>[=shader-creation error|Must=] be applied to a [=compute shader stage|compute shader=] entry point function.
     [=shader-creation error|Must not=] be applied to any other object.
 
@@ -961,17 +960,17 @@ They take no parameters.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>attribute</dfn> :
 
-    | [=syntax/attr=] `'align'` [=syntax/paren_left=] [=syntax/int_literal=] [=syntax/attrib_end=]
+    | [=syntax/attr=] `'align'` [=syntax/paren_left=] [=syntax/expression=] [=syntax/attrib_end=]
 
-    | [=syntax/attr=] `'binding'` [=syntax/paren_left=] [=syntax/int_literal=] [=syntax/attrib_end=]
+    | [=syntax/attr=] `'binding'` [=syntax/paren_left=] [=syntax/expression=] [=syntax/attrib_end=]
 
     | [=syntax/attr=] `'builtin'` [=syntax/paren_left=] [=syntax/builtin_value_name=] [=syntax/attrib_end=]
 
     | [=syntax/attr=] `'const'`
 
-    | [=syntax/attr=] `'group'` [=syntax/paren_left=] [=syntax/int_literal=] [=syntax/attrib_end=]
+    | [=syntax/attr=] `'group'` [=syntax/paren_left=] [=syntax/expression=] [=syntax/attrib_end=]
 
-    | [=syntax/attr=] `'id'` [=syntax/paren_left=] [=syntax/int_literal=] [=syntax/attrib_end=]
+    | [=syntax/attr=] `'id'` [=syntax/paren_left=] [=syntax/expression=] [=syntax/attrib_end=]
 
     | [=syntax/attr=] `'interpolate'` [=syntax/paren_left=] [=syntax/interpolation_type_name=] [=syntax/attrib_end=]
 
@@ -979,28 +978,21 @@ They take no parameters.
 
     | [=syntax/attr=] `'invariant'`
 
-    | [=syntax/attr=] `'location'` [=syntax/paren_left=] [=syntax/int_literal=] [=syntax/attrib_end=]
+    | [=syntax/attr=] `'location'` [=syntax/paren_left=] [=syntax/expression=] [=syntax/attrib_end=]
 
-    | [=syntax/attr=] `'size'` [=syntax/paren_left=] [=syntax/int_literal=] [=syntax/attrib_end=]
+    | [=syntax/attr=] `'size'` [=syntax/paren_left=] [=syntax/expression=] [=syntax/attrib_end=]
 
-    | [=syntax/attr=] `'workgroup_size'` [=syntax/paren_left=] [=syntax/ident_or_int_literal=] [=syntax/attrib_end=]
+    | [=syntax/attr=] `'workgroup_size'` [=syntax/paren_left=] [=syntax/expression=] [=syntax/attrib_end=]
 
-    | [=syntax/attr=] `'workgroup_size'` [=syntax/paren_left=] [=syntax/ident_or_int_literal=] [=syntax/comma=] [=syntax/ident_or_int_literal=] [=syntax/attrib_end=]
+    | [=syntax/attr=] `'workgroup_size'` [=syntax/paren_left=] [=syntax/expression=] [=syntax/comma=] [=syntax/expression=] [=syntax/attrib_end=]
 
-    | [=syntax/attr=] `'workgroup_size'` [=syntax/paren_left=] [=syntax/ident_or_int_literal=] [=syntax/comma=] [=syntax/ident_or_int_literal=] [=syntax/comma=] [=syntax/ident_or_int_literal=] [=syntax/attrib_end=]
+    | [=syntax/attr=] `'workgroup_size'` [=syntax/paren_left=] [=syntax/expression=] [=syntax/comma=] [=syntax/expression=] [=syntax/comma=] [=syntax/expression=] [=syntax/attrib_end=]
 
     | [=syntax/attr=] `'vertex'`
 
     | [=syntax/attr=] `'fragment'`
 
     | [=syntax/attr=] `'compute'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>ident_or_int_literal</dfn> :
-
-    | [=syntax/int_literal=]
-
-    | [=syntax/ident=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>attrib_end</dfn> :


### PR DESCRIPTION
* Allow attribute parameters to be either const-expressions if only
  literals were allowed previously, or override-expressions if overrides
  were allowed previously
  * only `workgroup_size` allows override-expression
  * align, binding, group, id, location, and size allow const-expression