### PR TITLE
Merge floating-point, integer, matrix and vector built-in functions

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -10961,7 +10961,7 @@ fn arrayLength(p: ptr<storage, array<E>, AM>) -> u32
     <td>Returns the number of elements in the [=runtime-sized=] array.
 </table>
 
-## Float Built-in Functions ## {#float-builtin-functions}
+## Numeric Built-in Functions ## {#numeric-builtin-functions}
 
 ### `abs` ### {#abs-float-builtin}
 <table class='data builtin'>
@@ -10972,11 +10972,16 @@ fn arrayLength(p: ptr<storage, array<E>, AM>) -> u32
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
-    <td>[ALLFLOATINGDECL]
+    <td>[ALLNUMERICDECL]
   <tr>
     <td>Description
-    <td>Returns the absolute value of `e` (e.g. `e` with a positive sign bit).
+    <td>The absolute value of `e`.
     [=Component-wise=] when `T` is a vector.
+
+    If `e` is a floating-point type, then the result is `e` with a positive sign bit.
+    If `e` is an unsigned integral type, then the result is `e`.
+    If `e` is a signed integral scalar type and evaluates to the largest
+    negative value, then the result is `e`.
 </table>
 
 ### `acos` ### {#acos-builtin}
@@ -11136,7 +11141,7 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
-    <td>[ALLFLOATINGDECL]
+    <td>[ALLNUMERICDECL]
   <tr>
     <td>Description
     <td>Returns either `min(max(e, low), high)`, or the median of
@@ -11176,6 +11181,59 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
     [=Component-wise=] when `T` is a vector
 </table>
 
+### `countLeadingZeros` ### {#countLeadingZeros-builtin}
+<table class='data builtin'>
+  <tr algorithm="count leading zeroes">
+    <td style="width:10%">Overload
+    <td class="nowrap"><xmp highlight=rust>
+@const fn countLeadingZeros(e: T) -> T
+</xmp>
+  <tr>
+    <td style="width:10%">Parameterization
+    <td>`T` is [INTEGRAL]
+  <tr>
+    <td>Description
+    <td>The number of consecutive 0 bits starting from the most significant bit
+        of `e`, when `T` is a scalar type.<br>
+        [=Component-wise=] when `T` is a vector.<br>
+        Also known as "clz" in some languages.
+</table>
+
+### `countOneBits` ### {#countOneBits-builtin}
+<table class='data builtin'>
+  <tr algorithm="count 1 bits">
+    <td style="width:10%">Overload
+    <td class="nowrap"><xmp highlight=rust>
+@const fn countOneBits(e: T) -> T
+</xmp>
+  <tr>
+    <td style="width:10%">Parameterization
+    <td>`T` is [INTEGRAL]
+  <tr>
+    <td>Description
+    <td>The number of 1 bits in the representation of `e`.<br>
+        Also known as "population count".<br>
+        [=Component-wise=] when `T` is a vector.
+</table>
+
+### `countTrailingZeros` ### {#countTrailingZeros-builtin}
+<table class='data builtin'>
+  <tr algorithm="count trailing zeroes">
+    <td style="width:10%">Overload
+    <td class="nowrap"><xmp highlight=rust>
+@const fn countTrailingZeros(e: T) -> T
+</xmp>
+  <tr>
+    <td style="width:10%">Parameterization
+    <td>`T` is [INTEGRAL]
+  <tr>
+    <td>Description
+    <td>The number of consecutive 0 bits starting from the least significant bit
+        of `e`, when `T` is a scalar type.<br>
+        [=Component-wise=] when `T` is a vector.<br>
+        Also known as "ctz" in some languages.
+</table>
+
 ### `cross` ### {#cross-builtin}
 <table class='data builtin'>
   <tr algorithm="vector case, cross">
@@ -11208,6 +11266,21 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
     [=Component-wise=] when `T` is a vector
 </table>
 
+### `determinant` ### {#determinant-builtin}
+<table class='data builtin'>
+  <tr algorithm="determinant">
+    <td style="width:10%">Overload
+    <td class="nowrap"><xmp highlight=rust>
+@const fn determinant(e: matCxC<T>) -> T
+</xmp>
+  <tr>
+    <td style="width:10%">Parameterization
+    <td>`T` is AbstractFloat, f32, or f16
+  <tr>
+    <td>Description
+    <td>Returns the determinant of `e`.
+</table>
+
 ### `distance` ### {#distance-builtin}
 <table class='data builtin'>
   <tr algorithm="distance">
@@ -11222,6 +11295,22 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
   <tr>
     <td>Description
     <td>Returns the distance between `e1` and `e2` (e.g. `length(e1 - e2)`).
+</table>
+
+### `dot` ### {#dot-builtin}
+<table class='data builtin'>
+  <tr algorithm="dot">
+    <td style="width:10%">Overload
+    <td class="nowrap"><xmp highlight=rust>
+@const fn dot(e1: vecN<T>,
+              e2: vecN<T>) -> T
+</xmp>
+  <tr>
+    <td style="width:10%">Parameterization
+    <td>`T` is AbstractInt, AbstractFloat, i32, u32, f32, or f16
+  <tr>
+    <td>Description
+    <td>Returns the dot product of `e1` and `e2`.
 </table>
 
 ### `exp` ### {#exp-builtin}
@@ -11256,6 +11345,64 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
     [=Component-wise=] when `T` is a vector.
 </table>
 
+### `extractBits` (signed) ### {#extractBits-signed-builtin}
+<table class='data builtin'>
+  <tr algorithm="signed extract bits">
+    <td style="width:10%">Overload
+    <td class="nowrap"><xmp highlight=rust>
+@const fn extractBits(e: T,
+                      offset: u32,
+                      count: u32) -> T
+</xmp>
+  <tr>
+    <td style="width:10%">Parameterization
+    <td>`T` is [SIGNEDINTEGRAL]
+  <tr>
+    <td>Description
+    <td>Reads bits from an integer, with sign extension.
+
+    When `T` is a scalar type, then:
+    <ul>
+    <li>`w` is the bit width of `T`
+    <li>`o = min(offset, w)`
+    <li>`c = min(count, w - o)`
+    <li>The result is 0 if `c` is 0.
+    <li>Otherwise, bits `0..c - 1` of the result are copied from bits
+       `o..o + c - 1` of `e`.
+       Other bits of the result are the same as bit `c - 1` of the result.
+    </ul>
+    [=Component-wise=] when `T` is a vector.
+</table>
+
+### `extractBits` (unsigned) ### {#extractBits-unsigned-builtin}
+<table class='data builtin'>
+  <tr algorithm="unsigned extract bits">
+    <td style="width:10%">Overload
+    <td class="nowrap"><xmp highlight=rust>
+@const fn extractBits(e: T,
+                      offset: u32,
+                      count: u32) -> T
+</xmp>
+  <tr>
+    <td style="width:10%">Parameterization
+    <td>`T` is [UNSIGNEDINTEGRAL]
+  <tr>
+    <td>Description
+    <td>Reads bits from an integer, without sign extension.
+
+    When `T` is a scalar type, then:
+    <ul>
+    <li>`w` is the bit width of `T`
+    <li>`o = min(offset, w)`
+    <li>`c = min(count, w - o)`
+    <li>The result is 0 if `c` is 0.
+    <li>Otherwise, bits `0..c - 1` of the result are copied from bits
+       `o..o + c - 1` of `e`.
+       Other bits of the result are 0.
+    </ul>
+    [=Component-wise=] when `T` is a vector.
+</table>
+
 ### `faceForward` ### {#faceForward-builtin}
 <table class='data builtin'>
   <tr algorithm="faceForward">
@@ -11271,6 +11418,77 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
   <tr>
     <td>Description
     <td>Returns `e1` if `dot(e2, e3)` is negative, and `-e1` otherwise.
+</table>
+
+### `firstLeadingBit` (signed) ### {#firstLeadingBit-signed-builtin}
+<table class='data builtin'>
+  <tr algorithm="signed find most significant one bit">
+    <td style="width:10%">Overload
+    <td class="nowrap"><xmp highlight=rust>
+@const fn firstLeadingBit(e: T) -> T
+</xmp>
+  <tr>
+    <td style="width:10%">Parameterization
+    <td>`T` is [SIGNEDINTEGRAL]
+  <tr>
+    <td>Description
+    <td>For scalar `T`, the result is:
+        <ul>
+        <li>-1 if `e` is 0 or -1.
+        <li>Otherwise the position of the most significant bit in
+            `e` that is different from `e`'s sign bit.
+        </ul>
+
+        [=Component-wise=] when `T` is a vector.
+  <tr>
+    <td>
+    <td>
+
+Note: Since signed integers use twos-complement representation,
+the sign bit appears in the most significant bit position.
+
+</table>
+
+### `firstLeadingBit` (unsigned) ### {#firstLeadingBit-unsigned-builtin}
+<table class='data builtin'>
+  <tr algorithm="unsigned find most significant one bit">
+    <td style="width:10%">Overload
+    <td class="nowrap"><xmp highlight=rust>
+@const fn firstLeadingBit(e: T) -> T
+</xmp>
+  <tr>
+    <td style="width:10%">Parameterization
+    <td>`T` is [UNSIGNEDINTEGRAL]
+  <tr>
+    <td>Description
+    <td>For scalar `T`, the result is:
+        <ul>
+        <li>`T(-1)` if `e` is zero.
+        <li>Otherwise the position of the most significant 1
+            bit in `e`.
+        </ul>
+        [=Component-wise=] when `T` is a vector.
+</table>
+
+### `firstTrailingBit` ### {#firstTrailingBit-builtin}
+<table class='data builtin'>
+  <tr algorithm="find least significant one bit">
+    <td style="width:10%">Overload
+    <td class="nowrap"><xmp highlight=rust>
+@const fn firstTrailingBit(e: T) -> T
+</xmp>
+  <tr>
+    <td style="width:10%">Parameterization
+    <td>`T` is [INTEGRAL]
+  <tr>
+    <td>Description
+    <td>For scalar `T`, the result is:
+        <ul>
+        <li>`T(-1)` if `e` is zero.
+        <li>Otherwise the position of the least significant 1
+            bit in `e`.
+        </ul>
+        [=Component-wise=] when `T` is a vector.
 </table>
 
 ### `floor` ### {#floor-builtin}
@@ -11462,6 +11680,36 @@ but a value may infer the type.
 
 </table>
 
+### `insertBits` ### {#insertBits-builtin}
+<table class='data builtin'>
+  <tr algorithm="insert bits">
+    <td style="width:10%">Overload
+    <td class="nowrap"><xmp highlight=rust>
+@const fn insertBits(e: T,
+                     newbits: T,
+                     offset: u32,
+                     count: u32) -> T
+</xmp>
+  <tr>
+    <td style="width:10%">Parameterization
+    <td>`T` is [INTEGRAL]
+  <tr>
+    <td>Description
+    <td>Sets bits in an integer.
+
+    When `T` is a scalar type, then:
+    <ul>
+    <li>`w` is the bit width of `T`
+    <li>`o = min(offset, w)`
+    <li>`c = min(count, w - o)`
+    <li>The result is `e` if `c` is 0.
+    <li>Otherwise,
+       bits `o..o + c - 1` of the result are copied from bits `0..c - 1` of `newbits`.
+       Other bits of the result are copied from `e`.
+    </ul>
+    [=Component-wise=] when `T` is a vector.
+</table>
+
 ### `inverseSqrt` ### {#inverseSqrt-builtin}
 <table class='data builtin'>
   <tr algorithm="inverseSqrt">
@@ -11557,13 +11805,15 @@ but a value may infer the type.
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
-    <td>[ALLFLOATINGDECL]
+    <td>[ALLNUMERICDECL]
   <tr>
     <td>Description
     <td>Returns `e2` if `e1` is less than `e2`, and `e1` otherwise.
-    If one operand is a NaN, the other is returned.
-    If both operands are NaNs, a NaN is returned.
     [=Component-wise=] when `T` is a vector.
+
+    If `e1` and `e2` are floating-point types, then:
+    * If one operand is a NaN, the other is returned.
+    * If both operands are NaNs, a NaN is returned.
 </table>
 
 ### `min` ### {#min-float-builtin}
@@ -11576,13 +11826,15 @@ but a value may infer the type.
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
-    <td>[ALLFLOATINGDECL]
+    <td>[ALLNUMERICDECL]
   <tr>
     <td>Description
     <td>Returns `e2` if `e2` is less than `e1`, and `e1` otherwise.
-    If one operand is a NaN, the other is returned.
-    If both operands are NaNs, a NaN is returned.
     [=Component-wise=] when `T` is a vector.
+
+    If `e1` and `e2` are floating-point types, then:
+    * If one operand is a NaN, the other is returned.
+    * If both operands are NaNs, a NaN is returned.
 </table>
 
 ### `mix` ### {#mix-builtin}
@@ -11872,6 +12124,23 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
     `e3 * e1 - (e3 * dot(e2, e1) + sqrt(k)) * e2`.
 </table>
 
+### `reverseBits` ### {#reverseBits-builtin}
+<table class='data builtin'>
+  <tr algorithm="bit reversal">
+    <td style="width:10%">Overload
+    <td class="nowrap"><xmp highlight=rust>
+@const fn reverseBits(e: T) -> T
+</xmp>
+  <tr>
+    <td style="width:10%">Parameterization
+    <td>`T` is [INTEGRAL]
+  <tr>
+    <td>Description
+    <td>Reverses the bits in `e`:  The bit at position `k` of the result equals the
+        bit at position `31 -k` of `e`.<br>
+        [=Component-wise=] when `T` is a vector.
+</table>
+
 ### `round` ### {#round-builtin}
 <table class='data builtin'>
   <tr algorithm="round">
@@ -12041,342 +12310,6 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
     [=Component-wise=] when `T` is a vector.
 </table>
 
-### `trunc` ### {#trunc-builtin}
-<table class='data builtin'>
-  <tr algorithm="trunc">
-        <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const fn trunc(e: T) -> T
-</xmp>
-  <tr>
-    <td style="width:10%">Parameterization
-    <td>[ALLFLOATINGDECL]
-  <tr>
-    <td>Description
-    <td>Returns [=truncate=](`e`), the nearest whole number whose absolute value
-    is less than or equal to `e`.
-    [=Component-wise=] when `T` is a vector.
-</table>
-
-## Integer Built-in Functions ## {#integer-builtin-functions}
-
-### `abs` ### {#abs-builtin}
-<table class='data builtin'>
-  <tr algorithm="integral abs">
-    <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const fn abs(e: T) -> T
-</xmp>
-  <tr>
-    <td style="width:10%">Parameterization
-    <td>[ALLINTEGRALDECL]
-  <tr>
-    <td>Description
-    <td>The absolute value of `e`.
-        [=Component-wise=] when `T` is a vector.
-        If `e` is a signed integral scalar type and evaluates to the largest negative
-        value, then the result is `e`.
-        If `e` is an unsigned integral type, then the result is `e`.
-</table>
-
-### `clamp` ### {#clamp-integral-builtin}
-<table class='data builtin'>
-  <tr algorithm="integral clamp">
-    <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const fn clamp(e: T,
-                low: T,
-                high: T) -> T
-</xmp>
-  <tr>
-    <td style="width:10%">Parameterization
-    <td>[ALLINTEGRALDECL]
-  <tr>
-    <td>Description
-    <td>Returns `min(max(e, low), high)`.
-    [=Component-wise=] when `T` is a vector.
-</table>
-
-### `countLeadingZeros` ### {#countLeadingZeros-builtin}
-<table class='data builtin'>
-  <tr algorithm="count leading zeroes">
-    <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const fn countLeadingZeros(e: T) -> T
-</xmp>
-  <tr>
-    <td style="width:10%">Parameterization
-    <td>`T` is [INTEGRAL]
-  <tr>
-    <td>Description
-    <td>The number of consecutive 0 bits starting from the most significant bit
-        of `e`, when `T` is a scalar type.<br>
-        [=Component-wise=] when `T` is a vector.<br>
-        Also known as "clz" in some languages.
-</table>
-
-### `countOneBits` ### {#countOneBits-builtin}
-<table class='data builtin'>
-  <tr algorithm="count 1 bits">
-    <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const fn countOneBits(e: T) -> T
-</xmp>
-  <tr>
-    <td style="width:10%">Parameterization
-    <td>`T` is [INTEGRAL]
-  <tr>
-    <td>Description
-    <td>The number of 1 bits in the representation of `e`.<br>
-        Also known as "population count".<br>
-        [=Component-wise=] when `T` is a vector.
-</table>
-
-### `countTrailingZeros` ### {#countTrailingZeros-builtin}
-<table class='data builtin'>
-  <tr algorithm="count trailing zeroes">
-    <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const fn countTrailingZeros(e: T) -> T
-</xmp>
-  <tr>
-    <td style="width:10%">Parameterization
-    <td>`T` is [INTEGRAL]
-  <tr>
-    <td>Description
-    <td>The number of consecutive 0 bits starting from the least significant bit
-        of `e`, when `T` is a scalar type.<br>
-        [=Component-wise=] when `T` is a vector.<br>
-        Also known as "ctz" in some languages.
-</table>
-
-### `extractBits` (signed) ### {#extractBits-signed-builtin}
-<table class='data builtin'>
-  <tr algorithm="signed extract bits">
-    <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const fn extractBits(e: T,
-                      offset: u32,
-                      count: u32) -> T
-</xmp>
-  <tr>
-    <td style="width:10%">Parameterization
-    <td>`T` is [SIGNEDINTEGRAL]
-  <tr>
-    <td>Description
-    <td>Reads bits from an integer, with sign extension.
-
-    When `T` is a scalar type, then:
-    <ul>
-    <li>`w` is the bit width of `T`
-    <li>`o = min(offset, w)`
-    <li>`c = min(count, w - o)`
-    <li>The result is 0 if `c` is 0.
-    <li>Otherwise, bits `0..c - 1` of the result are copied from bits
-       `o..o + c - 1` of `e`.
-       Other bits of the result are the same as bit `c - 1` of the result.
-    </ul>
-    [=Component-wise=] when `T` is a vector.
-</table>
-
-### `extractBits` (unsigned) ### {#extractBits-unsigned-builtin}
-<table class='data builtin'>
-  <tr algorithm="unsigned extract bits">
-    <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const fn extractBits(e: T,
-                      offset: u32,
-                      count: u32) -> T
-</xmp>
-  <tr>
-    <td style="width:10%">Parameterization
-    <td>`T` is [UNSIGNEDINTEGRAL]
-  <tr>
-    <td>Description
-    <td>Reads bits from an integer, without sign extension.
-
-    When `T` is a scalar type, then:
-    <ul>
-    <li>`w` is the bit width of `T`
-    <li>`o = min(offset, w)`
-    <li>`c = min(count, w - o)`
-    <li>The result is 0 if `c` is 0.
-    <li>Otherwise, bits `0..c - 1` of the result are copied from bits
-       `o..o + c - 1` of `e`.
-       Other bits of the result are 0.
-    </ul>
-    [=Component-wise=] when `T` is a vector.
-</table>
-
-### `firstLeadingBit` (signed) ### {#firstLeadingBit-signed-builtin}
-<table class='data builtin'>
-  <tr algorithm="signed find most significant one bit">
-    <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const fn firstLeadingBit(e: T) -> T
-</xmp>
-  <tr>
-    <td style="width:10%">Parameterization
-    <td>`T` is [SIGNEDINTEGRAL]
-  <tr>
-    <td>Description
-    <td>For scalar `T`, the result is:
-        <ul>
-        <li>-1 if `e` is 0 or -1.
-        <li>Otherwise the position of the most significant bit in
-            `e` that is different from `e`'s sign bit.
-        </ul>
-
-        [=Component-wise=] when `T` is a vector.
-  <tr>
-    <td>
-    <td>
-
-Note: Since signed integers use twos-complement representation,
-the sign bit appears in the most significant bit position.
-
-</table>
-
-### `firstLeadingBit` (unsigned) ### {#firstLeadingBit-unsigned-builtin}
-<table class='data builtin'>
-  <tr algorithm="unsigned find most significant one bit">
-    <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const fn firstLeadingBit(e: T) -> T
-</xmp>
-  <tr>
-    <td style="width:10%">Parameterization
-    <td>`T` is [UNSIGNEDINTEGRAL]
-  <tr>
-    <td>Description
-    <td>For scalar `T`, the result is:
-        <ul>
-        <li>`T(-1)` if `e` is zero.
-        <li>Otherwise the position of the most significant 1
-            bit in `e`.
-        </ul>
-        [=Component-wise=] when `T` is a vector.
-</table>
-
-### `firstTrailingBit` ### {#firstTrailingBit-builtin}
-<table class='data builtin'>
-  <tr algorithm="find least significant one bit">
-    <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const fn firstTrailingBit(e: T) -> T
-</xmp>
-  <tr>
-    <td style="width:10%">Parameterization
-    <td>`T` is [INTEGRAL]
-  <tr>
-    <td>Description
-    <td>For scalar `T`, the result is:
-        <ul>
-        <li>`T(-1)` if `e` is zero.
-        <li>Otherwise the position of the least significant 1
-            bit in `e`.
-        </ul>
-        [=Component-wise=] when `T` is a vector.
-</table>
-
-### `insertBits` ### {#insertBits-builtin}
-<table class='data builtin'>
-  <tr algorithm="insert bits">
-    <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const fn insertBits(e: T,
-                     newbits: T,
-                     offset: u32,
-                     count: u32) -> T
-</xmp>
-  <tr>
-    <td style="width:10%">Parameterization
-    <td>`T` is [INTEGRAL]
-  <tr>
-    <td>Description
-    <td>Sets bits in an integer.
-
-    When `T` is a scalar type, then:
-    <ul>
-    <li>`w` is the bit width of `T`
-    <li>`o = min(offset, w)`
-    <li>`c = min(count, w - o)`
-    <li>The result is `e` if `c` is 0.
-    <li>Otherwise,
-       bits `o..o + c - 1` of the result are copied from bits `0..c - 1` of `newbits`.
-       Other bits of the result are copied from `e`.
-    </ul>
-    [=Component-wise=] when `T` is a vector.
-</table>
-
-### `max` ### {#max-integral-builtin}
-<table class='data builtin'>
-  <tr algorithm="integral max">
-    <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const fn max(e1: T,
-              e2: T) -> T
-</xmp>
-  <tr>
-    <td style="width:10%">Parameterization
-    <td>[ALLINTEGRALDECL]
-  <tr>
-    <td>Description
-    <td>Returns `e2` if `e1` is less than `e2`, and `e1` otherwise.
-    [=Component-wise=] when `T` is a vector.
-</table>
-
-### `min` ### {#min-integral-builtin}
-<table class='data builtin'>
-  <tr algorithm="integral min">
-    <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const fn min(e1: T,
-              e2: T) -> T
-</xmp>
-  <tr>
-    <td style="width:10%">Parameterization
-    <td>[ALLINTEGRALDECL]
-  <tr>
-    <td>Description
-    <td>Returns `e1` if `e1` is less than `e2`, and `e2` otherwise.
-    [=Component-wise=] when `T` is a vector.
-</table>
-
-### `reverseBits` ### {#reverseBits-builtin}
-<table class='data builtin'>
-  <tr algorithm="bit reversal">
-    <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const fn reverseBits(e: T) -> T
-</xmp>
-  <tr>
-    <td style="width:10%">Parameterization
-    <td>`T` is [INTEGRAL]
-  <tr>
-    <td>Description
-    <td>Reverses the bits in `e`:  The bit at position `k` of the result equals the
-        bit at position `31 -k` of `e`.<br>
-        [=Component-wise=] when `T` is a vector.
-</table>
-
-## Matrix Built-in Functions ## {#matrix-builtin-functions}
-
-### `determinant` ### {#determinant-builtin}
-<table class='data builtin'>
-  <tr algorithm="determinant">
-    <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>
-@const fn determinant(e: matCxC<T>) -> T
-</xmp>
-  <tr>
-    <td style="width:10%">Parameterization
-    <td>`T` is AbstractFloat, f32, or f16
-  <tr>
-    <td>Description
-    <td>Returns the determinant of `e`.
-</table>
-
 ### `transpose` ### {#transpose-builtin}
 <table class='data builtin'>
   <tr algorithm="transpose">
@@ -12392,22 +12325,21 @@ the sign bit appears in the most significant bit position.
     <td>Returns the transpose of `e`.
 </table>
 
-## Vector Built-in Functions ## {#vector-builtin-functions}
-
-### `dot` ### {#dot-builtin}
+### `trunc` ### {#trunc-builtin}
 <table class='data builtin'>
-  <tr algorithm="dot">
-    <td style="width:10%">Overload
+  <tr algorithm="trunc">
+        <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn dot(e1: vecN<T>,
-              e2: vecN<T>) -> T
+@const fn trunc(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
-    <td>`T` is AbstractInt, AbstractFloat, i32, u32, f32, or f16
+    <td>[ALLFLOATINGDECL]
   <tr>
     <td>Description
-    <td>Returns the dot product of `e1` and `e2`.
+    <td>Returns [=truncate=](`e`), the nearest whole number whose absolute value
+    is less than or equal to `e`.
+    [=Component-wise=] when `T` is a vector.
 </table>
 
 ## Derivative Built-in Functions ## {#derivative-builtin-functions}


### PR DESCRIPTION
* Rename single section to Numeric Built-in Functions
  * de-duplicate entries where appropriate (e.g. clamp, min, max)