### PR TITLE
Clean up description of entry point IO

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8104,7 +8104,7 @@ For example, a four-component vector of floating-point values occupies a single 
 
 IO locations are specified via the [=attribute/location=] attribute.
 
-Each [=user-defined input datum|user-defined input=] and [=user-defined output datum|output=] [=shader-creation error|must=] have an explicitly specified IO location.
+Each user-defined [=user-defined input datum|input=] and [=user-defined output datum|output=] [=shader-creation error|must=] have an explicitly specified IO location.
 Each structure member in the entry point IO [=shader-creation error|must=] be one of either a built-in value
 (see [[#builtin-inputs-outputs]]), or assigned a location.
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2216,28 +2216,6 @@ A type is <dfn noexport>storable</dfn> if it is both [=type/concrete=] and one o
 
 Note: That is, the storable types are the [=type/concrete=] [=plain types=], texture types, and sampler types.
 
-### IO-shareable Types ### {#io-shareable-types}
-
-[[#user-defined-inputs-outputs|User-defined pipeline input and output values]]
-[=shader-creation error|must=] be of IO-shareable type.
-
-A type is <dfn noexport>IO-shareable</dfn> if it is both [=type/concrete=] and one of:
-
-* a [=numeric scalar=] type
-* a [=numeric vector=] type
-* a [=structure=] type, if all its members are [=numeric scalars=] or [=numeric vectors=]
-
-The following kinds of values [=shader-creation error|must=] be of IO-shareable type:
-
-* Values accepted as user-defined inputs from an upstream pipeline stage.
-* Values written as user-defined output for downstream processing in the pipeline, or to an output attachment.
-
-Note: Only user-defined pipeline input and output values must be
-IO-shareable. Built-in pipeline inputs and outputs have the types specified in
-[[#builtin-values]], which are not necessarily in this category. For example, the
-[=built-in values/front_facing=] [=built-in input value|built-in input=] for
-fragment shaders has type `bool`, which is not IO-shareable.
-
 ### Host-shareable Types ### {#host-shareable-types}
 
 Host-shareable types are used to describe the contents of buffers which are shared between
@@ -7138,7 +7116,7 @@ Note: If the function [=return value|returns a value=], that value is ignored.
 A static assertion statement produces a [=shader-creation error=] if the
 expression evaluates to `false`.
 The expression [=shader-creation error|must=] be a [=const-expression=].
-The statement can satisfy [=statically accessed|static access=] requirements in
+The statement can satisfy [=statically accessed|static access=] conditions in
 a shader, but otherwise has no effect on the compiled shader.
 This statement can be used at [=module scope=] and within [=function scope|functions=].
 
@@ -7928,9 +7906,20 @@ When configuring a [=pipeline=] in the WebGPU API,
 the entry point's function name maps to the `entryPoint` attribute of the
 [[WebGPU#GPUProgrammableStage]] object.
 
-The entry point's [=formal parameters=] form the stage's [=pipeline inputs=].
-The entry point's [=return type=], if specified, forms the stage's [=pipeline output=].
-Each input and output [=shader-creation error|must=] be an [=entry point IO type=].
+The entry point's [=formal parameters=] denote the stage's [=pipeline inputs=].
+The entry point's [=return value=], if specified, denotes the stage's [=pipeline outputs=].
+
+The the type of each formal parameter, and the entry point's return type, [=shader-creation error|must=] be one of:
+* [=bool=]
+* a [=numeric scalar=]
+* a [=numeric vector=]
+* a [=structure=] whose member types are any of [=bool=], [=numeric scalar=], or [=numeric vector=].
+
+Use a formal parameter type of structure type to group [=user-defined input datum|user-defined inputs=] with each other and optionally with [=built-in input value|built-in inputs=].
+Use a structure as a [=return type=] to group [=user-defined output datum|user-defined outputs=] with each other and optionally with [=built-in output value|built-in outputs=].
+
+Note: The [=bool=] case is forbidden for user-defined inputs and outputs.
+It is only permitted for the [=built-in values|front_facing builtin value=].
 
 Note: [=Compute=] entry points never have a return type.
 
@@ -7995,44 +7984,36 @@ through which the shader accesses data external to the [=shader stage=],
 either for reading or writing.
 The interface includes:
 
-* Pipeline inputs and outputs
+* [=Pipeline inputs=]
+* [=Pipeline outputs=]
 * Buffer resources
 * Texture resources
 * Sampler resources
+* [=Override-declarations=]
 
-These objects are represented by module-scope variables in certain [=address spaces=].
-
-When an [=identifier=] used in a [=function declaration=] [=resolves=] to a [=module scope|module-scope=] variable,
-then we say the variable is <dfn>statically accessed</dfn> by the function.
-Static access of a `let`-declared constant is defined similarly.
+When an [=identifier=] used in a [=function body=] [=resolves=] to a [=module scope|module-scope=] [[#var-and-value|variable or value declaration]],
+then we say that variable or value is <dfn>statically accessed</dfn> by the function.
 Note that being statically accessed is independent of whether an execution of the shader
 will actually evaluate the expression referring to the variable,
 or even execute the statement that may enclose the expression.
 
 More precisely, the <dfn noexport>interface of a shader stage</dfn> consists of:
-  - all parameters of the entry point
-  - the result value of the entry point
-  - all [=module scope=] variables that are [=statically accessed=] by [=functions in a shader stage|functions in the shader stage=],
-    and which are in address spaces [=address spaces/uniform=], [=address spaces/storage=], or [=address spaces/handle=].
+  - All [=formal parameters=] of the [=entry point=].
+     These denote the pipeline inputs.
+  - The [=return value=] of the entry point.
+     This denotes the pipeline outputs.
+  - All [=override-declarations=].
+  - All [=module scope=] variables that are [=statically accessed=] by [=functions in a shader stage|functions in the shader stage=], and which are in
+        [=address spaces/uniform=], [=address spaces/storage=], or [=address spaces/handle=] address spaces.
+        These are the buffer, texture, and sampler resources.
 
 ### Pipeline Input and Output Interface ### {#pipeline-inputs-outputs}
 
-The <dfn dfn>entry point IO type</dfn>s include the following:
-  - Built-in values. See [[#builtin-inputs-outputs]].
-  - User-defined IO. See [[#user-defined-inputs-outputs]]
-  - Structures containing only built-in values and user-defined IO.
-    The structure [=shader-creation error|must not=] contain a nested structure.
+A <dfn noexport>pipeline input</dfn> is a datum provided to the shader stage from upstream in the pipeline.
+Each datum is either a [=built-in input value=], or a [=user-defined input datum|user-defined input=].
 
-A <dfn noexport>pipeline input</dfn> is data provided to the shader stage from upstream in the pipeline.
-A pipeline input is denoted by the arguments of the entry point.
-
-A <dfn noexport>pipeline output</dfn> is data the shader provides for further processing downstream in the pipeline.
-A pipeline output is denoted by the return type of the entry point.
-
-Each pipeline input or output is one of:
-
-* A built-in value. See [[#builtin-inputs-outputs]].
-* A user-defined value. See [[#user-defined-inputs-outputs]].
+A <dfn noexport>pipeline output</dfn> is a datum the shader provides for further processing downstream in the pipeline.
+Each datum is either a [=built-in output value=], or a [=user-defined output datum|user-defined output=].
 
 #### Built-in Inputs and Outputs #### {#builtin-inputs-outputs}
 
@@ -8069,9 +8050,14 @@ Collectively, built-in input and built-in output values are known as <dfn noexpo
 
 User-defined data can be passed as input to the start of a pipeline, passed
 between stages of a pipeline or output from the end of a pipeline.
-User-defined IO [=shader-creation error|must not=] be passed to [=compute=] shader entry points.
-User-defined IO [=shader-creation error|must=] be of [=IO-shareable=] type.
-All user-defined IO [=shader-creation error|must=] be assigned locations (See [[#input-output-locations]]).
+
+Each <dfn noexport>user-defined input datum</dfn> and
+<dfn noexport>user-defined output datum</abbrev></dfn> [=shader-creation error|must=]:
+* be of [=numeric scalar=] type or [=numeric vector=] type.
+* be assigned an IO location. See [[#input-output-locations]].
+
+
+A [=compute=] shader [=shader-creation error|must not=] have user-defined inputs or outputs.
 
 #### Interpolation #### {#interpolation}
 
@@ -8112,14 +8098,13 @@ inputs with the same [=attribute/location=] assignment within the same [=pipelin
 
 #### Input-output Locations #### {#input-output-locations}
 
-Each location can store a value up to 16 bytes in size.
+Each input-output location can store a value up to 16 bytes in size.
 The byte size of a type is defined using the *SizeOf* column in [[#alignment-and-size]].
 For example, a four-component vector of floating-point values occupies a single location.
 
-Locations are specified via the [=attribute/location=] attribute.
+IO locations are specified via the [=attribute/location=] attribute.
 
-Every user-defined input and output [=shader-creation error|must=] have a fully specified set of
-locations.
+Each [=user-defined input datum|user-defined input=] and [=user-defined output datum|output=] [=shader-creation error|must=] have an explicitly specified IO location.
 Each structure member in the entry point IO [=shader-creation error|must=] be one of either a built-in value
 (see [[#builtin-inputs-outputs]]), or assigned a location.
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7916,7 +7916,7 @@ The type of each formal parameter, and the entry point's return type, [=shader-c
 * a [=structure=] whose member types are any of [=bool=], [=numeric scalar=], or [=numeric vector=].
 
 A structure type can be used to group [=user-defined input datum|user-defined inputs=] with each other and optionally with [=built-in input value|built-in inputs=].
-Use a structure as a [=return type=] to group [=user-defined output datum|user-defined outputs=] with each other and optionally with [=built-in output value|built-in outputs=].
+A structure type can be used as the [=return type=] to group [=user-defined output datum|user-defined outputs=] with each other and optionally with [=built-in output value|built-in outputs=].
 
 Note: The [=bool=] case is forbidden for user-defined inputs and outputs.
 It is only permitted for the [=built-in values|front_facing builtin value=].

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7915,7 +7915,7 @@ The type of each formal parameter, and the entry point's return type, [=shader-c
 * a [=numeric vector=]
 * a [=structure=] whose member types are any of [=bool=], [=numeric scalar=], or [=numeric vector=].
 
-Use a formal parameter type of structure type to group [=user-defined input datum|user-defined inputs=] with each other and optionally with [=built-in input value|built-in inputs=].
+A structure type can be used to group [=user-defined input datum|user-defined inputs=] with each other and optionally with [=built-in input value|built-in inputs=].
 Use a structure as a [=return type=] to group [=user-defined output datum|user-defined outputs=] with each other and optionally with [=built-in output value|built-in outputs=].
 
 Note: The [=bool=] case is forbidden for user-defined inputs and outputs.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7909,7 +7909,7 @@ the entry point's function name maps to the `entryPoint` attribute of the
 The entry point's [=formal parameters=] denote the stage's [=pipeline inputs=].
 The entry point's [=return value=], if specified, denotes the stage's [=pipeline outputs=].
 
-The the type of each formal parameter, and the entry point's return type, [=shader-creation error|must=] be one of:
+The type of each formal parameter, and the entry point's return type, [=shader-creation error|must=] be one of:
 * [=bool=]
 * a [=numeric scalar=]
 * a [=numeric vector=]

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2201,7 +2201,7 @@ In particular, the token does not [=resolve=] to any declared object.
 The value contained in a [=variable=] [=shader-creation error|must=] be of a [=storable=] type.
 A storable type may have an explicit representation defined by WGSL,
 as described in [[#internal-value-layout]],
-or it may be opaque, such as for textures and samplers.
+or it may be opaque, such as for [=texture resource|textures=] and [=sampler resource|samplers=].
 
 A type is <dfn noexport>storable</dfn> if it is both [=type/concrete=] and one of:
 
@@ -2278,19 +2278,13 @@ See [[#var-and-value]] for more details.
       <td>For [=storage buffer=] variables
   <tr><td><dfn noexport dfn-for="address spaces">handle</dfn>
       <td>Invocations in the same shader stage
-      <td>For [=sampler=] and texture variables.<br>
+      <td>For [=sampler resource|sampler=] and [=texture resource|texture=] variables.<br>
 </table>
 
 When a [=token=] matches the [=syntax/address_space=] grammar nonterminal, it is considered a [=context-dependent name=].
 In particular, the token does not [=resolve=] to any declared object.
 
 Note: The token `handle` is reserved: it is never used in a WGSL program.
-
-Note: A texture variable holds an opaque handle which is used to access the underlying
-grid of texels.
-The handle itself is always read-only.
-In most cases the underlying texels are read-only.
-For a write-only storage texture, the underlying texels are write-only.
 
 ### Memory Layout ### {#memory-layouts}
 
@@ -3270,7 +3264,7 @@ Note: From the above rules, it is not possible to form a "dangling" pointer,
 i.e. a pointer that does not reference the memory for a valid (or "live")
 originating variable.
 
-## Texture and Sampler Types ## {#texture-types}
+## Texture and Sampler Types ## {#texture-sampler-types}
 
 A <dfn noexport>texel</dfn> is a scalar or vector used as the smallest independently accessible element of a [=texture=].
 The word *texel* is short for *texture element*.
@@ -3317,7 +3311,7 @@ A texture's representation is typically optimized for rendering operations.
 To achieve this, many details are hidden from the programmer, including data layouts, data types, and
 internal operations that cannot be expressed directly in the shader language.
 
-As a consequence, a shader does not have direct access to the texel memory within a texture variable.
+As a consequence, a shader does not have direct access to the texel memory within a [=texture resource|texture variable=].
 Instead, access is mediated through an opaque handle:
 
 * Within the shader:
@@ -3339,7 +3333,13 @@ Note: The handle stored by a texture variable cannot be changed by the shader.
 That is, the variable is read-only, even if the underlying texture to which it provides
 access may be mutable (e.g. a write-only storage texture).
 
-A sampler is an opaque handle that controls how [=texel|texels=] are accessed
+The <dfn>texture types</dfn> are the set of types defined in:
+* [[#sampled-texture-type]]
+* [[#multisampled-texture-type]]
+* [[#external-texture-type]]
+* [[#texture-depth]]
+
+A [=sampler=] is an opaque handle that controls how [=texel|texels=] are accessed
 from a sampled texture.
 
 A WGSL sampler maps to a [[WebGPU#gpusampler|WebGPU GPUSampler]].
@@ -3543,15 +3543,19 @@ A <dfn>sampler</dfn> mediates access to a sampled texture or a depth texture, by
 * for a sampled texture, optionally filtering retrieved texel values.
 * for a depth texture, determining the comparison function applied to the retrieved texel.
 
+A <dfn noexport>sampler types</dfn> are:
+* [=type/sampler=]
+* [=type/sampler_comparison=]
+
 <table class='data'>
   <thead>
     <tr><th>Type<th>Description
   </thead>
   <tr algorithm="sampler type">
-    <td>sampler
+    <td><dfn dfn-for="type">sampler</dfn>
     <td>Sampler. Mediates access to a sampled texture.</td>
   <tr algorithm="comparison sampler type">
-    <td>sampler_comparison
+    <td><dfn dfn-for="type">sampler_comparison</dfn>
     <td>Comparison sampler.
         Mediates access to a depth texture.</td>
 </table>
@@ -3842,7 +3846,7 @@ effective-value-type.
     <td>[=type/concrete|Concrete=] [=host-shareable=]
     <td>Disallowed
     <td>
-    <td>Yes
+    <td>Yes.<br>[=storage buffer=]
 
 <tr><td class="nowrap">
         [=variable|var=]&lt;[=address spaces/storage=], read_write&gt;<sup>5</sup>
@@ -3851,7 +3855,7 @@ effective-value-type.
     <td>[=type/concrete|Concrete=] [=host-shareable=]
     <td>Disallowed
     <td>
-    <td>Yes
+    <td>Yes.<br>[=storage buffer=]
 
 <tr><td>[=variable|var=]&lt;[=address spaces/uniform=]&gt;
     <td>Immutable
@@ -3859,23 +3863,23 @@ effective-value-type.
     <td>[=type/concrete|Concrete=] [=constructible=] [=host-shareable=]
     <td>Disallowed
     <td>
-    <td>Yes
+    <td>Yes.<br>[=uniform buffer=]
 
 <tr><td>[=variable|var=]
     <td>Immutable<sup>6</sup>
     <td>[=module scope|Module=]
-    <td>[[#texture-types|Texture]]
+    <td>[=texture type|Texture=]
     <td>Disallowed
     <td>
-    <td>Yes
+    <td>Yes.<br>[=texture resource=]
 
 <tr><td>[=variable|var=]
     <td>Immutable
     <td>[=module scope|Module=]
-    <td>[[#texture-types|Sampler]]
+    <td>[=sampler type|Sampler=]
     <td>Disallowed
     <td>
-    <td>Yes
+    <td>Yes.<br>[=sampler resource=]
 
 <tr><td>[=variable|var=]&lt;[=address spaces/workgroup=]&gt;<sup>5</sup>
     <td>Mutable
@@ -4126,6 +4130,17 @@ Its [=store type=] must be a [=host-shareable=] type and must satisfy the
 [[#address-space-layout-constraints|address space layout constraints]].
 The variable may be declared with a [=access/read=] or [=access/read_write=]
 access mode; the default is read.
+
+A <dfn>texture resource</dfn> is a variable whose [=effective-value-type=] is a [=texture type=].
+It is declared at [=module scope=].
+It holds an opaque handle which is used to access the underlying grid of [=texels=] in a [=texture=].
+The handle itself is in the [=address spaces/handle=] address space and is is always read-only.
+In many cases the underlying texels are read-only.
+For a write-only [=storage texture=], the underlying texels are write-only.
+
+A <dfn>sampler resource</dfn> is a variable whose [=effective-value-type=] is a [=sampler type=].
+It is declared at [=module scope=], exists in the [=address spaces/handle=] address space,
+and is immutable.
 
 As described in [[#resource-interface]], uniform buffers, storage buffers,
 textures, and samplers form the [=resource interface of a shader=].
@@ -7986,12 +8001,13 @@ The interface includes:
 
 * [=Pipeline inputs=]
 * [=Pipeline outputs=]
-* Buffer resources
-* Texture resources
-* Sampler resources
+* [=Uniform buffers=]
+* [=Storage buffers=]
+* [=Texture resources=]
+* [=Sampler resources=]
 * [=Override-declarations=]
 
-When an [=identifier=] used in a [=function body=] [=resolves=] to a [=module scope|module-scope=] [[#var-and-value|variable or value declaration]],
+When an [=identifier=] in a [=function body=] [=resolves=] to a [=module scope|module-scope=] [[#var-and-value|variable or value declaration]],
 then we say that variable or value is <dfn>statically accessed</dfn> by the function.
 Note that being statically accessed is independent of whether an execution of the shader
 will actually evaluate the expression referring to the variable,
@@ -8003,9 +8019,8 @@ More precisely, the <dfn noexport>interface of a shader stage</dfn> consists of:
   - The [=return value=] of the entry point.
      This denotes the pipeline outputs.
   - All [=override-declarations=].
-  - All [=module scope=] variables that are [=statically accessed=] by [=functions in a shader stage|functions in the shader stage=], and which are in
-        [=address spaces/uniform=], [=address spaces/storage=], or [=address spaces/handle=] address spaces.
-        These are the buffer, texture, and sampler resources.
+  - All [=uniform buffer=], [=storage buffer=], [=texture resource=], and [=sampler resource=] variables that are
+        [=statically accessed=] by [=functions in a shader stage|functions in the shader stage=].
 
 ### Pipeline Input and Output Interface ### {#pipeline-inputs-outputs}
 
@@ -8207,17 +8222,16 @@ User-defined IO can be mixed with built-in values in the same structure. For exa
 
 ### Resource Interface ### {#resource-interface}
 
-A <dfn noexport>resource</dfn> is an object,
-other than a [[#pipeline-inputs-outputs|pipeline input or output]],
-which provides access to data external to a [=shader stage=].
+A <dfn noexport>resource</dfn> is an object which provides access to data external to a [=shader stage=],
+and which is not an [=override-declaration=] and not a [[#pipeline-inputs-outputs|pipeline input or output]].
 Resources are shared by all invocations of the shader.
 
 There are four kinds of resources:
 
-* [=uniform buffers=]
-* [=storage buffers=]
-* textures
-* samplers
+* [=Uniform buffers=]
+* [=Storage buffers=]
+* [=Texture resources=]
+* [=Sampler resources=]
 
 The <dfn noexport>resource interface of a shader</dfn> is the set of module-scope
 resource variables [=statically accessed=] by


### PR DESCRIPTION
- delete "IO-shareable" section
- define "user-define input datum" and "user-defined output datum"
  - each can be numeric scalar or numeric vector
- constrain the types of entry point formal parameters and return type,
  without having to define a term for that.
- remove redundancies between various sections about inputs and outputs
- Say more clearly in one place that compute shaders don't have
  user-defined inputs or outputs

Fixes: #3033, #3227