### PR TITLE
wgsl: Fix result type of distance built-in

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -11478,7 +11478,7 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
 @const fn distance(e1: T,
-                   e2: T) -> f32
+                   e2: T) -> S
 </xmp>
   <tr>
     <td style="width:10%">Parameterization


### PR DESCRIPTION
The PR make `distance` returns f32 with f32 parameters and f16 with f16 parameters. This behavior is aligned with `length`.

Issue: #2512, #3111