### PR TITLE
Remove confusing statement about identifiers declared inside `loop`

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6714,11 +6714,6 @@ A <dfn noexport dfn-for="statement">loop</dfn> statement repeatedly executes a <
 the loop body is specified as a [=compound statement=].
 Each execution of the loop body is called an <dfn noexport>iteration</dfn>.
 
-The [=identifier=] of a [=declaration=] in a loop is [=in scope=] from the start of the
-next statement until the end of the loop body.
-The declaration is executed each time it is reached, so each new iteration
-creates a new instance of the variable or constant, and re-initializes it.
-
 This repetition can be interrupted by a [=statement/break=], or
 [=statement/return=] statement.
 


### PR DESCRIPTION
Fixes: #3153