### PR TITLE
Clarify what location applies to

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -892,8 +892,8 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
         [=shader-creation error|Must=] be non-negative.
     <td>[=shader-creation error|Must=] only be applied to an entry point function parameter, entry point
     return type, or member of a [=structure=] type.
-    [=shader-creation error|Must=] only be applied to declarations of [=numeric scalar=] or [=numeric
-    vector=] type.
+    [=shader-creation error|Must=] only be applied to declarations of objects with [=numeric scalar=]
+    or [=numeric vector=] type.
     [=shader-creation error|Must not=] be used with the [=compute=] shader stage.
 
     Specifies a part of the user-defined IO of an entry point.


### PR DESCRIPTION
It applies to objects declared with numeric scalar or numeric vector type,
rather than the declaration of the types themselves.

The reader should think something like this:

   struct {   @location(0) a: f32  }

rather than:

  struct {   a: @location(0) f32  }

or even:

  type placed_int = @location(0) i32;