### PR TITLE
Add mermaid diagram support, with example

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -314,6 +314,18 @@ thead.stickyheader th, th.stickyheader {
 }
 </style>
 
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mermaid/9.1.3/mermaid.min.js"
+    integrity="sha512-E/owfVh8/U1xwhvIT4HSI064DRc1Eo/xf7AYax84rt9gVqA8tc/JNH/lvTl1tuw9PUHQIMGUtObkjYkgRjFqAA=="
+    crossorigin="anonymous"
+    referrerpolicy="no-referrer"></script>
+<script>
+    // Note: It doesn't seem to be possible to reinitialize mermaid with a new theme, so we can't
+    // change the theme without reloading the page.
+    mermaid.initialize({
+        theme: (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) ? "dark" : "neutral",
+    })
+</script>
+
 
 # Introduction # {#intro}
 
@@ -2601,6 +2613,40 @@ Note:
         numbers in {{GPUBuffer/[[mapping_range]]}} and a sequence of {{ArrayBuffer}}
         in {{GPUBuffer/[[mapped_ranges]]}}
     - [=buffer state/mapping pending=] with a {{Promise}} typed {{GPUBuffer/[[mapping]]}}.
+</div>
+
+<div class=example>
+    Mapping and unmapping a buffer.
+
+    <xmp class=mermaid>
+        sequenceDiagram
+            Note over Client: mapState: "unmapped"
+            Note over Server: [[state]]: "unmapped"
+            Client ->> Server: mapAsync()
+            Note over Client: mapState: "pending"
+            Note over Server: [[state]]: "mapping pending"
+            Server ->> Client: mapAsync() response
+            Note over Server: [[state]]: "mapped"
+            Note over Client: mapState: "mapped"
+            Client ->> Server: unmap()
+            Note over Client: mapState: "unmapped"
+            Note over Server: [[state]]: "unmapped"
+    </xmp>
+</div>
+
+<div class=example>
+    Failing to map a buffer.
+
+    <xmp class=mermaid>
+        sequenceDiagram
+            Note over Client: mapState: "unmapped"
+            Note over Server: [[state]]: "unmapped"
+            Client ->> Server: mapAsync()
+            Note over Client: mapState: "pending"
+            Note over Server: (failure, state unchanged)
+            Server ->> Client: mapAsync() response
+            Note over Client: mapState: "unmapped"
+    </xmp>
 </div>
 
 {{GPUBuffer}} is a reference to an internal buffer object.


### PR DESCRIPTION
Loads mermaid from a CDN, which is probably OK because the spec also
requires internet access to load its CSS. (Though it does add one more
origin to load, especially on TR.)