### PR TITLE
Make function returns reconverge

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8537,8 +8537,6 @@ requirement of the parameter value.
   <thead>
     <tr><th>Function Tag<th>Description
   </thead>
-  <tr><td><dfn noexport>SubsequentControlFlowMayBeNonUniform</dfn>
-      <td>Calling this function may cause control flow to be non-uniform immediately after the [=call site=].
   <tr><td><dfn noexport>ReturnValueMayBeNonUniform</dfn>
       <td>The [=return value=] of the function may be non-uniform.
   <tr><td><dfn noexport>NoRestriction</dfn>
@@ -8552,8 +8550,6 @@ requirement of the parameter value.
   </thead>
   <tr><td><dfn noexport>ParameterRequiredToBeUniform</dfn>
       <td>The parameter [=shader-creation error|must=] be a [=uniform value=].
-  <tr><td><dfn noexport>ParameterRequiredToBeUniformForSubsequentControlFlow</dfn>
-      <td>The parameter [=shader-creation error|must=] be a [=uniform value=] for control flow after the function call to be [=uniform control flow|uniform=].
   <tr><td><dfn noexport>ParameterRequiredToBeUniformForReturnValue</dfn>
       <td>The parameter [=shader-creation error|must=] be a [=uniform value=] in order for the [=return value=] to be a uniform value.
   <tr><td><dfn noexport>ParameterNoRestriction</dfn>
@@ -8562,18 +8558,14 @@ requirement of the parameter value.
 
 The following algorithm describes how to compute these tags for a given function:
 
-* Create nodes called "RequiredToBeUniform", "MayBeNonUniform", "CF_start", "CF_return", and if the function has a [=return type=] a node called "Value_return".
+* Create nodes called "RequiredToBeUniform", "MayBeNonUniform", "CF_start", and if the function has a [=return type=] a node called "Value_return".
 * Create one node for each parameter of the function which we'll call "arg_i".
 * Walk over the syntax of the function, adding nodes and edges to the graph following the rules of the next sections ([[#uniformity-statements]], [[#uniformity-function-calls]], [[#uniformity-expressions]]), using CF_start as the starting control-flow for the function's body.
 * Look at which nodes are reachable from "RequiredToBeUniform".
     * If this set includes the node "MayBeNonUniform", then reject the program.
-    * If this set includes "CF_start", then the [=call site tag=] for the function is [=CallSiteRequiredToBeuniform=].
+    * If this set includes "CF_start", then the [=call site tag=] for the function is [=CallSiteRequiredToBeUniform=].
     * Otherwise, the [=call site tag=] is [=CallSiteNoRestriction=].
     * For each "arg_i" in this set, the corresponding [=parameter tag=] is [=ParameterRequiredToBeUniform=].
-    * Remove from the graph all nodes that have been visited.
-* Look at which nodes are reachable from "CF_return"
-    * If this set includes "MayBeNonUniform", then the [=function tag=] for the function is [=SubsequentControlFlowMayBeNonUniform=].
-    * For each "arg_i" in this set, the corresponding [=parameter tag=] is [=ParameterRequiredToBeUniformForSubsequentControlFlow=].
     * Remove from the graph all nodes that have been visited.
 * If "Value_return" exists, look at which nodes are reachable from it
     * If this set includes "MayBeNonUniform", then the [=function tag=] is [=ReturnValueMayBeNonUniform=].
@@ -8680,23 +8672,18 @@ When several edges have to be created we use `X -> {Y, Z}` as a short-hand for `
       <td>*CF'*
       <td>
   <tr><td class="nowrap">continue;
-      <td rowspan=3>
-      <td rowspan=3>
-      <td rowspan=3>*CF*
-      <td rowspan=3>
+      <td rowspan=4>
+      <td rowspan=4>
+      <td rowspan=4>*CF*
+      <td rowspan=4>
   <tr><td class="nowrap">fallthrough;
   <tr><td class="nowrap">discard;
   <tr><td class="nowrap">return;
-      <td>
-      <td>
-      <td>*CF*
-      <td>*CF_return* -> *CF*
   <tr><td class="nowrap">return *e*;
       <td>
       <td class="nowrap">(*CF*, *e*) => (*CF'*, *V*)
       <td>*CF'*
-      <td>*CF_return* -> *CF'*<br>
-          *Value_return* -> *V*
+      <td>*Value_return* -> *V*
   <tr><td class="nowrap">*e2* = *e1*;
       <td>
       <td class="nowrap">(*CF*, *e1*) => (*CF1*, *V1*)<br>
@@ -8728,14 +8715,12 @@ Note: If the set of behaviors (see [[#behaviors]]) for an if, switch, or loop st
 The most complex rule is for function calls:
 - For each argument, apply the corresponding expression rule, with the control flow at the exit of the previous argument (using the control flow at the beginning of the function call for the first argument). Name the corresponding value nodes "arg_i" and the corresponding control flow nodes "CF_i"
 - Create two new nodes, named "Result" and "CF_after"
-- If the [=call site tag=] of the function is [=CallSiteRequiredToBeuniform=], then add an edge from RequiredToBeUniform to the last CF_i
+- If the [=call site tag=] of the function is [=CallSiteRequiredToBeUniform=], then add an edge from RequiredToBeUniform to the last CF_i
 - Otherwise add an edge from CF_after to the last CF_i
-- If the [=function tag=] is [=SubsequentControlFlowMayBeNonUniform=], then add an edge from CF_after to MayBeNonUniform
-- Otherwise if the [=function tag=] is [=ReturnValueMayBeNonUniform=], then add an edge from Result to MayBeNonUniform
+- If the [=function tag=] is [=ReturnValueMayBeNonUniform=], then add an edge from Result to MayBeNonUniform
 - Add an edge from Result to CF_after
 - For each argument *i*:
     - If the corresponding [=parameter tag=] is [=ParameterRequiredToBeUniform=], then add an edge from RequiredToBeUniform to arg_i
-    - Otherwise if the [=parameter tag=] is [=ParameterRequiredToBeUniformForSubsequentControlFlow=], then add an edge from CF_after to arg_i
     - Otherwise if the [=parameter tag=] is [=ParameterRequiredToBeUniformForReturnValue=], then add an edge from Result to arg_i
 
 Note: Notice that this rule only requires adding a number of edges bounded by 3 + the number of parameters of the functions, independently of how complex the implementation of the function might be. This is key to the linear complexity of the overall algorithm.
@@ -8746,9 +8731,9 @@ Most built-in functions have tags of:
 - For each parameter, a [=parameter tag|tag=] of [=ParameterRequiredToBeUniformForReturnValue=].
 
 Here is the list of exceptions:
-- All functions in [[#sync-builtin-functions]] have a [=call site tag=] of  [=CallSiteRequiredToBeuniform=].
+- All functions in [[#sync-builtin-functions]] have a [=call site tag=] of  [=CallSiteRequiredToBeUniform=].
 - All functions in [[#derivative-builtin-functions]], [[#texturesample]], [[#texturesamplebias]], and [[#texturesamplecompare]] have a [=call site tag=] of [=CallSiteRequiredToBeUniform=] and a [=function tag=] of [=ReturnValueMayBeNonUniform=].
-- `arrayLength` (see [[#array-builtin-functions]]) has a [=call site tag=] of
+- [[#arrayLength-builtin|arrayLength]] has a [=call site tag=] of
     [=CallSiteNoRestriction=], a [=function tag=] of [=NoRestriction=] and
     the input parameter `p` has a [=parameter tag=] of [=ParameterNoRestriction=]
 


### PR DESCRIPTION
Fixes #3007
Fixes #3221

* Change uniformity analysis to require functions to reconverge on
  return
  * Removes the function tag: SubsequentControlFlowMayBeNonUniform
  * Removes the parameter tag:
    ParameterRequiredToBeUniformForSubsequentControlFlow
  * updates `return` and `return e` rules
  * removes addition of CF_return node and traversal from it