### PR TITLE
Write "identifer" instead of "identifier use"

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1045,7 +1045,7 @@ We say such objects are <dfn noexport>predeclared</dfn>.
 For example, WGSL predeclares [=built-in functions=], and built-in types such as [=i32=] and [=f32=].
 
 The <dfn noexport>scope</dfn> of a declaration is the set of
-program source locations where a use of the declared identifier potentially denotes
+program source locations where a declared identifier potentially denotes
 its associated object.
 We say the identifier is <dfn noexport>in scope</dfn>
 (of the declaration) at those source locations.
@@ -3098,13 +3098,14 @@ In all cases, the [=access mode=] of the result is the same as the access mode o
         weight: f32
     }
     var<private> person: S;
-    // Uses of 'person' denote the reference to the memory underlying the variable,
+    // Elsewhere, 'person' denotes the reference to the memory underlying the variable,
     // and will have type ref<private,S,read_write>.
 
     fn f() {
         var uv: vec2<f32>;
-        // Uses of 'uv' denote the reference to the memory underlying the variable,
-        // and will have type ref<function,vec2<f32>,read_write>.
+        // For the remainder of this function body, 'uv' denotes the reference
+        // to the memory underlying the variable, and will have type
+        // ref<function,vec2<f32>,read_write>.
 
         // Evaluate the left-hand side of the assignment:
         //   Evaluate 'uv.x' to yield a reference:
@@ -4347,7 +4348,7 @@ WGSL defines two types of expressions that can be evaluated before runtime:
 Expressions that are evaluated at [=shader module creation|shader-creation
 time=] are called <dfn noexport>const-expressions</dfn>.
 In order for an expression to be evaluated at shader-creation time all
-[=identifiers=] used by the expression must [=resolve=] to:
+[=identifiers=] in the expression must [=resolve=] to:
 * [=const-declarations=], or
 * [=const-functions=], or 
 * [=type aliases=], or 
@@ -4393,7 +4394,7 @@ Example:  `let minint = -2147483648;` is analyzed as follows:
 Expressions that are evaluated at [=pipeline creation=] time are called <dfn
 noexport>override-expressions</dfn>.
 In order for an expression to be evaluated at pipeline creation time all
-[=identifiers=] used by the expression must [=resolve=] to:
+[=identifiers=] in the expression must [=resolve=] to:
 * [=override-declarations=], or
 * [=const-declarations=], or
 * [=const-functions=], or 


### PR DESCRIPTION
Simplifies the wording, when we can