### PR TITLE
Simplify device-timeline map states

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -781,7 +781,7 @@ object, or if there is not enough memory to allocate a resource.
 [=Internal objects=] of *most* types cannot become [=invalid=] after they are created, but still
 may become unusable, e.g. if the owning device is [=lose the device|lost=] or
 {{GPUDevice/destroy()|destroyed}}, or the object has a special internal state,
-like buffer state [=buffer state/destroyed=].
+like the buffer state {{GPUBuffer/[[destroyed]]}}.
 
 [=Internal objects=] of some types *can* become [=invalid=] after they are created; specifically,
 [=devices=], [=adapters=], {{GPUCommandBuffer}}s, and command/pass/bundle encoders.
@@ -2544,7 +2544,7 @@ GPUBuffer includes GPUObjectBase;
 <dl dfn-type=attribute dfn-for=GPUBuffer>
     : <dfn>\[[state]]</dfn>, of type [=buffer state=]
     ::
-        The current state of the {{GPUBuffer}}.
+        The current mapping state of the {{GPUBuffer}}.
 
     : <dfn>\[[mapping]]</dfn>, of type {{ArrayBuffer}} or {{Promise}} or `null`
     ::
@@ -2567,6 +2567,11 @@ GPUBuffer includes GPUObjectBase;
     : <dfn>\[[map_mode]]</dfn>, of type {{GPUMapModeFlags}}
     ::
         The {{GPUMapModeFlags}} of the last call to {{GPUBuffer/mapAsync()}} (if any).
+
+    : <dfn>\[[destroyed]]</dfn>, of type [=boolean=], initially `false`
+    ::
+        If the buffer is destroyed, it can no longer be used in any operation or mapped,
+        and its underlying memory can be freed.
 </dl>
 
 Each {{GPUBuffer}} has a current <dfn dfn>buffer state</dfn> on the [=Content timeline=]
@@ -2581,8 +2586,6 @@ which is one of the following:
     :: The {{GPUBuffer}} is being made available for CPU operations on its content.
     : "<dfn>unmapped</dfn>"
     :: The {{GPUBuffer}} is available for GPU operations.
-    : "<dfn>destroyed</dfn>"
-    :: The {{GPUBuffer}} is no longer available for any operations except {{GPUBuffer/destroy}}.
 </dl>
 
 Note:
@@ -2595,7 +2598,7 @@ Note:
     ({{GPUBuffer/[[mapping]]}}, {{GPUBuffer/[[mapping_range]]}},
     and {{GPUBuffer/[[mapped_ranges]]}} are `null` when not specified.)
 
-    - [=buffer state/unmapped=] and [=buffer state/destroyed=].
+    - [=buffer state/unmapped=]
     - [=buffer state/mapped=] or [=buffer state/mapped at creation=] with an
         {{ArrayBuffer}} typed {{GPUBuffer/[[mapping]]}}, a sequence of two
         numbers in {{GPUBuffer/[[mapping_range]]}} and a sequence of {{ArrayBuffer}}
@@ -2841,7 +2844,7 @@ once all previously submitted operations using it are complete.
                 or by {{GPUBuffer/unmap()|GPUBuffer.unmap()}}.
             -->
 
-            1. Set |this|.{{GPUBuffer/[[state]]}} to [=buffer state/destroyed=].
+            1. Set |this|.{{GPUBuffer/[[destroyed]]}} to `true`.
         </div>
 
         Note: Since no further operations can be enqueued using this buffer, implementations can
@@ -2955,6 +2958,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                         - |this| is a [=valid=] {{GPUBuffer}}.
 
                             Issue: Figure out exactly how [=invalid=] and destroyed buffers are handled.
+                        - |this|.{{GPUBuffer/[[destroyed]]}} is false.
                         - |offset| is a multiple of 8.
                         - |rangeSize| is a multiple of 4.
                         - |offset| + |rangeSize| &le; |this|.{{GPUBuffer/size}}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2579,9 +2579,7 @@ which is one of the following:
 
 <dl dfn-type=dfn dfn-for="buffer state">
     : "<dfn>mapped</dfn>"
-    :: The {{GPUBuffer}} is available for CPU operations on its content.
-    : "<dfn>mapping pending</dfn>"
-    :: The {{GPUBuffer}} is being made available for CPU operations on its content.
+    :: The {{GPUBuffer}} is unavailable for GPU operations.
     : "<dfn>unmapped</dfn>"
     :: The {{GPUBuffer}} is available for GPU operations.
 </dl>
@@ -2589,20 +2587,6 @@ which is one of the following:
 Note:
 {{GPUBuffer/size}} and {{GPUBuffer/usage}} are immutable once the
 {{GPUBuffer}} has been created.
-
-<div class=note>
-    Note:
-    {{GPUBuffer}} has a state machine with the following states.
-    ({{GPUBuffer/[[mapping]]}}, {{GPUBuffer/[[mapping_range]]}},
-    and {{GPUBuffer/[[mapped_ranges]]}} are `null` when not specified.)
-
-    - [=buffer state/unmapped=]
-    - [=buffer state/mapped=] with an
-        {{ArrayBuffer}} typed {{GPUBuffer/[[mapping]]}}, a sequence of two
-        numbers in {{GPUBuffer/[[mapping_range]]}} and a sequence of {{ArrayBuffer}}
-        in {{GPUBuffer/[[mapped_ranges]]}}
-    - [=buffer state/mapping pending=] with a {{Promise}} typed {{GPUBuffer/[[mapping]]}}.
-</div>
 
 {{GPUBuffer}} is a reference to an internal buffer object.
 
@@ -2935,7 +2919,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                 1. Let <var data-timeline=content>contentTimeline</var> be the current [=Content timeline=].
                 1. Let |p| be a new {{Promise}}.
                 1. Set |this|.{{GPUBuffer/[[mapping]]}} to |p|.
-                1. Set |this|.{{GPUBuffer/[[state]]}} to [=buffer state/mapping pending=].
+                1. Set |this|.{{GPUBuffer/[[state]]}} to [=buffer state/mapped=].
                 1. Set |this|.{{GPUBuffer/[[map_mode]]}} to |mode|.
                 1. Issue the |validation steps| on the [=Device timeline=] of
                     |this|.{{GPUObjectBase/[[device]]}}.
@@ -3083,8 +3067,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
             1. If any of the following requirements are unmet, [$generate a validation error$] and stop.
 
                 <div class=validusage>
-                    - |this|.{{GPUBuffer/[[state]]}} must be
-                        [=buffer state/mapping pending=] or [=buffer state/mapped=].
+                    - |this|.{{GPUBuffer/[[state]]}} must be [=buffer state/mapped=].
 
                     Note: It is valid to unmap an [=invalid=] {{GPUBuffer}} that is
                         {{GPUBufferDescriptor/mappedAtCreation}} because the [=Content timeline=]
@@ -3092,8 +3075,9 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                         {{GPUBuffer/[[mapping]]}} memory to be freed.
                 </div>
 
-            1. If |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapping pending=]:
+            1. If |this|.{{GPUBuffer/[[mapping]]}} is a {{Promise}}:
 
+                1. [=Assert=] |this|.{{GPUBuffer/[[mapping]]}} is pending.
                 1. [=Reject=] {{GPUBuffer/[[mapping]]}} with an {{AbortError}}.
                 1. Set |this|.{{GPUBuffer/[[mapping]]}} to `null`.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2580,8 +2580,6 @@ which is one of the following:
 <dl dfn-type=dfn dfn-for="buffer state">
     : "<dfn>mapped</dfn>"
     :: The {{GPUBuffer}} is available for CPU operations on its content.
-    : "<dfn>mapped at creation</dfn>"
-    :: The {{GPUBuffer}} was just created and is available for CPU operations on its content.
     : "<dfn>mapping pending</dfn>"
     :: The {{GPUBuffer}} is being made available for CPU operations on its content.
     : "<dfn>unmapped</dfn>"
@@ -2599,7 +2597,7 @@ Note:
     and {{GPUBuffer/[[mapped_ranges]]}} are `null` when not specified.)
 
     - [=buffer state/unmapped=]
-    - [=buffer state/mapped=] or [=buffer state/mapped at creation=] with an
+    - [=buffer state/mapped=] with an
         {{ArrayBuffer}} typed {{GPUBuffer/[[mapping]]}}, a sequence of two
         numbers in {{GPUBuffer/[[mapping_range]]}} and a sequence of {{ArrayBuffer}}
         in {{GPUBuffer/[[mapped_ranges]]}}
@@ -2786,7 +2784,8 @@ The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its
                         1. Set |b|.{{GPUBuffer/[[mapping]]}} to a new {{ArrayBuffer}} of size |b|.{{GPUBuffer/size}}.
                         1. Set |b|.{{GPUBuffer/[[mapping_range]]}} to `[0, descriptor.size]`.
                         1. Set |b|.{{GPUBuffer/[[mapped_ranges]]}} to `[]`.
-                        1. Set |b|.{{GPUBuffer/[[state]]}} to [=buffer state/mapped at creation=].
+                        1. Set |b|.{{GPUBuffer/[[state]]}} to [=buffer state/mapped=].
+                        1. Set |b|.{{GPUBuffer/[[map_mode]]}} to {{GPUMapMode/WRITE}}.
 
                         Else:
 
@@ -3037,7 +3036,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
             1. If any of the following conditions are unsatisfied, throw an {{OperationError}} and stop.
 
                 <div class=validusage>
-                    - |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapped=] or [=buffer state/mapped at creation=].
+                    - |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapped=].
                     - |offset| is a multiple of 8.
                     - |rangeSize| is a multiple of 4.
                     - |offset| &ge; |this|.{{GPUBuffer/[[mapping_range]]}}[0].
@@ -3045,7 +3044,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                     - [|offset|, |offset| + |rangeSize|) does not overlap another range in |this|.{{GPUBuffer/[[mapped_ranges]]}}.
 
                     Note: It is always valid to get mapped ranges of a {{GPUBuffer}} that is
-                    [=buffer state/mapped at creation=], even if it is [=invalid=], because
+                    {{GPUBufferDescriptor/mappedAtCreation}}, even if it is [=invalid=], because
                     the [=Content timeline=] might not know it is invalid.
 
                     Issue: Consider aligning mapAsync offset to 8 to match this.
@@ -3084,11 +3083,11 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
             1. If any of the following requirements are unmet, [$generate a validation error$] and stop.
 
                 <div class=validusage>
-                    - |this|.{{GPUBuffer/[[state]]}} must be [=buffer state/mapped at creation=],
-                        [=buffer state/mapping pending=], or [=buffer state/mapped=].
+                    - |this|.{{GPUBuffer/[[state]]}} must be
+                        [=buffer state/mapping pending=] or [=buffer state/mapped=].
 
                     Note: It is valid to unmap an [=invalid=] {{GPUBuffer}} that is
-                        [=buffer state/mapped at creation=] because the [=Content timeline=]
+                        {{GPUBufferDescriptor/mappedAtCreation}} because the [=Content timeline=]
                         might not know it is an error {{GPUBuffer}}. This allows the temporary
                         {{GPUBuffer/[[mapping]]}} memory to be freed.
                 </div>
@@ -3098,14 +3097,10 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                 1. [=Reject=] {{GPUBuffer/[[mapping]]}} with an {{AbortError}}.
                 1. Set |this|.{{GPUBuffer/[[mapping]]}} to `null`.
 
-            1. If |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapped=] or [=buffer state/mapped at creation=]:
+            1. If |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapped=]:
 
-                1. If one of the two following conditions holds:
-
-                    - |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapped at creation=]
-                    - |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapped=] and |this|.{{GPUBuffer/[[map_mode]]}} contains {{GPUMapMode/WRITE}}
-
-                    Then:
+                1. If |this|.{{GPUBuffer/[[state]]}} is [=buffer state/mapped=] and
+                    |this|.{{GPUBuffer/[[map_mode]]}} contains {{GPUMapMode/WRITE}}:
 
                     1. Enqueue an operation on the default queue's [=Queue timeline=] that updates the |this|.{{GPUBuffer/[[mapping_range]]}}
                         of |this|'s allocation to the content of |this|.{{GPUBuffer/[[mapping]]}}.
@@ -3118,7 +3113,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
 
             1. Set |this|.{{GPUBuffer/[[state]]}} to [=buffer state/unmapped=].
 
-            Note: When a {{GPUBufferUsage/MAP_READ}} buffer (not currently mapped at creation) is
+            Note: When a buffer is mapped without the {{GPUMapMode/WRITE}} mode, then
             unmapped, any local modifications done by the application to the mapped ranges
             {{ArrayBuffer}} are discarded and will not affect the content of follow-up mappings.
         </div>


### PR DESCRIPTION
This will need a significant rebase over #3014, but for now exists to prove we only need two buffer mapping states on the device timeline.

- Split `[[destroyed]]` into a separate state members
- Remove `"mapped at creation"` - nothing actually cares that this is different from `"mapped"`
- Remove `"mapping pending"` - the device timeline only cares whether the buffer is "available" or not

Exploration, in table form: https://docs.google.com/spreadsheets/d/1Ba7aUunjUyePz1Is0L_YlgT4Y8W3WaprO4HeAoI5dKc/edit?usp=sharing