### PR TITLE
Fix typo in example of user-defined function

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7669,7 +7669,7 @@ parameters and return types:
 
     // A compute shader entry point function, 'main'.
     // It has no specified return type.
-    // It invokes the ordinary_two function, and captures
+    // It invokes the add_two function, and captures
     // the resulting value in the named value 'six'.
     @compute fn main() {
        let six: i32 = add_two(4, 5.0);


### PR DESCRIPTION
Fixes: #3195