### PR TITLE
Fix repeated 'keyword' in explanation of extension names

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8331,8 +8331,8 @@ The grammar rules imply that all enable directives [=shader-creation error|must=
 
 The directive uses a [=context-dependent name=] to name the extension.
 
-In particular, an extension name may be spelled the same as a [=keyword=], [=reserved word=], or [=keyword=],
-but is not interpeted as any of those.
+In particular, an extension name may be spelled the same as a [=keyword=] or [=reserved word=],
+but is not interpreted as any of those.
 
 The valid extensions are listed in [[#extension-list]].
 


### PR DESCRIPTION
Fixes: #3216