### PR TITLE
Clarify effect of @builtin struct member when not an entry point IO

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2036,7 +2036,7 @@ Some consequences of the restrictions structure member and array element types a
     | [=syntax/attribute=] * [=syntax/member_ident=] [=syntax/colon=] [=syntax/type_decl=]
 </div>
 
-WGSL defines the following attributes that can be applied to structure members:
+The following attributes can be applied to structure members:
  * [=attribute/align=]
  * [=attribute/builtin=]
  * [=attribute/location=]
@@ -2044,8 +2044,19 @@ WGSL defines the following attributes that can be applied to structure members:
  * [=attribute/invariant=]
  * [=attribute/size=]
 
-Note: Layout attributes may be required if the structure type is used
-to define a [=uniform buffer=] or a [=storage buffer=]. See [[#memory-layouts]].
+Attributes [=attribute/builtin=] [=attribute/location=] [=attribute/interpolate=], and [=attribute/invariant=]
+are [=IO attributes=].
+An [=IO attribute=] on a member of a structure |S| has effect only when
+|S| is used as the type of a [=formal parameter=] or [=return type=] of an [=entry point=].
+See [[#pipeline-inputs-outputs]].
+
+Attributes [=attribute/align=] and [=attribute/size=] are [=layout attributes=],
+and may be required if the structure type is used to
+define a [=uniform buffer=] or a [=storage buffer=].
+See [[#memory-layouts]].
+
+When another type |T| is defined as a [=type alias=] for structure type |S|,
+all properties of the members of |S|, including attributes, carry over to the members of |T|.
 
 <div class='example wgsl global-scope' heading='Structure declaration'>
   <xmp highlight='rust'>
@@ -2218,7 +2229,7 @@ Note: That is, the storable types are the [=type/concrete=] [=plain types=], tex
 
 Host-shareable types are used to describe the contents of buffers which are shared between
 the host and the GPU, or copied between host and GPU without format translation.
-When used for this purpose, the type may be additionally decorated with layout attributes
+When used for this purpose, the type may be additionally decorated with [=layout attributes=]
 as described in [[#memory-layouts]].
 We will see in [[#var-decls]] that the [=store type=] of [=uniform buffer=] and [=storage buffer=]
 variables [=shader-creation error|must=] be host-shareable.
@@ -2232,10 +2243,6 @@ A type is <dfn noexport>host-shareable</dfn> if it is both [=type/concrete=] and
 * a [=fixed-size array=] type, if it has [=creation-fixed footprint=] and its element type is host-shareable
 * a [=runtime-sized=] array type, if its element type is host-shareable
 * a [=structure=] type, if all its members are host-shareable
-
-WGSL defines the following attributes that affect memory layouts:
- * [=attribute/align=]
- * [=attribute/size=]
 
 Note: Many types are host-shareable, but not IO-shareable, including [=atomic types=],
 [=runtime-sized=] arrays, and any composite types containing them.
@@ -2457,6 +2464,15 @@ following table:
 
 
 #### Structure Member Layout ####  {#structure-member-layout}
+
+The internal layout of a [=structure=] is computed from the sizes and alignments of its members.
+By default, the members are arranged tightly, in order, without overlap, while satisfying member alignment
+requirements.
+
+This default internal layout can be overriden by using <dfn noexport>layout attributes</dfn>, which are:
+
+* [=attribute/size=]
+* [=attribute/align=]
 
 The |i|'th member of structure type |S| has a size and alignment, denoted
 by [=SizeOfMember=](|S|, |i|) and [=AlignOfMember=](|S|, |i|), respectively.
@@ -8028,6 +8044,13 @@ Each datum is either a [=built-in input value=], or a [=user-defined input datum
 
 A <dfn noexport>pipeline output</dfn> is a datum the shader provides for further processing downstream in the pipeline.
 Each datum is either a [=built-in output value=], or a [=user-defined output datum|user-defined output=].
+
+[=IO attributes=] are used to establish an object as a [=pipeline input=] or a [=pipeline output=].
+The <dfn noexport>IO attributes</dfn> are:
+* [=attribute/builtin=]
+* [=attribute/location=]
+* [=attribute/interpolate=]
+* [=attribute/invariant=]
 
 #### Built-in Inputs and Outputs #### {#builtin-inputs-outputs}
 


### PR DESCRIPTION
Fixes: #3261

- Defines "IO attribute" in "Pipeline Input Output Interface"

- Out of symmetry, also defines "layout attribute"
  - Moves definition of "layout attribute" to "Structure Member Layout"
  - Adds an introductory blurb there that motivates the rest.

- At structure type, briefly describe uses of the two kinds of
  attributes you can put on a structure member.
  - Say that IO attributes only take effect when the struct is used
    as an entry point formal param or entry point return type.
    This is the actual fix.

- Clarify that when a type alias is made of a structure type, all
  member proprties, including their attributes, carry over to the new
  alias.