### PR TITLE
Remove types from keyword list.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1947,7 +1947,7 @@ of a variable in [=address spaces/workgroup=] space.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>array_type_decl</dfn> :
 
-    | [=syntax/array=] [=syntax/less_than=] [=syntax/type_decl=] ( [=syntax/comma=] [=syntax/element_count_expression=] ) ? [=syntax/greater_than=]
+    | `'array'` [=syntax/less_than=] [=syntax/type_decl=] ( [=syntax/comma=] [=syntax/element_count_expression=] ) ? [=syntax/greater_than=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>element_count_expression</dfn> :
@@ -3359,7 +3359,7 @@ Texel access is controlled via several properties of the sampler:
 : LOD clamp
 :: Controls the min and max levels of details that are accessed.
 : comparison
-:: Controls the type of comparison done for [=syntax/sampler_comparison|comparison sampler=].
+:: Controls the type of comparison done for a comparison sampler.
     See [[WebGPU#enumdef-gpucomparefunction|WebGPU GPUCompareFunction]].
 : max anisotropy
 :: Controls the maximum anisotropy value used by the sampler.
@@ -3587,53 +3587,53 @@ sampler_comparison
 <div class='syntax' noexport='true'>
   <dfn for=syntax>sampler_type</dfn> :
 
-    | [=syntax/sampler=]
+    | `'sampler'`
 
-    | [=syntax/sampler_comparison=]
+    | `'sampler_comparison'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>sampled_texture_type</dfn> :
 
-    | [=syntax/texture_1d=]
+    | `'texture_1d'`
 
-    | [=syntax/texture_2d=]
+    | `'texture_2d'`
 
-    | [=syntax/texture_2d_array=]
+    | `'texture_2d_array'`
 
-    | [=syntax/texture_3d=]
+    | `'texture_3d'`
 
-    | [=syntax/texture_cube=]
+    | `'texture_cube'`
 
-    | [=syntax/texture_cube_array=]
+    | `'texture_cube_array'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>multisampled_texture_type</dfn> :
 
-    | [=syntax/texture_multisampled_2d=]
+    | `'texture_multisampled_2d'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>storage_texture_type</dfn> :
 
-    | [=syntax/texture_storage_1d=]
+    | `'texture_storage_1d'`
 
-    | [=syntax/texture_storage_2d=]
+    | `'texture_storage_2d'`
 
-    | [=syntax/texture_storage_2d_array=]
+    | `'texture_storage_2d_array'`
 
-    | [=syntax/texture_storage_3d=]
+    | `'texture_storage_3d'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>depth_texture_type</dfn> :
 
-    | [=syntax/texture_depth_2d=]
+    | `'texture_depth_2d'`
 
-    | [=syntax/texture_depth_2d_array=]
+    | `'texture_depth_2d_array'`
 
-    | [=syntax/texture_depth_cube=]
+    | `'texture_depth_cube'`
 
-    | [=syntax/texture_depth_cube_array=]
+    | `'texture_depth_cube_array'`
 
-    | [=syntax/texture_depth_multisampled_2d=]
+    | `'texture_depth_multisampled_2d'`
 </div>
 
 ## Type Aliases ## {#type-aliases}
@@ -3674,57 +3674,57 @@ The declaration [=shader-creation error|must=] appear at [=module scope=], and i
 <div class='syntax' noexport='true'>
   <dfn for=syntax>type_decl_without_ident</dfn> :
 
-    | [=syntax/bool=]
+    | `'bool'`
 
-    | [=syntax/float32=]
+    | `'f32'`
 
-    | [=syntax/float16=]
+    | `'f16'`
 
-    | [=syntax/int32=]
+    | `'i32'`
 
-    | [=syntax/uint32=]
+    | `'u32'`
 
     | [=syntax/vec_prefix=] [=syntax/less_than=] [=syntax/type_decl=] [=syntax/greater_than=]
 
     | [=syntax/mat_prefix=] [=syntax/less_than=] [=syntax/type_decl=] [=syntax/greater_than=]
 
-    | [=syntax/pointer=] [=syntax/less_than=] [=syntax/address_space=] [=syntax/comma=] [=syntax/type_decl=] ( [=syntax/comma=] [=syntax/access_mode=] ) ? [=syntax/greater_than=]
+    | `'ptr'` [=syntax/less_than=] [=syntax/address_space=] [=syntax/comma=] [=syntax/type_decl=] ( [=syntax/comma=] [=syntax/access_mode=] ) ? [=syntax/greater_than=]
 
     | [=syntax/array_type_decl=]
 
-    | [=syntax/atomic=] [=syntax/less_than=] [=syntax/type_decl=] [=syntax/greater_than=]
+    | `'atomic'` [=syntax/less_than=] [=syntax/type_decl=] [=syntax/greater_than=]
 
     | [=syntax/texture_and_sampler_types=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>vec_prefix</dfn> :
 
-    | [=syntax/vec2=]
+    | `'vec2'`
 
-    | [=syntax/vec3=]
+    | `'vec3'`
 
-    | [=syntax/vec4=]
+    | `'vec4'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>mat_prefix</dfn> :
 
-    | [=syntax/mat2x2=]
+    | `'mat2x2'`
 
-    | [=syntax/mat2x3=]
+    | `'mat2x3'`
 
-    | [=syntax/mat2x4=]
+    | `'mat2x4'`
 
-    | [=syntax/mat3x2=]
+    | `'mat3x2'`
 
-    | [=syntax/mat3x3=]
+    | `'mat3x3'`
 
-    | [=syntax/mat3x4=]
+    | `'mat3x4'`
 
-    | [=syntax/mat4x2=]
+    | `'mat4x2'`
 
-    | [=syntax/mat4x3=]
+    | `'mat4x3'`
 
-    | [=syntax/mat4x4=]
+    | `'mat4x4'`
 </div>
 
 When the type is named by an [=identifier=], the use of the identifier [=shader-creation error|must=] be [=in scope=]
@@ -6069,7 +6069,7 @@ When an identifier is used as a [=syntax/callable=] item, it is one of:
 
     | [=syntax/mat_prefix=]
 
-    | [=syntax/array=]
+    | `'array'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>paren_expression</dfn> :
@@ -9389,217 +9389,6 @@ Issue: https://github.com/gpuweb/gpuweb/issues/1621
 # Keyword and Token Summary # {#grammar}
 
 ## Keyword Summary ## {#keyword-summary}
-
-### Type-defining Keywords ### {#type-defining-keywords}
-
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>array</dfn> :
-
-    | `'array'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>atomic</dfn> :
-
-    | `'atomic'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>bool</dfn> :
-
-    | `'bool'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>float32</dfn> :
-
-    | `'f32'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>float16</dfn> :
-
-    | `'f16'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>int32</dfn> :
-
-    | `'i32'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>mat2x2</dfn> :
-
-    | `'mat2x2'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>mat2x3</dfn> :
-
-    | `'mat2x3'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>mat2x4</dfn> :
-
-    | `'mat2x4'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>mat3x2</dfn> :
-
-    | `'mat3x2'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>mat3x3</dfn> :
-
-    | `'mat3x3'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>mat3x4</dfn> :
-
-    | `'mat3x4'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>mat4x2</dfn> :
-
-    | `'mat4x2'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>mat4x3</dfn> :
-
-    | `'mat4x3'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>mat4x4</dfn> :
-
-    | `'mat4x4'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>override</dfn> :
-
-    | `'override'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>pointer</dfn> :
-
-    | `'ptr'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>sampler</dfn> :
-
-    | `'sampler'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>sampler_comparison</dfn> :
-
-    | `'sampler_comparison'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>static_assert</dfn> :
-
-    | `'static_assert'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>struct</dfn> :
-
-    | `'struct'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_1d</dfn> :
-
-    | `'texture_1d'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_2d</dfn> :
-
-    | `'texture_2d'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_2d_array</dfn> :
-
-    | `'texture_2d_array'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_3d</dfn> :
-
-    | `'texture_3d'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_cube</dfn> :
-
-    | `'texture_cube'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_cube_array</dfn> :
-
-    | `'texture_cube_array'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_multisampled_2d</dfn> :
-
-    | `'texture_multisampled_2d'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_storage_1d</dfn> :
-
-    | `'texture_storage_1d'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_storage_2d</dfn> :
-
-    | `'texture_storage_2d'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_storage_2d_array</dfn> :
-
-    | `'texture_storage_2d_array'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_storage_3d</dfn> :
-
-    | `'texture_storage_3d'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_depth_2d</dfn> :
-
-    | `'texture_depth_2d'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_depth_2d_array</dfn> :
-
-    | `'texture_depth_2d_array'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_depth_cube</dfn> :
-
-    | `'texture_depth_cube'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_depth_cube_array</dfn> :
-
-    | `'texture_depth_cube_array'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_depth_multisampled_2d</dfn> :
-
-    | `'texture_depth_multisampled_2d'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>uint32</dfn> :
-
-    | `'u32'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>vec2</dfn> :
-
-    | `'vec2'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>vec3</dfn> :
-
-    | `'vec3'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>vec4</dfn> :
-
-    | `'vec4'`
-</div>
-
-### Other Keywords ### {#other-keywords}
-
 <div class='syntax' noexport='true'>
   <dfn for=syntax>bitcast</dfn> :
 
@@ -9691,6 +9480,11 @@ Issue: https://github.com/gpuweb/gpuweb/issues/1621
     | `'loop'`
 </div>
 <div class='syntax' noexport='true'>
+  <dfn for=syntax>override</dfn> :
+
+    | `'override'`
+</div>
+<div class='syntax' noexport='true'>
   <dfn for=syntax>private</dfn> :
 
     | `'private'`
@@ -9701,9 +9495,19 @@ Issue: https://github.com/gpuweb/gpuweb/issues/1621
     | `'return'`
 </div>
 <div class='syntax' noexport='true'>
+  <dfn for=syntax>static_assert</dfn> :
+
+    | `'static_assert'`
+</div>
+<div class='syntax' noexport='true'>
   <dfn for=syntax>storage</dfn> :
 
     | `'storage'`
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>struct</dfn> :
+
+    | `'struct'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>switch</dfn> :


### PR DESCRIPTION
This CL removes the type names from the list of keywords and makes
them context dependant.

Issue: #3166
Fixes: #3277