### PR TITLE
wgsl: Fix typo in cosh(x) accuracy definition

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9150,7 +9150,7 @@ value with the same sign.
   <tr><td>`cos(x)`
       <td>Absolute error at most 2<sup>-11</sup> when `x` is in the interval [-&pi;, &pi;]
       <td>Absolute error at most 2<sup>-7</sup> when `x` is in the interval [-&pi;, &pi;]
-  <tr><td>`cosh(x)`<td colspan=2 style="text-align:left;">Inherited from `(exp(x) - exp(-x)) * 0.5`
+  <tr><td>`cosh(x)`<td colspan=2 style="text-align:left;">Inherited from `(exp(x) + exp(-x)) * 0.5`
   <tr><td>`cross(x, y)`<td colspan=2 style="text-align:left;">Inherited from `(x[i] * y[j] - x[j] * y[i])`
   <tr><td>`degrees(x)`<td colspan=2 style="text-align:left;">Inherited from `x * 57.295779513082322865`
   <tr><td>`distance(x, y)`<td colspan=2 style="text-align:left;">Inherited from `length(x - y)`


### PR DESCRIPTION
Fixes #3281