### PR TITLE
Move non-type keywords into the other keyword section.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1317,7 +1317,7 @@ For example, the boolean negation rule has four overloads,
 because there are four possible ways to assign a type to its type parameter |T|.
 
 Note:
-In other words, a parameterized type rule provides the pattern 
+In other words, a parameterized type rule provides the pattern
 for a collection of fully elaborated type rules,
 each one produced by applying a different substitution to the parameterized rule.
 
@@ -4355,8 +4355,8 @@ time=] are called <dfn noexport>const-expressions</dfn>.
 In order for an expression to be evaluated at shader-creation time all
 [=identifiers=] in the expression must [=resolve=] to:
 * [=const-declarations=], or
-* [=const-functions=], or 
-* [=type aliases=], or 
+* [=const-functions=], or
+* [=type aliases=], or
 * [=structure=] names
 
 The type of a `const` expression must [=type rules|resolve=] to a type with a
@@ -4402,8 +4402,8 @@ In order for an expression to be evaluated at pipeline creation time all
 [=identifiers=] in the expression must [=resolve=] to:
 * [=override-declarations=], or
 * [=const-declarations=], or
-* [=const-functions=], or 
-* [=type aliases=], or 
+* [=const-functions=], or
+* [=type aliases=], or
 * [=structure=] names
 
 Note: All [=const-expressions=] are also override-expressions.
@@ -5178,7 +5178,7 @@ The internal layout rules are described in [[#internal-value-layout]].
 ### Vector Access Expression ### {#vector-access-expr}
 
 Accessing components of a vector can be done either:
-* Using array subscripting (e.g. `v[2]`), or 
+* Using array subscripting (e.g. `v[2]`), or
 * Using a <dfn noexport>swizzle</dfn> name, a [=context-dependent name=] written as a sequence of convenience names, each mapping to a component of the source vector.
     * The colour set of convenience names: `r`, `g`, `b`, `a` for vector components 0, 1, 2, and 3 respectively.
     * The dimensional set of convenience names: `x`, `y`, `z`, `w` for vector components 0, 1, 2, and 3, respectively.
@@ -9468,11 +9468,6 @@ Issue: https://github.com/gpuweb/gpuweb/issues/1621
     | `'mat4x4'`
 </div>
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>override</dfn> :
-
-    | `'override'`
-</div>
-<div class='syntax' noexport='true'>
   <dfn for=syntax>pointer</dfn> :
 
     | `'ptr'`
@@ -9486,16 +9481,6 @@ Issue: https://github.com/gpuweb/gpuweb/issues/1621
   <dfn for=syntax>sampler_comparison</dfn> :
 
     | `'sampler_comparison'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>static_assert</dfn> :
-
-    | `'static_assert'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>struct</dfn> :
-
-    | `'struct'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>texture_1d</dfn> :
@@ -9691,6 +9676,11 @@ Issue: https://github.com/gpuweb/gpuweb/issues/1621
     | `'loop'`
 </div>
 <div class='syntax' noexport='true'>
+  <dfn for=syntax>override</dfn> :
+
+    | `'override'`
+</div>
+<div class='syntax' noexport='true'>
   <dfn for=syntax>private</dfn> :
 
     | `'private'`
@@ -9701,9 +9691,19 @@ Issue: https://github.com/gpuweb/gpuweb/issues/1621
     | `'return'`
 </div>
 <div class='syntax' noexport='true'>
+  <dfn for=syntax>static_assert</dfn> :
+
+    | `'static_assert'`
+</div>
+<div class='syntax' noexport='true'>
   <dfn for=syntax>storage</dfn> :
 
     | `'storage'`
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>struct</dfn> :
+
+    | `'struct'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>switch</dfn> :


### PR DESCRIPTION
This CL moves `override`, `struct` and `static_assert` out of the
type defining keywords section as they aren't used to define types.