### PR TITLE
Remove non-generic types from keywords list.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3359,7 +3359,7 @@ Texel access is controlled via several properties of the sampler:
 : LOD clamp
 :: Controls the min and max levels of details that are accessed.
 : comparison
-:: Controls the type of comparison done for [=syntax/sampler_comparison|comparison sampler=].
+:: Controls the type of comparison done for a comparison sampler.
     See [[WebGPU#enumdef-gpucomparefunction|WebGPU GPUCompareFunction]].
 : max anisotropy
 :: Controls the maximum anisotropy value used by the sampler.
@@ -3587,9 +3587,9 @@ sampler_comparison
 <div class='syntax' noexport='true'>
   <dfn for=syntax>sampler_type</dfn> :
 
-    | [=syntax/sampler=]
+    | `'sampler'`
 
-    | [=syntax/sampler_comparison=]
+    | `'sampler_comparison'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>sampled_texture_type</dfn> :
@@ -3625,15 +3625,15 @@ sampler_comparison
 <div class='syntax' noexport='true'>
   <dfn for=syntax>depth_texture_type</dfn> :
 
-    | [=syntax/texture_depth_2d=]
+    | `'texture_depth_2d'`
 
-    | [=syntax/texture_depth_2d_array=]
+    | `'texture_depth_2d_array'`
 
-    | [=syntax/texture_depth_cube=]
+    | `'texture_depth_cube'`
 
-    | [=syntax/texture_depth_cube_array=]
+    | `'texture_depth_cube_array'`
 
-    | [=syntax/texture_depth_multisampled_2d=]
+    | `'texture_depth_multisampled_2d'`
 </div>
 
 ## Type Aliases ## {#type-aliases}
@@ -3674,15 +3674,15 @@ The declaration [=shader-creation error|must=] appear at [=module scope=], and i
 <div class='syntax' noexport='true'>
   <dfn for=syntax>type_decl_without_ident</dfn> :
 
-    | [=syntax/bool=]
+    | `'bool'`
 
-    | [=syntax/float32=]
+    | `'f32'`
 
-    | [=syntax/float16=]
+    | `'f16'`
 
-    | [=syntax/int32=]
+    | `'i32'`
 
-    | [=syntax/uint32=]
+    | `'u32'`
 
     | [=syntax/vec_prefix=] [=syntax/less_than=] [=syntax/type_decl=] [=syntax/greater_than=]
 
@@ -9403,26 +9403,6 @@ Issue: https://github.com/gpuweb/gpuweb/issues/1621
     | `'atomic'`
 </div>
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>bool</dfn> :
-
-    | `'bool'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>float32</dfn> :
-
-    | `'f32'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>float16</dfn> :
-
-    | `'f16'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>int32</dfn> :
-
-    | `'i32'`
-</div>
-<div class='syntax' noexport='true'>
   <dfn for=syntax>mat2x2</dfn> :
 
     | `'mat2x2'`
@@ -9476,16 +9456,6 @@ Issue: https://github.com/gpuweb/gpuweb/issues/1621
   <dfn for=syntax>pointer</dfn> :
 
     | `'ptr'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>sampler</dfn> :
-
-    | `'sampler'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>sampler_comparison</dfn> :
-
-    | `'sampler_comparison'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>static_assert</dfn> :
@@ -9551,36 +9521,6 @@ Issue: https://github.com/gpuweb/gpuweb/issues/1621
   <dfn for=syntax>texture_storage_3d</dfn> :
 
     | `'texture_storage_3d'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_depth_2d</dfn> :
-
-    | `'texture_depth_2d'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_depth_2d_array</dfn> :
-
-    | `'texture_depth_2d_array'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_depth_cube</dfn> :
-
-    | `'texture_depth_cube'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_depth_cube_array</dfn> :
-
-    | `'texture_depth_cube_array'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_depth_multisampled_2d</dfn> :
-
-    | `'texture_depth_multisampled_2d'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>uint32</dfn> :
-
-    | `'u32'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>vec2</dfn> :


### PR DESCRIPTION
This CL moves the types which do not have a generic component
from the keyword section section and makes them context
dependant.

This includes
 * bool
 * i32
 * u32
 * f32
 * f16
 * sampler
 * sampler_comparison
 * texture_depth_2d
 * texture_depth_2d_array
 * texture_depth_cube
 * texture_depth_cube_array
 * texture_depth_multisampled_2d

Issue: #3166, #3277