### PR TITLE
Add predeclared short names for vector types

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1962,6 +1962,63 @@ result vector is formed by operating on each component independently.
   </xmp>
 </div>
 
+WGSL also [=predeclared|predeclares=] the following [=type aliases=]:
+
+<table class='data'>
+  <thead>
+    <tr>
+        <th>Predeclared alias
+        <th>Original type
+        <th>Restrictions
+  </thead>
+  <tr>
+      <td><dfn noexport>vec2i</dfn>
+      <td>vec2&lt;i32&gt;
+      <td>
+  <tr>
+      <td><dfn noexport>vec3i</dfn>
+      <td>vec3&lt;i32&gt;
+      <td>
+  <tr>
+      <td><dfn noexport>vec4i</dfn>
+      <td>vec4&lt;i32&gt;
+      <td>
+  <tr>
+      <td><dfn noexport>vec2u</dfn>
+      <td>vec2&lt;u32&gt;
+      <td>
+  <tr>
+      <td><dfn noexport>vec3u</dfn>
+      <td>vec3&lt;u32&gt;
+      <td>
+  <tr>
+      <td><dfn noexport>vec4u</dfn>
+      <td>vec4&lt;u32&gt;
+      <td>
+  <tr>
+      <td><dfn noexport>vec2f</dfn>
+      <td>vec2&lt;f32&gt;
+      <td>
+  <tr>
+      <td><dfn noexport>vec3f</dfn>
+      <td>vec3&lt;f32&gt;
+      <td>
+  <tr>
+      <td><dfn noexport>vec4f</dfn>
+      <td>vec4&lt;f32&gt;
+      <td>
+  <tr>
+      <td><dfn noexport>vec2h</dfn>
+      <td>vec2&lt;f16&gt;
+      <td rowspan=3>Requires the [=extension/f16|f16 extension=].
+  <tr>
+      <td><dfn noexport>vec3h</dfn>
+      <td>vec3&lt;f16&gt;
+  <tr>
+      <td><dfn noexport>vec4h</dfn>
+      <td>vec4&lt;f16&gt;
+</table>
+
 ### Matrix Types ### {#matrix-types}
 
 A <dfn noexport>matrix</dfn> is a grouped sequence of 2, 3, or 4 floating point vectors.
@@ -4818,7 +4875,7 @@ There are three kinds of constructor expressions:
 * [[#zero-value-expr]]
 * [[#conversion-expr]]
 
-In the following sections, when a type name precedes a parenthesized argument list, any
+In the following sections, when a type name precedes a parenthesized argument list, any user-defined or [=predeclared=]
 [=type aliases|alias=] for that type can be used instead, with the same effect.
 
 <div class='example wgsl global-scope' heading="Type constructor expressions using type aliases">
@@ -4836,6 +4893,11 @@ In the following sections, when a type name precedes a parenthesized argument li
     // Same as writing vec3<f32>()
     // Computes vec3<f32>(0.0f, 0.0f, 0.0f)
     const threeD_zero = my_vec3f();
+
+    // Use the fully-elaborated name for a 4-element vector of f32.
+    const fourD_ones_first  = vec4<f32>(1.0f);
+    // Use vec4f, the predeclared alias to vec4<f32>.
+    const fourD_ones_second = vec4f(1.0f);
   </xmp>
 </div>
 


### PR DESCRIPTION
Fixes: #736