### PR TITLE
Rework WGSL grammar to make it nicer for recursive descent

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2028,7 +2028,7 @@ Some consequences of the restrictions structure member and array element types a
 <div class='syntax' noexport='true'>
   <dfn for=syntax>struct_body_decl</dfn> :
 
-    | [=syntax/brace_left=] ( [=syntax/struct_member=] [=syntax/comma=] ) * [=syntax/struct_member=] [=syntax/comma=] ? [=syntax/brace_right=]
+    | [=syntax/brace_left=] ( [=syntax/struct_member=] ( [=syntax/comma=] [=syntax/struct_member=] ) * [=syntax/comma=] ? ) ? [=syntax/brace_right=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>struct_member</dfn> :
@@ -4302,19 +4302,19 @@ such that the redundant loads are eliminated.
 
     | [=syntax/variable_decl=] [=syntax/equal=] [=syntax/expression=]
 
-    | [=syntax/let=] ( [=syntax/ident=] | [=syntax/variable_ident_decl=] ) [=syntax/equal=] [=syntax/expression=]
+    | [=syntax/let=] [=syntax/optionally_typed_ident=] [=syntax/equal=] [=syntax/expression=]
 
-    | [=syntax/const=] ( [=syntax/ident=] | [=syntax/variable_ident_decl=] ) [=syntax/equal=] [=syntax/expression=]
+    | [=syntax/const=] [=syntax/optionally_typed_ident=] [=syntax/equal=] [=syntax/expression=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>variable_decl</dfn> :
 
-    | [=syntax/var=] [=syntax/variable_qualifier=] ? ( [=syntax/ident=] | [=syntax/variable_ident_decl=] )
+    | [=syntax/var=] [=syntax/variable_qualifier=] ? [=syntax/optionally_typed_ident=]
 </div>
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>variable_ident_decl</dfn> :
+  <dfn for=syntax>optionally_typed_ident</dfn> :
 
-    | [=syntax/ident=] [=syntax/colon=] [=syntax/type_decl=]
+    | [=syntax/ident=] ( [=syntax/colon=] [=syntax/type_decl=] ) ?
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>variable_qualifier</dfn> :
@@ -4331,9 +4331,9 @@ such that the redundant loads are eliminated.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>global_constant_decl</dfn> :
 
-    | [=syntax/const=] ( [=syntax/ident=] | [=syntax/variable_ident_decl=] ) [=syntax/equal=] [=syntax/expression=]
+    | [=syntax/const=] [=syntax/optionally_typed_ident=] [=syntax/equal=] [=syntax/expression=]
 
-    | [=syntax/attribute=] * [=syntax/override=] ( [=syntax/ident=] | [=syntax/variable_ident_decl=] ) ( [=syntax/equal=] [=syntax/expression=] ) ?
+    | [=syntax/attribute=] * [=syntax/override=] [=syntax/optionally_typed_ident=] ( [=syntax/equal=] [=syntax/expression=] ) ?
 </div>
 
 # Expressions # {#expressions}
@@ -6095,7 +6095,7 @@ When an identifier is used as a [=syntax/callable=] item, it is one of:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>argument_expression_list</dfn> :
 
-    | [=syntax/paren_left=] ( ( [=syntax/expression=] [=syntax/comma=] ) * [=syntax/expression=] [=syntax/comma=] ? ) ? [=syntax/paren_right=]
+    | [=syntax/paren_left=] ( [=syntax/expression=] ( [=syntax/comma=] [=syntax/expression=] ) * [=syntax/comma=] ? ) ? [=syntax/paren_right=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>postfix_expression</dfn> :
@@ -6143,20 +6143,31 @@ When an identifier is used as a [=syntax/callable=] item, it is one of:
 
     | [=syntax/unary_expression=]
 
-    | [=syntax/multiplicative_expression=] [=syntax/star=] [=syntax/unary_expression=]
+    | [=syntax/multiplicative_expression=] [=syntax/multiplicative_operator=] [=syntax/unary_expression=]
 
-    | [=syntax/multiplicative_expression=] [=syntax/forward_slash=] [=syntax/unary_expression=]
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>multiplicative_operator</dfn> :
 
-    | [=syntax/multiplicative_expression=] [=syntax/modulo=] [=syntax/unary_expression=]
+    | [=syntax/star=]
+
+    | [=syntax/forward_slash=]
+
+    | [=syntax/modulo=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>additive_expression</dfn> :
 
     | [=syntax/multiplicative_expression=]
 
-    | [=syntax/additive_expression=] [=syntax/plus=] [=syntax/multiplicative_expression=]
+    | [=syntax/additive_expression=] [=syntax/additive_operator=] [=syntax/multiplicative_expression=]
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>additive_operator</dfn> :
 
-    | [=syntax/additive_expression=] [=syntax/minus=] [=syntax/multiplicative_expression=]
+    | [=syntax/plus=]
+
+    | [=syntax/minus=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>shift_expression</dfn> :
@@ -7659,12 +7670,12 @@ The [=return type=], if specified, [=shader-creation error|must=] be [=construct
 <div class='syntax' noexport='true'>
   <dfn for=syntax>param_list</dfn> :
 
-    | ( [=syntax/param=] [=syntax/comma=] ) * [=syntax/param=] [=syntax/comma=] ?
+    | [=syntax/param=] ( [=syntax/comma=] [=syntax/param=] ) * [=syntax/comma=] ?
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>param</dfn> :
 
-    | [=syntax/attribute=] * [=syntax/variable_ident_decl=]
+    | [=syntax/attribute=] * [=syntax/ident=] [=syntax/colon=] [=syntax/type_decl=]
 </div>
 
 WGSL defines the following attributes that can be applied to function declarations:

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2028,7 +2028,7 @@ Some consequences of the restrictions structure member and array element types a
 <div class='syntax' noexport='true'>
   <dfn for=syntax>struct_body_decl</dfn> :
 
-    | [=syntax/brace_left=] ( [=syntax/struct_member=] ( [=syntax/comma=] [=syntax/struct_member=] ) * [=syntax/comma=] ? ) ? [=syntax/brace_right=]
+    | [=syntax/brace_left=] [=syntax/struct_member=] ( [=syntax/comma=] [=syntax/struct_member=] ) * [=syntax/comma=] ? [=syntax/brace_right=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>struct_member</dfn> :


### PR DESCRIPTION
Contributes to #3286

1.
Make certain productions amenable for recursive descent

Avoid this kind of pattern:

   (x y) * x

When you see a substring that would match 'x', you don't know
if it should match the first or second 'x' in that phrase.

Rewrite it something like this, to put the certain match against 'x'
first.

   x (y x) *

In particular, rewrite these rules:
- struct_body_decl
- argument_expression_list
- param_list

2. Introduce additive_operator, multiplicative_operator

This helps eliminate epsilons in the left-recursive form of the grammar

3. Create optionally_typed_ident, and use it to replace
(ident | variable_ident_decl) pattern which became common
because of type inferencing rules.

Also expand last remaining use of variable_ident_decl, for formal
parameter declaration.