### PR TITLE
[editorial] Fix markdown

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2046,8 +2046,8 @@ The following attributes can be applied to structure members:
 
 Attributes [=attribute/builtin=], [=attribute/location=], [=attribute/interpolate=], and [=attribute/invariant=]
 are [=IO attributes=].
-An [=IO attribute=] on a member of a structure _S_ has effect only when
-_S_ is used as the type of a [=formal parameter=] or [=return type=] of an [=entry point=].
+An [=IO attribute=] on a member of a structure *S* has effect only when
+*S* is used as the type of a [=formal parameter=] or [=return type=] of an [=entry point=].
 See [[#pipeline-inputs-outputs]].
 
 Attributes [=attribute/align=] and [=attribute/size=] are [=layout attributes=],
@@ -3654,8 +3654,8 @@ sampler_comparison
 A <dfn noexport>type alias</dfn> declares a new name for an existing type.
 The declaration [=shader-creation error|must=] appear at [=module scope=], and its [=scope=] is the entire program.
 
-When type _T_ is defined as a [=type alias=] for a structure type _S_,
-all properties of the members of _S_, including attributes, carry over to the members of _T_.
+When type *T* is defined as a [=type alias=] for a structure type *S*,
+all properties of the members of *S*, including attributes, carry over to the members of *T*.
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>type_alias_decl</dfn> :


### PR DESCRIPTION
* Use asterisks (emphasis) instead of underscores to render properly