### PR TITLE
Disallow duplicated built-in inputs and outputs

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8061,6 +8061,7 @@ The <dfn noexport>IO attributes</dfn> are:
 
 A <dfn noexport>built-in input value</dfn> provides access to system-generated control information.
 The set of built-in inputs are listed in [[#builtin-values]].
+An entry point [=shader-creation error|must=] not contain duplicated built-in inputs.
 
 A built-in input for stage *S* with name *X* and type *T*<sub>*X*</sub> is accessed via a
 [=formal parameter=] to an [=entry point=] for [=shader stage=] *S*, in one of two ways:
@@ -8074,6 +8075,7 @@ the corresponding builtin [=shader-creation error|must=] be an input for the ent
 A <dfn noexport>built-in output value</dfn> is used by the shader to convey
 control information to later processing steps in the pipeline.
 The set of built-in outputs are listed in [[#builtin-values]].
+An entry point [=shader-creation error|must=] not contain duplicated built-in outputs.
 
 A built-in output for stage *S* with name *Y* and type *T*<sub>*Y*</sub> is set via the [=return value=] for an
 [=entry point=] for [=shader stage=] *S*, in one of two ways:


### PR DESCRIPTION
Fixes #3236

* Shader-creation error to duplicate built-in inputs or outputs

Separate errors to avoid confusion for using a built-in value as both input and output (e.g. `sample_mask`).