### PR TITLE
[editorial] Fixes for declaration and scope

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1022,7 +1022,7 @@ See [[#enable-directive-section]].
     | [=syntax/enable_directive=]
 </div>
 
-## Declaration and Scope ## {#declaration-and-scope}
+# Declaration and Scope # {#declaration-and-scope}
 
 A <dfn noexport>declaration</dfn> associates an [=identifier=] with one of
 the following kinds of objects:
@@ -1058,7 +1058,7 @@ We say the identifier is <dfn noexport>in scope</dfn>
 Where a declaration appears determines its scope:
 * Predeclared objects, and objects declared at module-scope, are [=in scope=] across the entire program source.
 * Otherwise, the scope is a span of text beginning immediately after the end of the declaration.
-    For details, see [[#var-decls]], and the declaration of [=formal parameters=] in [[#function-declaration-sec]].
+    For details, see [[#var-and-value]], and the declaration of [=formal parameters=] in [[#function-declaration-sec]].
 
 Two declarations in the same WGSL source program [=shader-creation error|must not=] simultaneously:
 * introduce the same identifier name, and
@@ -1116,7 +1116,7 @@ that identifier in the text.
 
 <div class='example wgsl' heading='Valid and invalid declarations'>
   <xmp highlight='rust'>
-    // Invalid, cannot reuse built-in function names (modf in this case).
+    // Valid, user-defined variables can have the same name as a built-in function.
     var<private> modf: f32 = 0.0;
 
     // Valid, foo_1 is in scope for the entire program.
@@ -1130,6 +1130,9 @@ that identifier in the text.
     fn my_func(foo: f32) { // my_func_1, foo_2
       // Any reference to 'foo' resolves to the function parameter.
 
+      // Invalid, modf resolves to the module-scope variable.
+      let res = modf(foo);
+
       // Invalid, the scope of foo_2 ends at the of the function.
       var foo: f32; // foo_3
 
@@ -1137,6 +1140,9 @@ that identifier in the text.
       var bar: u32; // bar_2
       // References to 'bar' resolve to bar_2
       {
+        // Valid, foo_4 is in scope until the end of the compound statement.
+        var foo : f32; // foo_4
+
         // Valid, bar_3 is in scope until the end of the compound statement.
         var bar: u32; // bar_3
         // References to 'bar' resolve to bar_3


### PR DESCRIPTION
Fixes #2933
Fixes #2934

* Make Declaration and Scope into its own chapter
* Fix example about shadowing built-in function
  * add invalid example of using shadowed built-in function
* Add valid example of shadowed parameter
* Fix link for describing for scoping to right section