### PR TITLE
Clarify stores to invalid memory references

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2930,6 +2930,8 @@ The originating variable for a formal parameter of a function depends on the
 [=call site|call sites=] for the function.
 Different call sites may supply pointers into different originating variables.
 
+### Invalid Memory Reference ### {#invalid-mem-reference}
+
 If a reference or pointer access is out of bounds, an
 <dfn noexport>invalid memory reference</dfn> is produced.
 [=Load Rule|Loads=] from an invalid reference return one of:
@@ -2942,9 +2944,13 @@ If a reference or pointer access is out of bounds, an
     * if the loaded value is a vector, the value (0, 0, 0, x), where x is:
         * 0, 1, or the maximum positive value for integer components
         * 0.0 or 1.0 for floating-point components
-[=statement/assignment|Stores=] to an invalid reference may either:
-    * store the value to any [=memory locations|memory location(s)=] of the
+[=statement/assignment|Stores=] to an invalid reference may do one of:
+    * when the [=originating variable=] is a [=uniform buffer=] or a [=storage buffer=],
+        store the value to any [=memory locations|memory location(s)=] of the
         [[WebGPU#buffers|WebGPU buffer]] bound to the [=originating variable=]
+    * when the [=originating variable=] is not a [=uniform buffer=] or [=storage buffer=],
+        store the value to any [=memory locations|memory locations(s)=] in the
+        originating variable
     * not be executed
 It is a [=dynamic error=] if [[#atomic-rmw|read-modify-write atomics]] that
 operate on an invalid memory reference load and store from different [=memory


### PR DESCRIPTION
Fixes #3128

* Pull invalid memory reference into its own subsection
* Clarify stores similar to previous load clarification