### PR TITLE
[editorial] Add links in the atomic types section

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1824,7 +1824,7 @@ See [[#arithmetic-expr]].
 ### Atomic Types ### {#atomic-types}
 
 An <dfn noexport>atomic type</dfn> encapsulates a [=type/concrete=] [=integer scalar=] type such that:
-* atomic objects provide certain guarantees to concurrent observers, and
+* atomic objects provide [[#memory-model|certain guarantees]] to concurrent observers, and
 * the only valid operations on atomic objects are the [[#atomic-builtin-functions|atomic builtin functions]].
 
 <table class='data'>
@@ -1841,9 +1841,9 @@ Atomic types may only be instantiated by variables in the [=address spaces/workg
 address space or by [=storage buffer=] variables with a [=access/read_write=] access mode.
 The [=memory scope=] of operations on the type is determined by the [=address space=]
 it is instantiated in.
-Atomic types in the [=address spaces/workgroup=] address space have a memory
-scope of `Workgroup`, while those in the [=address spaces/storage=]
-address space have a memory scope of `QueueFamily`.
+Atomic types in the [=address spaces/workgroup=] address space have a
+[[#scoped-operations|memory scope]] of `Workgroup`, while those in the
+[=address spaces/storage=] address space have a memory scope of `QueueFamily`.
 
 An <dfn noexport>atomic modification</dfn> is any
 [[#memory-operation|operation]] on an atomic object which sets the content of


### PR DESCRIPTION
Fixes #2979
Fixes #2978

* Links certain guarantees to the memory model section
* Links memory scopes to scoped operations instead of trying to define
  the Workgroup and QueueFamily scopes