### PR TITLE
[editorial] Replace uses of integral as a type

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1568,7 +1568,7 @@ A [=numeric literal=] without a suffix denotes a value in an [=abstract numeric 
 
 Example:  The expression `log2(32)` is analyzed as follows:
 * `log2(32)` is parsed as a function call to the `log2` builtin function with operand [=AbstractInt=] value 32.
-* There is no overload of `log2` with an integral scalar formal parameter.
+* There is no overload of `log2` with an [=integer scalar=] formal parameter.
 * Instead [=overload resolution=] applies, considering two possible overloads and [=feasible automatic conversions=]:
     * [=AbstractInt=] to [=AbstractFloat=]. (Conversion rank 4)
     * [=AbstractInt=] to [=f32=]. (Conversion rank 5)
@@ -1576,7 +1576,7 @@ Example:  The expression `log2(32)` is analyzed as follows:
 
 Example:  The expression `1 + 2.5` is analyzed as follows:
 * `1 + 2.5` is parsed as an addition operation with subexpressions [=AbstractInt=] value 1, and [=AbstractFloat=] value 2.5.
-* There is no overload for |e|+|f| where |e| is integral and |f| is floating point.
+* There is no overload for |e|+|f| where |e| is integer type and |f| is floating point.
 * However, using feasible automic conversions, there are two potential overloads:
     * `1` is converted to [=AbstractFloat=] value `1.0` (rank 4) and `2.5` remains an [=AbstractFloat=] (rank 0).
     * `1` is converted to [=f32=] value `1.0f` (rank 5) and `2.5` is converted to [=f32=] value `2.5f` (rank 1).
@@ -1592,8 +1592,8 @@ Example:  `1u + 2.5` results in a [=shader-creation error=]:
 * The `1u` term is an expression of type [=u32=].
 * The `2.5` term is an expression of type [=AbstractFloat=].
 * There are no valid overload candidates:
-    * There is no feaisble automatic conversion from a GPU-materialized integral type to a floating point type.
-    * No type rule matches *e*`+`*f* with *e* in an integral type, and *f* in a floating point type.
+    * There is no feaisble automatic conversion from a GPU-materialized [=integer scalar=] type to a floating point type.
+    * No type rule matches *e*`+`*f* with *e* in an [=integer scalar=] type, and *f* in a floating point type.
 
 <div class='example literals' heading="Type inference for literals">
   <xmp highlight='rust'>
@@ -5591,7 +5591,7 @@ See [[#sync-builtin-functions]].
   vec|N|&lt;AbstractFloat&gt;, vec|N|&lt;i32&gt;, vec|N|&lt;f32&gt;, or vec|N|&lt;f16&gt;
   <td>`-`|e|`:` |T|
   <td>Negation. [=Component-wise=] when |T| is a vector.
-  If |T| is an integral type and |e| evaluates to the largest negative value, then the result is |e|.
+  If |T| is an [=integer scalar=] type and |e| evaluates to the largest negative value, then the result is |e|.
 </table>
 
 <table class='data'>
@@ -5604,26 +5604,26 @@ See [[#sync-builtin-functions]].
     <td>|e1| : |T|<br>|e2| : |T|<br>[ALLNUMERICDECL]
     <td>|e1| `+` |e2| : |T|
     <td>Addition. [=Component-wise=] when |T| is a vector.
-    If |T| is a [=type/concrete=] integral type, then the result is modulo 2<sup>32</sup>.
+    If |T| is a [=type/concrete=] [=integer scalar=] type, then the result is modulo 2<sup>32</sup>.
 
   <tr algorithm="subtraction">
     <td>|e1| : |T|<br>|e2| : |T|<br>[ALLNUMERICDECL]
     <td>|e1| `-` |e2| : |T|
     <td>Subtraction [=Component-wise=] when |T| is a vector.
-    If |T| is a [=type/concrete=] integral type, then the result is modulo 2<sup>32</sup>.
+    If |T| is a [=type/concrete=] [=integer scalar=] type, then the result is modulo 2<sup>32</sup>.
 
   <tr algorithm="multiplication">
     <td>|e1| : |T|<br>|e2| : |T|<br>[ALLNUMERICDECL]
     <td>|e1| `*` |e2| : |T|
     <td>Multiplication. [=Component-wise=] when |T| is a vector.
-    If |T| is a [=type/concrete=] integral type, then the result is modulo 2<sup>32</sup>.
+    If |T| is a [=type/concrete=] [=integer scalar=] type, then the result is modulo 2<sup>32</sup>.
 
   <tr algorithm="division">
     <td>|e1| : |T|<br>|e2| : |T|<br>[ALLNUMERICDECL]
     <td>|e1| `/` |e2| : |T|
     <td>Division. [=Component-wise=] when |T| is a vector.
 
-        If |T| is a signed integral type, the scalar case, evaluates to:
+        If |T| is a signed [=integer scalar=] type, evaluates to:
         * |e1|, when |e2| is zero.
         * |e1|, when |e1| is the most negative value in |T|, and |e2| is -1.
         * [=truncate=](|x|) otherwise, where |x| is the
@@ -5640,7 +5640,7 @@ See [[#sync-builtin-functions]].
                result is truncate(e1/Divisor)
         -->
 
-        If |T| is an unsigned integral type, the scalar case, evaluates to:
+        If |T| is an unsigned [=integer scalar=] type, evaluates to:
         * |e1|, when |e2| is zero.
         * Otherwise, the integer |q| such that
             |e1|&nbsp;=&nbsp;|q|&nbsp;&times;&nbsp;|e2|&nbsp;+&nbsp;|r|,
@@ -5651,7 +5651,7 @@ See [[#sync-builtin-functions]].
     <td>|e1| `%` |e2| : |T|
     <td>Remainder. [=Component-wise=] when |T| is a vector.
 
-       If |T| is a signed integral scalar type, evaluates |e1| and |e2| once, and evaluates to:
+       If |T| is a signed [=integer scalar=] type, evaluates |e1| and |e2| once, and evaluates to:
        * 0, when |e2| is zero.
        * 0, when |e1| is the most negative value in |T|, and |e2| is -1.
        * Otherwise, |e1|&nbsp;-&nbsp;[=truncate=](|e1|&nbsp;&div;&nbsp;|e2|)&nbsp;&times;&nbsp;|e2|
@@ -5670,7 +5670,7 @@ See [[#sync-builtin-functions]].
                result is e1 - truncate(e1/Divisor) * Divisor
         -->
 
-        If |T| is an unsigned integral scalar type, evaluates to:
+        If |T| is an unsigned [=integer scalar=] scalar type, evaluates to:
         * 0, when |e2| is zero.
         * Otherwise, the integer |r| such that
             |e1|&nbsp;=&nbsp;|q|&nbsp;&times;&nbsp;|e2|&nbsp;+&nbsp;|r|,
@@ -9247,7 +9247,7 @@ In this section, a floating point type may be any of:
 
 Note: Recall that the [=f32=] WGSL type corresponds to the IEEE-754 binary32 format, and the [=f16=] WGSL type corresponds to the IEEE-754 binary16 format.
 
-When converting a floating point scalar value to an integral type:
+When converting a floating point scalar value to an [=integer scalar=] type:
 * If the original value is exactly representable in the destination type, then the result is that value.
 * Otherwise, the original value is rounded toward zero.
     * If the rounded value is exactly representable in the destination type, the result is that value.
@@ -9264,7 +9264,7 @@ Therefore the maximum u32 value resulting from a floating point conversion is 42
 
 When converting a value to a floating point type:
 * If the original value is exactly representable in the destination type, then the result is that value.
-    * Additionally, if the original value is zero and of integral type, then the resulting value has a zero sign bit.
+    * Additionally, if the original value is zero and of [=integer scalar=] type, then the resulting value has a zero sign bit.
 * Otherwise, the original value is not exactly representable.
     * If the original value is different from but lies between two adjacent finite values representable in the destination type,
          then the result is one of those two values.
@@ -10823,8 +10823,8 @@ fn arrayLength(p: ptr<storage, array<E>, AM>) -> u32
     [=Component-wise=] when `T` is a vector.
 
     If `e` is a floating-point type, then the result is `e` with a positive sign bit.
-    If `e` is an unsigned integral type, then the result is `e`.
-    If `e` is a signed integral scalar type and evaluates to the largest
+    If `e` is an unsigned [=integer scalar=] type, then the result is `e`.
+    If `e` is a signed [=integer scalar=] type and evaluates to the largest
     negative value, then the result is `e`.
 </table>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5670,7 +5670,7 @@ See [[#sync-builtin-functions]].
                result is e1 - truncate(e1/Divisor) * Divisor
         -->
 
-        If |T| is an unsigned [=integer scalar=] scalar type, evaluates to:
+        If |T| is an unsigned [=integer scalar=] type, evaluates to:
         * 0, when |e2| is zero.
         * Otherwise, the integer |r| such that
             |e1|&nbsp;=&nbsp;|q|&nbsp;&times;&nbsp;|e2|&nbsp;+&nbsp;|r|,


### PR DESCRIPTION
Fixes #3133

* Replace uses of integral type with integer scalar in most places