### PR TITLE
Lower the maximum binding index in createBindGroupLayout to 640

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5127,7 +5127,7 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                         <div class=validusage>
                             - |this| is [=valid=].
                             - The {{GPUBindGroupLayoutEntry/binding}} of each entry in |descriptor| is unique.
-                            - The {{GPUBindGroupLayoutEntry/binding}} of each entry in |descriptor| must be &lt; 65536.
+                            - The {{GPUBindGroupLayoutEntry/binding}} of each entry in |descriptor| must be &lt; 640.
                             - |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}} must not
                                 [=exceeds the binding slot limits|exceed the binding slot limits=]
                                 of |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.


### PR DESCRIPTION
See #3279

I suppose this should be properly discussed/approved at a standards meeting before being merged. In the mean time here is the proposed change.