### PR TITLE
[editorial] Function chapter clarifications

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7672,6 +7672,7 @@ A <dfn noexport>function declaration</dfn> creates a user-defined function, by s
 * The name of the function.
 * The formal parameter list: an ordered sequence of zero
     or more [=formal parameter=] declarations,
+    which may have attributes applied,
     separated by commas, and
     surrounded by parentheses.
 * An optional <dfn noexport>return type</dfn>, which may have attributes applied.
@@ -7694,6 +7695,17 @@ functions.
 
 The [=return type=], if specified, [=shader-creation error|must=] be [=constructible=].
 
+WGSL defines the following attributes that can be applied to function declarations:
+ * the [=pipeline stage attributes=]: [=attribute/vertex=], [=attribute/fragment=], and [=attribute/compute=]
+ * [=attribute/workgroup_size=]
+
+WGSL defines the following attributes that can be applied to function
+parameters and return types:
+ * [=attribute/builtin=]
+ * [=attribute/location=]
+ * [=attribute/interpolate=]
+ * [=attribute/invariant=]
+
 <div class='syntax' noexport='true'>
   <dfn for=syntax>function_decl</dfn> :
 
@@ -7714,15 +7726,6 @@ The [=return type=], if specified, [=shader-creation error|must=] be [=construct
 
     | [=syntax/attribute=] * [=syntax/ident=] [=syntax/colon=] [=syntax/type_decl=]
 </div>
-
-WGSL defines the following attributes that can be applied to function declarations:
- * the [=pipeline stage attributes=]: [=attribute/vertex=], [=attribute/fragment=], and [=attribute/compute=]
- * [=attribute/workgroup_size=]
-
-WGSL defines the following attributes that can be applied to function
-parameters and return types:
- * [=attribute/builtin=]
- * [=attribute/location=]
 
 <div class='example wgsl' heading='Simple functions'>
   <xmp highlight='rust'>
@@ -7779,13 +7782,14 @@ In detail, when a function call is executed the following steps occur:
     All [=function scope=] variables and constants maintain their current values.
 3. If the called function is [=user-defined function|user-defined=],
     memory is allocated for each function scope variable in the called function.
-    * Initialization occurs as described in [[#var-and-value]].
+    * Initialization occurs as described in [[#var-decls]].
 4. Values for the formal parameters of the called function are determined
     by matching the function call argument values by position.
-    For example, in the body of the called function the first formal parameter will denote
+    For example, the first formal parameter of the called function will have
     the value of the first argument at the [=call site=].
-5. If the called function is [=user-defined function|user-defined=],
-    control is transferred to the first statement in its [=function body|body=].
+5. Control is transferred to the called function.
+    If the called function is [=user-defined function|user-defined=], execution
+    proceeds starting from the first statement in the [=function body|body=].
 6. The called function is executed, until it [=returns=].
 7. Control is transferred back to the calling function, and the called function's execution is
     unsuspended.
@@ -7795,6 +7799,10 @@ In detail, when a function call is executed the following steps occur:
 The location of a function call is referred to as a <dfn noexport>call site</dfn>.
 Call sites are a [=dynamic context=].
 As such, the same textual location may represent multiple call sites.
+
+Note: It is possible that a function call in a [=fragment=] shader never
+returns if all of the invocations in a [=quad=] are [=discard|discarded=].
+In such a case, control will not be tranferred back to the calling function.
 
 ## `const` Functions ## {#const-funcs}
 


### PR DESCRIPTION
Contributes to #3193
Fixes #3194
Fixes #3196
Fixes #3197
Fixes #3198

* Clarify that parameters may have attributes
* Move list of attributes above the examples to improve locality
* Clarify function execution