### PR TITLE
Remove fallthrough statements

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6308,11 +6308,10 @@ from the start of the next statement until the end of the compound statement.
     | [=syntax/brace_left=] [=syntax/statement=] * [=syntax/brace_right=]
 </div>
 
-There are two special forms of compound statement:
-* a [=syntax/continuing_compound_statement=] forms the body of a [[#continuing-statement|continuing]] statement,
-     and allows an optional [[#break-if-statement|break-if]] statement at the end.
-* a [=syntax/case_compound_statement=] forms the body of a `case` or `default` clause in a [[#switch-statement|switch]] statement,
-     and allows an optional [=syntax/fallthrough_statement|fallthrough=] statement at the end.
+The [=syntax/continuing_compound_statement=] is a special form of compound
+statement that forms the body of a [[#continuing-statement|continuing]]
+statement, and allows an option [[#break-if-statement|break-if]] statement at
+the end.
 
 ## Assignment Statement ## {#assignment}
 
@@ -6682,24 +6681,22 @@ An `if` statement is executed as follows:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>switch_body</dfn> :
 
-    | [=syntax/case=] [=syntax/case_selectors=] [=syntax/colon=] ? [=syntax/case_compound_statement=]
+    | [=syntax/case=] [=syntax/case_selectors=] [=syntax/colon=] ? [=syntax/compound_statement=]
 
-    | [=syntax/default=] [=syntax/colon=] ? [=syntax/case_compound_statement=]
+    | [=syntax/default=] [=syntax/colon=] ? [=syntax/compound_statement=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>case_selectors</dfn> :
 
-    | [=syntax/expression=] ( [=syntax/comma=] [=syntax/expression=] ) * [=syntax/comma=] ?
+    | [=syntax/case_selector=] ( [=syntax/comma=] [=syntax/case_selector=] ) * [=syntax/comma=] ?
 </div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>case_compound_statement</dfn> :
 
-    | [=syntax/brace_left=] [=syntax/statement=] * [=syntax/fallthrough_statement=] ? [=syntax/brace_right=]
-</div>
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>fallthrough_statement</dfn> :
+  <dfn for=syntax>case_selector</dfn> :
 
-    | [=syntax/fallthrough=] [=syntax/semicolon=]
+    | [=syntax/default=]
+
+    | [=syntax/expression=]
 </div>
 
 A <dfn noexport dfn-for="statement">switch</dfn> statement transfers control to one of a set of case clauses, or to the `default` clause,
@@ -6724,15 +6721,8 @@ For example `0` and `0x0000` both denote the zero value.
 
 When control reaches the end of a case body, control normally transfers to the first statement
 after the switch statement.
-Alternately, executing a <dfn noexport dfn-for="statement">fallthrough</dfn> statement
-transfers control to the body of the next case clause or
-default clause, whichever appears next in the switch body.
-A `fallthrough` statement [=shader-creation error|must not=] appear as the last statement in the last clause of a switch.
 When a [=declaration=] appears in a case body, its [=identifier=] is [=in scope=] from
 the start of the next statement until the end of the case body.
-
-Note: Identifiers declared in a case body are not [=in scope=] of case bodies
-which are reachable via a `fallthrough` statement.
 
 <div class='example wgsl function-scope' heading='WGSL Switch'>
   <xmp highlight='rust'>
@@ -6747,9 +6737,27 @@ which are reachable via a `fallthrough` statement.
       }
       case 1, 2 {    // multiple selector values can be used
         a = 3;       // a will be overridden in the next case
-        fallthrough;
       }
       case 3 {
+        a = 4;
+      }
+    }
+  </xmp>
+</div>
+
+<div class='example wgsl function-scope' heading='WGSL Switch with default combined'>
+  <xmp highlight='rust'>
+    const c = 2;
+    var a : i32;
+    let x : i32 = generateValue();
+    switch x {
+      case 0: {
+        a = 1;
+      }
+      case 1, c {       // Const-expression can be used in case selectors
+        a = 3;
+      }
+      case 3, default { // The default keyword can be used with other clauses
         a = 4;
       }
     }
@@ -7267,17 +7275,15 @@ The [=syntax/statement=] rule matches statements that can be used in most places
 
 Additionally, certain statements may only be used in very specific contexts:
 * [=syntax/break_if_statement=]
-* [=syntax/case_compound_statement=]
 * [=syntax/continuing_compound_statement=]
-* [=syntax/fallthrough_statement=]
 
 ## Statements Behavior Analysis ## {#behaviors}
 
 ### Rules ### {#behaviors-rules}
 
 Some statements affecting control-flow are only valid in some contexts.
-For example, [=statement/fallthrough=] is invalid outside of a [=statement/switch=],
-and [=statement/continue=] is invalid outside of a [=statement/loop=], [=statement/for=], or [=statement/while=].
+For example, [=statement/continue=] is invalid outside of a [=statement/loop=],
+[=statement/for=], or [=statement/while=].
 Additionally, the uniformity analysis (see [[#uniformity]]) needs to know when control flow can exit a statement in multiple different ways.
 
 Both goals are achieved by a system for summarizing execution behaviors of statements and expressions. Behavior analysis maps each statement and expression to the set of possible ways execution proceeds after evaluation of the statement or expression completes.
@@ -7287,7 +7293,6 @@ A <dfn export>behavior</dfn> is a set, whose elements may be:
 - Return
 - Break
 - Continue
-- Fallthrough
 - Next
 
 Each of those correspond to a way to exit a compound statement: either through a keyword, or by falling to the next statement ("Next").
@@ -7380,10 +7385,6 @@ non-empty [=behavior=] for each statement, and function.
     <td>continue;
     <td>
     <td>{Continue}
-  <tr algorithm="fallthrough behavior">
-    <td>fallthrough;
-    <td>
-    <td>{Fallthrough}
   <tr algorithm="if statement behavior">
     <td class="nowrap">if |e| |s1| else |s2|
     <td class="nowrap">
@@ -7411,17 +7412,15 @@ non-empty [=behavior=] for each statement, and function.
         |s1|: |B1|<br>
         ...<br>
         |sn|: |Bn|<br>
-        Fallthrough is not in |Bn|<br>
         Break is not in (|B1| &cup; ... &cup; |Bn|)
-    <td class="nowrap">(|B1| &cup; ... &cup; |Bn|)&#x2216;{Fallthrough}
+    <td class="nowrap">|B1| &cup; ... &cup; |Bn|
   <tr algorithm="switch with break behavior">
     <td class="nowrap">
         |s1|: |B1|<br>
         ...<br>
         |sn|: |Bn|<br>
-        Fallthrough is not in |Bn|<br>
         Break is in (|B1| &cup; ... &cup; |Bn|)
-    <td class="nowrap">(|B1| &cup; ... &cup; |Bn| &cup; {Next})&#x2216;{Break, Fallthrough}
+    <td class="nowrap">(|B1| &cup; ... &cup; |Bn| &cup; {Next})&#x2216;Break
 </table>
 
 Note: The empty statement case occurs when a `loop` has an empty body, or when a `for` loop lacks an initialization or update statement.
@@ -7451,7 +7450,6 @@ Here is the full list of ways that these rules can cause a program to be rejecte
 - The body of a function (treated as a regular statement) has a behavior not included in {Next, Return}.
 - The body of a function with a return type has a behavior which is not {Return}.
 - The behavior of a continuing block contains any of Continue, or Return.
-- The behavior of the last case of a switch contains Fallthrough.
 - Some obviously infinite loops have an empty behaviour set, and are therefore invalid.
 
 This analysis can be run in linear time, by analyzing the call-graph bottom-up (since the behavior of a function call can depend on the function's code).
@@ -7647,7 +7645,7 @@ Here are some examples showing this analysis in action:
     }                   // Error: Continue is invalid in the body of a function
    </xmp>
 </div>
-The same example would also be invalid for the same reason if `continue` was replaced by `break` or `fallthrough`.
+The same example would also be invalid for the same reason if `continue` was replaced by `break`.
 
 # Functions # {#functions}
 
@@ -8737,8 +8735,7 @@ When several edges have to be created we use `X -> {Y, Z}` as a short-hand for `
       <td rowspan=2 class="nowrap">(*CF*, *e*) => (*CF'*, *V*)<br>
         (*V*, *s_1*) => *CF_1*<br>
         ...<br>
-        if *s_(n-1)* may fallthrough, (*CF_(n-1)*, *s_n*) => *CF_n*<br>
-        else (*V*, *s_n*) => *CF_n*
+        (*V*, *s_n*) => *CF_n*
       <td>*CF*
       <td>
   <tr><td class="nowrap">switch *e* case _: *s_1* .. case _: *s_n*<br> with another behavior
@@ -8757,11 +8754,10 @@ When several edges have to be created we use `X -> {Y, Z}` as a short-hand for `
       <td>*CF'*
       <td>
   <tr><td class="nowrap">continue;
-      <td rowspan=4>
-      <td rowspan=4>
-      <td rowspan=4>*CF*
-      <td rowspan=4>
-  <tr><td class="nowrap">fallthrough;
+      <td rowspan=3>
+      <td rowspan=3>
+      <td rowspan=3>*CF*
+      <td rowspan=3>
   <tr><td class="nowrap">discard;
   <tr><td class="nowrap">return;
   <tr><td class="nowrap">return *e*;
@@ -9710,11 +9706,6 @@ Issue: https://github.com/gpuweb/gpuweb/issues/1621
     | `'enable'`
 </div>
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>fallthrough</dfn> :
-
-    | `'fallthrough'`
-</div>
-<div class='syntax' noexport='true'>
   <dfn for=syntax>false</dfn> :
 
     | `'false'`
@@ -9924,6 +9915,8 @@ The following are reserved words:
     | `'extern'`   <!-- C++ Rust HLSL GLSL(reserved) -->
 
     | `'external'`   <!-- GLSL(reserved) -->
+
+    | `'fallthrough'`   <!-- WGSL -->
 
     | `'filter'`   <!-- GLSL(reserved) -->
 


### PR DESCRIPTION
Fixes #3294

* Remove fallthrough statements
  * remove from statement and uniformity analyses
* remove case_compound_statement and just use a regular compound
  statement
* allow default to be used with other case selectors
  * add example of that and const-expression selector