### PR TITLE
Clarify default mixed in with cases, fix rule about duplicate case values

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6673,6 +6673,9 @@ An `if` statement is executed as follows:
 
 ### Switch Statement ### {#switch-statement}
 
+A <dfn noexport dfn-for="statement">switch</dfn> statement transfers control to one of a set of [=case clauses=], or to the [=default clause=],
+depending on the evaluation of a selector expression.
+
 <div class='syntax' noexport='true'>
   <dfn for=syntax>switch_statement</dfn> :
 
@@ -6681,7 +6684,17 @@ An `if` statement is executed as follows:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>switch_body</dfn> :
 
+    | [=syntax/case_clause=]
+
+    | [=syntax/default_alone_clause=]
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>case_clause</dfn> :
+
     | [=syntax/case=] [=syntax/case_selectors=] [=syntax/colon=] ? [=syntax/compound_statement=]
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>default_alone_clause</dfn> :
 
     | [=syntax/default=] [=syntax/colon=] ? [=syntax/compound_statement=]
 </div>
@@ -6699,30 +6712,43 @@ An `if` statement is executed as follows:
     | [=syntax/expression=]
 </div>
 
-A <dfn noexport dfn-for="statement">switch</dfn> statement transfers control to one of a set of case clauses, or to the `default` clause,
-depending on the evaluation of a selector expression.
+A <dfn noexport>case clause</dfn> is the [=syntax/case=] token followed by a list of [=syntax/case_selectors=] and a
+<dfn noexport>case body</dfn> in the form of a [=compound statement=].
 
-If the selector value equals a value in a case selector list, then control is transferred to
-the body of that case clause.
-The expressions in the [=syntax/case_selectors=] [=shader-creation error|must=]
-be [=const-expressions=].
-If the selector value does not equal any of the case selector values, then control is
-transferred to the `default` clause.
+A <dfn noexport>default-alone clause</dfn> is the [=syntax/default=] token followed by a <dfn noexport>default-alone body</dfn>
+in the form of a [=compound statement=].
 
-Each switch statement [=shader-creation error|must=] have exactly one default clause.
+A <dfn noexport>default clause</dfn> is either:
+* a [=case clause=] where [=syntax/default=] appears as one of its selectors, or
+* a [=default-alone clause=].
+
+Each switch statement [=shader-creation error|must=] have exactly one [=default clause=].
+
+The [=syntax/default=] token [=shader-creation error|must=] not appear more than once in a single [=syntax/case_selector=] list.
 
 [=Type rule precondition=]:
 For a single switch statement, the selector expression and all case selector expressions [=shader-creation error|must=] be of the same [=type/concrete=] [=integer scalar=] type.
 
-A literal value [=shader-creation error|must not=] appear more than once in the case selectors for a switch statement.
+The expressions in the [=syntax/case_selectors=] [=shader-creation error|must=]
+be [=const-expressions=].
 
-Note: The value of the literal is what matters, not the spelling.
-For example `0` and `0x0000` both denote the zero value.
+Two different case selector expressions in the same switch statement [=shader-creation error|must not=] have the same value.
 
-When control reaches the end of a case body, control normally transfers to the first statement
+If the selector value equals the value of an expression in a [=syntax/case_selector=] list,
+then control is transferred to the body of that [=case clause=].
+If the selector value does not equal any of the case selector values, then control is
+transferred to the body of the [=default clause=].
+
+When control reaches the end of a [=case body=] or [=default-alone body=], control transfers to the first statement
 after the switch statement.
-When a [=declaration=] appears in a case body, its [=identifier=] is [=in scope=] from
-the start of the next statement until the end of the case body.
+
+When one of the statements in the [=case body=] or a [=default-alone body=] is a [=declaration=],
+it follows the normal [=scope=] and [=lifetime=] rules of a declaration in a [=compound statement=].
+That is, the body is a sequence of statements, and if one of those is a declaration
+then the scope of that declaration extends from the start of the next statement in the sequence
+until the end of the body.
+The declaration executes when it is reached,
+creating a new instance of the [=variable declaration|variable=] or [=value declaration|value=], and initializes it.
 
 <div class='example wgsl function-scope' heading='WGSL Switch'>
   <xmp highlight='rust'>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6712,7 +6712,7 @@ depending on the evaluation of a selector expression.
     | [=syntax/expression=]
 </div>
 
-A <dfn noexport>case clause</dfn> is the [=syntax/case=] token followed by a list of [=syntax/case_selectors=] and a
+A <dfn noexport>case clause</dfn> is the [=syntax/case=] token followed by a comma-separated list of [=syntax/case_selector|case selectors=] and a
 <dfn noexport>case body</dfn> in the form of a [=compound statement=].
 
 A <dfn noexport>default-alone clause</dfn> is the [=syntax/default=] token followed by a <dfn noexport>default-alone body</dfn>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6713,10 +6713,9 @@ depending on the evaluation of a selector expression.
 </div>
 
 A <dfn noexport>case clause</dfn> is the [=syntax/case=] token followed by a comma-separated list of [=syntax/case_selector|case selectors=] and a
-<dfn noexport>case body</dfn> in the form of a [=compound statement=].
+body in the form of a [=compound statement=].
 
-A <dfn noexport>default-alone clause</dfn> is the [=syntax/default=] token followed by a <dfn noexport>default-alone body</dfn>
-in the form of a [=compound statement=].
+A <dfn noexport>default-alone clause</dfn> is the [=syntax/default=] token followed by a body in the form of a [=compound statement=].
 
 A <dfn noexport>default clause</dfn> is either:
 * a [=case clause=] where [=syntax/default=] appears as one of its selectors, or
@@ -6739,10 +6738,9 @@ then control is transferred to the body of that [=case clause=].
 If the selector value does not equal any of the case selector values, then control is
 transferred to the body of the [=default clause=].
 
-When control reaches the end of a [=case body=] or [=default-alone body=], control transfers to the first statement
-after the switch statement.
+When control reaches the end of the body of a clause, control transfers to the first statement after the switch statement.
 
-When one of the statements in the [=case body=] or a [=default-alone body=] is a [=declaration=],
+When one of the statements in the body of a clause is a [=declaration=],
 it follows the normal [=scope=] and [=lifetime=] rules of a declaration in a [=compound statement=].
 That is, the body is a sequence of statements, and if one of those is a declaration
 then the scope of that declaration extends from the start of the next statement in the sequence
@@ -6755,17 +6753,20 @@ creating a new instance of the [=variable declaration|variable=] or [=value decl
     var a : i32;
     let x : i32 = generateValue();
     switch x {
-      case 0: {      // the colon is optional
+      case 0: {      // The colon is optional
         a = 1;
       }
-      default {      // the default needn't appear last
+      default {      // The default need not appear last
         a = 2;
       }
-      case 1, 2 {    // multiple selector values can be used
-        a = 3;       // a will be overridden in the next case
+      case 1, 2, {   // Multiple selector values can be used
+        a = 3;
       }
-      case 3 {
+      case 3, {      // The trailing comma is optional
         a = 4;
+      }
+      case 4 {
+        a = 5;
       }
     }
   </xmp>
@@ -8813,7 +8814,7 @@ When several edges have to be created we use `X -> {Y, Z}` as a short-hand for `
 Analysis of [[#for-statement|for]] and [[#while-statement|while]] loops follows
 from their respective desugaring translations to [[#loop-statement|loop]] statements.
 
-In [[#switch-statement|switch]], a `default` block is treated exactly like a case block with regards to uniformity.
+In [[#switch-statement|switch]], a [=default-alone clause=] block is treated exactly like a [=case clause=] with regards to uniformity.
 
 Note: If the set of behaviors (see [[#behaviors]]) for an if, switch, or loop statement is {Next}, this means that we either did not diverge within the statement, or we reconverged, so we pick the node corresponding to control flow at the start of the statement as the node corresponding to control flow at the exit of the statement.
 

--- a/wgsl/keywords
+++ b/wgsl/keywords
@@ -488,7 +488,6 @@ default
 discard
 else
 enable
-fallthrough
 false
 flat
 fn
@@ -524,6 +523,7 @@ demote
 demote_to_helper
 do
 enum
+fallthrough
 handle
 null
 premerge


### PR DESCRIPTION


- default can appear at most once in a case selector list
- Rephrase rule about duplicate case values. They are not always literals.
- Restate rules about "case bodies" to include the default-alone clause
- Fix the "declaration in a body" rule to mirror the clarifications
  recently made for the 'loop' statement

- Rearrange to pull validation rules above behaviours.

- Pull initial "purpose" statement at the top, above grammar rules.