### PR TITLE
Reduce max binding index and make it a limit

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1477,14 +1477,14 @@ applications should generally request the "worst" limits that work for their con
         ([=max bindings per shader stage=] &times; [=max shader stages per pipeline=]) for the same
         [=adapter=].
 
-        <dfn dfn dfn-for="">max bindings per shader stage</dfn> is
+        <dfn dfn for=>max bindings per shader stage</dfn> is
         ({{supported limits/maxSampledTexturesPerShaderStage}} +
         {{supported limits/maxSamplersPerShaderStage}} +
         {{supported limits/maxStorageBuffersPerShaderStage}} +
         {{supported limits/maxStorageTexturesPerShaderStage}} +
         {{supported limits/maxUniformBuffersPerShaderStage}}).
 
-        <dfn dfn dfn-for="">max shader stages per pipeline</dfn> is `2`, because a
+        <dfn dfn for=>max shader stages per pipeline</dfn> is `2`, because a
         {{GPURenderPipeline}} supports both a vertex and fragment shader.
 
         Note: 640 "ought to be enough for anybody" who is using the default

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1467,12 +1467,11 @@ applications should generally request the "worst" limits that work for their con
         allowed in {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
         when creating a {{GPUPipelineLayout}}.
 
-    <tr><td><dfn>maxBindingIndex</dfn>
+    <tr><td><dfn>maxBindingsPerBindGroup</dfn>
         <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>640
     <tr class=row-continuation><td colspan=4>
-        The maximum value allowed for a
-        {{GPUBindGroupLayoutEntry}}.{{GPUBindGroupLayoutEntry/binding}}
-        when creating a {{GPUBindGroupLayout}}.
+        The maximum allowed number of {{GPUBindGroupLayoutEntry}}.{{GPUBindGroupLayoutEntry/binding}}
+        values when creating a {{GPUBindGroupLayout}}.
 
         The [=supported limit=] for an [=adapter=] must be &gt;
         ({{supported limits/maxSampledTexturesPerShaderStage}} +
@@ -1686,7 +1685,7 @@ interface GPUSupportedLimits {
     readonly attribute unsigned long maxTextureDimension3D;
     readonly attribute unsigned long maxTextureArrayLayers;
     readonly attribute unsigned long maxBindGroups;
-    readonly attribute unsigned long maxBindingIndex;
+    readonly attribute unsigned long maxBindingsPerBindGroup;
     readonly attribute unsigned long maxDynamicUniformBuffersPerPipelineLayout;
     readonly attribute unsigned long maxDynamicStorageBuffersPerPipelineLayout;
     readonly attribute unsigned long maxSampledTexturesPerShaderStage;
@@ -5465,8 +5464,8 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                         - |this| is [=valid=].
                         - Let |limits| be |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.
                         - The {{GPUBindGroupLayoutEntry/binding}} of each entry in |descriptor| is unique.
-                        - The {{GPUBindGroupLayoutEntry/binding}} of each entry in |descriptor| must be &le;
-                            |limits|.{{supported limits/maxBindingIndex}}.
+                        - The {{GPUBindGroupLayoutEntry/binding}} of each entry in |descriptor| must be &lt;
+                            |limits|.{{supported limits/maxBindingsPerBindGroup}}.
                         - |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}} must not
                             [=exceeds the binding slot limits|exceed the binding slot limits=] of |limits|.
                         - For each {{GPUBindGroupLayoutEntry}} |entry| in |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1467,6 +1467,13 @@ applications should generally request the "worst" limits that work for their con
         allowed in {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
         when creating a {{GPUPipelineLayout}}.
 
+    <tr><td><dfn>maxBindingIndex</dfn>
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>640<sup><a href="https://quoteinvestigator.com/2011/09/08/640k-enough/">*</a></sup>
+    <tr class=row-continuation><td colspan=4>
+        The maximum value allowed for a
+        {{GPUBindGroupLayoutEntry}}.{{GPUBindGroupLayoutEntry/binding}}
+        when creating a {{GPUBindGroupLayout}}.
+
     <tr><td><dfn>maxDynamicUniformBuffersPerPipelineLayout</dfn>
         <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>8
     <tr class=row-continuation><td colspan=4>
@@ -1669,6 +1676,7 @@ interface GPUSupportedLimits {
     readonly attribute unsigned long maxTextureDimension3D;
     readonly attribute unsigned long maxTextureArrayLayers;
     readonly attribute unsigned long maxBindGroups;
+    readonly attribute unsigned long maxBindingIndex;
     readonly attribute unsigned long maxDynamicUniformBuffersPerPipelineLayout;
     readonly attribute unsigned long maxDynamicStorageBuffersPerPipelineLayout;
     readonly attribute unsigned long maxSampledTexturesPerShaderStage;
@@ -5445,11 +5453,12 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
 
                     <div class=validusage>
                         - |this| is [=valid=].
+                        - Let |limits| be |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.
                         - The {{GPUBindGroupLayoutEntry/binding}} of each entry in |descriptor| is unique.
-                        - The {{GPUBindGroupLayoutEntry/binding}} of each entry in |descriptor| must be &lt; 65536.
+                        - The {{GPUBindGroupLayoutEntry/binding}} of each entry in |descriptor| must be &le;
+                            |limits|.{{supported limits/maxBindingIndex}}.
                         - |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}} must not
-                            [=exceeds the binding slot limits|exceed the binding slot limits=]
-                            of |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.
+                            [=exceeds the binding slot limits|exceed the binding slot limits=] of |limits|.
                         - For each {{GPUBindGroupLayoutEntry}} |entry| in |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
                             - Let |bufferLayout| be |entry|.{{GPUBindGroupLayoutEntry/buffer}}
                             - Let |samplerLayout| be |entry|.{{GPUBindGroupLayoutEntry/sampler}}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1473,12 +1473,19 @@ applications should generally request the "worst" limits that work for their con
         The maximum allowed number of {{GPUBindGroupLayoutEntry}}.{{GPUBindGroupLayoutEntry/binding}}
         values when creating a {{GPUBindGroupLayout}}.
 
-        The [=supported limit=] for an [=adapter=] must be &gt;
+        The [=supported limit=] for an [=adapter=] must be &ge;
+        ([=max bindings per shader stage=] &times; [=max shader stages per pipeline=]) for the same
+        [=adapter=].
+
+        <dfn dfn dfn-for="">max bindings per shader stage</dfn> is
         ({{supported limits/maxSampledTexturesPerShaderStage}} +
         {{supported limits/maxSamplersPerShaderStage}} +
         {{supported limits/maxStorageBuffersPerShaderStage}} +
         {{supported limits/maxStorageTexturesPerShaderStage}} +
-        {{supported limits/maxUniformBuffersPerShaderStage}}) for the same [=adapter=].
+        {{supported limits/maxUniformBuffersPerShaderStage}}).
+
+        <dfn dfn dfn-for="">max shader stages per pipeline</dfn> is `2`, because a
+        {{GPURenderPipeline}} supports both a vertex and fragment shader.
 
         Note: 640 "ought to be enough for anybody" who is using the default
         [=exceeds the binding slot limits|binding slot limits=].

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1474,7 +1474,15 @@ applications should generally request the "worst" limits that work for their con
         {{GPUBindGroupLayoutEntry}}.{{GPUBindGroupLayoutEntry/binding}}
         when creating a {{GPUBindGroupLayout}}.
 
-        Note: 640 "ought to be enough for anybody" who is using the default [=exceeds the binding slot limits|binding slot limits=].
+        The [=supported limit=] for an [=adapter=] must be &gt;
+        ({{supported limits/maxSampledTexturesPerShaderStage}} +
+        {{supported limits/maxSamplersPerShaderStage}} +
+        {{supported limits/maxStorageBuffersPerShaderStage}} +
+        {{supported limits/maxStorageTexturesPerShaderStage}} +
+        {{supported limits/maxUniformBuffersPerShaderStage}}) for the same [=adapter=].
+
+        Note: 640 "ought to be enough for anybody" who is using the default
+        [=exceeds the binding slot limits|binding slot limits=].
 
     <tr><td><dfn>maxDynamicUniformBuffersPerPipelineLayout</dfn>
         <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>8

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1468,11 +1468,13 @@ applications should generally request the "worst" limits that work for their con
         when creating a {{GPUPipelineLayout}}.
 
     <tr><td><dfn>maxBindingIndex</dfn>
-        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>640<sup><a href="https://quoteinvestigator.com/2011/09/08/640k-enough/">*</a></sup>
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>640
     <tr class=row-continuation><td colspan=4>
         The maximum value allowed for a
         {{GPUBindGroupLayoutEntry}}.{{GPUBindGroupLayoutEntry/binding}}
         when creating a {{GPUBindGroupLayout}}.
+
+        Note: 640 "ought to be enough for anybody" who is using the default [=exceeds the binding slot limits|binding slot limits=].
 
     <tr><td><dfn>maxDynamicUniformBuffersPerPipelineLayout</dfn>
         <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>8


### PR DESCRIPTION
Fixes #3279.

Uses the suggested limit of 640, with an annotation to help out those who don't
get where that value comes from. Also took the opportunity to update the
timeline style of the affected algortihm, which I'll probably be doing for most
of my future PRs.