### PR TITLE
uniformity: Clarify partial/full assignment fo

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8727,7 +8727,7 @@ A [=full reference=], and similarly a [=full pointer=], is a [=memory view=]
 for *all* the memory locations for the corresponding [=originating variable=] *x*.
 
 A reference that is not a [=full reference=] is a <dfn noexport>partial reference</dfn>.
-As such, a partial reference is a memory view for a struct subset of the memory locations
+As such, a partial reference is a memory view for a strict subset of the memory locations
 for the corresponding [=originating variable=].
 
 An assignment through a [=full reference=] is a [=full assignment=].

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8711,20 +8711,24 @@ An assignment is a <dfn noexport>full assignment</dfn> if:
 Otherwise, an assignment is a <dfn noexport>partial assignment</dfn>.
 
 A <dfn>full reference</dfn> is an expression of [=reference type=] that is one of:
-* an identifier *x* [=resolving|resolves=] to a variable, or
-* `(`*x*`)` where *x* is a [=full reference=], or
+* an identifier *x* that [=resolving|resolves=] to a variable, or
+* `(`*r*`)` where *r* is a [=full reference=], or
 * `*`*p* where *p* is a [=full pointer=].
 
 A <dfn>full pointer</dfn> is an expression of [=pointer type=] that is one of:
 * `&`*r* where *r* is a [=full reference=], or
-* an identifier *p* [=resolving|resolves=] to a [=let-declaration=] initialized to a [=full pointer=], or
-* `(`*x*`)` where *x* is a [=full pointer=], or
+* an identifier *p* that [=resolving|resolves=] to a [=let-declaration=] initialized to a [=full pointer=], or
 * `(`*p*`)` where *p* is a [=full pointer=].
 
 Note: For the purposes of this analysis, we don't need the case where
 a formal parameter of pointer type may be a full pointer.
 
+A [=full reference=], and similarly a [=full pointer=], is a [=memory view=]
+for *all* the memory locations for the corresponding [=originating variable=] *x*.
+
 A reference that is not a [=full reference=] is a <dfn noexport>partial reference</dfn>.
+As such, a partial reference is a memory view for a struct subset of the memory locations
+for the corresponding [=originating variable=].
 
 An assignment through a [=full reference=] is a [=full assignment=].
 An assignment thorugh a [=partial reference=] is a [=partial assignment=].
@@ -8774,10 +8778,10 @@ notations:
           *x* = *e*;<br>
   <tr><td>
           *r* = *e*;<br>
-          where *r* is a [=full reference=] to all the memory locations for variable *x*
+          where *r* is a [=full reference=] to variable *x*
   <tr><td>
           *r* = *e*;<br>
-          where *r* is a [=partial reference=] to some (not all) memory locations for variable *x*
+          where *r* is a [=partial reference=] to variable *x*
       <td>*Vout*(*s*)
       <td>*V*(*e*), *V*(*prev*)
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8710,6 +8710,25 @@ An assignment is a <dfn noexport>full assignment</dfn> if:
 
 Otherwise, an assignment is a <dfn noexport>partial assignment</dfn>.
 
+A <dfn>full reference</dfn> is an expression of [=reference type=] that is one of:
+* an identifier *x* [=resolving|resolves=] to a variable, or
+* `(`*x*`)` where *x* is a [=full reference=], or
+* `*`*p* where *p* is a [=full pointer=].
+
+A <dfn>full pointer</dfn> is an expression of [=pointer type=] that is one of:
+* `&`*r* where *r* is a [=full reference=], or
+* an identifier *p* [=resolving|resolves=] to a [=let-declaration=] initialized to a [=full pointer=], or
+* `(`*x*`)` where *x* is a [=full pointer=], or
+* `(`*p*`)` where *p* is a [=full pointer=].
+
+Note: For the purposes of this analysis, we don't need the case where
+a formal parameter of pointer type may be a full pointer.
+
+A reference that is not a [=full reference=] is a <dfn noexport>partial reference</dfn>.
+
+An assignment through a [=full reference=] is a [=full assignment=].
+An assignment thorugh a [=partial reference=] is a [=partial assignment=].
+
 When the uniformity rules in subsequent sections refer to the value for a
 function-scope variable used as an RValue, it means the value of the variable
 prior to evaluation of the RValue expression.
@@ -8741,52 +8760,47 @@ notations:
         <th>Result
         <th>Edges from the Result
   </thead>
-  <tr><td class='nowrap'>
+  <tr><td>
           var *x*;
       <td>*Vin*(*next*)
       <td>*V*(*0*)
-  <tr><td class='nowrap'>
+  <tr><td>
           var *x* = *e*;<br>
       <td rowspan=3>*Vin*(*next*)
       <td rowspan=3>*V*(*e*)
 
           Note: This is a [=full assignment=] to *x*.
-  <tr><td class='nowrap'>
+  <tr><td>
           *x* = *e*;<br>
-  <tr><td class='nowrap'>
-          **p* = *e*;<br>
-          where *p* is a [=let-declaration=] initialized to &*x*
-  <tr><td class='nowrap'>
-          *f*(*x*) = *e*;<br>
-      <td rowspan=3>*Vout*(*s*)
-      <td rowspan=3>*V*(*e*), *V*(*prev*)
+  <tr><td>
+          *r* = *e*;<br>
+          where *r* is a [=full reference=] to all the memory locations for variable *x*
+  <tr><td>
+          *r* = *e*;<br>
+          where *r* is a [=partial reference=] to some (not all) memory locations for variable *x*
+      <td>*Vout*(*s*)
+      <td>*V*(*e*), *V*(*prev*)
 
           Note: This is a [=partial assignment=] to *x*.
 
           Note: Partial assignments include the previous value since only a subset of components are updated.
-  <tr><td class='nowrap'>
-          **p* = *e*;<br>
-          where *p* is a [=let-declaration=] initialized to &*f*(*x*)<br>
-  <tr><td class='nowrap'>
-          **f*(*p*) = *e*;<br>
-          where *p* is a [=let-declaration=] initialized to &*f*(*x*) or &*x*
   <tr><td>*s1* *s2*<br>
           where *Next* is in behavior of *s1*.
 
           Note: *s1* often ends in a semicolon.
       <td>*Vin*(*s2*)
       <td>*Vout*(*s1*)
-  <tr><td class='nowrap'>
+  <tr><td>
           if *e* *s1* else *s2*<br>
           where *Next* is in the behaviors of both *s1* and *s2*
       <td>*Vin*(*next*)
       <td>*Vout*(*s1*), *Vout*(*s2*)
-  <tr><td class='nowrap'>
+  <tr><td>
           if *e* *s1* else *s2*<br>
           where *Next* is in the behavior of *s1*, but not *s2*
       <td>*Vin*(*next*)
       <td>*Vout*(*s1*)
-  <tr><td class='nowrap'>if *e* *s1* else *s2*<br>
+  <tr><td>
           where *Next* is in the behavior of *s2*, but not *s1*
       <td>*Vin*(*next*)
       <td>*Vout*(*s2*)


### PR DESCRIPTION
Define "full reference" "full pointer" with mutually recursive
definitions.

This lets us remove the ambiguous use of 'f(x)' in the rules
about full and partial assignments to variables.