### PR TITLE
Convert Create* methods to new timeline style

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5422,7 +5422,7 @@ following members:
 
                 1. Let |bindGroup| be a new {{GPUBindGroup}} object.
                 1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
-                 1. Return |bindGroup|.
+                1. Return |bindGroup|.
             </div>
             <div data-timeline=device>
                 [=Device timeline=] |initialization steps|:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1911,33 +1911,37 @@ interface GPU {
         chooses according to the provided options.
 
         <div algorithm=GPU.requestAdapter>
-            **Called on:** {{GPU}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPU}} |this|.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPU/requestAdapter(options)">
-                |options|: Criteria used to select the adapter.
-            </pre>
+                <pre class=argumentdef for="GPU/requestAdapter(options)">
+                    |options|: Criteria used to select the adapter.
+                </pre>
 
-            **Returns:** {{Promise}}&lt;{{GPUAdapter}}?&gt;
+                **Returns:** {{Promise}}&lt;{{GPUAdapter}}?&gt;
 
-            1. Let |promise| be [=a new promise=].
-            1. Issue the following steps on the [=Device timeline=] of |this|:
+                [=Content timeline=] steps:
 
-                <div class=device-timeline>
-                    1. If the user agent chooses to return an adapter, it should:
-                        1. Create a [=valid=] [=adapter=] |adapter|, chosen according to
-                            the rules in [[#adapter-selection]] and the criteria in |options|.
+                1. Let |promise| be [=a new promise=].
+                1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
+                1. Return |promise|.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] |initialization steps|:
 
-                        1. If |adapter| meets the criteria of a [=fallback adapter=] set
-                            |adapter|.{{adapter/[[fallback]]}} to `true`.
+                1. If the user agent chooses to return an adapter, it should:
+                    1. Create a [=valid=] [=adapter=] |adapter|, chosen according to
+                        the rules in [[#adapter-selection]] and the criteria in |options|.
 
-                        1. [=Resolve=] |promise| with a new {{GPUAdapter}} encapsulating |adapter|.
+                    1. If |adapter| meets the criteria of a [=fallback adapter=] set
+                        |adapter|.{{adapter/[[fallback]]}} to `true`.
 
-                    1. Otherwise, |promise| [=resolves=] with `null`.
-                </div>
-            1. Return |promise|.
+                    1. [=Resolve=] |promise| with a new {{GPUAdapter}} encapsulating |adapter|.
 
+                1. Otherwise, |promise| [=resolves=] with `null`.
+            </div>
             <!-- If we add ways to make invalid adapter requests (aside from those
                 that violate IDL rules), specify that they reject the promise. -->
         </div>
@@ -1956,15 +1960,16 @@ interface GPU {
         format.
 
         <div algorithm=GPU.getPreferredCanvasFormat>
-            **Called on:** {{GPU}} this.
+            <div data-timeline=content>
+                **Called on:** {{GPU}} this.
 
-            **Returns:** {{GPUTextureFormat}}
+                **Returns:** {{GPUTextureFormat}}
 
-            <div class=content-timeline>
+                [=Content timeline=] steps:
+
                 1. Return either {{GPUTextureFormat/"rgba8unorm"}} or
                     {{GPUTextureFormat/"bgra8unorm"}}, depending on which format is optimal for
                     displaying WebGPU canvases on this system.
-            </div>
         </div>
 </dl>
 
@@ -2157,70 +2162,75 @@ interface GPUAdapter {
         Requests a [=device=] from the [=adapter=].
 
         <div algorithm=GPUAdapter.requestDevice>
-            **Called on:** {{GPUAdapter}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUAdapter}} |this|.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUAdapter/requestDevice(descriptor)">
-                |descriptor|: Description of the {{GPUDevice}} to request.
-            </pre>
+                <pre class=argumentdef for="GPUAdapter/requestDevice(descriptor)">
+                    |descriptor|: Description of the {{GPUDevice}} to request.
+                </pre>
 
-            **Returns:** {{Promise}}&lt;{{GPUDevice}}&gt;
+                **Returns:** {{Promise}}&lt;{{GPUDevice}}&gt;
 
-            1. Let |promise| be [=a new promise=].
-            1. Let |adapter| be |this|.{{GPUAdapter/[[adapter]]}}.
-            1. Issue the following steps to the [=Device timeline=]:
+                [=Content timeline=] steps:
 
-                <div class=device-timeline>
-                    1. If any of the following requirements are unmet,
-                        [=reject=] |promise| with a {{TypeError}} and stop.
+                1. Let |promise| be [=a new promise=].
+                1. Let |adapter| be |this|.{{GPUAdapter/[[adapter]]}}.
+                1. Issue the |initialization steps| to the [=Device timeline=] of |this|.
+                1. Return |promise|.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] |initialization steps|:
 
-                        <div class=validusage>
-                            - The set of values in |descriptor|.{{GPUDeviceDescriptor/requiredFeatures}}
-                                must be a subset of those in |adapter|.{{adapter/[[features]]}}.
-                        </div>
+                1. If any of the following requirements are unmet,
+                    [=reject=] |promise| with a {{TypeError}} and stop.
 
-                        Note: This is the same error that is produced if a feature name isn't known
-                        by the browser at all (in its {{GPUFeatureName}} definition).
-                        This converges the behavior when the browser doesn't support a feature
-                        with the behavior when a particular adapter doesn't support a feature.
+                    <div class=validusage>
+                        - The set of values in |descriptor|.{{GPUDeviceDescriptor/requiredFeatures}}
+                            must be a subset of those in |adapter|.{{adapter/[[features]]}}.
+                    </div>
 
-                    1. If any of the following requirements are unmet,
-                        [=reject=] |promise| with an {{OperationError}} and stop.
+                    Note: This is the same error that is produced if a feature name isn't known
+                    by the browser at all (in its {{GPUFeatureName}} definition).
+                    This converges the behavior when the browser doesn't support a feature
+                    with the behavior when a particular adapter doesn't support a feature.
 
-                        <div class=validusage>
-                            - Each key in |descriptor|.{{GPUDeviceDescriptor/requiredLimits}}
-                                must be the name of a member of [=supported limits=].
+                1. If any of the following requirements are unmet,
+                    [=reject=] |promise| with an {{OperationError}} and stop.
 
-                            - For each limit name |key| in the keys of [=supported limits=]:
-                                Let |value| be |descriptor|.{{GPUDeviceDescriptor/requiredLimits}}[|key|].
-                                - |value| must be no [=limit/better=] than the value of that limit in
-                                    |adapter|.{{adapter/[[limits]]}}.
-                                - If the limit's [=limit class|class=] is [=limit class/alignment=],
-                                    |value| must be a power of 2.
-                        </div>
+                    <div class=validusage>
+                        - Each key in |descriptor|.{{GPUDeviceDescriptor/requiredLimits}}
+                            must be the name of a member of [=supported limits=].
 
-                    1. If |adapter| is [=invalid=],
-                        or the user agent otherwise cannot fulfill the request:
+                        - For each limit name |key| in the keys of [=supported limits=]:
+                            Let |value| be |descriptor|.{{GPUDeviceDescriptor/requiredLimits}}[|key|].
+                            - |value| must be no [=limit/better=] than the value of that limit in
+                                |adapter|.{{adapter/[[limits]]}}.
+                            - If the limit's [=limit class|class=] is [=limit class/alignment=],
+                                |value| must be a power of 2.
+                    </div>
 
-                        1. Let |device| be a new [=device=].
-                        1. [=Lose the device=](|device|, `undefined`).
+                1. If |adapter| is [=invalid=],
+                    or the user agent otherwise cannot fulfill the request:
 
-                            Note:
-                            This makes |adapter| [=invalid=], if it wasn't already.
+                    1. Let |device| be a new [=device=].
+                    1. [=Lose the device=](|device|, `undefined`).
 
-                            Note:
-                            User agents should consider issuing developer-visible warnings in
-                            most or all cases when this occurs. Applications should perform
-                            reinitialization logic starting with {{GPU/requestAdapter()}}.
+                        Note:
+                        This makes |adapter| [=invalid=], if it wasn't already.
 
-                        1. [=Resolve=] |promise| with a new {{GPUDevice}} encapsulating |device|,
-                            and stop.
+                        Note:
+                        User agents should consider issuing developer-visible warnings in
+                        most or all cases when this occurs. Applications should perform
+                        reinitialization logic starting with {{GPU/requestAdapter()}}.
 
-                    1. [=Resolve=] |promise| with a new {{GPUDevice}} object encapsulating
-                        [=a new device=] with the capabilities described by |descriptor|.
-                </div>
-            1. Return |promise|.
+                    1. [=Resolve=] |promise| with a new {{GPUDevice}} encapsulating |device|,
+                        and stop.
+
+                1. [=Resolve=] |promise| with a new {{GPUDevice}} object encapsulating
+                    [=a new device=] with the capabilities described by |descriptor|.
+            </div>
         </div>
 
     : <dfn>requestAdapterInfo()</dfn>
@@ -2233,35 +2243,38 @@ interface GPUAdapter {
         however, no dialogs should be displayed to the user.
 
         <div algorithm=GPUAdapter.requestAdapterInfo>
-            **Called on:** {{GPUAdapter}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUAdapter}} |this|.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUAdapter/requestAdapterInfo()">
-                |unmaskHints|: A list of {{GPUAdapterInfo}} attribute names for which unmasked
-                    values are desired if available.
-            </pre>
+                <pre class=argumentdef for="GPUAdapter/requestAdapterInfo()">
+                    |unmaskHints|: A list of {{GPUAdapterInfo}} attribute names for which unmasked
+                        values are desired if available.
+                </pre>
 
-            **Returns:** {{Promise}}&lt;{{GPUAdapterInfo}}&gt;
+                **Returns:** {{Promise}}&lt;{{GPUAdapterInfo}}&gt;
 
-            1. Let |promise| be [=a new promise=].
-            1. Let |adapter| be |this|.{{GPUAdapter/[[adapter]]}}.
-            1. Let |hasActivation| be `true` if the [=relevant global object=] for |this| has
-                [=transient activation=], and `false` otherwise.
-            1. Run the following steps [=in parallel=]:
-                1. If |unmaskHints|.length &gt; `0`:
-                    1. If |hasActivation| is `false` [=reject=] |promise| with a {{NotAllowedError}}
-                        and abort these steps.
-                    1. Let |unmaskedKeys| be a [=list=] of the fields specified in |unmaskHints|
-                        which the user agent decides to unmask, if any.
+                [=Content timeline=] steps:
 
-                        Note: The user agent is free to use any method it deems appropriate to
-                        decide which fields to unmask.
-                    1. [=set/Append=] |unmaskedKeys| to |adapter|.{{adapter/[[unmaskedIdentifiers]]}}.
-                1. [=Resolve=] |promise| with a [$new adapter info$] for |adapter|.
+                1. Let |promise| be [=a new promise=].
+                1. Let |adapter| be |this|.{{GPUAdapter/[[adapter]]}}.
+                1. Let |hasActivation| be `true` if the [=relevant global object=] for |this| has
+                    [=transient activation=], and `false` otherwise.
+                1. Run the following steps [=in parallel=]:
+                    1. If |unmaskHints|.length &gt; `0`:
+                        1. If |hasActivation| is `false` [=reject=] |promise| with a {{NotAllowedError}}
+                            and abort these steps.
+                        1. Let |unmaskedKeys| be a [=list=] of the fields specified in |unmaskHints|
+                            which the user agent decides to unmask, if any.
 
-            1. Return |promise|.
+                            Note: The user agent is free to use any method it deems appropriate to
+                            decide which fields to unmask.
+                        1. [=set/Append=] |unmaskedKeys| to |adapter|.{{adapter/[[unmaskedIdentifiers]]}}.
+                    1. [=Resolve=] |promise| with a [$new adapter info$] for |adapter|.
 
+                1. Return |promise|.
+            </div>
         </div>
 </dl>
 
@@ -2431,6 +2444,8 @@ Those not defined here are defined elsewhere in this document.
             <div data-timeline=content>
                 **Called on:** {{GPUDevice}} |this|.
 
+                [=Content timeline=] steps:
+
                 1. {{GPUBuffer/unmap()}} all {{GPUBuffer}}s from this device.
 
                     <!-- [tentative text for multithreading:]
@@ -2444,6 +2459,8 @@ Those not defined here are defined elsewhere in this document.
                 1. Issue the subsequent steps on the [=Device timeline=] of |this|.
             </div>
             <div data-timeline=device>
+                [=Device timeline=] steps:
+
                 1. Once all <span data-timeline=queue>currently-enqueued operations on any queue on this device</span>
                     are completed, issue the subsequent steps on the <span data-timeline=device>current timeline</span>.
             </div>
@@ -2831,61 +2848,66 @@ The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its
         Creates a {{GPUBuffer}}.
 
         <div algorithm=GPUDevice.createBuffer>
-            **Called on:** {{GPUDevice}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUDevice}} |this|.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUDevice/createBuffer(descriptor)">
-                |descriptor|: Description of the {{GPUBuffer}} to create.
-            </pre>
+                <pre class=argumentdef for="GPUDevice/createBuffer(descriptor)">
+                    |descriptor|: Description of the {{GPUBuffer}} to create.
+                </pre>
 
-            **Returns:** {{GPUBuffer}}
+                **Returns:** {{GPUBuffer}}
 
-            1. Let |b| be a new {{GPUBuffer}} object.
-            1. Set |b|.{{GPUBuffer/size}} to |descriptor|.{{GPUBufferDescriptor/size}}.
-            1. Set |b|.{{GPUBuffer/usage}} to |descriptor|.{{GPUBufferDescriptor/usage}}.
-            1. If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`,
-                set |b|.{{GPUBuffer/[[mapping]]}} to an [=active buffer mapping=] with:
-                - [=active buffer mapping/data=] set to a new {{ArrayBuffer}} of size |b|.{{GPUBuffer/size}}.
-                - [=active buffer mapping/mode=] set to {{GPUMapMode/WRITE}}.
-                - [=active buffer mapping/range=] set to <code>[0, |descriptor|.{{GPUBufferDescriptor/size}}]</code>.
-                - [=active buffer mapping/views=] set to `[]`.
+                [=Content timeline=] steps:
 
-            1. Issue the following steps on the [=Device timeline=] of |this|:
+                1. Let |b| be a new {{GPUBuffer}} object.
+                1. Set |b|.{{GPUBuffer/size}} to |descriptor|.{{GPUBufferDescriptor/size}}.
+                1. Set |b|.{{GPUBuffer/usage}} to |descriptor|.{{GPUBufferDescriptor/usage}}.
+                1. If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`,
+                    set |b|.{{GPUBuffer/[[mapping]]}} to an [=active buffer mapping=] with:
+                    - [=active buffer mapping/data=] set to a new {{ArrayBuffer}} of size |b|.{{GPUBuffer/size}}.
+                    - [=active buffer mapping/mode=] set to {{GPUMapMode/WRITE}}.
+                    - [=active buffer mapping/range=] set to <code>[0, |descriptor|.{{GPUBufferDescriptor/size}}]</code>.
+                    - [=active buffer mapping/views=] set to `[]`.
 
-                <div class=device-timeline>
-                    1. If any of the following conditions are unsatisfied
-                        [$generate a validation error$], make |b| [=invalid=], and stop.
+                1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
+                1. Return |b|.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] |initialization steps|:
 
-                        <div class=validusage>
-                            - |this| is [=valid=].
-                            - [$validating GPUBufferDescriptor$](|this|, |descriptor|) returns true.
-                            - |descriptor|.{{GPUBufferDescriptor/usage}} must not be 0.
-                            - |descriptor|.{{GPUBufferDescriptor/usage}} is a subset of |this|'s [=allowed buffer usages=].
-                            - If |descriptor|.{{GPUBufferDescriptor/usage}} contains {{GPUBufferUsage/MAP_READ}}:
-                                - |descriptor|.{{GPUBufferDescriptor/usage}} contains no other flags
-                                    except {{GPUBufferUsage/COPY_DST}}.
-                            - If |descriptor|.{{GPUBufferDescriptor/usage}} contains {{GPUBufferUsage/MAP_WRITE}}:
-                                - |descriptor|.{{GPUBufferDescriptor/usage}} contains no other flags
-                                    except {{GPUBufferUsage/COPY_SRC}}.
-                            - If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`:
-                                - |descriptor|.{{GPUBufferDescriptor/size}} is a multiple of 4.
-                        </div>
+                1. If any of the following conditions are unsatisfied
+                    [$generate a validation error$], make |b| [=invalid=], and stop.
 
-                    Note: If buffer creation fails, and |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `false`,
-                    any calls to {{GPUBuffer/mapAsync()}} will reject, so any resources allocated to enable mapping can
-                    and may be discarded or recycled.
+                    <div class=validusage>
+                        - |this| is [=valid=].
+                        - [$validating GPUBufferDescriptor$](|this|, |descriptor|) returns true.
+                        - |descriptor|.{{GPUBufferDescriptor/usage}} must not be 0.
+                        - |descriptor|.{{GPUBufferDescriptor/usage}} is a subset of |this|'s [=allowed buffer usages=].
+                        - If |descriptor|.{{GPUBufferDescriptor/usage}} contains {{GPUBufferUsage/MAP_READ}}:
+                            - |descriptor|.{{GPUBufferDescriptor/usage}} contains no other flags
+                                except {{GPUBufferUsage/COPY_DST}}.
+                        - If |descriptor|.{{GPUBufferDescriptor/usage}} contains {{GPUBufferUsage/MAP_WRITE}}:
+                            - |descriptor|.{{GPUBufferDescriptor/usage}} contains no other flags
+                                except {{GPUBufferUsage/COPY_SRC}}.
+                        - If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`:
+                            - |descriptor|.{{GPUBufferDescriptor/size}} is a multiple of 4.
+                    </div>
 
-                    1. If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`:
-                        1. Set |b|.{{GPUBuffer/[[deviceTimelineState]]}} to "[=buffer device timeline state/unavailable=]".
+                Note: If buffer creation fails, and |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `false`,
+                any calls to {{GPUBuffer/mapAsync()}} will reject, so any resources allocated to enable mapping can
+                and may be discarded or recycled.
 
-                        Else:
+                1. If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`:
+                    1. Set |b|.{{GPUBuffer/[[deviceTimelineState]]}} to "[=buffer device timeline state/unavailable=]".
 
-                        1. Set |b|.{{GPUBuffer/[[deviceTimelineState]]}} to "[=buffer device timeline state/available=]".
+                    Else:
 
-                    1. Set each byte of |b|'s allocation to zero.
-                </div>
-            1. Return |b|.
+                    1. Set |b|.{{GPUBuffer/[[deviceTimelineState]]}} to "[=buffer device timeline state/available=]".
+
+                1. Set each byte of |b|'s allocation to zero.
+            </div>
         </div>
 </dl>
 
@@ -2917,22 +2939,33 @@ once all previously submitted operations using it are complete.
         Note: It is valid to destroy a buffer multiple times.
 
         <div algorithm=GPUBuffer.destroy>
-            **Called on:** {{GPUBuffer}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUBuffer}} |this|.
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
 
-            1. If |this| is mapped, call |this|.{{GPUBuffer/unmap()}}.
+                [=Content timeline=] steps:
 
-            <!-- [tentative text for multithreading:]
-            1. If |this| is mapped in this [=agent=] (thread), call |this|.{{GPUBuffer/unmap()}}.
+                1. If |this| is mapped, call |this|.{{GPUBuffer/unmap()}}.
 
-                Note: If the buffer is mapped in a different thread, it is not unmapped.
-                It can be unmapped only from the thread on which it is mapped, either by
-                another call to {{GPUBuffer/destroy()|GPUBuffer.destroy()}},
-                or by {{GPUBuffer/unmap()|GPUBuffer.unmap()}}.
-            -->
+                <!-- [tentative text for multithreading:]
+                1. If |this| is mapped in this [=agent=] (thread), call |this|.{{GPUBuffer/unmap()}}.
 
-            1. Set |this|.{{GPUBuffer/[[deviceTimelineState]]}} to "[=buffer device timeline state/destroyed=]".
+                    Note: If the buffer is mapped in a different thread, it is not unmapped.
+                    It can be unmapped only from the thread on which it is mapped, either by
+                    another call to {{GPUBuffer/destroy()|GPUBuffer.destroy()}},
+                    or by {{GPUBuffer/unmap()|GPUBuffer.unmap()}}.
+                -->
+
+                1. Issue the subsequent steps on the [=Device timeline=] of
+                    |this|.{{GPUObjectBase/[[device]]}}.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
+
+                1. Set |this|.{{GPUBuffer/[[deviceTimelineState]]}} to
+                    "[=buffer device timeline state/destroyed=]".
+            </div>
         </div>
 
         Note: Since no further operations can be enqueued using this buffer, implementations can
@@ -3130,6 +3163,8 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                 </pre>
 
                 **Returns:** {{ArrayBuffer}}
+
+                [=Content timeline=] steps:
 
                 1. If |size| is missing:
                     1. Let |rangeSize| be max(0, |this|.{{GPUBuffer/size}} - |offset|).
@@ -3508,43 +3543,48 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
         Creates a {{GPUTexture}}.
 
         <div algorithm=GPUDevice.createTexture>
-            **Called on:** {{GPUDevice}} this.
+            <div data-timeline=content>
+                **Called on:** {{GPUDevice}} this.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUDevice/createTexture(descriptor)">
-                |descriptor|: Description of the {{GPUTexture}} to create.
-            </pre>
+                <pre class=argumentdef for="GPUDevice/createTexture(descriptor)">
+                    |descriptor|: Description of the {{GPUTexture}} to create.
+                </pre>
 
-            **Returns:** {{GPUTexture}}
+                **Returns:** {{GPUTexture}}
 
-            1. [$Validate texture format required features$] of
-                |descriptor|.{{GPUTextureDescriptor/format}} with |this|.{{GPUObjectBase/[[device]]}}.
-            1. [$Validate texture format required features$] of each element of
-                |descriptor|.{{GPUTextureDescriptor/viewFormats}} with |this|.{{GPUObjectBase/[[device]]}}.
-            1. Let |t| be a new {{GPUTexture}} object.
-            1. Set |t|.{{GPUTexture/width}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=].
-            1. Set |t|.{{GPUTexture/height}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=].
-            1. Set |t|.{{GPUTexture/depthOrArrayLayers}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=].
-            1. Set |t|.{{GPUTexture/mipLevelCount}} to |descriptor|.{{GPUTextureDescriptor/mipLevelCount}}.
-            1. Set |t|.{{GPUTexture/sampleCount}} to |descriptor|.{{GPUTextureDescriptor/sampleCount}}.
-            1. Set |t|.{{GPUTexture/dimension}} to |descriptor|.{{GPUTextureDescriptor/dimension}}.
-            1. Set |t|.{{GPUTexture/format}} to |descriptor|.{{GPUTextureDescriptor/format}}.
-            1. Set |t|.{{GPUTexture/usage}} to |descriptor|.{{GPUTextureDescriptor/usage}}.
-            1. Issue the following steps on the [=Device timeline=] of |this|:
+                [=Content timeline=] steps:
 
-                <div class=device-timeline>
-                    1. If any of the following conditions are unsatisfied
-                        [$generate a validation error$], make |t| [=invalid=], and stop.
+                1. [$Validate texture format required features$] of
+                    |descriptor|.{{GPUTextureDescriptor/format}} with |this|.{{GPUObjectBase/[[device]]}}.
+                1. [$Validate texture format required features$] of each element of
+                    |descriptor|.{{GPUTextureDescriptor/viewFormats}} with |this|.{{GPUObjectBase/[[device]]}}.
+                1. Let |t| be a new {{GPUTexture}} object.
+                1. Set |t|.{{GPUTexture/width}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=].
+                1. Set |t|.{{GPUTexture/height}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=].
+                1. Set |t|.{{GPUTexture/depthOrArrayLayers}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=].
+                1. Set |t|.{{GPUTexture/mipLevelCount}} to |descriptor|.{{GPUTextureDescriptor/mipLevelCount}}.
+                1. Set |t|.{{GPUTexture/sampleCount}} to |descriptor|.{{GPUTextureDescriptor/sampleCount}}.
+                1. Set |t|.{{GPUTexture/dimension}} to |descriptor|.{{GPUTextureDescriptor/dimension}}.
+                1. Set |t|.{{GPUTexture/format}} to |descriptor|.{{GPUTextureDescriptor/format}}.
+                1. Set |t|.{{GPUTexture/usage}} to |descriptor|.{{GPUTextureDescriptor/usage}}.
+                1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
+                1. Return |t|.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] |initialization steps|:
 
-                        <div class=validusage>
-                            - [$validating GPUTextureDescriptor$](|this|, |descriptor|) returns `true`.
-                        </div>
+                1. If any of the following conditions are unsatisfied
+                    [$generate a validation error$], make |t| [=invalid=], and stop.
 
-                    1. Set |t|.{{GPUTexture/[[size]]}} to |descriptor|.{{GPUTextureDescriptor/size}}.
-                    1. Set |t|.{{GPUTexture/[[viewFormats]]}} to |descriptor|.{{GPUTextureDescriptor/viewFormats}}.
-                </div>
-            1. Return |t|.
+                    <div class=validusage>
+                        - [$validating GPUTextureDescriptor$](|this|, |descriptor|) returns `true`.
+                    </div>
+
+                1. Set |t|.{{GPUTexture/[[size]]}} to |descriptor|.{{GPUTextureDescriptor/size}}.
+                1. Set |t|.{{GPUTexture/[[viewFormats]]}} to |descriptor|.{{GPUTextureDescriptor/viewFormats}}.
+            </div>
         </div>
 </dl>
 
@@ -3641,11 +3681,15 @@ all previously submitted operations using it are complete.
         Destroys the {{GPUTexture}}.
 
         <div algorithm=GPUTexture.destroy>
-            **Called on:** {{GPUTexture}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUTexture}} |this|.
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
 
-            1. Set |this|.{{GPUTexture/[[destroyed]]}} to true.
+                [=Content timeline=] steps:
+
+                1. Set |this|.{{GPUTexture/[[destroyed]]}} to true.
+            </div>
         </div>
 </dl>
 
@@ -3848,96 +3892,101 @@ enum GPUTextureAspect {
         </div>
 
         <div algorithm=GPUTexture.createView>
-            **Called on:** {{GPUTexture}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUTexture}} |this|.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUTexture/createView(descriptor)">
-                |descriptor|: Description of the {{GPUTextureView}} to create.
-            </pre>
+                <pre class=argumentdef for="GPUTexture/createView(descriptor)">
+                    |descriptor|: Description of the {{GPUTextureView}} to create.
+                </pre>
 
-            **Returns:** |view|, of type {{GPUTextureView}}.
+                **Returns:** |view|, of type {{GPUTextureView}}.
 
-            1. [$Validate texture format required features$] of
-                |descriptor|.{{GPUTextureViewDescriptor/format}} with |this|.{{GPUObjectBase/[[device]]}}.
-            1. Let |view| be a new {{GPUTextureView}} object.
-            1. Issue the following steps on the [=Device timeline=] of |this|:
+                [=Content timeline=] steps:
 
-                <div class=device-timeline>
-                    1. Set |descriptor| to the result of [$resolving GPUTextureViewDescriptor defaults$]
-                        for |this| with |descriptor|.
-                    1. If any of the following conditions are unsatisfied
-                        [$generate a validation error$], make |view| [=invalid=], and stop.
+                1. [$Validate texture format required features$] of
+                    |descriptor|.{{GPUTextureViewDescriptor/format}} with |this|.{{GPUObjectBase/[[device]]}}.
+                1. Let |view| be a new {{GPUTextureView}} object.
+                1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
+                1. Return |view|.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] |initialization steps|:
 
-                        <div class=validusage>
-                            - |this| is [=valid=].
-                            - |descriptor|.{{GPUTextureViewDescriptor/aspect}} must be present in |this|.{{GPUTexture/format}}.
-                            - If the |descriptor|.{{GPUTextureViewDescriptor/aspect}} is {{GPUTextureAspect/"all"}}:
-                                - |descriptor|.{{GPUTextureViewDescriptor/format}} must equal either
-                                        |this|.{{GPUTexture/format}} or one
-                                        of the formats in |this|.{{GPUTexture/[[viewFormats]]}}.
+                1. Set |descriptor| to the result of [$resolving GPUTextureViewDescriptor defaults$]
+                    for |this| with |descriptor|.
+                1. If any of the following conditions are unsatisfied
+                    [$generate a validation error$], make |view| [=invalid=], and stop.
 
-                                Otherwise:
+                    <div class=validusage>
+                        - |this| is [=valid=].
+                        - |descriptor|.{{GPUTextureViewDescriptor/aspect}} must be present in |this|.{{GPUTexture/format}}.
+                        - If the |descriptor|.{{GPUTextureViewDescriptor/aspect}} is {{GPUTextureAspect/"all"}}:
+                            - |descriptor|.{{GPUTextureViewDescriptor/format}} must equal either
+                                    |this|.{{GPUTexture/format}} or one
+                                    of the formats in |this|.{{GPUTexture/[[viewFormats]]}}.
 
-                                - |descriptor|.{{GPUTextureViewDescriptor/format}} must equal the result of [$resolving GPUTextureAspect$](
-                                    |this|.{{GPUTexture/format}},
-                                    |descriptor|.{{GPUTextureViewDescriptor/aspect}}).
+                            Otherwise:
 
-                            - |descriptor|.{{GPUTextureViewDescriptor/mipLevelCount}} must be &gt; 0.
-                            - |descriptor|.{{GPUTextureViewDescriptor/baseMipLevel}} +
-                                |descriptor|.{{GPUTextureViewDescriptor/mipLevelCount}} must be &le;
-                                |this|.{{GPUTexture/mipLevelCount}}.
-                            - |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be &gt; 0.
-                            - |descriptor|.{{GPUTextureViewDescriptor/baseArrayLayer}} +
-                                |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be &le;
-                                the [$array layer count$] of |this|.
-                            - If |this|.{{GPUTexture/sampleCount}} &gt; 1,
-                                |descriptor|.{{GPUTextureViewDescriptor/dimension}} must be {{GPUTextureViewDimension/"2d"}}.
-                            - If |descriptor|.{{GPUTextureViewDescriptor/dimension}} is:
+                            - |descriptor|.{{GPUTextureViewDescriptor/format}} must equal the result of [$resolving GPUTextureAspect$](
+                                |this|.{{GPUTexture/format}},
+                                |descriptor|.{{GPUTextureViewDescriptor/aspect}}).
 
-                                <dl class=switch>
-                                    : {{GPUTextureViewDimension/"1d"}}
-                                    ::
-                                        - |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"1d"}}.
-                                        - |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `1`.
+                        - |descriptor|.{{GPUTextureViewDescriptor/mipLevelCount}} must be &gt; 0.
+                        - |descriptor|.{{GPUTextureViewDescriptor/baseMipLevel}} +
+                            |descriptor|.{{GPUTextureViewDescriptor/mipLevelCount}} must be &le;
+                            |this|.{{GPUTexture/mipLevelCount}}.
+                        - |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be &gt; 0.
+                        - |descriptor|.{{GPUTextureViewDescriptor/baseArrayLayer}} +
+                            |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be &le;
+                            the [$array layer count$] of |this|.
+                        - If |this|.{{GPUTexture/sampleCount}} &gt; 1,
+                            |descriptor|.{{GPUTextureViewDescriptor/dimension}} must be {{GPUTextureViewDimension/"2d"}}.
+                        - If |descriptor|.{{GPUTextureViewDescriptor/dimension}} is:
 
-                                    : {{GPUTextureViewDimension/"2d"}}
-                                    ::
+                            <dl class=switch>
+                                : {{GPUTextureViewDimension/"1d"}}
+                                ::
+                                    - |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"1d"}}.
+                                    - |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `1`.
 
-                                        - |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
-                                        - |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `1`.
+                                : {{GPUTextureViewDimension/"2d"}}
+                                ::
 
-                                    : {{GPUTextureViewDimension/"2d-array"}}
-                                    ::
-                                        - |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
+                                    - |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
+                                    - |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `1`.
 
-                                    : {{GPUTextureViewDimension/"cube"}}
-                                    ::
-                                        - |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
-                                        - |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `6`.
-                                        - |this|.{{GPUTexture/width}} must equal |this|.{{GPUTexture/height}}.
+                                : {{GPUTextureViewDimension/"2d-array"}}
+                                ::
+                                    - |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
 
-                                    : {{GPUTextureViewDimension/"cube-array"}}
-                                    ::
-                                        - |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
-                                        - |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be a multiple of `6`.
-                                        - |this|.{{GPUTexture/width}} must equal |this|.{{GPUTexture/height}}.
+                                : {{GPUTextureViewDimension/"cube"}}
+                                ::
+                                    - |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
+                                    - |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `6`.
+                                    - |this|.{{GPUTexture/width}} must equal |this|.{{GPUTexture/height}}.
 
-                                    : {{GPUTextureViewDimension/"3d"}}
-                                    ::
-                                        - |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"3d"}}.
-                                        - |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `1`.
-                                </dl>
-                        </div>
+                                : {{GPUTextureViewDimension/"cube-array"}}
+                                ::
+                                    - |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
+                                    - |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be a multiple of `6`.
+                                    - |this|.{{GPUTexture/width}} must equal |this|.{{GPUTexture/height}}.
 
-                    1. Let |view| be a new {{GPUTextureView}} object.
-                    1. Set |view|.{{GPUTextureView/[[texture]]}} to |this|.
-                    1. Set |view|.{{GPUTextureView/[[descriptor]]}} to |descriptor|.
-                    1. If |this|.{{GPUTexture/usage}} contains {{GPUTextureUsage/RENDER_ATTACHMENT}}:
-                        1. Let |renderExtent| be [$compute render extent$](|this|.{{GPUTexture/[[size]]}}, |descriptor|.{{GPUTextureViewDescriptor/baseMipLevel}}).
-                        1. Set |view|.{{GPUTextureView/[[renderExtent]]}} to |renderExtent|.
-                </div>
-            1. Return |view|.
+                                : {{GPUTextureViewDimension/"3d"}}
+                                ::
+                                    - |this|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"3d"}}.
+                                    - |descriptor|.{{GPUTextureViewDescriptor/arrayLayerCount}} must be `1`.
+                            </dl>
+                    </div>
+
+                1. Let |view| be a new {{GPUTextureView}} object.
+                1. Set |view|.{{GPUTextureView/[[texture]]}} to |this|.
+                1. Set |view|.{{GPUTextureView/[[descriptor]]}} to |descriptor|.
+                1. If |this|.{{GPUTexture/usage}} contains {{GPUTextureUsage/RENDER_ATTACHMENT}}:
+                    1. Let |renderExtent| be [$compute render extent$](|this|.{{GPUTexture/[[size]]}}, |descriptor|.{{GPUTextureViewDescriptor/baseMipLevel}}).
+                    1. Set |view|.{{GPUTextureView/[[renderExtent]]}} to |renderExtent|.
+            </div>
         </div>
 </dl>
 
@@ -4362,42 +4411,46 @@ dictionary GPUExternalTextureDescriptor : GPUObjectDescriptorBase {
         Creates a {{GPUExternalTexture}} wrapping the provided image source.
 
         <div algorithm=GPUDevice.importExternalTexture>
-            **Called on:** {{GPUDevice}} this.
+            <div data-timeline=content>
+                **Called on:** {{GPUDevice}} this.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUDevice/importExternalTexture(descriptor)">
-                |descriptor|: Provides the external image source object (and any creation options).
-            </pre>
+                <pre class=argumentdef for="GPUDevice/importExternalTexture(descriptor)">
+                    |descriptor|: Provides the external image source object (and any creation options).
+                </pre>
 
-            **Returns:** {{GPUExternalTexture}}
+                **Returns:** {{GPUExternalTexture}}
 
-            1. Let |source| be |descriptor|.{{GPUExternalTextureDescriptor/source}}.
+                [=Content timeline=] steps:
 
-            1. Let |usability| be the result of
-                [=check the usability of the image argument|checking the usability of=] |source|
-                (which may throw an exception).
+                1. Let |source| be |descriptor|.{{GPUExternalTextureDescriptor/source}}.
 
-            1. If |usability| is `bad`, throw an {{InvalidStateError}} and stop.
+                1. Let |usability| be the result of
+                    [=check the usability of the image argument|checking the usability of=] |source|
+                    (which may throw an exception).
 
-            1. If |source| <l spec=html>[=is not origin-clean=]</l>,
-                throw a {{SecurityError}} and stop.
+                1. If |usability| is `bad`, throw an {{InvalidStateError}} and stop.
 
-            1. Let |data| be the result of converting the current image contents of |source| into
-                the color space |descriptor|.{{GPUExternalTextureDescriptor/colorSpace}}
-                with unpremultiplied alpha.
+                1. If |source| <l spec=html>[=is not origin-clean=]</l>,
+                    throw a {{SecurityError}} and stop.
 
-                This [[#color-space-conversions|may result]] in values outside of the range [0, 1].
-                If clamping is desired, it may be performed after sampling.
+                1. Let |data| be the result of converting the current image contents of |source| into
+                    the color space |descriptor|.{{GPUExternalTextureDescriptor/colorSpace}}
+                    with unpremultiplied alpha.
 
-                Note: This is described like a copy, but may be implemented as a reference to
-                read-only underlying data plus appropriate metadata to perform conversion later.
+                    This [[#color-space-conversions|may result]] in values outside of the range [0, 1].
+                    If clamping is desired, it may be performed after sampling.
 
-            1. Let |result| be a new {{GPUExternalTexture}} object wrapping |data|.
+                    Note: This is described like a copy, but may be implemented as a reference to
+                    read-only underlying data plus appropriate metadata to perform conversion later.
 
-            1. Add |result| to {{GPUExternalTexture}}.{{GPUExternalTexture/[[active_imports]]}}.
+                1. Let |result| be a new {{GPUExternalTexture}} object wrapping |data|.
 
-            1. Return |result|.
+                1. Add |result| to {{GPUExternalTexture}}.{{GPUExternalTexture/[[active_imports]]}}.
+
+                1. Return |result|.
+            </div>
         </div>
 </dl>
 
@@ -4697,49 +4750,54 @@ enum GPUCompareFunction {
         Creates a {{GPUSampler}}.
 
         <div algorithm=GPUDevice.createSampler>
-            **Called on:** {{GPUDevice}} this.
+            <div data-timeline=content>
+                **Called on:** {{GPUDevice}} this.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUDevice/createSampler(descriptor)">
-                |descriptor|: Description of the {{GPUSampler}} to create.
-            </pre>
+                <pre class=argumentdef for="GPUDevice/createSampler(descriptor)">
+                    |descriptor|: Description of the {{GPUSampler}} to create.
+                </pre>
 
-            **Returns:** {{GPUSampler}}
+                **Returns:** {{GPUSampler}}
 
-            1. Let |s| be a new {{GPUSampler}} object.
-            1. Issue the following steps on the [=Device timeline=] of |this|:
+                [=Content timeline=] steps:
 
-                <div class=device-timeline>
-                    1. If any of the following conditions are unsatisfied
-                        [$generate a validation error$], make |s| [=invalid=], and stop.
+                1. Let |s| be a new {{GPUSampler}} object.
+                1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
+                1. Return |s|.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] |initialization steps|:
 
-                        <div class=validusage>
-                            - |this| is [=valid=].
-                            - |descriptor|.{{GPUSamplerDescriptor/lodMinClamp}} &ge; 0.
-                            - |descriptor|.{{GPUSamplerDescriptor/lodMaxClamp}} &ge;
-                                |descriptor|.{{GPUSamplerDescriptor/lodMinClamp}}.
-                            - |descriptor|.{{GPUSamplerDescriptor/maxAnisotropy}} &ge; 1.
+                1. If any of the following conditions are unsatisfied
+                    [$generate a validation error$], make |s| [=invalid=], and stop.
 
-                                Note: Most implementations support {{GPUSamplerDescriptor/maxAnisotropy}}
-                                values in range between 1 and 16, inclusive. The provided
-                                {{GPUSamplerDescriptor/maxAnisotropy}} value will be clamped to the
-                                maximum value that the platform supports.
+                    <div class=validusage>
+                        - |this| is [=valid=].
+                        - |descriptor|.{{GPUSamplerDescriptor/lodMinClamp}} &ge; 0.
+                        - |descriptor|.{{GPUSamplerDescriptor/lodMaxClamp}} &ge;
+                            |descriptor|.{{GPUSamplerDescriptor/lodMinClamp}}.
+                        - |descriptor|.{{GPUSamplerDescriptor/maxAnisotropy}} &ge; 1.
 
-                            - If |descriptor|.{{GPUSamplerDescriptor/maxAnisotropy}} &gt; 1:
-                                - |descriptor|.{{GPUSamplerDescriptor/magFilter}},
-                                    |descriptor|.{{GPUSamplerDescriptor/minFilter}},
-                                    and |descriptor|.{{GPUSamplerDescriptor/mipmapFilter}} must be
-                                    {{GPUMipmapFilterMode/"linear"}}.
-                        </div>
-                    1. Set |s|.{{GPUSampler/[[descriptor]]}} to |descriptor|.
-                    1. Set |s|.{{GPUSampler/[[isComparison]]}} to `false` if the {{GPUSamplerDescriptor/compare}} attribute
-                            of |s|.{{GPUSampler/[[descriptor]]}} is `null` or undefined. Otherwise, set it to `true`.
-                    1. Set |s|.{{GPUSampler/[[isFiltering]]}} to `false` if none of {{GPUSamplerDescriptor/minFilter}},
-                        {{GPUSamplerDescriptor/magFilter}}, or {{GPUSamplerDescriptor/mipmapFilter}} has the value of
-                        {{GPUFilterMode/"linear"}}. Otherwise, set it to `true`.
-                </div>
-            1. Return |s|.
+                            Note: Most implementations support {{GPUSamplerDescriptor/maxAnisotropy}}
+                            values in range between 1 and 16, inclusive. The provided
+                            {{GPUSamplerDescriptor/maxAnisotropy}} value will be clamped to the
+                            maximum value that the platform supports.
+
+                        - If |descriptor|.{{GPUSamplerDescriptor/maxAnisotropy}} &gt; 1:
+                            - |descriptor|.{{GPUSamplerDescriptor/magFilter}},
+                                |descriptor|.{{GPUSamplerDescriptor/minFilter}},
+                                and |descriptor|.{{GPUSamplerDescriptor/mipmapFilter}} must be
+                                {{GPUMipmapFilterMode/"linear"}}.
+                    </div>
+                1. Set |s|.{{GPUSampler/[[descriptor]]}} to |descriptor|.
+                1. Set |s|.{{GPUSampler/[[isComparison]]}} to `false` if the {{GPUSamplerDescriptor/compare}} attribute
+                        of |s|.{{GPUSampler/[[descriptor]]}} is `null` or undefined. Otherwise, set it to `true`.
+                1. Set |s|.{{GPUSampler/[[isFiltering]]}} to `false` if none of {{GPUSamplerDescriptor/minFilter}},
+                    {{GPUSamplerDescriptor/magFilter}}, or {{GPUSamplerDescriptor/mipmapFilter}} has the value of
+                    {{GPUFilterMode/"linear"}}. Otherwise, set it to `true`.
+            </div>
         </div>
 </dl>
 
@@ -5148,76 +5206,80 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
         Creates a {{GPUBindGroupLayout}}.
 
         <div algorithm=GPUDevice.createBindGroupLayout>
-            **Called on:** {{GPUDevice}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUDevice}} |this|.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUDevice/createBindGroupLayout(descriptor)">
-                |descriptor|: Description of the {{GPUBindGroupLayout}} to create.
-            </pre>
+                <pre class=argumentdef for="GPUDevice/createBindGroupLayout(descriptor)">
+                    |descriptor|: Description of the {{GPUBindGroupLayout}} to create.
+                </pre>
 
-            **Returns:** {{GPUBindGroupLayout}}
+                **Returns:** {{GPUBindGroupLayout}}
 
-            1. For each {{GPUBindGroupLayoutEntry}} |entry| in |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
-                1. If |entry|.{{GPUBindGroupLayoutEntry/storageTexture}} is not `undefined`:
-                    1. [$Validate texture format required features$] for
-                        |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/format}}
-                        with |this|.{{GPUObjectBase/[[device]]}}.
-            1. Let |layout| be a new {{GPUBindGroupLayout}} object.
-            1. Issue the following steps on the [=Device timeline=] of |this|:
+                [=Content timeline=] steps:
 
-                <div class=device-timeline>
-                    1. If any of the following conditions are unsatisfied
-                        [$generate a validation error$], make |layout| [=invalid=], and stop.
+                1. For each {{GPUBindGroupLayoutEntry}} |entry| in |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
+                    1. If |entry|.{{GPUBindGroupLayoutEntry/storageTexture}} is not `undefined`:
+                        1. [$Validate texture format required features$] for
+                            |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/format}}
+                            with |this|.{{GPUObjectBase/[[device]]}}.
+                1. Let |layout| be a new {{GPUBindGroupLayout}} object.
+                1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
+                1. Return |layout|.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] |initialization steps|:
 
-                        <div class=validusage>
-                            - |this| is [=valid=].
-                            - The {{GPUBindGroupLayoutEntry/binding}} of each entry in |descriptor| is unique.
-                            - The {{GPUBindGroupLayoutEntry/binding}} of each entry in |descriptor| must be &lt; 65536.
-                            - |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}} must not
-                                [=exceeds the binding slot limits|exceed the binding slot limits=]
-                                of |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.
-                            - For each {{GPUBindGroupLayoutEntry}} |entry| in |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
-                                - Let |bufferLayout| be |entry|.{{GPUBindGroupLayoutEntry/buffer}}
-                                - Let |samplerLayout| be |entry|.{{GPUBindGroupLayoutEntry/sampler}}
-                                - Let |textureLayout| be |entry|.{{GPUBindGroupLayoutEntry/texture}}
-                                - Let |storageTextureLayout| be |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}
+                1. If any of the following conditions are unsatisfied
+                    [$generate a validation error$], make |layout| [=invalid=], and stop.
 
-                                - Exactly one of |bufferLayout|, |samplerLayout|, |textureLayout|,
-                                    or |storageTextureLayout| are not `undefined`.
+                    <div class=validusage>
+                        - |this| is [=valid=].
+                        - The {{GPUBindGroupLayoutEntry/binding}} of each entry in |descriptor| is unique.
+                        - The {{GPUBindGroupLayoutEntry/binding}} of each entry in |descriptor| must be &lt; 65536.
+                        - |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}} must not
+                            [=exceeds the binding slot limits|exceed the binding slot limits=]
+                            of |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.
+                        - For each {{GPUBindGroupLayoutEntry}} |entry| in |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
+                            - Let |bufferLayout| be |entry|.{{GPUBindGroupLayoutEntry/buffer}}
+                            - Let |samplerLayout| be |entry|.{{GPUBindGroupLayoutEntry/sampler}}
+                            - Let |textureLayout| be |entry|.{{GPUBindGroupLayoutEntry/texture}}
+                            - Let |storageTextureLayout| be |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}
 
-                                - If |entry|.{{GPUBindGroupLayoutEntry/visibility}} includes
-                                    {{GPUShaderStage/VERTEX}}:
-                                    - |entry|.{{GPUBindGroupLayoutEntry/buffer}}?.{{GPUBufferBindingLayout/type}}
-                                        must not be {{GPUBufferBindingType/"storage"}}.
-                                    - |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}?.{{GPUStorageTextureBindingLayout/access}}
-                                        must not be {{GPUStorageTextureAccess/"write-only"}}.
+                            - Exactly one of |bufferLayout|, |samplerLayout|, |textureLayout|,
+                                or |storageTextureLayout| are not `undefined`.
 
-                                - If the |textureLayout| is not `undefined` and
-                                    |textureLayout|.{{GPUTextureBindingLayout/multisampled}} is `true`:
-                                    - |textureLayout|.{{GPUTextureBindingLayout/viewDimension}} is
-                                        {{GPUTextureViewDimension/"2d"}}.
-                                    - |textureLayout|.{{GPUTextureBindingLayout/sampleType}} is not
-                                        {{GPUTextureSampleType/"float"}}.
+                            - If |entry|.{{GPUBindGroupLayoutEntry/visibility}} includes
+                                {{GPUShaderStage/VERTEX}}:
+                                - |entry|.{{GPUBindGroupLayoutEntry/buffer}}?.{{GPUBufferBindingLayout/type}}
+                                    must not be {{GPUBufferBindingType/"storage"}}.
+                                - |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}?.{{GPUStorageTextureBindingLayout/access}}
+                                    must not be {{GPUStorageTextureAccess/"write-only"}}.
 
-                                - If |storageTextureLayout| is not `undefined`:
-                                    - |storageTextureLayout|.{{GPUStorageTextureBindingLayout/viewDimension}} is not
-                                        {{GPUTextureViewDimension/"cube"}} or {{GPUTextureViewDimension/"cube-array"}}.
-                                    - |storageTextureLayout|.{{GPUStorageTextureBindingLayout/format}} must be a format
-                                        which can support storage usage.
-                        </div>
+                            - If the |textureLayout| is not `undefined` and
+                                |textureLayout|.{{GPUTextureBindingLayout/multisampled}} is `true`:
+                                - |textureLayout|.{{GPUTextureBindingLayout/viewDimension}} is
+                                    {{GPUTextureViewDimension/"2d"}}.
+                                - |textureLayout|.{{GPUTextureBindingLayout/sampleType}} is not
+                                    {{GPUTextureSampleType/"float"}}.
 
-                    1. Set |layout|.{{GPUBindGroupLayout/[[descriptor]]}} to |descriptor|.
-                    1. Set |layout|.{{GPUBindGroupLayout/[[dynamicOffsetCount]]}} to the number of
-                        entries in |descriptor| where {{GPUBindGroupLayoutEntry/buffer}} is not `undefined` and
-                        {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}} is `true`.
-                    1. For each {{GPUBindGroupLayoutEntry}} |entry| in
-                        |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
-                        1. Insert |entry| into |layout|.{{GPUBindGroupLayout/[[entryMap]]}}
-                            with the key of |entry|.{{GPUBindGroupLayoutEntry/binding}}.
-                </div>
-            1. Return |layout|.
+                            - If |storageTextureLayout| is not `undefined`:
+                                - |storageTextureLayout|.{{GPUStorageTextureBindingLayout/viewDimension}} is not
+                                    {{GPUTextureViewDimension/"cube"}} or {{GPUTextureViewDimension/"cube-array"}}.
+                                - |storageTextureLayout|.{{GPUStorageTextureBindingLayout/format}} must be a format
+                                    which can support storage usage.
+                    </div>
 
+                1. Set |layout|.{{GPUBindGroupLayout/[[descriptor]]}} to |descriptor|.
+                1. Set |layout|.{{GPUBindGroupLayout/[[dynamicOffsetCount]]}} to the number of
+                    entries in |descriptor| where {{GPUBindGroupLayoutEntry/buffer}} is not `undefined` and
+                    {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}} is `true`.
+                1. For each {{GPUBindGroupLayoutEntry}} |entry| in
+                    |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
+                    1. Insert |entry| into |layout|.{{GPUBindGroupLayout/[[entryMap]]}}
+                        with the key of |entry|.{{GPUBindGroupLayoutEntry/binding}}.
+            </div>
         </div>
 </dl>
 
@@ -5345,139 +5407,143 @@ following members:
         Creates a {{GPUBindGroup}}.
 
         <div algorithm=GPUDevice.createBindGroup>
-            **Called on:** {{GPUDevice}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUDevice}} |this|.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUDevice/createBindGroup(descriptor)">
-                |descriptor|: Description of the {{GPUBindGroup}} to create.
-            </pre>
+                <pre class=argumentdef for="GPUDevice/createBindGroup(descriptor)">
+                    |descriptor|: Description of the {{GPUBindGroup}} to create.
+                </pre>
 
-            **Returns:** {{GPUBindGroup}}
+                **Returns:** {{GPUBindGroup}}
 
-            1. Let |bindGroup| be a new {{GPUBindGroup}} object.
-            1. Issue the following steps on the [=Device timeline=] of |this|:
+                [=Content timeline=] steps:
 
-                <div class=device-timeline>
-                    1. Let |limits| be |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.
-                    1. If any of the following conditions are unsatisfied
-                        [$generate a validation error$], make |bindGroup| [=invalid=], and stop.
+                1. Let |bindGroup| be a new {{GPUBindGroup}} object.
+                1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
+                 1. Return |bindGroup|.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] |initialization steps|:
 
-                        <div class=validusage>
-                            - |descriptor|.{{GPUBindGroupDescriptor/layout}} is [$valid to use with$] |this|.
-                            - The number of {{GPUBindGroupLayoutDescriptor/entries}} of
-                                |descriptor|.{{GPUBindGroupDescriptor/layout}} is exactly equal to
-                                the number of |descriptor|.{{GPUBindGroupDescriptor/entries}}.
+                1. Let |limits| be |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.
+                1. If any of the following conditions are unsatisfied
+                    [$generate a validation error$], make |bindGroup| [=invalid=], and stop.
 
-                            For each {{GPUBindGroupEntry}} |bindingDescriptor| in
-                                |descriptor|.{{GPUBindGroupDescriptor/entries}}:
-                                - Let |resource| be |bindingDescriptor|.{{GPUBindGroupEntry/resource}}.
-                                - There is exactly one {{GPUBindGroupLayoutEntry}} |layoutBinding|
-                                    in |descriptor|.{{GPUBindGroupDescriptor/layout}}.{{GPUBindGroupLayoutDescriptor/entries}}
-                                    such that |layoutBinding|.{{GPUBindGroupLayoutEntry/binding}} equals to
-                                    |bindingDescriptor|.{{GPUBindGroupEntry/binding}}.
+                    <div class=validusage>
+                        - |descriptor|.{{GPUBindGroupDescriptor/layout}} is [$valid to use with$] |this|.
+                        - The number of {{GPUBindGroupLayoutDescriptor/entries}} of
+                            |descriptor|.{{GPUBindGroupDescriptor/layout}} is exactly equal to
+                            the number of |descriptor|.{{GPUBindGroupDescriptor/entries}}.
 
-                                - If the defined [=binding member=] for |layoutBinding| is
+                        For each {{GPUBindGroupEntry}} |bindingDescriptor| in
+                            |descriptor|.{{GPUBindGroupDescriptor/entries}}:
+                            - Let |resource| be |bindingDescriptor|.{{GPUBindGroupEntry/resource}}.
+                            - There is exactly one {{GPUBindGroupLayoutEntry}} |layoutBinding|
+                                in |descriptor|.{{GPUBindGroupDescriptor/layout}}.{{GPUBindGroupLayoutDescriptor/entries}}
+                                such that |layoutBinding|.{{GPUBindGroupLayoutEntry/binding}} equals to
+                                |bindingDescriptor|.{{GPUBindGroupEntry/binding}}.
 
-                                    <dl class=switch>
-                                        : {{GPUBindGroupLayoutEntry/sampler}}
-                                        ::
-                                            - |resource| is a {{GPUSampler}}.
-                                            - |resource| is [$valid to use with$] |this|.
-                                            - If |layoutBinding|.{{GPUBindGroupLayoutEntry/sampler}}.{{GPUSamplerBindingLayout/type}} is:
+                            - If the defined [=binding member=] for |layoutBinding| is
 
-                                                <dl class=switch>
-                                                    : {{GPUSamplerBindingType/"filtering"}}
-                                                    :: |resource|.{{GPUSampler/[[isComparison]]}} is `false`.
+                                <dl class=switch>
+                                    : {{GPUBindGroupLayoutEntry/sampler}}
+                                    ::
+                                        - |resource| is a {{GPUSampler}}.
+                                        - |resource| is [$valid to use with$] |this|.
+                                        - If |layoutBinding|.{{GPUBindGroupLayoutEntry/sampler}}.{{GPUSamplerBindingLayout/type}} is:
 
-                                                    : {{GPUSamplerBindingType/"non-filtering"}}
-                                                    ::
-                                                        |resource|.{{GPUSampler/[[isFiltering]]}} is `false`.
-                                                        |resource|.{{GPUSampler/[[isComparison]]}} is `false`.
+                                            <dl class=switch>
+                                                : {{GPUSamplerBindingType/"filtering"}}
+                                                :: |resource|.{{GPUSampler/[[isComparison]]}} is `false`.
 
-                                                    : {{GPUSamplerBindingType/"comparison"}}
-                                                    :: |resource|.{{GPUSampler/[[isComparison]]}} is `true`.
-                                                </dl>
+                                                : {{GPUSamplerBindingType/"non-filtering"}}
+                                                ::
+                                                    |resource|.{{GPUSampler/[[isFiltering]]}} is `false`.
+                                                    |resource|.{{GPUSampler/[[isComparison]]}} is `false`.
 
-                                        : {{GPUBindGroupLayoutEntry/texture}}
-                                        ::
-                                            - |resource| is a {{GPUTextureView}}.
-                                            - |resource| is [$valid to use with$] |this|.
-                                            - Let |texture| be |resource|.{{GPUTextureView/[[texture]]}}.
-                                            - |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/viewDimension}}
-                                                is equal to |resource|'s {{GPUTextureViewDescriptor/dimension}}.
-                                            - |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/sampleType}}
-                                                is [[#texture-format-caps|compatible]] with
-                                                |resource|'s {{GPUTextureViewDescriptor/format}}.
-                                            - |texture|'s {{GPUTextureDescriptor/usage}} includes {{GPUTextureUsage/TEXTURE_BINDING}}.
-                                            - If |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/multisampled}}
-                                                is `true`, |texture|'s {{GPUTextureDescriptor/sampleCount}}
-                                                &gt; `1`, Otherwise |texture|'s {{GPUTextureDescriptor/sampleCount}} is `1`.
+                                                : {{GPUSamplerBindingType/"comparison"}}
+                                                :: |resource|.{{GPUSampler/[[isComparison]]}} is `true`.
+                                            </dl>
 
-                                        : {{GPUBindGroupLayoutEntry/storageTexture}}
-                                        ::
-                                            - |resource| is a {{GPUTextureView}}.
-                                            - |resource| is [$valid to use with$] |this|.
-                                            - Let |texture| be |resource|.{{GPUTextureView/[[texture]]}}.
-                                            - |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/viewDimension}}
-                                                is equal to |resource|'s {{GPUTextureViewDescriptor/dimension}}.
-                                            - |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/format}}
-                                                is equal to |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
-                                            - |texture|'s {{GPUTextureDescriptor/usage}} includes {{GPUTextureUsage/STORAGE_BINDING}}.
-                                            - |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/mipLevelCount}} must be 1.
+                                    : {{GPUBindGroupLayoutEntry/texture}}
+                                    ::
+                                        - |resource| is a {{GPUTextureView}}.
+                                        - |resource| is [$valid to use with$] |this|.
+                                        - Let |texture| be |resource|.{{GPUTextureView/[[texture]]}}.
+                                        - |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/viewDimension}}
+                                            is equal to |resource|'s {{GPUTextureViewDescriptor/dimension}}.
+                                        - |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/sampleType}}
+                                            is [[#texture-format-caps|compatible]] with
+                                            |resource|'s {{GPUTextureViewDescriptor/format}}.
+                                        - |texture|'s {{GPUTextureDescriptor/usage}} includes {{GPUTextureUsage/TEXTURE_BINDING}}.
+                                        - If |layoutBinding|.{{GPUBindGroupLayoutEntry/texture}}.{{GPUTextureBindingLayout/multisampled}}
+                                            is `true`, |texture|'s {{GPUTextureDescriptor/sampleCount}}
+                                            &gt; `1`, Otherwise |texture|'s {{GPUTextureDescriptor/sampleCount}} is `1`.
 
-                                        :  {{GPUBindGroupLayoutEntry/buffer}}
-                                        ::
-                                            - |resource| is a {{GPUBufferBinding}}.
-                                            - |resource|.{{GPUBufferBinding/buffer}} is [$valid to use with$] |this|.
-                                            - The bound part designated by |resource|.{{GPUBufferBinding/offset}} and
-                                                |resource|.{{GPUBufferBinding/size}} resides inside the buffer and has non-zero size.
-                                            - [$effective buffer binding size$](|resource|), &ge;
-                                                |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}}.
+                                    : {{GPUBindGroupLayoutEntry/storageTexture}}
+                                    ::
+                                        - |resource| is a {{GPUTextureView}}.
+                                        - |resource| is [$valid to use with$] |this|.
+                                        - Let |texture| be |resource|.{{GPUTextureView/[[texture]]}}.
+                                        - |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/viewDimension}}
+                                            is equal to |resource|'s {{GPUTextureViewDescriptor/dimension}}.
+                                        - |layoutBinding|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/format}}
+                                            is equal to |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
+                                        - |texture|'s {{GPUTextureDescriptor/usage}} includes {{GPUTextureUsage/STORAGE_BINDING}}.
+                                        - |resource|.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/mipLevelCount}} must be 1.
 
-                                            - If |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/type}} is
+                                    :  {{GPUBindGroupLayoutEntry/buffer}}
+                                    ::
+                                        - |resource| is a {{GPUBufferBinding}}.
+                                        - |resource|.{{GPUBufferBinding/buffer}} is [$valid to use with$] |this|.
+                                        - The bound part designated by |resource|.{{GPUBufferBinding/offset}} and
+                                            |resource|.{{GPUBufferBinding/size}} resides inside the buffer and has non-zero size.
+                                        - [$effective buffer binding size$](|resource|), &ge;
+                                            |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/minBindingSize}}.
 
-                                                <dl class=switch>
-                                                    : {{GPUBufferBindingType/"uniform"}}
-                                                    ::
-                                                        - |resource|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
-                                                            includes {{GPUBufferUsage/UNIFORM}}.
-                                                        - [$effective buffer binding size$](|resource|) &le;
-                                                            |limits|.{{supported limits/maxUniformBufferBindingSize}}.
-                                                        - |resource|.{{GPUBufferBinding/offset}} is a multiple of
-                                                            |limits|.{{supported limits/minUniformBufferOffsetAlignment}}.
+                                        - If |layoutBinding|.{{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/type}} is
 
-                                                    : {{GPUBufferBindingType/"storage"}} or
-                                                        {{GPUBufferBindingType/"read-only-storage"}}
-                                                    ::
-                                                        - |resource|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
-                                                            includes {{GPUBufferUsage/STORAGE}}.
-                                                        - [$effective buffer binding size$](|resource|) &le;
-                                                            |limits|.{{supported limits/maxStorageBufferBindingSize}}.
-                                                        - |resource|.{{GPUBufferBinding/offset}} is a multiple of
-                                                            |limits|.{{supported limits/minStorageBufferOffsetAlignment}}.
-                                                </dl>
+                                            <dl class=switch>
+                                                : {{GPUBufferBindingType/"uniform"}}
+                                                ::
+                                                    - |resource|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
+                                                        includes {{GPUBufferUsage/UNIFORM}}.
+                                                    - [$effective buffer binding size$](|resource|) &le;
+                                                        |limits|.{{supported limits/maxUniformBufferBindingSize}}.
+                                                    - |resource|.{{GPUBufferBinding/offset}} is a multiple of
+                                                        |limits|.{{supported limits/minUniformBufferOffsetAlignment}}.
 
-                                        :  {{GPUBindGroupLayoutEntry/externalTexture}}
-                                        ::
-                                            - |resource| is a {{GPUExternalTexture}}.
-                                            - |resource| is [$valid to use with$] |this|.
-                                    </dl>
-                        </div>
+                                                : {{GPUBufferBindingType/"storage"}} or
+                                                    {{GPUBufferBindingType/"read-only-storage"}}
+                                                ::
+                                                    - |resource|.{{GPUBufferBinding/buffer}}.{{GPUBufferDescriptor/usage}}
+                                                        includes {{GPUBufferUsage/STORAGE}}.
+                                                    - [$effective buffer binding size$](|resource|) &le;
+                                                        |limits|.{{supported limits/maxStorageBufferBindingSize}}.
+                                                    - |resource|.{{GPUBufferBinding/offset}} is a multiple of
+                                                        |limits|.{{supported limits/minStorageBufferOffsetAlignment}}.
+                                            </dl>
 
-                    1. Let |bindGroup|.{{GPUBindGroup/[[layout]]}} =
-                        |descriptor|.{{GPUBindGroupDescriptor/layout}}.
-                    1. Let |bindGroup|.{{GPUBindGroup/[[entries]]}} =
-                        |descriptor|.{{GPUBindGroupDescriptor/entries}}.
-                    1. Let |bindGroup|.{{GPUBindGroup/[[usedResources]]}} = {}.
+                                    :  {{GPUBindGroupLayoutEntry/externalTexture}}
+                                    ::
+                                        - |resource| is a {{GPUExternalTexture}}.
+                                        - |resource| is [$valid to use with$] |this|.
+                                </dl>
+                    </div>
 
-                    1. For each {{GPUBindGroupEntry}} |bindingDescriptor| in
-                        |descriptor|.{{GPUBindGroupDescriptor/entries}}:
-                        1. Let |internalUsage| be the [=binding usage=] for |layoutBinding|.
-                        1. Each [=subresource=] seen by |resource| is added to {{GPUBindGroup/[[usedResources]]}} as |internalUsage|.
-                </div>
+                1. Let |bindGroup|.{{GPUBindGroup/[[layout]]}} =
+                    |descriptor|.{{GPUBindGroupDescriptor/layout}}.
+                1. Let |bindGroup|.{{GPUBindGroup/[[entries]]}} =
+                    |descriptor|.{{GPUBindGroupDescriptor/entries}}.
+                1. Let |bindGroup|.{{GPUBindGroup/[[usedResources]]}} = {}.
 
-            1. Return |bindGroup|.
+                1. For each {{GPUBindGroupEntry}} |bindingDescriptor| in
+                    |descriptor|.{{GPUBindGroupDescriptor/entries}}:
+                    1. Let |internalUsage| be the [=binding usage=] for |layoutBinding|.
+                    1. Each [=subresource=] seen by |resource| is added to {{GPUBindGroup/[[usedResources]]}} as |internalUsage|.
+            </div>
         </div>
 </dl>
 
@@ -5573,40 +5639,45 @@ pipeline, and have the following members:
         Creates a {{GPUPipelineLayout}}.
 
         <div algorithm=GPUDevice.createPipelineLayout>
-            **Called on:** {{GPUDevice}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUDevice}} |this|.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUDevice/createPipelineLayout(descriptor)">
-                |descriptor|: Description of the {{GPUPipelineLayout}} to create.
-            </pre>
+                <pre class=argumentdef for="GPUDevice/createPipelineLayout(descriptor)">
+                    |descriptor|: Description of the {{GPUPipelineLayout}} to create.
+                </pre>
 
-            **Returns:** {{GPUPipelineLayout}}
+                **Returns:** {{GPUPipelineLayout}}
 
-            1. Let |pl| be a new {{GPUPipelineLayout}} object.
-            1. Issue the following steps on the [=Device timeline=] of |this|:
+                [=Content timeline=] steps:
 
-                <div class=device-timeline>
-                    1. Let |limits| be |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.
-                    1. Let |allEntries| be the result of concatenating
-                        |bgl|.{{GPUBindGroupLayout/[[descriptor]]}}.{{GPUBindGroupLayoutDescriptor/entries}}
-                        for all |bgl| in |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}.
-                    1. If any of the following conditions are unsatisfied
-                        [$generate a validation error$], make |pl| [=invalid=], and stop.
+                1. Let |pl| be a new {{GPUPipelineLayout}} object.
+                1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
+                1. Return |pl|.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] |initialization steps|:
 
-                        <div class=validusage>
-                            - Every {{GPUBindGroupLayout}} in |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
-                                must be [$valid to use with$] |this| and have a {{GPUBindGroupLayout/[[exclusivePipeline]]}}
-                                of `null`.
-                            - The [=list/size=] of |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
-                                must be &le; |limits|.{{supported limits/maxBindGroups}}.
-                            - |allEntries| must not [=exceeds the binding slot limits|exceed the binding slot limits=] of |limits|.
-                        </div>
+                1. Let |limits| be |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.
+                1. Let |allEntries| be the result of concatenating
+                    |bgl|.{{GPUBindGroupLayout/[[descriptor]]}}.{{GPUBindGroupLayoutDescriptor/entries}}
+                    for all |bgl| in |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}.
+                1. If any of the following conditions are unsatisfied
+                    [$generate a validation error$], make |pl| [=invalid=], and stop.
 
-                    1. Set the |pl|.{{GPUPipelineLayout/[[bindGroupLayouts]]}} to
-                        |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}.
-                </div>
-            1. Return |pl|.
+                    <div class=validusage>
+                        - Every {{GPUBindGroupLayout}} in |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
+                            must be [$valid to use with$] |this| and have a {{GPUBindGroupLayout/[[exclusivePipeline]]}}
+                            of `null`.
+                        - The [=list/size=] of |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
+                            must be &le; |limits|.{{supported limits/maxBindGroups}}.
+                        - |allEntries| must not [=exceeds the binding slot limits|exceed the binding slot limits=] of |limits|.
+                    </div>
+
+                1. Set the |pl|.{{GPUPipelineLayout/[[bindGroupLayouts]]}} to
+                    |descriptor|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}}.
+            </div>
         </div>
 </dl>
 
@@ -5719,31 +5790,36 @@ dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
         Creates a {{GPUShaderModule}}.
 
         <div algorithm=GPUDevice.createShaderModule>
-            **Called on:** {{GPUDevice}} this.
+            <div data-timeline=content>
+                **Called on:** {{GPUDevice}} this.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUDevice/createShaderModule(descriptor)">
-                descriptor: Description of the {{GPUShaderModule}} to create.
-            </pre>
+                <pre class=argumentdef for="GPUDevice/createShaderModule(descriptor)">
+                    descriptor: Description of the {{GPUShaderModule}} to create.
+                </pre>
 
-            **Returns:** {{GPUShaderModule}}
+                **Returns:** {{GPUShaderModule}}
 
-            1. Let |sm| be a new {{GPUShaderModule}} object.
-            1. Issue the following steps on the [=Device timeline=] of |this|:
+                [=Content timeline=] steps:
 
-                <div class=device-timeline>
-                    1. If any of the following conditions are unsatisfied
-                        [$generate a validation error$], make |sm| [=invalid=], and stop.
+                1. Let |sm| be a new {{GPUShaderModule}} object.
+                1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
+                1. Return |sm|.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] |initialization steps|:
 
-                        <div class=validusage>
-                            - |this| is [=valid=].
-                        </div>
+                1. If any of the following conditions are unsatisfied
+                    [$generate a validation error$], make |sm| [=invalid=], and stop.
 
-                    Issue: Describe remaining {{GPUDevice/createShaderModule()}} validation and
-                    algorithm steps.
-                </div>
-            1. Return |sm|.
+                    <div class=validusage>
+                        - |this| is [=valid=].
+                    </div>
+
+                Issue: Describe remaining {{GPUDevice/createShaderModule()}} validation and
+                algorithm steps.
+            </div>
 
             <div class=note>
                 Note:
@@ -6511,51 +6587,55 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
         Creates a {{GPUComputePipeline}}.
 
         <div algorithm=GPUDevice.createComputePipeline>
-            **Called on:** {{GPUDevice}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUDevice}} |this|.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUDevice/createComputePipeline(descriptor)">
-                |descriptor|: Description of the {{GPUComputePipeline}} to create.
-            </pre>
+                <pre class=argumentdef for="GPUDevice/createComputePipeline(descriptor)">
+                    |descriptor|: Description of the {{GPUComputePipeline}} to create.
+                </pre>
 
-            **Returns:** {{GPUComputePipeline}}
+                **Returns:** {{GPUComputePipeline}}
 
-            1. Let |pipeline| be a new {{GPUComputePipeline}} object.
-            1. Issue the following steps on the [=Device timeline=] of |this|:
+                [=Content timeline=] steps:
 
-                <div class=device-timeline>
-                    1. Let |layout| be a new [$default pipeline layout$] for |pipeline| if
-                        |descriptor|.{{GPUPipelineDescriptorBase/layout}} is {{GPUAutoLayoutMode/"auto"}},
-                        and |descriptor|.{{GPUPipelineDescriptorBase/layout}} otherwise.
+                1. Let |pipeline| be a new {{GPUComputePipeline}} object.
+                1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
+                1. Return |pipeline|.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] |initialization steps|:
 
-                    1. If any of the following conditions are unsatisfied
-                        [$generate a validation error$], make |pipeline| [=invalid=], and stop.
+                1. Let |layout| be a new [$default pipeline layout$] for |pipeline| if
+                    |descriptor|.{{GPUPipelineDescriptorBase/layout}} is {{GPUAutoLayoutMode/"auto"}},
+                    and |descriptor|.{{GPUPipelineDescriptorBase/layout}} otherwise.
 
-                        <div class=validusage>
-                            - |layout| is [$valid to use with$] |this|.
-                            - [$validating GPUProgrammableStage$]({{GPUShaderStage/COMPUTE}},
-                                |descriptor|.{{GPUComputePipelineDescriptor/compute}}, |layout|) succeeds.
-                            - |descriptor|.{{GPUComputePipelineDescriptor/compute}} uses &le;
-                                |device|.limits.{{supported limits/maxComputeWorkgroupStorageSize}} bytes of
-                                workgroup storage.
+                1. If any of the following conditions are unsatisfied
+                    [$generate a validation error$], make |pipeline| [=invalid=], and stop.
 
-                                Issue: Better define using static use, etc.
-                            - |descriptor|.{{GPUComputePipelineDescriptor/compute}} uses &le;
-                                |device|.limits.{{supported limits/maxComputeInvocationsPerWorkgroup}} per
-                                workgroup.
+                    <div class=validusage>
+                        - |layout| is [$valid to use with$] |this|.
+                        - [$validating GPUProgrammableStage$]({{GPUShaderStage/COMPUTE}},
+                            |descriptor|.{{GPUComputePipelineDescriptor/compute}}, |layout|) succeeds.
+                        - |descriptor|.{{GPUComputePipelineDescriptor/compute}} uses &le;
+                            |device|.limits.{{supported limits/maxComputeWorkgroupStorageSize}} bytes of
+                            workgroup storage.
 
-                            - |descriptor|.{{GPUComputePipelineDescriptor/compute}}'s `workgroup_size` attribute
-                                has each component &le; the corresponding component in
-                                [|device|.limits.{{supported limits/maxComputeWorkgroupSizeX}},
-                                |device|.limits.{{supported limits/maxComputeWorkgroupSizeY}},
-                                |device|.limits.{{supported limits/maxComputeWorkgroupSizeZ}}].
-                        </div>
+                            Issue: Better define using static use, etc.
+                        - |descriptor|.{{GPUComputePipelineDescriptor/compute}} uses &le;
+                            |device|.limits.{{supported limits/maxComputeInvocationsPerWorkgroup}} per
+                            workgroup.
 
-                    1. Set |pipeline|.{{GPUPipelineBase/[[layout]]}} to |layout|.
-                </div>
-            1. Return |pipeline|.
+                        - |descriptor|.{{GPUComputePipelineDescriptor/compute}}'s `workgroup_size` attribute
+                            has each component &le; the corresponding component in
+                            [|device|.limits.{{supported limits/maxComputeWorkgroupSizeX}},
+                            |device|.limits.{{supported limits/maxComputeWorkgroupSizeY}},
+                            |device|.limits.{{supported limits/maxComputeWorkgroupSizeZ}}].
+                    </div>
 
+                1. Set |pipeline|.{{GPUPipelineBase/[[layout]]}} to |layout|.
+            </div>
         </div>
 
     : <dfn>createComputePipelineAsync(descriptor)</dfn>
@@ -6569,27 +6649,32 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
         [=queue timeline=] work on pipeline compilation.
 
         <div algorithm=GPUDevice.createComputePipelineAsync>
-            **Called on:** {{GPUDevice}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUDevice}} |this|.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUDevice/createComputePipelineAsync(descriptor)">
-                |descriptor|: Description of the {{GPUComputePipeline}} to create.
-            </pre>
+                <pre class=argumentdef for="GPUDevice/createComputePipelineAsync(descriptor)">
+                    |descriptor|: Description of the {{GPUComputePipeline}} to create.
+                </pre>
 
-            **Returns:** {{Promise}}&lt;{{GPUComputePipeline}}&gt;
+                **Returns:** {{Promise}}&lt;{{GPUComputePipeline}}&gt;
 
-            1. Let |promise| be [=a new promise=].
-            1. Issue the following steps on the [=Device timeline=] of |this|:
+                [=Content timeline=] steps:
 
-                <div class=device-timeline>
-                    1. Let |pipeline| be a new {{GPUComputePipeline}} created as if
-                        |this|.{{GPUDevice/createComputePipeline()}} was called with |descriptor|;
+                1. Let |promise| be [=a new promise=].
+                1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
+                1. Return |promise|.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] |initialization steps|:
 
-                    1. When |pipeline| is ready to be used or has been made [=invalid=], [=resolve=]
-                        |promise| with |pipeline|.
-                </div>
-            1. Return |promise|.
+                1. Let |pipeline| be a new {{GPUComputePipeline}} created as if
+                    |this|.{{GPUDevice/createComputePipeline()}} was called with |descriptor|;
+
+                1. When |pipeline| is ready to be used or has been made [=invalid=], [=resolve=]
+                    |promise| with |pipeline|.
+            </div>
         </div>
 </dl>
 
@@ -6708,60 +6793,65 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
         Creates a {{GPURenderPipeline}}.
 
         <div algorithm=GPUDevice.createRenderPipeline>
-            **Called on:** {{GPUDevice}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUDevice}} |this|.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUDevice/createRenderPipeline(descriptor)">
-                |descriptor|: Description of the {{GPURenderPipeline}} to create.
-            </pre>
+                <pre class=argumentdef for="GPUDevice/createRenderPipeline(descriptor)">
+                    |descriptor|: Description of the {{GPURenderPipeline}} to create.
+                </pre>
 
-            **Returns:** {{GPURenderPipeline}}
+                **Returns:** {{GPURenderPipeline}}
 
-            1. If |descriptor|.{{GPURenderPipelineDescriptor/fragment}} is not `undefined`:
-                1. For each non-`null` |colorState| layout descriptor in the list
-                    |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.{{GPUFragmentState/targets}}:
+                [=Content timeline=] steps:
+
+                1. If |descriptor|.{{GPURenderPipelineDescriptor/fragment}} is not `undefined`:
+                    1. For each non-`null` |colorState| layout descriptor in the list
+                        |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.{{GPUFragmentState/targets}}:
+                        1. [$Validate texture format required features$] of
+                            |colorState|.{{GPUColorTargetState/format}} with |this|.{{GPUObjectBase/[[device]]}}.
+                1. If |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}} is not `null`:
                     1. [$Validate texture format required features$] of
-                        |colorState|.{{GPUColorTargetState/format}} with |this|.{{GPUObjectBase/[[device]]}}.
-            1. If |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}} is not `null`:
-                1. [$Validate texture format required features$] of
-                    |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}.{{GPUDepthStencilState/format}}
-                    with |this|.{{GPUObjectBase/[[device]]}}.
-            1. Let |pipeline| be a new {{GPURenderPipeline}} object.
-            1. Issue the following steps on the [=Device timeline=] of |this|:
+                        |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}.{{GPUDepthStencilState/format}}
+                        with |this|.{{GPUObjectBase/[[device]]}}.
+                1. Let |pipeline| be a new {{GPURenderPipeline}} object.
+                1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
+                1. Return |pipeline|.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] |initialization steps|:
 
-                <div class=device-timeline>
-                    1. Let |layout| be a new [$default pipeline layout$] for |pipeline| if
-                        |descriptor|.{{GPUPipelineDescriptorBase/layout}} is {{GPUAutoLayoutMode/"auto"}},
-                        and |descriptor|.{{GPUPipelineDescriptorBase/layout}} otherwise.
-                    1. If any of the following conditions are unsatisfied:
-                        [$generate a validation error$], make |pipeline| [=invalid=], and stop.
+                1. Let |layout| be a new [$default pipeline layout$] for |pipeline| if
+                    |descriptor|.{{GPUPipelineDescriptorBase/layout}} is {{GPUAutoLayoutMode/"auto"}},
+                    and |descriptor|.{{GPUPipelineDescriptorBase/layout}} otherwise.
+                1. If any of the following conditions are unsatisfied:
+                    [$generate a validation error$], make |pipeline| [=invalid=], and stop.
 
-                        <div class=validusage>
-                            - |layout| is [$valid to use with$] |this|.
-                            - [$validating GPURenderPipelineDescriptor$](|descriptor|, |layout|, |this|) succeeds.
-                        </div>
-                    1. Set |pipeline|.{{GPURenderPipeline/[[descriptor]]}} to |descriptor|.
-                    1. Set |pipeline|.{{GPURenderPipeline/[[writesDepth]]}} to false.
-                    1. Set |pipeline|.{{GPURenderPipeline/[[writesStencil]]}} to false.
-                    1. Let |depthStencil| be |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}.
-                    1. If |depthStencil| is not null:
-                        1. Set |pipeline|.{{GPURenderPipeline/[[writesDepth]]}} to |depthStencil|.{{GPUDepthStencilState/depthWriteEnabled}}.
-                        1. If |depthStencil|.{{GPUDepthStencilState/stencilWriteMask}} is not 0:
-                            1. Let |stencilFront| be |depthStencil|.{{GPUDepthStencilState/stencilFront}}.
-                            1. Let |stencilBack| be |depthStencil|.{{GPUDepthStencilState/stencilBack}}.
-                            1. Let |cullMode| be |descriptor|.{{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/cullMode}}.
-                            1. If |cullMode| is not {{GPUCullMode/"front"}}, and any of |stencilFront|.{{GPUStencilFaceState/passOp}},
-                                |stencilFront|.{{GPUStencilFaceState/depthFailOp}}, or |stencilFront|.{{GPUStencilFaceState/failOp}}
-                                is not {{GPUStencilOperation/"keep"}}:
-                                1. Set |pipeline|.{{GPURenderPipeline/[[writesStencil]]}} to true.
-                            1. If |cullMode| is not {{GPUCullMode/"back"}}, and any of |stencilBack|.{{GPUStencilFaceState/passOp}},
-                                |stencilBack|.{{GPUStencilFaceState/depthFailOp}}, or |stencilBack|.{{GPUStencilFaceState/failOp}}
-                                is not {{GPUStencilOperation/"keep"}}:
-                                1. Set |pipeline|.{{GPURenderPipeline/[[writesStencil]]}} to true.
-                    1. Set |pipeline|.{{GPUPipelineBase/[[layout]]}} to |layout|.
-                </div>
-            1. Return |pipeline|.
+                    <div class=validusage>
+                        - |layout| is [$valid to use with$] |this|.
+                        - [$validating GPURenderPipelineDescriptor$](|descriptor|, |layout|, |this|) succeeds.
+                    </div>
+                1. Set |pipeline|.{{GPURenderPipeline/[[descriptor]]}} to |descriptor|.
+                1. Set |pipeline|.{{GPURenderPipeline/[[writesDepth]]}} to false.
+                1. Set |pipeline|.{{GPURenderPipeline/[[writesStencil]]}} to false.
+                1. Let |depthStencil| be |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}.
+                1. If |depthStencil| is not null:
+                    1. Set |pipeline|.{{GPURenderPipeline/[[writesDepth]]}} to |depthStencil|.{{GPUDepthStencilState/depthWriteEnabled}}.
+                    1. If |depthStencil|.{{GPUDepthStencilState/stencilWriteMask}} is not 0:
+                        1. Let |stencilFront| be |depthStencil|.{{GPUDepthStencilState/stencilFront}}.
+                        1. Let |stencilBack| be |depthStencil|.{{GPUDepthStencilState/stencilBack}}.
+                        1. Let |cullMode| be |descriptor|.{{GPURenderPipelineDescriptor/primitive}}.{{GPUPrimitiveState/cullMode}}.
+                        1. If |cullMode| is not {{GPUCullMode/"front"}}, and any of |stencilFront|.{{GPUStencilFaceState/passOp}},
+                            |stencilFront|.{{GPUStencilFaceState/depthFailOp}}, or |stencilFront|.{{GPUStencilFaceState/failOp}}
+                            is not {{GPUStencilOperation/"keep"}}:
+                            1. Set |pipeline|.{{GPURenderPipeline/[[writesStencil]]}} to true.
+                        1. If |cullMode| is not {{GPUCullMode/"back"}}, and any of |stencilBack|.{{GPUStencilFaceState/passOp}},
+                            |stencilBack|.{{GPUStencilFaceState/depthFailOp}}, or |stencilBack|.{{GPUStencilFaceState/failOp}}
+                            is not {{GPUStencilOperation/"keep"}}:
+                            1. Set |pipeline|.{{GPURenderPipeline/[[writesStencil]]}} to true.
+                1. Set |pipeline|.{{GPUPipelineBase/[[layout]]}} to |layout|.
+            </div>
 
             Issue: need description of the render states.
         </div>
@@ -6777,27 +6867,33 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
         [=queue timeline=] work on pipeline compilation.
 
         <div algorithm=GPUDevice.createRenderPipelineAsync>
-            **Called on:** {{GPUDevice}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUDevice}} |this|.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUDevice/createRenderPipelineAsync(descriptor)">
-                |descriptor|: Description of the {{GPURenderPipeline}} to create.
-            </pre>
+                <pre class=argumentdef for="GPUDevice/createRenderPipelineAsync(descriptor)">
+                    |descriptor|: Description of the {{GPURenderPipeline}} to create.
+                </pre>
 
-            **Returns:** {{Promise}}&lt;{{GPURenderPipeline}}&gt;
+                **Returns:** {{Promise}}&lt;{{GPURenderPipeline}}&gt;
 
-            1. Let |promise| be [=a new promise=].
-            1. Issue the following steps on the [=Device timeline=] of |this|:
+                [=Content timeline=] steps:
 
-                <div class=device-timeline>
-                    1. Let |pipeline| be a new {{GPURenderPipeline}} created as if
-                        |this|.{{GPUDevice/createRenderPipeline()}} was called with |descriptor|;
+                1. Let |promise| be [=a new promise=].
+                1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
+                1. Return |promise|.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] |initialization steps|:
 
-                    1. When |pipeline| is ready to be used or has been made [=invalid=], [=resolve=]
-                        |promise| with |pipeline|.
-                </div>
-            1. Return |promise|.
+                1. Let |pipeline| be a new {{GPURenderPipeline}} created as if
+                    |this|.{{GPUDevice/createRenderPipeline()}} was called with |descriptor|;
+
+                1. When |pipeline| is ready to be used or has been made [=invalid=], [=resolve=]
+                    |promise| with |pipeline|.
+            </div>
+            
         </div>
 </dl>
 
@@ -8194,31 +8290,36 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
         Creates a {{GPUCommandEncoder}}.
 
         <div algorithm=GPUDevice.createCommandEncoder>
-            **Called on:** {{GPUDevice}} this.
+            <div data-timeline=content>
+                **Called on:** {{GPUDevice}} this.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUDevice/createCommandEncoder(descriptor)">
-                descriptor: Description of the {{GPUCommandEncoder}} to create.
-            </pre>
+                <pre class=argumentdef for="GPUDevice/createCommandEncoder(descriptor)">
+                    descriptor: Description of the {{GPUCommandEncoder}} to create.
+                </pre>
 
-            **Returns:** {{GPUCommandEncoder}}
+                **Returns:** {{GPUCommandEncoder}}
 
-            1. Let |e| be a new {{GPUCommandEncoder}} object.
-            1. Issue the following steps on the [=Device timeline=] of |this|:
+                [=Content timeline=] steps:
 
-                <div class=device-timeline>
-                    1. If any of the following conditions are unsatisfied
-                        [$generate a validation error$], make |e| [=invalid=], and stop.
+                1. Let |e| be a new {{GPUCommandEncoder}} object.
+                1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
+                1. Return |e|.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] |initialization steps|:
 
-                        <div class=validusage>
-                            - |this| is [=valid=].
-                        </div>
+                1. If any of the following conditions are unsatisfied
+                    [$generate a validation error$], make |e| [=invalid=], and stop.
 
-                    Issue: Describe remaining {{GPUDevice/createCommandEncoder()}} validation and
-                    algorithm steps.
-                </div>
-            1. Return |e|.
+                    <div class=validusage>
+                        - |this| is [=valid=].
+                    </div>
+
+                Issue: Describe remaining {{GPUDevice/createCommandEncoder()}} validation and
+                algorithm steps.
+            </div>
         </div>
 </dl>
 
@@ -10998,51 +11099,56 @@ GPURenderBundleEncoder includes GPURenderCommandsMixin;
         Creates a {{GPURenderBundleEncoder}}.
 
         <div algorithm=GPUDevice.createRenderBundleEncoder>
-            **Called on:** {{GPUDevice}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUDevice}} |this|.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUDevice/createRenderBundleEncoder(descriptor)">
-                |descriptor|: Description of the {{GPURenderBundleEncoder}} to create.
-            </pre>
+                <pre class=argumentdef for="GPUDevice/createRenderBundleEncoder(descriptor)">
+                    |descriptor|: Description of the {{GPURenderBundleEncoder}} to create.
+                </pre>
 
-            **Returns:** {{GPURenderBundleEncoder}}
+                **Returns:** {{GPURenderBundleEncoder}}
 
-            1. [$Validate texture format required features$] of each element of
-                |descriptor|.{{GPURenderPassLayout/colorFormats}} with |this|.{{GPUObjectBase/[[device]]}}.
-            1. [$Validate texture format required features$] of
-                |descriptor|.{{GPURenderPassLayout/depthStencilFormat}} with |this|.{{GPUObjectBase/[[device]]}}.
-            1. Let |e| be a new {{GPURenderBundleEncoder}} object.
-            1. Issue the following steps on the [=Device timeline=] of |this|:
+                [=Content timeline=] steps:
 
-                <div class=device-timeline>
-                    1. If any of the following conditions are unsatisfied
-                        [$generate a validation error$], make |e| [=invalid=], and stop.
+                1. [$Validate texture format required features$] of each element of
+                    |descriptor|.{{GPURenderPassLayout/colorFormats}} with |this|.{{GPUObjectBase/[[device]]}}.
+                1. [$Validate texture format required features$] of
+                    |descriptor|.{{GPURenderPassLayout/depthStencilFormat}} with |this|.{{GPUObjectBase/[[device]]}}.
+                1. Let |e| be a new {{GPURenderBundleEncoder}} object.
+                1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
+                1. Return |e|.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] |initialization steps|:
 
-                        <div class=validusage>
-                            - |this| is [=valid=].
-                            - |descriptor|.{{GPURenderPassLayout/colorFormats}}.length must be &le;
-                                |this|.{{device/[[limits]]}}.{{supported limits/maxColorAttachments}}.
-                            - If |descriptor|.{{GPURenderPassLayout/colorFormats}} only contains `null` members:
-                                - |descriptor|.{{GPURenderPassLayout/depthStencilFormat}} must not be `null`.
-                            - For each |colorFormat| in |descriptor|.{{GPURenderPassLayout/colorFormats}}:
-                                - |colorFormat| is `null`, or it must be a [=color renderable format=].
-                            - Let |depthStencilFormat| be |descriptor|.{{GPURenderPassLayout/depthStencilFormat}}.
-                            - If |depthStencilFormat| is not `null`:
-                                - |depthStencilFormat| must be a [=depth-or-stencil format=].
-                                - If |depthStencilFormat| is a [=combined depth-stencil format=]:
-                                    - |descriptor|.{{GPURenderBundleEncoderDescriptor/depthReadOnly}} must be equal to
-                                        |descriptor|.{{GPURenderBundleEncoderDescriptor/stencilReadOnly}}
-                        </div>
-                    1. Set |e|.{{GPURenderCommandsMixin/[[layout]]}} to a copy of |descriptor|'s included {{GPURenderPassLayout}} interface.
-                    1. Set |e|.{{GPURenderCommandsMixin/[[depthReadOnly]]}} to |descriptor|.{{GPURenderBundleEncoderDescriptor/depthReadOnly}}.
-                    1. Set |e|.{{GPURenderCommandsMixin/[[stencilReadOnly]]}} to |descriptor|.{{GPURenderBundleEncoderDescriptor/stencilReadOnly}}.
-                    1. Set |e|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/open=]".
-                    1. Set |e|.{{GPURenderCommandsMixin/[[drawCount]]}} to 0.
+                1. If any of the following conditions are unsatisfied
+                    [$generate a validation error$], make |e| [=invalid=], and stop.
 
-                    Issue: Describe the reset of the steps for {{GPUDevice/createRenderBundleEncoder()}}.
-                </div>
-            1. Return |e|.
+                    <div class=validusage>
+                        - |this| is [=valid=].
+                        - |descriptor|.{{GPURenderPassLayout/colorFormats}}.length must be &le;
+                            |this|.{{device/[[limits]]}}.{{supported limits/maxColorAttachments}}.
+                        - If |descriptor|.{{GPURenderPassLayout/colorFormats}} only contains `null` members:
+                            - |descriptor|.{{GPURenderPassLayout/depthStencilFormat}} must not be `null`.
+                        - For each |colorFormat| in |descriptor|.{{GPURenderPassLayout/colorFormats}}:
+                            - |colorFormat| is `null`, or it must be a [=color renderable format=].
+                        - Let |depthStencilFormat| be |descriptor|.{{GPURenderPassLayout/depthStencilFormat}}.
+                        - If |depthStencilFormat| is not `null`:
+                            - |depthStencilFormat| must be a [=depth-or-stencil format=].
+                            - If |depthStencilFormat| is a [=combined depth-stencil format=]:
+                                - |descriptor|.{{GPURenderBundleEncoderDescriptor/depthReadOnly}} must be equal to
+                                    |descriptor|.{{GPURenderBundleEncoderDescriptor/stencilReadOnly}}
+                    </div>
+                1. Set |e|.{{GPURenderCommandsMixin/[[layout]]}} to a copy of |descriptor|'s included {{GPURenderPassLayout}} interface.
+                1. Set |e|.{{GPURenderCommandsMixin/[[depthReadOnly]]}} to |descriptor|.{{GPURenderBundleEncoderDescriptor/depthReadOnly}}.
+                1. Set |e|.{{GPURenderCommandsMixin/[[stencilReadOnly]]}} to |descriptor|.{{GPURenderBundleEncoderDescriptor/stencilReadOnly}}.
+                1. Set |e|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/open=]".
+                1. Set |e|.{{GPURenderCommandsMixin/[[drawCount]]}} to 0.
+
+                Issue: Describe the reset of the steps for {{GPUDevice/createRenderBundleEncoder()}}.
+            </div>
         </div>
 </dl>
 
@@ -11488,36 +11594,41 @@ dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
         Creates a {{GPUQuerySet}}.
 
         <div algorithm=GPUDevice.createQuerySet>
-            **Called on:** {{GPUDevice}} this.
+            <div data-timeline=content>
+                **Called on:** {{GPUDevice}} this.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUDevice/createQuerySet(descriptor)">
-                descriptor: Description of the {{GPUQuerySet}} to create.
-            </pre>
+                <pre class=argumentdef for="GPUDevice/createQuerySet(descriptor)">
+                    descriptor: Description of the {{GPUQuerySet}} to create.
+                </pre>
 
-            **Returns:** {{GPUQuerySet}}
+                **Returns:** {{GPUQuerySet}}
 
-            1. If |descriptor|.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/"timestamp"}},
-                but |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} does not [=list/contain=]
-                {{GPUFeatureName/"timestamp-query"}}, throw a {{TypeError}}.
-            1. Let |q| be a new {{GPUQuerySet}} object.
-            1. Set |q|.{{GPUQuerySet/type}} to |descriptor|.{{GPUQuerySetDescriptor/type}}.
-            1. Set |q|.{{GPUQuerySet/count}} to |descriptor|.{{GPUQuerySetDescriptor/count}}.
-            1. Issue the following steps on the [=Device timeline=] of |this|:
+                [=Content timeline=] steps:
 
-                <div class=device-timeline>
-                    1. If any of the following requirements are unmet, [$generate a validation error$],
-                        make |q| [=invalid=], and stop.
+                1. If |descriptor|.{{GPUQuerySetDescriptor/type}} is {{GPUQueryType/"timestamp"}},
+                    but |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} does not [=list/contain=]
+                    {{GPUFeatureName/"timestamp-query"}}, throw a {{TypeError}}.
+                1. Let |q| be a new {{GPUQuerySet}} object.
+                1. Set |q|.{{GPUQuerySet/type}} to |descriptor|.{{GPUQuerySetDescriptor/type}}.
+                1. Set |q|.{{GPUQuerySet/count}} to |descriptor|.{{GPUQuerySetDescriptor/count}}.
+                1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
+                1. Return |q|.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] |initialization steps|:
 
-                        <div class=validusage>
-                            - |this| is [=valid=].
-                            - |descriptor|.{{GPUQuerySetDescriptor/count}} must be &le; 8192.
-                        </div>
+                1. If any of the following requirements are unmet, [$generate a validation error$],
+                    make |q| [=invalid=], and stop.
 
-                    1. Set |q|.{{GPUQuerySet/[[state]]}} to [=query set state/available=].
-                </div>
-            1. Return |q|.
+                    <div class=validusage>
+                        - |this| is [=valid=].
+                        - |descriptor|.{{GPUQuerySetDescriptor/count}} must be &le; 8192.
+                    </div>
+
+                1. Set |q|.{{GPUQuerySet/[[state]]}} to [=query set state/available=].
+            </div>
         </div>
 </dl>
 


### PR DESCRIPTION
Partially addresses #2961

Converts all the `Create*` methods (and a few others) to the new timeline style. Fairly straightforward, as they all generally follow the same pattern. Might want to view the diffs without whitespace, though.