### PR TITLE
wgsl: Fix the description of inverse triangle functions

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -11169,7 +11169,7 @@ fn arrayLength(p: ptr<storage, array<E>, AM>) -> u32
     <td>[ALLFLOATINGDECL]
   <tr>
     <td>Description
-    <td>Returns the ionverse hyperbolic cosine (cosh<sup>-1</sup>) of `e`.
+    <td>Returns the inverse hyperbolic cosine (cosh<sup>-1</sup>) of `e`.
     The result is 0 when `e` &lt; 1.<br>
     Computes the non-negative functional inverse of `cosh`.<br>
     [=Component-wise=] when `T` is a vector.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -11153,7 +11153,7 @@ fn arrayLength(p: ptr<storage, array<E>, AM>) -> u32
     <td>[ALLFLOATINGDECL]
   <tr>
     <td>Description
-    <td>Returns the arc cosine of `e`.
+    <td>Returns the inverse cosine (cos<sup>-1</sup>) of `e`.
     [=Component-wise=] when `T` is a vector.
 </table>
 
@@ -11169,7 +11169,7 @@ fn arrayLength(p: ptr<storage, array<E>, AM>) -> u32
     <td>[ALLFLOATINGDECL]
   <tr>
     <td>Description
-    <td>Returns the hyperbolic arc cosine of `e`.
+    <td>Returns the ionverse hyperbolic cosine (cosh<sup>-1</sup>) of `e`.
     The result is 0 when `e` &lt; 1.<br>
     Computes the non-negative functional inverse of `cosh`.<br>
     [=Component-wise=] when `T` is a vector.
@@ -11193,7 +11193,7 @@ Note: The result is not mathematically meaningful when `e` &lt; 1.
     <td>[ALLFLOATINGDECL]
   <tr>
     <td>Description
-    <td>Returns the arc sine of `e`.
+    <td>Returns the inverse sine (sin<sup>-1</sup>) of `e`.
     [=Component-wise=] when `T` is a vector.
 </table>
 
@@ -11209,7 +11209,7 @@ Note: The result is not mathematically meaningful when `e` &lt; 1.
     <td>[ALLFLOATINGDECL]
   <tr>
     <td>Description
-    <td>Returns the hyperbolic arc sine of `e`.<br>
+    <td>Returns the inverse hyperbolic sine (sin<sup>-1</sup>) of `e`.<br>
     Computes the functional inverse of `sinh`.<br>
     [=Component-wise=] when `T` is a vector.
 </table>
@@ -11226,7 +11226,7 @@ Note: The result is not mathematically meaningful when `e` &lt; 1.
     <td>[ALLFLOATINGDECL]
   <tr>
     <td>Description
-    <td>Returns the arc tangent of `e`.
+    <td>Returns the inverse tangent (tan<sup>-1</sup>) of `e`.
     [=Component-wise=] when `T` is a vector.
 </table>
 
@@ -11242,7 +11242,7 @@ Note: The result is not mathematically meaningful when `e` &lt; 1.
     <td>[ALLFLOATINGDECL]
   <tr>
     <td>Description
-    <td>Returns the hyperbolic arc tangent of `e`.
+    <td>Returns the inverse hyperbolic tangent (tanh<sup>-1</sup>) of `e`.
     The result is 0 when `abs(e)` &ge; 1.<br>
     Computes the functional inverse of `tanh`.<br>
     [=Component-wise=] when `T` is a vector.
@@ -11267,7 +11267,7 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
     <td>[ALLFLOATINGDECL]
   <tr>
     <td>Description
-    <td>Returns the arc tangent of `e1` over `e2`.
+    <td>Returns the inverse tangent (tan<sup>-1</sup>) of `e1` over `e2`.
     [=Component-wise=] when `T` is a vector.
 </table>
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -11209,7 +11209,7 @@ Note: The result is not mathematically meaningful when `e` &lt; 1.
     <td>[ALLFLOATINGDECL]
   <tr>
     <td>Description
-    <td>Returns the inverse hyperbolic sine (sin<sup>-1</sup>) of `e`.<br>
+    <td>Returns the inverse hyperbolic sine (sinh<sup>-1</sup>) of `e`.<br>
     Computes the functional inverse of `sinh`.<br>
     [=Component-wise=] when `T` is a vector.
 </table>


### PR DESCRIPTION
This PR fix the description of acos, acosh, asin, asinh, atan, atanh, and atan2 to "inverse [hyperbolic] cosine/sine/tangent".

Issue: #3323