### PR TITLE
Update remaining method algorithms to new timeline style

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6010,11 +6010,15 @@ Note: {{GPUCompilationMessage}}.{{GPUCompilationMessage/offset}} and
         In particular, messages may not be ordered by {{GPUCompilationMessage/lineNum}}.
 
         <div algorithm=GPUShaderModule.compilationInfo>
-            **Called on:** {{GPUShaderModule}} this
+            <div data-timeline=content>
+                **Called on:** {{GPUShaderModule}} this
 
-            **Returns:** {{Promise}}&lt;{{GPUCompilationInfo}}&gt;
+                **Returns:** {{Promise}}&lt;{{GPUCompilationInfo}}&gt;
 
-            Issue: Describe {{GPUShaderModule/compilationInfo()}} algorithm steps.
+                [=Content timeline=] steps:
+
+                Issue: Describe {{GPUShaderModule/compilationInfo()}} algorithm steps.
+            </div>
         </div>
 </dl>
 
@@ -6071,36 +6075,48 @@ interface mixin GPUPipelineBase {
         {{GPUBindGroupLayout}} at `index`.
 
         <div algorithm=GPUPipelineBase.getBindGroupLayout>
-            **Called on:** {{GPUPipelineBase}} |this|
+            <div data-timeline=content>
+                **Called on:** {{GPUPipelineBase}} |this|
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUPipelineBase/getBindGroupLayout(index)">
-                |index|: Index into the pipeline layout's {{GPUPipelineLayout/[[bindGroupLayouts]]}}
-                    sequence.
-            </pre>
+                <pre class=argumentdef for="GPUPipelineBase/getBindGroupLayout(index)">
+                    |index|: Index into the pipeline layout's {{GPUPipelineLayout/[[bindGroupLayouts]]}}
+                        sequence.
+                </pre>
 
-            **Returns:** {{GPUBindGroupLayout}}
+                **Returns:** {{GPUBindGroupLayout}}
 
-            1. If |index| &ge;
-                |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroups}}:
-                1. Throw a {{RangeError}}.
+                [=Content timeline=] steps:
 
-            1. If |this| is not [=valid=]:
-                1. Return a new error {{GPUBindGroupLayout}}.
+                1. If |index| &ge;
+                    |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroups}}:
+                    1. Throw a {{RangeError}}.
+                1. Let |layout| be a new {{GPUBindGroupLayout}} object.
+                1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
+                1. Return |layout|.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] |initialization steps|:
 
-            1. If |index| &ge; the [=list/size=] of
-                |this|.{{GPUPipelineBase/[[layout]]}}.{{GPUPipelineLayout/[[bindGroupLayouts]]}}:
-                1. Return a new error {{GPUBindGroupLayout}}.
+                1. If any of the following conditions are unsatisfied
+                    [$generate a validation error$], make |layout| [=invalid=], and stop.
+                
+                    <div class=validusage>
+                        - |this| is [=valid=].
+                        - |index| &lt; the [=list/size=] of
+                            |this|.{{GPUPipelineBase/[[layout]]}}.{{GPUPipelineLayout/[[bindGroupLayouts]]}}
+                    </div>
 
-            1. Return a new {{GPUBindGroupLayout}} object that references the same internal object as
-                |this|.{{GPUPipelineBase/[[layout]]}}.{{GPUPipelineLayout/[[bindGroupLayouts]]}}[|index|].
+                1. Update |layout| to reference the same internal object as
+                    |this|.{{GPUPipelineBase/[[layout]]}}.{{GPUPipelineLayout/[[bindGroupLayouts]]}}[|index|].
 
-            Issue: Specify this more properly once we have internal objects for {{GPUBindGroupLayout}}.
-                Alternatively only spec is as a new internal objects that's [=group-equivalent=]
+                Issue: Specify this more properly once we have internal objects for {{GPUBindGroupLayout}}.
+                    Alternatively only spec is as a new internal objects that's [=group-equivalent=]
 
-            Note: Only returning new {{GPUBindGroupLayout}} objects ensures no synchronization is necessary
-                between the [=Content timeline=] and the [=Device timeline=].
+                Note: Only returning new {{GPUBindGroupLayout}} objects ensures no synchronization is necessary
+                    between the [=Content timeline=] and the [=Device timeline=].
+            </div>
         </div>
 </dl>
 
@@ -8343,66 +8359,70 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
         Begins encoding a render pass described by |descriptor|.
 
         <div algorithm=GPUCommandEncoder.beginRenderPass>
-            **Called on:** {{GPUCommandEncoder}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUCommandEncoder}} |this|.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUCommandEncoder/beginRenderPass(descriptor)">
-                |descriptor|: Description of the {{GPURenderPassEncoder}} to create.
-            </pre>
+                <pre class=argumentdef for="GPUCommandEncoder/beginRenderPass(descriptor)">
+                    |descriptor|: Description of the {{GPURenderPassEncoder}} to create.
+                </pre>
 
-            **Returns:** {{GPURenderPassEncoder}}
+                **Returns:** {{GPURenderPassEncoder}}
 
-            1. Let |pass| be a new {{GPURenderPassEncoder}} object.
-            1. Issue the following steps on the [=Device timeline=] of |this|:
+                [=Content timeline=] steps:
 
-                <div class=device-timeline>
-                    1. If any of the following conditions are unsatisfied
-                        [$generate a validation error$], make |pass| [=invalid=], and stop.
+                1. Let |pass| be a new {{GPURenderPassEncoder}} object.
+                1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
+                1. Return |pass|.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] |initialization steps|:
 
-                        <div class=validusage>
-                            - |this|.{{GPUCommandsMixin/[[state]]}} is "[=encoder state/open=]".
-                            - |descriptor| meets the
-                                [$GPURenderPassDescriptor/Valid Usage$] rules.
-                            - |descriptor|.{{GPURenderPassDescriptor/timestampWrites}} is empty, or
-                                |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} [=list/contain=]s
-                                {{GPUFeatureName/"timestamp-query"}}.
-                            - For each |timestampWrite| in |descriptor|.{{GPURenderPassDescriptor/timestampWrites}},
-                                - |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}} is [$valid to use with$] |this|.
-                        </div>
+                1. If any of the following conditions are unsatisfied
+                    [$generate a validation error$], make |pass| [=invalid=], and stop.
 
-                    1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/locked=]".
-                    1. For each non-`null` |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
-                        1. The [=texture subresource=] seen by |colorAttachment|.{{GPURenderPassColorAttachment/view}}
-                            is considered to be used as [=internal usage/attachment=] for the
-                            duration of the render pass.
-                    1. Let |depthStencilAttachment| be |descriptor|.{{GPURenderPassDescriptor/depthStencilAttachment}}.
-                    1. If |depthStencilAttachment| is not `null`:
-                        1. Let |depthStencilView| be |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/view}}.
-                        1. If |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} and
-                            {{GPURenderPassDepthStencilAttachment/stencilReadOnly}} are `true`:
-                            1. The [=texture subresources=] seen by |depthStencilView|
-                                are considered to be used as [=internal usage/attachment-read=] for the duration of the render pass.
+                    <div class=validusage>
+                        - |this|.{{GPUCommandsMixin/[[state]]}} is "[=encoder state/open=]".
+                        - |descriptor| meets the
+                            [$GPURenderPassDescriptor/Valid Usage$] rules.
+                        - |descriptor|.{{GPURenderPassDescriptor/timestampWrites}} is empty, or
+                            |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} [=list/contain=]s
+                            {{GPUFeatureName/"timestamp-query"}}.
+                        - For each |timestampWrite| in |descriptor|.{{GPURenderPassDescriptor/timestampWrites}},
+                            - |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}} is [$valid to use with$] |this|.
+                    </div>
 
-                                Issue: Describe this in terms of a "set of subresources of" algorithm.
-                        1. Else, the [=texture subresource=] seen by |depthStencilView|
-                            is considered to be used as [=internal usage/attachment=] for the duration of the render pass.
-                        1. Set |pass|.{{GPURenderCommandsMixin/[[depthReadOnly]]}} to |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}}.
-                        1. Set |pass|.{{GPURenderCommandsMixin/[[stencilReadOnly]]}} to |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}}.
-                    1. Set |pass|.{{GPURenderCommandsMixin/[[layout]]}} to [$derive render targets layout from pass$](|descriptor|).
-                    1. For each |timestampWrite| in |descriptor|.{{GPURenderPassDescriptor/timestampWrites}},
-                        1. If |timestampWrite|.{{GPURenderPassTimestampWrite/location}} is {{GPURenderPassTimestampLocation/"beginning"}},
-                            [=list/append=] a [=GPU command=] to |this|.{{GPUCommandsMixin/[[commands]]}}
-                            that writes the GPU's timestamp value into the |timestampWrite|.{{GPURenderPassTimestampWrite/queryIndex}}th
-                            index in |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}}.
-                        1. Otherwise, if |timestampWrite|.{{GPURenderPassTimestampWrite/location}} is {{GPURenderPassTimestampLocation/"end"}},
-                            [=list/Append=] |timestampWrite| to |pass|.{{GPURenderPassEncoder/[[endTimestampWrites]]}}.
-                    1. Set |pass|.{{GPURenderCommandsMixin/[[drawCount]]}} to 0.
-                    1. Set |pass|.{{GPURenderPassEncoder/[[maxDrawCount]]}} to |descriptor|.{{GPURenderPassDescriptor/maxDrawCount}}.
-                    1. Issue: Enqueue attachment loads/clears.
+                1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/locked=]".
+                1. For each non-`null` |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
+                    1. The [=texture subresource=] seen by |colorAttachment|.{{GPURenderPassColorAttachment/view}}
+                        is considered to be used as [=internal usage/attachment=] for the
+                        duration of the render pass.
+                1. Let |depthStencilAttachment| be |descriptor|.{{GPURenderPassDescriptor/depthStencilAttachment}}.
+                1. If |depthStencilAttachment| is not `null`:
+                    1. Let |depthStencilView| be |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/view}}.
+                    1. If |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} and
+                        {{GPURenderPassDepthStencilAttachment/stencilReadOnly}} are `true`:
+                        1. The [=texture subresources=] seen by |depthStencilView|
+                            are considered to be used as [=internal usage/attachment-read=] for the duration of the render pass.
 
-                </div>
-            1. Return |pass|.
+                            Issue: Describe this in terms of a "set of subresources of" algorithm.
+                    1. Else, the [=texture subresource=] seen by |depthStencilView|
+                        is considered to be used as [=internal usage/attachment=] for the duration of the render pass.
+                    1. Set |pass|.{{GPURenderCommandsMixin/[[depthReadOnly]]}} to |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}}.
+                    1. Set |pass|.{{GPURenderCommandsMixin/[[stencilReadOnly]]}} to |depthStencilAttachment|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}}.
+                1. Set |pass|.{{GPURenderCommandsMixin/[[layout]]}} to [$derive render targets layout from pass$](|descriptor|).
+                1. For each |timestampWrite| in |descriptor|.{{GPURenderPassDescriptor/timestampWrites}},
+                    1. If |timestampWrite|.{{GPURenderPassTimestampWrite/location}} is {{GPURenderPassTimestampLocation/"beginning"}},
+                        [=list/append=] a [=GPU command=] to |this|.{{GPUCommandsMixin/[[commands]]}}
+                        that writes the GPU's timestamp value into the |timestampWrite|.{{GPURenderPassTimestampWrite/queryIndex}}th
+                        index in |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}}.
+                    1. Otherwise, if |timestampWrite|.{{GPURenderPassTimestampWrite/location}} is {{GPURenderPassTimestampLocation/"end"}},
+                        [=list/Append=] |timestampWrite| to |pass|.{{GPURenderPassEncoder/[[endTimestampWrites]]}}.
+                1. Set |pass|.{{GPURenderCommandsMixin/[[drawCount]]}} to 0.
+                1. Set |pass|.{{GPURenderPassEncoder/[[maxDrawCount]]}} to |descriptor|.{{GPURenderPassDescriptor/maxDrawCount}}.
+                1. Issue: Enqueue attachment loads/clears.
+            </div>
 
             Issue: specify the behavior of read-only depth/stencil
         </div>
@@ -8412,43 +8432,48 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
         Begins encoding a compute pass described by |descriptor|.
 
         <div algorithm=GPUCommandEncoder.beginComputePass>
-            **Called on:** {{GPUCommandEncoder}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUCommandEncoder}} |this|.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUCommandEncoder/beginComputePass(descriptor)">
-                descriptor:
-            </pre>
+                <pre class=argumentdef for="GPUCommandEncoder/beginComputePass(descriptor)">
+                    descriptor:
+                </pre>
 
-            **Returns:** {{GPUComputePassEncoder}}
+                **Returns:** {{GPUComputePassEncoder}}
 
-            1. Let |pass| be a new {{GPUComputePassEncoder}} object.
-            1. Issue the following steps on the [=Device timeline=] of |this|:
+                [=Content timeline=] steps:
 
-                <div class=device-timeline>
-                    1. If any of the following conditions are unsatisfied
-                        [$generate a validation error$], make |pass| [=invalid=], and stop.
+                1. Let |pass| be a new {{GPUComputePassEncoder}} object.
+                1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
+                1. Return |pass|.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] |initialization steps|:
 
-                        <div class=validusage>
-                            - |this|.{{GPUCommandsMixin/[[state]]}} is "[=encoder state/open=]".
-                            - |descriptor|.{{GPUComputePassDescriptor/timestampWrites}} is empty, or
-                                |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} [=list/contain=]s
-                                {{GPUFeatureName/"timestamp-query"}}.
-                            - For each |timestampWrite| in |descriptor|.{{GPUComputePassDescriptor/timestampWrites}},
-                                - |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}} is [$valid to use with$] |this|.
-                        </div>
-                    1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/locked=]".
+                1. If any of the following conditions are unsatisfied
+                    [$generate a validation error$], make |pass| [=invalid=], and stop.
 
-                    1. For each |timestampWrite| in |descriptor|.{{GPUComputePassDescriptor/timestampWrites}},
-                        1. If |timestampWrite|.{{GPUComputePassTimestampWrite/location}} is {{GPUComputePassTimestampLocation/"beginning"}},
-                            [=list/append=] a [=GPU command=] to
-                            |this|.{{GPUCommandsMixin/[[commands]]}}
-                            that writes the GPU's timestamp value into the |timestampWrite|.{{GPUComputePassTimestampWrite/queryIndex}}th
-                            index in |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}}.
-                        1. Otherwise, if |timestampWrite|.{{GPUComputePassTimestampWrite/location}} is {{GPUComputePassTimestampLocation/"end"}},
-                            [=list/Append=] |timestampWrite| to |pass|.{{GPUComputePassEncoder/[[endTimestampWrites]]}}.
-                </div>
-            1. Return |pass|.
+                    <div class=validusage>
+                        - |this|.{{GPUCommandsMixin/[[state]]}} is "[=encoder state/open=]".
+                        - |descriptor|.{{GPUComputePassDescriptor/timestampWrites}} is empty, or
+                            |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} [=list/contain=]s
+                            {{GPUFeatureName/"timestamp-query"}}.
+                        - For each |timestampWrite| in |descriptor|.{{GPUComputePassDescriptor/timestampWrites}},
+                            - |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}} is [$valid to use with$] |this|.
+                    </div>
+                1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/locked=]".
+
+                1. For each |timestampWrite| in |descriptor|.{{GPUComputePassDescriptor/timestampWrites}},
+                    1. If |timestampWrite|.{{GPUComputePassTimestampWrite/location}} is {{GPUComputePassTimestampLocation/"beginning"}},
+                        [=list/append=] a [=GPU command=] to
+                        |this|.{{GPUCommandsMixin/[[commands]]}}
+                        that writes the GPU's timestamp value into the |timestampWrite|.{{GPUComputePassTimestampWrite/queryIndex}}th
+                        index in |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}}.
+                    1. Otherwise, if |timestampWrite|.{{GPUComputePassTimestampWrite/location}} is {{GPUComputePassTimestampLocation/"end"}},
+                        [=list/Append=] |timestampWrite| to |pass|.{{GPUComputePassEncoder/[[endTimestampWrites]]}}.
+            </div>
         </div>
 </dl>
 
@@ -8692,25 +8717,31 @@ dictionary GPUImageCopyExternalImage {
         {{GPUBuffer}} to a sub-region of another {{GPUBuffer}}.
 
         <div algorithm=GPUCommandEncoder.copyBufferToBuffer>
-            **Called on:** {{GPUCommandEncoder}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUCommandEncoder}} |this|.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUCommandEncoder/copyBufferToBuffer(source, sourceOffset, destination, destinationOffset, size)">
-                |source|: The {{GPUBuffer}} to copy from.
-                |sourceOffset|: Offset in bytes into |source| to begin copying from.
-                |destination|: The {{GPUBuffer}} to copy to.
-                |destinationOffset|: Offset in bytes into |destination| to place the copied data.
-                |size|: Bytes to copy.
-            </pre>
+                <pre class=argumentdef for="GPUCommandEncoder/copyBufferToBuffer(source, sourceOffset, destination, destinationOffset, size)">
+                    |source|: The {{GPUBuffer}} to copy from.
+                    |sourceOffset|: Offset in bytes into |source| to begin copying from.
+                    |destination|: The {{GPUBuffer}} to copy to.
+                    |destinationOffset|: Offset in bytes into |destination| to place the copied data.
+                    |size|: Bytes to copy.
+                </pre>
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
+                
+                [=Content timeline=] steps:
 
-            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+                1. Issue the subsequent steps on the [=Device timeline=] of
+                    |this|.{{GPUObjectBase/[[device]]}}.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
 
-            <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+                1. If any of the following conditions are unsatisfied make |this| [=invalid=] and stop.
 
                     <div class=validusage>
                         - |source| is [$valid to use with$] |this|.
@@ -8742,24 +8773,30 @@ dictionary GPUImageCopyExternalImage {
         {{GPUBuffer}} with zeros.
 
         <div algorithm=GPUCommandEncoder.clearBuffer>
-            **Called on:** {{GPUCommandEncoder}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUCommandEncoder}} |this|.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUCommandEncoder/clearBuffer(buffer, offset, size)">
-                |buffer|: The {{GPUBuffer}} to clear.
-                |offset|: Offset in bytes into |buffer| where the sub-region to clear begins.
-                |size|: Size in bytes of the sub-region to clear. Defaults to the size of the buffer minus |offset|.
-            </pre>
+                <pre class=argumentdef for="GPUCommandEncoder/clearBuffer(buffer, offset, size)">
+                    |buffer|: The {{GPUBuffer}} to clear.
+                    |offset|: Offset in bytes into |buffer| where the sub-region to clear begins.
+                    |size|: Size in bytes of the sub-region to clear. Defaults to the size of the buffer minus |offset|.
+                </pre>
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
 
-            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+                [=Content timeline=] steps:
 
-            <div class=device-timeline>
+                1. Issue the subsequent steps on the [=Device timeline=] of
+                    |this|.{{GPUObjectBase/[[device]]}}.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
+
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If |size| is missing, set |size| to `max(0, |buffer|.{{GPUBuffer/size}} - |offset|)`.
-                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+                1. If any of the following conditions are unsatisfied make |this| [=invalid=] and stop.
 
                     <div class=validusage>
                         - |buffer| is [$valid to use with$] |this|.
@@ -8768,7 +8805,15 @@ dictionary GPUImageCopyExternalImage {
                         - |offset| is a multiple of 4.
                         - |buffer|.{{GPUBuffer/size}} &ge; (|offset| + |size|).
                     </div>
+
+                1. Issue the subsequent steps on the [=Queue timeline=] of |this|.
             </div>
+            <div data-timeline=queue>
+                [=Queue timeline=] steps:
+
+                1. Set |size| bytes of |buffer| to `0` starting at |offset|.
+            </div>
+            
         </div>
 </dl>
 
@@ -8886,21 +8931,26 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
         {{GPUBuffer}} to a sub-region of one or multiple continuous [=texture subresources=].
 
         <div algorithm=GPUCommandEncoder.copyBufferToTexture>
-            **Called on:** {{GPUCommandEncoder}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUCommandEncoder}} |this|.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUCommandEncoder/copyBufferToTexture(source, destination, copySize)">
-                |source|: Combined with |copySize|, defines the region of the source buffer.
-                |destination|: Combined with |copySize|, defines the region of the destination [=texture subresource=].
-                |copySize|:
-            </pre>
+                <pre class=argumentdef for="GPUCommandEncoder/copyBufferToTexture(source, destination, copySize)">
+                    |source|: Combined with |copySize|, defines the region of the source buffer.
+                    |destination|: Combined with |copySize|, defines the region of the destination [=texture subresource=].
+                    |copySize|:
+                </pre>
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
 
-            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+                [=Content timeline=] steps:
 
-            <div class=device-timeline>
+                1. Issue the subsequent steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
+
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
 
@@ -8937,21 +8987,26 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
         multiple continuous [=texture subresources=]to a sub-region of a {{GPUBuffer}}.
 
         <div algorithm=GPUCommandEncoder.copyTextureToBuffer>
-            **Called on:** {{GPUCommandEncoder}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUCommandEncoder}} |this|.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUCommandEncoder/copyTextureToBuffer(source, destination, copySize)">
-                |source|: Combined with |copySize|, defines the region of the source [=texture subresources=].
-                |destination|: Combined with |copySize|, defines the region of the destination buffer.
-                |copySize|:
-            </pre>
+                <pre class=argumentdef for="GPUCommandEncoder/copyTextureToBuffer(source, destination, copySize)">
+                    |source|: Combined with |copySize|, defines the region of the source [=texture subresources=].
+                    |destination|: Combined with |copySize|, defines the region of the destination buffer.
+                    |copySize|:
+                </pre>
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
 
-            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+                [=Content timeline=] steps:
 
-            <div class=device-timeline>
+                1. Issue the subsequent steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
+
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
 
@@ -8990,21 +9045,26 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
         multiple continuous [=texture subresources=].
 
         <div algorithm=GPUCommandEncoder.copyTextureToTexture>
-            **Called on:** {{GPUCommandEncoder}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUCommandEncoder}} |this|.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUCommandEncoder/copyTextureToTexture(source, destination, copySize)">
-                |source|: Combined with |copySize|, defines the region of the source [=texture subresources=].
-                |destination|: Combined with |copySize|, defines the region of the destination [=texture subresources=].
-                |copySize|:
-            </pre>
+                <pre class=argumentdef for="GPUCommandEncoder/copyTextureToTexture(source, destination, copySize)">
+                    |source|: Combined with |copySize|, defines the region of the source [=texture subresources=].
+                    |destination|: Combined with |copySize|, defines the region of the destination [=texture subresources=].
+                    |copySize|:
+                </pre>
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
+                
+                [=Content timeline=] steps:
 
-            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+                1. Issue the subsequent steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
 
-            <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
 
@@ -9068,33 +9128,38 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
         Writes a timestamp value into a querySet when all previous commands have completed executing.
 
         <div algorithm=GPUCommandEncoder.writeTimestamp>
-            **Called on:** {{GPUCommandEncoder}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUCommandEncoder}} |this|.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUCommandEncoder/writeTimestamp(querySet, queryIndex)">
-                |querySet|: The query set that will store the timestamp values.
-                |queryIndex|: The index of the query in the query set.
-            </pre>
+                <pre class=argumentdef for="GPUCommandEncoder/writeTimestamp(querySet, queryIndex)">
+                    |querySet|: The query set that will store the timestamp values.
+                    |queryIndex|: The index of the query in the query set.
+                </pre>
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
 
-            1. If |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} does not [=list/contain=]
-                {{GPUFeatureName/"timestamp-query"}}, throw a {{TypeError}}.
-            1. Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+                [=Content timeline=] steps:
 
-                <div class=device-timeline>
-                    1. [$Validate the encoder state$] of |this|. If it returns false, stop.
-                    1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
+                1. If |this|.{{GPUObjectBase/[[device]]}}.{{device/[[features]]}} does not [=list/contain=]
+                    {{GPUFeatureName/"timestamp-query"}}, throw a {{TypeError}}.
+                1. Issue the subsequent steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
 
-                        <div class=validusage>
-                            - |querySet| is [$valid to use with$] |this|.
-                            - |querySet|.{{GPUQuerySet/type}} is {{GPUQueryType/"timestamp"}}.
-                            - |queryIndex| &lt; |querySet|{{GPUQuerySet/count}}.
-                        </div>
+                1. [$Validate the encoder state$] of |this|. If it returns false, stop.
+                1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
 
-                    Issue: Describe {{GPUCommandEncoder/writeTimestamp()}} algorithm steps.
-                </div>
+                    <div class=validusage>
+                        - |querySet| is [$valid to use with$] |this|.
+                        - |querySet|.{{GPUQuerySet/type}} is {{GPUQueryType/"timestamp"}}.
+                        - |queryIndex| &lt; |querySet|{{GPUQuerySet/count}}.
+                    </div>
+
+                Issue: Describe {{GPUCommandEncoder/writeTimestamp()}} algorithm steps.
+            </div>
         </div>
 
     : <dfn>resolveQuerySet(querySet, firstQuery, queryCount, destination, destinationOffset)</dfn>
@@ -9102,23 +9167,29 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
         Resolves query results from a {{GPUQuerySet}} out into a range of a {{GPUBuffer}}.
 
         <div algorithm=GPUCommandEncoder.resolveQuerySet>
-            **Called on:** {{GPUCommandEncoder}} this.
+            <div data-timeline=content>
+                **Called on:** {{GPUCommandEncoder}} this.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUCommandEncoder/resolveQuerySet(querySet, firstQuery, queryCount, destination, destinationOffset)">
-                querySet:
-                firstQuery:
-                queryCount:
-                destination:
-                destinationOffset:
-            </pre>
+                <pre class=argumentdef for="GPUCommandEncoder/resolveQuerySet(querySet, firstQuery, queryCount, destination, destinationOffset)">
+                    querySet:
+                    firstQuery:
+                    queryCount:
+                    destination:
+                    destinationOffset:
+                </pre>
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
 
-            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+                [=Content timeline=] steps:
 
-            <div class=device-timeline>
+                1. Issue the subsequent steps on the [=Device timeline=] of
+                        |this|.{{GPUObjectBase/[[device]]}}.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
+
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
 
@@ -9149,37 +9220,42 @@ command encoder can no longer be used.
         Completes recording of the commands sequence and returns a corresponding {{GPUCommandBuffer}}.
 
         <div algorithm=GPUCommandEncoder.finish>
-            **Called on:** {{GPUCommandEncoder}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUCommandEncoder}} |this|.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUCommandEncoder/finish(descriptor)">
-                descriptor:
-            </pre>
+                <pre class=argumentdef for="GPUCommandEncoder/finish(descriptor)">
+                    descriptor: Reserved for future use.
+                </pre>
 
-            **Returns:** {{GPUCommandBuffer}}
+                **Returns:** {{GPUCommandBuffer}}
 
-            1. Let |commandBuffer| be a new {{GPUCommandBuffer}}.
-            1. Issue the following steps on the [=Device timeline=] of |this|:
+                [=Content timeline=] steps:
 
-                <div class=device-timeline>
-                    1. Let |validationSucceeded| be `true` if all of the following requirements are met, and `false` otherwise.
+                1. Let |commandBuffer| be a new {{GPUCommandBuffer}}.
+                1. Issue the |finish steps| on the [=Device timeline=] of
+                            |this|.{{GPUObjectBase/[[device]]}}.
+                1. Return |commandBuffer|.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] |finish steps|:
 
-                        <div class=validusage>
-                            - |this| must be [=valid=].
-                            - |this|.{{GPUCommandsMixin/[[state]]}} must be "[=encoder state/open=]".
-                            - |this|.{{GPUDebugCommandsMixin/[[debug_group_stack]]}} must [=list/is empty|be empty=].
-                            - Every [=usage scope=] contained in |this| must satisfy the [=usage scope validation=].
-                        </div>
-                    1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/ended=]".
-                    1. If |validationSucceeded| is `false`, then:
-                        1. [$Generate a validation error$].
-                        1. Return a new [=invalid=] {{GPUCommandBuffer}}.
-                    1. Set |commandBuffer|.{{GPUCommandBuffer/[[command_list]]}} to
-                        |this|.{{GPUCommandsMixin/[[commands]]}}.
-                </div>
+                1. Let |validationSucceeded| be `true` if all of the following requirements are met, and `false` otherwise.
 
-            1. Return |commandBuffer|.
+                    <div class=validusage>
+                        - |this| must be [=valid=].
+                        - |this|.{{GPUCommandsMixin/[[state]]}} must be "[=encoder state/open=]".
+                        - |this|.{{GPUDebugCommandsMixin/[[debug_group_stack]]}} must [=list/is empty|be empty=].
+                        - Every [=usage scope=] contained in |this| must satisfy the [=usage scope validation=].
+                    </div>
+                1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/ended=]".
+                1. If |validationSucceeded| is `false`, then:
+                    1. [$Generate a validation error$].
+                    1. Return a new [=invalid=] {{GPUCommandBuffer}}.
+                1. Set |commandBuffer|.{{GPUCommandBuffer/[[command_list]]}} to
+                    |this|.{{GPUCommandsMixin/[[commands]]}}.
+            </div>
         </div>
 </dl>
 
@@ -9221,38 +9297,44 @@ It must only be included by interfaces which also include those mixins.
         Sets the current {{GPUBindGroup}} for the given index.
 
         <div algorithm=GPUBindingCommandsMixin.setBindGroup>
-            **Called on:** {{GPUBindingCommandsMixin}} this.
+            <div data-timeline=content>
+                **Called on:** {{GPUBindingCommandsMixin}} this.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUBindingCommandsMixin/setBindGroup(index, bindGroup, dynamicOffsets)">
-                |index|: The index to set the bind group at.
-                |bindGroup|: Bind group to use for subsequent render or compute commands.
+                <pre class=argumentdef for="GPUBindingCommandsMixin/setBindGroup(index, bindGroup, dynamicOffsets)">
+                    |index|: The index to set the bind group at.
+                    |bindGroup|: Bind group to use for subsequent render or compute commands.
 
-                <!--The overload appears to be confusing bikeshed, and it ends up expecting this to
-                define the arguments for the 5-arg variant of the method, despite the "for"
-                explicitly pointing at the 3-arg variant. See
-                https://github.com/plinss/widlparser/issues/56 and
-                https://github.com/tabatkins/bikeshed/issues/1740 -->
+                    <!--The overload appears to be confusing bikeshed, and it ends up expecting this to
+                    define the arguments for the 5-arg variant of the method, despite the "for"
+                    explicitly pointing at the 3-arg variant. See
+                    https://github.com/plinss/widlparser/issues/56 and
+                    https://github.com/tabatkins/bikeshed/issues/1740 -->
 
-                <!--|dynamicOffsets|: Array containing buffer offsets in bytes for each entry in
-                    |bindGroup| marked as {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}}.-->
-            </pre>
+                    <!--|dynamicOffsets|: Array containing buffer offsets in bytes for each entry in
+                        |bindGroup| marked as {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}}.-->
+                </pre>
 
-            Issue: Resolve bikeshed conflict when using `argumentdef` with overloaded functions that prevents us from
-                defining |dynamicOffsets|.
+                Issue: Resolve bikeshed conflict when using `argumentdef` with overloaded functions that prevents us from
+                    defining |dynamicOffsets|.
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
 
-            Note:
-            |dynamicOffsets|[|i|] is used for the |i|-th dynamic buffer binding in the bind group,
-            when bindings are ordered by {{GPUBindGroupLayoutEntry}}.{{GPUBindGroupLayoutEntry/binding}}.
-            Said differently |dynamicOffsets| are in the same order as dynamic buffer binding's
-            {{GPUBindGroupLayoutEntry}}.{{GPUBindGroupLayoutEntry/binding}}.
+                Note:
+                |dynamicOffsets|[|i|] is used for the |i|-th dynamic buffer binding in the bind group,
+                when bindings are ordered by {{GPUBindGroupLayoutEntry}}.{{GPUBindGroupLayoutEntry/binding}}.
+                Said differently |dynamicOffsets| are in the same order as dynamic buffer binding's
+                {{GPUBindGroupLayoutEntry}}.{{GPUBindGroupLayoutEntry/binding}}.
 
-            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+                [=Content timeline=] steps:
 
-            <div class=device-timeline>
+                1. Issue the subsequent steps on the [=Device timeline=] of
+                    |this|.{{GPUObjectBase/[[device]]}}.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
+
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
 
@@ -9291,34 +9373,39 @@ It must only be included by interfaces which also include those mixins.
         of a {{Uint32Array}}.
 
         <div algorithm=GPUBindingCommandsMixin.setBindGroup2>
-            **Called on:** {{GPUBindingCommandsMixin}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUBindingCommandsMixin}} |this|.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUBindingCommandsMixin/setBindGroup(index, bindGroup, dynamicOffsetsData, dynamicOffsetsDataStart, dynamicOffsetsDataLength)">
-                |index|: The index to set the bind group at.
-                |bindGroup|: Bind group to use for subsequent render or compute commands.
-                |dynamicOffsetsData|: Array containing buffer offsets in bytes for each entry in
-                    |bindGroup| marked as {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}}.
-                |dynamicOffsetsDataStart|: Offset in elements into |dynamicOffsetsData| where the
-                    buffer offset data begins.
-                |dynamicOffsetsDataLength|: Number of buffer offsets to read from |dynamicOffsetsData|.
-            </pre>
+                <pre class=argumentdef for="GPUBindingCommandsMixin/setBindGroup(index, bindGroup, dynamicOffsetsData, dynamicOffsetsDataStart, dynamicOffsetsDataLength)">
+                    |index|: The index to set the bind group at.
+                    |bindGroup|: Bind group to use for subsequent render or compute commands.
+                    |dynamicOffsetsData|: Array containing buffer offsets in bytes for each entry in
+                        |bindGroup| marked as {{GPUBindGroupLayoutEntry/buffer}}.{{GPUBufferBindingLayout/hasDynamicOffset}}.
+                    |dynamicOffsetsDataStart|: Offset in elements into |dynamicOffsetsData| where the
+                        buffer offset data begins.
+                    |dynamicOffsetsDataLength|: Number of buffer offsets to read from |dynamicOffsetsData|.
+                </pre>
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
 
-            1. If any of the following requirements are unmet, throw a {{RangeError}} and stop.
+                [=Content timeline=] steps:
 
-                <div class=validusage>
-                    - |dynamicOffsetsDataStart| must be &ge; 0.
-                    - |dynamicOffsetsDataStart| + |dynamicOffsetsDataLength| must be &le;
-                        |dynamicOffsetsData|.`length`.
-                </div>
-            1. Let |dynamicOffsets| be a [=list=] containing the range, starting at index
-                |dynamicOffsetsDataStart|, of |dynamicOffsetsDataLength| elements of
-                [=get a copy of the buffer source|a copy of=] |dynamicOffsetsData|.
-            1. Call |this|.{{GPUBindingCommandsMixin/setBindGroup(index,
-                bindGroup, dynamicOffsets)|setBindGroup}}(|index|, |bindGroup|, |dynamicOffsets|).
+                1. If any of the following requirements are unmet, throw a {{RangeError}} and stop.
+
+                    <div class=validusage>
+                        - |dynamicOffsetsDataStart| must be &ge; 0.
+                        - |dynamicOffsetsDataStart| + |dynamicOffsetsDataLength| must be &le;
+                            |dynamicOffsetsData|.`length`.
+                    </div>
+                1. Let |dynamicOffsets| be a [=list=] containing the range, starting at index
+                    |dynamicOffsetsDataStart|, of |dynamicOffsetsDataLength| elements of
+                    [=get a copy of the buffer source|a copy of=] |dynamicOffsetsData|.
+                1. Call |this|.{{GPUBindingCommandsMixin/setBindGroup(index,
+                    bindGroup, dynamicOffsets)|setBindGroup}}(|index|, |bindGroup|, |dynamicOffsets|).
+            </div>
+        </div>
 </dl>
 
 <div algorithm>
@@ -9462,19 +9549,25 @@ It must only be included by interfaces which also include those mixins.
         Begins a labeled debug group containing subsequent commands.
 
         <div algorithm=GPUDebugCommandsMixin.pushDebugGroup>
-            **Called on:** {{GPUDebugCommandsMixin}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUDebugCommandsMixin}} |this|.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUDebugCommandsMixin/pushDebugGroup(groupLabel)">
-                |groupLabel|: The label for the command group.
-            </pre>
+                <pre class=argumentdef for="GPUDebugCommandsMixin/pushDebugGroup(groupLabel)">
+                    |groupLabel|: The label for the command group.
+                </pre>
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
 
-            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+                [=Content timeline=] steps:
 
-            <div class=device-timeline>
+                1. Issue the subsequent steps on the [=Device timeline=] of
+                    |this|.{{GPUObjectBase/[[device]]}}.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
+
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. [=stack/Push=] |groupLabel| onto |this|.{{GPUDebugCommandsMixin/[[debug_group_stack]]}}.
             </div>
@@ -9485,13 +9578,19 @@ It must only be included by interfaces which also include those mixins.
         Ends the labeled debug group most recently started by {{GPUDebugCommandsMixin/pushDebugGroup()}}.
 
         <div algorithm=GPUDebugCommandsMixin.popDebugGroup>
-            **Called on:** {{GPUDebugCommandsMixin}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUDebugCommandsMixin}} |this|.
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
 
-            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+                [=Content timeline=] steps:
 
-            <div class=device-timeline>
+                1. Issue the subsequent steps on the [=Device timeline=] of
+                    |this|.{{GPUObjectBase/[[device]]}}.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
+
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following requirements are unmet, make |this| [=invalid=], and stop.
 
@@ -9507,19 +9606,25 @@ It must only be included by interfaces which also include those mixins.
         Marks a point in a stream of commands with a label.
 
         <div algorithm=GPUDebugCommandsMixin.insertDebugMarker>
-            **Called on:** {{GPUDebugCommandsMixin}} this.
+            <div data-timeline=content>
+                **Called on:** {{GPUDebugCommandsMixin}} this.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUDebugCommandsMixin/insertDebugMarker(markerLabel)">
-                markerLabel: The label to insert.
-            </pre>
+                <pre class=argumentdef for="GPUDebugCommandsMixin/insertDebugMarker(markerLabel)">
+                    markerLabel: The label to insert.
+                </pre>
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
 
-            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+                [=Content timeline=] steps:
 
-            <div class=device-timeline>
+                1. Issue the subsequent steps on the [=Device timeline=] of
+                    |this|.{{GPUObjectBase/[[device]]}}.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
+
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
             </div>
         </div>
@@ -9609,19 +9714,25 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
         Sets the current {{GPUComputePipeline}}.
 
         <div algorithm=GPUComputePassEncoder.setPipeline>
-            **Called on:** {{GPUComputePassEncoder}} this.
+            <div data-timeline=content>
+                **Called on:** {{GPUComputePassEncoder}} this.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUComputePassEncoder/setPipeline(pipeline)">
-                |pipeline|: The compute pipeline to use for subsequent dispatch commands.
-            </pre>
+                <pre class=argumentdef for="GPUComputePassEncoder/setPipeline(pipeline)">
+                    |pipeline|: The compute pipeline to use for subsequent dispatch commands.
+                </pre>
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
 
-            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+                [=Content timeline=] steps:
 
-            <div class=device-timeline>
+                1. Issue the subsequent steps on the [=Device timeline=] of
+                    |this|.{{GPUObjectBase/[[device]]}}.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
+
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
 
@@ -9638,36 +9749,42 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
         See [[#computing-operations]] for the detailed specification.
 
         <div algorithm=GPUComputePassEncoder.dispatch>
-            **Called on:** {{GPUComputePassEncoder}} this.
+            <div data-timeline=content>
+                **Called on:** {{GPUComputePassEncoder}} this.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUComputePassEncoder/dispatchWorkgroups(workgroupCountX, workgroupCountY, workgroupCountZ)">
-                |workgroupCountX|: X dimension of the grid of workgroups to dispatch.
-                |workgroupCountY|: Y dimension of the grid of workgroups to dispatch.
-                |workgroupCountZ|: Z dimension of the grid of workgroups to dispatch.
-            </pre>
+                <pre class=argumentdef for="GPUComputePassEncoder/dispatchWorkgroups(workgroupCountX, workgroupCountY, workgroupCountZ)">
+                    |workgroupCountX|: X dimension of the grid of workgroups to dispatch.
+                    |workgroupCountY|: Y dimension of the grid of workgroups to dispatch.
+                    |workgroupCountZ|: Z dimension of the grid of workgroups to dispatch.
+                </pre>
 
-            <div class=note>
-                Note:
-                The `x`, `y`, and `z` values passed to {{GPUComputePassEncoder/dispatchWorkgroups()}}
-                and {{GPUComputePassEncoder/dispatchWorkgroupsIndirect()}} are the number of
-                *workgroups* to dispatch for each dimension, *not* the number of shader invocations
-                to perform across each dimension. This matches the behavior of modern native GPU
-                APIs, but differs from the behavior of OpenCL.
+                <div class=note>
+                    Note:
+                    The `x`, `y`, and `z` values passed to {{GPUComputePassEncoder/dispatchWorkgroups()}}
+                    and {{GPUComputePassEncoder/dispatchWorkgroupsIndirect()}} are the number of
+                    *workgroups* to dispatch for each dimension, *not* the number of shader invocations
+                    to perform across each dimension. This matches the behavior of modern native GPU
+                    APIs, but differs from the behavior of OpenCL.
 
-                This means that if a {{GPUShaderModule}} defines an entry point with
-                `@workgroup_size(4, 4)`, and work is dispatched to it with the call
-                `computePass.dispatchWorkgroups(8, 8);` the entry point will be invoked 1024 times
-                total: Dispatching a 4x4 workgroup 8 times along both the X and Y axes.
-                (`4*4*8*8=1024`)
+                    This means that if a {{GPUShaderModule}} defines an entry point with
+                    `@workgroup_size(4, 4)`, and work is dispatched to it with the call
+                    `computePass.dispatchWorkgroups(8, 8);` the entry point will be invoked 1024 times
+                    total: Dispatching a 4x4 workgroup 8 times along both the X and Y axes.
+                    (`4*4*8*8=1024`)
+                </div>
+
+                **Returns:** {{undefined}}
+
+                [=Content timeline=] steps:
+
+                1. Issue the subsequent steps on the [=Device timeline=] of
+                    |this|.{{GPUObjectBase/[[device]]}}.
             </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
 
-            **Returns:** {{undefined}}
-
-            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
-
-            <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
 
@@ -9710,20 +9827,26 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
         </pre>
 
         <div algorithm=GPUComputePassEncoder.dispatchIndirect>
-            **Called on:** {{GPUComputePassEncoder}} this.
+            <div data-timeline=content>
+                **Called on:** {{GPUComputePassEncoder}} this.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUComputePassEncoder/dispatchWorkgroupsIndirect(indirectBuffer, indirectOffset)">
-                |indirectBuffer|: Buffer containing the [=indirect dispatch parameters=].
-                |indirectOffset|: Offset in bytes into |indirectBuffer| where the dispatch data begins.
-            </pre>
+                <pre class=argumentdef for="GPUComputePassEncoder/dispatchWorkgroupsIndirect(indirectBuffer, indirectOffset)">
+                    |indirectBuffer|: Buffer containing the [=indirect dispatch parameters=].
+                    |indirectOffset|: Offset in bytes into |indirectBuffer| where the dispatch data begins.
+                </pre>
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
 
-            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+                [=Content timeline=] steps:
 
-            <div class=device-timeline>
+                1. Issue the subsequent steps on the [=Device timeline=] of
+                    |this|.{{GPUObjectBase/[[device]]}}.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
+
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
 
@@ -9757,13 +9880,19 @@ called the compute pass encoder can no longer be used.
         Completes recording of the compute pass commands sequence.
 
         <div algorithm=GPUComputePassEncoder.end>
-            **Called on:** {{GPUComputePassEncoder}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUComputePassEncoder}} |this|.
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
 
-            Issue the following steps on the [=Device timeline=] of |this|:
+                [=Content timeline=] steps:
 
-            <div class=device-timeline>
+                1. Issue the subsequent steps on the [=Device timeline=] of
+                    |this|.{{GPUObjectBase/[[device]]}}.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
+
                 1. If any of the following requirements are unmet,
                     [$generate a validation error$] and stop.
 
@@ -10332,13 +10461,19 @@ called the render pass encoder can no longer be used.
         Completes recording of the render pass commands sequence.
 
         <div algorithm=GPURenderPassEncoder.end>
-            **Called on:** {{GPURenderPassEncoder}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPURenderPassEncoder}} |this|.
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
 
-            Issue the following steps on the [=Device timeline=] of |this|:
+                [=Content timeline=] steps:
 
-            <div class=device-timeline>
+                1. Issue the subsequent steps on the [=Device timeline=] of
+                    |this|.{{GPUObjectBase/[[device]]}}.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
+
                 1. If any of the following requirements are unmet,
                     [$generate a validation error$] and stop.
 
@@ -10452,19 +10587,25 @@ It must only be included by interfaces which also include those mixins.
         Sets the current {{GPURenderPipeline}}.
 
         <div algorithm=GPURenderCommandsMixin.setPipeline>
-            **Called on:** {{GPURenderCommandsMixin}} this.
+            <div data-timeline=content>
+                **Called on:** {{GPURenderCommandsMixin}} this.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPURenderCommandsMixin/setPipeline(pipeline)">
-                |pipeline|: The render pipeline to use for subsequent drawing commands.
-            </pre>
+                <pre class=argumentdef for="GPURenderCommandsMixin/setPipeline(pipeline)">
+                    |pipeline|: The render pipeline to use for subsequent drawing commands.
+                </pre>
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
+                
+                [=Content timeline=] steps:
 
-            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+                1. Issue the subsequent steps on the [=Device timeline=] of
+                    |this|.{{GPUObjectBase/[[device]]}}.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
 
-            <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. Let |pipelineTargetsLayout| be [$derive render targets layout from pipeline$](|pipeline|.{{GPURenderPipeline/[[descriptor]]}}).
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
@@ -10815,24 +10956,30 @@ attachments used by this encoder.
         coordinates to viewport coordinates.
 
         <div algorithm=GPURenderPassEncoder.setViewport>
-            **Called on:** {{GPURenderPassEncoder}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPURenderPassEncoder}} |this|.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPURenderPassEncoder/setViewport(x, y, width, height, minDepth, maxDepth)">
-                |x|: Minimum X value of the viewport in pixels.
-                |y|: Minimum Y value of the viewport in pixels.
-                |width|: Width of the viewport in pixels.
-                |height|: Height of the viewport in pixels.
-                |minDepth|: Minimum depth value of the viewport.
-                |maxDepth|: Maximum depth value of the viewport.
-            </pre>
+                <pre class=argumentdef for="GPURenderPassEncoder/setViewport(x, y, width, height, minDepth, maxDepth)">
+                    |x|: Minimum X value of the viewport in pixels.
+                    |y|: Minimum Y value of the viewport in pixels.
+                    |width|: Width of the viewport in pixels.
+                    |height|: Height of the viewport in pixels.
+                    |minDepth|: Minimum depth value of the viewport.
+                    |maxDepth|: Maximum depth value of the viewport.
+                </pre>
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
+                
+                [=Content timeline=] steps:
 
-            Issue the following steps on the [=Device timeline=] of |this|:
+                1. Issue the subsequent steps on the [=Device timeline=] of
+                    |this|.{{GPUObjectBase/[[device]]}}.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
 
-            <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=]
                     and stop.
@@ -10861,22 +11008,28 @@ attachments used by this encoder.
         rectangle will be discarded.
 
         <div algorithm=GPURenderPassEncoder.setScissorRect>
-            **Called on:** {{GPURenderPassEncoder}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPURenderPassEncoder}} |this|.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPURenderPassEncoder/setScissorRect(x, y, width, height)">
-                |x|: Minimum X value of the scissor rectangle in pixels.
-                |y|: Minimum Y value of the scissor rectangle in pixels.
-                |width|: Width of the scissor rectangle in pixels.
-                |height|: Height of the scissor rectangle in pixels.
-            </pre>
+                <pre class=argumentdef for="GPURenderPassEncoder/setScissorRect(x, y, width, height)">
+                    |x|: Minimum X value of the scissor rectangle in pixels.
+                    |y|: Minimum Y value of the scissor rectangle in pixels.
+                    |width|: Width of the scissor rectangle in pixels.
+                    |height|: Height of the scissor rectangle in pixels.
+                </pre>
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
+                
+                [=Content timeline=] steps:
 
-            Issue the following steps on the [=Device timeline=] of |this|:
+                1. Issue the subsequent steps on the [=Device timeline=] of
+                    |this|.{{GPUObjectBase/[[device]]}}.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
 
-            <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=]
                     and stop.
@@ -10897,17 +11050,25 @@ attachments used by this encoder.
         and {{GPUBlendFactor/"one-minus-constant"}} {{GPUBlendFactor}}s.
 
         <div algorithm=GPURenderPassEncoder.setBlendConstant>
-            **Called on:** {{GPURenderPassEncoder}} this.
+            <div data-timeline=content>
+                **Called on:** {{GPURenderPassEncoder}} this.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPURenderPassEncoder/setBlendConstant(color)">
-                |color|: The color to use when blending.
-            </pre>
+                <pre class=argumentdef for="GPURenderPassEncoder/setBlendConstant(color)">
+                    |color|: The color to use when blending.
+                </pre>
 
-            Issue the following steps on the [=Device timeline=] of |this|:
+                **Returns:** {{undefined}}
+                
+                [=Content timeline=] steps:
 
-            <div class=device-timeline>
+                1. Issue the subsequent steps on the [=Device timeline=] of
+                    |this|.{{GPUObjectBase/[[device]]}}.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
+
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. Set {{GPURenderPassEncoder/[[blend_constant]]}} to |color|.
             </div>
@@ -10919,17 +11080,25 @@ attachments used by this encoder.
         the {{GPUStencilOperation/"replace"}} {{GPUStencilOperation}}.
 
         <div algorithm=GPURenderPassEncoder.setStencilReference>
-            **Called on:** {{GPURenderPassEncoder}} this.
+            <div data-timeline=content>
+                **Called on:** {{GPURenderPassEncoder}} this.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPURenderPassEncoder/setStencilReference(reference)">
-                |reference|: The new stencil reference value.
-            </pre>
+                <pre class=argumentdef for="GPURenderPassEncoder/setStencilReference(reference)">
+                    |reference|: The new stencil reference value.
+                </pre>
 
-            Issue the following steps on the [=Device timeline=] of |this|:
+                **Returns:** {{undefined}}
+                
+                [=Content timeline=] steps:
 
-            <div class=device-timeline>
+                1. Issue the subsequent steps on the [=Device timeline=] of
+                    |this|.{{GPUObjectBase/[[device]]}}.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
+
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. Set {{GPURenderPassEncoder/[[stencil_reference]]}} to |reference|.
             </div>
@@ -10942,19 +11111,25 @@ attachments used by this encoder.
     : <dfn>beginOcclusionQuery(queryIndex)</dfn>
     ::
         <div algorithm=GPURenderPassEncoder.beginOcclusionQuery>
-            **Called on:** {{GPURenderPassEncoder}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPURenderPassEncoder}} |this|.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPURenderPassEncoder/beginOcclusionQuery(queryIndex)">
-                |queryIndex|: The index of the query in the query set.
-            </pre>
+                <pre class=argumentdef for="GPURenderPassEncoder/beginOcclusionQuery(queryIndex)">
+                    |queryIndex|: The index of the query in the query set.
+                </pre>
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
+                
+                [=Content timeline=] steps:
 
-            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+                1. Issue the subsequent steps on the [=Device timeline=] of
+                    |this|.{{GPUObjectBase/[[device]]}}.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
 
-            <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
 
@@ -10971,13 +11146,19 @@ attachments used by this encoder.
     : <dfn>endOcclusionQuery()</dfn>
     ::
         <div algorithm=GPURenderPassEncoder.endOcclusionQuery>
-            **Called on:** {{GPURenderPassEncoder}} this.
+            <div data-timeline=content>
+                **Called on:** {{GPURenderPassEncoder}} this.
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
+                
+                [=Content timeline=] steps:
 
-            Issue the following steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
+                1. Issue the subsequent steps on the [=Device timeline=] of
+                    |this|.{{GPUObjectBase/[[device]]}}.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
 
-            <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=] and stop.
 
@@ -11006,19 +11187,25 @@ attachments used by this encoder.
         This occurs even if zero {{GPURenderBundle|GPURenderBundles}} are executed.
 
         <div algorithm=GPURenderPassEncoder.executeBundles>
-            **Called on:** {{GPURenderPassEncoder}} this.
+            <div data-timeline=content>
+                **Called on:** {{GPURenderPassEncoder}} this.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPURenderPassEncoder/executeBundles(bundles)">
-                |bundles|: List of render bundles to execute.
-            </pre>
+                <pre class=argumentdef for="GPURenderPassEncoder/executeBundles(bundles)">
+                    |bundles|: List of render bundles to execute.
+                </pre>
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
+                
+                [=Content timeline=] steps:
 
-            Issue the following steps on the [=Device timeline=] of |this|:
+                1. Issue the subsequent steps on the [=Device timeline=] of
+                    |this|.{{GPUObjectBase/[[device]]}}.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
 
-            <div class=device-timeline>
                 1. [$Validate the encoder state$] of |this|. If it returns false, stop.
                 1. If any of the following conditions are unsatisfied, make |this| [=invalid=]
                     and stop.
@@ -11169,39 +11356,44 @@ dictionary GPURenderBundleEncoderDescriptor : GPURenderPassLayout {
         Completes recording of the render bundle commands sequence.
 
         <div algorithm=GPURenderBundleEncoder.finish>
-            **Called on:** {{GPURenderBundleEncoder}} this.
+            <div data-timeline=content>
+                **Called on:** {{GPURenderBundleEncoder}} this.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPURenderBundleEncoder/finish(descriptor)">
-                descriptor:
-            </pre>
+                <pre class=argumentdef for="GPURenderBundleEncoder/finish(descriptor)">
+                    descriptor:
+                </pre>
 
-            **Returns:** {{GPURenderBundle}}
+                **Returns:** {{GPURenderBundle}}
 
-            1. Let |renderBundle| be a new {{GPURenderBundle}}.
-            1. Issue the following steps on the [=Device timeline=] of |this|:
+                [=Content timeline=] steps:
 
-                <div class=device-timeline>
-                    1. Let |validationSucceeded| be `true` if all of the following requirements are met, and `false` otherwise.
+                1. Let |renderBundle| be a new {{GPURenderBundle}}.
+                1. Issue the |finish steps| on the [=Device timeline=] of
+                    |this|.{{GPUObjectBase/[[device]]}}.
+                1. Return |renderBundle|.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] |finish steps|:
 
-                        <div class=validusage>
-                            - |this| must be [=valid=].
-                            - |this|.{{GPUCommandsMixin/[[state]]}} must be "[=encoder state/open=]".
-                            - |this|.{{GPUDebugCommandsMixin/[[debug_group_stack]]}} must [=list/is empty|be empty=].
-                            - Every [=usage scope=] contained in |this| must satisfy the [=usage scope validation=].
-                        </div>
-                    1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/ended=]".
-                    1. If |validationSucceeded| is `false`, then:
-                        1. [$Generate a validation error$].
-                        1. Return a new [=invalid=] {{GPURenderBundle}}.
-                    1. Set |renderBundle|.{{GPURenderBundle/[[command_list]]}} to
-                        |this|.{{GPUCommandsMixin/[[commands]]}}.
-                    1. Set |renderBundle|.{{GPURenderBundle/[[drawCount]]}} to
-                        |this|.{{GPURenderCommandsMixin/[[drawCount]]}}.
-                </div>
+                1. Let |validationSucceeded| be `true` if all of the following requirements are met, and `false` otherwise.
 
-            1. Return |renderBundle|.
+                    <div class=validusage>
+                        - |this| must be [=valid=].
+                        - |this|.{{GPUCommandsMixin/[[state]]}} must be "[=encoder state/open=]".
+                        - |this|.{{GPUDebugCommandsMixin/[[debug_group_stack]]}} must [=list/is empty|be empty=].
+                        - Every [=usage scope=] contained in |this| must satisfy the [=usage scope validation=].
+                    </div>
+                1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/ended=]".
+                1. If |validationSucceeded| is `false`, then:
+                    1. [$Generate a validation error$].
+                    1. Return a new [=invalid=] {{GPURenderBundle}}.
+                1. Set |renderBundle|.{{GPURenderBundle/[[command_list]]}} to
+                    |this|.{{GPUCommandsMixin/[[commands]]}}.
+                1. Set |renderBundle|.{{GPURenderBundle/[[drawCount]]}} to
+                    |this|.{{GPURenderCommandsMixin/[[drawCount]]}}.
+            </div>
         </div>
 </dl>
 
@@ -11254,57 +11446,62 @@ GPUQueue includes GPUObjectBase;
         Issues a write operation of the provided data into a {{GPUBuffer}}.
 
         <div algorithm=GPUQueue.writeBuffer>
-            **Called on:** {{GPUQueue}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUQueue}} |this|.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUQueue/writeBuffer(buffer, bufferOffset, data, dataOffset, size)">
-                |buffer|: The buffer to write to.
-                |bufferOffset|: Offset in bytes into |buffer| to begin writing at.
-                |data|: Data to write into |buffer|.
-                |dataOffset|: Offset in into |data| to begin writing from. Given in elements if
-                    |data| is a `TypedArray` and bytes otherwise.
-                |size|: Size of content to write from |data| to |buffer|. Given in elements if
-                    |data| is a `TypedArray` and bytes otherwise.
-            </pre>
+                <pre class=argumentdef for="GPUQueue/writeBuffer(buffer, bufferOffset, data, dataOffset, size)">
+                    |buffer|: The buffer to write to.
+                    |bufferOffset|: Offset in bytes into |buffer| to begin writing at.
+                    |data|: Data to write into |buffer|.
+                    |dataOffset|: Offset in into |data| to begin writing from. Given in elements if
+                        |data| is a `TypedArray` and bytes otherwise.
+                    |size|: Size of content to write from |data| to |buffer|. Given in elements if
+                        |data| is a `TypedArray` and bytes otherwise.
+                </pre>
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
 
-            1. If |data| is an {{ArrayBuffer}} or {{DataView}}, let the element type be "byte".
-                Otherwise, |data| is a TypedArray; let the element type be the type of the TypedArray.
-            1. Let |dataSize| be the size of |data|, in elements.
-            1. If |size| is missing,
-                let |contentsSize| be |dataSize| &minus; |dataOffset|.
-                Otherwise, let |contentsSize| be |size|.
-            1. If any of the following conditions are unsatisfied,
-                throw {{OperationError}} and stop.
+                [=Content timeline=] steps:
 
-                <!-- Note: it's easiest to write the valid usage rules inline
-                    here, because they depend on contentsSize above. -->
+                1. If |data| is an {{ArrayBuffer}} or {{DataView}}, let the element type be "byte".
+                    Otherwise, |data| is a TypedArray; let the element type be the type of the TypedArray.
+                1. Let |dataSize| be the size of |data|, in elements.
+                1. If |size| is missing,
+                    let |contentsSize| be |dataSize| &minus; |dataOffset|.
+                    Otherwise, let |contentsSize| be |size|.
+                1. If any of the following conditions are unsatisfied,
+                    throw {{OperationError}} and stop.
 
-                <div class=validusage>
-                    - |contentsSize| &ge; 0.
-                    - |dataOffset| + |contentsSize| &le; |dataSize|.
-                    - |contentsSize|, converted to bytes, is a multiple of 4 bytes.
-                </div>
-            1. Let |dataContents| be [=get a copy of the buffer source|a copy of the bytes held by the buffer source=].
-            1. Let |contents| be the |contentsSize| elements of |dataContents| starting at
-                an offset of |dataOffset| elements.
-            1. Issue the following steps on the [=Device timeline=] of |this|:
+                    <!-- Note: it's easiest to write the valid usage rules inline
+                        here, because they depend on contentsSize above. -->
 
-                <div class=device-timeline>
-                    1. If any of the following conditions are unsatisfied,
-                        [$generate a validation error$] and stop.
+                    <div class=validusage>
+                        - |contentsSize| &ge; 0.
+                        - |dataOffset| + |contentsSize| &le; |dataSize|.
+                        - |contentsSize|, converted to bytes, is a multiple of 4 bytes.
+                    </div>
+                1. Let |dataContents| be [=get a copy of the buffer source|a copy of the bytes held by the buffer source=].
+                1. Let |contents| be the |contentsSize| elements of |dataContents| starting at
+                    an offset of |dataOffset| elements.
+                1. Issue the subsequent steps on the [=Device timeline=] of |this|.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
 
-                        <div class=validusage>
-                            - |buffer| is [$valid to use with$] |this|.
-                            - |buffer|.{{GPUBuffer/[[deviceTimelineState]]}} is "[=buffer device timeline state/available=]".
-                            - |buffer|.{{GPUBuffer/usage}} includes {{GPUBufferUsage/COPY_DST}}.
-                            - |bufferOffset|, converted to bytes, is a multiple of 4 bytes.
-                            - |bufferOffset| + |contentsSize|, converted to bytes, &le; |buffer|.{{GPUBuffer/size}} bytes.
-                        </div>
-                    1. Write |contents| into |buffer| starting at |bufferOffset|.
-                </div>
+                1. If any of the following conditions are unsatisfied,
+                    [$generate a validation error$] and stop.
+
+                    <div class=validusage>
+                        - |buffer| is [$valid to use with$] |this|.
+                        - |buffer|.{{GPUBuffer/[[deviceTimelineState]]}} is "[=buffer device timeline state/available=]".
+                        - |buffer|.{{GPUBuffer/usage}} includes {{GPUBufferUsage/COPY_DST}}.
+                        - |bufferOffset|, converted to bytes, is a multiple of 4 bytes.
+                        - |bufferOffset| + |contentsSize|, converted to bytes, &le; |buffer|.{{GPUBuffer/size}} bytes.
+                    </div>
+                1. Write |contents| into |buffer| starting at |bufferOffset|.
+            </div>
         </div>
 
     : <dfn>writeTexture(destination, data, dataLayout, size)</dfn>
@@ -11394,66 +11591,71 @@ GPUQueue includes GPUObjectBase;
         Issue: If an srgb-linear color space is added, explain here how it interacts.
 
         <div algorithm=GPUQueue.copyExternalImageToTexture>
-            **Called on:** {{GPUQueue}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUQueue}} |this|.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUQueue/copyExternalImageToTexture(source, destination, copySize)">
-                |source|: source image and origin to copy to |destination|.
-                |destination|: The [=texture subresource=] and origin to write to, and its encoding metadata.
-                |copySize|: Extents of the content to write from |source| to |destination|.
-            </pre>
+                <pre class=argumentdef for="GPUQueue/copyExternalImageToTexture(source, destination, copySize)">
+                    |source|: source image and origin to copy to |destination|.
+                    |destination|: The [=texture subresource=] and origin to write to, and its encoding metadata.
+                    |copySize|: Extents of the content to write from |source| to |destination|.
+                </pre>
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
 
-            1. Let |sourceImage| be |source|.{{GPUImageCopyExternalImage/source}}
-            1. Run [=Check the usability of the image argument=](|sourceImage|).
-                If it throws an exception, stop.
-                If it does not return `good`, throw an {{InvalidStateError}} and stop.
-            1. If |sourceImage| <l spec=html>[=is not origin-clean=]</l>,
-                throw a {{SecurityError}} and stop.
-            1. If any of the following requirements are unmet, throw an {{OperationError}} and stop.
+                [=Content timeline=] steps:
 
-                <div class=validusage>
-                    - |source|.|origin|.[=Origin3D/x=] + |copySize|.[=Extent3D/width=]
-                        must be &le; the width of |sourceImage|.
-                    - |source|.|origin|.[=Origin3D/y=] + |copySize|.[=Extent3D/height=]
-                        must be &le; the height of |sourceImage|.
-                    - |source|.|origin|.[=Origin3D/z=] + |copySize|.[=Extent3D/depthOrArrayLayers=]
-                        must be &le; 1.
-                </div>
-            1. Issue the following steps on the [=Device timeline=] of |this|:
+                1. Let |sourceImage| be |source|.{{GPUImageCopyExternalImage/source}}
+                1. Run [=Check the usability of the image argument=](|sourceImage|).
+                    If it throws an exception, stop.
+                    If it does not return `good`, throw an {{InvalidStateError}} and stop.
+                1. If |sourceImage| <l spec=html>[=is not origin-clean=]</l>,
+                    throw a {{SecurityError}} and stop.
+                1. If any of the following requirements are unmet, throw an {{OperationError}} and stop.
 
-                <div class=device-timeline>
-                    1. Let |texture| be |destination|.{{GPUImageCopyTexture/texture}}.
-                    1. If any of the following requirements are unmet, [$generate a validation error$] and stop.
+                    <div class=validusage>
+                        - |source|.|origin|.[=Origin3D/x=] + |copySize|.[=Extent3D/width=]
+                            must be &le; the width of |sourceImage|.
+                        - |source|.|origin|.[=Origin3D/y=] + |copySize|.[=Extent3D/height=]
+                            must be &le; the height of |sourceImage|.
+                        - |source|.|origin|.[=Origin3D/z=] + |copySize|.[=Extent3D/depthOrArrayLayers=]
+                            must be &le; 1.
+                    </div>
+                1. Issue the subsequent steps on the [=Device timeline=] of |this|.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
 
-                        <div class=validusage>
-                            - |destination|.{{GPUImageCopyTexture/texture}} must be [$valid to use with$] |this|.
-                            - [$validating GPUImageCopyTexture$](destination, copySize) must return `true`.
-                            - [=validating texture copy range=](destination, copySize) must return `true`.
-                            - |texture|.{{GPUTexture/usage}} must include both
-                                {{GPUTextureUsage/RENDER_ATTACHMENT}} and {{GPUTextureUsage/COPY_DST}}.
-                            - |texture|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
-                            - |texture|.{{GPUTexture/sampleCount}} must be 1.
-                            - |texture|.{{GPUTexture/format}} must be one of the following
-                                formats (which all support {{GPUTextureUsage/RENDER_ATTACHMENT}} usage):
-                                - {{GPUTextureFormat/"r8unorm"}}
-                                - {{GPUTextureFormat/"r16float"}}
-                                - {{GPUTextureFormat/"r32float"}}
-                                - {{GPUTextureFormat/"rg8unorm"}}
-                                - {{GPUTextureFormat/"rg16float"}}
-                                - {{GPUTextureFormat/"rg32float"}}
-                                - {{GPUTextureFormat/"rgba8unorm"}}
-                                - {{GPUTextureFormat/"rgba8unorm-srgb"}}
-                                - {{GPUTextureFormat/"bgra8unorm"}}
-                                - {{GPUTextureFormat/"bgra8unorm-srgb"}}
-                                - {{GPUTextureFormat/"rgb10a2unorm"}}
-                                - {{GPUTextureFormat/"rgba16float"}}
-                                - {{GPUTextureFormat/"rgba32float"}}
-                        </div>
-                    1. Issue: Do the actual copy.
-                </div>
+                1. Let |texture| be |destination|.{{GPUImageCopyTexture/texture}}.
+                1. If any of the following requirements are unmet, [$generate a validation error$] and stop.
+
+                    <div class=validusage>
+                        - |destination|.{{GPUImageCopyTexture/texture}} must be [$valid to use with$] |this|.
+                        - [$validating GPUImageCopyTexture$](destination, copySize) must return `true`.
+                        - [=validating texture copy range=](destination, copySize) must return `true`.
+                        - |texture|.{{GPUTexture/usage}} must include both
+                            {{GPUTextureUsage/RENDER_ATTACHMENT}} and {{GPUTextureUsage/COPY_DST}}.
+                        - |texture|.{{GPUTexture/dimension}} must be {{GPUTextureDimension/"2d"}}.
+                        - |texture|.{{GPUTexture/sampleCount}} must be 1.
+                        - |texture|.{{GPUTexture/format}} must be one of the following
+                            formats (which all support {{GPUTextureUsage/RENDER_ATTACHMENT}} usage):
+                            - {{GPUTextureFormat/"r8unorm"}}
+                            - {{GPUTextureFormat/"r16float"}}
+                            - {{GPUTextureFormat/"r32float"}}
+                            - {{GPUTextureFormat/"rg8unorm"}}
+                            - {{GPUTextureFormat/"rg16float"}}
+                            - {{GPUTextureFormat/"rg32float"}}
+                            - {{GPUTextureFormat/"rgba8unorm"}}
+                            - {{GPUTextureFormat/"rgba8unorm-srgb"}}
+                            - {{GPUTextureFormat/"bgra8unorm"}}
+                            - {{GPUTextureFormat/"bgra8unorm-srgb"}}
+                            - {{GPUTextureFormat/"rgb10a2unorm"}}
+                            - {{GPUTextureFormat/"rgba16float"}}
+                            - {{GPUTextureFormat/"rgba32float"}}
+                    </div>
+                1. Issue: Do the actual copy.
+            </div>
         </div>
 
     : <dfn>submit(commandBuffers)</dfn>
@@ -11463,19 +11665,24 @@ GPUQueue includes GPUObjectBase;
         Submitted command buffers cannot be used again.
 
         <div algorithm=GPUQueue.submit>
-            **Called on:** {{GPUQueue}} this.
+            <div data-timeline=content>
+                **Called on:** {{GPUQueue}} this.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUQueue/submit(commandBuffers)">
-                |commandBuffers|:
-            </pre>
+                <pre class=argumentdef for="GPUQueue/submit(commandBuffers)">
+                    |commandBuffers|:
+                </pre>
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
 
-            Issue the following steps on the [=Device timeline=] of |this|:
+                [=Content timeline=] steps:
 
-            <div class=device-timeline>
+                1. Issue the subsequent steps on the [=Device timeline=] of |this|:
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
+
                 1. If any of the following conditions are unsatisfied, [$generate a validation error$] and stop.
 
                     <div class=validusage>
@@ -11492,12 +11699,13 @@ GPUQueue includes GPUObjectBase;
                 1. For each |commandBuffer| in |commandBuffers|:
                     1. Make |commandBuffer| [=invalid=].
 
-                1. Issue the following steps on the [=Queue timeline=] of |this|:
+                1. Issue the subsequent steps on the [=Queue timeline=] of |this|:
+            </div>
+            <div data-timeline=queue>
+                [=Queue timeline=] steps:
 
-                    <div class=queue-timeline>
-                        1. For each |commandBuffer| in |commandBuffers|:
-                            1. Execute each command in |commandBuffer|.{{GPUCommandBuffer/[[command_list]]}}.
-                    </div>
+                1. For each |commandBuffer| in |commandBuffers|:
+                    1. Execute each command in |commandBuffer|.{{GPUCommandBuffer/[[command_list]]}}.
             </div>
         </div>
 
@@ -11507,17 +11715,22 @@ GPUQueue includes GPUObjectBase;
         up to this moment.
 
         <div algorithm=GPUQueue.onSubmittedWorkDone>
-            **Called on:** {{GPUQueue}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUQueue}} |this|.
 
-            **Returns:** {{Promise}}&lt;{{undefined}}&gt;
+                **Returns:** {{Promise}}&lt;{{undefined}}&gt;
 
-            1. Let |promise| be [=a new promise=].
-            1. Enqueue an operation on the [=Queue timeline=] of |this| that will execute the following:
+                [=Content timeline=] steps:
 
-                <div class=queue-timeline>
-                    1. [=Resolve=] |promise|.
-                </div>
-            1. Return |promise|.
+                1. Let |promise| be [=a new promise=].
+                1. Issue the |resolve steps| on the [=Queue timeline=] of |this|.
+                1. Return |promise|.
+            </div>
+            <div data-timeline=queue>
+                [=Queue timeline=] |resolve steps|:
+
+                1. [=Resolve=] |promise|.
+            </div>
         </div>
 </dl>
 
@@ -11654,11 +11867,15 @@ garbage collection by calling {{GPUQuerySet/destroy()}}.
         Destroys the {{GPUQuerySet}}.
 
         <div algorithm=GPUQuerySet.destroy>
-            **Called on:** {{GPUQuerySet}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUQuerySet}} |this|.
 
-            **Returns:** {{undefined}}
+                **Returns:** {{undefined}}
 
-            1. Set |this|.{{GPUQuerySet/[[state]]}} to [=query set state/destroyed=].
+                [=Content timeline=] steps:
+
+                1. Set |this|.{{GPUQuerySet/[[state]]}} to [=query set state/destroyed=].
+            </div>
         </div>
 </dl>
 
@@ -11814,45 +12031,49 @@ interface GPUCanvasContext {
         This clears the drawing buffer to transparent black (in [$Replace the drawing buffer$]).
 
         <div algorithm=GPUCanvasContext.configure>
-            **Called on:** {{GPUCanvasContext}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUCanvasContext}} |this|.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUCanvasContext/configure(configuration)">
-                |configuration|: Desired configuration for the context.
-            </pre>
+                <pre class=argumentdef for="GPUCanvasContext/configure(configuration)">
+                    |configuration|: Desired configuration for the context.
+                </pre>
 
-            **Returns:** undefined
+                **Returns:** undefined
 
-            1. Let |device| be |configuration|.{{GPUCanvasConfiguration/device}}.
-            1. [$Validate texture format required features$] of
-                |configuration|.{{GPUCanvasConfiguration/format}} with |device|.{{GPUObjectBase/[[device]]}}.
-            1. [$Validate texture format required features$] of each element of
-                |configuration|.{{GPUTextureDescriptor/viewFormats}} with |device|.{{GPUObjectBase/[[device]]}}.
-            1. Let |descriptor| be the
-                [$GPUTextureDescriptor for the canvas and configuration$](|this|.{{GPUCanvasContext/canvas}}, |configuration|).
-            1. Set |this|.{{GPUCanvasContext/[[configuration]]}} to |configuration|.
-            1. Set |this|.{{GPUCanvasContext/[[textureDescriptor]]}} to |descriptor|.
-            1. [$Replace the drawing buffer$] of |this|, which resets
-                |this|.{{GPUCanvasContext/[[drawingBuffer]]}} with a bitmap with the new format and tags.
+                [=Content timeline=] steps:
 
-            1. Issue the following steps on the [=Device timeline=] of |device|:
+                1. Let |device| be |configuration|.{{GPUCanvasConfiguration/device}}.
+                1. [$Validate texture format required features$] of
+                    |configuration|.{{GPUCanvasConfiguration/format}} with |device|.{{GPUObjectBase/[[device]]}}.
+                1. [$Validate texture format required features$] of each element of
+                    |configuration|.{{GPUTextureDescriptor/viewFormats}} with |device|.{{GPUObjectBase/[[device]]}}.
+                1. Let |descriptor| be the
+                    [$GPUTextureDescriptor for the canvas and configuration$](|this|.{{GPUCanvasContext/canvas}}, |configuration|).
+                1. Set |this|.{{GPUCanvasContext/[[configuration]]}} to |configuration|.
+                1. Set |this|.{{GPUCanvasContext/[[textureDescriptor]]}} to |descriptor|.
+                1. [$Replace the drawing buffer$] of |this|, which resets
+                    |this|.{{GPUCanvasContext/[[drawingBuffer]]}} with a bitmap with the new format and tags.
+                1. Issue the subsequent steps on the [=Device timeline=] of |device|.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
 
-                <div class=device-timeline>
-                    1. If any of the following requirements are unmet, [$generate a validation error$] and stop.
+                1. If any of the following requirements are unmet, [$generate a validation error$] and stop.
 
-                        <div class=validusage>
-                            - [$validating GPUTextureDescriptor$](|device|, |descriptor|)
-                                must return true.
-                            - [=Supported context formats=] must [=set/contain=]
-                                |configuration|.{{GPUCanvasConfiguration/format}}.
-                        </div>
+                    <div class=validusage>
+                        - [$validating GPUTextureDescriptor$](|device|, |descriptor|)
+                            must return true.
+                        - [=Supported context formats=] must [=set/contain=]
+                            |configuration|.{{GPUCanvasConfiguration/format}}.
+                    </div>
 
-                        Note: This early validation remains valid until the next
-                        {{GPUCanvasContext/configure()}} call, **except** for
-                        validation of the {{GPUTextureDescriptor/size}}, which changes when
-                        the canvas is resized.
-                </div>
+                    Note: This early validation remains valid until the next
+                    {{GPUCanvasContext/configure()}} call, **except** for
+                    validation of the {{GPUTextureDescriptor/size}}, which changes when
+                    the canvas is resized.
+            </div>
         </div>
 
     : <dfn>unconfigure()</dfn>
@@ -11860,13 +12081,17 @@ interface GPUCanvasContext {
         Removes the context configuration. Destroys any textures produced while configured.
 
         <div algorithm=GPUCanvasContext.unconfigure>
-            **Called on:** {{GPUCanvasContext}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUCanvasContext}} |this|.
 
-            **Returns:** undefined
+                **Returns:** undefined
 
-            1. Set |this|.{{GPUCanvasContext/[[configuration]]}} to `null`.
-            1. Set |this|.{{GPUCanvasContext/[[textureDescriptor]]}} to `null`.
-            1. [$Replace the drawing buffer$] of |this|.
+                [=Content timeline=] steps:
+
+                1. Set |this|.{{GPUCanvasContext/[[configuration]]}} to `null`.
+                1. Set |this|.{{GPUCanvasContext/[[textureDescriptor]]}} to `null`.
+                1. [$Replace the drawing buffer$] of |this|.
+            </div>
         </div>
 
     : <dfn>getCurrentTexture()</dfn>
@@ -11875,27 +12100,31 @@ interface GPUCanvasContext {
         next.
 
         <div algorithm=GPUCanvasContext.getCurrentTexture>
-            **Called on:** {{GPUCanvasContext}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUCanvasContext}} |this|.
 
-            **Returns:** {{GPUTexture}}
+                **Returns:** {{GPUTexture}}
 
-            1. If |this|.{{GPUCanvasContext/[[configuration]]}} is `null`:
-                1. Throw an {{InvalidStateError}} and stop.
-            1. [=Assert=] |this|.{{GPUCanvasContext/[[textureDescriptor]]}} is not `null`.
-            1. Let |device| be |this|.{{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/device}}.
-            1. If |this|.{{GPUCanvasContext/[[currentTexture]]}} is `null`:
-                1. [$Replace the drawing buffer$].
-                1. Set |this|.{{GPUCanvasContext/[[currentTexture]]}} to the result of calling
-                    |device|.{{GPUDevice/createTexture()}} with |this|.{{GPUCanvasContext/[[textureDescriptor]]}},
-                    except with the {{GPUTexture}}'s underlying storage pointing to
-                    |this|.{{GPUCanvasContext/[[drawingBuffer]]}}.
+                [=Content timeline=] steps:
 
-                    Note:
-                    If the texture can't be created (e.g. due to validation failure or out-of-memory),
-                    this generates and error and returns an [=invalid=] {{GPUTexture}}.
-                    Some validation here is redundant with that done in {{GPUCanvasContext/configure()}}.
-                    Implementations **must not** skip this redundant validation.
-            1. Return |this|.{{GPUCanvasContext/[[currentTexture]]}}.
+                1. If |this|.{{GPUCanvasContext/[[configuration]]}} is `null`:
+                    1. Throw an {{InvalidStateError}} and stop.
+                1. [=Assert=] |this|.{{GPUCanvasContext/[[textureDescriptor]]}} is not `null`.
+                1. Let |device| be |this|.{{GPUCanvasContext/[[configuration]]}}.{{GPUCanvasConfiguration/device}}.
+                1. If |this|.{{GPUCanvasContext/[[currentTexture]]}} is `null`:
+                    1. [$Replace the drawing buffer$].
+                    1. Set |this|.{{GPUCanvasContext/[[currentTexture]]}} to the result of calling
+                        |device|.{{GPUDevice/createTexture()}} with |this|.{{GPUCanvasContext/[[textureDescriptor]]}},
+                        except with the {{GPUTexture}}'s underlying storage pointing to
+                        |this|.{{GPUCanvasContext/[[drawingBuffer]]}}.
+
+                        Note:
+                        If the texture can't be created (e.g. due to validation failure or out-of-memory),
+                        this generates and error and returns an [=invalid=] {{GPUTexture}}.
+                        Some validation here is redundant with that done in {{GPUCanvasContext/configure()}}.
+                        Implementations **must not** skip this redundant validation.
+                1. Return |this|.{{GPUCanvasContext/[[currentTexture]]}}.
+            </div>
         </div>
 
         Note: The same {{GPUTexture}} object will be returned by every
@@ -12366,21 +12595,28 @@ partial interface GPUDevice {
         Pushes a new [=GPU error scope=] onto the {{GPUDevice/[[errorScopeStack]]}} for |this|.
 
         <div algorithm=GPUDevice.pushErrorScope>
-            **Called on:** {{GPUDevice}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUDevice}} |this|.
 
-            **Arguments:**
+                **Arguments:**
 
-            <pre class=argumentdef for="GPUDevice/pushErrorScope(filter)">
-                |filter|: Which class of errors this error scope observes.
-            </pre>
+                <pre class=argumentdef for="GPUDevice/pushErrorScope(filter)">
+                    |filter|: Which class of errors this error scope observes.
+                </pre>
 
-            1. Issue the following steps to the [=Device timeline=]:
+                **Returns:** {{undefined}}
+                
+                [=Content timeline=] steps:
 
-                <div class=device-timeline>
-                    1. Let |scope| be a new [=GPU error scope=].
-                    1. Set |scope|.{{GPU error scope/[[filter]]}} to |filter|.
-                    1. [=stack/Push=] |scope| onto |this|.{{GPUDevice/[[errorScopeStack]]}}.
-                </div>
+                1. Issue the subsequent steps on the [=Device timeline=] of |this|.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] steps:
+
+                1. Let |scope| be a new [=GPU error scope=].
+                1. Set |scope|.{{GPU error scope/[[filter]]}} to |filter|.
+                1. [=stack/Push=] |scope| onto |this|.{{GPUDevice/[[errorScopeStack]]}}.
+            </div>
         </div>
 
     : <dfn>popErrorScope()</dfn>
@@ -12389,27 +12625,32 @@ partial interface GPUDevice {
         and resolves to a {{GPUError}} if one was observed by the error scope.
 
         <div algorithm=GPUDevice.popErrorScope>
-            **Called on:** {{GPUDevice}} |this|.
+            <div data-timeline=content>
+                **Called on:** {{GPUDevice}} |this|.
 
-            **Returns:** {{Promise}}&lt;{{GPUError}}?&gt;
+                **Returns:** {{Promise}}&lt;{{GPUError}}?&gt;
 
-            1. Let |promise| be [=a new promise=].
-            1. Issue the following steps to the [=Device timeline=]:
+                [=Content timeline=] steps:
 
-                <div class=device-timeline>
-                    1. If any of the following requirements are unmet,
-                        [=reject=] |promise| with an {{OperationError}} and stop.
+                1. Let |promise| be [=a new promise=].
+                1. Issue the |resolve steps| on the [=Device timeline=] of |this|.
+                1. Return |promise|.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] |resolve steps|:
 
-                        <div class=validusage>
-                            - |this| must not be [=lose the device|lost=].
-                            - |this|.{{GPUDevice/[[errorScopeStack]]}}.[=list/size=] &gt; 0.
-                        </div>
+                1. If any of the following requirements are unmet,
+                    [=reject=] |promise| with an {{OperationError}} and stop.
 
-                    1. Let |scope| be the result of [=stack/pop|popping=] an [=list/item=] off of
-                        |this|.{{GPUDevice/[[errorScopeStack]]}}.
-                    1. [=Resolve=] |promise| with |scope|.{{GPU error scope/[[error]]}}.
-                </div>
-            1. Return |promise|.
+                    <div class=validusage>
+                        - |this| must not be [=lose the device|lost=].
+                        - |this|.{{GPUDevice/[[errorScopeStack]]}}.[=list/size=] &gt; 0.
+                    </div>
+
+                1. Let |scope| be the result of [=stack/pop|popping=] an [=list/item=] off of
+                    |this|.{{GPUDevice/[[errorScopeStack]]}}.
+                1. [=Resolve=] |promise| with |scope|.{{GPU error scope/[[error]]}}.
+            </div>
         </div>
 </dl>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6101,7 +6101,7 @@ interface mixin GPUPipelineBase {
 
                 1. If any of the following conditions are unsatisfied
                     [$generate a validation error$], make |layout| [=invalid=], and stop.
-                
+
                     <div class=validusage>
                         - |this| is [=valid=].
                         - |index| &lt; the [=list/size=] of
@@ -6909,7 +6909,7 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
                 1. When |pipeline| is ready to be used or has been made [=invalid=], [=resolve=]
                     |promise| with |pipeline|.
             </div>
-            
+
         </div>
 </dl>
 
@@ -8731,7 +8731,7 @@ dictionary GPUImageCopyExternalImage {
                 </pre>
 
                 **Returns:** {{undefined}}
-                
+
                 [=Content timeline=] steps:
 
                 1. Issue the subsequent steps on the [=Device timeline=] of
@@ -8813,7 +8813,7 @@ dictionary GPUImageCopyExternalImage {
 
                 1. Set |size| bytes of |buffer| to `0` starting at |offset|.
             </div>
-            
+
         </div>
 </dl>
 
@@ -9057,7 +9057,7 @@ Issue: define this as an algorithm with (texture, mipmapLevel) parameters and us
                 </pre>
 
                 **Returns:** {{undefined}}
-                
+
                 [=Content timeline=] steps:
 
                 1. Issue the subsequent steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
@@ -9226,7 +9226,7 @@ command encoder can no longer be used.
                 **Arguments:**
 
                 <pre class=argumentdef for="GPUCommandEncoder/finish(descriptor)">
-                    descriptor: Reserved for future use.
+                    descriptor:
                 </pre>
 
                 **Returns:** {{GPUCommandBuffer}}
@@ -10597,7 +10597,7 @@ It must only be included by interfaces which also include those mixins.
                 </pre>
 
                 **Returns:** {{undefined}}
-                
+
                 [=Content timeline=] steps:
 
                 1. Issue the subsequent steps on the [=Device timeline=] of
@@ -10971,7 +10971,7 @@ attachments used by this encoder.
                 </pre>
 
                 **Returns:** {{undefined}}
-                
+
                 [=Content timeline=] steps:
 
                 1. Issue the subsequent steps on the [=Device timeline=] of
@@ -11021,7 +11021,7 @@ attachments used by this encoder.
                 </pre>
 
                 **Returns:** {{undefined}}
-                
+
                 [=Content timeline=] steps:
 
                 1. Issue the subsequent steps on the [=Device timeline=] of
@@ -11060,7 +11060,7 @@ attachments used by this encoder.
                 </pre>
 
                 **Returns:** {{undefined}}
-                
+
                 [=Content timeline=] steps:
 
                 1. Issue the subsequent steps on the [=Device timeline=] of
@@ -11090,7 +11090,7 @@ attachments used by this encoder.
                 </pre>
 
                 **Returns:** {{undefined}}
-                
+
                 [=Content timeline=] steps:
 
                 1. Issue the subsequent steps on the [=Device timeline=] of
@@ -11121,7 +11121,7 @@ attachments used by this encoder.
                 </pre>
 
                 **Returns:** {{undefined}}
-                
+
                 [=Content timeline=] steps:
 
                 1. Issue the subsequent steps on the [=Device timeline=] of
@@ -11150,7 +11150,7 @@ attachments used by this encoder.
                 **Called on:** {{GPURenderPassEncoder}} this.
 
                 **Returns:** {{undefined}}
-                
+
                 [=Content timeline=] steps:
 
                 1. Issue the subsequent steps on the [=Device timeline=] of
@@ -11197,7 +11197,7 @@ attachments used by this encoder.
                 </pre>
 
                 **Returns:** {{undefined}}
-                
+
                 [=Content timeline=] steps:
 
                 1. Issue the subsequent steps on the [=Device timeline=] of
@@ -12605,7 +12605,7 @@ partial interface GPUDevice {
                 </pre>
 
                 **Returns:** {{undefined}}
-                
+
                 [=Content timeline=] steps:
 
                 1. Issue the subsequent steps on the [=Device timeline=] of |this|.


### PR DESCRIPTION
Addressed more of #2961, though I'm not sure we want to close it just yet because there's many algorithms that fall outside the methods that don't have explicit timeline markup. We should discuss how we want to handle those.

This is another PR that's probably best viewed with whitespace changes off. Fixed a few minor things I found along the way as well, such as completing the algorithm for `clearBuffer()`.