### PR TITLE
Expire the current texture with a microtask

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12160,6 +12160,10 @@ interface GPUCanvasContext {
     "[=Update the rendering=]" step of the HTML processing model, each {{GPUCanvasContext}} |context|
     must <dfn abstract-op>update the rendering of the WebGPU canvas</dfn> by running the following steps:
 
+    1. [=Assert=] |context|.{{GPUCanvasContext/[[currentTexture]]}} is `null`.
+        <span class='note'>Note: The {{GPUCanvasContext/[[currentTexture]]}} should always be
+        [$expire access to the current texture|expired$] by the microtask scheduled in
+        {{GPUCanvasContext/getCurrentTexture()}} prior to reaching this sub-step.</span>
     1. Update the rendering of |context|.{{GPUCanvasContext/canvas}} with
         [$get a copy of the image contents of a context|a copy of the image contents$] of |context|.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12129,16 +12129,31 @@ interface GPUCanvasContext {
                         this generates and error and returns an [=invalid=] {{GPUTexture}}.
                         Some validation here is redundant with that done in {{GPUCanvasContext/configure()}}.
                         Implementations **must not** skip this redundant validation.
+                    1. [=Queue a microtask=] to [$expire access to the current texture$].
                 1. Return |this|.{{GPUCanvasContext/[[currentTexture]]}}.
             </div>
         </div>
 
         Note: The same {{GPUTexture}} object will be returned by every
-        call to {{GPUCanvasContext/getCurrentTexture()}} made within the same frame (i.e. between
-        invocations of "[$update the rendering of the WebGPU canvas$]"), even if that {{GPUTexture}}
-        is destroyed, failed validation, or failed to allocate, **unless** the current texture has
-        been removed (in [$Replace the drawing buffer$]).
+        call to {{GPUCanvasContext/getCurrentTexture()}} made until the access to the texture
+        [$expire access to the current texture|expires$], even if that {{GPUTexture}} is destroyed,
+        failed validation, or failed to allocate, **unless** the current texture has been removed
+        (in [$Replace the drawing buffer$]).
 </dl>
+
+<div algorithm>
+    To <dfn abstract-op>expire access to the current texture</dfn> run the following steps:
+
+    1. If |context|.{{GPUCanvasContext/[[currentTexture]]}} is not `null`:
+        1. Call |context|.{{GPUCanvasContext/[[currentTexture]]}}.{{GPUTexture/destroy()}}
+            (without destroying |context|.{{GPUCanvasContext/[[drawingBuffer]]}})
+            to terminate write access to the image.
+        1. Set |context|.{{GPUCanvasContext/[[currentTexture]]}} to `null`.
+
+    Note: When the current texture expires the page no longer has the ability to write to it, but
+    the contents remain accessible for [$update the rendering of the WebGPU canvas|compositing$] or
+    [$get a copy of the image contents of a context|copying$].
+</div>
 
 <div algorithm>
     In the "update the rendering or user interface of that `Document`" sub-step of the
@@ -12147,11 +12162,6 @@ interface GPUCanvasContext {
 
     1. Update the rendering of |context|.{{GPUCanvasContext/canvas}} with
         [$get a copy of the image contents of a context|a copy of the image contents$] of |context|.
-    1. If |context|.{{GPUCanvasContext/[[currentTexture]]}} is not `null`:
-        1. Call |context|.{{GPUCanvasContext/[[currentTexture]]}}.{{GPUTexture/destroy()}}
-            (without destroying |context|.{{GPUCanvasContext/[[drawingBuffer]]}})
-            to terminate write access to the image.
-        1. Set |context|.{{GPUCanvasContext/[[currentTexture]]}} to `null`.
 
     Note: If {{GPUCanvasConfiguration/alphaMode}} is {{GPUCanvasAlphaMode/"opaque"}},
     the presented image has its alpha channel cleared. Implementations may skip this step if they


### PR DESCRIPTION
Fixes #3295

Changes the logic to expire the current texture to happen as a microtask
scheduled in `getCurrentTexture()`. This allows the logic to be consistent
between windows and workers, and removes any dependence on compositing to
advance the frame.