### PR TITLE
Make getBGL return a "copy" instead of a "reference"

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6114,7 +6114,7 @@ interface mixin GPUPipelineBase {
                             |this|.{{GPUPipelineBase/[[layout]]}}.{{GPUPipelineLayout/[[bindGroupLayouts]]}}
                     </div>
 
-                1. Update |layout| to reference the same internal object as
+                1. Initialize |layout| so it is a copy of
                     |this|.{{GPUPipelineBase/[[layout]]}}.{{GPUPipelineLayout/[[bindGroupLayouts]]}}[|index|].
 
                 Issue: Specify this more properly once we have internal objects for {{GPUBindGroupLayout}}.


### PR DESCRIPTION
The spec only cares about value-equality ("group-equivalent") so this is
the same thing but more compatible with the client-server model.