### PR TITLE
[Editorial] Clarifying Abstract Types in the first line

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1547,6 +1547,8 @@ include atomic types and abstract numeric types.
 
 ### Abstract Numeric Types ### {#abstract-types}
 
+These types cannot be spelled in WGSL source. They are only used by [=type checking=].
+
 Certain expressions are evaluated at [=shader module creation|shader-creation time=],
 and with a numeric range and precision that may be larger than directly implemented by the GPU.
 
@@ -1557,8 +1559,6 @@ and with a numeric range and precision that may be larger than directly implemen
 
 An evaluation of an expression in one of these types [=shader-creation
 error|must not=] overflow or produce infinite, NaN, or undefined results.
-
-These types cannot be spelled in WGSL source. They are only used by [=type checking=].
 
 A type is <dfn dfn-for="type" noexport>abstract</dfn> if it is an abstract
 numeric type or contains an abstract numeric type.


### PR DESCRIPTION
Fix confusing that AbstractFloat is some emulated double precision format in shader.