### PR TITLE
Reject redundant map requests early so there are never multiple pending promises

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3273,6 +3273,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
 
                 1. If |this|.{{GPUBuffer/[[pending_map]]}} is not `null`:
                     1. [=Reject=] |this|.{{GPUBuffer/[[pending_map]]}} with an {{AbortError}}.
+                    1. Set |this|.{{GPUBuffer/[[pending_map]]}} to `null`.
                 1. Let |updatedBufferContents| be `null`.
                 1. If |this|.{{GPUBuffer/[[mapping]]}} is not `null`:
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2665,7 +2665,7 @@ enum GPUBufferMapState {
 
                 1. If |this|.{{GPUBuffer/[[mapping]]}} is not `null`,
                     return {{GPUBufferMapState/"mapped"}}.
-                1. If |this|.{{GPUBuffer/[[map_requests]]}} is not empty,
+                1. If |this|.{{GPUBuffer/[[pending_map]]}} is not `null`,
                     return {{GPUBufferMapState/"pending"}}.
                 1. Return {{GPUBufferMapState/"unmapped"}}.
             </div>
@@ -2695,26 +2695,17 @@ enum GPUBufferMapState {
 
         Issue: This is device-timeline state.
 
-    : <dfn>\[[map_requests]]</dfn>, of type [=ordered map=]&lt;unique id, [=map request status=]&gt;
+    : <dfn>\[[pending_map]]</dfn>, of type {{Promise}}&lt;void&gt; or `null`, initially `null`
     ::
-        The <dfn dfn for=>map request status</dfn> of each outstanding map request:
+        The {{Promise}} returned by the currently-pending {{GPUBuffer/mapAsync()}} call.
 
-        <dl dfn-type=dfn dfn-for="map request status">
-            : "<dfn>open</dfn>"
-            ::
-                The map request is in flight and may still succeed.
-
-            : "<dfn>cancelled</dfn>"
-            ::
-                The map request has been cancelled by {{GPUBuffer/unmap()}} and will reject when it completes.
-        </dl>
-
-        Requests are removed from this map when they complete.
+        There is never more than one pending map, because {{GPUBuffer/mapAsync()}}
+        will refuse immediately if a request is already in flight.
 
     : <dfn>\[[mapping]]</dfn>, of type [=active buffer mapping=] or `null`, initially `null`
     ::
         Set iff the buffer is currently mapped for use by {{GPUBuffer/getMappedRange()}}.
-        Null otherwise (even if there are outstanding {{GPUBuffer/[[map_requests]]}}).
+        Null otherwise (even if there is a {{GPUBuffer/[[pending_map]]}}).
 
         An <dfn dfn for=>active buffer mapping</dfn> is a structure with the following fields:
 
@@ -3107,9 +3098,10 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                 [=Content timeline=] steps:
 
                 1. Let <var data-timeline=content>contentTimeline</var> be the current [=Content timeline=].
-                1. Let |requestID| be a new unique ID identifying this map request.
+                1. If |this|.{{GPUBuffer/[[pending_map]]}} is not `null`:
+                    1. Return [=a promise rejected with=] {{OperationError}}.
                 1. Let |p| be a new {{Promise}}.
-                1. [=map/Set=] |this|.{{GPUBuffer/[[map_requests]]}}[|requestID|] to "[=map request status/open=]".
+                1. Set |this|.{{GPUBuffer/[[pending_map]]}} to |p|.
                 1. Issue the |validation steps| on the [=Device timeline=] of
                     |this|.{{GPUObjectBase/[[device]]}}.
                 1. Return |p|.
@@ -3148,10 +3140,16 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                         <div data-timeline=content>
                             [=Content timeline=] steps:
 
-                            1. [=Assert=] |this|.{{GPUBuffer/[[map_requests]]}}[|requestID|] [=map/exists=].
-                            1. [=map/Remove=] |this|.{{GPUBuffer/[[map_requests]]}}[|requestID|].
+                            1. If |this|.{{GPUBuffer/[[pending_map]]}} is `null`:
+
+                                Note: The map has been cancelled by {{GPUBuffer/unmap()}}.
+
+                                1. [=Assert=] |this|.{{GPUBuffer/[[mapping]]}} is `null`.
+                                1. Return.
+                            1. [=Assert=] |this|.{{GPUBuffer/[[pending_map]]}} == |p|.
                             1. [=Assert=] |p| is pending.
                             1. [=Reject=] |p| with an {{OperationError}}.
+                            1. Set |this|.{{GPUBuffer/[[pending_map]]}} to `null`.
                         </div>
 
                     1. [$Generate a validation error$].
@@ -3170,24 +3168,24 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
 
                 1. Let |deviceTimelineStateAtCompletion| be |this|.{{GPUBuffer/[[deviceTimelineState]]}}.
 
-                    Note: If at this point the buffer has become "[=buffer device timeline state/available=]"
-                    again due to an {{GPUBuffer/unmap()}} call, then the corresponding request status
-                    below will also be "[=map request status/cancelled=]", so mapping will not complete below.
+                    Note: If, and only if, at this point the buffer has become "[=buffer device timeline state/available=]"
+                    again due to an {{GPUBuffer/unmap()}} call, then {{GPUBuffer/[[pending_map]]}} below will be null,
+                    so mapping will not succeed in the steps below.
                 1. Let |dataForMappedRegion| be the contents of |this| starting at offset |offset|, for |rangeSize| bytes.
                 1. Issue the subsequent steps on <var data-timeline=content>contentTimeline</var>.
             </div>
             <div data-timeline=content>
                 [=Content timeline=] steps:
 
-                1. Let |requestStatus| be |this|.{{GPUBuffer/[[map_requests]]}}[|requestID|].
-                1. [=map/Remove=] |this|.{{GPUBuffer/[[map_requests]]}}[|requestID|].
-                1. [=Assert=] |p| is pending.
-                1. If |requestStatus| is "[=map request status/cancelled=]":
-                    1. Reject |p| with an {{AbortError}}.
-                    1. Return.
+                1. If |this|.{{GPUBuffer/[[pending_map]]}} is `null`:
 
-                    Issue(gpuweb/gpuweb#3271): This describes one possible behavior.
-                    Need to discuss whether it's the right one.
+                    Note: The map has been cancelled by {{GPUBuffer/unmap()}}.
+
+                    1. [=Assert=] |deviceTimelineStateAtCompletion| is "[=buffer device timeline state/available=]".
+                    1. [=Assert=] |this|.{{GPUBuffer/[[mapping]]}} is `null`.
+                    1. Return.
+                1. [=Assert=] |this|.{{GPUBuffer/[[pending_map]]}} == |p|.
+                1. [=Assert=] |p| is pending.
                 1. [=Assert=] |deviceTimelineStateAtCompletion| is "[=buffer device timeline state/unavailable=]".
                 1. Let |m| be a new {{ArrayBuffer}} of size |rangeSize|.
                 1. Set the content of |m| to |dataForMappedRegion|.
@@ -3273,12 +3271,8 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
 
                 [=Content timeline=] steps:
 
-                1. For each |requestID| in the [=map/keys=] of |this|.{{GPUBuffer/[[map_requests]]}}:
-                    1. Set |this|.{{GPUBuffer/[[map_requests]]}}[|requestID|] to [=map request status/cancelled=].
-
-                    Issue(gpuweb/gpuweb#3271): This describes one possible behavior.
-                    Need to discuss whether it's the right one.
-
+                1. If |this|.{{GPUBuffer/[[pending_map]]}} is not `null`:
+                    1. [=Reject=] |this|.{{GPUBuffer/[[pending_map]]}} with an {{AbortError}}.
                 1. Let |updatedBufferContents| be `null`.
                 1. If |this|.{{GPUBuffer/[[mapping]]}} is not `null`:
 


### PR DESCRIPTION
Fixes #3271