### PR TITLE
Specify OOM behavior in mapping

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2924,7 +2924,7 @@ The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its
                 1. If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`:
                     1. Let |data| be [$CreateByteDataBlock$](|b|.{{GPUBuffer/size}}).
 
-                        If the allocation fails, set |mapOutOfMemory| to `false` and |data| to "[=oom-at-creation=]".
+                        If the allocation fails, set |mapOutOfMemory| to `true` and |data| to "[=oom-at-creation=]".
                     1. Set |b|.{{GPUBuffer/[[mapping]]}} to an [=active buffer mapping=] with:
                         - [=active buffer mapping/data=] set to |data|.
                         - [=active buffer mapping/mode=] set to {{GPUMapMode/WRITE}}.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2986,8 +2986,10 @@ The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its
                 1. Create a device allocation for |b| where each byte is zero.
 
                     If the allocation fails without side-effects,
-                    [$Generate an internal error$] with reason {{GPUInternalErrorReason/"out-of-memory"}}
+                    (generate an error),
                     make |b| [=invalid=], and return.
+
+                    Issue(gpuweb/gpuweb#3123): Generate the appropriate error here.
             </div>
         </div>
 </dl>
@@ -14489,7 +14491,3 @@ Eventually all of these should disappear but they are useful to avoid warning wh
 [=Origin2D/x=] [=Origin2D/y=]
 [=RenderPassDescriptor/renderExtent=]
 [=vertex buffer=]
-
-<dfn abstract-op lt="Generate an internal error|generate an internal error"></dfn>
-<dfn enum>GPUInternalErrorReason</dfn>
-<dfn enum-value for=GPUInternalErrorReason>"out-of-memory"</dfn>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -47,9 +47,13 @@ spec: ECMA-262; urlPrefix: https://tc39.es/ecma262/#
         text: agent; url: agent
         text: surrounding agent; url: surrounding-agent
         text: agent cluster; url: sec-agent-clusters
+        text: ?; url: sec-returnifabrupt-shorthands
+        text: !; url: sec-returnifabrupt-shorthands
+        text: Data Block; url: sec-data-blocks
     type: abstract-op
         text: DetachArrayBuffer; url: sec-detacharraybuffer
         text: AllocateArrayBuffer; url: sec-allocatearraybuffer
+        text: CreateByteDataBlock; url: sec-createbytedatablock
     type: attribute
         for: ArrayBuffer
             text: [[ArrayBufferDetachKey]]; url: sec-properties-of-the-arraybuffer-instances
@@ -2719,16 +2723,15 @@ enum GPUBufferMapState {
         An <dfn dfn for=>active buffer mapping</dfn> is a structure with the following fields:
 
         <dl dfn-type=dfn dfn-for="active buffer mapping">
-            : <dfn>data</dfn>, of type {{ArrayBuffer}}
+            : <dfn>data</dfn>, of type [=Data Block=] or "<dfn dfn for=>oom-at-creation</dfn>"
             ::
-                The mapping for this {{GPUBuffer}}. The {{ArrayBuffer}} isn't directly accessible
-                and is instead accessed through views into it, called the mapped ranges, that are
+                The mapping for this {{GPUBuffer}}. This data is accessed through {{ArrayBuffer}}s
+                which are views onto this data, returned by {{GPUBuffer/getMappedRange()}} and
                 stored in [=active buffer mapping/views=].
 
-                Note: This is just a memory allocation; this {{ArrayBuffer}} object is not exposed directly.
-
-                Issue: Specify {{GPUBuffer/[[mapping]]}} in term of `DataBlock` similarly
-                to [$AllocateArrayBuffer$]?
+                If "[=oom-at-creation=]", allocation of the map failed in {{GPUDevice/createBuffer()}}
+                with {{GPUBufferDescriptor/mappedAtCreation}} `true`, but {{GPUBuffer/getMappedRange()}}
+                can still be called.
 
             : <dfn>mode</dfn>, of type {{GPUMapModeFlags}}
             ::
@@ -2917,12 +2920,16 @@ The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its
                 1. Let |b| be a new {{GPUBuffer}} object.
                 1. Set |b|.{{GPUBuffer/size}} to |descriptor|.{{GPUBufferDescriptor/size}}.
                 1. Set |b|.{{GPUBuffer/usage}} to |descriptor|.{{GPUBufferDescriptor/usage}}.
-                1. If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`,
-                    set |b|.{{GPUBuffer/[[mapping]]}} to an [=active buffer mapping=] with:
-                    - [=active buffer mapping/data=] set to a new {{ArrayBuffer}} of size |b|.{{GPUBuffer/size}}.
-                    - [=active buffer mapping/mode=] set to {{GPUMapMode/WRITE}}.
-                    - [=active buffer mapping/range=] set to <code>[0, |descriptor|.{{GPUBufferDescriptor/size}}]</code>.
-                    - [=active buffer mapping/views=] set to `[]`.
+                1. Let |mapOutOfMemory| be `false`.
+                1. If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`:
+                    1. Let |data| be [$CreateByteDataBlock$](|b|.{{GPUBuffer/size}}).
+
+                        If the allocation fails, set |mapOutOfMemory| to `false` and |data| to "[=oom-at-creation=]".
+                    1. Set |b|.{{GPUBuffer/[[mapping]]}} to an [=active buffer mapping=] with:
+                        - [=active buffer mapping/data=] set to |data|.
+                        - [=active buffer mapping/mode=] set to {{GPUMapMode/WRITE}}.
+                        - [=active buffer mapping/range=] set to <code>[0, |descriptor|.{{GPUBufferDescriptor/size}}]</code>.
+                        - [=active buffer mapping/views=] set to `[]`.
 
                 1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
                 1. Return |b|.
@@ -2944,6 +2951,7 @@ The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its
                         - If |descriptor|.{{GPUBufferDescriptor/usage}} contains {{GPUBufferUsage/MAP_WRITE}}:
                             - |descriptor|.{{GPUBufferDescriptor/usage}} contains no other flags
                                 except {{GPUBufferUsage/COPY_SRC}}.
+                        - |mapOutOfMemory| is `false`.
                         - If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`:
                             - |descriptor|.{{GPUBufferDescriptor/size}} is a multiple of 4.
                     </div>
@@ -2959,7 +2967,17 @@ The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its
 
                     1. Set |b|.{{GPUBuffer/[[deviceTimelineState]]}} to "[=buffer device timeline state/available=]".
 
-                1. Set each byte of |b|'s allocation to zero.
+                1. If |mapOutOfMemory| is `true`,
+                    [$Generate an internal error$] with reason `undefined`
+                    and make |b| [=invalid=].
+
+                    Issue: Should the reason be `undefined` or `"out-of-memory"`?
+
+                1. Create a device allocation for |b| where each byte is zero.
+
+                    If the allocation fails without side-effects,
+                    [$Generate an internal error$] with reason {{GPUInternalErrorReason/"out-of-memory"}}
+                    and make |b| [=invalid=].
             </div>
         </div>
 </dl>
@@ -3189,10 +3207,13 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                     Issue(gpuweb/gpuweb#3271): This describes one possible behavior.
                     Need to discuss whether it's the right one.
                 1. [=Assert=] |deviceTimelineStateAtCompletion| is "[=buffer device timeline state/unavailable=]".
-                1. Let |m| be a new {{ArrayBuffer}} of size |rangeSize|.
-                1. Set the content of |m| to |dataForMappedRegion|.
+                1. Let |data| be [$CreateByteDataBlock$](|rangeSize|).
+                1. If the allocations of |data| or |dataForMappedRegion| failed:
+                    1. [=Reject=] |p| with a {{RangeError}}.
+                    1. Return.
+                1. Set the content of |data| to |dataForMappedRegion|.
                 1. Set |this|.{{GPUBuffer/[[mapping]]}} to an [=active buffer mapping=] with:
-                    - [=active buffer mapping/data=] set to |m|.
+                    - [=active buffer mapping/data=] set to |data|.
                     - [=active buffer mapping/mode=] set to |mode|.
                     - [=active buffer mapping/range=] set to <code>[|offset|, |offset| + |rangeSize|]</code>.
                     - [=active buffer mapping/views=] set to `[]`.
@@ -3232,25 +3253,49 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                         - |rangeSize| is a multiple of 4.
                         - |offset| &ge; |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/range=][0].
                         - |offset| + |rangeSize| &le; |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/range=][1].
-                        - [|offset|, |offset| + |rangeSize|) does not overlap another range in |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/views=].
+                        - [|offset|, |offset| + |rangeSize|) does not overlap another range in
+                            |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/views=].
 
                         Note: It is always valid to get mapped ranges of a {{GPUBuffer}} that is
                         {{GPUBufferDescriptor/mappedAtCreation}}, even if it is [=invalid=], because
                         the [=Content timeline=] might not know it is invalid.
                     </div>
 
-                1. Let |m| be a new {{ArrayBuffer}} of size |rangeSize|, pointing at the content
-                    at offset (|offset| - {{GPUBuffer/[[mapping]]}}.[=active buffer mapping/range=][0])
-                    of |this|.{{GPUBuffer/[[mapping]]}}.
+                1. Let |data| be |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/data=].
 
-                1. Set |m|.{{ArrayBuffer/[[ArrayBufferDetachKey]]}} to "WebGPUBufferMapping".
+                1. Let |view| be [=?=] [=ArrayBuffer/create|create an ArrayBuffer=] of size |rangeSize|.
+
+                    If |data| is a [=Data Block=], let |view| mutably reference the content at offset
+                    (|offset| - {{GPUBuffer/[[mapping]]}}.[=active buffer mapping/range=][0])
+                    of |data|.
+
+                    If |data| is "[=oom-at-creation=]", |view| is a normally-allocated, zeroed
+                    {{ArrayBuffer}}. Its contents will be ignored because the |this| is [=invalid=].
+
+                    <div class=note>
+                        Note:
+                        Usually, this {{ArrayBuffer}} points to an existing allocation, so won't fail
+                        to allocate. However, implementations may require an allocation here anyway.
+                        In some circumstances, including when the existing allocation was
+                        "[=oom-at-creation=]", it can fail to allocate.
+
+                        For consistency and predictability:
+
+                        - For any size at which `new ArrayBuffer()` would succeed at a given moment,
+                            {{GPUBuffer/getMappedRange()}} **should** succeed at that moment.
+                        - For any size at which `new ArrayBuffer()` *deterministically* throws a
+                            {{RangeError}}, {{GPUBuffer/getMappedRange()}} **should** as well.
+                            (This is only possible in the "[=oom-at-creation=]" case.)
+                    </div>
+
+                1. Set |view|.{{ArrayBuffer/[[ArrayBufferDetachKey]]}} to "WebGPUBufferMapping".
 
                     Note: This causes a {{TypeError}} to be thrown if an attempt is made to
                     [$DetachArrayBuffer$], except by {{GPUBuffer/unmap()}}.
 
-                1. [=list/Append=] |m| to |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/views=].
+                1. [=list/Append=] |view| to |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/views=].
 
-                1. Return |m|.
+                1. Return |view|.
 
                 Note: User agents should consider issuing a developer-visible warning if
                 {{GPUBuffer/getMappedRange()}} succeeds without having checked the status of
@@ -14452,3 +14497,7 @@ Eventually all of these should disappear but they are useful to avoid warning wh
 [=Origin2D/x=] [=Origin2D/y=]
 [=RenderPassDescriptor/renderExtent=]
 [=vertex buffer=]
+
+<dfn abstract-op lt="Generate an internal error|generate an internal error"></dfn>
+<dfn enum>GPUInternalErrorReason</dfn>
+<dfn enum-value for=GPUInternalErrorReason>"out-of-memory"</dfn>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2969,7 +2969,7 @@ The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its
 
                 1. If |mapOutOfMemory| is `true`,
                     [$Generate an internal error$] with reason `undefined`
-                    and make |b| [=invalid=].
+                    make |b| [=invalid=], and return.
 
                     Issue: Should the reason be `undefined` or `"out-of-memory"`?
 
@@ -2977,7 +2977,7 @@ The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its
 
                     If the allocation fails without side-effects,
                     [$Generate an internal error$] with reason {{GPUInternalErrorReason/"out-of-memory"}}
-                    and make |b| [=invalid=].
+                    make |b| [=invalid=], and return.
             </div>
         </div>
 </dl>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2726,15 +2726,11 @@ enum GPUBufferMapState {
         An <dfn dfn for=>active buffer mapping</dfn> is a structure with the following fields:
 
         <dl dfn-type=dfn dfn-for="active buffer mapping">
-            : <dfn>data</dfn>, of type [=Data Block=] or "<dfn dfn for=>map-oom-at-creation</dfn>"
+            : <dfn>data</dfn>, of type [=Data Block=]
             ::
                 The mapping for this {{GPUBuffer}}. This data is accessed through {{ArrayBuffer}}s
                 which are views onto this data, returned by {{GPUBuffer/getMappedRange()}} and
                 stored in [=active buffer mapping/views=].
-
-                If "[=map-oom-at-creation=]", allocation of the map failed in {{GPUDevice/createBuffer()}}
-                with {{GPUBufferDescriptor/mappedAtCreation}} `true`, but {{GPUBuffer/getMappedRange()}}
-                can still be called.
 
             : <dfn>mode</dfn>, of type {{GPUMapModeFlags}}
             ::
@@ -2750,6 +2746,31 @@ enum GPUBufferMapState {
                 The {{ArrayBuffer}}s returned via {{GPUBuffer/getMappedRange()}} to the application.
                 They are tracked so they can be detached when {{GPUBuffer/unmap()}} is called.
         </dl>
+
+        <div algorithm>
+            To <dfn abstract-op for=>initialize an active buffer mapping</dfn> with mode |mode| and
+            range |range|:
+
+            1. Let |size| be |range|[1] - |range|[0].
+            1. Let |data| be [=?=] [$CreateByteDataBlock$](|size|).
+
+                <div class=note>
+                    Note:
+                    This may result in a {{RangeError}} being thrown.
+                    For consistency and predictability:
+
+                    - For any size at which `new ArrayBuffer()` would succeed at a given moment,
+                        this allocation **should** succeed at that moment.
+                    - For any size at which `new ArrayBuffer()` *deterministically* throws a
+                        {{RangeError}}, this allocation **should** as well.
+                </div>
+
+            1. Return an [=active buffer mapping=] with:
+                - [=active buffer mapping/data=] set to |data|.
+                - [=active buffer mapping/mode=] set to |mode|.
+                - [=active buffer mapping/range=] set to |range|.
+                - [=active buffer mapping/views=] set to `[]`.
+        </div>
 </dl>
 
 <div class=example>
@@ -2923,17 +2944,10 @@ The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its
                 1. Let |b| be a new {{GPUBuffer}} object.
                 1. Set |b|.{{GPUBuffer/size}} to |descriptor|.{{GPUBufferDescriptor/size}}.
                 1. Set |b|.{{GPUBuffer/usage}} to |descriptor|.{{GPUBufferDescriptor/usage}}.
-                1. Let |mapOutOfMemory| be `false`.
                 1. If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`:
-                    1. Let |data| be [$CreateByteDataBlock$](|b|.{{GPUBuffer/size}}).
-
-                        If the allocation fails, set |mapOutOfMemory| to `true` and |data| to "[=map-oom-at-creation=]".
-                    1. Set |b|.{{GPUBuffer/[[mapping]]}} to an [=active buffer mapping=] with:
-                        - [=active buffer mapping/data=] set to |data|.
-                        - [=active buffer mapping/mode=] set to {{GPUMapMode/WRITE}}.
-                        - [=active buffer mapping/range=] set to <code>[0, |descriptor|.{{GPUBufferDescriptor/size}}]</code>.
-                        - [=active buffer mapping/views=] set to `[]`.
-
+                    1. Set |b|.{{GPUBuffer/[[mapping]]}} to
+                        [=?=] [$initialize an active buffer mapping$] with mode {{GPUMapMode/WRITE}}
+                        and range <code>[0, |descriptor|.{{GPUBufferDescriptor/size}}]</code>.
                 1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
                 1. Return |b|.
             </div>
@@ -2954,7 +2968,6 @@ The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its
                         - If |descriptor|.{{GPUBufferDescriptor/usage}} contains {{GPUBufferUsage/MAP_WRITE}}:
                             - |descriptor|.{{GPUBufferDescriptor/usage}} contains no other flags
                                 except {{GPUBufferUsage/COPY_SRC}}.
-                        - |mapOutOfMemory| is `false`.
                         - If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`:
                             - |descriptor|.{{GPUBufferDescriptor/size}} is a multiple of 4.
                     </div>
@@ -2969,12 +2982,6 @@ The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its
                     Else:
 
                     1. Set |b|.{{GPUBuffer/[[deviceTimelineState]]}} to "[=buffer device timeline state/available=]".
-
-                1. If |mapOutOfMemory| is `true`,
-                    [$Generate an internal error$] with reason `undefined`
-                    make |b| [=invalid=], and return.
-
-                    Issue: Should the reason be `undefined` or `"out-of-memory"`?
 
                 1. Create a device allocation for |b| where each byte is zero.
 
@@ -3210,16 +3217,15 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                     Issue(gpuweb/gpuweb#3271): This describes one possible behavior.
                     Need to discuss whether it's the right one.
                 1. [=Assert=] |deviceTimelineStateAtCompletion| is "[=buffer device timeline state/unavailable=]".
-                1. Let |data| be [$CreateByteDataBlock$](|rangeSize|).
-                1. If the allocations of |data| or |dataForMappedRegion| failed:
+                1. Let |mapping| be [$initialize an active buffer mapping$]
+                    with mode |mode| and range <code>[|offset|, |offset| + |rangeSize|]</code>.
+
+                    If this allocation or the allocation of |dataForMappedRegion| fails:
+
                     1. [=Reject=] |p| with a {{RangeError}}.
                     1. Return.
-                1. Set the content of |data| to |dataForMappedRegion|.
-                1. Set |this|.{{GPUBuffer/[[mapping]]}} to an [=active buffer mapping=] with:
-                    - [=active buffer mapping/data=] set to |data|.
-                    - [=active buffer mapping/mode=] set to |mode|.
-                    - [=active buffer mapping/range=] set to <code>[|offset|, |offset| + |rangeSize|]</code>.
-                    - [=active buffer mapping/views=] set to `[]`.
+                1. Set the content of |mapping|.[=active buffer mapping/data=] to |dataForMappedRegion|.
+                1. Set |this|.{{GPUBuffer/[[mapping]]}} to |mapping|.
                 1. [=Resolve=] |p|.
             </div>
         </div>
@@ -3266,30 +3272,12 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
 
                 1. Let |data| be |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/data=].
 
-                1. Let |view| be [=?=] [=ArrayBuffer/create|create an ArrayBuffer=] of size |rangeSize|.
+                1. Let |view| be [=!=] [=ArrayBuffer/create|create an ArrayBuffer=] of size |rangeSize|,
+                    but with its pointer mutably referencing the content of |data| at offset
+                    (|offset| - {{GPUBuffer/[[mapping]]}}.[=active buffer mapping/range=][0]).
 
-                    If |data| is a [=Data Block=], let |view| mutably reference the content at offset
-                    (|offset| - {{GPUBuffer/[[mapping]]}}.[=active buffer mapping/range=][0])
-                    of |data|.
-
-                    If |data| is "[=map-oom-at-creation=]", |view| is a normally-allocated, zeroed
-                    {{ArrayBuffer}}. Its contents will be ignored because the |this| is [=invalid=].
-
-                    <div class=note>
-                        Note:
-                        Usually, this {{ArrayBuffer}} points to an existing allocation, so won't fail
-                        to allocate. However, implementations may require an allocation here anyway.
-                        In some circumstances, including when the existing allocation was
-                        "[=map-oom-at-creation=]", it can fail to allocate.
-
-                        For consistency and predictability:
-
-                        - For any size at which `new ArrayBuffer()` would succeed at a given moment,
-                            {{GPUBuffer/getMappedRange()}} **should** succeed at that moment.
-                        - For any size at which `new ArrayBuffer()` *deterministically* throws a
-                            {{RangeError}}, {{GPUBuffer/getMappedRange()}} **should** as well.
-                            (This is only possible in the "[=map-oom-at-creation=]" case.)
-                    </div>
+                    Note: A {{RangeError}} may not be thrown here, because the |data| has already
+                    been allocated during {{GPUBuffer/mapAsync()}} or {{GPUDevice/createBuffer()}}.
 
                 1. Set |view|.{{ArrayBuffer/[[ArrayBufferDetachKey]]}} to "WebGPUBufferMapping".
 
@@ -3332,8 +3320,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
 
                     1. For each {{ArrayBuffer}} |ab| in |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/views=]:
                         1. Perform [$DetachArrayBuffer$](|ab|, "WebGPUBufferMapping").
-                    1. If |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/mode=] contains {{GPUMapMode/WRITE}}
-                        and |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/data=] is not "[=map-oom-at-creation=]":
+                    1. If |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/mode=] contains {{GPUMapMode/WRITE}}:
                         1. Set |updatedBufferContents| to the content of
                             |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/data=].
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3248,7 +3248,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                 1. Let |mapping| be [$initialize an active buffer mapping$]
                     with mode |mode| and range <code>[|offset|, |offset| + |rangeSize|]</code>.
 
-                    If this allocation or the allocation of |dataForMappedRegion| fails:
+                    If this allocation fails:
 
                     1. [=Reject=] |p| with a {{RangeError}}.
                     1. Return.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3332,8 +3332,10 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
 
                     1. For each {{ArrayBuffer}} |ab| in |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/views=]:
                         1. Perform [$DetachArrayBuffer$](|ab|, "WebGPUBufferMapping").
-                    1. If |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/mode=] contains {{GPUMapMode/WRITE}}:
-                        1. Set |updatedBufferContents| to the content of |this|.{{GPUBuffer/[[mapping]]}}.
+                    1. If |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/mode=] contains {{GPUMapMode/WRITE}}
+                        and |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/data=] is not "[=oom-at-creation=]":
+                        1. Set |updatedBufferContents| to the content of
+                            |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/data=].
 
                         Note: When a buffer is mapped without the {{GPUMapMode/WRITE}} mode, then
                         unmapped, any local modifications done by the application to the mapped ranges

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1295,6 +1295,9 @@ A [=device=] has the following internal slots:
 
 Any time the user agent needs to revoke access to a device, it calls
 [=lose the device=](device, `undefined`).
+For example, if an operation fails with side effects that would observably
+change the state of objects on the device or potentially corrupt internal
+implementation/driver state, the device should be lost to prevent further access.
 
 <div algorithm>
     To <dfn dfn>lose the device</dfn>(|device|, |reason|):

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2726,13 +2726,13 @@ enum GPUBufferMapState {
         An <dfn dfn for=>active buffer mapping</dfn> is a structure with the following fields:
 
         <dl dfn-type=dfn dfn-for="active buffer mapping">
-            : <dfn>data</dfn>, of type [=Data Block=] or "<dfn dfn for=>oom-at-creation</dfn>"
+            : <dfn>data</dfn>, of type [=Data Block=] or "<dfn dfn for=>map-oom-at-creation</dfn>"
             ::
                 The mapping for this {{GPUBuffer}}. This data is accessed through {{ArrayBuffer}}s
                 which are views onto this data, returned by {{GPUBuffer/getMappedRange()}} and
                 stored in [=active buffer mapping/views=].
 
-                If "[=oom-at-creation=]", allocation of the map failed in {{GPUDevice/createBuffer()}}
+                If "[=map-oom-at-creation=]", allocation of the map failed in {{GPUDevice/createBuffer()}}
                 with {{GPUBufferDescriptor/mappedAtCreation}} `true`, but {{GPUBuffer/getMappedRange()}}
                 can still be called.
 
@@ -2927,7 +2927,7 @@ The {{GPUBufferUsage}} flags determine how a {{GPUBuffer}} may be used after its
                 1. If |descriptor|.{{GPUBufferDescriptor/mappedAtCreation}} is `true`:
                     1. Let |data| be [$CreateByteDataBlock$](|b|.{{GPUBuffer/size}}).
 
-                        If the allocation fails, set |mapOutOfMemory| to `true` and |data| to "[=oom-at-creation=]".
+                        If the allocation fails, set |mapOutOfMemory| to `true` and |data| to "[=map-oom-at-creation=]".
                     1. Set |b|.{{GPUBuffer/[[mapping]]}} to an [=active buffer mapping=] with:
                         - [=active buffer mapping/data=] set to |data|.
                         - [=active buffer mapping/mode=] set to {{GPUMapMode/WRITE}}.
@@ -3272,7 +3272,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                     (|offset| - {{GPUBuffer/[[mapping]]}}.[=active buffer mapping/range=][0])
                     of |data|.
 
-                    If |data| is "[=oom-at-creation=]", |view| is a normally-allocated, zeroed
+                    If |data| is "[=map-oom-at-creation=]", |view| is a normally-allocated, zeroed
                     {{ArrayBuffer}}. Its contents will be ignored because the |this| is [=invalid=].
 
                     <div class=note>
@@ -3280,7 +3280,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                         Usually, this {{ArrayBuffer}} points to an existing allocation, so won't fail
                         to allocate. However, implementations may require an allocation here anyway.
                         In some circumstances, including when the existing allocation was
-                        "[=oom-at-creation=]", it can fail to allocate.
+                        "[=map-oom-at-creation=]", it can fail to allocate.
 
                         For consistency and predictability:
 
@@ -3288,7 +3288,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                             {{GPUBuffer/getMappedRange()}} **should** succeed at that moment.
                         - For any size at which `new ArrayBuffer()` *deterministically* throws a
                             {{RangeError}}, {{GPUBuffer/getMappedRange()}} **should** as well.
-                            (This is only possible in the "[=oom-at-creation=]" case.)
+                            (This is only possible in the "[=map-oom-at-creation=]" case.)
                     </div>
 
                 1. Set |view|.{{ArrayBuffer/[[ArrayBufferDetachKey]]}} to "WebGPUBufferMapping".
@@ -3333,7 +3333,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                     1. For each {{ArrayBuffer}} |ab| in |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/views=]:
                         1. Perform [$DetachArrayBuffer$](|ab|, "WebGPUBufferMapping").
                     1. If |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/mode=] contains {{GPUMapMode/WRITE}}
-                        and |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/data=] is not "[=oom-at-creation=]":
+                        and |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/data=] is not "[=map-oom-at-creation=]":
                         1. Set |updatedBufferContents| to the content of
                             |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/data=].
 


### PR DESCRIPTION
Now that buffer mapping is well-specified, we can finally resolve this 2-year-old issue! I read through the past discussion several times and finally worked out the details of how this works again. Fortunately we wrote it down pretty well.

EDIT: After editors' discussion, I changed this to allow a RangeError to be generated by createBuffer w/ mappedAtCreation:true, instead of trying to hide the failure to allocate a mapping backing-store. This is much simpler and of course still allows getMappedRange to work if the buffer ultimately fails to allocate on the GPU.

~There's a tiny open question about whether a CPU OOM is exposed as "out-of-memory" or as a generic "internal" error. Unless we remove "out-of-memory" from #3123.~

~Depends on #3123~

Fixes #872