### PR TITLE
Remove device-timeline validation error in unmap()

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3479,18 +3479,6 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                                 with the data |bufferUpdate|.`data`.
                         </div>
                 1. Set |this|.{{GPUBuffer/[[deviceTimelineState]]}} to "[=buffer device timeline state/available=]".
-                1. If any of the following requirements are unmet, [$generate a validation error$] and stop.
-
-                    <div class=validusage>
-                        - |this|.{{GPUBuffer/[[deviceTimelineState]]}} must be "[=buffer device timeline state/unavailable=]".
-
-                        Note: It is valid to unmap an [=invalid=] {{GPUBuffer}} that is
-                        {{GPUBufferDescriptor/mappedAtCreation}} because the [=Content timeline=]
-                        might not know it is [=invalid=]. Unmapping allows the temporary memory
-                        |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/data=] to be freed.
-                    </div>
-
-                    Issue(gpuweb/gpuweb#3251): This validation isn't really necessary because it's not guarding anything.
             </div>
         </div>
 </dl>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3447,21 +3447,26 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                 1. If |this|.{{GPUBuffer/[[pending_map]]}} is not `null`:
                     1. [=Reject=] |this|.{{GPUBuffer/[[pending_map]]}} with an {{AbortError}}.
                     1. Set |this|.{{GPUBuffer/[[pending_map]]}} to `null`.
+
+                1. If |this|.{{GPUBuffer/[[mapping]]}} is `null`:
+                    1. Return.
+
+                1. For each {{ArrayBuffer}} |ab| in |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/views=]:
+                    1. Perform [$DetachArrayBuffer$](|ab|, "WebGPUBufferMapping").
+
                 1. Let |bufferUpdate| be `null`.
-                1. If |this|.{{GPUBuffer/[[mapping]]}} is not `null`:
 
-                    1. For each {{ArrayBuffer}} |ab| in |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/views=]:
-                        1. Perform [$DetachArrayBuffer$](|ab|, "WebGPUBufferMapping").
-                    1. If |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/mode=] contains {{GPUMapMode/WRITE}}:
-                        1. Set |bufferUpdate| to {
-                            `data`: |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/data=],
-                            `offset`: |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/range=][0]
-                            }.
+                1. If |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/mode=] contains {{GPUMapMode/WRITE}}:
+                    1. Set |bufferUpdate| to {
+                        `data`: |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/data=],
+                        `offset`: |this|.{{GPUBuffer/[[mapping]]}}.[=active buffer mapping/range=][0]
+                        }.
 
-                        Note: When a buffer is mapped without the {{GPUMapMode/WRITE}} mode, then
-                        unmapped, any local modifications done by the application to the mapped ranges
-                        {{ArrayBuffer}} are discarded and will not affect the content of later mappings.
-                    1. Set |this|.{{GPUBuffer/[[mapping]]}} to `null`.
+                    Note: When a buffer is mapped without the {{GPUMapMode/WRITE}} mode, then
+                    unmapped, any local modifications done by the application to the mapped ranges
+                    {{ArrayBuffer}} are discarded and will not affect the content of later mappings.
+
+                1. Set |this|.{{GPUBuffer/[[mapping]]}} to `null`.
 
                 1. Issue the subsequent steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}.
             </div>


### PR DESCRIPTION
Dependent on #3353; see last 2 commits only.

Fixes #3251.