### PR TITLE
[editorial] Vertical column headers for texture format table

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -330,6 +330,14 @@ table.data tr.row-continuation th {
 }
 
 /*
+ * Vertical class for table columns. (Can't use th.vertical because of a Safari bug.)
+ */
+span.vertical {
+    writing-mode: vertical-rl;
+    white-space: nowrap;
+}
+
+/*
  * Sticky table headers.
  */
 .overlarge {
@@ -10445,7 +10453,7 @@ dictionary GPURenderPassColorAttachment {
 
     **Arguments:**
 
-    - sequence<{{GPUTextureFormat}}?> |formats|
+    - sequence&lt;{{GPUTextureFormat}}?&gt; |formats|
 
     **Returns:** {{GPUSize32}}
 
@@ -13999,15 +14007,15 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <tr>
             <th>Format
             <th>{{GPUTextureSampleType}}
-            <th>{{GPUTextureUsage/RENDER_ATTACHMENT}}
-            <th>multisampling
-            <th>resolve
-            <th>{{GPUTextureUsage/STORAGE_BINDING}}
+            <th><span class=vertical>{{GPUTextureUsage/RENDER_ATTACHMENT}}</span>
+            <th><span class=vertical>multisampling</span>
+            <th><span class=vertical>resolve</span>
+            <th><span class=vertical>{{GPUTextureUsage/STORAGE_BINDING}}</span>
             <th>[=Texel block size=] (Bytes)
             <th><dfn dfn>Render target pixel byte cost</dfn> (Bytes)
             <th><dfn dfn>Render target component alignment</dfn> (Bytes)
     </thead>
-    <tr><th class=stickyheader>8-bit per component<th><th><th><th><th><th>
+    <tr><th>8-bit per component
     <tr>
         <td>{{GPUTextureFormat/r8unorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -14026,8 +14034,8 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>
         <td><!-- Vulkan -->
         <td>1
-        <td><!-- no render target -->
-        <td><!-- no render target -->
+        <td>&ndash; <!-- no render target -->
+        <td>&ndash; <!-- no render target -->
     <tr>
         <td>{{GPUTextureFormat/r8uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -14066,8 +14074,8 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>
         <td><!-- Vulkan -->
         <td>2
-        <td><!-- no render target -->
-        <td><!-- no render target -->
+        <td>&ndash; <!-- no render target -->
+        <td>&ndash; <!-- no render target -->
     <tr>
         <td>{{GPUTextureFormat/rg8uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -14116,8 +14124,8 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>
         <td>&checkmark;
         <td>4
-        <td><!-- no render target --> <!-- If we add render target support for this in the future, rgba8snorm has to be a special case where the render target pixel byte cost = 8 -->
-        <td><!-- no render target -->
+        <td>&ndash; <!-- no render target --> <!-- If we add render target support for this in the future, rgba8snorm has to be a special case where the render target pixel byte cost = 8 -->
+        <td>&ndash; <!-- no render target -->
     <tr>
         <td>{{GPUTextureFormat/rgba8uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -14158,7 +14166,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>4
         <td>8
         <td>1
-    <tr><th class=stickyheader>16-bit per component<th><th><th><th><th><th>
+    <tr><th>16-bit per component
     <tr>
         <td>{{GPUTextureFormat/r16uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -14249,7 +14257,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>8
         <td>8
         <td>2
-    <tr><th class=stickyheader>32-bit per component<th><th><th><th><th><th>
+    <tr><th>32-bit per component
     <tr>
         <td>{{GPUTextureFormat/r32uint}}
         <td>{{GPUTextureSampleType/"uint"}}
@@ -14340,7 +14348,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>16
         <td>16
         <td>4
-    <tr><th class=stickyheader>mixed component width<th><th><th><th><th><th>
+    <tr><th>mixed component width
     <tr>
         <td>{{GPUTextureFormat/rgb10a2unorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
@@ -14408,7 +14416,7 @@ be used with {{GPUSamplerBindingType/"comparison"}} samplers (which may use filt
         <td>{{GPUTextureFormat/depth24plus}}
         <td>4
         <td>depth
-        <td>- (<a href="#depthPlus">See prose</a>)
+        <td>&ndash; (<a href="#depthPlus">See prose</a>)
         <td>{{GPUTextureSampleType/"depth"}}, {{GPUTextureSampleType/"unfilterable-float"}}
         <td colspan=2>&cross;
         <td>{{GPUTextureFormat/depth24plus}}
@@ -14416,7 +14424,7 @@ be used with {{GPUSamplerBindingType/"comparison"}} samplers (which may use filt
         <td rowspan=2 style="white-space: nowrap">{{GPUTextureFormat/depth24plus-stencil8}}
         <td rowspan=2>4 &minus; 8
         <td>depth
-        <td>- (<a href="#depthPlus">See prose</a>)
+        <td>&ndash; (<a href="#depthPlus">See prose</a>)
         <td>{{GPUTextureSampleType/"depth"}}, {{GPUTextureSampleType/"unfilterable-float"}}
         <td colspan=2>&cross;
         <td>{{GPUTextureFormat/depth24plus}}


### PR DESCRIPTION
Also: en-dashes for N/A table cells, and a nit.