### PR TITLE
Add timestampWrites to the section of Timestamp Query

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12061,10 +12061,14 @@ and ended by calling {{GPURenderPassEncoder/beginOcclusionQuery()}} and
 
 ## Timestamp Query ## {#timestamp}
 
-Timestamp query allows application to write timestamp values to a {{GPUQuerySet}} by calling {{GPUCommandEncoder/writeTimestamp()}}
-on {{GPUCommandEncoder}} or setting {{GPUComputePassDescriptor/timestampWrites}} in {{GPUComputePassDescriptor}} or
-{{GPURenderPassDescriptor/timestampWrites}} in {{GPURenderPassDescriptor}}, and then resolve timestamp values in **nanoseconds**
-(type of {{GPUSize64}}) to a {{GPUBuffer}} (using {{GPUCommandEncoder/resolveQuerySet()}}).
+Timestamp queries allow applications to write timestamps to a {{GPUQuerySet}}, using:
+
+- {{GPUCommandEncoder}}.{{GPUCommandEncoder/writeTimestamp()}}
+- {{GPUComputePassDescriptor}}.{{GPUComputePassDescriptor/timestampWrites}}
+- {{GPURenderPassDescriptor}}.{{GPURenderPassDescriptor/timestampWrites}}
+
+and then resolve timestamp values (in nanoseconds as a 64-bit unsigned integer) into
+a {{GPUBuffer}}, using {{GPUCommandEncoder}}.{{GPUCommandEncoder/resolveQuerySet()}}.
 
 Timestamp query requires {{GPUFeatureName/"timestamp-query"}} is available on the device.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12061,7 +12061,10 @@ and ended by calling {{GPURenderPassEncoder/beginOcclusionQuery()}} and
 
 ## Timestamp Query ## {#timestamp}
 
-Timestamp query allows application to write timestamp values to a {{GPUQuerySet}} by calling {{GPUCommandEncoder/writeTimestamp()}} on {{GPUCommandEncoder}}, and then resolve timestamp values in **nanoseconds** (type of {{GPUSize64}}) to a {{GPUBuffer}} (using {{GPUCommandEncoder/resolveQuerySet()}}).
+Timestamp query allows application to write timestamp values to a {{GPUQuerySet}} by calling {{GPUCommandEncoder/writeTimestamp()}}
+on {{GPUCommandEncoder}} or setting {{GPUComputePassDescriptor/timestampWrites}} in {{GPUComputePassDescriptor}} or
+{{GPURenderPassDescriptor/timestampWrites}} in {{GPURenderPassDescriptor}}, and then resolve timestamp values in **nanoseconds**
+(type of {{GPUSize64}}) to a {{GPUBuffer}} (using {{GPUCommandEncoder/resolveQuerySet()}}).
 
 Timestamp query requires {{GPUFeatureName/"timestamp-query"}} is available on the device.
 


### PR DESCRIPTION
Current only writeTimestamp on GPUCommandEncoder is described in the
section of Timestamp Query, timestampWrites using querySet is missing.