### PR TITLE
[editorial] Fix uniformity for statements table render

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9016,24 +9016,20 @@ When several edges have to be created we use `X -> {Y, Z}` as a short-hand for `
       <td>*CFend*
       <td class="nowrap">*CFend* -> {*CF_1*, ..., *CF_n*}
   <tr><td class="nowrap">var x: T;
-      <td rowspan=2>
-      <td rowspan=2>
-      <td rowspan=2>*CF*
-      <td rowspan=2>
+      <td rowspan=3>
+      <td rowspan=3>
+      <td rowspan=3>*CF*
+      <td rowspan=3>
       Note: If x is a [=address spaces/function=] address space variable, *CF*
       is used as the zero value initializer in the
       [[#func-var-value-analysis|value analysis]].
   <tr><td class="nowrap">break;
+  <tr><td class="nowrap">continue;
   <tr><td class="nowrap">break if *e*;
       <td>
       <td class="nowrap">(*CF*, *e*) => (*CF'*, *V*)
       <td>*CF'*
       <td>
-  <tr><td class="nowrap">continue;
-      <td rowspan=2>
-      <td rowspan=2>
-      <td rowspan=2>*CF*
-      <td rowspan=2>
   <tr><td class="nowrap">return;
       <td>
       <td>


### PR DESCRIPTION
* Table displayed incorrectly
  * Moved continue to be grouped with similar statements earlier instead
    of on its own