### PR TITLE
Rename 'Creation' headers for disambiguation

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5003,7 +5003,7 @@ GPUBindGroupLayout includes GPUObjectBase;
     ::
 </dl>
 
-### Creation ### {#bind-group-layout-creation}
+### Bind Group Layout Creation ### {#bind-group-layout-creation}
 
 A {{GPUBindGroupLayout}} is created via {{GPUDevice/createBindGroupLayout()|GPUDevice.createBindGroupLayout()}}.
 
@@ -5780,7 +5780,7 @@ Issue: should this example and the note be moved to some "best practices" docume
 
 Note: the expected usage of the {{GPUPipelineLayout}} is placing the most common and the least frequently changing bind groups at the "bottom" of the layout, meaning lower bind group slot numbers, like 0 or 1. The more frequently a bind group needs to change between draw calls, the higher its index should be. This general guideline allows the user agent to minimize state changes between draw calls, and consequently lower the CPU overhead.
 
-### Creation ### {#pipeline-layout-creation}
+### Pipeline Layout Creation ### {#pipeline-layout-creation}
 
 A {{GPUPipelineLayout}} is created via {{GPUDevice/createPipelineLayout()|GPUDevice.createPipelineLayout()}}.
 
@@ -6746,7 +6746,7 @@ GPUComputePipeline includes GPUObjectBase;
 GPUComputePipeline includes GPUPipelineBase;
 </script>
 
-### Creation ### {#compute-pipeline-creation}
+### Compute Pipeline Creation ### {#compute-pipeline-creation}
 
 A {{GPURenderPipelineDescriptor}} describes a compute [=pipeline=]. See
 [[#computing-operations]] for additional details.
@@ -6931,7 +6931,7 @@ GPURenderPipeline includes GPUPipelineBase;
     :: True if the pipeline writes to the stencil component of the depth/stencil attachment
 </dl>
 
-### Creation ### {#render-pipeline-creation}
+### Render Pipeline Creation ### {#render-pipeline-creation}
 
 A {{GPURenderPipelineDescriptor}} describes a render [=pipeline=] by configuring each
 of the [=render stages=]. See [[#rendering-operations]] for additional details.
@@ -8349,7 +8349,7 @@ GPUCommandBuffer includes GPUObjectBase;
         buffer is submitted.
 </dl>
 
-### Creation ### {#command-buffer-creation}
+### Command Buffer Creation ### {#command-buffer-creation}
 
 <script type=idl>
 dictionary GPUCommandBufferDescriptor : GPUObjectDescriptorBase {
@@ -8472,7 +8472,7 @@ GPUCommandEncoder includes GPUCommandsMixin;
 GPUCommandEncoder includes GPUDebugCommandsMixin;
 </script>
 
-### Creation ### {#command-encoder-creation}
+### Command Encoder Creation ### {#command-encoder-creation}
 
 <script type=idl>
 dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
@@ -9844,7 +9844,7 @@ GPUComputePassEncoder includes GPUBindingCommandsMixin;
         The timestamp attachments which need to be executed when the pass ends.
 </dl>
 
-### Creation ### {#compute-pass-encoder-creation}
+### Compute Pass Encoder Creation ### {#compute-pass-encoder-creation}
 
 <script type=idl>
 enum GPUComputePassTimestampLocation {
@@ -10181,7 +10181,7 @@ When a {{GPURenderPassEncoder}} is created, it has the following default state:
     - `x, y` = `0, 0`
     - `width, height` = the dimensions of the pass's render targets
 
-### Creation ### {#render-pass-encoder-creation}
+### Render Pass Encoder Creation ### {#render-pass-encoder-creation}
 
 <script type=idl>
 enum GPURenderPassTimestampLocation {
@@ -11474,7 +11474,7 @@ GPURenderBundle includes GPUObjectBase;
         The number of draw commands in this {{GPURenderBundle}}.
 </dl>
 
-### Creation ### {#render-bundle-creation}
+### Render Bundle Creation ### {#render-bundle-creation}
 
 <script type=idl>
 dictionary GPURenderBundleDescriptor : GPUObjectDescriptorBase {


### PR DESCRIPTION
This prevents issues where you click on a definition and it returns a list like:

```
Used in:
 - Limits and Features [1][2]
 - Device Initialization
 - Creation
 - Creation
 - Creation [1][2]
 - Creation [1][2][3][4]
 - Queues and Stuff [1][2][3]
 - Creation
```