### PR TITLE
[editorial] Improve exposition of the uniformity analysis

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8600,7 +8600,27 @@ See [[#statements]] and [[#function-calls]].
 
 ## Uniformity ## {#uniformity}
 
-### Terminology and concepts ### {#uniformity-concepts}
+[[#collective-operations|Collective operations]] (e.g. barriers and
+derivatives) require coordination among different invocations running
+concurrently on the GPU.  To ensure correct and portable behavior, WGSL
+requires that these operations can be statically analyzed to not have any
+control dependencies such that a non-empty strict subset of invocations will
+execute the operation (i.e. the operation must be executed in [=uniform control
+flow=]).
+Non-uniform control dependencies arise from [[#control-flow|control flow]]
+statements whose behavior depends on [=uniform value|non-uniform values=].
+These non-uniform values can be traced back to certain sources that cannot be
+statically proven to be uniform.
+These sources include, but are not limited to:
+* Mutable [=module scope|module-scope=] [=variables=]
+* Most [=built-in values=], except [=built-in values/num_workgroups=] and [=built-in values/workgroup_id=]
+* [=user-defined input datum|User-defined inputs=]
+* Certain [=built-in functions=] (see [[#uniformity-function-calls]])
+
+The remainder of this section is devoted to a description of this static
+analysis an implementation will perform to validate the WGSL program.
+
+### Terminology and Concepts ### {#uniformity-concepts}
 
 The following definitions are merely informative, trying to give an intuition for what the analysis in the next subsection is computing.
 The analysis is what actually defines these concepts, and when a program is valid or breaks the uniformity rules.
@@ -8617,10 +8637,11 @@ For a given group of invocations:
 - If invocations hold the same value for a local variable at every point where it is live,
     it is said to be a <dfn noexport>uniform variable</dfn>.
 
-### Uniformity analysis overview ### {#uniformity-overview}
+### Uniformity Analysis Overview ### {#uniformity-overview}
 
-Some functions (e.g. barriers and derivatives) are only safe to call in [=uniform control flow=].
-In this section we specify an analysis that verifies that these functions are only called in such a context.
+The remaining subsections specify a static analysis that verifies that
+[[#collective-operations|collective operations]] are only executed in [=uniform
+control flow=].
 
 <div class="note">Note: This analysis has the following desirable properties:
       - Sound (meaning that it rejects every program that would break the uniformity requirements of builtins)
@@ -8629,7 +8650,7 @@ In this section we specify an analysis that verifies that these functions are on
       - If the analysis refuses a program, it provides a straightforward chain of implications that can be used by the user agent to craft a good error message
 </div>
 
-The analysis analyzes each function, verifying that there is a context where it is safe to call this function. It rejects the program as invalid if there is no such context.
+Each function is analyzed, verifying that there is a context where it is safe to call this function. It rejects the program as invalid if there is no such context.
 
 At the same time, it computes metadata about the function to help analyze its callers in turn.
 This means that the call graph must first be built, and functions must be analyzed from the leaves upwards, i.e. from functions that call no function outside the standard library toward the entry point.
@@ -8638,7 +8659,7 @@ There is no risk of being trapped in a cycle, as recurrence is forbidden in the 
 
 Note: another way of saying the same thing is that we do a topological sort of functions ordered by the "is a (possibly indirect) callee of" partial order, and analyze them in that order.
 
-### Analyzing the uniformity requirements of a function ### {#uniformity-function}
+### Analyzing the Uniformity Requirements of a Function ### {#uniformity-function}
 
 Each function is analyzed in two phases.
 
@@ -8931,7 +8952,7 @@ assignment|partial=] assignments depending on the initializer substitutions.
   </xmp>
 </div>
 
-### Uniformity rules for statements ### {#uniformity-statements}
+### Uniformity Rules for Statements ### {#uniformity-statements}
 
 The rules for analyzing statements take as argument both the statement itself and the node corresponding to control flow at the beginning of it (which we'll note "CF" below) and return both of the following:
 
@@ -9076,9 +9097,16 @@ from their respective desugaring translations to [[#loop-statement|loop]] statem
 
 In [[#switch-statement|switch]], a [=default-alone clause=] block is treated exactly like a [=case clause=] with regards to uniformity.
 
-Note: If the set of behaviors (see [[#behaviors]]) for an if, switch, or loop statement is {Next}, this means that we either did not diverge within the statement, or we reconverged, so we pick the node corresponding to control flow at the start of the statement as the node corresponding to control flow at the exit of the statement.
+GPUs are incentivized to minimize the amount of [=uniform control
+flow|non-uniform control flow=]; however, the points at which invocations can
+be said to be uniform varies depending on a number of factors.
+WGSL's static analysis conservatively assumes a return to uniform control flow
+occuring at the end of if, switch and loop statements if the
+[[#behaviors|behavior]] for the statement is {Next}.
+This is modelled in the preceding table as the resulting control flow node
+being the same as input control flow node.
 
-### Uniformity rules for function calls ### {#uniformity-function-calls}
+### Uniformity Rules for Function Calls ### {#uniformity-function-calls}
 
 The most complex rule is for function calls:
 - For each argument, apply the corresponding expression rule, with the control flow at the exit of the previous argument (using the control flow at the beginning of the function call for the first argument). Name the corresponding value nodes "arg_i" and the corresponding control flow nodes "CF_i"
@@ -9107,7 +9135,11 @@ Here is the list of exceptions:
     [=CallSiteNoRestriction=], a [=function tag=] of [=NoRestriction=] and
     the input parameter `p` has a [=parameter tag=] of [=ParameterNoRestriction=]
 
-### Uniformity rules for expressions ### {#uniformity-expressions}
+Note: A WGSL implementation will ensure that if control flow prior to a
+function call is [=uniform control flow|uniform=], it will also be uniform
+after the function call.
+
+### Uniformity Rules for Expressions ### {#uniformity-expressions}
 
 The rules for analyzing expressions take as argument both the expression itself and the node corresponding to control flow at the beginning of it (which we'll note "CF" below) and return the following:
 
@@ -9196,6 +9228,10 @@ The following built-in input variables are considered uniform:
 
 All other ones (see [[#builtin-values]]) are considered non-uniform.
 
+Note: An author should avoid grouping the uniform built-in values together with
+other non-uniform inputs because the analysis does not analyze the [=components=]
+of a [=composite=] type separately.
+
 <table class='data'>
   <caption>Uniformity rules for expressions in lvalue positions</caption>
   <thead>
@@ -9233,7 +9269,7 @@ All other ones (see [[#builtin-values]]) are considered non-uniform.
       <td class="nowrap">*L1* -> *V2*
 </table>
 
-### Annotating the uniformity of every point in the control-flow ### {#uniformity-optional-diagnosis-mode}
+### Annotating the Uniformity of Every Point in the Control-flow ### {#uniformity-optional-diagnosis-mode}
 
 This entire subsection is non-normative.
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -238,8 +238,8 @@ When executing a shader stage, the implementation:
 * Then it invokes the entry point.
 
 A WGSL program is organized into:
-* Functions, which specify execution behaviour.
-* Statements, which are declarations or units of executable behaviour.
+* Functions, which specify execution behavior.
+* Statements, which are declarations or units of executable behavior.
 * Literals, which are text representations for pure mathematical values.
 * Constants, each providing a name for a value computed at a specific time.
 * Variables, each providing a name for memory holding a value.
@@ -249,7 +249,7 @@ A WGSL program is organized into:
     * Constraints on supported expressions.
     * The semantics of those expressions.
 
-WGSL is an imperative language: behaviour is specified as a sequence of statements to execute.
+WGSL is an imperative language: behavior is specified as a sequence of statements to execute.
 Statements can:
 * Declare constants or variables.
 * Modify the contents of variables.
@@ -258,7 +258,7 @@ Statements can:
     * Repetition: loop, while, for.
     * Escaping a nested execution construct: break, continue.
     * Refactoring: function call and return.
-* Evaluate expressions to compute values as part of the above behaviours.
+* Evaluate expressions to compute values as part of the above behaviors.
 
 WGSL is statically typed: each value computed by a particular expression is in a specific type,
 determined only by examining the program source.
@@ -296,13 +296,13 @@ Each invocation has its own independent memory space in the form
 of variables in the [=address spaces/private=] and [=address spaces/function=] address spaces.
 
 Invocations within a shader stage execute concurrently, and may often execute in parallel.
-The shader author is responsible for ensuring the dynamic behaviour of the invocations
+The shader author is responsible for ensuring the dynamic behavior of the invocations
 in a shader stage:
 * Meet the [[#uniformity|uniformity]] requirements of certain primitive operations, including texture sampling and control barriers.
 * Coordinate potentially conflicting accesses to shared variables, to avoid race conditions.
 
-WGSL sometimes permits several possible behaviours for a given feature.
-This is a portability hazard, as different implementations may exhibit the different behaviours.
+WGSL sometimes permits several possible behaviors for a given feature.
+This is a portability hazard, as different implementations may exhibit the different behaviors.
 The design of WGSL aims to minimize such cases, but is constrained by feasibility,
 and goals for achieving high performance across a broad range of devices.
 
@@ -1219,7 +1219,7 @@ For example:
 * the spelling is different for structure types, or types containing structures.
 
 Some WGSL types are only used for analyzing a source program and
-for determining the program's runtime behaviour.
+for determining the program's runtime behavior.
 This specification will describe such types, but they do not appear in WGSL source text.
 
 Note: WGSL [=reference types=] are not written in WGSL programs. See [[#ref-ptr-types]].
@@ -5667,7 +5667,7 @@ See [[#sync-builtin-functions]].
             real-valued quotient |e1|&nbsp;&div;&nbsp;|e2|.
 
         Note:
-        The need to ensure truncation behaviour may require an implementation
+        The need to ensure truncation behavior may require an implementation
         to perform more operations than when computing an unsigned division.
         Use unsigned division when both operands are known to have the same sign.
 
@@ -5698,7 +5698,7 @@ See [[#sync-builtin-functions]].
        When non-zero, the result has the same sign as |e1|.
 
        Note:
-       The need to ensure consistent behaviour may require an implementation
+       The need to ensure consistent behavior may require an implementation
        to perform more operations than when computing an unsigned remainder.
 
         <!--
@@ -7394,7 +7394,7 @@ non-empty [=behavior=] for each statement, and function.
     <td class="nowrap">|f|(|e1|, ..., |en|);
     <td class="nowrap">|f| has behavior |B|
     <td class="nowrap">|B|
-  <tr algorithm="return behaviour">
+  <tr algorithm="return behavior">
     <td>return;
     <td>
     <td>{Return}
@@ -7483,7 +7483,7 @@ Here is the full list of ways that these rules can cause a program to be rejecte
 - The body of a function (treated as a regular statement) has a behavior not included in {Next, Return}.
 - The body of a function with a return type has a behavior which is not {Return}.
 - The behavior of a continuing block contains any of Continue, or Return.
-- Some obviously infinite loops have an empty behaviour set, and are therefore invalid.
+- Some obviously infinite loops have an empty behavior set, and are therefore invalid.
 
 This analysis can be run in linear time, by analyzing the call-graph bottom-up (since the behavior of a function call can depend on the function's code).
 
@@ -7499,7 +7499,7 @@ Here are some examples showing this analysis in action:
                  //   Statement behavior: {Next}
                  //   Overall behavior (due to sequential statements): {Return}
       return 2;  // Valid, statically unreachable code. Behavior: {Return}
-    } // Function behaviour: {Return}
+    } // Function behavior: {Return}
    </xmp>
 </div>
 
@@ -7600,7 +7600,7 @@ Here are some examples showing this analysis in action:
     fn invalid_infinite_loop() {
       loop {
         discard; // Behaviour { Next }.
-      }          // Invalid, behaviour of the whole loop is { }.
+      }          // Invalid, behavior of the whole loop is { }.
     }
   </xmp>
 </div>
@@ -8432,10 +8432,10 @@ The WGSL language is expected to evolve over time.
 
 An <dfn noexport>extension</dfn> is a named grouping for a coherent
 set of modifications to a particular version of the WGSL specification, consisting of any combination of:
-* Addition of new concepts and behaviours via new syntax, including:
+* Addition of new concepts and behaviors via new syntax, including:
     * declarations, statements, attributes, and built-in functions.
 * Removal of restrictions in the current specification or in previously published extensions.
-* Syntax for reducing the set of permissible behaviours.
+* Syntax for reducing the set of permissible behaviors.
 * Syntax for limiting the features available to a part of the program.
 * A description of how the extension interacts with the existing specification, and optionally with other extensions.
 
@@ -8609,7 +8609,7 @@ execute the operation (i.e. the operation must be executed in [=uniform control
 flow=]).
 Non-uniform control dependencies arise from [[#control-flow|control flow]]
 statements whose behavior depends on [=uniform value|non-uniform values=].
-These non-uniform values can be traced back to certain sources that cannot be
+These non-uniform values can be traced back to certain sources that are not
 statically proven to be uniform.
 These sources include, but are not limited to:
 * Mutable [=module scope|module-scope=] [=variables=]
@@ -8906,7 +8906,7 @@ notations:
           }<br>
       <td>*Vin*(*next*)
       <td>*Vout*(*s*<sub>i</sub>),<br>
-          for all *s*<sub>i</sub> whose behaviour includes *Next* or *Break*, and<br>
+          for all *s*<sub>i</sub> whose behavior includes *Next* or *Break*, and<br>
           *Vout*(*s*<sub>j</sub>)<br>
           for all statements inside *s*<sub>j</sub> whose behavior is {*Break*} and trasfer control to *next*
 </table>
@@ -9097,13 +9097,14 @@ from their respective desugaring translations to [[#loop-statement|loop]] statem
 
 In [[#switch-statement|switch]], a [=default-alone clause=] block is treated exactly like a [=case clause=] with regards to uniformity.
 
-GPUs are incentivized to minimize the amount of [=uniform control
-flow|non-uniform control flow=]; however, the points at which invocations can
-be said to be uniform varies depending on a number of factors.
-WGSL's static analysis conservatively assumes a return to uniform control flow
-occuring at the end of if, switch and loop statements if the
-[[#behaviors|behavior]] for the statement is {Next}.
-This is modelled in the preceding table as the resulting control flow node
+To maximize performance, implementations often try to minimize the amount of
+[=uniform control flow|non-uniform control flow=].
+However, the points at which invocations can be said to be uniform varies
+depending on a number of factors.  WGSL's static analysis conservatively
+assumes a return to uniform control flow occuring at the end of
+[=statement/if=], [=statement/switch=], and [=statement/loop=] statements if
+the [[#behaviors|behavior]] for the statement is {Next}.
+This is modeled in the preceding table as the resulting control flow node
 being the same as input control flow node.
 
 ### Uniformity Rules for Function Calls ### {#uniformity-function-calls}
@@ -9664,7 +9665,7 @@ the original type is one of [=i32=] or [=u32=] and the destination type is [=f32
 Note: The original value is always within range of the destination type when
 the source type is a floating point type with fewer exponent and mantissa bits than the target floating point type.
 
-Issue: Check behaviour of the f32 to f16 conversion for numbers just beyond the max normal f16 values.
+Issue: Check behavior of the f32 to f16 conversion for numbers just beyond the max normal f16 values.
 I've written what an NVIDIA GPU does.  See https://github.com/google/amber/pull/918 for an executable test case.
 
 # Memory Model # {#memory-model}
@@ -11066,7 +11067,7 @@ Note: Each [=user-defined function=] only has one [=overload=].
 Each [=overload=] is described below via:
 * Type parameterizations, if any.
 * The built-in function name, a parenthesized list of [=formal parameters=], and optionally a [=return type=].
-* The behaviour of this overload of the function.
+* The behavior of this overload of the function.
 
 Since a built-in function is always in scope, it is a [=shader-creation error=]
 to attempt to redefine one or to use the name of a built-in function as an


### PR DESCRIPTION
* Motivate the analysis at a high level in the intro section
* Promote the note about reconvergence to descriptive spec text
* Add a note about function reconvergence
* Add a note to avoid grouping uniform and non-uniform inputs in a
  composite
* Uniform naming conventions for sections