### PR TITLE
Style links with the timeline of the reference they point to

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -14696,7 +14696,7 @@ Eventually all of these should disappear but they are useful to avoid warning wh
 // Small script to collect all xrefs that refer to different timelines and highlight
 // them with an appropriate style.
 
-const dataLinks = document.querySelectorAll('[data-link-type]');
+const dataLinks = document.querySelectorAll("[data-link-type='abstract-op'], [data-link-type='dfn'], [data-link-type='attribute']");
 for (const dataLink of dataLinks) {
     const linkUrl = dataLink.getAttribute('href');
     if (linkUrl && linkUrl.startsWith('#')) {

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2872,8 +2872,6 @@ dictionary GPUBufferDescriptor : GPUObjectDescriptorBase {
 
 <div algorithm data-timeline=device>
     <dfn abstract-op>validating GPUBufferDescriptor</dfn>(|device|, |descriptor|)
-    
-    [=Device timeline=] steps:
 
     1. If |device| is lost return `false`.
     1. If any of the bits of |descriptor|'s {{GPUBufferDescriptor/usage}} aren't present in
@@ -14702,7 +14700,7 @@ for (const dataLink of dataLinks) {
     if (linkUrl && linkUrl.startsWith('#')) {
       const dataLinkTarget = document.getElementById(linkUrl.substring(1));
       if (dataLinkTarget) {
-          // Find the closets ancestor of the target (including the target itself)
+          // Find the closest ancestor of the target (including the target itself)
           // that contains a data-timeline.
           const timelineElement = dataLinkTarget.closest('[data-timeline]');
           if (timelineElement) {

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -166,6 +166,7 @@ div.content-timeline, div.device-timeline, div.queue-timeline {
 
 span[data-timeline],
 var[data-timeline],
+a[data-timeline],
 [href="#content-timeline"],
 [href="#device-timeline"],
 [href="#queue-timeline"] {
@@ -364,7 +365,6 @@ thead.stickyheader th, th.stickyheader {
     }
 }
 </style>
-
 
 # Introduction # {#intro}
 
@@ -2870,16 +2870,19 @@ dictionary GPUBufferDescriptor : GPUObjectDescriptorBase {
         mapped range can be written/read to until it is unmapped.
 </dl>
 
-<div algorithm>
+<div algorithm data-timeline=device>
     <dfn abstract-op>validating GPUBufferDescriptor</dfn>(|device|, |descriptor|)
-        1. If |device| is lost return `false`.
-        1. If any of the bits of |descriptor|'s {{GPUBufferDescriptor/usage}} aren't present in
-            |device|'s [=allowed buffer usages=], return `false`.
-        1. If both the {{GPUBufferUsage/MAP_READ}} and {{GPUBufferUsage/MAP_WRITE}} bits of
-            |descriptor|'s {{GPUBufferDescriptor/usage}} attribute are set, return `false`.
-        1. If |descriptor|.{{GPUBufferDescriptor/size}} is greater than
-            |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBufferSize}}, return `false`.
-        1. Return `true`.
+    
+    [=Device timeline=] steps:
+
+    1. If |device| is lost return `false`.
+    1. If any of the bits of |descriptor|'s {{GPUBufferDescriptor/usage}} aren't present in
+        |device|'s [=allowed buffer usages=], return `false`.
+    1. If both the {{GPUBufferUsage/MAP_READ}} and {{GPUBufferUsage/MAP_WRITE}} bits of
+        |descriptor|'s {{GPUBufferDescriptor/usage}} attribute are set, return `false`.
+    1. If |descriptor|.{{GPUBufferDescriptor/size}} is greater than
+        |device|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBufferSize}}, return `false`.
+    1. Return `true`.
 </div>
 
 ### Buffer Usage ### {#buffer-usage}
@@ -14688,3 +14691,26 @@ Eventually all of these should disappear but they are useful to avoid warning wh
 [=Origin2D/x=] [=Origin2D/y=]
 [=RenderPassDescriptor/renderExtent=]
 [=vertex buffer=]
+
+<script>
+// Small script to collect all xrefs that refer to different timelines and highlight
+// them with an appropriate style.
+
+const dataLinks = document.querySelectorAll('[data-link-type]');
+for (const dataLink of dataLinks) {
+    const linkUrl = dataLink.getAttribute('href');
+    if (linkUrl && linkUrl.startsWith('#')) {
+      const dataLinkTarget = document.getElementById(linkUrl.substring(1));
+      if (dataLinkTarget) {
+          // Find the closets ancestor of the target (including the target itself)
+          // that contains a data-timeline.
+          const timelineElement = dataLinkTarget.closest('[data-timeline]');
+          if (timelineElement) {
+            // If we found a timeline, apply an appropriate style the link.
+            const timeline = timelineElement.getAttribute('data-timeline');
+            dataLink.setAttribute('data-timeline', timeline);
+          }
+      }
+    }
+}
+</script>


### PR DESCRIPTION
Script takes less than 20ms to run in my tests, and doesn't shift the layout, so having this run on the client side shouldn't be too disruptive. I'd prefer to do it as a bikeshed plugin, but as far as I can tell those don't exist.