### PR TITLE
Move promise resolutions in algorithms to content timeline

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2306,7 +2306,7 @@ interface GPUAdapter {
                         reinitialization logic starting with {{GPU/requestAdapter()}}.
 
                     Otherwise:
-                        1. Let |device| [=a new device=] with the capabilities described by |descriptor|.
+                        1. Let |device| be [=a new device=] with the capabilities described by |descriptor|.
 
                 1. Issue the subsequent steps on <var data-timeline=content>contentTimeline</var>.
             </div>
@@ -11969,14 +11969,15 @@ GPUQueue includes GPUObjectBase;
 
                 1. Let <var data-timeline=content>contentTimeline</var> be the current [=Content timeline=].
                 1. Let |promise| be [=a new promise=].
-                1. Issue the |synchronization steps| on the [=Queue timeline=] of |this|.
+                1. Issue the |synchronization steps| on the [=Device timeline=] of |this|.
                 1. Return |promise|.
             </div>
-            <div data-timeline=queue>
-                [=Queue timeline=] |synchronization steps|:
+            <div data-timeline=device>
+                [=Device timeline=] |synchronization steps|:
 
-                1. At an **unspecified point now or in the future**, issue the subsequent steps on
-                    <var data-timeline=content>contentTimeline</var>.
+                1. After the [=device timeline=] becomes informed of the completion of all
+                    <span data-timeline=queue>currently-enqueued operations</span>:
+                    1. Issue the subsequent steps on <var data-timeline=content>contentTimeline</var>.
             </div>
             <div data-timeline=content>
                 [=Content timeline=] steps:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2263,21 +2263,28 @@ interface GPUAdapter {
             <div data-timeline=device>
                 [=Device timeline=] |initialization steps|:
 
-                1. If any of the following requirements are unmet,
-                    [=reject=] |promise| with a {{TypeError}} and stop.
+                1. If any of the following requirements are unmet:
 
                     <div class=validusage>
                         - The set of values in |descriptor|.{{GPUDeviceDescriptor/requiredFeatures}}
                             must be a subset of those in |adapter|.{{adapter/[[features]]}}.
                     </div>
 
+                    Then issue the following steps on <var data-timeline=content>contentTimeline</var>
+                    and stop:
+
+                        <div data-timeline=content>
+                            [=Content timeline=] steps:
+
+                            1. [=Reject=] |promise| with a {{TypeError}}
+                        </div>
+
                     Note: This is the same error that is produced if a feature name isn't known
                     by the browser at all (in its {{GPUFeatureName}} definition).
                     This converges the behavior when the browser doesn't support a feature
                     with the behavior when a particular adapter doesn't support a feature.
 
-                1. If any of the following requirements are unmet,
-                    [=reject=] |promise| with an {{OperationError}} and stop.
+                1. If any of the following requirements are unmet:
 
                     <div class=validusage>
                         - Each key in |descriptor|.{{GPUDeviceDescriptor/requiredLimits}}
@@ -2289,6 +2296,15 @@ interface GPUAdapter {
                                 |adapter|.{{adapter/[[limits]]}}.
                             - If the limit's [=limit class|class=] is [=limit class/alignment=],
                                 |value| must be a power of 2.
+                    </div>
+
+                    Then issue the following steps on <var data-timeline=content>contentTimeline</var>
+                    and stop:
+
+                    <div data-timeline=content>
+                        [=Content timeline=] steps:
+
+                        1. [=Reject=] |promise| with a {{OperationError}}.
                     </div>
 
                 1. If |adapter| is [=invalid=],
@@ -11975,8 +11991,8 @@ GPUQueue includes GPUObjectBase;
             <div data-timeline=device>
                 [=Device timeline=] |synchronization steps|:
 
-                1. After the [=device timeline=] becomes informed of the completion of all
-                    <span data-timeline=queue>currently-enqueued operations</span>:
+                1. When the [=device timeline=] becomes informed of the completion of all
+                    <span data-timeline=queue>currently-enqueued operations</span> on |this|:
                     1. Issue the subsequent steps on <var data-timeline=content>contentTimeline</var>.
             </div>
             <div data-timeline=content>
@@ -12892,6 +12908,7 @@ partial interface GPUDevice {
 
                 [=Content timeline=] steps:
 
+                1. Let <var data-timeline=content>contentTimeline</var> be the current [=Content timeline=].
                 1. Let |promise| be [=a new promise=].
                 1. Issue the |resolve steps| on the [=Device timeline=] of |this|.
                 1. Return |promise|.
@@ -12899,12 +12916,20 @@ partial interface GPUDevice {
             <div data-timeline=device>
                 [=Device timeline=] |resolve steps|:
 
-                1. If any of the following requirements are unmet,
-                    [=reject=] |promise| with an {{OperationError}} and stop.
+                1. If any of the following requirements are unmet:
 
                     <div class=validusage>
                         - |this| must not be [=lose the device|lost=].
                         - |this|.{{GPUDevice/[[errorScopeStack]]}}.[=list/size=] &gt; 0.
+                    </div>
+
+                    Then issue the following steps on <var data-timeline=content>contentTimeline</var>
+                    and stop:
+
+                    <div data-timeline=content>
+                        [=Content timeline=] steps:
+
+                        1. [=Reject=] |promise| with a {{OperationError}}.
                     </div>
 
                 1. Let |scope| be the result of [=stack/pop|popping=] an [=list/item=] off of

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2271,12 +2271,12 @@ interface GPUAdapter {
                     </div>
 
                     Then issue the following steps on <var data-timeline=content>contentTimeline</var>
-                    and stop:
+                    and return:
 
                         <div data-timeline=content>
                             [=Content timeline=] steps:
 
-                            1. [=Reject=] |promise| with a {{TypeError}}
+                            1. [=Reject=] |promise| with a {{TypeError}}.
                         </div>
 
                     Note: This is the same error that is produced if a feature name isn't known
@@ -2299,12 +2299,12 @@ interface GPUAdapter {
                     </div>
 
                     Then issue the following steps on <var data-timeline=content>contentTimeline</var>
-                    and stop:
+                    and return:
 
                     <div data-timeline=content>
                         [=Content timeline=] steps:
 
-                        1. [=Reject=] |promise| with a {{OperationError}}.
+                        1. [=Reject=] |promise| with an {{OperationError}}.
                     </div>
 
                 1. If |adapter| is [=invalid=],
@@ -12924,12 +12924,12 @@ partial interface GPUDevice {
                     </div>
 
                     Then issue the following steps on <var data-timeline=content>contentTimeline</var>
-                    and stop:
+                    and return:
 
                     <div data-timeline=content>
                         [=Content timeline=] steps:
 
-                        1. [=Reject=] |promise| with a {{OperationError}}.
+                        1. [=Reject=] |promise| with an {{OperationError}}.
                     </div>
 
                 1. Let |scope| be the result of [=stack/pop|popping=] an [=list/item=] off of

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1995,6 +1995,7 @@ interface GPU {
 
                 [=Content timeline=] steps:
 
+                1. Let <var data-timeline=content>contentTimeline</var> be the current [=Content timeline=].
                 1. Let |promise| be [=a new promise=].
                 1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
                 1. Return |promise|.
@@ -2002,16 +2003,23 @@ interface GPU {
             <div data-timeline=device>
                 [=Device timeline=] |initialization steps|:
 
+                1. Let |adapter| be `null`.
                 1. If the user agent chooses to return an adapter, it should:
-                    1. Create a [=valid=] [=adapter=] |adapter|, chosen according to
+                    1. Set |adapter| to a [=valid=] [=adapter=], chosen according to
                         the rules in [[#adapter-selection]] and the criteria in |options|.
 
                     1. If |adapter| meets the criteria of a [=fallback adapter=] set
                         |adapter|.{{adapter/[[fallback]]}} to `true`.
 
+                1. Issue the subsequent steps on <var data-timeline=content>contentTimeline</var>.
+            </div>
+            <div data-timeline=content>
+                [=Content timeline=] steps:
+
+                1. If |adapter| is not `null`:
                     1. [=Resolve=] |promise| with a new {{GPUAdapter}} encapsulating |adapter|.
 
-                1. Otherwise, |promise| [=resolves=] with `null`.
+                1. Otherwise, [=Resolve=] |promise| with `null`.
             </div>
             <!-- If we add ways to make invalid adapter requests (aside from those
                 that violate IDL rules), specify that they reject the promise. -->
@@ -2246,6 +2254,7 @@ interface GPUAdapter {
 
                 [=Content timeline=] steps:
 
+                1. Let <var data-timeline=content>contentTimeline</var> be the current [=Content timeline=].
                 1. Let |promise| be [=a new promise=].
                 1. Let |adapter| be |this|.{{GPUAdapter/[[adapter]]}}.
                 1. Issue the |initialization steps| to the [=Device timeline=] of |this|.
@@ -2296,11 +2305,15 @@ interface GPUAdapter {
                         most or all cases when this occurs. Applications should perform
                         reinitialization logic starting with {{GPU/requestAdapter()}}.
 
-                    1. [=Resolve=] |promise| with a new {{GPUDevice}} encapsulating |device|,
-                        and stop.
+                    Otherwise:
+                        1. Let |device| [=a new device=] with the capabilities described by |descriptor|.
 
-                1. [=Resolve=] |promise| with a new {{GPUDevice}} object encapsulating
-                    [=a new device=] with the capabilities described by |descriptor|.
+                1. Issue the subsequent steps on <var data-timeline=content>contentTimeline</var>.
+            </div>
+            <div data-timeline=content>
+                [=Content timeline=] steps:
+
+                1. [=Resolve=] |promise| with a new {{GPUDevice}} object |device|.
             </div>
         </div>
 
@@ -6850,6 +6863,7 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
 
                 [=Content timeline=] steps:
 
+                1. Let <var data-timeline=content>contentTimeline</var> be the current [=Content timeline=].
                 1. Let |promise| be [=a new promise=].
                 1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
                 1. Return |promise|.
@@ -6860,8 +6874,13 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
                 1. Let |pipeline| be a new {{GPUComputePipeline}} created as if
                     |this|.{{GPUDevice/createComputePipeline()}} was called with |descriptor|;
 
-                1. When |pipeline| is ready to be used or has been made [=invalid=], [=resolve=]
-                    |promise| with |pipeline|.
+                1. When |pipeline| is ready to be used or has been made [=invalid=], issue the
+                    subsequent steps on <var data-timeline=content>contentTimeline</var>.
+            </div>
+            <div data-timeline=content>
+                [=Content timeline=] steps:
+
+                1. [=Resolve=] |promise| with |pipeline|.
             </div>
         </div>
 </dl>
@@ -7068,6 +7087,7 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
 
                 [=Content timeline=] steps:
 
+                1. Let <var data-timeline=content>contentTimeline</var> be the current [=Content timeline=].
                 1. Let |promise| be [=a new promise=].
                 1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
                 1. Return |promise|.
@@ -7078,10 +7098,14 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
                 1. Let |pipeline| be a new {{GPURenderPipeline}} created as if
                     |this|.{{GPUDevice/createRenderPipeline()}} was called with |descriptor|;
 
-                1. When |pipeline| is ready to be used or has been made [=invalid=], [=resolve=]
-                    |promise| with |pipeline|.
+                1. When |pipeline| is ready to be used or has been made [=invalid=], issue the
+                    subsequent steps on <var data-timeline=content>contentTimeline</var>.
             </div>
+            <div data-timeline=content>
+                [=Content timeline=] steps:
 
+                1. [=Resolve=] |promise| with |pipeline|.
+            </div>
         </div>
 </dl>
 
@@ -11943,12 +11967,19 @@ GPUQueue includes GPUObjectBase;
 
                 [=Content timeline=] steps:
 
+                1. Let <var data-timeline=content>contentTimeline</var> be the current [=Content timeline=].
                 1. Let |promise| be [=a new promise=].
-                1. Issue the |resolve steps| on the [=Queue timeline=] of |this|.
+                1. Issue the |synchronization steps| on the [=Queue timeline=] of |this|.
                 1. Return |promise|.
             </div>
             <div data-timeline=queue>
-                [=Queue timeline=] |resolve steps|:
+                [=Queue timeline=] |synchronization steps|:
+
+                1. At an **unspecified point now or in the future**, issue the subsequent steps on
+                    <var data-timeline=content>contentTimeline</var>.
+            </div>
+            <div data-timeline=content>
+                [=Content timeline=] steps:
 
                 1. [=Resolve=] |promise|.
             </div>


### PR DESCRIPTION
I'd appreciate feedback specifically on the `onSubmittedWorkDone()` changes.