### PR TITLE
Fix declaration of [SameObject]-ness on interface rather than dictionary

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12983,11 +12983,11 @@ interface GPUUncapturedErrorEvent : Event {
         DOMString type,
         GPUUncapturedErrorEventInit gpuUncapturedErrorEventInitDict
     );
-    readonly attribute GPUError error;
+    [SameObject] readonly attribute GPUError error;
 };
 
 dictionary GPUUncapturedErrorEventInit : EventInit {
-    [SameObject] required GPUError error;
+    required GPUError error;
 };
 </script>
 


### PR DESCRIPTION
https://github.com/gpuweb/gpuweb/commit/547af357553c36e0777cbe4656701a2372552783 tried to revert https://github.com/gpuweb/gpuweb/commit/4a60f158361bea57843d02aa100e3fd37526178a following the conversion of `GPUError` to an interface, but applied the [SameObject] extended attribute to the member of the `…Init` dictionary instead of the intended attribute of the `GPUUncapturedErrorEvent` interface.