### PR TITLE
Fix address space for runtime-sized array example

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2622,7 +2622,7 @@ For each member index |i| > 1:
     // If B is the effective buffer binding size for the binding on the
     // draw or dispatch command, the number of elements is:
     //   N_runtime = floor(B / element stride) = floor(B / 16)
-    var<uniform> directions: array<vec3<f32>>;
+    var<storage> directions: array<vec3<f32>>;
   </xmp>
 </div>
 


### PR DESCRIPTION
Fixes: #3383