### PR TITLE
Clarify units for trig and hyperbolic functions

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -11207,7 +11207,9 @@ fn arrayLength(p: ptr<storage, array<E>, AM>) -> u32
     <td>[ALLFLOATINGDECL]
   <tr>
     <td>Description
-    <td>Returns the inverse cosine (cos<sup>-1</sup>) of `e`.
+    <td>Returns the principal value, in radians, of the inverse cosine (cos<sup>-1</sup>) of `e`.<br>
+    That is, approximates `x` with 0 &le; `x` &le; &pi;, such that `cos`(`x`) = `e`.
+
     [=Component-wise=] when `T` is a vector.
 </table>
 
@@ -11223,9 +11225,12 @@ fn arrayLength(p: ptr<storage, array<E>, AM>) -> u32
     <td>[ALLFLOATINGDECL]
   <tr>
     <td>Description
-    <td>Returns the inverse hyperbolic cosine (cosh<sup>-1</sup>) of `e`.
-    The result is 0 when `e` &lt; 1.<br>
-    Computes the non-negative functional inverse of `cosh`.<br>
+    <td>Returns the inverse hyperbolic cosine (cosh<sup>-1</sup>) of `e`, as a
+    hyperbolic angle in radians.<br>
+    That is, approximates `x` with 0 &le; x &le; &infin;, such that `cosh`(`x`) = `e`.
+
+    The result is 0 when `e` &lt; 1.
+
     [=Component-wise=] when `T` is a vector.
   <tr>
     <td>
@@ -11247,7 +11252,9 @@ Note: The result is not mathematically meaningful when `e` &lt; 1.
     <td>[ALLFLOATINGDECL]
   <tr>
     <td>Description
-    <td>Returns the inverse sine (sin<sup>-1</sup>) of `e`.
+    <td>Returns the principal value, in radians, of the inverse sine (sin<sup>-1</sup>) of `e`.<br>
+    That is, approximates `x` with -&pi;/2 &le; `x` &le; &pi;/2, such that `sin`(`x`) = `e`.
+
     [=Component-wise=] when `T` is a vector.
 </table>
 
@@ -11263,8 +11270,9 @@ Note: The result is not mathematically meaningful when `e` &lt; 1.
     <td>[ALLFLOATINGDECL]
   <tr>
     <td>Description
-    <td>Returns the inverse hyperbolic sine (sinh<sup>-1</sup>) of `e`.<br>
-    Computes the functional inverse of `sinh`.<br>
+    <td>Returns the inverse hyperbolic sine (sinh<sup>-1</sup>) of `e`, as a hyperbolic angle in radians.<br>
+    That is, approximates `x` such that `sinh`(`x`) = `e`.
+
     [=Component-wise=] when `T` is a vector.
 </table>
 
@@ -11280,7 +11288,9 @@ Note: The result is not mathematically meaningful when `e` &lt; 1.
     <td>[ALLFLOATINGDECL]
   <tr>
     <td>Description
-    <td>Returns the inverse tangent (tan<sup>-1</sup>) of `e`.
+    <td>Returns the principal value, in radians, of the inverse tangent (tan<sup>-1</sup>) of `e`.<br>
+    That is, approximates `x` with &pi;/2 &le; `x` &le; &pi;/2, such that `tan`(`x`) = `e`.
+
     [=Component-wise=] when `T` is a vector.
 </table>
 
@@ -11296,9 +11306,11 @@ Note: The result is not mathematically meaningful when `e` &lt; 1.
     <td>[ALLFLOATINGDECL]
   <tr>
     <td>Description
-    <td>Returns the inverse hyperbolic tangent (tanh<sup>-1</sup>) of `e`.
+    <td>Returns the inverse hyperbolic tangent (tanh<sup>-1</sup>) of `e`, as a hyperbolic angle in radians.<br>
+    That is, approximates `x` such that `tanh`(`x`) = `e`.
+
     The result is 0 when `abs(e)` &ge; 1.<br>
-    Computes the functional inverse of `tanh`.<br>
+
     [=Component-wise=] when `T` is a vector.
   <tr>
     <td>
@@ -11321,7 +11333,9 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
     <td>[ALLFLOATINGDECL]
   <tr>
     <td>Description
-    <td>Returns the inverse tangent (tan<sup>-1</sup>) of `e1` over `e2`.
+    <td>Returns the prinicipal value, in radians, of the inverse tangent (tan<sup>-1</sup>) of `e1` &divide; `e2`.<br>
+    That is, approximates `x` with &pi;/2 &le; `x` &le; &pi;/2, such that `tan`(`x`) = `e1` &divide; `e2`.
+
     [=Component-wise=] when `T` is a vector.
 </table>
 
@@ -11372,7 +11386,7 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
     <td>[ALLFLOATINGDECL]
   <tr>
     <td>Description
-    <td>Returns the cosine of `e`.
+    <td>Returns the cosine of `e`, where `e` is in radians.
     [=Component-wise=] when `T` is a vector.
 </table>
 
@@ -11381,14 +11395,17 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
   <tr algorithm="cosh">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn cosh(e: T) -> T
+@const fn cosh(arg: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
     <td>[ALLFLOATINGDECL]
   <tr>
     <td>Description
-    <td>Returns the hyperbolic cosine of `e`.
+    <td>Returns the hyperbolic cosine of `arg`, where `arg` is a hyperbolic angle in radians.
+    Approximates the pure mathematical function (*e*<sup>arg</sup> + *e*<sup>&minus;arg</sup>)&divide;2,
+    but not necessarily computed that way.
+
     [=Component-wise=] when `T` is a vector
 </table>
 
@@ -12420,7 +12437,7 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
     <td>[ALLFLOATINGDECL]
   <tr>
     <td>Description
-    <td>Returns the sine of `e`.
+    <td>Returns the sine of `e`, where `e` is in radians.
     [=Component-wise=] when `T` is a vector.
 </table>
 
@@ -12436,7 +12453,11 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
     <td>[ALLFLOATINGDECL]
   <tr>
     <td>Description
-    <td>Returns the hyperbolic sine of `e`.
+    <td>Returns the hyperbolic sine of `e`, where `e` is a hyperbolic angle in radians.
+    Approximates the pure mathematical function
+    (*e*<sup>arg</sup> &minus; *e*<sup>&minus;arg</sup>)&divide;2,
+    but not necessarily computed that way.
+
     [=Component-wise=] when `T` is a vector.
 </table>
 
@@ -12507,7 +12528,7 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
     <td>[ALLFLOATINGDECL]
   <tr>
     <td>Description
-    <td>Returns the tangent of `e`.
+    <td>Returns the tangent of `e`, where `e` is in radians.
     [=Component-wise=] when `T` is a vector.
 </table>
 
@@ -12523,7 +12544,11 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
     <td>[ALLFLOATINGDECL]
   <tr>
     <td>Description
-    <td>Returns the hyperbolic tangent of `e`.
+    <td>Returns the hyperbolic tangent of `e`, where `e` is a hyperbolic angle in radians.
+    Approximates the pure mathematical function
+    (*e*<sup>arg</sup> &minus; *e*<sup>&minus;arg</sup>) &divide (*e*<sup>arg</sup> + *e*<sup>&minus;arg</sup>)
+    but not necessarily computed that way.
+
     [=Component-wise=] when `T` is a vector.
 </table>
 


### PR DESCRIPTION
Trigonometric functions use angles in radians.
Hyperbolic functions use hyperbolic angles in radians.

For inverse functions, describe the specific prinicpal component
selected.

Fixes: #3191