### PR TITLE
Errors for constant out-of-bounds accesses

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5309,8 +5309,10 @@ The result type depends on the number of letters provided. Assuming a `vec4<f32>
            |e|[|i|]: |T|
        <td>Select the |i|'<sup>th</sup> component of vector<br>
            The first component is at index |i|=0.<br>
-           If |i| is outside the range [0,|N|-1], then any valid value for |T|
-           may be returned.
+           If |i| is outside the range [0,|N|-1]:<br>
+           * It is a [=shader-creation error=] if |i| is a [=const-expression=].
+           * It is a [=pipeline-creation error=] if |i| is an [=override-expression=].
+           * Otherwise any valid value for |T| may be returned.
 </table>
 
 #### Vector Multiple Component Selection #### {#vector-multi-component}
@@ -5443,8 +5445,10 @@ See [[#sync-builtin-functions]].
        <td>Compute a reference to the |i|'<sup>th</sup> component of the vector
            referenced by the reference |r|.
 
-           If |i| is outside the range [0,|N|-1], then the expression evaluates
-           to [=invalid memory reference=].
+           If |i| is outside the range [0,|N|-1]:<br>
+           * It is a [=shader-creation error=] if |i| is a [=const-expression=].
+           * It is a [=pipeline-creation error=] if |i| is an [=override-expression=].
+           * Otherwise, the expression evaluates to an [=invalid memory reference=].
 
            The [=originating variable=] of the resulting reference is
            the same as the originating variable of |r|.
@@ -5465,8 +5469,10 @@ See [[#sync-builtin-functions]].
            |e|[|i|]: vec|R|&lt;|T|&gt;
        <td>The result is the |i|'<sup>th</sup> column vector of |e|.
 
-           If |i| is outside the range [0,|C|-1], then any valid value for
-           vec|R|&lt;|T|&gt; may be returned.
+           If |i| is outside the range [0,|C|-1]:<br>
+           * It is a [=shader-creation error=] if |i| is a [=const-expression=].
+           * It is a [=pipeline-creation error=] if |i| is an [=override-expression=].
+           * Otherwise, any valid value for vec|R|&lt;|T|&gt; may be returned.
 </table>
 
 <table class='data'>
@@ -5483,8 +5489,10 @@ See [[#sync-builtin-functions]].
        <td>Compute a reference to the |i|'<sup>th</sup> column vector of the
            matrix referenced by the reference |r|.
 
-           If |i| is outside the range [0,|C|-1], then the expression evaluates to
-           [=invalid memory reference=].
+           If |i| is outside the range [0,|C|-1]:<br>
+           * It is a [=shader-creation error=] if |i| is a [=const-expression=].
+           * It is a [=pipeline-creation error=] if |i| is an [=override-expression=].
+           * Otherwise, the expression evaluates to an [=invalid memory reference=].
 
            The [=originating variable=] of the resulting reference is
            the same as the originating variable of |r|.
@@ -5505,8 +5513,10 @@ See [[#sync-builtin-functions]].
            |e|[|i|] : |T|
        <td>The result is the value of the |i|'<sup>th</sup> element of the array value |e|.
 
-           If |i| is outside the range [0,|N|-1], then any valid value for |T|
-           may be returned.
+           If |i| is outside the range [0,|N|-1]:<br>
+           * It is a [=shader-creation error=] if |i| is a [=const-expression=].
+           * It is a [=pipeline-creation error=] if |i| is an [=override-expression=].
+           * Otherwise, any valid value for |T| may be returned.
 </table>
 
 <table class='data'>
@@ -5523,8 +5533,10 @@ See [[#sync-builtin-functions]].
        <td>Compute a reference to the |i|'<sup>th</sup> element of the array
            referenced by the reference |r|.
 
-           If |i| is outside the range [0,|N|-1], then the expression evaluates
-           to an [=invalid memory reference=].
+           If |i| is outside the range [0,|N|-1]:<br>
+           * It is a [=shader-creation error=] if |i| is a [=const-expression=].
+           * It is a [=pipeline-creation error=] if |i| is an [=override-expression=].
+           * Otherwise, the expression evaluates to an [=invalid memory reference=].
 
            The [=originating variable=] of the resulting reference is
            the same as the originating variable of |r|.
@@ -5539,6 +5551,10 @@ See [[#sync-builtin-functions]].
            If at runtime the array has |N| elements, and |i| is outside the range
            [0,|N|-1], then the expression evaluates to an [=invalid memory
            reference=].
+
+           If |i| is a signed integer, and |i| is less than 0:<br>
+           * It is a [=shader-creation error=] if |i| is a [=const-expression=].
+           * It is a [=pipeline-creation error=] if |i| is an [=override-expression=].
 
            The [=originating variable=] of the resulting reference is
            the same as the originating variable of |r|.


### PR DESCRIPTION
Contributes to #3253

* Modify vector, matrix and array access expressions to make
  out-of-bounds accesses:
  * shader-creation errors if the index expression is a const-expression
  * pipeline-creation errors if the index expression is an
    override-expression
  * For runtime-sized arrays, this is special cased to checking for a
    non-negative index expression if the type is an signed integer