### PR TITLE
Constant errors for integer expressions

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5677,8 +5677,14 @@ See [[#sync-builtin-functions]].
     <td>Division. [=Component-wise=] when |T| is a vector.
 
         If |T| is a signed [=integer scalar=] type, evaluates to:
-        * |e1|, when |e2| is zero.
-        * |e1|, when |e1| is the most negative value in |T|, and |e2| is -1.
+        * If |e2| is zero:
+            * It is a [=shader-creation error=] if |e2| is a [=const-expression=].
+            * It is a [=pipeline-creation error=] if |e2| is an [=override-expression=].
+            * Otherwise, |e1|.
+        * If |e1| is most negative value in |T|, and |e2| is -1:
+            * It is a [=shader-creation error=] if |e1| and |e2| are [=const-expressions=].
+            * It is a [=pipeline-creation error=] if |e1| and |e2| are [=override-expressions=].
+            * Otherwise, |e1|.
         * [=truncate=](|x|) otherwise, where |x| is the
             real-valued quotient |e1|&nbsp;&div;&nbsp;|e2|.
 
@@ -5694,7 +5700,10 @@ See [[#sync-builtin-functions]].
         -->
 
         If |T| is an unsigned [=integer scalar=] type, evaluates to:
-        * |e1|, when |e2| is zero.
+        * If |e2| is zero:
+            * It is a [=shader-creation error=] if |e2| is a [=const-expression=].
+            * It is a [=pipeline-creation error=] if |e2| is an [=override-expression=].
+            * Otherwise, |e1|.
         * Otherwise, the integer |q| such that
             |e1|&nbsp;=&nbsp;|q|&nbsp;&times;&nbsp;|e2|&nbsp;+&nbsp;|r|,
             where 0 &le; |r| &lt; |e2|.
@@ -5705,8 +5714,14 @@ See [[#sync-builtin-functions]].
     <td>Remainder. [=Component-wise=] when |T| is a vector.
 
        If |T| is a signed [=integer scalar=] type, evaluates |e1| and |e2| once, and evaluates to:
-       * 0, when |e2| is zero.
-       * 0, when |e1| is the most negative value in |T|, and |e2| is -1.
+       * if |e2| is zero:
+          * It is a [=shader-creation error=] if |e2| is a [=const-expression=].
+          * It is a [=pipeline-creation error=] if |e2| is an [=override-expression=].
+          * Otherwise, 0.
+       * If |e1| is the most negative value in |T|, and |e2| is -1:
+          * It is a [=shader-creation error=] if |e1| and |e2| are [=const-expressions=].
+          * It is a [=pipeline-creation error=] if |e1| and |e2| are [=override-expressions].
+          * Otherwise, 0.
        * Otherwise, |e1|&nbsp;-&nbsp;[=truncate=](|e1|&nbsp;&div;&nbsp;|e2|)&nbsp;&times;&nbsp;|e2|
            where the quotient is computed as a real value.
 
@@ -5717,19 +5732,22 @@ See [[#sync-builtin-functions]].
        The need to ensure consistent behavior may require an implementation
        to perform more operations than when computing an unsigned remainder.
 
-        <!--
-               where MINIT = most negative value in |T|
-               where Divisor = select(e2, 1, (e2==0) | ((e1 == MININT) & (e2 == -1)))
-               result is e1 - truncate(e1/Divisor) * Divisor
-        -->
+       <!--
+              where MINIT = most negative value in |T|
+              where Divisor = select(e2, 1, (e2==0) | ((e1 == MININT) & (e2 == -1)))
+              result is e1 - truncate(e1/Divisor) * Divisor
+       -->
 
-        If |T| is an unsigned [=integer scalar=] type, evaluates to:
-        * 0, when |e2| is zero.
-        * Otherwise, the integer |r| such that
-            |e1|&nbsp;=&nbsp;|q|&nbsp;&times;&nbsp;|e2|&nbsp;+&nbsp;|r|,
-            where |q| is an integer and 0 &le; |r| &lt; |e2|.
+       If |T| is an unsigned [=integer scalar=] type, evaluates to:
+       * if |e2| is zero:
+          * It is a [=shader-creation error=] if |e2| is a [=const-expression=].
+          * It is a [=pipeline-creation error=] if |e2| is an [=override-expression=].
+          * Otherwise, 0.
+       * Otherwise, the integer |r| such that
+           |e1|&nbsp;=&nbsp;|q|&nbsp;&times;&nbsp;|e2|&nbsp;+&nbsp;|r|,
+           where |q| is an integer and 0 &le; |r| &lt; |e2|.
 
-        If |T| is a floating point type, the result is equal to:<br> |e1| - |e2| * trunc(|e1| / |e2|)
+       If |T| is a floating point type, the result is equal to:<br> |e1| - |e2| * trunc(|e1| / |e2|)
 
 </table>
 
@@ -5932,6 +5950,9 @@ See [[#sync-builtin-functions]].
         and discarding the most significant bits.
 
         The number of bits to shift is the value of |e2|, modulo the bit width of |e1|.<br>
+        If |e2| is greater or equal to the bit width or |e1|, then:
+        * It is a [=shader-creation error=] if |e2| is a [=const-expression=].
+        * It is a [=pipeline-creation error=] if |e2| is an [=override-expression=].
 
         [=Component-wise=] when |T| is a vector.
 
@@ -5967,6 +5988,13 @@ See [[#sync-builtin-functions]].
         and discarding the least significant bits.
 
         The number of bits to shift is the value of |e2|, modulo the bit width of |e1|.<br>
+        If |e2| is greater or equal to the bit width or |e1|, then:
+        * It is a [=shader-creation error=] if |e2| is a [=const-expression=].
+        * It is a [=pipeline-creation error=] if |e2| is an [=override-expression=].
+
+        If |e2|+1 most significant bits of |e1| do not have the same bit value, then:
+        * It is a [=shader-creation error=] if |e1| and |e2| are [=const-expressions=].
+        * It is a [=pipeline-creation error=] if |e1| and |e2| are [=override-expressions=].
 
         [=Component-wise=] when |T| is a vector.
 
@@ -11388,6 +11416,10 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
     <td>Returns either `min(max(e, low), high)`, or the median of
     the three values `e`, `low`, `high`.
     [=Component-wise=] when `T` is a vector.
+
+    If `low` is greater than `high`, then:
+    * It is a [=shader-creation error=] if `low` and `high` are [=const-expressions=].
+    * It is a [=pipeline-creation error=] if `low` and `high` are [=override-expressions=].
 </table>
 
 ### `cos` ### {#cos-builtin}
@@ -11616,6 +11648,10 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
        Other bits of the result are the same as bit `c - 1` of the result.
     </ul>
     [=Component-wise=] when `T` is a vector.
+
+    If `count` + `offset` is greater than `w`, then:
+    * It is a [=shader-creation error=] if `count` and `offset` are [=const-expressions=].
+    * It is a [=pipeline-creation error=] if `count` and `offset` are [=override-expressions=].
 </table>
 
 ### `extractBits` (unsigned) ### {#extractBits-unsigned-builtin}
@@ -11645,6 +11681,10 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
        Other bits of the result are 0.
     </ul>
     [=Component-wise=] when `T` is a vector.
+
+    If `count` + `offset` is greater than `w`, then:
+    * It is a [=shader-creation error=] if `count` and `offset` are [=const-expressions=].
+    * It is a [=pipeline-creation error=] if `count` and `offset` are [=override-expressions=].
 </table>
 
 ### `faceForward` ### {#faceForward-builtin}


### PR DESCRIPTION
Contributes to #3253

* Add errors for const- and override-expressions for the following:
  * integer division by 0
  * signed integer division of INT_MIN by -1
  * shifts greater than bitwidth
  * signed right shift that overflows
  * extracting bits out of bounds
  * clamp where low > high (also affects floating-point)

Requires committee review