### PR TITLE
Add texture sample function which clamps coordinates

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4844,9 +4844,9 @@ dictionary GPUExternalTextureDescriptor : GPUObjectDescriptorBase {
 ### Sampling External Textures ### {#external-texture-sampling}
 
 External textures are represented in WGSL with `texture_external` and may be read using
-`textureLoad` and `textureSampleLevel`.
+`textureLoad` and `textureSampleBaseClampToEdge`.
 
-The `sampler` provided to `textureSampleLevel` is used to sample the underlying textures.
+The `sampler` provided to `textureSampleBaseClampToEdge` is used to sample the underlying textures.
 The result is in the color space set by {{GPUExternalTextureDescriptor/colorSpace}}.
 It is implementation-dependent whether, for any given external texture, the sampler (and filtering)
 is applied before or after conversion from underlying values into the specified color space.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -13898,7 +13898,7 @@ The sampled value.
 
 ### `textureSampleLevel` ### {#texturesamplelevel}
 
-Samples a texture using an explicit mip level, or at mip level 0.
+Samples a texture using an explicit mip level.
 
 <table class='data'>
   <thead>
@@ -14019,13 +14019,6 @@ fn textureSampleLevel(t: texture_depth_cube_array,
                       array_index: C,
                       level: C) -> f32
 </xmp>
-  <tr algorithm="textureSampleLevel external">
-    <td>
-    <td><xmp highlight=rust>
-fn textureSampleLevel(t: texture_external,
-                      s: sampler,
-                      coords: vec2<f32>) -> vec4<f32></xmp>
-
 </table>
 
 **Parameters:**
@@ -14059,6 +14052,38 @@ fn textureSampleLevel(t: texture_external,
 
 The sampled value.
 
+### `textureSampleBaseClampToEdge` ### {#textureSampleBaseClampToEdge}
+
+Samples a texture view at its base level,
+with texture coordinates clamped to the [0, 1] range.
+
+<table class='data'>
+  <thead>
+    <tr><td style="width:25%">Parameterization<th>Overload
+  </thead>
+
+  <tr algorithm="textureSampleBaseClampToEdge">
+    <td><var ignore>T</var> is `texture_2d<f32>` or `texture_external`
+    <td><xmp highlight=rust>
+fn textureSampleBaseClampToEdge(t: T,
+                                s: sampler,
+                                coords: vec2<f32>) -> vec4<f32></xmp>
+</table>
+
+**Parameters:**
+
+<table class='data'>
+  <tr><td>`t`<td>
+  The [sampled](#sampled-texture-type) or [external](#external-texture-type) texture to sample.
+  <tr><td>`s`<td>
+  The [sampler type](#sampler-type).
+  <tr><td>`coords`<td>
+  The texture coordinates used for sampling.
+</table>
+
+**Returns:**
+
+The sampled value.
 
 ### `textureStore` ### {#texturestore}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -14037,8 +14037,7 @@ fn textureSampleLevel(t: texture_depth_cube_array,
   The mip level, with level 0 containing a full size version of the texture.
   For the functions where `level` is a `f32`, fractional values may interpolate
   between two levels if the format is filterable according to the
-  [Texture Format Capabilities](https://gpuweb.github.io/gpuweb/#texture-format-caps).<br>
-  When not specified, mip level 0 is sampled.
+  [Texture Format Capabilities](https://gpuweb.github.io/gpuweb/#texture-format-caps).
   <tr><td>`offset`<td>
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any


### PR DESCRIPTION
Adds this function for both texture_2d and texture_external for
symmetry as agreed in discussion.

Name up for bikeshedding, but this is my proposal.

Fixes #2766