### PR TITLE
wgsl: clarify length builtin on scalar

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9571,7 +9571,7 @@ value with the same sign.
   <tr><td>`frexp(x)`<td colspan=2 style="text-align:left;">Correctly rounded
   <tr><td>`inverseSqrt(x)`<td colspan=2 style="text-align:left;">2 ULP
   <tr><td>`ldexp(x, y)`<td colspan=2 style="text-align:left;">Correctly rounded
-  <tr><td>`length(x)`<td colspan=2 style="text-align:left;">Inherited from `sqrt(dot(x, x))`
+  <tr><td>`length(x)`<td colspan=2 style="text-align:left;">Inherited from `sqrt(dot(x, x))` in the vector case, and `sqrt(x*x)` in the scalar case.
   <tr><td>`log(x)`
       <td>Absolute error at most 2<sup>-21</sup> when `x` is in the interval [0.5, 2.0].<br>
           3 ULP when `x` is outside the interval [0.5, 2.0].<br>
@@ -11690,8 +11690,11 @@ but a value may infer the type.
   <tr>
     <td>Description
     <td>Returns the length of `e`.<br>
-        Evaluates to `abs(e)` if `T` is scalar or AbstractFloat.<br>
+        Evaluates to the absolute value of `e` if `T` is [=scalar=].<br>
         Evaluates to `sqrt(e[0]`<sup>`2`</sup> `+ e[1]`<sup>`2`</sup> `+ ...)` if `T` is a vector type.
+
+        Note: The scalar case may be evaluated as `sqrt(e * e)`,
+        which may unnecessarily overflow or lose accuracy.
 </table>
 
 ### `log` ### {#log-builtin}


### PR DESCRIPTION
- At definition, add a note about possible implementation of the scalar
  case
- In the accuray table, explain the scalar accuracy case as sqrt(x*x)
  since the dot builtin only operates on vectors.

Fixes: #3407