### PR TITLE
Upgrade dependency for grammar and ignore pre

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ wgsl/index.html
 wgsl/index.pre.html
 wgsl/wgsl.lalr.txt
 wgsl/wgsl.lalr.profile
+wgsl/wgsl.recursive.bs.include.pre
 explainer/index.html
 correspondence/index.html
 tools/node_modules/

--- a/tools/install-dependencies.sh
+++ b/tools/install-dependencies.sh
@@ -10,7 +10,7 @@ for opt in "$@"; do
             code=0
             ;;
         wgsl)
-            pip3 install tree_sitter==0.19.0
+            pip3 install tree_sitter==0.20.0
             code=0
             ;;
         diagrams)

--- a/wgsl/extract-grammar.py
+++ b/wgsl/extract-grammar.py
@@ -529,7 +529,7 @@ with open(grammar_path + "/package.json", "w") as grammar_package:
     grammar_package.write('        "nan": "^2.15.0"\n')
     grammar_package.write('    },\n')
     grammar_package.write('    "devDependencies": {\n')
-    grammar_package.write('        "tree-sitter-cli": "^0.20.0"\n')
+    grammar_package.write('        "tree-sitter-cli": "^0.19.0"\n')
     grammar_package.write('    },\n')
     grammar_package.write('    "main": "bindings/node"\n')
     grammar_package.write('}\n')


### PR DESCRIPTION
This PR upgrades tree-sitter's pip installation version to 0.20.0, which fixes the language version 14 issue and ignores pre file for the recursive include (@dneto0 is that OK?).