### PR TITLE
Adjust literals section

### DIFF
--- a/wgsl/extract-grammar.py
+++ b/wgsl/extract-grammar.py
@@ -529,7 +529,7 @@ with open(grammar_path + "/package.json", "w") as grammar_package:
     grammar_package.write('        "nan": "^2.15.0"\n')
     grammar_package.write('    },\n')
     grammar_package.write('    "devDependencies": {\n')
-    grammar_package.write('        "tree-sitter-cli": "^0.20.0"\n')
+    grammar_package.write('        "tree-sitter-cli": "^0.19.0"\n')
     grammar_package.write('    },\n')
     grammar_package.write('    "main": "bindings/node"\n')
     grammar_package.write('}\n')

--- a/wgsl/extract-grammar.py
+++ b/wgsl/extract-grammar.py
@@ -529,7 +529,7 @@ with open(grammar_path + "/package.json", "w") as grammar_package:
     grammar_package.write('        "nan": "^2.15.0"\n')
     grammar_package.write('    },\n')
     grammar_package.write('    "devDependencies": {\n')
-    grammar_package.write('        "tree-sitter-cli": "^0.19.0"\n')
+    grammar_package.write('        "tree-sitter-cli": "^0.20.0"\n')
     grammar_package.write('    },\n')
     grammar_package.write('    "main": "bindings/node"\n')
     grammar_package.write('}\n')

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -656,13 +656,13 @@ or a [=hexadecimal floating point literal=].
 <div class='syntax' noexport='true'>
   <dfn for=syntax>decimal_float_literal</dfn> :
 
+    | `/0[fh]/`
+
     | `/[0-9]*\.[0-9]+([eE][+-]?[0-9]+)?[fh]?/`
 
     | `/[0-9]+\.[0-9]*([eE][+-]?[0-9]+)?[fh]?/`
 
     | `/[0-9]+[eE][+-]?[0-9]+[fh]?/`
-
-    | `/0[fh]/`
 
     | `/[1-9][0-9]*[fh]/`
 </div>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -658,13 +658,13 @@ or a [=hexadecimal floating point literal=].
 
     | `/0[fh]/`
 
+    | `/[1-9][0-9]*[fh]/`
+
     | `/[0-9]*\.[0-9]+([eE][+-]?[0-9]+)?[fh]?/`
 
     | `/[0-9]+\.[0-9]*([eE][+-]?[0-9]+)?[fh]?/`
 
     | `/[0-9]+[eE][+-]?[0-9]+[fh]?/`
-
-    | `/[1-9][0-9]*[fh]/`
 </div>
 
 <div class='example wgsl decimal-float-literals' heading='decimal floating point literals'>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -543,7 +543,7 @@ A <dfn>literal</dfn> is one of:
     and is used to represent a number.
 
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>const_literal</dfn> :
+  <dfn for=syntax>literal</dfn> :
 
     | [=syntax/int_literal=]
 
@@ -6155,7 +6155,7 @@ When an identifier is used as a [=syntax/callable=] item, it is one of:
 
     | [=syntax/callable=] [=syntax/argument_expression_list=]
 
-    | [=syntax/const_literal=]
+    | [=syntax/literal=]
 
     | [=syntax/paren_expression=]
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -542,6 +542,18 @@ A <dfn>literal</dfn> is one of:
 * A <dfn>numeric literal</dfn>: either an [=integer literal=] or a [=floating point literal=],
     and is used to represent a number.
 
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>const_literal</dfn> :
+
+    | [=syntax/int_literal=]
+
+    | [=syntax/float_literal=]
+
+    | [=syntax/bool_literal=]
+</div>
+
+### Boolean Literals ### {#boolean-literals}
+
 <div class='example wgsl bool-literals' heading='boolean literals'>
   <xmp highlight='rust'>
     const a = true;
@@ -557,6 +569,8 @@ A <dfn>literal</dfn> is one of:
     | [=syntax/false=]
 </div>
 
+### Numeric Literals ### {#numeric-literals}
+
 The form of a [=numeric literal=] is defined via pattern-matching.
 
 An <dfn>integer literal</dfn> is:
@@ -566,26 +580,43 @@ An <dfn>integer literal</dfn> is:
     * `0x` or `0X` followed by a sequence of hexadecimal digits.
 * Then an optional `i` or `u` suffix.
 
-<div class='example wgsl int-literals' heading='integer literals'>
-  <xmp highlight='rust'>
-    const a = 0x123;
-    const b = 0X123u;
-    const c = 1u;
-    const d = 123;
-    const e = 0;
-    const f = 0i;
-    const g = 0x3f;
-  </xmp>
-</div>
-
 <div class='syntax' noexport='true'>
   <dfn for=syntax>int_literal</dfn> :
 
-    | `/0[xX][0-9a-fA-F]+[iu]?/`
+    | [=syntax/decimal_int_literal=]
+
+    | [=syntax/hex_int_literal=]
+</div>
+
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>decimal_int_literal</dfn> :
 
     | `/0[iu]?/`
 
     | `/[1-9][0-9]*[iu]?/`
+</div>
+
+<div class='example wgsl decimal-int-literals' heading='decimal integer literals'>
+  <xmp highlight='rust'>
+    const a = 1u;
+    const b = 123;
+    const c = 0;
+    const d = 0i;
+  </xmp>
+</div>
+
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>hex_int_literal</dfn> :
+
+    | `/0[xX][0-9a-fA-F]+[iu]?/`
+</div>
+
+<div class='example wgsl hexadecimal-int-literals' heading='hexadecimal integer literals'>
+  <xmp highlight='rust'>
+    const a = 0x123;
+    const b = 0X123u;
+    const c = 0x3f;
+  </xmp>
 </div>
 
 A <dfn>floating point literal</dfn> is either a [=decimal floating point literal=]
@@ -614,24 +645,6 @@ or a [=hexadecimal floating point literal=].
     * The value of the literal is the value of the mantissa multiplied by 2 to the power of the exponent.
          When no exponent is specified, an exponent of 0 is assumed.
 
-<div class='example wgsl float-literals' heading='floating point literals'>
-  <xmp highlight='rust'>
-    const a = 0.e+4f;
-    const b = 01.;
-    const c = .01;
-    const d = 12.34;
-    const f = .0f;
-    const g = 0h;
-    const h = 1e-3;
-    const i = 0xa.fp+2;
-    const j = 0x1P+4f;
-    const k = 0X.3;
-    const l = 0x3p+2h;
-    const m = 0X1.fp-4;
-    const n = 0x3.2p+2h;
-  </xmp>
-</div>
-
 <div class='syntax' noexport='true'>
   <dfn for=syntax>float_literal</dfn> :
 
@@ -654,6 +667,18 @@ or a [=hexadecimal floating point literal=].
     | `/[1-9][0-9]*[fh]/`
 </div>
 
+<div class='example wgsl decimal-float-literals' heading='decimal floating point literals'>
+  <xmp highlight='rust'>
+    const a = 0.e+4f;
+    const b = 01.;
+    const c = .01;
+    const d = 12.34;
+    const f = .0f;
+    const g = 0h;
+    const h = 1e-3;
+  </xmp>
+</div>
+
 <div class='syntax' noexport='true'>
   <dfn for=syntax>hex_float_literal</dfn> :
 
@@ -664,23 +689,24 @@ or a [=hexadecimal floating point literal=].
     | `/0[xX][0-9a-fA-F]+[pP][+-]?[0-9]+[fh]?/`
 </div>
 
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>const_literal</dfn> :
-
-    | [=syntax/int_literal=]
-
-    | [=syntax/float_literal=]
-
-    | [=syntax/bool_literal=]
+<div class='example wgsl hexadecimal-float-literals' heading='hexadecimal floating point literals'>
+  <xmp highlight='rust'>
+    const a = 0xa.fp+2;
+    const b = 0x1P+4f;
+    const c = 0X.3;
+    const d = 0x3p+2h;
+    const e = 0X1.fp-4;
+    const f = 0x3.2p+2h;
+  </xmp>
 </div>
 
 When a [=numeric literal=] has a suffix, the literal denotes a value in a specific [=type/concrete=] [=scalar=] type.
 Otherwise, the literal denotes a value one of the [=abstract numeric types=] defined below.
 
 <table class=data>
-  <caption>Mapping literals to types</caption>
+  <caption>Mapping numeric literals to types</caption>
   <thead>
-    <tr><th>Literal<th>Suffix<th>Type<th>Examples
+    <tr><th>Numeric Literal<th>Suffix<th>Type<th>Examples
   </thead>
 
   <tr><td>[=integer literal=]<td>`i`<td>[=i32=]<td>42i

--- a/wgsl/wgsl.recursive.bs.include
+++ b/wgsl/wgsl.recursive.bs.include
@@ -199,6 +199,14 @@
 </div>
 
 <div class='syntax' noexport='true'>
+  <dfn for='recursive descent syntax'>decimal_int_literal</dfn>:
+
+ | `/0[iu]?/`
+
+ | `/[1-9][0-9]*[iu]?/`
+</div>
+
+<div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>depth_texture_type</dfn>:
 
  | `'texture_depth_2d'`
@@ -302,11 +310,9 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>int_literal</dfn>:
 
- | `/0[iu]?/`
+ | [=recursive descent syntax/decimal_int_literal=]
 
- | `/0[xX][0-9a-fA-F]+[iu]?/`
-
- | `/[1-9][0-9]*[iu]?/`
+ | [=syntax/hex_int_literal=]
 </div>
 
 <div class='syntax' noexport='true'>

--- a/wgsl/wgsl.recursive.bs.include
+++ b/wgsl/wgsl.recursive.bs.include
@@ -167,16 +167,6 @@
 </div>
 
 <div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>const_literal</dfn>:
-
- | [=recursive descent syntax/bool_literal=]
-
- | [=recursive descent syntax/float_literal=]
-
- | [=recursive descent syntax/int_literal=]
-</div>
-
-<div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>core_lhs_expression</dfn>:
 
  | [=recursive descent syntax/ident=]
@@ -342,6 +332,16 @@
 </div>
 
 <div class='syntax' noexport='true'>
+  <dfn for='recursive descent syntax'>literal</dfn>:
+
+ | [=recursive descent syntax/bool_literal=]
+
+ | [=recursive descent syntax/float_literal=]
+
+ | [=recursive descent syntax/int_literal=]
+</div>
+
+<div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>mat_prefix</dfn>:
 
  | `'mat2x2'`
@@ -405,9 +405,9 @@
 
  | [=recursive descent syntax/callable=] [=syntax/paren_left=] ( [=recursive descent syntax/expression=] ( [=syntax/comma=] [=recursive descent syntax/expression=] )* [=syntax/comma=] ? )? [=syntax/paren_right=]
 
- | [=recursive descent syntax/const_literal=]
-
  | [=recursive descent syntax/ident=]
+
+ | [=recursive descent syntax/literal=]
 
  | [=syntax/paren_left=] [=recursive descent syntax/expression=] [=syntax/paren_right=]
 


### PR DESCRIPTION
This PR rearranges the literals section to have more subsections for ease of reading and section-internal-consistent definition of grammar. 
* In alignment with the rest of the spec, grammar bits now precede example bits.
* Examples now have presentations according to type (hexadecimal or decimal).
* const_literal definition is now at the top to provide better numeric literals subsection reading where it comes between two paragraphs/tables about numeric literals.