### PR TITLE
wgsl: ban ptr-to-workgroup params to user-defined functions

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7903,9 +7903,6 @@ Note: The [=attribute/const=] attribute cannot be applied to user-declared funct
     the following address spaces:
     * [=address spaces/function=]
     * [=address spaces/private=]
-    * [=address spaces/workgroup=]
-         * In this case, the pointer's [=store type=] [=shader-creation error|must not=] not be an [=atomic type=],
-            nor contain an atomic type at any [=nesting depth=].
 * For [=built-in functions=], a parameter of pointer type [=shader-creation error|must=] be in one of
     the following address spaces:
     * [=address spaces/function=]


### PR DESCRIPTION
Fixes: #3276