### PR TITLE
Constant floating point errors for NaN and inf

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -11712,7 +11712,8 @@ but a value may infer the type.
   <tr>
     <td>
     <td>
-Note: The result is not mathematically meaningful if `e` &le 0.
+
+Note: The result is not mathematically meaningful if `e` &le; 0.
 </table>
 
 ### `ldexp` ### {#ldexp-builtin}
@@ -11756,6 +11757,7 @@ Note: The result is not mathematically meaningful if `e` &le 0.
   <tr>
     <td>
     <td>
+
 Note: The result is not mathematically meaningful if `e` &le; -0.
 </table>
 
@@ -11776,7 +11778,8 @@ Note: The result is not mathematically meaningful if `e` &le; -0.
   <tr>
     <td>
     <td>
-Note: The result is not mathematically meaningful if `e` &lt 0.
+
+Note: The result is not mathematically meaningful if `e` &lt; 0.
 </table>
 
 ### `log2` ### {#log2-builtin}
@@ -11796,7 +11799,8 @@ Note: The result is not mathematically meaningful if `e` &lt 0.
   <tr>
     <td>
     <td>
-Note: The result is not mathematically meaningful if `e` &lt 0.
+
+Note: The result is not mathematically meaningful if `e` &lt; 0.
 </table>
 
 ### `max` ### {#max-float-builtin}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9493,9 +9493,9 @@ the following exceptions:
     * In such an implementation, when an evaluation would produce an infinity or a NaN,
         an undefined value of the target type is produced instead.
     * It is a [=shader-creation error=] if any [=const-expression=] of
-        floating-point type evaluates to to NaN or infinity.
+        floating-point type evaluates to NaN or infinity.
     * It is a [=pipeline-creation error=] if any [=override-expression=] of
-        floating-point type evaluates to to NaN or infinity.
+        floating-point type evaluates to NaN or infinity.
     * Note: This means some functions (e.g. `min` and `max`)
         may not return the expected result due to optimizations about the presence
         of NaNs and infinities.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -10946,6 +10946,11 @@ fn arrayLength(p: ptr<storage, array<E>, AM>) -> u32
     That is, approximates `x` with 0 &le; `x` &le; &pi;, such that `cos`(`x`) = `e`.
 
     [=Component-wise=] when `T` is a vector.
+  <tr>
+    <td>
+    <td>
+
+Note: The result is not mathematically meaningful when `abs(e)` &gt; 1.
 </table>
 
 ### `acosh` ### {#acosh-builtin}
@@ -10991,6 +10996,11 @@ Note: The result is not mathematically meaningful when `e` &lt; 1.
     That is, approximates `x` with -&pi;/2 &le; `x` &le; &pi;/2, such that `sin`(`x`) = `e`.
 
     [=Component-wise=] when `T` is a vector.
+  <tr>
+    <td>
+    <td>
+
+Note: The result is not mathematically meaningful when `abs(e)` &gt; 1.
 </table>
 
 ### `asinh` ### {#asinh-builtin}
@@ -11699,6 +11709,10 @@ but a value may infer the type.
     <td>Description
     <td>Returns the reciprocal of `sqrt(e)`.
     [=Component-wise=] when `T` is a vector.
+  <tr>
+    <td>
+    <td>
+Note: The result is not mathematically meaningful if `e` &le 0.
 </table>
 
 ### `ldexp` ### {#ldexp-builtin}
@@ -11739,6 +11753,10 @@ but a value may infer the type.
 
         Note: The scalar case may be evaluated as `sqrt(e * e)`,
         which may unnecessarily overflow or lose accuracy.
+  <tr>
+    <td>
+    <td>
+Note: The result is not mathematically meaningful if `e` &le; -0.
 </table>
 
 ### `log` ### {#log-builtin}
@@ -11755,6 +11773,10 @@ but a value may infer the type.
     <td>Description
     <td>Returns the natural logarithm of `e`.
     [=Component-wise=] when `T` is a vector.
+  <tr>
+    <td>
+    <td>
+Note: The result is not mathematically meaningful if `e` &lt 0.
 </table>
 
 ### `log2` ### {#log2-builtin}
@@ -11771,6 +11793,10 @@ but a value may infer the type.
     <td>Description
     <td>Returns the base-2 logarithm of `e`.
     [=Component-wise=] when `T` is a vector.
+  <tr>
+    <td>
+    <td>
+Note: The result is not mathematically meaningful if `e` &lt 0.
 </table>
 
 ### `max` ### {#max-float-builtin}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9489,9 +9489,13 @@ the following exceptions:
 * No floating point exceptions are generated.
 * Signaling NaNs may not be generated.
     Any signaling NaN may be converted to a quiet NaN.
-* Implementations may assume that NaNs and infinities are not present.
+* Implementations may assume that NaNs and infinities are not present at runtime.
     * In such an implementation, when an evaluation would produce an infinity or a NaN,
         an undefined value of the target type is produced instead.
+    * It is a [=shader-creation error=] if any [=const-expression=] of
+        floating-point type evaluates to to NaN or infinity.
+    * It is a [=pipeline-creation error=] if any [=override-expression=] of
+        floating-point type evaluates to to NaN or infinity.
     * Note: This means some functions (e.g. `min` and `max`)
         may not return the expected result due to optimizations about the presence
         of NaNs and infinities.


### PR DESCRIPTION
Shader-creation error if floating-point const-expression is inf or nan.
Pipeline-creation error if floating-point override-expression is inf or nan.

Expand notes to include domain errors (except those based on infinity).

Contributes to #3253.