### PR TITLE
[editorial] Fix access mode defaults

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2266,7 +2266,7 @@ Note: Both IO-shareable and host-shareable types have specified sizes, but count
 IO-shareable types are sized by a location-count metric, see [[#input-output-locations]].
 Host-shareable types are sized by a byte-count metric, see [[#memory-layouts]].
 
-### Address spaces ### {#address-space}
+### Address Spaces ### {#address-space}
 
 Memory locations are partitioned into <dfn noexport>address spaces</dfn>.
 Each address space has unique properties determining
@@ -2274,7 +2274,7 @@ mutability, visibility, the values it may contain,
 and how to use variables with it.
 See [[#var-and-value]] for more details.
 
-<table class='data' id="address-space-table">
+<table class='data'>
   <caption>Address Spaces</caption>
   <thead>
     <tr><th>Address space
@@ -2920,7 +2920,29 @@ where |p| and |r| describe the same memory view.
 The access mode for a memory view is often determined by context:
 
 * The [=address spaces/storage=] address space supports both [=access/read=] and [=access/read_write=] access modes.
-* Each other address space supports only one access mode, as described in the <a href="#address-space-table">address space</a> table.
+* Each other address space supports only one access mode, as follows:
+
+<table class='data'>
+<caption>
+  Access Mode Defaults.
+</caption>
+<thead>
+  <tr><th>Address Space
+      <td>Default Access Mode
+</thead>
+<tr><td>[=address spaces/function=]
+    <td>[=access/read_write=]
+<tr><td>[=address spaces/private=]
+    <td>[=access/read_write=]
+<tr><td>[=address spaces/workgroup=]
+    <td>[=access/read_write=]
+<tr><td>[=address spaces/uniform=]
+    <td>[=access/read=]
+<tr><td>[=address spaces/storage=]
+    <td>[=access/read=]
+<tr><td>[=address spaces/handle=]
+    <td>[=access/read=]
+</table>
 
 When writing a [=variable declaration=] or a [=pointer type=] in WGSL source:
 * For the [=address spaces/storage=] address space, the access mode is optional, and defaults to [=access/read=].

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2919,8 +2919,12 @@ where |p| and |r| describe the same memory view.
 
 The access mode for a memory view is often determined by context:
 
-* The [=address spaces/storage=] address space supports both [=access/read=] and [=access/read_write=] access modes.
-* Each other address space supports only one access mode, as follows:
+
+The [=address spaces/storage=] address spaces supports both [=access/read=] and
+[=access/read_write=] access modes.
+Each other address space supports only one access mode.
+The default access mode for each address space is described in the following
+table.
 
 <table class='data'>
 <caption>


### PR DESCRIPTION
Fixes #3419

* Remove reference to address space table from access mode default
* Add default values for access modes to access mode defaults

The var and value summary only describes mutability. While equivalent in this case, it does not use the actual enum values. Instead now, I've added the defaults directly in the defaults section.