### PR TITLE
Change atan2's accuracy to being inherited from atan(y/x)

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9844,7 +9844,7 @@ value with the same sign.
   <tr><td>`asin(x)`<td colspan=2 style="text-align:left;">Inherited from `atan2(x, sqrt(1.0 - x * x))`
   <tr><td>`asinh(x)`<td colspan=2 style="text-align:left;">Inherited from `log(x + sqrt(x * x + 1.0))`
   <tr><td>`atan(x)`<td>4096 ULP<td>5 ULP
-  <tr><td>`atan2(y, x)`<td colspan=2 style="text-align:left;">Inherited from `atan(y / xx)`
+  <tr><td>`atan2(y, x)`<td colspan=2 style="text-align:left;">Inherited from `atan(y / x)`
   <tr><td>`atanh(x)`<td colspan=2 style="text-align:left;">Inherited from `log( (1.0 + x) / (1.0 - x) ) * 0.5`
   <tr><td>`ceil(x)`<td colspan=2 style="text-align:left;">Correctly rounded
   <tr><td>`clamp(x,low,high)`<td colspan=2 style="text-align:left;">Correctly rounded.<br>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9412,7 +9412,7 @@ function-scope variable.
 The `workgroupBarrier` is invalid because the value of `x` is derived from the
 mutable module-scope variable `a`.
 The `storageBarrier` is valid because the value of `x` is derived from the
-immutable module-scope variable `b`. 
+immutable module-scope variable `b`.
 This example highlights the [[#func-var-value-analysis|value analysis']]
 ability to separate different periods of uniformity in a function-scope
 variable's lifetime.
@@ -9470,7 +9470,7 @@ authors can employ to avoid this limitation.
       // local_invocation_index is a non-uniform built-in value.
       @builtin(local_invocation_index) lid : u32
     }
-    
+
     @compute @workgroup_size(16,1,1)
     fn main(inputs : Inputs) {
       // This comparison is always uniform,
@@ -9570,10 +9570,10 @@ MayBeNonUniform.
       let v = in1 / in2;
       return v;
     }
-    
+
     @group(0) @binding(0) var t : texture_2d<f32>;
     @group(0) @binding(1) var s : sampler;
-    
+
     @fragment
     fn main(@builtin(position) pos : vec4<f32>) {
       let tmp = scale(pos.x, 0.5);
@@ -9589,7 +9589,7 @@ MayBeNonUniform.
     <figcaption>Uniformity graph for scale</figcaption>
     <object type="image/svg+xml" data="img/uniformity_5scale.mmd.svg"></object>
   </figure>
-  
+
   <figure>
     <figcaption>Uniformity graph for main</figcaption>
     <object type="image/svg+xml" data="img/uniformity_5main.mmd.svg"></object>
@@ -9844,7 +9844,7 @@ value with the same sign.
   <tr><td>`asin(x)`<td colspan=2 style="text-align:left;">Inherited from `atan2(x, sqrt(1.0 - x * x))`
   <tr><td>`asinh(x)`<td colspan=2 style="text-align:left;">Inherited from `log(x + sqrt(x * x + 1.0))`
   <tr><td>`atan(x)`<td>4096 ULP<td>5 ULP
-  <tr><td>`atan2(y, x)`<td>4096 ULP<td>5 ULP
+  <tr><td>`atan2(y, x)`<td colspan=2 style="text-align:left;">Inherited from `atan(y / xx)`
   <tr><td>`atanh(x)`<td colspan=2 style="text-align:left;">Inherited from `log( (1.0 + x) / (1.0 - x) ) * 0.5`
   <tr><td>`ceil(x)`<td colspan=2 style="text-align:left;">Correctly rounded
   <tr><td>`clamp(x,low,high)`<td colspan=2 style="text-align:left;">Correctly rounded.<br>


### PR DESCRIPTION
Some backends polyfill this as atan(y/x),
https://github.com/gpuweb/gpuweb/issues/3209#issuecomment-1213409945

Fixes #3209