### PR TITLE
[editorial] Change pipeline IO to shader-stage IO

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -208,9 +208,9 @@ that run on the GPU.
 WebGPU issues a unit of work to the GPU in the form of a [[WebGPU#gpu-command|GPU command]].
 WGSL is concerned with two kinds of GPU commands:
 * a <dfn noexport>draw command</dfn> executes a [=GPURenderPipeline|render pipeline=]
-    in the context of [=pipeline input|inputs=], [=pipeline output|outputs=], and attached [=resources=].
+    in the context of [=shader stage input|inputs=], [=shader stage output|outputs=], and attached [=resources=].
 * a <dfn noexport>dispatch command</dfn> executes a [=GPUComputePipeline|compute pipeline=]
-    in the context of [=pipeline input|inputs=] and attached [=resources=].
+    in the context of [=shader stage input|inputs=] and attached [=resources=].
 
 Both kinds of pipelines use shaders written in WGSL.
 
@@ -233,8 +233,8 @@ When executing a shader stage, the implementation:
     making the contents of those resources available to the shader during execution.
 * Allocates memory for other [=module scope|module-scope=] variables,
     and populates that memory with the specified initial values.
-* Populates the formal parameters of the entry point, if they exist, with the stage's pipeline inputs.
-* Connects the entry point [=return value=], if one exists, to the stage's pipeline outputs.
+* Populates the formal parameters of the entry point, if they exist, with the shader stage's inputs.
+* Connects the entry point [=return value=], if one exists, to the shader stage's outputs.
 * Then it invokes the entry point.
 
 A WGSL program is organized into:
@@ -290,7 +290,7 @@ Invocations in a shader stage share access to certain variables:
      variables in the [=address spaces/workgroup=] [=address space=].
      Invocations in different workgroups do not share those variables.
 
-However, the invocations act on different sets of pipeline inputs, including built-in inputs
+However, the invocations act on different sets of shader stage inputs, including built-in inputs
 that provide an identifying value to distinguish an invocation from its peers.
 Each invocation has its own independent memory space in the form
 of variables in the [=address spaces/private=] and [=address spaces/function=] address spaces.
@@ -949,14 +949,14 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
 
 </table>
 
-The <dfn noexport>pipeline stage attributes</dfn> below
+The <dfn noexport>shader stage attributes</dfn> below
 designate a function as an [=entry point=] for a particular [=shader stage=].
 These attributes [=shader-creation error|must=] only be applied to [=function declarations=],
 and at most one may be present on a given function.
 They take no parameters.
 
 <table class='data'>
-  <caption>Pipeline Stage Attributes</caption>
+  <caption>Shader Stage Attributes</caption>
   <thead>
     <tr><th>Attribute<th>Description
   </thead>
@@ -2066,7 +2066,7 @@ Attributes [=attribute/builtin=], [=attribute/location=], [=attribute/interpolat
 are [=IO attributes=].
 An [=IO attribute=] on a member of a structure *S* has effect only when
 *S* is used as the type of a [=formal parameter=] or [=return type=] of an [=entry point=].
-See [[#pipeline-inputs-outputs]].
+See [[#stage-inputs-outputs]].
 
 Attributes [=attribute/align=] and [=attribute/size=] are [=layout attributes=],
 and may be required if the structure type is used to
@@ -3978,7 +3978,7 @@ effective-value-type.
     converted=] to the [=effective-value-type=].
 3. If an initializer is not specified, a value must be provided at [=pipeline
     creation|pipeline-creation time=].
-4. [=Override-declarations=] are part of the pipeline interface, but are not
+4. [=Override-declarations=] are part of the shader interface, but are not
     bound resources.
 5. [=Atomic types=] can only appear in mutable storage buffers or workgroup
     variables.
@@ -7797,7 +7797,7 @@ functions.
 The [=return type=], if specified, [=shader-creation error|must=] be [=constructible=].
 
 WGSL defines the following attributes that can be applied to function declarations:
- * the [=pipeline stage attributes=]: [=attribute/vertex=], [=attribute/fragment=], and [=attribute/compute=]
+ * the [=shader stage attributes=]: [=attribute/vertex=], [=attribute/fragment=], and [=attribute/compute=]
  * [=attribute/workgroup_size=]
 
 WGSL defines the following attributes that can be applied to function
@@ -8053,8 +8053,9 @@ the work for a particular [=shader stage=].
 ## Shader Stages ## {#shader-stages-sec}
 
 WebGPU issues work to the GPU in the form of [=draw command|draw=] or [=dispatch commands=].
-These commands execute a pipeline in the context of a set of
-[=pipeline input|inputs=], [=pipeline output|outputs=], and attached [=resources=].
+These commands execute a pipeline in the context of a set of shader stage
+[=shader stage input|inputs=], [=shader stage output|outputs=], and attached
+[=resources=].
 
 A <dfn noexport>pipeline</dfn> describes the work to be performed on the GPU, as a sequence
 of stages, some of which are programmable.
@@ -8091,14 +8092,14 @@ Each shader stage has its own set of features and constraints, described elsewhe
 
 ## Entry Point Declaration ## {#entry-point-decl}
 
-To create an [=entry point=], declare a [=user-defined function=] with a [=pipeline stage attribute=].
+To create an [=entry point=], declare a [=user-defined function=] with a [=shader stage attribute=].
 
 When configuring a [=pipeline=] in the WebGPU API,
 the entry point's function name maps to the `entryPoint` attribute of the
 [[WebGPU#GPUProgrammableStage]] object.
 
-The entry point's [=formal parameters=] denote the stage's [=pipeline inputs=].
-The entry point's [=return value=], if specified, denotes the stage's [=pipeline outputs=].
+The entry point's [=formal parameters=] denote the stage's [=shader stage inputs=].
+The entry point's [=return value=], if specified, denotes the stage's [=shader stage outputs=].
 
 The type of each formal parameter, and the entry point's return type, [=shader-creation error|must=] be one of:
 * [=bool=]
@@ -8143,7 +8144,7 @@ It will stabilize in a finite number of steps.
 ### Function Attributes for Entry Points ### {#entry-point-attributes}
 
 WGSL defines the following attributes that can be applied to entry point declarations:
- * the [=pipeline stage attributes=]: [=attribute/vertex=], [=attribute/fragment=], and [=attribute/compute=]
+ * the [=shader stage attributes=]: [=attribute/vertex=], [=attribute/fragment=], and [=attribute/compute=]
  * [=attribute/workgroup_size=]
 
 ISSUE: Can we query upper bounds on workgroup size dimensions?  Is it independent of the shader, or
@@ -8175,13 +8176,14 @@ through which the shader accesses data external to the [=shader stage=],
 either for reading or writing.
 The interface includes:
 
-* [=Pipeline inputs=]
-* [=Pipeline outputs=]
-* [=Uniform buffers=]
-* [=Storage buffers=]
-* [=Texture resources=]
-* [=Sampler resources=]
+* [=Shader stage inputs=]
+* [=Shader stage outputs=]
 * [=Override-declarations=]
+* Attached [=resources=], which include:
+    * [=Uniform buffers=]
+    * [=Storage buffers=]
+    * [=Texture resources=]
+    * [=Sampler resources=]
 
 When an [=identifier=] in a [=function body=] [=resolves=] to a [=module scope|module-scope=] [[#var-and-value|variable or value declaration]],
 then we say that variable or value is <dfn>statically accessed</dfn> by the function.
@@ -8191,22 +8193,22 @@ or even execute the statement that may enclose the expression.
 
 More precisely, the <dfn noexport>interface of a shader stage</dfn> consists of:
   - All [=formal parameters=] of the [=entry point=].
-     These denote the pipeline inputs.
+     These denote the shader stage inputs.
   - The [=return value=] of the entry point.
-     This denotes the pipeline outputs.
+     This denotes the shader stage outputs.
   - All [=override-declarations=].
   - All [=uniform buffer=], [=storage buffer=], [=texture resource=], and [=sampler resource=] variables that are
         [=statically accessed=] by [=functions in a shader stage|functions in the shader stage=].
 
-### Pipeline Input and Output Interface ### {#pipeline-inputs-outputs}
+### Inter-stage Input and Output Interface ### {#stage-inputs-outputs}
 
-A <dfn noexport>pipeline input</dfn> is a datum provided to the shader stage from upstream in the pipeline.
+A <dfn noexport>shader stage input</dfn> is a datum provided to the shader stage from upstream in the pipeline.
 Each datum is either a [=built-in input value=], or a [=user-defined input datum|user-defined input=].
 
-A <dfn noexport>pipeline output</dfn> is a datum the shader provides for further processing downstream in the pipeline.
+A <dfn noexport>shader stage output</dfn> is a datum the shader provides for further processing downstream in the pipeline.
 Each datum is either a [=built-in output value=], or a [=user-defined output datum|user-defined output=].
 
-[=IO attributes=] are used to establish an object as a [=pipeline input=] or a [=pipeline output=],
+[=IO attributes=] are used to establish an object as a [=shader stage input=] or a [=shader stage output=],
 or to further describe the properties of an input or output.
 The <dfn noexport>IO attributes</dfn> are:
 * [=attribute/builtin=]
@@ -8226,7 +8228,7 @@ A built-in input for stage *S* with name *X* and type *T*<sub>*X*</sub> is acces
 1. The parameter has attribute `builtin(`*X*`)` and is of type *T*<sub>*X*</sub>.
 2. The parameter has structure type, where one of the structure members has attribute `builtin(`*X*`)` and is of type *T*<sub>*X*</sub>.
 
-Conversely, when a parameter or member of a parameter for an entry point has a `builtin` attribute,
+Conversely, when a parameter or member of a parameter for an entry point has a [=attribute/builtin=] attribute,
 the corresponding builtin [=shader-creation error|must=] be an input for the entry point's shader stage.
 
 A <dfn noexport>built-in output value</dfn> is used by the shader to convey
@@ -8240,7 +8242,7 @@ A built-in output for stage *S* with name *Y* and type *T*<sub>*Y*</sub> is set 
 1. The entry point [=return type=] has attribute `builtin(`*Y*`)` and is of type *T*<sub>*Y*</sub>.
 2. The entry point [=return type=] has structure type, where one of the structure members has attribute `builtin(`*Y*`)` and is of type *T*<sub>*Y*</sub>.
 
-Conversely, when the return type or member of a return type for an entry point has a `builtin` attribute,
+Conversely, when the return type or member of a return type for an entry point has a [=attribute/builtin=] attribute,
 the corresponding builtin [=shader-creation error|must=] be an output for the entry point's shader stage.
 
 Note: The [=built-in values/position=] built-in is both an output of a vertex shader, and an input to the fragement shader.
@@ -8274,12 +8276,12 @@ Each structure member in the entry point IO [=shader-creation error|must=] be on
 
 Locations [=shader-creation error|must not=] overlap within each of the following sets:
 * Members within a structure type.
-    This applies to any structure, not just those used in pipeline inputs or outputs.
-* An entry point's pipeline inputs,
+    This applies to any structure, not just those used in shader stage inputs or outputs.
+* An entry point's shader stage inputs,
     i.e. locations for its formal parameters, or for the members of its formal parameters of structure type.
 
 Note: Location numbering is distinct between inputs and outputs:
-Location numbers for an entry point's pipeline inputs do not conflict with location numbers for the entry point's pipeline outputs.
+Location numbers for an entry point's shader stage inputs do not conflict with location numbers for the entry point's shader stage outputs.
 
 Note: No additional rule is required to prevent location overlap within an entry point's outputs.
 When the output is a structure, the first rule above prevents overlap.
@@ -8410,7 +8412,7 @@ inputs with the same [=attribute/location=] assignment within the same [=pipelin
 ### Resource Interface ### {#resource-interface}
 
 A <dfn noexport>resource</dfn> is an object which provides access to data external to a [=shader stage=],
-and which is not an [=override-declaration=] and not a [[#pipeline-inputs-outputs|pipeline input or output]].
+and which is not an [=override-declaration=] and not a [[#stage-inputs-outputs|shader stage input or output]].
 Resources are shared by all invocations of the shader.
 
 There are four kinds of resources:


### PR DESCRIPTION
Fixes #3034

* Disambiguate uses of pipeline by renaming pipeline IO to shader stage IO