### PR TITLE
Add HTMLImageElement and ImageData to copyExternalImageToTexture

### DIFF
--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -241,6 +241,8 @@ dictionary GPUImageCopyTextureTagged
 
 <script type=idl>
 typedef (ImageBitmap or
+         ImageData or
+         HTMLImageElement or
          HTMLVideoElement or
          VideoFrame or
          HTMLCanvasElement or


### PR DESCRIPTION
HTMLImageElement requested by @kdashg , ImageData added to complete symmetry with [`TexImageSource`](https://registry.khronos.org/webgl/specs/latest/1.0/#5.14) WebGL (except for VideoFrame).