### PR TITLE
Rename maxColorAttachmentBytesPerPixel to *PerSample

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1753,10 +1753,11 @@ applications should generally request the "worst" limits that work for their con
         {{GPURenderPassDescriptor}}.{{GPURenderPassDescriptor/colorAttachments}},
         and {{GPURenderPassLayout}}.{{GPURenderPassLayout/colorFormats}}.
 
-    <tr><td><dfn>maxColorAttachmentBytesPerPixel</dfn>
+    <tr><td><dfn>maxColorAttachmentBytesPerSample</dfn>
         <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>32
     <tr class=row-continuation><td colspan=4>
-        The maximum number of bytes necessary to hold a pixel, across all color attachments.
+        The maximum number of bytes necessary to hold one sample (pixel or subpixel)
+        of render pipeline output data, across all color attachments.
 
     <tr><td><dfn>maxComputeWorkgroupStorageSize</dfn>
         <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>16384 bytes
@@ -1831,7 +1832,7 @@ interface GPUSupportedLimits {
     readonly attribute unsigned long maxInterStageShaderComponents;
     readonly attribute unsigned long maxInterStageShaderVariables;
     readonly attribute unsigned long maxColorAttachments;
-    readonly attribute unsigned long maxColorAttachmentBytesPerPixel;
+    readonly attribute unsigned long maxColorAttachmentBytesPerSample;
     readonly attribute unsigned long maxComputeWorkgroupStorageSize;
     readonly attribute unsigned long maxComputeInvocationsPerWorkgroup;
     readonly attribute unsigned long maxComputeWorkgroupSizeX;
@@ -7591,17 +7592,17 @@ dictionary GPUFragmentState : GPUProgrammableStage {
 
             Otherwise:
             - |colorState|.{{GPUColorTargetState/writeMask}} must be 0.
-    - [$Validating GPUFragmentState's color attachment bytes per pixel$](|device|, |descriptor|.{{GPUFragmentState/targets}}) succeeds.
+    - [$Validating GPUFragmentState's color attachment bytes per sample$](|device|, |descriptor|.{{GPUFragmentState/targets}}) succeeds.
 </div>
 
 <div algorithm>
-    <dfn abstract-op>Validating GPUFragmentState's color attachment bytes per pixel</dfn>({{GPUDevice}} |device|, sequence&lt;{{GPUColorTargetState}}?&gt; |targets|)
+    <dfn abstract-op>Validating GPUFragmentState's color attachment bytes per sample</dfn>({{GPUDevice}} |device|, sequence&lt;{{GPUColorTargetState}}?&gt; |targets|)
 
     1. Let |formats| be an empty [=list=]&lt;{{GPUTextureFormat}}?&gt;
     1. For each |target| in |targets|:
         1. If |target| is `undefined`, continue.
         1. [=list/Append=] |target|.{{GPUColorTargetState/format}} to |formats|.
-    1. [$Calculating color attachment bytes per pixel$](|formats|) must be &le; |device|.{{device/[[limits]]}}.{{supported limits/maxColorAttachmentBytesPerPixel}}.
+    1. [$Calculating color attachment bytes per sample$](|formats|) must be &le; |device|.{{device/[[limits]]}}.{{supported limits/maxColorAttachmentBytesPerSample}}.
 </div>
 
 Note:
@@ -10457,7 +10458,7 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
 
         1. |this|.{{GPURenderPassDescriptor/depthStencilAttachment}} must meet the [$GPURenderPassDepthStencilAttachment/GPURenderPassDepthStencilAttachment Valid Usage$] rules.
 
-    1. [$Validating GPURenderPassDescriptor's color attachment bytes per pixel$](|device|, |this|.{{GPURenderPassDescriptor/colorAttachments}}) succeeds.
+    1. [$Validating GPURenderPassDescriptor's color attachment bytes per sample$](|device|, |this|.{{GPURenderPassDescriptor/colorAttachments}}) succeeds.
 
     1. All {{GPURenderPassColorAttachment/view}}s in non-`null` members of |this|.{{GPURenderPassDescriptor/colorAttachments}},
         and |this|.{{GPURenderPassDescriptor/depthStencilAttachment}}.{{GPURenderPassDepthStencilAttachment/view}}
@@ -10500,13 +10501,13 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
 </div>
 
 <div algorithm>
-    <dfn abstract-op>Validating GPURenderPassDescriptor's color attachment bytes per pixel</dfn>({{GPUDevice}} |device|, sequence&lt;{{GPURenderPassColorAttachment}}?&gt; |colorAttachments|)
+    <dfn abstract-op>Validating GPURenderPassDescriptor's color attachment bytes per sample</dfn>({{GPUDevice}} |device|, sequence&lt;{{GPURenderPassColorAttachment}}?&gt; |colorAttachments|)
 
     1. Let |formats| be an empty [=list=]&lt;{{GPUTextureFormat}}?&gt;
     1. For each |colorAttachment| in |colorAttachments|:
         1. If |colorAttachment| is `undefined`, continue.
         1. [=list/Append=] |colorAttachment|.{{GPURenderPassColorAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}} to |formats|.
-    1. [$Calculating color attachment bytes per pixel$](|formats|) must be &le; |device|.{{device/[[limits]]}}.{{supported limits/maxColorAttachmentBytesPerPixel}}.
+    1. [$Calculating color attachment bytes per sample$](|formats|) must be &le; |device|.{{device/[[limits]]}}.{{supported limits/maxColorAttachmentBytesPerSample}}.
 </div>
 
 #### Color Attachments #### {#color-attachments}
@@ -10636,7 +10637,7 @@ dictionary GPURenderPassColorAttachment {
 </div>
 
 <div algorithm>
-    <dfn abstract-op>Calculating color attachment bytes per pixel</dfn>(|formats|)
+    <dfn abstract-op>Calculating color attachment bytes per sample</dfn>(|formats|)
 
     **Arguments:**
 
@@ -11733,7 +11734,7 @@ GPURenderBundleEncoder includes GPURenderCommandsMixin;
                             - |descriptor|.{{GPURenderPassLayout/depthStencilFormat}} must not be `null`.
                         - For each |colorFormat| in |descriptor|.{{GPURenderPassLayout/colorFormats}}:
                             - |colorFormat| is `null`, or it must be a [=color renderable format=].
-                        - [$Calculating color attachment bytes per pixel$](|descriptor|.{{GPURenderPassLayout/colorFormats}}) must be &le; |this|.{{device/[[limits]]}}.{{supported limits/maxColorAttachmentBytesPerPixel}}.
+                        - [$Calculating color attachment bytes per sample$](|descriptor|.{{GPURenderPassLayout/colorFormats}}) must be &le; |this|.{{device/[[limits]]}}.{{supported limits/maxColorAttachmentBytesPerSample}}.
                         - Let |depthStencilFormat| be |descriptor|.{{GPURenderPassLayout/depthStencilFormat}}.
                         - If |depthStencilFormat| is not `null`:
                             - |depthStencilFormat| must be a [=depth-or-stencil format=].


### PR DESCRIPTION
I think this name is more precise. We could also call it PerFragment. It depends on whether you think of this as a limit on the size of the pipe that carries fragments through the Output Merger stage, or a limit on the amount of data stored inside one sample of output.