### PR TITLE
Rename `type_decl` to `type_specifier`

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1989,9 +1989,9 @@ of a variable in [=address spaces/workgroup=] space.
 
 
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>array_type_decl</dfn> :
+  <dfn for=syntax>array_type_specifier</dfn> :
 
-    | [=syntax/array=] [=syntax/less_than=] [=syntax/type_decl=] ( [=syntax/comma=] [=syntax/element_count_expression=] ) ? [=syntax/greater_than=]
+    | [=syntax/array=] [=syntax/less_than=] [=syntax/type_specifier=] ( [=syntax/comma=] [=syntax/element_count_expression=] ) ? [=syntax/greater_than=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>element_count_expression</dfn> :
@@ -2077,7 +2077,7 @@ Some consequences of the restrictions structure member and array element types a
 <div class='syntax' noexport='true'>
   <dfn for=syntax>struct_member</dfn> :
 
-    | [=syntax/attribute=] * [=syntax/member_ident=] [=syntax/colon=] [=syntax/type_decl=]
+    | [=syntax/attribute=] * [=syntax/member_ident=] [=syntax/colon=] [=syntax/type_specifier=]
 </div>
 
 The following attributes can be applied to structure members:
@@ -3667,9 +3667,9 @@ sampler_comparison
 
     | [=syntax/depth_texture_type=]
 
-    | [=syntax/sampled_texture_type=] [=syntax/less_than=] [=syntax/type_decl=] [=syntax/greater_than=]
+    | [=syntax/sampled_texture_type=] [=syntax/less_than=] [=syntax/type_specifier=] [=syntax/greater_than=]
 
-    | [=syntax/multisampled_texture_type=] [=syntax/less_than=] [=syntax/type_decl=] [=syntax/greater_than=]
+    | [=syntax/multisampled_texture_type=] [=syntax/less_than=] [=syntax/type_specifier=] [=syntax/greater_than=]
 
     | [=syntax/storage_texture_type=] [=syntax/less_than=] [=syntax/texel_format=] [=syntax/comma=] [=syntax/access_mode=] [=syntax/greater_than=]
 </div>
@@ -3736,7 +3736,7 @@ all properties of the members of *S*, including attributes, carry over to the me
 <div class='syntax' noexport='true'>
   <dfn for=syntax>type_alias_decl</dfn> :
 
-    | [=syntax/type=] [=syntax/ident=] [=syntax/equal=] [=syntax/type_decl=]
+    | [=syntax/type=] [=syntax/ident=] [=syntax/equal=] [=syntax/type_specifier=]
 </div>
 
 <div class='example wgsl global-scope' heading='Type Alias'>
@@ -3753,18 +3753,18 @@ all properties of the members of *S*, including attributes, carry over to the me
   </xmp>
 </div>
 
-## Type Declaration Grammar ## {#type-declarations}
+## Type Specifier Grammar ## {#type-specifiers}
 
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>type_decl</dfn> :
+  <dfn for=syntax>type_specifier</dfn> :
 
     | [=syntax/ident=]
 
-    | [=syntax/type_decl_without_ident=]
+    | [=syntax/type_specifier_without_ident=]
 </div>
 
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>type_decl_without_ident</dfn> :
+  <dfn for=syntax>type_specifier_without_ident</dfn> :
 
     | [=syntax/bool=]
 
@@ -3776,15 +3776,15 @@ all properties of the members of *S*, including attributes, carry over to the me
 
     | [=syntax/uint32=]
 
-    | [=syntax/vec_prefix=] [=syntax/less_than=] [=syntax/type_decl=] [=syntax/greater_than=]
+    | [=syntax/vec_prefix=] [=syntax/less_than=] [=syntax/type_specifier=] [=syntax/greater_than=]
 
-    | [=syntax/mat_prefix=] [=syntax/less_than=] [=syntax/type_decl=] [=syntax/greater_than=]
+    | [=syntax/mat_prefix=] [=syntax/less_than=] [=syntax/type_specifier=] [=syntax/greater_than=]
 
-    | [=syntax/pointer=] [=syntax/less_than=] [=syntax/address_space=] [=syntax/comma=] [=syntax/type_decl=] ( [=syntax/comma=] [=syntax/access_mode=] ) ? [=syntax/greater_than=]
+    | [=syntax/pointer=] [=syntax/less_than=] [=syntax/address_space=] [=syntax/comma=] [=syntax/type_specifier=] ( [=syntax/comma=] [=syntax/access_mode=] ) ? [=syntax/greater_than=]
 
-    | [=syntax/array_type_decl=]
+    | [=syntax/array_type_specifier=]
 
-    | [=syntax/atomic=] [=syntax/less_than=] [=syntax/type_decl=] [=syntax/greater_than=]
+    | [=syntax/atomic=] [=syntax/less_than=] [=syntax/type_specifier=] [=syntax/greater_than=]
 
     | [=syntax/texture_and_sampler_types=]
 </div>
@@ -4390,7 +4390,7 @@ such that the redundant loads are eliminated.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>optionally_typed_ident</dfn> :
 
-    | [=syntax/ident=] ( [=syntax/colon=] [=syntax/type_decl=] ) ?
+    | [=syntax/ident=] ( [=syntax/colon=] [=syntax/type_specifier=] ) ?
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>variable_qualifier</dfn> :
@@ -6213,14 +6213,14 @@ When an identifier is used as a [=syntax/callable=] item, it is one of:
 
     | [=syntax/paren_expression=]
 
-    | [=syntax/bitcast=] [=syntax/less_than=] [=syntax/type_decl=] [=syntax/greater_than=] [=syntax/paren_expression=]
+    | [=syntax/bitcast=] [=syntax/less_than=] [=syntax/type_specifier=] [=syntax/greater_than=] [=syntax/paren_expression=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>callable</dfn> :
 
     | [=syntax/ident=]
 
-    | [=syntax/type_decl_without_ident=]
+    | [=syntax/type_specifier_without_ident=]
 
     | [=syntax/vec_prefix=]
 
@@ -7841,7 +7841,7 @@ parameters and return types:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>function_header</dfn> :
 
-    | [=syntax/fn=] [=syntax/ident=] [=syntax/paren_left=] [=syntax/param_list=] ? [=syntax/paren_right=] ( [=syntax/arrow=] [=syntax/attribute=] * [=syntax/type_decl=] ) ?
+    | [=syntax/fn=] [=syntax/ident=] [=syntax/paren_left=] [=syntax/param_list=] ? [=syntax/paren_right=] ( [=syntax/arrow=] [=syntax/attribute=] * [=syntax/type_specifier=] ) ?
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>param_list</dfn> :
@@ -7851,7 +7851,7 @@ parameters and return types:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>param</dfn> :
 
-    | [=syntax/attribute=] * [=syntax/ident=] [=syntax/colon=] [=syntax/type_decl=]
+    | [=syntax/attribute=] * [=syntax/ident=] [=syntax/colon=] [=syntax/type_specifier=]
 </div>
 
 <div class='example wgsl' heading='Simple functions'>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3760,11 +3760,11 @@ all properties of the members of *S*, including attributes, carry over to the me
 
     | [=syntax/ident=]
 
-    | [=syntax/type_without_ident=]
+    | [=syntax/type_specifier_without_ident=]
 </div>
 
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>type_without_ident</dfn> :
+  <dfn for=syntax>type_specifier_without_ident</dfn> :
 
     | [=syntax/bool=]
 
@@ -6220,7 +6220,7 @@ When an identifier is used as a [=syntax/callable=] item, it is one of:
 
     | [=syntax/ident=]
 
-    | [=syntax/type_without_ident=]
+    | [=syntax/type_specifier_without_ident=]
 
     | [=syntax/vec_prefix=]
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1989,9 +1989,9 @@ of a variable in [=address spaces/workgroup=] space.
 
 
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>array_type_specifier</dfn> :
+  <dfn for=syntax>array_type</dfn> :
 
-    | [=syntax/array=] [=syntax/less_than=] [=syntax/type_specifier=] ( [=syntax/comma=] [=syntax/element_count_expression=] ) ? [=syntax/greater_than=]
+    | [=syntax/array=] [=syntax/less_than=] [=syntax/type=] ( [=syntax/comma=] [=syntax/element_count_expression=] ) ? [=syntax/greater_than=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>element_count_expression</dfn> :
@@ -2077,7 +2077,7 @@ Some consequences of the restrictions structure member and array element types a
 <div class='syntax' noexport='true'>
   <dfn for=syntax>struct_member</dfn> :
 
-    | [=syntax/attribute=] * [=syntax/member_ident=] [=syntax/colon=] [=syntax/type_specifier=]
+    | [=syntax/attribute=] * [=syntax/member_ident=] [=syntax/colon=] [=syntax/type=]
 </div>
 
 The following attributes can be applied to structure members:
@@ -3667,9 +3667,9 @@ sampler_comparison
 
     | [=syntax/depth_texture_type=]
 
-    | [=syntax/sampled_texture_type=] [=syntax/less_than=] [=syntax/type_specifier=] [=syntax/greater_than=]
+    | [=syntax/sampled_texture_type=] [=syntax/less_than=] [=syntax/type=] [=syntax/greater_than=]
 
-    | [=syntax/multisampled_texture_type=] [=syntax/less_than=] [=syntax/type_specifier=] [=syntax/greater_than=]
+    | [=syntax/multisampled_texture_type=] [=syntax/less_than=] [=syntax/type=] [=syntax/greater_than=]
 
     | [=syntax/storage_texture_type=] [=syntax/less_than=] [=syntax/texel_format=] [=syntax/comma=] [=syntax/access_mode=] [=syntax/greater_than=]
 </div>
@@ -3736,7 +3736,7 @@ all properties of the members of *S*, including attributes, carry over to the me
 <div class='syntax' noexport='true'>
   <dfn for=syntax>type_alias_decl</dfn> :
 
-    | [=syntax/type=] [=syntax/ident=] [=syntax/equal=] [=syntax/type_specifier=]
+    | `'type'` [=syntax/ident=] [=syntax/equal=] [=syntax/type=]
 </div>
 
 <div class='example wgsl global-scope' heading='Type Alias'>
@@ -3756,15 +3756,15 @@ all properties of the members of *S*, including attributes, carry over to the me
 ## Type Specifier Grammar ## {#type-specifiers}
 
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>type_specifier</dfn> :
+  <dfn for=syntax>type</dfn> :
 
     | [=syntax/ident=]
 
-    | [=syntax/type_specifier_without_ident=]
+    | [=syntax/type_without_ident=]
 </div>
 
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>type_specifier_without_ident</dfn> :
+  <dfn for=syntax>type_without_ident</dfn> :
 
     | [=syntax/bool=]
 
@@ -3776,15 +3776,15 @@ all properties of the members of *S*, including attributes, carry over to the me
 
     | [=syntax/uint32=]
 
-    | [=syntax/vec_prefix=] [=syntax/less_than=] [=syntax/type_specifier=] [=syntax/greater_than=]
+    | [=syntax/vec_prefix=] [=syntax/less_than=] [=syntax/type=] [=syntax/greater_than=]
 
-    | [=syntax/mat_prefix=] [=syntax/less_than=] [=syntax/type_specifier=] [=syntax/greater_than=]
+    | [=syntax/mat_prefix=] [=syntax/less_than=] [=syntax/type=] [=syntax/greater_than=]
 
-    | [=syntax/pointer=] [=syntax/less_than=] [=syntax/address_space=] [=syntax/comma=] [=syntax/type_specifier=] ( [=syntax/comma=] [=syntax/access_mode=] ) ? [=syntax/greater_than=]
+    | [=syntax/pointer=] [=syntax/less_than=] [=syntax/address_space=] [=syntax/comma=] [=syntax/type=] ( [=syntax/comma=] [=syntax/access_mode=] ) ? [=syntax/greater_than=]
 
-    | [=syntax/array_type_specifier=]
+    | [=syntax/array_type=]
 
-    | [=syntax/atomic=] [=syntax/less_than=] [=syntax/type_specifier=] [=syntax/greater_than=]
+    | [=syntax/atomic=] [=syntax/less_than=] [=syntax/type=] [=syntax/greater_than=]
 
     | [=syntax/texture_and_sampler_types=]
 </div>
@@ -4390,7 +4390,7 @@ such that the redundant loads are eliminated.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>optionally_typed_ident</dfn> :
 
-    | [=syntax/ident=] ( [=syntax/colon=] [=syntax/type_specifier=] ) ?
+    | [=syntax/ident=] ( [=syntax/colon=] [=syntax/type=] ) ?
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>variable_qualifier</dfn> :
@@ -6213,14 +6213,14 @@ When an identifier is used as a [=syntax/callable=] item, it is one of:
 
     | [=syntax/paren_expression=]
 
-    | [=syntax/bitcast=] [=syntax/less_than=] [=syntax/type_specifier=] [=syntax/greater_than=] [=syntax/paren_expression=]
+    | [=syntax/bitcast=] [=syntax/less_than=] [=syntax/type=] [=syntax/greater_than=] [=syntax/paren_expression=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>callable</dfn> :
 
     | [=syntax/ident=]
 
-    | [=syntax/type_specifier_without_ident=]
+    | [=syntax/type_without_ident=]
 
     | [=syntax/vec_prefix=]
 
@@ -7841,7 +7841,7 @@ parameters and return types:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>function_header</dfn> :
 
-    | [=syntax/fn=] [=syntax/ident=] [=syntax/paren_left=] [=syntax/param_list=] ? [=syntax/paren_right=] ( [=syntax/arrow=] [=syntax/attribute=] * [=syntax/type_specifier=] ) ?
+    | [=syntax/fn=] [=syntax/ident=] [=syntax/paren_left=] [=syntax/param_list=] ? [=syntax/paren_right=] ( [=syntax/arrow=] [=syntax/attribute=] * [=syntax/type=] ) ?
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>param_list</dfn> :
@@ -7851,7 +7851,7 @@ parameters and return types:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>param</dfn> :
 
-    | [=syntax/attribute=] * [=syntax/ident=] [=syntax/colon=] [=syntax/type_specifier=]
+    | [=syntax/attribute=] * [=syntax/ident=] [=syntax/colon=] [=syntax/type=]
 </div>
 
 <div class='example wgsl' heading='Simple functions'>
@@ -10468,11 +10468,6 @@ Issue: https://github.com/gpuweb/gpuweb/issues/1621
   <dfn for=syntax>true</dfn> :
 
     | `'true'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>type</dfn> :
-
-    | `'type'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>uniform</dfn> :

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1991,7 +1991,7 @@ of a variable in [=address spaces/workgroup=] space.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>array_type</dfn> :
 
-    | [=syntax/array=] [=syntax/less_than=] [=syntax/type=] ( [=syntax/comma=] [=syntax/element_count_expression=] ) ? [=syntax/greater_than=]
+    | [=syntax/array=] [=syntax/less_than=] [=syntax/type_specifier=] ( [=syntax/comma=] [=syntax/element_count_expression=] ) ? [=syntax/greater_than=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>element_count_expression</dfn> :
@@ -2077,7 +2077,7 @@ Some consequences of the restrictions structure member and array element types a
 <div class='syntax' noexport='true'>
   <dfn for=syntax>struct_member</dfn> :
 
-    | [=syntax/attribute=] * [=syntax/member_ident=] [=syntax/colon=] [=syntax/type=]
+    | [=syntax/attribute=] * [=syntax/member_ident=] [=syntax/colon=] [=syntax/type_specifier=]
 </div>
 
 The following attributes can be applied to structure members:
@@ -3667,9 +3667,9 @@ sampler_comparison
 
     | [=syntax/depth_texture_type=]
 
-    | [=syntax/sampled_texture_type=] [=syntax/less_than=] [=syntax/type=] [=syntax/greater_than=]
+    | [=syntax/sampled_texture_type=] [=syntax/less_than=] [=syntax/type_specifier=] [=syntax/greater_than=]
 
-    | [=syntax/multisampled_texture_type=] [=syntax/less_than=] [=syntax/type=] [=syntax/greater_than=]
+    | [=syntax/multisampled_texture_type=] [=syntax/less_than=] [=syntax/type_specifier=] [=syntax/greater_than=]
 
     | [=syntax/storage_texture_type=] [=syntax/less_than=] [=syntax/texel_format=] [=syntax/comma=] [=syntax/access_mode=] [=syntax/greater_than=]
 </div>
@@ -3736,7 +3736,7 @@ all properties of the members of *S*, including attributes, carry over to the me
 <div class='syntax' noexport='true'>
   <dfn for=syntax>type_alias_decl</dfn> :
 
-    | `'type'` [=syntax/ident=] [=syntax/equal=] [=syntax/type=]
+    | [=syntax/type=] [=syntax/ident=] [=syntax/equal=] [=syntax/type_specifier=]
 </div>
 
 <div class='example wgsl global-scope' heading='Type Alias'>
@@ -3756,7 +3756,7 @@ all properties of the members of *S*, including attributes, carry over to the me
 ## Type Specifier Grammar ## {#type-specifiers}
 
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>type</dfn> :
+  <dfn for=syntax>type_specifier</dfn> :
 
     | [=syntax/ident=]
 
@@ -3776,15 +3776,15 @@ all properties of the members of *S*, including attributes, carry over to the me
 
     | [=syntax/uint32=]
 
-    | [=syntax/vec_prefix=] [=syntax/less_than=] [=syntax/type=] [=syntax/greater_than=]
+    | [=syntax/vec_prefix=] [=syntax/less_than=] [=syntax/type_specifier=] [=syntax/greater_than=]
 
-    | [=syntax/mat_prefix=] [=syntax/less_than=] [=syntax/type=] [=syntax/greater_than=]
+    | [=syntax/mat_prefix=] [=syntax/less_than=] [=syntax/type_specifier=] [=syntax/greater_than=]
 
-    | [=syntax/pointer=] [=syntax/less_than=] [=syntax/address_space=] [=syntax/comma=] [=syntax/type=] ( [=syntax/comma=] [=syntax/access_mode=] ) ? [=syntax/greater_than=]
+    | [=syntax/pointer=] [=syntax/less_than=] [=syntax/address_space=] [=syntax/comma=] [=syntax/type_specifier=] ( [=syntax/comma=] [=syntax/access_mode=] ) ? [=syntax/greater_than=]
 
     | [=syntax/array_type=]
 
-    | [=syntax/atomic=] [=syntax/less_than=] [=syntax/type=] [=syntax/greater_than=]
+    | [=syntax/atomic=] [=syntax/less_than=] [=syntax/type_specifier=] [=syntax/greater_than=]
 
     | [=syntax/texture_and_sampler_types=]
 </div>
@@ -4390,7 +4390,7 @@ such that the redundant loads are eliminated.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>optionally_typed_ident</dfn> :
 
-    | [=syntax/ident=] ( [=syntax/colon=] [=syntax/type=] ) ?
+    | [=syntax/ident=] ( [=syntax/colon=] [=syntax/type_specifier=] ) ?
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>variable_qualifier</dfn> :
@@ -6213,7 +6213,7 @@ When an identifier is used as a [=syntax/callable=] item, it is one of:
 
     | [=syntax/paren_expression=]
 
-    | [=syntax/bitcast=] [=syntax/less_than=] [=syntax/type=] [=syntax/greater_than=] [=syntax/paren_expression=]
+    | [=syntax/bitcast=] [=syntax/less_than=] [=syntax/type_specifier=] [=syntax/greater_than=] [=syntax/paren_expression=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>callable</dfn> :
@@ -7841,7 +7841,7 @@ parameters and return types:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>function_header</dfn> :
 
-    | [=syntax/fn=] [=syntax/ident=] [=syntax/paren_left=] [=syntax/param_list=] ? [=syntax/paren_right=] ( [=syntax/arrow=] [=syntax/attribute=] * [=syntax/type=] ) ?
+    | [=syntax/fn=] [=syntax/ident=] [=syntax/paren_left=] [=syntax/param_list=] ? [=syntax/paren_right=] ( [=syntax/arrow=] [=syntax/attribute=] * [=syntax/type_specifier=] ) ?
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>param_list</dfn> :
@@ -7851,7 +7851,7 @@ parameters and return types:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>param</dfn> :
 
-    | [=syntax/attribute=] * [=syntax/ident=] [=syntax/colon=] [=syntax/type=]
+    | [=syntax/attribute=] * [=syntax/ident=] [=syntax/colon=] [=syntax/type_specifier=]
 </div>
 
 <div class='example wgsl' heading='Simple functions'>
@@ -10468,6 +10468,11 @@ Issue: https://github.com/gpuweb/gpuweb/issues/1621
   <dfn for=syntax>true</dfn> :
 
     | `'true'`
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>type</dfn> :
+
+    | `'type'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>uniform</dfn> :

--- a/wgsl/wgsl.recursive.bs.include
+++ b/wgsl/wgsl.recursive.bs.include
@@ -121,7 +121,7 @@
 
  | [=recursive descent syntax/mat_prefix=]
 
- | [=recursive descent syntax/type_specifier_without_ident=]
+ | [=recursive descent syntax/type_without_ident=]
 
  | [=recursive descent syntax/vec_prefix=]
 
@@ -265,7 +265,7 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>global_decl</dfn>:
 
- | [=recursive descent syntax/attribute=] * `'fn'` [=recursive descent syntax/ident=] [=syntax/paren_left=] ( [=recursive descent syntax/attribute=] * [=recursive descent syntax/ident=] [=syntax/colon=] [=recursive descent syntax/type_specifier=] ( [=syntax/comma=] [=recursive descent syntax/param=] )* [=syntax/comma=] ? )? [=syntax/paren_right=] ( [=syntax/arrow=] [=recursive descent syntax/attribute=] * [=recursive descent syntax/type_specifier=] )? [=syntax/brace_left=] [=recursive descent syntax/statement=] * [=syntax/brace_right=]
+ | [=recursive descent syntax/attribute=] * `'fn'` [=recursive descent syntax/ident=] [=syntax/paren_left=] ( [=recursive descent syntax/attribute=] * [=recursive descent syntax/ident=] [=syntax/colon=] `'type'` ( [=syntax/comma=] [=recursive descent syntax/param=] )* [=syntax/comma=] ? )? [=syntax/paren_right=] ( [=syntax/arrow=] [=recursive descent syntax/attribute=] * `'type'` )? [=syntax/brace_left=] [=recursive descent syntax/statement=] * [=syntax/brace_right=]
 
  | [=recursive descent syntax/attribute=] * `'override'` [=recursive descent syntax/optionally_typed_ident=] ( [=syntax/equal=] [=recursive descent syntax/expression=] )? [=syntax/semicolon=]
 
@@ -277,9 +277,9 @@
 
  | `'static_assert'` [=recursive descent syntax/expression=] [=syntax/semicolon=]
 
- | `'struct'` [=recursive descent syntax/ident=] [=syntax/brace_left=] [=recursive descent syntax/attribute=] * [=recursive descent syntax/member_ident=] [=syntax/colon=] [=recursive descent syntax/type_specifier=] ( [=syntax/comma=] [=recursive descent syntax/attribute=] * [=recursive descent syntax/member_ident=] [=syntax/colon=] [=recursive descent syntax/type_specifier=] )* [=syntax/comma=] ? [=syntax/brace_right=]
+ | `'struct'` [=recursive descent syntax/ident=] [=syntax/brace_left=] [=recursive descent syntax/attribute=] * [=recursive descent syntax/member_ident=] [=syntax/colon=] `'type'` ( [=syntax/comma=] [=recursive descent syntax/attribute=] * [=recursive descent syntax/member_ident=] [=syntax/colon=] `'type'` )* [=syntax/comma=] ? [=syntax/brace_right=]
 
- | `'type'` [=recursive descent syntax/ident=] [=syntax/equal=] [=recursive descent syntax/type_specifier=] [=syntax/semicolon=]
+ | `'type'` [=recursive descent syntax/ident=] [=syntax/equal=] `'type'` [=syntax/semicolon=]
 </div>
 
 <div class='syntax' noexport='true'>
@@ -381,13 +381,13 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>optionally_typed_ident</dfn>:
 
- | [=recursive descent syntax/ident=] ( [=syntax/colon=] [=recursive descent syntax/type_specifier=] )?
+ | [=recursive descent syntax/ident=] ( [=syntax/colon=] `'type'` )?
 </div>
 
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>param</dfn>:
 
- | [=recursive descent syntax/attribute=] * [=recursive descent syntax/ident=] [=syntax/colon=] [=recursive descent syntax/type_specifier=]
+ | [=recursive descent syntax/attribute=] * [=recursive descent syntax/ident=] [=syntax/colon=] `'type'`
 </div>
 
 <div class='syntax' noexport='true'>
@@ -411,7 +411,7 @@
 
  | [=syntax/paren_left=] [=recursive descent syntax/expression=] [=syntax/paren_right=]
 
- | `'bitcast'` [=syntax/less_than=] [=recursive descent syntax/type_specifier=] [=syntax/greater_than=] [=syntax/paren_left=] [=recursive descent syntax/expression=] [=syntax/paren_right=]
+ | `'bitcast'` [=syntax/less_than=] `'type'` [=syntax/greater_than=] [=syntax/paren_left=] [=recursive descent syntax/expression=] [=syntax/paren_right=]
 </div>
 
 <div class='syntax' noexport='true'>
@@ -581,13 +581,13 @@
 
  | [=recursive descent syntax/depth_texture_type=]
 
- | [=recursive descent syntax/sampled_texture_type=] [=syntax/less_than=] [=recursive descent syntax/type_specifier=] [=syntax/greater_than=]
+ | [=recursive descent syntax/sampled_texture_type=] [=syntax/less_than=] `'type'` [=syntax/greater_than=]
 
  | [=recursive descent syntax/sampler_type=]
 
  | [=recursive descent syntax/storage_texture_type=] [=syntax/less_than=] [=recursive descent syntax/texel_format=] [=syntax/comma=] [=recursive descent syntax/access_mode=] [=syntax/greater_than=]
 
- | [=syntax/multisampled_texture_type=] [=syntax/less_than=] [=recursive descent syntax/type_specifier=] [=syntax/greater_than=]
+ | [=syntax/multisampled_texture_type=] [=syntax/less_than=] `'type'` [=syntax/greater_than=]
 </div>
 
 <div class='syntax' noexport='true'>
@@ -597,21 +597,13 @@
 </div>
 
 <div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>type_specifier</dfn>:
+  <dfn for='recursive descent syntax'>type_without_ident</dfn>:
 
- | [=recursive descent syntax/ident=]
-
- | [=recursive descent syntax/type_specifier_without_ident=]
-</div>
-
-<div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>type_specifier_without_ident</dfn>:
-
- | [=recursive descent syntax/mat_prefix=] [=syntax/less_than=] [=recursive descent syntax/type_specifier=] [=syntax/greater_than=]
+ | [=recursive descent syntax/mat_prefix=] [=syntax/less_than=] `'type'` [=syntax/greater_than=]
 
  | [=recursive descent syntax/texture_and_sampler_types=]
 
- | [=recursive descent syntax/vec_prefix=] [=syntax/less_than=] [=recursive descent syntax/type_specifier=] [=syntax/greater_than=]
+ | [=recursive descent syntax/vec_prefix=] [=syntax/less_than=] `'type'` [=syntax/greater_than=]
 
  | [=syntax/float16=]
 
@@ -619,13 +611,13 @@
 
  | [=syntax/int32=]
 
- | [=syntax/pointer=] [=syntax/less_than=] [=recursive descent syntax/address_space=] [=syntax/comma=] [=recursive descent syntax/type_specifier=] ( [=syntax/comma=] [=recursive descent syntax/access_mode=] )? [=syntax/greater_than=]
+ | [=syntax/pointer=] [=syntax/less_than=] [=recursive descent syntax/address_space=] [=syntax/comma=] `'type'` ( [=syntax/comma=] [=recursive descent syntax/access_mode=] )? [=syntax/greater_than=]
 
  | [=syntax/uint32=]
 
- | `'array'` [=syntax/less_than=] [=recursive descent syntax/type_specifier=] ( [=syntax/comma=] [=recursive descent syntax/element_count_expression=] )? [=syntax/greater_than=]
+ | `'array'` [=syntax/less_than=] `'type'` ( [=syntax/comma=] [=recursive descent syntax/element_count_expression=] )? [=syntax/greater_than=]
 
- | `'atomic'` [=syntax/less_than=] [=recursive descent syntax/type_specifier=] [=syntax/greater_than=]
+ | `'atomic'` [=syntax/less_than=] `'type'` [=syntax/greater_than=]
 
  | `'bool'`
 </div>

--- a/wgsl/wgsl.recursive.bs.include
+++ b/wgsl/wgsl.recursive.bs.include
@@ -265,7 +265,7 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>global_decl</dfn>:
 
- | [=recursive descent syntax/attribute=] * `'fn'` [=recursive descent syntax/ident=] [=syntax/paren_left=] ( [=recursive descent syntax/attribute=] * [=recursive descent syntax/ident=] [=syntax/colon=] `'type'` ( [=syntax/comma=] [=recursive descent syntax/param=] )* [=syntax/comma=] ? )? [=syntax/paren_right=] ( [=syntax/arrow=] [=recursive descent syntax/attribute=] * `'type'` )? [=syntax/brace_left=] [=recursive descent syntax/statement=] * [=syntax/brace_right=]
+ | [=recursive descent syntax/attribute=] * `'fn'` [=recursive descent syntax/ident=] [=syntax/paren_left=] ( [=recursive descent syntax/attribute=] * [=recursive descent syntax/ident=] [=syntax/colon=] [=recursive descent syntax/type_specifier=] ( [=syntax/comma=] [=recursive descent syntax/param=] )* [=syntax/comma=] ? )? [=syntax/paren_right=] ( [=syntax/arrow=] [=recursive descent syntax/attribute=] * [=recursive descent syntax/type_specifier=] )? [=syntax/brace_left=] [=recursive descent syntax/statement=] * [=syntax/brace_right=]
 
  | [=recursive descent syntax/attribute=] * `'override'` [=recursive descent syntax/optionally_typed_ident=] ( [=syntax/equal=] [=recursive descent syntax/expression=] )? [=syntax/semicolon=]
 
@@ -277,9 +277,9 @@
 
  | `'static_assert'` [=recursive descent syntax/expression=] [=syntax/semicolon=]
 
- | `'struct'` [=recursive descent syntax/ident=] [=syntax/brace_left=] [=recursive descent syntax/attribute=] * [=recursive descent syntax/member_ident=] [=syntax/colon=] `'type'` ( [=syntax/comma=] [=recursive descent syntax/attribute=] * [=recursive descent syntax/member_ident=] [=syntax/colon=] `'type'` )* [=syntax/comma=] ? [=syntax/brace_right=]
+ | `'struct'` [=recursive descent syntax/ident=] [=syntax/brace_left=] [=recursive descent syntax/attribute=] * [=recursive descent syntax/member_ident=] [=syntax/colon=] [=recursive descent syntax/type_specifier=] ( [=syntax/comma=] [=recursive descent syntax/attribute=] * [=recursive descent syntax/member_ident=] [=syntax/colon=] [=recursive descent syntax/type_specifier=] )* [=syntax/comma=] ? [=syntax/brace_right=]
 
- | `'type'` [=recursive descent syntax/ident=] [=syntax/equal=] `'type'` [=syntax/semicolon=]
+ | `'type'` [=recursive descent syntax/ident=] [=syntax/equal=] [=recursive descent syntax/type_specifier=] [=syntax/semicolon=]
 </div>
 
 <div class='syntax' noexport='true'>
@@ -381,13 +381,13 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>optionally_typed_ident</dfn>:
 
- | [=recursive descent syntax/ident=] ( [=syntax/colon=] `'type'` )?
+ | [=recursive descent syntax/ident=] ( [=syntax/colon=] [=recursive descent syntax/type_specifier=] )?
 </div>
 
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>param</dfn>:
 
- | [=recursive descent syntax/attribute=] * [=recursive descent syntax/ident=] [=syntax/colon=] `'type'`
+ | [=recursive descent syntax/attribute=] * [=recursive descent syntax/ident=] [=syntax/colon=] [=recursive descent syntax/type_specifier=]
 </div>
 
 <div class='syntax' noexport='true'>
@@ -411,7 +411,7 @@
 
  | [=syntax/paren_left=] [=recursive descent syntax/expression=] [=syntax/paren_right=]
 
- | `'bitcast'` [=syntax/less_than=] `'type'` [=syntax/greater_than=] [=syntax/paren_left=] [=recursive descent syntax/expression=] [=syntax/paren_right=]
+ | `'bitcast'` [=syntax/less_than=] [=recursive descent syntax/type_specifier=] [=syntax/greater_than=] [=syntax/paren_left=] [=recursive descent syntax/expression=] [=syntax/paren_right=]
 </div>
 
 <div class='syntax' noexport='true'>
@@ -581,13 +581,13 @@
 
  | [=recursive descent syntax/depth_texture_type=]
 
- | [=recursive descent syntax/sampled_texture_type=] [=syntax/less_than=] `'type'` [=syntax/greater_than=]
+ | [=recursive descent syntax/sampled_texture_type=] [=syntax/less_than=] [=recursive descent syntax/type_specifier=] [=syntax/greater_than=]
 
  | [=recursive descent syntax/sampler_type=]
 
  | [=recursive descent syntax/storage_texture_type=] [=syntax/less_than=] [=recursive descent syntax/texel_format=] [=syntax/comma=] [=recursive descent syntax/access_mode=] [=syntax/greater_than=]
 
- | [=syntax/multisampled_texture_type=] [=syntax/less_than=] `'type'` [=syntax/greater_than=]
+ | [=syntax/multisampled_texture_type=] [=syntax/less_than=] [=recursive descent syntax/type_specifier=] [=syntax/greater_than=]
 </div>
 
 <div class='syntax' noexport='true'>
@@ -597,13 +597,21 @@
 </div>
 
 <div class='syntax' noexport='true'>
+  <dfn for='recursive descent syntax'>type_specifier</dfn>:
+
+ | [=recursive descent syntax/ident=]
+
+ | [=recursive descent syntax/type_without_ident=]
+</div>
+
+<div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>type_without_ident</dfn>:
 
- | [=recursive descent syntax/mat_prefix=] [=syntax/less_than=] `'type'` [=syntax/greater_than=]
+ | [=recursive descent syntax/mat_prefix=] [=syntax/less_than=] [=recursive descent syntax/type_specifier=] [=syntax/greater_than=]
 
  | [=recursive descent syntax/texture_and_sampler_types=]
 
- | [=recursive descent syntax/vec_prefix=] [=syntax/less_than=] `'type'` [=syntax/greater_than=]
+ | [=recursive descent syntax/vec_prefix=] [=syntax/less_than=] [=recursive descent syntax/type_specifier=] [=syntax/greater_than=]
 
  | [=syntax/float16=]
 
@@ -611,13 +619,13 @@
 
  | [=syntax/int32=]
 
- | [=syntax/pointer=] [=syntax/less_than=] [=recursive descent syntax/address_space=] [=syntax/comma=] `'type'` ( [=syntax/comma=] [=recursive descent syntax/access_mode=] )? [=syntax/greater_than=]
+ | [=syntax/pointer=] [=syntax/less_than=] [=recursive descent syntax/address_space=] [=syntax/comma=] [=recursive descent syntax/type_specifier=] ( [=syntax/comma=] [=recursive descent syntax/access_mode=] )? [=syntax/greater_than=]
 
  | [=syntax/uint32=]
 
- | `'array'` [=syntax/less_than=] `'type'` ( [=syntax/comma=] [=recursive descent syntax/element_count_expression=] )? [=syntax/greater_than=]
+ | `'array'` [=syntax/less_than=] [=recursive descent syntax/type_specifier=] ( [=syntax/comma=] [=recursive descent syntax/element_count_expression=] )? [=syntax/greater_than=]
 
- | `'atomic'` [=syntax/less_than=] `'type'` [=syntax/greater_than=]
+ | `'atomic'` [=syntax/less_than=] [=recursive descent syntax/type_specifier=] [=syntax/greater_than=]
 
  | `'bool'`
 </div>

--- a/wgsl/wgsl.recursive.bs.include
+++ b/wgsl/wgsl.recursive.bs.include
@@ -121,7 +121,7 @@
 
  | [=recursive descent syntax/mat_prefix=]
 
- | [=recursive descent syntax/type_without_ident=]
+ | [=recursive descent syntax/type_specifier_without_ident=]
 
  | [=recursive descent syntax/vec_prefix=]
 
@@ -601,11 +601,11 @@
 
  | [=recursive descent syntax/ident=]
 
- | [=recursive descent syntax/type_without_ident=]
+ | [=recursive descent syntax/type_specifier_without_ident=]
 </div>
 
 <div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>type_without_ident</dfn>:
+  <dfn for='recursive descent syntax'>type_specifier_without_ident</dfn>:
 
  | [=recursive descent syntax/mat_prefix=] [=syntax/less_than=] [=recursive descent syntax/type_specifier=] [=syntax/greater_than=]
 

--- a/wgsl/wgsl.recursive.bs.include
+++ b/wgsl/wgsl.recursive.bs.include
@@ -121,7 +121,7 @@
 
  | [=recursive descent syntax/mat_prefix=]
 
- | [=recursive descent syntax/type_decl_without_ident=]
+ | [=recursive descent syntax/type_specifier_without_ident=]
 
  | [=recursive descent syntax/vec_prefix=]
 
@@ -265,7 +265,7 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>global_decl</dfn>:
 
- | [=recursive descent syntax/attribute=] * `'fn'` [=recursive descent syntax/ident=] [=syntax/paren_left=] ( [=recursive descent syntax/attribute=] * [=recursive descent syntax/ident=] [=syntax/colon=] [=recursive descent syntax/type_decl=] ( [=syntax/comma=] [=recursive descent syntax/param=] )* [=syntax/comma=] ? )? [=syntax/paren_right=] ( [=syntax/arrow=] [=recursive descent syntax/attribute=] * [=recursive descent syntax/type_decl=] )? [=syntax/brace_left=] [=recursive descent syntax/statement=] * [=syntax/brace_right=]
+ | [=recursive descent syntax/attribute=] * `'fn'` [=recursive descent syntax/ident=] [=syntax/paren_left=] ( [=recursive descent syntax/attribute=] * [=recursive descent syntax/ident=] [=syntax/colon=] [=recursive descent syntax/type_specifier=] ( [=syntax/comma=] [=recursive descent syntax/param=] )* [=syntax/comma=] ? )? [=syntax/paren_right=] ( [=syntax/arrow=] [=recursive descent syntax/attribute=] * [=recursive descent syntax/type_specifier=] )? [=syntax/brace_left=] [=recursive descent syntax/statement=] * [=syntax/brace_right=]
 
  | [=recursive descent syntax/attribute=] * `'override'` [=recursive descent syntax/optionally_typed_ident=] ( [=syntax/equal=] [=recursive descent syntax/expression=] )? [=syntax/semicolon=]
 
@@ -277,9 +277,9 @@
 
  | `'static_assert'` [=recursive descent syntax/expression=] [=syntax/semicolon=]
 
- | `'struct'` [=recursive descent syntax/ident=] [=syntax/brace_left=] [=recursive descent syntax/attribute=] * [=recursive descent syntax/member_ident=] [=syntax/colon=] [=recursive descent syntax/type_decl=] ( [=syntax/comma=] [=recursive descent syntax/attribute=] * [=recursive descent syntax/member_ident=] [=syntax/colon=] [=recursive descent syntax/type_decl=] )* [=syntax/comma=] ? [=syntax/brace_right=]
+ | `'struct'` [=recursive descent syntax/ident=] [=syntax/brace_left=] [=recursive descent syntax/attribute=] * [=recursive descent syntax/member_ident=] [=syntax/colon=] [=recursive descent syntax/type_specifier=] ( [=syntax/comma=] [=recursive descent syntax/attribute=] * [=recursive descent syntax/member_ident=] [=syntax/colon=] [=recursive descent syntax/type_specifier=] )* [=syntax/comma=] ? [=syntax/brace_right=]
 
- | `'type'` [=recursive descent syntax/ident=] [=syntax/equal=] [=recursive descent syntax/type_decl=] [=syntax/semicolon=]
+ | `'type'` [=recursive descent syntax/ident=] [=syntax/equal=] [=recursive descent syntax/type_specifier=] [=syntax/semicolon=]
 </div>
 
 <div class='syntax' noexport='true'>
@@ -381,13 +381,13 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>optionally_typed_ident</dfn>:
 
- | [=recursive descent syntax/ident=] ( [=syntax/colon=] [=recursive descent syntax/type_decl=] )?
+ | [=recursive descent syntax/ident=] ( [=syntax/colon=] [=recursive descent syntax/type_specifier=] )?
 </div>
 
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>param</dfn>:
 
- | [=recursive descent syntax/attribute=] * [=recursive descent syntax/ident=] [=syntax/colon=] [=recursive descent syntax/type_decl=]
+ | [=recursive descent syntax/attribute=] * [=recursive descent syntax/ident=] [=syntax/colon=] [=recursive descent syntax/type_specifier=]
 </div>
 
 <div class='syntax' noexport='true'>
@@ -411,7 +411,7 @@
 
  | [=syntax/paren_left=] [=recursive descent syntax/expression=] [=syntax/paren_right=]
 
- | `'bitcast'` [=syntax/less_than=] [=recursive descent syntax/type_decl=] [=syntax/greater_than=] [=syntax/paren_left=] [=recursive descent syntax/expression=] [=syntax/paren_right=]
+ | `'bitcast'` [=syntax/less_than=] [=recursive descent syntax/type_specifier=] [=syntax/greater_than=] [=syntax/paren_left=] [=recursive descent syntax/expression=] [=syntax/paren_right=]
 </div>
 
 <div class='syntax' noexport='true'>
@@ -581,13 +581,13 @@
 
  | [=recursive descent syntax/depth_texture_type=]
 
- | [=recursive descent syntax/sampled_texture_type=] [=syntax/less_than=] [=recursive descent syntax/type_decl=] [=syntax/greater_than=]
+ | [=recursive descent syntax/sampled_texture_type=] [=syntax/less_than=] [=recursive descent syntax/type_specifier=] [=syntax/greater_than=]
 
  | [=recursive descent syntax/sampler_type=]
 
  | [=recursive descent syntax/storage_texture_type=] [=syntax/less_than=] [=recursive descent syntax/texel_format=] [=syntax/comma=] [=recursive descent syntax/access_mode=] [=syntax/greater_than=]
 
- | [=syntax/multisampled_texture_type=] [=syntax/less_than=] [=recursive descent syntax/type_decl=] [=syntax/greater_than=]
+ | [=syntax/multisampled_texture_type=] [=syntax/less_than=] [=recursive descent syntax/type_specifier=] [=syntax/greater_than=]
 </div>
 
 <div class='syntax' noexport='true'>
@@ -597,21 +597,21 @@
 </div>
 
 <div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>type_decl</dfn>:
+  <dfn for='recursive descent syntax'>type_specifier</dfn>:
 
  | [=recursive descent syntax/ident=]
 
- | [=recursive descent syntax/type_decl_without_ident=]
+ | [=recursive descent syntax/type_specifier_without_ident=]
 </div>
 
 <div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>type_decl_without_ident</dfn>:
+  <dfn for='recursive descent syntax'>type_specifier_without_ident</dfn>:
 
- | [=recursive descent syntax/mat_prefix=] [=syntax/less_than=] [=recursive descent syntax/type_decl=] [=syntax/greater_than=]
+ | [=recursive descent syntax/mat_prefix=] [=syntax/less_than=] [=recursive descent syntax/type_specifier=] [=syntax/greater_than=]
 
  | [=recursive descent syntax/texture_and_sampler_types=]
 
- | [=recursive descent syntax/vec_prefix=] [=syntax/less_than=] [=recursive descent syntax/type_decl=] [=syntax/greater_than=]
+ | [=recursive descent syntax/vec_prefix=] [=syntax/less_than=] [=recursive descent syntax/type_specifier=] [=syntax/greater_than=]
 
  | [=syntax/float16=]
 
@@ -619,13 +619,13 @@
 
  | [=syntax/int32=]
 
- | [=syntax/pointer=] [=syntax/less_than=] [=recursive descent syntax/address_space=] [=syntax/comma=] [=recursive descent syntax/type_decl=] ( [=syntax/comma=] [=recursive descent syntax/access_mode=] )? [=syntax/greater_than=]
+ | [=syntax/pointer=] [=syntax/less_than=] [=recursive descent syntax/address_space=] [=syntax/comma=] [=recursive descent syntax/type_specifier=] ( [=syntax/comma=] [=recursive descent syntax/access_mode=] )? [=syntax/greater_than=]
 
  | [=syntax/uint32=]
 
- | `'array'` [=syntax/less_than=] [=recursive descent syntax/type_decl=] ( [=syntax/comma=] [=recursive descent syntax/element_count_expression=] )? [=syntax/greater_than=]
+ | `'array'` [=syntax/less_than=] [=recursive descent syntax/type_specifier=] ( [=syntax/comma=] [=recursive descent syntax/element_count_expression=] )? [=syntax/greater_than=]
 
- | `'atomic'` [=syntax/less_than=] [=recursive descent syntax/type_decl=] [=syntax/greater_than=]
+ | `'atomic'` [=syntax/less_than=] [=recursive descent syntax/type_specifier=] [=syntax/greater_than=]
 
  | `'bool'`
 </div>


### PR DESCRIPTION
Closes https://github.com/gpuweb/gpuweb/issues/3356

This PR is kind of a mix of both ideas in the issue. I renamed the section name to Type Specifier instead of Type Declaration and renamed `type_decl` to `type` only. Of course, to do this, I had to either rename or inline the `type` token, which I chose to inline (maybe a good precedent to do elsewhere when an easy-to-read-when-inline just adds an unnecessary amount of top-level tokens?). Feedback appreciated; thank you!