### PR TITLE
wgsl: Fix link to WebGPU GPUExternalTexture

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3583,7 +3583,7 @@ but potentially with a different representation.
 It can be read using [[#textureload|textureLoad]] or [[#texturesamplelevel|textureSampleLevel]] built-in functions,
 which handle these different representations opaquely.
 
-See [[WebGPU#GPUExternalTexture]].
+See [[WebGPU#gpu-external-texture|WebGPU &sect; GPUExternalTexture]].
 
 ### Storage Texture Types ### {#texture-storage}
 


### PR DESCRIPTION
Addresses part 2 of #2920