### PR TITLE
wgsl: clarify type equivalence of arrays with overridable element counts

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1943,8 +1943,8 @@ Two array types are the same if and only if all of the following are true:
         equal-valued element counts, even if one is signed and the other is unsigned.
         (Signed and unsigned values are comparable in this case because element counts
         are always positive.)
-    * They are both fixed-sized with element count specified as the same
-        [=pipeline-overridable=] constant.
+    * They are both fixed-sized with element counts specified as identifiers [=resolve|resolving=]
+        to the same declaration of a [=pipeline-overridable=] constant.
 
 <div class='example wgsl fixed-size array types' heading='Example fixed-size array types, non-overridable element count'>
   <xmp highlight='rust'>
@@ -1975,7 +1975,16 @@ of a variable in [=address spaces/workgroup=] space.
     override blockSize = 16;
 
     var<workgroup> odds: array<i32,blockSize>;
-    var<workgroup> evens: array<i32,blockSize>;
+    var<workgroup> evens: array<i32,blockSize>; // Same type
+
+    // None of the following have the same type as `odds` and `evens.
+
+    // Different type: Not the identifier `blockSize`
+    var<workgroup> evens_0: array<i32,16>;
+    // Different type: Uses arithmetic to express the element count.
+    var<workgroup> evens_1: array<i32,(blockSize * 2 / 2)>;
+    // Different type: Uses parentheses, not just an identifier.
+    var<workgroup> evens_2: array<i32,(blockSize)>;
 
     // An invalid example, because the overridable element count may only occur
     // at the outer level.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1977,7 +1977,7 @@ of a variable in [=address spaces/workgroup=] space.
     var<workgroup> odds: array<i32,blockSize>;
     var<workgroup> evens: array<i32,blockSize>; // Same type
 
-    // None of the following have the same type as `odds` and `evens.
+    // None of the following have the same type as `odds` and `evens`.
 
     // Different type: Not the identifier `blockSize`
     var<workgroup> evens_0: array<i32,16>;

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1977,9 +1977,9 @@ of a variable in [=address spaces/workgroup=] space.
     var<workgroup> odds: array<i32,blockSize>;
     var<workgroup> evens: array<i32,blockSize>; // Same type
 
-    // None of the following have the same type as `odds` and `evens`.
+    // None of the following have the same type as 'odds' and 'evens'.
 
-    // Different type: Not the identifier `blockSize`
+    // Different type: Not the identifier 'blockSize'
     var<workgroup> evens_0: array<i32,16>;
     // Different type: Uses arithmetic to express the element count.
     var<workgroup> evens_1: array<i32,(blockSize * 2 / 2)>;

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1943,7 +1943,7 @@ Two array types are the same if and only if all of the following are true:
         equal-valued element counts, even if one is signed and the other is unsigned.
         (Signed and unsigned values are comparable in this case because element counts
         are always positive.)
-    * They are both fixed-sized with element counts specified as identifiers [=resolve|resolving=]
+    * They are both fixed-sized with element counts specified as identifiers [=resolves|resolving=]
         to the same declaration of a [=pipeline-overridable=] constant.
 
 <div class='example wgsl fixed-size array types' heading='Example fixed-size array types, non-overridable element count'>


### PR DESCRIPTION
Fixes: #3441