### PR TITLE
Fix WGSL spec build error

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7937,7 +7937,7 @@ Call sites are a [=dynamic context=].
 As such, the same textual location may represent multiple call sites.
 
 Note: It is possible that a function call in a [=fragment=] shader never
-returns if all of the invocations in a [=quad=] are discarded.
+returns if all of the invocations in a [=quad=] are [=statement/discard|discarded=].
 In such a case, control will not be tranferred back to the calling function.
 
 ## `const` Functions ## {#const-funcs}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7937,7 +7937,7 @@ Call sites are a [=dynamic context=].
 As such, the same textual location may represent multiple call sites.
 
 Note: It is possible that a function call in a [=fragment=] shader never
-returns if all of the invocations in a [=quad=] are [=discard|discarded=].
+returns if all of the invocations in a [=quad=] are discarded.
 In such a case, control will not be tranferred back to the calling function.
 
 ## `const` Functions ## {#const-funcs}


### PR DESCRIPTION
This only linked discard word was linking to browsingContext discard https://html.spec.whatwg.org/multipage/window-object.html#a-browsing-context-is-discarded before, and now it prevents spec from building successfully. There are 3 discarded words and two were not linked, so tentatively making this unlinked too.