### PR TITLE
wgsl: Rename "array_type" to "array_type_specifier"

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1998,7 +1998,7 @@ of a variable in [=address spaces/workgroup=] space.
 
 
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>array_type</dfn> :
+  <dfn for=syntax>array_type_specifier</dfn> :
 
     | [=syntax/array=] [=syntax/less_than=] [=syntax/type_specifier=] ( [=syntax/comma=] [=syntax/element_count_expression=] ) ? [=syntax/greater_than=]
 </div>
@@ -3791,7 +3791,7 @@ all properties of the members of *S*, including attributes, carry over to the me
 
     | [=syntax/pointer=] [=syntax/less_than=] [=syntax/address_space=] [=syntax/comma=] [=syntax/type_specifier=] ( [=syntax/comma=] [=syntax/access_mode=] ) ? [=syntax/greater_than=]
 
-    | [=syntax/array_type=]
+    | [=syntax/array_type_specifier=]
 
     | [=syntax/atomic=] [=syntax/less_than=] [=syntax/type_specifier=] [=syntax/greater_than=]
 


### PR DESCRIPTION
Improves consistency with the names of other type specifier grammar elements.