### PR TITLE
Fix ldexp constraints lost when SPIR-V mappings were removed

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12038,11 +12038,14 @@ Note: The result is not mathematically meaningful if `e` &le; 0.
   <tr>
     <td>Description
     <td>Returns `e1 * 2`<sup>`e2`</sup>, except:
-    <ul>
-    <li>The result may be zero if `e2` + *bias* &le; 0.
-    <li>The result is any value of type `T` if `e2` &gt; *bias* + 1.
-    </ul>
-    Where *bias* is the exponent bias of the floating point format.
+    * The result may be zero if `e2` + *bias* &le; 0.
+    * The result is any value of type `T` if `e2` &gt; *bias* + 1.
+
+    Here, *bias* is the exponent bias of the floating point format:
+    * 15 for `f16`
+    * 127 for `f32`
+    * 1023 for AbstractFloat, when AbstractFloat is [[!IEEE-754|IEEE-754]] binary64
+
 
     [=Component-wise=] when `T` is a vector.
 </table>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12037,7 +12037,13 @@ Note: The result is not mathematically meaningful if `e` &le; 0.
         `I` is [=type/concrete=] if and only if `T` is a [=type/concrete=]
   <tr>
     <td>Description
-    <td>Returns `e1 * 2`<sup>`e2`</sup>.
+    <td>Returns `e1 * 2`<sup>`e2`</sup>, except:
+    <ul>
+    <li>The result may be zero if `e2` + *bias* &le; 0.
+    <li>The result is any value of type `T` if `e2` &gt; *bias* + 1.
+    </ul>
+    Where *bias* is the exponent bias of the floating point format.
+
     [=Component-wise=] when `T` is a vector.
 </table>
 


### PR DESCRIPTION
When SPIR-V mappings were removed (#2594) we lost constraints on ldexp behaviour.