### PR TITLE
Clarify abstract shift left

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6032,16 +6032,12 @@ See [[#sync-builtin-functions]].
         The |e2|+1 most significant bits of |e1| [=shader-creation error|must=] have the same bit value.
         Otherwise overflow would occur.
 
-        (That is, all the discarded bits must be the same as the sign bit of the original value,
-        and the same as the sign bit the final value.)
+        Note: This condition means all the discarded bits must be the same as the sign bit of the original value,
+        and the same as the sign bit of the final value.
 
         The value of |e2| [=shader-creation error|must=] be at least 0.
 
         [=Component-wise=] when |T| is a vector.
-
-        In particular, a [=shader-creation error=] results in the vector case
-        if the scalar shift corresponding to *any* component position
-        would cause a shader-creation error.
 
   <tr algorithm="concrete shift right">
     <td>|e1|: |T|<br>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6011,7 +6011,7 @@ See [[#sync-builtin-functions]].
         and discarding the most significant bits.
 
         The number of bits to shift is the value of |e2|, modulo the bit width of |e1|.<br>
-        If |e2| is greater or equal to the bit width or |e1|, then:
+        If |e2| is greater or equal to the bit width of |e1|, then:
         * It is a [=shader-creation error=] if |e2| is a [=const-expression=].
         * It is a [=pipeline-creation error=] if |e2| is an [=override-expression=].
 
@@ -6029,12 +6029,19 @@ See [[#sync-builtin-functions]].
 
         The number of bits to shift is the value of |e2|.
 
-        [=Component-wise=] when |T| is a vector.
-
         The |e2|+1 most significant bits of |e1| [=shader-creation error|must=] have the same bit value.
         Otherwise overflow would occur.
 
-        It is a [=shader-creation error=] if any of the |e2| values are less than 0.
+        (That is, all the discarded bits must be the same as the sign bit of the original value,
+        and the same as the sign bit the final value.)
+
+        The value of |e2| [=shader-creation error|must=] be at least 0.
+
+        [=Component-wise=] when |T| is a vector.
+
+        In particular, a [=shader-creation error=] results in the vector case
+        if the scalar shift corresponding to *any* component position
+        would cause a shader-creation error.
 
   <tr algorithm="concrete shift right">
     <td>|e1|: |T|<br>


### PR DESCRIPTION
- Fix a typo
- Clarify the overflow case.
- Clarify the shader-creation errors for the vector case