### PR TITLE
Clarify flushing of conversions between different width float types

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9807,8 +9807,11 @@ the following exceptions:
 * Implementations may ignore the sign of a zero.
     That is, a zero with a positive sign may behave like a zero a with a negative sign, and vice versa.
 * No rounding mode is specified.
-* Implementations may flush denormalized value on the input and/or output of
-    any operation listed in [[#floating-point-accuracy]].
+* To <dfn noexport title="flushed to zero">flush to zero</dfn> is to replace a denormalized value for a floating point type
+    with a zero value of that type.
+    * Any inputs or outputs of operations listed in [[#floating-point-accuracy]] may be flushed to zero.
+    * Any inputs, outputs, or intermediate values of operations listed in 
+        [[#pack-builtin-functions]] or [[#unpack-builtin-functions]] may be flushed to zero.
     * Other operations are required to preserve denormalized numbers.
 * The accuracy of operations is given in [[#floating-point-accuracy]].
 
@@ -9925,6 +9928,7 @@ value with the same sign.
   <tr><td>`modf(x)`<td colspan=2 style="text-align:left;">Correctly rounded
   <tr><td>`normalize(x)`<td colspan=2 style="text-align:left;">Inherited from `x / length(x)`
   <tr><td>`pow(x, y)`<td colspan=2 style="text-align:left;">Inherited from `exp2(y * log2(x))`
+  <tr><td>`quantizeToF16(x)`<td colspan=2 style="text-align:left;">Correctly rounded
   <tr><td>`radians(x)`<td colspan=2 style="text-align:left;">Inherited from `x * 0.017453292519943295474`
   <tr><td>`reflect(x, y)`<td colspan=2 style="text-align:left;">Inherited from `x - 2.0 * dot(x, y) * y`
   <tr><td>`refract(x, y, z)`<td colspan=2 style="text-align:left;">Inherited from `z * x - (z * dot(y, x) + sqrt(k)) * y`,<br>where `k = 1.0 - z * z * (1.0 - dot(y, x) * dot(y, x))`<br>If `k < 0.0` the result is precisely 0.0
@@ -12380,8 +12384,13 @@ but a value may infer the type.
     <td>Description
     <td>Quantizes a 32-bit floating point value `e` as if `e` were converted to
         a [[!IEEE-754|IEEE 754]] binary16 value, and then converted back to a
-        IEEE 754 binary32 value.<br>
-        See [[#floating-point-conversion]].<br>
+        IEEE 754 binary32 value.
+
+        The intermediate binary16 value may be [=flushed to zero=], i.e. the final
+        result may be zero if the intermediate binary16 value is denormalized.
+
+        See [[#floating-point-conversion]].
+
         [=Component-wise=] when `T` is a vector.
   <tr>
     <td>
@@ -14352,6 +14361,9 @@ do not correspond directly to types in WGSL.
 This enables a program to write many densely packed values to memory, which can
 reduce a shader's memory bandwidth demand.
 
+Intermediate values of floating point type are [=correctly rounded=].
+Inputs, outputs, and intermediate values of floating point type may be [=flushed to zero=].
+
 ### `pack4x8snorm` ### {#pack4x8snorm-builtin}
 <table class='data builtin'>
   <tr algorithm="packing 4x8snorm">
@@ -14444,6 +14456,9 @@ Data unpacking builtin functions can be used to decode values in
 data formats that do not correspond directly to types in WGSL.
 This enables a program to read many densely packed values from memory, which can
 reduce a shader's memory bandwidth demand.
+
+Intermediate values of floating point type are [=correctly rounded=].
+Inputs, outputs, and intermediate values of floating point type may be [=flushed to zero=].
 
 ### `unpack4x8snorm` ### {#unpack4x8snorm-builtin}
 <table class='data builtin'>


### PR DESCRIPTION
- Add quantizeFTo16 to the "accuracy" table, as "correctly rounded", so we capture its potential rounding behaviours.
- Update quantizeToF16 to say the intermediate binary16 value may be flushed to zero, resulting in a final zero value.
- Defines "flush to zero" as a general term.
- Add that inputs, outputs, and intermediate values of data packing and unpacking builtins may be flushed to zero.
- Add a general note at data packing and unpacking builtins that they are correctly rounded. (Without adding all of them to the "accuracy table".

Fixes: #3421