### PR TITLE
Fix t parameterization of textureSampleLevel

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -14121,7 +14121,7 @@ fn textureSampleLevel(t: texture_depth_cube_array,
 
 <table class='data'>
   <tr><td>`t`<td>
-  The [sampled](#sampled-texture-type), [depth](#texture-depth), or [external](#external-texture-type) texture to
+  The [sampled](#sampled-texture-type) or [depth](#texture-depth) texture to
   sample.
   <tr><td>`s`<td>
   The [sampler type](#sampler-type).


### PR DESCRIPTION
Remove texture_external.

Sampling texture_external was previously moved to a different function.