### PR TITLE
Revert "Make getBGL return a "copy" instead of a "reference""

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6460,7 +6460,7 @@ interface mixin GPUPipelineBase {
                             |this|.{{GPUPipelineBase/[[layout]]}}.{{GPUPipelineLayout/[[bindGroupLayouts]]}}
                     </div>
 
-                1. Initialize |layout| so it is a copy of
+                1. Update |layout| to reference the same internal object as
                     |this|.{{GPUPipelineBase/[[layout]]}}.{{GPUPipelineLayout/[[bindGroupLayouts]]}}[|index|].
 
                 Issue: Specify this more properly once we have internal objects for {{GPUBindGroupLayout}}.


### PR DESCRIPTION
Reverts gpuweb/gpuweb#3341

I thought this was an editorial change, but it's not. See #3454

We should test this (test whether the label is shared or not).