### PR TITLE
[editorial] Type chapter clarifications

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1437,7 +1437,7 @@ A <dfn>feasible automatic conversion</dfn> converts a value from type *Src* to t
 Such conversions are value-preserving, subject to limitations described in [[#floating-point-evaluation]].
 
 Note: Automatic conversions only occur in two kinds of situations.
-First, when converting a [=const-declarations=] to its corresponding typed numeric value that can be used on the GPU.
+First, when converting a [=const-expression=] to its corresponding typed numeric value that can be used on the GPU.
 Second, when a load from a reference-to-memory occurs, yielding the value stored in that memory.
 
 Note: A conversion of infinite rank is infeasible, i.e. not allowed.
@@ -1645,7 +1645,8 @@ Example:  `1u + 2.5` results in a [=shader-creation error=]:
     // Explicitly-typed unsigned integer literal cannot be negated.
     var u32_neg = -1u; // invalid: unary minus does not support u32
 
-    // When the context does not force a concrete type, an integer literal is
+    // When a concrete type is required, but no part of the statement or
+    // expression forces a particular concrete type, an integer literal is
     // interpreted as an i32 value:
     //   Initializer for a let-declaration must be constructible (or pointer).
     //   The most preferred automatic conversion from AbstractInt to a constructible type
@@ -1967,8 +1968,9 @@ Two array types are the same if and only if all of the following are true:
   </xmp>
 </div>
 
-Note: The only valid use of an array sized by an overridable constant is as the store type
-of a variable in [=address spaces/workgroup=] space.
+Note: The only valid use of an array type sized by an overridable constant is
+as a [=memory view=] in the [=address spaces/workgroup=] address space.
+This includes the [=store type=] of a workgroup variable.
 
 <div class='example wgsl global-scope' heading="Workgroup variables sized by overridable constants">
   <xmp highlight='rust'>
@@ -2205,11 +2207,12 @@ The plain types with [=fixed footprint=] are any of:
 * a [=fixed-size array=] type (without further constraining its [=element count=])
 
 Note: The only valid use of a fixed-size array with an element count that is an
-[=override-expression=] that is not a [=const-expression=] is as the
-[=store type=] for a [=address spaces/workgroup=] variable.
+[=override-expression=] that is not a [=const-expression=] is as a
+[=memory view=] in the [=address spaces/workgroup=] address space.
+This includes the [=store type=] of a workgroup variable.
 
 Note: A fixed-footprint type may contain an [=atomic type|atomic=] type, either directly or
-indirectly, while a [=constructible=] type must not.
+indirectly, while a [=constructible=] type cannot.
 
 Note: Fixed-footprint types exclude [=runtime-sized=] arrays, and any structures or arrays
 that contain [=runtime-sized=] arrays, recursively.
@@ -2228,7 +2231,7 @@ in size. An operation affecting memory interacts with a set of one or more
 memory locations.
 
 Two sets of memory locations <dfn noexport>overlap</dfn> if the intersection of
-their sets of memory locations is non-empty. Each variable declaration has a
+their sets of memory locations is non-empty. Each [=variable declaration=] has a
 set of memory locations that does not overlap with the sets of memory locations of
 any other variable declaration. Memory operations on structures and arrays will
 not access padding memory locations.
@@ -3340,7 +3343,7 @@ In particular:
 * In WGSL a reference can't directly be declared as an alias to another reference or variable,
     either as a variable or as a formal parameter.
 * In WGSL pointers and references are not [=storable=].
-    That is, the content of a WGSL variable may not contain a pointer or a reference.
+    That is, the content of a WGSL [=variable declaration=] may not contain a pointer or a reference.
 * In WGSL a function [=shader-creation error|must not=] return a pointer or reference.
 * In WGSL there is no way to convert between integer values and pointer values.
 * In WGSL there is no way to forcibly change the type of a pointer value into another pointer type.


### PR DESCRIPTION
Fixes #2939
Fixes #2970
Fixes #3023
Fixes #3024
Fixes #3026

* Clarify example about type inference
* Clarify note about automatic conversions
* Clarify notes about overridable constant sized arrays
* Clarify fixed-footprint note
* Link to variable declarations