### PR TITLE
Restore arithmetic right shift, when LHS is signed

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6056,11 +6056,13 @@ See [[#sync-builtin-functions]].
     <td class="nowrap">|e1| >> |e2|: |T|
     <td>Shift right (concrete).
 
-        Shift |e1| right, inserting zero bits at the most significant positions,
-        and discarding the least significant bits.
+        Shift |e1| right, discarding the least significant bits.
+
+        If |S| is an unsigned type, insert zero bits at the most significant positions.
+        If |S| is a signed type, each inserted bit is a copy of the sign bit of |e1|.
 
         The number of bits to shift is the value of |e2|, modulo the bit width of |e1|.<br>
-        If |e2| is greater or equal to the bit width or |e1|, then:
+        If |e2| is greater than or equal to the bit width or |e1|, then:
         * It is a [=shader-creation error=] if |e2| is a [=const-expression=].
         * It is a [=pipeline-creation error=] if |e2| is an [=override-expression=].
 
@@ -6073,8 +6075,10 @@ See [[#sync-builtin-functions]].
     <td class="nowrap">|e1| >> |e2|: |T|
     <td>Shift right (abstract).
 
-        Shift |e1| right, inserting zero bits at the most significant positions,
-        and discarding the least significant bits.
+        Shift |e1| right, discarding the least significant bits.
+
+        If |e1| is negative, each inserted bit is 1, and so the result is also negative.
+        Otherwise, each inserted bit is 0.
 
         The number of bits to shift is the value of |e2|.
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6059,9 +6059,13 @@ See [[#sync-builtin-functions]].
         Shift |e1| right, discarding the least significant bits.
 
         If |S| is an unsigned type, insert zero bits at the most significant positions.
-        If |S| is a signed type, each inserted bit is a copy of the sign bit of |e1|.
 
-        The number of bits to shift is the value of |e2|, modulo the bit width of |e1|.<br>
+        If |S| is a signed type:
+        * If |e1| is negative, each inserted bit is 1, and so the result is also negative.
+        * Otherwise, each inserted bit is 0.
+
+        The number of bits to shift is the value of |e2|, modulo the bit width of |e1|.
+
         If |e2| is greater than or equal to the bit width or |e1|, then:
         * It is a [=shader-creation error=] if |e2| is a [=const-expression=].
         * It is a [=pipeline-creation error=] if |e2| is an [=override-expression=].


### PR DESCRIPTION
Fixes: #3461