### PR TITLE
Further qualify composite types as decomposible

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2135,6 +2135,7 @@ See [[#memory-layouts]].
 A type is <dfn noexport>composite</dfn> if it has internal structure
 expressed as a composition of other types.
 The internal parts do not overlap, and are called <dfn noexport>components</dfn>.
+A composite value may be decomposed into its components. See [[#composite-value-decomposition-expr]].
 
 The composite types are:
 


### PR DESCRIPTION
This more clearly indicates that atomic types are not composite. It adds a helpful cross-link.

Fixes: #3004