### PR TITLE
Explain why u32(AbstractInt) conversion expression exists

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5073,10 +5073,22 @@ For details on conversion to and from floating point types, see [[#floating-poin
       <td>|e|: bool<td>`u32(`|e|`)`: u32
       <td>Conversion of a boolean value to an unsigned integer.<br>
           The result is 1u if |e| is true and 0u otherwise.
-  <tr algorithm="scalar conversion from signed integer to unsigned integer">
-      <td>|e|: AbstractInt or i32<td>`u32(`|e|`)`: u32
+  <tr algorithm="scalar conversion from concrete signed integer to unsigned integer">
+      <td>|e|: i32<td>`u32(`|e|`)`: u32
       <td>Reinterpretation of bits.<br>
           The result is the unique value in [=u32=] that has the same bit pattern as |e|.
+  <tr algorithm="scalar conversion from abstract integer to unsigned integer">
+      <td>|e|: AbstractInt<td>`u32(`|e|`)`: u32
+      <td>Value conversion.
+
+          Identity if the value of |e| can be represented in u32.
+          Otherwise produces a [=shader-creation error=].
+
+          Note: This overload exists so expressions such as `u32(4*1000*1000*1000)`
+          can create a u32 value that would otherwise overflow the i32 type.
+          If this overload did not exist, [=overload resolution=] would select the `u32(i32)`
+          overload, the AbstractInt expression would automatically convert
+          to i32, and this would cause a shader-creation error due to overflow.
   <tr algorithm="scalar conversion from floating point to unsigned integer">
       <td>|e|: f32<td>`u32(`|e|`)`: u32
       <td>Value conversion, rounding toward zero.


### PR DESCRIPTION
Fixes: #2959