### PR TITLE
Allow u32s for attributes

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -836,7 +836,7 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
   </thead>
 
   <tr><td><dfn noexport dfn-for="attribute">`align`</dfn>
-    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=].<br>
+    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
         [=shader-creation error|Must=] be positive.
     <td>[=shader-creation error|Must=] only be applied to a member of a [=structure=] type.
 
@@ -854,7 +854,7 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     See [[#memory-layouts]]
 
   <tr><td><dfn noexport dfn-for="attribute">`binding`</dfn>
-    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=].<br>
+    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
         [=shader-creation error|Must=] be non-negative.
     <td>[=shader-creation error|Must=] only be applied to a [=resource=] variable.
 
@@ -881,7 +881,7 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     built-in functions can be used in [=const-expressions=].
 
   <tr><td><dfn noexport dfn-for="attribute">`group`</dfn>
-    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=].<br>
+    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
         [=shader-creation error|Must=] be non-negative.
     <td>[=shader-creation error|Must=] only be applied to a [=resource=] variable.
 
@@ -889,7 +889,7 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     See [[#resource-interface]].
 
   <tr><td><dfn noexport dfn-for="attribute">`id`</dfn>
-    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=].<br>
+    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
         [=shader-creation error|Must=] be non-negative.
     <td>[=shader-creation error|Must=] only be applied to an [=override-declaration=] of [=scalar=] type.
 
@@ -929,7 +929,7 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     `invariant` qualifier in GLSL.
 
   <tr><td><dfn noexport dfn-for="attribute">`location`</dfn>
-    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=].<br>
+    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
         [=shader-creation error|Must=] be non-negative.
     <td>[=shader-creation error|Must=] only be applied to an entry point function parameter, entry point
     return type, or member of a [=structure=] type.
@@ -941,7 +941,7 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     See [[#input-output-locations]].
 
   <tr><td><dfn noexport dfn-for="attribute">`size`</dfn>
-    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=].<br>
+    <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
         [=shader-creation error|Must=] be positive.
     <td>[=shader-creation error|Must=] only be applied to a member of a [=structure=] type.
     The member type [=shader-creation error|must=] have [=creation-fixed footprint=].


### PR DESCRIPTION
Fixes #3465

* Allow u32 attribute operand values in all appropriate places