### PR TITLE
textureSampelBaseClampToEdge clamps to half-texel from the edge

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -14225,7 +14225,7 @@ The sampled value.
 ### `textureSampleBaseClampToEdge` ### {#textureSampleBaseClampToEdge}
 
 Samples a texture view at its base level,
-with texture coordinates clamped to the [0, 1] range.
+with texture coordinates clamped to the edge as described below.
 
 <table class='data'>
   <thead>
@@ -14249,6 +14249,21 @@ fn textureSampleBaseClampToEdge(t: T,
   The [sampler type](#sampler-type).
   <tr><td>`coords`<td>
   The texture coordinates used for sampling.
+
+  Before sampling, the given coordinates will be clamped to the rectangle
+
+  > [ *half_texel*, 1 - *half_texel* ]
+
+  where
+
+  >  *half_texel* = vec2(0.5) / vec2&lt;f32&gt;(textureDimensions(t))
+
+  Note: The half-texel adjustment ensures that,
+  independent of the sampler's [[WebGPU#enumdef-gpuaddressmode|addressing]]
+  and [[WebGPU#enumdef-gpufiltermode|filter]] modes,
+  wrapping will not occur.
+  That is, when sampling near an edge, the sampled texels
+  will be at or adjacent to that edge, and not selected from the opposite edge.
 </table>
 
 **Returns:**


### PR DESCRIPTION
Fixes: #3471