### PR TITLE
Require effective storage buffer binding size be a multiple of 4

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5867,6 +5867,7 @@ following members:
                                                         includes {{GPUBufferUsage/STORAGE}}.
                                                     - [$effective buffer binding size$](|resource|) &le;
                                                         |limits|.{{supported limits/maxStorageBufferBindingSize}}.
+                                                    - [$effective buffer binding size$](|resource|) is a multiple of 4.
                                                     - |resource|.{{GPUBufferBinding/offset}} is a multiple of
                                                         |limits|.{{supported limits/minStorageBufferOffsetAlignment}}.
                                             </dl>


### PR DESCRIPTION
This patch restricts the effective storage buffer binding size be a multiple of 4 because on D3D12 we need to declare the storage buffer to RWByteAddressBuffer and on the API side we need to create a UAV with format DXGI_FORMAT_R32_TYPELESS, which requires that the element size be 4 byte aligned.