### PR TITLE
Streamline tokens

### DIFF
--- a/wgsl/extract-grammar.py
+++ b/wgsl/extract-grammar.py
@@ -10,6 +10,8 @@ import sys
 
 from tree_sitter import Language, Parser
 
+# TODO: Normalize space character in extract
+
 HEADER = """
 // Copyright (C) [$YEAR] World Wide Web Consortium,
 // (Massachusetts Institute of Technology, European Research Consortium for


### PR DESCRIPTION
**Preface:** Sectioning makes it very clear that these tokens are context-aware keywords. Furthermore, this change enables us to highlight the special case of const within the context-dependent name tokens section.

This PR removes the only place where keyword listing is not part of grammar, causing inconsistency in the first-pass-direct reading of tools. This change is the minimal way to get consistency by making all tokens part of the constituent or otherwise (making them tokens, the way this PR completes).

@dneto0 This change did not result in any problem with the more strict & important checks you wrote (we had a dialogue about this at the editors' call). Or am I not reading some failure reports in the CLI well? Sorry...

I also apologize if this PR becomes a mail-sore with too many notifications (I know people are a bit tired) because I should have made this a style guide when @dneto0 suggested I review the PR that initiated the list. I did overlook codifying this aspect back then, and I was not closely keeping an eye on the development around context-aware tokens and their grammar expression.