### PR TITLE
Object labels are per-GPUObjectBase

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -844,18 +844,24 @@ interface mixin GPUObjectBase {
 <dl dfn-type=attribute dfn-for=GPUObjectBase data-timeline=content>
     : <dfn>label</dfn>
     ::
-        Initially the empty string.
-
-        A developer-provided label which can be used by the browser, OS, or other tools to help
-        identify the underlying [=internal object=] to the developer. Examples include displaying
-        the label in error/warning messages, browser developer tools, and platform debugging
-        utilities.
+        A developer-provided label which is used in an implementation-defined way.
+        It can be used by the browser, OS, or other tools to help
+        identify the underlying [=internal object=] to the developer.
+        Examples include displaying the label in {{GPUError}} messages, console warnings,
+        browser developer tools, and platform debugging utilities.
 
         <div class=note>
             Note:
-            The user agent is free to choose if and how it will use this label.
-            For this reason, this specification does not define how the label is propagated to the
-            [=device timeline=].
+            The {{GPUObjectBase/label}} is a property of the {{GPUObjectBase}}.
+            Two {{GPUObjectBase}} "wrapper" objects have completely separate label states,
+            even if they refer to the same underlying object
+            (for example returned by {{GPUPipelineBase/getBindGroupLayout()}}).
+            The {{GPUObjectBase/label}} property will not change except by being set from JavaScript.
+
+            This means one underlying object could be associated with multiple labels.
+            This specification does not define how the label is propagated to the [=device timeline=].
+            How labels are used is completely implementation-defined: error messages could
+            show the most recently set label, all known labels, or no labels at all.
 
             It is defined as a {{USVString}} because some user agents may
             supply it to the debug facilities of the underlying native APIs.
@@ -6545,13 +6551,12 @@ interface mixin GPUPipelineBase {
                             |this|.{{GPUPipelineBase/[[layout]]}}.{{GPUPipelineLayout/[[bindGroupLayouts]]}}
                     </div>
 
-                1. Update |layout| to reference the same internal object as
+                1. Initialize |layout| so it is a copy of
                     |this|.{{GPUPipelineBase/[[layout]]}}.{{GPUPipelineLayout/[[bindGroupLayouts]]}}[|index|].
 
-                Issue: Specify this more properly once we have internal objects for {{GPUBindGroupLayout}}.
-                    Alternatively only spec is as a new internal objects that's [=group-equivalent=]
-
-                Note: Only returning new {{GPUBindGroupLayout}} objects ensures no synchronization is necessary
+                    Note: {{GPUBindGroupLayout}} is only ever used by-value, not by-reference,
+                    so this is equivalent to returning the same internal object in a new wrapper.
+                    A new {{GPUBindGroupLayout}} wrapper is returned each time to avoid a round-trip
                     between the [=Content timeline=] and the [=Device timeline=].
             </div>
         </div>


### PR DESCRIPTION
Fixes #3263

Fixes #3454 as obsolete.
Reverts #3455 / Relands #3341, while clarifying the non-normative note.