### PR TITLE
wgsl concretiation: use T2 instead of T'

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1528,11 +1528,10 @@ Note: When no conversion is performed, the conversion rank is zero.
 The type `T` is the <dfn noexport>concretization</dfn> of type `S` if:
 * `T` is not a reference type, and
 * ConversionRank(`S`, `T`) is finite, and
-* For any other non-reference type `T'`, ConversionRank(`S`, `T'`) > ConversionRank(`S`, `T`).
+* For any other non-reference type `T2`, ConversionRank(`S`, `T2`) > ConversionRank(`S`, `T`).
 
 The <dfn noexport>concretization of a value</dfn> `e` of type `T` is the value
-resulting from applying, to `e`, the feasible conversion that maps `T` to `T’`s
-concretization.
+resulting from applying, to `e`, the feasible conversion that maps `T` to the concretization of `T`.
 
 ### Overload Resolution ### {#overload-resolution-section}
 


### PR DESCRIPTION
This likely improves readability / accessibility.