### PR TITLE
wgsl: indexing X by non-const-expr index requires X to be concrete

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5397,16 +5397,36 @@ The result type depends on the number of letters provided. Assuming a `vec4<f32>
            |e|`.w`: |T|<br>
            |e|`.a`: |T|
        <td>Select the fourth component of |e|
-  <tr algorithm="vector indexed component selection"><td>|e|: vec|N|&lt;|T|&gt;<br>
-          |i|: [INT]
+
+  <tr algorithm="vector indexed component selection concrete">
+       <td>|e|: vec|N|&lt;|T|&gt;<br>
+           |i|: [INT]<br>
+           |T| is [=type/concrete=]
        <td class="nowrap">
            |e|[|i|]: |T|
        <td>Select the |i|'<sup>th</sup> component of vector<br>
-           The first component is at index |i|=0.<br>
+           The first component is at index |i|=0.
+
            If |i| is outside the range [0,|N|-1]:<br>
            * It is a [=shader-creation error=] if |i| is a [=const-expression=].
            * It is a [=pipeline-creation error=] if |i| is an [=override-expression=].
            * Otherwise any valid value for |T| may be returned.
+
+  <tr algorithm="vector indexed component selection abstract">
+       <td>|e|: vec|N|&lt;|T|&gt;<br>
+           |i|: [INT]<br>
+           |T| is [=type/abstract=]<br>
+           |i| is a [=const-expression=]
+       <td class="nowrap">
+           |e|[|i|]: |T|
+       <td>Select the |i|'<sup>th</sup> component of vector<br>
+           The first component is at index |i|=0.
+
+           It is a [=shader-creation error=] if |i| is outside the range [0,|N|-1].
+
+           Note: When an abstract vector value |e| is indexed by an expression that
+           is not a [=const-expression=], then the vector is
+           [=concretization of a value|concretized=] before the index is applied.
 </table>
 
 #### Vector Multiple Component Selection #### {#vector-multi-component}
@@ -5555,10 +5575,11 @@ See [[#sync-builtin-functions]].
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Description
   </thead>
-  <tr algorithm="matrix indexed column vector selection">
+  <tr algorithm="matrix indexed column vector selection concrete">
        <td class="nowrap">
           |e|: mat|C|x|R|&lt;|T|&gt;<br>
-          |i|: [INT]
+          |i|: [INT]<br>
+          |T| is [=type/concrete=]
        <td class="nowrap">
            |e|[|i|]: vec|R|&lt;|T|&gt;
        <td>The result is the |i|'<sup>th</sup> column vector of |e|.
@@ -5567,6 +5588,22 @@ See [[#sync-builtin-functions]].
            * It is a [=shader-creation error=] if |i| is a [=const-expression=].
            * It is a [=pipeline-creation error=] if |i| is an [=override-expression=].
            * Otherwise, any valid value for vec|R|&lt;|T|&gt; may be returned.
+
+  <tr algorithm="matrix indexed column vector selection abstract">
+       <td class="nowrap">
+          |e|: mat|C|x|R|&lt;|T|&gt;<br>
+          |i|: [INT]<br>
+          |T| is [=type/abstract=]<br>
+          |i| is a [=const-expression=]
+       <td class="nowrap">
+           |e|[|i|]: vec|R|&lt;|T|&gt;
+       <td>The result is the |i|'<sup>th</sup> column vector of |e|.
+
+           It is a [=shader-creation error=] if |i| is outside the range [0,|C|-1].
+
+           Note: When an abstract matrix value |e| is indexed by an expression that
+           is not a [=const-expression=], then the matrix is
+           [=concretization of a value|concretized=] before the index is applied.
 </table>
 
 <table class='data'>
@@ -5599,10 +5636,11 @@ See [[#sync-builtin-functions]].
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Description
   </thead>
-  <tr algorithm="fixed-size array indexed element selection">
+  <tr algorithm="fixed-size array indexed element selection concrete">
        <td class="nowrap">
           |e|: array&lt;|T|,|N|&gt;<br>
-          |i|: [INT]
+          |i|: [INT]<br>
+          |T| is [=type/concrete=]
        <td class="nowrap">
            |e|[|i|] : |T|
        <td>The result is the value of the |i|'<sup>th</sup> element of the array value |e|.
@@ -5611,6 +5649,22 @@ See [[#sync-builtin-functions]].
            * It is a [=shader-creation error=] if |i| is a [=const-expression=].
            * It is a [=pipeline-creation error=] if |i| is an [=override-expression=].
            * Otherwise, any valid value for |T| may be returned.
+
+  <tr algorithm="fixed-size array indexed element selection abstract">
+       <td class="nowrap">
+          |e|: array&lt;|T|,|N|&gt;<br>
+          |i|: [INT]<br>
+          |T| is [=type/abstract=]<br>
+          |i| is a [=const-expression=]
+       <td class="nowrap">
+           |e|[|i|] : |T|
+       <td>The result is the value of the |i|'<sup>th</sup> element of the array value |e|.
+
+           It is a [=shader-creation error=] if |i| is outside the range [0,|N|-1].
+
+           Note: When an abstract array value |e| is indexed by an expression that
+           is not a [=const-expression=], then the array is
+           [=concretization of a value|concretized=] before the index is applied.
 </table>
 
 <table class='data'>


### PR DESCRIPTION
Fixes: #3210

Split indexing rules by the thing being indexed as concrete vs. abstract. Abstract may be indexed by const-expr, but no other kinds of expressions. This forces concretization of the indexed object in the other cases.