### PR TITLE
[editorial] Replace "super-luminant" with a more descriptive term

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2049,13 +2049,13 @@ to represent color values outside of its space (in both chrominance and luminanc
 Issue(gpuweb/gpuweb#1715):
 Consider a path for uploading srgb-encoded images into linearly-encoded textures.
 
-A premultiplied RGBA value is <dfn dfn>super-luminant</dfn> if any of the R/G/B channel values
+An <dfn dfn>out-of-gamut premultiplied RGBA value</dfn> is one where any of the R/G/B channel values
 exceeds the alpha channel value. For example, the premultiplied sRGB RGBA value [1.0, 0, 0, 0.5]
-represents the (unpremultiplied) sRGB color [2, 0, 0] with alpha of 50%. Just like any color
-value outside the sRGB color gamut, this is a well defined point in the extended color space.
-(Except when alpha is 0, in which case there is no color.)
-
-Issue: Super-luminant is a confusing term because it doesn't really have anything to do with luminance.
+represents the (unpremultiplied) color [2, 0, 0] with 50% alpha, written `rgb(srgb 2 0 0 / 50%)` in CSS.
+Just like any color value outside the sRGB color gamut, this is a well defined point in the extended color space
+(except when alpha is 0, in which case there is no color).
+However, when such values are output to a visible canvas, the result is undefined
+(see {{GPUCanvasAlphaMode}} {{GPUCanvasAlphaMode/"premultiplied"}}).
 
 ### Color Space Conversions ### {#color-space-conversions}
 
@@ -2073,7 +2073,8 @@ Grayscale images generally represent RGB values `(V, V, V)`, or RGBA values `(V,
 Colors are not lossily clamped during conversion: converting from one color space to another
 will result in values outside the range [0, 1] if the source color values were outside the range
 of the destination color space's gamut. For an sRGB destination, for example, this can occur if the
-source is rgba16float, in a wider color space like Display-P3, or [=super-luminant=].
+source is rgba16float, in a wider color space like Display-P3, or is premultiplied and contains
+[=out-of-gamut premultiplied RGBA value|out-of-gamut values=].
 
 Similarly, if the source value has a high bit depth (e.g. PNG with 16 bits per component) or
 extended range (e.g. canvas with `float16` storage), these colors are preserved through color space
@@ -12879,44 +12880,41 @@ In WebGPU, it does so by [$Replace the drawing buffer|replacing the drawing buff
     </pre>
 </div>
 
-## <dfn dfn-type=enum-value dfn-for=GPUCanvasAlphaMode>GPUCanvasAlphaMode</dfn> ## {#GPUCanvasAlphaMode}
+## <dfn dfn-type=enum>GPUCanvasAlphaMode</dfn> ## {#GPUCanvasAlphaMode}
 
 This enum selects how the contents of the canvas will be interpreted when read, when
 [$update the rendering of the WebGPU canvas|rendered to the screen$] or
 [$get a copy of the image contents of a context|used as an image source$]
 (in drawImage, toDataURL, etc.)
 
-<table class=data>
-    <thead>
-        <tr>
-            <th>GPUCanvasAlphaMode
-            <th>Description
-            <th>dst.rgb
-            <th>dst.a
-    </thead>
-    <tr>
-        <td>{{GPUCanvasAlphaMode/opaque}}
-        <td>Read RGB as opaque and ignore alpha values.
-            If the content is not already opaque, the alpha channel is cleared to 1.0
-            when [$get a copy of the image contents of a context|used as an image source$] or
-            [$update the rendering of the WebGPU canvas|rendered to the screen$].
-        <td>`dst.rgb = src.rgb`
-        <td>`dst.a = 1`
-    <tr>
-        <td>{{GPUCanvasAlphaMode/premultiplied}}
-        <td>Read RGBA as premultiplied: color values are premultiplied by their alpha value.
-            100% red 50% opaque is [0.5, 0, 0, 0.5].
+Below, `src` is a value in the canvas texture, and `dst` is an image that the canvas
+is being composited into (e.g. an HTML page rendering, or a 2D canvas).
 
-            When [$get a copy of the image contents of a context|used as an image source$],
-            [=super-luminant=] values undergo [[#color-space-conversions|color space conversion]].
+<dl dfn-type=enum-value dfn-for=GPUCanvasAlphaMode>
+    : <dfn>"opaque"</dfn>
+    ::
+        Read RGB as opaque and ignore alpha values.
+        If the content is not already opaque, the alpha channel is cleared to 1.0
+        when [$get a copy of the image contents of a context|used as an image source$] or
+        [$update the rendering of the WebGPU canvas|rendered to the screen$].
 
-            When displayed to the screen, [=super-luminant=] values have undefined
-            compositing results. This is true even if color space conversion would result in
-            non-super-luminant values before compositing, because the intermediate format for
-            compositing is not specified.
-        <td>`dst.rgb = src.rgb + dst.rgb * (1 - src.a)`
-        <td>`dst.a = src.a + dst.a * (1 - src.a)`
-</table>
+    : <dfn>"premultiplied"</dfn>
+    ::
+        Read RGBA as premultiplied: color values are premultiplied by their alpha value.
+        100% red at 50% alpha is `[0.5, 0, 0, 0.5]`.
+
+        If [=out-of-gamut premultiplied RGBA values=] are output to the canvas, and the canvas is:
+
+        <dl class=switch>
+            : [$get a copy of the image contents of a context|used as an image source$]
+            :: Values are preserved, as described in [[#color-space-conversions|color space conversion]].
+
+            : displayed to the screen
+            :: Compositing results are undefined.
+                This is true even if color space conversion would produce in-gamut values before
+                compositing, because the intermediate format for compositing is not specified.
+        </dl>
+</dl>
 
 # Errors &amp; Debugging # {#errors-and-debugging}
 


### PR DESCRIPTION
Also removes the src/dst definitions of GPUCanvasAlphaModes, because blending should be (and is) defined by the spec that's doing the blending (e.g. HTML compositing, or 2D canvas), and we can't account for all the factors there (e.g. CSS `opacity`, or 2D canvas `globalAlpha`).