### PR TITLE
Only allow defined GPUMapMode bits in mapAsync()

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3482,17 +3482,14 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
 
                     <div class=validusage>
                         - |this| is a [=valid=] {{GPUBuffer}}.
-
-                            Issue: Figure out exactly how [=invalid=] and destroyed buffers are handled.
+                        - |this|.{{GPUBuffer/[[internals]]}}.[=buffer internals/state=] is "[=buffer internals/state/available=]".
                         - |offset| is a multiple of 8.
                         - |rangeSize| is a multiple of 4.
                         - |offset| + |rangeSize| &le; |this|.{{GPUBuffer/size}}
-                        - |this|.{{GPUBuffer/[[internals]]}}.[=buffer internals/state=] is "[=buffer internals/state/available=]".
+                        - |mode| contains only bits defined in {{GPUMapMode}}.
                         - |mode| contains exactly one of {{GPUMapMode/READ}} or {{GPUMapMode/WRITE}}.
                         - If |mode| contains {{GPUMapMode/READ}} then |this|.{{GPUBuffer/usage}} must contain {{GPUBufferUsage/MAP_READ}}.
                         - If |mode| contains {{GPUMapMode/WRITE}} then |this|.{{GPUBuffer/usage}} must contain {{GPUBufferUsage/MAP_WRITE}}.
-
-                        Issue: Do we validate that |mode| contains only valid flags?
                     </div>
 
                     Then:


### PR DESCRIPTION
This matches the handling of our other bitflags. ~Technically not editorial, but I'm taking the liberty of calling it editorial.~

Also remove another obsolete inline issue.