### PR TITLE
Only allow defined GPUShaderStage bits in bind group layout entries

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -5678,6 +5678,8 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
                             - Exactly one of |bufferLayout|, |samplerLayout|, |textureLayout|,
                                 or |storageTextureLayout| are not `undefined`.
 
+                            - |entry|.{{GPUBindGroupLayoutEntry/visibility}} contains only bits defined in {{GPUShaderStage}}.
+
                             - If |entry|.{{GPUBindGroupLayoutEntry/visibility}} includes
                                 {{GPUShaderStage/VERTEX}}:
                                 - |entry|.{{GPUBindGroupLayoutEntry/buffer}}?.{{GPUBufferBindingLayout/type}}


### PR DESCRIPTION
This matches the handling of our other bitflags. ~Technically not editorial, but I'm taking the liberty of calling it editorial.~

