### PR TITLE
Don't trail with empty BGLs in default pipeline layout

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6571,6 +6571,7 @@ unexpected bind group creation errors.
 To create a <dfn abstract-op>default pipeline layout</dfn> for {{GPUPipelineBase}} |pipeline|,
 run the following steps:
 
+    1. Let |groupCount| be 0.
     1. Let |groupDescs| be a sequence of |device|.{{device/[[limits]]}}.{{supported limits/maxBindGroups}}
         new {{GPUBindGroupLayoutDescriptor}} objects.
     1. For each |groupDesc| in |groupDescs|:
@@ -6655,6 +6656,8 @@ run the following steps:
 
                 1. Set |entry|.{{GPUBindGroupLayoutEntry/storageTexture}} to |storageTextureLayout|.
 
+            1. Set |groupCount| to max(|groupCount|, |group| + 1).
+
             1. If |groupDescs|[|group|] has an entry |previousEntry| with {{GPUBindGroupLayoutEntry/binding}} equal to |binding|:
 
                 1. If |entry| has different {{GPUBindGroupLayoutEntry/visibility}} than |previousEntry|:
@@ -6683,9 +6686,9 @@ run the following steps:
 
                 1. Append |entry| to |groupDescs|[|group|].
 
-    1. Let |groupLayouts| be a new [=sequence=].
-    1. For each |groupDesc| in |groupDescs|:
-
+    1. Let |groupLayouts| be a new [=list=].
+    1. For each |i| from 0 to |groupCount| - 1, inclusive:
+        1. Let |groupDesc| be |groupDescs|[|i|].
         1. Let |bindGroupLayout| be the result of calling |device|.{{GPUDevice/createBindGroupLayout()}}(|groupDesc|).
         1. Set |bindGroupLayout|.{{GPUBindGroupLayout/[[exclusivePipeline]]}} to |pipeline|.
         1. Append |bindGroupLayout| to |groupLayouts|.
@@ -6693,8 +6696,6 @@ run the following steps:
     1. Let |desc| be a new {{GPUPipelineLayoutDescriptor}}.
     1. Set |desc|.{{GPUPipelineLayoutDescriptor/bindGroupLayouts}} to |groupLayouts|.
     1. Return |device|.{{GPUDevice/createPipelineLayout()}}(|desc|).
-
-    Issue: This fills the pipeline layout with empty bindgroups. Revisit once the behavior of empty bindgroups is specified.
 </div>
 
 ### <dfn dictionary>GPUProgrammableStage</dfn> ### {#GPUProgrammableStage}


### PR DESCRIPTION
The default pipeline layout algorithm should only output BGLs up to the highest `group` index used, rather than up to the maximum.

Without this, draw/dispatch would require setBindGroup for all 4 groups, even if you use fewer.

This is related to issue #2043, but I think only holes in the middle of the layout are an open question.