### PR TITLE
Don't throw exception when getBindGroupLayout index > maxBindGroups

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6526,9 +6526,6 @@ interface mixin GPUPipelineBase {
 
                 [=Content timeline=] steps:
 
-                1. If |index| &ge;
-                    |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroups}}:
-                    1. Throw a {{RangeError}}.
                 1. Let |layout| be a new {{GPUBindGroupLayout}} object.
                 1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
                 1. Return |layout|.


### PR DESCRIPTION
This can be handled by returning an invalid GPUBindGroupLayout instead, as we do if the index is past the end of the actual BGL list (just below in the device timeline validation steps).

Since getBindGroupLayout returns a new JS wrapper every time, there's no concern about that behavior in this case. I suspect that's why we had an exception to begin with.

This exception dates back to when we added getBindGroupLayout originally, in #543.