### PR TITLE
Clarify behaviour of pack2x16float, quantizeToF16 for large inputs

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12536,6 +12536,9 @@ but a value may infer the type.
         a [[!IEEE-754|IEEE 754]] binary16 value, and then converted back to a
         IEEE 754 binary32 value.
 
+        If `e` is outside the finite range of binary16, then the result is any
+        value of type f32.
+
         The intermediate binary16 value may be [=flushed to zero=], i.e. the final
         result may be zero if the intermediate binary16 value is denormalized.
 
@@ -14616,6 +14619,9 @@ Note: For packing snorm values, the normalized floating point values are in the 
         16 &times; `i` through
         16 &times; `i` + 15 of the result.
         See [[#floating-point-conversion]].
+
+        If either `e[0]` or `e[1]` is outside the finite range of binary16
+        then the result is any value of type u32.
 </table>
 
 ## Data Unpacking Built-in Functions ## {#unpack-builtin-functions}


### PR DESCRIPTION
Allow what may happen on conformant Vulkan implementations.

Fixes: #3470