### PR TITLE
wgsl: Define "indeterminate value"

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4574,6 +4574,8 @@ Each distinct evaluation of the expression may yield a distinct value.
 For example, if the evaluation occurs once per iteration of a loop, a distinct
 value may be computed for each loop iteration.
 
+Note: If the type is a floating point type supporting a NaN value, then
+the indeterminate value produced at runtime may be a NaN value.
 
 <div class='example wgsl global-scope' heading="Indeterminate value example">
   <xmp highlight='rust'>
@@ -4603,6 +4605,21 @@ value may be computed for each loop iteration.
        }
        if extracted_value[0] == extracted_values[1] {
           // This might be executed, but might not be executed.
+       }
+    }
+
+    fn float_fun(runtime_index: u32) {
+       const v = vec2<f32>(0,1); // A vector of floating point values
+
+       // As in the previous example, 'float_extract' is an indeterminate value.
+       // Since it is a floating point type, it may be a NaN.
+       let float_extract: f32 = v[runtime_index+5];
+
+       if float_extract == float_extract {
+          // This *might not* be executed, because:
+          //  -  'float_extract' may be NaN, and
+          //  -  a NaN is never equal to any other floating point number,
+          //     even another NaN.
        }
     }
   </xmp>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4564,17 +4564,17 @@ Example: `vec3(x,x,x)` is analyzed as follows:
 ## Indeterminate values ## {#indeterminate-values}
 
 In limited cases, an evaluation of a [=runtime expression=] can occur
-using nonsense or unsupported values for its [=subexpressions=].
+using unsupported values for its [=subexpressions=].
 
 In such a case, WGSL specifies that the result of that evaluation is
 an <dfn>indeterminate value</dfn> of the expression's [=static type=],
 meaning some arbitrary implementation-chosen value of the static type.
 
-Each distinct evaluation of the expression may yield a distinct value.
+A distinct value may be produced for each unique [=dynamic context=] in which the expression is evaluated.
 For example, if the evaluation occurs once per iteration of a loop, a distinct
 value may be computed for each loop iteration.
 
-Note: If the type is a floating point type supporting a NaN value, then
+Note: If the type is a floating point type and the implementation supports NaN values, then
 the indeterminate value produced at runtime may be a NaN value.
 
 <div class='example wgsl global-scope' heading="Indeterminate value example">

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4566,7 +4566,7 @@ Example: `vec3(x,x,x)` is analyzed as follows:
 In limited cases, an evaluation of a [=runtime expression=] can occur
 using unsupported values for its [=subexpressions=].
 
-In such a case, WGSL specifies that the result of that evaluation is
+In such a case, the result of that evaluation is
 an <dfn>indeterminate value</dfn> of the expression's [=static type=],
 meaning some arbitrary implementation-chosen value of the static type.
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4561,6 +4561,54 @@ Example: `vec3(x,x,x)` is analyzed as follows:
 * The type of the expression is a [=vector=] of 3 components
     of [=i32=] (`vec3<i32>`).
 
+## Indeterminate values ## {#indeterminate-values}
+
+In limited cases, an evaluation of a [=runtime expression=] can occur
+using nonsense or unsupported values for its [=subexpressions=].
+
+In such a case, WGSL specifies that the result of that evaluation is
+an <dfn>indeterminate value</dfn> of the expression's [=static type=],
+meaning some arbitrary implementation-chosen value of the static type.
+
+Each distinct evaluation of the expression may yield a distinct value.
+For example, if the evaluation occurs once per iteration of a loop, a distinct
+value may be computed for each loop iteration.
+
+
+<div class='example wgsl global-scope' heading="Indeterminate value example">
+  <xmp highlight='rust'>
+    fn fun() {
+       var extracted_values: array<i32,2>;
+       const v = vec2<i32>(0,1);
+
+       for (var i: i32 = 0; i < 2 ; i++) {
+          // A runtime-expression used to index a vector, but outside the
+          // indexing bounds of the vector, produces an indeterminate value
+          // of the vector component type.
+          let extract = v[i+5];
+
+          // Now 'extract' is any value of type i32.
+
+          // Save it for later.
+          extracted_values[i] = extract;
+
+          if extract == extract {
+             // This is always executed
+          }
+          if extract < 2 {
+             // This might be executed, but might not be executed.
+             // Even though the original vector components are 0 and 1,
+             // the extracted value might not be either of those values.
+          }
+       }
+       if extracted_value[0] == extracted_values[1] {
+          // This might be executed, but might not be executed.
+       }
+    }
+  </xmp>
+</div>
+
+
 ## Literal Value Expressions ## {#literal-expressions}
 
 <table class='data'>
@@ -5416,7 +5464,7 @@ The result type depends on the number of letters provided. Assuming a `vec4<f32>
            If |i| is outside the range [0,|N|-1]:<br>
            * It is a [=shader-creation error=] if |i| is a [=const-expression=].
            * It is a [=pipeline-creation error=] if |i| is an [=override-expression=].
-           * Otherwise any valid value for |T| may be returned.
+           * Otherwise an [=indeterminate value=] for |T| may be returned.
 
   <tr algorithm="vector indexed component selection abstract">
        <td>|e|: vec|N|&lt;|T|&gt;<br>
@@ -5593,7 +5641,7 @@ See [[#sync-builtin-functions]].
            If |i| is outside the range [0,|C|-1]:<br>
            * It is a [=shader-creation error=] if |i| is a [=const-expression=].
            * It is a [=pipeline-creation error=] if |i| is an [=override-expression=].
-           * Otherwise, any valid value for vec|R|&lt;|T|&gt; may be returned.
+           * Otherwise, an [=indeterminate value=] for vec|R|&lt;|T|&gt; may be returned.
 
   <tr algorithm="matrix indexed column vector selection abstract">
        <td class="nowrap">
@@ -5654,7 +5702,7 @@ See [[#sync-builtin-functions]].
            If |i| is outside the range [0,|N|-1]:<br>
            * It is a [=shader-creation error=] if |i| is a [=const-expression=].
            * It is a [=pipeline-creation error=] if |i| is an [=override-expression=].
-           * Otherwise, any valid value for |T| may be returned.
+           * Otherwise, an [=indeterminate value=] for |T| may be returned.
 
   <tr algorithm="fixed-size array indexed element selection abstract">
        <td class="nowrap">
@@ -12188,7 +12236,10 @@ Note: The result is not mathematically meaningful if `e` &le; 0.
     <td>Description
     <td>Returns `e1 * 2`<sup>`e2`</sup>, except:
     * The result may be zero if `e2` + *bias* &le; 0.
-    * The result is any value of type `T` if `e2` &gt; *bias* + 1.
+    * If `e2` &gt; *bias* + 1
+         * It is a [=shader-creation error=] if `e2` is a [=const-expression=].
+         * It is a [=pipeline-creation error=] if `e2` is an [=override-expression=].
+         * Otherwise the result is an [=indeterminate value=] for `T`.
 
     Here, *bias* is the exponent bias of the floating point format:
     * 15 for `f16`
@@ -13071,7 +13122,7 @@ The dimensions of the texture in texels.
 For textures based on cubes, the results are the dimensions of each face of the cube.
 Cube faces are square, so the x and y components of the result are equal.
 
-If `level` is outside the range `[0, textureNumLevels(t))` then any valid value
+If `level` is outside the range `[0, textureNumLevels(t))` then an [=indeterminate value=]
 for the return type may be returned.
 
 ### `textureGather` ### {#texturegather}


### PR DESCRIPTION
Also tightens ldexp such that it can generate shader-creation or pipeline-creation error when given an unsupported exponent argument.

Fixes: #2888