### PR TITLE
[editorial] Move texture extent algorithms to texture section

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1205,86 +1205,6 @@ The [=subresources=] of textures included in the views provided to
 {{GPURenderPassColorAttachment/resolveTarget|GPURenderPassColorAttachment.resolveTarget}}
 are considered to be used as [=internal usage/attachment=] for the [=usage scope=] of this render pass.
 
-Issue: Move the following into the [[#textures]] section.
-
-The <dfn dfn>logical miplevel-specific texture extent</dfn> of a [=texture=] is the size of the
-[=texture=] in texels at a specific miplevel. It is calculated by this procedure:
-
-<div algorithm>
-    <dfn abstract-op>Logical miplevel-specific texture extent</dfn>(descriptor, mipLevel)
-
-    **Arguments:**
-
-    - {{GPUTextureDescriptor}} |descriptor|
-    - {{GPUSize32}} |mipLevel|
-
-    **Returns:** {{GPUExtent3DDict}}
-
-    1. Let |extent| be a new {{GPUExtent3DDict}} object.
-    1. If |descriptor|.{{GPUTextureDescriptor/dimension}} is:
-
-        <dl class=switch>
-            : {{GPUTextureDimension/"1d"}}
-            ::
-                - Set |extent|.{{GPUExtent3DDict/width}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] &Gt; |mipLevel|).
-                - Set |extent|.{{GPUExtent3DDict/height}} to 1.
-                - Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=].
-
-            : {{GPUTextureDimension/"2d"}}
-            ::
-                - Set |extent|.{{GPUExtent3DDict/width}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] &Gt; |mipLevel|).
-                - Set |extent|.{{GPUExtent3DDict/height}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] &Gt; |mipLevel|).
-                - Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=].
-
-            : {{GPUTextureDimension/"3d"}}
-            ::
-                - Set |extent|.{{GPUExtent3DDict/width}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] &Gt; |mipLevel|).
-                - Set |extent|.{{GPUExtent3DDict/height}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] &Gt; |mipLevel|).
-                - Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] &Gt; |mipLevel|).
-        </dl>
-    1. Return |extent|.
-</div>
-
-The <dfn dfn>physical miplevel-specific texture extent</dfn> of a [=texture=] is the size of the
-[=texture=] in texels at a specific miplevel that includes the possible extra padding
-to form complete [=texel blocks=] in the [=texture=]. It is calculated by this procedure:
-
-<div algorithm>
-    <dfn abstract-op>Physical miplevel-specific texture extent</dfn>(descriptor, mipLevel)
-
-    **Arguments:**
-
-    - {{GPUTextureDescriptor}} |descriptor|
-    - {{GPUSize32}} |mipLevel|
-
-    **Returns:** {{GPUExtent3DDict}}
-
-    1. Let |extent| be a new {{GPUExtent3DDict}} object.
-    1. Let |logicalExtent| be [=logical miplevel-specific texture extent=](|descriptor|, |mipLevel|).
-    1. If |descriptor|.{{GPUTextureDescriptor/dimension}} is:
-
-        <dl class=switch>
-            : {{GPUTextureDimension/"1d"}}
-            ::
-                - Set |extent|.{{GPUExtent3DDict/width}} to |logicalExtent|.[=Extent3D/width=] rounded up to the nearest multiple of |descriptor|'s [=texel block width=].
-                - Set |extent|.{{GPUExtent3DDict/height}} to 1.
-                - Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |logicalExtent|.[=Extent3D/depthOrArrayLayers=].
-
-            : {{GPUTextureDimension/"2d"}}
-            ::
-                - Set |extent|.{{GPUExtent3DDict/width}} to |logicalExtent|.[=Extent3D/width=] rounded up to the nearest multiple of |descriptor|'s [=texel block width=].
-                - Set |extent|.{{GPUExtent3DDict/height}} to |logicalExtent|.[=Extent3D/height=] rounded up to the nearest multiple of |descriptor|'s [=texel block height=].
-                - Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |logicalExtent|.[=Extent3D/depthOrArrayLayers=].
-
-            : {{GPUTextureDimension/"3d"}}
-            ::
-                - Set |extent|.{{GPUExtent3DDict/width}} to |logicalExtent|.[=Extent3D/width=] rounded up to the nearest multiple of |descriptor|'s [=texel block width=].
-                - Set |extent|.{{GPUExtent3DDict/height}} to |logicalExtent|.[=Extent3D/height=] rounded up to the nearest multiple of |descriptor|'s [=texel block height=].
-                - Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |logicalExtent|.[=Extent3D/depthOrArrayLayers=].
-        </dl>
-    1. Return |extent|.
-</div>
-
 ### Synchronization ### {#programming-model-synchronization}
 
 For each [=subresource=] of a [=physical resource=], its set of
@@ -3740,8 +3660,6 @@ A {{GPUTextureDimension/"3d"}} texture may have multiple <dfn dfn>slice</dfn>s, 
 two-dimensional image at a particular `z` value in the texture.
 Slices are not separate subresources.
 
-{{GPUTexture}}s are created via {{GPUDevice/createTexture()}}.
-
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUTexture {
@@ -3835,7 +3753,87 @@ GPUTexture includes GPUObjectBase;
 
 Issue: share this definition with the part of the specification that describes sampling.
 
+The <dfn dfn>logical miplevel-specific texture extent</dfn> of a [=texture=] is the size of the
+[=texture=] in texels at a specific miplevel. It is calculated by this procedure:
+
+<div algorithm>
+    <dfn abstract-op>Logical miplevel-specific texture extent</dfn>(descriptor, mipLevel)
+
+    **Arguments:**
+
+    - {{GPUTextureDescriptor}} |descriptor|
+    - {{GPUSize32}} |mipLevel|
+
+    **Returns:** {{GPUExtent3DDict}}
+
+    1. Let |extent| be a new {{GPUExtent3DDict}} object.
+    1. If |descriptor|.{{GPUTextureDescriptor/dimension}} is:
+
+        <dl class=switch>
+            : {{GPUTextureDimension/"1d"}}
+            ::
+                - Set |extent|.{{GPUExtent3DDict/width}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] &Gt; |mipLevel|).
+                - Set |extent|.{{GPUExtent3DDict/height}} to 1.
+                - Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=].
+
+            : {{GPUTextureDimension/"2d"}}
+            ::
+                - Set |extent|.{{GPUExtent3DDict/width}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] &Gt; |mipLevel|).
+                - Set |extent|.{{GPUExtent3DDict/height}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] &Gt; |mipLevel|).
+                - Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=].
+
+            : {{GPUTextureDimension/"3d"}}
+            ::
+                - Set |extent|.{{GPUExtent3DDict/width}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] &Gt; |mipLevel|).
+                - Set |extent|.{{GPUExtent3DDict/height}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/height=] &Gt; |mipLevel|).
+                - Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=] &Gt; |mipLevel|).
+        </dl>
+    1. Return |extent|.
+</div>
+
+The <dfn dfn>physical miplevel-specific texture extent</dfn> of a [=texture=] is the size of the
+[=texture=] in texels at a specific miplevel that includes the possible extra padding
+to form complete [=texel blocks=] in the [=texture=]. It is calculated by this procedure:
+
+<div algorithm>
+    <dfn abstract-op>Physical miplevel-specific texture extent</dfn>(descriptor, mipLevel)
+
+    **Arguments:**
+
+    - {{GPUTextureDescriptor}} |descriptor|
+    - {{GPUSize32}} |mipLevel|
+
+    **Returns:** {{GPUExtent3DDict}}
+
+    1. Let |extent| be a new {{GPUExtent3DDict}} object.
+    1. Let |logicalExtent| be [=logical miplevel-specific texture extent=](|descriptor|, |mipLevel|).
+    1. If |descriptor|.{{GPUTextureDescriptor/dimension}} is:
+
+        <dl class=switch>
+            : {{GPUTextureDimension/"1d"}}
+            ::
+                - Set |extent|.{{GPUExtent3DDict/width}} to |logicalExtent|.[=Extent3D/width=] rounded up to the nearest multiple of |descriptor|'s [=texel block width=].
+                - Set |extent|.{{GPUExtent3DDict/height}} to 1.
+                - Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |logicalExtent|.[=Extent3D/depthOrArrayLayers=].
+
+            : {{GPUTextureDimension/"2d"}}
+            ::
+                - Set |extent|.{{GPUExtent3DDict/width}} to |logicalExtent|.[=Extent3D/width=] rounded up to the nearest multiple of |descriptor|'s [=texel block width=].
+                - Set |extent|.{{GPUExtent3DDict/height}} to |logicalExtent|.[=Extent3D/height=] rounded up to the nearest multiple of |descriptor|'s [=texel block height=].
+                - Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |logicalExtent|.[=Extent3D/depthOrArrayLayers=].
+
+            : {{GPUTextureDimension/"3d"}}
+            ::
+                - Set |extent|.{{GPUExtent3DDict/width}} to |logicalExtent|.[=Extent3D/width=] rounded up to the nearest multiple of |descriptor|'s [=texel block width=].
+                - Set |extent|.{{GPUExtent3DDict/height}} to |logicalExtent|.[=Extent3D/height=] rounded up to the nearest multiple of |descriptor|'s [=texel block height=].
+                - Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |logicalExtent|.[=Extent3D/depthOrArrayLayers=].
+        </dl>
+    1. Return |extent|.
+</div>
+
 ### Texture Creation ### {#texture-creation}
+
+{{GPUTexture}}s are created via {{GPUDevice/createTexture()}}.
 
 <script type=idl>
 dictionary GPUTextureDescriptor : GPUObjectDescriptorBase {


### PR DESCRIPTION
No text is changed, only moved.

Trivial, landing without review