### PR TITLE
[editorial] Consolidate "Detailed Operations" issues into one issue

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -13555,7 +13555,7 @@ a list of vertices to process for each instance.
     and other properties of |drawCall| are read from the indirect buffer
     instead of the draw command itself.
 
-    Issue: specify indirect commands better.
+    <p class="note editorial">Editorial: specify indirect commands better.
 </div>
 
 <div algorithm>
@@ -13746,7 +13746,7 @@ Primitives are assembled by a fixed-function stage of GPUs.
 Vertex shaders have to produce a built-in "position" (of type `vec4<f32>`),
 which denotes the <dfn dfn>clip position</dfn> of a vertex.
 
-Issue: link to WGSL built-ins
+<p class="note editorial">Editorial: link to WGSL built-ins
 
 Primitives are clipped to the <dfn dfn>clip volume</dfn>, which, for any [=clip position=] |p|
 inside a primitive, is defined by the following inequalities:
@@ -13804,7 +13804,7 @@ The clipped shader output |c|.v is produced based on the interpolation qualifier
         |c|.v = |t| &times; |a|.v &plus; (1 &minus; |t|) &times; |b|.v
 </dl>
 
-Issue: link to interpolation qualifiers in WGSL
+<p class="note editorial">Editorial: link to interpolation qualifiers in WGSL
 
 The result of primitive clipping is a new set of primitives, which are contained
 within the [=clip volume=].

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -122,6 +122,12 @@ p, ul, ol, dl {
     margin: 1em 0;
 }
 
+/* Styling for "editorial" issues */
+.note.editorial {
+    border-color: var(--note-editorial-border);
+    background: var(--note-editorial-bg);
+}
+
 /* Our SVGs aren't responsive to light/dark mode, so they're opaque with a
  * white or black background. Rounded corners make them a bit less jarring. */
 object[type="image/svg+xml"] {
@@ -383,6 +389,8 @@ thead.stickyheader th, th.stickyheader {
     --tint-green: rgba(0, 255, 0, 10%);
     --tint-blue: rgba(0, 0, 255, 5%);
     --tint-purple: rgba(255, 0, 255, 5%);
+    --note-editorial-border: #ffa500;
+    --note-editorial-bg: #ffeedd;
 }
 @media (prefers-color-scheme:dark) {
     :root {
@@ -392,6 +400,8 @@ thead.stickyheader th, th.stickyheader {
         --tint-green: rgba(0, 255, 0, 18%);
         --tint-blue: rgba(0, 130, 255, 24%);
         --tint-purple: rgba(255, 0, 255, 22%);
+        --note-editorial-border: #ffa500;
+        --note-editorial-bg: var(--borderedblock-bg);
     }
 }
 </style>
@@ -13408,9 +13418,11 @@ partial interface GPUDevice {
 
 This section describes the details of various GPU operations.
 
+Issue: This section is incomplete.
+
 ## Transfer ## {#transfer-operations}
 
-Issue: describe the transfers at the high level
+<p class="note editorial">Editorial: describe the transfers at the high level
 
 ## Computing ## {#computing-operations}
 
@@ -13423,7 +13435,7 @@ These operations are encoded within {{GPUComputePassEncoder}} as:
 - {{GPUComputePassEncoder/dispatchWorkgroups()}}
 - {{GPUComputePassEncoder/dispatchWorkgroupsIndirect()}}
 
-Issue: describe the computing algorithm
+<p class="note editorial">Editorial: describe the computing algorithm
 
 The [=device=] may become [=lose the device|lost=] if
 [[WGSL#shader-execution-end|shader execution does not end]]
@@ -13500,11 +13512,11 @@ The main rendering algorithm:
 
         1. **Process depth/stencil**.
 
-            Issue: fill out the section, using |fragments|
+            <p class="note editorial">Editorial: fill out the section, using |fragments|
 
         1. **Write pixels**.
 
-            Issue: fill out the section
+            <p class="note editorial">Editorial: fill out the section
 </div>
 
 ### Index Resolution ### {#index-resolution}
@@ -13724,7 +13736,7 @@ Primitives are assembled by a fixed-function stage of GPUs.
                 Each subsequent primitive takes 1 vertices.
         </dl>
 
-        Issue: should this be defined more formally?
+        <p class="note editorial">Editorial: should this be defined more formally?
 
         Any incomplete primitives are dropped.
 </div>
@@ -13783,7 +13795,7 @@ The clipped shader output |c|.v is produced based on the interpolation qualifier
         The interpolation ratio gets adjusted against the perspective coordinates of the
         [=clip position=]s, so that the result of interpolation is linear in screen space.
 
-        Issue: provide more specifics here, if possible
+        <p class="note editorial">Editorial: provide more specifics here, if possible
 
     : "perspective"
     ::
@@ -13843,7 +13855,7 @@ Rasterization produces a list of <dfn dfn>RasterizationPoint</dfn>s, each contai
     :: refers to [[#barycentric-coordinates]]
 </dl>
 
-Issue: define the depth computation algorithm
+<p class="note editorial">Editorial: define the depth computation algorithm
 
 <div algorithm>
     <dfn abstract-op>rasterize</dfn>(primitiveList, state)
@@ -13871,11 +13883,11 @@ Issue: define the depth computation algorithm
 
         framebufferCoords(|n|) = vector(|vp|.`x` &plus; 0.5 &times; (|n|.x &plus; 1) &times; |vp|.`width`, |vp|.`y` &plus; .5 &times; (|n|.y &plus; 1) &times; |vp|.`height`)
 
-        Issue: specify the depth translation into viewport as well
+        <p class="note editorial">Editorial: specify the depth translation into viewport as well
 
     1. Let |rasterizationPoints| be an empty list.
 
-        Issue: specify that each rasterization point gets assigned an interpolated `divisor(p)`
+        <p class="note editorial">Editorial: specify that each rasterization point gets assigned an interpolated `divisor(p)`
         and `framebufferCoords(n)`, as well as the other attributes.
 
     1. Proceed with a specific rasterization algorithm,
@@ -13916,7 +13928,7 @@ The coverage mask depends on multi-sampling mode:
 
 #### Line Rasterization #### {#line-rasterization}
 
-Issue: fill out this section
+<p class="note editorial">Editorial: fill out this section
 
 #### Barycentric coordinates #### {#barycentric-coordinates}
 
@@ -14022,7 +14034,7 @@ Otherwise, the polygon is <dfn dfn>back-facing</dfn>.
 
         1. Let |d|<sub>|i|</sub> be the depth value of |v|<sub>|i|</sub>.
 
-            Issue: define how this value is constructed.
+            <p class="note editorial">Editorial: define how this value is constructed.
         1. Set |rp|.[=RasterizationPoint/depth=] to &sum; (|b|<sub>|i|</sub> &times; |d|<sub>|i|</sub>)
         1. Append |rp| to |rasterizationPoints|.
 
@@ -14080,7 +14092,7 @@ This stage produces a <dfn dfn>Fragment</dfn> for each [=RasterizationPoint=]:
                 based on |rp|.[=RasterizationPoint/barycentricCoordinates=], |rp|.[=RasterizationPoint/primitiveVertices=],
                 and the [=interpolation=] qualifier on the input.
 
-                Issue: describe the exact equations.
+                <p class="note editorial">Editorial: describe the exact equations.
             1. Set the corresponding fragment shader [=location=] input to |value|.
         1. Invoke the fragment shader entry point described by |desc|.
 
@@ -14107,7 +14119,7 @@ may happen in any order.
 
 ### Output Merging ### {#output-merging}
 
-Issue: fill out this section
+<p class="note editorial">Editorial: fill out this section
 
 The depth input to this stage, if any, is clamped to the current
 {{GPURenderPassEncoder/[[viewport]]}} depth range
@@ -14136,7 +14148,7 @@ It guarantees that:
 
 ### Sample frequency shading ### {#sample-frequency-shading}
 
-Issue: fill out the section
+<p class="note editorial">Editorial: fill out the section
 
 ### Sample Masking ### {#sample-masking}
 


### PR DESCRIPTION
Leaves behind "editorial notes" where we previously had issues.

This is more or less an acknowledgement that this section isn't going to get fully fleshed out for V1.