### PR TITLE
wgsl: bit shift width is always u32 or vector of u32

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6098,17 +6098,17 @@ See [[#sync-builtin-functions]].
     |T| is |S| or vec|N|&lt;|S|&gt;<br>
     |TS| is u32 when |T| is |S|, otherwise |TS| is vec|N|&lt;u32&gt;
     <td class="nowrap">|e1| `<<` |e2|: |T|
-    <td>Shift left (concrete):
+    <td>Shift left (shifted value is concrete):
 
         Shift |e1| left, inserting zero bits at the least significant positions,
         and discarding the most significant bits.
 
         The number of bits to shift is the value of |e2|, modulo the bit width of |e1|.<br>
-        If |e2| is greater or equal to the bit width of |e1|, then:
+        If |e2| is greater than or equal to the bit width of |e1|, then:
         * It is a [=shader-creation error=] if |e2| is a [=const-expression=].
         * It is a [=pipeline-creation error=] if |e2| is an [=override-expression=].
 
-        If |e2|+1 most significant bits of |e1| do not have the same bit value, then:
+        If the |e2|+1 most significant bits of |e1| do not have the same bit value, then:
         * It is a [=shader-creation error=] if |e1| and |e2| are [=const-expressions=].
         * It is a [=pipeline-creation error=] if |e1| and |e2| are [=override-expressions=].
 
@@ -6116,10 +6116,11 @@ See [[#sync-builtin-functions]].
 
   <tr algorithm="abstract shift left">
     <td>|e1|: |T|<br>
-    |e2|: |T|<br>
+    |e2|: |TS|<br>
     |T| is AbstractInt or vec|N|&lt;AbstractInt&gt;
+    |TS| is u32 when |T| is AbstractInt, otherwise |TS| is vec|N|&lt;u32&gt;
     <td class="nowrap">|e1| `<<` |e2|: |T|
-    <td>Shift left (abstract):
+    <td>Shift left (shifted value abstract):
 
         Shift |e1| left, inserting zero bits at the least significant positions,
         and discarding the most significant bits.
@@ -6132,8 +6133,6 @@ See [[#sync-builtin-functions]].
         Note: This condition means all the discarded bits must be the same as the sign bit of the original value,
         and the same as the sign bit of the final value.
 
-        The value of |e2| [=shader-creation error|must=] be at least 0.
-
         [=Component-wise=] when |T| is a vector.
 
   <tr algorithm="concrete shift right">
@@ -6143,7 +6142,7 @@ See [[#sync-builtin-functions]].
     |T| is |S| or vec|N|&lt;|S|&gt;<br>
     |TS| is u32 when |T| is |S|, otherwise |TS| is vec|N|&lt;u32&gt;
     <td class="nowrap">|e1| >> |e2|: |T|
-    <td>Shift right (concrete).
+    <td>Shift right (shifted value is concrete).
 
         Shift |e1| right, discarding the least significant bits.
 
@@ -6163,8 +6162,9 @@ See [[#sync-builtin-functions]].
 
   <tr algorithm="abstract shift right">
     <td>|e1|: |T|<br>
-    |e2|: |T|<br>
+    |e2|: |TS|<br>
     |T| is AbstractInt or vec|N|&lt;AbstractInt&gt;
+    |TS| is u32 when |T| is AbstractInt, otherwise |TS| is vec|N|&lt;u32&gt;
     <td class="nowrap">|e1| >> |e2|: |T|
     <td>Shift right (abstract).
 
@@ -6176,8 +6176,6 @@ See [[#sync-builtin-functions]].
         The number of bits to shift is the value of |e2|.
 
         [=Component-wise=] when |T| is a vector.
-
-        It is a [=shader-creation error=] if any of the |e2| values are less than 0.
 </table>
 
 ## Function Call Expression ## {#function-call-expr}


### PR DESCRIPTION
* Allows (1<<2u) to remain abstract
* Remove the rule that the shift width must be non-negative, since it has to successfully concreteize to an unsigned value.

Fixes: #3511