### PR TITLE
wgsl: Remove address space names from "other keywords" list

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -10560,11 +10560,6 @@ Issue: https://github.com/gpuweb/gpuweb/issues/1621
     | `'for'`
 </div>
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>function</dfn> :
-
-    | `'function'`
-</div>
-<div class='syntax' noexport='true'>
   <dfn for=syntax>if</dfn> :
 
     | `'if'`
@@ -10585,11 +10580,6 @@ Issue: https://github.com/gpuweb/gpuweb/issues/1621
     | `'override'`
 </div>
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>private</dfn> :
-
-    | `'private'`
-</div>
-<div class='syntax' noexport='true'>
   <dfn for=syntax>return</dfn> :
 
     | `'return'`
@@ -10598,11 +10588,6 @@ Issue: https://github.com/gpuweb/gpuweb/issues/1621
   <dfn for=syntax>static_assert</dfn> :
 
     | `'static_assert'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>storage</dfn> :
-
-    | `'storage'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>struct</dfn> :
@@ -10625,11 +10610,6 @@ Issue: https://github.com/gpuweb/gpuweb/issues/1621
     | `'type'`
 </div>
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>uniform</dfn> :
-
-    | `'uniform'`
-</div>
-<div class='syntax' noexport='true'>
   <dfn for=syntax>var</dfn> :
 
     | `'var'`
@@ -10638,11 +10618,6 @@ Issue: https://github.com/gpuweb/gpuweb/issues/1621
   <dfn for=syntax>while</dfn> :
 
     | `'while'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>workgroup</dfn> :
-
-    | `'workgroup'`
 </div>
 
 ## Reserved Words ## {#reserved-words}
@@ -10982,18 +10957,16 @@ The [=address space=] names are:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>address_space</dfn> :
 
-    | [=syntax/function=]
+    | `'function'`
 
-    | [=syntax/private=]
+    | `'private'`
 
-    | [=syntax/workgroup=]
+    | `'workgroup'`
 
-    | [=syntax/uniform=]
+    | `'uniform'`
 
-    | [=syntax/storage=]
+    | `'storage'`
 </div>
-
-TODO: address space names don't have to be keywords.
 
 The [=texel format=] names are:
 <div class='syntax' noexport='true'>


### PR DESCRIPTION
They are already described as context-dependent names. This is an editorial fix

Fixes: #3517