### PR TITLE
Fix the definition of "src-alpha-saturated"

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7907,7 +7907,7 @@ enum GPUBlendFactor {
             <td><code>(1 - A<sub>dst</sub>, 1 - A<sub>dst</sub>, 1 - A<sub>dst</sub>, 1 - A<sub>dst</sub>)</code>
         <tr>
             <td><dfn>"src-alpha-saturated"</dfn>
-            <td><code>(A<sub>src</sub>, A<sub>src</sub>, A<sub>src</sub>, A<sub>src</sub>)</code>
+            <td><code>(min(A<sub>src</sub>, 1 - A<sub>dst</sub>), min(A<sub>src</sub>, 1 - A<sub>dst</sub>), min(A<sub>src</sub>, 1 - A<sub>dst</sub>), 1)</code>
         <tr>
             <td><dfn>"constant"</dfn>
             <td><code>(R<sub>const</sub>, G<sub>const</sub>, B<sub>const</sub>, A<sub>const</sub>)</code>


### PR DESCRIPTION
This patch fixes the definition of "src-alpha-saturated". The correct formulat should be (min(As, 1-Ad), min(As, 1-Ad), min(As, 1-Ad), 1).

fixes: #3432 