### PR TITLE
wgsl: Move * and & from lhs_expression to core_lhs_expression

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6381,7 +6381,7 @@ When an identifier is used as a [=syntax/callable=] item, it is one of:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>lhs_expression</dfn> :
 
-    | ( [=syntax/star=] | [=syntax/and=] ) * [=syntax/core_lhs_expression=] [=syntax/component_or_swizzle_specifier=] ?
+    | [=syntax/core_lhs_expression=] [=syntax/component_or_swizzle_specifier=] ?
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>core_lhs_expression</dfn> :
@@ -6389,6 +6389,10 @@ When an identifier is used as a [=syntax/callable=] item, it is one of:
     | [=syntax/ident=]
 
     | [=syntax/paren_left=] [=syntax/lhs_expression=] [=syntax/paren_right=]
+
+    | [=syntax/star=] [=syntax/core_lhs_expression=]
+
+    | [=syntax/and=] [=syntax/core_lhs_expression=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>multiplicative_expression</dfn> :

--- a/wgsl/wgsl.recursive.bs.include
+++ b/wgsl/wgsl.recursive.bs.include
@@ -181,7 +181,11 @@
 
  | [=recursive descent syntax/ident=]
 
+ | [=syntax/and=] [=recursive descent syntax/core_lhs_expression=]
+
  | [=syntax/paren_left=] [=recursive descent syntax/lhs_expression=] [=syntax/paren_right=]
+
+ | [=syntax/star=] [=recursive descent syntax/core_lhs_expression=]
 </div>
 
 <div class='syntax' noexport='true'>
@@ -338,7 +342,7 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>lhs_expression</dfn>:
 
- | ( [=syntax/star=] | [=syntax/and=] ) * [=recursive descent syntax/core_lhs_expression=] [=recursive descent syntax/component_or_swizzle_specifier=] ?
+ | [=recursive descent syntax/core_lhs_expression=] [=recursive descent syntax/component_or_swizzle_specifier=] ?
 </div>
 
 <div class='syntax' noexport='true'>
@@ -667,11 +671,11 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>variable_updating_statement</dfn>:
 
- | ( [=syntax/star=] | [=syntax/and=] ) * [=recursive descent syntax/core_lhs_expression=] [=recursive descent syntax/component_or_swizzle_specifier=] ? ( [=syntax/equal=] | [=recursive descent syntax/compound_assignment_operator=] ) [=recursive descent syntax/expression=]
+ | [=recursive descent syntax/core_lhs_expression=] [=recursive descent syntax/component_or_swizzle_specifier=] ? ( [=syntax/equal=] | [=recursive descent syntax/compound_assignment_operator=] ) [=recursive descent syntax/expression=]
 
- | ( [=syntax/star=] | [=syntax/and=] ) * [=recursive descent syntax/core_lhs_expression=] [=recursive descent syntax/component_or_swizzle_specifier=] ? [=syntax/minus_minus=]
+ | [=recursive descent syntax/core_lhs_expression=] [=recursive descent syntax/component_or_swizzle_specifier=] ? [=syntax/minus_minus=]
 
- | ( [=syntax/star=] | [=syntax/and=] ) * [=recursive descent syntax/core_lhs_expression=] [=recursive descent syntax/component_or_swizzle_specifier=] ? [=syntax/plus_plus=]
+ | [=recursive descent syntax/core_lhs_expression=] [=recursive descent syntax/component_or_swizzle_specifier=] ? [=syntax/plus_plus=]
 
  | [=syntax/underscore=] [=syntax/equal=] [=recursive descent syntax/expression=]
 </div>


### PR DESCRIPTION
This resolves an ambiguity on how to type-check things like:

    var m:mat2x2<f32>;
    let p = &m;
    *p[0] = m[1];

This grammar change pulls processing of the * and & from lhs_expression into core_lhs_expression. So this example will parse as if:

   (*p)[0] = m[1];

This is necessary, unless we want to support #1580 (which propooses to add apply array indexing and struct member selection on pointer values).

Note: This means reference expressions are parsed differently on the left side of an assignment than they anywhere else.

Fixes: #3530