### PR TITLE
wgsl: Fix how we say concrete left shift must not overflow (if known …

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6108,9 +6108,15 @@ See [[#sync-builtin-functions]].
         * It is a [=shader-creation error=] if |e2| is a [=const-expression=].
         * It is a [=pipeline-creation error=] if |e2| is an [=override-expression=].
 
-        If the |e2|+1 most significant bits of |e1| do not have the same bit value, then:
-        * It is a [=shader-creation error=] if |e1| and |e2| are [=const-expressions=].
-        * It is a [=pipeline-creation error=] if |e1| and |e2| are [=override-expressions=].
+        When both |e1| and |e2| are known before [=shader execution start=],
+        the result must not overflow:
+        * If |T| is a signed integer type,
+            and the |e2|+1 most significant bits of |e1| do not have the same bit value, then:
+            * It is a [=shader-creation error=] if |e1| and |e2| are [=const-expressions=].
+            * It is a [=pipeline-creation error=] if |e1| and |e2| are [=override-expressions=].
+        * If |T| is an unsigned integer type, and any of the |e2| most significant bits of |e1| are 1, then:
+            * It is a [=shader-creation error=] if |e1| and |e2| are [=const-expressions=].
+            * It is a [=pipeline-creation error=] if |e1| and |e2| are [=override-expressions=].
 
         [=Component-wise=] when |T| is a vector.
 


### PR DESCRIPTION
…before runtime)

Prior to this change, there was a condition on the top bits of the LHS.  But these should only apply if LHS is signed. There is a different condition if the LHS is unsigned.

Fixes: #3535