### PR TITLE
wgsl: Simplify note about runtime-sized array not being fixed-footprint

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2234,8 +2234,8 @@ This includes the [=store type=] of a workgroup variable.
 Note: A fixed-footprint type may contain an [=atomic type|atomic=] type, either directly or
 indirectly, while a [=constructible=] type cannot.
 
-Note: Fixed-footprint types exclude [=runtime-sized=] arrays, and any structures or arrays
-that contain [=runtime-sized=] arrays, recursively.
+Note: Fixed-footprint types exclude [=runtime-sized=] arrays, and any structure
+that contains a [=runtime-sized=] array.
 
 ## Memory ## {#memory}
 


### PR DESCRIPTION
Fixes: #3534