### PR TITLE
WGSL syntax styling upgrade with initial notation section

### DIFF
--- a/wgsl/extract-grammar.py
+++ b/wgsl/extract-grammar.py
@@ -375,6 +375,9 @@ def grammar_from_rule_item(rule_item):
             i_item = f"token({rule_item[i][1:-1]})"
         elif rule_item[i].startswith("`'"):
             i_item = f"token({rule_item[i][1:-1]})"
+        elif rule_item[i].startswith("<a"):
+            i_item = f"""token('{rule_item[i + 2].split(">`'")[1].split("'`</a")[0][:]}')"""
+            i += 2
         elif rule_item[i] == "(":
             j = i + 1
             j_span = 0

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -65,6 +65,7 @@ div.syntax > p {
   margin-inline-start: 1em;
   margin-inline-end: 0em;
   color: var(--text);
+  font-weight: 100;
 }
 div.syntax > p::first-letter {
   letter-spacing: 0.5em;

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -64,6 +64,7 @@ div.syntax > p {
   margin-block-end: 0em;
   margin-inline-start: 1em;
   margin-inline-end: 0em;
+  color: var(--text);
 }
 div.syntax > p::first-letter {
   letter-spacing: 0.5em;
@@ -71,10 +72,76 @@ div.syntax > p::first-letter {
 div.syntax > p > a {
   margin-inline-start: 0.1em;
   margin-inline-end: 0.1em;
+  font-style: italic;
+  font-weight: normal;
+  color: var(--text);
 }
 div.syntax > p > code {
   margin-inline-start: 0.1em;
   margin-inline-end: 0.1em;
+  color: var(--text);
+  font-style: normal;
+  font-weight: bold;
+}
+div.syntax > p > a > code {
+  margin-inline-start: 0.1em;
+  margin-inline-end: 0.1em;
+  color: var(--text);
+  font-style: normal;
+  font-weight: bold;
+}
+[data-dfn-for="syntax"] {
+  font-style: italic;
+  font-weight: normal;
+  color: var(--text);
+}
+[data-dfn-for="syntax_kw"] {
+  margin-inline-start: 0.1em;
+  margin-inline-end: 0.1em;
+  color: var(--text);
+  font-style: normal;
+  font-weight: bold;
+}
+[data-dfn-for="syntax_sym"] {
+  margin-inline-start: 0.1em;
+  margin-inline-end: 0.1em;
+  color: var(--text);
+  font-style: normal;
+  font-weight: bold;
+}
+@media (prefers-color-scheme: dark) {
+  div.syntax {
+    background: #060613;
+  }
+  div.syntax > p > code {
+    background: rgba(255, 255, 255, .08);
+  }
+  div.syntax > p > a > code {
+    background: rgba(255, 255, 255, .08);
+  }
+  [data-dfn-for="syntax_kw"] {
+    background: rgba(255, 255, 255, .08);
+  }
+  [data-dfn-for="syntax_sym"] {
+    background: rgba(255, 255, 255, .08);
+  }
+}
+@media (prefers-color-scheme: light) {
+  div.syntax {
+    background: #f0f7ff;
+  }
+  div.syntax > p > code {
+    background: rgba(0, 0, 0, .06);
+  }
+  div.syntax > p > a > code {
+    background: rgba(0, 0, 0, .06);
+  }
+  [data-dfn-for="syntax_kw"] {
+    background: rgba(0, 0, 0, .06);
+  }
+  [data-dfn-for="syntax_sym"] {
+    background: rgba(0, 0, 0, .06);
+  }
 }
 table.data.builtin tbody{
   border-bottom: 0;
@@ -305,6 +372,19 @@ WGSL sometimes permits several possible behaviors for a given feature.
 This is a portability hazard, as different implementations may exhibit the different behaviors.
 The design of WGSL aims to minimize such cases, but is constrained by feasibility,
 and goals for achieving high performance across a broad range of devices.
+
+## Syntax Notation ## {#syntax-notation}
+
+Following syntax notation describes the conventions of the syntactic grammar of WGSL:
+
+* Italic text on both sides of a rule indicates a syntax rule.
+* Bold monospace text starting and ending with single quotes (**'**) on the right-hand side of a rule indicates keywords and tokens.
+* A colon (**:**) in regular text registers a syntax rule.
+* A vertical bar (**|**) in regular text indicates alternatives.
+* An question mark (**?**) in regular text indicates that previous keyword, token, rule, or group occurs zero or one times (is optional).
+* An asterisk (<b>*</b>) in regular text indicates that previous keyword, token, rule, or group occurs zero or more times.
+* A plus (**+**) in regular text indicates that previous keyword, token, rule, or group occurs one or more times.
+* A matching pair of opening parenthesis (**(**) and closing parenthesis (**)**) in regular text indicates a group of elements.
 
 ## Mathematical Terms and Notation ## {#terms-and-notation}
 
@@ -584,9 +664,9 @@ A <dfn>literal</dfn> is one of:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>bool_literal</dfn> :
 
-    | [=syntax/true=]
+    | <a for=syntax_kw lt=true>`'true'`</a>
 
-    | [=syntax/false=]
+    | <a for=syntax_kw lt=false>`'false'`</a>
 </div>
 
 ### Numeric Literals ### {#numeric-literals}
@@ -1024,44 +1104,44 @@ They take no parameters.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>attribute</dfn> :
 
-    | [=syntax/attr=] `'align'` [=syntax/paren_left=] [=syntax/expression=] [=syntax/attrib_end=]
+    | <a for=syntax_sym lt=attr>`'@'`</a> `'align'` <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/expression=] [=syntax/attrib_end=]
 
-    | [=syntax/attr=] `'binding'` [=syntax/paren_left=] [=syntax/expression=] [=syntax/attrib_end=]
+    | <a for=syntax_sym lt=attr>`'@'`</a> `'binding'` <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/expression=] [=syntax/attrib_end=]
 
-    | [=syntax/attr=] `'builtin'` [=syntax/paren_left=] [=syntax/builtin_value_name=] [=syntax/attrib_end=]
+    | <a for=syntax_sym lt=attr>`'@'`</a> `'builtin'` <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/builtin_value_name=] [=syntax/attrib_end=]
 
-    | [=syntax/attr=] `'const'`
+    | <a for=syntax_sym lt=attr>`'@'`</a> `'const'`
 
-    | [=syntax/attr=] `'group'` [=syntax/paren_left=] [=syntax/expression=] [=syntax/attrib_end=]
+    | <a for=syntax_sym lt=attr>`'@'`</a> `'group'` <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/expression=] [=syntax/attrib_end=]
 
-    | [=syntax/attr=] `'id'` [=syntax/paren_left=] [=syntax/expression=] [=syntax/attrib_end=]
+    | <a for=syntax_sym lt=attr>`'@'`</a> `'id'` <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/expression=] [=syntax/attrib_end=]
 
-    | [=syntax/attr=] `'interpolate'` [=syntax/paren_left=] [=syntax/interpolation_type_name=] [=syntax/attrib_end=]
+    | <a for=syntax_sym lt=attr>`'@'`</a> `'interpolate'` <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/interpolation_type_name=] [=syntax/attrib_end=]
 
-    | [=syntax/attr=] `'interpolate'` [=syntax/paren_left=] [=syntax/interpolation_type_name=] [=syntax/comma=] [=syntax/interpolation_sample_name=] [=syntax/attrib_end=]
+    | <a for=syntax_sym lt=attr>`'@'`</a> `'interpolate'` <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/interpolation_type_name=] <a for=syntax_sym lt=comma>`','`</a> [=syntax/interpolation_sample_name=] [=syntax/attrib_end=]
 
-    | [=syntax/attr=] `'invariant'`
+    | <a for=syntax_sym lt=attr>`'@'`</a> `'invariant'`
 
-    | [=syntax/attr=] `'location'` [=syntax/paren_left=] [=syntax/expression=] [=syntax/attrib_end=]
+    | <a for=syntax_sym lt=attr>`'@'`</a> `'location'` <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/expression=] [=syntax/attrib_end=]
 
-    | [=syntax/attr=] `'size'` [=syntax/paren_left=] [=syntax/expression=] [=syntax/attrib_end=]
+    | <a for=syntax_sym lt=attr>`'@'`</a> `'size'` <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/expression=] [=syntax/attrib_end=]
 
-    | [=syntax/attr=] `'workgroup_size'` [=syntax/paren_left=] [=syntax/expression=] [=syntax/attrib_end=]
+    | <a for=syntax_sym lt=attr>`'@'`</a> `'workgroup_size'` <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/expression=] [=syntax/attrib_end=]
 
-    | [=syntax/attr=] `'workgroup_size'` [=syntax/paren_left=] [=syntax/expression=] [=syntax/comma=] [=syntax/expression=] [=syntax/attrib_end=]
+    | <a for=syntax_sym lt=attr>`'@'`</a> `'workgroup_size'` <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/expression=] <a for=syntax_sym lt=comma>`','`</a> [=syntax/expression=] [=syntax/attrib_end=]
 
-    | [=syntax/attr=] `'workgroup_size'` [=syntax/paren_left=] [=syntax/expression=] [=syntax/comma=] [=syntax/expression=] [=syntax/comma=] [=syntax/expression=] [=syntax/attrib_end=]
+    | <a for=syntax_sym lt=attr>`'@'`</a> `'workgroup_size'` <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/expression=] <a for=syntax_sym lt=comma>`','`</a> [=syntax/expression=] <a for=syntax_sym lt=comma>`','`</a> [=syntax/expression=] [=syntax/attrib_end=]
 
-    | [=syntax/attr=] `'vertex'`
+    | <a for=syntax_sym lt=attr>`'@'`</a> `'vertex'`
 
-    | [=syntax/attr=] `'fragment'`
+    | <a for=syntax_sym lt=attr>`'@'`</a> `'fragment'`
 
-    | [=syntax/attr=] `'compute'`
+    | <a for=syntax_sym lt=attr>`'@'`</a> `'compute'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>attrib_end</dfn> :
 
-    | [=syntax/comma=] ? [=syntax/paren_right=]
+    | <a for=syntax_sym lt=comma>`','`</a> ? <a for=syntax_sym lt=paren_right>`')'`</a>
 </div>
 
 ## Directives ## {#directives}
@@ -2021,7 +2101,7 @@ This includes the [=store type=] of a workgroup variable.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>array_type_specifier</dfn> :
 
-    | [=syntax/array=] [=syntax/less_than=] [=syntax/type_specifier=] ( [=syntax/comma=] [=syntax/element_count_expression=] ) ? [=syntax/greater_than=]
+    | <a for=syntax_kw lt=array>`'array'`</a> <a for=syntax_sym lt=less_than>`'<'`</a> [=syntax/type_specifier=] ( <a for=syntax_sym lt=comma>`','`</a> [=syntax/element_count_expression=] ) ? <a for=syntax_sym lt=greater_than>`'>'`</a>
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>element_count_expression</dfn> :
@@ -2097,17 +2177,17 @@ Some consequences of the restrictions structure member and array element types a
 <div class='syntax' noexport='true'>
   <dfn for=syntax>struct_decl</dfn> :
 
-    | [=syntax/struct=] [=syntax/ident=] [=syntax/struct_body_decl=]
+    | <a for=syntax_kw lt=struct>`'struct'`</a> [=syntax/ident=] [=syntax/struct_body_decl=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>struct_body_decl</dfn> :
 
-    | [=syntax/brace_left=] [=syntax/struct_member=] ( [=syntax/comma=] [=syntax/struct_member=] ) * [=syntax/comma=] ? [=syntax/brace_right=]
+    | <a for=syntax_sym lt=brace_left>`'{'`</a> [=syntax/struct_member=] ( <a for=syntax_sym lt=comma>`','`</a> [=syntax/struct_member=] ) * <a for=syntax_sym lt=comma>`','`</a> ? <a for=syntax_sym lt=brace_right>`'}'`</a>
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>struct_member</dfn> :
 
-    | [=syntax/attribute=] * [=syntax/member_ident=] [=syntax/colon=] [=syntax/type_specifier=]
+    | [=syntax/attribute=] * [=syntax/member_ident=] <a for=syntax_sym lt=colon>`':'`</a> [=syntax/type_specifier=]
 </div>
 
 The following attributes can be applied to structure members:
@@ -3480,7 +3560,7 @@ Texel access is controlled via several properties of the sampler:
 : LOD clamp
 :: Controls the min and max levels of details that are accessed.
 : comparison
-:: Controls the type of comparison done for [=syntax/sampler_comparison|comparison sampler=].
+:: Controls the type of comparison done for [=type/sampler_comparison|comparison sampler=].
     See [[WebGPU#enumdef-gpucomparefunction|WebGPU GPUCompareFunction]].
 : max anisotropy
 :: Controls the maximum anisotropy value used by the sampler.
@@ -3703,62 +3783,62 @@ sampler_comparison
 
     | [=syntax/depth_texture_type=]
 
-    | [=syntax/sampled_texture_type=] [=syntax/less_than=] [=syntax/type_specifier=] [=syntax/greater_than=]
+    | [=syntax/sampled_texture_type=] <a for=syntax_sym lt=less_than>`'<'`</a> [=syntax/type_specifier=] <a for=syntax_sym lt=greater_than>`'>'`</a>
 
-    | [=syntax/multisampled_texture_type=] [=syntax/less_than=] [=syntax/type_specifier=] [=syntax/greater_than=]
+    | [=syntax/multisampled_texture_type=] <a for=syntax_sym lt=less_than>`'<'`</a> [=syntax/type_specifier=] <a for=syntax_sym lt=greater_than>`'>'`</a>
 
-    | [=syntax/storage_texture_type=] [=syntax/less_than=] [=syntax/texel_format=] [=syntax/comma=] [=syntax/access_mode=] [=syntax/greater_than=]
+    | [=syntax/storage_texture_type=] <a for=syntax_sym lt=less_than>`'<'`</a> [=syntax/texel_format=] <a for=syntax_sym lt=comma>`','`</a> [=syntax/access_mode=] <a for=syntax_sym lt=greater_than>`'>'`</a>
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>sampler_type</dfn> :
 
-    | [=syntax/sampler=]
+    | <a for=syntax_kw lt=sampler>`'sampler'`</a>
 
-    | [=syntax/sampler_comparison=]
+    | <a for=syntax_kw lt=sampler_comparison>`'sampler_comparison'`</a>
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>sampled_texture_type</dfn> :
 
-    | [=syntax/texture_1d=]
+    | <a for=syntax_kw lt=texture_1d>`'texture_1d'`</a>
 
-    | [=syntax/texture_2d=]
+    | <a for=syntax_kw lt=texture_2d>`'texture_2d'`</a>
 
-    | [=syntax/texture_2d_array=]
+    | <a for=syntax_kw lt=texture_2d_array>`'texture_2d_array'`</a>
 
-    | [=syntax/texture_3d=]
+    | <a for=syntax_kw lt=texture_3d>`'texture_3d'`</a>
 
-    | [=syntax/texture_cube=]
+    | <a for=syntax_kw lt=texture_cube>`'texture_cube'`</a>
 
-    | [=syntax/texture_cube_array=]
+    | <a for=syntax_kw lt=texture_cube_array>`'texture_cube_array'`</a>
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>multisampled_texture_type</dfn> :
 
-    | [=syntax/texture_multisampled_2d=]
+    | <a for=syntax_kw lt=texture_multisampled_2d>`'texture_multisampled_2d'`</a>
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>storage_texture_type</dfn> :
 
-    | [=syntax/texture_storage_1d=]
+    | <a for=syntax_kw lt=texture_storage_1d>`'texture_storage_1d'`</a>
 
-    | [=syntax/texture_storage_2d=]
+    | <a for=syntax_kw lt=texture_storage_2d>`'texture_storage_2d'`</a>
 
-    | [=syntax/texture_storage_2d_array=]
+    | <a for=syntax_kw lt=texture_storage_2d_array>`'texture_storage_2d_array'`</a>
 
-    | [=syntax/texture_storage_3d=]
+    | <a for=syntax_kw lt=texture_storage_3d>`'texture_storage_3d'`</a>
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>depth_texture_type</dfn> :
 
-    | [=syntax/texture_depth_2d=]
+    | <a for=syntax_kw lt=texture_depth_2d>`'texture_depth_2d'`</a>
 
-    | [=syntax/texture_depth_2d_array=]
+    | <a for=syntax_kw lt=texture_depth_2d_array>`'texture_depth_2d_array'`</a>
 
-    | [=syntax/texture_depth_cube=]
+    | <a for=syntax_kw lt=texture_depth_cube>`'texture_depth_cube'`</a>
 
-    | [=syntax/texture_depth_cube_array=]
+    | <a for=syntax_kw lt=texture_depth_cube_array>`'texture_depth_cube_array'`</a>
 
-    | [=syntax/texture_depth_multisampled_2d=]
+    | <a for=syntax_kw lt=texture_depth_multisampled_2d>`'texture_depth_multisampled_2d'`</a>
 </div>
 
 ## Type Aliases ## {#type-aliases}
@@ -3772,7 +3852,7 @@ all properties of the members of *S*, including attributes, carry over to the me
 <div class='syntax' noexport='true'>
   <dfn for=syntax>type_alias_decl</dfn> :
 
-    | [=syntax/type=] [=syntax/ident=] [=syntax/equal=] [=syntax/type_specifier=]
+    | <a for=syntax_kw lt=type>`'type'`</a> [=syntax/ident=] <a for=syntax_sym lt=equal>`'='`</a> [=syntax/type_specifier=]
 </div>
 
 <div class='example wgsl global-scope' heading='Type Alias'>
@@ -3802,57 +3882,57 @@ all properties of the members of *S*, including attributes, carry over to the me
 <div class='syntax' noexport='true'>
   <dfn for=syntax>type_specifier_without_ident</dfn> :
 
-    | [=syntax/bool=]
+    | <a for=syntax_kw lt=bool>`'bool'`</a>
 
-    | [=syntax/float32=]
+    | <a for=syntax_kw lt=f32>`'f32'`</a>
 
-    | [=syntax/float16=]
+    | <a for=syntax_kw lt=f16>`'f16'`</a>
 
-    | [=syntax/int32=]
+    | <a for=syntax_kw lt=i32>`'i32'`</a>
 
-    | [=syntax/uint32=]
+    | <a for=syntax_kw lt=u32>`'u32'`</a>
 
-    | [=syntax/vec_prefix=] [=syntax/less_than=] [=syntax/type_specifier=] [=syntax/greater_than=]
+    | [=syntax/vec_prefix=] <a for=syntax_sym lt=less_than>`'<'`</a> [=syntax/type_specifier=] <a for=syntax_sym lt=greater_than>`'>'`</a>
 
-    | [=syntax/mat_prefix=] [=syntax/less_than=] [=syntax/type_specifier=] [=syntax/greater_than=]
+    | [=syntax/mat_prefix=] <a for=syntax_sym lt=less_than>`'<'`</a> [=syntax/type_specifier=] <a for=syntax_sym lt=greater_than>`'>'`</a>
 
-    | [=syntax/pointer=] [=syntax/less_than=] [=syntax/address_space=] [=syntax/comma=] [=syntax/type_specifier=] ( [=syntax/comma=] [=syntax/access_mode=] ) ? [=syntax/greater_than=]
+    | <a for=syntax_kw lt=ptr>`'ptr'`</a> <a for=syntax_sym lt=less_than>`'<'`</a> [=syntax/address_space=] <a for=syntax_sym lt=comma>`','`</a> [=syntax/type_specifier=] ( <a for=syntax_sym lt=comma>`','`</a> [=syntax/access_mode=] ) ? <a for=syntax_sym lt=greater_than>`'>'`</a>
 
     | [=syntax/array_type_specifier=]
 
-    | [=syntax/atomic=] [=syntax/less_than=] [=syntax/type_specifier=] [=syntax/greater_than=]
+    | <a for=syntax_kw lt=atomic>`'atomic'`</a> <a for=syntax_sym lt=less_than>`'<'`</a> [=syntax/type_specifier=] <a for=syntax_sym lt=greater_than>`'>'`</a>
 
     | [=syntax/texture_and_sampler_types=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>vec_prefix</dfn> :
 
-    | [=syntax/vec2=]
+    | <a for=syntax_kw lt=vec2>`'vec2'`</a>
 
-    | [=syntax/vec3=]
+    | <a for=syntax_kw lt=vec3>`'vec3'`</a>
 
-    | [=syntax/vec4=]
+    | <a for=syntax_kw lt=vec4>`'vec4'`</a>
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>mat_prefix</dfn> :
 
-    | [=syntax/mat2x2=]
+    | <a for=syntax_kw lt=mat2x2>`'mat2x2'`</a>
 
-    | [=syntax/mat2x3=]
+    | <a for=syntax_kw lt=mat2x3>`'mat2x3'`</a>
 
-    | [=syntax/mat2x4=]
+    | <a for=syntax_kw lt=mat2x4>`'mat2x4'`</a>
 
-    | [=syntax/mat3x2=]
+    | <a for=syntax_kw lt=mat3x2>`'mat3x2'`</a>
 
-    | [=syntax/mat3x3=]
+    | <a for=syntax_kw lt=mat3x3>`'mat3x3'`</a>
 
-    | [=syntax/mat3x4=]
+    | <a for=syntax_kw lt=mat3x4>`'mat3x4'`</a>
 
-    | [=syntax/mat4x2=]
+    | <a for=syntax_kw lt=mat4x2>`'mat4x2'`</a>
 
-    | [=syntax/mat4x3=]
+    | <a for=syntax_kw lt=mat4x3>`'mat4x3'`</a>
 
-    | [=syntax/mat4x4=]
+    | <a for=syntax_kw lt=mat4x4>`'mat4x4'`</a>
 </div>
 
 When the type is named by an [=identifier=], the use of the identifier [=shader-creation error|must=] be [=in scope=]
@@ -4412,40 +4492,40 @@ such that the redundant loads are eliminated.
 
     | [=syntax/variable_decl=]
 
-    | [=syntax/variable_decl=] [=syntax/equal=] [=syntax/expression=]
+    | [=syntax/variable_decl=] <a for=syntax_sym lt=equal>`'='`</a> [=syntax/expression=]
 
-    | [=syntax/let=] [=syntax/optionally_typed_ident=] [=syntax/equal=] [=syntax/expression=]
+    | <a for=syntax_kw lt=let>`'let'`</a> [=syntax/optionally_typed_ident=] <a for=syntax_sym lt=equal>`'='`</a> [=syntax/expression=]
 
-    | [=syntax/const=] [=syntax/optionally_typed_ident=] [=syntax/equal=] [=syntax/expression=]
+    | <a for=syntax_kw lt=const>`'const'`</a> [=syntax/optionally_typed_ident=] <a for=syntax_sym lt=equal>`'='`</a> [=syntax/expression=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>variable_decl</dfn> :
 
-    | [=syntax/var=] [=syntax/variable_qualifier=] ? [=syntax/optionally_typed_ident=]
+    | <a for=syntax_kw lt=var>`'var'`</a> [=syntax/variable_qualifier=] ? [=syntax/optionally_typed_ident=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>optionally_typed_ident</dfn> :
 
-    | [=syntax/ident=] ( [=syntax/colon=] [=syntax/type_specifier=] ) ?
+    | [=syntax/ident=] ( <a for=syntax_sym lt=colon>`':'`</a> [=syntax/type_specifier=] ) ?
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>variable_qualifier</dfn> :
 
-    | [=syntax/less_than=] [=syntax/address_space=] ( [=syntax/comma=] [=syntax/access_mode=] ) ? [=syntax/greater_than=]
+    | <a for=syntax_sym lt=less_than>`'<'`</a> [=syntax/address_space=] ( <a for=syntax_sym lt=comma>`','`</a> [=syntax/access_mode=] ) ? <a for=syntax_sym lt=greater_than>`'>'`</a>
 </div>
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>global_variable_decl</dfn> :
 
-    | [=syntax/attribute=] * [=syntax/variable_decl=] ( [=syntax/equal=] [=syntax/expression=] ) ?
+    | [=syntax/attribute=] * [=syntax/variable_decl=] ( <a for=syntax_sym lt=equal>`'='`</a> [=syntax/expression=] ) ?
 </div>
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>global_constant_decl</dfn> :
 
-    | [=syntax/const=] [=syntax/optionally_typed_ident=] [=syntax/equal=] [=syntax/expression=]
+    | <a for=syntax_kw lt=const>`'const'`</a> [=syntax/optionally_typed_ident=] <a for=syntax_sym lt=equal>`'='`</a> [=syntax/expression=]
 
-    | [=syntax/attribute=] * [=syntax/override=] [=syntax/optionally_typed_ident=] ( [=syntax/equal=] [=syntax/expression=] ) ?
+    | [=syntax/attribute=] * <a for=syntax_kw lt=override>`'override'`</a> [=syntax/optionally_typed_ident=] ( <a for=syntax_sym lt=equal>`'='`</a> [=syntax/expression=] ) ?
 </div>
 
 # Expressions # {#expressions}
@@ -6395,7 +6475,7 @@ When an identifier is used as a [=syntax/callable=] item, it is one of:
 
     | [=syntax/paren_expression=]
 
-    | [=syntax/bitcast=] [=syntax/less_than=] [=syntax/type_specifier=] [=syntax/greater_than=] [=syntax/paren_expression=]
+    | <a for=syntax_kw lt=bitcast>`'bitcast'`</a> <a for=syntax_sym lt=less_than>`'<'`</a> [=syntax/type_specifier=] <a for=syntax_sym lt=greater_than>`'>'`</a> [=syntax/paren_expression=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>callable</dfn> :
@@ -6408,41 +6488,41 @@ When an identifier is used as a [=syntax/callable=] item, it is one of:
 
     | [=syntax/mat_prefix=]
 
-    | [=syntax/array=]
+    | <a for=syntax_kw lt=array>`'array'`</a>
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>paren_expression</dfn> :
 
-    | [=syntax/paren_left=] [=syntax/expression=] [=syntax/paren_right=]
+    | <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/expression=] <a for=syntax_sym lt=paren_right>`')'`</a>
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>argument_expression_list</dfn> :
 
-    | [=syntax/paren_left=] ( [=syntax/expression=] ( [=syntax/comma=] [=syntax/expression=] ) * [=syntax/comma=] ? ) ? [=syntax/paren_right=]
+    | <a for=syntax_sym lt=paren_left>`'('`</a> ( [=syntax/expression=] ( <a for=syntax_sym lt=comma>`','`</a> [=syntax/expression=] ) * <a for=syntax_sym lt=comma>`','`</a> ? ) ? <a for=syntax_sym lt=paren_right>`')'`</a>
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>component_or_swizzle_specifier</dfn> :
 
-    | [=syntax/bracket_left=] [=syntax/expression=] [=syntax/bracket_right=] [=syntax/component_or_swizzle_specifier=] ?
+    | <a for=syntax_sym lt=bracket_left>`'['`</a> [=syntax/expression=] <a for=syntax_sym lt=bracket_right>`']'`</a> [=syntax/component_or_swizzle_specifier=] ?
 
-    | [=syntax/period=] [=syntax/member_ident=] [=syntax/component_or_swizzle_specifier=] ?
+    | <a for=syntax_sym lt=period>`'.'`</a> [=syntax/member_ident=] [=syntax/component_or_swizzle_specifier=] ?
 
-    | [=syntax/period=] [=syntax/swizzle_name=] [=syntax/component_or_swizzle_specifier=] ?
+    | <a for=syntax_sym lt=period>`'.'`</a> [=syntax/swizzle_name=] [=syntax/component_or_swizzle_specifier=] ?
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>unary_expression</dfn> :
 
     | [=syntax/singular_expression=]
 
-    | [=syntax/minus=] [=syntax/unary_expression=]
+    | <a for=syntax_sym lt=minus>`'-'`</a> [=syntax/unary_expression=]
 
-    | [=syntax/bang=] [=syntax/unary_expression=]
+    | <a for=syntax_sym lt=bang>`'!'`</a> [=syntax/unary_expression=]
 
-    | [=syntax/tilde=] [=syntax/unary_expression=]
+    | <a for=syntax_sym lt=tilde>`'~'`</a> [=syntax/unary_expression=]
 
-    | [=syntax/star=] [=syntax/unary_expression=]
+    | <a for=syntax_sym lt=star>`'*'`</a> [=syntax/unary_expression=]
 
-    | [=syntax/and=] [=syntax/unary_expression=]
+    | <a for=syntax_sym lt=and>`'&'`</a> [=syntax/unary_expression=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>singular_expression</dfn> :
@@ -6452,14 +6532,14 @@ When an identifier is used as a [=syntax/callable=] item, it is one of:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>lhs_expression</dfn> :
 
-    | ( [=syntax/star=] | [=syntax/and=] ) * [=syntax/core_lhs_expression=] [=syntax/component_or_swizzle_specifier=] ?
+    | ( <a for=syntax_sym lt=star>`'*'`</a> | <a for=syntax_sym lt=and>`'&'`</a> ) * [=syntax/core_lhs_expression=] [=syntax/component_or_swizzle_specifier=] ?
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>core_lhs_expression</dfn> :
 
     | [=syntax/ident=]
 
-    | [=syntax/paren_left=] [=syntax/lhs_expression=] [=syntax/paren_right=]
+    | <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/lhs_expression=] <a for=syntax_sym lt=paren_right>`')'`</a>
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>multiplicative_expression</dfn> :
@@ -6472,11 +6552,11 @@ When an identifier is used as a [=syntax/callable=] item, it is one of:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>multiplicative_operator</dfn> :
 
-    | [=syntax/star=]
+    | <a for=syntax_sym lt=star>`'*'`</a>
 
-    | [=syntax/forward_slash=]
+    | <a for=syntax_sym lt=forward_slash>`'/'`</a>
 
-    | [=syntax/modulo=]
+    | <a for=syntax_sym lt=modulo>`'%'`</a>
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>additive_expression</dfn> :
@@ -6488,88 +6568,88 @@ When an identifier is used as a [=syntax/callable=] item, it is one of:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>additive_operator</dfn> :
 
-    | [=syntax/plus=]
+    | <a for=syntax_sym lt=plus>`'+'`</a>
 
-    | [=syntax/minus=]
+    | <a for=syntax_sym lt=minus>`'-'`</a>
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>shift_expression</dfn> :
 
     | [=syntax/additive_expression=]
 
-    | [=syntax/unary_expression=] [=syntax/shift_left=] [=syntax/unary_expression=]
+    | [=syntax/unary_expression=] <a for=syntax_sym lt=shift_left>`'<<'`</a> [=syntax/unary_expression=]
 
-    | [=syntax/unary_expression=] [=syntax/shift_right=] [=syntax/unary_expression=]
+    | [=syntax/unary_expression=] <a for=syntax_sym lt=shift_right>`'>>'`</a> [=syntax/unary_expression=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>relational_expression</dfn> :
 
     | [=syntax/shift_expression=]
 
-    | [=syntax/shift_expression=] [=syntax/less_than=] [=syntax/shift_expression=]
+    | [=syntax/shift_expression=] <a for=syntax_sym lt=less_than>`'<'`</a> [=syntax/shift_expression=]
 
-    | [=syntax/shift_expression=] [=syntax/greater_than=] [=syntax/shift_expression=]
+    | [=syntax/shift_expression=] <a for=syntax_sym lt=greater_than>`'>'`</a> [=syntax/shift_expression=]
 
-    | [=syntax/shift_expression=] [=syntax/less_than_equal=] [=syntax/shift_expression=]
+    | [=syntax/shift_expression=] <a for=syntax_sym lt=less_than_equal>`'<='`</a> [=syntax/shift_expression=]
 
-    | [=syntax/shift_expression=] [=syntax/greater_than_equal=] [=syntax/shift_expression=]
+    | [=syntax/shift_expression=] <a for=syntax_sym lt=greater_than_equal>`'>='`</a> [=syntax/shift_expression=]
 
-    | [=syntax/shift_expression=] [=syntax/equal_equal=] [=syntax/shift_expression=]
+    | [=syntax/shift_expression=] <a for=syntax_sym lt=equal_equal>`'=='`</a> [=syntax/shift_expression=]
 
-    | [=syntax/shift_expression=] [=syntax/not_equal=] [=syntax/shift_expression=]
+    | [=syntax/shift_expression=] <a for=syntax_sym lt=not_equal>`'!='`</a> [=syntax/shift_expression=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>short_circuit_and_expression</dfn> :
 
     | [=syntax/relational_expression=]
 
-    | [=syntax/short_circuit_and_expression=] [=syntax/and_and=] [=syntax/relational_expression=]
+    | [=syntax/short_circuit_and_expression=] <a for=syntax_sym lt=and_and>`'&&'`</a> [=syntax/relational_expression=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>short_circuit_or_expression</dfn> :
 
     | [=syntax/relational_expression=]
 
-    | [=syntax/short_circuit_or_expression=] [=syntax/or_or=] [=syntax/relational_expression=]
+    | [=syntax/short_circuit_or_expression=] <a for=syntax_sym lt=or_or>`'||'`</a> [=syntax/relational_expression=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>binary_or_expression</dfn> :
 
     | [=syntax/unary_expression=]
 
-    | [=syntax/binary_or_expression=] [=syntax/or=] [=syntax/unary_expression=]
+    | [=syntax/binary_or_expression=] <a for=syntax_sym lt=or>`'|'`</a> [=syntax/unary_expression=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>binary_and_expression</dfn> :
 
     | [=syntax/unary_expression=]
 
-    | [=syntax/binary_and_expression=] [=syntax/and=] [=syntax/unary_expression=]
+    | [=syntax/binary_and_expression=] <a for=syntax_sym lt=and>`'&'`</a> [=syntax/unary_expression=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>binary_xor_expression</dfn> :
 
     | [=syntax/unary_expression=]
 
-    | [=syntax/binary_xor_expression=] [=syntax/xor=] [=syntax/unary_expression=]
+    | [=syntax/binary_xor_expression=] <a for=syntax_sym lt=xor>`'^'`</a> [=syntax/unary_expression=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>bitwise_expression</dfn> :
 
-    | [=syntax/binary_and_expression=] [=syntax/and=] [=syntax/unary_expression=]
+    | [=syntax/binary_and_expression=] <a for=syntax_sym lt=and>`'&'`</a> [=syntax/unary_expression=]
 
-    | [=syntax/binary_or_expression=] [=syntax/or=] [=syntax/unary_expression=]
+    | [=syntax/binary_or_expression=] <a for=syntax_sym lt=or>`'|'`</a> [=syntax/unary_expression=]
 
-    | [=syntax/binary_xor_expression=] [=syntax/xor=] [=syntax/unary_expression=]
+    | [=syntax/binary_xor_expression=] <a for=syntax_sym lt=xor>`'^'`</a> [=syntax/unary_expression=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>expression</dfn> :
 
     | [=syntax/relational_expression=]
 
-    | [=syntax/short_circuit_or_expression=] [=syntax/or_or=] [=syntax/relational_expression=]
+    | [=syntax/short_circuit_or_expression=] <a for=syntax_sym lt=or_or>`'||'`</a> [=syntax/relational_expression=]
 
-    | [=syntax/short_circuit_and_expression=] [=syntax/and_and=] [=syntax/relational_expression=]
+    | [=syntax/short_circuit_and_expression=] <a for=syntax_sym lt=and_and>`'&&'`</a> [=syntax/relational_expression=]
 
     | [=syntax/bitwise_expression=]
 </div>
@@ -6591,7 +6671,7 @@ from the start of the next statement until the end of the compound statement.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>compound_statement</dfn> :
 
-    | [=syntax/brace_left=] [=syntax/statement=] * [=syntax/brace_right=]
+    | <a for=syntax_sym lt=brace_left>`'{'`</a> [=syntax/statement=] * <a for=syntax_sym lt=brace_right>`'}'`</a>
 </div>
 
 The [=syntax/continuing_compound_statement=] is a special form of compound
@@ -6608,9 +6688,9 @@ and optionally stores it in memory (thus updating the contents of a variable).
 <div class='syntax' noexport='true'>
   <dfn for=syntax>assignment_statement</dfn> :
 
-    | [=syntax/lhs_expression=] ( [=syntax/equal=] | [=syntax/compound_assignment_operator=] ) [=syntax/expression=]
+    | [=syntax/lhs_expression=] ( <a for=syntax_sym lt=equal>`'='`</a> | [=syntax/compound_assignment_operator=] ) [=syntax/expression=]
 
-    | [=syntax/underscore=] [=syntax/equal=] [=syntax/expression=]
+    | <a for=syntax_sym lt=underscore>`'_'`</a> <a for=syntax_sym lt=equal>`'='`</a> [=syntax/expression=]
 </div>
 
 
@@ -6621,7 +6701,7 @@ expression to the right of the operator token is the <dfn noexport>right-hand si
 ### Simple Assignment ### {#simple-assignment-section}
 
 An [=statement/assignment=] is a <dfn noexport>simple assignment</dfn> when the
-[=left-hand side=] is an expression, and the operator is the [=syntax/equal=] token.
+[=left-hand side=] is an expression, and the operator is the <a for=syntax_sym lt=equal>`'='`</a> token.
 In this case the value of the [=right-hand side=] is written to the memory referenced by the left-hand side.
 
 <table class='data'>
@@ -6749,25 +6829,25 @@ An [=statement/assignment=] is a <dfn noexport>compound assignment</dfn> when th
 <div class='syntax' noexport='true'>
   <dfn for=syntax>compound_assignment_operator</dfn> :
 
-    | [=syntax/plus_equal=]
+    | <a for=syntax_sym lt=plus_equal>`'+='`</a>
 
-    | [=syntax/minus_equal=]
+    | <a for=syntax_sym lt=minus_equal>`'-='`</a>
 
-    | [=syntax/times_equal=]
+    | <a for=syntax_sym lt=times_equal>`'*='`</a>
 
-    | [=syntax/division_equal=]
+    | <a for=syntax_sym lt=division_equal>`'/='`</a>
 
-    | [=syntax/modulo_equal=]
+    | <a for=syntax_sym lt=modulo_equal>`'%='`</a>
 
-    | [=syntax/and_equal=]
+    | <a for=syntax_sym lt=and_equal>`'&='`</a>
 
-    | [=syntax/or_equal=]
+    | <a for=syntax_sym lt=or_equal>`'|='`</a>
 
-    | [=syntax/xor_equal=]
+    | <a for=syntax_sym lt=xor_equal>`'^='`</a>
 
-    | [=syntax/shift_right_equal=]
+    | <a for=syntax_sym lt=shift_right_equal>`'>>='`</a>
 
-    | [=syntax/shift_left_equal=]
+    | <a for=syntax_sym lt=shift_left_equal>`'<<='`</a>
 </div>
 
 The type requirements, semantics, and behavior of each statement is defined as if
@@ -6868,13 +6948,13 @@ A <dfn noexport>decrement statement</dfn> subtracts 1 from the contents of a var
 <div class='syntax' noexport='true'>
   <dfn for=syntax>increment_statement</dfn> :
 
-    | [=syntax/lhs_expression=] [=syntax/plus_plus=]
+    | [=syntax/lhs_expression=] <a for=syntax_sym lt=plus_plus>`'++'`</a>
 </div>
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>decrement_statement</dfn> :
 
-    | [=syntax/lhs_expression=] [=syntax/minus_minus=]
+    | [=syntax/lhs_expression=] <a for=syntax_sym lt=minus_minus>`'--'`</a>
 </div>
 
 The expression [=shader-creation error|must=] evaluate to a reference with a [=type/concrete=] [=integer scalar=] [=store type=] and [=access/read_write=] [=access mode=].
@@ -6929,19 +7009,19 @@ An `if` statement has an `if` clause, followed by zero or more `else if` clauses
 <div class='syntax' noexport='true'>
   <dfn for=syntax>if_clause</dfn> :
 
-    | [=syntax/if=] [=syntax/expression=] [=syntax/compound_statement=]
+    | <a for=syntax_kw lt=if>`'if'`</a> [=syntax/expression=] [=syntax/compound_statement=]
 </div>
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>else_if_clause</dfn> :
 
-    | [=syntax/else=] [=syntax/if=] [=syntax/expression=] [=syntax/compound_statement=]
+    | <a for=syntax_kw lt=else>`'else'`</a> <a for=syntax_kw lt=if>`'if'`</a> [=syntax/expression=] [=syntax/compound_statement=]
 </div>
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>else_clause</dfn> :
 
-    | [=syntax/else=] [=syntax/compound_statement=]
+    | <a for=syntax_kw lt=else>`'else'`</a> [=syntax/compound_statement=]
 </div>
 
 [=Type rule precondition=]:
@@ -6965,7 +7045,7 @@ depending on the evaluation of a selector expression.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>switch_statement</dfn> :
 
-    | [=syntax/switch=] [=syntax/expression=] [=syntax/brace_left=] [=syntax/switch_body=] + [=syntax/brace_right=]
+    | <a for=syntax_kw lt=switch>`'switch'`</a> [=syntax/expression=] <a for=syntax_sym lt=brace_left>`'{'`</a> [=syntax/switch_body=] + <a for=syntax_sym lt=brace_right>`'}'`</a>
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>switch_body</dfn> :
@@ -6977,39 +7057,39 @@ depending on the evaluation of a selector expression.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>case_clause</dfn> :
 
-    | [=syntax/case=] [=syntax/case_selectors=] [=syntax/colon=] ? [=syntax/compound_statement=]
+    | <a for=syntax_kw lt=case>`'case'`</a> [=syntax/case_selectors=] <a for=syntax_sym lt=colon>`':'`</a> ? [=syntax/compound_statement=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>default_alone_clause</dfn> :
 
-    | [=syntax/default=] [=syntax/colon=] ? [=syntax/compound_statement=]
+    | <a for=syntax_kw lt=default>`'default'`</a> <a for=syntax_sym lt=colon>`':'`</a> ? [=syntax/compound_statement=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>case_selectors</dfn> :
 
-    | [=syntax/case_selector=] ( [=syntax/comma=] [=syntax/case_selector=] ) * [=syntax/comma=] ?
+    | [=syntax/case_selector=] ( <a for=syntax_sym lt=comma>`','`</a> [=syntax/case_selector=] ) * <a for=syntax_sym lt=comma>`','`</a> ?
 </div>
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>case_selector</dfn> :
 
-    | [=syntax/default=]
+    | <a for=syntax_kw lt=default>`'default'`</a>
 
     | [=syntax/expression=]
 </div>
 
-A <dfn noexport>case clause</dfn> is the [=syntax/case=] token followed by a comma-separated list of [=syntax/case_selector|case selectors=] and a
+A <dfn noexport>case clause</dfn> is the <a for=syntax_kw lt=case>`'case'`</a> token followed by a comma-separated list of [=syntax/case_selector|case selectors=] and a
 body in the form of a [=compound statement=].
 
-A <dfn noexport>default-alone clause</dfn> is the [=syntax/default=] token followed by a body in the form of a [=compound statement=].
+A <dfn noexport>default-alone clause</dfn> is the <a for=syntax_kw lt=default>`'default'`</a> token followed by a body in the form of a [=compound statement=].
 
 A <dfn noexport>default clause</dfn> is either:
-* a [=case clause=] where [=syntax/default=] appears as one of its selectors, or
+* a [=case clause=] where <a for=syntax_kw lt=default>`'default'`</a> appears as one of its selectors, or
 * a [=default-alone clause=].
 
 Each switch statement [=shader-creation error|must=] have exactly one [=default clause=].
 
-The [=syntax/default=] token [=shader-creation error|must=] not appear more than once in a single [=syntax/case_selector=] list.
+The <a for=syntax_kw lt=default>`'default'`</a> token [=shader-creation error|must=] not appear more than once in a single [=syntax/case_selector=] list.
 
 [=Type rule precondition=]:
 For a single switch statement, the selector expression and all case selector expressions [=shader-creation error|must=] be of the same [=type/concrete=] [=integer scalar=] type.
@@ -7082,7 +7162,7 @@ creating a new instance of the [=variable declaration|variable=] or [=value decl
 <div class='syntax' noexport='true'>
   <dfn for=syntax>loop_statement</dfn> :
 
-    | [=syntax/loop=] [=syntax/brace_left=] [=syntax/statement=] * [=syntax/continuing_statement=] ? [=syntax/brace_right=]
+    | <a for=syntax_kw lt=loop>`'loop'`</a> <a for=syntax_sym lt=brace_left>`'{'`</a> [=syntax/statement=] * [=syntax/continuing_statement=] ? <a for=syntax_sym lt=brace_right>`'}'`</a>
 </div>
 
 A <dfn noexport dfn-for="statement">loop</dfn> statement repeatedly executes a <dfn noexport>loop body</dfn>;
@@ -7188,13 +7268,13 @@ allows them to naturally use values defined in the loop body.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>for_statement</dfn> :
 
-    | [=syntax/for=] [=syntax/paren_left=] [=syntax/for_header=] [=syntax/paren_right=] [=syntax/compound_statement=]
+    | <a for=syntax_kw lt=for>`'for'`</a> <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/for_header=] <a for=syntax_sym lt=paren_right>`')'`</a> [=syntax/compound_statement=]
 </div>
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>for_header</dfn> :
 
-    | [=syntax/for_init=] ? [=syntax/semicolon=] [=syntax/expression=] ? [=syntax/semicolon=] [=syntax/for_update=] ?
+    | [=syntax/for_init=] ? <a for=syntax_sym lt=semicolon>`';'`</a> [=syntax/expression=] ? <a for=syntax_sym lt=semicolon>`';'`</a> [=syntax/for_update=] ?
 </div>
 
 <div class='syntax' noexport='true'>
@@ -7277,7 +7357,7 @@ Converts to:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>while_statement</dfn> :
 
-    | [=syntax/while=] [=syntax/expression=] [=syntax/compound_statement=]
+    | <a for=syntax_kw lt=while>`'while'`</a> [=syntax/expression=] [=syntax/compound_statement=]
 </div>
 
 The <dfn noexport dfn-for="statement">while</dfn> statement is a kind of loop parameterized by a condition.
@@ -7298,7 +7378,7 @@ The following statement forms are equivalent:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>break_statement</dfn> :
 
-    | [=syntax/break=]
+    | <a for=syntax_kw lt=break>`'break'`</a>
 </div>
 
 A <dfn noexport dfn-for="statement">break</dfn> statement transfers control to immediately
@@ -7334,7 +7414,7 @@ Use a [[#break-if-statement|break-if]] statement instead.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>break_if_statement</dfn> :
 
-    | [=syntax/break=] [=syntax/if=] [=syntax/expression=] [=syntax/semicolon=]
+    | <a for=syntax_kw lt=break>`'break'`</a> <a for=syntax_kw lt=if>`'if'`</a> [=syntax/expression=] <a for=syntax_sym lt=semicolon>`';'`</a>
 </div>
 
 A <dfn noexport dfn-for="statement">break-if</dfn> statement evaluates a boolean condition;
@@ -7370,7 +7450,7 @@ statement.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>continue_statement</dfn> :
 
-    | [=syntax/continue=]
+    | <a for=syntax_kw lt=continue>`'continue'`</a>
 </div>
 
 A <dfn noexport dfn-for="statement">continue</dfn> statement transfers control in the nearest-enclosing [=statement/loop=]:
@@ -7412,13 +7492,13 @@ cannot be used to transfer control to the start of the currently executing `cont
 <div class='syntax' noexport='true'>
   <dfn for=syntax>continuing_statement</dfn> :
 
-    | [=syntax/continuing=] [=syntax/continuing_compound_statement=]
+    | <a for=syntax_kw lt=continuing>`'continuing'`</a> [=syntax/continuing_compound_statement=]
 </div>
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>continuing_compound_statement</dfn> :
 
-    | [=syntax/brace_left=] [=syntax/statement=] * [=syntax/break_if_statement=] ? [=syntax/brace_right=]
+    | <a for=syntax_sym lt=brace_left>`'{'`</a> [=syntax/statement=] * [=syntax/break_if_statement=] ? <a for=syntax_sym lt=brace_right>`'}'`</a>
 </div>
 
 A <dfn dfn-for="statement">continuing</dfn> statement specifies a [=compound statement=] to be executed at the end of a loop [=iteration=].
@@ -7431,7 +7511,7 @@ The compound statement [=shader-creation error|must not=] contain a [=statement/
 <div class='syntax' noexport='true'>
   <dfn for=syntax>return_statement</dfn> :
 
-    | [=syntax/return=] [=syntax/expression=] ?
+    | <a for=syntax_kw lt=return>`'return'`</a> [=syntax/expression=] ?
 </div>
 
 A <dfn noexport dfn-for="statement">return</dfn> statement ends execution of the current function.
@@ -7518,7 +7598,7 @@ This statement can be used at [=module scope=] and within [=function scope|funct
 <div class='syntax' noexport='true'>
   <dfn for=syntax>static_assert_statement</dfn> :
 
-    | [=syntax/static_assert=] [=syntax/expression=]
+    | <a for=syntax_kw lt=static_assert>`'static_assert'`</a> [=syntax/expression=]
 </div>
 
 <div class='example wgsl global-scope' heading="Static assertion examples">
@@ -7544,9 +7624,9 @@ The [=syntax/statement=] rule matches statements that can be used in most places
 <div class='syntax' noexport='true'>
   <dfn for=syntax>statement</dfn> :
 
-    | [=syntax/semicolon=]
+    | <a for=syntax_sym lt=semicolon>`';'`</a>
 
-    | [=syntax/return_statement=] [=syntax/semicolon=]
+    | [=syntax/return_statement=] <a for=syntax_sym lt=semicolon>`';'`</a>
 
     | [=syntax/if_statement=]
 
@@ -7558,21 +7638,21 @@ The [=syntax/statement=] rule matches statements that can be used in most places
 
     | [=syntax/while_statement=]
 
-    | [=syntax/func_call_statement=] [=syntax/semicolon=]
+    | [=syntax/func_call_statement=] <a for=syntax_sym lt=semicolon>`';'`</a>
 
-    | [=syntax/variable_statement=] [=syntax/semicolon=]
+    | [=syntax/variable_statement=] <a for=syntax_sym lt=semicolon>`';'`</a>
 
-    | [=syntax/break_statement=] [=syntax/semicolon=]
+    | [=syntax/break_statement=] <a for=syntax_sym lt=semicolon>`';'`</a>
 
-    | [=syntax/continue_statement=] [=syntax/semicolon=]
+    | [=syntax/continue_statement=] <a for=syntax_sym lt=semicolon>`';'`</a>
 
-    | [=syntax/discard=] [=syntax/semicolon=]
+    | <a for=syntax_kw lt=discard>`'discard'`</a> <a for=syntax_sym lt=semicolon>`';'`</a>
 
-    | [=syntax/variable_updating_statement=] [=syntax/semicolon=]
+    | [=syntax/variable_updating_statement=] <a for=syntax_sym lt=semicolon>`';'`</a>
 
     | [=syntax/compound_statement=]
 
-    | [=syntax/static_assert_statement=] [=syntax/semicolon=]
+    | [=syntax/static_assert_statement=] <a for=syntax_sym lt=semicolon>`';'`</a>
 </div>
 
 <div class='syntax' noexport='true'>
@@ -8024,17 +8104,17 @@ parameters and return types:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>function_header</dfn> :
 
-    | [=syntax/fn=] [=syntax/ident=] [=syntax/paren_left=] [=syntax/param_list=] ? [=syntax/paren_right=] ( [=syntax/arrow=] [=syntax/attribute=] * [=syntax/type_specifier=] ) ?
+    | <a for=syntax_kw lt=fn>`'fn'`</a> [=syntax/ident=] <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/param_list=] ? <a for=syntax_sym lt=paren_right>`')'`</a> ( <a for=syntax_sym lt=arrow>`'->'`</a> [=syntax/attribute=] * [=syntax/type_specifier=] ) ?
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>param_list</dfn> :
 
-    | [=syntax/param=] ( [=syntax/comma=] [=syntax/param=] ) * [=syntax/comma=] ?
+    | [=syntax/param=] ( <a for=syntax_sym lt=comma>`','`</a> [=syntax/param=] ) * <a for=syntax_sym lt=comma>`','`</a> ?
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>param</dfn> :
 
-    | [=syntax/attribute=] * [=syntax/ident=] [=syntax/colon=] [=syntax/type_specifier=]
+    | [=syntax/attribute=] * [=syntax/ident=] <a for=syntax_sym lt=colon>`':'`</a> [=syntax/type_specifier=]
 </div>
 
 <div class='example wgsl' heading='Simple functions'>
@@ -8762,7 +8842,7 @@ The valid extensions are listed in [[#extension-list]].
 <div class='syntax' noexport='true'>
   <dfn for=syntax>enable_directive</dfn> :
 
-    | [=syntax/enable=] [=syntax/extension_name=] [=syntax/semicolon=]
+    | <a for=syntax_kw lt=enable>`'enable'`</a> [=syntax/extension_name=] <a for=syntax_sym lt=semicolon>`';'`</a>
 </div>
 
 Note: The grammar rule includes the terminating semicolon token,
@@ -8821,19 +8901,19 @@ A WGSL program is a sequence of optional [=directives=] followed by [=module sco
 <div class='syntax' noexport='true'>
   <dfn for=syntax>global_decl</dfn> :
 
-    | [=syntax/semicolon=]
+    | <a for=syntax_sym lt=semicolon>`';'`</a>
 
-    | [=syntax/global_variable_decl=] [=syntax/semicolon=]
+    | [=syntax/global_variable_decl=] <a for=syntax_sym lt=semicolon>`';'`</a>
 
-    | [=syntax/global_constant_decl=] [=syntax/semicolon=]
+    | [=syntax/global_constant_decl=] <a for=syntax_sym lt=semicolon>`';'`</a>
 
-    | [=syntax/type_alias_decl=] [=syntax/semicolon=]
+    | [=syntax/type_alias_decl=] <a for=syntax_sym lt=semicolon>`';'`</a>
 
     | [=syntax/struct_decl=]
 
     | [=syntax/function_decl=]
 
-    | [=syntax/static_assert_statement=] [=syntax/semicolon=]
+    | [=syntax/static_assert_statement=] <a for=syntax_sym lt=semicolon>`';'`</a>
 </div>
 
 ## Limits ## {#limits}
@@ -10367,324 +10447,72 @@ Issue: https://github.com/gpuweb/gpuweb/issues/1621
 
 ### Type-defining Keywords ### {#type-defining-keywords}
 
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>array</dfn> :
-
-    | `'array'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>atomic</dfn> :
-
-    | `'atomic'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>bool</dfn> :
-
-    | `'bool'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>float32</dfn> :
-
-    | `'f32'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>float16</dfn> :
-
-    | `'f16'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>int32</dfn> :
-
-    | `'i32'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>mat2x2</dfn> :
-
-    | `'mat2x2'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>mat2x3</dfn> :
-
-    | `'mat2x3'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>mat2x4</dfn> :
-
-    | `'mat2x4'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>mat3x2</dfn> :
-
-    | `'mat3x2'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>mat3x3</dfn> :
-
-    | `'mat3x3'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>mat3x4</dfn> :
-
-    | `'mat3x4'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>mat4x2</dfn> :
-
-    | `'mat4x2'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>mat4x3</dfn> :
-
-    | `'mat4x3'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>mat4x4</dfn> :
-
-    | `'mat4x4'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>pointer</dfn> :
-
-    | `'ptr'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>sampler</dfn> :
-
-    | `'sampler'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>sampler_comparison</dfn> :
-
-    | `'sampler_comparison'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_1d</dfn> :
-
-    | `'texture_1d'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_2d</dfn> :
-
-    | `'texture_2d'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_2d_array</dfn> :
-
-    | `'texture_2d_array'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_3d</dfn> :
-
-    | `'texture_3d'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_cube</dfn> :
-
-    | `'texture_cube'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_cube_array</dfn> :
-
-    | `'texture_cube_array'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_multisampled_2d</dfn> :
-
-    | `'texture_multisampled_2d'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_storage_1d</dfn> :
-
-    | `'texture_storage_1d'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_storage_2d</dfn> :
-
-    | `'texture_storage_2d'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_storage_2d_array</dfn> :
-
-    | `'texture_storage_2d_array'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_storage_3d</dfn> :
-
-    | `'texture_storage_3d'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_depth_2d</dfn> :
-
-    | `'texture_depth_2d'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_depth_2d_array</dfn> :
-
-    | `'texture_depth_2d_array'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_depth_cube</dfn> :
-
-    | `'texture_depth_cube'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_depth_cube_array</dfn> :
-
-    | `'texture_depth_cube_array'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_depth_multisampled_2d</dfn> :
-
-    | `'texture_depth_multisampled_2d'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>uint32</dfn> :
-
-    | `'u32'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>vec2</dfn> :
-
-    | `'vec2'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>vec3</dfn> :
-
-    | `'vec3'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>vec4</dfn> :
-
-    | `'vec4'`
-</div>
+* <dfn for=syntax_kw noexport>`array`</dfn>
+* <dfn for=syntax_kw noexport>`atomic`</dfn>
+* <dfn for=syntax_kw noexport>`bool`</dfn>
+* <dfn for=syntax_kw noexport>`f32`</dfn>
+* <dfn for=syntax_kw noexport>`f16`</dfn>
+* <dfn for=syntax_kw noexport>`i32`</dfn>
+* <dfn for=syntax_kw noexport>`mat2x2`</dfn>
+* <dfn for=syntax_kw noexport>`mat2x3`</dfn>
+* <dfn for=syntax_kw noexport>`mat2x4`</dfn>
+* <dfn for=syntax_kw noexport>`mat3x2`</dfn>
+* <dfn for=syntax_kw noexport>`mat3x3`</dfn>
+* <dfn for=syntax_kw noexport>`mat3x4`</dfn>
+* <dfn for=syntax_kw noexport>`mat4x2`</dfn>
+* <dfn for=syntax_kw noexport>`mat4x3`</dfn>
+* <dfn for=syntax_kw noexport>`mat4x4`</dfn>
+* <dfn for=syntax_kw noexport>`ptr`</dfn>
+* <dfn for=syntax_kw noexport>`sampler`</dfn>
+* <dfn for=syntax_kw noexport>`sampler_comparison`</dfn>
+* <dfn for=syntax_kw noexport>`texture_1d`</dfn>
+* <dfn for=syntax_kw noexport>`texture_2d`</dfn>
+* <dfn for=syntax_kw noexport>`texture_2d_array`</dfn>
+* <dfn for=syntax_kw noexport>`texture_3d`</dfn>
+* <dfn for=syntax_kw noexport>`texture_cube`</dfn>
+* <dfn for=syntax_kw noexport>`texture_cube_array`</dfn>
+* <dfn for=syntax_kw noexport>`texture_multisampled_2d`</dfn>
+* <dfn for=syntax_kw noexport>`texture_storage_1d`</dfn>
+* <dfn for=syntax_kw noexport>`texture_storage_2d`</dfn>
+* <dfn for=syntax_kw noexport>`texture_storage_2d_array`</dfn>
+* <dfn for=syntax_kw noexport>`texture_storage_3d`</dfn>
+* <dfn for=syntax_kw noexport>`texture_depth_2d`</dfn>
+* <dfn for=syntax_kw noexport>`texture_depth_2d_array`</dfn>
+* <dfn for=syntax_kw noexport>`texture_depth_cube`</dfn>
+* <dfn for=syntax_kw noexport>`texture_depth_cube_array`</dfn>
+* <dfn for=syntax_kw noexport>`texture_depth_multisampled_2d`</dfn>
+* <dfn for=syntax_kw noexport>`u32`</dfn>
+* <dfn for=syntax_kw noexport>`vec2`</dfn>
+* <dfn for=syntax_kw noexport>`vec3`</dfn>
+* <dfn for=syntax_kw noexport>`vec4`</dfn>
 
 ### Other Keywords ### {#other-keywords}
 
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>bitcast</dfn> :
-
-    | `'bitcast'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>break</dfn> :
-
-    | `'break'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>case</dfn> :
-
-    | `'case'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>const</dfn> :
-
-    | `'const'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>continue</dfn> :
-
-    | `'continue'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>continuing</dfn> :
-
-    | `'continuing'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>default</dfn> :
-
-    | `'default'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>discard</dfn> :
-
-    | `'discard'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>else</dfn> :
-
-    | `'else'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>enable</dfn> :
-
-    | `'enable'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>false</dfn> :
-
-    | `'false'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>fn</dfn> :
-
-    | `'fn'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>for</dfn> :
-
-    | `'for'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>if</dfn> :
-
-    | `'if'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>let</dfn> :
-
-    | `'let'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>loop</dfn> :
-
-    | `'loop'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>override</dfn> :
-
-    | `'override'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>return</dfn> :
-
-    | `'return'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>static_assert</dfn> :
-
-    | `'static_assert'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>struct</dfn> :
-
-    | `'struct'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>switch</dfn> :
-
-    | `'switch'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>true</dfn> :
-
-    | `'true'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>type</dfn> :
-
-    | `'type'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>var</dfn> :
-
-    | `'var'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>while</dfn> :
-
-    | `'while'`
-</div>
+* <dfn for=syntax_kw noexport>`bitcast`</dfn>
+* <dfn for=syntax_kw noexport>`break`</dfn>
+* <dfn for=syntax_kw noexport>`case`</dfn>
+* <dfn for=syntax_kw noexport>`const`</dfn>
+* <dfn for=syntax_kw noexport>`continue`</dfn>
+* <dfn for=syntax_kw noexport>`continuing`</dfn>
+* <dfn for=syntax_kw noexport>`default`</dfn>
+* <dfn for=syntax_kw noexport>`discard`</dfn>
+* <dfn for=syntax_kw noexport>`else`</dfn>
+* <dfn for=syntax_kw noexport>`enable`</dfn>
+* <dfn for=syntax_kw noexport>`false`</dfn>
+* <dfn for=syntax_kw noexport>`fn`</dfn>
+* <dfn for=syntax_kw noexport>`for`</dfn>
+* <dfn for=syntax_kw noexport>`if`</dfn>
+* <dfn for=syntax_kw noexport>`let`</dfn>
+* <dfn for=syntax_kw noexport>`loop`</dfn>
+* <dfn for=syntax_kw noexport>`override`</dfn>
+* <dfn for=syntax_kw noexport>`return`</dfn>
+* <dfn for=syntax_kw noexport>`static_assert`</dfn>
+* <dfn for=syntax_kw noexport>`struct`</dfn>
+* <dfn for=syntax_kw noexport>`switch`</dfn>
+* <dfn for=syntax_kw noexport>`true`</dfn>
+* <dfn for=syntax_kw noexport>`type`</dfn>
+* <dfn for=syntax_kw noexport>`var`</dfn>
+* <dfn for=syntax_kw noexport>`while`</dfn>
 
 ## Reserved Words ## {#reserved-words}
 
@@ -10703,236 +10531,54 @@ A <dfn>syntactic token</dfn> is a sequence of special code points, used:
 * to spell an expression operator, or
 * as punctuation: to group, sequence, or separate other grammar elements.
 
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>and</dfn> :
+List of [=syntactic tokens=]:
 
-    | `'&'` (Code point: `U+0026`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>and_and</dfn> :
-
-    | `'&&'` (Code points: `U+0026` `U+0026`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>arrow</dfn> :
-
-    | `'->'` (Code points: `U+002D` `U+003E`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>attr</dfn> :
-
-    | `'@'` (Code point: `U+0040`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>forward_slash</dfn> :
-
-    | `'/'` (Code point: `U+002F`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>bang</dfn> :
-
-    | `'!'` (Code point: `U+0021`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>bracket_left</dfn> :
-
-    | `'['` (Code point: `U+005B`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>bracket_right</dfn> :
-
-    | `']'` (Code point: `U+005D`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>brace_left</dfn> :
-
-    | `'{'` (Code point: `U+007B`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>brace_right</dfn> :
-
-    | `'}'` (Code point: `U+007D`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>colon</dfn> :
-
-    | `':'` (Code point: `U+003A`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>comma</dfn> :
-
-    | `','` (Code point: `U+002C`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>equal</dfn> :
-
-    | `'='` (Code point: `U+003D`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>equal_equal</dfn> :
-
-    | `'=='` (Code points: `U+003D` `U+003D`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>not_equal</dfn> :
-
-    | `'!='` (Code points: `U+0021` `U+003D`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>greater_than</dfn> :
-
-    | `'>'` (Code point: `U+003E`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>greater_than_equal</dfn> :
-
-    | `'>='` (Code points: `U+003E` `U+003D`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>shift_right</dfn> :
-
-    | `'>>'` (Code point: `U+003E` `U+003E`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>less_than</dfn> :
-
-    | `'<'` (Code point: `U+003C`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>less_than_equal</dfn> :
-
-    | `'<='` (Code points: `U+003C` `U+003D`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>shift_left</dfn> :
-
-    | `'<<'` (Code points: `U+003C` `U+003C`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>modulo</dfn> :
-
-    | `'%'` (Code point: `U+0025`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>minus</dfn> :
-
-    | `'-'` (Code point: `U+002D`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>minus_minus</dfn> :
-
-    | `'--'` (Code points: `U+002D` `U+002D`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>period</dfn> :
-
-    | `'.'` (Code point: `U+002E`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>plus</dfn> :
-
-    | `'+'` (Code point: `U+002B`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>plus_plus</dfn> :
-
-    | `'++'` (Code points: `U+002B` `U+002B`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>or</dfn> :
-
-    | `'|'` (Code point: `U+007C`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>or_or</dfn> :
-
-    | `'||'` (Code points: `U+007C` `U+007C`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>paren_left</dfn> :
-
-    | `'('` (Code point: `U+0028`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>paren_right</dfn> :
-
-    | `')'` (Code point: `U+0029`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>semicolon</dfn> :
-
-    | `';'` (Code point: `U+003B`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>star</dfn> :
-
-    | `'*'` (Code point: `U+002A`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>tilde</dfn> :
-
-    | `'~'` (Code point: `U+007E`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>underscore</dfn> :
-
-    | `'_'` (Code point: `U+005F`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>xor</dfn> :
-
-    | `'^'` (Code point: `U+005E`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>plus_equal</dfn> :
-
-    | `'+='` (Code points: `U+002B` `U+003D`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>minus_equal</dfn> :
-
-    | `'-='` (Code points: `U+002D` `U+003D`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>times_equal</dfn> :
-
-    | `'*='` (Code points: `U+002A` `U+003D`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>division_equal</dfn> :
-
-    | `'/='` (Code points: `U+002F` `U+003D`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>modulo_equal</dfn> :
-
-    | `'%='` (Code points: `U+0025` `U+003D`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>and_equal</dfn> :
-
-    | `'&='` (Code points: `U+0026` `U+003D`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>or_equal</dfn> :
-
-    | `'|='` (Code points: `U+007C` `U+003D`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>xor_equal</dfn> :
-
-    | `'^='` (Code points: `U+005E` `U+003D`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>shift_right_equal</dfn> :
-
-    | `'>>='` (Code points: `U+003E` `U+003E` `U+003D`)
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>shift_left_equal</dfn> :
-
-    | `'<<='` (Code points: `U+003C` `U+003C` `U+003D`)
-</div>
+* <dfn for=syntax_sym lt='and' noexport>`'&'` (Code point: `U+0026`)</dfn>
+* <dfn for=syntax_sym lt='and_and' noexport>`'&&'` (Code points: `U+0026` `U+0026`)</dfn>
+* <dfn for=syntax_sym lt='arrow' noexport>`'->'` (Code points: `U+002D` `U+003E`)</dfn>
+* <dfn for=syntax_sym lt='attr' noexport>`'@'` (Code point: `U+0040`)</dfn>
+* <dfn for=syntax_sym lt='forward_slash' noexport>`'/'` (Code point: `U+002F`)</dfn>
+* <dfn for=syntax_sym lt='bang' noexport>`'!'` (Code point: `U+0021`)</dfn>
+* <dfn for=syntax_sym lt='bracket_left' noexport>`'['` (Code point: `U+005B`)</dfn>
+* <dfn for=syntax_sym lt='bracket_right' noexport>`']'` (Code point: `U+005D`)</dfn>
+* <dfn for=syntax_sym lt='brace_left' noexport>`'{'` (Code point: `U+007B`)</dfn>
+* <dfn for=syntax_sym lt='brace_right' noexport>`'}'` (Code point: `U+007D`)</dfn>
+* <dfn for=syntax_sym lt='colon' noexport>`':'` (Code point: `U+003A`)</dfn>
+* <dfn for=syntax_sym lt='comma' noexport>`','` (Code point: `U+002C`)</dfn>
+* <dfn for=syntax_sym lt='equal' noexport>`'='` (Code point: `U+003D`)</dfn>
+* <dfn for=syntax_sym lt='equal_equal' noexport>`'=='` (Code points: `U+003D` `U+003D`)</dfn>
+* <dfn for=syntax_sym lt='not_equal' noexport>`'!='` (Code points: `U+0021` `U+003D`)</dfn>
+* <dfn for=syntax_sym lt='greater_than' noexport>`'>'` (Code point: `U+003E`)</dfn>
+* <dfn for=syntax_sym lt='greater_than_equal' noexport>`'>='` (Code points: `U+003E` `U+003D`)</dfn>
+* <dfn for=syntax_sym lt='shift_right' noexport>`'>>'` (Code point: `U+003E` `U+003E`)</dfn>
+* <dfn for=syntax_sym lt='less_than' noexport>`'<'` (Code point: `U+003C`)</dfn>
+* <dfn for=syntax_sym lt='less_than_equal' noexport>`'<='` (Code points: `U+003C` `U+003D`)</dfn>
+* <dfn for=syntax_sym lt='shift_left' noexport>`'<<'` (Code points: `U+003C` `U+003C`)</dfn>
+* <dfn for=syntax_sym lt='modulo' noexport>`'%'` (Code point: `U+0025`)</dfn>
+* <dfn for=syntax_sym lt='minus' noexport>`'-'` (Code point: `U+002D`)</dfn>
+* <dfn for=syntax_sym lt='minus_minus' noexport>`'--'` (Code points: `U+002D` `U+002D`)</dfn>
+* <dfn for=syntax_sym lt='period' noexport>`'.'` (Code point: `U+002E`)</dfn>
+* <dfn for=syntax_sym lt='plus' noexport>`'+'` (Code point: `U+002B`)</dfn>
+* <dfn for=syntax_sym lt='plus_plus' noexport>`'++'` (Code points: `U+002B` `U+002B`)</dfn>
+* <dfn for=syntax_sym lt='or' noexport>`'|'` (Code point: `U+007C`)</dfn>
+* <dfn for=syntax_sym lt='or_or' noexport>`'||'` (Code points: `U+007C` `U+007C`)</dfn>
+* <dfn for=syntax_sym lt='paren_left' noexport>`'('` (Code point: `U+0028`)</dfn>
+* <dfn for=syntax_sym lt='paren_right' noexport>`')'` (Code point: `U+0029`)</dfn>
+* <dfn for=syntax_sym lt='semicolon' noexport>`';'` (Code point: `U+003B`)</dfn>
+* <dfn for=syntax_sym lt='star' noexport>`'*'` (Code point: `U+002A`)</dfn>
+* <dfn for=syntax_sym lt='tilde' noexport>`'~'` (Code point: `U+007E`)</dfn>
+* <dfn for=syntax_sym lt='underscore' noexport>`'_'` (Code point: `U+005F`)</dfn>
+* <dfn for=syntax_sym lt='xor' noexport>`'^'` (Code point: `U+005E`)</dfn>
+* <dfn for=syntax_sym lt='plus_equal' noexport>`'+='` (Code points: `U+002B` `U+003D`)</dfn>
+* <dfn for=syntax_sym lt='minus_equal' noexport>`'-='` (Code points: `U+002D` `U+003D`)</dfn>
+* <dfn for=syntax_sym lt='times_equal' noexport>`'*='` (Code points: `U+002A` `U+003D`)</dfn>
+* <dfn for=syntax_sym lt='division_equal' noexport>`'/='` (Code points: `U+002F` `U+003D`)</dfn>
+* <dfn for=syntax_sym lt='modulo_equal' noexport>`'%='` (Code points: `U+0025` `U+003D`)</dfn>
+* <dfn for=syntax_sym lt='and_equal' noexport>`'&='` (Code points: `U+0026` `U+003D`)</dfn>
+* <dfn for=syntax_sym lt='or_equal' noexport>`'|='` (Code points: `U+007C` `U+003D`)</dfn>
+* <dfn for=syntax_sym lt='xor_equal' noexport>`'^='` (Code points: `U+005E` `U+003D`)</dfn>
+* <dfn for=syntax_sym lt='shift_right_equal' noexport>`'>>='` (Code points: `U+003E` `U+003E` `U+003D`)</dfn>
+* <dfn for=syntax_sym lt='shift_left_equal' noexport>`'<<='` (Code points: `U+003C` `U+003C` `U+003D`)</dfn>
 
 ## Context-Dependent Name Tokens ## {#context-dependent-name-tokens}
 


### PR DESCRIPTION
<img width="1024" alt="IMG_6157" src="https://user-images.githubusercontent.com/5333693/197338905-f3c48830-d0c1-44f4-85f1-323a9b8a699e.PNG">

**Preview:** https://mehmetoguzderin.github.io/gpuweb-20221022-syntax/

## Motivation

As a textual language for a widely-anticipated Web API, WGSL should have a readable syntactic grammar styled to adopt emerging norms in this field to reduce the deviation & surprise factor in the spelling to be more welcoming.

## Comparison

The following table studies the widely taught programming languages with well-specified syntactic grammar. The breakdown of elements is then put into the utility to build this PR, with each element listing the rationale for the choice, where the choice is either majority or improvement. Besides styling, this study reveals at least one critical component WGSL spec lacks, whereas subjects have: an introduction of syntactic notation elements.

| Aspect | [CSS](https://www.w3.org/TR/css-syntax-3/) | [ECMAScript](https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html) | [Python](https://docs.python.org/3/reference/grammar.html) | [Rust](https://doc.rust-lang.org/reference/expressions/if-expr.html) | [Swift](https://docs.swift.org/swift-book/ReferenceManual/Statements.html) | [Go](https://go.dev/ref/spec) | [C++ (open-std)](https://www.open-std.org/JTC1/SC22/WG21/docs/papers/2020/n4849.pdf) | WGSL Old | [WGSL New](https://mehmetoguzderin.github.io/gpuweb-20221022-syntax/) |
|---|---|---|---|---|---|---|---|---|---|
| Introduction of Notation | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No | Yes |
| Notation Element Styling | Mono-space Color | Color | Mono-space | Regular | Italic | Mono-space | Italic | Regular | Regular |
| Notation Element Linking | Yes | No | No | No | No | No | No | No | No |
| Keyword Symbol Token Embedding | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No | Yes |
| Keyword Symbol Token Embedding Styling | Mono-space Single-quote | Mono-space No-quote | Mono-space Single-quote | Mono-space Back-ground No-quote | Mono-space Bold No-quote | Mono-space Double-quote | Mono-space No-quote | No-embedding | Bold Mono-space Back-ground Single-quote |
| Keyword Symbol Token Embedding Linking | No | No | No | No | No | No | No | No-embedding | Yes |
| Rule Styling | Mono-space | Italic | Mono-space Color | Italic | Italic-and-Regular | Mono-space Color | Italic | Color | Italic |
| Rule Linking | Partial | Yes | No | Yes | Yes | Yes | No | Yes | Yes |
| Rule Naming | Kebab-case | Pascal-case | Snake-case | Pascal-case | Kebab-case | Pascal-case | Kebab-case | Snake-case | Snake-case |
| Dark Mode Exists | No | No | No | Yes | No | Yes | No | Yes | Yes |

(Use of - for line wrapping in certain words)

## Conclusion

I believe this PR is necessary to deliver on the great responsibility of increasing access to the language and fitting what people around the world, especially non-Anglophone individuals, access allows for a practical increase in accessibility of the content with fewer surprises. The current build-through-names type of styling, reminiscent of GLSL, is far from that and does not favor the international reader or anybody with taste in modern programming languages' syntactic grammar rules. Furthermore, this improvement will increase the approachability for people to propose syntactic enhancements to the language in the future with a clean core.

Yes, this PR is a bit big in its change surface in the source code, but I could not pursue the iteratively-refining path toward this state. Additionally, this PR bundles a would-be-hard-to-spot mislink that I came across, which makes the commit an amalgamation of almost would-be-more-than-5 PRs.

And yes, this PR changes the extractor, hence, CI until the merge.

I have practical plans to improve the source (rule) authoring experience in the near future; besides other editorial changes, studies to come that I want to build off of the merge of this editorial change.

Thank you very much!

cc: @dneto0 @alan-baker