### PR TITLE
Force concrete types unless all subexpressions are const-expressions

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1576,6 +1576,12 @@ Overload resolution for |P| proceeds as follows, with the goal of finding a sing
     * There is a [=feasible automatic conversion=] from the expression's static type to the type required by the corresponding type assertion in the preconditions.
         Let |C|.|R|(i) be the [=ConversionRank=] of that conversion.
 
+1. Eliminate any candidate where one of its subexpressions resolves to an
+    [=type/abstract=] type after [=feasible automatic conversions=], but another
+    of the candidate's subexpressions is not a [=const-expression=].
+    * That is, overload resolution will [=concretization|concretize=] the type of
+        an expression unless all its subexpressions are [=const-expressions=].
+
 1. Rank candidates: Given two overload candidates |C1| and |C2|, |C1| is <dfn lt="preferable candidate">preferred</dfn> over |C2| if:
     * For each expression position |i| in |P|, |C1|.|R|(i) &le; |C2|.|R|(i).
          * That is, each expression conversion required to apply |C1| to |P| is at least as preferable as the corresponding expression conversion required to apply |C2| to |P|.
@@ -5720,22 +5726,6 @@ See [[#sync-builtin-functions]].
            * It is a [=shader-creation error=] if |i| is a [=const-expression=].
            * It is a [=pipeline-creation error=] if |i| is an [=override-expression=].
            * Otherwise, an [=indeterminate value=] for |T| may be returned.
-
-  <tr algorithm="fixed-size array indexed element selection abstract">
-       <td class="nowrap">
-          |e|: array&lt;|T|,|N|&gt;<br>
-          |i|: [INT]<br>
-          |T| is [=type/abstract=]<br>
-          |i| is a [=const-expression=]
-       <td class="nowrap">
-           |e|[|i|] : |T|
-       <td>The result is the value of the |i|'<sup>th</sup> element of the array value |e|.
-
-           It is a [=shader-creation error=] if |i| is outside the range [0,|N|-1].
-
-           Note: When an abstract array value |e| is indexed by an expression that
-           is not a [=const-expression=], then the array is
-           [=concretization of a value|concretized=] before the index is applied.
 </table>
 
 <table class='data'>


### PR DESCRIPTION
* Previously the spec had a special rule for array access expressions that a runtime index expression would concretize the whole array
  * this is special rule is removed and replaced with a more general one
* Add a new filter to overload resolution that eliminates any candidate involving abstract types (after conversion) and non-const-expressions