### PR TITLE
Generalize integer texture parameter requirements

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -13038,23 +13038,23 @@ Returns the dimensions of a texture, or texture's mip level in texels.
     <tr><td style="width:25%">Parameterization<th>Overload
   </thead>
   <tr algorithm="textureDimensions 1d">
-    <td><var ignore>ST</var> is [=i32=], [=u32=] or [=f32=]<br>
+    <td><var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]<br>
         <var ignore>F</var> is a [=texel format=]<br>
         <var ignore>A</var> is an [=access mode=]<br><br>
         |T| is `texture_1d<ST>` or `texture_storage_1d<F,A>`
     <td><xmp highlight=rust>fn textureDimensions(t: T) -> u32</xmp>
 
   <tr algorithm="textureDimensions 1d level">
-    <td><var ignore>ST</var> is [=i32=], [=u32=] or [=f32=]<br><br>
+    <td><var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]<br><br>
         |T| is `texture_1d<ST>`
 
-        <var ignore>C</var> is [=i32=] or [=u32=]
+        <var ignore>L</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureDimensions(t: T,
-                     level: C) -> u32</xmp>
+                     level: L) -> u32</xmp>
 
   <tr algorithm="textureDimensions 2d">
-    <td><var ignore>ST</var> is [=i32=], [=u32=] or [=f32=]<br>
+    <td><var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]<br>
         <var ignore>F</var> is a [=texel format=]<br>
         <var ignore>A</var> is an [=access mode=]<br><br>
         |T| is `texture_2d<ST>`, `texture_2d_array<ST>`, `texture_cube<ST>`,
@@ -13066,31 +13066,31 @@ fn textureDimensions(t: T,
     <td><xmp highlight=rust>fn textureDimensions(t: T) -> vec2<u32></xmp>
 
   <tr algorithm="textureDimensions 2d level">
-    <td><var ignore>ST</var> is [=i32=], [=u32=] or [=f32=]<br><br>
+    <td><var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]<br><br>
         |T| is `texture_2d<ST>`, `texture_2d_array<ST>`, `texture_cube<ST>`,
                `texture_cube_array<ST>`, `texture_depth_2d`, `texture_depth_2d_array`,
                `texture_depth_cube`, or `texture_depth_cube_array`
 
-        <var ignore>C</var> is [=i32=] or [=u32=]
+        <var ignore>L</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureDimensions(t: T,
-                     level: C) -> vec2<u32></xmp>
+                     level: L) -> vec2<u32></xmp>
 
   <tr algorithm="textureDimensions 3d">
-    <td><var ignore>ST</var> is [=i32=], [=u32=] or [=f32=]<br>
+    <td><var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]<br>
         <var ignore>F</var> is a [=texel format=]<br>
         <var ignore>A</var> is an [=access mode=]<br><br>
         |T| is `texture_3d<ST>` or `texture_storage_3d<F,A>`
     <td><xmp highlight=rust>fn textureDimensions(t: T) -> vec3<u32></xmp>
 
   <tr algorithm="textureDimensions 3d level">
-    <td><var ignore>ST</var> is [=i32=], [=u32=] or [=f32=]<br><br>
+    <td><var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]<br><br>
         |T| is `texture_3d<ST>`
 
-        <var ignore>C</var> is [=i32=] or [=u32=]
+        <var ignore>L</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureDimensions(t: T,
-                     level: C) -> vec3<u32></xmp>
+                     level: L) -> vec3<u32></xmp>
 </table>
 
 **Parameters:**
@@ -13151,8 +13151,8 @@ https://github.com/gpuweb/gpuweb/issues/2343
     <tr><td style="width:25%">Parameterization<th>Overload
   </thead>
   <tr algorithm="textureGather 2d">
-    <td><var ignore>C</var> is [=i32=] or [=u32=]<br>
-        <var ignore>ST</var> is [=i32=], [=u32=] or [=f32=]
+    <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
+        <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
     <td><xmp highlight=rust>
 fn textureGather(component: C,
                  t: texture_2d<ST>,
@@ -13160,8 +13160,8 @@ fn textureGather(component: C,
                  coords: vec2<f32>) -> vec4<ST></xmp>
 
   <tr algorithm="textureGather 2d offset">
-    <td><var ignore>C</var> is [=i32=] or [=u32=]<br>
-        <var ignore>ST</var> is [=i32=], [=u32=] or [=f32=]
+    <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
+        <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
     <td><xmp highlight=rust>
 fn textureGather(component: C,
                  t: texture_2d<ST>,
@@ -13170,9 +13170,9 @@ fn textureGather(component: C,
                  offset: vec2<i32>) -> vec4<ST></xmp>
 
   <tr algorithm="textureGather 2d array">
-    <td><var ignore>C</var> is [=i32=] or [=u32=]<br>
-        <var ignore>A</var> is [=i32=] or [=u32=]<br>
-        <var ignore>ST</var> is [=i32=], [=u32=] or [=f32=]
+    <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
+        <var ignore>A</var> is [=i32=], or [=u32=]<br>
+        <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
     <td><xmp highlight=rust>
 fn textureGather(component: C,
                  t: texture_2d_array<ST>,
@@ -13181,9 +13181,9 @@ fn textureGather(component: C,
                  array_index: A) -> vec4<ST></xmp>
 
   <tr algorithm="textureGather 2d array offset">
-    <td><var ignore>C</var> is [=i32=] or [=u32=]<br>
-        <var ignore>A</var> is [=i32=] or [=u32=]<br>
-        <var ignore>ST</var> is [=i32=], [=u32=] or [=f32=]
+    <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
+        <var ignore>A</var> is [=i32=], or [=u32=]<br>
+        <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
     <td><xmp highlight=rust>
 fn textureGather(component: C,
                  t: texture_2d_array<ST>,
@@ -13193,8 +13193,8 @@ fn textureGather(component: C,
                  offset: vec2<i32>) -> vec4<ST></xmp>
 
   <tr algorithm="textureGather cube">
-    <td><var ignore>C</var> is [=i32=] or [=u32=]<br>
-        <var ignore>ST</var> is [=i32=], [=u32=] or [=f32=]
+    <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
+        <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
     <td><xmp highlight=rust>
 fn textureGather(component: C,
                  t: texture_cube<ST>,
@@ -13202,9 +13202,9 @@ fn textureGather(component: C,
                  coords: vec3<f32>) -> vec4<ST></xmp>
 
   <tr algorithm="textureGather cube array">
-    <td><var ignore>C</var> is [=i32=] or [=u32=]<br>
-        <var ignore>A</var> is [=i32=] or [=u32=]<br>
-        <var ignore>ST</var> is [=i32=], [=u32=] or [=f32=]
+    <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
+        <var ignore>A</var> is [=i32=], or [=u32=]<br>
+        <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
     <td><xmp highlight=rust>
 fn textureGather(component: C,
                  t: texture_cube_array<ST>,
@@ -13235,7 +13235,7 @@ fn textureGather(t: texture_depth_cube,
                  coords: vec3<f32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureGather 2d depth array">
-    <td><var ignore>A</var> is [=i32=] or [=u32=]
+    <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureGather(t: texture_depth_2d_array,
                  s: sampler,
@@ -13243,7 +13243,7 @@ fn textureGather(t: texture_depth_2d_array,
                  array_index: A) -> vec4<f32></xmp>
 
   <tr algorithm="textureGather 2d depth array offset">
-    <td><var ignore>A</var> is [=i32=] or [=u32=]
+    <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureGather(t: texture_depth_2d_array,
                  s: sampler,
@@ -13252,7 +13252,7 @@ fn textureGather(t: texture_depth_2d_array,
                  offset: vec2<i32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureGather cube depth array">
-    <td><var ignore>A</var> is [=i32=] or [=u32=]
+    <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureGather(t: texture_depth_cube_array,
                  s: sampler,
@@ -13356,7 +13356,7 @@ fn textureGatherCompare(t: texture_depth_2d,
                         offset: vec2<i32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureGatherCompare 2d depth array">
-    <td><var ignore>A</var> is [=i32=] or [=u32=]
+    <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureGatherCompare(t: texture_depth_2d_array,
                         s: sampler_comparison,
@@ -13365,7 +13365,7 @@ fn textureGatherCompare(t: texture_depth_2d_array,
                         depth_ref: f32) -> vec4<f32></xmp>
 
   <tr algorithm="textureGatherCompare 2d depth array offset">
-    <td><var ignore>A</var> is [=i32=] or [=u32=]
+    <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureGatherCompare(t: texture_depth_2d_array,
                         s: sampler_comparison,
@@ -13383,7 +13383,7 @@ fn textureGatherCompare(t: texture_depth_cube,
                         depth_ref: f32) -> vec4<f32></xmp>
 
   <tr algorithm="textureGatherCompare 2d depth cube array">
-    <td><var ignore>A</var> is [=i32=] or [=u32=]
+    <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureGatherCompare(t: texture_depth_cube_array,
                         s: sampler_comparison,
@@ -13439,27 +13439,28 @@ Reads a single texel from a texture without sampling or filtering.
     <tr><td style="width:25%">Parameterization<th>Overload
   </thead>
   <tr algorithm="textureLoad 1d">
-    <td><var ignore>C</var> is [=i32=] or [=u32=]<br>
-        <var ignore>L</var> is [=i32=] or [=u32=]<br>
-        <var ignore>ST</var> is [=i32=], [=u32=] or [=f32=]
+    <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
+        <var ignore>L</var> is [=i32=], or [=u32=]<br>
+        <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
     <td><xmp highlight=rust>
 fn textureLoad(t: texture_1d<ST>,
                coords: C,
                level: L) -> vec4<ST></xmp>
 
   <tr algorithm="textureLoad 2d">
-    <td><var ignore>C</var> is [=i32=] or [=u32=]<br>
-        <var ignore>ST</var> is [=i32=], [=u32=] or [=f32=]
+    <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
+        <var ignore>L</var> is [=i32=], or [=u32=]<br>
+        <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
     <td><xmp highlight=rust>
 fn textureLoad(t: texture_2d<ST>,
                coords: vec2<C>,
                level: L) -> vec4<ST></xmp>
 
   <tr algorithm="textureLoad 2d array">
-    <td><var ignore>C</var> is [=i32=] or [=u32=]<br>
-        <var ignore>A</var> is [=i32=] or [=u32=]<br>
-        <var ignore>L</var> is [=i32=] or [=u32=]<br>
-        <var ignore>ST</var> is [=i32=], [=u32=] or [=f32=]
+    <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
+        <var ignore>A</var> is [=i32=], or [=u32=]<br>
+        <var ignore>L</var> is [=i32=], or [=u32=]<br>
+        <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
     <td><xmp highlight=rust>
 fn textureLoad(t: texture_2d_array<ST>,
               coords: vec2<C>,
@@ -13467,35 +13468,35 @@ fn textureLoad(t: texture_2d_array<ST>,
               level: L) -> vec4<ST></xmp>
 
   <tr algorithm="textureLoad 3d">
-    <td><var ignore>C</var> is [=i32=] or [=u32=]<br>
-        <var ignore>L</var> is [=i32=] or [=u32=]<br>
-        <var ignore>ST</var> is [=i32=], [=u32=] or [=f32=]
+    <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
+        <var ignore>L</var> is [=i32=], or [=u32=]<br>
+        <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
     <td><xmp highlight=rust>
 fn textureLoad(t: texture_3d<ST>,
                coords: vec3<C>,
                level: L) -> vec4<ST></xmp>
 
   <tr algorithm="textureLoad 2d multisampled">
-    <td><var ignore>C</var> is [=i32=] or [=u32=]<br>
-        <var ignore>S</var> is [=i32=] or [=u32=]<br>
-        <var ignore>ST</var> is [=i32=], [=u32=] or [=f32=]
+    <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
+        <var ignore>S</var> is [=i32=], or [=u32=]<br>
+        <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
     <td><xmp highlight=rust>
 fn textureLoad(t: texture_multisampled_2d<ST>,
                coords: vec2<C>,
                sample_index: S)-> vec4<ST></xmp>
 
   <tr algorithm="textureLoad 2d depth">
-    <td><var ignore>C</var> is [=i32=] or [=u32=]
-        <var ignore>L</var> is [=i32=] or [=u32=]<br>
+    <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
+        <var ignore>L</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureLoad(t: texture_depth_2d,
                coords: vec2<C>,
                level: L) -> f32</xmp>
 
   <tr algorithm="textureLoad 2d depth array">
-    <td><var ignore>C</var> is [=i32=] or [=u32=]
-        <var ignore>A</var> is [=i32=] or [=u32=]<br>
-        <var ignore>L</var> is [=i32=] or [=u32=]<br>
+    <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
+        <var ignore>A</var> is [=i32=], or [=u32=]<br>
+        <var ignore>L</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureLoad(t: texture_depth_2d_array,
                coords: vec2<C>,
@@ -13503,15 +13504,15 @@ fn textureLoad(t: texture_depth_2d_array,
                level: L) -> f32</xmp>
 
 <tr algorithm="textureLoad 2d depth multisampled">
-    <td><var ignore>C</var> is [=i32=] or [=u32=]
-        <var ignore>S</var> is [=i32=] or [=u32=]<br>
+    <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
+        <var ignore>S</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureLoad(t: texture_depth_multisampled_2d,
                coords: vec2<C>,
                sample_index: S)-> f32</xmp>
 
   <tr algorithm="textureLoad external">
-    <td><var ignore>C</var> is [=i32=] or [=u32=]
+    <td><var ignore>C</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureLoad(t: texture_external,
                coords: vec2<C>) -> vec4<f32></xmp>
@@ -13562,7 +13563,7 @@ Returns the number of layers (elements) of an array texture.
   <tr algorithm="texturenumlayers">
     <td><var ignore>F</var> is a [=texel format=]<br>
         <var ignore>A</var> is an [=access mode=]<br>
-        <var ignore>ST</var> is [=i32=], [=u32=] or [=f32=]<br><br>
+        <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]<br><br>
         <var ignore>T</var> is `texture_2d_array<ST>`, `texture_cube_array<ST>`,
                                `texture_depth_2d_array`, `texture_depth_cube_array`,
                                or `texture_storage_2d_array<F,A>`
@@ -13594,7 +13595,7 @@ Returns the number of mip levels of a texture.
     <tr><td style="width:25%">Parameterization<th>Overload
   </thead>
   <tr algorithm="texturenumlevels">
-    <td><var ignore>ST</var> is [=i32=], [=u32=] or [=f32=]<br><br>
+    <td><var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]<br><br>
         <var ignore>T</var> is `texture_1d<ST>`, `texture_2d<ST>`,
                                `texture_2d_array<ST>`, `texture_3d<ST>`,
                                `texture_cube<ST>`, `texture_cube_array<ST>`,
@@ -13626,7 +13627,7 @@ Returns the number samples per texel in a multisampled texture.
     <tr><td style="width:45%">Parameterization<th>Overload
   </thead>
   <tr algorithm="texturenumsamples">
-    <td><var ignore>ST</var> is [=i32=], [=u32=] or [=f32=]<br><br>
+    <td><var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]<br><br>
         <var ignore>T</var> is `texture_multisampled_2d<ST>`
                                 or `texture_depth_multisampled_2d`
     <td><xmp highlight=rust>
@@ -14289,12 +14290,13 @@ fn textureSampleLevel(t: texture_depth_2d,
                       offset: vec2<i32>) -> f32</xmp>
 
   <tr algorithm="textureSampleLevel 2d depth array">
-    <td><var ignore>L</var> is [=i32=], or [=u32=]
+    <td><var ignore>A</var> is [=i32=], or [=u32=]<br>
+        <var ignore>L</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSampleLevel(t: texture_depth_2d_array,
                       s: sampler,
                       coords: vec2<f32>,
-                      array_index: C,
+                      array_index: A,
                       level: L) -> f32</xmp>
 
   <tr algorithm="textureSampleLevel 2d depth array offset">
@@ -14317,12 +14319,13 @@ fn textureSampleLevel(t: texture_depth_cube,
                       level: L) -> f32</xmp>
 
   <tr algorithm="textureSampleLevel cube depth array">
-    <td><var ignore>L</var> is [=i32=], or [=u32=]
+    <td><var ignore>A</var> is [=i32=], or [=u32=]<br>
+        <var ignore>L</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSampleLevel(t: texture_depth_cube_array,
                       s: sampler,
                       coords: vec3<f32>,
-                      array_index: C,
+                      array_index: A,
                       level: L) -> f32
 </xmp>
 </table>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -13171,23 +13171,25 @@ fn textureGather(component: C,
 
   <tr algorithm="textureGather 2d array">
     <td><var ignore>C</var> is [=i32=] or [=u32=]<br>
+        <var ignore>A</var> is [=i32=] or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=] or [=f32=]
     <td><xmp highlight=rust>
 fn textureGather(component: C,
                  t: texture_2d_array<ST>,
                  s: sampler,
                  coords: vec2<f32>,
-                 array_index: C) -> vec4<ST></xmp>
+                 array_index: A) -> vec4<ST></xmp>
 
   <tr algorithm="textureGather 2d array offset">
     <td><var ignore>C</var> is [=i32=] or [=u32=]<br>
+        <var ignore>A</var> is [=i32=] or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=] or [=f32=]
     <td><xmp highlight=rust>
 fn textureGather(component: C,
                  t: texture_2d_array<ST>,
                  s: sampler,
                  coords: vec2<f32>,
-                 array_index: C,
+                 array_index: A,
                  offset: vec2<i32>) -> vec4<ST></xmp>
 
   <tr algorithm="textureGather cube">
@@ -13201,13 +13203,14 @@ fn textureGather(component: C,
 
   <tr algorithm="textureGather cube array">
     <td><var ignore>C</var> is [=i32=] or [=u32=]<br>
+        <var ignore>A</var> is [=i32=] or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=] or [=f32=]
     <td><xmp highlight=rust>
 fn textureGather(component: C,
                  t: texture_cube_array<ST>,
                  s: sampler,
                  coords: vec3<f32>,
-                 array_index: C) -> vec4<ST></xmp>
+                 array_index: A) -> vec4<ST></xmp>
 
   <tr algorithm="textureGather 2d depth">
     <td>
@@ -13232,29 +13235,29 @@ fn textureGather(t: texture_depth_cube,
                  coords: vec3<f32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureGather 2d depth array">
-    <td><var ignore>C</var> is [=i32=] or [=u32=]
+    <td><var ignore>A</var> is [=i32=] or [=u32=]
     <td><xmp highlight=rust>
 fn textureGather(t: texture_depth_2d_array,
                  s: sampler,
                  coords: vec2<f32>,
-                 array_index: C) -> vec4<f32></xmp>
+                 array_index: A) -> vec4<f32></xmp>
 
   <tr algorithm="textureGather 2d depth array offset">
-    <td><var ignore>C</var> is [=i32=] or [=u32=]
+    <td><var ignore>A</var> is [=i32=] or [=u32=]
     <td><xmp highlight=rust>
 fn textureGather(t: texture_depth_2d_array,
                  s: sampler,
                  coords: vec2<f32>,
-                 array_index: C,
+                 array_index: A,
                  offset: vec2<i32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureGather cube depth array">
-    <td><var ignore>C</var> is [=i32=] or [=u32=]
+    <td><var ignore>A</var> is [=i32=] or [=u32=]
     <td><xmp highlight=rust>
 fn textureGather(t: texture_depth_cube_array,
                  s: sampler,
                  coords: vec3<f32>,
-                 array_index: C) -> vec4<f32></xmp>
+                 array_index: A) -> vec4<f32></xmp>
 </table>
 
 **Parameters:**
@@ -13353,21 +13356,21 @@ fn textureGatherCompare(t: texture_depth_2d,
                         offset: vec2<i32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureGatherCompare 2d depth array">
-    <td><var ignore>C</var> is [=i32=] or [=u32=]
+    <td><var ignore>A</var> is [=i32=] or [=u32=]
     <td><xmp highlight=rust>
 fn textureGatherCompare(t: texture_depth_2d_array,
                         s: sampler_comparison,
                         coords: vec2<f32>,
-                        array_index: C,
+                        array_index: A,
                         depth_ref: f32) -> vec4<f32></xmp>
 
   <tr algorithm="textureGatherCompare 2d depth array offset">
-    <td><var ignore>C</var> is [=i32=] or [=u32=]
+    <td><var ignore>A</var> is [=i32=] or [=u32=]
     <td><xmp highlight=rust>
 fn textureGatherCompare(t: texture_depth_2d_array,
                         s: sampler_comparison,
                         coords: vec2<f32>,
-                        array_index: C,
+                        array_index: A,
                         depth_ref: f32,
                         offset: vec2<i32>) -> vec4<f32></xmp>
 
@@ -13380,12 +13383,12 @@ fn textureGatherCompare(t: texture_depth_cube,
                         depth_ref: f32) -> vec4<f32></xmp>
 
   <tr algorithm="textureGatherCompare 2d depth cube array">
-    <td><var ignore>C</var> is [=i32=] or [=u32=]
+    <td><var ignore>A</var> is [=i32=] or [=u32=]
     <td><xmp highlight=rust>
 fn textureGatherCompare(t: texture_depth_cube_array,
                         s: sampler_comparison,
                         coords: vec3<f32>,
-                        array_index: C,
+                        array_index: A,
                         depth_ref: f32) -> vec4<f32></xmp>
 
 </table>
@@ -13437,11 +13440,12 @@ Reads a single texel from a texture without sampling or filtering.
   </thead>
   <tr algorithm="textureLoad 1d">
     <td><var ignore>C</var> is [=i32=] or [=u32=]<br>
+        <var ignore>L</var> is [=i32=] or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=] or [=f32=]
     <td><xmp highlight=rust>
 fn textureLoad(t: texture_1d<ST>,
                coords: C,
-               level: C) -> vec4<ST></xmp>
+               level: L) -> vec4<ST></xmp>
 
   <tr algorithm="textureLoad 2d">
     <td><var ignore>C</var> is [=i32=] or [=u32=]<br>
@@ -13449,54 +13453,62 @@ fn textureLoad(t: texture_1d<ST>,
     <td><xmp highlight=rust>
 fn textureLoad(t: texture_2d<ST>,
                coords: vec2<C>,
-               level: C) -> vec4<ST></xmp>
+               level: L) -> vec4<ST></xmp>
 
   <tr algorithm="textureLoad 2d array">
     <td><var ignore>C</var> is [=i32=] or [=u32=]<br>
+        <var ignore>A</var> is [=i32=] or [=u32=]<br>
+        <var ignore>L</var> is [=i32=] or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=] or [=f32=]
     <td><xmp highlight=rust>
 fn textureLoad(t: texture_2d_array<ST>,
               coords: vec2<C>,
-              array_index: C,
-              level: C) -> vec4<ST></xmp>
+              array_index: A,
+              level: L) -> vec4<ST></xmp>
 
   <tr algorithm="textureLoad 3d">
     <td><var ignore>C</var> is [=i32=] or [=u32=]<br>
+        <var ignore>L</var> is [=i32=] or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=] or [=f32=]
     <td><xmp highlight=rust>
 fn textureLoad(t: texture_3d<ST>,
                coords: vec3<C>,
-               level: C) -> vec4<ST></xmp>
+               level: L) -> vec4<ST></xmp>
 
   <tr algorithm="textureLoad 2d multisampled">
     <td><var ignore>C</var> is [=i32=] or [=u32=]<br>
+        <var ignore>S</var> is [=i32=] or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=] or [=f32=]
     <td><xmp highlight=rust>
 fn textureLoad(t: texture_multisampled_2d<ST>,
                coords: vec2<C>,
-               sample_index: C)-> vec4<ST></xmp>
+               sample_index: S)-> vec4<ST></xmp>
 
   <tr algorithm="textureLoad 2d depth">
     <td><var ignore>C</var> is [=i32=] or [=u32=]
+        <var ignore>L</var> is [=i32=] or [=u32=]<br>
     <td><xmp highlight=rust>
 fn textureLoad(t: texture_depth_2d,
                coords: vec2<C>,
-               level: C) -> f32</xmp>
+               level: L) -> f32</xmp>
 
   <tr algorithm="textureLoad 2d depth array">
     <td><var ignore>C</var> is [=i32=] or [=u32=]
+        <var ignore>A</var> is [=i32=] or [=u32=]<br>
+        <var ignore>L</var> is [=i32=] or [=u32=]<br>
     <td><xmp highlight=rust>
 fn textureLoad(t: texture_depth_2d_array,
                coords: vec2<C>,
-               array_index: C,
-               level: C) -> f32</xmp>
+               array_index: A,
+               level: L) -> f32</xmp>
 
 <tr algorithm="textureLoad 2d depth multisampled">
     <td><var ignore>C</var> is [=i32=] or [=u32=]
+        <var ignore>S</var> is [=i32=] or [=u32=]<br>
     <td><xmp highlight=rust>
 fn textureLoad(t: texture_depth_multisampled_2d,
                coords: vec2<C>,
-               sample_index: C)-> f32</xmp>
+               sample_index: S)-> f32</xmp>
 
   <tr algorithm="textureLoad external">
     <td><var ignore>C</var> is [=i32=] or [=u32=]
@@ -13668,20 +13680,20 @@ fn textureSample(t: texture_2d<f32>,
                  offset: vec2<i32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureSample 2d array">
-    <td><var ignore>C</var> is [=i32=], or [=u32=]
+    <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSample(t: texture_2d_array<f32>,
                  s: sampler,
                  coords: vec2<f32>,
-                 array_index: C) -> vec4<f32></xmp>
+                 array_index: A) -> vec4<f32></xmp>
 
   <tr algorithm="textureSample 2d array offset">
-    <td><var ignore>C</var> is [=i32=], or [=u32=]
+    <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSample(t: texture_2d_array<f32>,
                  s: sampler,
                  coords: vec2<f32>,
-                 array_index: C,
+                 array_index: A,
                  offset: vec2<i32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureSample 3d">
@@ -13700,12 +13712,12 @@ fn textureSample(t: texture_3d<f32>,
                  offset: vec3<i32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureSample cube array">
-    <td><var ignore>C</var> is [=i32=], or [=u32=]
+    <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSample(t: texture_cube_array<f32>,
                  s: sampler,
                  coords: vec3<f32>,
-                 array_index: C) -> vec4<f32></xmp>
+                 array_index: A) -> vec4<f32></xmp>
 
   <tr algorithm="textureSample 2d depth">
     <td>
@@ -13723,20 +13735,20 @@ fn textureSample(t: texture_depth_2d,
                  offset: vec2<i32>) -> f32</xmp>
 
   <tr algorithm="textureSample 2d depth array">
-    <td><var ignore>C</var> is [=i32=], or [=u32=]
+    <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSample(t: texture_depth_2d_array,
                  s: sampler,
                  coords: vec2<f32>,
-                 array_index: C) -> f32</xmp>
+                 array_index: A) -> f32</xmp>
 
   <tr algorithm="textureSample 2d depth array offset">
-    <td><var ignore>C</var> is [=i32=], or [=u32=]
+    <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSample(t: texture_depth_2d_array,
                  s: sampler,
                  coords: vec2<f32>,
-                 array_index: C,
+                 array_index: A,
                  offset: vec2<i32>) -> f32</xmp>
 
   <tr algorithm="textureSample cube depth">
@@ -13747,12 +13759,12 @@ fn textureSample(t: texture_depth_cube,
                  coords: vec3<f32>) -> f32</xmp>
 
   <tr algorithm="textureSample cube depth array">
-    <td><var ignore>C</var> is [=i32=], or [=u32=]
+    <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSample(t: texture_depth_cube_array,
                  s: sampler,
                  coords: vec3<f32>,
-                 array_index: C) -> f32</xmp>
+                 array_index: A) -> f32</xmp>
 
 </table>
 
@@ -13810,21 +13822,21 @@ fn textureSampleBias(t: texture_2d<f32>,
                      offset: vec2<i32>) -> vec4<f32></xmp>
 
 <tr algorithm="textureSampleBias 2d array">
-    <td><var ignore>C</var> is [=i32=], or [=u32=]
+    <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSampleBias(t: texture_2d_array<f32>,
                      s: sampler,
                      coords: vec2<f32>,
-                     array_index: C,
+                     array_index: A,
                      bias: f32) -> vec4<f32></xmp>
 
 <tr algorithm="textureSampleBias 2d array offset">
-    <td><var ignore>C</var> is [=i32=], or [=u32=]
+    <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSampleBias(t: texture_2d_array<f32>,
                      s: sampler,
                      coords: vec2<f32>,
-                     array_index: C,
+                     array_index: A,
                      bias: f32,
                      offset: vec2<i32>) -> vec4<f32></xmp>
 
@@ -13846,12 +13858,12 @@ fn textureSampleBias(t: texture_3d<f32>,
                      offset: vec3<i32>) -> vec4<f32></xmp>
 
 <tr algorithm="textureSampleBias cube array">
-    <td><var ignore>C</var> is [=i32=], or [=u32=]
+    <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSampleBias(t: texture_cube_array<f32>,
                      s: sampler,
                      coords: vec3<f32>,
-                     array_index: C,
+                     array_index: A,
                      bias: f32) -> vec4<f32></xmp>
 
 </table>
@@ -13913,21 +13925,21 @@ fn textureSampleCompare(t: texture_depth_2d,
                         offset: vec2<i32>) -> f32</xmp>
 
   <tr algorithm="textureSampleCompare 2d array">
-    <td><var ignore>C</var> is [=i32=], or [=u32=]
+    <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSampleCompare(t: texture_depth_2d_array,
                         s: sampler_comparison,
                         coords: vec2<f32>,
-                        array_index: C,
+                        array_index: A,
                         depth_ref: f32) -> f32</xmp>
 
   <tr algorithm="textureSampleCompare 2d depth array">
-    <td><var ignore>C</var> is [=i32=], or [=u32=]
+    <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSampleCompare(t: texture_depth_2d_array,
                         s: sampler_comparison,
                         coords: vec2<f32>,
-                        array_index: C,
+                        array_index: A,
                         depth_ref: f32,
                         offset: vec2<i32>) -> f32</xmp>
 
@@ -13940,12 +13952,12 @@ fn textureSampleCompare(t: texture_depth_cube,
                         depth_ref: f32) -> f32</xmp>
 
   <tr algorithm="textureSampleCompare cube depth array">
-    <td><var ignore>C</var> is [=i32=], or [=u32=]
+    <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSampleCompare(t: texture_depth_cube_array,
                         s: sampler_comparison,
                         coords: vec3<f32>,
-                        array_index: C,
+                        array_index: A,
                         depth_ref: f32) -> f32</xmp>
 
 </table>
@@ -14011,21 +14023,21 @@ fn textureSampleCompareLevel(t: texture_depth_2d,
                              offset: vec2<i32>) -> f32</xmp>
 
   <tr algorithm="textureSampleCompareLevel 2d depth array">
-    <td><var ignore>C</var> is [=i32=], or [=u32=]
+    <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSampleCompareLevel(t: texture_depth_2d_array,
                              s: sampler_comparison,
                              coords: vec2<f32>,
-                             array_index: C,
+                             array_index: A,
                              depth_ref: f32) -> f32</xmp>
 
   <tr algorithm="textureSampleCompareLevel 2d depth array offset">
-    <td><var ignore>C</var> is [=i32=], or [=u32=]
+    <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSampleCompareLevel(t: texture_depth_2d_array,
                              s: sampler_comparison,
                              coords: vec2<f32>,
-                             array_index: C,
+                             array_index: A,
                              depth_ref: f32,
                              offset: vec2<i32>) -> f32</xmp>
 
@@ -14038,12 +14050,12 @@ fn textureSampleCompareLevel(t: texture_depth_cube,
                              depth_ref: f32) -> f32</xmp>
 
   <tr algorithm="textureSampleCompareLevel cube depth array">
-    <td><var ignore>C</var> is [=i32=], or [=u32=]
+    <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSampleCompareLevel(t: texture_depth_cube_array,
                              s: sampler_comparison,
                              coords: vec3<f32>,
-                             array_index: C,
+                             array_index: A,
                              depth_ref: f32) -> f32</xmp>
 
 </table>
@@ -14109,22 +14121,22 @@ fn textureSampleGrad(t: texture_2d<f32>,
                      offset: vec2<i32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureSampleGrad 2d array">
-    <td><var ignore>C</var> is [=i32=], or [=u32=]
+    <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSampleGrad(t: texture_2d_array<f32>,
                      s: sampler,
                      coords: vec2<f32>,
-                     array_index: C,
+                     array_index: A,
                      ddx: vec2<f32>,
                      ddy: vec2<f32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureSampleGrad 2d array offset">
-    <td><var ignore>C</var> is [=i32=], or [=u32=]
+    <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSampleGrad(t: texture_2d_array<f32>,
                      s: sampler,
                      coords: vec2<f32>,
-                     array_index: C,
+                     array_index: A,
                      ddx: vec2<f32>,
                      ddy: vec2<f32>,
                      offset: vec2<i32>) -> vec4<f32></xmp>
@@ -14149,12 +14161,12 @@ fn textureSampleGrad(t: texture_3d<f32>,
                      offset: vec3<i32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureSampleGrad cube array">
-    <td><var ignore>C</var> is [=i32=], or [=u32=]
+    <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSampleGrad(t: texture_cube_array<f32>,
                      s: sampler,
                      coords: vec3<f32>,
-                     array_index: C,
+                     array_index: A,
                      ddx: vec3<f32>,
                      ddy: vec3<f32>) -> vec4<f32></xmp>
 
@@ -14215,21 +14227,21 @@ fn textureSampleLevel(t: texture_2d<f32>,
                       offset: vec2<i32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureSampleLevel 2d array">
-    <td><var ignore>C</var> is [=i32=], or [=u32=]
+    <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSampleLevel(t: texture_2d_array<f32>,
                       s: sampler,
                       coords: vec2<f32>,
-                      array_index: C,
+                      array_index: A,
                       level: f32) -> vec4<f32></xmp>
 
   <tr algorithm="textureSampleLevel 2d array offset">
-    <td><var ignore>C</var> is [=i32=], or [=u32=]
+    <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSampleLevel(t: texture_2d_array<f32>,
                       s: sampler,
                       coords: vec2<f32>,
-                      array_index: C,
+                      array_index: A,
                       level: f32,
                       offset: vec2<i32>) -> vec4<f32></xmp>
 
@@ -14251,66 +14263,67 @@ fn textureSampleLevel(t: texture_3d<f32>,
                       offset: vec3<i32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureSampleLevel cube array">
-    <td><var ignore>C</var> is [=i32=], or [=u32=]
+    <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSampleLevel(t: texture_cube_array<f32>,
                       s: sampler,
                       coords: vec3<f32>,
-                      array_index: C,
+                      array_index: A,
                       level: f32) -> vec4<f32></xmp>
 
   <tr algorithm="textureSampleLevel 2d depth">
-    <td><var ignore>C</var> is [=i32=], or [=u32=]
+    <td><var ignore>L</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSampleLevel(t: texture_depth_2d,
                       s: sampler,
                       coords: vec2<f32>,
-                      level: C) -> f32</xmp>
+                      level: L) -> f32</xmp>
 
   <tr algorithm="textureSampleLevel 2d depth offset">
-    <td><var ignore>C</var> is [=i32=], or [=u32=]
+    <td><var ignore>L</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSampleLevel(t: texture_depth_2d,
                       s: sampler,
                       coords: vec2<f32>,
-                      level: C,
+                      level: L,
                       offset: vec2<i32>) -> f32</xmp>
 
   <tr algorithm="textureSampleLevel 2d depth array">
-    <td><var ignore>C</var> is [=i32=], or [=u32=]
+    <td><var ignore>L</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSampleLevel(t: texture_depth_2d_array,
                       s: sampler,
                       coords: vec2<f32>,
                       array_index: C,
-                      level: C) -> f32</xmp>
+                      level: L) -> f32</xmp>
 
   <tr algorithm="textureSampleLevel 2d depth array offset">
-    <td><var ignore>C</var> is [=i32=], or [=u32=]
+    <td><var ignore>A</var> is [=i32=], or [=u32=]<br>
+        <var ignore>L</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSampleLevel(t: texture_depth_2d_array,
                       s: sampler,
                       coords: vec2<f32>,
-                      array_index: C,
-                      level: C,
+                      array_index: A,
+                      level: L,
                       offset: vec2<i32>) -> f32</xmp>
 
   <tr algorithm="textureSampleLevel cube depth">
-    <td><var ignore>C</var> is [=i32=], or [=u32=]
+    <td><var ignore>L</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSampleLevel(t: texture_depth_cube,
                       s: sampler,
                       coords: vec3<f32>,
-                      level: C) -> f32</xmp>
+                      level: L) -> f32</xmp>
 
   <tr algorithm="textureSampleLevel cube depth array">
-    <td><var ignore>C</var> is [=i32=], or [=u32=]
+    <td><var ignore>L</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSampleLevel(t: texture_depth_cube_array,
                       s: sampler,
                       coords: vec3<f32>,
                       array_index: C,
-                      level: C) -> f32
+                      level: L) -> f32
 </xmp>
 </table>
 
@@ -14425,13 +14438,14 @@ fn textureStore(t: texture_storage_2d<F,write>,
   <tr algorithm="textureStore 2d array">
     <td>|F| is a [=texel format=]<br>
         <var ignore>C</var> is [=i32=], or [=u32=]<br>
+        <var ignore>A</var> is [=i32=], or [=u32=]<br>
         <var ignore>CF</var> depends on the storage texel format |F|.
         [See the texel format table](#storage-texel-formats) for the mapping of texel
         format to channel format.
     <td><xmp highlight=rust>
 fn textureStore(t: texture_storage_2d_array<F,write>,
                 coords: vec2<C>,
-                array_index: C,
+                array_index: A,
                 value: vec4<CF>)</xmp>
 
   <tr algorithm="textureStore 3d">


### PR DESCRIPTION
Fixes #3536

* When integer parameters for texture built-in functions do not require a specific signedness (e.g. not offset), allow different signedness for each such parameter
  * For example, in `textureSampleLevel` on an array texture the level and array_index parameters may be different types