### PR TITLE
[editorial] Clarify nan/inf eval applies to all expressions

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9985,8 +9985,8 @@ the following exceptions:
 * Signaling NaNs may not be generated.
     Any signaling NaN may be converted to a quiet NaN.
 * Implementations may assume that NaNs and infinities are not present at runtime.
-    * In such an implementation, when an evaluation would produce an infinity or a NaN,
-        an undefined value of the target type is produced instead.
+    * In such an implementation, when an expression evaluation would produce an
+        infinity or a NaN, an undefined value of the target type is produced instead.
     * It is a [=shader-creation error=] if any [=const-expression=] of
         floating-point type evaluates to NaN or infinity.
     * It is a [=pipeline-creation error=] if any [=override-expression=] of


### PR DESCRIPTION
Fixes #3533

* Improve the wording to clarify that any expression evaluation that produces a nan/inf may produce an undefined value