### PR TITLE
Limit the maximum statement nesting depth to 127

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8851,7 +8851,7 @@ shader that goes beyond the specified limits.
   </thead>
     <tr><td>Maximum number of members in a [=structure=] type<td>16383
     <tr><td>Maximum [=nesting depth=] of a [=composite=] type<td>255
-    <tr><td>Maximum nesting depth of statements in a function<td>127
+    <tr><td>Maximum nesting depth of brace-enclosed statements in a function<td>127
     <tr><td>Maximum number of [=formal parameter|parameters=] for a function<td>255
     <tr><td>Maximum number of case selector values in a [=statement/switch=] statement<td>16383
     <tr><td>Maximum [=byte-size=] of an [=array=] type instantiated in the

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8851,6 +8851,7 @@ shader that goes beyond the specified limits.
   </thead>
     <tr><td>Maximum number of members in a [=structure=] type<td>16383
     <tr><td>Maximum [=nesting depth=] of a [=composite=] type<td>255
+    <tr><td>Maximum nesting depth of statements in a function<td>127
     <tr><td>Maximum number of [=formal parameter|parameters=] for a function<td>255
     <tr><td>Maximum number of case selector values in a [=statement/switch=] statement<td>16383
     <tr><td>Maximum [=byte-size=] of an [=array=] type instantiated in the


### PR DESCRIPTION
Fixes #3527

* Limit the maximum nesting of statements to 127