### PR TITLE
Say "indeterminate value" where previously said "undefined value"

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1611,7 +1611,7 @@ and with a numeric range and precision that may be larger than directly implemen
     in the [[!IEEE-754|IEEE-754]] binary64 (double precision) format.
 
 An evaluation of an expression in one of these types [=shader-creation
-error|must not=] overflow or produce infinite, NaN, or undefined results.
+error|must not=] overflow or produce infinite, NaN, undefined, or [=indeterminate value|indeterminate=] results.
 
 A type is <dfn dfn-for="type" noexport>abstract</dfn> if it is an abstract
 numeric type or contains an abstract numeric type.
@@ -9932,7 +9932,7 @@ As such, helper invocations are subject to the following restrictions:
     will be performed on the [=address spaces/storage=], [=address
     spaces/workgroup=], or [=address spaces/handle=] address spaces.
 * [[#atomic-builtin-functions|Atomic built-in functions]] will return
-    undefined results.
+    [=indeterminate value|indeterminate=] results.
 * The [=Entry point=] [=return value=] will not be further processed
     downstream in the [=GPURenderPipeline=].
 
@@ -9986,7 +9986,7 @@ the following exceptions:
     Any signaling NaN may be converted to a quiet NaN.
 * Implementations may assume that NaNs and infinities are not present at runtime.
     * In such an implementation, when an expression evaluation would produce an
-        infinity or a NaN, an undefined value of the target type is produced instead.
+        infinity or a NaN, an [=indeterminate value=] of the target type is produced instead.
     * It is a [=shader-creation error=] if any [=const-expression=] of
         floating-point type evaluates to NaN or infinity.
     * It is a [=pipeline-creation error=] if any [=override-expression=] of


### PR DESCRIPTION
Also, add "indeterminate value" as another banned cased for expressions yielding bstract numeric types.

Followup to #3549