### PR TITLE
Remove special-case uniformity rules for short-circuiting ops

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9435,20 +9435,13 @@ The rules for analyzing expressions take as argument both the expression itself 
   <thead>
     <tr><th>Expression<th>New nodes<th>Recursive analyses<th>Resulting control flow node, value node<th>New edges
   </thead>
-  <tr><td class="nowrap">*e1* || *e2*<br>
-      with behavior {Next}
-      <td rowspan=4>
-      <td rowspan=4 class="nowrap">(*CF*, *e1*) => (*CF1*, *V1*)<br>
+  <tr><td class="nowrap">*e1* || *e2*
+      <td rowspan=2>
+      <td rowspan=2 class="nowrap">(*CF*, *e1*) => (*CF1*, *V1*)<br>
           (*V1*, *e2*) => (*CF2*, *V2*)
       <td rowspan=2 class="nowrap">*CF*, *V2*
-      <td rowspan=4>
-  <tr><td class="nowrap">*e1* && *e2*<br>
-      with behavior {Next}
-  <tr><td class="nowrap">*e1* || *e2*<br>
-      with behavior other than {Next}
-      <td rowspan=2 class="nowrap">*CF2*, *V2*
-  <tr><td class="nowrap">*e1* && *e2*<br>
-      with behavior other than {Next}
+      <td rowspan=2>
+  <tr><td class="nowrap">*e1* && *e2*
   <tr><td class="nowrap">Literal
       <td>
       <td>


### PR DESCRIPTION
Now that expressions can only ever have the `Next` behavior, short-circuiting operators will always reconverge.