### PR TITLE
Clarify rule about binding aliasing in a shader

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8666,7 +8666,7 @@ Together with the shader's stage, these identify the binding address
 of the resource on the shader's pipeline.
 See [[WebGPU#pipeline-layout|WebGPU &sect; GPUPipelineLayout]].
 
-Bindings [=shader-creation error|must not=] alias within a shader stage:
+Bindings [=shader-creation error|must not=] alias within a [=shader=]:
 two different variables in the resource interface of a given
 shader [=shader-creation error|must not=] have the same group and binding values, when considered as a pair of values.
 


### PR DESCRIPTION
Replace "shader stage" with "shader", to avoid confusion about whether the rule applies across all fragment shaders in a module, for example.