### PR TITLE
wgsl: add compile-time failure cases for quantizeToF16, pack2x16float

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12586,8 +12586,10 @@ but a value may infer the type.
         a [[!IEEE-754|IEEE 754]] binary16 value, and then converted back to a
         IEEE 754 binary32 value.
 
-        If `e` is outside the finite range of binary16, then the result is any
-        value of type f32.
+        If `e` is outside the finite range of binary16, then:
+        * It is a [=shader-creation error=] if `e` is a [=const-expression=].
+        * It is a [=pipeline-creation error=] if `e` is an [=override-expression=].
+        * Otherwise the result is an [=indeterminate value=] for `T`.
 
         The intermediate binary16 value may be [=flushed to zero=], i.e. the final
         result may be zero if the intermediate binary16 value is denormalized.
@@ -14687,8 +14689,10 @@ Note: For packing snorm values, the normalized floating point values are in the 
         16 &times; `i` + 15 of the result.
         See [[#floating-point-conversion]].
 
-        If either `e[0]` or `e[1]` is outside the finite range of binary16
-        then the result is any value of type u32.
+        If either `e[0]` or `e[1]` is outside the finite range of binary16 then:
+        * It is a [=shader-creation error=] if `e` is a [=const-expression=].
+        * It is a [=pipeline-creation error=] if `e` is an [=override-expression=].
+        * Otherwise the result is an [=indeterminate value=] for u32.
 </table>
 
 ## Data Unpacking Built-in Functions ## {#unpack-builtin-functions}


### PR DESCRIPTION
For out-of-bounds cases, generate creation-time, pipeline-time errors.

Also, for runtime rephrase as "indeterminate value" instead of "any value of type T".

Fixes: #3563