### PR TITLE
Clarify mathematical value of float literal

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -636,29 +636,6 @@ An <dfn>integer literal</dfn> is:
 
 A <dfn>floating point literal</dfn> is either a [=decimal floating point literal=]
 or a [=hexadecimal floating point literal=].
-* A <dfn noexport>decimal floating point literal</dfn> is:
-    * A mantissa, specified as a sequence of digits, with an optional decimal point (`.`) somewhere among them.
-    * Then an optional exponent suffix consisting of:
-        * `e` or `E`.
-        * Then an exponent specified as an decimal number with an optional leading sign (`+` or `-`).
-        * Then an optional `f` or `h` suffix.
-    * At least one of the decimal point, or the exponent, or the `f` or `h` suffix
-         [=shader-creation error|must=] be present.
-         If none are, then the token is instead an [=integer literal=].
-    * The value of the literal is the value of the mantissa multiplied by 10 to the power of the exponent.
-         When no exponent is specified, an exponent of 0 is assumed.
-
-* A <dfn noexport>hexadecimal floating point literal</dfn> is:
-    * A `0x` or `0X` prefix
-    * Then a mantissa, specified as a sequence of hexadecimal digits, with an optional hexadecimal point (`.`) somewhere among them.
-    * Then an optional exponent suffix consisting of:
-        * `p` or `P`
-        * Then an exponent specified as an decimal number with an optional leading sign (`+` or `-`).
-        * Then an optional `f` or `h` suffix.
-    * At least one of the hexadecimal point, or the exponent [=shader-creation error|must=] be present.
-         If neither are, then the token is instead an [=integer literal=].
-    * The value of the literal is the value of the mantissa multiplied by 2 to the power of the exponent.
-         When no exponent is specified, an exponent of 0 is assumed.
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>float_literal</dfn> :
@@ -667,6 +644,24 @@ or a [=hexadecimal floating point literal=].
 
     | [=syntax/hex_float_literal=]
 </div>
+
+A [=floating point literal=] has two logical parts: a mantissa to representing a fraction, and an optional exponent.
+Roughly, the value of the literal is the mantissa multiplied by a base value raised to the given exponent.
+A mantissa digit is <dfn dfn-for="mantissa">significant</dfn> if it is non-zero,
+or if there are mantissa digits to its left and to its right that are both non-zero.
+Significant digits are counted from left-to-right: the *N*'th significant digit has *N*-1 significant digits
+to its left.
+
+A <dfn noexport>decimal floating point literal</dfn> is:
+* A mantissa, specified as a sequence of digits, with an optional decimal point (`.`) somewhere among them.
+    The mantissa represents a fraction in base 10 notation.
+* Then an optional exponent suffix consisting of:
+    * `e` or `E`.
+    * Then an exponent specified as an decimal number with an optional leading sign (`+` or `-`).
+    * Then an optional `f` or `h` suffix.
+* At least one of the decimal point, or the exponent, or the `f` or `h` suffix
+     [=shader-creation error|must=] be present.
+     If none are, then the token is instead an [=integer literal=].
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>decimal_float_literal</dfn> :
@@ -694,6 +689,39 @@ or a [=hexadecimal floating point literal=].
   </xmp>
 </div>
 
+<div algorithm="mathematical value of decimal floating point literal">
+The mathematical value of a [=decimal floating point literal=] is computed as follows:
+* Compute |effective_mantissa| from |mantissa|:
+    * If |mantissa| has 20 or fewer [=mantissa/significant=] digits, then |effective_mantissa| is |mantissa|.
+    * Otherwise:
+        * Let |truncated_mantissa| be the same as |mantissa| except each digit to the
+             right of the 20th significant digit is replaced with 0.
+        * Let |truncated_mantissa_next| be the same as |mantissa| except:
+             * the 20th significant digit is incremented by 1, and carries are propagated to the left as needed
+                 needed to ensure each digit remains in the range 0 through 9, and
+             * each digit to the right of the 20th significant digit is replaced with 0.
+        * Set |effective_mantissa| to either |truncated_mantissa| or |truncated_mantissa_next|.
+             This is an implementation choice.
+* The mathematical value of the literal is the mathematical value of |effective_mantissa| as a decimal fraction,
+    multiplied by 10 to the power of the exponent.
+    When no exponent is specified, an exponent of 0 is assumed.
+
+</div>
+
+Note: The decimal mantissa is truncated after 20 decimal digits, preserving approximately log(10)/log(2)&times;20 &approx; 66.4 significant bits in the fraction.
+
+
+A <dfn noexport>hexadecimal floating point literal</dfn> is:
+* A `0x` or `0X` prefix
+* Then a mantissa, specified as a sequence of hexadecimal digits, with an optional hexadecimal point (`.`) somewhere among them.
+    The mantissa represents a fraction in base 16 notation.
+* Then an optional exponent suffix consisting of:
+    * `p` or `P`
+    * Then an exponent specified as an decimal number with an optional leading sign (`+` or `-`).
+    * Then an optional `f` or `h` suffix.
+* At least one of the hexadecimal point, or the exponent [=shader-creation error|must=] be present.
+     If neither are, then the token is instead an [=integer literal=].
+
 <div class='syntax' noexport='true'>
   <dfn for=syntax>hex_float_literal</dfn> :
 
@@ -715,8 +743,32 @@ or a [=hexadecimal floating point literal=].
   </xmp>
 </div>
 
+<div algorithm="mathematical value of hexadecimal floating point literal">
+The mathematical value of a [=hexadecimal floating point literal=] is computed as follows:
+* Compute *effective_mantissa* from *mantissa*:
+    * If *mantissa* has 17 or fewer [=mantissa/significant=] digits, then *effective_mantissa* is *mantissa*.
+    * Otherwise:
+        * Let |truncated_mantissa| be the same as |mantissa| except each digit to the
+             right of the 17th significant digit is replaced with 0.
+        * Let |truncated_mantissa_next| be the same as |mantissa| except:
+             * the 17th significant digit is incremented by 1, and carries are propagated to the left as needed
+                 needed to ensure each digit remains in the range 0 through `f`, and
+             * each digit to the right of the 17th significant digit is replaced with 0.
+        * Set |effective_mantissa| to either |truncated_mantissa| or |truncated_mantissa_next|.
+             This is an implementation choice.
+* The mathematical value of the literal is the mathematical value of |effective_mantissa| as a hexadecimal fraction,
+    multiplied by 2 to the power of the exponent.
+    When no exponent is specified, an exponent of 0 is assumed.
+
+</div>
+
+Note: The hexadecimal mantissa is truncated after 17 hexadecimal digits, preserving approximately 4 &times;17 &equals; 68 significant bits in the fraction.
+
+
 When a [=numeric literal=] has a suffix, the literal denotes a value in a specific [=type/concrete=] [=scalar=] type.
 Otherwise, the literal denotes a value one of the [=abstract numeric types=] defined below.
+In either case, the value denoted by the literal is its mathematical value after conversion to the target type,
+following the rules in [[#floating-point-conversion]].
 
 <table class=data>
   <caption>Mapping numeric literals to types</caption>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -746,14 +746,14 @@ A <dfn noexport>hexadecimal floating point literal</dfn> is:
 <div algorithm="mathematical value of hexadecimal floating point literal">
 The mathematical value of a [=hexadecimal floating point literal=] is computed as follows:
 * Compute *effective_mantissa* from *mantissa*:
-    * If *mantissa* has 17 or fewer [=mantissa/significant=] digits, then *effective_mantissa* is *mantissa*.
+    * If *mantissa* has 16 or fewer [=mantissa/significant=] digits, then *effective_mantissa* is *mantissa*.
     * Otherwise:
         * Let |truncated_mantissa| be the same as |mantissa| except each digit to the
-             right of the 17th significant digit is replaced with 0.
+             right of the 16th significant digit is replaced with 0.
         * Let |truncated_mantissa_next| be the same as |mantissa| except:
-             * the 17th significant digit is incremented by 1, and carries are propagated to the left as needed
+             * the 16th significant digit is incremented by 1, and carries are propagated to the left as needed
                  needed to ensure each digit remains in the range 0 through `f`, and
-             * each digit to the right of the 17th significant digit is replaced with 0.
+             * each digit to the right of the 16th significant digit is replaced with 0.
         * Set |effective_mantissa| to either |truncated_mantissa| or |truncated_mantissa_next|.
              This is an implementation choice.
 * The mathematical value of the literal is the mathematical value of |effective_mantissa| as a hexadecimal fraction,
@@ -762,7 +762,7 @@ The mathematical value of a [=hexadecimal floating point literal=] is computed a
 
 </div>
 
-Note: The hexadecimal mantissa is truncated after 17 hexadecimal digits, preserving approximately 4 &times;17 &equals; 68 significant bits in the fraction.
+Note: The hexadecimal mantissa is truncated after 16 hexadecimal digits, preserving approximately 4 &times;16 &equals; 64 significant bits in the fraction.
 
 
 When a [=numeric literal=] has a suffix, the literal denotes a value in a specific [=type/concrete=] [=scalar=] type.


### PR DESCRIPTION
Limit decimal floats to 20 significant digits, hex floats to 17. Explain the literal denotes the mathematical value after conversion to the target value.

Fixes: #3255 #3218