### PR TITLE
float conversion overflow is compile-time error if orginal expression…

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -10204,7 +10204,8 @@ When converting a value to a floating point type:
          WGSL does not specify whether the larger or smaller representable
          value is chosen, and different instances of such a conversion may choose differently.
     * Otherwise, the original value lies outside the finite range of the destination type:
-         * A [=shader-creation error=] results if the original value is of [=abstract numeric type=].
+         * A [=shader-creation error=] results if the original expression is a [=const-expression=].
+         * A [=pipeline-creation error=] results if the original expression is an [=override-expression=].
          * Otherwise the conversion proceeds as follows:
              1. Set |X| to the original value.
              2. If the source type is a floating point type with more mantissa bits than the destination type,


### PR DESCRIPTION
… is compile-time

Fixes the confusion of abstract == const-expression. It's not the same.

Fixes: #3571