### PR TITLE
Allow slightly more expressions for pointer arguments

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8222,7 +8222,7 @@ of declarations.
     var unusable_priv : array<i32, 4>;
     fn foo() {
       var usable_func : f32;
-      var unuable_func : S;
+      var unusable_func : S;
 
       let a_priv = &usable_priv;
       let b_priv = a_priv;

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8238,6 +8238,7 @@ of declarations.
 
       baz(&usable_priv); // Valid, address-of a variable.
       baz(a_priv);       // Valid, effectively address-of a variable.
+      baz(b_priv);       // Valid, effectively address-of a variable.
       baz(c_priv);       // Valid, effectively address-of a variable.
       baz(d_priv);       // Invalid, memory view has changed.
       baz(e_priv);       // Invalid, memory view has changed.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8181,20 +8181,14 @@ Note: The [=attribute/const=] attribute cannot be applied to user-declared funct
     * [=address spaces/private=]
     * [=address spaces/workgroup=]
     * [=address spaces/storage=]
-* Each argument of pointer type to a [=user-defined function=] [=shader-creation error|must=] be one of:
-    * An [[#address-of-expr|address-of expression]] of a
-        [[#var-identifier-expr|variable identifier expression]]
-    * A [=formal parameter|function parameter=]
-    * A [[#constant-identifier-expr|constant identifier expression]] or
-        [[#address-of-expr|address-of expression]] where the only expressions
-        applied to the [=root identifier=] would satisfy the previous two
-        rules.
-        That is, the [=memory view=] of the [=root identifier=] is unchanged.
-        This means no [[#vector-access-expr|vector]],
+* Each argument of pointer type to a [=user-defined function=]
+    [=shader-creation error|must=] have the same [=memory view=] as its [=root
+    identifier=].
+    * Note: This means no [[#vector-access-expr|vector]],
         [[#matrix-access-expr|matrix]], [[#array-access-expr|array]], or
         [[#struct-access-expr|struct]] access expressions can be applied to
-        produce a [=memory view=] into the root identifier when traced
-        from the argument back through all the [=let-declarations=].
+        produce a [=memory view=] into the root identifier when traced from the
+        argument back through all the [=let-declarations=].
 
 Note: Recursion is disallowed because cycles are not permitted among any kinds
 of declarations.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8202,7 +8202,7 @@ of declarations.
     }
 
     fn bar2(p : ptr<function, f32>) {
-      let a = &*&*&(p);
+      let a = &*&*(p);
 
       bar(p); // Valid
       bar(a); // Valid

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8185,14 +8185,75 @@ Note: The [=attribute/const=] attribute cannot be applied to user-declared funct
     * An [[#address-of-expr|address-of expression]] of a
         [[#var-identifier-expr|variable identifier expression]]
     * A [=formal parameter|function parameter=]
+    * A [[#constant-identifier-expr|constant identifier expression]] or
+        [[#address-of-expr|address-of expression]] where the only expressions
+        applied to the [=root identifier=] would satisfy the previous two
+        rules.
+        That is, the [=memory view=] of the [=root identifier=] is unchanged.
+        This means no [[#vector-access-expr|vector]],
+        [[#matrix-access-expr|matrix]], [[#array-access-expr|array]], or
+        [[#struct-access-expr|struct]] access expressions can be applied to
+        produce a [=memory view=] into the root identifier when traced
+        from the argument back through all the [=let-declarations=].
 
 Note: Recursion is disallowed because cycles are not permitted among any kinds
 of declarations.
 
+<div class='example wgsl' heading='Valid and invalid pointer arguments'>
+  <xmp highlight='rust'>
+    fn bar(p : ptr<function, f32>) {
+    }
+
+    fn baz(p : ptr<private, i32>) {
+    }
+
+    fn bar2(p : ptr<function, f32>) {
+      let a = &*&*&(p);
+
+      bar(p); // Valid
+      bar(a); // Valid
+    }
+
+    struct S {
+      x : i32
+    }
+
+    var usable_priv : i32;
+    var unusable_priv : array<i32, 4>;
+    fn foo() {
+      var usable_func : f32;
+      var unuable_func : S;
+
+      let a_priv = &usable_priv;
+      let b_priv = a_priv;
+      let c_priv = &*&usable_priv;
+      let d_priv = &(unusable_priv.x);
+      let e_priv = d_priv;
+
+      let a_func = &usable_func;
+      let b_func = &unusable_func;
+      let c_func = &(*b_func)[0];
+      let d_func = c_func;
+      let e_func = &*a_func;
+
+      baz(&usable_priv); // Valid, address-of a variable.
+      baz(a_priv);       // Valid, effectively address-of a variable.
+      baz(c_priv);       // Valid, effectively address-of a variable.
+      baz(d_priv);       // Invalid, memory view has changed.
+      baz(e_priv);       // Invalid, memory view has changed.
+
+      bar(&usable_func); // Valid, address-of a variable.
+      bar(c_func);       // Invalid, memory view has changed.
+      bar(d_func);       // Invalid, memory view has changed.
+      bar(e_func);       // Valid, effectively address-of a variable.
+    }
+  </xmp>
+</div>
+
 ### Alias Analysis ### {#alias-analysis}
 
 [=Memory locations=] can be accessed during the execution of a function using [=memory views=].
-Within a function, each [=memory view=] has a particular root identifier.
+Within a function, each [=memory view=] has a particular <dfn noexport>root identifier</dfn>.
 The root identifier can be an [=originating variable=] or a [=formal parameter=]
 of [=pointer type=].
 


### PR DESCRIPTION
* Modify the restriction on pointer arguments to allow intermediate names to be introduced without violating the restrictions
  * trace through let-declarations to the root identifier
* Changed to improve usability and consistency of the language