### PR TITLE
Allow aliased resource variables

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2908,6 +2908,7 @@ Each memory access is performed via a [=memory view=].
 
 A <dfn noexport>memory view</dfn> comprises:
 * a set of [=memory locations=] in a particular [=address space=],
+* a [[#memory-model-reference|memory model reference]],
 * an interpretation of the contents of those locations as a WGSL [=type=], known as the <dfn noexport>store type</dfn>, and
 * an [=access mode=].
 
@@ -4310,8 +4311,10 @@ The lifetime of a function-scope variable is determined by its scope:
     That is, the lifetime includes any functions [=function call|called=] while
     the name is in scope.
 
-Two variables with overlapping lifetimes will not have [=overlap|overlapping
-memory=] locations.
+Two [=resource=] variables may have [=overlap|overlapping memory=] locations,
+but it is a [=dynamic error=] if either of those variables is mutable.
+Other variables with overlapping lifetimes will not have overlapping memory
+locations.
 When a variable’s lifetime ends, its memory may be used for another variable.
 
 Note: WGSL ensures the contents of a variable are only observable during the
@@ -8722,9 +8725,8 @@ Together with the shader's stage, these identify the binding address
 of the resource on the shader's pipeline.
 See [[WebGPU#pipeline-layout|WebGPU &sect; GPUPipelineLayout]].
 
-Bindings [=shader-creation error|must not=] alias within a [=shader=]:
-two different variables in the resource interface of a given
-shader [=shader-creation error|must not=] have the same group and binding values, when considered as a pair of values.
+It is a [=dynamic error=] if two mutable resource variables have the same pair
+of group and binding values.
 
 ### Resource Layout Compatibility ### {#resource-layout-compatibility}
 
@@ -10353,10 +10355,11 @@ member.
 
 ## Memory Model Reference ## {#memory-model-reference}
 
-Each module-scope variable in WGSL forms a unique [=memory model
-reference=] for the lifetime of a given entry point.
-Each function-scope variable in WGSL forms a unique [=memory model
-reference=] for the lifetime of the variable.
+Each module-scope [=resource=] variable forms a [=memory model reference=] for
+the unique [=attribute/group=] and [=attribute/binding=] pair.
+All other variables (i.e. variables in the [=address spaces/function=],
+[=address spaces/private=], and [=address spaces/workgroup=] address spaces)
+for a unique [=memory model reference=] for the lifetime of the variable.
 
 ## Scoped Operations ## {#scoped-operations}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8725,8 +8725,9 @@ Together with the shader's stage, these identify the binding address
 of the resource on the shader's pipeline.
 See [[WebGPU#pipeline-layout|WebGPU &sect; GPUPipelineLayout]].
 
-It is a [=dynamic error=] if two mutable resource variables have the same pair
-of group and binding values.
+Two different resource variables in a [=shader=] [=shader-creation error|must
+not=] have the same [=attribute/group=] and [=attribute/binding=] values, when
+considered as a pair.
 
 ### Resource Layout Compatibility ### {#resource-layout-compatibility}
 
@@ -10355,11 +10356,11 @@ member.
 
 ## Memory Model Reference ## {#memory-model-reference}
 
-Each module-scope [=resource=] variable forms a [=memory model reference=] for
+Each module-scope [=resource=] variable forms a [=memory model reference=] form
 the unique [=attribute/group=] and [=attribute/binding=] pair.
-All other variables (i.e. variables in the [=address spaces/function=],
+Each other variable (i.e. variables in the [=address spaces/function=],
 [=address spaces/private=], and [=address spaces/workgroup=] address spaces)
-for a unique [=memory model reference=] for the lifetime of the variable.
+forms a unique [=memory model reference=] for the lifetime of the variable.
 
 ## Scoped Operations ## {#scoped-operations}
 


### PR DESCRIPTION
Contributes to #1842

* Clarify a memory view depends on the memory model reference
* Allow aliased resources, but make it a dynamic error if the aliased resources are mutable
* Clarify that resource variables form a memory model reference based on the group and binding pair
* Clarify resource variable may have overlapping memory locations