### PR TITLE
Disambiguate precedence of & and * vs. [] and .member in lhs_expression

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6474,7 +6474,11 @@ When an identifier is used as a [=syntax/callable=] item, it is one of:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>lhs_expression</dfn> :
 
-    | ( [=syntax/star=] | [=syntax/and=] ) * [=syntax/core_lhs_expression=] [=syntax/component_or_swizzle_specifier=] ?
+    | [=syntax/core_lhs_expression=] [=syntax/component_or_swizzle_specifier=] ?
+
+    | [=syntax/star=] [=syntax/lhs_expression=]
+
+    | [=syntax/and=] [=syntax/lhs_expression=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>core_lhs_expression</dfn> :

--- a/wgsl/wgsl.recursive.bs.include
+++ b/wgsl/wgsl.recursive.bs.include
@@ -338,7 +338,11 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>lhs_expression</dfn>:
 
- | ( [=syntax/star=] | [=syntax/and=] ) * [=recursive descent syntax/core_lhs_expression=] [=recursive descent syntax/component_or_swizzle_specifier=] ?
+ | [=recursive descent syntax/core_lhs_expression=] [=recursive descent syntax/component_or_swizzle_specifier=] ?
+
+ | [=syntax/and=] [=recursive descent syntax/lhs_expression=]
+
+ | [=syntax/star=] [=recursive descent syntax/lhs_expression=]
 </div>
 
 <div class='syntax' noexport='true'>
@@ -667,11 +671,11 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>variable_updating_statement</dfn>:
 
- | ( [=syntax/star=] | [=syntax/and=] ) * [=recursive descent syntax/core_lhs_expression=] [=recursive descent syntax/component_or_swizzle_specifier=] ? ( [=syntax/equal=] | [=recursive descent syntax/compound_assignment_operator=] ) [=recursive descent syntax/expression=]
+ | [=recursive descent syntax/lhs_expression=] ( [=syntax/equal=] | [=recursive descent syntax/compound_assignment_operator=] ) [=recursive descent syntax/expression=]
 
- | ( [=syntax/star=] | [=syntax/and=] ) * [=recursive descent syntax/core_lhs_expression=] [=recursive descent syntax/component_or_swizzle_specifier=] ? [=syntax/minus_minus=]
+ | [=recursive descent syntax/lhs_expression=] [=syntax/minus_minus=]
 
- | ( [=syntax/star=] | [=syntax/and=] ) * [=recursive descent syntax/core_lhs_expression=] [=recursive descent syntax/component_or_swizzle_specifier=] ? [=syntax/plus_plus=]
+ | [=recursive descent syntax/lhs_expression=] [=syntax/plus_plus=]
 
  | [=syntax/underscore=] [=syntax/equal=] [=recursive descent syntax/expression=]
 </div>


### PR DESCRIPTION
Make it the same as in the ordinary kind of expression:
- unary & and unary * are lower precedence than [] indexing and .member selection.

Fixes: #3530