### PR TITLE
Remove 0 return when a NaN would be produced for atanh and acosh

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -11510,8 +11510,6 @@ Note: The result is not mathematically meaningful when `abs(e)` &gt; 1.
     hyperbolic [=angle=] in radians.<br>
     That is, approximates `x` with 0 &le; x &le; &infin;, such that `cosh`(`x`) = `e`.
 
-    The result is 0 when `e` &lt; 1.
-
     [=Component-wise=] when `T` is a vector.
   <tr>
     <td>
@@ -11594,8 +11592,6 @@ Note: The result is not mathematically meaningful when `abs(e)` &gt; 1.
     <td>Description
     <td>Returns the inverse hyperbolic tangent (tanh<sup>-1</sup>) of `e`, as a hyperbolic [=angle=] in radians.<br>
     That is, approximates `x` such that `tanh`(`x`) = `e`.
-
-    The result is 0 when `abs(e)` &ge; 1.<br>
 
     [=Component-wise=] when `T` is a vector.
   <tr>


### PR DESCRIPTION
Fixes #3365

* Floating-point evaluation already says runtime nan and inf are indeterminate values