### PR TITLE
clarify when const- and override-expressions are evaluated

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4573,7 +4573,8 @@ Note: [=type/abstract|Abstract types=] can be the inferred type of a const-expre
 
 A const-expression |E| will be evaluated if and only if:
 * |E| is [=top-level expression=], or
-* |E| is a [=subexpression=] of a [=top-level expression=] |TE|, and evaluation of |TE| requires |E| to be evaluated.
+* |E| is a [=subexpression=] of an expression |OuterE|, and |OuterE| will be evaluated, and evaluation of |OuterE|
+    requires |E| to be evaluated.
 
 Note: The evaluation rule implies that short-circuting operators `&&` and `||` guard evaluation of their right-hand
 side subexpressions.
@@ -4630,7 +4631,8 @@ Note: All [=const-expressions=] are also override-expressions.
 
 An override-expression |E| will be evaluated if and only if:
 * |E| is [=top-level expression=], or
-* |E| is a [=subexpression=] of a [=top-level expression=] |TE|, and evaluation of |TE| requires |E| to be evaluated.
+* |E| is a [=subexpression=] of an expression |OuterE|, and |OuterE| will be evaluated, and evaluation of |OuterE|
+    requires |E| to be evaluated.
 
 Note: An override-expression may not be usable as the initializer for an
 [=override-declaration=], because such initializers must [=type rules|resolve=]

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -4558,19 +4558,25 @@ WGSL defines two types of expressions that can be evaluated before runtime:
 
 ### `const` Expressions ### {#const-expr}
 
-Expressions that are evaluated at [=shader module creation|shader-creation
+Expressions that can be evaluated at [=shader module creation|shader-creation
 time=] are called <dfn noexport>const-expressions</dfn>.
-In order for an expression to be evaluated at shader-creation time all
-[=identifiers=] in the expression must [=resolve=] to:
+An expression is a const-expression if all its [=identifiers=] [=resolve=] to:
 * [=const-declarations=], or
 * [=const-functions=], or
 * [=type aliases=], or
-* [=structure=] names
+* [=structure=] names.
 
-The type of a `const` expression must [=type rules|resolve=] to a type with a
+The type of a `const` expression [=shader-creation error|must=] [=type rules|resolve=] to a type with a
 [=creation-fixed footprint=].
 
 Note: [=type/abstract|Abstract types=] can be the inferred type of a const-expression.
+
+A const-expression |E| will be evaluated if and only if:
+* |E| is [=top-level expression=], or
+* |E| is a [=subexpression=] of a [=top-level expression=] |TE|, and evaluation of |TE| requires |E| to be evaluated.
+
+Note: The evaluation rule implies that short-circuting operators `&&` and `||` guard evaluation of their right-hand
+side subexpressions.
 
 Example:  `(42)` is analyzed as follows:
 * The term `42` is the [=AbstractInt=] value 42.
@@ -4602,19 +4608,29 @@ Example:  `let minint = -2147483648;` is analyzed as follows:
     [=AbstractInt=] -2147483648 value is converted to the [=i32=] value -2147483648.
 * The result is that `minint` is declared to be the i32 value -2147483648.
 
+Example:  `false && (10i < i32(5 * 1000 * 1000 * 1000))` is analyzed as follows:
+* The entire expression is a const-expression.
+* However, the short-circuiting rules of the `&&` operator apply:
+    the left-hand side evaluates to `false`, and so the right-hand side is *not evaluated*.
+* Evaluation of i32(5 * 1000 * 1000 * 1000) would have caused a [=shader-creation error=]
+    because the [=AbstractInt=] value 5000000000 overflows the [=i32=] type.
+
 ### `override` Expressions ### {#override-expr}
 
-Expressions that are evaluated at [=pipeline creation=] time are called <dfn
+Expressions that can be evaluated at [=pipeline creation=] time are called <dfn
 noexport>override-expressions</dfn>.
-In order for an expression to be evaluated at pipeline creation time all
-[=identifiers=] in the expression must [=resolve=] to:
+An expression is a const-expression if all its [=identifiers=] [=resolve=] to:
 * [=override-declarations=], or
 * [=const-declarations=], or
 * [=const-functions=], or
 * [=type aliases=], or
-* [=structure=] names
+* [=structure=] names.
 
 Note: All [=const-expressions=] are also override-expressions.
+
+An override-expression |E| will be evaluated if and only if:
+* |E| is [=top-level expression=], or
+* |E| is a [=subexpression=] of a [=top-level expression=] |TE|, and evaluation of |TE| requires |E| to be evaluated.
 
 Note: An override-expression may not be usable as the initializer for an
 [=override-declaration=], because such initializers must [=type rules|resolve=]


### PR DESCRIPTION
Short-circuting operators still short-circuit

Fixes: #3591