### PR TITLE
Remove early statement saying variables don't overlap

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2323,15 +2323,12 @@ describe the contents of memory.
 ### Memory Locations ### {#memory-locations-section}
 
 Memory consists of a set of distinct <dfn noexport>memory locations</dfn>.
-Each memory location is 8-bits
-in size. An operation affecting memory interacts with a set of one or more
-memory locations.
+Each memory location is 8-bits in size.
+An operation affecting memory interacts with a set of one or more memory locations.
+Memory operations on structures and arrays will not access padding memory locations.
 
 Two sets of memory locations <dfn noexport>overlap</dfn> if the intersection of
-their sets of memory locations is non-empty. Each [=variable declaration=] has a
-set of memory locations that does not overlap with the sets of memory locations of
-any other variable declaration. Memory operations on structures and arrays will
-not access padding memory locations.
+their sets of memory locations is non-empty.
 
 ### Memory Access Mode ### {#memory-access-mode}
 
@@ -4339,9 +4336,10 @@ access mode; the default is read.
 A <dfn>texture resource</dfn> is a variable whose [=effective-value-type=] is a [=texture type=].
 It is declared at [=module scope=].
 It holds an opaque handle which is used to access the underlying grid of [=texels=] in a [=texture=].
-The handle itself is in the [=address spaces/handle=] address space and is is always read-only.
-In many cases the underlying texels are read-only.
-For a write-only [=storage texture=], the underlying texels are write-only.
+The handle itself is in the [=address spaces/handle=] address space and is always read-only.
+In many cases the underlying texels are read-only, and we say the texture variable immutable.
+For a write-only [=storage texture=], the underlying texels are write-only, and by convention
+we say the texture variable is mutable.
 
 A <dfn>sampler resource</dfn> is a variable whose [=effective-value-type=] is a [=sampler type=].
 It is declared at [=module scope=], exists in the [=address spaces/handle=] address space,


### PR DESCRIPTION
The "var declarations" section already says resource variables may overlap.

Also:
- Clarify what we mean by a  mutable"/immutable texture variable. The "mutable" terminology isused by the "resource variables may overlap" wording.
- Move the statement about not touching padding memory closer to the sentence about memory operations affecting memory locations.
- Break lines in index.bs at sentence boundaries.