### PR TITLE
GPUBuffer.destroy() calls unmap() if pending

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3278,11 +3278,9 @@ once all previously submitted operations using it are complete.
 
                 [=Content timeline=] steps:
 
-                1. If |this| is mapped, call |this|.{{GPUBuffer/unmap()}}.
+                1. Call |this|.{{GPUBuffer/unmap()}}.
 
                 <!-- POSTV1(multithreading) tentative text:
-                1. If |this| is mapped in this [=agent=] (thread), call |this|.{{GPUBuffer/unmap()}}.
-
                     Note: If the buffer is mapped in a different thread, it is not unmapped.
                     It can be unmapped only from the thread on which it is mapped, either by
                     another call to {{GPUBuffer/destroy()|GPUBuffer.destroy()}},


### PR DESCRIPTION
Fixes #3597

Currently `GPUBuffer.destroy()` calls `unmap()` only if buffer is `mapped`.

This can cause a problem if buffer is destroyed after `mapAsync()` call but before `mapAsync()`
complete, that means buffer is `pending`, because `buffer.[[pending_map]]` doesn't become
`null` by `destroy()` and the content timeline steps don't immediately return although buffer is already destroyed.

So `GPUBuffer.destroy()` shold call `unmap()` if buffer is pending, too. The change resolves the problem.