### PR TITLE
Refactor argument_expression_list for readability

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6508,7 +6508,12 @@ When an identifier is used as a [=syntax/callable=] item, it is one of:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>argument_expression_list</dfn> :
 
-    | [=syntax/paren_left=] ( [=syntax/expression=] ( [=syntax/comma=] [=syntax/expression=] ) * [=syntax/comma=] ? ) ? [=syntax/paren_right=]
+    | [=syntax/paren_left=] [=syntax/expression_comma_list=] ? [=syntax/paren_right=]
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>expression_comma_list</dfn> :
+
+    | [=syntax/expression=] ( [=syntax/comma=] [=syntax/expression=] ) * [=syntax/comma=] ?
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>component_or_swizzle_specifier</dfn> :


### PR DESCRIPTION
Introduce "expression_comma_list" to avoid mixing EBNF parentheses with WGSL parentheses tokens.