### PR TITLE
wgsl: Limit the overrides declarations in shader interface

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8586,11 +8586,11 @@ A declaration *D* is <dfn>statically accessed</dfn> by a shader when:
     of any of the [=functions in a shader stage|functions in the shader stage=].
 * An identifier [=resolving=] to *D* is used to define a type for a [=statically accessed=] declaration.
 * An identifier [=resolving=] to *D* is used in the initializer for a [=statically accessed=] declaration.
-* An identifier [=resolving=] to *D* is by an attribute used by a [=statically accessed=] declaration.
+* An identifier [=resolving=] to *D* is used by an attribute used by a [=statically accessed=] declaration.
 
 <div class="note">Note: Static access is recursively defined, taking into account the following:
-* All the parts of a function declaration including attributes, formal parameters, return type, and function body
-* Any type needed to define the above, including following type aliases.
+* All the parts of a [=function declaration=] including attributes, formal parameters, return type, and function body.
+* Any type needed to define the above, including following [=type aliases=].
 * As a particular case of helping to define a type,
     any [=override-declaration=] used in an [=override-expression=] that is the [=element count=]
     of an [=array=] type for a variable in the [=address spaces/workgroup=] address space,
@@ -8600,7 +8600,7 @@ A declaration *D* is <dfn>statically accessed</dfn> by a shader when:
     </div>
 
 We can now precisely define the <dfn noexport>interface of a shader</dfn> as consisting of:
-  - All [=formal parameters=] of the [=entry point=].
+  - The [=formal parameters=] of the [=entry point=].
      These denote the shader stage inputs.
   - The [=return value=] of the entry point.
      This denotes the shader stage outputs.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8569,7 +8569,7 @@ ISSUE: Can we query upper bounds on workgroup size dimensions?  Is it independen
 
 The shader interface is the set of objects
 through which the shader accesses data external to the [=shader stage=],
-either for reading or writing.
+either for reading or writing, and the [=pipeline-overridable=] constants used to configure the shader.
 The interface includes:
 
 * [=Shader stage inputs=]
@@ -8581,20 +8581,33 @@ The interface includes:
     * [=Texture resources=]
     * [=Sampler resources=]
 
-When an [=identifier=] in a [=function body=] [=resolves=] to a [=module scope|module-scope=] [[#var-and-value|variable or value declaration]],
-then we say that variable or value is <dfn>statically accessed</dfn> by the function.
-Note that being statically accessed is independent of whether an execution of the shader
-will actually evaluate the expression referring to the variable,
-or even execute the statement that may enclose the expression.
+A declaration *D* is <dfn>statically accessed</dfn> by a shader when:
+* An identifier [=resolving=] to *D* appears in the [=function declaration|declaration=]
+    of any of the [=functions in a shader stage|functions in the shader stage=].
+* An identifier [=resolving=] to *D* is used to define a type for a [=statically accessed=] declaration.
+* An identifier [=resolving=] to *D* is used in the initializer for a [=statically accessed=] declaration.
+* An identifier [=resolving=] to *D* is by an attribute used by a [=statically accessed=] declaration.
 
-More precisely, the <dfn noexport>interface of a shader stage</dfn> consists of:
+<div class="note">Note: Static access is recursively defined, taking into account the following:
+* All the parts of a function declaration including attributes, formal parameters, return type, and function body
+* Any type needed to define the above, including following type aliases.
+* As a particular case of helping to define a type,
+    any [=override-declaration=] used in an [=override-expression=] that is the [=element count=]
+    of an [=array=] type for a variable in the [=address spaces/workgroup=] address space,
+    when that variable itself is statically accessed.
+* Any override declarations used to support the evaluation of override-expressions in any of the above.
+* Any attributes on any of the above.
+    </div>
+
+We can now precisely define the <dfn noexport>interface of a shader</dfn> as consisting of:
   - All [=formal parameters=] of the [=entry point=].
      These denote the shader stage inputs.
   - The [=return value=] of the entry point.
      This denotes the shader stage outputs.
-  - All [=override-declarations=].
-  - All [=uniform buffer=], [=storage buffer=], [=texture resource=], and [=sampler resource=] variables that are
-        [=statically accessed=] by [=functions in a shader stage|functions in the shader stage=].
+  - The [=uniform buffer=], [=storage buffer=], [=texture resource=], and [=sampler resource=] variables
+        [=statically accessed=] by the shader.
+  - The [=override-declarations=]
+        [=statically accessed=] by the shader.
 
 ### Inter-stage Input and Output Interface ### {#stage-inputs-outputs}
 


### PR DESCRIPTION
Only include the overrides that affect the functions in the shader stage.

This change makes the definition of "static access" do the heavy lifting. It is now recursively defined and must follow through on attributes, formal parameters, types, and type aliases.

A followup should add an example.

Fixes: #3555