### PR TITLE
Fix confusing "reference to" wording in uniformity analysis

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -8351,9 +8351,9 @@ but each expression has a statically determinable root identifier.
 Given an expression |E| of [=pointer type|pointer=] or [=reference type=], the
 [=root identifier=] is the [=originating variable=] or [=formal parameter=] of [=pointer type=]
 found as follows:
-* If |E| is an identifier [=resolving=] to a variable, then the root identifier is that variable.
-* If |E| is an identifier [=resolving=] to a formal parameter of pointer type, then the root identifier is that formal parameter.
-* If |E| is an identifier [=resolving=] to a [=let-declaration=] with initializer |E2|, then the root identifier is the root identifier of |E2|.
+* If |E| is an identifier [=resolves|resolving=] to a variable, then the root identifier is that variable.
+* If |E| is an identifier [=resolves|resolving=] to a formal parameter of pointer type, then the root identifier is that formal parameter.
+* If |E| is an identifier [=resolves|resolving=] to a [=let-declaration=] with initializer |E2|, then the root identifier is the root identifier of |E2|.
 * If |E| is of the form `(`|E2|`)`, `&`|E2|, `*`|E2|, or |E2|`[`<var ignore>Ei</var>`]` then the root identifier is the root identifier of |E2|.
 * If |E| is a [[#vector-access-expr|vector access expression]] of the form |E2|.|swiz|, where |swiz| is a [=swizzle=] name, then the root identifer is the root identifier of |E2|.
 * If |E| is a [[#struct-access-expr|structure access expression]] of the form |E2|.<var ignore>member_name</var>, then the root identifer is the root identifier of |E2|.
@@ -8582,11 +8582,11 @@ The interface includes:
     * [=Sampler resources=]
 
 A declaration *D* is <dfn>statically accessed</dfn> by a shader when:
-* An identifier [=resolving=] to *D* appears in the [=function declaration|declaration=]
+* An identifier [=resolves|resolving=] to *D* appears in the [=function declaration|declaration=]
     of any of the [=functions in a shader stage|functions in the shader stage=].
-* An identifier [=resolving=] to *D* is used to define a type for a [=statically accessed=] declaration.
-* An identifier [=resolving=] to *D* is used in the initializer for a [=statically accessed=] declaration.
-* An identifier [=resolving=] to *D* is used by an attribute used by a [=statically accessed=] declaration.
+* An identifier [=resolves|resolving=] to *D* is used to define a type for a [=statically accessed=] declaration.
+* An identifier [=resolves|resolving=] to *D* is used in the initializer for a [=statically accessed=] declaration.
+* An identifier [=resolves|resolving=] to *D* is used by an attribute used by a [=statically accessed=] declaration.
 
 <div class="note">Note: Static access is recursively defined, taking into account the following:
 * All the parts of a [=function declaration=] including attributes, formal parameters, return type, and function body.
@@ -9262,13 +9262,13 @@ An assignment is a <dfn noexport>full assignment</dfn> if:
 Otherwise, an assignment is a <dfn noexport>partial assignment</dfn>.
 
 A <dfn>full reference</dfn> is an expression of [=reference type=] that is one of:
-* an identifier *x* that [=resolving|resolves=] to a variable, or
+* an identifier *x* that [=resolves=] to a variable, or
 * `(`*r*`)` where *r* is a [=full reference=], or
 * `*`*p* where *p* is a [=full pointer=].
 
 A <dfn>full pointer</dfn> is an expression of [=pointer type=] that is one of:
 * `&`*r* where *r* is a [=full reference=], or
-* an identifier *p* that [=resolving|resolves=] to a [=let-declaration=] initialized to a [=full pointer=], or
+* an identifier *p* that [=resolves=] to a [=let-declaration=] initialized to a [=full pointer=], or
 * `(`*p*`)` where *p* is a [=full pointer=].
 
 Note: For the purposes of this analysis, we don't need the case where
@@ -9647,7 +9647,7 @@ The rules for analyzing expressions take as argument both the expression itself 
       <td>
       <td class="nowrap">*CF*, *CF*
       <td>
-   <tr><td>reference to function-scope variable "x"
+   <tr><td>identifier [=resolves|resolving=] to function-scope variable "x"
       <td>*Result*
       <td class>*X* is the node corresponding to the value of "x" at the input to the statement containing this expression
       <td class="nowrap">*CF*, *Result*
@@ -9655,29 +9655,29 @@ The rules for analyzing expressions take as argument both the expression itself 
 
       Note: *X* is equivalent to *Vout*(*prev*) for "x"<br>
       (see [[#func-var-value-analysis]])
-   <tr><td>reference to [=const-declaration=], [=override-declaration=],
-      [=let-declaration=], or non-built-in parameter "x"
+   <tr><td>identifier [=resolves|resolving=] to [=const-declaration=], [=override-declaration=],
+      [=let-declaration=], or non-built-in [=formal parameter=] "x"
       <td>*Result*
       <td>*X* is the node corresponding to "x"
       <td class="nowrap">*CF*, *Result*
       <td class="nowrap">*Result* -> {*CF*, *X*}
-   <tr><td>reference to uniform built-in value "x"
+   <tr><td>identifier [=resolves|resolving=] to uniform built-in value "x"
       <td>
       <td>
       <td class="nowrap">*CF*, *CF*
       <td>
-   <tr><td>reference to non-uniform built-in value "x"
+   <tr><td>identifier [=resolves|resolving=] to non-uniform built-in value "x"
       <td>
       <td>
       <td class="nowrap">*CF*,<br>
       *MayBeNonUniform*
       <td>
-   <tr><td>reference to read-only module-scope variable "x"
+   <tr><td>identifier [=resolves|resolving=] to read-only module-scope variable "x"
       <td>
       <td>
       <td class="nowrap">*CF*, *CF*
       <td>
-   <tr><td>reference to non-read-only module-scope variable "x"
+   <tr><td>identifier [=resolves|resolving=] to non-read-only module-scope variable "x"
       <td>
       <td>
       <td class="nowrap">*CF*,<br>
@@ -9713,7 +9713,7 @@ of a [=composite=] type separately.
   <thead>
     <tr><th>Expression<th>New nodes<th>Recursive analyses<th>Resulting control flow node, variable node<th>New edges
   </thead>
-   <tr><td>reference to function-scope variable "x"
+   <tr><td>identifier [=resolves|resolving=] to function-scope variable "x"
       <td>*Result*
       <td>*X* is the node corresponding to the value of "x" at the output of the statement containing this expression.
       <td class="nowrap">*CF*, *Result*
@@ -9721,12 +9721,13 @@ of a [=composite=] type separately.
 
       Note: *X* is equivalent to *Vin*(*next*) for "x"<br>
       (see [[#func-var-value-analysis]])
-  <tr><td>reference to [=const-declaration=], [=override-declaration=], [=let-declaration=], or parameter "x"
+  <tr><td>identifier [=resolves|resolving=] to
+          [=const-declaration=], [=override-declaration=], [=let-declaration=], or [=formal parameter=] "x"
       <td>
       <td>*X* is the node corresponding to "x"
       <td class="nowrap">*CF*, *X*
       <td>
-  <tr><td>reference to module-scope variable "x"
+  <tr><td>identifier [=resolves|resolving=] to module-scope variable "x"
       <td>
       <td>
       <td class="nowrap">*CF*,<br>


### PR DESCRIPTION
Editorial

Also, fix internal cross-reference to "resolves".
The bikeshed link had it reversed, and we were linking to the "resolves" definition in the WebIDL standard.

Fixes: #3457