### PR TITLE
wgsl: Make sections for each barrier function

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -14986,13 +14986,6 @@ Note: For unpacking snorm values, the normalized floating point result is in the
 
 ## Synchronization Built-in Functions ## {#sync-builtin-functions}
 
-WGSL provides the following synchronization functions:
-
-```rust
-fn storageBarrier()
-fn workgroupBarrier()
-```
-
 All synchronization functions execute a [=control barrier=] with
 Acquire/Release [[#memory-semantics|memory ordering]].
 That is, all synchronization functions, and affected memory and atomic
@@ -15002,14 +14995,41 @@ Additionally, the affected memory and atomic operations program-ordered before
 the synchronization function must be visible to all other threads in the
 workgroup before any affected memory or atomic operation program-ordered after
 the synchronization function is executed by a member of the workgroup.
-All synchronization functions use the `Workgroup` [=memory scope=].
-All synchronization functions have a `Workgroup` [=execution scope=].
-All synchronization functions [=shader-creation error|must=] only be used in the [=compute=] shader
-stage.
 
-`storageBarrier` affects memory and atomic operations in the [=address spaces/storage=] address space.
+All synchronization functions use the `Workgroup` [=memory scope=].<br>
+All synchronization functions have a `Workgroup` [=execution scope=].<br>
+All synchronization functions [=shader-creation error|must=] only be used in
+the [=compute=] shader stage.
 
-`workgroupBarrier` affects memory and atomic operations in the [=address spaces/workgroup=] address space.
+### `storageBarrier` ### {#storageBarrier-builtin}
+
+<table class='data builtin'>
+  <tr algorithm="storageBarrier">
+    <td style="width:10%" style="width:10%">Overload
+    <td class="nowrap"><xmp highlight=rust>
+fn storageBarrier()
+</xmp>
+  <tr>
+    <td>Description
+    <td>Executes a [=control barrier=] synchronization function that affects
+    memory and atomic operations in the [=address spaces/storage=] address
+    space.
+</table>
+
+### `workgroupBarrier` ### {#workgroupBarrier-builtin}
+
+<table class='data builtin'>
+  <tr algorithm="workgroupBarrier">
+    <td style="width:10%" style="width:10%">Overload
+    <td class="nowrap"><xmp highlight=rust>
+fn workgroupBarrier()
+</xmp>
+  <tr>
+    <td>Description
+    <td>Executes a [=control barrier=] synchronization function that affects
+    memory and atomic operations in the [=address spaces/workgroup=] address
+    space.
+</table>
 
 # Grammar for Recursive Descent Parsing # {#grammar-recursive-descent}
 


### PR DESCRIPTION
Make the synchronzation builtins section look like the other builtins sections.

This takes the editorial-only changes from #3586