### PR TITLE
wgsl: add concept of degenerate partial reference

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9318,11 +9318,53 @@ A [=full reference=], and similarly a [=full pointer=], is a [=memory view=]
 for *all* the memory locations for the corresponding [=originating variable=] *x*.
 
 A reference that is not a [=full reference=] is a <dfn noexport>partial reference</dfn>.
-As such, a partial reference is a memory view for a strict subset of the memory locations
-for the corresponding [=originating variable=].
+As such, a partial reference is either:
+* a memory view for a strict subset of the memory locations
+    for the corresponding [=originating variable=], or
+* a memory view the with same set of locations as the corresponding
+    originating variable, but with a different [=store type=].
+
+<div class="note">
+Note: A [=partial reference=] can still cover all the same memory locations
+as a full reference, i.e. all the locations used by a variable declaration.
+This can occur when the store type is a structure type having only one member,
+or when the store type is an array type with one element.
+
+Consider a structure type with a single member, and a variable storing that type:
+
+```rust
+     struct S { member: i32; }
+     fn foo () {
+        var v: S;
+     }
+```
+
+Then `v` is a full reference and `v.member` is a partial reference.
+Their memory views cover the same memory
+locations, but the store type for `v` is `S` and the store type of `v.s` is `i32`.
+
+A similar situation occurs with arrays having a single element:
+
+```rust
+     fn foo () {
+        var arr: array<i32,1>;
+     }
+```
+
+Then `arr` is a full reference and `arr[0]` is a partial reference.
+Their memory views cover the same memory
+locations, but the store type for `arr` is `array<i32,1>` and the store type of `arr[0]` is `i32`.
+
+To simplify analysis, an assignment via *any* kind of [=partial reference=] is treated as if
+it does *not* modify every memory location in the associated [=originating variable=].
+This causes the analysis to be conservative, potentially rejecting
+more programs than strictly necessary.
+</div>
 
 An assignment through a [=full reference=] is a [=full assignment=].
-An assignment thorugh a [=partial reference=] is a [=partial assignment=].
+
+An assignment through a [=partial reference=] is a [=partial assignment=].
+
 
 When the uniformity rules in subsequent sections refer to the value for a
 function-scope variable used as an RValue, it means the value of the variable
@@ -9378,7 +9420,10 @@ notations:
 
           Note: This is a [=partial assignment=] to *x*.
 
-          Note: Partial assignments include the previous value since only a subset of components are updated.
+          Note: Partial assignments include the previous value.
+          The assignment either writes only a subset of the stored components,
+          or the type of the written value differs from the [=store type=]
+          of the [=originating=] variable.
   <tr><td>*s1* *s2*<br>
           where *Next* is in behavior of *s1*.
 


### PR DESCRIPTION
A degenerate partial reference occurs for single-member structures, and single-element arrays, where the degenerate partial reference covers the same locations as the whole variable, but its store type is the member type or element type (respectively).

And say that when analyzing uniformity of function-scope variables, assignment through a degenerate partial reference is treated as if it's a full assignment.  This is conservative.

This resolves #3605 by saying it does *not* relax the rule for what a full reference can be.

Fixes: #3605