### PR TITLE
wgsl: Don't reserve line, lineadj, point

### DIFF
--- a/wgsl/keywords
+++ b/wgsl/keywords
@@ -509,6 +509,8 @@ while
 texture
 sampler
 );
+
+# https://github.com/gpuweb/gpuweb/pull/3615 Don't reserve: line lineadj point
 push @deliberately_unreserved, qw(
 AppendStructuredBuffer
 BlendState
@@ -520,9 +522,11 @@ dword
 false float
 half
 InputPatch int
+line lineadj
 LineStream
 matrix min16float min10float min16int min12int min16uint
 OutputPatch
+point
 PixelShader PointStream
 RasterizerState RenderTargetView row_major RWBuffer RWByteAddressBuffer RWStructuredBuffer RWTexture1D RWTexture1DArray RWTexture2D RWTexture2DArray RWTexture3D
 sampler SamplerState SamplerComparisonState stateblock stateblock_state string StructuredBuffer

--- a/wgsl/wgsl.reserved.bs.include
+++ b/wgsl/wgsl.reserved.bs.include
@@ -141,8 +141,6 @@
 
     | `'layout'`   <!-- GLSL -->
 
-    | `'lineadj'`   <!-- HLSL -->
-
     | `'lowp'`   <!-- GLSL -->
 
     | `'macro'`   <!-- Rust -->

--- a/wgsl/wgsl.reserved.bs.include
+++ b/wgsl/wgsl.reserved.bs.include
@@ -141,8 +141,6 @@
 
     | `'layout'`   <!-- GLSL -->
 
-    | `'line'`   <!-- HLSL -->
-
     | `'lineadj'`   <!-- HLSL -->
 
     | `'lowp'`   <!-- GLSL -->
@@ -200,8 +198,6 @@
     | `'patch'`   <!-- GLSL -->
 
     | `'pixelfragment'`   <!-- HLSL -->
-
-    | `'point'`   <!-- HLSL -->
 
     | `'precise'`   <!-- HLSL GLSL -->
 


### PR DESCRIPTION
Based on: https://github.com/gpuweb/gpuweb/issues/3613#issuecomment-1321207623
Looks like we need to add `triangle` or remove `point` and `line`.

Keywords `point`, `line` and `triangle` is [used in geometry shaders](https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-geometry-shader) in HLSL.

Seems other languages not reserving it. In GLSL exist #line directive and in MSL `primitive_type { point, line, line_strip, triangle, triangle_strip };`.
