### PR TITLE
Add abstract versions of modf and frexp

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1589,42 +1589,42 @@ Note: When no conversion is performed, the conversion rank is zero.
       <td>__frexp_result_abstract
       <td>__frexp_result
       <td>1
-      <td>Inherit conversion rank from input type.
+      <td>
   <tr algorithm="conversion rank for frexp result f16">
       <td>__frexp_result_abstract
       <td>__frexp_result_f16
       <td>2
-      <td>Inherit conversion rank from input type.
+      <td>
   <tr algorithm="conversion rank for frexp result vector">
       <td>__frexp_result_vecN_abstract
       <td>__frexp_result_vecN
       <td>1
-      <td>Inherit conversion rank from input type.
+      <td>
   <tr algorithm="conversion rank for frexp result vector f16">
       <td>__frexp_result_vecN_abstract
       <td>__frexp_result_vecN_f16
       <td>2
-      <td>Inherit conversion rank from input type.
+      <td>
   <tr algorithm="conversion rank for modf result">
       <td>__modf_result_abstract
       <td>__modf_result
       <td>1
-      <td>Inherit conversion rank from input type.
+      <td>
   <tr algorithm="conversion rank for modf result f16">
       <td>__modf_result_abstract
       <td>__modf_result_f16
       <td>2
-      <td>Inherit conversion rank from input type.
+      <td>
   <tr algorithm="conversion rank for modf result vector">
       <td>__modf_result_vecN_abstract
       <td>__modf_result_vecN
       <td>1
-      <td>Inherit conversion rank from input type.
+      <td>
   <tr algorithm="conversion rank for modf result vector f16">
       <td>__modf_result_vecN_abstract
       <td>__modf_result_vecN_f16
       <td>2
-      <td>Inherit conversion rank from input type.
+      <td>
   <tr algorithm="conversion rank for non-convertible cases">
       <td><var ignore>S</var>
       <td><var ignore>T</var><br>where above cases don't apply
@@ -12915,8 +12915,8 @@ but a value may infer the type.
     Returns the `__modf_result_vecN` built-in structure, defined as follows:
     ```rust
 struct __modf_result_vecN_abstract {
-  fract : vecN<f32>, // fractional part
-  whole : vecN<f32>  // whole part
+  fract : vecN<AbstractFloat>, // fractional part
+  whole : vecN<AbstractFloat>  // whole part
 }
     ```
   <tr>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1585,6 +1585,46 @@ Note: When no conversion is performed, the conversion rank is zero.
       <td>ConversionRank(|S|,|T|)
       <td>Inherit conversion rank from component type.
       Note: Only [=fixed-size arrays=] may have an [=type/abstract=] component type.
+  <tr algorithm="conversion rank for frexp result">
+      <td>__frexp_result_abstract
+      <td>__frexp_result
+      <td>1
+      <td>Inherit conversion rank from input type.
+  <tr algorithm="conversion rank for frexp result f16">
+      <td>__frexp_result_abstract
+      <td>__frexp_result_f16
+      <td>2
+      <td>Inherit conversion rank from input type.
+  <tr algorithm="conversion rank for frexp result vector">
+      <td>__frexp_result_vecN_abstract
+      <td>__frexp_result_vecN
+      <td>1
+      <td>Inherit conversion rank from input type.
+  <tr algorithm="conversion rank for frexp result vector f16">
+      <td>__frexp_result_vecN_abstract
+      <td>__frexp_result_vecN_f16
+      <td>2
+      <td>Inherit conversion rank from input type.
+  <tr algorithm="conversion rank for modf result">
+      <td>__modf_result_abstract
+      <td>__modf_result
+      <td>1
+      <td>Inherit conversion rank from input type.
+  <tr algorithm="conversion rank for modf result f16">
+      <td>__modf_result_abstract
+      <td>__modf_result_f16
+      <td>2
+      <td>Inherit conversion rank from input type.
+  <tr algorithm="conversion rank for modf result vector">
+      <td>__modf_result_vecN_abstract
+      <td>__modf_result_vecN
+      <td>1
+      <td>Inherit conversion rank from input type.
+  <tr algorithm="conversion rank for modf result vector f16">
+      <td>__modf_result_vecN_abstract
+      <td>__modf_result_vecN_f16
+      <td>2
+      <td>Inherit conversion rank from input type.
   <tr algorithm="conversion rank for non-convertible cases">
       <td><var ignore>S</var>
       <td><var ignore>T</var><br>where above cases don't apply
@@ -2148,7 +2188,7 @@ A structure member type [=shader-creation error|must=] be one of:
 * a [=runtime-sized=] array type, but only if it is the last member of the structure
 * a [=structure=] type that has a [=creation-fixed footprint=]
 
-Note: All structure types are [=type/concrete=].
+Note: All user-declared structure types are [=type/concrete=].
 
 Note: Each member type must be a [=plain type=].
 
@@ -12292,6 +12332,49 @@ but a value may infer the type.
 </table>
 
 <table class='data builtin'>
+  <tr algorithm="scalar case, abstract, frexp">
+    <td style="width:10%">Overload
+    <td class="nowrap"><xmp highlight=rust>
+@const fn frexp(e: T) -> __frexp_result_abstract
+</xmp>
+  <tr>
+    <td style="width:10%">Parameterization
+    <td>`T` is AbstractFloat
+  <tr>
+    <td>Description
+    <td>Splits `e` into a fraction and an exponent so that `e` &equals; `fraction * 2`<sup>`exponent`</sup>.
+    The fraction is 0.0 or its magnitude is in the range [0.5, 1.0).
+
+    Returns the `__frexp_result_abstract` built-in structure, defined as follows:
+    ```rust
+struct __frexp_result_abstract {
+  fract : AbstractFloat, // fraction part
+  exp : AbstractInt      // exponent part
+}
+    ```
+
+    Note: A mnemonic for the name `frexp` is "**fr**action and **exp**onent".
+  <tr>
+    <td>
+    <td>
+    <div class='example wgsl function-scope' heading='abstract frexp usage'>
+    <xmp highlight='rust'>
+     // Infers result type
+     const fraction_and_exponent = frexp(1.5);
+     // Sets fraction_only to 0.75
+     const fraction_only = frexp(1.5).fract;
+    </xmp>
+    </div>
+  <tr>
+    <td>
+    <td>
+
+Note: A value cannot be explicitly declared with the type `__frexp_result_abstract`,
+but a value may infer the type.
+
+</table>
+
+<table class='data builtin'>
   <tr algorithm="vector case, binary32, frexp">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
@@ -12351,6 +12434,38 @@ struct __frexp_result_vecN_f16 {
     <td>
 
 Note: A value cannot be explicitly declared with the type `__frexp_result_vecN_f16`,
+but a value may infer the type.
+
+</table>
+
+<table class='data builtin'>
+  <tr algorithm="vector case, abstract, frexp">
+    <td style="width:10%">Overload
+    <td class="nowrap"><xmp highlight=rust>
+@const fn frexp(e: T) -> __frexp_result_vecN_abstract
+</xmp>
+  <tr>
+    <td style="width:10%">Parameterization
+    <td>`T` is vecN&lt;AbstractFloat&gt;
+  <tr>
+    <td>Description
+    <td>Splits `e` into a fraction and an exponent so that `e` &equals; `fraction * 2`<sup>`exponent`</sup>.
+    Each component of the fraction is 0.0, or has a magnitude in the range [0.5, 1.0).
+
+    Returns the `__frexp_result_vecN_abstract` built-in structure, defined as follows:
+    ```rust
+struct __frexp_result_vecN_abstract {
+  fract : vecN<AbstractFloat>, // fraction part
+  exp : vecN<AbstractInt>      // exponent part
+}
+    ```
+
+    Note: A mnemonic for the name `frexp` is "**fr**action and **exp**onent".
+  <tr>
+    <td>
+    <td>
+
+Note: A value cannot be explicitly declared with the type `__frexp_result_vecN_abstract`,
 but a value may infer the type.
 
 </table>
@@ -12674,6 +12789,50 @@ but a value may infer the type.
 </table>
 
 <table class='data builtin'>
+  <tr algorithm="scalar case, abstract, modf">
+    <td style="width:10%">Overload
+    <td class="nowrap"><xmp highlight=rust>
+@const fn modf(e: T) -> __modf_result_abstract
+</xmp>
+  <tr>
+    <td style="width:10%">Parameterization
+    <td>`T` is AbstractFloat
+  <tr>
+    <td>Description
+    <td>Splits `e` into fractional and whole number parts.
+
+    The fractional part is (`e` % 1.0), and the whole part is `e` minus the fractional part.
+
+    Returns the `__modf_result_abstract` built-in structure, defined as follows:
+    ```rust
+struct __modf_result {
+  fract : AbstractFloat, // fractional part
+  whole : AbstractFloat  // whole part
+}
+    ```
+  <tr>
+    <td>
+    <td>
+    <div class='example wgsl function-scope' heading='modf abstract usage'>
+    <xmp highlight='rust'>
+     // Infers result type
+     const fract_and_whole = modf(1.5);
+     // Sets fract_only to 0.5
+     const fract_only = modf(1.5).fract;
+     // Sets whole_only to 1.0
+     const whole_only = modf(1.5).whole;
+    </xmp>
+    </div>
+  <tr>
+    <td>
+    <td>
+
+Note: A value cannot be explicitly declared with the type `__modf_result`,
+but a value may infer the type.
+
+</table>
+
+<table class='data builtin'>
   <tr algorithm="vector case, binary32, modf">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
@@ -12733,6 +12892,38 @@ struct __modf_result_vecN_f16 {
     <td>
 
 Note: A value cannot be explicitly declared with the type `__modf_result_vecN_f16`,
+but a value may infer the type.
+
+</table>
+
+<table class='data builtin'>
+  <tr algorithm="vector case, abstract, modf">
+    <td style="width:10%">Overload
+    <td class="nowrap"><xmp highlight=rust>
+@const fn modf(e: T) -> __modf_result_vecN_abstract
+</xmp>
+  <tr>
+    <td style="width:10%">Parameterization
+    <td>`T` is vecN&lt;AbstractFloat&gt;
+  <tr>
+    <td>Description
+    <td>Splits the components of `e` into fractional and whole number parts.
+
+    The `i`'th component of the whole and fractional parts equal the whole and fractional parts
+    of `modf(e[i])`.
+
+    Returns the `__modf_result_vecN` built-in structure, defined as follows:
+    ```rust
+struct __modf_result_vecN_abstract {
+  fract : vecN<f32>, // fractional part
+  whole : vecN<f32>  // whole part
+}
+    ```
+  <tr>
+    <td>
+    <td>
+
+Note: A value cannot be explicitly declared with the type `__modf_result_vecN_abstract`,
 but a value may infer the type.
 
 </table>


### PR DESCRIPTION
Fixes #3358

* Adds abstract numeric overloads of frexp and modf
* Adds conversion ranks for frexp and modf result structures from abstract to concrete types
  * necessary to support the following type of code:

```
const x = frexp(1.5);
let y = x;
```