### PR TITLE
wgsl: Fix typo .sig -> .fract

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12556,7 +12556,7 @@ Note: The result is not mathematically meaningful if `e` &le; 0.
     If `x` is zero or a finite normal value for its type, then:
   
     <blockquote>                
-    x = ldexp(frexp(x).sig, frexp(x).exp)
+    x = ldexp(frexp(x).fract, frexp(x).exp)
     </blockquote>                
 
     [=Component-wise=] when `T` is a vector.


### PR DESCRIPTION
according to https://github.com/gpuweb/gpuweb/pull/3619/files#r1029842454