### PR TITLE
wgsl: Fix typo in `modf` description

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12555,9 +12555,9 @@ Note: The result is not mathematically meaningful if `e` &le; 0.
 
     If `x` is zero or a finite normal value for its type, then:
   
-    <blockquote>                
+    <blockquote>
     x = ldexp(frexp(x).fract, frexp(x).exp)
-    </blockquote>                
+    </blockquote>
 
     [=Component-wise=] when `T` is a vector.
 
@@ -12726,7 +12726,7 @@ Note: The result is not mathematically meaningful if `e` &lt; 0.
     <td>Description
     <td>Splits `e` into fractional and whole number parts.
 
-    The fractional part is (`e` % 1.0), and the whole part is `e` minus the whole part.
+    The fractional part is (`e` % 1.0), and the whole part is `e` minus the fractional part.
 
     Returns the `__modf_result` built-in structure, defined as follows:
     ```rust
@@ -12770,7 +12770,7 @@ but a value may infer the type.
     <td>Description
     <td>Splits `e` into fractional and whole number parts.
 
-    The whole part is (`e` % 1.0), and the fractional part is `e` minus the whole part.
+    The fractional part is (`e` % 1.0), and the whole part is `e` minus the fractional part.
 
     Returns the `__modf_result_f16` built-in structure, defined as if as follows:
     ```rust


### PR DESCRIPTION
This is like #3619 but also fixes the f16 overload.