### PR TITLE
Fix issues in pass end() validation

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -10053,15 +10053,15 @@ called the compute pass encoder can no longer be used.
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
+                1. Let |parentEncoder| be |this|.{{GPURenderPassEncoder/[[command_encoder]]}}.
                 1. If any of the following requirements are unmet,
                     [$generate a validation error$] and stop.
 
                     <div class=validusage>
-                        - |this|.{{GPUCommandsMixin/[[state]]}} must be "[=encoder state/open=]",
+                        - |this|.{{GPUCommandsMixin/[[state]]}} must be "[=encoder state/open=]".
+                        - |parentEncoder|.{{GPUCommandsMixin/[[state]]}} must be "[=encoder state/locked=]".
                     </div>
-                1. Let |parentEncoder| be |this|.{{GPUComputePassEncoder/[[command_encoder]]}}.
                 1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/ended=]".
-                1. [=Assert=]: |parentEncoder|.{{GPUCommandsMixin/[[state]]}} is "[=encoder state/locked=]".
                 1. Set |parentEncoder|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/open=]".
                 1. If any of the following requirements are unmet, make
                     |parentEncoder| [=invalid=] and stop.
@@ -10630,17 +10630,18 @@ called the render pass encoder can no longer be used.
             <div data-timeline=device>
                 [=Device timeline=] steps:
 
+                1. Let |parentEncoder| be |this|.{{GPURenderPassEncoder/[[command_encoder]]}}.
                 1. If any of the following requirements are unmet,
                     [$generate a validation error$] and stop.
 
                     <div class=validusage>
-                        - |this|.{{GPUCommandsMixin/[[state]]}} must be "[=encoder state/open=]",
+                        - |this|.{{GPUCommandsMixin/[[state]]}} must be "[=encoder state/open=]".
+                        - |parentEncoder|.{{GPUCommandsMixin/[[state]]}} must be "[=encoder state/locked=]".
                     </div>
-                1. Let |parentEncoder| be |this|.{{GPURenderPassEncoder/[[command_encoder]]}}.
                 1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/ended=]".
-                1. [=Assert=]: |parentEncoder|.{{GPUCommandsMixin/[[state]]}} is "[=encoder state/locked=]".
                 1. Set |parentEncoder|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/open=]".
-                1. If any of the following requirements are unmet, make |this| [=invalid=] and stop.
+                1. If any of the following requirements are unmet, make
+                    |parentEncoder| [=invalid=] and stop.
 
                     <div class=validusage>
                         - |this| must be [=valid=].


### PR DESCRIPTION
- Changed incorrect assertion to a validation rule. This could be a no-op because finish() will have already failed if this is hit, but an error is chosen for consistency since other errors in the API also cascade, e.g. createTexture() into createView().
- Changed to invalidate the correct encoder when GPURenderPassEncoder.end() fails.

Followup to #2452 / #2751