### PR TITLE
Clarify "to WGSL type" use of TypeError

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2047,9 +2047,11 @@ Several parts of the WebGPU API ([=pipeline-overridable=] {{GPUProgrammableStage
 render pass clear values) take numeric values from WebIDL ({{double}} or {{float}}) and convert
 them to WGSL values (`bool`, `i32`, `u32`, `f32`, `f16`).
 
-<div algorithm>
+<div algorithm data-timeline=device>
     To convert an IDL value |idlValue| of type {{double}} or {{float}} <dfn abstract-op>to WGSL type</dfn> |T|,
     possibly throwing a {{TypeError}}:
+
+    Note: This {{TypeError}} is generated in the [=device timeline=] and never surfaced to JavaScript.
 
     1. [=Assert=] |idlValue| is a finite value, since it is not {{unrestricted double}} or {{unrestricted float}}.
 
@@ -2091,13 +2093,16 @@ them to WGSL values (`bool`, `i32`, `u32`, `f32`, `f16`).
                 1. Return <code>f16(|wgslF32|)</code>, the result of [=!=] converting the WGSL `f32` value
                     to `f16` as defined in [=WGSL floating point conversion=].
 
-                Note: An error is not thrown if the value is out-of-range for `f16` but in-range for `f32`.
+                Note: As long as the value is in-range of `f32`, no error is thrown, even if the
+                value is out-of-range of `f16`.
         </dl>
 </div>
 
-<div algorithm>
+<div algorithm data-timeline=device>
     To convert a {{GPUColor}} |color| <dfn abstract-op>to a texel value of texture format</dfn> |format|,
     possibly throwing a {{TypeError}}:
+
+    Note: This {{TypeError}} is generated in the [=device timeline=] and never surfaced to JavaScript.
 
     1. If the components of |format| ([=assert=] they all have the same type) are:
 
@@ -6832,7 +6837,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
         </div>
 </dl>
 
-<div algorithm>
+<div algorithm data-timeline=device>
     <dfn abstract-op>validating GPUProgrammableStage</dfn>(stage, descriptor, layout)
 
     **Arguments:**
@@ -7407,7 +7412,7 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
         </div>
 </dl>
 
-<div algorithm>
+<div algorithm data-timeline=device>
     <dfn abstract-op>validating GPURenderPipelineDescriptor</dfn>(descriptor, layout, device)
 
     **Arguments:**
@@ -10219,7 +10224,7 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
         is a good default, unless it is known that more draw calls will be done.
 </dl>
 
-<div class=validusage dfn-for=GPURenderPassDescriptor>
+<div class=validusage dfn-for=GPURenderPassDescriptor data-timeline=device>
     <dfn abstract-op>Valid Usage</dfn>
 
     Given a {{GPUDevice}} |device| and {{GPURenderPassDescriptor}} |this|, the following validation rules apply:
@@ -10325,7 +10330,7 @@ dictionary GPURenderPassColorAttachment {
         after executing the render pass.
 </dl>
 
-<div class=validusage dfn-for=GPURenderPassColorAttachment>
+<div class=validusage dfn-for=GPURenderPassColorAttachment data-timeline=device>
     <dfn abstract-op>GPURenderPassColorAttachment Valid Usage</dfn>
 
     Given a {{GPURenderPassColorAttachment}} |this|:


### PR DESCRIPTION
This is a JavaScript error, but it's never actually exposed to JavaScript; "to WGSL type" is only called from the device timeline. Updated all of the algorithms in the call tree so they're styled as running in the device timeline (though decided normative text wasn't needed to say that explicitly in each algorithm).