### PR TITLE
wgsl: Make builtin returned struct names consistent

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1587,7 +1587,7 @@ Note: When no conversion is performed, the conversion rank is zero.
       Note: Only [=fixed-size arrays=] may have an [=type/abstract=] component type.
   <tr algorithm="conversion rank for frexp result">
       <td>__frexp_result_abstract
-      <td>__frexp_result
+      <td>__frexp_result_f32
       <td>1
       <td>
   <tr algorithm="conversion rank for frexp result f16">
@@ -1597,7 +1597,7 @@ Note: When no conversion is performed, the conversion rank is zero.
       <td>
   <tr algorithm="conversion rank for frexp result vector">
       <td>__frexp_result_vecN_abstract
-      <td>__frexp_result_vecN
+      <td>__frexp_result_vecN_f32
       <td>1
       <td>
   <tr algorithm="conversion rank for frexp result vector f16">
@@ -1607,7 +1607,7 @@ Note: When no conversion is performed, the conversion rank is zero.
       <td>
   <tr algorithm="conversion rank for modf result">
       <td>__modf_result_abstract
-      <td>__modf_result
+      <td>__modf_result_f32
       <td>1
       <td>
   <tr algorithm="conversion rank for modf result f16">
@@ -1617,7 +1617,7 @@ Note: When no conversion is performed, the conversion rank is zero.
       <td>
   <tr algorithm="conversion rank for modf result vector">
       <td>__modf_result_vecN_abstract
-      <td>__modf_result_vecN
+      <td>__modf_result_vecN_f32
       <td>1
       <td>
   <tr algorithm="conversion rank for modf result vector f16">
@@ -12260,7 +12260,7 @@ For example, if `e` is a very small negative number, then `fract(e)` may be 1.0.
   <tr algorithm="scalar case, binary32, frexp">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn frexp(e: T) -> __frexp_result
+@const fn frexp(e: T) -> __frexp_result_f32
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12270,9 +12270,9 @@ For example, if `e` is a very small negative number, then `fract(e)` may be 1.0.
     <td>Splits `e` into a fraction and an exponent so that `e` &equals; `fraction * 2`<sup>`exponent`</sup>.
     The fraction is 0.0 or its magnitude is in the range [0.5, 1.0).
 
-    Returns the `__frexp_result` built-in structure, defined as follows:
+    Returns the `__frexp_result_f32` built-in structure, defined as follows:
     ```rust
-struct __frexp_result {
+struct __frexp_result_f32 {
   fract : f32, // fraction part
   exp : i32    // exponent part
 }
@@ -12294,7 +12294,7 @@ struct __frexp_result {
     <td>
     <td>
 
-Note: A value cannot be explicitly declared with the type `__frexp_result`,
+Note: A value cannot be explicitly declared with the type `__frexp_result_f32`,
 but a value may infer the type.
 
 </table>
@@ -12378,7 +12378,7 @@ but a value may infer the type.
   <tr algorithm="vector case, binary32, frexp">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn frexp(e: T) -> __frexp_result_vecN
+@const fn frexp(e: T) -> __frexp_result_vecN_f32
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12388,9 +12388,9 @@ but a value may infer the type.
     <td>Splits `e` into a fraction and an exponent so that `e` &equals; `fraction * 2`<sup>`exponent`</sup>.
     Each component of the fraction is 0.0, or has a magnitude in the range [0.5, 1.0).
 
-    Returns the `__frexp_result_vecN` built-in structure, defined as follows:
+    Returns the `__frexp_result_vecN_f32` built-in structure, defined as follows:
     ```rust
-struct __frexp_result_vecN {
+struct __frexp_result_vecN_f32 {
   fract : vecN<f32>, // fraction part
   exp : vecN<i32>    // exponent part
 }
@@ -12401,7 +12401,7 @@ struct __frexp_result_vecN {
     <td>
     <td>
 
-Note: A value cannot be explicitly declared with the type `__frexp_result_vecN`,
+Note: A value cannot be explicitly declared with the type `__frexp_result_vecN_f32`,
 but a value may infer the type.
 
 </table>
@@ -12420,7 +12420,7 @@ but a value may infer the type.
     <td>Splits `e` into a fraction and an exponent so that `e` &equals; `fraction * 2`<sup>`exponent`</sup>.
     Each component of the fraction is 0.0, or has a magnitude in the range [0.5, 1.0).
 
-    Returns the `__frexp_result_vecN` built-in structure, defined as if as follows:
+    Returns the `__frexp_result_vecN_f16` built-in structure, defined as if as follows:
     ```rust
 struct __frexp_result_vecN_f16 {
   fract : vecN<f16>, // fraction part
@@ -12554,10 +12554,10 @@ Note: The result is not mathematically meaningful if `e` &le; 0.
     * 1023 for AbstractFloat, when AbstractFloat is [[!IEEE-754|IEEE-754]] binary64
 
     If `x` is zero or a finite normal value for its type, then:
-  
-    <blockquote>                
+
+    <blockquote>
     x = ldexp(frexp(x).fract, frexp(x).exp)
-    </blockquote>                
+    </blockquote>
 
     [=Component-wise=] when `T` is a vector.
 
@@ -12717,7 +12717,7 @@ Note: The result is not mathematically meaningful if `e` &lt; 0.
   <tr algorithm="scalar case, binary32, modf">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn modf(e: T) -> __modf_result
+@const fn modf(e: T) -> __modf_result_f32
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12728,9 +12728,9 @@ Note: The result is not mathematically meaningful if `e` &lt; 0.
 
     The fractional part is (`e` % 1.0), and the whole part is `e` minus the whole part.
 
-    Returns the `__modf_result` built-in structure, defined as follows:
+    Returns the `__modf_result_f32` built-in structure, defined as follows:
     ```rust
-struct __modf_result {
+struct __modf_result_f32 {
   fract : f32, // fractional part
   whole : f32  // whole part
 }
@@ -12752,7 +12752,7 @@ struct __modf_result {
     <td>
     <td>
 
-Note: A value cannot be explicitly declared with the type `__modf_result`,
+Note: A value cannot be explicitly declared with the type `__modf_result_f32`,
 but a value may infer the type.
 
 </table>
@@ -12805,7 +12805,7 @@ but a value may infer the type.
 
     Returns the `__modf_result_abstract` built-in structure, defined as follows:
     ```rust
-struct __modf_result {
+struct __modf_result_abstract {
   fract : AbstractFloat, // fractional part
   whole : AbstractFloat  // whole part
 }
@@ -12827,7 +12827,7 @@ struct __modf_result {
     <td>
     <td>
 
-Note: A value cannot be explicitly declared with the type `__modf_result`,
+Note: A value cannot be explicitly declared with the type `__modf_result_abstract`,
 but a value may infer the type.
 
 </table>
@@ -12836,7 +12836,7 @@ but a value may infer the type.
   <tr algorithm="vector case, binary32, modf">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn modf(e: T) -> __modf_result_vecN
+@const fn modf(e: T) -> __modf_result_vecN_f32
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12848,9 +12848,9 @@ but a value may infer the type.
     The `i`'th component of the whole and fractional parts equal the whole and fractional parts
     of `modf(e[i])`.
 
-    Returns the `__modf_result_vecN` built-in structure, defined as follows:
+    Returns the `__modf_result_vecN_f32` built-in structure, defined as follows:
     ```rust
-struct __modf_result_vecN {
+struct __modf_result_vecN_f32 {
   fract : vecN<f32>, // fractional part
   whole : vecN<f32>  // whole part
 }
@@ -12859,7 +12859,7 @@ struct __modf_result_vecN {
     <td>
     <td>
 
-Note: A value cannot be explicitly declared with the type `__modf_result_vecN`,
+Note: A value cannot be explicitly declared with the type `__modf_result_vecN_f32`,
 but a value may infer the type.
 
 </table>
@@ -12912,7 +12912,7 @@ but a value may infer the type.
     The `i`'th component of the whole and fractional parts equal the whole and fractional parts
     of `modf(e[i])`.
 
-    Returns the `__modf_result_vecN` built-in structure, defined as follows:
+    Returns the `__modf_result_vecN_abstract` built-in structure, defined as follows:
     ```rust
 struct __modf_result_vecN_abstract {
   fract : vecN<AbstractFloat>, // fractional part


### PR DESCRIPTION
Apply a `_f32` suffix to `f32` overloads - there's no reason for `f32` to be special.

Fix a couple of typos along the way.