### PR TITLE
Describe modf in terms of trunc and subtraction

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -12771,7 +12771,7 @@ Note: The result is not mathematically meaningful if `e` &lt; 0.
     <td>Description
     <td>Splits `e` into fractional and whole number parts.
 
-    The fractional part is (`e` % 1.0), and the whole part is `e` minus the fractional part.
+    The whole part is [[#trunc-builtin|trunc]](`e`), and the fractional part is `e` - [[#trunc-builtin|trunc]](`e`).
 
     Returns the `__modf_result_f32` built-in structure, defined as follows:
     ```rust
@@ -12815,7 +12815,7 @@ but a value may infer the type.
     <td>Description
     <td>Splits `e` into fractional and whole number parts.
 
-    The fractional part is (`e` % 1.0), and the whole part is `e` minus the fractional part.
+    The whole part is [[#trunc-builtin|trunc]](`e`), and the fractional part is `e` - [[#trunc-builtin|trunc]](`e`).
 
     Returns the `__modf_result_f16` built-in structure, defined as if as follows:
     ```rust
@@ -12846,7 +12846,7 @@ but a value may infer the type.
     <td>Description
     <td>Splits `e` into fractional and whole number parts.
 
-    The fractional part is (`e` % 1.0), and the whole part is `e` minus the fractional part.
+    The whole part is [[#trunc-builtin|trunc]](`e`), and the fractional part is `e` - [[#trunc-builtin|trunc]](`e`).
 
     Returns the `__modf_result_abstract` built-in structure, defined as follows:
     ```rust


### PR DESCRIPTION
Both trunc and subtraction are "correctly rounded".

When the argument is infinity, IEEE math demands a specific result: the whole part is the same infinity, and the fractional part is zero. Treatment of infinities and NaNs is already to be addressed as part of #3230

Fixes: #3630