### PR TITLE
wgsl: sample `texture_external` with `textureSampleBaseClampToEdge`

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3731,7 +3731,7 @@ The last column in the table below uses the format-specific
 
 `texture_external` is an opaque 2d float-sampled texture type similar to `texture_2d<f32>`
 but potentially with a different representation.
-It can be read using [[#textureload|textureLoad]] or [[#texturesamplelevel|textureSampleLevel]] built-in functions,
+It can be read using [[#textureload|textureLoad]] or [[#textureSampleBaseClampToEdge|textureSampleBaseClampToEdge]] built-in functions,
 which handle these different representations opaquely.
 
 See [[WebGPU#gpu-external-texture|WebGPU &sect; GPUExternalTexture]].


### PR DESCRIPTION
As is discussed in #2766 and added into WGSL spec in #3403, `textureSampleBaseClampToEdge` instead of `textureSampleLevel` should be used when sampling from `texture_external`.