### PR TITLE
Add uniformity analysis opt-out for derivative-using builtins

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -82,6 +82,7 @@ spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
         text: pipeline input; url: pipeline-input
         text: builtin; url: builtin-variables
         text: channel formats; url: channel-formats
+        text: derivative collective operation; url: derivatives
         text: invalid memory reference; url: invalid-memory-reference
         text: shader module creation; url: shader-module-creation
         text: pipeline creation; url: pipeline-creation
@@ -92,6 +93,8 @@ spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
         text: pipeline-creation error; url: pipeline-creation-error
         text: store type; url: store-type
         text: runtime-sized; url: runtime-sized
+        text: uniformity analysis; url: uniformity-analysis
+        text: uniform control flow; url: uinform-control-flow
         text: WGSL floating point conversion; url: floating-point-conversion
         text: WGSL identifier comparison; url: identifier-comparison
         text: WGSL scalar type; url: scalar-types
@@ -6222,6 +6225,7 @@ dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
     required USVString code;
     object sourceMap;
     record<USVString, GPUShaderModuleCompilationHint> hints;
+    boolean fragmentShaderDerivativesCheckedUniformity = true;
 };
 </script>
 
@@ -6255,6 +6259,16 @@ dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
         possible once in {{GPUDevice/createShaderModule()}} rather than multiple times in
         the multiple calls to {{GPUDevice/createComputePipeline()}} /
         {{GPUDevice/createRenderPipeline()}}.
+
+    : <dfn>fragmentShaderDerivativesCheckedUniformity</dfn>
+    ::
+        When set to `false` weakens the uniformity requirement on WGSL derivative collective operations.
+
+        The implementation performs a [=uniformity analysis=] to try to prove that each
+        [=derivative collective operation=] executes in [=uniform control flow=].
+        When the option is `true`, a [=shader-creation error|shader-creation=] [=program error=] results if the analysis fails.
+        When the option is set to `false`, no error is generated.
+
 </dl>
 
 <dl dfn-type=method dfn-for=GPUDevice>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6262,10 +6262,8 @@ dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
 
     : <dfn>fragmentShaderDerivativesCheckedUniformity</dfn>
     ::
-        When set to `false` weakens the uniformity requirement on WGSL derivative collective operations.
-
         The implementation performs a [=uniformity analysis=] to try to prove that each
-        [=derivative collective operation=] executes in [=uniform control flow=].
+        WGSL builtin function that [=computes a derivative=] executes in [=uniform control flow=].
         When the option is `true`, a [=shader-creation error|shader-creation=] [=program error=] results if the analysis fails.
         When the option is set to `false`, no error is generated.
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9822,12 +9822,8 @@ Most built-in functions have tags of:
 Here is the list of exceptions:
 - All functions in [[#sync-builtin-functions]] have a [=call site tag=] of  [=CallSiteRequiredToBeUniform=].
 - All functions in
-    [[#derivative-builtin-functions]], [[#texturesample]], [[#texturesamplebias]], and [[#texturesamplecompare]]:
-    - have a [=function tag=] of [=ReturnValueMayBeNonUniform=].
-    - have a [=call site tag=] as follows:
-          - [=CallSiteNoRestriction=] if the [=option/fragmentShaderDerivativesCheckedUniformity=] option is set to `false`,
-               or if the call site has an [=attribute/unchecked_uniformity=] attribute.
-          - [=CallSiteNoRestriction=] otherwise.
+    [[#derivative-builtin-functions]], [[#texturesample]], [[#texturesamplebias]], and [[#texturesamplecompare]]
+    have a [=call site tag=] of [=CallSiteRequiredToBeUniform=], and a [=function tag=] of [=ReturnValueMayBeNonUniform=].
 - [[#arrayLength-builtin|arrayLength]] has a [=call site tag=] of
     [=CallSiteNoRestriction=], a [=function tag=] of [=NoRestriction=] and
     the input parameter `p` has a [=parameter tag=] of [=ParameterNoRestriction=]

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1118,6 +1118,8 @@ They take no parameters.
 
     | [=syntax/attr=] `'size'` [=syntax/paren_left=] [=syntax/expression=] [=syntax/attrib_end=]
 
+    | [=syntax/attr=] `'unchecked_uniformity'`
+
     | [=syntax/attr=] `'workgroup_size'` [=syntax/paren_left=] [=syntax/expression=] [=syntax/attrib_end=]
 
     | [=syntax/attr=] `'workgroup_size'` [=syntax/paren_left=] [=syntax/expression=] [=syntax/comma=] [=syntax/expression=] [=syntax/attrib_end=]
@@ -1129,11 +1131,6 @@ They take no parameters.
     | [=syntax/attr=] `'fragment'`
 
     | [=syntax/attr=] `'compute'`
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>attr_unchecked_uniformity</dfn> :
-
-    | [=syntax/attr=] `'unchecked_uniformity'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>attrib_end</dfn> :
@@ -6614,7 +6611,7 @@ When an identifier is used as a [=syntax/callable=] item, it is one of:
 
     | [=syntax/ident=]
 
-    | [=syntax/attr_unchecked_uniformity=] ? [=syntax/callable=] [=syntax/argument_expression_list=]
+    | [=syntax/attribute=] ? [=syntax/callable=] [=syntax/argument_expression_list=]
 
     | [=syntax/literal=]
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7730,12 +7730,15 @@ the fragment will be thrown away.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>func_call_statement</dfn> :
 
-    | [=syntax/ident=] [=syntax/argument_expression_list=]
+    | [=syntax/attribute=] ? [=syntax/ident=] [=syntax/argument_expression_list=]
 </div>
 
 A function call statement executes a [=function call=].
 
 Note: If the function [=return value|returns a value=], that value is ignored.
+
+Note: The only attribute that can be applied is the [=attribute/unchecked_uniformity=] attriute,
+and only when calling a builtin function that computes [[#derivatives|derivatives]].
 
 ## Static Assertion Statement ## {#static-assert-statement}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -440,6 +440,13 @@ results in a shader-creation, pipeline-creation, or dynamic error.
 
 The WebGPU specification describes the consequences of each kind of error.
 
+Some requirements can be weakened by setting a <dfn noexport>processing option</dfn> in
+the [[WebGPU#dictdef-gpushadermoduledescriptor|WebGPU GPUShaderModuleDescriptor]] object
+given to the [[WebGPU#dom-gpudevice-createshadermodule|WebGPU createShaderModule]] method.
+The processing options are:
+* <dfn dfn-for="option">fragmentShaderDerivativesCheckedUniformity</dfn>: a boolean option, defaulting to `true`.
+     See [=uniformity analysis=].
+
 # Textual Structure # {#textual-structure}
 
 A WGSL program is Unicode text using the UTF-8 encoding, with no byte order mark (BOM).
@@ -1027,6 +1034,18 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
 
     See [[#memory-layouts]]
 
+  <tr><td><dfn noexport dfn-for="attribute">`unchecked_uniformity`</dfn>
+    <td>
+    <td>Applies to a [=call site=] for
+        [[#derivative-builtin-functions|derivative builtin functions]],
+        [[#texturesample|textureSample]],
+        [[#texturesamplebias|textureSampleBias]], or
+        [[#texturesamplecompare|textureSampleCompare]].
+
+        Eliminates the requirement that the call to the builtin function be executed in [=uniform control flow=].
+
+        See [[#uniformity]]
+
   <tr><td><dfn noexport dfn-for="attribute">`workgroup_size`</dfn>
     <td>One, two or three parameters.
 
@@ -1109,6 +1128,11 @@ They take no parameters.
     | [=syntax/attr=] `'fragment'`
 
     | [=syntax/attr=] `'compute'`
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>attr_unchecked_uniformity</dfn> :
+
+    | [=syntax/attr=] `'unchecked_uniformity'`
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>attrib_end</dfn> :
@@ -6589,7 +6613,7 @@ When an identifier is used as a [=syntax/callable=] item, it is one of:
 
     | [=syntax/ident=]
 
-    | [=syntax/callable=] [=syntax/argument_expression_list=]
+    | [=syntax/attr_unchecked_uniformity=] ? [=syntax/callable=] [=syntax/argument_expression_list=]
 
     | [=syntax/literal=]
 
@@ -9193,16 +9217,25 @@ See [[#statements]] and [[#function-calls]].
 
 ## Uniformity ## {#uniformity}
 
-[[#collective-operations|Collective operations]] (e.g. barriers and
-derivatives) require coordination among different invocations running
-concurrently on the GPU.  To ensure correct and portable behavior, WGSL
-requires that these operations can be statically analyzed to not have any
-control dependencies such that a non-empty strict subset of invocations will
-execute the operation (i.e. the operation must be executed in [=uniform control
-flow=]).
+A [[#collective-operations|collective operation]]
+(e.g. barrier, derivative, or a texture operation relying on an implicitly computed derivative)
+requires coordination among different invocations running concurrently on the GPU.
+The operation executes correctly and portably
+when all invocations execute it concurrently, i.e. in [=uniform control flow=].
+
+Conversely, incorrect or non-portable behavior occurs when a strict subset of invocations
+execute the operation, i.e. in non-uniform control flow.
+Informally, some invocations reach the collective operation, but others do not,
+or not at the same time, as a result of non-uniform control dependencies.
 Non-uniform control dependencies arise from [[#control-flow|control flow]]
 statements whose behavior depends on [=uniform value|non-uniform values=].
-These non-uniform values can be traced back to certain sources that are not
+
+> For example, a non-uniform control dependency arises when different invocations compute
+    different values for the condition of an
+    [=statement/if=], [=statement/break-if=], [=statement/while=], or [=statement/for=],
+    or different values for the selector of a [=statement/switch=].
+
+These non-uniform values can often be traced back to certain sources that are not
 statically proven to be uniform.
 These sources include, but are not limited to:
 * Mutable [=module scope|module-scope=] [=variables=]
@@ -9210,9 +9243,16 @@ These sources include, but are not limited to:
 * [=user-defined input datum|User-defined inputs=]
 * Certain [=built-in functions=] (see [[#uniformity-function-calls]])
 
-The remainder of this section is devoted to a description of this static
-analysis an implementation [=behavioral requirement|will=] perform to validate
-the WGSL program.
+To ensure correct and portable behavior, a WGSL implementation [=behavioral requirement|will=]
+perform a static <dfn>uniformity analysis</dfn>, attempting to prove that each collective operation
+executes in [=uniform control flow=].
+Subsequent subsections describe the analysis.
+
+If [=uniformity analysis=] cannot prove that a particular [[#collective-operations|collective operation]] executes in [=uniform control flow=], then:
+* If the operation is a [[#barrier|barrier]], a [=shader-creation error=] results.
+* Otherwise, a [=shader-creation error=] results if:
+    * The [=option/fragmentShaderDerivativesCheckedUniformity=] option is *not* set to `false`, **and**
+    * The operation does *not* have an [=attribute/unchecked_uniformity=] attribute.
 
 ### Terminology and Concepts ### {#uniformity-concepts}
 
@@ -9751,7 +9791,12 @@ being the same as input control flow node.
 The most complex rule is for function calls:
 - For each argument, apply the corresponding expression rule, with the control flow at the exit of the previous argument (using the control flow at the beginning of the function call for the first argument). Name the corresponding value nodes "arg_i" and the corresponding control flow nodes "CF_i"
 - Create two new nodes, named "Result" and "CF_after"
-- If the [=call site tag=] of the function is [=CallSiteRequiredToBeUniform=], then add an edge from RequiredToBeUniform to the last CF_i
+- Add an edge from RequiredToBeUniform to the last CF_i if:
+    - The [=call site tag=] of the function is [=CallSiteRequiredToBeUniform=], and
+    - The [=call site=] does not have an [=attribute/unchecked_uniformity=] attribute, and
+    - Either:
+        - The called function is a not a [[#derivatives|derivative collective operation]], or
+        - The called function is a [[#derivatives|derivative collective operation]] and the [=option/fragmentShaderDerivativesCheckedUniformity=] option is *not* `false`.
 - Otherwise add an edge from CF_after to the last CF_i
 - If the [=function tag=] is [=ReturnValueMayBeNonUniform=], then add an edge from Result to MayBeNonUniform
 - Add an edge from Result to CF_after
@@ -9770,7 +9815,13 @@ Most built-in functions have tags of:
 
 Here is the list of exceptions:
 - All functions in [[#sync-builtin-functions]] have a [=call site tag=] of  [=CallSiteRequiredToBeUniform=].
-- All functions in [[#derivative-builtin-functions]], [[#texturesample]], [[#texturesamplebias]], and [[#texturesamplecompare]] have a [=call site tag=] of [=CallSiteRequiredToBeUniform=] and a [=function tag=] of [=ReturnValueMayBeNonUniform=].
+- All functions in
+    [[#derivative-builtin-functions]], [[#texturesample]], [[#texturesamplebias]], and [[#texturesamplecompare]]:
+    - have a [=function tag=] of [=ReturnValueMayBeNonUniform=].
+    - have a [=call site tag=] as follows:
+          - [=CallSiteNoRestriction=] if the [=option/fragmentShaderDerivativesCheckedUniformity=] option is set to `false`,
+               or if the call site has an [=attribute/unchecked_uniformity=] attribute.
+          - [=CallSiteNoRestriction=] otherwise.
 - [[#arrayLength-builtin|arrayLength]] has a [=call site tag=] of
     [=CallSiteNoRestriction=], a [=function tag=] of [=NoRestriction=] and
     the input parameter `p` has a [=parameter tag=] of [=ParameterNoRestriction=]
@@ -10312,8 +10363,13 @@ built-in functions described in [[#derivative-builtin-functions]]:
 * `fwidth`, `fwidthCoarse`, and `fwidthFine` compute the Manhattan metric over the associated x and y partial derivatives.
 
 Because neighbouring invocations collaborate to compute derivatives, these
-functions [=shader-creation error|must=] only be invoked in [=uniform control
-flow=] in a fragment shader.
+functions should only be invoked in [=uniform control flow=] in a fragment shader.
+For each call to one of these functions, a [=shader-creation error=] results if:
+* [[#uniformity|uniformity analysis]] cannot prove the call occurs in uniform control flow, and
+* the [=option/fragmentShaderDerivativesCheckedUniformity=] option is *not* set to `false`, and
+* the [=call site=] does *not* have an [=attribute/unchecked_uniformity=] attribute.
+
+If one of these functions is called in non-uniform control flow, then the result is an [=indeterminate value=].
 
 ## Floating Point Evaluation ## {#floating-point-evaluation}
 
@@ -13407,7 +13463,9 @@ See [[#derivatives]].
 
 These functions:
 * [=shader-creation error|Must=] only be used in a [=fragment=] shader stage.
-* [=shader-creation error|Must=] only be invoked in [=uniform control flow=].
+* [=shader-creation error|Must=] only be invoked in [=uniform control flow=],
+    or the call must have an [=attribute/unchecked_uniformity=] attribute,
+    or the [=option/fragmentShaderDerivativesCheckedUniformity=] option must be `false`.
 
 ### `dpdx` ### {#dpdx-builtin}
 <table class='data builtin'>
@@ -13423,6 +13481,8 @@ fn dpdx(e: T) -> T
     <td>Description
     <td>Partial derivative of `e` with respect to window x coordinates.
     The result is the same as either `dpdxFine(e)` or `dpdxCoarse(e)`.
+
+    Returns an [=indeterminate value=] if called in [=uniform control flow|non-uniform control flow=].
 </table>
 
 ### `dpdxCoarse` ### {#dpdxCoarse-builtin}
@@ -13439,6 +13499,8 @@ fn dpdxCoarse(e: T) -> T
     <td>Description
     <td>Returns the partial derivative of `e` with respect to window x coordinates using local differences.
     This may result in fewer unique positions that `dpdxFine(e)`.
+
+    Returns an [=indeterminate value=] if called in [=uniform control flow|non-uniform control flow=].
 </table>
 
 ### `dpdxFine` ### {#dpdxFine-builtin}
@@ -13454,6 +13516,8 @@ fn dpdxFine(e: T) -> T
   <tr>
     <td>Description
     <td>Returns the partial derivative of `e` with respect to window x coordinates.
+
+    Returns an [=indeterminate value=] if called in [=uniform control flow|non-uniform control flow=].
 </table>
 
 ### `dpdy` ### {#dpdy-builtin}
@@ -13470,6 +13534,8 @@ fn dpdy(e: T) -> T
     <td>Description
     <td>Partial derivative of `e` with respect to window y coordinates.
     The result is the same as either `dpdyFine(e)` or `dpdyCoarse(e)`.
+
+    Returns an [=indeterminate value=] if called in [=uniform control flow|non-uniform control flow=].
 </table>
 
 ### `dpdyCoarse` ### {#dpdyCoarse-builtin}
@@ -13486,6 +13552,8 @@ fn dpdyCoarse(e: T) -> T
     <td>Description
     <td>Returns the partial derivative of `e` with respect to window y coordinates using local differences.
     This may result in fewer unique positions that `dpdyFine(e)`.
+
+    Returns an [=indeterminate value=] if called in [=uniform control flow|non-uniform control flow=].
 </table>
 
 ### `dpdyFine` ### {#dpdyFine-builtin}
@@ -13501,6 +13569,8 @@ fn dpdyFine(e: T) -> T
   <tr>
     <td>Description
     <td>Returns the partial derivative of `e` with respect to window y coordinates.
+
+    Returns an [=indeterminate value=] if called in [=uniform control flow|non-uniform control flow=].
 </table>
 
 ### `fwidth` ### {#fwidth-builtin}
@@ -13516,6 +13586,8 @@ fn fwidth(e: T) -> T
   <tr>
     <td>Description
     <td>Returns `abs(dpdx(e)) + abs(dpdy(e))`.
+
+    Returns an [=indeterminate value=] if called in [=uniform control flow|non-uniform control flow=].
 </table>
 
 ### `fwidthCoarse` ### {#fwidthCoarse-builtin}
@@ -13531,6 +13603,8 @@ fn fwidthCoarse(e: T) -> T
   <tr>
     <td>Description
     <td>Returns `abs(dpdxCoarse(e)) + abs(dpdyCoarse(e))`.
+
+    Returns an [=indeterminate value=] if called in [=uniform control flow|non-uniform control flow=].
 </table>
 
 ### `fwidthFine` ### {#fwidthFine-builtin}
@@ -13546,6 +13620,8 @@ fn fwidthFine(e: T) -> T
   <tr>
     <td>Description
     <td>Returns `abs(dpdxFine(e)) + abs(dpdyFine(e))`.
+
+    Returns an [=indeterminate value=] if called in [=uniform control flow|non-uniform control flow=].
 </table>
 
 ## Texture Built-in Functions ## {#texture-builtin-functions}
@@ -14175,7 +14251,10 @@ The number of samples per texel in the multisampled texture.
 Samples a texture.
 
 [=shader-creation error|Must=] only be used in a [=fragment=] shader stage.
-[=shader-creation error|Must=] only be invoked in [=uniform control flow=].
+
+[=shader-creation error|Must=] only be invoked in [=uniform control flow=],
+    or the call must have an [=attribute/unchecked_uniformity=] attribute,
+    or the [=option/fragmentShaderDerivativesCheckedUniformity=] option must be `false`.
 
 <table class='data'>
   <thead>
@@ -14317,12 +14396,17 @@ fn textureSample(t: texture_depth_cube_array,
 
 The sampled value.
 
+An [=indeterminate value=] results if called in [=uniform control flow|non-uniform control flow=].
+
 ### `textureSampleBias` ### {#texturesamplebias}
 
 Samples a texture with a bias to the mip level.
 
 [=shader-creation error|Must=] only be used in a [=fragment=] shader stage.
-[=shader-creation error|Must=] only be invoked in [=uniform control flow=].
+
+[=shader-creation error|Must=] only be invoked in [=uniform control flow=],
+    or the call must have an [=attribute/unchecked_uniformity=] attribute,
+    or the [=option/fragmentShaderDerivativesCheckedUniformity=] option must be `false`.
 
 <table class='data'>
   <thead>
@@ -14419,13 +14503,17 @@ fn textureSampleBias(t: texture_cube_array<f32>,
 
 The sampled value.
 
+An [=indeterminate value=] results if called in [=uniform control flow|non-uniform control flow=].
 
 ### `textureSampleCompare` ### {#texturesamplecompare}
 
 Samples a depth texture and compares the sampled depth values against a reference value.
 
 [=shader-creation error|Must=] only be used in a [=fragment=] shader stage.
-[=shader-creation error|Must=] only be invoked in [=uniform control flow=].
+
+[=shader-creation error|Must=] only be invoked in [=uniform control flow=],
+    or the call must have an [=attribute/unchecked_uniformity=] attribute,
+    or the [=option/fragmentShaderDerivativesCheckedUniformity=] option must be `false`.
 
 <table class='data'>
   <thead>
@@ -14520,6 +14608,7 @@ If the sampler uses bilinear filtering then the returned value is
 the filtered average of these values, otherwise the comparison result of a
 single texel is returned.
 
+An [=indeterminate value=] results if called in [=uniform control flow|non-uniform control flow=].
 
 ### `textureSampleCompareLevel` ### {#texturesamplecomparelevel}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1036,7 +1036,9 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
 
   <tr><td><dfn noexport dfn-for="attribute">`unchecked_uniformity`</dfn>
     <td>
-    <td>Applies to a [=call site=] for a builtin function that compute derivatives, i.e. any of:
+    <td>Applies to a [=call site=] for a
+        [=builtin functions that compute a derivative|builtin function that computes a derivative=],
+        i.e. any of:
 
         * the [[#derivative-builtin-functions|derivative builtin functions]], or
         * [[#texturesample|textureSample]], or
@@ -7738,7 +7740,8 @@ A function call statement executes a [=function call=].
 Note: If the function [=return value|returns a value=], that value is ignored.
 
 Note: The only attribute that can be applied is the [=attribute/unchecked_uniformity=] attriute,
-and only when calling a builtin function that computes [[#derivatives|derivatives]].
+and only when calling a
+[=builtin functions that compute a derivative|builtin function that computes a derivative=].
 
 ## Static Assertion Statement ## {#static-assert-statement}
 
@@ -10348,6 +10351,12 @@ A <dfn noexport>partial derivative</dfn> is the rate of change of a value along 
 Fragment shader invocations within the same [=quad=] collaborate to compute
 approximate partial derivatives.
 
+The <dfn noexport>builtin functions that compute a derivative</dfn> are:
+* [[#texturesample|textureSample]], [[#texturesamplebias|textureSampleBias]], and [[#texturesamplecompare|textureSampleCompare]]
+* [[#dpdx-builtin|dpdx]], [[#dpdxCoarse-builtin|dpdxCoarse]], and [[#dpdxFine-builtin|dpdxFine]]
+* [[#dpdy-builtin|dpdy]], [[#dpdyCoarse-builtin|dpdyCoarse]], and [[#dpdyFine-builtin|dpdyFine]]
+* [[#fwidth-builtin|fwidth]], [[#fwidthCoarse-builtin|fwidthCoarse]], and [[#fwidthFine-builtin|fwidthFine]]
+
 Partial derivatives of the *fragment coordinate* are computed implicitly as part
 of operation of the following built-in functions:
 * [[#texturesample|textureSample]],
@@ -10359,9 +10368,10 @@ For these, the derivatives help determine the mip levels of texels to be sampled
 
 Partial derivatives of *invocation-specified* values are computed by the
 built-in functions described in [[#derivative-builtin-functions]]:
-* `dpdx`, `dpdxCoarse`, and `dpdxFine` compute partial derivatives along the x axis.
-* `dpdy`, `dpdyCoarse`, and `dpdyFine` compute partial derivatives along the y axis.
-* `fwidth`, `fwidthCoarse`, and `fwidthFine` compute the Manhattan metric over the associated x and y partial derivatives.
+* [[#dpdx-builtin|dpdx]], [[#dpdxCoarse-builtin|dpdxCoarse]], and [[#dpdxFine-builtin|dpdxFine]] compute partial derivatives along the x axis.
+* [[#dpdy-builtin|dpdy]], [[#dpdyCoarse-builtin|dpdyCoarse]], and [[#dpdyFine-builtin|dpdyFine]] compute partial derivatives along the y axis.
+* [[#fwidth-builtin|fwidth]], [[#fwidthCoarse-builtin|fwidthCoarse]], and [[#fwidthFine-builtin|fwidthFine]]
+    compute the Manhattan metric over the associated x and y partial derivatives.
 
 Because neighbouring invocations collaborate to compute derivatives, these
 functions should only be invoked in [=uniform control flow=] in a fragment shader.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1036,11 +1036,12 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
 
   <tr><td><dfn noexport dfn-for="attribute">`unchecked_uniformity`</dfn>
     <td>
-    <td>Applies to a [=call site=] for
-        [[#derivative-builtin-functions|derivative builtin functions]],
-        [[#texturesample|textureSample]],
-        [[#texturesamplebias|textureSampleBias]], or
-        [[#texturesamplecompare|textureSampleCompare]].
+    <td>Applies to a [=call site=] for a builtin function that compute derivatives, i.e. any of:
+
+        * the [[#derivative-builtin-functions|derivative builtin functions]], or
+        * [[#texturesample|textureSample]], or
+        * [[#texturesamplebias|textureSampleBias]], or
+        * [[#texturesamplecompare|textureSampleCompare]].
 
         Eliminates the requirement that the call to the builtin function be executed in [=uniform control flow=].
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9253,10 +9253,12 @@ executes in [=uniform control flow=].
 Subsequent subsections describe the analysis.
 
 If [=uniformity analysis=] cannot prove that a particular [[#collective-operations|collective operation]] executes in [=uniform control flow=], then:
-* If the operation is a [[#barrier|barrier]], a [=shader-creation error=] results.
-* Otherwise, a [=shader-creation error=] results if:
-    * The [=option/fragmentShaderDerivativesCheckedUniformity=] option is *not* set to `false`, **and**
-    * The operation does *not* have an [=attribute/unchecked_uniformity=] attribute.
+* If the operation is a
+    [=builtin functions that compute a derivative|builtin function that computes a derivative=]:
+    * A [=shader-creation error=] results if:
+        * The [=option/fragmentShaderDerivativesCheckedUniformity=] option is *not* set to `false`, and
+        * The operation does *not* have an [=attribute/unchecked_uniformity=] attribute.
+* If the operation is a [[#sync-builtin-functions|synchronization builtin]], a [=shader-creation error=] results.
 
 ### Terminology and Concepts ### {#uniformity-concepts}
 

--- a/wgsl/wgsl.recursive.bs.include
+++ b/wgsl/wgsl.recursive.bs.include
@@ -59,6 +59,8 @@
 
  | [=syntax/attr=] `'size'` [=syntax/paren_left=] [=recursive descent syntax/expression=] [=syntax/comma=] ? [=syntax/paren_right=]
 
+ | [=syntax/attr=] `'unchecked_uniformity'`
+
  | [=syntax/attr=] `'vertex'`
 
  | [=syntax/attr=] `'workgroup_size'` [=syntax/paren_left=] [=recursive descent syntax/expression=] [=syntax/comma=] ? [=syntax/paren_right=]
@@ -407,7 +409,7 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>primary_expression</dfn>:
 
- | ( [=syntax/attr=] `'unchecked_uniformity'` )? [=recursive descent syntax/callable=] [=syntax/paren_left=] ( [=recursive descent syntax/expression=] ( [=syntax/comma=] [=recursive descent syntax/expression=] )* [=syntax/comma=] ? )? [=syntax/paren_right=]
+ | [=recursive descent syntax/attribute=] ? [=recursive descent syntax/callable=] [=syntax/paren_left=] ( [=recursive descent syntax/expression=] ( [=syntax/comma=] [=recursive descent syntax/expression=] )* [=syntax/comma=] ? )? [=syntax/paren_right=]
 
  | [=recursive descent syntax/ident=]
 

--- a/wgsl/wgsl.recursive.bs.include
+++ b/wgsl/wgsl.recursive.bs.include
@@ -253,7 +253,7 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>for_init</dfn>:
 
- | [=recursive descent syntax/ident=] [=recursive descent syntax/func_call_statement.post.ident=]
+ | [=recursive descent syntax/attribute=] ? [=recursive descent syntax/ident=] [=syntax/paren_left=] ( [=recursive descent syntax/expression=] ( [=syntax/comma=] [=recursive descent syntax/expression=] )* [=syntax/comma=] ? )? [=syntax/paren_right=]
 
  | [=recursive descent syntax/variable_statement=]
 
@@ -263,15 +263,9 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>for_update</dfn>:
 
- | [=recursive descent syntax/ident=] [=recursive descent syntax/func_call_statement.post.ident=]
+ | [=recursive descent syntax/attribute=] ? [=recursive descent syntax/ident=] [=syntax/paren_left=] ( [=recursive descent syntax/expression=] ( [=syntax/comma=] [=recursive descent syntax/expression=] )* [=syntax/comma=] ? )? [=syntax/paren_right=]
 
  | [=recursive descent syntax/variable_updating_statement=]
-</div>
-
-<div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>func_call_statement.post.ident</dfn>:
-
- | [=syntax/paren_left=] ( [=recursive descent syntax/expression=] ( [=syntax/comma=] [=recursive descent syntax/expression=] )* [=syntax/comma=] ? )? [=syntax/paren_right=]
 </div>
 
 <div class='syntax' noexport='true'>
@@ -475,9 +469,9 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>statement</dfn>:
 
- | [=recursive descent syntax/compound_statement=]
+ | [=recursive descent syntax/attribute=] ? [=recursive descent syntax/ident=] [=syntax/paren_left=] ( [=recursive descent syntax/expression=] ( [=syntax/comma=] [=recursive descent syntax/expression=] )* [=syntax/comma=] ? )? [=syntax/paren_right=] [=syntax/semicolon=]
 
- | [=recursive descent syntax/ident=] [=syntax/paren_left=] ( [=recursive descent syntax/expression=] ( [=syntax/comma=] [=recursive descent syntax/expression=] )* [=syntax/comma=] ? )? [=syntax/paren_right=] [=syntax/semicolon=]
+ | [=recursive descent syntax/compound_statement=]
 
  | [=recursive descent syntax/variable_statement=] [=syntax/semicolon=]
 

--- a/wgsl/wgsl.recursive.bs.include
+++ b/wgsl/wgsl.recursive.bs.include
@@ -407,7 +407,7 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>primary_expression</dfn>:
 
- | [=recursive descent syntax/callable=] [=syntax/paren_left=] ( [=recursive descent syntax/expression=] ( [=syntax/comma=] [=recursive descent syntax/expression=] )* [=syntax/comma=] ? )? [=syntax/paren_right=]
+ | ( [=syntax/attr=] `'unchecked_uniformity'` )? [=recursive descent syntax/callable=] [=syntax/paren_left=] ( [=recursive descent syntax/expression=] ( [=syntax/comma=] [=recursive descent syntax/expression=] )* [=syntax/comma=] ? )? [=syntax/paren_right=]
 
  | [=recursive descent syntax/ident=]
 


### PR DESCRIPTION
1. Localized opt-out:

Add unchecked_uniformity attribute

It's a fine-grain control that disables uniformity errors for fragment shader builtins that ordinarily are required to execute in uniform control flow.

Updates those functions to say they yield an indeterminate value when invoked in non-uniform control flow.

2. Coarse-grain opt out: Add 'fragmentShaderDerivativesCheckedUniformity' boolean field defaulting `true`, in GPUShaderModuleDescriptor

When false, weakens the uniformity analysis so no uniformity error is generated for derivative-based collective operations.

Fixed: #3554