### PR TITLE
Reduce query set count limit to 4096

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -12018,7 +12018,7 @@ dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
 
                     <div class=validusage>
                         - |this| is [=valid=].
-                        - |descriptor|.{{GPUQuerySetDescriptor/count}} must be &le; 8192.
+                        - |descriptor|.{{GPUQuerySetDescriptor/count}} must be &le; 4096.
                     </div>
 
                 1. Set |q|.{{GPUQuerySet/[[state]]}} to [=query set state/available=].


### PR DESCRIPTION
This is a hardcoded limit, we could also consider adding an adapter/device limit for it.

Fixes #3648