### PR TITLE
Check user IO equality only if the fragment stage is present.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7433,18 +7433,17 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
         - [$validating GPUFragmentState$](|device|, |descriptor|.{{GPURenderPipelineDescriptor/fragment}}) succeeds.
         - If the "sample_mask" [=builtin=] is a [=pipeline output=] of |descriptor|.{{GPURenderPipelineDescriptor/fragment}}:
             - |descriptor|.{{GPURenderPipelineDescriptor/multisample}}.{{GPUMultisampleState/alphaToCoverageEnabled}} is `false`.
+        - For each user-defined input of |descriptor|.{{GPURenderPipelineDescriptor/fragment}} there
+            must be a user-defined output of |descriptor|.{{GPURenderPipelineDescriptor/vertex}} that
+            [=location=], type, and [=interpolation=] of the input.
+
+            Note: This means that vertex-only pipelines can have user-defined outputs in the vertex stage:
+            they will be discarded.
+
     - [$validating GPUPrimitiveState$](|descriptor|.{{GPURenderPipelineDescriptor/primitive}}, |device|) succeeds.
     - If |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}} is not `null`:
         - [$validating GPUDepthStencilState$](|descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}) succeeds.
     - [$validating GPUMultisampleState$](|descriptor|.{{GPURenderPipelineDescriptor/multisample}}) succeeds.
-    - For each user-defined input of
-        |descriptor|.{{GPURenderPipelineDescriptor/fragment}} there
-        must be a user-defined output of
-        |descriptor|.{{GPURenderPipelineDescriptor/vertex}} that
-        [=location=],
-        type, and
-        [=interpolation=]
-        of the input.
     - [$validating inter-stage interfaces$](|device|, |descriptor|) returns `true`.
 </div>
 


### PR DESCRIPTION
Also add a note to clarify that the corner case for vertex-only pipelines has been thought of.

Note that there are still compulsory usage of the fragment stage when validating inter stage variables. Maybe this validation should be split in two?