### PR TITLE
begin pass: only generate error on incorrect state

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8906,7 +8906,7 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                 [=Device timeline=] |initialization steps|:
 
                 1. [$Validate the encoder state$] of |this|.
-                    If it returns false, also make |pass| [=invalid=] and return.
+                    If it returns false, make |pass| [=invalid=] and return.
                 1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/locked=]".
                 1. If any of the following requirements are unmet, make |pass| [=invalid=] and return.
                     <div class=validusage>
@@ -8973,7 +8973,7 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                 [=Device timeline=] |initialization steps|:
 
                 1. [$Validate the encoder state$] of |this|.
-                    If it returns false, also make |pass| [=invalid=] and return.
+                    If it returns false, make |pass| [=invalid=] and return.
                 1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/locked=]".
                 1. If any of the following requirements are unmet, make |pass| [=invalid=] and return.
                     <div class=validusage>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8905,19 +8905,17 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
             <div data-timeline=device>
                 [=Device timeline=] |initialization steps|:
 
-                1. If any of the following requirements are unmet,
-                    [$generate a validation error$], make |pass| [=invalid=], and stop.
-
+                1. [$Validate the encoder state$] of |this|.
+                    If it returns false, also make |pass| [=invalid=] and return.
+                1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/locked=]".
+                1. If any of the following requirements are unmet, make |pass| [=invalid=] and return.
                     <div class=validusage>
-                        - |this|.{{GPUCommandsMixin/[[state]]}} must be "[=encoder state/open=]".
                         - |descriptor| must meet the [$GPURenderPassDescriptor/Valid Usage$] rules.
                         - If |descriptor|.{{GPURenderPassDescriptor/timestampWrites}} is not [=list/is empty|empty=]:
                             - {{GPUFeatureName/"timestamp-query"}} must be [=enabled for=] |this|.
                         - For each |timestampWrite| in |descriptor|.{{GPURenderPassDescriptor/timestampWrites}}:
                             - |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}} must be [$valid to use with$] |this|.
                     </div>
-
-                1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/locked=]".
                 1. For each non-`null` |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
                     1. The [=texture subresource=] seen by |colorAttachment|.{{GPURenderPassColorAttachment/view}}
                         is considered to be used as [=internal usage/attachment=] for the
@@ -8974,18 +8972,16 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
             <div data-timeline=device>
                 [=Device timeline=] |initialization steps|:
 
-                1. If any of the following requirements are unmet,
-                    [$generate a validation error$], make |pass| [=invalid=], and stop.
-
+                1. [$Validate the encoder state$] of |this|.
+                    If it returns false, also make |pass| [=invalid=] and return.
+                1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/locked=]".
+                1. If any of the following requirements are unmet, make |pass| [=invalid=] and return.
                     <div class=validusage>
-                        - |this|.{{GPUCommandsMixin/[[state]]}} must be "[=encoder state/open=]".
                         - If |descriptor|.{{GPURenderPassDescriptor/timestampWrites}} is not [=list/is empty|empty=]:
                             - {{GPUFeatureName/"timestamp-query"}} must be [=enabled for=] |this|.
                         - For each |timestampWrite| in |descriptor|.{{GPUComputePassDescriptor/timestampWrites}}:
                             - |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}} must be [$valid to use with$] |this|.
                     </div>
-                1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/locked=]".
-
                 1. For each |timestampWrite| in |descriptor|.{{GPUComputePassDescriptor/timestampWrites}},
                     1. If |timestampWrite|.{{GPUComputePassTimestampWrite/location}} is {{GPUComputePassTimestampLocation/"beginning"}},
                         [=list/append=] a [=GPU command=] to


### PR DESCRIPTION
Fixes #3663 

This fixes what I think was a semi-unintentional change of createRenderPass/createComputePass validation failures, from invalidating the parent encoder, to generating validation errors.