### PR TITLE
text/wgsl media type registration is a normative part of the WGSL spec.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -103,9 +103,23 @@ object[type="image/svg+xml"] {
       "Kai Ninomiya",
       "Brandon Jones"
     ],
-    "href": "https://gpuweb.github.io/gpuweb/",
+    "href": "https://w3.org/TR/webgpu",
     "title": "WebGPU",
-    "status": "Editor's Draft",
+    "status": "Working Draft",
+    "publisher": "W3C",
+    "deliveredBy": [
+      "https://github.com/gpuweb/gpuweb"
+    ]
+  },
+  "WGSL": {
+    "authors": [
+      "Alan Baker",
+      "Mehmet Oguz Derin",
+      "David Neto"
+    ],
+    "href": "https://www.w3.org/TR/WGSL/",
+    "title": "WebGPU Shading Language",
+    "status": "Working Draft",
     "publisher": "W3C",
     "deliveredBy": [
       "https://github.com/gpuweb/gpuweb"
@@ -441,6 +455,9 @@ results in a shader-creation, pipeline-creation, or dynamic error.
 The WebGPU specification describes the consequences of each kind of error.
 
 # Textual Structure # {#textual-structure}
+
+The `text/wgsl` media type is used to identify content as a WGSL program.
+See [[#text-wgsl-media-type]].
 
 A WGSL program is Unicode text using the UTF-8 encoding, with no byte order mark (BOM).
 
@@ -15556,3 +15573,61 @@ Use token definitions from the main part of the specification.
 <pre class=include>
 path: wgsl.recursive.bs.include
 </pre>
+
+# Appendix A: The `text/wgsl` media type # {#text-wgsl-media-type}
+
+The Internet Assigned Numbers Authority (IANA) maintains a registry of media types, at
+<a href="https://www.iana.org/assignments/media-types/media-types.xhtml">https://www.iana.org/assignments/media-types/media-types.xhtml</a>
+
+The following is the proposed registration for the `text/wgsl` media type for WGSL programs.
+It is published for community review, and is intended to be submitted to the
+Internet Engineering Steering Group (IESG) for review, approval, and registration with the IANA.
+
+: Type name
+:: text
+: Subtype name
+:: wgsl
+: Required parameters
+:: N/A
+: Optional parameters
+:: None
+: Encoding considerations
+::  binary
+::  WGSL is Unicode text using the UTF-8 encoding, with no byte order mark (BOM).
+    See [[!WGSL]] Section 3. Textual Structure.
+: Security considerations:
+:: WebGPU Shading Language (WGSL) is a programming language for GPU
+    code to be executed in the context of the WebGPU API. For security
+    considerations, see [[!WebGPU]] Section 2.1 Security Considerations.
+: Interoperability considerations:
+:: Implementations of WebGPU may have different capabilities, and
+    these differences may affect what features may be exercised by
+    WGSL programs. See [[!WebGPU]] Section 3.6 Optional capabilities,
+    and [[!WGSL]] Section 11. Language Extensions.
+
+    It is expected that implementations will behave as if this
+    registration applies to later editions of WGSL, and its published
+    specification references may be updated accordingly from time to
+    time.  Although this expectation is unusual among media type
+    registrations, it matches widespread industry conventions.
+: Published specification:
+:: [[!WGSL]]
+: Applications that use this media type:
+::  Implementations of WebGPU. This is expected to include web browsers.
+: Fragment identifier considerations
+:: None
+: Additional information:
+:: Magic number(s): None
+:: File extension(s): `.wgsl`
+:: Macintosh file type code(s): `TEXT`
+: Person & email address to contact for further information:
+:: David Neto, dneto@google.com, or the Editors listed in WGSL.
+: Intended usage
+:: COMMON
+: Author
+:: W3C. See the Editors listed in WGSL.
+: Change controller
+:: W3C
+: Normative References
+:: [[!WebGPU]] W3C, "WebGPU” W3C Working Draft, December 2022.  https://w3.org/TR/webgpu
+:: [[!WGSL]] W3C, “WebGPU Shading Language” W3C Working Draft, December 2022.  https://w3.org/TR/WGSL


### PR DESCRIPTION
Follow W3C recommended procedure and incorporate the text/wgsl media type registration information as a normative part of the WGSL spec.

Also, update the WebGPU and WGSL links to point to the w3.org working drafts.

Contributes to #1682