### PR TITLE
Allow bgra8unorm in pipeline layout be compatible with rgba8unorm in …

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -7011,6 +7011,9 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
                 ::
                     The texel format `T` equals
                     |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/format}}.
+                    If {{GPUFeatureName/"bgra8unorm-storage"}} is enabled, the texel format `T` can be `rgba8unorm`
+                    when |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/format}}
+                    is {{GPUTextureFormat/"bgra8unorm"}}.
             </dl>
 </div>
 


### PR DESCRIPTION
…WGSL

This patch allows the bgra8unorm storage texture format be compatible with the WGSL texel format `rgba8unorm` when the optional feature "bgra8unorm-storage" is enabled as WGSL doesn't support `bgra8unorm` as a valid texel format.