### PR TITLE
Added a notes about language/direction metadata

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -104,6 +104,12 @@ spec: WGSL; urlPrefix: https://gpuweb.github.io/gpuweb/wgsl/#
             text: f16; url: extension-f16
     type: abstract-op
         text: SizeOf; url: sizeof
+spec: Internationalization Glossary; urlPrefix: https://www.w3.org/TR/i18n-glossary/#
+    type: dfn
+        text: localizable text; url: def_localizable_text
+spec: Strings on the Web; urlPrefix: https://w3c.github.io/string-meta/#
+    type: dfn
+        text: best practices for language and direction information; url: bp_and-reco
 </pre>
 
 <style>
@@ -6429,6 +6435,11 @@ any specific point in the code at all.
     ::
         A human-readable string containing the message generated during the shader compilation.
 
+        Note: The {{GPUCompilationMessage/message}} is potentially [=localizable text=], and as such
+        should follow the [=best practices for language and direction information=]. This includes
+        making use of any future standards which may emerge regarding the reporting of string
+        language and direction metadata.
+
     : <dfn>type</dfn>
     ::
         The severity level of the message.
@@ -12669,6 +12680,11 @@ JSON, for a debug report).
         Note: User agents should not include potentially machine-parsable details in this message,
         such as free system memory on {{GPUErrorFilter/"out-of-memory"}} or other details about the
         conditions under which memory was exhausted.
+
+        Note: The {{GPUError/message}} is potentially [=localizable text=], and as such should
+        follow the [=best practices for language and direction information=]. This includes
+        making use of any future standards which may emerge regarding the reporting of string
+        language and direction metadata.
 </dl>
 
 <script type=idl>


### PR DESCRIPTION
Fixes #2780.

Indicates that human-readable messages should follow best practices regarding identification of language and direction metadata (which mostly means not including identification markers in the string itself) and that future platform standards around reporting this metadata should be followed.