### PR TITLE
wgsl: add predeclared type aliases for matrices

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2074,6 +2074,35 @@ See [[#arithmetic-expr]].
   </xmp>
 </div>
 
+WGSL also [=predeclared|predeclares=] the following [=type aliases=]:
+
+<table class='data'>
+  <thead>
+    <tr>
+        <th>Predeclared alias
+        <th>Original type
+        <th>Restrictions
+  </thead>
+  <tr> <td><dfn noexport>mat2x2f</dfn> <td>mat2x2&lt;f32&gt; <td>
+  <tr> <td><dfn noexport>mat2x3f</dfn> <td>mat2x3&lt;f32&gt; <td>
+  <tr> <td><dfn noexport>mat2x4f</dfn> <td>mat2x3&lt;f32&gt; <td>
+  <tr> <td><dfn noexport>mat3x2f</dfn> <td>mat3x2&lt;f32&gt; <td>
+  <tr> <td><dfn noexport>mat3x3f</dfn> <td>mat3x3&lt;f32&gt; <td>
+  <tr> <td><dfn noexport>mat3x4f</dfn> <td>mat3x3&lt;f32&gt; <td>
+  <tr> <td><dfn noexport>mat4x2f</dfn> <td>mat2x2&lt;f32&gt; <td>
+  <tr> <td><dfn noexport>mat4x3f</dfn> <td>mat2x3&lt;f32&gt; <td>
+  <tr> <td><dfn noexport>mat4x4f</dfn> <td>mat2x3&lt;f32&gt; <td>
+  <tr> <td><dfn noexport>mat2x2h</dfn> <td>mat2x2&lt;f16&gt; <td rowspan=9>Requires the [=extension/f16|f16 extension=].
+  <tr> <td><dfn noexport>mat2x3h</dfn> <td>mat2x3&lt;f16&gt;
+  <tr> <td><dfn noexport>mat2x4h</dfn> <td>mat2x3&lt;f16&gt;
+  <tr> <td><dfn noexport>mat3x2h</dfn> <td>mat3x2&lt;f16&gt;
+  <tr> <td><dfn noexport>mat3x3h</dfn> <td>mat3x3&lt;f16&gt;
+  <tr> <td><dfn noexport>mat3x4h</dfn> <td>mat3x3&lt;f16&gt;
+  <tr> <td><dfn noexport>mat4x2h</dfn> <td>mat2x2&lt;f16&gt;
+  <tr> <td><dfn noexport>mat4x3h</dfn> <td>mat2x3&lt;f16&gt;
+  <tr> <td><dfn noexport>mat4x4h</dfn> <td>mat2x3&lt;f16&gt;
+</table>
+
 ### Atomic Types ### {#atomic-types}
 
 An <dfn noexport>atomic type</dfn> encapsulates a [=type/concrete=] [=integer scalar=] type such that:


### PR DESCRIPTION
Fixes: #3673