### PR TITLE
Fix typo for vec2<u32> to vec2<f32> conversion

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -5537,7 +5537,7 @@ Details of conversion to and from floating point are explained in [[#floating-po
      <td>[=Component-wise=] value conversion to binary32 floating point, including invalid cases.
 
   <tr algorithm="vector conversion from unsigned integer to binary32 floating point">
-     <td>|e|: vec|N|&lt;f32&gt;
+     <td>|e|: vec|N|&lt;u32&gt;
      <td>`vec`|N|&lt;`f32`&gt;`(`|e|`)`: vec|N|&lt;f32&gt;
      <td>[=Component-wise=] value conversion to binary32 floating point, including invalid cases.
 


### PR DESCRIPTION
Fixes: #3681