### PR TITLE
Fill out the compilationInfo() algorithm

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6342,7 +6342,7 @@ dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
 
             @vertex
             fn vertexMain(@builtin(vertex_index) vertexIndex : u32) -&gt; @builtin(position) vec4&lt;f32&gt; {
-                return vec4(pos[input.vertexIndex], 1.0, 1.0);
+                return vec4(pos[vertexIndex], 1.0, 1.0);
             }
 
             @fragment
@@ -6448,8 +6448,8 @@ any specific point in the code at all.
     ::
         The severity level of the message.
 
-        If the {{GPUCompilationMessage/type}} is "error", it corresponds to a
-        [=shader-creation error=].
+        If the {{GPUCompilationMessage/type}} is {{GPUCompilationMessageType/"error"}}, it
+        corresponds to a [=shader-creation error=].
 
     : <dfn>lineNum</dfn>
     ::
@@ -6514,7 +6514,66 @@ Note: {{GPUCompilationMessage}}.{{GPUCompilationMessage/offset}} and
 
                 [=Content timeline=] steps:
 
-                Issue: Describe {{GPUShaderModule/compilationInfo()}} algorithm steps.
+                1. Let <var data-timeline=content>contentTimeline</var> be the current [=Content timeline=].
+                1. Let |promise| be [=a new promise=].
+                1. Issue the |synchronization steps| on the [=Device timeline=] of |this|.
+                1. Return |promise|.
+            </div>
+            <div data-timeline=device>
+                [=Device timeline=] |synchronization steps|:
+
+                1. When the [=device timeline=] becomes informed that [=shader module creation=] has
+                    completed for |this|:
+                    1. Let |messages| be a list of any errors, warnings, or informational messages
+                        generated during [=shader module creation=] for |this|.
+                    1. Issue the subsequent steps on <var data-timeline=content>contentTimeline</var>.
+            </div>
+            <div data-timeline=content>
+                [=Content timeline=] steps:
+
+                1. Let |info| be a new {{GPUCompilationInfo}}.
+                1. For each |message| in |messages|:
+                    1. Let |m| be a new {{GPUCompilationMessage}}.
+                    1. Set |m|.{{GPUCompilationMessage/message}} to be the text of |message|.
+                    1.
+                        <dl class=switch>
+                            : If |message| is a [=shader-creation error=]:
+                            :: Set |m|.{{GPUCompilationMessage/type}} to
+                                {{GPUCompilationMessageType/"error"}}
+                            : If |message| is a warning:
+                            :: Set |m|.{{GPUCompilationMessage/type}} to
+                                {{GPUCompilationMessageType/"warning"}}
+                            : Otherwise:
+                            :: Set |m|.{{GPUCompilationMessage/type}} to
+                                {{GPUCompilationMessageType/"info"}}
+                        </dl>
+                    1.
+                        <dl class=switch>
+                            : If |message| is associated with a specific substring or position
+                                within the shader {{GPUShaderModuleDescriptor/code}}:
+                            ::
+                                1. Set |m|.{{GPUCompilationMessage/lineNum}} to the one-based number
+                                    of the first line that the message refers to.
+                                1. Set |m|.{{GPUCompilationMessage/linePos}} to the one-based number
+                                    of the first UTF-16 code units on |m|.{{GPUCompilationMessage/lineNum}}
+                                    that the message refers to, or `1` if the |message| refers to
+                                    the entire line.
+                                1. Set |m|.{{GPUCompilationMessage/offset}} to the number of UTF-16
+                                    code units from the beginning of the shader to beginning of the
+                                    substring or position that |message| refers to.
+                                1. Set |m|.{{GPUCompilationMessage/length}} the length of the
+                                    substring in UTF-16 code units that |message| refers to, or 0
+                                    if |message| refers to a position
+                            : Otherwise:
+                            ::
+                                1. Set |m|.{{GPUCompilationMessage/lineNum}} to `0`.
+                                1. Set |m|.{{GPUCompilationMessage/linePos}} to `0`.
+                                1. Set |m|.{{GPUCompilationMessage/offset}} to `0`.
+                                1. Set |m|.{{GPUCompilationMessage/length}} to `0`.
+                        </dl>
+                    1. [=list/Append=] |m| to |info|.{{GPUCompilationInfo/messages}}.
+
+                1. [=Resolve=] |promise| with |info|.
             </div>
         </div>
 </dl>


### PR DESCRIPTION
Resolves an inline issue. Pretty hand-wavy about where the messages come from, but I don't think we're going to get too much more detailed unless the WGSL spec adds some related prose, at which point we can link it. 