### PR TITLE
Reset [[pending_map]] to null in the RangeError case

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3454,8 +3454,8 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                                 1. [=Assert=] |p| is rejected.
                                 1. Return.
                             1. [=Assert=] |p| is pending.
-                            1. Set |this|.{{GPUBuffer/[[pending_map]]}} to `null`.
-                            1. [=Reject=] |p| with an {{OperationError}}.
+                            1. Set |this|.{{GPUBuffer/[[pending_map]]}} to `null`,
+                                and [=reject=] |p| with an {{OperationError}}.
                         </div>
 
                     1. [$Generate a validation error$].
@@ -3504,13 +3504,13 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
 
                     If this allocation fails:
 
-                    1. Set |this|.{{GPUBuffer/[[pending_map]]}} to `null`.
-                    1. [=Reject=] |p| with a {{RangeError}}.
+                    1. Set |this|.{{GPUBuffer/[[pending_map]]}} to `null`,
+                        and [=reject=] |p| with a {{RangeError}}.
                     1. Return.
                 1. Set the content of |mapping|.[=active buffer mapping/data=] to |dataForMappedRegion|.
                 1. Set |this|.{{GPUBuffer/[[mapping]]}} to |mapping|.
-                1. Set |this|.{{GPUBuffer/[[pending_map]]}} to `null`.
-                1. [=Resolve=] |p|.
+                1. Set |this|.{{GPUBuffer/[[pending_map]]}} to `null`,
+                    and [=resolve=] |p|.
             </div>
         </div>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3454,8 +3454,8 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
                                 1. [=Assert=] |p| is rejected.
                                 1. Return.
                             1. [=Assert=] |p| is pending.
-                            1. [=Reject=] |p| with an {{OperationError}}.
                             1. Set |this|.{{GPUBuffer/[[pending_map]]}} to `null`.
+                            1. [=Reject=] |p| with an {{OperationError}}.
                         </div>
 
                     1. [$Generate a validation error$].
@@ -3504,6 +3504,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
 
                     If this allocation fails:
 
+                    1. Set |this|.{{GPUBuffer/[[pending_map]]}} to `null`.
                     1. [=Reject=] |p| with a {{RangeError}}.
                     1. Return.
                 1. Set the content of |mapping|.[=active buffer mapping/data=] to |dataForMappedRegion|.


### PR DESCRIPTION
This reset was missing, leaving the state invalid.

Also an editorial nit to always update `[[pending_map]]` together with resolving/rejecting promises.

Thanks again @takahirox for looking closely at these definitions and finding important issues.