### PR TITLE
Remove spurious note on depthStoreOp

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -10559,13 +10559,17 @@ dictionary GPURenderPassDepthStencilAttachment {
     - If |format| has a depth aspect and |this|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} is not `true`:
         - |this|.{{GPURenderPassDepthStencilAttachment/depthLoadOp}} must [=map/exist|be provided=].
         - |this|.{{GPURenderPassDepthStencilAttachment/depthStoreOp}} must [=map/exist|be provided=].
-    - Otherwise:
+
+        Otherwise:
+
         - |this|.{{GPURenderPassDepthStencilAttachment/depthLoadOp}} must not [=map/exist|be provided=].
         - |this|.{{GPURenderPassDepthStencilAttachment/depthStoreOp}} must not [=map/exist|be provided=].
     - If |format| has a stencil aspect and |this|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}} is not `true`:
         - |this|.{{GPURenderPassDepthStencilAttachment/depthLoadOp}} must [=map/exist|be provided=].
         - |this|.{{GPURenderPassDepthStencilAttachment/depthStoreOp}} must [=map/exist|be provided=].
-    - Otherwise:
+
+        Otherwise:
+
         - |this|.{{GPURenderPassDepthStencilAttachment/stencilLoadOp}} must not [=map/exist|be provided=].
         - |this|.{{GPURenderPassDepthStencilAttachment/stencilStoreOp}} must not [=map/exist|be provided=].
 </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -10509,8 +10509,6 @@ dictionary GPURenderPassDepthStencilAttachment {
         The store operation to perform on {{GPURenderPassDepthStencilAttachment/view}}'s
         depth component after executing the render pass.
 
-        Note: It is recommended to prefer a clear-value; see {{GPULoadOp/"load"}}.
-
     : <dfn>depthReadOnly</dfn>
     ::
         Indicates that the depth component of {{GPURenderPassDepthStencilAttachment/view}}


### PR DESCRIPTION
This note was supposed to be on `depthLoadOp`. Seems it was accidentally duplicated on `depthStoreOp` in #1451.