### PR TITLE
Make GPUPipelineError constructor `message` pseudo-optional

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -776,9 +776,9 @@ In this specification, the following syntactic shorthands are used:
     "if `buffer` is `null` or `undefined`, then `undefined`; otherwise,
     the `[[adapter]]` internal slot of the `[[device]]` internal slot of `buffer`.
 
-: The <dfn dfn>??</dfn> ("nullish coalescing") syntax, adopted from JavaScript.
+: The `??` ("nullish coalescing") syntax, adopted from JavaScript.
 ::
-    The phrasing "`x` [=??=] `y`" means "`x`, if `x` is not null/undefined, and `y` otherwise".
+    The phrasing "`x` ?? `y`" means "`x`, if `x` is not null/undefined, and `y` otherwise".
 
 : <dfn dfn>slot-backed attribute</dfn>
 ::
@@ -6658,7 +6658,7 @@ enum GPUPipelineErrorReason {
             </pre>
 
             1. Set [=this=].{{DOMException/name}} to `"GPUPipelineError"`.
-            1. Set [=this=].{{DOMException/message}} to |message| [=??=] `""`.
+            1. Set [=this=].{{DOMException/message}} to |message| ?? `""`.
             1. Set [=this=].{{GPUPipelineError/reason}} to |options|.{{GPUPipelineErrorInit/reason}}.
         </div>
 </dl>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -776,9 +776,9 @@ In this specification, the following syntactic shorthands are used:
     "if `buffer` is `null` or `undefined`, then `undefined`; otherwise,
     the `[[adapter]]` internal slot of the `[[device]]` internal slot of `buffer`.
 
-: The `??` ("nullish coalescing") syntax, adopted from JavaScript.
+: The <dfn dfn>??</dfn> ("nullish coalescing") syntax, adopted from JavaScript.
 ::
-    The phrasing "`x` ?? `y`" means "`x`, if `x` is not null/undefined, and `y` otherwise".
+    The phrasing "`x` [=??=] `y`" means "`x`, if `x` is not null/undefined, and `y` otherwise".
 
 : <dfn dfn>slot-backed attribute</dfn>
 ::
@@ -6627,13 +6627,12 @@ There are two ways to create pipelines:
 
 <dfn interface>GPUPipelineError</dfn> describes a pipeline creation failure.
 
-Issue: According to [whatwg/webidl#1211](https://github.com/whatwg/webidl/pull/1211),
-to conform to the standard pattern, `message` should be optional and default to `""`.
+<!--TODO(gpuweb/gpuweb#3709): Change `message` to optional, defaulting to `""`. -->
 
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext, Serializable]
 interface GPUPipelineError : DOMException {
-    constructor(DOMString message, GPUPipelineErrorInit options);
+    constructor((DOMString or undefined) message, GPUPipelineErrorInit options);
     readonly attribute GPUPipelineErrorReason reason;
 };
 
@@ -6659,7 +6658,7 @@ enum GPUPipelineErrorReason {
             </pre>
 
             1. Set [=this=].{{DOMException/name}} to `"GPUPipelineError"`.
-            1. Set [=this=].{{DOMException/message}} to |message|.
+            1. Set [=this=].{{DOMException/message}} to |message| [=??=] `""`.
             1. Set [=this=].{{GPUPipelineError/reason}} to |options|.{{GPUPipelineErrorInit/reason}}.
         </div>
 </dl>


### PR DESCRIPTION
This change should work around the widlparser issue tracked in #3709.

Since the second argument `options` is required, it's never possible to call
`new GPUPipelineError()`.
The only way to invoke the defaulting behavior is to explicitly write `undefined`:
`new GPUPipelineError(undefined, { reason: 'validation' })`, which this change allows.

IIUC, note passing `null` or other values that are neither DOMString nor `undefined`, in both cases, should result in the same conversion behavior, e.g. `null` becomes the `DOMString` value `"null"`.