### PR TITLE
Add missing line breaks in shift preconditions

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6506,7 +6506,7 @@ See [[#sync-builtin-functions]].
   <tr algorithm="abstract shift left">
     <td>|e1|: |T|<br>
     |e2|: |TS|<br>
-    |T| is AbstractInt or vec|N|&lt;AbstractInt&gt;
+    |T| is AbstractInt or vec|N|&lt;AbstractInt&gt;<br>
     |TS| is u32 when |T| is AbstractInt, otherwise |TS| is vec|N|&lt;u32&gt;
     <td class="nowrap">|e1| `<<` |e2|: |T|
     <td>Shift left (shifted value abstract):
@@ -6552,7 +6552,7 @@ See [[#sync-builtin-functions]].
   <tr algorithm="abstract shift right">
     <td>|e1|: |T|<br>
     |e2|: |TS|<br>
-    |T| is AbstractInt or vec|N|&lt;AbstractInt&gt;
+    |T| is AbstractInt or vec|N|&lt;AbstractInt&gt;<br>
     |TS| is u32 when |T| is AbstractInt, otherwise |TS| is vec|N|&lt;u32&gt;
     <td class="nowrap">|e1| >> |e2|: |T|
     <td>Shift right (abstract).


### PR DESCRIPTION
This was making these entries a little harder to read.