### PR TITLE
Add diagnostic filtering; range diagnostics apply to control flow constructs and compound statements

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1488,9 +1488,7 @@ ignored for the purposes of type and semantic checking.
 Additionally, the attribute name is a [=context-dependent name=], and
 some attribute parameters are also context-dependent names.
 
-With one exception, an attribute [=shader-creation error|must not=] be specified more than once per object or type.
-The exception is that more than one [=attribute/diagnostic=] attribute may be specified on an object, provided
-they specify different [=diagnostic/triggering rules=].
+Unless explicitly permitted below, an attribute [=shader-creation error|must not=] be specified more than once per object or type.
 
 <table class='data'>
   <caption>Attributes defined in WGSL</caption>
@@ -1555,8 +1553,8 @@ they specify different [=diagnostic/triggering rules=].
 
     <td>Specifies a [=range diagnostic filter=].  See [[#diagnostics]].
 
-        Two diagnostic attributes applied to the same object [=shader-creation error|must=]
-        specify different [=diagnostic/triggering rules=].
+        More than one [=attribute/diagnostic=] attribute may be specified on an object,
+        but they [=shader-creation error|must=] specify different [=diagnostic/triggering rules=].
 
   <tr><td><dfn noexport dfn-for="attribute">`group`</dfn>
     <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9675,6 +9675,17 @@ There is no risk of being trapped in a cycle, as recurrence is forbidden in the 
 
 Note: Another way of saying the same thing is that we do a topological sort of functions ordered by the "is a (possibly indirect) callee of" partial order, and analyze them in that order.
 
+Additionally, the analysis computes and propagates locations of [=call sites=] for [=builtin functions that compute a derivative=].
+This is used to [=triggered|trigger=] and filter [=diagnostics=] for [=uniformity failures=] on those calls.
+A set of such source locations is called a <dfn noexport>witness set</dfn>.
+Witness sets only support adding elements, not removing elements.
+In particular, a witness set is only formed via the following operations:
+* Create an empty set.
+* Create a witness set containing a single source location.
+* Form a witness set from the union of two others.
+
+Witness sets can be implemented such that their total cost across the entire uniformity analysis is linear in the source program size.
+
 ### Analyzing the Uniformity Requirements of a Function ### {#uniformity-function}
 
 Each function is analyzed in two phases.
@@ -9761,20 +9772,26 @@ value|non-uniform=] during the execution of the function call.
       <td>The uniformity of the value stored in the memory pointed to by the pointer parameter is unaffected by the function call.
 </table>
 
+To support generating [=diagnostics=], each instance of a [=CallSiteRequiredToBeUniform=] [=call site tag=] and each instance of a [=ParameterRequiredToBeUniform=]
+[=parameter tag=] also has an associated [=witness set=], which capture the root cause
+for the tags to be [=CallSiteRequiredToBeUniform=] and [=ParameterRequiredToBeUniform=], respectively.
+
 The following algorithm describes how to compute these tags for a given function:
 
 * Create nodes called <dfn noexport>RequiredToBeUniform</dfn>, <dfn noexport>MayBeNonUniform</dfn>, <dfn noexport>CF_start</dfn>, and if the function has a [=return type=] a node called <dfn noexport>Value_return</dfn>.
+    * Additionally, the [=RequiredToBeUniform=] tag has an associated [=witness set=], which is initially empty.
 * Create one node for each parameter of the function which we'll call <dfn noexport>param_i</dfn>.
 * Desugar pointers as described in [[#pointer-desugar]].
     * For each pointer parameter in the [=address spaces/function=] address space,
         create a <dfn noexport>Value_return_i</dfn> node.
-* Walk over the syntax of the function, adding nodes and edges to the graph following the rules of the next sections ([[#func-var-value-analysis]], [[#uniformity-statements]], [[#uniformity-function-calls]], [[#uniformity-expressions]]), using [=CF_start=] as the starting control-flow for the function's body.
+* Walk over the syntax of the function, adding nodes and edges to the graph, and building [=witness sets=], following the rules of the next sections ([[#func-var-value-analysis]], [[#uniformity-statements]], [[#uniformity-function-calls]], [[#uniformity-expressions]]), using [=CF_start=] as the starting control-flow for the function's body.
 * For each [=Value_return_i=] node, record which [=param_i=] nodes are reachable from it.
-* Look at which nodes are reachable from [=RequiredToBeUniform=].
-    * If this set includes the node [=MayBeNonUniform=], then trigger a [=uniformity failure=].
-    * If this set includes [=CF_start=], then the [=call site tag=] for the function is [=CallSiteRequiredToBeUniform=].
+* Examine the [=RequiredToBeUniform=] node. Let *W* be its associated [=witness set=]. Let *R* be the set of nodes reachable from [=RequiredToBeUniform=].
+    * If *R* includes the node [=MayBeNonUniform=], then trigger a [=uniformity failure=].
+         * If the uniformity failure triggers [=diagnostics=], then the [=diagnostic/triggering locations=] are taken from *W*.
+    * If *R* includes [=CF_start=], then the [=call site tag=] for the function is [=CallSiteRequiredToBeUniform=], with [=witness set=] *W*.
     * Otherwise, the [=call site tag=] is [=CallSiteNoRestriction=].
-    * For each [=param_i=] in this set, the corresponding [=parameter tag=] is [=ParameterRequiredToBeUniform=].
+    * For each [=param_i=] in *R*, the corresponding [=parameter tag=] is [=ParameterRequiredToBeUniform=], with [=witness set=] *W*.
     * Remove from the graph all nodes that have been visited.
 * If [=Value_return=] exists, look at which nodes are reachable from it
     * If this set includes [=MayBeNonUniform=], then the [=function tag=] is [=ReturnValueMayBeNonUniform=].
@@ -9785,7 +9802,7 @@ The following algorithm describes how to compute these tags for a given function
 * If the [=function tag=] has not been assigned, then it is [=NoRestriction=].
 * For each parameter, if it has not been assigned a [=parameter tag=], then it is [=ParameterNoRestriction=].
 
-Note: The entire graph can be destroyed at this point. The tags listed above are all that we need to remember to analyze callers of this function.
+Note: The entire graph can be destroyed at this point. The tags and [=witness sets=] described above are all that we need to remember to analyze callers of this function.
 
 ### Pointer Desugaring ### {#pointer-desugar}
 
@@ -10191,12 +10208,14 @@ being the same as input control flow node.
 The most complex rule is for function calls:
 - For each argument, apply the corresponding expression rule, with the control flow at the exit of the previous argument (using the control flow at the beginning of the function call for the first argument). Name the corresponding value nodes <dfn noexport>arg_i</dfn> and the corresponding control flow nodes <dfn noexport>CF_i</dfn>
 - Create two new nodes, named <dfn noexport>Result</dfn> and <dfn noexport>CF_after</dfn>
-- If the [=call site tag=] of the function is [=CallSiteRequiredToBeUniform=], then add an edge from [=RequiredToBeUniform=] to the last [=CF_i=]
+- If the [=call site tag=] of the function is [=CallSiteRequiredToBeUniform=], then add an edge from [=RequiredToBeUniform=] to the last [=CF_i=].
+    - Additionally add the [=witness set=] from the call site tag to the witness set associated with [=RequiredToBeUniform=].
 - Otherwise add an edge from [=CF_after=] to the last [=CF_i=]
 - If the [=function tag=] is [=ReturnValueMayBeNonUniform=], then add an edge from [=Result=] to [=MayBeNonUniform=]
 - Add an edge from [=Result=] to [=CF_after=]
 - For each argument *i*:
     - If the corresponding [=parameter tag=] is [=ParameterRequiredToBeUniform=], then add an edge from [=RequiredToBeUniform=] to [=arg_i=]
+        - Additionally add the [=witness set=] from the parameter tag to the witness set associated with [=RequiredToBeUniform=].
     - Otherwise if the [=parameter tag=] is [=ParameterRequiredToBeUniformForReturnValue=], then add an edge from [=Result=] to [=arg_i=]
     - If the corresponding parameter has a [=pointer parameter tag=] of [=PointerParameterMayBeNonUniform=], then add an edge from *Vout*(*call*) to [=MayBeNonUniform=]
     - If the parameter is a pointer in the [=address spaces/function=] address space, add an edge from *Vout*(*call*) to each corresponding [=arg_i=] for the reachable parameters recorded previously
@@ -10215,8 +10234,9 @@ Here is the list of exceptions:
     - The parameter `p` in [[#workgroupUniformLoad-builtin|workgroupUniformLoad]]
         has a [=parameter tag=] of [=ParameterRequiredToBeUniform=].
 - All functions in
-    [[#derivative-builtin-functions]], [[#texturesample]], [[#texturesamplebias]], and [[#texturesamplecompare]]
-    have a [=call site tag=] of [=CallSiteRequiredToBeUniform=], and a [=function tag=] of [=ReturnValueMayBeNonUniform=].
+    [[#derivative-builtin-functions]], [[#texturesample]], [[#texturesamplebias]], and [[#texturesamplecompare]]:
+    - Have a [=call site tag=] of [=CallSiteRequiredToBeUniform=]. The associated [=witness set=] is a singleton set containing the location of the [=call site=] to the builtin function.
+    - Have a [=function tag=] of [=ReturnValueMayBeNonUniform=].
 - [[#arrayLength-builtin|arrayLength]] has a [=call site tag=] of
     [=CallSiteNoRestriction=], a [=function tag=] of [=NoRestriction=] and
     the input parameter `p` has a [=parameter tag=] of [=ParameterNoRestriction=]

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -257,6 +257,7 @@ spec: WebGPU; urlPrefix: https://gpuweb.github.io/gpuweb/#
         text: binding member; url: binding-member
         text: binding resource type; url: binding-resource-type
         text: binding type; url: binding-type
+        text: GPU error scope; url: gpu-error-scope
         text: front-facing; url: front-facing
         text: shader-output mask; url: shader-output-mask
         text: framebuffer; url: framebuffer
@@ -571,7 +572,195 @@ When unclear from context, this specification indicates
 whether failure to meet a particular requirement
 results in a shader-creation, pipeline-creation, or dynamic error.
 
-The WebGPU specification describes the consequences of each kind of error.
+The WebGPU specification describes the consequences of each kind of error.  In particular:
+* Detectable errors [=behavioral requirement|will=] [=triggered|trigger=] a [=diagnostic=].
+* A WGSL program with a [=shader-creation error=] or [=pipeline-creation error=] error will not be incorporated
+    into a [=pipeline=] and hence will not be executed.
+
+## Diagnostics ## {#diagnostics}
+
+An implementation can generate [=diagnostics=] during [=shader module creation=] or [=pipeline creation=].
+A <dfn noexport>diagnostic</dfn> is a message produced by the implementation for the benefit of the application author.
+
+A diagnostic is created, or <dfn noexport>triggered</dfn>, when a particular condition is met,
+known as the <dfn dfn-for="diagnostic">triggering rule</dfn>.
+The place in the source text where the condition is met, expressed as a point or range in the source text, is known as the 
+<dfn dfn-for="diagnostic">triggering location</dfn>.
+
+A [=diagnostic=] has the following properties:
+* A [=diagnostic/severity=].
+* A [=diagnostic/triggering rule=].
+* A [=diagnostic/triggering location=].
+
+The <dfn dfn-for="diagnostic">severity</dfn> of a diagnostic is one of the following, ordered from greatest to least:
+: <dfn dfn-for="severity" noexport>error</a>
+:: The diagnostic is an error.
+     This corresponds to a [=shader-creation error=] or to a [=pipeline-creation error=].
+: <dfn dfn-for="severity" noexport>warning</a>
+:: The diagnostic describes an anomaly that merits the attention of the application developer, but is not an error.
+: <dfn dfn-for="severity" noexport>info</a>
+:: The diagnostic describes a notable condition that merits attention of the application developer, but is not an error or warning.
+: <dfn dfn-for="severity" noexport>off</a>
+:: The diagnostic is disabled. It will not be conveyed to the application.
+
+Triggered diagnostics [=behavioral requirement|will=] be processed as follows:
+1. For each diagnostic *D*, find the [=diagnostic filter=]
+    with the smallest [=affected range=] that contains D's [=diagnostic/triggering location=], and which has the same [=diagnostic/triggering rule=].
+    * If such a filter exists, apply it to *D*, updating *D*'s [=diagnostic/severity=].
+    * Otherwise *D* remains unchanged.
+2. Discard diagnostics that have severity [=severity/off=].
+3. If at least one remaining diagnostic *DI* has severity [=severity/info=], then:
+    * Other [=severity/info=] diagnostics with same triggering rule *may* be discarded, leaving only the original diagnostic *DI*.
+4. If at least one remaining diagnostic *DW* has severity [=severity/warning=], then:
+    * Other [=severity/info=] or [=severity/warning=] diagnostics with same triggering rule *may* be discarded, leaving only the original diagnostic *DW*.
+5. If at least one remaining diagnostic has [=severity/error=] severity, then:
+    * Other diagnostics *may* be discarded, including other diagnostics with [=severity/error=] severity.
+    * A [=program error=] is generated.
+         * The error is a [=shader-creation error=] if the diagnostic was triggered at [=shader module creation=] time.
+         * The error is a [=pipeline-creation error=] if the diagnostic was triggered at [=pipeline creation=] time.
+6. If processing during [=shader module creation=] time, the remaining diagnostics populates the
+    {{GPUCompilationInfo/messages}} member of the WebGPU {{GPUCompilationInfo}} object.
+7. If processing during [=pipeline creation=], the [=severity/error=] diagnostics are reported
+    in the nearest enclosing WebGPU [=GPU error scope=].
+    Issue: TODO: Adjust for [#3682](https://github.com/gpuweb/gpuweb/issues/3682).
+
+Note: The rules allow an implementation to stop processing a WGSL program as soon as an error is detected.
+Additionally, an analysis for a particular kind of warning can stop on the first warning,
+and an analysis for a particular kind of info diagnostic can stop on the first occurrence.
+
+### Filterable Triggering Rules ### {#filterable-triggering-rules}
+
+Most [=diagnostics=] are unconditionally reported to the WebGPU application.
+Some kinds of diagnostics can be [[#diagnostic-filtering|filtered]], in part by naming their [=diagnostic/triggering rule=].
+The following table lists the standard set of triggering rules that can be filtered.
+
+<table class='data'>
+  <caption>Filterable diagnostic triggering rules</caption>
+  <thead>
+    <tr><th>Filterable Triggering Rule<th>Default Severity<th>Triggering Location<th>Description
+  </thead>
+
+  <tr>
+    <td><dfn noexport dfn-for="trigger">derivative_uniformity</dfn>
+    <td>[=severity/error=]
+    <td>A call to a [=builtin functions that compute a derivative|builtin function that computes a derivative=].
+        That is, a call to any of:
+        * the [[#derivative-builtin-functions|derivative builtin functions]]
+        * [[#texturesample|textureSample]]
+        * [[#texturesamplebias|textureSampleBias]]
+        * [[#texturesamplecompare|textureSampleCompare]]
+
+    <td>A call to a builtin function computes derivatives, but [=uniformity analysis=] cannot prove that the call occurs in [=uniform control flow=].
+
+    See [[#uniformity]].
+</table>
+
+An implementation may support filtering triggering rules not specified here,
+provided they are spelled differently from the standard triggering rules.
+A [=diagnostic filter=] with an unrecognized [=diagnostic/triggering rule=] [=behavioral requirement|will=] be ignored.
+
+Future versions of this specification may remove a particular rule or weaken its default severity
+(i.e. replace its current default with a less severe default) and still be deemed as satisfying backward compatibility.
+For example, a future version of WGSL may change the default severity for [=trigger/derivative_uniformity=] from `error` to either `warning` or `info`.
+After such a change to the specification, previously valid programs would remain valid.
+
+### Diagnostic Filtering ### {#diagnostic-filtering}
+
+Once a [=diagnostic=] with a filterable [=diagnostic/triggering rule=] is [=triggered=], WGSL provides mechanisms to discard the diagnostic, or to modify its severity.
+
+A <dfn noexport>diagnostic filter</dfn> *DF* has three parameters:
+* *AR*: a range of source text known as the <dfn noexport>affected range</dfn>
+* *NS*: a new [=diagnostic/severity=]
+* *TR*: a [=diagnostic/triggering rule=]
+
+Applying a diagnostic filter *DF*(*AR*,*NS*,*TR*) to a diagnostic *D* has the following effect:
+* If *D*'s [=diagnostic/triggering location=] is in *AR* and *D*'s [=diagnostic/triggering rule=] is *TR*, then
+        set *D*'s [=diagnostic/severity=] property to *NS*.
+* Otherwise, *D* is unchanged.
+
+A <dfn noexport>range diagnostic filter</dfn> is a [=diagnostic filter=] that is applied to each
+diagnostic whose [=diagnostic/triggering location=] falls within a specified range of source text,
+and when no other more specific filter applies.
+A range diagnostic filter is specified as a `@diagnostic` [=attribute=] immediately before the affected source range,
+as specified in the following table.  A `@diagnostic` attribute [=shader-creation error|must not=] appear anywhere else.
+
+<table class='data'>
+  <caption>Placement of a range diagnostic filter</caption>
+  <thead>
+    <tr><th>Placement<th>Affected Range
+  </thead>
+    <tr><td>Beginning of a [=compound statement=].<td>The compound statement.
+    <tr><td>Beginning of a [=function declaration=].<td>The function declaration.
+    <tr><td>Beginning of an [=statement/if=] statement.<td>The if statement: the [=syntax/if_clause=]
+      and all associated [=syntax/else_if_clause=] and [=syntax/else_clause=] clauses,
+      including all controlling condition expressions.
+    <tr><td>Beginning of a [=statement/switch=] statement.<td>The switch statement: the selector expression and the [=syntax/switch_body=].
+    <tr><td>Beginning of a [=syntax/switch_body=].<td>The [=syntax/switch_body=].
+    <tr><td>Beginning of a [=statement/loop=] statement.<td>The loop statement.
+    <tr><td>Beginning of a [=statement/while=] statement.<td>The while statement: both the condition expression and the loop body.
+    <tr><td>Beginning of a [=statement/for=] statement.<td>The for statement: the [=syntax/for_header=] and the loop body.
+    <tr><td>Immediately before the opening brace (`'{'`) of the [=loop body=] of a [=statement/loop=], [=statement/while=], or [=statement/for=] loop.<td>The [=loop body=].
+    <tr><td>Beginning of a [=syntax/continuing_compound_statement=].<td>The [=syntax/continuing_compound_statement=].
+</table>
+
+Note: A [=function body=], a [=case clause=], a [=default-alone clause=],
+and the bodies of [=syntax/else_if_clause=] and [=syntax/else_clause=] are themselves [=compound statements=].
+
+<div class='example wgsl global-scope' heading='Range diagnostic filter on texture sampling'>
+  <xmp highlight='rust'>
+  var<private> d: f32;
+  fn helper() -> vec4<f32> {
+    // Disable the derivative_uniformity diagnostic in the
+    // body of the "if".
+    if (d < 0.5) @diagnostic(off,derivative_uniformity) {
+      return textureSample(t,s,vec2(0,0));
+    }
+    return vec4(0.0);
+  }
+  </xmp>
+</div>
+
+A <dfn noexport>global diagnostic filter</dfn> is a diagnostic filter whose [=affected range=] is the whole WGSL program.
+It is a [=directive=], thus appearing before any [=module scope|module-scope=] declarations.
+It is spelled like the attribute form, but without the leading `@` (U+0040) codepoint, and with a terminating semicolon.
+
+<div class='example wgsl global-scope' heading='Global diagnostic filter for derivative uniformity'>
+  <xmp highlight='rust'>
+  diagnostic(off,derivative_uniformity);
+  var<private> d: f32;
+  fn helper() -> vec4<f32> {
+    if (d < 0.5) {
+      // The derivative_uniformity diagnostic is disabled here
+      // by the global diagnostic filter.
+      return textureSample(t,s,vec2(0,0));
+    } else {
+      // The derivative_uniformity diagnostic is set to 'warning' severity.
+      @diagnostic(warning,derivative_uniformity) {
+        return textureSample(t,s,vec2(0,0));
+      }
+    }
+    return vec4(0.0);
+  }
+  </xmp>
+</div>
+
+
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>diagnostic_directive</dfn> :
+
+    | <a for=syntax_kw lt=diagnostic>`'diagnostic'`</a> [=syntax/diagnostic_control=] <a for=syntax_sym lt=semicolon>`';'`</a>
+</div>
+
+Two [=diagnostic filters=] *DF*(*AR1*,*NS1*,*TR1*) and *DF*(*AR2*,*NS2*,*TR2*) <dfn dfn-for="diagnostic">conflict</dfn> when:
+* (*AR1* &equals; *AR2*), and
+* (*TR1* &equals; *TR2*), and
+* (*NS1* &ne; *NS2*).
+
+[=Diagnostic filters=] [=shader-creation error|must=] not [=diagnostic/conflict=].
+
+Note: WGSL's diagnostic filters are designed so their affected ranges nest perfectly.
+If the affected range of DF1 overlaps with the affected range of DF2, then
+either DF1's affected range is fully contained in DF2's affected range, or the other way around.
 
 # Textual Structure # {#textual-structure}
 
@@ -1031,6 +1220,21 @@ The spelling of the token may be the same as an [=identifier=], but the token do
 
 Section [[#context-dependent-name-tokens]] lists all such tokens.
 
+## Diagnostic Rule Names ## {#diagnostic-rule-names}
+
+A <dfn noexport>diagnostic rule name</dfn> is a [=token=] used to name a diagnostic [=diagnostic/triggering rule=],
+in either a [=range diagnostic filter=] or a [=global diagnostic filter=].
+The spelling of the token may be the same as an [=identifier=], [=keyword=], or [=reserved word=],
+but is not interpeted as any of those.
+
+See [[#diagnostics]].
+
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>diagnostic_rule_name</dfn> :
+
+    | [=syntax/ident_pattern_token=]
+</div>
+
 ## Template Lists ## {#template-lists-sec}
 
 <dfn noexport>Template parameterization</dfn> is a way to specify parameters that modify a general concept.
@@ -1274,7 +1478,9 @@ ignored for the purposes of type and semantic checking.
 Additionally, the attribute name is a [=context-dependent name=], and
 some attribute parameters are also context-dependent names.
 
-An attribute [=shader-creation error|must not=] be specified more than once per object or type.
+With one exception, an attribute [=shader-creation error|must not=] be specified more than once per object or type.
+The exception is that more than one [=attribute/diagnostic=] attribute may be specified on an object, provided
+they do not [=diagnostic/conflict=].
 
 <table class='data'>
   <caption>Attributes defined in WGSL</caption>
@@ -1328,6 +1534,16 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
 
     Note: This attribute is used as a notational convention to describe which
     built-in functions can be used in [=const-expressions=].
+
+  <tr><td><dfn noexport dfn-for="attribute">`diagnostic`</dfn>
+    <td>Two parameters.
+
+        The first parameter is a [=syntax/severity_control_name=].
+
+        The second parameter is a [=syntax/diagnostic_rule_name=] token
+        specifying a [=diagnostic/triggering rule=].
+
+    <td>Specifies a [=range diagnostic filter=].  See [[#diagnostics]].
 
   <tr><td><dfn noexport dfn-for="attribute">`group`</dfn>
     <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
@@ -1475,6 +1691,8 @@ They take no parameters.
 
     | <a for=syntax_sym lt=attr>`'@'`</a> `'const'`
 
+    | <a for=syntax_sym lt=attr>`'@'`</a> `'diagnostic'` [=syntax/diagnostic_control=]
+
     | <a for=syntax_sym lt=attr>`'@'`</a> `'group'` <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/expression=] [=syntax/attrib_end=]
 
     | <a for=syntax_sym lt=attr>`'@'`</a> `'id'` <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/expression=] [=syntax/attrib_end=]
@@ -1508,6 +1726,11 @@ They take no parameters.
 
     | <a for=syntax_sym lt=comma>`','`</a> ? <a for=syntax_sym lt=paren_right>`')'`</a>
 </div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>diagnostic_control</dfn> :
+
+    | <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/severity_control_name=] <a for=syntax_sym lt=comma>`','`</a> [=syntax/diagnostic_rule_name=] [=syntax/attrib_end=]
+</div>
 
 ## Directives ## {#directives}
 
@@ -1517,10 +1740,12 @@ program is processed by a WebGPU implementation.
 Directives are optional.
 If present, all directives [=shader-creation error|must=] appear before any [=declarations=] or [[#const-assert-statement|const assertions]].
 
-See [[#enable-extensions-sec]] and [[#software-extensions-sec]].
+See [[#diagnostic-filtering]], [[#enable-extensions-sec]], and [[#software-extensions-sec]].
 
 <div class='syntax' noexport='true'>
   <dfn for=syntax>global_directive</dfn> :
+
+    | [=syntax/diagnostic_directive=]
 
     | [=syntax/enable_directive=]
 
@@ -5843,6 +6068,7 @@ Note: The [=syntax/call_expression=] rule exists to ensure [=type checking=] app
 
     | [=syntax/template_elaborated_ident=] [=syntax/argument_expression_list=]
 </div>
+
 <div class='syntax' noexport='true'>
   <dfn for=syntax>paren_expression</dfn> :
 
@@ -6155,7 +6381,7 @@ from the start of the next statement until the end of the compound statement.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>compound_statement</dfn> :
 
-    | <a for=syntax_sym lt=brace_left>`'{'`</a> [=syntax/statement=] * <a for=syntax_sym lt=brace_right>`'}'`</a>
+    | [=syntax/attribute=] * <a for=syntax_sym lt=brace_left>`'{'`</a> [=syntax/statement=] * <a for=syntax_sym lt=brace_right>`'}'`</a>
 </div>
 
 The [=syntax/continuing_compound_statement=] is a special form of compound
@@ -6488,7 +6714,7 @@ An `if` statement has an `if` clause, followed by zero or more `else if` clauses
 <div class='syntax' noexport='true'>
   <dfn for=syntax>if_statement</dfn> :
 
-    | [=syntax/if_clause=] [=syntax/else_if_clause=] * [=syntax/else_clause=] ?
+    | [=syntax/attribute=] * [=syntax/if_clause=] [=syntax/else_if_clause=] * [=syntax/else_clause=] ?
 </div>
 
 <div class='syntax' noexport='true'>
@@ -6530,10 +6756,15 @@ depending on the evaluation of a selector expression.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>switch_statement</dfn> :
 
-    | <a for=syntax_kw lt=switch>`'switch'`</a> [=syntax/expression=] <a for=syntax_sym lt=brace_left>`'{'`</a> [=syntax/switch_body=] + <a for=syntax_sym lt=brace_right>`'}'`</a>
+    | [=syntax/attribute=] * <a for=syntax_kw lt=switch>`'switch'`</a> [=syntax/expression=] [=syntax/switch_body=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>switch_body</dfn> :
+
+    | [=syntax/attribute=] * <a for=syntax_sym lt=brace_left>`'{'`</a> [=syntax/switch_clause=] + <a for=syntax_sym lt=brace_right>`'}'`</a>
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>switch_clause</dfn> :
 
     | [=syntax/case_clause=]
 
@@ -6647,7 +6878,7 @@ creating a new instance of the [=variable declaration|variable=] or [=value decl
 <div class='syntax' noexport='true'>
   <dfn for=syntax>loop_statement</dfn> :
 
-    | <a for=syntax_kw lt=loop>`'loop'`</a> <a for=syntax_sym lt=brace_left>`'{'`</a> [=syntax/statement=] * [=syntax/continuing_statement=] ? <a for=syntax_sym lt=brace_right>`'}'`</a>
+    | [=syntax/attribute=] * <a for=syntax_kw lt=loop>`'loop'`</a> [=syntax/attribute=] * <a for=syntax_sym lt=brace_left>`'{'`</a> [=syntax/statement=] * [=syntax/continuing_statement=] ? <a for=syntax_sym lt=brace_right>`'}'`</a>
 </div>
 
 A <dfn noexport dfn-for="statement">loop</dfn> statement repeatedly executes a <dfn noexport>loop body</dfn>;
@@ -6753,7 +6984,7 @@ allows them to naturally use values defined in the loop body.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>for_statement</dfn> :
 
-    | <a for=syntax_kw lt=for>`'for'`</a> <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/for_header=] <a for=syntax_sym lt=paren_right>`')'`</a> [=syntax/compound_statement=]
+    | [=syntax/attribute=] * <a for=syntax_kw lt=for>`'for'`</a> <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/for_header=] <a for=syntax_sym lt=paren_right>`')'`</a> [=syntax/compound_statement=]
 </div>
 
 <div class='syntax' noexport='true'>
@@ -6843,7 +7074,7 @@ Converts to:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>while_statement</dfn> :
 
-    | <a for=syntax_kw lt=while>`'while'`</a> [=syntax/expression=] [=syntax/compound_statement=]
+    | [=syntax/attribute=] * <a for=syntax_kw lt=while>`'while'`</a> [=syntax/expression=] [=syntax/compound_statement=]
 </div>
 
 The <dfn noexport dfn-for="statement">while</dfn> statement is a kind of loop parameterized by a condition.
@@ -6984,7 +7215,7 @@ cannot be used to transfer control to the start of the currently executing `cont
 <div class='syntax' noexport='true'>
   <dfn for=syntax>continuing_compound_statement</dfn> :
 
-    | <a for=syntax_sym lt=brace_left>`'{'`</a> [=syntax/statement=] * [=syntax/break_if_statement=] ? <a for=syntax_sym lt=brace_right>`'}'`</a>
+    | [=syntax/attribute=] * <a for=syntax_sym lt=brace_left>`'{'`</a> [=syntax/statement=] * [=syntax/break_if_statement=] ? <a for=syntax_sym lt=brace_right>`'}'`</a>
 </div>
 
 A <dfn dfn-for="statement">continuing</dfn> statement specifies a [=compound statement=] to be executed at the end of a loop [=iteration=].
@@ -7314,7 +7545,7 @@ For the purpose of this analysis:
 - `loop {s}` is treated as `loop {s continuing {}}`
 - `if` statements without an `else` branch are treated as if they had an empty else branch (which adds Next to their [=behavior=])
 - `if` statements with `else if` branches are treated as if they were nested simple `if/else` statements
-- a [=syntax/switch_body=] starting with `default` behaves just like a [=syntax/switch_body=] starting with `case _:`
+- a [=syntax/switch_clause=] starting with `default` behaves just like a [=syntax/switch_clause=] starting with `case _:`
 
 Each [=built-in function=] has a [=behavior=] of {Next}.
 And each operator application not listed in the table above has the same [=behavior=] as if it were a function call with the same operands and with a function's [=behavior=] of {Next}.
@@ -9365,16 +9596,25 @@ See [[#statements]] and [[#function-calls]].
 
 ## Uniformity ## {#uniformity}
 
-[[#collective-operations|Collective operations]] (e.g. barriers and
-derivatives) require coordination among different invocations running
-concurrently on the GPU.  To ensure correct and portable behavior, WGSL
-requires that these operations can be statically analyzed to not have any
-control dependencies such that a non-empty strict subset of invocations will
-execute the operation (i.e. the operation must be executed in [=uniform control
-flow=]).
+A [[#collective-operations|collective operation]]
+(e.g. barrier, derivative, or a texture operation relying on an implicitly computed derivative)
+requires coordination among different invocations running concurrently on the GPU.
+The operation executes correctly and portably
+when all invocations execute it concurrently, i.e. in [=uniform control flow=].
+
+Conversely, incorrect or non-portable behavior occurs when a strict subset of invocations
+execute the operation, i.e. in non-uniform control flow.
+Informally, some invocations reach the collective operation, but others do not,
+or not at the same time, as a result of non-uniform control dependencies.
 Non-uniform control dependencies arise from [[#control-flow|control flow]]
 statements whose behavior depends on [=uniform value|non-uniform values=].
-These non-uniform values can be traced back to certain sources that are not
+
+> For example, a non-uniform control dependency arises when different invocations compute
+    different values for the condition of an
+    [=statement/if=], [=statement/break-if=], [=statement/while=], or [=statement/for=],
+    or different values for the selector of a [=statement/switch=].
+
+These non-uniform values can often be traced back to certain sources that are not
 statically proven to be uniform.
 These sources include, but are not limited to:
 * Mutable [=module scope|module-scope=] [=variables=]
@@ -9382,9 +9622,18 @@ These sources include, but are not limited to:
 * [=user-defined input datum|User-defined inputs=]
 * Certain [=built-in functions=] (see [[#uniformity-function-calls]])
 
-The remainder of this section is devoted to a description of this static
-analysis an implementation [=behavioral requirement|will=] perform to validate
-the WGSL program.
+To ensure correct and portable behavior, a WGSL implementation [=behavioral requirement|will=]
+perform a static <dfn>uniformity analysis</dfn>, attempting to prove that each collective operation
+executes in [=uniform control flow=].
+Subsequent subsections describe the analysis.
+
+A <dfn noexport>uniformity failure</dfn> [=behavioral requirement|will=] be triggered
+when [=uniformity analysis=] cannot prove that a particular [[#collective-operations|collective operation]] executes in [=uniform control flow=].
+* If a uniformity failure is triggered for a
+    [=builtin functions that compute a derivative|builtin function that computes a derivative=], then
+    a [=trigger/derivative_uniformity=] [=diagnostic=] is [=triggered=].
+    The [=diagnostic/triggering location=] for the diagnostic is the [=call site=] of that builtin.
+* If a uniformity failure is triggered for a [[#sync-builtin-functions|synchronization builtin]], a [=shader-creation error=] results.
 
 ### Terminology and Concepts ### {#uniformity-concepts}
 
@@ -9409,15 +9658,15 @@ The remaining subsections specify a static analysis that verifies that
 [[#collective-operations|collective operations]] are only executed in [=uniform
 control flow=].
 
-<div class="note">
-<span class=marker>Note:</span>This analysis has the following desirable properties:
-      - Sound (meaning that it rejects every program that would break the uniformity requirements of builtins)
-      - Linear time complexity (in the number of tokens in the program)
-      - Refactoring a piece of code into a function, or inlining a function, cannot make a shader invalid if it was valid before the transformation
-      - If the analysis refuses a program, it provides a straightforward chain of implications that can be used by the user agent to craft a good error message
+<div class="note"><span class=marker>Note:</marker>This analysis has the following desirable properties:
+      - Sound, meaning that a [=uniformity failure=] [=behavioral requirement|will=] be triggered for a program that would break the uniformity requirements of builtins.
+      - Linear time complexity, in the number of tokens in the program.
+      - Refactoring a piece of code into a function, or inlining a function, cannot make a shader invalid if it was valid before the transformation.
+      - If the analysis refuses a program, it provides a straightforward chain of implications that can be used by the user agent to craft a good error message.
 </div>
 
-Each function is analyzed, verifying that there is a context where it is safe to call this function. It rejects the program as invalid if there is no such context.
+Each function is analyzed, verifying that there is a context where it is safe to call this function.
+It triggers a [=uniformity failure=] if there is no such context.
 
 At the same time, it computes metadata about the function to help analyze its callers in turn.
 This means that the call graph must first be built, and functions must be analyzed from the leaves upwards, i.e. from functions that call no function outside the standard library toward the entry point.
@@ -9431,7 +9680,8 @@ Note: Another way of saying the same thing is that we do a topological sort of f
 Each function is analyzed in two phases.
 
 The first phase walks over the syntax of the function, building a directed graph along the way based on the rules in the following subsections.
-The second phase explores that graph, resulting in either rejecting the program, or computing the constraints on calling this function.
+The second phase explores that graph, computing the constraints on calling this function,
+and potentially triggering a [=uniformity failure=].
 
 <div class="note"><span class=marker>Note:</span>Apart from two special nodes [=RequiredToBeUniform=] and [=MayBeNonUniform=], all nodes can be understood as having one of the following meanings:
         - A specific point of the program [=shader-creation error|must=] be executed in [=uniform control flow=]
@@ -9446,7 +9696,10 @@ The second phase explores that graph, resulting in either rejecting the program,
         Reciprocally, to express that we cannot ensure the uniformity of something (e.g. a variable which holds the thread id), we add an edge from the corresponding node to [=MayBeNonUniform=].
         One way to understand this, is that [=MayBeNonUniform=] corresponds to the proposition False, so that X -> [=MayBeNonUniform=] is the same as saying that X is false.
 
-        A consequence of this interpretation is that every node reachable from [=RequiredToBeUniform=] corresponds to something which is required to be uniform for the program to be valid, and every node from which [=MayBeNonUniform=] is reachable corresponds to something whose uniformity we cannot guarantee. It follows that we have a uniformity violation (and thus reject the program) if there is any path from [=RequiredToBeUniform=] to [=MayBeNonUniform=].
+        A consequence of this interpretation is that every node reachable from [=RequiredToBeUniform=] corresponds to
+        something which is required to be uniform for the program to be valid, and every node from which
+        [=MayBeNonUniform=] is reachable corresponds to something whose uniformity we cannot guarantee.
+        It follows that we have a uniformity violation, triggering a [=uniformity failure=], if there is any path from [=RequiredToBeUniform=] to [=MayBeNonUniform=].
 </div>
 
 For each function, two tags are computed:
@@ -9518,7 +9771,7 @@ The following algorithm describes how to compute these tags for a given function
 * Walk over the syntax of the function, adding nodes and edges to the graph following the rules of the next sections ([[#func-var-value-analysis]], [[#uniformity-statements]], [[#uniformity-function-calls]], [[#uniformity-expressions]]), using [=CF_start=] as the starting control-flow for the function's body.
 * For each [=Value_return_i=] node, record which [=param_i=] nodes are reachable from it.
 * Look at which nodes are reachable from [=RequiredToBeUniform=].
-    * If this set includes the node [=MayBeNonUniform=], then reject the program.
+    * If this set includes the node [=MayBeNonUniform=], then trigger a [=uniformity failure=].
     * If this set includes [=CF_start=], then the [=call site tag=] for the function is [=CallSiteRequiredToBeUniform=].
     * Otherwise, the [=call site tag=] is [=CallSiteNoRestriction=].
     * For each [=param_i=] in this set, the corresponding [=parameter tag=] is [=ParameterRequiredToBeUniform=].
@@ -9653,7 +9906,7 @@ locations, but the store type for `arr` is `array<i32,1>` and the store type of 
 
 To simplify analysis, an assignment via *any* kind of [=partial reference=] is treated as if
 it does *not* modify every memory location in the associated [=originating variable=].
-This causes the analysis to be conservative, potentially rejecting
+This causes the analysis to be conservative, potentially triggering a [=uniformity failure=] for
 more programs than strictly necessary.
 </div>
 
@@ -9961,7 +10214,9 @@ Here is the list of exceptions:
 - All functions in [[#sync-builtin-functions]] have a [=call site tag=] of  [=CallSiteRequiredToBeUniform=].
     - The parameter `p` in [[#workgroupUniformLoad-builtin|workgroupUniformLoad]]
         has a [=parameter tag=] of [=ParameterRequiredToBeUniform=].
-- All functions in [[#derivative-builtin-functions]], [[#texturesample]], [[#texturesamplebias]], and [[#texturesamplecompare]] have a [=call site tag=] of [=CallSiteRequiredToBeUniform=] and a [=function tag=] of [=ReturnValueMayBeNonUniform=].
+- All functions in
+    [[#derivative-builtin-functions]], [[#texturesample]], [[#texturesamplebias]], and [[#texturesamplecompare]]
+    have a [=call site tag=] of [=CallSiteRequiredToBeUniform=], and a [=function tag=] of [=ReturnValueMayBeNonUniform=].
 - [[#arrayLength-builtin|arrayLength]] has a [=call site tag=] of
     [=CallSiteNoRestriction=], a [=function tag=] of [=NoRestriction=] and
     the input parameter `p` has a [=parameter tag=] of [=ParameterNoRestriction=]
@@ -10508,6 +10763,12 @@ A <dfn noexport>partial derivative</dfn> is the rate of change of a value along 
 Fragment shader invocations within the same [=quad=] collaborate to compute
 approximate partial derivatives.
 
+The <dfn noexport>builtin functions that compute a derivative</dfn> are:
+* [[#texturesample|textureSample]], [[#texturesamplebias|textureSampleBias]], and [[#texturesamplecompare|textureSampleCompare]]
+* [[#dpdx-builtin|dpdx]], [[#dpdxCoarse-builtin|dpdxCoarse]], and [[#dpdxFine-builtin|dpdxFine]]
+* [[#dpdy-builtin|dpdy]], [[#dpdyCoarse-builtin|dpdyCoarse]], and [[#dpdyFine-builtin|dpdyFine]]
+* [[#fwidth-builtin|fwidth]], [[#fwidthCoarse-builtin|fwidthCoarse]], and [[#fwidthFine-builtin|fwidthFine]]
+
 Partial derivatives of the *fragment coordinate* are computed implicitly as part
 of operation of the following built-in functions:
 * [[#texturesample|textureSample]],
@@ -10519,13 +10780,17 @@ For these, the derivatives help determine the mip levels of texels to be sampled
 
 Partial derivatives of *invocation-specified* values are computed by the
 built-in functions described in [[#derivative-builtin-functions]]:
-* `dpdx`, `dpdxCoarse`, and `dpdxFine` compute partial derivatives along the x axis.
-* `dpdy`, `dpdyCoarse`, and `dpdyFine` compute partial derivatives along the y axis.
-* `fwidth`, `fwidthCoarse`, and `fwidthFine` compute the Manhattan metric over the associated x and y partial derivatives.
+* [[#dpdx-builtin|dpdx]], [[#dpdxCoarse-builtin|dpdxCoarse]], and [[#dpdxFine-builtin|dpdxFine]] compute partial derivatives along the x axis.
+* [[#dpdy-builtin|dpdy]], [[#dpdyCoarse-builtin|dpdyCoarse]], and [[#dpdyFine-builtin|dpdyFine]] compute partial derivatives along the y axis.
+* [[#fwidth-builtin|fwidth]], [[#fwidthCoarse-builtin|fwidthCoarse]], and [[#fwidthFine-builtin|fwidthFine]]
+    compute the Manhattan metric over the associated x and y partial derivatives.
 
 Because neighbouring invocations collaborate to compute derivatives, these
-functions [=shader-creation error|must=] only be invoked in [=uniform control
-flow=] in a fragment shader.
+functions should only be invoked in [=uniform control flow=] in a fragment shader.
+For each call to one of these functions, a [=trigger/derivative_uniformity=] [=diagnostic=] is triggered if 
+[[#uniformity|uniformity analysis]] cannot prove the call occurs in uniform control flow.
+
+If one of these functions is called in non-uniform control flow, then the result is an [=indeterminate value=].
 
 ## Floating Point Evaluation ## {#floating-point-evaluation}
 
@@ -10825,6 +11090,7 @@ the source type is a floating point type with fewer exponent and mantissa bits t
 * <dfn for=syntax_kw noexport>`continue`</dfn>
 * <dfn for=syntax_kw noexport>`continuing`</dfn>
 * <dfn for=syntax_kw noexport>`default`</dfn>
+* <dfn for=syntax_kw noexport>`diagnostic`</dfn>
 * <dfn for=syntax_kw noexport>`discard`</dfn>
 * <dfn for=syntax_kw noexport>`else`</dfn>
 * <dfn for=syntax_kw noexport>`enable`</dfn>
@@ -10937,6 +11203,20 @@ The [=syntax/attribute=] names are:
 * `'size'`
 * `'vertex'`
 * `'workgroup_size'`
+
+The [=diagnostic filter=] severity control names names are:
+
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>severity_control_name</dfn> :
+
+    | `'error'`
+
+    | `'warning'`
+
+    | `'info'`
+
+    | `'off'`
+</div>
 
 The valid [=enable-extension=] names are listed in [[#enable-extensions-sec]] but in general have the same form as an [=identifier=]:
 
@@ -13787,9 +14067,10 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
 
 See [[#derivatives]].
 
-These functions:
+Calls to these functions:
 * [=shader-creation error|Must=] only be used in a [=fragment=] shader stage.
-* [=shader-creation error|Must=] only be invoked in [=uniform control flow=].
+* [=Trigger=] a [=trigger/derivative_uniformity=] [=diagnostic=] if [=uniformity analysis=]
+    cannot prove the call is in [=uniform control flow=].
 
 ### `dpdx` ### {#dpdx-builtin}
 <table class='data builtin'>
@@ -13805,6 +14086,8 @@ These functions:
     <td>Description
     <td>Partial derivative of `e` with respect to window x coordinates.
     The result is the same as either `dpdxFine(e)` or `dpdxCoarse(e)`.
+
+    Returns an [=indeterminate value=] if called in [=uniform control flow|non-uniform control flow=].
 </table>
 
 ### `dpdxCoarse` ### {#dpdxCoarse-builtin}
@@ -13821,6 +14104,8 @@ These functions:
     <td>Description
     <td>Returns the partial derivative of `e` with respect to window x coordinates using local differences.
     This may result in fewer unique positions that `dpdxFine(e)`.
+
+    Returns an [=indeterminate value=] if called in [=uniform control flow|non-uniform control flow=].
 </table>
 
 ### `dpdxFine` ### {#dpdxFine-builtin}
@@ -13836,6 +14121,8 @@ These functions:
   <tr>
     <td>Description
     <td>Returns the partial derivative of `e` with respect to window x coordinates.
+
+    Returns an [=indeterminate value=] if called in [=uniform control flow|non-uniform control flow=].
 </table>
 
 ### `dpdy` ### {#dpdy-builtin}
@@ -13852,6 +14139,8 @@ These functions:
     <td>Description
     <td>Partial derivative of `e` with respect to window y coordinates.
     The result is the same as either `dpdyFine(e)` or `dpdyCoarse(e)`.
+
+    Returns an [=indeterminate value=] if called in [=uniform control flow|non-uniform control flow=].
 </table>
 
 ### `dpdyCoarse` ### {#dpdyCoarse-builtin}
@@ -13868,6 +14157,8 @@ These functions:
     <td>Description
     <td>Returns the partial derivative of `e` with respect to window y coordinates using local differences.
     This may result in fewer unique positions that `dpdyFine(e)`.
+
+    Returns an [=indeterminate value=] if called in [=uniform control flow|non-uniform control flow=].
 </table>
 
 ### `dpdyFine` ### {#dpdyFine-builtin}
@@ -13883,6 +14174,8 @@ These functions:
   <tr>
     <td>Description
     <td>Returns the partial derivative of `e` with respect to window y coordinates.
+
+    Returns an [=indeterminate value=] if called in [=uniform control flow|non-uniform control flow=].
 </table>
 
 ### `fwidth` ### {#fwidth-builtin}
@@ -13898,6 +14191,8 @@ These functions:
   <tr>
     <td>Description
     <td>Returns `abs(dpdx(e)) + abs(dpdy(e))`.
+
+    Returns an [=indeterminate value=] if called in [=uniform control flow|non-uniform control flow=].
 </table>
 
 ### `fwidthCoarse` ### {#fwidthCoarse-builtin}
@@ -13913,6 +14208,8 @@ These functions:
   <tr>
     <td>Description
     <td>Returns `abs(dpdxCoarse(e)) + abs(dpdyCoarse(e))`.
+
+    Returns an [=indeterminate value=] if called in [=uniform control flow|non-uniform control flow=].
 </table>
 
 ### `fwidthFine` ### {#fwidthFine-builtin}
@@ -13928,6 +14225,8 @@ These functions:
   <tr>
     <td>Description
     <td>Returns `abs(dpdxFine(e)) + abs(dpdyFine(e))`.
+
+    Returns an [=indeterminate value=] if called in [=uniform control flow|non-uniform control flow=].
 </table>
 
 ## Texture Built-in Functions ## {#texture-builtin-functions}
@@ -14557,7 +14856,9 @@ The number of samples per texel in the multisampled texture.
 Samples a texture.
 
 [=shader-creation error|Must=] only be used in a [=fragment=] shader stage.
-[=shader-creation error|Must=] only be invoked in [=uniform control flow=].
+
+If [=uniformity analysis=] cannot prove a call to this function is in [=uniform control flow=],
+then a [=trigger/derivative_uniformity=] [=diagnostic=] is [=triggered=].
 
 <table class='data'>
   <thead>
@@ -14699,12 +15000,16 @@ Samples a texture.
 
 The sampled value.
 
+An [=indeterminate value=] results if called in [=uniform control flow|non-uniform control flow=].
+
 ### `textureSampleBias` ### {#texturesamplebias}
 
 Samples a texture with a bias to the mip level.
 
 [=shader-creation error|Must=] only be used in a [=fragment=] shader stage.
-[=shader-creation error|Must=] only be invoked in [=uniform control flow=].
+
+If [=uniformity analysis=] cannot prove a call to this function is in [=uniform control flow=],
+then a [=trigger/derivative_uniformity=] [=diagnostic=] is [=triggered=].
 
 <table class='data'>
   <thead>
@@ -14801,13 +15106,16 @@ Samples a texture with a bias to the mip level.
 
 The sampled value.
 
+An [=indeterminate value=] results if called in [=uniform control flow|non-uniform control flow=].
 
 ### `textureSampleCompare` ### {#texturesamplecompare}
 
 Samples a depth texture and compares the sampled depth values against a reference value.
 
 [=shader-creation error|Must=] only be used in a [=fragment=] shader stage.
-[=shader-creation error|Must=] only be invoked in [=uniform control flow=].
+
+If [=uniformity analysis=] cannot prove a call to this function is in [=uniform control flow=],
+then a [=trigger/derivative_uniformity=] [=diagnostic=] is [=triggered=].
 
 <table class='data'>
   <thead>
@@ -14902,6 +15210,7 @@ If the sampler uses bilinear filtering then the returned value is
 the filtered average of these values, otherwise the comparison result of a
 single texel is returned.
 
+An [=indeterminate value=] results if called in [=uniform control flow|non-uniform control flow=].
 
 ### `textureSampleCompareLevel` ### {#texturesamplecomparelevel}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -645,7 +645,7 @@ The following table lists the standard set of triggering rules that can be filte
   <tr>
     <td><dfn noexport dfn-for="trigger">derivative_uniformity</dfn>
     <td>[=severity/error=]
-    <td>The [=call site=] for any of the
+    <td>The [=call site=] for any
         [=builtin functions that compute a derivative|builtin function that computes a derivative=].
         That is, the [=call site=] for any of:
         * the [[#derivative-builtin-functions|derivative builtin functions]]
@@ -706,8 +706,10 @@ A `@diagnostic` attribute [=shader-creation error|must not=] appear anywhere els
     <tr><td>Beginning of a [=syntax/continuing_compound_statement=].<td>The [=syntax/continuing_compound_statement=].
 </table>
 
-Note: A [=function body=], a [=case clause=], a [=default-alone clause=],
-and the bodies of [=syntax/else_if_clause=] and [=syntax/else_clause=] are themselves [=compound statements=].
+Note: The following are also [=compound statements=]:
+a [=function body=], a [=case clause=], a [=default-alone clause=],
+the bodies of [=statement/while=] and [=statement/for=] loops,
+and the bodies of [=syntax/if_clause=], [=syntax/else_if_clause=], and [=syntax/else_clause=].
 
 <div class='example wgsl global-scope' heading='Range diagnostic filter on texture sampling'>
   <xmp highlight='rust'>
@@ -1234,8 +1236,8 @@ Section [[#context-dependent-name-tokens]] lists all such tokens.
 
 A <dfn noexport>diagnostic rule name</dfn> is a [=token=] used to name a diagnostic [=diagnostic/triggering rule=],
 in either a [=range diagnostic filter=] or a [=global diagnostic filter=].
-The spelling of the token may be the same as an [=identifier=], [=keyword=], or [=reserved word=],
-but is not interpeted as any of those.
+The spelling of the token may be the same as an [=identifier=] but does not [=resolves|resolve to=] a declared object.
+The token must not be a [=keyword=] or [=reserved word=].
 
 See [[#diagnostics]].
 
@@ -9624,7 +9626,8 @@ statements whose behavior depends on [=uniform value|non-uniform values=].
 > For example, a non-uniform control dependency arises when different invocations compute
     different values for the condition of an
     [=statement/if=], [=statement/break-if=], [=statement/while=], or [=statement/for=],
-    or different values for the selector of a [=statement/switch=].
+    different values for the selector of a [=statement/switch=],
+    or the left-hand operand of a short-circuiting binary operator (`&&` or `||`).
 
 These non-uniform values can often be traced back to certain sources that are not
 statically proven to be uniform.
@@ -9680,10 +9683,12 @@ control flow=].
       - If the analysis refuses a program, it provides a straightforward chain of implications that can be used by the user agent to craft a good error message.
 </div>
 
-Each function is analyzed, verifying that there is a context where it is safe to call this function.
-It triggers a [=uniformity failure=] if there is no such context.
+Each function is analyzed, trying to ensure two things:
+    * Uniformity requirements are satisfied when it calls other functions, and
+    * Uniformity requirements are satisfied whenever it is called.
+A [=uniformity failure=] is triggered if either of these two checks fail.
 
-At the same time, it computes metadata about the function to help analyze its callers in turn.
+As part of this work, the analysis computes metadata about the function to help analyze its callers in turn.
 This means that the call graph must first be built, and functions must be analyzed from the leaves upwards, i.e. from functions that call no function outside the standard library toward the entry point.
 This way, whenever a function is analyzed, the metadata for all of its callees has already been computed.
 There is no risk of being trapped in a cycle, as recurrence is forbidden in the language.
@@ -9762,7 +9767,7 @@ For each [=formal parameter=] of a function, one or two tags are computed:
       <td><dfn noexport>CallSiteRequiredToBeUniform.S</dfn>,<br>
           where |S| is one of the severities: [=severity/error=], [=severity/warning=], or [=severity/info=].
       <td>The function must only be called from [=uniform control flow=].
-          Otherwise a diagnostic of with severity |S| will be triggered.
+          Otherwise a diagnostic with severity |S| will be triggered.
 
           Associated with a [=witness set=].
   <tr><td><dfn noexport>CallSiteNoRestriction</dfn>
@@ -9789,7 +9794,7 @@ For each [=formal parameter=] of a function, one or two tags are computed:
       <td><dfn noexport>ParameterRequiredToBeUniform.S</dfn>,<br>
           where |S| is one of the severities: [=severity/error=], [=severity/warning=], or [=severity/info=].
       <td>The parameter must be a [=uniform value=].
-          Otherwise a diagnostic of with severity |S| will be triggered.
+          Otherwise a diagnostic with severity |S| will be triggered.
 
           Associated with a [=witness set=].
   <tr><td><dfn noexport>ParameterRequiredToBeUniformForReturnValue</dfn>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9676,7 +9676,7 @@ The remaining subsections specify a static analysis that verifies that
 [[#collective-operations|collective operations]] are only executed in [=uniform
 control flow=].
 
-<div class="note"><span class=marker>Note:</marker>This analysis has the following desirable properties:
+<div class="note"><span class=marker>Note:</span>This analysis has the following desirable properties:
       - Sound, meaning that a [=uniformity failure=] [=behavioral requirement|will=] be triggered for a program that would break the uniformity requirements of builtins.
       - Linear time complexity, in the number of tokens in the program.
       - Refactoring a piece of code into a function, or inlining a function, cannot make a shader invalid if it was valid before the transformation.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9695,15 +9695,13 @@ There is no risk of being trapped in a cycle, as recurrence is forbidden in the 
 
 Note: Another way of saying the same thing is that we do a topological sort of functions ordered by the "is a (possibly indirect) callee of" partial order, and analyze them in that order.
 
-Additionally, the analysis computes and propagates information about
-calls to functions that must only be invoked in uniform control flow.
-This is used to [=triggered|trigger=] and potentially filter [=diagnostics=] for [=uniformity failures=] on those calls.
-A <dfn>witness</dfn> is a pair containing a [=call site=], and a [=diagnostic/triggering rule=].
-A <dfn>witness set</dfn> is a set of [=witnesses=], and only supports adding elements, not removing elements.
-In particular, a witness set is only formed via the following operations:
-* Create an empty set.
-* Create a witness set containing a single witness.
-* Form a witness set from the union of two others.
+Additionally, for each function call, the analysis computes and propagates
+the set of [=diagnostic/triggering rules=], if any, that would be triggered if that call cannot be proven to be in uniform control flow.
+We call this the <dfn noexport>potential-trigger-set</dfn> for the call.
+The elements of this set are drawn from two possibilites:
+* [=trigger/derivative_uniformity=], for functions relying on computing a derivative, or
+* an unnamed triggering rule, for the uniformity requirements that cannot be filtered.
+    * This is used for compute shader functions relying on [[#sync-builtin-functions|synchronization functions]].
 
 ### Analyzing the Uniformity Requirements of a Function ### {#uniformity-function}
 
@@ -9770,7 +9768,7 @@ For each [=formal parameter=] of a function, one or two tags are computed:
       <td>The function must only be called from [=uniform control flow=].
           Otherwise a diagnostic with severity |S| will be triggered.
 
-          Associated with a [=witness set=].
+          Associated with a [=potential-trigger-set=].
   <tr><td><dfn noexport>CallSiteNoRestriction</dfn>
       <td>The function may be called from [=uniform control flow|non-uniform control flow=].
 </table>
@@ -9797,7 +9795,7 @@ For each [=formal parameter=] of a function, one or two tags are computed:
       <td>The parameter must be a [=uniform value=].
           Otherwise a diagnostic with severity |S| will be triggered.
 
-          Associated with a [=witness set=].
+          Associated with a [=potential-trigger-set=].
   <tr><td><dfn noexport>ParameterNoRestriction</dfn>
       <td>The parameter value has no uniformity requirement.
 </table>
@@ -9829,7 +9827,7 @@ The following algorithm describes how to compute these tags for a given function
 * Create the following nodes:
     * <dfn noexport>RequiredToBeUniform.error</dfn>, <dfn noexport>RequiredToBeUniform.warning</dfn>, and <dfn noexport>RequiredToBeUniform.info</dfn>.
         Collectively these are called the <dfn noexport>RequiredToBeUniform.S</dfn> nodes.
-        * Each such node is associated with a [=witness set=], which is initially empty.
+        * Each such node is associated with a [=potential-trigger-set=], which is initially empty.
     * <dfn noexport>MayBeNonUniform</dfn>
     * <dfn noexport>CF_start</dfn>, representing the uniformity requirement for control flow when the function begins executing.
     * <dfn noexport>param_i</dfn>, where *i* ranges over the function's [=formal parameters=].
@@ -9849,14 +9847,14 @@ The following algorithm describes how to compute these tags for a given function
 * For each severity *S* in the order {[=severity/error=], [=severity/warning=], [=severity/info=]}, perform the following:
     * Let *R.S* be the set of unvisited nodes reachable from [=RequiredToBeUniform.S=].
     * Mark the [=interior nodes=] in *R.S* as visited.
-    * Let *W* be the [=witness set=] associated with [=RequiredToBeUniform.S=].
+    * Let *PTS* be the [=potential-trigger-set=] associated with [=RequiredToBeUniform.S=].
     * If *R.S* includes the node [=MayBeNonUniform=], then trigger a [=uniformity failure=]:
-         * For each [=witness=] *w* in *W*, [=triggered|trigger=] a diagnostic with severity *S*, using the call site and triggering rule from *w*.
+         * [=triggered|Trigger=] a diagnostic with severity *S* and triggering rule *t*, for each *t* in *PTS*.
     * Otherwise:
         * If *R.S* includes [=CF_start=], and the [=call site tag=] has not been updated since initialization, then
-             set the [=call site tag=] to [=CallSiteRequiredToBeUniform.S=], and set its [=witness set=] to *W*.
+             set the [=call site tag=] to [=CallSiteRequiredToBeUniform.S=], and set its [=potential-trigger-set=] to *PTS*.
         * For each [=param_i=] in *R.S*, if its corresponding [=parameter tag=] has not been updated since initialization, then
-             set that tag to [=ParameterRequiredToBeUniform.S=], and set its [=witness set=] to *W*.
+             set that tag to [=ParameterRequiredToBeUniform.S=], and set its [=potential-trigger-set=] to *PTS*.
 * Mark all the [=interior nodes=] as unvisited.
 * If [=Value_return=] exists, let *VR* be the set of nodes reachable from [=Value_return=].
     * If *VR* includes [=MayBeNonUniform=], then set the [=function tag=] to [=ReturnValueMayBeNonUniform=].
@@ -10280,14 +10278,14 @@ The most complex rule is for function calls:
 - Create two new nodes, named <dfn noexport>Result</dfn> and <dfn noexport>CF_after</dfn>
 - If the [=call site tag=] of the function is [=CallSiteRequiredToBeUniform.S=], then:
     - Add an edge from [=RequiredToBeUniform.S=] to the last [=CF_i=].
-    - Add the [=witness set=] of the [=call site tag=] to the witness set associated with [=RequiredToBeUniform.S=].
+    - Add the members of the [=potential-trigger-set=] of the [=call site tag=] to the potential-trigger-set associated with [=RequiredToBeUniform.S=].
 - Otherwise add an edge from [=CF_after=] to the last [=CF_i=]
 - If the [=function tag=] is [=ReturnValueMayBeNonUniform=], then add an edge from [=Result=] to [=MayBeNonUniform=]
 - Add an edge from [=Result=] to [=CF_after=]
 - For each argument *i*:
     - If the corresponding [=parameter tag=] is [=ParameterRequiredToBeUniform.S=], then:
         - Add an edge from [=RequiredToBeUniform.S=] to [=arg_i=].
-        - Add the [=witness set=] of the [=parameter tag=] to the witness set associated with [=RequiredToBeUniform.S=].
+        - Add the members of the [=potential-trigger-set=] of the [=parameter tag=] to the potential-trigger-set associated with [=RequiredToBeUniform.S=].
     - If the [=parameter return tag=] is [=ParameterReturnRequiredToBeUniform=], then add an edge from [=Result=] to [=arg_i=]
     - If the corresponding parameter has a [=pointer parameter tag=] of [=PointerParameterMayBeNonUniform=], then add an edge from *Vout*(*call*) to [=MayBeNonUniform=]
     - If the parameter is a pointer in the [=address spaces/function=] address space, add an edge from *Vout*(*call*) to each corresponding [=arg_i=] for the reachable parameters recorded previously
@@ -10306,23 +10304,24 @@ Most built-in functions have tags of:
 Here is the list of exceptions:
 - A call to a function in [[#sync-builtin-functions]]:
     - Has a [=function tag=] of [=NoRestriction=].
-    - Has a [=call site tag=] of [=CallSiteRequiredToBeUniform.S|CallSiteRequiredToBeUniform.error=].
-        The tag's associated [=witness=] is the source location of the call site, combined with an unnamed [=diagnostic/triggering rule=].
+    - Has a [=call site tag=] of [=CallSiteRequiredToBeUniform.S|CallSiteRequiredToBeUniform.error=], with [=potential-trigger-set=]
+        consisting of an unnamed [=diagnostic/triggering rule=].
         - Note: The triggering rule has no name, and so it cannot be filtered.
     - Additionally for the case of a call to [[#workgroupUniformLoad-builtin|workgroupUniformLoad]],
-        the parameter `p` has a [=parameter tag=] of [=ParameterRequiredToBeUniform.S|ParameterRequiredToBeUniform.error=].
-        The tag's associated [=witness=] is the source location of the call site, combined with an unnamed [=diagnostic/triggering rule=].
+        the parameter `p` has a [=parameter tag=] of [=ParameterRequiredToBeUniform.S|ParameterRequiredToBeUniform.error=],
+        with [=potential-trigger-set=] consisting of an unnamed [=diagnostic/triggering rule=].
 - A call to a function in
     [[#derivative-builtin-functions]], [[#texturesample]], [[#texturesamplebias]], and [[#texturesamplecompare]]:
     - Has a [=function tag=] of [=ReturnValueMayBeNonUniform=].
     - Has a [=call site tag=] as follows:
-        - Let *w* be the [=witness=] formed by combining the source location of the call site, with the [=trigger/derivative_uniformity=] triggering rule.
-        - Let *DF* be the [=nearest enclosing diagnostic filter=] for *w*.
+        - Let *DF* be the [=nearest enclosing diagnostic filter=] for the call site location and triggering rule [=trigger/derivative_uniformity=]
         - If *DF* exists, then let *S* be the *DF*'s new severity parameter.
-            - If *S* is the severity [=severity/off=], the call site tag is [=CallSiteNoRestriction=]. Throw away the witness *w*.
-            - Otherwise the call site tag is [=CallSiteRequiredToBeUniform.S=], with witness *w*.
+            - If *S* is the severity [=severity/off=], the call site tag is [=CallSiteNoRestriction=].
+            - Otherwise the call site tag is [=CallSiteRequiredToBeUniform.S=], with [=potential-trigger-set=]
+                consisting of a [=trigger/derivative_uniformity=] element.
         - If there is no such *DF*,
-            the call site tag is [=CallSiteRequiredToBeUniform.S|CallSiteRequiredToBeUniform.error=], with witness *w*.
+            the call site tag is [=CallSiteRequiredToBeUniform.S|CallSiteRequiredToBeUniform.error=], with [=potential-trigger-set=] 
+            consisting of a [=trigger/derivative_uniformity=] element.
 
 Note: A WGSL implementation will ensure that if control flow prior to a
 function call is [=uniform control flow|uniform=], it will also be uniform

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -727,7 +727,7 @@ and the bodies of [=syntax/if_clause=], [=syntax/else_if_clause=], and [=syntax/
 
 A <dfn noexport>global diagnostic filter</dfn> is a diagnostic filter whose [=affected range=] is the whole WGSL program.
 It is a [=directive=], thus appearing before any [=module scope|module-scope=] declarations.
-It is spelled like the attribute form, but without the leading `@` (U+0040) codepoint, and with a terminating semicolon.
+It is spelled like the attribute form, but without the leading `@` (U+0040) code point, and with a terminating semicolon.
 
 <div class='example wgsl global-scope' heading='Global diagnostic filter for derivative uniformity'>
   <xmp highlight='rust'>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -10300,12 +10300,14 @@ Here is the list of exceptions:
 - A call to a function in
     [[#derivative-builtin-functions]], [[#texturesample]], [[#texturesamplebias]], and [[#texturesamplecompare]]:
     - Has a [=function tag=] of [=ReturnValueMayBeNonUniform=].
-    - Has a [=call site tag=] of [=CallSiteRequiredToBeUniform.S=]:
-        - Where *S* is:
-            - the NS (new severity) parameter of the [=nearest enclosing diagnostic filter=]
-                for the combination of the call site and the [=trigger/derivative_uniformity=] triggering rule.
-            - [=severity/error=], if no such filter exists.
-        - The tag's associated [=witness=] is the source location of the call site, combined with the [=trigger/derivative_uniformity=] triggering rule.
+    - Has a [=call site tag=] as follows:
+        - Let *w* be the [=witness=] formed by combining the source location of the call site, with the [=trigger/derivative_uniformity=] triggering rule.
+        - Let *DF* be the [=nearest enclosing diagnostic filter=] for *w*.
+        - If *DF* exists, then let *S* be the *DF*'s new severity parameter.
+            - If *S* is the severity [=severity/off=], the call site tag is [=CallSiteNoRestriction=]. Throw away the witness *w*.
+            - Otherwise the call site tag is [=CallSiteRequiredToBeUniform.S=], with witness *w*.
+        - If there is no such *DF*,
+            the call site tag is [=CallSiteRequiredToBeUniform.S|CallSiteRequiredToBeUniform.error=], with witness *w*.
 
 - [[#arrayLength-builtin|arrayLength]]:
     - Has a [=function tag=] of [=NoRestriction=].

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -10691,7 +10691,7 @@ end of the loop body (CF_after_if).
 
 This example is modification of the [[#uniformity-example1|first example]], but
 uses a user-defined function call.
-The analysis tags the [=parameter return tag=] both parameters of `scale` as
+The analysis tags the [=parameter return tag=] of both parameters of `scale` as
 [=ParameterReturnRequiredToBeUniform=].
 This leads to the path in `main` between the return value of the `scale`
 function call and the `position` built-in value.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -618,7 +618,7 @@ Triggered diagnostics [=behavioral requirement|will=] be processed as follows:
     * A [=program error=] is generated.
          * The error is a [=shader-creation error=] if the diagnostic was triggered at [=shader module creation=] time.
          * The error is a [=pipeline-creation error=] if the diagnostic was triggered at [=pipeline creation=] time.
-6. If processing during [=shader module creation=] time, the remaining diagnostics populates the
+6. If processing during [=shader module creation=] time, the remaining diagnostics populate the
     {{GPUCompilationInfo/messages}} member of the WebGPU {{GPUCompilationInfo}} object.
 7. If processing during [=pipeline creation=], the [=severity/error=] diagnostics are reported
     in the nearest enclosing WebGPU [=GPU error scope=].
@@ -627,6 +627,8 @@ Triggered diagnostics [=behavioral requirement|will=] be processed as follows:
 Note: The rules allow an implementation to stop processing a WGSL program as soon as an error is detected.
 Additionally, an analysis for a particular kind of warning can stop on the first warning,
 and an analysis for a particular kind of info diagnostic can stop on the first occurrence.
+WGSL does not specify the order to perform different kinds of analyses, or an ordering within a single analysis.
+Therefore, for the same WGSL program, different implementations may report different instances of diagnostics with the same severity.
 
 ### Filterable Triggering Rules ### {#filterable-triggering-rules}
 
@@ -678,11 +680,11 @@ Applying a diagnostic filter *DF*(*AR*,*NS*,*TR*) to a diagnostic *D* has the fo
         set *D*'s [=diagnostic/severity=] property to *NS*.
 * Otherwise, *D* is unchanged.
 
-A <dfn noexport>range diagnostic filter</dfn> is a [=diagnostic filter=] that is applied to each
-diagnostic whose [=diagnostic/triggering location=] falls within a specified range of source text,
-and when no other more specific filter applies.
+A <dfn noexport>range diagnostic filter</dfn> is a [=diagnostic filter=] whose [=affected range=] is a specified
+range of source text.
 A range diagnostic filter is specified as a `@diagnostic` [=attribute=] at the start of the affected source range,
-as specified in the following table.  A `@diagnostic` attribute [=shader-creation error|must not=] appear anywhere else.
+as specified in the following table.
+A `@diagnostic` attribute [=shader-creation error|must not=] appear anywhere else.
 
 <table class='data'>
   <caption>Placement of a range diagnostic filter</caption>
@@ -763,9 +765,11 @@ If the affected range of DF1 overlaps with the affected range of DF2, then
 either DF1's affected range is fully contained in DF2's affected range, or the other way around.
 
 The <dfn noexport>nearest enclosing diagnostic filter</dfn> for source location *L* and triggering rule *TR*,
-if one exists, is the diagnostic filter *DF(AR,NS,TR)* where *L* falls in the affected range *AR*,
-and if there is another filter *DF'(AR',NS',TR)* where *L* falls in *AR'*, then *AR* is contained
-in *AR'*. Because affected ranges nest, the nearest diagnostic is unique, or does not exist.
+if one exists, is the diagnostic filter *DF(AR,NS,TR)* where:
+* *L* falls in the affected range *AR*, and
+* If there is another filter *DF'(AR',NS',TR)* where *L* falls in *AR'*, then *AR* is contained in *AR'*.
+
+Because affected ranges nest, the nearest enclosing diagnostic is unique, or does not exist.
 
 # Textual Structure # {#textual-structure}
 
@@ -9693,7 +9697,7 @@ A <dfn>witness</dfn> is a pair containing a [=call site=], and a [=diagnostic/tr
 A <dfn>witness set</dfn> is a set of [=witnesses=], and only supports adding elements, not removing elements.
 In particular, a witness set is only formed via the following operations:
 * Create an empty set.
-* Create a witness set containing a single source location.
+* Create a witness set containing a single witness.
 * Form a witness set from the union of two others.
 
 ### Analyzing the Uniformity Requirements of a Function ### {#uniformity-function}
@@ -9730,7 +9734,7 @@ and potentially triggering a [=uniformity failure=].
         path from [=RequiredToBeUniform.error=] to [=MayBeNonUniform=].
 
         The nodes [=RequiredToBeUniform.warning=] and [=RequiredToBeUniform.info=] are used in a similar way,
-        but instead determine when [=severity/warning=] or [=severity/info=] [=diagnostics=] should be triggered:
+        but instead help determine when [=severity/warning=] or [=severity/info=] [=diagnostics=] should be triggered:
         *   If there is a path from [=RequiredToBeUniform.warning=] to [=MayBeNonUniform=], then a [=severity/warning=]
             [=diagnostic=] will be triggered.
         *   If there is a path from [=RequiredToBeUniform.info=] to [=MayBeNonUniform=], then an [=severity/info=]
@@ -9743,14 +9747,11 @@ For each function, two tags are computed:
   * A <dfn noexport>call site tag</dfn> describing the control flow uniformity requirements on the [=call sites=] of the function, and
   * A <dfn noexport>function tag</dfn> describing the function's effects on uniformity.
 
-Additionally, for each [=formal parameter=] of a function, a [=parameter tag=] is
-computed and, if the parameter is a [=address spaces/function=] address space
-pointer, a [=pointer parameter tag=] is also computed.
-The <dfn noexport>parameter tag</dfn> describes the uniformity requirement of
-the parameter value.
-The <dfn noexport>pointer parameter tag</dfn> describes whether the value
-stored in the memory pointed to by the parameter becomes [=uniform
-value|non-uniform=] during the execution of the function call.
+For each [=formal parameter=] of a function, one or two tags are computed:
+  * A <dfn noexport>parameter tag</dfn> describes the uniformity requirement of the parameter value.
+  * A <dfn neoxport>pointer parameter tag</dfn>, when the parameter type is a pointer into the  [=address spaces/function=] address space.
+      The tag describes whether the value in the memory pointed to by the parameter may become
+      [=uniform value|non-uniform=] during the execution of the function call.
 
 <table class='data'>
   <caption>[=Call site tag=] values</caption>
@@ -9827,12 +9828,12 @@ The following algorithm describes how to compute these tags for a given function
     * The [=function tag=] is initialized to [=NoRestriction=].
     * The [=call site tag=] is initialized to [=CallSiteNoRestriction=].
     * The [=parameter tag=] for each [=param_i=] is initialized to [=ParameterNoRestriction=].
+    * The [=pointer parameter tag=] for each [=param_i=], if it exists, is initialized to [=PointerParameterNoRestriction=].
 * For each severity *S* in the order {[=severity/error=], [=severity/warning=], [=severity/info=]}, perform the following:
     * Let *R.S* be the set of nodes reachable from [=RequiredToBeUniform.S=].
     * Let *W* be the [=witness set=] associated with [=RequiredToBeUniform.S=].
     * If *R.S* includes the node [=MayBeNonUniform=], then trigger a [=uniformity failure=]:
-         * For each witness *w* in *W*, trigger a diagnostic with severity *S*, using the call site and triggering rule from *w*.
-         * Exit this loop, i.e. the loop over *S*.
+         * For each [=witness=] *w* in *W*, [=triggered|trigger=] a diagnostic with severity *S*, using the call site and triggering rule from *w*.
     * Otherwise:
         * If *R.S* includes [=CF_start=], and the [=call site tag=] has not been updated since initialization, then
              set the [=call site tag=] to [=CallSiteRequiredToBeUniform.S=], and set its [=witness set=] to *W*.
@@ -9846,10 +9847,14 @@ The following algorithm describes how to compute these tags for a given function
          For pointer parameters, handle the distinction between uniformity of the pointer
          value and the uniformity of the contents of the memory pointed at.
 * For each [=Value_return_i=] node, let *VRi* be the set of nodes reachable from [=Value_return_i=].
-    * If *VRi* includes [=MayBeNonUniform=], the corresponding [=pointer parameter tag=] is [=PointerParameterMayBeNonUniform=].
-    * Otherwise, the corresponding [=pointer parameter tag=] is [=PointerParameterNoRestriction=].
+    * If *VRi* includes [=MayBeNonUniform=], set the corresponding [=pointer parameter tag=] to [=PointerParameterMayBeNonUniform=].
 
 Note: The entire graph can be destroyed at this point. The tags described above are all that we need to remember to analyze callers of this function.
+However, the graph contains information that can be used to provide more informative diagnostics.
+For example a value in a one function may not be provably [=uniform value|uniform=],
+which then contributes to triggering a uniformity failure in another function.
+An informative diagnostic would describe the non-uniform value, as well as the function call at the diagnostic's
+[=diagnostic/triggering location|triggered location=].
 
 ### Pointer Desugaring ### {#pointer-desugar}
 
@@ -10262,7 +10267,9 @@ The most complex rule is for function calls:
 - If the [=function tag=] is [=ReturnValueMayBeNonUniform=], then add an edge from [=Result=] to [=MayBeNonUniform=]
 - Add an edge from [=Result=] to [=CF_after=]
 - For each argument *i*:
-    - If the corresponding [=parameter tag=] is [=ParameterRequiredToBeUniform.S=], then add an edge from [=RequiredToBeUniform.S=] to [=arg_i=]
+    - If the corresponding [=parameter tag=] is [=ParameterRequiredToBeUniform.S=], then:
+        - Add an edge from [=RequiredToBeUniform.S=] to [=arg_i=].
+        - Add the [=witness set=] of the [=parameter tag=] to the witness set associated with [=RequiredToBeUniform.S=].
     - Otherwise if the [=parameter tag=] is [=ParameterRequiredToBeUniformForReturnValue=], then add an edge from [=Result=] to [=arg_i=]
     - If the corresponding parameter has a [=pointer parameter tag=] of [=PointerParameterMayBeNonUniform=], then add an edge from *Vout*(*call*) to [=MayBeNonUniform=]
     - If the parameter is a pointer in the [=address spaces/function=] address space, add an edge from *Vout*(*call*) to each corresponding [=arg_i=] for the reachable parameters recorded previously
@@ -10274,7 +10281,7 @@ A [=value constructor=] expression is analyzed as if it were a function call wit
 Most built-in functions have tags of:
 - A [=call site tag=] of [=CallSiteNoRestriction=].
 - A [=function tag=] of [=NoRestriction=].
-- For each parameter, a [=parameter tag|tag=] of [=ParameterRequiredToBeUniformForReturnValue=].
+- For each parameter, a [=parameter tag=] of [=ParameterRequiredToBeUniformForReturnValue=].
 
 Here is the list of exceptions:
 - A call to a function in [[#sync-builtin-functions]]:
@@ -10458,9 +10465,9 @@ If implementers want to provide developers with a diagnostic mode that shows for
 - Run the (mandatory, normative) analysis described in the previous subsections, keeping the graph for every function.
 - Reverse all edges in all of those graphs
 - Go through each function, starting with the entry point and never visiting a function before having visited all of its callers:
-    - Add an edge from [=MayBeNonUniform=] to every argument that was non-uniform in at least one caller
-    - Add an edge from [=MayBeNonUniform=] to [=CF_start=] if the function was called in non-uniform control-flow in at least one caller
-    - Look at which nodes are reachable from [=MayBeNonUniform=]. Every node visited is an expression or point in the control-flow whose uniformity cannot be proven by the analysis
+    - Add an edge from [=MayBeNonUniform=] to every argument that was non-uniform in at least one caller.
+    - Add an edge from [=MayBeNonUniform=] to [=CF_start=] if the function was called in non-uniform control-flow in at least one caller.
+    - Look at which nodes are reachable from [=MayBeNonUniform=]. Every node visited is an expression or point in the control-flow whose uniformity cannot be proven by the analysis.
 
 Any node which is not visited by these reachability analyses can be proven to be uniform by the analysis (and so it would be safe to call a derivative or similar function there).
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -645,8 +645,9 @@ The following table lists the standard set of triggering rules that can be filte
   <tr>
     <td><dfn noexport dfn-for="trigger">derivative_uniformity</dfn>
     <td>[=severity/error=]
-    <td>A call to a [=builtin functions that compute a derivative|builtin function that computes a derivative=].
-        That is, a call to any of:
+    <td>The [=call site=] for any of the
+        [=builtin functions that compute a derivative|builtin function that computes a derivative=].
+        That is, the [=call site=] for any of:
         * the [[#derivative-builtin-functions|derivative builtin functions]]
         * [[#texturesample|textureSample]]
         * [[#texturesamplebias|textureSampleBias]]
@@ -7921,7 +7922,8 @@ In detail, when a function call is executed the following steps occur:
     If the called function [=return value|returns a value=], that value is supplied for the
     value of the function call expression.
 
-The location of a function call is referred to as a <dfn noexport>call site</dfn>.
+The location of a function call is referred to as a <dfn noexport>call site</dfn>, specifically
+the location of the first [=token=] in the parsed instance of the [=syntax/call_phrase=] grammar rule.
 Call sites are a [=dynamic context=].
 As such, the same textual location may represent multiple call sites.
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9839,6 +9839,7 @@ The following algorithm describes how to compute these tags for a given function
         create a <dfn noexport>Value_return_i</dfn> node.
         This represents the function's effect on the uniformity of the value pointed to by the *i*<sup>th</sup> parameter.
 * Walk over the syntax of the function, adding nodes and edges to the graph following the rules of the next sections ([[#func-var-value-analysis]], [[#uniformity-statements]], [[#uniformity-function-calls]], [[#uniformity-expressions]]), using [=CF_start=] as the starting control-flow for the function's body.
+    * The nodes added in this step are called <dfn noexport>interior nodes</dfn>.
 * Initialize as follows:
     * The [=function tag=] is initialized to [=NoRestriction=].
     * The [=call site tag=] is initialized to [=CallSiteNoRestriction=].
@@ -9847,7 +9848,7 @@ The following algorithm describes how to compute these tags for a given function
     * The [=pointer parameter tag=] for each [=param_i=], if it exists, is initialized to [=PointerParameterNoRestriction=].
 * For each severity *S* in the order {[=severity/error=], [=severity/warning=], [=severity/info=]}, perform the following:
     * Let *R.S* be the set of unvisited nodes reachable from [=RequiredToBeUniform.S=].
-    * Mark the nodes in *R.S* as visited.
+    * Mark the [=interior nodes=] in *R.S* as visited.
     * Let *W* be the [=witness set=] associated with [=RequiredToBeUniform.S=].
     * If *R.S* includes the node [=MayBeNonUniform=], then trigger a [=uniformity failure=]:
          * For each [=witness=] *w* in *W*, [=triggered|trigger=] a diagnostic with severity *S*, using the call site and triggering rule from *w*.
@@ -9856,11 +9857,10 @@ The following algorithm describes how to compute these tags for a given function
              set the [=call site tag=] to [=CallSiteRequiredToBeUniform.S=], and set its [=witness set=] to *W*.
         * For each [=param_i=] in *R.S*, if its corresponding [=parameter tag=] has not been updated since initialization, then
              set that tag to [=ParameterRequiredToBeUniform.S=], and set its [=witness set=] to *W*.
-* Mark all the nodes as unvisited.
+* Mark all the [=interior nodes=] as unvisited.
 * If [=Value_return=] exists, let *VR* be the set of nodes reachable from [=Value_return=].
     * If *VR* includes [=MayBeNonUniform=], then set the [=function tag=] to [=ReturnValueMayBeNonUniform=].
-    * For each [=param_i=] in *VR*, if the corresponding [=parameter return tag=] has not been updated since initialization,
-         then set it to [=ParameterReturnRequiredToBeUniform=].
+    * For each [=param_i=] in *VR*, set the corresponding [=parameter return tag=] to [=ParameterReturnRequiredToBeUniform=].
     * Issue: [#3677](https://github.com/gpuweb/gpuweb/issues/3677)
          For pointer parameters, handle the distinction between uniformity of the pointer
          value and the uniformity of the contents of the memory pointed at.
@@ -10691,7 +10691,7 @@ end of the loop body (CF_after_if).
 
 This example is modification of the [[#uniformity-example1|first example]], but
 uses a user-defined function call.
-The analysis tags the [=parameter return tag=] of both parameters of `scale` as
+The analysis sets the [=parameter return tag=] of both parameters of `scale` as
 [=ParameterReturnRequiredToBeUniform=].
 This leads to the path in `main` between the return value of the `scale`
 function call and the `position` built-in value.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9754,6 +9754,7 @@ For each function, two tags are computed:
 
 For each [=formal parameter=] of a function, one or two tags are computed:
   * A <dfn noexport>parameter tag</dfn> describes the uniformity requirement of the parameter value.
+  * A <dfn noexport>parameter return tag</dfn> describes the unifomity requirement of the parameter value on the function's [=return value=].
   * A <dfn noexport>pointer parameter tag</dfn>, when the parameter type is a pointer into the  [=address spaces/function=] address space.
       The tag describes whether the value in the memory pointed to by the parameter may become
       [=uniform value|non-uniform=] during the execution of the function call.
@@ -9797,9 +9798,18 @@ For each [=formal parameter=] of a function, one or two tags are computed:
           Otherwise a diagnostic with severity |S| will be triggered.
 
           Associated with a [=witness set=].
-  <tr><td><dfn noexport>ParameterRequiredToBeUniformForReturnValue</dfn>
-      <td>The parameter [=shader-creation error|must=] be a [=uniform value=] in order for the [=return value=] to be a uniform value.
   <tr><td><dfn noexport>ParameterNoRestriction</dfn>
+      <td>The parameter value has no uniformity requirement.
+</table>
+
+<table class='data'>
+  <caption>[=Parameter return tag=] values</caption>
+  <thead>
+    <tr><th>Parameter Return Tag<th>Description
+  </thead>
+  <tr><td><dfn noexport>ParameterReturnRequiredToBeUniform</dfn>
+      <td>The parameter [=shader-creation error|must=] be a [=uniform value=] in order for the [=return value=] to be a uniform value.
+  <tr><td><dfn noexport>ParameterReturnNoRestriction</dfn>
       <td>The parameter value has no uniformity requirement.
 </table>
 
@@ -9833,9 +9843,11 @@ The following algorithm describes how to compute these tags for a given function
     * The [=function tag=] is initialized to [=NoRestriction=].
     * The [=call site tag=] is initialized to [=CallSiteNoRestriction=].
     * The [=parameter tag=] for each [=param_i=] is initialized to [=ParameterNoRestriction=].
+    * The [=parameter return tag=] for each [=param_i=] is initialized to [=ParameterReturnNoRestriction=].
     * The [=pointer parameter tag=] for each [=param_i=], if it exists, is initialized to [=PointerParameterNoRestriction=].
 * For each severity *S* in the order {[=severity/error=], [=severity/warning=], [=severity/info=]}, perform the following:
-    * Let *R.S* be the set of nodes reachable from [=RequiredToBeUniform.S=].
+    * Let *R.S* be the set of unvisited nodes reachable from [=RequiredToBeUniform.S=].
+    * Mark the nodes in *R.S* as visited.
     * Let *W* be the [=witness set=] associated with [=RequiredToBeUniform.S=].
     * If *R.S* includes the node [=MayBeNonUniform=], then trigger a [=uniformity failure=]:
          * For each [=witness=] *w* in *W*, [=triggered|trigger=] a diagnostic with severity *S*, using the call site and triggering rule from *w*.
@@ -9844,10 +9856,11 @@ The following algorithm describes how to compute these tags for a given function
              set the [=call site tag=] to [=CallSiteRequiredToBeUniform.S=], and set its [=witness set=] to *W*.
         * For each [=param_i=] in *R.S*, if its corresponding [=parameter tag=] has not been updated since initialization, then
              set that tag to [=ParameterRequiredToBeUniform.S=], and set its [=witness set=] to *W*.
+* Mark all the nodes as unvisited.
 * If [=Value_return=] exists, let *VR* be the set of nodes reachable from [=Value_return=].
     * If *VR* includes [=MayBeNonUniform=], then set the [=function tag=] to [=ReturnValueMayBeNonUniform=].
-    * For each [=param_i=] in *VR*, if the corresponding [=parameter tag=] has not been updated since initialization,
-         then set it to [=ParameterRequiredToBeUniformForReturnValue=].
+    * For each [=param_i=] in *VR*, if the corresponding [=parameter return tag=] has not been updated since initialization,
+         then set it to [=ParameterReturnRequiredToBeUniform=].
     * Issue: [#3677](https://github.com/gpuweb/gpuweb/issues/3677)
          For pointer parameters, handle the distinction between uniformity of the pointer
          value and the uniformity of the contents of the memory pointed at.
@@ -10275,7 +10288,7 @@ The most complex rule is for function calls:
     - If the corresponding [=parameter tag=] is [=ParameterRequiredToBeUniform.S=], then:
         - Add an edge from [=RequiredToBeUniform.S=] to [=arg_i=].
         - Add the [=witness set=] of the [=parameter tag=] to the witness set associated with [=RequiredToBeUniform.S=].
-    - Otherwise if the [=parameter tag=] is [=ParameterRequiredToBeUniformForReturnValue=], then add an edge from [=Result=] to [=arg_i=]
+    - If the [=parameter return tag=] is [=ParameterReturnRequiredToBeUniform=], then add an edge from [=Result=] to [=arg_i=]
     - If the corresponding parameter has a [=pointer parameter tag=] of [=PointerParameterMayBeNonUniform=], then add an edge from *Vout*(*call*) to [=MayBeNonUniform=]
     - If the parameter is a pointer in the [=address spaces/function=] address space, add an edge from *Vout*(*call*) to each corresponding [=arg_i=] for the reachable parameters recorded previously
 
@@ -10286,7 +10299,9 @@ A [=value constructor=] expression is analyzed as if it were a function call wit
 Most built-in functions have tags of:
 - A [=call site tag=] of [=CallSiteNoRestriction=].
 - A [=function tag=] of [=NoRestriction=].
-- For each parameter, a [=parameter tag=] of [=ParameterRequiredToBeUniformForReturnValue=].
+- For each parameter:
+    - a [=parameter tag=] of [=ParameterNoRestriction=].
+    - a [=parameter return tag=] of [=ParameterReturnRequiredToBeUniform=].
 
 Here is the list of exceptions:
 - A call to a function in [[#sync-builtin-functions]]:
@@ -10313,6 +10328,7 @@ Here is the list of exceptions:
     - Has a [=function tag=] of [=NoRestriction=].
     - Has a [=call site tag=] of [=CallSiteNoRestriction=].
     - The input parameter `p` has a [=parameter tag=] of [=ParameterNoRestriction=]
+    - The input parameter `p` has a [=parameter return tag=] of [=ParameterReturnNoRestriction=]
 
 Note: A WGSL implementation will ensure that if control flow prior to a
 function call is [=uniform control flow|uniform=], it will also be uniform
@@ -10681,8 +10697,8 @@ end of the loop body (CF_after_if).
 
 This example is modification of the [[#uniformity-example1|first example]], but
 uses a user-defined function call.
-The analysis tags both parameters of `scale` as
-[=ParameterRequiredToBeUniformForReturnValue=].
+The analysis tags the [=parameter return tag=] both parameters of `scale` as
+[=ParameterReturnRequiredToBeUniform=].
 This leads to the path in `main` between the return value of the `scale`
 function call and the `position` built-in value.
 That path is a subpath of the overall invalid path from [=RequiredToBeUniform.S=] to

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -645,9 +645,9 @@ The following table lists the standard set of triggering rules that can be filte
   <tr>
     <td><dfn noexport dfn-for="trigger">derivative_uniformity</dfn>
     <td>[=severity/error=]
-    <td>The [=call site=] for any
+    <td>The location of the [=call site=] for any
         [=builtin functions that compute a derivative|builtin function that computes a derivative=].
-        That is, the [=call site=] for any of:
+        That is, the location of a call to any of:
         * the [[#derivative-builtin-functions|derivative builtin functions]]
         * [[#texturesample|textureSample]]
         * [[#texturesamplebias|textureSampleBias]]
@@ -9647,7 +9647,7 @@ when [=uniformity analysis=] cannot prove that a particular [[#collective-operat
 * If a uniformity failure is triggered for a
     [=builtin functions that compute a derivative|builtin function that computes a derivative=], then
     a [=trigger/derivative_uniformity=] [=diagnostic=] is [=triggered=].
-    * The diagnostic's [=diagnostic/triggering location=] is the [=call site=] of that builtin.
+    * The diagnostic's [=diagnostic/triggering location=] is the location of the [=call site=] of that builtin.
     * The diagnostic's [=diagnostic/severity=] defaults to an [=severity/error=] but can be controlled with a [=diagnostic filter=].
 * If a uniformity failure is triggered for a [[#sync-builtin-functions|synchronization builtin]],
     an [=severity/error=] [=diagnostic=] is [=triggered=],

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -584,7 +584,7 @@ A <dfn noexport>diagnostic</dfn> is a message produced by the implementation for
 
 A diagnostic is created, or <dfn noexport>triggered</dfn>, when a particular condition is met,
 known as the <dfn dfn-for="diagnostic">triggering rule</dfn>.
-The place in the source text where the condition is met, expressed as a point or range in the source text, is known as the 
+The place in the source text where the condition is met, expressed as a point or range in the source text, is known as the
 <dfn dfn-for="diagnostic">triggering location</dfn>.
 
 A [=diagnostic=] has the following properties:
@@ -681,7 +681,7 @@ Applying a diagnostic filter *DF*(*AR*,*NS*,*TR*) to a diagnostic *D* has the fo
 A <dfn noexport>range diagnostic filter</dfn> is a [=diagnostic filter=] that is applied to each
 diagnostic whose [=diagnostic/triggering location=] falls within a specified range of source text,
 and when no other more specific filter applies.
-A range diagnostic filter is specified as a `@diagnostic` [=attribute=] immediately before the affected source range,
+A range diagnostic filter is specified as a `@diagnostic` [=attribute=] at the start of the affected source range,
 as specified in the following table.  A `@diagnostic` attribute [=shader-creation error|must not=] appear anywhere else.
 
 <table class='data'>
@@ -758,9 +758,14 @@ Two [=diagnostic filters=] *DF*(*AR1*,*NS1*,*TR1*) and *DF*(*AR2*,*NS2*,*TR2*) <
 
 [=Diagnostic filters=] [=shader-creation error|must=] not [=diagnostic/conflict=].
 
-Note: WGSL's diagnostic filters are designed so their affected ranges nest perfectly.
+WGSL's diagnostic filters are designed so their affected ranges nest perfectly.
 If the affected range of DF1 overlaps with the affected range of DF2, then
 either DF1's affected range is fully contained in DF2's affected range, or the other way around.
+
+The <dfn noexport>nearest enclosing diagnostic filter</dfn> for source location *L* and triggering rule *TR*,
+if one exists, is the diagnostic filter *DF(AR,NS,TR)* where *L* falls in the affected range *AR*,
+and if there is another filter *DF'(AR',NS',TR)* where *L* falls in *AR'*, then *AR* is contained
+in *AR'*. Because affected ranges nest, the nearest diagnostic is unique, or does not exist.
 
 # Textual Structure # {#textual-structure}
 
@@ -1480,7 +1485,7 @@ some attribute parameters are also context-dependent names.
 
 With one exception, an attribute [=shader-creation error|must not=] be specified more than once per object or type.
 The exception is that more than one [=attribute/diagnostic=] attribute may be specified on an object, provided
-they do not [=diagnostic/conflict=].
+they specify different [=diagnostic/triggering rules=].
 
 <table class='data'>
   <caption>Attributes defined in WGSL</caption>
@@ -1544,6 +1549,9 @@ they do not [=diagnostic/conflict=].
         specifying a [=diagnostic/triggering rule=].
 
     <td>Specifies a [=range diagnostic filter=].  See [[#diagnostics]].
+
+        Two diagnostic attributes applied to the same object [=shader-creation error|must=]
+        specify different [=diagnostic/triggering rules=].
 
   <tr><td><dfn noexport dfn-for="attribute">`group`</dfn>
     <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
@@ -9632,8 +9640,11 @@ when [=uniformity analysis=] cannot prove that a particular [[#collective-operat
 * If a uniformity failure is triggered for a
     [=builtin functions that compute a derivative|builtin function that computes a derivative=], then
     a [=trigger/derivative_uniformity=] [=diagnostic=] is [=triggered=].
-    The [=diagnostic/triggering location=] for the diagnostic is the [=call site=] of that builtin.
-* If a uniformity failure is triggered for a [[#sync-builtin-functions|synchronization builtin]], a [=shader-creation error=] results.
+    * The diagnostic's [=diagnostic/triggering location=] is the [=call site=] of that builtin.
+    * The diagnostic's [=diagnostic/severity=] defaults to an [=severity/error=] but can be controlled with a [=diagnostic filter=].
+* If a uniformity failure is triggered for a [[#sync-builtin-functions|synchronization builtin]],
+    an [=severity/error=] [=diagnostic=] is [=triggered=],
+    which results in a [=shader-creation error=].
 
 ### Terminology and Concepts ### {#uniformity-concepts}
 
@@ -9675,16 +9686,15 @@ There is no risk of being trapped in a cycle, as recurrence is forbidden in the 
 
 Note: Another way of saying the same thing is that we do a topological sort of functions ordered by the "is a (possibly indirect) callee of" partial order, and analyze them in that order.
 
-Additionally, the analysis computes and propagates locations of [=call sites=] for [=builtin functions that compute a derivative=].
-This is used to [=triggered|trigger=] and filter [=diagnostics=] for [=uniformity failures=] on those calls.
-A set of such source locations is called a <dfn noexport>witness set</dfn>.
-Witness sets only support adding elements, not removing elements.
+Additionally, the analysis computes and propagates information about
+calls to functions that must only be invoked in uniform control flow.
+This is used to [=triggered|trigger=] and potentially filter [=diagnostics=] for [=uniformity failures=] on those calls.
+A <dfn>witness</dfn> is a pair containing a [=call site=], and a [=diagnostic/triggering rule=].
+A <dfn>witness set</dfn> is a set of [=witnesses=], and only supports adding elements, not removing elements.
 In particular, a witness set is only formed via the following operations:
 * Create an empty set.
 * Create a witness set containing a single source location.
 * Form a witness set from the union of two others.
-
-Witness sets can be implemented such that their total cost across the entire uniformity analysis is linear in the source program size.
 
 ### Analyzing the Uniformity Requirements of a Function ### {#uniformity-function}
 
@@ -9694,32 +9704,48 @@ The first phase walks over the syntax of the function, building a directed graph
 The second phase explores that graph, computing the constraints on calling this function,
 and potentially triggering a [=uniformity failure=].
 
-<div class="note"><span class=marker>Note:</span>Apart from two special nodes [=RequiredToBeUniform=] and [=MayBeNonUniform=], all nodes can be understood as having one of the following meanings:
-        - A specific point of the program [=shader-creation error|must=] be executed in [=uniform control flow=]
-        - An expression [=shader-creation error|must=] be a [=uniform value=]
-        - A variable [=shader-creation error|must=] be a [=uniform variable=]
+<div class="note"><span class=marker>Note:</span>Apart from four special nodes
+    [=RequiredToBeUniform.error=],
+    [=RequiredToBeUniform.warning=],
+    [=RequiredToBeUniform.info=], and [=MayBeNonUniform=], each node can be understood as capturing the truth-value one of the following statements:
+        - A specific point of the program must be executed in [=uniform control flow=].
+        - An expression must be a [=uniform value=].
+        - A variable must be a [=uniform variable=].
+        - A value stored in memory, that could be loaded via a pointer, must be a [=uniform value=].
 
         An edge can be understood as an implication from the statement corresponding to its source node to the statement corresponding to its target node.
 
-        To express that uniformity requirement (e.g. the control flow at the call site of a derivative), we add an edge from [=RequiredToBeUniform=] to the corresponding node.
-        One way to understand this, is that [=RequiredToBeUniform=] corresponds to the proposition True, so that [=RequiredToBeUniform=] -> X is the same as saying that X is true.
+        For example, one uniformity requirement is that the `workgroupBarrier` builtin function must only be called within uniform control flow.
+        To express this, we add an edge from [=RequiredToBeUniform.error=] to the node corresponding to the `workgroupBarrier` [=call site=].
+        One way to understand this is that [=RequiredToBeUniform.error=] corresponds to the proposition True,
+        so that [=RequiredToBeUniform.error=] -> X is the same as saying that X is true.
 
         Reciprocally, to express that we cannot ensure the uniformity of something (e.g. a variable which holds the thread id), we add an edge from the corresponding node to [=MayBeNonUniform=].
         One way to understand this, is that [=MayBeNonUniform=] corresponds to the proposition False, so that X -> [=MayBeNonUniform=] is the same as saying that X is false.
 
-        A consequence of this interpretation is that every node reachable from [=RequiredToBeUniform=] corresponds to
+        A consequence of this interpretation is that every node reachable from [=RequiredToBeUniform.error=] corresponds to
         something which is required to be uniform for the program to be valid, and every node from which
         [=MayBeNonUniform=] is reachable corresponds to something whose uniformity we cannot guarantee.
-        It follows that we have a uniformity violation, triggering a [=uniformity failure=], if there is any path from [=RequiredToBeUniform=] to [=MayBeNonUniform=].
+        It follows that we have a uniformity violation, triggering a [=uniformity failure=], if there is any
+        path from [=RequiredToBeUniform.error=] to [=MayBeNonUniform=].
+
+        The nodes [=RequiredToBeUniform.warning=] and [=RequiredToBeUniform.info=] are used in a similar way,
+        but instead determine when [=severity/warning=] or [=severity/info=] [=diagnostics=] should be triggered:
+        *   If there is a path from [=RequiredToBeUniform.warning=] to [=MayBeNonUniform=], then a [=severity/warning=]
+            [=diagnostic=] will be triggered.
+        *   If there is a path from [=RequiredToBeUniform.info=] to [=MayBeNonUniform=], then an [=severity/info=]
+            [=diagnostic=] will be triggered.
+
+        As described in [[#diagnostics]], lower severity diagnostics may be discarded if higher severity diagnostics have also been generated.
 </div>
 
 For each function, two tags are computed:
   * A <dfn noexport>call site tag</dfn> describing the control flow uniformity requirements on the [=call sites=] of the function, and
   * A <dfn noexport>function tag</dfn> describing the function's effects on uniformity.
 
-Additionally, for each [=formal parameter=] of a function, a parameter tag is
+Additionally, for each [=formal parameter=] of a function, a [=parameter tag=] is
 computed and, if the parameter is a [=address spaces/function=] address space
-pointer, a pointer parameter tag is also computed.
+pointer, a [=pointer parameter tag=] is also computed.
 The <dfn noexport>parameter tag</dfn> describes the uniformity requirement of
 the parameter value.
 The <dfn noexport>pointer parameter tag</dfn> describes whether the value
@@ -9731,8 +9757,13 @@ value|non-uniform=] during the execution of the function call.
   <thead>
     <tr><th>Call Site Tag<th>Description
   </thead>
-  <tr><td><dfn noexport>CallSiteRequiredToBeUniform</dfn>
-      <td>The function [=shader-creation error|must=] only be called from [=uniform control flow=].
+  <tr algorithm="CallSiteRequiredToBeUniform tag">
+      <td><dfn noexport>CallSiteRequiredToBeUniform.S</dfn>,<br>
+          where |S| is one of the severities: [=severity/error=], [=severity/warning=], or [=severity/info=].
+      <td>The function must only be called from [=uniform control flow=].
+          Otherwise a diagnostic of with severity |S| will be triggered.
+
+          Associated with a [=witness set=].
   <tr><td><dfn noexport>CallSiteNoRestriction</dfn>
       <td>The function may be called from [=uniform control flow|non-uniform control flow=].
 </table>
@@ -9753,8 +9784,13 @@ value|non-uniform=] during the execution of the function call.
   <thead>
     <tr><th>Parameter Tag<th>Description
   </thead>
-  <tr><td><dfn noexport>ParameterRequiredToBeUniform</dfn>
-      <td>The parameter [=shader-creation error|must=] be a [=uniform value=].
+  <tr algorithm="ParameterRequiredToBeUniform tag">
+      <td><dfn noexport>ParameterRequiredToBeUniform.S</dfn>,<br>
+          where |S| is one of the severities: [=severity/error=], [=severity/warning=], or [=severity/info=].
+      <td>The parameter must be a [=uniform value=].
+          Otherwise a diagnostic of with severity |S| will be triggered.
+
+          Associated with a [=witness set=].
   <tr><td><dfn noexport>ParameterRequiredToBeUniformForReturnValue</dfn>
       <td>The parameter [=shader-creation error|must=] be a [=uniform value=] in order for the [=return value=] to be a uniform value.
   <tr><td><dfn noexport>ParameterNoRestriction</dfn>
@@ -9772,37 +9808,48 @@ value|non-uniform=] during the execution of the function call.
       <td>The uniformity of the value stored in the memory pointed to by the pointer parameter is unaffected by the function call.
 </table>
 
-To support generating [=diagnostics=], each instance of a [=CallSiteRequiredToBeUniform=] [=call site tag=] and each instance of a [=ParameterRequiredToBeUniform=]
-[=parameter tag=] also has an associated [=witness set=], which capture the root cause
-for the tags to be [=CallSiteRequiredToBeUniform=] and [=ParameterRequiredToBeUniform=], respectively.
-
 The following algorithm describes how to compute these tags for a given function:
 
-* Create nodes called <dfn noexport>RequiredToBeUniform</dfn>, <dfn noexport>MayBeNonUniform</dfn>, <dfn noexport>CF_start</dfn>, and if the function has a [=return type=] a node called <dfn noexport>Value_return</dfn>.
-    * Additionally, the [=RequiredToBeUniform=] tag has an associated [=witness set=], which is initially empty.
-* Create one node for each parameter of the function which we'll call <dfn noexport>param_i</dfn>.
+* Create the following nodes:
+    * <dfn noexport>RequiredToBeUniform.error</dfn>, <dfn noexport>RequiredToBeUniform.warning</dfn>, and <dfn noexport>RequiredToBeUniform.info</dfn>.
+        Collectively these are called the <dfn noexport>RequiredToBeUniform.S</dfn> nodes.
+        * Each such node is associated with a [=witness set=], which is initially empty.
+    * <dfn noexport>MayBeNonUniform</dfn>
+    * <dfn noexport>CF_start</dfn>, representing the uniformity requirement for control flow when the function begins executing.
+    * <dfn noexport>param_i</dfn>, where *i* ranges over the function's [=formal parameters=].
+    * If the function has a [=return type=], create a node called <dfn noexport>Value_return</dfn>.
 * Desugar pointers as described in [[#pointer-desugar]].
-    * For each pointer parameter in the [=address spaces/function=] address space,
+    * For each formal parameter that is a pointer in the [=address spaces/function=] address space,
         create a <dfn noexport>Value_return_i</dfn> node.
-* Walk over the syntax of the function, adding nodes and edges to the graph, and building [=witness sets=], following the rules of the next sections ([[#func-var-value-analysis]], [[#uniformity-statements]], [[#uniformity-function-calls]], [[#uniformity-expressions]]), using [=CF_start=] as the starting control-flow for the function's body.
-* For each [=Value_return_i=] node, record which [=param_i=] nodes are reachable from it.
-* Examine the [=RequiredToBeUniform=] node. Let *W* be its associated [=witness set=]. Let *R* be the set of nodes reachable from [=RequiredToBeUniform=].
-    * If *R* includes the node [=MayBeNonUniform=], then trigger a [=uniformity failure=].
-         * If the uniformity failure triggers [=diagnostics=], then the [=diagnostic/triggering locations=] are taken from *W*.
-    * If *R* includes [=CF_start=], then the [=call site tag=] for the function is [=CallSiteRequiredToBeUniform=], with [=witness set=] *W*.
-    * Otherwise, the [=call site tag=] is [=CallSiteNoRestriction=].
-    * For each [=param_i=] in *R*, the corresponding [=parameter tag=] is [=ParameterRequiredToBeUniform=], with [=witness set=] *W*.
-    * Remove from the graph all nodes that have been visited.
-* If [=Value_return=] exists, look at which nodes are reachable from it
-    * If this set includes [=MayBeNonUniform=], then the [=function tag=] is [=ReturnValueMayBeNonUniform=].
-    * For each [=param_i=] in this set, the corresponding [=parameter tag=] is [=ParameterRequiredToBeUniformForReturnValue=].
-* For each [=Value_return_i=] node, look at which nodes are reachable from it
-    * If this set includes [=MayBeNonUniform=], the corresponding [=pointer parameter tag=] is [=PointerParameterMayBeNonUniform=].
+        This represents the function's effect on the uniformity of the value pointed to by the *i*<sup>th</sup> parameter.
+* Walk over the syntax of the function, adding nodes and edges to the graph following the rules of the next sections ([[#func-var-value-analysis]], [[#uniformity-statements]], [[#uniformity-function-calls]], [[#uniformity-expressions]]), using [=CF_start=] as the starting control-flow for the function's body.
+* Initialize as follows:
+    * The [=function tag=] is initialized to [=NoRestriction=].
+    * The [=call site tag=] is initialized to [=CallSiteNoRestriction=].
+    * The [=parameter tag=] for each [=param_i=] is initialized to [=ParameterNoRestriction=].
+* For each severity *S* in the order {[=severity/error=], [=severity/warning=], [=severity/info=]}, perform the following:
+    * Let *R.S* be the set of nodes reachable from [=RequiredToBeUniform.S=].
+    * Let *W* be the [=witness set=] associated with [=RequiredToBeUniform.S=].
+    * If *R.S* includes the node [=MayBeNonUniform=], then trigger a [=uniformity failure=]:
+         * For each witness *w* in *W*, trigger a diagnostic with severity *S*, using the call site and triggering rule from *w*.
+         * Exit this loop, i.e. the loop over *S*.
+    * Otherwise:
+        * If *R.S* includes [=CF_start=], and the [=call site tag=] has not been updated since initialization, then
+             set the [=call site tag=] to [=CallSiteRequiredToBeUniform.S=], and set its [=witness set=] to *W*.
+        * For each [=param_i=] in *R.S*, if its corresponding [=parameter tag=] has not been updated since initialization, then
+             set that tag to [=ParameterRequiredToBeUniform.S=], and set its [=witness set=] to *W*.
+* If [=Value_return=] exists, let *VR* be the set of nodes reachable from [=Value_return=].
+    * If *VR* includes [=MayBeNonUniform=], then set the [=function tag=] to [=ReturnValueMayBeNonUniform=].
+    * For each [=param_i=] in *VR*, if the corresponding [=parameter tag=] has not been updated since initialization,
+         then set it to [=ParameterRequiredToBeUniformForReturnValue=].
+    * Issue: [#3677](https://github.com/gpuweb/gpuweb/issues/3677)
+         For pointer parameters, handle the distinction between uniformity of the pointer
+         value and the uniformity of the contents of the memory pointed at.
+* For each [=Value_return_i=] node, let *VRi* be the set of nodes reachable from [=Value_return_i=].
+    * If *VRi* includes [=MayBeNonUniform=], the corresponding [=pointer parameter tag=] is [=PointerParameterMayBeNonUniform=].
     * Otherwise, the corresponding [=pointer parameter tag=] is [=PointerParameterNoRestriction=].
-* If the [=function tag=] has not been assigned, then it is [=NoRestriction=].
-* For each parameter, if it has not been assigned a [=parameter tag=], then it is [=ParameterNoRestriction=].
 
-Note: The entire graph can be destroyed at this point. The tags and [=witness sets=] described above are all that we need to remember to analyze callers of this function.
+Note: The entire graph can be destroyed at this point. The tags described above are all that we need to remember to analyze callers of this function.
 
 ### Pointer Desugaring ### {#pointer-desugar}
 
@@ -10208,14 +10255,14 @@ being the same as input control flow node.
 The most complex rule is for function calls:
 - For each argument, apply the corresponding expression rule, with the control flow at the exit of the previous argument (using the control flow at the beginning of the function call for the first argument). Name the corresponding value nodes <dfn noexport>arg_i</dfn> and the corresponding control flow nodes <dfn noexport>CF_i</dfn>
 - Create two new nodes, named <dfn noexport>Result</dfn> and <dfn noexport>CF_after</dfn>
-- If the [=call site tag=] of the function is [=CallSiteRequiredToBeUniform=], then add an edge from [=RequiredToBeUniform=] to the last [=CF_i=].
-    - Additionally add the [=witness set=] from the call site tag to the witness set associated with [=RequiredToBeUniform=].
+- If the [=call site tag=] of the function is [=CallSiteRequiredToBeUniform.S=], then:
+    - Add an edge from [=RequiredToBeUniform.S=] to the last [=CF_i=].
+    - Add the [=witness set=] of the [=call site tag=] to the witness set associated with [=RequiredToBeUniform.S=].
 - Otherwise add an edge from [=CF_after=] to the last [=CF_i=]
 - If the [=function tag=] is [=ReturnValueMayBeNonUniform=], then add an edge from [=Result=] to [=MayBeNonUniform=]
 - Add an edge from [=Result=] to [=CF_after=]
 - For each argument *i*:
-    - If the corresponding [=parameter tag=] is [=ParameterRequiredToBeUniform=], then add an edge from [=RequiredToBeUniform=] to [=arg_i=]
-        - Additionally add the [=witness set=] from the parameter tag to the witness set associated with [=RequiredToBeUniform=].
+    - If the corresponding [=parameter tag=] is [=ParameterRequiredToBeUniform.S=], then add an edge from [=RequiredToBeUniform.S=] to [=arg_i=]
     - Otherwise if the [=parameter tag=] is [=ParameterRequiredToBeUniformForReturnValue=], then add an edge from [=Result=] to [=arg_i=]
     - If the corresponding parameter has a [=pointer parameter tag=] of [=PointerParameterMayBeNonUniform=], then add an edge from *Vout*(*call*) to [=MayBeNonUniform=]
     - If the parameter is a pointer in the [=address spaces/function=] address space, add an edge from *Vout*(*call*) to each corresponding [=arg_i=] for the reachable parameters recorded previously
@@ -10230,16 +10277,28 @@ Most built-in functions have tags of:
 - For each parameter, a [=parameter tag|tag=] of [=ParameterRequiredToBeUniformForReturnValue=].
 
 Here is the list of exceptions:
-- All functions in [[#sync-builtin-functions]] have a [=call site tag=] of  [=CallSiteRequiredToBeUniform=].
-    - The parameter `p` in [[#workgroupUniformLoad-builtin|workgroupUniformLoad]]
-        has a [=parameter tag=] of [=ParameterRequiredToBeUniform=].
-- All functions in
+- A call to a function in [[#sync-builtin-functions]]:
+    - Has a [=function tag=] of [=NoRestriction=].
+    - Has a [=call site tag=] of [=CallSiteRequiredToBeUniform.S|CallSiteRequiredToBeUniform.error=].
+        The tag's associated [=witness=] is the source location of the call site, combined with an unnamed [=diagnostic/triggering rule=].
+        - Note: The triggering rule has no name, and so it cannot be filtered.
+    - Additionally for the case of a call to [[#workgroupUniformLoad-builtin|workgroupUniformLoad]],
+        the parameter `p` has a [=parameter tag=] of [=ParameterRequiredToBeUniform.S|ParameterRequiredToBeUniform.error=].
+        The tag's associated [=witness=] is the source location of the call site, combined with an unnamed [=diagnostic/triggering rule=].
+- A call to a function in
     [[#derivative-builtin-functions]], [[#texturesample]], [[#texturesamplebias]], and [[#texturesamplecompare]]:
-    - Have a [=call site tag=] of [=CallSiteRequiredToBeUniform=]. The associated [=witness set=] is a singleton set containing the location of the [=call site=] to the builtin function.
-    - Have a [=function tag=] of [=ReturnValueMayBeNonUniform=].
-- [[#arrayLength-builtin|arrayLength]] has a [=call site tag=] of
-    [=CallSiteNoRestriction=], a [=function tag=] of [=NoRestriction=] and
-    the input parameter `p` has a [=parameter tag=] of [=ParameterNoRestriction=]
+    - Has a [=function tag=] of [=ReturnValueMayBeNonUniform=].
+    - Has a [=call site tag=] of [=CallSiteRequiredToBeUniform.S=]:
+        - Where *S* is:
+            - the NS (new severity) parameter of the [=nearest enclosing diagnostic filter=]
+                for the combination of the call site and the [=trigger/derivative_uniformity=] triggering rule.
+            - [=severity/error=], if no such filter exists.
+        - The tag's associated [=witness=] is the source location of the call site, combined with the [=trigger/derivative_uniformity=] triggering rule.
+
+- [[#arrayLength-builtin|arrayLength]]:
+    - Has a [=function tag=] of [=NoRestriction=].
+    - Has a [=call site tag=] of [=CallSiteNoRestriction=].
+    - The input parameter `p` has a [=parameter tag=] of [=ParameterNoRestriction=]
 
 Note: A WGSL implementation will ensure that if control flow prior to a
 function call is [=uniform control flow|uniform=], it will also be uniform
@@ -10545,7 +10604,7 @@ composite up so that values that are known to be uniform are separate from
 value that are known to be non-uniform.
 In the alternative WGSL below, splitting the two built-in values into separate
 parameters satisfies the uniformity analysis.
-This can be seen by the lack of a path from [=RequiredToBeUniform=] to
+This can be seen by the lack of a path from [=RequiredToBeUniform.S=] to
 [=MayBeNonUniform=] in the graph.
 
 <div class='example wgsl' heading='Valid alternative WGSL'>
@@ -10612,7 +10671,7 @@ The analysis tags both parameters of `scale` as
 [=ParameterRequiredToBeUniformForReturnValue=].
 This leads to the path in `main` between the return value of the `scale`
 function call and the `position` built-in value.
-That path is a subpath of the overall invalid path from [=RequiredToBeUniform=] to
+That path is a subpath of the overall invalid path from [=RequiredToBeUniform.S=] to
 [=MayBeNonUniform=].
 
 <div class='example wgsl' heading='User-defined function call uniformity WGSL'>
@@ -10807,7 +10866,7 @@ built-in functions described in [[#derivative-builtin-functions]]:
 
 Because neighbouring invocations collaborate to compute derivatives, these
 functions should only be invoked in [=uniform control flow=] in a fragment shader.
-For each call to one of these functions, a [=trigger/derivative_uniformity=] [=diagnostic=] is triggered if 
+For each call to one of these functions, a [=trigger/derivative_uniformity=] [=diagnostic=] is triggered if
 [[#uniformity|uniformity analysis]] cannot prove the call occurs in uniform control flow.
 
 If one of these functions is called in non-uniform control flow, then the result is an [=indeterminate value=].

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9752,7 +9752,7 @@ For each function, two tags are computed:
 
 For each [=formal parameter=] of a function, one or two tags are computed:
   * A <dfn noexport>parameter tag</dfn> describes the uniformity requirement of the parameter value.
-  * A <dfn noexport>parameter return tag</dfn> describes the unifomity requirement of the parameter value on the function's [=return value=].
+  * A <dfn noexport>parameter return tag</dfn> describes how the uniformity of the parameter influences that of the function's [=return value=].
   * A <dfn noexport>pointer parameter tag</dfn>, when the parameter type is a pointer into the  [=address spaces/function=] address space.
       The tag describes whether the value in the memory pointed to by the parameter may become
       [=uniform value|non-uniform=] during the execution of the function call.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1555,7 +1555,7 @@ Unless explicitly permitted below, an attribute [=shader-creation error|must not
 
     <td>Specifies a [=range diagnostic filter=].  See [[#diagnostics]].
 
-        More than one [=attribute/diagnostic=] attribute may be specified on an object,
+        More than one [=attribute/diagnostic=] attribute may be specified on a syntactic form,
         but they [=shader-creation error|must=] specify different [=diagnostic/triggering rules=].
 
   <tr><td><dfn noexport dfn-for="attribute">`group`</dfn>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -692,18 +692,18 @@ A `@diagnostic` attribute [=shader-creation error|must not=] appear anywhere els
   <thead>
     <tr><th>Placement<th>Affected Range
   </thead>
-    <tr><td>Beginning of a [=compound statement=].<td>The compound statement.
-    <tr><td>Beginning of a [=function declaration=].<td>The function declaration.
-    <tr><td>Beginning of an [=statement/if=] statement.<td>The if statement: the [=syntax/if_clause=]
+    <tr><td>[=syntax/compound_statement|Beginning=] of a [=compound statement=].<td>The compound statement.
+    <tr><td>[=syntax/function_decl|Beginning=] of a [=function declaration=].<td>The function declaration.
+    <tr><td>[=syntax/if_statement|Beginning=] of an [=statement/if=] statement.<td>The if statement: the [=syntax/if_clause=]
       and all associated [=syntax/else_if_clause=] and [=syntax/else_clause=] clauses,
       including all controlling condition expressions.
-    <tr><td>Beginning of a [=statement/switch=] statement.<td>The switch statement: the selector expression and the [=syntax/switch_body=].
-    <tr><td>Beginning of a [=syntax/switch_body=].<td>The [=syntax/switch_body=].
-    <tr><td>Beginning of a [=statement/loop=] statement.<td>The loop statement.
-    <tr><td>Beginning of a [=statement/while=] statement.<td>The while statement: both the condition expression and the loop body.
-    <tr><td>Beginning of a [=statement/for=] statement.<td>The for statement: the [=syntax/for_header=] and the loop body.
+    <tr><td>[=syntax/switch_statement|Beginning=] of a [=statement/switch=] statement.<td>The switch statement: the selector expression and the [=syntax/switch_body=].
+    <tr><td>[=syntax/switch_body|Beginning=] of a [=syntax/switch_body=].<td>The [=syntax/switch_body=].
+    <tr><td>[=syntax/loop_statement|Beginning=] of a [=statement/loop=] statement.<td>The loop statement.
+    <tr><td>[=syntax/while_statement|Beginning=] of a [=statement/while=] statement.<td>The while statement: both the condition expression and the loop body.
+    <tr><td>[=syntax/for_statement|Beginning=] of a [=statement/for=] statement.<td>The for statement: the [=syntax/for_header=] and the loop body.
     <tr><td>Immediately before the opening brace (`'{'`) of the [=loop body=] of a [=statement/loop=], [=statement/while=], or [=statement/for=] loop.<td>The [=loop body=].
-    <tr><td>Beginning of a [=syntax/continuing_compound_statement=].<td>The [=syntax/continuing_compound_statement=].
+    <tr><td>[=syntax/continuing_compound_statement|Beginning=] of a [=syntax/continuing_compound_statement=].<td>The [=syntax/continuing_compound_statement=].
 </table>
 
 Note: The following are also [=compound statements=]:
@@ -10323,12 +10323,6 @@ Here is the list of exceptions:
             - Otherwise the call site tag is [=CallSiteRequiredToBeUniform.S=], with witness *w*.
         - If there is no such *DF*,
             the call site tag is [=CallSiteRequiredToBeUniform.S|CallSiteRequiredToBeUniform.error=], with witness *w*.
-
-- [[#arrayLength-builtin|arrayLength]]:
-    - Has a [=function tag=] of [=NoRestriction=].
-    - Has a [=call site tag=] of [=CallSiteNoRestriction=].
-    - The input parameter `p` has a [=parameter tag=] of [=ParameterNoRestriction=]
-    - The input parameter `p` has a [=parameter return tag=] of [=ParameterReturnNoRestriction=]
 
 Note: A WGSL implementation will ensure that if control flow prior to a
 function call is [=uniform control flow|uniform=], it will also be uniform

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9749,7 +9749,7 @@ For each function, two tags are computed:
 
 For each [=formal parameter=] of a function, one or two tags are computed:
   * A <dfn noexport>parameter tag</dfn> describes the uniformity requirement of the parameter value.
-  * A <dfn neoxport>pointer parameter tag</dfn>, when the parameter type is a pointer into the  [=address spaces/function=] address space.
+  * A <dfn noexport>pointer parameter tag</dfn>, when the parameter type is a pointer into the  [=address spaces/function=] address space.
       The tag describes whether the value in the memory pointed to by the parameter may become
       [=uniform value|non-uniform=] during the execution of the function call.
 

--- a/wgsl/keywords
+++ b/wgsl/keywords
@@ -569,6 +569,7 @@ const
 continue
 continuing
 default
+diagnostic
 discard
 else
 enable

--- a/wgsl/wgsl.recursive.bs.include
+++ b/wgsl/wgsl.recursive.bs.include
@@ -33,6 +33,8 @@
 
  | `'@'` `'const'`
 
+ | `'@'` `'diagnostic'` [=recursive descent syntax/diagnostic_control=]
+
  | `'@'` `'fragment'`
 
  | `'@'` `'group'` `'('` [=recursive descent syntax/expression=] `','` ? `')'`
@@ -123,7 +125,7 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>compound_statement</dfn>:
 
- | `'{'` [=recursive descent syntax/statement=] * `'}'`
+ | [=recursive descent syntax/attribute=] * `'{'` [=recursive descent syntax/statement=] * `'}'`
 </div>
 
 <div class='syntax' noexport='true'>
@@ -154,6 +156,12 @@
  | `/0[iu]?/`
 
  | `/[1-9][0-9]*[iu]?/`
+</div>
+
+<div class='syntax' noexport='true'>
+  <dfn for='recursive descent syntax'>diagnostic_control</dfn>:
+
+ | `'('` [=recursive descent syntax/severity_control_name=] `','` [=syntax/ident_pattern_token=] `','` ? `')'`
 </div>
 
 <div class='syntax' noexport='true'>
@@ -197,7 +205,7 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>global_decl</dfn>:
 
- | [=recursive descent syntax/attribute=] * `'fn'` [=recursive descent syntax/ident=] `'('` ( [=recursive descent syntax/attribute=] * [=recursive descent syntax/ident=] `':'` [=recursive descent syntax/type_specifier=] ( `','` [=recursive descent syntax/param=] )* `','` ? )? `')'` ( `'->'` [=recursive descent syntax/attribute=] * [=recursive descent syntax/ident=] [=recursive descent syntax/template_elaborated_ident.post.ident=] )? `'{'` [=recursive descent syntax/statement=] * `'}'`
+ | [=recursive descent syntax/attribute=] * `'fn'` [=recursive descent syntax/ident=] `'('` ( [=recursive descent syntax/attribute=] * [=recursive descent syntax/ident=] `':'` [=recursive descent syntax/type_specifier=] ( `','` [=recursive descent syntax/param=] )* `','` ? )? `')'` ( `'->'` [=recursive descent syntax/attribute=] * [=recursive descent syntax/ident=] [=recursive descent syntax/template_elaborated_ident.post.ident=] )? [=recursive descent syntax/attribute=] * `'{'` [=recursive descent syntax/statement=] * `'}'`
 
  | [=recursive descent syntax/attribute=] * `'override'` [=recursive descent syntax/optionally_typed_ident=] ( `'='` [=recursive descent syntax/expression=] )? `';'`
 
@@ -216,6 +224,8 @@
 
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>global_directive</dfn>:
+
+ | `'diagnostic'` `'('` [=recursive descent syntax/severity_control_name=] `','` [=syntax/ident_pattern_token=] `','` ? `')'` `';'`
 
  | `'enable'` [=syntax/ident_pattern_token=] `';'`
 
@@ -324,6 +334,18 @@
 </div>
 
 <div class='syntax' noexport='true'>
+  <dfn for='recursive descent syntax'>severity_control_name</dfn>:
+
+ | `'error'`
+
+ | `'info'`
+
+ | `'off'`
+
+ | `'warning'`
+</div>
+
+<div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>shift_expression.post.unary_expression</dfn>:
 
  | ( [=recursive descent syntax/multiplicative_operator=] [=recursive descent syntax/unary_expression=] )* ( [=recursive descent syntax/additive_operator=] [=recursive descent syntax/unary_expression=] ( [=recursive descent syntax/multiplicative_operator=] [=recursive descent syntax/unary_expression=] )* )*
@@ -340,6 +362,16 @@
 
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>statement</dfn>:
+
+ | [=recursive descent syntax/attribute=] * `'for'` `'('` [=recursive descent syntax/for_init=] ? `';'` [=recursive descent syntax/expression=] ? `';'` [=recursive descent syntax/for_update=] ? `')'` [=recursive descent syntax/compound_statement=]
+
+ | [=recursive descent syntax/attribute=] * `'if'` [=recursive descent syntax/expression=] [=recursive descent syntax/compound_statement=] ( `'else'` `'if'` [=recursive descent syntax/expression=] [=recursive descent syntax/compound_statement=] )* ( `'else'` [=recursive descent syntax/compound_statement=] )?
+
+ | [=recursive descent syntax/attribute=] * `'loop'` [=recursive descent syntax/attribute=] * `'{'` [=recursive descent syntax/statement=] * ( `'continuing'` [=recursive descent syntax/attribute=] * `'{'` [=recursive descent syntax/statement=] * ( `'break'` `'if'` [=recursive descent syntax/expression=] `';'` )? `'}'` )? `'}'`
+
+ | [=recursive descent syntax/attribute=] * `'switch'` [=recursive descent syntax/expression=] [=recursive descent syntax/attribute=] * `'{'` [=recursive descent syntax/switch_clause=] * `'}'`
+
+ | [=recursive descent syntax/attribute=] * `'while'` [=recursive descent syntax/expression=] [=recursive descent syntax/compound_statement=]
 
  | [=recursive descent syntax/compound_statement=]
 
@@ -359,21 +391,11 @@
 
  | `'discard'` `';'`
 
- | `'for'` `'('` [=recursive descent syntax/for_init=] ? `';'` [=recursive descent syntax/expression=] ? `';'` [=recursive descent syntax/for_update=] ? `')'` [=recursive descent syntax/compound_statement=]
-
- | `'if'` [=recursive descent syntax/expression=] [=recursive descent syntax/compound_statement=] ( `'else'` `'if'` [=recursive descent syntax/expression=] [=recursive descent syntax/compound_statement=] )* ( `'else'` [=recursive descent syntax/compound_statement=] )?
-
- | `'loop'` `'{'` [=recursive descent syntax/statement=] * ( `'continuing'` `'{'` [=recursive descent syntax/statement=] * ( `'break'` `'if'` [=recursive descent syntax/expression=] `';'` )? `'}'` )? `'}'`
-
  | `'return'` [=recursive descent syntax/expression=] ? `';'`
-
- | `'switch'` [=recursive descent syntax/expression=] `'{'` [=recursive descent syntax/switch_body=] * `'}'`
-
- | `'while'` [=recursive descent syntax/expression=] [=recursive descent syntax/compound_statement=]
 </div>
 
 <div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>switch_body</dfn>:
+  <dfn for='recursive descent syntax'>switch_clause</dfn>:
 
  | `'case'` [=recursive descent syntax/case_selector=] ( `','` [=recursive descent syntax/case_selector=] )* `','` ? `':'` ? [=recursive descent syntax/compound_statement=]
 


### PR DESCRIPTION
Builds on #3683, and removes the ability to apply range diagnostic filters directly to expressions.

The only new commit is the last one (for now).

Fixes #3554 
Fixes #3689