### PR TITLE
Introduce "call_expression" grammar rule

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6717,13 +6717,24 @@ When an identifier is used as a [=syntax/callable=] item, it is one of:
 
     | [=syntax/ident=]
 
-    | [=syntax/callable=] [=syntax/argument_expression_list=]
+    | [=syntax/call_expression=]
 
     | [=syntax/literal=]
 
     | [=syntax/paren_expression=]
 
     | <a for=syntax_kw lt=bitcast>`'bitcast'`</a> <a for=syntax_sym lt=less_than>`'<'`</a> [=syntax/type_specifier=] <a for=syntax_sym lt=greater_than>`'>'`</a> [=syntax/paren_expression=]
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>call_expression</dfn> :
+
+    | [=syntax/call_phrase=]
+</div>
+Note: The [=syntax/call_expression=] rule exists to ensure [=type checking=] applies to the call expression.
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>call_phrase</dfn> :
+
+    | [=syntax/callable=] [=syntax/argument_expression_list=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>callable</dfn> :
@@ -7958,7 +7969,7 @@ the fragment will be thrown away.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>func_call_statement</dfn> :
 
-    | [=syntax/ident=] [=syntax/argument_expression_list=]
+    | [=syntax/call_phrase=]
 </div>
 
 A function call statement executes a [=function call=].

--- a/wgsl/wgsl.recursive.bs.include
+++ b/wgsl/wgsl.recursive.bs.include
@@ -31,6 +31,12 @@
 </div>
 
 <div class='syntax' noexport='true'>
+  <dfn for='recursive descent syntax'>argument_expression_list</dfn>:
+
+ | `'('` ( [=recursive descent syntax/expression=] ( `','` [=recursive descent syntax/expression=] )* `','` ? )? `')'`
+</div>
+
+<div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>assignment_statement/0.1</dfn>:
 
  | [=recursive descent syntax/compound_assignment_operator=]
@@ -259,7 +265,7 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>for_init</dfn>:
 
- | [=recursive descent syntax/ident=] [=recursive descent syntax/func_call_statement.post.ident=]
+ | [=recursive descent syntax/callable=] [=recursive descent syntax/argument_expression_list=]
 
  | [=recursive descent syntax/variable_statement=]
 
@@ -269,15 +275,9 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>for_update</dfn>:
 
- | [=recursive descent syntax/ident=] [=recursive descent syntax/func_call_statement.post.ident=]
+ | [=recursive descent syntax/callable=] [=recursive descent syntax/argument_expression_list=]
 
  | [=recursive descent syntax/variable_updating_statement=]
-</div>
-
-<div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>func_call_statement.post.ident</dfn>:
-
- | `'('` ( [=recursive descent syntax/expression=] ( `','` [=recursive descent syntax/expression=] )* `','` ? )? `')'`
 </div>
 
 <div class='syntax' noexport='true'>
@@ -481,9 +481,9 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>statement</dfn>:
 
- | [=recursive descent syntax/compound_statement=]
+ | [=recursive descent syntax/callable=] `'('` ( [=recursive descent syntax/expression=] ( `','` [=recursive descent syntax/expression=] )* `','` ? )? `')'` `';'`
 
- | [=recursive descent syntax/ident=] `'('` ( [=recursive descent syntax/expression=] ( `','` [=recursive descent syntax/expression=] )* `','` ? )? `')'` `';'`
+ | [=recursive descent syntax/compound_statement=]
 
  | [=recursive descent syntax/variable_statement=] `';'`
 


### PR DESCRIPTION
Ensures function call expressions are type-checked, because type checking produces a type for every expression, i.e. any text that matches a grammar rule whose name ends with "_expression".

Fixes: #3717