### PR TITLE
Formal parameter scope is the function body

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1266,8 +1266,10 @@ We say the identifier is <dfn noexport>in scope</dfn>
 
 Where a declaration appears determines its scope:
 * Predeclared objects, and objects declared at module-scope, are [=in scope=] across the entire program source.
+* Each [=formal parameter=] of a user-declared function is [=in scope=] across the corresponding [=function body=].
+    See [[#function-declaration-sec]].
 * Otherwise, the scope is a span of text beginning immediately after the end of the declaration.
-    For details, see [[#var-and-value]], and the declaration of [=formal parameters=] in [[#function-declaration-sec]].
+    For details, see [[#var-and-value]].
 
 Two declarations in the same WGSL source program [=shader-creation error|must not=] simultaneously:
 * introduce the same identifier name, and
@@ -8455,7 +8457,7 @@ A <dfn noexport>formal parameter</dfn> [=declaration=] specifies an [=identifier
 provided when invoking the function.
 A formal parameter may have attributes.
 See [[#function-calls]].
-The identifier is [=in scope=] until the end of the function.
+The [=scope=] of the identifier is the [=function body=].
 Two formal parameters for a given function [=shader-creation error|must not=] have the same name.
 
 Note: Some built-in functions may allow parameters to be [=abstract numeric types=];


### PR DESCRIPTION
This allows a formal parameter to shadow the name of a return type.

Addresses part of #3692