### PR TITLE
Define/document behavior of missing channels in blending

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2074,7 +2074,7 @@ A color is converted between spaces by translating its representation in one spa
 representation in another according to the definitions above.
 
 If the source value has fewer than 4 RGBA channels, the missing green/blue/alpha channels are set to
-`0, 0, 1` respectively, as needed, before converting for color space/encoding and alpha premultiplication.
+`0, 0, 1`, respectively, before converting for color space/encoding and alpha premultiplication.
 After conversion, if the destination needs fewer than 4 channels, the additional channels
 are ignored.
 
@@ -8093,9 +8093,11 @@ location:
         <tr>
             <td><b><code>RGBA<sub>src</src></code></b>
             <td>Color output by the fragment shader for the color attachment.
+                If the shader doesn't return an alpha channel, src-alpha blend factors cannot be used.
         <tr>
             <td><b><code>RGBA<sub>dst</src></code></b>
             <td>Color currently in the color attachment.
+                Missing green/blue/alpha channels default to `0, 0, 1`, respectively.
         <tr>
             <td><b><code>RGBA<sub>const</src></code></b>
             <td>The current {{RenderState/[[blendConstant]]}}.


### PR DESCRIPTION
Behavior established in #2025 and #2013.