### PR TITLE
Allow abstract array element access via const-expression index

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6055,6 +6055,21 @@ See [[#sync-builtin-functions]].
            * It is a [=shader-creation error=] if |i| is a [=const-expression=].
            * It is a [=pipeline-creation error=] if |i| is an [=override-expression=].
            * Otherwise, an [=indeterminate value=] for |T| may be returned.
+  <tr algorithm="fixed-size array indexed element selection abstract">
+       <td class="nowrap">
+          |e|: array&lt;|T|,|N|&gt;<br>
+          |i|: [INT]<br>
+          |T| is [=type/abstract=]<br>
+          |i| is a [=const-expression=]
+       <td class="nowrap">
+           |e|[|i|] : |T|
+       <td>The result is the value of the |i|'<sup>th</sup> element of the array value |e|.
+
+           It is a [=shader-creation error=] if |i| is outside the range [0,|N|-1].
+
+           Note: When an abstract array value |e| is indexed by an expression that
+           is not a [=const-expression=], then the array is
+           [=concretization of a value|concretized=] before the index is applied.
 </table>
 
 <table class='data'>


### PR DESCRIPTION
* Spec was missing an expression for abstract array element access

Marking as editorial since this functionality has previously been agreed at committee.