### PR TITLE
Make bikeshed definitions for uniformity nodes

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9511,20 +9511,20 @@ Each function is analyzed in two phases.
 The first phase walks over the syntax of the function, building a directed graph along the way based on the rules in the following subsections.
 The second phase explores that graph, resulting in either rejecting the program, or computing the constraints on calling this function.
 
-<div class="note">Note: Apart from two special nodes RequiredToBeUniform and MayBeNonUniform, all nodes can be understood as having one of the following meanings:
+<div class="note">Note: Apart from two special nodes [=RequiredToBeUniform=] and [=MayBeNonUniform=], all nodes can be understood as having one of the following meanings:
         - A specific point of the program [=shader-creation error|must=] be executed in [=uniform control flow=]
         - An expression [=shader-creation error|must=] be a [=uniform value=]
         - A variable [=shader-creation error|must=] be a [=uniform variable=]
 
         An edge can be understood as an implication from the statement corresponding to its source node to the statement corresponding to its target node.
 
-        To express that uniformity requirement (e.g. the control flow at the call site of a derivative), we add an edge from RequiredToBeUniform to the corresponding node.
-        One way to understand this, is that RequiredToBeUniform corresponds to the proposition True, so that RequiredToBeUniform -> X is the same as saying that X is true.
+        To express that uniformity requirement (e.g. the control flow at the call site of a derivative), we add an edge from [=RequiredToBeUniform=] to the corresponding node.
+        One way to understand this, is that [=RequiredToBeUniform=] corresponds to the proposition True, so that [=RequiredToBeUniform=] -> X is the same as saying that X is true.
 
-        Reciprocally, to express that we cannot ensure the uniformity of something (e.g. a variable which holds the thread id), we add an edge from the corresponding node to MayBeNonUniform.
-        One way to understand this, is that MayBeNonUniform corresponds to the proposition False, so that X -> MayBeNonUniform is the same as saying that X is false.
+        Reciprocally, to express that we cannot ensure the uniformity of something (e.g. a variable which holds the thread id), we add an edge from the corresponding node to [=MayBeNonUniform=].
+        One way to understand this, is that [=MayBeNonUniform=] corresponds to the proposition False, so that X -> [=MayBeNonUniform=] is the same as saying that X is false.
 
-        A consequence of this interpretation is that every node reachable from RequiredToBeUniform corresponds to something which is required to be uniform for the program to be valid, and every node from which MayBeNonUniform is reachable corresponds to something whose uniformity we cannot guarantee. It follows that we have a uniformity violation (and thus reject the program) if there is any path from RequiredToBeUniform to MayBeNonUniform.
+        A consequence of this interpretation is that every node reachable from [=RequiredToBeUniform=] corresponds to something which is required to be uniform for the program to be valid, and every node from which [=MayBeNonUniform=] is reachable corresponds to something whose uniformity we cannot guarantee. It follows that we have a uniformity violation (and thus reject the program) if there is any path from [=RequiredToBeUniform=] to [=MayBeNonUniform=].
 </div>
 
 For each function, two tags are computed:
@@ -9588,24 +9588,24 @@ value|non-uniform=] during the execution of the function call.
 
 The following algorithm describes how to compute these tags for a given function:
 
-* Create nodes called "RequiredToBeUniform", "MayBeNonUniform", "CF_start", and if the function has a [=return type=] a node called "Value_return".
-* Create one node for each parameter of the function which we'll call "arg_i".
+* Create nodes called <dfn noexport>RequiredToBeUniform</dfn>, <dfn noexport>MayBeNonUniform</dfn>, <dfn noexport>CF_start</dfn>, and if the function has a [=return type=] a node called <dfn noexport>Value_return</dfn>.
+* Create one node for each parameter of the function which we'll call <dfn noexport>param_i</dfn>.
 * Desugar pointers as described in [[#pointer-desugar]].
     * For each pointer parameter in the [=address spaces/function=] address space,
-        create a "Value_return_i" node.
-* Walk over the syntax of the function, adding nodes and edges to the graph following the rules of the next sections ([[#func-var-value-analysis]], [[#uniformity-statements]], [[#uniformity-function-calls]], [[#uniformity-expressions]]), using "CF_start" as the starting control-flow for the function's body.
-* For each "Value_return_i" node, record which "arg_i" nodes are reachable from it.
-* Look at which nodes are reachable from "RequiredToBeUniform".
-    * If this set includes the node "MayBeNonUniform", then reject the program.
-    * If this set includes "CF_start", then the [=call site tag=] for the function is [=CallSiteRequiredToBeUniform=].
+        create a <dfn noexport>Value_return_i</dfn> node.
+* Walk over the syntax of the function, adding nodes and edges to the graph following the rules of the next sections ([[#func-var-value-analysis]], [[#uniformity-statements]], [[#uniformity-function-calls]], [[#uniformity-expressions]]), using [=CF_start=] as the starting control-flow for the function's body.
+* For each [=Value_return_i=] node, record which [=param_i=] nodes are reachable from it.
+* Look at which nodes are reachable from [=RequiredToBeUniform=].
+    * If this set includes the node [=MayBeNonUniform=], then reject the program.
+    * If this set includes [=CF_start=], then the [=call site tag=] for the function is [=CallSiteRequiredToBeUniform=].
     * Otherwise, the [=call site tag=] is [=CallSiteNoRestriction=].
-    * For each "arg_i" in this set, the corresponding [=parameter tag=] is [=ParameterRequiredToBeUniform=].
+    * For each [=param_i=] in this set, the corresponding [=parameter tag=] is [=ParameterRequiredToBeUniform=].
     * Remove from the graph all nodes that have been visited.
-* If "Value_return" exists, look at which nodes are reachable from it
-    * If this set includes "MayBeNonUniform", then the [=function tag=] is [=ReturnValueMayBeNonUniform=].
-    * For each "arg_i" in this set, the corresponding [=parameter tag=] is [=ParameterRequiredToBeUniformForReturnValue=].
-* For each "Value_return_i" node, look at which nodes are reachable from it
-    * If this set includes "MayBeNonUniform", the corresponding [=pointer parameter tag=] is [=PointerParameterMayBeNonUniform=].
+* If [=Value_return=] exists, look at which nodes are reachable from it
+    * If this set includes [=MayBeNonUniform=], then the [=function tag=] is [=ReturnValueMayBeNonUniform=].
+    * For each [=param_i=] in this set, the corresponding [=parameter tag=] is [=ParameterRequiredToBeUniformForReturnValue=].
+* For each [=Value_return_i=] node, look at which nodes are reachable from it
+    * If this set includes [=MayBeNonUniform=], the corresponding [=pointer parameter tag=] is [=PointerParameterMayBeNonUniform=].
     * Otherwise, the corresponding [=pointer parameter tag=] is [=PointerParameterNoRestriction=].
 * If the [=function tag=] has not been assigned, then it is [=NoRestriction=].
 * For each parameter, if it has not been assigned a [=parameter tag=], then it is [=ParameterNoRestriction=].
@@ -9962,15 +9962,15 @@ When several edges have to be created we use `X -> {Y, Z}` as a short-hand for `
       <td>*CF*
       <td>
       For each [=address spaces/function=] address space pointer parameter *i*,
-      *Value_return_i* -> *Vin*(*prev*) (see [[#func-var-value-analysis]])
+      [=Value_return_i=] -> *Vin*(*prev*) (see [[#func-var-value-analysis]])
   <tr><td class="nowrap">return *e*;
       <td>
       <td class="nowrap">(*CF*, *e*) => (*CF'*, *V*)
       <td>*CF'*
-      <td>*Value_return* -> *V*
+      <td>[=Value_return=] -> *V*
 
       For each [=address spaces/function=] address space pointer parameter *i*,
-      *Value_return_i* -> *Vin*(*prev*) (see [[#func-var-value-analysis]])
+      [=Value_return_i=] -> *Vin*(*prev*) (see [[#func-var-value-analysis]])
   <tr><td class="nowrap">*e2* = *e1*;
       <td>
       <td class="nowrap">(*CF*, *e1*) => (*CF1*, *V1*)<br>
@@ -10015,17 +10015,17 @@ being the same as input control flow node.
 ### Uniformity Rules for Function Calls ### {#uniformity-function-calls}
 
 The most complex rule is for function calls:
-- For each argument, apply the corresponding expression rule, with the control flow at the exit of the previous argument (using the control flow at the beginning of the function call for the first argument). Name the corresponding value nodes "arg_i" and the corresponding control flow nodes "CF_i"
-- Create two new nodes, named "Result" and "CF_after"
-- If the [=call site tag=] of the function is [=CallSiteRequiredToBeUniform=], then add an edge from RequiredToBeUniform to the last CF_i
-- Otherwise add an edge from CF_after to the last CF_i
-- If the [=function tag=] is [=ReturnValueMayBeNonUniform=], then add an edge from Result to MayBeNonUniform
-- Add an edge from Result to CF_after
+- For each argument, apply the corresponding expression rule, with the control flow at the exit of the previous argument (using the control flow at the beginning of the function call for the first argument). Name the corresponding value nodes <dfn noexport>arg_i</dfn> and the corresponding control flow nodes <dfn noexport>CF_i</dfn>
+- Create two new nodes, named <dfn noexport>Result</dfn> and <dfn noexport>CF_after</dfn>
+- If the [=call site tag=] of the function is [=CallSiteRequiredToBeUniform=], then add an edge from [=RequiredToBeUniform=] to the last [=CF_i=]
+- Otherwise add an edge from [=CF_after=] to the last [=CF_i=]
+- If the [=function tag=] is [=ReturnValueMayBeNonUniform=], then add an edge from [=Result=] to [=MayBeNonUniform=]
+- Add an edge from [=Result=] to [=CF_after=]
 - For each argument *i*:
-    - If the corresponding [=parameter tag=] is [=ParameterRequiredToBeUniform=], then add an edge from RequiredToBeUniform to arg_i
-    - Otherwise if the [=parameter tag=] is [=ParameterRequiredToBeUniformForReturnValue=], then add an edge from Result to arg_i
-    - If the corresponding parameter has a [=pointer parameter tag=] of [=PointerParameterMayBeNonUniform=], then add an edge from *Vout*(*call*) to MayBeNonUniform
-    - If the parameter is a pointer in the [=address spaces/function=] address space, add an edge from *Vout*(*call*) to each corresponding arg_i for the reachable parameters recorded previously
+    - If the corresponding [=parameter tag=] is [=ParameterRequiredToBeUniform=], then add an edge from [=RequiredToBeUniform=] to [=arg_i=]
+    - Otherwise if the [=parameter tag=] is [=ParameterRequiredToBeUniformForReturnValue=], then add an edge from [=Result=] to [=arg_i=]
+    - If the corresponding parameter has a [=pointer parameter tag=] of [=PointerParameterMayBeNonUniform=], then add an edge from *Vout*(*call*) to [=MayBeNonUniform=]
+    - If the parameter is a pointer in the [=address spaces/function=] address space, add an edge from *Vout*(*call*) to each corresponding [=arg_i=] for the reachable parameters recorded previously
 
 Note: Refer to [[#func-var-value-analysis]] for the definition of *Vout*(*call*).
 
@@ -10106,7 +10106,7 @@ The rules for analyzing expressions take as argument both the expression itself 
       <td>
       <td>
       <td class="nowrap">*CF*,<br>
-      *MayBeNonUniform*
+      [=MayBeNonUniform=]
       <td>
    <tr><td>identifier [=resolves|resolving=] to read-only module-scope variable "x"
       <td>
@@ -10120,7 +10120,7 @@ The rules for analyzing expressions take as argument both the expression itself 
       <td>
       <td>
       <td class="nowrap">*CF*,<br>
-      *MayBeNonUniform*
+      [=MayBeNonUniform=]
       <td>
    <tr><td>identifier [=resolves|resolving=] to non-read-only module-scope
       variable "x" where the identifier appears as the [=root identifier=] of a [=memory view=]
@@ -10178,7 +10178,7 @@ of a [=composite=] type separately.
       <td>
       <td>
       <td class="nowrap">*CF*,<br>
-      *MayBeNonUniform*
+      [=MayBeNonUniform=]
       <td>
   <tr><td class="nowrap">*e*.field
       <td>
@@ -10201,9 +10201,9 @@ If implementers want to provide developers with a diagnostic mode that shows for
 - Run the (mandatory, normative) analysis described in the previous subsections, keeping the graph for every function.
 - Reverse all edges in all of those graphs
 - Go through each function, starting with the entry point and never visiting a function before having visited all of its callers:
-    - Add an edge from MayBeNonUniform to every argument that was non-uniform in at least one caller
-    - Add an edge from MayBeNonUniform to CF_start if the function was called in non-uniform control-flow in at least one caller
-    - Look at which nodes are reachable from MayBeNonUniform. Every node visited is an expression or point in the control-flow whose uniformity cannot be proven by the analysis
+    - Add an edge from [=MayBeNonUniform=] to every argument that was non-uniform in at least one caller
+    - Add an edge from [=MayBeNonUniform=] to [=CF_start=] if the function was called in non-uniform control-flow in at least one caller
+    - Look at which nodes are reachable from [=MayBeNonUniform=]. Every node visited is an expression or point in the control-flow whose uniformity cannot be proven by the analysis
 
 Any node which is not visited by these reachability analyses can be proven to be uniform by the analysis (and so it would be safe to call a derivative or similar function there).
 
@@ -10247,7 +10247,7 @@ The invalid dependency chain is highlighted in red.
 
 The example also shows that uniformity of the control flow after the if
 statement is the same as the uniformity prior to the if statement (CF_return
-being connected to CF_start).
+being connected to [=CF_start=]).
 That is, the control flow is once again uniform after the if statement (because
 it is guaranteed to start as uniform control flow at the beginning of the entry
 point).
@@ -10347,8 +10347,8 @@ composite up so that values that are known to be uniform are separate from
 value that are known to be non-uniform.
 In the alternative WGSL below, splitting the two built-in values into separate
 parameters satisfies the uniformity analysis.
-This can be seen by the lack of a path from RequiredToBeUniform to
-MayBeNonUniform in the graph.
+This can be seen by the lack of a path from [=RequiredToBeUniform=] to
+[=MayBeNonUniform=] in the graph.
 
 <div class='example wgsl' heading='Valid alternative WGSL'>
   <xmp highlight='rust'>
@@ -10414,8 +10414,8 @@ The analysis tags both parameters of `scale` as
 [=ParameterRequiredToBeUniformForReturnValue=].
 This leads to the path in `main` between the return value of the `scale`
 function call and the `position` built-in value.
-That path is a subpath of the overall invalid path from RequiredToBeUniform to
-MayBeNonUniform.
+That path is a subpath of the overall invalid path from [=RequiredToBeUniform=] to
+[=MayBeNonUniform=].
 
 <div class='example wgsl' heading='User-defined function call uniformity WGSL'>
   <xmp highlight='rust'>


### PR DESCRIPTION
Make definitions for:
  RequiredToBeUniform
  MayBeNonUniform
  CF_start
  Value_return
  Value_return_i
  arg_i
  CF_i
  Result
  CF_after

Change the "arg_i" in description of the analysis of a function body to "param_i", and make param_i a bikeshed dfn. This avoids the collision with arg_i as defined in analysis of a function call.