### PR TITLE
Fix sort order in recursive-descent grammar

### DIFF
--- a/wgsl/wgsl.recursive.bs.include
+++ b/wgsl/wgsl.recursive.bs.include
@@ -555,6 +555,8 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>texel_format</dfn>:
 
+ | `'bgra8unorm'`
+
  | `'r32float'`
 
  | `'r32sint'`
@@ -586,8 +588,6 @@
  | `'rgba8uint'`
 
  | `'rgba8unorm'`
-
- | `'bgra8unorm'`
 </div>
 
 <div class='syntax' noexport='true'>


### PR DESCRIPTION
Put bgra8unorm in the correctly sorted spot, where the automatic generation puts it.