### PR TITLE
Remove static_assert from reserved words.

### DIFF
--- a/wgsl/wgsl.reserved.bs.include
+++ b/wgsl/wgsl.reserved.bs.include
@@ -243,8 +243,6 @@
 
     | `'static'`   <!-- C++ ECMAScript2022 Rust HLSL GLSL(reserved) -->
 
-    | `'static_assert'`   <!-- C++ -->
-
     | `'static_cast'`   <!-- C++ -->
 
     | `'std'`   <!-- WGSL -->


### PR DESCRIPTION
`static_assert` is listed as a keyword and should not be listed as a reserved word.