### PR TITLE
[wgsl] Change remainder to say Inherited from.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -10698,7 +10698,7 @@ value with the same sign.
   <tr><td>`x - y`<td colspan=2 style="text-align:left;">Correctly rounded
   <tr><td>`x * y`<td colspan=2 style="text-align:left;">Correctly rounded
   <tr><td>`x / y`<td>2.5 ULP for `|y|` in the range [2<sup>-126</sup>, 2<sup>126</sup>]<td>2.5 ULP for `|y|` in the range [2<sup>-14</sup>, 2<sup>14</sup>]
-  <tr><td>`x % y`<td colspan=2 style="text-align:left;">Derived from `x - y * trunc(x/y)`
+  <tr><td>`x % y`<td colspan=2 style="text-align:left;">Inherited from `x - y * trunc(x/y)`
   <tr><td>`-x`<td colspan=2 style="text-align:left;">Correctly rounded
 
   <tr><td>`x == y`<td colspan=2 style="text-align:left;">Correct result


### PR DESCRIPTION
In the Floating Point accuracy tables the majority say `Inherited from` and the preamble highlights `inherited from`. The remainder test says `Derived from`. This CL just changes remainder to be consistent with the rest of the table.