### PR TITLE
Remove static_assert from reserved words

### DIFF
--- a/wgsl/keywords
+++ b/wgsl/keywords
@@ -95,6 +95,11 @@ push @deliberately_unreserved, qw(
   bgra8unorm
 
 );
+# https://github.com/gpuweb/gpuweb/pull/3730
+# Don't reserve static_assert from C++
+push @deliberately_unreserved, qw(
+  static_assert
+);
 
 
 # C++ keywords

--- a/wgsl/wgsl.reserved.bs.include
+++ b/wgsl/wgsl.reserved.bs.include
@@ -243,8 +243,6 @@
 
     | `'static'`   <!-- C++ ECMAScript2022 Rust HLSL GLSL(reserved) -->
 
-    | `'static_assert'`   <!-- C++ -->
-
     | `'static_cast'`   <!-- C++ -->
 
     | `'std'`   <!-- WGSL -->


### PR DESCRIPTION
It's already a keyword. Don't reserve it.
Update the 'keywords' script which is the source of truth for wgsl.reserved.bs.include