### PR TITLE
Finalize text/wgsl media type registration

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -15282,9 +15282,9 @@ path: wgsl.recursive.bs.include
 The Internet Assigned Numbers Authority (IANA) maintains a registry of media types, at
 <a href="https://www.iana.org/assignments/media-types/media-types.xhtml">https://www.iana.org/assignments/media-types/media-types.xhtml</a>
 
-The following is the proposed registration for the `text/wgsl` media type for WGSL programs.
-It is published for community review, and is intended to be submitted to the
-Internet Engineering Steering Group (IESG) for review, approval, and registration with the IANA.
+The following is the definition of the `text/wgsl` media type for WGSL programs.
+It has been registered at IANA,
+appearing at [https://www.iana.org/assignments/media-types/text/wgsl](https://www.iana.org/assignments/media-types/text/wgsl).
 
 : Type name
 :: text
@@ -15334,5 +15334,5 @@ Internet Engineering Steering Group (IESG) for review, approval, and registratio
 : Change controller
 :: W3C
 : Normative References
-:: [[!WebGPU]] W3C, "WebGPU” W3C Working Draft, December 2022.  https://w3.org/TR/webgpu
-:: [[!WGSL]] W3C, “WebGPU Shading Language” W3C Working Draft, December 2022.  https://w3.org/TR/WGSL
+:: [[!WebGPU]] W3C, "WebGPU” W3C Working Draft, January 2023.  https://w3.org/TR/webgpu
+:: [[!WGSL]] W3C, “WebGPU Shading Language” W3C Working Draft, January 2023.  https://w3.org/TR/WGSL


### PR DESCRIPTION
It's been registered at IANA.
Say so in the WGSL spec, per W3C procedures at
https://www.w3.org/2020/01/registering-mediatypes

Fixes: #1682