### PR TITLE
Fix "For to Loop transformation" example

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -7724,9 +7724,10 @@ the next statement until the end of the `body`.
 The declaration is executed each time it is reached, so each new iteration
 creates a new instance of the variable or constant, and re-initializes it.
 
-<div class='example glsl' heading="For to Loop transformation">
+<div class='example wgsl function-scope' heading="For to Loop transformation">
   <xmp>
-    for(var i: i32 = 0; i < 4; i++) {
+    var a: i32 = 2;
+    for (var i: i32 = 0; i < 4; i++) {
       if a == 0 {
         continue;
       }
@@ -7739,9 +7740,9 @@ Converts to:
 
 <div class='example wgsl function-scope' heading="For to Loop transformation">
   <xmp highlight='rust'>
+    var a: i32 = 2;
     { // Introduce new scope for loop variable i
       var i: i32 = 0;
-      var a: i32 = 0;
       loop {
         if !(i < 4) {
           break;


### PR DESCRIPTION
Closes #3740
Fixes location of `var a` declaration in the "For to Loop transformation" example as explained in #3740