### PR TITLE
Update `atan2` accuracy to be 4096 ULP for f32

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -11791,7 +11791,7 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
     * `atan(y/x)` + &pi; when (`x` &lt; 0) and (`y` &gt; 0)
     * `atan(y/x)` - &pi; when (`x` &lt; 0) and (`y` &lt; 0)
 
-    Note: atan2 is ill-defined at the origin (`x`,`y`) = (0,0)
+    Note: atan2 is ill-defined at the origin (`x`,`y`) = (0,0). It is also ill-defined if `y` is non-normal or infinite
 
     [=Component-wise=] when `T` is a vector.
 </table>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -10735,7 +10735,7 @@ value with the same sign.
   <tr><td>`asin(x)`<td colspan=2 style="text-align:left;">Inherited from `atan2(x, sqrt(1.0 - x * x))`
   <tr><td>`asinh(x)`<td colspan=2 style="text-align:left;">Inherited from `log(x + sqrt(x * x + 1.0))`
   <tr><td>`atan(x)`<td>4096 ULP<td>5 ULP
-  <tr><td>`atan2(y, x)`<td colspan=2 style="text-align:left;">When `y` is finite and normal, inherited from `atan(y / x)`
+  <tr><td>`atan2(y, x)`<td>4096 ULP<td>5 ULP
   <tr><td>`atanh(x)`<td colspan=2 style="text-align:left;">Inherited from `log( (1.0 + x) / (1.0 - x) ) * 0.5`
   <tr><td>`ceil(x)`<td colspan=2 style="text-align:left;">Correctly rounded
   <tr><td>`clamp(x,low,high)`<td colspan=2 style="text-align:left;">Correctly rounded.<br>


### PR DESCRIPTION
Currently the spec says inherited from `atan(y/x)`, which leads to ambiguity/unexpected results when adjusting for the correct quadrant.

Fixes #3731