### PR TITLE
wgsl: align attribute constraint is technically redundant

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1011,9 +1011,13 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
         [=shader-creation error|Must=] be positive.
     <td>[=shader-creation error|Must=] only be applied to a member of a [=structure=] type.
 
-    [=shader-creation error|Must=] be a power of 2, and [=shader-creation error|must=] satisfy the required-alignment for the member type:
+    [=shader-creation error|Must=] be a power of 2.
 
-    <p algorithm="align constraint">
+    Note: This attribute influences how a value of the enclosing structure type can appear in memory:
+    at which byte addresses the structure itself and its component members can appear.
+    In particular, the rules in [[#memory-layouts]] combine to imply the following constraint:
+
+    <p class="note" algorithm="implied constraint on align attribute">
     If `align(`|n|`)` is applied to a member of |S|
     with type |T|, and |S| is the [=store type=]
     or contained in the store type for a variable in address space |C|,
@@ -1021,8 +1025,6 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     |n|&nbsp;=&nbsp;|k|&nbsp;&times;&nbsp;[=RequiredAlignOf=](|T|,|C|)
     for some positive integer |k|.
     </p>
-
-    See [[#memory-layouts]]
 
   <tr><td><dfn noexport dfn-for="attribute">`binding`</dfn>
     <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>


### PR DESCRIPTION
Change the statement of the constraint into a Note, and say that it's implied by existing rules in the Memory Layout section.

Fixes: #3756