### PR TITLE
Incorporate the restrictions on division into `atan2`

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -10735,7 +10735,7 @@ value with the same sign.
   <tr><td>`asin(x)`<td colspan=2 style="text-align:left;">Inherited from `atan2(x, sqrt(1.0 - x * x))`
   <tr><td>`asinh(x)`<td colspan=2 style="text-align:left;">Inherited from `log(x + sqrt(x * x + 1.0))`
   <tr><td>`atan(x)`<td>4096 ULP<td>5 ULP
-  <tr><td>`atan2(y, x)`<td>4096 ULP<td>5 ULP
+  <tr><td>`atan2(y, x)`<td>4096 ULP for `|x|` in the range [2<sup>-126</sup>, 2<sup>126</sup>], and `y` is finite and normal<td>5 ULP for `|x|` in the range [2<sup>-14</sup>, 2<sup>14</sup>], and `y` is finite and normal
   <tr><td>`atanh(x)`<td colspan=2 style="text-align:left;">Inherited from `log( (1.0 + x) / (1.0 - x) ) * 0.5`
   <tr><td>`ceil(x)`<td colspan=2 style="text-align:left;">Correctly rounded
   <tr><td>`clamp(x,low,high)`<td colspan=2 style="text-align:left;">Correctly rounded.<br>
@@ -11791,7 +11791,7 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
     * `atan(y/x)` + &pi; when (`x` &lt; 0) and (`y` &gt; 0)
     * `atan(y/x)` - &pi; when (`x` &lt; 0) and (`y` &lt; 0)
 
-    Note: atan2 is ill-defined at the origin (`x`,`y`) = (0,0). It is also ill-defined if `y` is non-normal or infinite
+    Note: atan2 is ill-defined when `y/x` is ill-defined, at the origin (`x`,`y`) = (0,0), and when `y` is non-normal or infinite.
 
     [=Component-wise=] when `T` is a vector.
 </table>


### PR DESCRIPTION
Since `atan2` is defined as `atan(y/x)` it should include the same restrictions as `y/x`.

Also explicitly calling out where accuracy is
defined, in the same style as division, since I keep on screwing this up in the CTS, so it probably worth calling out explicitly.

Issue #3731