### PR TITLE
Use 'alias' to create type aliases instead of 'type'

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2464,7 +2464,7 @@ See [[#memory-layouts]].
 <div class='example wgsl global-scope' heading='Structure used to declare a buffer'>
   <xmp highlight='rust'>
     // Runtime Array
-    type RTArr = array<vec4<f32>>;
+    alias RTArr = array<vec4<f32>>;
     struct S {
       a: f32,
       b: f32,
@@ -4095,16 +4095,16 @@ all properties of the members of *S*, including attributes, carry over to the me
 <div class='syntax' noexport='true'>
   <dfn for=syntax>type_alias_decl</dfn> :
 
-    | <a for=syntax_kw lt=type>`'type'`</a> [=syntax/ident=] <a for=syntax_sym lt=equal>`'='`</a> [=syntax/type_specifier=]
+    | <a for=syntax_kw lt=alias>`'alias'`</a> [=syntax/ident=] <a for=syntax_sym lt=equal>`'='`</a> [=syntax/type_specifier=]
 </div>
 
 <div class='example wgsl global-scope' heading='Type Alias'>
   <xmp highlight='rust'>
-    type Arr = array<i32, 5>;
+    alias Arr = array<i32, 5>;
 
-    type RTArr = array<vec4<f32>>;
+    alias RTArr = array<vec4<f32>>;
 
-    type single = f32;     // Declare an alias for f32
+    alias single = f32;     // Declare an alias for f32
     const pi_approx: single = 3.1415;
     fn two_pi() -> single {
       return single(2) * pi_approx;
@@ -5033,8 +5033,8 @@ In the following sections, when a type name precedes a parenthesized argument li
 
 <div class='example wgsl global-scope' heading="Type constructor expressions using type aliases">
   <xmp highlight='rust'>
-    type my_vec3f = vec3<f32>;
-    type my_vec4f = vec4<f32>;
+    alias my_vec3f = vec3<f32>;
+    alias my_vec4f = vec4<f32>;
 
     // Computes vec3<f32>(0.0f, 1.0f, 0.0f)
     const threeD_e2 = my_vec3f(0.0, 1.0, 0.0);
@@ -9662,8 +9662,7 @@ whose initial value is equivalent to dereferencing the parameter.
 That is, function address space pointers are viewed as aliases to a local
 variable declaration.
 
-Each [=let-declaration=], *L*, with an [=effective-value-type=] that is a [=pointer
-type=] is desugared as follows:
+Each [=let-declaration=], *L*, with an [=effective-value-type=] that is a [=pointer type=] is desugared as follows:
 * Visit each subexpression, *SE*, of the initializer expression of *L* in a postorder depth-first traversal:
     * If  *SE* invokes the [=load rule=] during [=type checking=] and the [=root identifier=]
         is a mutable variable then:
@@ -11080,6 +11079,7 @@ Issue: https://github.com/gpuweb/gpuweb/issues/1621
 
 ### Other Keywords ### {#other-keywords}
 
+* <dfn for=syntax_kw noexport>`alias`</dfn>
 * <dfn for=syntax_kw noexport>`bitcast`</dfn>
 * <dfn for=syntax_kw noexport>`break`</dfn>
 * <dfn for=syntax_kw noexport>`case`</dfn>
@@ -11102,7 +11102,6 @@ Issue: https://github.com/gpuweb/gpuweb/issues/1621
 * <dfn for=syntax_kw noexport>`struct`</dfn>
 * <dfn for=syntax_kw noexport>`switch`</dfn>
 * <dfn for=syntax_kw noexport>`true`</dfn>
-* <dfn for=syntax_kw noexport>`type`</dfn>
 * <dfn for=syntax_kw noexport>`var`</dfn>
 * <dfn for=syntax_kw noexport>`while`</dfn>
 

--- a/wgsl/keywords
+++ b/wgsl/keywords
@@ -586,7 +586,6 @@ storage
 struct
 switch
 true
-type
 uniform
 var
 while

--- a/wgsl/wgsl.recursive.bs.include
+++ b/wgsl/wgsl.recursive.bs.include
@@ -291,13 +291,13 @@
 
  | `';'`
 
+ | `'alias'` [=recursive descent syntax/ident=] `'='` [=recursive descent syntax/type_specifier=] `';'`
+
  | `'const'` [=recursive descent syntax/optionally_typed_ident=] `'='` [=recursive descent syntax/expression=] `';'`
 
  | `'const_assert'` [=recursive descent syntax/expression=] `';'`
 
  | `'struct'` [=recursive descent syntax/ident=] `'{'` [=recursive descent syntax/attribute=] * [=recursive descent syntax/member_ident=] `':'` [=recursive descent syntax/type_specifier=] ( `','` [=recursive descent syntax/attribute=] * [=recursive descent syntax/member_ident=] `':'` [=recursive descent syntax/type_specifier=] )* `','` ? `'}'`
-
- | `'type'` [=recursive descent syntax/ident=] `'='` [=recursive descent syntax/type_specifier=] `';'`
 </div>
 
 <div class='syntax' noexport='true'>

--- a/wgsl/wgsl.reserved.bs.include
+++ b/wgsl/wgsl.reserved.bs.include
@@ -267,6 +267,8 @@
 
     | `'try'`   <!-- C++ ECMAScript2022 -->
 
+    | `'type'`   <!-- Rust -->
+
     | `'typedef'`   <!-- C++ HLSL GLSL(reserved) WGSL -->
 
     | `'typeid'`   <!-- C++ -->


### PR DESCRIPTION
Fixes: #3738