### PR TITLE
Demo: Turbofish for generics is not ambiguous

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -6769,16 +6769,16 @@ Note: The [=syntax/call_expression=] rule exists to ensure [=type checking=] app
 
     | [=syntax/ident=]
 
-    | [=syntax/ident=] `'::'` <a for=syntax_sym lt=paren_left>`'<'`</a> [=syntax/primary_expression=] ( <a for=syntax_sym lt=comma>`','`</a> [=syntax/primary_expression=] ) * <a for=syntax_sym lt=comma>`','`</a> ? <a for=syntax_sym lt=paren_right>`'>'`</a>
+    | [=syntax/ident=] `'::'` <a for=syntax_sym lt=paren_left>`'<'`</a> [=syntax/additive_expression=] ( <a for=syntax_sym lt=comma>`','`</a> [=syntax/additive_expression=] ) * <a for=syntax_sym lt=comma>`','`</a> ? <a for=syntax_sym lt=paren_right>`'>'`</a>
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>callable_type</dfn> :
 
     | [=syntax/ident=]
 
-    | [=syntax/ident=] <a for=syntax_sym lt=paren_left>`'<'`</a> [=syntax/primary_expression=] ( <a for=syntax_sym lt=comma>`','`</a> [=syntax/primary_expression=] ) * <a for=syntax_sym lt=comma>`','`</a> ? <a for=syntax_sym lt=paren_right>`'>'`</a>
+    | [=syntax/ident=] <a for=syntax_sym lt=paren_left>`'<'`</a> [=syntax/additive_expression=] ( <a for=syntax_sym lt=comma>`','`</a> [=syntax/additive_expression=] ) * <a for=syntax_sym lt=comma>`','`</a> ? <a for=syntax_sym lt=paren_right>`'>'`</a>
 
-    | [=syntax/ident=] `'::'` <a for=syntax_sym lt=paren_left>`'<'`</a> [=syntax/primary_expression=] ( <a for=syntax_sym lt=comma>`','`</a> [=syntax/primary_expression=] ) * <a for=syntax_sym lt=comma>`','`</a> ? <a for=syntax_sym lt=paren_right>`'>'`</a>
+    | [=syntax/ident=] `'::'` <a for=syntax_sym lt=paren_left>`'<'`</a> [=syntax/additive_expression=] ( <a for=syntax_sym lt=comma>`','`</a> [=syntax/additive_expression=] ) * <a for=syntax_sym lt=comma>`','`</a> ? <a for=syntax_sym lt=paren_right>`'>'`</a>
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>paren_expression</dfn> :

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -294,8 +294,8 @@ that run on the GPU.
 <div class='example wgsl global-scope'>
   <xmp highlight='rust'>
     @fragment
-    fn main() -> @location(0) vec4<f32> {
-        return vec4<f32>(0.4, 0.4, 0.8, 1.0);
+    fn main() -> @location(0) vec4::<f32> {
+        return vec4::<f32>(0.4, 0.4, 0.8, 1.0);
     }
   </xmp>
 </div>
@@ -1529,16 +1529,16 @@ For example, here is the type rule for [[#logical-expr|logical negation]]
 
 This is a parameterized rule, because it contains the type parameter |T|,
 which can represent any one of four types
-[=bool=], `vec2<bool>`, `vec3<bool>`, or `vec4<bool>`.
-Applying the substitution that maps |T| to `vec3<bool>`
+[=bool=], `vec2::<bool>`, `vec3::<bool>`, or `vec4::<bool>`.
+Applying the substitution that maps |T| to `vec3::<bool>`
 produces the fully elaborated type rule:
 
 <table class='data'>
   <thead>
     <tr><th>Precondition<th>Conclusion
   </thead>
-  <tr algorithm="example2 boolean negation"><td>|e|`: vec3<bool>`<br>
-  <td>`!`|e|`: vec3<bool>`
+  <tr algorithm="example2 boolean negation"><td>|e|`: vec3::<bool>`<br>
+  <td>`!`|e|`: vec3::<bool>`
 </table>
 
 Each fully elaborated rule we can produce from a parameterized rule
@@ -1704,7 +1704,7 @@ Note: When no conversion is performed, the conversion rank is zero.
       <td>array&lt;|T|,|N|&gt;
       <td>ConversionRank(|S|,|T|)
       <td>Inherit conversion rank from component type.
-      Note: Only [=fixed-size arrays=] may have an [=type/abstract=] component type.
+      Note: Only fixed-size arrays may have an [=type/abstract=] component type.
   <tr algorithm="conversion rank for frexp result">
       <td>__frexp_result_abstract
       <td>__frexp_result_f32
@@ -2069,13 +2069,13 @@ result vector is formed by operating on each component independently.
 
 <div class='example wgsl type-scope' heading='Vector'>
   <xmp highlight='rust'>
-    vec2<f32>  // is a vector of two f32s.
+    vec2::<f32>  // is a vector of two f32s.
   </xmp>
 </div>
 
 <div class='example wgsl function-scope component-wise addition' heading='Component-wise addition'>
   <xmp highlight='rust'>
-    let x : vec3<f32> = a + b; // a and b are vec3<f32>
+    let x : vec3::<f32> = a + b; // a and b are vec3::<f32>
     // x[0] = a[0] + b[0]
     // x[1] = a[1] + b[1]
     // x[2] = a[2] + b[2]
@@ -2166,8 +2166,8 @@ See [[#arithmetic-expr]].
 
 <div class='example wgsl type-scope' heading='Matrix'>
   <xmp highlight='rust'>
-    mat2x3<f32>  // This is a 2 column, 3 row matrix of 32-bit floats.
-                 // Equivalently, it is 2 column vectors of type vec3<f32>.
+    mat2x3::<f32>  // This is a 2 column, 3 row matrix of 32-bit floats.
+                 // Equivalently, it is 2 column vectors of type vec3::<f32>.
   </xmp>
 </div>
 
@@ -2242,14 +2242,14 @@ workgroups.
 
 ### Array Types ### {#array-types}
 
-An <dfn noexport>array</dfn> is an indexable grouping of element values.
+An array is an indexable grouping of element values.
 
 <table class='data'>
   <thead>
     <tr><th>Type<th>Description
   </thead>
   <tr><td algorithm="fixed-size array type">array&lt;|E|,|N|&gt;
-      <td>A <dfn>fixed-size array</dfn> with |N| elements of type |E|.<br>
+      <td>A fixed-size array with |N| elements of type |E|.<br>
           |N| is called the <dfn noexport>element count</dfn> of the array.
   <tr><td algorithm="runtime-sized array type">array&lt;|E|&gt;
       <td>A <dfn noexport>runtime-sized</dfn> array of elements of type |E|.
@@ -2273,7 +2273,7 @@ An array element type [=shader-creation error|must=] be one of:
 * a [=vector=] type
 * a [=matrix=] type
 * an [=atomic type|atomic=] type
-* an [=array=] type having a [=creation-fixed footprint=]
+* an array type having a [=creation-fixed footprint=]
 * a [=structure=] type having a [=creation-fixed footprint=].
 
 Note: The element type must be a [=plain type=].
@@ -2291,22 +2291,22 @@ Two array types are the same if and only if all of the following are true:
 
 <div class='example wgsl fixed-size array types' heading='Example fixed-size array types, non-overridable element count'>
   <xmp highlight='rust'>
-    // array<f32,8> and array<i32,8> are different types:
+    // array::<f32,8> and array::<i32,8> are different types:
     // different element types
-    var<private> a: array<f32,8>;
-    var<private> b: array<i32,8>;
-    var<private> c: array<i32,8u>;  // array<i32,8> and array<i32,8u> are the same type
+    var<private> a: array::<f32,8>;
+    var<private> b: array::<i32,8>;
+    var<private> c: array::<i32,8u>;  // array::<i32,8> and array::<i32,8u> are the same type
 
     const width = 8;
     const height = 8;
 
-    // array<i32,8>, array<i32,8u>, and array<i32,width> are the same type.
+    // array::<i32,8>, array::<i32,8u>, and array::<i32,width> are the same type.
     // Their element counts evaluate to 8.
-    var<private> d: array<i32,width>;
+    var<private> d: array::<i32,width>;
 
-    // array<i32,height> and array<i32,width> are the same type.
-    var<private> e: array<i32,width>;
-    var<private> f: array<i32,height>;
+    // array::<i32,height> and array::<i32,width> are the same type.
+    var<private> e: array::<i32,width>;
+    var<private> f: array::<i32,height>;
   </xmp>
 </div>
 
@@ -2318,25 +2318,25 @@ This includes the [=store type=] of a workgroup variable.
   <xmp highlight='rust'>
     override blockSize = 16;
 
-    var<workgroup> odds: array<i32,blockSize>;
-    var<workgroup> evens: array<i32,blockSize>; // Same type
+    var<workgroup> odds: array::<i32,blockSize>;
+    var<workgroup> evens: array::<i32,blockSize>; // Same type
 
     // None of the following have the same type as 'odds' and 'evens'.
 
     // Different type: Not the identifier 'blockSize'
-    var<workgroup> evens_0: array<i32,16>;
+    var<workgroup> evens_0: array::<i32,16>;
     // Different type: Uses arithmetic to express the element count.
-    var<workgroup> evens_1: array<i32,(blockSize * 2 / 2)>;
+    var<workgroup> evens_1: array::<i32,(blockSize * 2 / 2)>;
     // Different type: Uses parentheses, not just an identifier.
-    var<workgroup> evens_2: array<i32,(blockSize)>;
+    var<workgroup> evens_2: array::<i32,(blockSize)>;
 
     // An invalid example, because the overridable element count may only occur
     // at the outer level.
-    // var<workgroup> both: array<array<i32,blockSize>,2>;
+    // var<workgroup> both: array::<array::<i32,blockSize>,2>;
 
     // An invalid example, because the overridable element count is only
     // valid for workgroup variables.
-    // var<private> bad_address_space: array<i32,blockSize>;
+    // var<private> bad_address_space: array::<i32,blockSize>;
   </xmp>
 </div>
 
@@ -2390,7 +2390,7 @@ A structure member type [=shader-creation error|must=] be one of:
 * a [=vector=] type
 * a [=matrix=] type
 * an [=atomic type|atomic=] type
-* a [=fixed-size array=] type with [=creation-fixed footprint=]
+* a fixed-size array type with [=creation-fixed footprint=]
 * a [=runtime-sized=] array type, but only if it is the last member of the structure
 * a [=structure=] type that has a [=creation-fixed footprint=]
 
@@ -2408,8 +2408,8 @@ Some consequences of the restrictions structure member and array element types a
     // A structure with three members.
     struct Data {
       a: i32,
-      b: vec2<f32>,
-      c: array<i32,10>, // last comma is optional
+      b: vec2::<f32>,
+      c: array::<i32,10>, // last comma is optional
     }
 
     // Declare a variable storing a value of type Data.
@@ -2456,7 +2456,7 @@ See [[#memory-layouts]].
   <xmp highlight='rust'>
     struct my_struct {
       a: f32,
-      b: vec4<f32>
+      b: vec4::<f32>
     }
   </xmp>
 </div>
@@ -2464,7 +2464,7 @@ See [[#memory-layouts]].
 <div class='example wgsl global-scope' heading='Structure used to declare a buffer'>
   <xmp highlight='rust'>
     // Runtime Array
-    type RTArr = array<vec4<f32>>;
+    type RTArr = array::<vec4::<f32>>;
     struct S {
       a: f32,
       b: f32,
@@ -2485,7 +2485,7 @@ The composite types are:
 
 * [=vector=] type
 * [=matrix=] type
-* [=array=] type
+* array type
 * [=structure=] type
 
 For a composite type |T|, the <dfn>nesting depth</dfn> of |T|, written *NestDepth*(|T|) is:
@@ -2507,7 +2507,7 @@ A type is <dfn>constructible</dfn> if it is one of:
 * a [=scalar=] type
 * a [=vector=] type
 * a [=matrix=] type
-* a [=fixed-size array=] type, if it has [=creation-fixed footprint=] and its element type is constructible.
+* a fixed-size array type, if it has [=creation-fixed footprint=] and its element type is constructible.
 * a [=structure=] type, if all its members are constructible.
 
 Note: All constructible types have a [=creation-fixed footprint=].
@@ -2539,7 +2539,7 @@ The types with [=creation-fixed footprint=] are:
 * a [=vector=] type
 * a [=matrix=] type
 * an [=atomic type|atomic=] type
-* a [=fixed-size array=] type, when:
+* a fixed-size array type, when:
      * its [=element count=] is a [=const-expression=].
 * a [=structure=] type, if all its members have [=creation-fixed footprint=].
 
@@ -2547,7 +2547,7 @@ Note: A [=constructible=] type has a [=creation-fixed footprint=].
 
 The plain types with [=fixed footprint=] are any of:
 * a type with [=creation-fixed footprint=]
-* a [=fixed-size array=] type (without further constraining its [=element count=])
+* a fixed-size array type (without further constraining its [=element count=])
 
 Note: The only valid use of a fixed-size array with an element count that is an
 [=override-expression=] that is not a [=const-expression=] is as a
@@ -2612,7 +2612,7 @@ A type is <dfn noexport>storable</dfn> if it is both [=type/concrete=] and one o
 * a [=vector=] type
 * a [=matrix=] type
 * an [=atomic type|atomic=] type
-* an [=array=] type
+* an array type
 * a [=structure=] type
 * a [=texture=] type
 * a [=sampler=] type
@@ -2634,7 +2634,7 @@ A type is <dfn noexport>host-shareable</dfn> if it is both [=type/concrete=] and
 * a [=numeric vector=] type
 * a [=matrix=] type
 * an [=atomic type|atomic=] type
-* a [=fixed-size array=] type, if it has [=creation-fixed footprint=] and its element type is host-shareable
+* a fixed-size array type, if it has [=creation-fixed footprint=] and its element type is host-shareable
 * a [=runtime-sized=] array type, if its element type is host-shareable
 * a [=structure=] type, if all its members are host-shareable
 
@@ -2720,8 +2720,8 @@ We will use the following notation:
     as the number of bytes from the start of one array element to the start of the next element.
     It equals the size of the array's element type, rounded up to the alignment of the element type:
         <p algorithm="array element stride">
-          [=StrideOf=](array<|E|, |N|>) = [=roundUp=]([=AlignOf=](E), [=SizeOf=](E))<br>
-          [=StrideOf=](array<|E|>) = [=roundUp=]([=AlignOf=](E), [=SizeOf=](E))
+          [=StrideOf=](array::<|E|, |N|>) = [=roundUp=]([=AlignOf=](E), [=SizeOf=](E))<br>
+          [=StrideOf=](array::<|E|>) = [=roundUp=]([=AlignOf=](E), [=SizeOf=](E))
         </p>
 
 
@@ -2847,10 +2847,10 @@ following table:
       <td>max([=AlignOfMember=](S,1), ... , [=AlignOfMember=](S,N))<br>
       <td>[=roundUp=]([=AlignOf=](|S|), justPastLastMember)<br><br>
           where justPastLastMember = [=OffsetOfMember=](|S|,N) + [=SizeOfMember=](|S|,N)
-  <tr><td>[=array=]<|E|, |N|><br>
+  <tr><td>array<|E|, |N|><br>
       <td>[=AlignOf=](|E|)
       <td>|N| &times; [=roundUp=]([=AlignOf=](|E|), [=SizeOf=](|E|))
-  <tr><td>array<|E|><br>
+  <tr><td>array::<|E|><br>
       <td>[=AlignOf=](|E|)
       <td>N<sub>runtime</sub> &times; [=roundUp=]([=AlignOf=](|E|),[=SizeOf=](|E|))<br><br>
           where N<sub>runtime</sub> is the runtime-determined number of elements of |T|
@@ -2910,22 +2910,22 @@ For each member index |i| > 1:
     struct A {                                     //             align(8)  size(24)
         u: f32,                                    // offset(0)   align(4)  size(4)
         v: f32,                                    // offset(4)   align(4)  size(4)
-        w: vec2<f32>,                              // offset(8)   align(8)  size(8)
+        w: vec2::<f32>,                              // offset(8)   align(8)  size(8)
         x: f32                                     // offset(16)  align(4)  size(4)
         // -- implicit struct size padding --      // offset(20)            size(4)
     }
 
     struct B {                                     //             align(16) size(160)
-        a: vec2<f32>,                              // offset(0)   align(8)  size(8)
+        a: vec2::<f32>,                              // offset(0)   align(8)  size(8)
         // -- implicit member alignment padding -- // offset(8)             size(8)
-        b: vec3<f32>,                              // offset(16)  align(16) size(12)
+        b: vec3::<f32>,                              // offset(16)  align(16) size(12)
         c: f32,                                    // offset(28)  align(4)  size(4)
         d: f32,                                    // offset(32)  align(4)  size(4)
         // -- implicit member alignment padding -- // offset(36)            size(4)
         e: A,                                      // offset(40)  align(8)  size(24)
-        f: vec3<f32>,                              // offset(64)  align(16) size(12)
+        f: vec3::<f32>,                              // offset(64)  align(16) size(12)
         // -- implicit member alignment padding -- // offset(76)            size(4)
-        g: array<A, 3>,    // element stride 24       offset(80)  align(8)  size(72)
+        g: array::<A, 3>,    // element stride 24       offset(80)  align(8)  size(72)
         h: i32                                     // offset(152) align(4)  size(4)
         // -- implicit struct size padding --      // offset(156)           size(4)
     }
@@ -2940,21 +2940,21 @@ For each member index |i| > 1:
     struct A {                                     //             align(8)  size(32)
         u: f32,                                    // offset(0)   align(4)  size(4)
         v: f32,                                    // offset(4)   align(4)  size(4)
-        w: vec2<f32>,                              // offset(8)   align(8)  size(8)
+        w: vec2::<f32>,                              // offset(8)   align(8)  size(8)
         @size(16) x: f32                           // offset(16)  align(4)  size(16)
     }
 
     struct B {                                     //             align(16) size(208)
-        a: vec2<f32>,                              // offset(0)   align(8)  size(8)
+        a: vec2::<f32>,                              // offset(0)   align(8)  size(8)
         // -- implicit member alignment padding -- // offset(8)             size(8)
-        b: vec3<f32>,                              // offset(16)  align(16) size(12)
+        b: vec3::<f32>,                              // offset(16)  align(16) size(12)
         c: f32,                                    // offset(28)  align(4)  size(4)
         d: f32,                                    // offset(32)  align(4)  size(4)
         // -- implicit member alignment padding -- // offset(36)            size(12)
         @align(16) e: A,                           // offset(48)  align(16) size(32)
-        f: vec3<f32>,                              // offset(80)  align(16) size(12)
+        f: vec3::<f32>,                              // offset(80)  align(16) size(12)
         // -- implicit member alignment padding -- // offset(92)            size(4)
-        g: array<A, 3>,    // element stride 32       offset(96)  align(8)  size(96)
+        g: array::<A, 3>,    // element stride 32       offset(96)  align(8)  size(96)
         h: i32                                     // offset(192) align(4)  size(4)
         // -- implicit struct size padding --      // offset(196)           size(12)
     }
@@ -2972,14 +2972,14 @@ For each member index |i| > 1:
     //   - alignment is 4 = AlignOf(f32)
     //   - element stride is 4 = roundUp(AlignOf(f32),SizeOf(f32)) = roundUp(4,4)
     //   - size is 32 = stride * number_of_elements = 4 * 8
-    var small_stride: array<f32, 8>;
+    var small_stride: array::<f32, 8>;
 
     // Array where:
-    //   - alignment is 16 = AlignOf(vec3<f32>) = 16
-    //   - element stride is 16 = roundUp(AlignOf(vec3<f32>), SizeOf(vec3<f32>))
+    //   - alignment is 16 = AlignOf(vec3::<f32>) = 16
+    //   - element stride is 16 = roundUp(AlignOf(vec3::<f32>), SizeOf(vec3::<f32>))
     //                          = roundUp(16,12)
     //   - size is 128 = stride * number_of_elements = 16 * 8
-    var bigger_stride: array<vec3<f32>, 8>;
+    var bigger_stride: array::<vec3::<f32>, 8>;
   </xmp>
 </div>
 
@@ -2992,16 +2992,16 @@ For each member index |i| > 1:
     // draw or dispatch command, the number of elements is:
     //   N_runtime = floor(B / element stride) = floor(B / 4)
     @group(0) @binding(0)
-    var<storage> weights: array<f32>;
+    var<storage> weights: array::<f32>;
 
     // Array where:
-    //   - alignment is 16 = AlignOf(vec3<f32>) = 16
-    //   - element stride is 16 = roundUp(AlignOf(vec3<f32>), SizeOf(vec3<f32>))
+    //   - alignment is 16 = AlignOf(vec3::<f32>) = 16
+    //   - element stride is 16 = roundUp(AlignOf(vec3::<f32>), SizeOf(vec3::<f32>))
     //                          = roundUp(16,12)
     // If B is the effective buffer binding size for the binding on the
     // draw or dispatch command, the number of elements is:
     //   N_runtime = floor(B / element stride) = floor(B / 16)
-    var<storage> directions: array<vec3<f32>>;
+    var<storage> directions: array::<vec3::<f32>>;
   </xmp>
 </div>
 
@@ -3064,7 +3064,7 @@ When a value |V| of [=matrix|matrix type=] mat|C|x|R|&lt;|T|&gt; is placed at
 byte offset |k| of a host-shared buffer, then:
   * Column vector |i| of |V| is placed at byte offset |k| + |i| &times; [=AlignOf=](vec|R|&lt;|T|&gt;)
 
-When a value of [=array|array type=] |A| is placed at byte offset |k| of a host-shared memory buffer,
+When a value of array type |A| is placed at byte offset |k| of a host-shared memory buffer,
 then:
    * Element |i| of the array is placed at byte offset |k| + |i| &times; [=StrideOf=](|A|)
 
@@ -3110,7 +3110,7 @@ used in address space |C|.
       <td>[=AlignOf=](|S|)
       <td>[=AlignOf=](|S|)
   <tr algorithm="alignment of an array">
-      <td>[=array=]&lt;T, N&gt;
+      <td>array&lt;T, N&gt;
       <td>[=AlignOf=](|S|)
       <td>[=roundUp=](16, [=AlignOf=](|S|))
   <tr algorithm="alignment of an runtime-sized array">
@@ -3136,8 +3136,8 @@ Arrays of element type |T| [=shader-creation error|must=] have an [=element stri
 multiple of the [=RequiredAlignOf=](|T|, |C|) for the address space |C|:
 
 <p algorithm="array element minimum alignment">
-    [=StrideOf=](array<|T|, |N|>) = |k| &times; [=RequiredAlignOf=](|T|, C)<br>
-    [=StrideOf=](array<|T|>) = |k| &times; [=RequiredAlignOf=](|T|, C)<br>
+    [=StrideOf=](array::<|T|, |N|>) = |k| &times; [=RequiredAlignOf=](|T|, C)<br>
+    [=StrideOf=](array::<|T|>) = |k| &times; [=RequiredAlignOf=](|T|, C)<br>
     Where |k| is a positive integer
 </p>
 
@@ -3181,7 +3181,7 @@ to WGSL.
 <div class='example wgsl global-scope' heading='Satisfying stride requirements for uniform address space'>
   <xmp highlight='rust'>
     struct small_stride {
-      a: array<f32,8> // stride 4
+      a: array::<f32,8> // stride 4
     }
     // Invalid, stride must be a multiple of 16
     @group(0) @binding(0) var<uniform> invalid: small_stride;
@@ -3190,7 +3190,7 @@ to WGSL.
       @size(16) elem: f32
     }
     struct big_stride {
-      a: array<wrapped_f32,8> // stride 16
+      a: array::<wrapped_f32,8> // stride 16
     }
     @group(0) @binding(1) var<uniform> valid: big_stride;     // Valid
   </xmp>
@@ -3270,18 +3270,18 @@ However, in WGSL *source* text:
 <div class='example wgsl' heading='Pointer type'>
   <xmp highlight='rust'>
     fn my_function(
-      /* 'ptr<function,i32,read_write>' is the type of a pointer value that references
+      /* 'ptr::<function,i32,read_write>' is the type of a pointer value that references
          memory for keeping an 'i32' value, using memory locations in the 'function'
          address space.  Here 'i32' is the store type.
          The implied access mode is 'read_write'. See below for access mode defaults. */
-      ptr_int: ptr<function,i32>,
+      ptr_int: ptr::<function,i32>,
 
-      // 'ptr<private,array<f32,50>,read_write>' is the type of a pointer value that
+      // 'ptr::<private,array::<f32,50>,read_write>' is the type of a pointer value that
       // refers to memory for keeping an array of 50 elements of type 'f32', using
       // memory locations in the 'private' address space.
-      // Here the store type is 'array<f32,50>'.
+      // Here the store type is 'array::<f32,50>'.
       // The implied access mode is 'read_write'. See below for access mode defaults.
-      ptr_array: ptr<private, array<f32, 50>>
+      ptr_array: ptr::<private, array::<f32, 50>>
     ) { }
   </xmp>
 </div>
@@ -3454,24 +3454,24 @@ Note: The following examples use WGSL features explained later in this specifica
 <div class='example wgsl' heading='Using a pointer as a short name for part of a variable'>
   <xmp highlight='rust'>
     struct Particle {
-      position: vec3<f32>,
-      velocity: vec3<f32>
+      position: vec3::<f32>,
+      velocity: vec3::<f32>
     }
     struct System {
       active_index: i32,
       timestep: f32,
-      particles: array<Particle,100>
+      particles: array::<Particle,100>
     }
     @group(0) @binding(0) var<storage,read_write> system: System;
 
     @compute @workgroup_size(1)
     fn main() {
       // Form a pointer to a specific Particle in storage memory.
-      let active_particle: ptr<storage,Particle> =
+      let active_particle: ptr::<storage,Particle> =
           &system.particles[system.active_index];
 
-      let delta_position: vec3<f32> = (*active_particle).velocity * system.timestep;
-      let current_position: vec3<f32>  = (*active_particle).position;
+      let delta_position: vec3::<f32> = (*active_particle).velocity * system.timestep;
+      let current_position: vec3::<f32>  = (*active_particle).position;
       (*active_particle).position = delta_position + current_position;
     }
   </xmp>
@@ -3479,7 +3479,7 @@ Note: The following examples use WGSL features explained later in this specifica
 
 <div class='example wgsl' heading='Using a pointer as a formal parameter'>
   <xmp highlight='rust'>
-    fn add_one(x: ptr<function,i32>) {
+    fn add_one(x: ptr::<function,i32>) {
       /* Update the locations for 'x' to contain the next higher integer value,
          (or to wrap around to the largest negative i32 value).
          On the left-hand side, unary '*' converts the pointer to a reference that
@@ -3530,7 +3530,7 @@ A reference value is formed in one of the following ways:
     * Given a reference with a [=matrix=] store type, appending an array index access phrase
         results in a reference to the indexed column vector of the matrix.
         See [[#matrix-access-expr]].
-    * Given a reference with an [=array=] store type, appending an array index access phrase
+    * Given a reference with an array store type, appending an array index access phrase
         results in a reference to the indexed element of the array.
         See [[#array-access-expr]].
     * Given a reference with a [=structure=] store type, appending a member access phrase
@@ -3550,15 +3550,15 @@ In all cases, the [=access mode=] of the result is the same as the access mode o
     // and will have type ref<private,S,read_write>.
 
     fn f() {
-        var uv: vec2<f32>;
+        var uv: vec2::<f32>;
         // For the remainder of this function body, 'uv' denotes the reference
         // to the memory underlying the variable, and will have type
-        // ref<function,vec2<f32>,read_write>.
+        // ref<function,vec2::<f32>,read_write>.
 
         // Evaluate the left-hand side of the assignment:
         //   Evaluate 'uv.x' to yield a reference:
         //   1. First evaluate 'uv', yielding a reference to the memory for
-        //      the 'uv' variable. The result has type ref<function,vec2<f32>,read_write>.
+        //      the 'uv' variable. The result has type ref<function,vec2::<f32>,read_write>.
         //   2. Then apply the '.x' vector access phrase, yielding a reference to
         //      the memory for the first component of the vector pointed at by the
         //      reference value from the previous step.
@@ -3570,7 +3570,7 @@ In all cases, the [=access mode=] of the result is the same as the access mode o
         // Evaluate the left-hand side of the assignment:
         //   Evaluate 'uv[1]' to yield a reference:
         //   1. First evaluate 'uv', yielding a reference to the memory for
-        //      the 'uv' variable. The result has type ref<function,vec2<f32>,read_write>.
+        //      the 'uv' variable. The result has type ref<function,vec2::<f32>,read_write>.
         //   2. Then apply the '[1]' array index phrase, yielding a reference to
         //      the memory for second component of the vector referenced from
         //      the previous step.  The result has type ref<function,f32,read_write>.
@@ -3578,26 +3578,26 @@ In all cases, the [=access mode=] of the result is the same as the access mode o
         // Store the f32 value 2.0 into the storage memory locations referenced by uv[1].
         uv[1] = 2.0;
 
-        var m: mat3x2<f32>;
+        var m: mat3x2::<f32>;
         // When evaluating 'm[2]':
         // 1. First evaluate 'm', yielding a reference to the memory for
-        //    the 'm' variable. The result has type ref<function,mat3x2<f32>,read_write>.
+        //    the 'm' variable. The result has type ref<function,mat3x2::<f32>,read_write>.
         // 2. Then apply the '[2]' array index phrase, yielding a reference to
         //    the memory for the third column vector pointed at by the reference
         //    value from the previous step.
-        //    Therefore the 'm[2]' expression has type ref<function,vec2<f32>,read_write>.
-        // The 'let' declaration is for type vec2<f32>, so the declaration
-        // statement requires the initializer to be of type vec2<f32>.
+        //    Therefore the 'm[2]' expression has type ref<function,vec2::<f32>,read_write>.
+        // The 'let' declaration is for type vec2::<f32>, so the declaration
+        // statement requires the initializer to be of type vec2::<f32>.
         // The Load Rule applies (because no other type rule can apply), and
-        // the evaluation of the initializer yields the vec2<f32> value loaded
+        // the evaluation of the initializer yields the vec2::<f32> value loaded
         // from the memory locations referenced by 'm[2]' at the time the declaration
         // is executed.
-        let p_m_col2: vec2<f32> = m[2];
+        let p_m_col2: vec2::<f32> = m[2];
 
-        var A: array<i32,5>;
+        var A: array::<i32,5>;
         // When evaluating 'A[4]'
         // 1. First evaluate 'A', yielding a reference to the memory for
-        //    the 'A' variable. The result has type ref<function,array<i32,5>,read_write>.
+        //    the 'A' variable. The result has type ref<function,array::<i32,5>,read_write>.
         // 2. Then apply the '[4]' array index phrase, yielding a reference to
         //    the memory for the fifth element of the array referenced by
         //    the reference value from the previous step.
@@ -3652,16 +3652,16 @@ In all cases, the access mode of the result is the same as the access mode of th
         // and has reference type ref<private,f32,read_write>.
         // Applying the unary '&' operator converts the reference to a pointer.
         // The access mode is the same as the access mode of the original variable, so
-        // the fully specified type is ptr<private,f32,read_write>.  But read_write
+        // the fully specified type is ptr::<private,f32,read_write>.  But read_write
         // is the default access mode for function address space, so read_write does not
         // have to be spelled in this case
-        let x_ptr: ptr<private,f32> = &x;
+        let x_ptr: ptr::<private,f32> = &x;
 
         // The name 'y' resolves to the function-scope variable 'y',
         // and has reference type ref<private,i32,read_write>.
         // Applying the unary '&' operator converts the reference to a pointer.
         // The access mode defaults to 'read_write'.
-        let y_ptr: ptr<function,i32> = &y;
+        let y_ptr: ptr::<function,i32> = &y;
 
         // A new variable, distinct from the variable declared at module scope.
         var x: u32;
@@ -3670,7 +3670,7 @@ In all cases, the access mode of the result is the same as the access mode of th
         // the previous statement, and has type ref<function,u32,read_write>.
         // Applying the unary '&' operator converts the reference to a pointer.
         // The access mode defaults to 'read_write'.
-        let inner_x_ptr: ptr<function,u32> = &x;
+        let inner_x_ptr: ptr::<function,u32> = &x;
     }
   </xmp>
 </div>
@@ -3912,12 +3912,12 @@ The last column in the table below uses the format-specific
 ### Sampled Texture Types ### {#sampled-texture-type}
 
 <pre class='def'>
-`texture_1d<type>`
-`texture_2d<type>`
-`texture_2d_array<type>`
-`texture_3d<type>`
+`texture_1d::<type>`
+`texture_2d::<type>`
+`texture_2d_array::<type>`
+`texture_3d::<type>`
 `texture_cube<type>`
-`texture_cube_array<type>`
+`texture_cube_array::<type>`
 </pre>
 * type [=shader-creation error|must=] be `f32`, `i32` or `u32`
 * The parameterized type for the images is the type after conversion from sampling.
@@ -3927,7 +3927,7 @@ The last column in the table below uses the format-specific
 ### Multisampled Texture Types ### {#multisampled-texture-type}
 
 <pre class='def'>
-`texture_multisampled_2d<type>`
+`texture_multisampled_2d::<type>`
 </pre>
 * type [=shader-creation error|must=] be `f32`, `i32` or `u32`
 
@@ -3937,7 +3937,7 @@ The last column in the table below uses the format-specific
 `texture_external`
 </pre>
 
-`texture_external` is an opaque 2d float-sampled texture type similar to `texture_2d<f32>`
+`texture_external` is an opaque 2d float-sampled texture type similar to `texture_2d::<f32>`
 but potentially with a different representation.
 It can be read using [[#textureload|textureLoad]] or [[#textureSampleBaseClampToEdge|textureSampleBaseClampToEdge]] built-in functions,
 which handle these different representations opaquely.
@@ -3964,10 +3964,10 @@ See [[#texture-builtin-functions]].
 TODO(dneto): Move description of the conversion to the builtin function that actually does the reading.
 
 <pre class='def'>
-`texture_storage_1d<texel_format,access>`
-`texture_storage_2d<texel_format,access>`
-`texture_storage_2d_array<texel_format,access>`
-`texture_storage_3d<texel_format,access>`
+`texture_storage_1d::<texel_format,access>`
+`texture_storage_2d::<texel_format,access>`
+`texture_storage_2d_array::<texel_format,access>`
+`texture_storage_3d::<texel_format,access>`
 </pre>
 
 * `texel_format` is a [=context-dependent name=] and [=shader-creation error|must=] be one of the texel types specified in [=storage-texel-formats=]
@@ -4100,9 +4100,9 @@ all properties of the members of *S*, including attributes, carry over to the me
 
 <div class='example wgsl global-scope' heading='Type Alias'>
   <xmp highlight='rust'>
-    type Arr = array<i32, 5>;
+    type Arr = array::<i32, 5>;
 
-    type RTArr = array<vec4<f32>>;
+    type RTArr = array::<vec4::<f32>>;
 
     type single = f32;     // Declare an alias for f32
     const pi_approx: single = 3.1415;
@@ -4117,9 +4117,7 @@ all properties of the members of *S*, including attributes, carry over to the me
 <div class='syntax' noexport='true'>
   <dfn for=syntax>type_specifier</dfn> :
 
-    | [=syntax/ident=]
-
-    | [=syntax/type_specifier_without_ident=]
+    | [=syntax/callable=]
 </div>
 
 <div class='syntax' noexport='true'>
@@ -4371,7 +4369,7 @@ effective-value-type.
     [=access mode=] is mutable, but can only be modified via
     [[#texturestore|textureStore]] built-in function.
     The variable itself cannot be modified.
-7. The [=element count=] of the outermost [=array=] may be an
+7. The [=element count=] of the outermost array may be an
     [=override-expression=].
 8. If there is no initializer, the variable is [=default initial value|default
     initialized=].
@@ -4646,7 +4644,7 @@ The initial values are computed as follows:
         value=] is determined by recursively applying these rules to each
         [=component=] of the [=composite=] until a [=constructible=] type is
         encountered.
-        * Note: This commonly occurs when using an [=array=] with a
+        * Note: This commonly occurs when using an array with a
             [=pipeline-overridable=] [=element count=] or a [=composite=] that
             contains an [=atomic type=].
 
@@ -4681,7 +4679,7 @@ such that the redundant loads are eliminated.
 <div class='example wgsl global-scope' heading="Module scope variable declarations">
   <xmp highlight='rust'>
     var<private> decibels: f32;
-    var<workgroup> worklist: array<i32,10>;
+    var<workgroup> worklist: array::<i32,10>;
 
     struct Params {
       specular: f32,
@@ -4694,7 +4692,7 @@ such that the redundant loads are eliminated.
 
     // A storage buffer, for reading and writing
     @group(0) @binding(0)
-    var<storage,read_write> pbuf: array<vec2<f32>>;
+    var<storage,read_write> pbuf: array::<vec2::<f32>>;
 
     // Textures and samplers are always in "handle" space.
     @group(0) @binding(1)
@@ -4788,7 +4786,7 @@ execution on the GPU, so only the result of the computation of the expression
 is necessary in the final GPU code.
 Additionally, because [=const-expressions=] are evaluated at [=shader module
 creation|shader-creation time=] they can be used in more situations than
-[=override-expressions=], for example, to size [=arrays=] in [=function scope=]
+[=override-expressions=], for example, to size arrays in [=function scope=]
 [=variable declaration|variables=].
 A <dfn noexport>runtime expression</dfn> is an expression that is neither a
 [=const-expression=] nor an [=override-expression=].
@@ -4905,7 +4903,7 @@ Example: `vec3(x,x,x)` is analyzed as follows:
 * `vec3(x,x,x)` is an override-expression because the only identifiers
     [=resolve=] to override-declarations.
 * The type of the expression is a [=vector=] of 3 components
-    of [=i32=] (`vec3<i32>`).
+    of [=i32=] (`vec3::<i32>`).
 
 ## Indeterminate values ## {#indeterminate-values}
 
@@ -4926,8 +4924,8 @@ the indeterminate value produced at runtime may be a NaN value.
 <div class='example wgsl global-scope' heading="Indeterminate value example">
   <xmp highlight='rust'>
     fn fun() {
-       var extracted_values: array<i32,2>;
-       const v = vec2<i32>(0,1);
+       var extracted_values: array::<i32,2>;
+       const v = vec2::<i32>(0,1);
 
        for (var i: i32 = 0; i < 2 ; i++) {
           // A runtime-expression used to index a vector, but outside the
@@ -4955,7 +4953,7 @@ the indeterminate value produced at runtime may be a NaN value.
     }
 
     fn float_fun(runtime_index: u32) {
-       const v = vec2<f32>(0,1); // A vector of floating point values
+       const v = vec2::<f32>(0,1); // A vector of floating point values
 
        // As in the previous example, 'float_extract' is an indeterminate value.
        // Since it is a floating point type, it may be a NaN.
@@ -5033,23 +5031,23 @@ In the following sections, when a type name precedes a parenthesized argument li
 
 <div class='example wgsl global-scope' heading="Type constructor expressions using type aliases">
   <xmp highlight='rust'>
-    type my_vec3f = vec3<f32>;
-    type my_vec4f = vec4<f32>;
+    type my_vec3f = vec3::<f32>;
+    type my_vec4f = vec4::<f32>;
 
-    // Computes vec3<f32>(0.0f, 1.0f, 0.0f)
+    // Computes vec3::<f32>(0.0f, 1.0f, 0.0f)
     const threeD_e2 = my_vec3f(0.0, 1.0, 0.0);
 
-    // Same as writing vec4<f32>(threeD_e2, 0.0)
-    // Computes vec4<f32>(0.0f, 1.0f, 0.0f, 0.0f)
+    // Same as writing vec4::<f32>(threeD_e2, 0.0)
+    // Computes vec4::<f32>(0.0f, 1.0f, 0.0f, 0.0f)
     const fourD_e2 = my_vec4f(threeD_e2, 0.0);
 
-    // Same as writing vec3<f32>()
-    // Computes vec3<f32>(0.0f, 0.0f, 0.0f)
+    // Same as writing vec3::<f32>()
+    // Computes vec3::<f32>(0.0f, 0.0f, 0.0f)
     const threeD_zero = my_vec3f();
 
     // Use the fully-elaborated name for a 4-element vector of f32.
-    const fourD_ones_first  = vec4<f32>(1.0f);
-    // Use vec4f, the predeclared alias to vec4<f32>.
+    const fourD_ones_first  = vec4::<f32>(1.0f);
+    // Use vec4f, the predeclared alias to vec4::<f32>.
     const fourD_ones_second = vec4f(1.0f);
   </xmp>
 </div>
@@ -5094,82 +5092,82 @@ specify the component type; the component type is inferred from the constructor 
   <tr>
     <td rowspan=2>*e1*: *T*<br>
         *e2*: *T*
-    <td>`vec2<T>(e1,e2)`: vec2<*T*>
+    <td>`vec2::<T>(e1,e2)`: vec2::<*T*>
     <td rowspan=2>
   <tr>
-    <td>`vec2(e1,e2)`: vec2<*T*>
+    <td>`vec2(e1,e2)`: vec2::<*T*>
   <tr>
     <td rowspan=2>*e*: vec2&lt;T&gt;
-    <td>`vec2<T>(e)`: vec2<*T*>
+    <td>`vec2::<T>(e)`: vec2::<*T*>
     <td rowspan=2>Identity. The result is |e|.
   <tr>
-    <td>`vec2(e)`: vec2<*T*>
+    <td>`vec2(e)`: vec2::<*T*>
   <tr>
     <td rowspan=2>*e1*: *T*<br>
         *e2*: *T*<br>
         *e3*: *T*
-    <td>`vec3<T>(e1,e2,e3)`: vec3<*T*>
+    <td>`vec3::<T>(e1,e2,e3)`: vec3::<*T*>
     <td rowspan=2>
   <tr>
-    <td>`vec3(e1,e2,e3)`: vec3<*T*>
+    <td>`vec3(e1,e2,e3)`: vec3::<*T*>
   <tr>
     <td rowspan=2>*e1*: *T*<br>
-        *e2*: vec2<*T*>
-    <td>`vec3<T>(e1,e2)`: vec3<*T*><br>
-        `vec3<T>(e2,e1)`: vec3<*T*>
+        *e2*: vec2::<*T*>
+    <td>`vec3::<T>(e1,e2)`: vec3::<*T*><br>
+        `vec3::<T>(e2,e1)`: vec3::<*T*>
     <td rowspan=2>
   <tr>
-    <td>`vec3(e1,e2)`: vec3<*T*><br>
-        `vec3(e2,e1)`: vec3<*T*>
+    <td>`vec3(e1,e2)`: vec3::<*T*><br>
+        `vec3(e2,e1)`: vec3::<*T*>
   <tr>
     <td rowspan=2>*e*: vec3&lt;T&gt;
-    <td>`vec3<T>(e)`: vec3<*T*>
+    <td>`vec3::<T>(e)`: vec3::<*T*>
     <td rowspan=2>Identity. The result is |e|.
   <tr>
-    <td>`vec3(e)`: vec3<*T*>
+    <td>`vec3(e)`: vec3::<*T*>
   <tr>
     <td rowspan=2>*e1*: *T*<br>
         *e2*: *T*<br>
         *e3*: *T*<br>
         *e4*: *T*
-    <td class=nowrap>`vec4<T>(e1,e2,e3,e4)`: vec4<*T*>
+    <td class=nowrap>`vec4::<T>(e1,e2,e3,e4)`: vec4::<*T*>
     <td rowspan=2>
   <tr>
-    <td class=nowrap>`vec4(e1,e2,e3,e4)`: vec4<*T*>
+    <td class=nowrap>`vec4(e1,e2,e3,e4)`: vec4::<*T*>
   <tr>
     <td rowspan=2>*e1*: *T*<br>
         *e2*: *T*<br>
-        *e3*: vec2<*T*>
-    <td class=nowrap>`vec4<T>(e1,e2,e3)`: vec4<*T*><br>
-        `vec4<T>(e1,e3,e2)`: vec4<*T*><br>
-        `vec4<T>(e3,e1,e2)`: vec4<*T*>
+        *e3*: vec2::<*T*>
+    <td class=nowrap>`vec4::<T>(e1,e2,e3)`: vec4::<*T*><br>
+        `vec4::<T>(e1,e3,e2)`: vec4::<*T*><br>
+        `vec4::<T>(e3,e1,e2)`: vec4::<*T*>
     <td rowspan=2>
   <tr>
-    <td class=nowrap>`vec4(e1,e2,e3)`: vec4<*T*><br>
-        `vec4(e1,e3,e2)`: vec4<*T*><br>
-        `vec4(e3,e1,e2)`: vec4<*T*>
+    <td class=nowrap>`vec4(e1,e2,e3)`: vec4::<*T*><br>
+        `vec4(e1,e3,e2)`: vec4::<*T*><br>
+        `vec4(e3,e1,e2)`: vec4::<*T*>
   <tr>
-    <td rowspan=2>*e1*: vec2<*T*><br>
-        *e2*: vec2<*T*>
-    <td class=nowrap>`vec4<T>(e1,e2)`: vec4<*T*>
+    <td rowspan=2>*e1*: vec2::<*T*><br>
+        *e2*: vec2::<*T*>
+    <td class=nowrap>`vec4::<T>(e1,e2)`: vec4::<*T*>
     <td rowspan=2>
   <tr>
-    <td class=nowrap>`vec4(e1,e2)`: vec4<*T*>
+    <td class=nowrap>`vec4(e1,e2)`: vec4::<*T*>
   <tr>
     <td rowspan=2>*e1*: *T*<br>
-        *e2*: vec3<*T*>
-    <td class=nowrap>`vec4<T>(e1,e2)`: vec4<*T*><br>
-        `vec4<T>(e2,e1)`: vec4<*T*>
+        *e2*: vec3::<*T*>
+    <td class=nowrap>`vec4::<T>(e1,e2)`: vec4::<*T*><br>
+        `vec4::<T>(e2,e1)`: vec4::<*T*>
     <td rowspan=2>
   <tr>
-    <td>`vec4(e1,e2)`: vec4<*T*><br>
-        `vec4(e2,e1)`: vec4<*T*>
+    <td>`vec4(e1,e2)`: vec4::<*T*><br>
+        `vec4(e2,e1)`: vec4::<*T*>
   <tr>
     <td rowspan=2>*e*: vec4&lt;T&gt;
-    <td class=nowrap>`vec4<T>(e)`: vec4<*T*>
+    <td class=nowrap>`vec4::<T>(e)`: vec4::<*T*>
     <td rowspan=2>Identity. The result is |e|.
   <tr>
-    <td class=nowrap>`vec4(e)`: vec4<*T*>
+    <td class=nowrap>`vec4(e)`: vec4::<*T*>
 </table>
 
 <table class='data'>
@@ -5179,54 +5177,54 @@ specify the component type; the component type is inferred from the constructor 
   </thead>
   <tr>
     <td>|e|: mat2x2&lt;|T|&gt;
-    <td>`mat2x2<`|T|`>(`|e|`)`: mat2x2&lt;|T|&gt;<br>
+    <td>`mat2x2::<`|T|`>(`|e|`)`: mat2x2&lt;|T|&gt;<br>
         `mat2x2(`|e|`)`: mat2x2&lt;|T|&gt;<br>
     <td rowspan=9>Identity type conversion. The result is |e|.
   <tr>
     <td>|e|: mat2x3&lt;|T|&gt;
-    <td>`mat2x3<`|T|`>(`|e|`)`: mat2x3&lt;|T|&gt;<br>
+    <td>`mat2x3::<`|T|`>(`|e|`)`: mat2x3&lt;|T|&gt;<br>
         `mat2x3(`|e|`)`: mat2x3&lt;|T|&gt;
   <tr>
     <td>|e|: mat2x4&lt;|T|&gt;
-    <td>`mat2x4<`|T|`>(`|e|`)`: mat2x4&lt;|T|&gt;<br>
+    <td>`mat2x4::<`|T|`>(`|e|`)`: mat2x4&lt;|T|&gt;<br>
         `mat2x4(`|e|`)`: mat2x4&lt;|T|&gt;
   <tr>
     <td>|e|: mat3x2&lt;|T|&gt;
-    <td>`mat3x2<`|T|`>(`|e|`)`: mat3x2&lt;|T|&gt;<br>
+    <td>`mat3x2::<`|T|`>(`|e|`)`: mat3x2&lt;|T|&gt;<br>
         `mat3x2(`|e|`)`: mat3x2&lt;|T|&gt;
   <tr>
     <td>|e|: mat3x3&lt;|T|&gt;
-    <td>`mat3x3<`|T|`>(`|e|`)`: mat3x3&lt;|T|&gt;<br>
+    <td>`mat3x3::<`|T|`>(`|e|`)`: mat3x3&lt;|T|&gt;<br>
         `mat3x3(`|e|`)`: mat3x3&lt;|T|&gt;
   <tr>
     <td>|e|: mat3x4&lt;|T|&gt;
-    <td>`mat3x4<`|T|`>(`|e|`)`: mat3x4&lt;|T|&gt;<br>
+    <td>`mat3x4::<`|T|`>(`|e|`)`: mat3x4&lt;|T|&gt;<br>
         `mat3x4(`|e|`)`: mat3x4&lt;|T|&gt;
   <tr>
     <td>|e|: mat4x2&lt;|T|&gt;
-    <td>`mat4x2<`|T|`>(`|e|`)`: mat4x2&lt;|T|&gt;<br>
+    <td>`mat4x2::<`|T|`>(`|e|`)`: mat4x2&lt;|T|&gt;<br>
         `mat4x2(`|e|`)`: mat4x2&lt;|T|&gt;
   <tr>
     <td>|e|: mat4x3&lt;|T|&gt;
-    <td>`mat4x3<`|T|`>(`|e|`)`: mat4x3&lt;|T|&gt;<br>
+    <td>`mat4x3::<`|T|`>(`|e|`)`: mat4x3&lt;|T|&gt;<br>
         `mat4x3(`|e|`)`: mat4x3&lt;|T|&gt;
   <tr>
     <td>|e|: mat4x4&lt;|T|&gt;
-    <td>`mat4x4<`|T|`>(`|e|`)`: mat4x4&lt;|T|&gt;<br>
+    <td>`mat4x4::<`|T|`>(`|e|`)`: mat4x4&lt;|T|&gt;<br>
         `mat4x4(`|e|`)`: mat4x4&lt;|T|&gt;
   <tr>
     <td rowspan=2>|e1|: |T|<br>
         ...<br>
         |eN|: |T|<br>
-    <td>`mat2x2<T>(e1,e2,e3,e4)`: mat2x2&lt;|T|&gt;<br>
-        `mat3x2<T>(e1,...,e6)`: mat3x2&lt;|T|&gt;<br>
-        `mat2x3<T>(e1,...,e6)`: mat2x3&lt;|T|&gt;<br>
-        `mat4x2<T>(e1,...,e8)`: mat4x2&lt;|T|&gt;<br>
-        `mat2x4<T>(e1,...,e8)`: mat2x4&lt;|T|&gt;<br>
-        `mat3x3<T>(e1,...,e9)`: mat3x3&lt;|T|&gt;<br>
-        `mat4x3<T>(e1,...,e12)`: mat4x3&lt;|T|&gt;<br>
-        `mat3x4<T>(e1,...,e12)`: mat3x4&lt;|T|&gt;<br>
-        `mat4x4<T>(e1,...,e16)`: mat4x4&lt;|T|&gt;
+    <td>`mat2x2::<T>(e1,e2,e3,e4)`: mat2x2&lt;|T|&gt;<br>
+        `mat3x2::<T>(e1,...,e6)`: mat3x2&lt;|T|&gt;<br>
+        `mat2x3::<T>(e1,...,e6)`: mat2x3&lt;|T|&gt;<br>
+        `mat4x2::<T>(e1,...,e8)`: mat4x2&lt;|T|&gt;<br>
+        `mat2x4::<T>(e1,...,e8)`: mat2x4&lt;|T|&gt;<br>
+        `mat3x3::<T>(e1,...,e9)`: mat3x3&lt;|T|&gt;<br>
+        `mat4x3::<T>(e1,...,e12)`: mat4x3&lt;|T|&gt;<br>
+        `mat3x4::<T>(e1,...,e12)`: mat3x4&lt;|T|&gt;<br>
+        `mat4x4::<T>(e1,...,e16)`: mat4x4&lt;|T|&gt;
     <td rowspan=2>Column-major construction by elements.<br>
   <tr>
     <td>`mat2x2(e1,e2,e3,e4)`: mat2x2&lt;|T|&gt;<br>
@@ -5243,9 +5241,9 @@ specify the component type; the component type is inferred from the constructor 
         *e2*: vec2&lt;|T|&gt;<br>
         *e3*: vec2&lt;|T|&gt;<br>
         *e4*: vec2&lt;|T|&gt;<br>
-    <td>`mat2x2<T>(e1,e2)`: mat2x2&lt;|T|&gt;<br>
-        `mat3x2<T>(e1,e2,e3)`: mat3x2&lt;|T|&gt;<br>
-        `mat4x2<T>(e1,e2,e3,e4)`: mat4x2&lt;|T|&gt;
+    <td>`mat2x2::<T>(e1,e2)`: mat2x2&lt;|T|&gt;<br>
+        `mat3x2::<T>(e1,e2,e3)`: mat3x2&lt;|T|&gt;<br>
+        `mat4x2::<T>(e1,e2,e3,e4)`: mat4x2&lt;|T|&gt;
     <td rowspan=2>Column by column construction.<br>
   <tr>
     <td>`mat2x2(e1,e2)`: mat2x2&lt;|T|&gt;<br>
@@ -5256,9 +5254,9 @@ specify the component type; the component type is inferred from the constructor 
         *e2*: vec3&lt;|T|&gt;<br>
         *e3*: vec3&lt;|T|&gt;<br>
         *e4*: vec3&lt;|T|&gt;<br>
-    <td>`mat2x3<T>(e1,e2)`: mat2x3&lt;|T|&gt;<br>
-        `mat3x3<T>(e1,e2,e3)`: mat3x3&lt;|T|&gt;<br>
-        `mat4x3<T>(e1,e2,e3,e4)`: mat4x3&lt;|T|&gt;
+    <td>`mat2x3::<T>(e1,e2)`: mat2x3&lt;|T|&gt;<br>
+        `mat3x3::<T>(e1,e2,e3)`: mat3x3&lt;|T|&gt;<br>
+        `mat4x3::<T>(e1,e2,e3,e4)`: mat4x3&lt;|T|&gt;
     <td rowspan=2>Column by column construction.<br>
   <tr>
     <td>`mat2x3(e1,e2)`: mat2x3&lt;|T|&gt;<br>
@@ -5269,9 +5267,9 @@ specify the component type; the component type is inferred from the constructor 
         *e2*: vec4&lt;|T|&gt;<br>
         *e3*: vec4&lt;|T|&gt;<br>
         *e4*: vec4&lt;|T|&gt;<br>
-    <td>`mat2x4<T>(e1,e2)`: mat2x4&lt;|T|&gt;<br>
-        `mat3x4<T>(e1,e2,e3)`: mat3x4&lt;|T|&gt;<br>
-        `mat4x4<T>(e1,e2,e3,e4)`: mat4x4&lt;|T|&gt;
+    <td>`mat2x4::<T>(e1,e2)`: mat2x4&lt;|T|&gt;<br>
+        `mat3x4::<T>(e1,e2,e3)`: mat3x4&lt;|T|&gt;<br>
+        `mat4x4::<T>(e1,e2,e3,e4)`: mat4x4&lt;|T|&gt;
     <td rowspan=2>Column by column construction.<br>
   <tr>
     <td>`mat2x4(e1,e2)`: mat2x4&lt;|T|&gt;<br>
@@ -5289,7 +5287,7 @@ specify the component type; the component type is inferred from the constructor 
         ...<br>
         |eN|: |T|,<br>
         |T| is [=type/concrete=] and [=constructible=]<br>
-    <td class="nowrap">`array<`|T|,|N|`>(`|e1|,...,|eN|`)` : array&lt;|T|,|N|&gt;
+    <td class="nowrap">`array::<`|T|,|N|`>(`|e1|,...,|eN|`)` : array&lt;|T|,|N|&gt;
     <td>Construction of an array from elements.
 
         Note: array&lt;|T|,|N|&gt; is [=constructible=] because its [=element count=]
@@ -5359,26 +5357,26 @@ Note: WGSL does not have zero expression for [=atomic types=],
   </thead>
   <tr>
     <td>
-    <td>`vec2<T>()`: vec2<|T|>
+    <td>`vec2::<T>()`: vec2::<|T|>
     <td>Zero value
   <tr>
     <td>
-    <td>`vec3<T>()`: vec3<|T|>
+    <td>`vec3::<T>()`: vec3::<|T|>
     <td>Zero value
   <tr>
     <td>
-    <td>`vec4<T>()`: vec4<|T|>
+    <td>`vec4::<T>()`: vec4::<|T|>
     <td>Zero value
 </table>
 
 
 <div class='example' heading="Zero-valued vectors">
   <xmp highlight='rust'>
-    vec2<f32>()                 // The zero-valued vector of two f32 components.
-    vec2<f32>(0.0, 0.0)         // The same value, written explicitly.
+    vec2::<f32>()                 // The zero-valued vector of two f32 components.
+    vec2::<f32>(0.0, 0.0)         // The same value, written explicitly.
 
-    vec3<i32>()                 // The zero-valued vector of three i32 components.
-    vec3<i32>(0, 0, 0)          // The same value, written explicitly.
+    vec3::<i32>()                 // The zero-valued vector of three i32 components.
+    vec3::<i32>(0, 0, 0)          // The same value, written explicitly.
   </xmp>
 </div>
 
@@ -5389,21 +5387,21 @@ Note: WGSL does not have zero expression for [=atomic types=],
   </thead>
   <tr>
     <td>|T| is f32 or f16
-    <td>`mat2x2<T>()`: mat2x2&lt;|T|&gt;<br>
-        `mat3x2<T>()`: mat3x2&lt;|T|&gt;<br>
-        `mat4x2<T>()`: mat4x2&lt;|T|&gt;
+    <td>`mat2x2::<T>()`: mat2x2&lt;|T|&gt;<br>
+        `mat3x2::<T>()`: mat3x2&lt;|T|&gt;<br>
+        `mat4x2::<T>()`: mat4x2&lt;|T|&gt;
     <td>Zero value
   <tr>
     <td>
-    <td>`mat2x3<T>()`: mat2x3&lt;|T|&gt;<br>
-        `mat3x3<T>()`: mat3x3&lt;|T|&gt;<br>
-        `mat4x3<T>()`: mat4x3&lt;|T|&gt;
+    <td>`mat2x3::<T>()`: mat2x3&lt;|T|&gt;<br>
+        `mat3x3::<T>()`: mat3x3&lt;|T|&gt;<br>
+        `mat4x3::<T>()`: mat4x3&lt;|T|&gt;
     <td>Zero value
   <tr>
     <td>
-    <td>`mat2x4<T>()`: mat2x4&lt;|T|&gt;<br>
-        `mat3x4<T>()`: mat3x4&lt;|T|&gt;<br>
-        `mat4x4<T>()`: mat4x4&lt;|T|&gt;
+    <td>`mat2x4::<T>()`: mat2x4&lt;|T|&gt;<br>
+        `mat3x4::<T>()`: mat3x4&lt;|T|&gt;<br>
+        `mat4x4::<T>()`: mat4x4&lt;|T|&gt;
     <td>Zero value
 </table>
 
@@ -5414,14 +5412,14 @@ Note: WGSL does not have zero expression for [=atomic types=],
   </thead>
   <tr algorithm="array zero value">
     <td>|T| is a [=constructible=]
-    <td>`array<`|T|,|N|`>()`: array&lt;|T|,|N|&gt;
+    <td>`array::<`|T|,|N|`>()`: array&lt;|T|,|N|&gt;
     <td>Zero-valued array
 </table>
 
 <div class='example' heading="Zero-valued arrays">
   <xmp highlight='rust'>
-    array<bool, 2>()               // The zero-valued array of two booleans.
-    array<bool, 2>(false, false)   // The same value, written explicitly.
+    array::<bool, 2>()               // The zero-valued array of two booleans.
+    array::<bool, 2>(false, false)   // The same value, written explicitly.
   </xmp>
 </div>
 
@@ -5442,7 +5440,7 @@ Note: WGSL does not have zero expression for [=atomic types=],
     struct Student {
       grade: i32,
       GPA: f32,
-      attendance: array<bool,4>
+      attendance: array::<bool,4>
     }
 
     fn func() {
@@ -5452,10 +5450,10 @@ Note: WGSL does not have zero expression for [=atomic types=],
       s = Student();
 
       // The same value, written explicitly.
-      s = Student(0, 0.0, array<bool,4>(false, false, false, false));
+      s = Student(0, 0.0, array::<bool,4>(false, false, false, false));
 
       // The same value, written with zero-valued members.
-      s = Student(i32(), f32(), array<bool,4>());
+      s = Student(i32(), f32(), array::<bool,4>());
     }
   </xmp>
 </div>
@@ -5770,23 +5768,23 @@ The convenience letterings can be applied in any order, including duplicating le
 The provided number of letters [=shader-creation error|must=] be between 1 and 4.
 That is, using convenience letters can only produce a valid vector type.
 
-The result type depends on the number of letters provided. Assuming a `vec4<f32>`
+The result type depends on the number of letters provided. Assuming a `vec4::<f32>`
 <table>
   <thead>
     <tr><th>Accessor<th>Result type
   </thead>
   <tr><td>r<td>`f32`
-  <tr><td>rg<td>`vec2<f32>`
-  <tr><td>rgb<td>`vec3<f32>`
-  <tr><td>rgba<td>`vec4<f32>`
+  <tr><td>rg<td>`vec2::<f32>`
+  <tr><td>rgb<td>`vec3::<f32>`
+  <tr><td>rgba<td>`vec4::<f32>`
 </table>
 
 <div class='example wgsl function-scope'>
   <xmp highlight='rust'>
-    var a: vec3<f32> = vec3<f32>(1., 2., 3.);
+    var a: vec3::<f32> = vec3::<f32>(1., 2., 3.);
     var b: f32 = a.y;          // b = 2.0
-    var c: vec2<f32> = a.bb;   // c = (3.0, 3.0)
-    var d: vec3<f32> = a.zyx;  // d = (3.0, 2.0, 1.0)
+    var c: vec2::<f32> = a.bb;   // c = (3.0, 3.0)
+    var d: vec3::<f32> = a.zyx;  // d = (3.0, 2.0, 1.0)
     var e: f32 = a[1];         // e = 2.0
   </xmp>
 </div>
@@ -6089,7 +6087,7 @@ See [[#sync-builtin-functions]].
 </table>
 
 <table class='data'>
-  <caption>Getting a reference to an array element from a reference to an array</caption>
+  <caption>Getting a reference to an array element from a reference to an array::</caption>
   <thead>
     <tr><th>Precondition<th>Conclusion<th>Description
   </thead>
@@ -6747,15 +6745,13 @@ When an identifier is used as a [=syntax/callable=] item, it is one of:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>primary_expression</dfn> :
 
-    | [=syntax/ident=]
+    | [=syntax/callable=]
 
     | [=syntax/call_expression=]
 
     | [=syntax/literal=]
 
     | [=syntax/paren_expression=]
-
-    | <a for=syntax_kw lt=bitcast>`'bitcast'`</a> <a for=syntax_sym lt=less_than>`'<'`</a> [=syntax/type_specifier=] <a for=syntax_sym lt=greater_than>`'>'`</a> [=syntax/paren_expression=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>call_expression</dfn> :
@@ -6773,13 +6769,7 @@ Note: The [=syntax/call_expression=] rule exists to ensure [=type checking=] app
 
     | [=syntax/ident=]
 
-    | [=syntax/type_specifier_without_ident=]
-
-    | [=syntax/vec_prefix=]
-
-    | [=syntax/mat_prefix=]
-
-    | <a for=syntax_kw lt=array>`'array'`</a>
+    | [=syntax/ident=] `'::'` <a for=syntax_sym lt=paren_left>`'<'`</a> [=syntax/primary_expression=] ( <a for=syntax_sym lt=comma>`','`</a> [=syntax/primary_expression=] ) * <a for=syntax_sym lt=comma>`','`</a> ? <a for=syntax_sym lt=paren_right>`'>'`</a>
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>paren_expression</dfn> :
@@ -7161,10 +7151,10 @@ See [[#forming-references-and-pointers]] for other cases.
 
             person.age = 31;  // Write 31 into the age field of the person variable.
 
-            var uv: vec2<f32>;
+            var uv: vec2::<f32>;
             uv.y = 1.25;      // Place 1.25 into the second component of uv.
 
-            let uv_x_ptr: ptr<function,f32> = &uv.x;
+            let uv_x_ptr: ptr::<function,f32> = &uv.x;
             *uv_x_ptr = 2.5;   // Place 2.5 into the first component of uv.
 
             var friend: S;
@@ -7224,21 +7214,21 @@ A phony-assignment is useful for:
 <div class='example wgsl global-scope' heading='Using phony-assignment to occupy bindings without using them'>
   <xmp highlight=rust>
     struct BufferContents {
-        counter: atomic<u32>,
-        data: array<vec4<f32>>
+        counter: atomic::<u32>,
+        data: array::<vec4::<f32>>
     }
     @group(0) @binding(0) var<storage> buf: BufferContents;
-    @group(0) @binding(1) var t: texture_2d<f32>;
+    @group(0) @binding(1) var t: texture_2d::<f32>;
     @group(0) @binding(2) var s: sampler;
 
     @fragment
-    fn shade_it() -> @location(0) vec4<f32> {
+    fn shade_it() -> @location(0) vec4::<f32> {
       // Declare that buf, t, and s are part of the shader interface, without
       // using them for anything.
       _ = &buf;
       _ = t;
       _ = s;
-      return vec4<f32>();
+      return vec4::<f32>();
     }
   </xmp>
 </div>
@@ -7328,7 +7318,7 @@ first a [=read access=] gets the old value, and then a [=write access=] stores t
     }
 
     fn bump_item() {
-      var data: array<f32,10>;
+      var data: array::<f32,10>;
       next_item = 0;
       // Adds 5.0 to data[0], calling advance_item() only once.
       data[advance_item()] += 5.0;
@@ -7973,7 +7963,7 @@ the fragment will be thrown away.
   @group(0) @binding(0)
   var<storage, read_write> will_emit_color : u32;
 
-  fn discard_if_shallow(pos: vec4<f32>) {
+  fn discard_if_shallow(pos: vec4::<f32>) {
     if pos.z < 0.001 {
       // If this is executed, then the will_emit_color variable will
       // never be set to 1 because helper invocations will not write
@@ -7984,15 +7974,15 @@ the fragment will be thrown away.
   }
 
   @fragment
-  fn main(@builtin(position) coord_in: vec4<f32>)
-    -> @location(0) vec4<f32>
+  fn main(@builtin(position) coord_in: vec4::<f32>)
+    -> @location(0) vec4::<f32>
   {
     discard_if_shallow(coord_in);
 
     // Set the value to 1 and emit red, but only if the helper function
     // did not execute the discard statement.
     will_emit_color = 1;
-    return vec4<f32>(1.0, 0.0, 0.0, 1.0);
+    return vec4::<f32>(1.0, 0.0, 0.0, 1.0);
   }
   </xmp>
 </div>
@@ -8644,7 +8634,7 @@ Note: The [=attribute/const=] attribute cannot be applied to user-declared funct
                                      // const-expression in this context.
 
     fn foo() {
-      var a : array<i32, firstLeadingBit(257)>; // const-functions can be used in
+      var a : array::<i32, firstLeadingBit(257)>; // const-functions can be used in
                                                 // const-expressions if all their
                                                 // parameters are const-expressions.
     }
@@ -8689,13 +8679,13 @@ of declarations.
 
 <div class='example wgsl' heading='Valid and invalid pointer arguments'>
   <xmp highlight='rust'>
-    fn bar(p : ptr<function, f32>) {
+    fn bar(p : ptr::<function, f32>) {
     }
 
-    fn baz(p : ptr<private, i32>) {
+    fn baz(p : ptr::<private, i32>) {
     }
 
-    fn bar2(p : ptr<function, f32>) {
+    fn bar2(p : ptr::<function, f32>) {
       let a = &*&*(p);
 
       bar(p); // Valid
@@ -8707,7 +8697,7 @@ of declarations.
     }
 
     var usable_priv : i32;
-    var unusable_priv : array<i32, 4>;
+    var unusable_priv : array::<i32, 4>;
     fn foo() {
       var usable_func : f32;
       var unusable_func : S;
@@ -8804,11 +8794,11 @@ of the following occur:
   <xmp highlight='rust'>
     var x : i32 = 0;
 
-    fn f1(p1 : ptr<function, i32>, p2 : ptr<function, i32>) {
+    fn f1(p1 : ptr::<function, i32>, p2 : ptr::<function, i32>) {
       *p1 = *p2;
     }
 
-    fn f2(p1 : ptr<function, i32>, p2 : ptr<function, i32>) {
+    fn f2(p1 : ptr::<function, i32>, p2 : ptr::<function, i32>) {
       f1(p1, p2);
     }
 
@@ -8819,7 +8809,7 @@ of the following occur:
                    // more are written (even by a subfunction).
     }
 
-    fn f4(p1 : ptr<function, i32>, p2 : ptr<function, i32>) -> i32 {
+    fn f4(p1 : ptr::<function, i32>, p2 : ptr::<function, i32>) -> i32 {
       return *p1 + *p2;
     }
 
@@ -8828,11 +8818,11 @@ of the following occur:
       let b = f4(&a, &a); // Valid. p1 and p2 in f4 are both only read.
     }
 
-    fn f6(p : ptr<private, i32>) {
+    fn f6(p : ptr::<private, i32>) {
       x = *p;
     }
 
-    fn f7(p : ptr<private, i32>) -> i32 {
+    fn f7(p : ptr::<private, i32>) -> i32 {
       return x + *p;
     }
 
@@ -8918,13 +8908,13 @@ Note: [=Compute=] entry points never have a return type.
 <div class='example wgsl global-scope' heading='Entry Point'>
   <xmp highlight='rust'>
     @vertex
-    fn vert_main() -> @builtin(position) vec4<f32> {
-      return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+    fn vert_main() -> @builtin(position) vec4::<f32> {
+      return vec4::<f32>(0.0, 0.0, 0.0, 1.0);
     }
 
     @fragment
-    fn frag_main(@builtin(position) coord_in: vec4<f32>) -> @location(0) vec4<f32> {
-      return vec4<f32>(coord_in.x, coord_in.y, 0.0, 1.0);
+    fn frag_main(@builtin(position) coord_in: vec4::<f32>) -> @location(0) vec4::<f32> {
+      return vec4::<f32>(coord_in.x, coord_in.y, 0.0, 1.0);
     }
 
     @compute @workgroup_size(1)
@@ -8997,7 +8987,7 @@ A declaration *D* is <dfn>statically accessed</dfn> by a shader when:
 * Any type needed to define the above, including following [=type aliases=].
 * As a particular case of helping to define a type,
     any [=override-declaration=] used in an [=override-expression=] that is the [=element count=]
-    of an [=array=] type for a variable in the [=address spaces/workgroup=] address space,
+    of an array type for a variable in the [=address spaces/workgroup=] address space,
     when that variable itself is statically accessed.
 * Any override declarations used to support the evaluation of override-expressions in any of the above.
 * Any attributes on any of the above.
@@ -9114,7 +9104,7 @@ Note: The number of available locations for an entry point is defined by the Web
     // in2 occupies location 2.
     // The return value occupies location 0.
     @fragment
-    fn fragShader(in1: A, @location(2) in2: f32) -> @location(0) vec4<f32> {
+    fn fragShader(in1: A, @location(2) in2: f32) -> @location(0) vec4::<f32> {
      // ...
     }
   </xmp>
@@ -9126,14 +9116,14 @@ User-defined IO can be mixed with built-in values in the same structure. For exa
   <xmp highlight='rust'>
     // Mixed builtins and user-defined inputs.
     struct MyInputs {
-      @location(0) x: vec4<f32>,
+      @location(0) x: vec4::<f32>,
       @builtin(front_facing) y: bool,
       @location(1) @interpolate(flat) z: u32
     }
 
     struct MyOutputs {
       @builtin(frag_depth) x: f32,
-      @location(0) y: vec4<f32>
+      @location(0) y: vec4::<f32>
     }
 
     @fragment
@@ -9161,7 +9151,7 @@ User-defined IO can be mixed with built-in values in the same structure. For exa
     }
 
     struct D {
-      x: vec4<f32>
+      x: vec4::<f32>
     }
 
     @fragment
@@ -9178,7 +9168,7 @@ User-defined IO can be mixed with built-in values in the same structure. For exa
 
     @fragment
     // Invalid, location cannot be applied to a structure.
-    fn fragShader3(@location(0) in1: vec4<f32>) -> @location(0) D {
+    fn fragShader3(@location(0) in1: vec4::<f32>) -> @location(0) D {
       // ...
     }
   </xmp>
@@ -9442,17 +9432,17 @@ shader that goes beyond the specified limits.
     <tr><td>Maximum nesting depth of brace-enclosed statements in a function<td>127
     <tr><td>Maximum number of [=formal parameter|parameters=] for a function<td>255
     <tr><td>Maximum number of case selector values in a [=statement/switch=] statement<td>16383
-    <tr><td>Maximum [=byte-size=] of an [=array=] type instantiated in the
+    <tr><td>Maximum [=byte-size=] of an array type instantiated in the
             [=address spaces/function=] or [=address spaces/private=] address spaces
 
             For the purposes of this limit, [=bool=] has a size of 1 byte.
         <td>65535
-    <tr><td>Maximum [=byte-size=] of an [=array=] type instantiated in the
+    <tr><td>Maximum [=byte-size=] of an array type instantiated in the
             [=address spaces/workgroup=] address space
 
             For the purposes of this limit, [=bool=] has a size of 1 byte.
         <td>[=supported limits/maxComputeWorkgroupStorageSize|16384=]
-    <tr><td>Maximum number of elements in [=const-expression=] of [=array=] type<td>65535
+    <tr><td>Maximum number of elements in [=const-expression=] of array type<td>65535
 </table>
 
 # Execution # {#execution}
@@ -9682,7 +9672,7 @@ occur both before and after this desugaring has occurred.
 
 <div class='example wgsl' heading='pointers in the uniformity analysis'>
   <xmp highlight='rust'>
-    fn foo(p : ptr<function, array<f32, 4>>, i : i32) -> f32 {
+    fn foo(p : ptr::<function, array::<f32, 4>>, i : i32) -> f32 {
       let p1 = p;
       var x = i;
       let p2 = &((*p1)[x]);
@@ -9692,7 +9682,7 @@ occur both before and after this desugaring has occurred.
     }
 
     // This is the equivalent version of foo for the analysis.
-    fn foo_for_analysis(p : ptr<function, array<f32, 4>>, i : i32) -> f32 {
+    fn foo_for_analysis(p : ptr::<function, array::<f32, 4>>, i : i32) -> f32 {
       var p_var = *p;            // Introduce variable for p.
       let p1 = &p_var;           // Use the variable for p1
       var x = i;
@@ -9764,13 +9754,13 @@ A similar situation occurs with arrays having a single element:
 
 ```rust
      fn foo () {
-        var arr: array<i32,1>;
+        var arr: array::<i32,1>;
      }
 ```
 
 Then `arr` is a full reference and `arr[0]` is a partial reference.
 Their memory views cover the same memory
-locations, but the store type for `arr` is `array<i32,1>` and the store type of `arr[0]` is `i32`.
+locations, but the store type for `arr` is `array::<i32,1>` and the store type of `arr[0]` is `i32`.
 
 To simplify analysis, an assignment via *any* kind of [=partial reference=] is treated as if
 it does *not* modify every memory location in the associated [=originating variable=].
@@ -10267,11 +10257,11 @@ The invalid dependency chain is highlighted in red.
 
 <div class='example wgsl' heading='WGSL invalid textureSample'>
   <xmp highlight='rust'>
-    @group(0) @binding(0) var t : texture_2d<f32>;
+    @group(0) @binding(0) var t : texture_2d::<f32>;
     @group(0) @binding(1) var s : sampler;
 
     @fragment
-    fn main(@builtin(position) pos : vec4<f32>) {
+    fn main(@builtin(position) pos : vec4::<f32>) {
       if (pos.x < 0.5) {
         // Invalid textureSample function call.
         _ = textureSample(t, s, pos.xy);
@@ -10361,7 +10351,7 @@ authors can employ to avoid this limitation.
   <xmp highlight='rust'>
     struct Inputs {
       // workgroup_id is a uniform built-in value.
-      @builtin(workgroup_id) wgid : vec3<u32>,
+      @builtin(workgroup_id) wgid : vec3::<u32>,
       // local_invocation_index is a non-uniform built-in value.
       @builtin(local_invocation_index) lid : u32
     }
@@ -10395,7 +10385,7 @@ This can be seen by the lack of a path from [=RequiredToBeUniform=] to
 <div class='example wgsl' heading='Valid alternative WGSL'>
   <xmp highlight='rust'>
     @compute @workgroup_size(16,1,1)
-    fn main(@builtin(workgroup_id) wgid : vec3<u32>,
+    fn main(@builtin(workgroup_id) wgid : vec3::<u32>,
             @builtin(local_invocation_index) lid : u32) {
       // The uniformity analysis can now correctly determine this comparison is
       // always uniform.
@@ -10466,11 +10456,11 @@ That path is a subpath of the overall invalid path from [=RequiredToBeUniform=] 
       return v;
     }
 
-    @group(0) @binding(0) var t : texture_2d<f32>;
+    @group(0) @binding(0) var t : texture_2d::<f32>;
     @group(0) @binding(1) var s : sampler;
 
     @fragment
-    fn main(@builtin(position) pos : vec4<f32>) {
+    fn main(@builtin(position) pos : vec4::<f32>) {
       let tmp = scale(pos.x, 0.5);
       if tmp > 1.0 {
         _ = textureSample(t, s, pos.xy);
@@ -11480,7 +11470,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in value.
 <div class='example wgsl global-scope' heading="Declaring built-in values">
   <xmp highlight='rust'>
     struct VertexOutput {
-      @builtin(position) my_pos: vec4<f32>
+      @builtin(position) my_pos: vec4::<f32>
     }
 
     @vertex
@@ -11497,16 +11487,16 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in value.
     @fragment
     fn fs_main(
       @builtin(front_facing) is_front: bool,
-      @builtin(position) coord: vec4<f32>,
+      @builtin(position) coord: vec4::<f32>,
       @builtin(sample_index) my_sample_index: u32,
       @builtin(sample_mask) mask_in: u32,
     ) -> FragmentOutput {}
 
     @compute @workgroup_size(64)
     fn cs_main(
-      @builtin(local_invocation_id) local_id: vec3<u32>,
+      @builtin(local_invocation_id) local_id: vec3::<u32>,
       @builtin(local_invocation_index) local_index: u32,
-      @builtin(global_invocation_id) global_id: vec3<u32>,
+      @builtin(global_invocation_id) global_id: vec3::<u32>,
    ) {}
   </xmp>
 </div>
@@ -11616,7 +11606,7 @@ See [[#function-calls]].
   <tr algorithm="runtime-sized array length">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-fn arrayLength(p: ptr<storage, array<E>, AM>) -> u32
+fn arrayLength(p: ptr::<storage, array::<E>, AM>) -> u32
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -11945,8 +11935,8 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
   <tr algorithm="vector case, cross">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn cross(e1: vec3<T>,
-                e2: vec3<T>) -> vec3<T>
+@const fn cross(e1: vec3::<T>,
+                e2: vec3::<T>) -> vec3::<T>
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13458,12 +13448,12 @@ Returns the dimensions of a texture, or texture's mip level in texels.
     <td><var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]<br>
         <var ignore>F</var> is a [=texel format=]<br>
         <var ignore>A</var> is an [=access mode=]<br><br>
-        |T| is `texture_1d<ST>` or `texture_storage_1d<F,A>`
+        |T| is `texture_1d::<ST>` or `texture_storage_1d::<F,A>`
     <td><xmp highlight=rust>fn textureDimensions(t: T) -> u32</xmp>
 
   <tr algorithm="textureDimensions 1d level">
     <td><var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]<br><br>
-        |T| is `texture_1d<ST>`
+        |T| is `texture_1d::<ST>`
 
         <var ignore>L</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
@@ -13474,40 +13464,40 @@ fn textureDimensions(t: T,
     <td><var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]<br>
         <var ignore>F</var> is a [=texel format=]<br>
         <var ignore>A</var> is an [=access mode=]<br><br>
-        |T| is `texture_2d<ST>`, `texture_2d_array<ST>`, `texture_cube<ST>`,
-               `texture_cube_array<ST>`, `texture_multisampled_2d<ST>`,
+        |T| is `texture_2d::<ST>`, `texture_2d_array::<ST>`, `texture_cube<ST>`,
+               `texture_cube_array::<ST>`, `texture_multisampled_2d::<ST>`,
                `texture_depth_2d`, `texture_depth_2d_array`, `texture_depth_cube`,
                `texture_depth_cube_array`, `texture_depth_multisampled_2d`,
-               `texture_storage_2d<F,A>`, `texture_storage_2d_array<F,A>`,
+               `texture_storage_2d::<F,A>`, `texture_storage_2d_array::<F,A>`,
                or `texture_external`
-    <td><xmp highlight=rust>fn textureDimensions(t: T) -> vec2<u32></xmp>
+    <td><xmp highlight=rust>fn textureDimensions(t: T) -> vec2::<u32></xmp>
 
   <tr algorithm="textureDimensions 2d level">
     <td><var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]<br><br>
-        |T| is `texture_2d<ST>`, `texture_2d_array<ST>`, `texture_cube<ST>`,
-               `texture_cube_array<ST>`, `texture_depth_2d`, `texture_depth_2d_array`,
+        |T| is `texture_2d::<ST>`, `texture_2d_array::<ST>`, `texture_cube<ST>`,
+               `texture_cube_array::<ST>`, `texture_depth_2d`, `texture_depth_2d_array`,
                `texture_depth_cube`, or `texture_depth_cube_array`
 
         <var ignore>L</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureDimensions(t: T,
-                     level: L) -> vec2<u32></xmp>
+                     level: L) -> vec2::<u32></xmp>
 
   <tr algorithm="textureDimensions 3d">
     <td><var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]<br>
         <var ignore>F</var> is a [=texel format=]<br>
         <var ignore>A</var> is an [=access mode=]<br><br>
-        |T| is `texture_3d<ST>` or `texture_storage_3d<F,A>`
-    <td><xmp highlight=rust>fn textureDimensions(t: T) -> vec3<u32></xmp>
+        |T| is `texture_3d::<ST>` or `texture_storage_3d::<F,A>`
+    <td><xmp highlight=rust>fn textureDimensions(t: T) -> vec3::<u32></xmp>
 
   <tr algorithm="textureDimensions 3d level">
     <td><var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]<br><br>
-        |T| is `texture_3d<ST>`
+        |T| is `texture_3d::<ST>`
 
         <var ignore>L</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureDimensions(t: T,
-                     level: L) -> vec3<u32></xmp>
+                     level: L) -> vec3::<u32></xmp>
 </table>
 
 **Parameters:**
@@ -13572,19 +13562,19 @@ https://github.com/gpuweb/gpuweb/issues/2343
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
     <td><xmp highlight=rust>
 fn textureGather(component: C,
-                 t: texture_2d<ST>,
+                 t: texture_2d::<ST>,
                  s: sampler,
-                 coords: vec2<f32>) -> vec4<ST></xmp>
+                 coords: vec2::<f32>) -> vec4::<ST></xmp>
 
   <tr algorithm="textureGather 2d offset">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
     <td><xmp highlight=rust>
 fn textureGather(component: C,
-                 t: texture_2d<ST>,
+                 t: texture_2d::<ST>,
                  s: sampler,
-                 coords: vec2<f32>,
-                 offset: vec2<i32>) -> vec4<ST></xmp>
+                 coords: vec2::<f32>,
+                 offset: vec2::<i32>) -> vec4::<ST></xmp>
 
   <tr algorithm="textureGather 2d array">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
@@ -13592,10 +13582,10 @@ fn textureGather(component: C,
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
     <td><xmp highlight=rust>
 fn textureGather(component: C,
-                 t: texture_2d_array<ST>,
+                 t: texture_2d_array::<ST>,
                  s: sampler,
-                 coords: vec2<f32>,
-                 array_index: A) -> vec4<ST></xmp>
+                 coords: vec2::<f32>,
+                 array_index: A) -> vec4::<ST></xmp>
 
   <tr algorithm="textureGather 2d array offset">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
@@ -13603,11 +13593,11 @@ fn textureGather(component: C,
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
     <td><xmp highlight=rust>
 fn textureGather(component: C,
-                 t: texture_2d_array<ST>,
+                 t: texture_2d_array::<ST>,
                  s: sampler,
-                 coords: vec2<f32>,
+                 coords: vec2::<f32>,
                  array_index: A,
-                 offset: vec2<i32>) -> vec4<ST></xmp>
+                 offset: vec2::<i32>) -> vec4::<ST></xmp>
 
   <tr algorithm="textureGather cube">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
@@ -13616,7 +13606,7 @@ fn textureGather(component: C,
 fn textureGather(component: C,
                  t: texture_cube<ST>,
                  s: sampler,
-                 coords: vec3<f32>) -> vec4<ST></xmp>
+                 coords: vec3::<f32>) -> vec4::<ST></xmp>
 
   <tr algorithm="textureGather cube array">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
@@ -13624,57 +13614,57 @@ fn textureGather(component: C,
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
     <td><xmp highlight=rust>
 fn textureGather(component: C,
-                 t: texture_cube_array<ST>,
+                 t: texture_cube_array::<ST>,
                  s: sampler,
-                 coords: vec3<f32>,
-                 array_index: A) -> vec4<ST></xmp>
+                 coords: vec3::<f32>,
+                 array_index: A) -> vec4::<ST></xmp>
 
   <tr algorithm="textureGather 2d depth">
     <td>
     <td><xmp highlight=rust>
 fn textureGather(t: texture_depth_2d,
                  s: sampler,
-                 coords: vec2<f32>) -> vec4<f32></xmp>
+                 coords: vec2::<f32>) -> vec4::<f32></xmp>
 
   <tr algorithm="textureGather 2d depth offset">
     <td>
     <td><xmp highlight=rust>
 fn textureGather(t: texture_depth_2d,
                  s: sampler,
-                 coords: vec2<f32>,
-                 offset: vec2<i32>) -> vec4<f32></xmp>
+                 coords: vec2::<f32>,
+                 offset: vec2::<i32>) -> vec4::<f32></xmp>
 
   <tr algorithm="textureGather cube depth">
     <td>
     <td><xmp highlight=rust>
 fn textureGather(t: texture_depth_cube,
                  s: sampler,
-                 coords: vec3<f32>) -> vec4<f32></xmp>
+                 coords: vec3::<f32>) -> vec4::<f32></xmp>
 
   <tr algorithm="textureGather 2d depth array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureGather(t: texture_depth_2d_array,
                  s: sampler,
-                 coords: vec2<f32>,
-                 array_index: A) -> vec4<f32></xmp>
+                 coords: vec2::<f32>,
+                 array_index: A) -> vec4::<f32></xmp>
 
   <tr algorithm="textureGather 2d depth array offset">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureGather(t: texture_depth_2d_array,
                  s: sampler,
-                 coords: vec2<f32>,
+                 coords: vec2::<f32>,
                  array_index: A,
-                 offset: vec2<i32>) -> vec4<f32></xmp>
+                 offset: vec2::<i32>) -> vec4::<f32></xmp>
 
   <tr algorithm="textureGather cube depth array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureGather(t: texture_depth_cube_array,
                  s: sampler,
-                 coords: vec3<f32>,
-                 array_index: A) -> vec4<f32></xmp>
+                 coords: vec3::<f32>,
+                 array_index: A) -> vec4::<f32></xmp>
 </table>
 
 **Parameters:**
@@ -13698,7 +13688,7 @@ fn textureGather(t: texture_depth_cube_array,
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  The `offset` expression [=shader-creation error|must=] be a [=const-expression=] (e.g. `vec2<i32>(1, 2)`).<br>
+  The `offset` expression [=shader-creation error|must=] be a [=const-expression=] (e.g. `vec2::<i32>(1, 2)`).<br>
   Each `offset` component [=shader-creation error|must=] be at least `-8` and at most `7`. Values outside
   of this range will result in a [=shader-creation error=].
 </table>
@@ -13709,20 +13699,20 @@ A four component vector with components extracted from the specified channel fro
 
 <div class='example wgsl global-scope' heading="Gather components from texels in 2D texture">
   <xmp highlight='rust'>
-    @group(0) @binding(0) var t: texture_2d<f32>;
+    @group(0) @binding(0) var t: texture_2d::<f32>;
     @group(0) @binding(1) var dt: texture_depth_2d;
     @group(0) @binding(2) var s: sampler;
 
-    fn gather_x_components(c: vec2<f32>) -> vec4<f32> {
+    fn gather_x_components(c: vec2::<f32>) -> vec4::<f32> {
       return textureGather(0,t,s,c);
     }
-    fn gather_y_components(c: vec2<f32>) -> vec4<f32> {
+    fn gather_y_components(c: vec2::<f32>) -> vec4::<f32> {
       return textureGather(1,t,s,c);
     }
-    fn gather_z_components(c: vec2<f32>) -> vec4<f32> {
+    fn gather_z_components(c: vec2::<f32>) -> vec4::<f32> {
       return textureGather(2,t,s,c);
     }
-    fn gather_depth_components(c: vec2<f32>) -> vec4<f32> {
+    fn gather_depth_components(c: vec2::<f32>) -> vec4::<f32> {
       return textureGather(dt,s,c);
     }
   </xmp>
@@ -13760,53 +13750,53 @@ texture and collects the results into a single vector, as follows:
     <td><xmp highlight=rust>
 fn textureGatherCompare(t: texture_depth_2d,
                         s: sampler_comparison,
-                        coords: vec2<f32>,
-                        depth_ref: f32) -> vec4<f32></xmp>
+                        coords: vec2::<f32>,
+                        depth_ref: f32) -> vec4::<f32></xmp>
 
   <tr algorithm="textureGatherCompare 2d depth offset">
     <td>
     <td><xmp highlight=rust>
 fn textureGatherCompare(t: texture_depth_2d,
                         s: sampler_comparison,
-                        coords: vec2<f32>,
+                        coords: vec2::<f32>,
                         depth_ref: f32,
-                        offset: vec2<i32>) -> vec4<f32></xmp>
+                        offset: vec2::<i32>) -> vec4::<f32></xmp>
 
   <tr algorithm="textureGatherCompare 2d depth array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureGatherCompare(t: texture_depth_2d_array,
                         s: sampler_comparison,
-                        coords: vec2<f32>,
+                        coords: vec2::<f32>,
                         array_index: A,
-                        depth_ref: f32) -> vec4<f32></xmp>
+                        depth_ref: f32) -> vec4::<f32></xmp>
 
   <tr algorithm="textureGatherCompare 2d depth array offset">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureGatherCompare(t: texture_depth_2d_array,
                         s: sampler_comparison,
-                        coords: vec2<f32>,
+                        coords: vec2::<f32>,
                         array_index: A,
                         depth_ref: f32,
-                        offset: vec2<i32>) -> vec4<f32></xmp>
+                        offset: vec2::<i32>) -> vec4::<f32></xmp>
 
   <tr algorithm="textureGatherCompare 2d depth cube">
     <td>
     <td><xmp highlight=rust>
 fn textureGatherCompare(t: texture_depth_cube,
                         s: sampler_comparison,
-                        coords: vec3<f32>,
-                        depth_ref: f32) -> vec4<f32></xmp>
+                        coords: vec3::<f32>,
+                        depth_ref: f32) -> vec4::<f32></xmp>
 
   <tr algorithm="textureGatherCompare 2d depth cube array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureGatherCompare(t: texture_depth_cube_array,
                         s: sampler_comparison,
-                        coords: vec3<f32>,
+                        coords: vec3::<f32>,
                         array_index: A,
-                        depth_ref: f32) -> vec4<f32></xmp>
+                        depth_ref: f32) -> vec4::<f32></xmp>
 
 </table>
 
@@ -13827,7 +13817,7 @@ fn textureGatherCompare(t: texture_depth_cube_array,
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  The `offset` expression [=shader-creation error|must=] be a [=const-expression=] (e.g. `vec2<i32>(1, 2)`).<br>
+  The `offset` expression [=shader-creation error|must=] be a [=const-expression=] (e.g. `vec2::<i32>(1, 2)`).<br>
   Each `offset` component [=shader-creation error|must=] be at least `-8` and at most `7`. Values outside
   of this range will result in a [=shader-creation error=].
 </table>
@@ -13841,7 +13831,7 @@ A four component vector with comparison result for the selected texels, as descr
     @group(0) @binding(0) var dt: texture_depth_2d;
     @group(0) @binding(1) var s: sampler;
 
-    fn gather_depth_compare(c: vec2<f32>, depth_ref: f32) -> vec4<f32> {
+    fn gather_depth_compare(c: vec2::<f32>, depth_ref: f32) -> vec4::<f32> {
       return textureGatherCompare(dt,s,c,depth_ref);
     }
   </xmp>
@@ -13860,18 +13850,18 @@ Reads a single texel from a texture without sampling or filtering.
         <var ignore>L</var> is [=i32=], or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
     <td><xmp highlight=rust>
-fn textureLoad(t: texture_1d<ST>,
+fn textureLoad(t: texture_1d::<ST>,
                coords: C,
-               level: L) -> vec4<ST></xmp>
+               level: L) -> vec4::<ST></xmp>
 
   <tr algorithm="textureLoad 2d">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
         <var ignore>L</var> is [=i32=], or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
     <td><xmp highlight=rust>
-fn textureLoad(t: texture_2d<ST>,
-               coords: vec2<C>,
-               level: L) -> vec4<ST></xmp>
+fn textureLoad(t: texture_2d::<ST>,
+               coords: vec2::<C>,
+               level: L) -> vec4::<ST></xmp>
 
   <tr algorithm="textureLoad 2d array">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
@@ -13879,35 +13869,35 @@ fn textureLoad(t: texture_2d<ST>,
         <var ignore>L</var> is [=i32=], or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
     <td><xmp highlight=rust>
-fn textureLoad(t: texture_2d_array<ST>,
-              coords: vec2<C>,
+fn textureLoad(t: texture_2d_array::<ST>,
+              coords: vec2::<C>,
               array_index: A,
-              level: L) -> vec4<ST></xmp>
+              level: L) -> vec4::<ST></xmp>
 
   <tr algorithm="textureLoad 3d">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
         <var ignore>L</var> is [=i32=], or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
     <td><xmp highlight=rust>
-fn textureLoad(t: texture_3d<ST>,
-               coords: vec3<C>,
-               level: L) -> vec4<ST></xmp>
+fn textureLoad(t: texture_3d::<ST>,
+               coords: vec3::<C>,
+               level: L) -> vec4::<ST></xmp>
 
   <tr algorithm="textureLoad 2d multisampled">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
         <var ignore>S</var> is [=i32=], or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
     <td><xmp highlight=rust>
-fn textureLoad(t: texture_multisampled_2d<ST>,
-               coords: vec2<C>,
-               sample_index: S)-> vec4<ST></xmp>
+fn textureLoad(t: texture_multisampled_2d::<ST>,
+               coords: vec2::<C>,
+               sample_index: S)-> vec4::<ST></xmp>
 
   <tr algorithm="textureLoad 2d depth">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
         <var ignore>L</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureLoad(t: texture_depth_2d,
-               coords: vec2<C>,
+               coords: vec2::<C>,
                level: L) -> f32</xmp>
 
   <tr algorithm="textureLoad 2d depth array">
@@ -13916,7 +13906,7 @@ fn textureLoad(t: texture_depth_2d,
         <var ignore>L</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureLoad(t: texture_depth_2d_array,
-               coords: vec2<C>,
+               coords: vec2::<C>,
                array_index: A,
                level: L) -> f32</xmp>
 
@@ -13925,14 +13915,14 @@ fn textureLoad(t: texture_depth_2d_array,
         <var ignore>S</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureLoad(t: texture_depth_multisampled_2d,
-               coords: vec2<C>,
+               coords: vec2::<C>,
                sample_index: S)-> f32</xmp>
 
   <tr algorithm="textureLoad external">
     <td><var ignore>C</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureLoad(t: texture_external,
-               coords: vec2<C>) -> vec4<f32></xmp>
+               coords: vec2::<C>) -> vec4::<f32></xmp>
 
 </table>
 
@@ -13981,9 +13971,9 @@ Returns the number of layers (elements) of an array texture.
     <td><var ignore>F</var> is a [=texel format=]<br>
         <var ignore>A</var> is an [=access mode=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]<br><br>
-        <var ignore>T</var> is `texture_2d_array<ST>`, `texture_cube_array<ST>`,
+        <var ignore>T</var> is `texture_2d_array::<ST>`, `texture_cube_array::<ST>`,
                                `texture_depth_2d_array`, `texture_depth_cube_array`,
-                               or `texture_storage_2d_array<F,A>`
+                               or `texture_storage_2d_array::<F,A>`
     <td><xmp highlight=rust>
 fn textureNumLayers(t: T) -> u32</xmp>
 
@@ -14013,9 +14003,9 @@ Returns the number of mip levels of a texture.
   </thead>
   <tr algorithm="texturenumlevels">
     <td><var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]<br><br>
-        <var ignore>T</var> is `texture_1d<ST>`, `texture_2d<ST>`,
-                               `texture_2d_array<ST>`, `texture_3d<ST>`,
-                               `texture_cube<ST>`, `texture_cube_array<ST>`,
+        <var ignore>T</var> is `texture_1d::<ST>`, `texture_2d::<ST>`,
+                               `texture_2d_array::<ST>`, `texture_3d::<ST>`,
+                               `texture_cube<ST>`, `texture_cube_array::<ST>`,
                                `texture_depth_2d`, `texture_depth_2d_array`,
                                `texture_depth_cube`, or `texture_depth_cube_array`
     <td><xmp highlight=rust>
@@ -14045,7 +14035,7 @@ Returns the number samples per texel in a multisampled texture.
   </thead>
   <tr algorithm="texturenumsamples">
     <td><var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]<br><br>
-        <var ignore>T</var> is `texture_multisampled_2d<ST>`
+        <var ignore>T</var> is `texture_multisampled_2d::<ST>`
                                 or `texture_depth_multisampled_2d`
     <td><xmp highlight=rust>
 fn textureNumSamples(t: T) -> u32</xmp>
@@ -14078,86 +14068,86 @@ Samples a texture.
   <tr algorithm="textureSample 1d">
     <td>
     <td><xmp highlight=rust>
-fn textureSample(t: texture_1d<f32>,
+fn textureSample(t: texture_1d::<f32>,
                  s: sampler,
-                 coords: f32) -> vec4<f32></xmp>
+                 coords: f32) -> vec4::<f32></xmp>
 
   <tr algorithm="textureSample 2d">
     <td>
     <td><xmp highlight=rust>
-fn textureSample(t: texture_2d<f32>,
+fn textureSample(t: texture_2d::<f32>,
                  s: sampler,
-                 coords: vec2<f32>) -> vec4<f32></xmp>
+                 coords: vec2::<f32>) -> vec4::<f32></xmp>
 
   <tr algorithm="textureSample 2d offset">
     <td>
     <td><xmp highlight=rust>
-fn textureSample(t: texture_2d<f32>,
+fn textureSample(t: texture_2d::<f32>,
                  s: sampler,
-                 coords: vec2<f32>,
-                 offset: vec2<i32>) -> vec4<f32></xmp>
+                 coords: vec2::<f32>,
+                 offset: vec2::<i32>) -> vec4::<f32></xmp>
 
   <tr algorithm="textureSample 2d array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSample(t: texture_2d_array<f32>,
+fn textureSample(t: texture_2d_array::<f32>,
                  s: sampler,
-                 coords: vec2<f32>,
-                 array_index: A) -> vec4<f32></xmp>
+                 coords: vec2::<f32>,
+                 array_index: A) -> vec4::<f32></xmp>
 
   <tr algorithm="textureSample 2d array offset">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSample(t: texture_2d_array<f32>,
+fn textureSample(t: texture_2d_array::<f32>,
                  s: sampler,
-                 coords: vec2<f32>,
+                 coords: vec2::<f32>,
                  array_index: A,
-                 offset: vec2<i32>) -> vec4<f32></xmp>
+                 offset: vec2::<i32>) -> vec4::<f32></xmp>
 
   <tr algorithm="textureSample 3d">
-    <td><var ignore>T</var> is `texture_3d<f32>`, or `texture_cube<f32>`
+    <td><var ignore>T</var> is `texture_3d::<f32>`, or `texture_cube<f32>`
     <td><xmp highlight=rust>
 fn textureSample(t: T,
                  s: sampler,
-                 coords: vec3<f32>) -> vec4<f32></xmp>
+                 coords: vec3::<f32>) -> vec4::<f32></xmp>
 
   <tr algorithm="textureSample 3d offset">
     <td>
     <td><xmp highlight=rust>
-fn textureSample(t: texture_3d<f32>,
+fn textureSample(t: texture_3d::<f32>,
                  s: sampler,
-                 coords: vec3<f32>,
-                 offset: vec3<i32>) -> vec4<f32></xmp>
+                 coords: vec3::<f32>,
+                 offset: vec3::<i32>) -> vec4::<f32></xmp>
 
   <tr algorithm="textureSample cube array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSample(t: texture_cube_array<f32>,
+fn textureSample(t: texture_cube_array::<f32>,
                  s: sampler,
-                 coords: vec3<f32>,
-                 array_index: A) -> vec4<f32></xmp>
+                 coords: vec3::<f32>,
+                 array_index: A) -> vec4::<f32></xmp>
 
   <tr algorithm="textureSample 2d depth">
     <td>
     <td><xmp highlight=rust>
 fn textureSample(t: texture_depth_2d,
                  s: sampler,
-                 coords: vec2<f32>) -> f32</xmp>
+                 coords: vec2::<f32>) -> f32</xmp>
 
   <tr algorithm="textureSample 2d depth offset">
     <td>
     <td><xmp highlight=rust>
 fn textureSample(t: texture_depth_2d,
                  s: sampler,
-                 coords: vec2<f32>,
-                 offset: vec2<i32>) -> f32</xmp>
+                 coords: vec2::<f32>,
+                 offset: vec2::<i32>) -> f32</xmp>
 
   <tr algorithm="textureSample 2d depth array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSample(t: texture_depth_2d_array,
                  s: sampler,
-                 coords: vec2<f32>,
+                 coords: vec2::<f32>,
                  array_index: A) -> f32</xmp>
 
   <tr algorithm="textureSample 2d depth array offset">
@@ -14165,23 +14155,23 @@ fn textureSample(t: texture_depth_2d_array,
     <td><xmp highlight=rust>
 fn textureSample(t: texture_depth_2d_array,
                  s: sampler,
-                 coords: vec2<f32>,
+                 coords: vec2::<f32>,
                  array_index: A,
-                 offset: vec2<i32>) -> f32</xmp>
+                 offset: vec2::<i32>) -> f32</xmp>
 
   <tr algorithm="textureSample cube depth">
     <td>
     <td><xmp highlight=rust>
 fn textureSample(t: texture_depth_cube,
                  s: sampler,
-                 coords: vec3<f32>) -> f32</xmp>
+                 coords: vec3::<f32>) -> f32</xmp>
 
   <tr algorithm="textureSample cube depth array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSample(t: texture_depth_cube_array,
                  s: sampler,
-                 coords: vec3<f32>,
+                 coords: vec3::<f32>,
                  array_index: A) -> f32</xmp>
 
 </table>
@@ -14202,7 +14192,7 @@ fn textureSample(t: texture_depth_cube_array,
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  The `offset` expression [=shader-creation error|must=] be a [=const-expression=] (e.g. `vec2<i32>(1, 2)`).<br>
+  The `offset` expression [=shader-creation error|must=] be a [=const-expression=] (e.g. `vec2::<i32>(1, 2)`).<br>
   Each `offset` component [=shader-creation error|must=] be at least `-8` and at most `7`. Values outside
   of this range will result in a [=shader-creation error=].
 </table>
@@ -14225,64 +14215,64 @@ Samples a texture with a bias to the mip level.
   <tr algorithm="textureSampleBias 2d">
     <td>
     <td><xmp highlight=rust>
-fn textureSampleBias(t: texture_2d<f32>,
+fn textureSampleBias(t: texture_2d::<f32>,
                      s: sampler,
-                     coords: vec2<f32>,
-                     bias: f32) -> vec4<f32></xmp>
+                     coords: vec2::<f32>,
+                     bias: f32) -> vec4::<f32></xmp>
 
 <tr algorithm="textureSampleBias 2d offset">
     <td>
     <td><xmp highlight=rust>
-fn textureSampleBias(t: texture_2d<f32>,
+fn textureSampleBias(t: texture_2d::<f32>,
                      s: sampler,
-                     coords: vec2<f32>,
+                     coords: vec2::<f32>,
                      bias: f32,
-                     offset: vec2<i32>) -> vec4<f32></xmp>
+                     offset: vec2::<i32>) -> vec4::<f32></xmp>
 
 <tr algorithm="textureSampleBias 2d array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSampleBias(t: texture_2d_array<f32>,
+fn textureSampleBias(t: texture_2d_array::<f32>,
                      s: sampler,
-                     coords: vec2<f32>,
+                     coords: vec2::<f32>,
                      array_index: A,
-                     bias: f32) -> vec4<f32></xmp>
+                     bias: f32) -> vec4::<f32></xmp>
 
 <tr algorithm="textureSampleBias 2d array offset">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSampleBias(t: texture_2d_array<f32>,
+fn textureSampleBias(t: texture_2d_array::<f32>,
                      s: sampler,
-                     coords: vec2<f32>,
+                     coords: vec2::<f32>,
                      array_index: A,
                      bias: f32,
-                     offset: vec2<i32>) -> vec4<f32></xmp>
+                     offset: vec2::<i32>) -> vec4::<f32></xmp>
 
 <tr algorithm="textureSampleBias 3d">
-    <td><var ignore>T</var> is `texture_3d<f32>`, or `texture_cube<f32>`
+    <td><var ignore>T</var> is `texture_3d::<f32>`, or `texture_cube<f32>`
     <td><xmp highlight=rust>
 fn textureSampleBias(t: T,
                      s: sampler,
-                     coords: vec3<f32>,
-                     bias: f32) -> vec4<f32></xmp>
+                     coords: vec3::<f32>,
+                     bias: f32) -> vec4::<f32></xmp>
 
 <tr algorithm="textureSampleBias 3d offset">
     <td>
     <td><xmp highlight=rust>
-fn textureSampleBias(t: texture_3d<f32>,
+fn textureSampleBias(t: texture_3d::<f32>,
                      s: sampler,
-                     coords: vec3<f32>,
+                     coords: vec3::<f32>,
                      bias: f32,
-                     offset: vec3<i32>) -> vec4<f32></xmp>
+                     offset: vec3::<i32>) -> vec4::<f32></xmp>
 
 <tr algorithm="textureSampleBias cube array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSampleBias(t: texture_cube_array<f32>,
+fn textureSampleBias(t: texture_cube_array::<f32>,
                      s: sampler,
-                     coords: vec3<f32>,
+                     coords: vec3::<f32>,
                      array_index: A,
-                     bias: f32) -> vec4<f32></xmp>
+                     bias: f32) -> vec4::<f32></xmp>
 
 </table>
 
@@ -14304,7 +14294,7 @@ fn textureSampleBias(t: texture_cube_array<f32>,
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  The `offset` expression [=shader-creation error|must=] be a [=const-expression=] (e.g. `vec2<i32>(1, 2)`).<br>
+  The `offset` expression [=shader-creation error|must=] be a [=const-expression=] (e.g. `vec2::<i32>(1, 2)`).<br>
   Each `offset` component [=shader-creation error|must=] be at least `-8` and at most `7`. Values outside
   of this range will result in a [=shader-creation error=].
 </table>
@@ -14330,7 +14320,7 @@ Samples a depth texture and compares the sampled depth values against a referenc
     <td><xmp highlight=rust>
 fn textureSampleCompare(t: texture_depth_2d,
                         s: sampler_comparison,
-                        coords: vec2<f32>,
+                        coords: vec2::<f32>,
                         depth_ref: f32) -> f32</xmp>
 
   <tr algorithm="textureSampleCompare 2d depth offset">
@@ -14338,16 +14328,16 @@ fn textureSampleCompare(t: texture_depth_2d,
     <td><xmp highlight=rust>
 fn textureSampleCompare(t: texture_depth_2d,
                         s: sampler_comparison,
-                        coords: vec2<f32>,
+                        coords: vec2::<f32>,
                         depth_ref: f32,
-                        offset: vec2<i32>) -> f32</xmp>
+                        offset: vec2::<i32>) -> f32</xmp>
 
   <tr algorithm="textureSampleCompare 2d array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSampleCompare(t: texture_depth_2d_array,
                         s: sampler_comparison,
-                        coords: vec2<f32>,
+                        coords: vec2::<f32>,
                         array_index: A,
                         depth_ref: f32) -> f32</xmp>
 
@@ -14356,17 +14346,17 @@ fn textureSampleCompare(t: texture_depth_2d_array,
     <td><xmp highlight=rust>
 fn textureSampleCompare(t: texture_depth_2d_array,
                         s: sampler_comparison,
-                        coords: vec2<f32>,
+                        coords: vec2::<f32>,
                         array_index: A,
                         depth_ref: f32,
-                        offset: vec2<i32>) -> f32</xmp>
+                        offset: vec2::<i32>) -> f32</xmp>
 
   <tr algorithm="textureSampleCompare cube depth">
     <td>
     <td><xmp highlight=rust>
 fn textureSampleCompare(t: texture_depth_cube,
                         s: sampler_comparison,
-                        coords: vec3<f32>,
+                        coords: vec3::<f32>,
                         depth_ref: f32) -> f32</xmp>
 
   <tr algorithm="textureSampleCompare cube depth array">
@@ -14374,7 +14364,7 @@ fn textureSampleCompare(t: texture_depth_cube,
     <td><xmp highlight=rust>
 fn textureSampleCompare(t: texture_depth_cube_array,
                         s: sampler_comparison,
-                        coords: vec3<f32>,
+                        coords: vec3::<f32>,
                         array_index: A,
                         depth_ref: f32) -> f32</xmp>
 
@@ -14397,7 +14387,7 @@ fn textureSampleCompare(t: texture_depth_cube_array,
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  The `offset` expression [=shader-creation error|must=] be a [=const-expression=] (e.g. `vec2<i32>(1, 2)`).<br>
+  The `offset` expression [=shader-creation error|must=] be a [=const-expression=] (e.g. `vec2::<i32>(1, 2)`).<br>
   Each `offset` component [=shader-creation error|must=] be at least `-8` and at most `7`. Values outside
   of this range will result in a [=shader-creation error=].
 </table>
@@ -14428,7 +14418,7 @@ Samples a depth texture and compares the sampled depth values against a referenc
     <td><xmp highlight=rust>
 fn textureSampleCompareLevel(t: texture_depth_2d,
                              s: sampler_comparison,
-                             coords: vec2<f32>,
+                             coords: vec2::<f32>,
                              depth_ref: f32) -> f32</xmp>
 
   <tr algorithm="textureSampleCompareLevel 2d depth offset">
@@ -14436,16 +14426,16 @@ fn textureSampleCompareLevel(t: texture_depth_2d,
     <td><xmp highlight=rust>
 fn textureSampleCompareLevel(t: texture_depth_2d,
                              s: sampler_comparison,
-                             coords: vec2<f32>,
+                             coords: vec2::<f32>,
                              depth_ref: f32,
-                             offset: vec2<i32>) -> f32</xmp>
+                             offset: vec2::<i32>) -> f32</xmp>
 
   <tr algorithm="textureSampleCompareLevel 2d depth array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSampleCompareLevel(t: texture_depth_2d_array,
                              s: sampler_comparison,
-                             coords: vec2<f32>,
+                             coords: vec2::<f32>,
                              array_index: A,
                              depth_ref: f32) -> f32</xmp>
 
@@ -14454,17 +14444,17 @@ fn textureSampleCompareLevel(t: texture_depth_2d_array,
     <td><xmp highlight=rust>
 fn textureSampleCompareLevel(t: texture_depth_2d_array,
                              s: sampler_comparison,
-                             coords: vec2<f32>,
+                             coords: vec2::<f32>,
                              array_index: A,
                              depth_ref: f32,
-                             offset: vec2<i32>) -> f32</xmp>
+                             offset: vec2::<i32>) -> f32</xmp>
 
   <tr algorithm="textureSampleCompareLevel cube depth">
     <td>
     <td><xmp highlight=rust>
 fn textureSampleCompareLevel(t: texture_depth_cube,
                              s: sampler_comparison,
-                             coords: vec3<f32>,
+                             coords: vec3::<f32>,
                              depth_ref: f32) -> f32</xmp>
 
   <tr algorithm="textureSampleCompareLevel cube depth array">
@@ -14472,7 +14462,7 @@ fn textureSampleCompareLevel(t: texture_depth_cube,
     <td><xmp highlight=rust>
 fn textureSampleCompareLevel(t: texture_depth_cube_array,
                              s: sampler_comparison,
-                             coords: vec3<f32>,
+                             coords: vec3::<f32>,
                              array_index: A,
                              depth_ref: f32) -> f32</xmp>
 
@@ -14495,7 +14485,7 @@ fn textureSampleCompareLevel(t: texture_depth_cube_array,
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  The `offset` expression [=shader-creation error|must=] be a [=const-expression=] (e.g. `vec2<i32>(1, 2)`).<br>
+  The `offset` expression [=shader-creation error|must=] be a [=const-expression=] (e.g. `vec2::<i32>(1, 2)`).<br>
   Each `offset` component [=shader-creation error|must=] be at least `-8` and at most `7`. Values outside
   of this range will result in a [=shader-creation error=].
 </table>
@@ -14522,71 +14512,71 @@ Samples a texture using explicit gradients.
   <tr algorithm="textureSampleGrad 2d">
     <td>
     <td><xmp highlight=rust>
-fn textureSampleGrad(t: texture_2d<f32>,
+fn textureSampleGrad(t: texture_2d::<f32>,
                      s: sampler,
-                     coords: vec2<f32>,
-                     ddx: vec2<f32>,
-                     ddy: vec2<f32>) -> vec4<f32></xmp>
+                     coords: vec2::<f32>,
+                     ddx: vec2::<f32>,
+                     ddy: vec2::<f32>) -> vec4::<f32></xmp>
 
   <tr algorithm="textureSampleGrad 2d offset">
     <td>
     <td><xmp highlight=rust>
-fn textureSampleGrad(t: texture_2d<f32>,
+fn textureSampleGrad(t: texture_2d::<f32>,
                      s: sampler,
-                     coords: vec2<f32>,
-                     ddx: vec2<f32>,
-                     ddy: vec2<f32>,
-                     offset: vec2<i32>) -> vec4<f32></xmp>
+                     coords: vec2::<f32>,
+                     ddx: vec2::<f32>,
+                     ddy: vec2::<f32>,
+                     offset: vec2::<i32>) -> vec4::<f32></xmp>
 
   <tr algorithm="textureSampleGrad 2d array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSampleGrad(t: texture_2d_array<f32>,
+fn textureSampleGrad(t: texture_2d_array::<f32>,
                      s: sampler,
-                     coords: vec2<f32>,
+                     coords: vec2::<f32>,
                      array_index: A,
-                     ddx: vec2<f32>,
-                     ddy: vec2<f32>) -> vec4<f32></xmp>
+                     ddx: vec2::<f32>,
+                     ddy: vec2::<f32>) -> vec4::<f32></xmp>
 
   <tr algorithm="textureSampleGrad 2d array offset">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSampleGrad(t: texture_2d_array<f32>,
+fn textureSampleGrad(t: texture_2d_array::<f32>,
                      s: sampler,
-                     coords: vec2<f32>,
+                     coords: vec2::<f32>,
                      array_index: A,
-                     ddx: vec2<f32>,
-                     ddy: vec2<f32>,
-                     offset: vec2<i32>) -> vec4<f32></xmp>
+                     ddx: vec2::<f32>,
+                     ddy: vec2::<f32>,
+                     offset: vec2::<i32>) -> vec4::<f32></xmp>
 
   <tr algorithm="textureSampleGrad 3d">
-    <td><var ignore>T</var> is `texture_3d<f32>`, or `texture_cube<f32>`
+    <td><var ignore>T</var> is `texture_3d::<f32>`, or `texture_cube<f32>`
     <td><xmp highlight=rust>
 fn textureSampleGrad(t: T,
                      s: sampler,
-                     coords: vec3<f32>,
-                     ddx: vec3<f32>,
-                     ddy: vec3<f32>) -> vec4<f32></xmp>
+                     coords: vec3::<f32>,
+                     ddx: vec3::<f32>,
+                     ddy: vec3::<f32>) -> vec4::<f32></xmp>
 
   <tr algorithm="textureSampleGrad 3d offset">
     <td>
     <td><xmp highlight=rust>
-fn textureSampleGrad(t: texture_3d<f32>,
+fn textureSampleGrad(t: texture_3d::<f32>,
                      s: sampler,
-                     coords: vec3<f32>,
-                     ddx: vec3<f32>,
-                     ddy: vec3<f32>,
-                     offset: vec3<i32>) -> vec4<f32></xmp>
+                     coords: vec3::<f32>,
+                     ddx: vec3::<f32>,
+                     ddy: vec3::<f32>,
+                     offset: vec3::<i32>) -> vec4::<f32></xmp>
 
   <tr algorithm="textureSampleGrad cube array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSampleGrad(t: texture_cube_array<f32>,
+fn textureSampleGrad(t: texture_cube_array::<f32>,
                      s: sampler,
-                     coords: vec3<f32>,
+                     coords: vec3::<f32>,
                      array_index: A,
-                     ddx: vec3<f32>,
-                     ddy: vec3<f32>) -> vec4<f32></xmp>
+                     ddx: vec3::<f32>,
+                     ddy: vec3::<f32>) -> vec4::<f32></xmp>
 
 </table>
 
@@ -14609,7 +14599,7 @@ fn textureSampleGrad(t: texture_cube_array<f32>,
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  The `offset` expression [=shader-creation error|must=] be a [=const-expression=] (e.g. `vec2<i32>(1, 2)`).<br>
+  The `offset` expression [=shader-creation error|must=] be a [=const-expression=] (e.g. `vec2::<i32>(1, 2)`).<br>
   Each `offset` component [=shader-creation error|must=] be at least `-8` and at most `7`. Values outside
   of this range will result in a [=shader-creation error=].
 </table>
@@ -14630,71 +14620,71 @@ Samples a texture using an explicit mip level.
   <tr algorithm="textureSampleLevel 2d">
     <td>
     <td><xmp highlight=rust>
-fn textureSampleLevel(t: texture_2d<f32>,
+fn textureSampleLevel(t: texture_2d::<f32>,
                       s: sampler,
-                      coords: vec2<f32>,
-                      level: f32) -> vec4<f32></xmp>
+                      coords: vec2::<f32>,
+                      level: f32) -> vec4::<f32></xmp>
 
   <tr algorithm="textureSampleLevel 2d offset">
     <td>
     <td><xmp highlight=rust>
-fn textureSampleLevel(t: texture_2d<f32>,
+fn textureSampleLevel(t: texture_2d::<f32>,
                       s: sampler,
-                      coords: vec2<f32>,
+                      coords: vec2::<f32>,
                       level: f32,
-                      offset: vec2<i32>) -> vec4<f32></xmp>
+                      offset: vec2::<i32>) -> vec4::<f32></xmp>
 
   <tr algorithm="textureSampleLevel 2d array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSampleLevel(t: texture_2d_array<f32>,
+fn textureSampleLevel(t: texture_2d_array::<f32>,
                       s: sampler,
-                      coords: vec2<f32>,
+                      coords: vec2::<f32>,
                       array_index: A,
-                      level: f32) -> vec4<f32></xmp>
+                      level: f32) -> vec4::<f32></xmp>
 
   <tr algorithm="textureSampleLevel 2d array offset">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSampleLevel(t: texture_2d_array<f32>,
+fn textureSampleLevel(t: texture_2d_array::<f32>,
                       s: sampler,
-                      coords: vec2<f32>,
+                      coords: vec2::<f32>,
                       array_index: A,
                       level: f32,
-                      offset: vec2<i32>) -> vec4<f32></xmp>
+                      offset: vec2::<i32>) -> vec4::<f32></xmp>
 
   <tr algorithm="textureSampleLevel 3d">
-    <td><var ignore>T</var> is `texture_3d<f32>`, or `texture_cube<f32>`
+    <td><var ignore>T</var> is `texture_3d::<f32>`, or `texture_cube<f32>`
     <td><xmp highlight=rust>
 fn textureSampleLevel(t: T,
                       s: sampler,
-                      coords: vec3<f32>,
-                      level: f32) -> vec4<f32></xmp>
+                      coords: vec3::<f32>,
+                      level: f32) -> vec4::<f32></xmp>
 
   <tr algorithm="textureSampleLevel 3d offset">
     <td>
     <td><xmp highlight=rust>
-fn textureSampleLevel(t: texture_3d<f32>,
+fn textureSampleLevel(t: texture_3d::<f32>,
                       s: sampler,
-                      coords: vec3<f32>,
+                      coords: vec3::<f32>,
                       level: f32,
-                      offset: vec3<i32>) -> vec4<f32></xmp>
+                      offset: vec3::<i32>) -> vec4::<f32></xmp>
 
   <tr algorithm="textureSampleLevel cube array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSampleLevel(t: texture_cube_array<f32>,
+fn textureSampleLevel(t: texture_cube_array::<f32>,
                       s: sampler,
-                      coords: vec3<f32>,
+                      coords: vec3::<f32>,
                       array_index: A,
-                      level: f32) -> vec4<f32></xmp>
+                      level: f32) -> vec4::<f32></xmp>
 
   <tr algorithm="textureSampleLevel 2d depth">
     <td><var ignore>L</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSampleLevel(t: texture_depth_2d,
                       s: sampler,
-                      coords: vec2<f32>,
+                      coords: vec2::<f32>,
                       level: L) -> f32</xmp>
 
   <tr algorithm="textureSampleLevel 2d depth offset">
@@ -14702,9 +14692,9 @@ fn textureSampleLevel(t: texture_depth_2d,
     <td><xmp highlight=rust>
 fn textureSampleLevel(t: texture_depth_2d,
                       s: sampler,
-                      coords: vec2<f32>,
+                      coords: vec2::<f32>,
                       level: L,
-                      offset: vec2<i32>) -> f32</xmp>
+                      offset: vec2::<i32>) -> f32</xmp>
 
   <tr algorithm="textureSampleLevel 2d depth array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]<br>
@@ -14712,7 +14702,7 @@ fn textureSampleLevel(t: texture_depth_2d,
     <td><xmp highlight=rust>
 fn textureSampleLevel(t: texture_depth_2d_array,
                       s: sampler,
-                      coords: vec2<f32>,
+                      coords: vec2::<f32>,
                       array_index: A,
                       level: L) -> f32</xmp>
 
@@ -14722,17 +14712,17 @@ fn textureSampleLevel(t: texture_depth_2d_array,
     <td><xmp highlight=rust>
 fn textureSampleLevel(t: texture_depth_2d_array,
                       s: sampler,
-                      coords: vec2<f32>,
+                      coords: vec2::<f32>,
                       array_index: A,
                       level: L,
-                      offset: vec2<i32>) -> f32</xmp>
+                      offset: vec2::<i32>) -> f32</xmp>
 
   <tr algorithm="textureSampleLevel cube depth">
     <td><var ignore>L</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
 fn textureSampleLevel(t: texture_depth_cube,
                       s: sampler,
-                      coords: vec3<f32>,
+                      coords: vec3::<f32>,
                       level: L) -> f32</xmp>
 
   <tr algorithm="textureSampleLevel cube depth array">
@@ -14741,7 +14731,7 @@ fn textureSampleLevel(t: texture_depth_cube,
     <td><xmp highlight=rust>
 fn textureSampleLevel(t: texture_depth_cube_array,
                       s: sampler,
-                      coords: vec3<f32>,
+                      coords: vec3::<f32>,
                       array_index: A,
                       level: L) -> f32
 </xmp>
@@ -14768,7 +14758,7 @@ fn textureSampleLevel(t: texture_depth_cube_array,
   The optional texel offset applied to the unnormalized texture coordinate
   before sampling the texture. This offset is applied before applying any
   texture wrapping modes.<br>
-  The `offset` expression [=shader-creation error|must=] be a [=const-expression=] (e.g. `vec2<i32>(1, 2)`).<br>
+  The `offset` expression [=shader-creation error|must=] be a [=const-expression=] (e.g. `vec2::<i32>(1, 2)`).<br>
   Each `offset` component [=shader-creation error|must=] be at least `-8` and at most `7`. Values outside
   of this range will result in a [=shader-creation error=].
 </table>
@@ -14788,11 +14778,11 @@ with texture coordinates clamped to the edge as described below.
   </thead>
 
   <tr algorithm="textureSampleBaseClampToEdge">
-    <td><var ignore>T</var> is `texture_2d<f32>` or `texture_external`
+    <td><var ignore>T</var> is `texture_2d::<f32>` or `texture_external`
     <td><xmp highlight=rust>
 fn textureSampleBaseClampToEdge(t: T,
                                 s: sampler,
-                                coords: vec2<f32>) -> vec4<f32></xmp>
+                                coords: vec2::<f32>) -> vec4::<f32></xmp>
 </table>
 
 **Parameters:**
@@ -14840,9 +14830,9 @@ Writes a single texel to a texture.
         [See the texel format table](#storage-texel-formats) for the mapping of texel
         format to channel format.
     <td><xmp highlight=rust>
-fn textureStore(t: texture_storage_1d<F,write>,
+fn textureStore(t: texture_storage_1d::<F,write>,
                 coords: C,
-                value: vec4<CF>)</xmp>
+                value: vec4::<CF>)</xmp>
 
   <tr algorithm="textureStore 2d">
     <td>|F| is a [=texel format=]<br>
@@ -14851,9 +14841,9 @@ fn textureStore(t: texture_storage_1d<F,write>,
         [See the texel format table](#storage-texel-formats) for the mapping of texel
         format to channel format.
     <td><xmp highlight=rust>
-fn textureStore(t: texture_storage_2d<F,write>,
-                coords: vec2<C>,
-                value: vec4<CF>)</xmp>
+fn textureStore(t: texture_storage_2d::<F,write>,
+                coords: vec2::<C>,
+                value: vec4::<CF>)</xmp>
 
   <tr algorithm="textureStore 2d array">
     <td>|F| is a [=texel format=]<br>
@@ -14863,10 +14853,10 @@ fn textureStore(t: texture_storage_2d<F,write>,
         [See the texel format table](#storage-texel-formats) for the mapping of texel
         format to channel format.
     <td><xmp highlight=rust>
-fn textureStore(t: texture_storage_2d_array<F,write>,
-                coords: vec2<C>,
+fn textureStore(t: texture_storage_2d_array::<F,write>,
+                coords: vec2::<C>,
                 array_index: A,
-                value: vec4<CF>)</xmp>
+                value: vec4::<CF>)</xmp>
 
   <tr algorithm="textureStore 3d">
     <td>|F| is a [=texel format=]<br>
@@ -14875,9 +14865,9 @@ fn textureStore(t: texture_storage_2d_array<F,write>,
         [See the texel format table](#storage-texel-formats) for the mapping of texel
         format to channel format.
     <td><xmp highlight=rust>
-fn textureStore(t: texture_storage_3d<F,write>,
-                coords: vec3<C>,
-                value: vec4<CF>)</xmp>
+fn textureStore(t: texture_storage_3d::<F,write>,
+                coords: vec3::<C>,
+                value: vec4::<CF>)</xmp>
 
 </table>
 
@@ -14926,7 +14916,7 @@ functions [=shader-creation error|must=] be either [=address spaces/storage=] or
 ### Atomic Load ### {#atomic-load}
 
 ```rust
-fn atomicLoad(atomic_ptr: ptr<AS, atomic<T>, read_write>) -> T
+fn atomicLoad(atomic_ptr: ptr::<AS, atomic::<T>, read_write>) -> T
 ```
 
 Returns the atomically loaded the value pointed to by `atomic_ptr`.
@@ -14935,7 +14925,7 @@ It does not [=atomic modification|modify=] the object.
 ### Atomic Store ### {#atomic-store}
 
 ```rust
-fn atomicStore(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T)
+fn atomicStore(atomic_ptr: ptr::<AS, atomic::<T>, read_write>, v: T)
 ```
 
 Atomically stores the value `v` in the atomic object pointed to by `atomic_ptr`.
@@ -14943,13 +14933,13 @@ Atomically stores the value `v` in the atomic object pointed to by `atomic_ptr`.
 ### Atomic Read-modify-write ### {#atomic-rmw}
 
 ```rust
-fn atomicAdd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
-fn atomicSub(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
-fn atomicMax(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
-fn atomicMin(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
-fn atomicAnd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
-fn atomicOr(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
-fn atomicXor(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
+fn atomicAdd(atomic_ptr: ptr::<AS, atomic::<T>, read_write>, v: T) -> T
+fn atomicSub(atomic_ptr: ptr::<AS, atomic::<T>, read_write>, v: T) -> T
+fn atomicMax(atomic_ptr: ptr::<AS, atomic::<T>, read_write>, v: T) -> T
+fn atomicMin(atomic_ptr: ptr::<AS, atomic::<T>, read_write>, v: T) -> T
+fn atomicAnd(atomic_ptr: ptr::<AS, atomic::<T>, read_write>, v: T) -> T
+fn atomicOr(atomic_ptr: ptr::<AS, atomic::<T>, read_write>, v: T) -> T
+fn atomicXor(atomic_ptr: ptr::<AS, atomic::<T>, read_write>, v: T) -> T
 ```
 Each function performs the following steps atomically:
 
@@ -14961,14 +14951,14 @@ Each function performs the following steps atomically:
 Each function returns the original value stored in the atomic object.
 
 ```rust
-fn atomicExchange(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
+fn atomicExchange(atomic_ptr: ptr::<AS, atomic::<T>, read_write>, v: T) -> T
 ```
 
 Atomically stores the value `v` in the atomic object pointed to
 `atomic_ptr` and returns the original value stored in the atomic object.
 
 ```rust
-fn atomicCompareExchangeWeak(atomic_ptr: ptr<AS, atomic<T>, read_write>, cmp: T, v: T) -> __atomic_compare_exchange_result<T>
+fn atomicCompareExchangeWeak(atomic_ptr: ptr::<AS, atomic::<T>, read_write>, cmp: T, v: T) -> __atomic_compare_exchange_result<T>
 
 struct __atomic_compare_exchange_result<T> {
   old_value : T; // old value stored in the atomic
@@ -15012,7 +15002,7 @@ Note: For packing snorm values, the normalized floating point values are in the 
   <tr algorithm="packing 4x8snorm">
     <td style="width:10%" style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn pack4x8snorm(e: vec4<f32>) -> u32
+@const fn pack4x8snorm(e: vec4::<f32>) -> u32
 </xmp>
   <tr>
     <td>Description
@@ -15029,7 +15019,7 @@ Note: For packing snorm values, the normalized floating point values are in the 
   <tr algorithm="packing 4x8unorm">
     <td style="width:10%" style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn pack4x8unorm(e: vec4<f32>) -> u32
+@const fn pack4x8unorm(e: vec4::<f32>) -> u32
 </xmp>
   <tr>
     <td>Description
@@ -15046,7 +15036,7 @@ Note: For packing snorm values, the normalized floating point values are in the 
   <tr algorithm="packing 2x16snorm">
     <td style="width:10%" style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn pack2x16snorm(e: vec2<f32>) -> u32
+@const fn pack2x16snorm(e: vec2::<f32>) -> u32
 </xmp>
   <tr>
     <td>Description
@@ -15063,7 +15053,7 @@ Note: For packing snorm values, the normalized floating point values are in the 
   <tr algorithm="packing 2x16unorm">
     <td style="width:10%" style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn pack2x16unorm(e: vec2<f32>) -> u32
+@const fn pack2x16unorm(e: vec2::<f32>) -> u32
 </xmp>
   <tr>
     <td>Description
@@ -15080,7 +15070,7 @@ Note: For packing snorm values, the normalized floating point values are in the 
   <tr algorithm="packing 2x16float">
     <td style="width:10%" style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn pack2x16float(e: vec2<f32>) -> u32
+@const fn pack2x16float(e: vec2::<f32>) -> u32
 </xmp>
   <tr>
     <td>Description
@@ -15116,7 +15106,7 @@ Note: For unpacking snorm values, the normalized floating point result is in the
   <tr algorithm="unpacking 4x8snorm">
     <td style="width:10%" style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn unpack4x8snorm(e: u32) -> vec4<f32>
+@const fn unpack4x8snorm(e: u32) -> vec4::<f32>
 </xmp>
   <tr>
     <td>Description
@@ -15131,7 +15121,7 @@ Note: For unpacking snorm values, the normalized floating point result is in the
   <tr algorithm="unpacking 4x8unorm">
     <td style="width:10%" style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn unpack4x8unorm(e: u32) -> vec4<f32>
+@const fn unpack4x8unorm(e: u32) -> vec4::<f32>
 </xmp>
   <tr>
     <td>Description
@@ -15146,7 +15136,7 @@ Note: For unpacking snorm values, the normalized floating point result is in the
   <tr algorithm="unpacking 2x16snorm">
     <td style="width:10%" style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn unpack2x16snorm(e: u32) -> vec2<f32>
+@const fn unpack2x16snorm(e: u32) -> vec2::<f32>
 </xmp>
   <tr>
     <td>Description
@@ -15161,7 +15151,7 @@ Note: For unpacking snorm values, the normalized floating point result is in the
   <tr algorithm="unpacking 2x16unorm">
     <td style="width:10%" style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn unpack2x16unorm(e: u32) -> vec2<f32>
+@const fn unpack2x16unorm(e: u32) -> vec2::<f32>
 </xmp>
   <tr>
     <td>Description
@@ -15176,7 +15166,7 @@ Note: For unpacking snorm values, the normalized floating point result is in the
   <tr algorithm="unpacking 2x16float">
     <td style="width:10%" style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn unpack2x16float(e: u32) -> vec2<f32>
+@const fn unpack2x16float(e: u32) -> vec2::<f32>
 </xmp>
   <tr>
     <td>Description
@@ -15241,7 +15231,7 @@ fn workgroupBarrier()
   <tr algorithm="workgroupUniformLoad">
     <td style="width:10%" style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-fn workgroupUniformLoad(p : ptr<workgroup, T>) -> T
+fn workgroupUniformLoad(p : ptr::<workgroup, T>) -> T
 </xmp>
   <tr>
     <td>Parameterization

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3454,13 +3454,13 @@ Note: The following examples use WGSL features explained later in this specifica
 <div class='example wgsl' heading='Using a pointer as a short name for part of a variable'>
   <xmp highlight='rust'>
     struct Particle {
-      position: vec3::<f32>,
-      velocity: vec3::<f32>
+      position: vec3<f32>,
+      velocity: vec3<f32>
     }
     struct System {
       active_index: i32,
       timestep: f32,
-      particles: array::<Particle,100>
+      particles: array<Particle,100>
     }
     @group(0) @binding(0) var<storage,read_write> system: System;
 
@@ -3470,8 +3470,8 @@ Note: The following examples use WGSL features explained later in this specifica
       let active_particle: ptr::<storage,Particle> =
           &system.particles[system.active_index];
 
-      let delta_position: vec3::<f32> = (*active_particle).velocity * system.timestep;
-      let current_position: vec3::<f32>  = (*active_particle).position;
+      let delta_position: vec3<f32> = (*active_particle).velocity * system.timestep;
+      let current_position: vec3<f32>  = (*active_particle).position;
       (*active_particle).position = delta_position + current_position;
     }
   </xmp>
@@ -4117,7 +4117,7 @@ all properties of the members of *S*, including attributes, carry over to the me
 <div class='syntax' noexport='true'>
   <dfn for=syntax>type_specifier</dfn> :
 
-    | [=syntax/callable=]
+    | [=syntax/callable_type=]
 </div>
 
 <div class='syntax' noexport='true'>
@@ -5781,10 +5781,10 @@ The result type depends on the number of letters provided. Assuming a `vec4::<f3
 
 <div class='example wgsl function-scope'>
   <xmp highlight='rust'>
-    var a: vec3::<f32> = vec3::<f32>(1., 2., 3.);
+    var a: vec3<f32> = vec3::<f32>(1., 2., 3.);
     var b: f32 = a.y;          // b = 2.0
-    var c: vec2::<f32> = a.bb;   // c = (3.0, 3.0)
-    var d: vec3::<f32> = a.zyx;  // d = (3.0, 2.0, 1.0)
+    var c: vec2<f32> = a.bb;   // c = (3.0, 3.0)
+    var d: vec3<f32> = a.zyx;  // d = (3.0, 2.0, 1.0)
     var e: f32 = a[1];         // e = 2.0
   </xmp>
 </div>
@@ -6768,6 +6768,15 @@ Note: The [=syntax/call_expression=] rule exists to ensure [=type checking=] app
   <dfn for=syntax>callable</dfn> :
 
     | [=syntax/ident=]
+
+    | [=syntax/ident=] `'::'` <a for=syntax_sym lt=paren_left>`'<'`</a> [=syntax/primary_expression=] ( <a for=syntax_sym lt=comma>`','`</a> [=syntax/primary_expression=] ) * <a for=syntax_sym lt=comma>`','`</a> ? <a for=syntax_sym lt=paren_right>`'>'`</a>
+</div>
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>callable_type</dfn> :
+
+    | [=syntax/ident=]
+
+    | [=syntax/ident=] <a for=syntax_sym lt=paren_left>`'<'`</a> [=syntax/primary_expression=] ( <a for=syntax_sym lt=comma>`','`</a> [=syntax/primary_expression=] ) * <a for=syntax_sym lt=comma>`','`</a> ? <a for=syntax_sym lt=paren_right>`'>'`</a>
 
     | [=syntax/ident=] `'::'` <a for=syntax_sym lt=paren_left>`'<'`</a> [=syntax/primary_expression=] ( <a for=syntax_sym lt=comma>`','`</a> [=syntax/primary_expression=] ) * <a for=syntax_sym lt=comma>`','`</a> ? <a for=syntax_sym lt=paren_right>`'>'`</a>
 </div>
@@ -7974,8 +7983,8 @@ the fragment will be thrown away.
   }
 
   @fragment
-  fn main(@builtin(position) coord_in: vec4::<f32>)
-    -> @location(0) vec4::<f32>
+  fn main(@builtin(position) coord_in: vec4<f32>)
+    -> @location(0) vec4<f32>
   {
     discard_if_shallow(coord_in);
 

--- a/wgsl/wgsl.recursive.bs.include
+++ b/wgsl/wgsl.recursive.bs.include
@@ -131,9 +131,9 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>callable_type.post.ident</dfn>:
 
- | `'::'` `'<'` [=recursive descent syntax/primary_expression=] ( `','` [=recursive descent syntax/primary_expression=] )* `','` ? `'>'`
+ | `'::'` `'<'` [=recursive descent syntax/primary_expression=] [=recursive descent syntax/component_or_swizzle_specifier=] ? ( `','` [=recursive descent syntax/singular_expression=] )* `','` ? `'>'`
 
- | `'<'` [=recursive descent syntax/primary_expression=] ( `','` [=recursive descent syntax/primary_expression=] )* `','` ? `'>'`
+ | `'<'` [=recursive descent syntax/primary_expression=] [=recursive descent syntax/component_or_swizzle_specifier=] ? ( `','` [=recursive descent syntax/singular_expression=] )* `','` ? `'>'`
 
  | `ε`
 </div>
@@ -239,7 +239,7 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>for_init</dfn>:
 
- | [=recursive descent syntax/ident=] ( `'::'` `'<'` [=recursive descent syntax/primary_expression=] ( `','` [=recursive descent syntax/primary_expression=] )* `','` ? `'>'` )? [=recursive descent syntax/argument_expression_list=]
+ | [=recursive descent syntax/ident=] ( `'::'` `'<'` [=recursive descent syntax/singular_expression=] ( `','` [=recursive descent syntax/singular_expression=] )* `','` ? `'>'` )? [=recursive descent syntax/argument_expression_list=]
 
  | [=recursive descent syntax/variable_statement=]
 
@@ -249,7 +249,7 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>for_update</dfn>:
 
- | [=recursive descent syntax/ident=] ( `'::'` `'<'` [=recursive descent syntax/primary_expression=] ( `','` [=recursive descent syntax/primary_expression=] )* `','` ? `'>'` )? [=recursive descent syntax/argument_expression_list=]
+ | [=recursive descent syntax/ident=] ( `'::'` `'<'` [=recursive descent syntax/singular_expression=] ( `','` [=recursive descent syntax/singular_expression=] )* `','` ? `'>'` )? [=recursive descent syntax/argument_expression_list=]
 
  | [=recursive descent syntax/variable_updating_statement=]
 </div>
@@ -367,9 +367,9 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>primary_expression</dfn>:
 
- | [=recursive descent syntax/ident=] ( `'::'` `'<'` [=recursive descent syntax/primary_expression=] ( `','` [=recursive descent syntax/primary_expression=] )* `','` ? `'>'` )?
+ | [=recursive descent syntax/ident=] ( `'::'` `'<'` [=recursive descent syntax/singular_expression=] ( `','` [=recursive descent syntax/singular_expression=] )* `','` ? `'>'` )?
 
- | [=recursive descent syntax/ident=] ( `'::'` `'<'` [=recursive descent syntax/primary_expression=] ( `','` [=recursive descent syntax/primary_expression=] )* `','` ? `'>'` )? `'('` ( [=recursive descent syntax/expression=] ( `','` [=recursive descent syntax/expression=] )* `','` ? )? `')'`
+ | [=recursive descent syntax/ident=] ( `'::'` `'<'` [=recursive descent syntax/singular_expression=] ( `','` [=recursive descent syntax/singular_expression=] )* `','` ? `'>'` )? `'('` ( [=recursive descent syntax/expression=] ( `','` [=recursive descent syntax/expression=] )* `','` ? )? `')'`
 
  | [=recursive descent syntax/literal=]
 
@@ -405,11 +405,17 @@
 </div>
 
 <div class='syntax' noexport='true'>
+  <dfn for='recursive descent syntax'>singular_expression</dfn>:
+
+ | [=recursive descent syntax/primary_expression=] [=recursive descent syntax/component_or_swizzle_specifier=] ?
+</div>
+
+<div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>statement</dfn>:
 
  | [=recursive descent syntax/compound_statement=]
 
- | [=recursive descent syntax/ident=] ( `'::'` `'<'` [=recursive descent syntax/primary_expression=] ( `','` [=recursive descent syntax/primary_expression=] )* `','` ? `'>'` )? `'('` ( [=recursive descent syntax/expression=] ( `','` [=recursive descent syntax/expression=] )* `','` ? )? `')'` `';'`
+ | [=recursive descent syntax/ident=] ( `'::'` `'<'` [=recursive descent syntax/singular_expression=] ( `','` [=recursive descent syntax/singular_expression=] )* `','` ? `'>'` )? `'('` ( [=recursive descent syntax/expression=] ( `','` [=recursive descent syntax/expression=] )* `','` ? )? `')'` `';'`
 
  | [=recursive descent syntax/variable_statement=] `';'`
 

--- a/wgsl/wgsl.recursive.bs.include
+++ b/wgsl/wgsl.recursive.bs.include
@@ -129,6 +129,16 @@
 </div>
 
 <div class='syntax' noexport='true'>
+  <dfn for='recursive descent syntax'>callable_type.post.ident</dfn>:
+
+ | `'::'` `'<'` [=recursive descent syntax/primary_expression=] ( `','` [=recursive descent syntax/primary_expression=] )* `','` ? `'>'`
+
+ | `'<'` [=recursive descent syntax/primary_expression=] ( `','` [=recursive descent syntax/primary_expression=] )* `','` ? `'>'`
+
+ | `ε`
+</div>
+
+<div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>case_selector</dfn>:
 
  | [=recursive descent syntax/expression=]
@@ -261,7 +271,7 @@
 
  | `'struct'` [=recursive descent syntax/ident=] `'{'` [=recursive descent syntax/attribute=] * [=recursive descent syntax/member_ident=] `':'` [=recursive descent syntax/type_specifier=] ( `','` [=recursive descent syntax/attribute=] * [=recursive descent syntax/member_ident=] `':'` [=recursive descent syntax/type_specifier=] )* `','` ? `'}'`
 
- | `'type'` [=recursive descent syntax/ident=] `'='` [=recursive descent syntax/ident=] ( `'::'` `'<'` [=recursive descent syntax/primary_expression=] ( `','` [=recursive descent syntax/primary_expression=] )* `','` ? `'>'` )? `';'`
+ | `'type'` [=recursive descent syntax/ident=] `'='` [=recursive descent syntax/ident=] [=recursive descent syntax/callable_type.post.ident=] `';'`
 </div>
 
 <div class='syntax' noexport='true'>
@@ -465,7 +475,7 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>type_specifier</dfn>:
 
- | [=recursive descent syntax/ident=] ( `'::'` `'<'` [=recursive descent syntax/primary_expression=] ( `','` [=recursive descent syntax/primary_expression=] )* `','` ? `'>'` )?
+ | [=recursive descent syntax/ident=] [=recursive descent syntax/callable_type.post.ident=]
 </div>
 
 <div class='syntax' noexport='true'>

--- a/wgsl/wgsl.recursive.bs.include
+++ b/wgsl/wgsl.recursive.bs.include
@@ -129,20 +129,6 @@
 </div>
 
 <div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>callable</dfn>:
-
- | [=recursive descent syntax/ident=]
-
- | [=recursive descent syntax/mat_prefix=]
-
- | [=recursive descent syntax/type_specifier_without_ident=]
-
- | [=recursive descent syntax/vec_prefix=]
-
- | `'array'`
-</div>
-
-<div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>case_selector</dfn>:
 
  | [=recursive descent syntax/expression=]
@@ -221,28 +207,6 @@
 </div>
 
 <div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>depth_texture_type</dfn>:
-
- | `'texture_depth_2d'`
-
- | `'texture_depth_2d_array'`
-
- | `'texture_depth_cube'`
-
- | `'texture_depth_cube_array'`
-
- | `'texture_depth_multisampled_2d'`
-</div>
-
-<div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>element_count_expression</dfn>:
-
- | [=recursive descent syntax/unary_expression=] ( [=recursive descent syntax/multiplicative_operator=] [=recursive descent syntax/unary_expression=] )* ( [=recursive descent syntax/additive_operator=] [=recursive descent syntax/unary_expression=] ( [=recursive descent syntax/multiplicative_operator=] [=recursive descent syntax/unary_expression=] )* )*
-
- | [=recursive descent syntax/unary_expression=] [=recursive descent syntax/bitwise_expression.post.unary_expression=]
-</div>
-
-<div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>expression</dfn>:
 
  | [=recursive descent syntax/unary_expression=] [=recursive descent syntax/bitwise_expression.post.unary_expression=]
@@ -265,7 +229,7 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>for_init</dfn>:
 
- | [=recursive descent syntax/callable=] [=recursive descent syntax/argument_expression_list=]
+ | [=recursive descent syntax/ident=] ( `'::'` `'<'` [=recursive descent syntax/primary_expression=] ( `','` [=recursive descent syntax/primary_expression=] )* `','` ? `'>'` )? [=recursive descent syntax/argument_expression_list=]
 
  | [=recursive descent syntax/variable_statement=]
 
@@ -275,7 +239,7 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>for_update</dfn>:
 
- | [=recursive descent syntax/callable=] [=recursive descent syntax/argument_expression_list=]
+ | [=recursive descent syntax/ident=] ( `'::'` `'<'` [=recursive descent syntax/primary_expression=] ( `','` [=recursive descent syntax/primary_expression=] )* `','` ? `'>'` )? [=recursive descent syntax/argument_expression_list=]
 
  | [=recursive descent syntax/variable_updating_statement=]
 </div>
@@ -297,7 +261,7 @@
 
  | `'struct'` [=recursive descent syntax/ident=] `'{'` [=recursive descent syntax/attribute=] * [=recursive descent syntax/member_ident=] `':'` [=recursive descent syntax/type_specifier=] ( `','` [=recursive descent syntax/attribute=] * [=recursive descent syntax/member_ident=] `':'` [=recursive descent syntax/type_specifier=] )* `','` ? `'}'`
 
- | `'type'` [=recursive descent syntax/ident=] `'='` [=recursive descent syntax/type_specifier=] `';'`
+ | `'type'` [=recursive descent syntax/ident=] `'='` [=recursive descent syntax/ident=] ( `'::'` `'<'` [=recursive descent syntax/primary_expression=] ( `','` [=recursive descent syntax/primary_expression=] )* `','` ? `'>'` )? `';'`
 </div>
 
 <div class='syntax' noexport='true'>
@@ -364,28 +328,6 @@
 </div>
 
 <div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>mat_prefix</dfn>:
-
- | `'mat2x2'`
-
- | `'mat2x3'`
-
- | `'mat2x4'`
-
- | `'mat3x2'`
-
- | `'mat3x3'`
-
- | `'mat3x4'`
-
- | `'mat4x2'`
-
- | `'mat4x3'`
-
- | `'mat4x4'`
-</div>
-
-<div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>member_ident</dfn>:
 [=syntax/ident_pattern_token=]
 </div>
@@ -415,15 +357,13 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>primary_expression</dfn>:
 
- | [=recursive descent syntax/callable=] `'('` ( [=recursive descent syntax/expression=] ( `','` [=recursive descent syntax/expression=] )* `','` ? )? `')'`
+ | [=recursive descent syntax/ident=] ( `'::'` `'<'` [=recursive descent syntax/primary_expression=] ( `','` [=recursive descent syntax/primary_expression=] )* `','` ? `'>'` )?
 
- | [=recursive descent syntax/ident=]
+ | [=recursive descent syntax/ident=] ( `'::'` `'<'` [=recursive descent syntax/primary_expression=] ( `','` [=recursive descent syntax/primary_expression=] )* `','` ? `'>'` )? `'('` ( [=recursive descent syntax/expression=] ( `','` [=recursive descent syntax/expression=] )* `','` ? )? `')'`
 
  | [=recursive descent syntax/literal=]
 
  | `'('` [=recursive descent syntax/expression=] `')'`
-
- | `'bitcast'` `'<'` [=recursive descent syntax/type_specifier=] `'>'` `'('` [=recursive descent syntax/expression=] `')'`
 </div>
 
 <div class='syntax' noexport='true'>
@@ -445,30 +385,6 @@
 </div>
 
 <div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>sampled_texture_type</dfn>:
-
- | `'texture_1d'`
-
- | `'texture_2d'`
-
- | `'texture_2d_array'`
-
- | `'texture_3d'`
-
- | `'texture_cube'`
-
- | `'texture_cube_array'`
-</div>
-
-<div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>sampler_type</dfn>:
-
- | `'sampler'`
-
- | `'sampler_comparison'`
-</div>
-
-<div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>shift_expression.post.unary_expression</dfn>:
 
  | ( [=recursive descent syntax/multiplicative_operator=] [=recursive descent syntax/unary_expression=] )* ( [=recursive descent syntax/additive_operator=] [=recursive descent syntax/unary_expression=] ( [=recursive descent syntax/multiplicative_operator=] [=recursive descent syntax/unary_expression=] )* )*
@@ -481,9 +397,9 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>statement</dfn>:
 
- | [=recursive descent syntax/callable=] `'('` ( [=recursive descent syntax/expression=] ( `','` [=recursive descent syntax/expression=] )* `','` ? )? `')'` `';'`
-
  | [=recursive descent syntax/compound_statement=]
+
+ | [=recursive descent syntax/ident=] ( `'::'` `'<'` [=recursive descent syntax/primary_expression=] ( `','` [=recursive descent syntax/primary_expression=] )* `','` ? `'>'` )? `'('` ( [=recursive descent syntax/expression=] ( `','` [=recursive descent syntax/expression=] )* `','` ? )? `')'` `';'`
 
  | [=recursive descent syntax/variable_statement=] `';'`
 
@@ -510,18 +426,6 @@
  | `'switch'` [=recursive descent syntax/expression=] `'{'` [=recursive descent syntax/switch_body=] * `'}'`
 
  | `'while'` [=recursive descent syntax/expression=] [=recursive descent syntax/compound_statement=]
-</div>
-
-<div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>storage_texture_type</dfn>:
-
- | `'texture_storage_1d'`
-
- | `'texture_storage_2d'`
-
- | `'texture_storage_2d_array'`
-
- | `'texture_storage_3d'`
 </div>
 
 <div class='syntax' noexport='true'>
@@ -553,58 +457,6 @@
 </div>
 
 <div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>texel_format</dfn>:
-
- | `'bgra8unorm'`
-
- | `'r32float'`
-
- | `'r32sint'`
-
- | `'r32uint'`
-
- | `'rg32float'`
-
- | `'rg32sint'`
-
- | `'rg32uint'`
-
- | `'rgba16float'`
-
- | `'rgba16sint'`
-
- | `'rgba16uint'`
-
- | `'rgba32float'`
-
- | `'rgba32sint'`
-
- | `'rgba32uint'`
-
- | `'rgba8sint'`
-
- | `'rgba8snorm'`
-
- | `'rgba8uint'`
-
- | `'rgba8unorm'`
-</div>
-
-<div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>texture_and_sampler_types</dfn>:
-
- | [=recursive descent syntax/depth_texture_type=]
-
- | [=recursive descent syntax/sampled_texture_type=] `'<'` [=recursive descent syntax/type_specifier=] `'>'`
-
- | [=recursive descent syntax/sampler_type=]
-
- | [=recursive descent syntax/storage_texture_type=] `'<'` [=recursive descent syntax/texel_format=] `','` [=recursive descent syntax/access_mode=] `'>'`
-
- | [=syntax/multisampled_texture_type=] `'<'` [=recursive descent syntax/type_specifier=] `'>'`
-</div>
-
-<div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>translation_unit</dfn>:
 
  | ( `'enable'` [=syntax/extension_name=] `';'` )* [=recursive descent syntax/global_decl=] *
@@ -613,35 +465,7 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>type_specifier</dfn>:
 
- | [=recursive descent syntax/ident=]
-
- | [=recursive descent syntax/type_specifier_without_ident=]
-</div>
-
-<div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>type_specifier_without_ident</dfn>:
-
- | [=recursive descent syntax/mat_prefix=] `'<'` [=recursive descent syntax/type_specifier=] `'>'`
-
- | [=recursive descent syntax/texture_and_sampler_types=]
-
- | [=recursive descent syntax/vec_prefix=] `'<'` [=recursive descent syntax/type_specifier=] `'>'`
-
- | `'array'` `'<'` [=recursive descent syntax/type_specifier=] ( `','` [=recursive descent syntax/element_count_expression=] )? `'>'`
-
- | `'atomic'` `'<'` [=recursive descent syntax/type_specifier=] `'>'`
-
- | `'bool'`
-
- | `'f16'`
-
- | `'f32'`
-
- | `'i32'`
-
- | `'ptr'` `'<'` [=recursive descent syntax/address_space=] `','` [=recursive descent syntax/type_specifier=] ( `','` [=recursive descent syntax/access_mode=] )? `'>'`
-
- | `'u32'`
+ | [=recursive descent syntax/ident=] ( `'::'` `'<'` [=recursive descent syntax/primary_expression=] ( `','` [=recursive descent syntax/primary_expression=] )* `','` ? `'>'` )?
 </div>
 
 <div class='syntax' noexport='true'>
@@ -688,14 +512,4 @@
  | [=recursive descent syntax/lhs_expression=] `'--'`
 
  | `'_'` `'='` [=recursive descent syntax/expression=]
-</div>
-
-<div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>vec_prefix</dfn>:
-
- | `'vec2'`
-
- | `'vec3'`
-
- | `'vec4'`
 </div>


### PR DESCRIPTION
This PR is a draft demo that only shows the lack of parsing ambiguity of turbofish `::<>` with primary_expression. Also, examples show how this would read in general. People can also use this as a starting point for alternative tokens, as syntax is there.

PS: This PR does not do special casing for `: typename` typed members or typed idents, where turbofish could go away for `<>` only.