### PR TITLE
NFKC normal WGSL spec sources and introduce check

### DIFF
--- a/tools/check-nfkc.py
+++ b/tools/check-nfkc.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+# Checks if all normative and informative
+# WGSL spec sources are NFKC normal
+# Note: Filters sources by the workimg directory,
+# any other directory can benefit as well as WGSL
+
+import unicodedata
+import subprocess
+import sys
+
+files = subprocess.run(
+    ["git", "ls-files", "--recurse-submodules"], check=True, capture_output=True
+).stdout.splitlines()
+
+fix = "--fix" in [unicodedata.normalize("NFKC", i) for i in sys.argv]
+
+for file in files:
+    contents = open(file).read()
+    normalized = unicodedata.normalize("NFKC", contents)
+    if contents != normalized:
+        if fix:
+            open(file, "w").write(normalized)
+        else:
+            raise SystemExit("Error: Source files are not NFKC normalized.")

--- a/tools/check-nfkc.py
+++ b/tools/check-nfkc.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 
 files = subprocess.run(
-    ["git", "ls-files", "--recurse-submodules"], check=True, capture_output=True
+    ["git", "ls-files"], check=True, capture_output=True
 ).stdout.splitlines()
 
 fix = "--fix" in [unicodedata.normalize("NFKC", i) for i in sys.argv]

--- a/wgsl/Makefile
+++ b/wgsl/Makefile
@@ -14,6 +14,7 @@ index.pre.html: $(WGSL_SOURCES)
 
 GHC=https://github.com/gpuweb/gpuweb/blob
 index.html: index.pre.html
+	python3 ../tools/check-nfkc.py
 	@echo 'Inserting source permalink: index.pre.html -> index.html'
 	@sed -e "s,gpuweb/wgsl/</a>,gpuweb/wgsl/</a><br><a href=\"$(GHC)/$(shell git rev-parse HEAD)/wgsl/index.bs\">$(GHC)/$(shell git rev-parse HEAD)/wgsl/index.bs</a>," <index.pre.html >index.html
 

--- a/wgsl/Makefile
+++ b/wgsl/Makefile
@@ -1,6 +1,6 @@
-.PHONY: all clean validate lalr validate-examples
+.PHONY: all clean nfkc validate lalr validate-examples
 
-all: index.html validate test diagrams
+all: index.html nfkc validate test diagrams
 validate: lalr validate-examples
 validate-examples: grammar/grammar.js
 
@@ -14,7 +14,6 @@ index.pre.html: $(WGSL_SOURCES)
 
 GHC=https://github.com/gpuweb/gpuweb/blob
 index.html: index.pre.html
-	python3 ../tools/check-nfkc.py
 	@echo 'Inserting source permalink: index.pre.html -> index.html'
 	@sed -e "s,gpuweb/wgsl/</a>,gpuweb/wgsl/</a><br><a href=\"$(GHC)/$(shell git rev-parse HEAD)/wgsl/index.bs\">$(GHC)/$(shell git rev-parse HEAD)/wgsl/index.bs</a>," <index.pre.html >index.html
 
@@ -33,6 +32,9 @@ grammar/grammar.js: index.bs extract-grammar.py
 WGSL_GRAMMAR=grammar/src/grammar.json
 $(WGSL_GRAMMAR) : grammar/grammar.js
 
+.PHONY: nfkc
+nfkc:
+	python3 ../tools/check-nfkc.py
 
 #### Grammar analyzer materials below here.
 #### You probably only want 'make validate'

--- a/wgsl/Makefile
+++ b/wgsl/Makefile
@@ -13,7 +13,7 @@ index.pre.html: $(WGSL_SOURCES)
 	DIE_ON=everything bash ../tools/invoke-bikeshed.sh $@ $(WGSL_SOURCES)
 
 GHC=https://github.com/gpuweb/gpuweb/blob
-index.html: index.pre.html
+index.html: index.pre.html nfkc
 	@echo 'Inserting source permalink: index.pre.html -> index.html'
 	@sed -e "s,gpuweb/wgsl/</a>,gpuweb/wgsl/</a><br><a href=\"$(GHC)/$(shell git rev-parse HEAD)/wgsl/index.bs\">$(GHC)/$(shell git rev-parse HEAD)/wgsl/index.bs</a>," <index.pre.html >index.html
 

--- a/wgsl/extract-grammar.py
+++ b/wgsl/extract-grammar.py
@@ -333,7 +333,7 @@ grammar_source += r"""
 module.exports = grammar({
     name: 'wgsl',
 
-    externals: $ => [
+    externals: $ => [
         $._block_comment,
     ],
 

--- a/wgsl/wgsl_spec_style_guide.md
+++ b/wgsl/wgsl_spec_style_guide.md
@@ -111,7 +111,7 @@ and end with `` /` `` and not contain any space character or line break between 
 WGSL specification normalizes its normative and informative sources to
 promote interoperability between developers using different input mechanisms.
 A developer intending to contribute can automatically normalize sources by
-passing `--fix` to `check-nfkc-wgsl.py` in the tools directory.
+passing `--fix` to `check-nfkc.py` in the tools directory.
 
 ## Tagging conventions
 

--- a/wgsl/wgsl_spec_style_guide.md
+++ b/wgsl/wgsl_spec_style_guide.md
@@ -93,12 +93,12 @@ and end with a line which only contains `` </div> ``. There must be only one
 syntactic rule between these lines.
 * Each syntactic rule must define itself for Bikeshed. Each syntactic rule definition must start with two spaces
 and then place the rule name between `` <dfn for=syntax> `` and `` </dfn> : `` on the same line.
-* Each syntactic rule item must start with four spaces and then list members after `` | `` followed by a space.
+* Each syntactic rule item must start with four spaces and then list members after `` | `` followed by a space.
     * Syntactic rule items can be split to multiple lines. For this, start the next line with six spaces.
 * Each syntactic rule item must be surrounded by only a space before and after,
 trailing space at the end of the line being redundant.
 * Members of syntactic rules items can be references to existing rules. These must be placed between
-`` [=syntax/ `` and `` =] ``.
+`` [=syntax/ `` and `` =] ``.
 * Members of syntactic rules can contain groups which should contain the group members between `` ( `` and `` ) ``.
 * Members of syntactic rule items which denote a string should start with `` `' ``
 and end with `` '` `` and not contain any space character or line break between these two.
@@ -107,6 +107,11 @@ and end with `` /` `` and not contain any space character or line break between 
 * If a member is optional, then it must be followed by a `` ? `` member token.
 * If a member can repeat and must appear at least once, then it must be followed by a `` + `` member token.
 * If a member can repeat and does not have to appear, then it must be followed by a `` * `` member token.
+
+WGSL specification normalizes its normative and informative sources to
+promote interoperability between developers using different input mechanisms.
+A developer intending to contribute can automatically normalize sources by
+passing `--fix` to `check-nfkc-wgsl.py` in the tools directory.
 
 ## Tagging conventions
 


### PR DESCRIPTION
I accidentally introduced quite a few international blank spaces over the last couple of years. Fixing and adding a script to primarily check and fix when needed for future contributors!

Part of my original plan for https://github.com/gpuweb/gpuweb/issues/3708 but @dneto0 informed in the last editors' meeting about a parallel development (hoping for preservation of tree-sitter compatibility and license in extract-grammar.py before its purge), hence, doing this additional step layout there.