### PR TITLE
Fix handling of comments

### DIFF
--- a/wgsl/extract-grammar.py
+++ b/wgsl/extract-grammar.py
@@ -433,7 +433,7 @@ def grammar_from_rule(key, value):
     return result
 
 
-scanner_components[scanner_rule.name()]["_comment"] = [["`'//'`", '`/.*/`']]
+scanner_components[scanner_rule.name()]["_comment"] = [["`'//.*'`"]]
 
 # Following sections are to allow out-of-order per syntactic grammar appearance of rules
 


### PR DESCRIPTION
The previous version allowed comments of the form:
```
//
This is the comment body
```
Which I believe is not consistent with the spec.
(This occured because the two different `token`s allowed a whitespace between them)