### PR TITLE
Working on a way to easily show issue milestones

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -389,6 +389,24 @@ thead.stickyheader th, th.stickyheader {
 }
 
 /*
+ * Issue milestones
+ */
+
+.issue .milestone{
+    display: inline-block;
+    padding: 3px;
+
+    border: 1px solid;
+    border-radius: 0.4em;
+    font-size: 0.6em;
+    font-weight: bold;
+    text-decoration: none;
+
+    background: var(--note-editorial-bg);
+    border-color: var(--note-editorial-border);
+}
+
+/*
  * Light-mode and dark-mode colors
  */
 :root {
@@ -648,9 +666,7 @@ especially due to potentially malicious usage.
 If a user agent implements such a warning, it should include WebGPU usage in
 its heuristics, in addition to JavaScript, WebAssembly, WebGL, and so on.
 
-Issue(gpuweb/gpuweb#3483):
-Should WebGPU have Permissions Policy / Feature Policy?
-
+Issue(3483): <label data-milestone="V1.0"> Should WebGPU have Permissions Policy / Feature Policy?
 
 ## Privacy Considerations ## {#privacy-considerations}
 
@@ -2010,7 +2026,7 @@ WebGPU defines a new [=task source=] called the <dfn dfn>automatic expiry task s
 It is used for the automatic, timed expiry (destruction) of certain objects:
 
 - {{GPUTexture}}s returned by {{GPUCanvasContext/getCurrentTexture()}}
-- Issue(gpuweb/gpuweb#3324): {{GPUExternalTexture}}s created from {{HTMLVideoElement}}s?
+- Issue(3324): {{GPUExternalTexture}}s created from {{HTMLVideoElement}}s?
 
 <div algorithm>
     To <dfn abstract-op>queue an automatic expiry task</dfn>
@@ -2058,7 +2074,7 @@ WebGPU allows all of the color spaces in the {{PredefinedColorSpace}} enum.
 Note, each color space is defined over an extended range, as defined by the referenced CSS definitions,
 to represent color values outside of its space (in both chrominance and luminance).
 
-Issue(gpuweb/gpuweb#1715):
+Issue(1715):
 Consider a path for uploading srgb-encoded images into linearly-encoded textures.
 
 An <dfn dfn>out-of-gamut premultiplied RGBA value</dfn> is one where any of the R/G/B channel values
@@ -3986,7 +4002,7 @@ dictionary GPUTextureDescriptor : GPUObjectDescriptorBase {
             - |format| equals |viewFormat|, or
             - |format| and |viewFormat| differ only in whether they are `srgb` formats (have the `-srgb` suffix).
 
-            Issue(gpuweb/gpuweb#168): Define larger compatibility classes.
+            Issue(168): Define larger compatibility classes.
         </div>
 </dl>
 
@@ -4800,7 +4816,7 @@ The depth component of the {{GPUTextureFormat/"depth24plus"}} and {{GPUTextureFo
 formats may be implemented as either a [=24-bit depth=] value or a {{GPUTextureFormat/"depth32float"}} value.
 </p>
 
-Issue(gpuweb/gpuweb#1887): add something on GPUAdapter(?) that gives an estimate of the bytes per texel of
+Issue(1887): add something on GPUAdapter(?) that gives an estimate of the bytes per texel of
 {{GPUTextureFormat/"stencil8"}}, {{GPUTextureFormat/"depth24plus-stencil8"}}, and {{GPUTextureFormat/"depth32float-stencil8"}}.
 
 The {{GPUTextureFormat/stencil8}} format may be implemented as
@@ -5675,7 +5691,7 @@ dictionary GPUTextureBindingLayout {
 };
 </script>
 
-Issue(https://github.com/gpuweb/gpuweb/issues/851): consider making {{GPUTextureBindingLayout/sampleType}}
+Issue(851): consider making {{GPUTextureBindingLayout/sampleType}}
 truly optional.
 
 {{GPUTextureBindingLayout}} dictionaries have the following members:
@@ -5707,7 +5723,7 @@ dictionary GPUStorageTextureBindingLayout {
 };
 </script>
 
-Issue(https://github.com/gpuweb/gpuweb/issues/851): consider making {{GPUStorageTextureBindingLayout/format}}
+Issue(851): consider making {{GPUStorageTextureBindingLayout/format}}
 truly optional.
 
 {{GPUStorageTextureBindingLayout}} dictionaries have the following members:
@@ -6375,7 +6391,7 @@ dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
                         - |result| must not be a [=shader-creation error|shader-creation=] [=program error=].
                     </div>
 
-                Issue(gpuweb/gpuweb#2308):
+                Issue(2308):
                 Should internal errors ([=uncategorized errors=]) be allowed here or should we
                 force them to be deferred to pipeline creation?
 
@@ -7362,7 +7378,7 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
                             |workgroupStorageUsed| must be &le;
                             |device|.limits.{{supported limits/maxComputeWorkgroupStorageSize}}.
 
-                            Issue(gpuweb/gpuweb#3485): Does this need to account for padding?
+                            Issue(3485): Does this need to account for padding?
                         - |descriptor|.{{GPUComputePipelineDescriptor/compute}} must use &le;
                             |device|.limits.{{supported limits/maxComputeInvocationsPerWorkgroup}} per
                             workgroup.
@@ -8327,7 +8343,7 @@ will affect a render pass's {{GPURenderPassDescriptor/depthStencilAttachment}}:
             |descriptor|.{{GPUDepthStencilState/stencilBack}} are not the default values:
             - |descriptor|.{{GPUDepthStencilState/format}} must have a stencil component.
 
-    Issue: how can this algorithm support depth/stencil formats that are added in extensions?
+    Issue: <label data-milestone="post-V1"> how can this algorithm support depth/stencil formats that are added in extensions?
 </div>
 
 <script type=idl>
@@ -9132,7 +9148,7 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                         - |this| is [=valid=].
                     </div>
 
-                Issue: Describe remaining {{GPUDevice/createCommandEncoder()}} validation and
+                Issue: <label data-milestone="V1.0"> Describe remaining {{GPUDevice/createCommandEncoder()}} validation and
                 algorithm steps.
             </div>
         </div>
@@ -9325,7 +9341,7 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                         - |destination|.{{GPUBuffer/size}} &ge; (|destinationOffset| + |size|).
                         - |source| and |destination| are not the same {{GPUBuffer}}.
 
-                        Issue(gpuweb/gpuweb#69): figure out how to handle overflows in the spec.
+                        Issue(69): figure out how to handle overflows in the spec.
                     </div>
 
                 1. [$Enqueue a command$] on |this| which issues the subsequent steps on the
@@ -9453,7 +9469,7 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
             <div data-timeline=queue>
                 [=Queue timeline=] steps:
 
-                Issue: Define copy, including provision for snorm.
+                Issue: <label data-milestone="V1.0"> Define copy, including provision for snorm.
             </div>
 
         </div>
@@ -9519,7 +9535,7 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
             <div data-timeline=queue>
                 [=Queue timeline=] steps:
 
-                Issue: Define copy, including provision for snorm.
+                Issue: <label data-milestone="V1.0"> Define copy, including provision for snorm.
             </div>
 
         </div>
@@ -9580,7 +9596,7 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
             <div data-timeline=queue>
                 [=Queue timeline=] steps:
 
-                Issue: Define copy, including provision for snorm.
+                Issue: <label data-milestone="V1.0"> Define copy, including provision for snorm.
             </div>
 
         </div>
@@ -9937,13 +9953,13 @@ It must only be included by interfaces which also include those mixins.
                 - |bindGroup| must not be `null`.
                 - |bindGroup|.{{GPUBindGroup/[[layout]]}} must be [=group-equivalent=] with |bindGroupLayout|.
 
-            Issue: Add validation that, for buffer bindings that weren't prevalidated with
+            Issue: <label data-milestone="V1.0"> Add validation that, for buffer bindings that weren't prevalidated with
             {{GPUBufferBindingLayout/minBindingSize}}, the binding ranges are large enough for
             the [=minimum buffer binding size=].
         </div>
     1. [$Encoder bind groups alias a writable resource$](|encoder|, |pipeline|) must be `false`.
 
-        Issue(gpuweb/gpuweb#1842): Determine what happens when an application violates this.
+        Issue(1842): Determine what happens when an application violates this.
         Is it a validation error, one of multiple possible behaviors, or do we just remove this
         restriction entirely and allow writable bindings to alias with undefined results?
 
@@ -10621,7 +10637,7 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
 
         1. |timestampWrite|.{{GPURenderPassTimestampWrite/queryIndex}} is written at most once in the same |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}} in this render pass.
 
-    Issue(gpuweb/gpuweb#503): support for no attachments
+    Issue(503): support for no attachments
 </div>
 
 <div algorithm>
@@ -12237,7 +12253,7 @@ GPUQueue includes GPUObjectBase;
 
                 1. Write |contents| into |destination|.
 
-                    Issue: Define copy, including provision for snorm.
+                    Issue: <label data-milestone="V1.0"> Define copy, including provision for snorm.
             </div>
         </div>
 
@@ -12319,7 +12335,7 @@ GPUQueue includes GPUObjectBase;
                             - {{GPUTextureFormat/"rgba16float"}}
                             - {{GPUTextureFormat/"rgba32float"}}
                     </div>
-                1. Issue: Do the actual copy.
+                1. Issue: <label data-milestone="V1.0"> Do the actual copy.
             </div>
         </div>
 
@@ -13609,7 +13625,7 @@ partial interface GPUDevice {
 
 This section describes the details of various GPU operations.
 
-Issue: This section is incomplete.
+Issue: <label data-milestone="post-V1"> This section is incomplete.
 
 ## Transfer ## {#transfer-operations}
 
@@ -15308,24 +15324,37 @@ Eventually all of these should disappear but they are useful to avoid warning wh
 [=buffer internals/state/destroyed=]
 
 <script>
-// Small script to collect all xrefs that refer to different timelines and highlight
-// them with an appropriate style.
+window.addEventListener('load', () => {
+    // Small script to collect all xrefs that refer to different timelines and highlight
+    // them with an appropriate style.
 
-const dataLinks = document.querySelectorAll("[data-link-type='abstract-op'], [data-link-type='dfn'], [data-link-type='idl'], [data-link-type='attribute']");
-for (const dataLink of dataLinks) {
-    const linkUrl = dataLink.getAttribute('href');
-    if (linkUrl && linkUrl.startsWith('#')) {
-      const dataLinkTarget = document.getElementById(linkUrl.substring(1));
-      if (dataLinkTarget) {
-          // Find the closest ancestor of the target (including the target itself)
-          // that contains a data-timeline.
-          const timelineElement = dataLinkTarget.closest('[data-timeline]');
-          if (timelineElement) {
-            // If we found a timeline, apply an appropriate style the link.
-            const timeline = timelineElement.getAttribute('data-timeline');
-            dataLink.setAttribute('data-timeline', timeline);
-          }
-      }
+    const dataLinks = document.querySelectorAll("[data-link-type='abstract-op'], [data-link-type='dfn'], [data-link-type='idl'], [data-link-type='attribute']");
+    for (const dataLink of dataLinks) {
+        const linkUrl = dataLink.getAttribute('href');
+        if (linkUrl && linkUrl.startsWith('#')) {
+        const dataLinkTarget = document.getElementById(linkUrl.substring(1));
+        if (dataLinkTarget) {
+            // Find the closest ancestor of the target (including the target itself)
+            // that contains a data-timeline.
+            const timelineElement = dataLinkTarget.closest('[data-timeline]');
+            if (timelineElement) {
+                // If we found a timeline, apply an appropriate style the link.
+                const timeline = timelineElement.getAttribute('data-timeline');
+                dataLink.setAttribute('data-timeline', timeline);
+            }
+        }
+        }
     }
-}
+
+    // Script to find each milestone label and link it back to the appropriate GitHub milestones
+    const milestoneLabels = document.querySelectorAll('label[data-milestone]');
+    for (const label of milestoneLabels) {
+        const milestone = label.getAttribute('data-milestone');
+        const link = document.createElement('a');
+        link.href = 'https://github.com/gpuweb/gpuweb/milestones/' + milestone;
+        link.innerText = 'Target: ' + milestone;
+        link.classList.add('milestone');
+        label.prepend(link);
+    }
+});
 </script>


### PR DESCRIPTION
This came from a conversation with @Kangz about making it easier to see what spec items were high priority. It gives us the ability to slap a little milestone ship on inline issues. The chip links back to the milestone issue list (but doesn't magically create a corresponding GH issue or anything like that, obviously.)

Slapped milestones on a few items for testing purposes, but a full triage would need to happen after this lands to ensure we've properly categorized the issues. Hopefully that will help other team members not working directly on the spec understand the scope of remaining V1 work.