### PR TITLE
Reserve common scalar types, and quat

### DIFF
--- a/wgsl/keywords
+++ b/wgsl/keywords
@@ -614,6 +614,20 @@ using
 wgsl
 );
 
+# Common scalar types, incluing bf16 for bfloat16
+push @wgsl_reserved, qw(
+i8 i16 i64
+u8 u16 u64
+f64
+bf16
+);
+
+# A foreseeable templated quaternion type.
+# Swift has simd_quatf and simd_quatd
+push @wgsl_reserved, qw(
+quat
+);
+
 
 # Key is a keyword.
 # Value is a list of languages that reserve the word in some way.

--- a/wgsl/wgsl.reserved.bs.include
+++ b/wgsl/wgsl.reserved.bs.include
@@ -39,6 +39,8 @@
 
     | `'become'`   <!-- Rust -->
 
+    | `'bf16'`   <!-- WGSL -->
+
     | `'binding_array'`   <!-- WGSL -->
 
     | `'cast'`   <!-- GLSL(reserved) -->
@@ -101,6 +103,8 @@
 
     | `'external'`   <!-- GLSL(reserved) -->
 
+    | `'f64'`   <!-- WGSL -->
+
     | `'fallthrough'`   <!-- WGSL -->
 
     | `'filter'`   <!-- GLSL(reserved) -->
@@ -124,6 +128,12 @@
     | `'handle'`   <!-- WGSL -->
 
     | `'highp'`   <!-- GLSL -->
+
+    | `'i16'`   <!-- WGSL -->
+
+    | `'i64'`   <!-- WGSL -->
+
+    | `'i8'`   <!-- WGSL -->
 
     | `'impl'`   <!-- Rust -->
 
@@ -211,6 +221,8 @@
 
     | `'public'`   <!-- C++ ECMAScript2022 GLSL(reserved) -->
 
+    | `'quat'`   <!-- WGSL -->
+
     | `'readonly'`   <!-- GLSL -->
 
     | `'ref'`   <!-- Rust -->
@@ -276,6 +288,12 @@
     | `'typename'`   <!-- C++ -->
 
     | `'typeof'`   <!-- ECMAScript2022 Rust -->
+
+    | `'u16'`   <!-- WGSL -->
+
+    | `'u64'`   <!-- WGSL -->
+
+    | `'u8'`   <!-- WGSL -->
 
     | `'union'`   <!-- C++ Rust GLSL(reserved) -->
 


### PR DESCRIPTION
One possible outcome of #3739 is that we *do* want to reserve certain type names as keywords.

Reserve common scalar types.

Also reserve `quat` so that we can in future we can easily write `quat<f32>` and `quat<f16>`.
Note that Swift has simd_quatf and simd_quatf which would correspond to `quat<f32>` and `quat<f64>`.