### PR TITLE
Add maxBindGroupsPlusVertexBuffers limit

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1546,6 +1546,13 @@ applications should generally request the "worst" limits that work for their con
         allowed in {{GPUPipelineLayoutDescriptor/bindGroupLayouts}}
         when creating a {{GPUPipelineLayout}}.
 
+    <tr><td><dfn>maxBindGroupsPlusVertexBuffers</dfn>
+        <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>4
+    <tr class=row-continuation><td colspan=4>
+        The highest index of any {{GPUVertexBufferLayout|GPUVertexBufferLayout}} within {{GPUVertexState/buffers}},
+        plus the number of {{GPUBindGroupLayout|GPUBindGroupLayouts}} within {{GPUPipelineLayoutDescriptor/bindGroupLayouts}},
+        when creating a {{GPUPipelineLayout}}.
+
     <tr><td><dfn>maxBindingsPerBindGroup</dfn>
         <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>640
     <tr class=row-continuation><td colspan=4>
@@ -1774,6 +1781,7 @@ interface GPUSupportedLimits {
     readonly attribute unsigned long maxTextureDimension3D;
     readonly attribute unsigned long maxTextureArrayLayers;
     readonly attribute unsigned long maxBindGroups;
+    readonly attribute unsigned long maxBindGroupsPlusVertexBuffers;
     readonly attribute unsigned long maxBindingsPerBindGroup;
     readonly attribute unsigned long maxDynamicUniformBuffersPerPipelineLayout;
     readonly attribute unsigned long maxDynamicStorageBuffersPerPipelineLayout;
@@ -7588,6 +7596,9 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
                     <div class=validusage>
                         - |layout| is [$valid to use with$] |this|.
                         - [$validating GPURenderPipelineDescriptor$](|descriptor|, |layout|, |this|) succeeds.
+                        - |layout|.{{GPUPipelineLayout/[[bindGroupLayouts]]}}.length + |vertexBufferCount| is &le;
+                            |this|.{{GPUObjectBase/[[device]]}}.{{device/[[limits]]}}.{{supported limits/maxBindGroupsPlusVertexBuffers}},
+                            where |vertexBufferCount| is the maximum index in |descriptor|.{{GPURenderPipelineDescriptor/vertex}}.{{GPUVertexState/buffers}} that is not `undefined`
                     </div>
                 1. Set |pipeline|.{{GPURenderPipeline/[[descriptor]]}} to |descriptor|.
                 1. Set |pipeline|.{{GPURenderPipeline/[[writesDepth]]}} to false.


### PR DESCRIPTION
Fixes https://github.com/gpuweb/gpuweb/issues/2749

On an implementation on top of Metal that chooses to use argument buffers, bind groups and vertex buffers use the same metal resource (vertex buffer slots). This limit allows the site to trade-off bind groups and vertex buffers themselves, as long as the total sum of them don't exceed a limit.

This will be a bit tricky to implement on Metal if it's possible to unbind vertex buffers or bind groups (see
https://github.com/gpuweb/gpuweb/issues/3787) but I think it's possible and worth the tradeoff to not expose the complexity to the web, but to instead just handle it in the browser.