### PR TITLE
Add wgsl_version_at_least builtin function.

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9289,7 +9289,7 @@ Version numbers are often written with the major number first, then a period ('`
 
 Versions are ordered lexicographically, i.e. *Version(major1, minor1)* is earlier than *Version(major2, minor2)* when:
     * *major1* &lt; *major2*, or
-    * (*major1* &equals; *major2*) and (*minor1* < *minor2*)
+    * (*major1* &equals; *major2*) and (*minor1* &lt; *minor2*)
 
 A valid program for an earlier version of WGSL, with major number at least 1,
 is valid and has the same meaning in a later version of WGSL with the same major version number.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -28,7 +28,7 @@ Editor: Mehmet Oguz Derin, mehmetoguzderin@mehmetoguzderin.com, w3cid 101130
 Editor: David Neto, Google https://www.google.com, dneto@google.com, w3cid 99785
 Former Editor: Myles C. Maxfield, Apple Inc., mmaxfield@apple.com, w3cid 77180
 Former Editor: dan sinclair, Google https://www.google.com, dsinclair@google.com, w3cid 107549
-Abstract: Shading language for WebGPU.
+Abstract: WebGPU Shading Language (WGSL) is the shading language for [[!WebGPU]].
 Markup Shorthands: markdown yes
 Markup Shorthands: biblio yes
 Markup Shorthands: idl yes
@@ -252,7 +252,7 @@ spec: WebGPU; urlPrefix: https://gpuweb.github.io/gpuweb/#
 
 # Introduction # {#intro}
 
-WebGPU Shading Language (WGSL) is the shader language for [[!WebGPU]].
+WebGPU Shading Language (WGSL) is the shading language for [[!WebGPU]].
 That is, an application using the WebGPU API uses WGSL to express the programs, known as shaders,
 that run on the GPU.
 
@@ -9277,9 +9277,26 @@ where compatibility is defined by the following table.
 See the [$validating GPUProgrammableStage|WebGPU API$]
 specification for interface validation requirements.
 
-# Language Extensions # {#language-extensions}
+# Language Evolution # {#language-evolution}
 
 The WGSL language is expected to evolve over time.
+
+## Language Versions ## {#language-verions}
+
+The WGSL language has a <dfn noexport>version</dfn>, with two non-negative integer components:
+a <dfn noexport>major version number</dfn> and a <dfn noexport>minor version number</dfn>.
+Version numbers are often written with the major number first, then a period ('`.`' `U+002E`), then the minor number.
+
+Versions are ordered lexicographically, i.e. *Version(major1, minor1)* is earlier than *Version(major2, minor2)* when:
+    * *major1* &lt; *major2*, or
+    * (*major1* &equals; *major2*) and (*minor1* < *minor2*)
+
+A valid program for an earlier version of WGSL, with major number at least 1,
+is valid and has the same meaning in a later version of WGSL with the same major version number.
+
+This version of WGSL has major version 0, and minor version 0, or alternately, version `0.0`.
+
+## Language Extensions ## {#language-extensions}
 
 An <dfn noexport>extension</dfn> is a named grouping for a coherent
 set of modifications to a particular version of the WGSL specification, consisting of any combination of:
@@ -11574,6 +11591,31 @@ See [[#function-calls]].
     <td>[=Component-wise=] selection. Result component `i` is evaluated
         as `select(f[i], t[i], cond[i])`.
 </table>
+
+### `wgsl_version_at_least` ### {#wgsl-version-at-least-builtin}
+<table class='data builtin'>
+  <tr algorithm="wgsl_version_at_least">
+    <td style="width:10%">Overload
+    <td class="nowrap"><xmp highlight=rust>
+@const fn wgsl_version_at_least(major: T,
+                                minor: T) -> bool
+</xmp>
+  <tr>
+    <td style="width:10%">Parameterization
+    <td>`T` is AbstractInt, i32, or u32
+  <tr>
+    <td>Description
+    <td>Where *WGSLMajor* is the WGSL [=major version number=], and *WGSLMinor* is the [=minor version number=],
+        returns:
+
+        ((`major` &lt; *WGSLMajor*) | ((`major` == *WSGSLMajor*) & (`minor` &le; *WGSLMinor*)))
+</table>
+
+<div class='example wgsl global-scope' heading="Ensure a shader only runs on an implementation with WGSL version 1.0">
+  <xmp highlight='rust'>
+    const_assert wgsl_version_at_least(1,0);
+  </xmp>
+</div>
 
 ## Array Built-in Functions ## {#array-builtin-functions}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -9294,6 +9294,11 @@ Versions are ordered lexicographically, i.e. *Version(major1, minor1)* is earlie
 A valid program for an earlier version of WGSL, with major number at least 1,
 is valid and has the same meaning in a later version of WGSL with the same major version number.
 
+When an implementation says it supports a particular version of WGSL,
+then it supports *all* the features in that version.
+The implementation can support additional features, including features included in a *later* version of WGSL.
+See [[#wgsl-version-at-least-builtin]].
+
 This version of WGSL has major version 0, and minor version 0, or alternately, version `0.0`.
 
 ## Language Extensions ## {#language-extensions}

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -11605,13 +11605,15 @@ See [[#function-calls]].
     <td>`T` is AbstractInt, i32, or u32
   <tr>
     <td>Description
-    <td>Where *WGSLMajor* is the WGSL [=major version number=], and *WGSLMinor* is the [=minor version number=],
+    <td>Returns true if the implementation's WGSL [=version=] is greater than or equal to the version specified in the parameters.
+
+        Where *WGSLMajor* is the WGSL [=major version number=], and *WGSLMinor* is the [=minor version number=],
         returns:
 
         ((`major` &lt; *WGSLMajor*) | ((`major` == *WSGSLMajor*) & (`minor` &le; *WGSLMinor*)))
 </table>
 
-<div class='example wgsl global-scope' heading="Ensure a shader only runs on an implementation with WGSL version 1.0">
+<div class='example wgsl global-scope' heading="Ensure a shader only runs on an implementation supporting version 1.0 or later">
   <xmp highlight='rust'>
     const_assert wgsl_version_at_least(1,0);
   </xmp>


### PR DESCRIPTION
Define notion of language version with major and minor numbers.

State a backward compatility rule within the same version of WGSL.

This is WGSL version 0.0

Contributes to #3149