### PR TITLE
Support STORAGE usage on bgra8unorm as an extension

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2729,7 +2729,8 @@ enum GPUFeatureName {
     "timestamp-query",
     "indirect-first-instance",
     "shader-f16",
-    "rg11b10ufloat-renderable"
+    "rg11b10ufloat-renderable",
+    "bgra8unorm-storage"
 };
 </script>
 
@@ -14586,6 +14587,12 @@ and also allows textures of that format to be multisampled.
 
 This feature adds no [=optional API surfaces=].
 
+## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>"bgra8unorm-storage"</dfn> ## {#bgra8unorm-storage}
+
+Allows the {{GPUTextureUsage/STORAGE_BINDING}} usage on textures with format {{GPUTextureFormat/"bgra8unorm"}}.
+
+This feature adds no [=optional API surfaces=].
+
 # Appendices # {#appendices}
 
 ## Texture Format Capabilities ## {#texture-format-caps}
@@ -14750,7 +14757,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
-        <td>&checkmark;
+        <td>If {{GPUFeatureName/"bgra8unorm-storage"}} is enabled
         <td>4
         <td>8
         <td>1

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3838,6 +3838,8 @@ which support the WebGPU {{GPUTextureUsage/STORAGE_BINDING}} usage.
 These texel formats are used to parameterize the storage texture types defined
 in [[#texture-storage]].
 
+Note that `bgra8unorm` can only be used when the extension `bgra8unorm_storage` is enabled.
+
 When the texel format does not have all four channels, then:
 
 * When reading the texel:
@@ -9360,6 +9362,9 @@ the implementation can issue a clear diagnostic.
   <tr><td><dfn noexport dfn-for="extension">`f16`</dfn>
       <td>`"shader-f16"`
       <td>Keyword `f16` and any [=floating point literal=] with a `h` suffix is valid if and only if this extension is enabled. Otherwise, using `f16` keyword or any [=floating point literal=] with a `h` suffix will result in a [=shader-creation error=].
+  <tr><td><dfn noexport dfn-for="extension">`bgra8unorm_storage`</dfn>
+      <td>`"bgra8unorm-storage"`
+      <td> Using `bgra8unorm` as a texel format if and only if this extension is enabled. Otherwise, it will result in a [=shader-creation error=].
 </table>
 
 # WGSL Program # {#wgsl-program}
@@ -11283,6 +11288,8 @@ The [=extension=] names are:
   <dfn for=syntax>extension_name</dfn> :
 
     | `'f16'`
+
+    | `'bgra8unorm_storage'`
 </div>
 
 The [=swizzle=] names are used in [[#vector-access-expr|vector access expressions]]:

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3838,8 +3838,6 @@ which support the WebGPU {{GPUTextureUsage/STORAGE_BINDING}} usage.
 These texel formats are used to parameterize the storage texture types defined
 in [[#texture-storage]].
 
-Note that `bgra8unorm` can only be used when the extension `bgra8unorm_storage` is enabled.
-
 When the texel format does not have all four channels, then:
 
 * When reading the texel:
@@ -9362,9 +9360,6 @@ the implementation can issue a clear diagnostic.
   <tr><td><dfn noexport dfn-for="extension">`f16`</dfn>
       <td>`"shader-f16"`
       <td>Keyword `f16` and any [=floating point literal=] with a `h` suffix is valid if and only if this extension is enabled. Otherwise, using `f16` keyword or any [=floating point literal=] with a `h` suffix will result in a [=shader-creation error=].
-  <tr><td><dfn noexport dfn-for="extension">`bgra8unorm_storage`</dfn>
-      <td>`"bgra8unorm-storage"`
-      <td> Using `bgra8unorm` as a texel format if and only if this extension is enabled. Otherwise, it will result in a [=shader-creation error=].
 </table>
 
 # WGSL Program # {#wgsl-program}
@@ -11288,8 +11283,6 @@ The [=extension=] names are:
   <dfn for=syntax>extension_name</dfn> :
 
     | `'f16'`
-
-    | `'bgra8unorm_storage'`
 </div>
 
 The [=swizzle=] names are used in [[#vector-access-expr|vector access expressions]]:


### PR DESCRIPTION
This patch intends to only support STORAGE usage on bgra8unorm behind the WebGPU extension `bgra8unorm_storage` because there are still a wide range of Vulkan devices that don't support BGRA8Unorm with STORAGE usage.

Fixed: #3799