### PR TITLE
Fix outdated `maxTextureArrayLayers` description

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -3857,7 +3857,7 @@ The <dfn dfn>logical miplevel-specific texture extent</dfn> of a [=texture=] is 
             ::
                 - Set |extent|.{{GPUExtent3DDict/width}} to max(1, |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=] &Gt; |mipLevel|).
                 - Set |extent|.{{GPUExtent3DDict/height}} to 1.
-                - Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=].
+                - Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to 1.
 
             : {{GPUTextureDimension/"2d"}}
             ::
@@ -3897,7 +3897,7 @@ to form complete [=texel blocks=] in the [=texture=]. It is calculated by this p
             ::
                 - Set |extent|.{{GPUExtent3DDict/width}} to |logicalExtent|.[=Extent3D/width=] rounded up to the nearest multiple of |descriptor|'s [=texel block width=].
                 - Set |extent|.{{GPUExtent3DDict/height}} to 1.
-                - Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to |logicalExtent|.[=Extent3D/depthOrArrayLayers=].
+                - Set |extent|.{{GPUExtent3DDict/depthOrArrayLayers}} to 1.
 
             : {{GPUTextureDimension/"2d"}}
             ::

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1537,7 +1537,7 @@ applications should generally request the "worst" limits that work for their con
         <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>256
     <tr class=row-continuation><td colspan=4>
         The maximum allowed value for the {{GPUTextureDescriptor/size}}.[=Extent3D/depthOrArrayLayers=]
-        of a [=texture=] created with {{GPUTextureDescriptor/dimension}} {{GPUTextureDimension/"1d"}} or {{GPUTextureDimension/"2d"}}.
+        of a [=texture=] created with {{GPUTextureDescriptor/dimension}} {{GPUTextureDimension/"2d"}}.
 
     <tr><td><dfn>maxBindGroups</dfn>
         <td>{{GPUSize32}} <td>[=limit class/maximum=] <td>4


### PR DESCRIPTION
We no longer have 1d array textures.