### PR TITLE
Rename `getBindGroupLayout()` to `createBindGroupLayout()`

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -876,7 +876,7 @@ interface mixin GPUObjectBase {
             The {{GPUObjectBase/label}} is a property of the {{GPUObjectBase}}.
             Two {{GPUObjectBase}} "wrapper" objects have completely separate label states,
             even if they refer to the same underlying object
-            (for example returned by {{GPUPipelineBase/getBindGroupLayout()}}).
+            (for example returned by {{GPUPipelineBase/createBindGroupLayout()}}).
             The {{GPUObjectBase/label}} property will not change except by being set from JavaScript.
 
             This means one underlying object could be associated with multiple labels.
@@ -6774,7 +6774,7 @@ dictionary GPUPipelineDescriptorBase : GPUObjectDescriptorBase {
 };
 
 interface mixin GPUPipelineBase {
-    [NewObject] GPUBindGroupLayout getBindGroupLayout(unsigned long index);
+    [NewObject] GPUBindGroupLayout createBindGroupLayout(unsigned long index);
 };
 </script>
 
@@ -6789,18 +6789,18 @@ interface mixin GPUPipelineBase {
 {{GPUPipelineBase}} has the following methods:
 
 <dl dfn-type=method dfn-for=GPUPipelineBase>
-    : <dfn>getBindGroupLayout(index)</dfn>
+    : <dfn>createBindGroupLayout(index)</dfn>
     ::
-        Gets a {{GPUBindGroupLayout}} that is compatible with the {{GPUPipelineBase}}'s
+        Creates a {{GPUBindGroupLayout}} that is compatible with the {{GPUPipelineBase}}'s
         {{GPUBindGroupLayout}} at `index`.
 
-        <div algorithm=GPUPipelineBase.getBindGroupLayout>
+        <div algorithm=GPUPipelineBase.createBindGroupLayout>
             <div data-timeline=content>
                 **Called on:** {{GPUPipelineBase}} |this|
 
                 **Arguments:**
 
-                <pre class=argumentdef for="GPUPipelineBase/getBindGroupLayout(index)">
+                <pre class=argumentdef for="GPUPipelineBase/createBindGroupLayout(index)">
                     |index|: Index into the pipeline layout's {{GPUPipelineLayout/[[bindGroupLayouts]]}}
                         sequence.
                 </pre>


### PR DESCRIPTION
Every time it's called, it returns a new object. This is observable from Javascript like so:

```
let bgl = pipeline.createBindGroupLayout();
bgl.foo = "bar";
let bgl2 = pipeline.createBindGroupLayout();
assert(bgl2.foo == undefined);
```

Because it returns a new object each time, naming it "create" makes it more clear.