### PR TITLE
Rename `compilationInfo()` to `createCompilationInfo()`

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -986,7 +986,7 @@ Several operations in WebGPU return promises.
 - {{GPUDevice}}.{{GPUDevice/createComputePipelineAsync()}}
 - {{GPUDevice}}.{{GPUDevice/createRenderPipelineAsync()}}
 - {{GPUBuffer}}.{{GPUBuffer/mapAsync()}}
-- {{GPUShaderModule}}.{{GPUShaderModule/compilationInfo()}}
+- {{GPUShaderModule}}.{{GPUShaderModule/createCompilationInfo()}}
 - {{GPUQueue}}.{{GPUQueue/onSubmittedWorkDone()}}
 - {{GPUDevice}}.{{GPUDevice/lost}}
 - {{GPUDevice}}.{{GPUDevice/popErrorScope()}}
@@ -6289,7 +6289,7 @@ if their internal {{GPUPipelineLayout/[[bindGroupLayouts]]}} sequences contain
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUShaderModule {
-    Promise<GPUCompilationInfo> compilationInfo();
+    Promise<GPUCompilationInfo> createCompilationInfo();
 };
 GPUShaderModule includes GPUObjectBase;
 </script>
@@ -6385,7 +6385,7 @@ dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
                     Note:
                     User agents **should not** include detailed compiler error messages or shader text in
                     the {{GPUError/message}} text of validation errors arising here:
-                    these details are accessible via {{GPUShaderModule/compilationInfo()}}.
+                    these details are accessible via {{GPUShaderModule/createCompilationInfo()}}.
                     User agents **should** surface human-readable, formatted error details *to
                     developers* for easier debugging (for example as a warning in the browser developer
                     console, expandable to show full shader source).
@@ -6570,14 +6570,14 @@ Note: {{GPUCompilationMessage}}.{{GPUCompilationMessage/offset}} and
 {{GPUCompilationMessage/message}} corresponds to.
 
 <dl dfn-type=method dfn-for=GPUShaderModule>
-    : <dfn>compilationInfo()</dfn>
+    : <dfn>createCompilationInfo()</dfn>
     ::
         Returns any messages generated during the {{GPUShaderModule}}'s compilation.
 
         The locations, order, and contents of messages are implementation-defined.
         In particular, messages may not be ordered by {{GPUCompilationMessage/lineNum}}.
 
-        <div algorithm=GPUShaderModule.compilationInfo>
+        <div algorithm=GPUShaderModule.createCompilationInfo>
             <div data-timeline=content>
                 **Called on:** {{GPUShaderModule}} this
 


### PR DESCRIPTION
Every time it's called, it returns a new object. This is observable from Javascript like so:

```
let ci = await shaderModule.createCompilationInfo();
ci.foo = "bar";
let ci2 = await shaderModule.createCompilationInfo();
assert(ci2.foo == undefined);
```

Because it returns a new object each time, naming it "create" makes it more clear.