### PR TITLE
Make regex single-line comment

### DIFF
--- a/wgsl/extract-grammar.py
+++ b/wgsl/extract-grammar.py
@@ -433,7 +433,7 @@ def grammar_from_rule(key, value):
     return result
 
 
-scanner_components[scanner_rule.name()]["_comment"] = [["`'//.*'`"]]
+scanner_components[scanner_rule.name()]["_comment"] = [["`/\\/\\/.*/`"]]
 
 # Following sections are to allow out-of-order per syntactic grammar appearance of rules
 


### PR DESCRIPTION
While writing some examples, some errors made me realize recent change translates as direct token instead of regular expression (only matches literally `//.*` as comment rather than anything in a line preceded by `//`).

TYVM!