### PR TITLE
Prevent matrix padding from being modified

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2538,7 +2538,7 @@ describe the contents of memory.
 Memory consists of a set of distinct <dfn noexport>memory locations</dfn>.
 Each memory location is 8-bits in size.
 An operation affecting memory interacts with a set of one or more memory locations.
-Memory operations on structures and arrays [=behavioral requirement|will=] not
+Memory operations on [=composites=] [=behavioral requirement|will=] not
 access padding memory locations.
 
 Two sets of memory locations <dfn noexport>overlap</dfn> if the intersection of


### PR DESCRIPTION
Fixes #3753

* Prevent padding modification on composites instead of just arrays and structures