### PR TITLE
Improve validation language around timestampWrites

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6182,7 +6182,7 @@ pipeline, and have the following members:
 <dl dfn-type=dict-member dfn-for=GPUPipelineLayoutDescriptor>
     : <dfn>bindGroupLayouts</dfn>
     ::
-        A list of {{GPUBindGroupLayout}}s the pipline will use. Each element corresponds to a
+        A list of {{GPUBindGroupLayout}}s the pipeline will use. Each element corresponds to a
         [=@group=] attribute in the {{GPUShaderModule}}, with the `N`th element corresponding with
         `@group(N)`.
 </dl>
@@ -9182,11 +9182,8 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                 1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/locked=]".
                 1. If any of the following requirements are unmet, make |pass| [=invalid=] and return.
                     <div class=validusage>
-                        - |descriptor| must meet the [$GPURenderPassDescriptor/Valid Usage$] rules.
-                        - If |descriptor|.{{GPURenderPassDescriptor/timestampWrites}} is not [=list/is empty|empty=]:
-                            - {{GPUFeatureName/"timestamp-query"}} must be [=enabled for=] |this|.
-                        - For each |timestampWrite| in |descriptor|.{{GPURenderPassDescriptor/timestampWrites}}:
-                            - |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}} must be [$valid to use with$] |this|.
+                        - |descriptor| must meet the [$GPURenderPassDescriptor/Valid Usage$] rules
+                            given device |this|.{{GPUObjectBase/[[device]]}}.
                     </div>
                 1. For each non-`null` |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
                     1. The [=texture subresource=] seen by |colorAttachment|.{{GPURenderPassColorAttachment/view}}
@@ -9258,10 +9255,9 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
                 1. Set |this|.{{GPUCommandsMixin/[[state]]}} to "[=encoder state/locked=]".
                 1. If any of the following requirements are unmet, make |pass| [=invalid=] and return.
                     <div class=validusage>
-                        - If |descriptor|.{{GPURenderPassDescriptor/timestampWrites}} is not [=list/is empty|empty=]:
-                            - {{GPUFeatureName/"timestamp-query"}} must be [=enabled for=] |this|.
-                        - For each |timestampWrite| in |descriptor|.{{GPUComputePassDescriptor/timestampWrites}}:
-                            - |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}} must be [$valid to use with$] |this|.
+                        - [$Validate timestampWrites$](|this|.{{GPUObjectBase/[[device]]}},
+                            |descriptor|.{{GPUComputePassDescriptor/timestampWrites}})
+                            must return true.
                     </div>
                 1. For each |timestampWrite| in |descriptor|.{{GPUComputePassDescriptor/timestampWrites}},
                     1. If |timestampWrite|.{{GPUComputePassTimestampWrite/location}} is {{GPUComputePassTimestampLocation/"beginning"}},
@@ -10182,20 +10178,6 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
         A sequence of {{GPUComputePassTimestampWrite}} values define where and when timestamp values will be written for this pass.
 </dl>
 
-<div class=validusage dfn-for=GPUComputePassDescriptor>
-    <dfn abstract-op>Valid Usage</dfn>
-
-    Given a {{GPUComputePassDescriptor}} |this| the following validation rules apply:
-
-    1. No two entries in |this|.{{GPUComputePassDescriptor/timestampWrites}} have the same {{GPUComputePassTimestampWrite/location}}.
-
-    1. For each |timestampWrite| in |this|.{{GPUComputePassDescriptor/timestampWrites}}:
-
-        1. |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}}.{{GPUQuerySet/type}} is {{GPUQueryType/"timestamp"}}.
-
-        1. |timestampWrite|.{{GPUComputePassTimestampWrite/queryIndex}} &lt; |timestampWrite|.{{GPUComputePassTimestampWrite/querySet}}.{{GPUQuerySet/count}}.
-</div>
-
 ### Dispatch ### {#compute-pass-encoder-dispatch}
 
 <dl dfn-type=method dfn-for=GPUComputePassEncoder>
@@ -10575,7 +10557,7 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
         is a good default, unless it is known that more draw calls will be done.
 </dl>
 
-<div class=validusage dfn-for=GPURenderPassDescriptor data-timeline=device>
+<div algorithm class=validusage dfn-for=GPURenderPassDescriptor data-timeline=device>
     <dfn abstract-op>Valid Usage</dfn>
 
     Given a {{GPUDevice}} |device| and {{GPURenderPassDescriptor}} |this|, the following validation rules apply:
@@ -10610,17 +10592,8 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
         1. |this|.{{GPURenderPassDescriptor/occlusionQuerySet}}.{{GPUQuerySet/type}}
             must be {{GPUQueryType/occlusion}}.
 
-    1. No two entries in |this|.{{GPURenderPassDescriptor/timestampWrites}} have the same {{GPURenderPassTimestampWrite/location}}.
-
-    1. For each |timestampWrite| in |this|.{{GPURenderPassDescriptor/timestampWrites}}:
-
-        1. |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}}.{{GPUQuerySet/type}} is {{GPUQueryType/"timestamp"}}.
-
-        1. |timestampWrite|.{{GPURenderPassTimestampWrite/queryIndex}} &lt; |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}}.{{GPUQuerySet/count}}.
-
-        1. |timestampWrite|.{{GPURenderPassTimestampWrite/queryIndex}} is written at most once in the same |timestampWrite|.{{GPURenderPassTimestampWrite/querySet}} in this render pass.
-
-    Issue(gpuweb/gpuweb#503): support for no attachments
+    1. [$Validate timestampWrites$](|device|, |this|.{{GPURenderPassDescriptor/timestampWrites}})
+        must return true.
 </div>
 
 <div algorithm>
@@ -12605,6 +12578,22 @@ Note: The timestamp values may be zero if the physical device reset timestamp co
 Issue: Write normative text about timestamp value resets.
 
 Issue: Because timestamp query provides high-resolution GPU timestamp, we need to decide what constraints, if any, are on its availability.
+
+<div algorithm class=validusage>
+    <dfn abstract-op>Validate timestampWrites</dfn>({{GPUDevice}} |device|,
+    <code>({{GPUComputePassTimestampWrites}} or {{GPURenderPassTimestampWrites}})</code> |timestampWrites|)
+
+    Return `true` if the following requirements are met, and `false` if not.
+
+    - If |timestampWrites| is not [=list/is empty|empty=],
+        {{GPUFeatureName/"timestamp-query"}} must be [=enabled for=] |device|.
+    - No two entries in |timestampWrites| may have the same `location`.
+    - No two entries in |timestampWrites| may have the same `querySet` and `queryIndex` pair.
+    - For each |timestampWrite| in |timestampWrites|:
+        - |timestampWrite|.`querySet` must be [$valid to use with$] |device|.
+        - |timestampWrite|.`querySet`.{{GPUQuerySet/type}} is {{GPUQueryType/"timestamp"}}.
+        - |timestampWrite|.`queryIndex` &lt; |timestampWrite|.`querySet`.{{GPUQuerySet/count}}.
+</div>
 
 # Canvas Rendering # {#canvas-rendering}
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -10594,6 +10594,9 @@ dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
 
     1. [$Validate timestampWrites$](|device|, |this|.{{GPURenderPassDescriptor/timestampWrites}})
         must return true.
+
+    1. No two entries in |this|.{{GPURenderPassDescriptor/timestampWrites}} may have the same
+        [{{GPURenderPassTimestampWrite/querySet}}, {{GPURenderPassTimestampWrite/queryIndex}}] pair.
 </div>
 
 <div algorithm>
@@ -12588,7 +12591,6 @@ Issue: Because timestamp query provides high-resolution GPU timestamp, we need t
     - If |timestampWrites| is not [=list/is empty|empty=],
         {{GPUFeatureName/"timestamp-query"}} must be [=enabled for=] |device|.
     - No two entries in |timestampWrites| may have the same `location`.
-    - No two entries in |timestampWrites| may have the same `querySet` and `queryIndex` pair.
     - For each |timestampWrite| in |timestampWrites|:
         - |timestampWrite|.`querySet` must be [$valid to use with$] |device|.
         - |timestampWrite|.`querySet`.{{GPUQuerySet/type}} is {{GPUQueryType/"timestamp"}}.


### PR DESCRIPTION
- Deduplicates effectively identical between compute and render pass descriptor validation
- Actually links to this validation from beginComputePass, instead of not
- Consolidate validation that was unnecessarily split between begin*Pass and the descriptors' valid usage blocks
- Removes an unnecessary `Issue`
- Fixes an unrelated typo

(Note, this is not related to #3808.)