### PR TITLE
Merge dfns in headings with the headings themselves

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1759,7 +1759,9 @@ applications should generally request the "worst" limits that work for their con
         {{GPUComputePassEncoder/dispatchWorkgroups(workgroupCountX, workgroupCountY, workgroupCountZ)}}.
 </table>
 
-<h5 id=gpusupportedlimits data-dfn-type=interface>`GPUSupportedLimits`</h5>
+<h5 id=gpusupportedlimits data-dfn-type=interface>`GPUSupportedLimits`
+<span id=gpu-supportedlimits></span>
+</h5>
 
 {{GPUSupportedLimits}} exposes the [=limits=] supported by an adapter or device.
 See {{GPUAdapter/limits|GPUAdapter.limits}} and {{GPUDevice/limits|GPUDevice.limits}}.
@@ -1803,7 +1805,9 @@ interface GPUSupportedLimits {
 };
 </script>
 
-<h5 id=gpusupportedfeatures data-dfn-type=interface>`GPUSupportedFeatures`</h5>
+<h5 id=gpusupportedfeatures data-dfn-type=interface>`GPUSupportedFeatures`
+<span id=gpu-supportedfeatures></span>
+</h5>
 
 {{GPUSupportedFeatures}} is a [=setlike=] interface. Its [=set entries=] are
 the {{GPUFeatureName}} values of the [=features=] supported by an adapter or
@@ -1836,7 +1840,9 @@ interface GPUSupportedFeatures {
     </div>
 </div>
 
-<h5 id=gpuadapterinfo data-dfn-type=interface>`GPUAdapterInfo`</h5>
+<h5 id=gpuadapterinfo data-dfn-type=interface>`GPUAdapterInfo`
+<span id=gpu-adapterinfo></span>
+</h5>
 
 {{GPUAdapterInfo}} exposes various identifying information about an adapter.
 
@@ -2453,7 +2459,9 @@ enum GPUPowerPreference {
     </pre>
 </div>
 
-<h3 id=gpuadapter data-dfn-type=interface>`GPUAdapter`</h3>
+<h3 id=gpuadapter data-dfn-type=interface>`GPUAdapter`
+<span id=gpu-adapter></span>
+</h3>
 
 A {{GPUAdapter}} encapsulates an [=adapter=],
 and describes its capabilities ([=features=] and [=limits=]).
@@ -2655,7 +2663,9 @@ interface GPUAdapter {
     </pre>
 </div>
 
-<h4 id=gpudevicedescriptor data-dfn-type=dictionary>`GPUDeviceDescriptor`</h4>
+<h4 id=gpudevicedescriptor data-dfn-type=dictionary>`GPUDeviceDescriptor`
+<span id=dictdef-gpudevicedescriptor></span>
+</h4>
 
 {{GPUDeviceDescriptor}} describes a device request.
 
@@ -2714,7 +2724,9 @@ dictionary GPUDeviceDescriptor : GPUObjectDescriptorBase {
     </pre>
 </div>
 
-<h5 id=gpufeaturename data-dfn-type=enum>`GPUFeatureName`</h5>
+<h5 id=gpufeaturename data-dfn-type=enum>`GPUFeatureName`
+<span id=enumdef-gpufeaturename></span>
+</h5>
 
 Each {{GPUFeatureName}} identifies a set of functionality which, if available,
 allows additional usages of WebGPU that would have otherwise been invalid.
@@ -2733,7 +2745,9 @@ enum GPUFeatureName {
 };
 </script>
 
-<h3 id=gpudevice data-dfn-type=interface>`GPUDevice`</h3>
+<h3 id=gpudevice data-dfn-type=interface>`GPUDevice`
+<span id=gpu-device></span>
+</h3>
 
 A {{GPUDevice}} encapsulates a [=device=] and exposes
 the functionality of that device.
@@ -2938,7 +2952,9 @@ Those not defined here are defined elsewhere in this document.
 
 # Buffers # {#buffers}
 
-<h3 id=gpubuffer data-dfn-type=interface>`GPUBuffer`</h3>
+<h3 id=gpubuffer data-dfn-type=interface>`GPUBuffer`
+<span id=buffer-interface></span>
+</h3>
 
 A {{GPUBuffer}} represents a block of memory that can be used in GPU operations.
 Data is stored in linear layout, meaning that each byte of the allocation can be
@@ -3711,7 +3727,9 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
 
 # Textures and Texture Views # {#textures}
 
-<h3 id=gputexture data-dfn-type=interface>`GPUTexture`</h3>
+<h3 id=gputexture data-dfn-type=interface>`GPUTexture`
+<span id=texture-interface></span>
+</h3>
 
 Issue: Remove this definition: <dfn dfn>texture</dfn>
 
@@ -4239,7 +4257,9 @@ all previously submitted operations using it are complete.
         </div>
 </dl>
 
-<h3 id=gputextureview data-dfn-type=interface>`GPUTextureView`</h3>
+<h3 id=gputextureview data-dfn-type=interface>`GPUTextureView`
+<span id=gpu-textureview></span>
+</h3>
 
 A {{GPUTextureView}} is a view onto some subset of the [=texture subresources=] defined by
 a particular {{GPUTexture}}.
@@ -4864,7 +4884,9 @@ See [[#texture-format-caps]] for information about which {{GPUTextureFormat}}s r
         1. Throw a {{TypeError}}.
 </div>
 
-<h3 id=gpuexternaltexture data-dfn-type=interface>`GPUExternalTexture`</h3>
+<h3 id=gpuexternaltexture data-dfn-type=interface>`GPUExternalTexture`
+<span id=gpu-external-texture></span>
+</h3>
 
 A {{GPUExternalTexture}} is a sampleable 2D texture wrapping an external video object.
 The contents of a {{GPUExternalTexture}} object are a snapshot and may not change, either from inside WebGPU
@@ -5090,7 +5112,9 @@ underlying texture separately, prior to conversion from YUV to the specified col
 
 # Samplers # {#samplers}
 
-<h3 id=gpusampler data-dfn-type=interface>`GPUSampler`</h3>
+<h3 id=gpusampler data-dfn-type=interface>`GPUSampler`
+<span id=sampler-interface></span>
+</h3>
 
 A {{GPUSampler}} encodes transformations and filtering information that can
 be used in a shader to interpret texture resource data.
@@ -5368,7 +5392,9 @@ enum GPUCompareFunction {
 
 # Resource Binding # {#bindings}
 
-<h3 id=gpubindgrouplayout data-dfn-type=interface>`GPUBindGroupLayout`</h3>
+<h3 id=gpubindgrouplayout data-dfn-type=interface>`GPUBindGroupLayout`
+<span id=bind-group-layout></span>
+</h3>
 
 A {{GPUBindGroupLayout}} defines the interface between a set of resources bound in a {{GPUBindGroup}} and their accessibility in shader stages.
 
@@ -5851,7 +5877,9 @@ if and only if all of the following conditions are satisfied:
 
 If bind groups layouts are [=group-equivalent=] they can be interchangeably used in all contents.
 
-<h3 id=gpubindgroup data-dfn-type=interface>`GPUBindGroup`</h3>
+<h3 id=gpubindgroup data-dfn-type=interface>`GPUBindGroup`
+<span id=gpu-bind-group></span>
+</h3>
 
 A {{GPUBindGroup}} defines a set of resources to be bound together in a group
     and how the resources are used in shader stages.
@@ -6120,7 +6148,9 @@ following members:
     Issue: Define how a range is formed by offset/size when size can be undefined.
 </div>
 
-<h3 id=gpupipelinelayout data-dfn-type=interface>`GPUPipelineLayout`</h3>
+<h3 id=gpupipelinelayout data-dfn-type=interface>`GPUPipelineLayout`
+<span id=pipeline-layout></span>
+</h3>
 
 A {{GPUPipelineLayout}} defines the mapping between resources of all {{GPUBindGroup}} objects set up during command encoding in [=GPUBindingCommandsMixin/setBindGroup()=], and the shaders of the pipeline set by {{GPURenderCommandsMixin/setPipeline(pipeline)|GPURenderCommandsMixin.setPipeline}} or {{GPUComputePassEncoder/setPipeline(pipeline)|GPUComputePassEncoder.setPipeline}}.
 
@@ -6284,7 +6314,9 @@ if their internal {{GPUPipelineLayout/[[bindGroupLayouts]]}} sequences contain
 
 # Shader Modules # {#shader-modules}
 
-<h3 id=gpushadermodule data-dfn-type=interface>`GPUShaderModule`</h3>
+<h3 id=gpushadermodule data-dfn-type=interface>`GPUShaderModule`
+<span id=shader-module></span>
+</h3>
 
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
@@ -6978,7 +7010,9 @@ run the following steps:
     1. Return |device|.{{GPUDevice/createPipelineLayout()}}(|desc|).
 </div>
 
-<h4 id=gpuprogrammablestage data-dfn-type=dictionary>`GPUProgrammableStage`</h4>
+<h4 id=gpuprogrammablestage data-dfn-type=dictionary>`GPUProgrammableStage`
+<span id=GPUProgrammableStage></span>
+</h4>
 
 A {{GPUProgrammableStage}} describes the entry point in the user-provided
 {{GPUShaderModule}} that controls one of the programmable stages of a [=pipeline=].
@@ -7276,7 +7310,9 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
     {{GPUProgrammableStage/entryPoint}}, in the specified shader {{GPUProgrammableStage/module}}.
 </div>
 
-<h3 id=gpucomputepipeline data-dfn-type=interface>`GPUComputePipeline`</h3>
+<h3 id=gpucomputepipeline data-dfn-type=interface>`GPUComputePipeline`
+<span id=compute-pipeline></span>
+</h3>
 
 A {{GPUComputePipeline}} is a kind of [=pipeline=] that controls the compute shader stage,
 and can be used in {{GPUComputePassEncoder}}.
@@ -7448,7 +7484,9 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
     </pre>
 </div>
 
-<h3 id=gpurenderpipeline data-dfn-type=interface>`GPURenderPipeline`</h3>
+<h3 id=gpurenderpipeline data-dfn-type=interface>`GPURenderPipeline`
+<span id=render-pipeline></span>
+</h3>
 
 A {{GPURenderPipeline}} is a kind of [=pipeline=] that controls the vertex
 and fragment shader stages, and can be used in {{GPURenderPassEncoder}}
@@ -8937,7 +8975,9 @@ setting state, drawing, copying resources, etc.
 A {{GPUCommandBuffer}} can only be submitted once, at which point it becomes [=invalid=].
 To reuse rendering commands across multiple submissions, use {{GPURenderBundle}}.
 
-<h3 id=gpucommandbuffer data-dfn-type=interface>`GPUCommandBuffer`</h3>
+<h3 id=gpucommandbuffer data-dfn-type=interface>`GPUCommandBuffer`
+<span id=command-buffer></span>
+</h3>
 
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
@@ -8969,7 +9009,9 @@ dictionary GPUCommandBufferDescriptor : GPUObjectDescriptorBase {
 
 # Command Encoding # {#command-encoding}
 
-<h3 id=gpucommandsmixin data-dfn-type=interface>`GPUCommandsMixin`</h3>
+<h3 id=gpucommandsmixin data-dfn-type=interface>`GPUCommandsMixin`
+<span id=commans-mixin></span>
+</h3>
 
 {{GPUCommandsMixin}} defines state common to all interfaces which encode commands.
 It has no methods.
@@ -9040,7 +9082,9 @@ The <dfn dfn>encoder state</dfn> may be one of the following:
             1. Issue the steps of |command|.
 </div>
 
-<h3 id=gpucommandencoder data-dfn-type=interface>`GPUCommandEncoder`</h3>
+<h3 id=gpucommandencoder data-dfn-type=interface>`GPUCommandEncoder`
+<span id=command-encoder></span>
+</h3>
 
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
@@ -10122,7 +10166,9 @@ It must only be included by interfaces which also include those mixins.
 
 # Compute Passes # {#compute-passes}
 
-<h3 id=gpucomputepassencoder data-dfn-type=interface>`GPUComputePassEncoder`</h3>
+<h3 id=gpucomputepassencoder data-dfn-type=interface>`GPUComputePassEncoder`
+<span id=compute-pass-encoder></span>
+</h3>
 
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
@@ -10430,7 +10476,9 @@ called the compute pass encoder can no longer be used.
 
 # Render Passes # {#render-passes}
 
-<h3 id=gpurenderpassencoder data-dfn-type=interface>`GPURenderPassEncoder`</h3>
+<h3 id=gpurenderpassencoder data-dfn-type=interface>`GPURenderPassEncoder`
+<span id=render-pass-encoder></span>
+</h3>
 
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
@@ -11029,7 +11077,9 @@ called the render pass encoder can no longer be used.
         </div>
 </dl>
 
-<h3 id=gpurendercommandsmixin data-dfn-type=interface>`GPURenderCommandsMixin`</h3>
+<h3 id=gpurendercommandsmixin data-dfn-type=interface>`GPURenderCommandsMixin`
+<span id=render-commands></span>
+</h3>
 
 {{GPURenderCommandsMixin}} defines rendering commands common to {{GPURenderPassEncoder}}
 and {{GPURenderBundleEncoder}}.
@@ -11892,7 +11942,9 @@ attachments used by this encoder.
 
 # Bundles # {#bundles}
 
-<h3 id=gpurenderbundle data-dfn-type=interface>`GPURenderBundle`</h3>
+<h3 id=gpurenderbundle data-dfn-type=interface>`GPURenderBundle`
+<span id=render-bundle></span>
+</h3>
 
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
@@ -12064,7 +12116,9 @@ dictionary GPURenderBundleEncoderDescriptor : GPURenderPassLayout {
 
 # Queues # {#queues}
 
-<h3 id=gpuqueuedescriptor data-dfn-type=dictionary>`GPUQueueDescriptor`</h3>
+<h3 id=gpuqueuedescriptor data-dfn-type=dictionary>`GPUQueueDescriptor`
+<span id=dictdef-gpuqueuedescriptor></span>
+</h3>
 
 {{GPUQueueDescriptor}} describes a queue request.
 
@@ -12073,7 +12127,9 @@ dictionary GPUQueueDescriptor : GPUObjectDescriptorBase {
 };
 </script>
 
-<h3 id=gpuqueue data-dfn-type=interface>`GPUQueue`</h3>
+<h3 id=gpuqueue data-dfn-type=interface>`GPUQueue`
+<span id=gpu-queue></span>
+</h3>
 
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
@@ -12423,7 +12479,9 @@ GPUQueue includes GPUObjectBase;
 
 # Queries # {#queries}
 
-<h3 id=gpuqueryset data-dfn-type=interface>`GPUQuerySet`</h3>
+<h3 id=gpuqueryset data-dfn-type=interface>`GPUQuerySet`
+<span id=queryset></span>
+</h3>
 
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
@@ -13097,7 +13155,9 @@ In WebGPU, it does so by [$Replace the drawing buffer|replacing the drawing buff
     </pre>
 </div>
 
-<h3 id=gpucanvasalphamode data-dfn-type=enum>`GPUCanvasAlphaMode`</h3>
+<h3 id=gpucanvasalphamode data-dfn-type=enum>`GPUCanvasAlphaMode`
+<span id=GPUCanvasAlphaMode></span>
+</h3>
 
 This enum selects how the contents of the canvas will be interpreted when read, when
 [$update the rendering of the WebGPU canvas|rendered to the screen$] or
@@ -13164,7 +13224,9 @@ partial interface GPUDevice {
         Upon initialization, it is set to [=a new promise=].
 </dl>
 
-<h3 id=gpuerror data-dfn-type=interface>`GPUError`</h3>
+<h3 id=gpuerror data-dfn-type=interface>`GPUError`
+<span id=error></span>
+</h3>
 
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
@@ -14455,7 +14517,9 @@ An <dfn dfn>Extent3D</dfn> is a {{GPUExtent3D}}.
 
 # Feature Index # {#feature-index}
 
-<h3 id=depth-clip-control data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"depth-clip-control"`</h3>
+<h3 id=depth-clip-control data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"depth-clip-control"`
+<span id=dom-gpufeaturename-depth-clip-control></span>
+</h3>
 
 Allows [=depth clipping=] to be disabled.
 
@@ -14464,7 +14528,9 @@ This feature adds the following [=optional API surfaces=]:
 - New {{GPUPrimitiveState}} dictionary members:
     - {{GPUPrimitiveState/unclippedDepth}}
 
-<h3 id=depth32float-stencil8 data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"depth32float-stencil8"`</h3>
+<h3 id=depth32float-stencil8 data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"depth32float-stencil8"`
+<span id=dom-gpufeaturename-depth32float-stencil8></span>
+</h3>
 
 Allows for explicit creation of textures of format {{GPUTextureFormat/"depth32float-stencil8"}}.
 
@@ -14473,7 +14539,9 @@ This feature adds the following [=optional API surfaces=]:
 - New {{GPUTextureFormat}} enum values:
     - {{GPUTextureFormat/"depth32float-stencil8"}}
 
-<h3 id=texture-compression-bc data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-compression-bc"`</h3>
+<h3 id=texture-compression-bc data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-compression-bc"`
+<span id=dom-gpufeaturename-texture-compression-bc></span>
+</h3>
 
 Allows for explicit creation of textures of BC compressed formats.
 
@@ -14495,7 +14563,10 @@ This feature adds the following [=optional API surfaces=]:
     - {{GPUTextureFormat/"bc7-rgba-unorm"}}
     - {{GPUTextureFormat/"bc7-rgba-unorm-srgb"}}
 
-<h3 id=texture-compression-etc2 data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-compression-etc2"`</h3>
+<h3 id=texture-compression-etc2 data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-compression-etc2"`
+<span id=texture-compression-etc></span>
+<span id=dom-gpufeaturename-texture-compression-etc2></span>
+</h3>
 
 Allows for explicit creation of textures of ETC2 compressed formats.
 
@@ -14513,7 +14584,9 @@ This feature adds the following [=optional API surfaces=]:
     - {{GPUTextureFormat/"eac-rg11unorm"}}
     - {{GPUTextureFormat/"eac-rg11snorm"}}
 
-<h3 id=texture-compression-astc data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-compression-astc"`</h3>
+<h3 id=texture-compression-astc data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-compression-astc"`
+<span id=dom-gpufeaturename-texture-compression-astc></span>
+</h3>
 
 Allows for explicit creation of textures of ASTC compressed formats.
 
@@ -14549,7 +14622,9 @@ This feature adds the following [=optional API surfaces=]:
     - {{GPUTextureFormat/"astc-12x12-unorm"}}
     - {{GPUTextureFormat/"astc-12x12-unorm-srgb"}}
 
-<h3 id=timestamp-query data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"timestamp-query"`</h3>
+<h3 id=timestamp-query data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"timestamp-query"`
+<span id=dom-gpufeaturename-timestamp-query></span>
+</h3>
 
 Adds the ability to query timestamps from GPU command buffers. See [[#timestamp]].
 
@@ -14564,13 +14639,17 @@ This feature adds the following [=optional API surfaces=]:
 - New {{GPURenderPassDescriptor}} members:
     - {{GPURenderPassDescriptor/timestampWrites}}
 
-<h3 id=indirect-first-instance data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"indirect-first-instance"`</h3>
+<h3 id=indirect-first-instance data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"indirect-first-instance"`
+<span id=dom-gpufeaturename-indirect-first-instance></span>
+</h3>
 
 Allows the use of non-zero `firstInstance` values in [=indirect draw parameters=] and [=indirect drawIndexed parameters=].
 
 This feature adds no [=optional API surfaces=].
 
-<h3 id=shader-f16 data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"shader-f16"`</h3>
+<h3 id=shader-f16 data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"shader-f16"`
+<span id=dom-gpufeaturename-shader-f16></span>
+</h3>
 
 Allows the use of the half-precision floating-point type [=f16=] in WGSL.
 
@@ -14579,7 +14658,9 @@ This feature adds the following [=optional API surfaces=]:
 - New WGSL extensions:
     - [=extension/f16=]
 
-<h3 id=rg11b10ufloat-renderable data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"rg11b10ufloat-renderable"`</h3>
+<h3 id=rg11b10ufloat-renderable data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"rg11b10ufloat-renderable"`
+<span id=dom-gpufeaturename-rg11b10ufloat-renderable></span>
+</h3>
 
 Allows the {{GPUTextureUsage/RENDER_ATTACHMENT}} usage on textures with format {{GPUTextureFormat/"rg11b10ufloat"}},
 and also allows textures of that format to be multisampled.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -14455,7 +14455,7 @@ An <dfn dfn>Extent3D</dfn> is a {{GPUExtent3D}}.
 
 # Feature Index # {#feature-index}
 
-## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>"depth-clip-control"</dfn> ## {#depth-clip-control}
+<h3 id=depth-clip-control data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"depth-clip-control"`</h3>
 
 Allows [=depth clipping=] to be disabled.
 
@@ -14464,7 +14464,7 @@ This feature adds the following [=optional API surfaces=]:
 - New {{GPUPrimitiveState}} dictionary members:
     - {{GPUPrimitiveState/unclippedDepth}}
 
-## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>"depth32float-stencil8"</dfn> ## {#depth32float-stencil8}
+<h3 id=depth32float-stencil8 data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"depth32float-stencil8"`</h3>
 
 Allows for explicit creation of textures of format {{GPUTextureFormat/"depth32float-stencil8"}}.
 
@@ -14473,7 +14473,7 @@ This feature adds the following [=optional API surfaces=]:
 - New {{GPUTextureFormat}} enum values:
     - {{GPUTextureFormat/"depth32float-stencil8"}}
 
-## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>"texture-compression-bc"</dfn> ## {#texture-compression-bc}
+<h3 id=texture-compression-bc data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-compression-bc"`</h3>
 
 Allows for explicit creation of textures of BC compressed formats.
 
@@ -14495,7 +14495,7 @@ This feature adds the following [=optional API surfaces=]:
     - {{GPUTextureFormat/"bc7-rgba-unorm"}}
     - {{GPUTextureFormat/"bc7-rgba-unorm-srgb"}}
 
-## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>"texture-compression-etc2"</dfn> ## {#texture-compression-etc}
+<h3 id=texture-compression-etc2 data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-compression-etc2"`</h3>
 
 Allows for explicit creation of textures of ETC2 compressed formats.
 
@@ -14513,7 +14513,7 @@ This feature adds the following [=optional API surfaces=]:
     - {{GPUTextureFormat/"eac-rg11unorm"}}
     - {{GPUTextureFormat/"eac-rg11snorm"}}
 
-## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>"texture-compression-astc"</dfn> ## {#texture-compression-astc}
+<h3 id=texture-compression-astc data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"texture-compression-astc"`</h3>
 
 Allows for explicit creation of textures of ASTC compressed formats.
 
@@ -14549,7 +14549,7 @@ This feature adds the following [=optional API surfaces=]:
     - {{GPUTextureFormat/"astc-12x12-unorm"}}
     - {{GPUTextureFormat/"astc-12x12-unorm-srgb"}}
 
-## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>"timestamp-query"</dfn> ## {#timestamp-query}
+<h3 id=timestamp-query data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"timestamp-query"`</h3>
 
 Adds the ability to query timestamps from GPU command buffers. See [[#timestamp]].
 
@@ -14564,13 +14564,13 @@ This feature adds the following [=optional API surfaces=]:
 - New {{GPURenderPassDescriptor}} members:
     - {{GPURenderPassDescriptor/timestampWrites}}
 
-## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>"indirect-first-instance"</dfn> ## {#indirect-first-instance}
+<h3 id=indirect-first-instance data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"indirect-first-instance"`</h3>
 
 Allows the use of non-zero `firstInstance` values in [=indirect draw parameters=] and [=indirect drawIndexed parameters=].
 
 This feature adds no [=optional API surfaces=].
 
-## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>"shader-f16"</dfn> ## {#shader-f16}
+<h3 id=shader-f16 data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"shader-f16"`</h3>
 
 Allows the use of the half-precision floating-point type [=f16=] in WGSL.
 
@@ -14579,7 +14579,7 @@ This feature adds the following [=optional API surfaces=]:
 - New WGSL extensions:
     - [=extension/f16=]
 
-## <dfn dfn-type=enum-value dfn-for=GPUFeatureName>"rg11b10ufloat-renderable"</dfn> ## {#rg11b10ufloat-renderable}
+<h3 id=rg11b10ufloat-renderable data-dfn-type=enum-value data-dfn-for=GPUFeatureName>`"rg11b10ufloat-renderable"`</h3>
 
 Allows the {{GPUTextureUsage/RENDER_ATTACHMENT}} usage on textures with format {{GPUTextureFormat/"rg11b10ufloat"}},
 and also allows textures of that format to be multisampled.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1759,7 +1759,7 @@ applications should generally request the "worst" limits that work for their con
         {{GPUComputePassEncoder/dispatchWorkgroups(workgroupCountX, workgroupCountY, workgroupCountZ)}}.
 </table>
 
-#### <dfn interface>GPUSupportedLimits</dfn> #### {#gpu-supportedlimits}
+<h5 id=gpusupportedlimits data-dfn-type=interface>`GPUSupportedLimits`</h5>
 
 {{GPUSupportedLimits}} exposes the [=limits=] supported by an adapter or device.
 See {{GPUAdapter/limits|GPUAdapter.limits}} and {{GPUDevice/limits|GPUDevice.limits}}.
@@ -1803,7 +1803,7 @@ interface GPUSupportedLimits {
 };
 </script>
 
-#### <dfn interface>GPUSupportedFeatures</dfn> #### {#gpu-supportedfeatures}
+<h5 id=gpusupportedfeatures data-dfn-type=interface>`GPUSupportedFeatures`</h5>
 
 {{GPUSupportedFeatures}} is a [=setlike=] interface. Its [=set entries=] are
 the {{GPUFeatureName}} values of the [=features=] supported by an adapter or
@@ -1836,7 +1836,7 @@ interface GPUSupportedFeatures {
     </div>
 </div>
 
-#### <dfn interface>GPUAdapterInfo</dfn> #### {#gpu-adapterinfo}
+<h5 id=gpuadapterinfo data-dfn-type=interface>`GPUAdapterInfo`</h5>
 
 {{GPUAdapterInfo}} exposes various identifying information about an adapter.
 
@@ -2453,7 +2453,7 @@ enum GPUPowerPreference {
     </pre>
 </div>
 
-## <dfn interface>GPUAdapter</dfn> ## {#gpu-adapter}
+<h3 id=gpuadapter data-dfn-type=interface>`GPUAdapter`</h3>
 
 A {{GPUAdapter}} encapsulates an [=adapter=],
 and describes its capabilities ([=features=] and [=limits=]).
@@ -2655,7 +2655,7 @@ interface GPUAdapter {
     </pre>
 </div>
 
-### <dfn dictionary>GPUDeviceDescriptor</dfn> ### {#gpudevicedescriptor}
+<h4 id=gpudevicedescriptor data-dfn-type=dictionary>`GPUDeviceDescriptor`</h4>
 
 {{GPUDeviceDescriptor}} describes a device request.
 
@@ -2714,7 +2714,7 @@ dictionary GPUDeviceDescriptor : GPUObjectDescriptorBase {
     </pre>
 </div>
 
-#### <dfn enum>GPUFeatureName</dfn> #### {#gpufeaturename}
+<h5 id=gpufeaturename data-dfn-type=enum>`GPUFeatureName`</h5>
 
 Each {{GPUFeatureName}} identifies a set of functionality which, if available,
 allows additional usages of WebGPU that would have otherwise been invalid.
@@ -2733,7 +2733,7 @@ enum GPUFeatureName {
 };
 </script>
 
-## <dfn interface>GPUDevice</dfn> ## {#gpu-device}
+<h3 id=gpudevice data-dfn-type=interface>`GPUDevice`</h3>
 
 A {{GPUDevice}} encapsulates a [=device=] and exposes
 the functionality of that device.
@@ -2938,7 +2938,7 @@ Those not defined here are defined elsewhere in this document.
 
 # Buffers # {#buffers}
 
-## <dfn interface>GPUBuffer</dfn> ## {#buffer-interface}
+<h3 id=gpubuffer data-dfn-type=interface>`GPUBuffer`</h3>
 
 A {{GPUBuffer}} represents a block of memory that can be used in GPU operations.
 Data is stored in linear layout, meaning that each byte of the allocation can be
@@ -3711,7 +3711,7 @@ The {{GPUMapMode}} flags determine how a {{GPUBuffer}} is mapped when calling
 
 # Textures and Texture Views # {#textures}
 
-## <dfn interface>GPUTexture</dfn> ## {#texture-interface}
+<h3 id=gputexture data-dfn-type=interface>`GPUTexture`</h3>
 
 Issue: Remove this definition: <dfn dfn>texture</dfn>
 
@@ -4239,7 +4239,7 @@ all previously submitted operations using it are complete.
         </div>
 </dl>
 
-## <dfn interface>GPUTextureView</dfn> ## {#gpu-textureview}
+<h3 id=gputextureview data-dfn-type=interface>`GPUTextureView`</h3>
 
 A {{GPUTextureView}} is a view onto some subset of the [=texture subresources=] defined by
 a particular {{GPUTexture}}.
@@ -4864,7 +4864,7 @@ See [[#texture-format-caps]] for information about which {{GPUTextureFormat}}s r
         1. Throw a {{TypeError}}.
 </div>
 
-## <dfn interface>GPUExternalTexture</dfn> ## {#gpu-external-texture}
+<h3 id=gpuexternaltexture data-dfn-type=interface>`GPUExternalTexture`</h3>
 
 A {{GPUExternalTexture}} is a sampleable 2D texture wrapping an external video object.
 The contents of a {{GPUExternalTexture}} object are a snapshot and may not change, either from inside WebGPU
@@ -5090,7 +5090,7 @@ underlying texture separately, prior to conversion from YUV to the specified col
 
 # Samplers # {#samplers}
 
-## <dfn interface>GPUSampler</dfn> ## {#sampler-interface}
+<h3 id=gpusampler data-dfn-type=interface>`GPUSampler`</h3>
 
 A {{GPUSampler}} encodes transformations and filtering information that can
 be used in a shader to interpret texture resource data.
@@ -5368,7 +5368,7 @@ enum GPUCompareFunction {
 
 # Resource Binding # {#bindings}
 
-## <dfn interface>GPUBindGroupLayout</dfn> ## {#bind-group-layout}
+<h3 id=gpubindgrouplayout data-dfn-type=interface>`GPUBindGroupLayout`</h3>
 
 A {{GPUBindGroupLayout}} defines the interface between a set of resources bound in a {{GPUBindGroup}} and their accessibility in shader stages.
 
@@ -5851,7 +5851,7 @@ if and only if all of the following conditions are satisfied:
 
 If bind groups layouts are [=group-equivalent=] they can be interchangeably used in all contents.
 
-## <dfn interface>GPUBindGroup</dfn> ## {#gpu-bind-group}
+<h3 id=gpubindgroup data-dfn-type=interface>`GPUBindGroup`</h3>
 
 A {{GPUBindGroup}} defines a set of resources to be bound together in a group
     and how the resources are used in shader stages.
@@ -6120,7 +6120,7 @@ following members:
     Issue: Define how a range is formed by offset/size when size can be undefined.
 </div>
 
-## <dfn interface>GPUPipelineLayout</dfn> ## {#pipeline-layout}
+<h3 id=gpupipelinelayout data-dfn-type=interface>`GPUPipelineLayout`</h3>
 
 A {{GPUPipelineLayout}} defines the mapping between resources of all {{GPUBindGroup}} objects set up during command encoding in [=GPUBindingCommandsMixin/setBindGroup()=], and the shaders of the pipeline set by {{GPURenderCommandsMixin/setPipeline(pipeline)|GPURenderCommandsMixin.setPipeline}} or {{GPUComputePassEncoder/setPipeline(pipeline)|GPUComputePassEncoder.setPipeline}}.
 
@@ -6284,7 +6284,7 @@ if their internal {{GPUPipelineLayout/[[bindGroupLayouts]]}} sequences contain
 
 # Shader Modules # {#shader-modules}
 
-## <dfn interface>GPUShaderModule</dfn> ## {#shader-module}
+<h3 id=gpushadermodule data-dfn-type=interface>`GPUShaderModule`</h3>
 
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
@@ -6978,7 +6978,7 @@ run the following steps:
     1. Return |device|.{{GPUDevice/createPipelineLayout()}}(|desc|).
 </div>
 
-### <dfn dictionary>GPUProgrammableStage</dfn> ### {#GPUProgrammableStage}
+<h4 id=gpuprogrammablestage data-dfn-type=dictionary>`GPUProgrammableStage`</h4>
 
 A {{GPUProgrammableStage}} describes the entry point in the user-provided
 {{GPUShaderModule}} that controls one of the programmable stages of a [=pipeline=].
@@ -7276,7 +7276,7 @@ typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32,
     {{GPUProgrammableStage/entryPoint}}, in the specified shader {{GPUProgrammableStage/module}}.
 </div>
 
-## <dfn interface>GPUComputePipeline</dfn> ## {#compute-pipeline}
+<h3 id=gpucomputepipeline data-dfn-type=interface>`GPUComputePipeline`</h3>
 
 A {{GPUComputePipeline}} is a kind of [=pipeline=] that controls the compute shader stage,
 and can be used in {{GPUComputePassEncoder}}.
@@ -7448,7 +7448,7 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
     </pre>
 </div>
 
-## <dfn interface>GPURenderPipeline</dfn> ## {#render-pipeline}
+<h3 id=gpurenderpipeline data-dfn-type=interface>`GPURenderPipeline`</h3>
 
 A {{GPURenderPipeline}} is a kind of [=pipeline=] that controls the vertex
 and fragment shader stages, and can be used in {{GPURenderPassEncoder}}
@@ -8937,7 +8937,7 @@ setting state, drawing, copying resources, etc.
 A {{GPUCommandBuffer}} can only be submitted once, at which point it becomes [=invalid=].
 To reuse rendering commands across multiple submissions, use {{GPURenderBundle}}.
 
-## <dfn interface>GPUCommandBuffer</dfn> ## {#command-buffer}
+<h3 id=gpucommandbuffer data-dfn-type=interface>`GPUCommandBuffer`</h3>
 
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
@@ -8969,7 +8969,7 @@ dictionary GPUCommandBufferDescriptor : GPUObjectDescriptorBase {
 
 # Command Encoding # {#command-encoding}
 
-## <dfn interface>GPUCommandsMixin</dfn> ## {#commands-mixin}
+<h3 id=gpucommandsmixin data-dfn-type=interface>`GPUCommandsMixin`</h3>
 
 {{GPUCommandsMixin}} defines state common to all interfaces which encode commands.
 It has no methods.
@@ -9040,7 +9040,7 @@ The <dfn dfn>encoder state</dfn> may be one of the following:
             1. Issue the steps of |command|.
 </div>
 
-## <dfn interface>GPUCommandEncoder</dfn> ## {#command-encoder}
+<h3 id=gpucommandencoder data-dfn-type=interface>`GPUCommandEncoder`</h3>
 
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
@@ -10122,7 +10122,7 @@ It must only be included by interfaces which also include those mixins.
 
 # Compute Passes # {#compute-passes}
 
-## <dfn interface>GPUComputePassEncoder</dfn> ## {#compute-pass-encoder}
+<h3 id=gpucomputepassencoder data-dfn-type=interface>`GPUComputePassEncoder`</h3>
 
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
@@ -10430,7 +10430,7 @@ called the compute pass encoder can no longer be used.
 
 # Render Passes # {#render-passes}
 
-## <dfn interface>GPURenderPassEncoder</dfn> ## {#render-pass-encoder}
+<h3 id=gpurenderpassencoder data-dfn-type=interface>`GPURenderPassEncoder`</h3>
 
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
@@ -11029,7 +11029,7 @@ called the render pass encoder can no longer be used.
         </div>
 </dl>
 
-## <dfn interface>GPURenderCommandsMixin</dfn> ## {#render-commands}
+<h3 id=gpurendercommandsmixin data-dfn-type=interface>`GPURenderCommandsMixin`</h3>
 
 {{GPURenderCommandsMixin}} defines rendering commands common to {{GPURenderPassEncoder}}
 and {{GPURenderBundleEncoder}}.
@@ -11892,7 +11892,7 @@ attachments used by this encoder.
 
 # Bundles # {#bundles}
 
-## <dfn interface>GPURenderBundle</dfn> ## {#render-bundle}
+<h3 id=gpurenderbundle data-dfn-type=interface>`GPURenderBundle`</h3>
 
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
@@ -12064,7 +12064,7 @@ dictionary GPURenderBundleEncoderDescriptor : GPURenderPassLayout {
 
 # Queues # {#queues}
 
-## <dfn dictionary>GPUQueueDescriptor</dfn> ## {#gpuqueuedescriptor}
+<h3 id=gpuqueuedescriptor data-dfn-type=dictionary>`GPUQueueDescriptor`</h3>
 
 {{GPUQueueDescriptor}} describes a queue request.
 
@@ -12073,7 +12073,7 @@ dictionary GPUQueueDescriptor : GPUObjectDescriptorBase {
 };
 </script>
 
-## <dfn interface>GPUQueue</dfn> ## {#gpu-queue}
+<h3 id=gpuqueue data-dfn-type=interface>`GPUQueue`</h3>
 
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
@@ -12423,7 +12423,7 @@ GPUQueue includes GPUObjectBase;
 
 # Queries # {#queries}
 
-## <dfn interface>GPUQuerySet</dfn> ## {#queryset}
+<h3 id=gpuqueryset data-dfn-type=interface>`GPUQuerySet`</h3>
 
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
@@ -13097,7 +13097,7 @@ In WebGPU, it does so by [$Replace the drawing buffer|replacing the drawing buff
     </pre>
 </div>
 
-## <dfn dfn-type=enum>GPUCanvasAlphaMode</dfn> ## {#GPUCanvasAlphaMode}
+<h3 id=gpucanvasalphamode data-dfn-type=enum>`GPUCanvasAlphaMode`</h3>
 
 This enum selects how the contents of the canvas will be interpreted when read, when
 [$update the rendering of the WebGPU canvas|rendered to the screen$] or
@@ -13164,7 +13164,7 @@ partial interface GPUDevice {
         Upon initialization, it is set to [=a new promise=].
 </dl>
 
-## <dfn interface>GPUError</dfn> ## {#error}
+<h3 id=gpuerror data-dfn-type=interface>`GPUError`</h3>
 
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -34,7 +34,9 @@ Copy commands are not guaranteed to preserve the source's bit-representation.
 
 The following definitions are used by these methods.
 
-<h4 id=gpuimagedatalayout data-dfn-type=dictionary>GPUImageDataLayout</h4>
+<h4 id=gpuimagedatalayout data-dfn-type=dictionary>`GPUImageDataLayout`
+<span id=gpu-image-data-layout></span>
+</h4>
 
 <script type=idl>
 dictionary GPUImageDataLayout {
@@ -87,7 +89,9 @@ Issue: Define the exact copy semantics, by reference to common algorithms shared
         Required if there are multiple [=images=] (i.e. the copy depth is more than one).
 </dl>
 
-<h4 id=gpuimagecopybuffer data-dfn-type=dictionary>GPUImageCopyBuffer</h4>
+<h4 id=gpuimagecopybuffer data-dfn-type=dictionary>`GPUImageCopyBuffer`
+<span id=gpu-image-copy-buffer></span>
+</h4>
 
 In an [=image copy=] operation, {{GPUImageCopyBuffer}} defines a {{GPUBuffer}} and, together with
 the `copySize`, how image data is laid out in the buffer's memory (see {{GPUImageDataLayout}}).
@@ -119,7 +123,9 @@ dictionary GPUImageCopyBuffer : GPUImageDataLayout {
         - |imageCopyBuffer|.{{GPUImageDataLayout/bytesPerRow}} must be a multiple of 256.
 </div>
 
-<h4 id=gpuimagecopytexture data-dfn-type=dictionary>GPUImageCopyTexture</h4>
+<h4 id=gpuimagecopytexture data-dfn-type=dictionary>`GPUImageCopyTexture`
+<span id=gpu-image-copy-texture></span>
+</h4>
 
 In an [=image copy=] operation, a {{GPUImageCopyTexture}} defines a {{GPUTexture}} and, together with
 the `copySize`, the sub-region of the texture (spanning one or more contiguous
@@ -180,7 +186,9 @@ dictionary GPUImageCopyTexture {
 
 Issue(gpuweb/gpuweb#69): Define the copies with {{GPUTextureDimension/1d}} and {{GPUTextureDimension/3d}} textures.
 
-<h4 id=gpuimagecopytexturetagged data-dfn-type=dictionary>GPUImageCopyTextureTagged</h4>
+<h4 id=gpuimagecopytexturetagged data-dfn-type=dictionary>`GPUImageCopyTextureTagged`
+<span id=gpu-image-copy-texture-tagged></span>
+</h4>
 
 WebGPU textures hold raw numeric data, and are not tagged with semantic metadata describing colors.
 However, {{GPUQueue/copyExternalImageToTexture()}} copies from sources that describe colors.
@@ -225,7 +233,9 @@ dictionary GPUImageCopyTextureTagged : GPUImageCopyTexture {
         conversion may not be necessary. See [[#color-space-conversion-elision]].
 </dl>
 
-<h4 id=gpuimagecopyexternalimage data-dfn-type=dictionary>GPUImageCopyExternalImage</h4>
+<h4 id=gpuimagecopyexternalimage data-dfn-type=dictionary>`GPUImageCopyExternalImage`
+<span id=gpu-image-copy-external-image></span>
+</h4>
 
 <script type=idl>
 dictionary GPUImageCopyExternalImage {

--- a/spec/sections/copies.bs
+++ b/spec/sections/copies.bs
@@ -34,7 +34,7 @@ Copy commands are not guaranteed to preserve the source's bit-representation.
 
 The following definitions are used by these methods.
 
-### <dfn dictionary>GPUImageDataLayout</dfn> ### {#gpu-image-data-layout}
+<h4 id=gpuimagedatalayout data-dfn-type=dictionary>GPUImageDataLayout</h4>
 
 <script type=idl>
 dictionary GPUImageDataLayout {
@@ -87,7 +87,7 @@ Issue: Define the exact copy semantics, by reference to common algorithms shared
         Required if there are multiple [=images=] (i.e. the copy depth is more than one).
 </dl>
 
-### <dfn dictionary>GPUImageCopyBuffer</dfn> ### {#gpu-image-copy-buffer}
+<h4 id=gpuimagecopybuffer data-dfn-type=dictionary>GPUImageCopyBuffer</h4>
 
 In an [=image copy=] operation, {{GPUImageCopyBuffer}} defines a {{GPUBuffer}} and, together with
 the `copySize`, how image data is laid out in the buffer's memory (see {{GPUImageDataLayout}}).
@@ -119,7 +119,7 @@ dictionary GPUImageCopyBuffer : GPUImageDataLayout {
         - |imageCopyBuffer|.{{GPUImageDataLayout/bytesPerRow}} must be a multiple of 256.
 </div>
 
-### <dfn dictionary>GPUImageCopyTexture</dfn> ### {#gpu-image-copy-texture}
+<h4 id=gpuimagecopytexture data-dfn-type=dictionary>GPUImageCopyTexture</h4>
 
 In an [=image copy=] operation, a {{GPUImageCopyTexture}} defines a {{GPUTexture}} and, together with
 the `copySize`, the sub-region of the texture (spanning one or more contiguous
@@ -180,7 +180,7 @@ dictionary GPUImageCopyTexture {
 
 Issue(gpuweb/gpuweb#69): Define the copies with {{GPUTextureDimension/1d}} and {{GPUTextureDimension/3d}} textures.
 
-### <dfn dictionary>GPUImageCopyTextureTagged</dfn> ### {#gpu-image-copy-texture-tagged}
+<h4 id=gpuimagecopytexturetagged data-dfn-type=dictionary>GPUImageCopyTextureTagged</h4>
 
 WebGPU textures hold raw numeric data, and are not tagged with semantic metadata describing colors.
 However, {{GPUQueue/copyExternalImageToTexture()}} copies from sources that describe colors.
@@ -225,7 +225,7 @@ dictionary GPUImageCopyTextureTagged : GPUImageCopyTexture {
         conversion may not be necessary. See [[#color-space-conversion-elision]].
 </dl>
 
-### <dfn dictionary>GPUImageCopyExternalImage</dfn> ### {#gpu-image-copy-external-image}
+<h4 id=gpuimagecopyexternalimage data-dfn-type=dictionary>GPUImageCopyExternalImage</h4>
 
 <script type=idl>
 dictionary GPUImageCopyExternalImage {


### PR DESCRIPTION
Bikeshed handles this pattern in accordance with the "Definitions data model": https://speced.github.io/bikeshed/#dfn-contract

Note, previously each of these had two ids: one for the heading, one for the dfn. Some but not all of these are preserved:
- `#gpudevice` (was the dfn), removed `#gpu-device` (was the heading)
- `#gpudevicedescriptor` (was the heading), removed `#dictdef-gpudevicedescriptor` (was the dfn)
  - Same for all the feature names (e.g. `#depth-clip-control`, removed `#dom-gpufeaturename-depth-clip-control`)
- `#gpuimagedatalayout` (did not exist before), removed `#gpu-image-data-layout` (was the heading) and `#dictdef-gpuimagedatalayout` (was the dfn)
  - Same for `#gpuimagecopybuffer`, `#gpuimagecopytexture`, `#gpuimagecopytexturetagged`, `#gpuimagecopyexternalimage`
- `#gpuprogrammablestage` (did not exist before), removed `#GPUProgrammableStage` (was the heading) and `#dictdef-gpuprogrammablestage` (was the dfn)
  - Same for `#gpucanvasalphamode`
- `#texture-compression-etc2` (did not exist before), removed `#texture-compression-etc` (sic)

We can preserve some of these historical URLs if we want. Should we?