### PR TITLE
Add column for whether format is blendable

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -14682,8 +14682,6 @@ This feature adds no [=optional API surfaces=].
 
 All plain color formats support {{GPUTextureUsage/COPY_SRC}}, {{GPUTextureUsage/COPY_DST}}, and {{GPUTextureUsage/TEXTURE_BINDING}} usage.
 
-Only formats with {{GPUTextureSampleType}} {{GPUTextureSampleType/"float"}} can be blended.
-
 The {{GPUTextureUsage/RENDER_ATTACHMENT}} and {{GPUTextureUsage/STORAGE_BINDING}} columns
 specify support for {{GPUTextureUsage/RENDER_ATTACHMENT|GPUTextureUsage.RENDER_ATTACHMENT}}
 and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage respectively.
@@ -14694,6 +14692,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
             <th>Format
             <th>{{GPUTextureSampleType}}
             <th><span class=vertical>{{GPUTextureUsage/RENDER_ATTACHMENT}}</span>
+            <th><span class=vertical>blending</span>
             <th><span class=vertical>multisampling</span>
             <th><span class=vertical>resolve</span>
             <th><span class=vertical>{{GPUTextureUsage/STORAGE_BINDING}}</span>
@@ -14708,6 +14707,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
+        <td>&checkmark;
         <td>
         <td>1
         <td>1
@@ -14716,6 +14716,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>{{GPUTextureFormat/r8snorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td><!-- Vulkan -->
+        <td>
         <td><!-- no multisampling without RENDER_ATTACHMENT (gpuweb/gpuweb#2465) -->
         <td>
         <td><!-- Vulkan -->
@@ -14726,6 +14727,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>{{GPUTextureFormat/r8uint}}
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
+        <td>
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
@@ -14736,6 +14738,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>{{GPUTextureFormat/r8sint}}
         <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
+        <td>
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
@@ -14748,6 +14751,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
+        <td>&checkmark;
         <td><!-- Vulkan -->
         <td>2
         <td>2
@@ -14756,6 +14760,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>{{GPUTextureFormat/rg8snorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td><!-- Vulkan -->
+        <td>
         <td><!-- no multisampling without RENDER_ATTACHMENT (gpuweb/gpuweb#2465) -->
         <td>
         <td><!-- Vulkan -->
@@ -14766,6 +14771,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>{{GPUTextureFormat/rg8uint}}
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
+        <td>
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
@@ -14776,6 +14782,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>{{GPUTextureFormat/rg8sint}}
         <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
+        <td>
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
@@ -14789,12 +14796,14 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
+        <td>&checkmark;
         <td>4
         <td>8
         <td>1
     <tr>
         <td>{{GPUTextureFormat/rgba8unorm-srgb}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
@@ -14806,6 +14815,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>{{GPUTextureFormat/rgba8snorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
         <td><!-- Vulkan -->
+        <td>
         <td><!-- no multisampling without RENDER_ATTACHMENT (gpuweb/gpuweb#2465) -->
         <td>
         <td>&checkmark;
@@ -14816,6 +14826,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>{{GPUTextureFormat/rgba8uint}}
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
+        <td>
         <td>&checkmark;
         <td><!-- Metal -->
         <td>&checkmark;
@@ -14826,6 +14837,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>{{GPUTextureFormat/rgba8sint}}
         <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
+        <td>
         <td>&checkmark;
         <td><!-- Metal -->
         <td>&checkmark;
@@ -14835,6 +14847,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
     <tr>
         <td>{{GPUTextureFormat/bgra8unorm}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
+        <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
@@ -14848,6 +14861,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
+        <td>&checkmark;
         <td>
         <td>4
         <td>8
@@ -14857,6 +14871,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>{{GPUTextureFormat/r16uint}}
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
+        <td>
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
@@ -14867,6 +14882,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>{{GPUTextureFormat/r16sint}}
         <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
+        <td>
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
@@ -14879,6 +14895,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
+        <td>&checkmark;
         <td>
         <td>2
         <td>2
@@ -14887,6 +14904,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>{{GPUTextureFormat/rg16uint}}
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
+        <td>
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
@@ -14897,6 +14915,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>{{GPUTextureFormat/rg16sint}}
         <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
+        <td>
         <td>&checkmark;
         <td><!-- Metal -->
         <td>
@@ -14909,6 +14928,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
+        <td>&checkmark;
         <td><!-- Vulkan -->
         <td>4
         <td>4
@@ -14917,6 +14937,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>{{GPUTextureFormat/rgba16uint}}
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
+        <td>
         <td>&checkmark;
         <td><!-- Metal -->
         <td>&checkmark;
@@ -14927,6 +14948,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>{{GPUTextureFormat/rgba16sint}}
         <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
+        <td>
         <td>&checkmark;
         <td><!-- Metal -->
         <td>&checkmark;
@@ -14940,6 +14962,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
+        <td>&checkmark;
         <td>8
         <td>8
         <td>2
@@ -14948,6 +14971,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>{{GPUTextureFormat/r32uint}}
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
+        <td>
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
@@ -14958,6 +14982,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>{{GPUTextureFormat/r32sint}}
         <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
+        <td>
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
@@ -14968,6 +14993,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>{{GPUTextureFormat/r32float}}
         <td>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
+        <td>
         <td>&checkmark;
         <td><!-- Metal -->
         <td>&checkmark;
@@ -14978,6 +15004,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>{{GPUTextureFormat/rg32uint}}
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
+        <td>
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
@@ -14988,6 +15015,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>{{GPUTextureFormat/rg32sint}}
         <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
+        <td>
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
@@ -14998,6 +15026,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>{{GPUTextureFormat/rg32float}}
         <td>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
+        <td>
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
@@ -15008,6 +15037,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>{{GPUTextureFormat/rgba32uint}}
         <td>{{GPUTextureSampleType/"uint"}}
         <td>&checkmark;
+        <td>
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
@@ -15018,6 +15048,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>{{GPUTextureFormat/rgba32sint}}
         <td>{{GPUTextureSampleType/"sint"}}
         <td>&checkmark;
+        <td>
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
@@ -15028,6 +15059,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>{{GPUTextureFormat/rgba32float}}
         <td>{{GPUTextureSampleType/"unfilterable-float"}}
         <td>&checkmark;
+        <td>
         <td><!-- Metal -->
         <td>
         <td>&checkmark;
@@ -15041,6 +15073,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
         <td>&checkmark;
         <td>&checkmark;
         <td>&checkmark;
+        <td>&checkmark;
         <td>
         <td>4
         <td>8
@@ -15048,7 +15081,7 @@ and {{GPUTextureUsage/STORAGE_BINDING|GPUTextureUsage.STORAGE_BINDING}} usage re
     <tr>
         <td>{{GPUTextureFormat/rg11b10ufloat}}
         <td>{{GPUTextureSampleType/"float"}},<br/>{{GPUTextureSampleType/"unfilterable-float"}}
-        <td colspan=2>If {{GPUFeatureName/"rg11b10ufloat-renderable"}} is enabled
+        <td colspan=3>If {{GPUFeatureName/"rg11b10ufloat-renderable"}} is enabled
         <td>
         <td><!-- Vulkan -->
         <td>4


### PR DESCRIPTION
Previously this was just "filterable && renderable" but that's kind of buried and prone to getting updated incorrectly.
Confirmed in #3566 that rg11b10ufloat is always blendable when it's renderable.

This change is in service of #3828 which will add cases for which "filterable && renderable" isn't true.