### PR TITLE
UAs MUST restrict to <=32 distinguishable [fingerprinting] buckets.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -661,6 +661,8 @@ take advantage of those capabilities effectively. The general mitigation approac
 normalizing or binning potentially identifying information and enforcing uniform behavior where
 possible.
 
+A user agent must not reveal more than 32 distinguishable configurations or buckets.
+
 ### Machine-specific features and limits ### {#privacy-machine-limits}
 
 WebGPU can expose a lot of detail on the underlying GPU architecture and the device geometry.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1435,6 +1435,8 @@ describe WebGPU functionality that differs between different implementations,
 typically due to hardware or system software constraints.
 A [=capability=] is either a [=feature=] or a [=limit=].
 
+A user agent must not reveal more than 32 distinguishable configurations or buckets.
+
 <p tracking-vector>
 For privacy considerations, see [[#privacy-machine-limits]].
 


### PR DESCRIPTION
As resolved in the F2F.

Issue: #3101