### PR TITLE
Add longer WGSL example to top of WGSL spec

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -298,10 +298,10 @@ that run on the GPU.
 
         // Determine the contribution of this light to the surface color.
         let radiance = lights.point[i].color * (1 / pow(dist, 2));
-        let nDotL = max(dot(N, dir), 0.0);
+        let nDotL = max(dot(N, dir), 0);
 
         // Accumulate light contribution to the surface color.
-        surfaceColor += (baseColor.rgb * radiance * nDotL);
+        surfaceColor += baseColor.rgb * radiance * nDotL;
       }
 
       // Return the accumulated surface color.

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -261,9 +261,51 @@ that run on the GPU.
 
 <div class='example wgsl global-scope'>
   <xmp highlight='rust'>
+    // A fragment shader which lights textured geometry with point lights.
+
+    // Lights from a storage buffer binding.
+    struct PointLight {
+      position : vec3f,
+      color : vec3f,
+    };
+
+    struct LightUniforms {
+      pointCount : u32,
+      point : array<Light>,
+    };
+    @group(0) @binding(0) var<storage> lights : LightUniforms;
+
+    // Texture and sampler.
+    @group(1) @binding(0) var baseColorSampler : sampler;
+    @group(1) @binding(1) var baseColorTexture : texture_2d<f32>;
+
+    // Function arguments are values from from vertex shader.
     @fragment
-    fn main() -> @location(0) vec4<f32> {
-        return vec4<f32>(0.4, 0.4, 0.8, 1.0);
+    fn fragmentMain(@location(0) worldPos : vec3f,
+                    @location(1) normal : vec3f,
+                    @location(2) uv : vec3f) -> @location(0) vec4f {
+      // Sample the base color of the surface from a texture.
+      let baseColor = textureSample(baseColorTexture, baseColorSampler, uv);
+
+      let N = normalize(normal);
+      var surfaceColor = vec3(0.0);
+
+      // Loop over the scene point lights.
+      for (var i = 0u; i < lights.pointCount; i++) {
+        let worldToLight = lights.point[i].position - worldPos;
+        let dist = length(worldToLight);
+        let dir = normalize(worldToLight);
+
+        // Determine the contribution of this light to the surface color.
+        let radiance = lights.point[i].color * (1.0 / pow(dist, 2.0));
+        let nDotL = max(dot(N, dir)), 0.0);
+
+        // Accumulate light contribution to the surface color.
+        surfaceColor = surfaceColor + (baseColor * radiance * nDotL);
+      }
+
+      // Return the accumulated surface color.
+      return vec4(surfaceColor, 1.0);
     }
   </xmp>
 </div>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -271,13 +271,13 @@ that run on the GPU.
 
     struct LightUniforms {
       pointCount : u32,
-      point : array<Light>,
+      point : array&lt;Light&gt;,
     };
     @group(0) @binding(0) var<storage> lights : LightUniforms;
 
     // Texture and sampler.
     @group(1) @binding(0) var baseColorSampler : sampler;
-    @group(1) @binding(1) var baseColorTexture : texture_2d<f32>;
+    @group(1) @binding(1) var baseColorTexture : texture_2d&lt;f32&gt;;
 
     // Function arguments are values from from vertex shader.
     @fragment

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -269,11 +269,11 @@ that run on the GPU.
       color : vec3f,
     };
 
-    struct LightUniforms {
+    struct LightStorage {
       pointCount : u32,
       point : array&lt;Light&gt;,
     };
-    @group(0) @binding(0) var<storage> lights : LightUniforms;
+    @group(0) @binding(0) var&lt;storage&gt; lights : LightStorage;
 
     // Texture and sampler.
     @group(1) @binding(0) var baseColorSampler : sampler;

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -267,12 +267,12 @@ that run on the GPU.
     struct PointLight {
       position : vec3f,
       color : vec3f,
-    };
+    }
 
     struct LightStorage {
       pointCount : u32,
       point : array&lt;Light&gt;,
-    };
+    }
     @group(0) @binding(0) var&lt;storage&gt; lights : LightStorage;
 
     // Texture and sampler.
@@ -288,7 +288,7 @@ that run on the GPU.
       let baseColor = textureSample(baseColorTexture, baseColorSampler, uv);
 
       let N = normalize(normal);
-      var surfaceColor = vec3(0.0);
+      var surfaceColor = vec3f(0);
 
       // Loop over the scene point lights.
       for (var i = 0u; i < lights.pointCount; i++) {
@@ -297,15 +297,15 @@ that run on the GPU.
         let dir = normalize(worldToLight);
 
         // Determine the contribution of this light to the surface color.
-        let radiance = lights.point[i].color * (1.0 / pow(dist, 2.0));
+        let radiance = lights.point[i].color * (1 / pow(dist, 2));
         let nDotL = max(dot(N, dir)), 0.0);
 
         // Accumulate light contribution to the surface color.
-        surfaceColor = surfaceColor + (baseColor * radiance * nDotL);
+        surfaceColor += (baseColor * radiance * nDotL);
       }
 
       // Return the accumulated surface color.
-      return vec4(surfaceColor, 1.0);
+      return vec4(surfaceColor, 1);
     }
   </xmp>
 </div>

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -271,19 +271,19 @@ that run on the GPU.
 
     struct LightStorage {
       pointCount : u32,
-      point : array&lt;Light&gt;,
+      point : array<PointLight>,
     }
-    @group(0) @binding(0) var&lt;storage&gt; lights : LightStorage;
+    @group(0) @binding(0) var<storage> lights : LightStorage;
 
     // Texture and sampler.
     @group(1) @binding(0) var baseColorSampler : sampler;
-    @group(1) @binding(1) var baseColorTexture : texture_2d&lt;f32&gt;;
+    @group(1) @binding(1) var baseColorTexture : texture_2d<f32>;
 
     // Function arguments are values from from vertex shader.
     @fragment
     fn fragmentMain(@location(0) worldPos : vec3f,
                     @location(1) normal : vec3f,
-                    @location(2) uv : vec3f) -> @location(0) vec4f {
+                    @location(2) uv : vec2f) -> @location(0) vec4f {
       // Sample the base color of the surface from a texture.
       let baseColor = textureSample(baseColorTexture, baseColorSampler, uv);
 
@@ -298,14 +298,14 @@ that run on the GPU.
 
         // Determine the contribution of this light to the surface color.
         let radiance = lights.point[i].color * (1 / pow(dist, 2));
-        let nDotL = max(dot(N, dir)), 0.0);
+        let nDotL = max(dot(N, dir), 0.0);
 
         // Accumulate light contribution to the surface color.
-        surfaceColor += (baseColor * radiance * nDotL);
+        surfaceColor += (baseColor.rgb * radiance * nDotL);
       }
 
       // Return the accumulated surface color.
-      return vec4(surfaceColor, 1);
+      return vec4(surfaceColor, baseColor.a);
     }
   </xmp>
 </div>


### PR DESCRIPTION
The current example that the spec opens with is very short and doesn't give an good sense of the feel of the language as a whole:

```rs
@fragment
fn main() -> @location(0) vec4<f32> {
  return vec4<f32>(0.4, 0.4, 0.8, 1.0);
}
```

It's also not making use of vector aliases or similar syntactic sugar that can help influence developers opinion of the language.

A related problem is that if you open the spec and search for the word "loop" the you'll be directed to the "Loop Statement" section which contains this made-to-be-mocked-by-Twitter comparison:

<img width="366" alt="Screenshot 2023-02-17 at 2 44 49 PM" src="https://user-images.githubusercontent.com/805273/219811799-af4ddb0d-c11b-4f8b-9ff1-dba4accc72cb.png">

For developers that are looking at the WGSL spec for their first impressions of the language, these example code snippets don't leave a great first impression.

This PR updates the initial code example with more practical, real-world fragment shader which includes varyings, structs, bind groups, textures samples, and a loop. It uses aliases, type inference, and the for loop syntax to help the code read better. Hopefully it strikes a good balance of demonstrating many common features of the language without being overly complex.

(Also, I would recommend just dropping the "Example: GLSL Loop" section entirely, or reducing it to only having the GLSL example next to an example of WGSLs for loops.)