### PR TITLE
Clarify all sync built-in functions must only be in uniform control flow

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -15338,6 +15338,8 @@ All synchronization functions use the `Workgroup` [=memory scope=].<br>
 All synchronization functions have a `Workgroup` [=execution scope=].<br>
 All synchronization functions [=shader-creation error|must=] only be used in
 the [=compute=] shader stage.
+All synchronization functions [=shader-creation error|must=] only be invoked in
+[=uniform control flow=].
 
 ### `storageBarrier` ### {#storageBarrier-builtin}
 


### PR DESCRIPTION
Fixes #3836