### PR TITLE
Make depthClearValue, depthWriteEnabled, depthCompare required

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8263,8 +8263,8 @@ enum GPUBlendOperation {
 dictionary GPUDepthStencilState {
     required GPUTextureFormat format;
 
-    boolean depthWriteEnabled = false;
-    GPUCompareFunction depthCompare = "always";
+    required boolean depthWriteEnabled = false;
+    required GPUCompareFunction depthCompare = "always";
 
     GPUStencilFaceState stencilFront = {};
     GPUStencilFaceState stencilBack = {};
@@ -10805,7 +10805,7 @@ dictionary GPURenderPassColorAttachment {
 dictionary GPURenderPassDepthStencilAttachment {
     required GPUTextureView view;
 
-    float depthClearValue = 0;
+    required float depthClearValue = 0;
     GPULoadOp depthLoadOp;
     GPUStoreOp depthStoreOp;
     boolean depthReadOnly = false;

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -10883,7 +10883,7 @@ dictionary GPURenderPassDepthStencilAttachment {
     - |this|.{{GPURenderPassDepthStencilAttachment/view}} must have a [=depth-or-stencil format=].
     - |this|.{{GPURenderPassDepthStencilAttachment/view}} must be a [$renderable texture view$].
     - Let |format| be |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
-    - If format has a depth aspect and |this|.{{GPURenderPassDepthStencilAttachment/depthLoadOp}} is {{GPULoadOp/"clear"}},
+    - If |format| has a depth aspect and |this|.{{GPURenderPassDepthStencilAttachment/depthLoadOp}} is {{GPULoadOp/"clear"}},
         |this|.{{GPURenderPassDepthStencilAttachment/depthClearValue}} must [=map/exist|be provided=] and must be between 0.0 and 1.0,
         inclusive.
         <!-- POSTV1(unrestricted-depth): unless unrestricted depth is enabled -->

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -10805,7 +10805,7 @@ dictionary GPURenderPassColorAttachment {
 dictionary GPURenderPassDepthStencilAttachment {
     required GPUTextureView view;
 
-    required float depthClearValue = 0;
+    float depthClearValue;
     GPULoadOp depthLoadOp;
     GPUStoreOp depthStoreOp;
     boolean depthReadOnly = false;
@@ -10882,11 +10882,11 @@ dictionary GPURenderPassDepthStencilAttachment {
 
     - |this|.{{GPURenderPassDepthStencilAttachment/view}} must have a [=depth-or-stencil format=].
     - |this|.{{GPURenderPassDepthStencilAttachment/view}} must be a [$renderable texture view$].
-    - If |this|.{{GPURenderPassDepthStencilAttachment/depthLoadOp}} is {{GPULoadOp/"clear"}},
-        |this|.{{GPURenderPassDepthStencilAttachment/depthClearValue}} must be between 0.0 and 1.0,
+    - Let |format| be |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
+    - If format has a depth aspect and |this|.{{GPURenderPassDepthStencilAttachment/depthLoadOp}} is {{GPULoadOp/"clear"}},
+        |this|.{{GPURenderPassDepthStencilAttachment/depthClearValue}} must [=map/exist|be provided=] and must be between 0.0 and 1.0,
         inclusive.
         <!-- POSTV1(unrestricted-depth): unless unrestricted depth is enabled -->
-    - Let |format| be |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
     - If |format| is a [=combined depth-stencil format=]:
         - |this|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} must be equal to |this|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}}
     - If |format| has a depth aspect and |this|.{{GPURenderPassDepthStencilAttachment/depthReadOnly}} is not `true`:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -10883,7 +10883,7 @@ dictionary GPURenderPassDepthStencilAttachment {
     - |this|.{{GPURenderPassDepthStencilAttachment/view}} must have a [=depth-or-stencil format=].
     - |this|.{{GPURenderPassDepthStencilAttachment/view}} must be a [$renderable texture view$].
     - Let |format| be |this|.{{GPURenderPassDepthStencilAttachment/view}}.{{GPUTextureView/[[descriptor]]}}.{{GPUTextureViewDescriptor/format}}.
-    - If |format| has a depth aspect and |this|.{{GPURenderPassDepthStencilAttachment/depthLoadOp}} is {{GPULoadOp/"clear"}},
+    - If |this|.{{GPURenderPassDepthStencilAttachment/depthLoadOp}} is {{GPULoadOp/"clear"}},
         |this|.{{GPURenderPassDepthStencilAttachment/depthClearValue}} must [=map/exist|be provided=] and must be between 0.0 and 1.0,
         inclusive.
         <!-- POSTV1(unrestricted-depth): unless unrestricted depth is enabled -->

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -8263,8 +8263,8 @@ enum GPUBlendOperation {
 dictionary GPUDepthStencilState {
     required GPUTextureFormat format;
 
-    required boolean depthWriteEnabled = false;
-    required GPUCompareFunction depthCompare = "always";
+    required boolean depthWriteEnabled;
+    required GPUCompareFunction depthCompare;
 
     GPUStencilFaceState stencilFront = {};
     GPUStencilFaceState stencilBack = {};


### PR DESCRIPTION
Related: #3777 #3798

This PR makes depthClearValue, depthWriteEnabled, and depthCompare required for V1 as discussed at #3798. We might revisit them Post-V1.