### PR TITLE
Add wgsl to install-dependencies.sh args in spec/README.md

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -8,7 +8,7 @@ with diagrams generated using [Mermaid](https://mermaid-js.github.io/mermaid/).
 To install the necessary tools, run:
 
 ```bash
-./tools/install-dependencies.sh bikeshed diagrams
+./tools/install-dependencies.sh bikeshed diagrams wgsl
 ```
 
 Alternatively, invoke `pip3`/`npx` directly, using the commands in [that script](../tools/install-dependencies.sh).


### PR DESCRIPTION
Make failed on my Windows 10 + WGSL although I followed `spec/README.md`.

```
$ make
make -j -C spec
make[1]: Entering directory '/mnt/c/Users/Takahiro/Documents/gpuweb-master/spec'
make[1]: Nothing to be done for 'all'.
make[1]: Leaving directory '/mnt/c/Users/Takahiro/Documents/gpuweb-master/spec'
make -j -C wgsl
make[1]: Entering directory '/mnt/c/Users/Takahiro/Documents/gpuweb-master/wgsl'
python3 analyze/lalr.py -recursive -bs grammar/src/grammar.json >wgsl.recursive.bs.include.pre
python3 ../tools/check-nfkc.py
python3 wgsl_unit_tests.py --parser grammar/build/wgsl.so
python3 ./extract-grammar.py --flow e
python3 analyze/test.py 2>&1
.........................................................................sh ../tools/copy-if-different.sh wgsl.recursive.bs.include.pre wgsl.recursive.bs.include
Traceback (most recent call last):
  File "wgsl_unit_tests.py", line 38, in <module>
    from tree_sitter import Language, Parser
ModuleNotFoundError: No module named 'tree_sitter'
.............Traceback (most recent call last):
  File "./extract-grammar.py", line 12, in <module>
..    import wgsl_unit_tests
  File "/mnt/c/Users/Takahiro/Documents/gpuweb-master/wgsl/wgsl_unit_tests.py", line 38, in <module>
.......    from tree_sitter import Language, Parser
ModuleNotFoundError: No module named 'tree_sitter'
........make[1]: *** [Makefile:41: unit_tests] Error 1
make[1]: *** Waiting for unfinished jobs....
.make[1]: *** [Makefile:36: validate-examples] Error 1
..........
----------------------------------------------------------------------
Ran 114 tests in 0.096s

OK
make[1]: Leaving directory '/mnt/c/Users/Takahiro/Documents/gpuweb-master/wgsl'
make: *** [Makefile:15: wgsl] Error 2
```

Adding `wgsl` to `./tools/install-dependencies.sh` args fixed the problem. Then I would like to suggest it in `spec/README.md`.