### PR TITLE
Rename to getCompilationInfo()

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6610,7 +6610,7 @@ Note: {{GPUCompilationMessage}}.{{GPUCompilationMessage/offset}} and
         The locations, order, and contents of messages are implementation-defined.
         In particular, messages may not be ordered by {{GPUCompilationMessage/lineNum}}.
 
-        <div algorithm=GPUShaderModule.compilationInfo>
+        <div algorithm=GPUShaderModule.getCompilationInfo>
             <div data-timeline=content>
                 **Called on:** {{GPUShaderModule}} this
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -986,7 +986,7 @@ Several operations in WebGPU return promises.
 - {{GPUDevice}}.{{GPUDevice/createComputePipelineAsync()}}
 - {{GPUDevice}}.{{GPUDevice/createRenderPipelineAsync()}}
 - {{GPUBuffer}}.{{GPUBuffer/mapAsync()}}
-- {{GPUShaderModule}}.{{GPUShaderModule/compilationInfo()}}
+- {{GPUShaderModule}}.{{GPUShaderModule/getCompilationInfo()}}
 - {{GPUQueue}}.{{GPUQueue/onSubmittedWorkDone()}}
 - {{GPUDevice}}.{{GPUDevice/lost}}
 - {{GPUDevice}}.{{GPUDevice/popErrorScope()}}
@@ -6322,7 +6322,7 @@ if their internal {{GPUPipelineLayout/[[bindGroupLayouts]]}} sequences contain
 <script type=idl>
 [Exposed=(Window, DedicatedWorker), SecureContext]
 interface GPUShaderModule {
-    Promise<GPUCompilationInfo> compilationInfo();
+    Promise<GPUCompilationInfo> getCompilationInfo();
 };
 GPUShaderModule includes GPUObjectBase;
 </script>
@@ -6418,7 +6418,7 @@ dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
                     Note:
                     User agents **should not** include detailed compiler error messages or shader text in
                     the {{GPUError/message}} text of validation errors arising here:
-                    these details are accessible via {{GPUShaderModule/compilationInfo()}}.
+                    these details are accessible via {{GPUShaderModule/getCompilationInfo()}}.
                     User agents **should** surface human-readable, formatted error details *to
                     developers* for easier debugging (for example as a warning in the browser developer
                     console, expandable to show full shader source).
@@ -6603,7 +6603,7 @@ Note: {{GPUCompilationMessage}}.{{GPUCompilationMessage/offset}} and
 {{GPUCompilationMessage/message}} corresponds to.
 
 <dl dfn-type=method dfn-for=GPUShaderModule>
-    : <dfn>compilationInfo()</dfn>
+    : <dfn>getCompilationInfo()</dfn>
     ::
         Returns any messages generated during the {{GPUShaderModule}}'s compilation.
 


### PR DESCRIPTION
This PR renames from `GPUShaderModule.compilationInfo()` to `GPUShaderModule.getCompilationInfo()` as https://github.com/gpuweb/gpuweb/pull/3805#issuecomment-1433931903