### PR TITLE
types, type-generators, enumerants are ordinary predeclared identifiers; not keywords or context-dependent names

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1458,7 +1458,7 @@ the following kinds of objects:
 
 In other words, a declaration introduces a <dfn noexport>name</dfn> for an object.
 
-A declaration in is at <dfn noexport>module scope</dfn> if the declaration appears
+A declaration is at <dfn noexport>module scope</dfn> if the declaration appears
 in the program source, but outside the text of any other declaration.
 
 A [=function/function=] declaration appears at module-scope.
@@ -1491,8 +1491,8 @@ Where a declaration appears determines its scope:
     For details, see [[#var-and-value]].
 
 Two declarations in the same WGSL source program [=shader-creation error|must not=] simultaneously:
-* Introduce the same identifier name, and
-* Have the same end-of-scope.
+* introduce the same identifier name, and
+* have the same end-of-scope.
 
 Note: A predeclared object does not have a declaration in the WGSL source.
 So a user-specified declaration at module-scope or inside a function can have the same name as a predeclared object.
@@ -2758,7 +2758,7 @@ module creation|shader creation=] time.
 A type has a <dfn>fixed footprint</dfn> if its size is fully determined
 at [=pipeline creation=] time.
 
-All creation-fixed footprint and fixed footprint types are [=storeable=].
+All creation-fixed footprint and fixed footprint types are [=storable=].
 
 Note: Pipeline creation depends on shader creation, so a type with [=creation-fixed footprint=] also has [=fixed footprint=].
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -948,7 +948,7 @@ WGSL uses two grammar nonterminals to separate use cases:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>ident</dfn> :
 
-    | [=syntax/ident_pattern_token=]
+    | [=syntax/ident_pattern_token=] <span class=hidden>_disambiguate_template</span>
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>member_ident</dfn> :
@@ -1159,7 +1159,26 @@ The `'>'` in `a>b` does not terminate the template list because it is enclosed i
 
 Note: Both ends of a template list must appear within the same array indexing phrase. For example `a[b<d]>()` does not contain a valid template list.
 
+After [=template list discovery=] completes,
+[[#parsing|parsing]] [=behavioral requirement|will=] attempt to match each template list to the [=syntax/template_list=] grammar rule.
 
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>template_list</dfn> :
+
+    | <a for=syntax_sym lt=_template_args_start>_template_args_start</a> [=syntax/template_arg_comma_list=] <a for=syntax_sym lt=_template_args_end>_template_args_end</a>
+</div>
+
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>template_arg_comma_list</dfn> :
+
+    | [=syntax/template_arg_expression=] ( <a for=syntax_sym lt=comma>`','`</a> [=syntax/template_arg_expression=] ) * <a for=syntax_sym lt=comma>`','`</a> ?
+</div>
+
+<div class='syntax' noexport='true'>
+  <dfn for=syntax>template_arg_expression</dfn> :
+
+    | [=syntax/expression=]
+</div>
 
 ## Attributes ## {#attributes}
 
@@ -1213,7 +1232,7 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     <td>[=shader-creation error|Must=] only be applied to an entry point
     function parameter, entry point return type, or member of a [=structure=].
 
-    Declares a built-in value with the given [=context-dependent name=].
+    Specifies that the associated object is a built-in value, as denoted by the specified [=enumerant=].
     See [[#builtin-values]].
 
   <tr><td><dfn noexport dfn-for="attribute">`const`</dfn>
@@ -1246,9 +1265,10 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
   <tr><td><dfn noexport dfn-for="attribute">`interpolate`</dfn>
     <td>One or two parameters.
 
-    The first parameter [=shader-creation error|must=] be an [=interpolation type=].
+    The first parameter [=shader-creation error|must=] be an [=enumerant=] for an [=interpolation type=].
 
-    The second parameter, if present, [=shader-creation error|must=] specify the [=interpolation sampling=].
+    The second parameter, if present, [=shader-creation error|must=] be
+    an [=enumerant=] for the [=interpolation sampling=].
 
     <td>[=shader-creation error|Must=] only be applied to a declaration that
     has a [=attribute/location=] attribute applied.
@@ -1370,7 +1390,7 @@ They take no parameters.
 
     | <a for=syntax_sym lt=attr>`'@'`</a> `'binding'` <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/expression=] [=syntax/attrib_end=]
 
-    | <a for=syntax_sym lt=attr>`'@'`</a> `'builtin'` <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/builtin_value_name=] [=syntax/attrib_end=]
+    | <a for=syntax_sym lt=attr>`'@'`</a> `'builtin'` <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/expression=] [=syntax/attrib_end=]
 
     | <a for=syntax_sym lt=attr>`'@'`</a> `'const'`
 
@@ -1378,9 +1398,9 @@ They take no parameters.
 
     | <a for=syntax_sym lt=attr>`'@'`</a> `'id'` <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/expression=] [=syntax/attrib_end=]
 
-    | <a for=syntax_sym lt=attr>`'@'`</a> `'interpolate'` <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/interpolation_type_name=] [=syntax/attrib_end=]
+    | <a for=syntax_sym lt=attr>`'@'`</a> `'interpolate'` <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/expression=] [=syntax/attrib_end=]
 
-    | <a for=syntax_sym lt=attr>`'@'`</a> `'interpolate'` <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/interpolation_type_name=] <a for=syntax_sym lt=comma>`','`</a> [=syntax/interpolation_sample_name=] [=syntax/attrib_end=]
+    | <a for=syntax_sym lt=attr>`'@'`</a> `'interpolate'` <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/expression=] <a for=syntax_sym lt=comma>`','`</a> [=syntax/expression=] [=syntax/attrib_end=]
 
     | <a for=syntax_sym lt=attr>`'@'`</a> `'invariant'`
 
@@ -1429,15 +1449,17 @@ See [[#enable-directive-section]].
 A <dfn noexport>declaration</dfn> associates an [=identifier=] with one of
 the following kinds of objects:
 * a [=type=]
+* a [=type-generator=]
 * a [=value declaration|value=]
 * a [=variable=]
 * a [=function/function=]
 * a [=formal parameter=]
+* an [=enumerant=]
 
 In other words, a declaration introduces a <dfn noexport>name</dfn> for an object.
 
-A declaration is at <dfn noexport>module scope</dfn> if the declaration appears outside
-the text of any other declaration.
+A declaration in is at <dfn noexport>module scope</dfn> if the declaration appears
+in the program source, but outside the text of any other declaration.
 
 A [=function/function=] declaration appears at module-scope.
 A function declaration contains declarations for formal parameters, if it has any,
@@ -1449,7 +1471,11 @@ Note: The only kind of declaration that contain another declaration is a [=funct
 Certain objects are provided by the WebGPU implementation, and are treated as
 if they have been declared before the start of the WGSL program source.
 We say such objects are <dfn noexport>predeclared</dfn>.
-For example, WGSL predeclares [=built-in functions=], and built-in types such as [=i32=] and [=f32=].
+For example, WGSL predeclares:
+* [=built-in functions=],
+* built-in types such as [=i32=] and [=f32=],
+* built-in [=type-generators=] such as `array`, `ptr`, and `texture_2d`, and
+* [=enumerants=] such as [=access/read_write=], [=interpolation type/perspective=], and [=texel format/rgba8unorm=].
 
 The <dfn noexport>scope</dfn> of a declaration is the set of
 program source locations where a declared identifier potentially denotes
@@ -1465,15 +1491,11 @@ Where a declaration appears determines its scope:
     For details, see [[#var-and-value]].
 
 Two declarations in the same WGSL source program [=shader-creation error|must not=] simultaneously:
-* introduce the same identifier name, and
-* have the same end-of-scope.
+* Introduce the same identifier name, and
+* Have the same end-of-scope.
 
 Note: A predeclared object does not have a declaration in the WGSL source.
-So a declaration at module-scope or inside a function can have the same
-name as a [=built-in function=].
-
-TODO(#2941): Once built-in types are not named by keywords or reserved words, then user
-declarations can also have the same name as a built-in type.
+So a user-specified declaration at module-scope or inside a function can have the same name as a predeclared object.
 
 Identifiers are used as follows, distinguished by grammatical context:
 * A token matching the [=syntax/ident=] grammar element is:
@@ -1584,6 +1606,17 @@ the text.
   </xmp>
 </div>
 
+<div class='example wgsl' heading='Shadowing predeclared objects'>
+  <xmp highlight='rust'>
+     // This declaration hides the predeclared 'min' built-in function.
+     // Since this declaration is at module-scope, it is in scope over the entire
+     // source.  The built-in function is no longer accessible.
+     fn min() -> u32 { return 0; }
+
+     const rgba8unorm = 12; // This shadows the predeclared 'rgba8unorm' enumerant.
+  </xmp>
+</div>
+
 # Types # {#types}
 
 Programs calculate values.
@@ -1603,6 +1636,10 @@ WGSL treats these as different because their machine representation and operatio
 
 A type is either [=predeclared=], or created in WGSL source via a [=declaration=].
 
+Some types are expressed as [=template parameterizations=].
+A <dfn noexport>type-generator</dfn> is a [=predeclared=] object which, when parameterized with a [=template list=], denotes a type.
+For example, the type `atomic<u32>` combines the type-generator `atomic` with template list `<u32>`.
+
 We distinguish between the *concept* of a type and the *syntax* in WGSL to denote that type.
 In many cases the spelling of a type in this specification is the same as its WGSL syntax.
 For example:
@@ -1620,7 +1657,7 @@ Note: [=Reference types=] are not written in WGSL programs. See [[#ref-ptr-types
 
 A WGSL value is computed by evaluating an expression.
 An <dfn noexport>expression</dfn> is a segment of source text
-parsed as one of the WGSL grammar rules whose name ends with "`_expression`".
+parsed as one of the WGSL grammar rules whose name ends with "`expression`".
 An expression |E| can contain <dfn noexport>subexpressions</dfn> which are expressions properly contained
 in the outer expression |E|.
 A <dfn noexport>top-level expression</dfn> is an expression that is not itself a subexpression.
@@ -2543,20 +2580,6 @@ See [[#var-and-value]].
   </xmp>
 </div>
 
-
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>array_type_specifier</dfn> :
-
-    | <a for=syntax_kw lt=array>`'array'`</a> <span class=hidden>_disambiguate_template</span> <a for=syntax_sym lt=_template_args_start>_template_args_start</a> [=syntax/type_specifier=] ( <a for=syntax_sym lt=comma>`','`</a> [=syntax/element_count_expression=] ) ? <a for=syntax_sym lt=_template_args_end>_template_args_end</a>
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>element_count_expression</dfn> :
-
-    | [=syntax/additive_expression=]
-
-    | [=syntax/bitwise_expression=]
-</div>
-
 ### Structure Types ### {#struct-types}
 
 A <dfn noexport>structure</dfn> is a named grouping of named <dfn noexport>member</dfn> values.
@@ -2735,6 +2758,8 @@ module creation|shader creation=] time.
 A type has a <dfn>fixed footprint</dfn> if its size is fully determined
 at [=pipeline creation=] time.
 
+Only [=storable=] types can have creation-fixed footprint or fixed footprint.
+
 Note: Pipeline creation depends on shader creation, so a type with [=creation-fixed footprint=] also has [=fixed footprint=].
 
 The types with [=creation-fixed footprint=] are:
@@ -2748,7 +2773,7 @@ The types with [=creation-fixed footprint=] are:
 
 Note: A [=constructible=] type has a [=creation-fixed footprint=].
 
-The plain types with [=fixed footprint=] are any of:
+The [=plain types=] with [=fixed footprint=] are any of:
 * a type with [=creation-fixed footprint=]
 * a [=fixed-size array=] type (without further constraining its [=element count=])
 
@@ -2762,6 +2787,77 @@ indirectly, while a [=constructible=] type cannot.
 
 Note: Fixed-footprint types exclude [=runtime-sized=] arrays, and any structure
 that contains a [=runtime-sized=] array.
+
+## Enumerant Type ## {#enumerants}
+
+An <dfn noexport>enumerant</dfn> is a value whose sole purpose is to be distinguished from another value.
+A set of enumerants is used distinguish among a set of distinct items.
+
+Each enumerant is distinct from all other enumerants, and distinct from all other kinds of values.
+
+WGSL has an unnamed <dfn noexport>enumerant type</dfn>.
+It contains the [=predeclared=] [=enumerant=] values as listed in the following table.
+
+<table class=data>
+<caption>
+  Predeclared enumerants
+</caption>
+<thead>
+  <tr><th>Predeclared enumerant<th>Cross-reference
+</thead>
+  <tr><td>[=access/read=]<td rowspan=3>[=access mode=]
+  <tr><td>[=access/write=]
+  <tr><td>[=access/read_write=]
+  <tr><td>[=address spaces/function=]
+      <td rowspan=5>[=address space=]
+
+      Note: The `handle` address space is never written in a WGSL program source.
+  <tr><td>[=address spaces/private=]
+  <tr><td>[=address spaces/workgroup=]
+  <tr><td>[=address spaces/uniform=]
+  <tr><td>[=address spaces/storage=]
+  <tr><td>[=interpolation type/perspective=]
+      <td rowspan=3>[=interpolation type=]
+  <tr><td>[=interpolation type/linear=]
+  <tr><td>[=interpolation type/flat=]
+  <tr><td>[=interpolation sampling/center=]
+      <td rowspan=3>[=interpolation sampling=]
+  <tr><td>[=interpolation sampling/centroid=]
+  <tr><td>[=interpolation sampling/sample=]
+  <tr><td>[=built-in values/vertex_index=]
+      <td rowspan=12>[=built-in value=]
+  <tr><td>[=built-in values/instance_index=]
+  <tr><td>[=built-in values/position=]
+  <tr><td>[=built-in values/front_facing=]
+  <tr><td>[=built-in values/frag_depth=]
+  <tr><td>[=built-in values/local_invocation_id=]
+  <tr><td>[=built-in values/local_invocation_index=]
+  <tr><td>[=built-in values/global_invocation_id=]
+  <tr><td>[=built-in values/workgroup_id=]
+  <tr><td>[=built-in values/num_workgroups=]
+  <tr><td>[=built-in values/sample_index=]
+  <tr><td>[=built-in values/sample_mask=]
+  <tr><td>[=texel format/rgba8unorm=]
+      <td rowspan=17>[=texel format=]
+  <tr><td>[=texel format/rgba8snorm=]
+  <tr><td>[=texel format/rgba8uint=]
+  <tr><td>[=texel format/rgba8sint=]
+  <tr><td>[=texel format/rgba16uint=]
+  <tr><td>[=texel format/rgba16sint=]
+  <tr><td>[=texel format/rgba16float=]
+  <tr><td>[=texel format/r32uint=]
+  <tr><td>[=texel format/r32sint=]
+  <tr><td>[=texel format/r32float=]
+  <tr><td>[=texel format/rg32uint=]
+  <tr><td>[=texel format/rg32sint=]
+  <tr><td>[=texel format/rg32float=]
+  <tr><td>[=texel format/rgba32uint=]
+  <tr><td>[=texel format/rgba32sint=]
+  <tr><td>[=texel format/rgba32float=]
+  <tr><td>[=texel format/bgra8unorm=]
+</table>
+
+WGSL does not provide a mechanism for declaring new enumerants, or another enumerant type.
 
 ## Memory Views ## {#memory-views}
 
@@ -3475,24 +3571,26 @@ The last column in the table below uses the format-specific
         <th>Channels in memory order
         <th style="width:50%">Corresponding shader value
   </thead>
-  <tr><td>rgba8unorm<td>8unorm<td>r, g, b, a<td>vec4&lt;f32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
-  <tr><td>rgba8snorm<td>8snorm<td>r, g, b, a<td>vec4&lt;f32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
-  <tr><td>rgba8uint<td>8uint<td>r, g, b, a<td>vec4&lt;u32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
-  <tr><td>rgba8sint<td>8sint<td>r, g, b, a<td>vec4&lt;i32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
-  <tr><td>rgba16uint<td>16uint<td>r, g, b, a<td>vec4&lt;u32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
-  <tr><td>rgba16sint<td>16sint<td>r, g, b, a<td>vec4&lt;i32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
-  <tr><td>rgba16float<td>16float<td>r, g, b, a<td>vec4&lt;f32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
-  <tr><td>r32uint<td>32uint<td>r<td>vec4&lt;u32&gt;(CTF(r), 0u, 0u, 1u)
-  <tr><td>r32sint<td>32sint<td>r<td>vec4&lt;i32&gt;(CTF(r), 0, 0, 1)
-  <tr><td>r32float<td>32float<td>r<td>vec4&lt;f32&gt;(CTF(r), 0.0, 0.0, 1.0)
-  <tr><td>rg32uint<td>32uint<td>r, g<td>vec4&lt;u32&gt;(CTF(r), CTF(g), 0.0, 1.0)
-  <tr><td>rg32sint<td>32sint<td>r, g<td>vec4&lt;i32&gt;(CTF(r), CTF(g), 0.0, 1.0)
-  <tr><td>rg32float<td>32float<td>r, g<td>vec4&lt;f32&gt;(CTF(r), CTF(g), 0.0, 1.0)
-  <tr><td>rgba32uint<td>32uint<td>r, g, b, a<td>vec4&lt;u32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
-  <tr><td>rgba32sint<td>32sint<td>r, g, b, a<td>vec4&lt;i32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
-  <tr><td>rgba32float<td>32float<td>r, g, b, a<td>vec4&lt;f32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
-  <tr><td>bgra8unorm<td>8unorm<td>b, g, r, a<td>vec4&lt;f32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
+  <tr><td><dfn for="texel format">rgba8unorm</dfn><td>8unorm<td>r, g, b, a<td>vec4&lt;f32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
+  <tr><td><dfn for="texel format">rgba8snorm</dfn><td>8snorm<td>r, g, b, a<td>vec4&lt;f32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
+  <tr><td><dfn for="texel format">rgba8uint</dfn><td>8uint<td>r, g, b, a<td>vec4&lt;u32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
+  <tr><td><dfn for="texel format">rgba8sint</dfn><td>8sint<td>r, g, b, a<td>vec4&lt;i32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
+  <tr><td><dfn for="texel format">rgba16uint</dfn><td>16uint<td>r, g, b, a<td>vec4&lt;u32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
+  <tr><td><dfn for="texel format">rgba16sint</dfn><td>16sint<td>r, g, b, a<td>vec4&lt;i32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
+  <tr><td><dfn for="texel format">rgba16float</dfn><td>16float<td>r, g, b, a<td>vec4&lt;f32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
+  <tr><td><dfn for="texel format">r32uint</dfn><td>32uint<td>r<td>vec4&lt;u32&gt;(CTF(r), 0u, 0u, 1u)
+  <tr><td><dfn for="texel format">r32sint</dfn><td>32sint<td>r<td>vec4&lt;i32&gt;(CTF(r), 0, 0, 1)
+  <tr><td><dfn for="texel format">r32float</dfn><td>32float<td>r<td>vec4&lt;f32&gt;(CTF(r), 0.0, 0.0, 1.0)
+  <tr><td><dfn for="texel format">rg32uint</dfn><td>32uint<td>r, g<td>vec4&lt;u32&gt;(CTF(r), CTF(g), 0.0, 1.0)
+  <tr><td><dfn for="texel format">rg32sint</dfn><td>32sint<td>r, g<td>vec4&lt;i32&gt;(CTF(r), CTF(g), 0.0, 1.0)
+  <tr><td><dfn for="texel format">rg32float</dfn><td>32float<td>r, g<td>vec4&lt;f32&gt;(CTF(r), CTF(g), 0.0, 1.0)
+  <tr><td><dfn for="texel format">rgba32uint</dfn><td>32uint<td>r, g, b, a<td>vec4&lt;u32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
+  <tr><td><dfn for="texel format">rgba32sint</dfn><td>32sint<td>r, g, b, a<td>vec4&lt;i32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
+  <tr><td><dfn for="texel format">rgba32float</dfn><td>32float<td>r, g, b, a<td>vec4&lt;f32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
+  <tr><td><dfn for="texel format">bgra8unorm</dfn><td>8unorm<td>b, g, r, a<td>vec4&lt;f32&gt;(CTF(r), CTF(g), CTF(b), CTF(a))
 </table>
+
+WGSL [=predeclared|predeclares=] an [=enumerant=] for each of the texel formats in the table.
 
 ### Sampled Texture Types ### {#sampled-texture-type}
 
@@ -3600,71 +3698,27 @@ sampler
 sampler_comparison
 </pre>
 
-### Texture and Sampler Types Grammar ### {#texture-and-sampler-types-grammar}
+## AllTypes Type ## {#alltypes-type}
 
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texture_and_sampler_types</dfn> :
+The <dfn noexport>AllTypes</dfn> type is the set of all WGSL [=types=].
 
-    | [=syntax/sampler_type=]
+There is no way to write the AllTypes type in WGSL source.
 
-    | [=syntax/depth_texture_type=]
+See [[#predeclared-types]] for the list of all [=predeclared=] types and [=type-generators=].
 
-    | [=syntax/sampled_texture_type=] <span class=hidden>_disambiguate_template</span> <a for=syntax_sym lt=_template_args_start>_template_args_start</a> [=syntax/type_specifier=] <a for=syntax_sym lt=_template_args_end>_template_args_end</a>
+<div class=note>
+<p>
+Note: A type is not a value in an ordinary sense.
+It is not data that is manipulated by a shader at runtime.
 
-    | [=syntax/multisampled_texture_type=] <span class=hidden>_disambiguate_template</span> <a for=syntax_sym lt=_template_args_start>_template_args_start</a> [=syntax/type_specifier=] <a for=syntax_sym lt=_template_args_end>_template_args_end</a>
+<p>
+Instead, the AllTypes type exists so [=type checking=] rules will apply to any phrase that *may* contain an ordinary value.
+WGSL makes the rules consistent by defining a type to be a kind of value, and allowing an expression to denote a type.
 
-    | [=syntax/storage_texture_type=] <span class=hidden>_disambiguate_template</span> <a for=syntax_sym lt=_template_args_start>_template_args_start</a> [=syntax/texel_format=] <a for=syntax_sym lt=comma>`','`</a> [=syntax/access_mode=] <a for=syntax_sym lt=_template_args_end>_template_args_end</a>
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>sampler_type</dfn> :
-
-    | <a for=syntax_kw lt=sampler>`'sampler'`</a>
-
-    | <a for=syntax_kw lt=sampler_comparison>`'sampler_comparison'`</a>
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>sampled_texture_type</dfn> :
-
-    | <a for=syntax_kw lt=texture_1d>`'texture_1d'`</a>
-
-    | <a for=syntax_kw lt=texture_2d>`'texture_2d'`</a>
-
-    | <a for=syntax_kw lt=texture_2d_array>`'texture_2d_array'`</a>
-
-    | <a for=syntax_kw lt=texture_3d>`'texture_3d'`</a>
-
-    | <a for=syntax_kw lt=texture_cube>`'texture_cube'`</a>
-
-    | <a for=syntax_kw lt=texture_cube_array>`'texture_cube_array'`</a>
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>multisampled_texture_type</dfn> :
-
-    | <a for=syntax_kw lt=texture_multisampled_2d>`'texture_multisampled_2d'`</a>
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>storage_texture_type</dfn> :
-
-    | <a for=syntax_kw lt=texture_storage_1d>`'texture_storage_1d'`</a>
-
-    | <a for=syntax_kw lt=texture_storage_2d>`'texture_storage_2d'`</a>
-
-    | <a for=syntax_kw lt=texture_storage_2d_array>`'texture_storage_2d_array'`</a>
-
-    | <a for=syntax_kw lt=texture_storage_3d>`'texture_storage_3d'`</a>
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>depth_texture_type</dfn> :
-
-    | <a for=syntax_kw lt=texture_depth_2d>`'texture_depth_2d'`</a>
-
-    | <a for=syntax_kw lt=texture_depth_2d_array>`'texture_depth_2d_array'`</a>
-
-    | <a for=syntax_kw lt=texture_depth_cube>`'texture_depth_cube'`</a>
-
-    | <a for=syntax_kw lt=texture_depth_cube_array>`'texture_depth_cube_array'`</a>
-
-    | <a for=syntax_kw lt=texture_depth_multisampled_2d>`'texture_depth_multisampled_2d'`</a>
+<p>
+The motivating case is a [=template parameter=], which in various contexts may denote several kinds of things,
+including a [=type=], an [=enumerant=], or a [=plain type|plain=] value.
+In particular, the [=syntax/template_arg_expression=] grammar rule expands to the [=syntax/expression=] grammar nonterminal.
 </div>
 
 ## Type Aliases ## {#type-aliases}
@@ -3697,73 +3751,92 @@ all properties of the members of *S*, including attributes, carry over to the me
 
 ## Type Specifier Grammar ## {#type-specifiers}
 
+See [[#type-expr]].
+
 <div class='syntax' noexport='true'>
   <dfn for=syntax>type_specifier</dfn> :
 
-    | [=syntax/ident=]
-
-    | [=syntax/type_specifier_without_ident=]
+    | [=syntax/template_elaborated_ident=]
 </div>
 
 <div class='syntax' noexport='true'>
-  <dfn for=syntax>type_specifier_without_ident</dfn> :
+  <dfn for=syntax>template_elaborated_ident</dfn> :
 
-    | <a for=syntax_kw lt=bool>`'bool'`</a>
-
-    | <a for=syntax_kw lt=f32>`'f32'`</a>
-
-    | <a for=syntax_kw lt=f16>`'f16'`</a>
-
-    | <a for=syntax_kw lt=i32>`'i32'`</a>
-
-    | <a for=syntax_kw lt=u32>`'u32'`</a>
-
-    | [=syntax/vec_prefix=] <span class=hidden>_disambiguate_template</span> <a for=syntax_sym lt=_template_args_start>_template_args_start</a> [=syntax/type_specifier=] <a for=syntax_sym lt=_template_args_start>_template_args_end</a>
-
-    | [=syntax/mat_prefix=] <span class=hidden>_disambiguate_template</span> <a for=syntax_sym lt=_template_args_start>_template_args_start</a> [=syntax/type_specifier=] <a for=syntax_sym lt=_template_args_end>_template_args_end</a>
-
-    | <a for=syntax_kw lt=ptr>`'ptr'`</a> <span class=hidden>_disambiguate_template</span> <a for=syntax_sym lt=_template_args_start>_template_args_start</a> [=syntax/address_space=] <a for=syntax_sym lt=comma>`','`</a> [=syntax/type_specifier=] ( <a for=syntax_sym lt=comma>`','`</a> [=syntax/access_mode=] ) ? <a for=syntax_sym lt=_template_args_end>_template_args_end</a>
-
-    | [=syntax/array_type_specifier=]
-
-    | <a for=syntax_kw lt=atomic>`'atomic'`</a> <span class=hidden>_disambiguate_template</span> <a for=syntax_sym lt=_template_args_start>_template_args_start</a> [=syntax/type_specifier=] <a for=syntax_sym lt=_template_args_end>_template_args_end</a>
-
-    | [=syntax/texture_and_sampler_types=]
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>vec_prefix</dfn> :
-
-    | <a for=syntax_kw lt=vec2>`'vec2'`</a>
-
-    | <a for=syntax_kw lt=vec3>`'vec3'`</a>
-
-    | <a for=syntax_kw lt=vec4>`'vec4'`</a>
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>mat_prefix</dfn> :
-
-    | <a for=syntax_kw lt=mat2x2>`'mat2x2'`</a>
-
-    | <a for=syntax_kw lt=mat2x3>`'mat2x3'`</a>
-
-    | <a for=syntax_kw lt=mat2x4>`'mat2x4'`</a>
-
-    | <a for=syntax_kw lt=mat3x2>`'mat3x2'`</a>
-
-    | <a for=syntax_kw lt=mat3x3>`'mat3x3'`</a>
-
-    | <a for=syntax_kw lt=mat3x4>`'mat3x4'`</a>
-
-    | <a for=syntax_kw lt=mat4x2>`'mat4x2'`</a>
-
-    | <a for=syntax_kw lt=mat4x3>`'mat4x3'`</a>
-
-    | <a for=syntax_kw lt=mat4x4>`'mat4x4'`</a>
+    | [=syntax/ident=] <span class=hidden>_disambiguate_template</span> [=syntax/template_list=] ?
 </div>
 
-When the type is named by an [=identifier=], the use of the identifier [=shader-creation error|must=] be [=in scope=]
-of a [=type alias=] or a [=structure=] type declaration for that name.
-See [[#declaration-and-scope]].
+Note: An [=expression=] can also denote a type, by expanding via the [=syntax/primary_expression=] grammar rule to [=syntax/template_elaborated_ident=],
+and via [[#parenthesized-expressions|parenthesization]].
+
+## Predeclared Types and Type-Generators Summary ## {#predeclared-types}
+
+The [=predeclared=] [=types=] are listed in the following table:
+
+<table class=data>
+<caption>Predeclared types</caption>
+<thead>
+  <tr><th>Predeclared type<th>Cross-reference
+</thead>
+  <tr><td>[=bool=]<td>See [[#bool-type]]
+  <tr><td>[=f16=]<td rowspan=2>See [[#floating-point-types]]
+  <tr><td>[=f32=]
+  <tr><td>[=i32=]<td>See [[#integer-types]]
+  <tr><td>[=type/sampler=]<td rowspan=2>See [[#sampler-type]]
+  <tr><td>[=type/sampler_comparison=]
+  <tr><td>texture_depth_2d<td rowspan=4>See [[#sampled-texture-type]]
+  <tr><td>texture_depth_2d_array
+  <tr><td>texture_depth_cube
+  <tr><td>texture_depth_cube_array
+  <tr><td>texture_depth_multisampled_2d<td>See [[#multisampled-texture-type]]
+  <tr><td>texture_external<td>See [[#external-texture-type]]
+  <tr><td>[=u32=]<td>See [[#integer-types]]
+</table>
+
+TODO: Editorial: Make dfn nodes for each predeclared type.
+
+The predeclared [=type-generators=] are listed in the following table:
+<table class=data>
+<caption>
+  Predeclared type generators
+</caption>
+<thead>
+  <tr><th>Predeclared type-generator<th>Cross-reference
+</thead>
+  <tr><td>array<td>See [[#array-types]]
+  <tr><td>atomic<td>See [[#atomic-types]]
+  <tr><td>mat2x2<td rowspan=9>See [[#matrix-types]], which also lists 
+     predeclared [=type aliases|aliases=] for matrix types.
+
+     Note: These are also used in [=value constructor=] expressions
+     to create matrices.
+  <tr><td>mat2x3
+  <tr><td>mat2x4
+  <tr><td>mat3x2
+  <tr><td>mat3x3
+  <tr><td>mat3x4
+  <tr><td>mat4x2
+  <tr><td>mat4x3
+  <tr><td>mat4x4
+  <tr><td>ptr<td>See [[#ref-ptr-types]]
+  <tr><td>texture_1d<td rowspan=6>See [[#sampled-texture-type]]
+  <tr><td>texture_2d
+  <tr><td>texture_2d_array
+  <tr><td>texture_3d
+  <tr><td>texture_cube
+  <tr><td>texture_cube_array
+  <tr><td>texture_multisampled_2d<td>See [[#multisampled-texture-type]]
+  <tr><td>texture_storage_1d<td rowspan=4>See [[#texture-storage]]
+  <tr><td>texture_storage_2d
+  <tr><td>texture_storage_2d_array
+  <tr><td>texture_storage_3d
+  <tr><td>vec2<td rowspan=3>See [[#vector-types]], which also lists
+     predeclared [=type aliases|aliases=] for vector types.
+
+     Note: These are also used in [=value constructor=] expressions
+     to create vectors.
+  <tr><td>vec3
+  <tr><td>vec4
+</table>
 
 # Variable and Value Declarations # {#var-and-value}
 
@@ -4136,6 +4209,12 @@ is an expression denoting the reference [=memory view=] for the variable’s mem
 and its type is the variable’s [=reference type=].
 See [[#var-identifier-expr]].
 
+If the [=address space=] or [=access mode=] for a variable declaration are specified
+in program source, they are written as a [=template list=] after the `var` keyword:
+* The [=address space=] is specified first, as one of the [=predeclared=] address space [=enumerants=].
+* The [=access mode=] is specified second, if present, as one of the [=predeclared=] address mode [=enumerants=].
+    * The address space must be specified if the access mode is specified.
+
 Variables in the [=address spaces/private=], [=address spaces/storage=],
 [=address spaces/uniform=], [=address spaces/workgroup=], and [=address
 spaces/handle=] address spaces must only be declared in [=module scope=], while
@@ -4330,19 +4409,13 @@ such that the redundant loads are eliminated.
 <div class='syntax' noexport='true'>
   <dfn for=syntax>variable_decl</dfn> :
 
-    | <a for=syntax_kw lt=var>`'var'`</a> <span class=hidden>_disambiguate_template</span> [=syntax/variable_qualifier=] ? [=syntax/optionally_typed_ident=]
+    | <a for=syntax_kw lt=var>`'var'`</a> <span class=hidden>_disambiguate_template</span> [=syntax/template_list=] ? [=syntax/optionally_typed_ident=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>optionally_typed_ident</dfn> :
 
     | [=syntax/ident=] ( <a for=syntax_sym lt=colon>`':'`</a> [=syntax/type_specifier=] ) ?
 </div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>variable_qualifier</dfn> :
-
-    | <a for=syntax_sym lt=_template_args_start>_template_args_start</a> [=syntax/address_space=] ( <a for=syntax_sym lt=comma>`','`</a> [=syntax/access_mode=] ) ? <a for=syntax_sym lt=_template_args_end>_template_args_end</a>
-</div>
-
 <div class='syntax' noexport='true'>
   <dfn for=syntax>global_variable_decl</dfn> :
 
@@ -4605,7 +4678,9 @@ the indeterminate value produced at runtime may be a NaN value.
 ## Value Constructor Expressions ## {#value-constructor-expr}
 
 A <dfn noexport>value constructor</dfn> expression explicitly creates a value of a given [=type/concrete=] [=constructible=] type.
-It is a [=syntax/call_expression=] where the [=syntax/callable=] item names a [=type=].
+It is a [=syntax/call_expression=] where the called item (a [=syntax/template_elaborated_ident=]) names a [=type=] or a [=type-generator=].
+Not all types and type-generators are valid.
+Only the [=overloads=] listed in the following sections are valid as type constructors.
 
 There are three kinds of constructor expressions:
 * [[#construction-from-components]]
@@ -6321,13 +6396,52 @@ The <dfn noexport>indirection</dfn> operator converts a pointer to its correspon
            is evaluated each time control flow reaches the declaration.<br>
 </table>
 
+## Type Expressions ## {#type-expr}
+
+<table class='data'>
+  <caption>Type expressions</caption>
+  <thead>
+    <tr><th>Precondition<th>Conclusion<th>Description
+  </thead>
+    <tr algorithm="predeclared type expression">
+        <td>|t| is an [=identifier=] resolving to a [=predeclared=] [=type=]
+        <td>|t| : [=AllTypes=]
+        <td>See [[#predeclared-types]]
+    <tr algorithm="type alias expression">
+        <td>|a| is an [=identifier=] resolving to a [=type alias=].
+        <td>|a| : [=AllTypes=]
+        <td>Additionally, |a| denotes the type to which it is aliased.
+    <tr algorithm="structure type expression">
+        <td>|s| is an [=identifier=] resolving to the declaration of a [=structure=] type.
+        <td>|s| : [=AllTypes=]
+        <td>Additionally, |s| denotes the structure type.
+    <tr algorithm="predeclared type generator expression no trailing comma">
+        <td rowspan=2>|tg| is an [=identifier=] resolving to a [=type-generator=]
+
+            |e1|: |T1|<br>
+              ...<br>
+            |eN|: <var ignore>TN</var>
+        <td>|tg| [=syntax_sym/_template_args_start=]<br>|e1|,<br>...,<br>|eN|<br> [=syntax_sym/_template_args_end=]<br>: [=AllTypes=]
+        <td rowspan=2>Each [=type-generator=] has its own requirements on the template parameters it requires and accepts,
+            and defines how the template paramters help determine the resulting type.
+
+            The expressions |e1| through |eN| are the [=template parameters=] for the type-generator.
+          
+            For example, the type expression `vec2<f32>` is the [=vector=] of two [=f32=] elements.
+
+            See [[#predeclared-types]] for the list of predeclared type-generators.
+
+            Note: The two variants here differ only in whether they have a trailing comma after |eN|.
+    <tr algorithm="predeclared type generator expression trailing comma">
+        <td><var ignore>tg</var> [=syntax_sym/_template_args_start=]<br>|e1|,<br>...,<br>|eN|,<br> [=syntax_sym/_template_args_end=]<br>: [=AllTypes=]
+</table>
 
 ## Expression Grammar Summary ## {#expression-grammar}
 
-When an identifier is used as a [=syntax/callable=] item, it is one of:
+When an [=identifier=] is the first [=token=] in a [=syntax/call_phrase=], it is one of:
 * The name of a [=user-defined function=] or [=built-in function=],
     as part of a [=function call=].
-* The name of a [[#struct-types|structure type]] or a [[#type-aliases|type alias]],
+* The name of a [=type=], [[#type-aliases|type alias]], or [=type-generator=],
     as part of a [=value constructor=] expression.
 
 [[#declaration-and-scope|Declaration and scope]] rules ensure those names are always distinct.
@@ -6335,7 +6449,7 @@ When an identifier is used as a [=syntax/callable=] item, it is one of:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>primary_expression</dfn> :
 
-    | [=syntax/ident=]
+    | [=syntax/template_elaborated_ident=]
 
     | [=syntax/call_expression=]
 
@@ -6354,20 +6468,7 @@ Note: The [=syntax/call_expression=] rule exists to ensure [=type checking=] app
 <div class='syntax' noexport='true'>
   <dfn for=syntax>call_phrase</dfn> :
 
-    | [=syntax/callable=] [=syntax/argument_expression_list=]
-</div>
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>callable</dfn> :
-
-    | [=syntax/ident=]
-
-    | [=syntax/type_specifier_without_ident=]
-
-    | [=syntax/vec_prefix=] <span class=hidden>_disambiguate_template</span>
-
-    | [=syntax/mat_prefix=] <span class=hidden>_disambiguate_template</span>
-
-    | <a for=syntax_kw lt=array>`'array'`</a> <span class=hidden>_disambiguate_template</span>
+    | [=syntax/template_elaborated_ident=] [=syntax/argument_expression_list=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>paren_expression</dfn> :
@@ -6425,7 +6526,7 @@ Note: The [=syntax/call_expression=] rule exists to ensure [=type checking=] app
 <div class='syntax' noexport='true'>
   <dfn for=syntax>core_lhs_expression</dfn> :
 
-    | [=syntax/ident=]
+    | [=syntax/ident=] <span class=hidden>_disambiguate_template</span>
 
     | <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/lhs_expression=] <a for=syntax_sym lt=paren_right>`')'`</a>
 </div>
@@ -6465,9 +6566,9 @@ Note: The [=syntax/call_expression=] rule exists to ensure [=type checking=] app
 
     | [=syntax/additive_expression=]
 
-    | [=syntax/unary_expression=] <a for=syntax_sym lt=shift_left>`'<<'`</a> [=syntax/unary_expression=]
+    | [=syntax/unary_expression=] <a for=syntax_sym lt=shift_left>_shift_left</a> [=syntax/unary_expression=]
 
-    | [=syntax/unary_expression=] <a for=syntax_sym lt=shift_right>`'>>'`</a> [=syntax/unary_expression=]
+    | [=syntax/unary_expression=] <a for=syntax_sym lt=shift_right>_shift_right</a> [=syntax/unary_expression=]
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>relational_expression</dfn> :
@@ -8122,7 +8223,7 @@ parameters and return types:
 <div class='syntax' noexport='true'>
   <dfn for=syntax>function_header</dfn> :
 
-    | <a for=syntax_kw lt=fn>`'fn'`</a> [=syntax/ident=] <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/param_list=] ? <a for=syntax_sym lt=paren_right>`')'`</a> ( <a for=syntax_sym lt=arrow>`'->'`</a> [=syntax/attribute=] * [=syntax/type_specifier=] ) ?
+    | <a for=syntax_kw lt=fn>`'fn'`</a> [=syntax/ident=] <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/param_list=] ? <a for=syntax_sym lt=paren_right>`')'`</a> ( <a for=syntax_sym lt=arrow>`'->'`</a> [=syntax/attribute=] * [=syntax/template_elaborated_ident=] ) ?
 </div>
 <div class='syntax' noexport='true'>
   <dfn for=syntax>param_list</dfn> :
@@ -8783,18 +8884,24 @@ the [=attribute/interpolate=] attribute.
 WGSL offers two aspects of interpolation to control: the type of
 interpolation, and the sampling of the interpolation.
 
-The <dfn noexport>interpolation type</dfn> [=shader-creation error|must=] be one of:
-* `perspective` - Values are interpolated in a perspective correct manner.
-* `linear` - Values are interpolated in a linear, non-perspective correct manner.
-* `flat` - Values are not interpolated.
+The <dfn noexport>interpolation type</dfn> [=shader-creation error|must=] be one of the following [=predeclared=] [=enumerants=]:
+: <dfn for="interpolation type">perspective</dfn>
+:: Values are interpolated in a perspective correct manner.
+: <dfn for="interpolation type">linear</dfn>
+:: Values are interpolated in a linear, non-perspective correct manner.
+: <dfn for="interpolation type">flat</dfn>
+:: Values are not interpolated.
     Interpolation sampling is not used with `flat` interpolation.
 
-The <dfn noexport>interpolation sampling</dfn> [=shader-creation error|must=] be one of:
-* `center` - Interpolation is performed at the center of the pixel.
-* `centroid` - Interpolation is performed at a point that lies within all the
+The <dfn noexport>interpolation sampling</dfn> [=shader-creation error|must=] be one of the following [=predeclared=] [=enumerants=]:
+: <dfn for="interpolation sampling">center</dfn>
+:: Interpolation is performed at the center of the pixel.
+: <dfn for="interpolation sampling">centroid</dfn>
+:: Interpolation is performed at a point that lies within all the
     samples covered by the fragment within the current primitive.
     This value is the same for all samples in the primitive.
-* `sample` - Interpolation is performed per sample.
+: <dfn for="interpolation sampling">sample</dfn>
+:: Interpolation is performed per sample.
     The [=fragment=] shader is invoked once per sample when this attribute is
     applied.
 
@@ -9092,8 +9199,7 @@ as the memory's <dfn noexport>access mode</dfn>.
       <td>Supports both read and write accesses.
 </table>
 
-When a [=token=] matches the [=syntax/access_mode=] grammar nonterminal, it is considered a [=context-dependent name=].
-In particular, the token does not [=resolve=] to any declared object.
+WGSL [=predeclared|predeclares=] the [=enumerants=] `read`, `write`, and `read_write`.
 
 ## Address Spaces ## {#address-space}
 
@@ -9145,10 +9251,7 @@ table.
       <td>For [=sampler resource|sampler=] and [=texture resource|texture=] variables.<br>
 </table>
 
-When a [=token=] matches the [=syntax/address_space=] grammar nonterminal, it is considered a [=context-dependent name=].
-In particular, the token does not [=resolve=] to any declared object.
-
-Note: The token `handle` is reserved: it is never used in a WGSL program.
+WGSL [=predeclared|predeclares=] an [=enumerant=] for each address space, except for the `handle` address space.
 
 Note: Each address space may have different performance characteristics.
 
@@ -11264,49 +11367,6 @@ the source type is a floating point type with fewer exponent and mantissa bits t
 
 ## Keyword Summary ## {#keyword-summary}
 
-### Type-defining Keywords ### {#type-defining-keywords}
-
-* <dfn for=syntax_kw noexport>`array`</dfn>
-* <dfn for=syntax_kw noexport>`atomic`</dfn>
-* <dfn for=syntax_kw noexport>`bool`</dfn>
-* <dfn for=syntax_kw noexport>`f32`</dfn>
-* <dfn for=syntax_kw noexport>`f16`</dfn>
-* <dfn for=syntax_kw noexport>`i32`</dfn>
-* <dfn for=syntax_kw noexport>`mat2x2`</dfn>
-* <dfn for=syntax_kw noexport>`mat2x3`</dfn>
-* <dfn for=syntax_kw noexport>`mat2x4`</dfn>
-* <dfn for=syntax_kw noexport>`mat3x2`</dfn>
-* <dfn for=syntax_kw noexport>`mat3x3`</dfn>
-* <dfn for=syntax_kw noexport>`mat3x4`</dfn>
-* <dfn for=syntax_kw noexport>`mat4x2`</dfn>
-* <dfn for=syntax_kw noexport>`mat4x3`</dfn>
-* <dfn for=syntax_kw noexport>`mat4x4`</dfn>
-* <dfn for=syntax_kw noexport>`ptr`</dfn>
-* <dfn for=syntax_kw noexport>`sampler`</dfn>
-* <dfn for=syntax_kw noexport>`sampler_comparison`</dfn>
-* <dfn for=syntax_kw noexport>`texture_1d`</dfn>
-* <dfn for=syntax_kw noexport>`texture_2d`</dfn>
-* <dfn for=syntax_kw noexport>`texture_2d_array`</dfn>
-* <dfn for=syntax_kw noexport>`texture_3d`</dfn>
-* <dfn for=syntax_kw noexport>`texture_cube`</dfn>
-* <dfn for=syntax_kw noexport>`texture_cube_array`</dfn>
-* <dfn for=syntax_kw noexport>`texture_multisampled_2d`</dfn>
-* <dfn for=syntax_kw noexport>`texture_storage_1d`</dfn>
-* <dfn for=syntax_kw noexport>`texture_storage_2d`</dfn>
-* <dfn for=syntax_kw noexport>`texture_storage_2d_array`</dfn>
-* <dfn for=syntax_kw noexport>`texture_storage_3d`</dfn>
-* <dfn for=syntax_kw noexport>`texture_depth_2d`</dfn>
-* <dfn for=syntax_kw noexport>`texture_depth_2d_array`</dfn>
-* <dfn for=syntax_kw noexport>`texture_depth_cube`</dfn>
-* <dfn for=syntax_kw noexport>`texture_depth_cube_array`</dfn>
-* <dfn for=syntax_kw noexport>`texture_depth_multisampled_2d`</dfn>
-* <dfn for=syntax_kw noexport>`u32`</dfn>
-* <dfn for=syntax_kw noexport>`vec2`</dfn>
-* <dfn for=syntax_kw noexport>`vec3`</dfn>
-* <dfn for=syntax_kw noexport>`vec4`</dfn>
-
-### Other Keywords ### {#other-keywords}
-
 * <dfn for=syntax_kw noexport>`alias`</dfn>
 * <dfn for=syntax_kw noexport>`bitcast`</dfn>
 * <dfn for=syntax_kw noexport>`break`</dfn>
@@ -11401,11 +11461,11 @@ The [=syntactic tokens=] are:
 * <dfn for=syntax_sym lt='_template_args_end' noexport>`_template_args_end`</dfn>
     * Text:  `'>'` (Code point: `U+003E`)
     * This token is textually the same as the [=syntax_sym/greater_than=] syntactic token.
-    * It is generated by [=template list discovery=], and is used as the last token in a [=template list=].
+    * It is generated by template list disambiguation, and is used as the last token in a template list.
 * <dfn for=syntax_sym lt='_template_args_start' noexport>`_template_args_start`</dfn>
     * Text: `'<'` (Code point: `U+003C`)
     * This token is textually the same as the [=syntax_sym/less_than=] syntactic token.
-    * It is generated by [=template list discovery=], and is used as the first token in a [=template list=].
+    * It is generated by template list disambiguation, and is used as the first token in a template list.
 
 ## Context-Dependent Name Tokens ## {#context-dependent-name-tokens}
 
@@ -11427,124 +11487,6 @@ The [=syntax/attribute=] names are:
 * `'size'`
 * `'vertex'`
 * `'workgroup_size'`
-
-The [=interpolation type=] names are:
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>interpolation_type_name</dfn> :
-
-    | `'perspective'`
-
-    | `'linear'`
-
-    | `'flat'`
-</div>
-
-The [=interpolation sampling=] names are:
-
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>interpolation_sample_name</dfn> :
-
-    | `'center'`
-
-    | `'centroid'`
-
-    | `'sample'`
-</div>
-
-The [[#builtin-values|built-in value]] names are:
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>builtin_value_name</dfn> :
-
-    | `'vertex_index'`
-
-    | `'instance_index'`
-
-    | `'position'`
-
-    | `'front_facing'`
-
-    | `'frag_depth'`
-
-    | `'local_invocation_id'`
-
-    | `'local_invocation_index'`
-
-    | `'global_invocation_id'`
-
-    | `'workgroup_id'`
-
-    | `'num_workgroups'`
-
-    | `'sample_index'`
-
-    | `'sample_mask'`
-</div>
-
-The [=Access mode|access mode=] names are:
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>access_mode</dfn> :
-
-    | `'read'`
-
-    | `'write'`
-
-    | `'read_write'`
-</div>
-
-
-The [=address space=] names are:
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>address_space</dfn> :
-
-    | `'function'`
-
-    | `'private'`
-
-    | `'workgroup'`
-
-    | `'uniform'`
-
-    | `'storage'`
-</div>
-
-The [=texel format=] names are:
-<div class='syntax' noexport='true'>
-  <dfn for=syntax>texel_format</dfn> :
-
-    | `'rgba8unorm'`
-
-    | `'rgba8snorm'`
-
-    | `'rgba8uint'`
-
-    | `'rgba8sint'`
-
-    | `'rgba16uint'`
-
-    | `'rgba16sint'`
-
-    | `'rgba16float'`
-
-    | `'r32uint'`
-
-    | `'r32sint'`
-
-    | `'r32float'`
-
-    | `'rg32uint'`
-
-    | `'rg32sint'`
-
-    | `'rg32float'`
-
-    | `'rgba32uint'`
-
-    | `'rgba32sint'`
-
-    | `'rgba32float'`
-
-    | `'bgra8unorm'`
-</div>
 
 The [=extension=] names are:
 
@@ -11580,16 +11522,17 @@ The [=swizzle=] names are used in [[#vector-access-expr|vector access expression
 # Built-in Values # {#builtin-values}
 
 The following table lists the available [=built-in values=].
+Each is a [=predeclared=] [=enumerant=].
 
-See [[#builtin-inputs-outputs]] for how to declare a built-in value.
+See [[#builtin-inputs-outputs]] for how to specify that a pipeline input or output is a built-in value.
 
 <table class='data'>
   <caption>Built-in input and output values</caption>
   <thead>
-    <tr><th>Name<th>Stage<th>Input or Output<th>Type<th>Description
+    <tr><th>Predeclared Name<th>Stage<th>Input or Output<th>Type<th>Description
   </thead>
 
-  <tr><td><dfn noexport dfn-for="built-in values">`vertex_index`</dfn>
+  <tr><td><dfn noexport dfn-for="built-in values">vertex_index</dfn>
       <td>vertex
       <td>input
       <td>u32
@@ -11603,7 +11546,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in value.
          For an indexed draw, the index is equal to the index buffer entry for the
          vertex, plus the `baseVertex` argument of the draw, whether provided directly or indirectly.
 
-  <tr><td><dfn noexport dfn-for="built-in values">`instance_index`</dfn>
+  <tr><td><dfn noexport dfn-for="built-in values">instance_index</dfn>
       <td>vertex
       <td>input
       <td>u32
@@ -11613,7 +11556,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in value.
          whether provided directly or indirectly.
          The index is incremented by one for each additional instance in the draw.
 
-  <tr><td rowspan=2><dfn noexport dfn-for="built-in values">`position`</dfn>
+  <tr><td rowspan=2><dfn noexport dfn-for="built-in values">position</dfn>
       <td>vertex
       <td>output
       <td>vec4&lt;f32&gt;
@@ -11631,49 +11574,49 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in value.
       (The *x*, *y*, and *z* components have already been scaled such that *w* is now 1.)
       See [[WebGPU#coordinate-systems]].
 
-  <tr><td><dfn noexport dfn-for="built-in values">`front_facing`</dfn>
+  <tr><td><dfn noexport dfn-for="built-in values">front_facing</dfn>
       <td>fragment
       <td>input
       <td>bool
       <td style="width:50%">True when the current fragment is on a [=front-facing=] primitive.
          False otherwise.
 
-  <tr><td><dfn noexport dfn-for="built-in values">`frag_depth`</dfn>
+  <tr><td><dfn noexport dfn-for="built-in values">frag_depth</dfn>
       <td>fragment
       <td>output
       <td>f32
       <td style="width:50%">Updated depth of the fragment, in the viewport depth range.
       See [[WebGPU#coordinate-systems]].
 
-  <tr><td><dfn noexport dfn-for="built-in values">`local_invocation_id`</dfn>
+  <tr><td><dfn noexport dfn-for="built-in values">local_invocation_id</dfn>
       <td>compute
       <td>input
       <td>vec3&lt;u32&gt;
       <td style="width:50%">The current invocation's [=local invocation ID=],
             i.e. its position in the [=workgroup grid=].
 
-  <tr><td><dfn noexport dfn-for="built-in values">`local_invocation_index`</dfn>
+  <tr><td><dfn noexport dfn-for="built-in values">local_invocation_index</dfn>
       <td>compute
       <td>input
       <td>u32
       <td style="width:50%">The current invocation's [=local invocation index=], a linearized index of
           the invocation's position within the [=workgroup grid=].
 
-  <tr><td><dfn noexport dfn-for="built-in values">`global_invocation_id`</dfn>
+  <tr><td><dfn noexport dfn-for="built-in values">global_invocation_id</dfn>
       <td>compute
       <td>input
       <td>vec3&lt;u32&gt;
       <td style="width:50%">The current invocation's [=global invocation ID=],
           i.e. its position in the [=compute shader grid=].
 
-  <tr><td><dfn noexport dfn-for="built-in values">`workgroup_id`</dfn>
+  <tr><td><dfn noexport dfn-for="built-in values">workgroup_id</dfn>
       <td>compute
       <td>input
       <td>vec3&lt;u32&gt;
       <td style="width:50%">The current invocation's [=workgroup ID=],
           i.e. the position of the workgroup in the [=workgroup grid=].
 
-  <tr><td><dfn noexport dfn-for="built-in values">`num_workgroups`</dfn>
+  <tr><td><dfn noexport dfn-for="built-in values">num_workgroups</dfn>
       <td>compute
       <td>input
       <td>vec3&lt;u32&gt;
@@ -11681,7 +11624,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in value.
       group_count_y, group_count_z)`, of the compute shader
       [[WebGPU#compute-pass-encoder-dispatch|dispatched]] by the API.
 
-  <tr><td><dfn noexport dfn-for="built-in values">`sample_index`</dfn>
+  <tr><td><dfn noexport dfn-for="built-in values">sample_index</dfn>
       <td>fragment
       <td>input
       <td>u32
@@ -11691,7 +11634,7 @@ See [[#builtin-inputs-outputs]] for how to declare a built-in value.
          specified for the GPU render pipeline.
          <br>See [[WebGPU#gpurenderpipeline]].
 
-  <tr><td rowspan=2><dfn noexport dfn-for="built-in values">`sample_mask`</dfn>
+  <tr><td rowspan=2><dfn noexport dfn-for="built-in values">sample_mask</dfn>
       <td>fragment
       <td>input
       <td>u32

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3770,7 +3770,7 @@ and via [[#parenthesized-expressions|parenthesization]].
 
 ## Predeclared Types and Type-Generators Summary ## {#predeclared-types}
 
-The [=predeclared=] [=types=] are listed in the following table:
+The [=predeclared=] [=types=] that can be spelled in WGSL source are listed in the following table:
 
 <table class=data>
 <caption>Predeclared types</caption>
@@ -3791,6 +3791,9 @@ The [=predeclared=] [=types=] are listed in the following table:
   <tr><td>texture_external<td>See [[#external-texture-type]]
   <tr><td>[=u32=]<td>See [[#integer-types]]
 </table>
+
+WGSL also predeclares the return types for the [[#frexp-builtin|frexp]] and [[#modf-builtin|modf]] built-in functions.
+However, they cannot be spelled in WGSL source.
 
 TODO: Editorial: Make dfn nodes for each predeclared type.
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2788,44 +2788,56 @@ indirectly, while a [=constructible=] type cannot.
 Note: Fixed-footprint types exclude [=runtime-sized=] arrays, and any structure
 that contains a [=runtime-sized=] array.
 
-## Enumerant Type ## {#enumerants}
+## Enumerantion Types ## {#enumerants}
 
-An <dfn noexport>enumerant</dfn> is a value whose sole purpose is to be distinguished from another value.
-A set of enumerants is used distinguish among a set of distinct items.
+An <dfn noexport>enumeration</dfn> type is a limited set of named values.
+An enumeration is used to distinguish among the set of possibilities for a specific concept, such as the set of valid [=texel formats=].
 
-Each enumerant is distinct from all other enumerants, and distinct from all other kinds of values.
+An <dfn noexport>enumerant</dfn> is one of the named values in an [=enumeration=].
+Each [=enumerant=] is distinct from all other enumerants, and distinct from all other kinds of values.
 
-WGSL has an unnamed <dfn noexport>enumerant type</dfn>.
-It contains the [=predeclared=] [=enumerant=] values as listed in the following table.
+Note: Enumerants are used as [=template parameters=].
+
+<div class=note>
+<span class=marker>Note:</span> There is no way to copy or to create an alternative name for an enumerant:
+* A [[#var-and-value|variable or value]] declaration cannot have an enumeration as its [=store type=] or its [=effective-value-type=].
+* A function formal parameter cannot be an enumeration type, in part because enumerations are not [=constructible=].
+
+</div>
+
+There is no mechanism for declaring new enumerants or new enumeration types in WGSL source.
+
+The following table lists the enumeration types in WGSL, and their [=predeclared=] enumerants.
+The enumeration types exist, but cannot be spelled in WGSL source.
 
 <table class=data>
 <caption>
   Predeclared enumerants
 </caption>
 <thead>
-  <tr><th>Predeclared enumerant<th>Cross-reference
+  <tr><th>Enumeration<br>(Cannot be spelled in WGSL)<th>Predeclared enumerant<th>
 </thead>
-  <tr><td>[=access/read=]<td rowspan=3>[=access mode=]
+  <tr><td rowspan=3>[=access mode=]<td>[=access/read=]
   <tr><td>[=access/write=]
   <tr><td>[=access/read_write=]
-  <tr><td>[=address spaces/function=]
-      <td rowspan=5>[=address space=]
+  <tr><td rowspan=5>[=address space=]
 
       Note: The `handle` address space is never written in a WGSL program source.
+      <td>[=address spaces/function=]
   <tr><td>[=address spaces/private=]
   <tr><td>[=address spaces/workgroup=]
   <tr><td>[=address spaces/uniform=]
   <tr><td>[=address spaces/storage=]
-  <tr><td>[=interpolation type/perspective=]
-      <td rowspan=3>[=interpolation type=]
+  <tr><td rowspan=3>[=interpolation type=]
+      <td>[=interpolation type/perspective=]
   <tr><td>[=interpolation type/linear=]
   <tr><td>[=interpolation type/flat=]
-  <tr><td>[=interpolation sampling/center=]
-      <td rowspan=3>[=interpolation sampling=]
+  <tr><td rowspan=3>[=interpolation sampling=]
+      <td>[=interpolation sampling/center=]
   <tr><td>[=interpolation sampling/centroid=]
   <tr><td>[=interpolation sampling/sample=]
-  <tr><td>[=built-in values/vertex_index=]
-      <td rowspan=12>[=built-in value=]
+  <tr><td rowspan=12>[=built-in value=]
+      <td>[=built-in values/vertex_index=]
   <tr><td>[=built-in values/instance_index=]
   <tr><td>[=built-in values/position=]
   <tr><td>[=built-in values/front_facing=]
@@ -2837,8 +2849,8 @@ It contains the [=predeclared=] [=enumerant=] values as listed in the following 
   <tr><td>[=built-in values/num_workgroups=]
   <tr><td>[=built-in values/sample_index=]
   <tr><td>[=built-in values/sample_mask=]
-  <tr><td>[=texel format/rgba8unorm=]
-      <td rowspan=17>[=texel format=]
+  <tr><td rowspan=17>[=texel format=]
+      <td>[=texel format/rgba8unorm=]
   <tr><td>[=texel format/rgba8snorm=]
   <tr><td>[=texel format/rgba8uint=]
   <tr><td>[=texel format/rgba8sint=]
@@ -2856,8 +2868,6 @@ It contains the [=predeclared=] [=enumerant=] values as listed in the following 
   <tr><td>[=texel format/rgba32float=]
   <tr><td>[=texel format/bgra8unorm=]
 </table>
-
-WGSL does not provide a mechanism for declaring new enumerants, or another enumerant type.
 
 ## Memory Views ## {#memory-views}
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2758,7 +2758,7 @@ module creation|shader creation=] time.
 A type has a <dfn>fixed footprint</dfn> if its size is fully determined
 at [=pipeline creation=] time.
 
-Only [=storable=] types can have creation-fixed footprint or fixed footprint.
+All creation-fixed footprint and fixed footprint types are [=storeable=].
 
 Note: Pipeline creation depends on shader creation, so a type with [=creation-fixed footprint=] also has [=fixed footprint=].
 

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1228,7 +1228,7 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     See [[#resource-interface]].
 
   <tr><td><dfn noexport dfn-for="attribute">`builtin`</dfn>
-    <td>Name of a built-in value
+    <td>[=shader-creation error|Must=] be an [=enumerant=] for a [=built-in value=].
     <td>[=shader-creation error|Must=] only be applied to an entry point
     function parameter, entry point return type, or member of a [=structure=].
 
@@ -1277,8 +1277,6 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     The attribute is only significant on user-defined [=vertex=] outputs
     and [=fragment=] inputs.
     See [[#interpolation]].
-
-    Both parameters are [=context-dependent names=].
 
   <tr><td><dfn noexport dfn-for="attribute">`invariant`</dfn>
     <td>*None*
@@ -2788,13 +2786,15 @@ indirectly, while a [=constructible=] type cannot.
 Note: Fixed-footprint types exclude [=runtime-sized=] arrays, and any structure
 that contains a [=runtime-sized=] array.
 
-## Enumerantion Types ## {#enumerants}
+## Enumeration Types ## {#enumeration-types}
 
 An <dfn noexport>enumeration</dfn> type is a limited set of named values.
 An enumeration is used to distinguish among the set of possibilities for a specific concept, such as the set of valid [=texel formats=].
 
 An <dfn noexport>enumerant</dfn> is one of the named values in an [=enumeration=].
 Each [=enumerant=] is distinct from all other enumerants, and distinct from all other kinds of values.
+
+There is no mechanism for declaring new enumerants or new enumeration types in WGSL source.
 
 Note: Enumerants are used as [=template parameters=].
 
@@ -2805,9 +2805,9 @@ Note: Enumerants are used as [=template parameters=].
 
 </div>
 
-There is no mechanism for declaring new enumerants or new enumeration types in WGSL source.
+### Predeclared enumerants ### {#predeclared-enumerants}
 
-The following table lists the enumeration types in WGSL, and their [=predeclared=] enumerants.
+The following table lists the [=enumeration=] types in WGSL, and their [=predeclared=] [=enumerants=].
 The enumeration types exist, but cannot be spelled in WGSL source.
 
 <table class=data>
@@ -6409,6 +6409,20 @@ The <dfn noexport>indirection</dfn> operator converts a pointer to its correspon
            is evaluated each time control flow reaches the declaration.<br>
 </table>
 
+## Enumeration Expressions ## {#enum-expr}
+
+<table class='data'>
+  <caption>Enumeration expressions</caption>
+  <thead>
+    <tr><th>Precondition<th>Conclusion<th>Description
+  </thead>
+    <tr algorithm="enumerant expression">
+        <td>|e| is an [=identifier=] [=resolves|resolving=] to a [=predeclared=] [=enumerant=]
+            belonging to [=enumeration=] type |E|
+        <td>|e| : |E|
+        <td>See [[#predeclared-enumerants]]
+</table>
+
 ## Type Expressions ## {#type-expr}
 
 <table class='data'>
@@ -6417,19 +6431,19 @@ The <dfn noexport>indirection</dfn> operator converts a pointer to its correspon
     <tr><th>Precondition<th>Conclusion<th>Description
   </thead>
     <tr algorithm="predeclared type expression">
-        <td>|t| is an [=identifier=] resolving to a [=predeclared=] [=type=]
+        <td>|t| is an [=identifier=] [=resolves|resolving=] to a [=predeclared=] [=type=]
         <td>|t| : [=AllTypes=]
         <td>See [[#predeclared-types]]
     <tr algorithm="type alias expression">
-        <td>|a| is an [=identifier=] resolving to a [=type alias=].
+        <td>|a| is an [=identifier=] [=resolves|resolving=] to a [=type alias=].
         <td>|a| : [=AllTypes=]
         <td>Additionally, |a| denotes the type to which it is aliased.
     <tr algorithm="structure type expression">
-        <td>|s| is an [=identifier=] resolving to the declaration of a [=structure=] type.
+        <td>|s| is an [=identifier=] [=resolves|resolving=] to the declaration of a [=structure=] type.
         <td>|s| : [=AllTypes=]
         <td>Additionally, |s| denotes the structure type.
     <tr algorithm="predeclared type generator expression no trailing comma">
-        <td rowspan=2>|tg| is an [=identifier=] resolving to a [=type-generator=]
+        <td rowspan=2>|tg| is an [=identifier=] [=resolves|resolving=] to a [=type-generator=]
 
             |e1|: |T1|<br>
               ...<br>

--- a/wgsl/keywords
+++ b/wgsl/keywords
@@ -72,6 +72,7 @@ push @deliberately_unreserved, qw(
   workgroup
   uniform
   storage
+  handle
 
   rgba8unorm
   rgba8snorm
@@ -606,7 +607,6 @@ demote_to_helper
 do
 enum
 fallthrough
-handle
 null
 premerge
 regardless
@@ -618,7 +618,7 @@ wgsl
 );
 
 # Common scalar types, incluing bf16 for bfloat16
-push @wgsl_reserved, qw(
+push @deliberately_unreserved, qw(
 i8 i16 i64
 u8 u16 u64
 f64
@@ -627,10 +627,49 @@ bf16
 
 # A foreseeable templated quaternion type.
 # Swift has simd_quatf and simd_quatd
-push @wgsl_reserved, qw(
+push @deliberately_unreserved, qw(
 quat
 );
 
+# Don't reserve words that generate types
+# https://github.com/gpuweb/gpuweb/issues/2632
+push @deliberately_unreserved, qw(
+bool
+i32 u32 f32
+f16
+vec2 vec3 vec4
+mat2x2 mat2x3 mat2x4
+mat3x2 mat3x3 mat3x4
+mat4x2 mat4x3 mat4x4
+ptr
+atomic
+array
+
+texture_1d
+texture_2d
+texture_2d_array
+texture_3d
+texture_cube
+texture_cube_array
+
+texture_multisampled_2d
+
+texture_external
+
+texture_storage_1d
+texture_storage_2d
+texture_storage_2d_array
+texture_storage_3d
+
+texture_depth_2d
+texture_depth_2d_array
+texture_depth_cube
+texture_depth_cube_array
+texture_depth_multisampled_2d
+
+sampler
+sampler_comparison
+);
 
 # Key is a keyword.
 # Value is a list of languages that reserve the word in some way.

--- a/wgsl/wgsl.recursive.bs.include
+++ b/wgsl/wgsl.recursive.bs.include
@@ -1,33 +1,9 @@
 <div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>access_mode</dfn>:
-
- | `'read'`
-
- | `'read_write'`
-
- | `'write'`
-</div>
-
-<div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>additive_operator</dfn>:
 
  | `'+'`
 
  | `'-'`
-</div>
-
-<div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>address_space</dfn>:
-
- | `'function'`
-
- | `'private'`
-
- | `'storage'`
-
- | `'uniform'`
-
- | `'workgroup'`
 </div>
 
 <div class='syntax' noexport='true'>
@@ -51,7 +27,7 @@
 
  | `'@'` `'binding'` `'('` [=recursive descent syntax/expression=] `','` ? `')'`
 
- | `'@'` `'builtin'` `'('` [=recursive descent syntax/builtin_value_name=] `','` ? `')'`
+ | `'@'` `'builtin'` `'('` [=recursive descent syntax/expression=] `','` ? `')'`
 
  | `'@'` `'compute'`
 
@@ -63,9 +39,9 @@
 
  | `'@'` `'id'` `'('` [=recursive descent syntax/expression=] `','` ? `')'`
 
- | `'@'` `'interpolate'` `'('` [=recursive descent syntax/interpolation_type_name=] `','` ? `')'`
+ | `'@'` `'interpolate'` `'('` [=recursive descent syntax/expression=] `','` ? `')'`
 
- | `'@'` `'interpolate'` `'('` [=recursive descent syntax/interpolation_type_name=] `','` [=recursive descent syntax/interpolation_sample_name=] `','` ? `')'`
+ | `'@'` `'interpolate'` `'('` [=recursive descent syntax/expression=] `','` [=recursive descent syntax/expression=] `','` ? `')'`
 
  | `'@'` `'invariant'`
 
@@ -100,48 +76,6 @@
  | `'false'`
 
  | `'true'`
-</div>
-
-<div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>builtin_value_name</dfn>:
-
- | `'frag_depth'`
-
- | `'front_facing'`
-
- | `'global_invocation_id'`
-
- | `'instance_index'`
-
- | `'local_invocation_id'`
-
- | `'local_invocation_index'`
-
- | `'num_workgroups'`
-
- | `'position'`
-
- | `'sample_index'`
-
- | `'sample_mask'`
-
- | `'vertex_index'`
-
- | `'workgroup_id'`
-</div>
-
-<div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>callable</dfn>:
-
- | [=recursive descent syntax/ident=]
-
- | [=recursive descent syntax/mat_prefix=]
-
- | [=recursive descent syntax/type_specifier_without_ident=]
-
- | [=recursive descent syntax/vec_prefix=]
-
- | `'array'`
 </div>
 
 <div class='syntax' noexport='true'>
@@ -223,28 +157,6 @@
 </div>
 
 <div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>depth_texture_type</dfn>:
-
- | `'texture_depth_2d'`
-
- | `'texture_depth_2d_array'`
-
- | `'texture_depth_cube'`
-
- | `'texture_depth_cube_array'`
-
- | `'texture_depth_multisampled_2d'`
-</div>
-
-<div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>element_count_expression</dfn>:
-
- | [=recursive descent syntax/unary_expression=] ( [=recursive descent syntax/multiplicative_operator=] [=recursive descent syntax/unary_expression=] )* ( [=recursive descent syntax/additive_operator=] [=recursive descent syntax/unary_expression=] ( [=recursive descent syntax/multiplicative_operator=] [=recursive descent syntax/unary_expression=] )* )*
-
- | [=recursive descent syntax/unary_expression=] [=recursive descent syntax/bitwise_expression.post.unary_expression=]
-</div>
-
-<div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>expression</dfn>:
 
  | [=recursive descent syntax/unary_expression=] [=recursive descent syntax/bitwise_expression.post.unary_expression=]
@@ -267,7 +179,7 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>for_init</dfn>:
 
- | [=recursive descent syntax/callable=] [=recursive descent syntax/argument_expression_list=]
+ | [=recursive descent syntax/ident=] [=recursive descent syntax/template_elaborated_ident.post.ident=] [=recursive descent syntax/argument_expression_list=]
 
  | [=recursive descent syntax/variable_statement=]
 
@@ -277,7 +189,7 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>for_update</dfn>:
 
- | [=recursive descent syntax/callable=] [=recursive descent syntax/argument_expression_list=]
+ | [=recursive descent syntax/ident=] [=recursive descent syntax/template_elaborated_ident.post.ident=] [=recursive descent syntax/argument_expression_list=]
 
  | [=recursive descent syntax/variable_updating_statement=]
 </div>
@@ -285,15 +197,15 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>global_decl</dfn>:
 
- | [=recursive descent syntax/attribute=] * `'fn'` [=recursive descent syntax/ident=] `'('` ( [=recursive descent syntax/attribute=] * [=recursive descent syntax/ident=] `':'` [=recursive descent syntax/type_specifier=] ( `','` [=recursive descent syntax/param=] )* `','` ? )? `')'` ( `'->'` [=recursive descent syntax/attribute=] * [=recursive descent syntax/type_specifier=] )? `'{'` [=recursive descent syntax/statement=] * `'}'`
+ | [=recursive descent syntax/attribute=] * `'fn'` [=recursive descent syntax/ident=] `'('` ( [=recursive descent syntax/attribute=] * [=recursive descent syntax/ident=] `':'` [=recursive descent syntax/type_specifier=] ( `','` [=recursive descent syntax/param=] )* `','` ? )? `')'` ( `'->'` [=recursive descent syntax/attribute=] * [=recursive descent syntax/ident=] [=recursive descent syntax/template_elaborated_ident.post.ident=] )? `'{'` [=recursive descent syntax/statement=] * `'}'`
 
  | [=recursive descent syntax/attribute=] * `'override'` [=recursive descent syntax/optionally_typed_ident=] ( `'='` [=recursive descent syntax/expression=] )? `';'`
 
- | [=recursive descent syntax/attribute=] * `'var'` ( [=syntax_sym/_template_args_start=] [=recursive descent syntax/address_space=] ( `','` [=recursive descent syntax/access_mode=] )? [=syntax_sym/_template_args_end=] )? [=recursive descent syntax/optionally_typed_ident=] ( `'='` [=recursive descent syntax/expression=] )? `';'`
+ | [=recursive descent syntax/attribute=] * `'var'` ( [=syntax_sym/_template_args_start=] [=recursive descent syntax/expression=] ( `','` [=recursive descent syntax/expression=] )* `','` ? [=syntax_sym/_template_args_end=] )? [=recursive descent syntax/optionally_typed_ident=] ( `'='` [=recursive descent syntax/expression=] )? `';'`
 
  | `';'`
 
- | `'alias'` [=recursive descent syntax/ident=] `'='` [=recursive descent syntax/type_specifier=] `';'`
+ | `'alias'` [=recursive descent syntax/ident=] `'='` [=recursive descent syntax/ident=] [=recursive descent syntax/template_elaborated_ident.post.ident=] `';'`
 
  | `'const'` [=recursive descent syntax/optionally_typed_ident=] `'='` [=recursive descent syntax/expression=] `';'`
 
@@ -314,7 +226,8 @@
 
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>ident</dfn>:
-[=syntax/ident_pattern_token=]
+
+ | [=syntax/ident_pattern_token=]
 </div>
 
 <div class='syntax' noexport='true'>
@@ -323,26 +236,6 @@
  | [=recursive descent syntax/decimal_int_literal=]
 
  | [=syntax/hex_int_literal=]
-</div>
-
-<div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>interpolation_sample_name</dfn>:
-
- | `'center'`
-
- | `'centroid'`
-
- | `'sample'`
-</div>
-
-<div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>interpolation_type_name</dfn>:
-
- | `'flat'`
-
- | `'linear'`
-
- | `'perspective'`
 </div>
 
 <div class='syntax' noexport='true'>
@@ -363,28 +256,6 @@
  | [=recursive descent syntax/float_literal=]
 
  | [=recursive descent syntax/int_literal=]
-</div>
-
-<div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>mat_prefix</dfn>:
-
- | `'mat2x2'`
-
- | `'mat2x3'`
-
- | `'mat2x4'`
-
- | `'mat3x2'`
-
- | `'mat3x3'`
-
- | `'mat3x4'`
-
- | `'mat4x2'`
-
- | `'mat4x3'`
-
- | `'mat4x4'`
 </div>
 
 <div class='syntax' noexport='true'>
@@ -417,9 +288,9 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>primary_expression</dfn>:
 
- | [=recursive descent syntax/callable=] `'('` ( [=recursive descent syntax/expression=] ( `','` [=recursive descent syntax/expression=] )* `','` ? )? `')'`
+ | [=recursive descent syntax/ident=] [=recursive descent syntax/template_elaborated_ident.post.ident=]
 
- | [=recursive descent syntax/ident=]
+ | [=recursive descent syntax/ident=] [=recursive descent syntax/template_elaborated_ident.post.ident=] `'('` ( [=recursive descent syntax/expression=] ( `','` [=recursive descent syntax/expression=] )* `','` ? )? `')'`
 
  | [=recursive descent syntax/literal=]
 
@@ -447,30 +318,6 @@
 </div>
 
 <div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>sampled_texture_type</dfn>:
-
- | `'texture_1d'`
-
- | `'texture_2d'`
-
- | `'texture_2d_array'`
-
- | `'texture_3d'`
-
- | `'texture_cube'`
-
- | `'texture_cube_array'`
-</div>
-
-<div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>sampler_type</dfn>:
-
- | `'sampler'`
-
- | `'sampler_comparison'`
-</div>
-
-<div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>shift_expression.post.unary_expression</dfn>:
 
  | ( [=recursive descent syntax/multiplicative_operator=] [=recursive descent syntax/unary_expression=] )* ( [=recursive descent syntax/additive_operator=] [=recursive descent syntax/unary_expression=] ( [=recursive descent syntax/multiplicative_operator=] [=recursive descent syntax/unary_expression=] )* )*
@@ -483,9 +330,9 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>statement</dfn>:
 
- | [=recursive descent syntax/callable=] `'('` ( [=recursive descent syntax/expression=] ( `','` [=recursive descent syntax/expression=] )* `','` ? )? `')'` `';'`
-
  | [=recursive descent syntax/compound_statement=]
+
+ | [=recursive descent syntax/ident=] [=recursive descent syntax/template_elaborated_ident.post.ident=] `'('` ( [=recursive descent syntax/expression=] ( `','` [=recursive descent syntax/expression=] )* `','` ? )? `')'` `';'`
 
  | [=recursive descent syntax/variable_statement=] `';'`
 
@@ -512,18 +359,6 @@
  | `'switch'` [=recursive descent syntax/expression=] `'{'` [=recursive descent syntax/switch_body=] * `'}'`
 
  | `'while'` [=recursive descent syntax/expression=] [=recursive descent syntax/compound_statement=]
-</div>
-
-<div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>storage_texture_type</dfn>:
-
- | `'texture_storage_1d'`
-
- | `'texture_storage_2d'`
-
- | `'texture_storage_2d_array'`
-
- | `'texture_storage_3d'`
 </div>
 
 <div class='syntax' noexport='true'>
@@ -555,55 +390,14 @@
 </div>
 
 <div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>texel_format</dfn>:
-
- | `'bgra8unorm'`
-
- | `'r32float'`
-
- | `'r32sint'`
-
- | `'r32uint'`
-
- | `'rg32float'`
-
- | `'rg32sint'`
-
- | `'rg32uint'`
-
- | `'rgba16float'`
-
- | `'rgba16sint'`
-
- | `'rgba16uint'`
-
- | `'rgba32float'`
-
- | `'rgba32sint'`
-
- | `'rgba32uint'`
-
- | `'rgba8sint'`
-
- | `'rgba8snorm'`
-
- | `'rgba8uint'`
-
- | `'rgba8unorm'`
+  <dfn for='recursive descent syntax'>template_arg_expression</dfn>:
+[=recursive descent syntax/expression=]
 </div>
 
 <div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>texture_and_sampler_types</dfn>:
+  <dfn for='recursive descent syntax'>template_elaborated_ident.post.ident</dfn>:
 
- | [=recursive descent syntax/depth_texture_type=]
-
- | [=recursive descent syntax/sampled_texture_type=] [=syntax_sym/_template_args_start=] [=recursive descent syntax/type_specifier=] [=syntax_sym/_template_args_end=]
-
- | [=recursive descent syntax/sampler_type=]
-
- | [=recursive descent syntax/storage_texture_type=] [=syntax_sym/_template_args_start=] [=recursive descent syntax/texel_format=] `','` [=recursive descent syntax/access_mode=] [=syntax_sym/_template_args_end=]
-
- | [=syntax/multisampled_texture_type=] [=syntax_sym/_template_args_start=] [=recursive descent syntax/type_specifier=] [=syntax_sym/_template_args_end=]
+ | ( [=syntax_sym/_template_args_start=] [=recursive descent syntax/template_arg_expression=] ( `','` [=recursive descent syntax/expression=] )* `','` ? [=syntax_sym/_template_args_end=] )?
 </div>
 
 <div class='syntax' noexport='true'>
@@ -615,35 +409,7 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>type_specifier</dfn>:
 
- | [=recursive descent syntax/ident=]
-
- | [=recursive descent syntax/type_specifier_without_ident=]
-</div>
-
-<div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>type_specifier_without_ident</dfn>:
-
- | [=recursive descent syntax/mat_prefix=] [=syntax_sym/_template_args_start=] [=recursive descent syntax/type_specifier=] [=syntax_sym/_template_args_end=]
-
- | [=recursive descent syntax/texture_and_sampler_types=]
-
- | [=recursive descent syntax/vec_prefix=] [=syntax_sym/_template_args_start=] [=recursive descent syntax/type_specifier=] [=syntax_sym/_template_args_end=]
-
- | `'array'` [=syntax_sym/_template_args_start=] [=recursive descent syntax/type_specifier=] ( `','` [=recursive descent syntax/element_count_expression=] )? [=syntax_sym/_template_args_end=]
-
- | `'atomic'` [=syntax_sym/_template_args_start=] [=recursive descent syntax/type_specifier=] [=syntax_sym/_template_args_end=]
-
- | `'bool'`
-
- | `'f16'`
-
- | `'f32'`
-
- | `'i32'`
-
- | `'ptr'` [=syntax_sym/_template_args_start=] [=recursive descent syntax/address_space=] `','` [=recursive descent syntax/type_specifier=] ( `','` [=recursive descent syntax/access_mode=] )? [=syntax_sym/_template_args_end=]
-
- | `'u32'`
+ | [=recursive descent syntax/ident=] ( [=syntax_sym/_template_args_start=] [=recursive descent syntax/template_arg_expression=] ( `','` [=recursive descent syntax/expression=] )* `','` ? [=syntax_sym/_template_args_end=] )?
 </div>
 
 <div class='syntax' noexport='true'>
@@ -665,7 +431,7 @@
 <div class='syntax' noexport='true'>
   <dfn for='recursive descent syntax'>variable_decl</dfn>:
 
- | `'var'` ( [=syntax_sym/_template_args_start=] [=recursive descent syntax/address_space=] ( `','` [=recursive descent syntax/access_mode=] )? [=syntax_sym/_template_args_end=] )? [=recursive descent syntax/optionally_typed_ident=]
+ | `'var'` ( [=syntax_sym/_template_args_start=] [=recursive descent syntax/expression=] ( `','` [=recursive descent syntax/expression=] )* `','` ? [=syntax_sym/_template_args_end=] )? [=recursive descent syntax/optionally_typed_ident=]
 </div>
 
 <div class='syntax' noexport='true'>
@@ -690,14 +456,4 @@
  | [=recursive descent syntax/lhs_expression=] `'--'`
 
  | `'_'` `'='` [=recursive descent syntax/expression=]
-</div>
-
-<div class='syntax' noexport='true'>
-  <dfn for='recursive descent syntax'>vec_prefix</dfn>:
-
- | `'vec2'`
-
- | `'vec3'`
-
- | `'vec4'`
 </div>

--- a/wgsl/wgsl.reserved.bs.include
+++ b/wgsl/wgsl.reserved.bs.include
@@ -31,8 +31,6 @@
 
     | `'become'`   <!-- Rust -->
 
-    | `'bf16'`   <!-- WGSL -->
-
     | `'binding_array'`   <!-- WGSL -->
 
     | `'cast'`   <!-- GLSL(reserved) -->
@@ -95,8 +93,6 @@
 
     | `'external'`   <!-- GLSL(reserved) -->
 
-    | `'f64'`   <!-- WGSL -->
-
     | `'fallthrough'`   <!-- WGSL -->
 
     | `'filter'`   <!-- GLSL(reserved) -->
@@ -117,15 +113,7 @@
 
     | `'groupshared'`   <!-- HLSL -->
 
-    | `'handle'`   <!-- WGSL -->
-
     | `'highp'`   <!-- GLSL -->
-
-    | `'i16'`   <!-- WGSL -->
-
-    | `'i64'`   <!-- WGSL -->
-
-    | `'i8'`   <!-- WGSL -->
 
     | `'impl'`   <!-- Rust -->
 
@@ -211,8 +199,6 @@
 
     | `'public'`   <!-- C++ ECMAScript2022 GLSL(reserved) -->
 
-    | `'quat'`   <!-- WGSL -->
-
     | `'readonly'`   <!-- GLSL -->
 
     | `'ref'`   <!-- Rust -->
@@ -276,12 +262,6 @@
     | `'typename'`   <!-- C++ -->
 
     | `'typeof'`   <!-- ECMAScript2022 Rust -->
-
-    | `'u16'`   <!-- WGSL -->
-
-    | `'u64'`   <!-- WGSL -->
-
-    | `'u8'`   <!-- WGSL -->
 
     | `'union'`   <!-- C++ Rust GLSL(reserved) -->
 

--- a/wgsl/wgsl_unit_tests.py
+++ b/wgsl/wgsl_unit_tests.py
@@ -65,7 +65,7 @@ cases = [
     Case("var<workgroup> w: i32;"),
     Case("fn foo() {var f: i32;}"),
     Case("var<workgroup> w: array<vec3<f32>,1>;"),
-    XFail("var<workgroup> w: array<vec3<f32>,(vec<i32>(1).x)>;"),
+    Case("var<workgroup> w: array<vec3<f32>,(vec<i32>(1).x)>;"), # vec<i32> treated like generic template invocation. Should fail in semantic checks.
     Case( "var<workgroup> w: array<vec3<f32>,(vec3<i32>(1).x)>;"),
     XFail("const c = array<a>b>;"),
     Case("var c : array<f32,(a>b)>;"),
@@ -81,7 +81,7 @@ cases = [
     Case("alias t = vec3<float>;"),
     Case("alias t = array<t,(1<2)>;"),
     Case("var c : array<t,(1<2)>;"),
-    XFail("var c : array<(a>b)>;"), # Type specifier must start with identifier
+    Case("var c : array<(a>b)>;"), # Parses ok, but should fail in semantic check: (a>b) is not a type.
     Case("fn f(p: ptr<function,i32>) {}"),
     Case("fn m(){x++;}"),
     Case("fn m(){x--;}"),


### PR DESCRIPTION

    Types and type-generating words are not keywords
    
    Fixes: #3739
    
    - Deliberately don't reserve types and type-defining words
    
    - Remove "type-defining keywords"
      A declaration can be a predeclared type-defining word.
    
    - Add concept of type-generator
      Type-generators can be predeclared.
    
    - Add a section to summarize predeclared types and type-generators.
    
    - Add access_mode to template_arg
    
    - Add TODO to make a "type" type
    
    Rename fully_qualified_ident to template_elaborated_ident
    
    Define enumerants, and the enumerant type
    
    - Many context-dependent names are now predeclared enumerants:
      - access mode
      - address space
      - interpolation type
      - interpolation sampling
      - texel format
      - built-in value names
    - Unreserve 'handle'
    
    Make builtin param names into expressions
    
    Make var decl template params expressions
    
    Rename template_arg_list to template_list
    
    Remove variable_qualifier in favour of template_list
    
    Clarify shadowing of predeclared objects
    
    - Add an example of shadowing predeclared objects
    
    Define the AllType type
    
    - Motivate it by saying we use it to allow an expression to yield a type.
    
    Add a "Type Expressions" section to the Expressions chapter
    
    Move the grammar for template_list up to the Template Lists section.
    It didn't really belong in type-specifier grammar since it is also used
    in the varaible declaration grammar.
