### PR TITLE
Make reserved words list more consistent

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2149,7 +2149,7 @@ Example:  `1u + 2.5` results in a [=shader-creation error=]:
 
     // Similar, but invalid
     let out_of_range = (0x1ffffffff / 8u); // requires computation is done in 32-bits,
-			                   // making 0x1ffffffff out of range.
+                                           // making 0x1ffffffff out of range.
 
   </xmp>
 </div>

--- a/wgsl/keywords
+++ b/wgsl/keywords
@@ -197,11 +197,13 @@ push @deliberately_unreserved, qw(
   char16_t
   char32_t
   char8_t
-  int
-  short
-  long
-  float
   double
+  float
+  int
+  long
+  short
+  signed
+  unsigned
   void
   wchar_t
 );
@@ -477,6 +479,7 @@ namespace using
 sampler3DRect
 );
 push @deliberately_unreserved, qw(
+  inout
   long short half
   long short half fixed unsigned superp
   hvec2 hvec3 hvec4 fvec2 fvec3 fvec4
@@ -517,11 +520,12 @@ AppendStructuredBuffer
 BlendState
 Buffer ByteAddressBuffer
 cbuffer
-ConsumeStructuredBuffer
-DepthStencilState DepthStencilView double
+CompileShader ComputeShader ConsumeStructuredBuffer
+DepthStencilState DepthStencilView double DomainShader
 dword
 false float
-half
+GeometryShader
+half HullShader
 InputPatch int
 line lineadj
 LineStream
@@ -555,7 +559,7 @@ foreach my $type (qw(float int uint bool
   }
 }
 
-# Already in use by WGSL 
+# Already in use by WGSL
 my @wgsl = qw(
 bitcast
 break
@@ -597,7 +601,6 @@ workgroup
 my @wgsl_reserved = qw(
 asm
 binding_array
-const
 demote
 demote_to_helper
 do

--- a/wgsl/wgsl.reserved.bs.include
+++ b/wgsl/wgsl.reserved.bs.include
@@ -1,14 +1,6 @@
 <div class='syntax' noexport='true'>
   <dfn for=syntax>_reserved</dfn> :
 
-    | `'CompileShader'`   <!-- HLSL -->
-
-    | `'ComputeShader'`   <!-- HLSL -->
-
-    | `'DomainShader'`   <!-- HLSL -->
-
-    | `'GeometryShader'`   <!-- HLSL -->
-
     | `'Hullshader'`   <!-- HLSL -->
 
     | `'NULL'`   <!-- HLSL -->
@@ -143,8 +135,6 @@
 
     | `'inline'`   <!-- C++ HLSL GLSL(reserved) -->
 
-    | `'inout'`   <!-- HLSL GLSL -->
-
     | `'instanceof'`   <!-- ECMAScript2022 -->
 
     | `'interface'`   <!-- ECMAScript2022 HLSL GLSL(reserved) -->
@@ -244,8 +234,6 @@
     | `'set'`   <!-- ECMAScript2022 -->
 
     | `'shared'`   <!-- HLSL GLSL -->
-
-    | `'signed'`   <!-- C++ -->
 
     | `'sizeof'`   <!-- C++ GLSL(reserved) -->
 


### PR DESCRIPTION
* Removes `signed`. `unsigned` is already unreserved in HLSL and GLSL
* Remove `inout`. `in` and `out` are already unreserved unconditionally
* Remove `DomainShader`, `HullShader`, `CompileShader`, `ComputeShader`, and `HullShader`. `VertexShader` and `PixelShader` are already unreserved.