### PR TITLE
Fix intro to "Memory" section, to refer to Memory Views

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -2149,7 +2149,7 @@ Example:  `1u + 2.5` results in a [=shader-creation error=]:
 
     // Similar, but invalid
     let out_of_range = (0x1ffffffff / 8u); // requires computation is done in 32-bits,
-			                   // making 0x1ffffffff out of range.
+                                           // making 0x1ffffffff out of range.
 
   </xmp>
 </div>
@@ -2749,7 +2749,7 @@ that contains a [=runtime-sized=] array.
 ## Memory Views ## {#memory-views}
 
 In addition to calculating with [=plain types|plain=] values, a WGSL program will
-also often read values from memory or write values to memory, via [=memory access=] operations.
+also often read values from [[#memory|memory]] or write values to memory, via [=memory access=] operations.
 Each memory access is performed via a [=memory view=].
 
 A <dfn noexport>memory view</dfn> comprises:
@@ -9035,8 +9035,8 @@ shader that goes beyond the specified limits.
 # Memory # {#memory}
 
 In WGSL, a value of [=storable=] type may be stored in memory, for later retrieval.
-This section describes the structure of memory, and how WGSL types are used to
-describe the contents of memory.
+This section describes the structure of memory, and the semantics of operations accessing memory.
+See [[#memory-views]] for the types of values that can be placed in memory, and the types used to perform memory accesses.
 
 ## Memory Locations ## {#memory-locations-section}
 


### PR DESCRIPTION
The "Memory" section no longer defines the storable types or memory view types.