### PR TITLE
Add @must_use attribute

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1287,6 +1287,20 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
     Specifies a part of the user-defined IO of an entry point.
     See [[#input-output-locations]].
 
+  <tr><td><dfn noexport dfn-for="attribute">`must_use`</dfn>
+    <td>*None*
+    <td>Must only be applied to the declaration of a [=function/function=] with a [=return type=].
+
+        Specifies that a [=function call|call=] to this function [=shader-creation error|must=] be used as an [=expression=].
+        That is, a call to this function [=shader-creation error|must=] not be the entirety of a [[#function-call-statement|function call statement]].
+
+        Note: Many functions return a value and do not have side effects.
+        It is often a programming error to call such a function as the only thing in a function call statement.
+        Such functions are declared as `@must_use`.
+
+        Note: To deliberately work around the `@must_use` rule, use a [=phony assignment=]
+        or [=value declaration|declare a value=] using the function call as the initializer.
+
   <tr><td><dfn noexport dfn-for="attribute">`size`</dfn>
     <td>[=shader-creation error|Must=] be a [=const-expression=] that [=type rules|resolves=] to an [=i32=] or [=u32=].<br>
         [=shader-creation error|Must=] be positive.
@@ -1370,6 +1384,8 @@ They take no parameters.
     | <a for=syntax_sym lt=attr>`'@'`</a> `'invariant'`
 
     | <a for=syntax_sym lt=attr>`'@'`</a> `'location'` <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/expression=] [=syntax/attrib_end=]
+
+    | <a for=syntax_sym lt=attr>`'@'`</a> `'must_use'`
 
     | <a for=syntax_sym lt=attr>`'@'`</a> `'size'` <a for=syntax_sym lt=paren_left>`'('`</a> [=syntax/expression=] [=syntax/attrib_end=]
 
@@ -11756,7 +11772,7 @@ See [[#function-calls]].
 <table class='data builtin'>
   <tr algorithm="vector all">
     <td style="width:10%" style="width:10%">Overload
-    <td><xmp highlight=rust>@const fn all(e: vecN<bool>) -> bool</xmp>
+    <td><xmp highlight=rust>@const @must_use fn all(e: vecN<bool>) -> bool</xmp>
   <tr>
     <td>Description
     <td>Returns true if each component of `e` is true.
@@ -11765,7 +11781,7 @@ See [[#function-calls]].
 <table class='data builtin'>
   <tr algorithm="scalar all">
     <td style="width:10%" style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>@const fn all(e: bool) -> bool</xmp>
+    <td class="nowrap"><xmp highlight=rust>@const @must_use fn all(e: bool) -> bool</xmp>
   <tr>
     <td>Description
     <td>Returns `e`.
@@ -11776,7 +11792,7 @@ See [[#function-calls]].
   <tr algorithm="vector any">
     <td style="width:10%" style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn any(e: vecN<bool>) -> bool
+@const @must_use fn any(e: vecN<bool>) -> bool
 </xmp>
   <tr>
     <td style="width:10%">Description
@@ -11786,7 +11802,7 @@ See [[#function-calls]].
 <table class='data builtin'>
   <tr algorithm="scalar any">
     <td style="width:10%">Overload
-    <td class="nowrap"><xmp highlight=rust>@const fn any(e: bool) -> bool</xmp>
+    <td class="nowrap"><xmp highlight=rust>@const @must_use fn any(e: bool) -> bool</xmp>
   <tr>
     <td>Description
     <td>Returns `e`.
@@ -11797,9 +11813,9 @@ See [[#function-calls]].
   <tr algorithm="scalar select">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn select(f: T,
-                 t: T,
-                 cond: bool) -> T
+@const @must_use fn select(f: T,
+                           t: T,
+                           cond: bool) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -11813,9 +11829,9 @@ See [[#function-calls]].
   <tr algorithm="vector select">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn select(f: vecN<T>,
-                 t: vecN<T>,
-                 cond: vecN<bool>) -> vecN<T>
+@const @must_use fn select(f: vecN<T>,
+                           t: vecN<T>,
+                           cond: vecN<bool>) -> vecN<T>
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -11833,7 +11849,7 @@ See [[#function-calls]].
   <tr algorithm="runtime-sized array length">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-fn arrayLength(p: ptr<storage, array<E>, AM>) -> u32
+@must_use fn arrayLength(p: ptr<storage, array<E>, AM>) -> u32
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -11851,7 +11867,7 @@ fn arrayLength(p: ptr<storage, array<E>, AM>) -> u32
   <tr algorithm="float abs">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn abs(e: T ) -> T
+@const @must_use fn abs(e: T ) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -11872,7 +11888,7 @@ fn arrayLength(p: ptr<storage, array<E>, AM>) -> u32
   <tr algorithm="acos">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn acos(e: T) -> T
+@const @must_use fn acos(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -11895,7 +11911,7 @@ Note: The result is not mathematically meaningful when `abs(e)` &gt; 1.
   <tr algorithm="acosh">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn acosh(e: T) -> T
+@const @must_use fn acosh(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -11920,7 +11936,7 @@ Note: The result is not mathematically meaningful when `e` &lt; 1.
   <tr algorithm="asin">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn asin(e: T) -> T
+@const @must_use fn asin(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -11943,7 +11959,7 @@ Note: The result is not mathematically meaningful when `abs(e)` &gt; 1.
   <tr algorithm="asinh">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn asinh(e: T) -> T
+@const @must_use fn asinh(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -11961,7 +11977,7 @@ Note: The result is not mathematically meaningful when `abs(e)` &gt; 1.
   <tr algorithm="atan">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn atan(e: T) -> T
+@const @must_use fn atan(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -11979,7 +11995,7 @@ Note: The result is not mathematically meaningful when `abs(e)` &gt; 1.
   <tr algorithm="atanh">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn atanh(e: T) -> T
+@const @must_use fn atanh(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12003,7 +12019,7 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
   <tr algorithm="atan2">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn atan2(y: T,
+@const @must_use fn atan2(y: T,
                 x: T) -> T
 </xmp>
   <tr>
@@ -12030,7 +12046,7 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
   <tr algorithm="ceil">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn ceil(e: T) -> T
+@const @must_use fn ceil(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12046,7 +12062,7 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
   <tr algorithm="clamp">
   <td style="width:10%">Overload
   <td class="nowrap"><xmp highlight=rust>
-@const fn clamp(e: T,
+@const @must_use fn clamp(e: T,
                 low: T,
                 high: T) -> T
 </xmp>
@@ -12074,7 +12090,7 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
   <tr algorithm="cos">
   <td style="width:10%">Overload
   <td class="nowrap"><xmp highlight=rust>
-@const fn cos(e: T) -> T
+@const @must_use fn cos(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12090,7 +12106,7 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
   <tr algorithm="cosh">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn cosh(arg: T) -> T
+@const @must_use fn cosh(arg: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12109,7 +12125,7 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
   <tr algorithm="count leading zeroes">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn countLeadingZeros(e: T) -> T
+@const @must_use fn countLeadingZeros(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12127,7 +12143,7 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
   <tr algorithm="count 1 bits">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn countOneBits(e: T) -> T
+@const @must_use fn countOneBits(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12144,7 +12160,7 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
   <tr algorithm="count trailing zeroes">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn countTrailingZeros(e: T) -> T
+@const @must_use fn countTrailingZeros(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12162,7 +12178,7 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
   <tr algorithm="vector case, cross">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn cross(e1: vec3<T>,
+@const @must_use fn cross(e1: vec3<T>,
                 e2: vec3<T>) -> vec3<T>
 </xmp>
   <tr>
@@ -12178,7 +12194,7 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
   <tr algorithm="degrees">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn degrees(e1: T) -> T
+@const @must_use fn degrees(e1: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12194,7 +12210,7 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
   <tr algorithm="determinant">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn determinant(e: matCxC<T>) -> T
+@const @must_use fn determinant(e: matCxC<T>) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12209,8 +12225,8 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
   <tr algorithm="distance">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn distance(e1: T,
-                   e2: T) -> S
+@const @must_use fn distance(e1: T,
+                             e2: T) -> S
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12225,8 +12241,8 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
   <tr algorithm="dot">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn dot(e1: vecN<T>,
-              e2: vecN<T>) -> T
+@const @must_use fn dot(e1: vecN<T>,
+                        e2: vecN<T>) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12241,7 +12257,7 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
   <tr algorithm="exp">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn exp(e1: T) -> T
+@const @must_use fn exp(e1: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12257,7 +12273,7 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
   <tr algorithm="exp2">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn exp2(e: T) -> T
+@const @must_use fn exp2(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12273,9 +12289,9 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
   <tr algorithm="signed extract bits">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn extractBits(e: T,
-                      offset: u32,
-                      count: u32) -> T
+@const @must_use fn extractBits(e: T,
+                                offset: u32,
+                                count: u32) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12306,9 +12322,9 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
   <tr algorithm="unsigned extract bits">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn extractBits(e: T,
-                      offset: u32,
-                      count: u32) -> T
+@const @must_use fn extractBits(e: T,
+                                offset: u32,
+                                count: u32) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12339,9 +12355,9 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
   <tr algorithm="faceForward">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn faceForward(e1: T,
-                      e2: T,
-                      e3: T) -> T
+@const @must_use fn faceForward(e1: T,
+                                e2: T,
+                                e3: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12356,7 +12372,7 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
   <tr algorithm="signed find most significant one bit">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn firstLeadingBit(e: T) -> T
+@const @must_use fn firstLeadingBit(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12385,7 +12401,7 @@ the sign bit appears in the most significant bit position.
   <tr algorithm="unsigned find most significant one bit">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn firstLeadingBit(e: T) -> T
+@const @must_use fn firstLeadingBit(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12406,7 +12422,7 @@ the sign bit appears in the most significant bit position.
   <tr algorithm="find least significant one bit">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn firstTrailingBit(e: T) -> T
+@const @must_use fn firstTrailingBit(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12427,7 +12443,7 @@ the sign bit appears in the most significant bit position.
   <tr algorithm="floor">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn floor(e: T) -> T
+@const @must_use fn floor(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12443,9 +12459,9 @@ the sign bit appears in the most significant bit position.
   <tr algorithm="fma">
   <td style="width:10%">Overload
   <td class="nowrap"><xmp highlight=rust>
-@const fn fma(e1: T,
-              e2: T,
-              e3: T) -> T
+@const @must_use fn fma(e1: T,
+                        e2: T,
+                        e3: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12472,7 +12488,7 @@ the sign bit appears in the most significant bit position.
   <tr algorithm="fract">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn fract(e: T) -> T
+@const @must_use fn fract(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12495,7 +12511,7 @@ For example, if `e` is a very small negative number, then `fract(e)` may be 1.0.
   <tr algorithm="scalar case, binary32, frexp">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn frexp(e: T) -> __frexp_result_f32
+@const @must_use fn frexp(e: T) -> __frexp_result_f32
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12538,7 +12554,7 @@ but a value may infer the type.
   <tr algorithm="scalar case, binary16, frexp">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn frexp(e: T) -> __frexp_result_f16
+@const @must_use fn frexp(e: T) -> __frexp_result_f16
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12570,7 +12586,7 @@ but a value may infer the type.
   <tr algorithm="scalar case, abstract, frexp">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn frexp(e: T) -> __frexp_result_abstract
+@const @must_use fn frexp(e: T) -> __frexp_result_abstract
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12613,7 +12629,7 @@ but a value may infer the type.
   <tr algorithm="vector case, binary32, frexp">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn frexp(e: T) -> __frexp_result_vecN_f32
+@const @must_use fn frexp(e: T) -> __frexp_result_vecN_f32
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12645,7 +12661,7 @@ but a value may infer the type.
   <tr algorithm="vector case, binary16, frexp">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn frexp(e: T) -> __frexp_result_vecN_f16
+@const @must_use fn frexp(e: T) -> __frexp_result_vecN_f16
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12677,7 +12693,7 @@ but a value may infer the type.
   <tr algorithm="vector case, abstract, frexp">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn frexp(e: T) -> __frexp_result_vecN_abstract
+@const @must_use fn frexp(e: T) -> __frexp_result_vecN_abstract
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12710,10 +12726,10 @@ but a value may infer the type.
   <tr algorithm="insert bits">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn insertBits(e: T,
-                     newbits: T,
-                     offset: u32,
-                     count: u32) -> T
+@const @must_use fn insertBits(e: T,
+                               newbits: T,
+                               offset: u32,
+                               count: u32) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12744,7 +12760,7 @@ but a value may infer the type.
   <tr algorithm="inverseSqrt">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn inverseSqrt(e: T) -> T
+@const @must_use fn inverseSqrt(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12765,8 +12781,8 @@ Note: The result is not mathematically meaningful if `e` &le; 0.
   <tr algorithm="ldexp">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn ldexp(e1: T,
-                e2: I) -> T
+@const @must_use fn ldexp(e1: T,
+                          e2: I) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12806,7 +12822,7 @@ Note: The result is not mathematically meaningful if `e` &le; 0.
   <tr algorithm="length">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn length(e: T) -> S
+@const @must_use fn length(e: T) -> S
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12826,7 +12842,7 @@ Note: The result is not mathematically meaningful if `e` &le; 0.
   <tr algorithm="log">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn log(e: T) -> T
+@const @must_use fn log(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12847,7 +12863,7 @@ Note: The result is not mathematically meaningful if `e` &lt; 0.
   <tr algorithm="log2">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn log2(e: T) -> T
+@const @must_use fn log2(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12868,8 +12884,8 @@ Note: The result is not mathematically meaningful if `e` &lt; 0.
   <tr algorithm="max">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn max(e1: T,
-              e2: T) -> T
+@const @must_use fn max(e1: T,
+                        e2: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12889,8 +12905,8 @@ Note: The result is not mathematically meaningful if `e` &lt; 0.
   <tr algorithm="min">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn min(e1: T,
-              e2: T) -> T
+@const @must_use fn min(e1: T,
+                        e2: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12910,9 +12926,9 @@ Note: The result is not mathematically meaningful if `e` &lt; 0.
   <tr algorithm="mix all same type operands">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn mix(e1: T,
-              e2: T,
-              e3: T) -> T
+@const @must_use fn mix(e1: T,
+                        e2: T,
+                        e3: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12927,9 +12943,9 @@ Note: The result is not mathematically meaningful if `e` &lt; 0.
   <tr algorithm="vector mix with scalar blending factor">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn mix(e1: T2,
-              e2: T2,
-              e3: T) -> T2
+@const @must_use fn mix(e1: T2,
+                        e2: T2,
+                        e3: T) -> T2
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12947,7 +12963,7 @@ Note: The result is not mathematically meaningful if `e` &lt; 0.
   <tr algorithm="scalar case, binary32, modf">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn modf(e: T) -> __modf_result_f32
+@const @must_use fn modf(e: T) -> __modf_result_f32
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12991,7 +13007,7 @@ but a value may infer the type.
   <tr algorithm="scalar case, binary16, modf">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn modf(e: T) -> __modf_result_f16
+@const @must_use fn modf(e: T) -> __modf_result_f16
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13022,7 +13038,7 @@ but a value may infer the type.
   <tr algorithm="scalar case, abstract, modf">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn modf(e: T) -> __modf_result_abstract
+@const @must_use fn modf(e: T) -> __modf_result_abstract
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13066,7 +13082,7 @@ but a value may infer the type.
   <tr algorithm="vector case, binary32, modf">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn modf(e: T) -> __modf_result_vecN_f32
+@const @must_use fn modf(e: T) -> __modf_result_vecN_f32
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13098,7 +13114,7 @@ but a value may infer the type.
   <tr algorithm="vector case, binary16, modf">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn modf(e: T) -> __modf_result_vecN_f16
+@const @must_use fn modf(e: T) -> __modf_result_vecN_f16
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13130,7 +13146,7 @@ but a value may infer the type.
   <tr algorithm="vector case, abstract, modf">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn modf(e: T) -> __modf_result_vecN_abstract
+@const @must_use fn modf(e: T) -> __modf_result_vecN_abstract
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13163,7 +13179,7 @@ but a value may infer the type.
   <tr algorithm="vector case, normalize">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn normalize(e: vecN<T> ) -> vecN<T>
+@const @must_use fn normalize(e: vecN<T> ) -> vecN<T>
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13178,8 +13194,8 @@ but a value may infer the type.
   <tr algorithm="pow">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn pow(e1: T,
-              e2: T) -> T
+@const @must_use fn pow(e1: T,
+                        e2: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13195,7 +13211,7 @@ but a value may infer the type.
   <tr algorithm="quantize to f16">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn quantizeToF16(e: T) -> T
+@const @must_use fn quantizeToF16(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13230,7 +13246,7 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
   <tr algorithm="radians">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn radians(e1: T) -> T
+@const @must_use fn radians(e1: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13246,8 +13262,8 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
   <tr algorithm="reflect">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn reflect(e1: T,
-                  e2: T) -> T
+@const @must_use fn reflect(e1: T,
+                            e2: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13263,9 +13279,9 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
   <tr algorithm="refract">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn refract(e1: T,
-                  e2: T,
-                  e3: I) -> T
+@const @must_use fn refract(e1: T,
+                            e2: T,
+                            e3: I) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13285,7 +13301,7 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
   <tr algorithm="bit reversal">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn reverseBits(e: T) -> T
+@const @must_use fn reverseBits(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13302,7 +13318,7 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
   <tr algorithm="round">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn round(e: T) -> T
+@const @must_use fn round(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13320,7 +13336,7 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
   <tr algorithm="saturate">
   <td style="width:10%">Overload
   <td class="nowrap"><xmp highlight=rust>
-@const fn saturate(e: T) -> T
+@const @must_use fn saturate(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13336,7 +13352,7 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
   <tr algorithm="numeric sign">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn sign(e: T) -> T
+@const @must_use fn sign(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13358,7 +13374,7 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
   <tr algorithm="sin">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn sin(e: T) -> T
+@const @must_use fn sin(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13374,7 +13390,7 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
   <tr algorithm="sinh">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn sinh(e: T) -> T
+@const @must_use fn sinh(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13394,9 +13410,9 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
   <tr algorithm="smoothstep">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn smoothstep(low: T,
-                     high: T,
-                     x: T) -> T
+@const @must_use fn smoothstep(low: T,
+                               high: T,
+                               x: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13416,7 +13432,7 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
   <tr algorithm="sqrt">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn sqrt(e: T) -> T
+@const @must_use fn sqrt(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13432,8 +13448,8 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
   <tr algorithm="step">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn step(edge: T,
-               x: T) -> T
+@const @must_use fn step(edge: T,
+                         x: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13449,7 +13465,7 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
   <tr algorithm="tan">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn tan(e: T) -> T
+@const @must_use fn tan(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13465,7 +13481,7 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
   <tr algorithm="tanh">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn tanh(e: T) -> T
+@const @must_use fn tanh(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13485,7 +13501,7 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
   <tr algorithm="transpose">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn transpose(e: matRxC<T>) -> matCxR<T>
+@const @must_use fn transpose(e: matRxC<T>) -> matCxR<T>
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13500,7 +13516,7 @@ Note: The vec2&lt;f32&gt; case is the same as `unpack2x16float(pack2x16float(e))
   <tr algorithm="trunc">
         <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn trunc(e: T) -> T
+@const @must_use fn trunc(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13525,7 +13541,7 @@ These functions:
   <tr algorithm="dpdx">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-fn dpdx(e: T) -> T
+@must_use fn dpdx(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13541,7 +13557,7 @@ fn dpdx(e: T) -> T
   <tr algorithm="dpdxCoarse">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-fn dpdxCoarse(e: T) -> T
+@must_use fn dpdxCoarse(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13557,7 +13573,7 @@ fn dpdxCoarse(e: T) -> T
   <tr algorithm="dpdxFine">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-fn dpdxFine(e: T) -> T
+@must_use fn dpdxFine(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13572,7 +13588,7 @@ fn dpdxFine(e: T) -> T
   <tr algorithm="dpdy">
   <td style="width:10%">Overload
   <td class="nowrap"><xmp highlight=rust>
-fn dpdy(e: T) -> T
+@must_use fn dpdy(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13588,7 +13604,7 @@ fn dpdy(e: T) -> T
   <tr algorithm="dpdyCoarse">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-fn dpdyCoarse(e: T) -> T
+@must_use fn dpdyCoarse(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13604,7 +13620,7 @@ fn dpdyCoarse(e: T) -> T
   <tr algorithm="dpdyFine">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-fn dpdyFine(e: T) -> T
+@must_use fn dpdyFine(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13619,7 +13635,7 @@ fn dpdyFine(e: T) -> T
   <tr algorithm="fwidth">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-fn fwidth(e: T) -> T
+@must_use fn fwidth(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13634,7 +13650,7 @@ fn fwidth(e: T) -> T
   <tr algorithm="fwidthCoarse">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-fn fwidthCoarse(e: T) -> T
+@must_use fn fwidthCoarse(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13649,7 +13665,7 @@ fn fwidthCoarse(e: T) -> T
   <tr algorithm="fwidthFine">
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-fn fwidthFine(e: T) -> T
+@must_use fn fwidthFine(e: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -13684,8 +13700,8 @@ Returns the dimensions of a texture, or texture's mip level in texels.
 
         <var ignore>L</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureDimensions(t: T,
-                     level: L) -> u32</xmp>
+@must_use fn textureDimensions(t: T,
+                               level: L) -> u32</xmp>
 
   <tr algorithm="textureDimensions 2d">
     <td><var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]<br>
@@ -13707,8 +13723,8 @@ fn textureDimensions(t: T,
 
         <var ignore>L</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureDimensions(t: T,
-                     level: L) -> vec2<u32></xmp>
+@must_use fn textureDimensions(t: T,
+                               level: L) -> vec2<u32></xmp>
 
   <tr algorithm="textureDimensions 3d">
     <td><var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]<br>
@@ -13723,8 +13739,8 @@ fn textureDimensions(t: T,
 
         <var ignore>L</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureDimensions(t: T,
-                     level: L) -> vec3<u32></xmp>
+@must_use fn textureDimensions(t: T,
+                               level: L) -> vec3<u32></xmp>
 </table>
 
 **Parameters:**
@@ -13788,110 +13804,110 @@ https://github.com/gpuweb/gpuweb/issues/2343
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
     <td><xmp highlight=rust>
-fn textureGather(component: C,
-                 t: texture_2d<ST>,
-                 s: sampler,
-                 coords: vec2<f32>) -> vec4<ST></xmp>
+@must_use fn textureGather(component: C,
+                           t: texture_2d<ST>,
+                           s: sampler,
+                           coords: vec2<f32>) -> vec4<ST></xmp>
 
   <tr algorithm="textureGather 2d offset">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
     <td><xmp highlight=rust>
-fn textureGather(component: C,
-                 t: texture_2d<ST>,
-                 s: sampler,
-                 coords: vec2<f32>,
-                 offset: vec2<i32>) -> vec4<ST></xmp>
+@must_use fn textureGather(component: C,
+                           t: texture_2d<ST>,
+                           s: sampler,
+                           coords: vec2<f32>,
+                           offset: vec2<i32>) -> vec4<ST></xmp>
 
   <tr algorithm="textureGather 2d array">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
         <var ignore>A</var> is [=i32=], or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
     <td><xmp highlight=rust>
-fn textureGather(component: C,
-                 t: texture_2d_array<ST>,
-                 s: sampler,
-                 coords: vec2<f32>,
-                 array_index: A) -> vec4<ST></xmp>
+@must_use fn textureGather(component: C,
+                           t: texture_2d_array<ST>,
+                           s: sampler,
+                           coords: vec2<f32>,
+                           array_index: A) -> vec4<ST></xmp>
 
   <tr algorithm="textureGather 2d array offset">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
         <var ignore>A</var> is [=i32=], or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
     <td><xmp highlight=rust>
-fn textureGather(component: C,
-                 t: texture_2d_array<ST>,
-                 s: sampler,
-                 coords: vec2<f32>,
-                 array_index: A,
-                 offset: vec2<i32>) -> vec4<ST></xmp>
+@must_use fn textureGather(component: C,
+                           t: texture_2d_array<ST>,
+                           s: sampler,
+                           coords: vec2<f32>,
+                           array_index: A,
+                           offset: vec2<i32>) -> vec4<ST></xmp>
 
   <tr algorithm="textureGather cube">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
     <td><xmp highlight=rust>
-fn textureGather(component: C,
-                 t: texture_cube<ST>,
-                 s: sampler,
-                 coords: vec3<f32>) -> vec4<ST></xmp>
+@must_use fn textureGather(component: C,
+                           t: texture_cube<ST>,
+                           s: sampler,
+                           coords: vec3<f32>) -> vec4<ST></xmp>
 
   <tr algorithm="textureGather cube array">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
         <var ignore>A</var> is [=i32=], or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
     <td><xmp highlight=rust>
-fn textureGather(component: C,
-                 t: texture_cube_array<ST>,
-                 s: sampler,
-                 coords: vec3<f32>,
-                 array_index: A) -> vec4<ST></xmp>
+@must_use fn textureGather(component: C,
+                           t: texture_cube_array<ST>,
+                           s: sampler,
+                           coords: vec3<f32>,
+                           array_index: A) -> vec4<ST></xmp>
 
   <tr algorithm="textureGather 2d depth">
     <td>
     <td><xmp highlight=rust>
-fn textureGather(t: texture_depth_2d,
-                 s: sampler,
-                 coords: vec2<f32>) -> vec4<f32></xmp>
+@must_use fn textureGather(t: texture_depth_2d,
+                           s: sampler,
+                           coords: vec2<f32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureGather 2d depth offset">
     <td>
     <td><xmp highlight=rust>
-fn textureGather(t: texture_depth_2d,
-                 s: sampler,
-                 coords: vec2<f32>,
-                 offset: vec2<i32>) -> vec4<f32></xmp>
+@must_use fn textureGather(t: texture_depth_2d,
+                           s: sampler,
+                           coords: vec2<f32>,
+                           offset: vec2<i32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureGather cube depth">
     <td>
     <td><xmp highlight=rust>
-fn textureGather(t: texture_depth_cube,
-                 s: sampler,
-                 coords: vec3<f32>) -> vec4<f32></xmp>
+@must_use fn textureGather(t: texture_depth_cube,
+                           s: sampler,
+                           coords: vec3<f32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureGather 2d depth array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureGather(t: texture_depth_2d_array,
-                 s: sampler,
-                 coords: vec2<f32>,
-                 array_index: A) -> vec4<f32></xmp>
+@must_use fn textureGather(t: texture_depth_2d_array,
+                           s: sampler,
+                           coords: vec2<f32>,
+                           array_index: A) -> vec4<f32></xmp>
 
   <tr algorithm="textureGather 2d depth array offset">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureGather(t: texture_depth_2d_array,
-                 s: sampler,
-                 coords: vec2<f32>,
-                 array_index: A,
-                 offset: vec2<i32>) -> vec4<f32></xmp>
+@must_use fn textureGather(t: texture_depth_2d_array,
+                           s: sampler,
+                           coords: vec2<f32>,
+                           array_index: A,
+                           offset: vec2<i32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureGather cube depth array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureGather(t: texture_depth_cube_array,
-                 s: sampler,
-                 coords: vec3<f32>,
-                 array_index: A) -> vec4<f32></xmp>
+@must_use fn textureGather(t: texture_depth_cube_array,
+                           s: sampler,
+                           coords: vec3<f32>,
+                           array_index: A) -> vec4<f32></xmp>
 </table>
 
 **Parameters:**
@@ -13975,55 +13991,55 @@ texture and collects the results into a single vector, as follows:
   <tr algorithm="textureGatherCompare 2d depth">
     <td>
     <td><xmp highlight=rust>
-fn textureGatherCompare(t: texture_depth_2d,
-                        s: sampler_comparison,
-                        coords: vec2<f32>,
-                        depth_ref: f32) -> vec4<f32></xmp>
+@must_use fn textureGatherCompare(t: texture_depth_2d,
+                                  s: sampler_comparison,
+                                  coords: vec2<f32>,
+                                  depth_ref: f32) -> vec4<f32></xmp>
 
   <tr algorithm="textureGatherCompare 2d depth offset">
     <td>
     <td><xmp highlight=rust>
-fn textureGatherCompare(t: texture_depth_2d,
-                        s: sampler_comparison,
-                        coords: vec2<f32>,
-                        depth_ref: f32,
-                        offset: vec2<i32>) -> vec4<f32></xmp>
+@must_use fn textureGatherCompare(t: texture_depth_2d,
+                                  s: sampler_comparison,
+                                  coords: vec2<f32>,
+                                  depth_ref: f32,
+                                  offset: vec2<i32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureGatherCompare 2d depth array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureGatherCompare(t: texture_depth_2d_array,
-                        s: sampler_comparison,
-                        coords: vec2<f32>,
-                        array_index: A,
-                        depth_ref: f32) -> vec4<f32></xmp>
+@must_use fn textureGatherCompare(t: texture_depth_2d_array,
+                                  s: sampler_comparison,
+                                  coords: vec2<f32>,
+                                  array_index: A,
+                                  depth_ref: f32) -> vec4<f32></xmp>
 
   <tr algorithm="textureGatherCompare 2d depth array offset">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureGatherCompare(t: texture_depth_2d_array,
-                        s: sampler_comparison,
-                        coords: vec2<f32>,
-                        array_index: A,
-                        depth_ref: f32,
-                        offset: vec2<i32>) -> vec4<f32></xmp>
+@must_use fn textureGatherCompare(t: texture_depth_2d_array,
+                                  s: sampler_comparison,
+                                  coords: vec2<f32>,
+                                  array_index: A,
+                                  depth_ref: f32,
+                                  offset: vec2<i32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureGatherCompare 2d depth cube">
     <td>
     <td><xmp highlight=rust>
-fn textureGatherCompare(t: texture_depth_cube,
-                        s: sampler_comparison,
-                        coords: vec3<f32>,
-                        depth_ref: f32) -> vec4<f32></xmp>
+@must_use fn textureGatherCompare(t: texture_depth_cube,
+                                  s: sampler_comparison,
+                                  coords: vec3<f32>,
+                                  depth_ref: f32) -> vec4<f32></xmp>
 
   <tr algorithm="textureGatherCompare 2d depth cube array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureGatherCompare(t: texture_depth_cube_array,
-                        s: sampler_comparison,
-                        coords: vec3<f32>,
-                        array_index: A,
-                        depth_ref: f32) -> vec4<f32></xmp>
+@must_use fn textureGatherCompare(t: texture_depth_cube_array,
+                                  s: sampler_comparison,
+                                  coords: vec3<f32>,
+                                  array_index: A,
+                                  depth_ref: f32) -> vec4<f32></xmp>
 
 </table>
 
@@ -14077,18 +14093,18 @@ Reads a single texel from a texture without sampling or filtering.
         <var ignore>L</var> is [=i32=], or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
     <td><xmp highlight=rust>
-fn textureLoad(t: texture_1d<ST>,
-               coords: C,
-               level: L) -> vec4<ST></xmp>
+@must_use fn textureLoad(t: texture_1d<ST>,
+                         coords: C,
+                         level: L) -> vec4<ST></xmp>
 
   <tr algorithm="textureLoad 2d">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
         <var ignore>L</var> is [=i32=], or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
     <td><xmp highlight=rust>
-fn textureLoad(t: texture_2d<ST>,
-               coords: vec2<C>,
-               level: L) -> vec4<ST></xmp>
+@must_use fn textureLoad(t: texture_2d<ST>,
+                         coords: vec2<C>,
+                         level: L) -> vec4<ST></xmp>
 
   <tr algorithm="textureLoad 2d array">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
@@ -14096,60 +14112,60 @@ fn textureLoad(t: texture_2d<ST>,
         <var ignore>L</var> is [=i32=], or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
     <td><xmp highlight=rust>
-fn textureLoad(t: texture_2d_array<ST>,
-              coords: vec2<C>,
-              array_index: A,
-              level: L) -> vec4<ST></xmp>
+@must_use fn textureLoad(t: texture_2d_array<ST>,
+                        coords: vec2<C>,
+                        array_index: A,
+                        level: L) -> vec4<ST></xmp>
 
   <tr algorithm="textureLoad 3d">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
         <var ignore>L</var> is [=i32=], or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
     <td><xmp highlight=rust>
-fn textureLoad(t: texture_3d<ST>,
-               coords: vec3<C>,
-               level: L) -> vec4<ST></xmp>
+@must_use fn textureLoad(t: texture_3d<ST>,
+                         coords: vec3<C>,
+                         level: L) -> vec4<ST></xmp>
 
   <tr algorithm="textureLoad 2d multisampled">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
         <var ignore>S</var> is [=i32=], or [=u32=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]
     <td><xmp highlight=rust>
-fn textureLoad(t: texture_multisampled_2d<ST>,
-               coords: vec2<C>,
-               sample_index: S)-> vec4<ST></xmp>
+@must_use fn textureLoad(t: texture_multisampled_2d<ST>,
+                         coords: vec2<C>,
+                         sample_index: S)-> vec4<ST></xmp>
 
   <tr algorithm="textureLoad 2d depth">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
         <var ignore>L</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureLoad(t: texture_depth_2d,
-               coords: vec2<C>,
-               level: L) -> f32</xmp>
+@must_use fn textureLoad(t: texture_depth_2d,
+                         coords: vec2<C>,
+                         level: L) -> f32</xmp>
 
   <tr algorithm="textureLoad 2d depth array">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
         <var ignore>A</var> is [=i32=], or [=u32=]<br>
         <var ignore>L</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureLoad(t: texture_depth_2d_array,
-               coords: vec2<C>,
-               array_index: A,
-               level: L) -> f32</xmp>
+@must_use fn textureLoad(t: texture_depth_2d_array,
+                         coords: vec2<C>,
+                         array_index: A,
+                         level: L) -> f32</xmp>
 
 <tr algorithm="textureLoad 2d depth multisampled">
     <td><var ignore>C</var> is [=i32=], or [=u32=]<br>
         <var ignore>S</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureLoad(t: texture_depth_multisampled_2d,
-               coords: vec2<C>,
-               sample_index: S)-> f32</xmp>
+@must_use fn textureLoad(t: texture_depth_multisampled_2d,
+                         coords: vec2<C>,
+                         sample_index: S)-> f32</xmp>
 
   <tr algorithm="textureLoad external">
     <td><var ignore>C</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureLoad(t: texture_external,
-               coords: vec2<C>) -> vec4<f32></xmp>
+@must_use fn textureLoad(t: texture_external,
+                         coords: vec2<C>) -> vec4<f32></xmp>
 
 </table>
 
@@ -14202,7 +14218,7 @@ Returns the number of layers (elements) of an array texture.
                                `texture_depth_2d_array`, `texture_depth_cube_array`,
                                or `texture_storage_2d_array<F,A>`
     <td><xmp highlight=rust>
-fn textureNumLayers(t: T) -> u32</xmp>
+@must_use fn textureNumLayers(t: T) -> u32</xmp>
 
 </table>
 
@@ -14236,7 +14252,7 @@ Returns the number of mip levels of a texture.
                                `texture_depth_2d`, `texture_depth_2d_array`,
                                `texture_depth_cube`, or `texture_depth_cube_array`
     <td><xmp highlight=rust>
-fn textureNumLevels(t: T) -> u32</xmp>
+@must_use fn textureNumLevels(t: T) -> u32</xmp>
 
 </table>
 
@@ -14265,7 +14281,7 @@ Returns the number samples per texel in a multisampled texture.
         <var ignore>T</var> is `texture_multisampled_2d<ST>`
                                 or `texture_depth_multisampled_2d`
     <td><xmp highlight=rust>
-fn textureNumSamples(t: T) -> u32</xmp>
+@must_use fn textureNumSamples(t: T) -> u32</xmp>
 
 </table>
 
@@ -14295,111 +14311,111 @@ Samples a texture.
   <tr algorithm="textureSample 1d">
     <td>
     <td><xmp highlight=rust>
-fn textureSample(t: texture_1d<f32>,
-                 s: sampler,
-                 coords: f32) -> vec4<f32></xmp>
+@must_use fn textureSample(t: texture_1d<f32>,
+                           s: sampler,
+                           coords: f32) -> vec4<f32></xmp>
 
   <tr algorithm="textureSample 2d">
     <td>
     <td><xmp highlight=rust>
-fn textureSample(t: texture_2d<f32>,
-                 s: sampler,
-                 coords: vec2<f32>) -> vec4<f32></xmp>
+@must_use fn textureSample(t: texture_2d<f32>,
+                           s: sampler,
+                           coords: vec2<f32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureSample 2d offset">
     <td>
     <td><xmp highlight=rust>
-fn textureSample(t: texture_2d<f32>,
-                 s: sampler,
-                 coords: vec2<f32>,
-                 offset: vec2<i32>) -> vec4<f32></xmp>
+@must_use fn textureSample(t: texture_2d<f32>,
+                           s: sampler,
+                           coords: vec2<f32>,
+                           offset: vec2<i32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureSample 2d array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSample(t: texture_2d_array<f32>,
-                 s: sampler,
-                 coords: vec2<f32>,
-                 array_index: A) -> vec4<f32></xmp>
+@must_use fn textureSample(t: texture_2d_array<f32>,
+                           s: sampler,
+                           coords: vec2<f32>,
+                           array_index: A) -> vec4<f32></xmp>
 
   <tr algorithm="textureSample 2d array offset">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSample(t: texture_2d_array<f32>,
-                 s: sampler,
-                 coords: vec2<f32>,
-                 array_index: A,
-                 offset: vec2<i32>) -> vec4<f32></xmp>
+@must_use fn textureSample(t: texture_2d_array<f32>,
+                           s: sampler,
+                           coords: vec2<f32>,
+                           array_index: A,
+                           offset: vec2<i32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureSample 3d">
     <td><var ignore>T</var> is `texture_3d<f32>`, or `texture_cube<f32>`
     <td><xmp highlight=rust>
-fn textureSample(t: T,
-                 s: sampler,
-                 coords: vec3<f32>) -> vec4<f32></xmp>
+@must_use fn textureSample(t: T,
+                           s: sampler,
+                           coords: vec3<f32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureSample 3d offset">
     <td>
     <td><xmp highlight=rust>
-fn textureSample(t: texture_3d<f32>,
-                 s: sampler,
-                 coords: vec3<f32>,
-                 offset: vec3<i32>) -> vec4<f32></xmp>
+@must_use fn textureSample(t: texture_3d<f32>,
+                           s: sampler,
+                           coords: vec3<f32>,
+                           offset: vec3<i32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureSample cube array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSample(t: texture_cube_array<f32>,
-                 s: sampler,
-                 coords: vec3<f32>,
-                 array_index: A) -> vec4<f32></xmp>
+@must_use fn textureSample(t: texture_cube_array<f32>,
+                           s: sampler,
+                           coords: vec3<f32>,
+                           array_index: A) -> vec4<f32></xmp>
 
   <tr algorithm="textureSample 2d depth">
     <td>
     <td><xmp highlight=rust>
-fn textureSample(t: texture_depth_2d,
-                 s: sampler,
-                 coords: vec2<f32>) -> f32</xmp>
+@must_use fn textureSample(t: texture_depth_2d,
+                           s: sampler,
+                           coords: vec2<f32>) -> f32</xmp>
 
   <tr algorithm="textureSample 2d depth offset">
     <td>
     <td><xmp highlight=rust>
-fn textureSample(t: texture_depth_2d,
-                 s: sampler,
-                 coords: vec2<f32>,
-                 offset: vec2<i32>) -> f32</xmp>
+@must_use fn textureSample(t: texture_depth_2d,
+                           s: sampler,
+                           coords: vec2<f32>,
+                           offset: vec2<i32>) -> f32</xmp>
 
   <tr algorithm="textureSample 2d depth array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSample(t: texture_depth_2d_array,
-                 s: sampler,
-                 coords: vec2<f32>,
-                 array_index: A) -> f32</xmp>
+@must_use fn textureSample(t: texture_depth_2d_array,
+                           s: sampler,
+                           coords: vec2<f32>,
+                           array_index: A) -> f32</xmp>
 
   <tr algorithm="textureSample 2d depth array offset">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSample(t: texture_depth_2d_array,
-                 s: sampler,
-                 coords: vec2<f32>,
-                 array_index: A,
-                 offset: vec2<i32>) -> f32</xmp>
+@must_use fn textureSample(t: texture_depth_2d_array,
+                           s: sampler,
+                           coords: vec2<f32>,
+                           array_index: A,
+                           offset: vec2<i32>) -> f32</xmp>
 
   <tr algorithm="textureSample cube depth">
     <td>
     <td><xmp highlight=rust>
-fn textureSample(t: texture_depth_cube,
-                 s: sampler,
-                 coords: vec3<f32>) -> f32</xmp>
+@must_use fn textureSample(t: texture_depth_cube,
+                           s: sampler,
+                           coords: vec3<f32>) -> f32</xmp>
 
   <tr algorithm="textureSample cube depth array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSample(t: texture_depth_cube_array,
-                 s: sampler,
-                 coords: vec3<f32>,
-                 array_index: A) -> f32</xmp>
+@must_use fn textureSample(t: texture_depth_cube_array,
+                           s: sampler,
+                           coords: vec3<f32>,
+                           array_index: A) -> f32</xmp>
 
 </table>
 
@@ -14442,64 +14458,64 @@ Samples a texture with a bias to the mip level.
   <tr algorithm="textureSampleBias 2d">
     <td>
     <td><xmp highlight=rust>
-fn textureSampleBias(t: texture_2d<f32>,
-                     s: sampler,
-                     coords: vec2<f32>,
-                     bias: f32) -> vec4<f32></xmp>
+@must_use fn textureSampleBias(t: texture_2d<f32>,
+                               s: sampler,
+                               coords: vec2<f32>,
+                               bias: f32) -> vec4<f32></xmp>
 
 <tr algorithm="textureSampleBias 2d offset">
     <td>
     <td><xmp highlight=rust>
-fn textureSampleBias(t: texture_2d<f32>,
-                     s: sampler,
-                     coords: vec2<f32>,
-                     bias: f32,
-                     offset: vec2<i32>) -> vec4<f32></xmp>
+@must_use fn textureSampleBias(t: texture_2d<f32>,
+                               s: sampler,
+                               coords: vec2<f32>,
+                               bias: f32,
+                               offset: vec2<i32>) -> vec4<f32></xmp>
 
 <tr algorithm="textureSampleBias 2d array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSampleBias(t: texture_2d_array<f32>,
-                     s: sampler,
-                     coords: vec2<f32>,
-                     array_index: A,
-                     bias: f32) -> vec4<f32></xmp>
+@must_use fn textureSampleBias(t: texture_2d_array<f32>,
+                               s: sampler,
+                               coords: vec2<f32>,
+                               array_index: A,
+                               bias: f32) -> vec4<f32></xmp>
 
 <tr algorithm="textureSampleBias 2d array offset">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSampleBias(t: texture_2d_array<f32>,
-                     s: sampler,
-                     coords: vec2<f32>,
-                     array_index: A,
-                     bias: f32,
-                     offset: vec2<i32>) -> vec4<f32></xmp>
+@must_use fn textureSampleBias(t: texture_2d_array<f32>,
+                               s: sampler,
+                               coords: vec2<f32>,
+                               array_index: A,
+                               bias: f32,
+                               offset: vec2<i32>) -> vec4<f32></xmp>
 
 <tr algorithm="textureSampleBias 3d">
     <td><var ignore>T</var> is `texture_3d<f32>`, or `texture_cube<f32>`
     <td><xmp highlight=rust>
-fn textureSampleBias(t: T,
-                     s: sampler,
-                     coords: vec3<f32>,
-                     bias: f32) -> vec4<f32></xmp>
+@must_use fn textureSampleBias(t: T,
+                               s: sampler,
+                               coords: vec3<f32>,
+                               bias: f32) -> vec4<f32></xmp>
 
 <tr algorithm="textureSampleBias 3d offset">
     <td>
     <td><xmp highlight=rust>
-fn textureSampleBias(t: texture_3d<f32>,
-                     s: sampler,
-                     coords: vec3<f32>,
-                     bias: f32,
-                     offset: vec3<i32>) -> vec4<f32></xmp>
+@must_use fn textureSampleBias(t: texture_3d<f32>,
+                               s: sampler,
+                               coords: vec3<f32>,
+                               bias: f32,
+                               offset: vec3<i32>) -> vec4<f32></xmp>
 
 <tr algorithm="textureSampleBias cube array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSampleBias(t: texture_cube_array<f32>,
-                     s: sampler,
-                     coords: vec3<f32>,
-                     array_index: A,
-                     bias: f32) -> vec4<f32></xmp>
+@must_use fn textureSampleBias(t: texture_cube_array<f32>,
+                               s: sampler,
+                               coords: vec3<f32>,
+                               array_index: A,
+                               bias: f32) -> vec4<f32></xmp>
 
 </table>
 
@@ -14545,55 +14561,55 @@ Samples a depth texture and compares the sampled depth values against a referenc
   <tr algorithm="textureSampleCompare 2d depth">
     <td>
     <td><xmp highlight=rust>
-fn textureSampleCompare(t: texture_depth_2d,
-                        s: sampler_comparison,
-                        coords: vec2<f32>,
-                        depth_ref: f32) -> f32</xmp>
+@must_use fn textureSampleCompare(t: texture_depth_2d,
+                                  s: sampler_comparison,
+                                  coords: vec2<f32>,
+                                  depth_ref: f32) -> f32</xmp>
 
   <tr algorithm="textureSampleCompare 2d depth offset">
     <td>
     <td><xmp highlight=rust>
-fn textureSampleCompare(t: texture_depth_2d,
-                        s: sampler_comparison,
-                        coords: vec2<f32>,
-                        depth_ref: f32,
-                        offset: vec2<i32>) -> f32</xmp>
+@must_use fn textureSampleCompare(t: texture_depth_2d,
+                                  s: sampler_comparison,
+                                  coords: vec2<f32>,
+                                  depth_ref: f32,
+                                  offset: vec2<i32>) -> f32</xmp>
 
   <tr algorithm="textureSampleCompare 2d array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSampleCompare(t: texture_depth_2d_array,
-                        s: sampler_comparison,
-                        coords: vec2<f32>,
-                        array_index: A,
-                        depth_ref: f32) -> f32</xmp>
+@must_use fn textureSampleCompare(t: texture_depth_2d_array,
+                                  s: sampler_comparison,
+                                  coords: vec2<f32>,
+                                  array_index: A,
+                                  depth_ref: f32) -> f32</xmp>
 
   <tr algorithm="textureSampleCompare 2d depth array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSampleCompare(t: texture_depth_2d_array,
-                        s: sampler_comparison,
-                        coords: vec2<f32>,
-                        array_index: A,
-                        depth_ref: f32,
-                        offset: vec2<i32>) -> f32</xmp>
+@must_use fn textureSampleCompare(t: texture_depth_2d_array,
+                                  s: sampler_comparison,
+                                  coords: vec2<f32>,
+                                  array_index: A,
+                                  depth_ref: f32,
+                                  offset: vec2<i32>) -> f32</xmp>
 
   <tr algorithm="textureSampleCompare cube depth">
     <td>
     <td><xmp highlight=rust>
-fn textureSampleCompare(t: texture_depth_cube,
-                        s: sampler_comparison,
-                        coords: vec3<f32>,
-                        depth_ref: f32) -> f32</xmp>
+@must_use fn textureSampleCompare(t: texture_depth_cube,
+                                  s: sampler_comparison,
+                                  coords: vec3<f32>,
+                                  depth_ref: f32) -> f32</xmp>
 
   <tr algorithm="textureSampleCompare cube depth array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSampleCompare(t: texture_depth_cube_array,
-                        s: sampler_comparison,
-                        coords: vec3<f32>,
-                        array_index: A,
-                        depth_ref: f32) -> f32</xmp>
+@must_use fn textureSampleCompare(t: texture_depth_cube_array,
+                                  s: sampler_comparison,
+                                  coords: vec3<f32>,
+                                  array_index: A,
+                                  depth_ref: f32) -> f32</xmp>
 
 </table>
 
@@ -14643,55 +14659,55 @@ Samples a depth texture and compares the sampled depth values against a referenc
   <tr algorithm="textureSampleCompareLevel 2d depth">
     <td>
     <td><xmp highlight=rust>
-fn textureSampleCompareLevel(t: texture_depth_2d,
-                             s: sampler_comparison,
-                             coords: vec2<f32>,
-                             depth_ref: f32) -> f32</xmp>
+@must_use fn textureSampleCompareLevel(t: texture_depth_2d,
+                                       s: sampler_comparison,
+                                       coords: vec2<f32>,
+                                       depth_ref: f32) -> f32</xmp>
 
   <tr algorithm="textureSampleCompareLevel 2d depth offset">
     <td>
     <td><xmp highlight=rust>
-fn textureSampleCompareLevel(t: texture_depth_2d,
-                             s: sampler_comparison,
-                             coords: vec2<f32>,
-                             depth_ref: f32,
-                             offset: vec2<i32>) -> f32</xmp>
+@must_use fn textureSampleCompareLevel(t: texture_depth_2d,
+                                       s: sampler_comparison,
+                                       coords: vec2<f32>,
+                                       depth_ref: f32,
+                                       offset: vec2<i32>) -> f32</xmp>
 
   <tr algorithm="textureSampleCompareLevel 2d depth array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSampleCompareLevel(t: texture_depth_2d_array,
-                             s: sampler_comparison,
-                             coords: vec2<f32>,
-                             array_index: A,
-                             depth_ref: f32) -> f32</xmp>
+@must_use fn textureSampleCompareLevel(t: texture_depth_2d_array,
+                                       s: sampler_comparison,
+                                       coords: vec2<f32>,
+                                       array_index: A,
+                                       depth_ref: f32) -> f32</xmp>
 
   <tr algorithm="textureSampleCompareLevel 2d depth array offset">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSampleCompareLevel(t: texture_depth_2d_array,
-                             s: sampler_comparison,
-                             coords: vec2<f32>,
-                             array_index: A,
-                             depth_ref: f32,
-                             offset: vec2<i32>) -> f32</xmp>
+@must_use fn textureSampleCompareLevel(t: texture_depth_2d_array,
+                                       s: sampler_comparison,
+                                       coords: vec2<f32>,
+                                       array_index: A,
+                                       depth_ref: f32,
+                                       offset: vec2<i32>) -> f32</xmp>
 
   <tr algorithm="textureSampleCompareLevel cube depth">
     <td>
     <td><xmp highlight=rust>
-fn textureSampleCompareLevel(t: texture_depth_cube,
-                             s: sampler_comparison,
-                             coords: vec3<f32>,
-                             depth_ref: f32) -> f32</xmp>
+@must_use fn textureSampleCompareLevel(t: texture_depth_cube,
+                                       s: sampler_comparison,
+                                       coords: vec3<f32>,
+                                       depth_ref: f32) -> f32</xmp>
 
   <tr algorithm="textureSampleCompareLevel cube depth array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSampleCompareLevel(t: texture_depth_cube_array,
-                             s: sampler_comparison,
-                             coords: vec3<f32>,
-                             array_index: A,
-                             depth_ref: f32) -> f32</xmp>
+@must_use fn textureSampleCompareLevel(t: texture_depth_cube_array,
+                                       s: sampler_comparison,
+                                       coords: vec3<f32>,
+                                       array_index: A,
+                                       depth_ref: f32) -> f32</xmp>
 
 </table>
 
@@ -14739,71 +14755,71 @@ Samples a texture using explicit gradients.
   <tr algorithm="textureSampleGrad 2d">
     <td>
     <td><xmp highlight=rust>
-fn textureSampleGrad(t: texture_2d<f32>,
-                     s: sampler,
-                     coords: vec2<f32>,
-                     ddx: vec2<f32>,
-                     ddy: vec2<f32>) -> vec4<f32></xmp>
+@must_use fn textureSampleGrad(t: texture_2d<f32>,
+                               s: sampler,
+                               coords: vec2<f32>,
+                               ddx: vec2<f32>,
+                               ddy: vec2<f32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureSampleGrad 2d offset">
     <td>
     <td><xmp highlight=rust>
-fn textureSampleGrad(t: texture_2d<f32>,
-                     s: sampler,
-                     coords: vec2<f32>,
-                     ddx: vec2<f32>,
-                     ddy: vec2<f32>,
-                     offset: vec2<i32>) -> vec4<f32></xmp>
+@must_use fn textureSampleGrad(t: texture_2d<f32>,
+                               s: sampler,
+                               coords: vec2<f32>,
+                               ddx: vec2<f32>,
+                               ddy: vec2<f32>,
+                               offset: vec2<i32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureSampleGrad 2d array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSampleGrad(t: texture_2d_array<f32>,
-                     s: sampler,
-                     coords: vec2<f32>,
-                     array_index: A,
-                     ddx: vec2<f32>,
-                     ddy: vec2<f32>) -> vec4<f32></xmp>
+@must_use fn textureSampleGrad(t: texture_2d_array<f32>,
+                               s: sampler,
+                               coords: vec2<f32>,
+                               array_index: A,
+                               ddx: vec2<f32>,
+                               ddy: vec2<f32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureSampleGrad 2d array offset">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSampleGrad(t: texture_2d_array<f32>,
-                     s: sampler,
-                     coords: vec2<f32>,
-                     array_index: A,
-                     ddx: vec2<f32>,
-                     ddy: vec2<f32>,
-                     offset: vec2<i32>) -> vec4<f32></xmp>
+@must_use fn textureSampleGrad(t: texture_2d_array<f32>,
+                               s: sampler,
+                               coords: vec2<f32>,
+                               array_index: A,
+                               ddx: vec2<f32>,
+                               ddy: vec2<f32>,
+                               offset: vec2<i32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureSampleGrad 3d">
     <td><var ignore>T</var> is `texture_3d<f32>`, or `texture_cube<f32>`
     <td><xmp highlight=rust>
-fn textureSampleGrad(t: T,
-                     s: sampler,
-                     coords: vec3<f32>,
-                     ddx: vec3<f32>,
-                     ddy: vec3<f32>) -> vec4<f32></xmp>
+@must_use fn textureSampleGrad(t: T,
+                               s: sampler,
+                               coords: vec3<f32>,
+                               ddx: vec3<f32>,
+                               ddy: vec3<f32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureSampleGrad 3d offset">
     <td>
     <td><xmp highlight=rust>
-fn textureSampleGrad(t: texture_3d<f32>,
-                     s: sampler,
-                     coords: vec3<f32>,
-                     ddx: vec3<f32>,
-                     ddy: vec3<f32>,
-                     offset: vec3<i32>) -> vec4<f32></xmp>
+@must_use fn textureSampleGrad(t: texture_3d<f32>,
+                               s: sampler,
+                               coords: vec3<f32>,
+                               ddx: vec3<f32>,
+                               ddy: vec3<f32>,
+                               offset: vec3<i32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureSampleGrad cube array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSampleGrad(t: texture_cube_array<f32>,
-                     s: sampler,
-                     coords: vec3<f32>,
-                     array_index: A,
-                     ddx: vec3<f32>,
-                     ddy: vec3<f32>) -> vec4<f32></xmp>
+@must_use fn textureSampleGrad(t: texture_cube_array<f32>,
+                               s: sampler,
+                               coords: vec3<f32>,
+                               array_index: A,
+                               ddx: vec3<f32>,
+                               ddy: vec3<f32>) -> vec4<f32></xmp>
 
 </table>
 
@@ -14847,120 +14863,120 @@ Samples a texture using an explicit mip level.
   <tr algorithm="textureSampleLevel 2d">
     <td>
     <td><xmp highlight=rust>
-fn textureSampleLevel(t: texture_2d<f32>,
-                      s: sampler,
-                      coords: vec2<f32>,
-                      level: f32) -> vec4<f32></xmp>
+@must_use fn textureSampleLevel(t: texture_2d<f32>,
+                                s: sampler,
+                                coords: vec2<f32>,
+                                level: f32) -> vec4<f32></xmp>
 
   <tr algorithm="textureSampleLevel 2d offset">
     <td>
     <td><xmp highlight=rust>
-fn textureSampleLevel(t: texture_2d<f32>,
-                      s: sampler,
-                      coords: vec2<f32>,
-                      level: f32,
-                      offset: vec2<i32>) -> vec4<f32></xmp>
+@must_use fn textureSampleLevel(t: texture_2d<f32>,
+                                s: sampler,
+                                coords: vec2<f32>,
+                                level: f32,
+                                offset: vec2<i32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureSampleLevel 2d array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSampleLevel(t: texture_2d_array<f32>,
-                      s: sampler,
-                      coords: vec2<f32>,
-                      array_index: A,
-                      level: f32) -> vec4<f32></xmp>
+@must_use fn textureSampleLevel(t: texture_2d_array<f32>,
+                                s: sampler,
+                                coords: vec2<f32>,
+                                array_index: A,
+                                level: f32) -> vec4<f32></xmp>
 
   <tr algorithm="textureSampleLevel 2d array offset">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSampleLevel(t: texture_2d_array<f32>,
-                      s: sampler,
-                      coords: vec2<f32>,
-                      array_index: A,
-                      level: f32,
-                      offset: vec2<i32>) -> vec4<f32></xmp>
+@must_use fn textureSampleLevel(t: texture_2d_array<f32>,
+                                s: sampler,
+                                coords: vec2<f32>,
+                                array_index: A,
+                                level: f32,
+                                offset: vec2<i32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureSampleLevel 3d">
     <td><var ignore>T</var> is `texture_3d<f32>`, or `texture_cube<f32>`
     <td><xmp highlight=rust>
-fn textureSampleLevel(t: T,
-                      s: sampler,
-                      coords: vec3<f32>,
-                      level: f32) -> vec4<f32></xmp>
+@must_use fn textureSampleLevel(t: T,
+                                s: sampler,
+                                coords: vec3<f32>,
+                                level: f32) -> vec4<f32></xmp>
 
   <tr algorithm="textureSampleLevel 3d offset">
     <td>
     <td><xmp highlight=rust>
-fn textureSampleLevel(t: texture_3d<f32>,
-                      s: sampler,
-                      coords: vec3<f32>,
-                      level: f32,
-                      offset: vec3<i32>) -> vec4<f32></xmp>
+@must_use fn textureSampleLevel(t: texture_3d<f32>,
+                                s: sampler,
+                                coords: vec3<f32>,
+                                level: f32,
+                                offset: vec3<i32>) -> vec4<f32></xmp>
 
   <tr algorithm="textureSampleLevel cube array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSampleLevel(t: texture_cube_array<f32>,
-                      s: sampler,
-                      coords: vec3<f32>,
-                      array_index: A,
-                      level: f32) -> vec4<f32></xmp>
+@must_use fn textureSampleLevel(t: texture_cube_array<f32>,
+                                s: sampler,
+                                coords: vec3<f32>,
+                                array_index: A,
+                                level: f32) -> vec4<f32></xmp>
 
   <tr algorithm="textureSampleLevel 2d depth">
     <td><var ignore>L</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSampleLevel(t: texture_depth_2d,
-                      s: sampler,
-                      coords: vec2<f32>,
-                      level: L) -> f32</xmp>
+@must_use fn textureSampleLevel(t: texture_depth_2d,
+                                s: sampler,
+                                coords: vec2<f32>,
+                                level: L) -> f32</xmp>
 
   <tr algorithm="textureSampleLevel 2d depth offset">
     <td><var ignore>L</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSampleLevel(t: texture_depth_2d,
-                      s: sampler,
-                      coords: vec2<f32>,
-                      level: L,
-                      offset: vec2<i32>) -> f32</xmp>
+@must_use fn textureSampleLevel(t: texture_depth_2d,
+                                s: sampler,
+                                coords: vec2<f32>,
+                                level: L,
+                                offset: vec2<i32>) -> f32</xmp>
 
   <tr algorithm="textureSampleLevel 2d depth array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]<br>
         <var ignore>L</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSampleLevel(t: texture_depth_2d_array,
-                      s: sampler,
-                      coords: vec2<f32>,
-                      array_index: A,
-                      level: L) -> f32</xmp>
+@must_use fn textureSampleLevel(t: texture_depth_2d_array,
+                                s: sampler,
+                                coords: vec2<f32>,
+                                array_index: A,
+                                level: L) -> f32</xmp>
 
   <tr algorithm="textureSampleLevel 2d depth array offset">
     <td><var ignore>A</var> is [=i32=], or [=u32=]<br>
         <var ignore>L</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSampleLevel(t: texture_depth_2d_array,
-                      s: sampler,
-                      coords: vec2<f32>,
-                      array_index: A,
-                      level: L,
-                      offset: vec2<i32>) -> f32</xmp>
+@must_use fn textureSampleLevel(t: texture_depth_2d_array,
+                                s: sampler,
+                                coords: vec2<f32>,
+                                array_index: A,
+                                level: L,
+                                offset: vec2<i32>) -> f32</xmp>
 
   <tr algorithm="textureSampleLevel cube depth">
     <td><var ignore>L</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSampleLevel(t: texture_depth_cube,
-                      s: sampler,
-                      coords: vec3<f32>,
-                      level: L) -> f32</xmp>
+@must_use fn textureSampleLevel(t: texture_depth_cube,
+                                s: sampler,
+                                coords: vec3<f32>,
+                                level: L) -> f32</xmp>
 
   <tr algorithm="textureSampleLevel cube depth array">
     <td><var ignore>A</var> is [=i32=], or [=u32=]<br>
         <var ignore>L</var> is [=i32=], or [=u32=]
     <td><xmp highlight=rust>
-fn textureSampleLevel(t: texture_depth_cube_array,
-                      s: sampler,
-                      coords: vec3<f32>,
-                      array_index: A,
-                      level: L) -> f32
+@must_use fn textureSampleLevel(t: texture_depth_cube_array,
+                                s: sampler,
+                                coords: vec3<f32>,
+                                array_index: A,
+                                level: L) -> f32
 </xmp>
 </table>
 
@@ -15007,9 +15023,9 @@ with texture coordinates clamped to the edge as described below.
   <tr algorithm="textureSampleBaseClampToEdge">
     <td><var ignore>T</var> is `texture_2d<f32>` or `texture_external`
     <td><xmp highlight=rust>
-fn textureSampleBaseClampToEdge(t: T,
-                                s: sampler,
-                                coords: vec2<f32>) -> vec4<f32></xmp>
+@must_use fn textureSampleBaseClampToEdge(t: T,
+                                          s: sampler,
+                                          coords: vec2<f32>) -> vec4<f32></xmp>
 </table>
 
 **Parameters:**
@@ -15232,7 +15248,7 @@ Note: For packing snorm values, the normalized floating point values are in the 
   <tr algorithm="packing 4x8snorm">
     <td style="width:10%" style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn pack4x8snorm(e: vec4<f32>) -> u32
+@const @must_use fn pack4x8snorm(e: vec4<f32>) -> u32
 </xmp>
   <tr>
     <td>Description
@@ -15249,7 +15265,7 @@ Note: For packing snorm values, the normalized floating point values are in the 
   <tr algorithm="packing 4x8unorm">
     <td style="width:10%" style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn pack4x8unorm(e: vec4<f32>) -> u32
+@const @must_use fn pack4x8unorm(e: vec4<f32>) -> u32
 </xmp>
   <tr>
     <td>Description
@@ -15266,7 +15282,7 @@ Note: For packing snorm values, the normalized floating point values are in the 
   <tr algorithm="packing 2x16snorm">
     <td style="width:10%" style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn pack2x16snorm(e: vec2<f32>) -> u32
+@const @must_use fn pack2x16snorm(e: vec2<f32>) -> u32
 </xmp>
   <tr>
     <td>Description
@@ -15283,7 +15299,7 @@ Note: For packing snorm values, the normalized floating point values are in the 
   <tr algorithm="packing 2x16unorm">
     <td style="width:10%" style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn pack2x16unorm(e: vec2<f32>) -> u32
+@const @must_use fn pack2x16unorm(e: vec2<f32>) -> u32
 </xmp>
   <tr>
     <td>Description
@@ -15300,7 +15316,7 @@ Note: For packing snorm values, the normalized floating point values are in the 
   <tr algorithm="packing 2x16float">
     <td style="width:10%" style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn pack2x16float(e: vec2<f32>) -> u32
+@const @must_use fn pack2x16float(e: vec2<f32>) -> u32
 </xmp>
   <tr>
     <td>Description
@@ -15336,7 +15352,7 @@ Note: For unpacking snorm values, the normalized floating point result is in the
   <tr algorithm="unpacking 4x8snorm">
     <td style="width:10%" style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn unpack4x8snorm(e: u32) -> vec4<f32>
+@const @must_use fn unpack4x8snorm(e: u32) -> vec4<f32>
 </xmp>
   <tr>
     <td>Description
@@ -15351,7 +15367,7 @@ Note: For unpacking snorm values, the normalized floating point result is in the
   <tr algorithm="unpacking 4x8unorm">
     <td style="width:10%" style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn unpack4x8unorm(e: u32) -> vec4<f32>
+@const @must_use fn unpack4x8unorm(e: u32) -> vec4<f32>
 </xmp>
   <tr>
     <td>Description
@@ -15366,7 +15382,7 @@ Note: For unpacking snorm values, the normalized floating point result is in the
   <tr algorithm="unpacking 2x16snorm">
     <td style="width:10%" style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn unpack2x16snorm(e: u32) -> vec2<f32>
+@const @must_use fn unpack2x16snorm(e: u32) -> vec2<f32>
 </xmp>
   <tr>
     <td>Description
@@ -15381,7 +15397,7 @@ Note: For unpacking snorm values, the normalized floating point result is in the
   <tr algorithm="unpacking 2x16unorm">
     <td style="width:10%" style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn unpack2x16unorm(e: u32) -> vec2<f32>
+@const @must_use fn unpack2x16unorm(e: u32) -> vec2<f32>
 </xmp>
   <tr>
     <td>Description
@@ -15396,7 +15412,7 @@ Note: For unpacking snorm values, the normalized floating point result is in the
   <tr algorithm="unpacking 2x16float">
     <td style="width:10%" style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-@const fn unpack2x16float(e: u32) -> vec2<f32>
+@const @must_use fn unpack2x16float(e: u32) -> vec2<f32>
 </xmp>
   <tr>
     <td>Description
@@ -15463,7 +15479,7 @@ fn workgroupBarrier()
   <tr algorithm="workgroupUniformLoad">
     <td style="width:10%" style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
-fn workgroupUniformLoad(p : ptr<workgroup, T>) -> T
+@must_use fn workgroupUniformLoad(p : ptr<workgroup, T>) -> T
 </xmp>
   <tr>
     <td>Parameterization

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1296,7 +1296,8 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
 
         Note: Many functions return a value and do not have side effects.
         It is often a programming error to call such a function as the only thing in a function call statement.
-        Such functions are declared as `@must_use`.
+        Built-in functions with these properties are declared as `@must_use`.
+        User-defined functions can also have the `@must_use` attribute.
 
         Note: To deliberately work around the `@must_use` rule, use a [=phony assignment=]
         or [=value declaration|declare a value=] using the function call as the initializer.
@@ -12020,7 +12021,7 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
 @const @must_use fn atan2(y: T,
-                x: T) -> T
+                          x: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12063,8 +12064,8 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
   <td style="width:10%">Overload
   <td class="nowrap"><xmp highlight=rust>
 @const @must_use fn clamp(e: T,
-                low: T,
-                high: T) -> T
+                          low: T,
+                          high: T) -> T
 </xmp>
   <tr>
     <td style="width:10%">Parameterization
@@ -12179,7 +12180,7 @@ Note: The result is not mathematically meaningful when `abs(e)` &ge; 1.
     <td style="width:10%">Overload
     <td class="nowrap"><xmp highlight=rust>
 @const @must_use fn cross(e1: vec3<T>,
-                e2: vec3<T>) -> vec3<T>
+                          e2: vec3<T>) -> vec3<T>
 </xmp>
   <tr>
     <td style="width:10%">Parameterization

--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1289,7 +1289,7 @@ An attribute [=shader-creation error|must not=] be specified more than once per 
 
   <tr><td><dfn noexport dfn-for="attribute">`must_use`</dfn>
     <td>*None*
-    <td>Must only be applied to the declaration of a [=function/function=] with a [=return type=].
+    <td>[=shader-creation error|Must=] only be applied to the declaration of a [=function/function=] with a [=return type=].
 
         Specifies that a [=function call|call=] to this function [=shader-creation error|must=] be used as an [=expression=].
         That is, a call to this function [=shader-creation error|must=] not be the entirety of a [[#function-call-statement|function call statement]].

--- a/wgsl/wgsl.recursive.bs.include
+++ b/wgsl/wgsl.recursive.bs.include
@@ -71,6 +71,8 @@
 
  | `'@'` `'location'` `'('` [=recursive descent syntax/expression=] `','` ? `')'`
 
+ | `'@'` `'must_use'`
+
  | `'@'` `'size'` `'('` [=recursive descent syntax/expression=] `','` ? `')'`
 
  | `'@'` `'vertex'`


### PR DESCRIPTION
Must only be applied to the declaration of a function.

All side-effect-free built-in functions that return a value are @must_use. (Where side-effecting ignores derivative computation)

Built-ins that don't get must-use:
 - atomic functions
 - barriers
 - textureStore

Fixes: #3819