### PR TITLE
Fix case of `Hullshader` in unreserve list.

### DIFF
--- a/wgsl/keywords
+++ b/wgsl/keywords
@@ -525,7 +525,7 @@ DepthStencilState DepthStencilView double DomainShader
 dword
 false float
 GeometryShader
-half HullShader
+half Hullshader
 InputPatch int
 line lineadj
 LineStream


### PR DESCRIPTION
Unlike the others, e.g. `VertexShader`, `Hullshader` has a lower case `s`. This CL updates the unreserve list to match the correct name.