### PR TITLE
Define floating point accuracy for `transpose`

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -11154,6 +11154,7 @@ value with the same sign.
   <tr><td>`step(edge, x)`<td colspan=2 style="text-align:left;">Correctly rounded
   <tr><td>`tan(x)`<td colspan=2 style="text-align:left;">Inherited from `sin(x) / cos(x)`
   <tr><td>`tanh(x)`<td colspan=2 style="text-align:left;">Inherited from `sinh(x) / cosh(x)`
+  <tr><td>`transpose(x)`<td colspan=2 style="text-align:left;">Correctly rounded
   <tr><td>`trunc(x)`<td colspan=2 style="text-align:left;">Correctly rounded
 
   <tr><td>`unpack4x8snorm(x)`<td colspan=2 style="text-align:left;">Correctly rounded


### PR DESCRIPTION
Fixes #3871