### PR TITLE
Treesitter scanner: fix handling of '=' and shifts in template args

### DIFF
--- a/wgsl/scanner.cc
+++ b/wgsl/scanner.cc
@@ -694,17 +694,19 @@ struct Scanner {
     // The current expression nesting depth.
     size_t expr_depth = 0;
 
-    // A stack of '<' tokens.
+    // A stack of '<' tokens. Each is a candidate for the start of a template list.
     // Used to pair '<' and '>' tokens at the same expression depth.
     struct StackEntry {
       size_t index;       // Index of the opening '>' in lt_is_tmpl
       size_t expr_depth;  // The value of 'expr_depth' for the opening '<'
     };
+    // The stack of unclosed candidates for template-list starts.
     std::vector<StackEntry> lt_stack;
 
-    LOG("classify_template_args() '<'");
+    LOG("classify_template_args() '<' (initial)");
     lt_stack.push_back(StackEntry{state.lt_is_tmpl.count(), expr_depth});
-    state.lt_is_tmpl.push_back(false);  // Default to less-than
+    // Default to less-than (or less-than-equal, or left-shift, or left-shift-equal)
+    state.lt_is_tmpl.push_back(false);
 
     while (!lt_stack.empty() && !lexer.match(kEOF)) {
       lexer.skip_whitespace();
@@ -714,13 +716,46 @@ struct Scanner {
         continue;
       }
 
+      // A template list can't contain an assignment or a compound assignment.
+      // There is logic below which clears the stack when reaching one of those.
+      // It looks for a '=' code point.  But we still want to allow
+      // comparison operations inside expressions. So we must pre-emptively
+      // allow operators: == >= <= !=
+
+      // Look for a nested template-list.
       if (lexer.match_identifier()) {
         lexer.skip_whitespace(); // TODO: Skip comments
         if (lexer.match('<')) {
-          LOG("classify_template_args() '<'");
+          LOG("classify_template_args() '<' after ident");
           lt_stack.push_back(StackEntry{state.lt_is_tmpl.count(), expr_depth});
-          state.lt_is_tmpl.push_back(false);  // Default to less-than
+          // Default to less-than (or less-than-equal, or left-shift, or left-shift-equal)
+          state.lt_is_tmpl.push_back(false);
+
+          if (lexer.match('=')) {
+            // Allow "ident<=".
+            // We entered the loop at "ident<=". No template arg can start with '=',
+            // so consider "<=" to be a single token.
+            // Litmus test: "alias z = a<b<=c>;"
+            lt_stack.pop_back();
+          } else if (lexer.match('<')) {
+            // Allow "ident<<".
+            // We entered the loop at "ident<<". No template arg can start with '<',
+            // so consider "<<" to be a single token.
+            // Litmus test: "alias z = a<b<<c>;"
+            state.lt_is_tmpl.push_back(false);
+            lt_stack.pop_back();
+          }
         }
+        continue;
+      }
+
+      // Each '<' must be recorded in the lt_is_tmpl queue.
+      // Each '>' must be recorded in the gt_is_tmpl queue.
+
+      if (lexer.match('<')) {
+        // Litmus test: "alias z =a<1<<c<d>()>;"
+        LOG("classify_template_args() '<'");
+        state.lt_is_tmpl.push_back(false);
         continue;
       }
 
@@ -734,19 +769,30 @@ struct Scanner {
         } else {
           LOG("   non-template '>'");
           state.gt_is_tmpl.push_back(false);
+          // Pre-emptvely allow >= as a comparison operator:
+          // Skip over '=', if present.
+          lexer.match('=');
         }
         continue;
       }
 
+      // Pre-emptively allow the != operator.
+      // As a side effect, allow unary negation operator !
+      if (lexer.match('!')) {
+        lexer.match('=');
+        continue;
+      }
+
+      CodePoint was = lexer.peek();
       if (lexer.match_anyof({'(', '['})) {
-        LOG("   expr_depth++");
+        LOG("   %c expr_depth++", was);
         // Entering a nested expression
         expr_depth++;
         continue;
       }
 
       if (lexer.match_anyof({')', ']'})) {
-        LOG("   expr_depth--");
+        LOG("   %c expr_depth--", was);
         // Exiting a nested expression
         // Pop the stack until we return to the current expression
         // expr_depth
@@ -759,10 +805,31 @@ struct Scanner {
         continue;
       }
 
-      if (lexer.match_anyof({';', '{', '=', ':'})) {
-        LOG("   expression terminator");
-        // Expression terminating tokens. No opening template list can
-        // hold these tokens, so clear the stack and expression depth.
+      was = lexer.peek();
+      if (lexer.match('=')) {
+        // A subtle point. The '=' we just matched might be the start of a
+        // syntactic token, or the end of a compound-assignment operator like +=
+        // In either case, it's fine to proceed with the logic below.
+
+        if (lexer.match('=')) {
+          // Pre-emptively allow equality ==
+          continue;
+        }
+        // A template list can't contain an assignment, because an expression
+        // can't contain an assignment.
+        // This might be a regular assignment, or the tail end of a compound
+        // assignment.
+        LOG("   %c expression terminator", was);
+        expr_depth = 0;
+        lt_stack.clear();
+        continue;
+      }
+
+      was = lexer.peek();
+      if (lexer.match_anyof({';', '{', ':'})) {
+        LOG("   %c expression terminator", was);
+        // Expression terminating tokens. No template list can
+        // hold these code points, so clear the stack and expression depth.
         expr_depth = 0;
         lt_stack.clear();
         continue;
@@ -834,6 +901,7 @@ struct Scanner {
 
       // TODO(dneto): should also skip comments, both line comments
       // and block comments.
+      // https://github.com/gpuweb/gpuweb/issues/3876
       lexer.skip_whitespace();
       if (lexer.peek() == '<') {
         if (state.lt_is_tmpl.empty()) {
@@ -868,6 +936,11 @@ struct Scanner {
         return match(Token::LESS_THAN_EQUAL);
       }
       if (lexer.match('<')) {
+        // Consume the '<' in the lt queue.
+        // Litmus test: "alias z = a<1<<c<d>()>;"
+        if (!state.lt_is_tmpl.empty()) {
+          state.lt_is_tmpl.pop_front();
+        }
         if (lexer.match('=')) {
           return match(Token::SHIFT_LEFT_ASSIGN);
         }
@@ -885,6 +958,10 @@ struct Scanner {
         return match(Token::GREATER_THAN_EQUAL);
       }
       if (lexer.match('>')) {
+        // Consume the '>' in the gt queue.
+        if (!state.gt_is_tmpl.empty()) {
+          state.gt_is_tmpl.pop_front();
+        }
         if (lexer.match('=')) {
           return match(Token::SHIFT_RIGHT_ASSIGN);
         }

--- a/wgsl/wgsl_unit_tests_equals.py
+++ b/wgsl/wgsl_unit_tests_equals.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+#
+# Copyright 2023 Google LLC
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of works must retain the original copyright
+# notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the original
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#
+# 3. Neither the name of the W3C nor the names of its contributors
+# may be used to endorse or promote products derived from this work
+# without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from wgsl_unit_tests import Case, XFail
+
+cases = [
+    Case("const z = a<c;",name="plain <"),
+    Case("const z = a<<c;",name="plain <<"),
+    Case("const z = a<=c;",name="plain <="),
+    XFail("const z = a<=c>;",name="plain <= extra >: const"),
+    XFail("alias z = a<=c>;",name="plain <= extra >: alias"),
+    Case("fn foo() { a<<=c; }",name="plain <<="),
+    Case("const z = a>c;",name="plain >"),
+    Case("const z = a>>c;",name="plain >>"),
+    Case("const z = a>=c;",name="plain >="),
+    Case("fn foo() { a>>=c; }",name="plain >>="),
+    Case("alias z = a<b<=c>;",name="template arg <="),
+    Case("alias z = a<(b<=c)>;",name="template arg nested <="),
+    XFail("alias z = array<f32,select(1,2,x=b)>;",name="nested assignment ="),
+    XFail("alias z = array<f32,select(1,2,x+=b)>;",name="nested assignment +="),
+    XFail("alias z = array<f32,select(1,2,x-=b)>;",name="nested assignment -="),
+    XFail("alias z = array<f32,select(1,2,x*=b)>;",name="nested assignment *="),
+    XFail("alias z = array<f32,select(1,2,x/=b)>;",name="nested assignment /="),
+    XFail("alias z = array<f32,select(1,2,x%=b)>;",name="nested assignment %="),
+    XFail("alias z = array<f32,select(1,2,x&=b)>;",name="nested assignment &="),
+    XFail("alias z = array<f32,select(1,2,x|=b)>;",name="nested assignment |="),
+    XFail("alias z = array<f32,select(1,2,x^=b)>;",name="nested assignment ^="),
+    XFail("alias z = array<f32,select(1,2,x>>=b)>;",name="nested assignment >>="),
+    XFail("alias z = array<f32,select(1,2,x<<=b)>;",name="nested assignment <<="),
+    Case("alias z = array<f32,1<<2>;",name="exposed <<"),
+    XFail("alias z = array<f32,2>>1>;",name="exposed >> prematurely closes template"),
+    XFail("alias z = a<2>1>;",name="exposed > prematurely closes template"),
+    Case("alias z = a<1!=2>;",name="exposed !="),
+    Case("alias z = a<!2>;",name="exposed !"),
+    Case("alias z = a<1==2>;",name="exposed =="),
+    Case("alias a = array<f32,(2>>1)>;",name="nested >>"),
+    Case("alias a = array<f32,(2<<1)>;",name="nested <<"),
+    Case("alias z = array<f32,select(1,2,x>b)>;",name="nested >"),
+    Case("alias z = array<f32,select(1,2,x<b)>;",name="nested <"),
+    Case("alias z = array<f32,select(1,2,x==b)>;",name="nested =="),
+    Case("alias z = array<f32,select(1,2,x>=b)>;",name="nested >="),
+    Case("alias z = array<f32,select(1,2,x<=b)>;",name="nested <="),
+    Case("alias z = array<f32,select(1,2,x!=b)>;",name="nested !="),
+    XFail("alias z = a<=>;",name="if <= is skipped too early, should still fail parse"),
+    XFail("alias z = a<b>=c>;",name=">= prematurely ends template"),
+    Case("alias z = a<(b>=c)>;",name="template arg nested >="),
+    XFail("alias z = a<b<c>>=;"),
+]

--- a/wgsl/wgsl_unit_tests_simple.py
+++ b/wgsl/wgsl_unit_tests_simple.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+#
+# Copyright 2023 Google LLC
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of works must retain the original copyright
+# notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the original
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#
+# 3. Neither the name of the W3C nor the names of its contributors
+# may be used to endorse or promote products derived from this work
+# without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+from wgsl_unit_tests import Case, XFail
+
+cases = [
+    XFail("this fails"),
+    XFail("#version 450"),
+    Case("const pi = 3.14;"),
+    Case("const b = bitcast<i32>(1u);"),
+    Case("var s: sampler;"),
+    Case("@group(0) @binding(0) var s: sampler;"),
+    Case("var<workgroup> w: i32;"),
+    Case("fn foo() {var f: i32;}"),
+    Case("var<workgroup> w: array<vec3<f32>,1>;"),
+    Case("var<workgroup> w: array<vec3<f32>,(vec<i32>(1).x)>;"), # vec<i32> treated like generic template invocation. Should fail in semantic checks.
+    Case( "var<workgroup> w: array<vec3<f32>,(vec3<i32>(1).x)>;"),
+    XFail("const c = array<a>b>;"),
+    Case("var c : array<f32,(a>b)>;"),
+    Case("const a = array<i32,select(1,2,(a>b))>();"),
+    Case("const b = array<i32,select(1,2,a>b)>();"),
+    XFail("const d : array<select(1,2,a>b)>();"),
+    Case("fn main(){i=1;}"),
+    Case("fn main(){var i:i32; i=1;}"),
+    Case("var w: array<f32,1>;"),
+    Case("var w: array<vec3<f32>,1>;"),
+    Case("var w: vec3<f32>;"),
+    Case("alias t = vec3<f32>;"),
+    Case("alias t = vec3<float>;"),
+    Case("alias t = array<t,(1<2)>;"),
+    Case("var c : array<t,(1<2)>;"),
+    Case("var c : array<(a>b)>;"), # Parses ok, but should fail in semantic check: (a>b) is not a type.
+    Case("fn f(p: ptr<function,i32>) {}"),
+    Case("fn m(){x++;}"),
+    Case("fn m(){x--;}"),
+    Case("fn m(){x();}"),
+]

--- a/wgsl/wgsl_unit_tests_template.py
+++ b/wgsl/wgsl_unit_tests_template.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+#
+# Copyright 2023 Google LLC
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of works must retain the original copyright
+# notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the original
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#
+# 3. Neither the name of the W3C nor the names of its contributors
+# may be used to endorse or promote products derived from this work
+# without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from wgsl_unit_tests import Case, XFail
+
+cases = [
+    Case ("const abc=0;"),
+    Case ("const z = a<b;",name="exposed <"),
+    Case ("const z = a>b;",name="exposed >"),
+    Case ("const z = (a<b)>c;",name="nested initial <"),
+    Case ("const z = a<(b>c);",name="nested final >"),
+    Case ("const z = a((b<c), d>(e));"),
+    Case ("const z = a<b[c];",name="a less than b array element simple index: const"),
+    XFail("alias z = a<b[c];",name="a less than b array element simple index: alias"),
+    Case ("const z = a<b[select(1,2,c>(d))];",name="a less than b array element select"),
+    Case ("const z = a<b[c>(d)];",name="a less than b array element complex index"),
+    XFail("alias z = a<b;c>d();",name="plain ;"),
+    Case ("fn z() {if a < b {} else if c > d {}}"),
+    XFail("alias z = a<b&&c>;",name="&& with unexpected trailing >"),
+    Case ("const z = a<b&&c>d;",name="&&"),
+    XFail("alias z = a<b||c>;",name="|| with unexpected trailing >"),
+    Case ("const z = a<b||c>d;",name="||"),
+    XFail("alias z = a<b<c||d>>;",name="|| terminates template list"),
+
+    Case ("const z = a<b>();",name="templated value constructor"),
+    XFail("alias z = a<b>c;"),
+    XFail("alias z = a<b>=c;"),
+    XFail("alias z = a<b>>=c;"),
+    Case ("alias z = vec3<i32>;"),
+    Case ("const z = vec3<i32>();"),
+    Case ("alias z = array<vec3<i32>,5>;"),
+    Case ("const z = a(b<c, d>(e));"),
+    Case ("const z = a<1+2>();"),
+    Case ("const z = a<1,b>();"),
+    XFail("const z = a<b,c>=d;"),
+    Case ("const z = a<b,c>==d;",name="template equals ident"), # Not in Tint
+    XFail("const z = a<b,c>=d>();"),
+    XFail("alias z = a<b<c>>=;"),
+    XFail("const z = a<b>c>();",name="premature end at b>c"),
+    Case ("const z = a<b<c>();"),
+    Case ("const z = a<b<c>>();"),
+    Case ("const z = a<b<c>()>();"),
+    XFail("alias z = a<b>.c;"),
+    Case ("alias z = a<(b&&c)>;"),
+    XFail("alias z = a<(b&&c)>d;"),
+    Case ("alias z = a<(b||c)>;"),
+    XFail("alias z = a<(b||c)>d;"),
+    Case ("alias z = a<b<(c||d)>>;"),
+    Case ("alias z = a<b<=c>;",name="template arg <="),
+    Case ("alias z = a<(b<=c)>;",name="template arg nested <="),
+    XFail("alias z = a<b>>c>;",name="template arg >> ends template"),
+    Case ("alias z = a<b<<c>;",name="template arg << is shift"),
+    Case ("alias z = a<(b>>c)>;",name="tempalte arg nested >> is shift"),
+    Case ("alias z = a<(b<<c)>;",name="tempalte arg nested << is shift"),
+    Case ("alias z = a<1<<c>;",name="template arg after 1 << is shift"),
+    Case ("alias z = a<1<<c<d>()>;",name="template arg after 1 << is shift followed by templated value constructor"),
+]


### PR DESCRIPTION
- Before, '=' was always seen as the end of all unclosed template candidates. But we need to handle != == >= <= as relational operators in expressions as template args. So various cases need to see and skip over '='.

- The template classification algorithm must record a decision for every '<' and '>' it sees or skips over.

  Sometimes are handled in a special place in the code, like the second '<' in: a<b<<c> or in the normal flow, as in the second '<' in: a<1<<2>

- After classification, and during custom token scanning, every '<' and '>' that is seen must *consume* one of the previously recorded decisions, if any remain.

Part of #3868