### PR TITLE
Fix GPURenderPassDepthStencilAttachment validation

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -10894,8 +10894,8 @@ dictionary GPURenderPassDepthStencilAttachment {
         - |this|.{{GPURenderPassDepthStencilAttachment/depthLoadOp}} must not [=map/exist|be provided=].
         - |this|.{{GPURenderPassDepthStencilAttachment/depthStoreOp}} must not [=map/exist|be provided=].
     - If |format| has a stencil aspect and |this|.{{GPURenderPassDepthStencilAttachment/stencilReadOnly}} is not `true`:
-        - |this|.{{GPURenderPassDepthStencilAttachment/depthLoadOp}} must [=map/exist|be provided=].
-        - |this|.{{GPURenderPassDepthStencilAttachment/depthStoreOp}} must [=map/exist|be provided=].
+        - |this|.{{GPURenderPassDepthStencilAttachment/stencilLoadOp}} must [=map/exist|be provided=].
+        - |this|.{{GPURenderPassDepthStencilAttachment/stencilStoreOp}} must [=map/exist|be provided=].
 
         Otherwise:
 


### PR DESCRIPTION
From WebGPU:matrix.org.

Currently the validation mentions that `depthLoad/StoreOp` must be provided if format has a stencil aspect and `stencilReadOnly` is not true, but what must be provided are `stencilLoad/StoreOp`, not `depthLoad/StoreOp`.

This PR fixes this bug.