### PR TITLE
wgsl/Makefile: fix the "clean" target

### DIFF
--- a/wgsl/Makefile
+++ b/wgsl/Makefile
@@ -4,7 +4,8 @@ all: index.html nfkc validate test diagrams
 validate: lalr tspath_tests unit_tests validate-examples
 
 clean:
-	rm -f index.html index.pre.html index.bs.pre grammar/grammar.js grammar/build wgsl.lalr.txt
+	rm -f index.html index.bs.pre index.pre.html wgsl.recursive.bs.include.pre grammar/grammar.js wgsl.lalr.txt
+	rm -rf grammar/build
 
 
 # Generate spec HTML from Bikeshed source.


### PR DESCRIPTION
- grammar/build is a directory and needs rm -rf

~~- index.bs.pre doesn't exist and is not generated~~

- wgsl.recursive.bs.include.pre doesn is generated, and needs to be cleaned