### PR TITLE
wgsl: uniform buffers don't support stores

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3119,10 +3119,10 @@ access is an <dfn noexport>invalid memory reference</dfn>.
         * 0, 1, or the maximum positive value for integer components
         * 0.0 or 1.0 for floating-point components
 [=statement/assignment|Stores=] to an invalid reference may do one of:
-    * when the [=originating variable=] is a [=uniform buffer=] or a [=storage buffer=],
+    * when the [=originating variable=] is a [=storage buffer=],
         store the value to any [=memory locations|memory location(s)=] of the
         WebGPU {{GPUBuffer}} bound to the [=originating variable=]
-    * when the [=originating variable=] is not a [=uniform buffer=] or [=storage buffer=],
+    * when the [=originating variable=] is not a [=storage buffer=],
         store the value to any [=memory locations|memory locations(s)=] in the
         originating variable
     * not be executed
@@ -3134,6 +3134,8 @@ Note: An invalid memory reference can occur even if the bytes accessed would
 still be within memory locations of the originating variable.
 Each access into a [=composite=] type must be made by a valid memory reference.
 See [[#composite-value-decomposition-expr]].
+
+Note: [=Uniform buffers=] do not support stores.
 
 ### Use Cases for References and Pointers ### {#ref-ptr-use-cases}
 


### PR DESCRIPTION
Fix wording in the "Invalid Memory Reference" that hinted they might