### PR TITLE
treesitter: Add more specific unit tests for template parsing

### DIFF
--- a/wgsl/TSPath.py
+++ b/wgsl/TSPath.py
@@ -117,13 +117,13 @@ class DescendantNode(ExprNode):
     def match(self,ts_node):
         result = []
         # Stack of treesitter nodes to explore
-        stack = [ts_node]
+        stack = list(reversed(ts_node.children))
         while len(stack) > 0:
             top = stack.pop()
             top_result = self.expr.match(top)
             if len(top_result) == 0:
                 # Explore children instead
-                stack.extend(top.children)
+                stack.extend(list(reversed(top.children)))
             else:
                 result.extend(top_result)
         return result
@@ -155,7 +155,8 @@ class NamedNode(ExprNode):
 
     def match(self,ts_node):
         if ts_node.type == self.name:
-            return self.expr.match(ts_node)
+            result = self.expr.match(ts_node)
+            return result
         else:
             return []
 

--- a/wgsl/wgsl_unit_tests_template.py
+++ b/wgsl/wgsl_unit_tests_template.py
@@ -90,6 +90,8 @@ cases = [
 
 UNMATCHED = ''
 match_cases = [
+    # Match result of UNMATCHED, i.e. the empty string, means there were no 'template_list'
+    # nodes in the tree.
     MatchCase("const z = a<b;","template_list",UNMATCHED,name="exposed <"),
     MatchCase("const z = a>b;","template_list",UNMATCHED,name="exposed >"),
     MatchCase("const z = (a<b)>c;","template_list",UNMATCHED,name="nested initial <"),
@@ -110,7 +112,9 @@ match_cases = [
     MatchCase("const z = a<(b||c)>(d);","template_list","template_list:<(b||c)>",name="(||)"),
 
     MatchCase("const z = a<b>();","template_list","template_list:<b>",name="templated value constructor"),
+    # e.g. This next test says the outermost template_list node exists, and corresponds to <vec3<i32,5> in the source.
     MatchCase("alias z = array<vec3<i32>,5>;","template_list","template_list:<vec3<i32>,5>",name="nested outer"),
+    # E.g. This next test syas there is a template_list node that has an inner template_list node, and that inner node maps to the source text <i32>
     MatchCase("alias z = array<vec3<i32>,5>;","//template_list//template_list","template_list:<i32>",name="nested inner"),
     MatchCase("const z = a<1+2>();","template_list","template_list:<1+2>"),
     MatchCase("const z = a<1,b>();","template_list","template_list:<1,b>"),
@@ -128,6 +132,8 @@ match_cases = [
     MatchCase("const z = a<b<c>()>();","template_list","template_list:<b<c>()>"),
     MatchCase("const z = a<b<c>()>();","template_list//template_list","template_list:<c>"),
     # Check '<='
+    #   There is a template_list in the parse tree, corresponding to <b<=c> in the source text.
+    #   The point is that the code points <= is recognized as an operator in the middle of an expression b<=c.
     MatchCase("alias z = a<b<=c>;",  "template_list","template_list:<b<=c>",name="template arg <="),
     MatchCase("alias z = a<(b<=c)>;","template_list","template_list:<(b<=c)>",name="template arg nested <="),
     # Check shifts

--- a/wgsl/wgsl_unit_tests_template.py
+++ b/wgsl/wgsl_unit_tests_template.py
@@ -31,7 +31,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from wgsl_unit_tests import Case, XFail
+from wgsl_unit_tests import Case, XFail, MatchCase
 
 cases = [
     Case ("const abc=0;"),
@@ -62,8 +62,9 @@ cases = [
     Case ("const z = a(b<c, d>(e));"),
     Case ("const z = a<1+2>();"),
     Case ("const z = a<1,b>();"),
+
     XFail("const z = a<b,c>=d;"),
-    Case ("const z = a<b,c>==d;",name="template equals ident"), # Not in Tint
+    Case ("const z = a<b,c>==d;",name="template equals ident"),
     XFail("const z = a<b,c>=d>();"),
     XFail("alias z = a<b<c>>=;"),
     XFail("const z = a<b>c>();",name="premature end at b>c"),
@@ -76,6 +77,7 @@ cases = [
     Case ("alias z = a<(b||c)>;"),
     XFail("alias z = a<(b||c)>d;"),
     Case ("alias z = a<b<(c||d)>>;"),
+
     Case ("alias z = a<b<=c>;",name="template arg <="),
     Case ("alias z = a<(b<=c)>;",name="template arg nested <="),
     XFail("alias z = a<b>>c>;",name="template arg >> ends template"),
@@ -85,3 +87,58 @@ cases = [
     Case ("alias z = a<1<<c>;",name="template arg after 1 << is shift"),
     Case ("alias z = a<1<<c<d>()>;",name="template arg after 1 << is shift followed by templated value constructor"),
 ]
+
+UNMATCHED = ''
+match_cases = [
+    MatchCase("const z = a<b;","template_list",UNMATCHED,name="exposed <"),
+    MatchCase("const z = a>b;","template_list",UNMATCHED,name="exposed >"),
+    MatchCase("const z = (a<b)>c;","template_list",UNMATCHED,name="nested initial <"),
+    MatchCase("const z = a<(b>c);","template_list",UNMATCHED,name="nested final >"),
+
+    MatchCase("const z = a( b<c,  d>(e));","template_list","template_list:<c,  d>"),
+    MatchCase("const z = a((b<c), d>(e));","template_list",UNMATCHED,"nested initial <, exposed final >"),
+
+    MatchCase("const z = a<b[c];","temlate_list",UNMATCHED),
+    MatchCase("const z = a<b[select(1,2,c>(d))];","template_list",UNMATCHED),
+    MatchCase("const z = a<b[c>(d)];","template_list",UNMATCHED),
+    MatchCase("fn z() {if a < b {} else if c > d {}}","template_list",UNMATCHED,name="stop at braces"),
+
+    # Test interaction with lower-precedence expression operators: && and ||
+    MatchCase("const z = a<b&&c>(d);","template_list",UNMATCHED,name="&&"),
+    MatchCase("const z = a<b||c>(d);","template_list",UNMATCHED,name="||"),
+    MatchCase("const z = a<(b&&c)>(d);","template_list","template_list:<(b&&c)>",name="(&&)"),
+    MatchCase("const z = a<(b||c)>(d);","template_list","template_list:<(b||c)>",name="(||)"),
+
+    MatchCase("const z = a<b>();","template_list","template_list:<b>",name="templated value constructor"),
+    MatchCase("alias z = array<vec3<i32>,5>;","template_list","template_list:<vec3<i32>,5>",name="nested outer"),
+    MatchCase("alias z = array<vec3<i32>,5>;","//template_list//template_list","template_list:<i32>",name="nested inner"),
+    MatchCase("const z = a<1+2>();","template_list","template_list:<1+2>"),
+    MatchCase("const z = a<1,b>();","template_list","template_list:<1,b>"),
+    MatchCase("const z = a<b,c>==d;","template_list","template_list:<b,c>"),
+
+    # Check valid parses with things that start with '<' in a template list.
+
+    # This is a comparison of a less-than b<c>()
+    MatchCase("const z = a<b<c>();","ident","ident:z ident:a ident:b ident:c"),
+    MatchCase("const z = a<b<c>();","template_elaborated_ident","template_elaborated_ident:a template_elaborated_ident:b<c>"),
+    MatchCase("const z = a<b<c>();","template_list","template_list:<c>"),
+    # This is a nested template list
+    MatchCase("const z = a<b<c>>();","template_list","template_list:<b<c>>"),
+    MatchCase("const z = a<b<c>>();","template_list//template_list","template_list:<c>"),
+    MatchCase("const z = a<b<c>()>();","template_list","template_list:<b<c>()>"),
+    MatchCase("const z = a<b<c>()>();","template_list//template_list","template_list:<c>"),
+    # Check '<='
+    MatchCase("alias z = a<b<=c>;",  "template_list","template_list:<b<=c>",name="template arg <="),
+    MatchCase("alias z = a<(b<=c)>;","template_list","template_list:<(b<=c)>",name="template arg nested <="),
+    # Check shifts
+    XFail("alias z = a<b>>c>;",name="template arg >> ends template"),
+    MatchCase("alias z = a<b<<c>;",     "template_list","template_list:<b<<c>",name="template arg << is shift"),
+    MatchCase("alias z = a<(b>>c)>;",   "template_list","template_list:<(b>>c)>",name="tempalte arg nested >> is shift"),
+    MatchCase("alias z = a<(b<<c)>;",   "template_list","template_list:<(b<<c)>",name="tempalte arg nested << is shift"),
+    # The Treesitter scanner handles identifier..shift differently from number..shift
+    MatchCase("alias z = a<1<<c>;",     "template_list","template_list:<1<<c>", name="template arg after 1 << is shift"),
+    MatchCase("alias z = a<1<<c<d>()>;","template_list","template_list:<1<<c<d>()>",name="template arg after 1 << is shift followed by templated value constructor"),
+    MatchCase("alias z = a<1<<c<d>()>;","template_list//template_list","template_list:<d>",name="template arg after 1 << is shift followed by templated value constructor"),
+]
+
+cases.extend(match_cases)


### PR DESCRIPTION
Fix a bug in TSPath Descendant parsing: Start the search from the children of the node, not the node itself.
Otherwise things like foo//foo will never work.

Followup to #3877