### PR TITLE
wgsl: weaken determinant error bounds

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -199,6 +199,18 @@ object[type="image/svg+xml"] {
     "date":"24 October 1969",
     "title":"Practical Translators for LR(k) Languages"
   },
+  "Jeannerod2013": {
+    "href":"https://www.ams.org/journals/mcom/2013-82-284/S0025-5718-2013-02679-8/S0025-5718-2013-02679-8.pdf",
+    "title":"Further Analysis of Kahan's Algorithm for the Accurate Computation of 2x2 Determinants",
+    "authors": [
+      "Claude-Pierre Jeannerod",
+      "Nicolas Louvet",
+      "Jean-Michel Muller"
+    ],
+    "publisher": "American Mathematical Society",
+    "rawDate":"2013-10",
+    "pages": "2245-2264"
+  },
   "VanWyk2007": {
     "href":"https://dl.acm.org/doi/10.1145/1289971.1289983",
     "title":"Context-Aware Scanning for Parsing Extensible Languages",
@@ -10631,25 +10643,26 @@ value with the same sign.
   <tr><td>`cosh(x)`<td colspan=2 style="text-align:left;">Inherited from `(exp(x) + exp(-x)) * 0.5`
   <tr><td>`cross(x, y)`<td colspan=2 style="text-align:left;">Inherited from `(x[i] * y[j] - x[j] * y[i])`
   <tr><td>`degrees(x)`<td colspan=2 style="text-align:left;">Inherited from `x * 57.295779513082322865`
-  <tr><td>`determinant(m:mat2x2<T>)`<td colspan=2 style="text-align:left;">Inherited from `m[0][0] * m[1][1] - m[0][1] * m[1][0]`.
-  <tr><td>`determinant(m:mat3x3<T>)`<td colspan=2 style="text-align:left;">Inherited from<br>
-         `m[0][0] * determinant(m0)`<br>
-       `- m[1][0] * determinant(m1)`<br>
-       `+ m[2][0] * determinant(m2)`<br>
-       where:<br>
-           m0 = mat2x2(m[1].yz,m[2].yz)<br>
-           m1 = mat2x2(m[0].yz,m[2].yz)<br>
-           m2 = mat2x2(m[0].yz,m[1].yz)
-  <tr><td>`determinant(m:mat4x4<T>)`<td colspan=2 style="text-align:left;">Inherited from<br>
-        `m[0][0] * determinant(m0)`<br>
-       `- m[1][0] * determinant(m1)`<br>
-       `+ m[2][0] * determinant(m2)`<br>
-       `- m[3][0] * determinant(m3)`<br>
-        where:<br>
-           m0 = mat3x3(m[1].yzw,m[2].yzw,m[3].yzw)<br>
-           m1 = mat3x3(m[0].yzw,m[2].yzw,m[3].yzw)<br>
-           m2 = mat3x3(m[0].yzw,m[1].yzw,m[3].yzw)<br>
-           m3 = mat3x3(m[0].yzw,m[1].yzw,m[2].yzw)
+  <tr><td>`determinant(m:mat2x2<T>)`<br>
+          `determinant(m:mat3x3<T>)`<br>
+          `determinant(m:mat4x4<T>)`
+     <td colspan=2 style="text-align:left;">Infinite ULP.
+
+     <div class=note>
+     <span class=marker>Note:</span>WebGPU implementations should provide a pragmatically useful determinant function.
+
+     In ideal math, determinants are computed with add, subtract, and multiply operations.
+
+     However, GPUs use floating point math, and GPU implementations of determinant
+     favour speed and simplicity over robustness against overflow and error.
+
+     For example, the naive computation of even a 2x2 determinant (`m[0][0] * m[1][1] - m[1][0] * m[0][1]`)
+     fails to guard against catastrophic cancellation.
+     Providing tighter error bounds for 2x2 determinants is the subject of relatively recent research [[Jeannerod2013]].
+     The challenges compound quickly as matrix sizes increase.
+
+     The lack of a finite error bound for determinants in WGSL reflects the same lack in underlying implementations.
+     </div>
   <tr><td>`distance(x, y)`<td colspan=2 style="text-align:left;">Inherited from `length(x - y)`
   <tr><td>`dot(x, y)`<td colspan=2 style="text-align:left;">Inherited from sum of `x[i] * y[i]`
   <tr><td>`exp(x)`<td>`3 + 2 * |x|` ULP<td>`1 + 2 * |x|` ULP


### PR DESCRIPTION
Underlyin platforms don't have error bounds.
CTS experience shows they actively exploit that freedom.

Fixes: #3873