### PR TITLE
Add ReturnIfAbrupt [=?=] on content-timeline validation

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -4121,10 +4121,10 @@ The {{GPUTextureUsage}} flags determine how a {{GPUTexture}} may be used after i
 
                 [=Content timeline=] steps:
 
-                1. [$validate GPUExtent3D shape$](|descriptor|.{{GPUTextureDescriptor/size}}).
-                1. [$Validate texture format required features$] of
+                1. [=?=] [$validate GPUExtent3D shape$](|descriptor|.{{GPUTextureDescriptor/size}}).
+                1. [=?=] [$Validate texture format required features$] of
                     |descriptor|.{{GPUTextureDescriptor/format}} with |this|.{{GPUObjectBase/[[device]]}}.
-                1. [$Validate texture format required features$] of each element of
+                1. [=?=] [$Validate texture format required features$] of each element of
                     |descriptor|.{{GPUTextureDescriptor/viewFormats}} with |this|.{{GPUObjectBase/[[device]]}}.
                 1. Let |t| be a new {{GPUTexture}} object.
                 1. Set |t|.{{GPUTexture/width}} to |descriptor|.{{GPUTextureDescriptor/size}}.[=Extent3D/width=].
@@ -4507,7 +4507,7 @@ enum GPUTextureAspect {
 
                 [=Content timeline=] steps:
 
-                1. [$Validate texture format required features$] of
+                1. [=?=] [$Validate texture format required features$] of
                     |descriptor|.{{GPUTextureViewDescriptor/format}} with |this|.{{GPUObjectBase/[[device]]}}.
                 1. Let |view| be a new {{GPUTextureView}} object.
                 1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
@@ -5795,7 +5795,7 @@ A {{GPUBindGroupLayout}} object has the following internal slots:
 
                 1. For each {{GPUBindGroupLayoutEntry}} |entry| in |descriptor|.{{GPUBindGroupLayoutDescriptor/entries}}:
                     1. If |entry|.{{GPUBindGroupLayoutEntry/storageTexture}} is [=map/exist|provided=]:
-                        1. [$Validate texture format required features$] for
+                        1. [=?=] [$Validate texture format required features$] for
                             |entry|.{{GPUBindGroupLayoutEntry/storageTexture}}.{{GPUStorageTextureBindingLayout/format}}
                             with |this|.{{GPUObjectBase/[[device]]}}.
                 1. Let |layout| be a new {{GPUBindGroupLayout}} object.
@@ -7597,10 +7597,10 @@ dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
                 1. If |descriptor|.{{GPURenderPipelineDescriptor/fragment}} is [=map/exist|provided=]:
                     1. [=list/For each=] non-`null` |colorState| of
                         |descriptor|.{{GPURenderPipelineDescriptor/fragment}}.{{GPUFragmentState/targets}}:
-                        1. [$Validate texture format required features$] of
+                        1. [=?=] [$Validate texture format required features$] of
                             |colorState|.{{GPUColorTargetState/format}} with |this|.{{GPUObjectBase/[[device]]}}.
                 1. If |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}} is [=map/exist|provided=]:
-                    1. [$Validate texture format required features$] of
+                    1. [=?=] [$Validate texture format required features$] of
                         |descriptor|.{{GPURenderPipelineDescriptor/depthStencil}}.{{GPUDepthStencilState/format}}
                         with |this|.{{GPUObjectBase/[[device]]}}.
                 1. Let |pipeline| be a new {{GPURenderPipeline}} object.
@@ -9210,7 +9210,7 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 
                 1. For each non-`null` |colorAttachment| in |descriptor|.{{GPURenderPassDescriptor/colorAttachments}}:
                     1. If |colorAttachment|.{{GPURenderPassColorAttachment/clearValue}} is not `null`.
-                        1. [$validate GPUColor shape$](|colorAttachment|.{{GPURenderPassColorAttachment/clearValue}}).
+                        1. [=?=] [$validate GPUColor shape$](|colorAttachment|.{{GPURenderPassColorAttachment/clearValue}}).
                 1. Let |pass| be a new {{GPURenderPassEncoder}} object.
                 1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
                 1. Return |pass|.
@@ -9451,8 +9451,8 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 
                 [=Content timeline=] steps:
 
-                1. [$validate GPUOrigin3D shape$](|destination|.{{GPUImageCopyTexture/origin}}).
-                1. [$validate GPUExtent3D shape$](|copySize|).
+                1. [=?=] [$validate GPUOrigin3D shape$](|destination|.{{GPUImageCopyTexture/origin}}).
+                1. [=?=] [$validate GPUExtent3D shape$](|copySize|).
                 1. Issue the subsequent steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             </div>
             <div data-timeline=device>
@@ -9518,8 +9518,8 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 
                 [=Content timeline=] steps:
 
-                1. [$validate GPUOrigin3D shape$](|source|.{{GPUImageCopyTexture/origin}}).
-                1. [$validate GPUExtent3D shape$](|copySize|).
+                1. [=?=] [$validate GPUOrigin3D shape$](|source|.{{GPUImageCopyTexture/origin}}).
+                1. [=?=] [$validate GPUExtent3D shape$](|copySize|).
                 1. Issue the subsequent steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             </div>
             <div data-timeline=device>
@@ -9587,9 +9587,9 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 
                 [=Content timeline=] steps:
 
-                1. [$validate GPUOrigin3D shape$](|source|.{{GPUImageCopyTexture/origin}}).
-                1. [$validate GPUOrigin3D shape$](|destination|.{{GPUImageCopyTexture/origin}}).
-                1. [$validate GPUExtent3D shape$](|copySize|).
+                1. [=?=] [$validate GPUOrigin3D shape$](|source|.{{GPUImageCopyTexture/origin}}).
+                1. [=?=] [$validate GPUOrigin3D shape$](|destination|.{{GPUImageCopyTexture/origin}}).
+                1. [=?=] [$validate GPUExtent3D shape$](|copySize|).
                 1. Issue the subsequent steps on the [=Device timeline=] of |this|.{{GPUObjectBase/[[device]]}}:
             </div>
             <div data-timeline=device>
@@ -11728,7 +11728,7 @@ attachments used by this encoder.
 
                 [=Content timeline=] steps:
 
-                1. [$validate GPUColor shape$](|color|).
+                1. [=?=] [$validate GPUColor shape$](|color|).
                 1. Issue the subsequent steps on the [=Device timeline=] of
                     |this|.{{GPUObjectBase/[[device]]}}.
             </div>
@@ -12017,9 +12017,9 @@ GPURenderBundleEncoder includes GPURenderCommandsMixin;
 
                 [=Content timeline=] steps:
 
-                1. [$Validate texture format required features$] of each non-`null` element of
+                1. [=?=] [$Validate texture format required features$] of each non-`null` element of
                     |descriptor|.{{GPURenderPassLayout/colorFormats}} with |this|.{{GPUObjectBase/[[device]]}}.
-                1. [$Validate texture format required features$] of
+                1. [=?=] [$Validate texture format required features$] of
                     |descriptor|.{{GPURenderPassLayout/depthStencilFormat}} with |this|.{{GPUObjectBase/[[device]]}}.
                 1. Let |e| be a new {{GPURenderBundleEncoder}} object.
                 1. Issue the |initialization steps| on the [=Device timeline=] of |this|.
@@ -12250,8 +12250,8 @@ GPUQueue includes GPUObjectBase;
 
                 [=Content timeline=] steps:
 
-                1. [$validate GPUOrigin3D shape$](|destination|.{{GPUImageCopyTexture/origin}}).
-                1. [$validate GPUExtent3D shape$](|size|).
+                1. [=?=] [$validate GPUOrigin3D shape$](|destination|.{{GPUImageCopyTexture/origin}}).
+                1. [=?=] [$validate GPUExtent3D shape$](|size|).
                 1. Let |dataBytes| be [=get a copy of the buffer source|a copy of the bytes held by the buffer source=] |data|.
                 1. Issue the subsequent steps on the [=Device timeline=] of |this|.
             </div>
@@ -12333,9 +12333,9 @@ GPUQueue includes GPUObjectBase;
 
                 [=Content timeline=] steps:
 
-                1. [$validate GPUOrigin2D shape$](|source|.{{GPUImageCopyExternalImage/origin}}).
-                1. [$validate GPUOrigin3D shape$](|destination|.{{GPUImageCopyTexture/origin}}).
-                1. [$validate GPUExtent3D shape$](|copySize|).
+                1. [=?=] [$validate GPUOrigin2D shape$](|source|.{{GPUImageCopyExternalImage/origin}}).
+                1. [=?=] [$validate GPUOrigin3D shape$](|destination|.{{GPUImageCopyTexture/origin}}).
+                1. [=?=] [$validate GPUExtent3D shape$](|copySize|).
                 1. Let |sourceImage| be |source|.{{GPUImageCopyExternalImage/source}}
                 1. If |sourceImage| <l spec=html>[=is not origin-clean=]</l>,
                     throw a {{SecurityError}} and stop.
@@ -12805,9 +12805,9 @@ interface GPUCanvasContext {
                 [=Content timeline=] steps:
 
                 1. Let |device| be |configuration|.{{GPUCanvasConfiguration/device}}.
-                1. [$Validate texture format required features$] of
+                1. [=?=] [$Validate texture format required features$] of
                     |configuration|.{{GPUCanvasConfiguration/format}} with |device|.{{GPUObjectBase/[[device]]}}.
-                1. [$Validate texture format required features$] of each element of
+                1. [=?=] [$Validate texture format required features$] of each element of
                     |configuration|.{{GPUTextureDescriptor/viewFormats}} with |device|.{{GPUObjectBase/[[device]]}}.
                 1. Let |descriptor| be the
                     [$GPUTextureDescriptor for the canvas and configuration$](|this|.{{GPUCanvasContext/canvas}}, |configuration|).
@@ -14456,10 +14456,7 @@ integers and single-precision floats.
 
    **Returns:** {{undefined}}
 
-    1. Throw a {{TypeError}} if:
-
-       - |color| is a sequence, and
-       - |color|.length &ne; 4.
+    1. Throw a {{TypeError}} if |color| is a sequence and |color|.length &ne; 4.
 </div>
 
 <script type=idl>


### PR DESCRIPTION
This demarcates these as possibly throwing an exception. I'd like to be more thorough someday with our [=?=] and [=!=] marks, but this at least makes a few key points more explicit.