### PR TITLE
Weaken asin accuracy rule for f32

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -10625,9 +10625,21 @@ value with the same sign.
   </thead>
 
   <tr><td>`abs(x)`<td colspan=2 style="text-align:left;">Correctly rounded
-  <tr><td>`acos(x)`<td colspan=2 style="text-align:left;">Inherited from `atan2(sqrt(1.0 - x * x), x)`
+  <tr><td>`acos(x)`<td>
+       The worse of:
+       * Absolute error 6.77&times;10<sup>-5</sup>
+       * Inherited from `atan2(sqrt(1.0 - x * x), x)`
+
+      <td>Inherited from `atan2(sqrt(1.0 - x * x), x)`
+          <p>TODO: check this with conformance tests
   <tr><td>`acosh(x)`<td colspan=2 style="text-align:left;">Inherited from `log(x + sqrt(x * x - 1.0))`
-  <tr><td>`asin(x)`<td colspan=2 style="text-align:left;">Inherited from `atan2(x, sqrt(1.0 - x * x))`
+  <tr><td>`asin(x)`<td>
+       The worse of:
+       * Absolute error 6.77&times;10<sup>-5</sup>
+       * Inherited from `atan2(x, sqrt(1.0 - x * x))`
+
+      <td>Inherited from `atan2(x, sqrt(1.0 - x * x))`
+          <p>TODO: check this with conformance tests
   <tr><td>`asinh(x)`<td colspan=2 style="text-align:left;">Inherited from `log(x + sqrt(x * x + 1.0))`
   <tr><td>`atan(x)`<td>4096 ULP<td>5 ULP
   <tr><td>`atan2(y, x)`<td>4096 ULP for `|x|` in the range [2<sup>-126</sup>, 2<sup>126</sup>], and `y` is finite and normal<td>5 ULP for `|x|` in the range [2<sup>-14</sup>, 2<sup>14</sup>], and `y` is finite and normal


### PR DESCRIPTION
Conformance testing shows some implementations are (almost surely) using polynomial-based approximations with absolute error guarantees.

Fixes: #3906