### PR TITLE
[editorial] clarify host-shareable types

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -3011,6 +3011,11 @@ Note: Restrictions on the types of inter-stage inputs and outputs]] are
 described in [[#stage-inputs-outputs]] and subsequent sections.
 Those types are also sized, but the counting is differs.
 
+Note: [[#texture-sampler-types|Textures and samplers]] can also be shared
+between the host and the GPU, but their contents are opaque.
+The host-shareable types in this section are specifically for use in [=storage
+buffer|storage=] and [=uniform buffer|uniform=] buffers.
+
 ### Reference and Pointer Types ### {#ref-ptr-types}
 
 WGSL has two kinds of types for representing [=memory views=]:


### PR DESCRIPTION
Fixes #3035

* Add a note that texture and samplers can be shared, but host-shareable is about buffers