### PR TITLE
wgsl:editorial: Consistenly stye "Notes" as markers

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -1052,7 +1052,7 @@ Together, `vec3<f32>` denotes a specific [=vector=] type.
 Note: For example, the phrase `var<storage,read_write>` modifies the general `var` concept with template parameters `storage` and `read_write`.
 
 <div class=note>
-Note: For example, the phrase `array<vec4<f32>>` has two template parameterizations:
+<span class=marker>Note:</span>For example, the phrase `array<vec4<f32>>` has two template parameterizations:
 * `vec4<f32>` modifies the general `vec4` concept with template parameter `f32`.
 * `array<vec4<f32>>` modifies the general `array` concept with template parameter `vec4<f32>`.
 
@@ -1189,7 +1189,7 @@ Let |TemplateList| be a record type containing:
 </blockquote>
 
 <div class=note algorithm="find template paramters">
-Note: The algorithm can be modified to find the source ranges for [=template parameters=], as follows:
+<span class=marker>Note:</span>The algorithm can be modified to find the source ranges for [=template parameters=], as follows:
 
 * Modify |UnclosedCandidate| to add the following fields:
     *  |parameters|, a list of source ranges of template parameters.
@@ -3809,8 +3809,7 @@ There is no way to write the AllTypes type in WGSL source.
 See [[#predeclared-types]] for the list of all [=predeclared=] types and [=type-generators=].
 
 <div class=note>
-<p>
-Note: A type is not a value in an ordinary sense.
+<span class=marker>Note:</span>A type is not a value in an ordinary sense.
 It is not data that is manipulated by a shader at runtime.
 
 <p>
@@ -3904,7 +3903,7 @@ The predeclared [=type-generators=] are listed in the following table:
 </thead>
   <tr><td>array<td>See [[#array-types]]
   <tr><td>atomic<td>See [[#atomic-types]]
-  <tr><td>mat2x2<td rowspan=9>See [[#matrix-types]], which also lists 
+  <tr><td>mat2x2<td rowspan=9>See [[#matrix-types]], which also lists
      predeclared [=type aliases|aliases=] for matrix types.
 
      Note: These are also used in [=value constructor=] expressions
@@ -5802,7 +5801,7 @@ The <dfn noexport>indirection</dfn> operator converts a pointer to its correspon
             and defines how the template paramters help determine the resulting type.
 
             The expressions |e1| through |eN| are the [=template parameters=] for the type-generator.
-          
+
             For example, the type expression `vec2<f32>` is the [=vector=] of two [=f32=] elements.
 
             See [[#predeclared-types]] for the list of predeclared type-generators.
@@ -8059,7 +8058,7 @@ A declaration *D* is <dfn>statically accessed</dfn> by a shader when:
 * An identifier [=resolves|resolving=] to *D* is used in the initializer for a [=statically accessed=] declaration.
 * An identifier [=resolves|resolving=] to *D* is used by an attribute used by a [=statically accessed=] declaration.
 
-<div class="note">Note: Static access is recursively defined, taking into account the following:
+<div class="note"><span class=marker>Note:</span>Static access is recursively defined, taking into account the following:
 * All the parts of a [=function declaration=] including attributes, formal parameters, return type, and function body.
 * Any type needed to define the above, including following [=type aliases=].
 * As a particular case of helping to define a type,
@@ -9410,7 +9409,8 @@ The remaining subsections specify a static analysis that verifies that
 [[#collective-operations|collective operations]] are only executed in [=uniform
 control flow=].
 
-<div class="note">Note: This analysis has the following desirable properties:
+<div class="note">
+<span class=marker>Note:</span>This analysis has the following desirable properties:
       - Sound (meaning that it rejects every program that would break the uniformity requirements of builtins)
       - Linear time complexity (in the number of tokens in the program)
       - Refactoring a piece of code into a function, or inlining a function, cannot make a shader invalid if it was valid before the transformation
@@ -9433,7 +9433,7 @@ Each function is analyzed in two phases.
 The first phase walks over the syntax of the function, building a directed graph along the way based on the rules in the following subsections.
 The second phase explores that graph, resulting in either rejecting the program, or computing the constraints on calling this function.
 
-<div class="note">Note: Apart from two special nodes [=RequiredToBeUniform=] and [=MayBeNonUniform=], all nodes can be understood as having one of the following meanings:
+<div class="note"><span class=marker>Note:</span>Apart from two special nodes [=RequiredToBeUniform=] and [=MayBeNonUniform=], all nodes can be understood as having one of the following meanings:
         - A specific point of the program [=shader-creation error|must=] be executed in [=uniform control flow=]
         - An expression [=shader-creation error|must=] be a [=uniform value=]
         - A variable [=shader-creation error|must=] be a [=uniform variable=]
@@ -9621,7 +9621,7 @@ As such, a partial reference is either:
     originating variable, but with a different [=store type=].
 
 <div class="note">
-Note: A [=partial reference=] can still cover all the same memory locations
+<span class=marker>Note:</span> A [=partial reference=] can still cover all the same memory locations
 as a full reference, i.e. all the locations used by a variable declaration.
 This can occur when the store type is a structure type having only one member,
 or when the store type is an array type with one element.


### PR DESCRIPTION
Multi-paragraph "notes" are set off with class=note on a <div> element. In that case, we need to manually mark the first "Note" word with class=marker, so it gets the "note" styling (bold, green).