### PR TITLE
Remove textureNumLayers overloads for texture_cube_array texture_dept…

### DIFF
--- a/wgsl/index.bs
+++ b/wgsl/index.bs
@@ -14469,8 +14469,8 @@ Returns the number of layers (elements) of an array texture.
     <td><var ignore>F</var> is a [=texel format=]<br>
         <var ignore>A</var> is an [=access mode=]<br>
         <var ignore>ST</var> is [=i32=], [=u32=], or [=f32=]<br><br>
-        <var ignore>T</var> is `texture_2d_array<ST>`, `texture_cube_array<ST>`,
-                               `texture_depth_2d_array`, `texture_depth_cube_array`,
+        <var ignore>T</var> is `texture_2d_array<ST>`,
+                               `texture_depth_2d_array`,
                                or `texture_storage_2d_array<F,A>`
     <td><xmp highlight=rust>
 @must_use fn textureNumLayers(t: T) -> u32</xmp>


### PR DESCRIPTION
…h_cube_array

HLSL shader model 5.1 does not support the GetDimensions query on those types.

Fixes: #3913